### PR TITLE
fix nodejs app detection

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -378,7 +378,7 @@ sidekiq: *sidekiq*
 java: java
 ipfs: ipfs
 
-node: node*
+node: node
 factorio: factorio
 
 p4: p4*


### PR DESCRIPTION
##### Summary

Fixes: #14154

I think the assumption in https://github.com/netdata/netdata/pull/5962 was wrong, `proc/PID/comm` is always `node`.

##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
