### PR TITLE
Fix a crash when xen libraries are misconfigured

### DIFF
--- a/collectors/xenstat.plugin/xenstat_plugin.c
+++ b/collectors/xenstat.plugin/xenstat_plugin.c
@@ -1006,12 +1006,16 @@ int main(int argc, char **argv) {
 
     if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: calling xenstat_init()\n");
     xhandle = xenstat_init();
-    if (xhandle == NULL)
+    if (xhandle == NULL) {
         error("XENSTAT: failed to initialize xenstat library.");
+        return 1;
+    }
 
     if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: calling libxl_ctx_alloc()\n");
     if (libxl_ctx_alloc(&ctx, LIBXL_VERSION, 0, NULL)) {
         error("XENSTAT: failed to initialize xl context.");
+        xenstat_uninit(xhandle);
+        return 1;
     }
     libxl_dominfo_init(&info);
 
@@ -1062,4 +1066,6 @@ int main(int argc, char **argv) {
     libxl_ctx_free(ctx);
     xenstat_uninit(xhandle);
     info("XENSTAT process exiting");
+    
+    return 0;
 }

--- a/collectors/xenstat.plugin/xenstat_plugin.c
+++ b/collectors/xenstat.plugin/xenstat_plugin.c
@@ -171,7 +171,7 @@ static struct domain_metrics *domain_metrics_free(struct domain_metrics *d) {
     struct vbd_metrics *vbd, *vbd_f;
     struct network_metrics *network, *network_f;
 
-    if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: freeing memory for domain '%s' id %d, uuid %s\n", d->name, d->id, d->uuid);
+    if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: freeing memory for domain '%s' id %u, uuid %s\n", d->name, d->id, d->uuid);
 
     for(cur = node_metrics.domain_root; cur ; last = cur, cur = cur->next) {
         if(unlikely(cur->hash == d->hash && !strcmp(cur->uuid, d->uuid))) break;
@@ -401,7 +401,7 @@ static int xenstat_collect(xenstat_handle *xhandle, libxl_ctx *ctx, libxl_dominf
         if(unlikely(!d->name)) {
             d->name = strdupz(xenstat_domain_name(domain));
             netdata_fix_chart_id(d->name);
-            if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: domain id %d, uuid %s has name '%s'\n", d->id, d->uuid, d->name);
+            if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: domain id %u, uuid %s has name '%s'\n", d->id, d->uuid, d->name);
         }
 
         d->running  = xenstat_domain_running(domain);
@@ -569,7 +569,7 @@ static void print_domain_vcpu_chart_definition(char *type, struct domain_metrics
 }
 
 static void print_domain_vbd_oo_chart_definition(char *type, unsigned int vbd, int obsolete_flag) {
-    printf("CHART %s.oo_req_vbd%u '' 'VBD%u \"Out Of\" Requests' 'requests/s' 'vbd' 'xendomain.oo_req_vbd' line %d %d %s %s\n"
+    printf("CHART %s.oo_req_vbd%u '' 'VBD%u \"Out Of\" Requests' 'requests/s' 'vbd' 'xendomain.oo_req_vbd' line %u %d %s %s\n"
                        , type
                        , vbd
                        , vbd
@@ -582,7 +582,7 @@ static void print_domain_vbd_oo_chart_definition(char *type, unsigned int vbd, i
 }
 
 static void print_domain_vbd_requests_chart_definition(char *type, unsigned int vbd, int obsolete_flag) {
-    printf("CHART %s.requests_vbd%u '' 'VBD%u Requests' 'requests/s' 'vbd' 'xendomain.requests_vbd' line %d %d %s %s\n"
+    printf("CHART %s.requests_vbd%u '' 'VBD%u Requests' 'requests/s' 'vbd' 'xendomain.requests_vbd' line %u %d %s %s\n"
                        , type
                        , vbd
                        , vbd
@@ -596,7 +596,7 @@ static void print_domain_vbd_requests_chart_definition(char *type, unsigned int 
 }
 
 static void print_domain_vbd_sectors_chart_definition(char *type, unsigned int vbd, int obsolete_flag) {
-    printf("CHART %s.sectors_vbd%u '' 'VBD%u Read/Written Sectors' 'sectors/s' 'vbd' 'xendomain.sectors_vbd' line %d %d %s %s\n"
+    printf("CHART %s.sectors_vbd%u '' 'VBD%u Read/Written Sectors' 'sectors/s' 'vbd' 'xendomain.sectors_vbd' line %u %d %s %s\n"
                        , type
                        , vbd
                        , vbd
@@ -610,7 +610,7 @@ static void print_domain_vbd_sectors_chart_definition(char *type, unsigned int v
 }
 
 static void print_domain_network_bytes_chart_definition(char *type, unsigned int network, int obsolete_flag) {
-    printf("CHART %s.bytes_network%u '' 'Network%u Received/Sent Bytes' 'kilobits/s' 'network' 'xendomain.bytes_network' line %d %d %s %s\n"
+    printf("CHART %s.bytes_network%u '' 'Network%u Received/Sent Bytes' 'kilobits/s' 'network' 'xendomain.bytes_network' line %u %d %s %s\n"
                        , type
                        , network
                        , network
@@ -624,7 +624,7 @@ static void print_domain_network_bytes_chart_definition(char *type, unsigned int
 }
 
 static void print_domain_network_packets_chart_definition(char *type, unsigned int network, int obsolete_flag) {
-    printf("CHART %s.packets_network%u '' 'Network%u Received/Sent Packets' 'packets/s' 'network' 'xendomain.packets_network' line %d %d %s %s\n"
+    printf("CHART %s.packets_network%u '' 'Network%u Received/Sent Packets' 'packets/s' 'network' 'xendomain.packets_network' line %u %d %s %s\n"
                        , type
                        , network
                        , network
@@ -638,7 +638,7 @@ static void print_domain_network_packets_chart_definition(char *type, unsigned i
 }
 
 static void print_domain_network_errors_chart_definition(char *type, unsigned int network, int obsolete_flag) {
-    printf("CHART %s.errors_network%u '' 'Network%u Receive/Transmit Errors' 'errors/s' 'network' 'xendomain.errors_network' line %d %d %s %s\n"
+    printf("CHART %s.errors_network%u '' 'Network%u Receive/Transmit Errors' 'errors/s' 'network' 'xendomain.errors_network' line %u %d %s %s\n"
                        , type
                        , network
                        , network
@@ -652,7 +652,7 @@ static void print_domain_network_errors_chart_definition(char *type, unsigned in
 }
 
 static void print_domain_network_drops_chart_definition(char *type, unsigned int network, int obsolete_flag) {
-    printf("CHART %s.drops_network%u '' 'Network%u Receive/Transmit Drops' 'drops/s' 'network' 'xendomain.drops_network' line %d %d %s %s\n"
+    printf("CHART %s.drops_network%u '' 'Network%u Receive/Transmit Drops' 'drops/s' 'network' 'xendomain.drops_network' line %u %d %s %s\n"
                        , type
                        , network
                        , network
@@ -808,7 +808,7 @@ static void xenstat_send_domain_metrics() {
                     if(unlikely(vbd_m->oo_req_chart_generated
                                 || vbd_m->requests_chart_generated
                                 || vbd_m->sectors_chart_generated)) {
-                        if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: mark charts as obsolete for vbd %d, domain '%s', id %d, uuid %s\n", vbd_m->id, d->name, d->id, d->uuid);
+                        if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: mark charts as obsolete for vbd %u, domain '%s', id %u, uuid %s\n", vbd_m->id, d->name, d->id, d->uuid);
                         print_domain_vbd_oo_chart_definition(type, vbd_m->id, CHART_IS_OBSOLETE);
                         print_domain_vbd_requests_chart_definition(type, vbd_m->id, CHART_IS_OBSOLETE);
                         print_domain_vbd_sectors_chart_definition(type, vbd_m->id, CHART_IS_OBSOLETE);
@@ -895,7 +895,7 @@ static void xenstat_send_domain_metrics() {
                                 || network_m->packets_chart_generated
                                 || network_m->errors_chart_generated
                                 || network_m->drops_chart_generated))
-                    if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: mark charts as obsolete for network %d, domain '%s', id %d, uuid %s\n", network_m->id, d->name, d->id, d->uuid);
+                    if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: mark charts as obsolete for network %u, domain '%s', id %u, uuid %s\n", network_m->id, d->name, d->id, d->uuid);
                     print_domain_network_bytes_chart_definition(type, network_m->id, CHART_IS_OBSOLETE);
                     print_domain_network_packets_chart_definition(type, network_m->id, CHART_IS_OBSOLETE);
                     print_domain_network_errors_chart_definition(type, network_m->id, CHART_IS_OBSOLETE);
@@ -908,7 +908,7 @@ static void xenstat_send_domain_metrics() {
             }
         }
         else{
-            if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: mark charts as obsolete for domain '%s', id %d, uuid %s\n", d->name, d->id, d->uuid);
+            if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: mark charts as obsolete for domain '%s', id %u, uuid %s\n", d->name, d->id, d->uuid);
             print_domain_states_chart_definition(type, CHART_IS_OBSOLETE);
             print_domain_cpu_chart_definition(type, CHART_IS_OBSOLETE);
             print_domain_vcpu_chart_definition(type, d, CHART_IS_OBSOLETE);


### PR DESCRIPTION
##### Summary
If xen libraries are installed but xen hypervisor isn't present on the host, the `xenstat` plugin crashes
```
==42074== Process terminating with default action of signal 11 (SIGSEGV)
==42074==  Access not within mapped region at address 0x0
==42074==    at 0x4D0F3F0: xtl_logv (in /usr/lib/x86_64-linux-gnu/libxentoollog.so.1.0)
==42074==    by 0x4D0F4B8: xtl_log (in /usr/lib/x86_64-linux-gnu/libxentoollog.so.1.0)
==42074==    by 0x4A065C0: ??? (in /usr/lib/x86_64-linux-gnu/libxenlight.so.4.16.0)
==42074==    by 0x4A067EC: ??? (in /usr/lib/x86_64-linux-gnu/libxenlight.so.4.16.0)
==42074==    by 0x49E726B: libxl_ctx_alloc (in /usr/lib/x86_64-linux-gnu/libxenlight.so.4.16.0)
==42074==    by 0x11419D: main (xenstat_plugin.c:1013)
```
We have to shut down the plugin gracefully in such cases.

Fixes #13519

##### Test Plan
1. Install `libyajl` and `libxen-dev` on a fresh Ubuntu 22.01 VM. Don't run xen hypervisor.
2. Check if `xenstat` plugin doesn't crash.