### PR TITLE
Improve agent shutdown time

### DIFF
--- a/database/engine/datafile.c
+++ b/database/engine/datafile.c
@@ -444,44 +444,17 @@ void finalize_data_files(struct rrdengine_instance *ctx)
     struct rrdengine_journalfile *journalfile;
     struct extent_info *extent, *next_extent;
 
-    size_t extents_number = 0;
-    size_t extents_bytes = 0;
-    size_t page_compressed_sizes = 0;
-
-    size_t files_number = 0;
-    size_t files_bytes = 0;
-
     for (datafile = ctx->datafiles.first ; datafile != NULL ; datafile = next_datafile) {
         journalfile = datafile->journalfile;
         next_datafile = datafile->next;
 
         for (extent = datafile->extents.first ; extent != NULL ; extent = next_extent) {
-            extents_number++;
-            extents_bytes += sizeof(*extent) + sizeof(struct rrdeng_page_descr *) * extent->number_of_pages;
-            page_compressed_sizes += extent->size;
-
             next_extent = extent->next;
             freez(extent);
         }
         close_journal_file(journalfile, datafile);
         close_data_file(datafile);
-
-        files_number++;
-        files_bytes += sizeof(*journalfile) + sizeof(*datafile);
-
         freez(journalfile);
         freez(datafile);
     }
-
-    if(!files_number) files_number = 1;
-    if(!extents_number) extents_number = 1;
-
-    info("DBENGINE STATISTICS ON DATAFILES:"
-         " Files %zu, structures %zu bytes, %0.2f bytes per file."
-         " Extents %zu, structures %zu bytes, %0.2f bytes per extent."
-         " Compressed size of all pages: %zu bytes."
-         , files_number, files_bytes, (double)files_bytes/files_number
-         , extents_number, extents_bytes, (double)extents_bytes/extents_number
-         , page_compressed_sizes
-         );
 }

--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -1238,24 +1238,6 @@ void init_page_cache(struct rrdengine_instance *ctx)
     init_committed_page_index(ctx);
 }
 
-
-
-/*
- * METRIC                                            # number
- * 1. INDEX: JudyHS                                  # bytes
- * 2. DATA: page_index                               # bytes
- *
- * PAGE (1 page of 1 metric)                         # number
- * 1. INDEX AT METRIC: page_index->JudyL_array       # bytes
- * 2. DATA: descr                                    # bytes
- *
- * PAGE CACHE (1 page of 1 metric at the cache)      # number
- * 1. pg_cache_descr (if PG_CACHE_DESCR_ALLOCATED)   # bytes
- * 2. data (if RRD_PAGE_POPULATED)                   # bytes
- *
- */
-
-
 void free_page_cache(struct rrdengine_instance *ctx)
 {
     struct page_cache *pg_cache = &ctx->pg_cache;
@@ -1265,30 +1247,15 @@ void free_page_cache(struct rrdengine_instance *ctx)
     struct rrdeng_page_descr *descr;
     struct page_cache_descr *pg_cache_descr;
 
-    Word_t metrics_number      = 0,
-           metrics_bytes       = 0,
-           metrics_index_bytes = 0,
-           metrics_duration    = 0;
-
-    Word_t pages_number        = 0,
-           pages_bytes         = 0,
-           pages_index_bytes   = 0;
-
-    Word_t pages_size_per_type[256]  = { 0 },
-           pages_count_per_type[256] = { 0 };
-
-    Word_t cache_pages_number  = 0,
-           cache_pages_bytes   = 0,
-           cache_pages_data_bytes  = 0;
-
-    size_t points_in_db        = 0,
-           uncompressed_points_size = 0,
-           seconds_in_db       = 0,
-           single_point_pages  = 0;
-
-    Word_t pages_dirty_index_bytes = 0;
-
-    usec_t oldest_time_ut = LONG_MAX, latest_time_ut = 0;
+    // if we are exiting, the OS will recover all memory so do not slow down the shutdown process
+    // Do the cleanup if we are compiling with NETDATA_INTERNAL_CHECKS
+    // This affects the reporting of dbengine statistics which are available in real time
+    // via the /api/v1/dbengine_stats endpoint
+#ifndef NETDATA_INTERNAL_CHECKS
+    if (netdata_exit)
+        return;
+#endif
+    Word_t metrics_index_bytes = 0, pages_index_bytes = 0, pages_dirty_index_bytes = 0;
 
     /* Free committed page index */
     pages_dirty_index_bytes = JudyLFreeArray(&pg_cache->committed_page_index.JudyL_array, PJE0);
@@ -1305,116 +1272,30 @@ void free_page_cache(struct rrdengine_instance *ctx)
         PValue = JudyLFirst(page_index->JudyL_array, &Index, PJE0);
         descr = unlikely(NULL == PValue) ? NULL : *PValue;
 
-        size_t metric_duration = 0;
-        size_t metric_update_every = 0;
-        size_t metric_single_point_pages = 0;
-
         while (descr != NULL) {
             /* Iterate all page descriptors of this metric */
 
             if (descr->pg_cache_descr_state & PG_CACHE_DESCR_ALLOCATED) {
-                cache_pages_number++;
-
                 /* Check rrdenglocking.c */
                 pg_cache_descr = descr->pg_cache_descr;
                 if (pg_cache_descr->flags & RRD_PAGE_POPULATED) {
                     dbengine_page_free(pg_cache_descr->page);
-                    cache_pages_data_bytes += RRDENG_BLOCK_SIZE;
                 }
                 rrdeng_destroy_pg_cache_descr(ctx, pg_cache_descr);
-                cache_pages_bytes += sizeof(*pg_cache_descr);
             }
-
-            if(descr->start_time < oldest_time_ut)
-                oldest_time_ut = descr->start_time;
-
-            if(descr->end_time > latest_time_ut)
-                latest_time_ut = descr->end_time;
-
-            pages_size_per_type[descr->type] += descr->page_length;
-            pages_count_per_type[descr->type]++;
-
-            size_t points_in_page = (descr->page_length / PAGE_POINT_SIZE_BYTES(descr));
-            size_t page_duration  = ((descr->end_time - descr->start_time) / USEC_PER_SEC);
-            size_t update_every = (page_duration == 0) ? 1 : page_duration / (points_in_page - 1);
-
-            if (!page_duration && metric_update_every) {
-                page_duration = metric_update_every;
-                update_every = metric_update_every;
-            }
-            else if(page_duration)
-                metric_update_every = update_every;
-
-            uncompressed_points_size += descr->page_length;
-
-            if(page_duration > 0) {
-                page_duration = update_every * points_in_page;
-                metric_duration += page_duration;
-                seconds_in_db += page_duration;
-                points_in_db += descr->page_length / PAGE_POINT_SIZE_BYTES(descr);
-            }
-            else
-                metric_single_point_pages++;
-
             rrdeng_page_descr_freez(descr);
-            pages_bytes += sizeof(*descr);
-            pages_number++;
 
             PValue = JudyLNext(page_index->JudyL_array, &Index, PJE0);
             descr = unlikely(NULL == PValue) ? NULL : *PValue;
         }
 
-        if(metric_single_point_pages && metric_update_every) {
-            points_in_db += metric_single_point_pages;
-            seconds_in_db += metric_update_every * metric_single_point_pages;
-            metric_duration += metric_update_every * metric_single_point_pages;
-        }
-        else
-            single_point_pages += metric_single_point_pages;
-
         /* Free page index */
         pages_index_bytes += JudyLFreeArray(&page_index->JudyL_array, PJE0);
         fatal_assert(NULL == page_index->JudyL_array);
         freez(page_index);
-
-        metrics_number++;
-        metrics_bytes += sizeof(*page_index);
-        metrics_duration += metric_duration;
     }
     /* Free metrics index */
     metrics_index_bytes = JudyHSFreeArray(&pg_cache->metrics_index.JudyHS_array, PJE0);
     fatal_assert(NULL == pg_cache->metrics_index.JudyHS_array);
-
-    if(!metrics_number) metrics_number = 1;
-    if(!pages_number) pages_number = 1;
-    if(!cache_pages_number) cache_pages_number = 1;
-    if(!points_in_db) points_in_db = 1;
-    if(latest_time_ut == oldest_time_ut) oldest_time_ut -= USEC_PER_SEC;
-
-    if(single_point_pages) {
-        long double avg_duration = (long double)seconds_in_db / points_in_db;
-        points_in_db += single_point_pages;
-        seconds_in_db += (size_t)(avg_duration * single_point_pages);
-    }
-
-    info("DBENGINE STATISTICS ON METRICS:"
-         " Metrics: %lu (structures %lu bytes - per metric %0.2f, index (HS) %lu bytes - per metric %0.2f bytes - duration %zu secs) |"
-         " Page descriptors: %lu (structures %lu bytes - per page %0.2f bytes, index (L) %lu bytes - per page %0.2f, dirty index %lu bytes). |"
-         " Page cache: %lu pages (structures %lu bytes - per page %0.2f bytes, data %lu bytes). |"
-         " Points in db %zu, uncompressed size of points database %zu bytes. |"
-         " Duration of all points %zu seconds, average point duration %0.2f seconds."
-         " Duration of the database %llu seconds, average metric duration %0.2f seconds, average metric lifetime %0.2f%%."
-         , metrics_number, metrics_bytes, (double)metrics_bytes/metrics_number, metrics_index_bytes, (double)metrics_index_bytes/metrics_number, metrics_duration
-         , pages_number, pages_bytes, (double)pages_bytes/pages_number, pages_index_bytes, (double)pages_index_bytes/pages_number, pages_dirty_index_bytes
-         , cache_pages_number, cache_pages_bytes, (double)cache_pages_bytes/cache_pages_number, cache_pages_data_bytes
-         , points_in_db, uncompressed_points_size
-         , seconds_in_db, (double)seconds_in_db/points_in_db
-         , (latest_time_ut - oldest_time_ut) / USEC_PER_SEC, (double)metrics_duration/metrics_number
-         , (double)metrics_duration/metrics_number * 100.0 / ((latest_time_ut - oldest_time_ut) / USEC_PER_SEC)
-         );
-
-    for(int i = 0; i < 256 ;i++) {
-        if(pages_count_per_type[i])
-            info("DBENGINE STATISTICS ON PAGE TYPES: page type %d total pages %lu, average page size %0.2f bytes", i, pages_count_per_type[i], (double)pages_size_per_type[i]/pages_count_per_type[i]);
-    }
+    info("Freed %lu bytes of memory from page cache.", pages_dirty_index_bytes + pages_index_bytes + metrics_index_bytes);
 }

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -1329,7 +1329,7 @@ void rrdeng_worker(void* arg)
     }
 
     /* cleanup operations of the event loop */
-    info("Shutting down RRD engine event loop.");
+    info("Shutting down RRD engine event loop for tier %d", ctx->tier);
 
     /*
      * uv_async_send after uv_close does not seem to crash in linux at the moment,
@@ -1344,7 +1344,7 @@ void rrdeng_worker(void* arg)
     wal_flush_transaction_buffer(wc);
     uv_run(loop, UV_RUN_DEFAULT);
 
-    info("Shutting down RRD engine event loop complete.");
+    info("Shutting down RRD engine event loop for tier %d complete", ctx->tier);
     /* TODO: don't let the API block by waiting to enqueue commands */
     uv_cond_destroy(&wc->cmd_cond);
 /*  uv_mutex_destroy(&wc->cmd_mutex); */

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1007,8 +1007,6 @@ void __rrd_check_wrlock(const char *file, const char *function, const unsigned l
 // RRDHOST - free
 
 void rrdhost_system_info_free(struct rrdhost_system_info *system_info) {
-    info("SYSTEM_INFO: free %p", system_info);
-
     if(likely(system_info)) {
         freez(system_info->cloud_provider_type);
         freez(system_info->cloud_instance_type);


### PR DESCRIPTION
##### Summary
Skips memory release of dbengine page cache during shutdown as the OS will reclaim memory (it can make shutdown much faster on agents with big data retention).

Removes dbengine statistics on shutdown. This information is now available via `/api/v1/dbengine_stats` 

It will still do memory cleanup (for testing when compiled with NETDATA_INTERNAL_CHECKS)

##### Test Plan
- Compile the agent with and without `NETDATA_INTERNAL_CHECKS` 
  - Depending on your current dbengine database size you will notice faster shutdown times. 