### PR TITLE
feat(health): add new Redis alarms

### DIFF
--- a/health/health.d/redis.conf
+++ b/health/health.d/redis.conf
@@ -1,3 +1,18 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+ template: redis_connections_rejected
+ families: *
+       on: redis.connections
+    class: Errors
+     type: KV Storage
+component: Redis
+   lookup: sum -1m unaligned of rejected
+    every: 10s
+    units: connections
+     warn: $this > 0
+     info: connections rejected because of maxclients limit in the last minute
+    delay: down 5m multiplier 1.5 max 1h
+       to: dba
 
  template: redis_bgsave_broken
  families: *
@@ -24,5 +39,19 @@ component: Redis
      crit: $this > 1200
     units: seconds
      info: duration of the on-going RDB save operation
+    delay: down 5m multiplier 1.5 max 1h
+       to: dba
+
+ template: redis_master_link_down
+ families: *
+       on: redis.master_link_down_since_time
+    class: Errors
+     type: KV Storage
+component: Redis
+    every: 10s
+     calc: $time
+    units: seconds
+     crit: $this != nan AND $this > 0
+     info: time elapsed since the link between master and slave is down
     delay: down 5m multiplier 1.5 max 1h
        to: dba


### PR DESCRIPTION
##### Summary

Part of #13691

##### Test Plan

Check new alarms on the dashboard.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
