### PR TITLE
Remove extern from function declared in headers.

### DIFF
--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -163,8 +163,8 @@ enum ebpf_algorithms_list {
 };
 
 // Threads
-extern void *ebpf_process_thread(void *ptr);
-extern void *ebpf_socket_thread(void *ptr);
+void *ebpf_process_thread(void *ptr);
+void *ebpf_socket_thread(void *ptr);
 
 // Common variables
 extern pthread_mutex_t lock;
@@ -177,14 +177,14 @@ extern pthread_mutex_t collect_data_mutex;
 extern pthread_cond_t collect_data_cond_var;
 
 // Common functions
-extern void ebpf_global_labels(netdata_syscall_stat_t *is,
+void ebpf_global_labels(netdata_syscall_stat_t *is,
                                netdata_publish_syscall_t *pio,
                                char **dim,
                                char **name,
                                int *algorithm,
                                int end);
 
-extern void ebpf_write_chart_cmd(char *type,
+void ebpf_write_chart_cmd(char *type,
                                  char *id,
                                  char *title,
                                  char *units,
@@ -195,11 +195,11 @@ extern void ebpf_write_chart_cmd(char *type,
                                  int update_every,
                                  char *module);
 
-extern void ebpf_write_global_dimension(char *name, char *id, char *algorithm);
+void ebpf_write_global_dimension(char *name, char *id, char *algorithm);
 
-extern void ebpf_create_global_dimension(void *ptr, int end);
+void ebpf_create_global_dimension(void *ptr, int end);
 
-extern void ebpf_create_chart(char *type,
+void ebpf_create_chart(char *type,
                               char *id,
                               char *title,
                               char *units,
@@ -213,18 +213,18 @@ extern void ebpf_create_chart(char *type,
                               int update_every,
                               char *module);
 
-extern void write_begin_chart(char *family, char *name);
+void write_begin_chart(char *family, char *name);
 
-extern void write_chart_dimension(char *dim, long long value);
+void write_chart_dimension(char *dim, long long value);
 
-extern void write_count_chart(char *name, char *family, netdata_publish_syscall_t *move, uint32_t end);
+void write_count_chart(char *name, char *family, netdata_publish_syscall_t *move, uint32_t end);
 
-extern void write_err_chart(char *name, char *family, netdata_publish_syscall_t *move, int end);
+void write_err_chart(char *name, char *family, netdata_publish_syscall_t *move, int end);
 
-extern void write_io_chart(char *chart, char *family, char *dwrite, long long vwrite,
+void write_io_chart(char *chart, char *family, char *dwrite, long long vwrite,
                            char *dread, long long vread);
 
-extern void ebpf_create_charts_on_apps(char *name,
+void ebpf_create_charts_on_apps(char *name,
                                        char *title,
                                        char *units,
                                        char *family,
@@ -235,15 +235,15 @@ extern void ebpf_create_charts_on_apps(char *name,
                                        int update_every,
                                        char *module);
 
-extern void write_end_chart();
+void write_end_chart();
 
-extern void ebpf_cleanup_publish_syscall(netdata_publish_syscall_t *nps);
+void ebpf_cleanup_publish_syscall(netdata_publish_syscall_t *nps);
 
-extern int ebpf_enable_tracepoint(ebpf_tracepoint_t *tp);
-extern int ebpf_disable_tracepoint(ebpf_tracepoint_t *tp);
-extern uint32_t ebpf_enable_tracepoints(ebpf_tracepoint_t *tps);
+int ebpf_enable_tracepoint(ebpf_tracepoint_t *tp);
+int ebpf_disable_tracepoint(ebpf_tracepoint_t *tp);
+uint32_t ebpf_enable_tracepoints(ebpf_tracepoint_t *tps);
 
-extern void ebpf_pid_file(char *filename, size_t length);
+void ebpf_pid_file(char *filename, size_t length);
 
 #define EBPF_PROGRAMS_SECTION "ebpf programs"
 
@@ -279,15 +279,15 @@ extern void *default_btf;
 
 // Socket functions and variables
 // Common functions
-extern void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr);
-extern void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr);
-extern void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *root);
-extern void ebpf_one_dimension_write_charts(char *family, char *chart, char *dim, long long v1);
-extern collected_number get_value_from_structure(char *basis, size_t offset);
-extern void ebpf_update_pid_table(ebpf_local_maps_t *pid, ebpf_module_t *em);
-extern void ebpf_write_chart_obsolete(char *type, char *id, char *title, char *units, char *family,
+void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr);
+void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr);
+void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *root);
+void ebpf_one_dimension_write_charts(char *family, char *chart, char *dim, long long v1);
+collected_number get_value_from_structure(char *basis, size_t offset);
+void ebpf_update_pid_table(ebpf_local_maps_t *pid, ebpf_module_t *em);
+void ebpf_write_chart_obsolete(char *type, char *id, char *title, char *units, char *family,
                                       char *charttype, char *context, int order, int update_every);
-extern void write_histogram_chart(char *family, char *name, const netdata_idx_t *hist, char **dimensions, uint32_t end);
+void write_histogram_chart(char *family, char *name, const netdata_idx_t *hist, char **dimensions, uint32_t end);
 void ebpf_update_disabled_plugin_stats(ebpf_module_t *em);
 extern ebpf_filesystem_partitions_t localfs[];
 extern ebpf_sync_syscalls_t local_syscalls[];

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -408,30 +408,30 @@ static inline void debug_log_int(const char *fmt, ...)
 //
 extern struct pid_stat **all_pids;
 
-extern int ebpf_read_apps_groups_conf(struct target **apps_groups_default_target,
+int ebpf_read_apps_groups_conf(struct target **apps_groups_default_target,
                                       struct target **apps_groups_root_target,
                                       const char *path,
                                       const char *file);
 
-extern void clean_apps_groups_target(struct target *apps_groups_root_target);
+void clean_apps_groups_target(struct target *apps_groups_root_target);
 
-extern size_t zero_all_targets(struct target *root);
+size_t zero_all_targets(struct target *root);
 
-extern int am_i_running_as_root();
+int am_i_running_as_root();
 
-extern void cleanup_exited_pids();
+void cleanup_exited_pids();
 
-extern int ebpf_read_hash_table(void *ep, int fd, uint32_t pid);
+int ebpf_read_hash_table(void *ep, int fd, uint32_t pid);
 
-extern int get_pid_comm(pid_t pid, size_t n, char *dest);
+int get_pid_comm(pid_t pid, size_t n, char *dest);
 
-extern size_t read_processes_statistic_using_pid_on_target(ebpf_process_stat_t **ep,
+size_t read_processes_statistic_using_pid_on_target(ebpf_process_stat_t **ep,
                                                            int fd,
                                                            struct pid_on_target *pids);
 
-extern size_t read_bandwidth_statistic_using_pid_on_target(ebpf_bandwidth_t **ep, int fd, struct pid_on_target *pids);
+size_t read_bandwidth_statistic_using_pid_on_target(ebpf_bandwidth_t **ep, int fd, struct pid_on_target *pids);
 
-extern void collect_data_for_all_processes(int tbl_pid_stats_fd);
+void collect_data_for_all_processes(int tbl_pid_stats_fd);
 
 extern ebpf_process_stat_t **global_process_stats;
 extern ebpf_process_publish_apps_t **current_apps_data;

--- a/collectors/ebpf.plugin/ebpf_cachestat.h
+++ b/collectors/ebpf.plugin/ebpf_cachestat.h
@@ -81,7 +81,7 @@ typedef struct netdata_publish_cachestat {
     netdata_cachestat_pid_t prev;
 } netdata_publish_cachestat_t;
 
-extern void *ebpf_cachestat_thread(void *ptr);
+void *ebpf_cachestat_thread(void *ptr);
 
 extern struct config cachestat_config;
 extern netdata_ebpf_targets_t cachestat_targets[];

--- a/collectors/ebpf.plugin/ebpf_cgroup.h
+++ b/collectors/ebpf.plugin/ebpf_cgroup.h
@@ -60,10 +60,10 @@ typedef struct ebpf_cgroup_target {
     struct ebpf_cgroup_target *next;
 } ebpf_cgroup_target_t;
 
-extern void ebpf_map_cgroup_shared_memory();
-extern void ebpf_parse_cgroup_shm_data();
-extern void ebpf_close_cgroup_shm();
-extern void ebpf_create_charts_on_systemd(char *id, char *title, char *units, char *family, char *charttype, int order,
+void ebpf_map_cgroup_shared_memory();
+void ebpf_parse_cgroup_shm_data();
+void ebpf_close_cgroup_shm();
+void ebpf_create_charts_on_systemd(char *id, char *title, char *units, char *family, char *charttype, int order,
                                           char *algorithm, char *context, char *module, int update_every);
 
 #endif /* NETDATA_EBPF_CGROUP_H */

--- a/collectors/ebpf.plugin/ebpf_dcstat.h
+++ b/collectors/ebpf.plugin/ebpf_dcstat.h
@@ -75,8 +75,8 @@ typedef struct netdata_publish_dcstat {
     netdata_dcstat_pid_t prev;
 } netdata_publish_dcstat_t;
 
-extern void *ebpf_dcstat_thread(void *ptr);
-extern void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr);
+void *ebpf_dcstat_thread(void *ptr);
+void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr);
 extern struct config dcstat_config;
 extern netdata_ebpf_targets_t dc_targets[];
 extern ebpf_local_maps_t dcstat_maps[];

--- a/collectors/ebpf.plugin/ebpf_disk.h
+++ b/collectors/ebpf.plugin/ebpf_disk.h
@@ -72,7 +72,7 @@ typedef struct netdata_ebpf_publish_disk {
 
 extern struct config disk_config;
 
-extern void *ebpf_disk_thread(void *ptr);
+void *ebpf_disk_thread(void *ptr);
 
 #endif /* NETDATA_EBPF_DISK_H */
 

--- a/collectors/ebpf.plugin/ebpf_fd.h
+++ b/collectors/ebpf.plugin/ebpf_fd.h
@@ -75,8 +75,8 @@ enum fd_syscalls {
 };
 
 
-extern void *ebpf_fd_thread(void *ptr);
-extern void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr);
+void *ebpf_fd_thread(void *ptr);
+void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr);
 extern struct config fd_config;
 extern netdata_fd_stat_t **fd_pid;
 extern netdata_ebpf_targets_t fd_targets[];

--- a/collectors/ebpf.plugin/ebpf_filesystem.h
+++ b/collectors/ebpf.plugin/ebpf_filesystem.h
@@ -43,7 +43,7 @@ enum netdata_filesystem_table {
     NETDATA_ADDR_FS_TABLE
 };
 
-extern void *ebpf_filesystem_thread(void *ptr);
+void *ebpf_filesystem_thread(void *ptr);
 extern struct config fs_config;
 
 #endif /* NETDATA_EBPF_FILESYSTEM_H */

--- a/collectors/ebpf.plugin/ebpf_hardirq.h
+++ b/collectors/ebpf.plugin/ebpf_hardirq.h
@@ -68,6 +68,6 @@ typedef struct hardirq_static_val {
 } hardirq_static_val_t;
 
 extern struct config hardirq_config;
-extern void *ebpf_hardirq_thread(void *ptr);
+void *ebpf_hardirq_thread(void *ptr);
 
 #endif /* NETDATA_EBPF_HARDIRQ_H */

--- a/collectors/ebpf.plugin/ebpf_mdflush.h
+++ b/collectors/ebpf.plugin/ebpf_mdflush.h
@@ -35,7 +35,7 @@ typedef struct netdata_mdflush {
     uint64_t cnt;
 } netdata_mdflush_t;
 
-extern void *ebpf_mdflush_thread(void *ptr);
+void *ebpf_mdflush_thread(void *ptr);
 
 extern struct config mdflush_config;
 

--- a/collectors/ebpf.plugin/ebpf_mount.h
+++ b/collectors/ebpf.plugin/ebpf_mount.h
@@ -38,7 +38,7 @@ enum netdata_mount_syscalls {
 };
 
 extern struct config mount_config;
-extern void *ebpf_mount_thread(void *ptr);
+void *ebpf_mount_thread(void *ptr);
 extern netdata_ebpf_targets_t mount_targets[];
 
 #endif /* NETDATA_EBPF_MOUNT_H */

--- a/collectors/ebpf.plugin/ebpf_oomkill.h
+++ b/collectors/ebpf.plugin/ebpf_oomkill.h
@@ -26,7 +26,7 @@ typedef uint8_t oomkill_ebpf_val_t;
 #define NETDATA_CGROUP_OOMKILLS_CONTEXT "cgroup.oomkills"
 
 extern struct config oomkill_config;
-extern void *ebpf_oomkill_thread(void *ptr);
-extern void ebpf_oomkill_create_apps_charts(struct ebpf_module *em, void *ptr);
+void *ebpf_oomkill_thread(void *ptr);
+void ebpf_oomkill_create_apps_charts(struct ebpf_module *em, void *ptr);
 
 #endif /* NETDATA_EBPF_OOMKILL_H */

--- a/collectors/ebpf.plugin/ebpf_shm.h
+++ b/collectors/ebpf.plugin/ebpf_shm.h
@@ -54,8 +54,8 @@ enum shm_counters {
 
 extern netdata_publish_shm_t **shm_pid;
 
-extern void *ebpf_shm_thread(void *ptr);
-extern void ebpf_shm_create_apps_charts(struct ebpf_module *em, void *ptr);
+void *ebpf_shm_thread(void *ptr);
+void ebpf_shm_create_apps_charts(struct ebpf_module *em, void *ptr);
 extern netdata_ebpf_targets_t shm_targets[];
 
 extern struct config shm_config;

--- a/collectors/ebpf.plugin/ebpf_socket.h
+++ b/collectors/ebpf.plugin/ebpf_socket.h
@@ -356,12 +356,12 @@ typedef struct netdata_vector_plot {
 
 } netdata_vector_plot_t;
 
-extern void clean_port_structure(ebpf_network_viewer_port_list_t **clean);
+void clean_port_structure(ebpf_network_viewer_port_list_t **clean);
 extern ebpf_network_viewer_port_list_t *listen_ports;
-extern void update_listen_table(uint16_t value, uint16_t proto, netdata_passive_connection_t *values);
-extern void parse_network_viewer_section(struct config *cfg);
-extern void fill_ip_list(ebpf_network_viewer_ip_list_t **out, ebpf_network_viewer_ip_list_t *in, char *table);
-extern void parse_service_name_section(struct config *cfg);
+void update_listen_table(uint16_t value, uint16_t proto, netdata_passive_connection_t *values);
+void parse_network_viewer_section(struct config *cfg);
+void fill_ip_list(ebpf_network_viewer_ip_list_t **out, ebpf_network_viewer_ip_list_t *in, char *table);
+void parse_service_name_section(struct config *cfg);
 
 extern ebpf_socket_publish_apps_t **socket_bandwidth_curr;
 extern struct config socket_config;

--- a/collectors/ebpf.plugin/ebpf_softirq.h
+++ b/collectors/ebpf.plugin/ebpf_softirq.h
@@ -29,6 +29,6 @@ typedef struct sofirq_val {
 } softirq_val_t;
 
 extern struct config softirq_config;
-extern void *ebpf_softirq_thread(void *ptr);
+void *ebpf_softirq_thread(void *ptr);
 
 #endif /* NETDATA_EBPF_SOFTIRQ_H */

--- a/collectors/ebpf.plugin/ebpf_swap.h
+++ b/collectors/ebpf.plugin/ebpf_swap.h
@@ -44,8 +44,8 @@ enum swap_counters {
 
 extern netdata_publish_swap_t **swap_pid;
 
-extern void *ebpf_swap_thread(void *ptr);
-extern void ebpf_swap_create_apps_charts(struct ebpf_module *em, void *ptr);
+void *ebpf_swap_thread(void *ptr);
+void ebpf_swap_create_apps_charts(struct ebpf_module *em, void *ptr);
 
 extern struct config swap_config;
 extern netdata_ebpf_targets_t swap_targets[];

--- a/collectors/ebpf.plugin/ebpf_sync.h
+++ b/collectors/ebpf.plugin/ebpf_sync.h
@@ -52,7 +52,7 @@ enum netdata_sync_table {
     NETDATA_SYNC_GLOBAL_TABLE
 };
 
-extern void *ebpf_sync_thread(void *ptr);
+void *ebpf_sync_thread(void *ptr);
 extern struct config sync_config;
 extern netdata_ebpf_targets_t sync_targets[];
 

--- a/collectors/ebpf.plugin/ebpf_vfs.h
+++ b/collectors/ebpf.plugin/ebpf_vfs.h
@@ -168,8 +168,8 @@ enum netdata_vfs_calls_name {
 
 extern netdata_publish_vfs_t **vfs_pid;
 
-extern void *ebpf_vfs_thread(void *ptr);
-extern void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr);
+void *ebpf_vfs_thread(void *ptr);
+void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr);
 extern netdata_ebpf_targets_t vfs_targets[];
 
 extern struct config vfs_config;

--- a/collectors/freebsd.plugin/plugin_freebsd.h
+++ b/collectors/freebsd.plugin/plugin_freebsd.h
@@ -13,41 +13,41 @@
 
 #define MAX_INT_DIGITS 10 // maximum number of digits for int
 
-extern int freebsd_plugin_init();
+int freebsd_plugin_init();
 
-extern int do_vm_loadavg(int update_every, usec_t dt);
-extern int do_vm_vmtotal(int update_every, usec_t dt);
-extern int do_kern_cp_time(int update_every, usec_t dt);
-extern int do_kern_cp_times(int update_every, usec_t dt);
-extern int do_dev_cpu_temperature(int update_every, usec_t dt);
-extern int do_dev_cpu_0_freq(int update_every, usec_t dt);
-extern int do_hw_intcnt(int update_every, usec_t dt);
-extern int do_vm_stats_sys_v_intr(int update_every, usec_t dt);
-extern int do_vm_stats_sys_v_soft(int update_every, usec_t dt);
-extern int do_vm_stats_sys_v_swtch(int update_every, usec_t dt);
-extern int do_vm_stats_sys_v_forks(int update_every, usec_t dt);
-extern int do_vm_swap_info(int update_every, usec_t dt);
-extern int do_system_ram(int update_every, usec_t dt);
-extern int do_vm_stats_sys_v_swappgs(int update_every, usec_t dt);
-extern int do_vm_stats_sys_v_pgfaults(int update_every, usec_t dt);
-extern int do_kern_ipc_sem(int update_every, usec_t dt);
-extern int do_kern_ipc_shm(int update_every, usec_t dt);
-extern int do_kern_ipc_msq(int update_every, usec_t dt);
-extern int do_uptime(int update_every, usec_t dt);
-extern int do_net_isr(int update_every, usec_t dt);
-extern int do_net_inet_tcp_states(int update_every, usec_t dt);
-extern int do_net_inet_tcp_stats(int update_every, usec_t dt);
-extern int do_net_inet_udp_stats(int update_every, usec_t dt);
-extern int do_net_inet_icmp_stats(int update_every, usec_t dt);
-extern int do_net_inet_ip_stats(int update_every, usec_t dt);
-extern int do_net_inet6_ip6_stats(int update_every, usec_t dt);
-extern int do_net_inet6_icmp6_stats(int update_every, usec_t dt);
-extern int do_getifaddrs(int update_every, usec_t dt);
-extern int do_getmntinfo(int update_every, usec_t dt);
-extern int do_kern_devstat(int update_every, usec_t dt);
-extern int do_kstat_zfs_misc_arcstats(int update_every, usec_t dt);
-extern int do_kstat_zfs_misc_zio_trim(int update_every, usec_t dt);
-extern int do_ipfw(int update_every, usec_t dt);
+int do_vm_loadavg(int update_every, usec_t dt);
+int do_vm_vmtotal(int update_every, usec_t dt);
+int do_kern_cp_time(int update_every, usec_t dt);
+int do_kern_cp_times(int update_every, usec_t dt);
+int do_dev_cpu_temperature(int update_every, usec_t dt);
+int do_dev_cpu_0_freq(int update_every, usec_t dt);
+int do_hw_intcnt(int update_every, usec_t dt);
+int do_vm_stats_sys_v_intr(int update_every, usec_t dt);
+int do_vm_stats_sys_v_soft(int update_every, usec_t dt);
+int do_vm_stats_sys_v_swtch(int update_every, usec_t dt);
+int do_vm_stats_sys_v_forks(int update_every, usec_t dt);
+int do_vm_swap_info(int update_every, usec_t dt);
+int do_system_ram(int update_every, usec_t dt);
+int do_vm_stats_sys_v_swappgs(int update_every, usec_t dt);
+int do_vm_stats_sys_v_pgfaults(int update_every, usec_t dt);
+int do_kern_ipc_sem(int update_every, usec_t dt);
+int do_kern_ipc_shm(int update_every, usec_t dt);
+int do_kern_ipc_msq(int update_every, usec_t dt);
+int do_uptime(int update_every, usec_t dt);
+int do_net_isr(int update_every, usec_t dt);
+int do_net_inet_tcp_states(int update_every, usec_t dt);
+int do_net_inet_tcp_stats(int update_every, usec_t dt);
+int do_net_inet_udp_stats(int update_every, usec_t dt);
+int do_net_inet_icmp_stats(int update_every, usec_t dt);
+int do_net_inet_ip_stats(int update_every, usec_t dt);
+int do_net_inet6_ip6_stats(int update_every, usec_t dt);
+int do_net_inet6_icmp6_stats(int update_every, usec_t dt);
+int do_getifaddrs(int update_every, usec_t dt);
+int do_getmntinfo(int update_every, usec_t dt);
+int do_kern_devstat(int update_every, usec_t dt);
+int do_kstat_zfs_misc_arcstats(int update_every, usec_t dt);
+int do_kstat_zfs_misc_zio_trim(int update_every, usec_t dt);
+int do_ipfw(int update_every, usec_t dt);
 
 // metrics that need to be shared among data collectors
 extern unsigned long long zfs_arcstats_shrinkable_cache_size_bytes;

--- a/collectors/macos.plugin/plugin_macos.h
+++ b/collectors/macos.plugin/plugin_macos.h
@@ -5,8 +5,8 @@
 
 #include "daemon/common.h"
 
-extern int do_macos_sysctl(int update_every, usec_t dt);
-extern int do_macos_mach_smi(int update_every, usec_t dt);
-extern int do_macos_iokit(int update_every, usec_t dt);
+int do_macos_sysctl(int update_every, usec_t dt);
+int do_macos_mach_smi(int update_every, usec_t dt);
+int do_macos_iokit(int update_every, usec_t dt);
 
 #endif /* NETDATA_PLUGIN_MACOS_H */

--- a/collectors/plugins.d/plugins_d.h
+++ b/collectors/plugins.d/plugins_d.h
@@ -67,9 +67,9 @@ struct plugind {
 
 extern struct plugind *pluginsd_root;
 
-extern size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp_plugin_input, FILE *fp_plugin_output, int trust_durations);
+size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp_plugin_input, FILE *fp_plugin_output, int trust_durations);
 
-extern int pluginsd_initialize_plugin_directories();
+int pluginsd_initialize_plugin_directories();
 
 
 

--- a/collectors/plugins.d/pluginsd_parser.h
+++ b/collectors/plugins.d/pluginsd_parser.h
@@ -22,22 +22,22 @@ typedef struct parser_user_object {
     void *private; // the user can set this for private use
 } PARSER_USER_OBJECT;
 
-extern PARSER_RC pluginsd_set_action(void *user, RRDSET *st, RRDDIM *rd, long long int value);
-extern PARSER_RC pluginsd_flush_action(void *user, RRDSET *st);
-extern PARSER_RC pluginsd_begin_action(void *user, RRDSET *st, usec_t microseconds, int trust_durations);
-extern PARSER_RC pluginsd_end_action(void *user, RRDSET *st);
-extern PARSER_RC pluginsd_chart_action(void *user, char *type, char *id, char *name, char *family, char *context,
+PARSER_RC pluginsd_set_action(void *user, RRDSET *st, RRDDIM *rd, long long int value);
+PARSER_RC pluginsd_flush_action(void *user, RRDSET *st);
+PARSER_RC pluginsd_begin_action(void *user, RRDSET *st, usec_t microseconds, int trust_durations);
+PARSER_RC pluginsd_end_action(void *user, RRDSET *st);
+PARSER_RC pluginsd_chart_action(void *user, char *type, char *id, char *name, char *family, char *context,
                                        char *title, char *units, char *plugin, char *module, int priority,
                                        int update_every, RRDSET_TYPE chart_type, char *options);
-extern PARSER_RC pluginsd_disable_action(void *user);
-extern PARSER_RC pluginsd_variable_action(void *user, RRDHOST *host, RRDSET *st, char *name, int global, NETDATA_DOUBLE value);
-extern PARSER_RC pluginsd_dimension_action(void *user, RRDSET *st, char *id, char *name, char *algorithm,
+PARSER_RC pluginsd_disable_action(void *user);
+PARSER_RC pluginsd_variable_action(void *user, RRDHOST *host, RRDSET *st, char *name, int global, NETDATA_DOUBLE value);
+PARSER_RC pluginsd_dimension_action(void *user, RRDSET *st, char *id, char *name, char *algorithm,
                                            long multiplier, long divisor, char *options, RRD_ALGORITHM algorithm_type);
-extern PARSER_RC pluginsd_label_action(void *user, char *key, char *value, RRDLABEL_SRC source);
-extern PARSER_RC pluginsd_overwrite_action(void *user, RRDHOST *host, DICTIONARY *new_host_labels);
+PARSER_RC pluginsd_label_action(void *user, char *key, char *value, RRDLABEL_SRC source);
+PARSER_RC pluginsd_overwrite_action(void *user, RRDHOST *host, DICTIONARY *new_host_labels);
 
-extern PARSER_RC pluginsd_function(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
-extern PARSER_RC pluginsd_function_result_begin(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
-extern void inflight_functions_init(PARSER *parser);
+PARSER_RC pluginsd_function(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+PARSER_RC pluginsd_function_result_begin(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+void inflight_functions_init(PARSER *parser);
 
 #endif //NETDATA_PLUGINSD_PARSER_H

--- a/collectors/proc.plugin/plugin_proc.h
+++ b/collectors/proc.plugin/plugin_proc.h
@@ -9,58 +9,58 @@
 #define PLUGIN_PROC_NAME PLUGIN_PROC_CONFIG_NAME ".plugin"
 
 #define THREAD_NETDEV_NAME "PLUGIN[proc netdev]"
-extern void *netdev_main(void *ptr);
+void *netdev_main(void *ptr);
 
-extern int do_proc_net_wireless(int update_every, usec_t dt);
-extern int do_proc_diskstats(int update_every, usec_t dt);
-extern int do_proc_mdstat(int update_every, usec_t dt);
-extern int do_proc_net_snmp(int update_every, usec_t dt);
-extern int do_proc_net_snmp6(int update_every, usec_t dt);
-extern int do_proc_net_netstat(int update_every, usec_t dt);
-extern int do_proc_net_stat_conntrack(int update_every, usec_t dt);
-extern int do_proc_net_ip_vs_stats(int update_every, usec_t dt);
-extern int do_proc_stat(int update_every, usec_t dt);
-extern int do_proc_meminfo(int update_every, usec_t dt);
-extern int do_proc_vmstat(int update_every, usec_t dt);
-extern int do_proc_net_rpc_nfs(int update_every, usec_t dt);
-extern int do_proc_net_rpc_nfsd(int update_every, usec_t dt);
-extern int do_proc_sys_kernel_random_entropy_avail(int update_every, usec_t dt);
-extern int do_proc_interrupts(int update_every, usec_t dt);
-extern int do_proc_softirqs(int update_every, usec_t dt);
-extern int do_proc_pressure(int update_every, usec_t dt);
-extern int do_sys_kernel_mm_ksm(int update_every, usec_t dt);
-extern int do_sys_block_zram(int update_every, usec_t dt);
-extern int do_proc_loadavg(int update_every, usec_t dt);
-extern int do_proc_net_stat_synproxy(int update_every, usec_t dt);
-extern int do_proc_net_softnet_stat(int update_every, usec_t dt);
-extern int do_proc_uptime(int update_every, usec_t dt);
-extern int do_proc_sys_devices_system_edac_mc(int update_every, usec_t dt);
-extern int do_proc_sys_devices_system_node(int update_every, usec_t dt);
-extern int do_proc_spl_kstat_zfs_arcstats(int update_every, usec_t dt);
-extern int do_proc_spl_kstat_zfs_pool_state(int update_every, usec_t dt);
-extern int do_sys_fs_btrfs(int update_every, usec_t dt);
-extern int do_proc_net_sockstat(int update_every, usec_t dt);
-extern int do_proc_net_sockstat6(int update_every, usec_t dt);
-extern int do_proc_net_sctp_snmp(int update_every, usec_t dt);
-extern int do_ipc(int update_every, usec_t dt);
-extern int do_sys_class_power_supply(int update_every, usec_t dt);
-extern int do_proc_pagetypeinfo(int update_every, usec_t dt);
-extern int do_sys_class_infiniband(int update_every, usec_t dt);
-extern int get_numa_node_count(void);
+int do_proc_net_wireless(int update_every, usec_t dt);
+int do_proc_diskstats(int update_every, usec_t dt);
+int do_proc_mdstat(int update_every, usec_t dt);
+int do_proc_net_snmp(int update_every, usec_t dt);
+int do_proc_net_snmp6(int update_every, usec_t dt);
+int do_proc_net_netstat(int update_every, usec_t dt);
+int do_proc_net_stat_conntrack(int update_every, usec_t dt);
+int do_proc_net_ip_vs_stats(int update_every, usec_t dt);
+int do_proc_stat(int update_every, usec_t dt);
+int do_proc_meminfo(int update_every, usec_t dt);
+int do_proc_vmstat(int update_every, usec_t dt);
+int do_proc_net_rpc_nfs(int update_every, usec_t dt);
+int do_proc_net_rpc_nfsd(int update_every, usec_t dt);
+int do_proc_sys_kernel_random_entropy_avail(int update_every, usec_t dt);
+int do_proc_interrupts(int update_every, usec_t dt);
+int do_proc_softirqs(int update_every, usec_t dt);
+int do_proc_pressure(int update_every, usec_t dt);
+int do_sys_kernel_mm_ksm(int update_every, usec_t dt);
+int do_sys_block_zram(int update_every, usec_t dt);
+int do_proc_loadavg(int update_every, usec_t dt);
+int do_proc_net_stat_synproxy(int update_every, usec_t dt);
+int do_proc_net_softnet_stat(int update_every, usec_t dt);
+int do_proc_uptime(int update_every, usec_t dt);
+int do_proc_sys_devices_system_edac_mc(int update_every, usec_t dt);
+int do_proc_sys_devices_system_node(int update_every, usec_t dt);
+int do_proc_spl_kstat_zfs_arcstats(int update_every, usec_t dt);
+int do_proc_spl_kstat_zfs_pool_state(int update_every, usec_t dt);
+int do_sys_fs_btrfs(int update_every, usec_t dt);
+int do_proc_net_sockstat(int update_every, usec_t dt);
+int do_proc_net_sockstat6(int update_every, usec_t dt);
+int do_proc_net_sctp_snmp(int update_every, usec_t dt);
+int do_ipc(int update_every, usec_t dt);
+int do_sys_class_power_supply(int update_every, usec_t dt);
+int do_proc_pagetypeinfo(int update_every, usec_t dt);
+int do_sys_class_infiniband(int update_every, usec_t dt);
+int get_numa_node_count(void);
 
 // metrics that need to be shared among data collectors
 extern unsigned long long tcpext_TCPSynRetrans;
 extern unsigned long long zfs_arcstats_shrinkable_cache_size_bytes;
 
 // netdev renames
-extern void netdev_rename_device_add(
+void netdev_rename_device_add(
     const char *host_device,
     const char *container_device,
     const char *container_name,
     DICTIONARY *labels,
     const char *ctx_prefix);
 
-extern void netdev_rename_device_del(const char *host_device);
+void netdev_rename_device_del(const char *host_device);
 
 #include "proc_self_mountinfo.h"
 #include "proc_pressure.h"

--- a/collectors/proc.plugin/proc_pressure.h
+++ b/collectors/proc.plugin/proc_pressure.h
@@ -38,6 +38,6 @@ struct pressure {
     } some, full;
 };
 
-extern void update_pressure_charts(struct pressure_charts *charts);
+void update_pressure_charts(struct pressure_charts *charts);
 
 #endif //NETDATA_PROC_PRESSURE_H

--- a/collectors/proc.plugin/proc_self_mountinfo.h
+++ b/collectors/proc.plugin/proc_self_mountinfo.h
@@ -51,11 +51,11 @@ struct mountinfo {
     struct mountinfo *next;
 };
 
-extern struct mountinfo *mountinfo_find(struct mountinfo *root, unsigned long major, unsigned long minor, char *device);
-extern struct mountinfo *mountinfo_find_by_filesystem_mount_source(struct mountinfo *root, const char *filesystem, const char *mount_source);
-extern struct mountinfo *mountinfo_find_by_filesystem_super_option(struct mountinfo *root, const char *filesystem, const char *super_options);
+struct mountinfo *mountinfo_find(struct mountinfo *root, unsigned long major, unsigned long minor, char *device);
+struct mountinfo *mountinfo_find_by_filesystem_mount_source(struct mountinfo *root, const char *filesystem, const char *mount_source);
+struct mountinfo *mountinfo_find_by_filesystem_super_option(struct mountinfo *root, const char *filesystem, const char *super_options);
 
-extern void mountinfo_free_all(struct mountinfo *mi);
-extern struct mountinfo *mountinfo_read(int do_statvfs);
+void mountinfo_free_all(struct mountinfo *mi);
+struct mountinfo *mountinfo_read(int do_statvfs);
 
 #endif /* NETDATA_PROC_SELF_MOUNTINFO_H */

--- a/daemon/analytics.h
+++ b/daemon/analytics.h
@@ -69,18 +69,18 @@ struct analytics_data {
     uint8_t dashboard_hits;
 };
 
-extern void analytics_get_data(char *name, BUFFER *wb);
-extern void set_late_global_environment(void);
-extern void analytics_free_data(void);
-extern void set_global_environment(void);
-extern void send_statistics(const char *action, const char *action_result, const char *action_data);
-extern void analytics_log_shell(void);
-extern void analytics_log_json(void);
-extern void analytics_log_prometheus(void);
-extern void analytics_log_dashboard(void);
-extern void analytics_gather_mutable_meta_data(void);
-extern void analytics_report_oom_score(long long int score);
-extern void get_system_timezone(void);
+void analytics_get_data(char *name, BUFFER *wb);
+void set_late_global_environment(void);
+void analytics_free_data(void);
+void set_global_environment(void);
+void send_statistics(const char *action, const char *action_result, const char *action_data);
+void analytics_log_shell(void);
+void analytics_log_json(void);
+void analytics_log_prometheus(void);
+void analytics_log_dashboard(void);
+void analytics_gather_mutable_meta_data(void);
+void analytics_report_oom_score(long long int score);
+void get_system_timezone(void);
 
 extern struct analytics_data analytics_data;
 

--- a/daemon/buildinfo.h
+++ b/daemon/buildinfo.h
@@ -3,12 +3,12 @@
 #ifndef NETDATA_BUILDINFO_H
 #define NETDATA_BUILDINFO_H 1
 
-extern void print_build_info(void);
+void print_build_info(void);
 
-extern void print_build_info_json(void);
+void print_build_info_json(void);
 
-extern char *get_value_from_key(char *buffer, char *key);
+char *get_value_from_key(char *buffer, char *key);
 
-extern void get_install_type(char **install_type, char **prebuilt_arch, char **prebuilt_dist);
+void get_install_type(char **install_type, char **prebuilt_arch, char **prebuilt_dist);
 
 #endif // NETDATA_BUILDINFO_H

--- a/daemon/commands.h
+++ b/daemon/commands.h
@@ -76,7 +76,7 @@ typedef struct command_info {
 typedef void (command_lock_t) (unsigned index);
 
 cmd_status_t execute_command(cmd_t idx, char *args, char **message);
-extern void commands_init(void);
-extern void commands_exit(void);
+void commands_init(void);
+void commands_exit(void);
 
 #endif //NETDATA_COMMANDS_H

--- a/daemon/daemon.h
+++ b/daemon/daemon.h
@@ -3,14 +3,14 @@
 #ifndef NETDATA_DAEMON_H
 #define NETDATA_DAEMON_H 1
 
-extern int become_user(const char *username, int pid_fd);
+int become_user(const char *username, int pid_fd);
 
-extern int become_daemon(int dont_fork, const char *user);
+int become_daemon(int dont_fork, const char *user);
 
-extern void netdata_cleanup_and_exit(int i);
-extern void send_statistics(const char *action, const char *action_result, const char *action_data);
+void netdata_cleanup_and_exit(int i);
+void send_statistics(const char *action, const char *action_result, const char *action_data);
 
-extern void get_netdata_execution_path(void);
+void get_netdata_execution_path(void);
 
 extern char pidfile[];
 extern char exepath[];

--- a/daemon/global_statistics.h
+++ b/daemon/global_statistics.h
@@ -8,17 +8,17 @@
 // ----------------------------------------------------------------------------
 // global statistics
 
-extern void rrdr_query_completed(uint64_t db_points_read, uint64_t result_points_generated);
-extern void sqlite3_query_completed(bool success, bool busy, bool locked);
-extern void sqlite3_row_completed(void);
+void rrdr_query_completed(uint64_t db_points_read, uint64_t result_points_generated);
+void sqlite3_query_completed(bool success, bool busy, bool locked);
+void sqlite3_row_completed(void);
 
-extern void finished_web_request_statistics(uint64_t dt,
+void finished_web_request_statistics(uint64_t dt,
                                      uint64_t bytes_received,
                                      uint64_t bytes_sent,
                                      uint64_t content_size,
                                      uint64_t compressed_content_size);
 
-extern uint64_t web_client_connected(void);
-extern void web_client_disconnected(void);
+uint64_t web_client_connected(void);
+void web_client_disconnected(void);
 
 #endif /* NETDATA_GLOBAL_STATISTICS_H */

--- a/daemon/main.h
+++ b/daemon/main.h
@@ -22,9 +22,9 @@ struct option_def {
     const char *default_value;
 };
 
-extern void cancel_main_threads(void);
-extern int killpid(pid_t pid);
-extern void netdata_cleanup_and_exit(int ret) NORETURN;
-extern void send_statistics(const char *action, const char *action_result, const char *action_data);
+void cancel_main_threads(void);
+int killpid(pid_t pid);
+void netdata_cleanup_and_exit(int ret) NORETURN;
+void send_statistics(const char *action, const char *action_result, const char *action_data);
 
 #endif /* NETDATA_MAIN_H */

--- a/daemon/signals.h
+++ b/daemon/signals.h
@@ -3,11 +3,11 @@
 #ifndef NETDATA_SIGNALS_H
 #define NETDATA_SIGNALS_H 1
 
-extern void signals_init(void);
-extern void signals_block(void);
-extern void signals_unblock(void);
-extern void signals_restore_SIGCHLD(void);
-extern void signals_reset(void);
-extern void signals_handle(void) NORETURN;
+void signals_init(void);
+void signals_block(void);
+void signals_unblock(void);
+void signals_restore_SIGCHLD(void);
+void signals_reset(void);
+void signals_handle(void) NORETURN;
 
 #endif //NETDATA_SIGNALS_H

--- a/daemon/unit_test.h
+++ b/daemon/unit_test.h
@@ -3,18 +3,18 @@
 #ifndef NETDATA_UNIT_TEST_H
 #define NETDATA_UNIT_TEST_H 1
 
-extern int unit_test_storage(void);
-extern int unit_test(long delay, long shift);
-extern int run_all_mockup_tests(void);
-extern int unit_test_str2ld(void);
-extern int unit_test_buffer(void);
-extern int unit_test_static_threads(void);
-extern int test_sqlite(void);
-extern int unit_test_bitmap256(void);
+int unit_test_storage(void);
+int unit_test(long delay, long shift);
+int run_all_mockup_tests(void);
+int unit_test_str2ld(void);
+int unit_test_buffer(void);
+int unit_test_static_threads(void);
+int test_sqlite(void);
+int unit_test_bitmap256(void);
 #ifdef ENABLE_DBENGINE
-extern int test_dbengine(void);
-extern void generate_dbengine_dataset(unsigned history_seconds);
-extern void dbengine_stress_test(unsigned TEST_DURATION_SEC, unsigned DSET_CHARTS, unsigned QUERY_THREADS,
+int test_dbengine(void);
+void generate_dbengine_dataset(unsigned history_seconds);
+void dbengine_stress_test(unsigned TEST_DURATION_SEC, unsigned DSET_CHARTS, unsigned QUERY_THREADS,
                                  unsigned RAMP_UP_SECONDS, unsigned PAGE_CACHE_MB, unsigned DISK_SPACE_MB);
 
 #endif

--- a/database/engine/datafile.h
+++ b/database/engine/datafile.h
@@ -52,16 +52,16 @@ struct rrdengine_datafile_list {
     struct rrdengine_datafile *last; /* newest */
 };
 
-extern void df_extent_insert(struct extent_info *extent);
-extern void datafile_list_insert(struct rrdengine_instance *ctx, struct rrdengine_datafile *datafile);
-extern void datafile_list_delete(struct rrdengine_instance *ctx, struct rrdengine_datafile *datafile);
-extern void generate_datafilepath(struct rrdengine_datafile *datafile, char *str, size_t maxlen);
-extern int close_data_file(struct rrdengine_datafile *datafile);
-extern int unlink_data_file(struct rrdengine_datafile *datafile);
-extern int destroy_data_file(struct rrdengine_datafile *datafile);
-extern int create_data_file(struct rrdengine_datafile *datafile);
-extern int create_new_datafile_pair(struct rrdengine_instance *ctx, unsigned tier, unsigned fileno);
-extern int init_data_files(struct rrdengine_instance *ctx);
-extern void finalize_data_files(struct rrdengine_instance *ctx);
+void df_extent_insert(struct extent_info *extent);
+void datafile_list_insert(struct rrdengine_instance *ctx, struct rrdengine_datafile *datafile);
+void datafile_list_delete(struct rrdengine_instance *ctx, struct rrdengine_datafile *datafile);
+void generate_datafilepath(struct rrdengine_datafile *datafile, char *str, size_t maxlen);
+int close_data_file(struct rrdengine_datafile *datafile);
+int unlink_data_file(struct rrdengine_datafile *datafile);
+int destroy_data_file(struct rrdengine_datafile *datafile);
+int create_data_file(struct rrdengine_datafile *datafile);
+int create_new_datafile_pair(struct rrdengine_instance *ctx, unsigned tier, unsigned fileno);
+int init_data_files(struct rrdengine_instance *ctx);
+void finalize_data_files(struct rrdengine_instance *ctx);
 
 #endif /* NETDATA_DATAFILE_H */

--- a/database/engine/journalfile.h
+++ b/database/engine/journalfile.h
@@ -33,17 +33,17 @@ struct transaction_commit_log {
     unsigned buf_size;
 };
 
-extern void generate_journalfilepath(struct rrdengine_datafile *datafile, char *str, size_t maxlen);
-extern void journalfile_init(struct rrdengine_journalfile *journalfile, struct rrdengine_datafile *datafile);
-extern void *wal_get_transaction_buffer(struct rrdengine_worker_config* wc, unsigned size);
-extern void wal_flush_transaction_buffer(struct rrdengine_worker_config* wc);
-extern int close_journal_file(struct rrdengine_journalfile *journalfile, struct rrdengine_datafile *datafile);
-extern int unlink_journal_file(struct rrdengine_journalfile *journalfile);
-extern int destroy_journal_file(struct rrdengine_journalfile *journalfile, struct rrdengine_datafile *datafile);
-extern int create_journal_file(struct rrdengine_journalfile *journalfile, struct rrdengine_datafile *datafile);
-extern int load_journal_file(struct rrdengine_instance *ctx, struct rrdengine_journalfile *journalfile,
+void generate_journalfilepath(struct rrdengine_datafile *datafile, char *str, size_t maxlen);
+void journalfile_init(struct rrdengine_journalfile *journalfile, struct rrdengine_datafile *datafile);
+void *wal_get_transaction_buffer(struct rrdengine_worker_config* wc, unsigned size);
+void wal_flush_transaction_buffer(struct rrdengine_worker_config* wc);
+int close_journal_file(struct rrdengine_journalfile *journalfile, struct rrdengine_datafile *datafile);
+int unlink_journal_file(struct rrdengine_journalfile *journalfile);
+int destroy_journal_file(struct rrdengine_journalfile *journalfile, struct rrdengine_datafile *datafile);
+int create_journal_file(struct rrdengine_journalfile *journalfile, struct rrdengine_datafile *datafile);
+int load_journal_file(struct rrdengine_instance *ctx, struct rrdengine_journalfile *journalfile,
                              struct rrdengine_datafile *datafile);
-extern void init_commit_log(struct rrdengine_instance *ctx);
+void init_commit_log(struct rrdengine_instance *ctx);
 
 
 #endif /* NETDATA_JOURNALFILE_H */

--- a/database/engine/metadata_log/compaction.h
+++ b/database/engine/metadata_log/compaction.h
@@ -8,7 +8,7 @@
 #endif
 #include "../rrdengine.h"
 
-extern int compaction_failure_recovery(struct metalog_instance *ctx, struct metadata_logfile **metalogfiles,
+int compaction_failure_recovery(struct metalog_instance *ctx, struct metadata_logfile **metalogfiles,
                                        unsigned *matched_files);
 
 #endif /* NETDATA_COMPACTION_H */

--- a/database/engine/metadata_log/logfile.h
+++ b/database/engine/metadata_log/logfile.h
@@ -28,12 +28,12 @@ struct metadata_logfile_list {
     struct metadata_logfile *last; /* newest */
 };
 
-extern void generate_metadata_logfile_path(struct metadata_logfile *metadatalog, char *str, size_t maxlen);
-extern int rename_metadata_logfile(struct metadata_logfile *metalogfile, unsigned new_starting_fileno,
+void generate_metadata_logfile_path(struct metadata_logfile *metadatalog, char *str, size_t maxlen);
+int rename_metadata_logfile(struct metadata_logfile *metalogfile, unsigned new_starting_fileno,
                                    unsigned new_fileno);
-extern int unlink_metadata_logfile(struct metadata_logfile *metalogfile);
-extern int load_metadata_logfile(struct metalog_instance *ctx, struct metadata_logfile *logfile);
-extern int init_metalog_files(struct metalog_instance *ctx);
+int unlink_metadata_logfile(struct metadata_logfile *metalogfile);
+int load_metadata_logfile(struct metalog_instance *ctx, struct metadata_logfile *logfile);
+int init_metalog_files(struct metalog_instance *ctx);
 
 
 #endif /* NETDATA_LOGFILE_H */

--- a/database/engine/metadata_log/metadatalogapi.h
+++ b/database/engine/metadata_log/metadatalogapi.h
@@ -3,10 +3,10 @@
 #ifndef NETDATA_METADATALOGAPI_H
 #define NETDATA_METADATALOGAPI_H
 
-extern void metalog_commit_delete_chart(RRDSET *st);
-extern void metalog_delete_dimension_by_uuid(struct metalog_instance *ctx, uuid_t *metric_uuid);
+void metalog_commit_delete_chart(RRDSET *st);
+void metalog_delete_dimension_by_uuid(struct metalog_instance *ctx, uuid_t *metric_uuid);
 
 /* must call once before using anything */
-extern int metalog_init(struct rrdengine_instance *rrdeng_parent_ctx);
+int metalog_init(struct rrdengine_instance *rrdeng_parent_ctx);
 
 #endif /* NETDATA_METADATALOGAPI_H */

--- a/database/engine/metadata_log/metalogpluginsd.h
+++ b/database/engine/metadata_log/metalogpluginsd.h
@@ -16,18 +16,18 @@ struct metalog_pluginsd_state {
     struct metadata_logfile *metalogfile; /* current metadata log file being replayed */
 };
 
-extern void metalog_pluginsd_state_init(struct metalog_pluginsd_state *state, struct metalog_instance *ctx);
+void metalog_pluginsd_state_init(struct metalog_pluginsd_state *state, struct metalog_instance *ctx);
 
-extern PARSER_RC metalog_pluginsd_chart_action(void *user, char *type, char *id, char *name, char *family,
+PARSER_RC metalog_pluginsd_chart_action(void *user, char *type, char *id, char *name, char *family,
                                                char *context, char *title, char *units, char *plugin, char *module,
                                                int priority, int update_every, RRDSET_TYPE chart_type, char *options);
-extern PARSER_RC metalog_pluginsd_dimension_action(void *user, RRDSET *st, char *id, char *name, char *algorithm,
+PARSER_RC metalog_pluginsd_dimension_action(void *user, RRDSET *st, char *id, char *name, char *algorithm,
                                                    long multiplier, long divisor, char *options,
                                                    RRD_ALGORITHM algorithm_type);
-extern PARSER_RC metalog_pluginsd_guid_action(void *user, uuid_t *uuid);
-extern PARSER_RC metalog_pluginsd_context_action(void *user, uuid_t *uuid);
-extern PARSER_RC metalog_pluginsd_tombstone_action(void *user, uuid_t *uuid);
-extern PARSER_RC metalog_pluginsd_host(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
-extern PARSER_RC metalog_pluginsd_host_action(void *user, char *machine_guid, char *hostname, char *registry_hostname, int update_every, char *os, char *timezone, char *tags);
+PARSER_RC metalog_pluginsd_guid_action(void *user, uuid_t *uuid);
+PARSER_RC metalog_pluginsd_context_action(void *user, uuid_t *uuid);
+PARSER_RC metalog_pluginsd_tombstone_action(void *user, uuid_t *uuid);
+PARSER_RC metalog_pluginsd_host(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+PARSER_RC metalog_pluginsd_host_action(void *user, char *machine_guid, char *hostname, char *registry_hostname, int update_every, char *os, char *timezone, char *tags);
 
 #endif /* NETDATA_METALOGPLUGINSD_H */

--- a/database/engine/pagecache.h
+++ b/database/engine/pagecache.h
@@ -152,30 +152,30 @@ struct page_cache { /* TODO: add statistics */
     unsigned populated_pages;
 };
 
-extern void pg_cache_wake_up_waiters_unsafe(struct rrdeng_page_descr *descr);
-extern void pg_cache_wake_up_waiters(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr);
-extern void pg_cache_wait_event_unsafe(struct rrdeng_page_descr *descr);
-extern unsigned long pg_cache_wait_event(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr);
-extern void pg_cache_replaceQ_insert(struct rrdengine_instance *ctx,
+void pg_cache_wake_up_waiters_unsafe(struct rrdeng_page_descr *descr);
+void pg_cache_wake_up_waiters(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr);
+void pg_cache_wait_event_unsafe(struct rrdeng_page_descr *descr);
+unsigned long pg_cache_wait_event(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr);
+void pg_cache_replaceQ_insert(struct rrdengine_instance *ctx,
                                      struct rrdeng_page_descr *descr);
-extern void pg_cache_replaceQ_delete(struct rrdengine_instance *ctx,
+void pg_cache_replaceQ_delete(struct rrdengine_instance *ctx,
                                      struct rrdeng_page_descr *descr);
-extern void pg_cache_replaceQ_set_hot(struct rrdengine_instance *ctx,
+void pg_cache_replaceQ_set_hot(struct rrdengine_instance *ctx,
                                       struct rrdeng_page_descr *descr);
-extern struct rrdeng_page_descr *pg_cache_create_descr(void);
-extern int pg_cache_try_get_unsafe(struct rrdeng_page_descr *descr, int exclusive_access);
-extern void pg_cache_put_unsafe(struct rrdeng_page_descr *descr);
-extern void pg_cache_put(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr);
-extern void pg_cache_insert(struct rrdengine_instance *ctx, struct pg_cache_page_index *index,
+struct rrdeng_page_descr *pg_cache_create_descr(void);
+int pg_cache_try_get_unsafe(struct rrdeng_page_descr *descr, int exclusive_access);
+void pg_cache_put_unsafe(struct rrdeng_page_descr *descr);
+void pg_cache_put(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr);
+void pg_cache_insert(struct rrdengine_instance *ctx, struct pg_cache_page_index *index,
                             struct rrdeng_page_descr *descr);
-extern uint8_t pg_cache_punch_hole(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr,
+uint8_t pg_cache_punch_hole(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr,
                                    uint8_t remove_dirty, uint8_t is_exclusive_holder, uuid_t *metric_id);
-extern usec_t pg_cache_oldest_time_in_range(struct rrdengine_instance *ctx, uuid_t *id,
+usec_t pg_cache_oldest_time_in_range(struct rrdengine_instance *ctx, uuid_t *id,
                                             usec_t start_time, usec_t end_time);
-extern void pg_cache_get_filtered_info_prev(struct rrdengine_instance *ctx, struct pg_cache_page_index *page_index,
+void pg_cache_get_filtered_info_prev(struct rrdengine_instance *ctx, struct pg_cache_page_index *page_index,
                                             usec_t point_in_time, pg_cache_page_info_filter_t *filter,
                                             struct rrdeng_page_info *page_info);
-extern struct rrdeng_page_descr *pg_cache_lookup_unpopulated_and_lock(struct rrdengine_instance *ctx, uuid_t *id,
+struct rrdeng_page_descr *pg_cache_lookup_unpopulated_and_lock(struct rrdengine_instance *ctx, uuid_t *id,
                                                                       usec_t start_time);
 extern unsigned
         pg_cache_preload(struct rrdengine_instance *ctx, uuid_t *id, usec_t start_time, usec_t end_time,
@@ -186,22 +186,22 @@ extern struct rrdeng_page_descr *
 extern struct rrdeng_page_descr *
         pg_cache_lookup_next(struct rrdengine_instance *ctx, struct pg_cache_page_index *index, uuid_t *id,
                      usec_t start_time, usec_t end_time);
-extern struct pg_cache_page_index *create_page_index(uuid_t *id);
-extern void init_page_cache(struct rrdengine_instance *ctx);
-extern void free_page_cache(struct rrdengine_instance *ctx);
-extern void pg_cache_add_new_metric_time(struct pg_cache_page_index *page_index, struct rrdeng_page_descr *descr);
-extern void pg_cache_update_metric_times(struct pg_cache_page_index *page_index);
-extern unsigned long pg_cache_hard_limit(struct rrdengine_instance *ctx);
-extern unsigned long pg_cache_soft_limit(struct rrdengine_instance *ctx);
-extern unsigned long pg_cache_committed_hard_limit(struct rrdengine_instance *ctx);
+struct pg_cache_page_index *create_page_index(uuid_t *id);
+void init_page_cache(struct rrdengine_instance *ctx);
+void free_page_cache(struct rrdengine_instance *ctx);
+void pg_cache_add_new_metric_time(struct pg_cache_page_index *page_index, struct rrdeng_page_descr *descr);
+void pg_cache_update_metric_times(struct pg_cache_page_index *page_index);
+unsigned long pg_cache_hard_limit(struct rrdengine_instance *ctx);
+unsigned long pg_cache_soft_limit(struct rrdengine_instance *ctx);
+unsigned long pg_cache_committed_hard_limit(struct rrdengine_instance *ctx);
 
-extern void rrdeng_page_descr_aral_go_singlethreaded(void);
-extern void rrdeng_page_descr_aral_go_multithreaded(void);
-extern void rrdeng_page_descr_use_malloc(void);
-extern void rrdeng_page_descr_use_mmap(void);
-extern bool rrdeng_page_descr_is_mmap(void);
-extern struct rrdeng_page_descr *rrdeng_page_descr_mallocz(void);
-extern void rrdeng_page_descr_freez(struct rrdeng_page_descr *descr);
+void rrdeng_page_descr_aral_go_singlethreaded(void);
+void rrdeng_page_descr_aral_go_multithreaded(void);
+void rrdeng_page_descr_use_malloc(void);
+void rrdeng_page_descr_use_mmap(void);
+bool rrdeng_page_descr_is_mmap(void);
+struct rrdeng_page_descr *rrdeng_page_descr_mallocz(void);
+void rrdeng_page_descr_freez(struct rrdeng_page_descr *descr);
 
 static inline void
     pg_cache_atomic_get_pg_info(struct rrdeng_page_descr *descr, usec_t *end_timep, uint32_t *page_lengthp)

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -256,14 +256,14 @@ struct rrdengine_instance {
     struct rrdengine_statistics stats;
 };
 
-extern void *dbengine_page_alloc(void);
-extern void dbengine_page_free(void *page);
+void *dbengine_page_alloc(void);
+void dbengine_page_free(void *page);
 
-extern int init_rrd_files(struct rrdengine_instance *ctx);
-extern void finalize_rrd_files(struct rrdengine_instance *ctx);
-extern void rrdeng_test_quota(struct rrdengine_worker_config* wc);
-extern void rrdeng_worker(void* arg);
-extern void rrdeng_enq_cmd(struct rrdengine_worker_config* wc, struct rrdeng_cmd *cmd);
-extern struct rrdeng_cmd rrdeng_deq_cmd(struct rrdengine_worker_config* wc);
+int init_rrd_files(struct rrdengine_instance *ctx);
+void finalize_rrd_files(struct rrdengine_instance *ctx);
+void rrdeng_test_quota(struct rrdengine_worker_config* wc);
+void rrdeng_worker(void* arg);
+void rrdeng_enq_cmd(struct rrdengine_worker_config* wc, struct rrdeng_cmd *cmd);
+struct rrdeng_cmd rrdeng_deq_cmd(struct rrdengine_worker_config* wc);
 
 #endif /* NETDATA_RRDENGINE_H */

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -30,53 +30,53 @@ struct rrdeng_region_info {
     unsigned points;
 };
 
-extern void *rrdeng_create_page(struct rrdengine_instance *ctx, uuid_t *id, struct rrdeng_page_descr **ret_descr);
-extern void rrdeng_commit_page(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr,
+void *rrdeng_create_page(struct rrdengine_instance *ctx, uuid_t *id, struct rrdeng_page_descr **ret_descr);
+void rrdeng_commit_page(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr,
                                Word_t page_correlation_id);
-extern void *rrdeng_get_latest_page(struct rrdengine_instance *ctx, uuid_t *id, void **handle);
-extern void *rrdeng_get_page(struct rrdengine_instance *ctx, uuid_t *id, usec_t point_in_time, void **handle);
-extern void rrdeng_put_page(struct rrdengine_instance *ctx, void *handle);
+void *rrdeng_get_latest_page(struct rrdengine_instance *ctx, uuid_t *id, void **handle);
+void *rrdeng_get_page(struct rrdengine_instance *ctx, uuid_t *id, usec_t point_in_time, void **handle);
+void rrdeng_put_page(struct rrdengine_instance *ctx, void *handle);
 
-extern void rrdeng_generate_legacy_uuid(const char *dim_id, char *chart_id, uuid_t *ret_uuid);
-extern void rrdeng_convert_legacy_uuid_to_multihost(char machine_guid[GUID_LEN + 1], uuid_t *legacy_uuid,
+void rrdeng_generate_legacy_uuid(const char *dim_id, char *chart_id, uuid_t *ret_uuid);
+void rrdeng_convert_legacy_uuid_to_multihost(char machine_guid[GUID_LEN + 1], uuid_t *legacy_uuid,
                                                     uuid_t *ret_uuid);
 
 
-extern STORAGE_METRIC_HANDLE *rrdeng_metric_init(RRDDIM *rd, STORAGE_INSTANCE *db_instance);
-extern void rrdeng_metric_free(STORAGE_METRIC_HANDLE *db_metric_handle);
+STORAGE_METRIC_HANDLE *rrdeng_metric_init(RRDDIM *rd, STORAGE_INSTANCE *db_instance);
+void rrdeng_metric_free(STORAGE_METRIC_HANDLE *db_metric_handle);
 
-extern STORAGE_COLLECT_HANDLE *rrdeng_store_metric_init(STORAGE_METRIC_HANDLE *db_metric_handle);
-extern void rrdeng_store_metric_flush_current_page(STORAGE_COLLECT_HANDLE *collection_handle);
-extern void rrdeng_store_metric_next(STORAGE_COLLECT_HANDLE *collection_handle, usec_t point_in_time, NETDATA_DOUBLE n,
+STORAGE_COLLECT_HANDLE *rrdeng_store_metric_init(STORAGE_METRIC_HANDLE *db_metric_handle);
+void rrdeng_store_metric_flush_current_page(STORAGE_COLLECT_HANDLE *collection_handle);
+void rrdeng_store_metric_next(STORAGE_COLLECT_HANDLE *collection_handle, usec_t point_in_time, NETDATA_DOUBLE n,
                                      NETDATA_DOUBLE min_value,
                                      NETDATA_DOUBLE max_value,
                                      uint16_t count,
                                      uint16_t anomaly_count,
                                      SN_FLAGS flags);
-extern int rrdeng_store_metric_finalize(STORAGE_COLLECT_HANDLE *collection_handle);
+int rrdeng_store_metric_finalize(STORAGE_COLLECT_HANDLE *collection_handle);
 
-extern unsigned rrdeng_variable_step_boundaries(RRDSET *st, time_t start_time, time_t end_time,
+unsigned rrdeng_variable_step_boundaries(RRDSET *st, time_t start_time, time_t end_time,
                                     struct rrdeng_region_info **region_info_arrayp, unsigned *max_intervalp, struct context_param *context_param_list);
 
-extern void rrdeng_load_metric_init(STORAGE_METRIC_HANDLE *db_metric_handle, struct rrddim_query_handle *rrdimm_handle,
+void rrdeng_load_metric_init(STORAGE_METRIC_HANDLE *db_metric_handle, struct rrddim_query_handle *rrdimm_handle,
                                     time_t start_time, time_t end_time, TIER_QUERY_FETCH tier_query_fetch_type);
-extern STORAGE_POINT rrdeng_load_metric_next(struct rrddim_query_handle *rrdimm_handle);
+STORAGE_POINT rrdeng_load_metric_next(struct rrddim_query_handle *rrdimm_handle);
 
-extern int rrdeng_load_metric_is_finished(struct rrddim_query_handle *rrdimm_handle);
-extern void rrdeng_load_metric_finalize(struct rrddim_query_handle *rrdimm_handle);
-extern time_t rrdeng_metric_latest_time(STORAGE_METRIC_HANDLE *db_metric_handle);
-extern time_t rrdeng_metric_oldest_time(STORAGE_METRIC_HANDLE *db_metric_handle);
+int rrdeng_load_metric_is_finished(struct rrddim_query_handle *rrdimm_handle);
+void rrdeng_load_metric_finalize(struct rrddim_query_handle *rrdimm_handle);
+time_t rrdeng_metric_latest_time(STORAGE_METRIC_HANDLE *db_metric_handle);
+time_t rrdeng_metric_oldest_time(STORAGE_METRIC_HANDLE *db_metric_handle);
 
-extern void rrdeng_get_37_statistics(struct rrdengine_instance *ctx, unsigned long long *array);
+void rrdeng_get_37_statistics(struct rrdengine_instance *ctx, unsigned long long *array);
 
 /* must call once before using anything */
-extern int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_path, unsigned page_cache_mb,
+int rrdeng_init(RRDHOST *host, struct rrdengine_instance **ctxp, char *dbfiles_path, unsigned page_cache_mb,
                        unsigned disk_space_mb, int tier);
 
-extern int rrdeng_exit(struct rrdengine_instance *ctx);
-extern void rrdeng_prepare_exit(struct rrdengine_instance *ctx);
-extern int rrdeng_metric_latest_time_by_uuid(uuid_t *dim_uuid, time_t *first_entry_t, time_t *last_entry_t, int tier);
-extern int rrdeng_metric_retention_by_uuid(STORAGE_INSTANCE *si, uuid_t *dim_uuid, time_t *first_entry_t, time_t *last_entry_t);
+int rrdeng_exit(struct rrdengine_instance *ctx);
+void rrdeng_prepare_exit(struct rrdengine_instance *ctx);
+int rrdeng_metric_latest_time_by_uuid(uuid_t *dim_uuid, time_t *first_entry_t, time_t *last_entry_t, int tier);
+int rrdeng_metric_retention_by_uuid(STORAGE_INSTANCE *si, uuid_t *dim_uuid, time_t *first_entry_t, time_t *last_entry_t);
 
 typedef struct rrdengine_size_statistics {
     size_t default_granularity_secs;
@@ -134,6 +134,6 @@ typedef struct rrdengine_size_statistics {
     double average_page_size_bytes;
 } RRDENG_SIZE_STATS;
 
-extern RRDENG_SIZE_STATS rrdeng_size_statistics(struct rrdengine_instance *ctx);
+RRDENG_SIZE_STATS rrdeng_size_statistics(struct rrdengine_instance *ctx);
 
 #endif /* NETDATA_RRDENGINEAPI_H */

--- a/database/engine/rrdenginelib.h
+++ b/database/engine/rrdenginelib.h
@@ -83,10 +83,10 @@ static inline void crc32set(void *crcp, uLong crc)
     *(uint32_t *)crcp = crc;
 }
 
-extern void print_page_cache_descr(struct rrdeng_page_descr *page_cache_descr);
-extern void print_page_descr(struct rrdeng_page_descr *descr);
-extern int check_file_properties(uv_file file, uint64_t *file_size, size_t min_size);
-extern int open_file_for_io(char *path, int flags, uv_file *file, int direct);
+void print_page_cache_descr(struct rrdeng_page_descr *page_cache_descr);
+void print_page_descr(struct rrdeng_page_descr *descr);
+int check_file_properties(uv_file file, uint64_t *file_size, size_t min_size);
+int open_file_for_io(char *path, int flags, uv_file *file, int direct);
 static inline int open_file_direct_io(char *path, int flags, uv_file *file)
 {
     return open_file_for_io(path, flags, file, 1);
@@ -95,8 +95,8 @@ static inline int open_file_buffered_io(char *path, int flags, uv_file *file)
 {
     return open_file_for_io(path, flags, file, 0);
 }
-extern char *get_rrdeng_statistics(struct rrdengine_instance *ctx, char *str, size_t size);
-extern int compute_multidb_diskspace();
-extern int is_legacy_child(const char *machine_guid);
+char *get_rrdeng_statistics(struct rrdengine_instance *ctx, char *str, size_t size);
+int compute_multidb_diskspace();
+int is_legacy_child(const char *machine_guid);
 
 #endif /* NETDATA_RRDENGINELIB_H */

--- a/database/engine/rrdenglocking.h
+++ b/database/engine/rrdenglocking.h
@@ -8,10 +8,10 @@
 /* Forward declarations */
 struct page_cache_descr;
 
-extern struct page_cache_descr *rrdeng_create_pg_cache_descr(struct rrdengine_instance *ctx);
-extern void rrdeng_destroy_pg_cache_descr(struct rrdengine_instance *ctx, struct page_cache_descr *pg_cache_descr);
-extern void rrdeng_page_descr_mutex_lock(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr);
-extern void rrdeng_page_descr_mutex_unlock(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr);
-extern void rrdeng_try_deallocate_pg_cache_descr(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr);
+struct page_cache_descr *rrdeng_create_pg_cache_descr(struct rrdengine_instance *ctx);
+void rrdeng_destroy_pg_cache_descr(struct rrdengine_instance *ctx, struct page_cache_descr *pg_cache_descr);
+void rrdeng_page_descr_mutex_lock(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr);
+void rrdeng_page_descr_mutex_unlock(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr);
+void rrdeng_try_deallocate_pg_cache_descr(struct rrdengine_instance *ctx, struct rrdeng_page_descr *descr);
 
 #endif /* NETDATA_RRDENGLOCKING_H */

--- a/database/ram/rrddim_mem.h
+++ b/database/ram/rrddim_mem.h
@@ -20,24 +20,24 @@ struct mem_query_handle {
     size_t last_slot;
 };
 
-extern STORAGE_METRIC_HANDLE *rrddim_metric_init(RRDDIM *rd, STORAGE_INSTANCE *db_instance);
-extern void rrddim_metric_free(STORAGE_METRIC_HANDLE *db_metric_handle);
+STORAGE_METRIC_HANDLE *rrddim_metric_init(RRDDIM *rd, STORAGE_INSTANCE *db_instance);
+void rrddim_metric_free(STORAGE_METRIC_HANDLE *db_metric_handle);
 
-extern STORAGE_COLLECT_HANDLE *rrddim_collect_init(STORAGE_METRIC_HANDLE *db_metric_handle);
-extern void rrddim_collect_store_metric(STORAGE_COLLECT_HANDLE *collection_handle, usec_t point_in_time, NETDATA_DOUBLE number,
+STORAGE_COLLECT_HANDLE *rrddim_collect_init(STORAGE_METRIC_HANDLE *db_metric_handle);
+void rrddim_collect_store_metric(STORAGE_COLLECT_HANDLE *collection_handle, usec_t point_in_time, NETDATA_DOUBLE number,
                                  NETDATA_DOUBLE min_value,
                                  NETDATA_DOUBLE max_value,
                                  uint16_t count,
                                  uint16_t anomaly_count,
                                  SN_FLAGS flags);
-extern void rrddim_store_metric_flush(STORAGE_COLLECT_HANDLE *collection_handle);
-extern int rrddim_collect_finalize(STORAGE_COLLECT_HANDLE *collection_handle);
+void rrddim_store_metric_flush(STORAGE_COLLECT_HANDLE *collection_handle);
+int rrddim_collect_finalize(STORAGE_COLLECT_HANDLE *collection_handle);
 
-extern void rrddim_query_init(STORAGE_METRIC_HANDLE *db_metric_handle, struct rrddim_query_handle *handle, time_t start_time, time_t end_time, TIER_QUERY_FETCH tier_query_fetch_type);
-extern STORAGE_POINT rrddim_query_next_metric(struct rrddim_query_handle *handle);
-extern int rrddim_query_is_finished(struct rrddim_query_handle *handle);
-extern void rrddim_query_finalize(struct rrddim_query_handle *handle);
-extern time_t rrddim_query_latest_time(STORAGE_METRIC_HANDLE *db_metric_handle);
-extern time_t rrddim_query_oldest_time(STORAGE_METRIC_HANDLE *db_metric_handle);
+void rrddim_query_init(STORAGE_METRIC_HANDLE *db_metric_handle, struct rrddim_query_handle *handle, time_t start_time, time_t end_time, TIER_QUERY_FETCH tier_query_fetch_type);
+STORAGE_POINT rrddim_query_next_metric(struct rrddim_query_handle *handle);
+int rrddim_query_is_finished(struct rrddim_query_handle *handle);
+void rrddim_query_finalize(struct rrddim_query_handle *handle);
+time_t rrddim_query_latest_time(STORAGE_METRIC_HANDLE *db_metric_handle);
+time_t rrddim_query_oldest_time(STORAGE_METRIC_HANDLE *db_metric_handle);
 
 #endif

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -132,8 +132,8 @@ typedef enum rrd_memory_mode {
 
 extern RRD_MEMORY_MODE default_rrd_memory_mode;
 
-extern const char *rrd_memory_mode_name(RRD_MEMORY_MODE id);
-extern RRD_MEMORY_MODE rrd_memory_mode_id(const char *name);
+const char *rrd_memory_mode_name(RRD_MEMORY_MODE id);
+RRD_MEMORY_MODE rrd_memory_mode_id(const char *name);
 
 
 // ----------------------------------------------------------------------------
@@ -153,17 +153,17 @@ typedef enum rrd_algorithm {
 #define RRD_ALGORITHM_PCENT_OVER_DIFF_TOTAL_NAME   "percentage-of-incremental-row"
 #define RRD_ALGORITHM_PCENT_OVER_ROW_TOTAL_NAME    "percentage-of-absolute-row"
 
-extern RRD_ALGORITHM rrd_algorithm_id(const char *name);
-extern const char *rrd_algorithm_name(RRD_ALGORITHM algorithm);
+RRD_ALGORITHM rrd_algorithm_id(const char *name);
+const char *rrd_algorithm_name(RRD_ALGORITHM algorithm);
 
 // ----------------------------------------------------------------------------
 // RRD FAMILY
 
-extern const RRDFAMILY_ACQUIRED *rrdfamily_add_and_acquire(RRDHOST *host, const char *id);
-extern void rrdfamily_release(RRDHOST *host, const RRDFAMILY_ACQUIRED *rfa);
-extern void rrdfamily_index_init(RRDHOST *host);
-extern void rrdfamily_index_destroy(RRDHOST *host);
-extern DICTIONARY *rrdfamily_rrdvars_dict(const RRDFAMILY_ACQUIRED *rf);
+const RRDFAMILY_ACQUIRED *rrdfamily_add_and_acquire(RRDHOST *host, const char *id);
+void rrdfamily_release(RRDHOST *host, const RRDFAMILY_ACQUIRED *rfa);
+void rrdfamily_index_init(RRDHOST *host);
+void rrdfamily_index_destroy(RRDHOST *host);
+DICTIONARY *rrdfamily_rrdvars_dict(const RRDFAMILY_ACQUIRED *rf);
 
 
 // ----------------------------------------------------------------------------
@@ -217,37 +217,37 @@ typedef enum rrdlabel_source {
 
 #define RRDLABEL_FLAG_INTERNAL (RRDLABEL_FLAG_OLD | RRDLABEL_FLAG_NEW | RRDLABEL_FLAG_PERMANENT)
 
-extern size_t text_sanitize(unsigned char *dst, const unsigned char *src, size_t dst_size, unsigned char *char_map, bool utf, const char *empty, size_t *multibyte_length);
+size_t text_sanitize(unsigned char *dst, const unsigned char *src, size_t dst_size, unsigned char *char_map, bool utf, const char *empty, size_t *multibyte_length);
 
-extern DICTIONARY *rrdlabels_create(void);
-extern void rrdlabels_destroy(DICTIONARY *labels_dict);
-extern void rrdlabels_add(DICTIONARY *dict, const char *name, const char *value, RRDLABEL_SRC ls);
-extern void rrdlabels_add_pair(DICTIONARY *dict, const char *string, RRDLABEL_SRC ls);
-extern void rrdlabels_get_value_to_buffer_or_null(DICTIONARY *labels, BUFFER *wb, const char *key, const char *quote, const char *null);
-extern void rrdlabels_get_value_to_char_or_null(DICTIONARY *labels, char **value, const char *key);
+DICTIONARY *rrdlabels_create(void);
+void rrdlabels_destroy(DICTIONARY *labels_dict);
+void rrdlabels_add(DICTIONARY *dict, const char *name, const char *value, RRDLABEL_SRC ls);
+void rrdlabels_add_pair(DICTIONARY *dict, const char *string, RRDLABEL_SRC ls);
+void rrdlabels_get_value_to_buffer_or_null(DICTIONARY *labels, BUFFER *wb, const char *key, const char *quote, const char *null);
+void rrdlabels_get_value_to_char_or_null(DICTIONARY *labels, char **value, const char *key);
 
-extern void rrdlabels_unmark_all(DICTIONARY *labels);
-extern void rrdlabels_remove_all_unmarked(DICTIONARY *labels);
+void rrdlabels_unmark_all(DICTIONARY *labels);
+void rrdlabels_remove_all_unmarked(DICTIONARY *labels);
 
-extern int rrdlabels_walkthrough_read(DICTIONARY *labels, int (*callback)(const char *name, const char *value, RRDLABEL_SRC ls, void *data), void *data);
-extern int rrdlabels_sorted_walkthrough_read(DICTIONARY *labels, int (*callback)(const char *name, const char *value, RRDLABEL_SRC ls, void *data), void *data);
+int rrdlabels_walkthrough_read(DICTIONARY *labels, int (*callback)(const char *name, const char *value, RRDLABEL_SRC ls, void *data), void *data);
+int rrdlabels_sorted_walkthrough_read(DICTIONARY *labels, int (*callback)(const char *name, const char *value, RRDLABEL_SRC ls, void *data), void *data);
 
-extern void rrdlabels_log_to_buffer(DICTIONARY *labels, BUFFER *wb);
-extern bool rrdlabels_match_simple_pattern(DICTIONARY *labels, const char *simple_pattern_txt);
-extern bool rrdlabels_match_simple_pattern_parsed(DICTIONARY *labels, SIMPLE_PATTERN *pattern, char equal);
-extern int rrdlabels_to_buffer(DICTIONARY *labels, BUFFER *wb, const char *before_each, const char *equal, const char *quote, const char *between_them, bool (*filter_callback)(const char *name, const char *value, RRDLABEL_SRC ls, void *data), void *filter_data, void (*name_sanitizer)(char *dst, const char *src, size_t dst_size), void (*value_sanitizer)(char *dst, const char *src, size_t dst_size));
+void rrdlabels_log_to_buffer(DICTIONARY *labels, BUFFER *wb);
+bool rrdlabels_match_simple_pattern(DICTIONARY *labels, const char *simple_pattern_txt);
+bool rrdlabels_match_simple_pattern_parsed(DICTIONARY *labels, SIMPLE_PATTERN *pattern, char equal);
+int rrdlabels_to_buffer(DICTIONARY *labels, BUFFER *wb, const char *before_each, const char *equal, const char *quote, const char *between_them, bool (*filter_callback)(const char *name, const char *value, RRDLABEL_SRC ls, void *data), void *filter_data, void (*name_sanitizer)(char *dst, const char *src, size_t dst_size), void (*value_sanitizer)(char *dst, const char *src, size_t dst_size));
 
-extern void rrdlabels_migrate_to_these(DICTIONARY *dst, DICTIONARY *src);
-extern void rrdlabels_copy(DICTIONARY *dst, DICTIONARY *src);
+void rrdlabels_migrate_to_these(DICTIONARY *dst, DICTIONARY *src);
+void rrdlabels_copy(DICTIONARY *dst, DICTIONARY *src);
 
 void reload_host_labels(void);
-extern void rrdset_update_rrdlabels(RRDSET *st, DICTIONARY *new_rrdlabels);
-extern void rrdset_save_rrdlabels_to_sql(RRDSET *st);
+void rrdset_update_rrdlabels(RRDSET *st, DICTIONARY *new_rrdlabels);
+void rrdset_save_rrdlabels_to_sql(RRDSET *st);
 
-extern int rrdlabels_unittest(void);
+int rrdlabels_unittest(void);
 
 // unfortunately this break when defined in exporting_engine.h
-extern bool exporting_labels_filter_callback(const char *name, const char *value, RRDLABEL_SRC ls, void *data);
+bool exporting_labels_filter_callback(const char *name, const char *value, RRDLABEL_SRC ls, void *data);
 
 // ----------------------------------------------------------------------------
 // RRD DIMENSION - this is a metric
@@ -328,20 +328,20 @@ struct rrddim {
 #define rrddim_name(rd) string2str((rd) ->name)
 
 // returns the RRDDIM cache filename, or NULL if it does not exist
-extern const char *rrddim_cache_filename(RRDDIM *rd);
+const char *rrddim_cache_filename(RRDDIM *rd);
 
 // updated the header with the latest RRDDIM value, for memory mode MAP and SAVE
-extern void rrddim_memory_file_update(RRDDIM *rd);
+void rrddim_memory_file_update(RRDDIM *rd);
 
 // free the memory file structures for memory mode MAP and SAVE
-extern void rrddim_memory_file_free(RRDDIM *rd);
+void rrddim_memory_file_free(RRDDIM *rd);
 
-extern bool rrddim_memory_load_or_create_map_save(RRDSET *st, RRDDIM *rd, RRD_MEMORY_MODE memory_mode);
+bool rrddim_memory_load_or_create_map_save(RRDSET *st, RRDDIM *rd, RRD_MEMORY_MODE memory_mode);
 
 // return the v019 header size of RRDDIM files
-extern size_t rrddim_memory_file_header_size(void);
+size_t rrddim_memory_file_header_size(void);
 
-extern void rrddim_memory_file_save(RRDDIM *rd);
+void rrddim_memory_file_save(RRDDIM *rd);
 
 // ----------------------------------------------------------------------------
 // engine-specific iterator state for dimension data collection
@@ -451,7 +451,7 @@ struct rrddim_tier {
     struct rrddim_query_ops query_ops;
 };
 
-extern void rrdr_fill_tier_gap_from_smaller_tiers(RRDDIM *rd, int tier, time_t now);
+void rrdr_fill_tier_gap_from_smaller_tiers(RRDDIM *rd, int tier, time_t now);
 
 // ----------------------------------------------------------------------------
 // these loop macros make sure the linked list is accessed with the right lock
@@ -659,7 +659,7 @@ struct rrdset {
 #define rrdset_wrlock(st) netdata_rwlock_wrlock(&((st)->rrdset_rwlock))
 #define rrdset_unlock(st) netdata_rwlock_unlock(&((st)->rrdset_rwlock))
 
-extern STRING *rrd_string_strdupz(const char *s);
+STRING *rrd_string_strdupz(const char *s);
 
 // ----------------------------------------------------------------------------
 // these loop macros make sure the linked list is accessed with the right lock
@@ -679,11 +679,11 @@ extern STRING *rrd_string_strdupz(const char *s);
 #define rrdset_number_of_dimensions(st) \
     dictionary_entries((st)->rrddim_root_index)
 
-extern void rrdset_memory_file_save(RRDSET *st);
-extern void rrdset_memory_file_free(RRDSET *st);
-extern void rrdset_memory_file_update(RRDSET *st);
-extern const char *rrdset_cache_filename(RRDSET *st);
-extern bool rrdset_memory_load_or_create_map_save(RRDSET *st_on_file, RRD_MEMORY_MODE memory_mode);
+void rrdset_memory_file_save(RRDSET *st);
+void rrdset_memory_file_free(RRDSET *st);
+void rrdset_memory_file_update(RRDSET *st);
+const char *rrdset_cache_filename(RRDSET *st);
+bool rrdset_memory_load_or_create_map_save(RRDSET *st_on_file, RRD_MEMORY_MODE memory_mode);
 
 #include "rrdfunctions.h"
 
@@ -1016,7 +1016,7 @@ extern RRDHOST *localhost;
 #define rrdhost_aclk_state_lock(host) netdata_mutex_lock(&((host)->aclk_state_lock))
 #define rrdhost_aclk_state_unlock(host) netdata_mutex_unlock(&((host)->aclk_state_lock))
 
-extern long rrdhost_hosts_available(void);
+long rrdhost_hosts_available(void);
 
 // ----------------------------------------------------------------------------
 // these loop macros make sure the linked list is accessed with the right lock
@@ -1039,24 +1039,24 @@ extern netdata_rwlock_t rrd_rwlock;
 
 // ----------------------------------------------------------------------------
 
-extern bool is_storage_engine_shared(STORAGE_INSTANCE *engine);
-extern void rrdset_index_init(RRDHOST *host);
-extern void rrdset_index_destroy(RRDHOST *host);
+bool is_storage_engine_shared(STORAGE_INSTANCE *engine);
+void rrdset_index_init(RRDHOST *host);
+void rrdset_index_destroy(RRDHOST *host);
 
-extern void rrddim_index_init(RRDSET *st);
-extern void rrddim_index_destroy(RRDSET *st);
+void rrddim_index_init(RRDSET *st);
+void rrddim_index_destroy(RRDSET *st);
 
 // ----------------------------------------------------------------------------
 
 extern size_t rrd_hosts_available;
 extern time_t rrdhost_free_orphan_time;
 
-extern int rrd_init(char *hostname, struct rrdhost_system_info *system_info);
+int rrd_init(char *hostname, struct rrdhost_system_info *system_info);
 
-extern RRDHOST *rrdhost_find_by_hostname(const char *hostname);
-extern RRDHOST *rrdhost_find_by_guid(const char *guid);
+RRDHOST *rrdhost_find_by_hostname(const char *hostname);
+RRDHOST *rrdhost_find_by_guid(const char *guid);
 
-extern RRDHOST *rrdhost_find_or_create(
+RRDHOST *rrdhost_find_or_create(
         const char *hostname
         , const char *registry_hostname
         , const char *guid
@@ -1079,7 +1079,7 @@ extern RRDHOST *rrdhost_find_or_create(
         , bool is_archived
 );
 
-extern void rrdhost_update(RRDHOST *host
+void rrdhost_update(RRDHOST *host
     , const char *hostname
     , const char *registry_hostname
     , const char *guid
@@ -1101,15 +1101,15 @@ extern void rrdhost_update(RRDHOST *host
     , struct rrdhost_system_info *system_info
 );
 
-extern int rrdhost_set_system_info_variable(struct rrdhost_system_info *system_info, char *name, char *value);
+int rrdhost_set_system_info_variable(struct rrdhost_system_info *system_info, char *name, char *value);
 
 #if defined(NETDATA_INTERNAL_CHECKS) && defined(NETDATA_VERIFY_LOCKS)
-extern void __rrdhost_check_wrlock(RRDHOST *host, const char *file, const char *function, const unsigned long line);
-extern void __rrdhost_check_rdlock(RRDHOST *host, const char *file, const char *function, const unsigned long line);
-extern void __rrdset_check_rdlock(RRDSET *st, const char *file, const char *function, const unsigned long line);
-extern void __rrdset_check_wrlock(RRDSET *st, const char *file, const char *function, const unsigned long line);
-extern void __rrd_check_rdlock(const char *file, const char *function, const unsigned long line);
-extern void __rrd_check_wrlock(const char *file, const char *function, const unsigned long line);
+void __rrdhost_check_wrlock(RRDHOST *host, const char *file, const char *function, const unsigned long line);
+void __rrdhost_check_rdlock(RRDHOST *host, const char *file, const char *function, const unsigned long line);
+void __rrdset_check_rdlock(RRDSET *st, const char *file, const char *function, const unsigned long line);
+void __rrdset_check_wrlock(RRDSET *st, const char *file, const char *function, const unsigned long line);
+void __rrd_check_rdlock(const char *file, const char *function, const unsigned long line);
+void __rrd_check_wrlock(const char *file, const char *function, const unsigned long line);
 
 #define rrdhost_check_rdlock(host) __rrdhost_check_rdlock(host, __FILE__, __FUNCTION__, __LINE__)
 #define rrdhost_check_wrlock(host) __rrdhost_check_wrlock(host, __FILE__, __FUNCTION__, __LINE__)
@@ -1130,9 +1130,9 @@ extern void __rrd_check_wrlock(const char *file, const char *function, const uns
 // ----------------------------------------------------------------------------
 // RRDSET functions
 
-extern int rrdset_reset_name(RRDSET *st, const char *name);
+int rrdset_reset_name(RRDSET *st, const char *name);
 
-extern RRDSET *rrdset_create_custom(RRDHOST *host
+RRDSET *rrdset_create_custom(RRDHOST *host
                              , const char *type
                              , const char *id
                              , const char *name
@@ -1154,20 +1154,20 @@ extern RRDSET *rrdset_create_custom(RRDHOST *host
 #define rrdset_create_localhost(type, id, name, family, context, title, units, plugin, module, priority, update_every, chart_type) \
     rrdset_create(localhost, type, id, name, family, context, title, units, plugin, module, priority, update_every, chart_type)
 
-extern void rrdhost_free_all(void);
-extern void rrdhost_save_all(void);
-extern void rrdhost_cleanup_all(void);
+void rrdhost_free_all(void);
+void rrdhost_save_all(void);
+void rrdhost_cleanup_all(void);
 
-extern void rrdhost_system_info_free(struct rrdhost_system_info *system_info);
-extern void rrdhost_free(RRDHOST *host, bool force);
-extern void rrdhost_save_charts(RRDHOST *host);
-extern void rrdhost_delete_charts(RRDHOST *host);
+void rrdhost_system_info_free(struct rrdhost_system_info *system_info);
+void rrdhost_free(RRDHOST *host, bool force);
+void rrdhost_save_charts(RRDHOST *host);
+void rrdhost_delete_charts(RRDHOST *host);
 
-extern int rrdhost_should_be_removed(RRDHOST *host, RRDHOST *protected_host, time_t now);
+int rrdhost_should_be_removed(RRDHOST *host, RRDHOST *protected_host, time_t now);
 
-extern void rrdset_update_heterogeneous_flag(RRDSET *st);
+void rrdset_update_heterogeneous_flag(RRDSET *st);
 
-extern RRDSET *rrdset_find(RRDHOST *host, const char *id);
+RRDSET *rrdset_find(RRDHOST *host, const char *id);
 #define rrdset_find_localhost(id) rrdset_find(localhost, id)
 /* This will not return charts that are archived */
 static inline RRDSET *rrdset_find_active_localhost(const char *id)
@@ -1178,7 +1178,7 @@ static inline RRDSET *rrdset_find_active_localhost(const char *id)
     return st;
 }
 
-extern RRDSET *rrdset_find_bytype(RRDHOST *host, const char *type, const char *id);
+RRDSET *rrdset_find_bytype(RRDHOST *host, const char *type, const char *id);
 #define rrdset_find_bytype_localhost(type, id) rrdset_find_bytype(localhost, type, id)
 /* This will not return charts that are archived */
 static inline RRDSET *rrdset_find_active_bytype_localhost(const char *type, const char *id)
@@ -1189,7 +1189,7 @@ static inline RRDSET *rrdset_find_active_bytype_localhost(const char *type, cons
     return st;
 }
 
-extern RRDSET *rrdset_find_byname(RRDHOST *host, const char *name);
+RRDSET *rrdset_find_byname(RRDHOST *host, const char *name);
 #define rrdset_find_byname_localhost(name)  rrdset_find_byname(localhost, name)
 /* This will not return charts that are archived */
 static inline RRDSET *rrdset_find_active_byname_localhost(const char *name)
@@ -1200,30 +1200,30 @@ static inline RRDSET *rrdset_find_active_byname_localhost(const char *name)
     return st;
 }
 
-extern void rrdset_next_usec_unfiltered(RRDSET *st, usec_t microseconds);
-extern void rrdset_next_usec(RRDSET *st, usec_t microseconds);
+void rrdset_next_usec_unfiltered(RRDSET *st, usec_t microseconds);
+void rrdset_next_usec(RRDSET *st, usec_t microseconds);
 #define rrdset_next(st) rrdset_next_usec(st, 0ULL)
 
-extern void rrdset_done(RRDSET *st);
+void rrdset_done(RRDSET *st);
 
-extern void rrdset_is_obsolete(RRDSET *st);
-extern void rrdset_isnot_obsolete(RRDSET *st);
+void rrdset_is_obsolete(RRDSET *st);
+void rrdset_isnot_obsolete(RRDSET *st);
 
 // checks if the RRDSET should be offered to viewers
 #define rrdset_is_available_for_viewers(st) (!rrdset_flag_check(st, RRDSET_FLAG_HIDDEN) && !rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && !rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && rrdset_number_of_dimensions(st) && (st)->rrd_memory_mode != RRD_MEMORY_MODE_NONE)
 #define rrdset_is_available_for_exporting_and_alarms(st) (!rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE) && !rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && (st)->dimensions)
 #define rrdset_is_archived(st) (rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && (st)->dimensions)
 
-extern time_t rrddim_first_entry_t(RRDDIM *rd);
-extern time_t rrddim_last_entry_t(RRDDIM *rd);
-extern time_t rrdset_last_entry_t(RRDSET *st);
-extern time_t rrdset_first_entry_t(RRDSET *st);
-extern time_t rrdhost_last_entry_t(RRDHOST *h);
+time_t rrddim_first_entry_t(RRDDIM *rd);
+time_t rrddim_last_entry_t(RRDDIM *rd);
+time_t rrdset_last_entry_t(RRDSET *st);
+time_t rrdset_first_entry_t(RRDSET *st);
+time_t rrdhost_last_entry_t(RRDHOST *h);
 
 // ----------------------------------------------------------------------------
 // RRD DIMENSION functions
 
-extern RRDDIM *rrddim_add_custom(RRDSET *st
+RRDDIM *rrddim_add_custom(RRDSET *st
                                  , const char *id
                                  , const char *name
                                  , collected_number multiplier
@@ -1235,49 +1235,49 @@ extern RRDDIM *rrddim_add_custom(RRDSET *st
 #define rrddim_add(st, id, name, multiplier, divisor, algorithm) \
     rrddim_add_custom(st, id, name, multiplier, divisor, algorithm, (st)->rrd_memory_mode)
 
-extern int rrddim_reset_name(RRDSET *st, RRDDIM *rd, const char *name);
-extern int rrddim_set_algorithm(RRDSET *st, RRDDIM *rd, RRD_ALGORITHM algorithm);
-extern int rrddim_set_multiplier(RRDSET *st, RRDDIM *rd, collected_number multiplier);
-extern int rrddim_set_divisor(RRDSET *st, RRDDIM *rd, collected_number divisor);
+int rrddim_reset_name(RRDSET *st, RRDDIM *rd, const char *name);
+int rrddim_set_algorithm(RRDSET *st, RRDDIM *rd, RRD_ALGORITHM algorithm);
+int rrddim_set_multiplier(RRDSET *st, RRDDIM *rd, collected_number multiplier);
+int rrddim_set_divisor(RRDSET *st, RRDDIM *rd, collected_number divisor);
 
-extern RRDDIM *rrddim_find(RRDSET *st, const char *id);
-extern RRDDIM *rrddim_find_active(RRDSET *st, const char *id);
+RRDDIM *rrddim_find(RRDSET *st, const char *id);
+RRDDIM *rrddim_find_active(RRDSET *st, const char *id);
 
-extern int rrddim_hide(RRDSET *st, const char *id);
-extern int rrddim_unhide(RRDSET *st, const char *id);
+int rrddim_hide(RRDSET *st, const char *id);
+int rrddim_unhide(RRDSET *st, const char *id);
 
-extern void rrddim_is_obsolete(RRDSET *st, RRDDIM *rd);
-extern void rrddim_isnot_obsolete(RRDSET *st, RRDDIM *rd);
+void rrddim_is_obsolete(RRDSET *st, RRDDIM *rd);
+void rrddim_isnot_obsolete(RRDSET *st, RRDDIM *rd);
 
-extern collected_number rrddim_set_by_pointer(RRDSET *st, RRDDIM *rd, collected_number value);
-extern collected_number rrddim_set(RRDSET *st, const char *id, collected_number value);
+collected_number rrddim_set_by_pointer(RRDSET *st, RRDDIM *rd, collected_number value);
+collected_number rrddim_set(RRDSET *st, const char *id, collected_number value);
 #ifdef ENABLE_ACLK
-extern time_t calc_dimension_liveness(RRDDIM *rd, time_t now);
+time_t calc_dimension_liveness(RRDDIM *rd, time_t now);
 #endif
-extern long align_entries_to_pagesize(RRD_MEMORY_MODE mode, long entries);
+long align_entries_to_pagesize(RRD_MEMORY_MODE mode, long entries);
 
 // ----------------------------------------------------------------------------
 // Miscellaneous functions
 
-extern char *rrdset_strncpyz_name(char *to, const char *from, size_t length);
+char *rrdset_strncpyz_name(char *to, const char *from, size_t length);
 
 // ----------------------------------------------------------------------------
 // RRD internal functions
 
-extern void rrdset_delete_files(RRDSET *st);
-extern void rrdset_save(RRDSET *st);
-extern void rrdset_free(RRDSET *st);
+void rrdset_delete_files(RRDSET *st);
+void rrdset_save(RRDSET *st);
+void rrdset_free(RRDSET *st);
 
 #ifdef NETDATA_RRD_INTERNALS
 
-extern char *rrdset_cache_dir(RRDHOST *host, const char *id);
+char *rrdset_cache_dir(RRDHOST *host, const char *id);
 
-extern void rrddim_free(RRDSET *st, RRDDIM *rd);
+void rrddim_free(RRDSET *st, RRDDIM *rd);
 
-extern void rrdset_reset(RRDSET *st);
-extern void rrdset_delete_obsolete_dimensions(RRDSET *st);
+void rrdset_reset(RRDSET *st);
+void rrdset_delete_obsolete_dimensions(RRDSET *st);
 
-extern RRDHOST *rrdhost_create(
+RRDHOST *rrdhost_create(
     const char *hostname, const char *registry_hostname, const char *guid, const char *os, const char *timezone,
     const char *abbrev_timezone, int32_t utc_offset,const char *tags, const char *program_name, const char *program_version,
     int update_every, long entries, RRD_MEMORY_MODE memory_mode, unsigned int health_enabled, unsigned int rrdpush_enabled,
@@ -1286,12 +1286,12 @@ extern RRDHOST *rrdhost_create(
 
 #endif /* NETDATA_RRD_INTERNALS */
 
-extern void set_host_properties(
+void set_host_properties(
     RRDHOST *host, int update_every, RRD_MEMORY_MODE memory_mode, const char *registry_hostname,
     const char *os, const char *tags, const char *tzone, const char *abbrev_tzone, int32_t utc_offset,
     const char *program_name, const char *program_version);
 
-extern int get_tier_grouping(int tier);
+int get_tier_grouping(int tier);
 
 // ----------------------------------------------------------------------------
 // RRD DB engine declarations

--- a/database/rrdcalc.h
+++ b/database/rrdcalc.h
@@ -218,24 +218,24 @@ struct alert_config {
 
 #define RRDCALC_HAS_DB_LOOKUP(rc) ((rc)->after)
 
-extern void rrdcalc_update_info_using_rrdset_labels(RRDCALC *rc);
+void rrdcalc_update_info_using_rrdset_labels(RRDCALC *rc);
 
-extern void rrdcalc_link_matching_alerts_to_rrdset(RRDSET *st);
+void rrdcalc_link_matching_alerts_to_rrdset(RRDSET *st);
 
-extern const RRDCALC_ACQUIRED *rrdcalc_from_rrdset_get(RRDSET *st, const char *alert_name);
-extern void rrdcalc_from_rrdset_release(RRDSET *st, const RRDCALC_ACQUIRED *rca);
-extern RRDCALC *rrdcalc_acquired_to_rrdcalc(const RRDCALC_ACQUIRED *rca);
+const RRDCALC_ACQUIRED *rrdcalc_from_rrdset_get(RRDSET *st, const char *alert_name);
+void rrdcalc_from_rrdset_release(RRDSET *st, const RRDCALC_ACQUIRED *rca);
+RRDCALC *rrdcalc_acquired_to_rrdcalc(const RRDCALC_ACQUIRED *rca);
 
-extern const char *rrdcalc_status2string(RRDCALC_STATUS status);
+const char *rrdcalc_status2string(RRDCALC_STATUS status);
 
-extern void rrdcalc_free_unused_rrdcalc_loaded_from_config(RRDCALC *rc);
+void rrdcalc_free_unused_rrdcalc_loaded_from_config(RRDCALC *rc);
 
-extern uint32_t rrdcalc_get_unique_id(RRDHOST *host, STRING *chart, STRING *name, uint32_t *next_event_id);
-extern void rrdcalc_add_from_rrdcalctemplate(RRDHOST *host, RRDCALCTEMPLATE *rt, RRDSET *st, const char *overwrite_alert_name, const char *overwrite_dimensions);
-extern int rrdcalc_add_from_config(RRDHOST *host, RRDCALC *rc);
+uint32_t rrdcalc_get_unique_id(RRDHOST *host, STRING *chart, STRING *name, uint32_t *next_event_id);
+void rrdcalc_add_from_rrdcalctemplate(RRDHOST *host, RRDCALCTEMPLATE *rt, RRDSET *st, const char *overwrite_alert_name, const char *overwrite_dimensions);
+int rrdcalc_add_from_config(RRDHOST *host, RRDCALC *rc);
 
-extern void rrdcalc_delete_alerts_not_matching_host_labels_from_all_hosts();
-extern void rrdcalc_delete_alerts_not_matching_host_labels_from_this_host(RRDHOST *host);
+void rrdcalc_delete_alerts_not_matching_host_labels_from_all_hosts();
+void rrdcalc_delete_alerts_not_matching_host_labels_from_this_host(RRDHOST *host);
 
 static inline int rrdcalc_isrepeating(RRDCALC *rc) {
     if (unlikely(rc->warn_repeat_every > 0 || rc->crit_repeat_every > 0)) {
@@ -244,11 +244,11 @@ static inline int rrdcalc_isrepeating(RRDCALC *rc) {
     return 0;
 }
 
-extern void rrdcalc_unlink_all_rrdset_alerts(RRDSET *st);
-extern void rrdcalc_delete_all(RRDHOST *host);
+void rrdcalc_unlink_all_rrdset_alerts(RRDSET *st);
+void rrdcalc_delete_all(RRDHOST *host);
 
-extern void rrdcalc_rrdhost_index_init(RRDHOST *host);
-extern void rrdcalc_rrdhost_index_destroy(RRDHOST *host);
+void rrdcalc_rrdhost_index_init(RRDHOST *host);
+void rrdcalc_rrdhost_index_destroy(RRDHOST *host);
 
 #define RRDCALC_VAR_MAX 100
 #define RRDCALC_VAR_FAMILY "$family"

--- a/database/rrdcalctemplate.h
+++ b/database/rrdcalctemplate.h
@@ -110,19 +110,19 @@ struct rrdcalctemplate {
 
 #define RRDCALCTEMPLATE_HAS_DB_LOOKUP(rt) ((rt)->after)
 
-extern void rrdcalctemplate_link_matching_templates_to_rrdset(RRDSET *st);
+void rrdcalctemplate_link_matching_templates_to_rrdset(RRDSET *st);
 
-extern void rrdcalctemplate_free_unused_rrdcalctemplate_loaded_from_config(RRDCALCTEMPLATE *rt);
-extern void rrdcalctemplate_delete_all(RRDHOST *host);
-extern void rrdcalctemplate_add_from_config(RRDHOST *host, RRDCALCTEMPLATE *rt);
+void rrdcalctemplate_free_unused_rrdcalctemplate_loaded_from_config(RRDCALCTEMPLATE *rt);
+void rrdcalctemplate_delete_all(RRDHOST *host);
+void rrdcalctemplate_add_from_config(RRDHOST *host, RRDCALCTEMPLATE *rt);
 
-extern void rrdcalctemplate_check_conditions_and_link(RRDCALCTEMPLATE *rt, RRDSET *st, RRDHOST *host);
+void rrdcalctemplate_check_conditions_and_link(RRDCALCTEMPLATE *rt, RRDSET *st, RRDHOST *host);
 
-extern bool rrdcalctemplate_check_rrdset_conditions(RRDCALCTEMPLATE *rt, RRDSET *st, RRDHOST *host);
-extern void rrdcalctemplate_check_rrddim_conditions_and_link(RRDCALCTEMPLATE *rt, RRDSET *st, RRDDIM *rd, RRDHOST *host);
+bool rrdcalctemplate_check_rrdset_conditions(RRDCALCTEMPLATE *rt, RRDSET *st, RRDHOST *host);
+void rrdcalctemplate_check_rrddim_conditions_and_link(RRDCALCTEMPLATE *rt, RRDSET *st, RRDDIM *rd, RRDHOST *host);
 
 
-extern void rrdcalctemplate_index_init(RRDHOST *host);
-extern void rrdcalctemplate_index_destroy(RRDHOST *host);
+void rrdcalctemplate_index_init(RRDHOST *host);
+void rrdcalctemplate_index_destroy(RRDHOST *host);
 
 #endif //NETDATA_RRDCALCTEMPLATE_H

--- a/database/rrdcontext.h
+++ b/database/rrdcontext.h
@@ -27,14 +27,14 @@ typedef struct rrdcontext_acquired RRDCONTEXT_ACQUIRED;
 // ----------------------------------------------------------------------------
 // public API for rrdhost
 
-extern void rrdhost_load_rrdcontext_data(RRDHOST *host);
-extern void rrdhost_create_rrdcontexts(RRDHOST *host);
-extern void rrdhost_destroy_rrdcontexts(RRDHOST *host);
+void rrdhost_load_rrdcontext_data(RRDHOST *host);
+void rrdhost_create_rrdcontexts(RRDHOST *host);
+void rrdhost_destroy_rrdcontexts(RRDHOST *host);
 
-extern void rrdcontext_host_child_connected(RRDHOST *host);
-extern void rrdcontext_host_child_disconnected(RRDHOST *host);
+void rrdcontext_host_child_connected(RRDHOST *host);
+void rrdcontext_host_child_disconnected(RRDHOST *host);
 
-extern int rrdcontext_foreach_instance_with_rrdset_in_context(RRDHOST *host, const char *context, int (*callback)(RRDSET *st, void *data), void *data);
+int rrdcontext_foreach_instance_with_rrdset_in_context(RRDHOST *host, const char *context, int (*callback)(RRDSET *st, void *data), void *data);
 
 typedef enum {
     RRDCONTEXT_OPTION_NONE               = 0,
@@ -52,41 +52,41 @@ typedef enum {
 
 #define RRDCONTEXT_OPTIONS_ALL (RRDCONTEXT_OPTION_SHOW_METRICS|RRDCONTEXT_OPTION_SHOW_INSTANCES|RRDCONTEXT_OPTION_SHOW_LABELS|RRDCONTEXT_OPTION_SHOW_QUEUED|RRDCONTEXT_OPTION_SHOW_FLAGS|RRDCONTEXT_OPTION_SHOW_DELETED|RRDCONTEXT_OPTION_SHOW_UUIDS|RRDCONTEXT_OPTION_SHOW_HIDDEN)
 
-extern int rrdcontext_to_json(RRDHOST *host, BUFFER *wb, time_t after, time_t before, RRDCONTEXT_TO_JSON_OPTIONS options, const char *context, SIMPLE_PATTERN *chart_label_key, SIMPLE_PATTERN *chart_labels_filter, SIMPLE_PATTERN *chart_dimensions);
-extern int rrdcontexts_to_json(RRDHOST *host, BUFFER *wb, time_t after, time_t before, RRDCONTEXT_TO_JSON_OPTIONS options, SIMPLE_PATTERN *chart_label_key, SIMPLE_PATTERN *chart_labels_filter, SIMPLE_PATTERN *chart_dimensions);
+int rrdcontext_to_json(RRDHOST *host, BUFFER *wb, time_t after, time_t before, RRDCONTEXT_TO_JSON_OPTIONS options, const char *context, SIMPLE_PATTERN *chart_label_key, SIMPLE_PATTERN *chart_labels_filter, SIMPLE_PATTERN *chart_dimensions);
+int rrdcontexts_to_json(RRDHOST *host, BUFFER *wb, time_t after, time_t before, RRDCONTEXT_TO_JSON_OPTIONS options, SIMPLE_PATTERN *chart_label_key, SIMPLE_PATTERN *chart_labels_filter, SIMPLE_PATTERN *chart_dimensions);
 
 // ----------------------------------------------------------------------------
 // public API for rrddims
 
-extern void rrdcontext_updated_rrddim(RRDDIM *rd);
-extern void rrdcontext_removed_rrddim(RRDDIM *rd);
-extern void rrdcontext_updated_rrddim_algorithm(RRDDIM *rd);
-extern void rrdcontext_updated_rrddim_multiplier(RRDDIM *rd);
-extern void rrdcontext_updated_rrddim_divisor(RRDDIM *rd);
-extern void rrdcontext_updated_rrddim_flags(RRDDIM *rd);
-extern void rrdcontext_collected_rrddim(RRDDIM *rd);
+void rrdcontext_updated_rrddim(RRDDIM *rd);
+void rrdcontext_removed_rrddim(RRDDIM *rd);
+void rrdcontext_updated_rrddim_algorithm(RRDDIM *rd);
+void rrdcontext_updated_rrddim_multiplier(RRDDIM *rd);
+void rrdcontext_updated_rrddim_divisor(RRDDIM *rd);
+void rrdcontext_updated_rrddim_flags(RRDDIM *rd);
+void rrdcontext_collected_rrddim(RRDDIM *rd);
 
 // ----------------------------------------------------------------------------
 // public API for rrdsets
 
-extern void rrdcontext_updated_rrdset(RRDSET *st);
-extern void rrdcontext_removed_rrdset(RRDSET *st);
-extern void rrdcontext_updated_rrdset_name(RRDSET *st);
-extern void rrdcontext_updated_rrdset_flags(RRDSET *st);
-extern void rrdcontext_collected_rrdset(RRDSET *st);
+void rrdcontext_updated_rrdset(RRDSET *st);
+void rrdcontext_removed_rrdset(RRDSET *st);
+void rrdcontext_updated_rrdset_name(RRDSET *st);
+void rrdcontext_updated_rrdset_flags(RRDSET *st);
+void rrdcontext_collected_rrdset(RRDSET *st);
 
 // ----------------------------------------------------------------------------
 // public API for ACLK
 
-extern void rrdcontext_hub_checkpoint_command(void *cmd);
-extern void rrdcontext_hub_stop_streaming_command(void *cmd);
+void rrdcontext_hub_checkpoint_command(void *cmd);
+void rrdcontext_hub_stop_streaming_command(void *cmd);
 
 
 // ----------------------------------------------------------------------------
 // public API for threads
 
-extern void rrdcontext_db_rotation(void);
-extern void *rrdcontext_main(void *);
+void rrdcontext_db_rotation(void);
+void *rrdcontext_main(void *);
 
 #endif // NETDATA_RRDCONTEXT_H
 

--- a/database/rrddimvar.h
+++ b/database/rrddimvar.h
@@ -11,11 +11,11 @@
 // This means, there will be no speed penalty for using
 // these variables
 
-extern void rrddimvar_rename_all(RRDDIM *rd);
-extern void rrddimvar_add_and_leave_released(RRDDIM *rd, RRDVAR_TYPE type, const char *prefix, const char *suffix, void *value, RRDVAR_FLAGS flags);
-extern void rrddimvar_delete_all(RRDDIM *rd);
+void rrddimvar_rename_all(RRDDIM *rd);
+void rrddimvar_add_and_leave_released(RRDDIM *rd, RRDVAR_TYPE type, const char *prefix, const char *suffix, void *value, RRDVAR_FLAGS flags);
+void rrddimvar_delete_all(RRDDIM *rd);
 
-extern void rrddimvar_index_init(RRDSET *st);
-extern void rrddimvar_index_destroy(RRDSET *st);
+void rrddimvar_index_init(RRDSET *st);
+void rrddimvar_index_destroy(RRDSET *st);
 
 #endif //NETDATA_RRDDIMVAR_H

--- a/database/rrdfunctions.h
+++ b/database/rrdfunctions.h
@@ -3,33 +3,33 @@
 
 #include "rrd.h"
 
-extern void rrdfunctions_init(RRDHOST *host);
-extern void rrdfunctions_destroy(RRDHOST *host);
+void rrdfunctions_init(RRDHOST *host);
+void rrdfunctions_destroy(RRDHOST *host);
 
-extern void rrd_collector_started(void);
-extern void rrd_collector_finished(void);
+void rrd_collector_started(void);
+void rrd_collector_finished(void);
 
 typedef void (*function_data_ready_callback)(BUFFER *wb, int code, void *callback_data);
 
 typedef int (*function_execute_at_collector)(BUFFER *wb, int timeout, const char *function, void *collector_data,
                                              function_data_ready_callback callback, void *callback_data);
 
-extern void rrd_collector_add_function(RRDHOST *host, RRDSET *st, const char *name, int timeout, const char *help,
+void rrd_collector_add_function(RRDHOST *host, RRDSET *st, const char *name, int timeout, const char *help,
                                        bool sync, function_execute_at_collector function, void *collector_data);
 
-extern int rrd_call_function_and_wait(RRDHOST *host, BUFFER *wb, int timeout, const char *name);
+int rrd_call_function_and_wait(RRDHOST *host, BUFFER *wb, int timeout, const char *name);
 
 typedef void (*rrd_call_function_async_callback)(BUFFER *wb, int code, void *callback_data);
-extern int rrd_call_function_async(RRDHOST *host, BUFFER *wb, int timeout, const char *name, rrd_call_function_async_callback, void *callback_data);
+int rrd_call_function_async(RRDHOST *host, BUFFER *wb, int timeout, const char *name, rrd_call_function_async_callback, void *callback_data);
 
-extern void rrd_functions_expose_rrdpush(RRDSET *st, BUFFER *wb);
+void rrd_functions_expose_rrdpush(RRDSET *st, BUFFER *wb);
 
-extern void chart_functions2json(RRDSET *st, BUFFER *wb, int tabs, const char *kq, const char *sq);
-extern void chart_functions_to_dict(RRDSET *st, DICTIONARY *dict);
-extern void host_functions2json(RRDHOST *host, BUFFER *wb, int tabs, const char *kq, const char *sq);
+void chart_functions2json(RRDSET *st, BUFFER *wb, int tabs, const char *kq, const char *sq);
+void chart_functions_to_dict(RRDSET *st, DICTIONARY *dict);
+void host_functions2json(RRDHOST *host, BUFFER *wb, int tabs, const char *kq, const char *sq);
 
-extern uint8_t functions_format_to_content_type(const char *format);
-extern const char *functions_content_type_to_format(uint8_t content_type);
-extern int rrd_call_function_error(BUFFER *wb, const char *msg, int code);
+uint8_t functions_format_to_content_type(const char *format);
+const char *functions_content_type_to_format(uint8_t content_type);
+int rrd_call_function_error(BUFFER *wb, const char *msg, int code);
 
 #endif // NETDATA_RRDFUNCTIONS_H

--- a/database/rrdsetvar.h
+++ b/database/rrdsetvar.h
@@ -11,20 +11,20 @@
 // This means, there will be no speed penalty for using
 // these variables
 
-extern void rrdsetvar_index_init(RRDSET *st);
-extern void rrdsetvar_index_destroy(RRDSET *st);
-extern void rrdsetvar_release_and_delete_all(RRDSET *st);
+void rrdsetvar_index_init(RRDSET *st);
+void rrdsetvar_index_destroy(RRDSET *st);
+void rrdsetvar_release_and_delete_all(RRDSET *st);
 
 #define rrdsetvar_custom_chart_variable_release(st, rsa) rrdsetvar_release((st)->rrdsetvar_root_index, rsa)
-extern void rrdsetvar_release(DICTIONARY *dict, const RRDSETVAR_ACQUIRED *rsa);
+void rrdsetvar_release(DICTIONARY *dict, const RRDSETVAR_ACQUIRED *rsa);
 
-extern const RRDSETVAR_ACQUIRED *rrdsetvar_custom_chart_variable_add_and_acquire(RRDSET *st, const char *name);
-extern void rrdsetvar_custom_chart_variable_set(RRDSET *st, const RRDSETVAR_ACQUIRED *rsa, NETDATA_DOUBLE value);
+const RRDSETVAR_ACQUIRED *rrdsetvar_custom_chart_variable_add_and_acquire(RRDSET *st, const char *name);
+void rrdsetvar_custom_chart_variable_set(RRDSET *st, const RRDSETVAR_ACQUIRED *rsa, NETDATA_DOUBLE value);
 
-extern void rrdsetvar_rename_all(RRDSET *st);
-extern const RRDSETVAR_ACQUIRED *rrdsetvar_add_and_acquire(RRDSET *st, const char *name, RRDVAR_TYPE type, void *value, RRDVAR_FLAGS flags);
-extern void rrdsetvar_add_and_leave_released(RRDSET *st, const char *name, RRDVAR_TYPE type, void *value, RRDVAR_FLAGS flags);
+void rrdsetvar_rename_all(RRDSET *st);
+const RRDSETVAR_ACQUIRED *rrdsetvar_add_and_acquire(RRDSET *st, const char *name, RRDVAR_TYPE type, void *value, RRDVAR_FLAGS flags);
+void rrdsetvar_add_and_leave_released(RRDSET *st, const char *name, RRDVAR_TYPE type, void *value, RRDVAR_FLAGS flags);
 
-extern void rrdsetvar_print_to_streaming_custom_chart_variables(RRDSET *st, BUFFER *wb);
+void rrdsetvar_print_to_streaming_custom_chart_variables(RRDSET *st, BUFFER *wb);
 
 #endif //NETDATA_RRDSETVAR_H

--- a/database/rrdvar.h
+++ b/database/rrdvar.h
@@ -40,32 +40,32 @@ typedef enum rrdvar_options {
 
 #define RRDVAR_MAX_LENGTH 1024
 
-extern int rrdvar_fix_name(char *variable);
+int rrdvar_fix_name(char *variable);
 
 #include "rrd.h"
 
-extern STRING *rrdvar_name_to_string(const char *name);
+STRING *rrdvar_name_to_string(const char *name);
 
-extern const RRDVAR_ACQUIRED *rrdvar_custom_host_variable_add_and_acquire(RRDHOST *host, const char *name);
-extern void rrdvar_custom_host_variable_set(RRDHOST *host, const RRDVAR_ACQUIRED *rva, NETDATA_DOUBLE value);
+const RRDVAR_ACQUIRED *rrdvar_custom_host_variable_add_and_acquire(RRDHOST *host, const char *name);
+void rrdvar_custom_host_variable_set(RRDHOST *host, const RRDVAR_ACQUIRED *rva, NETDATA_DOUBLE value);
 
-extern int rrdvar_walkthrough_read(DICTIONARY *dict, int (*callback)(const DICTIONARY_ITEM *item, void *rrdvar, void *data), void *data);
+int rrdvar_walkthrough_read(DICTIONARY *dict, int (*callback)(const DICTIONARY_ITEM *item, void *rrdvar, void *data), void *data);
 
 #define rrdvar_custom_host_variable_release(host, rva) rrdvar_release((host)->rrdvars, rva)
-extern void rrdvar_release(DICTIONARY *dict, const RRDVAR_ACQUIRED *rva);
+void rrdvar_release(DICTIONARY *dict, const RRDVAR_ACQUIRED *rva);
 
-extern NETDATA_DOUBLE rrdvar2number(const RRDVAR_ACQUIRED *rva);
+NETDATA_DOUBLE rrdvar2number(const RRDVAR_ACQUIRED *rva);
 
-extern const RRDVAR_ACQUIRED *rrdvar_add_and_acquire(const char *scope, DICTIONARY *dict, STRING *name, RRDVAR_TYPE type, RRDVAR_FLAGS options, void *value);
-extern void rrdvar_release_and_del(DICTIONARY *dict, const RRDVAR_ACQUIRED *rva);
+const RRDVAR_ACQUIRED *rrdvar_add_and_acquire(const char *scope, DICTIONARY *dict, STRING *name, RRDVAR_TYPE type, RRDVAR_FLAGS options, void *value);
+void rrdvar_release_and_del(DICTIONARY *dict, const RRDVAR_ACQUIRED *rva);
 
-extern DICTIONARY *rrdvariables_create(void);
-extern void rrdvariables_destroy(DICTIONARY *dict);
+DICTIONARY *rrdvariables_create(void);
+void rrdvariables_destroy(DICTIONARY *dict);
 
-extern void rrdvar_delete_all(DICTIONARY *dict);
+void rrdvar_delete_all(DICTIONARY *dict);
 
-extern const char *rrdvar_name(const RRDVAR_ACQUIRED *rva);
-extern RRDVAR_FLAGS rrdvar_flags(const RRDVAR_ACQUIRED *rva);
-extern RRDVAR_TYPE rrdvar_type(const RRDVAR_ACQUIRED *rva);
+const char *rrdvar_name(const RRDVAR_ACQUIRED *rva);
+RRDVAR_FLAGS rrdvar_flags(const RRDVAR_ACQUIRED *rva);
+RRDVAR_TYPE rrdvar_type(const RRDVAR_ACQUIRED *rva);
 
 #endif //NETDATA_RRDVAR_H

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -184,9 +184,9 @@ static inline RRDHOST *find_host_by_node_id(char *node_id)
 
 extern sqlite3 *db_meta;
 
-extern int aclk_database_enq_cmd_noblock(struct aclk_database_worker_config *wc, struct aclk_database_cmd *cmd);
-extern void aclk_database_enq_cmd(struct aclk_database_worker_config *wc, struct aclk_database_cmd *cmd);
-extern void sql_create_aclk_table(RRDHOST *host, uuid_t *host_uuid, uuid_t *node_id);
+int aclk_database_enq_cmd_noblock(struct aclk_database_worker_config *wc, struct aclk_database_cmd *cmd);
+void aclk_database_enq_cmd(struct aclk_database_worker_config *wc, struct aclk_database_cmd *cmd);
+void sql_create_aclk_table(RRDHOST *host, uuid_t *host_uuid, uuid_t *node_id);
 int aclk_worker_enq_cmd(char *node_id, struct aclk_database_cmd *cmd);
 void sql_aclk_sync_init(void);
 void sql_check_aclk_table_list(struct aclk_database_worker_config *wc);

--- a/database/sqlite/sqlite_aclk_alert.h
+++ b/database/sqlite/sqlite_aclk_alert.h
@@ -26,6 +26,6 @@ void sql_process_queue_removed_alerts_to_aclk(struct aclk_database_worker_config
 void aclk_push_alert_snapshot_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 void aclk_process_send_alarm_snapshot(char *node_id, char *claim_id, uint64_t snapshot_id, uint64_t sequence_id);
 int get_proto_alert_status(RRDHOST *host, struct proto_alert_status *proto_alert_status);
-extern int sql_queue_alarm_to_aclk(RRDHOST *host, ALARM_ENTRY *ae, int skip_filter);
+int sql_queue_alarm_to_aclk(RRDHOST *host, ALARM_ENTRY *ae, int skip_filter);
 
 #endif //NETDATA_SQLITE_ACLK_ALERT_H

--- a/database/sqlite/sqlite_context.h
+++ b/database/sqlite/sqlite_context.h
@@ -6,7 +6,7 @@
 #include "daemon/common.h"
 #include "sqlite3.h"
 
-extern int sql_context_cache_stats(int op);
+int sql_context_cache_stats(int op);
 typedef struct ctx_chart {
     uuid_t chart_id;
     const char *id;
@@ -51,19 +51,19 @@ typedef struct versioned_context_data {
 
 } VERSIONED_CONTEXT_DATA;
 
-extern void ctx_get_context_list(uuid_t *host_uuid, void (*dict_cb)(VERSIONED_CONTEXT_DATA *, void *), void *data);
+void ctx_get_context_list(uuid_t *host_uuid, void (*dict_cb)(VERSIONED_CONTEXT_DATA *, void *), void *data);
 
-extern void ctx_get_chart_list(uuid_t *host_uuid, void (*dict_cb)(SQL_CHART_DATA *, void *), void *data);
-extern void ctx_get_label_list(uuid_t *chart_uuid, void (*dict_cb)(SQL_CLABEL_DATA *, void *), void *data);
-extern void ctx_get_dimension_list(uuid_t *chart_uuid, void (*dict_cb)(SQL_DIMENSION_DATA *, void *), void *data);
+void ctx_get_chart_list(uuid_t *host_uuid, void (*dict_cb)(SQL_CHART_DATA *, void *), void *data);
+void ctx_get_label_list(uuid_t *chart_uuid, void (*dict_cb)(SQL_CLABEL_DATA *, void *), void *data);
+void ctx_get_dimension_list(uuid_t *chart_uuid, void (*dict_cb)(SQL_DIMENSION_DATA *, void *), void *data);
 
-extern int ctx_store_context(uuid_t *host_uuid, VERSIONED_CONTEXT_DATA *context_data);
+int ctx_store_context(uuid_t *host_uuid, VERSIONED_CONTEXT_DATA *context_data);
 
 #define ctx_update_context(host_uuid, context_data)    ctx_store_context(host_uuid, context_data)
 
-extern int ctx_delete_context(uuid_t *host_id, VERSIONED_CONTEXT_DATA *context_data);
+int ctx_delete_context(uuid_t *host_id, VERSIONED_CONTEXT_DATA *context_data);
 
-extern int sql_init_context_database(int memory);
-extern void sql_close_context_database(void);
-extern int ctx_unittest(void);
+int sql_init_context_database(int memory);
+void sql_close_context_database(void);
+int ctx_unittest(void);
 #endif //NETDATA_SQLITE_CONTEXT_H

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -52,8 +52,8 @@ typedef enum db_check_action_type {
         return 1;                                                                                                      \
     }
 
-extern SQLITE_API int sqlite3_step_monitored(sqlite3_stmt *stmt);
-extern SQLITE_API int sqlite3_exec_monitored(
+SQLITE_API int sqlite3_step_monitored(sqlite3_stmt *stmt);
+SQLITE_API int sqlite3_exec_monitored(
     sqlite3 *db,                               /* An open database */
     const char *sql,                           /* SQL to be evaluated */
     int (*callback)(void*,int,char**,char**),  /* Callback function */
@@ -61,55 +61,55 @@ extern SQLITE_API int sqlite3_exec_monitored(
     char **errmsg                              /* Error msg written here */
     );
 
-extern int sql_init_database(db_check_action_type_t rebuild, int memory);
-extern void sql_close_database(void);
-extern int bind_text_null(sqlite3_stmt *res, int position, const char *text, bool can_be_null);
-extern int sql_store_host(uuid_t *guid, const char *hostname, const char *registry_hostname, int update_every, const char *os,
+int sql_init_database(db_check_action_type_t rebuild, int memory);
+void sql_close_database(void);
+int bind_text_null(sqlite3_stmt *res, int position, const char *text, bool can_be_null);
+int sql_store_host(uuid_t *guid, const char *hostname, const char *registry_hostname, int update_every, const char *os,
                           const char *timezone, const char *tags, int hops);
 
-extern int sql_store_host_info(RRDHOST *host);
+int sql_store_host_info(RRDHOST *host);
 
-extern int sql_store_chart(
+int sql_store_chart(
     uuid_t *chart_uuid, uuid_t *host_uuid, const char *type, const char *id, const char *name, const char *family,
     const char *context, const char *title, const char *units, const char *plugin, const char *module, long priority,
     int update_every, int chart_type, int memory_mode, long history_entries);
-extern int sql_store_dimension(uuid_t *dim_uuid, uuid_t *chart_uuid, const char *id, const char *name, collected_number multiplier,
+int sql_store_dimension(uuid_t *dim_uuid, uuid_t *chart_uuid, const char *id, const char *name, collected_number multiplier,
                                collected_number divisor, int algorithm);
 
-extern int find_dimension_uuid(RRDSET *st, RRDDIM *rd, uuid_t *store_uuid);
+int find_dimension_uuid(RRDSET *st, RRDDIM *rd, uuid_t *store_uuid);
 
-extern int find_chart_uuid(RRDHOST *host, const char *type, const char *id, const char *name, uuid_t *store_uuid);
-extern int update_chart_metadata(uuid_t *chart_uuid, RRDSET *st, const char *id, const char *name);
+int find_chart_uuid(RRDHOST *host, const char *type, const char *id, const char *name, uuid_t *store_uuid);
+int update_chart_metadata(uuid_t *chart_uuid, RRDSET *st, const char *id, const char *name);
 
-extern int find_uuid_type(uuid_t *uuid);
+int find_uuid_type(uuid_t *uuid);
 
-extern void sql_rrdset2json(RRDHOST *host, BUFFER *wb);
+void sql_rrdset2json(RRDHOST *host, BUFFER *wb);
 
-extern RRDHOST *sql_create_host_by_uuid(char *guid);
-extern int prepare_statement(sqlite3 *database, char *query, sqlite3_stmt **statement);
-extern int execute_insert(sqlite3_stmt *res);
-extern void db_execute(const char *cmd);
-extern int file_is_migrated(char *path);
-extern void add_migrated_file(char *path, uint64_t file_size);
-extern void db_unlock(void);
-extern void db_lock(void);
-extern void delete_dimension_uuid(uuid_t *dimension_uuid);
-extern void sql_build_context_param_list(ONEWAYALLOC  *owa, struct context_param **param_list, RRDHOST *host, char *context, char *chart);
-extern void store_claim_id(uuid_t *host_id, uuid_t *claim_id);
-extern int update_node_id(uuid_t *host_id, uuid_t *node_id);
-extern int get_node_id(uuid_t *host_id, uuid_t *node_id);
-extern int get_host_id(uuid_t *node_id, uuid_t *host_id);
-extern void invalidate_node_instances(uuid_t *host_id, uuid_t *claim_id);
-extern struct node_instance_list *get_node_list(void);
-extern void sql_load_node_id(RRDHOST *host);
-extern int sql_set_dimension_option(uuid_t *dim_uuid, char *option);
+RRDHOST *sql_create_host_by_uuid(char *guid);
+int prepare_statement(sqlite3 *database, char *query, sqlite3_stmt **statement);
+int execute_insert(sqlite3_stmt *res);
+void db_execute(const char *cmd);
+int file_is_migrated(char *path);
+void add_migrated_file(char *path, uint64_t file_size);
+void db_unlock(void);
+void db_lock(void);
+void delete_dimension_uuid(uuid_t *dimension_uuid);
+void sql_build_context_param_list(ONEWAYALLOC  *owa, struct context_param **param_list, RRDHOST *host, char *context, char *chart);
+void store_claim_id(uuid_t *host_id, uuid_t *claim_id);
+int update_node_id(uuid_t *host_id, uuid_t *node_id);
+int get_node_id(uuid_t *host_id, uuid_t *node_id);
+int get_host_id(uuid_t *node_id, uuid_t *host_id);
+void invalidate_node_instances(uuid_t *host_id, uuid_t *claim_id);
+struct node_instance_list *get_node_list(void);
+void sql_load_node_id(RRDHOST *host);
+int sql_set_dimension_option(uuid_t *dim_uuid, char *option);
 char *get_hostname_by_node_id(char *node_id);
 void free_temporary_host(RRDHOST *host);
 int init_database_batch(sqlite3 *database, int rebuild, int init_type, const char *batch[]);
 void migrate_localhost(uuid_t *host_uuid);
-extern void sql_store_host_system_info(uuid_t *host_id, const struct rrdhost_system_info *system_info);
-extern void sql_build_host_system_info(uuid_t *host_id, struct rrdhost_system_info *system_info);
+void sql_store_host_system_info(uuid_t *host_id, const struct rrdhost_system_info *system_info);
+void sql_build_host_system_info(uuid_t *host_id, struct rrdhost_system_info *system_info);
 void sql_store_host_labels(RRDHOST *host);
-extern int sql_metadata_cache_stats(int op);
+int sql_metadata_cache_stats(int op);
 DICTIONARY *sql_load_host_labels(uuid_t *host_id);
 #endif //NETDATA_SQLITE_FUNCTIONS_H

--- a/database/sqlite/sqlite_health.h
+++ b/database/sqlite/sqlite_health.h
@@ -6,12 +6,12 @@
 #include "sqlite3.h"
 
 extern sqlite3 *db_meta;
-extern void sql_health_alarm_log_load(RRDHOST *host);
-extern int sql_create_health_log_table(RRDHOST *host);
-extern void sql_health_alarm_log_update(RRDHOST *host, ALARM_ENTRY *ae);
-extern void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae);
-extern void sql_health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae);
-extern void sql_health_alarm_log_cleanup(RRDHOST *host);
-extern int alert_hash_and_store_config(uuid_t hash_id, struct alert_config *cfg, int store_hash);
-extern void sql_aclk_alert_clean_dead_entries(RRDHOST *host);
+void sql_health_alarm_log_load(RRDHOST *host);
+int sql_create_health_log_table(RRDHOST *host);
+void sql_health_alarm_log_update(RRDHOST *host, ALARM_ENTRY *ae);
+void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae);
+void sql_health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae);
+void sql_health_alarm_log_cleanup(RRDHOST *host);
+int alert_hash_and_store_config(uuid_t hash_id, struct alert_config *cfg, int store_hash);
+void sql_aclk_alert_clean_dead_entries(RRDHOST *host);
 #endif //NETDATA_SQLITE_HEALTH_H

--- a/database/storage_engine.h
+++ b/database/storage_engine.h
@@ -22,11 +22,11 @@ struct storage_engine {
     STORAGE_ENGINE_API api;
 };
 
-extern STORAGE_ENGINE* storage_engine_get(RRD_MEMORY_MODE mmode);
-extern STORAGE_ENGINE* storage_engine_find(const char* name);
+STORAGE_ENGINE* storage_engine_get(RRD_MEMORY_MODE mmode);
+STORAGE_ENGINE* storage_engine_find(const char* name);
 
 // Iterator over existing engines
-extern STORAGE_ENGINE* storage_engine_foreach_init();
-extern STORAGE_ENGINE* storage_engine_foreach_next(STORAGE_ENGINE* it);
+STORAGE_ENGINE* storage_engine_foreach_init();
+STORAGE_ENGINE* storage_engine_foreach_next(STORAGE_ENGINE* it);
 
 #endif

--- a/exporting/exporting_engine.h
+++ b/exporting/exporting_engine.h
@@ -271,7 +271,7 @@ size_t exporting_name_copy(char *dst, const char *src, size_t max_len);
 int rrdhost_is_exportable(struct instance *instance, RRDHOST *host);
 int rrdset_is_exportable(struct instance *instance, RRDSET *st);
 
-extern EXPORTING_OPTIONS exporting_parse_data_source(const char *source, EXPORTING_OPTIONS exporting_options);
+EXPORTING_OPTIONS exporting_parse_data_source(const char *source, EXPORTING_OPTIONS exporting_options);
 
 NETDATA_DOUBLE
 exporting_calculate_value_from_stored_data(
@@ -300,7 +300,7 @@ void create_main_rusage_chart(RRDSET **st_rusage, RRDDIM **rd_user, RRDDIM **rd_
 void send_main_rusage(RRDSET *st_rusage, RRDDIM *rd_user, RRDDIM *rd_system);
 void send_internal_metrics(struct instance *instance);
 
-extern void clean_instance(struct instance *ptr);
+void clean_instance(struct instance *ptr);
 void simple_connector_cleanup(struct instance *instance);
 
 static inline void disable_instance(struct instance *instance)

--- a/exporting/prometheus/prometheus.h
+++ b/exporting/prometheus/prometheus.h
@@ -22,10 +22,10 @@ typedef enum prometheus_output_flags {
 	PROMETHEUS_OUTPUT_HIDEUNITS  = (1 << 6)
 } PROMETHEUS_OUTPUT_OPTIONS;
 
-extern void rrd_stats_api_v1_charts_allmetrics_prometheus_single_host(
+void rrd_stats_api_v1_charts_allmetrics_prometheus_single_host(
     RRDHOST *host, const char *filter_string, BUFFER *wb, const char *server, const char *prefix,
     EXPORTING_OPTIONS exporting_options, PROMETHEUS_OUTPUT_OPTIONS output_options);
-extern void rrd_stats_api_v1_charts_allmetrics_prometheus_all_hosts(
+void rrd_stats_api_v1_charts_allmetrics_prometheus_all_hosts(
     RRDHOST *host, const char *filter_string, BUFFER *wb, const char *server, const char *prefix,
     EXPORTING_OPTIONS exporting_options, PROMETHEUS_OUTPUT_OPTIONS output_options);
 
@@ -36,6 +36,6 @@ char *prometheus_units_copy(char *d, const char *s, size_t usable, int showoldun
 
 void format_host_labels_prometheus(struct instance *instance, RRDHOST *host);
 
-extern void prometheus_clean_server_root();
+void prometheus_clean_server_root();
 
 #endif //NETDATA_EXPORTING_PROMETHEUS_H

--- a/exporting/prometheus/remote_write/remote_write.h
+++ b/exporting/prometheus/remote_write/remote_write.h
@@ -18,7 +18,7 @@ struct prometheus_remote_write_variables_callback_options {
 };
 
 int init_prometheus_remote_write_instance(struct instance *instance);
-extern void clean_prometheus_remote_write(struct instance *instance);
+void clean_prometheus_remote_write(struct instance *instance);
 
 int format_host_prometheus_remote_write(struct instance *instance, RRDHOST *host);
 int format_chart_prometheus_remote_write(struct instance *instance, RRDSET *st);

--- a/health/health.h
+++ b/health/health.h
@@ -32,23 +32,23 @@ extern unsigned int default_health_enabled;
 
 extern char *silencers_filename;
 
-extern void health_init(void);
+void health_init(void);
 
-extern void health_reload(void);
+void health_reload(void);
 
-extern void health_aggregate_alarms(RRDHOST *host, BUFFER *wb, BUFFER* context, RRDCALC_STATUS status);
-extern void health_alarms2json(RRDHOST *host, BUFFER *wb, int all);
-extern void health_alarms_values2json(RRDHOST *host, BUFFER *wb, int all);
-extern void health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *chart);
+void health_aggregate_alarms(RRDHOST *host, BUFFER *wb, BUFFER* context, RRDCALC_STATUS status);
+void health_alarms2json(RRDHOST *host, BUFFER *wb, int all);
+void health_alarms_values2json(RRDHOST *host, BUFFER *wb, int all);
+void health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *chart);
 
 void health_api_v1_chart_variables2json(RRDSET *st, BUFFER *buf);
 void health_api_v1_chart_custom_variables2json(RRDSET *st, BUFFER *buf);
 
-extern int health_alarm_log_open(RRDHOST *host);
-extern void health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae);
-extern void health_alarm_log_load(RRDHOST *host);
+int health_alarm_log_open(RRDHOST *host);
+void health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae);
+void health_alarm_log_load(RRDHOST *host);
 
-extern ALARM_ENTRY* health_create_alarm_entry(
+ALARM_ENTRY* health_create_alarm_entry(
     RRDHOST *host,
     uint32_t alarm_id,
     uint32_t alarm_event_id,
@@ -74,20 +74,20 @@ extern ALARM_ENTRY* health_create_alarm_entry(
     int delay,
     uint32_t flags);
 
-extern void health_alarm_log_add_entry(RRDHOST *host, ALARM_ENTRY *ae);
+void health_alarm_log_add_entry(RRDHOST *host, ALARM_ENTRY *ae);
 
-extern void health_readdir(RRDHOST *host, const char *user_path, const char *stock_path, const char *subpath);
-extern char *health_user_config_dir(void);
-extern char *health_stock_config_dir(void);
-extern void health_alarm_log_free(RRDHOST *host);
+void health_readdir(RRDHOST *host, const char *user_path, const char *stock_path, const char *subpath);
+char *health_user_config_dir(void);
+char *health_stock_config_dir(void);
+void health_alarm_log_free(RRDHOST *host);
 
-extern void health_alarm_log_free_one_nochecks_nounlink(ALARM_ENTRY *ae);
+void health_alarm_log_free_one_nochecks_nounlink(ALARM_ENTRY *ae);
 
-extern void *health_cmdapi_thread(void *ptr);
+void *health_cmdapi_thread(void *ptr);
 
-extern void health_label_log_save(RRDHOST *host);
+void health_label_log_save(RRDHOST *host);
 
-extern char *health_edit_command_from_source(const char *source);
-extern void sql_refresh_hashes(void);
+char *health_edit_command_from_source(const char *source);
+void sql_refresh_hashes(void);
 
 #endif //NETDATA_HEALTH_H

--- a/libnetdata/adaptive_resortable_list/adaptive_resortable_list.h
+++ b/libnetdata/adaptive_resortable_list/adaptive_resortable_list.h
@@ -64,25 +64,25 @@ typedef struct arl_base {
 } ARL_BASE;
 
 // create a new ARL
-extern ARL_BASE *arl_create(const char *name, void (*processor)(const char *, uint32_t, const char *, void *), size_t rechecks);
+ARL_BASE *arl_create(const char *name, void (*processor)(const char *, uint32_t, const char *, void *), size_t rechecks);
 
 // free an ARL
-extern void arl_free(ARL_BASE *arl_base);
+void arl_free(ARL_BASE *arl_base);
 
 // register an expected keyword to the ARL
 // together with its destination ( i.e. the output of the processor() )
-extern ARL_ENTRY *arl_expect_custom(ARL_BASE *base, const char *keyword, void (*processor)(const char *name, uint32_t hash, const char *value, void *dst), void *dst);
+ARL_ENTRY *arl_expect_custom(ARL_BASE *base, const char *keyword, void (*processor)(const char *name, uint32_t hash, const char *value, void *dst), void *dst);
 #define arl_expect(base, keyword, dst) arl_expect_custom(base, keyword, NULL, dst)
 
 // an internal call to complete the check() call
-extern int arl_find_or_create_and_relink(ARL_BASE *base, const char *s, const char *value);
+int arl_find_or_create_and_relink(ARL_BASE *base, const char *s, const char *value);
 
 // begin an ARL iteration
-extern void arl_begin(ARL_BASE *base);
+void arl_begin(ARL_BASE *base);
 
-extern void arl_callback_str2ull(const char *name, uint32_t hash, const char *value, void *dst);
-extern void arl_callback_str2kernel_uint_t(const char *name, uint32_t hash, const char *value, void *dst);
-extern void arl_callback_ssize_t(const char *name, uint32_t hash, const char *value, void *dst);
+void arl_callback_str2ull(const char *name, uint32_t hash, const char *value, void *dst);
+void arl_callback_str2kernel_uint_t(const char *name, uint32_t hash, const char *value, void *dst);
+void arl_callback_ssize_t(const char *name, uint32_t hash, const char *value, void *dst);
 
 // check a keyword against the ARL
 // this is to be called for each keyword read from source data

--- a/libnetdata/arrayalloc/arrayalloc.h
+++ b/libnetdata/arrayalloc/arrayalloc.h
@@ -28,8 +28,8 @@ typedef struct arrayalloc {
     } internal;
 } ARAL;
 
-extern ARAL *arrayalloc_create(size_t element_size, size_t elements, const char *filename, char **cache_dir);
-extern void *arrayalloc_mallocz(ARAL *ar);
-extern void arrayalloc_freez(ARAL *ar, void *ptr);
+ARAL *arrayalloc_create(size_t element_size, size_t elements, const char *filename, char **cache_dir);
+void *arrayalloc_mallocz(ARAL *ar);
+void arrayalloc_freez(ARAL *ar, void *ptr);
 
 #endif // ARRAYALLOC_H

--- a/libnetdata/buffer/buffer.h
+++ b/libnetdata/buffer/buffer.h
@@ -49,37 +49,37 @@ typedef struct web_buffer {
 #define buffer_no_cacheable(wb) do { (wb)->options |= WB_CONTENT_NO_CACHEABLE; if((wb)->options & WB_CONTENT_CACHEABLE)    (wb)->options &= ~WB_CONTENT_CACHEABLE;  (wb)->expires = 0; } while(0)
 
 #define buffer_strlen(wb) ((wb)->len)
-extern const char *buffer_tostring(BUFFER *wb);
+const char *buffer_tostring(BUFFER *wb);
 
 #define buffer_flush(wb) wb->buffer[(wb)->len = 0] = '\0'
-extern void buffer_reset(BUFFER *wb);
+void buffer_reset(BUFFER *wb);
 
-extern void buffer_strcat(BUFFER *wb, const char *txt);
-extern void buffer_fast_strcat(BUFFER *wb, const char *txt, size_t len);
-extern void buffer_rrd_value(BUFFER *wb, NETDATA_DOUBLE value);
+void buffer_strcat(BUFFER *wb, const char *txt);
+void buffer_fast_strcat(BUFFER *wb, const char *txt, size_t len);
+void buffer_rrd_value(BUFFER *wb, NETDATA_DOUBLE value);
 
-extern void buffer_date(BUFFER *wb, int year, int month, int day, int hours, int minutes, int seconds);
-extern void buffer_jsdate(BUFFER *wb, int year, int month, int day, int hours, int minutes, int seconds);
+void buffer_date(BUFFER *wb, int year, int month, int day, int hours, int minutes, int seconds);
+void buffer_jsdate(BUFFER *wb, int year, int month, int day, int hours, int minutes, int seconds);
 
-extern BUFFER *buffer_create(size_t size);
-extern void buffer_free(BUFFER *b);
-extern void buffer_increase(BUFFER *b, size_t free_size_required);
+BUFFER *buffer_create(size_t size);
+void buffer_free(BUFFER *b);
+void buffer_increase(BUFFER *b, size_t free_size_required);
 
-extern void buffer_snprintf(BUFFER *wb, size_t len, const char *fmt, ...) PRINTFLIKE(3, 4);
-extern void buffer_vsprintf(BUFFER *wb, const char *fmt, va_list args);
-extern void buffer_sprintf(BUFFER *wb, const char *fmt, ...) PRINTFLIKE(2,3);
-extern void buffer_strcat_jsonescape(BUFFER *wb, const char *txt);
-extern void buffer_strcat_htmlescape(BUFFER *wb, const char *txt);
+void buffer_snprintf(BUFFER *wb, size_t len, const char *fmt, ...) PRINTFLIKE(3, 4);
+void buffer_vsprintf(BUFFER *wb, const char *fmt, va_list args);
+void buffer_sprintf(BUFFER *wb, const char *fmt, ...) PRINTFLIKE(2,3);
+void buffer_strcat_jsonescape(BUFFER *wb, const char *txt);
+void buffer_strcat_htmlescape(BUFFER *wb, const char *txt);
 
-extern void buffer_char_replace(BUFFER *wb, char from, char to);
+void buffer_char_replace(BUFFER *wb, char from, char to);
 
-extern char *print_number_lu_r(char *str, unsigned long uvalue);
-extern char *print_number_llu_r(char *str, unsigned long long uvalue);
-extern char *print_number_llu_r_smart(char *str, unsigned long long uvalue);
+char *print_number_lu_r(char *str, unsigned long uvalue);
+char *print_number_llu_r(char *str, unsigned long long uvalue);
+char *print_number_llu_r_smart(char *str, unsigned long long uvalue);
 
-extern void buffer_print_llu(BUFFER *wb, unsigned long long uvalue);
-extern void buffer_print_ll(BUFFER *wb, long long value);
-extern void buffer_print_llu_hex(BUFFER *wb, unsigned long long value);
+void buffer_print_llu(BUFFER *wb, unsigned long long uvalue);
+void buffer_print_ll(BUFFER *wb, long long value);
+void buffer_print_llu_hex(BUFFER *wb, unsigned long long value);
 
 static inline void buffer_need_bytes(BUFFER *buffer, size_t needed_free_size) {
     if(unlikely(buffer->size - buffer->len < needed_free_size))

--- a/libnetdata/circular_buffer/circular_buffer.h
+++ b/libnetdata/circular_buffer/circular_buffer.h
@@ -8,12 +8,12 @@ struct circular_buffer {
     char *data;
 };
 
-extern struct circular_buffer *cbuffer_new(size_t initial, size_t max);
-extern void cbuffer_free(struct circular_buffer *buf);
-extern int cbuffer_add_unsafe(struct circular_buffer *buf, const char *d, size_t d_len);
-extern void cbuffer_remove_unsafe(struct circular_buffer *buf, size_t num);
-extern size_t cbuffer_next_unsafe(struct circular_buffer *buf, char **start);
-extern size_t cbuffer_available_size_unsafe(struct circular_buffer *buf);
-extern void cbuffer_flush(struct circular_buffer*buf);
+struct circular_buffer *cbuffer_new(size_t initial, size_t max);
+void cbuffer_free(struct circular_buffer *buf);
+int cbuffer_add_unsafe(struct circular_buffer *buf, const char *d, size_t d_len);
+void cbuffer_remove_unsafe(struct circular_buffer *buf, size_t num);
+size_t cbuffer_next_unsafe(struct circular_buffer *buf, char **start);
+size_t cbuffer_available_size_unsafe(struct circular_buffer *buf);
+void cbuffer_flush(struct circular_buffer*buf);
 
 #endif

--- a/libnetdata/clocks/clocks.h
+++ b/libnetdata/clocks/clocks.h
@@ -82,7 +82,7 @@ typedef struct heartbeat {
  * make systems without clock_gettime() support sensitive
  * to time jumps or hibernation/suspend side effects.
  */
-extern int clock_gettime(clockid_t clk_id, struct timespec *ts);
+int clock_gettime(clockid_t clk_id, struct timespec *ts);
 #endif
 
 /*
@@ -111,50 +111,50 @@ extern int clock_gettime(clockid_t clk_id, struct timespec *ts);
  * All now_*_usec() functions return the time in microseconds from the appropriate clock, or 0 on error.
  *
  */
-extern int now_realtime_timeval(struct timeval *tv);
-extern time_t now_realtime_sec(void);
-extern usec_t now_realtime_usec(void);
+int now_realtime_timeval(struct timeval *tv);
+time_t now_realtime_sec(void);
+usec_t now_realtime_usec(void);
 
-extern int now_monotonic_timeval(struct timeval *tv);
-extern time_t now_monotonic_sec(void);
-extern usec_t now_monotonic_usec(void);
-extern int now_monotonic_high_precision_timeval(struct timeval *tv);
-extern time_t now_monotonic_high_precision_sec(void);
-extern usec_t now_monotonic_high_precision_usec(void);
+int now_monotonic_timeval(struct timeval *tv);
+time_t now_monotonic_sec(void);
+usec_t now_monotonic_usec(void);
+int now_monotonic_high_precision_timeval(struct timeval *tv);
+time_t now_monotonic_high_precision_sec(void);
+usec_t now_monotonic_high_precision_usec(void);
 
-extern int now_boottime_timeval(struct timeval *tv);
-extern time_t now_boottime_sec(void);
-extern usec_t now_boottime_usec(void);
+int now_boottime_timeval(struct timeval *tv);
+time_t now_boottime_sec(void);
+usec_t now_boottime_usec(void);
 
-extern usec_t timeval_usec(struct timeval *tv);
-extern msec_t timeval_msec(struct timeval *tv);
+usec_t timeval_usec(struct timeval *tv);
+msec_t timeval_msec(struct timeval *tv);
 
-extern usec_t dt_usec(struct timeval *now, struct timeval *old);
-extern susec_t dt_usec_signed(struct timeval *now, struct timeval *old);
+usec_t dt_usec(struct timeval *now, struct timeval *old);
+susec_t dt_usec_signed(struct timeval *now, struct timeval *old);
 
-extern void heartbeat_init(heartbeat_t *hb);
+void heartbeat_init(heartbeat_t *hb);
 
 /* Sleeps until next multiple of tick using monotonic clock.
  * Returns elapsed time in microseconds since previous heartbeat
  */
-extern usec_t heartbeat_next(heartbeat_t *hb, usec_t tick);
+usec_t heartbeat_next(heartbeat_t *hb, usec_t tick);
 
-extern void heartbeat_statistics(usec_t *min_ptr, usec_t *max_ptr, usec_t *average_ptr, size_t *count_ptr);
+void heartbeat_statistics(usec_t *min_ptr, usec_t *max_ptr, usec_t *average_ptr, size_t *count_ptr);
 
-extern void sleep_usec(usec_t usec);
+void sleep_usec(usec_t usec);
 
-extern void clocks_init(void);
+void clocks_init(void);
 
 // lower level functions - avoid using directly
-extern time_t now_sec(clockid_t clk_id);
-extern usec_t now_usec(clockid_t clk_id);
-extern int now_timeval(clockid_t clk_id, struct timeval *tv);
+time_t now_sec(clockid_t clk_id);
+usec_t now_usec(clockid_t clk_id);
+int now_timeval(clockid_t clk_id, struct timeval *tv);
 
-extern collected_number uptime_msec(char *filename);
+collected_number uptime_msec(char *filename);
 
 extern usec_t clock_monotonic_resolution;
 extern usec_t clock_realtime_resolution;
 
-extern void sleep_to_absolute_time(usec_t usec);
+void sleep_to_absolute_time(usec_t usec);
 
 #endif /* NETDATA_CLOCKS_H */

--- a/libnetdata/config/appconfig.h
+++ b/libnetdata/config/appconfig.h
@@ -163,41 +163,41 @@ struct config {
 #define CONFIG_BOOLEAN_AUTO 2       // enabled if it has useful info when enabled
 #endif
 
-extern int appconfig_load(struct config *root, char *filename, int overwrite_used, const char *section_name);
-extern void config_section_wrlock(struct section *co);
-extern void config_section_unlock(struct section *co);
+int appconfig_load(struct config *root, char *filename, int overwrite_used, const char *section_name);
+void config_section_wrlock(struct section *co);
+void config_section_unlock(struct section *co);
 
-extern char *appconfig_get_by_section(struct section *co, const char *name, const char *default_value);
-extern char *appconfig_get(struct config *root, const char *section, const char *name, const char *default_value);
-extern long long appconfig_get_number(struct config *root, const char *section, const char *name, long long value);
-extern NETDATA_DOUBLE appconfig_get_float(struct config *root, const char *section, const char *name, NETDATA_DOUBLE value);
-extern int appconfig_get_boolean_by_section(struct section *co, const char *name, int value);
-extern int appconfig_get_boolean(struct config *root, const char *section, const char *name, int value);
-extern int appconfig_get_boolean_ondemand(struct config *root, const char *section, const char *name, int value);
-extern int appconfig_get_duration(struct config *root, const char *section, const char *name, const char *value);
+char *appconfig_get_by_section(struct section *co, const char *name, const char *default_value);
+char *appconfig_get(struct config *root, const char *section, const char *name, const char *default_value);
+long long appconfig_get_number(struct config *root, const char *section, const char *name, long long value);
+NETDATA_DOUBLE appconfig_get_float(struct config *root, const char *section, const char *name, NETDATA_DOUBLE value);
+int appconfig_get_boolean_by_section(struct section *co, const char *name, int value);
+int appconfig_get_boolean(struct config *root, const char *section, const char *name, int value);
+int appconfig_get_boolean_ondemand(struct config *root, const char *section, const char *name, int value);
+int appconfig_get_duration(struct config *root, const char *section, const char *name, const char *value);
 
-extern const char *appconfig_set(struct config *root, const char *section, const char *name, const char *value);
-extern const char *appconfig_set_default(struct config *root, const char *section, const char *name, const char *value);
-extern long long appconfig_set_number(struct config *root, const char *section, const char *name, long long value);
-extern NETDATA_DOUBLE appconfig_set_float(struct config *root, const char *section, const char *name, NETDATA_DOUBLE value);
-extern int appconfig_set_boolean(struct config *root, const char *section, const char *name, int value);
+const char *appconfig_set(struct config *root, const char *section, const char *name, const char *value);
+const char *appconfig_set_default(struct config *root, const char *section, const char *name, const char *value);
+long long appconfig_set_number(struct config *root, const char *section, const char *name, long long value);
+NETDATA_DOUBLE appconfig_set_float(struct config *root, const char *section, const char *name, NETDATA_DOUBLE value);
+int appconfig_set_boolean(struct config *root, const char *section, const char *name, int value);
 
-extern int appconfig_exists(struct config *root, const char *section, const char *name);
-extern int appconfig_move(struct config *root, const char *section_old, const char *name_old, const char *section_new, const char *name_new);
+int appconfig_exists(struct config *root, const char *section, const char *name);
+int appconfig_move(struct config *root, const char *section_old, const char *name_old, const char *section_new, const char *name_new);
 
-extern void appconfig_generate(struct config *root, BUFFER *wb, int only_changed);
+void appconfig_generate(struct config *root, BUFFER *wb, int only_changed);
 
-extern int appconfig_section_compare(void *a, void *b);
+int appconfig_section_compare(void *a, void *b);
 
-extern void appconfig_section_destroy_non_loaded(struct config *root, const char *section);
-extern void appconfig_section_option_destroy_non_loaded(struct config *root, const char *section, const char *name);
+void appconfig_section_destroy_non_loaded(struct config *root, const char *section);
+void appconfig_section_option_destroy_non_loaded(struct config *root, const char *section, const char *name);
 
-extern int config_parse_duration(const char* string, int* result);
+int config_parse_duration(const char* string, int* result);
 
-extern struct section *appconfig_get_section(struct config *root, const char *name);
+struct section *appconfig_get_section(struct config *root, const char *name);
 
-extern void appconfig_wrlock(struct config *root);
-extern void appconfig_unlock(struct config *root);
+void appconfig_wrlock(struct config *root);
+void appconfig_unlock(struct config *root);
 
 struct connector_instance {
     char instance_name[CONFIG_MAX_NAME + 1];
@@ -212,6 +212,6 @@ typedef struct _connector_instance {
     struct _connector_instance *next; // Next instance
 } _CONNECTOR_INSTANCE;
 
-extern _CONNECTOR_INSTANCE *add_connector_instance(struct section *connector, struct section *instance);
+_CONNECTOR_INSTANCE *add_connector_instance(struct section *connector, struct section *instance);
 
 #endif /* NETDATA_CONFIG_H */

--- a/libnetdata/dictionary/dictionary.h
+++ b/libnetdata/dictionary/dictionary.h
@@ -108,51 +108,51 @@ struct dictionary_stats {
 #ifdef NETDATA_INTERNAL_CHECKS
 #define dictionary_create(options) dictionary_create_advanced_with_trace(options, NULL, __FUNCTION__, __LINE__, __FILE__)
 #define dictionary_create_advanced(options, stats) dictionary_create_advanced_with_trace(options, stats, __FUNCTION__, __LINE__, __FILE__)
-extern DICTIONARY *dictionary_create_advanced_with_trace(DICT_OPTIONS options, struct dictionary_stats *stats, const char *function, size_t line, const char *file);
+DICTIONARY *dictionary_create_advanced_with_trace(DICT_OPTIONS options, struct dictionary_stats *stats, const char *function, size_t line, const char *file);
 #else
 #define dictionary_create(options) dictionary_create_advanced(options, NULL);
-extern DICTIONARY *dictionary_create_advanced(DICT_OPTIONS options, struct dictionary_stats *stats);
+DICTIONARY *dictionary_create_advanced(DICT_OPTIONS options, struct dictionary_stats *stats);
 #endif
 
 // Create a view on a dictionary
 #ifdef NETDATA_INTERNAL_CHECKS
 #define dictionary_create_view(master) dictionary_create_view_with_trace(master, __FUNCTION__, __LINE__, __FILE__)
-extern DICTIONARY *dictionary_create_view_with_trace(DICTIONARY *master, const char *function, size_t line, const char *file);
+DICTIONARY *dictionary_create_view_with_trace(DICTIONARY *master, const char *function, size_t line, const char *file);
 #else
-extern DICTIONARY *dictionary_create_view(DICTIONARY *master);
+DICTIONARY *dictionary_create_view(DICTIONARY *master);
 #endif
 
 // an insert callback to be called just after an item is added to the dictionary
 // this callback is called while the dictionary is write locked!
-extern void dictionary_register_insert_callback(DICTIONARY *dict, void (*ins_callback)(const DICTIONARY_ITEM *item, void *value, void *data), void *data);
+void dictionary_register_insert_callback(DICTIONARY *dict, void (*ins_callback)(const DICTIONARY_ITEM *item, void *value, void *data), void *data);
 
 // a delete callback to be called just before an item is deleted forever
 // this callback is called while the dictionary is write locked!
-extern void dictionary_register_delete_callback(DICTIONARY *dict, void (*del_callback)(const DICTIONARY_ITEM *item, void *value, void *data), void *data);
+void dictionary_register_delete_callback(DICTIONARY *dict, void (*del_callback)(const DICTIONARY_ITEM *item, void *value, void *data), void *data);
 
 // a merge callback to be called when DICT_OPTION_DONT_OVERWRITE_VALUE
 // and an item is already found in the dictionary - the dictionary does nothing else in this case
 // the old_value will remain in the dictionary - the new_value is ignored
 // The callback should return true if the value has been updated (it increases the dictionary version).
-extern void dictionary_register_conflict_callback(DICTIONARY *dict, bool (*conflict_callback)(const DICTIONARY_ITEM *item, void *old_value, void *new_value, void *data), void *data);
+void dictionary_register_conflict_callback(DICTIONARY *dict, bool (*conflict_callback)(const DICTIONARY_ITEM *item, void *old_value, void *new_value, void *data), void *data);
 
 // a reaction callback to be called after every item insertion or conflict
 // after the constructors have finished and the items are fully available for use
 // and the dictionary is not write locked anymore
-extern void dictionary_register_react_callback(DICTIONARY *dict, void (*react_callback)(const DICTIONARY_ITEM *item, void *value, void *data), void *data);
+void dictionary_register_react_callback(DICTIONARY *dict, void (*react_callback)(const DICTIONARY_ITEM *item, void *value, void *data), void *data);
 
 // Destroy a dictionary
 // Returns the number of bytes freed
 // The returned value will not include name/key sizes
 // Registered delete callbacks will be run for each item in the dictionary.
-extern size_t dictionary_destroy(DICTIONARY *dict);
+size_t dictionary_destroy(DICTIONARY *dict);
 
 // Empties a dictionary
 // Referenced items will survive, but are not offered anymore.
 // Registered delete callbacks will be run for each item in the dictionary.
-extern void dictionary_flush(DICTIONARY *dict);
+void dictionary_flush(DICTIONARY *dict);
 
-extern void dictionary_version_increment(DICTIONARY *dict);
+void dictionary_version_increment(DICTIONARY *dict);
 
 // ----------------------------------------------------------------------------
 // Set an item in the dictionary
@@ -171,26 +171,26 @@ extern void dictionary_version_increment(DICTIONARY *dict);
 // Passing NULL as value, the dictionary will callocz() the newly allocated value, otherwise it will copy it.
 // Passing 0 as value_len, the dictionary will set the value to NULL (no allocations for value will be made).
 #define dictionary_set(dict, name, value, value_len) dictionary_set_advanced(dict, name, -1, value, value_len, NULL)
-extern void *dictionary_set_advanced(DICTIONARY *dict, const char *name, ssize_t name_len, void *value, size_t value_len, void *constructor_data);
+void *dictionary_set_advanced(DICTIONARY *dict, const char *name, ssize_t name_len, void *value, size_t value_len, void *constructor_data);
 
 #define dictionary_set_and_acquire_item(dict, name, value, value_len) dictionary_set_and_acquire_item_advanced(dict, name, -1, value, value_len, NULL)
-extern DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_set_and_acquire_item_advanced(DICTIONARY *dict, const char *name, ssize_t name_len, void *value, size_t value_len, void *constructor_data);
+DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_set_and_acquire_item_advanced(DICTIONARY *dict, const char *name, ssize_t name_len, void *value, size_t value_len, void *constructor_data);
 
 // set an item in a dictionary view
 #define dictionary_view_set_and_acquire_item(dict, name, master_item) dictionary_view_set_and_acquire_item_advanced(dict, name, -1, master_item)
-extern DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_view_set_and_acquire_item_advanced(DICTIONARY *dict, const char *name, ssize_t name_len, DICTIONARY_ITEM *master_item);
+DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_view_set_and_acquire_item_advanced(DICTIONARY *dict, const char *name, ssize_t name_len, DICTIONARY_ITEM *master_item);
 #define dictionary_view_set(dict, name, master_item) dictionary_view_set_advanced(dict, name, -1, master_item)
-extern void *dictionary_view_set_advanced(DICTIONARY *dict, const char *name, ssize_t name_len, DICT_ITEM_CONST DICTIONARY_ITEM *master_item);
+void *dictionary_view_set_advanced(DICTIONARY *dict, const char *name, ssize_t name_len, DICT_ITEM_CONST DICTIONARY_ITEM *master_item);
 
 // ----------------------------------------------------------------------------
 // Get an item from the dictionary
 // If it returns NULL, the item is not found
 
 #define dictionary_get(dict, name) dictionary_get_advanced(dict, name, -1)
-extern void *dictionary_get_advanced(DICTIONARY *dict, const char *name, ssize_t name_len);
+void *dictionary_get_advanced(DICTIONARY *dict, const char *name, ssize_t name_len);
 
 #define dictionary_get_and_acquire_item(dict, name) dictionary_get_and_acquire_item_advanced(dict, name, -1)
-extern DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_get_and_acquire_item_advanced(DICTIONARY *dict, const char *name, ssize_t name_len);
+DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_get_and_acquire_item_advanced(DICTIONARY *dict, const char *name, ssize_t name_len);
 
 
 // ----------------------------------------------------------------------------
@@ -199,19 +199,19 @@ extern DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_get_and_acquire_item_advanced
 // returns false if the item was not found in the index
 
 #define dictionary_del(dict, name) dictionary_del_advanced(dict, name, -1)
-extern bool dictionary_del_advanced(DICTIONARY *dict, const char *name, ssize_t name_len);
+bool dictionary_del_advanced(DICTIONARY *dict, const char *name, ssize_t name_len);
 
 // ----------------------------------------------------------------------------
 // reference counters management
 
-extern void dictionary_acquired_item_release(DICTIONARY *dict, DICT_ITEM_CONST DICTIONARY_ITEM *item);
+void dictionary_acquired_item_release(DICTIONARY *dict, DICT_ITEM_CONST DICTIONARY_ITEM *item);
 
-extern DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_acquired_item_dup(DICTIONARY *dict, DICT_ITEM_CONST DICTIONARY_ITEM *item);
+DICT_ITEM_CONST DICTIONARY_ITEM *dictionary_acquired_item_dup(DICTIONARY *dict, DICT_ITEM_CONST DICTIONARY_ITEM *item);
 
-extern const char *dictionary_acquired_item_name(DICT_ITEM_CONST DICTIONARY_ITEM *item);
-extern void *dictionary_acquired_item_value(DICT_ITEM_CONST DICTIONARY_ITEM *item);
+const char *dictionary_acquired_item_name(DICT_ITEM_CONST DICTIONARY_ITEM *item);
+void *dictionary_acquired_item_value(DICT_ITEM_CONST DICTIONARY_ITEM *item);
 
-extern size_t dictionary_acquired_item_references(DICT_ITEM_CONST DICTIONARY_ITEM *item);
+size_t dictionary_acquired_item_references(DICT_ITEM_CONST DICTIONARY_ITEM *item);
 
 // ----------------------------------------------------------------------------
 // Traverse (walk through) the items of the dictionary.
@@ -228,7 +228,7 @@ extern size_t dictionary_acquired_item_references(DICT_ITEM_CONST DICTIONARY_ITE
 //
 #define dictionary_walkthrough_read(dict, callback, data) dictionary_walkthrough_rw(dict, 'r', callback, data)
 #define dictionary_walkthrough_write(dict, callback, data) dictionary_walkthrough_rw(dict, 'w', callback, data)
-extern int dictionary_walkthrough_rw(DICTIONARY *dict, char rw, int (*callback)(const DICTIONARY_ITEM *item, void *value, void *data), void *data);
+int dictionary_walkthrough_rw(DICTIONARY *dict, char rw, int (*callback)(const DICTIONARY_ITEM *item, void *value, void *data), void *data);
 
 #define dictionary_sorted_walkthrough_read(dict, callback, data) dictionary_sorted_walkthrough_rw(dict, 'r', callback, data)
 #define dictionary_sorted_walkthrough_write(dict, callback, data) dictionary_sorted_walkthrough_rw(dict, 'w', callback, data)
@@ -253,8 +253,8 @@ int dictionary_sorted_walkthrough_rw(DICTIONARY *dict, char rw, int (*callback)(
 #define DICTIONARY_LOCK_WRITE     'w'
 #define DICTIONARY_LOCK_REENTRANT 'z'
 
-extern void dictionary_write_lock(DICTIONARY *dict);
-extern void dictionary_write_unlock(DICTIONARY *dict);
+void dictionary_write_lock(DICTIONARY *dict);
+void dictionary_write_unlock(DICTIONARY *dict);
 
 typedef DICTFE_CONST struct dictionary_foreach {
     DICTIONARY *dict;           // the dictionary upon we work
@@ -290,31 +290,31 @@ typedef DICTFE_CONST struct dictionary_foreach {
             dictionary_foreach_done(&value ## _dfe);                                                \
         } while(0)
 
-extern void *dictionary_foreach_start_rw(DICTFE *dfe, DICTIONARY *dict, char rw);
-extern void *dictionary_foreach_next(DICTFE *dfe);
-extern void  dictionary_foreach_done(DICTFE *dfe);
+void *dictionary_foreach_start_rw(DICTFE *dfe, DICTIONARY *dict, char rw);
+void *dictionary_foreach_next(DICTFE *dfe);
+void  dictionary_foreach_done(DICTFE *dfe);
 
 // ----------------------------------------------------------------------------
 // Get statistics about the dictionary
 
-extern size_t dictionary_version(DICTIONARY *dict);
-extern size_t dictionary_entries(DICTIONARY *dict);
-extern size_t dictionary_referenced_items(DICTIONARY *dict);
-extern long int dictionary_stats_for_registry(DICTIONARY *dict);
+size_t dictionary_version(DICTIONARY *dict);
+size_t dictionary_entries(DICTIONARY *dict);
+size_t dictionary_referenced_items(DICTIONARY *dict);
+long int dictionary_stats_for_registry(DICTIONARY *dict);
 
 // for all cases that the caller does not provide a stats structure, this is where they are accumulated.
 extern struct dictionary_stats dictionary_stats_category_other;
 
-extern int dictionary_unittest(size_t entries);
+int dictionary_unittest(size_t entries);
 
 // ----------------------------------------------------------------------------
 // THREAD CACHE
 
-extern void *thread_cache_entry_get_or_set(void *key,
+void *thread_cache_entry_get_or_set(void *key,
                                     ssize_t key_length,
                                     void *value,
                                     void *(*transform_the_value_before_insert)(void *key, size_t key_length, void *value));
 
-extern void thread_cache_destroy(void);
+void thread_cache_destroy(void);
 
 #endif /* NETDATA_DICTIONARY_H */

--- a/libnetdata/ebpf/ebpf.h
+++ b/libnetdata/ebpf/ebpf.h
@@ -270,25 +270,25 @@ typedef struct ebpf_module {
     struct bpf_object *objects;
 } ebpf_module_t;
 
-extern int ebpf_get_kernel_version();
-extern int get_redhat_release();
-extern int has_condition_to_run(int version);
-extern char *ebpf_kernel_suffix(int version, int isrh);
-extern struct bpf_link **ebpf_load_program(char *plugins_dir, ebpf_module_t *em, int kver, int is_rhf,
+int ebpf_get_kernel_version();
+int get_redhat_release();
+int has_condition_to_run(int version);
+char *ebpf_kernel_suffix(int version, int isrh);
+struct bpf_link **ebpf_load_program(char *plugins_dir, ebpf_module_t *em, int kver, int is_rhf,
                                            struct bpf_object **obj);
 
-extern void ebpf_mount_config_name(char *filename, size_t length, char *path, const char *config);
-extern int ebpf_load_config(struct config *config, char *filename);
-extern void ebpf_update_module(ebpf_module_t *em, struct btf *btf_file);
-extern void ebpf_update_names(ebpf_specify_name_t *opt, ebpf_module_t *em);
-extern void ebpf_adjust_apps_cgroup(ebpf_module_t *em, netdata_ebpf_program_loaded_t mode);
-extern char *ebpf_find_symbol(char *search);
-extern void ebpf_load_addresses(ebpf_addresses_t *fa, int fd);
-extern void ebpf_fill_algorithms(int *algorithms, size_t length, int algorithm);
-extern char **ebpf_fill_histogram_dimension(size_t maximum);
-extern void ebpf_update_stats(ebpf_plugin_stats_t *report, ebpf_module_t *em);
-extern void ebpf_update_controller(int fd, ebpf_module_t *em);
-extern void ebpf_update_map_size(struct bpf_map *map, ebpf_local_maps_t *lmap, ebpf_module_t *em, const char *map_name);
+void ebpf_mount_config_name(char *filename, size_t length, char *path, const char *config);
+int ebpf_load_config(struct config *config, char *filename);
+void ebpf_update_module(ebpf_module_t *em, struct btf *btf_file);
+void ebpf_update_names(ebpf_specify_name_t *opt, ebpf_module_t *em);
+void ebpf_adjust_apps_cgroup(ebpf_module_t *em, netdata_ebpf_program_loaded_t mode);
+char *ebpf_find_symbol(char *search);
+void ebpf_load_addresses(ebpf_addresses_t *fa, int fd);
+void ebpf_fill_algorithms(int *algorithms, size_t length, int algorithm);
+char **ebpf_fill_histogram_dimension(size_t maximum);
+void ebpf_update_stats(ebpf_plugin_stats_t *report, ebpf_module_t *em);
+void ebpf_update_controller(int fd, ebpf_module_t *em);
+void ebpf_update_map_size(struct bpf_map *map, ebpf_local_maps_t *lmap, ebpf_module_t *em, const char *map_name);
 
 // Histogram
 #define NETDATA_EBPF_HIST_MAX_BINS 24UL
@@ -339,13 +339,13 @@ typedef struct ebpf_sync_syscalls {
 #endif
 } ebpf_sync_syscalls_t;
 
-extern void ebpf_histogram_dimension_cleanup(char **ptr, size_t length);
+void ebpf_histogram_dimension_cleanup(char **ptr, size_t length);
 
 // Tracepoint helpers
 // For more information related to tracepoints read https://www.kernel.org/doc/html/latest/trace/tracepoints.html
-extern int ebpf_is_tracepoint_enabled(char *subsys, char *eventname);
-extern int ebpf_enable_tracing_values(char *subsys, char *eventname);
-extern int ebpf_disable_tracing_values(char *subsys, char *eventname);
+int ebpf_is_tracepoint_enabled(char *subsys, char *eventname);
+int ebpf_enable_tracing_values(char *subsys, char *eventname);
+int ebpf_disable_tracing_values(char *subsys, char *eventname);
 
 // BTF Section
 #define EBPF_DEFAULT_BTF_FILE "vmlinux"
@@ -355,14 +355,14 @@ extern int ebpf_disable_tracing_values(char *subsys, char *eventname);
 // BTF helpers
 #define NETDATA_EBPF_MAX_SYSCALL_LENGTH 255
 
-extern netdata_ebpf_load_mode_t epbf_convert_string_to_load_mode(char *str);
-extern netdata_ebpf_program_loaded_t ebpf_convert_core_type(char *str, netdata_run_mode_t lmode);
-extern void ebpf_select_host_prefix(char *output, size_t length, char *syscall, int kver);
+netdata_ebpf_load_mode_t epbf_convert_string_to_load_mode(char *str);
+netdata_ebpf_program_loaded_t ebpf_convert_core_type(char *str, netdata_run_mode_t lmode);
+void ebpf_select_host_prefix(char *output, size_t length, char *syscall, int kver);
 #ifdef LIBBPF_MAJOR_VERSION
-extern void ebpf_adjust_thread_load(ebpf_module_t *mod, struct btf *file);
-extern struct btf *ebpf_parse_btf_file(const char *filename);
-extern struct btf *ebpf_load_btf_file(char *path, char *filename);
-extern int ebpf_is_function_inside_btf(struct btf *file, char *function);
+void ebpf_adjust_thread_load(ebpf_module_t *mod, struct btf *file);
+struct btf *ebpf_parse_btf_file(const char *filename);
+struct btf *ebpf_load_btf_file(char *path, char *filename);
+int ebpf_is_function_inside_btf(struct btf *file, char *function);
 #endif
 
 #endif /* NETDATA_EBPF_H */

--- a/libnetdata/eval/eval.h
+++ b/libnetdata/eval/eval.h
@@ -69,19 +69,19 @@ typedef struct eval_expression {
 // parse the given string as an expression and return:
 //   a pointer to an expression if it parsed OK
 //   NULL in which case the pointer to error has the error code
-extern EVAL_EXPRESSION *expression_parse(const char *string, const char **failed_at, int *error);
+EVAL_EXPRESSION *expression_parse(const char *string, const char **failed_at, int *error);
 
 // free all resources allocated for an expression
-extern void expression_free(EVAL_EXPRESSION *expression);
+void expression_free(EVAL_EXPRESSION *expression);
 
 // convert an error code to a message
-extern const char *expression_strerror(int error);
+const char *expression_strerror(int error);
 
 // evaluate an expression and return
 // 1 = OK, the result is in: expression->result
 // 2 = FAILED, the error message is in: buffer_tostring(expression->error_msg)
-extern int expression_evaluate(EVAL_EXPRESSION *expression);
+int expression_evaluate(EVAL_EXPRESSION *expression);
 
-extern int health_variable_lookup(STRING *variable, struct rrdcalc *rc, NETDATA_DOUBLE *result);
+int health_variable_lookup(STRING *variable, struct rrdcalc *rc, NETDATA_DOUBLE *result);
 
 #endif //NETDATA_EVAL_H

--- a/libnetdata/health/health.h
+++ b/libnetdata/health/health.h
@@ -46,10 +46,10 @@ typedef struct silencers {
 
 extern SILENCERS *silencers;
 
-extern SILENCER *create_silencer(void);
-extern int health_silencers_json_read_callback(JSON_ENTRY *e);
-extern void health_silencers_add(SILENCER *silencer);
-extern SILENCER * health_silencers_addparam(SILENCER *silencer, char *key, char *value);
-extern int health_initialize_global_silencers();
+SILENCER *create_silencer(void);
+int health_silencers_json_read_callback(JSON_ENTRY *e);
+void health_silencers_add(SILENCER *silencer);
+SILENCER * health_silencers_addparam(SILENCER *silencer, char *key, char *value);
+int health_initialize_global_silencers();
 
 #endif

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -284,16 +284,16 @@ extern "C" {
 // ---------------------------------------------------------------------------------------------
 
 
-extern void netdata_fix_chart_id(char *s);
-extern void netdata_fix_chart_name(char *s);
+void netdata_fix_chart_id(char *s);
+void netdata_fix_chart_name(char *s);
 
-extern void strreverse(char* begin, char* end);
-extern char *mystrsep(char **ptr, char *s);
-extern char *trim(char *s); // remove leading and trailing spaces; may return NULL
-extern char *trim_all(char *buffer); // like trim(), but also remove duplicate spaces inside the string; may return NULL
+void strreverse(char* begin, char* end);
+char *mystrsep(char **ptr, char *s);
+char *trim(char *s); // remove leading and trailing spaces; may return NULL
+char *trim_all(char *buffer); // like trim(), but also remove duplicate spaces inside the string; may return NULL
 
-extern int  vsnprintfz(char *dst, size_t n, const char *fmt, va_list args);
-extern int  snprintfz(char *dst, size_t n, const char *fmt, ...) PRINTFLIKE(3, 4);
+int  vsnprintfz(char *dst, size_t n, const char *fmt, va_list args);
+int  snprintfz(char *dst, size_t n, const char *fmt, ...) PRINTFLIKE(3, 4);
 
 // memory allocation functions that handle failures
 #ifdef NETDATA_LOG_ALLOCATIONS
@@ -305,47 +305,47 @@ extern __thread size_t log_thread_memory_allocations;
 #define freez(ptr) freez_int(__FILE__, __FUNCTION__, __LINE__, ptr)
 #define log_allocations() log_allocations_int(__FILE__, __FUNCTION__, __LINE__)
 
-extern char *strdupz_int(const char *file, const char *function, const unsigned long line, const char *s);
-extern void *callocz_int(const char *file, const char *function, const unsigned long line, size_t nmemb, size_t size);
-extern void *mallocz_int(const char *file, const char *function, const unsigned long line, size_t size);
-extern void *reallocz_int(const char *file, const char *function, const unsigned long line, void *ptr, size_t size);
-extern void freez_int(const char *file, const char *function, const unsigned long line, void *ptr);
-extern void log_allocations_int(const char *file, const char *function, const unsigned long line);
+char *strdupz_int(const char *file, const char *function, const unsigned long line, const char *s);
+void *callocz_int(const char *file, const char *function, const unsigned long line, size_t nmemb, size_t size);
+void *mallocz_int(const char *file, const char *function, const unsigned long line, size_t size);
+void *reallocz_int(const char *file, const char *function, const unsigned long line, void *ptr, size_t size);
+void freez_int(const char *file, const char *function, const unsigned long line, void *ptr);
+void log_allocations_int(const char *file, const char *function, const unsigned long line);
 
 #else // NETDATA_LOG_ALLOCATIONS
-extern char *strdupz(const char *s) MALLOCLIKE NEVERNULL;
-extern void *callocz(size_t nmemb, size_t size) MALLOCLIKE NEVERNULL;
-extern void *mallocz(size_t size) MALLOCLIKE NEVERNULL;
-extern void *reallocz(void *ptr, size_t size) MALLOCLIKE NEVERNULL;
-extern void freez(void *ptr);
+char *strdupz(const char *s) MALLOCLIKE NEVERNULL;
+void *callocz(size_t nmemb, size_t size) MALLOCLIKE NEVERNULL;
+void *mallocz(size_t size) MALLOCLIKE NEVERNULL;
+void *reallocz(void *ptr, size_t size) MALLOCLIKE NEVERNULL;
+void freez(void *ptr);
 #endif // NETDATA_LOG_ALLOCATIONS
 
-extern void json_escape_string(char *dst, const char *src, size_t size);
-extern void json_fix_string(char *s);
+void json_escape_string(char *dst, const char *src, size_t size);
+void json_fix_string(char *s);
 
-extern void *netdata_mmap(const char *filename, size_t size, int flags, int ksm);
-extern int memory_file_save(const char *filename, void *mem, size_t size);
+void *netdata_mmap(const char *filename, size_t size, int flags, int ksm);
+int memory_file_save(const char *filename, void *mem, size_t size);
 
-extern int fd_is_valid(int fd);
+int fd_is_valid(int fd);
 
 extern struct rlimit rlimit_nofile;
 
 extern int enable_ksm;
 
-extern char *fgets_trim_len(char *buf, size_t buf_size, FILE *fp, size_t *len);
+char *fgets_trim_len(char *buf, size_t buf_size, FILE *fp, size_t *len);
 
-extern int verify_netdata_host_prefix();
+int verify_netdata_host_prefix();
 
-extern int recursively_delete_dir(const char *path, const char *reason);
+int recursively_delete_dir(const char *path, const char *reason);
 
 extern volatile sig_atomic_t netdata_exit;
 
 extern const char *program_version;
 
-extern char *strdupz_path_subpath(const char *path, const char *subpath);
-extern int path_is_dir(const char *path, const char *subpath);
-extern int path_is_file(const char *path, const char *subpath);
-extern void recursive_config_double_dir_load(
+char *strdupz_path_subpath(const char *path, const char *subpath);
+int path_is_dir(const char *path, const char *subpath);
+int path_is_file(const char *path, const char *subpath);
+void recursive_config_double_dir_load(
         const char *user_path
         , const char *stock_path
         , const char *subpath
@@ -353,8 +353,8 @@ extern void recursive_config_double_dir_load(
         , void *data
         , size_t depth
 );
-extern char *read_by_filename(char *filename, long *file_size);
-extern char *find_and_replace(const char *src, const char *find, const char *replace, const char *where);
+char *read_by_filename(char *filename, long *file_size);
+char *find_and_replace(const char *src, const char *find, const char *replace, const char *where);
 
 /* fix for alpine linux */
 #ifndef RUSAGE_THREAD
@@ -385,20 +385,20 @@ typedef struct bitmap256 {
     uint64_t data[4];
 } BITMAP256;
 
-extern bool bitmap256_get_bit(BITMAP256 *ptr, uint8_t idx);
-extern void bitmap256_set_bit(BITMAP256 *ptr, uint8_t idx, bool value);
+bool bitmap256_get_bit(BITMAP256 *ptr, uint8_t idx);
+void bitmap256_set_bit(BITMAP256 *ptr, uint8_t idx, bool value);
 
 #define COMPRESSION_MAX_MSG_SIZE 0x4000
 #define PLUGINSD_LINE_MAX (COMPRESSION_MAX_MSG_SIZE - 1024)
-extern int config_isspace(char c);
-extern int pluginsd_space(char c);
+int config_isspace(char c);
+int pluginsd_space(char c);
 int quoted_strings_splitter(char *str, char **words, int max_words, int (*custom_isspace)(char), char *recover_input, char **recover_location, int max_recover);
-extern int pluginsd_split_words(char *str, char **words, int max_words, char *recover_string, char **recover_location, int max_recover);
+int pluginsd_split_words(char *str, char **words, int max_words, char *recover_string, char **recover_location, int max_recover);
 
-extern bool run_command_and_copy_output_to_stdout(const char *command, int max_line_length);
+bool run_command_and_copy_output_to_stdout(const char *command, int max_line_length);
 
-extern void netdata_cleanup_and_exit(int ret) NORETURN;
-extern void send_statistics(const char *action, const char *action_result, const char *action_data);
+void netdata_cleanup_and_exit(int ret) NORETURN;
+void send_statistics(const char *action, const char *action_result, const char *action_data);
 extern char *netdata_configured_host_prefix;
 #include "os.h"
 #include "storage_number/storage_number.h"

--- a/libnetdata/locks/locks.h
+++ b/libnetdata/locks/locks.h
@@ -51,38 +51,38 @@ typedef struct netdata_rwlock_t {
 
 #endif // NETDATA_TRACE_RWLOCKS
 
-extern int __netdata_mutex_init(netdata_mutex_t *mutex);
-extern int __netdata_mutex_destroy(netdata_mutex_t *mutex);
-extern int __netdata_mutex_lock(netdata_mutex_t *mutex);
-extern int __netdata_mutex_trylock(netdata_mutex_t *mutex);
-extern int __netdata_mutex_unlock(netdata_mutex_t *mutex);
+int __netdata_mutex_init(netdata_mutex_t *mutex);
+int __netdata_mutex_destroy(netdata_mutex_t *mutex);
+int __netdata_mutex_lock(netdata_mutex_t *mutex);
+int __netdata_mutex_trylock(netdata_mutex_t *mutex);
+int __netdata_mutex_unlock(netdata_mutex_t *mutex);
 
-extern int __netdata_rwlock_destroy(netdata_rwlock_t *rwlock);
-extern int __netdata_rwlock_init(netdata_rwlock_t *rwlock);
-extern int __netdata_rwlock_rdlock(netdata_rwlock_t *rwlock);
-extern int __netdata_rwlock_wrlock(netdata_rwlock_t *rwlock);
-extern int __netdata_rwlock_unlock(netdata_rwlock_t *rwlock);
-extern int __netdata_rwlock_tryrdlock(netdata_rwlock_t *rwlock);
-extern int __netdata_rwlock_trywrlock(netdata_rwlock_t *rwlock);
+int __netdata_rwlock_destroy(netdata_rwlock_t *rwlock);
+int __netdata_rwlock_init(netdata_rwlock_t *rwlock);
+int __netdata_rwlock_rdlock(netdata_rwlock_t *rwlock);
+int __netdata_rwlock_wrlock(netdata_rwlock_t *rwlock);
+int __netdata_rwlock_unlock(netdata_rwlock_t *rwlock);
+int __netdata_rwlock_tryrdlock(netdata_rwlock_t *rwlock);
+int __netdata_rwlock_trywrlock(netdata_rwlock_t *rwlock);
 
-extern void netdata_thread_disable_cancelability(void);
-extern void netdata_thread_enable_cancelability(void);
+void netdata_thread_disable_cancelability(void);
+void netdata_thread_enable_cancelability(void);
 
 #ifdef NETDATA_TRACE_RWLOCKS
 
-extern int netdata_mutex_init_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
-extern int netdata_mutex_destroy_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
-extern int netdata_mutex_lock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
-extern int netdata_mutex_trylock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
-extern int netdata_mutex_unlock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
+int netdata_mutex_init_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
+int netdata_mutex_destroy_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
+int netdata_mutex_lock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
+int netdata_mutex_trylock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
+int netdata_mutex_unlock_debug( const char *file, const char *function, const unsigned long line, netdata_mutex_t *mutex);
 
-extern int netdata_rwlock_destroy_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
-extern int netdata_rwlock_init_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
-extern int netdata_rwlock_rdlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
-extern int netdata_rwlock_wrlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
-extern int netdata_rwlock_unlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
-extern int netdata_rwlock_tryrdlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
-extern int netdata_rwlock_trywrlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+int netdata_rwlock_destroy_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+int netdata_rwlock_init_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+int netdata_rwlock_rdlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+int netdata_rwlock_wrlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+int netdata_rwlock_unlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+int netdata_rwlock_tryrdlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
+int netdata_rwlock_trywrlock_debug( const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock);
 
 #define netdata_mutex_init(mutex)    netdata_mutex_init_debug(__FILE__, __FUNCTION__, __LINE__, mutex)
 #define netdata_mutex_destroy(mutex) netdata_mutex_init_debug(__FILE__, __FUNCTION__, __LINE__, mutex)

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -74,10 +74,10 @@ extern int output_log_syslog;
 
 extern time_t error_log_throttle_period;
 extern unsigned long error_log_errors_per_period, error_log_errors_per_period_backup;
-extern int error_log_limit(int reset);
+int error_log_limit(int reset);
 
-extern void open_all_log_files();
-extern void reopen_all_log_files();
+void open_all_log_files();
+void reopen_all_log_files();
 
 static inline void debug_dummy(void) {}
 
@@ -98,15 +98,15 @@ void error_log_limit_unlimited(void);
 #define fatal(args...)   fatal_int(__FILE__, __FUNCTION__, __LINE__, ##args)
 #define fatal_assert(expr) ((expr) ? (void)(0) : fatal_int(__FILE__, __FUNCTION__, __LINE__, "Assertion `%s' failed", #expr))
 
-extern void send_statistics(const char *action, const char *action_result, const char *action_data);
-extern void debug_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(4, 5);
-extern void info_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(4, 5);
-extern void error_int( const char *prefix, const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(5, 6);
-extern void fatal_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) NORETURN PRINTFLIKE(4, 5);
-extern void log_access( const char *fmt, ... ) PRINTFLIKE(1, 2);
+void send_statistics(const char *action, const char *action_result, const char *action_data);
+void debug_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(4, 5);
+void info_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(4, 5);
+void error_int( const char *prefix, const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(5, 6);
+void fatal_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) NORETURN PRINTFLIKE(4, 5);
+void log_access( const char *fmt, ... ) PRINTFLIKE(1, 2);
 
 #ifdef ENABLE_ACLK
-extern void log_aclk_message_bin( const char *data, const size_t data_len, int tx, const char *mqtt_topic, const char *message_name);
+void log_aclk_message_bin( const char *data, const size_t data_len, int tx, const char *mqtt_topic, const char *message_name);
 #endif
 
 # ifdef __cplusplus

--- a/libnetdata/onewayalloc/onewayalloc.h
+++ b/libnetdata/onewayalloc/onewayalloc.h
@@ -5,15 +5,15 @@
 
 typedef void ONEWAYALLOC;
 
-extern ONEWAYALLOC *onewayalloc_create(size_t size_hint);
-extern void onewayalloc_destroy(ONEWAYALLOC *owa);
+ONEWAYALLOC *onewayalloc_create(size_t size_hint);
+void onewayalloc_destroy(ONEWAYALLOC *owa);
 
-extern void *onewayalloc_mallocz(ONEWAYALLOC *owa, size_t size);
-extern void *onewayalloc_callocz(ONEWAYALLOC *owa, size_t nmemb, size_t size);
-extern char *onewayalloc_strdupz(ONEWAYALLOC *owa, const char *s);
-extern void *onewayalloc_memdupz(ONEWAYALLOC *owa, const void *src, size_t size);
-extern void onewayalloc_freez(ONEWAYALLOC *owa, const void *ptr);
+void *onewayalloc_mallocz(ONEWAYALLOC *owa, size_t size);
+void *onewayalloc_callocz(ONEWAYALLOC *owa, size_t nmemb, size_t size);
+char *onewayalloc_strdupz(ONEWAYALLOC *owa, const char *s);
+void *onewayalloc_memdupz(ONEWAYALLOC *owa, const void *src, size_t size);
+void onewayalloc_freez(ONEWAYALLOC *owa, const void *ptr);
 
-extern void *onewayalloc_doublesize(ONEWAYALLOC *owa, const void *src, size_t oldsize);
+void *onewayalloc_doublesize(ONEWAYALLOC *owa, const void *src, size_t oldsize);
 
 #endif // ONEWAYALLOC_H

--- a/libnetdata/os.h
+++ b/libnetdata/os.h
@@ -13,21 +13,21 @@
 #include <sys/sysctl.h>
 
 #define GETSYSCTL_BY_NAME(name, var) getsysctl_by_name(name, &(var), sizeof(var))
-extern int getsysctl_by_name(const char *name, void *ptr, size_t len);
+int getsysctl_by_name(const char *name, void *ptr, size_t len);
 
 #define GETSYSCTL_MIB(name, mib) getsysctl_mib(name, mib, sizeof(mib)/sizeof(int))
 
-extern int getsysctl_mib(const char *name, int *mib, size_t len);
+int getsysctl_mib(const char *name, int *mib, size_t len);
 
 #define GETSYSCTL_SIMPLE(name, mib, var) getsysctl_simple(name, mib, sizeof(mib)/sizeof(int), &(var), sizeof(var))
 #define GETSYSCTL_WSIZE(name, mib, var, size) getsysctl_simple(name, mib, sizeof(mib)/sizeof(int), var, size)
 
-extern int getsysctl_simple(const char *name, int *mib, size_t miblen, void *ptr, size_t len);
+int getsysctl_simple(const char *name, int *mib, size_t miblen, void *ptr, size_t len);
 
 #define GETSYSCTL_SIZE(name, mib, size) getsysctl(name, mib, sizeof(mib)/sizeof(int), NULL, &(size))
 #define GETSYSCTL(name, mib, var, size) getsysctl(name, mib, sizeof(mib)/sizeof(int), &(var), &(size))
 
-extern int getsysctl(const char *name, int *mib, size_t miblen, void *ptr, size_t *len);
+int getsysctl(const char *name, int *mib, size_t miblen, void *ptr, size_t *len);
 
 #endif
 
@@ -39,7 +39,7 @@ extern int getsysctl(const char *name, int *mib, size_t miblen, void *ptr, size_
 #include <sys/sysctl.h>
 
 #define GETSYSCTL_BY_NAME(name, var) getsysctl_by_name(name, &(var), sizeof(var))
-extern int getsysctl_by_name(const char *name, void *ptr, size_t len);
+int getsysctl_by_name(const char *name, void *ptr, size_t len);
 
 #endif
 
@@ -49,13 +49,13 @@ extern int getsysctl_by_name(const char *name, void *ptr, size_t len);
 extern const char *os_type;
 
 extern int processors;
-extern long get_system_cpus(void);
+long get_system_cpus(void);
 
 extern pid_t pid_max;
-extern pid_t get_system_pid_max(void);
+pid_t get_system_pid_max(void);
 
 extern unsigned int system_hz;
-extern void get_system_HZ(void);
+void get_system_HZ(void);
 
 #include <sys/timex.h>
 #if defined(__FreeBSD__) || defined(__APPLE__)

--- a/libnetdata/popen/popen.h
+++ b/libnetdata/popen/popen.h
@@ -22,19 +22,19 @@
 #define netdata_popen_raw_default_flags(pidptr, env, fpp_child_input, fpp_child_output, command, args...) netdata_popene_variadic_internal_dont_use_directly(pidptr, env, POPEN_FLAGS_DEFAULT, fpp_child_input, fpp_child_output, command, command, ##args, NULL)
 #define netdata_popen_raw(pidptr, env, flags, fpp_child_input, fpp_child_output, command, args...) netdata_popene_variadic_internal_dont_use_directly(pidptr, env, flags, fpp_child_input, fpp_child_output, command, command, ##args, NULL)
 
-extern FILE *netdata_popen(const char *command, volatile pid_t *pidptr, FILE **fp_child_input);
-extern FILE *netdata_popene(const char *command, volatile pid_t *pidptr, char **env, FILE **fp_child_input);
-extern int netdata_popene_variadic_internal_dont_use_directly(volatile pid_t *pidptr, char **env, uint8_t flags, FILE **fpp_child_input, FILE **fpp_child_output, const char *command, ...);
-extern int netdata_pclose(FILE *fp_child_input, FILE *fp_child_output, pid_t pid);
+FILE *netdata_popen(const char *command, volatile pid_t *pidptr, FILE **fp_child_input);
+FILE *netdata_popene(const char *command, volatile pid_t *pidptr, char **env, FILE **fp_child_input);
+int netdata_popene_variadic_internal_dont_use_directly(volatile pid_t *pidptr, char **env, uint8_t flags, FILE **fpp_child_input, FILE **fpp_child_output, const char *command, ...);
+int netdata_pclose(FILE *fp_child_input, FILE *fp_child_output, pid_t pid);
 
-extern int netdata_spawn(const char *command, volatile pid_t *pidptr);
-extern int netdata_spawn_waitpid(pid_t pid);
+int netdata_spawn(const char *command, volatile pid_t *pidptr);
+int netdata_spawn_waitpid(pid_t pid);
 
-extern void netdata_popen_tracking_init(void);
-extern void netdata_popen_tracking_cleanup(void);
-extern int netdata_popen_tracking_pid_shoud_be_reaped(pid_t pid);
+void netdata_popen_tracking_init(void);
+void netdata_popen_tracking_cleanup(void);
+int netdata_popen_tracking_pid_shoud_be_reaped(pid_t pid);
 
-extern void signals_unblock(void);
-extern void signals_reset(void);
+void signals_unblock(void);
+void signals_reset(void);
 
 #endif /* NETDATA_POPEN_H */

--- a/libnetdata/procfile/procfile.h
+++ b/libnetdata/procfile/procfile.h
@@ -60,25 +60,25 @@ typedef struct {
 } procfile;
 
 // close the proc file and free all related memory
-extern void procfile_close(procfile *ff);
+void procfile_close(procfile *ff);
 
 // (re)read and parse the proc file
-extern procfile *procfile_readall(procfile *ff);
+procfile *procfile_readall(procfile *ff);
 
 // open a /proc or /sys file
-extern procfile *procfile_open(const char *filename, const char *separators, uint32_t flags);
+procfile *procfile_open(const char *filename, const char *separators, uint32_t flags);
 
 // re-open a file
 // if separators == NULL, the last separators are used
-extern procfile *procfile_reopen(procfile *ff, const char *filename, const char *separators, uint32_t flags);
+procfile *procfile_reopen(procfile *ff, const char *filename, const char *separators, uint32_t flags);
 
 // example walk-through a procfile parsed file
-extern void procfile_print(procfile *ff);
+void procfile_print(procfile *ff);
 
-extern void procfile_set_quotes(procfile *ff, const char *quotes);
-extern void procfile_set_open_close(procfile *ff, const char *open, const char *close);
+void procfile_set_quotes(procfile *ff, const char *quotes);
+void procfile_set_open_close(procfile *ff, const char *open, const char *close);
 
-extern char *procfile_filename(procfile *ff);
+char *procfile_filename(procfile *ff);
 
 // ----------------------------------------------------------------------------
 

--- a/libnetdata/simple_pattern/simple_pattern.h
+++ b/libnetdata/simple_pattern/simple_pattern.h
@@ -18,21 +18,21 @@ typedef void SIMPLE_PATTERN;
 // create a simple_pattern from the string given
 // default_mode is used in cases where EXACT matches, without an asterisk,
 // should be considered PREFIX matches.
-extern SIMPLE_PATTERN *simple_pattern_create(const char *list, const char *separators, SIMPLE_PREFIX_MODE default_mode);
+SIMPLE_PATTERN *simple_pattern_create(const char *list, const char *separators, SIMPLE_PREFIX_MODE default_mode);
 
 // test if string str is matched from the pattern and fill 'wildcarded' with the parts matched by '*'
-extern int simple_pattern_matches_extract(SIMPLE_PATTERN *list, const char *str, char *wildcarded, size_t wildcarded_size);
+int simple_pattern_matches_extract(SIMPLE_PATTERN *list, const char *str, char *wildcarded, size_t wildcarded_size);
 
 // test if string str is matched from the pattern
 #define simple_pattern_matches(list, str) simple_pattern_matches_extract(list, str, NULL, 0)
 
 // free a simple_pattern that was created with simple_pattern_create()
 // list can be NULL, in which case, this does nothing.
-extern void simple_pattern_free(SIMPLE_PATTERN *list);
+void simple_pattern_free(SIMPLE_PATTERN *list);
 
-extern void simple_pattern_dump(uint64_t debug_type, SIMPLE_PATTERN *p) ;
-extern int simple_pattern_is_potential_name(SIMPLE_PATTERN *p) ;
-extern char *simple_pattern_iterate(SIMPLE_PATTERN **p);
+void simple_pattern_dump(uint64_t debug_type, SIMPLE_PATTERN *p) ;
+int simple_pattern_is_potential_name(SIMPLE_PATTERN *p) ;
+char *simple_pattern_iterate(SIMPLE_PATTERN **p);
 
 //Auxiliary function to create a pattern
 char *simple_pattern_trim_around_equal(char *src);

--- a/libnetdata/socket/security.h
+++ b/libnetdata/socket/security.h
@@ -50,7 +50,7 @@ extern const char *netdata_ssl_security_cert;
 extern const char *tls_version;
 extern const char *tls_ciphers;
 extern int netdata_ssl_validate_server;
-extern int ssl_security_location_for_context(SSL_CTX *ctx,char *file,char *path);
+int ssl_security_location_for_context(SSL_CTX *ctx,char *file,char *path);
 
 void security_openssl_library();
 void security_clean_openssl();

--- a/libnetdata/socket/socket.h
+++ b/libnetdata/socket/socket.h
@@ -52,40 +52,40 @@ typedef struct listen_sockets {
     WEB_CLIENT_ACL fds_acl_flags[MAX_LISTEN_FDS];  // the acl to apply to the open sockets (dashboard, badges, streaming, netdata.conf, management)
 } LISTEN_SOCKETS;
 
-extern char *strdup_client_description(int family, const char *protocol, const char *ip, uint16_t port);
+char *strdup_client_description(int family, const char *protocol, const char *ip, uint16_t port);
 
-extern int listen_sockets_setup(LISTEN_SOCKETS *sockets);
-extern void listen_sockets_close(LISTEN_SOCKETS *sockets);
+int listen_sockets_setup(LISTEN_SOCKETS *sockets);
+void listen_sockets_close(LISTEN_SOCKETS *sockets);
 
-extern void foreach_entry_in_connection_string(const char *destination, bool (*callback)(char *entry, void *data), void *data);
-extern int connect_to_this_ip46(int protocol, int socktype, const char *host, uint32_t scope_id, const char *service, struct timeval *timeout);
-extern int connect_to_this(const char *definition, int default_port, struct timeval *timeout);
-extern int connect_to_one_of(const char *destination, int default_port, struct timeval *timeout, size_t *reconnects_counter, char *connected_to, size_t connected_to_size);
-extern int connect_to_one_of_urls(const char *destination, int default_port, struct timeval *timeout, size_t *reconnects_counter, char *connected_to, size_t connected_to_size);
+void foreach_entry_in_connection_string(const char *destination, bool (*callback)(char *entry, void *data), void *data);
+int connect_to_this_ip46(int protocol, int socktype, const char *host, uint32_t scope_id, const char *service, struct timeval *timeout);
+int connect_to_this(const char *definition, int default_port, struct timeval *timeout);
+int connect_to_one_of(const char *destination, int default_port, struct timeval *timeout, size_t *reconnects_counter, char *connected_to, size_t connected_to_size);
+int connect_to_one_of_urls(const char *destination, int default_port, struct timeval *timeout, size_t *reconnects_counter, char *connected_to, size_t connected_to_size);
 
 
 #ifdef ENABLE_HTTPS
-extern ssize_t recv_timeout(struct netdata_ssl *ssl,int sockfd, void *buf, size_t len, int flags, int timeout);
-extern ssize_t send_timeout(struct netdata_ssl *ssl,int sockfd, void *buf, size_t len, int flags, int timeout);
+ssize_t recv_timeout(struct netdata_ssl *ssl,int sockfd, void *buf, size_t len, int flags, int timeout);
+ssize_t send_timeout(struct netdata_ssl *ssl,int sockfd, void *buf, size_t len, int flags, int timeout);
 #else
-extern ssize_t recv_timeout(int sockfd, void *buf, size_t len, int flags, int timeout);
-extern ssize_t send_timeout(int sockfd, void *buf, size_t len, int flags, int timeout);
+ssize_t recv_timeout(int sockfd, void *buf, size_t len, int flags, int timeout);
+ssize_t send_timeout(int sockfd, void *buf, size_t len, int flags, int timeout);
 #endif
 
-extern int sock_setnonblock(int fd);
-extern int sock_delnonblock(int fd);
-extern int sock_setreuse(int fd, int reuse);
-extern int sock_setreuse_port(int fd, int reuse);
-extern int sock_enlarge_in(int fd);
-extern int sock_enlarge_out(int fd);
+int sock_setnonblock(int fd);
+int sock_delnonblock(int fd);
+int sock_setreuse(int fd, int reuse);
+int sock_setreuse_port(int fd, int reuse);
+int sock_enlarge_in(int fd);
+int sock_enlarge_out(int fd);
 
-extern int connection_allowed(int fd, char *client_ip, char *client_host, size_t hostsize,
+int connection_allowed(int fd, char *client_ip, char *client_host, size_t hostsize,
                               SIMPLE_PATTERN *access_list, const char *patname, int allow_dns);
-extern int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *client_port, size_t portsize,
+int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *client_port, size_t portsize,
                          char *client_host, size_t hostsize, SIMPLE_PATTERN *access_list, int allow_dns);
 
 #ifndef HAVE_ACCEPT4
-extern int accept4(int sock, struct sockaddr *addr, socklen_t *addrlen, int flags);
+int accept4(int sock, struct sockaddr *addr, socklen_t *addrlen, int flags);
 
 #ifndef SOCK_NONBLOCK
 #define SOCK_NONBLOCK 00004000
@@ -173,12 +173,12 @@ struct poll {
 
 #define pollinfo_from_slot(p, slot) (&((p)->inf[(slot)]))
 
-extern int poll_default_snd_callback(POLLINFO *pi, short int *events);
-extern int poll_default_rcv_callback(POLLINFO *pi, short int *events);
-extern void poll_default_del_callback(POLLINFO *pi);
-extern void *poll_default_add_callback(POLLINFO *pi, short int *events, void *data);
+int poll_default_snd_callback(POLLINFO *pi, short int *events);
+int poll_default_rcv_callback(POLLINFO *pi, short int *events);
+void poll_default_del_callback(POLLINFO *pi);
+void *poll_default_add_callback(POLLINFO *pi, short int *events, void *data);
 
-extern POLLINFO *poll_add_fd(POLLJOB *p
+POLLINFO *poll_add_fd(POLLJOB *p
                              , int fd
                              , int socktype
                              , WEB_CLIENT_ACL port_acl
@@ -192,9 +192,9 @@ extern POLLINFO *poll_add_fd(POLLJOB *p
                              , int   (*snd_callback)(POLLINFO *pi, short int *events)
                              , void *data
 );
-extern void poll_close_fd(POLLINFO *pi);
+void poll_close_fd(POLLINFO *pi);
 
-extern void poll_events(LISTEN_SOCKETS *sockets
+void poll_events(LISTEN_SOCKETS *sockets
         , void *(*add_callback)(POLLINFO *pi, short int *events, void *data)
         , void  (*del_callback)(POLLINFO *pi)
         , int   (*rcv_callback)(POLLINFO *pi, short int *events)

--- a/libnetdata/statistical/statistical.h
+++ b/libnetdata/statistical/statistical.h
@@ -5,30 +5,30 @@
 
 #include "../libnetdata.h"
 
-extern void log_series_to_stderr(NETDATA_DOUBLE *series, size_t entries, NETDATA_DOUBLE result, const char *msg);
+void log_series_to_stderr(NETDATA_DOUBLE *series, size_t entries, NETDATA_DOUBLE result, const char *msg);
 
-extern NETDATA_DOUBLE average(const NETDATA_DOUBLE *series, size_t entries);
-extern NETDATA_DOUBLE moving_average(const NETDATA_DOUBLE *series, size_t entries, size_t period);
-extern NETDATA_DOUBLE median(const NETDATA_DOUBLE *series, size_t entries);
-extern NETDATA_DOUBLE moving_median(const NETDATA_DOUBLE *series, size_t entries, size_t period);
-extern NETDATA_DOUBLE running_median_estimate(const NETDATA_DOUBLE *series, size_t entries);
-extern NETDATA_DOUBLE standard_deviation(const NETDATA_DOUBLE *series, size_t entries);
-extern NETDATA_DOUBLE single_exponential_smoothing(const NETDATA_DOUBLE *series, size_t entries, NETDATA_DOUBLE alpha);
+NETDATA_DOUBLE average(const NETDATA_DOUBLE *series, size_t entries);
+NETDATA_DOUBLE moving_average(const NETDATA_DOUBLE *series, size_t entries, size_t period);
+NETDATA_DOUBLE median(const NETDATA_DOUBLE *series, size_t entries);
+NETDATA_DOUBLE moving_median(const NETDATA_DOUBLE *series, size_t entries, size_t period);
+NETDATA_DOUBLE running_median_estimate(const NETDATA_DOUBLE *series, size_t entries);
+NETDATA_DOUBLE standard_deviation(const NETDATA_DOUBLE *series, size_t entries);
+NETDATA_DOUBLE single_exponential_smoothing(const NETDATA_DOUBLE *series, size_t entries, NETDATA_DOUBLE alpha);
 extern NETDATA_DOUBLE
 single_exponential_smoothing_reverse(const NETDATA_DOUBLE *series, size_t entries, NETDATA_DOUBLE alpha);
-extern NETDATA_DOUBLE double_exponential_smoothing(const NETDATA_DOUBLE *series, size_t entries,
+NETDATA_DOUBLE double_exponential_smoothing(const NETDATA_DOUBLE *series, size_t entries,
     NETDATA_DOUBLE alpha,
     NETDATA_DOUBLE beta,
     NETDATA_DOUBLE *forecast);
-extern NETDATA_DOUBLE holtwinters(const NETDATA_DOUBLE *series, size_t entries,
+NETDATA_DOUBLE holtwinters(const NETDATA_DOUBLE *series, size_t entries,
     NETDATA_DOUBLE alpha,
     NETDATA_DOUBLE beta,
     NETDATA_DOUBLE gamma,
     NETDATA_DOUBLE *forecast);
-extern NETDATA_DOUBLE sum_and_count(const NETDATA_DOUBLE *series, size_t entries, size_t *count);
-extern NETDATA_DOUBLE sum(const NETDATA_DOUBLE *series, size_t entries);
-extern NETDATA_DOUBLE median_on_sorted_series(const NETDATA_DOUBLE *series, size_t entries);
-extern NETDATA_DOUBLE *copy_series(const NETDATA_DOUBLE *series, size_t entries);
-extern void sort_series(NETDATA_DOUBLE *series, size_t entries);
+NETDATA_DOUBLE sum_and_count(const NETDATA_DOUBLE *series, size_t entries, size_t *count);
+NETDATA_DOUBLE sum(const NETDATA_DOUBLE *series, size_t entries);
+NETDATA_DOUBLE median_on_sorted_series(const NETDATA_DOUBLE *series, size_t entries);
+NETDATA_DOUBLE *copy_series(const NETDATA_DOUBLE *series, size_t entries);
+void sort_series(NETDATA_DOUBLE *series, size_t entries);
 
 #endif //NETDATA_STATISTICAL_H

--- a/libnetdata/string/string.h
+++ b/libnetdata/string/string.h
@@ -8,14 +8,14 @@
 // STRING implementation
 
 typedef struct netdata_string STRING;
-extern STRING *string_strdupz(const char *str);
-extern STRING *string_dup(STRING *string);
-extern void string_freez(STRING *string);
-extern size_t string_strlen(STRING *string);
-extern const char *string2str(STRING *string) NEVERNULL;
+STRING *string_strdupz(const char *str);
+STRING *string_dup(STRING *string);
+void string_freez(STRING *string);
+size_t string_strlen(STRING *string);
+const char *string2str(STRING *string) NEVERNULL;
 
 // keep common prefix/suffix and replace everything else with [x]
-extern STRING *string_2way_merge(STRING *a, STRING *b);
+STRING *string_2way_merge(STRING *a, STRING *b);
 
 static inline int string_cmp(STRING *s1, STRING *s2) {
     // STRINGs are deduplicated, so the same strings have the same pointer
@@ -23,8 +23,8 @@ static inline int string_cmp(STRING *s1, STRING *s2) {
     return (s1 == s2)?0:strcmp(string2str(s1), string2str(s2));
 }
 
-extern void string_statistics(size_t *inserts, size_t *deletes, size_t *searches, size_t *entries, size_t *references, size_t *memory, size_t *duplications, size_t *releases);
+void string_statistics(size_t *inserts, size_t *deletes, size_t *searches, size_t *entries, size_t *references, size_t *memory, size_t *duplications, size_t *releases);
 
-extern int string_unittest(size_t entries);
+int string_unittest(size_t entries);
 
 #endif

--- a/libnetdata/threads/threads.h
+++ b/libnetdata/threads/threads.h
@@ -5,7 +5,7 @@
 
 #include "../libnetdata.h"
 
-extern pid_t gettid(void);
+pid_t gettid(void);
 
 typedef enum {
     NETDATA_THREAD_OPTION_DEFAULT          = 0 << 0,
@@ -21,27 +21,27 @@ typedef enum {
 typedef pthread_t netdata_thread_t;
 
 #define NETDATA_THREAD_TAG_MAX 100
-extern const char *netdata_thread_tag(void);
-extern int netdata_thread_tag_exists(void);
+const char *netdata_thread_tag(void);
+int netdata_thread_tag_exists(void);
 
-extern size_t netdata_threads_init(void);
-extern void netdata_threads_init_after_fork(size_t stacksize);
+size_t netdata_threads_init(void);
+void netdata_threads_init_after_fork(size_t stacksize);
 
-extern int netdata_thread_create(netdata_thread_t *thread, const char *tag, NETDATA_THREAD_OPTIONS options, void *(*start_routine) (void *), void *arg);
+int netdata_thread_create(netdata_thread_t *thread, const char *tag, NETDATA_THREAD_OPTIONS options, void *(*start_routine) (void *), void *arg);
 
 #ifdef NETDATA_INTERNAL_CHECKS
 #define netdata_thread_cancel(thread) netdata_thread_cancel_with_trace(thread, __LINE__, __FILE__, __FUNCTION__)
-extern int netdata_thread_cancel_with_trace(netdata_thread_t thread, int line, const char *file, const char *function);
+int netdata_thread_cancel_with_trace(netdata_thread_t thread, int line, const char *file, const char *function);
 #else
-extern int netdata_thread_cancel(netdata_thread_t thread);
+int netdata_thread_cancel(netdata_thread_t thread);
 #endif
 
-extern int netdata_thread_join(netdata_thread_t thread, void **retval);
-extern int netdata_thread_detach(pthread_t thread);
+int netdata_thread_join(netdata_thread_t thread, void **retval);
+int netdata_thread_detach(pthread_t thread);
 
 #define NETDATA_THREAD_NAME_MAX 15
-extern void uv_thread_set_name_np(uv_thread_t ut, const char* name);
-extern void os_thread_get_current_name_np(char threadname[NETDATA_THREAD_NAME_MAX + 1]);
+void uv_thread_set_name_np(uv_thread_t ut, const char* name);
+void os_thread_get_current_name_np(char threadname[NETDATA_THREAD_NAME_MAX + 1]);
 
 #define netdata_thread_self pthread_self
 #define netdata_thread_testcancel pthread_testcancel

--- a/libnetdata/url/url.h
+++ b/libnetdata/url/url.h
@@ -10,26 +10,26 @@
 // code from: http://www.geekhideout.com/urlcode.shtml
 
 /* Converts a hex character to its integer value */
-extern char from_hex(char ch);
+char from_hex(char ch);
 
 /* Converts an integer value to its hex character*/
-extern char to_hex(char code);
+char to_hex(char code);
 
 /* Returns a url-encoded version of str */
 /* IMPORTANT: be sure to free() the returned string after use */
-extern char *url_encode(char *str);
+char *url_encode(char *str);
 
 /* Returns a url-decoded version of str */
 /* IMPORTANT: be sure to free() the returned string after use */
-extern char *url_decode(char *str);
+char *url_decode(char *str);
 
-extern char *url_decode_r(char *to, char *url, size_t size);
+char *url_decode_r(char *to, char *url, size_t size);
 
 #define WEB_FIELDS_MAX 400
-extern int url_map_query_string(char **out, char *url);
-extern int url_parse_query_string(char *output, size_t max, char **map, int total);
+int url_map_query_string(char **out, char *url);
+int url_parse_query_string(char *output, size_t max, char **map, int total);
 
-extern int url_is_request_complete(char *begin,char *end,size_t length);
-extern char *url_find_protocol(char *s);
+int url_is_request_complete(char *begin,char *end,size_t length);
+char *url_find_protocol(char *s);
 
 #endif /* NETDATA_URL_H */

--- a/libnetdata/worker_utilization/worker_utilization.h
+++ b/libnetdata/worker_utilization/worker_utilization.h
@@ -14,18 +14,18 @@ typedef enum {
     WORKER_METRIC_INCREMENTAL = 3,
 } WORKER_METRIC_TYPE;
 
-extern void worker_register(const char *workname);
-extern void worker_register_job_name(size_t job_id, const char *name);
-extern void worker_register_job_custom_metric(size_t job_id, const char *name, const char *units, WORKER_METRIC_TYPE type);
-extern void worker_unregister(void);
+void worker_register(const char *workname);
+void worker_register_job_name(size_t job_id, const char *name);
+void worker_register_job_custom_metric(size_t job_id, const char *name, const char *units, WORKER_METRIC_TYPE type);
+void worker_unregister(void);
 
-extern void worker_is_idle(void);
-extern void worker_is_busy(size_t job_id);
-extern void worker_set_metric(size_t job_id, NETDATA_DOUBLE value);
+void worker_is_idle(void);
+void worker_is_busy(size_t job_id);
+void worker_set_metric(size_t job_id, NETDATA_DOUBLE value);
 
 // statistics interface
 
-extern void workers_foreach(const char *workname, void (*callback)(
+void workers_foreach(const char *workname, void (*callback)(
                                                       void *data
                                                       , pid_t pid
                                                       , const char *thread_tag

--- a/ml/ml.h
+++ b/ml/ml.h
@@ -12,7 +12,7 @@ extern "C" {
 
 // This is a DBEngine function redeclared here so that we can free
 // the anomaly rate dimension, whenever its backing dimension is freed.
-extern void rrddim_free(RRDSET *st, RRDDIM *rd);
+void rrddim_free(RRDSET *st, RRDDIM *rd);
 
 typedef void* ml_host_t;
 typedef void* ml_dimension_t;

--- a/parser/parser.h
+++ b/parser/parser.h
@@ -105,7 +105,7 @@ typedef struct parser {
 
 } PARSER;
 
-extern int find_first_keyword(const char *str, char *keyword, int max_size, int (*custom_isspace)(char));
+int find_first_keyword(const char *str, char *keyword, int max_size, int (*custom_isspace)(char));
 
 PARSER *parser_init(RRDHOST *host, void *user, void *input, void *output, PARSER_INPUT_TYPE flags);
 int parser_add_keyword(PARSER *working_parser, char *keyword, keyword_function func);
@@ -115,22 +115,22 @@ int parser_push(PARSER *working_parser, char *line);
 void parser_destroy(PARSER *working_parser);
 int parser_recover_input(PARSER *working_parser);
 
-extern size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp_plugin_input, FILE *fp_plugin_output, int trust_durations);
+size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp_plugin_input, FILE *fp_plugin_output, int trust_durations);
 
-extern PARSER_RC pluginsd_set(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
-extern PARSER_RC pluginsd_begin(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
-extern PARSER_RC pluginsd_end(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
-extern PARSER_RC pluginsd_chart(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
-extern PARSER_RC pluginsd_dimension(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
-extern PARSER_RC pluginsd_variable(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
-extern PARSER_RC pluginsd_flush(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
-extern PARSER_RC pluginsd_disable(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
-extern PARSER_RC pluginsd_label(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
-extern PARSER_RC pluginsd_overwrite(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
-extern PARSER_RC pluginsd_guid(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
-extern PARSER_RC pluginsd_context(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
-extern PARSER_RC pluginsd_tombstone(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
-extern PARSER_RC pluginsd_clabel_commit(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
-extern PARSER_RC pluginsd_clabel(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+PARSER_RC pluginsd_set(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+PARSER_RC pluginsd_begin(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+PARSER_RC pluginsd_end(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+PARSER_RC pluginsd_chart(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+PARSER_RC pluginsd_dimension(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+PARSER_RC pluginsd_variable(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+PARSER_RC pluginsd_flush(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+PARSER_RC pluginsd_disable(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+PARSER_RC pluginsd_label(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+PARSER_RC pluginsd_overwrite(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+PARSER_RC pluginsd_guid(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+PARSER_RC pluginsd_context(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+PARSER_RC pluginsd_tombstone(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+PARSER_RC pluginsd_clabel_commit(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
+PARSER_RC pluginsd_clabel(char **words, void *user, PLUGINSD_ACTION  *plugins_action);
 
 #endif

--- a/registry/registry.h
+++ b/registry/registry.h
@@ -55,29 +55,29 @@
 
 // initialize the registry
 // should only happen when netdata starts
-extern int registry_init(void);
+int registry_init(void);
 
 // free all data held by the registry
 // should only happen when netdata exits
-extern void registry_free(void);
+void registry_free(void);
 
 // HTTP requests handled by the registry
-extern int registry_request_access_json(RRDHOST *host, struct web_client *w, char *person_guid, char *machine_guid, char *url, char *name, time_t when);
-extern int registry_request_delete_json(RRDHOST *host, struct web_client *w, char *person_guid, char *machine_guid, char *url, char *delete_url, time_t when);
-extern int registry_request_search_json(RRDHOST *host, struct web_client *w, char *person_guid, char *machine_guid, char *url, char *request_machine, time_t when);
-extern int registry_request_switch_json(RRDHOST *host, struct web_client *w, char *person_guid, char *machine_guid, char *url, char *new_person_guid, time_t when);
-extern int registry_request_hello_json(RRDHOST *host, struct web_client *w);
+int registry_request_access_json(RRDHOST *host, struct web_client *w, char *person_guid, char *machine_guid, char *url, char *name, time_t when);
+int registry_request_delete_json(RRDHOST *host, struct web_client *w, char *person_guid, char *machine_guid, char *url, char *delete_url, time_t when);
+int registry_request_search_json(RRDHOST *host, struct web_client *w, char *person_guid, char *machine_guid, char *url, char *request_machine, time_t when);
+int registry_request_switch_json(RRDHOST *host, struct web_client *w, char *person_guid, char *machine_guid, char *url, char *new_person_guid, time_t when);
+int registry_request_hello_json(RRDHOST *host, struct web_client *w);
 
 // update the registry config
-extern void registry_update_cloud_base_url();
+void registry_update_cloud_base_url();
 
 // update the registry monitoring charts
-extern void registry_statistics(void);
+void registry_statistics(void);
 
-extern char *registry_get_this_machine_guid(void);
-extern char *registry_get_mgmt_api_key(void);
-extern char *registry_get_this_machine_hostname(void);
+char *registry_get_this_machine_guid(void);
+char *registry_get_mgmt_api_key(void);
+char *registry_get_this_machine_hostname(void);
 
-extern int regenerate_guid(const char *guid, char *result);
+int regenerate_guid(const char *guid, char *result);
 
 #endif /* NETDATA_REGISTRY_H */

--- a/registry/registry_internals.h
+++ b/registry/registry_internals.h
@@ -71,20 +71,20 @@ struct registry {
 extern struct registry registry;
 
 // REGISTRY LOW-LEVEL REQUESTS (in registry-internals.c)
-extern REGISTRY_PERSON *registry_request_access(char *person_guid, char *machine_guid, char *url, char *name, time_t when);
-extern REGISTRY_PERSON *registry_request_delete(char *person_guid, char *machine_guid, char *url, char *delete_url, time_t when);
-extern REGISTRY_MACHINE *registry_request_machine(char *person_guid, char *machine_guid, char *url, char *request_machine, time_t when);
+REGISTRY_PERSON *registry_request_access(char *person_guid, char *machine_guid, char *url, char *name, time_t when);
+REGISTRY_PERSON *registry_request_delete(char *person_guid, char *machine_guid, char *url, char *delete_url, time_t when);
+REGISTRY_MACHINE *registry_request_machine(char *person_guid, char *machine_guid, char *url, char *request_machine, time_t when);
 
 // REGISTRY LOG (in registry_log.c)
-extern void registry_log(char action, REGISTRY_PERSON *p, REGISTRY_MACHINE *m, REGISTRY_URL *u, char *name);
-extern int registry_log_open(void);
-extern void registry_log_close(void);
-extern void registry_log_recreate(void);
-extern ssize_t registry_log_load(void);
+void registry_log(char action, REGISTRY_PERSON *p, REGISTRY_MACHINE *m, REGISTRY_URL *u, char *name);
+int registry_log_open(void);
+void registry_log_close(void);
+void registry_log_recreate(void);
+ssize_t registry_log_load(void);
 
 // REGISTRY DB (in registry_db.c)
-extern int registry_db_save(void);
-extern size_t registry_db_load(void);
-extern int registry_db_should_be_saved(void);
+int registry_db_save(void);
+size_t registry_db_load(void);
+int registry_db_should_be_saved(void);
 
 #endif //NETDATA_REGISTRY_INTERNALS_H_H

--- a/registry/registry_machine.h
+++ b/registry/registry_machine.h
@@ -34,10 +34,10 @@ struct registry_machine {
 };
 typedef struct registry_machine REGISTRY_MACHINE;
 
-extern REGISTRY_MACHINE *registry_machine_find(const char *machine_guid);
-extern REGISTRY_MACHINE_URL *registry_machine_url_allocate(REGISTRY_MACHINE *m, REGISTRY_URL *u, time_t when);
-extern REGISTRY_MACHINE *registry_machine_allocate(const char *machine_guid, time_t when);
-extern REGISTRY_MACHINE *registry_machine_get(const char *machine_guid, time_t when);
-extern REGISTRY_MACHINE_URL *registry_machine_link_to_url(REGISTRY_MACHINE *m, REGISTRY_URL *u, time_t when);
+REGISTRY_MACHINE *registry_machine_find(const char *machine_guid);
+REGISTRY_MACHINE_URL *registry_machine_url_allocate(REGISTRY_MACHINE *m, REGISTRY_URL *u, time_t when);
+REGISTRY_MACHINE *registry_machine_allocate(const char *machine_guid, time_t when);
+REGISTRY_MACHINE *registry_machine_get(const char *machine_guid, time_t when);
+REGISTRY_MACHINE_URL *registry_machine_link_to_url(REGISTRY_MACHINE *m, REGISTRY_URL *u, time_t when);
 
 #endif //NETDATA_REGISTRY_MACHINE_H

--- a/registry/registry_person.h
+++ b/registry/registry_person.h
@@ -42,20 +42,20 @@ struct registry_person {
 typedef struct registry_person REGISTRY_PERSON;
 
 // PERSON_URL
-extern REGISTRY_PERSON_URL *registry_person_url_index_find(REGISTRY_PERSON *p, const char *url);
-extern REGISTRY_PERSON_URL *registry_person_url_index_add(REGISTRY_PERSON *p, REGISTRY_PERSON_URL *pu) NEVERNULL WARNUNUSED;
-extern REGISTRY_PERSON_URL *registry_person_url_index_del(REGISTRY_PERSON *p, REGISTRY_PERSON_URL *pu) WARNUNUSED;
+REGISTRY_PERSON_URL *registry_person_url_index_find(REGISTRY_PERSON *p, const char *url);
+REGISTRY_PERSON_URL *registry_person_url_index_add(REGISTRY_PERSON *p, REGISTRY_PERSON_URL *pu) NEVERNULL WARNUNUSED;
+REGISTRY_PERSON_URL *registry_person_url_index_del(REGISTRY_PERSON *p, REGISTRY_PERSON_URL *pu) WARNUNUSED;
 
-extern REGISTRY_PERSON_URL *registry_person_url_allocate(REGISTRY_PERSON *p, REGISTRY_MACHINE *m, REGISTRY_URL *u, char *name, size_t namelen, time_t when);
-extern REGISTRY_PERSON_URL *registry_person_url_reallocate(REGISTRY_PERSON *p, REGISTRY_MACHINE *m, REGISTRY_URL *u, char *name, size_t namelen, time_t when, REGISTRY_PERSON_URL *pu);
+REGISTRY_PERSON_URL *registry_person_url_allocate(REGISTRY_PERSON *p, REGISTRY_MACHINE *m, REGISTRY_URL *u, char *name, size_t namelen, time_t when);
+REGISTRY_PERSON_URL *registry_person_url_reallocate(REGISTRY_PERSON *p, REGISTRY_MACHINE *m, REGISTRY_URL *u, char *name, size_t namelen, time_t when, REGISTRY_PERSON_URL *pu);
 
 // PERSON
-extern REGISTRY_PERSON *registry_person_find(const char *person_guid);
-extern REGISTRY_PERSON *registry_person_allocate(const char *person_guid, time_t when);
-extern REGISTRY_PERSON *registry_person_get(const char *person_guid, time_t when);
+REGISTRY_PERSON *registry_person_find(const char *person_guid);
+REGISTRY_PERSON *registry_person_allocate(const char *person_guid, time_t when);
+REGISTRY_PERSON *registry_person_get(const char *person_guid, time_t when);
 
 // LINKING PERSON -> PERSON_URL
-extern REGISTRY_PERSON_URL *registry_person_link_to_url(REGISTRY_PERSON *p, REGISTRY_MACHINE *m, REGISTRY_URL *u, char *name, size_t namelen, time_t when);
-extern void registry_person_unlink_from_url(REGISTRY_PERSON *p, REGISTRY_PERSON_URL *pu);
+REGISTRY_PERSON_URL *registry_person_link_to_url(REGISTRY_PERSON *p, REGISTRY_MACHINE *m, REGISTRY_URL *u, char *name, size_t namelen, time_t when);
+void registry_person_unlink_from_url(REGISTRY_PERSON *p, REGISTRY_PERSON_URL *pu);
 
 #endif //NETDATA_REGISTRY_PERSON_H

--- a/registry/registry_url.h
+++ b/registry/registry_url.h
@@ -23,13 +23,13 @@ struct registry_url {
 typedef struct registry_url REGISTRY_URL;
 
 // REGISTRY_URL INDEX
-extern int registry_url_compare(void *a, void *b);
-extern REGISTRY_URL *registry_url_index_del(REGISTRY_URL *u) WARNUNUSED;
-extern REGISTRY_URL *registry_url_index_add(REGISTRY_URL *u) NEVERNULL WARNUNUSED;
+int registry_url_compare(void *a, void *b);
+REGISTRY_URL *registry_url_index_del(REGISTRY_URL *u) WARNUNUSED;
+REGISTRY_URL *registry_url_index_add(REGISTRY_URL *u) NEVERNULL WARNUNUSED;
 
 // REGISTRY_URL MANAGEMENT
-extern REGISTRY_URL *registry_url_get(const char *url, size_t urllen) NEVERNULL;
-extern void registry_url_link(REGISTRY_URL *u);
-extern void registry_url_unlink(REGISTRY_URL *u);
+REGISTRY_URL *registry_url_get(const char *url, size_t urllen) NEVERNULL;
+void registry_url_link(REGISTRY_URL *u);
+void registry_url_unlink(REGISTRY_URL *u);
 
 #endif //NETDATA_REGISTRY_URL_H

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -220,28 +220,28 @@ extern char *default_rrdpush_api_key;
 extern char *default_rrdpush_send_charts_matching;
 extern unsigned int remote_clock_resync_iterations;
 
-extern void rrdpush_destinations_init(RRDHOST *host);
-extern void rrdpush_destinations_free(RRDHOST *host);
+void rrdpush_destinations_init(RRDHOST *host);
+void rrdpush_destinations_free(RRDHOST *host);
 
-extern void sender_init(RRDHOST *parent);
+void sender_init(RRDHOST *parent);
 BUFFER *sender_start(struct sender_state *s);
 void sender_commit(struct sender_state *s, BUFFER *wb);
 void sender_cancel(struct sender_state *s);
-extern int rrdpush_init();
-extern int configured_as_parent();
-extern void rrdset_done_push(RRDSET *st);
-extern bool rrdset_push_chart_definition_now(RRDSET *st);
-extern bool rrdpush_incremental_transmission_of_chart_definitions(RRDHOST *host, DICTFE *dictfe, bool restart, bool stop);
-extern void *rrdpush_sender_thread(void *ptr);
-extern void rrdpush_send_host_labels(RRDHOST *host);
-extern void rrdpush_claimed_id(RRDHOST *host);
+int rrdpush_init();
+int configured_as_parent();
+void rrdset_done_push(RRDSET *st);
+bool rrdset_push_chart_definition_now(RRDSET *st);
+bool rrdpush_incremental_transmission_of_chart_definitions(RRDHOST *host, DICTFE *dictfe, bool restart, bool stop);
+void *rrdpush_sender_thread(void *ptr);
+void rrdpush_send_host_labels(RRDHOST *host);
+void rrdpush_claimed_id(RRDHOST *host);
 
-extern int rrdpush_receiver_thread_spawn(struct web_client *w, char *url);
-extern void rrdpush_sender_thread_stop(RRDHOST *host);
+int rrdpush_receiver_thread_spawn(struct web_client *w, char *url);
+void rrdpush_sender_thread_stop(RRDHOST *host);
 
-extern void rrdpush_sender_send_this_host_variable_now(RRDHOST *host, const RRDVAR_ACQUIRED *rva);
-extern void log_stream_connection(const char *client_ip, const char *client_port, const char *api_key, const char *machine_guid, const char *host, const char *msg);
-extern int connect_to_one_of_destinations(
+void rrdpush_sender_send_this_host_variable_now(RRDHOST *host, const RRDVAR_ACQUIRED *rva);
+void log_stream_connection(const char *client_ip, const char *client_port, const char *api_key, const char *machine_guid, const char *host, const char *msg);
+int connect_to_one_of_destinations(
     RRDHOST *host,
     int default_port,
     struct timeval *timeout,
@@ -250,7 +250,7 @@ extern int connect_to_one_of_destinations(
     size_t connected_to_size,
     struct rrdpush_destinations **destination);
 
-extern void rrdpush_signal_sender_to_wake_up(struct sender_state *s);
+void rrdpush_signal_sender_to_wake_up(struct sender_state *s);
 
 #ifdef ENABLE_COMPRESSION
 struct compressor_state *create_compressor();
@@ -258,9 +258,9 @@ struct decompressor_state *create_decompressor();
 size_t is_compressed_data(const char *data, size_t data_size);
 #endif
 
-extern void log_receiver_capabilities(struct receiver_state *rpt);
-extern void log_sender_capabilities(struct sender_state *s);
-extern STREAM_CAPABILITIES convert_stream_version_to_capabilities(int32_t version);
-extern int32_t stream_capabilities_to_vn(uint32_t caps);
+void log_receiver_capabilities(struct receiver_state *rpt);
+void log_sender_capabilities(struct sender_state *s);
+STREAM_CAPABILITIES convert_stream_version_to_capabilities(int32_t version);
+int32_t stream_capabilities_to_vn(uint32_t caps);
 
 #endif //NETDATA_RRDPUSH_H

--- a/web/api/badges/web_buffer_svg.h
+++ b/web/api/badges/web_buffer_svg.h
@@ -6,12 +6,12 @@
 #include "libnetdata/libnetdata.h"
 #include "web/server/web_client.h"
 
-extern void buffer_svg(BUFFER *wb, const char *label,
+void buffer_svg(BUFFER *wb, const char *label,
     NETDATA_DOUBLE value, const char *units, const char *label_color, const char *value_color, int precision, int scale, uint32_t options, int fixed_width_lbl, int fixed_width_val, const char* text_color_lbl, const char* text_color_val);
-extern char *format_value_and_unit(char *value_string, size_t value_string_len,
+char *format_value_and_unit(char *value_string, size_t value_string_len,
     NETDATA_DOUBLE value, const char *units, int precision);
 
-extern int web_client_api_request_v1_badge(struct rrdhost *host, struct web_client *w, char *url);
+int web_client_api_request_v1_badge(struct rrdhost *host, struct web_client *w, char *url);
 
 #include "web/api/web_api_v1.h"
 

--- a/web/api/exporters/allmetrics.h
+++ b/web/api/exporters/allmetrics.h
@@ -7,6 +7,6 @@
 #include "shell/allmetrics_shell.h"
 #include "web/server/web_client.h"
 
-extern int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client *w, char *url);
+int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client *w, char *url);
 
 #endif //NETDATA_API_ALLMETRICS_H

--- a/web/api/exporters/shell/allmetrics_shell.h
+++ b/web/api/exporters/shell/allmetrics_shell.h
@@ -15,7 +15,7 @@
 #define ALLMETRICS_JSON                         3
 #define ALLMETRICS_PROMETHEUS_ALL_HOSTS         4
 
-extern void rrd_stats_api_v1_charts_allmetrics_json(RRDHOST *host, const char *filter_string, BUFFER *wb);
-extern void rrd_stats_api_v1_charts_allmetrics_shell(RRDHOST *host, const char *filter_string, BUFFER *wb);
+void rrd_stats_api_v1_charts_allmetrics_json(RRDHOST *host, const char *filter_string, BUFFER *wb);
+void rrd_stats_api_v1_charts_allmetrics_shell(RRDHOST *host, const char *filter_string, BUFFER *wb);
 
 #endif //NETDATA_API_ALLMETRICS_SHELL_H

--- a/web/api/formatters/charts2json.h
+++ b/web/api/formatters/charts2json.h
@@ -5,8 +5,8 @@
 
 #include "rrd2json.h"
 
-extern void charts2json(RRDHOST *host, BUFFER *wb, int skip_volatile, int show_archived);
-extern void chartcollectors2json(RRDHOST *host, BUFFER *wb);
-extern const char* get_release_channel();
+void charts2json(RRDHOST *host, BUFFER *wb, int skip_volatile, int show_archived);
+void chartcollectors2json(RRDHOST *host, BUFFER *wb);
+const char* get_release_channel();
 
 #endif //NETDATA_API_FORMATTER_CHARTS2JSON_H

--- a/web/api/formatters/csv/csv.h
+++ b/web/api/formatters/csv/csv.h
@@ -5,7 +5,7 @@
 
 #include "web/api/queries/rrdr.h"
 
-extern void rrdr2csv(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, const char *startline, const char *separator, const char *endline, const char *betweenlines, RRDDIM *temp_rd);
+void rrdr2csv(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, const char *startline, const char *separator, const char *endline, const char *betweenlines, RRDDIM *temp_rd);
 
 #include "../rrd2json.h"
 

--- a/web/api/formatters/json/json.h
+++ b/web/api/formatters/json/json.h
@@ -5,6 +5,6 @@
 
 #include "../rrd2json.h"
 
-extern void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable, struct context_param *context_param_list);
+void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable, struct context_param *context_param_list);
 
 #endif //NETDATA_API_FORMATTER_JSON_H

--- a/web/api/formatters/json_wrapper.h
+++ b/web/api/formatters/json_wrapper.h
@@ -7,9 +7,9 @@
 #include "web/api/queries/query.h"
 
 
-extern void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, int string_value,
+void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, int string_value,
     RRDR_GROUPING group_method, QUERY_PARAMS *query_params);
-extern void rrdr_json_wrapper_anomaly_rates(RRDR *r, BUFFER *wb, uint32_t format, uint32_t options, int string_value);
-extern void rrdr_json_wrapper_end(RRDR *r, BUFFER *wb, uint32_t format, uint32_t options, int string_value);
+void rrdr_json_wrapper_anomaly_rates(RRDR *r, BUFFER *wb, uint32_t format, uint32_t options, int string_value);
+void rrdr_json_wrapper_end(RRDR *r, BUFFER *wb, uint32_t format, uint32_t options, int string_value);
 
 #endif //NETDATA_API_FORMATTER_JSON_WRAPPER_H

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -61,10 +61,10 @@ typedef struct query_params {
 #define DATASOURCE_FORMAT_CSV_JSON_ARRAY "csvjsonarray"
 #define DATASOURCE_FORMAT_CSV_MARKDOWN "markdown"
 
-extern void rrd_stats_api_v1_chart(RRDSET *st, BUFFER *wb);
-extern void rrdr_buffer_print_format(BUFFER *wb, uint32_t format);
+void rrd_stats_api_v1_chart(RRDSET *st, BUFFER *wb);
+void rrdr_buffer_print_format(BUFFER *wb, uint32_t format);
 
-extern int rrdset2anything_api_v1(
+int rrdset2anything_api_v1(
           ONEWAYALLOC *owa
         , RRDSET *st
         , QUERY_PARAMS *query_params
@@ -81,7 +81,7 @@ extern int rrdset2anything_api_v1(
         , int tier
 );
 
-extern int rrdset2value_api_v1(
+int rrdset2value_api_v1(
           RRDSET *st
         , BUFFER *wb
         , NETDATA_DOUBLE *n
@@ -104,8 +104,8 @@ extern int rrdset2value_api_v1(
         , int tier
 );
 
-extern void build_context_param_list(ONEWAYALLOC *owa, struct context_param **param_list, RRDSET *st);
-extern void rebuild_context_param_list(ONEWAYALLOC *owa, struct context_param *context_param_list, time_t after_requested);
-extern void free_context_param_list(ONEWAYALLOC *owa, struct context_param **param_list);
+void build_context_param_list(ONEWAYALLOC *owa, struct context_param **param_list, RRDSET *st);
+void rebuild_context_param_list(ONEWAYALLOC *owa, struct context_param *context_param_list, time_t after_requested);
+void free_context_param_list(ONEWAYALLOC *owa, struct context_param **param_list);
 
 #endif /* NETDATA_RRD2JSON_H */

--- a/web/api/formatters/rrdset2json.h
+++ b/web/api/formatters/rrdset2json.h
@@ -5,6 +5,6 @@
 
 #include "rrd2json.h"
 
-extern void rrdset2json(RRDSET *st, BUFFER *wb, size_t *dimensions_count, size_t *memory_used, int skip_volatile);
+void rrdset2json(RRDSET *st, BUFFER *wb, size_t *dimensions_count, size_t *memory_used, int skip_volatile);
 
 #endif //NETDATA_API_FORMATTER_RRDSET2JSON_H

--- a/web/api/formatters/ssv/ssv.h
+++ b/web/api/formatters/ssv/ssv.h
@@ -5,6 +5,6 @@
 
 #include "../rrd2json.h"
 
-extern void rrdr2ssv(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, const char *prefix, const char *separator, const char *suffix, RRDDIM *temp_rd);
+void rrdr2ssv(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, const char *prefix, const char *separator, const char *suffix, RRDDIM *temp_rd);
 
 #endif //NETDATA_API_FORMATTER_SSV_H

--- a/web/api/formatters/value/value.h
+++ b/web/api/formatters/value/value.h
@@ -5,6 +5,6 @@
 
 #include "../rrd2json.h"
 
-extern NETDATA_DOUBLE rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all_values_are_null, NETDATA_DOUBLE *anomaly_rate, RRDDIM *temp_rd);
+NETDATA_DOUBLE rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all_values_are_null, NETDATA_DOUBLE *anomaly_rate, RRDDIM *temp_rd);
 
 #endif //NETDATA_API_FORMATTER_VALUE_H

--- a/web/api/health/health_cmdapi.h
+++ b/web/api/health/health_cmdapi.h
@@ -24,7 +24,7 @@
 #define HEALTH_CMDAPI_MSG_STYPEWARNING "WARNING: Added alarm selector to silence/disable alarms without a SILENCE or DISABLE command.\n"
 #define HEALTH_CMDAPI_MSG_NOSELECTORWARNING "WARNING: SILENCE or DISABLE command is ineffective without defining any alarm selectors.\n"
 
-extern int web_client_api_request_v1_mgmt_health(RRDHOST *host, struct web_client *w, char *url);
+int web_client_api_request_v1_mgmt_health(RRDHOST *host, struct web_client *w, char *url);
 
 #include "web/api/web_api_v1.h"
 

--- a/web/api/queries/average/average.h
+++ b/web/api/queries/average/average.h
@@ -6,10 +6,10 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void grouping_create_average(RRDR *r, const char *options __maybe_unused);
-extern void grouping_reset_average(RRDR *r);
-extern void grouping_free_average(RRDR *r);
-extern void grouping_add_average(RRDR *r, NETDATA_DOUBLE value);
-extern NETDATA_DOUBLE grouping_flush_average(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
+void grouping_create_average(RRDR *r, const char *options __maybe_unused);
+void grouping_reset_average(RRDR *r);
+void grouping_free_average(RRDR *r);
+void grouping_add_average(RRDR *r, NETDATA_DOUBLE value);
+NETDATA_DOUBLE grouping_flush_average(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
 
 #endif //NETDATA_API_QUERY_AVERAGE_H

--- a/web/api/queries/countif/countif.h
+++ b/web/api/queries/countif/countif.h
@@ -6,10 +6,10 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void grouping_create_countif(RRDR *r, const char *options __maybe_unused);
-extern void grouping_reset_countif(RRDR *r);
-extern void grouping_free_countif(RRDR *r);
-extern void grouping_add_countif(RRDR *r, NETDATA_DOUBLE value);
-extern NETDATA_DOUBLE grouping_flush_countif(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
+void grouping_create_countif(RRDR *r, const char *options __maybe_unused);
+void grouping_reset_countif(RRDR *r);
+void grouping_free_countif(RRDR *r);
+void grouping_add_countif(RRDR *r, NETDATA_DOUBLE value);
+NETDATA_DOUBLE grouping_flush_countif(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
 
 #endif //NETDATA_API_QUERY_COUNTIF_H

--- a/web/api/queries/des/des.h
+++ b/web/api/queries/des/des.h
@@ -6,12 +6,12 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void grouping_init_des(void);
+void grouping_init_des(void);
 
-extern void grouping_create_des(RRDR *r, const char *options __maybe_unused);
-extern void grouping_reset_des(RRDR *r);
-extern void grouping_free_des(RRDR *r);
-extern void grouping_add_des(RRDR *r, NETDATA_DOUBLE value);
-extern NETDATA_DOUBLE grouping_flush_des(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
+void grouping_create_des(RRDR *r, const char *options __maybe_unused);
+void grouping_reset_des(RRDR *r);
+void grouping_free_des(RRDR *r);
+void grouping_add_des(RRDR *r, NETDATA_DOUBLE value);
+NETDATA_DOUBLE grouping_flush_des(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
 
 #endif //NETDATA_API_QUERIES_DES_H

--- a/web/api/queries/incremental_sum/incremental_sum.h
+++ b/web/api/queries/incremental_sum/incremental_sum.h
@@ -6,10 +6,10 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void grouping_create_incremental_sum(RRDR *r, const char *options __maybe_unused);
-extern void grouping_reset_incremental_sum(RRDR *r);
-extern void grouping_free_incremental_sum(RRDR *r);
-extern void grouping_add_incremental_sum(RRDR *r, NETDATA_DOUBLE value);
-extern NETDATA_DOUBLE grouping_flush_incremental_sum(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
+void grouping_create_incremental_sum(RRDR *r, const char *options __maybe_unused);
+void grouping_reset_incremental_sum(RRDR *r);
+void grouping_free_incremental_sum(RRDR *r);
+void grouping_add_incremental_sum(RRDR *r, NETDATA_DOUBLE value);
+NETDATA_DOUBLE grouping_flush_incremental_sum(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
 
 #endif //NETDATA_API_QUERY_INCREMENTAL_SUM_H

--- a/web/api/queries/max/max.h
+++ b/web/api/queries/max/max.h
@@ -6,10 +6,10 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void grouping_create_max(RRDR *r, const char *options __maybe_unused);
-extern void grouping_reset_max(RRDR *r);
-extern void grouping_free_max(RRDR *r);
-extern void grouping_add_max(RRDR *r, NETDATA_DOUBLE value);
-extern NETDATA_DOUBLE grouping_flush_max(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
+void grouping_create_max(RRDR *r, const char *options __maybe_unused);
+void grouping_reset_max(RRDR *r);
+void grouping_free_max(RRDR *r);
+void grouping_add_max(RRDR *r, NETDATA_DOUBLE value);
+NETDATA_DOUBLE grouping_flush_max(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
 
 #endif //NETDATA_API_QUERY_MAX_H

--- a/web/api/queries/median/median.h
+++ b/web/api/queries/median/median.h
@@ -6,18 +6,18 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void grouping_create_median(RRDR *r, const char *options);
-extern void grouping_create_trimmed_median1(RRDR *r, const char *options);
-extern void grouping_create_trimmed_median2(RRDR *r, const char *options);
-extern void grouping_create_trimmed_median3(RRDR *r, const char *options);
-extern void grouping_create_trimmed_median5(RRDR *r, const char *options);
-extern void grouping_create_trimmed_median10(RRDR *r, const char *options);
-extern void grouping_create_trimmed_median15(RRDR *r, const char *options);
-extern void grouping_create_trimmed_median20(RRDR *r, const char *options);
-extern void grouping_create_trimmed_median25(RRDR *r, const char *options);
-extern void grouping_reset_median(RRDR *r);
-extern void grouping_free_median(RRDR *r);
-extern void grouping_add_median(RRDR *r, NETDATA_DOUBLE value);
-extern NETDATA_DOUBLE grouping_flush_median(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
+void grouping_create_median(RRDR *r, const char *options);
+void grouping_create_trimmed_median1(RRDR *r, const char *options);
+void grouping_create_trimmed_median2(RRDR *r, const char *options);
+void grouping_create_trimmed_median3(RRDR *r, const char *options);
+void grouping_create_trimmed_median5(RRDR *r, const char *options);
+void grouping_create_trimmed_median10(RRDR *r, const char *options);
+void grouping_create_trimmed_median15(RRDR *r, const char *options);
+void grouping_create_trimmed_median20(RRDR *r, const char *options);
+void grouping_create_trimmed_median25(RRDR *r, const char *options);
+void grouping_reset_median(RRDR *r);
+void grouping_free_median(RRDR *r);
+void grouping_add_median(RRDR *r, NETDATA_DOUBLE value);
+NETDATA_DOUBLE grouping_flush_median(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
 
 #endif //NETDATA_API_QUERIES_MEDIAN_H

--- a/web/api/queries/min/min.h
+++ b/web/api/queries/min/min.h
@@ -6,10 +6,10 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void grouping_create_min(RRDR *r, const char *options __maybe_unused);
-extern void grouping_reset_min(RRDR *r);
-extern void grouping_free_min(RRDR *r);
-extern void grouping_add_min(RRDR *r, NETDATA_DOUBLE value);
-extern NETDATA_DOUBLE grouping_flush_min(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
+void grouping_create_min(RRDR *r, const char *options __maybe_unused);
+void grouping_reset_min(RRDR *r);
+void grouping_free_min(RRDR *r);
+void grouping_add_min(RRDR *r, NETDATA_DOUBLE value);
+NETDATA_DOUBLE grouping_flush_min(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
 
 #endif //NETDATA_API_QUERY_MIN_H

--- a/web/api/queries/percentile/percentile.h
+++ b/web/api/queries/percentile/percentile.h
@@ -6,18 +6,18 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void grouping_create_percentile25(RRDR *r, const char *options);
-extern void grouping_create_percentile50(RRDR *r, const char *options);
-extern void grouping_create_percentile75(RRDR *r, const char *options);
-extern void grouping_create_percentile80(RRDR *r, const char *options);
-extern void grouping_create_percentile90(RRDR *r, const char *options);
-extern void grouping_create_percentile95(RRDR *r, const char *options);
-extern void grouping_create_percentile97(RRDR *r, const char *options);
-extern void grouping_create_percentile98(RRDR *r, const char *options);
-extern void grouping_create_percentile99(RRDR *r, const char *options );
-extern void grouping_reset_percentile(RRDR *r);
-extern void grouping_free_percentile(RRDR *r);
-extern void grouping_add_percentile(RRDR *r, NETDATA_DOUBLE value);
-extern NETDATA_DOUBLE grouping_flush_percentile(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
+void grouping_create_percentile25(RRDR *r, const char *options);
+void grouping_create_percentile50(RRDR *r, const char *options);
+void grouping_create_percentile75(RRDR *r, const char *options);
+void grouping_create_percentile80(RRDR *r, const char *options);
+void grouping_create_percentile90(RRDR *r, const char *options);
+void grouping_create_percentile95(RRDR *r, const char *options);
+void grouping_create_percentile97(RRDR *r, const char *options);
+void grouping_create_percentile98(RRDR *r, const char *options);
+void grouping_create_percentile99(RRDR *r, const char *options );
+void grouping_reset_percentile(RRDR *r);
+void grouping_free_percentile(RRDR *r);
+void grouping_add_percentile(RRDR *r, NETDATA_DOUBLE value);
+NETDATA_DOUBLE grouping_flush_percentile(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
 
 #endif //NETDATA_API_QUERIES_PERCENTILE_H

--- a/web/api/queries/query.h
+++ b/web/api/queries/query.h
@@ -47,10 +47,10 @@ typedef enum rrdr_grouping {
     RRDR_GROUPING_COUNTIF,
 } RRDR_GROUPING;
 
-extern const char *group_method2string(RRDR_GROUPING group);
-extern void web_client_api_v1_init_grouping(void);
-extern RRDR_GROUPING web_client_api_request_v1_data_group(const char *name, RRDR_GROUPING def);
-extern const char *web_client_api_request_v1_data_group_to_string(RRDR_GROUPING group);
+const char *group_method2string(RRDR_GROUPING group);
+void web_client_api_v1_init_grouping(void);
+RRDR_GROUPING web_client_api_request_v1_data_group(const char *name, RRDR_GROUPING def);
+const char *web_client_api_request_v1_data_group_to_string(RRDR_GROUPING group);
 
 #ifdef __cplusplus
 }

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -128,20 +128,20 @@ typedef struct rrdresult {
 #define rrdr_rows(r) ((r)->rows)
 
 #include "database/rrd.h"
-extern void rrdr_free(ONEWAYALLOC *owa, RRDR *r);
-extern RRDR *rrdr_create(ONEWAYALLOC *owa, struct rrdset *st, long n, struct context_param *context_param_list);
-extern RRDR *rrdr_create_for_x_dimensions(ONEWAYALLOC *owa, int dimensions, long points);
+void rrdr_free(ONEWAYALLOC *owa, RRDR *r);
+RRDR *rrdr_create(ONEWAYALLOC *owa, struct rrdset *st, long n, struct context_param *context_param_list);
+RRDR *rrdr_create_for_x_dimensions(ONEWAYALLOC *owa, int dimensions, long points);
 
 #include "../web_api_v1.h"
 #include "web/api/queries/query.h"
 
-extern RRDR *rrd2rrdr(
+RRDR *rrd2rrdr(
     ONEWAYALLOC *owa,
     RRDSET *st, long points_wanted, long long after_wanted, long long before_wanted,
     RRDR_GROUPING group_method, long resampling_time_requested, RRDR_OPTIONS options, const char *dimensions,
     struct context_param *context_param_list, const char *group_options, int timeout, int tier);
 
-extern int rrdr_relative_window_to_absolute(long long *after, long long *before);
+int rrdr_relative_window_to_absolute(long long *after, long long *before);
 
 #ifdef __cplusplus
 }

--- a/web/api/queries/ses/ses.h
+++ b/web/api/queries/ses/ses.h
@@ -6,12 +6,12 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void grouping_init_ses(void);
+void grouping_init_ses(void);
 
-extern void grouping_create_ses(RRDR *r, const char *options __maybe_unused);
-extern void grouping_reset_ses(RRDR *r);
-extern void grouping_free_ses(RRDR *r);
-extern void grouping_add_ses(RRDR *r, NETDATA_DOUBLE value);
-extern NETDATA_DOUBLE grouping_flush_ses(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
+void grouping_create_ses(RRDR *r, const char *options __maybe_unused);
+void grouping_reset_ses(RRDR *r);
+void grouping_free_ses(RRDR *r);
+void grouping_add_ses(RRDR *r, NETDATA_DOUBLE value);
+NETDATA_DOUBLE grouping_flush_ses(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
 
 #endif //NETDATA_API_QUERIES_SES_H

--- a/web/api/queries/stddev/stddev.h
+++ b/web/api/queries/stddev/stddev.h
@@ -6,13 +6,13 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void grouping_create_stddev(RRDR *r, const char *options __maybe_unused);
-extern void grouping_reset_stddev(RRDR *r);
-extern void grouping_free_stddev(RRDR *r);
-extern void grouping_add_stddev(RRDR *r, NETDATA_DOUBLE value);
-extern NETDATA_DOUBLE grouping_flush_stddev(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
-extern NETDATA_DOUBLE grouping_flush_coefficient_of_variation(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
-// extern NETDATA_DOUBLE grouping_flush_mean(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
-// extern NETDATA_DOUBLE grouping_flush_variance(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
+void grouping_create_stddev(RRDR *r, const char *options __maybe_unused);
+void grouping_reset_stddev(RRDR *r);
+void grouping_free_stddev(RRDR *r);
+void grouping_add_stddev(RRDR *r, NETDATA_DOUBLE value);
+NETDATA_DOUBLE grouping_flush_stddev(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
+NETDATA_DOUBLE grouping_flush_coefficient_of_variation(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
+// NETDATA_DOUBLE grouping_flush_mean(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
+// NETDATA_DOUBLE grouping_flush_variance(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
 
 #endif //NETDATA_API_QUERIES_STDDEV_H

--- a/web/api/queries/sum/sum.h
+++ b/web/api/queries/sum/sum.h
@@ -6,10 +6,10 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void grouping_create_sum(RRDR *r, const char *options __maybe_unused);
-extern void grouping_reset_sum(RRDR *r);
-extern void grouping_free_sum(RRDR *r);
-extern void grouping_add_sum(RRDR *r, NETDATA_DOUBLE value);
-extern NETDATA_DOUBLE grouping_flush_sum(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
+void grouping_create_sum(RRDR *r, const char *options __maybe_unused);
+void grouping_reset_sum(RRDR *r);
+void grouping_free_sum(RRDR *r);
+void grouping_add_sum(RRDR *r, NETDATA_DOUBLE value);
+NETDATA_DOUBLE grouping_flush_sum(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
 
 #endif //NETDATA_API_QUERY_SUM_H

--- a/web/api/queries/trimmed_mean/trimmed_mean.h
+++ b/web/api/queries/trimmed_mean/trimmed_mean.h
@@ -6,17 +6,17 @@
 #include "../query.h"
 #include "../rrdr.h"
 
-extern void grouping_create_trimmed_mean1(RRDR *r, const char *options);
-extern void grouping_create_trimmed_mean2(RRDR *r, const char *options);
-extern void grouping_create_trimmed_mean3(RRDR *r, const char *options);
-extern void grouping_create_trimmed_mean5(RRDR *r, const char *options);
-extern void grouping_create_trimmed_mean10(RRDR *r, const char *options);
-extern void grouping_create_trimmed_mean15(RRDR *r, const char *options);
-extern void grouping_create_trimmed_mean20(RRDR *r, const char *options);
-extern void grouping_create_trimmed_mean25(RRDR *r, const char *options);
-extern void grouping_reset_trimmed_mean(RRDR *r);
-extern void grouping_free_trimmed_mean(RRDR *r);
-extern void grouping_add_trimmed_mean(RRDR *r, NETDATA_DOUBLE value);
-extern NETDATA_DOUBLE grouping_flush_trimmed_mean(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
+void grouping_create_trimmed_mean1(RRDR *r, const char *options);
+void grouping_create_trimmed_mean2(RRDR *r, const char *options);
+void grouping_create_trimmed_mean3(RRDR *r, const char *options);
+void grouping_create_trimmed_mean5(RRDR *r, const char *options);
+void grouping_create_trimmed_mean10(RRDR *r, const char *options);
+void grouping_create_trimmed_mean15(RRDR *r, const char *options);
+void grouping_create_trimmed_mean20(RRDR *r, const char *options);
+void grouping_create_trimmed_mean25(RRDR *r, const char *options);
+void grouping_reset_trimmed_mean(RRDR *r);
+void grouping_free_trimmed_mean(RRDR *r);
+void grouping_add_trimmed_mean(RRDR *r, NETDATA_DOUBLE value);
+NETDATA_DOUBLE grouping_flush_trimmed_mean(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
 
 #endif //NETDATA_API_QUERIES_TRIMMED_MEAN_H

--- a/web/api/queries/weights.h
+++ b/web/api/queries/weights.h
@@ -20,14 +20,14 @@ extern int enable_metric_correlations;
 extern int metric_correlations_version;
 extern WEIGHTS_METHOD default_metric_correlations_method;
 
-extern int web_api_v1_weights (RRDHOST *host, BUFFER *wb, WEIGHTS_METHOD method, WEIGHTS_FORMAT format,
+int web_api_v1_weights (RRDHOST *host, BUFFER *wb, WEIGHTS_METHOD method, WEIGHTS_FORMAT format,
                                RRDR_GROUPING group, const char *group_options,
                                long long baseline_after, long long baseline_before,
                                long long after, long long before,
                                long long points, RRDR_OPTIONS options, SIMPLE_PATTERN *contexts, int tier, int timeout);
 
-extern WEIGHTS_METHOD weights_string_to_method(const char *method);
-extern const char *weights_method_to_string(WEIGHTS_METHOD method);
-extern int mc_unittest(void);
+WEIGHTS_METHOD weights_string_to_method(const char *method);
+const char *weights_method_to_string(WEIGHTS_METHOD method);
+int mc_unittest(void);
 
 #endif //NETDATA_API_WEIGHTS_H

--- a/web/api/web_api_v1.h
+++ b/web/api/web_api_v1.h
@@ -10,30 +10,30 @@
 #include "web/api/queries/weights.h"
 
 #define MAX_CHART_LABELS_FILTER (32)
-extern RRDR_OPTIONS web_client_api_request_v1_data_options(char *o);
-extern void web_client_api_request_v1_data_options_to_string(BUFFER *wb, RRDR_OPTIONS options);
+RRDR_OPTIONS web_client_api_request_v1_data_options(char *o);
+void web_client_api_request_v1_data_options_to_string(BUFFER *wb, RRDR_OPTIONS options);
 
-extern uint32_t web_client_api_request_v1_data_format(char *name);
-extern uint32_t web_client_api_request_v1_data_google_format(char *name);
+uint32_t web_client_api_request_v1_data_format(char *name);
+uint32_t web_client_api_request_v1_data_google_format(char *name);
 
-extern int web_client_api_request_v1_alarms(RRDHOST *host, struct web_client *w, char *url);
-extern int web_client_api_request_v1_alarms_values(RRDHOST *host, struct web_client *w, char *url);
-extern int web_client_api_request_v1_alarm_log(RRDHOST *host, struct web_client *w, char *url);
-extern int web_client_api_request_single_chart(RRDHOST *host, struct web_client *w, char *url, void callback(RRDSET *st, BUFFER *buf));
-extern int web_client_api_request_v1_alarm_variables(RRDHOST *host, struct web_client *w, char *url);
-extern int web_client_api_request_v1_alarm_count(RRDHOST *host, struct web_client *w, char *url);
-extern int web_client_api_request_v1_charts(RRDHOST *host, struct web_client *w, char *url);
-extern int web_client_api_request_v1_archivedcharts(RRDHOST *host, struct web_client *w, char *url);
-extern int web_client_api_request_v1_chart(RRDHOST *host, struct web_client *w, char *url);
-extern int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, char *url);
-extern int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *w, char *url);
-extern int web_client_api_request_v1_info(RRDHOST *host, struct web_client *w, char *url);
-extern int web_client_api_request_v1(RRDHOST *host, struct web_client *w, char *url);
-extern int web_client_api_request_v1_info_fill_buffer(RRDHOST *host, BUFFER *wb);
-extern void host_labels2json(RRDHOST *host, BUFFER *wb, size_t indentation);
+int web_client_api_request_v1_alarms(RRDHOST *host, struct web_client *w, char *url);
+int web_client_api_request_v1_alarms_values(RRDHOST *host, struct web_client *w, char *url);
+int web_client_api_request_v1_alarm_log(RRDHOST *host, struct web_client *w, char *url);
+int web_client_api_request_single_chart(RRDHOST *host, struct web_client *w, char *url, void callback(RRDSET *st, BUFFER *buf));
+int web_client_api_request_v1_alarm_variables(RRDHOST *host, struct web_client *w, char *url);
+int web_client_api_request_v1_alarm_count(RRDHOST *host, struct web_client *w, char *url);
+int web_client_api_request_v1_charts(RRDHOST *host, struct web_client *w, char *url);
+int web_client_api_request_v1_archivedcharts(RRDHOST *host, struct web_client *w, char *url);
+int web_client_api_request_v1_chart(RRDHOST *host, struct web_client *w, char *url);
+int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, char *url);
+int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *w, char *url);
+int web_client_api_request_v1_info(RRDHOST *host, struct web_client *w, char *url);
+int web_client_api_request_v1(RRDHOST *host, struct web_client *w, char *url);
+int web_client_api_request_v1_info_fill_buffer(RRDHOST *host, BUFFER *wb);
+void host_labels2json(RRDHOST *host, BUFFER *wb, size_t indentation);
 
-extern void web_client_api_v1_init(void);
-extern void web_client_api_v1_management_init(void);
+void web_client_api_v1_init(void);
+void web_client_api_v1_management_init(void);
 
 extern char *api_secret;
 

--- a/web/server/static/static-threaded.h
+++ b/web/server/static/static-threaded.h
@@ -5,6 +5,6 @@
 
 #include "web/server/web_server.h"
 
-extern void *socket_listen_main_static_threaded(void *ptr);
+void *socket_listen_main_static_threaded(void *ptr);
 
 #endif //NETDATA_WEB_SERVER_STATIC_THREADED_H

--- a/web/server/web_client.h
+++ b/web/server/web_client.h
@@ -190,21 +190,21 @@ struct web_client {
 #endif
 };
 
-extern int web_client_permission_denied(struct web_client *w);
+int web_client_permission_denied(struct web_client *w);
 
-extern ssize_t web_client_send(struct web_client *w);
-extern ssize_t web_client_receive(struct web_client *w);
-extern ssize_t web_client_read_file(struct web_client *w);
+ssize_t web_client_send(struct web_client *w);
+ssize_t web_client_receive(struct web_client *w);
+ssize_t web_client_read_file(struct web_client *w);
 
-extern void web_client_process_request(struct web_client *w);
-extern void web_client_request_done(struct web_client *w);
+void web_client_process_request(struct web_client *w);
+void web_client_request_done(struct web_client *w);
 
-extern void buffer_data_options2string(BUFFER *wb, uint32_t options);
+void buffer_data_options2string(BUFFER *wb, uint32_t options);
 
-extern int mysendfile(struct web_client *w, char *filename);
+int mysendfile(struct web_client *w, char *filename);
 
-extern void web_client_build_http_header(struct web_client *w);
-extern char *strip_control_characters(char *url);
+void web_client_build_http_header(struct web_client *w);
+char *strip_control_characters(char *url);
 
 #include "daemon/common.h"
 

--- a/web/server/web_client_cache.h
+++ b/web/server/web_client_cache.h
@@ -21,10 +21,10 @@ struct clients_cache {
 
 extern __thread struct clients_cache web_clients_cache;
 
-extern void web_client_release(struct web_client *w);
-extern struct web_client *web_client_get_from_cache_or_allocate();
-extern void web_client_cache_destroy(void);
-extern void web_client_cache_verify(int force);
+void web_client_release(struct web_client *w);
+struct web_client *web_client_get_from_cache_or_allocate();
+void web_client_cache_destroy(void);
+void web_client_cache_verify(int force);
 
 #include "web_server.h"
 

--- a/web/server/web_server.h
+++ b/web/server/web_server.h
@@ -36,10 +36,10 @@ extern int             web_allow_mgmt_dns;
 
 extern WEB_SERVER_MODE web_server_mode;
 
-extern WEB_SERVER_MODE web_server_mode_id(const char *mode);
-extern const char *web_server_mode_name(WEB_SERVER_MODE id);
+WEB_SERVER_MODE web_server_mode_id(const char *mode);
+const char *web_server_mode_name(WEB_SERVER_MODE id);
 
-extern void api_listen_sockets_setup(void);
+void api_listen_sockets_setup(void);
 
 #define DEFAULT_TIMEOUT_TO_RECEIVE_FIRST_WEB_REQUEST 60
 #define DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS 60
@@ -49,10 +49,10 @@ extern long web_client_streaming_rate_t;
 
 #ifdef WEB_SERVER_INTERNALS
 extern LISTEN_SOCKETS api_sockets;
-extern void web_client_update_acl_matches(struct web_client *w);
-extern void web_server_log_connection(struct web_client *w, const char *msg);
-extern void web_client_initialize_connection(struct web_client *w);
-extern struct web_client *web_client_create_on_listenfd(int listener);
+void web_client_update_acl_matches(struct web_client *w);
+void web_server_log_connection(struct web_client *w, const char *msg);
+void web_client_initialize_connection(struct web_client *w);
+struct web_client *web_client_create_on_listenfd(int listener);
 
 #include "web_client_cache.h"
 #endif // WEB_SERVER_INTERNALS


### PR DESCRIPTION
##### Summary

By default functions are declared as extern in C/C++ headers. The goal of this PR is to reduce the wall of text that many headers have and, more importantly, to make the declaration of extern'd variables - of which we have many dispersed in various places - easily and quickly identifiable.

Automatically generated with:

    $ git grep -l '^extern.*(' '**.h' | \
            grep -v libjudy | \
            grep -v 'sqlite3.h' | \
            xargs sed -i -e 's/extern \(.*(.*$\)/\1/'

This is a NFC.

##### Test Plan

- Built & run locally.
- CI jobs green.