### PR TITLE
Add analytics entries for health's disabled and silenced alerts

### DIFF
--- a/daemon/analytics.h
+++ b/daemon/analytics.h
@@ -18,7 +18,7 @@
 #define ANALYTICS_MAX_DASHBOARD_HITS 255
 
 /* Needed to calculate the space needed for parameters */
-#define ANALYTICS_NO_OF_ITEMS 39
+#define ANALYTICS_NO_OF_ITEMS 42
 
 struct analytics_data {
     char *netdata_config_stream_enabled;
@@ -60,6 +60,9 @@ struct analytics_data {
     char *netdata_config_use_private_registry;
     char *netdata_config_oom_score;
     char *netdata_prebuilt_distro;
+    char *netdata_health_enabled;
+    char *netdata_health_conf_alarms_disabled;
+    char *netdata_health_alarms_silenced;
 
     size_t data_length;
 
@@ -81,6 +84,7 @@ void analytics_log_dashboard(void);
 void analytics_gather_mutable_meta_data(void);
 void analytics_report_oom_score(long long int score);
 void get_system_timezone(void);
+void analytics_log_conf_disabled_alarm(char *name);
 
 extern struct analytics_data analytics_data;
 

--- a/daemon/anonymous-statistics.sh.in
+++ b/daemon/anonymous-statistics.sh.in
@@ -68,7 +68,9 @@ NETDATA_IS_PRIVATE_REGISTRY="${39}"
 NETDATA_USE_PRIVATE_REGISTRY="${40}"
 NETDATA_CONFIG_OOM_SCORE="${41}"
 NETDATA_PREBUILT_DISTRO="${42}"
-
+NETDATA_HEALTH_ENABLED="${43}"
+NETDATA_HEALTH_CONF_ALARMS_DISABLED="${44}"
+NETDATA_HEALTH_ALARMS_SILENCED="${45}"
 
 # define body of request to be sent
 REQ_BODY="$(cat << EOF
@@ -157,7 +159,10 @@ REQ_BODY="$(cat << EOF
         "mirrored_host_count": ${NETDATA_MIRRORED_HOST_COUNT},
         "mirrored_hosts_reachable": ${NETDATA_MIRRORED_HOSTS_REACHABLE},
         "mirrored_hosts_unreachable": ${NETDATA_MIRRORED_HOSTS_UNREACHABLE},
-        "exporting_connectors": ${NETDATA_EXPORTING_CONNECTORS}
+        "exporting_connectors": ${NETDATA_EXPORTING_CONNECTORS},
+        "health_enabled": ${NETDATA_HEALTH_ENABLED},
+        "health_conf_alarms_disabled": ${NETDATA_HEALTH_CONF_ALARMS_DISABLED},
+        "health_alarms_silenced": ${NETDATA_HEALTH_ALARMS_SILENCED}
   }
 }
 EOF

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -582,6 +582,7 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->alarm = string_dup(rc->name);
                 ignore_this = 0;
             } else {
+                analytics_log_conf_disabled_alarm(value);
                 rc = NULL;
             }
         }
@@ -628,6 +629,7 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->template_key = string_dup(rt->name);
                 ignore_this = 0;
             } else {
+                analytics_log_conf_disabled_alarm(value);
                 rt = NULL;
             }
         }


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Adds 3 new PH attributes:

* `health_enabled`

true/false depending on whether health is enabled or not

* `health_conf_alarms_disabled`

A list of alerts disabled via the configuration option `enabled alarms`.

* health_alarms_silenced

A list of alerts silenced.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Run an agent with D_ANALYTICS debug. After 2 minutes, it will print in `debug.log` these 3 new attributes.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
