### PR TITLE
optimize workers statistics performance

### DIFF
--- a/collectors/proc.plugin/ipc.c
+++ b/collectors/proc.plugin/ipc.c
@@ -195,7 +195,7 @@ int ipc_msq_get_info(char *msg_filename, struct message_queue **message_queue_ro
     size_t words = 0;
 
     if(unlikely(lines < 2)) {
-        error("Cannot read %s. Expected 2 or more lines, read %zu.", ff->filename, lines);
+        error("Cannot read %s. Expected 2 or more lines, read %zu.", procfile_filename(ff), lines);
         return 1;
     }
 
@@ -205,7 +205,7 @@ int ipc_msq_get_info(char *msg_filename, struct message_queue **message_queue_ro
         words = procfile_linewords(ff, l);
         if(unlikely(words < 2)) continue;
         if(unlikely(words < 14)) {
-            error("Cannot read %s line. Expected 14 params, read %zu.", ff->filename, words);
+            error("Cannot read %s line. Expected 14 params, read %zu.", procfile_filename(ff), words);
             continue;
         }
 
@@ -250,7 +250,7 @@ int ipc_shm_get_info(char *shm_filename, struct shm_stats *shm) {
     size_t words = 0;
 
     if(unlikely(lines < 2)) {
-        error("Cannot read %s. Expected 2 or more lines, read %zu.", ff->filename, lines);
+        error("Cannot read %s. Expected 2 or more lines, read %zu.", procfile_filename(ff), lines);
         return 1;
     }
 
@@ -263,7 +263,7 @@ int ipc_shm_get_info(char *shm_filename, struct shm_stats *shm) {
         words = procfile_linewords(ff, l);
         if(unlikely(words < 2)) continue;
         if(unlikely(words < 16)) {
-            error("Cannot read %s line. Expected 16 params, read %zu.", ff->filename, words);
+            error("Cannot read %s line. Expected 16 params, read %zu.", procfile_filename(ff), words);
             continue;
         }
 

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -2691,7 +2691,7 @@ static void global_statistics_register_workers(void) {
     worker_register_job_name(WORKER_JOB_STRINGS, "strings");
     worker_register_job_name(WORKER_JOB_DICTIONARIES, "dictionaries");
     worker_register_job_name(WORKER_JOB_MALLOC_TRACE, "malloc_trace");
-    worker_register_job_name(WORKER_JOB_WORKERS, "workers collect");
+    worker_register_job_name(WORKER_JOB_WORKERS, "workers");
 }
 
 static void global_statistics_cleanup(void *ptr)

--- a/libnetdata/procfile/procfile.h
+++ b/libnetdata/procfile/procfile.h
@@ -37,7 +37,7 @@ typedef struct {
 #define PROCFILE_FLAG_DEFAULT             0x00000000
 #define PROCFILE_FLAG_NO_ERROR_ON_FILE_IO 0x00000001
 
-typedef enum procfile_separator {
+typedef enum __attribute__ ((__packed__)) procfile_separator {
     PF_CHAR_IS_SEPARATOR,
     PF_CHAR_IS_NEWLINE,
     PF_CHAR_IS_WORD,
@@ -46,17 +46,16 @@ typedef enum procfile_separator {
     PF_CHAR_IS_CLOSE
 } PF_CHAR_TYPE;
 
-typedef struct {
-    char filename[FILENAME_MAX + 1]; // not populated until profile_filename() is called
-
+typedef struct procfile {
+    char *filename;                 // not populated until procfile_filename() is called
     uint32_t flags;
-    int fd;               // the file descriptor
-    size_t len;           // the bytes we have placed into data
-    size_t size;          // the bytes we have allocated for data
+    int fd;                         // the file descriptor
+    size_t len;                     // the bytes we have placed into data
+    size_t size;                    // the bytes we have allocated for data
     pflines *lines;
     pfwords *words;
     PF_CHAR_TYPE separators[256];
-    char data[];          // allocated buffer to keep file contents
+    char data[];                    // allocated buffer to keep file contents
 } procfile;
 
 // close the proc file and free all related memory

--- a/libnetdata/worker_utilization/worker_utilization.h
+++ b/libnetdata/worker_utilization/worker_utilization.h
@@ -15,7 +15,7 @@ typedef enum {
     WORKER_METRIC_INCREMENTAL_TOTAL = 4,
 } WORKER_METRIC_TYPE;
 
-void worker_register(const char *workname);
+void worker_register(const char *name);
 void worker_register_job_name(size_t job_id, const char *name);
 void worker_register_job_custom_metric(size_t job_id, const char *name, const char *units, WORKER_METRIC_TYPE type);
 void worker_unregister(void);
@@ -26,7 +26,7 @@ void worker_set_metric(size_t job_id, NETDATA_DOUBLE value);
 
 // statistics interface
 
-void workers_foreach(const char *workname, void (*callback)(
+void workers_foreach(const char *name, void (*callback)(
                                                       void *data
                                                       , pid_t pid
                                                       , const char *thread_tag


### PR DESCRIPTION
On very busy parents, workers charts have gaps.
This optimizes workers statistics in the following ways:

- [x] use spinlock instead of mutex
- [x] use 2 levels of locks, one to manage the index of workers and another to manage the linked list of threads in each worker, allowing new workers to be registered independently of the statistics running.
- [x] hugely improved the performance of reading workers cpu utilization (10x faster compared to master) - this was the main offender for the performance issue of workers statistics. Now it is not even noticeable.

Also, in this PR:

- [x] remove the pre-allocated filename on each procfile, saving 4KB per procfile open - replaced with a dynamically allocated, if and when is needed - replaced all references to `procfile->filename` with the already existing `procfile_filename()` that does the same job dynamically.
- [x] improved the performance of `procfile_set_separators()`, using a constructor to set the default separators and using `memcpy()` to copy the defaults to each procfile.