### PR TITLE
Fix warnings during compilation time on ARM (32 bits)

### DIFF
--- a/cli/cli.c
+++ b/cli/cli.c
@@ -78,7 +78,7 @@ static void pipe_read_cb(uv_stream_t *client, ssize_t nread, const uv_buf_t *buf
     } else if (nread) {
         size_t to_copy;
 
-        to_copy = MIN(nread, MAX_COMMAND_LENGTH - 1 - response_string_size);
+        to_copy = MIN((unsigned int) nread, MAX_COMMAND_LENGTH - 1 - response_string_size);
         memcpy(response_string + response_string_size, buf->base, to_copy);
         response_string_size += to_copy;
         response_string[response_string_size] = '\0';

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -79,7 +79,7 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
     static RRDSET **st_nodezonetype = NULL;
 
     // Local temp variables
-    size_t l, o, p;
+    long unsigned int l, o, p;
     struct pageline *pgl = NULL;
 
     // --------------------------------------------------------------------
@@ -149,7 +149,8 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
         pageorders_cnt -= 9;
 
         if (pageorders_cnt > MAX_PAGETYPE_ORDER) {
-            error("PLUGIN: PROC_PAGETYPEINFO: pageorder found (%lu) is higher than max %d", pageorders_cnt, MAX_PAGETYPE_ORDER);
+            error("PLUGIN: PROC_PAGETYPEINFO: pageorder found (%lu) is higher than max %d",
+                  (long unsigned int) pageorders_cnt, MAX_PAGETYPE_ORDER);
             return 1;
         }
 
@@ -157,7 +158,8 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
         if (!pagelines) {
             pagelines = callocz(pagelines_cnt, sizeof(struct pageline));
             if (!pagelines) {
-                error("PLUGIN: PROC_PAGETYPEINFO: Cannot allocate %lu pagelines of %lu B", pagelines_cnt, sizeof(struct pageline));
+                error("PLUGIN: PROC_PAGETYPEINFO: Cannot allocate %lu pagelines of %lu B",
+                      (long unsigned int) pagelines_cnt, (long unsigned int) sizeof(struct pageline));
                 return 1;
             }
         }
@@ -289,7 +291,8 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
         size_t words = procfile_linewords(ff, l);
 
         if (words != 7+pageorders_cnt) {
-            error("PLUGIN: PROC_PAGETYPEINFO: Unable to read line %lu, %lu words found instead of %lu", l+1, words, 7+pageorders_cnt);
+            error("PLUGIN: PROC_PAGETYPEINFO: Unable to read line %lu, %lu words found instead of %lu",
+                  l+1, (long unsigned int) words, (long unsigned int) 7+pageorders_cnt);
             break;
         }
 

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -515,7 +515,7 @@ static void pipe_read_cb(uv_stream_t *client, ssize_t nread, const uv_buf_t *buf
     } else if (nread) {
         size_t to_copy;
 
-        to_copy = MIN(nread, MAX_COMMAND_LENGTH - 1 - cmd_ctx->command_string_size);
+        to_copy = MIN((size_t) nread, MAX_COMMAND_LENGTH - 1 - cmd_ctx->command_string_size);
         memcpy(cmd_ctx->command_string + cmd_ctx->command_string_size, buf->base, to_copy);
         cmd_ctx->command_string_size += to_copy;
         cmd_ctx->command_string[cmd_ctx->command_string_size] = '\0';

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1636,28 +1636,28 @@ int unit_test_bitmap256(void) {
     if (test_bitmap.data[0] == 0xffffffffffffffff)
         fprintf(stderr, "%s() INDEX 0 is fully set OK\n", __FUNCTION__);
     else {
-        fprintf(stderr, "%s() INDEX 0 is %lx expected 0xffffffffffffffff\n", __FUNCTION__, (long unsigned int) test_bitmap.data[0]);
+        fprintf(stderr, "%s() INDEX 0 is %"PRIu64" expected 0xffffffffffffffff\n", __FUNCTION__, test_bitmap.data[0]);
         return 1;
     }
 
     if (test_bitmap.data[1] == 0xffffffffffffffff)
         fprintf(stderr, "%s() INDEX 1 is fully set OK\n", __FUNCTION__);
     else {
-        fprintf(stderr, "%s() INDEX 1 is %lx expected 0xffffffffffffffff\n", __FUNCTION__, (long unsigned int) test_bitmap.data[0]);
+        fprintf(stderr, "%s() INDEX 1 is %"PRIu64" expected 0xffffffffffffffff\n", __FUNCTION__, test_bitmap.data[0]);
         return 1;
     }
 
     if (test_bitmap.data[2] == 0xffffffffffffffff)
         fprintf(stderr, "%s() INDEX 2 is fully set OK\n", __FUNCTION__);
     else {
-        fprintf(stderr, "%s() INDEX 2 is %lx expected 0xffffffffffffffff\n", __FUNCTION__, (long unsigned int) test_bitmap.data[0]);
+        fprintf(stderr, "%s() INDEX 2 is %"PRIu64" expected 0xffffffffffffffff\n", __FUNCTION__, test_bitmap.data[0]);
         return 1;
     }
 
     if (test_bitmap.data[3] == 0xffffffffffffffff)
         fprintf(stderr, "%s() INDEX 3 is fully set OK\n", __FUNCTION__);
     else {
-        fprintf(stderr, "%s() INDEX 3 is %lx expected 0xffffffffffffffff\n", __FUNCTION__, (long unsigned int) test_bitmap.data[0]);
+        fprintf(stderr, "%s() INDEX 3 is %"PRIu64" expected 0xffffffffffffffff\n", __FUNCTION__, test_bitmap.data[0]);
         return 1;
     }
 
@@ -1706,28 +1706,28 @@ int unit_test_bitmap256(void) {
     if (test_bitmap.data[0] == 0x1111111111111111)
         fprintf(stderr, "%s() INDEX 0 is 0x1111111111111111 set OK\n", __FUNCTION__);
     else {
-        fprintf(stderr, "%s() INDEX 0 is %lx expected 0x1111111111111111\n", __FUNCTION__, (long unsigned int) test_bitmap.data[0]);
+        fprintf(stderr, "%s() INDEX 0 is %"PRIu64" expected 0x1111111111111111\n", __FUNCTION__, test_bitmap.data[0]);
         return 1;
     }
 
     if (test_bitmap.data[1] == 0x1111111111111111)
         fprintf(stderr, "%s() INDEX 1 is 0x1111111111111111 set OK\n", __FUNCTION__);
     else {
-        fprintf(stderr, "%s() INDEX 1 is %lx expected 0x1111111111111111\n", __FUNCTION__, (long unsigned int) test_bitmap.data[1]);
+        fprintf(stderr, "%s() INDEX 1 is %"PRIu64" expected 0x1111111111111111\n", __FUNCTION__, test_bitmap.data[1]);
         return 1;
     }
 
     if (test_bitmap.data[2] == 0x1111111111111111)
         fprintf(stderr, "%s() INDEX 2 is 0x1111111111111111 set OK\n", __FUNCTION__);
     else {
-        fprintf(stderr, "%s() INDEX 2 is %lx expected 0x1111111111111111\n", __FUNCTION__, (long unsigned int) test_bitmap.data[2]);
+        fprintf(stderr, "%s() INDEX 2 is %"PRIu64" expected 0x1111111111111111\n", __FUNCTION__, test_bitmap.data[2]);
         return 1;
     }
 
     if (test_bitmap.data[3] == 0x1111111111111111)
         fprintf(stderr, "%s() INDEX 3 is 0x1111111111111111 set OK\n", __FUNCTION__);
     else {
-        fprintf(stderr, "%s() INDEX 3 is %lx expected 0x1111111111111111\n", __FUNCTION__, (long unsigned int) test_bitmap.data[3]);
+        fprintf(stderr, "%s() INDEX 3 is %"PRIu64" expected 0x1111111111111111\n", __FUNCTION__, test_bitmap.data[3]);
         return 1;
     }
 

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1636,28 +1636,28 @@ int unit_test_bitmap256(void) {
     if (test_bitmap.data[0] == 0xffffffffffffffff)
         fprintf(stderr, "%s() INDEX 0 is fully set OK\n", __FUNCTION__);
     else {
-        fprintf(stderr, "%s() INDEX 0 is %lx expected 0xffffffffffffffff\n", __FUNCTION__, test_bitmap.data[0]);
+        fprintf(stderr, "%s() INDEX 0 is %lx expected 0xffffffffffffffff\n", __FUNCTION__, (long unsigned int) test_bitmap.data[0]);
         return 1;
     }
 
     if (test_bitmap.data[1] == 0xffffffffffffffff)
         fprintf(stderr, "%s() INDEX 1 is fully set OK\n", __FUNCTION__);
     else {
-        fprintf(stderr, "%s() INDEX 1 is %lx expected 0xffffffffffffffff\n", __FUNCTION__, test_bitmap.data[0]);
+        fprintf(stderr, "%s() INDEX 1 is %lx expected 0xffffffffffffffff\n", __FUNCTION__, (long unsigned int) test_bitmap.data[0]);
         return 1;
     }
 
     if (test_bitmap.data[2] == 0xffffffffffffffff)
         fprintf(stderr, "%s() INDEX 2 is fully set OK\n", __FUNCTION__);
     else {
-        fprintf(stderr, "%s() INDEX 2 is %lx expected 0xffffffffffffffff\n", __FUNCTION__, test_bitmap.data[0]);
+        fprintf(stderr, "%s() INDEX 2 is %lx expected 0xffffffffffffffff\n", __FUNCTION__, (long unsigned int) test_bitmap.data[0]);
         return 1;
     }
 
     if (test_bitmap.data[3] == 0xffffffffffffffff)
         fprintf(stderr, "%s() INDEX 3 is fully set OK\n", __FUNCTION__);
     else {
-        fprintf(stderr, "%s() INDEX 3 is %lx expected 0xffffffffffffffff\n", __FUNCTION__, test_bitmap.data[0]);
+        fprintf(stderr, "%s() INDEX 3 is %lx expected 0xffffffffffffffff\n", __FUNCTION__, (long unsigned int) test_bitmap.data[0]);
         return 1;
     }
 
@@ -1706,28 +1706,28 @@ int unit_test_bitmap256(void) {
     if (test_bitmap.data[0] == 0x1111111111111111)
         fprintf(stderr, "%s() INDEX 0 is 0x1111111111111111 set OK\n", __FUNCTION__);
     else {
-        fprintf(stderr, "%s() INDEX 0 is %lx expected 0x1111111111111111\n", __FUNCTION__, test_bitmap.data[0]);
+        fprintf(stderr, "%s() INDEX 0 is %lx expected 0x1111111111111111\n", __FUNCTION__, (long unsigned int) test_bitmap.data[0]);
         return 1;
     }
 
     if (test_bitmap.data[1] == 0x1111111111111111)
         fprintf(stderr, "%s() INDEX 1 is 0x1111111111111111 set OK\n", __FUNCTION__);
     else {
-        fprintf(stderr, "%s() INDEX 1 is %lx expected 0x1111111111111111\n", __FUNCTION__, test_bitmap.data[1]);
+        fprintf(stderr, "%s() INDEX 1 is %lx expected 0x1111111111111111\n", __FUNCTION__, (long unsigned int) test_bitmap.data[1]);
         return 1;
     }
 
     if (test_bitmap.data[2] == 0x1111111111111111)
         fprintf(stderr, "%s() INDEX 2 is 0x1111111111111111 set OK\n", __FUNCTION__);
     else {
-        fprintf(stderr, "%s() INDEX 2 is %lx expected 0x1111111111111111\n", __FUNCTION__, test_bitmap.data[2]);
+        fprintf(stderr, "%s() INDEX 2 is %lx expected 0x1111111111111111\n", __FUNCTION__, (long unsigned int) test_bitmap.data[2]);
         return 1;
     }
 
     if (test_bitmap.data[3] == 0x1111111111111111)
         fprintf(stderr, "%s() INDEX 3 is 0x1111111111111111 set OK\n", __FUNCTION__);
     else {
-        fprintf(stderr, "%s() INDEX 3 is %lx expected 0x1111111111111111\n", __FUNCTION__, test_bitmap.data[3]);
+        fprintf(stderr, "%s() INDEX 3 is %lx expected 0x1111111111111111\n", __FUNCTION__, (long unsigned int) test_bitmap.data[3]);
         return 1;
     }
 

--- a/database/engine/journalfile.c
+++ b/database/engine/journalfile.c
@@ -315,14 +315,14 @@ static void restore_extent_metadata(struct rrdengine_instance *ctx, struct rrden
         uint64_t end_time = jf_metric_data->descr[i].end_time;
 
         if (unlikely(start_time > end_time)) {
-            error("Invalid page encountered, start time %lu > end time %lu", (long unsigned int) start_time , (long unsigned int) end_time );
+            error("Invalid page encountered, start time %"PRIu64" > end time %"PRIu64"", start_time , end_time);
             continue;
         }
 
         if (unlikely(start_time == end_time)) {
             size_t entries = jf_metric_data->descr[i].page_length / page_type_size[page_type];
             if (unlikely(entries > 1)) {
-                error("Invalid page encountered, start time %lu = end time but %zu entries were found", (long unsigned int) start_time, entries);
+                error("Invalid page encountered, start time %"PRIu64" = end time but %zu entries were found", start_time, entries);
                 continue;
             }
         }

--- a/database/engine/journalfile.c
+++ b/database/engine/journalfile.c
@@ -315,14 +315,14 @@ static void restore_extent_metadata(struct rrdengine_instance *ctx, struct rrden
         uint64_t end_time = jf_metric_data->descr[i].end_time;
 
         if (unlikely(start_time > end_time)) {
-            error("Invalid page encountered, start time %lu > end time %lu", start_time , end_time );
+            error("Invalid page encountered, start time %lu > end time %lu", (long unsigned int) start_time , (long unsigned int) end_time );
             continue;
         }
 
         if (unlikely(start_time == end_time)) {
             size_t entries = jf_metric_data->descr[i].page_length / page_type_size[page_type];
             if (unlikely(entries > 1)) {
-                error("Invalid page encountered, start time %lu = end time but %zu entries were found", start_time, entries);
+                error("Invalid page encountered, start time %lu = end time but %zu entries were found", (long unsigned int) start_time, entries);
                 continue;
             }
         }

--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -857,7 +857,7 @@ static void rrdinstance_trigger_updates(RRDINSTANCE *ri, const char *function) {
     RRDSET *st = ri->rrdset;
 
     if(likely(st)) {
-        if(unlikely(st->priority != ri->priority)) {
+        if(unlikely((unsigned int) st->priority != ri->priority)) {
             ri->priority = st->priority;
             rrd_flag_set_updated(ri, RRD_FLAG_UPDATE_REASON_CHANGED_PRIORITY);
         }

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -700,7 +700,7 @@ bool rrddim_memory_load_or_create_map_save(RRDSET *st, RRDDIM *rd, RRD_MEMORY_MO
         reset = 1;
     }
     else if(rd_on_file->memsize != size) {
-        error("File %s does not have the desired size, expected %lu but found %lu. Clearing it.", fullfilename, size, rd_on_file->memsize);
+        error("File %s does not have the desired size, expected %lu but found %lu. Clearing it.", fullfilename, size, (unsigned long int) rd_on_file->memsize);
         memset(rd_on_file, 0, size);
         reset = 1;
     }

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -558,7 +558,7 @@ void aclk_database_worker(void *arg)
 //    wc->retry_count = 0;
     wc->node_info_send = 1;
 //    aclk_add_worker_thread(wc);
-    info("Starting ACLK sync thread for host %s -- scratch area %lu bytes", wc->host_guid, sizeof(*wc));
+    info("Starting ACLK sync thread for host %s -- scratch area %lu bytes", wc->host_guid, (unsigned long int) sizeof(*wc));
 
     memset(&cmd, 0, sizeof(cmd));
 #ifdef ENABLE_ACLK

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -877,7 +877,7 @@ static int have_recent_alarm(RRDHOST *host, uint32_t alarm_id, time_t mark)
     ALARM_ENTRY *ae = host->health_log.alarms;
 
     while (ae) {
-        if (ae->alarm_id == alarm_id && ae->unique_id > mark &&
+        if (ae->alarm_id == alarm_id && ae->unique_id > (uint32_t)mark &&
             (ae->new_status != RRDCALC_STATUS_WARNING && ae->new_status != RRDCALC_STATUS_CRITICAL))
             return 1;
         ae = ae->next;

--- a/database/sqlite/sqlite_aclk_chart.c
+++ b/database/sqlite/sqlite_aclk_chart.c
@@ -928,7 +928,7 @@ void aclk_update_retention(struct aclk_database_worker_config *wc)
             start_time = MIN(start_time, first_entry_t);
 
         if (memory_mode == RRD_MEMORY_MODE_DBENGINE && wc->chart_updates && (dimension_update_count < ACLK_MAX_DIMENSION_CLEANUP)) {
-            int live = ((now - last_entry_t) < (RRDSET_MINIMUM_DIM_LIVE_MULTIPLIER * update_every));
+            int live = ((uint32_t)(now - last_entry_t) < (RRDSET_MINIMUM_DIM_LIVE_MULTIPLIER * update_every));
             if (rc) {
                 first_entry_t = 0;
                 last_entry_t = 0;

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -381,7 +381,7 @@ void sql_health_alarm_log_cleanup(RRDHOST *host) {
     char uuid_str[GUID_LEN + 1];
     uuid_unparse_lower_fix(&host->host_uuid, uuid_str);
 
-    snprintfz(command, MAX_HEALTH_SQL_SIZE, SQL_CLEANUP_HEALTH_LOG(uuid_str, uuid_str, host->health_log_entries_written - rotate_every));
+    snprintfz(command, MAX_HEALTH_SQL_SIZE, SQL_CLEANUP_HEALTH_LOG(uuid_str, uuid_str, (unsigned long int) (host->health_log_entries_written - rotate_every)));
 
     rc = sqlite3_prepare_v2(db_meta, command, -1, &res, 0);
     if (unlikely(rc != SQLITE_OK)) {
@@ -436,7 +436,7 @@ void sql_health_alarm_log_count(RRDHOST *host) {
     if (unlikely(rc != SQLITE_OK))
         error_report("Failed to finalize the prepared statement to count health log entries from db");
 
-    info("HEALTH [%s]: Table health_log_%s, contains %lu entries.", rrdhost_hostname(host), uuid_str, host->health_log_entries_written);
+    info("HEALTH [%s]: Table health_log_%s, contains %lu entries.", rrdhost_hostname(host), uuid_str, (unsigned long int) host->health_log_entries_written);
 }
 
 #define SQL_INJECT_REMOVED(guid, guid2) "insert into health_log_%s (hostname, unique_id, alarm_id, alarm_event_id, config_hash_id, updated_by_id, updates_id, when_key, duration, non_clear_duration, flags, exec_run_timestamp, " \

--- a/exporting/graphite/graphite.c
+++ b/exporting/graphite/graphite.c
@@ -214,7 +214,7 @@ void graphite_http_prepare_header(struct instance *instance)
         "\r\n",
         instance->config.destination,
         simple_connector_data->auth_string ? simple_connector_data->auth_string : "",
-        buffer_strlen(simple_connector_data->last_buffer->buffer));
+        (unsigned long int) buffer_strlen(simple_connector_data->last_buffer->buffer));
 
     return;
 }

--- a/exporting/json/json.c
+++ b/exporting/json/json.c
@@ -344,7 +344,7 @@ void json_http_prepare_header(struct instance *instance)
         "\r\n",
         instance->config.destination,
         simple_connector_data->auth_string ? simple_connector_data->auth_string : "",
-        buffer_strlen(simple_connector_data->last_buffer->buffer));
+        (unsigned long int) buffer_strlen(simple_connector_data->last_buffer->buffer));
 
     return;
 }

--- a/exporting/opentsdb/opentsdb.c
+++ b/exporting/opentsdb/opentsdb.c
@@ -268,7 +268,7 @@ void opentsdb_http_prepare_header(struct instance *instance)
         "\r\n",
         instance->config.destination,
         simple_connector_data->auth_string ? simple_connector_data->auth_string : "",
-        buffer_strlen(simple_connector_data->last_buffer->buffer));
+        (unsigned long int) buffer_strlen(simple_connector_data->last_buffer->buffer));
 
     return;
 }

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -402,7 +402,7 @@ static int have_recent_alarm(RRDHOST *host, uint32_t alarm_id, time_t mark)
     ALARM_ENTRY *ae = host->health_log.alarms;
 
     while(ae) {
-        if (ae->alarm_id == alarm_id && ae->unique_id > mark &&
+        if (ae->alarm_id == alarm_id && ae->unique_id > (unsigned int) mark &&
             (ae->new_status != RRDCALC_STATUS_WARNING && ae->new_status != RRDCALC_STATUS_CRITICAL))
             return 1;
         ae = ae->next;

--- a/libnetdata/dictionary/dictionary.c
+++ b/libnetdata/dictionary/dictionary.c
@@ -1684,7 +1684,7 @@ static bool api_is_name_good_with_trace(DICTIONARY *dict __maybe_unused, const c
         function,
         name,
         strlen(name) + 1,
-        name_len,
+        (long int) name_len,
         dict?dict->creation_function:"unknown",
         dict?dict->creation_line:0,
         dict?dict->creation_file:"unknown");
@@ -1695,7 +1695,7 @@ static bool api_is_name_good_with_trace(DICTIONARY *dict __maybe_unused, const c
         function,
         name,
         strlen(name) + 1,
-        name_len,
+        (long int) name_len,
         dict?dict->creation_function:"unknown",
         dict?dict->creation_line:0,
         dict?dict->creation_file:"unknown");

--- a/libnetdata/json/json.c
+++ b/libnetdata/json/json.c
@@ -102,7 +102,7 @@ int json_callback_print(JSON_ENTRY *e)
 
         case JSON_ARRAY:
             e->callback_function = json_callback_print;
-            sprintf(txt,"ARRAY[%lu]", e->data.items);
+            sprintf(txt,"ARRAY[%lu]", (long unsigned int) e->data.items);
             buffer_strcat(wb, txt);
             break;
 

--- a/libnetdata/json/json.c
+++ b/libnetdata/json/json.c
@@ -554,3 +554,4 @@ int json_test(char *str)
     return json_parse(str, NULL, json_callback_print);
 }
  */
+

--- a/streaming/compression.c
+++ b/streaming/compression.c
@@ -67,7 +67,7 @@ static size_t lz4_compressor_compress(struct compressor_state *state, const char
         return 0;
 
     if(unlikely(size > LZ4_MAX_MSG_SIZE)) {
-        error("%s: Compression Failed - Message size %lu above compression buffer limit: %d", STREAM_COMPRESSION_MSG, size, LZ4_MAX_MSG_SIZE);
+        error("%s: Compression Failed - Message size %lu above compression buffer limit: %d", STREAM_COMPRESSION_MSG, (long unsigned int) size, LZ4_MAX_MSG_SIZE);
         return 0;
     }
 
@@ -239,7 +239,8 @@ static size_t lz4_decompressor_put(struct decompressor_state *state, const char 
 
     if (state->buffer_pos + size > state->buffer_len) {
         error("STREAM: Decompressor buffer overflow %lu + %lu > %lu",
-                    state->buffer_pos, size, state->buffer_len);
+                    (long unsigned int) state->buffer_pos, (long unsigned int) size,
+                    (long unsigned int) state->buffer_len);
         size = state->buffer_len - state->buffer_pos;
     }
     memcpy(state->buffer + state->buffer_pos, data, size);
@@ -299,7 +300,8 @@ static size_t lz4_decompressor_decompress(struct decompressor_state *state)
     (void)saving;
 
     if (old_avg_saving != avg_saving || old_avg_size != avg_size){
-        debug(D_STREAM, "%s: Saving: %lu%% (avg. %lu%%), avg.size: %lu", STREAM_COMPRESSION_MSG, saving, avg_saving, avg_size);
+        debug(D_STREAM, "%s: Saving: %lu%% (avg. %lu%%), avg.size: %lu", STREAM_COMPRESSION_MSG,
+              (long unsigned int) saving, (long unsigned int) avg_saving, (long unsigned int) avg_size);
     }
     return decompressed_size;
 }


### PR DESCRIPTION
##### Summary
Fixes #13637 

While we were developing some PRs, we brought some warnings that appear only on specific platforms. This PR is fixing issues that were appearning on `ArmVL7`. For an update report, please, take a look at  [errors](https://github.com/netdata/netdata/files/9603869/original_err.txt)

##### Test Plan
1. Compile current master branch on `Raspberry PI`, and you will see a lot of warnings.
2. Now compile this branch and verify that all warnings are gone.

##### Additional Information
In both scenarios I used the flags `CFLAGS="-Og -ggdb -Wall -Wextra -fno-omit-frame-pointer -Wformat-signedness -fstack-protector-all -Wformat-truncation=2 -Wunused-result -DNETDATA_INTERNAL_CHECKS=1 -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1"` to compile and take a look in the warnings.

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? Compilation
- Can they see the change or is it an under the hood? If they can see it, where? they cannot see.
- How is the user impacted by the change? During compilation time Netdata does not show warnings.
- What are there any benefits of the change? Less noise
</details>
