### PR TITLE
Add sqlite page cache hit and miss statistics

### DIFF
--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -137,9 +137,9 @@ static inline void global_statistics_copy(struct global_statistics *gs, uint8_t 
     gs->sqlite3_queries_failed_locked = __atomic_load_n(&global_statistics.sqlite3_queries_failed_locked, __ATOMIC_RELAXED);
     gs->sqlite3_rows                  = __atomic_load_n(&global_statistics.sqlite3_rows, __ATOMIC_RELAXED);
 
-    gs->sqlite3_cache_hit = (uint64_t) sql_metadata_cache_stats(SQLITE_DBSTATUS_CACHE_HIT);
+    gs->sqlite3_cache_hit = (uint64_t) sql_context_cache_stats(SQLITE_DBSTATUS_CACHE_HIT);
     gs->sqlite3_cache_hit += (uint64_t) sql_metadata_cache_stats(SQLITE_DBSTATUS_CACHE_HIT);
-    gs->sqlite3_cache_miss = (uint64_t) sql_metadata_cache_stats(SQLITE_DBSTATUS_CACHE_MISS);
+    gs->sqlite3_cache_miss = (uint64_t) sql_context_cache_stats(SQLITE_DBSTATUS_CACHE_MISS);
     gs->sqlite3_cache_miss += (uint64_t) sql_metadata_cache_stats(SQLITE_DBSTATUS_CACHE_MISS);
 }
 

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -38,6 +38,8 @@ static struct global_statistics {
     volatile uint64_t sqlite3_queries_failed_busy;
     volatile uint64_t sqlite3_queries_failed_locked;
     volatile uint64_t sqlite3_rows;
+    volatile uint64_t sqlite3_cache_hit;
+    volatile uint64_t sqlite3_cache_miss;
 
 } global_statistics = {
         .connected_clients = 0,
@@ -134,6 +136,11 @@ static inline void global_statistics_copy(struct global_statistics *gs, uint8_t 
     gs->sqlite3_queries_failed_busy   = __atomic_load_n(&global_statistics.sqlite3_queries_failed_busy, __ATOMIC_RELAXED);
     gs->sqlite3_queries_failed_locked = __atomic_load_n(&global_statistics.sqlite3_queries_failed_locked, __ATOMIC_RELAXED);
     gs->sqlite3_rows                  = __atomic_load_n(&global_statistics.sqlite3_rows, __ATOMIC_RELAXED);
+
+    gs->sqlite3_cache_hit = (uint64_t) sql_metadata_cache_stats(SQLITE_DBSTATUS_CACHE_HIT);
+    gs->sqlite3_cache_hit += (uint64_t) sql_metadata_cache_stats(SQLITE_DBSTATUS_CACHE_HIT);
+    gs->sqlite3_cache_miss = (uint64_t) sql_metadata_cache_stats(SQLITE_DBSTATUS_CACHE_MISS);
+    gs->sqlite3_cache_miss += (uint64_t) sql_metadata_cache_stats(SQLITE_DBSTATUS_CACHE_MISS);
 }
 
 static void global_statistics_charts(void) {
@@ -579,6 +586,39 @@ static void global_statistics_charts(void) {
         rrddim_set_by_pointer(st_sqlite3_rows, rd_rows, (collected_number)gs.sqlite3_rows);
 
         rrdset_done(st_sqlite3_rows);
+    }
+
+    if(gs.sqlite3_cache_hit) {
+        static RRDSET *st_sqlite3_cache = NULL;
+        static RRDDIM *rd_cache_hit = NULL;
+        static RRDDIM *rd_cache_miss= NULL;
+
+        if (unlikely(!st_sqlite3_cache)) {
+            st_sqlite3_cache = rrdset_create_localhost(
+                "netdata"
+                , "sqlite3_cache"
+                , NULL
+                , "sqlite3"
+                , NULL
+                , "Netdata SQLite3 Cache"
+                , "ops/s"
+                , "netdata"
+                , "stats"
+                , 131103
+                , localhost->rrd_update_every
+                , RRDSET_TYPE_LINE
+            );
+
+            rd_cache_hit = rrddim_add(st_sqlite3_cache, "cache_hit", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+            rd_cache_miss = rrddim_add(st_sqlite3_cache, "cache_miss", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        }
+        else
+            rrdset_next(st_sqlite3_cache);
+
+        rrddim_set_by_pointer(st_sqlite3_cache, rd_cache_hit, (collected_number)gs.sqlite3_cache_hit);
+        rrddim_set_by_pointer(st_sqlite3_cache, rd_cache_miss, (collected_number)gs.sqlite3_cache_miss);
+
+        rrdset_done(st_sqlite3_cache);
     }
 
     // ----------------------------------------------------------------

--- a/database/sqlite/sqlite_context.c
+++ b/database/sqlite/sqlite_context.c
@@ -444,6 +444,13 @@ skip_delete:
     return (rc_stored != SQLITE_DONE);
 }
 
+int sql_context_cache_stats(int op)
+{
+    int count, dummy;
+    sqlite3_db_status(db_context_meta, op, &count, &dummy, 0);
+    return count;
+}
+
 //
 // TESTING FUNCTIONS
 //

--- a/database/sqlite/sqlite_context.h
+++ b/database/sqlite/sqlite_context.h
@@ -6,6 +6,7 @@
 #include "daemon/common.h"
 #include "sqlite3.h"
 
+extern int sql_context_cache_stats(int op);
 typedef struct ctx_chart {
     uuid_t chart_id;
     const char *id;

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -2760,3 +2760,10 @@ int bind_text_null(sqlite3_stmt *res, int position, const char *text, bool can_b
         return 1;
     return sqlite3_bind_null(res, position);
 }
+
+int sql_metadata_cache_stats(int op);
+{
+    int count, dummy;
+    sqlite3_db_status(db_meta, op, &count, &dummy, 0);
+    return count;
+}

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -2761,7 +2761,7 @@ int bind_text_null(sqlite3_stmt *res, int position, const char *text, bool can_b
     return sqlite3_bind_null(res, position);
 }
 
-int sql_metadata_cache_stats(int op);
+int sql_metadata_cache_stats(int op)
 {
     int count, dummy;
     sqlite3_db_status(db_meta, op, &count, &dummy, 0);

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -121,5 +121,6 @@ void migrate_localhost(uuid_t *host_uuid);
 extern void sql_store_host_system_info(uuid_t *host_id, const struct rrdhost_system_info *system_info);
 extern void sql_build_host_system_info(uuid_t *host_id, struct rrdhost_system_info *system_info);
 void sql_store_host_labels(RRDHOST *host);
+extern int sql_metadata_cache_stats(int op);
 DICTIONARY *sql_load_host_labels(uuid_t *host_id);
 #endif //NETDATA_SQLITE_FUNCTIONS_H


### PR DESCRIPTION
##### Summary
Adds page cache hit / miss statistics for sqlite (under netdata moniting / sqlite3)

##### Test Plan
- Check that the new statistics chart appears
