### PR TITLE
Match number of dims returned from /info endpoint.

### DIFF
--- a/ml/Dimension.cc
+++ b/ml/Dimension.cc
@@ -7,9 +7,14 @@
 using namespace ml;
 
 bool Dimension::isActive() const {
-    bool SetObsolete = rrdset_flag_check(RD->rrdset, RRDSET_FLAG_OBSOLETE);
-    bool DimObsolete = rrddim_flag_check(RD, RRDDIM_FLAG_OBSOLETE);
-    return !SetObsolete && !DimObsolete;
+    if (!rrdset_is_available_for_viewers(RD->rrdset))
+        return false;
+
+    if (rrddim_option_check(RD, RRDDIM_OPTION_HIDDEN) ||
+        rrddim_flag_check(RD, RRDDIM_FLAG_OBSOLETE))
+        return false;
+
+    return true;
 }
 
 std::pair<CalculatedNumber *, size_t> Dimension::getCalculatedNumbers() {


### PR DESCRIPTION
##### Summary
Change the way we are reporting active dimensions, ie. dimensions that we are training and predicting. This should match the number of charts/dimensions we are reporting from the /info endpoint.

##### Test Plan

CI + testing on staging (where we have containers come & go, leaving "stale" dimensions/charts for a while.