### PR TITLE
Initialize st->rrdvars from rrdset insert callback

### DIFF
--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -181,6 +181,10 @@ static void rrdset_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
     // chart variables - we need this for data collection to work (collector given chart variables) - not only health
     rrdsetvar_index_init(st);
 
+    if (host->health_enabled) {
+        st->rrdvars = rrdvariables_create();
+    }
+
     st->rrdlabels = rrdlabels_create();
     rrdset_update_permanent_labels(st);
 

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -182,7 +182,10 @@ static void rrdset_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
     rrdsetvar_index_init(st);
 
     if (host->health_enabled) {
+        st->rrdfamily = rrdfamily_add_and_acquire(host, rrdset_family(st));
         st->rrdvars = rrdvariables_create();
+        rrddimvar_index_init(st);
+
     }
 
     st->rrdlabels = rrdlabels_create();

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -185,7 +185,6 @@ static void rrdset_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
         st->rrdfamily = rrdfamily_add_and_acquire(host, rrdset_family(st));
         st->rrdvars = rrdvariables_create();
         rrddimvar_index_init(st);
-
     }
 
     st->rrdlabels = rrdlabels_create();

--- a/health/health.c
+++ b/health/health.c
@@ -690,11 +690,6 @@ static void health_execute_delayed_initializations(RRDHOST *host) {
 
         worker_is_busy(WORKER_HEALTH_JOB_DELAYED_INIT_RRDSET);
 
-        if(!st->rrdfamily)
-            st->rrdfamily = rrdfamily_add_and_acquire(host, rrdset_family(st));
-
-        rrddimvar_index_init(st);
-
         rrdsetvar_add_and_leave_released(st, "last_collected_t", RRDVAR_TYPE_TIME_T, &st->last_collected_time.tv_sec, RRDVAR_FLAG_NONE);
         rrdsetvar_add_and_leave_released(st, "collected_total_raw", RRDVAR_TYPE_TOTAL, &st->last_collected_total, RRDVAR_FLAG_NONE);
         rrdsetvar_add_and_leave_released(st, "green", RRDVAR_TYPE_CALCULATED, &st->green, RRDVAR_FLAG_NONE);

--- a/health/health.c
+++ b/health/health.c
@@ -693,9 +693,6 @@ static void health_execute_delayed_initializations(RRDHOST *host) {
         if(!st->rrdfamily)
             st->rrdfamily = rrdfamily_add_and_acquire(host, rrdset_family(st));
 
-        if(!st->rrdvars)
-            st->rrdvars = rrdvariables_create();
-
         rrddimvar_index_init(st);
 
         rrdsetvar_add_and_leave_released(st, "last_collected_t", RRDVAR_TYPE_TIME_T, &st->last_collected_time.tv_sec, RRDVAR_FLAG_NONE);


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #13781 

This PR brings back the initialization of `st->rrdvars` to be done during the `rrdset_insert_callback`.

If left to be initialized during health, it will delay, and `rrdsetvar_update_rrdvars_unsafe` will not find `st->rrdvars` to populate it.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

On a build from master, check e.g. chart `system.active_processes`. Notice it's missing `chart_variables`. With this PR, it should have there a `pidmax`.

Similarly, please test with a pi-hole installation. There should be a `file_exists` (not sure of the exact name) chart variable under the `pihole.blocklist_last_update`.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

Not sure if we need to also move back initialization of `st->rrdfamily` and `rrddimvar_index_init(st);` back there as well. Most likely yes, but haven't tested yet.

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
