### PR TITLE
Remove daemon/common.h header from libnetdata

### DIFF
--- a/libnetdata/arrayalloc/arrayalloc.c
+++ b/libnetdata/arrayalloc/arrayalloc.c
@@ -1,6 +1,5 @@
 #include "../libnetdata.h"
 #include "arrayalloc.h"
-#include "daemon/common.h"
 
 #ifdef NETDATA_TRACE_ALLOCATIONS
 #define TRACE_ALLOCATIONS_FUNCTION_DEFINITION_PARAMS , const char *file, const char *function, size_t line


### PR DESCRIPTION
##### Summary

Functionality in libnetdata is meant to be used by both external collectors and the agent itself. We want to keep libnetdata completely independent from agent specific code.

##### Test Plan

- Build the agent successfully with/without the `ifdefs` referenced in the modified file.
- CI jobs.