### PR TITLE
Fix __atomic_compare_exchange_n() atomics

### DIFF
--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -320,7 +320,7 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
                 , SIMPLE_PATTERN_EXACT
         );
 
-        dict_mountpoints = dictionary_create(DICT_OPTION_SINGLE_THREADED);
+        dict_mountpoints = dictionary_create(DICT_OPTION_NONE);
     }
 
     struct mount_point_metadata *m = dictionary_get(dict_mountpoints, mi->mount_point);

--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -29,7 +29,7 @@
 #define WORKER_JOB_PP_QUEUE_SIZE   13
 
 
-typedef enum {
+typedef enum __attribute__ ((__packed__)) {
     RRD_FLAG_NONE           = 0,
     RRD_FLAG_DELETED        = (1 << 0), // this is a deleted object (metrics, instances, contexts)
     RRD_FLAG_COLLECTED      = (1 << 1), // this object is currently being collected
@@ -115,6 +115,7 @@ typedef enum {
 static inline void
 rrd_flag_add_remove_atomic(RRD_FLAGS *flags, RRD_FLAGS check, RRD_FLAGS conditionally_add, RRD_FLAGS always_remove) {
     RRD_FLAGS expected, desired;
+
     do {
         expected = *flags;
 


### PR DESCRIPTION
- [x] `__atomic_compare_exchange_n()` returns the existing value at its second parameter. So, there is no point to get the existing value with another atomic operation when __atomic_compare_exchange_n() is in a loop.
- [x] flags and options bitmap enums should be packed, to use the optimal space.
- [x] diskspace plugin was using a single threaded dictionary but it is multi-threaded.

