### PR TITLE
replication improvements

### DIFF
--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -1144,6 +1144,8 @@ PARSER_RC pluginsd_replay_end(char **words, size_t num_words, void *user)
         return PARSER_RC_OK;
     }
 
+    rrdcontext_updated_retention_rrdset(st);
+
     bool ok = replicate_chart_request(send_to_plugin, user_object->parser, host, st, first_entry_child, last_entry_child,
                                       first_entry_requested, last_entry_requested);
     return ok ? PARSER_RC_OK : PARSER_RC_ERROR;

--- a/database/rrdcontext.h
+++ b/database/rrdcontext.h
@@ -87,6 +87,7 @@ void rrdcontext_updated_rrdset(RRDSET *st);
 void rrdcontext_removed_rrdset(RRDSET *st);
 void rrdcontext_updated_rrdset_name(RRDSET *st);
 void rrdcontext_updated_rrdset_flags(RRDSET *st);
+void rrdcontext_updated_retention_rrdset(RRDSET *st);
 void rrdcontext_collected_rrdset(RRDSET *st);
 int rrdcontext_find_chart_uuid(RRDSET *st, uuid_t *store_uuid);
 
@@ -177,6 +178,7 @@ typedef struct query_target {
     QUERY_TARGET_REQUEST request;
 
     bool used;                              // when true, this query is currently being used
+    size_t queries;                         // how many query we have done so far
 
     struct {
         bool relative;                      // true when the request made with relative timestamps, true if it was absolute

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1097,8 +1097,6 @@ void rrddim_store_metric(RRDDIM *rd, usec_t point_end_time_ut, NETDATA_DOUBLE n,
 
         store_metric_at_tier(rd, t, sp, point_end_time_ut);
     }
-
-    rrdcontext_collected_rrddim(rd);
 }
 
 // caching of dimensions rrdset_done() and rrdset_done_interpolate() loop through
@@ -1257,6 +1255,7 @@ static inline size_t rrdset_done_interpolate(
             if(unlikely(!store_this_entry)) {
                 (void) ml_is_anomalous(rd, 0, false);
                 rrddim_store_metric(rd, next_store_ut, NAN, SN_FLAG_NONE);
+                rrdcontext_collected_rrddim(rd);
                 continue;
             }
 
@@ -1269,6 +1268,7 @@ static inline size_t rrdset_done_interpolate(
                 }
 
                 rrddim_store_metric(rd, next_store_ut, new_value, dim_storage_flags);
+                rrdcontext_collected_rrddim(rd);
                 rd->last_stored_value = new_value;
             }
             else {
@@ -1277,6 +1277,7 @@ static inline size_t rrdset_done_interpolate(
                 rrdset_debug(st, "%s: STORE[%ld] = NON EXISTING ", rrddim_name(rd), current_entry);
 
                 rrddim_store_metric(rd, next_store_ut, NAN, SN_FLAG_NONE);
+                rrdcontext_collected_rrddim(rd);
                 rd->last_stored_value = NAN;
             }
 

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -153,10 +153,13 @@ bool replicate_chart_response(RRDHOST *host, RRDSET *st, bool start_streaming, t
     time_t query_after = after;
     time_t query_before = before;
     time_t now = now_realtime_sec();
+    time_t tolerance = 2;   // sometimes from the time we get this value, to the time we check,
+                            // a data collection has been made
+                            // so, we give this tolerance to detect invalid timestamps
 
     // find the first entry we have
     time_t first_entry_local = rrdset_first_entry_t(st);
-    if(first_entry_local > now) {
+    if(first_entry_local > now + tolerance) {
         internal_error(true,
                        "RRDSET: '%s' first time %llu is in the future (now is %llu)",
                        rrdset_id(st), (unsigned long long)first_entry_local, (unsigned long long)now);
@@ -175,7 +178,7 @@ bool replicate_chart_response(RRDHOST *host, RRDSET *st, bool start_streaming, t
         last_entry_local = rrdset_last_entry_t(st);
     }
 
-    if(last_entry_local > now) {
+    if(last_entry_local > now + tolerance) {
         internal_error(true,
                        "RRDSET: '%s' last updated time %llu is in the future (now is %llu)",
                        rrdset_id(st), (unsigned long long)last_entry_local, (unsigned long long)now);

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -1132,9 +1132,13 @@ static void process_replication_requests(struct sender_state *s) {
             continue;
         }
 
+        netdata_thread_disable_cancelability();
+
         // send the replication data
         bool start_streaming = replicate_chart_response(st->rrdhost, st,
                 rr->start_streaming, rr->after, rr->before);
+
+        netdata_thread_enable_cancelability();
 
         // enable normal streaming if we have to
         if (start_streaming) {


### PR DESCRIPTION
- [x] contexts are not set to collected until replication finishes for them, so on Netdata Cloud the parent is not available for queries until replication finishes.

- [x] sender thread disables cancelability while replication queries are executed. Without it when a child disconnects, the sender thread may cancel in sensitive areas of dbengine leaving mutexes locked, thus deadlocking dbengine entirely.
