### PR TITLE
Improve coverage of Linux kernel threads in apps_groups.conf

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -201,7 +201,7 @@ proxmox-ve: pve*
 # containers & virtual machines
 
 containers: lxc* docker* balena*
-VMs: vbox* VBox* qemu* kvm
+VMs: vbox* VBox* qemu* kvm*
 
 # -----------------------------------------------------------------------------
 # ssh servers and clients
@@ -310,13 +310,19 @@ X: '*systemd --user*' chrome *chrome-sandbox* *google-chrome* *chromium* *firefo
 # Kernel / System
 
 ksmd: ksmd
+khugepaged: khugepaged
+kdamond: kdamond
+kswapd: kswapd
+zswap: zswap
+kcompactd: kcompactd
 
 system: systemd-* udisks* udevd* *udevd connmand ipv6_addrconf dbus-* rtkit*
 system: inetd xinetd mdadm polkitd acpid uuidd packagekitd upowerd colord
 system: accounts-daemon rngd haveged
 
-kernel: kthreadd kauditd lockd khelper kdevtmpfs khungtaskd rpciod
-kernel: fsnotify_mark kthrotld deferwq scsi_*
+kernel: kworker kthreadd kauditd lockd khelper kdevtmpfs khungtaskd rpciod
+kernel: fsnotify_mark kthrotld deferwq scsi_* kdmflush oom_reaper kdevtempfs
+kernel: ksoftirqd
 
 # -----------------------------------------------------------------------------
 # other application servers


### PR DESCRIPTION
##### Summary

The following specific ‘groups’ have been added:

- khugepaged is the scanning thread for transparent hugepage (THP) support. It’s present on any Linux system with THP support, but generally not very active except for certain workloads that are pathologically bad for THP usage. Seeing it separated out will make identifying such workloads much easier. I intend to add an alarm for this purpose in a separate PR.
- kdamond is the prefix for the scanning threads for the DAMON framework, a relatively new subsystem for monitoring memory access patterns. Showing these threads separately will help indicate what, if any, impact use of this functionality has on a given workload.
- kswapd is the thread responsible for moving pages between RAM and swap space. normal usage should be proportionate to the rate of swap in/out on the system, but it can be used as a good indicator of exactly how much impact on the system swapping is having (because the CPU overhead is related to a handful of other factors than just rate of swap in/out).
- The zswap kthreads manage the automatic compressed memory mechanism used on some distros. Essentially, they cache compressed copies of pages that got swapped out in RAM when system-wide memory pressure is low. Because compression is involved, this can have a nontrivial impact on CPU usage on the system, so it’s useful to track these threads separately.
- kcompactd is the thread responsible for memory compaction, usually triggered as part of memory reclaim. High CPU usage for this thread usually indicates that the system is underperforming due to memory fragmentation, so tracking it separately is generally useful. I also intend to add an alarm for this one in a separate PR.

The general `kernel` group has also bee expanded to include `ksoftirqd` (responsible for handling soft interrupts per-CPU), `kdmflush` (responsible for flushing data for DM targets, one thread per DM mapping), `oom_reaper`, and `kdevtempfs` (responsible for the filesystem of the same name).

Additionally, the matching for KVM threads has been modified to prefix-match so that it properly catches the supplementary kthreads used for interrupt handling and memory protections.

##### Test Plan

Easily tested by just copying the modified file to a Linux system with Netdata and restarting the agent.