### PR TITLE
Schedule next rotation based on absolute time

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -426,7 +426,7 @@ static void timer_cb(uv_timer_t* handle)
         if (wc->rotation_after && wc->rotation_after < now) {
             cmd.opcode = ACLK_DATABASE_UPD_RETENTION;
             if (!aclk_database_enq_cmd_noblock(wc, &cmd))
-                wc->rotation_after += ACLK_DATABASE_ROTATION_INTERVAL;
+                wc->rotation_after = now + ACLK_DATABASE_ROTATION_INTERVAL;
         }
 
         if (wc->chart_updates && !wc->chart_pending && wc->chart_payload_count) {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

There is currently an agent, streaming to the cloud that sends an `UpdateNodeInfo` message every second.

Looking with @vkuznecovas we deduced that most likely the clock of the user is slowly drifting. At some point a timestamp sent with `UpdateNodeInfo` had the year of 2037.

The `UpdateNodeInfo` message is scheduled to go out every hour, right after the `UpdateRetention` message when `ACLK_DATABASE_UPD_RETENTION` is run. When this command is scheduled, it is then set to repeat in 3600 seconds. (Note that with rrdcontext, the `UpdateRetention` is not run, however the `UpdateNodeInfo` does).

It is repeated though by setting the value to `+ACLK_DATABASE_ROTATION_INTERVAL` which if the clock skews enough can lead to `now` being always more than the scheduled time. This PR just sets this schedule based on `now + ACLK_DATABASE_ROTATION_INTERVAL`.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

To re-create try the following:

1) Setup and claim an agent to the cloud. Start it.
2) Modify the machine's clock to e.g. 1 year later.
3) Notice in access.log the `UpdateNodeInfo` running every second.

Apply this PR and retry. `UpdateNodeInfo` should run only every hour even if clock is skewed.

(For better testing change `ACLK_DATABASE_ROTATION_INTERVAL` to e.g. 20 seconds).

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
