### PR TITLE
Drop ARMv7 native packages for Fedora 36.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -124,10 +124,6 @@ include:
     packages:
       <<: *fedora_packages
       repo_distro: fedora/36
-      arches:
-        - x86_64
-        - armhfp
-        - aarch64
     test:
       ebpf-core: true
 

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -58,7 +58,7 @@ to work on these platforms with minimal user effort.
 | Debian | 11.x | x86\_64, i386, ARMv7, AArch64 | |
 | Debian | 10.x | x86\_64, i386, ARMv7, AArch64 | |
 | Fedora | 37 | x86\_64, AArch64 | |
-| Fedora | 36 | x86\_64, ARMv7, AArch64 | |
+| Fedora | 36 | x86\_64, AArch64 | |
 | openSUSE | Leap 15.4 | x86\_64, AArch64 | |
 | Oracle Linux | 9.x | x86\_64, AArch64 | |
 | Oracle Linux | 8.x | x86\_64, AArch64 | |


### PR DESCRIPTION
##### Summary

They have not been building properly for quite some time now due to upstream bugs in Fedora itself, so stop wasting resources trying to build them.

##### Test Plan

n/a

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
No functional changes for users because we were not successfully publishing these packages anyway.
</details>
