### PR TITLE
chore(python.d): rename dockerd job on lock registration

### DIFF
--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -903,6 +903,8 @@ def main():
         registry,
     )
 
+    # cheap attempt to reduce chance of python.d job running before go.d
+    # TODO: better implementation needed
     if not IS_ATTY:
         time.sleep(1.5)
 

--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -497,6 +497,8 @@ class FileLockRegistry:
         self.locks = dict()
 
     def register(self, name):
+        if name.startswith("dockerd"):
+            name = "docker" + name[7:]
         if name in self.locks:
             return
         file = os.path.join(self.path, '{0}.collector.lock'.format(name))
@@ -505,6 +507,8 @@ class FileLockRegistry:
         self.locks[name] = lock
 
     def unregister(self, name):
+        if name.startswith("dockerd"):
+            name = "docker" + name[7:]
         if name not in self.locks:
             return
         lock = self.locks[name]

--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -131,7 +131,7 @@ def dirs():
 
 DIRS = dirs()
 
-IS_ATTY = sys.stdout.isatty()
+IS_ATTY = sys.stdout.isatty() or sys.stderr.isatty()
 
 MODULE_SUFFIX = '.chart.py'
 
@@ -902,6 +902,9 @@ def main():
         cmd.update_every,
         registry,
     )
+
+    if not IS_ATTY:
+        time.sleep(1.5)
 
     try:
         if not p.setup():

--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -496,9 +496,16 @@ class FileLockRegistry:
         self.path = path
         self.locks = dict()
 
-    def register(self, name):
+    @staticmethod
+    def rename(name):
+        # go version name is 'docker'
         if name.startswith("dockerd"):
             name = "docker" + name[7:]
+        return name
+
+
+    def register(self, name):
+        name = self.rename(name)
         if name in self.locks:
             return
         file = os.path.join(self.path, '{0}.collector.lock'.format(name))
@@ -507,8 +514,7 @@ class FileLockRegistry:
         self.locks[name] = lock
 
     def unregister(self, name):
-        if name.startswith("dockerd"):
-            name = "docker" + name[7:]
+        name = self.rename(name)
         if name not in self.locks:
             return
         lock = self.locks[name]


### PR DESCRIPTION
##### Summary

[python.d/dockerd](https://github.com/netdata/netdata/tree/master/collectors/python.d.plugin/dockerd) was [rewritten in go](https://github.com/netdata/go.d.plugin/pull/760) (now works out of the box, no need in installing additional python libraries). 

Go version name is `docker`, and the python version is `dockerd` ("d" was added to resolve import conflict: the docker lib name is "docker"). I don't want to name go version `dockerd`, but we need to have the same so only one of them will be active at a time.

---

In addition, this PR adds a (1.5s, insignificant) delay on python.d.plugin start to reduce the chance of the python.d job running before go.d.

##### Test Plan

- Get both python and go versions of docker collector enabled
- Check the dashboard, only one data collection job should be active.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
