### PR TITLE
dictionaries technical debt

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1190,6 +1190,8 @@ int rrdhost_should_be_removed(RRDHOST *host, RRDHOST *protected_host, time_t now
 
 void rrdset_update_heterogeneous_flag(RRDSET *st);
 
+void rrdset_acquired_release(RRDSET_ACQUIRED *rsa);
+RRDSET_ACQUIRED *rrdset_find_and_acquire(RRDHOST *host, const char *id);
 RRDSET *rrdset_find(RRDHOST *host, const char *id);
 #define rrdset_find_localhost(id) rrdset_find(localhost, id)
 /* This will not return charts that are archived */


### PR DESCRIPTION
- [x] RRDSET name index using dictionary views (was independent dictionary)
- [ ] RRDCALC chart index using dictionary views (was linked list)
- [ ] RRDHOST memory management using dictionaries

Traversing dictionaries acquires the currently working item, so working on it is safe, the item cannot suddenly vanish. However, there are still unsafe calls that allow a caller to get an RRDHOST, RRDSET or RRDDIM without traversing a dictionary and therefore access to these objects this way is prone for errors and crashes. The following work should eliminate all such cases:

- [ ] RRDHOST acquiring for all uses (eliminate direct access to RRDHOST)
- [ ] RRDSET acquiring for all uses (eliminate direct access to RRDSET)
- [ ] RRDDIM acquiring for all uses (eliminate direct access to RRDDIM)
