### PR TITLE
do not free hosts if a change on db mode is not needed

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -631,7 +631,7 @@ RRDHOST *rrdhost_find_or_create(
 
     rrd_wrlock();
     RRDHOST *host = rrdhost_find_by_guid(guid);
-    if (unlikely(host && RRD_MEMORY_MODE_DBENGINE != mode && rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED))) {
+    if (unlikely(host && host->rrd_memory_mode != mode && rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED))) {
         /* If a legacy memory mode instantiates all dbengine state must be discarded to avoid inconsistencies */
         error("Archived host '%s' has memory mode '%s', but the wanted one is '%s'. Discarding archived state.",
               rrdhost_hostname(host), rrd_memory_mode_name(host->rrd_memory_mode), rrd_memory_mode_name(mode));


### PR DESCRIPTION
Fixes this crash:

```
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140437224445504) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=140437224445504) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140437224445504, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#3  0x00007fba27772476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#4  0x00007fba277587f3 in __GI_abort () at ./stdlib/abort.c:79
#5  0x0000556594534f61 in crash_netdata () at libnetdata/log/log.c:867
#6  0x00005565945352af in fatal_int (file=0x556594be9e30 "libnetdata/dictionary/dictionary.c", function=0x556594bec8f0 <__FUNCTION__.28> "api_internal_check_with_trace", line=1630, fmt=0x556594bea8a8 "DICTIONARY: attempted to %s() but dict is NULL") at libnetdata/log/log.c:935
#7  0x000055659452515b in api_internal_check_with_trace (dict=0x0, item=0x556597c1da60, function=0x556594bec9c0 <__FUNCTION__.24> "dictionary_acquired_item_release", allow_null_dict=false, allow_null_item=true) at libnetdata/dictionary/dictionary.c:1630
#8  0x0000556594526057 in dictionary_acquired_item_release (dict=0x0, item=0x556597c1da60) at libnetdata/dictionary/dictionary.c:1948
#9  0x00005565947304c1 in rrdcontext_release (rca=0x556597c1da60) at database/rrdcontext.c:416
#10 0x0000556594736d3c in query_target_release (qt=0x7fba16e05268) at database/rrdcontext.c:2327
#11 0x0000556594739523 in query_target_create (qtr=0x7fba16e020a0) at database/rrdcontext.c:2829
#12 0x000055659456a25e in web_client_api_request_v1_data (host=0x556597c1db80, w=0x5565981a8d00, url=0x0) at web/api/web_api_v1.c:760
#13 0x000055659456dcb9 in web_client_api_request_v1 (host=0x556597c1db80, w=0x5565981a8d00, url=0x5565981a99a8 "data") at web/api/web_api_v1.c:1693
#14 0x000055659487dd56 in web_client_api_request (host=0x556597c1db80, w=0x5565981a8d00, url=0x5565981a99a8 "data") at web/server/web_client.c:537
#15 0x000055659487dc81 in check_host_and_call (host=0x556597c1db80, w=0x5565981a8d00, url=0x5565981a99a5 "v1", func=0x55659487dc83 <web_client_api_request>) at web/server/web_client.c:513
#16 0x0000556594880350 in web_client_process_url (host=0x556597c1db80, w=0x5565981a8d00, url=0x5565981a99a5 "v1") at web/server/web_client.c:1349
#17 0x0000556594880084 in web_client_switch_host (host=0x556597c1db80, w=0x5565981a8d00, url=0x5565981a99a1 "api") at web/server/web_client.c:1311
#18 0x000055659488040a in web_client_process_url (host=0x55659753e400, w=0x5565981a8d00, url=0x5565981a9993 "costa-xps9500") at web/server/web_client.c:1353
#19 0x0000556594880efc in web_client_process_request (w=0x5565981a8d00) at web/server/web_client.c:1495
#20 0x000055659488519a in web_server_rcv_callback (pi=0x5565981a8060, events=0x556598150814) at web/server/static/static-threaded.c:304
#21 0x000055659453f75e in poll_process_tcp_read (p=0x7fba16e04610, pi=0x5565981a8060, pf=0x556598150810, now=65379) at libnetdata/socket/socket.c:1493
#22 0x0000556594540ee6 in poll_events (sockets=0x556594e7fee0 <api_sockets>, add_callback=0x556594884b22 <web_server_add_callback>, del_callback=0x556594884f2c <web_server_del_callback>, rcv_callback=0x5565948850b3 <web_server_rcv_callback>, snd_callback=0x55659488545c <web_server_snd_callback>, tmr_callback=0x0, 
    access_list=0x556597fdf450, allow_dns=1, data=0x0, tcp_request_timeout_seconds=60, tcp_idle_timeout_seconds=60, timer_milliseconds=1000, timer_data=0x55659807c260, max_tcp_sockets=42) at libnetdata/socket/socket.c:1812
#23 0x0000556594885899 in socket_listen_main_static_threaded_worker (ptr=0x55659807c260) at web/server/static/static-threaded.c:427
#24 0x000055659454654c in thread_start (ptr=0x556598048150) at libnetdata/threads/threads.c:203
#25 0x00007fba277c4b43 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:442

```