### PR TITLE
Revert health to run in a single thread

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -49,6 +49,8 @@ float last_backoff_value = 0;
 
 time_t aclk_block_until = 0;
 
+int aclk_alert_reloaded = 0; //1 on health log exchange, and again on health_reload
+
 #ifdef ENABLE_ACLK
 mqtt_wss_client mqttwss_client;
 

--- a/aclk/aclk.h
+++ b/aclk/aclk.h
@@ -26,6 +26,8 @@ extern time_t aclk_block_until;
 
 extern int disconnect_req;
 
+extern int aclk_alert_reloaded;
+
 #ifdef ENABLE_ACLK
 void *aclk_main(void *ptr);
 

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -201,7 +201,7 @@ static void svc_rrd_cleanup_obsolete_charts_from_all_hosts() {
             && (
                    (
                     host->child_last_chart_command
-                 && host->child_last_chart_command + host->health_delay_up_to < now_realtime_sec()
+                 && host->child_last_chart_command + host->health.health_delay_up_to < now_realtime_sec()
                    )
                 || (host->child_connect_time + TIME_TO_RUN_OBSOLETIONS_ON_CHILD_CONNECT < now_realtime_sec())
                 )

--- a/daemon/static_threads.c
+++ b/daemon/static_threads.c
@@ -37,6 +37,15 @@ const struct netdata_static_thread static_threads_common[] = {
         .start_routine = cpuidlejitter_main
     },
     {
+        .name = "HEALTH",
+        .config_section = NULL,
+        .config_name = NULL,
+        .enabled = 1,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = health_main
+    },
+    {
         .name = "ANALYTICS",
         .config_section = NULL,
         .config_name = NULL,

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -888,6 +888,17 @@ typedef struct alarm_log {
     netdata_rwlock_t alarm_log_rwlock;
 } ALARM_LOG;
 
+typedef struct health {
+    unsigned int health_enabled;                   // 1 when this host has health enabled
+    time_t health_delay_up_to;                     // a timestamp to delay alarms processing up to
+    STRING *health_default_exec;                   // the full path of the alarms notifications program
+    STRING *health_default_recipient;              // the default recipient for all alarms
+    char *health_log_filename;                     // the alarms event log filename
+    size_t health_log_entries_written;             // the number of alarm events written to the alarms event log
+    FILE *health_log_fp;                           // the FILE pointer to the open alarms event log file
+    uint32_t health_default_warn_repeat_every;     // the default value for the interval between repeating warning notifications
+    uint32_t health_default_crit_repeat_every;     // the default value for the interval between repeating critical notifications
+} HEALTH;
 
 // ----------------------------------------------------------------------------
 // RRD HOST
@@ -1005,15 +1016,8 @@ struct rrdhost {
     // ------------------------------------------------------------------------
     // health monitoring options
 
-    unsigned int health_enabled;                   // 1 when this host has health enabled
-    time_t health_delay_up_to;                     // a timestamp to delay alarms processing up to
-    STRING *health_default_exec;                   // the full path of the alarms notifications program
-    STRING *health_default_recipient;              // the default recipient for all alarms
-    char *health_log_filename;                     // the alarms event log filename
-    size_t health_log_entries_written;             // the number of alarm events written to the alarms event log
-    FILE *health_log_fp;                           // the FILE pointer to the open alarms event log file
-    uint32_t health_default_warn_repeat_every;     // the default value for the interval between repeating warning notifications
-    uint32_t health_default_crit_repeat_every;     // the default value for the interval between repeating critical notifications
+    // health variables
+    HEALTH health;
 
     // all RRDCALCs are primarily allocated and linked here
     DICTIONARY *rrdcalc_root_index;

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1006,8 +1006,6 @@ struct rrdhost {
     // health monitoring options
 
     unsigned int health_enabled;                   // 1 when this host has health enabled
-    bool health_spawn;                             // true when health thread is running
-    unsigned int aclk_alert_reloaded;              // 1 on thread start and health reload, 0 after removed are sent
     time_t health_delay_up_to;                     // a timestamp to delay alarms processing up to
     STRING *health_default_exec;                   // the full path of the alarms notifications program
     STRING *health_default_recipient;              // the default recipient for all alarms

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -755,7 +755,7 @@ void rrdcalc_delete_alerts_not_matching_host_labels_from_all_hosts() {
 
     RRDHOST *host;
     rrdhost_foreach_read(host) {
-        if (unlikely(!host->health_enabled))
+        if (unlikely(!host->health.health_enabled))
             continue;
 
         if (host->rrdlabels)

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -739,7 +739,7 @@ void rrdcalc_delete_alerts_not_matching_host_labels_from_this_host(RRDHOST *host
             continue;
 
         if(!rrdlabels_match_simple_pattern_parsed(host->rrdlabels, rc->host_labels_pattern, '=')) {
-            info("Health configuration for alarm '%s' cannot be applied, because the host %s does not have the label(s) '%s'",
+            log_health("Health configuration for alarm '%s' cannot be applied, because the host %s does not have the label(s) '%s'",
                  rrdcalc_name(rc),
                  rrdhost_hostname(host),
                  rrdcalc_host_labels(rc));

--- a/database/rrddimvar.c
+++ b/database/rrddimvar.c
@@ -65,7 +65,7 @@ static inline void rrddimvar_free_variables_unsafe(RRDDIMVAR *rs) {
 
     // HOST VARIABLES FOR THIS DIMENSION
 
-    if(host->rrdvars && host->health_enabled) {
+    if(host->rrdvars && host->health.health_enabled) {
         rrdvar_release_and_del(host->rrdvars, rs->rrdvar_host_chart_id_dim_id);
         rs->rrdvar_host_chart_id_dim_id = NULL;
 
@@ -152,7 +152,7 @@ static inline void rrddimvar_update_variables_unsafe(RRDDIMVAR *rs) {
     // - $chart-name.id
     // - $chart-name.name
 
-    if(host->rrdvars && host->health_enabled) {
+    if(host->rrdvars && host->health.health_enabled) {
         rs->rrdvar_host_chart_id_dim_id = rrdvar_add_and_acquire("host", host->rrdvars, key_chart_id_dim_id, rs->type, RRDVAR_FLAG_NONE, rs->value);
         rs->rrdvar_host_chart_id_dim_name = rrdvar_add_and_acquire("host", host->rrdvars, key_chart_id_dim_name, rs->type, RRDVAR_FLAG_NONE, rs->value);
         rs->rrdvar_host_chart_name_dim_id = rrdvar_add_and_acquire("host", host->rrdvars, key_chart_name_dim_id, rs->type, RRDVAR_FLAG_NONE, rs->value);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -281,8 +281,8 @@ int is_legacy = 1;
 
     rrdhost_init_hostname(host, hostname, false);
 
-    host->rrd_history_entries = align_entries_to_pagesize(memory_mode, entries);
-    host->health_enabled      = ((memory_mode == RRD_MEMORY_MODE_NONE)) ? 0 : health_enabled;
+    host->rrd_history_entries        = align_entries_to_pagesize(memory_mode, entries);
+    host->health.health_enabled      = ((memory_mode == RRD_MEMORY_MODE_NONE)) ? 0 : health_enabled;
 
     if (likely(!archived)) {
         rrdfunctions_init(host);
@@ -512,12 +512,12 @@ int is_legacy = 1;
          , rrdhost_has_rrdpush_sender_enabled(host)?"enabled":"disabled"
          , host->rrdpush_send_destination?host->rrdpush_send_destination:""
          , host->rrdpush_send_api_key?host->rrdpush_send_api_key:""
-         , host->health_enabled?"enabled":"disabled"
+         , host->health.health_enabled?"enabled":"disabled"
          , host->cache_dir
          , host->varlib_dir
-         , host->health_log_filename
-         , string2str(host->health_default_exec)
-         , string2str(host->health_default_recipient)
+         , host->health.health_log_filename
+         , string2str(host->health.health_default_exec)
+         , string2str(host->health.health_default_recipient)
     );
 
     if(!archived)
@@ -562,7 +562,7 @@ static void rrdhost_update(RRDHOST *host
 
     netdata_spinlock_lock(&host->rrdhost_update_lock);
 
-    host->health_enabled = (mode == RRD_MEMORY_MODE_NONE) ? 0 : health_enabled;
+    host->health.health_enabled = (mode == RRD_MEMORY_MODE_NONE) ? 0 : health_enabled;
 
     {
         struct rrdhost_system_info *old = host->system_info;
@@ -1168,9 +1168,9 @@ void rrdhost_free___while_having_rrd_wrlock(RRDHOST *host, bool force) {
     freez(host->rrdpush_send_api_key);
     freez(host->rrdpush_send_destination);
     rrdpush_destinations_free(host);
-    string_freez(host->health_default_exec);
-    string_freez(host->health_default_recipient);
-    freez(host->health_log_filename);
+    string_freez(host->health.health_default_exec);
+    string_freez(host->health.health_default_recipient);
+    freez(host->health.health_log_filename);
     string_freez(host->registry_hostname);
     simple_pattern_free(host->rrdpush_send_charts_matching);
     netdata_rwlock_destroy(&host->health_log.alarm_log_rwlock);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -365,9 +365,6 @@ int is_legacy = 1;
     rrdcalctemplate_index_init(host);
     rrdcalc_rrdhost_index_init(host);
 
-    if (health_enabled)
-        health_thread_spawn(host);
-
     if (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
 #ifdef ENABLE_DBENGINE
         char dbenginepath[FILENAME_MAX + 1];
@@ -649,9 +646,6 @@ static void rrdhost_update(RRDHOST *host
         rrdhost_load_rrdcontext_data(host);
         info("Host %s is not in archived mode anymore", rrdhost_hostname(host));
     }
-
-    if (health_enabled)
-        health_thread_spawn(host);
 
     netdata_spinlock_unlock(&host->rrdhost_update_lock);
 }
@@ -1375,7 +1369,6 @@ void reload_host_labels(void) {
     health_label_log_save(localhost);
 
     rrdpush_send_host_labels(localhost);
-    health_reload();
 }
 
 // ----------------------------------------------------------------------------

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -168,7 +168,7 @@ static void rrdset_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
     // chart variables - we need this for data collection to work (collector given chart variables) - not only health
     rrdsetvar_index_init(st);
 
-    if (host->health_enabled) {
+    if (host->health.health_enabled) {
         st->rrdfamily = rrdfamily_add_and_acquire(host, rrdset_family(st));
         st->rrdvars = rrdvariables_create();
         rrddimvar_index_init(st);
@@ -366,7 +366,7 @@ static void rrdset_react_callback(const DICTIONARY_ITEM *item __maybe_unused, vo
 
     st->last_accessed_time_s = now_realtime_sec();
 
-    if(host->health_enabled && (ctr->react_action & (RRDSET_REACT_NEW | RRDSET_REACT_CHART_ACTIVATED))) {
+    if(host->health.health_enabled && (ctr->react_action & (RRDSET_REACT_NEW | RRDSET_REACT_CHART_ACTIVATED))) {
         rrdset_flag_set(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
         rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
     }

--- a/database/rrdsetvar.c
+++ b/database/rrdsetvar.c
@@ -43,7 +43,7 @@ static inline void rrdsetvar_free_rrdvars_unsafe(RRDSET *st, RRDSETVAR *rs) {
     // ------------------------------------------------------------------------
     // HOST
 
-    if(host->rrdvars && host->health_enabled) {
+    if(host->rrdvars && host->health.health_enabled) {
         rrdvar_release_and_del(host->rrdvars, rs->rrdvar_host_chart_id);
         rs->rrdvar_host_chart_id = NULL;
 
@@ -93,7 +93,7 @@ static inline void rrdsetvar_update_rrdvars_unsafe(RRDSET *st, RRDSETVAR *rs) {
     // ------------------------------------------------------------------------
     // HOST
 
-    if(host->rrdvars && host->health_enabled) {
+    if(host->rrdvars && host->health.health_enabled) {
         rs->rrdvar_host_chart_id = rrdvar_add_and_acquire("host", host->rrdvars, key_chart_id, rs->type, options, rs->value);
         rs->rrdvar_host_chart_name = rrdvar_add_and_acquire("host", host->rrdvars, key_chart_name, rs->type, options, rs->value);
     }

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -544,6 +544,8 @@ void aclk_push_alarm_health_log(struct aclk_database_worker_config *wc, struct a
 
     freez(claim_id);
     buffer_free(sql);
+
+    aclk_alert_reloaded = 1;
 #endif
 
     return;

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -314,7 +314,7 @@ void aclk_push_alert_event(struct aclk_database_worker_config *wc, struct aclk_d
         alarm_log.utc_offset = wc->host->utc_offset;
         alarm_log.timezone = strdupz(rrdhost_abbrev_timezone(wc->host));
         alarm_log.exec_path = sqlite3_column_bytes(res, 14) > 0 ? strdupz((char *)sqlite3_column_text(res, 14)) :
-                                                                  strdupz((char *)string2str(wc->host->health_default_exec));
+                                                                  strdupz((char *)string2str(wc->host->health.health_default_exec));
         alarm_log.conf_source = strdupz((char *)sqlite3_column_text(res, 16));
 
         char *edit_command = sqlite3_column_bytes(res, 16) > 0 ?
@@ -531,7 +531,7 @@ void aclk_push_alarm_health_log(struct aclk_database_worker_config *wc, struct a
     alarm_log.node_id =  wc->node_id;
     alarm_log.log_entries = log_entries;
     alarm_log.status = wc->alert_updates == 0 ? 2 : 1;
-    alarm_log.enabled = (int)host->health_enabled;
+    alarm_log.enabled = (int)host->health.health_enabled;
 
     wc->alert_sequence_id = last_sequence;
 
@@ -711,7 +711,7 @@ void aclk_start_alert_streaming(char *node_id, uint64_t batch_id, uint64_t start
                  (struct aclk_database_worker_config *)host->dbsync_worker :
                  (struct aclk_database_worker_config *)find_inactive_wc_by_node_id(node_id);
 
-        if (unlikely(!host->health_enabled)) {
+        if (unlikely(!host->health.health_enabled)) {
             log_access("ACLK STA [%s (N/A)]: Ignoring request to stream alert state changes, health is disabled.", node_id);
             return;
         }
@@ -851,7 +851,7 @@ void health_alarm_entry2proto_nolock(struct alarm_log_entry *alarm_log, ALARM_EN
 
     alarm_log->utc_offset = host->utc_offset;
     alarm_log->timezone = strdupz(rrdhost_abbrev_timezone(host));
-    alarm_log->exec_path = ae->exec ? strdupz(ae_exec(ae)) : strdupz((char *)string2str(host->health_default_exec));
+    alarm_log->exec_path = ae->exec ? strdupz(ae_exec(ae)) : strdupz((char *)string2str(host->health.health_default_exec));
     alarm_log->conf_source = ae->source ? strdupz(ae_source(ae)) : strdupz((char *)"");
 
     alarm_log->command = strdupz((char *)edit_command);

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -337,7 +337,7 @@ void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae) {
     }
 
     ae->flags |= HEALTH_ENTRY_FLAG_SAVED;
-    host->health_log_entries_written++;
+    host->health.health_log_entries_written++;
 
     failed:
     if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
@@ -369,7 +369,7 @@ void sql_health_alarm_log_cleanup(RRDHOST *host) {
         if(rotate_every < 100) rotate_every = 100;
     }
 
-    if(likely(host->health_log_entries_written < rotate_every)) {
+    if(likely(host->health.health_log_entries_written < rotate_every)) {
         return;
     }
 
@@ -382,7 +382,7 @@ void sql_health_alarm_log_cleanup(RRDHOST *host) {
     char uuid_str[GUID_LEN + 1];
     uuid_unparse_lower_fix(&host->host_uuid, uuid_str);
 
-    snprintfz(command, MAX_HEALTH_SQL_SIZE, SQL_CLEANUP_HEALTH_LOG(uuid_str, uuid_str, (unsigned long int) (host->health_log_entries_written - rotate_every)));
+    snprintfz(command, MAX_HEALTH_SQL_SIZE, SQL_CLEANUP_HEALTH_LOG(uuid_str, uuid_str, (unsigned long int) (host->health.health_log_entries_written - rotate_every)));
 
     rc = sqlite3_prepare_v2(db_meta, command, -1, &res, 0);
     if (unlikely(rc != SQLITE_OK)) {
@@ -398,7 +398,7 @@ void sql_health_alarm_log_cleanup(RRDHOST *host) {
     if (unlikely(rc != SQLITE_OK))
         error_report("Failed to finalize the prepared statement to cleanup health log table");
 
-    host->health_log_entries_written = rotate_every;
+    host->health.health_log_entries_written = rotate_every;
 
     sql_aclk_alert_clean_dead_entries(host);
 }
@@ -431,13 +431,13 @@ void sql_health_alarm_log_count(RRDHOST *host) {
 
     rc = sqlite3_step_monitored(res);
     if (likely(rc == SQLITE_ROW))
-        host->health_log_entries_written = (size_t) sqlite3_column_int64(res, 0);
+        host->health.health_log_entries_written = (size_t) sqlite3_column_int64(res, 0);
 
     rc = sqlite3_finalize(res);
     if (unlikely(rc != SQLITE_OK))
         error_report("Failed to finalize the prepared statement to count health log entries from db");
 
-    info("HEALTH [%s]: Table health_log_%s, contains %lu entries.", rrdhost_hostname(host), uuid_str, (unsigned long int) host->health_log_entries_written);
+    info("HEALTH [%s]: Table health_log_%s, contains %lu entries.", rrdhost_hostname(host), uuid_str, (unsigned long int) host->health.health_log_entries_written);
 }
 
 #define SQL_INJECT_REMOVED(guid, guid2) "insert into health_log_%s (hostname, unique_id, alarm_id, alarm_event_id, config_hash_id, updated_by_id, updates_id, when_key, duration, non_clear_duration, flags, exec_run_timestamp, " \
@@ -612,7 +612,7 @@ void sql_health_alarm_log_load(RRDHOST *host) {
     ssize_t errored = 0, loaded = 0;
     char command[MAX_HEALTH_SQL_SIZE + 1];
 
-    host->health_log_entries_written = 0;
+    host->health.health_log_entries_written = 0;
 
     if (unlikely(!db_meta)) {
         if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -685,6 +685,16 @@ skip_run:
         error_report("Failed to finalize the prepared statement when reading dimensions");
 }
 
+static void cleanup_health_log(void)
+{
+    RRDHOST *host;
+    dfe_start_reentrant(rrdhost_root_index, host) {
+        if (rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED) || !rrdhost_flag_check(host, RRDHOST_FLAG_METADATA_UPDATE))
+            continue;
+        sql_health_alarm_log_cleanup(host);
+    }
+    dfe_done(host);
+}
 
 //
 // EVENT LOOP STARTS HERE
@@ -844,6 +854,7 @@ static void start_metadata_cleanup(uv_work_t *req)
     worker_is_busy(UV_EVENT_METADATA_CLEANUP);
     struct metadata_wc *wc = req->data;
     check_dimension_metadata(wc);
+    cleanup_health_log();
     worker_is_idle();
 }
 

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -689,7 +689,7 @@ static void cleanup_health_log(void)
 {
     RRDHOST *host;
     dfe_start_reentrant(rrdhost_root_index, host) {
-        if (rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED) || !rrdhost_flag_check(host, RRDHOST_FLAG_METADATA_UPDATE))
+        if (rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED))
             continue;
         sql_health_alarm_log_cleanup(host);
     }

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -327,7 +327,7 @@ static int sql_store_host_info(RRDHOST *host)
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = sqlite3_bind_int(res, ++param, (int ) host->health_enabled);
+    rc = sqlite3_bind_int(res, ++param, (int ) host->health.health_enabled);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 

--- a/health/health.c
+++ b/health/health.c
@@ -1010,8 +1010,6 @@ void *health_main(void *ptr) {
     int min_run_every = (int)config_get_number(CONFIG_SECTION_HEALTH, "run at least every seconds", 10);
     if(min_run_every < 1) min_run_every = 1;
 
-    int cleanup_sql_every_loop = 7200 / min_run_every;
-
     time_t hibernation_delay  = config_get_number(CONFIG_SECTION_HEALTH, "postpone alarms during hibernation for seconds", 60);
 
     bool health_running_logged = false;
@@ -1103,9 +1101,6 @@ void *health_main(void *ptr) {
                 log_health("[%s]: Health is running.", rrdhost_hostname(host));
                 health_running_logged = true;
             }
-
-            if(likely(!host->health.health_log_fp) && (loop == 1 || loop % cleanup_sql_every_loop == 0))
-                sql_health_alarm_log_cleanup(host);
 
             worker_is_busy(WORKER_HEALTH_JOB_HOST_LOCK);
 

--- a/health/health.c
+++ b/health/health.c
@@ -1012,7 +1012,6 @@ void *health_main(void *ptr) {
 
     int cleanup_sql_every_loop = 7200 / min_run_every;
 
-    time_t now                = now_realtime_sec();
     time_t hibernation_delay  = config_get_number(CONFIG_SECTION_HEALTH, "postpone alarms during hibernation for seconds", 60);
 
     bool health_running_logged = false;
@@ -1027,7 +1026,7 @@ void *health_main(void *ptr) {
         loop++;
         debug(D_HEALTH, "Health monitoring iteration no %u started", loop);
 
-        now = now_realtime_sec();
+        time_t now = now_realtime_sec();
         int runnable = 0, apply_hibernation_delay = 0;
         time_t next_run = now + min_run_every;
         RRDCALC *rc;

--- a/health/health.c
+++ b/health/health.c
@@ -1206,21 +1206,6 @@ void *health_main(void *ptr) {
                     } else
                         rc->run_flags &= ~RRDCALC_FLAG_DB_ERROR;
 
-                    /* - RRDCALC_FLAG_DB_STALE not currently used
-                       if (unlikely(old_db_timestamp == rc->db_before)) {
-                       // database is stale
-
-                       debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': database is stale", host->hostname, rc->chart?rc->chart:"NOCHART", rc->name);
-
-                       if (unlikely(!(rc->rrdcalc_flags & RRDCALC_FLAG_DB_STALE))) {
-                       rc->rrdcalc_flags |= RRDCALC_FLAG_DB_STALE;
-                       error("Health on host '%s', alarm '%s.%s': database is stale", host->hostname, rc->chart?rc->chart:"NOCHART", rc->name);
-                       }
-                       }
-                       else if (unlikely(rc->rrdcalc_flags & RRDCALC_FLAG_DB_STALE))
-                       rc->rrdcalc_flags &= ~RRDCALC_FLAG_DB_STALE;
-                    */
-
                     if (unlikely(value_is_null)) {
                         // collected value is null
                         rc->value = NAN;

--- a/health/health.c
+++ b/health/health.c
@@ -162,7 +162,7 @@ char *silencers_filename;
 SIMPLE_PATTERN *conf_enabled_alarms = NULL;
 
 // the queue of executed alarm notifications that haven't been waited for yet
-static __thread struct {
+static struct {
     ALARM_ENTRY *head; // oldest
     ALARM_ENTRY *tail; // latest
 } alarm_notifications_in_progress = {NULL, NULL};
@@ -346,7 +346,6 @@ static void health_reload_host(RRDHOST *host) {
         rrdcalctemplate_link_matching_templates_to_rrdset(st);
     }
     rrdset_foreach_done(st);
-    host->aclk_alert_reloaded = 1;
 }
 
 /**
@@ -364,6 +363,12 @@ void health_reload(void) {
         health_reload_host(host);
 
     rrd_unlock();
+
+#ifdef ENABLE_ACLK
+    if (netdata_cloud_setting) {
+        aclk_alert_reloaded = 1;
+    }
+#endif
 }
 
 // ----------------------------------------------------------------------------
@@ -720,7 +725,7 @@ static inline int rrdcalc_isrunnable(RRDCALC *rc, time_t now, time_t *next_run) 
 }
 
 static inline int check_if_resumed_from_suspension(void) {
-    static __thread usec_t last_realtime = 0, last_monotonic = 0;
+    static usec_t last_realtime = 0, last_monotonic = 0;
     usec_t realtime = now_realtime_usec(), monotonic = now_monotonic_usec();
     int ret = 0;
 
@@ -736,14 +741,15 @@ static inline int check_if_resumed_from_suspension(void) {
     return ret;
 }
 
-static void health_thread_cleanup(void *ptr) {
+static void health_main_cleanup(void *ptr) {
     worker_unregister();
 
-    struct health_state *h = ptr;
-    h->host->health_spawn = 0;
+    struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
+    info("cleaning up...");
+    static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 
-    log_health("[%s]: Health thread ended.", rrdhost_hostname(h->host));
-    debug(D_HEALTH, "HEALTH %s: Health thread ended.", rrdhost_hostname(h->host));
+    log_health("Health thread ended.");
 }
 
 static void initialize_health(RRDHOST *host, int is_localhost) {
@@ -834,16 +840,14 @@ static void initialize_health(RRDHOST *host, int is_localhost) {
 
     //Discard alarms with labels that do not apply to host
     rrdcalc_delete_alerts_not_matching_host_labels_from_this_host(host);
-
-    health_silencers_init();
 }
 
-static void health_sleep(time_t next_run, unsigned int loop __maybe_unused, RRDHOST *host) {
+static void health_sleep(time_t next_run, unsigned int loop __maybe_unused) {
     time_t now = now_realtime_sec();
     if(now < next_run) {
         worker_is_idle();
         debug(D_HEALTH, "Health monitoring iteration no %u done. Next iteration in %d secs", loop, (int) (next_run - now));
-        while (now < next_run && host->health_enabled && service_running(SERVICE_HEALTH)) {
+        while (now < next_run && service_running(SERVICE_HEALTH)) {
             sleep_usec(USEC_PER_SEC);
             now = now_realtime_sec();
         }
@@ -1001,11 +1005,7 @@ void *health_main(void *ptr) {
     worker_register_job_name(WORKER_HEALTH_JOB_DELAYED_INIT_RRDSET, "rrdset init");
     worker_register_job_name(WORKER_HEALTH_JOB_DELAYED_INIT_RRDDIM, "rrddim init");
 
-    struct health_state *h = ptr;
-    netdata_thread_cleanup_push(health_thread_cleanup, ptr);
-
-    RRDHOST *host = h->host;
-    initialize_health(host, host == localhost);
+    netdata_thread_cleanup_push(health_main_cleanup, ptr);
 
     int min_run_every = (int)config_get_number(CONFIG_SECTION_HEALTH, "run at least every seconds", 10);
     if(min_run_every < 1) min_run_every = 1;
@@ -1017,13 +1017,13 @@ void *health_main(void *ptr) {
 
     bool health_running_logged = false;
 
-    rrdcalc_delete_alerts_not_matching_host_labels_from_this_host(host);
+    rrdcalc_delete_alerts_not_matching_host_labels_from_all_hosts();
 
     unsigned int loop = 0;
 #ifdef ENABLE_ACLK
     unsigned int marked_aclk_reload_loop = 0;
 #endif
-    while(service_running(SERVICE_HEALTH) && host->health_enabled) {
+    while(service_running(SERVICE_HEALTH)) {
         loop++;
         debug(D_HEALTH, "Health monitoring iteration no %u started", loop);
 
@@ -1031,504 +1031,517 @@ void *health_main(void *ptr) {
         int runnable = 0, apply_hibernation_delay = 0;
         time_t next_run = now + min_run_every;
         RRDCALC *rc;
+        RRDHOST *host;
 
         if (unlikely(check_if_resumed_from_suspension())) {
             apply_hibernation_delay = 1;
 
             log_health(
-                       "[%s]: Postponing alarm checks for %"PRId64" seconds, "
+                       "Postponing alarm checks for %"PRId64" seconds, "
                        "because it seems that the system was just resumed from suspension.",
-                       rrdhost_hostname(host),
                        (int64_t)hibernation_delay);
         }
 
         if (unlikely(silencers->all_alarms && silencers->stype == STYPE_DISABLE_ALARMS)) {
-            static __thread int logged=0;
+            static int logged=0;
             if (!logged) {
-                log_health("[%s]: Skipping health checks, because all alarms are disabled via a %s command.",
-                           rrdhost_hostname(host),
+                log_health("Skipping health checks, because all alarms are disabled via a %s command.",
                            HEALTH_CMDAPI_CMD_DISABLEALL);
                 logged = 1;
             }
         }
 
 #ifdef ENABLE_ACLK
-        if (host->aclk_alert_reloaded && !marked_aclk_reload_loop)
+        if (aclk_alert_reloaded && !marked_aclk_reload_loop)
             marked_aclk_reload_loop = loop;
 #endif
 
-        if (unlikely(apply_hibernation_delay)) {
-            log_health(
-                       "[%s]: Postponing health checks for %"PRId64" seconds.",
-                       rrdhost_hostname(host),
-                       (int64_t)hibernation_delay);
+        worker_is_busy(WORKER_HEALTH_JOB_RRD_LOCK);
+        rrd_rdlock();
 
-            host->health_delay_up_to = now + hibernation_delay;
-            next_run = now + hibernation_delay;
-            health_sleep(next_run, loop, host);
-        }
+        rrdhost_foreach_read(host) {
 
-        if (unlikely(host->health_delay_up_to)) {
-            if (unlikely(now < host->health_delay_up_to)) {
-                next_run = host->health_delay_up_to;
-                health_sleep(next_run, loop, host);
+            if (unlikely(!host->health_enabled))
                 continue;
+
+            if (unlikely(!rrdhost_flag_check(host, RRDHOST_FLAG_INITIALIZED_HEALTH))) {
+                rrd_unlock();
+                initialize_health(host, host == localhost);
+                rrd_rdlock();
             }
 
-            log_health("[%s]: Resuming health checks after delay.", rrdhost_hostname(host));
-            host->health_delay_up_to = 0;
-        }
+            health_execute_delayed_initializations(host);
 
-        // wait until cleanup of obsolete charts on children is complete
-        if (host != localhost) {
-            if (unlikely(host->trigger_chart_obsoletion_check == 1)) {
-                log_health("[%s]: Waiting for chart obsoletion check.", rrdhost_hostname(host));
-                health_sleep(next_run, loop, host);
-                continue;
+            rrdcalc_delete_alerts_not_matching_host_labels_from_this_host(host);
+
+            if (unlikely(apply_hibernation_delay)) {
+                log_health(
+                           "[%s]: Postponing health checks for %"PRId64" seconds.",
+                           rrdhost_hostname(host),
+                           (int64_t)hibernation_delay);
+
+                host->health_delay_up_to = now + hibernation_delay;
             }
-        }
 
-        if (!health_running_logged) {
-            log_health("[%s]: Health is running.", rrdhost_hostname(host));
-            health_running_logged = true;
-        }
+            if (unlikely(host->health_delay_up_to)) {
+                if (unlikely(now < host->health_delay_up_to)) {
+                    continue;
+                }
 
-        if(likely(!host->health_log_fp) && (loop == 1 || loop % cleanup_sql_every_loop == 0))
-            sql_health_alarm_log_cleanup(host);
+                log_health("[%s]: Resuming health checks after delay.", rrdhost_hostname(host));
+                host->health_delay_up_to = 0;
+            }
 
-        health_execute_delayed_initializations(host);
+            // wait until cleanup of obsolete charts on children is complete
+            if (host != localhost) {
+                if (unlikely(host->trigger_chart_obsoletion_check == 1)) {
+                    log_health("[%s]: Waiting for chart obsoletion check.", rrdhost_hostname(host));
+                    continue;
+                }
+            }
 
-        worker_is_busy(WORKER_HEALTH_JOB_HOST_LOCK);
+            if (!health_running_logged) {
+                log_health("[%s]: Health is running.", rrdhost_hostname(host));
+                health_running_logged = true;
+            }
 
-        // the first loop is to lookup values from the db
-        foreach_rrdcalc_in_rrdhost_read(host, rc) {
+            if(likely(!host->health_log_fp) && (loop == 1 || loop % cleanup_sql_every_loop == 0))
+                sql_health_alarm_log_cleanup(host);
 
-            rrdcalc_update_info_using_rrdset_labels(rc);
+            worker_is_busy(WORKER_HEALTH_JOB_HOST_LOCK);
 
-            if (update_disabled_silenced(host, rc))
-                continue;
+            // the first loop is to lookup values from the db
+            foreach_rrdcalc_in_rrdhost_read(host, rc) {
 
-            // create an alert removed event if the chart is obsolete and
-            // has stopped being collected for 60 seconds
-            if (unlikely(rc->rrdset && rc->status != RRDCALC_STATUS_REMOVED &&
-                         rrdset_flag_check(rc->rrdset, RRDSET_FLAG_OBSOLETE) &&
-                         now > (rc->rrdset->last_collected_time.tv_sec + 60))) {
-                if (!rrdcalc_isrepeating(rc)) {
-                    worker_is_busy(WORKER_HEALTH_JOB_ALARM_LOG_ENTRY);
-                    time_t now = now_realtime_sec();
+                rrdcalc_update_info_using_rrdset_labels(rc);
 
-                    ALARM_ENTRY *ae = health_create_alarm_entry(
-                                                                host,
-                                                                rc->id,
-                                                                rc->next_event_id++,
-                                                                rc->config_hash_id,
-                                                                now,
-                                                                rc->name,
-                                                                rc->rrdset->id,
-                                                                rc->rrdset->context,
-                                                                rc->rrdset->family,
-                                                                rc->classification,
-                                                                rc->component,
-                                                                rc->type,
-                                                                rc->exec,
-                                                                rc->recipient,
-                                                                now - rc->last_status_change,
-                                                                rc->value,
-                                                                NAN,
-                                                                rc->status,
-                                                                RRDCALC_STATUS_REMOVED,
-                                                                rc->source,
-                                                                rc->units,
-                                                                rc->info,
-                                                                0,
-                                                                rrdcalc_isrepeating(rc)?HEALTH_ENTRY_FLAG_IS_REPEATING:0);
+                if (update_disabled_silenced(host, rc))
+                    continue;
 
-                    if (ae) {
-                        health_alarm_log_add_entry(host, ae);
-                        rc->old_status = rc->status;
-                        rc->status = RRDCALC_STATUS_REMOVED;
-                        rc->last_status_change = now;
-                        rc->last_updated = now;
-                        rc->value = NAN;
+                // create an alert removed event if the chart is obsolete and
+                // has stopped being collected for 60 seconds
+                if (unlikely(rc->rrdset && rc->status != RRDCALC_STATUS_REMOVED &&
+                             rrdset_flag_check(rc->rrdset, RRDSET_FLAG_OBSOLETE) &&
+                             now > (rc->rrdset->last_collected_time.tv_sec + 60))) {
+                    if (!rrdcalc_isrepeating(rc)) {
+                        worker_is_busy(WORKER_HEALTH_JOB_ALARM_LOG_ENTRY);
+                        time_t now = now_realtime_sec();
+
+                        ALARM_ENTRY *ae = health_create_alarm_entry(
+                                                                    host,
+                                                                    rc->id,
+                                                                    rc->next_event_id++,
+                                                                    rc->config_hash_id,
+                                                                    now,
+                                                                    rc->name,
+                                                                    rc->rrdset->id,
+                                                                    rc->rrdset->context,
+                                                                    rc->rrdset->family,
+                                                                    rc->classification,
+                                                                    rc->component,
+                                                                    rc->type,
+                                                                    rc->exec,
+                                                                    rc->recipient,
+                                                                    now - rc->last_status_change,
+                                                                    rc->value,
+                                                                    NAN,
+                                                                    rc->status,
+                                                                    RRDCALC_STATUS_REMOVED,
+                                                                    rc->source,
+                                                                    rc->units,
+                                                                    rc->info,
+                                                                    0,
+                                                                    rrdcalc_isrepeating(rc)?HEALTH_ENTRY_FLAG_IS_REPEATING:0);
+
+                        if (ae) {
+                            health_alarm_log_add_entry(host, ae);
+                            rc->old_status = rc->status;
+                            rc->status = RRDCALC_STATUS_REMOVED;
+                            rc->last_status_change = now;
+                            rc->last_updated = now;
+                            rc->value = NAN;
 
 #ifdef ENABLE_ACLK
-                        if (netdata_cloud_setting && likely(!host->aclk_alert_reloaded))
-                            sql_queue_alarm_to_aclk(host, ae, 1);
+                            if (netdata_cloud_setting && likely(!aclk_alert_reloaded))
+                                sql_queue_alarm_to_aclk(host, ae, 1);
 #endif
-                    }
-                }
-            }
-
-            if (unlikely(!rrdcalc_isrunnable(rc, now, &next_run))) {
-                if (unlikely(rc->run_flags & RRDCALC_FLAG_RUNNABLE))
-                    rc->run_flags &= ~RRDCALC_FLAG_RUNNABLE;
-                continue;
-            }
-
-            runnable++;
-            rc->old_value = rc->value;
-            rc->run_flags |= RRDCALC_FLAG_RUNNABLE;
-
-            // ------------------------------------------------------------
-            // if there is database lookup, do it
-
-            if (unlikely(RRDCALC_HAS_DB_LOOKUP(rc))) {
-                worker_is_busy(WORKER_HEALTH_JOB_DB_QUERY);
-
-                /* time_t old_db_timestamp = rc->db_before; */
-                int value_is_null = 0;
-
-                int ret = rrdset2value_api_v1(rc->rrdset, NULL, &rc->value, rrdcalc_dimensions(rc), 1,
-                                              rc->after, rc->before, rc->group, NULL,
-                                              0, rc->options,
-                                              &rc->db_after,&rc->db_before,
-                                              NULL, NULL, NULL,
-                                              &value_is_null, NULL, 0, 0,
-                                              QUERY_SOURCE_HEALTH, STORAGE_PRIORITY_LOW);
-
-                if (unlikely(ret != 200)) {
-                    // database lookup failed
-                    rc->value = NAN;
-                    rc->run_flags |= RRDCALC_FLAG_DB_ERROR;
-
-                    debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': database lookup returned error %d",
-                          rrdhost_hostname(host), rrdcalc_chart_name(rc), rrdcalc_name(rc), ret
-                          );
-                } else
-                    rc->run_flags &= ~RRDCALC_FLAG_DB_ERROR;
-
-                /* - RRDCALC_FLAG_DB_STALE not currently used
-                   if (unlikely(old_db_timestamp == rc->db_before)) {
-                   // database is stale
-
-                   debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': database is stale", host->hostname, rc->chart?rc->chart:"NOCHART", rc->name);
-
-                   if (unlikely(!(rc->rrdcalc_flags & RRDCALC_FLAG_DB_STALE))) {
-                   rc->rrdcalc_flags |= RRDCALC_FLAG_DB_STALE;
-                   error("Health on host '%s', alarm '%s.%s': database is stale", host->hostname, rc->chart?rc->chart:"NOCHART", rc->name);
-                   }
-                   }
-                   else if (unlikely(rc->rrdcalc_flags & RRDCALC_FLAG_DB_STALE))
-                   rc->rrdcalc_flags &= ~RRDCALC_FLAG_DB_STALE;
-                */
-
-                if (unlikely(value_is_null)) {
-                    // collected value is null
-                    rc->value = NAN;
-                    rc->run_flags |= RRDCALC_FLAG_DB_NAN;
-
-                    debug(D_HEALTH,
-                          "Health on host '%s', alarm '%s.%s': database lookup returned empty value (possibly value is not collected yet)",
-                          rrdhost_hostname(host), rrdcalc_chart_name(rc), rrdcalc_name(rc)
-                          );
-                } else
-                    rc->run_flags &= ~RRDCALC_FLAG_DB_NAN;
-
-                debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': database lookup gave value " NETDATA_DOUBLE_FORMAT,
-                      rrdhost_hostname(host), rrdcalc_chart_name(rc), rrdcalc_name(rc), rc->value
-                      );
-            }
-
-            // ------------------------------------------------------------
-            // if there is calculation expression, run it
-
-            if (unlikely(rc->calculation)) {
-                worker_is_busy(WORKER_HEALTH_JOB_CALC_EVAL);
-
-                if (unlikely(!expression_evaluate(rc->calculation))) {
-                    // calculation failed
-                    rc->value = NAN;
-                    rc->run_flags |= RRDCALC_FLAG_CALC_ERROR;
-
-                    debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': expression '%s' failed: %s",
-                          rrdhost_hostname(host), rrdcalc_chart_name(rc), rrdcalc_name(rc),
-                          rc->calculation->parsed_as, buffer_tostring(rc->calculation->error_msg)
-                          );
-                } else {
-                    rc->run_flags &= ~RRDCALC_FLAG_CALC_ERROR;
-
-                    debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': expression '%s' gave value "
-                          NETDATA_DOUBLE_FORMAT
-                          ": %s (source: %s)", rrdhost_hostname(host), rrdcalc_chart_name(rc), rrdcalc_name(rc),
-                          rc->calculation->parsed_as, rc->calculation->result,
-                          buffer_tostring(rc->calculation->error_msg), rrdcalc_source(rc)
-                          );
-
-                    rc->value = rc->calculation->result;
-                }
-            }
-        }
-        foreach_rrdcalc_in_rrdhost_done(rc);
-
-        if (unlikely(runnable && service_running(SERVICE_HEALTH))) {
-            foreach_rrdcalc_in_rrdhost_read(host, rc) {
-                if (unlikely(!(rc->run_flags & RRDCALC_FLAG_RUNNABLE)))
-                    continue;
-
-                if (rc->run_flags & RRDCALC_FLAG_DISABLED) {
-                    continue;
-                }
-                RRDCALC_STATUS warning_status = RRDCALC_STATUS_UNDEFINED;
-                RRDCALC_STATUS critical_status = RRDCALC_STATUS_UNDEFINED;
-
-                // --------------------------------------------------------
-                // check the warning expression
-
-                if (likely(rc->warning)) {
-                    worker_is_busy(WORKER_HEALTH_JOB_WARNING_EVAL);
-
-                    if (unlikely(!expression_evaluate(rc->warning))) {
-                        // calculation failed
-                        rc->run_flags |= RRDCALC_FLAG_WARN_ERROR;
-
-                        debug(D_HEALTH,
-                              "Health on host '%s', alarm '%s.%s': warning expression failed with error: %s",
-                              rrdhost_hostname(host), rrdcalc_chart_name(rc), rrdcalc_name(rc),
-                              buffer_tostring(rc->warning->error_msg)
-                              );
-                    } else {
-                        rc->run_flags &= ~RRDCALC_FLAG_WARN_ERROR;
-                        debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': warning expression gave value "
-                              NETDATA_DOUBLE_FORMAT
-                              ": %s (source: %s)", rrdhost_hostname(host), rrdcalc_chart_name(rc),
-                              rrdcalc_name(rc), rc->warning->result, buffer_tostring(rc->warning->error_msg), rrdcalc_source(rc)
-                              );
-                        warning_status = rrdcalc_value2status(rc->warning->result);
-                    }
-                }
-
-                // --------------------------------------------------------
-                // check the critical expression
-
-                if (likely(rc->critical)) {
-                    worker_is_busy(WORKER_HEALTH_JOB_CRITICAL_EVAL);
-
-                    if (unlikely(!expression_evaluate(rc->critical))) {
-                        // calculation failed
-                        rc->run_flags |= RRDCALC_FLAG_CRIT_ERROR;
-
-                        debug(D_HEALTH,
-                              "Health on host '%s', alarm '%s.%s': critical expression failed with error: %s",
-                              rrdhost_hostname(host), rrdcalc_chart_name(rc), rrdcalc_name(rc),
-                              buffer_tostring(rc->critical->error_msg)
-                              );
-                    } else {
-                        rc->run_flags &= ~RRDCALC_FLAG_CRIT_ERROR;
-                        debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': critical expression gave value "
-                              NETDATA_DOUBLE_FORMAT
-                              ": %s (source: %s)", rrdhost_hostname(host), rrdcalc_chart_name(rc),
-                              rrdcalc_name(rc), rc->critical->result, buffer_tostring(rc->critical->error_msg),
-                              rrdcalc_source(rc)
-                              );
-                        critical_status = rrdcalc_value2status(rc->critical->result);
-                    }
-                }
-
-                // --------------------------------------------------------
-                // decide the final alarm status
-
-                RRDCALC_STATUS status = RRDCALC_STATUS_UNDEFINED;
-
-                switch (warning_status) {
-                case RRDCALC_STATUS_CLEAR:
-                    status = RRDCALC_STATUS_CLEAR;
-                    break;
-
-                case RRDCALC_STATUS_RAISED:
-                    status = RRDCALC_STATUS_WARNING;
-                    break;
-
-                default:
-                    break;
-                }
-
-                switch (critical_status) {
-                case RRDCALC_STATUS_CLEAR:
-                    if (status == RRDCALC_STATUS_UNDEFINED)
-                        status = RRDCALC_STATUS_CLEAR;
-                    break;
-
-                case RRDCALC_STATUS_RAISED:
-                    status = RRDCALC_STATUS_CRITICAL;
-                    break;
-
-                default:
-                    break;
-                }
-
-                // --------------------------------------------------------
-                // check if the new status and the old differ
-
-                if (status != rc->status) {
-                    worker_is_busy(WORKER_HEALTH_JOB_ALARM_LOG_ENTRY);
-                    int delay = 0;
-
-                    // apply trigger hysteresis
-
-                    if (now > rc->delay_up_to_timestamp) {
-                        rc->delay_up_current = rc->delay_up_duration;
-                        rc->delay_down_current = rc->delay_down_duration;
-                        rc->delay_last = 0;
-                        rc->delay_up_to_timestamp = 0;
-                    } else {
-                        rc->delay_up_current = (int) (rc->delay_up_current * rc->delay_multiplier);
-                        if (rc->delay_up_current > rc->delay_max_duration)
-                            rc->delay_up_current = rc->delay_max_duration;
-
-                        rc->delay_down_current = (int) (rc->delay_down_current * rc->delay_multiplier);
-                        if (rc->delay_down_current > rc->delay_max_duration)
-                            rc->delay_down_current = rc->delay_max_duration;
-                    }
-
-                    if (status > rc->status)
-                        delay = rc->delay_up_current;
-                    else
-                        delay = rc->delay_down_current;
-
-                    // COMMENTED: because we do need to send raising alarms
-                    // if(now + delay < rc->delay_up_to_timestamp)
-                    //      delay = (int)(rc->delay_up_to_timestamp - now);
-
-                    rc->delay_last = delay;
-                    rc->delay_up_to_timestamp = now + delay;
-
-                    ALARM_ENTRY *ae = health_create_alarm_entry(
-                                                                host,
-                                                                rc->id,
-                                                                rc->next_event_id++,
-                                                                rc->config_hash_id,
-                                                                now,
-                                                                rc->name,
-                                                                rc->rrdset->id,
-                                                                rc->rrdset->context,
-                                                                rc->rrdset->family,
-                                                                rc->classification,
-                                                                rc->component,
-                                                                rc->type,
-                                                                rc->exec,
-                                                                rc->recipient,
-                                                                now - rc->last_status_change,
-                                                                rc->old_value,
-                                                                rc->value,
-                                                                rc->status,
-                                                                status,
-                                                                rc->source,
-                                                                rc->units,
-                                                                rc->info,
-                                                                rc->delay_last,
-                                                                (
-                                                                 ((rc->options & RRDCALC_OPTION_NO_CLEAR_NOTIFICATION)? HEALTH_ENTRY_FLAG_NO_CLEAR_NOTIFICATION : 0) |
-                                                                 ((rc->run_flags & RRDCALC_FLAG_SILENCED)? HEALTH_ENTRY_FLAG_SILENCED : 0) |
-                                                                 (rrdcalc_isrepeating(rc)?HEALTH_ENTRY_FLAG_IS_REPEATING:0)
-                                                                 )
-                                                                );
-
-                    health_alarm_log_add_entry(host, ae);
-
-                    log_health("[%s]: Alert event for [%s.%s], value [%s], status [%s].", rrdhost_hostname(host), ae_chart_name(ae), ae_name(ae), ae_new_value_string(ae), rrdcalc_status2string(ae->new_status));
-
-                    rc->last_status_change = now;
-                    rc->old_status = rc->status;
-                    rc->status = status;
-                }
-
-                rc->last_updated = now;
-                rc->next_update = now + rc->update_every;
-
-                if (next_run > rc->next_update)
-                    next_run = rc->next_update;
-            }
-            foreach_rrdcalc_in_rrdhost_done(rc);
-
-            // process repeating alarms
-            foreach_rrdcalc_in_rrdhost_read(host, rc) {
-                int repeat_every = 0;
-                if(unlikely(rrdcalc_isrepeating(rc) && rc->delay_up_to_timestamp <= now)) {
-                    if(unlikely(rc->status == RRDCALC_STATUS_WARNING)) {
-                        rc->run_flags &= ~RRDCALC_FLAG_RUN_ONCE;
-                        repeat_every = rc->warn_repeat_every;
-                    } else if(unlikely(rc->status == RRDCALC_STATUS_CRITICAL)) {
-                        rc->run_flags &= ~RRDCALC_FLAG_RUN_ONCE;
-                        repeat_every = rc->crit_repeat_every;
-                    } else if(unlikely(rc->status == RRDCALC_STATUS_CLEAR)) {
-                        if(!(rc->run_flags & RRDCALC_FLAG_RUN_ONCE)) {
-                            if(rc->old_status == RRDCALC_STATUS_CRITICAL) {
-                                repeat_every = 1;
-                            } else if (rc->old_status == RRDCALC_STATUS_WARNING) {
-                                repeat_every = 1;
-                            }
                         }
                     }
-                } else {
+                }
+
+                if (unlikely(!rrdcalc_isrunnable(rc, now, &next_run))) {
+                    if (unlikely(rc->run_flags & RRDCALC_FLAG_RUNNABLE))
+                        rc->run_flags &= ~RRDCALC_FLAG_RUNNABLE;
                     continue;
                 }
 
-                if(unlikely(repeat_every > 0 && (rc->last_repeat + repeat_every) <= now)) {
-                    worker_is_busy(WORKER_HEALTH_JOB_ALARM_LOG_ENTRY);
-                    rc->last_repeat = now;
-                    if (likely(rc->times_repeat < UINT32_MAX)) rc->times_repeat++;
+                runnable++;
+                rc->old_value = rc->value;
+                rc->run_flags |= RRDCALC_FLAG_RUNNABLE;
 
-                    ALARM_ENTRY *ae = health_create_alarm_entry(
-                                                                host,
-                                                                rc->id,
-                                                                rc->next_event_id++,
-                                                                rc->config_hash_id,
-                                                                now,
-                                                                rc->name,
-                                                                rc->rrdset->id,
-                                                                rc->rrdset->context,
-                                                                rc->rrdset->family,
-                                                                rc->classification,
-                                                                rc->component,
-                                                                rc->type,
-                                                                rc->exec,
-                                                                rc->recipient,
-                                                                now - rc->last_status_change,
-                                                                rc->old_value,
-                                                                rc->value,
-                                                                rc->old_status,
-                                                                rc->status,
-                                                                rc->source,
-                                                                rc->units,
-                                                                rc->info,
-                                                                rc->delay_last,
-                                                                (
-                                                                 ((rc->options & RRDCALC_OPTION_NO_CLEAR_NOTIFICATION)? HEALTH_ENTRY_FLAG_NO_CLEAR_NOTIFICATION : 0) |
-                                                                 ((rc->run_flags & RRDCALC_FLAG_SILENCED)? HEALTH_ENTRY_FLAG_SILENCED : 0) |
-                                                                 (rrdcalc_isrepeating(rc)?HEALTH_ENTRY_FLAG_IS_REPEATING:0)
-                                                                 )
-                                                                );
+                // ------------------------------------------------------------
+                // if there is database lookup, do it
 
-                    ae->last_repeat = rc->last_repeat;
-                    if (!(rc->run_flags & RRDCALC_FLAG_RUN_ONCE) && rc->status == RRDCALC_STATUS_CLEAR) {
-                        ae->flags |= HEALTH_ENTRY_RUN_ONCE;
+                if (unlikely(RRDCALC_HAS_DB_LOOKUP(rc))) {
+                    worker_is_busy(WORKER_HEALTH_JOB_DB_QUERY);
+
+                    /* time_t old_db_timestamp = rc->db_before; */
+                    int value_is_null = 0;
+
+                    int ret = rrdset2value_api_v1(rc->rrdset, NULL, &rc->value, rrdcalc_dimensions(rc), 1,
+                                                  rc->after, rc->before, rc->group, NULL,
+                                                  0, rc->options,
+                                                  &rc->db_after,&rc->db_before,
+                                                  NULL, NULL, NULL,
+                                                  &value_is_null, NULL, 0, 0,
+                                                  QUERY_SOURCE_HEALTH, STORAGE_PRIORITY_LOW);
+
+                    if (unlikely(ret != 200)) {
+                        // database lookup failed
+                        rc->value = NAN;
+                        rc->run_flags |= RRDCALC_FLAG_DB_ERROR;
+
+                        debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': database lookup returned error %d",
+                              rrdhost_hostname(host), rrdcalc_chart_name(rc), rrdcalc_name(rc), ret
+                              );
+                    } else
+                        rc->run_flags &= ~RRDCALC_FLAG_DB_ERROR;
+
+                    /* - RRDCALC_FLAG_DB_STALE not currently used
+                       if (unlikely(old_db_timestamp == rc->db_before)) {
+                       // database is stale
+
+                       debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': database is stale", host->hostname, rc->chart?rc->chart:"NOCHART", rc->name);
+
+                       if (unlikely(!(rc->rrdcalc_flags & RRDCALC_FLAG_DB_STALE))) {
+                       rc->rrdcalc_flags |= RRDCALC_FLAG_DB_STALE;
+                       error("Health on host '%s', alarm '%s.%s': database is stale", host->hostname, rc->chart?rc->chart:"NOCHART", rc->name);
+                       }
+                       }
+                       else if (unlikely(rc->rrdcalc_flags & RRDCALC_FLAG_DB_STALE))
+                       rc->rrdcalc_flags &= ~RRDCALC_FLAG_DB_STALE;
+                    */
+
+                    if (unlikely(value_is_null)) {
+                        // collected value is null
+                        rc->value = NAN;
+                        rc->run_flags |= RRDCALC_FLAG_DB_NAN;
+
+                        debug(D_HEALTH,
+                              "Health on host '%s', alarm '%s.%s': database lookup returned empty value (possibly value is not collected yet)",
+                              rrdhost_hostname(host), rrdcalc_chart_name(rc), rrdcalc_name(rc)
+                              );
+                    } else
+                        rc->run_flags &= ~RRDCALC_FLAG_DB_NAN;
+
+                    debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': database lookup gave value " NETDATA_DOUBLE_FORMAT,
+                          rrdhost_hostname(host), rrdcalc_chart_name(rc), rrdcalc_name(rc), rc->value
+                          );
+                }
+
+                // ------------------------------------------------------------
+                // if there is calculation expression, run it
+
+                if (unlikely(rc->calculation)) {
+                    worker_is_busy(WORKER_HEALTH_JOB_CALC_EVAL);
+
+                    if (unlikely(!expression_evaluate(rc->calculation))) {
+                        // calculation failed
+                        rc->value = NAN;
+                        rc->run_flags |= RRDCALC_FLAG_CALC_ERROR;
+
+                        debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': expression '%s' failed: %s",
+                              rrdhost_hostname(host), rrdcalc_chart_name(rc), rrdcalc_name(rc),
+                              rc->calculation->parsed_as, buffer_tostring(rc->calculation->error_msg)
+                              );
+                    } else {
+                        rc->run_flags &= ~RRDCALC_FLAG_CALC_ERROR;
+
+                        debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': expression '%s' gave value "
+                              NETDATA_DOUBLE_FORMAT
+                              ": %s (source: %s)", rrdhost_hostname(host), rrdcalc_chart_name(rc), rrdcalc_name(rc),
+                              rc->calculation->parsed_as, rc->calculation->result,
+                              buffer_tostring(rc->calculation->error_msg), rrdcalc_source(rc)
+                              );
+
+                        rc->value = rc->calculation->result;
                     }
-                    rc->run_flags |= RRDCALC_FLAG_RUN_ONCE;
-                    health_process_notifications(host, ae);
-                    debug(D_HEALTH, "Notification sent for the repeating alarm %u.", ae->alarm_id);
-                    health_alarm_wait_for_execution(ae);
-                    health_alarm_log_free_one_nochecks_nounlink(ae);
                 }
             }
             foreach_rrdcalc_in_rrdhost_done(rc);
-        }
 
-        if (unlikely(!service_running(SERVICE_HEALTH)))
-            break;
+            if (unlikely(runnable && service_running(SERVICE_HEALTH))) {
+                foreach_rrdcalc_in_rrdhost_read(host, rc) {
+                    if (unlikely(!(rc->run_flags & RRDCALC_FLAG_RUNNABLE)))
+                        continue;
 
-        // execute notifications
-        // and cleanup
-        worker_is_busy(WORKER_HEALTH_JOB_ALARM_LOG_PROCESS);
-        health_alarm_log_process(host);
+                    if (rc->run_flags & RRDCALC_FLAG_DISABLED) {
+                        continue;
+                    }
+                    RRDCALC_STATUS warning_status = RRDCALC_STATUS_UNDEFINED;
+                    RRDCALC_STATUS critical_status = RRDCALC_STATUS_UNDEFINED;
 
-        if (unlikely(!service_running(SERVICE_HEALTH))) {
-            // wait for all notifications to finish before allowing health to be cleaned up
-            ALARM_ENTRY *ae;
-            while (NULL != (ae = alarm_notifications_in_progress.head)) {
-                health_alarm_wait_for_execution(ae);
+                    // --------------------------------------------------------
+                    // check the warning expression
+
+                    if (likely(rc->warning)) {
+                        worker_is_busy(WORKER_HEALTH_JOB_WARNING_EVAL);
+
+                        if (unlikely(!expression_evaluate(rc->warning))) {
+                            // calculation failed
+                            rc->run_flags |= RRDCALC_FLAG_WARN_ERROR;
+
+                            debug(D_HEALTH,
+                                  "Health on host '%s', alarm '%s.%s': warning expression failed with error: %s",
+                                  rrdhost_hostname(host), rrdcalc_chart_name(rc), rrdcalc_name(rc),
+                                  buffer_tostring(rc->warning->error_msg)
+                                  );
+                        } else {
+                            rc->run_flags &= ~RRDCALC_FLAG_WARN_ERROR;
+                            debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': warning expression gave value "
+                                  NETDATA_DOUBLE_FORMAT
+                                  ": %s (source: %s)", rrdhost_hostname(host), rrdcalc_chart_name(rc),
+                                  rrdcalc_name(rc), rc->warning->result, buffer_tostring(rc->warning->error_msg), rrdcalc_source(rc)
+                                  );
+                            warning_status = rrdcalc_value2status(rc->warning->result);
+                        }
+                    }
+
+                    // --------------------------------------------------------
+                    // check the critical expression
+
+                    if (likely(rc->critical)) {
+                        worker_is_busy(WORKER_HEALTH_JOB_CRITICAL_EVAL);
+
+                        if (unlikely(!expression_evaluate(rc->critical))) {
+                            // calculation failed
+                            rc->run_flags |= RRDCALC_FLAG_CRIT_ERROR;
+
+                            debug(D_HEALTH,
+                                  "Health on host '%s', alarm '%s.%s': critical expression failed with error: %s",
+                                  rrdhost_hostname(host), rrdcalc_chart_name(rc), rrdcalc_name(rc),
+                                  buffer_tostring(rc->critical->error_msg)
+                                  );
+                        } else {
+                            rc->run_flags &= ~RRDCALC_FLAG_CRIT_ERROR;
+                            debug(D_HEALTH, "Health on host '%s', alarm '%s.%s': critical expression gave value "
+                                  NETDATA_DOUBLE_FORMAT
+                                  ": %s (source: %s)", rrdhost_hostname(host), rrdcalc_chart_name(rc),
+                                  rrdcalc_name(rc), rc->critical->result, buffer_tostring(rc->critical->error_msg),
+                                  rrdcalc_source(rc)
+                                  );
+                            critical_status = rrdcalc_value2status(rc->critical->result);
+                        }
+                    }
+
+                    // --------------------------------------------------------
+                    // decide the final alarm status
+
+                    RRDCALC_STATUS status = RRDCALC_STATUS_UNDEFINED;
+
+                    switch (warning_status) {
+                    case RRDCALC_STATUS_CLEAR:
+                        status = RRDCALC_STATUS_CLEAR;
+                        break;
+
+                    case RRDCALC_STATUS_RAISED:
+                        status = RRDCALC_STATUS_WARNING;
+                        break;
+
+                    default:
+                        break;
+                    }
+
+                    switch (critical_status) {
+                    case RRDCALC_STATUS_CLEAR:
+                        if (status == RRDCALC_STATUS_UNDEFINED)
+                            status = RRDCALC_STATUS_CLEAR;
+                        break;
+
+                    case RRDCALC_STATUS_RAISED:
+                        status = RRDCALC_STATUS_CRITICAL;
+                        break;
+
+                    default:
+                        break;
+                    }
+
+                    // --------------------------------------------------------
+                    // check if the new status and the old differ
+
+                    if (status != rc->status) {
+                        worker_is_busy(WORKER_HEALTH_JOB_ALARM_LOG_ENTRY);
+                        int delay = 0;
+
+                        // apply trigger hysteresis
+
+                        if (now > rc->delay_up_to_timestamp) {
+                            rc->delay_up_current = rc->delay_up_duration;
+                            rc->delay_down_current = rc->delay_down_duration;
+                            rc->delay_last = 0;
+                            rc->delay_up_to_timestamp = 0;
+                        } else {
+                            rc->delay_up_current = (int) (rc->delay_up_current * rc->delay_multiplier);
+                            if (rc->delay_up_current > rc->delay_max_duration)
+                                rc->delay_up_current = rc->delay_max_duration;
+
+                            rc->delay_down_current = (int) (rc->delay_down_current * rc->delay_multiplier);
+                            if (rc->delay_down_current > rc->delay_max_duration)
+                                rc->delay_down_current = rc->delay_max_duration;
+                        }
+
+                        if (status > rc->status)
+                            delay = rc->delay_up_current;
+                        else
+                            delay = rc->delay_down_current;
+
+                        // COMMENTED: because we do need to send raising alarms
+                        // if(now + delay < rc->delay_up_to_timestamp)
+                        //      delay = (int)(rc->delay_up_to_timestamp - now);
+
+                        rc->delay_last = delay;
+                        rc->delay_up_to_timestamp = now + delay;
+
+                        ALARM_ENTRY *ae = health_create_alarm_entry(
+                                                                    host,
+                                                                    rc->id,
+                                                                    rc->next_event_id++,
+                                                                    rc->config_hash_id,
+                                                                    now,
+                                                                    rc->name,
+                                                                    rc->rrdset->id,
+                                                                    rc->rrdset->context,
+                                                                    rc->rrdset->family,
+                                                                    rc->classification,
+                                                                    rc->component,
+                                                                    rc->type,
+                                                                    rc->exec,
+                                                                    rc->recipient,
+                                                                    now - rc->last_status_change,
+                                                                    rc->old_value,
+                                                                    rc->value,
+                                                                    rc->status,
+                                                                    status,
+                                                                    rc->source,
+                                                                    rc->units,
+                                                                    rc->info,
+                                                                    rc->delay_last,
+                                                                    (
+                                                                     ((rc->options & RRDCALC_OPTION_NO_CLEAR_NOTIFICATION)? HEALTH_ENTRY_FLAG_NO_CLEAR_NOTIFICATION : 0) |
+                                                                     ((rc->run_flags & RRDCALC_FLAG_SILENCED)? HEALTH_ENTRY_FLAG_SILENCED : 0) |
+                                                                     (rrdcalc_isrepeating(rc)?HEALTH_ENTRY_FLAG_IS_REPEATING:0)
+                                                                     )
+                                                                    );
+
+                        health_alarm_log_add_entry(host, ae);
+
+                        log_health("[%s]: Alert event for [%s.%s], value [%s], status [%s].", rrdhost_hostname(host), ae_chart_name(ae), ae_name(ae), ae_new_value_string(ae), rrdcalc_status2string(ae->new_status));
+
+                        rc->last_status_change = now;
+                        rc->old_status = rc->status;
+                        rc->status = status;
+                    }
+
+                    rc->last_updated = now;
+                    rc->next_update = now + rc->update_every;
+
+                    if (next_run > rc->next_update)
+                        next_run = rc->next_update;
+                }
+                foreach_rrdcalc_in_rrdhost_done(rc);
+
+                // process repeating alarms
+                foreach_rrdcalc_in_rrdhost_read(host, rc) {
+                    int repeat_every = 0;
+                    if(unlikely(rrdcalc_isrepeating(rc) && rc->delay_up_to_timestamp <= now)) {
+                        if(unlikely(rc->status == RRDCALC_STATUS_WARNING)) {
+                            rc->run_flags &= ~RRDCALC_FLAG_RUN_ONCE;
+                            repeat_every = rc->warn_repeat_every;
+                        } else if(unlikely(rc->status == RRDCALC_STATUS_CRITICAL)) {
+                            rc->run_flags &= ~RRDCALC_FLAG_RUN_ONCE;
+                            repeat_every = rc->crit_repeat_every;
+                        } else if(unlikely(rc->status == RRDCALC_STATUS_CLEAR)) {
+                            if(!(rc->run_flags & RRDCALC_FLAG_RUN_ONCE)) {
+                                if(rc->old_status == RRDCALC_STATUS_CRITICAL) {
+                                    repeat_every = 1;
+                                } else if (rc->old_status == RRDCALC_STATUS_WARNING) {
+                                    repeat_every = 1;
+                                }
+                            }
+                        }
+                    } else {
+                        continue;
+                    }
+
+                    if(unlikely(repeat_every > 0 && (rc->last_repeat + repeat_every) <= now)) {
+                        worker_is_busy(WORKER_HEALTH_JOB_ALARM_LOG_ENTRY);
+                        rc->last_repeat = now;
+                        if (likely(rc->times_repeat < UINT32_MAX)) rc->times_repeat++;
+
+                        ALARM_ENTRY *ae = health_create_alarm_entry(
+                                                                    host,
+                                                                    rc->id,
+                                                                    rc->next_event_id++,
+                                                                    rc->config_hash_id,
+                                                                    now,
+                                                                    rc->name,
+                                                                    rc->rrdset->id,
+                                                                    rc->rrdset->context,
+                                                                    rc->rrdset->family,
+                                                                    rc->classification,
+                                                                    rc->component,
+                                                                    rc->type,
+                                                                    rc->exec,
+                                                                    rc->recipient,
+                                                                    now - rc->last_status_change,
+                                                                    rc->old_value,
+                                                                    rc->value,
+                                                                    rc->old_status,
+                                                                    rc->status,
+                                                                    rc->source,
+                                                                    rc->units,
+                                                                    rc->info,
+                                                                    rc->delay_last,
+                                                                    (
+                                                                     ((rc->options & RRDCALC_OPTION_NO_CLEAR_NOTIFICATION)? HEALTH_ENTRY_FLAG_NO_CLEAR_NOTIFICATION : 0) |
+                                                                     ((rc->run_flags & RRDCALC_FLAG_SILENCED)? HEALTH_ENTRY_FLAG_SILENCED : 0) |
+                                                                     (rrdcalc_isrepeating(rc)?HEALTH_ENTRY_FLAG_IS_REPEATING:0)
+                                                                     )
+                                                                    );
+
+                        ae->last_repeat = rc->last_repeat;
+                        if (!(rc->run_flags & RRDCALC_FLAG_RUN_ONCE) && rc->status == RRDCALC_STATUS_CLEAR) {
+                            ae->flags |= HEALTH_ENTRY_RUN_ONCE;
+                        }
+                        rc->run_flags |= RRDCALC_FLAG_RUN_ONCE;
+                        health_process_notifications(host, ae);
+                        debug(D_HEALTH, "Notification sent for the repeating alarm %u.", ae->alarm_id);
+                        health_alarm_wait_for_execution(ae);
+                        health_alarm_log_free_one_nochecks_nounlink(ae);
+                    }
+                }
+                foreach_rrdcalc_in_rrdhost_done(rc);
             }
-            break;
-        }
+
+            if (unlikely(!service_running(SERVICE_HEALTH)))
+                break;
+
+            // execute notifications
+            // and cleanup
+            worker_is_busy(WORKER_HEALTH_JOB_ALARM_LOG_PROCESS);
+            health_alarm_log_process(host);
+
+            if (unlikely(!service_running(SERVICE_HEALTH))) {
+                // wait for all notifications to finish before allowing health to be cleaned up
+                ALARM_ENTRY *ae;
+                while (NULL != (ae = alarm_notifications_in_progress.head)) {
+                    health_alarm_wait_for_execution(ae);
+                }
+                break;
+            }
+        } //for each host
+
+        rrd_unlock();
 
         // wait for all notifications to finish before allowing health to be cleaned up
         ALARM_ENTRY *ae;
@@ -1537,9 +1550,13 @@ void *health_main(void *ptr) {
         }
 
 #ifdef ENABLE_ACLK
-        if (netdata_cloud_setting && unlikely(host->aclk_alert_reloaded) && loop > (marked_aclk_reload_loop + 2)) {
-            sql_queue_removed_alerts_to_aclk(host);
-            host->aclk_alert_reloaded = 0;
+        if (netdata_cloud_setting && unlikely(aclk_alert_reloaded) && loop > (marked_aclk_reload_loop + 2)) {
+            rrdhost_foreach_read(host) {
+                if (unlikely(!host->health_enabled))
+                    continue;
+                sql_queue_removed_alerts_to_aclk(host);
+            }
+            aclk_alert_reloaded = 0;
             marked_aclk_reload_loop = 0;
         }
 #endif
@@ -1547,7 +1564,7 @@ void *health_main(void *ptr) {
         if(unlikely(!service_running(SERVICE_HEALTH)))
             break;
 
-        health_sleep(next_run, loop, host);
+        health_sleep(next_run, loop);
 
     } // forever
 
@@ -1568,22 +1585,3 @@ void health_add_host_labels(void) {
     rrdlabels_add(labels, "_has_unstable_connection", has_unstable_connection ? "true" : "false", RRDLABEL_SRC_AUTO);
 }
 
-void health_thread_spawn(RRDHOST * host) {
-    if(!host->health_spawn) {
-        char tag[NETDATA_THREAD_TAG_MAX + 1];
-        snprintfz(tag, NETDATA_THREAD_TAG_MAX, "HEALTH[%s]", rrdhost_hostname(host));
-        struct health_state *health = callocz(1, sizeof(*health));
-        health->host = host;
-
-        netdata_thread_t health_thread;
-        if(netdata_thread_create(&health_thread, tag, NETDATA_THREAD_OPTION_DEFAULT, health_main, (void *) health)) {
-            log_health("[%s]: Failed to create new thread for client.", rrdhost_hostname(host));
-            error("HEALTH [%s]: Failed to create new thread for client.", rrdhost_hostname(host));
-        }
-        else {
-            log_health("[%s]: Created new thread for client.", rrdhost_hostname(host));
-            host->health_spawn = 1;
-            host->aclk_alert_reloaded = 1;
-        }
-    }
-}

--- a/health/health.h
+++ b/health/health.h
@@ -49,9 +49,6 @@ int health_alarm_log_open(RRDHOST *host);
 void health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae);
 void health_alarm_log_load(RRDHOST *host);
 
-void health_thread_spawn(RRDHOST *host);
-void health_thread_stop(RRDHOST *host);
-
 ALARM_ENTRY* health_create_alarm_entry(
     RRDHOST *host,
     uint32_t alarm_id,
@@ -79,10 +76,6 @@ ALARM_ENTRY* health_create_alarm_entry(
     uint32_t flags);
 
 void health_alarm_log_add_entry(RRDHOST *host, ALARM_ENTRY *ae);
-
-struct health_state {
-    RRDHOST *host;
-};
 
 void health_readdir(RRDHOST *host, const char *user_path, const char *stock_path, const char *subpath);
 char *health_user_config_dir(void);

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -573,8 +573,8 @@ static int health_readfile(const char *filename, void *data) {
                 rc->old_value = NAN;
                 rc->delay_multiplier = 1.0;
                 rc->old_status = RRDCALC_STATUS_UNINITIALIZED;
-                rc->warn_repeat_every = host->health_default_warn_repeat_every;
-                rc->crit_repeat_every = host->health_default_crit_repeat_every;
+                rc->warn_repeat_every = host->health.health_default_warn_repeat_every;
+                rc->crit_repeat_every = host->health.health_default_crit_repeat_every;
                 if (alert_cfg)
                     alert_config_free(alert_cfg);
                 alert_cfg = callocz(1, sizeof(struct alert_config));
@@ -619,8 +619,8 @@ static int health_readfile(const char *filename, void *data) {
                 rt->green = NAN;
                 rt->red = NAN;
                 rt->delay_multiplier = (float)1.0;
-                rt->warn_repeat_every = host->health_default_warn_repeat_every;
-                rt->crit_repeat_every = host->health_default_crit_repeat_every;
+                rt->warn_repeat_every = host->health.health_default_warn_repeat_every;
+                rt->crit_repeat_every = host->health.health_default_crit_repeat_every;
                 if (alert_cfg)
                     alert_config_free(alert_cfg);
                 alert_cfg = callocz(1, sizeof(struct alert_config));
@@ -1171,7 +1171,7 @@ void sql_refresh_hashes(void)
 }
 
 void health_readdir(RRDHOST *host, const char *user_path, const char *stock_path, const char *subpath) {
-    if(unlikely((!host->health_enabled) && !rrdhost_flag_check(host, RRDHOST_FLAG_INITIALIZED_HEALTH)) ||
+    if(unlikely((!host->health.health_enabled) && !rrdhost_flag_check(host, RRDHOST_FLAG_INITIALIZED_HEALTH)) ||
         !service_running(SERVICE_HEALTH)) {
         debug(D_HEALTH, "CONFIG health is not enabled for host '%s'", rrdhost_hostname(host));
         return;

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -75,8 +75,8 @@ void health_alarm_entry2json_nolock(BUFFER *wb, ALARM_ENTRY *ae, RRDHOST *host) 
                    , (ae->flags & HEALTH_ENTRY_FLAG_UPDATED)?"true":"false"
                    , (unsigned long)ae->exec_run_timestamp
                    , (ae->flags & HEALTH_ENTRY_FLAG_EXEC_FAILED)?"true":"false"
-                   , ae->exec?ae_exec(ae):string2str(host->health_default_exec)
-                   , ae->recipient?ae_recipient(ae):string2str(host->health_default_recipient)
+                   , ae->exec?ae_exec(ae):string2str(host->health.health_default_exec)
+                   , ae->recipient?ae_recipient(ae):string2str(host->health.health_default_recipient)
                    , ae->exec_code
                    , ae_source(ae)
                    , edit_command
@@ -219,8 +219,8 @@ static inline void health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC
                    , (rc->rrdset)?"true":"false"
                    , (rc->run_flags & RRDCALC_FLAG_DISABLED)?"true":"false"
                    , (rc->run_flags & RRDCALC_FLAG_SILENCED)?"true":"false"
-                   , rc->exec?rrdcalc_exec(rc):string2str(host->health_default_exec)
-                   , rc->recipient?rrdcalc_recipient(rc):string2str(host->health_default_recipient)
+                   , rc->exec?rrdcalc_exec(rc):string2str(host->health.health_default_exec)
+                   , rc->recipient?rrdcalc_recipient(rc):string2str(host->health.health_default_recipient)
                    , rrdcalc_source(rc)
                    , rrdcalc_units(rc)
                    , rrdcalc_info(rc)
@@ -372,7 +372,7 @@ void health_alarms2json(RRDHOST *host, BUFFER *wb, int all) {
                     "\n\t\"alarms\": {\n",
             rrdhost_hostname(host),
             (host->health_log.next_log_id > 0)?(host->health_log.next_log_id - 1):0,
-            host->health_enabled?"true":"false",
+            host->health.health_enabled?"true":"false",
             (unsigned long)now_realtime_sec());
 
     health_alarms2json_fill_alarms(host, wb, all,  health_rrdcalc2json_nolock);

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -449,7 +449,7 @@ bool rrdhost_set_receiver(RRDHOST *host, struct receiver_state *rpt) {
 
         if (rpt->config.health_enabled != CONFIG_BOOLEAN_NO) {
             if (rpt->config.alarms_delay > 0) {
-                host->health_delay_up_to = now_realtime_sec() + rpt->config.alarms_delay;
+                host->health.health_delay_up_to = now_realtime_sec() + rpt->config.alarms_delay;
                 log_health(
                         "[%s]: Postponing health checks for %" PRId64 " seconds, because it was just connected.",
                         rrdhost_hostname(host),
@@ -487,7 +487,7 @@ static void rrdhost_clear_receiver(struct receiver_state *rpt) {
             host->child_disconnected_time = now_realtime_sec();
 
             if (rpt->config.health_enabled == CONFIG_BOOLEAN_AUTO)
-                host->health_enabled = 0;
+                host->health.health_enabled = 0;
 
             rrdpush_sender_thread_stop(host, "RECEIVER LEFT", false);
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR reverts health to run in a single thread for all hosts. It still retains the health initialization in the health thread as so to not delay host creation.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Will be tested that it performs as it should in regards also to the cloud.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
