### PR TITLE
improve performance of worker utilization statistics

### DIFF
--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -421,6 +421,7 @@ bool run_command_and_copy_output_to_stdout(const char *command, int max_line_len
 void netdata_cleanup_and_exit(int ret) NORETURN;
 void send_statistics(const char *action, const char *action_result, const char *action_data);
 extern char *netdata_configured_host_prefix;
+#include "libjudy/src/Judy.h"
 #include "os.h"
 #include "storage_number/storage_number.h"
 #include "threads/threads.h"

--- a/libnetdata/worker_utilization/worker_utilization.h
+++ b/libnetdata/worker_utilization/worker_utilization.h
@@ -30,6 +30,7 @@ void workers_foreach(const char *workname, void (*callback)(
                                                       void *data
                                                       , pid_t pid
                                                       , const char *thread_tag
+                                                      , size_t max_job_id
                                                       , size_t utilization_usec
                                                       , size_t duration_usec
                                                       , size_t jobs_started


### PR DESCRIPTION
On very busy parents, the internal worker statistics charts are not refreshed on time and present gaps, because there are thousands of workers.

This PR makes the workers statistics optimal by utilizing 2 Judy arrays (a JudyHS to index the workers by name and a JudyL to index the worker threads by pid).

Also, it also maintains the max number of jobs used by each worker, to avoid unnecessary loops to collect their metrics.