### PR TITLE
Fix service installation on FreeBSD.

### DIFF
--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -113,7 +113,7 @@ install_generic_service() {
     ENABLE="enable"
   fi
 
-  if ! install -p -m 0755 -o 0 -g 0 "${SVC_SOURCE}/netdata-${svc_type}" /etc/init.d/netdata; then
+  if ! install -p -m 0755 -o 0 -g 0 "${SVC_SOURCE}/netdata-${svc_type}" "${svc_file}"; then
     error "Failed to install service file."
     exit 4
   fi


### PR DESCRIPTION


##### Summary

Instead of using the correct path for installing the system service file, we were always hard-coding `/etc/init.d/netdata`. This happened to work correctly on Linux, but obviously breaks horribly on FreeBSD.

##### Test Plan

Without this PR, installing on FreeBSD will not properly configure the Netdata agent as a system service.

With this PR, installing on FreeBSD will correctly set up the Netdata agent as a system service.