### PR TITLE
fix(health): don't assume 2 cores if the number is unknown

### DIFF
--- a/health/health.d/load.conf
+++ b/health/health.d/load.conf
@@ -11,7 +11,7 @@
 component: Load
        os: linux
     hosts: *
-     calc: ($active_processors == nan or $active_processors == inf or $active_processors < 2) ? ( 2 ) : ( $active_processors )
+     calc: ($active_processors < 2) ? ( 2 ) : ( $active_processors )
     units: cpus
     every: 1m
      info: number of active CPU cores in the system
@@ -28,6 +28,7 @@ component: Load
        os: linux
     hosts: *
    lookup: max -1m unaligned of load15
+     calc: ($load_cpu_number == nan) ? (nan) : ($this)
     units: load
     every: 1m
      warn: ($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 175 : 200)
@@ -43,6 +44,7 @@ component: Load
        os: linux
     hosts: *
    lookup: max -1m unaligned of load5
+     calc: ($load_cpu_number == nan) ? (nan) : ($this)
     units: load
     every: 1m
      warn: ($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 350 : 400)
@@ -58,6 +60,7 @@ component: Load
        os: linux
     hosts: *
    lookup: max -1m unaligned of load1
+     calc: ($load_cpu_number == nan) ? (nan) : ($this)
     units: load
     every: 1m
      warn: ($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 700 : 800)


### PR DESCRIPTION
##### Summary

Fixes: #14258

> It appears the load_cpu_number value isn't being collected and so is defaulting to 2, **ultimately resulting in tons of inappropriate CPU load alarms going off**.


##### Test Plan

- check loadavg alarms if `$load_cpu_number` is not NaN (should have values).
- check loadavg alarms if `$load_cpu_number` is NaN (should have `-` values).

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
