### PR TITLE
Avoids receiving warning about galera state

### DIFF
--- a/health/health.d/mysql.conf
+++ b/health/health.d/mysql.conf
@@ -160,7 +160,7 @@ component: MySQL
 component: MySQL
      calc: $wsrep_cluster_status
     every: 10s
-     crit: $mysql_galera_cluster_state != nan AND $this != 0
+     crit: $mysql_galera_cluster_state != nan AND $this != 0 AND $this != 'Primary'
     delay: up 30s down 5m multiplier 1.5 max 1h
      info: galera node cluster component status \
            (-1: unknown, 0: primary/quorum present, 1: non-primary/quorum lost, 2: disconnected). \


### PR DESCRIPTION
Since 1.36, I started receiving alerts about this on all my servers (7 running Ubuntu and MariaDB 10.6.7 / 10.6.9).
I had to edit the configuration to remove the warning.

Galera status is a text like Primary or Donor/Desync, however the alert seems to expect a number?
