### PR TITLE
add `apt` to `apps_groups.conf`

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -235,6 +235,8 @@ dnsdist: dnsdist
 build: cc1 cc1plus as gcc* cppcheck ld make cmake automake autoconf autoreconf
 build: cargo rustc bazel buck git gdb valgrind*
 
+apt: apt*
+
 # -----------------------------------------------------------------------------
 # antivirus
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This is useful to help spot when someone may have been installing something or updating something on the system using `apt`

Example of is working when i did a series of 

`sudo apt install stress`
`sudo apt update`
`sudo apt upgrade`

![image](https://user-images.githubusercontent.com/2178292/186713714-4e79c7c5-1560-44e0-97c5-321cc6004f7a.png)


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
