### PR TITLE
Don't build ACLK with CMake when cloud is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1193,6 +1193,11 @@ ENDIF()
 
 set(NETDATA_COMMON_LIBRARIES ${NETDATA_COMMON_LIBRARIES} m ${CMAKE_THREAD_LIBS_INIT})
 
+# -----------------------------------------------------------------------------
+# ACLK
+
+IF(ENABLE_ACLK)
+
 find_package(Protobuf REQUIRED)
 
 function(PROTOBUF_ACLK_GENERATE_CPP SRCS HDRS)
@@ -1252,16 +1257,19 @@ PROTOBUF_ACLK_GENERATE_CPP(ACLK_PROTO_BUILT_SRCS ACLK_PROTO_BUILT_HDRS ${ACLK_PR
 list(APPEND NETDATA_COMMON_LIBRARIES ${PROTOBUF_LIBRARIES})
 list(APPEND NETDATA_COMMON_INCLUDE_DIRS ${PROTOBUF_INCLUDE_DIRS})
 list(APPEND NETDATA_COMMON_CFLAGS ${PROTOBUF_CFLAGS_OTHER})
-list(APPEND NETDATA_FILES ${ACLK_ALWAYS_BUILD})
-list(APPEND NETDATA_FILES ${TIMEX_PLUGIN_FILES})
 list(APPEND NETDATA_FILES ${ACLK_FILES} ${ACLK_PROTO_BUILT_SRCS} ${ACLK_PROTO_BUILT_HDRS})
 include_directories(BEFORE ${CMAKE_SOURCE_DIR}/aclk/aclk-schemas)
 include_directories(BEFORE ${CMAKE_SOURCE_DIR}/mqtt_websockets/MQTT-C/include)
 include_directories(BEFORE ${CMAKE_SOURCE_DIR}/mqtt_websockets/src/include)
 include_directories(BEFORE ${CMAKE_SOURCE_DIR}/mqtt_websockets/c-rbuf/include)
 
+ENDIF()
+
 # -----------------------------------------------------------------------------
 # netdata
+
+list(APPEND NETDATA_FILES ${ACLK_ALWAYS_BUILD})
+list(APPEND NETDATA_FILES ${TIMEX_PLUGIN_FILES})
 
 IF(LINUX)
     list(APPEND NETDATA_FILES daemon/static_threads_linux.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1196,6 +1196,13 @@ set(NETDATA_COMMON_LIBRARIES ${NETDATA_COMMON_LIBRARIES} m ${CMAKE_THREAD_LIBS_I
 # -----------------------------------------------------------------------------
 # ACLK
 
+file(STRINGS "${CMAKE_SOURCE_DIR}/config.h" DEFINE_ENABLE_ACLK REGEX "^#define ENABLE_ACLK 1$")
+IF(DEFINE_ENABLE_ACLK MATCHES ".+")
+    set(ENABLE_ACLK True)
+ELSE()
+    set(ENABLE_ACLK False)
+ENDIF()
+
 IF(ENABLE_ACLK)
 
 find_package(Protobuf REQUIRED)


### PR DESCRIPTION
##### Summary
We won't try building ACLK if the cloud is disabled in `config.h`

Fixes #13655

##### Test Plan
Netdata should be build with the following commands
```
$ autoreconf -ivf
$ ./configure --disable-cloud
$ mkdir cmake-build-debug; cd cmake-build-debug
$ cmake -DCMAKE_BUILD_TYPE="Debug" -DUNIT_TESTING=ON ..
$ make
```