### PR TITLE
Clean chart hash map 

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -1023,6 +1023,10 @@ void sql_check_aclk_table_list(struct aclk_database_worker_config *wc)
     }
     db_execute("DELETE FROM dimension_delete WHERE host_id NOT IN (SELECT host_id FROM host) "
                " OR unixepoch() - date_created > 604800;");
+
+    db_execute("DELETE FROM chart_hash WHERE CAST(last_used AS INT) < unixepoch() - 604800;");
+    db_execute("DELETE FROM chart_hash_map WHERE hash_id NOT IN (SELECT hash_id FROM chart_hash);");
+
     return;
 }
 


### PR DESCRIPTION
##### Summary
Incremental cleanup of the chart hash map (after a week of entries not being updated)

This table will eventually be removed. This is used by the old (not context) ACLK communication. 
_The old protocol can still be used if so negotiated._

##### Test Plan
- Start the agent and notice the row count in the chart_hash / chart_hash_map table drop after a whil