### PR TITLE
Rewrite the logind collector to work more efficiently and report more useful data.

### DIFF
--- a/collectors/python.d.plugin/logind/README.md
+++ b/collectors/python.d.plugin/logind/README.md
@@ -6,25 +6,30 @@ sidebar_label: "systemd-logind"
 
 # Systemd-Logind monitoring with Netdata
 
-Monitors active sessions, users, and seats tracked by `systemd-logind` or `elogind`.
+Monitors counts of sessions and users as reported by the `org.freedesktop.login1` DBus API (provided by `systemd-logind` or `elogind`).
 
 It provides the following charts:
 
-1.  **Sessions** Tracks the total number of sessions.
+1.  **Sessions By Type** Tracks the total number of sessions by session type.
 
-    -   Graphical: Local graphical sessions (running X11, or Wayland, or something else).
-    -   Console: Local console sessions.
+    -   Graphical: Local graphical sessions (running one of X11, Mir, or Wayland)
+    -   Console: Local console sessions (`tty` sessions in Logind terms)
     -   Remote: Remote sessions.
+    -   Other: Other sessions that do not fit the above types (for example, a session for a cron job or systemd timer unit).
 
-2.  **Users** Tracks total number of unique user logins of each type.
+2.  **Sessions By State** Tracks the total number of sessions by session state.
 
-    -   Graphical
-    -   Console
-    -   Remote
+    -   Online: Sessions that are logged in, but not in the foreground.
+    -   Active: Sessions that are logged in and in the foreground.
+    -   Closing: Sessions that are in the process of logging out.
 
-3.  **Seats** Total number of seats in use.
+3.  **Users** Tracks the total number of users by user state.
 
-    -   Seats
+    -   Offline: Users that are not logged in, but are tacked by logind.
+    -   Lingering: Users that are logged out, but have associated services still running.
+    -   Online: Users that are logged in but do not have an associated active session.
+    -   Active: Users that are logged in and have an associated active session.
+    -   Closing: Users that are in the process of logging out and are not lingering.
 
 ## Enable the collector
 
@@ -41,46 +46,19 @@ restart netdata`, or the appropriate method for your system, to finish enabling 
 
 ## Configuration
 
-This module needs no configuration. Just make sure the `netdata` user
-can run the `loginctl` command and get a session list without having to
-specify a path.
-
-This will work with any command that can output data in the _exact_
-same format as `loginctl list-sessions --no-legend`.  If you have some
-other command you want to use that outputs data in this format, you can
-specify it using the `command` key like so:
-
-```yaml
-command: '/path/to/other/command'
-```
-
-Edit the `python.d/logind.conf` configuration file using `edit-config` from the Netdata [config
-directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
-
-```bash
-cd /etc/netdata   # Replace this path with your Netdata config directory, if different
-sudo ./edit-config python.d/logind.conf
-```
+This module needs no configuration. Just make sure the `netdata` user has the required permissions to query the
+`org.freedesktop.login1` DBus interface (this should be the case by default on most systems).
 
 ## Notes
 
+-   This module requires the `dbus-python` Python bindings for DBus to run. On many systems that use Logind this
+    will already be installed. If it is not, you will need to install it (in most cases, the package name will be
+    something along the lines of `dbus-python` or `python-dbus`)
+
 -   This module's ability to track logins is dependent on what PAM services
-    are configured to register sessions with logind.  In particular, for
-    most systems, it will only track TTY logins, local desktop logins,
-    and logins through remote shell connections.
+    are configured to register sessions with logind.  In particular, for most systems, it will only track TTY
+    logins, local desktop logins, and logins through remote shell connections.
 
--   The users chart counts _usernames_ not UID's.  This is potentially
-    important in configurations where multiple users have the same UID.
-
--   The users chart counts any given user name up to once for _each_ type
-    of login.  So if the same user has a graphical and a console login on a
-    system, they will show up once in the graphical count, and once in the
-    console count.
-
--   Because the data collection process is rather expensive, this plugin
-    is currently disabled by default, and needs to be explicitly enabled in
-    `/etc/netdata/python.d.conf` before it will run.
-
----
-
-
+-   Both `systemd-logind` and `elogind` track users by username, not by UID. In most cases this should not matter, but
+    if you have multiple users who share a UID for some reason, they will be treated as separate users by this
+    collector.

--- a/collectors/python.d.plugin/logind/logind.chart.py
+++ b/collectors/python.d.plugin/logind/logind.chart.py
@@ -3,83 +3,165 @@
 # Author: Austin S. Hemmelgarn (Ferroin)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from bases.FrameworkServices.ExecutableService import ExecutableService
+from bases.FrameworkServices.SimpleService import SimpleService
+
+try:
+    import dbus
+    HAVE_DBUS = True
+except ImportError:
+    HAVE_DBUS = False
 
 priority = 59999
 disabled_by_default = True
 
-LOGINCTL_COMMAND = 'loginctl list-sessions --no-legend'
+BUS_NAME = 'org.freedesktop.login1'
+OBJ_PATH = '/org/freedesktop/login1'
+MGR_IFACE = 'org.freedesktop.login1.Manager'
+PROP_IFACE = 'org.freedesktop.DBus.Properties'
+SESSION_IFACE = 'org.freedesktop.login1.Session'
+USER_IFACE = 'org.freedesktop.login1.User'
+
+GUI_SESSION_TYPES = [
+    'x11',
+    'mir',
+    'wayland'
+]
 
 ORDER = [
-    'sessions',
+    'session_types',
+    'session_states',
     'users',
-    'seats',
 ]
 
 CHARTS = {
-    'sessions': {
-        'options': [None, 'Logind Sessions', 'sessions', 'sessions', 'logind.sessions', 'stacked'],
+    'session_types': {
+        'options': [None, 'Logind Session By Type', 'session_types', 'session_types', 'logind.session_types', 'stacked'],
         'lines': [
             ['sessions_graphical', 'Graphical', 'absolute', 1, 1],
             ['sessions_console', 'Console', 'absolute', 1, 1],
-            ['sessions_remote', 'Remote', 'absolute', 1, 1]
+            ['sessions_remote', 'Remote', 'absolute', 1, 1],
+            ['sessions_other', 'Other', 'absolute', 1, 1]
+        ]
+    },
+    'session_states': {
+        'options': [None, 'Logind Sessions By State', 'session_states', 'session_states', 'logind.session_states', 'stacked'],
+        'lines': [
+            ['sessions_online', 'Online', 'absolute', 1, 1],
+            ['sessions_active', 'Active', 'absolute', 1, 1],
+            ['sessions_closing', 'Closing', 'absolute', 1, 1]
         ]
     },
     'users': {
         'options': [None, 'Logind Users', 'users', 'users', 'logind.users', 'stacked'],
         'lines': [
-            ['users_graphical', 'Graphical', 'absolute', 1, 1],
-            ['users_console', 'Console', 'absolute', 1, 1],
-            ['users_remote', 'Remote', 'absolute', 1, 1]
+            ['users_offline', 'Offline', 'absolute', 1, 1],
+            ['users_lingering', 'Lingering', 'absolute', 1, 1],
+            ['users_online', 'Online', 'absolute', 1, 1],
+            ['users_active', 'Active', 'absolute', 1, 1],
+            ['users_closing', 'Closing', 'absolute', 1, 1]
         ]
     },
-    'seats': {
-        'options': [None, 'Logind Seats', 'seats', 'seats', 'logind.seats', 'line'],
-        'lines': [
-            ['seats', 'Active Seats', 'absolute', 1, 1]
-        ]
-    }
 }
 
 
-class Service(ExecutableService):
+class Service(SimpleService):
     def __init__(self, configuration=None, name=None):
-        ExecutableService.__init__(self, configuration=configuration, name=name)
+        SimpleService.__init__(self, configuration=configuration, name=name)
         self.order = ORDER
         self.definitions = CHARTS
-        self.command = LOGINCTL_COMMAND
+        self.bus_name = configuration.get('bus_name', BUS_NAME)
+        self.obj_path = configuration.get('object_path', OBJ_PATH)
+        self.bus = dbus.SystemBus()
+        self.mgr = None
+        self.iface = None
+
+        try:
+            self.mgr = self.bus.get_object(self.bus_name, self.obj_path)
+            self.iface = dbus.Interface(self.mgr, MGR_IFACE)
+        except dbus.DBusException:
+            pass
+
+    def check(self):
+        if not HAVE_DBUS:
+            self.error('dbus-python is not available')
+            return False
+
+        if self.mgr is None:
+            self.error('Unable to connect to ' + self.bus_name + ' service')
+            return False
+
+        if self.iface is None:
+            self.error('Failed to construct interface')
+
+        return self._get_data()
 
     def _get_data(self):
+        try:
+            sessions = self.iface.ListSessions()
+            users = self.iface.ListUsers()
+        except dbus.DBusException:
+            return None
+
         ret = {
             'sessions_graphical': 0,
             'sessions_console': 0,
             'sessions_remote': 0,
+            'sessions_other': 0,
+            'sessions_online': 0,
+            'sessions_active': 0,
+            'sessions_closing': 0,
+            'users_offline': 0,
+            'users_lingering': 0,
+            'users_online': 0,
+            'users_active': 0,
+            'users_closing': 0,
         }
-        users = {
-            'graphical': list(),
-            'console': list(),
-            'remote': list()
-        }
-        seats = list()
-        data = self._get_raw_data()
 
-        for item in data:
-            fields = item.split()
-            if len(fields) == 3:
-                users['remote'].append(fields[2])
+        session_paths = {s[4] for s in sessions}
+        user_paths = {u[2] for u in users}
+
+        for p in session_paths:
+            o = self.bus.get_object(self.bus_name, p)
+            i = dbus.Interface(o, PROP_IFACE)
+            props = i.GetAll(SESSION_IFACE)
+
+            if bool(props['Remote']):
                 ret['sessions_remote'] += 1
-            elif len(fields) == 4:
-                users['graphical'].append(fields[2])
+            elif str(props['Type']) in GUI_SESSION_TYPES:
                 ret['sessions_graphical'] += 1
-                seats.append(fields[3])
-            elif len(fields) == 5:
-                users['console'].append(fields[2])
+            elif str(props['Type']) == 'tty':
                 ret['sessions_console'] += 1
-                seats.append(fields[3])
+            elif str(props['Type']) == 'unspecified':
+                ret['sessions_other'] += 1
+            else:
+                self.error('Unknown session type ' + str(props['Type']) + ' for session ' + str(p))
+                ret['sessions_other'] += 1
 
-        ret['users_graphical'] = len(set(users['graphical']))
-        ret['users_console'] = len(set(users['console']))
-        ret['users_remote'] = len(set(users['remote']))
-        ret['seats'] = len(set(seats))
+            if str(props['State']) == 'online':
+                ret['sessions_online'] += 1
+            elif str(props['State']) == 'active':
+                ret['sessions_active'] += 1
+            elif str(props['State']) == 'closing':
+                ret['sessions_closing'] += 1
+            else:
+                self.error('Unknown session state ' + str(props['State']) + ' for session ' + str(p))
+
+        for p in user_paths:
+            o = self.bus.get_object(self.bus_name, p)
+            i = dbus.Interface(o, PROP_IFACE)
+            state = i.Get(USER_IFACE, 'State')
+
+            if str(state) == 'offline':
+                ret['users_offline'] += 1
+            elif str(state) == 'lingering':
+                ret['users_lingering'] += 1
+            elif str(state) == 'online':
+                ret['users_online'] += 1
+            elif str(state) == 'active':
+                ret['users_active'] += 1
+            elif str(state) == 'closing':
+                ret['users_closing'] += 1
+            else:
+                self.error('Unknown user state ' + str(state) + ' for user ' + str(p))
 
         return ret

--- a/collectors/python.d.plugin/logind/logind.chart.py
+++ b/collectors/python.d.plugin/logind/logind.chart.py
@@ -87,7 +87,7 @@ class Service(SimpleService):
             return False
 
         if self.mgr is None:
-            self.error('Unable to connect to ' + self.bus_name + ' service')
+            self.error('Unable to connect to {} service'.format(self.bus_name))
             return False
 
         if self.iface is None:
@@ -144,7 +144,7 @@ class Service(SimpleService):
             elif str(props['State']) == 'closing':
                 ret['sessions_closing'] += 1
             else:
-                self.error('Unknown session state ' + str(props['State']) + ' for session ' + str(p))
+                self.error('Unknown session state {} for session {}'.format(props['State'], p))
 
         for p in user_paths:
             o = self.bus.get_object(self.bus_name, p)
@@ -162,6 +162,6 @@ class Service(SimpleService):
             elif str(state) == 'closing':
                 ret['users_closing'] += 1
             else:
-                self.error('Unknown user state ' + str(state) + ' for user ' + str(p))
+                self.error('Unknown user state {} for user {}'.format(state, p))
 
         return ret

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -534,7 +534,7 @@ netdataDashboard.menu = {
     'logind': {
         title: 'Logind',
         icon: '<i class="fas fa-user"></i>',
-        info: undefined
+        info: 'Counts of users and sessions by state and type provided by either systemd-logind or elogind.'
     },
 
     'powersupply': {
@@ -5920,16 +5920,16 @@ netdataDashboard.context = {
         info: 'Temperature derived from 1-Wire temperature sensors.'
     },
 
-    'logind.sessions': {
-        info: 'Shows the number of active sessions of each type tracked by logind.'
+    'logind.session_types': {
+        info: 'Shows the number of sessions of each type tracked by logind. <code>Graphical</code> sessions are running under one of X11, Mir, or Wayland. <code>Console</code> sessions are usually regular text mode local logins, but depending on how the system is configured may have an associated GUI. <code>Remote</code> sessions are sessions accessed over a remote connection such as SSH. <code>Other</code> sessions are those that do not fall into the above categories (such as sessions for cron jobs or systemd timer units).'
+    },
+
+    'logind.session_states': {
+        info: 'Shows the number of sessions in each state tracked by logind. <code>Online</code> sessions are logged in but running in the background. <code>Active</code> sessions are logged in and running in the foreground. <code>Closing</code> sessions are in the process of logging out.'
     },
 
     'logind.users': {
-        info: 'Shows the number of active users of each type tracked by logind.'
-    },
-
-    'logind.seats': {
-        info: 'Shows the number of active seats tracked by logind.  Each seat corresponds to a combination of a display device and input device providing a physical presence for the system.'
+        info: 'Shows the number of active users in each state tracked by logind. <code>Offline</code> users are tracked, but not logged in. <code>Lingering</code> users are not logged in, but have one or more services still running. <code>Online</code> users are logged in, but have no active sessions. <code>Active</code> users are logged in, and have at least one active session. <code>Closing</code> users are in the process of logging out without lingering.'
     },
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary

- Switch to usin the DBus API directly instead of executing loginctl each cycle. This reduces the collection times significantly for systems without many users logged in concurrently. This results in a new dependency on the DBus bindings provided by `dbus-python`. This module is present by default on many systems that use either `systemd-logind` or `elogind`, so this should not be a significant issue for most users. This switch reduces the regular runtime on my laptop (with a single user session) to about 5ms (compared to hundreds for the old implementation).
- Drop the `seats` chart. A vast majority of systems have exactly one seat, and even when a multi-seat setup is present, it’s pretty much always set up statically at boot and then never reconfigured at runtime. This means that the seats chart is essentially useless for more than 99% of users, so we can eliminate it and save some processing time.
- Track users by state and not login type. Our approach to tracking users by login type was actually a bit expensive in terms of
  processing time, and was not especially useful (any given user can easily have many sessions of differing types). However, tracking users by state _is_ useful, and is very easy to do given that we0re using the DBus API directly, so do that instead.
- Add a new `other` type to the possible session types. This is a catch-all for types we don’t recognize, as well as for cases that are explicitly uncategorized (that is, they are not graphical, not attached to a terminal, and not remote logins). This ensures we correctly match up with both how logind tracks sessions, and what other tools report for session counts.
- Add a new chart tracking sessions by state. Similar logic to having tracking of users by states.

##### Test Plan

This can be tested on any system that uses systemd-logind or elogind, just like the old module. It may require installation of the `dbus-python` Python module on some such systems.

##### Additional Information

Relevant link for the DBus API being used here: https://www.freedesktop.org/software/systemd/man/org.freedesktop.login1.html

And for the Python module being used to talk to DBus: https://dbus.freedesktop.org/doc/dbus-python/index.html

`dbus-python` was picked specifically because it’s exceedingly lightweight compared to the GLib or Qt based DBus bindings for Python.

I’m hoping this will pave the way to this module both being enabled by default, and possibly being reimplemented in Go.

<details> <summary>For users: How does this change affect me?</summary>
Users who use the current logind collector will see a change in what charts and metrics are provided, most likely requiring an update to any alarms they may be using for this collector, though the provided metrics should be generally more useful. Additionally, users may need to install an additional optional dependency to allow the collector to run.
</details>