### PR TITLE
Use mmap if possible during startup for journal replay

### DIFF
--- a/database/engine/journalfile.h
+++ b/database/engine/journalfile.h
@@ -19,7 +19,7 @@ struct rrdengine_journalfile;
 struct rrdengine_journalfile {
     uv_file file;
     uint64_t pos;
-
+    void *data;
     struct rrdengine_datafile *datafile;
 };
 


### PR DESCRIPTION
##### Summary
During agent startup if configured in with dbengine it will do a journal replay. This PR will allow the agent to mmap the journal files and replay the transactions instead of calling uv_fs_read. 

##### Test Plan
- Agent should start as usual. It will report if journal replay was done using mmap or uv_fs_read
