### PR TITLE
Assorted updates for apps_groups.conf.

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -206,6 +206,7 @@ containers: lxc* docker* balena*
 VMs: vbox* VBox* qemu* kvm*
 libvirt: virtlogd virtqemud virtstoraged virtnetworkd virtlockd virtinterfaced
 libvirt: virtnodedevd virtproxyd virtsecretd libvirtd
+guest-agent: qemu-ga spice-vdagent cloud-init*
 
 # -----------------------------------------------------------------------------
 # ssh servers and clients

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -121,7 +121,7 @@ columndb: clickhouse-server*
 # -----------------------------------------------------------------------------
 # email servers
 
-email: dovecot imapd pop3d amavis* zmstat-* zmdiaglog zmmailboxdmgr saslauthd opendkim postfwd2 smtp* lmtp* sendmail postfix master pickup qmgr showq tlsmgr postscreen oqmgr
+email: dovecot imapd pop3d amavis* zmstat-* zmdiaglog zmmailboxdmgr saslauthd opendkim postfwd2 smtp* lmtp* sendmail postfix master pickup qmgr showq tlsmgr postscreen oqmgr msmtp* nullmailer*
 
 # -----------------------------------------------------------------------------
 # network, routing, VPN

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -246,7 +246,7 @@ build: cargo rustc bazel buck git gdb valgrind* rpmbuild dpkg-buildpackage
 # package management
 
 packagemanager: apt* dpkg* dselect dnf yum rpm zypp* yast* pacman xbps* swupd* emerge*
-packagemanager: packagekitd pkgin pkg apk snapd
+packagemanager: packagekitd pkgin pkg apk snapd slackpkg slapt-get
 
 # -----------------------------------------------------------------------------
 # antivirus
@@ -316,7 +316,7 @@ airflow: *airflow*
 
 gui: X Xorg xinit lightdm xdm gkrellm xfwm4 xfdesktop xfce* Thunar
 gui: xfsettingsd xfconfd gnome-* gdm gconf* dconf* xfconf* *gvfs gvfs* slim
-gui: kdeinit* kdm plasmashell
+gui: *kdeinit* kdm plasmashell
 gui: evolution-* firefox chromium opera vivaldi-bin epiphany WebKit*
 gui: '*systemd --user*' chrome *chrome-sandbox* *google-chrome* *chromium* *firefox*
 gui: colord seatd greetd wayfire sway weston cage

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -218,7 +218,7 @@ print: cups* lpd lpq
 # -----------------------------------------------------------------------------
 # time servers and clients
 
-time: ntp* systemd-timesyn* chronyd
+time: ntp* systemd-timesyn* chronyd ptp*
 
 # -----------------------------------------------------------------------------
 # dhcp servers and clients

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -96,7 +96,7 @@ agent_sd: agent_sd
 # -----------------------------------------------------------------------------
 # authentication/authorization related servers
 
-auth: radius* openldap* ldap* slapd authelia
+auth: radius* openldap* ldap* slapd authelia sssd saslauthd polkitd gssproxy
 fail2ban: fail2ban*
 
 # -----------------------------------------------------------------------------
@@ -121,7 +121,7 @@ columndb: clickhouse-server*
 # -----------------------------------------------------------------------------
 # email servers
 
-email: dovecot imapd pop3d amavis* zmstat-* zmdiaglog zmmailboxdmgr saslauthd opendkim postfwd2 smtp* lmtp* sendmail postfix master pickup qmgr showq tlsmgr postscreen oqmgr msmtp* nullmailer*
+email: dovecot imapd pop3d amavis* zmstat-* zmdiaglog zmmailboxdmgr opendkim postfwd2 smtp* lmtp* sendmail postfix master pickup qmgr showq tlsmgr postscreen oqmgr msmtp* nullmailer*
 
 # -----------------------------------------------------------------------------
 # network, routing, VPN
@@ -131,7 +131,8 @@ vpn: openvpn pptp* cjdroute gvpe tincd wireguard tailscaled
 wifi: hostapd wpa_supplicant
 routing: ospfd* ospf6d* bgpd bfdd fabricd isisd eigrpd sharpd staticd ripd ripngd pimd pbrd nhrpd ldpd zebra vrrpd vtysh bird*
 modem: ModemManager
-netmanager: NetworkManager nm* systemd-networkd networkctl netplan connmand wicked* avahi-autoipd
+netmanager: NetworkManager nm* systemd-networkd networkctl netplan connmand wicked* avahi-autoipd networkd-dispatcher
+firewall: firewalld ufw nft
 tor: tor
 
 # -----------------------------------------------------------------------------
@@ -244,7 +245,7 @@ build: cargo rustc bazel buck git gdb valgrind* rpmbuild dpkg-buildpackage
 # package management
 
 packagemanager: apt* dpkg* dselect dnf yum rpm zypp* yast* pacman xbps* swupd* emerge*
-packagemanager: packagekitd pkgin pkg apk
+packagemanager: packagekitd pkgin pkg apk snapd
 
 # -----------------------------------------------------------------------------
 # antivirus
@@ -330,9 +331,10 @@ zswap: zswap
 kcompactd: kcompactd
 
 system: systemd-* udisks* udevd* *udevd ipv6_addrconf dbus-* rtkit*
-system: mdadm polkitd acpid uuidd upowerd elogind eudev mdev lvmpolld dmeventd
+system: mdadm acpid uuidd upowerd elogind* eudev mdev lvmpolld dmeventd
 system: accounts-daemon rngd haveged rasdaemon irqbalance start-stop-daemon
-system: supervise-daemon openrc* init runit runsvdir runsv
+system: supervise-daemon openrc* init runit runsvdir runsv auditd lsmd
+system: abrt* nscd
 
 kernel: kworker kthreadd kauditd lockd khelper kdevtmpfs khungtaskd rpciod
 kernel: fsnotify_mark kthrotld deferwq scsi_* kdmflush oom_reaper kdevtempfs

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -347,11 +347,6 @@ kernel: ksoftirqd
 inetd: inetd xinetd
 
 # -----------------------------------------------------------------------------
-# printing
-
-printing: cups* lpd
-
-# -----------------------------------------------------------------------------
 # other application servers
 
 consul: consul

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -155,7 +155,7 @@ chat: irssi *vines* *prosody* murmurd
 # -----------------------------------------------------------------------------
 # monitoring
 
-logs: ulogd* syslog* rsyslog* logrotate systemd-journald rotatelogs
+logs: ulogd* syslog* rsyslog* logrotate systemd-journald rotatelogs sysklogd metalog
 nms: snmpd vnstatd smokeping zabbix* munin* mon openhpid tailon nrpe
 monit: monit
 splunk: splunkd
@@ -327,12 +327,18 @@ zswap: zswap
 kcompactd: kcompactd
 
 system: systemd-* udisks* udevd* *udevd ipv6_addrconf dbus-* rtkit*
-system: inetd xinetd mdadm polkitd acpid uuidd upowerd
-system: accounts-daemon rngd haveged
+system: mdadm polkitd acpid uuidd upowerd elogind eudev mdev lvmpolld dmeventd
+system: accounts-daemon rngd haveged rasdaemon irqbalance start-stop-daemon
+system: supervise-daemon openrc* init runit runsvdir runsv
 
 kernel: kworker kthreadd kauditd lockd khelper kdevtmpfs khungtaskd rpciod
 kernel: fsnotify_mark kthrotld deferwq scsi_* kdmflush oom_reaper kdevtempfs
 kernel: ksoftirqd
+
+# -----------------------------------------------------------------------------
+# inetd
+
+inetd: inetd xinetd
 
 # -----------------------------------------------------------------------------
 # other application servers

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -398,3 +398,8 @@ locust: locust
 # data science and machine learning tools
 
 jupyter: jupyter*
+
+# -----------------------------------------------------------------------------
+# File synchronization tools
+
+filesync: dropbox syncthing

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -208,7 +208,7 @@ VMs: vbox* VBox* qemu* kvm*
 # -----------------------------------------------------------------------------
 # ssh servers and clients
 
-ssh: ssh* scp dropbear
+ssh: ssh* scp sftp* dropbear
 
 # -----------------------------------------------------------------------------
 # print servers and clients

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -204,6 +204,8 @@ proxmox-ve: pve* spiceproxy
 
 containers: lxc* docker* balena*
 VMs: vbox* VBox* qemu* kvm*
+libvirt: virtlogd virtqemud virtstoraged virtnetworkd virtlockd virtinterfaced
+libvirt: virtnodedevd virtproxyd virtsecretd libvirtd
 
 # -----------------------------------------------------------------------------
 # ssh servers and clients

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -139,7 +139,7 @@ tor: tor
 
 camo: *camo*
 balancer: ipvs_* haproxy
-ha: corosync hs_logd ha_logd stonithd pacemakerd lrmd crmd keepalived
+ha: corosync hs_logd ha_logd stonithd pacemakerd lrmd crmd keepalived ucarp*
 
 # -----------------------------------------------------------------------------
 # telephony

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -344,6 +344,11 @@ kernel: ksoftirqd
 inetd: inetd xinetd
 
 # -----------------------------------------------------------------------------
+# printing
+
+printing: cups* lpd
+
+# -----------------------------------------------------------------------------
 # other application servers
 
 consul: consul

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -273,6 +273,9 @@ ups: upsmon upsd */nut/* apcupsd
 
 media: mplayer vlc xine mediatomb omxplayer* kodi* xbmc* mediacenter eventlircd
 media: mpd minidlnad mt-daapd avahi* Plex* jellyfin squeeze* jackett Ombi
+media: strawberry* clementine*
+
+audio: pulse* pipewire wireplumber jack*
 
 # -----------------------------------------------------------------------------
 # java applications

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -226,7 +226,7 @@ time: ntp* systemd-timesyn* chronyd ptp*
 # -----------------------------------------------------------------------------
 # dhcp servers and clients
 
-dhcp: *dhcp*
+dhcp: *dhcp* dhclient
 
 # -----------------------------------------------------------------------------
 # name servers and clients

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -134,6 +134,7 @@ modem: ModemManager
 netmanager: NetworkManager nm* systemd-networkd networkctl netplan connmand wicked* avahi-autoipd networkd-dispatcher
 firewall: firewalld ufw nft
 tor: tor
+bluetooth: bluetooth bluez bluedevil obexd
 
 # -----------------------------------------------------------------------------
 # high availability and balancers

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -102,7 +102,7 @@ fail2ban: fail2ban*
 # -----------------------------------------------------------------------------
 # web/ftp servers
 
-httpd: apache* httpd nginx* lighttpd hiawatha caddy
+httpd: apache* httpd nginx* lighttpd hiawatha caddy h2o
 proxy: squid* c-icap squidGuard varnish*
 php: php* lsphp*
 ftpd: proftpd in.tftpd vsftpd

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -156,7 +156,8 @@ chat: irssi *vines* *prosody* murmurd
 # monitoring
 
 logs: ulogd* syslog* rsyslog* logrotate systemd-journald rotatelogs
-nms: snmpd vnstatd smokeping zabbix* monit munin* mon openhpid watchdog tailon nrpe
+nms: snmpd vnstatd smokeping zabbix* munin* mon openhpid tailon nrpe
+monit: monit
 splunk: splunkd
 azure: mdsd *waagent* *omiserver* *omiagent* hv_kvp_daemon hv_vss_daemon *auoms* *omsagent*
 datadog: *datadog*
@@ -165,6 +166,7 @@ newrelic: newrelic*
 google-agent: *google_guest_agent* *google_osconfig_agent*
 nvidia-smi: nvidia-smi
 htop: htop
+watchdog: watchdog
 
 # -----------------------------------------------------------------------------
 # storage, file systems and file servers

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -131,7 +131,7 @@ vpn: openvpn pptp* cjdroute gvpe tincd wireguard tailscaled
 wifi: hostapd wpa_supplicant
 routing: ospfd* ospf6d* bgpd bfdd fabricd isisd eigrpd sharpd staticd ripd ripngd pimd pbrd nhrpd ldpd zebra vrrpd vtysh bird*
 modem: ModemManager
-netmanager: NetworkManager nm* systemd-networkd networkctl netplan
+netmanager: NetworkManager nm* systemd-networkd networkctl netplan connmand wicked*
 tor: tor
 
 # -----------------------------------------------------------------------------
@@ -316,7 +316,7 @@ kswapd: kswapd
 zswap: zswap
 kcompactd: kcompactd
 
-system: systemd-* udisks* udevd* *udevd connmand ipv6_addrconf dbus-* rtkit*
+system: systemd-* udisks* udevd* *udevd ipv6_addrconf dbus-* rtkit*
 system: inetd xinetd mdadm polkitd acpid uuidd packagekitd upowerd colord
 system: accounts-daemon rngd haveged
 

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -131,7 +131,7 @@ vpn: openvpn pptp* cjdroute gvpe tincd wireguard tailscaled
 wifi: hostapd wpa_supplicant
 routing: ospfd* ospf6d* bgpd bfdd fabricd isisd eigrpd sharpd staticd ripd ripngd pimd pbrd nhrpd ldpd zebra vrrpd vtysh bird*
 modem: ModemManager
-netmanager: NetworkManager nm* systemd-networkd networkctl netplan connmand wicked*
+netmanager: NetworkManager nm* systemd-networkd networkctl netplan connmand wicked* avahi-autoipd
 tor: tor
 
 # -----------------------------------------------------------------------------
@@ -231,7 +231,7 @@ dhcp: *dhcp* dhclient
 # -----------------------------------------------------------------------------
 # name servers and clients
 
-dns: named unbound nsd pdns_server knotd gdnsd yadifad dnsmasq systemd-resolve* pihole*
+dns: named unbound nsd pdns_server knotd gdnsd yadifad dnsmasq systemd-resolve* pihole* avahi-daemon avahi-dnsconfd
 dnsdist: dnsdist
 
 # -----------------------------------------------------------------------------
@@ -275,7 +275,7 @@ ups: upsmon upsd */nut/* apcupsd
 # media players, servers, clients
 
 media: mplayer vlc xine mediatomb omxplayer* kodi* xbmc* mediacenter eventlircd
-media: mpd minidlnad mt-daapd avahi* Plex* jellyfin squeeze* jackett Ombi
+media: mpd minidlnad mt-daapd Plex* jellyfin squeeze* jackett Ombi
 media: strawberry* clementine*
 
 audio: pulse* pipewire wireplumber jack*

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -307,13 +307,14 @@ solr: *solr.install.dir*
 airflow: *airflow*
 
 # -----------------------------------------------------------------------------
-# X
+# GUI
 
-X: X Xorg xinit lightdm xdm pulseaudio gkrellm xfwm4 xfdesktop xfce* Thunar
-X: xfsettingsd xfconfd gnome-* gdm gconf* dconf* xfconf* *gvfs gvfs* slim
-X: kdeinit* kdm plasmashell
-X: evolution-* firefox chromium opera vivaldi-bin epiphany WebKit*
-X: '*systemd --user*' chrome *chrome-sandbox* *google-chrome* *chromium* *firefox*
+gui: X Xorg xinit lightdm xdm gkrellm xfwm4 xfdesktop xfce* Thunar
+gui: xfsettingsd xfconfd gnome-* gdm gconf* dconf* xfconf* *gvfs gvfs* slim
+gui: kdeinit* kdm plasmashell
+gui: evolution-* firefox chromium opera vivaldi-bin epiphany WebKit*
+gui: '*systemd --user*' chrome *chrome-sandbox* *google-chrome* *chromium* *firefox*
+gui: colord seatd greetd wayfire sway weston cage
 
 # -----------------------------------------------------------------------------
 # Kernel / System
@@ -326,7 +327,7 @@ zswap: zswap
 kcompactd: kcompactd
 
 system: systemd-* udisks* udevd* *udevd ipv6_addrconf dbus-* rtkit*
-system: inetd xinetd mdadm polkitd acpid uuidd upowerd colord
+system: inetd xinetd mdadm polkitd acpid uuidd upowerd
 system: accounts-daemon rngd haveged
 
 kernel: kworker kthreadd kauditd lockd khelper kdevtmpfs khungtaskd rpciod

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -235,9 +235,13 @@ dnsdist: dnsdist
 # installation / compilation / debugging
 
 build: cc1 cc1plus as gcc* cppcheck ld make cmake automake autoconf autoreconf
-build: cargo rustc bazel buck git gdb valgrind*
+build: cargo rustc bazel buck git gdb valgrind* rpmbuild dpkg-buildpackage
 
-apt: apt*
+# -----------------------------------------------------------------------------
+# package management
+
+packagemanager: apt* dpkg* dselect dnf yum rpm zypp* yast* pacman xbps* swupd* emerge*
+packagemanager: packagekitd pkgin pkg apk
 
 # -----------------------------------------------------------------------------
 # antivirus
@@ -319,7 +323,7 @@ zswap: zswap
 kcompactd: kcompactd
 
 system: systemd-* udisks* udevd* *udevd ipv6_addrconf dbus-* rtkit*
-system: inetd xinetd mdadm polkitd acpid uuidd packagekitd upowerd colord
+system: inetd xinetd mdadm polkitd acpid uuidd upowerd colord
 system: accounts-daemon rngd haveged
 
 kernel: kworker kthreadd kauditd lockd khelper kdevtmpfs khungtaskd rpciod


### PR DESCRIPTION
##### Summary

This is a sweeping set of updates to the default apps plugin configuration, with the goal of a basic install of most Linux distributions having complete coverage of all basic system services (IOW, everything under `other` on such a system should be user activity).

- The `auth` group is expanded to include sssd (used on Fedora and RHEL systems) and gssproxy, as well as properly categorizing polkitd and saslauthd as authentication tools instead of ‘system’ and ‘mail’ respectively.
- The `httpd` group now includes H2O.
- The `email` group now includes msmtp (widely used on minimalist systems, as well as in our own Docker images) and nullmailer (widely used on Debian systems).
- The `netmanager` group is expanded to include all the common network management daemons.
- A new ‘firewall’ group covers firewalld, UFW, and the nftables tooling.
- A new `bluetooth` group has been added to cover Bluetooth tooling.
- The `ha` group now includes `ucarp`, which is a userspace FOSS implementation of Cisco’s VRRP, used on pfSense and other firewall appliances.
- The `logs` group now includes syskogd and metalog (the next most common syslog implementations after what we already have listed).
- Monit is now it’s own group, instead of being grouped with other NMS tools. It’s used for a _lot_ more than just NMS.
- Watchdog is now it’s own group, instead of being grouped with other NMS tools, as it has a nontrivial probability of matching things that are _not_ NMS tools.
- A new group has been added to cover libvirt services.
- A new group has been added to cover userspace guest agents for VMs. Currently includes the QEMU and SPICE guest agents, plus cloud-init (which is functionally a guest agent).
- SFTP tooling has been added to the `ssh` group. Depending on circumstances, the SFTP component may actually be a separate process from the SSH server, so we should be explicitly matching on it here.
- PTP tooling has been added to the `time` group. PTP is an alternative to NTP that provides much tighter synchronization over local networks with much lower overhead, but does not support ‘internet time’. It’s used mostly in scientific computing contexts where clock synchronization within a cluster is more important than the cluster having the ‘correct’ time from outside perspectives.
- The ISC DHCP client (`dhclient`) is now properly categorized as DHCP tooling.
- Avahi is now properly categorized in the `dns` group (except for `avahi-autoipd`, which is a netowrk manager).
- Coverage of package managers has been greatly expanded with a new `packagemanager` group. This group includes standard package management tooling from most common distributions, as well as packagekit (moved from the system group).
- The media group has been expanded to include a couple of additional media players.
- A new `audio` group has been added to cover sound servers. It includes pulseaudio (moved from the now renamed `X` group), pipewire, wireplumber (the pipewire session management tooling), and JACK.
- The `X` group has been renamed to `gui`, and expanded to include colord (moved from the system group), seatd (a seat management daemon popular for use with Wayland), greetd (a display-manager equivalent tool used widely with Wayland), and a selection of popular Wayland compositors.
- The `system` group has been greatly expanded, and now includes all of the following:
    - elogind: A popular non-systemd replacement for systemd-logind.  Used by default on most non-systemd systems.
    - eudev and mdev: Popular alternatives to the systemd udev implementation.
    - llvmpolld and dmeventd: Widely used supplementary services for LVM. llvmpolld provides background completion polling for long running LVM operations, and dmeventd provides monitoring and auto-remediation functionality.
    - rasdaemon: Provides userspace logging of memory errors and MCEs.
    - irqbalance: Widely used tool for managing IRQ distribution on large x86 systems
    - start-stop-daemon: Widely used tool for managing daemons on non-systemd systems.
    - A generic match for init.
    - OpenRC’s standard tooling (the `openrc*` and `supervise-daemon` matches).
    - Runit’s standard tooling (the `runit`, `runsvdir`, and `runsv` matches).
    - auditd: the standard userspace component for Linux’s auditing framework.
    - lsmd: System service for libstoragemanagement, used by default on RHEL systems.
    - abrt: The RHEL/Fedora automatic bug reporting tool.
    - NSCD: The name service cache daemon, used by default on openSUSE, provides caching for `getent()` calls.
- A new `inetd` group has been created for inetd and xinetd (moved from the system group). These both are potential targets for DoS attacks, so categorizing them separately is important.
- A new `filesysnc` group has been created for Dropbox and Syncthing.

##### Test Plan

The modified config file can be directly copied to any system running Netdata, and then the agent restarted.