### PR TITLE
Change static image urls to app.netdata.cloud in alarm-notify.sh

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2418,7 +2418,7 @@ status_email_subject="${status}"
 case "${status}" in
 CRITICAL)
   image="${images_base_url}/images/alert-128-red.png"
-  alarm_badge="${NETDATA_REGISTRY_CLOUD_BASE_URL}/static/email/img/label_critical.png"
+  alarm_badge="https://app.netdata.cloud/static/email/img/label_critical.png"
   status_message="is critical"
   status_email_subject="Critical"
   color="#ca414b"
@@ -2431,7 +2431,7 @@ CRITICAL)
 
 WARNING)
   image="${images_base_url}/images/alert-128-orange.png"
-  alarm_badge="${NETDATA_REGISTRY_CLOUD_BASE_URL}/static/email/img/label_warning.png"
+  alarm_badge="https://app.netdata.cloud/static/email/img/label_warning.png"
   status_message="needs attention"
   status_email_subject="Warning"
   color="#ffc107"
@@ -2444,7 +2444,7 @@ WARNING)
 
 CLEAR)
   image="${images_base_url}/images/check-mark-2-128-green.png"
-  alarm_badge="${NETDATA_REGISTRY_CLOUD_BASE_URL}/static/email/img/label_recovered.png"
+  alarm_badge="https://app.netdata.cloud/static/email/img/label_recovered.png"
   status_message="recovered"
   status_email_subject="Clear"
   color="#77ca6d"


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

With the recent change from `app.netdata.cloud` to `api.netdata.cloud`, some static images in alarm notifications where lost. This points them back to `app.netdata.cloud`.

There is also an issue with the `go to chart` link. If the agent is unclaimed, or claimed without providing an `-url https://app.netdata.cloud` it will default to using `api.netdata.cloud` for the link, which doesn't appear to work. But this is pending tbd how to fix exactly.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Raise a couple of alerts and see the html mail. Check if severity images are missing, i.e. 

![image](https://user-images.githubusercontent.com/1905463/202203962-cb67d99d-be5c-45d2-b805-14dd360c62e1.png)


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
