### PR TITLE
Set an explicit timeout in updater checks.

### DIFF
--- a/.github/scripts/run-updater-check.sh
+++ b/.github/scripts/run-updater-check.sh
@@ -12,7 +12,13 @@ netdata -W buildinfo
 echo "::endgroup::"
 echo ">>> Updating Netdata..."
 export NETDATA_BASE_URL="http://localhost:8080/artifacts/" # Pull the tarball from the local web server.
-/netdata/packaging/installer/netdata-updater.sh --not-running-from-cron --no-updater-self-update || exit 1
+timeout 3600 /netdata/packaging/installer/netdata-updater.sh --not-running-from-cron --no-updater-self-update
+
+case "$?" in
+    124) echo "!!! Updater timed out." ; exit 1 ;;
+    0) ;;
+    *) echo "!!! Updater failed." ; exit 1 ;;
+esac
 echo "::group::>>> Post-Update Environment File Contents"
 cat /etc/netdata/.environment
 echo "::endgroup::"


### PR DESCRIPTION
##### Summary

If it takes more than an hour to run the updater, something has gone horribly wrong, so just kill it instead of letting it keep running.

##### Test Plan

Watch the checks on this PR.

##### Additional Information

This should make it easier for us to debug the issues we’re seeing with the Alpine checks.