### PR TITLE
fix chart definition end time_t printing and parsing

### DIFF
--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -273,6 +273,12 @@ PARSER_RC pluginsd_chart_definition_end(char **words, size_t num_words, void *us
         return PARSER_RC_ERROR;
     }
 
+    internal_error(
+               (first_entry_child != 0 || last_entry_child != 0)
+            && (first_entry_child == 0 || last_entry_child == 0),
+            "REPLAY: received " PLUGINSD_KEYWORD_CHART_DEFINITION_END " with malformed timings (first time %llu, last time %llu).",
+            (unsigned long long)first_entry_child, (unsigned long long)last_entry_child);
+
     rrdset_flag_clear(st, RRDSET_FLAG_RECEIVER_REPLICATION_FINISHED);
 
     bool ok = replicate_chart_request(send_to_plugin, user_object->parser, host, st, first_entry_child, last_entry_child, 0, 0);

--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -261,8 +261,16 @@ PARSER_RC pluginsd_chart(char **words, size_t num_words, void *user)
 
 PARSER_RC pluginsd_chart_definition_end(char **words, size_t num_words, void *user)
 {
-    long first_entry_child = str2l(get_word(words, num_words, 1));
-    long last_entry_child = str2l(get_word(words, num_words, 2));
+    const char *first_entry_txt = get_word(words, num_words, 1);
+    const char *last_entry_txt = get_word(words, num_words, 2);
+
+    if(unlikely(!first_entry_txt || !last_entry_txt)) {
+        error("REPLAY: received " PLUGINSD_KEYWORD_CHART_DEFINITION_END " command without first or last entry. Disabling it.");
+        return PARSER_RC_ERROR;
+    }
+
+    long first_entry_child = str2l(first_entry_txt);
+    long last_entry_child = str2l(last_entry_txt);
 
     PARSER_USER_OBJECT *user_object = (PARSER_USER_OBJECT *) user;
 

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -170,6 +170,13 @@ bool replicate_chart_response(RRDHOST *host, RRDSET *st, bool start_streaming, t
 
     // find the latest entry we have
     time_t last_entry_local = st->last_updated.tv_sec;
+    if(!last_entry_local) {
+        internal_error(true,
+                       "RRDSET: '%s' last updated time zero. Querying db for last updated time.",
+                       rrdset_id(st));
+        last_entry_local = rrdset_last_entry_t(st);
+    }
+
     if(last_entry_local > now) {
         internal_error(true,
                        "RRDSET: '%s' last updated time %llu is in the future (now is %llu)",


### PR DESCRIPTION
Some 32-bit machines do not report their retention to parents properly.
This PR uses the retention from the db, when the last_updated time is zero and also log debug messages in case retention from a child is malformed.