### PR TITLE
update ml defaults and readme

### DIFF
--- a/ml/Config.cc
+++ b/ml/Config.cc
@@ -28,10 +28,10 @@ void Config::readMLConfig(void) {
      * Read values
      */
 
-    unsigned MaxTrainSamples = config_get_number(ConfigSectionML, "maximum num samples to train", 4 * 3600);
+    unsigned MaxTrainSamples = config_get_number(ConfigSectionML, "maximum num samples to train", 6 * 3600);
     unsigned MinTrainSamples = config_get_number(ConfigSectionML, "minimum num samples to train", 1 * 900);
-    unsigned TrainEvery = config_get_number(ConfigSectionML, "train every", 1 * 3600);
-    unsigned NumModelsToUse = config_get_number(ConfigSectionML, "number of models per dimension", 1);
+    unsigned TrainEvery = config_get_number(ConfigSectionML, "train every", 3 * 3600);
+    unsigned NumModelsToUse = config_get_number(ConfigSectionML, "number of models per dimension", 9);
 
     unsigned DiffN = config_get_number(ConfigSectionML, "num samples to diff", 1);
     unsigned SmoothN = config_get_number(ConfigSectionML, "num samples to smooth", 3);
@@ -75,7 +75,7 @@ void Config::readMLConfig(void) {
         error("invalid min/max train samples found (%u >= %u)", MinTrainSamples, MaxTrainSamples);
 
         MinTrainSamples = 1 * 3600;
-        MaxTrainSamples = 4 * 3600;
+        MaxTrainSamples = 6 * 3600;
     }
 
     /*

--- a/ml/README.md
+++ b/ml/README.md
@@ -117,11 +117,10 @@ Below is a list of all the available configuration params and their default valu
 ```
 [ml]
 	# enabled = yes
-	# maximum num samples to train = 14400
-	# minimum num samples to train = 3600
-	# train every = 3600
-	# number of models per dimension = 1
-	# dbengine anomaly rate every = 30
+	# maximum num samples to train = 21600
+	# minimum num samples to train = 900
+	# train every = 10800
+	# number of models per dimension = 9
 	# num samples to diff = 1
 	# num samples to smooth = 3
 	# num samples to lag = 5
@@ -174,11 +173,10 @@ This example assumes 3 child nodes [streaming](https://learn.netdata.cloud/docs/
 ### Descriptions (min/max)
 
 - `enabled`: `yes` to enable, `no` to disable.
-- `maximum num samples to train`: (`3600`/`86400`) This is the maximum amount of time you would like to train each model on. For example, the default of `14400` trains on the preceding 4 hours of data, assuming an `update every` of 1 second.
+- `maximum num samples to train`: (`3600`/`86400`) This is the maximum amount of time you would like to train each model on. For example, the default of `21600` trains on the preceding 6 hours of data, assuming an `update every` of 1 second.
 - `minimum num samples to train`: (`900`/`21600`) This is the minimum amount of data required to be able to train a model. For example, the default of `900` implies that once at least 15 minutes of data is available for training, a model is trained, otherwise it is skipped and checked again at the next training run.
-- `train every`: (`1800`/`21600`) This is how often each model will be retrained. For example, the default of `3600` means that each model is retrained every hour. Note: The training of all models is spread out across the `train every` period for efficiency, so in reality, it means that each model will be trained in a staggered manner within each `train every` period.
-- `number of models per dimension`: (`1`/`168`) This is the number of trained models that will be used for scoring. For example the default `number of models per dimension = 1` means that just the most recently trained model (covering up to the most recent `maximum num samples to train` of training data) for the dimension will be used to determine the corresponding anomaly bit. Alternatively, if you have `train every = 3600` and `number of models per dimension = 24` this means that netdata will store and use the last 24 trained models for each dimension when determining the anomaly bit, this means that for the latest feature vector in this configuration to be considered anomalous it would need to look anomalous across _all_ the models trained for that dimension in the last 24 hours. As such, increasing `number of models per dimension` may reduce some false positives since it will result in more models (covering a wider time frame of training) being used during scoring.
-- `dbengine anomaly rate every`: (`30`/`900`) This is how often netdata will aggregate all the anomaly bits into a single chart (`anomaly_detection.anomaly_rates`). The aggregation into a single chart allows enabling anomaly rate ranking over _all_ metrics with one API call as opposed to a call per chart.
+- `train every`: (`1800`/`21600`) This is how often each model will be retrained. For example, the default of `10800` means that each model is retrained every 3 hours. Note: The training of all models is spread out across the `train every` period for efficiency, so in reality, it means that each model will be trained in a staggered manner within each `train every` period.
+- `number of models per dimension`: (`1`/`168`) This is the number of trained models that will be used for scoring. For example the default `number of models per dimension = 9` means that just the most recently trained 9 models for the dimension will be used to determine the corresponding anomaly bit. This means that under default settings of `maximum num samples to train = 21600`, `train every = 10800` and `number of models per dimension = 9`, means that netdata will store and use the last 9 trained models for each dimension when determining the anomaly bit, this means that for the latest feature vector in this configuration to be considered anomalous it would need to look anomalous across _all_ the models trained for that dimension in the last 9*(10800/3600) ~= 27 hours. As such, increasing `number of models per dimension` may reduce some false positives since it will result in more models (covering a wider time frame of training) being used during scoring.
 - `num samples to diff`: (`0`/`1`) This is a `0` or `1` to determine if you want the model to operate on differences of the raw data or just the raw data. For example, the default of `1` means that we take differences of the raw values. Using differences is more general and works on dimensions that might naturally tend to have some trends or cycles in them that is normal behavior to which we don't want to be too sensitive.
 - `num samples to smooth`: (`0`/`5`) This is a small integer that controls the amount of smoothing applied as part of the feature processing used by the model. For example, the default of `3` means that the rolling average of the last 3 values is used. Smoothing like this helps the model be a little more robust to spiky types of dimensions that naturally "jump" up or down as part of their normal behavior.
 - `num samples to lag`: (`0`/`5`) This is a small integer that determines how many lagged values of the dimension to include in the feature vector. For example, the default of `5` means that in addition to the most recent (by default, differenced and smoothed) value of the dimension, the feature vector will also include the 5 previous values too. Using lagged values in our feature representation allows the model to work over strange patterns over recent values of a dimension as opposed to just focusing on if the most recent value itself is big or small enough to be anomalous.


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR updates the below default params for the `[ml]` section in `netdata.conf`

- `maximum num samples to train` from `14400` (4 hours) to `21600` (6 hours).
- `train every` from `3600` (1 hour) to `10800` (3 hours).
- `number of models per dimension` from `1` to `9`.

The aim of this is to have anomaly detection in Netdata by default (in steady state once all models trained) covering last 24+ hours in terms of "what it is trained on". 

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

This PR will be created as draft first and results from test and experiments of internal dogfooding will be added to the PR to provide a log of testing, results and motivations for this change.

depends on #14217 
