### PR TITLE
ci: show docker logs if docker-test fails

### DIFF
--- a/.github/scripts/docker-test.sh
+++ b/.github/scripts/docker-test.sh
@@ -26,6 +26,8 @@ wait_for() {
     sleep 1
     if [ "$i" -gt "$timeout" ]; then
       printf "Timed out!\n"
+      docker ps -a
+      docker logs netdata 2>&1
       return 1
     fi
     i="$((i + 1))"

--- a/.github/scripts/docker-test.sh
+++ b/.github/scripts/docker-test.sh
@@ -27,7 +27,9 @@ wait_for() {
     if [ "$i" -gt "$timeout" ]; then
       printf "Timed out!\n"
       docker ps -a
+      echo "::group::Netdata container logs"
       docker logs netdata 2>&1
+      echo "::endgroup::"
       return 1
     fi
     i="$((i + 1))"


### PR DESCRIPTION
##### Summary

https://github.com/netdata/netdata/blob/cd80dd6a04d4d3467189e63c29f01a01b229c2d8/.github/scripts/docker-test.sh#L25-L29

We need to check the container logs. Otherwise, it is not clear what is happening.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
