### PR TITLE
Setup default certificates path

### DIFF
--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -360,14 +360,10 @@ int ssl_security_location_for_context(SSL_CTX *ctx, char *file, char *path) {
     struct stat statbuf;
     if (stat(file, &statbuf)) {
         info("Netdata does not have the parent's SSL certificate, so it will use the default OpenSSL configuration to validate certificates!");
-        return 0;
-    }
-
-    ERR_clear_error();
-    u_long err;
-    char buf[256];
-    if(!SSL_CTX_load_verify_locations(ctx, file, path)) {
-        goto slfc;
+    } else {
+        if(!SSL_CTX_load_verify_locations(ctx, file, path)) {
+            goto slfc;
+        }
     }
 
     if(!SSL_CTX_set_default_verify_paths(ctx)) {
@@ -377,6 +373,9 @@ int ssl_security_location_for_context(SSL_CTX *ctx, char *file, char *path) {
     return 0;
 
 slfc:
+    ERR_clear_error();
+    u_long err;
+    char buf[256];
     while ((err = ERR_get_error()) != 0) {
         ERR_error_string_n(err, buf, sizeof(buf));
         error("Cannot set the directory for the certificates and the parent SSL certificate: %s",buf);

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -357,30 +357,22 @@ int security_test_certificate(SSL *ssl) {
  * @return It returns 0 on success and -1 otherwise.
  */
 int ssl_security_location_for_context(SSL_CTX *ctx, char *file, char *path) {
-    struct stat statbuf;
-    if (stat(file, &statbuf)) {
-        info("Netdata does not have the parent's SSL certificate, so it will use the default OpenSSL configuration to validate certificates!");
-    } else {
+    int load_custom = 1, load_default = 1;
+    if (file || path) {
         if(!SSL_CTX_load_verify_locations(ctx, file, path)) {
-            goto slfc;
+            info("Netdata can not verify custom CAfile or CApath for parent's SSL certificate, so it will use the default OpenSSL configuration to validate certificates!");
+            load_custom = 0;
         }
     }
 
     if(!SSL_CTX_set_default_verify_paths(ctx)) {
-        goto slfc;
+        info("Can not verify default OpenSSL configuration to validate certificates!");
+        load_default = 0;
     }
+
+    if (load_custom  == 0 && load_default == 0)
+        return -1;
 
     return 0;
-
-slfc:
-    ERR_clear_error();
-    u_long err;
-    char buf[256];
-    while ((err = ERR_get_error()) != 0) {
-        ERR_error_string_n(err, buf, sizeof(buf));
-        error("Cannot set the directory for the certificates and the parent SSL certificate: %s",buf);
-    }
-    return -1;
 }
-
 #endif

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -140,8 +140,8 @@ int rrdpush_init() {
         }
     }
 
-    netdata_ssl_ca_path = appconfig_get(&stream_config, CONFIG_SECTION_STREAM, "CApath", "/etc/ssl/certs/");
-    netdata_ssl_ca_file = appconfig_get(&stream_config, CONFIG_SECTION_STREAM, "CAfile", "/etc/ssl/certs/certs.pem");
+    netdata_ssl_ca_path = appconfig_get(&stream_config, CONFIG_SECTION_STREAM, "CApath", NULL);
+    netdata_ssl_ca_file = appconfig_get(&stream_config, CONFIG_SECTION_STREAM, "CAfile", NULL);
 #endif
 
     return default_rrdpush_enabled;

--- a/streaming/stream.conf
+++ b/streaming/stream.conf
@@ -40,17 +40,18 @@
     #ssl skip certificate verification = yes
 
     # Certificate Authority Path
-    # OpenSSL has a default directory where the known certificates are stored,
-    # case it is necessary it is possible to change this rule using the variable
-    # "CApath"
-    #CApath = /etc/ssl/certs/
+    # OpenSSL has a default directory where the known certificates are stored.
+    # In case it is necessary, it is possible to change this rule using the variable
+    # "CApath", e.g. CApath = /etc/ssl/certs/
+    #
+    #CApath =
 
     # Certificate Authority file
-    # When the Netdata parent has certificate, that is not recognized as valid,
-    # we can add this certificate in the list of known certificates in CApath
-    # and give for Netdata as argument.
+    # When the Netdata parent has a certificate that is not recognized as valid,
+    # we can add it to the list of known certificates in "CApath" and give it to
+    # Netdata as an argument, e.g. CAfile = /etc/ssl/certs/cert.pem
     #
-    #CAfile = /etc/ssl/certs/cert.pem
+    #CAfile =
 
     # The API_KEY to use (as the sender)
     api key =


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #13283 

When a parent is using properly signed ssl certificate (e.g. via letsencrypt) the child will try to validate it (if `ssl skip certificate verification` is not set to `yes`).

If we want to validate using the system's OpenSSL default CA certificates, we need to call `SSL_CTX_set_default_verify_paths`. Before this PR though, this happened only if `CAfile` in `stream.conf` actually existed. If it didn't exist (as in my machine `/etc/ssl/certs/certs.pem` which is the default doesn't), the streaming child could not validate the parent's certificate.

The change is to do the call to `SSL_CTX_set_default_verify_paths` irregardless of whether `CAfile` exists or not. If it does, it will be added with `SSL_CTX_load_verify_locations`.

If the user has also specified custom paths (using `CApath` and `CAfile`) they should be added as well to the search path for certificates (according to [this](https://stackoverflow.com/questions/33421002/openssl-and-trusted-system-certifcates) it should work).

With this PR even without setting `CAfile` in the child's `stream.conf`, the certificate is validated.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Needs a parent with a Trusted certificate. I used certbot to create letsencrypt keys. Note that when the keys are created, the parent needs to set in the `[web]` section the path to the keys as follows:

`ssl key = /path/to/letsencrypt/privkey.pem`
`ssl certificate = /path/to/letsencrypt/fullchain.pem`

The files and dirs need to have permissions for the user running netdata to read them.

Use a child with `ssl skip certificate verification = no` and define the destination with `:SSL`. It should connect properly.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
