### PR TITLE
Add Ubuntu 22.10 to supported distros, CI, and package builds.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -162,20 +162,25 @@ include:
 
   - &ubuntu
     distro: ubuntu
-    version: "22.04"
+    version: "22.10"
     env_prep: |
       rm -f /etc/apt/apt.conf.d/docker && apt-get update
     jsonc_removal: |
       apt-get remove -y libjson-c-dev
     packages: &ubuntu_packages
       type: deb
-      repo_distro: ubuntu/jammy
+      repo_distro: ubuntu/kinetic
       arches:
         - amd64
         - armhf
         - arm64
     test:
       ebpf-core: true
+  - <<: *ubuntu
+    version: "22.04"
+    packages:
+      <<: *ubuntu_packages
+      repo_distro: ubuntu/jammy
   - <<: *ubuntu
     version: "20.04"
     packages:

--- a/.github/scripts/pkg-test.sh
+++ b/.github/scripts/pkg-test.sh
@@ -4,13 +4,19 @@ install_debian_like() {
   # This is needed to ensure package installs don't prompt for any user input.
   export DEBIAN_FRONTEND=noninteractive
 
+  if apt-cache show netcat 2>&1 | grep -q "No packages found"; then
+    netcat="netcat-traditional"
+  else
+    netcat="netcat"
+  fi
+
   apt-get update
 
   # Install Netdata
   apt-get install -y /netdata/artifacts/netdata_"${VERSION}"*_*.deb || exit 1
 
   # Install testing tools
-  apt-get install -y --no-install-recommends curl netcat jq || exit 1
+  apt-get install -y --no-install-recommends curl "${netcat}" jq || exit 1
 }
 
 install_fedora_like() {

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -66,8 +66,9 @@ to work on these platforms with minimal user effort.
 | Red Hat Enterprise Linux | 9.x | x86\_64, AArch64 | |
 | Red Hat Enterprise Linux | 8.x | x86\_64, AArch64 | |
 | Red Hat Enterprise Linux | 7.x | x86\_64 | |
+| Ubuntu | 22.10 | x86\_64, ARMv7, AArch64 | |
 | Ubuntu | 22.04 | x86\_64, ARMv7, AArch64 | |
-| Ubuntu | 20.04 | x86\_64, i386, ARMv7, AArch64 | |
+| Ubuntu | 20.04 | x86\_64, ARMv7, AArch64 | |
 | Ubuntu | 18.04 | x86\_64, i386, ARMv7, AArch64 | |
 
 ### Intermediate


### PR DESCRIPTION
##### Summary

Expected release date is 2022-10-20.

##### Test Plan

n/a

##### Additional Info

Depends on: https://github.com/netdata/netdata/pull/13787