### PR TITLE
Add basic clang-format checking to PR review.

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -41,12 +41,12 @@ jobs:
         id: clangformat
         run: |
           if [ "${{ contains(github.event.pull_request.labels.*.name, 'run-ci/clang-format') }}" = "true" ]; then
-            echo '::set-output name=run::true'
+            echo "run=true" >> "${GITHUB_OUTPUT}"
           elif git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '.*\.\(cpp|cxx|c|hpp|hxx|h\)$' ; then
-            echo '::set-output name=run::true'
+            echo "run=true" >> "${GITHUB_OUTPUT}"
             echo 'C/C++ code has changed, need to run clang-format.'
           else
-            echo '::set-output name=run::false'
+            echo "run=false" >> "${GITHUB_OUTPUT}"
           fi
       - name: Check files for eslint
         id: eslint
@@ -134,7 +134,8 @@ jobs:
           if [ "${{ steps.label.outputs.check-all }}" == 'true' ]; then
             find . -regex '.*\.\(c\|cpp\|cxx\|h\|hpp\|hxx\)$' -exec clang-format -i --style=file '{}' \;
           else
-            git diff --name-only origin/${{ github.base_ref }} HEAD | grep -E '.*\.\(cpp|cxx|c|hpp|hxx|h\)$' | xargs -n 1 -r clang-format -i --style=file
+            git diff --name-only origin/${{ github.base_ref }} HEAD | grep -E '.*\.\(cpp|cxx|c|hpp|hxx|h\)$' | \
+            xargs -n 1 -r clang-format -i --style=file
           fi
           git status --porcelain=v1 > /tmp/porcelain
           if [ -s /tmp/porcelain ]; then

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,5 +1,5 @@
 ---
-# Runs various ReviewDog based checks against PR with suggested changes to improve quality
+# Runs various linter checks against PR with suggested changes to improve quality
 name: Review
 on:
   pull_request:
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       actionlint: ${{ steps.actionlint.outputs.run }}
+      clangformat: ${{ steps.clangformat.outputs.run }}
       eslint: ${{ steps.eslint.outputs.run }}
       hadolint: ${{ steps.hadolint.outputs.run }}
       shellcheck: ${{ steps.shellcheck.outputs.run }}
@@ -33,6 +34,17 @@ jobs:
           elif git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '\.github/workflows/.*' ; then
             echo '::set-output name=run::true'
             echo 'GitHub Actions workflows have changed, need to run actionlint.'
+          else
+            echo '::set-output name=run::false'
+          fi
+      - name: Check files for clang-format
+        id: clangformat
+        run: |
+          if [ "${{ contains(github.event.pull_request.labels.*.name, 'run-ci/clang-format') }}" = "true" ]; then
+            echo '::set-output name=run::true'
+          elif git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '.*\.\(cpp|cxx|c|hpp|hxx|h\)$' ; then
+            echo '::set-output name=run::true'
+            echo 'C/C++ code has changed, need to run clang-format.'
           else
             echo '::set-output name=run::false'
           fi
@@ -97,6 +109,38 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check
+
+  clang-format:
+    name: clang-format
+    needs: prep-review
+    if: needs.prep-review.outputs.clangformat == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v3
+        with:
+          submodules: false
+          fetch-depth: 0
+      - name: Check for label
+        id: label
+        run: |
+          if [ "${{ contains(github.event.pull_request.labels.*.name, 'run-ci/clang-format') }}" = "true" ]; then
+            echo 'check-all=true' >> "${GITHUB_OUTPUT}"
+          else
+            echo 'check-all=false' >> "${GITHUB_OUTPUT}"
+          fi
+      - name: Run clang-format
+        run: |
+          if [ "${{ steps.label.outputs.check-all }}" == 'true' ]; then
+            find . -regex '.*\.\(c\|cpp\|cxx\|h\|hpp\|hxx\)$' -exec clang-format -i --style=file '{}' \;
+          else
+            git diff --name-only origin/${{ github.base_ref }} HEAD | grep -E '.*\.\(cpp|cxx|c|hpp|hxx|h\)$' | xargs -n 1 -r clang-format -i --style=file
+          fi
+          git status --porcelain=v1 > /tmp/porcelain
+          if [ -s /tmp/porcelain ]; then
+            cat /tmp/porcelain
+            exit 1
+          fi
 
   eslint:
     name: eslint


### PR DESCRIPTION
##### Summary

This adds a new check to the Review workflow which runs `clang-format` against any modified C/C++ files in a PR.

By default, this check is skipped if no C/C++ files are modified.

This check can be forced to run against the entire repository on a given PR by labeling that PR with the `run-ci/clang-format` label.

##### Test Plan

Observe the run on this PR due to the `run-ci/clang-format` label.

##### Additional Information

Fixes: https://github.com/netdata/netdata/issues/13769