### PR TITLE
Faster streaming by 25% on the child

### DIFF
--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -363,8 +363,8 @@ inline int rrddim_set_algorithm(RRDSET *st, RRDDIM *rd, RRD_ALGORITHM algorithm)
     debug(D_RRD_CALLS, "Updating algorithm of dimension '%s/%s' from %s to %s", rrdset_id(st), rrddim_name(rd), rrd_algorithm_name(rd->algorithm), rrd_algorithm_name(algorithm));
     rd->algorithm = algorithm;
     rd->exposed = 0;
-    rrdset_flag_set(st, RRDSET_FLAG_HOMOGENEOUS_CHECK);
     rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
+    rrdset_flag_set(st, RRDSET_FLAG_HOMOGENEOUS_CHECK);
     rrdcontext_updated_rrddim_algorithm(rd);
     return 1;
 }
@@ -376,8 +376,8 @@ inline int rrddim_set_multiplier(RRDSET *st, RRDDIM *rd, collected_number multip
     debug(D_RRD_CALLS, "Updating multiplier of dimension '%s/%s' from " COLLECTED_NUMBER_FORMAT " to " COLLECTED_NUMBER_FORMAT, rrdset_id(st), rrddim_name(rd), rd->multiplier, multiplier);
     rd->multiplier = multiplier;
     rd->exposed = 0;
-    rrdset_flag_set(st, RRDSET_FLAG_HOMOGENEOUS_CHECK);
     rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
+    rrdset_flag_set(st, RRDSET_FLAG_HOMOGENEOUS_CHECK);
     rrdcontext_updated_rrddim_multiplier(rd);
     return 1;
 }
@@ -389,8 +389,8 @@ inline int rrddim_set_divisor(RRDSET *st, RRDDIM *rd, collected_number divisor) 
     debug(D_RRD_CALLS, "Updating divisor of dimension '%s/%s' from " COLLECTED_NUMBER_FORMAT " to " COLLECTED_NUMBER_FORMAT, rrdset_id(st), rrddim_name(rd), rd->divisor, divisor);
     rd->divisor = divisor;
     rd->exposed = 0;
-    rrdset_flag_set(st, RRDSET_FLAG_HOMOGENEOUS_CHECK);
     rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
+    rrdset_flag_set(st, RRDSET_FLAG_HOMOGENEOUS_CHECK);
     rrdcontext_updated_rrddim_divisor(rd);
     return 1;
 }

--- a/libnetdata/buffer/buffer.c
+++ b/libnetdata/buffer/buffer.c
@@ -136,6 +136,18 @@ void buffer_print_llu(BUFFER *wb, unsigned long long uvalue)
     wb->len += wstr - str;
 }
 
+void buffer_print_ll(BUFFER *wb, long long value)
+{
+    buffer_need_bytes(wb, 50);
+
+    if(value < 0) {
+        buffer_fast_strcat(wb, "-", 1);
+        value = -value;
+    }
+
+    buffer_print_llu(wb, value);
+}
+
 void buffer_fast_strcat(BUFFER *wb, const char *txt, size_t len) {
     if(unlikely(!txt || !*txt)) return;
 

--- a/libnetdata/buffer/buffer.c
+++ b/libnetdata/buffer/buffer.c
@@ -148,18 +148,23 @@ void buffer_print_ll(BUFFER *wb, long long value)
     buffer_print_llu(wb, value);
 }
 
-//void buffer_fast_strcat(BUFFER *wb, const char *txt, size_t len) {
-//    if(unlikely(!txt || !*txt)) return;
-//
-//    buffer_need_bytes(wb, len + 1);
-//
-//    memcpy(&wb->buffer[wb->len], txt, len);
-//    wb->len += len;
-//
-//    // keep it NULL terminating
-//    // not counting it at wb->len
-//    wb->buffer[wb->len] = '\0';
-//}
+void buffer_fast_strcat(BUFFER *wb, const char *txt, size_t len) {
+    if(unlikely(!txt || !*txt)) return;
+
+    buffer_need_bytes(wb, len + 1);
+
+    char *s = &wb->buffer[wb->len];
+    const char *end = &txt[len + 1];
+
+    while(txt != end)
+        *s++ = *txt++;
+
+    wb->len += len;
+
+    // keep it NULL terminating
+    // not counting it at wb->len
+    wb->buffer[wb->len] = '\0';
+}
 
 void buffer_strcat(BUFFER *wb, const char *txt)
 {

--- a/libnetdata/buffer/buffer.c
+++ b/libnetdata/buffer/buffer.c
@@ -148,23 +148,18 @@ void buffer_print_ll(BUFFER *wb, long long value)
     buffer_print_llu(wb, value);
 }
 
-void buffer_fast_strcat(BUFFER *wb, const char *txt, size_t len) {
-    if(unlikely(!txt || !*txt)) return;
-
-    buffer_need_bytes(wb, len + 1);
-
-    char *s = &wb->buffer[wb->len];
-    const char *end = &txt[len + 1];
-
-    while(txt != end)
-        *s++ = *txt++;
-
-    wb->len += len;
-
-    // keep it NULL terminating
-    // not counting it at wb->len
-    wb->buffer[wb->len] = '\0';
-}
+//void buffer_fast_strcat(BUFFER *wb, const char *txt, size_t len) {
+//    if(unlikely(!txt || !*txt)) return;
+//
+//    buffer_need_bytes(wb, len + 1);
+//
+//    memcpy(&wb->buffer[wb->len], txt, len);
+//    wb->len += len;
+//
+//    // keep it NULL terminating
+//    // not counting it at wb->len
+//    wb->buffer[wb->len] = '\0';
+//}
 
 void buffer_strcat(BUFFER *wb, const char *txt)
 {

--- a/libnetdata/buffer/buffer.h
+++ b/libnetdata/buffer/buffer.h
@@ -78,6 +78,7 @@ extern char *print_number_llu_r(char *str, unsigned long long uvalue);
 extern char *print_number_llu_r_smart(char *str, unsigned long long uvalue);
 
 extern void buffer_print_llu(BUFFER *wb, unsigned long long uvalue);
+extern void buffer_print_ll(BUFFER *wb, long long value);
 
 static inline void buffer_need_bytes(BUFFER *buffer, size_t needed_free_size) {
     if(unlikely(buffer->size - buffer->len < needed_free_size))

--- a/libnetdata/buffer/buffer.h
+++ b/libnetdata/buffer/buffer.h
@@ -54,11 +54,11 @@ extern const char *buffer_tostring(BUFFER *wb);
 #define buffer_flush(wb) wb->buffer[(wb)->len = 0] = '\0'
 extern void buffer_reset(BUFFER *wb);
 
-#define buffer_fast_strcat(wb, txt, len) do {               \
+#define buffer_fast_strcat(wb, txt, txt_len) do {           \
         if(likely((txt) && *(txt))) {                       \
-            buffer_need_bytes(wb, (len) + 1);               \
-            memcpy(&(wb)->buffer[(wb)->len], txt, len);     \
-            (wb)->len += (len);                             \
+            buffer_need_bytes(wb, (txt_len) + 1);           \
+            memcpy(&(wb)->buffer[(wb)->len], txt, txt_len); \
+            (wb)->len += (txt_len);                         \
             (wb)->buffer[(wb)->len] = '\0';                 \
         }                                                   \
     } while(0)

--- a/libnetdata/buffer/buffer.h
+++ b/libnetdata/buffer/buffer.h
@@ -54,8 +54,17 @@ extern const char *buffer_tostring(BUFFER *wb);
 #define buffer_flush(wb) wb->buffer[(wb)->len = 0] = '\0'
 extern void buffer_reset(BUFFER *wb);
 
+#define buffer_fast_strcat(wb, txt, len) do {               \
+        if(likely((txt) && *(txt))) {                       \
+            buffer_need_bytes(wb, (len) + 1);               \
+            memcpy(&(wb)->buffer[(wb)->len], txt, len);     \
+            (wb)->len += (len);                             \
+            (wb)->buffer[(wb)->len] = '\0';                 \
+        }                                                   \
+    } while(0)
+
 extern void buffer_strcat(BUFFER *wb, const char *txt);
-extern void buffer_fast_strcat(BUFFER *wb, const char *txt, size_t len);
+// extern void buffer_fast_strcat(BUFFER *wb, const char *txt, size_t len);
 extern void buffer_rrd_value(BUFFER *wb, NETDATA_DOUBLE value);
 
 extern void buffer_date(BUFFER *wb, int year, int month, int day, int hours, int minutes, int seconds);

--- a/libnetdata/buffer/buffer.h
+++ b/libnetdata/buffer/buffer.h
@@ -54,17 +54,8 @@ extern const char *buffer_tostring(BUFFER *wb);
 #define buffer_flush(wb) wb->buffer[(wb)->len = 0] = '\0'
 extern void buffer_reset(BUFFER *wb);
 
-#define buffer_fast_strcat(wb, txt, txt_len) do {           \
-        if(likely((txt) && *(txt))) {                       \
-            buffer_need_bytes(wb, (txt_len) + 1);           \
-            memcpy(&(wb)->buffer[(wb)->len], txt, txt_len); \
-            (wb)->len += (txt_len);                         \
-            (wb)->buffer[(wb)->len] = '\0';                 \
-        }                                                   \
-    } while(0)
-
 extern void buffer_strcat(BUFFER *wb, const char *txt);
-// extern void buffer_fast_strcat(BUFFER *wb, const char *txt, size_t len);
+extern void buffer_fast_strcat(BUFFER *wb, const char *txt, size_t len);
 extern void buffer_rrd_value(BUFFER *wb, NETDATA_DOUBLE value);
 
 extern void buffer_date(BUFFER *wb, int year, int month, int day, int hours, int minutes, int seconds);

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -389,9 +389,6 @@ void rrdset_done_push(RRDSET *st) {
         host->rrdpush_sender_error_shown = 0;
     }
 
-    if(dictionary_entries(st->rrddim_root_index) == 0)
-        return;
-
     sender_start(host->sender);
 
     if(unlikely(need_to_send_chart_definition(st)))

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -129,29 +129,44 @@ int rrdpush_init() {
 unsigned int remote_clock_resync_iterations = 60;
 
 
-static inline int should_send_chart_matching(RRDSET *st) {
-    // Do not stream anomaly rates charts.
-    if (unlikely(rrdset_is_ar_chart(st)))
-        return false;
+static inline bool should_send_chart_matching(RRDSET *st) {
+    RRDSET_FLAGS flags = rrdset_flag_check(st, RRDSET_FLAG_UPSTREAM_SEND|RRDSET_FLAG_UPSTREAM_IGNORE);
 
-    if (rrdset_flag_check(st, RRDSET_FLAG_ANOMALY_DETECTION))
-        return ml_streaming_enabled();
-
-    if(!rrdset_flag_check(st, RRDSET_FLAG_UPSTREAM_SEND|RRDSET_FLAG_UPSTREAM_IGNORE)) {
+    if(unlikely(!flags)) {
         RRDHOST *host = st->rrdhost;
 
-        if(simple_pattern_matches(host->rrdpush_send_charts_matching, rrdset_id(st)) ||
+        // Do not stream anomaly rates charts.
+        if (unlikely(rrdset_is_ar_chart(st))) {
+            rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_SEND);
+            rrdset_flag_set(st, RRDSET_FLAG_UPSTREAM_IGNORE);
+            flags = RRDSET_FLAG_UPSTREAM_IGNORE;
+        }
+        else if (rrdset_flag_check(st, RRDSET_FLAG_ANOMALY_DETECTION)) {
+            if(ml_streaming_enabled()) {
+                rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_IGNORE);
+                rrdset_flag_set(st, RRDSET_FLAG_UPSTREAM_SEND);
+                flags = RRDSET_FLAG_UPSTREAM_SEND;
+            }
+            else {
+                rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_SEND);
+                rrdset_flag_set(st, RRDSET_FLAG_UPSTREAM_IGNORE);
+                flags = RRDSET_FLAG_UPSTREAM_IGNORE;
+            }
+        }
+        else if(simple_pattern_matches(host->rrdpush_send_charts_matching, rrdset_id(st)) ||
             simple_pattern_matches(host->rrdpush_send_charts_matching, rrdset_name(st))) {
             rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_IGNORE);
             rrdset_flag_set(st, RRDSET_FLAG_UPSTREAM_SEND);
+            flags = RRDSET_FLAG_UPSTREAM_SEND;
         }
         else {
             rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_SEND);
             rrdset_flag_set(st, RRDSET_FLAG_UPSTREAM_IGNORE);
+            flags = RRDSET_FLAG_UPSTREAM_IGNORE;
         }
     }
 
-    return(rrdset_flag_check(st, RRDSET_FLAG_UPSTREAM_SEND));
+    return flags & RRDSET_FLAG_UPSTREAM_SEND;
 }
 
 int configured_as_parent() {
@@ -355,15 +370,16 @@ void rrdset_done_push(RRDSET *st) {
 
     RRDHOST *host = st->rrdhost;
 
-    if(unlikely(host->rrdpush_send_enabled && !host->rrdpush_sender_spawn))
-        rrdpush_sender_thread_spawn(host);
-
     // Handle non-connected case
     if(unlikely(!__atomic_load_n(&host->rrdpush_sender_connected, __ATOMIC_SEQ_CST)
                  || !rrdhost_flag_check(host, RRDHOST_FLAG_STREAM_COLLECTED_METRICS))) {
 
+        if(unlikely(host->rrdpush_send_enabled && !host->rrdpush_sender_spawn))
+            rrdpush_sender_thread_spawn(host);
+
         if(unlikely(!host->rrdpush_sender_error_shown))
             error("STREAM %s [send]: not ready - collected metrics are not sent to parent.", rrdhost_hostname(host));
+
         host->rrdpush_sender_error_shown = 1;
 
         return;
@@ -378,10 +394,10 @@ void rrdset_done_push(RRDSET *st) {
 
     sender_start(host->sender);
 
-    if(need_to_send_chart_definition(st))
+    if(unlikely(need_to_send_chart_definition(st)))
         rrdpush_send_chart_definition(st);
 
-    if(rrdpush_send_chart_metrics_nolock(st, host->sender)) {
+    if(likely(rrdpush_send_chart_metrics_nolock(st, host->sender))) {
         // signal the sender there are more data
         if (host->rrdpush_sender_pipe[PIPE_WRITE] != -1 && write(host->rrdpush_sender_pipe[PIPE_WRITE], " ", 1) == -1)
             error("STREAM %s [send]: cannot write to internal pipe", rrdhost_hostname(host));


### PR DESCRIPTION
We are testing a child-parent setup where the child tries to push 800k metrics / second to the parent.

Without streaming on the child, this works. It can collect 800k metrics / second for go.d.plugin.
With streaming however, the child cannot push more than 450k metrics / second.

With this PR, the child can push about 600k metrics / second to the parent, about 25% - 30% increase.

My observation is the following:

1. The code uses the shared chart flags for keeping sender flags in them. This requires atomic operations for every single chart. These can be eliminated by having a different `sender_flags` member in RRDSET and using it without atomics (there will be no data race in this case, because the sending thread is fixed for each chart - although many charts use different threads, each of the charts is fixed to one thread).
2. The same is true for host flags. Quite a few atomics probably without reason.
3. `sender_start()` and `sender_commit()` have been implemented in a non-scalable way. Sender commit locks the entire host from sending metrics for way too long, forcing all threads to be serialized. It does not matter if the child has 10 threads collecting the metrics, they will go one by one in this `send_start()`, `sender_commit()` loop. Ideally, there should be a thread `BUFFER *` variable returned by `sender_start()`, which will be filled up and be compressed without any locks, and acquire the mutex for just copying the compressed buffer into the circular buffer for dispatch.

We probably need to re-think streaming. Now the child and parent are doing the same job. The child is pushing collected values and both the parent and the child have to interpolate them to store them in their databases. Probably it would be a lot faster to push from the child interpolated data, which the parent will just get and store. A binary protocol would also benefit the performance a lot.
