### PR TITLE
Use ln instead of ls to detect glibc

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -747,9 +747,9 @@ detect_libc() {
     echo >&2 " Detected musl"
     libc="musl"
   else
-    ls_path=$(command -v ls)
-    if [ -n "${ls_path}" ] ; then
-      cmd=$(ldd "$ls_path" | grep -w libc | cut -d" " -f 3)
+    ln_path=$(command -v ln)
+    if [ -n "${ln_path}" ] ; then
+      cmd=$(ldd "$ln_path" | grep -w libc | cut -d" " -f 3)
       if bash -c "${cmd}" 2>&1 | grep -q -i "GNU C Library"; then
         echo >&2 " Detected GLIBC"
         libc="glibc"


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #13718 

On some systems (as in Gentoo), `ls` might be aliased to e.g. `ls --color=auto`. That could make the ldd check on it fail to detect ebpf glibc or musl.

`ln` should most likely not be aliased, it is not commonly replaced by shell versions, is provided from the same coreutils package, and should be safer.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

On a gentoo system (which ldd checks fail), alias in `/etc/profile.d/aliases.sh` `ls` as e.g. `alias ls="ls --color=auto"`. Try the netdata-installer.sh script.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
