### PR TITLE
Finish switch to self-hosted RPM repositories.

### DIFF
--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -81,6 +81,10 @@ operating systems.
     os="General Linux with one-line installer (recommended)"
     svg="linux" />
   <InstallBox
+    to="/docs/agent/packaging/installer/methods/packages"
+    os="Native DEB/RPM packages for Linux"
+    svg="linux" />
+  <InstallBox
     to="/docs/agent/packaging/docker"
     os="Run with Docker"
     svg="docker" />

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -28,8 +28,10 @@ KICKSTART_SOURCE="$(
 PACKAGES_SCRIPT="https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh"
 PATH="${PATH}:/usr/local/bin:/usr/local/sbin"
 PUBLIC_CLOUD_URL="https://app.netdata.cloud"
-REPOCONFIG_URL_PREFIX="https://packagecloud.io/netdata/netdata-repoconfig/packages"
-REPOCONFIG_VERSION="1-2"
+REPOCONFIG_DEB_URL_PREFIX="https://packagecloud.io/netdata/netdata-repoconfig/packages"
+REPOCONFIG_DEB_VERSION="1-2"
+REPOCONFIG_RPM_URL_PREFIX="https://repo.netdata.cloud/repos/repoconfig/"
+REPOCONFIG_RPM_VERSION="2-1"
 START_TIME="$(date +%s)"
 STATIC_INSTALL_ARCHES="x86_64 armv7l aarch64 ppc64le"
 TELEMETRY_URL="https://posthog.netdata.cloud/capture/"
@@ -1468,8 +1470,17 @@ try_package_install() {
   fi
 
   repoconfig_name="netdata-repo${release}"
-  repoconfig_file="${repoconfig_name}${pkg_vsep}${REPOCONFIG_VERSION}${pkg_suffix}.${pkg_type}"
-  repoconfig_url="${REPOCONFIG_URL_PREFIX}/${repo_prefix}/${repoconfig_file}/download.${pkg_type}"
+
+  case "${pkg_type}" in
+    deb)
+      repoconfig_file="${repoconfig_name}${pkg_vsep}${REPOCONFIG_DEB_VERSION}${pkg_suffix}.${pkg_type}"
+      repoconfig_url="${REPOCONFIG_DEB_URL_PREFIX}/${repo_prefix}/${repoconfig_file}/download.${pkg_type}"
+      ;;
+    rpm)
+      repoconfig_file="${repoconfig_name}${pkg_vsep}${REPOCONFIG_RPM_VERSION}${pkg_suffix}.${pkg_type}"
+      repoconfig_url="${REPOCONFIG_RPM_URL_PREFIX}/${repo_prefix}/${repoconfig_file}/${repoconfig_file}"
+      ;;
+  esac
 
   if ! pkg_installed "${repoconfig_name}"; then
     progress "Checking for availability of repository configuration package."

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -30,7 +30,7 @@ PATH="${PATH}:/usr/local/bin:/usr/local/sbin"
 PUBLIC_CLOUD_URL="https://app.netdata.cloud"
 REPOCONFIG_DEB_URL_PREFIX="https://packagecloud.io/netdata/netdata-repoconfig/packages"
 REPOCONFIG_DEB_VERSION="1-2"
-REPOCONFIG_RPM_URL_PREFIX="https://repo.netdata.cloud/repos/repoconfig/"
+REPOCONFIG_RPM_URL_PREFIX="https://repo.netdata.cloud/repos/repoconfig"
 REPOCONFIG_RPM_VERSION="2-1"
 START_TIME="$(date +%s)"
 STATIC_INSTALL_ARCHES="x86_64 armv7l aarch64 ppc64le"
@@ -1478,7 +1478,7 @@ try_package_install() {
       ;;
     rpm)
       repoconfig_file="${repoconfig_name}${pkg_vsep}${REPOCONFIG_RPM_VERSION}${pkg_suffix}.${pkg_type}"
-      repoconfig_url="${REPOCONFIG_RPM_URL_PREFIX}/${repo_prefix}/${repoconfig_file}/${repoconfig_file}"
+      repoconfig_url="${REPOCONFIG_RPM_URL_PREFIX}/${repo_prefix}/${SYSARCH}/${repoconfig_file}"
       ;;
   esac
 

--- a/packaging/installer/methods/packages.md
+++ b/packaging/installer/methods/packages.md
@@ -33,7 +33,7 @@ Within each top level group of repositories, there are directories for each supp
 - `opensuse`: Is for openSUSE and binary compatible distros.
 
 Under each of those directories is a directory for each supported release of that distribution, and under that a
-directory for each supported CPU architecture which contains tthe actual repository.
+directory for each supported CPU architecture which contains the actual repository.
 
 For example, for stable release packages for RHEL 9 on 64-bit x86, the full URL for the repository would be
 https://repo.netdata.cloud/repos/stable/el/9/x86\_64/

--- a/packaging/installer/methods/packages.md
+++ b/packaging/installer/methods/packages.md
@@ -1,0 +1,47 @@
+<!--
+title: "Install Netdata using native DEB/RPM packages."
+description: "Instructions for how to install Netdata using native DEB or RPM packages."
+custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/methods/packages.md
+-->
+
+# Installing Netdata using native DEB or RPM packages.
+
+For most common Linux distributions that use either DEB or RPM packages, Netdata provides pre-built native packages
+for current releases in-line with our [official platform support policy](/packaging/PLATFORM_SUPPORT.md). These
+packages will be used by default when attempting to install on a supported platform using our [kickstart.sh
+installer script](/packaging/installer/methods/kickstart.md).
+
+When using the kickstart script, you can force usage of native DEB or RPM packages by passing the option
+`--native-only` when invoking the script. This will cause it to only attempt to use native packages for the install,
+and fail if it cannot do so.
+
+## Manual setup of RPM packages.
+
+Netdata’s official RPM repositories are hosted at https://repo.netdata.cloud/repos. We provide four groups of
+repositories at that top level:
+
+- `stable`: Contains packages for stable releases of the Netdata Agent.
+- `edge`: Contains packages for nightly builds of the Netdata Agent.
+- `repoconfig`: Provides packages that set up configuration files for using the other repositories.
+- `devel`: Is used for one-off development builds of the Netdata Agent, and can simply be ignored by users.
+
+Within each top level group of repositories, there are directories for each supported group of distributions:
+
+- `el`: Is for Red Hat Enterprise Linux and binary compatible distros, such as CentOS, Alma Linux, and Rocky Linux.
+- `fedora`: Is for Fedora and binary compatible distros.
+- `ol`: Is for Oracle Linux and binary compatible distros.
+- `opensuse`: Is for openSUSE and binary compatible distros.
+
+Under each of those directories is a directory for each supported release of that distribution, and under that a
+directory for each supported CPU architecture which contains tthe actual repository.
+
+For example, for stable release packages for RHEL 9 on 64-bit x86, the full URL for the repository would be
+https://repo.netdata.cloud/repos/stable/el/9/x86\_64/
+
+Our RPM packages and repository metadata are signed using a GPG key with a user name of ‘Netdatabot’. The
+current key fingerprint is `6588FDD7B14721FE7C3115E6F9177B5265F56346`
+
+If you are explicitly configuring a system to use our repositories, the recommended setup is to download the
+appropriate repository configuration package from https://repo.netdata.cloud/repos/repoconfig and install it
+directly on the target system using the system package manager. This will ensure any packages needed to use the
+repository are also installed, and will help enable a seamless transition if we ever need to change our infrastructure.


### PR DESCRIPTION
##### Summary

Followup to #14100, this updates the kickstart script to use the new infrastructure, and adds documentation about how to manually set up our RPM repositories.

##### Test Plan

Running the kickstart script from this PR on a platform we provide native for with the `--native-only` switch should correctly install the agent.

##### Additional Information

The new documentation added by this PR will be further expanded when we have working repositories for DEB packages on the new infrastructure.