### PR TITLE
Do not free AR dimensions from within ML.

### DIFF
--- a/ml/Dimension.h
+++ b/ml/Dimension.h
@@ -47,9 +47,7 @@ public:
         rrddim_set_name(AnomalyRateRD->rrdset, AnomalyRateRD, Name);
     }
 
-    virtual ~RrdDimension() {
-        rrddim_free(AnomalyRateRD->rrdset, AnomalyRateRD);
-    }
+    virtual ~RrdDimension() {}
 
 private:
     RRDDIM *RD;


### PR DESCRIPTION
##### Summary

Recently introduced changes started removing the AR dimensions outside of the ML code. This PR removes the stale/duplicate call to `rrddim_free` for AR dimensions.

##### Test Plan

Observe no crash during shutdown when ML is enabled.

##### Additional Information

I'm a little bit puzzled as to which change introduced the double free for AR dimensions, considering that we haven't introduced any changes in ML for quite a while. I think it's safe to merge this considering the state of things. However, considering this error and the number of changes we've introduced in the agent the last couple weeks, we need to:

- Ensure that the anomaly rates charts is not sent through ACLK (@underhood or @vkalintiris),
- RRD context does not track the anomaly rates PR (currently, it's clear that it does but do we really need to process the ARs chart through RRD context?) @ktsaou .