### PR TITLE
Dont call worker_utilization_finish() twice

### DIFF
--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -2786,8 +2786,6 @@ static void global_statistics_cleanup(void *ptr)
 
     info("cleaning up...");
 
-    worker_utilization_finish();
-
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #14167 

During shutdown, it seems `worker_utilization_finish()` is called twice, once from `global_statistics_workers_cleanup` and again from `global_statistics_cleanup`. Since there is no locking in place, it could lead to race freeing same strings twice, that could lead to a random crash during shutdown. I believe only calling it once should do the cleanup correctly.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Check for core dumps during shutdown, related bug report has the information.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
