### PR TITLE
Enable retries for SSL_ERROR_WANT_READ

### DIFF
--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -310,7 +310,7 @@ int security_process_accept(SSL *ssl,int msg) {
                  int counter = 0;
                  while ((err = ERR_get_error()) != 0) {
                      ERR_error_string_n(err, buf, sizeof(buf));
-                     info("%d SSL Handshake error (%s) on socket %d ", counter++, ERR_error_string((long)SSL_get_error(ssl, test), NULL), sock);
+                     error("%d SSL Handshake error (%s) on socket %d", counter++, ERR_error_string((long)SSL_get_error(ssl, test), NULL), sock);
 			     }
                  return NETDATA_SSL_NO_HANDSHAKE;
 			 }

--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -925,11 +925,11 @@ ssize_t netdata_ssl_read(SSL *ssl, void *buf, size_t num) {
 
     int bytes, err, retries = 0;
 
-    //do {
+    do {
         bytes = SSL_read(ssl, buf, (int)num);
         err = SSL_get_error(ssl, bytes);
         retries++;
-    //} while (bytes <= 0 && (err == SSL_ERROR_WANT_READ));
+    } while (err == SSL_ERROR_WANT_READ);
 
     if(unlikely(bytes <= 0))
         error("SSL_read() returned %d bytes, SSL error %d", bytes, err);

--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -932,10 +932,10 @@ ssize_t netdata_ssl_read(SSL *ssl, void *buf, size_t num) {
         //} while (bytes <= 0 && err == SSL_ERROR_WANT_READ);
 
     if(unlikely(bytes <= 0)) {
-        error("SSL_write() returned %d bytes, SSL error %d", bytes, err);
         if (err == SSL_ERROR_WANT_WRITE || err == SSL_ERROR_WANT_READ) {
             bytes = 0;
-        }
+        } else
+            error("SSL_write() returned %d bytes, SSL error %d", bytes, err);
     }
 
     if(retries > 1)
@@ -951,21 +951,21 @@ ssize_t netdata_ssl_write(SSL *ssl, const void *buf, size_t num) {
     size_t total = 0;
 
     //do {
-        bytes = SSL_write(ssl, (uint8_t *)buf + total, (int)(num - total));
-        err = SSL_get_error(ssl, bytes);
-        retries++;
+    bytes = SSL_write(ssl, (uint8_t *)buf + total, (int)(num - total));
+    err = SSL_get_error(ssl, bytes);
+    retries++;
 
-        if(bytes > 0)
-            total += bytes;
+    if(bytes > 0)
+        total += bytes;
 
     //} while ((bytes <= 0 && (err == SSL_ERROR_WANT_WRITE)) || (bytes > 0 && total < num));
 
-        if(unlikely(bytes <= 0)) {
+    if(unlikely(bytes <= 0)) {
+        if (err == SSL_ERROR_WANT_WRITE || err == SSL_ERROR_WANT_READ) {
+            bytes = 0;
+        } else
             error("SSL_write() returned %d bytes, SSL error %d", bytes, err);
-            if (err == SSL_ERROR_WANT_WRITE || err == SSL_ERROR_WANT_READ) {
-                bytes = 0;
-            }
-        }
+    }
 
     if(retries > 1)
         error_limit(&erl, "SSL_write() retried %d times", retries);

--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -929,7 +929,7 @@ ssize_t netdata_ssl_read(SSL *ssl, void *buf, size_t num) {
         bytes = SSL_read(ssl, buf, (int)num);
         err = SSL_get_error(ssl, bytes);
         retries++;
-    } while (err == SSL_ERROR_WANT_READ);
+    } while (bytes <= 0 && err == SSL_ERROR_WANT_READ);
 
     if(unlikely(bytes <= 0))
         error("SSL_read() returned %d bytes, SSL error %d", bytes, err);

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -167,7 +167,7 @@ static bool receiver_read_uncompressed(struct receiver_state *r) {
 #endif
 
     int bytes_read = read_stream(r, r->read_buffer + r->read_len, sizeof(r->read_buffer) - r->read_len - 1);
-    if(unlikely(bytes_read < 0))
+    if(unlikely(bytes_read <= 0))
         return false;
 
     worker_set_metric(WORKER_RECEIVER_JOB_BYTES_READ, (NETDATA_DOUBLE)bytes_read);
@@ -219,7 +219,7 @@ static bool receiver_read_compressed(struct receiver_state *r) {
     int bytes_read = 0;
     do {
         int ret = read_stream(r, r->read_buffer + r->read_len + bytes_read, r->decompressor->signature_size - bytes_read);
-        if (unlikely(ret < 0))
+        if (unlikely(ret <= 0))
             return false;
 
         bytes_read += ret;
@@ -255,7 +255,7 @@ static bool receiver_read_compressed(struct receiver_state *r) {
         size_t remaining = compressed_message_size - start;
 
         int last_read_bytes = read_stream(r, &compressed[start], remaining);
-        if (unlikely(last_read_bytes < 0)) {
+        if (unlikely(last_read_bytes <= 0)) {
             internal_error(true, "read_stream() failed #2, with code %d", last_read_bytes);
             return false;
         }

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -167,7 +167,7 @@ static bool receiver_read_uncompressed(struct receiver_state *r) {
 #endif
 
     int bytes_read = read_stream(r, r->read_buffer + r->read_len, sizeof(r->read_buffer) - r->read_len - 1);
-    if(unlikely(bytes_read <= 0))
+    if(unlikely(bytes_read < 0))
         return false;
 
     worker_set_metric(WORKER_RECEIVER_JOB_BYTES_READ, (NETDATA_DOUBLE)bytes_read);
@@ -219,7 +219,7 @@ static bool receiver_read_compressed(struct receiver_state *r) {
     int bytes_read = 0;
     do {
         int ret = read_stream(r, r->read_buffer + r->read_len + bytes_read, r->decompressor->signature_size - bytes_read);
-        if (unlikely(ret <= 0))
+        if (unlikely(ret < 0))
             return false;
 
         bytes_read += ret;
@@ -255,7 +255,7 @@ static bool receiver_read_compressed(struct receiver_state *r) {
         size_t remaining = compressed_message_size - start;
 
         int last_read_bytes = read_stream(r, &compressed[start], remaining);
-        if (unlikely(last_read_bytes <= 0)) {
+        if (unlikely(last_read_bytes < 0)) {
             internal_error(true, "read_stream() failed #2, with code %d", last_read_bytes);
             return false;
         }

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -801,8 +801,10 @@ static ssize_t attempt_read(struct sender_state *s) {
             return ret;
         }
 
-        worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_SSL_ERROR);
-        rrdpush_sender_thread_close_socket(s->host);
+        if (ret == -1) {
+            worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_SSL_ERROR);
+            rrdpush_sender_thread_close_socket(s->host);
+        }
         return ret;
     }
 #endif

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1775,7 +1775,6 @@ ssize_t web_client_send_deflate(struct web_client *w)
         debug(D_WEB_CLIENT, "%llu: Did not send any bytes to the client (zhave = %zu, zsent = %zu, need to send = %zu).",
             w->id, w->response.zhave, w->response.zsent, w->response.zhave - w->response.zsent);
 
-        WEB_CLIENT_IS_DEAD(w);
     }
     else {
         debug(D_WEB_CLIENT, "%llu: Failed to send data to client.", w->id);
@@ -1828,7 +1827,6 @@ ssize_t web_client_send(struct web_client *w) {
     }
     else if(likely(bytes == 0)) {
         debug(D_WEB_CLIENT, "%llu: Did not send any bytes to the client.", w->id);
-        WEB_CLIENT_IS_DEAD(w);
     }
     else {
         debug(D_WEB_CLIENT, "%llu: Failed to send data to client.", w->id);

--- a/web/server/web_client_cache.c
+++ b/web/server/web_client_cache.c
@@ -14,7 +14,9 @@ static void web_client_reuse_ssl(struct web_client *w) {
             SSL_SESSION *session = SSL_get_session(w->ssl.conn);
             SSL *old = w->ssl.conn;
             w->ssl.conn = SSL_new(netdata_ssl_srv_ctx);
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_111
             if (SSL_SESSION_is_resumable(session))
+#endif
                 SSL_set_session(w->ssl.conn, session);
             SSL_free(old);
         }

--- a/web/server/web_client_cache.c
+++ b/web/server/web_client_cache.c
@@ -11,7 +11,12 @@
 static void web_client_reuse_ssl(struct web_client *w) {
     if (netdata_ssl_srv_ctx) {
         if (w->ssl.conn) {
-            SSL_clear(w->ssl.conn);
+            SSL_SESSION *session = SSL_get_session(w->ssl.conn);
+            SSL *old = w->ssl.conn;
+            w->ssl.conn = SSL_new(netdata_ssl_srv_ctx);
+            if (SSL_SESSION_is_resumable(session))
+                SSL_set_session(w->ssl.conn, session);
+            SSL_free(old);
         }
     }
 }


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR enables retries for `SSL_read` when the error returned is `SSL_ERROR_WANT_READ`.

This appears to help when a child attempts to connect and stream to a parent over a bad network line when using SSL.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Would like some feedback on testing this scenario.

1) Create a child and parent from master on different machines.
2) Establish between them an SSL streaming configuration.
3) Use [this utility](https://gist.github.com/denilsonsa/5176e1c9b6a119594ce0) to simulate a bad network connection on the parent. For my tests I used `sudo ./slow -d enp4s0f4u2u4 3G -l 600ms -p 10%` (replace enp4s0f4u2u4 with your network adapter).
4) Start child/parent and observe the logs. On my tests the child was throwing `SSL_read() returned -1 bytes, SSL error 2` (Error 2 is `SSL_ERROR_WANT_READ`). The parent side had similar errors, going into a connect/disconnect loop.
5) Apply the patch on both parent and child. Re-try and notice if now there is a stable streaming connection between them.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

I would like some more tests on this in case my setup is an isolated instance.

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
