### PR TITLE
eBPF cmake missing include dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,7 +328,7 @@ IF(LINUX AND EXISTS "${CMAKE_SOURCE_DIR}/externaldeps/libbpf/libbpf.a")
             ${CMAKE_SOURCE_DIR}/externaldeps/libbpf/libbpf.a
             ${ELF_LIBRARIES})
         list(APPEND NETDATA_COMMON_INCLUDE_DIRS ${ELF_INCLUDE_DIRS})
-        include_directories(BEFORE ${CMAKE_SOURCE_DIR}/externaldeps/libbpf/include)
+        include_directories(BEFORE ${CMAKE_SOURCE_DIR}/externaldeps/libbpf/include ${CMAKE_SOURCE_DIR}/externaldeps/libbpf/include/uapi)
         set(ENABLE_PLUGIN_EBPF True)
     ELSE(ELF_LIBRARIES)
         set(ENABLE_PLUGIN_EBPF False)


### PR DESCRIPTION
##### Summary
While working on other CMake stuff i noticed this include folder was missing and was one of the problems causing failure to build eBPF.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
