### PR TITLE
fix(packaging): add setuid for cgroup-network and ebpf.plugin in RPM

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -40,7 +40,7 @@ AutoReqProv: yes
 #
 # Conditional build:
 %bcond_without  systemd  # systemd
-%bcond_with     netns    # build with netns support (cgroup-network)
+%bcond_without  netns    # build with netns support (cgroup-network)
 
 %if 0%{?fedora} || 0%{?rhel} >= 7 || 0%{?suse_version} >= 1140
 %else

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -505,7 +505,9 @@ rm -rf "${RPM_BUILD_ROOT}"
 %endif
 
 # ebpf plugin
+%if 0%{?_have_ebpf}
 %attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/ebpf.plugin
+%endif
 
 # perf plugin
 # This should be CAP_PERFMON once RPM finally learns about it, but needs to be CAP_SYS_ADMIN for now.

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -504,6 +504,9 @@ rm -rf "${RPM_BUILD_ROOT}"
 %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/cgroup-network-helper.sh
 %endif
 
+# ebpf plugin
+%attr(4750,root,netdata) %{_libexecdir}/%{name}/plugins.d/ebpf.plugin
+
 # perf plugin
 # This should be CAP_PERFMON once RPM finally learns about it, but needs to be CAP_SYS_ADMIN for now.
 # %caps(cap_perfmon=ep) %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/perf.plugin


### PR DESCRIPTION
##### Summary

Fixes: #14132

This PR fixes the lack of setuid bit for:

 - cgroup-network
 - ebpf.plugin

In fact, it doesn't really fix #14132, but it is up to @Ferroin if we want to keep the issue open.

##### Test Plan

- Build an rpm package locally.
- Install netdata.
- Check cgroup-network and ebpf.plugin permissions.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
