### PR TITLE
pre gcc v5 support and allow building without dbengine

### DIFF
--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -996,6 +996,8 @@ static void sqlite3_statistics_charts(void) {
     // ----------------------------------------------------------------
 }
 
+#ifdef ENABLE_DBENGINE
+
 struct dbengine2_cache_pointers {
     RRDSET *st_cache_hit_ratio;
     RRDDIM *rd_hit_ratio_closest;
@@ -2323,6 +2325,7 @@ static void dbengine2_statistics_charts(void) {
         }
     }
 }
+#endif // ENABLE_DBENGINE
 
 static void update_strings_charts() {
     static RRDSET *st_ops = NULL, *st_entries = NULL, *st_mem = NULL;

--- a/database/engine/datafile.c
+++ b/database/engine/datafile.c
@@ -25,12 +25,11 @@ static struct rrdengine_datafile *datafile_alloc_and_init(struct rrdengine_insta
     fatal_assert(0 == uv_rwlock_init(&datafile->extent_rwlock));
     datafile->ctx = ctx;
 
-    datafile->users.spinlock = NETDATA_SPINLOCK_INITIALIZER;
     datafile->users.available = true;
 
-    datafile->extent_exclusive_access.spinlock = NETDATA_SPINLOCK_INITIALIZER;
-
-    datafile->writers.spinlock = NETDATA_SPINLOCK_INITIALIZER;
+    netdata_spinlock_init(&datafile->users.spinlock);
+    netdata_spinlock_init(&datafile->extent_exclusive_access.spinlock);
+    netdata_spinlock_init(&datafile->writers.spinlock);
 
     return datafile;
 }

--- a/database/engine/metric.c
+++ b/database/engine/metric.c
@@ -120,7 +120,7 @@ static METRIC *metric_add(MRG *mrg, MRG_ENTRY *entry, bool *ret) {
     metric->latest_time_s_clean = entry->last_time_s;
     metric->latest_time_s_hot = 0;
     metric->latest_update_every_s = entry->latest_update_every_s;
-    metric->timestamps_lock = NETDATA_SPINLOCK_INITIALIZER;
+    netdata_spinlock_init(&metric->timestamps_lock);
     *PValue = metric;
 
     mrg_index_write_unlock(mrg);

--- a/libnetdata/locks/locks.c
+++ b/libnetdata/locks/locks.c
@@ -279,7 +279,7 @@ int __netdata_rwlock_trywrlock(netdata_rwlock_t *rwlock) {
 // https://www.youtube.com/watch?v=rmGJc9PXpuE&t=41s
 
 void netdata_spinlock_init(SPINLOCK *spinlock) {
-    *spinlock = NETDATA_SPINLOCK_INITIALIZER;
+    memset(spinlock, 0, sizeof(SPINLOCK));
 }
 
 void netdata_spinlock_lock(SPINLOCK *spinlock) {

--- a/libnetdata/locks/locks.h
+++ b/libnetdata/locks/locks.h
@@ -16,7 +16,9 @@ typedef struct netdata_spinlock {
     pid_t locker_pid;
 #endif
 } SPINLOCK;
-#define NETDATA_SPINLOCK_INITIALIZER (SPINLOCK) { .locked = false }
+
+#define NETDATA_SPINLOCK_INITIALIZER \
+    { .locked = false }
 
 void netdata_spinlock_init(SPINLOCK *spinlock);
 void netdata_spinlock_lock(SPINLOCK *spinlock);

--- a/libnetdata/worker_utilization/worker_utilization.c
+++ b/libnetdata/worker_utilization/worker_utilization.c
@@ -83,7 +83,7 @@ void worker_register(const char *name) {
     struct workers_workname *workname = *PValue;
     if(!workname) {
         workname = mallocz(sizeof(struct workers_workname));
-        workname->spinlock = NETDATA_SPINLOCK_INITIALIZER;
+        netdata_spinlock_init(&workname->spinlock);
         workname->base = NULL;
         *PValue = workname;
     }


### PR DESCRIPTION
gcc versions prior to 5 do not allow initializing static members/variables with this expression:

```c
#define NETDATA_SPINLOCK_INITIALIZER (SPINLOCK){ .locked = false, }
```

They throw a message that the above is not a constant initializer. But they accept the same without the cast:

```c
#define NETDATA_SPINLOCK_INITIALIZER { .locked = false, }
```

This PR changes the code to allow compiling with gcc versions prior to 5.

Also, global statistics fail when dbengine is not enabled. This PR fixes that too.