### PR TITLE
Overhaul generation of distinct-ids for install telemetry events.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -247,10 +247,16 @@ telemetry_event() {
     TOTAL_RAM="$((TOTAL_RAM * 1024))"
   fi
 
-  if [ -f /etc/machine-id ]; then
-    DISTINCT_ID="$(cat /etc/machine-id)"
+  if [ "${KERNEL_NAME}" = Darwin ] && command -v ioreg >/dev/null 2>&1; then
+    DISTINCT_ID="macos-$(ioreg -rd1 -c IOPlatformExpertDevice | awk '/IOPlatformUUID/ { split($0, line, "\""); printf("%s\n", line[4]); }')"
+  elif [ -f /etc/machine-id ]; then
+    DISTINCT_ID="machine-$(cat /etc/machine-id)"
+  elif [ -f /var/db/dbus/machine-id ]; then
+    DISTINCT_ID="dbus-$(cat /var/db/dbus/machine-id)"
+  elif [ -f /var/lib/dbus/machine-id ]; then
+    DISTINCT_ID="dbus-$(cat /var/lib/dbus/machine-id)"
   elif command -v uuidgen > /dev/null 2>&1; then
-    DISTINCT_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+    DISTINCT_ID="uuid-$(uuidgen | tr '[:upper:]' '[:lower:]')"
   else
     DISTINCT_ID="null"
   fi


### PR DESCRIPTION
##### Summary

- IDs are now tagged with the way they were generated. This will allow differentiation between duplicate IDs resulting from cloning of systems and those that are duplicates due to collisions.
- On macOS, try asking the IOKit registry for the machine ID. Unlike `/etc/machine-id` this will usually work correctly and avoid falling back to uuidgen.
- If `/etc/machine-id` does not exist, try the legacy paths for DBus machine IDs before falling back to uuidgen. This will often work on non-systemd systems (including some BSD installs).

##### Test Plan

n/a