### PR TITLE
timeframe matching should take into account the update frequency of the chart

### DIFF
--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -2441,8 +2441,8 @@ static void query_target_add_metric(QUERY_TARGET_LOCALS *qtl, RRDMETRIC_ACQUIRED
 
     bool timeframe_matches =
             (tiers_added
-            && (common_first_time_t - common_update_every) <= qt->window.before
-            && (common_last_time_t + common_update_every) >= qt->window.after
+            && (common_first_time_t - common_update_every * 2) <= qt->window.before
+            && (common_last_time_t + common_update_every * 2) >= qt->window.after
             ) ? true : false;
 
     if(timeframe_matches) {

--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -2439,7 +2439,11 @@ static void query_target_add_metric(QUERY_TARGET_LOCALS *qtl, RRDMETRIC_ACQUIRED
         }
     }
 
-    bool timeframe_matches = (tiers_added && common_first_time_t <= qt->window.before && common_last_time_t >= qt->window.after) ? true : false;
+    bool timeframe_matches =
+            (tiers_added
+            && (common_first_time_t - common_update_every) <= qt->window.before
+            && (common_last_time_t + common_update_every) >= qt->window.after
+            ) ? true : false;
 
     if(timeframe_matches) {
         RRDR_DIMENSION_FLAGS options = RRDR_DIMENSION_DEFAULT;


### PR DESCRIPTION
The new query engine did a match on the timeframe requested, but it didn't take into account the update frequency of the chart. Fixed it.