### PR TITLE
do not resend charts upstream when chart variables are being updated

### DIFF
--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -287,6 +287,12 @@ PARSER_RC pluginsd_chart_definition_end(char **words, size_t num_words, void *us
             "REPLAY: received " PLUGINSD_KEYWORD_CHART_DEFINITION_END " with malformed timings (first time %llu, last time %llu).",
             (unsigned long long)first_entry_child, (unsigned long long)last_entry_child);
 
+//    internal_error(
+//            true,
+//            "REPLAY host '%s', chart '%s': received " PLUGINSD_KEYWORD_CHART_DEFINITION_END " first time %llu, last time %llu.",
+//            rrdhost_hostname(host), rrdset_id(st),
+//            (unsigned long long)first_entry_child, (unsigned long long)last_entry_child);
+
     rrdset_flag_clear(st, RRDSET_FLAG_RECEIVER_REPLICATION_FINISHED);
 
     bool ok = replicate_chart_request(send_to_plugin, user_object->parser, host, st, first_entry_child, last_entry_child, 0, 0);
@@ -1103,12 +1109,12 @@ PARSER_RC pluginsd_replay_end(char **words, size_t num_words, void *user)
     }
 
     time_t update_every_child = str2l(get_word(words, num_words, 1));
-    time_t first_entry_child = str2l(get_word(words, num_words, 2));
-    time_t last_entry_child = str2l(get_word(words, num_words, 3));
+    time_t first_entry_child = (time_t)str2ull(get_word(words, num_words, 2));
+    time_t last_entry_child = (time_t)str2ull(get_word(words, num_words, 3));
 
     bool start_streaming = (strcmp(get_word(words, num_words, 4), "true") == 0);
-    time_t first_entry_requested = str2l(get_word(words, num_words, 5));
-    time_t last_entry_requested = str2l(get_word(words, num_words, 6));
+    time_t first_entry_requested = (time_t)str2ull(get_word(words, num_words, 5));
+    time_t last_entry_requested = (time_t)str2ull(get_word(words, num_words, 6));
 
     PARSER_USER_OBJECT *user_object = user;
 
@@ -1120,6 +1126,13 @@ PARSER_RC pluginsd_replay_end(char **words, size_t num_words, void *user)
               rrdhost_hostname(host));
         return PARSER_RC_ERROR;
     }
+
+//    internal_error(true,
+//                   "REPLAY: host '%s', chart '%s': received " PLUGINSD_KEYWORD_REPLAY_END " child first_t = %llu, last_t = %llu, start_streaming = %s, requested first_t = %llu, last_t = %llu",
+//                   rrdhost_hostname(host), rrdset_id(st),
+//                   (unsigned long long)first_entry_child, (unsigned long long)last_entry_child,
+//                   start_streaming?"true":"false",
+//                   (unsigned long long)first_entry_requested, (unsigned long long)last_entry_requested);
 
     ((PARSER_USER_OBJECT *) user)->st = NULL;
     ((PARSER_USER_OBJECT *) user)->count++;

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -510,9 +510,11 @@ typedef enum rrdset_flags {
     RRDSET_FLAG_OBSOLETE                = (1 << 3),  // this is marked by the collector/module as obsolete
     RRDSET_FLAG_EXPORTING_SEND          = (1 << 4),  // if set, this chart should be sent to Prometheus web API and external databases
     RRDSET_FLAG_EXPORTING_IGNORE        = (1 << 5),  // if set, this chart should not be sent to Prometheus web API and external databases
+
     RRDSET_FLAG_UPSTREAM_SEND           = (1 << 6),  // if set, this chart should be sent upstream (streaming)
     RRDSET_FLAG_UPSTREAM_IGNORE         = (1 << 7),  // if set, this chart should not be sent upstream (streaming)
     RRDSET_FLAG_UPSTREAM_EXPOSED        = (1 << 8),  // if set, we have sent this chart definition to netdata parent (streaming)
+
     RRDSET_FLAG_STORE_FIRST             = (1 << 9),  // if set, do not eliminate the first collection during interpolation
     RRDSET_FLAG_HETEROGENEOUS           = (1 << 10), // if set, the chart is not homogeneous (dimensions in it have multiple algorithms, multipliers or dividers)
     RRDSET_FLAG_HOMOGENEOUS_CHECK       = (1 << 11), // if set, the chart should be checked to determine if the dimensions are homogeneous
@@ -532,6 +534,8 @@ typedef enum rrdset_flags {
 
     RRDSET_FLAG_SENDER_REPLICATION_FINISHED   = (1 << 23), // the sending side has completed replication
     RRDSET_FLAG_RECEIVER_REPLICATION_FINISHED = (1 << 24), // the receiving side has completed replication
+
+    RRDSET_FLAG_UPSTREAM_SEND_VARIABLES = (1 << 25), // a custom variable has been updated and needs to be exposed to parent
 } RRDSET_FLAGS;
 
 #define rrdset_flag_check(st, flag) (__atomic_load_n(&((st)->flags), __ATOMIC_SEQ_CST) & (flag))

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1044,6 +1044,7 @@ void stop_streaming_sender(RRDHOST *host)
     dictionary_destroy(host->sender->replication_requests);
     freez(host->sender);
     host->sender = NULL;
+    rrdhost_flag_clear(host, RRDHOST_FLAG_RRDPUSH_SENDER_INITIALIZED);
 }
 
 void stop_streaming_receiver(RRDHOST *host)

--- a/database/rrdsetvar.c
+++ b/database/rrdsetvar.c
@@ -268,14 +268,14 @@ void rrdsetvar_custom_chart_variable_set(RRDSET *st, const RRDSETVAR_ACQUIRED *r
         NETDATA_DOUBLE *v = rs->value;
         if(*v != value) {
             *v = value;
-
-            // mark the chart to be sent upstream
-            rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_EXPOSED);
+            rrdset_flag_set(st, RRDSET_FLAG_UPSTREAM_SEND_VARIABLES);
         }
     }
 }
 
 void rrdsetvar_print_to_streaming_custom_chart_variables(RRDSET *st, BUFFER *wb) {
+    rrdset_flag_clear(st, RRDSET_FLAG_UPSTREAM_SEND_VARIABLES);
+
     // send the chart local custom variables
     RRDSETVAR *rs;
     dfe_start_read(st->rrdsetvar_root_index, rs) {

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -272,6 +272,4 @@ void log_sender_capabilities(struct sender_state *s);
 STREAM_CAPABILITIES convert_stream_version_to_capabilities(int32_t version);
 int32_t stream_capabilities_to_vn(uint32_t caps);
 
-void rrdpush_send_chart_metrics(BUFFER *wb, RRDSET *st, struct sender_state *s);
-
 #endif //NETDATA_RRDPUSH_H


### PR DESCRIPTION
Before this PR, chart variables updates force the entire chart to be pushed upstream again, triggering replication for that chart.

With this PR, chart variables updates are pushed upstream in BEGIN, SET, END, like the plugins do.

Also, there were 3 atomic operations on the chart flags for each BEGIN, SET, END loop. With this PR there is only 1 atomic operation.

Finally, there was a bug and proxies were not propagating metrics to their parents, if the host turned to be archived. Fixed it.