### PR TITLE
Add compatibility links for RHEL repos.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -51,6 +51,9 @@ include:
     packages: &alma_packages
       type: rpm
       repo_distro: el/9
+      alt_links:
+        - el/9Server
+        - el/9Client
       arches:
         - x86_64
         - aarch64
@@ -61,12 +64,18 @@ include:
     packages:
       <<: *alma_packages
       repo_distro: el/8
+      alt_links:
+        - el/8Server
+        - el/8Client
 
   - distro: centos
     version: "7"
     packages:
       type: rpm
       repo_distro: el/7
+      alt_links:
+        - el/7Server
+        - el/7Client
       arches:
         - x86_64
     test:


### PR DESCRIPTION
##### Summary

Because RHEL does things differently than it’s various clones when compsing the value of the `$releasever` variable.

Code to handle these is already in-place on the repository backend system, this is just properly codifying things here in an extensible manner.

##### Test Plan

n/a