### PR TITLE
Change relative links to absolute for learn components

### DIFF
--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -6,8 +6,8 @@ sidebar_label: "Get started"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/get-started.mdx
 ---
 
-import { OneLineInstallWget } from '../src/components/OneLineInstall/'
-import { Install, InstallBox } from '../src/components/Install/'
+import { OneLineInstallWget } from '@site/src/components/OneLineInstall/'
+import { Install, InstallBox } from '@site/src/components/Install/'
 
 # Get started with Netdata
 

--- a/docs/guides/export/export-netdata-metrics-graphite.md
+++ b/docs/guides/export/export-netdata-metrics-graphite.md
@@ -3,7 +3,7 @@ title: Export and visualize Netdata metrics in Graphite
 description: "Use Netdata to collect and export thousands of metrics to Graphite for long-term storage or further analysis."
 image: /img/seo/guides/export/export-netdata-metrics-graphite.png
 -->
-import { OneLineInstallWget } from '../../src/components/OneLineInstall/'
+import { OneLineInstallWget } from '@site/src/components/OneLineInstall/'
 
 # Export and visualize Netdata metrics in Graphite
 

--- a/docs/guides/monitor/lamp-stack.md
+++ b/docs/guides/monitor/lamp-stack.md
@@ -7,7 +7,7 @@ author_title: "Editorial Director, Technical & Educational Resources"
 author_img: "/img/authors/joel-hans.jpg"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/monitor/lamp-stack.md
 -->
-import { OneLineInstallWget } from '../../src/components/OneLineInstall/'
+import { OneLineInstallWget } from '@site/src/components/OneLineInstall/'
 
 # LAMP stack monitoring (Linux, Apache, MySQL, PHP) with Netdata
 

--- a/docs/guides/monitor/pi-hole-raspberry-pi.md
+++ b/docs/guides/monitor/pi-hole-raspberry-pi.md
@@ -4,7 +4,7 @@ description: "Monitor Pi-hole metrics, plus Raspberry Pi system metrics, in minu
 image: /img/seo/guides/monitor/netdata-pi-hole-raspberry-pi.png
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/monitor/pi-hole-raspberry-pi.md
 -->
-import { OneLineInstallWget } from '../../src/components/OneLineInstall/'
+import { OneLineInstallWget } from '@site/src/components/OneLineInstall/'
 
 # Monitor Pi-hole (and a Raspberry Pi) with Netdata
 

--- a/docs/guides/step-by-step/step-00.md
+++ b/docs/guides/step-by-step/step-00.md
@@ -3,7 +3,7 @@ title: "The step-by-step Netdata guide"
 date: 2020-03-31
 custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/step-by-step/step-00.md
 -->
-import { OneLineInstallWget, OneLineInstallCurl } from '../../src/components/OneLineInstall/'
+import { OneLineInstallWget, OneLineInstallCurl } from '@site/src/components/OneLineInstall/'
 
 # The step-by-step Netdata guide
 

--- a/exporting/prometheus/README.md
+++ b/exporting/prometheus/README.md
@@ -4,7 +4,7 @@ description: "Export Netdata metrics to Prometheus for archiving and further ana
 custom_edit_url: https://github.com/netdata/netdata/edit/master/exporting/prometheus/README.md
 sidebar_label: "Using Netdata with Prometheus"
 -->
-import { OneLineInstallWget, OneLineInstallCurl } from '../../../src/components/OneLineInstall/'
+import { OneLineInstallWget, OneLineInstallCurl } from '@site/src/components/OneLineInstall/'
 
 # Using Netdata with Prometheus
 

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -3,9 +3,9 @@ title: "Installation guide"
 custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/README.md
 -->
 
-import { Install, InstallBox } from '../../../src/components/Install/'
+import { Install, InstallBox } from '@site/src/components/Install/'
 
-import { OneLineInstallWget, OneLineInstallCurl } from '../../../src/components/OneLineInstall/'
+import { OneLineInstallWget, OneLineInstallCurl } from '@site/src/components/OneLineInstall/'
 
 # Installation guide
 

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -3,7 +3,7 @@ title: "Install Netdata with kickstart.sh"
 description: "The kickstart.sh script installs Netdata from source, including all dependencies required to connect to Netdata Cloud, with a single command."
 custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/methods/kickstart.md
 -->
-import { OneLineInstallWget, OneLineInstallCurl } from '../../../../../src/components/OneLineInstall/'
+import { OneLineInstallWget, OneLineInstallCurl } from '@site/src/components/OneLineInstall/'
 
 # Install Netdata with kickstart.sh
 


### PR DESCRIPTION
##### Summary

We shouldn't use relative links when we want to reference components or/and pages in learn, they introduce to many breaking points if you move files, plus it's a pain when you want to calculate the relative path. This PR changes the relative links to absolute based on `@site` from the docusarus framework.



##### Test Plan

Part of learn

