### PR TITLE
Do not try to start an archived host in dbengine if dbengine is not compiled

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -287,6 +287,13 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
 
     struct rrdhost_system_info *system_info = callocz(1, sizeof(struct rrdhost_system_info));
     system_info->hops = str2i((const char *) argv[IDX_HOPS]);
+    RRD_MEMORY_MODE memory_mode;
+
+#ifdef ENABLE_DBENGINE
+    memory_mode = RRD_MEMORY_MODE_DBENGINE;
+#else
+    memory_mode = RRD_MEMORY_MODE_RAM;
+#endif
 
     sql_build_host_system_info((uuid_t *)argv[IDX_HOST_ID], system_info);
 
@@ -303,7 +310,7 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
         , (const char *) (argv[IDX_PROGRAM_VERSION] ? argv[IDX_PROGRAM_VERSION] : "unknown")
         , argv[3] ? str2i(argv[IDX_UPDATE_EVERY]) : 1
         , argv[13] ? str2i(argv[IDX_ENTRIES]) : 0
-        , RRD_MEMORY_MODE_DBENGINE
+        , memory_mode
         , 0 // health
         , 0 // rrdpush enabled
         , NULL  //destination


### PR DESCRIPTION
##### Summary
On agent startup archived hosts (children) are created with dbengine memory mode. If dbengine is not compiled, 
the agent will not start. 

This PR will create the archived hosts in memory mode RAM. If tthe child connects it will pickup the specified memory mode as needed (in that case if dbengine is specified, because it is not available, it will switch to "save") 

##### Test Plan
- Setup parent child and start the agents with memory mode dbengine. 
- Stop the agents, compile the parent without dbengine and start the parent only. Notice it will not start
- Apply the PR on the parent and restart
