### PR TITLE
apps.plugin: Re-add `chrome` to the `webbrowser` group.

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -336,7 +336,7 @@ wayfire: wayfire
 gui: lightdm colord seatd greetd gkrellm slim qingy dconf* *gvfs gvfs*
 gui: '*systemd --user*' xdg-* at-spi-*
 
-webbrowser: *chrome-sandbox* *google-chrome* *chromium* *firefox* vivaldi* opera* epiphany
+webbrowser: *chrome-sandbox* *google-chrome* *chromium* *firefox* vivaldi* opera* epiphany chrome*
 webbrowser: lynx elinks w3m w3mmee links
 mua: evolution-* thunderbird* mutt neomutt pine mailx alpine
 


### PR DESCRIPTION
##### Summary

It’s a relatively common name on some systems, and unintentionally got removed with the recent changes to the GUI application grouping.

##### Test Plan

n/a