### PR TITLE
Do not create train/predict dimensions meant for tracking anomaly rates.

### DIFF
--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -79,6 +79,9 @@ void ml_new_dimension(RRDDIM *RD) {
     if (simple_pattern_matches(Cfg.SP_ChartsToSkip, rrdset_name(RS)))
         return;
 
+    if (rrdset_is_ar_chart(RS))
+        return;
+
     Dimension *D = new Dimension(RD);
     RD->ml_dimension = static_cast<ml_dimension_t>(D);
     H->addDimension(D);


### PR DESCRIPTION
##### Summary

In theory, [we already cover this scenario](https://github.com/netdata/netdata/blob/06368384c10e81d15b2c5408cfeff0a29f65b47f/ml/ml.cc#L79). The new check tests if a newly created dimension belongs to the anomaly rates chart by checking directly the chart's flags.

##### Test Plan

N/A due to not being able to reproduce the bug locally.

##### Additional Information

Fixes https://github.com/netdata/netdata/issues/13694.
