### PR TITLE
chore(health): rm pihole_blocklist_gravity_file_existence_state

### DIFF
--- a/health/health.d/pihole.conf
+++ b/health/health.d/pihole.conf
@@ -15,21 +15,6 @@ component: Pi-hole
      info: gravity.list (blocklist) file last update time
        to: sysadmin
 
-# Gravity file check (gravity.list).
-
- template: pihole_blocklist_gravity_file_existence_state
-       on: pihole.blocklist_file_existence_state
-    class: Errors
-     type: Ad Filtering
-component: Pi-hole
-    every: 10s
-    units: state
-     calc: $not_exists
-     crit: $this != nan AND $this == 1
-    delay: up 2m down 5m
-     info: gravity.list (blocklist) file does not exist
-       to: sysadmin
-
 # Pi-hole's ability to block unwanted domains.
 # Should be enabled. The whole point of Pi-hole!
 


### PR DESCRIPTION
##### Summary

As we [found out](https://github.com/netdata/netdata/issues/13781#issuecomment-1277864715), the `gravity.list` file has been removed (2019 or earlier). The metric removed in netdata/go.d.plugin#914


##### Test Plan

n/a

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
