### PR TITLE
Add CloudLinux OS detection to kickstart

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -607,7 +607,7 @@ get_system_info() {
             opensuse-leap)
                 DISTRO_COMPAT_NAME="opensuse"
                 ;;
-            almalinux|rocky|rhel)
+            cloudlinux|almalinux|rocky|rhel)
                 DISTRO_COMPAT_NAME="centos"
                 ;;
             *)


### PR DESCRIPTION
##### Summary
Using the kickstart script on systems using CloudLinux OS will always fall back to building from source, rather than using the native packages available through yum. This PR adds CloudLinux to the list of CentOS forks so that the kickstart script checks for the native packages instead of skipping them.

##### Test Plan
Successfully tested this change on several CloudLinux OS systems that were previously failing to check for native packages.

##### Additional Information
Fixes: #13748 
