### PR TITLE
use charts labels in portcheck alarms

### DIFF
--- a/health/health.d/portcheck.conf
+++ b/health/health.d/portcheck.conf
@@ -25,7 +25,7 @@ component: TCP endpoint
      warn: $this >= 10 AND $this < 40
      crit: $this >= 40
     delay: down 5m multiplier 1.5 max 1h
-     info: percentage of timed-out connections to host $label:host port $label:port in the last 5 minutes
+     info: percentage of timed-out TCP connections to host $label:host port $label:port in the last 5 minutes
        to: sysadmin
 
  template: portcheck_connection_fails
@@ -40,5 +40,5 @@ component: TCP endpoint
      warn: $this >= 10 AND $this < 40
      crit: $this >= 40
     delay: down 5m multiplier 1.5 max 1h
-     info: percentage of failed connections to host $label:host port $label:port in the last 5 minutes
+     info: percentage of failed TCP connections to host $label:host port $label:port in the last 5 minutes
        to: sysadmin

--- a/health/health.d/portcheck.conf
+++ b/health/health.d/portcheck.conf
@@ -10,7 +10,7 @@ component: TCP endpoint
      calc: ($this < 75) ? (0) : ($this)
     every: 5s
     units: up/down
-     info: average ratio of successful connections over the last minute (at least 75%)
+     info: TCP host $label:host port $label:port liveness status
        to: silent
 
  template: portcheck_connection_timeouts
@@ -25,7 +25,7 @@ component: TCP endpoint
      warn: $this >= 10 AND $this < 40
      crit: $this >= 40
     delay: down 5m multiplier 1.5 max 1h
-     info: average ratio of timeouts over the last 5 minutes
+     info: percentage of timed-out connections to host $label:host port $label:port in the last 5 minutes
        to: sysadmin
 
  template: portcheck_connection_fails
@@ -40,5 +40,5 @@ component: TCP endpoint
      warn: $this >= 10 AND $this < 40
      crit: $this >= 40
     delay: down 5m multiplier 1.5 max 1h
-     info: average ratio of failed connections over the last 5 minutes
+     info: percentage of failed connections to host $label:host port $label:port in the last 5 minutes
        to: sysadmin


### PR DESCRIPTION
##### Summary

This PR updates portcheck alarms info line.

##### Test Plan

Tested locally by copying the portcheck.conf file.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
