### PR TITLE
Use string_freez instead of freez in rrdhost_init_timezone

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -175,7 +175,7 @@ static inline void rrdhost_init_timezone(RRDHOST *host, const char *timezone, co
 
     old = (void *)host->abbrev_timezone;
     host->abbrev_timezone = string_strdupz((abbrev_timezone && *abbrev_timezone) ? abbrev_timezone : "UTC");
-    freez(old);
+    string_freez(old);
 
     host->utc_offset = utc_offset;
 }


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Could be solving #13694 

There was a forgotten `freez` on a `STRING`, changed to do `string_freez` instead.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

The patch was tested on a parent from #13694 (thanks Max!) that would crash on every start in various random places each time, or getting locked. With the patch the server appears to correctly restart each time requested. More tests needed if this was the only case there.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
