### PR TITLE
Add a CodeQL analysis workflow.

### DIFF
--- a/.github/codeql/python-config.yml
+++ b/.github/codeql/python-config.yml
@@ -1,7 +1,7 @@
 paths-ignore:
-- .github
-- build_external/
-- ml/dlib
-- ml/json
-- tests/api
-- web/gui
+  - .github
+  - build_external/
+  - ml/dlib
+  - ml/json
+  - tests/api
+  - web/gui

--- a/.github/codeql/python-config.yml
+++ b/.github/codeql/python-config.yml
@@ -1,0 +1,7 @@
+paths-ignore:
+- .github
+- build_external/
+- ml/dlib
+- ml/json
+- tests/api
+- web/gui

--- a/.github/codeql/python-config.yml
+++ b/.github/codeql/python-config.yml
@@ -5,3 +5,6 @@ paths-ignore:
   - ml/json
   - tests/api
   - web/gui
+  - collectors/python.d.plugin/python_modules/pyyaml*
+  - collectors/python.d.plugin/python_modules/third_party
+  - collectors/python.d.plugin/python_modules/urllib3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,7 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             if [ "${{ contains(github.event.pull_request.labels.*.name, 'ci/codeql') }}" = "true" ]; then
               echo '::set-output name=run::true'
+              echo '::notice::Found ci/codeql label, unconditionally running all CodeQL checks.'
             else
               echo '::set-output name=run::false'
             fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,8 @@
 # Run CodeQL to analyze C/C++ and Python code.
 name: CodeQL
 on:
-  pull_request: null
+  pull_request:
+    types: [opened, reopened, labeled, synchronize]
   push:
     branches: [master]
   schedule:
@@ -25,10 +26,22 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+      - name: Check if we should always run
+        id: always
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "${{ contains(github.event.pull_request.labels.*.name, 'ci/codeql') }}" = "true" ]; then
+              echo '::set-output name=run::true'
+            else
+              echo '::set-output name=run::false'
+            fi
+          else
+            echo '::set-output name=run::true'
+          fi
       - name: Check for C/C++ changes
         id: cpp
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ steps.always.outputs.run }}" = "false" ]; then
             if git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '.*\.[ch](xx|\+\+)?' ; then
               echo '::set-output name=run::true'
               echo '::notice::C/C++ code has changed, need to run CodeQL.'
@@ -41,7 +54,7 @@ jobs:
       - name: Check for python changes
         id: python
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ steps.always.outputs.run }}" = "false" ]; then
             if git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq 'collectors/python.d.plugin/.*\.py' ; then
               echo '::set-output name=run::true'
               echo '::notice::Python code has changed, need to run CodeQL.'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,101 @@
+---
+# Run CodeQL to analyze C/C++ and Python code.
+name: CodeQL
+on:
+  pull_request: null
+  push:
+    branches: [master]
+  schedule:
+    - cron: "27 2 * * * 1"
+env:
+  DISABLE_TELEMETRY: 1
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  prepare:
+    name: Prepare Jobs
+    runs-on: ubuntu-latest
+    output:
+      cpp: ${{ steps.cpp.outputs.run }}
+      python: ${{ steps.python.outputs.run }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Check for C/C++ changes
+        id: cpp
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '.*\.[ch](xx|\+\+)?' ; then
+              echo '::set-output name=run::true'
+              echo '::notice::C/C++ code has changed, need to run CodeQL.'
+            else
+              echo '::set-output name=run::false'
+            fi
+          else
+            echo '::set-output name=run::true'
+          fi
+      - name: Check for python changes
+        id: python
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq 'collectors/python.d.plugin/.*\.py' ; then
+              echo '::set-output name=run::true'
+              echo '::notice::Python code has changed, need to run CodeQL.'
+            else
+              echo '::set-output name=run::false'
+            fi
+          else
+            echo '::set-output name=run::true'
+          fi
+
+  analyze-cpp:
+    name: Analyze C/C++
+    runs-on: ubuntu-latest
+    needs: prepare
+    if: needs.prepare.outputs.cpp == 'true'
+    permissions:
+      security-events: write
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: cpp
+      - name: Prepare environment
+        run: ./packaging/installer/install-required-packages.sh --dont-wait --non-interactive netdata
+      - name: Build netdata
+        run: ./netdata-installer.sh --dont-start-it --disable-telemetry --dont-wait --install /tmp/install --one-time-build
+      - name: Run CodeQL
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:cpp"
+
+  analyze-python:
+    name: Analyze Python
+    runs-on: ubuntu-latest
+    needs: prepare
+    if: needs.prepare.outputs.python == 'true'
+    permissions:
+      security-events: write
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: python
+      - name: Run CodeQL
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:python"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [master]
   schedule:
-    - cron: "27 2 * * * 1"
+    - cron: "27 2 * * 1"
 env:
   DISABLE_TELEMETRY: 1
 concurrency:
@@ -17,7 +17,7 @@ jobs:
   prepare:
     name: Prepare Jobs
     runs-on: ubuntu-latest
-    output:
+    outputs:
       cpp: ${{ steps.cpp.outputs.run }}
       python: ${{ steps.python.outputs.run }}
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,7 @@ name: CodeQL
 on:
   pull_request:
     types: [opened, reopened, labeled, synchronize]
+    branches: [master]
   push:
     branches: [master]
   schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
+          config-file: ./.github/codeql/python-config.yml
           languages: python
       - name: Run CodeQL
         uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
##### Summary

This currently is limited to checking C/C++ code and Python code. Analysis is run on PRs, pushes to the master branch, and as a scheduled run every Monday morning.

The PR checks include special logic to skip checking files for languages that have no changes in the PR unless the PR is labelled with a label named `ci/codeql`.

##### Test Plan

The full checks will run on this PR due to the presence of the label mentioned above.

##### Additional Information

The Python checking has been intentionally limited to only caring about the code that actually goes to end users so we don’t waste time on things like build scripts.