### PR TITLE
Prompt users about updates/claiming on unknown install types.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
-# Next unused error code: F050C
+# Next unused error code: F050D
 
 # ======================================================================
 # Constants
@@ -900,7 +900,15 @@ handle_existing_install() {
 
         return 0
       elif [ "${INSTALL_TYPE}" = "unknown" ]; then
-        fatal "We do not support trying to update or claim installations when we cannot determine the install type. You will need to uninstall the existing install using the same method you used to install it to proceed." F0106
+        if [ "${INTERACTIVE}" -eq 0 ] && [ "${NETDATA_CLAIM_ONLY}" -eq 0 ]; then
+          fatal "We do not support trying to update or claim installations when we cannot determine the install type. You will need to uninstall the existing install using the same method you used to install it to proceed. If you just want to claim this install, you can re-run this command with the --claim-only option." F0106
+        elif [ "${INTERACTIVE}" -eq 1 ] && [ "${NETDATA_CLAIM_ONLY}" -eq 0 ]; then
+          if confirm "Attempting to update an existing install is not officially supported. It may work, but it also might break your system. If you just want to claim this install, you should re-run this command with the --claim-only option instead. Are you sure you want to continue?"; then
+            progress "OK, continuing"
+          else
+            fatal "Cancelling update of unknown installation type at user request." F050C
+          fi
+        fi
       fi
 
       ret=0


### PR DESCRIPTION
##### Summary

Instead of blindly claiming a lack of support when dealing with an install of an unknown type and not running a reinstall:

- If the `--claim-only` option was provided, just continue and attempt to claim the install.
- If the `--claim-only` option was not specified, and we’re running interactively, prompt the user about whether they want to continue or not, warning them that the update may break things.
- If the `--claim-only` option was not specified, and we’re not running interactively, throw a fatal error just like we are already doing.
- In both of the above two cases, add info about the existence of the `--claim-only` option to the user-visible messaging.

This should significantly reduce the number of users getting stuck trying to claim installs made through third-party package managers.

##### Test Plan

The new code paths can be tested by doing a normal install, and then removing or renaming the `.install-type` file in the system configuration directory for Netdata.
