### PR TITLE
Populate field values in send_slack() for Mattermost

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1480,10 +1480,12 @@ send_slack() {
                     "fields": [
                         {
                             "title": "${chart}",
+                            "value": "chart",
                             "short": true
                         },
                         {
                             "title": "${family}",
+                            "value": "family",
                             "short": true
                         }
                     ],


### PR DESCRIPTION
This fixes an issue when using Slack-compatible webhooks in Mattermost where the message would display "null" below the titles.

Closes #14152 