### PR TITLE
Split plugins to individual packages for DEB/RPM packaging.

### DIFF
--- a/collectors/charts.d.plugin/README.md
+++ b/collectors/charts.d.plugin/README.md
@@ -17,6 +17,8 @@ memory, collecting data with as little overheads as possible
 `charts.d.plugin` looks for scripts in `/usr/lib/netdata/charts.d`.
 The scripts should have the filename suffix: `.chart.sh`.
 
+By default, `charts.d.plugin` is not included as part of the install when using our native DEB/RPM packages. You can install it by installing the `netdata-plugin-chartsd` package to use it.
+
 ## Configuration
 
 `charts.d.plugin` itself can be [configured](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md#use-edit-config-to-edit-configuration-files) using the configuration file `/etc/netdata/charts.d.conf`. This file is also a BASH script.

--- a/collectors/charts.d.plugin/README.md
+++ b/collectors/charts.d.plugin/README.md
@@ -17,7 +17,7 @@ memory, collecting data with as little overheads as possible
 `charts.d.plugin` looks for scripts in `/usr/lib/netdata/charts.d`.
 The scripts should have the filename suffix: `.chart.sh`.
 
-By default, `charts.d.plugin` is not included as part of the install when using our native DEB/RPM packages. You can install it by installing the `netdata-plugin-chartsd` package to use it.
+By default, `charts.d.plugin` is not included as part of the install when using [our official native DEB/RPM packages](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/packages.md). You can install it by installing the `netdata-plugin-chartsd` package.
 
 ## Configuration
 

--- a/collectors/charts.d.plugin/ap/README.md
+++ b/collectors/charts.d.plugin/ap/README.md
@@ -85,7 +85,7 @@ Station 40:b8:37:5a:ed:5e (on wlan0)
 
 ## Configuration
 
-If using our native DEB/RPM packages, make sure `netdata-plugin-chartsd` is installed.
+If using [our official native DEB/RPM packages](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/packages.md), make sure `netdata-plugin-chartsd` is installed.
 
 Edit the `charts.d/ap.conf` configuration file using `edit-config` from the Netdata [config
 directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.

--- a/collectors/charts.d.plugin/ap/README.md
+++ b/collectors/charts.d.plugin/ap/README.md
@@ -85,6 +85,8 @@ Station 40:b8:37:5a:ed:5e (on wlan0)
 
 ## Configuration
 
+If using our native DEB/RPM packages, make sure `netdata-plugin-chartsd` is installed.
+
 Edit the `charts.d/ap.conf` configuration file using `edit-config` from the Netdata [config
 directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 

--- a/collectors/charts.d.plugin/apcupsd/README.md
+++ b/collectors/charts.d.plugin/apcupsd/README.md
@@ -13,7 +13,7 @@ Monitors different APC UPS models and retrieves status information using `apcacc
 
 ## Configuration
 
-If using our native DEB/RPM packages, make sure `netdata-plugin-chartsd` is installed.
+If using [our official native DEB/RPM packages](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/packages.md), make sure `netdata-plugin-chartsd` is installed.
 
 Edit the `charts.d/apcupsd.conf` configuration file using `edit-config` from the Netdata [config
 directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.

--- a/collectors/charts.d.plugin/apcupsd/README.md
+++ b/collectors/charts.d.plugin/apcupsd/README.md
@@ -13,6 +13,8 @@ Monitors different APC UPS models and retrieves status information using `apcacc
 
 ## Configuration
 
+If using our native DEB/RPM packages, make sure `netdata-plugin-chartsd` is installed.
+
 Edit the `charts.d/apcupsd.conf` configuration file using `edit-config` from the Netdata [config
 directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 

--- a/collectors/charts.d.plugin/libreswan/README.md
+++ b/collectors/charts.d.plugin/libreswan/README.md
@@ -24,7 +24,7 @@ The following charts are created, **per tunnel**:
 
 ## Configuration
 
-If using our native DEB/RPM packages, make sure `netdata-plugin-chartsd` is installed.
+If using [our official native DEB/RPM packages](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/packages.md), make sure `netdata-plugin-chartsd` is installed.
 
 Edit the `charts.d/libreswan.conf` configuration file using `edit-config` from the Netdata [config
 directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.

--- a/collectors/charts.d.plugin/libreswan/README.md
+++ b/collectors/charts.d.plugin/libreswan/README.md
@@ -24,6 +24,8 @@ The following charts are created, **per tunnel**:
 
 ## Configuration
 
+If using our native DEB/RPM packages, make sure `netdata-plugin-chartsd` is installed.
+
 Edit the `charts.d/libreswan.conf` configuration file using `edit-config` from the Netdata [config
 directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 

--- a/collectors/charts.d.plugin/nut/README.md
+++ b/collectors/charts.d.plugin/nut/README.md
@@ -53,7 +53,7 @@ The following charts will be created:
 
 ## Configuration
 
-If using our native DEB/RPM packages, make sure `netdata-plugin-chartsd` is installed.
+If using [our official native DEB/RPM packages](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/packages.md), make sure `netdata-plugin-chartsd` is installed.
 
 Edit the `charts.d/nut.conf` configuration file using `edit-config` from the Netdata [config
 directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.

--- a/collectors/charts.d.plugin/nut/README.md
+++ b/collectors/charts.d.plugin/nut/README.md
@@ -53,6 +53,8 @@ The following charts will be created:
 
 ## Configuration
 
+If using our native DEB/RPM packages, make sure `netdata-plugin-chartsd` is installed.
+
 Edit the `charts.d/nut.conf` configuration file using `edit-config` from the Netdata [config
 directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 

--- a/collectors/charts.d.plugin/opensips/README.md
+++ b/collectors/charts.d.plugin/opensips/README.md
@@ -11,7 +11,7 @@ learn_rel_path: "Integrations/Monitor/Networking"
 
 ## Configuration
 
-If using our native DEB/RPM packages, make sure `netdata-plugin-chartsd` is installed.
+If using [our official native DEB/RPM packages](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/packages.md), make sure `netdata-plugin-chartsd` is installed.
 
 Edit the `charts.d/opensips.conf` configuration file using `edit-config` from the Netdata [config
 directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.

--- a/collectors/charts.d.plugin/opensips/README.md
+++ b/collectors/charts.d.plugin/opensips/README.md
@@ -11,6 +11,8 @@ learn_rel_path: "Integrations/Monitor/Networking"
 
 ## Configuration
 
+If using our native DEB/RPM packages, make sure `netdata-plugin-chartsd` is installed.
+
 Edit the `charts.d/opensips.conf` configuration file using `edit-config` from the Netdata [config
 directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md), which is typically at `/etc/netdata`.
 

--- a/collectors/charts.d.plugin/sensors/README.md
+++ b/collectors/charts.d.plugin/sensors/README.md
@@ -21,13 +21,15 @@ One chart for every sensor chip found and each of the above will be created.
 
 ## Enable the collector
 
+If using our native DEB/RPM packages, make sure `netdata-plugin-chartsd` is installed.
+
 The `sensors` collector is disabled by default.
 
-To enable the collector, you need to edit the configuration file of `charts.d/sensors.conf`. You can do so by using the `edit config` script.  
+To enable the collector, you need to edit the configuration file of `charts.d/sensors.conf`. You can do so by using the `edit config` script.
 
 > ### Info
 >
-> To edit configuration files in a safe way, we provide the [`edit config` script](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md#use-edit-config-to-edit-configuration-files) located in your [Netdata config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md#the-netdata-config-directory) (typically is `/etc/netdata`) that creates the proper file and opens it in an editor automatically.  
+> To edit configuration files in a safe way, we provide the [`edit config` script](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md#use-edit-config-to-edit-configuration-files) located in your [Netdata config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md#the-netdata-config-directory) (typically is `/etc/netdata`) that creates the proper file and opens it in an editor automatically.
 > It is recommended to use this way for configuring Netdata.
 >
 > Please also note that after most configuration changes you will need to [restart the Agent](https://github.com/netdata/netdata/blob/master/docs/configure/start-stop-restart.md) for the changes to take effect.

--- a/collectors/charts.d.plugin/sensors/README.md
+++ b/collectors/charts.d.plugin/sensors/README.md
@@ -21,7 +21,7 @@ One chart for every sensor chip found and each of the above will be created.
 
 ## Enable the collector
 
-If using our native DEB/RPM packages, make sure `netdata-plugin-chartsd` is installed.
+If using [our official native DEB/RPM packages](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/packages.md), make sure `netdata-plugin-chartsd` is installed.
 
 The `sensors` collector is disabled by default.
 

--- a/collectors/nfacct.plugin/README.md
+++ b/collectors/nfacct.plugin/README.md
@@ -13,6 +13,11 @@ learn_rel_path: "Integrations/Monitor/Networking"
 
 ## Prerequisites
 
+If you are using our native DEB/RPM packages, install the
+`netdata-plugin-nfacct` package using your system package manager.
+
+If you built Netdata locally:
+
 1.  install `libmnl-dev` and `libnetfilter-acct-dev` using the package manager of your system.
 
 2.  re-install Netdata from source. The installer will detect that the required libraries are now available and will also build `netdata.plugin`.

--- a/collectors/nfacct.plugin/README.md
+++ b/collectors/nfacct.plugin/README.md
@@ -13,7 +13,7 @@ learn_rel_path: "Integrations/Monitor/Networking"
 
 ## Prerequisites
 
-If you are using our native DEB/RPM packages, install the
+If you are using [our official native DEB/RPM packages](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/packages.md), install the
 `netdata-plugin-nfacct` package using your system package manager.
 
 If you built Netdata locally:

--- a/collectors/perf.plugin/README.md
+++ b/collectors/perf.plugin/README.md
@@ -14,7 +14,7 @@ the `perf_event_open()` system call.
 
 ## Important Notes
 
-If you are using our native DEB/RPM packages, you will need to install
+If you are using [our official native DEB/RPM packages](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/packages.md), you will need to install
 the `netdata-plugin-perf` package using your system package manager.
 
 Accessing hardware PMUs requires root permissions, so the plugin is setuid to root.

--- a/collectors/perf.plugin/README.md
+++ b/collectors/perf.plugin/README.md
@@ -14,6 +14,9 @@ the `perf_event_open()` system call.
 
 ## Important Notes
 
+If you are using our native DEB/RPM packages, you will need to install
+the `netdata-plugin-perf` package using your system package manager.
+
 Accessing hardware PMUs requires root permissions, so the plugin is setuid to root.
 
 Keep in mind that the number of PMUs in a system is usually quite limited and every hardware monitoring

--- a/collectors/slabinfo.plugin/README.md
+++ b/collectors/slabinfo.plugin/README.md
@@ -18,7 +18,7 @@ Each internal structure (process, file descriptor, inode...) is stored within a 
 The plugin is disabled by default because it collects and displays a huge amount of metrics.
 To enable it set `slabinfo = yes` in the `plugins` section of the `netdata.conf` configuration file.
 
-If you are using our native DEB/RPM packages, you will additionally need to install the `netdata-plugin-slabinfo`
+If you are using [our official native DEB/RPM packages](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/packages.md), you will additionally need to install the `netdata-plugin-slabinfo`
 package using your system package manager.
 
 There is currently no configuration needed for the plugin itself.

--- a/collectors/slabinfo.plugin/README.md
+++ b/collectors/slabinfo.plugin/README.md
@@ -18,6 +18,9 @@ Each internal structure (process, file descriptor, inode...) is stored within a 
 The plugin is disabled by default because it collects and displays a huge amount of metrics.
 To enable it set `slabinfo = yes` in the `plugins` section of the `netdata.conf` configuration file.
 
+If you are using our native DEB/RPM packages, you will additionally need to install the `netdata-plugin-slabinfo`
+package using your system package manager.
+
 There is currently no configuration needed for the plugin itself.
 
 As `/proc/slabinfo` is only readable by root, this plugin is setuid root.

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -111,6 +111,7 @@ Description: The python.d metrics collection plugin for the Netdata Agent
 Package: netdata-plugin-go
 Architecture: any
 Depends: ${shlibs:Depends},
+         libcap2-bin,
          netdata (>= ${source:Version})
 Description: The go.d metrics collection plugin for the Netdata Agent
  This plugin adds a selection of additional collectors written in Go to
@@ -121,6 +122,7 @@ Description: The go.d metrics collection plugin for the Netdata Agent
 Package: netdata-plugin-apps
 Architecture: any
 Depends: ${shlibs:Depends},
+         libcap2-bin,
          netdata (>= ${source:Version})
 Description: The per-application metrics collection plugin for the Netdata Agent
  This plugin allows the Netdata Agent to collect per-application and

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -59,7 +59,8 @@ Depends: cups,
          ${shlibs:Depends},
          netdata (>= ${source:Version})
 Description: The CUPS metrics collection plugin for the Netdata Agent
- This plugin allows the Netdata Agent to collect metrics from the Common UNIX Printing System.
+ This plugin allows the Netdata Agent to collect metrics from the Common
+ UNIX Printing System.
 
 Package: netdata-plugin-freeipmi
 Architecture: any
@@ -67,14 +68,16 @@ Depends: freeipmi,
          ${shlibs:Depends},
          netdata (= ${source:Version})
 Description: The FreeIPMI metrics collection plugin for the Netdata Agent
- This plugin allows the Netdata Agent to collect metrics from hardware using FreeIPMI.
+ This plugin allows the Netdata Agent to collect metrics from hardware
+ using FreeIPMI.
 
 Package: netdata-plugin-nfacct
 Architecture: any
 Depends: ${shlibs:Depends},
          netdata (>= ${source:Version})
 Description: The NFACCT metrics collection plugin for the Netdata Agent
- This plugin allows the Netdata Agent to collect metrics from the firewall using NFACCT objects.
+ This plugin allows the Netdata Agent to collect metrics from the firewall
+ using NFACCT objects.
 
 Package: netdata-plugin-chartsd
 Architecture: all
@@ -82,8 +85,9 @@ Depends: bash,
          netdata (>= ${source:Version})
 Suggests: apcupsd, nut, iw, sudo
 Description: The charts.d metrics collection plugin for the Netdata Agent
- This plugin adds a selection of additional collectors written in shell script to the Netdata Agent. It includes
- collectors for NUT, APCUPSD, LibreSWAN, OpenSIPS, and Wireless access point statistics.
+ This plugin adds a selection of additional collectors written in shell
+ script to the Netdata Agent. It includes collectors for NUT, APCUPSD,
+ LibreSWAN, OpenSIPS, and Wireless access point statistics.
 
 Package: netdata-plugin-ebpf
 Architecture: i386 amd64
@@ -92,12 +96,14 @@ Depends: ${shlibs:Depends},
          netdata-plugin-ebpf-code (>= ${source:Version}),
          netdata (>= ${source:Version})
 Description: The eBPF metrics collection plugin for the Netdata Agent
- This plugin allows the Netdata Agent to use eBPF code to collect more detailed kernel-level metrics for the system.
+ This plugin allows the Netdata Agent to use eBPF code to collect more
+ detailed kernel-level metrics for the system.
 
 Package: netdata-plugin-ebpf-code
 Architecture: i386 amd64
 Description: Compiled eBPF code for the Netdata eBPF plugin
- This package provides the pre-compiled eBPF code for use by the Netdata eBPF plugin.
+ This package provides the pre-compiled eBPF code for use by the Netdata
+ eBPF plugin.
 
 Package: netdata-plugin-pythond
 Architecture: all

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -109,7 +109,8 @@ Conflicts: netdata (< ${source:Version})
 Description: Compiled eBPF legacy code for the Netdata eBPF plugin
  This package provides the pre-compiled eBPF legacy code for use by
  the Netdata eBPF plugin.  This code is only needed when using the eBPF
- plugin with kernel versions before 5.10.
+ plugin with kernel that do not include BTF support (mostly kernel
+ versions lower than 5.10)..
 
 Package: netdata-plugin-pythond
 Architecture: all
@@ -131,7 +132,7 @@ Suggests: nvme-cli, sudo
 Conflicts: netdata (< ${source:Version})
 Description: The go.d metrics collection plugin for the Netdata Agent
  This plugin adds a selection of additional collectors written in Go to
- the Netdata Agent A significant percentage of the application specific
+ the Netdata Agent. A significant percentage of the application specific
  collectors provided by Netdata are part of this plugin, so most users
  will want it installed.
 

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -42,7 +42,8 @@ Conflicts: netdata-core,
            netdata-plugins-bash,
            netdata-plugins-python,
            netdata-web
-Recommends: netdata-plugin-ebpf
+Recommends: netdata-plugin-ebpf,
+            netdata-plugin-pythond
 Pre-Depends: dpkg (>= 1.17.14)
 Description: real-time charts for system monitoring
  Netdata is a daemon that collects data in realtime (per second)
@@ -94,3 +95,12 @@ Package: netdata-plugin-ebpf-code
 Architecture: i386 amd64
 Description: Compiled eBPF code for the Netdata eBPF plugin
  This package provides the pre-compiled eBPF code for use by the Netdata eBPF plugin.
+
+Package: netdata-plugin-pythond
+Architecture: all
+Depends: ${shlibs:Depends},
+         netdata (>= ${source:Version})
+Description: The python.d metrics collection plugin for the Netdata Agent
+ Many of the collectors provided by this package are also available
+ in netdata-plugin-god. In msot cases, you probably want to use those
+ versions instead of the Python versions.

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -71,3 +71,12 @@ Depends: ${shlibs:Depends},
          netdata (>= ${source:Version})
 Description: The NFACCT metrics collection plugin for the Netdata Agent
  This plugin allows the Netdata Agent to collect metrics from the firewall using NFACCT objects.
+
+Package: netdata-plugin-chartsd
+Architecture: all
+Depends: bash,
+         netdata (>= ${source:Version})
+Suggests: apcupsd, nut, iw, sudo
+Description: The charts.d metrics collection plugin for the Netdata Agent
+ This plugin adds a selection of additional collectors written in shell script to the Netdata Agent. It includes
+ collectors for NUT, APCUPSD, LibreSWAN, OpenSIPS, and Wireless access point statistics.

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -45,7 +45,8 @@ Conflicts: netdata-core,
 Recommends: netdata-plugin-ebpf,
             netdata-plugin-apps,
             netdata-plugin-pythond,
-            netdata-plugin-go
+            netdata-plugin-go,
+            netdata-plugin-debugfs
 Suggests: netdata-plugin-cups,
           netdata-plugin-freeipmi,
           netdata-plugin-nfacct,

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -54,14 +54,13 @@ Architecture: any
 Depends: cups,
          ${shlibs:Depends},
          netdata (>= ${source:Version})
-Description: The Common Unix Printing System plugin for metrics collection from cupsd
+Description: The CUPS metrics collection plugin for the Netdata Agent
+ This plugin allows the Netdata Agent to collect metrics from the Common UNIX Printing System.
 
 Package: netdata-plugin-freeipmi
 Architecture: any
 Depends: freeipmi,
          ${shlibs:Depends},
          netdata (= ${source:Version})
-Description: FreeIPMI - The Intelligent Platform Management System.
- The IPMI specification defines a set of interfaces for platform management.
- It is implemented by a number vendors for system management. The features of IPMI that most users will be interested in
- are sensor monitoring, system event monitoring, power control, and serial-over-LAN (SOL).
+Description: The FreeIPMI metrics collection plugin for the Netdata Agent
+ This plugin allows the Netdata Agent to collect metrics from hardware using FreeIPMI.

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -64,3 +64,10 @@ Depends: freeipmi,
          netdata (= ${source:Version})
 Description: The FreeIPMI metrics collection plugin for the Netdata Agent
  This plugin allows the Netdata Agent to collect metrics from hardware using FreeIPMI.
+
+Package: netdata-plugin-nfacct
+Architecture: any
+Depends: ${shlibs:Depends},
+         netdata (>= ${source:Version})
+Description: The NFACCT metrics collection plugin for the Netdata Agent
+ This plugin allows the Netdata Agent to collect metrics from the firewall using NFACCT objects.

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -43,6 +43,7 @@ Conflicts: netdata-core,
            netdata-plugins-python,
            netdata-web
 Recommends: netdata-plugin-ebpf,
+            netdata-plugin-apps,
             netdata-plugin-pythond,
             netdata-plugin-go
 Pre-Depends: dpkg (>= 1.17.14)
@@ -87,6 +88,7 @@ Description: The charts.d metrics collection plugin for the Netdata Agent
 Package: netdata-plugin-ebpf
 Architecture: i386 amd64
 Depends: ${shlibs:Depends},
+         netdata-plugin-apps (>= ${source:Version}),
          netdata-plugin-ebpf-code (>= ${source:Version}),
          netdata (>= ${source:Version})
 Description: The eBPF metrics collection plugin for the Netdata Agent
@@ -115,3 +117,11 @@ Description: The go.d metrics collection plugin for the Netdata Agent
  the Netdata Agent A significant percentage of the application specific
  collectors provided by Netdata are part of this plugin, so most users
  will want it installed.
+
+Package: netdata-plugin-apps
+Architecture: any
+Depends: ${shlibs:Depends},
+         netdata (>= ${source:Version})
+Description: The per-application metrics collection plugin for the Netdata Agent
+ This plugin allows the Netdata Agent to collect per-application and
+ per-user metrics without using cgroups.

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -133,3 +133,12 @@ Depends: ${shlibs:Depends},
 Description: The per-application metrics collection plugin for the Netdata Agent
  This plugin allows the Netdata Agent to collect per-application and
  per-user metrics without using cgroups.
+
+Package: netdata-plugin-slabinfo
+Architecture: any
+Depends: ${shlibs:Depends},
+         libcap2-bin,
+         netdata (>= ${source:Version})
+Description: The slabinfo metrics collector for the Netdata Agent
+ This plugin allows the Netdata Agent to collect perfromance and
+ utilization metrics for the Linux kernel’s SLAB allocator.

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -90,11 +90,11 @@ Description: The charts.d metrics collection plugin for the Netdata Agent
  LibreSWAN, OpenSIPS, and Wireless access point statistics.
 
 Package: netdata-plugin-ebpf
-Architecture: i386 amd64
+Architecture: any
 Depends: ${shlibs:Depends},
          netdata-plugin-apps (>= ${source:Version}),
-         netdata-plugin-ebpf-code (>= ${source:Version}),
          netdata (>= ${source:Version})
+Recommends: netdata-plugin-ebpf-code (>= ${source:Version}),
 Description: The eBPF metrics collection plugin for the Netdata Agent
  This plugin allows the Netdata Agent to use eBPF code to collect more
  detailed kernel-level metrics for the system.
@@ -109,6 +109,7 @@ Package: netdata-plugin-pythond
 Architecture: all
 Depends: ${shlibs:Depends},
          netdata (>= ${source:Version})
+Suggests: sudo
 Description: The python.d metrics collection plugin for the Netdata Agent
  Many of the collectors provided by this package are also available
  in netdata-plugin-god. In msot cases, you probably want to use those
@@ -119,6 +120,7 @@ Architecture: any
 Depends: ${shlibs:Depends},
          libcap2-bin,
          netdata (>= ${source:Version})
+Suggests: nvme-cli sudo
 Description: The go.d metrics collection plugin for the Netdata Agent
  This plugin adds a selection of additional collectors written in Go to
  the Netdata Agent A significant percentage of the application specific

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -142,3 +142,12 @@ Depends: ${shlibs:Depends},
 Description: The slabinfo metrics collector for the Netdata Agent
  This plugin allows the Netdata Agent to collect perfromance and
  utilization metrics for the Linux kernel’s SLAB allocator.
+
+Package: netdata-plugin-perf
+Architecture: any
+Depends: ${shlibs:Depends},
+         libcap2-bin,
+         netdata (>= ${source:Version})
+Description: The perf metrics collector for the Netdata Agent
+ This plugin allows the Netdata to collect metrics from the Linux perf
+ subsystem.

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -171,3 +171,13 @@ Conflicts: netdata (< ${source:Version})
 Description: The perf metrics collector for the Netdata Agent
  This plugin allows the Netdata to collect metrics from the Linux perf
  subsystem.
+
+Package: netdata-plugin-debugfs
+Architecture: any
+Depends: ${shlibs:Debends},
+         libcap2-bin,
+         netdata (>= ${source:Version})
+Conflicts: netdata (< ${source:Version})
+Description: The debugfs metrics collector for the Netdata Agent
+ This plugin allows the Netdata Agent to collect Linux kernel metrics
+ exposed through debugfs.

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -43,7 +43,8 @@ Conflicts: netdata-core,
            netdata-plugins-python,
            netdata-web
 Recommends: netdata-plugin-ebpf,
-            netdata-plugin-pythond
+            netdata-plugin-pythond,
+            netdata-plugin-go
 Pre-Depends: dpkg (>= 1.17.14)
 Description: real-time charts for system monitoring
  Netdata is a daemon that collects data in realtime (per second)
@@ -104,3 +105,13 @@ Description: The python.d metrics collection plugin for the Netdata Agent
  Many of the collectors provided by this package are also available
  in netdata-plugin-god. In msot cases, you probably want to use those
  versions instead of the Python versions.
+
+Package: netdata-plugin-go
+Architecture: any
+Depends: ${shlibs:Depends},
+         netdata (>= ${source:Version})
+Description: The go.d metrics collection plugin for the Netdata Agent
+ This plugin adds a selection of additional collectors written in Go to
+ the Netdata Agent A significant percentage of the application specific
+ collectors provided by Netdata are part of this plugin, so most users
+ will want it installed.

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -66,7 +66,7 @@ Package: netdata-plugin-freeipmi
 Architecture: any
 Depends: freeipmi,
          ${shlibs:Depends},
-         netdata (= ${source:Version})
+         netdata (>= ${source:Version})
 Description: The FreeIPMI metrics collection plugin for the Netdata Agent
  This plugin allows the Netdata Agent to collect metrics from hardware
  using FreeIPMI.
@@ -75,6 +75,7 @@ Package: netdata-plugin-nfacct
 Architecture: any
 Depends: ${shlibs:Depends},
          netdata (>= ${source:Version})
+Conflicts: netdata (< ${source:Version})
 Description: The NFACCT metrics collection plugin for the Netdata Agent
  This plugin allows the Netdata Agent to collect metrics from the firewall
  using NFACCT objects.
@@ -83,6 +84,7 @@ Package: netdata-plugin-chartsd
 Architecture: all
 Depends: bash,
          netdata (>= ${source:Version})
+Conflicts: netdata (< ${source:Version})
 Suggests: apcupsd, nut, iw, sudo
 Description: The charts.d metrics collection plugin for the Netdata Agent
  This plugin adds a selection of additional collectors written in shell
@@ -93,23 +95,28 @@ Package: netdata-plugin-ebpf
 Architecture: any
 Depends: ${shlibs:Depends},
          netdata (>= ${source:Version})
-Recommends: netdata-plugin-ebpf-code (>= ${source:Version}),
+Recommends: netdata-ebpf-code-legacy (>= ${source:Version}),
             netdata-plugin-apps (>= ${source:Version})
+Conflicts: netdata (< ${source:Version})
 Description: The eBPF metrics collection plugin for the Netdata Agent
  This plugin allows the Netdata Agent to use eBPF code to collect more
  detailed kernel-level metrics for the system.
 
-Package: netdata-plugin-ebpf-code
+Package: netdata-ebpf-code-legacy
 Architecture: i386 amd64
-Description: Compiled eBPF code for the Netdata eBPF plugin
- This package provides the pre-compiled eBPF code for use by the Netdata
- eBPF plugin.
+Depends: netdata-plugin-ebpf (= ${source:Version})
+Conflicts: netdata (< ${source:Version})
+Description: Compiled eBPF legacy code for the Netdata eBPF plugin
+ This package provides the pre-compiled eBPF legacy code for use by
+ the Netdata eBPF plugin.  This code is only needed when using the eBPF
+ plugin with kernel versions before 5.10.
 
 Package: netdata-plugin-pythond
 Architecture: all
 Depends: ${shlibs:Depends},
          netdata (>= ${source:Version})
 Suggests: sudo
+Conflicts: netdata (< ${source:Version})
 Description: The python.d metrics collection plugin for the Netdata Agent
  Many of the collectors provided by this package are also available
  in netdata-plugin-god. In msot cases, you probably want to use those
@@ -121,6 +128,7 @@ Depends: ${shlibs:Depends},
          libcap2-bin,
          netdata (>= ${source:Version})
 Suggests: nvme-cli, sudo
+Conflicts: netdata (< ${source:Version})
 Description: The go.d metrics collection plugin for the Netdata Agent
  This plugin adds a selection of additional collectors written in Go to
  the Netdata Agent A significant percentage of the application specific
@@ -132,6 +140,7 @@ Architecture: any
 Depends: ${shlibs:Depends},
          libcap2-bin,
          netdata (>= ${source:Version})
+Conflicts: netdata (< ${source:Version})
 Description: The per-application metrics collection plugin for the Netdata Agent
  This plugin allows the Netdata Agent to collect per-application and
  per-user metrics without using cgroups.
@@ -141,6 +150,7 @@ Architecture: any
 Depends: ${shlibs:Depends},
          libcap2-bin,
          netdata (>= ${source:Version})
+Conflicts: netdata (< ${source:Version})
 Description: The slabinfo metrics collector for the Netdata Agent
  This plugin allows the Netdata Agent to collect perfromance and
  utilization metrics for the Linux kernel’s SLAB allocator.
@@ -150,6 +160,7 @@ Architecture: any
 Depends: ${shlibs:Depends},
          libcap2-bin,
          netdata (>= ${source:Version})
+Conflicts: netdata (< ${source:Version})
 Description: The perf metrics collector for the Netdata Agent
  This plugin allows the Netdata to collect metrics from the Linux perf
  subsystem.

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -92,9 +92,9 @@ Description: The charts.d metrics collection plugin for the Netdata Agent
 Package: netdata-plugin-ebpf
 Architecture: any
 Depends: ${shlibs:Depends},
-         netdata-plugin-apps (>= ${source:Version}),
          netdata (>= ${source:Version})
 Recommends: netdata-plugin-ebpf-code (>= ${source:Version}),
+            netdata-plugin-apps (>= ${source:Version})
 Description: The eBPF metrics collection plugin for the Netdata Agent
  This plugin allows the Netdata Agent to use eBPF code to collect more
  detailed kernel-level metrics for the system.
@@ -120,7 +120,7 @@ Architecture: any
 Depends: ${shlibs:Depends},
          libcap2-bin,
          netdata (>= ${source:Version})
-Suggests: nvme-cli sudo
+Suggests: nvme-cli, sudo
 Description: The go.d metrics collection plugin for the Netdata Agent
  This plugin adds a selection of additional collectors written in Go to
  the Netdata Agent A significant percentage of the application specific

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -46,6 +46,12 @@ Recommends: netdata-plugin-ebpf,
             netdata-plugin-apps,
             netdata-plugin-pythond,
             netdata-plugin-go
+Suggests: netdata-plugin-cups,
+          netdata-plugin-freeipmi,
+          netdata-plugin-nfacct,
+          netdata-plugin-chartsd,
+          netdata-plugin-slabinfo,
+          netdata-plugin-perf
 Pre-Depends: dpkg (>= 1.17.14)
 Description: real-time charts for system monitoring
  Netdata is a daemon that collects data in realtime (per second)

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -42,6 +42,7 @@ Conflicts: netdata-core,
            netdata-plugins-bash,
            netdata-plugins-python,
            netdata-web
+Recommends: netdata-plugin-ebpf
 Pre-Depends: dpkg (>= 1.17.14)
 Description: real-time charts for system monitoring
  Netdata is a daemon that collects data in realtime (per second)
@@ -80,3 +81,16 @@ Suggests: apcupsd, nut, iw, sudo
 Description: The charts.d metrics collection plugin for the Netdata Agent
  This plugin adds a selection of additional collectors written in shell script to the Netdata Agent. It includes
  collectors for NUT, APCUPSD, LibreSWAN, OpenSIPS, and Wireless access point statistics.
+
+Package: netdata-plugin-ebpf
+Architecture: i386 amd64
+Depends: ${shlibs:Depends},
+         netdata-plugin-ebpf-code (>= ${source:Version}),
+         netdata (>= ${source:Version})
+Description: The eBPF metrics collection plugin for the Netdata Agent
+ This plugin allows the Netdata Agent to use eBPF code to collect more detailed kernel-level metrics for the system.
+
+Package: netdata-plugin-ebpf-code
+Architecture: i386 amd64
+Description: Compiled eBPF code for the Netdata eBPF plugin
+ This package provides the pre-compiled eBPF code for use by the Netdata eBPF plugin.

--- a/contrib/debian/netdata-plugin-apps.postinst
+++ b/contrib/debian/netdata-plugin-apps.postinst
@@ -3,7 +3,7 @@
 set -e
 
 case "$1" in
-  configure|recnfigure)
+  configure|reconfigure)
     setcap "cap_dac_read_search=eip cap_sys_ptrace=eip" /usr/libexec/netdata/plugins.d/apps.plugin
     ;;
 esac

--- a/contrib/debian/netdata-plugin-apps.postinst
+++ b/contrib/debian/netdata-plugin-apps.postinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+  configure|recnfigure)
+    setcap "cap_dac_read_search=eip cap_sys_ptrace=eip" /usr/libexec/netdata/plugins.d/apps.plugin
+    ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/contrib/debian/netdata-plugin-debugfs.postinst
+++ b/contrib/debian/netdata-plugin-debugfs.postinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+  configure|reconfigure)
+    setcap "cap_dac_read_search=eip" /usr/libexec/netdata/plugins.d/debugfs.plugin
+    ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/contrib/debian/netdata-plugin-ebpf.postinst
+++ b/contrib/debian/netdata-plugin-ebpf.postinst
@@ -3,7 +3,7 @@
 set -e
 
 case "$1" in
-  configure|recnfigure)
+  configure|reconfigure)
     chmod -f 4750 /usr/libexec/netdata/plugins.d/ebpf.plugin
     ;;
 esac

--- a/contrib/debian/netdata-plugin-ebpf.postinst
+++ b/contrib/debian/netdata-plugin-ebpf.postinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+  configure|recnfigure)
+    chmod -f 4750 /usr/libexec/netdata/plugins.d/ebpf.plugin
+    ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/contrib/debian/netdata-plugin-freeipmi.postinst
+++ b/contrib/debian/netdata-plugin-freeipmi.postinst
@@ -3,7 +3,7 @@
 set -e
 
 case "$1" in
-  configure|recnfigure)
+  configure|reconfigure)
     chmod -f 4750 /usr/libexec/netdata/plugins.d/freeipmi.plugin
     ;;
 esac

--- a/contrib/debian/netdata-plugin-freeipmi.postinst
+++ b/contrib/debian/netdata-plugin-freeipmi.postinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+  configure|recnfigure)
+    chmod -f 4750 /usr/libexec/netdata/plugins.d/freeipmi.plugin
+    ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/contrib/debian/netdata-plugin-go.postinst
+++ b/contrib/debian/netdata-plugin-go.postinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+  configure|recnfigure)
+    setcap "cap_net_admin=eip cap_net_raw=eip" /usr/libexec/netdata/plugins.d/go.d.plugin
+    ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/contrib/debian/netdata-plugin-go.postinst
+++ b/contrib/debian/netdata-plugin-go.postinst
@@ -3,7 +3,7 @@
 set -e
 
 case "$1" in
-  configure|recnfigure)
+  configure|reconfigure)
     setcap "cap_net_admin=eip cap_net_raw=eip" /usr/libexec/netdata/plugins.d/go.d.plugin
     ;;
 esac

--- a/contrib/debian/netdata-plugin-nfacct.postinst
+++ b/contrib/debian/netdata-plugin-nfacct.postinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+  configure|recnfigure)
+    chmod -f 4750 /usr/libexec/netdata/plugins.d/nfacct.plugin
+    ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/contrib/debian/netdata-plugin-nfacct.postinst
+++ b/contrib/debian/netdata-plugin-nfacct.postinst
@@ -3,7 +3,7 @@
 set -e
 
 case "$1" in
-  configure|recnfigure)
+  configure|reconfigure)
     chmod -f 4750 /usr/libexec/netdata/plugins.d/nfacct.plugin
     ;;
 esac

--- a/contrib/debian/netdata-plugin-perf.postinst
+++ b/contrib/debian/netdata-plugin-perf.postinst
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+  configure|recnfigure)
+    if capsh --supports=cap_perfmon 2>/dev/null; then
+        setcap cap_perfmon+ep /usr/libexec/netdata/plugins.d/perf.plugin
+    else
+        setcap cap_sys_admin+ep /usr/libexec/netdata/plugins.d/perf.plugin
+    fi
+    ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/contrib/debian/netdata-plugin-perf.postinst
+++ b/contrib/debian/netdata-plugin-perf.postinst
@@ -3,7 +3,7 @@
 set -e
 
 case "$1" in
-  configure|recnfigure)
+  configure|reconfigure)
     if capsh --supports=cap_perfmon 2>/dev/null; then
         setcap cap_perfmon+ep /usr/libexec/netdata/plugins.d/perf.plugin
     else

--- a/contrib/debian/netdata-plugin-slabinfo.postinst
+++ b/contrib/debian/netdata-plugin-slabinfo.postinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+  configure|recnfigure)
+    setcap "cap_dac_read_search=eip" /usr/libexec/netdata/plugins.d/apps.plugin
+    ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/contrib/debian/netdata-plugin-slabinfo.postinst
+++ b/contrib/debian/netdata-plugin-slabinfo.postinst
@@ -3,7 +3,7 @@
 set -e
 
 case "$1" in
-  configure|recnfigure)
+  configure|reconfigure)
     setcap "cap_dac_read_search=eip" /usr/libexec/netdata/plugins.d/apps.plugin
     ;;
 esac

--- a/contrib/debian/netdata.postinst
+++ b/contrib/debian/netdata.postinst
@@ -59,7 +59,6 @@ case "$1" in
     dpkg-statoverride --force --update --add root netdata 0775 /var/lib/netdata/registry > /dev/null 2>&1
 
     chown -R root:netdata /usr/libexec/netdata/plugins.d
-    setcap cap_dac_read_search+ep /usr/libexec/netdata/plugins.d/slabinfo.plugin
     setcap cap_dac_read_search+ep /usr/libexec/netdata/plugins.d/debugfs.plugin
 
     if capsh --supports=cap_perfmon 2>/dev/null; then

--- a/contrib/debian/netdata.postinst
+++ b/contrib/debian/netdata.postinst
@@ -61,12 +61,6 @@ case "$1" in
     chown -R root:netdata /usr/libexec/netdata/plugins.d
     setcap cap_dac_read_search+ep /usr/libexec/netdata/plugins.d/debugfs.plugin
 
-    if capsh --supports=cap_perfmon 2>/dev/null; then
-        setcap cap_perfmon+ep /usr/libexec/netdata/plugins.d/perf.plugin
-    else
-        setcap cap_sys_admin+ep /usr/libexec/netdata/plugins.d/perf.plugin
-    fi
-
     chmod 4750 /usr/libexec/netdata/plugins.d/cgroup-network
 
     # Workaround for other plugins not installed directly by this package

--- a/contrib/debian/netdata.postinst
+++ b/contrib/debian/netdata.postinst
@@ -74,13 +74,13 @@ case "$1" in
     fi
 
     chmod 4750 /usr/libexec/netdata/plugins.d/cgroup-network
-    chmod 4750 /usr/libexec/netdata/plugins.d/nfacct.plugin
 
     # Workaround if system does not have ebpf.plugin
     chmod -f 4750 /usr/libexec/netdata/plugins.d/ebpf.plugin || true
 
     # Workaround for other plugins not installed directly by this package
     chmod -f 4750 /usr/libexec/netdata/plugins.d/freeipmi.plugin || true
+    chmod -f 4750 /usr/libexec/netdata/plugins.d/nfacct.plugin || true
     chmod -f 4750 /usr/libexec/netdata/plugins.d/ioping || true
 
     ;;

--- a/contrib/debian/netdata.postinst
+++ b/contrib/debian/netdata.postinst
@@ -59,7 +59,6 @@ case "$1" in
     dpkg-statoverride --force --update --add root netdata 0775 /var/lib/netdata/registry > /dev/null 2>&1
 
     chown -R root:netdata /usr/libexec/netdata/plugins.d
-    setcap cap_dac_read_search,cap_sys_ptrace+ep /usr/libexec/netdata/plugins.d/apps.plugin
     setcap cap_dac_read_search+ep /usr/libexec/netdata/plugins.d/slabinfo.plugin
     setcap cap_dac_read_search+ep /usr/libexec/netdata/plugins.d/debugfs.plugin
 
@@ -69,18 +68,9 @@ case "$1" in
         setcap cap_sys_admin+ep /usr/libexec/netdata/plugins.d/perf.plugin
     fi
 
-    if [ -f "/usr/libexec/netdata/plugins.d/go.d.plugin" ]; then
-      setcap "cap_net_admin+epi cap_net_raw=eip" /usr/libexec/netdata/plugins.d/go.d.plugin
-    fi
-
     chmod 4750 /usr/libexec/netdata/plugins.d/cgroup-network
 
-    # Workaround if system does not have ebpf.plugin
-    chmod -f 4750 /usr/libexec/netdata/plugins.d/ebpf.plugin || true
-
     # Workaround for other plugins not installed directly by this package
-    chmod -f 4750 /usr/libexec/netdata/plugins.d/freeipmi.plugin || true
-    chmod -f 4750 /usr/libexec/netdata/plugins.d/nfacct.plugin || true
     chmod -f 4750 /usr/libexec/netdata/plugins.d/ioping || true
 
     ;;

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -130,9 +130,13 @@ override_dh_install:
 	[ $(HAVE_EBPF) -eq 1 ] && mkdir -p $(TOP)-plugin-ebpf-code/usr/libexec/netdata/plugins.d/
 	[ $(HAVE_EBPF) -eq 1 ] && packaging/bundle-ebpf.sh . ${TOP}-plugin-ebpf-code/usr/libexec/netdata/plugins.d/
 
-	# Install go
+	# Install go to it's own package directory
 	#
-	debian/install_go.sh $$(cat ${CURDIR}/packaging/go.d.version) $(TOP)/usr/lib/netdata $(TOP)/usr/libexec/netdata
+	mkdir -p $(TOP)-plugin-go/usr/lib/netdata/conf.d
+	mkdir -p $(TOP)-plugin-go/usr/libexec/netdata/plugins.d
+	debian/install_go.sh $$(cat ${CURDIR}/packaging/go.d.version) \
+	$(TOP)-plugin-go/usr/lib/netdata \
+	$(TOP)-plugin-go/usr/libexec/netdata
 
 override_dh_installdocs:
 	dh_installdocs
@@ -160,7 +164,9 @@ override_dh_fixperms:
 	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/debugfs.plugin
 	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/perf.plugin
 	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/slabinfo.plugin
-	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/go.d.plugin
+
+	# Go plugin package
+	chmod 0750 $(TOP)-plugin-go/usr/libexec/netdata/plugins.d/go.d.plugin
 
 	# CUPS plugin package
 	chmod 0750 $(TOP)-plugin-cups/usr/libexec/netdata/plugins.d/cups.plugin

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -111,6 +111,11 @@ override_dh_install:
 	mv -f $(TEMPTOP)/usr/lib/netdata/conf.d/apps_groups.conf \
 	$(TOP)-plugin-apps/usr/lib/netdata/conf.d/apps_groups.conf
 
+	# Add slabinfo plugin install rules
+	mkdir -p $(TOP)-plugin-slabinfo/usr/libexec/netdata/plugins.d/
+	mv -f $(TEMPTOP)/usr/libexec/netdata/plugins.d/slabinfo.plugin \
+	$(TOP)-plugin-slabinfo/usr/libexec/netdata/plugins.d/slabinfo.plugin
+
 	# Set the rest of the software in the main package
 	#
 	cp -rp $(TEMPTOP)/usr $(TOP)
@@ -166,7 +171,6 @@ override_dh_fixperms:
 	chmod 0755 $(TOP)/usr/libexec/netdata/netdata-updater.sh
 
 	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/perf.plugin
-	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/slabinfo.plugin
 
 	# debugfs plugin
 	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/debugfs.plugin
@@ -175,6 +179,9 @@ override_dh_fixperms:
 	# given extra capabilities in the postinst script.
 	#
 	chmod 0750 $(TOP)-plugin-apps/usr/libexec/netdata/plugins.d/apps.plugin
+
+	# slabinfo package
+	chmod 0750 $(TOP)-plugin-slabinfo/usr/libexec/netdata/plugins.d/slabinfo.plugin
 
 	# Go plugin package
 	chmod 0750 $(TOP)-plugin-go/usr/libexec/netdata/plugins.d/go.d.plugin
@@ -185,7 +192,7 @@ override_dh_fixperms:
 	# freeIPMI plugin package
 	chmod 4750 $(TOP)-plugin-freeipmi/usr/libexec/netdata/plugins.d/freeipmi.plugin
 
-	# freeIPMI plugin package
+	# NFACCT plugin package
 	chmod 4750 $(TOP)-plugin-nfacct/usr/libexec/netdata/plugins.d/nfacct.plugin
 
 override_dh_installlogrotate:

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -66,6 +66,21 @@ override_dh_install:
 	mv -f $(TEMPTOP)/usr/libexec/netdata/plugins.d/nfacct.plugin \
 	$(TOP)-plugin-nfacct/usr/libexec/netdata/plugins.d/nfacct.plugin
 
+	# Add charts.d plugin install rules
+	#
+	mkdir -p $(TOP)-plugin-chartsd/usr/libexec/netdata/plugins.d/
+	mkdir -p $(TOP)-plugin-chartsd/usr/lib/netdata/conf.d/
+	mv -f $(TEMPTOP)/usr/libexec/netdata/plugins.d/charts.d.plugin \
+	$(TOP)-plugin-chartsd/usr/libexec/netdata/plugins.d/charts.d.plugin
+	mv -f $(TEMPTOP)/usr/libexec/netdata/plugins.d/charts.d.dryrun-helper.sh \
+	$(TOP)-plugin-chartsd/usr/libexec/netdata/plugins.d/charts.d.dryrun-helper.sh
+	mv -f $(TEMPTOP)/usr/libexec/netdata/charts.d \
+	$(TOP)-plugin-chartsd/usr/libexec/netdata/charts.d
+	mv -f $(TEMPTOP)/usr/lib/netdata/conf.d/charts.d.conf \
+	$(TOP)-plugin-chartsd/usr/lib/netdata/conf.d/charts.d.conf
+	mv -f $(TEMPTOP)/usr/lib/netdata/conf.d/charts.d \
+	$(TOP)-plugin-chartsd/usr/lib/netdata/conf.d/charts.d
+
 	# Set the rest of the software in the main package
 	#
 	cp -rp $(TEMPTOP)/usr $(TOP)

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -116,6 +116,11 @@ override_dh_install:
 	mv -f $(TEMPTOP)/usr/libexec/netdata/plugins.d/slabinfo.plugin \
 	$(TOP)-plugin-slabinfo/usr/libexec/netdata/plugins.d/slabinfo.plugin
 
+	# Add perf plugin install rules
+	mkdir -p $(TOP)-plugin-perf/usr/libexec/netdata/plugins.d/
+	mv -f $(TEMPTOP)/usr/libexec/netdata/plugins.d/perf.plugin \
+	$(TOP)-plugin-perf/usr/libexec/netdata/plugins.d/perf.plugin
+
 	# Set the rest of the software in the main package
 	#
 	cp -rp $(TEMPTOP)/usr $(TOP)
@@ -170,8 +175,6 @@ override_dh_fixperms:
 	#
 	chmod 0755 $(TOP)/usr/libexec/netdata/netdata-updater.sh
 
-	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/perf.plugin
-
 	# debugfs plugin
 	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/debugfs.plugin
 
@@ -182,6 +185,9 @@ override_dh_fixperms:
 
 	# slabinfo package
 	chmod 0750 $(TOP)-plugin-slabinfo/usr/libexec/netdata/plugins.d/slabinfo.plugin
+
+	# perf package
+	chmod 0750 $(TOP)-plugin-perf/usr/libexec/netdata/plugins.d/perf.plugin
 
 	# Go plugin package
 	chmod 0750 $(TOP)-plugin-go/usr/libexec/netdata/plugins.d/go.d.plugin

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -81,6 +81,16 @@ override_dh_install:
 	mv -f $(TEMPTOP)/usr/lib/netdata/conf.d/charts.d \
 	$(TOP)-plugin-chartsd/usr/lib/netdata/conf.d/charts.d
 
+	# Add ebpf plugin install rules
+	[ $(HAVE_EBPF) -eq 1 ] && mkdir -p $(TOP)-plugin-ebpf/usr/libexec/netdata/plugins.d/
+	[ $(HAVE_EBPF) -eq 1 ] && mkdir -p $(TOP)-plugin-ebpf/usr/lib/netdata/conf.d/
+	[ $(HAVE_EBPF) -eq 1 ] && mv -f $(TEMPTOP)/usr/libexec/netdata/plugins.d/ebpf.plugin \
+	$(TOP)-plugin-ebpf/usr/libexec/netdata/plugins.d/ebpf.plugin
+	[ $(HAVE_EBPF) -eq 1 ] && mv -f $(TEMPTOP)/usr/lib/netdata/conf.d/ebpf.d.conf \
+	$(TOP)-plugin-ebpf/usr/lib/netdata/conf.d/ebpf.d.conf
+	[ $(HAVE_EBPF) -eq 1 ] && mv -f $(TEMPTOP)/usr/lib/netdata/conf.d/ebpf.d \
+	$(TOP)-plugin-ebpf/usr/lib/netdata/conf.d/ebpf.d
+
 	# Set the rest of the software in the main package
 	#
 	cp -rp $(TEMPTOP)/usr $(TOP)
@@ -103,9 +113,10 @@ override_dh_install:
 		ln -s "/usr/share/netdata/www/$$D" "$(TOP)/var/lib/netdata/www/$$D"; \
 	done
 
-	if [ $(HAVE_EBPF) -eq 1 ]; then \
-		packaging/bundle-ebpf.sh . ${TOP}/usr/libexec/netdata/plugins.d; \
-	fi
+	# Handle eBPF code
+	#
+	[ $(HAVE_EBPF) -eq 1 ] && mkdir -p $(TOP)-plugin-ebpf-code/usr/libexec/netdata/plugins.d/
+	[ $(HAVE_EBPF) -eq 1 ] && packaging/bundle-ebpf.sh . ${TOP}-plugin-ebpf-code/usr/libexec/netdata/plugins.d/
 
 	# Install go
 	#

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -91,6 +91,18 @@ override_dh_install:
 	[ $(HAVE_EBPF) -eq 1 ] && mv -f $(TEMPTOP)/usr/lib/netdata/conf.d/ebpf.d \
 	$(TOP)-plugin-ebpf/usr/lib/netdata/conf.d/ebpf.d
 
+	# Add python plugin install rules
+	mkdir -p $(TOP)-plugin-pythond/usr/libexec/netdata/plugins.d/
+	mkdir -p $(TOP)-plugin-pythond/usr/lib/netdata/conf.d/
+	mv -f $(TEMPTOP)/usr/libexec/netdata/plugins.d/python.d.plugin \
+	$(TOP)-plugin-pythond/usr/libexec/netdata/plugins.d/python.d.plugin
+	mv -f $(TEMPTOP)/usr/libexec/netdata/python.d \
+	$(TOP)-plugin-pythond/usr/libexec/netdata/python.d
+	mv -f $(TEMPTOP)/usr/lib/netdata/conf.d/python.d.conf \
+	$(TOP)-plugin-pythond/usr/lib/netdata/conf.d/python.d.conf
+	mv -f $(TEMPTOP)/usr/lib/netdata/conf.d/python.d \
+	$(TOP)-plugin-pythond/usr/lib/netdata/conf.d/python.d
+
 	# Set the rest of the software in the main package
 	#
 	cp -rp $(TEMPTOP)/usr $(TOP)

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -60,6 +60,12 @@ override_dh_install:
 	mv -f $(TEMPTOP)/usr/libexec/netdata/plugins.d/freeipmi.plugin \
 	$(TOP)-plugin-freeipmi/usr/libexec/netdata/plugins.d/freeipmi.plugin
 
+	# Add free IPMI plugin install rules
+	#
+	mkdir -p $(TOP)-plugin-nfacct/usr/libexec/netdata/plugins.d
+	mv -f $(TEMPTOP)/usr/libexec/netdata/plugins.d/nfacct.plugin \
+	$(TOP)-plugin-nfacct/usr/libexec/netdata/plugins.d/nfacct.plugin
+
 	# Set the rest of the software in the main package
 	#
 	cp -rp $(TEMPTOP)/usr $(TOP)
@@ -123,6 +129,9 @@ override_dh_fixperms:
 
 	# freeIPMI plugin package
 	chmod 4750 $(TOP)-plugin-freeipmi/usr/libexec/netdata/plugins.d/freeipmi.plugin
+
+	# freeIPMI plugin package
+	chmod 4750 $(TOP)-plugin-nfacct/usr/libexec/netdata/plugins.d/nfacct.plugin
 
 override_dh_installlogrotate:
 	cp system/logrotate/netdata debian/netdata.logrotate

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -103,6 +103,14 @@ override_dh_install:
 	mv -f $(TEMPTOP)/usr/lib/netdata/conf.d/python.d \
 	$(TOP)-plugin-pythond/usr/lib/netdata/conf.d/python.d
 
+	# Add apps plugin install rules
+	mkdir -p $(TOP)-plugin-apps/usr/libexec/netdata/plugins.d/
+	mkdir -p $(TOP)-plugin-apps/usr/lib/netdata/conf.d/
+	mv -f $(TEMPTOP)/usr/libexec/netdata/plugins.d/apps.plugin \
+	$(TOP)-plugin-apps/usr/libexec/netdata/plugins.d/apps.plugin
+	mv -f $(TEMPTOP)/usr/lib/netdata/conf.d/apps_groups.conf \
+	$(TOP)-plugin-apps/usr/lib/netdata/conf.d/apps_groups.conf
+
 	# Set the rest of the software in the main package
 	#
 	cp -rp $(TEMPTOP)/usr $(TOP)
@@ -157,13 +165,16 @@ override_dh_fixperms:
 	#
 	chmod 0755 $(TOP)/usr/libexec/netdata/netdata-updater.sh
 
+	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/perf.plugin
+	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/slabinfo.plugin
+
+	# debugfs plugin
+	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/debugfs.plugin
+
 	# apps.plugin should only be runnable by the netdata user. It will be
 	# given extra capabilities in the postinst script.
 	#
-	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/apps.plugin
-	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/debugfs.plugin
-	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/perf.plugin
-	chmod 0750 $(TOP)/usr/libexec/netdata/plugins.d/slabinfo.plugin
+	chmod 0750 $(TOP)-plugin-apps/usr/libexec/netdata/plugins.d/apps.plugin
 
 	# Go plugin package
 	chmod 0750 $(TOP)-plugin-go/usr/libexec/netdata/plugins.d/go.d.plugin

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -480,10 +480,7 @@ rm -rf "${RPM_BUILD_ROOT}"
 %{_sysconfdir}/%{name}
 %config(noreplace) %{_sysconfdir}/%{name}/netdata.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
-%dir %{_libdir}/%{name}
-%dir %{_datadir}/%{name}
 %{_libdir}/%{name}
-%{_libdir}/%{name}/conf.d/
 %{_libexecdir}/%{name}
 %{_sbindir}/%{name}
 %{_sbindir}/netdatacli
@@ -493,8 +490,6 @@ rm -rf "${RPM_BUILD_ROOT}"
 %{_presetdir}/50-netdata.preset
 
 %defattr(0750,root,netdata,0750)
-
-%dir %{_libexecdir}/%{name}/plugins.d
 
 %{_libexecdir}/%{name}/plugins.d
 

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -330,6 +330,11 @@ install -m 755 -d "${RPM_BUILD_ROOT}%{_localstatedir}/log/%{name}"
 install -m 755 -d "${RPM_BUILD_ROOT}%{_localstatedir}/lib/%{name}/registry"
 
 # ###########################################################
+# Install uninstaller script
+install -m 750 -p packaging/installer/netdata-uninstaller.sh \
+        "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/netdata-uninstaller.sh"
+
+# ###########################################################
 # Install netdata service
 install -m 755 -d "${RPM_BUILD_ROOT}%{_unitdir}"
 install -m 644 -p system/systemd/netdata.service "${RPM_BUILD_ROOT}%{_unitdir}/netdata.service"
@@ -477,11 +482,13 @@ rm -rf "${RPM_BUILD_ROOT}"
 
 %files
 %doc README.md
-%{_sysconfdir}/%{name}
 %config(noreplace) %{_sysconfdir}/%{name}/netdata.conf
+%attr(0755,root,netdata) %{_sysconfdir}/%{name}/edit-config
+%attr(0644,root,netdata) %{_sysconfdir}/%{name}/.install-type
+%dir %{_sysconfdir}/%{name}/health.d
+%dir %{_sysconfdir}/%{name}/statsd.d
 %config(noreplace) %{_sysconfdir}/logrotate.d/%{name}
 %{_libdir}/%{name}
-%{_libexecdir}/%{name}
 %{_sbindir}/%{name}
 %{_sbindir}/netdatacli
 %{_sbindir}/netdata-claim.sh
@@ -489,10 +496,24 @@ rm -rf "${RPM_BUILD_ROOT}"
 %{_unitdir}/netdata.service
 %{_presetdir}/50-netdata.preset
 
+%dir %{_libexecdir}/%{name}
+%dir %{_libexecdir}/%{name}/plugins.d
 %defattr(0750,root,netdata,0750)
-
-%{_libexecdir}/%{name}/plugins.d
-
+%{_libexecdir}/%{name}/install-service.sh
+%{_libexecdir}/%{name}/netdata-updater.sh
+%{_libexecdir}/%{name}/netdata-uninstaller.sh
+%{_libexecdir}/%{name}/plugins.d/acl.sh
+%{_libexecdir}/%{name}/plugins.d/alarm-email.sh
+%{_libexecdir}/%{name}/plugins.d/alarm-notify.sh
+%{_libexecdir}/%{name}/plugins.d/alarm-test.sh
+%{_libexecdir}/%{name}/plugins.d/anonymous-statistics.sh
+%{_libexecdir}/%{name}/plugins.d/get-kubernetes-labels.sh
+%{_libexecdir}/%{name}/plugins.d/health-cmdapi-test.sh
+%{_libexecdir}/%{name}/plugins.d/ioping.plugin
+%{_libexecdir}/%{name}/plugins.d/request.sh
+%{_libexecdir}/%{name}/plugins.d/system-info.sh
+%{_libexecdir}/%{name}/plugins.d/tc-qos-helper.sh
+%{_libexecdir}/%{name}/plugins.d/template_dim.sh
 
 %if %{with netns}
 # cgroup-network detects the network interfaces of CGROUPs

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -157,8 +157,10 @@ Recommends: netdata-plugin-go
 %if %{_have_freeipmi}
 Suggests:   netdata-plugin-freeipmi
 %endif
-Suggests:   netdata-plugin-cups
+%if %{_have_nfacct}
 Suggests:   netdata-plugin-nfacct
+%endif
+Suggests:   netdata-plugin-cups
 Suggests:   netdata-plugin-chartsd
 Suggests:   netdata-plugin-slabinfo
 Suggests:   netdata-plugin-perf
@@ -237,6 +239,12 @@ autoreconf -ivf
 %configure \
 	%if 0%{!?_have_ebpf}
 	--disable-ebpf
+	%endif
+	%if 0%{!?_have_freeipmi}
+	--disable-plugin-freeipmi
+	%endif
+	%if 0%{!?_have_nfacct}
+	--disable-plugin-nfacct
 	%endif
 	%if 0%{?centos_ver:1}
 	%if %{centos_ver} < 8

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -130,7 +130,7 @@ Requires(pre): /usr/sbin/useradd
 # #####################################################################
 # CentOS prior to CentOS 8 does not have a new enough version of RPM
 # to support weak dependencies. Explicitly requiring our default plugins
-# makes it impossible to properly test the packages prior to updload,
+# makes it impossible to properly test the packages prior to upload,
 # so we just skip depending on them on CentOS 7.
 %if 0%{?centos_ver} != 7
 %if 0%{?_have_ebpf}
@@ -139,6 +139,12 @@ Recommends: netdata-plugin-ebpf
 Recommends: netdata-plugin-apps
 Recommends: netdata-plugin-pythond
 Recommends: netdata-plugin-go
+Suggests:   netdata-plugin-cups
+Suggests:   netdata-plugin-freeipmi
+Suggests:   netdata-plugin-nfacct
+Suggests:   netdata-plugin-chartsd
+Suggests:   netdata-plugin-slabinfo
+Suggests:   netdata-plugin-perf
 %endif
 
 # #####################################################################

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -547,9 +547,7 @@ rm -rf "${RPM_BUILD_ROOT}"
 %endif
 
 # NFACCT belongs to a different sub-package
-%if 0%{!?ol8} && 0%{!?ol9} && 0%{?centos_ver} != 7
 %exclude %{_libexecdir}/%{name}/plugins.d/nfacct.plugin
-%endif
 
 # Charts.d belongs to a different sub-package
 %exclude %{_libexecdir}/%{name}/plugins.d/charts.d.plugin
@@ -615,7 +613,6 @@ Requires: netdata = %{version}
 %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin
 %endif
 
-%if 0%{!?ol8} && 0%{!?ol9} && 0%{?centos_ver} != 7
 %package plugin-nfacct
 Summary: The NFACCT metrics collection plugin for the Netdata Agent
 Group: Applications/System
@@ -630,7 +627,6 @@ Requires: netdata = %{version}
 
 %files plugin-nfacct
 %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/nfacct.plugin
-%endif
 
 %package plugin-chartsd
 Summary: The charts.d metrics collection plugin for the Netdata Agent

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -154,6 +154,7 @@ Recommends: netdata-plugin-ebpf
 Recommends: netdata-plugin-apps
 Recommends: netdata-plugin-pythond
 Recommends: netdata-plugin-go
+Recommends: netdata-plugin-debugfs
 %if 0%{?_have_freeipmi}
 Suggests:   netdata-plugin-freeipmi
 %endif

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -503,6 +503,7 @@ rm -rf "${RPM_BUILD_ROOT}"
 %{_libexecdir}/%{name}/plugins.d/get-kubernetes-labels.sh
 %{_libexecdir}/%{name}/plugins.d/health-cmdapi-test.sh
 %{_libexecdir}/%{name}/plugins.d/ioping.plugin
+%{_libexecdir}/%{name}/plugins.d/loopsleepms.sh.inc
 %{_libexecdir}/%{name}/plugins.d/request.sh
 %{_libexecdir}/%{name}/plugins.d/system-info.sh
 %{_libexecdir}/%{name}/plugins.d/tc-qos-helper.sh

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -481,16 +481,6 @@ rm -rf "${RPM_BUILD_ROOT}"
 %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/cgroup-network
 %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/cgroup-network-helper.sh
 
-# ebpf plugin
-%if 0%{?_have_ebpf}
-%attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/ebpf.plugin
-%endif
-
-# perf plugin
-# This should be CAP_PERFMON once RPM finally learns about it, but needs to be CAP_SYS_ADMIN for now.
-# %caps(cap_perfmon=ep) %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/perf.plugin
-%caps(cap_sys_admin=ep) %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/perf.plugin
-
 # debugfs plugin
 %caps(cap_dac_read_search=ep) %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/debugfs.plugin
 
@@ -547,6 +537,9 @@ rm -rf "${RPM_BUILD_ROOT}"
 
 # slabinfo belongs to a different sub-package
 %exclude %{_libexecdir}/%{name}/plugins.d/slabinfo.plugin
+
+# perf belongs to a different sub-package
+%exclude %{_libexecdir}/%{name}/plugins.d/perf.plugin
 
 # CUPS belongs to a different sub package
 %if 0%{?centos_ver} != 6 && 0%{?centos_ver} != 7
@@ -723,6 +716,24 @@ Requires: netdata = %{version}
 %defattr(0750,root,netdata,0750)
 # CAP_DAC_READ_SEARCH needed to access the files the plugin reads to collect data.
 %caps(cap_dac_read_search=ep) %{_libexecdir}/%{name}/plugins.d/slabinfo.plugin
+
+%package plugin-perf
+Summary: The perf metrics collector for the Netdata Agent
+Group: Applications/System
+Requires: netdata = %{version}
+
+%description plugin-perf
+ This plugin allows the Netdata to collect metrics from the Linux perf subsystem.
+
+%files plugin-perf
+%defattr(0750,root,netdata,0750)
+# Either CAP_SYS_ADMIN or CAP_PERFMON needed for data collection
+# PERFMON is newer, so only try to use it on platforms which support it.
+%if 0%{?centos_ver} >= 9 || 0%{?fedora} >= 36
+%caps(cap_perfmon=ep) %{_libexecdir}/%{name}/plugins.d/perf.plugin
+%else
+%caps(cap_sys_admin=ep) %{_libexecdir}/%{name}/plugins.d/perf.plugin
+%endif
 
 %changelog
 * Tue Nov 01 2022 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-17

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -150,6 +150,19 @@ Requires(pre): /usr/sbin/groupadd
 Requires(pre): /usr/sbin/useradd
 
 # #####################################################################
+# External plugin package dependencies
+# #####################################################################
+# CentOS prior to CentOS 8 does not have a new enough version of RPM
+# to support weak dependencies. Explicitly requiring our default plugins
+# makes it impossible to properly test the packages prior to updload,
+# so we just skip depending on them on CentOS 7.
+%if 0%{?centos_ver} != 7
+%if 0%{?_have_ebpf}
+Recommends: netdata-plugin-ebpf
+%endif
+%endif
+
+# #####################################################################
 # Functionality-dependent package dependencies
 # #####################################################################
 # Note: Some or all of the Packages may be found in the EPEL repo,
@@ -543,6 +556,14 @@ rm -rf "${RPM_BUILD_ROOT}"
 %exclude %{_libdir}/%{name}/conf.d/charts.d.conf
 %exclude %{_libdir}/%{name}/conf.d/charts.d/
 
+# eBPF belongs to a different sub-package
+%if 0%{?_have_ebpf}
+%exclude %{_libexecdir}/%{name}/plugins.d/ebpf.plugin
+%exclude %{_libdir}/%{name}/conf.d/ebpf.d.conf
+%exclude %{_libdir}/%{name}/conf.d/ebpf.d
+%exclude %{_libexecdir}/%{name}/plugins.d/ebpf.d
+%endif
+
 # CUPS belongs to a different sub package
 %if 0%{?centos_ver} != 6 && 0%{?centos_ver} != 7
 %exclude %{_libexecdir}/%{name}/plugins.d/cups.plugin
@@ -604,7 +625,7 @@ Suggests: sudo
 %endif
 
 %description plugin-chartsd
-  This plugin adds a selection of additional collectors written in shell script to the Netdata Agent.
+ This plugin adds a selection of additional collectors written in shell script to the Netdata Agent.
 It includes collectors for NUT, APCUPSD, LibreSWAN, OpenSIPS, and Wireless access point statistics.
 
 %files plugin-chartsd
@@ -615,6 +636,36 @@ It includes collectors for NUT, APCUPSD, LibreSWAN, OpenSIPS, and Wireless acces
 %defattr(0644,root,netdata,0644)
 %{_libdir}/%{name}/conf.d/charts.d.conf
 %{_libdir}/%{name}/conf.d/charts.d/
+
+%if 0%{?_have_ebpf}
+%package plugin-ebpf
+Summary: The eBPF metrics collection plugin for the Netdata Agent
+Group: Applications/System
+Requires: netdata = %{version}
+Requires: netdata-plugin-ebpf-code >= %{version}
+
+%description plugin-ebpf
+ This plugin allows the Netdata Agent to use eBPF code to collect more detailed kernel-level metrics for the system.
+
+%files plugin-ebpf
+%defattr(4750,root,netdata,4750)
+%{_libexecdir}/%{name}/plugins.d/ebpf.plugin
+%defattr(0644,root,netdata,0644)
+%{_libdir}/%{name}/conf.d/ebpf.d.conf
+%{_libdir}/%{name}/conf.d/ebpf.d
+
+%package plugin-ebpf-code
+Summary: Compiled eBPF code for the Netdata eBPF plugin
+Group: Applications/System
+
+%description plugin-ebpf-code
+ This package provides the pre-compiled eBPF code for use by the Netdata eBPF plugin.
+
+%files plugin-ebpf-code
+%defattr(0640,root,netdata,0640)
+%{_libexecdir}/%{name}/plugins.d/ebpf.d
+
+%endif
 
 %changelog
 * Fri Apr 07 2023 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-19

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -34,11 +34,21 @@ AutoReqProv: yes
 %define _libexecdir /usr/libexec
 %define _libdir /usr/lib
 
+# Fedora doesn’t define this, but other distros do
+%{!?_presetdir:%global _presetdir %{_libdir}/systemd/system-preset}
+
 # Redefine centos_ver to standardize on a single macro
 %{?rhel:%global centos_ver %rhel}
 
-# Disable NFACCT for RHEL equivalents
-%if 0%{?centos_ver}
+# Disable FreeIPMI on Amazon Linux
+%if 0%{?amzn}
+%global _have_freeipmi 0
+%else
+%global _have_freeipmi 1
+%endif
+
+# Disable NFACCT for RHEL equivalents and Amazon Linux
+%if 0%{?centos_ver} || 0%{?amzn}
 %global _have_nfacct 0
 %else
 %global _have_nfacct 1
@@ -70,7 +80,7 @@ BuildRequires: git-core
 BuildRequires: autoconf
 %if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1140
 BuildRequires: autoconf-archive
-%if 0%{?rhel} <= 8
+%if 0%{?rhel} <= 8 && 0%{?amzn} < 2023
 BuildRequires: autogen
 %endif
 %endif
@@ -88,12 +98,14 @@ BuildRequires: protobuf-devel
 BuildRequires: libprotobuf-c-devel
 BuildRequires: liblz4-devel
 BuildRequires: libjson-c-devel
+BuildRequires: libyaml-devel
 %else
 %if 0%{?fedora}
 BuildRequires: protobuf-devel
 BuildRequires: protobuf-c-devel
 BuildRequires: lz4-devel
 BuildRequires: json-c-devel
+BuildRequires: libyaml-devel
 %else
 %if 0%{?centos_ver} >= 8
 BuildRequires: protobuf-devel
@@ -101,11 +113,16 @@ BuildRequires: protobuf-c-devel
 %endif
 BuildRequires: lz4-devel
 BuildRequires: json-c-devel
+BuildRequires: libyaml-devel
 %endif
 %endif
 
 # Core build requirements for service install
-%{netdata_initd_buildrequires}
+%if 0%{?suse_version}
+BuildRequires: systemd-rpm-macros
+%else
+BuildRequires: systemd
+%endif
 
 # Runtime dependencies
 #
@@ -123,8 +140,6 @@ Requires: python3
 Requires(pre): /usr/sbin/groupadd
 Requires(pre): /usr/sbin/useradd
 
-%{netdata_initd_requires}
-
 # #####################################################################
 # External plugin package dependencies
 # #####################################################################
@@ -139,8 +154,10 @@ Recommends: netdata-plugin-ebpf
 Recommends: netdata-plugin-apps
 Recommends: netdata-plugin-pythond
 Recommends: netdata-plugin-go
-Suggests:   netdata-plugin-cups
+%if %{_have_freeipmi}
 Suggests:   netdata-plugin-freeipmi
+%endif
+Suggests:   netdata-plugin-cups
 Suggests:   netdata-plugin-nfacct
 Suggests:   netdata-plugin-chartsd
 Suggests:   netdata-plugin-slabinfo
@@ -163,7 +180,9 @@ BuildRequires:  libnetfilter_acct-devel
 # end nfacct plugin dependencies
 
 # freeipmi plugin dependencies
+%if %{_have_freeipmi}
 BuildRequires:  freeipmi-devel
+%endif
 # end - freeipmi plugin dependencies
 
 # CUPS plugin dependencies
@@ -257,7 +276,9 @@ install -m 644 -p system/logrotate/netdata "${RPM_BUILD_ROOT}%{_sysconfdir}/logr
 
 # ###########################################################
 # Install freeipmi
+%if %{_have_freeipmi}
 install -m 4750 -p freeipmi.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/freeipmi.plugin"
+%endif
 
 # ###########################################################
 # Install apps.plugin
@@ -303,15 +324,10 @@ install -m 750 -p packaging/installer/netdata-uninstaller.sh \
 
 # ###########################################################
 # Install netdata service
-%if %{with systemd}
 install -m 755 -d "${RPM_BUILD_ROOT}%{_unitdir}"
 install -m 644 -p system/systemd/netdata.service "${RPM_BUILD_ROOT}%{_unitdir}/netdata.service"
-%else
-# install SYSV init stuff
-install -d "${RPM_BUILD_ROOT}/etc/rc.d/init.d"
-install -m 755 system/initd/init.d/netdata \
-        "${RPM_BUILD_ROOT}/etc/rc.d/init.d/netdata"
-%endif
+install -m 755 -d "${RPM_BUILD_ROOT}%{_presetdir}"
+install -m 644 -p system/systemd/50-netdata.preset "${RPM_BUILD_ROOT}%{_presetdir}/50-netdata.preset"
 
 # ############################################################
 # Package Go within netdata (TBD: Package it separately)
@@ -429,13 +445,25 @@ for item in docker nginx varnish haproxy adm nsd proxy squid ceph nobody I2C; do
 done
 
 %post
-%{netdata_init_post}
+%if 0%{?suse_version}
+%service_add_post netdata.service
+%else
+%systemd_post netdata.service
+%endif
 
 %preun
-%{netdata_init_preun}
+%if 0%{?suse_version}
+%service_del_preun netdata.service
+%else
+%systemd_preun netdata.service
+%endif
 
 %postun
-%{netdata_init_postun}
+%if 0%{?suse_version}
+%service_del_postun netdata.service
+%else
+%systemd_postun_with_restart netdata.service
+%endif
 
 %clean
 rm -rf "${RPM_BUILD_ROOT}"
@@ -453,11 +481,8 @@ rm -rf "${RPM_BUILD_ROOT}"
 %{_sbindir}/netdatacli
 %{_sbindir}/netdata-claim.sh
 
-%if %{with systemd}
 %{_unitdir}/netdata.service
-%else
-%{_sysconfdir}/rc.d/init.d/netdata
-%endif
+%{_presetdir}/50-netdata.preset
 
 %dir %{_libexecdir}/%{name}
 %dir %{_libexecdir}/%{name}/plugins.d
@@ -504,7 +529,9 @@ rm -rf "${RPM_BUILD_ROOT}"
 %attr(0770,netdata,netdata) %dir %{_localstatedir}/lib/%{name}/registry
 
 # Free IPMI belongs to a different sub-package
+%if %{_have_freeipmi}
 %exclude %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin
+%endif
 
 # NFACCT belongs to a different sub-package
 %if 0%{?_have_nfacct}
@@ -564,6 +591,7 @@ Requires: netdata = %{version}
 %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/cups.plugin
 %endif
 
+%if %{_have_freeipmi}
 %package plugin-freeipmi
 Summary: The FreeIPMI metrics collection plugin for the Netdata Agent
 Group: Applications/System
@@ -575,6 +603,7 @@ Requires: netdata = %{version}
 
 %files plugin-freeipmi
 %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin
+%endif
 
 %if 0%{?_have_nfacct}
 %package plugin-nfacct

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -520,9 +520,6 @@ rm -rf "${RPM_BUILD_ROOT}"
 %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/cgroup-network
 %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/cgroup-network-helper.sh
 
-# debugfs plugin
-%caps(cap_dac_read_search=ep) %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/debugfs.plugin
-
 # Enforce 0644 for files and 0755 for directories
 # for the netdata web directory
 %defattr(0644,root,root,0755)
@@ -800,6 +797,20 @@ Conflicts: netdata <= %{version}
 %else
 %caps(cap_sys_admin=ep) %{_libexecdir}/%{name}/plugins.d/perf.plugin
 %endif
+
+%package plugin-debugfs
+Summary: The debugfs metrics collector for the Netdata Agent
+Group: Applications/System
+Requires: netdata = %{version}
+Conflicts: netdata <= %{version}
+
+%description plugin-debugfs
+ This plugin allows the Netdata Agent to collect Linux kernel metrics exposed through debugfs.
+
+%files plugin-debugfs
+%defattr(0750,root,netdata,0750)
+# CAP_DAC_READ_SEARCH required for data collection.
+%caps(cap_dac_read_search=ep) %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/debugfs.plugin
 
 %changelog
 * Fri Apr 07 2023 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-19

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -479,7 +479,6 @@ rm -rf "${RPM_BUILD_ROOT}"
 %defattr(0750,root,netdata,0750)
 
 %dir %{_libexecdir}/%{name}/python.d
-%dir %{_libexecdir}/%{name}/charts.d
 %dir %{_libexecdir}/%{name}/plugins.d
 
 %{_libexecdir}/%{name}/python.d
@@ -537,6 +536,13 @@ rm -rf "${RPM_BUILD_ROOT}"
 %exclude %{_libexecdir}/%{name}/plugins.d/nfacct.plugin
 %endif
 
+# Charts.d belongs to a different sub-package
+%exclude %{_libexecdir}/%{name}/plugins.d/charts.d.plugin
+%exclude %{_libexecdir}/%{name}/plugins.d/charts.d.dryrun-helper.sh
+%exclude %{_libexecdir}/%{name}/charts.d/
+%exclude %{_libdir}/%{name}/conf.d/charts.d.conf
+%exclude %{_libdir}/%{name}/conf.d/charts.d/
+
 # CUPS belongs to a different sub package
 %if 0%{?centos_ver} != 6 && 0%{?centos_ver} != 7
 %exclude %{_libexecdir}/%{name}/plugins.d/cups.plugin
@@ -584,6 +590,31 @@ Requires: netdata = %{version}
 %files plugin-nfacct
 %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/nfacct.plugin
 %endif
+
+%package plugin-chartsd
+Summary: The charts.d metrics collection plugin for the Netdata Agent
+Group: Applications/System
+Requires: bash
+Requires: netdata = %{version}
+%if 0%{?centos_ver} != 7
+Suggests: nut
+Suggests: apcupsd
+Suggests: iw
+Suggests: sudo
+%endif
+
+%description plugin-chartsd
+  This plugin adds a selection of additional collectors written in shell script to the Netdata Agent.
+It includes collectors for NUT, APCUPSD, LibreSWAN, OpenSIPS, and Wireless access point statistics.
+
+%files plugin-chartsd
+%defattr(0750,root,netdata,0750)
+%{_libexecdir}/%{name}/plugins.d/charts.d.plugin
+%{_libexecdir}/%{name}/plugins.d/charts.d.dryrun-helper.sh
+%{_libexecdir}/%{name}/charts.d/
+%defattr(0644,root,netdata,0644)
+%{_libdir}/%{name}/conf.d/charts.d.conf
+%{_libdir}/%{name}/conf.d/charts.d/
 
 %changelog
 * Fri Apr 07 2023 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-19

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -575,10 +575,11 @@ Requires: netdata = %{version}
 Summary: The NFACCT metrics collection plugin for the Netdata Agent
 Group: Applications/System
 Requires: libmnl
+Requires: netdata = %{version}
+Conflicts: netdata <= %{version}
 %if 0%{?fedora} || 0%{?suse_version} >= 1140
 Requires: libnetfilter_acct
 %endif
-Requires: netdata = %{version}
 
 %description plugin-nfacct
  This plugin allows the Netdata Agent to collect metrics from the firewall using NFACCT objects.
@@ -592,6 +593,7 @@ Summary: The charts.d metrics collection plugin for the Netdata Agent
 Group: Applications/System
 Requires: bash
 Requires: netdata = %{version}
+Conflicts: netdata <= %{version}
 %if 0%{?centos_ver} != 7
 Suggests: nut
 Suggests: apcupsd
@@ -617,12 +619,16 @@ It includes collectors for NUT, APCUPSD, LibreSWAN, OpenSIPS, and Wireless acces
 Summary: The eBPF metrics collection plugin for the Netdata Agent
 Group: Applications/System
 Requires: netdata = %{version}
+Conflicts: netdata <= %{version}
 %if 0%{?centos_ver} != 7
 Recommends: netdata-plugin-apps = %{version}
-Recommends: netdata-plugin-ebpf-code >= %{version}
 %else
 Requires: netdata-plugin-apps = %{version}
-Requires: netdata-plugin-ebpf-code >= %{version}
+%endif
+%if 0%{?centos_ver} > 8 || 0%{?fedora} >= 35 || 0%{?suse_version} >= 1500
+Suggests: netdata-ebpf-legacy-code >= %{version}
+%else
+Requires: netdata-ebpf-legacy-code >= %{version}
 %endif
 
 %description plugin-ebpf
@@ -635,14 +641,17 @@ Requires: netdata-plugin-ebpf-code >= %{version}
 %{_libdir}/%{name}/conf.d/ebpf.d.conf
 %{_libdir}/%{name}/conf.d/ebpf.d
 
-%package plugin-ebpf-code
-Summary: Compiled eBPF code for the Netdata eBPF plugin
+%package ebpf-legacy-code
+Summary: Compiled eBPF legacy code for the Netdata eBPF plugin
 Group: Applications/System
+Requires: netdata-plugin-ebpf = %{version}
+Conflicts: netdata <= %{version}
 
-%description plugin-ebpf-code
- This package provides the pre-compiled eBPF code for use by the Netdata eBPF plugin.
+%description ebpf-legacy-code
+ This package provides the pre-compiled eBPF legacy code for use by the Netdata eBPF plugin.
+This code is only needed when using the eBPF plugin with kernel versions before 5.10.
 
-%files plugin-ebpf-code
+%files ebpf-legacy-code
 %defattr(0640,root,netdata,0640)
 %{_libexecdir}/%{name}/plugins.d/ebpf.d/*.o
 
@@ -652,6 +661,7 @@ Group: Applications/System
 Summary: The python.d metrics collection plugin for the Netdata Agent
 Group: Applications/System
 Requires: netdata = %{version}
+Conflicts: netdata <= %{version}
 %if 0%{?centos_ver} == 7 || 0%{?centos_ver} == 6
 Requires: python
 %else
@@ -682,6 +692,7 @@ want to use those versions instead of the Python versions.
 Summary: The go.d metrics collection plugin for the Netdata Agent
 Group: Applications/System
 Requires: netdata = %{version}
+Conflicts: netdata <= %{version}
 %if 0%{?centos_ver} != 7
 Suggests: nvme-cli
 Suggests: sudo
@@ -705,6 +716,7 @@ so most users will want it installed.
 Summary: The per-application metrics collection plugin for the Netdata Agent
 Group: Applications/System
 Requires: netdata = %{version}
+Conflicts: netdata <= %{version}
 
 %description plugin-apps
  This plugin allows the Netdata Agent to collect per-application and per-user metrics without using cgroups.
@@ -720,6 +732,7 @@ Requires: netdata = %{version}
 Summary: The slabinfo metrics collector for the Netdata Agent
 Group: Applications/System
 Requires: netdata = %{version}
+Conflicts: netdata <= %{version}
 
 %description plugin-slabinfo
  This plugin allows the Netdata Agent to collect perfromance and utilization metrics for the Linux kernel’s SLAB allocator.
@@ -733,6 +746,7 @@ Requires: netdata = %{version}
 Summary: The perf metrics collector for the Netdata Agent
 Group: Applications/System
 Requires: netdata = %{version}
+Conflicts: netdata <= %{version}
 
 %description plugin-perf
  This plugin allows the Netdata to collect metrics from the Linux perf subsystem.

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -705,6 +705,7 @@ want to use those versions instead of the Python versions.
 %package plugin-go
 Summary: The go.d metrics collection plugin for the Netdata Agent
 Group: Applications/System
+Requires: netdata = %{version}
 
 %description plugin-go
  This plugin adds a selection of additional collectors written in Go to the Netdata Agent
@@ -723,6 +724,7 @@ so most users will want it installed.
 %package plugin-apps
 Summary: The per-application metrics collection plugin for the Netdata Agent
 Group: Applications/System
+Requires: netdata = %{version}
 
 %description plugin-apps
  This plugin allows the Netdata Agent to collect per-application and per-user metrics without using cgroups.

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -536,9 +536,6 @@ rm -rf "${RPM_BUILD_ROOT}"
 # debugfs plugin
 %caps(cap_dac_read_search=ep) %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/debugfs.plugin
 
-# slabinfo plugin
-%caps(cap_dac_read_search=ep) %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/slabinfo.plugin
-
 # Enforce 0644 for files and 0755 for directories
 # for the netdata web directory
 %defattr(0644,root,root,0755)
@@ -591,6 +588,9 @@ rm -rf "${RPM_BUILD_ROOT}"
 # apps belongs to a different sub-package
 %exclude %{_libexecdir}/%{name}/plugins.d/apps.plugin
 %exclude %{_libdir}/%{name}/conf.d/apps_groups.conf
+
+# slabinfo belongs to a different sub-package
+%exclude %{_libexecdir}/%{name}/plugins.d/slabinfo.plugin
 
 # CUPS belongs to a different sub package
 %if 0%{?centos_ver} != 6 && 0%{?centos_ver} != 7
@@ -756,6 +756,19 @@ Requires: netdata = %{version}
 %caps(cap_dac_read_search,cap_sys_ptrace=ep) %{_libexecdir}/%{name}/plugins.d/apps.plugin
 %defattr(0644,root,netdata,0644)
 %{_libdir}/%{name}/conf.d/apps_groups.conf
+
+%package plugin-slabinfo
+Summary: The slabinfo metrics collector for the Netdata Agent
+Group: Applications/System
+Requires: netdata = %{version}
+
+%description plugin-slabinfo
+ This plugin allows the Netdata Agent to collect perfromance and utilization metrics for the Linux kernel’s SLAB allocator.
+
+%files plugin-slabinfo
+%defattr(0750,root,netdata,0750)
+# CAP_DAC_READ_SEARCH needed to access the files the plugin reads to collect data.
+%caps(cap_dac_read_search=ep) %{_libexecdir}/%{name}/plugins.d/slabinfo.plugin
 
 %changelog
 * Fri Apr 07 2023 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-19

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -644,7 +644,7 @@ Group: Applications/System
 
 %files plugin-ebpf-code
 %defattr(0640,root,netdata,0640)
-%{_libexecdir}/%{name}/plugins.d/ebpf.d
+%{_libexecdir}/%{name}/plugins.d/ebpf.d/*.o
 
 %endif
 

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -160,6 +160,7 @@ Requires(pre): /usr/sbin/useradd
 %if 0%{?_have_ebpf}
 Recommends: netdata-plugin-ebpf
 %endif
+Recommends: netdata-plugin-pythond
 %endif
 
 # #####################################################################
@@ -491,10 +492,8 @@ rm -rf "${RPM_BUILD_ROOT}"
 
 %defattr(0750,root,netdata,0750)
 
-%dir %{_libexecdir}/%{name}/python.d
 %dir %{_libexecdir}/%{name}/plugins.d
 
-%{_libexecdir}/%{name}/python.d
 %{_libexecdir}/%{name}/plugins.d
 
 %caps(cap_dac_read_search,cap_sys_ptrace=ep) %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/apps.plugin
@@ -563,6 +562,12 @@ rm -rf "${RPM_BUILD_ROOT}"
 %exclude %{_libdir}/%{name}/conf.d/ebpf.d
 %exclude %{_libexecdir}/%{name}/plugins.d/ebpf.d
 %endif
+
+# Python.d belongs to a different sub-package
+%exclude %{_libexecdir}/%{name}/plugins.d/python.d.plugin
+%exclude %{_libexecdir}/%{name}/python.d
+%exclude %{_libdir}/%{name}/conf.d/python.d.conf
+%exclude %{_libdir}/%{name}/conf.d/python.d
 
 # CUPS belongs to a different sub package
 %if 0%{?centos_ver} != 6 && 0%{?centos_ver} != 7
@@ -666,6 +671,33 @@ Group: Applications/System
 %{_libexecdir}/%{name}/plugins.d/ebpf.d
 
 %endif
+
+%package plugin-pythond
+Summary: The python.d metrics collection plugin for the Netdata Agent
+Group: Applications/System
+%if 0%{?centos_ver} == 7 || 0%{?centos_ver} == 6
+Requires: python
+%else
+%if 0%{?centos_ver} == 8
+Requires: python38
+%else
+Requires: python3
+%endif
+%endif
+Requires: netdata = %{version}
+
+%description plugin-pythond
+ This plugin adds a selection of additional collectors written in Python to the Netdata Agent.
+Many of the collectors provided by this package are also available in netdata-plugin-god. In msot cases, you probably
+want to use those versions instead of the Python versions.
+
+%files plugin-pythond
+%defattr(0750,root,netdata,0750)
+%{_libexecdir}/%{name}/plugins.d/python.d.plugin
+%{_libexecdir}/%{name}/python.d
+%defattr(0640,root,netdata,0640)
+%{_libdir}/%{name}/conf.d/python.d.conf
+%{_libdir}/%{name}/conf.d/python.d
 
 %changelog
 * Fri Apr 07 2023 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-19

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -537,14 +537,13 @@ rm -rf "${RPM_BUILD_ROOT}"
 %exclude %{_libexecdir}/%{name}/plugins.d/cups.plugin
 
 %package plugin-cups
-Summary: The Common Unix Printing System plugin for netdata
+Summary: The CUPS metrics collection plugin for the Netdata Agent
 Group: Applications/System
 Requires: cups >= 1.7
 Requires: netdata = %{version}
 
 %description plugin-cups
- This is the Common Unix Printing System plugin for the netdata daemon.
-Use this plugin to enable metrics collection from cupsd, the daemon running when CUPS is enabled on the system
+ This plugin allows the Netdata Agent to collect metrics from the Common UNIX Printing System.
 
 %files plugin-cups
 %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/cups.plugin
@@ -552,15 +551,13 @@ Use this plugin to enable metrics collection from cupsd, the daemon running when
 
 %if %{_have_freeipmi}
 %package plugin-freeipmi
-Summary: FreeIPMI - The Intelligent Platform Management System
+Summary: The FreeIPMI metrics collection plugin for the Netdata Agent
 Group: Applications/System
 Requires: freeipmi
 Requires: netdata = %{version}
 
 %description plugin-freeipmi
- The IPMI specification defines a set of interfaces for platform management.
-It is implemented by a number vendors for system management. The features of IPMI that most users will be interested in
-are sensor monitoring, system event monitoring, power control, and serial-over-LAN (SOL).
+ This plugin allows the Netdata Agent to collect metrics from hardware using FreeIPMI.
 
 %files plugin-freeipmi
 %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -161,6 +161,7 @@ Requires(pre): /usr/sbin/useradd
 Recommends: netdata-plugin-ebpf
 %endif
 Recommends: netdata-plugin-pythond
+Recommends: netdata-plugin-go
 %endif
 
 # #####################################################################
@@ -522,9 +523,6 @@ rm -rf "${RPM_BUILD_ROOT}"
 # slabinfo plugin
 %caps(cap_dac_read_search=ep) %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/slabinfo.plugin
 
-# go.d.plugin (the capability required for wireguard module)
-%caps(cap_net_admin,cap_net_raw=eip) %{_libexecdir}/%{name}/plugins.d/go.d.plugin
-
 # Enforce 0644 for files and 0755 for directories
 # for the netdata web directory
 %defattr(0644,root,root,0755)
@@ -568,6 +566,11 @@ rm -rf "${RPM_BUILD_ROOT}"
 %exclude %{_libexecdir}/%{name}/python.d
 %exclude %{_libdir}/%{name}/conf.d/python.d.conf
 %exclude %{_libdir}/%{name}/conf.d/python.d
+
+# Go.d belongs to a different sub-package
+%exclude %{_libexecdir}/%{name}/plugins.d/go.d.plugin
+%exclude %{_libdir}/%{name}/conf.d/go.d.conf
+%exclude %{_libdir}/%{name}/conf.d/go.d
 
 # CUPS belongs to a different sub package
 %if 0%{?centos_ver} != 6 && 0%{?centos_ver} != 7
@@ -698,6 +701,24 @@ want to use those versions instead of the Python versions.
 %defattr(0640,root,netdata,0640)
 %{_libdir}/%{name}/conf.d/python.d.conf
 %{_libdir}/%{name}/conf.d/python.d
+
+%package plugin-go
+Summary: The go.d metrics collection plugin for the Netdata Agent
+Group: Applications/System
+
+%description plugin-go
+ This plugin adds a selection of additional collectors written in Go to the Netdata Agent
+A significant percentage of the application specific collectors provided by Netdata are part of this plugin,
+so most users will want it installed.
+
+%files plugin-go
+%defattr(0750,root,netdata,0750)
+# CAP_NET_ADMIN needed for WireGuard collector
+# CAP_NET_RAW needed for ping collector
+%caps(cap_net_admin,cap_net_raw=eip) %{_libexecdir}/%{name}/plugins.d/go.d.plugin
+%defattr(0644,root,netdata,0644)
+%{_libdir}/%{name}/conf.d/go.d.conf
+%{_libdir}/%{name}/conf.d/go.d
 
 %changelog
 * Fri Apr 07 2023 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-19

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -532,6 +532,11 @@ rm -rf "${RPM_BUILD_ROOT}"
 %exclude %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin
 %endif
 
+# NFACCT belongs to a different sub-package
+%if 0%{!?ol8} && 0%{!?ol9} && 0%{?centos_ver} != 7
+%exclude %{_libexecdir}/%{name}/plugins.d/nfacct.plugin
+%endif
+
 # CUPS belongs to a different sub package
 %if 0%{?centos_ver} != 6 && 0%{?centos_ver} != 7
 %exclude %{_libexecdir}/%{name}/plugins.d/cups.plugin
@@ -563,13 +568,32 @@ Requires: netdata = %{version}
 %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin
 %endif
 
+%if 0%{!?ol8} && 0%{!?ol9} && 0%{?centos_ver} != 7
+%package plugin-nfacct
+Summary: The NFACCT metrics collection plugin for the Netdata Agent
+Group: Applications/System
+Requires: libmnl
+%if 0%{?fedora} || 0%{?suse_version} >= 1140
+Requires: libnetfilter_acct
+%endif
+Requires: netdata = %{version}
+
+%description plugin-nfacct
+ This plugin allows the Netdata Agent to collect metrics from the firewall using NFACCT objects.
+
+%files plugin-nfacct
+%attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/nfacct.plugin
+%endif
+
 %changelog
+* Fri Apr 07 2023 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-19
+- Split additional plugins out in their own packages.
 * Tue Mar 21 2023 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-18
 - Fix systemd handling to follow BCP.
 - Drop pre-systemd init support.
 * Thu Feb 16 2023 Konstantin Shalygin <k0ste@k0ste.ru> 0.0.0-17
 - Added eBPF build dependency
-* Fri Feb 03 2022 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-16
+* Wed Feb 03 2022 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-16
 - Bundle updater script in native packages.
 * Mon Oct 11 2021 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-15
 - Remove support code for legacy ACLK implementation.

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -802,9 +802,14 @@ Conflicts: netdata <= %{version}
 %endif
 
 %changelog
-* Tue Nov 01 2022 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-17
+* Fri Apr 07 2023 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-19
 - Split additional plugins out in their own packages.
-* Wed Feb 03 2022 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-16
+* Tue Mar 21 2023 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-18
+- Fix systemd handling to follow BCP.
+- Drop pre-systemd init support.
+* Thu Feb 16 2023 Konstantin Shalygin <k0ste@k0ste.ru> 0.0.0-17
+- Added eBPF build dependency
+* Fri Feb 03 2022 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-16
 - Bundle updater script in native packages.
 * Mon Oct 11 2021 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-15
 - Remove support code for legacy ACLK implementation.

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -622,12 +622,9 @@ Requires: netdata = %{version}
 Conflicts: netdata <= %{version}
 %if 0%{?centos_ver} != 7
 Recommends: netdata-plugin-apps = %{version}
+Recommends: netdata-ebpf-legacy-code >= %{version}
 %else
 Requires: netdata-plugin-apps = %{version}
-%endif
-%if 0%{?centos_ver} > 8 || 0%{?fedora} >= 35 || 0%{?suse_version} >= 1500
-Suggests: netdata-ebpf-legacy-code >= %{version}
-%else
 Requires: netdata-ebpf-legacy-code >= %{version}
 %endif
 

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -54,15 +54,6 @@ AutoReqProv: yes
 # Redefine centos_ver to standardize on a single macro
 %{?rhel:%global centos_ver %rhel}
 
-#
-# Conditional build:
-%bcond_without  netns    # build with netns support (cgroup-network)
-
-%if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1140
-%else
-%undefine	with_netns
-%endif
-
 Summary:	Real-time performance monitoring, done right!
 Name:		netdata
 Version:	%{version}
@@ -503,10 +494,12 @@ rm -rf "${RPM_BUILD_ROOT}"
 %{_libexecdir}/%{name}/netdata-updater.sh
 %{_libexecdir}/%{name}/netdata-uninstaller.sh
 %{_libexecdir}/%{name}/plugins.d/acl.sh
+%{_libexecdir}/%{name}/plugins.d/alarm.sh
 %{_libexecdir}/%{name}/plugins.d/alarm-email.sh
 %{_libexecdir}/%{name}/plugins.d/alarm-notify.sh
 %{_libexecdir}/%{name}/plugins.d/alarm-test.sh
 %{_libexecdir}/%{name}/plugins.d/anonymous-statistics.sh
+%{_libexecdir}/%{name}/plugins.d/cgroup-name.sh
 %{_libexecdir}/%{name}/plugins.d/get-kubernetes-labels.sh
 %{_libexecdir}/%{name}/plugins.d/health-cmdapi-test.sh
 %{_libexecdir}/%{name}/plugins.d/ioping.plugin
@@ -515,13 +508,11 @@ rm -rf "${RPM_BUILD_ROOT}"
 %{_libexecdir}/%{name}/plugins.d/tc-qos-helper.sh
 %{_libexecdir}/%{name}/plugins.d/template_dim.sh
 
-%if %{with netns}
 # cgroup-network detects the network interfaces of CGROUPs
 # it must be able to use setns() and run cgroup-network-helper.sh as root
 # the helper script reads /proc/PID/fdinfo/* files, runs virsh, etc.
 %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/cgroup-network
 %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/cgroup-network-helper.sh
-%endif
 
 # ebpf plugin
 %if 0%{?_have_ebpf}

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -160,6 +160,7 @@ Requires(pre): /usr/sbin/useradd
 %if 0%{?_have_ebpf}
 Recommends: netdata-plugin-ebpf
 %endif
+Recommends: netdata-plugin-apps
 Recommends: netdata-plugin-pythond
 Recommends: netdata-plugin-go
 %endif
@@ -497,7 +498,6 @@ rm -rf "${RPM_BUILD_ROOT}"
 
 %{_libexecdir}/%{name}/plugins.d
 
-%caps(cap_dac_read_search,cap_sys_ptrace=ep) %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/apps.plugin
 
 %if %{with netns}
 # cgroup-network detects the network interfaces of CGROUPs
@@ -571,6 +571,10 @@ rm -rf "${RPM_BUILD_ROOT}"
 %exclude %{_libexecdir}/%{name}/plugins.d/go.d.plugin
 %exclude %{_libdir}/%{name}/conf.d/go.d.conf
 %exclude %{_libdir}/%{name}/conf.d/go.d
+
+# apps belongs to a different sub-package
+%exclude %{_libexecdir}/%{name}/plugins.d/apps.plugin
+%exclude %{_libdir}/%{name}/conf.d/apps_groups.conf
 
 # CUPS belongs to a different sub package
 %if 0%{?centos_ver} != 6 && 0%{?centos_ver} != 7
@@ -650,6 +654,7 @@ It includes collectors for NUT, APCUPSD, LibreSWAN, OpenSIPS, and Wireless acces
 Summary: The eBPF metrics collection plugin for the Netdata Agent
 Group: Applications/System
 Requires: netdata = %{version}
+Requires: netdata-plugin-apps = %{version}
 Requires: netdata-plugin-ebpf-code >= %{version}
 
 %description plugin-ebpf
@@ -719,6 +724,20 @@ so most users will want it installed.
 %defattr(0644,root,netdata,0644)
 %{_libdir}/%{name}/conf.d/go.d.conf
 %{_libdir}/%{name}/conf.d/go.d
+
+%package plugin-apps
+Summary: The per-application metrics collection plugin for the Netdata Agent
+Group: Applications/System
+
+%description plugin-apps
+ This plugin allows the Netdata Agent to collect per-application and per-user metrics without using cgroups.
+
+%files plugin-apps
+%defattr(0750,root,netdata,0750)
+# CAP_DAC_READ_SEARCH and CAP_SYS_PTRACE needed for data collection by the plugin.
+%caps(cap_dac_read_search,cap_sys_ptrace=ep) %{_libexecdir}/%{name}/plugins.d/apps.plugin
+%defattr(0644,root,netdata,0644)
+%{_libdir}/%{name}/conf.d/apps_groups.conf
 
 %changelog
 * Fri Apr 07 2023 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-19

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -154,10 +154,10 @@ Recommends: netdata-plugin-ebpf
 Recommends: netdata-plugin-apps
 Recommends: netdata-plugin-pythond
 Recommends: netdata-plugin-go
-%if %{_have_freeipmi}
+%if 0%{?_have_freeipmi}
 Suggests:   netdata-plugin-freeipmi
 %endif
-%if %{_have_nfacct}
+%if 0%{?_have_nfacct}
 Suggests:   netdata-plugin-nfacct
 %endif
 Suggests:   netdata-plugin-cups
@@ -182,7 +182,7 @@ BuildRequires:  libnetfilter_acct-devel
 # end nfacct plugin dependencies
 
 # freeipmi plugin dependencies
-%if %{_have_freeipmi}
+%if 0%{?_have_freeipmi}
 BuildRequires:  freeipmi-devel
 %endif
 # end - freeipmi plugin dependencies
@@ -284,7 +284,7 @@ install -m 644 -p system/logrotate/netdata "${RPM_BUILD_ROOT}%{_sysconfdir}/logr
 
 # ###########################################################
 # Install freeipmi
-%if %{_have_freeipmi}
+%if 0%{?_have_freeipmi}
 install -m 4750 -p freeipmi.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/freeipmi.plugin"
 %endif
 
@@ -537,7 +537,7 @@ rm -rf "${RPM_BUILD_ROOT}"
 %attr(0770,netdata,netdata) %dir %{_localstatedir}/lib/%{name}/registry
 
 # Free IPMI belongs to a different sub-package
-%if %{_have_freeipmi}
+%if 0%{?_have_freeipmi}
 %exclude %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin
 %endif
 
@@ -599,7 +599,7 @@ Requires: netdata = %{version}
 %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/cups.plugin
 %endif
 
-%if %{_have_freeipmi}
+%if 0%{?_have_freeipmi}
 %package plugin-freeipmi
 Summary: The FreeIPMI metrics collection plugin for the Netdata Agent
 Group: Applications/System

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -40,8 +40,8 @@ AutoReqProv: yes
 # Redefine centos_ver to standardize on a single macro
 %{?rhel:%global centos_ver %rhel}
 
-# Disable FreeIPMI on Amazon Linux
-%if 0%{?amzn}
+# Disable FreeIPMI on Amazon Linux 2023 and newer
+%if 0%{?amzn} >= 2023
 %global _have_freeipmi 0
 %else
 %global _have_freeipmi 1

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -618,7 +618,11 @@ Summary: The eBPF metrics collection plugin for the Netdata Agent
 Group: Applications/System
 Requires: netdata = %{version}
 Requires: netdata-plugin-apps = %{version}
+%if 0%{?centos_ver} != 7
+Recommends: netdata-plugin-ebpf-code >= %{version}
+%else
 Requires: netdata-plugin-ebpf-code >= %{version}
+%endif
 
 %description plugin-ebpf
  This plugin allows the Netdata Agent to use eBPF code to collect more detailed kernel-level metrics for the system.
@@ -646,6 +650,7 @@ Group: Applications/System
 %package plugin-pythond
 Summary: The python.d metrics collection plugin for the Netdata Agent
 Group: Applications/System
+Requires: netdata = %{version}
 %if 0%{?centos_ver} == 7 || 0%{?centos_ver} == 6
 Requires: python
 %else
@@ -655,11 +660,13 @@ Requires: python38
 Requires: python3
 %endif
 %endif
-Requires: netdata = %{version}
+%if 0%{?centos_ver} != 7
+Suggests: sudo
+%endif
 
 %description plugin-pythond
  This plugin adds a selection of additional collectors written in Python to the Netdata Agent.
-Many of the collectors provided by this package are also available in netdata-plugin-god. In msot cases, you probably
+Many of the collectors provided by this package are also available in netdata-plugin-go. In msot cases, you probably
 want to use those versions instead of the Python versions.
 
 %files plugin-pythond
@@ -674,6 +681,10 @@ want to use those versions instead of the Python versions.
 Summary: The go.d metrics collection plugin for the Netdata Agent
 Group: Applications/System
 Requires: netdata = %{version}
+%if 0%{?centos_ver} != 7
+Suggests: nvme-cli
+Suggests: sudo
+%endif
 
 %description plugin-go
  This plugin adds a selection of additional collectors written in Go to the Netdata Agent

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -617,10 +617,11 @@ It includes collectors for NUT, APCUPSD, LibreSWAN, OpenSIPS, and Wireless acces
 Summary: The eBPF metrics collection plugin for the Netdata Agent
 Group: Applications/System
 Requires: netdata = %{version}
-Requires: netdata-plugin-apps = %{version}
 %if 0%{?centos_ver} != 7
+Recommends: netdata-plugin-apps = %{version}
 Recommends: netdata-plugin-ebpf-code >= %{version}
 %else
+Requires: netdata-plugin-apps = %{version}
 Requires: netdata-plugin-ebpf-code >= %{version}
 %endif
 

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -27,20 +27,6 @@ AutoReqProv: yes
 %global _have_ebpf 0
 %endif
 
-# Disable FreeIPMI on Amazon Linux
-%if 0%{?amzn}
-%global _have_freeipmi 0
-%else
-%global _have_freeipmi 1
-%endif
-
-# Disable the NFACCT plugin on Amazon Linux
-%if 0%{?amzn}
-%global _have_nfacct 0
-%else
-%global _have_nfacct 1
-%endif
-
 # Mitigate the cross-distro mayhem by strictly defining the libexec destination
 %define _prefix /usr
 %define _sysconfdir /etc
@@ -48,11 +34,15 @@ AutoReqProv: yes
 %define _libexecdir /usr/libexec
 %define _libdir /usr/lib
 
-# Fedora doesn’t define this, but other distros do
-%{!?_presetdir:%global _presetdir %{_libdir}/systemd/system-preset}
-
 # Redefine centos_ver to standardize on a single macro
 %{?rhel:%global centos_ver %rhel}
+
+# Disable NFACCT for RHEL equivalents
+%if 0%{?centos_ver}
+%global _have_nfacct 0
+%else
+%global _have_nfacct 1
+%endif
 
 Summary:	Real-time performance monitoring, done right!
 Name:		netdata
@@ -80,7 +70,7 @@ BuildRequires: git-core
 BuildRequires: autoconf
 %if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1140
 BuildRequires: autoconf-archive
-%if 0%{?rhel} <= 8 && 0%{?amzn} < 2023
+%if 0%{?rhel} <= 8
 BuildRequires: autogen
 %endif
 %endif
@@ -98,14 +88,12 @@ BuildRequires: protobuf-devel
 BuildRequires: libprotobuf-c-devel
 BuildRequires: liblz4-devel
 BuildRequires: libjson-c-devel
-BuildRequires: libyaml-devel
 %else
 %if 0%{?fedora}
 BuildRequires: protobuf-devel
 BuildRequires: protobuf-c-devel
 BuildRequires: lz4-devel
 BuildRequires: json-c-devel
-BuildRequires: libyaml-devel
 %else
 %if 0%{?centos_ver} >= 8
 BuildRequires: protobuf-devel
@@ -113,16 +101,11 @@ BuildRequires: protobuf-c-devel
 %endif
 BuildRequires: lz4-devel
 BuildRequires: json-c-devel
-BuildRequires: libyaml-devel
 %endif
 %endif
 
 # Core build requirements for service install
-%if 0%{?suse_version}
-BuildRequires: systemd-rpm-macros
-%else
-BuildRequires: systemd
-%endif
+%{netdata_initd_buildrequires}
 
 # Runtime dependencies
 #
@@ -139,6 +122,8 @@ Requires: python3
 # Core requirements for the install to succeed
 Requires(pre): /usr/sbin/groupadd
 Requires(pre): /usr/sbin/useradd
+
+%{netdata_initd_requires}
 
 # #####################################################################
 # External plugin package dependencies
@@ -162,30 +147,17 @@ Recommends: netdata-plugin-go
 # Note: Some or all of the Packages may be found in the EPEL repo,
 # rather than the standard ones
 
-# epbf dependencies
-%if 0%{?_have_ebpf}
-%if 0%{?suse_version}
-BuildRequires:	libelf-devel
-%else
-BuildRequires:	elfutils-libelf-devel
-%endif
-%endif
-# end - ebpf dependencies
-
 # nfacct plugin dependencies
-%if %{_have_nfacct}
+
+%if 0%{?_have_nfacct}
 BuildRequires:  libmnl-devel
-%if 0%{?fedora} || 0%{?suse_version} >= 1140
 BuildRequires:  libnetfilter_acct-devel
-%endif
 %endif
 
 # end nfacct plugin dependencies
 
 # freeipmi plugin dependencies
-%if %{_have_freeipmi}
 BuildRequires:  freeipmi-devel
-%endif
 # end - freeipmi plugin dependencies
 
 # CUPS plugin dependencies
@@ -279,9 +251,7 @@ install -m 644 -p system/logrotate/netdata "${RPM_BUILD_ROOT}%{_sysconfdir}/logr
 
 # ###########################################################
 # Install freeipmi
-%if %{_have_freeipmi}
 install -m 4750 -p freeipmi.plugin "${RPM_BUILD_ROOT}%{_libexecdir}/%{name}/plugins.d/freeipmi.plugin"
-%endif
 
 # ###########################################################
 # Install apps.plugin
@@ -327,10 +297,15 @@ install -m 750 -p packaging/installer/netdata-uninstaller.sh \
 
 # ###########################################################
 # Install netdata service
+%if %{with systemd}
 install -m 755 -d "${RPM_BUILD_ROOT}%{_unitdir}"
 install -m 644 -p system/systemd/netdata.service "${RPM_BUILD_ROOT}%{_unitdir}/netdata.service"
-install -m 755 -d "${RPM_BUILD_ROOT}%{_presetdir}"
-install -m 644 -p system/systemd/50-netdata.preset "${RPM_BUILD_ROOT}%{_presetdir}/50-netdata.preset"
+%else
+# install SYSV init stuff
+install -d "${RPM_BUILD_ROOT}/etc/rc.d/init.d"
+install -m 755 system/initd/init.d/netdata \
+        "${RPM_BUILD_ROOT}/etc/rc.d/init.d/netdata"
+%endif
 
 # ############################################################
 # Package Go within netdata (TBD: Package it separately)
@@ -448,25 +423,13 @@ for item in docker nginx varnish haproxy adm nsd proxy squid ceph nobody I2C; do
 done
 
 %post
-%if 0%{?suse_version}
-%service_add_post netdata.service
-%else
-%systemd_post netdata.service
-%endif
+%{netdata_init_post}
 
 %preun
-%if 0%{?suse_version}
-%service_del_preun netdata.service
-%else
-%systemd_preun netdata.service
-%endif
+%{netdata_init_preun}
 
 %postun
-%if 0%{?suse_version}
-%service_del_postun netdata.service
-%else
-%systemd_postun_with_restart netdata.service
-%endif
+%{netdata_init_postun}
 
 %clean
 rm -rf "${RPM_BUILD_ROOT}"
@@ -484,8 +447,11 @@ rm -rf "${RPM_BUILD_ROOT}"
 %{_sbindir}/netdatacli
 %{_sbindir}/netdata-claim.sh
 
+%if %{with systemd}
 %{_unitdir}/netdata.service
-%{_presetdir}/50-netdata.preset
+%else
+%{_sysconfdir}/rc.d/init.d/netdata
+%endif
 
 %dir %{_libexecdir}/%{name}
 %dir %{_libexecdir}/%{name}/plugins.d
@@ -542,12 +508,12 @@ rm -rf "${RPM_BUILD_ROOT}"
 %attr(0770,netdata,netdata) %dir %{_localstatedir}/lib/%{name}/registry
 
 # Free IPMI belongs to a different sub-package
-%if %{_have_freeipmi}
 %exclude %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin
-%endif
 
 # NFACCT belongs to a different sub-package
+%if 0%{?_have_nfacct}
 %exclude %{_libexecdir}/%{name}/plugins.d/nfacct.plugin
+%endif
 
 # Charts.d belongs to a different sub-package
 %exclude %{_libexecdir}/%{name}/plugins.d/charts.d.plugin
@@ -599,7 +565,6 @@ Requires: netdata = %{version}
 %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/cups.plugin
 %endif
 
-%if %{_have_freeipmi}
 %package plugin-freeipmi
 Summary: The FreeIPMI metrics collection plugin for the Netdata Agent
 Group: Applications/System
@@ -611,8 +576,8 @@ Requires: netdata = %{version}
 
 %files plugin-freeipmi
 %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/freeipmi.plugin
-%endif
 
+%if 0%{?_have_nfacct}
 %package plugin-nfacct
 Summary: The NFACCT metrics collection plugin for the Netdata Agent
 Group: Applications/System
@@ -627,6 +592,7 @@ Requires: netdata = %{version}
 
 %files plugin-nfacct
 %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/nfacct.plugin
+%endif
 
 %package plugin-chartsd
 Summary: The charts.d metrics collection plugin for the Netdata Agent
@@ -759,13 +725,8 @@ Requires: netdata = %{version}
 %caps(cap_dac_read_search=ep) %{_libexecdir}/%{name}/plugins.d/slabinfo.plugin
 
 %changelog
-* Fri Apr 07 2023 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-19
+* Tue Nov 01 2022 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-17
 - Split additional plugins out in their own packages.
-* Tue Mar 21 2023 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-18
-- Fix systemd handling to follow BCP.
-- Drop pre-systemd init support.
-* Thu Feb 16 2023 Konstantin Shalygin <k0ste@k0ste.ru> 0.0.0-17
-- Added eBPF build dependency
 * Wed Feb 03 2022 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-16
 - Bundle updater script in native packages.
 * Mon Oct 11 2021 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-15
@@ -803,8 +764,9 @@ First draft refactor on package dependencies section
 * Wed Jan 02 2019 Pawel Krupa <pkrupa@redhat.com> - 0.0.0-3
 - Temporary set version statically
 - Fix changelog ordering
-- Comment-out node.d configuration directory
+- Comment-out node.d configuration directory 
 * Wed Jan 02 2019 Pawel Krupa <pkrupa@redhat.com> - 0.0.0-2
 - Fix permissions for log files
 * Sun Nov 15 2015 Alon Bar-Lev <alonbl@redhat.com> - 0.0.0-1
 - Initial add.
+

--- a/packaging/bundle-ebpf.sh
+++ b/packaging/bundle-ebpf.sh
@@ -15,5 +15,5 @@ if [ -x "${PLUGINDIR}/ebpf.plugin" ] ; then
         mkdir "${PLUGINDIR}/ebpf.d"
     fi
     # shellcheck disable=SC2046
-    cp -a $(find "${SRCDIR}/tmp/ebpf" -mindepth 1 -maxdepth 1) "${PLUGINDIR}/ebpf.d"
+    cp -r $(find "${SRCDIR}/tmp/ebpf" -mindepth 1 -maxdepth 1) "${PLUGINDIR}/ebpf.d"
 fi

--- a/packaging/bundle-libbpf.sh
+++ b/packaging/bundle-libbpf.sh
@@ -22,6 +22,6 @@ curl -sSL --connect-timeout 10 --retry 3 "https://github.com/netdata/libbpf/arch
 sha256sum -c "${1}/packaging/libbpf.checksums" || exit 1
 tar -xzf "${LIBBPF_TARBALL}" -C "${1}/externaldeps/libbpf" || exit 1
 make -C "${LIBBPF_BUILD_PATH}/src" BUILD_STATIC_ONLY=1 OBJDIR=build/ DESTDIR=../ install || exit 1
-cp -a "${LIBBPF_BUILD_PATH}/usr/${lib_subdir}/libbpf.a" "${1}/externaldeps/libbpf" || exit 1
-cp -a "${LIBBPF_BUILD_PATH}/usr/include" "${1}/externaldeps/libbpf" || exit 1
-cp -a "${LIBBPF_BUILD_PATH}/include/uapi" "${1}/externaldeps/libbpf/include" || exit 1
+cp -r "${LIBBPF_BUILD_PATH}/usr/${lib_subdir}/libbpf.a" "${1}/externaldeps/libbpf" || exit 1
+cp -r "${LIBBPF_BUILD_PATH}/usr/include" "${1}/externaldeps/libbpf" || exit 1
+cp -r "${LIBBPF_BUILD_PATH}/include/uapi" "${1}/externaldeps/libbpf/include" || exit 1

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1543,7 +1543,7 @@ try_package_install() {
   if [ -n "${explicitly_install_native_plugins}" ]; then
     progress "Installing external plugins."
     # shellcheck disable=SC2086
-    if ! run_as_root env ${env} ${pm_cmd} install ${DEFAULT_PLUGIN_PKGS}; then
+    if ! run_as_root env ${env} ${pm_cmd} install ${DEFAULT_PLUGIN_PACKAGES}; then
       warning "Failed to install external plugin packages. Some collectors may not be available."
     fi
   fi

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -26,6 +26,7 @@ KICKSTART_SOURCE="$(
     echo "$(pwd -P)/${self##*/}"
 )"
 PACKAGES_SCRIPT="https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh"
+DEFAULT_PLUGIN_PACKAGES="netdata-plugin-go netdata-plugin-python netdata-plugin-apps netdata-plugin-ebpf"
 PATH="${PATH}:/usr/local/bin:/usr/local/sbin"
 PUBLIC_CLOUD_URL="https://app.netdata.cloud"
 REPOCONFIG_DEB_URL_PREFIX="https://repo.netdata.cloud/repos/repoconfig"
@@ -1400,6 +1401,9 @@ try_package_install() {
       common_rpm_opts
       common_dnf_opts
       repo_prefix="el/${SYSVERSION}"
+      if [ "${SYSVERSION}" -lt 8 ]; then
+        explicitly_install_native_plugins=1
+      fi
       ;;
     fedora|ol)
       common_rpm_opts
@@ -1534,6 +1538,14 @@ try_package_install() {
       run_as_root env ${env} ${pm_cmd} ${uninstall_subcmd} ${pkg_install_opts} "${repoconfig_name}"
     fi
     return 2
+  fi
+
+  if [ -n "${explicitly_install_native_plugins}" ]; then
+    progress "Installing external plugins."
+    # shellcheck disable=SC2086
+    if ! run_as_root env ${env} ${pm_cmd} install ${DEFAULT_PLUGIN_PKGS}; then
+      warning "Failed to install external plugin packages. Some collectors may not be available."
+    fi
   fi
 }
 


### PR DESCRIPTION
##### Summary

This continues the trend that was started a few years back with the CUPS and IPMI collectors of using separate packages for individual plugins. The following plugins are being split to their own packages in this PR:

- [x] NFACCT
- [x] charts.d
- [x] slabinfo
- [x] perf
- [x] eBPF (as a soft dependency so it gets installed by default)
- [x] eBPF legacy code (packaged separately from the plugin as it is only required on older kernels, listed as a soft dependency of the eBPF plugin so it gets installed by default for DEB packages, and as a required dependency on systems where it’s required for RPM packages)
- [x] python.d (as a soft dependency so it gets installed by default)
- [x] go.d (as a soft dependency so it gets installed by default)
- [x] apps (as a soft dependency so it gets installed by default, this will also be a hard dependency for the ebpf plugin)

Long term, I hope to decouple the packaging of the Go plugin and the eBPF programs from the main agent repository so that those can be updated on their own.

##### Test Plan

Local testing is probably most easily done by [building the packages locally](https://github.com/netdata/netdata/blob/master/packaging/building-native-packages-locally.md).

With this PR, there should be additional packages created for each of the plugins listed above, plus one extra package called `netdata-plugin-ebpf-code`. Oracle Linux, CentOS, and Alma Linux should not include the nfacct plugin, as they do not have the required dependencies available.

Because of how RPM and dpkg handle soft dependencies when installing package files directly (instead of from a repository), metadata inspection will be required to verify the soft dependencies outlined in the description above. RPM package metadata can be inspected by running `rpm -qip` on the package file. DEB package metadata can be inspected by running `dpkg-deb -I` on the package file.

##### Additional Information

Fixes: #7857
Fixes: #7631
Fixes: #6932

This PR has two goals:

- Make life simpler for users who are only using a subset of the plugins we ship by not making them install things they will not use.
- Make life simpler for us by reducing the total amount of data that a user needs to download when they install or update Netdata.

This PR also includes an assortment of cleanups and minor fixes for the existing DEB/RPM packaging code, such as properly splitting out postinst scripts to their dependent packages for the DEB packages, tidying up the file list for the spec file, and formatting package descriptions more consistently.