### PR TITLE
Fix duplicate error code in kickstart.sh.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
-# Next unused error code: F050B
+# Next unused error code: F050C
 
 # ======================================================================
 # Constants
@@ -1087,7 +1087,7 @@ claim() {
   fi
 
   if [ ! -x "${NETDATA_CLAIM_PATH}" ]; then
-    fatal "Unable to find usable claiming script. Reinstalling Netdata may resolve this." F050A
+    fatal "Unable to find usable claiming script. Reinstalling Netdata may resolve this." F050B
   fi
 
   if ! is_netdata_running; then

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
-# Next unused error code: F050A
+# Next unused error code: F050B
 
 # ======================================================================
 # Constants
@@ -1087,7 +1087,7 @@ claim() {
   fi
 
   if [ ! -x "${NETDATA_CLAIM_PATH}" ]; then
-    fatal "Unable to find usable claiming script. Reinstalling Netdata may resolve this." F0106
+    fatal "Unable to find usable claiming script. Reinstalling Netdata may resolve this." F050A
   fi
 
   if ! is_netdata_running; then


### PR DESCRIPTION
##### Summary

The `F0106` error code was being used in two unrelated places. Fix this by updating the less commonly encountered instance to a different code.

##### Test Plan

n/a