### PR TITLE
Sanitize command arguments.

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1024,6 +1024,9 @@ int main(int argc, char **argv) {
                             fprintf(stderr, "\n\nALL TESTS PASSED\n\n");
                             return 0;
                         }
+                        else if(strcmp(optarg, "escapetest") == 0) {
+                            return command_argument_sanitization_tests();
+                        }
 #ifdef ENABLE_ML_TESTS
                         else if(strcmp(optarg, "mltest") == 0) {
                             return test_ml(argc, argv);

--- a/daemon/unit_test.h
+++ b/daemon/unit_test.h
@@ -3,6 +3,8 @@
 #ifndef NETDATA_UNIT_TEST_H
 #define NETDATA_UNIT_TEST_H 1
 
+#include "stdbool.h"
+
 int unit_test_storage(void);
 int unit_test(long delay, long shift);
 int run_all_mockup_tests(void);
@@ -18,5 +20,7 @@ void dbengine_stress_test(unsigned TEST_DURATION_SEC, unsigned DSET_CHARTS, unsi
                                  unsigned RAMP_UP_SECONDS, unsigned PAGE_CACHE_MB, unsigned DISK_SPACE_MB);
 
 #endif
+
+bool command_argument_sanitization_tests();
 
 #endif /* NETDATA_UNIT_TEST_H */

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -250,7 +250,7 @@ fi
 # -----------------------------------------------------------------------------
 # find a suitable hostname to use, if netdata did not supply a hostname
 
-if [ -z ${args_host} ]; then
+if [ -z "${args_host}" ]; then
   this_host=$(hostname -s 2>/dev/null)
   host="${this_host}"
   args_host="${this_host}"

--- a/libnetdata/inlined.h
+++ b/libnetdata/inlined.h
@@ -181,6 +181,42 @@ static inline void sanitize_json_string(char *dst, const char *src, size_t dst_s
     *dst = '\0';
 }
 
+static inline bool sanitize_command_argument_string(char *dst, const char *src, size_t dst_size) {
+    // skip leading dashes
+    while (src[0] == '-')
+        src++;
+
+    // escape single quotes
+    while (src[0] != '\0') {
+        if (src[0] == '\'') {
+            if (dst_size < 4)
+                return false;
+
+            dst[0] = '\''; dst[1] = '\\'; dst[2] = '\''; dst[3] = '\'';
+
+            dst += 4;
+            dst_size -= 4;
+        } else {
+            if (dst_size < 1)
+                return false;
+
+            dst[0] = src[0];
+
+            dst += 1;
+            dst_size -= 1;
+        }
+
+        src++;
+    }
+
+    // make sure we have space to terminate the string
+    if (dst_size == 0)
+        return false;
+    *dst = '\0';
+
+    return true;
+}
+
 static inline int read_file(const char *filename, char *buffer, size_t size) {
     if(unlikely(!size)) return 3;
 

--- a/spawn/spawn.c
+++ b/spawn/spawn.c
@@ -8,7 +8,7 @@ int spawn_thread_shutdown;
 
 struct spawn_queue spawn_cmd_queue;
 
-static struct spawn_cmd_info *create_spawn_cmd(char *command_to_run)
+static struct spawn_cmd_info *create_spawn_cmd(const char *command_to_run)
 {
     struct spawn_cmd_info *cmdinfo;
 
@@ -57,7 +57,7 @@ static void init_spawn_cmd_queue(void)
 /*
  * Returns serial number of the enqueued command
  */
-uint64_t spawn_enq_cmd(char *command_to_run)
+uint64_t spawn_enq_cmd(const char *command_to_run)
 {
     unsigned queue_size;
     uint64_t serial;

--- a/spawn/spawn.h
+++ b/spawn/spawn.h
@@ -84,7 +84,7 @@ void spawn_init(void);
 void spawn_server(void);
 void spawn_client(void *arg);
 void destroy_spawn_cmd(struct spawn_cmd_info *cmdinfo);
-uint64_t spawn_enq_cmd(char *command_to_run);
+uint64_t spawn_enq_cmd(const char *command_to_run);
 void spawn_wait_cmd(uint64_t serial, int *exit_status, time_t *exec_run_timestamp);
 void spawn_deq_cmd(struct spawn_cmd_info *cmdinfo);
 struct spawn_cmd_info *spawn_get_unprocessed_cmd(void);


### PR DESCRIPTION
This PR escapes single quotes and removes leading dashes from command arguments executed by the health component.

## Impact for users

Not applicable. This should be a transparent change for users considering the values we are passing to the alarm notification script.

## Credits

This issue has been identified by [Stefan Schiller](https://github.com/stefan-schiller-sonarsource) of SonarSource.com

Thank you Stefan!