### PR TITLE
Additional sqlite statistics

### DIFF
--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -137,9 +137,9 @@ static inline void global_statistics_copy(struct global_statistics *gs, uint8_t 
     gs->sqlite3_queries_failed_locked = __atomic_load_n(&global_statistics.sqlite3_queries_failed_locked, __ATOMIC_RELAXED);
     gs->sqlite3_rows                  = __atomic_load_n(&global_statistics.sqlite3_rows, __ATOMIC_RELAXED);
 
-    gs->sqlite3_cache_hit = (uint64_t) sql_metadata_cache_stats(SQLITE_DBSTATUS_CACHE_HIT);
+    gs->sqlite3_cache_hit = (uint64_t) sql_context_cache_stats(SQLITE_DBSTATUS_CACHE_HIT);
     gs->sqlite3_cache_hit += (uint64_t) sql_metadata_cache_stats(SQLITE_DBSTATUS_CACHE_HIT);
-    gs->sqlite3_cache_miss = (uint64_t) sql_metadata_cache_stats(SQLITE_DBSTATUS_CACHE_MISS);
+    gs->sqlite3_cache_miss = (uint64_t) sql_context_cache_stats(SQLITE_DBSTATUS_CACHE_MISS);
     gs->sqlite3_cache_miss += (uint64_t) sql_metadata_cache_stats(SQLITE_DBSTATUS_CACHE_MISS);
 }
 

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -137,9 +137,9 @@ static inline void global_statistics_copy(struct global_statistics *gs, uint8_t 
     gs->sqlite3_queries_failed_locked = __atomic_load_n(&global_statistics.sqlite3_queries_failed_locked, __ATOMIC_RELAXED);
     gs->sqlite3_rows                  = __atomic_load_n(&global_statistics.sqlite3_rows, __ATOMIC_RELAXED);
 
-    gs->sqlite3_cache_hit = (uint64_t) sql_context_cache_stats(SQLITE_DBSTATUS_CACHE_HIT);
+    gs->sqlite3_cache_hit = (uint64_t) sql_metadata_cache_stats(SQLITE_DBSTATUS_CACHE_HIT);
     gs->sqlite3_cache_hit += (uint64_t) sql_metadata_cache_stats(SQLITE_DBSTATUS_CACHE_HIT);
-    gs->sqlite3_cache_miss = (uint64_t) sql_context_cache_stats(SQLITE_DBSTATUS_CACHE_MISS);
+    gs->sqlite3_cache_miss = (uint64_t) sql_metadata_cache_stats(SQLITE_DBSTATUS_CACHE_MISS);
     gs->sqlite3_cache_miss += (uint64_t) sql_metadata_cache_stats(SQLITE_DBSTATUS_CACHE_MISS);
 }
 


### PR DESCRIPTION
##### Summary
- Split statistics for metadata and context databases
- Add statistics for cache writes and cache spills

So now we have the following (descriptions from the sqlite documentation)
```
SQLITE_DBSTATUS_CACHE_HIT (cache hits)
Number of pager cache hits that have occurred. 

SQLITE_DBSTATUS_CACHE_MISS (cache miss)
Number of pager cache misses that have occurred.

SQLITE_DBSTATUS_CACHE_WRITE (cache writes)
Number of dirty cache entries that have been written to disk. Specifically, the number of pages written to the wal file in wal mode databases, or the number of pages written to the database file in rollback mode databases. Any pages written as part of transaction rollback or database recovery operations are not included. 

SQLITE_DBSTATUS_CACHE_SPILL (cache spills)
Number of dirty cache entries that have been written to disk in the middle of a transaction due to the page cache overflowing. Transactions are more efficient if they are written to disk all at once. When pages spill mid-transaction, that introduces additional overhead. This parameter can be used help identify inefficiencies that can be resolved by increasing the cache size
```

##### Test Plan
- Check the two new charts each having two additional dimensions