### PR TITLE
Support HTTP proxy Basic auth

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -512,7 +512,7 @@ static int aclk_attempt_to_connect(mqtt_wss_client client)
         }
 
         struct mqtt_wss_proxy proxy_conf = { .host = NULL, .port = 0, .username = NULL, .password = NULL, .type = MQTT_WSS_DIRECT };
-        aclk_set_proxy((char**)&proxy_conf.host, &proxy_conf.port, &proxy_conf.type);
+        aclk_set_proxy((char**)&proxy_conf.host, &proxy_conf.port, (char**)&proxy_conf.username, (char**)&proxy_conf.password, &proxy_conf.type);
 
         struct mqtt_connect_params mqtt_conn_params = {
             .clientid   = "anon",
@@ -610,7 +610,10 @@ static int aclk_attempt_to_connect(mqtt_wss_client client)
         freez((char*)mqtt_conn_params.username);
 #endif
 
-        freez((char *)mqtt_conn_params.will_msg);
+        freez((char*)mqtt_conn_params.will_msg);
+        freez((char*)proxy_conf.host);
+        freez((char*)proxy_conf.username);
+        freez((char*)proxy_conf.password);
 
         if (!ret) {
             last_conn_time_mqtt = now_realtime_sec();

--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -14,7 +14,7 @@ static int aclk_https_request(https_req_t *request, https_req_response_t *respon
     // wrapper for ACLK only which loads ACLK specific proxy settings
     // then only calls https_request
     struct mqtt_wss_proxy proxy_conf = { .host = NULL, .port = 0, .username = NULL, .password = NULL, .type = MQTT_WSS_DIRECT };
-    aclk_set_proxy((char**)&proxy_conf.host, &proxy_conf.port, &proxy_conf.type);
+    aclk_set_proxy((char**)&proxy_conf.host, &proxy_conf.port, (char**)&proxy_conf.username, (char**)&proxy_conf.password, &proxy_conf.type);
 
     if (proxy_conf.type == MQTT_WSS_PROXY_HTTP) {
         request->proxy_host = (char*)proxy_conf.host; // TODO make it const as well
@@ -23,6 +23,8 @@ static int aclk_https_request(https_req_t *request, https_req_response_t *respon
 
     rc = https_request(request, response);
     freez((char*)proxy_conf.host);
+    freez((char*)proxy_conf.username);
+    freez((char*)proxy_conf.password);
     return rc;
 }
 

--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -19,6 +19,8 @@ static int aclk_https_request(https_req_t *request, https_req_response_t *respon
     if (proxy_conf.type == MQTT_WSS_PROXY_HTTP) {
         request->proxy_host = (char*)proxy_conf.host; // TODO make it const as well
         request->proxy_port = proxy_conf.port;
+        request->proxy_username = proxy_conf.username;
+        request->proxy_password = proxy_conf.password;
     }
 
     rc = https_request(request, response);
@@ -302,25 +304,6 @@ inline static int base64_decode_helper(unsigned char *out, int *outl, const unsi
         error("Unexpected data at EVP_DecodeFinal");
         return 1;
     }
-    return 0;
-}
-
-inline static int base64_encode_helper(unsigned char *out, int *outl, const unsigned char *in, int in_len)
-{
-    int len;
-    unsigned char *str = out;
-    EVP_ENCODE_CTX *ctx = EVP_ENCODE_CTX_new();
-    EVP_EncodeInit(ctx);
-    EVP_EncodeUpdate(ctx, str, outl, in, in_len);
-    str += *outl;
-    EVP_EncodeFinal(ctx, str, &len);
-    *outl += len;
-    // if we ever expect longer output than what OpenSSL would pack into single line
-    // we would have to skip the endlines, until then we can just cut the string short
-    str = (unsigned char*)strchr((char*)out, '\n');
-    if (str)
-        *str = 0;
-    EVP_ENCODE_CTX_free(ctx);
     return 0;
 }
 

--- a/aclk/aclk_util.h
+++ b/aclk/aclk_util.h
@@ -107,6 +107,6 @@ extern volatile int aclk_conversation_log_counter;
 unsigned long int aclk_tbeb_delay(int reset, int base, unsigned long int min, unsigned long int max);
 #define aclk_tbeb_reset(x) aclk_tbeb_delay(1, 0, 0, 0)
 
-void aclk_set_proxy(char **ohost, int *port, enum mqtt_wss_proxy_type *type);
+void aclk_set_proxy(char **ohost, int *port, char **uname, char **pwd, enum mqtt_wss_proxy_type *type);
 
 #endif /* ACLK_UTIL_H */

--- a/aclk/aclk_util.h
+++ b/aclk/aclk_util.h
@@ -109,4 +109,6 @@ unsigned long int aclk_tbeb_delay(int reset, int base, unsigned long int min, un
 
 void aclk_set_proxy(char **ohost, int *port, char **uname, char **pwd, enum mqtt_wss_proxy_type *type);
 
+int base64_encode_helper(unsigned char *out, int *outl, const unsigned char *in, int in_len);
+
 #endif /* ACLK_UTIL_H */

--- a/aclk/https_client.c
+++ b/aclk/https_client.c
@@ -404,6 +404,9 @@ static int handle_http_request(https_req_ctx_t *ctx) {
         strcpy(ptr, ctx->request->proxy_password);
 
         int creds_base64_len = (((4 * creds_plain_len / 3) + 3) & ~3);
+        // OpenSSL encoder puts newline every 64 output bytes
+        // we remove those but during encoding we need that space in the buffer
+        creds_base64_len += (1+(creds_base64_len/64)) * strlen("\n");
         char *creds_base64 = callocz(1, creds_base64_len + 1);
         base64_encode_helper((unsigned char*)creds_base64, &creds_base64_len, (unsigned char*)creds_plain, creds_plain_len);
         buffer_sprintf(hdr, "Proxy-Authorization: Basic %s\x0D\x0A", creds_base64);

--- a/aclk/https_client.c
+++ b/aclk/https_client.c
@@ -6,6 +6,8 @@
 
 #include "mqtt_websockets/c-rbuf/include/ringbuffer.h"
 
+#include "aclk_util.h"
+
 enum http_parse_state {
     HTTP_PARSE_INITIAL = 0,
     HTTP_PARSE_HEADERS,
@@ -392,6 +394,21 @@ static int handle_http_request(https_req_ctx_t *ctx) {
     if (ctx->request->request_type == HTTP_REQ_POST && ctx->request->payload && ctx->request->payload_size) {
         buffer_sprintf(hdr, "Content-Length: %zu\x0D\x0A", ctx->request->payload_size);
     }
+    if (ctx->request->proxy_username) {
+        size_t creds_plain_len = strlen(ctx->request->proxy_username) + strlen(ctx->request->proxy_password) + 1 /* ':' */;
+        char *creds_plain = callocz(1, creds_plain_len + 1);
+        char *ptr = creds_plain;
+        strcpy(ptr, ctx->request->proxy_username);
+        ptr += strlen(ctx->request->proxy_username);
+        *ptr++ = ':';
+        strcpy(ptr, ctx->request->proxy_password);
+
+        int creds_base64_len = (((4 * creds_plain_len / 3) + 3) & ~3);
+        char *creds_base64 = callocz(1, creds_base64_len + 1);
+        base64_encode_helper((unsigned char*)creds_base64, &creds_base64_len, (unsigned char*)creds_plain, creds_plain_len);
+        buffer_sprintf(hdr, "Proxy-Authorization: Basic %s\x0D\x0A", creds_base64);
+        freez(creds_plain);
+    }
 
     buffer_strcat(hdr, "\x0D\x0A");
 
@@ -491,6 +508,8 @@ int https_request(https_req_t *request, https_req_response_t *response) {
         req.host = request->host;
         req.port = request->port;
         req.url = request->url;
+        req.proxy_username = request->proxy_username;
+        req.proxy_password = request->proxy_password;
         ctx->request = &req;
         if (handle_http_request(ctx)) {
             error("Failed to CONNECT with proxy");

--- a/aclk/https_client.h
+++ b/aclk/https_client.h
@@ -25,8 +25,8 @@ typedef struct {
 
     char *proxy_host;
     int proxy_port;
-    char *proxy_username;
-    char *proxy_password;
+    const char *proxy_username;
+    const char *proxy_password;
 } https_req_t;
 
 typedef struct {

--- a/aclk/https_client.h
+++ b/aclk/https_client.h
@@ -25,6 +25,8 @@ typedef struct {
 
     char *proxy_host;
     int proxy_port;
+    char *proxy_username;
+    char *proxy_password;
 } https_req_t;
 
 typedef struct {


### PR DESCRIPTION
##### Summary

Fixes #12629

##### Test Plan
Squid http proxy with Basic auth user and pass should work now

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
ACLK
- Can they see the change or is it an under the hood? If they can see it, where?
Visible
- How is the user impacted by the change? 
Now can use authenticated http proxy
- What are there any benefits of the change? 
detto
-->
</details>
