### PR TITLE
Fix a memory leak on archived host creation

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -274,7 +274,8 @@ RRDHOST *rrdhost_create(const char *hostname,
 #endif
 
     netdata_rwlock_init(&host->rrdhost_rwlock);
-    host->rrdlabels = rrdlabels_create();
+    if (likely(!archived))
+        host->rrdlabels = rrdlabels_create();
 
     netdata_mutex_init(&host->aclk_state_lock);
 


### PR DESCRIPTION
##### Summary
When creating a host it initializes a host labels dictionary. This is not needed as the labels are 
created after the (archived) host creation on startup (this leads to a small memory leak)

```
Direct leak of 496 byte(s) in 2 object(s) allocated from:
    #0 0x7f9944e1aa37 in __interceptor_calloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:154
    #1 0x5555e840b069 in callocz /home/stelios/git/netdata/libnetdata/libnetdata.c:176
    #2 0x5555e83e65b6 in dictionary_create_advanced /home/stelios/git/netdata/libnetdata/dictionary/dictionary.c:761
    #3 0x5555e858a1c2 in rrdlabels_create /home/stelios/git/netdata/database/rrdlabels.c:526
    #4 0x5555e8577c99 in rrdhost_create /home/stelios/git/netdata/database/rrdhost.c:277
    #5 0x5555e857fa5b in rrdhost_find_or_create /home/stelios/git/netdata/database/rrdhost.c:694
    #6 0x5555e85cfd10 in create_host_callback /home/stelios/git/netdata/database/sqlite/sqlite_aclk.c:293
    #7 0x5555e8642869 in sqlite3_exec /home/stelios/git/netdata/database/sqlite/sqlite3.c:128207
    #8 0x5555e85ad301 in sqlite3_exec_monitored /home/stelios/git/netdata/database/sqlite/sqlite_functions.c:100
    #9 0x5555e85cec3c in sql_aclk_sync_init /home/stelios/git/netdata/database/sqlite/sqlite_aclk.c:375
    #10 0x5555e8581db8 in rrd_init /home/stelios/git/netdata/database/rrdhost.c:963
    #11 0x5555e8395875 in main /home/stelios/git/netdata/daemon/main.c:1465
    #12 0x7f9943b7fd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
```

##### Test Plan
- Use agent - parent setup
- Start the parent and verify (valgrind or sanitizer) 
