### PR TITLE
Disable integration by default (eBPF <-> APPS)

### DIFF
--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -106,8 +106,7 @@ The eBPF collector also creates charts for each running application through an i
 [`apps.plugin`](/collectors/apps.plugin/README.md). This integration helps you understand how specific applications
 interact with the Linux kernel.
 
-If you want to _enable_ the integration with `apps.plugin` along with the above charts, change the setting `apps` to
-`yes`.
+If you want to enable `apps.plugin` integration, change the "apps" setting to "yes".
 
 ```conf
 [global]

--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -106,8 +106,8 @@ The eBPF collector also creates charts for each running application through an i
 [`apps.plugin`](/collectors/apps.plugin/README.md). This integration helps you understand how specific applications
 interact with the Linux kernel.
 
-If you want to _disable_ the integration with `apps.plugin` along with the above charts, change the setting `apps` to
-`no`.
+If you want to _enable_ the integration with `apps.plugin` along with the above charts, change the setting `apps` to
+`yes`.
 
 ```conf
 [global]

--- a/collectors/ebpf.plugin/ebpf.d.conf
+++ b/collectors/ebpf.plugin/ebpf.d.conf
@@ -17,7 +17,7 @@
 #
 [global]
     ebpf load mode = entry
-    apps = yes
+    apps = no
     cgroups = no
     update every = 5
     pid table size = 32768


### PR DESCRIPTION
##### Summary
Fixes #14138 

This PR is disabling integration between eBPF.plugin and apps.plugin by default avoiding overloading servers with huge sample of process running.

##### Test Plan

1. Compile this branch and start `netdata` using stock files, you should not have `ebpf.plugin` and `apps` integration enabled. As consequence of this eBPF plugin will allocate less memory and use less resources from computers.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
