### PR TITLE
Change cast to remove coverity warnings

### DIFF
--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -872,12 +872,12 @@ void health_alarm_entry2proto_nolock(struct alarm_log_entry *alarm_log, ALARM_EN
 #endif
 
 #ifdef ENABLE_ACLK
-static int have_recent_alarm(RRDHOST *host, uint32_t alarm_id, time_t mark)
+static int have_recent_alarm(RRDHOST *host, uint32_t alarm_id, uint32_t mark)
 {
     ALARM_ENTRY *ae = host->health_log.alarms;
 
     while (ae) {
-        if (ae->alarm_id == alarm_id && (time_t) ae->unique_id >mark &&
+        if (ae->alarm_id == alarm_id && ae->unique_id >mark &&
             (ae->new_status != RRDCALC_STATUS_WARNING && ae->new_status != RRDCALC_STATUS_CRITICAL))
             return 1;
         ae = ae->next;

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -877,7 +877,7 @@ static int have_recent_alarm(RRDHOST *host, uint32_t alarm_id, time_t mark)
     ALARM_ENTRY *ae = host->health_log.alarms;
 
     while (ae) {
-        if (ae->alarm_id == alarm_id && ae->unique_id > (uint32_t)mark &&
+        if (ae->alarm_id == alarm_id && (time_t) ae->unique_id >mark &&
             (ae->new_status != RRDCALC_STATUS_WARNING && ae->new_status != RRDCALC_STATUS_CRITICAL))
             return 1;
         ae = ae->next;

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -402,7 +402,7 @@ static int have_recent_alarm(RRDHOST *host, uint32_t alarm_id, time_t mark)
     ALARM_ENTRY *ae = host->health_log.alarms;
 
     while(ae) {
-        if (ae->alarm_id == alarm_id && ae->unique_id > (unsigned int) mark &&
+        if (ae->alarm_id == alarm_id && (time_t) ae->unique_id > mark &&
             (ae->new_status != RRDCALC_STATUS_WARNING && ae->new_status != RRDCALC_STATUS_CRITICAL))
             return 1;
         ae = ae->next;

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -397,12 +397,12 @@ void health_alarms_values2json(RRDHOST *host, BUFFER *wb, int all) {
     buffer_strcat(wb, "\n\t}\n}\n");
 }
 
-static int have_recent_alarm(RRDHOST *host, uint32_t alarm_id, time_t mark)
+static int have_recent_alarm(RRDHOST *host, uint32_t alarm_id, uint32_t mark)
 {
     ALARM_ENTRY *ae = host->health_log.alarms;
 
     while(ae) {
-        if (ae->alarm_id == alarm_id && (time_t) ae->unique_id > mark &&
+        if (ae->alarm_id == alarm_id && ae->unique_id > mark &&
             (ae->new_status != RRDCALC_STATUS_WARNING && ae->new_status != RRDCALC_STATUS_CRITICAL))
             return 1;
         ae = ae->next;


### PR DESCRIPTION
##### Summary
Fix Coverity report:

```sh
*** CID 380995:    (Y2K38_SAFETY)
/health/health_json.c: 405 in have_recent_alarm()
399     
400     static int have_recent_alarm(RRDHOST *host, uint32_t alarm_id, time_t mark)
401     {
402         ALARM_ENTRY *ae = host->health_log.alarms;
403     
404         while(ae) {
>>>     CID 380995:    (Y2K38_SAFETY)
>>>     A "time_t" value is stored in an integer with too few bits to accommodate it.  The expression "mark" is cast to "unsigned int".
405             if (ae->alarm_id == alarm_id && ae->unique_id > (unsigned int) mark &&
406                 (ae->new_status != RRDCALC_STATUS_WARNING && ae->new_status != RRDCALC_STATUS_CRITICAL))
407                 return 1;
408             ae = ae->next;
409         }
410         return 0;
/database/sqlite/sqlite_aclk_alert.c: 880 in have_recent_alarm()
874     #ifdef ENABLE_ACLK
875     static int have_recent_alarm(RRDHOST *host, uint32_t alarm_id, time_t mark)
876     {
877         ALARM_ENTRY *ae = host->health_log.alarms;
878     
879         while (ae) {
>>>     CID 380995:    (Y2K38_SAFETY)
>>>     A "time_t" value is stored in an integer with too few bits to accommodate it.  The expression "mark" is cast to "uint32_t".
880             if (ae->alarm_id == alarm_id && ae->unique_id > (uint32_t)mark &&
881                 (ae->new_status != RRDCALC_STATUS_WARNING && ae->new_status != RRDCALC_STATUS_CRITICAL))
882                 return 1;
883             ae = ae->next;
884         }
885     
```

##### Test Plan

1. Compile this PR
2. Run netdata and verify nothing is broken with `health`.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
