### PR TITLE
Fix eBPF load on RH 8.x family and improve code.

### DIFF
--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -123,6 +123,9 @@ enum ebpf_threads_status {
 #endif
 #endif
 
+// Messages
+#define NETDATA_EBPF_DEFAULT_FNT_NOT_FOUND "Cannot find the necessary functions to monitor"
+
 // Chart definitions
 #define NETDATA_EBPF_FAMILY "ebpf"
 #define NETDATA_EBPF_IP_FAMILY "ip"

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -363,7 +363,8 @@ static void ebpf_cachestat_free(ebpf_module_t *em)
 static void ebpf_cachestat_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
-    netdata_thread_cancel(*cachestat_threads.thread);
+    if (cachestat_threads.thread)
+        netdata_thread_cancel(*cachestat_threads.thread);
     ebpf_cachestat_free(em);
 }
 

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -1254,7 +1254,7 @@ static int ebpf_cachestat_set_internal_value()
     }
 
     if (!address.addr) {
-        error("Cannot find the necessary functions to monitor cachestat");
+        error("%s cachestat.", NETDATA_EBPF_DEFAULT_FNT_NOT_FOUND);
         return -1;
     }
 

--- a/collectors/ebpf.plugin/ebpf_cachestat.h
+++ b/collectors/ebpf.plugin/ebpf_cachestat.h
@@ -48,7 +48,9 @@ enum cachestat_counters {
 enum cachestat_account_dirty_pages {
     NETDATA_CACHESTAT_ACCOUNT_PAGE_DIRTY,
     NETDATA_CACHESTAT_SET_PAGE_DIRTY,
-    NETDATA_CACHESTAT_FOLIO_DIRTY
+    NETDATA_CACHESTAT_FOLIO_DIRTY,
+
+    NETDATA_CACHESTAT_ACCOUNT_DIRTY_END
 };
 
 enum cachestat_indexes {

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -338,7 +338,8 @@ static void ebpf_dcstat_free(ebpf_module_t *em )
 static void ebpf_dcstat_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
-    netdata_thread_cancel(*dcstat_threads.thread);
+    if (dcstat_threads.thread)
+        netdata_thread_cancel(*dcstat_threads.thread);
     ebpf_dcstat_free(em);
 }
 

--- a/collectors/ebpf.plugin/ebpf_disk.c
+++ b/collectors/ebpf.plugin/ebpf_disk.c
@@ -473,7 +473,8 @@ static void ebpf_disk_free(ebpf_module_t *em)
 static void ebpf_disk_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
-    netdata_thread_cancel(*disk_threads.thread);
+    if (disk_threads.thread)
+        netdata_thread_cancel(*disk_threads.thread);
     ebpf_disk_free(em);
 }
 

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -405,7 +405,8 @@ static void ebpf_fd_free(ebpf_module_t *em)
 static void ebpf_fd_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
-    netdata_thread_cancel(*fd_thread.thread);
+    if (fd_thread.thread)
+        netdata_thread_cancel(*fd_thread.thread);
     ebpf_fd_free(em);
 }
 

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -6,6 +6,9 @@
 static char *fd_dimension_names[NETDATA_FD_SYSCALL_END] = { "open", "close" };
 static char *fd_id_names[NETDATA_FD_SYSCALL_END] = { "do_sys_open",  "__close_fd" };
 
+static char *close_targets[NETDATA_EBPF_MAX_FD_TARGETS] = {"close_fd", "__close_fd"};
+static char *open_targets[NETDATA_EBPF_MAX_FD_TARGETS] = {"do_sys_openat2", "do_sys_open"};
+
 static netdata_syscall_stat_t fd_aggregated_data[NETDATA_FD_SYSCALL_END];
 static netdata_publish_syscall_t fd_publish_aggregated[NETDATA_FD_SYSCALL_END];
 
@@ -65,7 +68,7 @@ static inline void ebpf_fd_disable_probes(struct fd_bpf *obj)
     bpf_program__set_autoload(obj->progs.netdata_sys_open_kprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_sys_open_kretprobe, false);
     bpf_program__set_autoload(obj->progs.netdata_release_task_fd_kprobe, false);
-    if (running_on_kernel >= NETDATA_EBPF_KERNEL_5_11) {
+    if (!strcmp(fd_targets[NETDATA_FD_SYSCALL_CLOSE].name, close_targets[NETDATA_FD_CLOSE_FD])) {
         bpf_program__set_autoload(obj->progs.netdata___close_fd_kretprobe, false);
         bpf_program__set_autoload(obj->progs.netdata___close_fd_kprobe, false);
         bpf_program__set_autoload(obj->progs.netdata_close_fd_kprobe, false);
@@ -85,7 +88,7 @@ static inline void ebpf_fd_disable_probes(struct fd_bpf *obj)
  */
 static inline void ebpf_disable_specific_probes(struct fd_bpf *obj)
 {
-    if (running_on_kernel >= NETDATA_EBPF_KERNEL_5_11) {
+    if (!strcmp(fd_targets[NETDATA_FD_SYSCALL_CLOSE].name, close_targets[NETDATA_FD_CLOSE_FD])) {
         bpf_program__set_autoload(obj->progs.netdata___close_fd_kretprobe, false);
         bpf_program__set_autoload(obj->progs.netdata___close_fd_kprobe, false);
     } else {
@@ -121,7 +124,7 @@ static inline void ebpf_disable_trampoline(struct fd_bpf *obj)
  */
 static inline void ebpf_disable_specific_trampoline(struct fd_bpf *obj)
 {
-    if (running_on_kernel >= NETDATA_EBPF_KERNEL_5_11) {
+    if (!strcmp(fd_targets[NETDATA_FD_SYSCALL_CLOSE].name, close_targets[NETDATA_FD_CLOSE_FD])) {
         bpf_program__set_autoload(obj->progs.netdata___close_fd_fentry, false);
         bpf_program__set_autoload(obj->progs.netdata___close_fd_fexit, false);
     } else {
@@ -143,7 +146,7 @@ static void ebpf_set_trampoline_target(struct fd_bpf *obj)
     bpf_program__set_attach_target(obj->progs.netdata_sys_open_fexit, 0, fd_targets[NETDATA_FD_SYSCALL_OPEN].name);
     bpf_program__set_attach_target(obj->progs.netdata_release_task_fd_fentry, 0, EBPF_COMMON_FNCT_CLEAN_UP);
 
-    if (running_on_kernel >= NETDATA_EBPF_KERNEL_5_11) {
+    if (!strcmp(fd_targets[NETDATA_FD_SYSCALL_CLOSE].name, close_targets[NETDATA_FD_CLOSE_FD])) {
         bpf_program__set_attach_target(
             obj->progs.netdata_close_fd_fentry, 0, fd_targets[NETDATA_FD_SYSCALL_CLOSE].name);
         bpf_program__set_attach_target(obj->progs.netdata_close_fd_fexit, 0, fd_targets[NETDATA_FD_SYSCALL_CLOSE].name);
@@ -185,7 +188,7 @@ static int ebpf_fd_attach_probe(struct fd_bpf *obj)
     if (ret)
         return -1;
 
-    if (running_on_kernel >= NETDATA_EBPF_KERNEL_5_11) {
+    if (!strcmp(fd_targets[NETDATA_FD_SYSCALL_CLOSE].name, close_targets[NETDATA_FD_CLOSE_FD])) {
         obj->links.netdata_close_fd_kretprobe = bpf_program__attach_kprobe(obj->progs.netdata_close_fd_kretprobe, true,
                                                                            fd_targets[NETDATA_FD_SYSCALL_CLOSE].name);
         ret = libbpf_get_error(obj->links.netdata_close_fd_kretprobe);
@@ -241,9 +244,6 @@ static inline void ebpf_fd_fill_address(ebpf_addresses_t *address, char **target
  */
 static int ebpf_fd_set_target_values()
 {
-    static char *close_targets[NETDATA_EBPF_MAX_FD_TARGETS] = {"close_fd", "__close_fd"};
-    static char *open_targets[NETDATA_EBPF_MAX_FD_TARGETS] = {"do_sys_openat2", "do_sys_open"};
-
     ebpf_addresses_t address = {.function = NULL, .hash = 0, .addr = 0};
     ebpf_fd_fill_address(&address, close_targets);
 

--- a/collectors/ebpf.plugin/ebpf_fd.h
+++ b/collectors/ebpf.plugin/ebpf_fd.h
@@ -74,6 +74,7 @@ enum fd_syscalls {
     NETDATA_FD_SYSCALL_END
 };
 
+#define NETDATA_EBPF_MAX_FD_TARGETS 2
 
 void *ebpf_fd_thread(void *ptr);
 void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr);

--- a/collectors/ebpf.plugin/ebpf_fd.h
+++ b/collectors/ebpf.plugin/ebpf_fd.h
@@ -74,6 +74,13 @@ enum fd_syscalls {
     NETDATA_FD_SYSCALL_END
 };
 
+enum fd_close_syscall {
+    NETDATA_FD_CLOSE_FD,
+    NETDATA_FD___CLOSE_FD,
+
+    NETDATA_FD_CLOSE_END
+};
+
 #define NETDATA_EBPF_MAX_FD_TARGETS 2
 
 void *ebpf_fd_thread(void *ptr);

--- a/collectors/ebpf.plugin/ebpf_filesystem.c
+++ b/collectors/ebpf.plugin/ebpf_filesystem.c
@@ -367,7 +367,8 @@ static void ebpf_filesystem_free(ebpf_module_t *em)
 static void ebpf_filesystem_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
-    netdata_thread_cancel(*filesystem_threads.thread);
+    if (filesystem_threads.thread)
+        netdata_thread_cancel(*filesystem_threads.thread);
     ebpf_filesystem_free(em);
 }
 

--- a/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -183,7 +183,8 @@ static void ebpf_hardirq_free(ebpf_module_t *em)
 static void hardirq_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
-    netdata_thread_cancel(*hardirq_threads.thread);
+    if (hardirq_threads.thread)
+        netdata_thread_cancel(*hardirq_threads.thread);
     ebpf_hardirq_free(em);
 }
 

--- a/collectors/ebpf.plugin/ebpf_mdflush.c
+++ b/collectors/ebpf.plugin/ebpf_mdflush.c
@@ -92,7 +92,8 @@ static void mdflush_exit(void *ptr)
 static void mdflush_cleanup(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
-    netdata_thread_cancel(*mdflush_threads.thread);
+    if (mdflush_threads.thread)
+        netdata_thread_cancel(*mdflush_threads.thread);
     ebpf_mdflush_free(em);
 }
 

--- a/collectors/ebpf.plugin/ebpf_mount.c
+++ b/collectors/ebpf.plugin/ebpf_mount.c
@@ -269,7 +269,8 @@ static void ebpf_mount_free(ebpf_module_t *em)
 static void ebpf_mount_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
-    netdata_thread_cancel(*mount_thread.thread);
+    if (mount_thread.thread)
+        netdata_thread_cancel(*mount_thread.thread);
     ebpf_mount_free(em);
 }
 

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -745,7 +745,8 @@ static void ebpf_process_exit(void *ptr)
     pthread_mutex_lock(&ebpf_exit_cleanup);
     em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
-    pthread_cancel(*cgroup_thread.thread);
+    if (*cgroup_thread.thread)
+        pthread_cancel(*cgroup_thread.thread);
 }
 
 /*****************************************************************

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -745,7 +745,7 @@ static void ebpf_process_exit(void *ptr)
     pthread_mutex_lock(&ebpf_exit_cleanup);
     em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
-    if (*cgroup_thread.thread)
+    if (cgroup_thread.thread)
         pthread_cancel(*cgroup_thread.thread);
 }
 

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -329,7 +329,8 @@ static void ebpf_shm_free(ebpf_module_t *em)
 static void ebpf_shm_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
-    netdata_thread_cancel(*shm_threads.thread);
+    if (shm_threads.thread)
+        netdata_thread_cancel(*shm_threads.thread);
     ebpf_shm_free(em);
 }
 

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -647,7 +647,8 @@ static void ebpf_socket_free(ebpf_module_t *em )
 static void ebpf_socket_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
-    netdata_thread_cancel(*socket_threads.thread);
+    if (socket_threads.thread)
+        netdata_thread_cancel(*socket_threads.thread);
     ebpf_socket_free(em);
 }
 

--- a/collectors/ebpf.plugin/ebpf_softirq.c
+++ b/collectors/ebpf.plugin/ebpf_softirq.c
@@ -104,7 +104,8 @@ static void ebpf_softirq_free(ebpf_module_t *em)
 static void softirq_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
-    netdata_thread_cancel(*softirq_threads.thread);
+    if (softirq_threads.thread)
+        netdata_thread_cancel(*softirq_threads.thread);
     ebpf_softirq_free(em);
 }
 

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -268,7 +268,8 @@ static void ebpf_swap_free(ebpf_module_t *em)
 static void ebpf_swap_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
-    netdata_thread_cancel(*swap_threads.thread);
+    if (swap_threads.thread)
+        netdata_thread_cancel(*swap_threads.thread);
     ebpf_swap_free(em);
 }
 

--- a/collectors/ebpf.plugin/ebpf_sync.c
+++ b/collectors/ebpf.plugin/ebpf_sync.c
@@ -243,7 +243,8 @@ static void ebpf_sync_free(ebpf_module_t *em)
 static void ebpf_sync_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
-    netdata_thread_cancel(*sync_threads.thread);
+    if (sync_threads.thread)
+        netdata_thread_cancel(*sync_threads.thread);
     ebpf_sync_free(em);
 }
 

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -440,7 +440,8 @@ static void ebpf_vfs_free(ebpf_module_t *em)
 static void ebpf_vfs_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
-    netdata_thread_cancel(*vfs_threads.thread);
+    if (vfs_threads.thread)
+        netdata_thread_cancel(*vfs_threads.thread);
     ebpf_vfs_free(em);
 }
 

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -1183,13 +1183,14 @@ void ebpf_load_addresses(ebpf_addresses_t *fa, int fd)
         char *fcnt = procfile_lineword(ff, l, 2);
         uint32_t hash = simple_hash(fcnt);
         if (fa->hash == hash && !strcmp(fcnt, fa->function)) {
-            char addr[128];
-            snprintf(addr, 127, "0x%s", procfile_lineword(ff, l, 0));
-            fa->addr = (unsigned long) strtoul(addr, NULL, 16);
             if (fd > 0) {
+                char addr[128];
+                snprintf(addr, 127, "0x%s", procfile_lineword(ff, l, 0));
+                fa->addr = (unsigned long) strtoul(addr, NULL, 16);
                 uint32_t key = 0;
                 bpf_map_update_elem(fd, &key, &fa->addr, BPF_ANY);
-            }
+            } else
+                fa->addr = 1;
             break;
         }
     }

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -1160,7 +1160,8 @@ void ebpf_adjust_apps_cgroup(ebpf_module_t *em, netdata_ebpf_program_loaded_t mo
  * Helper used to get address from /proc/kallsym
  *
  * @param fa address structure
- * @param fd file descriptor loaded inside kernel.
+ * @param fd file descriptor loaded inside kernel. If a negative value is given
+ *           the function will load address and it won't update hash table.
  */
 void ebpf_load_addresses(ebpf_addresses_t *fa, int fd)
 {
@@ -1185,8 +1186,11 @@ void ebpf_load_addresses(ebpf_addresses_t *fa, int fd)
             char addr[128];
             snprintf(addr, 127, "0x%s", procfile_lineword(ff, l, 0));
             fa->addr = (unsigned long) strtoul(addr, NULL, 16);
-            uint32_t key = 0;
-            bpf_map_update_elem(fd, &key, &fa->addr, BPF_ANY);
+            if (fd > 0) {
+                uint32_t key = 0;
+                bpf_map_update_elem(fd, &key, &fa->addr, BPF_ANY);
+            }
+            break;
         }
     }
 


### PR DESCRIPTION
##### Summary
This PR is fixing some issues on RH 8.x family found while I was developing https://github.com/netdata/ebpf-co-re/pull/33 .

##### Test Plan
1. Clone branch and compile it.
2. Set `cachestat` and `fd` as `yes` in your `/etc/netdata/ebpf.d.conf`.
3. Start netdata.
4. After few seconds run next command:
```sh
curl http://localhost:19999/api/v1/charts?all | grep -E "(mem\.cachestat_ratio|filesystem.file_descriptor)"
```
You must have charts loaded and running.

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
This PR was tested on:

| Distribution | Kernel | Result |
|-------------------|-----------|-----------|
| Slackware Current  |     5.19.17     | [slacware_5_19.txt](https://github.com/netdata/netdata/files/10182007/slacware_5_19.txt) | 
| Arch Linux         |  6.0.10-arch2-1 | [arch_6_0.txt](https://github.com/netdata/netdata/files/10182008/arch_6_0.txt)|
| Ubuntu 22.04       |  5.15.0-33-generic | [ubuntu_5_15.txt](https://github.com/netdata/netdata/files/10182009/ubuntu_5_15.txt) |
| Alma 9             | 5.14.0-162.6.1.el9_1.x86_64  | [alma_5_14.txt](https://github.com/netdata/netdata/files/10189077/alma_5_14.txt)        |
| Debian 11          | 5.10.0-19-amd64 |[debian_5_10.txt](https://github.com/netdata/netdata/files/10189286/debian_5_10.txt) |
| Oracle 8.6         | 5.4.17-2136.313.6.el8uek.x86_64 | [oracle_5_4.txt](https://github.com/netdata/netdata/files/10189380/oracle_5_4.txt) |
| Alma 8.6           | 4.18.0-425.3.1.el8.x86_64 | [alma_4_18.txt](https://github.com/netdata/netdata/files/10189080/alma_4_18.txt) |
| Ubuntu 18.04       |  4.15.0-180-generic    | [ubuntu_4_15.txt](https://github.com/netdata/netdata/files/10189516/ubuntu_4_15.txt) |
| Slackware Current  |     4.14.290   | [slackware_4_14.txt](https://github.com/netdata/netdata/files/10189787/slackware_4_14.txt) | 
| CentOS 7.9         | 3.10.0-1160.71.1.el7.x86_64. | [centos_3_10.txt](https://github.com/netdata/netdata/files/10190456/centos_3_10.txt)|

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? eBPF.plugin
- Can they see the change or is it an under the hood? If they can see it, where?  Only on RH 8.x family
- How is the user impacted by the change?  They won't have more issues with fixed threads and they will have data collected correctly.
- What are there any benefits of the change? eBPF will run as expected on RH 8 family.
</details>
