### PR TITLE
fix get_system_cpus()

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -288,7 +288,7 @@ static void puback_callback(uint16_t packet_id)
 
 static int read_query_thread_count()
 {
-    int threads = MIN(processors/2, 6);
+    int threads = MIN(get_system_cpus()/2, 6);
     threads = MAX(threads, 2);
     threads = config_get_number(CONFIG_SECTION_CLOUD, "query thread count", threads);
     if(threads < 1) {

--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -3359,7 +3359,7 @@ static void normalize_utilization(struct target *root) {
     // here we try to eliminate them by disabling childs processing either for specific dimensions
     // or entirely. Of course, either way, we disable it just a single iteration.
 
-    kernel_uint_t max_time = processors * time_factor * RATES_DETAIL;
+    kernel_uint_t max_time = get_system_cpus() * time_factor * RATES_DETAIL;
     kernel_uint_t utime = 0, cutime = 0, stime = 0, cstime = 0, gtime = 0, cgtime = 0, minflt = 0, cminflt = 0, majflt = 0, cmajflt = 0;
 
     if(global_utime > max_time) global_utime = max_time;
@@ -4897,7 +4897,7 @@ int main(int argc, char **argv) {
 #endif
 
     get_system_pid_max();
-    get_system_cpus();
+    get_system_cpus_uncached();
 
     parse_args(argc, argv);
 

--- a/collectors/proc.plugin/proc_stat.c
+++ b/collectors/proc.plugin/proc_stat.c
@@ -483,7 +483,7 @@ int do_proc_stat(int update_every, usec_t dt) {
            *time_in_state_filename = NULL, *schedstat_filename = NULL, *cpuidle_name_filename = NULL, *cpuidle_time_filename = NULL;
     static const RRDVAR_ACQUIRED *cpus_var = NULL;
     static int accurate_freq_avail = 0, accurate_freq_is_used = 0;
-    size_t cores_found = (size_t)processors;
+    size_t cores_found = (size_t)get_system_cpus();
 
     if(unlikely(do_cpu == -1)) {
         do_cpu                    = config_get_boolean("plugin:proc:/proc/stat", "cpu utilization", CONFIG_BOOLEAN_YES);
@@ -494,7 +494,7 @@ int do_proc_stat(int update_every, usec_t dt) {
         do_processes              = config_get_boolean("plugin:proc:/proc/stat", "processes running", CONFIG_BOOLEAN_YES);
 
         // give sane defaults based on the number of processors
-        if(unlikely(processors > 50)) {
+        if(unlikely(get_system_cpus() > 50)) {
             // the system has too many processors
             keep_per_core_fds_open = CONFIG_BOOLEAN_NO;
             do_core_throttle_count = CONFIG_BOOLEAN_NO;
@@ -510,7 +510,7 @@ int do_proc_stat(int update_every, usec_t dt) {
             do_cpu_freq = CONFIG_BOOLEAN_YES;
             do_cpuidle = CONFIG_BOOLEAN_YES;
         }
-        if(unlikely(processors > 24)) {
+        if(unlikely(get_system_cpus() > 24)) {
             // the system has too many processors
             keep_cpuidle_fds_open = CONFIG_BOOLEAN_NO;
         }

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -751,7 +751,7 @@ static void get_netdata_configured_variables() {
     // get various system parameters
 
     get_system_HZ();
-    get_system_cpus();
+    get_system_cpus_uncached();
     get_system_pid_max();
 
 

--- a/libnetdata/os.h
+++ b/libnetdata/os.h
@@ -48,8 +48,9 @@ int getsysctl_by_name(const char *name, void *ptr, size_t len);
 
 extern const char *os_type;
 
-extern int processors;
-long get_system_cpus(void);
+#define get_system_cpus() get_system_cpus_with_cache(true)
+#define get_system_cpus_uncached() get_system_cpus_with_cache(false)
+long get_system_cpus_with_cache(bool cache);
 
 extern pid_t pid_max;
 pid_t get_system_pid_max(void);

--- a/web/server/static/static-threaded.c
+++ b/web/server/static/static-threaded.c
@@ -502,7 +502,7 @@ void *socket_listen_main_static_threaded(void *ptr) {
     // 6 threads is the optimal value
     // since 6 are the parallel connections browsers will do
     // so, if the machine has more CPUs, avoid using resources unnecessarily
-    int def_thread_count = (processors > 6) ? 6 : processors;
+    int def_thread_count = (get_system_cpus() > 6) ? 6 : (int)get_system_cpus();
 
     if (!strcmp(config_get(CONFIG_SECTION_WEB, "mode", ""),"single-threaded")) {
                 info("Running web server with one thread, because mode is single-threaded");


### PR DESCRIPTION
`get_system_cpus()` is now caching its results by itself.

There are 2 macros defined:

- `get_system_cpus()`
- `get_system_cpus_uncached()`, which reads again the system cpus from the system

## Problems fixed:
- [x] External C plugins that were not initializing `netdata_configured_host_prefix` were failing to read the number of system of cpus prior to this PR (perf.plugin was such a case).
- [x] All calls to `get_system_cpus()` were non-cached. Parts of the code was using the global `processors` variable, some of the code the function `get_system_cpus()`. Now it is always cached, unless the code needs an non-cached version for whatever reason.

## Discussion
`get_system_cpus()` respects the host prefix. There are cases however that the code may need:

1. the current number of system cpus on the container or VM netdata is running
2. the current number of system cpus of the monitored host

The code currently does not distinguish between the two. Probably the best way would be to have 2 such functions. To make things more complex, for Darwin and FreeBSD the function call completely ignores the host prefix, so it always returns the cpus of the system netdata runs at.

For the moment I decided not to touch that part. The only possibility of these 2 processor counts to be different is when netdata is running in a container that monitors the parent host.

