### PR TITLE
Fix worker utilization cleanup

### DIFF
--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -1917,7 +1917,7 @@ static void worker_utilization_charts(void) {
 }
 
 static void worker_utilization_finish(void) {
-    int i;
+    int i, j;
     for(i = 0; all_workers_utilization[i].name ;i++) {
         struct worker_utilization *wu = &all_workers_utilization[i];
 
@@ -1926,12 +1926,12 @@ static void worker_utilization_finish(void) {
             wu->name_lowercase = NULL;
         }
 
-        for(i = 0; i < WORKER_UTILIZATION_MAX_JOB_TYPES ;i++) {
-            string_freez(wu->per_job_type[i].name);
-            wu->per_job_type[i].name = NULL;
+        for(j = 0; j < WORKER_UTILIZATION_MAX_JOB_TYPES ;j++) {
+            string_freez(wu->per_job_type[j].name);
+            wu->per_job_type[j].name = NULL;
 
-            string_freez(wu->per_job_type[i].units);
-            wu->per_job_type[i].units = NULL;
+            string_freez(wu->per_job_type[j].units);
+            wu->per_job_type[j].units = NULL;
         }
 
         // mark all threads as not enabled


### PR DESCRIPTION
##### Summary
Fixes the worker utilization cleanup that may cause a crash (and issue reported by the sanitizer)

```
    #0 0x55a269dba80f in worker_utilization_finish daemon/global_statistics.c:1867
    #1 0x55a269dba8e2 in global_statistics_cleanup daemon/global_statistics.c:1903
    #2 0x55a269dbaada in global_statistics_main daemon/global_statistics.c:1917
    #3 0x55a269e39372 in thread_start libnetdata/threads/threads.c:187
    #4 0x7fef441a2b42 in start_thread nptl/pthread_create.c:442
    #5 0x7fef442349ff  (/lib/x86_64-linux-gnu/libc.so.6+0x1269ff)
```

eg. Compile adding the following flags
`-fno-omit-frame-pointer -fsanitize=address -fno-sanitize=shift -fno-sanitize-recover=all -fno-sanitize=null -fno-sanitize=alignment -fno-omit-frame-pointer` 

##### Test Plan
- No error reported by the sanitizer in global_statistics cleanup