### PR TITLE
Fix typo in CI distribution data file.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -114,7 +114,7 @@ include:
     version: "36"
     packages:
       <<: *fedora_packages
-      repo_distro: fedora/35
+      repo_distro: fedora/36
       arches:
         - x86_64
         - armhfp


### PR DESCRIPTION
##### Summary

The file listed the incorrect repository name for the Fedora 36 entry.

##### Test Plan

n/a