### PR TITLE
Bump websockets submodule

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -513,7 +513,7 @@ static int aclk_attempt_to_connect(mqtt_wss_client client)
             continue;
         }
 
-        struct mqtt_wss_proxy proxy_conf = { .host = NULL, .port = 0, .type = MQTT_WSS_DIRECT };
+        struct mqtt_wss_proxy proxy_conf = { .host = NULL, .port = 0, .username = NULL, .password = NULL, .type = MQTT_WSS_DIRECT };
         aclk_set_proxy((char**)&proxy_conf.host, &proxy_conf.port, &proxy_conf.type);
 
         struct mqtt_connect_params mqtt_conn_params = {

--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -13,7 +13,7 @@ static int aclk_https_request(https_req_t *request, https_req_response_t *respon
     int rc;
     // wrapper for ACLK only which loads ACLK specific proxy settings
     // then only calls https_request
-    struct mqtt_wss_proxy proxy_conf = { .host = NULL, .port = 0, .type = MQTT_WSS_DIRECT };
+    struct mqtt_wss_proxy proxy_conf = { .host = NULL, .port = 0, .username = NULL, .password = NULL, .type = MQTT_WSS_DIRECT };
     aclk_set_proxy((char**)&proxy_conf.host, &proxy_conf.port, &proxy_conf.type);
 
     if (proxy_conf.type == MQTT_WSS_PROXY_HTTP) {


### PR DESCRIPTION
##### Summary
@MrZammler identified bug on 32 bit systems 🙇🏻‍♂️  with keep-alive (long int is different size), this brings his fix into netdata.

Meanwhile mqtt_websockets got basic proxy auth support, this bump brings those changes too so minimal changes in agent were done to reflect the new API

##### Test Plan
connection on 32 bit RPi should be more stable

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
