### PR TITLE
remove _instance_family label

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -472,7 +472,6 @@ static inline void rrdset_update_permanent_labels(RRDSET *st) {
 
     rrdlabels_add(st->rrdlabels, "_collect_plugin", rrdset_plugin_name(st), RRDLABEL_SRC_AUTO| RRDLABEL_FLAG_PERMANENT);
     rrdlabels_add(st->rrdlabels, "_collect_module", rrdset_module_name(st), RRDLABEL_SRC_AUTO| RRDLABEL_FLAG_PERMANENT);
-    rrdlabels_add(st->rrdlabels, "_instance_family",rrdset_family(st),      RRDLABEL_SRC_AUTO| RRDLABEL_FLAG_PERMANENT);
 }
 
 RRDSET *rrdset_create_custom(


### PR DESCRIPTION
##### Summary

The label is senseless in 99% of the cases and was added mainly for network interfaces, disks, and mount points (cases where "family" is an instance). Not needed anymore because instance labels (device for network interfaces and disks, mount_point for mountpoints) were added.

##### Test Plan

ci

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
