### PR TITLE
break active-active loop from replicating non-existing child to each other

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -731,6 +731,8 @@ typedef enum rrdhost_flags {
     RRDHOST_FLAG_ACLK_STREAM_CONTEXTS           = (1 << 24), // when set, we should send ACLK stream context updates
     // Metadata
     RRDHOST_FLAG_METADATA_UPDATE                = (1 << 25), // metadata needs to be stored in the database
+
+    RRDHOST_FLAG_RRDPUSH_RECEIVER_DISCONNECTED = ( 1 << 26), // set when the receiver part is disconnected
 } RRDHOST_FLAGS;
 
 #define rrdhost_flag_check(host, flag) (__atomic_load_n(&((host)->flags), __ATOMIC_SEQ_CST) & (flag))

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -726,6 +726,9 @@ static int rrdpush_receive(struct receiver_state *rpt)
 
     rrdcontext_host_child_connected(rpt->host);
 
+
+    rrdhost_flag_clear(rpt->host, RRDHOST_FLAG_RRDPUSH_RECEIVER_DISCONNECTED);
+
     size_t count = streaming_parser(rpt, &cd, fp_in, fp_out,
 #ifdef ENABLE_HTTPS
                                     (rpt->ssl.conn) ? &rpt->ssl : NULL
@@ -733,6 +736,8 @@ static int rrdpush_receive(struct receiver_state *rpt)
                                     NULL
 #endif
                                     );
+
+    rrdhost_flag_set(rpt->host, RRDHOST_FLAG_RRDPUSH_RECEIVER_DISCONNECTED);
 
     log_stream_connection(rpt->client_ip, rpt->client_port,
                           rpt->key, rpt->host->machine_guid, rpt->hostname,

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -165,13 +165,13 @@ void sender_commit(struct sender_state *s, BUFFER *wb) {
 
 
 static inline void rrdpush_sender_thread_close_socket(RRDHOST *host) {
-    rrdhost_flag_clear(host, RRDHOST_FLAG_RRDPUSH_SENDER_READY_4_METRICS);
-    rrdhost_flag_clear(host, RRDHOST_FLAG_RRDPUSH_SENDER_CONNECTED);
-
     if(host->sender->rrdpush_sender_socket != -1) {
         close(host->sender->rrdpush_sender_socket);
         host->sender->rrdpush_sender_socket = -1;
     }
+
+    rrdhost_flag_clear(host, RRDHOST_FLAG_RRDPUSH_SENDER_READY_4_METRICS);
+    rrdhost_flag_clear(host, RRDHOST_FLAG_RRDPUSH_SENDER_CONNECTED);
 }
 
 static inline void rrdpush_sender_add_host_variable_to_buffer(BUFFER *wb, const RRDVAR_ACQUIRED *rva) {


### PR DESCRIPTION
When a child disconnects from a parent, and the parent has a grand-parent, the parent manages to spawn a sender thread for the just disconnected child.

This was not a problem if parent and grand-parent do not replicate to each other.

When they replicate to each other, then the 2 parents connect to each other, without any child connected and they stay like that forever, preventing the child from connect back to any of them.

This PR adds a flag that prevents any parent to spawn a sender thread while the child is disconnected.
