### PR TITLE
use calculator app instead of spreadsheet

### DIFF
--- a/docs/store/change-metrics-storage.md
+++ b/docs/store/change-metrics-storage.md
@@ -52,9 +52,7 @@ the accuracy of the values you enter below, changes in the compression ratio, an
 :::
 
 Visit the [Netdata Storage Calculator](https://netdata-storage-calculator.herokuapp.com/) app to customize 
-data retention according to your preferences. There is also a 
-[python notebook](https://github.com/netdata/netdata-storage-calculator/blob/main/calculator.ipynb) 
-version you can also use.
+data retention according to your preferences.
 
 ## Edit `netdata.conf` with recommended database engine settings
 

--- a/docs/store/change-metrics-storage.md
+++ b/docs/store/change-metrics-storage.md
@@ -51,7 +51,7 @@ the accuracy of the values you enter below, changes in the compression ratio, an
 
 :::
 
-Visit the [Google Sheet Calculator](https://docs.google.com/spreadsheets/d/1aRLZJGJk6fvQDktkCB44l-EFROJcUrwOLe8rBQcfpPE/edit?usp=sharing) to customize data retention according to your preferences. To use it, you need to make a copy of this Google Sheet. Experiment with the variables highlighted in yellow to find the best settings for your use case.
+Visit the [Netdata Storage Calculator]([https://docs.google.com/spreadsheets/d/1aRLZJGJk6fvQDktkCB44l-EFROJcUrwOLe8rBQcfpPE/edit?usp=sharing](https://netdata-storage-calculator.streamlit.app/)) app to customize data retention according to your preferences. There is also a [python notebook](https://github.com/netdata/netdata-storage-calculator/blob/main/calculator.ipynb) version you can also use.
 
 ## Edit `netdata.conf` with recommended database engine settings
 

--- a/docs/store/change-metrics-storage.md
+++ b/docs/store/change-metrics-storage.md
@@ -51,7 +51,10 @@ the accuracy of the values you enter below, changes in the compression ratio, an
 
 :::
 
-Visit the [Netdata Storage Calculator](https://netdata-storage-calculator.herokuapp.com/) app to customize data retention according to your preferences. There is also a [python notebook](https://github.com/netdata/netdata-storage-calculator/blob/main/calculator.ipynb) version you can also use.
+Visit the [Netdata Storage Calculator](https://netdata-storage-calculator.herokuapp.com/) app to customize 
+data retention according to your preferences. There is also a 
+[python notebook](https://github.com/netdata/netdata-storage-calculator/blob/main/calculator.ipynb) 
+version you can also use.
 
 ## Edit `netdata.conf` with recommended database engine settings
 

--- a/docs/store/change-metrics-storage.md
+++ b/docs/store/change-metrics-storage.md
@@ -51,7 +51,7 @@ the accuracy of the values you enter below, changes in the compression ratio, an
 
 :::
 
-Visit the [Netdata Storage Calculator]([https://docs.google.com/spreadsheets/d/1aRLZJGJk6fvQDktkCB44l-EFROJcUrwOLe8rBQcfpPE/edit?usp=sharing](https://netdata-storage-calculator.streamlit.app/)) app to customize data retention according to your preferences. There is also a [python notebook](https://github.com/netdata/netdata-storage-calculator/blob/main/calculator.ipynb) version you can also use.
+Visit the [Netdata Storage Calculator](https://netdata-storage-calculator.herokuapp.com/) app to customize data retention according to your preferences. There is also a [python notebook](https://github.com/netdata/netdata-storage-calculator/blob/main/calculator.ipynb) version you can also use.
 
 ## Edit `netdata.conf` with recommended database engine settings
 


### PR DESCRIPTION
I think we should use the app instead of a spreadsheet. 

- It's a better user experience.
- It's easier to maintain and open for all since it just lives here: https://github.com/netdata/netdata-storage-calculator.
- Anyone who wants to customize it or play with it can also just open the notebook in colab.
- It feels a bit more polished.

p.s. we should be able to make any other look and feel improvements easy too as just PR's to the repo.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
