### PR TITLE
Switch nightlies to GitHub releases.

### DIFF
--- a/.github/scripts/run-updater-check.sh
+++ b/.github/scripts/run-updater-check.sh
@@ -13,11 +13,11 @@ echo "::endgroup::"
 echo ">>> Updating Netdata..."
 export NETDATA_NIGHTLIES_BASEURL="http://localhost:8080/artifacts/" # Pull the tarball from the local web server.
 /netdata/packaging/installer/netdata-updater.sh --not-running-from-cron --no-updater-self-update || exit 1
-echo ">>> Checking if update was successful..."
-/netdata/.github/scripts/check-updater.sh || exit 1
 echo "::group::>>> Post-Update Environment File Contents"
 cat /etc/netdata/.environment
 echo "::endgroup::"
 echo "::group::>>> Post-Update Netdata Build Info"
 netdata -W buildinfo
 echo "::endgroup::"
+echo ">>> Checking if update was successful..."
+/netdata/.github/scripts/check-updater.sh || exit 1

--- a/.github/scripts/run-updater-check.sh
+++ b/.github/scripts/run-updater-check.sh
@@ -11,7 +11,7 @@ echo "::group::>>> Pre-Update Netdata Build Info"
 netdata -W buildinfo
 echo "::endgroup::"
 echo ">>> Updating Netdata..."
-export NETDATA_NIGHTLIES_BASEURL="http://localhost:8080/artifacts/" # Pull the tarball from the local web server.
+export NETDATA_BASE_URL="http://localhost:8080/artifacts/" # Pull the tarball from the local web server.
 /netdata/packaging/installer/netdata-updater.sh --not-running-from-cron --no-updater-self-update || exit 1
 echo "::group::>>> Post-Update Environment File Contents"
 cat /etc/netdata/.environment

--- a/.github/scripts/run-updater-check.sh
+++ b/.github/scripts/run-updater-check.sh
@@ -4,11 +4,20 @@ echo ">>> Installing CI support packages..."
 /netdata/.github/scripts/ci-support-pkgs.sh
 echo ">>> Installing Netdata..."
 /netdata/packaging/installer/kickstart.sh --dont-wait --build-only --disable-telemetry || exit 1
-echo "::group::Environment File Contents"
+echo "::group::>>> Pre-Update Environment File Contents"
 cat /etc/netdata/.environment
+echo "::endgroup::"
+echo "::group::>>> Pre-Update Netdata Build Info"
+netdata -W buildinfo
 echo "::endgroup::"
 echo ">>> Updating Netdata..."
 export NETDATA_NIGHTLIES_BASEURL="http://localhost:8080/artifacts/" # Pull the tarball from the local web server.
 /netdata/packaging/installer/netdata-updater.sh --not-running-from-cron --no-updater-self-update || exit 1
 echo ">>> Checking if update was successful..."
 /netdata/.github/scripts/check-updater.sh || exit 1
+echo "::group::>>> Post-Update Environment File Contents"
+cat /etc/netdata/.environment
+echo "::endgroup::"
+echo "::group::>>> Post-Update Netdata Build Info"
+netdata -W buildinfo
+echo "::endgroup::"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -556,6 +556,7 @@ jobs:
           mkdir -p download/test
           mv artifacts/* download/test
           echo 'Redirect 301 "/latest" "/test"' > .htaccess
+          echo 'Redirect 301 "/download/latest" "/download/test"' >> .htaccess
       - name: Verify that artifacts work with installer
         id: verify
         env:
@@ -611,6 +612,7 @@ jobs:
           mkdir -p download/test
           mv artifacts/* download/test
           echo 'Redirect 301 "/latest" "/test"' > .htaccess
+          echo 'Redirect 301 "/download/latest" "/download/test"' >> .htaccess
       - name: Verify that artifacts work with installer
         id: verify
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -413,11 +413,10 @@ jobs:
       - name: Prepare artifact directory
         id: prepare
         run: |
-          mkdir -p artifacts/download/test || exit 1
-          echo "9999.0.0-0" > artifacts/download/test/latest-version.txt || exit 1
-          cp dist-tarball/* artifacts/download/test || exit 1
-          echo 'Redirect 301 "/latest" "/test"' > artifacts/.htaccess || exit 1
-          cd artifacts/download/test || exit 1
+          mkdir -p artifacts/download/latest || exit 1
+          echo "9999.0.0-0" > artifacts/download/latest/latest-version.txt || exit 1
+          cp dist-tarball/* artifacts/download/latest || exit 1
+          cd artifacts/download/latest || exit 1
           ln -s ${{ needs.build-dist.outputs.distfile }} netdata-latest.tar.gz || exit 1
           sha256sum -b ./* > "sha256sums.txt" || exit 1
           cat sha256sums.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -413,10 +413,11 @@ jobs:
       - name: Prepare artifact directory
         id: prepare
         run: |
-          mkdir -p artifacts || exit 1
-          echo "9999.0.0-0" > artifacts/latest-version.txt || exit 1
-          cp dist-tarball/* artifacts || exit 1
-          cd artifacts || exit 1
+          mkdir -p artifacts/download/test || exit 1
+          echo "9999.0.0-0" > artifacts/download/test/latest-version.txt || exit 1
+          cp dist-tarball/* artifacts/download/test || exit 1
+          echo 'Redirect 301 "/latest" "/test"' > artifacts/.htaccess || exit 1
+          cd artifacts/download/test || exit 1
           ln -s ${{ needs.build-dist.outputs.distfile }} netdata-latest.tar.gz || exit 1
           sha256sum -b ./* > "sha256sums.txt" || exit 1
           cat sha256sums.txt
@@ -549,10 +550,16 @@ jobs:
         with:
           name: final-artifacts
           path: artifacts
+      - name: Prepare artifacts directory
+        id: prepare
+        run: |
+          mkdir -p download/test
+          mv artifacts/* download/test
+          echo 'Redirect 301 "/latest" "/test"' > .htaccess
       - name: Verify that artifacts work with installer
         id: verify
         env:
-          NETDATA_TARBALL_BASEURL: http://localhost:8080/artifacts
+          NETDATA_TARBALL_BASEURL: http://localhost:8080/
         run: packaging/installer/kickstart.sh --build-only --dont-start-it --disable-telemetry --dont-wait
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
@@ -598,10 +605,16 @@ jobs:
         with:
           name: final-artifacts
           path: artifacts
+      - name: Prepare artifacts directory
+        id: prepare
+        run: |
+          mkdir -p download/test
+          mv artifacts/* download/test
+          echo 'Redirect 301 "/latest" "/test"' > .htaccess
       - name: Verify that artifacts work with installer
         id: verify
         env:
-          NETDATA_TARBALL_BASEURL: http://localhost:8080/artifacts
+          NETDATA_TARBALL_BASEURL: http://localhost:8080/
         run: packaging/installer/kickstart.sh --static-only --dont-start-it --disable-telemetry
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -553,10 +553,8 @@ jobs:
       - name: Prepare artifacts directory
         id: prepare
         run: |
-          mkdir -p download/test
-          mv artifacts/* download/test
-          echo 'Redirect 301 "/latest" "/test"' > .htaccess
-          echo 'Redirect 301 "/download/latest" "/download/test"' >> .htaccess
+          mkdir -p download/latest
+          mv artifacts/* download/latest
       - name: Verify that artifacts work with installer
         id: verify
         env:
@@ -609,10 +607,8 @@ jobs:
       - name: Prepare artifacts directory
         id: prepare
         run: |
-          mkdir -p download/test
-          mv artifacts/* download/test
-          echo 'Redirect 301 "/latest" "/test"' > .htaccess
-          echo 'Redirect 301 "/download/latest" "/download/test"' >> .htaccess
+          mkdir -p download/latest
+          mv artifacts/* download/latest
       - name: Verify that artifacts work with installer
         id: verify
         env:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://github.com/netdata/netdata/"><img src="https://img.shields.io/github/stars/netdata/netdata?style=social" alt="GitHub Stars"></a>
   <br />
   <a href="https://github.com/netdata/netdata/releases/latest"><img src="https://img.shields.io/github/release/netdata/netdata.svg" alt="Latest release"></a>
-  <a href="https://storage.googleapis.com/netdata-nightlies/latest-version.txt"><img src="https://img.shields.io/badge/dynamic/xml?url=https://storage.googleapis.com/netdata-nightlies/latest-version.txt&label=nightly%20release&query=/text()" alt="Nightly release"></a>
+  <a href="https://github.com/netdata/netdata-nightlies/releases/latest"><img src="https://img.shields.io/github/release/netdata/netdata-nightlies.svg" alt="Latest nightly build"></a>
   <br />
   <a href="https://travis-ci.com/netdata/netdata"><img src="https://travis-ci.com/netdata/netdata.svg?branch=master" alt="Build status"></a>
   <a href="https://bestpractices.coreinfrastructure.org/projects/2231"><img src="https://bestpractices.coreinfrastructure.org/projects/2231/badge" alt="CII Best Practices"></a>

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1595,7 +1595,7 @@ set_static_archive_urls() {
       export NETDATA_STATIC_ARCHIVE_OLD_URL="${NETDATA_TARBALL_BASEURL}/download/v${INSTALL_VERSION}/netdata-v${INSTALL_VERSION}.gz.run"
       export NETDATA_STATIC_ARCHIVE_NAME="netdata-${arch}-v${INSTALL_VERSION}.gz.run"
       export NETDATA_STATIC_ARCHIVE_OLD_NAME="netdata-v${INSTALL_VERSION}.gz.run"
-      export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/sha256sums.txt"
+      export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/download/v${INSTALL_VERSION}/sha256sums.txt"
     else
       tag="$(get_redirect "${NETDATA_TARBALL_BASEURL}/latest")"
       export NETDATA_STATIC_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/download/${tag}/netdata-${arch}-latest.gz.run"
@@ -1686,11 +1686,12 @@ set_source_archive_urls() {
     fi
   else
     if [ -n "${INSTALL_VERSION}" ]; then
-      export NETDATA_SOURCE_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/netdata-v${INSTALL_VERSION}.tar.gz"
-      export NETDATA_SOURCE_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/sha256sums.txt"
+      export NETDATA_SOURCE_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/download/v${INSTALL_VERSION}/netdata-latest.tar.gz"
+      export NETDATA_SOURCE_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/download/v${INSTALL_VERSION}/sha256sums.txt"
     else
-      export NETDATA_SOURCE_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/netdata-latest.tar.gz"
-      export NETDATA_SOURCE_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/sha256sums.txt"
+      tag="$(get_redirect "${NETDATA_TARBALL_BASEURL}/latest")"
+      export NETDATA_SOURCE_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/download/${tag}/netdata-latest.tar.gz"
+      export NETDATA_SOURCE_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/download/${tag}/sha256sums.txt"
     fi
   fi
 }

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -65,7 +65,7 @@ else
   NETDATA_DISABLE_TELEMETRY=0
 fi
 
-NETDATA_TARBALL_BASEURL="${NETDATA_TARBALL_BASEURL:-https://storage.googleapis.com/netdata-nightlies}"
+NETDATA_TARBALL_BASEURL="${NETDATA_TARBALL_BASEURL:-https://github.com/netdata/netdata-nightlies/releases}"
 TELEMETRY_API_KEY="${NETDATA_POSTHOG_API_KEY:-mqkwGT0JNFqO-zX2t0mW6Tec9yooaVu7xCBlXtHnt5Y}"
 
 if echo "${0}" | grep -q 'kickstart-static64'; then
@@ -1574,25 +1574,33 @@ set_static_archive_urls() {
   if [ -n "${NETDATA_OFFLINE_INSTALL_SOURCE}" ]; then
     path="$(cd "${NETDATA_OFFLINE_INSTALL_SOURCE}" || exit 1; pwd)"
     export NETDATA_STATIC_ARCHIVE_URL="file://${path}/netdata-${arch}-latest.gz.run"
+    export NETDATA_STATIC_ARCHIVE_NAME="netdata-${arch}-latest.gz.run"
     export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="file://${path}/sha256sums.txt"
   elif [ "${1}" = "stable" ]; then
     if [ -n "${INSTALL_VERSION}" ]; then
-      export NETDATA_STATIC_ARCHIVE_OLD_URL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/netdata-v${INSTALL_VERSION}.gz.run"
       export NETDATA_STATIC_ARCHIVE_URL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/netdata-${arch}-v${INSTALL_VERSION}.gz.run"
+      export NETDATA_STATIC_ARCHIVE_OLD_URL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/netdata-v${INSTALL_VERSION}.gz.run"
+      export NETDATA_STATIC_ARCHIVE_NAME="netdata-${arch}-v${INSTALL_VERSION}.gz.run"
+      export NETDATA_STATIC_ARCHIVE_OLD_NAME="netdata-v${INSTALL_VERSION}.gz.run"
       export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/sha256sums.txt"
     else
       latest="$(get_redirect "https://github.com/netdata/netdata/releases/latest")"
       export NETDATA_STATIC_ARCHIVE_URL="https://github.com/netdata/netdata/releases/download/${latest}/netdata-${arch}-latest.gz.run"
+      export NETDATA_STATIC_ARCHIVE_NAME="netdata-${arch}-latest.gz.run"
       export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/${latest}/sha256sums.txt"
     fi
   else
     if [ -n "${INSTALL_VERSION}" ]; then
-      export NETDATA_STATIC_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/netdata-${arch}-v${INSTALL_VERSION}.gz.run"
-      export NETDATA_STATIC_ARCHIVE_OLD_URL="${NETDATA_TARBALL_BASEURL}/netdata-v${INSTALL_VERSION}.gz.run"
+      export NETDATA_STATIC_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/download/v${INSTALL_VERSION}/netdata-${arch}-v${INSTALL_VERSION}.gz.run"
+      export NETDATA_STATIC_ARCHIVE_OLD_URL="${NETDATA_TARBALL_BASEURL}/download/v${INSTALL_VERSION}/netdata-v${INSTALL_VERSION}.gz.run"
+      export NETDATA_STATIC_ARCHIVE_NAME="netdata-${arch}-v${INSTALL_VERSION}.gz.run"
+      export NETDATA_STATIC_ARCHIVE_OLD_NAME="netdata-v${INSTALL_VERSION}.gz.run"
       export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/sha256sums.txt"
     else
-      export NETDATA_STATIC_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/netdata-${arch}-latest.gz.run"
-      export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/sha256sums.txt"
+      tag="$(get_redirect "${NETDATA_TARBALL_BASEURL}/latest")"
+      export NETDATA_STATIC_ARCHIVE_URL="${NETDATA_TARBALL_BASEURL}/download/${tag}/netdata-${arch}-latest.gz.run"
+      export NETDATA_STATIC_ARCHIVE_NAME="netdata-${arch}-latest.gz.run"
+      export NETDATA_STATIC_ARCHIVE_CHECKSUM_URL="${NETDATA_TARBALL_BASEURL}/download/${tag}/sha256sums.txt"
     fi
   fi
 }
@@ -1607,23 +1615,9 @@ try_static_install() {
 
   # Check status code first, so that we can provide nicer fallback for dry runs.
   if check_for_remote_file "${NETDATA_STATIC_ARCHIVE_URL}"; then
-    if [ -n "${NETDATA_OFFLINE_INSTALL_SOURCE}" ]; then
-      netdata_agent="$(basename "${NETDATA_STATIC_ARCHIVE_URL#"file://"}")"
-    elif [ -n "${INSTALL_VERSION}" ]; then
-      if [ "${SELECTED_RELEASE_CHANNEL}" = "stable" ]; then
-        netdata_agent="${NETDATA_STATIC_ARCHIVE_URL#"https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/"}"
-      else
-        netdata_agent="${NETDATA_STATIC_ARCHIVE_URL#"${NETDATA_TARBALL_BASEURL}/"}"
-      fi
-    else
-      if [ "${SELECTED_RELEASE_CHANNEL}" = "stable" ]; then
-        netdata_agent="${NETDATA_STATIC_ARCHIVE_URL#"https://github.com/netdata/netdata/releases/download/${latest}/"}"
-      else
-        netdata_agent="${NETDATA_STATIC_ARCHIVE_URL#"${NETDATA_TARBALL_BASEURL}/"}"
-      fi
-    fi
+    netdata_agent="${NETDATA_STATIC_ARCHIVE_NAME}"
   elif [ "${SYSARCH}" = "x86_64" ] && check_for_remote_file "${NETDATA_STATIC_ARCHIVE_OLD_URL}"; then
-    netdata_agent="${NETDATA_STATIC_ARCHIVE_OLD_URL#"https://github.com/netdata/netdata/releases/download/v${INSTALL_VERSION}/"}"
+    netdata_agent="${NETDATA_STATIC_ARCHIVE_OLD_NAME}"
     export NETDATA_STATIC_ARCHIVE_URL="${NETDATA_STATIC_ARCHIVE_OLD_URL}"
   else
     warning "There is no static build available for ${SYSARCH} CPUs. This usually means we simply do not currently provide static builds for ${SYSARCH} CPUs."

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -369,8 +369,8 @@ download() {
 }
 
 get_netdata_latest_tag() {
-  dest="${1}"
-  url="https://github.com/netdata/netdata/releases/latest"
+  url="https://github.com/netdata/${1}/releases/latest"
+  dest="${2}"
 
   if command -v curl >/dev/null 2>&1; then
     tag=$(curl "${url}" -s -L -I -o /dev/null -w '%{url_effective}' | grep -m 1 -o '[^/]*$')
@@ -463,9 +463,9 @@ parse_version() {
 
 get_latest_version() {
   if [ "${RELEASE_CHANNEL}" = "stable" ]; then
-    get_netdata_latest_tag /dev/stdout
+    get_netdata_latest_tag netdata /dev/stdout
   else
-    download "$NETDATA_NIGHTLIES_BASEURL/latest-version.txt" /dev/stdout
+    get_netdata_latest_tag netdata-nightlies /dev/stdout
   fi
 }
 
@@ -529,12 +529,13 @@ set_tarball_urls() {
   fi
 
   if [ "$1" = "stable" ]; then
-    latest="$(get_netdata_latest_tag /dev/stdout)"
+    latest="$(get_netdata_latest_tag netdata /dev/stdout)"
     export NETDATA_TARBALL_URL="https://github.com/netdata/netdata/releases/download/$latest/${filename}"
     export NETDATA_TARBALL_CHECKSUM_URL="https://github.com/netdata/netdata/releases/download/$latest/sha256sums.txt"
   else
-    export NETDATA_TARBALL_URL="$NETDATA_NIGHTLIES_BASEURL/${filename}"
-    export NETDATA_TARBALL_CHECKSUM_URL="$NETDATA_NIGHTLIES_BASEURL/sha256sums.txt"
+    tag="$(get_netdata_latest_tag netdata-nightlies /dev/stdout)"
+    export NETDATA_TARBALL_URL="$NETDATA_NIGHTLIES_BASEURL/download/${tag}/${filename}"
+    export NETDATA_TARBALL_CHECKSUM_URL="$NETDATA_NIGHTLIES_BASEURL/download/${tag}/sha256sums.txt"
   fi
 }
 
@@ -908,7 +909,7 @@ export NETDATA_LIB_DIR="${NETDATA_LIB_DIR:-${NETDATA_PREFIX}/var/lib/netdata}"
 [ -z "${NETDATA_TARBALL_CHECKSUM}" ] && [ -f "${NETDATA_LIB_DIR}/netdata.tarball.checksum" ] && NETDATA_TARBALL_CHECKSUM="$(cat "${NETDATA_LIB_DIR}/netdata.tarball.checksum")"
 
 # Grab the nightlies baseurl (defaulting to our Google Storage bucket)
-export NETDATA_NIGHTLIES_BASEURL="${NETDATA_NIGHTLIES_BASEURL:-https://storage.googleapis.com/netdata-nightlies}"
+export NETDATA_NIGHTLIES_BASEURL="${NETDATA_NIGHTLIES_BASEURL:-https://github.com/netdata/netdata-nightlies/releases}"
 
 if echo "$INSTALL_TYPE" | grep -qv ^binpkg && [ "${INSTALL_UID}" != "$(id -u)" ]; then
   fatal "You are running this script as user with uid $(id -u). We recommend to run this script as root (user with uid 0)" U0011

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -442,7 +442,10 @@ self_update() {
 
 parse_version() {
   r="${1}"
-  if echo "${r}" | grep -q '^v.*'; then
+  if [ "${r}" = "latest" ]; then
+    printf "99999999999999"
+    return 0
+  elif echo "${r}" | grep -q '^v.*'; then
     # shellcheck disable=SC2001
     # XXX: Need a regex group substitution here.
     r="$(echo "${r}" | sed -e 's/^v\(.*\)/\1/')"


### PR DESCRIPTION
##### Summary

Second half of https://github.com/netdata/netdata/pull/13961.

This switches to pulling nightly builds from https://github.com/netdata/netdata-nightlies instead of our GCS buckets when installing static builds or local builds.

##### Test Plan

Easily testable by simply attempting to use the kickstart script from this PR without using native packages and noting where it downloads the files from.

Equivalent testing can be done with the updater script.

##### Additional Information

We will still need changes to the update availability checks, but that will need to be in a different PR.