### PR TITLE
minor - add host labels for ephemerality and nodes with unstable connections

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1303,6 +1303,8 @@ static void rrdhost_load_auto_labels(void) {
 
     add_aclk_host_labels();
 
+    health_add_host_labels();
+
     rrdlabels_add(
         labels, "_is_parent", (rrdhost_hosts_available() > 1 || configured_as_parent()) ? "true" : "false", RRDLABEL_SRC_AUTO);
 

--- a/health/health.c
+++ b/health/health.c
@@ -1304,8 +1304,8 @@ void health_add_host_labels(void) {
     DICTIONARY *labels = localhost->rrdlabels;
 
     int is_ephemeral = appconfig_get_boolean(&netdata_config, CONFIG_SECTION_HEALTH, "is ephemeral", CONFIG_BOOLEAN_NO);
-    rrdlabels_add(labels, "_is_ephemeral", is_ephemeral ? "true" : "false", RRDLABEL_SRC_AUTO);
+    rrdlabels_add(labels, "_is_ephemeral", is_ephemeral ? "true" : "false", RRDLABEL_SRC_CONFIG);
 
     int has_unstable_connection = appconfig_get_boolean(&netdata_config, CONFIG_SECTION_HEALTH, "has unstable connection", CONFIG_BOOLEAN_NO);
-    rrdlabels_add(labels, "_has_unstable_connection", has_unstable_connection ? "true" : "false", RRDLABEL_SRC_AUTO);
+    rrdlabels_add(labels, "_has_unstable_connection", has_unstable_connection ? "true" : "false", RRDLABEL_SRC_CONFIG);
 }

--- a/health/health.c
+++ b/health/health.c
@@ -1299,3 +1299,13 @@ void *health_main(void *ptr) {
     netdata_thread_cleanup_pop(1);
     return NULL;
 }
+
+void health_add_host_labels(void) {
+    DICTIONARY *labels = localhost->rrdlabels;
+
+    int is_ephemeral = appconfig_get_boolean(&netdata_config, CONFIG_SECTION_HEALTH, "is ephemeral", CONFIG_BOOLEAN_NO);
+    rrdlabels_add(labels, "_is_ephemeral", is_ephemeral ? "true" : "false", RRDLABEL_SRC_AUTO);
+
+    int has_unstable_connection = appconfig_get_boolean(&netdata_config, CONFIG_SECTION_HEALTH, "has unstable connection", CONFIG_BOOLEAN_NO);
+    rrdlabels_add(labels, "_has_unstable_connection", has_unstable_connection ? "true" : "false", RRDLABEL_SRC_AUTO);
+}

--- a/health/health.h
+++ b/health/health.h
@@ -90,6 +90,6 @@ void health_label_log_save(RRDHOST *host);
 char *health_edit_command_from_source(const char *source);
 void sql_refresh_hashes(void);
 
-extern void health_add_host_labels(void);
+void health_add_host_labels(void);
 
 #endif //NETDATA_HEALTH_H

--- a/health/health.h
+++ b/health/health.h
@@ -90,4 +90,6 @@ void health_label_log_save(RRDHOST *host);
 char *health_edit_command_from_source(const char *source);
 void sql_refresh_hashes(void);
 
+extern void health_add_host_labels(void);
+
 #endif //NETDATA_HEALTH_H


### PR DESCRIPTION
##### Summary
This allows the user to mark the node as ephemeral or as a node with an unstable connection. This will be used by the cloud to know for example it can delete this node more quickly from the list etc.

Fixes https://github.com/netdata/netdata/issues/13160

##### Test Plan
`/api/v1/info`

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
