### PR TITLE
Properly propagate errors from installer/updater to kickstart script.

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -253,9 +253,17 @@ exit_reason() {
     EXIT_REASON="${1}"
     EXIT_CODE="${2}"
     if [ -n "${NETDATA_PROPAGATE_WARNINGS}" ]; then
-      export EXIT_REASON
-      export EXIT_CODE
-      export NETDATA_WARNINGS="${NETDATA_WARNINGS}${SAVED_WARNINGS}"
+      if [ -n "${NETDATA_SCRIPT_STATUS_PATH}" ]; then
+        {
+          echo "EXIT_REASON=\"${EXIT_REASON}\""
+          echo "EXIT_CODE=\"${EXIT_CODE}\""
+          echo "NETDATA_WARNINGS=\"${NETDATA_WARNINGS}${SAVED_WARNINGS}\""
+        } >> "${NETDATA_SCRIPT_STATUS_PATH}"
+      else
+        export EXIT_REASON
+        export EXIT_CODE
+        export NETDATA_WARNINGS="${NETDATA_WARNINGS}${SAVED_WARNINGS}"
+      fi
     fi
   fi
 }

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -473,6 +473,26 @@ run() {
   return ${ret}
 }
 
+run_script() {
+  set_tmpdir
+
+  export NETDATA_SCRIPT_STATUS_PATH="${tmpdir}/.script-status"
+
+  export NETDATA_SAVE_WARNINGS=1
+  export NETDATA_PROPAGATE_WARNINGS=1
+  # shellcheck disable=SC2090
+  export NETDATA_WARNINGS="${NETDATA_WARNINGS}"
+
+  # shellcheck disable=SC2086
+  run ${ROOTCMD} "${@}"
+
+  if [ -r "${NETDATA_SCRIPT_STATUS_PATH}" ]; then
+    # shellcheck disable=SC1090
+    . "${NETDATA_SCRIPT_STATUS_PATH}"
+    rm -f "${NETDATA_SCRIPT_STATUS_PATH}"
+  fi
+}
+
 warning() {
   printf >&2 "%s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} WARNING ${TPUT_RESET} ${*}"
   NETDATA_WARNINGS="${NETDATA_WARNINGS}\n  - ${*}"
@@ -711,11 +731,7 @@ update() {
         opts="--interactive"
     fi
 
-    export NETDATA_SAVE_WARNINGS=1
-    export NETDATA_PROPAGATE_WARNINGS=1
-    # shellcheck disable=SC2090
-    export NETDATA_WARNINGS="${NETDATA_WARNINGS}"
-    if run ${ROOTCMD} "${updater}" ${opts} --not-running-from-cron; then
+    if run_script "${updater}" ${opts} --not-running-from-cron; then
       progress "Updated existing install at ${ndprefix}"
       return 0
     else
@@ -757,11 +773,7 @@ uninstall() {
       return 0
     else
       progress "Found existing netdata-uninstaller. Running it.."
-      export NETDATA_SAVE_WARNINGS=1
-      export NETDATA_PROPAGATE_WARNINGS=1
-      # shellcheck disable=SC2090
-      export NETDATA_WARNINGS="${NETDATA_WARNINGS}"
-      if ! run ${ROOTCMD} "${uninstaller}" $FLAGS; then
+      if ! run_script "${uninstaller}" ${FLAGS}; then
         warning "Uninstaller failed. Some parts of Netdata may still be present on the system."
       fi
     fi
@@ -774,11 +786,7 @@ uninstall() {
       progress "Downloading netdata-uninstaller ..."
       download "${uninstaller_url}" "${tmpdir}/netdata-uninstaller.sh"
       chmod +x "${tmpdir}/netdata-uninstaller.sh"
-      export NETDATA_SAVE_WARNINGS=1
-      export NETDATA_PROPAGATE_WARNINGS=1
-      # shellcheck disable=SC2090
-      export NETDATA_WARNINGS="${NETDATA_WARNINGS}"
-      if ! run ${ROOTCMD} "${tmpdir}/netdata-uninstaller.sh" $FLAGS; then
+      if ! run_script "${tmpdir}/netdata-uninstaller.sh" ${FLAGS}; then
         warning "Uninstaller failed. Some parts of Netdata may still be present on the system."
       fi
     fi
@@ -1665,12 +1673,8 @@ build_and_install() {
     opts="${opts} --disable-cloud"
   fi
 
-  export NETDATA_SAVE_WARNINGS=1
-  export NETDATA_PROPAGATE_WARNINGS=1
-  # shellcheck disable=SC2090
-  export NETDATA_WARNINGS="${NETDATA_WARNINGS}"
   # shellcheck disable=SC2086
-  run ${ROOTCMD} ./netdata-installer.sh ${opts}
+  run_script ./netdata-installer.sh ${opts}
 
   case $? in
     1)


### PR DESCRIPTION
##### Summary

This should result in errors in these scripts being properly deaggregated, instead of being always reported as ‘generic’ failures, thus simplifying diagnosis of end-user problems with the installation or update process.

##### Test Plan

These changes can most easily be tested by running the kickstart script on a system with an existing Netdata install when it is known that the updater script will exit with a failure code.

Without this PR, the kickstart script should provide only a non-specific error message at the end in the list of deferred warnings.

With this PR, the kickstart script should provide both the above-mentioned non-specific message, as well as a more specific message from the updater script in the list of deferred warnings.

##### Additional Information

This provides more concrete messaging to users when a failure occurs, as well as providing more useful information in anonymous telemetry about why a given installation failed.


