### PR TITLE
Fix binpkg updates on OpenSUSE

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -769,8 +769,8 @@ update_binpkg() {
     opensuse)
       pm_cmd="zypper"
       repo_subcmd="--gpg-auto-import-keys refresh"
-      upgrade_cmd="upgrade"
-      pkg_install_opts="${interactive_opts} --allow-unsigned-rpm"
+      upgrade_cmd="update"
+      pkg_install_opts="${interactive_opts}"
       repo_update_opts=""
       pkg_installed_check="rpm -q"
       INSTALL_TYPE="binpkg-rpm"


### PR DESCRIPTION
##### Summary
Fixes https://github.com/netdata/netdata/issues/14110 .

##### Test Plan

1. Install a previous version of Netdata on openSUSE using native packages (can go to an older version using `zypper in -f netdata-1.37.0.121.nightly-1`).
2. Try to run `netdata-updater.sh` manually and see it failing. 
3. Then try to run `netdata-updater.sh` from this branch, it should succeed. 
