### PR TITLE
ci: fix cgroup-parent name in packaging

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -160,7 +160,7 @@ jobs:
         id: docker-config
         shell: bash
         run: |
-          echo '{"cgroup-parent": "/actions_job", "experimental": true}' | sudo tee /etc/docker/daemon.json 2>/dev/null
+          echo '{"cgroup-parent": "/actions_job.slice", "experimental": true}' | sudo tee /etc/docker/daemon.json 2>/dev/null
           sudo service docker restart
       - name: Fetch images
         id: fetch-images

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -160,7 +160,7 @@ jobs:
         id: docker-config
         shell: bash
         run: |
-          echo '{"cgroup-parent": "/actions_job.slice", "experimental": true}' | sudo tee /etc/docker/daemon.json 2>/dev/null
+          echo '{"cgroup-parent": "actions-job.slice", "experimental": true}' | sudo tee /etc/docker/daemon.json 2>/dev/null
           sudo service docker restart
       - name: Fetch images
         id: fetch-images


### PR DESCRIPTION
##### Summary

I checked the logs and the error is

> cgroup-parent for systemd cgroup should be a valid slice named as "xxx.slice"

##### Test Plan

ci

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
