### PR TITLE
fix(health): set default curl connection timeout if not set

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -428,6 +428,10 @@ else
   done
 fi
 
+if [[ ! $curl_options =~ .*\--connect-timeout ]]; then
+  curl_options+=" --connect-timeout 5"
+fi
+
 OPSGENIE_API_URL=${OPSGENIE_API_URL:-"https://api.opsgenie.com"}
 
 # If we didn't autodetect the character set for e-mail and it wasn't


### PR DESCRIPTION
##### Summary

This PR adds the `--connect-timeout 5` curl option if not set.

---

It turns out we have no timeout set when sending notifications [using `curl`](https://github.com/netdata/netdata/blob/c3dba899af944853aaf2f4be0f7a3be24ae0e29d/health/notifications/alarm-notify.sh.in#L133).

Discovered in https://community.netdata.cloud/t/can-not-get-matrix-notifications-to-work/3198


##### Test Plan

Set any notification method that uses `curl`, and ensure that `--connect-timeout 5` is added to the options.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
