### PR TITLE
Add languagetool and markdownlint to CI.

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -17,6 +17,8 @@ jobs:
       actionlint: ${{ steps.actionlint.outputs.run }}
       eslint: ${{ steps.eslint.outputs.run }}
       hadolint: ${{ steps.hadolint.outputs.run }}
+      languagetool: ${{ steps.languagetool.outputs.run }}
+      markdownlint: ${{ steps.markdownlint.outputs.run }}
       shellcheck: ${{ steps.shellcheck.outputs.run }}
       yamllint: ${{ steps.yamllint.outputs.run }}
     steps:
@@ -57,6 +59,28 @@ jobs:
             echo 'Dockerfiles have changed, need to run Hadolint.'
           else
             echo '::set-output name=run::false'
+          fi
+      - name: Check files for languagetool
+        id: languagetool
+        run: |
+          if [ "${{ contains(github.event.pull_request.labels.*.name, 'run-ci/languagetool') }}" = "true" ]; then
+            echo 'run=true' >> "${GITHUB_OUTPUT}"
+          elif git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '.*\.md' ; then
+            echo 'run=true' >> "${GITHUB_OUTPUT}"
+            echo 'Markdown files have changed, need to run languagetool.'
+          else
+            echo 'run=false' >> "${GITHUB_OUTPUT}"
+          fi
+      - name: Check files for markdownlint
+        id: markdownlint
+        run: |
+          if [ "${{ contains(github.event.pull_request.labels.*.name, 'run-ci/markdownlint') }}" = "true" ]; then
+            echo 'run=true' >> "${GITHUB_OUTPUT}"
+          elif git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '.*\.md' ; then
+            echo 'run=true' >> "${GITHUB_OUTPUT}"
+            echo 'Markdown files have changed, need to run markdownlint.'
+          else
+            echo 'run=false' >> "${GITHUB_OUTPUT}"
           fi
       - name: Check files for shellcheck
         id: shellcheck
@@ -133,6 +157,35 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check
+
+  languagetool:
+    name: languagetool
+    needs: prep-review
+    if: needs.prep-review.outputs.languagetool == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Run languagetool
+        uses: reviewdog/action-languagetool@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-check
+
+  markdownlint:
+    name: markdownlint
+    needs: prep-review
+    if: needs.prep-review.outputs.markdownlint == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Run markdownlint
+        uses: reviewdog/action-markdownlint@v0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-check
+          markdownlint_flags: -s ./.mdl-style.rb .
 
   shellcheck:
     name: shellcheck

--- a/.mdl-style.rb
+++ b/.mdl-style.rb
@@ -1,0 +1,7 @@
+all
+rule 'MD003', :style => :atx      # Header style. 'atx' is the classic hash style headers
+rule 'MD004', :style => :dash     # Unordered list character style, we always use `-`.
+rule 'MD013', :line_length => 150 # Max line length
+rule 'MD046', :style => :fenced   # Code block style, we always use fenced (``` at top and bottom).
+
+exclude_rule 'MD033'              # Allow inline HTML


### PR DESCRIPTION
##### Summary

Only run against markdown files, specifically relevant to documentation. Full runs can be explicitly triggered with the usual `run-ci/*` labels matched to the tools.

languagetool is a multi-lingual proofing tool that checks both grammar and some basic stylistic aspects (such as flagging unnesesceary verbosity).

markdownlint is a linting tool for markdown, for enfocing certain stylistic conventions. It cannot cover the entirety of our documentation style guide, but does cover all the basics (like always using specific styles for headers, lists, and code blocks) and the ‘default’ rules mostly match our own standards.

##### Test Plan

n/a

##### Additional Information

This is currently a POC as a demonstration for later discussion with the docs team.