### PR TITLE
fix(cgroup.plugin): handle qemu-1- prefix when extracting virsh domain

### DIFF
--- a/collectors/cgroups.plugin/cgroup-network-helper.sh
+++ b/collectors/cgroups.plugin/cgroup-network-helper.sh
@@ -150,6 +150,7 @@ virsh_cgroup_to_domain_name() {
 
     # extract for the cgroup path
     sed -n -e "s|.*/machine-qemu\\\\x2d[0-9]\+\\\\x2d\(.*\)\.scope$|\1|p" \
+           -e "s|.*/machine/qemu-[0-9]\+-\(.*\)\.libvirt-qemu$|\1|p" \
            -e "s|.*/machine/\(.*\)\.libvirt-qemu$|\1|p" \
            <<EOF
 ${c}


### PR DESCRIPTION
##### Summary

Fixes: #13865

##### Test Plan

Tested the updated `sed` match expression manually.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
