### PR TITLE
Fix crash on child reconnect and lost metrics

### DIFF
--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -124,8 +124,6 @@ void rrdeng_metric_release(STORAGE_METRIC_HANDLE *db_metric_handle) {
         page_index->alignment = NULL;
     }
     uv_rwlock_rdunlock(&pg_cache->metrics_index.lock);
-
-    freez(db_metric_handle);
 }
 
 STORAGE_METRIC_HANDLE *rrdeng_metric_get(STORAGE_INSTANCE *db_instance, uuid_t *uuid, STORAGE_METRICS_GROUP *smg) {
@@ -170,6 +168,7 @@ STORAGE_METRIC_HANDLE *rrdeng_metric_create(STORAGE_INSTANCE *db_instance, uuid_
     page_index->prev = pg_cache->metrics_index.last_page_index;
     pg_cache->metrics_index.last_page_index = page_index;
     page_index->alignment = pa;
+    page_index->refcount = 1;
     if(pa)
         pa->refcount++;
     uv_rwlock_wrunlock(&pg_cache->metrics_index.lock);


### PR DESCRIPTION
##### Summary

Updates the reference count on the storage handle
Does not release the storage handle since it is needed to commit data

##### Test Plan
- Use a clean setup (remove files under /var/cache/netdata)
- Set up parent child with the parent having 
  ```
  cleanup obsolete charts after seconds = 30
  cleanup orphan hosts after seconds = 30
  delete obsolete charts files = yes
  delete orphan hosts files = yes
  ```
- Start the parent and the child and let it run for a few seconds
- Stop the child and wait until the parent sets it to archive mode 
- Start the child, notice the parent will crash

- Repeat the test and this time stop and restart the parent while observing the dashboard
- Notice that after each stop and restart data may be missing from the dashboard 
---
- Apply the PR and retest
