### PR TITLE
Make sure variables are streamed after SENDER_CONNECTED flag is set

### DIFF
--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -275,6 +275,9 @@ static void rrdpush_sender_charts_and_replication_reset(RRDHOST *host) {
 static void rrdpush_sender_on_connect(RRDHOST *host) {
     rrdpush_sender_cbuffer_flush(host);
     rrdpush_sender_charts_and_replication_reset(host);
+}
+
+static void rrdpush_sender_after_connect(RRDHOST *host) {
     rrdpush_sender_thread_send_custom_host_variables(host);
 }
 
@@ -738,6 +741,8 @@ static bool attempt_to_connect(struct sender_state *state)
 
         // let the data collection threads know we are ready
         rrdhost_flag_set(state->host, RRDHOST_FLAG_RRDPUSH_SENDER_CONNECTED);
+
+        rrdpush_sender_after_connect(state->host);
 
         return true;
     }


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->
Fixes #14258 

`rrdpush_sender_thread_send_custom_host_variables` is called before the flag `RRDHOST_FLAG_RRDPUSH_SENDER_CONNECTED` is set, and because there is a check for this flag the function is not actually executed to transmit host variables over streaming.

Host variables eventually are streamed when the agent connects (by using the `rrdpush_sender_send_this_host_variable_now` function), but not again if the parent is restarted.

This PR just changes to call the function after the flag is set.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Setup a parent/child.
Start parent, start child.
Check the alert on the parent for the child: `system.load.load_cpu_number`. It should have the correct cpu cores of the child.
Restart the parent.
Without this PR the core count will be 0 (or dash). With this PR (running on the child) the parent should correctly display the core count of the child.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
