### PR TITLE
allow disabling netdata monitoring section of the dashboard

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -686,7 +686,7 @@ void *aclk_main(void *ptr)
     // that send JSON payloads of 10 MB as single messages
     mqtt_wss_set_max_buf_size(mqttwss_client, 25*1024*1024);
 
-    aclk_stats_enabled = config_get_boolean(CONFIG_SECTION_CLOUD, "statistics", CONFIG_BOOLEAN_YES);
+    aclk_stats_enabled = config_get_boolean(CONFIG_SECTION_CLOUD, "statistics", global_statistics_enabled);
     if (aclk_stats_enabled) {
         stats_thread = callocz(1, sizeof(struct aclk_stats_thread));
         stats_thread->thread = mallocz(sizeof(netdata_thread_t));

--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -4777,6 +4777,13 @@ int main(int argc, char **argv) {
     error_log_errors_per_period = 100;
     error_log_throttle_period = 3600;
 
+    bool send_resource_usage = true;
+    {
+        const char *s = getenv("NETDATA_INTERNALS_MONITORING");
+        if(s && *s && strcmp(s, "NO") == 0)
+            send_resource_usage = false;
+    }
+
     // since apps.plugin runs as root, prevent it from opening symbolic links
     procfile_open_flags = O_RDONLY|O_NOFOLLOW;
 
@@ -4904,7 +4911,8 @@ int main(int argc, char **argv) {
         calculate_netdata_statistics();
         normalize_utilization(apps_groups_root_target);
 
-        send_resource_usage_to_netdata(dt);
+        if(send_resource_usage)
+            send_resource_usage_to_netdata(dt);
 
 #ifndef __FreeBSD__
         send_proc_states_count(dt);

--- a/collectors/checks.plugin/plugin_checks.c
+++ b/collectors/checks.plugin/plugin_checks.c
@@ -12,6 +12,9 @@ static void checks_main_cleanup(void *ptr) {
 }
 
 void *checks_main(void *ptr) {
+    if (!global_statistics_enabled)
+        return NULL;
+
     netdata_thread_cleanup_push(checks_main_cleanup, ptr);
 
     usec_t usec = 0, susec = localhost->rrd_update_every * USEC_PER_SEC, loop_usec = 0, total_susec = 0;

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -166,40 +166,176 @@ ebpf_module_t ebpf_modules[] = {
 };
 
 struct netdata_static_thread ebpf_threads[] = {
-    {"EBPF PROCESS", NULL, NULL, 1,
-        NULL, NULL, NULL},
-    {"EBPF SOCKET" , NULL, NULL, 1,
-        NULL, NULL, NULL},
-    {"EBPF CACHESTAT" , NULL, NULL, 1,
-        NULL, NULL, NULL},
-    {"EBPF SYNC" , NULL, NULL, 1,
-        NULL, NULL, NULL},
-    {"EBPF DCSTAT" , NULL, NULL, 1,
-        NULL, NULL, NULL},
-    {"EBPF SWAP" , NULL, NULL, 1,
-        NULL, NULL, NULL},
-    {"EBPF VFS" , NULL, NULL, 1,
-        NULL, NULL, NULL},
-    {"EBPF FILESYSTEM" , NULL, NULL, 1,
-        NULL, NULL, NULL},
-    {"EBPF DISK" , NULL, NULL, 1,
-        NULL, NULL, NULL},
-    {"EBPF MOUNT" , NULL, NULL, 1,
-        NULL, NULL, NULL},
-    {"EBPF FD" , NULL, NULL, 1,
-        NULL, NULL, NULL},
-    {"EBPF HARDIRQ" , NULL, NULL, 1,
-        NULL, NULL, NULL},
-    {"EBPF SOFTIRQ" , NULL, NULL, 1,
-        NULL, NULL, NULL},
-    {"EBPF OOMKILL" , NULL, NULL, 1,
-        NULL, NULL, NULL},
-    {"EBPF SHM" , NULL, NULL, 1,
-        NULL, NULL, NULL},
-    {"EBPF MDFLUSH" , NULL, NULL, 1,
-        NULL, NULL, NULL},
-    {NULL          , NULL, NULL, 0,
-                     NULL, NULL, NULL}
+    {
+        .name = "EBPF PROCESS",
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 1,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    },
+    {
+        .name = "EBPF SOCKET",
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 1,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    },
+    {
+        .name = "EBPF CACHESTAT",
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 1,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    },
+    {
+        .name = "EBPF SYNC",
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 1,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    },
+    {
+        .name = "EBPF DCSTAT",
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 1,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    },
+    {
+        .name = "EBPF SWAP",
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 1,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    },
+    {
+        .name = "EBPF VFS",
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 1,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    },
+    {
+        .name = "EBPF FILESYSTEM",
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 1,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    },
+    {
+        .name = "EBPF DISK",
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 1,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    },
+    {
+        .name = "EBPF MOUNT",
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 1,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    },
+    {
+        .name = "EBPF FD",
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 1,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    },
+    {
+        .name = "EBPF HARDIRQ",
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 1,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    },
+    {
+        .name = "EBPF SOFTIRQ",
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 1,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    },
+    {
+        .name = "EBPF OOMKILL",
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 1,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    },
+    {
+        .name = "EBPF SHM",
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 1,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    },
+    {
+        .name = "EBPF MDFLUSH",
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 1,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    },
+    {
+        .name = NULL,
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 0,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    },
 };
 
 ebpf_filesystem_partitions_t localfs[] =

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -15,9 +15,14 @@ netdata_cachestat_pid_t *cachestat_vector = NULL;
 static netdata_idx_t cachestat_hash_values[NETDATA_CACHESTAT_END];
 static netdata_idx_t *cachestat_values = NULL;
 
-struct netdata_static_thread cachestat_threads = {"CACHESTAT KERNEL",
-                                                  NULL, NULL, 1, NULL,
-                                                  NULL,  NULL};
+struct netdata_static_thread cachestat_threads = {.name = "CACHESTAT KERNEL",
+                                                  .config_section = NULL,
+                                                  .config_name = NULL,
+                                                  .env_name = NULL,
+                                                  .enabled = 1,
+                                                  .thread = NULL,
+                                                  .init_routine = NULL,
+                                                  .start_routine = NULL};
 
 ebpf_local_maps_t cachestat_maps[] = {{.name = "cstat_global", .internal_input = NETDATA_CACHESTAT_END,
                                               .user_input = 0, .type = NETDATA_EBPF_MAP_STATIC,

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -20,8 +20,13 @@ struct config dcstat_config = { .first_section = NULL,
         .rwlock = AVL_LOCK_INITIALIZER } };
 
 struct netdata_static_thread dcstat_threads = {"DCSTAT KERNEL",
-                                               NULL, NULL, 1, NULL,
-                                               NULL,  NULL};
+                                               .config_section = NULL,
+                                               .config_name = NULL,
+                                               .env_name = NULL,
+                                               .enabled = 1,
+                                               .thread = NULL,
+                                               .init_routine = NULL,
+                                               .start_routine = NULL};
 static enum ebpf_threads_status ebpf_dcstat_exited = NETDATA_THREAD_EBPF_RUNNING;
 
 ebpf_local_maps_t dcstat_maps[] = {{.name = "dcstat_global", .internal_input = NETDATA_DIRECTORY_CACHE_END,

--- a/collectors/ebpf.plugin/ebpf_disk.c
+++ b/collectors/ebpf.plugin/ebpf_disk.c
@@ -33,9 +33,16 @@ static netdata_syscall_stat_t disk_aggregated_data[NETDATA_EBPF_HIST_MAX_BINS];
 static netdata_publish_syscall_t disk_publish_aggregated[NETDATA_EBPF_HIST_MAX_BINS];
 
 static netdata_idx_t *disk_hash_values = NULL;
-static struct netdata_static_thread disk_threads = {"DISK KERNEL",
-                                                    NULL, NULL, 1, NULL,
-                                                    NULL, NULL };
+static struct netdata_static_thread disk_threads = {
+                                        .name = "DISK KERNEL",
+                                        .config_section = NULL,
+                                        .config_name = NULL,
+                                        .env_name = NULL,
+                                        .enabled = 1,
+                                        .thread = NULL,
+                                        .init_routine = NULL,
+                                        .start_routine = NULL
+};
 static enum ebpf_threads_status ebpf_disk_exited = NETDATA_THREAD_EBPF_RUNNING;
 
 ebpf_publish_disk_t *plot_disks = NULL;

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -29,8 +29,15 @@ struct config fd_config = { .first_section = NULL, .last_section = NULL, .mutex 
                            .index = {.avl_tree = { .root = NULL, .compar = appconfig_section_compare },
                                      .rwlock = AVL_LOCK_INITIALIZER } };
 
-struct netdata_static_thread fd_thread = {"FD KERNEL", NULL, NULL, 1, NULL,
-                                          NULL,  NULL};
+struct netdata_static_thread fd_thread = {"FD KERNEL",
+                                          .config_section = NULL,
+                                          .config_name = NULL,
+                                          .env_name = NULL,
+                                          .enabled = 1,
+                                          .thread = NULL,
+                                          .init_routine = NULL,
+                                          .start_routine = NULL};
+
 static enum ebpf_threads_status ebpf_fd_exited = NETDATA_THREAD_EBPF_RUNNING;
 static netdata_idx_t fd_hash_values[NETDATA_FD_COUNTER];
 static netdata_idx_t *fd_values = NULL;

--- a/collectors/ebpf.plugin/ebpf_filesystem.c
+++ b/collectors/ebpf.plugin/ebpf_filesystem.c
@@ -30,9 +30,17 @@ static ebpf_local_maps_t fs_maps[] = {{.name = "tbl_ext4", .internal_input = NET
                                        .type = NETDATA_EBPF_MAP_CONTROLLER,
                                        .map_fd = ND_EBPF_MAP_FD_NOT_INITIALIZED}};
 
-struct netdata_static_thread filesystem_threads = {"EBPF FS READ",
-                                                   NULL, NULL, 1, NULL,
-                                                   NULL, NULL };
+struct netdata_static_thread filesystem_threads = {
+                                 .name = "EBPF FS READ",
+                                 .config_section = NULL,
+                                 .config_name = NULL,
+                                 .env_name = NULL,
+                                 .enabled = 1,
+                                 .thread = NULL,
+                                 .init_routine = NULL,
+                                 .start_routine = NULL
+};
+
 static enum ebpf_threads_status ebpf_fs_exited = NETDATA_THREAD_EBPF_RUNNING;
 
 static netdata_syscall_stat_t filesystem_aggregated_data[NETDATA_EBPF_HIST_MAX_BINS];

--- a/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -135,9 +135,16 @@ static hardirq_ebpf_val_t *hardirq_ebpf_vals = NULL;
 // tmp store for static hard IRQ values we get from a per-CPU eBPF map.
 static hardirq_ebpf_static_val_t *hardirq_ebpf_static_vals = NULL;
 
-static struct netdata_static_thread hardirq_threads = {"HARDIRQ KERNEL",
-                                                    NULL, NULL, 1, NULL,
-                                                    NULL, NULL };
+static struct netdata_static_thread hardirq_threads = {
+                                        .name = "HARDIRQ KERNEL",
+                                        .config_section = NULL,
+                                        .config_name = NULL,
+                                        .env_name = NULL,
+                                        .enabled = 1,
+                                        .thread = NULL,
+                                        .init_routine = NULL,
+                                        .start_routine = NULL
+};
 static enum ebpf_threads_status ebpf_hardirq_exited = NETDATA_THREAD_EBPF_RUNNING;
 
 /**

--- a/collectors/ebpf.plugin/ebpf_mdflush.c
+++ b/collectors/ebpf.plugin/ebpf_mdflush.c
@@ -35,9 +35,16 @@ static avl_tree_lock mdflush_pub;
 // tmp store for mdflush values we get from a per-CPU eBPF map.
 static mdflush_ebpf_val_t *mdflush_ebpf_vals = NULL;
 
-static struct netdata_static_thread mdflush_threads = {"MDFLUSH KERNEL",
-                                                    NULL, NULL, 1, NULL,
-                                                    NULL, NULL };
+static struct netdata_static_thread mdflush_threads = {
+                                        .name = "MDFLUSH KERNEL",
+                                        .config_section = NULL,
+                                        .config_name = NULL,
+                                        .env_name = NULL,
+                                        .enabled = 1,
+                                        .thread = NULL,
+                                        .init_routine = NULL,
+                                        .start_routine = NULL
+};
 static enum ebpf_threads_status ebpf_mdflush_exited = NETDATA_THREAD_EBPF_RUNNING;
 
 /**

--- a/collectors/ebpf.plugin/ebpf_mount.c
+++ b/collectors/ebpf.plugin/ebpf_mount.c
@@ -22,9 +22,16 @@ static netdata_idx_t *mount_values = NULL;
 
 static netdata_idx_t mount_hash_values[NETDATA_MOUNT_END];
 
-struct netdata_static_thread mount_thread = {"MOUNT KERNEL",
-                                              NULL, NULL, 1, NULL,
-                                              NULL,  NULL};
+struct netdata_static_thread mount_thread = {
+                                 .name = "MOUNT KERNEL",
+                                 .config_section = NULL,
+                                 .config_name = NULL,
+                                 .env_name = NULL,
+                                 .enabled = 1,
+                                 .thread = NULL,
+                                 .init_routine = NULL,
+                                 .start_routine = NULL
+};
 
 netdata_ebpf_targets_t mount_targets[] = { {.name = "mount", .mode = EBPF_LOAD_TRAMPOLINE},
                                            {.name = "umount", .mode = EBPF_LOAD_TRAMPOLINE},

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -53,8 +53,16 @@ struct config process_config = { .first_section = NULL,
     .index = { .avl_tree = { .root = NULL, .compar = appconfig_section_compare },
         .rwlock = AVL_LOCK_INITIALIZER } };
 
-static struct netdata_static_thread cgroup_thread = {"EBPF CGROUP", NULL, NULL,
-                                                    1, NULL, NULL,  NULL};
+static struct netdata_static_thread cgroup_thread = {
+                                        .name = "EBPF CGROUP",
+                                        .config_section = NULL,
+                                        .config_name = NULL,
+                                        .env_name = NULL,
+                                        .enabled = 1,
+                                        .thread = NULL,
+                                        .init_routine = NULL,
+                                        .start_routine = NULL
+};
 static enum ebpf_threads_status ebpf_process_exited = NETDATA_THREAD_EBPF_RUNNING;
 
 static char *threads_stat[NETDATA_EBPF_THREAD_STAT_END] = {"total", "running"};

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -46,6 +46,7 @@ ebpf_process_stat_t **global_process_stats = NULL;
 ebpf_process_publish_apps_t **current_apps_data = NULL;
 
 int process_enabled = 0;
+bool publish_internal_metrics = true;
 
 struct config process_config = { .first_section = NULL,
     .last_section = NULL,
@@ -501,6 +502,21 @@ static inline void ebpf_create_statistic_load_chart(ebpf_module_t *em)
 }
 
 /**
+ * Update Internal Metric variable
+ *
+ * By default eBPF.plugin sends internal metrics for netdata, but user can
+ * disable this.
+ *
+ * The function updates the variable used to send charts.
+ */
+static void update_internal_metric_variable()
+{
+    const char *s = getenv("NETDATA_INTERNALS_MONITORING");
+    if (s && *s && strcmp(s, "NO") == 0)
+        publish_internal_metrics = false;
+}
+
+/**
  * Create Statistics Charts
  *
  * Create charts that will show statistics related to eBPF plugin.
@@ -509,6 +525,10 @@ static inline void ebpf_create_statistic_load_chart(ebpf_module_t *em)
  */
 static void ebpf_create_statistic_charts(ebpf_module_t *em)
 {
+    update_internal_metric_variable();
+    if (!publish_internal_metrics)
+        return;
+
     ebpf_create_statistic_thread_chart(em);
 
     ebpf_create_statistic_load_chart(em);
@@ -1079,6 +1099,9 @@ void ebpf_process_update_cgroup_algorithm()
  */
 void ebpf_send_statistic_data()
 {
+    if (!publish_internal_metrics)
+        return;
+
     write_begin_chart(NETDATA_MONITORING_FAMILY, NETDATA_EBPF_THREADS);
     write_chart_dimension(threads_stat[NETDATA_EBPF_THREAD_STAT_TOTAL], (long long)plugin_statistics.threads);
     write_chart_dimension(threads_stat[NETDATA_EBPF_THREAD_STAT_RUNNING], (long long)plugin_statistics.running);

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -34,8 +34,16 @@ static ebpf_local_maps_t shm_maps[] = {{.name = "tbl_pid_shm", .internal_input =
                                          .map_fd = ND_EBPF_MAP_FD_NOT_INITIALIZED},
                                         {.name = NULL, .internal_input = 0, .user_input = 0}};
 
-struct netdata_static_thread shm_threads = {"SHM KERNEL", NULL, NULL, 1,
-                                             NULL, NULL,  NULL};
+struct netdata_static_thread shm_threads = {
+                                            .name = "SHM KERNEL",
+                                            .config_section = NULL,
+                                            .config_name = NULL,
+                                            .env_name = NULL,
+                                            .enabled = 1,
+                                            .thread = NULL,
+                                            .init_routine = NULL,
+                                            .start_routine = NULL
+};
 static enum ebpf_threads_status ebpf_shm_exited = NETDATA_THREAD_EBPF_RUNNING;
 
 netdata_ebpf_targets_t shm_targets[] = { {.name = "shmget", .mode = EBPF_LOAD_TRAMPOLINE},

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -87,9 +87,16 @@ netdata_ebpf_targets_t socket_targets[] = { {.name = "inet_csk_accept", .mode = 
                                             {.name = "tcp_v6_connect", .mode = EBPF_LOAD_TRAMPOLINE},
                                             {.name = NULL, .mode = EBPF_LOAD_TRAMPOLINE}};
 
-struct netdata_static_thread socket_threads = {"EBPF SOCKET READ",
-                                               NULL, NULL, 1, NULL,
-                                               NULL, NULL };
+struct netdata_static_thread socket_threads = {
+    .name = "EBPF SOCKET READ",
+    .config_section = NULL,
+    .config_name = NULL,
+    .env_name = NULL,
+    .enabled = 1,
+    .thread = NULL,
+    .init_routine = NULL,
+    .start_routine = NULL
+};
 static enum ebpf_threads_status ebpf_socket_exited = NETDATA_THREAD_EBPF_RUNNING;
 
 #ifdef LIBBPF_MAJOR_VERSION

--- a/collectors/ebpf.plugin/ebpf_softirq.c
+++ b/collectors/ebpf.plugin/ebpf_softirq.c
@@ -54,9 +54,16 @@ static softirq_val_t softirq_vals[] = {
 // tmp store for soft IRQ values we get from a per-CPU eBPF map.
 static softirq_ebpf_val_t *softirq_ebpf_vals = NULL;
 
-static struct netdata_static_thread softirq_threads = {"SOFTIRQ KERNEL",
-                                                    NULL, NULL, 1, NULL,
-                                                    NULL, NULL };
+static struct netdata_static_thread softirq_threads = {
+    .name = "SOFTIRQ KERNEL",
+    .config_section = NULL,
+    .config_name = NULL,
+    .env_name = NULL,
+    .enabled = 1,
+    .thread = NULL,
+    .init_routine = NULL,
+    .start_routine = NULL
+};
 static enum ebpf_threads_status ebpf_softirq_exited = NETDATA_THREAD_EBPF_RUNNING;
 
 /**

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -34,8 +34,16 @@ static ebpf_local_maps_t swap_maps[] = {{.name = "tbl_pid_swap", .internal_input
                                          .map_fd = ND_EBPF_MAP_FD_NOT_INITIALIZED},
                                         {.name = NULL, .internal_input = 0, .user_input = 0}};
 
-struct netdata_static_thread swap_threads = {"SWAP KERNEL", NULL, NULL, 1,
-                                             NULL, NULL,  NULL};
+struct netdata_static_thread swap_threads = {
+    .name = "SWAP KERNEL",
+    .config_section = NULL,
+    .config_name = NULL,
+    .env_name = NULL,
+    .enabled = 1,
+    .thread = NULL,
+    .init_routine = NULL,
+    .start_routine = NULL
+};
 static enum ebpf_threads_status ebpf_swap_exited = NETDATA_THREAD_EBPF_RUNNING;
 
 netdata_ebpf_targets_t swap_targets[] = { {.name = "swap_readpage", .mode = EBPF_LOAD_TRAMPOLINE},

--- a/collectors/ebpf.plugin/ebpf_sync.c
+++ b/collectors/ebpf.plugin/ebpf_sync.c
@@ -10,8 +10,16 @@ static netdata_publish_syscall_t sync_counter_publish_aggregated[NETDATA_SYNC_ID
 
 static netdata_idx_t sync_hash_values[NETDATA_SYNC_IDX_END];
 
-struct netdata_static_thread sync_threads = {"SYNC KERNEL", NULL, NULL, 1,
-                                              NULL, NULL,  NULL};
+struct netdata_static_thread sync_threads = {
+    .name = "SYNC KERNEL",
+    .config_section = NULL,
+    .config_name = NULL,
+    .env_name = NULL,
+    .enabled = 1,
+    .thread = NULL,
+    .init_routine = NULL,
+    .start_routine = NULL
+};
 
 static ebpf_local_maps_t sync_maps[] = {{.name = "tbl_sync", .internal_input = NETDATA_SYNC_END,
                                          .user_input = 0, .type = NETDATA_EBPF_MAP_STATIC,

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -34,9 +34,16 @@ struct config vfs_config = { .first_section = NULL,
     .index = { .avl_tree = { .root = NULL, .compar = appconfig_section_compare },
     .rwlock = AVL_LOCK_INITIALIZER } };
 
-struct netdata_static_thread vfs_threads = {"VFS KERNEL",
-                                            NULL, NULL, 1, NULL,
-                                            NULL,  NULL};
+struct netdata_static_thread vfs_threads = {
+    .name = "VFS KERNEL",
+    .config_section = NULL,
+    .config_name = NULL,
+    .env_name = NULL,
+    .enabled = 1,
+    .thread = NULL,
+    .init_routine = NULL,
+    .start_routine = NULL
+};
 static enum ebpf_threads_status ebpf_vfs_exited = NETDATA_THREAD_EBPF_RUNNING;
 
 netdata_ebpf_targets_t vfs_targets[] = { {.name = "vfs_write", .mode = EBPF_LOAD_TRAMPOLINE},

--- a/collectors/statsd.plugin/statsd.c
+++ b/collectors/statsd.plugin/statsd.c
@@ -2532,173 +2532,209 @@ void *statsd_main(void *ptr) {
     // ----------------------------------------------------------------------------------------------------------------
     // statsd monitoring charts
 
-    RRDSET *st_metrics = rrdset_create_localhost(
-            "netdata"
-            , "statsd_metrics"
-            , NULL
-            , "statsd"
-            , NULL
-            , "Metrics in the netdata statsd database"
-            , "metrics"
-            , PLUGIN_STATSD_NAME
-            , "stats"
-            , 132010
-            , statsd.update_every
-            , RRDSET_TYPE_STACKED
-    );
-    RRDDIM *rd_metrics_gauge     = rrddim_add(st_metrics, "gauges", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-    RRDDIM *rd_metrics_counter   = rrddim_add(st_metrics, "counters", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-    RRDDIM *rd_metrics_timer     = rrddim_add(st_metrics, "timers", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-    RRDDIM *rd_metrics_meter     = rrddim_add(st_metrics, "meters", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-    RRDDIM *rd_metrics_histogram = rrddim_add(st_metrics, "histograms", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-    RRDDIM *rd_metrics_set       = rrddim_add(st_metrics, "sets", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-    RRDDIM *rd_metrics_dictionary= rrddim_add(st_metrics, "dictionaries", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+    RRDSET *st_metrics = NULL;
+    RRDDIM *rd_metrics_gauge = NULL;
+    RRDDIM *rd_metrics_counter = NULL;
+    RRDDIM *rd_metrics_timer = NULL;
+    RRDDIM *rd_metrics_meter = NULL;
+    RRDDIM *rd_metrics_histogram = NULL;
+    RRDDIM *rd_metrics_set = NULL;
+    RRDDIM *rd_metrics_dictionary = NULL;
+    RRDSET *st_useful_metrics = NULL;
+    RRDDIM *rd_useful_metrics_gauge = NULL;
+    RRDDIM *rd_useful_metrics_counter = NULL;
+    RRDDIM *rd_useful_metrics_timer = NULL;
+    RRDDIM *rd_useful_metrics_meter = NULL;
+    RRDDIM *rd_useful_metrics_histogram = NULL;
+    RRDDIM *rd_useful_metrics_set = NULL;
+    RRDDIM *rd_useful_metrics_dictionary = NULL;
+    RRDSET *st_events = NULL;
+    RRDDIM *rd_events_gauge = NULL;
+    RRDDIM *rd_events_counter = NULL;
+    RRDDIM *rd_events_timer = NULL;
+    RRDDIM *rd_events_meter = NULL;
+    RRDDIM *rd_events_histogram = NULL;
+    RRDDIM *rd_events_set = NULL;
+    RRDDIM *rd_events_dictionary = NULL;
+    RRDDIM *rd_events_unknown = NULL;
+    RRDDIM *rd_events_errors = NULL;
+    RRDSET *st_reads = NULL;
+    RRDDIM *rd_reads_tcp = NULL;
+    RRDDIM *rd_reads_udp = NULL;
+    RRDSET *st_bytes = NULL;
+    RRDDIM *rd_bytes_tcp = NULL;
+    RRDDIM *rd_bytes_udp = NULL;
+    RRDSET *st_packets = NULL;
+    RRDDIM *rd_packets_tcp = NULL;
+    RRDDIM *rd_packets_udp = NULL;
+    RRDSET *st_tcp_connects = NULL;
+    RRDDIM *rd_tcp_connects = NULL;
+    RRDDIM *rd_tcp_disconnects = NULL;
+    RRDSET *st_tcp_connected = NULL;
+    RRDDIM *rd_tcp_connected = NULL;
+    RRDSET *st_pcharts = NULL;
+    RRDDIM *rd_pcharts = NULL;
 
-    RRDSET *st_useful_metrics = rrdset_create_localhost(
-            "netdata"
-            , "statsd_useful_metrics"
-            , NULL
-            , "statsd"
-            , NULL
-            , "Useful metrics in the netdata statsd database"
-            , "metrics"
-            , PLUGIN_STATSD_NAME
-            , "stats"
-            , 132010
-            , statsd.update_every
-            , RRDSET_TYPE_STACKED
-    );
-    RRDDIM *rd_useful_metrics_gauge     = rrddim_add(st_useful_metrics, "gauges", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-    RRDDIM *rd_useful_metrics_counter   = rrddim_add(st_useful_metrics, "counters", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-    RRDDIM *rd_useful_metrics_timer     = rrddim_add(st_useful_metrics, "timers", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-    RRDDIM *rd_useful_metrics_meter     = rrddim_add(st_useful_metrics, "meters", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-    RRDDIM *rd_useful_metrics_histogram = rrddim_add(st_useful_metrics, "histograms", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-    RRDDIM *rd_useful_metrics_set       = rrddim_add(st_useful_metrics, "sets", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-    RRDDIM *rd_useful_metrics_dictionary= rrddim_add(st_useful_metrics, "dictionaries", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+    if(global_statistics_enabled) {
+        st_metrics = rrdset_create_localhost(
+            "netdata",
+            "statsd_metrics",
+            NULL,
+            "statsd",
+            NULL,
+            "Metrics in the netdata statsd database",
+            "metrics",
+            PLUGIN_STATSD_NAME,
+            "stats",
+            132010,
+            statsd.update_every,
+            RRDSET_TYPE_STACKED);
+        rd_metrics_gauge = rrddim_add(st_metrics, "gauges", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        rd_metrics_counter = rrddim_add(st_metrics, "counters", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        rd_metrics_timer = rrddim_add(st_metrics, "timers", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        rd_metrics_meter = rrddim_add(st_metrics, "meters", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        rd_metrics_histogram = rrddim_add(st_metrics, "histograms", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        rd_metrics_set = rrddim_add(st_metrics, "sets", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        rd_metrics_dictionary = rrddim_add(st_metrics, "dictionaries", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
 
-    RRDSET *st_events = rrdset_create_localhost(
-            "netdata"
-            , "statsd_events"
-            , NULL
-            , "statsd"
-            , NULL
-            , "Events processed by the netdata statsd server"
-            , "events/s"
-            , PLUGIN_STATSD_NAME
-            , "stats"
-            , 132011
-            , statsd.update_every
-            , RRDSET_TYPE_STACKED
-    );
-    RRDDIM *rd_events_gauge     = rrddim_add(st_events, "gauges", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
-    RRDDIM *rd_events_counter   = rrddim_add(st_events, "counters", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
-    RRDDIM *rd_events_timer     = rrddim_add(st_events, "timers", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
-    RRDDIM *rd_events_meter     = rrddim_add(st_events, "meters", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
-    RRDDIM *rd_events_histogram = rrddim_add(st_events, "histograms", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
-    RRDDIM *rd_events_set       = rrddim_add(st_events, "sets", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
-    RRDDIM *rd_events_dictionary= rrddim_add(st_events, "dictionaries", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
-    RRDDIM *rd_events_unknown   = rrddim_add(st_events, "unknown", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
-    RRDDIM *rd_events_errors    = rrddim_add(st_events, "errors", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        st_useful_metrics = rrdset_create_localhost(
+            "netdata",
+            "statsd_useful_metrics",
+            NULL,
+            "statsd",
+            NULL,
+            "Useful metrics in the netdata statsd database",
+            "metrics",
+            PLUGIN_STATSD_NAME,
+            "stats",
+            132010,
+            statsd.update_every,
+            RRDSET_TYPE_STACKED);
+        rd_useful_metrics_gauge = rrddim_add(st_useful_metrics, "gauges", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        rd_useful_metrics_counter = rrddim_add(st_useful_metrics, "counters", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        rd_useful_metrics_timer = rrddim_add(st_useful_metrics, "timers", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        rd_useful_metrics_meter = rrddim_add(st_useful_metrics, "meters", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        rd_useful_metrics_histogram = rrddim_add(st_useful_metrics, "histograms", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        rd_useful_metrics_set = rrddim_add(st_useful_metrics, "sets", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        rd_useful_metrics_dictionary = rrddim_add(st_useful_metrics, "dictionaries", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
 
-    RRDSET *st_reads = rrdset_create_localhost(
-            "netdata"
-            , "statsd_reads"
-            , NULL
-            , "statsd"
-            , NULL
-            , "Read operations made by the netdata statsd server"
-            , "reads/s"
-            , PLUGIN_STATSD_NAME
-            , "stats"
-            , 132012
-            , statsd.update_every
-            , RRDSET_TYPE_STACKED
-    );
-    RRDDIM *rd_reads_tcp = rrddim_add(st_reads, "tcp", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
-    RRDDIM *rd_reads_udp = rrddim_add(st_reads, "udp", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        st_events = rrdset_create_localhost(
+            "netdata",
+            "statsd_events",
+            NULL,
+            "statsd",
+            NULL,
+            "Events processed by the netdata statsd server",
+            "events/s",
+            PLUGIN_STATSD_NAME,
+            "stats",
+            132011,
+            statsd.update_every,
+            RRDSET_TYPE_STACKED);
+        rd_events_gauge = rrddim_add(st_events, "gauges", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rd_events_counter = rrddim_add(st_events, "counters", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rd_events_timer = rrddim_add(st_events, "timers", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rd_events_meter = rrddim_add(st_events, "meters", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rd_events_histogram = rrddim_add(st_events, "histograms", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rd_events_set = rrddim_add(st_events, "sets", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rd_events_dictionary = rrddim_add(st_events, "dictionaries", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rd_events_unknown = rrddim_add(st_events, "unknown", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rd_events_errors = rrddim_add(st_events, "errors", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
-    RRDSET *st_bytes = rrdset_create_localhost(
-            "netdata"
-            , "statsd_bytes"
-            , NULL
-            , "statsd"
-            , NULL
-            , "Bytes read by the netdata statsd server"
-            , "kilobits/s"
-            , PLUGIN_STATSD_NAME
-            , "stats"
-            , 132013
-            , statsd.update_every
-            , RRDSET_TYPE_STACKED
-    );
-    RRDDIM *rd_bytes_tcp = rrddim_add(st_bytes, "tcp", NULL, 8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
-    RRDDIM *rd_bytes_udp = rrddim_add(st_bytes, "udp", NULL, 8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
+        st_reads = rrdset_create_localhost(
+            "netdata",
+            "statsd_reads",
+            NULL,
+            "statsd",
+            NULL,
+            "Read operations made by the netdata statsd server",
+            "reads/s",
+            PLUGIN_STATSD_NAME,
+            "stats",
+            132012,
+            statsd.update_every,
+            RRDSET_TYPE_STACKED);
+        rd_reads_tcp = rrddim_add(st_reads, "tcp", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rd_reads_udp = rrddim_add(st_reads, "udp", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
-    RRDSET *st_packets = rrdset_create_localhost(
-            "netdata"
-            , "statsd_packets"
-            , NULL
-            , "statsd"
-            , NULL
-            , "Network packets processed by the netdata statsd server"
-            , "packets/s"
-            , PLUGIN_STATSD_NAME
-            , "stats"
-            , 132014
-            , statsd.update_every
-            , RRDSET_TYPE_STACKED
-    );
-    RRDDIM *rd_packets_tcp = rrddim_add(st_packets, "tcp", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
-    RRDDIM *rd_packets_udp = rrddim_add(st_packets, "udp", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        st_bytes = rrdset_create_localhost(
+            "netdata",
+            "statsd_bytes",
+            NULL,
+            "statsd",
+            NULL,
+            "Bytes read by the netdata statsd server",
+            "kilobits/s",
+            PLUGIN_STATSD_NAME,
+            "stats",
+            132013,
+            statsd.update_every,
+            RRDSET_TYPE_STACKED);
+        rd_bytes_tcp = rrddim_add(st_bytes, "tcp", NULL, 8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
+        rd_bytes_udp = rrddim_add(st_bytes, "udp", NULL, 8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
 
-    RRDSET *st_tcp_connects = rrdset_create_localhost(
-            "netdata"
-            , "tcp_connects"
-            , NULL
-            , "statsd"
-            , NULL
-            , "statsd server TCP connects and disconnects"
-            , "events"
-            , PLUGIN_STATSD_NAME
-            , "stats"
-            , 132015
-            , statsd.update_every
-            , RRDSET_TYPE_LINE
-    );
-    RRDDIM *rd_tcp_connects = rrddim_add(st_tcp_connects, "connects", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
-    RRDDIM *rd_tcp_disconnects = rrddim_add(st_tcp_connects, "disconnects", NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
+        st_packets = rrdset_create_localhost(
+            "netdata",
+            "statsd_packets",
+            NULL,
+            "statsd",
+            NULL,
+            "Network packets processed by the netdata statsd server",
+            "packets/s",
+            PLUGIN_STATSD_NAME,
+            "stats",
+            132014,
+            statsd.update_every,
+            RRDSET_TYPE_STACKED);
+        rd_packets_tcp = rrddim_add(st_packets, "tcp", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rd_packets_udp = rrddim_add(st_packets, "udp", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
-    RRDSET *st_tcp_connected = rrdset_create_localhost(
-            "netdata"
-            , "tcp_connected"
-            , NULL
-            , "statsd"
-            , NULL
-            , "statsd server TCP connected sockets"
-            , "sockets"
-            , PLUGIN_STATSD_NAME
-            , "stats"
-            , 132016
-            , statsd.update_every
-            , RRDSET_TYPE_LINE
-    );
-    RRDDIM *rd_tcp_connected = rrddim_add(st_tcp_connected, "connected", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        st_tcp_connects = rrdset_create_localhost(
+            "netdata",
+            "tcp_connects",
+            NULL,
+            "statsd",
+            NULL,
+            "statsd server TCP connects and disconnects",
+            "events",
+            PLUGIN_STATSD_NAME,
+            "stats",
+            132015,
+            statsd.update_every,
+            RRDSET_TYPE_LINE);
+        rd_tcp_connects = rrddim_add(st_tcp_connects, "connects", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rd_tcp_disconnects = rrddim_add(st_tcp_connects, "disconnects", NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
 
-    RRDSET *st_pcharts = rrdset_create_localhost(
-            "netdata"
-            , "private_charts"
-            , NULL
-            , "statsd"
-            , NULL
-            , "Private metric charts created by the netdata statsd server"
-            , "charts"
-            , PLUGIN_STATSD_NAME
-            , "stats"
-            , 132020
-            , statsd.update_every
-            , RRDSET_TYPE_AREA
-    );
-    RRDDIM *rd_pcharts = rrddim_add(st_pcharts, "charts", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        st_tcp_connected = rrdset_create_localhost(
+            "netdata",
+            "tcp_connected",
+            NULL,
+            "statsd",
+            NULL,
+            "statsd server TCP connected sockets",
+            "sockets",
+            PLUGIN_STATSD_NAME,
+            "stats",
+            132016,
+            statsd.update_every,
+            RRDSET_TYPE_LINE);
+        rd_tcp_connected = rrddim_add(st_tcp_connected, "connected", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+
+        st_pcharts = rrdset_create_localhost(
+            "netdata",
+            "private_charts",
+            NULL,
+            "statsd",
+            NULL,
+            "Private metric charts created by the netdata statsd server",
+            "charts",
+            PLUGIN_STATSD_NAME,
+            "stats",
+            132020,
+            statsd.update_every,
+            RRDSET_TYPE_AREA);
+        rd_pcharts = rrddim_add(st_pcharts, "charts", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+    }
 
     // ----------------------------------------------------------------------------------------------------------------
     // statsd thread to turn metrics into charts
@@ -2737,68 +2773,70 @@ void *statsd_main(void *ptr) {
         if(unlikely(netdata_exit))
             break;
 
-        if(likely(hb_dt)) {
-            rrdset_next(st_metrics);
-            rrdset_next(st_useful_metrics);
-            rrdset_next(st_events);
-            rrdset_next(st_reads);
-            rrdset_next(st_bytes);
-            rrdset_next(st_packets);
-            rrdset_next(st_tcp_connects);
-            rrdset_next(st_tcp_connected);
-            rrdset_next(st_pcharts);
+        if(global_statistics_enabled) {
+            if(likely(hb_dt)) {
+                rrdset_next(st_metrics);
+                rrdset_next(st_useful_metrics);
+                rrdset_next(st_events);
+                rrdset_next(st_reads);
+                rrdset_next(st_bytes);
+                rrdset_next(st_packets);
+                rrdset_next(st_tcp_connects);
+                rrdset_next(st_tcp_connected);
+                rrdset_next(st_pcharts);
+            }
+
+            rrddim_set_by_pointer(st_metrics, rd_metrics_gauge,        (collected_number)statsd.gauges.metrics);
+            rrddim_set_by_pointer(st_metrics, rd_metrics_counter,      (collected_number)statsd.counters.metrics);
+            rrddim_set_by_pointer(st_metrics, rd_metrics_timer,        (collected_number)statsd.timers.metrics);
+            rrddim_set_by_pointer(st_metrics, rd_metrics_meter,        (collected_number)statsd.meters.metrics);
+            rrddim_set_by_pointer(st_metrics, rd_metrics_histogram,    (collected_number)statsd.histograms.metrics);
+            rrddim_set_by_pointer(st_metrics, rd_metrics_set,          (collected_number)statsd.sets.metrics);
+            rrddim_set_by_pointer(st_metrics, rd_metrics_dictionary,   (collected_number)statsd.dictionaries.metrics);
+            rrdset_done(st_metrics);
+
+            rrddim_set_by_pointer(st_useful_metrics, rd_useful_metrics_gauge,        (collected_number)statsd.gauges.useful);
+            rrddim_set_by_pointer(st_useful_metrics, rd_useful_metrics_counter,      (collected_number)statsd.counters.useful);
+            rrddim_set_by_pointer(st_useful_metrics, rd_useful_metrics_timer,        (collected_number)statsd.timers.useful);
+            rrddim_set_by_pointer(st_useful_metrics, rd_useful_metrics_meter,        (collected_number)statsd.meters.useful);
+            rrddim_set_by_pointer(st_useful_metrics, rd_useful_metrics_histogram,    (collected_number)statsd.histograms.useful);
+            rrddim_set_by_pointer(st_useful_metrics, rd_useful_metrics_set,          (collected_number)statsd.sets.useful);
+            rrddim_set_by_pointer(st_useful_metrics, rd_useful_metrics_dictionary,   (collected_number)statsd.dictionaries.useful);
+            rrdset_done(st_useful_metrics);
+
+            rrddim_set_by_pointer(st_events,  rd_events_gauge,         (collected_number)statsd.gauges.events);
+            rrddim_set_by_pointer(st_events,  rd_events_counter,       (collected_number)statsd.counters.events);
+            rrddim_set_by_pointer(st_events,  rd_events_timer,         (collected_number)statsd.timers.events);
+            rrddim_set_by_pointer(st_events,  rd_events_meter,         (collected_number)statsd.meters.events);
+            rrddim_set_by_pointer(st_events,  rd_events_histogram,     (collected_number)statsd.histograms.events);
+            rrddim_set_by_pointer(st_events,  rd_events_set,           (collected_number)statsd.sets.events);
+            rrddim_set_by_pointer(st_events,  rd_events_dictionary,    (collected_number)statsd.dictionaries.events);
+            rrddim_set_by_pointer(st_events,  rd_events_unknown,       (collected_number)statsd.unknown_types);
+            rrddim_set_by_pointer(st_events,  rd_events_errors,        (collected_number)statsd.socket_errors);
+            rrdset_done(st_events);
+
+            rrddim_set_by_pointer(st_reads,   rd_reads_tcp,            (collected_number)statsd.tcp_socket_reads);
+            rrddim_set_by_pointer(st_reads,   rd_reads_udp,            (collected_number)statsd.udp_socket_reads);
+            rrdset_done(st_reads);
+
+            rrddim_set_by_pointer(st_bytes,   rd_bytes_tcp,            (collected_number)statsd.tcp_bytes_read);
+            rrddim_set_by_pointer(st_bytes,   rd_bytes_udp,            (collected_number)statsd.udp_bytes_read);
+            rrdset_done(st_bytes);
+
+            rrddim_set_by_pointer(st_packets, rd_packets_tcp,          (collected_number)statsd.tcp_packets_received);
+            rrddim_set_by_pointer(st_packets, rd_packets_udp,          (collected_number)statsd.udp_packets_received);
+            rrdset_done(st_packets);
+
+            rrddim_set_by_pointer(st_tcp_connects, rd_tcp_connects,    (collected_number)statsd.tcp_socket_connects);
+            rrddim_set_by_pointer(st_tcp_connects, rd_tcp_disconnects, (collected_number)statsd.tcp_socket_disconnects);
+            rrdset_done(st_tcp_connects);
+
+            rrddim_set_by_pointer(st_tcp_connected, rd_tcp_connected,  (collected_number)statsd.tcp_socket_connected);
+            rrdset_done(st_tcp_connected);
+
+            rrddim_set_by_pointer(st_pcharts, rd_pcharts,              (collected_number)statsd.private_charts);
+            rrdset_done(st_pcharts);
         }
-
-        rrddim_set_by_pointer(st_metrics, rd_metrics_gauge,        (collected_number)statsd.gauges.metrics);
-        rrddim_set_by_pointer(st_metrics, rd_metrics_counter,      (collected_number)statsd.counters.metrics);
-        rrddim_set_by_pointer(st_metrics, rd_metrics_timer,        (collected_number)statsd.timers.metrics);
-        rrddim_set_by_pointer(st_metrics, rd_metrics_meter,        (collected_number)statsd.meters.metrics);
-        rrddim_set_by_pointer(st_metrics, rd_metrics_histogram,    (collected_number)statsd.histograms.metrics);
-        rrddim_set_by_pointer(st_metrics, rd_metrics_set,          (collected_number)statsd.sets.metrics);
-        rrddim_set_by_pointer(st_metrics, rd_metrics_dictionary,   (collected_number)statsd.dictionaries.metrics);
-        rrdset_done(st_metrics);
-
-        rrddim_set_by_pointer(st_useful_metrics, rd_useful_metrics_gauge,        (collected_number)statsd.gauges.useful);
-        rrddim_set_by_pointer(st_useful_metrics, rd_useful_metrics_counter,      (collected_number)statsd.counters.useful);
-        rrddim_set_by_pointer(st_useful_metrics, rd_useful_metrics_timer,        (collected_number)statsd.timers.useful);
-        rrddim_set_by_pointer(st_useful_metrics, rd_useful_metrics_meter,        (collected_number)statsd.meters.useful);
-        rrddim_set_by_pointer(st_useful_metrics, rd_useful_metrics_histogram,    (collected_number)statsd.histograms.useful);
-        rrddim_set_by_pointer(st_useful_metrics, rd_useful_metrics_set,          (collected_number)statsd.sets.useful);
-        rrddim_set_by_pointer(st_useful_metrics, rd_useful_metrics_dictionary,   (collected_number)statsd.dictionaries.useful);
-        rrdset_done(st_useful_metrics);
-
-        rrddim_set_by_pointer(st_events,  rd_events_gauge,         (collected_number)statsd.gauges.events);
-        rrddim_set_by_pointer(st_events,  rd_events_counter,       (collected_number)statsd.counters.events);
-        rrddim_set_by_pointer(st_events,  rd_events_timer,         (collected_number)statsd.timers.events);
-        rrddim_set_by_pointer(st_events,  rd_events_meter,         (collected_number)statsd.meters.events);
-        rrddim_set_by_pointer(st_events,  rd_events_histogram,     (collected_number)statsd.histograms.events);
-        rrddim_set_by_pointer(st_events,  rd_events_set,           (collected_number)statsd.sets.events);
-        rrddim_set_by_pointer(st_events,  rd_events_dictionary,    (collected_number)statsd.dictionaries.events);
-        rrddim_set_by_pointer(st_events,  rd_events_unknown,       (collected_number)statsd.unknown_types);
-        rrddim_set_by_pointer(st_events,  rd_events_errors,        (collected_number)statsd.socket_errors);
-        rrdset_done(st_events);
-
-        rrddim_set_by_pointer(st_reads,   rd_reads_tcp,            (collected_number)statsd.tcp_socket_reads);
-        rrddim_set_by_pointer(st_reads,   rd_reads_udp,            (collected_number)statsd.udp_socket_reads);
-        rrdset_done(st_reads);
-
-        rrddim_set_by_pointer(st_bytes,   rd_bytes_tcp,            (collected_number)statsd.tcp_bytes_read);
-        rrddim_set_by_pointer(st_bytes,   rd_bytes_udp,            (collected_number)statsd.udp_bytes_read);
-        rrdset_done(st_bytes);
-
-        rrddim_set_by_pointer(st_packets, rd_packets_tcp,          (collected_number)statsd.tcp_packets_received);
-        rrddim_set_by_pointer(st_packets, rd_packets_udp,          (collected_number)statsd.udp_packets_received);
-        rrdset_done(st_packets);
-
-        rrddim_set_by_pointer(st_tcp_connects, rd_tcp_connects,    (collected_number)statsd.tcp_socket_connects);
-        rrddim_set_by_pointer(st_tcp_connects, rd_tcp_disconnects, (collected_number)statsd.tcp_socket_disconnects);
-        rrdset_done(st_tcp_connects);
-
-        rrddim_set_by_pointer(st_tcp_connected, rd_tcp_connected,  (collected_number)statsd.tcp_socket_connected);
-        rrdset_done(st_tcp_connected);
-
-        rrddim_set_by_pointer(st_pcharts, rd_pcharts,              (collected_number)statsd.private_charts);
-        rrdset_done(st_pcharts);
     }
 
 cleanup: ; // added semi-colon to prevent older gcc error: label at end of compound statement

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -16,6 +16,8 @@
 #error WORKER_UTILIZATION_MAX_JOB_TYPES has to be at least 5
 #endif
 
+bool global_statistics_enabled = true;
+
 static struct global_statistics {
     volatile uint16_t connected_clients;
 

--- a/daemon/global_statistics.h
+++ b/daemon/global_statistics.h
@@ -21,4 +21,6 @@ extern void finished_web_request_statistics(uint64_t dt,
 extern uint64_t web_client_connected(void);
 extern void web_client_disconnected(void);
 
+extern bool global_statistics_enabled;
+
 #endif /* NETDATA_GLOBAL_STATISTICS_H */

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1405,8 +1405,13 @@ int main(int argc, char **argv) {
 
             if(st->enabled && st->init_routine)
                 st->init_routine();
-        }
 
+            if(st->env_name)
+                setenv(st->env_name, st->enabled?"YES":"NO", 1);
+
+            if(st->global_variable)
+                *st->global_variable = (st->enabled && st->init_routine) ? true : false;
+        }
 
         // --------------------------------------------------------------------
         // create the listening sockets

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1410,7 +1410,7 @@ int main(int argc, char **argv) {
                 setenv(st->env_name, st->enabled?"YES":"NO", 1);
 
             if(st->global_variable)
-                *st->global_variable = (st->enabled && st->init_routine) ? true : false;
+                *st->global_variable = (st->enabled) ? true : false;
         }
 
         // --------------------------------------------------------------------

--- a/daemon/static_threads.c
+++ b/daemon/static_threads.c
@@ -13,6 +13,8 @@ extern void *service_main(void *ptr);
 extern void *statsd_main(void *ptr);
 extern void *timex_main(void *ptr);
 
+extern bool global_statistics_enabled;
+
 const struct netdata_static_thread static_threads_common[] = {
     {
         .name = "PLUGIN[timex]",
@@ -52,8 +54,10 @@ const struct netdata_static_thread static_threads_common[] = {
     },
     {
         .name = "GLOBAL_STATS",
-        .config_section = NULL,
-        .config_name = NULL,
+        .config_section = CONFIG_SECTION_PLUGINS,
+        .config_name = "netdata monitoring",
+        .env_name = "NETDATA_INTERNALS_MONITORING",
+        .global_variable = &global_statistics_enabled,
         .enabled = 1,
         .thread = NULL,
         .init_routine = NULL,
@@ -145,7 +149,17 @@ const struct netdata_static_thread static_threads_common[] = {
         .start_routine = rrdcontext_main
     },
 
-    {NULL, NULL, NULL, 0, NULL, NULL, NULL}
+    // terminator
+    {
+        .name = NULL,
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 0,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    }
 };
 
 struct netdata_static_thread *

--- a/daemon/static_threads.h
+++ b/daemon/static_threads.h
@@ -26,6 +26,12 @@ struct netdata_static_thread {
 
     // the threaded worker
     void *(*start_routine) (void *);
+
+    // the environment variable to create
+    char *env_name;
+
+    // global variable
+    bool *global_variable;
 };
 
 #define NETDATA_MAIN_THREAD_RUNNING     CONFIG_BOOLEAN_YES

--- a/daemon/static_threads_linux.c
+++ b/daemon/static_threads_linux.c
@@ -46,15 +46,45 @@ const struct netdata_static_thread static_threads_linux[] = {
         .start_routine = cgroups_main
     },
 
-    {NULL, NULL, NULL, 0, NULL, NULL, NULL}
+    // terminator
+    {
+        .name = NULL,
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 0,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    }
 };
 
 const struct netdata_static_thread static_threads_freebsd[] = {
-    {NULL, NULL, NULL, 0, NULL, NULL, NULL}
+    // terminator
+    {
+        .name = NULL,
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 0,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    }
 };
 
 const struct netdata_static_thread static_threads_macos[] = {
-    {NULL, NULL, NULL, 0, NULL, NULL, NULL}
+    // terminator
+    {
+        .name = NULL,
+        .config_section = NULL,
+        .config_name = NULL,
+        .env_name = NULL,
+        .enabled = 0,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = NULL
+    }
 };
 
 struct netdata_static_thread *static_threads_get() {

--- a/exporting/send_internal_metrics.c
+++ b/exporting/send_internal_metrics.c
@@ -11,6 +11,9 @@
  */
 void create_main_rusage_chart(RRDSET **st_rusage, RRDDIM **rd_user, RRDDIM **rd_system)
 {
+    if (!global_statistics_enabled)
+        return;
+        
     if (*st_rusage && *rd_user && *rd_system)
         return;
 
@@ -31,6 +34,9 @@ void create_main_rusage_chart(RRDSET **st_rusage, RRDDIM **rd_user, RRDDIM **rd_
  */
 void send_main_rusage(RRDSET *st_rusage, RRDDIM *rd_user, RRDDIM *rd_system)
 {
+    if (!global_statistics_enabled)
+        return;
+
     struct rusage thread;
     getrusage(RUSAGE_THREAD, &thread);
 
@@ -52,6 +58,9 @@ void send_main_rusage(RRDSET *st_rusage, RRDDIM *rd_user, RRDDIM *rd_system)
  */
 void send_internal_metrics(struct instance *instance)
 {
+    if (!global_statistics_enabled)
+        return;
+
     struct stats *stats = &instance->stats;
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds the netdata.conf option:

```
[plugins]
   netdata monitoring = yes | no
```

It disables global statistics of Netdata Agent.

Users may need to disable netdata internal monitoring to lower the number of collected metrics, thus lowering the memory and CPU footprint of Netdata Agents.

An environment variable is exposed to let the plugins know:

```
NETDATA_INTERNALS_MONITORING=YES|NO
```

When set to `NO`, plugins are expected to disable reporting of their internal metrics.

- [x] global statistics
- [x] statsd
- [x] aclk
- [x] ebpf.d.plugin
- [x] go.d.plugin
- [x] python.d.plugin

@thiagoftsm @ilyam8 please help me finish this. I can't do the rest. You can check apps.plugin to see what you need to do.