### PR TITLE
Switch to self-hosted infrastructure for RPM package distribution.

### DIFF
--- a/packaging/repoconfig/netdata-edge.repo.centos
+++ b/packaging/repoconfig/netdata-edge.repo.centos
@@ -11,7 +11,7 @@ priority=50
 
 [netdata-repoconfig]
 name=Netdata Repository Config
-baseurl=https://repo.netdata.cloud/repos/repocnfig/el/$releasever/$basearch
+baseurl=https://repo.netdata.cloud/repos/repoconfig/el/$releasever/$basearch
 repo_gpgcheck=1
 gpgcheck=1
 gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key

--- a/packaging/repoconfig/netdata-edge.repo.centos
+++ b/packaging/repoconfig/netdata-edge.repo.centos
@@ -1,9 +1,9 @@
 [netdata-edge]
 name=Netdata Edge
-baseurl=https://packagecloud.io/netdata/netdata-edge/el/$releasever/$basearch
+baseurl=https://repo.netdata.cloud/repos/edge/el/$releasever/$basearch
 repo_gpgcheck=1
-gpgcheck=0
-gpgkey=https://packagecloud.io/netdata/netdata-edge/gpgkey
+gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
@@ -11,10 +11,10 @@ priority=50
 
 [netdata-repoconfig]
 name=Netdata Repository Config
-baseurl=https://packagecloud.io/netdata/netdata-repoconfig/el/$releasever/$basearch
+baseurl=https://repo.netdata.cloud/repos/repocnfig/el/$releasever/$basearch
 repo_gpgcheck=1
-gpgcheck=0
-gpgkey=https://packagecloud.io/netdata/netdata-repoconfig/gpgkey
+gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt

--- a/packaging/repoconfig/netdata-edge.repo.fedora
+++ b/packaging/repoconfig/netdata-edge.repo.fedora
@@ -1,9 +1,9 @@
 [netdata-edge]
 name=Netdata Edge
-baseurl=https://packagecloud.io/netdata/netdata-edge/fedora/$releasever/$basearch
+baseurl=https://repo.netdata.cloud/repos/edge/fedora/$releasever/$basearch
 repo_gpgcheck=1
-gpgcheck=0
-gpgkey=https://packagecloud.io/netdata/netdata-edge/gpgkey
+gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
@@ -11,10 +11,10 @@ priority=50
 
 [netdata-repoconfig]
 name=Netdata Repository Config
-baseurl=https://packagecloud.io/netdata/netdata-repoconfig/fedora/$releasever/$basearch
+baseurl=https://repo.netdata.cloud/repos/repoconfig/fedora/$releasever/$basearch
 repo_gpgcheck=1
-gpgcheck=0
-gpgkey=https://packagecloud.io/netdata/netdata-repoconfig/gpgkey
+gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt

--- a/packaging/repoconfig/netdata-edge.repo.ol
+++ b/packaging/repoconfig/netdata-edge.repo.ol
@@ -1,9 +1,9 @@
 [netdata-edge]
 name=Netdata Edge
-baseurl=https://packagecloud.io/netdata/netdata-edge/ol/$releasever/$basearch
+baseurl=https://repo.netdata.cloud/repos/edge/ol/$releasever/$basearch
 repo_gpgcheck=1
-gpgcheck=0
-gpgkey=https://packagecloud.io/netdata/netdata-edge/gpgkey
+gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
@@ -11,10 +11,10 @@ priority=50
 
 [netdata-repoconfig]
 name=Netdata Repository Config
-baseurl=https://packagecloud.io/netdata/netdata-repoconfig/ol/$releasever/$basearch
+baseurl=https://repo.netdata.cloud/repos/repoconfig/ol/$releasever/$basearch
 repo_gpgcheck=1
-gpgcheck=0
-gpgkey=https://packagecloud.io/netdata/netdata-repoconfig/gpgkey
+gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt

--- a/packaging/repoconfig/netdata-edge.repo.suse
+++ b/packaging/repoconfig/netdata-edge.repo.suse
@@ -1,19 +1,19 @@
 [netdata-edge]
 name=Netdata Edge
-baseurl=https://packagecloud.io/netdata/netdata-edge/opensuse/$releasever/$basearch
+baseurl=https://repo.netdata.cloud/repos/edge/opensuse/$releasever/$basearch
 repo_gpgcheck=1
-pkg_gpgcheck=0
-gpgkey=https://packagecloud.io/netdata/netdata-edge/gpgkey
+pkg_gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
 enabled=1
 type=rpm-md
 autorefresh=1
 
 [netdata-repoconfig]
 name=Netdata Repoconfig
-baseurl=https://packagecloud.io/netdata/netdata-repoconfig/opensuse/$releasever/$basearch
+baseurl=https://repo.netdata.cloud/repos/repoconfig/opensuse/$releasever/$basearch
 repo_gpgcheck=1
-pkg_gpgcheck=0
-gpgkey=https://packagecloud.io/netdata/netdata-repoconfig/gpgkey
+pkg_gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
 enabled=1
 type=rpm-md
 autorefresh=1

--- a/packaging/repoconfig/netdata-repo.spec
+++ b/packaging/repoconfig/netdata-repo.spec
@@ -1,8 +1,8 @@
 %{?rhel:%global centos_ver %rhel}
 
 Name:           netdata-repo
-Version:        1
-Release:        2
+Version:        2
+Release:        1
 Summary:        Netdata stable repositories configuration.
 
 Group:          System Environment/Base
@@ -96,6 +96,8 @@ This package contains the official Netdata package repository configuration for 
 %endif
 
 %changelog
+* Wed Dec 7 2022 Austin Hemmelgarn <austin@netdata.cloud> 2-1
+- Switch to new hosting at repo.netdata.cloud.
 * Mon Jun 6 2022 Austin Hemmelgarn <austin@netdata.cloud> 1-2
 - Bump release to keep in sync with DEB package.
 * Mon Jun 14 2021 Austin Hemmelgarn <austin@netdata.cloud> 1-1

--- a/packaging/repoconfig/netdata.repo.centos
+++ b/packaging/repoconfig/netdata.repo.centos
@@ -1,9 +1,9 @@
 [netdata]
 name=Netdata
-baseurl=https://packagecloud.io/netdata/netdata/el/$releasever/$basearch
+baseurl=https://repo.netdata.cloud/repos/stable/el/$releasever/$basearch
 repo_gpgcheck=1
-gpgcheck=0
-gpgkey=https://packagecloud.io/netdata/netdata/gpgkey
+gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
@@ -11,10 +11,10 @@ priority=50
 
 [netdata-repoconfig]
 name=Netdata Repository Config
-baseurl=https://packagecloud.io/netdata/netdata-repoconfig/el/$releasever/$basearch
+baseurl=https://repo.netdata.cloud/repos/repoconfig/el/$releasever/$basearch
 repo_gpgcheck=1
-gpgcheck=0
-gpgkey=https://packagecloud.io/netdata/netdata-repoconfig/gpgkey
+gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt

--- a/packaging/repoconfig/netdata.repo.fedora
+++ b/packaging/repoconfig/netdata.repo.fedora
@@ -1,9 +1,9 @@
 [netdata]
 name=Netdata
-baseurl=https://packagecloud.io/netdata/netdata/fedora/$releasever/$basearch
+baseurl=https://repo.netdata.cloud/repos/stable/fedora/$releasever/$basearch
 repo_gpgcheck=1
-gpgcheck=0
-gpgkey=https://packagecloud.io/netdata/netdata/gpgkey
+gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
@@ -11,10 +11,10 @@ priority=50
 
 [netdata-repoconfig]
 name=Netdata Repository Config
-baseurl=https://packagecloud.io/netdata/netdata-repoconfig/fedora/$releasever/$basearch
+baseurl=https://repo.netdata.cloud/repos/repoconfig/fedora/$releasever/$basearch
 repo_gpgcheck=1
-gpgcheck=0
-gpgkey=https://packagecloud.io/netdata/netdata-repoconfig/gpgkey
+gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt

--- a/packaging/repoconfig/netdata.repo.ol
+++ b/packaging/repoconfig/netdata.repo.ol
@@ -1,9 +1,9 @@
 [netdata]
 name=Netdata
-baseurl=https://packagecloud.io/netdata/netdata/ol/$releasever/$basearch
+baseurl=https://repo.netdata.cloud/repos/stable/ol/$releasever/$basearch
 repo_gpgcheck=1
-gpgcheck=0
-gpgkey=https://packagecloud.io/netdata/netdata/gpgkey
+gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
@@ -11,10 +11,10 @@ priority=50
 
 [netdata-repoconfig]
 name=Netdata Repository Config
-baseurl=https://packagecloud.io/netdata/netdata-repoconfig/ol/$releasever/$basearch
+baseurl=https://repo.netdata.cloud/repos/repoconfig/ol/$releasever/$basearch
 repo_gpgcheck=1
-gpgcheck=0
-gpgkey=https://packagecloud.io/netdata/netdata-repoconfig/gpgkey
+gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
 enabled=1
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt

--- a/packaging/repoconfig/netdata.repo.suse
+++ b/packaging/repoconfig/netdata.repo.suse
@@ -1,19 +1,19 @@
 [netdata]
 name=Netdata
-baseurl=https://packagecloud.io/netdata/netdata/opensuse/$releasever/$basearch
+baseurl=https://repo.netdata.cloud/repos/stable/opensuse/$releasever/$basearch
 repo_gpgcheck=1
-pkg_gpgcheck=0
-gpgkey=https://packagecloud.io/netdata/netdata/gpgkey
+pkg_gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
 enabled=1
 type=rpm-md
 autorefresh=1
 
 [netdata-repoconfig]
 name=Netdata Repoconfig
-baseurl=https://packagecloud.io/netdata/netdata-repoconfig/opensuse/$releasever/$basearch
+baseurl=https://repo.netdata.cloud/repos/repoconfig/opensuse/$releasever/$basearch
 repo_gpgcheck=1
-pkg_gpgcheck=0
-gpgkey=https://packagecloud.io/netdata/netdata-repoconfig/gpgkey
+pkg_gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
 enabled=1
 type=rpm-md
 autorefresh=1


### PR DESCRIPTION
##### Summary

This updates our repository configuration packages to point to our new self-hosted repository infrastructure for our RPM packages. A secondary PR migrating DEB package infrastructure will be created later.

##### Test Plan

The repository configuration can be tested by copying the `netdata*.repo.*` file for the distribution to be tested on (`centos` for Alma/CentOS/RHEL/Rocky, `ol` for Oracle Linux, `fedora` for Fedora, `suse` for openSUSE) to the test system and putting it in the appropriate directory (`/etc/yum.repos.d` on most distros, or `/etc/zypp/repos.d` on openSUSE) with the correct name (just remove the `.<distro>` extension).

After setting up the repository configuration, refreshing metadata or attempting to install a package should result in a prompt about accepting a new GPG key for netdatabot.