### PR TITLE
Fallback to ar and ranlib if llvm-ar and llvm-ranlib are not there

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,8 +47,8 @@ AC_LANG_PUSH([C])
 AX_COMPILER_VENDOR
 AC_LANG_POP([C])
 if test "$ax_cv_c_compiler_vendor" = "clang"; then
-  AC_CHECK_TOOL([AR], [llvm-ar])
-  AC_CHECK_TOOL([RANLIB], [llvm-ranlib])
+  AC_CHECK_PROG([AR], [llvm-ar], [llvm-ar], [ar])
+  AC_CHECK_PROG([RANLIB], [llvm-ranlib], [llvm-ranlib], [ranlib])
 else
   AC_CHECK_TOOL([RANLIB], [ranlib])
   AC_CHECK_TOOL([AR], [ar])


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #13952 

On Macs even though they use clang, they don't have `llvm-ar` or `llvm-ranlib`. So if they're not there, fall back to standard `ar` and `ranlib`.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Need to test builds on various systems, using `--enable-lto` or without.

* Tested on MacOS with `Apple clang version 12.0.5` (no gcc) with & without LTO
* Tested on FreeBSD with `FreeBSD clang version 13.0.0` (no gcc) with & without LTO
* Tested on Gentoo with `gcc version 11.3.0` with and without LTO
* Tested on Gentoo with `clang version 14.0.6` with and without LTO

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
