### PR TITLE
add _collect_job label to python.d/* charts

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SimpleService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SimpleService.py
@@ -7,11 +7,10 @@
 
 from time import sleep, time
 
-from third_party.monotonic import monotonic
-
 from bases.charts import Charts, ChartError, create_runtime_chart
 from bases.collection import safe_print
 from bases.loggers import PythonDLimitedLogger
+from third_party.monotonic import monotonic
 
 RUNTIME_CHART_UPDATE = 'BEGIN netdata.runtime_{job_name} {since_last}\n' \
                        'SET run_time = {elapsed}\n' \
@@ -79,11 +78,13 @@ class SimpleService(PythonDLimitedLogger, object):
 
         self.module_name = clean_module_name(self.__module__)
         self.job_name = configuration.pop('job_name')
+        self.actual_job_name = self.job_name or self.module_name
         self.override_name = configuration.pop('override_name')
         self.fake_name = None
 
         self._runtime_counters = RuntimeCounters(configuration=configuration)
         self.charts = Charts(job_name=self.actual_name,
+                             actual_job_name=self.actual_job_name,
                              priority=configuration.pop('priority'),
                              cleanup=configuration.pop('chart_cleanup'),
                              get_update_every=self.get_update_every,

--- a/collectors/python.d.plugin/python_modules/bases/charts.py
+++ b/collectors/python.d.plugin/python_modules/bases/charts.py
@@ -18,6 +18,9 @@ CHART_CREATE = "CHART {type}.{id} '{name}' '{title}' '{units}' '{family}' '{cont
 CHART_OBSOLETE = "CHART {type}.{id} '{name}' '{title}' '{units}' '{family}' '{context}' " \
                  "{chart_type} {priority} {update_every} '{hidden} obsolete'\n"
 
+CLABEL_COLLECT_JOB = "CLABEL '_collect_job' '{actual_job_name}' '0'\n"
+CLABEL_COMMIT = "CLABEL_COMMIT\n"
+
 DIMENSION_CREATE = "DIMENSION '{id}' '{name}' {algorithm} {multiplier} {divisor} '{hidden} {obsolete}'\n"
 DIMENSION_SET = "SET '{id}' = {value}\n"
 
@@ -25,6 +28,8 @@ CHART_VARIABLE_SET = "VARIABLE CHART '{id}' = {value}\n"
 
 RUNTIME_CHART_CREATE = "CHART netdata.runtime_{job_name} '' 'Execution time' 'ms' 'python.d' " \
                        "netdata.pythond_runtime line 145000 {update_every} '' 'python.d.plugin' '{module_name}'\n" \
+                       "CLABEL '_collect_job' '{actual_job_name}' '0'\n" \
+                       "CLABEL_COMMIT\n" \
                        "DIMENSION run_time 'run time' absolute 1 1\n"
 
 
@@ -44,6 +49,7 @@ def create_runtime_chart(func):
         self = args[0]
         chart = RUNTIME_CHART_CREATE.format(
             job_name=self.name,
+            actual_job_name=self.actual_job_name,
             update_every=self._runtime_counters.update_every,
             module_name=self.module_name,
         )
@@ -77,13 +83,14 @@ class Charts:
     Chart is a instance of Chart class.
     Charts adding must be done using Charts.add_chart() method only"""
 
-    def __init__(self, job_name, priority, cleanup, get_update_every, module_name):
+    def __init__(self, job_name, actual_job_name, priority, cleanup, get_update_every, module_name):
         """
         :param job_name: <bound method>
         :param priority: <int>
         :param get_update_every: <bound method>
         """
         self.job_name = job_name
+        self.actual_job_name = actual_job_name
         self.priority = priority
         self.cleanup = cleanup
         self.get_update_every = get_update_every
@@ -131,6 +138,7 @@ class Charts:
         new_chart.params['update_every'] = self.get_update_every()
         new_chart.params['priority'] = self.priority
         new_chart.params['module_name'] = self.module_name
+        new_chart.params['actual_job_name'] = self.actual_job_name
 
         self.priority += 1
         self.charts[new_chart.id] = new_chart
@@ -230,13 +238,14 @@ class Chart:
         :return:
         """
         chart = CHART_CREATE.format(**self.params)
+        labels = CLABEL_COLLECT_JOB.format(**self.params) + CLABEL_COMMIT
         dimensions = ''.join([dimension.create() for dimension in self.dimensions])
         variables = ''.join([var.set(var.value) for var in self.variables if var])
 
         self.flags.push = False
         self.flags.created = True
 
-        safe_print(chart + dimensions + variables)
+        safe_print(chart + labels + dimensions + variables)
 
     def can_be_updated(self, data):
         for dim in self.dimensions:


### PR DESCRIPTION
##### Summary

Adds `_collect_job` label to pyhton.d/* charts. The label value is a data collection job name.

##### Test Plan

Check python.d/* charts labels using `/api/v1/charts`.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
