### PR TITLE
add netdata_version to ph install events

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -284,6 +284,7 @@ telemetry_event() {
     "selected_install_method": "${SELECTED_INSTALL_METHOD}",
     "netdata_release_channel": "${RELEASE_CHANNEL:-null}",
     "netdata_install_type": "${INSTALL_TYPE}",
+    "netdata_version": "${INSTALL_VERSION}",
     "host_os_name": "${HOST_NAME:-unknown}",
     "host_os_id": "${HOST_ID:-unknown}",
     "host_os_id_like": "${HOST_ID_LIKE:-unknown}",


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

add netdata_version to ph install events.

@Ferroin - would something like this be enough to add the netdata_version that the install event relates to? @amalkov was looking to break out some of the fail and crash event counts by netdata version and i realised that, i think, we dont actually have `netdata_version` in the events going to PH.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
