### PR TITLE
fix warning when -Wfree-nonheap-object is used

### DIFF
--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -380,7 +380,7 @@ int aclk_get_otp_challenge(url_t *target, const char *agent_id, unsigned char **
     base64_decode_helper(*challenge, challenge_bytes, (const unsigned char*)challenge_base64, strlen(challenge_base64));
     if (*challenge_bytes != CHALLENGE_LEN) {
         error("Unexpected challenge length of %d instead of %d", *challenge_bytes, CHALLENGE_LEN);
-        freez(challenge);
+        freez(*challenge);
         *challenge = NULL;
         goto cleanup_json;
     }
@@ -490,7 +490,7 @@ int aclk_get_mqtt_otp(EVP_PKEY *p_key, char **mqtt_id, char **mqtt_usr, char **m
 int aclk_get_mqtt_otp(RSA *p_key, char **mqtt_id, char **mqtt_usr, char **mqtt_pass, url_t *target)
 #endif
 {
-    unsigned char *challenge;
+    unsigned char *challenge = NULL;
     int challenge_bytes;
 
     char *agent_id = get_agent_claimid();


### PR DESCRIPTION
##### Summary
In case of failed decryption of challenge there was a wrong freez called.

```
In function 'freez',
    inlined from 'aclk_get_otp_challenge' at aclk/aclk_otp.c:383:9,
    inlined from 'aclk_get_mqtt_otp' at aclk/aclk_otp.c:503:9,
    inlined from 'aclk_attempt_to_connect' at aclk/aclk.c:566:15:
libnetdata/libnetdata.c:275:5: warning: 'free' called on unallocated object 'challenge' [-Wfree-nonheap-object]
  275 |     free(ptr);
      |     ^
libnetdata/libnetdata.c: In function 'aclk_attempt_to_connect':
aclk/aclk_otp.c:493:20: note: declared here
  493 |     unsigned char *challenge;
      |                    ^
```

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
