### PR TITLE
fix docker builds

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -82,7 +82,6 @@ RUN mkdir -p /opt/src /var/log/netdata && \
     # Fix handling of config directory
 
 # Long-term this should leverage BuildKit’s mount option.
-COPY --from=builder /wheels /wheels
 COPY --from=builder /app /
 
 # Apply the permissions as described in
@@ -109,8 +108,6 @@ RUN chown -R root:root \
     # Group write permissions due to: https://github.com/netdata/netdata/pull/6543
     find /var/lib/netdata /var/cache/netdata -type d -exec chmod 0770 {} \; && \
     find /var/lib/netdata /var/cache/netdata -type f -exec chmod 0660 {} \; && \
-    pip --no-cache-dir install /wheels/* && \
-    rm -rf /wheels && \
     cp -va /etc/netdata /etc/netdata.stock
 
 ENV NETDATA_LISTENER_PORT 19999


### PR DESCRIPTION
##### Summary

There is no `wheels` after https://github.com/netdata/helper-images/pull/181

##### Test Plan

ci

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
