### PR TITLE
Improve file descriptor closing loops

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -251,6 +251,7 @@ AC_SEARCH_LIBS([clock_gettime], [rt posix4])
 AC_CHECK_FUNCS([clock_gettime])
 AC_CHECK_FUNCS([sched_setscheduler sched_getscheduler sched_getparam sched_get_priority_min sched_get_priority_max getpriority setpriority nice])
 AC_CHECK_FUNCS([recvmmsg])
+AC_CHECK_FUNCS([close_range])
 
 AC_TYPE_INT8_T
 AC_TYPE_INT16_T

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1703,7 +1703,7 @@ int main(int argc, char **argv) {
     if (close_open_fds == true) {
         // close all open file descriptors, except the standard ones
         // the caller may have left open files (lxc-attach has this issue)
-        for_each_open_fd("close");
+        for_each_open_fd(OPEN_FD_ACTION_CLOSE, OPEN_FD_EXCLUDE_STDIN | OPEN_FD_EXCLUDE_STDOUT | OPEN_FD_EXCLUDE_STDERR);
     }
 
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1700,15 +1700,12 @@ int main(int argc, char **argv) {
         }
     }
 
-#ifdef _SC_OPEN_MAX
     if (close_open_fds == true) {
         // close all open file descriptors, except the standard ones
         // the caller may have left open files (lxc-attach has this issue)
-        for(int fd = (int) (sysconf(_SC_OPEN_MAX) - 1); fd > 2; fd--)
-            if(fd_is_valid(fd))
-                close(fd);
+        for_each_open_fd("close");
     }
-#endif
+
 
     if(!config_loaded) {
         load_netdata_conf(NULL, 0);

--- a/libnetdata/libnetdata.c
+++ b/libnetdata/libnetdata.c
@@ -1963,7 +1963,7 @@ void for_each_open_fd(int action, unsigned int excluded_fds) {
     } else {
         struct dirent *entry;
         while ((entry = readdir(dir)) != NULL) {
-            fd = atoi(entry->d_name);
+            fd = str2i(entry->d_name);
             if(unlikely(((fd == STDIN_FILENO ) && (excluded_fds & OPEN_FD_EXCLUDE_STDIN )) || 
                         ((fd == STDOUT_FILENO) && (excluded_fds & OPEN_FD_EXCLUDE_STDOUT)) ||
                         ((fd == STDERR_FILENO) && (excluded_fds & OPEN_FD_EXCLUDE_STDERR)))) continue;

--- a/libnetdata/libnetdata.c
+++ b/libnetdata/libnetdata.c
@@ -1957,7 +1957,7 @@ void for_each_open_fd(int action, unsigned int excluded_fds) {
                     (void)fcntl(fd, F_SETFD, FD_CLOEXEC);
                     break;
                 default:
-                    // do nothing
+                    break; // do nothing
             }
         }
     } else {
@@ -1975,7 +1975,7 @@ void for_each_open_fd(int action, unsigned int excluded_fds) {
                     (void)fcntl(fd, F_SETFD, FD_CLOEXEC);
                     break;
                 default:
-                    // do nothing
+                    break; // do nothing
             }
         }
         closedir(dir);

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -430,12 +430,16 @@ static inline char *get_word(char **words, size_t num_words, size_t index) {
 
 bool run_command_and_copy_output_to_stdout(const char *command, int max_line_length);
 
-#define OPEN_FD_ACTION_CLOSE 1
-#define OPEN_FD_ACTION_FD_CLOEXEC 2
-#define OPEN_FD_EXCLUDE_STDIN  0x01
-#define OPEN_FD_EXCLUDE_STDOUT 0x02
-#define OPEN_FD_EXCLUDE_STDERR 0x04
-void for_each_open_fd(int action, unsigned int excluded_fds);
+typedef enum {
+    OPEN_FD_ACTION_CLOSE,
+    OPEN_FD_ACTION_FD_CLOEXEC
+} OPEN_FD_ACTION;
+typedef enum {
+    OPEN_FD_EXCLUDE_STDIN   = 0x01,
+    OPEN_FD_EXCLUDE_STDOUT  = 0x02,
+    OPEN_FD_EXCLUDE_STDERR  = 0x04
+} OPEN_FD_EXCLUDE;
+void for_each_open_fd(OPEN_FD_ACTION action, OPEN_FD_EXCLUDE excluded_fds);
 
 void netdata_cleanup_and_exit(int ret) NORETURN;
 void send_statistics(const char *action, const char *action_result, const char *action_data);

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -430,7 +430,12 @@ static inline char *get_word(char **words, size_t num_words, size_t index) {
 
 bool run_command_and_copy_output_to_stdout(const char *command, int max_line_length);
 
-void for_each_open_fd(char *action_str);
+#define OPEN_FD_ACTION_CLOSE 1
+#define OPEN_FD_ACTION_FD_CLOEXEC 2
+#define OPEN_FD_EXCLUDE_STDIN  0x01
+#define OPEN_FD_EXCLUDE_STDOUT 0x02
+#define OPEN_FD_EXCLUDE_STDERR 0x04
+void for_each_open_fd(int action, unsigned int excluded_fds);
 
 void netdata_cleanup_and_exit(int ret) NORETURN;
 void send_statistics(const char *action, const char *action_result, const char *action_data);

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -430,6 +430,8 @@ static inline char *get_word(char **words, size_t num_words, size_t index) {
 
 bool run_command_and_copy_output_to_stdout(const char *command, int max_line_length);
 
+void for_each_open_fd(char *action_str);
+
 void netdata_cleanup_and_exit(int ret) NORETURN;
 void send_statistics(const char *action, const char *action_result, const char *action_data);
 extern char *netdata_configured_host_prefix;

--- a/spawn/spawn_server.c
+++ b/spawn/spawn_server.c
@@ -317,7 +317,7 @@ void spawn_server(void)
 
     // close all open file descriptors, except the standard ones
     // the caller may have left open files (lxc-attach has this issue)
-    for_each_open_fd("close");
+    for_each_open_fd(OPEN_FD_ACTION_CLOSE, OPEN_FD_EXCLUDE_STDIN | OPEN_FD_EXCLUDE_STDOUT | OPEN_FD_EXCLUDE_STDERR);
 
     // Have the libuv IPC pipe be closed when forking child processes
     (void) fcntl(0, F_SETFD, FD_CLOEXEC);

--- a/spawn/spawn_server.c
+++ b/spawn/spawn_server.c
@@ -317,10 +317,7 @@ void spawn_server(void)
 
     // close all open file descriptors, except the standard ones
     // the caller may have left open files (lxc-attach has this issue)
-    int fd;
-    for(fd = (int)(sysconf(_SC_OPEN_MAX) - 1) ; fd > 2 ; --fd)
-        if(fd_is_valid(fd))
-            close(fd);
+    for_each_open_fd("close");
 
     // Have the libuv IPC pipe be closed when forking child processes
     (void) fcntl(0, F_SETFD, FD_CLOEXEC);


### PR DESCRIPTION
##### Summary
Fixes https://github.com/netdata/netdata/issues/14177 , fixes https://github.com/netdata/netdata/issues/14062 .

There are 3 places in the agent where we either try to close all open file descriptors or mark them to be closed by the `exec()` stage of `posix_spawn()`. This is done in a bruteforce way, by looping through all FD IDs up to `_SC_OPEN_MAX`.

While this is a valid approach, it creates issues on platforms that (incorrectly) set the maximum FD limit to infinity (in practice, it can be as high as `1073741816`).

This PR instead of bruteforcing its way through all possible FD IDs, it reads `/proc/self/fd` (if available) to discover which FDs are actually open and closes (or marks to be closed) only them (unless `STDIN`, `STDOUT` and/or `STDERR` are to be excluded).

This should also speed up slightly the agent initialisation time (by how much, it depends on the `_SC_OPEN_MAX` value) .

##### Test Plan

Test on a system with a very high `ulimit -n` such as `1073741816`. The agent should start up in reasonable time instead of taking >10min and consuming 100% CPU in the meantime.

TODO: Revert https://github.com/netdata/netdata/pull/14178