### PR TITLE
feat(packaging): add netdata to www-data group on Proxmox

### DIFF
--- a/contrib/debian/netdata.postinst
+++ b/contrib/debian/netdata.postinst
@@ -30,6 +30,11 @@ case "$1" in
         usermod -a -G $item netdata
       fi
     done
+    # Netdata must be able to read /etc/pve/qemu-server/* and /etc/pve/lxc/*
+    # for reading VMs/containers names, CPU and memory limits on Proxmox.
+    if [ -d "/etc/pve" ] && getent group "www-data" > /dev/null 2>&1; then
+      usermod -a -G www-data netdata
+    fi
 
     if ! dpkg-statoverride --list /var/lib/netdata > /dev/null 2>&1; then
       dpkg-statoverride --update --add netdata netdata 0755 /var/lib/netdata

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1089,6 +1089,11 @@ if [ "$(id -u)" -eq 0 ]; then
     # shellcheck disable=SC2086
     portable_add_user_to_group ${g} netdata && NETDATA_ADDED_TO_GROUPS="${NETDATA_ADDED_TO_GROUPS} ${g}"
   done
+  # Netdata must be able to read /etc/pve/qemu-server/* and /etc/pve/lxc/* 
+  # for reading VMs/containers names, CPU and memory limits on Proxmox.
+  if [ -d "/etc/pve" ]; then
+    portable_add_user_to_group "www-data" netdata && NETDATA_ADDED_TO_GROUPS="${NETDATA_ADDED_TO_GROUPS} www-data"
+  fi
 else
   run_failed "The installer does not run as root. Nothing to do for user and groups"
 fi

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -121,6 +121,11 @@ if portable_add_group netdata; then
         run_failed "Failed to add netdata user to secondary groups"
       fi
     done
+    # Netdata must be able to read /etc/pve/qemu-server/* and /etc/pve/lxc/*
+    # for reading VMs/containers names, CPU and memory limits on Proxmox.
+    if [ -d "/etc/pve" ]; then
+      portable_add_user_to_group "www-data" netdata && NETDATA_ADDED_TO_GROUPS="${NETDATA_ADDED_TO_GROUPS} www-data"
+    fi
     NETDATA_USER="netdata"
     NETDATA_GROUP="netdata"
   else


### PR DESCRIPTION
##### Summary

This is needed for VMs/containers:

- name resolution.
- reading CPU and memory limits (for CPU, mem % utilization charts, and alarms).

Both are must-haves on Proxmox (server for virtualization management).

##### Test Plan

- ci
- [x] test the change for source/static/deb builds on Proxmox and (any) other system.



##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
