### PR TITLE
Finish renaming the `--install` option to `--install-prefix`.

### DIFF
--- a/.github/scripts/run_install_with_dist_file.sh
+++ b/.github/scripts/run_install_with_dist_file.sh
@@ -33,7 +33,7 @@ docker run \
   -v "${PWD}:/netdata" \
   -w /netdata \
   "ubuntu:latest" \
-  /bin/bash -c "./install-required-packages.sh --dont-wait --non-interactive netdata && apt install wget && ./netdata-installer.sh --dont-wait --require-cloud --disable-telemetry --install /tmp --one-time-build && echo \"Validating netdata instance is running\" && wget -O - 'http://127.0.0.1:19999/api/v1/info' | grep version"
+  /bin/bash -c "./install-required-packages.sh --dont-wait --non-interactive netdata && apt install wget && ./netdata-installer.sh --dont-wait --require-cloud --disable-telemetry --install-prefix /tmp --one-time-build && echo \"Validating netdata instance is running\" && wget -O - 'http://127.0.0.1:19999/api/v1/info' | grep version"
 popd || exit 1
 
 echo "All Done!"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Prepare environment
         run: ./packaging/installer/install-required-packages.sh --dont-wait --non-interactive netdata
       - name: Build netdata
-        run: ./netdata-installer.sh --dont-start-it --disable-telemetry --dont-wait --install /tmp/install --one-time-build
+        run: ./netdata-installer.sh --dont-start-it --disable-telemetry --dont-wait --install-prefix /tmp/install --one-time-build
       - name: Check that repo is clean
         run: |
           git status --porcelain=v1 > /tmp/porcelain

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Prepare environment
         run: ./packaging/installer/install-required-packages.sh --dont-wait --non-interactive netdata
       - name: Build netdata
-        run: ./netdata-installer.sh --dont-start-it --disable-telemetry --dont-wait --install /tmp/install --one-time-build
+        run: ./netdata-installer.sh --dont-start-it --disable-telemetry --dont-wait --install-prefix /tmp/install --one-time-build
       - name: Run CodeQL
         uses: github/codeql-action/analyze@v2
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,6 @@ jobs:
     - stage: Build process
 
       name: Standard netdata build
-      script: fakeroot ./netdata-installer.sh --install $HOME --dont-wait --dont-start-it --enable-plugin-nfacct --enable-plugin-freeipmi --disable-lto
+      script: fakeroot ./netdata-installer.sh --install-prefix $HOME --dont-wait --dont-start-it --enable-plugin-nfacct --enable-plugin-freeipmi --disable-lto
       env: CFLAGS='-O1 -Wall -Wextra -Wformat-signedness -fstack-protector-all -fno-common   -DNETDATA_INTERNAL_CHECKS=1 -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1'
       after_failure: post_message "TRAVIS_MESSAGE" "<!here> standard netdata build is failing (Still dont know which one, will improve soon)"

--- a/claim/README.md
+++ b/claim/README.md
@@ -288,7 +288,7 @@ you don't see the node in your Space after 60 seconds, see the [troubleshooting 
 To connect a node that is running on a macOS environment the script that will be provided to you by Netdata Cloud is the [kickstart](/packaging/installer/methods/macos.md#install-netdata-with-our-automatic-one-line-installation-script) which will install the Netdata Agent on your node, if it isn't already installed, and connect the node to Netdata Cloud. It should be similar to:
 
 ```bash
-curl https://my-netdata.io/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh --install /usr/local/ --claim-token TOKEN --claim-rooms ROOM1,ROOM2 --claim-url https://api.netdata.cloud
+curl https://my-netdata.io/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh --install-prefix /usr/local/ --claim-token TOKEN --claim-rooms ROOM1,ROOM2 --claim-url https://api.netdata.cloud
 ```
 The script should return `Agent was successfully claimed.`. If the connecting to Netdata Cloud process returns errors, or if you don't see
 the node in your Space after 60 seconds, see the [troubleshooting information](#troubleshooting).
@@ -382,10 +382,10 @@ For a successful execution you will need to run the script with root privileges 
 
 #### bash: netdata-claim.sh: command not found
 
-If you run the claiming script and see a `command not found` error, you either installed Netdata in a non-standard
-location or are using an unsupported package. If you installed Netdata in a non-standard path using the `--install`
-option, you need to update your `$PATH` or run `netdata-claim.sh` using the full path. For example, if you installed
-Netdata to `/opt/netdata`, use `/opt/netdata/bin/netdata-claim.sh` to run the claiming script.
+If you run the claiming script and see a `command not found` error, you either installed Netdata in a
+non-standard location or are using an unsupported package. If you installed Netdata in a non-standard path using the
+`--install-prefix` option, you need to update your `$PATH` or run `netdata-claim.sh` using the full path. For example,
+if you installed Netdata to `/opt/netdata`, use `/opt/netdata/bin/netdata-claim.sh` to run the claiming script.
 
 If you are using an unsupported package, such as a third-party `.deb`/`.rpm` package provided by your distribution,
 please remove that package and reinstall using our [recommended kickstart
@@ -538,7 +538,7 @@ wget -O /tmp/netdata-kickstart.sh https://my-netdata.io/kickstart.sh && sh /tmp/
 **macOS**
 
 ```bash
-curl https://my-netdata.io/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh --install /usr/local/
+curl https://my-netdata.io/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh --install-prefix /usr/local/
 ```
 ### Claiming script
 

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -163,10 +163,6 @@ banner_nonroot_install() {
 
       $PROGRAM ${@} --install-prefix /tmp
 
-  or
-
-      $PROGRAM ${@} --install /tmp
-
   or, run the installer as root:
 
       sudo $PROGRAM ${@}
@@ -203,8 +199,7 @@ usage() {
 USAGE: ${PROGRAM} [options]
        where options include:
 
-  --install <path>           Install netdata in <path>. Ex. --install /opt will put netdata in /opt/netdata, this option is deprecated and will be removed in a future version, please use --install-prefix instead.
-  --install-prefix <path>           Install netdata in <path>. Ex. --install-prefix /opt will put netdata in /opt/netdata.
+  --install-prefix <path>    Install netdata in <path>. Ex. --install-prefix /opt will put netdata in /opt/netdata.
   --dont-start-it            Do not (re)start netdata after installation.
   --dont-wait                Run installation in non-interactive mode.
   --stable-channel           Use packages from GitHub release pages instead of nightly updates.
@@ -365,10 +360,6 @@ while [ -n "${1}" ]; do
       ;;
     "--build-json-c")
       NETDATA_BUILD_JSON_C=1
-      ;;
-    "--install")
-      NETDATA_PREFIX="${2}/netdata"
-      shift 1
       ;;
     "--install-prefix")
       NETDATA_PREFIX="${2}/netdata"

--- a/packaging/installer/UNINSTALL.md
+++ b/packaging/installer/UNINSTALL.md
@@ -51,7 +51,7 @@ A workflow for uninstallation looks like this:
 2.  If you cannot find that file and would like to uninstall Netdata, then create a new file with the following content:
 
 ```sh
-NETDATA_PREFIX="<installation prefix>"   # put what you used as a parameter to shell installed `--install` flag. Otherwise it should be empty
+NETDATA_PREFIX="<installation prefix>"   # put what you used as a parameter to shell installed `--install-prefix` flag. Otherwise it should be empty
 NETDATA_ADDED_TO_GROUPS="<additional groups>"  # Additional groups for a user running the Netdata process
 ```
 

--- a/packaging/installer/UPDATE.md
+++ b/packaging/installer/UPDATE.md
@@ -45,7 +45,7 @@ command:
 wget -O /tmp/netdata-kickstart.sh https://my-netdata.io/kickstart.sh && sh /tmp/netdata-kickstart.sh --dry-run
 ```
 
-Note that if you installed Netdata using an installation prefix, you will need to add an `--install` option
+Note that if you installed Netdata using an installation prefix, you will need to add an `--install-prefix` option
 specifying that prefix to make sure it finds the existing install.
 
 If you see a line starting with `--- Would attempt to update existing installation by running the updater script
@@ -61,7 +61,7 @@ In most cases, you can update netdata using our one-line installation script.  T
 run the update script that was installed as part of the initial install (even if you disabled automatic updates)
 and preserve the existing install options you specified.
 
-If you installed Netdata using an installation prefix, you will need to add an `--install` option specifying
+If you installed Netdata using an installation prefix, you will need to add an `--install-prefix` option specifying
 that prefix to this command to make sure it finds Netdata.
 
 ```bash

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -181,7 +181,6 @@ USAGE: kickstart.sh [options]
   --reinstall-even-if-unsafe       Even try to reinstall if we don't think we can do so safely (implies --reinstall).
   --disable-cloud                  Disable support for Netdata Cloud (default: detect)
   --require-cloud                  Only install if Netdata Cloud can be enabled. Overrides --disable-cloud.
-  --install <path>                 This option is deprecated and will be removed in a future version, use --install-prefix instead.
   --install-prefix <path>          Specify an installation prefix for local builds (default: autodetect based on system type).
   --old-install-prefix <path>      Specify an old local builds installation prefix for uninstall/reinstall (if it's not default).
   --install-version <version>      Specify the version of Netdata to install.
@@ -1044,7 +1043,7 @@ EOF
 
 confirm_install_prefix() {
   if [ -n "${INSTALL_PREFIX}" ] && [ "${NETDATA_ONLY_BUILD}" -ne 1 ]; then
-    fatal "The --install-prefix and --install options are only supported together with the --build-only option." F0204
+    fatal "The --install-prefix option is only supported together with the --build-only option." F0204
   fi
 
   if [ -n "${INSTALL_PREFIX}" ]; then
@@ -2146,11 +2145,6 @@ parse_args() {
       "--disable-telemetry")
         NETDATA_DISABLE_TELEMETRY="1"
         NETDATA_INSTALLER_OPTIONS="${NETDATA_INSTALLER_OPTIONS} --disable-telemetry"
-        ;;
-      "--install")
-        warning "--install flag is deprecated and will be removed in a future version. Please use --install-prefix instead."
-        INSTALL_PREFIX="${2}"
-        shift 1
         ;;
       "--install-prefix")
         INSTALL_PREFIX="${2}"

--- a/packaging/installer/methods/freebsd.md
+++ b/packaging/installer/methods/freebsd.md
@@ -45,7 +45,7 @@ gunzip netdata*.tar.gz && tar xf netdata*.tar && rm -rf netdata*.tar
 Install Netdata in `/opt/netdata`. If you want to enable automatic updates, add `--auto-update` or `-u` to install `netdata-updater` in `cron` (**need root permission**):
 
 ```sh
-cd netdata-v* && ./netdata-installer.sh --install /opt && cp /opt/netdata/usr/sbin/netdata-claim.sh /usr/sbin/
+cd netdata-v* && ./netdata-installer.sh --install-prefix /opt && cp /opt/netdata/usr/sbin/netdata-claim.sh /usr/sbin/
 ```
 
 You also need to enable the `netdata` service in `/etc/rc.conf`:
@@ -75,7 +75,7 @@ The `netdata-updater.sh` script will update your Agent.
 ## Optional parameters to alter your installation
 | parameters | Description |
 |:-----:|-----------|
-|`--install <path>`| Install netdata in `<path>.` Ex: `--install /opt` will put netdata in `/opt/netdata`|
+|`--install-prefix <path>`| Install netdata in `<path>.` Ex: `--install-prefix /opt` will put netdata in `/opt/netdata`|
 | `--dont-start-it` | Do not (re)start netdata after installation|
 | `--dont-wait` | Run installation in non-interactive mode|
 | `--auto-update` or `-u` | Install netdata-updater in cron to update netdata automatically once per day|

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -68,7 +68,6 @@ The `kickstart.sh` script accepts a number of optional parameters to control how
 - `--disable-cloud`: For local builds, don’t build any of the cloud code at all. For native packages and static builds,
     use runtime configuration to disable cloud support.
 - `--require-cloud`: Only install if Netdata Cloud can be enabled. Overrides `--disable-cloud`.
-- `--install`: Specify an installation prefix for local builds (by default, we use a sane prefix based on the type of system), this option is deprecated and will be removed in a future version, please use `--install-prefix` instead.
 - `--install-prefix`: Specify an installation prefix for local builds (by default, we use a sane prefix based on the type of system).
 - `--install-version`: Specify the version of Netdata to install.
 - `--old-install-prefix`: Specify the custom local build's installation prefix that should be removed.

--- a/packaging/installer/methods/macos.md
+++ b/packaging/installer/methods/macos.md
@@ -48,7 +48,7 @@ area](https://learn.netdata.cloud/docs/cloud/spaces#manage-spaces).
 
 For example: 
 ```bash
-curl https://my-netdata.io/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh --install /usr/local/ --claim-token TOKEN --claim-rooms ROOM1,ROOM2 --claim-url https://api.netdata.cloud
+curl https://my-netdata.io/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh --install-prefix /usr/local/ --claim-token TOKEN --claim-rooms ROOM1,ROOM2 --claim-url https://api.netdata.cloud
 ```
 The Netdata Agent is installed under `/usr/local/netdata` on your machine. Your machine will also show up as a node in your Netdata Cloud.
 
@@ -93,7 +93,7 @@ We don't recommend installing Netdata from source on macOS, as it can be difficu
 
    ```bash
    cd netdata/
-   sudo ./netdata-installer.sh --install /usr/local
+   sudo ./netdata-installer.sh --install-prefix /usr/local
    ```
 
 > Your Netdata configuration directory will be at `/usr/local/netdata/`. 

--- a/packaging/installer/methods/manual.md
+++ b/packaging/installer/methods/manual.md
@@ -189,7 +189,7 @@ cd netdata
 
 -   You can also append `--stable-channel` to fetch and install only the official releases from GitHub, instead of the nightly builds.
 
--   If you don't want to install it on the default directories, you can run the installer like this: `./netdata-installer.sh --install /opt`. This one will install Netdata in `/opt/netdata`.
+-   If you don't want to install it on the default directories, you can run the installer like this: `./netdata-installer.sh --install-prefix /opt`. This one will install Netdata in `/opt/netdata`.
 
 -   If your server does not have access to the internet and you have manually put the installation directory on your server, you will need to pass the option `--disable-go` to the installer. The option will prevent the installer from attempting to download and install `go.d.plugin`. 
 

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -27,7 +27,7 @@ export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"
 export CMAKE_FLAGS="-DOPENSSL_ROOT_DIR=/openssl-static -DOPENSSL_LIBRARIES=/openssl-static/lib -DCMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE=/openssl-static -DLWS_OPENSSL_INCLUDE_DIRS=/openssl-static/include -DLWS_OPENSSL_LIBRARIES=/openssl-static/lib/libssl.a;/openssl-static/lib/libcrypto.a"
 
 run ./netdata-installer.sh \
-  --install "${NETDATA_INSTALL_PARENT}" \
+  --install-prefix "${NETDATA_INSTALL_PARENT}" \
   --dont-wait \
   --dont-start-it \
   --require-cloud \

--- a/tests/lifecycle.bats
+++ b/tests/lifecycle.bats
@@ -34,7 +34,7 @@ setup() {
 }
 
 @test "install netdata" {
-	./netdata-installer.sh  --dont-wait --dont-start-it --auto-update --install "${INSTALLATION}"
+	./netdata-installer.sh  --dont-wait --dont-start-it --auto-update --install-prefix "${INSTALLATION}"
 
 	# Validate particular files
 	for file in $FILES; do

--- a/tests/run-unit-tests.sh
+++ b/tests/run-unit-tests.sh
@@ -21,7 +21,7 @@
 install_netdata() {
   echo "Installing Netdata"
   fakeroot ./netdata-installer.sh \
-    --install "$HOME" \
+    --install-prefix "$HOME" \
     --dont-wait \
     --dont-start-it \
     --enable-plugin-nfacct \

--- a/tests/updater_checks.bats
+++ b/tests/updater_checks.bats
@@ -34,7 +34,7 @@ setup() {
 }
 
 @test "install stable netdata using kickstart" {
-	./packaging/installer/kickstart.sh --dont-wait --dont-start-it --auto-update --install ${INSTALLATION}
+	./packaging/installer/kickstart.sh --dont-wait --dont-start-it --auto-update --install-prefix ${INSTALLATION}
 
 	# Validate particular files
 	for file in $FILES; do


### PR DESCRIPTION
##### Summary

SSIA

##### Test Plan

Attempting to use `--install` with the kickstart script or netdata-installer.sh should not result in the agent being installed to the specified prefix.

##### Additional Information

Fixes: #12659 

Should not be merged before #12943 (otherwise the error messages for the user will be more confusing).