### PR TITLE
fix(proc.plugin): fix read retry logic when reading interface speed

### DIFF
--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -1015,7 +1015,7 @@ int do_proc_net_dev(int update_every, usec_t dt) {
                         (d->speed_file_exists || now_monotonic_sec() - d->speed_file_lost_time > READ_RETRY_PERIOD)) {
                         ret = read_single_number_file(d->filename_speed, (unsigned long long *) &d->speed);
                     } else {
-                        d->speed = 0;
+                        d->speed = 0; // TODO: this is wrong, shouldn't use 0 value, but NULL.
                     }
 
                     if(ret) {
@@ -1057,8 +1057,10 @@ int do_proc_net_dev(int update_every, usec_t dt) {
                         rrdsetvar_custom_chart_variable_set(
                             d->st_bandwidth, d->chart_var_speed, (NETDATA_DOUBLE)d->speed * KILOBITS_IN_A_MEGABIT);
 
-                        d->speed_file_exists = 1;
-                        d->speed_file_lost_time = 0;
+                        if (d->speed) {
+                            d->speed_file_exists = 1;
+                            d->speed_file_lost_time = 0;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
##### Summary

`speed_file_exists` and `speed_file_lost_time` are used when deciding if we need to retry reading network interface speed. We should reset the flags only when the speed is successfully read.


##### Test Plan

Changes are straightforward, don't plan to test them. 

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
