### PR TITLE
Fix streaming crash when child reconnects and is archived on the parent

### DIFF
--- a/daemon/service.c
+++ b/daemon/service.c
@@ -23,7 +23,7 @@
 static void svc_rrddim_obsolete_to_archive(RRDDIM *rd) {
     RRDSET *st = rd->rrdset;
 
-    if(rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED | RRDDIM_FLAG_ACLK) || !rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE))
+    if(rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED) || !rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE))
         return;
 
     worker_is_busy(WORKER_JOB_ARCHIVE_DIMENSION);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -632,6 +632,9 @@ void rrdhost_update(RRDHOST *host
         if(!host->rrdlabels)
             host->rrdlabels = rrdlabels_create();
 
+        if (!host->rrdset_root_index)
+            rrdset_index_init(host);
+
         rrdhost_initialize_rrdpush(host,
                                    rrdpush_enabled,
                                    rrdpush_destination,


### PR DESCRIPTION
##### Summary
During a parent child setup, if the child disconnects and the parent removes it's data from memory (default 3600 seconds)
when the child tries to reconnects the parent will crash


##### Test Plan
- Setup a parent and child, configure the parent with a short child removal 
  -  e.g `cleanup orphan hosts after seconds = 30`
- Start the parent and child
- Disconnect the child and wait for the child to be removed from memory
  - Notice a message in the error.log such as
   `Host 'xxxxx' with machine guid 'xxxxxx' is obsolete - cleaning up.`
- Restart the child and notice the crash
- Retest after applying the PR

