### PR TITLE
Stop pulling in netcat as a mandatory dependency.

### DIFF
--- a/packaging/installer/dependencies/alpine.sh
+++ b/packaging/installer/dependencies/alpine.sh
@@ -22,7 +22,6 @@ package_tree="
   tar
   curl
   gzip
-  netcat-openbsd
   libuv-dev
   lz4-dev
   openssl-dev

--- a/packaging/installer/dependencies/arch.sh
+++ b/packaging/installer/dependencies/arch.sh
@@ -16,7 +16,6 @@ declare -a package_tree=(
   automake
   libtool
   cmake
-  gnu-netcat
   zlib
   util-linux
   libmnl

--- a/packaging/installer/dependencies/centos.sh
+++ b/packaging/installer/dependencies/centos.sh
@@ -15,7 +15,6 @@ declare -a package_tree=(
   libtool
   pkgconfig
   cmake
-  nmap-ncat
   zlib-devel
   libuuid-devel
   libmnl-devel

--- a/packaging/installer/dependencies/debian.sh
+++ b/packaging/installer/dependencies/debian.sh
@@ -23,7 +23,6 @@ package_tree="
   tar
   curl
   gzip
-  netcat
   zlib1g-dev
   uuid-dev
   libmnl-dev

--- a/packaging/installer/dependencies/fedora.sh
+++ b/packaging/installer/dependencies/fedora.sh
@@ -35,7 +35,6 @@ declare -a package_tree=(
   libatomic
   libtool
   cmake
-  nmap-ncat
   zlib-devel
   libuuid-devel
   libmnl-devel

--- a/packaging/installer/dependencies/freebsd.sh
+++ b/packaging/installer/dependencies/freebsd.sh
@@ -18,7 +18,6 @@ package_tree="
   cmake
   curl
   gzip
-  netcat
   lzlib
   e2fsprogs-libuuid
   json-c

--- a/packaging/installer/dependencies/gentoo.sh
+++ b/packaging/installer/dependencies/gentoo.sh
@@ -21,7 +21,6 @@ package_tree="
   app-arch/tar
   net-misc/curl
   app-arch/gzip
-  net-analyzer/netcat
   sys-apps/util-linux
   net-libs/libmnl
   dev-libs/json-c

--- a/packaging/installer/dependencies/ol.sh
+++ b/packaging/installer/dependencies/ol.sh
@@ -19,7 +19,6 @@ declare -a package_tree=(
   libtool
   pkgconfig
   cmake
-  nmap-ncat
   tar
   zlib-devel
   libuuid-devel

--- a/packaging/installer/dependencies/opensuse.sh
+++ b/packaging/installer/dependencies/opensuse.sh
@@ -21,7 +21,6 @@ declare -a package_tree=(
   libtool
   pkg-config
   cmake
-  netcat-openbsd
   zlib-devel
   libuuid-devel
   libmnl-devel

--- a/packaging/installer/dependencies/rockylinux.sh
+++ b/packaging/installer/dependencies/rockylinux.sh
@@ -19,7 +19,6 @@ declare -a package_tree=(
   libtool
   pkgconfig
   cmake
-  nmap-ncat
   zlib-devel
   libuuid-devel
   libmnl-devel

--- a/packaging/installer/dependencies/ubuntu.sh
+++ b/packaging/installer/dependencies/ubuntu.sh
@@ -23,7 +23,6 @@ package_tree="
   tar
   curl
   gzip
-  netcat
   zlib1g-dev
   uuid-dev
   libmnl-dev

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -878,26 +878,6 @@ declare -A pkg_make=(
   ['default']="make"
 )
 
-declare -A pkg_netcat=(
-  ['alpine']="netcat-openbsd"
-  ['arch']="netcat"
-  ['centos']="nmap-ncat"
-  ['debian']="netcat"
-  ['gentoo']="net-analyzer/netcat"
-  ['sabayon']="net-analyzer/gnu-netcat"
-  ['rhel']="nmap-ncat"
-  ['ol']="nmap-ncat"
-  ['suse']="netcat-openbsd"
-  ['clearlinux']="sysadmin-basic"
-  ['arch']="gnu-netcat"
-  ['macos']="NOTREQUIRED"
-  ['default']="netcat"
-
-  # exceptions
-  ['centos-6']="nc"
-  ['rhel-6']="nc"
-)
-
 declare -A pkg_nginx=(
   ['gentoo']="www-servers/nginx"
   ['default']="nginx"
@@ -1253,7 +1233,6 @@ packages() {
     require_cmd tar || suitable_package tar
     require_cmd curl || suitable_package curl
     require_cmd gzip || suitable_package gzip
-    require_cmd nc || suitable_package netcat
   fi
 
   # -------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary

It’s only used by a single exporter which is itself not in widespread usage. Requiring users to install netcat themselves if they want to use that exporter is not a significant burden, and not pulling it in ourselves reduces our install footprint for ‘regular’ users without really impacting usability for them.

This also makes life easier supporting newer versions of Ubuntu (22.10 and newer do not have a `netcat` package, you have to pick between specific implementations) and upcoming releases of Debian (Sid is already like Ubuntu 22.10, and it’s expected that Debian 12 will do the same).

##### Test Plan

n/a
