### PR TITLE
remove interface name from cgroup net family

### DIFF
--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -516,8 +516,7 @@ static inline void netdev_rename_cgroup(struct netdev *d, struct netdev_rename *
     snprintfz(buffer, RRD_ID_LENGTH_MAX, "%scgroup.net_mtu", r->ctx_prefix);
     d->chart_ctx_net_mtu        = strdupz(buffer);
 
-    snprintfz(buffer, RRD_ID_LENGTH_MAX, "net %s", r->container_device);
-    d->chart_family = strdupz(buffer);
+    d->chart_family = strdupz("net");
 
     rrdlabels_copy(d->chart_labels, r->chart_labels);
 


### PR DESCRIPTION
##### Summary

Fixes: #14170

Should be merged on the same day as https://github.com/netdata/netdata/pull/14173

@hugovalente-pm this PR removes the interface name from the `net` family. Still, we will get `net` and `net IFACE_NAME` families (Netdata version after/before this commit).

##### Test Plan

Install this branch, and check cgroup net family.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
