### PR TITLE
More 32bit fixes

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -4,6 +4,10 @@
 #include "buildinfo.h"
 #include "static_threads.h"
 
+#if defined(ENV32BIT)
+#warning COMPILING 32BIT NETDATA
+#endif
+
 bool unittest_running = false;
 int netdata_zero_metrics_enabled;
 int netdata_anonymous_statistics_enabled;

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -10,13 +10,17 @@ struct rrdengine_instance multidb_ctx_storage_tier4;
 
 #define mrg_metric_ctx(metric) (struct rrdengine_instance *)mrg_metric_section(main_mrg, metric)
 
-
 #if RRD_STORAGE_TIERS != 5
 #error RRD_STORAGE_TIERS is not 5 - you need to add allocations here
 #endif
 struct rrdengine_instance *multidb_ctx[RRD_STORAGE_TIERS];
 uint8_t tier_page_type[RRD_STORAGE_TIERS] = {PAGE_METRICS, PAGE_TIER, PAGE_TIER, PAGE_TIER, PAGE_TIER};
+
+#if defined(ENV32BIT)
+size_t tier_page_size[RRD_STORAGE_TIERS] = {2048, 1024, 192, 192, 192};
+#else
 size_t tier_page_size[RRD_STORAGE_TIERS] = {4096, 2048, 384, 384, 384};
+#endif
 
 #if PAGE_TYPE_MAX != 1
 #error PAGE_TYPE_MAX is not 1 - you need to add allocations here
@@ -33,10 +37,15 @@ __attribute__((constructor)) void initialize_multidb_ctx(void) {
 
 int default_rrdeng_page_fetch_timeout = 3;
 int default_rrdeng_page_fetch_retries = 3;
-int default_rrdeng_page_cache_mb = 32;
 int db_engine_journal_check = 0;
 int default_rrdeng_disk_quota_mb = 256;
 int default_multidb_disk_quota_mb = 256;
+
+#if defined(ENV32BIT)
+int default_rrdeng_page_cache_mb = 16;
+#else
+int default_rrdeng_page_cache_mb = 32;
+#endif
 
 // ----------------------------------------------------------------------------
 // metrics groups

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -154,13 +154,14 @@ extern time_t rrdset_free_obsolete_time_s;
 
 #if defined(ENV32BIT)
 #define MIN_LIBUV_WORKER_THREADS 8
-#define MAX_LIBUV_WORKER_THREADS 32
+#define MAX_LIBUV_WORKER_THREADS 64
+#define RESERVED_LIBUV_WORKER_THREADS 3
 #else
 #define MIN_LIBUV_WORKER_THREADS 16
 #define MAX_LIBUV_WORKER_THREADS 128
+#define RESERVED_LIBUV_WORKER_THREADS 6
 #endif
 
-#define RESERVED_LIBUV_WORKER_THREADS 6
 extern int libuv_worker_threads;
 
 #define RRD_ID_LENGTH_MAX 200

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -152,8 +152,14 @@ extern int default_rrd_history_entries;
 extern int gap_when_lost_iterations_above;
 extern time_t rrdset_free_obsolete_time_s;
 
+#if defined(ENV32BIT)
+#define MIN_LIBUV_WORKER_THREADS 8
+#define MAX_LIBUV_WORKER_THREADS 32
+#else
 #define MIN_LIBUV_WORKER_THREADS 16
 #define MAX_LIBUV_WORKER_THREADS 128
+#endif
+
 #define RESERVED_LIBUV_WORKER_THREADS 6
 extern int libuv_worker_threads;
 

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -15,6 +15,12 @@ extern "C" {
 #define NETDATA_INTERNAL_CHECKS 1
 #endif
 
+#if INTPTR_MAX == INT32_MAX
+#define ENV32BIT 1
+#else
+#define ENV64BIT 1
+#endif
+
 // NETDATA_TRACE_ALLOCATIONS does not work under musl libc, so don't enable it
 //#if defined(NETDATA_INTERNAL_CHECKS) && !defined(NETDATA_TRACE_ALLOCATIONS)
 //#define NETDATA_TRACE_ALLOCATIONS 1

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -15,7 +15,7 @@ extern "C" {
 #define NETDATA_INTERNAL_CHECKS 1
 #endif
 
-#if INTPTR_MAX == INT32_MAX
+#if SIZEOF_VOID_P == 4
 #define ENV32BIT 1
 #else
 #define ENV64BIT 1

--- a/ml/Host.cc
+++ b/ml/Host.cc
@@ -142,6 +142,9 @@ void Host::detectOnce() {
         TSCopy.RemainingUT = 0;
     }
 
+    if(!RH)
+        return;
+
     worker_is_busy(WORKER_JOB_DETECTION_DIM_CHART);
     updateDimensionsChart(RH, MLSCopy);
 

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -457,6 +457,10 @@ bool rrdhost_set_receiver(RRDHOST *host, struct receiver_state *rpt) {
             }
         }
 
+//         this is a test
+//        if(rpt->hops <= host->sender->hops)
+//            rrdpush_sender_thread_stop(host, "HOPS MISMATCH", false);
+
         signal_rrdcontext = true;
         rrdpush_receiver_replication_reset(host);
 

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -4,6 +4,7 @@
 #include "Judy.h"
 
 #define STREAMING_START_MAX_SENDER_BUFFER_PERCENTAGE_ALLOWED 50ULL
+#define MAX_REPLICATION_MESSAGE_PERCENT_SENDER_BUFFER 25ULL
 #define MAX_SENDER_BUFFER_PERCENTAGE_ALLOWED 50ULL
 #define MIN_SENDER_BUFFER_PERCENTAGE_ALLOWED 10ULL
 
@@ -1215,7 +1216,7 @@ static bool replication_execute_request(struct replication_request *rq, bool wor
     // send the replication data
     rq->q->rq = rq;
     replication_response_execute_and_finalize(
-            rq->q, (size_t)((unsigned long long)rq->sender->host->sender->buffer->max_size * MAX_SENDER_BUFFER_PERCENTAGE_ALLOWED / 100ULL));
+            rq->q, (size_t)((unsigned long long)rq->sender->host->sender->buffer->max_size * MAX_REPLICATION_MESSAGE_PERCENT_SENDER_BUFFER / 100ULL));
 
     netdata_thread_enable_cancelability();
 

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -336,6 +336,8 @@ static time_t replication_query_execute_and_finalize(BUFFER *wb, struct replicat
             if(buffer_strlen(wb) > max_msg_size && last_end_time_in_buffer) {
                 q->query.before = last_end_time_in_buffer;
                 q->query.enable_streaming = false;
+                internal_error(true, "REPLICATION: buffer size %zu is more than the max message size %zu, interrupting replication query.",
+                               buffer_strlen(wb), max_msg_size);
                 break;
             }
             last_end_time_in_buffer = min_end_time;

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -336,8 +336,8 @@ static time_t replication_query_execute_and_finalize(BUFFER *wb, struct replicat
             if(buffer_strlen(wb) > max_msg_size && last_end_time_in_buffer) {
                 q->query.before = last_end_time_in_buffer;
                 q->query.enable_streaming = false;
-                internal_error(true, "REPLICATION: buffer size %zu is more than the max message size %zu, interrupting replication query.",
-                               buffer_strlen(wb), max_msg_size);
+                internal_error(true, "REPLICATION: buffer size %zu is more than the max message size %zu for chart '%s' of host '%s', interrupting replication query.",
+                               buffer_strlen(wb), max_msg_size, rrdset_id(q->st), rrdhost_hostname(q->st->rrdhost));
                 break;
             }
             last_end_time_in_buffer = min_end_time;

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -1404,7 +1404,11 @@ static int replication_execute_next_pending_request(void) {
     struct replication_request *rq;
 
     if(unlikely(!rqs)) {
-        max_requests_ahead = libuv_worker_threads * 2;
+        max_requests_ahead = get_system_cpus() / 2;
+
+        if(max_requests_ahead > libuv_worker_threads * 2)
+            max_requests_ahead = libuv_worker_threads * 2;
+
         if(max_requests_ahead < 2)
             max_requests_ahead = 2;
 

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -633,9 +633,10 @@ int rrdpush_receiver_thread_spawn(struct web_client *w, char *url) {
     struct receiver_state *rpt = callocz(1, sizeof(*rpt));
     rpt->last_msg_t = now_realtime_sec();
     rpt->capabilities = STREAM_CAP_INVALID;
+    rpt->hops = 1;
 
     rpt->system_info = callocz(1, sizeof(struct rrdhost_system_info));
-    rpt->system_info->hops = 1;
+    rpt->system_info->hops = rpt->hops;
 
     rpt->fd                = w->ifd;
     rpt->client_ip         = strdupz(w->client_ip);
@@ -689,7 +690,7 @@ int rrdpush_receiver_thread_spawn(struct web_client *w, char *url) {
             rpt->utc_offset = (int32_t)strtol(value, NULL, 0);
 
         else if(!strcmp(name, "hops"))
-            rpt->system_info->hops = (uint16_t) strtoul(value, NULL, 0);
+            rpt->hops = rpt->system_info->hops = (uint16_t) strtoul(value, NULL, 0);
 
         else if(!strcmp(name, "ml_capable"))
             rpt->system_info->ml_capable = strtoul(value, NULL, 0);

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -161,6 +161,8 @@ struct sender_state {
     int rrdpush_sender_pipe[2];                     // collector to sender thread signaling
     int rrdpush_sender_socket;
 
+    uint16_t hops;
+
 #ifdef ENABLE_COMPRESSION
     struct compressor_state *compressor;
 #endif
@@ -231,6 +233,8 @@ struct receiver_state {
     time_t last_msg_t;
     char read_buffer[PLUGINSD_LINE_MAX + 1];
     int read_len;
+
+    uint16_t hops;
 
     struct {
         bool shutdown;      // signal the streaming parser to exit

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -510,6 +510,8 @@ static bool rrdpush_sender_thread_connect_to_parent(RRDHOST *host, int default_p
     stream_encoded_t se;
     rrdpush_encode_variable(&se, host);
 
+    host->sender->hops = host->system_info->hops + 1;
+
     char http[HTTP_HEADER_SIZE + 1];
     int eol = snprintfz(http, HTTP_HEADER_SIZE,
             "STREAM "
@@ -568,7 +570,7 @@ static bool rrdpush_sender_thread_connect_to_parent(RRDHOST *host, int default_p
                  , rrdhost_timezone(host)
                  , rrdhost_abbrev_timezone(host)
                  , host->utc_offset
-                 , host->system_info->hops + 1
+                 , host->sender->hops
                  , host->system_info->ml_capable
                  , host->system_info->ml_enabled
                  , host->system_info->mc_version

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -726,15 +726,15 @@ static long query_plan_points_coverage_weight(time_t db_first_time_s, time_t db_
         db_last_time_s < after_wanted)
         return -LONG_MAX;
 
-    time_t common_first_t = MAX(db_first_time_s, after_wanted);
-    time_t common_last_t = MIN(db_last_time_s, before_wanted);
+    long long common_first_t = MAX(db_first_time_s, after_wanted);
+    long long common_last_t = MIN(db_last_time_s, before_wanted);
 
-    long time_coverage = (common_last_t - common_first_t) * 1000000 / (before_wanted - after_wanted);
-    size_t points_wanted_in_coverage = points_wanted * time_coverage / 1000000;
+    long long time_coverage = (common_last_t - common_first_t) * 1000000LL / (before_wanted - after_wanted);
+    long long points_wanted_in_coverage = (long long)points_wanted * time_coverage / 1000000LL;
 
-    long points_available = (common_last_t - common_first_t) / db_update_every_s;
-    long points_delta = (long)(points_available - points_wanted_in_coverage);
-    long points_coverage = (points_delta < 0) ? (long)(points_available * time_coverage / points_wanted_in_coverage) : time_coverage;
+    long long points_available = (common_last_t - common_first_t) / db_update_every_s;
+    long long points_delta = (long)(points_available - points_wanted_in_coverage);
+    long long points_coverage = (points_delta < 0) ? (long)(points_available * time_coverage / points_wanted_in_coverage) : time_coverage;
 
     // a way to benefit higher tiers
     // points_coverage += (long)tier * 10000;
@@ -742,7 +742,7 @@ static long query_plan_points_coverage_weight(time_t db_first_time_s, time_t db_
     if(points_available <= 0)
         return -LONG_MAX;
 
-    return points_coverage + (long)(25000 * tier); // 2.5% benefit for each higher tier
+    return (long)(points_coverage + (25000LL * tier)); // 2.5% benefit for each higher tier
 }
 
 static size_t query_metric_best_tier_for_timeframe(QUERY_METRIC *qm, time_t after_wanted, time_t before_wanted, size_t points_wanted) {


### PR DESCRIPTION
1. Query planner uses 64 bit numbers to calculate tier weight
2. Replication adapts its pipeline to the number of cores in the system
3. Replication stops creating too big messages that require increasing the streaming buffer to unrealistic sizes
4. Fixed ML crash when RH is NULL
5. On 32-bit use smaller page sizes, less libuv workers, less cache by default