### PR TITLE
Obsolete RRDSET state

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -1231,7 +1231,7 @@ char *aclk_state_json(void)
 }
 
 void add_aclk_host_labels(void) {
-    DICTIONARY *labels = localhost->host_labels;
+    DICTIONARY *labels = localhost->rrdlabels;
 
 #ifdef ENABLE_ACLK
     rrdlabels_add(labels, "_aclk_available", "true", RRDLABEL_SRC_AUTO|RRDLABEL_SRC_ACLK);

--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -197,10 +197,10 @@ PARSER_RC pluginsd_overwrite_action(void *user, RRDHOST *host, DICTIONARY *new_h
 {
     UNUSED(user);
 
-    if(!host->host_labels)
-        host->host_labels = rrdlabels_create();
+    if(!host->rrdlabels)
+        host->rrdlabels = rrdlabels_create();
 
-    rrdlabels_migrate_to_these(host->host_labels, new_host_labels);
+    rrdlabels_migrate_to_these(host->rrdlabels, new_host_labels);
     sql_store_host_labels(host);
 
     return PARSER_RC_OK;

--- a/collectors/proc.plugin/proc_diskstats.c
+++ b/collectors/proc.plugin/proc_diskstats.c
@@ -853,25 +853,25 @@ static struct disk *get_disk(unsigned long major, unsigned long minor, char *dis
 }
 
 static void add_labels_to_disk(struct disk *d, RRDSET *st) {
-    rrdlabels_add(st->chart_labels, "device", d->disk, RRDLABEL_SRC_AUTO);
-    rrdlabels_add(st->chart_labels, "mount_point", d->mount_point, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(st->rrdlabels, "device", d->disk, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(st->rrdlabels, "mount_point", d->mount_point, RRDLABEL_SRC_AUTO);
 
     switch (d->type) {
         default:
         case DISK_TYPE_UNKNOWN:
-            rrdlabels_add(st->chart_labels, "device_type", "unknown", RRDLABEL_SRC_AUTO);
+            rrdlabels_add(st->rrdlabels, "device_type", "unknown", RRDLABEL_SRC_AUTO);
             break;
 
         case DISK_TYPE_PHYSICAL:
-            rrdlabels_add(st->chart_labels, "device_type", "physical", RRDLABEL_SRC_AUTO);
+            rrdlabels_add(st->rrdlabels, "device_type", "physical", RRDLABEL_SRC_AUTO);
             break;
 
         case DISK_TYPE_PARTITION:
-            rrdlabels_add(st->chart_labels, "device_type", "partition", RRDLABEL_SRC_AUTO);
+            rrdlabels_add(st->rrdlabels, "device_type", "partition", RRDLABEL_SRC_AUTO);
             break;
 
         case DISK_TYPE_VIRTUAL:
-            rrdlabels_add(st->chart_labels, "device_type", "virtual", RRDLABEL_SRC_AUTO);
+            rrdlabels_add(st->rrdlabels, "device_type", "virtual", RRDLABEL_SRC_AUTO);
             break;
     }
 

--- a/collectors/proc.plugin/proc_diskstats.c
+++ b/collectors/proc.plugin/proc_diskstats.c
@@ -853,25 +853,25 @@ static struct disk *get_disk(unsigned long major, unsigned long minor, char *dis
 }
 
 static void add_labels_to_disk(struct disk *d, RRDSET *st) {
-    rrdlabels_add(st->state->chart_labels, "device", d->disk, RRDLABEL_SRC_AUTO);
-    rrdlabels_add(st->state->chart_labels, "mount_point", d->mount_point, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(st->chart_labels, "device", d->disk, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(st->chart_labels, "mount_point", d->mount_point, RRDLABEL_SRC_AUTO);
 
     switch (d->type) {
         default:
         case DISK_TYPE_UNKNOWN:
-            rrdlabels_add(st->state->chart_labels, "device_type", "unknown", RRDLABEL_SRC_AUTO);
+            rrdlabels_add(st->chart_labels, "device_type", "unknown", RRDLABEL_SRC_AUTO);
             break;
 
         case DISK_TYPE_PHYSICAL:
-            rrdlabels_add(st->state->chart_labels, "device_type", "physical", RRDLABEL_SRC_AUTO);
+            rrdlabels_add(st->chart_labels, "device_type", "physical", RRDLABEL_SRC_AUTO);
             break;
 
         case DISK_TYPE_PARTITION:
-            rrdlabels_add(st->state->chart_labels, "device_type", "partition", RRDLABEL_SRC_AUTO);
+            rrdlabels_add(st->chart_labels, "device_type", "partition", RRDLABEL_SRC_AUTO);
             break;
 
         case DISK_TYPE_VIRTUAL:
-            rrdlabels_add(st->state->chart_labels, "device_type", "virtual", RRDLABEL_SRC_AUTO);
+            rrdlabels_add(st->chart_labels, "device_type", "virtual", RRDLABEL_SRC_AUTO);
             break;
     }
 

--- a/collectors/proc.plugin/proc_interrupts.c
+++ b/collectors/proc.plugin/proc_interrupts.c
@@ -228,7 +228,7 @@ int do_proc_interrupts(int update_every, usec_t dt) {
 
                 char core[50+1];
                 snprintfz(core, 50, "cpu%d", c);
-                rrdlabels_add(core_st[c]->chart_labels, "cpu", core, RRDLABEL_SRC_AUTO);
+                rrdlabels_add(core_st[c]->rrdlabels, "cpu", core, RRDLABEL_SRC_AUTO);
             }
             else rrdset_next(core_st[c]);
 

--- a/collectors/proc.plugin/proc_interrupts.c
+++ b/collectors/proc.plugin/proc_interrupts.c
@@ -228,7 +228,7 @@ int do_proc_interrupts(int update_every, usec_t dt) {
 
                 char core[50+1];
                 snprintfz(core, 50, "cpu%d", c);
-                rrdlabels_add(core_st[c]->state->chart_labels, "cpu", core, RRDLABEL_SRC_AUTO);
+                rrdlabels_add(core_st[c]->chart_labels, "cpu", core, RRDLABEL_SRC_AUTO);
             }
             else rrdset_next(core_st[c]);
 

--- a/collectors/proc.plugin/proc_mdstat.c
+++ b/collectors/proc.plugin/proc_mdstat.c
@@ -78,8 +78,8 @@ static inline void make_chart_obsolete(char *name, const char *id_modifier)
 }
 
 static void add_labels_to_mdstat(struct raid *raid, RRDSET *st) {
-    rrdlabels_add(st->state->chart_labels, "device", raid->name, RRDLABEL_SRC_AUTO);
-    rrdlabels_add(st->state->chart_labels, "raid_level", raid->level, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(st->chart_labels, "device", raid->name, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(st->chart_labels, "raid_level", raid->level, RRDLABEL_SRC_AUTO);
     rrdcalc_update_rrdlabels(st);
 }
 

--- a/collectors/proc.plugin/proc_mdstat.c
+++ b/collectors/proc.plugin/proc_mdstat.c
@@ -78,8 +78,8 @@ static inline void make_chart_obsolete(char *name, const char *id_modifier)
 }
 
 static void add_labels_to_mdstat(struct raid *raid, RRDSET *st) {
-    rrdlabels_add(st->chart_labels, "device", raid->name, RRDLABEL_SRC_AUTO);
-    rrdlabels_add(st->chart_labels, "raid_level", raid->level, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(st->rrdlabels, "device", raid->name, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(st->rrdlabels, "raid_level", raid->level, RRDLABEL_SRC_AUTO);
     rrdcalc_update_rrdlabels(st);
 }
 

--- a/collectors/proc.plugin/proc_net_wireless.c
+++ b/collectors/proc.plugin/proc_net_wireless.c
@@ -199,7 +199,7 @@ static void configure_device(int do_status, int do_quality, int do_discarded_pac
 }
 
 static void add_labels_to_wireless(struct netwireless *w, RRDSET *st) {
-    rrdlabels_add(st->chart_labels, "device", w->name, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(st->rrdlabels, "device", w->name, RRDLABEL_SRC_AUTO);
     rrdcalc_update_rrdlabels(st);
 }
 

--- a/collectors/proc.plugin/proc_net_wireless.c
+++ b/collectors/proc.plugin/proc_net_wireless.c
@@ -199,7 +199,7 @@ static void configure_device(int do_status, int do_quality, int do_discarded_pac
 }
 
 static void add_labels_to_wireless(struct netwireless *w, RRDSET *st) {
-    rrdlabels_add(st->state->chart_labels, "device", w->name, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(st->chart_labels, "device", w->name, RRDLABEL_SRC_AUTO);
     rrdcalc_update_rrdlabels(st);
 }
 

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -261,9 +261,9 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
 
             char node[50+1];
             snprintfz(node, 50, "node%d", pgl->node);
-            rrdlabels_add(st_nodezonetype[p]->state->chart_labels, "node_id", node, RRDLABEL_SRC_AUTO);
-            rrdlabels_add(st_nodezonetype[p]->state->chart_labels, "node_zone", pgl->zone, RRDLABEL_SRC_AUTO);
-            rrdlabels_add(st_nodezonetype[p]->state->chart_labels, "node_type", pgl->type, RRDLABEL_SRC_AUTO);
+            rrdlabels_add(st_nodezonetype[p]->chart_labels, "node_id", node, RRDLABEL_SRC_AUTO);
+            rrdlabels_add(st_nodezonetype[p]->chart_labels, "node_zone", pgl->zone, RRDLABEL_SRC_AUTO);
+            rrdlabels_add(st_nodezonetype[p]->chart_labels, "node_type", pgl->type, RRDLABEL_SRC_AUTO);
 
             for (o = 0; o < pageorders_cnt; o++) {
                 char dimid[3+1];

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -261,9 +261,9 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
 
             char node[50+1];
             snprintfz(node, 50, "node%d", pgl->node);
-            rrdlabels_add(st_nodezonetype[p]->chart_labels, "node_id", node, RRDLABEL_SRC_AUTO);
-            rrdlabels_add(st_nodezonetype[p]->chart_labels, "node_zone", pgl->zone, RRDLABEL_SRC_AUTO);
-            rrdlabels_add(st_nodezonetype[p]->chart_labels, "node_type", pgl->type, RRDLABEL_SRC_AUTO);
+            rrdlabels_add(st_nodezonetype[p]->rrdlabels, "node_id", node, RRDLABEL_SRC_AUTO);
+            rrdlabels_add(st_nodezonetype[p]->rrdlabels, "node_zone", pgl->zone, RRDLABEL_SRC_AUTO);
+            rrdlabels_add(st_nodezonetype[p]->rrdlabels, "node_type", pgl->type, RRDLABEL_SRC_AUTO);
 
             for (o = 0; o < pageorders_cnt; o++) {
                 char dimid[3+1];

--- a/collectors/proc.plugin/proc_softirqs.c
+++ b/collectors/proc.plugin/proc_softirqs.c
@@ -220,7 +220,7 @@ int do_proc_softirqs(int update_every, usec_t dt) {
 
                 char core[50+1];
                 snprintfz(core, 50, "cpu%d", c);
-                rrdlabels_add(core_st[c]->state->chart_labels, "cpu", core, RRDLABEL_SRC_AUTO);
+                rrdlabels_add(core_st[c]->chart_labels, "cpu", core, RRDLABEL_SRC_AUTO);
             }
             else
                 rrdset_next(core_st[c]);

--- a/collectors/proc.plugin/proc_softirqs.c
+++ b/collectors/proc.plugin/proc_softirqs.c
@@ -220,7 +220,7 @@ int do_proc_softirqs(int update_every, usec_t dt) {
 
                 char core[50+1];
                 snprintfz(core, 50, "cpu%d", c);
-                rrdlabels_add(core_st[c]->chart_labels, "cpu", core, RRDLABEL_SRC_AUTO);
+                rrdlabels_add(core_st[c]->rrdlabels, "cpu", core, RRDLABEL_SRC_AUTO);
             }
             else
                 rrdset_next(core_st[c]);

--- a/collectors/proc.plugin/proc_stat.c
+++ b/collectors/proc.plugin/proc_stat.c
@@ -1041,7 +1041,7 @@ int do_proc_stat(int update_every, usec_t dt) {
 
                         char corebuf[50+1];
                         snprintfz(corebuf, 50, "cpu%zu", core);
-                        rrdlabels_add(cpuidle_charts[core].st->chart_labels, "cpu", corebuf, RRDLABEL_SRC_AUTO);
+                        rrdlabels_add(cpuidle_charts[core].st->rrdlabels, "cpu", corebuf, RRDLABEL_SRC_AUTO);
 
                         char cpuidle_dim_id[RRD_ID_LENGTH_MAX + 1];
                         cpuidle_charts[core].active_time_rd = rrddim_add(cpuidle_charts[core].st, "active", "C0 (active)", 1, 1, RRD_ALGORITHM_PCENT_OVER_DIFF_TOTAL);

--- a/collectors/proc.plugin/proc_stat.c
+++ b/collectors/proc.plugin/proc_stat.c
@@ -1041,7 +1041,7 @@ int do_proc_stat(int update_every, usec_t dt) {
 
                         char corebuf[50+1];
                         snprintfz(corebuf, 50, "cpu%zu", core);
-                        rrdlabels_add(cpuidle_charts[core].st->state->chart_labels, "cpu", corebuf, RRDLABEL_SRC_AUTO);
+                        rrdlabels_add(cpuidle_charts[core].st->chart_labels, "cpu", corebuf, RRDLABEL_SRC_AUTO);
 
                         char cpuidle_dim_id[RRD_ID_LENGTH_MAX + 1];
                         cpuidle_charts[core].active_time_rd = rrddim_add(cpuidle_charts[core].st, "active", "C0 (active)", 1, 1, RRD_ALGORITHM_PCENT_OVER_DIFF_TOTAL);

--- a/collectors/proc.plugin/sys_block_zram.c
+++ b/collectors/proc.plugin/sys_block_zram.c
@@ -75,7 +75,7 @@ static inline void init_rrd(const char *name, ZRAM_DEVICE *d, int update_every) 
         , RRDSET_TYPE_AREA);
     d->rd_compr_data_size = rrddim_add(d->st_usage, "compressed", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
     d->rd_metadata_size = rrddim_add(d->st_usage, "metadata", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-    rrdlabels_add(d->st_usage->state->chart_labels, "device", name, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(d->st_usage->chart_labels, "device", name, RRDLABEL_SRC_AUTO);
 
     snprintfz(chart_name, RRD_ID_LENGTH_MAX, "zram_savings.%s", name);
     d->st_savings = rrdset_create_localhost(
@@ -93,7 +93,7 @@ static inline void init_rrd(const char *name, ZRAM_DEVICE *d, int update_every) 
         , RRDSET_TYPE_AREA);
     d->rd_savings_size = rrddim_add(d->st_savings, "savings", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
     d->rd_original_size = rrddim_add(d->st_savings, "original", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-    rrdlabels_add(d->st_savings->state->chart_labels, "device", name, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(d->st_savings->chart_labels, "device", name, RRDLABEL_SRC_AUTO);
 
     snprintfz(chart_name, RRD_ID_LENGTH_MAX, "zram_ratio.%s", name);
     d->st_comp_ratio = rrdset_create_localhost(
@@ -110,7 +110,7 @@ static inline void init_rrd(const char *name, ZRAM_DEVICE *d, int update_every) 
         , update_every
         , RRDSET_TYPE_LINE);
     d->rd_comp_ratio = rrddim_add(d->st_comp_ratio, "ratio", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
-    rrdlabels_add(d->st_comp_ratio->state->chart_labels, "device", name, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(d->st_comp_ratio->chart_labels, "device", name, RRDLABEL_SRC_AUTO);
 
     snprintfz(chart_name, RRD_ID_LENGTH_MAX, "zram_efficiency.%s", name);
     d->st_alloc_efficiency = rrdset_create_localhost(
@@ -127,7 +127,7 @@ static inline void init_rrd(const char *name, ZRAM_DEVICE *d, int update_every) 
         , update_every
         , RRDSET_TYPE_LINE);
     d->rd_alloc_efficiency = rrddim_add(d->st_alloc_efficiency, "percent", NULL, 1, 10000, RRD_ALGORITHM_ABSOLUTE);
-    rrdlabels_add(d->st_alloc_efficiency->state->chart_labels, "device", name, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(d->st_alloc_efficiency->chart_labels, "device", name, RRDLABEL_SRC_AUTO);
 }
 
 static int init_devices(DICTIONARY *devices, unsigned int zram_id, int update_every) {

--- a/collectors/proc.plugin/sys_block_zram.c
+++ b/collectors/proc.plugin/sys_block_zram.c
@@ -75,7 +75,7 @@ static inline void init_rrd(const char *name, ZRAM_DEVICE *d, int update_every) 
         , RRDSET_TYPE_AREA);
     d->rd_compr_data_size = rrddim_add(d->st_usage, "compressed", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
     d->rd_metadata_size = rrddim_add(d->st_usage, "metadata", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-    rrdlabels_add(d->st_usage->chart_labels, "device", name, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(d->st_usage->rrdlabels, "device", name, RRDLABEL_SRC_AUTO);
 
     snprintfz(chart_name, RRD_ID_LENGTH_MAX, "zram_savings.%s", name);
     d->st_savings = rrdset_create_localhost(
@@ -93,7 +93,7 @@ static inline void init_rrd(const char *name, ZRAM_DEVICE *d, int update_every) 
         , RRDSET_TYPE_AREA);
     d->rd_savings_size = rrddim_add(d->st_savings, "savings", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
     d->rd_original_size = rrddim_add(d->st_savings, "original", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-    rrdlabels_add(d->st_savings->chart_labels, "device", name, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(d->st_savings->rrdlabels, "device", name, RRDLABEL_SRC_AUTO);
 
     snprintfz(chart_name, RRD_ID_LENGTH_MAX, "zram_ratio.%s", name);
     d->st_comp_ratio = rrdset_create_localhost(
@@ -110,7 +110,7 @@ static inline void init_rrd(const char *name, ZRAM_DEVICE *d, int update_every) 
         , update_every
         , RRDSET_TYPE_LINE);
     d->rd_comp_ratio = rrddim_add(d->st_comp_ratio, "ratio", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
-    rrdlabels_add(d->st_comp_ratio->chart_labels, "device", name, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(d->st_comp_ratio->rrdlabels, "device", name, RRDLABEL_SRC_AUTO);
 
     snprintfz(chart_name, RRD_ID_LENGTH_MAX, "zram_efficiency.%s", name);
     d->st_alloc_efficiency = rrdset_create_localhost(
@@ -127,7 +127,7 @@ static inline void init_rrd(const char *name, ZRAM_DEVICE *d, int update_every) 
         , update_every
         , RRDSET_TYPE_LINE);
     d->rd_alloc_efficiency = rrddim_add(d->st_alloc_efficiency, "percent", NULL, 1, 10000, RRD_ALGORITHM_ABSOLUTE);
-    rrdlabels_add(d->st_alloc_efficiency->chart_labels, "device", name, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(d->st_alloc_efficiency->rrdlabels, "device", name, RRDLABEL_SRC_AUTO);
 }
 
 static int init_devices(DICTIONARY *devices, unsigned int zram_id, int update_every) {

--- a/collectors/proc.plugin/sys_class_power_supply.c
+++ b/collectors/proc.plugin/sys_class_power_supply.c
@@ -113,7 +113,7 @@ void power_supply_free(struct power_supply *ps) {
 }
 
 static void add_labels_to_power_supply(struct power_supply *ps, RRDSET *st) {
-    rrdlabels_add(st->chart_labels, "device", ps->name, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(st->rrdlabels, "device", ps->name, RRDLABEL_SRC_AUTO);
     rrdcalc_update_rrdlabels(st);
 }
 

--- a/collectors/proc.plugin/sys_class_power_supply.c
+++ b/collectors/proc.plugin/sys_class_power_supply.c
@@ -113,7 +113,7 @@ void power_supply_free(struct power_supply *ps) {
 }
 
 static void add_labels_to_power_supply(struct power_supply *ps, RRDSET *st) {
-    rrdlabels_add(st->state->chart_labels, "device", ps->name, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(st->chart_labels, "device", ps->name, RRDLABEL_SRC_AUTO);
     rrdcalc_update_rrdlabels(st);
 }
 

--- a/collectors/proc.plugin/sys_devices_system_node.c
+++ b/collectors/proc.plugin/sys_devices_system_node.c
@@ -115,7 +115,7 @@ int do_proc_sys_devices_system_node(int update_every, usec_t dt) {
                             , RRDSET_TYPE_LINE
                     );
 
-                    rrdlabels_add(m->numastat_st->state->chart_labels, "numa_node", m->name, RRDLABEL_SRC_AUTO);
+                    rrdlabels_add(m->numastat_st->chart_labels, "numa_node", m->name, RRDLABEL_SRC_AUTO);
 
                     rrdset_flag_set(m->numastat_st, RRDSET_FLAG_DETAIL);
 

--- a/collectors/proc.plugin/sys_devices_system_node.c
+++ b/collectors/proc.plugin/sys_devices_system_node.c
@@ -115,7 +115,7 @@ int do_proc_sys_devices_system_node(int update_every, usec_t dt) {
                             , RRDSET_TYPE_LINE
                     );
 
-                    rrdlabels_add(m->numastat_st->chart_labels, "numa_node", m->name, RRDLABEL_SRC_AUTO);
+                    rrdlabels_add(m->numastat_st->rrdlabels, "numa_node", m->name, RRDLABEL_SRC_AUTO);
 
                     rrdset_flag_set(m->numastat_st, RRDSET_FLAG_DETAIL);
 

--- a/collectors/proc.plugin/sys_fs_btrfs.c
+++ b/collectors/proc.plugin/sys_fs_btrfs.c
@@ -449,8 +449,8 @@ static inline int find_all_btrfs_pools(const char *path) {
 }
 
 static void add_labels_to_btrfs(BTRFS_NODE *n, RRDSET *st) {
-    rrdlabels_add(st->state->chart_labels, "device", n->id, RRDLABEL_SRC_AUTO);
-    rrdlabels_add(st->state->chart_labels, "device_label", n->label, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(st->chart_labels, "device", n->id, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(st->chart_labels, "device_label", n->label, RRDLABEL_SRC_AUTO);
     rrdcalc_update_rrdlabels(st);
 }
 

--- a/collectors/proc.plugin/sys_fs_btrfs.c
+++ b/collectors/proc.plugin/sys_fs_btrfs.c
@@ -449,8 +449,8 @@ static inline int find_all_btrfs_pools(const char *path) {
 }
 
 static void add_labels_to_btrfs(BTRFS_NODE *n, RRDSET *st) {
-    rrdlabels_add(st->chart_labels, "device", n->id, RRDLABEL_SRC_AUTO);
-    rrdlabels_add(st->chart_labels, "device_label", n->label, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(st->rrdlabels, "device", n->id, RRDLABEL_SRC_AUTO);
+    rrdlabels_add(st->rrdlabels, "device_label", n->label, RRDLABEL_SRC_AUTO);
     rrdcalc_update_rrdlabels(st);
 }
 

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -217,7 +217,7 @@ static cmd_status_t cmd_reload_labels_execute(char *args, char **message)
     reload_host_labels();
 
     BUFFER *wb = buffer_create(10);
-    rrdlabels_log_to_buffer(localhost->host_labels, wb);
+    rrdlabels_log_to_buffer(localhost->rrdlabels, wb);
     (*message)=strdupz(buffer_tostring(wb));
     buffer_free(wb);
 

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -445,11 +445,6 @@ struct rrddim_tier {
 extern void rrdr_fill_tier_gap_from_smaller_tiers(RRDDIM *rd, int tier, time_t now);
 
 // ----------------------------------------------------------------------------
-// volatile state per chart
-struct rrdset_volatile {
-};
-
-// ----------------------------------------------------------------------------
 // these loop macros make sure the linked list is accessed with the right lock
 
 #define rrddim_foreach_read(rd, st) \
@@ -491,7 +486,7 @@ typedef enum rrdset_flags {
     RRDSET_FLAG_INDEXED_ID              = (1 << 19), // the rrdset is indexed by its id
     RRDSET_FLAG_INDEXED_NAME            = (1 << 20), // the rrdset is indexed by its name
 
-    RRDSET_FLAG_ANOMALY_RATE_CHART      = (1 << 21), // the rrdset is for storing anomaly rates for all dimesions
+    RRDSET_FLAG_ANOMALY_RATE_CHART      = (1 << 21), // the rrdset is for storing anomaly rates for all dimensions
 } RRDSET_FLAGS;
 
 #define rrdset_flag_check(st, flag) (__atomic_load_n(&((st)->flags), __ATOMIC_SEQ_CST) & (flag))
@@ -553,8 +548,6 @@ struct rrdset {
 
     uuid_t *chart_uuid;                             // Store the global GUID for this chart
                                                     // this object.
-    struct rrdset_volatile *state;                  // volatile state that is not persistently stored
-
     size_t rrddim_page_alignment;                   // keeps metric pages in alignment when using dbengine
 
     usec_t usec_since_last_update;                  // the time in microseconds since the last collection of data

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -447,7 +447,6 @@ extern void rrdr_fill_tier_gap_from_smaller_tiers(RRDDIM *rd, int tier, time_t n
 // ----------------------------------------------------------------------------
 // volatile state per chart
 struct rrdset_volatile {
-    bool is_ar_chart;
 };
 
 // ----------------------------------------------------------------------------
@@ -489,13 +488,17 @@ typedef enum rrdset_flags {
     RRDSET_FLAG_ACLK                    = (1 << 16),
     RRDSET_FLAG_PENDING_FOREACH_ALARMS  = (1 << 17), // contains dims with uninitialized foreach alarms
     RRDSET_FLAG_ANOMALY_DETECTION       = (1 << 18), // flag to identify anomaly detection charts.
-    RRDSET_FLAG_INDEXED_ID              = (1 << 19),
-    RRDSET_FLAG_INDEXED_NAME            = (1 << 20),
+    RRDSET_FLAG_INDEXED_ID              = (1 << 19), // the rrdset is indexed by its id
+    RRDSET_FLAG_INDEXED_NAME            = (1 << 20), // the rrdset is indexed by its name
+
+    RRDSET_FLAG_ANOMALY_RATE_CHART      = (1 << 21), // the rrdset is for storing anomaly rates for all dimesions
 } RRDSET_FLAGS;
 
 #define rrdset_flag_check(st, flag) (__atomic_load_n(&((st)->flags), __ATOMIC_SEQ_CST) & (flag))
 #define rrdset_flag_set(st, flag)   __atomic_or_fetch(&((st)->flags), flag, __ATOMIC_SEQ_CST)
 #define rrdset_flag_clear(st, flag) __atomic_and_fetch(&((st)->flags), ~(flag), __ATOMIC_SEQ_CST)
+
+#define rrdset_is_ar_chart(st) rrdset_flag_check(st, RRDSET_FLAG_ANOMALY_RATE_CHART)
 
 struct rrdset {
     uuid_t uuid;

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -843,9 +843,6 @@ struct rrdhost {
     // ------------------------------------------------------------------------
     // streaming of data from remote hosts - rrdpush
 
-    volatile size_t connected_senders;              // when remote hosts are streaming to this
-                                                    // host, this is the counter of connected clients
-
     time_t senders_connect_time;                    // the time the last sender was connected
     time_t senders_last_chart_command;              // the time of the last CHART streaming command
     time_t senders_disconnected_time;               // the time the last sender was disconnected

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -447,7 +447,6 @@ extern void rrdr_fill_tier_gap_from_smaller_tiers(RRDDIM *rd, int tier, time_t n
 // ----------------------------------------------------------------------------
 // volatile state per chart
 struct rrdset_volatile {
-    uuid_t hash_id;
     bool is_ar_chart;
 };
 
@@ -499,6 +498,8 @@ typedef enum rrdset_flags {
 #define rrdset_flag_clear(st, flag) __atomic_and_fetch(&((st)->flags), ~(flag), __ATOMIC_SEQ_CST)
 
 struct rrdset {
+    uuid_t uuid;
+
     // ------------------------------------------------------------------------
     // the set configuration
 

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -448,7 +448,6 @@ extern void rrdr_fill_tier_gap_from_smaller_tiers(RRDDIM *rd, int tier, time_t n
 // volatile state per chart
 struct rrdset_volatile {
     uuid_t hash_id;
-    DICTIONARY *chart_labels;
     bool is_ar_chart;
 };
 
@@ -583,6 +582,11 @@ struct rrdset {
 
     unsigned long memsize;                          // how much mem we have allocated for this (without dimensions)
     void *st_on_file;                               // compatibility with V019 RRDSET files
+
+    // ------------------------------------------------------------------------
+    // chart labels
+
+    DICTIONARY *chart_labels;
 
     // ------------------------------------------------------------------------
     // the dimensions

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -639,7 +639,6 @@ typedef enum rrdhost_flags {
     RRDHOST_FLAG_EXPORTING_SEND           = (1 << 3), // send it to external databases
     RRDHOST_FLAG_EXPORTING_DONT_SEND      = (1 << 4), // don't send it to external databases
     RRDHOST_FLAG_ARCHIVED                 = (1 << 5), // The host is archived, no collected charts yet
-    RRDHOST_FLAG_MULTIHOST                = (1 << 6), // Host belongs to localhost/megadb
     RRDHOST_FLAG_PENDING_FOREACH_ALARMS   = (1 << 7), // contains dims with uninitialized foreach alarms
     RRDHOST_FLAG_STREAM_LABELS_UPDATE     = (1 << 8),
     RRDHOST_FLAG_STREAM_LABELS_STOP       = (1 << 9),

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -586,7 +586,7 @@ struct rrdset {
     // ------------------------------------------------------------------------
     // chart labels
 
-    DICTIONARY *chart_labels;
+    DICTIONARY *rrdlabels;
 
     // ------------------------------------------------------------------------
     // the dimensions

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -900,7 +900,7 @@ struct rrdhost {
 
     // ------------------------------------------------------------------------
     // Support for host-level labels
-    DICTIONARY *host_labels;
+    DICTIONARY *rrdlabels;
 
     // ------------------------------------------------------------------------
     // indexes

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -67,8 +67,8 @@ static STRING *rrdcalc_replace_variables(const char *line, RRDCALC *rc) {
             temp = buf;
         }
         else if (!strncmp(var, RRDCALC_VAR_LABEL, RRDCALC_VAR_LABEL_LEN)) {
-            if(likely(rc->rrdset && rc->rrdset->chart_labels)) {
-                rrdlabels_get_value_to_char_or_null(rc->rrdset->chart_labels, &lbl_value, var+RRDCALC_VAR_LABEL_LEN);
+            if(likely(rc->rrdset && rc->rrdset->rrdlabels)) {
+                rrdlabels_get_value_to_char_or_null(rc->rrdset->rrdlabels, &lbl_value, var+RRDCALC_VAR_LABEL_LEN);
                 if (lbl_value) {
                     char *buf = find_and_replace(temp, var, lbl_value, m);
                     freez(temp);

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -191,7 +191,7 @@ static inline int rrdcalc_is_matching_rrdset(RRDCALC *rc, RRDSET *st) {
     if (rc->plugin_pattern && !simple_pattern_matches(rc->plugin_pattern, rrdset_plugin_name(st)))
         return 0;
 
-    if (st->rrdhost->host_labels && rc->host_labels_pattern && !rrdlabels_match_simple_pattern_parsed(st->rrdhost->host_labels, rc->host_labels_pattern, '='))
+    if (st->rrdhost->rrdlabels && rc->host_labels_pattern && !rrdlabels_match_simple_pattern_parsed(st->rrdhost->rrdlabels, rc->host_labels_pattern, '='))
         return 0;
 
     return 1;
@@ -672,7 +672,7 @@ static void rrdcalc_labels_unlink_alarm_loop(RRDHOST *host, RRDCALC *alarms) {
             continue;
         }
 
-        if(!rrdlabels_match_simple_pattern_parsed(host->host_labels, rc->host_labels_pattern, '=')) {
+        if(!rrdlabels_match_simple_pattern_parsed(host->rrdlabels, rc->host_labels_pattern, '=')) {
             info("Health configuration for alarm '%s' cannot be applied, because the host %s does not have the label(s) '%s'",
                  rrdcalc_name(rc),
                  rrdhost_hostname(host),
@@ -700,7 +700,7 @@ void rrdcalc_labels_unlink() {
         if (unlikely(!host->health_enabled))
             continue;
 
-        if (host->host_labels) {
+        if (host->rrdlabels) {
             rrdhost_wrlock(host);
 
             rrdcalc_labels_unlink_alarm_from_host(host);

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -67,8 +67,8 @@ static STRING *rrdcalc_replace_variables(const char *line, RRDCALC *rc) {
             temp = buf;
         }
         else if (!strncmp(var, RRDCALC_VAR_LABEL, RRDCALC_VAR_LABEL_LEN)) {
-            if(likely(rc->rrdset && rc->rrdset->state && rc->rrdset->state->chart_labels)) {
-                rrdlabels_get_value_to_char_or_null(rc->rrdset->state->chart_labels, &lbl_value, var+RRDCALC_VAR_LABEL_LEN);
+            if(likely(rc->rrdset && rc->rrdset->chart_labels)) {
+                rrdlabels_get_value_to_char_or_null(rc->rrdset->chart_labels, &lbl_value, var+RRDCALC_VAR_LABEL_LEN);
                 if (lbl_value) {
                     char *buf = find_and_replace(temp, var, lbl_value, m);
                     freez(temp);

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -27,7 +27,7 @@ void rrdcalctemplate_check_conditions_and_link(RRDCALCTEMPLATE *rt, RRDSET *st, 
     if (rt->plugin_pattern && !simple_pattern_matches(rt->plugin_pattern, rrdset_plugin_name(st)))
         return;
 
-    if(host->host_labels && rt->host_labels_pattern && !rrdlabels_match_simple_pattern_parsed(host->host_labels, rt->host_labels_pattern, '='))
+    if(host->rrdlabels && rt->host_labels_pattern && !rrdlabels_match_simple_pattern_parsed(host->rrdlabels, rt->host_labels_pattern, '='))
         return;
 
     RRDCALC *rc = rrdcalc_create_from_template(host, rt, rrdset_id(st));

--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -268,7 +268,7 @@ typedef struct rrdinstance {
     int update_every;                   // data collection frequency
     RRDSET *rrdset;                     // pointer to RRDSET when collected, or NULL
 
-    DICTIONARY *rrdlabels;              // linked to RRDSET->state->chart_labels or own version
+    DICTIONARY *rrdlabels;              // linked to RRDSET->chart_labels or own version
 
     struct rrdcontext *rc;
     DICTIONARY *rrdmetrics;
@@ -705,8 +705,8 @@ static void rrdinstance_insert_callback(const char *id __maybe_unused, void *val
     if(!ri->name)
         ri->name = string_dup(ri->id);
 
-    if(ri->rrdset && ri->rrdset->state) {
-        ri->rrdlabels = ri->rrdset->state->chart_labels;
+    if(ri->rrdset) {
+        ri->rrdlabels = ri->rrdset->chart_labels;
         ri->flags &= ~RRD_FLAG_OWN_LABELS; // no need of atomics at the constructor
     }
     else {
@@ -814,7 +814,7 @@ static void rrdinstance_conflict_callback(const char *id __maybe_unused, void *o
 
         if(ri->rrdset && rrd_flag_check(ri, RRD_FLAG_OWN_LABELS)) {
             DICTIONARY *old = ri->rrdlabels;
-            ri->rrdlabels = ri->rrdset->state->chart_labels;
+            ri->rrdlabels = ri->rrdset->chart_labels;
             rrd_flag_clear(ri, RRD_FLAG_OWN_LABELS);
             rrdlabels_destroy(old);
         }
@@ -1034,7 +1034,7 @@ static inline void rrdinstance_rrdset_is_freed(RRDSET *st) {
 
     if(!rrd_flag_check(ri, RRD_FLAG_OWN_LABELS)) {
         ri->rrdlabels = rrdlabels_create();
-        rrdlabels_copy(ri->rrdlabels, st->state->chart_labels);
+        rrdlabels_copy(ri->rrdlabels, st->chart_labels);
         rrd_flag_set(ri, RRD_FLAG_OWN_LABELS);
     }
 

--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -706,7 +706,7 @@ static void rrdinstance_insert_callback(const char *id __maybe_unused, void *val
         ri->name = string_dup(ri->id);
 
     if(ri->rrdset) {
-        ri->rrdlabels = ri->rrdset->chart_labels;
+        ri->rrdlabels = ri->rrdset->rrdlabels;
         ri->flags &= ~RRD_FLAG_OWN_LABELS; // no need of atomics at the constructor
     }
     else {
@@ -814,7 +814,7 @@ static void rrdinstance_conflict_callback(const char *id __maybe_unused, void *o
 
         if(ri->rrdset && rrd_flag_check(ri, RRD_FLAG_OWN_LABELS)) {
             DICTIONARY *old = ri->rrdlabels;
-            ri->rrdlabels = ri->rrdset->chart_labels;
+            ri->rrdlabels = ri->rrdset->rrdlabels;
             rrd_flag_clear(ri, RRD_FLAG_OWN_LABELS);
             rrdlabels_destroy(old);
         }
@@ -1034,7 +1034,7 @@ static inline void rrdinstance_rrdset_is_freed(RRDSET *st) {
 
     if(!rrd_flag_check(ri, RRD_FLAG_OWN_LABELS)) {
         ri->rrdlabels = rrdlabels_create();
-        rrdlabels_copy(ri->rrdlabels, st->chart_labels);
+        rrdlabels_copy(ri->rrdlabels, st->rrdlabels);
         rrd_flag_set(ri, RRD_FLAG_OWN_LABELS);
     }
 

--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -715,7 +715,7 @@ static void rrdinstance_insert_callback(const char *id __maybe_unused, void *val
     }
 
     if(ri->rrdset) {
-        if(unlikely((rrdset_flag_check(ri->rrdset, RRDSET_FLAG_HIDDEN)) || (ri->rrdset->state && ri->rrdset->state->is_ar_chart)))
+        if(unlikely((rrdset_flag_check(ri->rrdset, RRDSET_FLAG_HIDDEN)) || rrdset_is_ar_chart(ri->rrdset)))
             ri->flags |= RRD_FLAG_HIDDEN; // no need of atomics at the constructor
         else
             ri->flags &= ~RRD_FLAG_HIDDEN; // no need of atomics at the constructor
@@ -825,7 +825,7 @@ static void rrdinstance_conflict_callback(const char *id __maybe_unused, void *o
     }
 
     if(ri->rrdset) {
-        if(unlikely((rrdset_flag_check(ri->rrdset, RRDSET_FLAG_HIDDEN)) || (ri->rrdset->state && ri->rrdset->state->is_ar_chart)))
+        if(unlikely((rrdset_flag_check(ri->rrdset, RRDSET_FLAG_HIDDEN)) || rrdset_is_ar_chart(ri->rrdset)))
             rrd_flag_set(ri, RRD_FLAG_HIDDEN);
         else
             rrd_flag_clear(ri, RRD_FLAG_HIDDEN);

--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -1995,7 +1995,7 @@ int rrdcontexts_to_json(RRDHOST *host, BUFFER *wb, time_t after, time_t before, 
 
     if(options & RRDCONTEXT_OPTION_SHOW_LABELS) {
         buffer_sprintf(wb, ",\n\t\"host_labels\": {\n");
-        rrdlabels_to_buffer(host->host_labels, wb, "\t\t", ":", "\"", ",\n", NULL, NULL, NULL, NULL);
+        rrdlabels_to_buffer(host->rrdlabels, wb, "\t\t", ":", "\"", ",\n", NULL, NULL, NULL, NULL);
         buffer_strcat(wb, "\n\t}");
     }
 

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -64,7 +64,7 @@ inline int rrddim_set_name(RRDSET *st, RRDDIM *rd, const char *name) {
     string_freez(rd->name);
     rd->name = rrd_string_strdupz(name);
 
-    if (!st->state->is_ar_chart)
+    if (!rrdset_is_ar_chart(st))
         rrddimvar_rename_all(rd);
 
     rd->exposed = 0;
@@ -340,7 +340,7 @@ RRDDIM *rrddim_add_custom(RRDSET *st
     // append this dimension
     DOUBLE_LINKED_LIST_APPEND_UNSAFE(st->dimensions, rd, prev, next);
 
-    if(host->health_enabled && !st->state->is_ar_chart) {
+    if(host->health_enabled && !rrdset_is_ar_chart(st)) {
         rrddimvar_create(rd, RRDVAR_TYPE_CALCULATED, NULL, NULL, &rd->last_stored_value, RRDVAR_OPTION_DEFAULT);
         rrddimvar_create(rd, RRDVAR_TYPE_COLLECTED, NULL, "_raw", &rd->last_collected_value, RRDVAR_OPTION_DEFAULT);
         rrddimvar_create(rd, RRDVAR_TYPE_TIME_T, NULL, "_last_collected_t", &rd->last_collected_time.tv_sec, RRDVAR_OPTION_DEFAULT);

--- a/database/rrdlabels.c
+++ b/database/rrdlabels.c
@@ -955,11 +955,11 @@ static int chart_label_store_to_sql_callback(const char *name, const char *value
 }
 
 void rrdset_update_rrdlabels(RRDSET *st, DICTIONARY *new_rrdlabels) {
-    if(!st->chart_labels)
-        st->chart_labels = rrdlabels_create();
+    if(!st->rrdlabels)
+        st->rrdlabels = rrdlabels_create();
 
     if (new_rrdlabels)
-        rrdlabels_migrate_to_these(st->chart_labels, new_rrdlabels);
+        rrdlabels_migrate_to_these(st->rrdlabels, new_rrdlabels);
 
     rrdcalc_update_rrdlabels(st);
 
@@ -967,7 +967,7 @@ void rrdset_update_rrdlabels(RRDSET *st, DICTIONARY *new_rrdlabels) {
     BUFFER  *sql_buf = buffer_create(1024);
     struct label_str tmp = {.sql = sql_buf, .count = 0 };
     uuid_unparse_lower(*st->chart_uuid, tmp.uuid_str);
-    rrdlabels_walkthrough_read(st->chart_labels, chart_label_store_to_sql_callback, &tmp);
+    rrdlabels_walkthrough_read(st->rrdlabels, chart_label_store_to_sql_callback, &tmp);
     db_execute(buffer_tostring(sql_buf));
     buffer_free(sql_buf);
 }

--- a/database/rrdlabels.c
+++ b/database/rrdlabels.c
@@ -955,11 +955,11 @@ static int chart_label_store_to_sql_callback(const char *name, const char *value
 }
 
 void rrdset_update_rrdlabels(RRDSET *st, DICTIONARY *new_rrdlabels) {
-    if(!st->state->chart_labels)
-        st->state->chart_labels = rrdlabels_create();
+    if(!st->chart_labels)
+        st->chart_labels = rrdlabels_create();
 
     if (new_rrdlabels)
-        rrdlabels_migrate_to_these(st->state->chart_labels, new_rrdlabels);
+        rrdlabels_migrate_to_these(st->chart_labels, new_rrdlabels);
 
     rrdcalc_update_rrdlabels(st);
 
@@ -967,7 +967,7 @@ void rrdset_update_rrdlabels(RRDSET *st, DICTIONARY *new_rrdlabels) {
     BUFFER  *sql_buf = buffer_create(1024);
     struct label_str tmp = {.sql = sql_buf, .count = 0 };
     uuid_unparse_lower(*st->chart_uuid, tmp.uuid_str);
-    rrdlabels_walkthrough_read(st->state->chart_labels, chart_label_store_to_sql_callback, &tmp);
+    rrdlabels_walkthrough_read(st->chart_labels, chart_label_store_to_sql_callback, &tmp);
     db_execute(buffer_tostring(sql_buf));
     buffer_free(sql_buf);
 }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -373,7 +373,7 @@ void rrdset_free(RRDSET *st) {
     netdata_rwlock_destroy(&st->rrdset_rwlock);
 
     rrdset_memory_file_free(st);
-    rrdlabels_destroy(st->state->chart_labels);
+    rrdlabels_destroy(st->chart_labels);
 
     // free directly allocated members
 
@@ -469,11 +469,11 @@ static inline RRDSET *rrdset_find_on_create(RRDHOST *host, const char *fullid) {
 }
 
 static inline void rrdset_update_permanent_labels(RRDSET *st) {
-    if(!st->state || !st->state->chart_labels) return;
+    if(!st->chart_labels) return;
 
-    rrdlabels_add(st->state->chart_labels, "_collect_plugin", rrdset_plugin_name(st), RRDLABEL_SRC_AUTO| RRDLABEL_FLAG_PERMANENT);
-    rrdlabels_add(st->state->chart_labels, "_collect_module", rrdset_module_name(st), RRDLABEL_SRC_AUTO| RRDLABEL_FLAG_PERMANENT);
-    rrdlabels_add(st->state->chart_labels, "_instance_family",rrdset_family(st),      RRDLABEL_SRC_AUTO| RRDLABEL_FLAG_PERMANENT);
+    rrdlabels_add(st->chart_labels, "_collect_plugin", rrdset_plugin_name(st), RRDLABEL_SRC_AUTO| RRDLABEL_FLAG_PERMANENT);
+    rrdlabels_add(st->chart_labels, "_collect_module", rrdset_module_name(st), RRDLABEL_SRC_AUTO| RRDLABEL_FLAG_PERMANENT);
+    rrdlabels_add(st->chart_labels, "_instance_family",rrdset_family(st),      RRDLABEL_SRC_AUTO| RRDLABEL_FLAG_PERMANENT);
 }
 
 RRDSET *rrdset_create_custom(
@@ -718,7 +718,7 @@ RRDSET *rrdset_create_custom(
         );
 
     netdata_rwlock_init(&st->rrdset_rwlock);
-    st->state->chart_labels = rrdlabels_create();
+    st->chart_labels = rrdlabels_create();
     rrdset_update_permanent_labels(st);
 
     if(name && *name && rrdset_set_name(st, name))

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -690,7 +690,8 @@ RRDSET *rrdset_create_custom(
     st->type        = rrd_string_strdupz(type);
     st->family      = family ? rrd_string_strdupz(family) : string_dup(st->type);
 
-    st->state->is_ar_chart = strcmp(rrdset_id(st), ML_ANOMALY_RATES_CHART_ID) == 0;
+    if(strcmp(rrdset_id(st), ML_ANOMALY_RATES_CHART_ID) == 0)
+        rrdset_flag_set(st, RRDSET_FLAG_ANOMALY_RATE_CHART);
 
     st->units = rrd_string_strdupz(units);
 
@@ -1264,7 +1265,7 @@ void rrdset_done(RRDSET *st) {
     rrdset_rdlock(st);
 
 #ifdef ENABLE_ACLK
-    if (likely(!st->state->is_ar_chart)) {
+    if (likely(!rrdset_is_ar_chart(st))) {
         if (unlikely(!rrdset_flag_check(st, RRDSET_FLAG_ACLK))) {
             if (likely(st->dimensions && st->counter_done && !queue_chart_to_aclk(st))) {
                 rrdset_flag_set(st, RRDSET_FLAG_ACLK);
@@ -1693,7 +1694,7 @@ after_second_database_work:
             continue;
 
 #ifdef ENABLE_ACLK
-        if (likely(!st->state->is_ar_chart)) {
+        if (likely(!rrdset_is_ar_chart(st))) {
             if (!rrddim_flag_check(rd, RRDDIM_FLAG_HIDDEN) && likely(rrdset_flag_check(st, RRDSET_FLAG_ACLK)))
                 queue_dimension_to_aclk(rd, calc_dimension_liveness(rd, mark));
         }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -373,7 +373,7 @@ void rrdset_free(RRDSET *st) {
     netdata_rwlock_destroy(&st->rrdset_rwlock);
 
     rrdset_memory_file_free(st);
-    rrdlabels_destroy(st->chart_labels);
+    rrdlabels_destroy(st->rrdlabels);
 
     // free directly allocated members
 
@@ -469,11 +469,11 @@ static inline RRDSET *rrdset_find_on_create(RRDHOST *host, const char *fullid) {
 }
 
 static inline void rrdset_update_permanent_labels(RRDSET *st) {
-    if(!st->chart_labels) return;
+    if(!st->rrdlabels) return;
 
-    rrdlabels_add(st->chart_labels, "_collect_plugin", rrdset_plugin_name(st), RRDLABEL_SRC_AUTO| RRDLABEL_FLAG_PERMANENT);
-    rrdlabels_add(st->chart_labels, "_collect_module", rrdset_module_name(st), RRDLABEL_SRC_AUTO| RRDLABEL_FLAG_PERMANENT);
-    rrdlabels_add(st->chart_labels, "_instance_family",rrdset_family(st),      RRDLABEL_SRC_AUTO| RRDLABEL_FLAG_PERMANENT);
+    rrdlabels_add(st->rrdlabels, "_collect_plugin", rrdset_plugin_name(st), RRDLABEL_SRC_AUTO| RRDLABEL_FLAG_PERMANENT);
+    rrdlabels_add(st->rrdlabels, "_collect_module", rrdset_module_name(st), RRDLABEL_SRC_AUTO| RRDLABEL_FLAG_PERMANENT);
+    rrdlabels_add(st->rrdlabels, "_instance_family",rrdset_family(st),      RRDLABEL_SRC_AUTO| RRDLABEL_FLAG_PERMANENT);
 }
 
 RRDSET *rrdset_create_custom(
@@ -718,7 +718,7 @@ RRDSET *rrdset_create_custom(
         );
 
     netdata_rwlock_init(&st->rrdset_rwlock);
-    st->chart_labels = rrdlabels_create();
+    st->rrdlabels = rrdlabels_create();
     rrdset_update_permanent_labels(st);
 
     if(name && *name && rrdset_set_name(st, name))

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -391,7 +391,6 @@ void rrdset_free(RRDSET *st) {
     string_freez(st->module_name);
 
     freez(st->cache_dir);
-    freez(st->state);
     freez(st->chart_uuid);
 
     freez(st);
@@ -667,7 +666,6 @@ RRDSET *rrdset_create_custom(
     debug(D_RRD_CALLS, "Creating RRD_STATS for '%s.%s'.", type, id);
 
     st = callocz(1, sizeof(RRDSET));
-    st->state = callocz(1, sizeof(*st->state));
 
     st->id = string_strdupz(fullid); // fullid is already json_fix'ed
 

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -313,7 +313,7 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
         , 1
     );
     if (likely(host))
-        host->host_labels = sql_load_host_labels((uuid_t *)argv[IDX_HOST_ID]);
+        host->rrdlabels = sql_load_host_labels((uuid_t *)argv[IDX_HOST_ID]);
 
 #ifdef NETDATA_INTERNAL_CHECKS
     char node_str[UUID_STR_LEN] = "<none>";

--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -150,7 +150,7 @@ int aclk_add_chart_event(struct aclk_database_worker_config *wc, struct aclk_dat
     if (likely(claim_id)) {
         struct chart_instance_updated chart_payload;
         memset(&chart_payload, 0, sizeof(chart_payload));
-        chart_payload.config_hash = get_str_from_uuid(&st->state->hash_id);
+        chart_payload.config_hash = get_str_from_uuid(&st->uuid);
         chart_payload.update_every = st->update_every;
         chart_payload.memory_mode = st->rrd_memory_mode;
         chart_payload.name = (char *)rrdset_name(st);

--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -159,7 +159,7 @@ int aclk_add_chart_event(struct aclk_database_worker_config *wc, struct aclk_dat
         chart_payload.id = strdupz(rrdset_id(st));
 
         chart_payload.chart_labels = rrdlabels_create();
-        rrdlabels_copy(chart_payload.chart_labels, st->chart_labels);
+        rrdlabels_copy(chart_payload.chart_labels, st->rrdlabels);
 
         size_t size;
         char *payload = generate_chart_instance_updated(&size, &chart_payload);

--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -1265,7 +1265,7 @@ struct aclk_chart_sync_stats *aclk_get_chart_sync_stats(RRDHOST *host)
 void sql_check_chart_liveness(RRDSET *st) {
     RRDDIM *rd;
 
-    if (unlikely(st->state->is_ar_chart))
+    if (unlikely(rrdset_is_ar_chart(st)))
         return;
 
     rrdset_rdlock(st);

--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -159,7 +159,7 @@ int aclk_add_chart_event(struct aclk_database_worker_config *wc, struct aclk_dat
         chart_payload.id = strdupz(rrdset_id(st));
 
         chart_payload.chart_labels = rrdlabels_create();
-        rrdlabels_copy(chart_payload.chart_labels, st->state->chart_labels);
+        rrdlabels_copy(chart_payload.chart_labels, st->chart_labels);
 
         size_t size;
         char *payload = generate_chart_instance_updated(&size, &chart_payload);

--- a/database/sqlite/sqlite_aclk_node.c
+++ b/database/sqlite/sqlite_aclk_node.c
@@ -123,7 +123,7 @@ void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_dat
     node_info.data.ml_info.ml_capable = host->system_info->ml_capable;
     node_info.data.ml_info.ml_enabled = host->system_info->ml_enabled;
 
-    node_info.data.host_labels_ptr = host->host_labels;
+    node_info.data.host_labels_ptr = host->rrdlabels;
 
     aclk_update_node_info(&node_info);
     log_access("ACLK RES [%s (%s)]: NODE INFO SENT for guid [%s] (%s)", wc->node_id, rrdhost_hostname(wc->host), wc->host_guid, wc->host == localhost ? "parent" : "child");

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -2122,7 +2122,7 @@ void compute_chart_hash(RRDSET *st)
     char uuid_str[GUID_LEN + 1];
     uuid_unparse_lower(*((uuid_t *) &hash_value), uuid_str);
     //info("Calculating HASH %s for chart %s", uuid_str, st->name);
-    uuid_copy(st->state->hash_id, *((uuid_t *) &hash_value));
+    uuid_copy(st->uuid, *((uuid_t *) &hash_value));
 
     (void)sql_store_chart_hash(
         (uuid_t *)&hash_value,

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -2710,7 +2710,7 @@ void sql_store_host_labels(RRDHOST *host)
     if (rc != SQLITE_OK)
         error_report("Failed to remove old host labels for host %s", rrdhost_hostname(host));
 
-    rrdlabels_walkthrough_read(host->host_labels, save_host_label_callback, host);
+    rrdlabels_walkthrough_read(host->rrdlabels, save_host_label_callback, host);
 }
 
 #define SELECT_HOST_LABELS "SELECT label_key, label_value, source_type FROM host_label WHERE host_id = @host_id " \

--- a/exporting/check_filters.c
+++ b/exporting/check_filters.c
@@ -56,7 +56,7 @@ int rrdset_is_exportable(struct instance *instance, RRDSET *st)
 #endif
 
     // Do not export anomaly rates charts.
-    if (st->state && st->state->is_ar_chart)
+    if (rrdset_is_ar_chart(st))
         return 0;
 
     if (st->exporting_flags == NULL)

--- a/exporting/graphite/graphite.c
+++ b/exporting/graphite/graphite.c
@@ -101,7 +101,7 @@ int format_host_labels_graphite_plaintext(struct instance *instance, RRDHOST *ho
     if (unlikely(!sending_labels_configured(instance)))
         return 0;
 
-    rrdlabels_to_buffer(host->host_labels, instance->labels_buffer, ";", "=", "", "",
+    rrdlabels_to_buffer(host->rrdlabels, instance->labels_buffer, ";", "=", "", "",
                         exporting_labels_filter_callback, instance,
                         NULL, sanitize_graphite_label_value);
 

--- a/exporting/json/json.c
+++ b/exporting/json/json.c
@@ -125,7 +125,7 @@ int format_host_labels_json_plaintext(struct instance *instance, RRDHOST *host)
         return 0;
 
     buffer_strcat(instance->labels_buffer, "\"labels\":{");
-    rrdlabels_to_buffer(host->host_labels, instance->labels_buffer, "", ":", "\"", ",",
+    rrdlabels_to_buffer(host->rrdlabels, instance->labels_buffer, "", ":", "\"", ",",
                         exporting_labels_filter_callback, instance,
                         NULL, sanitize_json_string);
     buffer_strcat(instance->labels_buffer, "},");

--- a/exporting/opentsdb/opentsdb.c
+++ b/exporting/opentsdb/opentsdb.c
@@ -156,7 +156,7 @@ int format_host_labels_opentsdb_telnet(struct instance *instance, RRDHOST *host)
         return 0;
 
     buffer_strcat(instance->labels_buffer, " ");
-    rrdlabels_to_buffer(host->host_labels, instance->labels_buffer, "", "=", "", " ",
+    rrdlabels_to_buffer(host->rrdlabels, instance->labels_buffer, "", "=", "", " ",
                         exporting_labels_filter_callback, instance,
                         NULL, sanitize_opentsdb_label_value);
     return 0;
@@ -288,7 +288,7 @@ int format_host_labels_opentsdb_http(struct instance *instance, RRDHOST *host) {
     if (unlikely(!sending_labels_configured(instance)))
         return 0;
 
-    rrdlabels_to_buffer(host->host_labels, instance->labels_buffer, ",", ":", "\"", "",
+    rrdlabels_to_buffer(host->rrdlabels, instance->labels_buffer, ",", ":", "\"", "",
                         exporting_labels_filter_callback, instance,
                         NULL, sanitize_opentsdb_label_value);
     return 0;

--- a/exporting/prometheus/prometheus.c
+++ b/exporting/prometheus/prometheus.c
@@ -29,7 +29,7 @@ inline int can_send_rrdset(struct instance *instance, RRDSET *st, SIMPLE_PATTERN
 #endif
 
     // Do not send anomaly rates charts.
-    if (st->state && st->state->is_ar_chart)
+    if (rrdset_is_ar_chart(st))
         return 0;
 
     if (unlikely(rrdset_flag_check(st, RRDSET_FLAG_EXPORTING_IGNORE)))

--- a/exporting/prometheus/prometheus.c
+++ b/exporting/prometheus/prometheus.c
@@ -327,7 +327,7 @@ void format_host_labels_prometheus(struct instance *instance, RRDHOST *host)
         .instance = instance,
         .count = 0
     };
-    rrdlabels_walkthrough_read(host->host_labels, format_prometheus_label_callback, &tmp);
+    rrdlabels_walkthrough_read(host->rrdlabels, format_prometheus_label_callback, &tmp);
 }
 
 struct host_variables_callback_options {

--- a/exporting/prometheus/remote_write/remote_write.c
+++ b/exporting/prometheus/remote_write/remote_write.c
@@ -183,7 +183,7 @@ int format_host_prometheus_remote_write(struct instance *instance, RRDHOST *host
             .write_request = connector_specific_data->write_request,
             .instance = instance
         };
-        rrdlabels_walkthrough_read(host->host_labels, format_remote_write_label_callback, &tmp);
+        rrdlabels_walkthrough_read(host->rrdlabels, format_remote_write_label_callback, &tmp);
     }
 
     return 0;

--- a/exporting/tests/exporting_fixtures.c
+++ b/exporting/tests/exporting_fixtures.c
@@ -41,9 +41,9 @@ int setup_rrdhost()
 
     localhost->tags = string_strdupz("TAG1=VALUE1 TAG2=VALUE2");
 
-    localhost->host_labels = rrdlabels_create();
-    rrdlabels_add(localhost->host_labels, "key1", "value1", RRDLABEL_SRC_CONFIG);
-    rrdlabels_add(localhost->host_labels, "key2", "value2", RRDLABEL_SRC_CONFIG);
+    localhost->rrdlabels = rrdlabels_create();
+    rrdlabels_add(localhost->rrdlabels, "key1", "value1", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(localhost->rrdlabels, "key2", "value2", RRDLABEL_SRC_CONFIG);
 
     localhost->rrdset_root = calloc(1, sizeof(RRDSET));
     RRDSET *st = localhost->rrdset_root;
@@ -86,7 +86,7 @@ int teardown_rrdhost()
     string_freez(st->name);
     free(st);
 
-    rrdlabels_destroy(localhost->host_labels);
+    rrdlabels_destroy(localhost->rrdlabels);
 
     string_freez(localhost->tags);
     free(localhost);

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -75,7 +75,7 @@ inline void health_label_log_save(RRDHOST *host) {
     if(unlikely(host->health_log_fp)) {
         BUFFER *wb = buffer_create(1024);
 
-        rrdlabels_to_buffer(localhost->host_labels, wb, "", "=", "", "\t ", NULL, NULL, NULL, NULL);
+        rrdlabels_to_buffer(localhost->rrdlabels, wb, "", "=", "", "\t ", NULL, NULL, NULL, NULL);
         char *write = (char *) buffer_tostring(wb);
 
         if (unlikely(fprintf(host->health_log_fp, "L\t%s", write) < 0))

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -406,12 +406,12 @@ static int send_labels_callback(const char *name, const char *value, RRDLABEL_SR
     return 1;
 }
 void rrdpush_send_labels(RRDHOST *host) {
-    if (!host->host_labels || !rrdhost_flag_check(host, RRDHOST_FLAG_STREAM_LABELS_UPDATE) || (rrdhost_flag_check(host, RRDHOST_FLAG_STREAM_LABELS_STOP)))
+    if (!host->rrdlabels || !rrdhost_flag_check(host, RRDHOST_FLAG_STREAM_LABELS_UPDATE) || (rrdhost_flag_check(host, RRDHOST_FLAG_STREAM_LABELS_STOP)))
         return;
 
     sender_start(host->sender);
 
-    rrdlabels_walkthrough_read(host->host_labels, send_labels_callback, host->sender->build);
+    rrdlabels_walkthrough_read(host->rrdlabels, send_labels_callback, host->sender->build);
     buffer_sprintf(host->sender->build, "OVERWRITE %s\n", "labels");
     sender_commit(host->sender);
 

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -131,7 +131,7 @@ unsigned int remote_clock_resync_iterations = 60;
 
 static inline int should_send_chart_matching(RRDSET *st) {
     // Do not stream anomaly rates charts.
-    if (unlikely(st->state->is_ar_chart))
+    if (unlikely(rrdset_is_ar_chart(st)))
         return false;
 
     if (rrdset_flag_check(st, RRDSET_FLAG_ANOMALY_DETECTION))

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -197,8 +197,8 @@ static int send_clabels_callback(const char *name, const char *value, RRDLABEL_S
     return 1;
 }
 void rrdpush_send_clabels(RRDHOST *host, RRDSET *st) {
-    if (st->chart_labels) {
-        if(rrdlabels_walkthrough_read(st->chart_labels, send_clabels_callback, host->sender->build) > 0)
+    if (st->rrdlabels) {
+        if(rrdlabels_walkthrough_read(st->rrdlabels, send_clabels_callback, host->sender->build) > 0)
             buffer_sprintf(host->sender->build,"CLABEL_COMMIT\n");
     }
 }

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -197,8 +197,8 @@ static int send_clabels_callback(const char *name, const char *value, RRDLABEL_S
     return 1;
 }
 void rrdpush_send_clabels(RRDHOST *host, RRDSET *st) {
-    if (st->state && st->state->chart_labels) {
-        if(rrdlabels_walkthrough_read(st->state->chart_labels, send_clabels_callback, host->sender->build) > 0)
+    if (st->chart_labels) {
+        if(rrdlabels_walkthrough_read(st->chart_labels, send_clabels_callback, host->sender->build) > 0)
             buffer_sprintf(host->sender->build,"CLABEL_COMMIT\n");
     }
 }

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -174,8 +174,8 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
         dict = dictionary_create(DICTIONARY_FLAG_SINGLE_THREADED);
         for (i = 0, rd = temp_rd ? temp_rd : r->st->dimensions; rd; rd = rd->next) {
             st = rd->rrdset;
-            if (st->chart_labels)
-                rrdlabels_walkthrough_read(st->chart_labels, fill_formatted_callback, dict);
+            if (st->rrdlabels)
+                rrdlabels_walkthrough_read(st->rrdlabels, fill_formatted_callback, dict);
         }
         dictionary_walkthrough_read(dict, value_list_output, &co);
         dictionary_destroy(dict);
@@ -231,7 +231,7 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
                     if (i)
                         buffer_strcat(wb, ", ");
 
-                    rrdlabels_get_value_to_buffer_or_null(rd->rrdset->chart_labels, wb, label_key, sq, "null");
+                    rrdlabels_get_value_to_buffer_or_null(rd->rrdset->rrdlabels, wb, label_key, sq, "null");
                     i++;
                 }
                 if (!i) {

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -174,8 +174,8 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
         dict = dictionary_create(DICTIONARY_FLAG_SINGLE_THREADED);
         for (i = 0, rd = temp_rd ? temp_rd : r->st->dimensions; rd; rd = rd->next) {
             st = rd->rrdset;
-            if (st->state && st->state->chart_labels)
-                rrdlabels_walkthrough_read(st->state->chart_labels, fill_formatted_callback, dict);
+            if (st->chart_labels)
+                rrdlabels_walkthrough_read(st->chart_labels, fill_formatted_callback, dict);
         }
         dictionary_walkthrough_read(dict, value_list_output, &co);
         dictionary_destroy(dict);
@@ -231,7 +231,7 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
                     if (i)
                         buffer_strcat(wb, ", ");
 
-                    rrdlabels_get_value_to_buffer_or_null(rd->rrdset->state->chart_labels, wb, label_key, sq, "null");
+                    rrdlabels_get_value_to_buffer_or_null(rd->rrdset->chart_labels, wb, label_key, sq, "null");
                     i++;
                 }
                 if (!i) {

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -300,7 +300,7 @@ int rrdset2anything_api_v1(
         return HTTP_RESP_BACKEND_FETCH_FAILED;
     }
 
-    if (st->state && st->state->is_ar_chart)
+    if (rrdset_is_ar_chart(st))
         ml_process_rrdr(r, query_params->max_anomaly_rates);
 
     RRDDIM *temp_rd = query_params->context_param_list ? query_params->context_param_list->rd : NULL;

--- a/web/api/formatters/rrdset2json.c
+++ b/web/api/formatters/rrdset2json.c
@@ -4,7 +4,7 @@
 
 void chart_labels2json(RRDSET *st, BUFFER *wb, size_t indentation)
 {
-    if(unlikely(!st->state || !st->chart_labels))
+    if(unlikely(!st->state || !st->rrdlabels))
         return;
 
     char tabs[11];
@@ -18,7 +18,7 @@ void chart_labels2json(RRDSET *st, BUFFER *wb, size_t indentation)
         indentation--;
     }
 
-    rrdlabels_to_buffer(st->chart_labels, wb, tabs, ":", "\"", ",\n", NULL, NULL, NULL, NULL);
+    rrdlabels_to_buffer(st->rrdlabels, wb, tabs, ":", "\"", ",\n", NULL, NULL, NULL, NULL);
     buffer_strcat(wb, "\n");
 }
 

--- a/web/api/formatters/rrdset2json.c
+++ b/web/api/formatters/rrdset2json.c
@@ -4,7 +4,7 @@
 
 void chart_labels2json(RRDSET *st, BUFFER *wb, size_t indentation)
 {
-    if(unlikely(!st->state || !st->rrdlabels))
+    if(unlikely(!st->rrdlabels))
         return;
 
     char tabs[11];

--- a/web/api/formatters/rrdset2json.c
+++ b/web/api/formatters/rrdset2json.c
@@ -4,7 +4,7 @@
 
 void chart_labels2json(RRDSET *st, BUFFER *wb, size_t indentation)
 {
-    if(unlikely(!st->state || !st->state->chart_labels))
+    if(unlikely(!st->state || !st->chart_labels))
         return;
 
     char tabs[11];
@@ -18,7 +18,7 @@ void chart_labels2json(RRDSET *st, BUFFER *wb, size_t indentation)
         indentation--;
     }
 
-    rrdlabels_to_buffer(st->state->chart_labels, wb, tabs, ":", "\"", ",\n", NULL, NULL, NULL, NULL);
+    rrdlabels_to_buffer(st->chart_labels, wb, tabs, ":", "\"", ",\n", NULL, NULL, NULL, NULL);
     buffer_strcat(wb, "\n");
 }
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -713,8 +713,8 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
         rrdhost_rdlock(host);
         rrdset_foreach_read(st1, host) {
             if (st1->context == context_string &&
-                (!chart_label_key_pattern || rrdlabels_match_simple_pattern_parsed(st1->state->chart_labels, chart_label_key_pattern, ':')) &&
-                (!chart_labels_filter_pattern || rrdlabels_match_simple_pattern_parsed(st1->state->chart_labels, chart_labels_filter_pattern, ':')))
+                (!chart_label_key_pattern || rrdlabels_match_simple_pattern_parsed(st1->chart_labels, chart_label_key_pattern, ':')) &&
+                (!chart_labels_filter_pattern || rrdlabels_match_simple_pattern_parsed(st1->chart_labels, chart_labels_filter_pattern, ':')))
                     build_context_param_list(owa, &context_param_list, st1);
         }
         rrdhost_unlock(host);

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -713,8 +713,8 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
         rrdhost_rdlock(host);
         rrdset_foreach_read(st1, host) {
             if (st1->context == context_string &&
-                (!chart_label_key_pattern || rrdlabels_match_simple_pattern_parsed(st1->chart_labels, chart_label_key_pattern, ':')) &&
-                (!chart_labels_filter_pattern || rrdlabels_match_simple_pattern_parsed(st1->chart_labels, chart_labels_filter_pattern, ':')))
+                (!chart_label_key_pattern || rrdlabels_match_simple_pattern_parsed(st1->rrdlabels, chart_label_key_pattern, ':')) &&
+                (!chart_labels_filter_pattern || rrdlabels_match_simple_pattern_parsed(st1->rrdlabels, chart_labels_filter_pattern, ':')))
                     build_context_param_list(owa, &context_param_list, st1);
         }
         rrdhost_unlock(host);

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1140,7 +1140,7 @@ inline void host_labels2json(RRDHOST *host, BUFFER *wb, size_t indentation) {
         indentation--;
     }
 
-    rrdlabels_to_buffer(host->host_labels, wb, tabs, ":", "\"", ",\n", NULL, NULL, NULL, NULL);
+    rrdlabels_to_buffer(host->rrdlabels, wb, tabs, ":", "\"", ",\n", NULL, NULL, NULL, NULL);
     buffer_strcat(wb, "\n");
 }
 


### PR DESCRIPTION
This PR obsoletes `RRDSET->state`.
Moves the 2 useful members directly into RRDSET and turns the `is_ar_chart` boolean into an RRDSET flag.

No functionality changed. Just code cleanup.