### PR TITLE
replication fixes No 8

### DIFF
--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -2474,6 +2474,8 @@ static int read_thread_cpu_time_from_proc_stat(pid_t pid __maybe_unused, kernel_
 static Pvoid_t workers_by_pid_JudyL_array = NULL;
 
 static void workers_threads_cleanup(struct worker_utilization *wu) {
+    netdata_thread_disable_cancelability();
+
     struct worker_thread *t = wu->threads;
     while(t) {
         struct worker_thread *next = t->next;
@@ -2483,9 +2485,10 @@ static void workers_threads_cleanup(struct worker_utilization *wu) {
             DOUBLE_LINKED_LIST_REMOVE_UNSAFE(wu->threads, t, prev, next);
             freez(t);
         }
-
         t = next;
     }
+
+    netdata_thread_enable_cancelability();
  }
 
 static struct worker_thread *worker_thread_find(struct worker_utilization *wu __maybe_unused, pid_t pid) {

--- a/daemon/static_threads.c
+++ b/daemon/static_threads.c
@@ -134,7 +134,7 @@ const struct netdata_static_thread static_threads_common[] = {
 #endif
 
     {
-        .name = "rrdcontext",
+        .name = "RRDCONTEXT",
         .config_section = NULL,
         .config_name = NULL,
         .enabled = 1,
@@ -144,7 +144,7 @@ const struct netdata_static_thread static_threads_common[] = {
     },
 
     {
-            .name = "replication",
+            .name = "REPLICATION",
             .config_section = NULL,
             .config_name = NULL,
             .enabled = 1,

--- a/libnetdata/locks/locks.c
+++ b/libnetdata/locks/locks.c
@@ -287,6 +287,8 @@ void netdata_spinlock_init(SPINLOCK *spinlock) {
 }
 
 void netdata_spinlock_lock(SPINLOCK *spinlock) {
+    netdata_thread_disable_cancelability();
+
     static const struct timespec ns = { .tv_sec = 0, .tv_nsec = 1 };
     bool expected = false, desired = true;
 
@@ -306,6 +308,8 @@ void netdata_spinlock_lock(SPINLOCK *spinlock) {
 
 void netdata_spinlock_unlock(SPINLOCK *spinlock) {
     __atomic_store_n(&spinlock->locked, false, __ATOMIC_RELEASE);
+
+    netdata_thread_enable_cancelability();
 }
 
 #ifdef NETDATA_TRACE_RWLOCKS

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -856,10 +856,13 @@ static struct replication_request replication_request_get_first_available() {
     while(!rq_to_return.found) {
         round++;
 
-        if(unlikely(round > 2 || started_after == 0))
+        if(round > 2)
             break;
 
         if(round == 2) {
+            if(started_after == 0)
+                break;
+            
             replication_globals.protected.queue.after = 0;
             replication_globals.protected.queue.unique_id = 0;
         }

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -1345,10 +1345,6 @@ void *replication_thread_main(void *ptr __maybe_unused) {
         if(unlikely(replication_execute_next_pending_request() == REQUEST_QUEUE_EMPTY)) {
             replication_recursive_lock();
 
-            // make it scan all the pending requests next time
-            replication_set_next_point_in_time(0, 0);
-            replication_reset_next_point_in_time_countdown = SECONDS_TO_RESET_POINT_IN_TIME;
-
             // the timeout also defines now frequently we will traverse all the pending requests
             // when the outbound buffers of all senders is full
             usec_t timeout;
@@ -1373,6 +1369,11 @@ void *replication_thread_main(void *ptr __maybe_unused) {
 
             worker_is_idle();
             sleep_usec(timeout);
+
+            // make it scan all the pending requests next time
+            replication_set_next_point_in_time(0, 0);
+            replication_reset_next_point_in_time_countdown = SECONDS_TO_RESET_POINT_IN_TIME;
+
             continue;
         }
     }

--- a/streaming/replication.h
+++ b/streaming/replication.h
@@ -6,6 +6,7 @@
 #include "daemon/common.h"
 
 struct replication_query_statistics {
+    SPINLOCK spinlock;
     size_t queries_started;
     size_t queries_finished;
     size_t points_read;

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -1345,7 +1345,7 @@ void *rrdpush_sender_thread(void *ptr) {
             rrdpush_sender_thread_close_socket(s->host);
         }
 
-        worker_set_metric(WORKER_SENDER_JOB_REPLAY_DICT_SIZE, (NETDATA_DOUBLE) dictionary_entries(s->replication_requests));
+        worker_set_metric(WORKER_SENDER_JOB_REPLAY_DICT_SIZE, (NETDATA_DOUBLE) dictionary_entries(s->replication.requests));
     }
 
     netdata_thread_cleanup_pop(1);


### PR DESCRIPTION
Replication requests with `start_streaming=true` are executed immediately upon reception, instead of being placed in the queue.

Mostly re-arranging code to make it possible for the sender thread to execute replication requests from its own thread, without putting them in the replication thread pending requests queue.
