### PR TITLE
Rename variable for old CentOS version

### DIFF
--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -161,7 +161,7 @@ static SSL_CTX * security_initialize_openssl_server() {
         return NULL;
     }
 
-    SSL_CTX_use_certificate_file(ctx, ssl_security_cert, SSL_FILETYPE_PEM);
+    SSL_CTX_use_certificate_file(ctx, netdata_ssl_security_cert, SSL_FILETYPE_PEM);
 #else
     ctx = SSL_CTX_new(TLS_server_method());
     if (!ctx) {


### PR DESCRIPTION
##### Summary
When we modified `ssl` variables, there was one that were not modified and it affects all ancient versions of OpenSSL. This PR is renaming it.

##### Test Plan

1. Compile `netdata` on `CentOS 7.9` and verify it is compiled with success, another possibility is to take a look in our CI for this distribution.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? Webserver and streaming
- Can they see the change or is it an under the hood? If they can see it, where? only if they use TLS.
- How is the user impacted by the change?  Users are able to compile netdata against ancient TLS versions.
- What are there any benefits of the change?  Fix a bug.
</details>
