### PR TITLE
Store host and claim info in sqlite as soon as possible

### DIFF
--- a/claim/claim.c
+++ b/claim/claim.c
@@ -170,6 +170,7 @@ void load_claiming_state(void)
     }
 
     invalidate_node_instances(&localhost->host_uuid, claimed_id ? &uuid : NULL);
+    metaqueue_store_claim_id(&localhost->host_uuid, claimed_id ? &uuid : NULL);
     rrdhost_aclk_state_unlock(localhost);
 
     rrdhost_flag_set(localhost, RRDHOST_FLAG_METADATA_CLAIMID | RRDHOST_FLAG_METADATA_UPDATE);

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -173,8 +173,6 @@ void load_claiming_state(void)
     metaqueue_store_claim_id(&localhost->host_uuid, claimed_id ? &uuid : NULL);
     rrdhost_aclk_state_unlock(localhost);
 
-    rrdhost_flag_set(localhost, RRDHOST_FLAG_METADATA_CLAIMID | RRDHOST_FLAG_METADATA_UPDATE);
-
     if (!claimed_id) {
         info("Unable to load '%s', setting state to AGENT_UNCLAIMED", filename);
         return;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -364,6 +364,7 @@ int is_legacy = 1;
     rrdfamily_index_init(host);
     rrdcalctemplate_index_init(host);
     rrdcalc_rrdhost_index_init(host);
+    metaqueue_host_update_info(host);
 
     if (health_enabled)
         health_thread_spawn(host);

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -1309,6 +1309,8 @@ void metaqueue_store_claim_id(uuid_t *host_uuid, uuid_t *claim_uuid)
 
 void metaqueue_host_update_info(RRDHOST *host)
 {
+    if (unlikely(!metasync_worker.loop))
+        return;
     queue_metadata_cmd(METADATA_ADD_HOST_INFO, host, NULL);
 }
 

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -62,6 +62,7 @@ enum metadata_opcode {
     METADATA_DATABASE_TIMER,
     METADATA_DEL_DIMENSION,
     METADATA_STORE_CLAIM_ID,
+    METADATA_ADD_HOST_INFO,
     METADATA_SCAN_HOSTS,
     METADATA_MAINTENANCE,
     METADATA_SYNC_SHUTDOWN,
@@ -1014,6 +1015,7 @@ static void metadata_event_loop(void *arg)
     worker_register_job_name(METADATA_DATABASE_TIMER,       "timer");
     worker_register_job_name(METADATA_DEL_DIMENSION,        "delete dimension");
     worker_register_job_name(METADATA_STORE_CLAIM_ID,       "add claim id");
+    worker_register_job_name(METADATA_ADD_HOST_INFO,        "add host info");
     worker_register_job_name(METADATA_MAINTENANCE,          "maintenance");
 
     int ret;
@@ -1063,6 +1065,8 @@ static void metadata_event_loop(void *arg)
 
     while (shutdown == 0 || (wc->flags & METADATA_WORKER_BUSY)) {
         uuid_t  *uuid;
+        RRDHOST *host = NULL;
+        int rc;
 
         worker_is_idle();
         uv_run(loop, UV_RUN_DEFAULT);
@@ -1101,6 +1105,12 @@ static void metadata_event_loop(void *arg)
                     store_claim_id((uuid_t *) cmd.param[0], (uuid_t *) cmd.param[1]);
                     freez((void *) cmd.param[0]);
                     freez((void *) cmd.param[1]);
+                    break;
+                case METADATA_ADD_HOST_INFO:
+                    host = (RRDHOST *) cmd.param[0];
+                    rc = sql_store_host_info(host);
+                    if (unlikely(rc))
+                        error_report("Failed to store host info in the database for %s", string2str(host->hostname));
                     break;
                 case METADATA_SCAN_HOSTS:
                     if (unlikely(metadata_flag_check(wc, METADATA_FLAG_SCANNING_HOSTS)))
@@ -1279,6 +1289,27 @@ void metaqueue_delete_dimension_uuid(uuid_t *uuid)
     uuid_t *use_uuid = mallocz(sizeof(*uuid));
     uuid_copy(*use_uuid, *uuid);
     queue_metadata_cmd(METADATA_DEL_DIMENSION, use_uuid, NULL);
+}
+
+void metaqueue_store_claim_id(uuid_t *host_uuid, uuid_t *claim_uuid)
+{
+    if (unlikely(!host_uuid))
+        return;
+
+    uuid_t *local_host_uuid = mallocz(sizeof(*host_uuid));
+    uuid_t *local_claim_uuid = NULL;
+
+    uuid_copy(*local_host_uuid, *host_uuid);
+    if (likely(claim_uuid)) {
+        local_claim_uuid = mallocz(sizeof(*claim_uuid));
+        uuid_copy(*local_claim_uuid, *claim_uuid);
+    }
+    queue_metadata_cmd(METADATA_STORE_CLAIM_ID, local_host_uuid, local_claim_uuid);
+}
+
+void metaqueue_host_update_info(RRDHOST *host)
+{
+    queue_metadata_cmd(METADATA_ADD_HOST_INFO, host, NULL);
 }
 
 //

--- a/database/sqlite/sqlite_metadata.h
+++ b/database/sqlite/sqlite_metadata.h
@@ -12,6 +12,8 @@ void metadata_sync_shutdown(void);
 void metadata_sync_shutdown_prepare(void);
 
 void metaqueue_delete_dimension_uuid(uuid_t *uuid);
+void metaqueue_store_claim_id(uuid_t *host_uuid, uuid_t *claim_uuid);
+void metaqueue_host_update_info(RRDHOST *host);
 void migrate_localhost(uuid_t *host_uuid);
 
 // UNIT TEST


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

In some cases, when the claim procedure happens shortly after the agent start, it might be possible that the `node_instance` and `host` tables are not yet populated. In this case, aclk does not find any nodes and as such does not send out any `CreateNodeInstance` messages.

The result is that the node does not appear as online ever in the cloud. This also affects our set team's test suite.

This PR reverts some recent changes, to populate these tables as soon as there are data for them.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Has been tested in set's test suite (but will be tested again).

If the agent is claimed a couple of seconds after start, it should appear online in the cloud.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
