### PR TITLE
Remove temporary allocations when preprocessing a samples buffer

### DIFF
--- a/ml/SamplesBuffer.cc
+++ b/ml/SamplesBuffer.cc
@@ -139,7 +139,7 @@ void SamplesBuffer::preprocess(std::vector<DSample> &Samples) {
         const Sample PS = getPreprocessedSample(Idx);
         PS.initDSample(DS);
 
-        Samples.push_back(DS);
+        Samples.push_back(std::move(DS));
     }
 }
 

--- a/ml/SamplesBuffer.cc
+++ b/ml/SamplesBuffer.cc
@@ -54,12 +54,12 @@ void SamplesBuffer::diffSamples() {
 
 void SamplesBuffer::smoothSamples() {
     // Holds the mean value of each window
-    CalculatedNumber *AccCNs = new CalculatedNumber[NumDimsPerSample]();
-    Sample Acc(AccCNs, NumDimsPerSample);
+    CalculatedNumber AccCNs[1] = { 0 };
+    Sample Acc(AccCNs, 1);
 
     // Used to avoid clobbering the accumulator when moving the window
-    CalculatedNumber *TmpCNs = new CalculatedNumber[NumDimsPerSample]();
-    Sample Tmp(TmpCNs, NumDimsPerSample);
+    CalculatedNumber TmpCNs[1] = { 0 };
+    Sample Tmp(TmpCNs, 1);
 
     CalculatedNumber Factor = (CalculatedNumber) 1 / SmoothN;
 
@@ -88,9 +88,6 @@ void SamplesBuffer::smoothSamples() {
         Acc.copy(Tmp);
         Acc.scale(Factor);
     }
-
-    delete[] AccCNs;
-    delete[] TmpCNs;
 }
 
 void SamplesBuffer::lagSamples() {

--- a/ml/SamplesBuffer.h
+++ b/ml/SamplesBuffer.h
@@ -86,7 +86,9 @@ public:
         DiffN(DiffN), SmoothN(SmoothN), LagN(LagN),
         SamplingRatio(SamplingRatio), RandNums(RandNums),
         BytesPerSample(NumDimsPerSample * sizeof(CalculatedNumber)),
-        Preprocessed(false) {};
+        Preprocessed(false) {
+        assert(NumDimsPerSample == 1 && "SamplesBuffer supports only one dimension per sample");
+    };
 
     void preprocess(std::vector<DSample> &Samples);
     void preprocess(DSample &Feature);

--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -52,16 +52,12 @@ void ml_host_new(RRDHOST *RH) {
 
     Host *H = new Host(RH);
     RH->ml_host = reinterpret_cast<ml_host_t *>(H);
-
-    H->startAnomalyDetectionThreads();
 }
 
 void ml_host_delete(RRDHOST *RH) {
     Host *H = reinterpret_cast<Host *>(RH->ml_host);
     if (!H)
         return;
-
-    H->stopAnomalyDetectionThreads();
 
     delete H;
     RH->ml_host = nullptr;


### PR DESCRIPTION
##### Summary

This PR replaces two temporary heap allocations with stack arrays. We can do this because our features are produced from single dimensions.

##### Test Plan

- CI job
- Run ML with address sanitizer