### PR TITLE
Teach the agent how to exchange protobuf messages prior to streaming.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,6 +441,8 @@ set_source_files_properties(libnetdata/libjudy/src/JudyL/j__udyLGet.c PROPERTIES
 set_source_files_properties(libnetdata/libjudy/src/JudyL/JudyLByCount.c PROPERTIES COMPILE_OPTIONS "-DNOSMARTJBB -DNOSMARTJBU -DNOSMARTJLB")
 set_source_files_properties(JudyLTables.c PROPERTIES COMPILE_OPTIONS "-I${CMAKE_SOURCE_DIR}/libnetdata/libjudy/src/JudyL")
 
+set(ENABLE_HANDSHAKE True)
+
 # -----------------------------------------------------------------------------
 # netdata files
 
@@ -859,12 +861,23 @@ set(API_PLUGIN_FILES
         )
 
 set(STREAMING_PLUGIN_FILES
+        streaming/protocol/handshake.h
         streaming/rrdpush.c
         streaming/rrdpush.h
         streaming/compression.c
         streaming/receiver.c
         streaming/sender.c
-        )
+        streaming/protocol/setup.h
+        streaming/protocol/setup.c
+)
+
+if(ENABLE_HANDSHAKE)
+    list(APPEND STREAMING_PLUGIN_FILES
+        streaming/protocol/handshake.cc
+        streaming/protocol/message.cc
+        streaming/protocol/message.h
+    )
+endif()
 
 set(CLAIM_PLUGIN_FILES
         claim/claim.c
@@ -1266,8 +1279,51 @@ include_directories(BEFORE ${CMAKE_SOURCE_DIR}/mqtt_websockets/c-rbuf/include)
 
 ENDIF()
 
-list(APPEND NETDATA_FILES ${ACLK_ALWAYS_BUILD})
-list(APPEND NETDATA_FILES ${TIMEX_PLUGIN_FILES})
+# -----------------------------------------------------------------------------
+# handshake
+
+function(PROTOBUF_HANDSHAKE_GENERATE_CPP SRCS HDRS)
+  if(NOT ARGN)
+    message(SEND_ERROR "Error: PROTOBUF_HANDSHAKE_GENERATE_CPP() called without any proto files")
+    return()
+  endif()
+
+  set(${SRCS})
+  set(${HDRS})
+  foreach(FIL ${ARGN})
+    get_filename_component(ABS_FIL ${FIL} ABSOLUTE)
+    get_filename_component(DIR ${ABS_FIL} DIRECTORY)
+    get_filename_component(FIL_WE ${FIL} NAME_WE)
+    set(GENERATED_PB_CC "${DIR}/${FIL_WE}.pb.cc")
+    set(GENERATED_PB_H "${DIR}/${FIL_WE}.pb.h")
+# cmake > 3.20 required :(
+#    cmake_path(SET GENERATED_PB_CC "${DIR}")
+#    cmake_path(SET GENERATED_PB_H "${DIR}")
+#    cmake_path(APPEND GENERATED_PB_CC "${FIL_WE}.pb.cc")
+#    cmake_path(APPEND GENERATED_PB_H "${FIL_WE}.pb.h")
+
+    list(APPEND ${SRCS} ${GENERATED_PB_CC})
+    list(APPEND ${HDRS} ${GENERATED_PB_H})
+    add_custom_command(
+      OUTPUT ${GENERATED_PB_CC}
+             ${GENERATED_PB_H}
+      COMMAND  ${PROTOBUF_PROTOC_EXECUTABLE}
+      ARGS -I=${CMAKE_SOURCE_DIR}/streaming/protocol/proto --cpp_out=${CMAKE_SOURCE_DIR}/streaming/protocol/proto ${ABS_FIL}
+      DEPENDS ${ABS_FIL} ${PROTOBUF_PROTOC_EXECUTABLE}
+      COMMENT "Running C++ protocol buffer compiler on ${FIL}"
+      VERBATIM )
+  endforeach()
+  set_source_files_properties(${${SRCS}} ${${HDRS}} PROPERTIES GENERATED TRUE)
+  set(${SRCS} ${${SRCS}} PARENT_SCOPE)
+  set(${HDRS} ${${HDRS}} PARENT_SCOPE)
+endfunction()
+
+set(HANDSHAKE_PROTO_DEFS streaming/protocol/proto/command.proto)
+PROTOBUF_HANDSHAKE_GENERATE_CPP(HANDSHAKE_PROTO_BUILT_SRCS HANDSHAKE_PROTO_BUILT_HDRS ${HANDSHAKE_PROTO_DEFS})
+
+
+#list(APPEND NETDATA_FILES ${ACLK_ALWAYS_BUILD})
+#list(APPEND NETDATA_FILES ${TIMEX_PLUGIN_FILES})
 
 # -----------------------------------------------------------------------------
 # netdata

--- a/Makefile.am
+++ b/Makefile.am
@@ -123,6 +123,7 @@ AM_CFLAGS = \
     $(OPTIONAL_CUPS_CFLAGS) \
     $(OPTIONAL_XENSTAT_CFLAGS) \
     $(OPTIONAL_BPF_CFLAGS) \
+    $(OPTIONAL_PROTOBUF_CFLAGS) \
     $(NULL)
 
 sbin_PROGRAMS =
@@ -631,7 +632,35 @@ STREAMING_PLUGIN_FILES = \
     streaming/sender.c \
     streaming/receiver.c \
     streaming/rrdpush.h \
+    streaming/protocol/setup.h \
+    streaming/protocol/setup.c \
+    streaming/protocol/handshake.h \
     $(NULL)
+
+if ENABLE_HANDSHAKE
+
+dist_noinst_DATA += streaming/protocol/proto/command.proto
+
+streaming/protocol/proto/command.pb.cc \
+streaming/protocol/proto/command.pb.h: streaming/protocol/proto/command.proto
+	$(PROTOC) --proto_path=$(srcdir) --cpp_out=$(builddir) $^
+
+HANDSHAKE_BUILT_FILES = \
+    streaming/protocol/proto/command.pb.cc \
+    streaming/protocol/proto/command.pb.h \
+    $(NULL)
+
+BUILT_SOURCES += $(HANDSHAKE_BUILT_FILES)
+nodist_netdata_SOURCES += $(HANDSHAKE_BUILT_FILES)
+CLEANFILES += $(HANDSHAKE_BUILT_FILES)
+
+STREAMING_PLUGIN_FILES += \
+    streaming/protocol/message.cc \
+    streaming/protocol/message.h \
+    streaming/protocol/handshake.cc \
+    $(NULL)
+
+endif # ENABLE_HANDSHAKE
 
 REGISTRY_PLUGIN_FILES = \
     registry/registry.c \
@@ -970,6 +999,7 @@ NETDATA_COMMON_LIBS = \
     $(OPTIONAL_SSL_LIBS) \
     $(OPTIONAL_JSONC_LIBS) \
     $(OPTIONAL_ATOMIC_LIBS) \
+    $(OPTIONAL_PROTOBUF_LIBS) \
     $(NULL)
 
 if LINK_STATIC_JSONC

--- a/config.cmake.h.in
+++ b/config.cmake.h.in
@@ -51,6 +51,7 @@
 #define ENABLE_COMPRESSION // pkg_check_modules(LIBLZ4 REQUIRED liblz4)
 #cmakedefine ENABLE_APPS_PLUGIN
 
+#cmakedefine ENABLE_HANDSHAKE
 
 #define __always_unused @ALWAYS_UNUSED_MACRO@
 #define __maybe_unused @MAYBE_UNUSED_MACRO@

--- a/configure.ac
+++ b/configure.ac
@@ -1168,6 +1168,23 @@ if test "${build_ml_tests}" = "yes"; then
 fi
 
 # -----------------------------------------------------------------------------
+# handshake
+
+if test "${have_libprotobuf}" = "yes" -a "${have_protoc}" = "yes"; then
+    build_handshake="yes"
+else
+    build_handshake="no"
+fi
+
+AM_CONDITIONAL([ENABLE_HANDSHAKE], [test "${build_handshake}" = "yes"])
+if test "${build_handshake}" = "yes"; then
+    AC_DEFINE([ENABLE_HANDSHAKE], [1], [handshake usability])
+
+    OPTIONAL_PROTOBUF_CFLAGS="${PROTOBUF_CFLAGS}"
+    OPTIONAL_PROTOBUF_LIBS="${PROTOBUF_LIBS}"
+fi
+
+# -----------------------------------------------------------------------------
 # ebpf.plugin
 
 if test "${build_target}" = "linux" -a "${enable_ebpf}" != "no"; then

--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -319,7 +319,7 @@ void print_build_info_json(void) {
     printf("    \"aclk\": %s,\n", FEAT_JSON_BOOL(FEAT_CLOUD));
 
     printf("    \"tls-host-verify\": %s,\n",   FEAT_JSON_BOOL(FEAT_TLS_HOST_VERIFY));
-    printf("    \"machine-learning\": %s\n",   FEAT_JSON_BOOL(FEAT_ML));
+    printf("    \"machine-learning\": %s,\n",  FEAT_JSON_BOOL(FEAT_ML));
     printf("    \"stream-compression\": %s\n",   FEAT_JSON_BOOL(FEAT_STREAM_COMPRESSION));
     printf("  },\n");
 

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -837,6 +837,7 @@ struct rrdhost_system_info {
     uint16_t hops;
     bool ml_capable;
     bool ml_enabled;
+    bool handshake_enabled;
     char *install_type;
     char *prebuilt_arch;
     char *prebuilt_dist;
@@ -974,10 +975,8 @@ struct rrdhost {
     uuid_t  host_uuid;                              // Global GUID for this host
     uuid_t  *node_id;                               // Cloud node_id
 
-#ifdef ENABLE_HTTPS
-    struct netdata_ssl ssl;                         //Structure used to encrypt the connection
-    struct netdata_ssl stream_ssl;                         //Structure used to encrypt the stream
-#endif
+    struct netdata_ssl ssl;                         // Structure used to encrypt the connection
+    struct netdata_ssl stream_ssl;                  // Structure used to encrypt the stream
 
     netdata_mutex_t aclk_state_lock;
     aclk_rrdhost_state aclk_state;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -494,6 +494,11 @@ RRDHOST *rrdhost_create(const char *hostname,
     //
 
     if (is_localhost && host->system_info) {
+#ifdef ENABLE_HANDSHAKE
+        host->system_info->handshake_enabled = true;
+#else
+        host->system_info->handshake_enabled = false;
+#endif
         host->system_info->ml_capable = ml_capable();
         host->system_info->ml_enabled = ml_enabled(host);
         host->system_info->mc_version = enable_metric_correlations ? metric_correlations_version : 0;

--- a/libnetdata/socket/security.h
+++ b/libnetdata/socket/security.h
@@ -59,5 +59,12 @@ int security_process_accept(SSL *ssl,int msg);
 int security_test_certificate(SSL *ssl);
 SSL_CTX * security_initialize_openssl_client();
 
+#else // ENABLE_HTTPS
+
+struct netdata_ssl {
+    int dummy_field;
+};
+
 # endif //ENABLE_HTTPS
+
 #endif //NETDATA_SECURITY_H

--- a/libnetdata/socket/socket.h
+++ b/libnetdata/socket/socket.h
@@ -58,13 +58,12 @@ extern int connect_to_this(const char *definition, int default_port, struct time
 extern int connect_to_one_of(const char *destination, int default_port, struct timeval *timeout, size_t *reconnects_counter, char *connected_to, size_t connected_to_size);
 int connect_to_this_ip46(int protocol, int socktype, const char *host, uint32_t scope_id, const char *service, struct timeval *timeout);
 
-#ifdef ENABLE_HTTPS
 extern ssize_t recv_timeout(struct netdata_ssl *ssl,int sockfd, void *buf, size_t len, int flags, int timeout);
 extern ssize_t send_timeout(struct netdata_ssl *ssl,int sockfd, void *buf, size_t len, int flags, int timeout);
-#else
-extern ssize_t recv_timeout(int sockfd, void *buf, size_t len, int flags, int timeout);
-extern ssize_t send_timeout(int sockfd, void *buf, size_t len, int flags, int timeout);
-#endif
+
+// 0 on success. Otherwise, a non-zero value denoting the number of unprocessed bytes
+extern size_t recv_exact(struct netdata_ssl *ssl, int sockfd, void *buf, size_t len, int flags, time_t timeout);
+extern size_t send_exact(struct netdata_ssl *ssl, int sockfd, void *buf, size_t len, int flags, time_t timeout);
 
 extern int sock_setnonblock(int fd);
 extern int sock_delnonblock(int fd);

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -605,7 +605,7 @@ copy_protobuf() {
 }
 
 bundle_protobuf() {
-  if [ -n "${NETDATA_DISABLE_CLOUD}" ] && [ -n "${NETDATA_DISABLE_PROMETHEUS}" ]; then
+  if [ -n "${NETDATA_DISABLE_CLOUD}" ] && [ -n "${NETDATA_DISABLE_PROMETHEUS}" ] && [ -n "${DISABLE_HANDSHAKE}" ]; then
     echo "Skipping protobuf"
     return 0
   fi

--- a/streaming/protocol/handshake.cc
+++ b/streaming/protocol/handshake.cc
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "handshake.h"
+#include "message.h"
+
+#include "proto/command.pb.h"
+
+enum class handshake_version : uint8_t {
+    unknown = 0,
+    v1 = 1,
+};
+
+typedef struct {
+    enum handshake_version version;
+} handshake_info_t;
+
+static std::string derseBuffer;
+
+bool send_handshake_info(connection_handle_t *conn, handshake_info_t *info) {
+    protocol::HandshakeInfo pb_info;
+    switch (info->version) {
+        case handshake_version::v1:
+            pb_info.set_version(protocol::VersionValue::V1);
+            break;
+        default:
+            pb_info.set_version(protocol::VersionValue::Unknown);
+            break;
+    }
+
+    derseBuffer.clear();
+    pb_info.SerializeToString(&derseBuffer);
+
+    binary_message_t msg;
+    msg.buf = const_cast<char *>(derseBuffer.data());
+    msg.len = derseBuffer.size();
+    return binary_message_send(conn, &msg);
+}
+
+bool recv_handshake_info(connection_handle_t *conn, handshake_info_t *info) {
+    binary_message_t msg;
+    bool ok = binary_message_recv(conn, &msg);
+    if (!ok)
+        return false;
+
+    protocol::HandshakeInfo pb_info;
+    pb_info.ParseFromArray(msg.buf, msg.len);
+
+    switch (pb_info.version()) {
+        case protocol::VersionValue::V1:
+            info->version = handshake_version::v1;
+            break;
+        default:
+            info->version = handshake_version::unknown;
+            break;
+    }
+    freez(msg.buf);
+    return true;
+}
+
+bool sender_handshake_start(struct sender_state *ss) {
+    bool ok = true;
+
+    connection_handle_t conn;
+    conn.host = ss->host;
+    conn.ssl = &ss->host->ssl;
+    conn.sockfd = ss->host->rrdpush_sender_socket;
+    conn.flags = 0;
+    conn.timeout = 60;
+
+    handshake_info_t local_info;
+    local_info.version = handshake_version::v1;
+
+    ok = send_handshake_info(&conn, &local_info);
+    if (!ok)
+        return false;
+
+    handshake_info_t remote_info;
+    ok = recv_handshake_info(&conn, &remote_info);
+    if (!ok)
+        return false;
+
+    return ok;
+}
+
+bool receiver_handshake_start(struct receiver_state *rs) {
+    bool ok = true;
+
+    connection_handle_t conn;
+    conn.host = rs->host;
+    conn.ssl = &rs->ssl;
+    conn.sockfd = rs->fd;
+    conn.flags = 0;
+    conn.timeout = 60;
+
+    handshake_info_t remote_info;
+    ok = recv_handshake_info(&conn, &remote_info);
+    if (!ok)
+        return false;
+
+    handshake_info_t local_info;
+    local_info.version = handshake_version::v1;
+
+    ok = send_handshake_info(&conn, &local_info);
+    if (!ok)
+        return false;
+
+    return true;
+}

--- a/streaming/protocol/handshake.h
+++ b/streaming/protocol/handshake.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef PROTOCOL_HANDSHAKE_H
+#define PROTOCOL_HANDSHAKE_H
+
+#include "daemon/common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef ENABLE_HANDSHAKE
+bool sender_handshake_start(struct sender_state *ss);
+bool receiver_handshake_start(struct receiver_state *rs);
+#else
+static inline bool sender_handshake_start(struct sender_state *ss) {
+    UNUSED(ss);
+    return false;
+}
+
+static inline bool receiver_handshake_start(struct receiver_state *rs) {
+    UNUSED(rs);
+    return true;
+}
+#endif
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif /* PROTOCOL_HANDSHAKE_H */

--- a/streaming/protocol/message.cc
+++ b/streaming/protocol/message.cc
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "message.h"
+
+static bool send_uint32(struct netdata_ssl *ssl, int sockfd,
+                        int flags, time_t timeout, uint32_t value)
+{
+    uint32_t network_value = htonl(value);
+    char *buf = (char*) &network_value;
+    size_t n = sizeof(uint32_t);
+
+    size_t remaining = send_exact(ssl, sockfd, buf, n, flags, timeout);
+    return remaining == 0;
+}
+
+static bool recv_uint32(struct netdata_ssl *ssl, int sockfd,
+                        int flags, time_t timeout, uint32_t *value)
+{
+    const size_t n = sizeof(uint32_t);
+    char buf[n];
+
+    size_t remaining = recv_exact(ssl, sockfd, buf, n, flags, timeout);
+    if (remaining)
+        return false;
+
+    memcpy(value, buf, n);
+    *value = ntohl(*value);
+    return true;
+}
+
+static bool send_binary_message(connection_handle_t *conn, binary_message_t *msg)
+{
+    struct netdata_ssl *ssl = conn->ssl;
+    int sockfd = conn->sockfd;
+    int flags = conn->flags;
+    time_t timeout = conn->timeout;
+
+    if (!send_uint32(ssl, sockfd, flags, timeout, msg->len))
+        return false;
+
+    if (!msg->len)
+        return true;
+
+    size_t remaining = send_exact(ssl, sockfd, msg->buf, msg->len, flags, timeout);
+    if (remaining)
+        return false;
+
+    return true;
+}
+
+static bool recv_binary_message(connection_handle_t *conn,
+                                binary_message_t *msg)
+{
+    struct netdata_ssl *ssl = conn->ssl;
+    int sockfd = conn->sockfd;
+    int flags = conn->flags;
+    time_t timeout = conn->timeout;
+
+    if (!recv_uint32(ssl, sockfd, flags, timeout, &msg->len))
+        return false;
+
+    if (!msg->len)
+        return true;
+
+    msg->buf = static_cast<char *>(callocz(sizeof(char), msg->len));
+
+    size_t remaining = recv_exact(ssl, sockfd, msg->buf, msg->len, flags, timeout);
+
+    if (remaining) {
+        freez(msg->buf);
+        return false;
+    }
+
+    return true;
+}
+
+bool binary_message_send(connection_handle_t *connection_handle,
+                         binary_message_t *binary_message)
+{
+    return send_binary_message(connection_handle, binary_message);
+}
+
+bool binary_message_recv(connection_handle_t *connection_handle,
+                         binary_message_t *binary_message)
+{
+    return recv_binary_message(connection_handle, binary_message);
+}

--- a/streaming/protocol/message.h
+++ b/streaming/protocol/message.h
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef PROTOCOL_MESSAGE_H
+#define PROTOCOL_MESSAGE_H
+
+#include "daemon/common.h"
+
+typedef struct {
+    RRDHOST *host;
+    struct netdata_ssl *ssl;
+    int sockfd;
+    int flags;
+    time_t timeout;
+} connection_handle_t;
+
+typedef struct {
+    char *buf;
+    uint32_t len;
+} binary_message_t;
+
+bool binary_message_send(connection_handle_t *connection_handle,
+                         binary_message_t *binary_message);
+
+bool binary_message_recv(connection_handle_t *connection_handle,
+                         binary_message_t *binary_message);
+
+#endif /* PROTOCOL_MESSAGE_H */

--- a/streaming/protocol/proto/command.proto
+++ b/streaming/protocol/proto/command.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package protocol;
+
+enum VersionValue {
+    Unknown = 0;
+    V1 = 1;
+}
+
+message HandshakeInfo {
+    VersionValue Version = 1;
+}

--- a/streaming/protocol/setup.c
+++ b/streaming/protocol/setup.c
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "setup.h"
+#include "handshake.h"
+
+static const size_t HANDSHAKE_PROTOCOL_INITIAL_RESPONSE_SIZE = 1024;
+
+static void rrdpush_set_flags_to_newest_stream(RRDHOST *host) {
+    rrdhost_flag_set(host, RRDHOST_FLAG_STREAM_LABELS_UPDATE);
+    rrdhost_flag_clear(host, RRDHOST_FLAG_STREAM_LABELS_STOP);
+}
+
+static long int parse_stream_version_for_errors(const char *http)
+{
+    if (!memcmp(http, START_STREAMING_ERROR_SAME_LOCALHOST, sizeof(START_STREAMING_ERROR_SAME_LOCALHOST)))
+        return -2;
+    else if (!memcmp(http, START_STREAMING_ERROR_ALREADY_STREAMING, sizeof(START_STREAMING_ERROR_ALREADY_STREAMING)))
+        return -3;
+    else if (!memcmp(http, START_STREAMING_ERROR_NOT_PERMITTED, sizeof(START_STREAMING_ERROR_NOT_PERMITTED)))
+        return -4;
+    else
+        return -1;
+}
+
+static long int parse_stream_version(RRDHOST *host, const char *http)
+{
+    long int stream_version = -1;
+    int answer = -1;
+    char *stream_version_start = strchr(http, '=');
+    if (stream_version_start) {
+        stream_version_start++;
+        stream_version = strtol(stream_version_start, NULL, 10);
+        answer = memcmp(http, START_STREAMING_PROMPT_VN, (size_t)(stream_version_start - http));
+        if (!answer) {
+            rrdpush_set_flags_to_newest_stream(host);
+        }
+    } else {
+        answer = memcmp(http, START_STREAMING_PROMPT_V2, strlen(START_STREAMING_PROMPT_V2));
+        if (!answer) {
+            stream_version = 1;
+            rrdpush_set_flags_to_newest_stream(host);
+        } else {
+            answer = memcmp(http, START_STREAMING_PROMPT, strlen(START_STREAMING_PROMPT));
+            if (!answer) {
+                stream_version = 0;
+                rrdhost_flag_set(host, RRDHOST_FLAG_STREAM_LABELS_STOP);
+                rrdhost_flag_clear(host, RRDHOST_FLAG_STREAM_LABELS_UPDATE);
+            }
+            else {
+                stream_version = parse_stream_version_for_errors(http);
+            }
+        }
+    }
+    return stream_version;
+}
+
+static inline struct netdata_ssl *sender_ssl(struct sender_state *ss) {
+    return &ss->host->ssl;
+}
+
+static inline int sender_sockfd(struct sender_state *ss) {
+    return ss->host->rrdpush_sender_socket;
+}
+
+static inline RRDHOST *receiver_host(struct receiver_state *rs) {
+    return rs->host;
+}
+
+static inline struct netdata_ssl *receiver_ssl(struct receiver_state *rs) {
+    return &rs->ssl;
+}
+
+static inline int receiver_sockfd(struct receiver_state *rs) {
+    return rs->fd;
+}
+
+#define sender_error(sender, fmt, args...) do { \
+    size_t len = 1024; \
+    char newfmt[len]; \
+    memset(newfmt, 0, len); \
+    const char *connected_to = s->connected_to; \
+    snprintfz(newfmt, len, " [send to %%s]: %s", fmt); \
+    error(newfmt, connected_to, ##args); \
+} while(0);
+
+#define receiver_error(receiver, fmt, args...) do { \
+    size_t len = 1024; \
+    char newfmt[len]; \
+    memset(newfmt, 0, len); \
+    snprintfz(newfmt, len, " [recv from %%s (%%s:%%s)]: %s", fmt); \
+    error(newfmt, receiver_host(receiver), receiver->client_ip, receiver->client_port, ##args); \
+} while(0);
+
+static size_t dummy_tcp_data(struct netdata_ssl *ssl, int sockfd, time_t timeout,
+                           size_t processed, size_t expected, bool recv)
+{
+    if (processed > expected)
+        return ~0;
+
+    ssize_t remaining = expected - processed;
+    if (!remaining)
+        return 0;
+
+    char *buf = callocz(sizeof(char), remaining);
+    if (!buf)
+        return remaining;
+
+    if (recv)
+        remaining = recv_exact(ssl, sockfd, buf, remaining, 0, timeout);
+    else
+        remaining = send_exact(ssl, sockfd, buf, remaining, 0, timeout);
+
+    freez(buf);
+
+    return remaining;
+}
+
+static bool drain_dummy_tcp_data(struct sender_state *ss, time_t timeout,
+                                 size_t received, size_t expected)
+{
+    size_t n = dummy_tcp_data(sender_ssl(ss), sender_sockfd(ss),
+                              timeout, received, expected, /* recv: */ true);
+    if (n)
+        error("Could not drain tcp data (recv'd=%zu, expected=%zu, remaining=%zu)",
+              received, expected, n);
+    return n == 0;
+}
+
+static bool fill_dummy_tcp_data(struct receiver_state *rs, time_t timeout,
+                                size_t written, size_t expected)
+{
+    size_t n = dummy_tcp_data(receiver_ssl(rs), receiver_sockfd(rs),
+                              timeout, written, expected, /* recv: */ false);
+    if (n)
+        error("Could not drain tcp data (sent=%zu, expected=%zu, remaining=%zu)",
+              written, expected, n);
+    return n == 0;
+}
+
+bool protocol_setup_on_sender(struct sender_state *s, int timeout) {
+    RRDHOST *host = s->host;
+
+#ifdef ENABLE_HANDSHAKE
+    bool enable_handshake_protocol = localhost->system_info->handshake_enabled &&
+                                     host->system_info->handshake_enabled;
+#else
+    bool enable_handshake_protocol = false;
+#endif
+
+    char http[HTTP_HEADER_SIZE + 1];
+    ssize_t received;
+
+    received = recv_timeout(sender_ssl(s), sender_sockfd(s), http, HTTP_HEADER_SIZE, 0, timeout);
+    if(received == -1) {
+        worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_TIMEOUT);
+        sender_error(s, "remote netdata does not respond");
+        rrdpush_sender_thread_close_socket(host);
+        return false;
+    }
+
+    http[received] = '\0';
+    debug(D_STREAM, "Response to sender from far end: %s", http);
+
+    if (enable_handshake_protocol && strstr(http, HANDSHAKE_PROTOCOL_PROMPT)) {
+        bool ok = drain_dummy_tcp_data(s, timeout, received, HANDSHAKE_PROTOCOL_INITIAL_RESPONSE_SIZE);
+        if (!ok) {
+            worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_TIMEOUT);
+            sender_error(s, "handshake protocol initialization failed.");
+            rrdpush_sender_thread_close_socket(host);
+            return false;
+        }
+
+        ok = sender_handshake_start(s);
+        if (!ok) {
+            worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_TIMEOUT);
+            sender_error(s, "handshake protocol initialization failed.");
+            rrdpush_sender_thread_close_socket(host);
+            return false;
+        }
+    }
+
+    int32_t version = (int32_t)parse_stream_version(host, http);
+    if(version == -1) {
+        worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_BAD_HANDSHAKE);
+        sender_error(s, "server is not replying properly (is it a netdata?).");
+        rrdpush_sender_thread_close_socket(host);
+        return false;
+    }
+    else if(version == -2) {
+        sender_error(s, "remote server is localhost");
+        rrdpush_sender_thread_close_socket(host);
+        host->destination->disabled_because_of_localhost = 1;
+        return false;
+    }
+    else if(version == -3) {
+        sender_error(s, "remote server already receives metrics for host '%s'", rrdhost_hostname(host));
+        rrdpush_sender_thread_close_socket(host);
+        host->destination->disabled_already_streaming = now_realtime_sec();
+        return false;
+    }
+    else if(version == -4) {
+        sender_error(s, "remote server denied access for [%s].", rrdhost_hostname(host));
+        rrdpush_sender_thread_close_socket(host);
+        if (host->destination->next)
+            host->destination->disabled_because_of_denied_access = 1;
+        return false;
+    }
+    s->version = version;
+
+    return true;
+}
+
+bool protocol_setup_on_receiver(struct receiver_state *rpt) {
+#ifdef ENABLE_HANDSHAKE
+    bool enable_handshake_protocol = localhost->system_info->handshake_enabled &&
+                                     rpt->system_info->handshake_enabled;
+#else
+    bool enable_handshake_protocol = false;
+#endif
+
+    info("STREAM %s [receive from [%s]:%s]: initializing communication...", rrdhost_hostname(rpt->host), rpt->client_ip, rpt->client_port);
+
+    char initial_response[HTTP_HEADER_SIZE];
+    memset(initial_response, 0, HTTP_HEADER_SIZE);
+
+    if (rpt->stream_version > 1) {
+        if(rpt->stream_version >= STREAM_VERSION_COMPRESSION){
+#ifdef ENABLE_COMPRESSION
+            if(!rpt->rrdpush_compression)
+                rpt->stream_version = STREAM_VERSION_CLABELS;
+#else
+            if(STREAMING_PROTOCOL_CURRENT_VERSION < rpt->stream_version)
+                rpt->stream_version =  STREAMING_PROTOCOL_CURRENT_VERSION;
+#endif
+        }
+        info("STREAM %s [receive from [%s]:%s]: Netdata is using the stream version %u.", rrdhost_hostname(rpt->host), rpt->client_ip, rpt->client_port, rpt->stream_version);
+        sprintf(initial_response, "%s%u", START_STREAMING_PROMPT_VN, rpt->stream_version);
+    } else if (rpt->stream_version == 1) {
+        info("STREAM %s [receive from [%s]:%s]: Netdata is using the stream version %u.", rrdhost_hostname(rpt->host), rpt->client_ip, rpt->client_port, rpt->stream_version);
+        sprintf(initial_response, "%s", START_STREAMING_PROMPT_V2);
+    } else {
+        info("STREAM %s [receive from [%s]:%s]: Netdata is using first stream protocol.", rrdhost_hostname(rpt->host), rpt->client_ip, rpt->client_port);
+        sprintf(initial_response, "%s", START_STREAMING_PROMPT);
+    }
+
+    if (enable_handshake_protocol) {
+        char handshake_response[HTTP_HEADER_SIZE];
+        memset(handshake_response, 0, HTTP_HEADER_SIZE);
+
+        sprintf(handshake_response, "%s&%s", initial_response, HANDSHAKE_PROTOCOL_PROMPT);
+        memcpy(initial_response, handshake_response, HTTP_HEADER_SIZE);
+    }
+
+    debug(D_STREAM, "Initial response to %s: %s", rpt->client_ip, initial_response);
+
+#ifdef ENABLE_HTTPS
+    rpt->host->stream_ssl.conn = rpt->ssl.conn;
+    rpt->host->stream_ssl.flags = rpt->ssl.flags;
+#endif
+
+    time_t timeout = 60;
+    ssize_t sent = strlen(initial_response);
+
+    if (send_timeout(&rpt->ssl, rpt->fd, initial_response, strlen(initial_response), 0, timeout) != sent) {
+        log_stream_connection(rpt->client_ip, rpt->client_port, rpt->key, rpt->host->machine_guid, rrdhost_hostname(rpt->host), "FAILED - CANNOT REPLY");
+        error("STREAM %s [receive from [%s]:%s]: cannot send ready command.", rrdhost_hostname(rpt->host), rpt->client_ip, rpt->client_port);
+        close(rpt->fd);
+        return false;
+    }
+    receiver_error(rpt, "sent initial response");
+
+    if (enable_handshake_protocol) {
+        bool ok = fill_dummy_tcp_data(rpt, timeout, sent, HANDSHAKE_PROTOCOL_INITIAL_RESPONSE_SIZE);
+        if (!ok) {
+            fatal("Could not fill all data");
+            return false;
+        }
+
+        return receiver_handshake_start(rpt);
+    }
+
+    return true;
+}

--- a/streaming/protocol/setup.h
+++ b/streaming/protocol/setup.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_PROTOCOL_SETUP_H
+#define NETDATA_PROTOCOL_SETUP_H
+
+#include "streaming/rrdpush.h"
+
+bool protocol_setup_on_receiver(struct receiver_state *rpt);
+bool protocol_setup_on_sender(struct sender_state *s, int timeout);
+
+#endif /* NETDATA_PROTOCOL_SETUP_H */

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -2,6 +2,7 @@
 
 #include "rrdpush.h"
 #include "parser/parser.h"
+#include "protocol/setup.h"
 
 #define WORKER_RECEIVER_JOB_BYTES_READ (WORKER_PARSER_FIRST_JOB - 1)
 
@@ -432,7 +433,6 @@ done:
     return result;
 }
 
-
 static int rrdpush_receive(struct receiver_state *rpt)
 {
     int history = default_rrd_history_entries;
@@ -497,10 +497,9 @@ static int rrdpush_receive(struct receiver_state *rpt)
 #ifdef ENABLE_HTTPS
         rpt->host->stream_ssl.conn = rpt->ssl.conn;
         rpt->host->stream_ssl.flags = rpt->ssl.flags;
-        if(send_timeout(&rpt->ssl, rpt->fd, initial_response, strlen(initial_response), 0, 60) != (ssize_t)strlen(initial_response)) {
-#else
-        if(send_timeout(rpt->fd, initial_response, strlen(initial_response), 0, 60) != strlen(initial_response)) {
 #endif
+
+        if(send_timeout(&rpt->ssl, rpt->fd, initial_response, strlen(initial_response), 0, 60) != (ssize_t)strlen(initial_response)) {
             log_stream_connection(rpt->client_ip, rpt->client_port, rpt->key, rpt->host->machine_guid, rrdhost_hostname(rpt->host), "FAILED - CANNOT REPLY");
             error("STREAM %s [receive from [%s]:%s]: cannot send command.", rrdhost_hostname(rpt->host), rpt->client_ip, rpt->client_port);
             close(rpt->fd);
@@ -620,41 +619,9 @@ static int rrdpush_receive(struct receiver_state *rpt)
     snprintfz(cd.fullfilename, FILENAME_MAX,     "%s:%s", rpt->client_ip, rpt->client_port);
     snprintfz(cd.cmd,          PLUGINSD_CMD_MAX, "%s:%s", rpt->client_ip, rpt->client_port);
 
-    info("STREAM %s [receive from [%s]:%s]: initializing communication...", rrdhost_hostname(rpt->host), rpt->client_ip, rpt->client_port);
-    char initial_response[HTTP_HEADER_SIZE];
-    if (rpt->stream_version > 1) {
-        if(rpt->stream_version >= STREAM_VERSION_COMPRESSION){
-#ifdef ENABLE_COMPRESSION
-            if(!rpt->rrdpush_compression)
-                rpt->stream_version = STREAM_VERSION_CLABELS;
-#else
-            if(STREAMING_PROTOCOL_CURRENT_VERSION < rpt->stream_version) {
-                rpt->stream_version =  STREAMING_PROTOCOL_CURRENT_VERSION;               
-            }
-#endif
-        }
-        info("STREAM %s [receive from [%s]:%s]: Netdata is using the stream version %u.", rrdhost_hostname(rpt->host), rpt->client_ip, rpt->client_port, rpt->stream_version);
-        sprintf(initial_response, "%s%u", START_STREAMING_PROMPT_VN, rpt->stream_version);
-    } else if (rpt->stream_version == 1) {
-        info("STREAM %s [receive from [%s]:%s]: Netdata is using the stream version %u.", rrdhost_hostname(rpt->host), rpt->client_ip, rpt->client_port, rpt->stream_version);
-        sprintf(initial_response, "%s", START_STREAMING_PROMPT_V2);
-    } else {
-        info("STREAM %s [receive from [%s]:%s]: Netdata is using first stream protocol.", rrdhost_hostname(rpt->host), rpt->client_ip, rpt->client_port);
-        sprintf(initial_response, "%s", START_STREAMING_PROMPT);
-    }
-    debug(D_STREAM, "Initial response to %s: %s", rpt->client_ip, initial_response);
-    #ifdef ENABLE_HTTPS
-    rpt->host->stream_ssl.conn = rpt->ssl.conn;
-    rpt->host->stream_ssl.flags = rpt->ssl.flags;
-    if(send_timeout(&rpt->ssl, rpt->fd, initial_response, strlen(initial_response), 0, 60) != (ssize_t)strlen(initial_response)) {
-#else
-    if(send_timeout(rpt->fd, initial_response, strlen(initial_response), 0, 60) != strlen(initial_response)) {
-#endif
-        log_stream_connection(rpt->client_ip, rpt->client_port, rpt->key, rpt->host->machine_guid, rrdhost_hostname(rpt->host), "FAILED - CANNOT REPLY");
-        error("STREAM %s [receive from [%s]:%s]: cannot send ready command.", rrdhost_hostname(rpt->host), rpt->client_ip, rpt->client_port);
-        close(rpt->fd);
+    bool ok = protocol_setup_on_receiver(rpt);
+    if (!ok)
         return 0;
-    }
 
     // remove the non-blocking flag from the socket
     if(sock_delnonblock(rpt->fd) < 0)
@@ -780,4 +747,3 @@ void *rrdpush_receiver_thread(void *ptr) {
     netdata_thread_cleanup_pop(1);
     return NULL;
 }
-

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -8,6 +8,29 @@
 #include "web/server/web_client.h"
 #include "daemon/common.h"
 
+#define WORKER_SENDER_JOB_CONNECT                    0
+#define WORKER_SENDER_JOB_PIPE_READ                  1
+#define WORKER_SENDER_JOB_SOCKET_RECEIVE             2
+#define WORKER_SENDER_JOB_EXECUTE                    3
+#define WORKER_SENDER_JOB_SOCKET_SEND                4
+#define WORKER_SENDER_JOB_DISCONNECT_BAD_HANDSHAKE   5
+#define WORKER_SENDER_JOB_DISCONNECT_OVERFLOW        6
+#define WORKER_SENDER_JOB_DISCONNECT_TIMEOUT         7
+#define WORKER_SENDER_JOB_DISCONNECT_POLL_ERROR      8
+#define WORKER_SENDER_JOB_DISCONNECT_SOCKER_ERROR    9
+#define WORKER_SENDER_JOB_DISCONNECT_SSL_ERROR      10
+#define WORKER_SENDER_JOB_DISCONNECT_PARENT_CLOSED  11
+#define WORKER_SENDER_JOB_DISCONNECT_RECEIVE_ERROR  12
+#define WORKER_SENDER_JOB_DISCONNECT_SEND_ERROR     13
+#define WORKER_SENDER_JOB_DISCONNECT_NO_COMPRESSION 14
+#define WORKER_SENDER_JOB_BUFFER_RATIO              15
+#define WORKER_SENDER_JOB_BYTES_RECEIVED            16
+#define WORKER_SENDER_JOB_BYTES_SENT                17
+
+#if WORKER_UTILIZATION_MAX_JOB_TYPES < 18
+#error WORKER_UTILIZATION_MAX_JOB_TYPES has to be at least 18
+#endif
+
 #define CONNECTED_TO_SIZE 100
 
 #define STREAM_VERSION_CLAIM 3
@@ -25,6 +48,7 @@
 #define START_STREAMING_PROMPT "Hit me baby, push them over..."
 #define START_STREAMING_PROMPT_V2  "Hit me baby, push them over and bring the host labels..."
 #define START_STREAMING_PROMPT_VN "Hit me baby, push them over with the version="
+#define HANDSHAKE_PROTOCOL_PROMPT "handshake_protocol=1"
 
 #define START_STREAMING_ERROR_SAME_LOCALHOST "Don't hit me baby, you are trying to stream my localhost back"
 #define START_STREAMING_ERROR_ALREADY_STREAMING "This GUID is already streaming to this server"
@@ -194,5 +218,7 @@ struct compressor_state *create_compressor();
 struct decompressor_state *create_decompressor();
 size_t is_compressed_data(const char *data, size_t data_size);
 #endif
+
+void rrdpush_sender_thread_close_socket(RRDHOST *host);
 
 #endif //NETDATA_RRDPUSH_H

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -1,29 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "rrdpush.h"
-
-#define WORKER_SENDER_JOB_CONNECT                    0
-#define WORKER_SENDER_JOB_PIPE_READ                  1
-#define WORKER_SENDER_JOB_SOCKET_RECEIVE             2
-#define WORKER_SENDER_JOB_EXECUTE                    3
-#define WORKER_SENDER_JOB_SOCKET_SEND                4
-#define WORKER_SENDER_JOB_DISCONNECT_BAD_HANDSHAKE   5
-#define WORKER_SENDER_JOB_DISCONNECT_OVERFLOW        6
-#define WORKER_SENDER_JOB_DISCONNECT_TIMEOUT         7
-#define WORKER_SENDER_JOB_DISCONNECT_POLL_ERROR      8
-#define WORKER_SENDER_JOB_DISCONNECT_SOCKER_ERROR    9
-#define WORKER_SENDER_JOB_DISCONNECT_SSL_ERROR      10
-#define WORKER_SENDER_JOB_DISCONNECT_PARENT_CLOSED  11
-#define WORKER_SENDER_JOB_DISCONNECT_RECEIVE_ERROR  12
-#define WORKER_SENDER_JOB_DISCONNECT_SEND_ERROR     13
-#define WORKER_SENDER_JOB_DISCONNECT_NO_COMPRESSION 14
-#define WORKER_SENDER_JOB_BUFFER_RATIO              15
-#define WORKER_SENDER_JOB_BYTES_RECEIVED            16
-#define WORKER_SENDER_JOB_BYTES_SENT                17
-
-#if WORKER_UTILIZATION_MAX_JOB_TYPES < 18
-#error WORKER_UTILIZATION_MAX_JOB_TYPES has to be at least 18
-#endif
+#include "protocol/setup.h"
 
 extern struct config stream_config;
 extern int netdata_use_ssl_on_stream;
@@ -40,8 +18,6 @@ void sender_cancel(struct sender_state *s) {
     buffer_flush(s->build);
     netdata_mutex_unlock(&s->mutex);
 }
-
-static inline void rrdpush_sender_thread_close_socket(RRDHOST *host);
 
 #ifdef ENABLE_COMPRESSION
 /*
@@ -111,17 +87,6 @@ void sender_commit(struct sender_state *s) {
 
     buffer_flush(s->build);
     netdata_mutex_unlock(&s->mutex);
-}
-
-
-static inline void rrdpush_sender_thread_close_socket(RRDHOST *host) {
-    rrdhost_flag_clear(host, RRDHOST_FLAG_STREAM_COLLECTED_METRICS);
-    __atomic_clear(&host->rrdpush_sender_connected, __ATOMIC_SEQ_CST);
-
-    if(host->rrdpush_sender_socket != -1) {
-        close(host->rrdpush_sender_socket);
-        host->rrdpush_sender_socket = -1;
-    }
 }
 
 static inline void rrdpush_sender_add_host_variable_to_buffer_nolock(RRDHOST *host, const RRDVAR_ACQUIRED *rva) {
@@ -199,11 +164,6 @@ static inline void rrdpush_sender_thread_data_flush(RRDHOST *host) {
     rrdpush_sender_thread_send_custom_host_variables(host);
 }
 
-static inline void rrdpush_set_flags_to_newest_stream(RRDHOST *host) {
-    rrdhost_flag_set(host, RRDHOST_FLAG_STREAM_LABELS_UPDATE);
-    rrdhost_flag_clear(host, RRDHOST_FLAG_STREAM_LABELS_STOP);
-}
-
 void rrdpush_encode_variable(stream_encoded_t *se, RRDHOST *host)
 {
     se->os_name = (host->system_info->host_os_name)?url_encode(host->system_info->host_os_name):"";
@@ -229,50 +189,6 @@ void rrdpush_clean_encoded(stream_encoded_t *se)
 
     if (se->kernel_version)
         freez(se->kernel_version);
-}
-
-static inline long int parse_stream_version_for_errors(char *http)
-{
-    if (!memcmp(http, START_STREAMING_ERROR_SAME_LOCALHOST, sizeof(START_STREAMING_ERROR_SAME_LOCALHOST)))
-        return -2;
-    else if (!memcmp(http, START_STREAMING_ERROR_ALREADY_STREAMING, sizeof(START_STREAMING_ERROR_ALREADY_STREAMING)))
-        return -3;
-    else if (!memcmp(http, START_STREAMING_ERROR_NOT_PERMITTED, sizeof(START_STREAMING_ERROR_NOT_PERMITTED)))
-        return -4;
-    else
-        return -1;
-}
-
-static inline long int parse_stream_version(RRDHOST *host, char *http)
-{
-    long int stream_version = -1;
-    int answer = -1;
-    char *stream_version_start = strchr(http, '=');
-    if (stream_version_start) {
-        stream_version_start++;
-        stream_version = strtol(stream_version_start, NULL, 10);
-        answer = memcmp(http, START_STREAMING_PROMPT_VN, (size_t)(stream_version_start - http));
-        if (!answer) {
-            rrdpush_set_flags_to_newest_stream(host);
-        }
-    } else {
-        answer = memcmp(http, START_STREAMING_PROMPT_V2, strlen(START_STREAMING_PROMPT_V2));
-        if (!answer) {
-            stream_version = 1;
-            rrdpush_set_flags_to_newest_stream(host);
-        } else {
-            answer = memcmp(http, START_STREAMING_PROMPT, strlen(START_STREAMING_PROMPT));
-            if (!answer) {
-                stream_version = 0;
-                rrdhost_flag_set(host, RRDHOST_FLAG_STREAM_LABELS_STOP);
-                rrdhost_flag_clear(host, RRDHOST_FLAG_STREAM_LABELS_UPDATE);
-            }
-            else {
-                stream_version = parse_stream_version_for_errors(http);
-            }
-        }
-    }
-    return stream_version;
 }
 
 static int rrdpush_sender_thread_connect_to_parent(RRDHOST *host, int default_port, int timeout,
@@ -366,6 +282,7 @@ if(!s->rrdpush_compression)
                  "&mc_version=%d"
                  "&tags=%s"
                  "&ver=%d"
+                 "&handshake_enabled=%d"
                  "&NETDATA_INSTANCE_CLOUD_TYPE=%s"
                  "&NETDATA_INSTANCE_CLOUD_INSTANCE_TYPE=%s"
                  "&NETDATA_INSTANCE_CLOUD_INSTANCE_REGION=%s"
@@ -412,6 +329,7 @@ if(!s->rrdpush_compression)
                  , host->system_info->mc_version
                  , rrdhost_tags(host)
                  , s->version
+                 , host->system_info->handshake_enabled
                  , (host->system_info->cloud_provider_type) ? host->system_info->cloud_provider_type : ""
                  , (host->system_info->cloud_instance_type) ? host->system_info->cloud_instance_type : ""
                  , (host->system_info->cloud_instance_region) ? host->system_info->cloud_instance_region : ""
@@ -479,10 +397,9 @@ if(!s->rrdpush_compression)
             }
         }
     }
-    if(send_timeout(&host->ssl,host->rrdpush_sender_socket, http, strlen(http), 0, timeout) == -1) {
-#else
-    if(send_timeout(host->rrdpush_sender_socket, http, strlen(http), 0, timeout) == -1) {
 #endif
+
+    if(send_timeout(&host->ssl,host->rrdpush_sender_socket, http, strlen(http), 0, timeout) == -1) {
         worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_TIMEOUT);
         error("STREAM %s [send to %s]: failed to send HTTP header to remote netdata.", rrdhost_hostname(host), s->connected_to);
         rrdpush_sender_thread_close_socket(host);
@@ -491,52 +408,9 @@ if(!s->rrdpush_compression)
 
     info("STREAM %s [send to %s]: waiting response from remote netdata...", rrdhost_hostname(host), s->connected_to);
 
-    ssize_t received;
-#ifdef ENABLE_HTTPS
-    received = recv_timeout(&host->ssl,host->rrdpush_sender_socket, http, HTTP_HEADER_SIZE, 0, timeout);
-    if(received == -1) {
-#else
-    received = recv_timeout(host->rrdpush_sender_socket, http, HTTP_HEADER_SIZE, 0, timeout);
-    if(received == -1) {
-#endif
-        worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_TIMEOUT);
-        error("STREAM %s [send to %s]: remote netdata does not respond.", rrdhost_hostname(host), s->connected_to);
-        rrdpush_sender_thread_close_socket(host);
+    bool ok = protocol_setup_on_sender(s, timeout);
+    if (!ok)
         return 0;
-    }
-
-    http[received] = '\0';
-    debug(D_STREAM, "Response to sender from far end: %s", http);
-    int32_t version = (int32_t)parse_stream_version(host, http);
-    if(version == -1) {
-        worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_BAD_HANDSHAKE);
-        error("STREAM %s [send to %s]: server is not replying properly (is it a netdata?).", rrdhost_hostname(host), s->connected_to);
-        rrdpush_sender_thread_close_socket(host);
-        //catch other reject reasons and force to check other destinations
-        if (host->destination->next)
-            host->destination->disabled_no_proper_reply = 1;
-        return 0;
-    }
-    else if(version == -2) {
-        error("STREAM %s [send to %s]: remote server is the localhost for [%s].", rrdhost_hostname(host), s->connected_to, rrdhost_hostname(host));
-        rrdpush_sender_thread_close_socket(host);
-        host->destination->disabled_because_of_localhost = 1;
-        return 0;
-    }
-    else if(version == -3) {
-        error("STREAM %s [send to %s]: remote server already receives metrics for [%s].", rrdhost_hostname(host), s->connected_to, rrdhost_hostname(host));
-        rrdpush_sender_thread_close_socket(host);
-        host->destination->disabled_already_streaming = now_realtime_sec();
-        return 0;
-    }
-    else if(version == -4) {
-        error("STREAM %s [send to %s]: remote server denied access for [%s].", rrdhost_hostname(host), s->connected_to, rrdhost_hostname(host));
-        rrdpush_sender_thread_close_socket(host);
-        if (host->destination->next)
-            host->destination->disabled_because_of_denied_access = 1;
-        return 0;
-    }
-    s->version = version;
 
 #ifdef ENABLE_COMPRESSION
     s->rrdpush_compression = (s->rrdpush_compression && (s->version >= STREAM_VERSION_COMPRESSION));
@@ -551,7 +425,7 @@ if(!s->rrdpush_compression)
         debug(D_STREAM, "Stream is uncompressed! One of the agents (%s <-> %s) does not support compression OR compression is disabled.", s->connected_to, rrdhost_hostname(s->host));
         infoerr("Stream is uncompressed! One of the agents (%s <-> %s) does not support compression OR compression is disabled.", s->connected_to, rrdhost_hostname(s->host));
         s->version = STREAM_VERSION_CLABELS;
-    }        
+    }
 #endif  //ENABLE_COMPRESSION
 
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1247,6 +1247,8 @@ inline int web_client_api_request_v1_info_fill_buffer(RRDHOST *host, BUFFER *wb)
     analytics_get_data(analytics_data.netdata_config_stream_enabled, wb);
     buffer_strcat(wb, ",\n");
 
+    buffer_sprintf(wb, "\t\"handshake-enabled\": %s,\n", host->system_info->handshake_enabled ? "true" : "false");
+
 #ifdef  ENABLE_COMPRESSION
     if(host->sender){
         buffer_strcat(wb, "\t\"stream-compression\": ");


### PR DESCRIPTION
##### Summary

  - A child connects to a parent via a HTTP request.
  - If the request contains the parameter "enable_handshake" the parent knows that the child supports communication via protobuf messages, otherwise it's simply ignored.
  - If the "enable_handshake" parameter was set by the child, the parent *appends* the "&handshake_protocol=1" string to the version.
  - A child that supports protobuf messages will (a) exchange any custom messages with the parent, and (b) the usual version parsing logic will run afterwards.

A couple of notes regarding the implementation:

  - New functions where added to libnetdata/socket/* that process the entire input/output buffer of send/receive system calls.
  - A careful dance needs to happen in a child in between the receival of the stream version prompt and before passing control to the code that is responsible for exchanging protobuf messages. This is due to the fact that the first recv() performed by a child performs a partial read.
  - The stream that transfers protocol messages is length-coded, ie. we prepend the size of each message prior to sending/receiving the actual message.
  - Everything related to version negotiation has been moved to streaming/protocol/setup.{c,h} to keep the code under streaming/{sender,receiver,rrdpush}.{c,h} maintainable and easier to understand.

##### Test Plan

- Test every child/parent combination with/without this patch. Streaming should work correctly.