### PR TITLE
Remove eBPF plugin warning

### DIFF
--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -239,7 +239,7 @@ static int kernel_is_rejected()
     }
 
     fclose(kernel_reject_list);
-    freez(reject_string);
+    free(reject_string);
 
     return 0;
 }

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -239,7 +239,8 @@ static int kernel_is_rejected()
     }
 
     fclose(kernel_reject_list);
-    free(reject_string);
+    if (reject_string)
+        free(reject_string);
 
     return 0;
 }

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -239,8 +239,7 @@ static int kernel_is_rejected()
     }
 
     fclose(kernel_reject_list);
-    if (reject_string)
-        free(reject_string);
+    free(reject_string);
 
     return 0;
 }


### PR DESCRIPTION
##### Summary
Remove next warning

```sh
Nov 27 10:07:45 lab-nd-dev-parent2 ebpf.plugin[1835034]: pointer 0x55fe893d5c30 is not our pointer (called freez_int() from 242@libnetdata/ebpf/ebpf.c, kernel_is_rejected()).
```

because we were cleanup memory with `z` functions where we should not.

##### Test Plan

1. Compile PR with flag `-DNETDATA_TRACE_ALLOCATIONS=1` and start netdata
2. Wait few minutes and stop plugin, you should not have the warning.
3. Recompile now master branch and execute previous step. You will have the error again.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? ebpf.plugin
- Can they see the change or is it an under the hood? If they can see it, where? o
- How is the user impacted by the change? Remove a warning when they are learning how netdata works.
- What are there any benefits of the change?  A coherent plugin.
</details>
