### PR TITLE
Fix container virtualization info

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -33,7 +33,8 @@ if [ -z "${VIRTUALIZATION}" ]; then
   if command -v systemd-detect-virt >/dev/null 2>&1; then
     VIRTUALIZATION="$(systemd-detect-virt -v)"
     VIRT_DETECTION="systemd-detect-virt"
-    CONTAINER=${CONTAINER:-$(systemd-detect-virt -c)}
+    CONTAINER_DETECT_TMP="$(systemd-detect-virt -c)"
+    [ -n "$CONTAINER_DETECT_TMP" ] && CONTAINER="$CONTAINER_DETECT_TMP"
     CONT_DETECTION="systemd-detect-virt"
   elif command -v lscpu >/dev/null 2>&1; then
     VIRTUALIZATION=$(lscpu | grep "Hypervisor vendor:" | cut -d: -f 2 | awk '{$1=$1};1')

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -22,6 +22,10 @@ virtualization_normalize_name() {
   echo "$vname" | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g'
 }
 
+CONTAINER="unknown"
+CONT_DETECTION="none"
+CONTAINER_IS_OFFICIAL_IMAGE="${NETDATA_OFFICIAL_IMAGE:-false}"
+
 if [ -z "${VIRTUALIZATION}" ]; then
   VIRTUALIZATION="unknown"
   VIRT_DETECTION="none"
@@ -61,10 +65,6 @@ fi
 
 # -------------------------------------------------------------------------------------------------
 # detect containers with heuristics
-
-CONTAINER=${CONTAINER:-"unknown"}
-CONT_DETECTION=${CONT_DETECTION:-"none"}
-CONTAINER_IS_OFFICIAL_IMAGE=${NETDATA_OFFICIAL_IMAGE:-"false"}
 
 if [ "${CONTAINER}" = "unknown" ]; then
   if [ -f /proc/1/sched ]; then

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -22,10 +22,6 @@ virtualization_normalize_name() {
   echo "$vname" | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g'
 }
 
-CONTAINER="unknown"
-CONT_DETECTION="none"
-CONTAINER_IS_OFFICIAL_IMAGE="${NETDATA_OFFICIAL_IMAGE:-false}"
-
 if [ -z "${VIRTUALIZATION}" ]; then
   VIRTUALIZATION="unknown"
   VIRT_DETECTION="none"
@@ -65,6 +61,10 @@ fi
 
 # -------------------------------------------------------------------------------------------------
 # detect containers with heuristics
+
+CONTAINER=${CONTAINER:-"unknown"}
+CONT_DETECTION=${CONT_DETECTION:-"none"}
+CONTAINER_IS_OFFICIAL_IMAGE=${NETDATA_OFFICIAL_IMAGE:-"false"}
 
 if [ "${CONTAINER}" = "unknown" ]; then
   if [ -f /proc/1/sched ]; then


### PR DESCRIPTION
##### Summary
The detection of container virtualization technology was prevented by an incorrect check for the corresponding variable.

Fixes #10568

##### Test Plan
Run `system-info.sh` in a Proxmox container. It should return `NETDATA_SYSTEM_CONTAINER=lxc`