### PR TITLE
Always mark nightly build releases as latest.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -726,6 +726,7 @@ jobs:
           repo: netdata-nightlies
           body: Netdata nightly build for ${{ steps.version.outputs.date }}.
           commit: ${{ steps.version.outputs.commit }}
+          makeLatest: true
           tag: ${{ steps.version.outputs.version }}
           token: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}
       - name: Failure Notification


### PR DESCRIPTION
##### Summary

This compensates for the fact that GitHub’s release sorting is based on a byte-wise sort of the associated tag name, which does not match up with the temporal sorting that we actually want for this.

##### Test Plan

n/a