### PR TITLE
expose ACLK SSL KeyLog interface for developers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -740,6 +740,10 @@ libmqttwebsockets_a_SOURCES = \
 
 libmqttwebsockets_a_CFLAGS = $(CFLAGS) -DMQTT_WSS_CUSTOM_ALLOC -DRBUF_CUSTOM_MALLOC -I$(srcdir)/aclk/helpers -I$(srcdir)/mqtt_websockets/c_rhash/include
 
+if MQTT_WSS_DEBUG
+libmqttwebsockets_a_CFLAGS += -DMQTT_WSS_DEBUG
+endif
+
 mqtt_websockets/src/mqtt_wss_client.$(OBJEXT) : CFLAGS += -Wno-unused-result
 
 ACLK_PROTO_DEFINITIONS = \

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -71,8 +71,10 @@ static void aclk_ssl_keylog_cb(const SSL *ssl, const char *line)
     (void)ssl;
     if (!ssl_log_file)
         ssl_log_file = fopen(ssl_log_filename, "a");
-    if (!ssl_log_file)
+    if (!ssl_log_file) {
+        error("Couldn't open ssl_log file (%s) for append.", ssl_log_filename);
         return;
+    }
     fputs(line, ssl_log_file);
     putc('\n', ssl_log_file);
     fflush(ssl_log_file);

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -61,6 +61,24 @@ struct aclk_shared_state aclk_shared_state = {
     .mqtt_shutdown_msg_rcvd = 0
 };
 
+#ifdef MQTT_WSS_DEBUG
+#include <openssl/ssl.h>
+#define DEFAULT_SSKEYLOGFILE_NAME "SSLKEYLOGFILE"
+const char *ssl_log_filename = NULL;
+FILE *ssl_log_file = NULL;
+static void aclk_ssl_keylog_cb(const SSL *ssl, const char *line)
+{
+    (void)ssl;
+    if (!ssl_log_file)
+        ssl_log_file = fopen(ssl_log_filename, "a");
+    if (!ssl_log_file)
+        return;
+    fputs(line, ssl_log_file);
+    putc('\n', ssl_log_file);
+    fflush(ssl_log_file);
+}
+#endif
+
 #if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_300
 OSSL_DECODER_CTX *aclk_dctx = NULL;
 EVP_PKEY *aclk_private_key = NULL;
@@ -681,6 +699,18 @@ void *aclk_main(void *ptr)
         goto exit;
     }
 
+#ifdef MQTT_WSS_DEBUG
+    size_t default_ssl_log_filename_size = strlen(netdata_configured_log_dir) + strlen(DEFAULT_SSKEYLOGFILE_NAME) + 2;
+    char *default_ssl_log_filename = mallocz(default_ssl_log_filename_size);
+    snprintfz(default_ssl_log_filename, default_ssl_log_filename_size, "%s/%s", netdata_configured_log_dir, DEFAULT_SSKEYLOGFILE_NAME);
+    ssl_log_filename = config_get(CONFIG_SECTION_CLOUD, "aclk ssl keylog file", default_ssl_log_filename);
+    freez(default_ssl_log_filename);
+    if (ssl_log_filename) {
+        error_report("SSLKEYLOGFILE active (path:\"%s\")!", ssl_log_filename);
+        mqtt_wss_set_SSL_CTX_keylog_cb(mqttwss_client, aclk_ssl_keylog_cb);
+    }
+#endif
+
     // Enable MQTT buffer growth if necessary
     // e.g. old cloud architecture clients with huge nodes
     // that send JSON payloads of 10 MB as single messages
@@ -716,6 +746,11 @@ void *aclk_main(void *ptr)
     } while (!netdata_exit);
 
     aclk_graceful_disconnect(mqttwss_client);
+
+#ifdef MQTT_WSS_DEBUG
+    if (ssl_log_file)
+        fclose(ssl_log_file);
+#endif
 
 exit_full:
 // Tear Down

--- a/configure.ac
+++ b/configure.ac
@@ -213,6 +213,12 @@ AC_ARG_ENABLE(
     [enable_ml_tests="yes"],
     [enable_ml_tests="no"]
 )
+AC_ARG_ENABLE(
+    [aclk_ssl_debug],
+    [AS_HELP_STRING([--enable-aclk-ssl-debug], [Enables possibility for SSL key logging @<:@default no@:>@])],
+    [aclk_ssl_debug="yes"],
+    [aclk_ssl_debug="no"]
+)
 
 # -----------------------------------------------------------------------------
 # Enforce building with C99, bail early if we can't.
@@ -711,6 +717,11 @@ if test "${with_bundled_protobuf}" != "no"; then
     if test "${with_bundled_protobuf}" == "detect" -a "${bundled_proto_avail}" == "yes"; then
         with_bundled_protobuf="yes"
     fi
+fi
+
+AM_CONDITIONAL([MQTT_WSS_DEBUG], [test "${aclk_ssl_debug}" = "yes"])
+if test "${aclk_ssl_debug}" = "yes"; then
+    AC_DEFINE([MQTT_WSS_DEBUG], [1], [ACLK SSL allow debugging])
 fi
 
 if test "${with_bundled_protobuf}" != "yes"; then


### PR DESCRIPTION
##### Summary
- not exposed trough installer on purpose - not meant to be used by users only by devs etc.
- allows netdata to be built in such way that developer can debug and inspect decrypted real traffic between agent and cloud
- this helps debug-ability (example if there is a suspected bug in MQTT parser we can capture the offending packet easily)
- while software like firefox allows this to be enabled by environment variable, I decided to be extra paranoid and make it a compile time optional thing

generates file in https://firefox-source-docs.mozilla.org/security/nss/legacy/key_log_format/index.html format that can be used with Wireshark and other tools to decrypt the captured traffic



##### Test Plan
Compile netdata with `./configure ... -enable-aclk-ssl-debug` then the file `SSLKEYLOGFILE` will be created on next connection to cloud. Use this file with wireshark and you should be able to see decrypted/plaintext traffic between your agent and cloud.
##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
