### PR TITLE
replication fixes #6

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -673,6 +673,7 @@ struct rrdset {
 
 #ifdef NETDATA_LOG_REPLICATION_REQUESTS
     struct {
+        bool log_next_data_collection;
         bool start_streaming;
         time_t after;
         time_t before;
@@ -1078,6 +1079,7 @@ extern RRDHOST *localhost;
 #define rrdhost_sender_replicating_charts_minus_one(host) (__atomic_sub_fetch(&((host)->rrdpush_sender_replicating_charts), 1, __ATOMIC_RELAXED))
 #define rrdhost_sender_replicating_charts_zero(host) (__atomic_store_n(&((host)->rrdpush_sender_replicating_charts), 0, __ATOMIC_RELAXED))
 
+extern DICTIONARY *rrdhost_root_index;
 long rrdhost_hosts_available(void);
 
 // ----------------------------------------------------------------------------

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -2,8 +2,6 @@
 
 #include "sqlite_metadata.h"
 
-extern DICTIONARY *rrdhost_root_index;
-
 // SQL statements
 
 #define SQL_STORE_CLAIM_ID  "insert into node_instance " \

--- a/libnetdata/worker_utilization/worker_utilization.c
+++ b/libnetdata/worker_utilization/worker_utilization.c
@@ -56,7 +56,7 @@ void worker_register(const char *workname) {
     worker->tag = strdupz(netdata_thread_tag());
     worker->workname = strdupz(workname);
 
-    usec_t now = now_realtime_usec();
+    usec_t now = now_monotonic_usec();
     worker->statistics_last_checkpoint = now;
     worker->last_action_timestamp = now;
     worker->last_action = WORKER_IDLE;
@@ -145,14 +145,14 @@ static inline void worker_is_idle_with_time(usec_t now) {
 void worker_is_idle(void) {
     if(unlikely(!worker || worker->last_action != WORKER_BUSY)) return;
 
-    worker_is_idle_with_time(now_realtime_usec());
+    worker_is_idle_with_time(now_monotonic_usec());
 }
 
 void worker_is_busy(size_t job_id) {
     if(unlikely(!worker || job_id >= WORKER_UTILIZATION_MAX_JOB_TYPES))
         return;
 
-    usec_t now = now_realtime_usec();
+    usec_t now = now_monotonic_usec();
 
     if(worker->last_action == WORKER_BUSY)
         worker_is_idle_with_time(now);
@@ -215,7 +215,7 @@ void workers_foreach(const char *workname, void (*callback)(
 
     struct worker *p;
     DOUBLE_LINKED_LIST_FOREACH_FORWARD(base, p, prev, next) {
-        usec_t now = now_realtime_usec();
+        usec_t now = now_monotonic_usec();
 
         // find per job type statistics
         STRING *per_job_type_name[WORKER_UTILIZATION_MAX_JOB_TYPES];

--- a/streaming/replication.h
+++ b/streaming/replication.h
@@ -11,7 +11,7 @@ typedef int (*send_command)(const char *txt, void *data);
 
 bool replicate_chart_request(send_command callback, void *callback_data,
                              RRDHOST *rh, RRDSET *rs,
-                             time_t first_entry_child, time_t last_entry_child,
+                             time_t first_entry_child, time_t last_entry_child, time_t child_world_time,
                              time_t response_first_start_time, time_t response_last_end_time);
 
 void replication_init_sender(struct sender_state *sender);


### PR DESCRIPTION
- use the faster monotonic clock in workers and replication
- avoid unecessary statistics functions on every request on replication - gather them all together once every second
- when replication completes, check the chart flags on all hosts to make sure streaming is enabled (this does not fix the possible issues, it just reports them)
- cleanup and unify replication logs
- added child world time to CHART_DEFINITION_END, RBEGIN and REND, so that the parent verifies all timestamps based on the child's clock, not its own
- fix first BEGIN been transmitted when replication starts
- dimensions replicated are not losing their OBSOLETE flag
