### PR TITLE
Deaggregate the `gui` and `email` app groupx and improve GUI coverage.

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -354,7 +354,7 @@ system: systemd-* udisks* udevd* *udevd ipv6_addrconf dbus-* rtkit*
 system: mdadm acpid uuidd upowerd elogind* eudev mdev lvmpolld dmeventd
 system: accounts-daemon rngd haveged rasdaemon irqbalance start-stop-daemon
 system: supervise-daemon openrc* init runit runsvdir runsv auditd lsmd
-system: abrt* nscd rtkit-daemon gpg-agent
+system: abrt* nscd rtkit-daemon gpg-agent usbguard*
 
 kernel: kworker kthreadd kauditd lockd khelper kdevtmpfs khungtaskd rpciod
 kernel: fsnotify_mark kthrotld deferwq scsi_* kdmflush oom_reaper kdevtempfs

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -337,7 +337,7 @@ gui: lightdm colord seatd greetd gkrellm slim qingy dconf* *gvfs gvfs*
 gui: '*systemd --user*' xdg-* at-spi-*
 
 webbrowser: *chrome-sandbox* *google-chrome* *chromium* *firefox* vivaldi* opera* epiphany
-webbrowser: lynx elinks w3m w3mmee
+webbrowser: lynx elinks w3m w3mmee links
 mua: evolution-* thunderbird* mutt neomutt pine mailx alpine
 
 # -----------------------------------------------------------------------------

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -121,7 +121,8 @@ columndb: clickhouse-server*
 # -----------------------------------------------------------------------------
 # email servers
 
-email: dovecot imapd pop3d amavis* zmstat-* zmdiaglog zmmailboxdmgr opendkim postfwd2 smtp* lmtp* sendmail postfix master pickup qmgr showq tlsmgr postscreen oqmgr msmtp* nullmailer*
+mta: amavis* zmstat-* zmdiaglog zmmailboxdmgr opendkim postfwd2 smtp* lmtp* sendmail postfix master pickup qmgr showq tlsmgr postscreen oqmgr msmtp* nullmailer*
+mda: dovecot *imapd *pop3d *popd
 
 # -----------------------------------------------------------------------------
 # network, routing, VPN
@@ -180,6 +181,7 @@ zfs: spl_* z_* txg_* zil_* arc_* l2arc*
 btrfs: btrfs*
 iscsi: iscsid iscsi_eh
 afp: netatalk afpd cnid_dbd cnid_metad
+ntfs-3g: ntfs-3g
 
 # -----------------------------------------------------------------------------
 # kubernetes
@@ -314,12 +316,28 @@ airflow: *airflow*
 # -----------------------------------------------------------------------------
 # GUI
 
-gui: X Xorg xinit lightdm xdm gkrellm xfwm4 xfdesktop xfce* Thunar
-gui: xfsettingsd xfconfd gnome-* gdm gconf* dconf* xfconf* *gvfs gvfs* slim
-gui: *kdeinit* kdm plasmashell
-gui: evolution-* firefox chromium opera vivaldi-bin epiphany WebKit*
-gui: '*systemd --user*' chrome *chrome-sandbox* *google-chrome* *chromium* *firefox*
-gui: colord seatd greetd wayfire sway weston cage
+X: X Xorg xinit xdm Xwayland xsettingsd
+wayland: swaylock swayidle waypipe wayvnc
+kde: *kdeinit* kdm sddm plasmashell startplasma-* kwin* kwallet* krunner kactivitymanager*
+gnome: gnome-* gdm gconf* mutter
+mate: mate-* msd-* marco*
+cinnamon: cinnamon* muffin
+xfce: xfwm4 xfdesktop xfce* Thunar xfsettingsd xfconf*
+lxde: lxde* startlxde lxdm lxappearance* lxlauncher* lxpanel* lxsession* lxsettings*
+lxqt: lxqt* startlxqt
+enlightenment: entrance enlightenment*
+i3: i3*
+awesome: awesome awesome-client
+dwm: dwm.*
+sway: sway
+weston: weston
+cage: cage
+wayfire: wayfire
+gui: lightdm colord seatd greetd gkrellm slim qingy dconf* *gvfs gvfs*
+gui: '*systemd --user*' xdg-* at-spi-*
+
+webbrowser: *chrome-sandbox* *google-chrome* *chromium* *firefox* vivaldi* opera* epiphany
+mua: evolution-* thunderbird* mutt neomutt pine mailx alpine
 
 # -----------------------------------------------------------------------------
 # Kernel / System
@@ -335,7 +353,7 @@ system: systemd-* udisks* udevd* *udevd ipv6_addrconf dbus-* rtkit*
 system: mdadm acpid uuidd upowerd elogind* eudev mdev lvmpolld dmeventd
 system: accounts-daemon rngd haveged rasdaemon irqbalance start-stop-daemon
 system: supervise-daemon openrc* init runit runsvdir runsv auditd lsmd
-system: abrt* nscd
+system: abrt* nscd rtkit-daemon gpg-agent
 
 kernel: kworker kthreadd kauditd lockd khelper kdevtmpfs khungtaskd rpciod
 kernel: fsnotify_mark kthrotld deferwq scsi_* kdmflush oom_reaper kdevtempfs

--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -337,6 +337,7 @@ gui: lightdm colord seatd greetd gkrellm slim qingy dconf* *gvfs gvfs*
 gui: '*systemd --user*' xdg-* at-spi-*
 
 webbrowser: *chrome-sandbox* *google-chrome* *chromium* *firefox* vivaldi* opera* epiphany
+webbrowser: lynx elinks w3m w3mmee
 mua: evolution-* thunderbird* mutt neomutt pine mailx alpine
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary

This splits the `gui` and `email` groups in the apps plugin config into a number of much smaller and more descriptive groups, as well as expanding what we cover for a number of the resultant groups. In particular:

- The `email` group has been explicitly split into two separate groups, `mta` for mail transfer agents (SMTP servers), and `mda` for mail delivery agents (IMAP/POP3 servers). The new `mda` group prrovides slightly better coverage of MDA software than the old `email` group did.
-  A new `mua` group has been added for email clients (formally Mail User Agents), covering Evolution, Thunderbird, and a selection of popular console email clients.
- A new `ntfs` group has been created, matching on NTFS-3G. This particular software is in relatively widespread usage on Linux desktop systems, and does not generally get automatically matched by the `gui` group.
- A re-added `X` group covers _only_ X11, XDM, Xwayland, and xsettingsd.
- A new `wayland` group covers a handful of tools commonly used with Wayland independent of the choice of compositor.
- A new `kde` group covers all of the standard KDE 5 and Plasma tooling, including some things we were previously not matching correctly that may not be in the process tree of the KDE session itself.
- New groups also cover the GNOME, MATE, Cinnamon, XFCE4, LXDE, LXQt, and Enlightenment desktop environments.
- New groups have been added to cover i3, DWM, and AwesomeWM, three of the most popular standalone X11 window managers on Linux.
- New groups have been added to cover Sway, Wayfire, Cage, and Westom, four commonly used Wayland compositors.
- The `gui` group is retained, matching on GUI specific tooling that is not DE/Compositor specific. It has also been expanded to include a couple of additional components we were not matching on previously, such as the XDG portal tooling.
- A new `webbrowser` group has been added, covering the most common web browsers on Linux (including some widely used text-mode browsers).
- RTKit and gpg-agent have both been added to the system group. Both are relatively commonly used on Linux desktop systems, but are not GUI specific.
- USBGuard has been added to the system group. It’s mostly of interest on desktop systems, but again is not GUI specific.

This approach has a couple of potentially undesirable limitations:
- Any GUI applications not matched explicitly will be grouped under the desktop environment they are running under, instead of being generically listed as `gui`.
- This does not resolve the existing issue of not reliably including desktop components that are outside of the primary desktop session process tree. There’s not really any way to fix this within the current semantics of the plugin, as we need to be looking at session grouping information provided by logind/elogind.
- Similarly, Wayland compositors we do not explicitly match may not even show up as GUI applications in most cases, due to there not reliably being a consistent top-level application name to match on for Wayland.

##### Test Plan

Simply copy the modified config file to a system with a desktop environment running Netdata.

##### Additional Information

Attempt at a resolution for: https://github.com/netdata/netdata/discussions/13491

This is an initial revision of this change, put together over the past week or so during my free time. Aside from the limitations mentioned above in the summary, I’ve probably also missed some things, and there are probably certain aspects that may be contentious.