### PR TITLE
Fix local dashboard cloud links

### DIFF
--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -458,6 +458,7 @@ extern char *netdata_configured_host_prefix;
 
 // BEWARE: Outside of the C code this also exists in alarm-notify.sh
 #define DEFAULT_CLOUD_BASE_URL "https://api.netdata.cloud"
+#define DEFAULT_CLOUD_UI_URL "https://app.netdata.cloud"
 
 #define RRD_STORAGE_TIERS 5
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -27,7 +27,7 @@ KICKSTART_SOURCE="$(
 )"
 PACKAGES_SCRIPT="https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh"
 PATH="${PATH}:/usr/local/bin:/usr/local/sbin"
-PUBLIC_CLOUD_URL="https://api.netdata.cloud"
+PUBLIC_CLOUD_URL="https://app.netdata.cloud"
 REPOCONFIG_URL_PREFIX="https://packagecloud.io/netdata/netdata-repoconfig/packages"
 REPOCONFIG_VERSION="1-2"
 START_TIME="$(date +%s)"
@@ -43,7 +43,7 @@ INSTALL_TYPE="unknown"
 INSTALL_PREFIX=""
 NETDATA_AUTO_UPDATES="default"
 NETDATA_CLAIM_ONLY=0
-NETDATA_CLAIM_URL="${PUBLIC_CLOUD_URL}"
+NETDATA_CLAIM_URL="api.netdata.cloud"
 NETDATA_COMMAND="default"
 NETDATA_DISABLE_CLOUD=0
 NETDATA_ONLY_BUILD=0

--- a/registry/registry.c
+++ b/registry/registry.c
@@ -164,10 +164,12 @@ void registry_update_cloud_base_url()
 int registry_request_hello_json(RRDHOST *host, struct web_client *w) {
     registry_json_header(host, w, "hello", REGISTRY_STATUS_OK);
 
+    const char *cloud_ui_url = appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "cloud ui url", DEFAULT_CLOUD_UI_URL);
+
     buffer_sprintf(w->response.data,
             ",\n\t\"registry\": \"%s\",\n\t\"cloud_base_url\": \"%s\",\n\t\"anonymous_statistics\": %s",
             registry.registry_to_announce,
-            registry.cloud_base_url, netdata_anonymous_statistics_enabled?"true":"false");
+            cloud_ui_url, netdata_anonymous_statistics_enabled?"true":"false");
 
     registry_json_footer(w);
     return 200;


### PR DESCRIPTION
##### Summary
- Fixes Sign in button in local agent dashboard (by workaround)
- Fixes message in kickstart script

point 1 will ideally be fixed in future on agent UI by using new api endpoint returning both urls

##### Test Plan
Sign in button in local agent dashboard should point to `app.netdata.cloud` instead of `api.netdata.cloud`

#### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
