### PR TITLE
fix(ci): fix fetching tags in Build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         id: fix-tags
         if: github.event_name != 'push'
         run: |
-          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          git fetch --tags --force
       - name: Mark Stable
         id: channel
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.type != 'nightly'
@@ -111,7 +111,7 @@ jobs:
         id: fix-tags
         if: github.event_name != 'push'
         run: |
-          git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+          git fetch --tags --force
       - name: Mark Stable
         id: channel
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.type != 'nightly'


### PR DESCRIPTION
##### Summary

This should fix the problem with building and publishing distribution tarballs (.tar.gz) and static builds (.gz.run).

Previous fix attempt: #13508.

##### Test Plan

Wait for nighly builds I guess? @Ferroin 

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
