### PR TITLE
fix rrdcontexts left in the post-processing queue from the garbage collector

### DIFF
--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -323,16 +323,8 @@ static inline void rrdmetric_release(RRDMETRIC_ACQUIRED *rma) {
 // ----------------------------------------------------------------------------
 // helper one-liners for RRDINSTANCE
 
-static inline RRDINSTANCE_ACQUIRED *rrdinstance_dup(RRDINSTANCE_ACQUIRED *ria) {
-    return (RRDINSTANCE_ACQUIRED *)dictionary_acquired_item_dup((DICTIONARY_ITEM *)ria);
-}
-
 static inline RRDINSTANCE *rrdinstance_acquired_value(RRDINSTANCE_ACQUIRED *ria) {
     return dictionary_acquired_item_value((DICTIONARY_ITEM *)ria);
-}
-
-static inline const char *rrdinstance_acquired_name(RRDINSTANCE_ACQUIRED *ria) {
-    return dictionary_acquired_item_name((DICTIONARY_ITEM *)ria);
 }
 
 static inline void rrdinstance_release(RRDINSTANCE_ACQUIRED *ria) {
@@ -343,20 +335,8 @@ static inline void rrdinstance_release(RRDINSTANCE_ACQUIRED *ria) {
 // ----------------------------------------------------------------------------
 // helper one-liners for RRDCONTEXT
 
-static inline RRDCONTEXT_ACQUIRED *rrdcontext_dup(RRDCONTEXT_ACQUIRED *rca) {
-    return (RRDCONTEXT_ACQUIRED *)dictionary_acquired_item_dup((DICTIONARY_ITEM *)rca);
-}
-
-static inline const char *rrdcontext_acquired_name(RRDCONTEXT_ACQUIRED *rca) {
-    return dictionary_acquired_item_name((DICTIONARY_ITEM *)rca);
-}
-
 static inline RRDCONTEXT *rrdcontext_acquired_value(RRDCONTEXT_ACQUIRED *rca) {
     return dictionary_acquired_item_value((DICTIONARY_ITEM *)rca);
-}
-
-static inline RRDCONTEXT_ACQUIRED *rrdcontext_acquire(RRDHOST *host, const char *name) {
-    return (RRDCONTEXT_ACQUIRED *)dictionary_get_and_acquire_item((DICTIONARY *)host->rrdctx, name);
 }
 
 static inline void rrdcontext_release(RRDCONTEXT_ACQUIRED *rca) {
@@ -1279,6 +1259,37 @@ static void rrdcontext_trigger_updates(RRDCONTEXT *rc, const char *function) {
         rrdcontext_queue_for_post_processing(rc, function, rc->flags);
 }
 
+static void rrdcontext_hub_queue_insert_callback(const char *name __maybe_unused, void *context, void *data __maybe_unused) {
+    RRDCONTEXT *rc = context;
+    rrd_flag_set(rc, RRD_FLAG_QUEUED_FOR_HUB);
+    rc->queue.queued_ut = now_realtime_usec();
+    rc->queue.queued_flags = rrd_flags_get(rc);
+}
+
+static void rrdcontext_hub_queue_delete_callback(const char *name __maybe_unused, void *context, void *data __maybe_unused) {
+    RRDCONTEXT *rc = context;
+    rrd_flag_clear(rc, RRD_FLAG_QUEUED_FOR_HUB);
+}
+
+static void rrdcontext_hub_queue_conflict_callback(const char *name __maybe_unused, void *context, void *new_context __maybe_unused, void *data __maybe_unused) {
+    // context and new_context are the same
+    // we just need to update the timings
+    RRDCONTEXT *rc = context;
+    rrd_flag_set(rc, RRD_FLAG_QUEUED_FOR_HUB);
+    rc->queue.queued_ut = now_realtime_usec();
+    rc->queue.queued_flags |= rrd_flags_get(rc);
+}
+
+static void rrdcontext_post_processing_queue_insert_callback(const char *name __maybe_unused, void *context, void *data __maybe_unused) {
+    RRDCONTEXT *rc = context;
+    rrd_flag_set(rc, RRD_FLAG_QUEUED_FOR_POST_PROCESSING);
+}
+
+static void rrdcontext_post_processing_queue_delete_callback(const char *name __maybe_unused, void *context, void *data __maybe_unused) {
+    RRDCONTEXT *rc = context;
+    rrd_flag_clear(rc, RRD_FLAG_QUEUED_FOR_POST_PROCESSING);
+}
+
 void rrdhost_create_rrdcontexts(RRDHOST *host) {
     if(unlikely(rrdcontext_enabled == CONFIG_BOOLEAN_NO))
         return;
@@ -1292,8 +1303,20 @@ void rrdhost_create_rrdcontexts(RRDHOST *host) {
     dictionary_register_conflict_callback((DICTIONARY *)host->rrdctx, rrdcontext_conflict_callback, (void *)host);
     dictionary_register_react_callback((DICTIONARY *)host->rrdctx, rrdcontext_react_callback, (void *)host);
 
-    host->rrdctx_hub_queue = (RRDCONTEXTS *)dictionary_create(DICTIONARY_FLAG_DONT_OVERWRITE_VALUE | DICTIONARY_FLAG_VALUE_LINK_DONT_CLONE);
-    host->rrdctx_post_processing_queue = (RRDCONTEXTS *)dictionary_create(DICTIONARY_FLAG_DONT_OVERWRITE_VALUE | DICTIONARY_FLAG_VALUE_LINK_DONT_CLONE);
+    host->rrdctx_hub_queue = (RRDCONTEXTS *)dictionary_create(
+         DICTIONARY_FLAG_DONT_OVERWRITE_VALUE
+        |DICTIONARY_FLAG_VALUE_LINK_DONT_CLONE);
+
+    dictionary_register_insert_callback((DICTIONARY *)host->rrdctx_hub_queue, rrdcontext_hub_queue_insert_callback, NULL);
+    dictionary_register_delete_callback((DICTIONARY *)host->rrdctx_hub_queue, rrdcontext_hub_queue_delete_callback, NULL);
+    dictionary_register_conflict_callback((DICTIONARY *)host->rrdctx_hub_queue, rrdcontext_hub_queue_conflict_callback, NULL);
+
+    host->rrdctx_post_processing_queue = (RRDCONTEXTS *)dictionary_create(
+         DICTIONARY_FLAG_DONT_OVERWRITE_VALUE
+        |DICTIONARY_FLAG_VALUE_LINK_DONT_CLONE);
+
+    dictionary_register_insert_callback((DICTIONARY *)host->rrdctx_hub_queue, rrdcontext_post_processing_queue_insert_callback, NULL);
+    dictionary_register_delete_callback((DICTIONARY *)host->rrdctx_hub_queue, rrdcontext_post_processing_queue_delete_callback, NULL);
 }
 
 void rrdhost_destroy_rrdcontexts(RRDHOST *host) {
@@ -1309,7 +1332,6 @@ void rrdhost_destroy_rrdcontexts(RRDHOST *host) {
         RRDCONTEXT *rc;
         dfe_start_write(old, rc) {
             dictionary_del_having_write_lock(old, string2str(rc->id));
-            rrdset_flag_clear(rc, RRD_FLAG_QUEUED_FOR_HUB);
         }
         dfe_done(rc);
         dictionary_destroy(old);
@@ -1322,7 +1344,6 @@ void rrdhost_destroy_rrdcontexts(RRDHOST *host) {
         RRDCONTEXT *rc;
         dfe_start_write(old, rc) {
             dictionary_del_having_write_lock(old, string2str(rc->id));
-            rrdset_flag_clear(rc, RRD_FLAG_QUEUED_FOR_POST_PROCESSING);
         }
         dfe_done(rc);
         dictionary_destroy(old);
@@ -2670,17 +2691,8 @@ static void rrdcontext_post_process_updates(RRDCONTEXT *rc, bool force, RRD_FLAG
     if(unlikely(rrd_flag_is_updated(rc) && rc->rrdhost->rrdctx_hub_queue)) {
         if(check_if_cloud_version_changed_unsafe(rc, false)) {
             rc->version = rrdcontext_get_next_version(rc);
-
-            if(rrd_flag_check(rc, RRD_FLAG_QUEUED_FOR_HUB)) {
-                rc->queue.queued_ut = now_realtime_usec();
-                rc->queue.queued_flags |= rrd_flags_get(rc);
-            }
-            else {
-                rc->queue.queued_ut = now_realtime_usec();
-                rc->queue.queued_flags = rrd_flags_get(rc);
-                rrd_flag_set(rc, RRD_FLAG_QUEUED_FOR_HUB);
-                dictionary_set((DICTIONARY *)rc->rrdhost->rrdctx_hub_queue, string2str(rc->id), rc, sizeof(*rc));
-            }
+            dictionary_set((DICTIONARY *)rc->rrdhost->rrdctx_hub_queue,
+                           string2str(rc->id), rc, sizeof(*rc));
         }
     }
 
@@ -2692,8 +2704,10 @@ static void rrdcontext_queue_for_post_processing(RRDCONTEXT *rc, const char *fun
     if(unlikely(!rc->rrdhost->rrdctx_post_processing_queue)) return;
 
     if(!rrd_flag_check(rc, RRD_FLAG_QUEUED_FOR_POST_PROCESSING)) {
-        rrd_flag_set(rc, RRD_FLAG_QUEUED_FOR_POST_PROCESSING);
-        dictionary_set((DICTIONARY *)rc->rrdhost->rrdctx_post_processing_queue, string2str(rc->id), rc, sizeof(*rc));
+        dictionary_set((DICTIONARY *)rc->rrdhost->rrdctx_post_processing_queue,
+                       string2str(rc->id),
+                       rc,
+                       sizeof(*rc));
 
 #ifdef NETDATA_INTERNAL_CHECKS
         {
@@ -2717,9 +2731,7 @@ static void rrdcontext_queue_for_post_processing(RRDCONTEXT *rc, const char *fun
 
 static void rrdcontext_dequeue_from_post_processing(RRDCONTEXT *rc) {
     if(unlikely(!rc->rrdhost->rrdctx_post_processing_queue)) return;
-
     dictionary_del((DICTIONARY *)rc->rrdhost->rrdctx_post_processing_queue, string2str(rc->id));
-    rrd_flag_clear(rc, RRD_FLAG_QUEUED_FOR_POST_PROCESSING);
 }
 
 static void rrdcontext_post_process_queued_contexts(RRDHOST *host) {
@@ -2884,6 +2896,10 @@ static inline usec_t rrdcontext_calculate_queued_dispatch_time_ut(RRDCONTEXT *rc
     return dispatch_ut;
 }
 
+static void rrdcontext_dequeue_from_hub_queue(RRDCONTEXT *rc) {
+    dictionary_del((DICTIONARY *)rc->rrdhost->rrdctx_hub_queue, string2str(rc->id));
+}
+
 static void rrdcontext_dispatch_queued_contexts_to_hub(RRDHOST *host, usec_t now_ut) {
 
     // check if we have received a streaming command for this host
@@ -2938,12 +2954,9 @@ static void rrdcontext_dispatch_queued_contexts_to_hub(RRDHOST *host, usec_t now
             else
                 rc->version = rc->hub.version;
 
-            // remove the queued flag, so that it can be queued again
-            rrd_flag_clear(rc, RRD_FLAG_QUEUED_FOR_HUB);
-
             // remove it from the queue
             worker_is_busy(WORKER_JOB_DEQUEUE);
-            dictionary_del((DICTIONARY *)host->rrdctx_hub_queue, string2str(rc->id));
+            rrdcontext_dequeue_from_hub_queue(rc);
 
             if(unlikely(rrdcontext_should_be_deleted(rc))) {
                 // this is a deleted context - delete it forever...

--- a/libnetdata/dictionary/dictionary.c
+++ b/libnetdata/dictionary/dictionary.c
@@ -914,6 +914,10 @@ static NAME_VALUE *dictionary_set_name_value_unsafe(DICTIONARY *dict, const char
         // so, either we will return the old one
         // or overwrite the value, depending on dictionary flags
 
+        // We should not compare the values here!
+        // even if they are the same, we have to do the whole job
+        // so that the callbacks will be called.
+
         nv = *pnv;
 
         if(!(dict->flags & DICTIONARY_FLAG_DONT_OVERWRITE_VALUE)) {
@@ -927,7 +931,8 @@ static NAME_VALUE *dictionary_set_name_value_unsafe(DICTIONARY *dict, const char
         }
 
         else {
-            // make sure this flag is not set
+            // we did really nothing!
+            // make sure this flag is not set.
             nv->flags &= ~NAME_VALUE_FLAG_NEW_OR_UPDATED;
         }
     }


### PR DESCRIPTION
Fixes the first item reported in https://github.com/netdata/netdata/issues/13644

The bug was that the garbage collector was deleting contexts without removing them from the post-processing queue.

These fixes have been added:

- [x] do not attempt to delete a context that is in the context post-processing queue
- [x] once a context is decided to be deleted, first delete it from the post-processing queue.
- [x] set/clear the queuing flags atomically, using the dictionary callbacks, so that there will be no way for a flag to be cleared and the context to be in the queue and vice versa.