### PR TITLE
remove retries from SSL

### DIFF
--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -925,11 +925,11 @@ ssize_t netdata_ssl_read(SSL *ssl, void *buf, size_t num) {
 
     int bytes, err, retries = 0;
 
-    do {
+    //do {
         bytes = SSL_read(ssl, buf, (int)num);
         err = SSL_get_error(ssl, bytes);
         retries++;
-    } while (bytes <= 0 && (err == SSL_ERROR_WANT_READ));
+    //} while (bytes <= 0 && (err == SSL_ERROR_WANT_READ));
 
     if(unlikely(bytes <= 0))
         error("SSL_read() returned %d bytes, SSL error %d", bytes, err);
@@ -946,7 +946,7 @@ ssize_t netdata_ssl_write(SSL *ssl, const void *buf, size_t num) {
     int bytes, err, retries = 0;
     size_t total = 0;
 
-    do {
+    //do {
         bytes = SSL_write(ssl, (uint8_t *)buf + total, (int)(num - total));
         err = SSL_get_error(ssl, bytes);
         retries++;
@@ -954,13 +954,13 @@ ssize_t netdata_ssl_write(SSL *ssl, const void *buf, size_t num) {
         if(bytes > 0)
             total += bytes;
 
-    } while ((bytes <= 0 && (err == SSL_ERROR_WANT_WRITE)) || (bytes > 0 && total < num));
+    //} while ((bytes <= 0 && (err == SSL_ERROR_WANT_WRITE)) || (bytes > 0 && total < num));
 
     if(unlikely(bytes <= 0))
-        error("SSL_read() returned %d bytes, SSL error %d", bytes, err);
+        error("SSL_write() returned %d bytes, SSL error %d", bytes, err);
 
     if(retries > 1)
-        error_limit(&erl, "SSL_read() retried %d times", retries);
+        error_limit(&erl, "SSL_write() retried %d times", retries);
 
     return bytes;
 }

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1212,25 +1212,9 @@ static inline void web_client_send_http_header(struct web_client *w) {
     ssize_t bytes;
 #ifdef ENABLE_HTTPS
     if ( (!web_client_check_unix(w)) && (netdata_ssl_srv_ctx) ) {
-           if ( ( w->ssl.conn ) && ( !w->ssl.flags ) ){
-                while((bytes = netdata_ssl_write(w->ssl.conn, buffer_tostring(w->response.header_output), buffer_strlen(w->response.header_output))) < 0) {
-                    count++;
-                    if(count > 100 || (errno != EAGAIN && errno != EWOULDBLOCK)) {
-                        error("Cannot send HTTPS headers to web client.");
-                        break;
-                    }
-                }
-            } else {
-                while((bytes = send(w->ofd, buffer_tostring(w->response.header_output), buffer_strlen(w->response.header_output), 0)) == -1) {
-                    count++;
-
-                    if(count > 100 || (errno != EAGAIN && errno != EWOULDBLOCK)) {
-                        error("Cannot send HTTP headers to web client.");
-                        break;
-                    }
-                }
-            }
-    } else {
+        if ( ( w->ssl.conn ) && ( w->ssl.flags == NETDATA_SSL_HANDSHAKE_COMPLETE ) )
+            bytes = netdata_ssl_write(w->ssl.conn, buffer_tostring(w->response.header_output), buffer_strlen(w->response.header_output));
+        else {
             while((bytes = send(w->ofd, buffer_tostring(w->response.header_output), buffer_strlen(w->response.header_output), 0)) == -1) {
                 count++;
 
@@ -1239,6 +1223,17 @@ static inline void web_client_send_http_header(struct web_client *w) {
                     break;
                 }
             }
+        }
+    }
+    else {
+        while((bytes = send(w->ofd, buffer_tostring(w->response.header_output), buffer_strlen(w->response.header_output), 0)) == -1) {
+            count++;
+
+            if(count > 100 || (errno != EAGAIN && errno != EWOULDBLOCK)) {
+                error("Cannot send HTTP headers to web client.");
+                break;
+            }
+        }
     }
 #else
     while((bytes = send(w->ofd, buffer_tostring(w->response.header_output), buffer_strlen(w->response.header_output), 0)) == -1) {


### PR DESCRIPTION
It seems that retrying reading or writing corrupts the data.
Temporarily remove the retries that were introduced with PR #14023 