### PR TITLE
added debug info on left-over query targets

### DIFF
--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -2276,6 +2276,7 @@ typedef struct query_target_locals {
 static __thread QUERY_TARGET thread_query_target = {};
 void query_target_release(QUERY_TARGET *qt) {
     if(unlikely(!qt)) return;
+    if(unlikely(!qt->used)) return;
 
     simple_pattern_free(qt->hosts.pattern);
     qt->hosts.pattern = NULL;

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -1963,7 +1963,13 @@ RRDR *rrd2rrdr_legacy(
 }
 
 RRDR *rrd2rrdr(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
-    if(!qt || !owa) return NULL;
+    if(!qt)
+        return NULL;
+
+    if(!owa) {
+        query_target_release(qt);
+        return NULL;
+    }
 
     time_t timeout = qt->request.timeout;
     time_t resampling_time_requested = qt->request.resampling_time;

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -71,13 +71,8 @@ inline void rrdr_free(ONEWAYALLOC *owa, RRDR *r) {
 }
 
 RRDR *rrdr_create(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
-    if(unlikely(!qt))
+    if(unlikely(!qt || !qt->query.used || !qt->window.points))
         return NULL;
-
-    if(unlikely(!qt->query.used || !qt->window.points)) {
-        query_target_release(qt);
-        return NULL;
-    }
 
     size_t dimensions = qt->query.used;
     size_t points = qt->window.points;


### PR DESCRIPTION
We see a very rare condition that QUERY_TARGET is not released.
This PR adds an internal log error and a temporary fix, until we figure out how this happens.