### PR TITLE
Strict control of streaming API keys and MACHINE GUIDs in stream.conf

### DIFF
--- a/streaming/stream.conf
+++ b/streaming/stream.conf
@@ -111,6 +111,11 @@
 [API_KEY]
     # Default settings for this API key
 
+    # This GUID is to be used as an API key from remote agents connecting
+    # to this machine. Failure to match such a key, denies access.
+    # YOU MUST SET THIS FIELD ON ALL API KEYS.
+    type = api
+
     # You can disable the API key, by setting this to: no
     # The default (for unknown API keys) is: no
     enabled = no
@@ -187,6 +192,11 @@
 # you can give settings for each sending host here.
 
 [MACHINE_GUID]
+    # This GUID is to be used as a MACHINE GUID from remote agents connecting
+    # to this machine, not an API key.
+    # YOU MUST SET THIS FIELD ON ALL MACHINE GUIDs.
+    type = machine
+
     # enable this host: yes | no
     # When disabled, the parent will not receive metrics for this host.
     # THIS IS NOT A SECURITY MECHANISM - AN ATTACKER CAN SET ANY OTHER GUID.


### PR DESCRIPTION
This PR applies strict rules on UUIDs defined in `stream.conf`.

`MACHINE_GUID` UUIDs can no longer be used as API keys and vice versa. A new option is introduced in `stream.conf` to define what an UUID section defines:

```
[UUID]
   type = api | machine
```

If this option is absent, the default value depends on the first use of the `UUID`. If it is used first as an API key, it will automatically get `type = api`, if it is first used as MACHINE GUID, it will get `type = machine`. Once this is set, it can only be used as such.

UUIDs that are indirectly created by Netdata, always get `type = machine` and cannot be used as API keys.

## Impact for users

- Users who are only setting API keys in `stream.conf` are advised to set `type = api` to their configuration, although it is not required. All their UUID sections will automatically get `type = api` once they are used as API keys and the indirectly created `[MACHINE_GUID]` sections will automatically get `type = machine` so that they cannot be used as API keys.

- Users who are setting both API keys and MACHINE GUIDs in `stream.conf` **MUST** set `type = machine` to the relative sections of MACHINE GUIDs. This will prevent their use as API keys. To improve the situation for these users, if they don't set `type = machine` in `stream.conf`, Netdata will automatically set `type = machine` on the first use of each UUID as a MACHINE GUID, preventing any future use as an API key.

- Users who are using the same UUID as both API key and MACHINE GUID need to set new API keys. An API key can no longer be used as a MACHINE GUID, and vice versa. Streaming for these users will no longer work until they update their configuration.

## Credits

This issue has been identified by [Stefan Schiller](https://github.com/stefan-schiller-sonarsource) of SonarSource.com

Thank you Stefan!