### PR TITLE
Array Allocator Memory Leak Fix

### DIFF
--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -4,8 +4,8 @@
 #include "rrdengine.h"
 
 ARAL page_descr_aral = {
-    .element_size = sizeof(struct rrdeng_page_descr),
-    .elements = 20000,
+    .requested_element_size = sizeof(struct rrdeng_page_descr),
+    .initial_elements = 20000,
     .filename = "page_descriptors",
     .cache_dir = &netdata_configured_cache_dir,
     .use_mmap = false,

--- a/libnetdata/arrayalloc/arrayalloc.c
+++ b/libnetdata/arrayalloc/arrayalloc.c
@@ -32,6 +32,33 @@ static inline size_t natural_alignment(size_t size, size_t alignment) {
     return size;
 }
 
+static void arrayalloc_delete_leftover_files(const char *path, const char *required_prefix) {
+    DIR *dir = opendir(path);
+    if(!dir) return;
+
+    char fullpath[FILENAME_MAX + 1];
+    size_t len = strlen(required_prefix);
+
+    struct dirent *de = NULL;
+    while((de = readdir(dir))) {
+        if(de->d_type == DT_DIR)
+            continue;
+
+        if(strncmp(de->d_name, required_prefix, len) != 0)
+            continue;
+
+        snprintfz(fullpath, FILENAME_MAX, "%s/%s", path, de->d_name);
+        info("ARRAYALLOC: removing left-over file '%s'", fullpath);
+        if(unlikely(unlink(fullpath) == -1))
+            error("Cannot delete file '%s'", fullpath);
+    }
+
+    closedir(dir);
+}
+
+// ----------------------------------------------------------------------------
+// arrayalloc_init()
+
 static void arrayalloc_init(ARAL *ar) {
     static netdata_mutex_t mutex = NETDATA_MUTEX_INITIALIZER;
     netdata_mutex_lock(&mutex);
@@ -59,7 +86,7 @@ static void arrayalloc_init(ARAL *ar) {
         // and finally align it to the natural alignment
         ar->internal.element_size = natural_alignment(ar->internal.element_size, ARAL_NATURAL_ALIGNMENT);
 
-        // this is where we should write the pointer
+        // we write the page pointer just after each element
         ar->internal.page_ptr_offset = ar->internal.element_size - sizeof(uintptr_t);
 
         if(ar->element_size + sizeof(uintptr_t) > ar->internal.element_size)
@@ -81,17 +108,20 @@ static void arrayalloc_init(ARAL *ar) {
         if(ar->internal.max_alloc_size % ar->internal.element_size)
             ar->internal.max_alloc_size -= ar->internal.max_alloc_size % ar->internal.element_size;
 
-        ar->internal.first_page = NULL;
-        ar->internal.last_page = NULL;
+        ar->internal.pages = NULL;
         ar->internal.allocation_multiplier = 1;
         ar->internal.file_number = 0;
 
         if(ar->internal.mmap) {
-            char filename[FILENAME_MAX + 1];
-            snprintfz(filename, FILENAME_MAX, "%s/array_alloc.mmap", *ar->cache_dir);
-            int r = mkdir(filename, 0775);
+            char directory_name[FILENAME_MAX + 1];
+            snprintfz(directory_name, FILENAME_MAX, "%s/array_alloc.mmap", *ar->cache_dir);
+            int r = mkdir(directory_name, 0775);
             if (r != 0 && errno != EEXIST)
-                fatal("Cannot create directory '%s'", filename);
+                fatal("Cannot create directory '%s'", directory_name);
+
+            char filename[FILENAME_MAX + 1];
+            snprintfz(filename, FILENAME_MAX, "%s.", ar->filename);
+            arrayalloc_delete_leftover_files(directory_name, filename);
         }
 
         ar->internal.initialized = true;
@@ -100,8 +130,11 @@ static void arrayalloc_init(ARAL *ar) {
     netdata_mutex_unlock(&mutex);
 }
 
+// ----------------------------------------------------------------------------
+// check a free slot
+
 #ifdef NETDATA_INTERNAL_CHECKS
-static inline void arrayalloc_free_checks(ARAL *ar, ARAL_FREE *fr) {
+static inline void arrayalloc_free_validate_internal_check(ARAL *ar, ARAL_FREE *fr) {
     if(fr->size < ar->internal.element_size)
         fatal("ARRAYALLOC: free item of size %zu, less than the expected element size %zu", fr->size, ar->internal.element_size);
 
@@ -112,55 +145,38 @@ static inline void arrayalloc_free_checks(ARAL *ar, ARAL_FREE *fr) {
 #define arrayalloc_free_checks(ar, fr) debug_dummy()
 #endif
 
-static inline void unlink_page(ARAL *ar, ARAL_PAGE *page) {
-    if(unlikely(!page)) return;
+// ----------------------------------------------------------------------------
+// check a free slot
 
-    if(page->next)
-        page->next->prev = page->prev;
-
-    if(page->prev)
-        page->prev->next = page->next;
-
-    if(page == ar->internal.first_page)
-        ar->internal.first_page = page->next;
-
-    if(page == ar->internal.last_page)
-        ar->internal.last_page = page->prev;
-}
-
-static inline void link_page_first(ARAL *ar, ARAL_PAGE *page) {
-    page->prev = NULL;
-    page->next = ar->internal.first_page;
-    if(page->next) page->next->prev = page;
-
-    ar->internal.first_page = page;
-
-    if(!ar->internal.last_page)
-        ar->internal.last_page = page;
-}
-
-static inline void link_page_last(ARAL *ar, ARAL_PAGE *page) {
-    page->next = NULL;
-    page->prev = ar->internal.last_page;
-    if(page->prev) page->prev->next = page;
-
-    ar->internal.last_page = page;
-
-    if(!ar->internal.first_page)
-        ar->internal.first_page = page;
-}
-
-static inline ARAL_PAGE *find_page_with_allocation(ARAL *ar, void *ptr) {
+#ifdef NETDATA_INTERNAL_CHECKS
+static inline ARAL_PAGE *find_page_with_allocation_internal_check(ARAL *ar, void *ptr) {
     uintptr_t seeking = (uintptr_t)ptr;
     ARAL_PAGE *page;
 
-    for(page = ar->internal.first_page; page ; page = page->next) {
+    for(page = ar->internal.pages; page ; page = page->next) {
         if(unlikely(seeking >= (uintptr_t)page->data && seeking < (uintptr_t)page->data + page->size))
             break;
     }
 
     return page;
 }
+#endif
+
+// ----------------------------------------------------------------------------
+// find a page with a free slot (there shouldn't be any)
+
+#ifdef NETDATA_INTERNAL_CHECKS
+static inline ARAL_PAGE *find_page_with_free_slots_internal_check(ARAL *ar) {
+    ARAL_PAGE *page;
+
+    for(page = ar->internal.pages; page ; page = page->next) {
+        if(page->free_list)
+            break;
+    }
+
+    return page;
+}
+#endif
 
 #ifdef NETDATA_TRACE_ALLOCATIONS
 static void arrayalloc_add_page(ARAL *ar, const char *file, const char *function, size_t line) {
@@ -202,9 +218,9 @@ static void arrayalloc_add_page(ARAL *ar) {
     page->free_list = fr;
 
     // link the new page at the front of the list of pages
-    link_page_first(ar, page);
+    DOUBLE_LINKED_LIST_PREPEND_UNSAFE(ar->internal.pages, page, prev, next);
 
-    arrayalloc_free_checks(ar, fr);
+    arrayalloc_free_validate_internal_check(ar, fr);
 }
 
 static void arrayalloc_lock(ARAL *ar) {
@@ -236,7 +252,10 @@ void *arrayalloc_mallocz(ARAL *ar) {
 
     arrayalloc_lock(ar);
 
-    if(unlikely(!ar->internal.first_page || !ar->internal.first_page->free_list)) {
+    if(unlikely(!ar->internal.pages || !ar->internal.pages->free_list)) {
+            internal_fatal(find_page_with_free_slots_internal_check(ar) != NULL,
+                           "ARRAYALLOC: first page does not have any free slots, but there is another that has!");
+
 #ifdef NETDATA_TRACE_ALLOCATIONS
         arrayalloc_add_page(ar, file, function, line);
 #else
@@ -244,33 +263,35 @@ void *arrayalloc_mallocz(ARAL *ar) {
 #endif
     }
 
-    ARAL_PAGE *page = ar->internal.first_page;
+    ARAL_PAGE *page = ar->internal.pages;
     ARAL_FREE *fr = page->free_list;
 
-    if(unlikely(!fr))
-        fatal("ARRAYALLOC: free item cannot be NULL.");
+    internal_fatal(!fr,
+                   "ARRAYALLOC: free item to use, cannot be NULL.");
 
-    if(unlikely(fr->size < ar->internal.element_size))
-        fatal("ARRAYALLOC: free item size %zu is smaller than %zu", fr->size, ar->internal.element_size);
+    internal_fatal(fr->size < ar->internal.element_size,
+                   "ARRAYALLOC: free item size %zu, cannot be smaller than %zu", fr->size, ar->internal.element_size);
 
     if(fr->size - ar->internal.element_size <= ar->internal.element_size) {
         // we are done with this page
         page->free_list = NULL;
 
-        if(page != ar->internal.last_page) {
-            unlink_page(ar, page);
-            link_page_last(ar, page);
-        }
+        // move the full page last
+        // so that pages with free items remain first in the list
+        DOUBLE_LINKED_LIST_REMOVE_UNSAFE(ar->internal.pages, page, prev, next);
+        DOUBLE_LINKED_LIST_APPEND_UNSAFE(ar->internal.pages, page, prev, next);
     }
     else {
         uint8_t *data = (uint8_t *)fr;
         ARAL_FREE *fr2 = (ARAL_FREE *)&data[ar->internal.element_size];
         fr2->page = fr->page;
         fr2->size = fr->size - ar->internal.element_size;
+
+        // link the free slot first in the page
         fr2->next = fr->next;
         page->free_list = fr2;
 
-        arrayalloc_free_checks(ar, fr2);
+        arrayalloc_free_validate_internal_check(ar, fr2);
     }
 
     fr->page->used_elements++;
@@ -289,7 +310,7 @@ void arrayalloc_freez_int(ARAL *ar, void *ptr, const char *file, const char *fun
 #else
 void arrayalloc_freez(ARAL *ar, void *ptr) {
 #endif
-    if(!ptr) return;
+    if(unlikely(!ptr)) return;
     arrayalloc_lock(ar);
 
     // get the page pointer
@@ -310,7 +331,7 @@ void arrayalloc_freez(ARAL *ar, void *ptr) {
 #ifdef NETDATA_INTERNAL_CHECKS
     {
         // find the page ptr belongs
-        ARAL_PAGE *page2 = find_page_with_allocation(ar, ptr);
+        ARAL_PAGE *page2 = find_page_with_allocation_internal_check(ar, ptr);
 
         if(unlikely(page != page2))
             fatal("ARRAYALLOC: page pointers do not match!");
@@ -337,7 +358,7 @@ void arrayalloc_freez(ARAL *ar, void *ptr) {
 
     // if the page is empty, release it
     if(!page->used_elements) {
-        unlink_page(ar, page);
+        DOUBLE_LINKED_LIST_REMOVE_UNSAFE(ar->internal.pages, page, prev, next);
 
         // free it
         if(ar->internal.mmap) {
@@ -356,9 +377,11 @@ void arrayalloc_freez(ARAL *ar, void *ptr) {
 
         freez(page);
     }
-    else if(page != ar->internal.first_page) {
-        unlink_page(ar, page);
-        link_page_first(ar, page);
+    else if(page != ar->internal.pages) {
+        // move the page with free item first
+        // so that the next allocation will use this page
+        DOUBLE_LINKED_LIST_REMOVE_UNSAFE(ar->internal.pages, page, prev, next);
+        DOUBLE_LINKED_LIST_PREPEND_UNSAFE(ar->internal.pages, page, prev, next);
     }
 
     arrayalloc_unlock(ar);
@@ -399,7 +422,7 @@ int aral_unittest(size_t elements) {
         arrayalloc_freez(ar, pointers[i]);
     }
 
-    if(ar->internal.first_page) {
+    if(ar->internal.pages) {
         fprintf(stderr, "ARAL leftovers detected (1)");
         return 1;
     }
@@ -442,7 +465,7 @@ int aral_unittest(size_t elements) {
 
     arrayalloc_freez(ar, pointers[allocated - 1]);
 
-    if(ar->internal.first_page) {
+    if(ar->internal.pages) {
         fprintf(stderr, "ARAL leftovers detected (2)");
         return 1;
     }

--- a/libnetdata/arrayalloc/arrayalloc.c
+++ b/libnetdata/arrayalloc/arrayalloc.c
@@ -142,7 +142,7 @@ static inline void arrayalloc_free_validate_internal_check(ARAL *ar, ARAL_FREE *
         fatal("ARRAYALLOC: free item of size %zu is not multiple to element size %zu", fr->size, ar->internal.element_size);
 }
 #else
-#define arrayalloc_free_checks(ar, fr) debug_dummy()
+#define arrayalloc_free_validate_internal_check(ar, fr) debug_dummy()
 #endif
 
 // ----------------------------------------------------------------------------

--- a/libnetdata/arrayalloc/arrayalloc.h
+++ b/libnetdata/arrayalloc/arrayalloc.h
@@ -5,8 +5,8 @@
 #include "../libnetdata.h"
 
 typedef struct arrayalloc {
-    size_t element_size;
-    size_t elements;
+    size_t requested_element_size;
+    size_t initial_elements;
     const char *filename;
     char **cache_dir;
     bool use_mmap;
@@ -27,7 +27,7 @@ typedef struct arrayalloc {
     } internal;
 } ARAL;
 
-ARAL *arrayalloc_create(size_t element_size, size_t elements, const char *filename, char **cache_dir);
+ARAL *arrayalloc_create(size_t element_size, size_t elements, const char *filename, char **cache_dir, bool mmap);
 int aral_unittest(size_t elements);
 
 #ifdef NETDATA_TRACE_ALLOCATIONS

--- a/libnetdata/arrayalloc/arrayalloc.h
+++ b/libnetdata/arrayalloc/arrayalloc.h
@@ -23,8 +23,7 @@ typedef struct arrayalloc {
         size_t allocation_multiplier;
         size_t max_alloc_size;
         netdata_mutex_t mutex;
-        struct arrayalloc_page *first_page;
-        struct arrayalloc_page *last_page;
+        struct arrayalloc_page *pages;
     } internal;
 } ARAL;
 

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -87,9 +87,11 @@ void error_log_limit_unlimited(void);
 #ifdef NETDATA_INTERNAL_CHECKS
 #define debug(type, args...) do { if(unlikely(debug_flags & type)) debug_int(__FILE__, __FUNCTION__, __LINE__, ##args); } while(0)
 #define internal_error(condition, args...) do { if(unlikely(condition)) error_int("IERR", __FILE__, __FUNCTION__, __LINE__, ##args); } while(0)
+#define internal_fatal(condition, args...) do { if(unlikely(condition)) fatal_int(__FILE__, __FUNCTION__, __LINE__, ##args); } while(0)
 #else
 #define debug(type, args...) debug_dummy()
 #define internal_error(args...) debug_dummy()
+#define internal_fatal(args...) debug_dummy()
 #endif
 
 #define info(args...)    info_int(__FILE__, __FUNCTION__, __LINE__, ##args)


### PR DESCRIPTION
- [x] ARAL now cleans up left-over mmap files
- [x] ARAL now uses the standard double linked list instead of the custom one
- [x] ARAL now validates (with `-DNETDATA_INTERNAL_CHECKS=1`) that there is no page with free slots before allocating a new page
- [x] ARAL had a memory leak. It was reusing only one element per page. This made ARAL allocate way more memory than needed when dbengine was rotating databases.
