### PR TITLE
fix docker host editable config

### DIFF
--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -196,12 +196,12 @@ docker rm -f netdata_tmp
 ```
 
 **`docker run`**: Use the `docker run` command, along with the following options, to start a new container. Note the
-changed `-v $(pwd)/netdataconfig/netdata:/etc/netdata:ro \` line from the recommended example above.
+changed `-v $(pwd)/netdataconfig/netdata:/etc/netdata \` line from the recommended example above.
 
 ```bash
 docker run -d --name=netdata \
   -p 19999:19999 \
-  -v $(pwd)/netdataconfig/netdata:/etc/netdata:ro \
+  -v $(pwd)/netdataconfig/netdata:/etc/netdata \
   -v netdatalib:/var/lib/netdata \
   -v netdatacache:/var/cache/netdata \
   -v /etc/passwd:/host/etc/passwd:ro \

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -49,10 +49,12 @@ if mountpoint -q /etc/netdata && [ -z "$(ls -A /etc/netdata)" ]; then
   cp -a /etc/netdata.stock/. /etc/netdata
 fi
 
-if mountpoint -q /etc/netdata && [ -w "/etc/netdata" ]; then
-  hostname > /etc/netdata/.container-hostname
-else
-  rm -f /etc/netdata/.container-hostname
+if [ -w "/etc/netdata" ]; then
+  if mountpoint -q /etc/netdata; then
+    hostname >/etc/netdata/.container-hostname
+  else
+    rm -f /etc/netdata/.container-hostname
+  fi
 fi
 
 if [ -n "${NETDATA_CLAIM_URL}" ] && [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ ! -f /var/lib/netdata/cloud.d/claimed_id ]; then

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -49,7 +49,7 @@ if mountpoint -q /etc/netdata && [ -z "$(ls -A /etc/netdata)" ]; then
   cp -a /etc/netdata.stock/. /etc/netdata
 fi
 
-if mountpoint -q /etc/netdata; then
+if mountpoint -q /etc/netdata && [ -w "/etc/netdata" ]; then
   hostname > /etc/netdata/.container-hostname
 else
   rm -f /etc/netdata/.container-hostname


### PR DESCRIPTION
##### Summary

Fixes #14103

##### Test Plan

Start container with read-only/not read-only `/etc/netdata` mount.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
