### PR TITLE
Fix inconsistent alert class names

### DIFF
--- a/health/health.d/go.d.plugin.conf
+++ b/health/health.d/go.d.plugin.conf
@@ -3,7 +3,7 @@
 
  template: go.d_job_last_collected_secs
        on: netdata.go_plugin_execution_time
-    class: Error
+    class: Errors
      type: Netdata
 component: go.d.plugin
    module: !* *

--- a/health/health.d/python.d.plugin.conf
+++ b/health/health.d/python.d.plugin.conf
@@ -3,7 +3,7 @@
 
  template: python.d_job_last_collected_secs
        on: netdata.pythond_runtime
-    class: Error
+    class: Errors
      type: Netdata
 component: python.d.plugin
    module: !* *

--- a/health/health.d/timex.conf
+++ b/health/health.d/timex.conf
@@ -5,7 +5,7 @@
     alarm: system_clock_sync_state
        on: system.clock_sync_state
        os: linux
-    class: Error
+    class: Errors
      type: System
 component: Clock
      calc: $state


### PR DESCRIPTION
This renames the alert classes from Error to Errors, to align with the 125 occurrences of the latter, vs. these three of the former.