### PR TITLE
alarms collector: ability to exclude certain alarms via config

### DIFF
--- a/collectors/python.d.plugin/alarms/README.md
+++ b/collectors/python.d.plugin/alarms/README.md
@@ -58,6 +58,9 @@ local:
   # a "," separated list of words you want to filter alarm names for. For example 'cpu,load' would filter for only
   # alarms with "cpu" or "load" in alarm name. Default includes all.
   alarm_contains_words: ''
+  # a "," separated list of words you want to exclude based on alarm name. For example 'cpu,load' would exclude 
+  # all alarms with "cpu" or "load" in alarm name. Default excludes None.
+  alarm_excludes_words: ''
 ```
 
 It will default to pulling all alarms at each time step from the Netdata rest api at `http://127.0.0.1:19999/api/v1/alarms?all`

--- a/collectors/python.d.plugin/alarms/alarms.chart.py
+++ b/collectors/python.d.plugin/alarms/alarms.chart.py
@@ -67,7 +67,7 @@ class Service(UrlService):
                       self.alarm_contains_words_list if alarm_contains_word in alarm_name}
         if self.alarm_excludes_words != '':
             alarms = {alarm_name: alarms[alarm_name] for alarm_name in alarms for alarm_excludes_word in
-                      self.alarm_excludes_words_list if not alarm_excludes_word in alarm_name}
+                      self.alarm_excludes_words_list if alarm_excludes_word not in alarm_name}
 
         data = {a: self.sm[alarms[a]['status']] for a in alarms if alarms[a]['status'] in self.sm}
         self.update_charts('alarms', data)

--- a/collectors/python.d.plugin/alarms/alarms.chart.py
+++ b/collectors/python.d.plugin/alarms/alarms.chart.py
@@ -39,6 +39,7 @@ DEFAULT_URL = 'http://127.0.0.1:19999/api/v1/alarms?all'
 DEFAULT_COLLECT_ALARM_VALUES = False
 DEFAULT_ALARM_STATUS_CHART_TYPE = 'line'
 DEFAULT_ALARM_CONTAINS_WORDS = ''
+DEFAULT_ALARM_EXCLUDES_WORDS = ''
 
 class Service(UrlService):
     def __init__(self, configuration=None, name=None):
@@ -51,6 +52,8 @@ class Service(UrlService):
         self.collected_dims = {'alarms': set(), 'values': set()}
         self.alarm_contains_words = self.configuration.get('alarm_contains_words', DEFAULT_ALARM_CONTAINS_WORDS)
         self.alarm_contains_words_list = [alarm_contains_word.lstrip(' ').rstrip(' ') for alarm_contains_word in self.alarm_contains_words.split(',')]
+        self.alarm_excludes_words = self.configuration.get('alarm_excludes_words', DEFAULT_ALARM_EXCLUDES_WORDS)
+        self.alarm_excludes_words_list = [alarm_excludes_word.lstrip(' ').rstrip(' ') for alarm_excludes_word in self.alarm_excludes_words.split(',')]
 
     def _get_data(self):
         raw_data = self._get_raw_data()
@@ -62,6 +65,9 @@ class Service(UrlService):
         if self.alarm_contains_words != '':
             alarms = {alarm_name: alarms[alarm_name] for alarm_name in alarms for alarm_contains_word in
                       self.alarm_contains_words_list if alarm_contains_word in alarm_name}
+        if self.alarm_excludes_words != '':
+            alarms = {alarm_name: alarms[alarm_name] for alarm_name in alarms for alarm_excludes_word in
+                      self.alarm_excludes_words_list if not alarm_excludes_word in alarm_name}
 
         data = {a: self.sm[alarms[a]['status']] for a in alarms if alarms[a]['status'] in self.sm}
         self.update_charts('alarms', data)

--- a/collectors/python.d.plugin/alarms/alarms.conf
+++ b/collectors/python.d.plugin/alarms/alarms.conf
@@ -55,3 +55,6 @@ local:
   # a "," separated list of words you want to filter alarm names for. For example 'cpu,load' would filter for only
   # alarms with "cpu" or "load" in alarm name. Default includes all.
   alarm_contains_words: ''
+  # a "," separated list of words you want to exclude based on alarm name. For example 'cpu,load' would exclude 
+  # all alarms with "cpu" or "load" in alarm name. Default excludes None.
+  alarm_excludes_words: ''


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->


Ability to define what alarms to exclude via config. Useful if you want to have one subset of alarms in one job and then "everything else" in another job for example.

##### Test Plan

Tested locally with config like this:

```
ml:
  update_every: 5
  url: 'http://127.0.0.1:19999/api/v1/alarms?all'
  status_map:
    CLEAR: 0
    WARNING: 1
    CRITICAL: 2
  collect_alarm_values: true
  alarm_status_chart_type: 'stacked'
  alarm_contains_words: 'ml_1min'

default:
  update_every: 5
  url: 'http://127.0.0.1:19999/api/v1/alarms?all'
  status_map:
    CLEAR: 0
    WARNING: 1
    CRITICAL: 2
  collect_alarm_values: true
  alarm_status_chart_type: 'stacked'
  alarm_excludes_words: 'ml_1min'
```

Works as expected: 

![image](https://user-images.githubusercontent.com/2178292/191731998-cdf77ca0-6924-442d-aa5c-f7c4b1fba48f.png)


<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
