### PR TITLE
fix httpcheck alarms

### DIFF
--- a/health/health.d/httpcheck.conf
+++ b/health/health.d/httpcheck.conf
@@ -10,7 +10,7 @@ component: HTTP endpoint
      calc: ($this < 75) ? (0) : ($this)
     every: 5s
     units: up/down
-     info: average ratio of successful HTTP requests over the last minute (at least 75%)
+     info: percentage of successful HTTP requests to $label:url in the last minute
        to: silent
 
  template: httpcheck_web_service_bad_content
@@ -25,8 +25,7 @@ component: HTTP endpoint
      warn: $this >= 10 AND $this < 40
      crit: $this >= 40
     delay: down 5m multiplier 1.5 max 1h
-     info: average ratio of HTTP responses with unexpected content over the last 5 minutes
-  options: no-clear-notification
+     info: percentage of HTTP responses from $label:url with unexpected content in the last 5 minutes
        to: webmaster
 
  template: httpcheck_web_service_bad_status
@@ -41,8 +40,7 @@ component: HTTP endpoint
      warn: $this >= 10 AND $this < 40
      crit: $this >= 40
     delay: down 5m multiplier 1.5 max 1h
-     info: average ratio of HTTP responses with unexpected status over the last 5 minutes
-  options: no-clear-notification
+     info: percentage of HTTP responses from $label:url with unexpected status in the last 5 minutes
        to: webmaster
 
  template: httpcheck_web_service_timeouts
@@ -54,9 +52,13 @@ component: HTTP endpoint
    lookup: average -5m unaligned percentage of timeout
     every: 10s
     units: %
-     info: average ratio of HTTP request timeouts over the last 5 minutes
+     warn: $this >= 10 AND $this < 40
+     crit: $this >= 40
+    delay: down 5m multiplier 1.5 max 1h
+     info: percentage of timed-out HTTP requests to $label:url in the last 5 minutes
+       to: webmaster
 
- template: httpcheck_no_web_service_connections
+ template: httpcheck_web_service_no_connection
  families: *
        on: httpcheck.status
     class: Errors
@@ -65,48 +67,8 @@ component: HTTP endpoint
    lookup: average -5m unaligned percentage of no_connection
     every: 10s
     units: %
-     info: average ratio of failed requests during the last 5 minutes
-
-# combined timeout & no connection alarm
- template: httpcheck_web_service_unreachable
- families: *
-       on: httpcheck.status
-    class: Errors
-     type: Web Server
-component: HTTP endpoint
-     calc: ($httpcheck_no_web_service_connections >= $httpcheck_web_service_timeouts) ? ($httpcheck_no_web_service_connections) : ($httpcheck_web_service_timeouts)
-    units: %
-    every: 10s
-     warn: ($httpcheck_no_web_service_connections >= 10 OR $httpcheck_web_service_timeouts >= 10) AND ($httpcheck_no_web_service_connections < 40 OR $httpcheck_web_service_timeouts < 40)
-     crit: $httpcheck_no_web_service_connections >= 40 OR $httpcheck_web_service_timeouts >= 40
+     warn: $this >= 10 AND $this < 40
+     crit: $this >= 40
     delay: down 5m multiplier 1.5 max 1h
-     info: ratio of failed requests either due to timeouts or no connection over the last 5 minutes
-  options: no-clear-notification
-       to: webmaster
-
- template: httpcheck_1h_web_service_response_time
- families: *
-       on: httpcheck.responsetime
-    class: Latency
-     type: Other
-component: HTTP endpoint
-   lookup: average -1h unaligned of time
-    every: 30s
-    units: ms
-     info: average HTTP response time over the last hour
-
- template: httpcheck_web_service_slow
- families: *
-       on: httpcheck.responsetime
-    class: Latency
-     type: Web Server
-component: HTTP endpoint
-   lookup: average -3m unaligned of time
-    units: ms
-    every: 10s
-     warn: ($this > ($httpcheck_1h_web_service_response_time * 2) )
-     crit: ($this > ($httpcheck_1h_web_service_response_time * 3) )
-    delay: down 5m multiplier 1.5 max 1h
-     info: average HTTP response time over the last 3 minutes, compared to the average over the last hour
-  options: no-clear-notification
+     info: percentage of failed HTTP requests to $label:url in the last 5 minutes
        to: webmaster

--- a/health/health.d/httpcheck.conf
+++ b/health/health.d/httpcheck.conf
@@ -10,7 +10,7 @@ component: HTTP endpoint
      calc: ($this < 75) ? (0) : ($this)
     every: 5s
     units: up/down
-     info: percentage of successful HTTP requests to $label:url in the last minute
+     info: HTTP endpoint $label:url liveness status
        to: silent
 
  template: httpcheck_web_service_bad_content


### PR DESCRIPTION
##### Summary

This PR:

 - Deletes alarms that use other alarms in calculations (this doesn't work correctly when having more than one HTTP check).
 - Removes the `no-clear-notification` option.
 - Adds `warn` and `crit` for `timeout` and `no_connection` statuses (`bad_content` and `bad_status` alarms had them).
 - Adds the `url` label value to the info line.

##### Test Plan

Tested locally by copying the httpcheck.conf file.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
