### PR TITLE
MQTT5 Topic Alias

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -733,9 +733,12 @@ libmqttwebsockets_a_SOURCES = \
     mqtt_websockets/c-rbuf/include/ringbuffer.h \
     mqtt_websockets/c-rbuf/src/ringbuffer_internal.h \
     mqtt_websockets/MQTT-C/src/mqtt.c \
-    mqtt_websockets/MQTT-C/include/mqtt.h
+    mqtt_websockets/MQTT-C/include/mqtt.h \
+    mqtt_websockets/c_rhash/src/c_rhash.c \
+    mqtt_websockets/c_rhash/include/c_rhash.h \
+    mqtt_websockets/c_rhash/src/c_rhash_internal.h
 
-libmqttwebsockets_a_CFLAGS = $(CFLAGS) -DMQTT_WSS_CUSTOM_ALLOC -DRBUF_CUSTOM_MALLOC -I$(srcdir)/aclk/helpers
+libmqttwebsockets_a_CFLAGS = $(CFLAGS) -DMQTT_WSS_CUSTOM_ALLOC -DRBUF_CUSTOM_MALLOC -I$(srcdir)/aclk/helpers -I$(srcdir)/mqtt_websockets/c_rhash/include
 
 if MQTT_WSS_DEBUG
 libmqttwebsockets_a_CFLAGS += -DMQTT_WSS_DEBUG

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -385,6 +385,10 @@ static inline void mqtt_connected_actions(mqtt_wss_client client)
     aclk_rcvd_cloud_msgs = 0;
     aclk_connection_counter++;
 
+    aclk_topic_cache_iter_t iter = ACLK_TOPIC_CACHE_ITER_T_INITIALIZER;
+    while ((topic = (char*)aclk_topic_cache_iterate(&iter)) != NULL)
+        mqtt_wss_set_topic_alias(client, topic);
+
     aclk_send_agent_connection_update(client, 1);
 }
 

--- a/aclk/aclk_util.c
+++ b/aclk/aclk_util.c
@@ -308,6 +308,24 @@ const char *aclk_get_topic(enum aclk_topics topic)
 }
 
 /*
+ * Allows iterating all topics in topic cache without
+ * having to resort to callbacks. 
+ */
+
+const char *aclk_topic_cache_iterate(aclk_topic_cache_iter_t *iter)
+{
+    if (!aclk_topic_cache) {
+        error("Topic cache not initialized when %s was called.", __FUNCTION__);
+        return NULL;
+    }
+
+    if (*iter >= aclk_topic_cache_items)
+        return NULL;
+
+    return aclk_topic_cache[(*iter)++]->topic;
+}
+
+/*
  * TBEB with randomness
  *
  * @param reset 1 - to reset the delay,

--- a/aclk/aclk_util.h
+++ b/aclk/aclk_util.h
@@ -93,9 +93,13 @@ enum aclk_topics {
     ACLK_TOPICID_CTXS_UPDATED          = 20
 };
 
+typedef size_t aclk_topic_cache_iter_t;
+#define ACLK_TOPIC_CACHE_ITER_T_INITIALIZER (0)
+
 const char *aclk_get_topic(enum aclk_topics topic);
 int aclk_generate_topic_cache(struct json_object *json);
 void free_topic_cache(void);
+const char *aclk_topic_cache_iterate(aclk_topic_cache_iter_t *iter);
 // TODO
 // aclk_topics_reload //when claim id changes
 


### PR DESCRIPTION
##### Summary
Fixes bug discovered which was reason for (https://github.com/netdata/netdata/pull/14145) - fixes are part of last commits so that is clear to reviewers what was changed since (#14067):
- rx topic alias list was not cleared on reconnect upon failure (according to MQTT spec topic aliases are not to be persisted across connection even if same session is continued
- this in combination with us not allowing topic alias reassignment caused agent not being able to reconnect

Reintroduces https://github.com/netdata/netdata/pull/14067

Automated tests are being worked on to prevent such problems in future.

##### Test Plan
This has to be tested extensively as it introduces wide changes to the mqtt_websockets incl. both parsers and message generators.
- test connection is stable
- test connection is eventually established after `ss -K dst IP_YOUR_AGENT_USES_FOR_CLOUD_CONNECTION`

Testing properties parser for datatypes which EMQX doesn't actually use can be done using:
`mosquitto_pub -t "test" -m "umbakarna" --property PUBLISH user-property "daewjaedon" "maybe"` while running mqtt_websockets test application. This way all of the parser options can be verified even though cloud actually doesn't use them.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
