### PR TITLE
Fix race on query thread startup

### DIFF
--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -359,14 +359,13 @@ void aclk_query_threads_start(struct aclk_query_threads *query_threads, mqtt_wss
     query_threads->thread_list = callocz(query_threads->count, sizeof(struct aclk_query_thread));
     for (int i = 0; i < query_threads->count; i++) {
         query_threads->thread_list[i].idx = i; //thread needs to know its index for statistics
+        query_threads->thread_list[i].client = client;
 
         if(unlikely(snprintfz(thread_name, TASK_LEN_MAX, "%s_%d", ACLK_QUERY_THREAD_NAME, i) < 0))
             error("snprintf encoding error");
         netdata_thread_create(
             &query_threads->thread_list[i].thread, thread_name, NETDATA_THREAD_OPTION_JOINABLE, aclk_query_main_thread,
             &query_threads->thread_list[i]);
-
-        query_threads->thread_list[i].client = client;
     }
 }
 


### PR DESCRIPTION
##### Summary
I could not reproduce this problem personally but @ktsaou reported at agent startup he somethimes gets this:
```
Core was generated by `/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x000055c6b4887457 in mqtt_wss_publish5 (client=0x0, topic=0x55c7000e4b20 "/agent/68d47046-61e8-11ed-a3d8-ceb8dac27b23/outbound/v1/nodeinstance/connection", topic_free=0x0, msg=0x55c721bcfb00, msg_free=0x55c6b47542aa <freez_aclk_publish5a>, msg_len=168, publish_flags=1 '\001', packet_id=0x7f6bc4dc074e) at mqtt_websockets/src/mqtt_wss_client.c:1433
1433	    if (!client->internal_mqtt) {
[Current thread is 1 (Thread 0x7f6bc4dc1700 (LWP 2844291))]
(gdb) bt
#0  0x000055c6b4887457 in mqtt_wss_publish5 (client=0x0, topic=0x55c7000e4b20 "/agent/68d47046-61e8-11ed-a3d8-ceb8dac27b23/outbound/v1/nodeinstance/connection", topic_free=0x0, msg=0x55c721bcfb00, msg_free=0x55c6b47542aa <freez_aclk_publish5a>, msg_len=168, publish_flags=1 '\001', packet_id=0x7f6bc4dc074e)
    at mqtt_websockets/src/mqtt_wss_client.c:1433
#1  0x000055c6b475437f in aclk_send_bin_message_subtopic_pid (client=0x0, 
    msg=0x55c721bcfb00 "\n$68d47046-61e8-11ed-a3d8-ceb8dac27b23\022$fa41b4b2-f189-4bbd-89bb-75ff11ce0dcb \001(\222\275\204\260\365\206\374\002\062\f\b\254\375\203\235\006\020ؼ\252\222\003H\001R\b\n\004json\020\002R\v\n\005proto\020\001\030\001R\006\n\002ml\020\001R\b\n\002mc\020\001\030\001R\t\n\003ctx\020\001\030\001R\v\n\005funcs\020\001\030\001Q", msg_len=168, subtopic=ACLK_TOPICID_NODE_CONN, msgname=0x55c6b4ad373c "UpdateNodeInstanceConnection") at aclk/aclk_tx_msgs.c:39
#2  0x000055c6b47512b0 in send_bin_msg (query_thr=0x55c7117ca838, query=0x55c71c519850) at aclk/aclk_query.c:255
#3  0x000055c6b4751513 in aclk_query_process_msg (query_thr=0x55c7117ca838, query=0x55c71c519850) at aclk/aclk_query.c:296
#4  0x000055c6b47515cf in aclk_query_process_msgs (query_thr=0x55c7117ca838) at aclk/aclk_query.c:318
#5  0x000055c6b475165a in aclk_query_main_thread (ptr=0x55c7117ca838) at aclk/aclk_query.c:340
#6  0x000055c6b444c42e in thread_start (ptr=0x55c6f4e94a40) at libnetdata/threads/threads.c:203
#7  0x00007f6f45b0aea7 in start_thread (arg=<optimized out>) at pthread_create.c:477
#8  0x00007f6f456fda2f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

Upon code investigation I noticed `client` is assigned after thread is created (🤦🏻) which can lead to race where query thread attempts to use it before assignment (in case there are already queued queries at that time)

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
