### PR TITLE
fix(alarms): treat 0 processors as unknown in load_cpu_number

### DIFF
--- a/health/health.d/load.conf
+++ b/health/health.d/load.conf
@@ -11,7 +11,7 @@
 component: Load
        os: linux
     hosts: *
-     calc: ($active_processors < 2) ? ( 2 ) : ( $active_processors )
+     calc: ($active_processors == nan or $active_processors == 0) ? (nan) : ( ($active_processors < 2) ? ( 2 ) : ( $active_processors ) )
     units: cpus
     every: 1m
      info: number of active CPU cores in the system


### PR DESCRIPTION
##### Summary

ssia, related PR #14283

##### Test Plan

Test the alarm locally

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
