### PR TITLE
add proxysql dashboard info

### DIFF
--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -345,6 +345,12 @@ netdataDashboard.menu = {
         info: 'Performance metrics for <b>PostgreSQL</b>, the open source object-relational database management system (ORDBMS).'
     },
 
+    'proxysql': {
+        title: 'ProxySQL',
+        icon: '<i class="fas fa-database"></i>',
+        info: 'Performance metrics for <b>ProxySQL</b>, a high-performance open-source MySQL proxy.'
+    },
+
     'pgbouncer': {
         title: 'PgBouncer',
         icon: '<i class="fas fa-exchange-alt"></i>',


### PR DESCRIPTION
##### Summary

Recently [merged go version](https://github.com/netdata/go.d.plugin/pull/703) and noticed we have no icon for ProxySQL collector.

##### Test Plan

Copy the changed file, and check the dashboard.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
