### PR TITLE
allow the cache to grow when huge queries are running that exceed the cache size

### DIFF
--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -2093,17 +2093,20 @@ RRDR *rrd2rrdr(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
     if (qt->request.timeout)
         now_realtime_timeval(&query_start_time);
 
+    QUERY_ENGINE_OPS **ops = onewayalloc_callocz(r->internal.owa, qt->query.used, sizeof(QUERY_ENGINE_OPS *));
+
     size_t capacity = libuv_worker_threads * 2;
     size_t max_queries_to_prepare = (qt->query.used > (capacity - 1)) ? (capacity - 1) : qt->query.used;
-    size_t queries_prepared;
-
-    QUERY_ENGINE_OPS **ops = onewayalloc_callocz(r->internal.owa, qt->query.used, sizeof(QUERY_ENGINE_OPS *));
-    for(queries_prepared = 0; queries_prepared < max_queries_to_prepare ; queries_prepared++)
+    size_t queries_prepared = 0;
+    while(queries_prepared < max_queries_to_prepare) {
+        // preload another query
         ops[queries_prepared] = rrd2rrdr_query_prep(r, queries_prepared);
+        queries_prepared++;
+    }
 
     for(size_t c = 0, max = qt->query.used; c < max ; c++) {
 
-        if(queries_prepared < qt->query.used) {
+        if(queries_prepared < max) {
             // preload another query
             ops[queries_prepared] = rrd2rrdr_query_prep(r, queries_prepared);
             queries_prepared++;
@@ -2160,6 +2163,12 @@ RRDR *rrd2rrdr(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
             log_access("QUERY CANCELED RUNTIME EXCEEDED %0.2f ms (LIMIT %lld ms)",
                        (NETDATA_DOUBLE)dt_usec(&query_start_time, &query_current_time) / 1000.0, (long long)qt->request.timeout);
             r->result_options |= RRDR_RESULT_OPTION_CANCEL;
+
+            for(size_t i = c + 1; i < queries_prepared ; i++) {
+                if(ops[i])
+                    query_planer_finalize_remaining_plans(ops[i]);
+            }
+
             break;
         }
     }


### PR DESCRIPTION
When huge queries are running that exceed the target size of the cache, the cache enters a mode trying to aggressively evict pages from it. This makes it extremely slow.

This PR applies 3 fixes:

## Allow the cache size to grow to accommodate queries

The cache can now grow up to 1,5 times the size of the referenced pages in it.

So, the target cache size is now calculated like this:

1. `A = max hot size ever encountered x 2`
   
   The hot size is the number of pages concurrently being collected.
   
2. `B = max hot size ever encountered + twice the max dirty size ever encountered`

   The max dirty size is the number of pages that are committed to disk concurrently.

3. `C = currently referenced size x 1.5`

   The currently referenced size includes any page that is concurrently used for any reason (hot while being collected, dirty while being saved, clean while being used in queries)

The final size is:

```
MAX( MIN(A, B), C)
```

## Prevent the pre-initialization of too many queries

Instead of initializing all the queries concurrently (which will reference pages in the cache), this PR adds an initialize ahead mechanism that will initialize dimensions up to twice the number of libuv workers. So at beginning it initializes that many and as dimensions are executed it initializes more and more to always have 2x libuv workers open.

## Fix a page reference leak when queries timeout

In the current master there is a page reference leak when queries timeout.
This PR finalizes the queued queries of dimensions when a timeout occurs.
