### PR TITLE
WMI Alerts

### DIFF
--- a/health/health.d/wmi.conf
+++ b/health/health.d/wmi.conf
@@ -120,6 +120,26 @@ component: Network
        to: sysadmin
 
 
+## TCP
+
+
+ template: wmi_tcp_connections_failure
+       on: wmi.tcp_conns_failures
+    class: Errors
+     type: Windows
+component: TCP
+       os: *
+    hosts: *
+ families: *
+   lookup: sum -10m unaligned absolute match-names of tcp_conns_failures_ipv4,tcp_conns_failures_ipv6
+    units: failures
+    every: 1m
+     warn: $this >= 5
+    delay: down 1h multiplier 1.5 max 2h
+     info: number of connection failures in the last 10 minutes
+       to: sysadmin
+
+
 ## Disk
 
  template: wmi_disk_in_use

--- a/health/health.d/wmi.conf
+++ b/health/health.d/wmi.conf
@@ -130,7 +130,7 @@ component: Services
        os: *
     hosts: *
  families: *
-   lookup: sum -10m unaligned absolute match-names foreach *error*,*stressed*,*nonrecover*
+   lookup: max -60s unaligned of error,stressed,nonrecover
     units: failures
     every: 1m
      warn: $this >= 1

--- a/health/health.d/wmi.conf
+++ b/health/health.d/wmi.conf
@@ -149,7 +149,7 @@ component: Services
 #       os: *
 #    hosts: *
 # families: *
-#   lookup: sum -10m unaligned absolute match-names of tcp_conns_failures_ipv4,tcp_conns_failures_ipv6
+#   lookup: sum -10m unaligned of ipv4,ipv6
 #    units: failures
 #    every: 1m
 #     warn: $this >= 60

--- a/health/health.d/wmi.conf
+++ b/health/health.d/wmi.conf
@@ -135,7 +135,7 @@ component: Services
     every: 1m
      warn: $this >= 1
     delay: down 10m multiplier 1.5 max 30m
-     info: number of errors reported for $label:service in the last 10 minutes
+     info: service $label:service is not operating properly
        to: sysadmin
 
 

--- a/health/health.d/wmi.conf
+++ b/health/health.d/wmi.conf
@@ -135,7 +135,7 @@ component: Services
     every: 1m
      warn: $this >= 1
     delay: down 1h multiplier 1.5 max 2h
-     info: number of connection failures in the last 10 minutes
+     info: number of errors reported for $label:service in the last 10 minutes
        to: sysadmin
 
 

--- a/health/health.d/wmi.conf
+++ b/health/health.d/wmi.conf
@@ -6,7 +6,7 @@
     class: Utilization
      type: Windows
 component: CPU
-       os: linux
+       os: *
     hosts: *
    lookup: average -10m unaligned match-names of dpc,user,privileged,interrupt
     units: %
@@ -25,7 +25,7 @@ component: CPU
     class: Utilization
      type: Windows
 component: Memory
-       os: linux
+       os: *
     hosts: *
      calc: ($used) * 100 / ($used + $available)
     units: %
@@ -41,7 +41,7 @@ component: Memory
     class: Utilization
      type: Windows
 component: Memory
-       os: linux
+       os: *
     hosts: *
      calc: ($used) * 100 / ($used + $available)
     units: %
@@ -60,7 +60,7 @@ component: Memory
     class: Errors
      type: Windows
 component: Network
-       os: linux
+       os: *
     hosts: *
  families: *
    lookup: sum -10m unaligned absolute match-names of inbound
@@ -76,7 +76,7 @@ component: Network
     class: Errors
      type: Windows
 component: Network
-       os: linux
+       os: *
     hosts: *
  families: *
    lookup: sum -10m unaligned absolute match-names of outbound
@@ -92,7 +92,7 @@ component: Network
     class: Errors
      type: Windows
 component: Network
-       os: linux
+       os: *
     hosts: *
  families: *
    lookup: sum -10m unaligned absolute match-names of inbound
@@ -108,7 +108,7 @@ component: Network
     class: Errors
      type: Windows
 component: Network
-       os: linux
+       os: *
     hosts: *
  families: *
    lookup: sum -10m unaligned absolute match-names of outbound
@@ -147,7 +147,7 @@ component: TCP
     class: Utilization
      type: Windows
 component: Disk
-       os: linux
+       os: *
     hosts: *
      calc: ($used) * 100 / ($used + $free)
     units: %

--- a/health/health.d/wmi.conf
+++ b/health/health.d/wmi.conf
@@ -120,8 +120,26 @@ component: Network
        to: sysadmin
 
 
-## TCP
+## Service
 
+ template: wmi_service_status
+       on: wmi.service_status
+    class: Errors
+     type: Windows
+component: Services
+       os: *
+    hosts: *
+ families: *
+   lookup: sum -10m unaligned absolute match-names foreach *error*,*stressed*,*nonrecover*
+    units: failures
+    every: 1m
+     warn: $this >= 1
+    delay: down 1h multiplier 1.5 max 2h
+     info: number of connection failures in the last 10 minutes
+       to: sysadmin
+
+
+## TCP
 
  template: wmi_tcp_connections_failure
        on: wmi.tcp_conns_failures

--- a/health/health.d/wmi.conf
+++ b/health/health.d/wmi.conf
@@ -134,7 +134,7 @@ component: Services
     units: failures
     every: 1m
      warn: $this >= 1
-    delay: down 1h multiplier 1.5 max 2h
+    delay: down 10m multiplier 1.5 max 30m
      info: number of errors reported for $label:service in the last 10 minutes
        to: sysadmin
 

--- a/health/health.d/wmi.conf
+++ b/health/health.d/wmi.conf
@@ -141,21 +141,21 @@ component: Services
 
 ## TCP
 
- template: wmi_tcp_connections_failure
-       on: wmi.tcp_conns_failures
-    class: Errors
-     type: Windows
-component: TCP
-       os: *
-    hosts: *
- families: *
-   lookup: sum -10m unaligned absolute match-names of tcp_conns_failures_ipv4,tcp_conns_failures_ipv6
-    units: failures
-    every: 1m
-     warn: $this >= 5
-    delay: down 1h multiplier 1.5 max 2h
-     info: number of connection failures in the last 10 minutes
-       to: sysadmin
+# template: wmi_tcp_connections_failure
+#       on: wmi.tcp_conns_failures
+#    class: Errors
+#     type: Windows
+#component: TCP
+#       os: *
+#    hosts: *
+# families: *
+#   lookup: sum -10m unaligned absolute match-names of tcp_conns_failures_ipv4,tcp_conns_failures_ipv6
+#    units: failures
+#    every: 1m
+#     warn: $this >= 60
+#    delay: down 10m multiplier 1.5 max 1h
+#     info: number of connection failures in the last 10 minutes
+#       to: sysadmin
 
 
 ## Disk


### PR DESCRIPTION
##### Summary
This PR is bringing new alerts for metrics we added for WMI module.

It is also changing `os` for `*`, because Windows can be monitored from other Operate Systems.

##### Test Plan

1. Review if nothing is missing.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? health
- Can they see the change or is it an under the hood? If they can see it, where? Only if they are monitoring a Windows.
- How is the user impacted by the change? They will be notified when there is an issue on Microsoft servers.
- What are there any benefits of the change? A complete monitoring for new metrics.
</details>
