### PR TITLE
fix logrotate postrotate

### DIFF
--- a/system/netdata.logrotate.in
+++ b/system/netdata.logrotate.in
@@ -7,6 +7,6 @@
 	notifempty
 	sharedscripts
 	postrotate
-		/bin/kill -HUP `cat @localstatedir_POST@/run/netdata/netdata.pid 2>/dev/null` 2>/dev/null || true
+		/bin/kill -HUP `cat /run/netdata/netdata.pid 2>/dev/null` 2>/dev/null || true
 	endscript
 }


### PR DESCRIPTION
##### Summary

Netdata no longer stores its PID file under the `@localstatedir_POST@/run/netdata/` dir after #13504 => Netdata keeps writing to the old log file after rotating because we don't send HUP

https://github.com/netdata/netdata/blob/4409202f33cd6d20c9f6f2cdffa9d2112d6a437b/system/netdata.logrotate.in#L10
 

##### Test Plan

Do `cat /run/netdata/netdata.pid` and see it returns the netdata process PID.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
