### PR TITLE
Use LVM UUIDs in chart ids for logical volumes

### DIFF
--- a/collectors/proc.plugin/proc_diskstats.c
+++ b/collectors/proc.plugin/proc_diskstats.c
@@ -2043,12 +2043,19 @@ int do_proc_diskstats(int update_every, usec_t dt) {
             struct disk *t = d;
 
             rrdset_obsolete_and_pointer_null(d->st_avgsz);
+            rrdset_obsolete_and_pointer_null(d->st_ext_avgsz);
             rrdset_obsolete_and_pointer_null(d->st_await);
+            rrdset_obsolete_and_pointer_null(d->st_ext_await);
             rrdset_obsolete_and_pointer_null(d->st_backlog);
+            rrdset_obsolete_and_pointer_null(d->st_busy);
             rrdset_obsolete_and_pointer_null(d->st_io);
+            rrdset_obsolete_and_pointer_null(d->st_ext_io);
             rrdset_obsolete_and_pointer_null(d->st_iotime);
+            rrdset_obsolete_and_pointer_null(d->st_ext_iotime);
             rrdset_obsolete_and_pointer_null(d->st_mops);
+            rrdset_obsolete_and_pointer_null(d->st_ext_mops);
             rrdset_obsolete_and_pointer_null(d->st_ops);
+            rrdset_obsolete_and_pointer_null(d->st_ext_ops);
             rrdset_obsolete_and_pointer_null(d->st_qops);
             rrdset_obsolete_and_pointer_null(d->st_svctm);
             rrdset_obsolete_and_pointer_null(d->st_util);
@@ -2058,6 +2065,8 @@ int do_proc_diskstats(int update_every, usec_t dt) {
             rrdset_obsolete_and_pointer_null(d->st_bcache_size);
             rrdset_obsolete_and_pointer_null(d->st_bcache_usage);
             rrdset_obsolete_and_pointer_null(d->st_bcache_hit_ratio);
+            rrdset_obsolete_and_pointer_null(d->st_bcache_cache_allocations);
+            rrdset_obsolete_and_pointer_null(d->st_bcache_cache_read_races);
 
             if(d == disk_root) {
                 disk_root = d = d->next;


### PR DESCRIPTION
##### Summary
Removing old LVM volumes and adding new ones causes the reuse of the devices with the lowest serial numbers. That leads to the reuse of obsolete charts with old metadata. The solution is to distinguish devices by LVM UUIDs, not by names. The UUIDs for `dm-*` (device mapper) devices can be found in `/sys/devices/virtual/block/dm-*/dm/uuid`.

Fixes #9554

##### Test Plan
1. Create a virtual block device
```
$ dd if=/dev/zero of=/tmp/lvm.test.file bs=1k count=100k
$ sudo losetup /dev/loop0 /tmp/lvm.test.file
```
2. Create an LVM Volume Group
```
$ sudo pvcreate /dev/loop0
$ sudo vgcreate vg /dev/loop0
```
3. Create/remove/create logical volumes with different names
```
$ sudo lvcreate -L 1M -n vol1 vg
$ sudo lvremove vg/vol1
$ sudo lvcreate -L 1M -n vol2 vg
...
```
4. Check if families and chart names are correct.