### PR TITLE
use 2 levels of judy arrays to speed up replication on very busy parents

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1265,8 +1265,10 @@ void rrdset_isnot_obsolete(RRDSET *st);
 #define rrdset_is_archived(st) (rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED) && rrdset_number_of_dimensions(st))
 
 time_t rrddim_first_entry_t(RRDDIM *rd);
+time_t rrddim_first_entry_t_of_tier(RRDDIM *rd, size_t tier);
 time_t rrddim_last_entry_t(RRDDIM *rd);
 time_t rrdset_last_entry_t(RRDSET *st);
+time_t rrdset_first_entry_t_of_tier(RRDSET *st, size_t tier);
 time_t rrdset_first_entry_t(RRDSET *st);
 time_t rrdhost_last_entry_t(RRDHOST *h);
 

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -435,13 +435,18 @@ time_t rrddim_last_entry_t(RRDDIM *rd) {
     return latest;
 }
 
+time_t rrddim_first_entry_t_of_tier(RRDDIM *rd, size_t tier) {
+    if(unlikely(tier > storage_tiers || !rd->tiers[tier]))
+        return 0;
+
+    return rd->tiers[tier]->query_ops->oldest_time(rd->tiers[tier]->db_metric_handle);
+}
+
 time_t rrddim_first_entry_t(RRDDIM *rd) {
     time_t oldest = 0;
 
     for(size_t tier = 0; tier < storage_tiers ;tier++) {
-        if(unlikely(!rd->tiers[tier])) continue;
-
-        time_t t = rd->tiers[tier]->query_ops->oldest_time(rd->tiers[tier]->db_metric_handle);
+        time_t t = rrddim_first_entry_t_of_tier(rd, tier);
         if(t != 0 && (oldest == 0 || t < oldest))
             oldest = t;
     }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -549,6 +549,24 @@ time_t rrdset_first_entry_t(RRDSET *st) {
     return first_entry_t;
 }
 
+time_t rrdset_first_entry_t_of_tier(RRDSET *st, size_t tier) {
+    if(unlikely(tier > storage_tiers))
+        return 0;
+
+    RRDDIM *rd;
+    time_t first_entry_t = LONG_MAX;
+
+    rrddim_foreach_read(rd, st) {
+        time_t t = rrddim_first_entry_t_of_tier(rd, tier);
+        if(t && t < first_entry_t)
+            first_entry_t = t;
+    }
+    rrddim_foreach_done(rd);
+
+    if (unlikely(LONG_MAX == first_entry_t)) return 0;
+    return first_entry_t;
+}
+
 inline void rrdset_is_obsolete(RRDSET *st) {
     if(unlikely(rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED))) {
         info("Cannot obsolete already archived chart %s", rrdset_name(st));

--- a/libnetdata/dictionary/dictionary.c
+++ b/libnetdata/dictionary/dictionary.c
@@ -1075,6 +1075,13 @@ static inline const char *item_get_name(const DICTIONARY_ITEM *item) {
         return item->caller_name;
 }
 
+static inline size_t item_get_name_len(const DICTIONARY_ITEM *item) {
+    if(item->options & ITEM_OPTION_ALLOCATED_NAME)
+        return string_strlen(item->string_name);
+    else
+        return strlen(item->caller_name);
+}
+
 static DICTIONARY_ITEM *dict_item_create(DICTIONARY *dict __maybe_unused, size_t *allocated_bytes, DICTIONARY_ITEM *master_item) {
     DICTIONARY_ITEM *item;
 
@@ -1794,10 +1801,10 @@ void dictionary_flush(DICTIONARY *dict) {
     if(unlikely(!dict))
         return;
 
-    // delete the index
-    dictionary_index_lock_wrlock(dict);
-    hashtable_destroy_unsafe(dict);
-    dictionary_index_lock_unlock(dict);
+//    // delete the index
+//    dictionary_index_lock_wrlock(dict);
+//    hashtable_destroy_unsafe(dict);
+//    dictionary_index_lock_unlock(dict);
 
     // delete all items
     ll_recursive_lock(dict, DICTIONARY_LOCK_WRITE); // get write lock here, to speed it up (it is recursive)
@@ -1805,8 +1812,9 @@ void dictionary_flush(DICTIONARY *dict) {
     for (item = dict->items.list; item; item = item_next) {
         item_next = item->next;
 
-        if(!item_flag_check(item, ITEM_FLAG_DELETED))
-            dict_item_free_or_mark_deleted(dict, item);
+//        if(!item_flag_check(item, ITEM_FLAG_DELETED))
+//            dict_item_free_or_mark_deleted(dict, item);
+        dict_item_del(dict, item_get_name(item), (ssize_t)item_get_name_len(item));
     }
     ll_recursive_unlock(dict, DICTIONARY_LOCK_WRITE);
 

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -505,6 +505,12 @@ static struct replication_sort_entry *replication_sort_entry_add(struct replicat
 
     struct replication_sort_entry *rse = replication_sort_entry_create(rq);
 
+    if(rq->after < (time_t)rep.last_after) {
+        // make it find this request first
+        rep.last_after = rq->after - 1;
+        rep.last_unique_id = rq->unique_id - 1;
+    }
+    
     rep.added++;
     rep.requests_count++;
 
@@ -819,7 +825,7 @@ void *replication_thread_main(void *ptr __maybe_unused) {
             rep.last_unique_id = 0;
 
             rep.waits++;
-            
+
             sleep_usec(1000 * USEC_PER_MS);
             continue;
         }

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -416,6 +416,7 @@ struct replication_request {
     STRING *chart_id;
     time_t after;                       // key for sorting (JudyL)
     time_t before;
+    Word_t unique_id;
     bool start_streaming;
     bool found;
 };
@@ -425,9 +426,8 @@ struct replication_request {
 struct replication_sort_entry {
     struct replication_request req;
 
-    const void *unique_id;              // used as a key to identify the sort entry - we never access its contents
+    size_t unique_id;              // used as a key to identify the sort entry - we never access its contents
     bool executed;
-    struct replication_sort_entry *next;
 };
 
 // the global variables for the replication thread
@@ -438,6 +438,7 @@ static struct replication_thread {
     size_t removed;
     time_t first_time_t;
     size_t requests_count;
+    Word_t next_unique_id;
     struct replication_request *requests;
 
     Pvoid_t JudyL_array;
@@ -447,6 +448,7 @@ static struct replication_thread {
         .removed = 0,
         .first_time_t = 0,
         .requests_count = 0,
+        .next_unique_id = 1,
         .requests = NULL,
         .JudyL_array = NULL,
 };
@@ -476,159 +478,132 @@ static void replication_recursive_unlock() {
 // ----------------------------------------------------------------------------
 // replication sort entry management
 
-static struct replication_sort_entry *replication_sort_entry_create(struct replication_request *r, const void *unique_id) {
-    struct replication_sort_entry *t = mallocz(sizeof(struct replication_sort_entry));
+static struct replication_sort_entry *replication_sort_entry_create(struct replication_request *rq) {
+    struct replication_sort_entry *rse = mallocz(sizeof(struct replication_sort_entry));
 
     // copy the request
-    t->req = *r;
-    t->req.chart_id = string_dup(r->chart_id);
+    rse->req = *rq;
+    rse->req.chart_id = string_dup(rq->chart_id);
 
+    rse->unique_id = rep.next_unique_id++;
+    rse->executed = false;
 
-    t->unique_id = unique_id;
-    t->executed = false;
-    t->next = NULL;
-    return t;
+    // save the unique id into the request, to be able to delete it later
+    rq->unique_id = rse->unique_id;
+    return rse;
 }
 
-static void replication_sort_entry_destroy(struct replication_sort_entry *t) {
-    string_freez(t->req.chart_id);
-    freez(t);
+static void replication_sort_entry_destroy(struct replication_sort_entry *rse) {
+    string_freez(rse->req.chart_id);
+    freez(rse);
 }
 
-static struct replication_sort_entry *replication_sort_entry_add(struct replication_request *r, const void *unique_id) {
-    struct replication_sort_entry *t = replication_sort_entry_create(r, unique_id);
-
+static struct replication_sort_entry *replication_sort_entry_add(struct replication_request *rq) {
     replication_recursive_lock();
 
+    struct replication_sort_entry *rse = replication_sort_entry_create(rq);
+
     rep.added++;
+    rep.requests_count++;
 
-    Pvoid_t *PValue;
+    Pvoid_t *inner_judy_ptr;
 
-    PValue = JudyLGet(rep.JudyL_array, (Word_t) r->after, PJE0);
-    if(!PValue)
-        PValue = JudyLIns(&rep.JudyL_array, (Word_t) r->after, PJE0);
+    // find the outer judy entry, using after as key
+    inner_judy_ptr = JudyLGet(rep.JudyL_array, (Word_t) rq->after, PJE0);
+    if(!inner_judy_ptr)
+        inner_judy_ptr = JudyLIns(&rep.JudyL_array, (Word_t) rq->after, PJE0);
 
-    t->next = *PValue;
-    *PValue = t;
+    // add it to the inner judy, using unique_id as key
+    Pvoid_t *item = JudyLIns(inner_judy_ptr, rq->unique_id, PJE0);
+    *item = rse;
 
-    if(!rep.first_time_t || r->after < rep.first_time_t)
-        rep.first_time_t = r->after;
+    if(!rep.first_time_t || rq->after < rep.first_time_t)
+        rep.first_time_t = rq->after;
 
     replication_recursive_unlock();
 
-    return t;
+    return rse;
 }
 
-static void replication_sort_entry_del(struct sender_state *sender, STRING *chart_id, time_t after, const DICTIONARY_ITEM *item) {
-    Pvoid_t *PValue;
-    struct replication_sort_entry *to_delete = NULL;
+static void replication_sort_entry_del(struct sender_state *sender, STRING *chart_id, time_t after, Word_t unique_id) {
+    Pvoid_t *inner_judy_ptr;
+    struct replication_sort_entry *rse_to_delete = NULL;
 
     replication_recursive_lock();
 
     rep.removed++;
+    rep.requests_count--;
 
-    PValue = JudyLGet(rep.JudyL_array, after, PJE0);
-    if(PValue) {
-        struct replication_sort_entry *t = *PValue;
-        t->executed = true; // make sure we don't get it again
+    inner_judy_ptr = JudyLGet(rep.JudyL_array, after, PJE0);
+    if(inner_judy_ptr) {
+        Pvoid_t *our_item_pptr = JudyLGet(*inner_judy_ptr, unique_id, PJE0);
+        if(our_item_pptr) {
+            rse_to_delete = *our_item_pptr;
+            rse_to_delete->executed = true; // make sure we don't get it again
 
-        if(!t->next) {
-            // we are alone here, delete the judy entry
+            // delete it from the inner judy
+            JudyLDel(inner_judy_ptr, unique_id, PJE0);
 
-            if(t->unique_id != item)
-                fatal("Item to delete is not matching host '%s', chart '%s', time %ld.",
-                      rrdhost_hostname(sender->host), string2str(chart_id), after);
-
-            to_delete = t;
-            JudyLDel(&rep.JudyL_array, after, PJE0);
-        }
-        else {
-            // find our entry in the linked list
-
-            struct replication_sort_entry *t_old = NULL;
-            do {
-                if(t->unique_id == item) {
-                    to_delete = t;
-
-                    if(t_old)
-                        t_old->next = t->next;
-                    else
-                        *PValue = t->next;
-
-                    break;
-                }
-
-                t_old = t;
-                t = t->next;
-
-            } while(t);
+            // if no items left, delete it from the outer judy
+            if(*inner_judy_ptr == NULL)
+                JudyLDel(&rep.JudyL_array, after, PJE0);
         }
     }
 
-    if(!to_delete)
+    if(!rse_to_delete)
         fatal("Cannot find sort entry to delete for host '%s', chart '%s', time %ld.",
               rrdhost_hostname(sender->host), string2str(chart_id), after);
 
     replication_recursive_unlock();
 
-    replication_sort_entry_destroy(to_delete);
+    replication_sort_entry_destroy(rse_to_delete);
 }
 
 static struct replication_request replication_request_get_first_available() {
-    struct replication_sort_entry *found = NULL;
-    Pvoid_t *PValue;
-    Word_t Index;
+    struct replication_sort_entry *rse_found = NULL;
+    Pvoid_t *inner_judy_ptr;
 
     replication_recursive_lock();
 
-    rep.requests_count = JudyLCount(rep.JudyL_array, 0, 0xFFFFFFFF, PJE0);
-    if(!rep.requests_count) {
-        replication_recursive_unlock();
-        return (struct replication_request){ .found = false };
-    }
+    Word_t first_after = 0;
+    while(!rse_found && (inner_judy_ptr = JudyLNext(rep.JudyL_array, &first_after, PJE0))) {
+        Pvoid_t *our_item_ptr;
+        Word_t first_unique_id = 0;
+        while(!rse_found && (our_item_ptr = JudyLNext(*inner_judy_ptr, &first_unique_id, PJE0))) {
+            struct replication_sort_entry *rse = *our_item_ptr;
 
-    Index = 0;
-    PValue = JudyLFirst(rep.JudyL_array, &Index, PJE0);
-    while(!found && PValue) {
-        struct replication_sort_entry *t;
-
-        for(t = *PValue; t ;t = t->next) {
-            if(!t->executed
-                && sender_buffer_used_percent(t->req.sender) <= 10
-                && t->req.sender_last_flush_ut == __atomic_load_n(&t->req.sender->last_flush_time_ut, __ATOMIC_SEQ_CST)
-                ) {
-                found = t;
-                found->executed = true;
-                break;
+            if(!rse->executed
+               && sender_buffer_used_percent(rse->req.sender) <= 10
+               && rse->req.sender_last_flush_ut == __atomic_load_n(&rse->req.sender->last_flush_time_ut, __ATOMIC_SEQ_CST)
+                    ) {
+                rse_found = rse;
+                rse_found->executed = true;
             }
         }
-
-        if(!found)
-            PValue = JudyLNext(rep.JudyL_array, &Index, PJE0);
     }
 
     // copy the values we need, while we have the lock
-    struct replication_request ret;
+    struct replication_request rq;
 
-    if(found) {
-        ret = found->req;
-        ret.chart_id = string_dup(ret.chart_id);
-        ret.found = true;
+    if(rse_found) {
+        rq = rse_found->req;
+        rq.chart_id = string_dup(rq.chart_id);
+        rq.found = true;
     }
     else
-        ret.found = false;
+        rq.found = false;
 
     replication_recursive_unlock();
 
-    return ret;
+    return rq;
 }
 
 // ----------------------------------------------------------------------------
 // replication request management
 
-static void replication_request_react_callback(const DICTIONARY_ITEM *item, void *value __maybe_unused, void *sender_state __maybe_unused) {
+static void replication_request_react_callback(const DICTIONARY_ITEM *item __maybe_unused, void *value __maybe_unused, void *sender_state __maybe_unused) {
     struct sender_state *s = sender_state; (void)s;
-    struct replication_request *r = value;
+    struct replication_request *rq = value;
 
     // IMPORTANT:
     // We use the react instead of the insert callback
@@ -640,34 +615,34 @@ static void replication_request_react_callback(const DICTIONARY_ITEM *item, void
     // may see the replication sort entry, but fail to find the dictionary item
     // related to it.
 
-    replication_sort_entry_add(r, item);
-    __atomic_fetch_add(&r->sender->replication_pending_requests, 1, __ATOMIC_SEQ_CST);
+    replication_sort_entry_add(rq);
+    __atomic_fetch_add(&rq->sender->replication_pending_requests, 1, __ATOMIC_SEQ_CST);
 }
 
 static bool replication_request_conflict_callback(const DICTIONARY_ITEM *item __maybe_unused, void *old_value, void *new_value, void *sender_state) {
     struct sender_state *s = sender_state; (void)s;
-    struct replication_request *r = old_value; (void)r;
-    struct replication_request *r_new = new_value;
+    struct replication_request *rq = old_value; (void)rq;
+    struct replication_request *rq_new = new_value;
 
     internal_error(
             true,
             "STREAM %s [send to %s]: ignoring duplicate replication command received for chart '%s' (existing from %llu to %llu [%s], new from %llu to %llu [%s])",
             rrdhost_hostname(s->host), s->connected_to, dictionary_acquired_item_name(item),
-            (unsigned long long)r->after, (unsigned long long)r->before, r->start_streaming ? "true" : "false",
-            (unsigned long long)r_new->after, (unsigned long long)r_new->before, r_new->start_streaming ? "true" : "false");
+            (unsigned long long)rq->after, (unsigned long long)rq->before, rq->start_streaming ? "true" : "false",
+            (unsigned long long)rq_new->after, (unsigned long long)rq_new->before, rq_new->start_streaming ? "true" : "false");
 
-    string_freez(r_new->chart_id);
+    string_freez(rq_new->chart_id);
 
     return false;
 }
 
-static void replication_request_delete_callback(const DICTIONARY_ITEM *item, void *value, void *sender_state __maybe_unused) {
-    struct replication_request *r = value;
+static void replication_request_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *sender_state __maybe_unused) {
+    struct replication_request *rq = value;
 
-    replication_sort_entry_del(r->sender, r->chart_id, r->after, item);
+    replication_sort_entry_del(rq->sender, rq->chart_id, rq->after, rq->unique_id);
 
-    string_freez(r->chart_id);
-    __atomic_fetch_sub(&r->sender->replication_pending_requests, 1, __ATOMIC_SEQ_CST);
+    string_freez(rq->chart_id);
+    __atomic_fetch_sub(&rq->sender->replication_pending_requests, 1, __ATOMIC_SEQ_CST);
 }
 
 
@@ -675,7 +650,7 @@ static void replication_request_delete_callback(const DICTIONARY_ITEM *item, voi
 // public API
 
 void replication_add_request(struct sender_state *sender, const char *chart_id, time_t after, time_t before, bool start_streaming) {
-    struct replication_request tmp = {
+    struct replication_request rq = {
             .sender = sender,
             .chart_id = string_strdupz(chart_id),
             .after = after,
@@ -684,7 +659,7 @@ void replication_add_request(struct sender_state *sender, const char *chart_id, 
             .sender_last_flush_ut = __atomic_load_n(&sender->last_flush_time_ut, __ATOMIC_SEQ_CST),
     };
 
-    dictionary_set(sender->replication_requests, chart_id, &tmp, sizeof(struct replication_request));
+    dictionary_set(sender->replication_requests, chart_id, &rq, sizeof(struct replication_request));
 }
 
 void replication_flush_sender(struct sender_state *sender) {
@@ -745,64 +720,64 @@ void *replication_thread_main(void *ptr __maybe_unused) {
         worker_is_busy(WORKER_JOB_ITERATION);
 
         // this call also updates our statistics
-        struct replication_request r = replication_request_get_first_available();
+        struct replication_request rq = replication_request_get_first_available();
 
-        if(r.found) {
+        if(rq.found) {
             // delete the request from the dictionary
-            dictionary_del(r.sender->replication_requests, string2str(r.chart_id));
+            dictionary_del(rq.sender->replication_requests, string2str(rq.chart_id));
         }
 
         worker_set_metric(WORKER_JOB_CUSTOM_METRIC_PENDING_REQUESTS, (NETDATA_DOUBLE)rep.requests_count);
         worker_set_metric(WORKER_JOB_CUSTOM_METRIC_ADDED, (NETDATA_DOUBLE)rep.added);
         worker_set_metric(WORKER_JOB_CUSTOM_METRIC_DONE, (NETDATA_DOUBLE)rep.removed);
 
-        if(!r.found && !rep.requests_count) {
+        if(!rq.found && !rep.requests_count) {
             worker_set_metric(WORKER_JOB_CUSTOM_METRIC_COMPLETION, 100.0);
             worker_is_idle();
             sleep_usec(1000 * USEC_PER_MS);
             continue;
         }
 
-        if(!r.found) {
+        if(!rq.found) {
             worker_is_idle();
             sleep_usec(1 * USEC_PER_MS);
             continue;
         }
 
-        RRDSET *st = rrdset_find(r.sender->host, string2str(r.chart_id));
+        RRDSET *st = rrdset_find(rq.sender->host, string2str(rq.chart_id));
         if(!st) {
             internal_error(true, "REPLAY: chart '%s' not found on host '%s'",
-                           string2str(r.chart_id), rrdhost_hostname(r.sender->host));
+                           string2str(rq.chart_id), rrdhost_hostname(rq.sender->host));
 
             continue;
         }
 
         worker_is_busy(WORKER_JOB_REPLAYING);
 
-        time_t latest_first_time_t = r.after;
+        time_t latest_first_time_t = rq.after;
 
-        if(r.after < r.sender->replication_first_time || !r.sender->replication_first_time)
-            r.sender->replication_first_time = r.after;
+        if(rq.after < rq.sender->replication_first_time || !rq.sender->replication_first_time)
+            rq.sender->replication_first_time = rq.after;
 
-        if(r.before < r.sender->replication_min_time || !r.sender->replication_min_time)
-            r.sender->replication_min_time = r.before;
+        if(rq.before < rq.sender->replication_min_time || !rq.sender->replication_min_time)
+            rq.sender->replication_min_time = rq.before;
 
         netdata_thread_disable_cancelability();
 
         // send the replication data
         bool start_streaming = replicate_chart_response(st->rrdhost, st,
-                                                        r.start_streaming, r.after, r.before);
+                                                        rq.start_streaming, rq.after, rq.before);
 
         netdata_thread_enable_cancelability();
 
-        if(start_streaming && r.sender_last_flush_ut == __atomic_load_n(&r.sender->last_flush_time_ut, __ATOMIC_SEQ_CST)) {
-            __atomic_fetch_add(&r.sender->receiving_metrics, 1, __ATOMIC_SEQ_CST);
+        if(start_streaming && rq.sender_last_flush_ut == __atomic_load_n(&rq.sender->last_flush_time_ut, __ATOMIC_SEQ_CST)) {
+            __atomic_fetch_add(&rq.sender->receiving_metrics, 1, __ATOMIC_SEQ_CST);
 
             // enable normal streaming if we have to
             // but only if the sender buffer has not been flushed since we started
 
             debug(D_REPLICATION, "Enabling metric streaming for chart %s.%s",
-                  rrdhost_hostname(r.sender->host), rrdset_id(st));
+                  rrdhost_hostname(rq.sender->host), rrdset_id(st));
 
             rrdset_flag_set(st, RRDSET_FLAG_SENDER_REPLICATION_FINISHED);
         }

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -778,6 +778,9 @@ void *replication_thread_main(void *ptr __maybe_unused) {
     worker_register_job_custom_metric(WORKER_JOB_CUSTOM_METRIC_COMPLETION, "completion", "%", WORKER_METRIC_ABSOLUTE);
     worker_register_job_custom_metric(WORKER_JOB_CUSTOM_METRIC_ADDED, "added requests", "requests/s", WORKER_METRIC_INCREMENTAL_TOTAL);
     worker_register_job_custom_metric(WORKER_JOB_CUSTOM_METRIC_DONE, "finished requests", "requests/s", WORKER_METRIC_INCREMENTAL_TOTAL);
+    worker_register_job_custom_metric(WORKER_JOB_CUSTOM_METRIC_SKIPPED_NOT_CONNECTED, "not connected requests", "requests/s", WORKER_METRIC_INCREMENTAL_TOTAL);
+    worker_register_job_custom_metric(WORKER_JOB_CUSTOM_METRIC_SKIPPED_NO_ROOM, "no room requests", "requests/s", WORKER_METRIC_INCREMENTAL_TOTAL);
+    worker_register_job_custom_metric(WORKER_JOB_CUSTOM_METRIC_SENDER_RESETS, "sender resets", "resets/s", WORKER_METRIC_INCREMENTAL_TOTAL);
 
     time_t latest_first_time_t = 0;
 

--- a/streaming/replication.h
+++ b/streaming/replication.h
@@ -18,5 +18,6 @@ void replication_init_sender(struct sender_state *sender);
 void replication_cleanup_sender(struct sender_state *sender);
 void replication_flush_sender(struct sender_state *sender);
 void replication_add_request(struct sender_state *sender, const char *chart_id, time_t after, time_t before, bool start_streaming);
+void replication_recalculate_buffer_used_ratio_unsafe(struct sender_state *s);
 
 #endif /* REPLICATION_H */

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -293,7 +293,7 @@ static inline void rrdpush_send_chart_definition(BUFFER *wb, RRDSET *st) {
     rrdsetvar_print_to_streaming_custom_chart_variables(st, wb);
 
     if (stream_has_capability(host->sender, STREAM_CAP_REPLICATION)) {
-        time_t first_entry_local = rrdset_first_entry_t(st);
+        time_t first_entry_local = rrdset_first_entry_t_of_tier(st, 0);
         time_t last_entry_local = st->last_updated.tv_sec;
 
         if(!last_entry_local) {

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -166,6 +166,7 @@ struct sender_state {
     size_t replication_pending_requests;
     time_t replication_first_time;
     time_t replication_min_time;
+    size_t replication_sender_buffer_percent_used;
 
     usec_t last_flush_time_ut;
     size_t receiving_metrics;

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -167,6 +167,7 @@ struct sender_state {
     time_t replication_first_time;
     time_t replication_min_time;
     size_t replication_sender_buffer_percent_used;
+    bool replication_reached_max;
 
     usec_t last_flush_time_ut;
     size_t receiving_metrics;

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -176,6 +176,8 @@ static inline void rrdpush_sender_thread_close_socket(RRDHOST *host) {
 
     rrdhost_flag_clear(host, RRDHOST_FLAG_RRDPUSH_SENDER_READY_4_METRICS);
     rrdhost_flag_clear(host, RRDHOST_FLAG_RRDPUSH_SENDER_CONNECTED);
+
+    replication_flush_sender(host->sender);
 }
 
 static inline void rrdpush_sender_add_host_variable_to_buffer(BUFFER *wb, const RRDVAR_ACQUIRED *rva) {

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -163,6 +163,8 @@ void sender_commit(struct sender_state *s, BUFFER *wb) {
         s->flags |= SENDER_FLAG_OVERFLOW;
 #endif
 
+    replication_recalculate_buffer_used_ratio_unsafe(s);
+
     netdata_mutex_unlock(&s->mutex);
     rrdpush_signal_sender_to_wake_up(s);
 }
@@ -265,6 +267,7 @@ static inline void rrdpush_sender_thread_data_flush(RRDHOST *host) {
 
     netdata_mutex_lock(&host->sender->mutex);
     cbuffer_flush(host->sender->buffer);
+    replication_recalculate_buffer_used_ratio_unsafe(host->sender);
     netdata_mutex_unlock(&host->sender->mutex);
 
     rrdpush_sender_thread_reset_all_charts(host);
@@ -772,6 +775,7 @@ static ssize_t attempt_to_send(struct sender_state *s) {
     else
         debug(D_STREAM, "STREAM: send() returned 0 -> no error but no transmission");
 
+    replication_recalculate_buffer_used_ratio_unsafe(s);
     netdata_mutex_unlock(&s->mutex);
 
     return ret;


### PR DESCRIPTION
Speed up replication thread on very busy parents.

Instead of using the JudyL and a linked list, now it uses 2 JudyL nested to each other. The first JudyL uses the `after` timestamp as key and for each timestamp there is another JudyL that uses a unique id to store the entries.

During deletion, instead of traversing the linked list, it now uses the inner JudyL to find the entry to delete, using its unique id, without any traversal.