### PR TITLE
Use PR label to trigger full packaging CI instead of PR body contents.

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -3,9 +3,13 @@
 name: Packages
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - labeled
+      - synchronize
     branches:
       - master
-      - develop
   push:
     branches:
       - master
@@ -41,16 +45,12 @@ jobs:
       - name: Read build matrix
         id: set-matrix
         shell: python3 {0}
-        env:
-          PR_BODY: "${{ github.event.pull_request.body }}"
         run: |
           from ruamel.yaml import YAML
           import json
           import re
           import os
-          FULL_CI_REGEX = '/actions run full ci'
           ALWAYS_RUN_ARCHES = ["amd64", "x86_64"]
-          PR_BODY = os.environ['PR_BODY']
           yaml = YAML(typ='safe')
           entries = list()
           run_limited = False
@@ -58,7 +58,7 @@ jobs:
           with open('.github/data/distros.yml') as f:
               data = yaml.load(f)
 
-          if "${{ github.event_name }}" == "pull_request" and re.search(FULL_CI_REGEX, PR_BODY, re.I) is None:
+          if "${{ github.event_name }}" == "pull_request" and "${{ contains(github.event.pull_request.labels.*.name, 'ci/packaging') }}" != "true":
               run_limited = True
 
           for i, v in enumerate(data['include']):


### PR DESCRIPTION
##### Summary

Instead of requiring a specific string in the PR body, use the presence of a PR label to trigger running all the packaging CI jobs.  This is more robust, more secure, and also provides a much cleaner way for maintainers to trigger the CI jobs on contributor’s PRs.

The specific label used for this is `ci/packaging`

##### Test Plan

Observe that all packaging jobs ran on this PR because of the presence of the above-mentioned label.