### PR TITLE
Parser cleanup 

### DIFF
--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -723,7 +723,7 @@ PARSER_RC pluginsd_disable(char **words, void *user, PLUGINSD_ACTION  *plugins_a
     return PARSER_RC_ERROR;
 }
 
-PARSER_RC pluginsd_label(char **words, void *user, PLUGINSD_ACTION  *plugins_action)
+PARSER_RC pluginsd_label(char **words, void *user, PLUGINSD_ACTION  *plugins_action __maybe_unused)
 {
     char *store;
 
@@ -754,12 +754,10 @@ PARSER_RC pluginsd_label(char **words, void *user, PLUGINSD_ACTION  *plugins_act
         }
     }
 
-    if (plugins_action->label_action) {
-        PARSER_RC rc = plugins_action->label_action(user, words[1], store, strtol(words[2], NULL, 10));
-        if (store != words[3])
-            freez(store);
-        return rc;
-    }
+    if(unlikely(!((PARSER_USER_OBJECT *) user)->new_host_labels))
+        ((PARSER_USER_OBJECT *) user)->new_host_labels = rrdlabels_create();
+
+    rrdlabels_add(((PARSER_USER_OBJECT *)user)->new_host_labels, words[1], store, strtol(words[2], NULL, 10));
 
     if (store != words[3])
         freez(store);

--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -28,17 +28,6 @@ PARSER_RC pluginsd_variable_action(void *user, RRDHOST *host, RRDSET *st, char *
     return PARSER_RC_OK;
 }
 
-PARSER_RC pluginsd_label_action(void *user, char *key, char *value, RRDLABEL_SRC source)
-{
-
-    if(unlikely(!((PARSER_USER_OBJECT *) user)->new_host_labels))
-        ((PARSER_USER_OBJECT *) user)->new_host_labels = rrdlabels_create();
-
-    rrdlabels_add(((PARSER_USER_OBJECT *)user)->new_host_labels, key, value, source);
-
-    return PARSER_RC_OK;
-}
-
 PARSER_RC pluginsd_set(char **words, void *user, PLUGINSD_ACTION  *plugins_action __maybe_unused)
 {
     char *dimension = words[1];

--- a/collectors/plugins.d/pluginsd_parser.h
+++ b/collectors/plugins.d/pluginsd_parser.h
@@ -22,11 +22,6 @@ typedef struct parser_user_object {
     void *private; // the user can set this for private use
 } PARSER_USER_OBJECT;
 
-extern PARSER_RC pluginsd_variable_action(void *user, RRDHOST *host, RRDSET *st, char *name, int global, NETDATA_DOUBLE value);
-extern PARSER_RC pluginsd_dimension_action(void *user, RRDSET *st, char *id, char *name, char *algorithm,
-                                           long multiplier, long divisor, char *options, RRD_ALGORITHM algorithm_type);
-extern PARSER_RC pluginsd_overwrite_action(void *user, RRDHOST *host, DICTIONARY *new_host_labels);
-
 extern PARSER_RC pluginsd_function(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
 extern PARSER_RC pluginsd_function_result_begin(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
 extern void inflight_functions_init(PARSER *parser);

--- a/collectors/plugins.d/pluginsd_parser.h
+++ b/collectors/plugins.d/pluginsd_parser.h
@@ -22,9 +22,6 @@ typedef struct parser_user_object {
     void *private; // the user can set this for private use
 } PARSER_USER_OBJECT;
 
-extern PARSER_RC pluginsd_chart_action(void *user, char *type, char *id, char *name, char *family, char *context,
-                                       char *title, char *units, char *plugin, char *module, int priority,
-                                       int update_every, RRDSET_TYPE chart_type, char *options);
 extern PARSER_RC pluginsd_variable_action(void *user, RRDHOST *host, RRDSET *st, char *name, int global, NETDATA_DOUBLE value);
 extern PARSER_RC pluginsd_dimension_action(void *user, RRDSET *st, char *id, char *name, char *algorithm,
                                            long multiplier, long divisor, char *options, RRD_ALGORITHM algorithm_type);

--- a/collectors/plugins.d/pluginsd_parser.h
+++ b/collectors/plugins.d/pluginsd_parser.h
@@ -25,7 +25,6 @@ typedef struct parser_user_object {
 extern PARSER_RC pluginsd_variable_action(void *user, RRDHOST *host, RRDSET *st, char *name, int global, NETDATA_DOUBLE value);
 extern PARSER_RC pluginsd_dimension_action(void *user, RRDSET *st, char *id, char *name, char *algorithm,
                                            long multiplier, long divisor, char *options, RRD_ALGORITHM algorithm_type);
-extern PARSER_RC pluginsd_label_action(void *user, char *key, char *value, RRDLABEL_SRC source);
 extern PARSER_RC pluginsd_overwrite_action(void *user, RRDHOST *host, DICTIONARY *new_host_labels);
 
 extern PARSER_RC pluginsd_function(char **words, void *user, PLUGINSD_ACTION  *plugins_action);

--- a/collectors/plugins.d/pluginsd_parser.h
+++ b/collectors/plugins.d/pluginsd_parser.h
@@ -22,14 +22,10 @@ typedef struct parser_user_object {
     void *private; // the user can set this for private use
 } PARSER_USER_OBJECT;
 
-extern PARSER_RC pluginsd_set_action(void *user, RRDSET *st, RRDDIM *rd, long long int value);
-extern PARSER_RC pluginsd_flush_action(void *user, RRDSET *st);
 extern PARSER_RC pluginsd_begin_action(void *user, RRDSET *st, usec_t microseconds, int trust_durations);
-extern PARSER_RC pluginsd_end_action(void *user, RRDSET *st);
 extern PARSER_RC pluginsd_chart_action(void *user, char *type, char *id, char *name, char *family, char *context,
                                        char *title, char *units, char *plugin, char *module, int priority,
                                        int update_every, RRDSET_TYPE chart_type, char *options);
-extern PARSER_RC pluginsd_disable_action(void *user);
 extern PARSER_RC pluginsd_variable_action(void *user, RRDHOST *host, RRDSET *st, char *name, int global, NETDATA_DOUBLE value);
 extern PARSER_RC pluginsd_dimension_action(void *user, RRDSET *st, char *id, char *name, char *algorithm,
                                            long multiplier, long divisor, char *options, RRD_ALGORITHM algorithm_type);

--- a/collectors/plugins.d/pluginsd_parser.h
+++ b/collectors/plugins.d/pluginsd_parser.h
@@ -22,7 +22,6 @@ typedef struct parser_user_object {
     void *private; // the user can set this for private use
 } PARSER_USER_OBJECT;
 
-extern PARSER_RC pluginsd_begin_action(void *user, RRDSET *st, usec_t microseconds, int trust_durations);
 extern PARSER_RC pluginsd_chart_action(void *user, char *type, char *id, char *name, char *family, char *context,
                                        char *title, char *units, char *plugin, char *module, int priority,
                                        int update_every, RRDSET_TYPE chart_type, char *options);

--- a/database/engine/metadata_log/logfile.c
+++ b/database/engine/metadata_log/logfile.c
@@ -389,7 +389,6 @@ static int scan_metalog_files(struct metalog_instance *ctx)
     parser_add_keyword(parser, PLUGINSD_KEYWORD_CONTEXT, pluginsd_context);
     parser_add_keyword(parser, PLUGINSD_KEYWORD_TOMBSTONE, pluginsd_tombstone);
     parser->plugins_action->dimension_action = &metalog_pluginsd_dimension_action;
-    parser->plugins_action->chart_action     = &metalog_pluginsd_chart_action;
     parser->plugins_action->guid_action      = &metalog_pluginsd_guid_action;
     parser->plugins_action->context_action   = &metalog_pluginsd_context_action;
     parser->plugins_action->tombstone_action = &metalog_pluginsd_tombstone_action;

--- a/database/engine/metadata_log/logfile.c
+++ b/database/engine/metadata_log/logfile.c
@@ -388,7 +388,6 @@ static int scan_metalog_files(struct metalog_instance *ctx)
     parser_add_keyword(parser, PLUGINSD_KEYWORD_GUID, pluginsd_guid);
     parser_add_keyword(parser, PLUGINSD_KEYWORD_CONTEXT, pluginsd_context);
     parser_add_keyword(parser, PLUGINSD_KEYWORD_TOMBSTONE, pluginsd_tombstone);
-    parser->plugins_action->dimension_action = &metalog_pluginsd_dimension_action;
     parser->plugins_action->guid_action      = &metalog_pluginsd_guid_action;
     parser->plugins_action->context_action   = &metalog_pluginsd_context_action;
     parser->plugins_action->tombstone_action = &metalog_pluginsd_tombstone_action;

--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -44,30 +44,6 @@ PARSER_RC metalog_pluginsd_host_action(
     return PARSER_RC_OK;
 }
 
-PARSER_RC metalog_pluginsd_chart_action(void *user, char *type, char *id, char *name, char *family, char *context,
-                                        char *title, char *units, char *plugin, char *module, int priority,
-                                        int update_every, RRDSET_TYPE chart_type, char *options)
-{
-    UNUSED(options);
-
-    struct metalog_pluginsd_state *state = ((PARSER_USER_OBJECT *)user)->private;
-    RRDHOST *host = ((PARSER_USER_OBJECT *) user)->host;
-
-    if (unlikely(uuid_is_null(state->host_uuid))) {
-        debug(D_METADATALOG, "Ignoring chart belonging to missing or ignored host.");
-        return PARSER_RC_OK;
-    }
-    uuid_copy(state->chart_uuid, state->uuid);
-    uuid_clear(state->uuid); /* Consume UUID */
-    (void) sql_store_chart(&state->chart_uuid, &state->host_uuid,
-        type, id, name, family, context, title, units,
-        plugin, module, priority, update_every,
-        chart_type, RRD_MEMORY_MODE_DBENGINE, host ? host->rrd_history_entries : 1);
-    ((PARSER_USER_OBJECT *)user)->st_exists = 1;
-
-    return PARSER_RC_OK;
-}
-
 PARSER_RC metalog_pluginsd_dimension_action(void *user, RRDSET *st, char *id, char *name, char *algorithm,
                                             long multiplier, long divisor, char *options, RRD_ALGORITHM algorithm_type)
 {

--- a/database/engine/metadata_log/metalogpluginsd.c
+++ b/database/engine/metadata_log/metalogpluginsd.c
@@ -44,33 +44,6 @@ PARSER_RC metalog_pluginsd_host_action(
     return PARSER_RC_OK;
 }
 
-PARSER_RC metalog_pluginsd_dimension_action(void *user, RRDSET *st, char *id, char *name, char *algorithm,
-                                            long multiplier, long divisor, char *options, RRD_ALGORITHM algorithm_type)
-{
-    struct metalog_pluginsd_state *state = ((PARSER_USER_OBJECT *)user)->private;
-    UNUSED(user);
-    UNUSED(options);
-    UNUSED(algorithm);
-    UNUSED(st);
-
-    if (unlikely(uuid_is_null(state->chart_uuid))) {
-        debug(D_METADATALOG, "Ignoring dimension belonging to missing or ignored chart.");
-        info("Ignoring dimension belonging to missing or ignored chart.");
-        return PARSER_RC_OK;
-    }
-
-    if (unlikely(uuid_is_null(state->uuid))) {
-        debug(D_METADATALOG, "Ignoring dimension without unknown UUID");
-        info("Ignoring dimension without unknown UUID");
-        return PARSER_RC_OK;
-    }
-
-    (void) sql_store_dimension(&state->uuid, &state->chart_uuid, id, name, multiplier, divisor, algorithm_type);
-    uuid_clear(state->uuid); /* Consume UUID */
-
-    return PARSER_RC_OK;
-}
-
 PARSER_RC metalog_pluginsd_guid_action(void *user, uuid_t *uuid)
 {
     struct metalog_pluginsd_state *state = ((PARSER_USER_OBJECT *)user)->private;

--- a/database/engine/metadata_log/metalogpluginsd.h
+++ b/database/engine/metadata_log/metalogpluginsd.h
@@ -17,10 +17,6 @@ struct metalog_pluginsd_state {
 };
 
 extern void metalog_pluginsd_state_init(struct metalog_pluginsd_state *state, struct metalog_instance *ctx);
-
-extern PARSER_RC metalog_pluginsd_chart_action(void *user, char *type, char *id, char *name, char *family,
-                                               char *context, char *title, char *units, char *plugin, char *module,
-                                               int priority, int update_every, RRDSET_TYPE chart_type, char *options);
 extern PARSER_RC metalog_pluginsd_dimension_action(void *user, RRDSET *st, char *id, char *name, char *algorithm,
                                                    long multiplier, long divisor, char *options,
                                                    RRD_ALGORITHM algorithm_type);

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -67,7 +67,6 @@ PARSER *parser_init(RRDHOST *host, void *user, void *input, void *output, PARSER
     }
 
     if(unlikely(!(flags & PARSER_NO_ACTION_INIT))) {
-        parser->plugins_action->begin_action            = &pluginsd_begin_action;
         parser->plugins_action->variable_action         = &pluginsd_variable_action;
         parser->plugins_action->dimension_action        = &pluginsd_dimension_action;
         parser->plugins_action->label_action            = &pluginsd_label_action;

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -66,10 +66,6 @@ PARSER *parser_init(RRDHOST *host, void *user, void *input, void *output, PARSER
         //parser_add_keyword(parser, PLUGINSD_KEYWORD_GAPS_REQUEST,   pluginsd_gaps_request);
     }
 
-    if(unlikely(!(flags & PARSER_NO_ACTION_INIT))) {
-        parser->plugins_action->variable_action         = &pluginsd_variable_action;
-    }
-
     return parser;
 }
 

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -68,15 +68,11 @@ PARSER *parser_init(RRDHOST *host, void *user, void *input, void *output, PARSER
 
     if(unlikely(!(flags & PARSER_NO_ACTION_INIT))) {
         parser->plugins_action->begin_action            = &pluginsd_begin_action;
-        parser->plugins_action->flush_action            = &pluginsd_flush_action;
-        parser->plugins_action->end_action              = &pluginsd_end_action;
-        parser->plugins_action->disable_action          = &pluginsd_disable_action;
         parser->plugins_action->variable_action         = &pluginsd_variable_action;
         parser->plugins_action->dimension_action        = &pluginsd_dimension_action;
         parser->plugins_action->label_action            = &pluginsd_label_action;
         parser->plugins_action->overwrite_action        = &pluginsd_overwrite_action;
         parser->plugins_action->chart_action            = &pluginsd_chart_action;
-        parser->plugins_action->set_action              = &pluginsd_set_action;
     }
 
     return parser;

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -69,7 +69,6 @@ PARSER *parser_init(RRDHOST *host, void *user, void *input, void *output, PARSER
     if(unlikely(!(flags & PARSER_NO_ACTION_INIT))) {
         parser->plugins_action->variable_action         = &pluginsd_variable_action;
         parser->plugins_action->dimension_action        = &pluginsd_dimension_action;
-        parser->plugins_action->chart_action            = &pluginsd_chart_action;
     }
 
     return parser;

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -68,7 +68,6 @@ PARSER *parser_init(RRDHOST *host, void *user, void *input, void *output, PARSER
 
     if(unlikely(!(flags & PARSER_NO_ACTION_INIT))) {
         parser->plugins_action->variable_action         = &pluginsd_variable_action;
-        parser->plugins_action->dimension_action        = &pluginsd_dimension_action;
     }
 
     return parser;

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -69,7 +69,6 @@ PARSER *parser_init(RRDHOST *host, void *user, void *input, void *output, PARSER
     if(unlikely(!(flags & PARSER_NO_ACTION_INIT))) {
         parser->plugins_action->variable_action         = &pluginsd_variable_action;
         parser->plugins_action->dimension_action        = &pluginsd_dimension_action;
-        parser->plugins_action->overwrite_action        = &pluginsd_overwrite_action;
         parser->plugins_action->chart_action            = &pluginsd_chart_action;
     }
 

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -69,7 +69,6 @@ PARSER *parser_init(RRDHOST *host, void *user, void *input, void *output, PARSER
     if(unlikely(!(flags & PARSER_NO_ACTION_INIT))) {
         parser->plugins_action->variable_action         = &pluginsd_variable_action;
         parser->plugins_action->dimension_action        = &pluginsd_dimension_action;
-        parser->plugins_action->label_action            = &pluginsd_label_action;
         parser->plugins_action->overwrite_action        = &pluginsd_overwrite_action;
         parser->plugins_action->chart_action            = &pluginsd_chart_action;
     }

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -17,9 +17,7 @@ typedef enum parser_rc {
 } PARSER_RC;
 
 typedef struct pluginsd_action {
-    PARSER_RC (*set_action)(void *user, RRDSET *st, RRDDIM *rd, long long int value);
     PARSER_RC (*begin_action)(void *user, RRDSET *st, usec_t microseconds, int trust_durations);
-    PARSER_RC (*end_action)(void *user, RRDSET *st);
     PARSER_RC (*chart_action)
     (void *user, char *type, char *id, char *name, char *family, char *context, char *title, char *units, char *plugin,
      char *module, int priority, int update_every, RRDSET_TYPE chart_type, char *options);
@@ -27,8 +25,6 @@ typedef struct pluginsd_action {
     (void *user, RRDSET *st, char *id, char *name, char *algorithm, long multiplier, long divisor, char *options,
      RRD_ALGORITHM algorithm_type);
 
-    PARSER_RC (*flush_action)(void *user, RRDSET *st);
-    PARSER_RC (*disable_action)(void *user);
     PARSER_RC (*variable_action)(void *user, RRDHOST *host, RRDSET *st, char *name, int global, NETDATA_DOUBLE value);
     PARSER_RC (*label_action)(void *user, char *key, char *value, RRDLABEL_SRC source);
     PARSER_RC (*overwrite_action)(void *user, RRDHOST *host, DICTIONARY *new_labels);

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -17,7 +17,6 @@ typedef enum parser_rc {
 } PARSER_RC;
 
 typedef struct pluginsd_action {
-    PARSER_RC (*begin_action)(void *user, RRDSET *st, usec_t microseconds, int trust_durations);
     PARSER_RC (*chart_action)
     (void *user, char *type, char *id, char *name, char *family, char *context, char *title, char *units, char *plugin,
      char *module, int priority, int update_every, RRDSET_TYPE chart_type, char *options);

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -17,12 +17,6 @@ typedef enum parser_rc {
 } PARSER_RC;
 
 typedef struct pluginsd_action {
-    PARSER_RC (*dimension_action)
-    (void *user, RRDSET *st, char *id, char *name, char *algorithm, long multiplier, long divisor, char *options,
-     RRD_ALGORITHM algorithm_type);
-
-    PARSER_RC (*variable_action)(void *user, RRDHOST *host, RRDSET *st, char *name, int global, NETDATA_DOUBLE value);
-
     PARSER_RC (*guid_action)(void *user, uuid_t *uuid);
     PARSER_RC (*context_action)(void *user, uuid_t *uuid);
     PARSER_RC (*tombstone_action)(void *user, uuid_t *uuid);

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -25,7 +25,6 @@ typedef struct pluginsd_action {
      RRD_ALGORITHM algorithm_type);
 
     PARSER_RC (*variable_action)(void *user, RRDHOST *host, RRDSET *st, char *name, int global, NETDATA_DOUBLE value);
-    PARSER_RC (*overwrite_action)(void *user, RRDHOST *host, DICTIONARY *new_labels);
 
     PARSER_RC (*guid_action)(void *user, uuid_t *uuid);
     PARSER_RC (*context_action)(void *user, uuid_t *uuid);

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -17,9 +17,6 @@ typedef enum parser_rc {
 } PARSER_RC;
 
 typedef struct pluginsd_action {
-    PARSER_RC (*chart_action)
-    (void *user, char *type, char *id, char *name, char *family, char *context, char *title, char *units, char *plugin,
-     char *module, int priority, int update_every, RRDSET_TYPE chart_type, char *options);
     PARSER_RC (*dimension_action)
     (void *user, RRDSET *st, char *id, char *name, char *algorithm, long multiplier, long divisor, char *options,
      RRD_ALGORITHM algorithm_type);

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -25,7 +25,6 @@ typedef struct pluginsd_action {
      RRD_ALGORITHM algorithm_type);
 
     PARSER_RC (*variable_action)(void *user, RRDHOST *host, RRDSET *st, char *name, int global, NETDATA_DOUBLE value);
-    PARSER_RC (*label_action)(void *user, char *key, char *value, RRDLABEL_SRC source);
     PARSER_RC (*overwrite_action)(void *user, RRDHOST *host, DICTIONARY *new_labels);
 
     PARSER_RC (*guid_action)(void *user, uuid_t *uuid);

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -306,7 +306,7 @@ static int receiver_read(struct receiver_state *r, FILE *fp) {
         internal_error(true, "read_stream() failed (1).");
         return 1;
     }
-    
+
     worker_set_metric(WORKER_RECEIVER_JOB_BYTES_READ, ret);
 
     if (!is_compressed_data(r->read_buffer, ret)) {


### PR DESCRIPTION
##### Summary
Removes the need to have to register a keyword and an action separately. A function registered with a keyword will need to do the parsing and the actual work needed.

##### Test Plan
