### PR TITLE
Fix reading health "enable" from the configuration

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -849,6 +849,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info) {
         goto unittest;
     }
 
+    health_init();
     rrdpush_init();
 
     if(default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE || storage_tiers > 1 || rrdpush_receiver_needs_dbengine()) {

--- a/health/health.c
+++ b/health/health.c
@@ -135,6 +135,22 @@ static void health_silencers_init(void) {
     }
 }
 
+/**
+ * Health Init
+ *
+ * Initialize the health thread.
+ */
+void health_init(void) {
+    debug(D_HEALTH, "Health configuration initializing");
+
+    if(!(default_health_enabled = (unsigned int)config_get_boolean(CONFIG_SECTION_HEALTH, "enabled", default_health_enabled))) {
+        debug(D_HEALTH, "Health is disabled.");
+        return;
+    }
+
+    health_silencers_init();
+}
+
 // ----------------------------------------------------------------------------
 // re-load health configuration
 


### PR DESCRIPTION
##### Summary
The health init function was dropped by accident. This restores it and make sure the `[health]` enable configuration 
option is respected

##### Test Plan
Attempt to configure agent with health disabled before and after this PR
