### PR TITLE
Check session variable before resuming it

### DIFF
--- a/web/server/web_client_cache.c
+++ b/web/server/web_client_cache.c
@@ -14,10 +14,12 @@ static void web_client_reuse_ssl(struct web_client *w) {
             SSL_SESSION *session = SSL_get_session(w->ssl.conn);
             SSL *old = w->ssl.conn;
             w->ssl.conn = SSL_new(netdata_ssl_srv_ctx);
+            if (session) {
 #if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_111
-            if (SSL_SESSION_is_resumable(session))
+                if (SSL_SESSION_is_resumable(session))
 #endif
-                SSL_set_session(w->ssl.conn, session);
+                    SSL_set_session(w->ssl.conn, session);
+            }
             SSL_free(old);
         }
     }


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR checks the session variable before attempting to use it. If it's not checked, and the variable is null it can lead to a crash.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Tested locally by specifically setting `session` to null. Indeed the crash reported here -> https://github.com/netdata/netdata/issues/14249#issuecomment-1384666296 occurs. With the check in place there is no crash.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
