### PR TITLE
fix(health.d/mysql): adjust `mysql_galera_cluster_size_max_2m` lookup to make time in warn/crit predictable

### DIFF
--- a/health/health.d/mysql.conf
+++ b/health/health.d/mysql.conf
@@ -117,7 +117,7 @@ component: MySQL
    lookup: max -2m at -1m unaligned
     units: nodes
     every: 10s
-     info: maximum galera cluster size in the last 2 minutes
+     info: maximum galera cluster size in the last 2 minutes starting one minute ago
        to: dba
 
  template: mysql_galera_cluster_size

--- a/health/health.d/mysql.conf
+++ b/health/health.d/mysql.conf
@@ -114,7 +114,7 @@ component: MySQL
     class: Utilization
      type: Database
 component: MySQL
-   lookup: max -2m absolute
+   lookup: max -2m at -1m unaligned
     units: nodes
     every: 10s
      info: maximum galera cluster size in the last 2 minutes


### PR DESCRIPTION
##### Summary

Fixes: #13427

This PR adds 2 changes:

- changes `absolute` option to `unaligned`.
- changes the timeframe from _last 2 minutes_ to _last 2 minutes starting 1 minute ago_. That is needed for the [warn](https://github.com/netdata/netdata/blob/331b52b94a1b19d3ad03de7560047de1a7e0f661/health/health.d/mysql.conf#L131) condition (otherwise max of last 2 minutes == current).


##### Test Plan

Set up Galera cluster, and test alerts (stop one node, wait, start the node).

<details>
<summary>set up Galera cluster using Docker</summary>

```bash
docker run -d --name mariadb-galera-0 \
  -p 3306:3306 \
  -e MARIADB_GALERA_CLUSTER_NAME=my_galera \
  -e MARIADB_GALERA_MARIABACKUP_USER=my_mariabackup_user \
  -e MARIADB_GALERA_MARIABACKUP_PASSWORD=my_mariabackup_password \
  -e MARIADB_ROOT_PASSWORD=my_root_password \
  -e MARIADB_GALERA_CLUSTER_BOOTSTRAP=yes \
  -e MARIADB_USER=my_user \
  -e MARIADB_PASSWORD=my_password \
  -e MARIADB_DATABASE=my_database \
  -e MARIADB_REPLICATION_USER=my_replication_user \
  -e MARIADB_REPLICATION_PASSWORD=my_replication_password \
  -e MARIADB_GALERA_FORCE_SAFETOBOOTSTRAP=yes \
  bitnami/mariadb-galera:latest

docker run -d --name mariadb-galera-1 --link mariadb-galera-0:mariadb-galera \
  -p 3307:3306 \
  -e MARIADB_GALERA_CLUSTER_NAME=my_galera \
  -e MARIADB_GALERA_CLUSTER_ADDRESS=gcomm://mariadb-galera:4567,0.0.0.0:4567 \
  -e MARIADB_GALERA_MARIABACKUP_USER=my_mariabackup_user \
  -e MARIADB_GALERA_MARIABACKUP_PASSWORD=my_mariabackup_password \
  -e MARIADB_ROOT_PASSWORD=my_root_password \
  -e MARIADB_REPLICATION_USER=my_replication_user \
  -e MARIADB_REPLICATION_PASSWORD=my_replication_password \
  -e MARIADB_GALERA_FORCE_SAFETOBOOTSTRAP=yes \
  bitnami/mariadb-galera:latest

docker run -d --name mariadb-galera-2 --link mariadb-galera-0:mariadb-galera \
  -p 3308:3306 \
  -e MARIADB_GALERA_CLUSTER_NAME=my_galera \
  -e MARIADB_GALERA_CLUSTER_ADDRESS=gcomm://mariadb-galera:4567,0.0.0.0:4567 \
  -e MARIADB_GALERA_MARIABACKUP_USER=my_mariabackup_user \
  -e MARIADB_GALERA_MARIABACKUP_PASSWORD=my_mariabackup_password \
  -e MARIADB_ROOT_PASSWORD=my_root_password \
  -e MARIADB_REPLICATION_USER=my_replication_user \
  -e MARIADB_REPLICATION_PASSWORD=my_replication_password \
  -e MARIADB_GALERA_FORCE_SAFETOBOOTSTRAP=yes \
  bitnami/mariadb-galera:latest
```

</details>

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
