### PR TITLE
Fix handling of temporary directories in kickstart code.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -515,7 +515,7 @@ create_tmp_directory() {
 }
 
 set_tmpdir() {
-  if [ -z "${tmpdir}" ]; then
+  if [ -z "${tmpdir}" ] || [ ! -d "${tmpdir}" ]; then
     tmpdir="$(create_tmp_directory)"
     progress "Using ${tmpdir} as a temporary directory."
     cd "${tmpdir}" || fatal "Failed to change current working directory to ${tmpdir}." F000A


### PR DESCRIPTION
##### Summary

Instead of just checking whether the `$tmpdir` variable is set and short-circuiting if it is, we should additionally check if the directory it references exists. This ensures that code that needs to use temporary directories can do so even if earlier code calls `cleanup()`.

##### Test Plan

See the steps to reproduce in #13741. When they are attempted using the kickstart script from this PR, things should work correctly instead of failing as outlined in that issue.

##### Additional Information

Fixes: #13741 