### PR TITLE
Add CloudLinux OS detection to the updater script

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -691,7 +691,7 @@ update_binpkg() {
       opensuse-leap)
         DISTRO_COMPAT_NAME="opensuse"
         ;;
-      almalinux|rocky|rhel)
+      cloudlinux|almalinux|rocky|rhel)
         DISTRO_COMPAT_NAME="centos"
         ;;
       *)


### PR DESCRIPTION
##### Summary
The netdata updater also doesn't have CloudLinux OS detection, thus resulting in a warning when installing.
`WARNING: netdata-updater.sh:  We do not provide native packages for cloudlinux.`

##### Test Plan
Tested as working on our CloudLinux machines

##### Additional Information
Related to: #13750 
