### PR TITLE
Properly guard commands when installing services for offline service managers.

### DIFF
--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -243,7 +243,9 @@ install_systemd_service() {
   fi
 
   if [ "${ENABLE}" = "auto" ]; then
-    IS_NETDATA_ENABLED="$(systemctl is-enabled netdata 2> /dev/null || echo "Netdata not there")"
+    if [ "$(check_systemd)" = "YES" ]; then
+      IS_NETDATA_ENABLED="$(systemctl is-enabled netdata 2> /dev/null || echo "Netdata not there")"
+    fi
 
     if [ "${IS_NETDATA_ENABLED}" = "disabled" ]; then
       ENABLE="disable"
@@ -258,7 +260,7 @@ install_systemd_service() {
     exit 4
   fi
 
-  if check_systemd; then
+  if [ "$(check_systemd)" = "YES" ]; then
     if ! systemctl daemon-reload; then
         warning "Failed to reload systemd unit files."
     fi
@@ -270,7 +272,7 @@ install_systemd_service() {
 }
 
 systemd_cmds() {
-  if check_systemd; then
+  if [ "$(check_systemd)" = "YES" ]; then
     NETDATA_START_CMD='systemctl start netdata'
     NETDATA_STOP_CMD='systemctl stop netdata'
   else # systemd is not running, use external defaults by providing no commands
@@ -316,8 +318,12 @@ check_openrc() {
 }
 
 enable_openrc() {
-  runlevel="$(rc-status -r)"
+  if [ "$(check_openrc)" = "YES" ]; then
+    runlevel="$(rc-status -r)"
+  fi
+
   runlevel="${runlevel:-default}"
+
   if ! rc-update add netdata "${runlevel}"; then
     warning "Failed to enable Netdata service in runlevel ${runlevel}."
   fi
@@ -339,7 +345,7 @@ install_openrc_service() {
 }
 
 openrc_cmds() {
-  if check_openrc; then
+  if [ "$(check_openrc)" = "YES" ]; then
     NETDATA_START_CMD='rc-service netdata start'
     NETDATA_STOP_CMD='rc-service netdata stop'
   else # Not booted using OpenRC, use external defaults by not providing commands.


### PR DESCRIPTION
##### Summary

The service installation code supports installing the agent as a system service for systemd or OpenRC on offline systems (that is, those not booted into those service managers), but in a number of places it was either blindly assuming the service manager was online or not properly checking that it was online. This PR fixes those cases, ensuring that installation in these cases proceeds correctly.

##### Test Plan

Testing for the OpenRC code can be done easily using the `gentoo/stage3:latest` Docker image. Without this PR, installation should fail to start the agent properly. With this PR, it should start the agent properly, albeit not as a system service.

Systemd testing is much more complicated, as I have not found a Docker image that provides an offline systemd installation. The easiest approach here is probably to mount an offline root filesystem from a system that uses systemd, chroot into that mount point, and attempt the install there. Unlike with OpenRC, the systemd case is _very_ noisy without this PR, and fails in a number of places.