### PR TITLE
fix health emphemerality labels src

### DIFF
--- a/health/health.c
+++ b/health/health.c
@@ -1555,15 +1555,14 @@ void health_add_host_labels(void) {
     DICTIONARY *labels = localhost->rrdlabels;
     enum rrdlabel_source src;
 
-    src = appconfig_exists(&netdata_config, CONFIG_SECTION_HEALTH, "is ephemeral") ? RRDLABEL_SRC_CONFIG :
-                                                                                     RRDLABEL_SRC_AUTO;
-    int is_ephemeral = appconfig_get_boolean(&netdata_config, CONFIG_SECTION_HEALTH, "is ephemeral", CONFIG_BOOLEAN_NO);
-    rrdlabels_add(labels, "_is_ephemeral", is_ephemeral ? "true" : "false", src);
+    // The source should be CONF, but when it is set, these labels are exported by default ('send configured labels' in exporting.conf).
+    // Their export seems to break exporting to Graphite, see https://github.com/netdata/netdata/issues/14084.
 
-    src = appconfig_exists(&netdata_config, CONFIG_SECTION_HEALTH, "has unstable connection") ? RRDLABEL_SRC_CONFIG :
-                                                                                                RRDLABEL_SRC_AUTO;
+    int is_ephemeral = appconfig_get_boolean(&netdata_config, CONFIG_SECTION_HEALTH, "is ephemeral", CONFIG_BOOLEAN_NO);
+    rrdlabels_add(labels, "_is_ephemeral", is_ephemeral ? "true" : "false", RRDLABEL_SRC_AUTO);
+
     int has_unstable_connection = appconfig_get_boolean(&netdata_config, CONFIG_SECTION_HEALTH, "has unstable connection", CONFIG_BOOLEAN_NO);
-    rrdlabels_add(labels, "_has_unstable_connection", has_unstable_connection ? "true" : "false", src);
+    rrdlabels_add(labels, "_has_unstable_connection", has_unstable_connection ? "true" : "false", RRDLABEL_SRC_AUTO);
 }
 
 void health_thread_spawn(RRDHOST * host) {

--- a/health/health.c
+++ b/health/health.c
@@ -1553,12 +1553,17 @@ void *health_main(void *ptr) {
 
 void health_add_host_labels(void) {
     DICTIONARY *labels = localhost->rrdlabels;
+    enum rrdlabel_source src;
 
+    src = appconfig_exists(&netdata_config, CONFIG_SECTION_HEALTH, "is ephemeral") ? RRDLABEL_SRC_CONFIG :
+                                                                                     RRDLABEL_SRC_AUTO;
     int is_ephemeral = appconfig_get_boolean(&netdata_config, CONFIG_SECTION_HEALTH, "is ephemeral", CONFIG_BOOLEAN_NO);
-    rrdlabels_add(labels, "_is_ephemeral", is_ephemeral ? "true" : "false", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(labels, "_is_ephemeral", is_ephemeral ? "true" : "false", src);
 
+    src = appconfig_exists(&netdata_config, CONFIG_SECTION_HEALTH, "has unstable connection") ? RRDLABEL_SRC_CONFIG :
+                                                                                                RRDLABEL_SRC_AUTO;
     int has_unstable_connection = appconfig_get_boolean(&netdata_config, CONFIG_SECTION_HEALTH, "has unstable connection", CONFIG_BOOLEAN_NO);
-    rrdlabels_add(labels, "_has_unstable_connection", has_unstable_connection ? "true" : "false", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(labels, "_has_unstable_connection", has_unstable_connection ? "true" : "false", lbl_src);
 }
 
 void health_thread_spawn(RRDHOST * host) {

--- a/health/health.c
+++ b/health/health.c
@@ -1563,7 +1563,7 @@ void health_add_host_labels(void) {
     src = appconfig_exists(&netdata_config, CONFIG_SECTION_HEALTH, "has unstable connection") ? RRDLABEL_SRC_CONFIG :
                                                                                                 RRDLABEL_SRC_AUTO;
     int has_unstable_connection = appconfig_get_boolean(&netdata_config, CONFIG_SECTION_HEALTH, "has unstable connection", CONFIG_BOOLEAN_NO);
-    rrdlabels_add(labels, "_has_unstable_connection", has_unstable_connection ? "true" : "false", lbl_src);
+    rrdlabels_add(labels, "_has_unstable_connection", has_unstable_connection ? "true" : "false", src);
 }
 
 void health_thread_spawn(RRDHOST * host) {


### PR DESCRIPTION
##### Summary

Fixes: #14084

`_is_ephemeral` and `_has_unstable_connection` labels [src is config](https://github.com/netdata/netdata/blob/bf8f277746cf912b2e12c5c5248866cd126767b9/health/health.c#L1557-L1561)


Exporting configured labels is [enabled by default](https://github.com/netdata/netdata/blob/bf8f277746cf912b2e12c5c5248866cd126767b9/exporting/read_config.c#L256).

It causes problems even though the format is [correct](https://graphite.readthedocs.io/en/latest/tags.html#carbon) (🤷)

> my.series;tag1=value1;tag2=value2

I doubt we were going to export those labels anyway. I am not sure my fix is correct, but I think it is acceptable as a quick fix.

##### Test Plan

Build docker images, configure graphite exporter, and check exporter metrics.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
