### PR TITLE
Fix runtime directory ownership when installed as non-root user.

### DIFF
--- a/system/netdata-freebsd.in
+++ b/system/netdata-freebsd.in
@@ -25,6 +25,7 @@ savedb_cmd="netdata_savedb"
 netdata_prestart()
 {
 	[ ! -d "${piddir}" ] && mkdir -p "${piddir}"
+	chown @netdata_user_POST@:@netdata_user_POST@ "${piddir}"
 	return 0
 }
 

--- a/system/netdata-init-d.in
+++ b/system/netdata-init-d.in
@@ -27,6 +27,7 @@ service_start()
 {
 	[ -x $DAEMON_PATH ] || exit 5
 	[ ! -d $PIDFILE_PATH ] && mkdir -p $PIDFILE_PATH
+	chown @netdata_user_POST@:@netdata_user_POST@ $PIDFIE_PATH
 	echo -n "Starting $DAEMON..."
 	daemon $DAEMON_PATH/$DAEMON $DAEMONOPTS
 	RETVAL=$?

--- a/system/netdata-init-d.in
+++ b/system/netdata-init-d.in
@@ -27,7 +27,7 @@ service_start()
 {
 	[ -x $DAEMON_PATH ] || exit 5
 	[ ! -d $PIDFILE_PATH ] && mkdir -p $PIDFILE_PATH
-	chown @netdata_user_POST@:@netdata_user_POST@ $PIDFIE_PATH
+	chown @netdata_user_POST@:@netdata_user_POST@ $PIDFILE_PATH
 	echo -n "Starting $DAEMON..."
 	daemon $DAEMON_PATH/$DAEMON $DAEMONOPTS
 	RETVAL=$?

--- a/system/netdata-lsb.in
+++ b/system/netdata-lsb.in
@@ -45,6 +45,8 @@ service_start() {
 		mkdir -p $PIDFILE_PATH
 	fi
 	
+	chown @netdata_user_POST@:@netdata_user_POST@ $PIDFILE_PATH
+	
 	log_daemon_msg "Starting real-time performance monitoring" "netdata"
 	start_daemon -p $PIDFILE $DAEMON_PATH/$DAEMON $DAEMONOPTS
 	RETVAL=$?

--- a/system/netdata-openrc.in
+++ b/system/netdata-openrc.in
@@ -4,7 +4,7 @@
 # The user netdata is configured to run as.
 # If you edit its configuration file to set a different
 # user, set it here too, to have its files switch ownership
-: "${NETDATA_OWNER:=netdata:netdata}"
+: "${NETDATA_OWNER:=@netdata_user_POST@:@netdata_user_POST@}"
 
 # The timeout in seconds to wait for netdata
 # to save its database on disk and exit.


### PR DESCRIPTION
##### Summary

Followup to #13780.

This fixes most of the init script types.

##### Test Plan

Install from this branch as a non-root user, and confirm that the agent rusn as the proper user when started as a system service.