### PR TITLE
Ensure consistency of kickstart script options that change operational mode of the script.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -104,7 +104,7 @@ main() {
       uninstall
       cleanup
 
-      ACTION=
+      ACTION=''
       INSTALL_PREFIX="${NEW_INSTALL_PREFIX}"
       # shellcheck disable=SC2086
       main
@@ -176,12 +176,9 @@ USAGE: kickstart.sh [options]
   --auto-update                    Enable automatic updates.
   --auto-update-type               Specify a particular scheduling type for auto-updates (valid types: systemd, interval, crontab)
   --disable-telemetry              Opt-out of anonymous statistics.
-  --repositories-only              Only install appropriate repository configuration packages (only for native install).
   --native-only                    Only install if native binary packages are available.
   --static-only                    Only install if a static build is available.
   --build-only                     Only install using a local build.
-  --reinstall                      Explicitly reinstall instead of updating any existing install.
-  --reinstall-even-if-unsafe       Even try to reinstall if we don't think we can do so safely (implies --reinstall).
   --disable-cloud                  Disable support for Netdata Cloud (default: detect)
   --require-cloud                  Only install if Netdata Cloud can be enabled. Overrides --disable-cloud.
   --install-prefix <path>          Specify an installation prefix for local builds (default: autodetect based on system type).
@@ -189,13 +186,19 @@ USAGE: kickstart.sh [options]
   --install-version <version>      Specify the version of Netdata to install.
   --claim-token                    Use a specified token for claiming to Netdata Cloud.
   --claim-rooms                    When claiming, add the node to the specified rooms.
-  --claim-only                     If there is an existing install, only try to claim it, not update it.
   --claim-*                        Specify other options for the claiming script.
   --no-cleanup                     Don't do any cleanup steps. This is intended to help with debugging the installer.
-  --uninstall                      Uninstall an existing installation of Netdata.
-  --reinstall-clean                Clean reinstall Netdata.
   --local-build-options            Specify additional options to pass to the installer code when building locally. Only valid if --build-only is also specified.
   --static-install-options         Specify additional options to pass to the static installer code. Only valid if --static-only is also specified.
+
+The following options are mutually exclusive and specifiy special operations other than trying to install Netdata normally or update an existing install:
+
+  --reinstall                      If there is an existing install, reinstall it instead of trying to update it. If there is not an existing install, install netdata normally.
+  --reinstall-even-if-unsafe       If there is an existing install, reinstall it instead of trying to update it, even if doing so is known to potentially break things. If there is not an existing install, install Netdata normally.
+  --reinstall-clean                If there is an existing install, uninstall it before trying to install Netdata. Fails if there is no existing install.
+  --uninstall                      Uninstall an existing installation of Netdata. Fails if there is no existing install.
+  --claim-only                     If there is an existing install, only try to claim it without attempting to update it. If there is no existing install, install and claim Netdata normally.
+  --repositories-only              Only install repository configuration packages instead of doing a full install of Netdata. Automatically sets --native-only.
   --prepare-offline-install-source Instead of installing the agent, prepare a directory that can be used to install on another system without needing to download anything.
 
 Additionally, this script may use the following environment variables:
@@ -2123,6 +2126,17 @@ validate_args() {
   fi
 }
 
+set_action() {
+  new_action="${1}"
+
+  if [ -n "${ACTION}" ]; then
+    warning "Ignoring previously specified '${ACTION}' operation in favor of '${new_action}' specified later on the command line."
+  fi
+
+  ACTION="${new_action}"
+  NETDATA_COMMAND="${new_action}"
+}
+
 parse_args() {
   while [ -n "${1}" ]; do
     case "${1}" in
@@ -2150,6 +2164,11 @@ parse_args() {
         ;;
       "--stable-channel") RELEASE_CHANNEL="stable" ;;
       "--nightly-channel") RELEASE_CHANNEL="nightly" ;;
+      "--reinstall") set_action 'reinstall' ;;
+      "--reinstall-even-if-unsafe") set_action 'unsafe-reinstall' ;;
+      "--reinstall-clean") set_action 'reinstall-clean' ;;
+      "--uninstall") set_action 'uninstall' ;;
+      "--claim-only") set_action 'claim' ;;
       "--no-updates") NETDATA_AUTO_UPDATES=0 ;;
       "--auto-update") NETDATA_AUTO_UPDATES="1" ;;
       "--auto-update-method")
@@ -2163,18 +2182,6 @@ parse_args() {
             exit 1
             ;;
         esac
-        ;;
-      "--reinstall")
-        ACTION="reinstall"
-        NETDATA_COMMAND="reinstall"
-        ;;
-      "--reinstall-even-if-unsafe")
-        ACTION="unsafe-reinstall"
-        NETDATA_COMMAND="unsafe-reinstall"
-        ;;
-      "--claim-only")
-        ACTION="claim"
-        NETDATA_COMMAND="claim"
         ;;
       "--disable-cloud")
         NETDATA_DISABLE_CLOUD=1
@@ -2221,23 +2228,14 @@ parse_args() {
           fatal "A distribution name and release must be specified for the --distro-override option." F050F
         fi
         ;;
-      "--uninstall")
-        ACTION="uninstall"
-        NETDATA_COMMAND="uninstall"
-        ;;
-      "--reinstall-clean")
-        ACTION="reinstall-clean"
-        NETDATA_COMMAND="reinstall-clean"
-        ;;
-      "--repositories-only")
-        ACTION="repositories-only"
-        NETDATA_COMMAND="repositories"
+      "--native-only")
         NETDATA_ONLY_NATIVE=1
         NETDATA_ONLY_STATIC=0
         NETDATA_ONLY_BUILD=0
         SELECTED_INSTALL_METHOD="native"
         ;;
-      "--native-only")
+      "--repositories-only")
+        set_action 'repositories-only'
         NETDATA_ONLY_NATIVE=1
         NETDATA_ONLY_STATIC=0
         NETDATA_ONLY_BUILD=0
@@ -2292,8 +2290,7 @@ parse_args() {
         ;;
       "--prepare-offline-install-source")
         if [ -n "${2}" ]; then
-          ACTION="prepare-offline"
-          NETDATA_COMMAND="prepare-offline"
+          set_action 'prepare-offline'
           OFFLINE_TARGET="${2}"
           shift 1
         else

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -193,8 +193,8 @@ USAGE: kickstart.sh [options]
 
 The following options are mutually exclusive and specifiy special operations other than trying to install Netdata normally or update an existing install:
 
-  --reinstall                      If there is an existing install, reinstall it instead of trying to update it. If there is not an existing install, install netdata normally.
-  --reinstall-even-if-unsafe       If there is an existing install, reinstall it instead of trying to update it, even if doing so is known to potentially break things. If there is not an existing install, install Netdata normally.
+  --reinstall                      If there is an existing install, reinstall it instead of trying to update it. If there is no existing install, install netdata normally.
+  --reinstall-even-if-unsafe       If there is an existing install, reinstall it instead of trying to update it, even if doing so is known to potentially break things. If there is no existing install, install Netdata normally.
   --reinstall-clean                If there is an existing install, uninstall it before trying to install Netdata. Fails if there is no existing install.
   --uninstall                      Uninstall an existing installation of Netdata. Fails if there is no existing install.
   --claim-only                     If there is an existing install, only try to claim it without attempting to update it. If there is no existing install, install and claim Netdata normally.

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -82,23 +82,17 @@ The `kickstart.sh` script accepts a number of optional parameters to control how
 - `--auto-update`: Enable automatic updates (this is the default).
 - `--no-updates`: Disable automatic updates.
 - `--disable-telemetry`: Disable anonymous statistics.
-- `--repositories-only`: Only install appropriate repository configuration packages (only for native install).
 - `--native-only`: Only install if native binary packages are available.
 - `--static-only`: Only install if a static build is available.
 - `--build-only`: Only install using a local build.
-- `--reinstall`: If an existing install is found, reinstall instead of trying to update it in place.
-- `--reinstall-even-if-unsafe`: Even try to reinstall if we don't think we can do so safely (implies `--reinstall`).
 - `--disable-cloud`: For local builds, don’t build any of the cloud code at all. For native packages and static builds,
     use runtime configuration to disable cloud support.
 - `--require-cloud`: Only install if Netdata Cloud can be enabled. Overrides `--disable-cloud`.
 - `--install-prefix`: Specify an installation prefix for local builds (by default, we use a sane prefix based on the type of system).
 - `--install-version`: Specify the version of Netdata to install.
 - `--old-install-prefix`: Specify the custom local build's installation prefix that should be removed.
-- `--uninstall`: Uninstall an existing installation of Netdata.
-- `--reinstall-clean`: Performs an uninstall of Netdata and clean installation.
 - `--local-build-options`: Specify additional options to pass to the installer code when building locally. Only valid if `--build-only` is also specified.
 - `--static-install-options`: Specify additional options to pass to the static installer code. Only valid if --static-only is also specified.
-- `--prepare-offline-install-source`: Instead of installing the agent, prepare a directory that can be used to install on another system without needing to download anything. See our [offline installation documentation](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/offline.md) for more info.
 - `--claim-token`: Specify a unique claiming token associated with your Space in Netdata Cloud to be used to connect to the node
   after the install.
 - `--claim-rooms`: Specify a comma-separated list of tokens for each War Room this node should appear in.
@@ -107,6 +101,15 @@ The `kickstart.sh` script accepts a number of optional parameters to control how
 - `--claim-url`: Specify a URL to use when connecting to the cloud. Defaults to `https://api.netdata.cloud`.
 - `--override-distro`: Override the distro detection logic and assume the system is using a specific Linux distribution and release. Takes a single argument consisting of the values of the `ID`, `VERSION_ID`, and `VERSION_CODENAME` fields from `/etc/os-release` for the desired distribution.
 
+The following options are mutually exclusive and specifiy special operations other than trying to install Netdata normally or update an existing install:
+
+- `--reinstall`: If there is an existing install, reinstall it instead of trying to update it. If there is not an existing install, install netdata normally.
+- `--reinstall-even-if-unsafe`: If there is an existing install, reinstall it instead of trying to update it, even if doing so is known to potentially break things (for example, if we cannot detect what tyep of installation it is). If there is not an existing install, install Netdata normally.
+- `--reinstall-clean`: If there is an existing install, uninstall it before trying to install Netdata. Fails if there is no existing install.
+- `--uninstall`: Uninstall an existing installation of Netdata. Fails if there is no existing install.
+- `--claim-only`: If there is an existing install, only try to claim it without attempting to update it. If there is no existing install, install and claim Netdata normally.
+- `--repositories-only`: Only install repository configuration packages instead of doing a full install of Netdata. Automatically sets --native-only.
+- `--prepare-offline-install-source`: Instead of insallling the agent, prepare a directory that can be used to install on another system without needing to download anything. See our [offline installation documentation](/packaging/installer/methods/offline.md) for more info.
 
 Additionally, the following environment variables may be used to further customize how the script runs (most users
 should not need to use special values for any of these):


### PR DESCRIPTION
##### Summary

This unifies handling of the (currently) six kickstart.sh options that change the operational mode of the script from the default of attempting to update or install the agent. In particular:

- They are now mutually exclusive, with only the last one specified being honored.
- A warning is now issued every time that one of these options overrides a previously specified option.
- The help text about these options has been updated to better describe them in detail, and to clearly offset them from the ‘normal’ kickstart options.

The affected options are:

- `--reinstall`
- `--reinstall-even-if-unsafe`
- `--reinstall-clean`
- `--uninstall`
- `--claim-only`
- `--repositories-only`
- `--prepare-offline-install-source`

##### Test Plan

The mutual exclusion and warnings for overrides can be tested by simply running the script with more than one of the above options specified on the command line. A separate warning should be issued for each overridden option, with the last option being the one that actually gets used.

The help text updates can be viewed either in the documentation, or by running the kickstart script from this PR with the `--help` option.

##### Additional Information

This PR also re-synchronizes the FreeBSD install documentation with the regular kickstart install documentation WRT the kickstart script options.
