### PR TITLE
Reference the bash collector for RPi

### DIFF
--- a/collectors/python.d.plugin/sensors/README.md
+++ b/collectors/python.d.plugin/sensors/README.md
@@ -26,6 +26,8 @@ There have been reports from users that on certain servers, ACPI ring buffer err
 We are tracking such cases in issue [#827](https://github.com/netdata/netdata/issues/827).
 Please join this discussion for help.
 
+When `lm-sensors` doesn't work on your device (e.g. for RPi temperatures), use [the legacy bash collector](https://learn.netdata.cloud/docs/agent/collectors/charts.d.plugin/sensors)
+
 ---
 
 


### PR DESCRIPTION
RPi temperatures not possible with this plugin, add a note to point to the bash one