### PR TITLE
minor - fnc error_report should not clear errno

### DIFF
--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -389,7 +389,7 @@ char *find_and_replace(const char *src, const char *find, const char *replace, c
 #define UNUSED_FUNCTION(x) UNUSED_##x
 #endif
 
-#define error_report(x, args...) do { errno = 0; error(x, ##args); } while(0)
+#define error_report(x, args...) error(x, 0, ##args)
 
 // Taken from linux kernel
 #define BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2*!!(condition)]))

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -880,7 +880,7 @@ void error_limit_int(ERROR_LIMIT *erl, const char *prefix, const char *file __ma
     log_unlock();
 }
 
-void error_int(const char *prefix, const char *file __maybe_unused, const char *function __maybe_unused, const unsigned long line __maybe_unused, const char *fmt, ... ) {
+void error_int(const char *prefix, int p_errno, const char *file __maybe_unused, const char *function __maybe_unused, const unsigned long line __maybe_unused, const char *fmt, ... ) {
     // save a copy of errno - just in case this function generates a new error
     int __errno = errno;
 
@@ -912,7 +912,7 @@ void error_int(const char *prefix, const char *file __maybe_unused, const char *
     vfprintf( stderr, fmt, args );
     va_end( args );
 
-    if(__errno) {
+    if(p_errno && __errno) {
         char buf[1024];
         fprintf(stderr, " (errno %d, %s)\n", __errno, strerror_result(strerror_r(__errno, buf, 1023), buf));
         errno = 0;

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -115,8 +115,8 @@ typedef struct error_with_limit {
 #endif
 
 #define info(args...)    info_int(__FILE__, __FUNCTION__, __LINE__, ##args)
-#define infoerr(args...) error_int("INFO", __FILE__, __FUNCTION__, __LINE__, ##args)
-#define error(args...)   error_int("ERROR", __FILE__, __FUNCTION__, __LINE__, ##args)
+#define infoerr(args...) error_int("INFO", 1, __FILE__, __FUNCTION__, __LINE__, ##args)
+#define error(args...)   error_int("ERROR", 1, __FILE__, __FUNCTION__, __LINE__, ##args)
 #define error_limit(erl, args...)   error_limit_int(erl, "ERROR", __FILE__, __FUNCTION__, __LINE__, ##args)
 #define fatal(args...)   fatal_int(__FILE__, __FUNCTION__, __LINE__, ##args)
 #define fatal_assert(expr) ((expr) ? (void)(0) : fatal_int(__FILE__, __FUNCTION__, __LINE__, "Assertion `%s' failed", #expr))
@@ -124,7 +124,7 @@ typedef struct error_with_limit {
 void send_statistics(const char *action, const char *action_result, const char *action_data);
 void debug_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(4, 5);
 void info_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(4, 5);
-void error_int( const char *prefix, const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(5, 6);
+void error_int( const char *prefix, int p_errno, const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(6, 7);
 void error_limit_int(ERROR_LIMIT *erl, const char *prefix, const char *file __maybe_unused, const char *function __maybe_unused, unsigned long line __maybe_unused, const char *fmt, ... ) PRINTFLIKE(6, 7);;
 void fatal_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) NORETURN PRINTFLIKE(4, 5);
 void log_access( const char *fmt, ... ) PRINTFLIKE(1, 2);


### PR DESCRIPTION
##### Summary
Meaning of `error_report` function was to be able to log error for which `errno` has no meaning/effect.
Current implementation (`#define error_report(x, args...) do { errno = 0; error(x, ##args); } while(0)`) however does reset errno which I consider not terrible but definitely unfortunate and can lead to surprise (in case errno is later used in switch etc. and has been meanwhile reset by another call to error_report).

In general `error_report`  should behave like any other `errno` touching funcion -> only modify it on failure/error.

This modifies it to behave that way.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
