### PR TITLE
Add _total suffix to raw increment metrics for remote write

### DIFF
--- a/exporting/prometheus/remote_write/remote_write.c
+++ b/exporting/prometheus/remote_write/remote_write.c
@@ -257,6 +257,11 @@ int format_dimension_prometheus_remote_write(struct instance *instance, RRDDIM *
                 return 0;
             }
 
+            if (rd->algorithm == RRD_ALGORITHM_INCREMENTAL || rd->algorithm == RRD_ALGORITHM_PCENT_OVER_DIFF_TOTAL) {
+                if (strcmp(rrdset_module_name(rd->rrdset), "prometheus"))
+                    suffix = "_total";
+            }
+
             if (homogeneous) {
                 // all the dimensions of the chart, has the same algorithm, multiplier and divisor
                 // we add all dimensions as labels


### PR DESCRIPTION
##### Summary
The remote write exporting connector should follow the same metric naming scheme as the Prometheus API. We should add the `_total` suffix for incremental metrics when the data source is `raw`.

Fixes #13963

##### Test Plan
1. Configure the remote write exporting connector
```
 [prometheus_remote_write:my_prometheus_remote_write_instance]
     enabled = yes
     destination = localhost:1234
     data source = raw
```
2. Run [Remote write adapter example](https://github.com/prometheus/prometheus/tree/main/documentation/examples/remote_storage/example_write_adapter)
3. Check the output. It should contain metrics with the `_total` suffix, like `netdata_cpu_cpu_total`, `netdata_system_interrupts_total` etc.