### PR TITLE
Fix minor typo in systemdunits.conf alert

### DIFF
--- a/health/health.d/systemdunits.conf
+++ b/health/health.d/systemdunits.conf
@@ -71,7 +71,7 @@ component: Systemd units
        to: sysadmin
 
 ## Mount units
- template: systemd_mount_unit_failed_failed_state
+ template: systemd_mount_unit_failed_state
        on: systemd.mount_unit_state
     class: Errors
      type: Linux


### PR DESCRIPTION
##### Summary

Alert's title contains two times the _failed_ keyword

##### Test Plan

CI tests

