### PR TITLE
add spiceproxy to proxmox group

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -195,7 +195,7 @@ aws: aws
 # -----------------------------------------------------------------------------
 # virtualization platform
 
-proxmox-ve: pve*
+proxmox-ve: pve* spiceproxy
 
 # -----------------------------------------------------------------------------
 # containers & virtual machines


### PR DESCRIPTION
##### Summary

Add [spiceproxy](https://pve.proxmox.com/pve-docs/spiceproxy.8.html) service. Was checking the "other" dimension on the Proxmox server and found that the biggest contributor is spiceproxy (~100MB mem)

##### Test Plan

Tested locally by using updated apps_groups.conf.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
