### PR TITLE
allow single chart to be filtered in context queries

### DIFF
--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -723,7 +723,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
         goto cleanup;
     }
 
-    if(chart) {
+    if(chart && !context) {
         // check if this is a specific chart
         st = rrdset_find(host, chart);
         if (!st) st = rrdset_find_byname(host, chart);


### PR DESCRIPTION
Fixes https://github.com/netdata/netdata-cloud/issues/434

When a single chart was given in a context query, the query engine mistakenly was turning the query from a context query to a chart query.

When both chart and context are given, the query engine now run the query as a context one, with a chart filtering.