### PR TITLE
chore: removing logging that a chart collection in the same interpolation point

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1714,13 +1714,13 @@ after_first_database_work:
     // at this point we have all the calculated values ready
     // it is now time to interpolate values on a second boundary
 
-#ifdef NETDATA_INTERNAL_CHECKS
-    if(unlikely(now_collect_ut < next_store_ut && st->counter_done > 1)) {
-        // this is collected in the same interpolation point
-        rrdset_debug(st, "THIS IS IN THE SAME INTERPOLATION POINT");
-        info("INTERNAL CHECK: host '%s', chart '%s' collection %zu is in the same interpolation point: short by %llu microseconds", st->rrdhost->hostname, st->name, st->counter_done, next_store_ut - now_collect_ut);
-    }
-#endif
+// #ifdef NETDATA_INTERNAL_CHECKS
+//     if(unlikely(now_collect_ut < next_store_ut && st->counter_done > 1)) {
+//         // this is collected in the same interpolation point
+//         rrdset_debug(st, "THIS IS IN THE SAME INTERPOLATION POINT");
+//         info("INTERNAL CHECK: host '%s', chart '%s' collection %zu is in the same interpolation point: short by %llu microseconds", st->rrdhost->hostname, st->name, st->counter_done, next_store_ut - now_collect_ut);
+//     }
+// #endif
 
     rrdset_done_interpolate(st
             , update_every_ut


### PR DESCRIPTION
##### Summary

We have millions of those lines on our AWS parents and it seems there is no action - these messages are just noise.

##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
