### PR TITLE
minor - add trace alloc to buildinfo

### DIFF
--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -197,6 +197,11 @@
 
 #define FEAT_YES_NO(x) ((x) ? "YES" : "NO")
 
+#ifdef NETDATA_TRACE_ALLOCATIONS
+#define FEAT_TRACE_ALLOC 1
+#else
+#define FEAT_TRACE_ALLOC 0
+#endif
 
 char *get_value_from_key(char *buffer, char *key) {
     char *s = NULL, *t = NULL;
@@ -298,6 +303,9 @@ void print_build_info(void) {
     printf("    GCP PubSub:              %s\n", FEAT_YES_NO(FEAT_PUBSUB));
     printf("    MongoDB:                 %s\n", FEAT_YES_NO(FEAT_MONGO));
     printf("    Prometheus Remote Write: %s\n", FEAT_YES_NO(FEAT_REMOTE_WRITE));
+
+    printf("Debug/Developer Features:\n");
+    printf("    Trace Allocations:       %s\n", FEAT_YES_NO(FEAT_TRACE_ALLOC));
 };
 
 #define FEAT_JSON_BOOL(x) ((x) ? "true" : "false")
@@ -354,6 +362,8 @@ void print_build_info_json(void) {
     printf("    \"mongodb\": %s,\n",          FEAT_JSON_BOOL(FEAT_MONGO));
     printf("    \"prom-remote-write\": %s\n", FEAT_JSON_BOOL(FEAT_REMOTE_WRITE));
     printf("  }\n");
+    printf("  \"debug-n-devel\": {\n");
+    printf("    \"trace-allocations\": %s\n  }\n",FEAT_JSON_BOOL(FEAT_TRACE_ALLOC));
     printf("}\n");
 };
 
@@ -453,5 +463,8 @@ void analytics_build_info(BUFFER *b) {
 #endif
 #ifdef ENABLE_PROMETHEUS_REMOTE_WRITE
     add_to_bi(b, "Prometheus Remote Write");
+#endif
+#ifdef NETDATA_TRACE_ALLOCATIONS
+    add_to_bi(b, "DebugTraceAlloc");
 #endif
 }


### PR DESCRIPTION
##### Summary
Title is self descripting

##### Test Plan
`netdata -W buildinfo[json]`

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
