### PR TITLE
health/ping: use 'host' label in alerts info

### DIFF
--- a/health/health.d/ping.conf
+++ b/health/health.d/ping.conf
@@ -1,3 +1,4 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
 
  template: ping_host_reachable
  families: *
@@ -11,7 +12,7 @@ component: Network
     every: 10s
      crit: $this == 0
     delay: down 30m multiplier 1.5 max 2h
-     info: reachability status of the network host
+     info: network host $label:host reachability status
        to: sysadmin
 
  template: ping_packet_loss
@@ -28,7 +29,7 @@ component: Network
      warn: $this > $green
      crit: $this > $red
     delay: down 30m multiplier 1.5 max 2h
-     info: packet loss percentage to the network host over the last 10 minutes
+     info: packet loss percentage to the network host $label:host over the last 10 minutes
        to: sysadmin
 
  template: ping_host_latency
@@ -45,5 +46,5 @@ component: Network
      warn: $this > $green OR $max > $red
      crit: $this > $red
     delay: down 30m multiplier 1.5 max 2h
-     info: average latency to the network host over the last 10 seconds
+     info: average latency to the network host $label:host over the last 10 seconds
        to: sysadmin


### PR DESCRIPTION
##### Summary

ping charts have `host` label. This PR updates ping alerts info.

##### Test Plan

Check alarms infos.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
