### PR TITLE
Enable aclk conversation log even without NETDATA_INTERNAL CHECKS

### DIFF
--- a/aclk/aclk_rx_msgs.c
+++ b/aclk/aclk_rx_msgs.c
@@ -527,15 +527,16 @@ void aclk_handle_new_cloud_msg(const char *message_type, const char *msg, size_t
         return;
     }
 
-#ifdef NETDATA_INTERNAL_CHECKS
-    if (!strncmp(message_type, "cmd", strlen("cmd"))) {
-        log_aclk_message_bin(msg, msg_len, 0, topic, msg_descriptor->name);
-    } else {
-        char *json = protomsg_to_json(msg, msg_len, msg_descriptor->name);
-        log_aclk_message_bin(json, strlen(json), 0, topic, msg_descriptor->name);
-        freez(json);
+
+    if (aclklog_enabled) {
+        if (!strncmp(message_type, "cmd", strlen("cmd"))) {
+            log_aclk_message_bin(msg, msg_len, 0, topic, msg_descriptor->name);
+        } else {
+            char *json = protomsg_to_json(msg, msg_len, msg_descriptor->name);
+            log_aclk_message_bin(json, strlen(json), 0, topic, msg_descriptor->name);
+            freez(json);
+        }
     }
-#endif
 
     if (aclk_stats_enabled) {
         ACLK_STATS_LOCK;

--- a/aclk/aclk_tx_msgs.c
+++ b/aclk/aclk_tx_msgs.c
@@ -39,10 +39,13 @@ uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, s
 
 #ifdef NETDATA_INTERNAL_CHECKS
     aclk_stats_msg_published(packet_id);
-    char *json = protomsg_to_json(msg, msg_len, msgname);
-    log_aclk_message_bin(json, strlen(json), 1, topic, msgname);
-    freez(json);
 #endif
+
+    if (aclklog_enabled) {
+        char *json = protomsg_to_json(msg, msg_len, msgname);
+        log_aclk_message_bin(json, strlen(json), 1, topic, msgname);
+        freez(json);
+    }
 
     return packet_id;
 }


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This will allow to debug some cases of cloud connectivity on user side, where mostly Netdata will not be compiled with NETDATA_INTERNAL CHECKS.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Test with a build without `NETDATA_INTERNAL CHECKS` that entries are written to `aclk.log` if `conversation log` is enabled.
Also make sure if `conversation log = no` is set, there are no entries there.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
