### PR TITLE
Use brackets around info variables

### DIFF
--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -95,8 +95,9 @@ static STRING *rrdcalc_replace_variables_with_rrdset_labels(const char *line, RR
             temp = buf;
         }
         else if (!strncmp(var, RRDCALC_VAR_LABEL, RRDCALC_VAR_LABEL_LEN)) {
-            char label_val[RRDCALC_VAR_MAX];
-            strncpyz(label_val, var+RRDCALC_VAR_LABEL_LEN, strlen(var+RRDCALC_VAR_LABEL_LEN)-1);
+            char label_val[RRDCALC_VAR_MAX + 1] = { 0 };
+            strcpy(label_val, var+RRDCALC_VAR_LABEL_LEN);
+            label_val[i - RRDCALC_VAR_LABEL_LEN - 1] = '\0';
 
             if(likely(rc->rrdset && rc->rrdset->rrdlabels)) {
                 rrdlabels_get_value_to_char_or_null(rc->rrdset->rrdlabels, &lbl_value, label_val);

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -74,18 +74,16 @@ static STRING *rrdcalc_replace_variables_with_rrdset_labels(const char *line, RR
     char var[RRDCALC_VAR_MAX];
     char *m, *lbl_value = NULL;
 
-    while ((m = strchr(temp + pos, '$'))) {
+    while ((m = strchr(temp + pos, '$')) && m+1 && *(m+1) == '{') {
         int i = 0;
         char *e = m;
         while (*e) {
+            var[i++] = *e;
 
-            if (*e == ' ' || i == RRDCALC_VAR_MAX - 1)
+            if (*e == '}' || i == RRDCALC_VAR_MAX - 1)
                 break;
-            else
-                var[i] = *e;
 
             e++;
-            i++;
         }
 
         var[i] = '\0';
@@ -97,8 +95,12 @@ static STRING *rrdcalc_replace_variables_with_rrdset_labels(const char *line, RR
             temp = buf;
         }
         else if (!strncmp(var, RRDCALC_VAR_LABEL, RRDCALC_VAR_LABEL_LEN)) {
+            char label_val[RRDCALC_VAR_MAX];
+            strcpy(label_val, var+RRDCALC_VAR_LABEL_LEN);
+            label_val[strlen(label_val)-1]='\0';
+
             if(likely(rc->rrdset && rc->rrdset->rrdlabels)) {
-                rrdlabels_get_value_to_char_or_null(rc->rrdset->rrdlabels, &lbl_value, var+RRDCALC_VAR_LABEL_LEN);
+                rrdlabels_get_value_to_char_or_null(rc->rrdset->rrdlabels, &lbl_value, label_val);
                 if (lbl_value) {
                     char *buf = find_and_replace(temp, var, lbl_value, m);
                     freez(temp);

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -74,7 +74,7 @@ static STRING *rrdcalc_replace_variables_with_rrdset_labels(const char *line, RR
     char var[RRDCALC_VAR_MAX];
     char *m, *lbl_value = NULL;
 
-    while ((m = strchr(temp + pos, '$')) && m+1 && *(m+1) == '{') {
+    while ((m = strchr(temp + pos, '$')) && *(m+1) == '{') {
         int i = 0;
         char *e = m;
         while (*e) {
@@ -96,8 +96,7 @@ static STRING *rrdcalc_replace_variables_with_rrdset_labels(const char *line, RR
         }
         else if (!strncmp(var, RRDCALC_VAR_LABEL, RRDCALC_VAR_LABEL_LEN)) {
             char label_val[RRDCALC_VAR_MAX];
-            strcpy(label_val, var+RRDCALC_VAR_LABEL_LEN);
-            label_val[strlen(label_val)-1]='\0';
+            strncpyz(label_val, var+RRDCALC_VAR_LABEL_LEN, strlen(var+RRDCALC_VAR_LABEL_LEN)-1);
 
             if(likely(rc->rrdset && rc->rrdset->rrdlabels)) {
                 rrdlabels_get_value_to_char_or_null(rc->rrdset->rrdlabels, &lbl_value, label_val);

--- a/database/rrdcalc.h
+++ b/database/rrdcalc.h
@@ -251,8 +251,8 @@ void rrdcalc_rrdhost_index_init(RRDHOST *host);
 void rrdcalc_rrdhost_index_destroy(RRDHOST *host);
 
 #define RRDCALC_VAR_MAX 100
-#define RRDCALC_VAR_FAMILY "$family"
-#define RRDCALC_VAR_LABEL "$label:"
+#define RRDCALC_VAR_FAMILY "${family}"
+#define RRDCALC_VAR_LABEL "${label:"
 #define RRDCALC_VAR_LABEL_LEN (sizeof(RRDCALC_VAR_LABEL)-1)
 
 #endif //NETDATA_RRDCALC_H

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -548,13 +548,13 @@ alert information. Current variables supported are:
 
 | variable | description |
 | ---------| ----------- |
-| $family  | Will be replaced by the family instance for the alert (e.g. eth0) |
-| $label:  | Followed by a chart label name, this will replace the variable with the chart label's value |
+| ${family}  | Will be replaced by the family instance for the alert (e.g. eth0) |
+| ${label:XXX}  | This will replace the variable with the chart label's XXX value |
 
 For example, an info field like the following:
 
 ```yaml
-info: average inbound utilization for the network interface $family over the last minute
+info: average inbound utilization for the network interface ${family} over the last minute
 ```
 
 Will be rendered on the alert acting on interface `eth0` as:
@@ -567,7 +567,7 @@ An alert acting on a chart that has a chart label named e.g. `target`, with a va
 can be enriched as follows:
 
 ```yaml
-info: average ratio of HTTP responses with unexpected status over the last 5 minutes for the site $label:target
+info: average ratio of HTTP responses with unexpected status over the last 5 minutes for the site ${label:target}
 ```
 
 Will become:

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -549,7 +549,7 @@ alert information. Current variables supported are:
 | variable | description |
 | ---------| ----------- |
 | ${family}  | Will be replaced by the family instance for the alert (e.g. eth0) |
-| ${label:XXX}  | This will replace the variable with the chart label's XXX value |
+| ${label:LABEL_NAME}  | The variable will be replaced with the value of the label |
 
 For example, an info field like the following:
 

--- a/health/health.d/cgroups.conf
+++ b/health/health.d/cgroups.conf
@@ -51,7 +51,7 @@ component: Network
    lookup: average -1m unaligned of received
     units: packets
     every: 10s
-     info: average number of packets received by the network interface $label:device over the last minute
+     info: average number of packets received by the network interface ${label:device} over the last minute
 
  template: cgroup_10s_received_packets_storm
        on: cgroup.net_packets
@@ -66,7 +66,7 @@ component: Network
      warn: $this > (($status >= $WARNING)?(200):(5000))
      crit: $this > (($status == $CRITICAL)?(5000):(6000))
   options: no-clear-notification
-     info: ratio of average number of received packets for the network interface $label:device over the last 10 seconds, \
+     info: ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, \
            compared to the rate over the last minute
        to: sysadmin
 
@@ -121,7 +121,7 @@ component: Network
    lookup: average -1m unaligned of received
     units: packets
     every: 10s
-     info: average number of packets received by the network interface $label:device over the last minute
+     info: average number of packets received by the network interface ${label:device} over the last minute
 
  template: k8s_cgroup_10s_received_packets_storm
        on: k8s.cgroup.net_packets
@@ -136,6 +136,6 @@ component: Network
      warn: $this > (($status >= $WARNING)?(200):(5000))
      crit: $this > (($status == $CRITICAL)?(5000):(6000))
   options: no-clear-notification
-     info: ratio of average number of received packets for the network interface $label:device over the last 10 seconds, \
+     info: ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, \
            compared to the rate over the last minute
        to: sysadmin

--- a/health/health.d/consul.conf
+++ b/health/health.d/consul.conf
@@ -10,7 +10,7 @@ component: Consul
     units: status
      warn: $this == 1
     delay: down 5m multiplier 1.5 max 1h
-     info: datacenter $label:datacenter cluster is unhealthy as reported by server $label:node_name
+     info: datacenter ${label:datacenter} cluster is unhealthy as reported by server ${label:node_name}
        to: sysadmin
 
  template: consul_autopilot_server_health_status
@@ -23,7 +23,7 @@ component: Consul
     units: status
      warn: $this == 1
     delay: down 5m multiplier 1.5 max 1h
-     info: server $label:node_name from datacenter $label:datacenter is unhealthy
+     info: server ${label:node_name} from datacenter ${label:datacenter} is unhealthy
        to: sysadmin
 
  template: consul_raft_leader_last_contact_time
@@ -37,7 +37,7 @@ component: Consul
      warn: $this > (($status >= $WARNING)  ? (150) : (200))
      crit: $this > (($status == $CRITICAL) ? (200) : (500))
     delay: down 5m multiplier 1.5 max 1h
-     info: median time elapsed since leader server $label:node_name datacenter $label:datacenter was last able to contact the follower nodes
+     info: median time elapsed since leader server ${label:node_name} datacenter ${label:datacenter} was last able to contact the follower nodes
        to: sysadmin
 
  template: consul_raft_leadership_transitions
@@ -50,7 +50,7 @@ component: Consul
     units: percentage
      warn: $this > 0
     delay: down 5m multiplier 1.5 max 1h
-     info: there has been a leadership change and server $label:node_name datacenter $label:datacenter has become the leader
+     info: there has been a leadership change and server ${label:node_name} datacenter ${label:datacenter} has become the leader
        to: sysadmin
 
  template: consul_raft_thread_main_saturation
@@ -63,7 +63,7 @@ component: Consul
     units: percentage
      warn: $this > (($status >= $WARNING)  ? (40) : (50))
     delay: down 5m multiplier 1.5 max 1h
-     info: average saturation of the main Raft goroutine on server $label:node_name datacenter $label:datacenter
+     info: average saturation of the main Raft goroutine on server ${label:node_name} datacenter ${label:datacenter}
        to: sysadmin
 
  template: consul_raft_thread_fsm_saturation
@@ -76,7 +76,7 @@ component: Consul
     units: milliseconds
      warn: $this > (($status >= $WARNING)  ? (40) : (50))
     delay: down 5m multiplier 1.5 max 1h
-     info: average saturation of the FSM Raft goroutine on server $label:node_name datacenter $label:datacenter
+     info: average saturation of the FSM Raft goroutine on server ${label:node_name} datacenter ${label:datacenter}
        to: sysadmin
 
  template: consul_client_rpc_requests_exceeded
@@ -89,7 +89,7 @@ component: Consul
     units: requests
      warn: $this > (($status >= $WARNING)  ? (0) : (5))
     delay: down 5m multiplier 1.5 max 1h
-     info: number of rate-limited RPC requests made by server $label:node_name datacenter $label:datacenter
+     info: number of rate-limited RPC requests made by server ${label:node_name} datacenter ${label:datacenter}
        to: sysadmin
 
  template: consul_client_rpc_requests_failed
@@ -102,7 +102,7 @@ component: Consul
     units: requests
      warn: $this > (($status >= $WARNING)  ? (0) : (5))
     delay: down 5m multiplier 1.5 max 1h
-     info: number of failed RPC requests made by server $label:node_name datacenter $label:datacenter
+     info: number of failed RPC requests made by server ${label:node_name} datacenter ${label:datacenter}
        to: sysadmin
 
  template: consul_node_health_check_status
@@ -115,7 +115,7 @@ component: Consul
     units: status
      warn: $this != nan AND $this != 0
     delay: down 5m multiplier 1.5 max 1h
-     info: node health check $label:check_name has failed on server $label:node_name datacenter $label:datacenter
+     info: node health check ${label:check_name} has failed on server ${label:node_name} datacenter ${label:datacenter}
        to: sysadmin
 
  template: consul_service_health_check_status
@@ -128,7 +128,7 @@ component: Consul
     units: status
      warn: $this == 1
     delay: down 5m multiplier 1.5 max 1h
-     info: service health check $label:check_name for service $label:service_name has failed on server $label:node_name datacenter $label:datacenter
+     info: service health check ${label:check_name} for service ${label:service_name} has failed on server ${label:node_name} datacenter ${label:datacenter}
        to: sysadmin
 
  template: consul_gc_pause_time
@@ -142,5 +142,5 @@ component: Consul
      warn: $this > (($status >= $WARNING)  ? (1) : (2))
      crit: $this > (($status >= $WARNING)  ? (2) : (5))
     delay: down 5m multiplier 1.5 max 1h
-     info: time spent in stop-the-world garbage collection pauses on server $label:node_name datacenter $label:datacenter
+     info: time spent in stop-the-world garbage collection pauses on server ${label:node_name} datacenter ${label:datacenter}
        to: sysadmin

--- a/health/health.d/disks.conf
+++ b/health/health.d/disks.conf
@@ -23,7 +23,7 @@ component: Disk
      warn: $this > (($status >= $WARNING ) ? (80) : (90))
      crit: $this > (($status == $CRITICAL) ? (90) : (98))
     delay: up 1m down 15m multiplier 1.5 max 1h
-     info: disk $label:mount_point space utilization
+     info: disk ${label:mount_point} space utilization
        to: sysadmin
 
  template: disk_inode_usage
@@ -40,7 +40,7 @@ component: Disk
      warn: $this > (($status >= $WARNING)  ? (80) : (90))
      crit: $this > (($status == $CRITICAL) ? (90) : (98))
     delay: up 1m down 15m multiplier 1.5 max 1h
-     info: disk $label:mount_point inode utilization
+     info: disk ${label:mount_point} inode utilization
        to: sysadmin
 
 
@@ -147,7 +147,7 @@ component: Disk
     every: 1m
      warn: $this > 98 * (($status >= $WARNING)  ? (0.7) : (1))
     delay: down 15m multiplier 1.2 max 1h
-     info: average percentage of time $label:device disk was busy over the last 10 minutes
+     info: average percentage of time ${label:device} disk was busy over the last 10 minutes
        to: silent
 
 
@@ -169,5 +169,5 @@ component: Disk
     every: 1m
      warn: $this > 5000 * (($status >= $WARNING)  ? (0.7) : (1))
     delay: down 15m multiplier 1.2 max 1h
-     info: average backlog size of the $label:device disk over the last 10 minutes
+     info: average backlog size of the ${label:device} disk over the last 10 minutes
        to: silent

--- a/health/health.d/dns_query.conf
+++ b/health/health.d/dns_query.conf
@@ -10,5 +10,5 @@ component: DNS
     every: 10s
      warn: $this != nan && $this != 1
     delay: up 30s down 5m multiplier 1.5 max 1h
-     info: DNS request type $label:record_type to server $label:server is unsuccessful
+     info: DNS request type ${label:record_type} to server ${label:server} is unsuccessful
        to: sysadmin

--- a/health/health.d/httpcheck.conf
+++ b/health/health.d/httpcheck.conf
@@ -10,7 +10,7 @@ component: HTTP endpoint
      calc: ($this < 75) ? (0) : ($this)
     every: 5s
     units: up/down
-     info: HTTP endpoint $label:url liveness status
+     info: HTTP endpoint ${label:url} liveness status
        to: silent
 
  template: httpcheck_web_service_bad_content
@@ -25,7 +25,7 @@ component: HTTP endpoint
      warn: $this >= 10 AND $this < 40
      crit: $this >= 40
     delay: down 5m multiplier 1.5 max 1h
-     info: percentage of HTTP responses from $label:url with unexpected content in the last 5 minutes
+     info: percentage of HTTP responses from ${label:url} with unexpected content in the last 5 minutes
        to: webmaster
 
  template: httpcheck_web_service_bad_status
@@ -40,7 +40,7 @@ component: HTTP endpoint
      warn: $this >= 10 AND $this < 40
      crit: $this >= 40
     delay: down 5m multiplier 1.5 max 1h
-     info: percentage of HTTP responses from $label:url with unexpected status in the last 5 minutes
+     info: percentage of HTTP responses from ${label:url} with unexpected status in the last 5 minutes
        to: webmaster
 
  template: httpcheck_web_service_timeouts
@@ -55,7 +55,7 @@ component: HTTP endpoint
      warn: $this >= 10 AND $this < 40
      crit: $this >= 40
     delay: down 5m multiplier 1.5 max 1h
-     info: percentage of timed-out HTTP requests to $label:url in the last 5 minutes
+     info: percentage of timed-out HTTP requests to ${label:url} in the last 5 minutes
        to: webmaster
 
  template: httpcheck_web_service_no_connection
@@ -70,5 +70,5 @@ component: HTTP endpoint
      warn: $this >= 10 AND $this < 40
      crit: $this >= 40
     delay: down 5m multiplier 1.5 max 1h
-     info: percentage of failed HTTP requests to $label:url in the last 5 minutes
+     info: percentage of failed HTTP requests to ${label:url} in the last 5 minutes
        to: webmaster

--- a/health/health.d/mdstat.conf
+++ b/health/health.d/mdstat.conf
@@ -20,7 +20,7 @@ component: RAID
     every: 10s
      calc: $down
      crit: $this > 0
-     info: number of devices in the down state for the $label:device $label:raid_level array. \
+     info: number of devices in the down state for the ${label:device} ${label:raid_level} array. \
            Any number > 0 indicates that the array is degraded.
        to: sysadmin
 
@@ -35,7 +35,7 @@ component: RAID
     every: 60s
      warn: $this > 1024
     delay: up 30m
-     info: number of unsynchronized blocks for the $label:device $label:raid_level array
+     info: number of unsynchronized blocks for the ${label:device} ${label:raid_level} array
        to: sysadmin
 
  template: mdstat_nonredundant_last_collected

--- a/health/health.d/net.conf
+++ b/health/health.d/net.conf
@@ -15,7 +15,7 @@ component: Network
      calc: ( $nic_speed_max > 0 ) ? ( $nic_speed_max) : ( nan )
     units: Mbit
     every: 10s
-     info: network interface $label:device current speed
+     info: network interface ${label:device} current speed
 
  template: 1m_received_traffic_overflow
        on: net.net
@@ -31,7 +31,7 @@ component: Network
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (85) : (90))
     delay: up 1m down 1m multiplier 1.5 max 1h
-     info: average inbound utilization for the network interface $label:device over the last minute
+     info: average inbound utilization for the network interface ${label:device} over the last minute
        to: sysadmin
 
  template: 1m_sent_traffic_overflow
@@ -48,7 +48,7 @@ component: Network
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (85) : (90))
     delay: up 1m down 1m multiplier 1.5 max 1h
-     info: average outbound utilization for the network interface $label:device over the last minute
+     info: average outbound utilization for the network interface ${label:device} over the last minute
        to: sysadmin
 
 # -----------------------------------------------------------------------------
@@ -72,7 +72,7 @@ component: Network
    lookup: sum -10m unaligned absolute of inbound
     units: packets
     every: 1m
-     info: number of inbound dropped packets for the network interface $label:device in the last 10 minutes
+     info: number of inbound dropped packets for the network interface ${label:device} in the last 10 minutes
 
  template: outbound_packets_dropped
        on: net.drops
@@ -85,7 +85,7 @@ component: Network
    lookup: sum -10m unaligned absolute of outbound
     units: packets
     every: 1m
-     info: number of outbound dropped packets for the network interface $label:device in the last 10 minutes
+     info: number of outbound dropped packets for the network interface ${label:device} in the last 10 minutes
 
  template: inbound_packets_dropped_ratio
        on: net.packets
@@ -101,7 +101,7 @@ component: Network
     every: 1m
      warn: $this >= 2
     delay: up 1m down 1h multiplier 1.5 max 2h
-     info: ratio of inbound dropped packets for the network interface $label:device over the last 10 minutes
+     info: ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
        to: sysadmin
 
  template: outbound_packets_dropped_ratio
@@ -118,7 +118,7 @@ component: Network
     every: 1m
      warn: $this >= 2
     delay: up 1m down 1h multiplier 1.5 max 2h
-     info: ratio of outbound dropped packets for the network interface $label:device over the last 10 minutes
+     info: ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
        to: sysadmin
 
  template: wifi_inbound_packets_dropped_ratio
@@ -135,7 +135,7 @@ component: Network
     every: 1m
      warn: $this >= 10
     delay: up 1m down 1h multiplier 1.5 max 2h
-     info: ratio of inbound dropped packets for the network interface $label:device over the last 10 minutes
+     info: ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
        to: sysadmin
 
  template: wifi_outbound_packets_dropped_ratio
@@ -152,7 +152,7 @@ component: Network
     every: 1m
      warn: $this >= 10
     delay: up 1m down 1h multiplier 1.5 max 2h
-     info: ratio of outbound dropped packets for the network interface $label:device over the last 10 minutes
+     info: ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
        to: sysadmin
 
 # -----------------------------------------------------------------------------
@@ -171,7 +171,7 @@ component: Network
     every: 1m
      warn: $this >= 5
     delay: down 1h multiplier 1.5 max 2h
-     info: number of inbound errors for the network interface $label:device in the last 10 minutes
+     info: number of inbound errors for the network interface ${label:device} in the last 10 minutes
        to: sysadmin
 
  template: interface_outbound_errors
@@ -187,7 +187,7 @@ component: Network
     every: 1m
      warn: $this >= 5
     delay: down 1h multiplier 1.5 max 2h
-     info: number of outbound errors for the network interface $label:device in the last 10 minutes
+     info: number of outbound errors for the network interface ${label:device} in the last 10 minutes
        to: sysadmin
 
 # -----------------------------------------------------------------------------
@@ -211,7 +211,7 @@ component: Network
     every: 1m
      warn: $this > 0
     delay: down 1h multiplier 1.5 max 2h
-     info: number of FIFO errors for the network interface $label:device in the last 10 minutes
+     info: number of FIFO errors for the network interface ${label:device} in the last 10 minutes
        to: sysadmin
 
 # -----------------------------------------------------------------------------
@@ -234,7 +234,7 @@ component: Network
    lookup: average -1m unaligned of received
     units: packets
     every: 10s
-     info: average number of packets received by the network interface $label:device over the last minute
+     info: average number of packets received by the network interface ${label:device} over the last minute
 
  template: 10s_received_packets_storm
        on: net.packets
@@ -251,6 +251,6 @@ component: Network
      warn: $this > (($status >= $WARNING)?(200):(5000))
      crit: $this > (($status == $CRITICAL)?(5000):(6000))
   options: no-clear-notification
-     info: ratio of average number of received packets for the network interface $label:device over the last 10 seconds, \
+     info: ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, \
            compared to the rate over the last minute
        to: sysadmin

--- a/health/health.d/nvme.conf
+++ b/health/health.d/nvme.conf
@@ -11,5 +11,5 @@ component: Disk
     every: 10s
      crit: $this != nan AND $this != 0
     delay: down 5m multiplier 1.5 max 2h
-     info: NVMe device $label:device has critical warnings
+     info: NVMe device ${label:device} has critical warnings
        to: sysadmin

--- a/health/health.d/ping.conf
+++ b/health/health.d/ping.conf
@@ -12,7 +12,7 @@ component: Network
     every: 10s
      crit: $this == 0
     delay: down 30m multiplier 1.5 max 2h
-     info: network host $label:host reachability status
+     info: network host ${label:host} reachability status
        to: sysadmin
 
  template: ping_packet_loss
@@ -29,7 +29,7 @@ component: Network
      warn: $this > $green
      crit: $this > $red
     delay: down 30m multiplier 1.5 max 2h
-     info: packet loss percentage to the network host $label:host over the last 10 minutes
+     info: packet loss percentage to the network host ${label:host} over the last 10 minutes
        to: sysadmin
 
  template: ping_host_latency
@@ -46,5 +46,5 @@ component: Network
      warn: $this > $green OR $max > $red
      crit: $this > $red
     delay: down 30m multiplier 1.5 max 2h
-     info: average latency to the network host $label:host over the last 10 seconds
+     info: average latency to the network host ${label:host} over the last 10 seconds
        to: sysadmin

--- a/health/health.d/portcheck.conf
+++ b/health/health.d/portcheck.conf
@@ -10,7 +10,7 @@ component: TCP endpoint
      calc: ($this < 75) ? (0) : ($this)
     every: 5s
     units: up/down
-     info: TCP host $label:host port $label:port liveness status
+     info: TCP host ${label:host} port ${label:port} liveness status
        to: silent
 
  template: portcheck_connection_timeouts
@@ -25,7 +25,7 @@ component: TCP endpoint
      warn: $this >= 10 AND $this < 40
      crit: $this >= 40
     delay: down 5m multiplier 1.5 max 1h
-     info: percentage of timed-out TCP connections to host $label:host port $label:port in the last 5 minutes
+     info: percentage of timed-out TCP connections to host ${label:host} port ${label:port} in the last 5 minutes
        to: sysadmin
 
  template: portcheck_connection_fails
@@ -40,5 +40,5 @@ component: TCP endpoint
      warn: $this >= 10 AND $this < 40
      crit: $this >= 40
     delay: down 5m multiplier 1.5 max 1h
-     info: percentage of failed TCP connections to host $label:host port $label:port in the last 5 minutes
+     info: percentage of failed TCP connections to host ${label:host} port ${label:port} in the last 5 minutes
        to: sysadmin

--- a/health/health.d/postgres.conf
+++ b/health/health.d/postgres.conf
@@ -58,7 +58,7 @@ component: PostgreSQL
      warn: $this < (($status >= $WARNING)  ? (70) : (60))
      crit: $this < (($status == $CRITICAL) ? (60) : (50))
     delay: down 15m multiplier 1.5 max 1h
-     info: average cache hit ratio in db $label:database over the last minute
+     info: average cache hit ratio in db ${label:database} over the last minute
        to: dba
 
  template: postgres_db_transactions_rollback_ratio	
@@ -72,7 +72,7 @@ component: PostgreSQL
     every: 1m
      warn: $this > (($status >= $WARNING)  ? (0) : (2))
     delay: down 15m multiplier 1.5 max 1h
-     info: average aborted transactions percentage in db $label:database over the last five minutes
+     info: average aborted transactions percentage in db ${label:database} over the last five minutes
        to: dba
 
  template: postgres_db_deadlocks_rate
@@ -86,7 +86,7 @@ component: PostgreSQL
     every: 1m
      warn: $this > (($status >= $WARNING)  ? (0) : (10))
     delay: down 15m multiplier 1.5 max 1h
-     info: number of deadlocks detected in db $label:database in the last minute
+     info: number of deadlocks detected in db ${label:database} in the last minute
        to: dba
 
 # Table alarms
@@ -104,7 +104,7 @@ component: PostgreSQL
      warn: $this < (($status >= $WARNING)  ? (70) : (60))
      crit: $this < (($status == $CRITICAL) ? (60) : (50))
     delay: down 15m multiplier 1.5 max 1h
-     info: average cache hit ratio in db $label:database table $label:table over the last minute
+     info: average cache hit ratio in db ${label:database} table ${label:table} over the last minute
        to: dba
 
  template: postgres_table_index_cache_io_ratio
@@ -120,7 +120,7 @@ component: PostgreSQL
      warn: $this < (($status >= $WARNING)  ? (70) : (60))
      crit: $this < (($status == $CRITICAL) ? (60) : (50))
     delay: down 15m multiplier 1.5 max 1h
-     info: average index cache hit ratio in db $label:database table $label:table over the last minute
+     info: average index cache hit ratio in db ${label:database} table ${label:table} over the last minute
        to: dba
 
  template: postgres_table_toast_cache_io_ratio
@@ -136,7 +136,7 @@ component: PostgreSQL
      warn: $this < (($status >= $WARNING)  ? (70) : (60))
      crit: $this < (($status == $CRITICAL) ? (60) : (50))
     delay: down 15m multiplier 1.5 max 1h
-     info: average TOAST hit ratio in db $label:database table $label:table over the last minute
+     info: average TOAST hit ratio in db ${label:database} table ${label:table} over the last minute
        to: dba
 
  template: postgres_table_toast_index_cache_io_ratio
@@ -152,7 +152,7 @@ component: PostgreSQL
      warn: $this < (($status >= $WARNING)  ? (70) : (60))
      crit: $this < (($status == $CRITICAL) ? (60) : (50))
     delay: down 15m multiplier 1.5 max 1h
-     info: average index TOAST hit ratio in db $label:database table $label:table over the last minute
+     info: average index TOAST hit ratio in db ${label:database} table ${label:table} over the last minute
        to: dba
 
  template: postgres_table_bloat_size_perc
@@ -167,7 +167,7 @@ component: PostgreSQL
      warn: $this > (($status >= $WARNING)  ? (60) : (70))
      crit: $this > (($status == $CRITICAL) ? (70) : (80))
     delay: down 15m multiplier 1.5 max 1h
-     info: bloat size percentage in db $label:database table $label:table
+     info: bloat size percentage in db ${label:database} table ${label:table}
        to: dba
 
  template: postgres_table_last_autovacuum_time
@@ -180,7 +180,7 @@ component: PostgreSQL
     units: seconds
     every: 1m
      warn: $this != nan AND $this > (60 * 60 * 24 * 7)
-     info: time elapsed since db $label:database table $label:table was vacuumed by the autovacuum daemon
+     info: time elapsed since db ${label:database} table ${label:table} was vacuumed by the autovacuum daemon
        to: dba
 
  template: postgres_table_last_autoanalyze_time
@@ -193,7 +193,7 @@ component: PostgreSQL
     units: seconds
     every: 1m
      warn: $this != nan AND $this > (60 * 60 * 24 * 7)
-     info: time elapsed since db $label:database table $label:table was analyzed by the autovacuum daemon
+     info: time elapsed since db ${label:database} table ${label:table} was analyzed by the autovacuum daemon
        to: dba
 
 # Index alarms
@@ -210,5 +210,5 @@ component: PostgreSQL
      warn: $this > (($status >= $WARNING)  ? (60) : (70))
      crit: $this > (($status == $CRITICAL) ? (70) : (80))
     delay: down 15m multiplier 1.5 max 1h
-     info: bloat size percentage in db $label:database table $label:table index $label:index
+     info: bloat size percentage in db ${label:database} table ${label:table} index ${label:index}
        to: dba

--- a/health/health.d/zfs.conf
+++ b/health/health.d/zfs.conf
@@ -24,7 +24,7 @@ component: File system
     every: 10s
      warn: $this > 0
     delay: down 1m multiplier 1.5 max 1h
-     info: ZFS pool $label:pool state is degraded
+     info: ZFS pool ${label:pool} state is degraded
        to: sysadmin
 
  template: zfs_pool_state_crit
@@ -37,5 +37,5 @@ component: File system
     every: 10s
      crit: $this > 0
     delay: down 1m multiplier 1.5 max 1h
-     info: ZFS pool $label:pool state is faulted or unavail
+     info: ZFS pool ${label:pool} state is faulted or unavail
        to: sysadmin


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->
Fixes #14175 

This PR changes the format of the alert info variables to use `${label:something}` instead of `$label:something`. This will allow the variables to have other characters around them and not be defined by spaces. The old way of defining the variables will not work.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Check that variables are correctly replaced.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

The only problem is if a user has custom alerts will need to update them with the new format.

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
