### PR TITLE
Bump Coverity version to latest (2022.06).

### DIFF
--- a/coverity-scan.sh
+++ b/coverity-scan.sh
@@ -40,7 +40,7 @@ set -e
 INSTALL_DIR="/opt"
 
 # the version of coverity to use
-COVERITY_BUILD_VERSION="${COVERITY_BUILD_VERSION:-cov-analysis-linux64-2021.12}"
+COVERITY_BUILD_VERSION="${COVERITY_BUILD_VERSION:-cov-analysis-linux64-2022.06}"
 
 # TODO: For some reasons this does not fully load on Debian 10 (Haven't checked if it happens on other distros yet), it breaks
 source packaging/installer/functions.sh || echo "Failed to fully load the functions library"


### PR DESCRIPTION

##### Summary

THis should fix the fialing Coverity scan CI jobs.

##### Test Plan

n/a