### PR TITLE
Record installation command in telemetry events.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -44,6 +44,7 @@ INSTALL_PREFIX=""
 NETDATA_AUTO_UPDATES="default"
 NETDATA_CLAIM_ONLY=0
 NETDATA_CLAIM_URL="${PUBLIC_CLOUD_URL}"
+NETDATA_COMMAND="default"
 NETDATA_DISABLE_CLOUD=0
 NETDATA_ONLY_BUILD=0
 NETDATA_ONLY_NATIVE=0
@@ -272,6 +273,7 @@ telemetry_event() {
     "install_options": "${KICKSTART_OPTIONS}",
     "install_interactivity": "${INTERACTIVE}",
     "install_auto_updates": "${NETDATA_AUTO_UPDATES}",
+    "install_command": "${NETDATA_COMMAND}",
     "total_runtime": "${total_duration}",
     "selected_install_method": "${SELECTED_INSTALL_METHOD}",
     "netdata_release_channel": "${RELEASE_CHANNEL:-null}",
@@ -2051,9 +2053,18 @@ parse_args() {
             ;;
         esac
         ;;
-      "--reinstall") NETDATA_REINSTALL=1 ;;
-      "--reinstall-even-if-unsafe") NETDATA_UNSAFE_REINSTALL=1 ;;
-      "--claim-only") NETDATA_CLAIM_ONLY=1 ;;
+      "--reinstall")
+        NETDATA_REINSTALL=1
+        NETDATA_COMMAND="reinstall"
+        ;;
+      "--reinstall-even-if-unsafe")
+        NETDATA_UNSAFE_REINSTALL=1
+        NETDATA_COMMAND="unsafe-reinstall"
+        ;;
+      "--claim-only")
+        NETDATA_CLAIM_ONLY=1
+        NETDATA_COMMAND="claim-only"
+        ;;
       "--disable-cloud")
         NETDATA_DISABLE_CLOUD=1
         NETDATA_REQUIRE_CLOUD=0
@@ -2090,12 +2101,15 @@ parse_args() {
         ;;
       "--uninstall")
         ACTION="uninstall"
+        NETDATA_COMMAND="uninstall"
         ;;
       "--reinstall-clean")
         ACTION="reinstall-clean"
+        NETDATA_COMMAND="reinstall-clean"
         ;;
       "--repositories-only")
         REPO_ACTION="repositories-only"
+        NETDATA_COMMAND="repositories"
         ;;
       "--native-only")
         NETDATA_ONLY_NATIVE=1
@@ -2153,6 +2167,7 @@ parse_args() {
       "--prepare-offline-install-source")
         if [ -n "${2}" ]; then
           ACTION="prepare-offline"
+          NETDATA_COMMAND="prepare-offline"
           OFFLINE_TARGET="${2}"
           shift 1
         else


### PR DESCRIPTION
##### Summary

This way we can differentiate what type of thing users were trying to do for a given run of the kickstart script.

This adds a new parameter to telemetry events called `install_command` on the PostHog install events. Currently possible values for this and their meanings are:

- `default`: Used when no specific operation has been requested.
- `reinstall`: User requested a regular reinstall.
- `reinstall-clean`: User requested a clean reinstall.
- `unsafe-reinstall`: User requested a reinstall, even if it would be considered unsafe.
- `claim-only`: User required that the kickstart script only try to claim an existing install.
- `uninstall`: User requested that an existing install be uninstalled.
- `repositories`: User requested that only repository configuration be installed.
- `prepare-offline`: User requested that an offline install source be prepared.

##### Test Plan

n/a