### PR TITLE
Remove health_thread_stop

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1112,7 +1112,6 @@ void rrdhost_free(RRDHOST *host, bool force) {
 
     freez(host->exporting_flags);
 
-    health_thread_stop(host);
     health_alarm_log_free(host);
 
 #ifdef ENABLE_DBENGINE


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #13933 (likely).

During tests for the above, it appears that _likely_ the health thread is responsible for the issue.

It could be because during shutdown, both `health_thread_stop` called from `rrdhost_free` and `netdata_thread_cleanup_pop(1)` which was called when the health loop exited, could be run. Depending on the timing of those two, there could be a hang. 

There is no need actually for `health_thread_stop`. For the parent agent `netdata_exit` will escape the loop and `netdata_thread_cleanup_pop(1)` will be called, and for the children when `health_enabled` is set to 0, it will do the same.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Run this PR on a parent. Connect some children and basically ensure when a child is disconnected it's health thread will stop (it will be logged in `health.log`).

There's no easy way to test this on WSL1 under Alpine (which is what our image is based on), we will need to test again on WSL1 with a new nightly containing this patch.
