### PR TITLE
Inject costallocz to mqtt_websockets library and its children

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -900,22 +900,6 @@ set(ACLK_FILES
         aclk/aclk_alarm_api.h
         aclk/aclk_contexts_api.c
         aclk/aclk_contexts_api.h
-        mqtt_websockets/src/mqtt_wss_client.c
-        mqtt_websockets/src/include/mqtt_wss_client.h
-        mqtt_websockets/src/mqtt_wss_log.c
-        mqtt_websockets/src/include/mqtt_wss_log.h
-        mqtt_websockets/src/ws_client.c
-        mqtt_websockets/src/include/ws_client.h
-        mqtt_websockets/src/mqtt_ng.c
-        mqtt_websockets/src/include/mqtt_ng.h
-        mqtt_websockets/src/common_public.c
-        mqtt_websockets/src/include/common_public.h
-        mqtt_websockets/src/include/common_internal.h
-        mqtt_websockets/c-rbuf/src/ringbuffer.c
-        mqtt_websockets/c-rbuf/include/ringbuffer.h
-        mqtt_websockets/c-rbuf/src/ringbuffer_internal.h
-        mqtt_websockets/MQTT-C/src/mqtt.c
-        mqtt_websockets/MQTT-C/include/mqtt.h
         aclk/schema-wrappers/connection.cc
         aclk/schema-wrappers/connection.h
         aclk/schema-wrappers/node_connection.cc
@@ -939,6 +923,27 @@ set(ACLK_FILES
         aclk/schema-wrappers/schema_wrappers.h
         aclk/schema-wrappers/schema_wrapper_utils.cc
         aclk/schema-wrappers/schema_wrapper_utils.h
+        aclk/helpers/mqtt_wss_pal.h
+        aclk/helpers/ringbuffer_pal.h
+        )
+
+set(MQTT_WEBSOCKETS_FILES
+        mqtt_websockets/src/mqtt_wss_client.c
+        mqtt_websockets/src/include/mqtt_wss_client.h
+        mqtt_websockets/src/mqtt_wss_log.c
+        mqtt_websockets/src/include/mqtt_wss_log.h
+        mqtt_websockets/src/ws_client.c
+        mqtt_websockets/src/include/ws_client.h
+        mqtt_websockets/src/mqtt_ng.c
+        mqtt_websockets/src/include/mqtt_ng.h
+        mqtt_websockets/src/common_public.c
+        mqtt_websockets/src/include/common_public.h
+        mqtt_websockets/src/include/common_internal.h
+        mqtt_websockets/c-rbuf/src/ringbuffer.c
+        mqtt_websockets/c-rbuf/include/ringbuffer.h
+        mqtt_websockets/c-rbuf/src/ringbuffer_internal.h
+        mqtt_websockets/MQTT-C/src/mqtt.c
+        mqtt_websockets/MQTT-C/include/mqtt.h
         )
 
 set(SPAWN_PLUGIN_FILES
@@ -1257,6 +1262,18 @@ include_directories(BEFORE ${CMAKE_SOURCE_DIR}/aclk/aclk-schemas)
 include_directories(BEFORE ${CMAKE_SOURCE_DIR}/mqtt_websockets/MQTT-C/include)
 include_directories(BEFORE ${CMAKE_SOURCE_DIR}/mqtt_websockets/src/include)
 include_directories(BEFORE ${CMAKE_SOURCE_DIR}/mqtt_websockets/c-rbuf/include)
+
+ADD_LIBRARY(mqttwebsockets STATIC
+            ${MQTT_WEBSOCKETS_FILES})
+
+target_compile_options(mqttwebsockets PUBLIC
+                        -DMQTT_WSS_CUSTOM_ALLOC
+                        -DRBUF_CUSTOM_MALLOC)
+
+target_include_directories(mqttwebsockets PUBLIC
+             ${CMAKE_SOURCE_DIR}/aclk/helpers)
+
+set(NETDATA_COMMON_LIBRARIES ${NETDATA_COMMON_LIBRARIES} mqttwebsockets)
 
 ENDIF()
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -686,26 +686,11 @@ ACLK_FILES = \
     aclk/aclk_rx_msgs.h \
     aclk/https_client.c \
     aclk/https_client.h \
-    mqtt_websockets/src/mqtt_wss_client.c \
-    mqtt_websockets/src/include/mqtt_wss_client.h \
-    mqtt_websockets/src/mqtt_wss_log.c \
-    mqtt_websockets/src/include/mqtt_wss_log.h \
-    mqtt_websockets/src/ws_client.c \
-    mqtt_websockets/src/include/ws_client.h \
-    mqtt_websockets/src/mqtt_ng.c \
-    mqtt_websockets/src/include/mqtt_ng.h \
-    mqtt_websockets/src/common_public.c \
-    mqtt_websockets/src/include/common_public.h \
-    mqtt_websockets/src/include/common_internal.h \
-    mqtt_websockets/c-rbuf/src/ringbuffer.c \
-    mqtt_websockets/c-rbuf/include/ringbuffer.h \
-    mqtt_websockets/c-rbuf/src/ringbuffer_internal.h \
-    mqtt_websockets/MQTT-C/src/mqtt.c \
-    mqtt_websockets/MQTT-C/include/mqtt.h \
     aclk/aclk_alarm_api.c \
     aclk/aclk_alarm_api.h \
     aclk/aclk_contexts_api.c \
     aclk/aclk_contexts_api.h \
+    aclk/helpers/mqtt_wss_pal.h \
     aclk/schema-wrappers/connection.cc \
     aclk/schema-wrappers/connection.h \
     aclk/schema-wrappers/node_connection.cc \
@@ -730,6 +715,28 @@ ACLK_FILES = \
     aclk/schema-wrappers/context.cc \
     aclk/schema-wrappers/context.h \
     $(NULL)
+
+noinst_LIBRARIES += libmqttwebsockets.a
+
+libmqttwebsockets_a_SOURCES = \
+    mqtt_websockets/src/mqtt_wss_client.c \
+    mqtt_websockets/src/include/mqtt_wss_client.h \
+    mqtt_websockets/src/mqtt_wss_log.c \
+    mqtt_websockets/src/include/mqtt_wss_log.h \
+    mqtt_websockets/src/ws_client.c \
+    mqtt_websockets/src/include/ws_client.h \
+    mqtt_websockets/src/mqtt_ng.c \
+    mqtt_websockets/src/include/mqtt_ng.h \
+    mqtt_websockets/src/common_public.c \
+    mqtt_websockets/src/include/common_public.h \
+    mqtt_websockets/src/include/common_internal.h \
+    mqtt_websockets/c-rbuf/src/ringbuffer.c \
+    mqtt_websockets/c-rbuf/include/ringbuffer.h \
+    mqtt_websockets/c-rbuf/src/ringbuffer_internal.h \
+    mqtt_websockets/MQTT-C/src/mqtt.c \
+    mqtt_websockets/MQTT-C/include/mqtt.h
+
+libmqttwebsockets_a_CFLAGS = $(CFLAGS) -DMQTT_WSS_CUSTOM_ALLOC -DRBUF_CUSTOM_MALLOC -I$(srcdir)/aclk/helpers
 
 mqtt_websockets/src/mqtt_wss_client.$(OBJEXT) : CFLAGS += -Wno-unused-result
 
@@ -965,6 +972,10 @@ NETDATA_COMMON_LIBS = \
     $(OPTIONAL_JSONC_LIBS) \
     $(OPTIONAL_ATOMIC_LIBS) \
     $(NULL)
+
+if ENABLE_ACLK
+    NETDATA_COMMON_LIBS += libmqttwebsockets.a
+endif
 
 if LINK_STATIC_JSONC
     NETDATA_COMMON_LIBS += $(abs_top_srcdir)/externaldeps/jsonc/libjson-c.a

--- a/Makefile.am
+++ b/Makefile.am
@@ -691,6 +691,7 @@ ACLK_FILES = \
     aclk/aclk_contexts_api.c \
     aclk/aclk_contexts_api.h \
     aclk/helpers/mqtt_wss_pal.h \
+    aclk/helpers/ringbuffer_pal.h \
     aclk/schema-wrappers/connection.cc \
     aclk/schema-wrappers/connection.h \
     aclk/schema-wrappers/node_connection.cc \

--- a/aclk/helpers/mqtt_wss_pal.h
+++ b/aclk/helpers/mqtt_wss_pal.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef MQTT_WSS_PAL_H
+#define MQTT_WSS_PAL_H
+
+#include "libnetdata/libnetdata.h"
+
+#undef OPENSSL_VERSION_095
+#undef OPENSSL_VERSION_097
+#undef OPENSSL_VERSION_110
+#undef OPENSSL_VERSION_111
+
+#define mw_malloc(...) mallocz(__VA_ARGS__)
+#define mw_calloc(...) callocz(__VA_ARGS__)
+#define mw_free(...) freez(__VA_ARGS__)
+#define mw_strdup(...) strdupz(__VA_ARGS__)
+#define mw_realloc(...) reallocz(__VA_ARGS__)
+
+#endif /* MQTT_WSS_PAL_H */

--- a/aclk/helpers/ringbuffer_pal.h
+++ b/aclk/helpers/ringbuffer_pal.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef RINGBUFFER_PAL_H
+#define RINGBUFFER_PAL_H
+
+#include "libnetdata/libnetdata.h"
+
+#define crbuf_malloc(...) mallocz(__VA_ARGS__)
+#define crbuf_free(...) freez(__VA_ARGS__)
+
+#endif /* RINGBUFFER_PAL_H */

--- a/aclk/schema-wrappers/connection.cc
+++ b/aclk/schema-wrappers/connection.cc
@@ -38,7 +38,7 @@ char *generate_update_agent_connection(size_t *len, const update_agent_connectio
     }
 
     *len = PROTO_COMPAT_MSG_SIZE(connupd);
-    char *msg = (char*)malloc(*len);
+    char *msg = (char*)mallocz(*len);
     if (msg)
         connupd.SerializeToArray(msg, *len);
 
@@ -52,7 +52,7 @@ struct disconnect_cmd *parse_disconnect_cmd(const char *data, size_t len) {
     if (!req.ParseFromArray(data, len))
         return NULL;
 
-    res = (struct disconnect_cmd *)calloc(1, sizeof(struct disconnect_cmd));
+    res = (struct disconnect_cmd *)callocz(1, sizeof(struct disconnect_cmd));
 
     if (!res)
         return NULL;
@@ -61,9 +61,9 @@ struct disconnect_cmd *parse_disconnect_cmd(const char *data, size_t len) {
     res->permaban = req.permaban();
     res->error_code = req.error_code();
     if (req.error_description().c_str()) {
-        res->error_description = strdup(req.error_description().c_str());
+        res->error_description = strdupz(req.error_description().c_str());
         if (!res->error_description) {
-            free(res);
+            freez(res);
             return NULL;
         }
     }

--- a/aclk/schema-wrappers/node_connection.cc
+++ b/aclk/schema-wrappers/node_connection.cc
@@ -38,7 +38,7 @@ char *generate_node_instance_connection(size_t *len, const node_instance_connect
     }
 
     *len = PROTO_COMPAT_MSG_SIZE(msg);
-    char *bin = (char*)malloc(*len);
+    char *bin = (char*)mallocz(*len);
     if (bin)
         msg.SerializeToArray(bin, *len);
 

--- a/aclk/schema-wrappers/node_creation.cc
+++ b/aclk/schema-wrappers/node_creation.cc
@@ -18,7 +18,7 @@ char *generate_node_instance_creation(size_t *len, const node_instance_creation_
     msg.set_hops(data->hops);
 
     *len = PROTO_COMPAT_MSG_SIZE(msg);
-    char *bin = (char*)malloc(*len);
+    char *bin = (char*)mallocz(*len);
     if (bin)
         msg.SerializeToArray(bin, *len);
 
@@ -33,7 +33,7 @@ node_instance_creation_result_t parse_create_node_instance_result(const char *da
     if (!msg.ParseFromArray(data, len))
         return res;
 
-    res.node_id = strdup(msg.node_id().c_str());
-    res.machine_guid = strdup(msg.machine_guid().c_str());
+    res.node_id = strdupz(msg.node_id().c_str());
+    res.machine_guid = strdupz(msg.machine_guid().c_str());
     return res;
 }

--- a/aclk/schema-wrappers/node_info.cc
+++ b/aclk/schema-wrappers/node_info.cc
@@ -104,7 +104,7 @@ char *generate_update_node_info_message(size_t *len, struct update_node_info *in
     }
 
     *len = PROTO_COMPAT_MSG_SIZE(msg);
-    char *bin = (char*)malloc(*len);
+    char *bin = (char*)mallocz(*len);
     if (bin)
         msg.SerializeToArray(bin, *len);
 
@@ -128,7 +128,7 @@ char *generate_update_node_collectors_message(size_t *len, struct update_node_co
     dfe_done(colls);
 
     *len = PROTO_COMPAT_MSG_SIZE(msg);
-    char *bin = (char*)malloc(*len);
+    char *bin = (char*)mallocz(*len);
     if (bin)
         msg.SerializeToArray(bin, *len);
 


### PR DESCRIPTION
##### Summary

Allows the specialized netdata memory functions/macros to be used from within mqttwebsockets and its children. Supported is MQTT5 implementation.

MQTT3 will be removed soon and therefore not implemented there.

##### Test Plan
Build with/without trace allocations

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
