### PR TITLE
heartbeat: don't log every discrepancy

### DIFF
--- a/libnetdata/clocks/clocks.c
+++ b/libnetdata/clocks/clocks.c
@@ -296,7 +296,9 @@ usec_t heartbeat_next(heartbeat_t *hb, usec_t tick) {
     if(unlikely(hb->randomness > tick / 2)) {
         // TODO: The heartbeat tick should be specified at the heartbeat_init() function
         usec_t tmp = (now_realtime_usec() * clock_realtime_resolution) % (tick / 2);
-        info("heartbeat randomness of %llu is too big for a tick of %llu - setting it to %llu", hb->randomness, tick, tmp);
+
+        error_limit_static_global_var(erl, 10, 0);
+        error_limit(&erl, "heartbeat randomness of %llu is too big for a tick of %llu - setting it to %llu", hb->randomness, tick, tmp);
         hb->randomness = tmp;
     }
 
@@ -322,11 +324,13 @@ usec_t heartbeat_next(heartbeat_t *hb, usec_t tick) {
 
     if(unlikely(now < next)) {
         errno = 0;
-        error("heartbeat clock: woke up %llu microseconds earlier than expected (can be due to the CLOCK_REALTIME set to the past).", next - now);
+        error_limit_static_global_var(erl, 10, 0);
+        error_limit(&erl, "heartbeat clock: woke up %llu microseconds earlier than expected (can be due to the CLOCK_REALTIME set to the past).", next - now);
     }
     else if(unlikely(now - next >  tick / 2)) {
         errno = 0;
-        error("heartbeat clock: woke up %llu microseconds later than expected (can be due to system load or the CLOCK_REALTIME set to the future).", now - next);
+        error_limit_static_global_var(erl, 10, 0);
+        error_limit(&erl, "heartbeat clock: woke up %llu microseconds later than expected (can be due to system load or the CLOCK_REALTIME set to the future).", now - next);
     }
 
     if(unlikely(!hb->realtime)) {


### PR DESCRIPTION
On overloaded systems, heartbeat logs way too much. This adds a limit of one log line every 10 seconds.