### PR TITLE
Cleanly reimplement system/edit-config.in.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,7 +126,6 @@ system/netdata-updater.service
 !system/netdata.service.*.in
 system/netdata.plist
 system/netdata-freebsd
-system/edit-config
 system/netdata.crontab
 system/install-service.sh
 

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -49,6 +49,12 @@ if mountpoint -q /etc/netdata && [ -z "$(ls -A /etc/netdata)" ]; then
   cp -a /etc/netdata.stock/. /etc/netdata
 fi
 
+if mountpoint -q /etc/netdata; then
+  hostname > /etc/netdata/.container-hostname
+else
+  rm -f /etc/netdata/.container-hostname
+fi
+
 if [ -n "${NETDATA_CLAIM_URL}" ] && [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ ! -f /var/lib/netdata/cloud.d/claimed_id ]; then
   # shellcheck disable=SC2086
   /usr/sbin/netdata-claim.sh -token="${NETDATA_CLAIM_TOKEN}" \

--- a/system/Makefile.am
+++ b/system/Makefile.am
@@ -3,7 +3,6 @@
 
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 CLEANFILES = \
-    edit-config \
     netdata-openrc \
     netdata.logrotate \
     netdata.service \
@@ -55,7 +54,7 @@ dist_libsys_DATA = \
     $(NULL)
 
 dist_noinst_DATA = \
-    edit-config.in \
+    edit-config \
     install-service.sh.in \
     netdata-openrc.in \
     netdata.logrotate.in \

--- a/system/Makefile.am
+++ b/system/Makefile.am
@@ -54,7 +54,6 @@ dist_libsys_DATA = \
     $(NULL)
 
 dist_noinst_DATA = \
-    edit-config \
     install-service.sh.in \
     netdata-openrc.in \
     netdata.logrotate.in \

--- a/system/edit-config
+++ b/system/edit-config
@@ -8,6 +8,7 @@ set -e
 script_dir="$(CDPATH="" cd -- "$(dirname -- "$0")" && pwd -P)"
 
 usage() {
+  check_directories
   cat << EOF
 USAGE:
   ${0} [options] FILENAME

--- a/system/edit-config
+++ b/system/edit-config
@@ -97,7 +97,7 @@ check_editor() {
 running_in_container() {
   [ -e /.dockerenv ] && return 0
   [ -e /.dockerinit ] && return 0
-  [ -e /proc/1/environ ] && tr '\000' '\n' < /proc/1/environ | grep -Eiq '^container=podman' && return 0
+  [ -r /proc/1/environ ] && tr '\000' '\n' < /proc/1/environ | grep -Eiq '^container=podman' && return 0
   grep -qF -e /docker/ -e /libpod- /proc/self/cgroup 2>/dev/null && return 0
 }
 

--- a/system/edit-config
+++ b/system/edit-config
@@ -35,9 +35,9 @@ error() {
 
 abspath() {
   if [ -d "${1}" ]; then
-    echo "$(cd "${1}" && /bin/env PWD= pwd -P)/"
+    echo "$(cd "${1}" && /usr/bin/env PWD= pwd -P)/"
   else
-    echo "$(cd "$(dirname "${1}")" && /bin/env PWD= pwd -P )/$(basename "${1}")"
+    echo "$(cd "$(dirname "${1}")" && /usr/bin/env PWD= pwd -P )/$(basename "${1}")"
   fi
 }
 

--- a/system/edit-config
+++ b/system/edit-config
@@ -1,9 +1,9 @@
 #!/usr/bin/env sh
 
-set -e
-
 # shellcheck disable=SC1091
 [ -f /etc/profile ] && . /etc/profile
+
+set -e
 
 script_dir="$(CDPATH="" cd -- "$(dirname -- "$0")" && pwd -P)"
 

--- a/system/edit-config
+++ b/system/edit-config
@@ -22,6 +22,8 @@ USAGE:
   environment variable, or by using the --editor option.
 
   The file to edit can also be specified using the --file option.
+
+  For a list of known config files, run '${0} --list'
 EOF
   exit 0
 }
@@ -148,10 +150,34 @@ handle_container() {
   fi
 }
 
+list_files() {
+  check_directories
+  handle_container
+
+  if [ -z "${container}" ]; then
+    files="$(cd "${NETDATA_STOCK_CONFIG_DIR}" && find . -type f | cut -d '/' -f 2-)"
+  else
+    files="$(run_in_container "${container}" "cd /usr/lib/netdata/conf.d && find . -type f" | cut -d '/' -f 2-)"
+  fi
+
+  if [ -z "${files}" ]; then
+    error "Failed to find any configuration files."
+    exit 1
+  fi
+
+  cat << EOF
+The following configuration files are known to this script:
+
+${files}
+EOF
+  exit 0
+}
+
 parse_args() {
   while [ -n "${1}" ]; do
     case "${1}" in
       "--help") usage ;;
+      "--list") list_files ;;
       "--file")
         if [ -n "${2}" ]; then
           file="${2}"

--- a/system/edit-config
+++ b/system/edit-config
@@ -42,10 +42,8 @@ abspath() {
 }
 
 is_prefix() {
-  case "${2}" in
-    "${1}*") return 0 ;;
-    *) return 1 ;;
-  esac
+  echo "${2}" | grep -qE "^${1}"
+  return $?
 }
 
 check_directories() {

--- a/system/edit-config
+++ b/system/edit-config
@@ -275,7 +275,7 @@ copy_container() {
 }
 
 copy() {
-  if [ -f "${1}" ]; then
+  if [ -f "${NETDATA_USER_CONFIG_DIR}/${1}" ]; then
     return 0
   elif [ -n "${container}" ]; then
     copy_container "${1}"

--- a/system/edit-config
+++ b/system/edit-config
@@ -2,12 +2,10 @@
 
 set -e
 
+# shellcheck disable=SC1091
 [ -f /etc/profile ] && . /etc/profile
 
 script_dir="$(CDPATH="" cd -- "$(dirname -- "$0")" && pwd -P)"
-
-[ -z "${NETDATA_USER_CONFIG_DIR}" ] && NETDATA_USER_CONFIG_DIR="${script_dir}"
-[ -z "${NETDATA_STOCK_CONFIG_DIR}" ] && NETDATA_STOCK_CONFIG_DIR="@libconfigdir_POST@"
 
 usage() {
   cat << EOF
@@ -45,6 +43,35 @@ is_prefix() {
     "${1}*") return 0 ;;
     *) return 1 ;;
   esac
+}
+
+check_directories() {
+  if [ -e "${script_dir}/.environment" ]; then
+    OLDPATH="${PATH}"
+    # shellcheck disable=SC1091
+    . "${script_dir}/.environment"
+    PATH="${OLDPATH}"
+  fi
+
+  if [ -n "${NETDATA_PREFIX}" ] && [ -d "${NETDATA_PREFIX}/usr/lib/netdata/conf.d" ]; then
+    stock_dir="${NETDATA_PREFIX}/usr/lib/netdata/conf.d"
+  elif [ -n "${NETDATA_PREFIX}" ] && [ -d "${NETDATA_PREFIX}/lib/netdata/conf.d" ]; then
+    stock_dir="${NETDATA_PREFIX}/lib/netdata/conf.d"
+  elif [ -d "${script_dir}/../../usr/lib/netdata/conf.d" ]; then
+    stock_dir="${script_dir}/../../usr/lib/netdata/conf.d"
+  elif [ -d "${script_dir}/../../lib/netdata/conf.d" ]; then
+    stock_dir="${script_dir}/../../lib/netdata/conf.d"
+  elif [ -d "/usr/lib/netdata/conf.d" ]; then
+    stock_dir="/usr/lib/netdata/conf.d"
+  fi
+
+  [ -z "${NETDATA_USER_CONFIG_DIR}" ] && NETDATA_USER_CONFIG_DIR="${script_dir}"
+  [ -z "${NETDATA_STOCK_CONFIG_DIR}" ] && NETDATA_STOCK_CONFIG_DIR="${stock_dir}"
+
+  if [ -z "${NETDATA_STOCK_CONFIG_DIR}" ]; then
+    error "Unable to find stock config directory."
+    exit 1
+  fi
 }
 
 check_editor() {
@@ -229,6 +256,7 @@ edit() {
 
 main() {
   parse_args "${@}"
+  check_directories
   check_editor
   handle_container
   copy "${file}"

--- a/system/edit-config
+++ b/system/edit-config
@@ -276,7 +276,7 @@ edit() {
     exit 1
   fi
 
-  "${EDITOR}" "${1}"
+  "${editor}" "${1}"
   exit $?
 }
 

--- a/system/edit-config
+++ b/system/edit-config
@@ -223,6 +223,8 @@ parse_args() {
     error "${file} is not located under ${script_dir}"
     exit 1
   fi
+
+  file="${absfile##"${script_dir}"}"
 }
 
 copy_native() {
@@ -285,7 +287,7 @@ main() {
   check_editor
   handle_container
   copy "${file}"
-  edit "${file}"
+  edit "${absfile}"
 }
 
 main "${@}"

--- a/system/edit-config
+++ b/system/edit-config
@@ -153,10 +153,27 @@ list_files() {
   check_directories
   handle_container
 
+  if test -t; then
+    width="$(tput cols)"
+  fi
+
   if [ -z "${container}" ]; then
-    files="$(cd "${NETDATA_STOCK_CONFIG_DIR}" && find . -type f | cut -d '/' -f 2-)"
+    if [ "$(uname -s)" = "Linux" ]; then
+      # shellcheck disable=SC2046,SC2086
+      files="$(cd "${NETDATA_STOCK_CONFIG_DIR}" && ls ${width:+-C} ${width:+-w ${width}} $(find . -type f | cut -d '/' -f 2-))"
+    elif [ "$(uname -s)" = "FreeBSD" ]; then
+      if [ -n "${width}" ]; then
+        export COLUMNS="${width}"
+      fi
+
+      # shellcheck disable=SC2046
+      files="$(cd "${NETDATA_STOCK_CONFIG_DIR}" && ls ${width:+-C} $(find . -type f | cut -d '/' -f 2-))"
+    else
+      # shellcheck disable=SC2046
+      files="$(cd "${NETDATA_STOCK_CONFIG_DIR}" && ls $(find . -type f | cut -d '/' -f 2-))"
+    fi
   else
-    files="$(run_in_container "${container}" "cd /usr/lib/netdata/conf.d && find . -type f" | cut -d '/' -f 2-)"
+    files="$(run_in_container "${container}" "cd /usr/lib/netdata/conf.d && ls ${width:+-C} ${width:+-w ${width}} \$(find . -type f | cut -d '/' -f 2-)")"
   fi
 
   if [ -z "${files}" ]; then

--- a/system/edit-config
+++ b/system/edit-config
@@ -9,7 +9,7 @@ script_dir="$(CDPATH="" cd -- "$(dirname -- "$0")" && pwd -P)"
 
 usage() {
   check_directories
-  cat << EOF
+  cat <<EOF
 USAGE:
   ${0} [options] FILENAME
 
@@ -37,7 +37,7 @@ abspath() {
   if [ -d "${1}" ]; then
     echo "$(cd "${1}" && /usr/bin/env PWD= pwd -P)/"
   else
-    echo "$(cd "$(dirname "${1}")" && /usr/bin/env PWD= pwd -P )/$(basename "${1}")"
+    echo "$(cd "$(dirname "${1}")" && /usr/bin/env PWD= pwd -P)/$(basename "${1}")"
   fi
 }
 
@@ -96,16 +96,16 @@ check_editor() {
 running_in_container() {
   [ -e /.dockerenv ] && return 0
   [ -e /.dockerinit ] && return 0
-  [ -r /proc/1/environ ] && tr '\000' '\n' < /proc/1/environ | grep -Eiq '^container=podman' && return 0
+  [ -r /proc/1/environ ] && tr '\000' '\n' </proc/1/environ | grep -Eiq '^container=podman' && return 0
   grep -qF -e /docker/ -e /libpod- /proc/self/cgroup 2>/dev/null && return 0
 }
 
 get_docker_command() {
   if [ -x "${docker}" ]; then
     return 0
-  elif command -v docker >/dev/null 2>&1 ; then
+  elif command -v docker >/dev/null 2>&1; then
     docker="$(command -v docker)"
-  elif command -v podman >/dev/null 2>&1 ; then
+  elif command -v podman >/dev/null 2>&1; then
     docker="$(command -v podman)"
   else
     error "Unable to find a usable container tool stack. I support Docker and Podman."
@@ -131,9 +131,9 @@ handle_container() {
   elif [ -z "${container}" ] && [ -f "${script_dir}/.container-hostname" ]; then
     echo >&2 "Autodetected containerized Netdata instance. Attempting to autodetect container ID."
     possible_container="$(cat "${script_dir}/.container-hostname")"
-    if check_for_container "${possible_container}" ; then
+    if check_for_container "${possible_container}"; then
       container="${possible_container}"
-    elif check_for_container netdata ; then
+    elif check_for_container netdata; then
       container="netdata"
     else
       error "Could not autodetect container ID. It must be supplied on the command line with the --container option."
@@ -142,7 +142,7 @@ handle_container() {
 
     echo >&2 "Found Netdata container with ID or name ${container}"
   elif [ -n "${container}" ]; then
-    if ! check_for_container "${container}" ; then
+    if ! check_for_container "${container}"; then
       error "No container with ID or name ${container} exists."
       exit 1
     fi
@@ -181,7 +181,7 @@ list_files() {
     exit 1
   fi
 
-  cat << EOF
+  cat <<EOF
 The following configuration files are known to this script:
 
 ${files}
@@ -296,7 +296,6 @@ edit() {
   "${editor}" "${1}"
   exit $?
 }
-
 
 main() {
   parse_args "${@}"

--- a/system/edit-config.in
+++ b/system/edit-config.in
@@ -1,48 +1,215 @@
 #!/usr/bin/env sh
 
+set -e
+
 [ -f /etc/profile ] && . /etc/profile
 
-file="${1}"
+script_dir="$(CDPATH="" cd -- "$(dirname -- "$0")" && pwd -P)"
 
-if [ "$(command -v editor)" ]; then
-  EDITOR="${EDITOR-editor}"
-else
-  EDITOR="${EDITOR-vi}"
-fi
-
-[ -z "${NETDATA_USER_CONFIG_DIR}" ] && NETDATA_USER_CONFIG_DIR="@configdir_POST@"
+[ -z "${NETDATA_USER_CONFIG_DIR}" ] && NETDATA_USER_CONFIG_DIR="${script_dir}"
 [ -z "${NETDATA_STOCK_CONFIG_DIR}" ] && NETDATA_STOCK_CONFIG_DIR="@libconfigdir_POST@"
 
-if [ -z "${file}" ]; then
+usage() {
   cat << EOF
-
 USAGE:
-  ${0} FILENAME
+  ${0} [options] FILENAME
 
   Copy and edit the stock config file named: FILENAME
   if FILENAME is already copied, it will be edited as-is.
 
-  The EDITOR shell variable is used to define the editor to be used.
-
   Stock config files at: '${NETDATA_STOCK_CONFIG_DIR}'
   User  config files at: '${NETDATA_USER_CONFIG_DIR}'
 
-  Available files in '${NETDATA_STOCK_CONFIG_DIR}' to copy and edit:
+  The editor to use can be specified either by setting the EDITOR
+  environment variable, or by using the --editor option.
 
+  The file to edit can also be specified using the --file option.
 EOF
+  exit 0
+}
 
-  cd "${NETDATA_STOCK_CONFIG_DIR}" || exit 1
-  ls >&2 -R ./*.conf ./*/*.conf
-  exit 1
+error() {
+  echo >&2 "ERROR: ${1}"
+}
 
-fi
+abspath() {
+  if [ -d "${1}" ]; then
+    echo "$(cd "${1}" && /bin/env PWD= pwd -P)/"
+  else
+    echo "$(cd "$(dirname "${1}")" && /bin/env PWD= pwd -P )/$(basename "${1}")"
+  fi
+}
+
+is_prefix() {
+  case "${2}" in
+    "${1}*") return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+check_editor() {
+  if [ -z "${editor}" ]; then
+    if [ -n "${EDITOR}" ] && command -v "${EDITOR}" >/dev/null 2>&1; then
+      editor="${EDITOR}"
+    elif command -v editor >/dev/null 2>&1; then
+      editor="editor"
+    elif command -v vi >/dev/null 2>&1; then
+      editor="vi"
+    else
+      error "Unable to find a usable editor, tried \${EDITOR} (${EDITOR}), editor, and vi."
+      exit 1
+    fi
+  elif ! command -v "${editor}" >/dev/null 2>&1; then
+    error "Unable to locate user specified editor ${editor}, is it in your PATH?"
+    exit 1
+  fi
+}
+
+get_docker_command() {
+  if [ -x "${docker}" ]; then
+    return 0
+  elif command -v docker >/dev/null 2>&1 ; then
+    docker="$(command -v docker)"
+  elif command -v podman >/dev/null 2>&1 ; then
+    docker="$(command -v podman)"
+  else
+    error "Unable to find a usable container tool stack. I support Docker and Podman."
+    exit 1
+  fi
+}
+
+run_in_container() {
+  ${docker} exec "${1}" /bin/sh -c "${2}" || return 1
+  return 0
+}
+
+check_for_container() {
+  get_docker_command
+  ${docker} container inspect "${1}" >/dev/null 2>&1 || return 1
+  run_in_container "${1}" "[ -d \"${NETDATA_STOCK_CONFIG_DIR}\" ]" >/dev/null 2>&1 || return 1
+  return 0
+}
+
+handle_container() {
+  if [ -z "${container}" ] && [ -f "${script_dir}/.container-hostname" ] && [ ! -d "${NETDATA_STOCK_CONFIG_DIR}" ]; then
+    echo >&2 "Autodetected containerized Netdata instance. Attempting to autodetect container ID."
+    possible_container="$(cat "${script_dir}/.container-hostname")"
+    if check_for_container "${possible_container}" ; then
+      container="${possible_container}"
+    elif check_for_container netdata ; then
+      container="netdata"
+    else
+      error "Could not autodetect container ID. It must be supplied on the command line with the --container option."
+      exit 1
+    fi
+
+    echo >&2 "Found Netdata container with ID or name ${container}"
+  elif [ -n "${container}" ]; then
+    if ! check_for_container "${container}" ; then
+      error "No container with ID or name ${container} exists."
+      exit 1
+    fi
+  fi
+}
+
+parse_args() {
+  while [ -n "${1}" ]; do
+    case "${1}" in
+      "--help") usage ;;
+      "--file")
+        if [ -n "${2}" ]; then
+          file="${2}"
+          shift 1
+        else
+          error "No file specified to edit."
+          exit 1
+        fi
+        ;;
+      "--container")
+        if [ -n "${2}" ]; then
+          container="${2}"
+          shift 1
+        else
+          error "No container ID or name specified with the --container option."
+          exit 1
+        fi
+        ;;
+      "--editor")
+        if [ -n "${2}" ]; then
+          editor="${2}"
+          shift 1
+        else
+          error "No editor specified with the --editor option."
+          exit 1
+        fi
+        ;;
+      *)
+        if [ -z "${2}" ]; then
+          file="${1}"
+        else
+          error "Unrecognized option ${1}."
+          exit 1
+        fi
+        ;;
+    esac
+    shift 1
+  done
+
+  [ -z "${file}" ] && usage
+
+  absfile="$(abspath "${file}")"
+  if ! is_prefix "${script_dir}" "${absfile}"; then
+    error "${file} is not located under ${script_dir}"
+    exit 1
+  fi
+}
+
+copy_native() {
+  if [ ! -w "${NETDATA_USER_CONFIG_DIR}" ]; then
+    error "Cannot write to ${NETDATA_USER_CONFIG_DIR}!"
+    exit 1
+  fi
+
+  if [ -f "${NETDATA_STOCK_CONFIG_DIR}/${1}" ]; then
+    echo >&2 "Copying '${NETDATA_STOCK_CONFIG_DIR}/${1}' to '${NETDATA_USER_CONFIG_DIR}/${1}' ... "
+    cp -p "${NETDATA_STOCK_CONFIG_DIR}/${1}" "${NETDATA_USER_CONFIG_DIR}/${1}" || exit 1
+  else
+    echo >&2 "Creating empty '${NETDATA_USER_CONFIG_DIR}/${1}' ... "
+    touch "${NETDATA_USER_CONFIG_DIR}/${1}" || exit 1
+  fi
+}
+
+copy_container() {
+  if [ ! -w "${NETDATA_USER_CONFIG_DIR}" ]; then
+    error "Cannot write to ${NETDATA_USER_CONFIG_DIR}!"
+    exit 1
+  fi
+
+  if run_in_container "${container}" "[ -f \"${NETDATA_STOCK_CONFIG_DIR}/${1}\" ]"; then
+    echo >&2 "Copying '${NETDATA_STOCK_CONFIG_DIR}/${1}' to '${NETDATA_USER_CONFIG_DIR}/${1}' ... "
+    ${docker} cp -a "${container}:${NETDATA_STOCK_CONFIG_DIR}/${1}" "${NETDATA_USER_CONFIG_DIR}/${1}" || exit 1
+  else
+    echo >&2 "Creating empty '${NETDATA_USER_CONFIG_DIR}/${1}' ... "
+    touch "${NETDATA_USER_CONFIG_DIR}/${1}" || exit 1
+  fi
+}
+
+copy() {
+  if [ -f "${1}" ]; then
+    return 0
+  elif [ -n "${container}" ]; then
+    copy_container "${1}"
+  else
+    copy_native "${1}"
+  fi
+}
 
 edit() {
   echo >&2 "Editing '${1}' ..."
 
   # check we can edit
   if [ ! -w "${1}" ]; then
-    echo >&2 "Cannot write to ${1}! Aborting ..."
+    error "Cannot write to ${1}!"
     exit 1
   fi
 
@@ -50,34 +217,13 @@ edit() {
   exit $?
 }
 
-copy_and_edit() {
-  # check we can copy
-  if [ ! -w "${NETDATA_USER_CONFIG_DIR}" ]; then
-    echo >&2 "Cannot write to ${NETDATA_USER_CONFIG_DIR}! Aborting ..."
-    exit 1
-  fi
 
-  if [ ! -f "${NETDATA_USER_CONFIG_DIR}/${1}" ]; then
-    echo >&2 "Copying '${NETDATA_STOCK_CONFIG_DIR}/${1}' to '${NETDATA_USER_CONFIG_DIR}/${1}' ... "
-    cp -p "${NETDATA_STOCK_CONFIG_DIR}/${1}" "${NETDATA_USER_CONFIG_DIR}/${1}" || exit 1
-  fi
-
-  edit "${NETDATA_USER_CONFIG_DIR}/${1}"
+main() {
+  parse_args "${@}"
+  check_editor
+  handle_container
+  copy "${file}"
+  edit "${file}"
 }
 
-# make sure it is not absolute filename
-c1="$(echo "${file}" | cut -b 1)"
-if [ "${c1}" = "/" ] || [ "${c1}" = "." ]; then
-  echo >&2 "Please don't use filenames starting with '/' or '.'"
-  exit 1
-fi
-
-# already exists
-[ -f "${NETDATA_USER_CONFIG_DIR}/${file}" ] && edit "${NETDATA_USER_CONFIG_DIR}/${file}"
-
-# stock config is valid, copy and edit
-[ -f "${NETDATA_STOCK_CONFIG_DIR}/${file}" ] && copy_and_edit "${file}"
-
-# no such config found
-echo >&2 "File '${file}' is not found in '${NETDATA_STOCK_CONFIG_DIR}'"
-exit 1
+main "${@}"

--- a/system/edit-config.in
+++ b/system/edit-config.in
@@ -65,6 +65,13 @@ check_editor() {
   fi
 }
 
+running_in_container() {
+  [ -e /.dockerenv ] && return 0
+  [ -e /.dockerinit ] && return 0
+  [ -e /proc/1/environ ] && tr '\000' '\n' < /proc/1/environ | grep -Eiq '^container=podman' && return 0
+  grep -qF -e /docker/ -e /libpod- /proc/self/cgroup 2>/dev/null && return 0
+}
+
 get_docker_command() {
   if [ -x "${docker}" ]; then
     return 0
@@ -91,7 +98,9 @@ check_for_container() {
 }
 
 handle_container() {
-  if [ -z "${container}" ] && [ -f "${script_dir}/.container-hostname" ] && [ ! -d "${NETDATA_STOCK_CONFIG_DIR}" ]; then
+  if running_in_container; then
+    return 0
+  elif [ -z "${container}" ] && [ -f "${script_dir}/.container-hostname" ]; then
     echo >&2 "Autodetected containerized Netdata instance. Attempting to autodetect container ID."
     possible_container="$(cat "${script_dir}/.container-hostname")"
     if check_for_container "${possible_container}" ; then


### PR DESCRIPTION
##### Summary

This is a clean reimplementation of the `edit-config` script we install in the user config directory. It adds a few new features, and fixes a number of outstanding issues with the script.

Overall changes from the existing script:

- Error messages are now clearly prefixed with `ERROR:` instead of looking no different from other output from the script.
- We now have proper support for command-line arguments. In particular, `edit-config --help` now properly returns usage information instead of throwing an error. Other supported options are `--file` for explicitly specifying the file to edit (using this is not required, but we should ideally encourage it), and `--editor` to specify an editor of choice on the command-line.
- We now can handle editing configuration for a Docker container on the host side, instead of requiring it to be done in the container. This is done by copying the file out of the container itself. The script includes primitive auto-detection that should work in most common cases, but the user can also use the new `--container` option to bypass the auto-detection and explicitly specify a container ID or name to use. Supports both Docker and Podman.
- Instead of templating in the user config directory at build time, the script now uses the directory it was run from as the target for copying stock config files to. This is required for the above-mentioned Docker support, and also makes it a bit easier to test the script without having to do a full build of Netdata. Users can still override this by setting `NETDATA_USER_CONFIG_DIR` in the environment, just like with the old script.
- Similarly, instead of templating the stock config directory at build time, we now determine it at runtime by inspecting the `.environment` file created by the install, falling back first to inferring the location from the script’s path and if that fails using the ‘default’ of `/usr/lib/netdata/conf.d`. From a user perspective, this changes nothing for any type of install we officially support and for any third-party packages I know of. This results in a slight simplification of the build code, as well as making testing of the script much easier (you can now literally just copy it to the right place and it should work). Users can still override this by setting `NETDATA_STOCK_CONFIG_DIR`.
- Instead of listing all known files in the help text, we now require the user to run the script with the `--list` option. This has two specific benefits:
    - It ensures that the actual usage information won’t end up scrolled off the top of the screen by the list of known files.
    - It avoids the expensive container checks and stock config directory computation when the user just needs the help output.
- We now do a quick check of the validity of the editor (either auto-detected or user-supplied) instead of just blindly trusting that it’s usable. This should not result in any user-visible changes, but will provide a more useful error message if the user mistypes the name of their editor of choice.
- Instead of blindly excluding paths starting with `/` or `.`, we now do a proper prefix check for the supplied file path to make sure it’s under the user config directory. This provides tow specific benefits:
    - We no longer blindly copy files into directories that are not ours. For example, with the existing script, you can do `/etc/netdata/edit-config apps_groups.conf` and it will blindly copy the stock `apps_groups.conf` file to the current directory. With the new script, this will throw an error instead.
    - Invoking the script using absolute paths that point under the user config directory will work properly. In particular, this means that you do not need to be in the user config directory when invoking the script, provided you use a proper path. Running `netdata/edit-config netdata/apps_groups.conf` when in `/etc` will now work, and `/etc/netdata/edit-config /etc/netdata/apps_groups.conf` will work from anywhere on the system.
- If the requested file does not exist, and we do not provide a stock version of it, the script will now create an empty file instead of throwing an error. This is intended to allow it to behave better when dealing with configuration for third-party plugins (we may also want to define a standard location for third party plugins to store their stock configuration to improve this further, but that’s out of scope for this PR).

##### Test Plan

Testing can be done by replacing the installed copy of the edit-config script on a system with netdata installed with the one found in this PR.

If testing the Docker container handling without building a Docker image from this branch, the following command must be manually run in the container being used for testing: `echo ${HOSTNAME} > /etc/netdata/.container-hostname`. This file is used by the container auto-detection code in the script, and will normally be created by the Docker entrypoint script once this PR is merged.

##### Additional Information

Fixes: https://github.com/netdata/netdata/issues/13495

<details> <summary>For users: How does this change affect me?</summary>
The edit-config script will now work correctly when dealing with configuration for Docker containers from the Docker host. Additionally, a number of other benefits 
</details>
