### PR TITLE
Use llvm's ar and ranlib when compiling with clang

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,17 @@ AC_PROG_CXX
 AC_PROG_INSTALL
 PKG_PROG_PKG_CONFIG
 AC_USE_SYSTEM_EXTENSIONS
-AC_PROG_RANLIB
+
+AC_LANG_PUSH([C])
+AX_COMPILER_VENDOR
+AC_LANG_POP([C])
+if test "$ax_cv_c_compiler_vendor" == "clang"; then
+  AC_CHECK_TOOL([AR], [llvm-ar])
+  AC_CHECK_TOOL([RANLIB], [llvm-ranlib])
+else
+  AC_CHECK_TOOL([RANLIB], [ranlib])
+  AC_CHECK_TOOL([AR], [ar])
+fi
 
 # -----------------------------------------------------------------------------
 # configurable options

--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ AC_USE_SYSTEM_EXTENSIONS
 AC_LANG_PUSH([C])
 AX_COMPILER_VENDOR
 AC_LANG_POP([C])
-if test "$ax_cv_c_compiler_vendor" == "clang"; then
+if test "$ax_cv_c_compiler_vendor" = "clang"; then
   AC_CHECK_TOOL([AR], [llvm-ar])
   AC_CHECK_TOOL([RANLIB], [llvm-ranlib])
 else


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #13527 

This PR check for the C compiler vendor, and if it's `clang` sets `ar` and `ranlib` to `llvm-ar` and `llvm-ranlib`. It should fix the linker problem on FreeBSD with clang and lto enabled.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Need to cover various compile setups, i.e. a mix of Systems (FreeBSD/Linux) with compilers (clang/gcc) and enabled or disabled LTO.

Compiling on FreeBSD with gcc and LTO enabled, doesn't work. I think it's because `ar` and `ranlib` are not linked to gcc's one (whereas on Linux I believe it does). When installing gcc it includes e.g. `gcc-ar11` but not sure if we need to explicitly set configure to use that...

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

Not a configure expert, so if there is a better way to do it, please let me know!

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
