### PR TITLE
Switch to actions/labeler@v4 for labeling PRs.

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,17 +2,20 @@
 # Handles labelling of PR's.
 name: Pull Request Labeler
 on:
-  schedule:
-    - cron: '*/10 * * * *'
-env:
-  DISABLE_TELEMETRY: 1
+  pull_request_target: null
+concurrency:
+  group: pr-label-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   labeler:
+    name: Apply PR Labels
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
-      - uses: docker://docker.io/ilyam8/periodic-pr-labeler:v0.1.0
+      - uses: actions/labeler@v4
         if: github.repository == 'netdata/netdata'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          LABEL_MAPPINGS_FILE: .github/labeler.yml
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true


### PR DESCRIPTION
##### Summary

This has a number of advantages:

- It allows us to make PR labeling event-driven instead of polling. This, in turn, means that it only runs when a PR is modified, and only evaluates that specific PR, which results in spending far less time running PR labeler jobs.
- This is the ‘official’ way to handle PR labels automatically as code, and thus @ilyam8 will no longer need to maintain a custom labeling action for this purpose.
- The matching syntax supported by this action is more expressive than what is supported by our existing infrastructure, allowing for things such as requiring all of a group of files to be modified in a PR for it to have a specific label applied. We have no need right now for this, but it is useful to have it available long-term.
- Because the labeling is PR-triggered, it shows up in the PR checks, so we can more easily see if auto-labeling has run for a given PR or not.
- actions/labeler@v4 supports removing labels that no-longer match a PR. It’s not often that this is relevant for our usage, but it is still useful.

The only major disadvantage is that changes to the labeling rules only get propagated out to PRs when those PRs are updated. Given how infrequently our labeling rules change, this is probably not an issue for our usage.

The ‘magic’ here has to do with usage of the `pull_request_target` event instead of the regular `pull_request` event. Workflows triggered from this event run from the target branch of the PR, as opposed to the PR branch itself, so they are not affected by the security implications, thus they are allowed full access to the repository even on pull requests from forks, allowing them to reliably do things like apply labels or comment on the PR.

Happily, the existing syntax we’re using for for the labeler configuration works with the new action as well, so no changes are needed in the labeler configuration.

##### Test Plan

Because of how the `pull_request_target` event works, this is only testable once merged.