### PR TITLE
ARAL optimal alloc size

### DIFF
--- a/libnetdata/arrayalloc/arrayalloc.c
+++ b/libnetdata/arrayalloc/arrayalloc.c
@@ -6,7 +6,9 @@
 #define ARAL_MAX_PAGE_SIZE_MMAP (1*1024*1024*1024)
 
 // max malloc size
-#define ARAL_MAX_PAGE_SIZE_MALLOC (10*1024*1024)
+// optimal at current versions of libc is up to 256k
+// ideal to have the same overhead as libc is 4k
+#define ARAL_MAX_PAGE_SIZE_MALLOC (64*1024)
 
 typedef struct arrayalloc_free {
     size_t size;


### PR DESCRIPTION
We did several tests to find how RSS and VM size of netdata are affected by ARAL, that allocates dbengine page descriptors.

We found that VM size grows significantly with the default ARAL max size of 10MB, compared to plain `mallloc()`.

On our tests we got the same VM size with malloc and ARAL, for max allocation size of up to 256k.
We decided to go with 64k as a safe option that should work as expected among different libc versions and operating systems.
