### PR TITLE
fix(pacakging): fix cpu/memory metrics when running inside LXC container as systemd service

### DIFF
--- a/collectors/proc.plugin/plugin_proc.c
+++ b/collectors/proc.plugin/plugin_proc.c
@@ -122,8 +122,10 @@ static bool is_lxcfs_proc_mounted() {
         if (words < 2) {
             continue;
         }
-        if (!strcmp(procfile_lineword(ff, l, 0), "lxcfs") && !strncmp(procfile_lineword(ff, l, 1), "/proc", 5))
-            return true;
+        if (!strcmp(procfile_lineword(ff, l, 0), "lxcfs") && !strncmp(procfile_lineword(ff, l, 1), "/proc", 5)) {
+            procfile_close(ff);
+            return true;   
+        }            
     }
 
     procfile_close(ff);

--- a/collectors/proc.plugin/plugin_proc.c
+++ b/collectors/proc.plugin/plugin_proc.c
@@ -98,6 +98,37 @@ static void proc_main_cleanup(void *ptr)
     worker_unregister();
 }
 
+bool inside_lxc_container = false;
+
+static bool is_lxcfs_proc_mounted() {
+    static procfile *ff = NULL;
+
+    if (unlikely(!ff)) {
+        char filename[FILENAME_MAX + 1];
+        snprintfz(filename, FILENAME_MAX, "/proc/self/mounts");
+        ff = procfile_open(filename, " \t", PROCFILE_FLAG_DEFAULT);
+        if (unlikely(!ff))
+            return false;
+    }
+
+    ff = procfile_readall(ff);
+    if (unlikely(!ff))
+        return false;
+
+    unsigned long l, lines = procfile_lines(ff);
+
+    for (l = 0; l < lines; l++) {
+        size_t words = procfile_linewords(ff, l);
+        if (words < 2) {
+            continue;
+        }
+        if (!strcmp(procfile_lineword(ff, l, 0), "lxcfs") && !strncmp(procfile_lineword(ff, l, 1), "/proc", 5))
+            return true;
+    }
+
+    return false;
+}
+
 void *proc_main(void *ptr)
 {
     worker_register("PROC");
@@ -127,6 +158,8 @@ void *proc_main(void *ptr)
     usec_t step = localhost->rrd_update_every * USEC_PER_SEC;
     heartbeat_t hb;
     heartbeat_init(&hb);
+
+    inside_lxc_container = is_lxcfs_proc_mounted();
 
     while (service_running(SERVICE_COLLECTORS)) {
         worker_is_idle();

--- a/collectors/proc.plugin/plugin_proc.c
+++ b/collectors/proc.plugin/plugin_proc.c
@@ -101,7 +101,7 @@ static void proc_main_cleanup(void *ptr)
 bool inside_lxc_container = false;
 
 static bool is_lxcfs_proc_mounted() {
-    static procfile *ff = NULL;
+    procfile *ff = NULL;
 
     if (unlikely(!ff)) {
         char filename[FILENAME_MAX + 1];
@@ -125,6 +125,8 @@ static bool is_lxcfs_proc_mounted() {
         if (!strcmp(procfile_lineword(ff, l, 0), "lxcfs") && !strncmp(procfile_lineword(ff, l, 1), "/proc", 5))
             return true;
     }
+
+    procfile_close(ff);
 
     return false;
 }

--- a/collectors/proc.plugin/plugin_proc.h
+++ b/collectors/proc.plugin/plugin_proc.h
@@ -48,6 +48,7 @@ int get_numa_node_count(void);
 
 // metrics that need to be shared among data collectors
 extern unsigned long long zfs_arcstats_shrinkable_cache_size_bytes;
+extern bool inside_lxc_container;
 
 // netdev renames
 void netdev_rename_device_add(

--- a/collectors/proc.plugin/proc_meminfo.c
+++ b/collectors/proc.plugin/proc_meminfo.c
@@ -158,9 +158,11 @@ int do_proc_meminfo(int update_every, usec_t dt) {
     unsigned long long MemCached = Cached + SReclaimable - Shmem;
     unsigned long long MemUsed = MemTotal - MemFree - MemCached - Buffers;
     // The Linux kernel doesn't report ZFS ARC usage as cache memory (the ARC is included in the total used system memory)
-    MemCached += (zfs_arcstats_shrinkable_cache_size_bytes / 1024);
-    MemUsed -= (zfs_arcstats_shrinkable_cache_size_bytes / 1024);
-    MemAvailable += (zfs_arcstats_shrinkable_cache_size_bytes / 1024);
+    if (!inside_lxc_container) {
+        MemCached += (zfs_arcstats_shrinkable_cache_size_bytes / 1024);
+        MemUsed -= (zfs_arcstats_shrinkable_cache_size_bytes / 1024);
+        MemAvailable += (zfs_arcstats_shrinkable_cache_size_bytes / 1024);
+    }
 
     if(do_ram) {
         {

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -217,6 +217,9 @@ if [ -n "${lscpu}" ] && lscpu > /dev/null 2>&1; then
   LCPU_COUNT="$(echo "${lscpu_output}" | grep "^CPU(s):" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
   CPU_VENDOR="$(echo "${lscpu_output}" | grep "^Vendor ID:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
   CPU_MODEL="$(echo "${lscpu_output}" | grep "^Model name:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  if grep -q "^lxcfs /proc" /proc/self/mounts 2>/dev/null && count=$(grep -c ^processor /proc/cpuinfo 2>/dev/null); then
+    LCPU_COUNT="$count"
+  fi
   possible_cpu_freq="$(echo "${lscpu_output}" | grep -F "CPU max MHz:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | grep -o '^[0-9]*')"
   if [ -z "$possible_cpu_freq" ]; then
     possible_cpu_freq="$(echo "${lscpu_output}" | grep -F "CPU MHz:" | cut -f 2 -d ':' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | grep -o '^[0-9]*')"
@@ -437,7 +440,7 @@ CLOUD_INSTANCE_TYPE="unknown"
 CLOUD_INSTANCE_REGION="unknown"
 
 if [ "${VIRTUALIZATION}" != "none" ] && command -v curl > /dev/null 2>&1; then
-  # Returned HTTP status codes: GCP is 200, AWS is 200, DO is 404. 
+  # Returned HTTP status codes: GCP is 200, AWS is 200, DO is 404.
   curl --fail -s -m 1 --noproxy "*" http://169.254.169.254 >/dev/null 2>&1
   ret=$?
   # anything but operation timeout.

--- a/system/netdata.service.in
+++ b/system/netdata.service.in
@@ -71,6 +71,10 @@ ProtectControlGroups=on
 ReadWriteDirectories=/run/netdata
 # This is needed to make email-based alert deliver work if Postfix is the email provider on the system.
 ReadWriteDirectories=-/var/spool/postfix/maildrop
+# LXCFS directories (https://github.com/lxc/lxcfs#lxcfs)
+# If we don't set them explicitly, systemd mounts procfs from the host. See https://github.com/netdata/netdata/issues/14238. 
+BindReadOnlyPaths=-/proc/cpuinfo -/proc/diskstats -/proc/loadavg -/proc/meminfo
+BindReadOnlyPaths=-/proc/stat -/proc/swaps -/proc/uptime -/proc/slabinfo
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
##### Summary

Fixes: #14238

The issue is that the [LXCFS proc](https://github.com/lxc/lxcfs#introduction) is not mounted [because of ProtectControlGroups=on](https://github.com/netdata/netdata/issues/14238#issuecomment-1380719725) which causes Netdata to track the host system and not the LXC container it's running in.

> to track the host system and not the LXC container it's running in.

That is impossible to "fix" completely because an LXC container is not a VM, so we are limited to LXCFC procfs.

A further improvement in this direction will be to disable plugins that collect host system metrics, which do not make sense to collect inside the LXC container (e.g. ZFS, KSM, etc). I am not going to do it in this PR.

---

This PR:

 - Updates Netdata systemd unit file: configures [LXCFS proc mounts](https://github.com/lxc/lxcfs#introduction).
 - Fixes RAM calculation when using ZFS (we should ignore ZFS ARC cache shrinkable size).
 - Fixes calculation of the number of processors in system-info.sh.

##### Test Plan

- install this branch in LXC container
- check CPU cores (number) and memory (ram, mem available) charts.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
