### PR TITLE
Fix missing required package install of tar on FreeBSD

### DIFF
--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -715,6 +715,7 @@ declare -A pkg_tar=(
   ['gentoo']="app-arch/tar"
   ['clearlinux']="os-core-update"
   ['macos']="NOTREQUIRED"
+  ['freebsd']="NOTREQUIRED"
   ['default']="tar"
 )
 


### PR DESCRIPTION
##### Summary
There is no `tar` package to be installed on FreeBSD, when the `--ignore-installed` argument is passed on to `install-required-packages.sh`, so the script fails. This PR fixes this issue (BTW the script works correctly without the `--ignore-installed` argument, probably why we haven't noticed so far). 

##### Test Plan

Run `./packaging/installer/install-required-packages.sh -i netdata` before and after this PR on FreeBSD. 

