### PR TITLE
Count currently streaming senders on the localhost

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -1182,3 +1182,10 @@ void add_aclk_host_labels(void) {
     rrdlabels_add(labels, "_aclk_available", "false", RRDLABEL_SRC_AUTO|RRDLABEL_SRC_ACLK);
 #endif
 }
+
+void aclk_queue_node_info(RRDHOST *host) {
+    struct aclk_database_worker_config *wc = (struct aclk_database_worker_config *) host->dbsync_worker;
+    if (likely(wc)) {
+        wc->node_info_send = 1;
+    }
+}

--- a/aclk/aclk.h
+++ b/aclk/aclk.h
@@ -54,5 +54,6 @@ void aclk_send_bin_msg(char *msg, size_t msg_len, enum aclk_topics subtopic, con
 char *aclk_state(void);
 char *aclk_state_json(void);
 void add_aclk_host_labels(void);
+void aclk_queue_node_info(RRDHOST *host);
 
 #endif /* ACLK_H */

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -244,7 +244,7 @@ void rrdlabels_copy(DICTIONARY *dst, DICTIONARY *src);
 void reload_host_labels(void);
 void rrdset_update_rrdlabels(RRDSET *st, DICTIONARY *new_rrdlabels);
 void rrdset_save_rrdlabels_to_sql(RRDSET *st);
-
+void rrdhost_set_is_parent_label(int count);
 int rrdlabels_unittest(void);
 
 // unfortunately this break when defined in exporting_engine.h
@@ -926,6 +926,7 @@ struct rrdhost {
     time_t senders_connect_time;                    // the time the last sender was connected
     time_t senders_last_chart_command;              // the time of the last CHART streaming command
     time_t senders_disconnected_time;               // the time the last sender was disconnected
+    int senders_count;                              // number of senders currently streaming
 
     struct receiver_state *receiver;
     netdata_mutex_t receiver_lock;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1306,10 +1306,26 @@ static void rrdhost_load_auto_labels(void) {
     health_add_host_labels();
 
     rrdlabels_add(
-        labels, "_is_parent", (rrdhost_hosts_available() > 1 || configured_as_parent()) ? "true" : "false", RRDLABEL_SRC_AUTO);
+        labels, "_is_parent", (localhost->senders_count > 0) ? "true" : "false", RRDLABEL_SRC_AUTO);
 
     if (localhost->rrdpush_send_destination)
         rrdlabels_add(labels, "_streams_to", localhost->rrdpush_send_destination, RRDLABEL_SRC_AUTO);
+}
+
+void rrdhost_set_is_parent_label(int count) {
+    DICTIONARY *labels = localhost->rrdlabels;
+
+    if (count == 0 || count == 1) {
+        rrdlabels_add(
+                      labels, "_is_parent", (count) ? "true" : "false", RRDLABEL_SRC_AUTO);
+
+        //queue a node info
+#ifdef ENABLE_ACLK
+        if (netdata_cloud_setting) {
+            aclk_queue_node_info(localhost);
+        }
+#endif
+    }
 }
 
 static void rrdhost_load_config_labels(void) {

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -747,6 +747,7 @@ static int rrdpush_receive(struct receiver_state *rpt)
     rpt->host->senders_connect_time = now_realtime_sec();
     rpt->host->senders_last_chart_command = 0;
     rpt->host->trigger_chart_obsoletion_check = 1;
+
     rrdhost_unlock(rpt->host);
 
     // call the plugins.d processor to receive the metrics
@@ -762,6 +763,8 @@ static int rrdpush_receive(struct receiver_state *rpt)
         aclk_host_state_update(rpt->host, 1);
 #endif
 
+    rrdhost_set_is_parent_label(++localhost->senders_count);
+
     rrdcontext_host_child_connected(rpt->host);
 
     size_t count = streaming_parser(rpt, &cd, fp_in, fp_out);
@@ -775,10 +778,12 @@ static int rrdpush_receive(struct receiver_state *rpt)
 
 #ifdef ENABLE_ACLK
     // in case we have cloud connection we inform cloud
-    // new child connected
+    // a child disconnected
     if (netdata_cloud_setting)
         aclk_host_state_update(rpt->host, 0);
 #endif
+
+    rrdhost_set_is_parent_label(--localhost->senders_count);
 
     // During a shutdown there is cleanup code in rrdhost that will cancel the sender thread
     if (!netdata_exit && rpt->host) {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->
Fixes https://github.com/netdata/netdata-cloud/issues/598

![image](https://user-images.githubusercontent.com/1905463/193616745-8b949b3f-78d1-479e-83d4-36e5fe0eaf0e.png)

The above image on cloud, on Home tab, shows the current status of streaming for the nodes on that room.

The number of parents is taken from the count of host's labels `_is_parent = true`, and of the children from the same label being `false`.

Currently we mark a localhost as a parent just because it has been configured as a parent, or there are more than one hosts in memory.

We would like instead to show there as parent only those hosts that are currently receiving metrics from other hosts. This PR adds a counter on localhost of how many senders are currently streaming to it. Depending on this counter it will adjust the `_is_parent` label, and send an `UpdateNodeInfo` message to send it to the cloud.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Observe the above part of the cloud Home tab, with and without this PR.
If there is a child-parent relationship, without this PR when the child disconnects we still show one node in the room as acting as parent (when in fact it's not).
With this PR when the child disconnects it should list both nodes as children.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
