### PR TITLE
Fix systemd chart update (eBPF)

### DIFF
--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -905,21 +905,16 @@ static void ebpf_create_systemd_cachestat_charts(int update_every)
  * Send Cache Stat charts
  *
  * Send collected data to Netdata.
- *
- * @return It returns the status for chart creation, if it is necessary to remove a specific dimension, zero is returned
- *         otherwise function returns 1 to avoid chart recreation
  */
 static int ebpf_send_systemd_cachestat_charts()
 {
-    int ret = 1;
     ebpf_cgroup_target_t *ect;
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_HIT_RATIO_CHART);
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_cachestat.ratio);
-        } else if (unlikely(ect->systemd))
-            ret = 0;
+        }
     }
     write_end_chart();
 
@@ -946,8 +941,6 @@ static int ebpf_send_systemd_cachestat_charts()
         }
     }
     write_end_chart();
-
-    return ret;
 }
 
 /**
@@ -1071,13 +1064,11 @@ void ebpf_cachestat_send_cgroup_data(int update_every)
 
     int has_systemd = shm_ebpf_cgroup.header->systemd_enabled;
     if (has_systemd) {
-        static int systemd_charts = 0;
-        if (!systemd_charts) {
+        if (send_cgroup_chart) {
             ebpf_create_systemd_cachestat_charts(update_every);
-            systemd_charts = 1;
         }
 
-        systemd_charts = ebpf_send_systemd_cachestat_charts();
+        ebpf_send_systemd_cachestat_charts();
     }
 
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -906,7 +906,7 @@ static void ebpf_create_systemd_cachestat_charts(int update_every)
  *
  * Send collected data to Netdata.
  */
-static int ebpf_send_systemd_cachestat_charts()
+static void ebpf_send_systemd_cachestat_charts()
 {
     ebpf_cgroup_target_t *ect;
 

--- a/collectors/ebpf.plugin/ebpf_cgroup.c
+++ b/collectors/ebpf.plugin/ebpf_cgroup.c
@@ -100,24 +100,6 @@ void ebpf_map_cgroup_shared_memory()
 // Close and Cleanup
 
 /**
- * Close shared memory
- */
-void ebpf_close_cgroup_shm()
-{
-    if (shm_sem_ebpf_cgroup != SEM_FAILED) {
-        sem_close(shm_sem_ebpf_cgroup);
-        sem_unlink(NETDATA_NAMED_SEMAPHORE_EBPF_CGROUP_NAME);
-        shm_sem_ebpf_cgroup = SEM_FAILED;
-    }
-
-    if (shm_fd_ebpf_cgroup > 0) {
-        close(shm_fd_ebpf_cgroup);
-        shm_unlink(NETDATA_SHARED_MEMORY_EBPF_CGROUP_NAME);
-        shm_fd_ebpf_cgroup = -1;
-    }
-}
-
-/**
  * Clean Specific cgroup pid
  *
  * Clean all PIDs associated with cgroup.

--- a/collectors/ebpf.plugin/ebpf_cgroup.c
+++ b/collectors/ebpf.plugin/ebpf_cgroup.c
@@ -6,6 +6,7 @@
 #include "ebpf_cgroup.h"
 
 ebpf_cgroup_target_t *ebpf_cgroup_pids = NULL;
+int send_cgroup_chart = 0;
 
 // --------------------------------------------------------------------------------------------------------------------
 // Map shared memory
@@ -259,7 +260,7 @@ static void ebpf_update_pid_link_list(ebpf_cgroup_target_t *ect, char *path)
  *
  * Set variable remove. If this variable is not reset, the structure will be removed from link list.
  */
- void ebpf_reset_updated_var()
+void ebpf_reset_updated_var()
  {
      ebpf_cgroup_target_t *ect;
      for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
@@ -274,6 +275,7 @@ static void ebpf_update_pid_link_list(ebpf_cgroup_target_t *ect, char *path)
  */
 void ebpf_parse_cgroup_shm_data()
 {
+    static int previous = 0;
     if (shm_ebpf_cgroup.header) {
         sem_wait(shm_sem_ebpf_cgroup);
         int i, end = shm_ebpf_cgroup.header->cgroup_root_count;
@@ -291,6 +293,11 @@ void ebpf_parse_cgroup_shm_data()
                 ebpf_update_pid_link_list(ect, ptr->path);
             }
         }
+        send_cgroup_chart = previous != shm_ebpf_cgroup.header->cgroup_root_count;
+        previous = shm_ebpf_cgroup.header->cgroup_root_count;
+#ifdef NETDATA_DEV_MODE
+        error("Updating cgroup %d (Previous: %d, Current: %d)", send_cgroup_chart, previous, shm_ebpf_cgroup.header->cgroup_root_count);
+#endif
         pthread_mutex_unlock(&mutex_cgroup_shm);
 
         sem_post(shm_sem_ebpf_cgroup);

--- a/collectors/ebpf.plugin/ebpf_cgroup.h
+++ b/collectors/ebpf.plugin/ebpf_cgroup.h
@@ -65,5 +65,6 @@ void ebpf_parse_cgroup_shm_data();
 void ebpf_close_cgroup_shm();
 void ebpf_create_charts_on_systemd(char *id, char *title, char *units, char *family, char *charttype, int order,
                                           char *algorithm, char *context, char *module, int update_every);
+extern int send_cgroup_chart;
 
 #endif /* NETDATA_EBPF_CGROUP_H */

--- a/collectors/ebpf.plugin/ebpf_cgroup.h
+++ b/collectors/ebpf.plugin/ebpf_cgroup.h
@@ -62,7 +62,6 @@ typedef struct ebpf_cgroup_target {
 
 void ebpf_map_cgroup_shared_memory();
 void ebpf_parse_cgroup_shm_data();
-void ebpf_close_cgroup_shm();
 void ebpf_create_charts_on_systemd(char *id, char *title, char *units, char *family, char *charttype, int order,
                                           char *algorithm, char *context, char *module, int update_every);
 extern int send_cgroup_chart;

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -1150,8 +1150,6 @@ static void process_collector(ebpf_module_t *em)
             update_apps_list = 0;
             cleanup_exited_pids();
             collect_data_for_all_processes(pid_fd);
-
-            ebpf_create_apps_charts(apps_groups_root_target);
         }
         pthread_mutex_unlock(&collect_data_mutex);
 
@@ -1162,6 +1160,8 @@ static void process_collector(ebpf_module_t *em)
 
             netdata_apps_integration_flags_t apps_enabled = em->apps_charts;
             pthread_mutex_lock(&collect_data_mutex);
+
+            ebpf_create_apps_charts(apps_groups_root_target);
             if (all_pids_count > 0) {
                 if (apps_enabled) {
                     ebpf_process_update_apps_data();

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -973,20 +973,15 @@ static void ebpf_create_systemd_process_charts(ebpf_module_t *em)
  * Send collected data to Netdata.
  *
  *  @param em   the structure with thread information
- *
- * @return It returns the status for chart creation, if it is necessary to remove a specific dimension, zero is returned
- *         otherwise function returns 1 to avoid chart recreation
  */
-static int ebpf_send_systemd_process_charts(ebpf_module_t *em)
+static void ebpf_send_systemd_process_charts(ebpf_module_t *em)
 {
-    int ret = 1;
     ebpf_cgroup_target_t *ect;
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_PROCESS);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_ps.create_process);
-        } else if (unlikely(ect->systemd))
-            ret = 0;
+        }
     }
     write_end_chart();
 
@@ -1023,8 +1018,6 @@ static int ebpf_send_systemd_process_charts(ebpf_module_t *em)
         }
         write_end_chart();
     }
-
-    return ret;
 }
 
 /**
@@ -1046,13 +1039,11 @@ static void ebpf_process_send_cgroup_data(ebpf_module_t *em)
     int has_systemd = shm_ebpf_cgroup.header->systemd_enabled;
 
     if (has_systemd) {
-        static int systemd_chart = 0;
-        if (!systemd_chart) {
+        if (send_cgroup_chart) {
             ebpf_create_systemd_process_charts(em);
-            systemd_chart = 1;
         }
 
-        systemd_chart = ebpf_send_systemd_process_charts(em);
+        ebpf_send_systemd_process_charts(em);
     }
 
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -1336,20 +1336,15 @@ static void ebpf_create_systemd_vfs_charts(ebpf_module_t *em)
  * Send collected data to Netdata.
  *
  *  @param em the main collector structure
- *
- *  @return It returns the status for chart creation, if it is necessary to remove a specific dimension, zero is returned
- *          otherwise function returns 1 to avoid chart recreation
  */
-static int ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
+static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
 {
-    int ret = 1;
     ebpf_cgroup_target_t *ect;
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_DELETED);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.unlink_call);
-        } else if (unlikely(ect->systemd))
-            ret = 0;
+        }
     }
     write_end_chart();
 
@@ -1465,8 +1460,6 @@ static int ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
         }
         write_end_chart();
     }
-
-    return ret;
 }
 
 /**
@@ -1487,13 +1480,10 @@ static void ebpf_vfs_send_cgroup_data(ebpf_module_t *em)
 
     int has_systemd = shm_ebpf_cgroup.header->systemd_enabled;
     if (has_systemd) {
-        static int systemd_charts = 0;
-        if (!systemd_charts) {
+        if (send_cgroup_chart) {
             ebpf_create_systemd_vfs_charts(em);
-            systemd_charts = 1;
         }
-
-        systemd_charts = ebpf_send_systemd_vfs_charts(em);
+        ebpf_send_systemd_vfs_charts(em);
     }
 
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {


### PR DESCRIPTION
##### Summary
This PR fix:

```sh
2022-10-23 03:18:30: netdata ERROR : PLUGINSD[ebpf] : (0258@collectors/plugins.d:pluginsd_dimens): requested a DIMENSION, without a CHART, on host 'box'. Disabling it.
2022-10-23 03:18:30: netdata IERR  : PLUGINSD[ebpf] : (0337@parser/parser.c     :parser_action  ): action_function() failed with rc = 2
2022-10-23 03:18:30: netdata IERR  : PLUGINSD[ebpf] : (0348@parser/parser.c     :parser_action  ): parser_action() failed.
2022-10-23 03:18:30: netdata ERROR : PLUGINSD[ebpf] : (0133@collectors/plugins.d:pluginsd_worker): '/usr/libexec/netdata/plugins.d/ebpf.plugin' (pid 21184) disconnected after 59773 successful data collections (ENDs).
2022-10-23 03:18:34: netdata ERROR : PLUGINSD[ebpf] : (0412@libnetdata/popen/pop:netdata_pclose ): child pid 21184 exited with code 15.
2022-10-23 03:18:34: netdata ERROR : PLUGINSD[ebpf] : (0091@collectors/plugins.d:pluginsd_worker): '/usr/libexec/netdata/plugins.d/ebpf.plugin' (pid 21184) exited with error code 15, but has given useful output in the past (59773 times). Will not start it again - it is disabled.
2022-10-23 03:18:44: netdata INFO  : PLUGINSD[ebpf] : (0120@libnetdata/threads/t:thread_cleanup ): thread with task id 21167 finished
```

When a service was starting after eBPF plugin is running, it was not recreating properly the dimensions and this could create previous error. This PR is fixing this.

##### Test Plan
I am really sorry for this, but you will need to use `systemd` to test the PR. :smile: 

1. Compile this PR on an environment with `systemd`. I suggest to compile with flag `-DNETDATA_DEV_MODE=1`.
2. Be sure that integration between `eBPF` and `cgroup` inside your `/etc/netdata/ebpf.d.conf`:
```sh
[global]
    apps = yes
    cgroups = yes
```
3. Start netdata.
4. Wait at least 2 minutes and stop a service. 
5. Now start the service again, and wait few minutes.  
6. After these steps the plugin should not stop anymore.
##### Additional Information
It is not necessary to test on different kernels.

A quick update, I ran this PR during 10 hours without any issue. I was not able to run too long with current master on Arch Linux.

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? eBPF.plugin
- Can they see the change or is it an under the hood? If they can see it, where? Yes, the plugin won't fail when a service is stopped.
- How is the user impacted by the change?  A better plugin
- What are there any benefits of the change? eBPF will monitor systemd without issues.
</details>