### PR TITLE
full memory tracking and profiling of Netdata Agent

### DIFF
--- a/aclk/aclk_tx_msgs.c
+++ b/aclk/aclk_tx_msgs.c
@@ -15,6 +15,13 @@
 // version for aclk legacy (old cloud arch)
 #define ACLK_VERSION 2
 
+static void freez_aclk_publish5a(void *ptr) {
+    freez(ptr);
+}
+static void freez_aclk_publish5b(void *ptr) {
+    freez(ptr);
+}
+
 uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, size_t msg_len, enum aclk_topics subtopic, const char *msgname)
 {
 #ifndef ACLK_LOG_CONVERSATION_DIR
@@ -29,7 +36,7 @@ uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, s
     }
 
     if (use_mqtt_5)
-        mqtt_wss_publish5(client, (char*)topic, NULL, msg, &freez, msg_len, MQTT_WSS_PUB_QOS1, &packet_id);
+        mqtt_wss_publish5(client, (char*)topic, NULL, msg, &freez_aclk_publish5a, msg_len, MQTT_WSS_PUB_QOS1, &packet_id);
     else
         mqtt_wss_publish_pid(client, topic, msg, msg_len,  MQTT_WSS_PUB_QOS1, &packet_id);
 
@@ -81,7 +88,7 @@ static int aclk_send_message_with_bin_payload(mqtt_wss_client client, json_objec
     }
 
     if (use_mqtt_5)
-        mqtt_wss_publish5(client, (char*)topic, NULL, (char*)(payload_len ? full_msg : str), (payload_len ? &freez : &json_object_put_wrapper), len, MQTT_WSS_PUB_QOS1, &packet_id);
+        mqtt_wss_publish5(client, (char*)topic, NULL, (char*)(payload_len ? full_msg : str), (payload_len ? &freez_aclk_publish5b : &json_object_put_wrapper), len, MQTT_WSS_PUB_QOS1, &packet_id);
     else {
         rc = mqtt_wss_publish_pid_block(client, topic, payload_len ? full_msg : str, len,  MQTT_WSS_PUB_QOS1, &packet_id, 5000);
         freez(full_msg);

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -2553,8 +2553,10 @@ void *global_statistics_main(void *ptr)
         worker_is_busy(WORKER_JOB_REGISTRY);
         registry_statistics();
 
-        worker_is_busy(WORKER_JOB_DBENGINE);
-        dbengine_statistics_charts();
+        if(dbengine_enabled) {
+            worker_is_busy(WORKER_JOB_DBENGINE);
+            dbengine_statistics_charts();
+        }
 
         worker_is_busy(WORKER_JOB_HEARTBEAT);
         update_heartbeat_charts();

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -11,8 +11,9 @@
 #define WORKER_JOB_HEARTBEAT          4
 #define WORKER_JOB_STRINGS            5
 #define WORKER_JOB_DICTIONARIES       6
+#define WORKER_JOB_MALLOC_TRACE       7
 
-#if WORKER_UTILIZATION_MAX_JOB_TYPES < 7
+#if WORKER_UTILIZATION_MAX_JOB_TYPES < 8
 #error WORKER_UTILIZATION_MAX_JOB_TYPES has to be at least 5
 #endif
 
@@ -1571,6 +1572,153 @@ static void update_dictionary_category_charts(struct dictionary_categories *c) {
     }
 }
 
+#ifdef NETDATA_TRACE_ALLOCATIONS
+
+struct memory_trace_data {
+    RRDSET *st_memory;
+    RRDSET *st_allocations;
+    RRDSET *st_avg_alloc;
+    RRDSET *st_ops;
+};
+
+static int do_memory_trace_item(void *item, void *data) {
+    struct memory_trace_data *tmp = data;
+    struct malloc_trace *p = item;
+
+    // ------------------------------------------------------------------------
+
+    if(!p->rd_bytes)
+        p->rd_bytes = rrddim_add(tmp->st_memory, p->function, NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+
+    collected_number bytes = (collected_number)__atomic_load_n(&p->bytes, __ATOMIC_RELAXED);
+    rrddim_set_by_pointer(tmp->st_memory, p->rd_bytes, bytes);
+
+    // ------------------------------------------------------------------------
+
+    if(!p->rd_allocations)
+        p->rd_allocations = rrddim_add(tmp->st_allocations, p->function, NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+
+    collected_number allocs = (collected_number)__atomic_load_n(&p->allocations, __ATOMIC_RELAXED);
+    rrddim_set_by_pointer(tmp->st_allocations, p->rd_allocations, allocs);
+
+    // ------------------------------------------------------------------------
+
+    if(!p->rd_avg_alloc)
+        p->rd_avg_alloc = rrddim_add(tmp->st_avg_alloc, p->function, NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
+
+    collected_number avg_alloc = (allocs)?(bytes * 100 / allocs):0;
+    rrddim_set_by_pointer(tmp->st_avg_alloc, p->rd_avg_alloc, avg_alloc);
+
+    // ------------------------------------------------------------------------
+
+    if(!p->rd_ops)
+        p->rd_ops = rrddim_add(tmp->st_ops, p->function, NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+
+    collected_number ops = 0;
+    ops += (collected_number)__atomic_load_n(&p->malloc_calls, __ATOMIC_RELAXED);
+    ops += (collected_number)__atomic_load_n(&p->calloc_calls, __ATOMIC_RELAXED);
+    ops += (collected_number)__atomic_load_n(&p->realloc_calls, __ATOMIC_RELAXED);
+    ops += (collected_number)__atomic_load_n(&p->strdup_calls, __ATOMIC_RELAXED);
+    ops += (collected_number)__atomic_load_n(&p->free_calls, __ATOMIC_RELAXED);
+    rrddim_set_by_pointer(tmp->st_ops, p->rd_ops, ops);
+
+    // ------------------------------------------------------------------------
+
+    return 1;
+}
+static void malloc_trace_statistics(void) {
+    static struct memory_trace_data tmp = {
+        .st_memory = NULL,
+        .st_allocations = NULL,
+        .st_avg_alloc = NULL,
+        .st_ops = NULL,
+    };
+
+    if(!tmp.st_memory) {
+        tmp.st_memory = rrdset_create_localhost(
+            "netdata"
+            , "memory_size"
+            , NULL
+            , "memory"
+            , "netdata.memory.size"
+            , "Netdata Memory Used by Function"
+            , "bytes"
+            , "netdata"
+            , "stats"
+            , 900000
+            , localhost->rrd_update_every
+            , RRDSET_TYPE_STACKED
+        );
+    }
+    else
+        rrdset_next(tmp.st_memory);
+
+    if(!tmp.st_ops) {
+        tmp.st_ops = rrdset_create_localhost(
+            "netdata"
+            , "memory_operations"
+            , NULL
+            , "memory"
+            , "netdata.memory.operations"
+            , "Netdata Memory Operations by Function"
+            , "ops/s"
+            , "netdata"
+            , "stats"
+            , 900001
+            , localhost->rrd_update_every
+            , RRDSET_TYPE_LINE
+        );
+    }
+    else
+        rrdset_next(tmp.st_ops);
+
+    if(!tmp.st_allocations) {
+        tmp.st_allocations = rrdset_create_localhost(
+            "netdata"
+            , "memory_allocations"
+            , NULL
+            , "memory"
+            , "netdata.memory.allocations"
+            , "Netdata Memory Allocations by Function"
+            , "allocations"
+            , "netdata"
+            , "stats"
+            , 900002
+            , localhost->rrd_update_every
+            , RRDSET_TYPE_STACKED
+        );
+    }
+    else
+        rrdset_next(tmp.st_allocations);
+
+    if(!tmp.st_avg_alloc) {
+        tmp.st_avg_alloc = rrdset_create_localhost(
+            "netdata"
+            , "memory_avg_alloc"
+            , NULL
+            , "memory"
+            , "netdata.memory.avg_alloc"
+            , "Netdata Average Allocation Size by Function"
+            , "bytes"
+            , "netdata"
+            , "stats"
+            , 900003
+            , localhost->rrd_update_every
+            , RRDSET_TYPE_LINE
+        );
+    }
+    else
+        rrdset_next(tmp.st_avg_alloc);
+
+    malloc_trace_walkthrough(do_memory_trace_item, &tmp);
+
+    rrdset_done(tmp.st_memory);
+    rrdset_done(tmp.st_ops);
+    rrdset_done(tmp.st_allocations);
+    rrdset_done(tmp.st_avg_alloc);
+}
+#endif
+
 static void dictionary_statistics(void) {
     for(int i = 0; dictionary_categories[i].stats ;i++) {
         update_dictionary_category_charts(&dictionary_categories[i]);
@@ -2375,6 +2523,7 @@ void *global_statistics_main(void *ptr)
     worker_register_job_name(WORKER_JOB_DBENGINE, "dbengine");
     worker_register_job_name(WORKER_JOB_STRINGS, "strings");
     worker_register_job_name(WORKER_JOB_DICTIONARIES, "dictionaries");
+    worker_register_job_name(WORKER_JOB_MALLOC_TRACE, "malloc_trace");
 
     netdata_thread_cleanup_push(global_statistics_cleanup, ptr);
 
@@ -2415,6 +2564,11 @@ void *global_statistics_main(void *ptr)
 
         worker_is_busy(WORKER_JOB_DICTIONARIES);
         dictionary_statistics();
+
+#ifdef NETDATA_TRACE_ALLOCATIONS
+        worker_is_busy(WORKER_JOB_MALLOC_TRACE);
+        malloc_trace_statistics();
+#endif
     }
 
     netdata_thread_cleanup_pop(1);

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -259,7 +259,8 @@ void cancel_main_threads() {
 
     for (i = 0; static_threads[i].name != NULL ; i++)
         freez(static_threads[i].thread);
-    free(static_threads);
+
+    freez(static_threads);
 }
 
 struct option_def option_definitions[] = {

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -55,13 +55,17 @@ void netdata_cleanup_and_exit(int ret) {
         // free the database
         info("EXIT: freeing database memory...");
 #ifdef ENABLE_DBENGINE
-        for(int tier = 0; tier < storage_tiers ; tier++)
-            rrdeng_prepare_exit(multidb_ctx[tier]);
+        if(dbengine_enabled) {
+            for (int tier = 0; tier < storage_tiers; tier++)
+                rrdeng_prepare_exit(multidb_ctx[tier]);
+        }
 #endif
         rrdhost_free_all();
 #ifdef ENABLE_DBENGINE
-        for(int tier = 0; tier < storage_tiers ; tier++)
-            rrdeng_exit(multidb_ctx[tier]);
+        if(dbengine_enabled) {
+            for (int tier = 0; tier < storage_tiers; tier++)
+                rrdeng_exit(multidb_ctx[tier]);
+        }
 #endif
     }
     sql_close_context_database();

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1006,6 +1006,8 @@ int main(int argc, char **argv) {
                             if(string_unittest(10000)) return 1;
                             if (dictionary_unittest(10000))
                                 return 1;
+                            if(aral_unittest(10000))
+                                return 1;
                             if (rrdlabels_unittest())
                                 return 1;
                             if (ctx_unittest())
@@ -1027,6 +1029,9 @@ int main(int argc, char **argv) {
                         }
                         else if(strcmp(optarg, "dicttest") == 0) {
                             return dictionary_unittest(10000);
+                        }
+                        else if(strcmp(optarg, "araltest") == 0) {
+                            return aral_unittest(10000);
                         }
                         else if(strcmp(optarg, "stringtest") == 0) {
                             return string_unittest(10000);

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -216,10 +216,8 @@ restart_after_removal:
             info("Host '%s' with machine guid '%s' is obsolete - cleaning up.", rrdhost_hostname(host), host->machine_guid);
 
             if (rrdhost_option_check(host, RRDHOST_OPTION_DELETE_ORPHAN_HOST)
-#ifdef ENABLE_DBENGINE
                 /* don't delete multi-host DB host files */
                 && !(host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && is_storage_engine_shared(host->storage_instance[0]))
-#endif
             ) {
                 worker_is_busy(WORKER_JOB_DELETE_HOST_CHARTS);
                 rrdhost_delete_charts(host);

--- a/database/engine/journalfile.c
+++ b/database/engine/journalfile.c
@@ -527,7 +527,7 @@ int load_journal_file(struct rrdengine_instance *ctx, struct rrdengine_journalfi
 
     info("Journal file \"%s\" loaded (size:%"PRIu64").", path, file_size);
     if (likely(journalfile->data))
-        munmap(journalfile->data, file_size);
+        netdata_munmap(journalfile->data, file_size);
     return 0;
 
     error:

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -30,7 +30,7 @@ void dbengine_page_free(void *page) {
     if (unlikely(db_engine_use_malloc))
         freez(page);
     else
-        munmap(page, RRDENG_BLOCK_SIZE);
+        netdata_munmap(page, RRDENG_BLOCK_SIZE);
 }
 
 static void sanity_check(void)

--- a/database/ram/rrddim_mem.c
+++ b/database/ram/rrddim_mem.c
@@ -142,7 +142,7 @@ void rrddim_query_init(STORAGE_METRIC_HANDLE *db_metric_handle, struct rrddim_qu
     handle->rd = rd;
     handle->start_time = start_time;
     handle->end_time = end_time;
-    struct mem_query_handle* h = callocz(1, sizeof(struct mem_query_handle));
+    struct mem_query_handle* h = mallocz(sizeof(struct mem_query_handle));
     h->slot           = rrddim_time2slot(rd, start_time);
     h->last_slot      = rrddim_time2slot(rd, end_time);
     h->dt = rd->rrdset->update_every;

--- a/database/ram/rrddim_mem.c
+++ b/database/ram/rrddim_mem.c
@@ -16,7 +16,7 @@ void rrddim_metric_free(STORAGE_METRIC_HANDLE *db_metric_handle __maybe_unused) 
 STORAGE_COLLECT_HANDLE *rrddim_collect_init(STORAGE_METRIC_HANDLE *db_metric_handle) {
     RRDDIM *rd = (RRDDIM *)db_metric_handle;
     rd->db[rd->rrdset->current_entry] = pack_storage_number(NAN, SN_FLAG_NONE);
-    struct mem_collect_handle *ch = calloc(1, sizeof(struct mem_collect_handle));
+    struct mem_collect_handle *ch = callocz(1, sizeof(struct mem_collect_handle));
     ch->rd = rd;
     return (STORAGE_COLLECT_HANDLE *)ch;
 }
@@ -46,7 +46,7 @@ void rrddim_store_metric_flush(STORAGE_COLLECT_HANDLE *collection_handle) {
 }
 
 int rrddim_collect_finalize(STORAGE_COLLECT_HANDLE *collection_handle) {
-    free(collection_handle);
+    freez(collection_handle);
     return 0;
 }
 
@@ -142,7 +142,7 @@ void rrddim_query_init(STORAGE_METRIC_HANDLE *db_metric_handle, struct rrddim_qu
     handle->rd = rd;
     handle->start_time = start_time;
     handle->end_time = end_time;
-    struct mem_query_handle* h = calloc(1, sizeof(struct mem_query_handle));
+    struct mem_query_handle* h = callocz(1, sizeof(struct mem_query_handle));
     h->slot           = rrddim_time2slot(rd, start_time);
     h->last_slot      = rrddim_time2slot(rd, end_time);
     h->dt = rd->rrdset->update_every;

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -52,6 +52,7 @@ struct pg_cache_page_index;
 #include "sqlite/sqlite_health.h"
 #include "rrdcontext.h"
 
+extern bool dbengine_enabled;
 extern int storage_tiers;
 extern int storage_tiers_grouping_iterations[RRD_STORAGE_TIERS];
 

--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -2200,7 +2200,7 @@ static void rrdmetric_update_retention(RRDMETRIC *rm) {
         max_last_time_t = rrddim_last_entry_t(rm->rrddim);
     }
 #ifdef ENABLE_DBENGINE
-    else {
+    else if (dbengine_enabled) {
         RRDHOST *rrdhost = rm->ri->rc->rrdhost;
         for (int tier = 0; tier < storage_tiers; tier++) {
             if(!rrdhost->storage_instance[tier]) continue;
@@ -2214,6 +2214,10 @@ static void rrdmetric_update_retention(RRDMETRIC *rm) {
                     max_last_time_t = last_time_t;
             }
         }
+    }
+    else {
+        // cannot get retention
+        return;
     }
 #endif
 

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -27,6 +27,12 @@ struct rrddim_constructor {
 
 };
 
+// isolated call to appear
+// separate in statistics
+static void *rrddim_alloc_db(size_t entries) {
+    return callocz(entries, sizeof(storage_number));
+}
+
 static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, void *rrddim, void *constructor_data) {
     struct rrddim_constructor *ctr = constructor_data;
     RRDDIM *rd = rrddim;
@@ -73,7 +79,7 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
         size_t entries = st->entries;
         if(entries < 5) entries = 5;
 
-        rd->db = callocz(entries, sizeof(storage_number));
+        rd->db = rrddim_alloc_db(entries);
         rd->memsize = entries * sizeof(storage_number);
     }
 
@@ -222,7 +228,7 @@ static void rrddim_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, v
 
     if(rd->db) {
         if(rd->rrd_memory_mode == RRD_MEMORY_MODE_RAM)
-            munmap(rd->db, rd->memsize);
+            netdata_munmap(rd->db, rd->memsize);
         else
             freez(rd->db);
     }
@@ -641,7 +647,7 @@ void rrddim_memory_file_free(RRDDIM *rd) {
 
     struct rrddim_map_save_v019 *rd_on_file = rd->rd_on_file;
     freez(rd_on_file->cache_filename);
-    munmap(rd_on_file, rd_on_file->memsize);
+    netdata_munmap(rd_on_file, rd_on_file->memsize);
 
     // remove the pointers from the RRDDIM
     rd->rd_on_file = NULL;

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -2,9 +2,6 @@
 
 #define NETDATA_RRD_INTERNALS
 #include "rrd.h"
-#ifdef ENABLE_DBENGINE
-#include "database/engine/rrdengineapi.h"
-#endif
 #include "storage_engine.h"
 
 // ----------------------------------------------------------------------------

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -888,8 +888,10 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
         error_report("Failed to initialize context metadata database");
     }
 
-    if (unlikely(!system_info))
+    if (unlikely(strcmp(hostname, "unittest"))) {
+        dbengine_enabled = true;
         goto unittest;
+    }
 
     rrdpush_init();
 

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -336,7 +336,12 @@ RRDHOST *rrdhost_create(const char *hostname,
         memory_mode = RRD_MEMORY_MODE_ALLOC;
     }
 
+#ifdef ENABLE_DBENGINE
     int is_legacy = (memory_mode == RRD_MEMORY_MODE_DBENGINE) && is_legacy_child(guid);
+#else
+int is_legacy = 1;
+#endif
+
     int is_in_multihost = (memory_mode == RRD_MEMORY_MODE_DBENGINE && !is_legacy);
     RRDHOST *host = callocz(1, sizeof(RRDHOST));
 

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -888,7 +888,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
         error_report("Failed to initialize context metadata database");
     }
 
-    if (unlikely(strcmp(hostname, "unittest"))) {
+    if (unlikely(strcmp(hostname, "unittest") == 0)) {
         dbengine_enabled = true;
         goto unittest;
     }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -895,7 +895,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
 
     rrdpush_init();
 
-    if(default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE || storage_tiers > 1 || rrdpush_needs_dbengine()) {
+    if(default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE || storage_tiers > 1 || rrdpush_receiver_needs_dbengine()) {
         info("Initializing dbengine...");
         dbengine_init(hostname);
     }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -754,22 +754,7 @@ inline int rrdhost_should_be_removed(RRDHOST *host, RRDHOST *protected_host, tim
 // ----------------------------------------------------------------------------
 // RRDHOST global / startup initialization
 
-int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
-    rrdhost_init();
-
-    if (unlikely(sql_init_database(DB_CHECK_NONE, system_info ? 0 : 1))) {
-        if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
-            fatal("Failed to initialize SQLite");
-        info("Skipping SQLITE metadata initialization since memory mode is not dbengine");
-    }
-
-    if (unlikely(sql_init_context_database(system_info ? 0 : 1))) {
-        error_report("Failed to initialize context metadata database");
-    }
-
-    if (unlikely(!system_info))
-        goto unittest;
-
+void dbengine_init(char *hostname) {
 #ifdef ENABLE_DBENGINE
     storage_tiers = config_get_number(CONFIG_SECTION_DB, "storage tiers", storage_tiers);
     if(storage_tiers < 1) {
@@ -857,7 +842,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
             error("DBENGINE on '%s': dbengine tier %d gives aggregation of more than 65535 points of tier 0. Disabling tiers above %d", hostname, tier, tier);
             break;
         }
-        
+
         internal_error(true, "DBENGINE tier %d grouping iterations is set to %d", tier, storage_tiers_grouping_iterations[tier]);
         ret = rrdeng_init(NULL, NULL, dbenginepath, page_cache_mb, disk_space_mb, tier);
         if(ret != 0) {
@@ -885,9 +870,34 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
         config_set_number(CONFIG_SECTION_DB, "storage tiers", storage_tiers);
     }
 #endif
+}
+
+int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
+    rrdhost_init();
+
+    if (unlikely(sql_init_database(DB_CHECK_NONE, system_info ? 0 : 1))) {
+        if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
+            fatal("Failed to initialize SQLite");
+        info("Skipping SQLITE metadata initialization since memory mode is not dbengine");
+    }
+
+    if (unlikely(sql_init_context_database(system_info ? 0 : 1))) {
+        error_report("Failed to initialize context metadata database");
+    }
+
+    if (unlikely(!system_info))
+        goto unittest;
+
+    rrdpush_init();
+
+    if(default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE || storage_tiers > 1 || rrdpush_needs_dbengine()) {
+        info("Initializing dbengine...");
+        dbengine_init(hostname);
+    }
+    else
+        info("Not initializing dbengine...");
 
     health_init();
-    rrdpush_init();
 
 unittest:
     debug(D_RRDHOST, "Initializing localhost with hostname '%s'", hostname);

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1972,7 +1972,7 @@ void rrdset_memory_file_free(RRDSET *st) {
     rrdset_memory_file_update(st);
 
     struct rrdset_map_save_v019 *st_on_file = st->st_on_file;
-    munmap(st_on_file, st_on_file->memsize);
+    netdata_munmap(st_on_file, st_on_file->memsize);
 
     // remove the pointers from the RRDDIM
     st->st_on_file = NULL;

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -264,13 +264,6 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
 
     struct rrdhost_system_info *system_info = callocz(1, sizeof(struct rrdhost_system_info));
     system_info->hops = str2i((const char *) argv[IDX_HOPS]);
-    RRD_MEMORY_MODE memory_mode;
-
-#ifdef ENABLE_DBENGINE
-    memory_mode = RRD_MEMORY_MODE_DBENGINE;
-#else
-    memory_mode = RRD_MEMORY_MODE_RAM;
-#endif
 
     sql_build_host_system_info((uuid_t *)argv[IDX_HOST_ID], system_info);
 
@@ -287,7 +280,7 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
         , (const char *) (argv[IDX_PROGRAM_VERSION] ? argv[IDX_PROGRAM_VERSION] : "unknown")
         , argv[3] ? str2i(argv[IDX_UPDATE_EVERY]) : 1
         , argv[13] ? str2i(argv[IDX_ENTRIES]) : 0
-        , memory_mode
+        , default_rrd_memory_mode
         , 0 // health
         , 0 // rrdpush enabled
         , NULL  //destination

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -1408,8 +1408,10 @@ RRDHOST *sql_create_host_by_uuid(char *hostname)
     rrdhost_flag_set(host, RRDHOST_FLAG_ARCHIVED);
 
 #ifdef ENABLE_DBENGINE
-    for(int tier = 0; tier < storage_tiers ; tier++)
-        host->storage_instance[tier] = (STORAGE_INSTANCE *)multidb_ctx[tier];
+    if(dbengine_enabled) {
+        for (int tier = 0; tier < storage_tiers; tier++)
+            host->storage_instance[tier] = (STORAGE_INSTANCE *)multidb_ctx[tier];
+    }
 #endif
 
 failed:

--- a/libnetdata/arrayalloc/arrayalloc.c
+++ b/libnetdata/arrayalloc/arrayalloc.c
@@ -363,3 +363,89 @@ void arrayalloc_freez(ARAL *ar, void *ptr) {
 
     arrayalloc_unlock(ar);
 }
+
+int aral_unittest(size_t elements) {
+    char *cache_dir = "/tmp/";
+    ARAL *ar = arrayalloc_create(20, 10, "test-aral", &cache_dir);
+    ar->use_mmap = false;
+
+    void *pointers[elements];
+
+    for(size_t i = 0; i < elements ;i++) {
+        pointers[i] = arrayalloc_mallocz(ar);
+    }
+
+    for(size_t div = 5; div >= 2 ;div--) {
+        for (size_t i = 0; i < elements / div; i++) {
+            arrayalloc_freez(ar, pointers[i]);
+        }
+
+        for (size_t i = 0; i < elements / div; i++) {
+            pointers[i] = arrayalloc_mallocz(ar);
+        }
+    }
+
+    for(size_t step = 50; step >= 10 ;step -= 10) {
+        for (size_t i = 0; i < elements; i += step) {
+            arrayalloc_freez(ar, pointers[i]);
+        }
+
+        for (size_t i = 0; i < elements; i += step) {
+            pointers[i] = arrayalloc_mallocz(ar);
+        }
+    }
+
+    for(size_t i = 0; i < elements ;i++) {
+        arrayalloc_freez(ar, pointers[i]);
+    }
+
+    if(ar->internal.first_page) {
+        fprintf(stderr, "ARAL leftovers detected (1)");
+        return 1;
+    }
+
+    size_t ops = 0;
+    size_t increment = elements / 10;
+    size_t allocated = 0;
+    for(size_t all = increment; all <= elements ; all += increment) {
+
+        for(; allocated < all ; allocated++) {
+            pointers[allocated] = arrayalloc_mallocz(ar);
+            ops++;
+        }
+
+        size_t to_free = now_realtime_usec() % all;
+        size_t free_list[to_free];
+        for(size_t i = 0; i < to_free ;i++) {
+            size_t pos;
+            do {
+                pos = now_realtime_usec() % all;
+            } while(!pointers[pos]);
+
+            arrayalloc_freez(ar, pointers[pos]);
+            pointers[pos] = NULL;
+            free_list[i] = pos;
+            ops++;
+        }
+
+        for(size_t i = 0; i < to_free ;i++) {
+            size_t pos = free_list[i];
+            pointers[pos] = arrayalloc_mallocz(ar);
+            ops++;
+        }
+    }
+
+    for(size_t i = 0; i < allocated - 1 ;i++) {
+        arrayalloc_freez(ar, pointers[i]);
+        ops++;
+    }
+
+    arrayalloc_freez(ar, pointers[allocated - 1]);
+
+    if(ar->internal.first_page) {
+        fprintf(stderr, "ARAL leftovers detected (2)");
+        return 1;
+    }
+
+    return 0;
+}

--- a/libnetdata/arrayalloc/arrayalloc.h
+++ b/libnetdata/arrayalloc/arrayalloc.h
@@ -29,7 +29,20 @@ typedef struct arrayalloc {
 } ARAL;
 
 extern ARAL *arrayalloc_create(size_t element_size, size_t elements, const char *filename, char **cache_dir);
+
+#ifdef NETDATA_TRACE_ALLOCATIONS
+
+#define arrayalloc_mallocz(ar) arrayalloc_mallocz_int(ar, __FILE__, __FUNCTION__, __LINE__)
+#define arrayalloc_freez(ar, ptr) arrayalloc_freez_int(ar, ptr, __FILE__, __FUNCTION__, __LINE__)
+
+extern void *arrayalloc_mallocz_int(ARAL *ar, const char *file, const char *function, size_t line);
+extern void arrayalloc_freez_int(ARAL *ar, void *ptr, const char *file, const char *function, size_t line);
+
+#else // NETDATA_TRACE_ALLOCATIONS
+
 extern void *arrayalloc_mallocz(ARAL *ar);
 extern void arrayalloc_freez(ARAL *ar, void *ptr);
+
+#endif // NETDATA_TRACE_ALLOCATIONS
 
 #endif // ARRAYALLOC_H

--- a/libnetdata/arrayalloc/arrayalloc.h
+++ b/libnetdata/arrayalloc/arrayalloc.h
@@ -29,6 +29,7 @@ typedef struct arrayalloc {
 } ARAL;
 
 ARAL *arrayalloc_create(size_t element_size, size_t elements, const char *filename, char **cache_dir);
+int aral_unittest(size_t elements);
 
 #ifdef NETDATA_TRACE_ALLOCATIONS
 

--- a/libnetdata/config/appconfig.c
+++ b/libnetdata/config/appconfig.c
@@ -473,7 +473,7 @@ NETDATA_DOUBLE appconfig_get_float(struct config *root, const char *section, con
     return str2ndd(s, NULL);
 }
 
-static inline int appconfig_test_boolean_value(char *s) {
+inline int appconfig_test_boolean_value(char *s) {
     if(!strcasecmp(s, "yes") || !strcasecmp(s, "true") || !strcasecmp(s, "on")
        || !strcasecmp(s, "auto") || !strcasecmp(s, "on demand"))
         return 1;

--- a/libnetdata/config/appconfig.h
+++ b/libnetdata/config/appconfig.h
@@ -199,6 +199,8 @@ extern struct section *appconfig_get_section(struct config *root, const char *na
 extern void appconfig_wrlock(struct config *root);
 extern void appconfig_unlock(struct config *root);
 
+extern int appconfig_test_boolean_value(char *s);
+
 struct connector_instance {
     char instance_name[CONFIG_MAX_NAME + 1];
     char connector_name[CONFIG_MAX_NAME + 1];

--- a/libnetdata/config/appconfig.h
+++ b/libnetdata/config/appconfig.h
@@ -199,7 +199,7 @@ struct section *appconfig_get_section(struct config *root, const char *name);
 void appconfig_wrlock(struct config *root);
 void appconfig_unlock(struct config *root);
 
-extern int appconfig_test_boolean_value(char *s);
+int appconfig_test_boolean_value(char *s);
 
 struct connector_instance {
     char instance_name[CONFIG_MAX_NAME + 1];

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -11,6 +11,14 @@ extern "C" {
 #include <config.h>
 #endif
 
+#if defined(NETDATA_DEV_MODE) && !defined(NETDATA_INTERNAL_CHECKS)
+#define NETDATA_INTERNAL_CHECKS 1
+#endif
+
+#if defined(NETDATA_INTERNAL_CHECKS) && !defined(NETDATA_TRACE_ALLOCATIONS)
+#define NETDATA_TRACE_ALLOCATIONS 1
+#endif
+
 #define OS_LINUX   1
 #define OS_FREEBSD 2
 #define OS_MACOS   3

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -487,13 +487,10 @@ static int rrdpush_receive(struct receiver_state *rpt)
     mode = rrd_memory_mode_id(appconfig_get(&stream_config, rpt->key, "default memory mode", rrd_memory_mode_name(mode)));
     mode = rrd_memory_mode_id(appconfig_get(&stream_config, rpt->machine_guid, "memory mode", rrd_memory_mode_name(mode)));
 
-#ifndef ENABLE_DBENGINE
-    if (unlikely(mode == RRD_MEMORY_MODE_DBENGINE)) {
-        close(rpt->fd);
-        log_stream_connection(rpt->client_ip, rpt->client_port, rpt->key, rpt->machine_guid, rpt->hostname, "REJECTED -- DBENGINE MEMORY MODE NOT SUPPORTED");
-        return 1;
+    if (unlikely(mode == RRD_MEMORY_MODE_DBENGINE && !dbengine_enabled)) {
+        error("STREAM %s [receive from %s:%s]: dbengine is not enabled, falling back to default.", rpt->hostname, rpt->client_ip, rpt->client_port);
+        mode = default_rrd_memory_mode;
     }
-#endif
 
     health_enabled = appconfig_get_boolean_ondemand(&stream_config, rpt->key, "health enabled by default", health_enabled);
     health_enabled = appconfig_get_boolean_ondemand(&stream_config, rpt->machine_guid, "health enabled", health_enabled);

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -66,6 +66,31 @@ static void load_stream_conf() {
     freez(filename);
 }
 
+bool rrdpush_needs_dbengine() {
+    struct section *co;
+
+    for(co = stream_config.first_section; co; co = co->next) {
+        if(strcmp(co->name, "stream") == 0)
+            continue; // the first section is not relevant
+
+        char *s;
+
+        s = appconfig_get_by_section(co, "enabled", NULL);
+        if(!s || !appconfig_test_boolean_value(s))
+            continue;
+
+        s = appconfig_get_by_section(co, "default memory mode", NULL);
+        if(s && strcmp(s, "dbengine") == 0)
+            return true;
+
+        s = appconfig_get_by_section(co, "memory mode", NULL);
+        if(s && strcmp(s, "dbengine") == 0)
+            return true;
+    }
+
+    return false;
+}
+
 int rrdpush_init() {
     // --------------------------------------------------------------------
     // load stream.conf

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -66,7 +66,7 @@ static void load_stream_conf() {
     freez(filename);
 }
 
-bool rrdpush_needs_dbengine() {
+bool rrdpush_receiver_needs_dbengine() {
     struct section *co;
 
     for(co = stream_config.first_section; co; co = co->next) {

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -228,6 +228,7 @@ BUFFER *sender_start(struct sender_state *s);
 void sender_commit(struct sender_state *s, BUFFER *wb);
 void sender_cancel(struct sender_state *s);
 extern int rrdpush_init();
+extern bool rrdpush_needs_dbengine();
 extern int configured_as_parent();
 extern void rrdset_done_push(RRDSET *st);
 extern bool rrdset_push_chart_definition_now(RRDSET *st);

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -228,7 +228,7 @@ BUFFER *sender_start(struct sender_state *s);
 void sender_commit(struct sender_state *s, BUFFER *wb);
 void sender_cancel(struct sender_state *s);
 int rrdpush_init();
-bool rrdpush_needs_dbengine();
+bool rrdpush_receiver_needs_dbengine();
 int configured_as_parent();
 void rrdset_done_push(RRDSET *st);
 bool rrdset_push_chart_definition_now(RRDSET *st);

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1621,9 +1621,14 @@ int web_client_api_request_v1_dbengine_stats(RRDHOST *host __maybe_unused, struc
 
     BUFFER *wb = w->response.data;
     buffer_flush(wb);
+
+    if(!dbengine_enabled) {
+        buffer_strcat(wb, "dbengine is not enabled");
+        return HTTP_RESP_NOT_FOUND;
+    }
+
     wb->contenttype = CT_APPLICATION_JSON;
     buffer_no_cacheable(wb);
-
     buffer_strcat(wb, "{");
     for(int tier = 0; tier < storage_tiers ;tier++) {
         buffer_sprintf(wb, "%s\n\t\"tier%d\": {", tier?",":"", tier);


### PR DESCRIPTION
This PR tracks all `mallocz()`, `callocz()`, `reallocz()`, `strdupz()` and `freez()` calls, per function calling them, and generates 4 charts in the Netdata Monitoring section:

- total currently memory allocated per function
- total currently memory allocations per function
- average memory allocation per function (based on the currently allocated memory)
- rate of operations per function

To enable it, compile netdata with `-DNETDATA_TRACE_ALLOCATIONS=1`. It is slower that running without it, so it is only available as a compile time option.

It works like this:

- [x] replaces all these functions with the ones tracking usage
- [x] maintains an AVL tree (AVL instead of Judy, because AVL does not allocate memory itself, so it does not interfere with memory tracking) of all the functions doing memory allocations.
- [x] when a memory call is made, it uses the AVL tree to find the structure of the calling function and it updates a few usage counters.
- [x] global statistics traverses this AVL tree every second and generates the 4 charts mentioned, all providing information per function.
- [x] array allocator propagates its own calling function to these statistics - before that all array allocator callers were hidden behind it.
- [x] I renamed a few functions in PROCFILE and DICTIONARY, to make them more descriptive for the charts.

While implementing this, I found that a few modules of netdata do not use these functions, or mix these functions with the libc ones:

- [x] rrddim_mem storage engine
- [ ] aclk_tx_msgs is mixing `freez()` with `malloc()` (instead of `mallocz()`) - @underhood please fix this - You will also using the `freez()` as a function pointer. This is not possible since `freez()` is now a macro. So, I created 2 wrapper functions for you. I receive lines like these at error.log: `pointer 0x55556e84f440 is not our pointer (called freez_int() from 19@aclk/aclk_tx_msgs.c, freez_aclk_publish5a()).` What they mean is that you are attempting to `freez()` a pointer that has not been allocated with any of the `z` functions.
- [ ] mqtt-ng is using the libc ones - @underhood please fix this too
- [ ] aclk-schemas - @underhood please fix this too

Example charts generated:

![image](https://user-images.githubusercontent.com/2662304/194723278-8dd69119-cccc-4679-acb6-d4e8f41cb6ec.png)


---

## Why is this important?

It all started this this forum thread: https://community.netdata.cloud/t/insane-netdata-memory-usage/3342

The user believes our memory footprint is insane. 

He is right. We do need a lot of memory with every single module enabled.

As I see it, the main problem is that are failing to explain to our users how they should use Netdata. Netdata has really a lot of functions and modules and of course it needs memory when all of them are enabled.

So I plan to use this PR to create the necessary documentation, with facts, of what exactly is happening and what is the suggested deployment option for every case.
