### PR TITLE
Don't create a REMOVED alert event after a REMOVED.

### DIFF
--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -289,33 +289,35 @@ static void rrdcalc_unlink_from_rrdset(RRDCALC *rc, bool having_ll_wrlock) {
 
     time_t now = now_realtime_sec();
 
-    ALARM_ENTRY *ae = health_create_alarm_entry(
-        host,
-        rc->id,
-        rc->next_event_id++,
-        rc->config_hash_id,
-        now,
-        rc->name,
-        rc->rrdset->id,
-        rc->rrdset->context,
-        rc->rrdset->family,
-        rc->classification,
-        rc->component,
-        rc->type,
-        rc->exec,
-        rc->recipient,
-        now - rc->last_status_change,
-        rc->old_value,
-        rc->value,
-        rc->status,
-        RRDCALC_STATUS_REMOVED,
-        rc->source,
-        rc->units,
-        rc->info,
-        0,
-        0);
+    if (likely(rc->status != RRDCALC_STATUS_REMOVED)) {
+        ALARM_ENTRY *ae = health_create_alarm_entry(
+            host,
+            rc->id,
+            rc->next_event_id++,
+            rc->config_hash_id,
+            now,
+            rc->name,
+            rc->rrdset->id,
+            rc->rrdset->context,
+            rc->rrdset->family,
+            rc->classification,
+            rc->component,
+            rc->type,
+            rc->exec,
+            rc->recipient,
+            now - rc->last_status_change,
+            rc->old_value,
+            rc->value,
+            rc->status,
+            RRDCALC_STATUS_REMOVED,
+            rc->source,
+            rc->units,
+            rc->info,
+            0,
+            0);
 
-    health_alarm_log_add_entry(host, ae);
+        health_alarm_log_add_entry(host, ae);
+    }
 
     debug(D_HEALTH, "Health unlinking alarm '%s.%s' from chart '%s' of host '%s'", rrdcalc_chart_name(rc), rrdcalc_name(rc), rrdset_id(st), rrdhost_hostname(host));
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

When a chart becomes obsolete and we create a REMOVED event, when the agent shutsdown it creates another REMOVED event on top of that during the unlink procedure.

This PR adds a check to prevent from creating a second REMOVED if the alarm status is already REMOVED.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

1) Mount a storage device
2) Start netdata, make sure it creates an alert for it. (e.g. disk space)
3) Unmount the device.
4) There should be a REMOVED event for that device's alert.
5) Shutdown the agent. Without this PR there will be another REMOVED event. With this PR there should not.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
