### PR TITLE
Don't let slow disk plugin thread delay shutdown

### DIFF
--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -511,12 +511,19 @@ void *diskspace_slow_worker(void *ptr)
     netdata_thread_cleanup_push(diskspace_slow_worker_cleanup, data->slow_thread);
 
     usec_t step = slow_update_every * USEC_PER_SEC;
+    usec_t real_step = USEC_PER_SEC;
     heartbeat_t hb;
     heartbeat_init(&hb);
 
     while(!netdata_exit) {
         worker_is_idle();
-        heartbeat_next(&hb, step);
+        heartbeat_next(&hb, USEC_PER_SEC);
+
+        if (real_step < step) {
+            real_step += USEC_PER_SEC;
+            continue;
+        }
+        real_step = USEC_PER_SEC;
 
         usec_t start_time = now_monotonic_high_precision_usec();
 
@@ -549,7 +556,6 @@ void *diskspace_slow_worker(void *ptr)
 
         for(bmi = slow_mountinfo_root; bmi; bmi = bmi->next) {
             struct mount_point_metadata *m = dictionary_get(dict_mountpoints, bmi->mount_point);
-
             if (m)
                 mount_point_cleanup(bmi->mount_point, m, 1);
         }

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -556,6 +556,7 @@ void *diskspace_slow_worker(void *ptr)
 
         for(bmi = slow_mountinfo_root; bmi; bmi = bmi->next) {
             struct mount_point_metadata *m = dictionary_get(dict_mountpoints, bmi->mount_point);
+
             if (m)
                 mount_point_cleanup(bmi->mount_point, m, 1);
         }


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

The slow disk thread in diskspace plugin can delay the shutdown sequence for the duration of it's `step` sleep.

If `step` is 5 seconds, it can sleep as much, and can delay the shutdown for up to that time depending when during sleep shutdown was requested. This PR lowers the sleep time to 1 second, while respecting the real `step` time to perform work.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Observe the log file during shutdown before and after this PR. If requested to shutdown during the start of the while loop in `diskspace_slow_worker`, it could take up to `step` seconds to end the thread. With this PR it should be during the first second.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
