### PR TITLE
prevent crash on rrdcontext apis when rrdcontexts is not initialized

### DIFF
--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -2377,6 +2377,11 @@ static inline int rrdcontext_to_json_callback(const char *id, void *value, void 
 }
 
 int rrdcontext_to_json(RRDHOST *host, BUFFER *wb, time_t after, time_t before, RRDCONTEXT_TO_JSON_OPTIONS options, const char *context, SIMPLE_PATTERN *chart_label_key, SIMPLE_PATTERN *chart_labels_filter, SIMPLE_PATTERN *chart_dimensions) {
+    if(!host->rrdctx) {
+        error("%s(): request for host '%s' that does not have rrdcontexts initialized.", __FUNCTION__, host->hostname);
+        return HTTP_RESP_NOT_FOUND;
+    }
+
     RRDCONTEXT_ACQUIRED *rca = (RRDCONTEXT_ACQUIRED *)dictionary_get_and_acquire_item((DICTIONARY *)host->rrdctx, context);
     if(!rca) return HTTP_RESP_NOT_FOUND;
 
@@ -2412,6 +2417,11 @@ int rrdcontext_to_json(RRDHOST *host, BUFFER *wb, time_t after, time_t before, R
 }
 
 int rrdcontexts_to_json(RRDHOST *host, BUFFER *wb, time_t after, time_t before, RRDCONTEXT_TO_JSON_OPTIONS options, SIMPLE_PATTERN *chart_label_key, SIMPLE_PATTERN *chart_labels_filter, SIMPLE_PATTERN *chart_dimensions) {
+    if(!host->rrdctx) {
+        error("%s(): request for host '%s' that does not have rrdcontexts initialized.", __FUNCTION__, host->hostname);
+        return HTTP_RESP_NOT_FOUND;
+    }
+
     char node_uuid[UUID_STR_LEN] = "";
 
     if(host->node_id)


### PR DESCRIPTION
Prevent this crash:

```
Core was generated by `/usr/sbin/netdata -P /run/netdata/netdata.pid'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  dictionary_lock (dict=dict@entry=0x0, rw=rw@entry=114 'r') at libnetdata/dictionary/dictionary.c:322
322	        __atomic_add_fetch(&dict->readers, 1, __ATOMIC_RELAXED);
[Current thread is 1 (Thread 0x7f31e9791640 (LWP 31389))]
(gdb) bt
#0  dictionary_lock (dict=dict@entry=0x0, rw=rw@entry=114 'r') at libnetdata/dictionary/dictionary.c:322
#1  0x000055b5b0aca04f in dictionary_get_and_acquire_item (dict=0x0, name=name@entry=0x55b5bf391cb7 "netdata.uptime") at libnetdata/dictionary/dictionary.c:1136
#2  0x000055b5b0c00e7b in rrdcontext_to_json (host=host@entry=0x55b5bf33f300, wb=0x55b5bbd8d560, after=after@entry=0, before=before@entry=0, options=options@entry=447, 
    context=context@entry=0x55b5bf391cb7 "netdata.uptime", chart_label_key=0x0, chart_labels_filter=0x0, chart_dimensions=0x0) at database/rrdcontext.c:2380
#3  0x000055b5b0af6628 in web_client_api_request_v1_context (host=0x55b5bf33f300, w=0x55b5bf38f020, url=<optimized out>) at web/api/web_api_v1.c:463
#4  0x000055b5b0af97e0 in web_client_api_request_v1 (host=host@entry=0x55b5bf33f300, w=w@entry=0x55b5bf38f020, url=url@entry=0x55b5bd874242 "context") at web/api/web_api_v1.c:1723
#5  0x000055b5b0cdcfe5 in aclk_web_api_v1_request (url=0x55b5bd874242 "context", w=0x55b5bf38f020, host=0x55b5bf33f300) at aclk/aclk_query.c:21
#6  http_api_v2 (query=0x55b5bf2fa910, query_thr=0x55b5bc5fe110) at aclk/aclk_query.c:147
#7  aclk_query_process_msg (query=0x55b5bf2fa910, query_thr=0x55b5bc5fe110) at aclk/aclk_query.c:299
#8  aclk_query_process_msgs (query_thr=query_thr@entry=0x55b5bc5fe110) at aclk/aclk_query.c:324
#9  0x000055b5b0cdd9b6 in aclk_query_main_thread (ptr=0x55b5bc5fe110) at aclk/aclk_query.c:346
#10 0x000055b5b0adf011 in thread_start (ptr=<optimized out>) at libnetdata/threads/threads.c:185
#11 0x00007f3208e65fef in start_thread (arg=0x7f31e9791640) at pthread_create.c:463
#12 0x00007f3208a3100f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

Note that `dict=0x0`.
