### PR TITLE
fix tiers update frequency

### DIFF
--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -122,7 +122,7 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
         size_t initialized = 0;
         for (int tier = 0; tier < storage_tiers; tier++) {
             if (rd->tiers[tier]) {
-                rd->tiers[tier]->db_collection_handle = rd->tiers[tier]->collect_ops.init(rd->tiers[tier]->db_metric_handle, st->update_every * storage_tiers_grouping_iterations[tier]);
+                rd->tiers[tier]->db_collection_handle = rd->tiers[tier]->collect_ops.init(rd->tiers[tier]->db_metric_handle, get_tier_grouping(tier) * st->update_every);
                 initialized++;
             }
         }
@@ -255,7 +255,7 @@ static bool rrddim_conflict_callback(const DICTIONARY_ITEM *item __maybe_unused,
         for(int tier = 0; tier < storage_tiers ;tier++) {
             if (rd->tiers[tier])
                 rd->tiers[tier]->db_collection_handle =
-                    rd->tiers[tier]->collect_ops.init(rd->tiers[tier]->db_metric_handle, st->update_every * storage_tiers_grouping_iterations[tier]);
+                    rd->tiers[tier]->collect_ops.init(rd->tiers[tier]->db_metric_handle, get_tier_grouping(tier) * st->update_every);
         }
 
         rrddim_flag_clear(rd, RRDDIM_FLAG_ARCHIVED);

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -315,7 +315,7 @@ static bool rrdset_conflict_callback(const DICTIONARY_ITEM *item __maybe_unused,
         rrddim_foreach_read(rd, st) {
             for (int tier = 0; tier < storage_tiers; tier++) {
                 if (rd->tiers[tier] && rd->tiers[tier]->db_collection_handle)
-                    rd->tiers[tier]->collect_ops.change_collection_frequency(rd->tiers[tier]->db_collection_handle, st->update_every);
+                    rd->tiers[tier]->collect_ops.change_collection_frequency(rd->tiers[tier]->db_collection_handle, get_tier_grouping(tier) * st->update_every);
             }
         }
         rrddim_foreach_done(rd);


### PR DESCRIPTION
The calculation of tiers update every is wrong with 2 results:

1. tier2 becomes totally invalid
2. changing data collection frequency on the fly is wrong for tier1 and tier2

Fixed both of them.