### PR TITLE
Add info for Docker containers about using hostname from host.

### DIFF
--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -252,7 +252,7 @@ If you don't want to destroy and recreate your container, you can edit the Agent
 above section on [configuring Agent containers](#configure-agent-containers) to find the appropriate method based on
 how you created the container.
 
-Alternatively to the above, you can directly use the hostname from the node running the container by mounting
+Alternatively, you can directly use the hostname from the node running the container by mounting
 `/etc/hostname` from the host in the container. With `docker run`, this can be done by adding `--volume
 /etc/hostname:/etc/hostname:ro` to the options. If you are using Docker Compose, you can add an entry to the
 container's `volumes` section reading `- /etc/hostname:/etc/hostname:ro`

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -252,6 +252,11 @@ If you don't want to destroy and recreate your container, you can edit the Agent
 above section on [configuring Agent containers](#configure-agent-containers) to find the appropriate method based on
 how you created the container.
 
+Alternatively to the above, you can directly use the hostname from the node running the container by mounting
+`/etc/hostname` from the host in the container. With `docker run`, this can be done by adding `--volume
+/etc/hostname:/etc/hostname:ro` to the options. If you are using Docker Compose, you can add an entry to the
+container's `volumes` section reading `- /etc/hostname:/etc/hostname:ro`
+
 ### Add or remove other volumes
 
 Some volumes are optional depending on how you use Netdata:

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -255,7 +255,7 @@ how you created the container.
 Alternatively, you can directly use the hostname from the node running the container by mounting
 `/etc/hostname` from the host in the container. With `docker run`, this can be done by adding `--volume
 /etc/hostname:/etc/hostname:ro` to the options. If you are using Docker Compose, you can add an entry to the
-container's `volumes` section reading `- /etc/hostname:/etc/hostname:ro`
+container's `volumes` section reading `- /etc/hostname:/etc/hostname:ro`.
 
 ### Add or remove other volumes
 


### PR DESCRIPTION
##### Summary

Inspired by discussion in https://github.com/netdata/netdata-cloud/issues/567.

We are not including this by default as it causes problems if users run multiple Netdata containers on the same node.

Directly mounting the hostname file was chosen as the suggested approach because it’s the most robust option and does not rely on using specific tools for creating or starting the container.

##### Test Plan

n/a