### PR TITLE
track memory footprint of Netdata

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -947,7 +947,7 @@ char *aclk_state(void)
 #ifndef ENABLE_ACLK
     return strdupz("ACLK Available: No");
 #else
-    BUFFER *wb = buffer_create(1024);
+    BUFFER *wb = buffer_create(1024, &netdata_buffers_statistics.buffers_aclk);
     struct tm *tmptr, tmbuf;
     char *ret;
 

--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -314,7 +314,7 @@ int aclk_get_otp_challenge(url_t *target, const char *agent_id, unsigned char **
     https_req_t req = HTTPS_REQ_T_INITIALIZER;
     https_req_response_t resp = HTTPS_REQ_RESPONSE_T_INITIALIZER;
 
-    BUFFER *url = buffer_create(strlen(OTP_URL_PREFIX) + UUID_STR_LEN + 20);
+    BUFFER *url = buffer_create(strlen(OTP_URL_PREFIX) + UUID_STR_LEN + 20, &netdata_buffers_statistics.buffers_aclk);
 
     req.host = target->host;
     req.port = target->port;
@@ -394,8 +394,8 @@ int aclk_send_otp_response(const char *agent_id, const unsigned char *response, 
 
     base64_encode_helper(base64, &len, response, response_bytes);
 
-    BUFFER *url = buffer_create(strlen(OTP_URL_PREFIX) + UUID_STR_LEN + 20);
-    BUFFER *resp_json = buffer_create(strlen(OTP_URL_PREFIX) + UUID_STR_LEN + 20);
+    BUFFER *url = buffer_create(strlen(OTP_URL_PREFIX) + UUID_STR_LEN + 20, &netdata_buffers_statistics.buffers_aclk);
+    BUFFER *resp_json = buffer_create(strlen(OTP_URL_PREFIX) + UUID_STR_LEN + 20, &netdata_buffers_statistics.buffers_aclk);
 
     buffer_sprintf(url, "%s/node/%s/password", target->path, agent_id);
     buffer_sprintf(resp_json, "{\"response\":\"%s\"}", base64);
@@ -814,7 +814,7 @@ exit:
 }
 
 int aclk_get_env(aclk_env_t *env, const char* aclk_hostname, int aclk_port) {
-    BUFFER *buf = buffer_create(1024);
+    BUFFER *buf = buffer_create(1024, &netdata_buffers_statistics.buffers_aclk);
 
     https_req_t req = HTTPS_REQ_T_INITIALIZER;
     https_req_response_t resp = HTTPS_REQ_RESPONSE_T_INITIALIZER;

--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -62,19 +62,19 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query)
     int retval = 0;
     usec_t t;
     BUFFER *local_buffer = NULL;
-    BUFFER *log_buffer = buffer_create(NETDATA_WEB_REQUEST_URL_SIZE);
+    BUFFER *log_buffer = buffer_create(NETDATA_WEB_REQUEST_URL_SIZE, &netdata_buffers_statistics.buffers_aclk);
     RRDHOST *query_host = localhost;
 
 #ifdef NETDATA_WITH_ZLIB
     int z_ret;
-    BUFFER *z_buffer = buffer_create(NETDATA_WEB_RESPONSE_INITIAL_SIZE);
+    BUFFER *z_buffer = buffer_create(NETDATA_WEB_RESPONSE_INITIAL_SIZE, &netdata_buffers_statistics.buffers_aclk);
     char *start, *end;
 #endif
 
     struct web_client *w = (struct web_client *)callocz(1, sizeof(struct web_client));
-    w->response.data = buffer_create(NETDATA_WEB_RESPONSE_INITIAL_SIZE);
-    w->response.header = buffer_create(NETDATA_WEB_RESPONSE_HEADER_SIZE);
-    w->response.header_output = buffer_create(NETDATA_WEB_RESPONSE_HEADER_SIZE);
+    w->response.data = buffer_create(NETDATA_WEB_RESPONSE_INITIAL_SIZE, &netdata_buffers_statistics.buffers_aclk);
+    w->response.header = buffer_create(NETDATA_WEB_RESPONSE_HEADER_SIZE, &netdata_buffers_statistics.buffers_aclk);
+    w->response.header_output = buffer_create(NETDATA_WEB_RESPONSE_HEADER_SIZE, &netdata_buffers_statistics.buffers_aclk);
     strcpy(w->origin, "*"); // Simulate web_client_create_on_fd()
     w->cookie1[0] = 0;      // Simulate web_client_create_on_fd()
     w->cookie2[0] = 0;      // Simulate web_client_create_on_fd()
@@ -191,7 +191,7 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query)
 
     w->response.data->date = w->tv_ready.tv_sec;
     web_client_build_http_header(w);
-    local_buffer = buffer_create(NETDATA_WEB_RESPONSE_INITIAL_SIZE);
+    local_buffer = buffer_create(NETDATA_WEB_RESPONSE_INITIAL_SIZE, &netdata_buffers_statistics.buffers_aclk);
     local_buffer->contenttype = CT_APPLICATION_JSON;
 
     buffer_strcat(local_buffer, w->response.header_output->buffer);

--- a/aclk/https_client.c
+++ b/aclk/https_client.c
@@ -8,6 +8,8 @@
 
 #include "aclk_util.h"
 
+#include "daemon/global_statistics.h"
+
 enum http_parse_state {
     HTTP_PARSE_INITIAL = 0,
     HTTP_PARSE_HEADERS,
@@ -354,7 +356,7 @@ static int read_parse_response(https_req_ctx_t *ctx) {
 #define TX_BUFFER_SIZE 8192
 #define RX_BUFFER_SIZE (TX_BUFFER_SIZE*2)
 static int handle_http_request(https_req_ctx_t *ctx) {
-    BUFFER *hdr = buffer_create(TX_BUFFER_SIZE);
+    BUFFER *hdr = buffer_create(TX_BUFFER_SIZE, &netdata_buffers_statistics.buffers_aclk);
     int rc = 0;
 
     http_parse_ctx_clear(&ctx->parse_ctx);

--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -4396,7 +4396,7 @@ static void apps_plugin_function_processes(const char *transaction, char *functi
     unsigned int memory_divisor = 1024;
     unsigned int io_divisor = 1024 * RATES_DETAIL;
 
-    BUFFER *wb = buffer_create(PLUGINSD_LINE_MAX);
+    BUFFER *wb = buffer_create(PLUGINSD_LINE_MAX, NULL);
     buffer_sprintf(wb,
                    "{"
                    "\n   \"status\":%d"

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -319,7 +319,7 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
                 , SIMPLE_PATTERN_EXACT
         );
 
-        dict_mountpoints = dictionary_create(DICT_OPTION_NONE);
+        dict_mountpoints = dictionary_create_advanced(DICT_OPTION_NONE, &dictionary_stats_category_collectors);
     }
 
     struct mount_point_metadata *m = dictionary_get(dict_mountpoints, mi->mount_point);

--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -530,7 +530,7 @@ static void inflight_functions_delete_callback(const DICTIONARY_ITEM *item __may
 }
 
 void inflight_functions_init(PARSER *parser) {
-    parser->inflight.functions = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);
+    parser->inflight.functions = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE, &dictionary_stats_category_functions);
     dictionary_register_insert_callback(parser->inflight.functions, inflight_functions_insert_callback, parser);
     dictionary_register_delete_callback(parser->inflight.functions, inflight_functions_delete_callback, parser);
     dictionary_register_conflict_callback(parser->inflight.functions, inflight_functions_conflict_callback, parser);

--- a/collectors/proc.plugin/proc_self_mountinfo.c
+++ b/collectors/proc.plugin/proc_self_mountinfo.c
@@ -227,8 +227,9 @@ struct mountinfo *mountinfo_read(int do_statvfs) {
     struct mountinfo *root = NULL, *last = NULL, *mi = NULL;
 
     // create a dictionary to track uniqueness
-    DICTIONARY *dict = dictionary_create(
-        DICT_OPTION_SINGLE_THREADED | DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_NAME_LINK_DONT_CLONE);
+    DICTIONARY *dict = dictionary_create_advanced(
+            DICT_OPTION_SINGLE_THREADED | DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_NAME_LINK_DONT_CLONE,
+            &dictionary_stats_category_collectors);
 
     unsigned long l, lines = procfile_lines(ff);
     for(l = 0; l < lines ;l++) {

--- a/collectors/proc.plugin/proc_spl_kstat_zfs.c
+++ b/collectors/proc.plugin/proc_spl_kstat_zfs.c
@@ -322,7 +322,7 @@ int do_proc_spl_kstat_zfs_pool_state(int update_every, usec_t dt)
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/spl/kstat/zfs");
         dirname = config_get("plugin:proc:" ZFS_PROC_POOLS, "directory to monitor", filename);
 
-        zfs_pools = dictionary_create(DICT_OPTION_SINGLE_THREADED);
+        zfs_pools = dictionary_create_advanced(DICT_OPTION_SINGLE_THREADED, &dictionary_stats_category_collectors);
 
         do_zfs_pool_state = 1;
     }

--- a/collectors/proc.plugin/sys_block_zram.c
+++ b/collectors/proc.plugin/sys_block_zram.c
@@ -267,7 +267,7 @@ int do_sys_block_zram(int update_every, usec_t dt) {
         }
         procfile_close(ff);
 
-        devices = dictionary_create(DICT_OPTION_SINGLE_THREADED);
+        devices = dictionary_create_advanced(DICT_OPTION_SINGLE_THREADED, &dictionary_stats_category_collectors);
         device_count = init_devices(devices, (unsigned int)zram_id, update_every);
     }
 

--- a/collectors/statsd.plugin/statsd.c
+++ b/collectors/statsd.plugin/statsd.c
@@ -595,7 +595,7 @@ static inline void statsd_process_set(STATSD_METRIC *m, const char *value) {
     }
 
     if (unlikely(!m->set.dict)) {
-        m->set.dict   = dictionary_create(STATSD_DICTIONARY_OPTIONS);
+        m->set.dict   = dictionary_create_advanced(STATSD_DICTIONARY_OPTIONS, &dictionary_stats_category_collectors);
         dictionary_register_insert_callback(m->set.dict, dictionary_metric_set_value_insert_callback, m);
         m->set.unique = 0;
     }
@@ -635,7 +635,7 @@ static inline void statsd_process_dictionary(STATSD_METRIC *m, const char *value
         statsd_reset_metric(m);
 
     if (unlikely(!m->dictionary.dict)) {
-        m->dictionary.dict   = dictionary_create(STATSD_DICTIONARY_OPTIONS);
+        m->dictionary.dict   = dictionary_create_advanced(STATSD_DICTIONARY_OPTIONS, &dictionary_stats_category_collectors);
         dictionary_register_insert_callback(m->dictionary.dict, dictionary_metric_dict_value_insert_callback, m);
         m->dictionary.unique = 0;
     }
@@ -1339,7 +1339,7 @@ static int statsd_readfile(const char *filename, STATSD_APP *app, STATSD_APP_CHA
             else if(app) {
                 if(!strcmp(s, "dictionary")) {
                     if(!app->dict)
-                        app->dict = dictionary_create(DICT_OPTION_SINGLE_THREADED);
+                        app->dict = dictionary_create_advanced(DICT_OPTION_SINGLE_THREADED, &dictionary_stats_category_collectors);
 
                     dict = app->dict;
                 }
@@ -2424,13 +2424,13 @@ void *statsd_main(void *ptr) {
 
     netdata_thread_cleanup_push(statsd_main_cleanup, ptr);
 
-    statsd.gauges.dict = dictionary_create(STATSD_DICTIONARY_OPTIONS);
-    statsd.meters.dict = dictionary_create(STATSD_DICTIONARY_OPTIONS);
-    statsd.counters.dict = dictionary_create(STATSD_DICTIONARY_OPTIONS);
-    statsd.histograms.dict = dictionary_create(STATSD_DICTIONARY_OPTIONS);
-    statsd.dictionaries.dict = dictionary_create(STATSD_DICTIONARY_OPTIONS);
-    statsd.sets.dict = dictionary_create(STATSD_DICTIONARY_OPTIONS);
-    statsd.timers.dict = dictionary_create(STATSD_DICTIONARY_OPTIONS);
+    statsd.gauges.dict = dictionary_create_advanced(STATSD_DICTIONARY_OPTIONS, &dictionary_stats_category_collectors);
+    statsd.meters.dict = dictionary_create_advanced(STATSD_DICTIONARY_OPTIONS, &dictionary_stats_category_collectors);
+    statsd.counters.dict = dictionary_create_advanced(STATSD_DICTIONARY_OPTIONS, &dictionary_stats_category_collectors);
+    statsd.histograms.dict = dictionary_create_advanced(STATSD_DICTIONARY_OPTIONS, &dictionary_stats_category_collectors);
+    statsd.dictionaries.dict = dictionary_create_advanced(STATSD_DICTIONARY_OPTIONS, &dictionary_stats_category_collectors);
+    statsd.sets.dict = dictionary_create_advanced(STATSD_DICTIONARY_OPTIONS, &dictionary_stats_category_collectors);
+    statsd.timers.dict = dictionary_create_advanced(STATSD_DICTIONARY_OPTIONS, &dictionary_stats_category_collectors);
 
     dictionary_register_insert_callback(statsd.gauges.dict, dictionary_metric_insert_callback, &statsd.gauges);
     dictionary_register_insert_callback(statsd.meters.dict, dictionary_metric_insert_callback, &statsd.meters);

--- a/collectors/tc.plugin/plugin_tc.c
+++ b/collectors/tc.plugin/plugin_tc.c
@@ -98,7 +98,7 @@ static bool tc_class_conflict_callback(const DICTIONARY_ITEM *item __maybe_unuse
 
 static void tc_class_index_init(struct tc_device *d) {
     if(!d->classes) {
-        d->classes = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_SINGLE_THREADED);
+        d->classes = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_SINGLE_THREADED, &dictionary_stats_category_collectors);
 
         dictionary_register_delete_callback(d->classes, tc_class_free_callback, d);
         dictionary_register_conflict_callback(d->classes, tc_class_conflict_callback, d);
@@ -144,8 +144,9 @@ static void tc_device_free_callback(const DICTIONARY_ITEM *item __maybe_unused, 
 
 static void tc_device_index_init() {
     if(!tc_device_root_index) {
-        tc_device_root_index = dictionary_create(
-            DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_SINGLE_THREADED | DICT_OPTION_ADD_IN_FRONT);
+        tc_device_root_index = dictionary_create_advanced(
+            DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_SINGLE_THREADED | DICT_OPTION_ADD_IN_FRONT,
+            &dictionary_stats_category_collectors);
 
         dictionary_register_insert_callback(tc_device_root_index, tc_device_add_callback, NULL);
         dictionary_register_delete_callback(tc_device_root_index, tc_device_free_callback, NULL);

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -241,7 +241,7 @@ void analytics_exporters(void)
 {
     //when no exporters are available, an empty string will be sent
     //decide if something else is more suitable (but probably not null)
-    BUFFER *bi = buffer_create(1000);
+    BUFFER *bi = buffer_create(1000, NULL);
     analytics_exporting_connectors(bi);
     analytics_set_data_str(&analytics_data.netdata_exporting_connectors, (char *)buffer_tostring(bi));
     buffer_free(bi);
@@ -278,7 +278,7 @@ void analytics_collectors(void)
     RRDSET *st;
     DICTIONARY *dict = dictionary_create(DICT_OPTION_SINGLE_THREADED);
     char name[500];
-    BUFFER *bt = buffer_create(1000);
+    BUFFER *bt = buffer_create(1000, NULL);
 
     rrdset_foreach_read(st, localhost) {
         if(!rrdset_is_available_for_viewers(st))
@@ -333,7 +333,7 @@ void analytics_alarms_notifications(void)
 
     debug(D_ANALYTICS, "Executing %s", script);
 
-    BUFFER *b = buffer_create(1000);
+    BUFFER *b = buffer_create(1000, NULL);
     int cnt = 0;
     FILE *fp_child_input;
     FILE *fp_child_output = netdata_popen(script, &command_pid, &fp_child_input);
@@ -380,7 +380,7 @@ void analytics_get_install_type(void)
  */
 void analytics_https(void)
 {
-    BUFFER *b = buffer_create(30);
+    BUFFER *b = buffer_create(30, NULL);
 #ifdef ENABLE_HTTPS
     analytics_exporting_connectors_ssl(b);
     buffer_strcat(b, netdata_ssl_client_ctx && rrdhost_flag_check(localhost, RRDHOST_FLAG_RRDPUSH_SENDER_CONNECTED) && localhost->sender->ssl.flags == NETDATA_SSL_HANDSHAKE_COMPLETE ? "streaming|" : "|");
@@ -675,7 +675,7 @@ void set_late_global_environment()
     analytics_set_data_str(&analytics_data.netdata_config_release_channel, (char *)get_release_channel());
 
     {
-        BUFFER *bi = buffer_create(1000);
+        BUFFER *bi = buffer_create(1000, NULL);
         analytics_build_info(bi);
         analytics_set_data_str(&analytics_data.netdata_buildinfo, (char *)buffer_tostring(bi));
         buffer_free(bi);
@@ -836,7 +836,7 @@ void set_global_environment()
     setenv("NETDATA_HOST_PREFIX", netdata_configured_host_prefix, 1);
 
     {
-        BUFFER *user_plugins_dirs = buffer_create(FILENAME_MAX);
+        BUFFER *user_plugins_dirs = buffer_create(FILENAME_MAX, NULL);
 
         for (size_t i = 1; i < PLUGINSD_MAX_DIRECTORIES && plugin_directories[i]; i++) {
             if (i > 1)

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -220,7 +220,7 @@ static cmd_status_t cmd_reload_labels_execute(char *args, char **message)
     info("COMMAND: reloading host labels.");
     reload_host_labels();
 
-    BUFFER *wb = buffer_create(10);
+    BUFFER *wb = buffer_create(10, NULL);
     rrdlabels_log_to_buffer(localhost->rrdlabels, wb);
     (*message)=strdupz(buffer_tostring(wb));
     buffer_free(wb);

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -288,6 +288,7 @@ static void global_statistics_charts(void) {
         static RRDDIM *rd_functions = NULL;
         static RRDDIM *rd_labels = NULL;
         static RRDDIM *rd_strings = NULL;
+        static RRDDIM *rd_streaming = NULL;
         static RRDDIM *rd_buffers = NULL;
         static RRDDIM *rd_other = NULL;
 
@@ -315,6 +316,7 @@ static void global_statistics_charts(void) {
             rd_functions = rrddim_add(st_memory, "functions", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_labels = rrddim_add(st_memory, "labels", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_strings = rrddim_add(st_memory, "strings", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_streaming = rrddim_add(st_memory, "streaming", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_buffers = rrddim_add(st_memory, "buffers", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_other = rrddim_add(st_memory, "other", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
         }
@@ -343,6 +345,7 @@ static void global_statistics_charts(void) {
         rrddim_set_by_pointer(st_memory, rd_functions, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_functions));
         rrddim_set_by_pointer(st_memory, rd_labels, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_rrdlabels));
         rrddim_set_by_pointer(st_memory, rd_strings, (collected_number)strings);
+        rrddim_set_by_pointer(st_memory, rd_streaming, (collected_number)netdata_buffers_statistics.rrdhost_senders + (collected_number)netdata_buffers_statistics.rrdhost_receivers);
         rrddim_set_by_pointer(st_memory, rd_buffers, (collected_number)buffers);
         rrddim_set_by_pointer(st_memory, rd_other, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_other));
 
@@ -360,6 +363,7 @@ static void global_statistics_charts(void) {
         static RRDDIM *rd_buffers_exporters = NULL;
         static RRDDIM *rd_buffers_health = NULL;
         static RRDDIM *rd_buffers_streaming = NULL;
+        static RRDDIM *rd_cbuffers_streaming = NULL;
         static RRDDIM *rd_buffers_web = NULL;
 
         if (unlikely(!st_memory_buffers)) {
@@ -386,6 +390,7 @@ static void global_statistics_charts(void) {
             rd_buffers_exporters = rrddim_add(st_memory_buffers, "exporters", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_buffers_health = rrddim_add(st_memory_buffers, "health", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_buffers_streaming = rrddim_add(st_memory_buffers, "streaming", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_cbuffers_streaming = rrddim_add(st_memory_buffers, "streaming cbuf", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_buffers_web = rrddim_add(st_memory_buffers, "web", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
         }
 
@@ -398,6 +403,7 @@ static void global_statistics_charts(void) {
         rrddim_set_by_pointer(st_memory_buffers, rd_buffers_exporters, (collected_number)netdata_buffers_statistics.buffers_exporters);
         rrddim_set_by_pointer(st_memory_buffers, rd_buffers_health, (collected_number)netdata_buffers_statistics.buffers_health);
         rrddim_set_by_pointer(st_memory_buffers, rd_buffers_streaming, (collected_number)netdata_buffers_statistics.buffers_streaming);
+        rrddim_set_by_pointer(st_memory_buffers, rd_cbuffers_streaming, (collected_number)netdata_buffers_statistics.cbuffers_streaming);
         rrddim_set_by_pointer(st_memory_buffers, rd_buffers_web, (collected_number)netdata_buffers_statistics.buffers_web);
 
         rrdset_done(st_memory_buffers);

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -23,6 +23,7 @@ bool global_statistics_enabled = true;
 struct netdata_buffers_statistics netdata_buffers_statistics = {};
 
 static size_t dbengine_total_memory = 0;
+size_t rrddim_db_memory_size = 0;
 
 static struct global_statistics {
     uint16_t connected_clients;
@@ -333,7 +334,7 @@ static void global_statistics_charts(void) {
         size_t strings = 0;
         string_statistics(NULL, NULL, NULL, NULL, NULL, &strings, NULL, NULL);
 
-        rrddim_set_by_pointer(st_memory, rd_database, (collected_number)dbengine_total_memory);
+        rrddim_set_by_pointer(st_memory, rd_database, (collected_number)dbengine_total_memory + rrddim_db_memory_size);
         rrddim_set_by_pointer(st_memory, rd_collectors, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_collectors));
         rrddim_set_by_pointer(st_memory, rd_hosts, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_rrdhost));
         rrddim_set_by_pointer(st_memory, rd_rrd, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_rrdset_rrddim));

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -289,6 +289,7 @@ static void global_statistics_charts(void) {
         static RRDDIM *rd_labels = NULL;
         static RRDDIM *rd_strings = NULL;
         static RRDDIM *rd_streaming = NULL;
+        static RRDDIM *rd_replication = NULL;
         static RRDDIM *rd_buffers = NULL;
         static RRDDIM *rd_workers = NULL;
         static RRDDIM *rd_other = NULL;
@@ -318,6 +319,7 @@ static void global_statistics_charts(void) {
             rd_labels = rrddim_add(st_memory, "labels", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_strings = rrddim_add(st_memory, "strings", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_streaming = rrddim_add(st_memory, "streaming", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_replication = rrddim_add(st_memory, "replication", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_buffers = rrddim_add(st_memory, "buffers", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_workers = rrddim_add(st_memory, "workers", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_other = rrddim_add(st_memory, "other", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
@@ -334,7 +336,8 @@ static void global_statistics_charts(void) {
             netdata_buffers_statistics.buffers_health +
             netdata_buffers_statistics.buffers_streaming +
             netdata_buffers_statistics.cbuffers_streaming +
-            netdata_buffers_statistics.buffers_web;
+            netdata_buffers_statistics.buffers_web +
+            replication_allocated_buffers();
 
         size_t strings = 0;
         string_statistics(NULL, NULL, NULL, NULL, NULL, &strings, NULL, NULL);
@@ -349,6 +352,7 @@ static void global_statistics_charts(void) {
         rrddim_set_by_pointer(st_memory, rd_labels, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_rrdlabels));
         rrddim_set_by_pointer(st_memory, rd_strings, (collected_number)strings);
         rrddim_set_by_pointer(st_memory, rd_streaming, (collected_number)netdata_buffers_statistics.rrdhost_senders + (collected_number)netdata_buffers_statistics.rrdhost_receivers);
+        rrddim_set_by_pointer(st_memory, rd_replication, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_replication) + (collected_number)replication_allocated_memory());
         rrddim_set_by_pointer(st_memory, rd_buffers, (collected_number)buffers);
         rrddim_set_by_pointer(st_memory, rd_workers, (collected_number) workers_allocated_memory());
         rrddim_set_by_pointer(st_memory, rd_other, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_other));
@@ -368,6 +372,7 @@ static void global_statistics_charts(void) {
         static RRDDIM *rd_buffers_health = NULL;
         static RRDDIM *rd_buffers_streaming = NULL;
         static RRDDIM *rd_cbuffers_streaming = NULL;
+        static RRDDIM *rd_buffers_replication = NULL;
         static RRDDIM *rd_buffers_web = NULL;
 
         if (unlikely(!st_memory_buffers)) {
@@ -395,6 +400,7 @@ static void global_statistics_charts(void) {
             rd_buffers_health = rrddim_add(st_memory_buffers, "health", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_buffers_streaming = rrddim_add(st_memory_buffers, "streaming", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_cbuffers_streaming = rrddim_add(st_memory_buffers, "streaming cbuf", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_buffers_replication = rrddim_add(st_memory_buffers, "replication", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_buffers_web = rrddim_add(st_memory_buffers, "web", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
         }
 
@@ -408,6 +414,7 @@ static void global_statistics_charts(void) {
         rrddim_set_by_pointer(st_memory_buffers, rd_buffers_health, (collected_number)netdata_buffers_statistics.buffers_health);
         rrddim_set_by_pointer(st_memory_buffers, rd_buffers_streaming, (collected_number)netdata_buffers_statistics.buffers_streaming);
         rrddim_set_by_pointer(st_memory_buffers, rd_cbuffers_streaming, (collected_number)netdata_buffers_statistics.cbuffers_streaming);
+        rrddim_set_by_pointer(st_memory_buffers, rd_buffers_replication, (collected_number)replication_allocated_buffers());
         rrddim_set_by_pointer(st_memory_buffers, rd_buffers_web, (collected_number)netdata_buffers_statistics.buffers_web);
 
         rrdset_done(st_memory_buffers);
@@ -2705,6 +2712,7 @@ struct dictionary_stats dictionary_stats_category_rrdcontext = { .name = "contex
 struct dictionary_stats dictionary_stats_category_rrdlabels = { .name = "labels" };
 struct dictionary_stats dictionary_stats_category_rrdhealth = { .name = "health" };
 struct dictionary_stats dictionary_stats_category_functions = { .name = "functions" };
+struct dictionary_stats dictionary_stats_category_replication = { .name = "replication" };
 
 struct dictionary_categories {
     struct dictionary_stats *stats;
@@ -2758,6 +2766,7 @@ struct dictionary_categories {
     { .stats = &dictionary_stats_category_rrdlabels, "dictionaries labels", "dictionaries", 900000 },
     { .stats = &dictionary_stats_category_rrdhealth, "dictionaries health", "dictionaries", 900000 },
     { .stats = &dictionary_stats_category_functions, "dictionaries functions", "dictionaries", 900000 },
+    { .stats = &dictionary_stats_category_replication, "dictionaries replication", "dictionaries", 900000 },
     { .stats = &dictionary_stats_category_other, "dictionaries other", "dictionaries", 900000 },
 
     // terminator

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -220,7 +220,7 @@ static inline void global_statistics_copy(struct global_statistics *gs, uint8_t 
 }
 
 #define dictionary_stats_memory_total(stats) \
-    ((stats).memory.dict + (stats).memory.values + ((stats).memory.indexed * 3))
+    ((stats).memory.dict + (stats).memory.values + (stats).memory.index)
 
 static void global_statistics_charts(void) {
     static unsigned long long old_web_requests = 0,
@@ -290,6 +290,7 @@ static void global_statistics_charts(void) {
         static RRDDIM *rd_strings = NULL;
         static RRDDIM *rd_streaming = NULL;
         static RRDDIM *rd_buffers = NULL;
+        static RRDDIM *rd_workers = NULL;
         static RRDDIM *rd_other = NULL;
 
         if (unlikely(!st_memory)) {
@@ -318,6 +319,7 @@ static void global_statistics_charts(void) {
             rd_strings = rrddim_add(st_memory, "strings", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_streaming = rrddim_add(st_memory, "streaming", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_buffers = rrddim_add(st_memory, "buffers", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_workers = rrddim_add(st_memory, "workers", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rd_other = rrddim_add(st_memory, "other", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
         }
 
@@ -348,6 +350,7 @@ static void global_statistics_charts(void) {
         rrddim_set_by_pointer(st_memory, rd_strings, (collected_number)strings);
         rrddim_set_by_pointer(st_memory, rd_streaming, (collected_number)netdata_buffers_statistics.rrdhost_senders + (collected_number)netdata_buffers_statistics.rrdhost_receivers);
         rrddim_set_by_pointer(st_memory, rd_buffers, (collected_number)buffers);
+        rrddim_set_by_pointer(st_memory, rd_workers, (collected_number) workers_allocated_memory());
         rrddim_set_by_pointer(st_memory, rd_other, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_other));
 
         rrdset_done(st_memory);
@@ -395,7 +398,7 @@ static void global_statistics_charts(void) {
             rd_buffers_web = rrddim_add(st_memory_buffers, "web", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
         }
 
-        rrddim_set_by_pointer(st_memory_buffers, rd_queries, (collected_number)netdata_buffers_statistics.query_targets_size);
+        rrddim_set_by_pointer(st_memory_buffers, rd_queries, (collected_number)netdata_buffers_statistics.query_targets_size + (collected_number) onewayalloc_allocated_memory());
         rrddim_set_by_pointer(st_memory_buffers, rd_collectors, (collected_number)netdata_buffers_statistics.rrdset_done_rda_size);
         rrddim_set_by_pointer(st_memory_buffers, rd_buffers_aclk, (collected_number)netdata_buffers_statistics.buffers_aclk);
         rrddim_set_by_pointer(st_memory_buffers, rd_buffers_api, (collected_number)netdata_buffers_statistics.buffers_api);
@@ -2965,7 +2968,7 @@ static void update_dictionary_category_charts(struct dictionary_categories *c) {
     // ------------------------------------------------------------------------
 
     total = 0;
-    load_dictionary_stats_entry(memory.indexed);
+    load_dictionary_stats_entry(memory.index);
     load_dictionary_stats_entry(memory.values);
     load_dictionary_stats_entry(memory.dict);
 
@@ -2999,7 +3002,7 @@ static void update_dictionary_category_charts(struct dictionary_categories *c) {
             rrdlabels_add(c->st_memory->rrdlabels, "category", stats.name, RRDLABEL_SRC_AUTO);
         }
 
-        rrddim_set_by_pointer(c->st_memory, c->rd_memory_indexed, (collected_number)stats.memory.indexed);
+        rrddim_set_by_pointer(c->st_memory, c->rd_memory_indexed, (collected_number)stats.memory.index);
         rrddim_set_by_pointer(c->st_memory, c->rd_memory_values, (collected_number)stats.memory.values);
         rrddim_set_by_pointer(c->st_memory, c->rd_memory_dict, (collected_number)stats.memory.dict);
 

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -334,9 +334,9 @@ static void global_statistics_charts(void) {
         size_t strings = 0;
         string_statistics(NULL, NULL, NULL, NULL, NULL, &strings, NULL, NULL);
 
-        rrddim_set_by_pointer(st_memory, rd_database, (collected_number)dbengine_total_memory + rrddim_db_memory_size);
+        rrddim_set_by_pointer(st_memory, rd_database, (collected_number)dbengine_total_memory + (collected_number)rrddim_db_memory_size);
         rrddim_set_by_pointer(st_memory, rd_collectors, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_collectors));
-        rrddim_set_by_pointer(st_memory, rd_hosts, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_rrdhost));
+        rrddim_set_by_pointer(st_memory, rd_hosts, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_rrdhost) + (collected_number)netdata_buffers_statistics.rrdhost_allocations_size);
         rrddim_set_by_pointer(st_memory, rd_rrd, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_rrdset_rrddim));
         rrddim_set_by_pointer(st_memory, rd_contexts, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_rrdcontext));
         rrddim_set_by_pointer(st_memory, rd_health, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_rrdhealth));

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -20,6 +20,10 @@
 
 bool global_statistics_enabled = true;
 
+struct netdata_buffers_statistics netdata_buffers_statistics = {};
+
+static size_t dbengine_total_memory = 0;
+
 static struct global_statistics {
     uint16_t connected_clients;
 
@@ -214,6 +218,9 @@ static inline void global_statistics_copy(struct global_statistics *gs, uint8_t 
     }
 }
 
+#define dictionary_stats_memory_total(stats) \
+    ((stats).memory.dict + (stats).memory.values + ((stats).memory.indexed * 3))
+
 static void global_statistics_charts(void) {
     static unsigned long long old_web_requests = 0,
                               old_web_usec = 0,
@@ -270,23 +277,151 @@ static void global_statistics_charts(void) {
     // ----------------------------------------------------------------
 
     {
+        static RRDSET *st_memory = NULL;
+        static RRDDIM *rd_database = NULL;
+        static RRDDIM *rd_collectors = NULL;
+        static RRDDIM *rd_hosts = NULL;
+        static RRDDIM *rd_rrd = NULL;
+        static RRDDIM *rd_contexts = NULL;
+        static RRDDIM *rd_health = NULL;
+        static RRDDIM *rd_functions = NULL;
+        static RRDDIM *rd_labels = NULL;
+        static RRDDIM *rd_strings = NULL;
+        static RRDDIM *rd_buffers = NULL;
+        static RRDDIM *rd_other = NULL;
+
+        if (unlikely(!st_memory)) {
+            st_memory = rrdset_create_localhost(
+                    "netdata",
+                    "memory",
+                    NULL,
+                    "netdata",
+                    NULL,
+                    "Netdata Memory",
+                    "bytes",
+                    "netdata",
+                    "stats",
+                    130100,
+                    localhost->rrd_update_every,
+                    RRDSET_TYPE_STACKED);
+
+            rd_database = rrddim_add(st_memory, "db", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_collectors = rrddim_add(st_memory, "collectors", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_hosts = rrddim_add(st_memory, "hosts", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_rrd = rrddim_add(st_memory, "rrdset rrddim", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_contexts = rrddim_add(st_memory, "contexts", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_health = rrddim_add(st_memory, "health", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_functions = rrddim_add(st_memory, "functions", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_labels = rrddim_add(st_memory, "labels", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_strings = rrddim_add(st_memory, "strings", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_buffers = rrddim_add(st_memory, "buffers", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_other = rrddim_add(st_memory, "other", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        }
+
+        size_t buffers =
+            netdata_buffers_statistics.query_targets_size +
+            netdata_buffers_statistics.rrdset_done_rda_size +
+            netdata_buffers_statistics.buffers_aclk +
+            netdata_buffers_statistics.buffers_api +
+            netdata_buffers_statistics.buffers_functions +
+            netdata_buffers_statistics.buffers_sqlite +
+            netdata_buffers_statistics.buffers_exporters +
+            netdata_buffers_statistics.buffers_health +
+            netdata_buffers_statistics.buffers_streaming +
+            netdata_buffers_statistics.buffers_web;
+
+        size_t strings = 0;
+        string_statistics(NULL, NULL, NULL, NULL, NULL, &strings, NULL, NULL);
+
+        rrddim_set_by_pointer(st_memory, rd_database, (collected_number)dbengine_total_memory);
+        rrddim_set_by_pointer(st_memory, rd_collectors, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_collectors));
+        rrddim_set_by_pointer(st_memory, rd_hosts, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_rrdhost));
+        rrddim_set_by_pointer(st_memory, rd_rrd, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_rrdset_rrddim));
+        rrddim_set_by_pointer(st_memory, rd_contexts, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_rrdcontext));
+        rrddim_set_by_pointer(st_memory, rd_health, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_rrdhealth));
+        rrddim_set_by_pointer(st_memory, rd_functions, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_functions));
+        rrddim_set_by_pointer(st_memory, rd_labels, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_rrdlabels));
+        rrddim_set_by_pointer(st_memory, rd_strings, (collected_number)strings);
+        rrddim_set_by_pointer(st_memory, rd_buffers, (collected_number)buffers);
+        rrddim_set_by_pointer(st_memory, rd_other, (collected_number)dictionary_stats_memory_total(dictionary_stats_category_other));
+
+        rrdset_done(st_memory);
+    }
+
+    {
+        static RRDSET *st_memory_buffers = NULL;
+        static RRDDIM *rd_queries = NULL;
+        static RRDDIM *rd_collectors = NULL;
+        static RRDDIM *rd_buffers_aclk = NULL;
+        static RRDDIM *rd_buffers_api = NULL;
+        static RRDDIM *rd_buffers_functions = NULL;
+        static RRDDIM *rd_buffers_sqlite = NULL;
+        static RRDDIM *rd_buffers_exporters = NULL;
+        static RRDDIM *rd_buffers_health = NULL;
+        static RRDDIM *rd_buffers_streaming = NULL;
+        static RRDDIM *rd_buffers_web = NULL;
+
+        if (unlikely(!st_memory_buffers)) {
+            st_memory_buffers = rrdset_create_localhost(
+                "netdata",
+                "memory_buffers",
+                NULL,
+                "netdata",
+                NULL,
+                "Netdata Memory Buffers",
+                "bytes",
+                "netdata",
+                "stats",
+                130101,
+                localhost->rrd_update_every,
+                RRDSET_TYPE_STACKED);
+
+            rd_queries = rrddim_add(st_memory_buffers, "queries", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_collectors = rrddim_add(st_memory_buffers, "collection", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_buffers_aclk = rrddim_add(st_memory_buffers, "aclk", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_buffers_api = rrddim_add(st_memory_buffers, "api", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_buffers_functions = rrddim_add(st_memory_buffers, "functions", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_buffers_sqlite = rrddim_add(st_memory_buffers, "sqlite", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_buffers_exporters = rrddim_add(st_memory_buffers, "exporters", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_buffers_health = rrddim_add(st_memory_buffers, "health", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_buffers_streaming = rrddim_add(st_memory_buffers, "streaming", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_buffers_web = rrddim_add(st_memory_buffers, "web", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        }
+
+        rrddim_set_by_pointer(st_memory_buffers, rd_queries, (collected_number)netdata_buffers_statistics.query_targets_size);
+        rrddim_set_by_pointer(st_memory_buffers, rd_collectors, (collected_number)netdata_buffers_statistics.rrdset_done_rda_size);
+        rrddim_set_by_pointer(st_memory_buffers, rd_buffers_aclk, (collected_number)netdata_buffers_statistics.buffers_aclk);
+        rrddim_set_by_pointer(st_memory_buffers, rd_buffers_api, (collected_number)netdata_buffers_statistics.buffers_api);
+        rrddim_set_by_pointer(st_memory_buffers, rd_buffers_functions, (collected_number)netdata_buffers_statistics.buffers_functions);
+        rrddim_set_by_pointer(st_memory_buffers, rd_buffers_sqlite, (collected_number)netdata_buffers_statistics.buffers_sqlite);
+        rrddim_set_by_pointer(st_memory_buffers, rd_buffers_exporters, (collected_number)netdata_buffers_statistics.buffers_exporters);
+        rrddim_set_by_pointer(st_memory_buffers, rd_buffers_health, (collected_number)netdata_buffers_statistics.buffers_health);
+        rrddim_set_by_pointer(st_memory_buffers, rd_buffers_streaming, (collected_number)netdata_buffers_statistics.buffers_streaming);
+        rrddim_set_by_pointer(st_memory_buffers, rd_buffers_web, (collected_number)netdata_buffers_statistics.buffers_web);
+
+        rrdset_done(st_memory_buffers);
+    }
+
+    // ----------------------------------------------------------------
+
+    {
         static RRDSET *st_uptime = NULL;
         static RRDDIM *rd_uptime = NULL;
 
         if (unlikely(!st_uptime)) {
             st_uptime = rrdset_create_localhost(
-                "netdata",
-                "uptime",
-                NULL,
-                "netdata",
-                NULL,
-                "Netdata uptime",
-                "seconds",
-                "netdata",
-                "stats",
-                130100,
-                localhost->rrd_update_every,
-                RRDSET_TYPE_LINE);
+                    "netdata",
+                    "uptime",
+                    NULL,
+                    "netdata",
+                    NULL,
+                    "Netdata uptime",
+                    "seconds",
+                    "netdata",
+                    "stats",
+                    130150,
+                    localhost->rrd_update_every,
+                    RRDSET_TYPE_LINE);
 
             rd_uptime = rrddim_add(st_uptime, "uptime", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
         }
@@ -1076,13 +1211,13 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
 
     {
         if (unlikely(!ptrs->st_cache_hit_ratio)) {
-            BUFFER *id = buffer_create(100);
+            BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_cache_hit_ratio", name);
 
-            BUFFER *family = buffer_create(100);
+            BUFFER *family = buffer_create(100, NULL);
             buffer_sprintf(family, "dbengine %s cache", name);
 
-            BUFFER *title = buffer_create(100);
+            BUFFER *title = buffer_create(100, NULL);
             buffer_sprintf(title, "Netdata %s Cache Hit Ratio", name);
 
             ptrs->st_cache_hit_ratio = rrdset_create_localhost(
@@ -1124,13 +1259,13 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
 
     {
         if (unlikely(!ptrs->st_operations)) {
-            BUFFER *id = buffer_create(100);
+            BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_cache_operations", name);
 
-            BUFFER *family = buffer_create(100);
+            BUFFER *family = buffer_create(100, NULL);
             buffer_sprintf(family, "dbengine %s cache", name);
 
-            BUFFER *title = buffer_create(100);
+            BUFFER *title = buffer_create(100, NULL);
             buffer_sprintf(title, "Netdata %s Cache Operations", name);
 
             ptrs->st_operations = rrdset_create_localhost(
@@ -1178,13 +1313,13 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
 
     {
         if (unlikely(!ptrs->st_pgc_memory)) {
-            BUFFER *id = buffer_create(100);
+            BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_cache_memory", name);
 
-            BUFFER *family = buffer_create(100);
+            BUFFER *family = buffer_create(100, NULL);
             buffer_sprintf(family, "dbengine %s cache", name);
 
-            BUFFER *title = buffer_create(100);
+            BUFFER *title = buffer_create(100, NULL);
             buffer_sprintf(title, "Netdata %s Cache Memory", name);
 
             ptrs->st_pgc_memory = rrdset_create_localhost(
@@ -1232,13 +1367,13 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
 
     {
         if (unlikely(!ptrs->st_pgc_tm)) {
-            BUFFER *id = buffer_create(100);
+            BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_target_memory", name);
 
-            BUFFER *family = buffer_create(100);
+            BUFFER *family = buffer_create(100, NULL);
             buffer_sprintf(family, "dbengine %s cache", name);
 
-            BUFFER *title = buffer_create(100);
+            BUFFER *title = buffer_create(100, NULL);
             buffer_sprintf(title, "Netdata %s Target Cache Memory", name);
 
             ptrs->st_pgc_tm = rrdset_create_localhost(
@@ -1282,13 +1417,13 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
 
     {
         if (unlikely(!ptrs->st_pgc_pages)) {
-            BUFFER *id = buffer_create(100);
+            BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_cache_pages", name);
 
-            BUFFER *family = buffer_create(100);
+            BUFFER *family = buffer_create(100, NULL);
             buffer_sprintf(family, "dbengine %s cache", name);
 
-            BUFFER *title = buffer_create(100);
+            BUFFER *title = buffer_create(100, NULL);
             buffer_sprintf(title, "Netdata %s Cache Pages", name);
 
             ptrs->st_pgc_pages = rrdset_create_localhost(
@@ -1326,13 +1461,13 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
 
     {
         if (unlikely(!ptrs->st_pgc_memory_changes)) {
-            BUFFER *id = buffer_create(100);
+            BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_cache_memory_changes", name);
 
-            BUFFER *family = buffer_create(100);
+            BUFFER *family = buffer_create(100, NULL);
             buffer_sprintf(family, "dbengine %s cache", name);
 
-            BUFFER *title = buffer_create(100);
+            BUFFER *title = buffer_create(100, NULL);
             buffer_sprintf(title, "Netdata %s Cache Memory Changes", name);
 
             ptrs->st_pgc_memory_changes = rrdset_create_localhost(
@@ -1368,13 +1503,13 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
 
     {
         if (unlikely(!ptrs->st_pgc_memory_migrations)) {
-            BUFFER *id = buffer_create(100);
+            BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_cache_memory_migrations", name);
 
-            BUFFER *family = buffer_create(100);
+            BUFFER *family = buffer_create(100, NULL);
             buffer_sprintf(family, "dbengine %s cache", name);
 
-            BUFFER *title = buffer_create(100);
+            BUFFER *title = buffer_create(100, NULL);
             buffer_sprintf(title, "Netdata %s Cache Memory Migrations", name);
 
             ptrs->st_pgc_memory_migrations = rrdset_create_localhost(
@@ -1408,13 +1543,13 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
 
     {
         if (unlikely(!ptrs->st_pgc_memory_events)) {
-            BUFFER *id = buffer_create(100);
+            BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_cache_events", name);
 
-            BUFFER *family = buffer_create(100);
+            BUFFER *family = buffer_create(100, NULL);
             buffer_sprintf(family, "dbengine %s cache", name);
 
-            BUFFER *title = buffer_create(100);
+            BUFFER *title = buffer_create(100, NULL);
             buffer_sprintf(title, "Netdata %s Cache Events", name);
 
             ptrs->st_pgc_memory_events = rrdset_create_localhost(
@@ -1450,13 +1585,13 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
 
     {
         if (unlikely(!ptrs->st_pgc_waste)) {
-            BUFFER *id = buffer_create(100);
+            BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_waste_events", name);
 
-            BUFFER *family = buffer_create(100);
+            BUFFER *family = buffer_create(100, NULL);
             buffer_sprintf(family, "dbengine %s cache", name);
 
-            BUFFER *title = buffer_create(100);
+            BUFFER *title = buffer_create(100, NULL);
             buffer_sprintf(title, "Netdata %s Waste Events", name);
 
             ptrs->st_pgc_waste = rrdset_create_localhost(
@@ -1502,13 +1637,13 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
 
     {
         if (unlikely(!ptrs->st_pgc_workers)) {
-            BUFFER *id = buffer_create(100);
+            BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_cache_workers", name);
 
-            BUFFER *family = buffer_create(100);
+            BUFFER *family = buffer_create(100, NULL);
             buffer_sprintf(family, "dbengine %s cache", name);
 
-            BUFFER *title = buffer_create(100);
+            BUFFER *title = buffer_create(100, NULL);
             buffer_sprintf(title, "Netdata %s Cache Workers", name);
 
             ptrs->st_pgc_workers = rrdset_create_localhost(
@@ -1587,6 +1722,8 @@ static void dbengine2_statistics_charts(void) {
     buffers_total_size += buffers.julyl;
 #endif
 
+    dbengine_total_memory = pgc_main_stats.size + pgc_open_stats.size + pgc_extent_stats.size + mrg_stats.size + buffers_total_size;
+
     size_t priority = 135000;
 
     {
@@ -1619,6 +1756,7 @@ static void dbengine2_statistics_charts(void) {
             rd_pgc_memory_buffers = rrddim_add(st_pgc_memory, "buffers", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
         }
         priority++;
+
 
         rrddim_set_by_pointer(st_pgc_memory, rd_pgc_memory_main, (collected_number)pgc_main_stats.size);
         rrddim_set_by_pointer(st_pgc_memory, rd_pgc_memory_open, (collected_number)pgc_open_stats.size);
@@ -2549,6 +2687,14 @@ static void update_heartbeat_charts() {
 // ---------------------------------------------------------------------------------------------------------------------
 // dictionary statistics
 
+struct dictionary_stats dictionary_stats_category_collectors = { .name = "collectors" };
+struct dictionary_stats dictionary_stats_category_rrdhost = { .name = "rrdhost" };
+struct dictionary_stats dictionary_stats_category_rrdset_rrddim = { .name = "rrdset_rrddim" };
+struct dictionary_stats dictionary_stats_category_rrdcontext = { .name = "context" };
+struct dictionary_stats dictionary_stats_category_rrdlabels = { .name = "labels" };
+struct dictionary_stats dictionary_stats_category_rrdhealth = { .name = "health" };
+struct dictionary_stats dictionary_stats_category_functions = { .name = "functions" };
+
 struct dictionary_categories {
     struct dictionary_stats *stats;
     const char *family;
@@ -2594,7 +2740,14 @@ struct dictionary_categories {
     RRDDIM *rd_spins_delete;
 
 } dictionary_categories[] = {
-    { .stats = &dictionary_stats_category_other, "dictionaries", "dictionaries", 900000 },
+    { .stats = &dictionary_stats_category_collectors, "dictionaries collectors", "dictionaries", 900000 },
+    { .stats = &dictionary_stats_category_rrdhost, "dictionaries hosts", "dictionaries", 900000 },
+    { .stats = &dictionary_stats_category_rrdset_rrddim, "dictionaries rrd", "dictionaries", 900000 },
+    { .stats = &dictionary_stats_category_rrdcontext, "dictionaries contexts", "dictionaries", 900000 },
+    { .stats = &dictionary_stats_category_rrdlabels, "dictionaries labels", "dictionaries", 900000 },
+    { .stats = &dictionary_stats_category_rrdhealth, "dictionaries health", "dictionaries", 900000 },
+    { .stats = &dictionary_stats_category_functions, "dictionaries functions", "dictionaries", 900000 },
+    { .stats = &dictionary_stats_category_other, "dictionaries other", "dictionaries", 900000 },
 
     // terminator
     { .stats = NULL, NULL, NULL, 0 },

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -331,6 +331,7 @@ static void global_statistics_charts(void) {
             netdata_buffers_statistics.buffers_exporters +
             netdata_buffers_statistics.buffers_health +
             netdata_buffers_statistics.buffers_streaming +
+            netdata_buffers_statistics.cbuffers_streaming +
             netdata_buffers_statistics.buffers_web;
 
         size_t strings = 0;

--- a/daemon/global_statistics.h
+++ b/daemon/global_statistics.h
@@ -29,6 +29,7 @@ extern struct dictionary_stats dictionary_stats_category_rrdcontext;
 extern struct dictionary_stats dictionary_stats_category_rrdlabels;
 extern struct dictionary_stats dictionary_stats_category_rrdhealth;
 extern struct dictionary_stats dictionary_stats_category_functions;
+extern struct dictionary_stats dictionary_stats_category_replication;
 
 extern size_t rrddim_db_memory_size;
 

--- a/daemon/global_statistics.h
+++ b/daemon/global_statistics.h
@@ -6,6 +6,7 @@
 #include "database/rrd.h"
 
 extern struct netdata_buffers_statistics {
+    size_t rrdhost_allocations_size;
     size_t query_targets_size;
     size_t rrdset_done_rda_size;
     size_t buffers_aclk;

--- a/daemon/global_statistics.h
+++ b/daemon/global_statistics.h
@@ -5,6 +5,28 @@
 
 #include "database/rrd.h"
 
+extern struct netdata_buffers_statistics {
+    size_t query_targets_size;
+    size_t rrdset_done_rda_size;
+    size_t buffers_aclk;
+    size_t buffers_api;
+    size_t buffers_functions;
+    size_t buffers_sqlite;
+    size_t buffers_exporters;
+    size_t buffers_health;
+    size_t buffers_streaming;
+    size_t buffers_web;
+} netdata_buffers_statistics;
+
+extern struct dictionary_stats dictionary_stats_category_collectors;
+extern struct dictionary_stats dictionary_stats_category_rrdhost;
+extern struct dictionary_stats dictionary_stats_category_rrdset_rrddim;
+extern struct dictionary_stats dictionary_stats_category_rrdcontext;
+extern struct dictionary_stats dictionary_stats_category_rrdlabels;
+extern struct dictionary_stats dictionary_stats_category_rrdhealth;
+extern struct dictionary_stats dictionary_stats_category_functions;
+
+
 // ----------------------------------------------------------------------------
 // global statistics
 

--- a/daemon/global_statistics.h
+++ b/daemon/global_statistics.h
@@ -7,6 +7,8 @@
 
 extern struct netdata_buffers_statistics {
     size_t rrdhost_allocations_size;
+    size_t rrdhost_senders;
+    size_t rrdhost_receivers;
     size_t query_targets_size;
     size_t rrdset_done_rda_size;
     size_t buffers_aclk;
@@ -16,6 +18,7 @@ extern struct netdata_buffers_statistics {
     size_t buffers_exporters;
     size_t buffers_health;
     size_t buffers_streaming;
+    size_t cbuffers_streaming;
     size_t buffers_web;
 } netdata_buffers_statistics;
 

--- a/daemon/global_statistics.h
+++ b/daemon/global_statistics.h
@@ -26,6 +26,7 @@ extern struct dictionary_stats dictionary_stats_category_rrdlabels;
 extern struct dictionary_stats dictionary_stats_category_rrdhealth;
 extern struct dictionary_stats dictionary_stats_category_functions;
 
+extern size_t rrddim_db_memory_size;
 
 // ----------------------------------------------------------------------------
 // global statistics

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1929,6 +1929,7 @@ int main(int argc, char **argv) {
 
     netdata_anonymous_statistics_enabled=-1;
     struct rrdhost_system_info *system_info = callocz(1, sizeof(struct rrdhost_system_info));
+    __atomic_sub_fetch(&netdata_buffers_statistics.rrdhost_allocations_size, sizeof(struct rrdhost_system_info), __ATOMIC_RELAXED);
     get_system_info(system_info);
     system_info->hops = 0;
     get_install_type(&system_info->install_type, &system_info->prebuilt_arch, &system_info->prebuilt_dist);

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -174,8 +174,8 @@ static void service_to_buffer(BUFFER *wb, SERVICE_TYPE service) {
 }
 
 static bool service_wait_exit(SERVICE_TYPE service, usec_t timeout_ut) {
-    BUFFER *service_list = buffer_create(1024);
-    BUFFER *thread_list = buffer_create(1024);
+    BUFFER *service_list = buffer_create(1024, NULL);
+    BUFFER *thread_list = buffer_create(1024, NULL);
     usec_t started_ut = now_monotonic_usec(), ended_ut;
     size_t running;
     SERVICE_TYPE running_services = 0;

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -52,13 +52,13 @@ static void svc_rrddim_obsolete_to_archive(RRDDIM *rd) {
 
         size_t tiers_available = 0, tiers_said_no_retention = 0;
         for(size_t tier = 0; tier < storage_tiers ;tier++) {
-            if(rd->tiers[tier]) {
+            if(rd->tiers[tier].db_collection_handle) {
                 tiers_available++;
 
-                if(rd->tiers[tier]->collect_ops->finalize(rd->tiers[tier]->db_collection_handle))
+                if(rd->tiers[tier].collect_ops->finalize(rd->tiers[tier].db_collection_handle))
                     tiers_said_no_retention++;
 
-                rd->tiers[tier]->db_collection_handle = NULL;
+                rd->tiers[tier].db_collection_handle = NULL;
             }
         }
 

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1861,7 +1861,7 @@ static void test_dbengine_create_charts(RRDHOST *host, RRDSET *st[CHARTS], RRDDI
     // Fluh pages for subsequent real values
     for (i = 0 ; i < CHARTS ; ++i) {
         for (j = 0; j < DIMS; ++j) {
-            rrdeng_store_metric_flush_current_page((rd[i][j])->tiers[0]->db_collection_handle);
+            rrdeng_store_metric_flush_current_page((rd[i][j])->tiers[0].db_collection_handle);
         }
     }
 }
@@ -1880,7 +1880,7 @@ static time_t test_dbengine_create_metrics(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS
     // feed it with the test data
     for (i = 0 ; i < CHARTS ; ++i) {
         for (j = 0 ; j < DIMS ; ++j) {
-            rd[i][j]->tiers[0]->collect_ops->change_collection_frequency(rd[i][j]->tiers[0]->db_collection_handle, update_every);
+            rd[i][j]->tiers[0].collect_ops->change_collection_frequency(rd[i][j]->tiers[0].db_collection_handle, update_every);
 
             rd[i][j]->last_collected_time.tv_sec =
             st[i]->last_collected_time.tv_sec = st[i]->last_updated.tv_sec = time_now;
@@ -1931,13 +1931,13 @@ static int test_dbengine_check_metrics(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS][DI
         time_now = time_start + (c + 1) * update_every;
         for (i = 0 ; i < CHARTS ; ++i) {
             for (j = 0; j < DIMS; ++j) {
-                rd[i][j]->tiers[0]->query_ops->init(rd[i][j]->tiers[0]->db_metric_handle, &handle, time_now, time_now + QUERY_BATCH * update_every, STORAGE_PRIORITY_NORMAL);
+                rd[i][j]->tiers[0].query_ops->init(rd[i][j]->tiers[0].db_metric_handle, &handle, time_now, time_now + QUERY_BATCH * update_every, STORAGE_PRIORITY_NORMAL);
                 for (k = 0; k < QUERY_BATCH; ++k) {
                     last = ((collected_number)i * DIMS) * REGION_POINTS[current_region] +
                            j * REGION_POINTS[current_region] + c + k;
                     expected = unpack_storage_number(pack_storage_number((NETDATA_DOUBLE)last, SN_DEFAULT_FLAGS));
 
-                    STORAGE_POINT sp = rd[i][j]->tiers[0]->query_ops->next_metric(&handle);
+                    STORAGE_POINT sp = rd[i][j]->tiers[0].query_ops->next_metric(&handle);
                     value = sp.sum;
                     time_retrieved = sp.start_time_s;
                     end_time = sp.end_time_s;
@@ -1959,7 +1959,7 @@ static int test_dbengine_check_metrics(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS][DI
                         errors++;
                     }
                 }
-                rd[i][j]->tiers[0]->query_ops->finalize(&handle);
+                rd[i][j]->tiers[0].query_ops->finalize(&handle);
             }
         }
     }
@@ -2084,7 +2084,7 @@ int test_dbengine(void)
     for (i = 0 ; i < CHARTS ; ++i) {
         st[i]->update_every = update_every;
         for (j = 0; j < DIMS; ++j) {
-            rrdeng_store_metric_flush_current_page((rd[i][j])->tiers[0]->db_collection_handle);
+            rrdeng_store_metric_flush_current_page((rd[i][j])->tiers[0].db_collection_handle);
         }
     }
 
@@ -2103,7 +2103,7 @@ int test_dbengine(void)
     for (i = 0 ; i < CHARTS ; ++i) {
         st[i]->update_every = update_every;
         for (j = 0; j < DIMS; ++j) {
-            rrdeng_store_metric_flush_current_page((rd[i][j])->tiers[0]->db_collection_handle);
+            rrdeng_store_metric_flush_current_page((rd[i][j])->tiers[0].db_collection_handle);
         }
     }
 
@@ -2270,7 +2270,7 @@ static void generate_dbengine_chart(void *arg)
         thread_info->time_max = time_current;
     }
     for (j = 0; j < DSET_DIMS; ++j) {
-        rrdeng_store_metric_finalize((rd[j])->tiers[0]->db_collection_handle);
+        rrdeng_store_metric_finalize((rd[j])->tiers[0].db_collection_handle);
     }
 }
 
@@ -2390,13 +2390,13 @@ static void query_dbengine_chart(void *arg)
             time_before = MIN(time_after + duration, time_max); /* up to 1 hour queries */
         }
 
-        rd->tiers[0]->query_ops->init(rd->tiers[0]->db_metric_handle, &handle, time_after, time_before, STORAGE_PRIORITY_NORMAL);
+        rd->tiers[0].query_ops->init(rd->tiers[0].db_metric_handle, &handle, time_after, time_before, STORAGE_PRIORITY_NORMAL);
         ++thread_info->queries_nr;
         for (time_now = time_after ; time_now <= time_before ; time_now += update_every) {
             generatedv = generate_dbengine_chart_value(i, j, time_now);
             expected = unpack_storage_number(pack_storage_number((NETDATA_DOUBLE) generatedv, SN_DEFAULT_FLAGS));
 
-            if (unlikely(rd->tiers[0]->query_ops->is_finished(&handle))) {
+            if (unlikely(rd->tiers[0].query_ops->is_finished(&handle))) {
                 if (!thread_info->delete_old_data) { /* data validation only when we don't delete */
                     fprintf(stderr, "    DB-engine stresstest %s/%s: at %lu secs, expecting value " NETDATA_DOUBLE_FORMAT
                         ", found data gap, ### E R R O R ###\n",
@@ -2406,7 +2406,7 @@ static void query_dbengine_chart(void *arg)
                 break;
             }
 
-            STORAGE_POINT sp = rd->tiers[0]->query_ops->next_metric(&handle);
+            STORAGE_POINT sp = rd->tiers[0].query_ops->next_metric(&handle);
             value = sp.sum;
             time_retrieved = sp.start_time_s;
             end_time = sp.end_time_s;
@@ -2444,7 +2444,7 @@ static void query_dbengine_chart(void *arg)
                 }
             }
         }
-        rd->tiers[0]->query_ops->finalize(&handle);
+        rd->tiers[0].query_ops->finalize(&handle);
     } while(!thread_info->done);
 
     if(value_errors)

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -439,7 +439,7 @@ int unit_test_str2ld() {
 }
 
 int unit_test_buffer() {
-    BUFFER *wb = buffer_create(1);
+    BUFFER *wb = buffer_create(1, NULL);
     char string[2048 + 1];
     char final[9000 + 1];
     int i;
@@ -1349,7 +1349,7 @@ static int test_variable_renames(void) {
     rrddim_reset_name(st, rd2, "DIM2NAME2");
     fprintf(stderr, "Renamed dimension with id '%s' to name '%s'\n", rrddim_id(rd2), rrddim_name(rd2));
 
-    BUFFER *buf = buffer_create(1);
+    BUFFER *buf = buffer_create(1, NULL);
     health_api_v1_chart_variables2json(st, buf);
     fprintf(stderr, "%s", buffer_tostring(buf));
     buffer_free(buf);
@@ -1604,7 +1604,7 @@ int test_sqlite(void) {
         return 1;
     }
 
-    BUFFER *sql = buffer_create(ACLK_SYNC_QUERY_SIZE);
+    BUFFER *sql = buffer_create(ACLK_SYNC_QUERY_SIZE, NULL);
     char *uuid_str = "0000_000";
 
     buffer_sprintf(sql, TABLE_ACLK_ALERT, uuid_str);

--- a/database/engine/cache.c
+++ b/database/engine/cache.c
@@ -205,7 +205,7 @@ static inline void pointer_del(PGC *cache __maybe_unused, PGC_PAGE *page __maybe
 // ----------------------------------------------------------------------------
 // locking
 
-static size_t pgc_indexing_partition(PGC *cache, Word_t metric_id) {
+static inline size_t pgc_indexing_partition(PGC *cache, Word_t metric_id) {
     static __thread Word_t last_metric_id = 0;
     static __thread size_t last_partition = 0;
 
@@ -218,19 +218,19 @@ static size_t pgc_indexing_partition(PGC *cache, Word_t metric_id) {
     return last_partition;
 }
 
-static void pgc_index_read_lock(PGC *cache, size_t partition) {
+static inline void pgc_index_read_lock(PGC *cache, size_t partition) {
     netdata_rwlock_rdlock(&cache->index[partition].rwlock);
 }
-static void pgc_index_read_unlock(PGC *cache, size_t partition) {
+static inline void pgc_index_read_unlock(PGC *cache, size_t partition) {
     netdata_rwlock_unlock(&cache->index[partition].rwlock);
 }
-//static bool pgc_index_write_trylock(PGC *cache, size_t partition) {
+//static inline bool pgc_index_write_trylock(PGC *cache, size_t partition) {
 //    return !netdata_rwlock_trywrlock(&cache->index[partition].rwlock);
 //}
-static void pgc_index_write_lock(PGC *cache, size_t partition) {
+static inline void pgc_index_write_lock(PGC *cache, size_t partition) {
     netdata_rwlock_wrlock(&cache->index[partition].rwlock);
 }
-static void pgc_index_write_unlock(PGC *cache, size_t partition) {
+static inline void pgc_index_write_unlock(PGC *cache, size_t partition) {
     netdata_rwlock_unlock(&cache->index[partition].rwlock);
 }
 
@@ -382,11 +382,11 @@ static inline bool flushing_critical(PGC *cache) {
 // ----------------------------------------------------------------------------
 // helpers
 
-static size_t page_assumed_size(PGC *cache, size_t size) {
+static inline size_t page_assumed_size(PGC *cache, size_t size) {
     return size + (sizeof(PGC_PAGE) + cache->config.additional_bytes_per_page + sizeof(Word_t) * 3);
 }
 
-static size_t page_size_from_assumed_size(PGC *cache, size_t assumed_size) {
+static inline size_t page_size_from_assumed_size(PGC *cache, size_t assumed_size) {
     return assumed_size - (sizeof(PGC_PAGE) + cache->config.additional_bytes_per_page + sizeof(Word_t) * 3);
 }
 
@@ -422,7 +422,7 @@ static ARAL section_pages_aral = {
         .requested_element_size = sizeof(struct section_pages),
 };
 
-static void pgc_stats_ll_judy_change(PGC *cache, struct pgc_linked_list *ll, size_t mem_before_judyl, size_t mem_after_judyl) {
+static inline void pgc_stats_ll_judy_change(PGC *cache, struct pgc_linked_list *ll, size_t mem_before_judyl, size_t mem_after_judyl) {
     if(mem_after_judyl > mem_before_judyl) {
         __atomic_add_fetch(&ll->stats->size, mem_after_judyl - mem_before_judyl, __ATOMIC_RELAXED);
         __atomic_add_fetch(&cache->stats.size, mem_after_judyl - mem_before_judyl, __ATOMIC_RELAXED);
@@ -433,7 +433,7 @@ static void pgc_stats_ll_judy_change(PGC *cache, struct pgc_linked_list *ll, siz
     }
 }
 
-static void pgc_stats_index_judy_change(PGC *cache, size_t mem_before_judyl, size_t mem_after_judyl) {
+static inline void pgc_stats_index_judy_change(PGC *cache, size_t mem_before_judyl, size_t mem_after_judyl) {
     if(mem_after_judyl > mem_before_judyl) {
         __atomic_add_fetch(&cache->stats.size, mem_after_judyl - mem_before_judyl, __ATOMIC_RELAXED);
     }
@@ -556,7 +556,7 @@ static void pgc_ll_del(PGC *cache __maybe_unused, struct pgc_linked_list *ll, PG
         pgc_ll_unlock(cache, ll);
 }
 
-static void page_has_been_accessed(PGC *cache, PGC_PAGE *page) {
+static inline void page_has_been_accessed(PGC *cache, PGC_PAGE *page) {
     PGC_PAGE_FLAGS flags = page_flag_check(page, PGC_PAGE_CLEAN | PGC_PAGE_HAS_NO_DATA_IGNORE_ACCESSES);
 
     if (!(flags & PGC_PAGE_HAS_NO_DATA_IGNORE_ACCESSES)) {
@@ -604,7 +604,7 @@ static inline void page_set_clean(PGC *cache, PGC_PAGE *page, bool having_transi
         page_transition_unlock(cache, page);
 }
 
-static void page_set_dirty(PGC *cache, PGC_PAGE *page, bool having_hot_lock) {
+static inline void page_set_dirty(PGC *cache, PGC_PAGE *page, bool having_hot_lock) {
     if(!having_hot_lock)
         // to avoid deadlocks, we have to get the hot lock before the page transition
         // since this is what all_hot_to_dirty() does
@@ -830,7 +830,7 @@ static inline bool acquired_page_get_for_deletion_or_release_it(PGC *cache __may
 // ----------------------------------------------------------------------------
 // Indexing
 
-static void free_this_page(PGC *cache, PGC_PAGE *page) {
+static inline void free_this_page(PGC *cache, PGC_PAGE *page) {
     // call the callback to free the user supplied memory
     cache->config.pgc_free_clean_cb(cache, (PGC_ENTRY){
             .section = page->section,
@@ -916,7 +916,7 @@ static void remove_this_page_from_index_unsafe(PGC *cache, PGC_PAGE *page, size_
     pointer_del(cache, page);
 }
 
-static void remove_and_free_page_not_in_any_queue_and_acquired_for_deletion(PGC *cache, PGC_PAGE *page) {
+static inline void remove_and_free_page_not_in_any_queue_and_acquired_for_deletion(PGC *cache, PGC_PAGE *page) {
     size_t partition = pgc_indexing_partition(cache, page->metric_id);
     pgc_index_write_lock(cache, partition);
     remove_this_page_from_index_unsafe(cache, page, partition);
@@ -924,7 +924,7 @@ static void remove_and_free_page_not_in_any_queue_and_acquired_for_deletion(PGC 
     free_this_page(cache, page);
 }
 
-static bool make_acquired_page_clean_and_evict_or_page_release(PGC *cache, PGC_PAGE *page) {
+static inline bool make_acquired_page_clean_and_evict_or_page_release(PGC *cache, PGC_PAGE *page) {
     pointer_check(cache, page);
 
     page_transition_lock(cache, page);

--- a/database/engine/cache.h
+++ b/database/engine/cache.h
@@ -160,10 +160,10 @@ struct pgc_statistics {
 
 typedef void (*free_clean_page_callback)(PGC *cache, PGC_ENTRY entry);
 typedef void (*save_dirty_page_callback)(PGC *cache, PGC_ENTRY *entries_array, PGC_PAGE **pages_array, size_t entries);
-
+typedef void (*save_dirty_init_callback)(PGC *cache, Word_t section);
 // create a cache
 PGC *pgc_create(size_t clean_size_bytes, free_clean_page_callback pgc_free_clean_cb,
-                size_t max_dirty_pages_per_flush, save_dirty_page_callback pgc_save_dirty_cb,
+                size_t max_dirty_pages_per_flush, save_dirty_init_callback pgc_save_init_cb, save_dirty_page_callback pgc_save_dirty_cb,
                 size_t max_pages_per_inline_eviction, size_t max_inline_evictors,
                 size_t max_skip_pages_per_inline_eviction,
                 size_t max_flushes_inline,

--- a/database/engine/datafile.c
+++ b/database/engine/datafile.c
@@ -560,23 +560,34 @@ int init_data_files(struct rrdengine_instance *ctx)
 
 void finalize_data_files(struct rrdengine_instance *ctx)
 {
+    bool logged = false;
+
     do {
         struct rrdengine_datafile *datafile = ctx->datafiles.first;
         struct rrdengine_journalfile *journalfile = datafile->journalfile;
 
+        logged = false;
         if(datafile == ctx->datafiles.first->prev) {
             // this is the last file
             while(__atomic_load_n(&ctx->worker_config.atomics.extents_currently_being_flushed, __ATOMIC_RELAXED)) {
-                info("Waiting to inflight flush to finish on tier %d", ctx->tier);
-                sleep_usec(500 * USEC_PER_MS);
+                if(!logged) {
+                    info("Waiting for inflight flush to finish on tier %d to close last datafile %u...", ctx->tier, datafile->fileno);
+                    logged = true;
+                }
+                sleep_usec(100 * USEC_PER_MS);
             }
         }
 
+        logged = false;
         while(!datafile_acquire_for_deletion(datafile) && datafile != ctx->datafiles.first->prev) {
-            info("Waiting to acquire data file %u of tier %d to close it...", datafile->fileno, ctx->tier);
-            sleep_usec(500 * USEC_PER_MS);
+            if(!logged) {
+                info("Waiting to acquire data file %u of tier %d to close it...", datafile->fileno, ctx->tier);
+                logged = true;
+            }
+            sleep_usec(100 * USEC_PER_MS);
         }
 
+        logged = false;
         bool available = false;
         do {
             uv_rwlock_wrlock(&ctx->datafiles.rwlock);
@@ -586,8 +597,11 @@ void finalize_data_files(struct rrdengine_instance *ctx)
             if(!available) {
                 netdata_spinlock_unlock(&datafile->writers.spinlock);
                 uv_rwlock_wrunlock(&ctx->datafiles.rwlock);
-                info("Waiting for writers to data file %u of tier %d to finish...", datafile->fileno, ctx->tier);
-                sleep_usec(500 * USEC_PER_MS);
+                if(!logged) {
+                    info("Waiting for writers to data file %u of tier %d to finish...", datafile->fileno, ctx->tier);
+                    logged = true;
+                }
+                sleep_usec(100 * USEC_PER_MS);
             }
         } while(!available);
 

--- a/database/engine/metric.c
+++ b/database/engine/metric.c
@@ -277,16 +277,16 @@ void mrg_metric_expand_retention(MRG *mrg __maybe_unused, METRIC *metric, time_t
 
     netdata_spinlock_lock(&metric->timestamps_lock);
 
-    if(first_time_s && (!metric->first_time_s || first_time_s < metric->first_time_s))
+    if(unlikely(first_time_s && (!metric->first_time_s || first_time_s < metric->first_time_s)))
         metric->first_time_s = first_time_s;
 
-    if(last_time_s && (!metric->latest_time_s_clean || last_time_s > metric->latest_time_s_clean)) {
+    if(likely(last_time_s && (!metric->latest_time_s_clean || last_time_s > metric->latest_time_s_clean))) {
         metric->latest_time_s_clean = last_time_s;
 
-        if(update_every_s)
+        if(likely(update_every_s))
             metric->latest_update_every_s = update_every_s;
     }
-    else if(!metric->latest_update_every_s && update_every_s)
+    else if(unlikely(!metric->latest_update_every_s && update_every_s))
         metric->latest_update_every_s = update_every_s;
 
     netdata_spinlock_unlock(&metric->timestamps_lock);

--- a/database/engine/metric.c
+++ b/database/engine/metric.c
@@ -54,16 +54,16 @@ static inline void MRG_STATS_DELETE_MISS(MRG *mrg) {
     __atomic_add_fetch(&mrg->stats.delete_misses, 1, __ATOMIC_RELAXED);
 }
 
-static void mrg_index_read_lock(MRG *mrg) {
+static inline void mrg_index_read_lock(MRG *mrg) {
     netdata_rwlock_rdlock(&mrg->index.rwlock);
 }
-static void mrg_index_read_unlock(MRG *mrg) {
+static inline void mrg_index_read_unlock(MRG *mrg) {
     netdata_rwlock_unlock(&mrg->index.rwlock);
 }
-static void mrg_index_write_lock(MRG *mrg) {
+static inline void mrg_index_write_lock(MRG *mrg) {
     netdata_rwlock_wrlock(&mrg->index.rwlock);
 }
-static void mrg_index_write_unlock(MRG *mrg) {
+static inline void mrg_index_write_unlock(MRG *mrg) {
     netdata_rwlock_unlock(&mrg->index.rwlock);
 }
 
@@ -88,10 +88,10 @@ static METRIC *metric_add(MRG *mrg, MRG_ENTRY *entry, bool *ret) {
     size_t mem_before_judyl, mem_after_judyl;
 
     Pvoid_t *sections_judy_pptr = JudyHSIns(&mrg->index.uuid_judy, &entry->uuid, sizeof(uuid_t), PJE0);
-    if(!sections_judy_pptr || sections_judy_pptr == PJERR)
+    if(unlikely(!sections_judy_pptr || sections_judy_pptr == PJERR))
         fatal("DBENGINE METRIC: corrupted UUIDs JudyHS array");
 
-    if(!*sections_judy_pptr)
+    if(unlikely(!*sections_judy_pptr))
         mrg_stats_size_judyhs_added_uuid(mrg);
 
     mem_before_judyl = JudyLMemUsed(*sections_judy_pptr);
@@ -99,7 +99,7 @@ static METRIC *metric_add(MRG *mrg, MRG_ENTRY *entry, bool *ret) {
     mem_after_judyl = JudyLMemUsed(*sections_judy_pptr);
     mrg_stats_size_judyl_change(mrg, mem_before_judyl, mem_after_judyl);
 
-    if(!PValue || PValue == PJERR)
+    if(unlikely(!PValue || PValue == PJERR))
         fatal("DBENGINE METRIC: corrupted section JudyL array");
 
     if(*PValue != NULL) {
@@ -137,14 +137,14 @@ static METRIC *metric_get(MRG *mrg, uuid_t *uuid, Word_t section) {
     mrg_index_read_lock(mrg);
 
     Pvoid_t *sections_judy_pptr = JudyHSGet(mrg->index.uuid_judy, uuid, sizeof(uuid_t));
-    if(!sections_judy_pptr) {
+    if(unlikely(!sections_judy_pptr)) {
         mrg_index_read_unlock(mrg);
         MRG_STATS_SEARCH_MISS(mrg);
         return NULL;
     }
 
     Pvoid_t *PValue = JudyLGet(*sections_judy_pptr, section, PJE0);
-    if(!PValue) {
+    if(unlikely(!PValue)) {
         mrg_index_read_unlock(mrg);
         MRG_STATS_SEARCH_MISS(mrg);
         return NULL;
@@ -164,7 +164,7 @@ static bool metric_del(MRG *mrg, METRIC *metric) {
     mrg_index_write_lock(mrg);
 
     Pvoid_t *sections_judy_pptr = JudyHSGet(mrg->index.uuid_judy, &metric->uuid, sizeof(uuid_t));
-    if(!sections_judy_pptr || !*sections_judy_pptr) {
+    if(unlikely(!sections_judy_pptr || !*sections_judy_pptr)) {
         mrg_index_write_unlock(mrg);
         MRG_STATS_DELETE_MISS(mrg);
         return false;
@@ -175,7 +175,7 @@ static bool metric_del(MRG *mrg, METRIC *metric) {
     mem_after_judyl = JudyLMemUsed(*sections_judy_pptr);
     mrg_stats_size_judyl_change(mrg, mem_before_judyl, mem_after_judyl);
 
-    if(!rc) {
+    if(unlikely(!rc)) {
         mrg_index_write_unlock(mrg);
         MRG_STATS_DELETE_MISS(mrg);
         return false;
@@ -183,7 +183,7 @@ static bool metric_del(MRG *mrg, METRIC *metric) {
 
     if(!*sections_judy_pptr) {
         rc = JudyHSDel(&mrg->index.uuid_judy, &metric->uuid, sizeof(uuid_t), PJE0);
-        if(!rc)
+        if(unlikely(!rc))
             fatal("DBENGINE METRIC: cannot delete UUID from JudyHS");
         mrg_stats_size_judyhs_removed_uuid(mrg);
     }

--- a/database/engine/metric.c
+++ b/database/engine/metric.c
@@ -75,11 +75,11 @@ static inline void mrg_stats_size_judyl_change(MRG *mrg, size_t mem_before_judyl
 }
 
 static inline void mrg_stats_size_judyhs_added_uuid(MRG *mrg) {
-    __atomic_add_fetch(&mrg->stats.size, sizeof(uuid_t) * 3, __ATOMIC_RELAXED);
+    __atomic_add_fetch(&mrg->stats.size, JUDYHS_INDEX_SIZE_ESTIMATE(sizeof(uuid_t)), __ATOMIC_RELAXED);
 }
 
 static inline void mrg_stats_size_judyhs_removed_uuid(MRG *mrg) {
-    __atomic_sub_fetch(&mrg->stats.size, sizeof(uuid_t) * 3, __ATOMIC_RELAXED);
+    __atomic_sub_fetch(&mrg->stats.size, JUDYHS_INDEX_SIZE_ESTIMATE(sizeof(uuid_t)), __ATOMIC_RELAXED);
 }
 
 static METRIC *metric_add(MRG *mrg, MRG_ENTRY *entry, bool *ret) {

--- a/database/ram/rrddim_mem.c
+++ b/database/ram/rrddim_mem.c
@@ -60,7 +60,7 @@ rrddim_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE *db_instance __maybe_un
             mh->refcount = 1;
             update_metric_handle_from_rrddim(mh, rd);
             *PValue = mh;
-            __atomic_add_fetch(&rrddim_db_memory_size, sizeof(struct mem_metric_handle) + sizeof(uuid_t) * 3, __ATOMIC_RELAXED);
+            __atomic_add_fetch(&rrddim_db_memory_size, sizeof(struct mem_metric_handle) + JUDYHS_INDEX_SIZE_ESTIMATE(sizeof(uuid_t)), __ATOMIC_RELAXED);
         }
         else {
             if(__atomic_add_fetch(&mh->refcount, 1, __ATOMIC_RELAXED) <= 0)
@@ -111,7 +111,7 @@ void rrddim_metric_release(STORAGE_METRIC_HANDLE *db_metric_handle __maybe_unuse
             netdata_rwlock_unlock(&rrddim_JudyHS_rwlock);
 
             freez(mh);
-            __atomic_sub_fetch(&rrddim_db_memory_size, sizeof(struct mem_metric_handle) + sizeof(uuid_t) * 3, __ATOMIC_RELAXED);
+            __atomic_sub_fetch(&rrddim_db_memory_size, sizeof(struct mem_metric_handle) + JUDYHS_INDEX_SIZE_ESTIMATE(sizeof(uuid_t)), __ATOMIC_RELAXED);
         }
     }
 }

--- a/database/ram/rrddim_mem.c
+++ b/database/ram/rrddim_mem.c
@@ -60,6 +60,7 @@ rrddim_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE *db_instance __maybe_un
             mh->refcount = 1;
             update_metric_handle_from_rrddim(mh, rd);
             *PValue = mh;
+            __atomic_add_fetch(&rrddim_db_memory_size, sizeof(struct mem_metric_handle) + sizeof(uuid_t) * 3, __ATOMIC_RELAXED);
         }
         else {
             if(__atomic_add_fetch(&mh->refcount, 1, __ATOMIC_RELAXED) <= 0)
@@ -108,6 +109,9 @@ void rrddim_metric_release(STORAGE_METRIC_HANDLE *db_metric_handle __maybe_unuse
             netdata_rwlock_wrlock(&rrddim_JudyHS_rwlock);
             JudyHSDel(&rrddim_JudyHS_array, &rd->metric_uuid, sizeof(uuid_t), PJE0);
             netdata_rwlock_unlock(&rrddim_JudyHS_rwlock);
+
+            freez(mh);
+            __atomic_sub_fetch(&rrddim_db_memory_size, sizeof(struct mem_metric_handle) + sizeof(uuid_t) * 3, __ATOMIC_RELAXED);
         }
     }
 }
@@ -141,6 +145,8 @@ STORAGE_COLLECT_HANDLE *rrddim_collect_init(STORAGE_METRIC_HANDLE *db_metric_han
     struct mem_collect_handle *ch = callocz(1, sizeof(struct mem_collect_handle));
     ch->rd = rd;
     ch->db_metric_handle = db_metric_handle;
+
+    __atomic_add_fetch(&rrddim_db_memory_size, sizeof(struct mem_collect_handle), __ATOMIC_RELAXED);
 
     return (STORAGE_COLLECT_HANDLE *)ch;
 }
@@ -228,6 +234,7 @@ void rrddim_collect_store_metric(STORAGE_COLLECT_HANDLE *collection_handle,
 
 int rrddim_collect_finalize(STORAGE_COLLECT_HANDLE *collection_handle) {
     freez(collection_handle);
+    __atomic_sub_fetch(&rrddim_db_memory_size, sizeof(struct mem_collect_handle), __ATOMIC_RELAXED);
     return 0;
 }
 
@@ -346,6 +353,7 @@ void rrddim_query_init(STORAGE_METRIC_HANDLE *db_metric_handle, struct storage_e
 
     // info("RRDDIM QUERY INIT: start %ld, end %ld, next %ld, first %ld, last %ld, dt %ld", start_time, end_time, h->next_timestamp, h->slot_timestamp, h->last_timestamp, h->dt);
 
+    __atomic_add_fetch(&rrddim_db_memory_size, sizeof(struct mem_query_handle), __ATOMIC_RELAXED);
     handle->handle = (STORAGE_QUERY_HANDLE *)h;
 }
 
@@ -406,6 +414,7 @@ void rrddim_query_finalize(struct storage_engine_query_handle *handle) {
         error("QUERY: query for chart '%s' dimension '%s' has been stopped unfinished", rrdset_id(mh->rd->rrdset), rrddim_name(mh->rd));
 #endif
     freez(handle->handle);
+    __atomic_sub_fetch(&rrddim_db_memory_size, sizeof(struct mem_query_handle), __ATOMIC_RELAXED);
 }
 
 time_t rrddim_query_align_to_optimal_before(struct storage_engine_query_handle *rrddim_handle) {

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -627,7 +627,7 @@ static void rrdcalc_rrdhost_delete_callback(const DICTIONARY_ITEM *item __maybe_
 
 void rrdcalc_rrdhost_index_init(RRDHOST *host) {
     if(!host->rrdcalc_root_index) {
-        host->rrdcalc_root_index = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);
+        host->rrdcalc_root_index = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE, &dictionary_stats_category_rrdhealth);
 
         dictionary_register_insert_callback(host->rrdcalc_root_index, rrdcalc_rrdhost_insert_callback, NULL);
         dictionary_register_conflict_callback(host->rrdcalc_root_index, rrdcalc_rrdhost_conflict_callback, NULL);

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -189,7 +189,7 @@ static void rrdcalctemplate_delete_callback(const DICTIONARY_ITEM *item __maybe_
 
 void rrdcalctemplate_index_init(RRDHOST *host) {
     if(!host->rrdcalctemplate_root_index) {
-        host->rrdcalctemplate_root_index = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);
+        host->rrdcalctemplate_root_index = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE, &dictionary_stats_category_rrdhealth);
 
         dictionary_register_insert_callback(host->rrdcalctemplate_root_index, rrdcalctemplate_insert_callback, NULL);
         dictionary_register_delete_callback(host->rrdcalctemplate_root_index, rrdcalctemplate_delete_callback, host);

--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -2449,8 +2449,8 @@ static void query_target_add_metric(QUERY_TARGET_LOCALS *qtl, RRDMETRIC_ACQUIRED
         tier_retention[tier].eng = eng;
         tier_retention[tier].db_update_every_s = (time_t) (qtl->host->db[tier].tier_grouping * ri->update_every_s);
 
-        if(rm->rrddim && rm->rrddim->tiers[tier] && rm->rrddim->tiers[tier]->db_metric_handle)
-            tier_retention[tier].db_metric_handle = eng->api.metric_dup(rm->rrddim->tiers[tier]->db_metric_handle);
+        if(rm->rrddim && rm->rrddim->tiers[tier].db_metric_handle)
+            tier_retention[tier].db_metric_handle = eng->api.metric_dup(rm->rrddim->tiers[tier].db_metric_handle);
         else
             tier_retention[tier].db_metric_handle = eng->api.metric_get(qtl->host->db[tier].instance, &rm->uuid);
 

--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -611,7 +611,7 @@ static void rrdmetrics_create_in_rrdinstance(RRDINSTANCE *ri) {
     if(unlikely(!ri)) return;
     if(likely(ri->rrdmetrics)) return;
 
-    ri->rrdmetrics = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);
+    ri->rrdmetrics = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE, &dictionary_stats_category_rrdcontext);
     dictionary_register_insert_callback(ri->rrdmetrics, rrdmetric_insert_callback, ri);
     dictionary_register_delete_callback(ri->rrdmetrics, rrdmetric_delete_callback, ri);
     dictionary_register_conflict_callback(ri->rrdmetrics, rrdmetric_conflict_callback, ri);
@@ -914,7 +914,7 @@ static void rrdinstance_react_callback(const DICTIONARY_ITEM *item __maybe_unuse
 void rrdinstances_create_in_rrdcontext(RRDCONTEXT *rc) {
     if(unlikely(!rc || rc->rrdinstances)) return;
 
-    rc->rrdinstances = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);
+    rc->rrdinstances = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE, &dictionary_stats_category_rrdcontext);
     dictionary_register_insert_callback(rc->rrdinstances, rrdinstance_insert_callback, rc);
     dictionary_register_delete_callback(rc->rrdinstances, rrdinstance_delete_callback, rc);
     dictionary_register_conflict_callback(rc->rrdinstances, rrdinstance_conflict_callback, rc);
@@ -1392,18 +1392,18 @@ void rrdhost_create_rrdcontexts(RRDHOST *host) {
     if(unlikely(!host)) return;
     if(likely(host->rrdctx)) return;
 
-    host->rrdctx = (RRDCONTEXTS *)dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);
+    host->rrdctx = (RRDCONTEXTS *)dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE, &dictionary_stats_category_rrdcontext);
     dictionary_register_insert_callback((DICTIONARY *)host->rrdctx, rrdcontext_insert_callback, host);
     dictionary_register_delete_callback((DICTIONARY *)host->rrdctx, rrdcontext_delete_callback, host);
     dictionary_register_conflict_callback((DICTIONARY *)host->rrdctx, rrdcontext_conflict_callback, host);
     dictionary_register_react_callback((DICTIONARY *)host->rrdctx, rrdcontext_react_callback, host);
 
-    host->rrdctx_hub_queue = (RRDCONTEXTS *)dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_VALUE_LINK_DONT_CLONE);
+    host->rrdctx_hub_queue = (RRDCONTEXTS *)dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_VALUE_LINK_DONT_CLONE, &dictionary_stats_category_rrdcontext);
     dictionary_register_insert_callback((DICTIONARY *)host->rrdctx_hub_queue, rrdcontext_hub_queue_insert_callback, NULL);
     dictionary_register_delete_callback((DICTIONARY *)host->rrdctx_hub_queue, rrdcontext_hub_queue_delete_callback, NULL);
     dictionary_register_conflict_callback((DICTIONARY *)host->rrdctx_hub_queue, rrdcontext_hub_queue_conflict_callback, NULL);
 
-    host->rrdctx_post_processing_queue = (RRDCONTEXTS *)dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_VALUE_LINK_DONT_CLONE);
+    host->rrdctx_post_processing_queue = (RRDCONTEXTS *)dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_VALUE_LINK_DONT_CLONE, &dictionary_stats_category_rrdcontext);
     dictionary_register_insert_callback((DICTIONARY *)host->rrdctx_post_processing_queue, rrdcontext_post_processing_queue_insert_callback, NULL);
     dictionary_register_delete_callback((DICTIONARY *)host->rrdctx_post_processing_queue, rrdcontext_post_processing_queue_delete_callback, NULL);
     dictionary_register_conflict_callback((DICTIONARY *)host->rrdctx_post_processing_queue, rrdcontext_post_processing_queue_conflict_callback, NULL);
@@ -1845,7 +1845,7 @@ static inline int rrdinstance_to_json_callback(const DICTIONARY_ITEM *item, void
     BUFFER *wb_metrics = NULL;
     if(options & RRDCONTEXT_OPTION_SHOW_METRICS || t_parent->chart_dimensions) {
 
-        wb_metrics = buffer_create(4096);
+        wb_metrics = buffer_create(4096, &netdata_buffers_statistics.buffers_api);
 
         struct rrdcontext_to_json t_metrics = {
             .wb = wb_metrics,
@@ -1983,7 +1983,7 @@ static inline int rrdcontext_to_json_callback(const DICTIONARY_ITEM *item, void 
         || t_parent->chart_labels_filter
         || t_parent->chart_dimensions) {
 
-        wb_instances = buffer_create(4096);
+        wb_instances = buffer_create(4096, &netdata_buffers_statistics.buffers_api);
 
         struct rrdcontext_to_json t_instances = {
             .wb = wb_instances,
@@ -2211,7 +2211,7 @@ DICTIONARY *rrdcontext_all_metrics_to_dict(RRDHOST *host, SIMPLE_PATTERN *contex
     if(!host || !host->rrdctx)
         return NULL;
 
-    DICTIONARY *dict = dictionary_create(DICT_OPTION_SINGLE_THREADED|DICT_OPTION_DONT_OVERWRITE_VALUE);
+    DICTIONARY *dict = dictionary_create_advanced(DICT_OPTION_SINGLE_THREADED|DICT_OPTION_DONT_OVERWRITE_VALUE, &dictionary_stats_category_rrdcontext);
     dictionary_register_insert_callback(dict, metric_entry_insert_callback, NULL);
     dictionary_register_delete_callback(dict, metric_entry_delete_callback, NULL);
     dictionary_register_conflict_callback(dict, metric_entry_conflict_callback, NULL);
@@ -2380,28 +2380,35 @@ void query_target_release(QUERY_TARGET *qt) {
     qt->used = false;
 }
 void query_target_free(void) {
-    if(thread_query_target.used)
-        query_target_release(&thread_query_target);
+    QUERY_TARGET *qt = &thread_query_target;
 
-    freez(thread_query_target.query.array);
-    thread_query_target.query.array = NULL;
-    thread_query_target.query.size = 0;
+    if(qt->used)
+        query_target_release(qt);
 
-    freez(thread_query_target.metrics.array);
-    thread_query_target.metrics.array = NULL;
-    thread_query_target.metrics.size = 0;
+    __atomic_sub_fetch(&netdata_buffers_statistics.query_targets_size, qt->query.size * sizeof(QUERY_METRIC), __ATOMIC_RELAXED);
+    freez(qt->query.array);
+    qt->query.array = NULL;
+    qt->query.size = 0;
 
-    freez(thread_query_target.instances.array);
-    thread_query_target.instances.array = NULL;
-    thread_query_target.instances.size = 0;
+    __atomic_sub_fetch(&netdata_buffers_statistics.query_targets_size, qt->metrics.size * sizeof(RRDMETRIC_ACQUIRED *), __ATOMIC_RELAXED);
+    freez(qt->metrics.array);
+    qt->metrics.array = NULL;
+    qt->metrics.size = 0;
 
-    freez(thread_query_target.contexts.array);
-    thread_query_target.contexts.array = NULL;
-    thread_query_target.contexts.size = 0;
+    __atomic_sub_fetch(&netdata_buffers_statistics.query_targets_size, qt->instances.size * sizeof(RRDINSTANCE_ACQUIRED *), __ATOMIC_RELAXED);
+    freez(qt->instances.array);
+    qt->instances.array = NULL;
+    qt->instances.size = 0;
 
-    freez(thread_query_target.hosts.array);
-    thread_query_target.hosts.array = NULL;
-    thread_query_target.hosts.size = 0;
+    __atomic_sub_fetch(&netdata_buffers_statistics.query_targets_size, qt->contexts.size * sizeof(RRDCONTEXT_ACQUIRED *), __ATOMIC_RELAXED);
+    freez(qt->contexts.array);
+    qt->contexts.array = NULL;
+    qt->contexts.size = 0;
+
+    __atomic_sub_fetch(&netdata_buffers_statistics.query_targets_size, qt->hosts.size * sizeof(RRDHOST *), __ATOMIC_RELAXED);
+    freez(qt->hosts.array);
+    qt->hosts.array = NULL;
+    qt->hosts.size = 0;
 }
 
 static void query_target_add_metric(QUERY_TARGET_LOCALS *qtl, RRDMETRIC_ACQUIRED *rma, RRDINSTANCE *ri,
@@ -2413,8 +2420,12 @@ static void query_target_add_metric(QUERY_TARGET_LOCALS *qtl, RRDMETRIC_ACQUIRED
         return;
 
     if(qt->metrics.used == qt->metrics.size) {
+        size_t old_mem = qt->metrics.size * sizeof(RRDMETRIC_ACQUIRED *);
         qt->metrics.size = (qt->metrics.size) ? qt->metrics.size * 2 : 1;
-        qt->metrics.array = reallocz(qt->metrics.array, qt->metrics.size * sizeof(RRDMETRIC_ACQUIRED *));
+        size_t new_mem = qt->metrics.size * sizeof(RRDMETRIC_ACQUIRED *);
+        qt->metrics.array = reallocz(qt->metrics.array, new_mem);
+
+        __atomic_add_fetch(&netdata_buffers_statistics.query_targets_size, new_mem - old_mem, __ATOMIC_RELAXED);
     }
     qt->metrics.array[qt->metrics.used++] = rrdmetric_acquired_dup(rma);
 
@@ -2523,8 +2534,12 @@ static void query_target_add_metric(QUERY_TARGET_LOCALS *qtl, RRDMETRIC_ACQUIRED
                 ri->rrdset->last_accessed_time_s = qtl->start_s;
 
             if (qt->query.used == qt->query.size) {
+                size_t old_mem = qt->query.size * sizeof(QUERY_METRIC);
                 qt->query.size = (qt->query.size) ? qt->query.size * 2 : 1;
-                qt->query.array = reallocz(qt->query.array, qt->query.size * sizeof(QUERY_METRIC));
+                size_t new_mem = qt->query.size * sizeof(QUERY_METRIC);
+                qt->query.array = reallocz(qt->query.array, new_mem);
+
+                __atomic_add_fetch(&netdata_buffers_statistics.query_targets_size, new_mem - old_mem, __ATOMIC_RELAXED);
             }
             QUERY_METRIC *qm = &qt->query.array[qt->query.used++];
 
@@ -2578,8 +2593,12 @@ static void query_target_add_instance(QUERY_TARGET_LOCALS *qtl, RRDINSTANCE_ACQU
         return;
 
     if(qt->instances.used == qt->instances.size) {
+        size_t old_mem = qt->instances.size * sizeof(RRDINSTANCE_ACQUIRED *);
         qt->instances.size = (qt->instances.size) ? qt->instances.size * 2 : 1;
-        qt->instances.array = reallocz(qt->instances.array, qt->instances.size * sizeof(RRDINSTANCE_ACQUIRED *));
+        size_t new_mem = qt->instances.size * sizeof(RRDINSTANCE_ACQUIRED *);
+        qt->instances.array = reallocz(qt->instances.array, new_mem);
+
+        __atomic_add_fetch(&netdata_buffers_statistics.query_targets_size, new_mem - old_mem, __ATOMIC_RELAXED);
     }
 
     qtl->ria = qt->instances.array[qt->instances.used++] = rrdinstance_acquired_dup(ria);
@@ -2622,8 +2641,12 @@ static void query_target_add_context(QUERY_TARGET_LOCALS *qtl, RRDCONTEXT_ACQUIR
         return;
 
     if(qt->contexts.used == qt->contexts.size) {
+        size_t old_mem = qt->contexts.size * sizeof(RRDCONTEXT_ACQUIRED *);
         qt->contexts.size = (qt->contexts.size) ? qt->contexts.size * 2 : 1;
-        qt->contexts.array = reallocz(qt->contexts.array, qt->contexts.size * sizeof(RRDCONTEXT_ACQUIRED *));
+        size_t new_mem = qt->contexts.size * sizeof(RRDCONTEXT_ACQUIRED *);
+        qt->contexts.array = reallocz(qt->contexts.array, new_mem);
+
+        __atomic_add_fetch(&netdata_buffers_statistics.query_targets_size, new_mem - old_mem, __ATOMIC_RELAXED);
     }
     qtl->rca = qt->contexts.array[qt->contexts.used++] = rrdcontext_acquired_dup(rca);
 
@@ -2662,8 +2685,12 @@ static void query_target_add_host(QUERY_TARGET_LOCALS *qtl, RRDHOST *host) {
     QUERY_TARGET *qt = qtl->qt;
 
     if(qt->hosts.used == qt->hosts.size) {
+        size_t old_mem = qt->hosts.size * sizeof(RRDHOST *);
         qt->hosts.size = (qt->hosts.size) ? qt->hosts.size * 2 : 1;
-        qt->hosts.array = reallocz(qt->hosts.array, qt->hosts.size * sizeof(RRDHOST *));
+        size_t new_mem = qt->hosts.size * sizeof(RRDHOST *);
+        qt->hosts.array = reallocz(qt->hosts.array, new_mem);
+
+        __atomic_add_fetch(&netdata_buffers_statistics.query_targets_size, new_mem - old_mem, __ATOMIC_RELAXED);
     }
     qtl->host = qt->hosts.array[qt->hosts.used++] = host;
 

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -69,7 +69,10 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
             info("Failed to use memory mode ram for chart '%s', dimension '%s', falling back to alloc", rrdset_name(st), rrddim_name(rd));
             ctr->memory_mode = RRD_MEMORY_MODE_ALLOC;
         }
-        else rd->memsize = entries * sizeof(storage_number);
+        else {
+            rd->memsize = entries * sizeof(storage_number);
+            __atomic_add_fetch(&rrddim_db_memory_size, rd->memsize, __ATOMIC_RELAXED);
+        }
     }
 
     if(ctr->memory_mode == RRD_MEMORY_MODE_ALLOC || ctr->memory_mode == RRD_MEMORY_MODE_NONE) {
@@ -78,6 +81,7 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
 
         rd->db = rrddim_alloc_db(entries);
         rd->memsize = entries * sizeof(storage_number);
+        __atomic_add_fetch(&rrddim_db_memory_size, rd->memsize, __ATOMIC_RELAXED);
     }
 
     rd->rrd_memory_mode = ctr->memory_mode;
@@ -108,12 +112,11 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
         size_t initialized = 0;
         for(size_t tier = 0; tier < storage_tiers ; tier++) {
             STORAGE_ENGINE *eng = host->db[tier].eng;
-            rd->tiers[tier] = callocz(1, sizeof(struct rrddim_tier));
-            rd->tiers[tier]->tier_grouping = host->db[tier].tier_grouping;
-            rd->tiers[tier]->collect_ops = &eng->api.collect_ops;
-            rd->tiers[tier]->query_ops = &eng->api.query_ops;
-            rd->tiers[tier]->db_metric_handle = eng->api.metric_get_or_create(rd, host->db[tier].instance);
-            storage_point_unset(rd->tiers[tier]->virtual_point);
+            rd->tiers[tier].tier_grouping = host->db[tier].tier_grouping;
+            rd->tiers[tier].collect_ops = &eng->api.collect_ops;
+            rd->tiers[tier].query_ops = &eng->api.query_ops;
+            rd->tiers[tier].db_metric_handle = eng->api.metric_get_or_create(rd, host->db[tier].instance);
+            storage_point_unset(rd->tiers[tier].virtual_point);
             initialized++;
 
             // internal_error(true, "TIER GROUPING of chart '%s', dimension '%s' for tier %d is set to %d", rd->rrdset->name, rd->name, tier, rd->tiers[tier]->tier_grouping);
@@ -122,7 +125,7 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
         if(!initialized)
             error("Failed to initialize all db tiers for chart '%s', dimension '%s", rrdset_name(st), rrddim_name(rd));
 
-        if(!rd->tiers[0])
+        if(!rd->tiers[0].db_metric_handle)
             error("Failed to initialize the first db tier for chart '%s', dimension '%s", rrdset_name(st), rrddim_name(rd));
     }
 
@@ -130,8 +133,8 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
     {
         size_t initialized = 0;
         for (size_t tier = 0; tier < storage_tiers; tier++) {
-            if (rd->tiers[tier]) {
-                rd->tiers[tier]->db_collection_handle = rd->tiers[tier]->collect_ops->init(rd->tiers[tier]->db_metric_handle, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->storage_metrics_groups[tier]);
+            if (rd->tiers[tier].db_metric_handle) {
+                rd->tiers[tier].db_collection_handle = rd->tiers[tier].collect_ops->init(rd->tiers[tier].db_metric_handle, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->storage_metrics_groups[tier]);
                 initialized++;
             }
         }
@@ -197,13 +200,13 @@ static void rrddim_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, v
 
     size_t tiers_available = 0, tiers_said_no_retention = 0;
     for(size_t tier = 0; tier < storage_tiers ;tier++) {
-        if(rd->tiers[tier] && rd->tiers[tier]->db_collection_handle) {
+        if(rd->tiers[tier].db_collection_handle) {
             tiers_available++;
 
-            if(rd->tiers[tier]->collect_ops->finalize(rd->tiers[tier]->db_collection_handle))
+            if(rd->tiers[tier].collect_ops->finalize(rd->tiers[tier].db_collection_handle))
                 tiers_said_no_retention++;
 
-            rd->tiers[tier]->db_collection_handle = NULL;
+            rd->tiers[tier].db_collection_handle = NULL;
         }
     }
 
@@ -224,16 +227,16 @@ static void rrddim_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, v
     rrddim_memory_file_free(rd);
 
     for(size_t tier = 0; tier < storage_tiers ;tier++) {
-        if(!rd->tiers[tier]) continue;
+        if(!rd->tiers[tier].db_metric_handle) continue;
 
         STORAGE_ENGINE* eng = host->db[tier].eng;
-        eng->api.metric_release(rd->tiers[tier]->db_metric_handle);
-
-        freez(rd->tiers[tier]);
-        rd->tiers[tier] = NULL;
+        eng->api.metric_release(rd->tiers[tier].db_metric_handle);
+        rd->tiers[tier].db_metric_handle = NULL;
     }
 
     if(rd->db) {
+        __atomic_sub_fetch(&rrddim_db_memory_size, rd->memsize, __ATOMIC_RELAXED);
+
         if(rd->rrd_memory_mode == RRD_MEMORY_MODE_RAM)
             netdata_munmap(rd->db, rd->memsize);
         else
@@ -259,9 +262,9 @@ static bool rrddim_conflict_callback(const DICTIONARY_ITEM *item __maybe_unused,
     rc += rrddim_set_divisor(st, rd, ctr->divisor);
 
     for(size_t tier = 0; tier < storage_tiers ;tier++) {
-        if (rd->tiers[tier] && !rd->tiers[tier]->db_collection_handle)
-            rd->tiers[tier]->db_collection_handle =
-                rd->tiers[tier]->collect_ops->init(rd->tiers[tier]->db_metric_handle, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->storage_metrics_groups[tier]);
+        if (!rd->tiers[tier].db_collection_handle)
+            rd->tiers[tier].db_collection_handle =
+                rd->tiers[tier].collect_ops->init(rd->tiers[tier].db_metric_handle, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->storage_metrics_groups[tier]);
     }
 
     if(rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED)) {
@@ -420,10 +423,10 @@ inline int rrddim_set_divisor(RRDSET *st, RRDDIM *rd, collected_number divisor) 
 // ----------------------------------------------------------------------------
 
 time_t rrddim_last_entry_s_of_tier(RRDDIM *rd, size_t tier) {
-    if(unlikely(tier > storage_tiers || !rd->tiers[tier]))
+    if(unlikely(tier > storage_tiers || !rd->tiers[tier].db_metric_handle))
         return 0;
 
-    return rd->tiers[tier]->query_ops->latest_time_s(rd->tiers[tier]->db_metric_handle);
+    return rd->tiers[tier].query_ops->latest_time_s(rd->tiers[tier].db_metric_handle);
 }
 
 // get the timestamp of the last entry in the round-robin database
@@ -431,7 +434,7 @@ time_t rrddim_last_entry_s(RRDDIM *rd) {
     time_t latest_time_s = rrddim_last_entry_s_of_tier(rd, 0);
 
     for(size_t tier = 1; tier < storage_tiers ;tier++) {
-        if(unlikely(!rd->tiers[tier])) continue;
+        if(unlikely(!rd->tiers[tier].db_metric_handle)) continue;
 
         time_t t = rrddim_last_entry_s_of_tier(rd, tier);
         if(t > latest_time_s)
@@ -442,10 +445,10 @@ time_t rrddim_last_entry_s(RRDDIM *rd) {
 }
 
 time_t rrddim_first_entry_s_of_tier(RRDDIM *rd, size_t tier) {
-    if(unlikely(tier > storage_tiers || !rd->tiers[tier]))
+    if(unlikely(tier > storage_tiers || !rd->tiers[tier].db_metric_handle))
         return 0;
 
-    return rd->tiers[tier]->query_ops->oldest_time_s(rd->tiers[tier]->db_metric_handle);
+    return rd->tiers[tier].query_ops->oldest_time_s(rd->tiers[tier].db_metric_handle);
 }
 
 time_t rrddim_first_entry_s(RRDDIM *rd) {
@@ -657,6 +660,7 @@ void rrddim_memory_file_free(RRDDIM *rd) {
     rrddim_memory_file_update(rd);
 
     struct rrddim_map_save_v019 *rd_on_file = rd->rd_on_file;
+    __atomic_sub_fetch(&rrddim_db_memory_size, rd_on_file->memsize + strlen(rd_on_file->cache_filename), __ATOMIC_RELAXED);
     freez(rd_on_file->cache_filename);
     netdata_munmap(rd_on_file, rd_on_file->memsize);
 
@@ -753,6 +757,8 @@ bool rrddim_memory_load_or_create_map_save(RRDSET *st, RRDDIM *rd, RRD_MEMORY_MO
     rd_on_file->memsize = size;
     rd_on_file->rrd_memory_mode = memory_mode;
     rd_on_file->cache_filename = strdupz(fullfilename);
+
+    __atomic_add_fetch(&rrddim_db_memory_size, rd_on_file->memsize + strlen(rd_on_file->cache_filename), __ATOMIC_RELAXED);
 
     rd->db = &rd_on_file->values[0];
     rd->rd_on_file = rd_on_file;

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -299,7 +299,7 @@ static void rrddim_react_callback(const DICTIONARY_ITEM *item __maybe_unused, vo
 
 void rrddim_index_init(RRDSET *st) {
     if(!st->rrddim_root_index) {
-        st->rrddim_root_index = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);
+        st->rrddim_root_index = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE, &dictionary_stats_category_rrdset_rrddim);
 
         dictionary_register_insert_callback(st->rrddim_root_index, rrddim_insert_callback, NULL);
         dictionary_register_conflict_callback(st->rrddim_root_index, rrddim_conflict_callback, NULL);

--- a/database/rrddimvar.c
+++ b/database/rrddimvar.c
@@ -214,7 +214,7 @@ static void rrddimvar_delete_callback(const DICTIONARY_ITEM *item __maybe_unused
 
 void rrddimvar_index_init(RRDSET *st) {
     if(!st->rrddimvar_root_index) {
-        st->rrddimvar_root_index = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);
+        st->rrddimvar_root_index = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE, &dictionary_stats_category_rrdhealth);
 
         dictionary_register_insert_callback(st->rrddimvar_root_index, rrddimvar_insert_callback, NULL);
         dictionary_register_conflict_callback(st->rrddimvar_root_index, rrddimvar_conflict_callback, NULL);

--- a/database/rrdfamily.c
+++ b/database/rrdfamily.c
@@ -33,7 +33,7 @@ static void rrdfamily_delete_callback(const DICTIONARY_ITEM *item __maybe_unused
 
 void rrdfamily_index_init(RRDHOST *host) {
     if(!host->rrdfamily_root_index) {
-        host->rrdfamily_root_index = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);
+        host->rrdfamily_root_index = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE, &dictionary_stats_category_rrdhealth);
 
         dictionary_register_insert_callback(host->rrdfamily_root_index, rrdfamily_insert_callback, NULL);
         dictionary_register_delete_callback(host->rrdfamily_root_index, rrdfamily_delete_callback, host);

--- a/database/rrdfunctions.c
+++ b/database/rrdfunctions.c
@@ -424,7 +424,7 @@ static bool rrd_functions_conflict_callback(const DICTIONARY_ITEM *item __maybe_
 void rrdfunctions_init(RRDHOST *host) {
     if(host->functions) return;
 
-    host->functions = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);
+    host->functions = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE, &dictionary_stats_category_functions);
     dictionary_register_insert_callback(host->functions, rrd_functions_insert_callback, host);
     dictionary_register_delete_callback(host->functions, rrd_functions_delete_callback, host);
     dictionary_register_conflict_callback(host->functions, rrd_functions_conflict_callback, host);
@@ -629,7 +629,7 @@ int rrd_call_function_and_wait(RRDHOST *host, BUFFER *wb, int timeout, const cha
         pthread_cond_init(&tmp->cond, NULL);
 
         bool we_should_free = true;
-        BUFFER *temp_wb  = buffer_create(PLUGINSD_LINE_MAX + 1); // we need it because we may give up on it
+        BUFFER *temp_wb  = buffer_create(PLUGINSD_LINE_MAX + 1, &netdata_buffers_statistics.buffers_functions); // we need it because we may give up on it
         temp_wb->contenttype = wb->contenttype;
         code = rdcf->function(temp_wb, timeout, key, rdcf->collector_data, rrd_call_function_signal_when_ready, tmp);
         if (code == HTTP_RESP_OK) {

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1033,10 +1033,10 @@ static void rrdhost_streaming_sender_structures_init(RRDHOST *host)
         return;
 
     host->sender = callocz(1, sizeof(*host->sender));
-    __atomic_add_fetch(&netdata_buffers_statistics.buffers_streaming, sizeof(*host->sender), __ATOMIC_RELAXED);
+    __atomic_add_fetch(&netdata_buffers_statistics.rrdhost_senders, sizeof(*host->sender), __ATOMIC_RELAXED);
 
     host->sender->host = host;
-    host->sender->buffer = cbuffer_new(CBUFFER_INITIAL_SIZE, 1024 * 1024, &netdata_buffers_statistics.buffers_streaming);
+    host->sender->buffer = cbuffer_new(CBUFFER_INITIAL_SIZE, 1024 * 1024, &netdata_buffers_statistics.cbuffers_streaming);
     host->sender->capabilities = STREAM_OUR_CAPABILITIES;
 
     host->sender->rrdpush_sender_pipe[PIPE_READ] = -1;
@@ -1071,7 +1071,7 @@ static void rrdhost_streaming_sender_structures_free(RRDHOST *host)
 #endif
     replication_cleanup_sender(host->sender);
 
-    __atomic_sub_fetch(&netdata_buffers_statistics.buffers_streaming, sizeof(*host->sender), __ATOMIC_RELAXED);
+    __atomic_sub_fetch(&netdata_buffers_statistics.rrdhost_senders, sizeof(*host->sender), __ATOMIC_RELAXED);
 
     freez(host->sender);
     host->sender = NULL;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -51,13 +51,15 @@ static DICTIONARY *rrdhost_root_index_hostname = NULL;
 
 static inline void rrdhost_init() {
     if(unlikely(!rrdhost_root_index)) {
-        rrdhost_root_index = dictionary_create(
-            DICT_OPTION_NAME_LINK_DONT_CLONE | DICT_OPTION_VALUE_LINK_DONT_CLONE | DICT_OPTION_DONT_OVERWRITE_VALUE);
+        rrdhost_root_index = dictionary_create_advanced(
+            DICT_OPTION_NAME_LINK_DONT_CLONE | DICT_OPTION_VALUE_LINK_DONT_CLONE | DICT_OPTION_DONT_OVERWRITE_VALUE,
+            &dictionary_stats_category_rrdhost);
     }
 
     if(unlikely(!rrdhost_root_index_hostname)) {
-        rrdhost_root_index_hostname = dictionary_create(
-            DICT_OPTION_NAME_LINK_DONT_CLONE | DICT_OPTION_VALUE_LINK_DONT_CLONE | DICT_OPTION_DONT_OVERWRITE_VALUE);
+        rrdhost_root_index_hostname = dictionary_create_advanced(
+            DICT_OPTION_NAME_LINK_DONT_CLONE | DICT_OPTION_VALUE_LINK_DONT_CLONE | DICT_OPTION_DONT_OVERWRITE_VALUE,
+            &dictionary_stats_category_rrdhost);
     }
 }
 
@@ -1029,7 +1031,7 @@ static void rrdhost_streaming_sender_structures_init(RRDHOST *host)
 
     host->sender = callocz(1, sizeof(*host->sender));
     host->sender->host = host;
-    host->sender->buffer = cbuffer_new(CBUFFER_INITIAL_SIZE, 1024 * 1024);
+    host->sender->buffer = cbuffer_new(CBUFFER_INITIAL_SIZE, 1024 * 1024, &netdata_buffers_statistics.buffers_streaming);
     host->sender->capabilities = STREAM_OUR_CAPABILITIES;
 
     host->sender->rrdpush_sender_pipe[PIPE_READ] = -1;

--- a/database/rrdlabels.c
+++ b/database/rrdlabels.c
@@ -533,7 +533,7 @@ static bool rrdlabel_conflict_callback(const DICTIONARY_ITEM *item __maybe_unuse
 }
 
 DICTIONARY *rrdlabels_create(void) {
-    DICTIONARY *dict = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);
+    DICTIONARY *dict = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE, &dictionary_stats_category_rrdlabels);
     dictionary_register_insert_callback(dict, rrdlabel_insert_callback, dict);
     dictionary_register_delete_callback(dict, rrdlabel_delete_callback, dict);
     dictionary_register_conflict_callback(dict, rrdlabel_conflict_callback, dict);

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -401,7 +401,7 @@ static void rrdset_react_callback(const DICTIONARY_ITEM *item __maybe_unused, vo
 
 void rrdset_index_init(RRDHOST *host) {
     if(!host->rrdset_root_index) {
-        host->rrdset_root_index = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);
+        host->rrdset_root_index = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE, &dictionary_stats_category_rrdset_rrddim);
 
         dictionary_register_insert_callback(host->rrdset_root_index, rrdset_insert_callback, NULL);
         dictionary_register_conflict_callback(host->rrdset_root_index, rrdset_conflict_callback, NULL);
@@ -410,8 +410,9 @@ void rrdset_index_init(RRDHOST *host) {
     }
 
     if(!host->rrdset_root_index_name) {
-        host->rrdset_root_index_name = dictionary_create(
-            DICT_OPTION_NAME_LINK_DONT_CLONE | DICT_OPTION_VALUE_LINK_DONT_CLONE | DICT_OPTION_DONT_OVERWRITE_VALUE);
+        host->rrdset_root_index_name = dictionary_create_advanced(
+            DICT_OPTION_NAME_LINK_DONT_CLONE | DICT_OPTION_VALUE_LINK_DONT_CLONE | DICT_OPTION_DONT_OVERWRITE_VALUE,
+            &dictionary_stats_category_rrdset_rrddim);
 
         dictionary_register_insert_callback(host->rrdset_root_index_name, rrdset_name_insert_callback, host);
         dictionary_register_delete_callback(host->rrdset_root_index_name, rrdset_name_delete_callback, host);
@@ -1238,12 +1239,16 @@ struct rda_item {
 static __thread struct rda_item *thread_rda = NULL;
 static __thread size_t thread_rda_entries = 0;
 
-struct rda_item *rrdset_thread_rda(size_t *dimensions) {
+struct rda_item *rrdset_thread_rda_get(size_t *dimensions) {
 
     if(unlikely(!thread_rda || (*dimensions) > thread_rda_entries)) {
+        size_t old_mem = thread_rda_entries * sizeof(struct rda_item);
         freez(thread_rda);
-        thread_rda = mallocz((*dimensions) * sizeof(struct rda_item));
         thread_rda_entries = *dimensions;
+        size_t new_mem = thread_rda_entries * sizeof(struct rda_item);
+        thread_rda = mallocz(new_mem);
+
+        __atomic_add_fetch(&netdata_buffers_statistics.rrdset_done_rda_size, new_mem - old_mem, __ATOMIC_RELAXED);
     }
 
     *dimensions = thread_rda_entries;
@@ -1251,6 +1256,8 @@ struct rda_item *rrdset_thread_rda(size_t *dimensions) {
 }
 
 void rrdset_thread_rda_free(void) {
+    __atomic_sub_fetch(&netdata_buffers_statistics.rrdset_done_rda_size, thread_rda_entries * sizeof(struct rda_item), __ATOMIC_RELAXED);
+
     freez(thread_rda);
     thread_rda = NULL;
     thread_rda_entries = 0;
@@ -1585,7 +1592,7 @@ after_first_database_work:
     uint32_t has_reset_value = 0;
 
     size_t rda_slots = dictionary_entries(st->rrddim_root_index);
-    struct rda_item *rda_base = rrdset_thread_rda(&rda_slots);
+    struct rda_item *rda_base = rrdset_thread_rda_get(&rda_slots);
 
     size_t dim_id;
     size_t dimensions = 0;

--- a/database/rrdsetvar.c
+++ b/database/rrdsetvar.c
@@ -189,7 +189,7 @@ static void rrdsetvar_delete_callback(const DICTIONARY_ITEM *item __maybe_unused
 
 void rrdsetvar_index_init(RRDSET *st) {
     if(!st->rrdsetvar_root_index) {
-        st->rrdsetvar_root_index = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);
+        st->rrdsetvar_root_index = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE, &dictionary_stats_category_rrdhealth);
 
         dictionary_register_insert_callback(st->rrdsetvar_root_index, rrdsetvar_insert_callback, NULL);
         dictionary_register_conflict_callback(st->rrdsetvar_root_index, rrdsetvar_conflict_callback, NULL);

--- a/database/rrdvar.c
+++ b/database/rrdvar.c
@@ -84,7 +84,7 @@ static void rrdvar_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, v
 }
 
 DICTIONARY *rrdvariables_create(void) {
-    DICTIONARY *dict = dictionary_create(DICT_OPTION_DONT_OVERWRITE_VALUE);
+    DICTIONARY *dict = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE, &dictionary_stats_category_rrdhealth);
 
     dictionary_register_insert_callback(dict, rrdvar_insert_callback, NULL);
     dictionary_register_delete_callback(dict, rrdvar_delete_callback, NULL);

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -355,6 +355,8 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
     uuid_unparse_lower(*(uuid_t *)argv[IDX_HOST_ID], guid);
 
     struct rrdhost_system_info *system_info = callocz(1, sizeof(struct rrdhost_system_info));
+    __atomic_sub_fetch(&netdata_buffers_statistics.rrdhost_allocations_size, sizeof(struct rrdhost_system_info), __ATOMIC_RELAXED);
+
     system_info->hops = str2i((const char *) argv[IDX_HOPS]);
 
     sql_build_host_system_info((uuid_t *)argv[IDX_HOST_ID], system_info);

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -45,7 +45,7 @@ static void sql_maint_aclk_sync_database(struct aclk_database_worker_config *wc,
 
     debug(D_ACLK, "Checking database for %s", wc->host_guid);
 
-    BUFFER *sql = buffer_create(ACLK_SYNC_QUERY_SIZE);
+    BUFFER *sql = buffer_create(ACLK_SYNC_QUERY_SIZE, &netdata_buffers_statistics.buffers_sqlite);
 
     buffer_sprintf(sql,"DELETE FROM aclk_alert_%s WHERE date_submitted IS NOT NULL AND "
                         "CAST(date_cloud_ack AS INT) < unixepoch()-%d;", wc->uuid_str, ACLK_DELETE_ACK_ALERTS_INTERNAL);
@@ -120,7 +120,7 @@ void sql_delete_aclk_table_list(struct aclk_database_worker_config *wc, struct a
     debug(D_ACLK_SYNC, "Host %s does NOT exist, can delete aclk sync tables", host_str);
 
     sqlite3_stmt *res = NULL;
-    BUFFER *sql = buffer_create(ACLK_SYNC_QUERY_SIZE);
+    BUFFER *sql = buffer_create(ACLK_SYNC_QUERY_SIZE, &netdata_buffers_statistics.buffers_sqlite);
 
     buffer_sprintf(sql,"SELECT 'drop '||type||' IF EXISTS '||name||';' FROM sqlite_schema " \
                         "WHERE name LIKE 'aclk_%%_%s' AND type IN ('table', 'trigger', 'index');", uuid_str);
@@ -731,7 +731,7 @@ void sql_create_aclk_table(RRDHOST *host, uuid_t *host_uuid, uuid_t *node_id)
 
     uuid_unparse_lower(*host_uuid, host_guid);
 
-    BUFFER *sql = buffer_create(ACLK_SYNC_QUERY_SIZE);
+    BUFFER *sql = buffer_create(ACLK_SYNC_QUERY_SIZE, &netdata_buffers_statistics.buffers_sqlite);
 
     buffer_sprintf(sql, TABLE_ACLK_ALERT, uuid_str);
     db_execute(buffer_tostring(sql));

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -156,7 +156,7 @@ int sql_queue_alarm_to_aclk(RRDHOST *host, ALARM_ENTRY *ae, int skip_filter)
     char uuid_str[GUID_LEN + 1];
     uuid_unparse_lower_fix(&host->host_uuid, uuid_str);
 
-    BUFFER *sql = buffer_create(1024);
+    BUFFER *sql = buffer_create(1024, &netdata_buffers_statistics.buffers_sqlite);
 
     buffer_sprintf(
         sql,
@@ -245,7 +245,7 @@ void aclk_push_alert_event(struct aclk_database_worker_config *wc, struct aclk_d
         return;
     }
 
-    BUFFER *sql = buffer_create(1024);
+    BUFFER *sql = buffer_create(1024, &netdata_buffers_statistics.buffers_sqlite);
 
     if (wc->alerts_start_seq_id != 0) {
         buffer_sprintf(
@@ -410,7 +410,7 @@ void sql_queue_existing_alerts_to_aclk(RRDHOST *host)
 {
     char uuid_str[GUID_LEN + 1];
     uuid_unparse_lower_fix(&host->host_uuid, uuid_str);
-    BUFFER *sql = buffer_create(1024);
+    BUFFER *sql = buffer_create(1024, &netdata_buffers_statistics.buffers_sqlite);
 
     buffer_sprintf(sql,"delete from aclk_alert_%s; " \
                        "insert into aclk_alert_%s (alert_unique_id, date_created, filtered_alert_unique_id) " \
@@ -487,7 +487,7 @@ void aclk_push_alarm_health_log(struct aclk_database_worker_config *wc, struct a
     struct timeval first_timestamp;
     struct timeval last_timestamp;
 
-    BUFFER *sql = buffer_create(1024);
+    BUFFER *sql = buffer_create(1024, &netdata_buffers_statistics.buffers_sqlite);
 
     sqlite3_stmt *res = NULL;
 
@@ -656,7 +656,7 @@ int aclk_push_alert_config_event(struct aclk_database_worker_config *wc, struct 
             alarm_config.p_db_lookup_dimensions = sqlite3_column_bytes(res, 27) > 0 ? strdupz((char *)sqlite3_column_text(res, 27)) : NULL;
             alarm_config.p_db_lookup_method = sqlite3_column_bytes(res, 28) > 0 ? strdupz((char *)sqlite3_column_text(res, 28)) : NULL;
 
-            BUFFER *tmp_buf = buffer_create(1024);
+            BUFFER *tmp_buf = buffer_create(1024, &netdata_buffers_statistics.buffers_sqlite);
             buffer_data_options2string(tmp_buf, sqlite3_column_int(res, 29));
             alarm_config.p_db_lookup_options = strdupz((char *)buffer_tostring(tmp_buf));
             buffer_free(tmp_buf);
@@ -740,7 +740,7 @@ void sql_process_queue_removed_alerts_to_aclk(struct aclk_database_worker_config
 {
     UNUSED(cmd);
 
-    BUFFER *sql = buffer_create(1024);
+    BUFFER *sql = buffer_create(1024, &netdata_buffers_statistics.buffers_sqlite);
 
     buffer_sprintf(sql,"insert into aclk_alert_%s (alert_unique_id, date_created, filtered_alert_unique_id) " \
         "select unique_id alert_unique_id, unixepoch(), unique_id alert_unique_id from health_log_%s " \
@@ -818,7 +818,7 @@ void aclk_process_send_alarm_snapshot(char *node_id, char *claim_id, uint64_t sn
 
 void aclk_mark_alert_cloud_ack(char *uuid_str, uint64_t alerts_ack_sequence_id)
 {
-    BUFFER *sql = buffer_create(1024);
+    BUFFER *sql = buffer_create(1024, &netdata_buffers_statistics.buffers_sqlite);
 
     if (alerts_ack_sequence_id != 0) {
         buffer_sprintf(
@@ -1027,7 +1027,7 @@ void sql_aclk_alert_clean_dead_entries(RRDHOST *host)
     char uuid_str[GUID_LEN + 1];
     uuid_unparse_lower_fix(&host->host_uuid, uuid_str);
 
-    BUFFER *sql = buffer_create(1024);
+    BUFFER *sql = buffer_create(1024, &netdata_buffers_statistics.buffers_sqlite);
 
     buffer_sprintf(sql,"delete from aclk_alert_%s where filtered_alert_unique_id not in "
                    " (select unique_id from health_log_%s); ", uuid_str, uuid_str);
@@ -1053,7 +1053,7 @@ int get_proto_alert_status(RRDHOST *host, struct proto_alert_status *proto_alert
     proto_alert_status->alert_updates = wc->alert_updates;
     proto_alert_status->alerts_batch_id = wc->alerts_batch_id;
 
-    BUFFER *sql = buffer_create(1024);
+    BUFFER *sql = buffer_create(1024, &netdata_buffers_statistics.buffers_sqlite);
     sqlite3_stmt *res = NULL;
 
     buffer_sprintf(sql, "SELECT MIN(sequence_id), MAX(sequence_id), " \

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -969,6 +969,7 @@ static void start_metadata_hosts(uv_work_t *req __maybe_unused)
         if (rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED) || !rrdhost_flag_check(host, RRDHOST_FLAG_METADATA_UPDATE))
             continue;
         internal_error(true, "METADATA: Scanning host %s", rrdhost_hostname(host));
+        rrdhost_flag_clear(host,RRDHOST_FLAG_METADATA_UPDATE);
 
         if (unlikely(rrdhost_flag_check(host, RRDHOST_FLAG_METADATA_LABELS))) {
             rrdhost_flag_clear(host, RRDHOST_FLAG_METADATA_LABELS);

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -372,7 +372,7 @@ static BUFFER *sql_store_host_system_info(RRDHOST *host)
     if (unlikely(!system_info))
         return NULL;
 
-    BUFFER *work_buffer = buffer_create(1024);
+    BUFFER *work_buffer = buffer_create(1024, &netdata_buffers_statistics.buffers_sqlite);
 
     struct query_build key_data = {.sql = work_buffer, .count = 0};
     uuid_unparse_lower(host->host_uuid, key_data.uuid_str);
@@ -887,7 +887,7 @@ static bool metadata_scan_host(RRDHOST *host, uint32_t max_count) {
 
     bool more_to_do = false;
     uint32_t scan_count = 1;
-    BUFFER *work_buffer = buffer_create(1024);
+    BUFFER *work_buffer = buffer_create(1024, &netdata_buffers_statistics.buffers_sqlite);
 
     rrdset_foreach_reentrant(st, host) {
         if (scan_count == max_count) {
@@ -974,7 +974,7 @@ static void start_metadata_hosts(uv_work_t *req __maybe_unused)
             rrdhost_flag_clear(host, RRDHOST_FLAG_METADATA_LABELS);
             int rc = exec_statement_with_uuid(SQL_DELETE_HOST_LABELS, &host->host_uuid);
             if (likely(rc == SQLITE_OK)) {
-                BUFFER *work_buffer = buffer_create(1024);
+                BUFFER *work_buffer = buffer_create(1024, &netdata_buffers_statistics.buffers_sqlite);
                 struct query_build tmp = {.sql = work_buffer, .count = 0};
                 uuid_unparse_lower(host->host_uuid, tmp.uuid_str);
                 rrdlabels_walkthrough_read(host->rrdlabels, host_label_store_to_sql_callback, &tmp);

--- a/exporting/graphite/graphite.c
+++ b/exporting/graphite/graphite.c
@@ -48,7 +48,7 @@ int init_graphite_instance(struct instance *instance)
 
     instance->check_response = exporting_discard_response;
 
-    instance->buffer = (void *)buffer_create(0);
+    instance->buffer = (void *)buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
     if (!instance->buffer) {
         error("EXPORTING: cannot create buffer for graphite exporting connector instance %s", instance->config.name);
         return 1;
@@ -96,7 +96,7 @@ void sanitize_graphite_label_value(char *dst, const char *src, size_t len)
 int format_host_labels_graphite_plaintext(struct instance *instance, RRDHOST *host)
 {
     if (!instance->labels_buffer)
-        instance->labels_buffer = buffer_create(1024);
+        instance->labels_buffer = buffer_create(1024, &netdata_buffers_statistics.buffers_exporters);
 
     if (unlikely(!sending_labels_configured(instance)))
         return 0;

--- a/exporting/init_connectors.c
+++ b/exporting/init_connectors.c
@@ -171,8 +171,8 @@ void simple_connector_init(struct instance *instance)
     if (connector_specific_data->first_buffer)
         return;
 
-    connector_specific_data->header = buffer_create(0);
-    connector_specific_data->buffer = buffer_create(0);
+    connector_specific_data->header = buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
+    connector_specific_data->buffer = buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
 
     // create a ring buffer
     struct simple_connector_buffer *first_buffer = NULL;
@@ -195,7 +195,7 @@ void simple_connector_init(struct instance *instance)
     connector_specific_data->last_buffer = connector_specific_data->first_buffer;
 
     if (*instance->config.username || *instance->config.password) {
-        BUFFER *auth_string = buffer_create(0);
+        BUFFER *auth_string = buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
 
         buffer_sprintf(auth_string, "%s:%s", instance->config.username, instance->config.password);
 

--- a/exporting/json/json.c
+++ b/exporting/json/json.c
@@ -37,7 +37,7 @@ int init_json_instance(struct instance *instance)
 
     instance->check_response = exporting_discard_response;
 
-    instance->buffer = (void *)buffer_create(0);
+    instance->buffer = (void *)buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
     if (!instance->buffer) {
         error("EXPORTING: cannot create buffer for json exporting connector instance %s", instance->config.name);
         return 1;
@@ -96,7 +96,7 @@ int init_json_http_instance(struct instance *instance)
 
     instance->check_response = exporting_discard_response;
 
-    instance->buffer = (void *)buffer_create(0);
+    instance->buffer = (void *)buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
 
     simple_connector_init(instance);
 
@@ -119,7 +119,7 @@ int init_json_http_instance(struct instance *instance)
 int format_host_labels_json_plaintext(struct instance *instance, RRDHOST *host)
 {
     if (!instance->labels_buffer)
-        instance->labels_buffer = buffer_create(1024);
+        instance->labels_buffer = buffer_create(1024, &netdata_buffers_statistics.buffers_exporters);
 
     if (unlikely(!sending_labels_configured(instance)))
         return 0;

--- a/exporting/mongodb/mongodb.c
+++ b/exporting/mongodb/mongodb.c
@@ -106,7 +106,7 @@ int init_mongodb_instance(struct instance *instance)
     instance->prepare_header = NULL;
     instance->check_response = NULL;
 
-    instance->buffer = (void *)buffer_create(0);
+    instance->buffer = (void *)buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
     if (!instance->buffer) {
         error("EXPORTING: cannot create buffer for MongoDB exporting connector instance %s", instance->config.name);
         return 1;

--- a/exporting/opentsdb/opentsdb.c
+++ b/exporting/opentsdb/opentsdb.c
@@ -45,7 +45,7 @@ int init_opentsdb_telnet_instance(struct instance *instance)
     instance->prepare_header = NULL;
     instance->check_response = exporting_discard_response;
 
-    instance->buffer = (void *)buffer_create(0);
+    instance->buffer = (void *)buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
     if (!instance->buffer) {
         error("EXPORTING: cannot create buffer for opentsdb telnet exporting connector instance %s", instance->config.name);
         return 1;
@@ -102,7 +102,7 @@ int init_opentsdb_http_instance(struct instance *instance)
     instance->prepare_header = opentsdb_http_prepare_header;
     instance->check_response = exporting_discard_response;
 
-    instance->buffer = (void *)buffer_create(0);
+    instance->buffer = (void *)buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
     if (!instance->buffer) {
         error("EXPORTING: cannot create buffer for opentsdb HTTP exporting connector instance %s", instance->config.name);
         return 1;
@@ -150,7 +150,7 @@ void sanitize_opentsdb_label_value(char *dst, const char *src, size_t len)
 
 int format_host_labels_opentsdb_telnet(struct instance *instance, RRDHOST *host) {
     if(!instance->labels_buffer)
-        instance->labels_buffer = buffer_create(1024);
+        instance->labels_buffer = buffer_create(1024, &netdata_buffers_statistics.buffers_exporters);
 
     if (unlikely(!sending_labels_configured(instance)))
         return 0;
@@ -283,7 +283,7 @@ void opentsdb_http_prepare_header(struct instance *instance)
 
 int format_host_labels_opentsdb_http(struct instance *instance, RRDHOST *host) {
     if (!instance->labels_buffer)
-        instance->labels_buffer = buffer_create(1024);
+        instance->labels_buffer = buffer_create(1024, &netdata_buffers_statistics.buffers_exporters);
 
     if (unlikely(!sending_labels_configured(instance)))
         return 0;

--- a/exporting/process_data.c
+++ b/exporting/process_data.c
@@ -77,8 +77,8 @@ NETDATA_DOUBLE exporting_calculate_value_from_stored_data(
     time_t before = instance->before;
 
     // find the edges of the rrd database for this chart
-    time_t first_t = rd->tiers[0]->query_ops->oldest_time_s(rd->tiers[0]->db_metric_handle);
-    time_t last_t = rd->tiers[0]->query_ops->latest_time_s(rd->tiers[0]->db_metric_handle);
+    time_t first_t = rd->tiers[0].query_ops->oldest_time_s(rd->tiers[0].db_metric_handle);
+    time_t last_t = rd->tiers[0].query_ops->latest_time_s(rd->tiers[0].db_metric_handle);
     time_t update_every = st->update_every;
     struct storage_engine_query_handle handle;
 
@@ -126,8 +126,8 @@ NETDATA_DOUBLE exporting_calculate_value_from_stored_data(
     size_t counter = 0;
     NETDATA_DOUBLE sum = 0;
 
-    for (rd->tiers[0]->query_ops->init(rd->tiers[0]->db_metric_handle, &handle, after, before, STORAGE_PRIORITY_LOW); !rd->tiers[0]->query_ops->is_finished(&handle);) {
-        STORAGE_POINT sp = rd->tiers[0]->query_ops->next_metric(&handle);
+    for (rd->tiers[0].query_ops->init(rd->tiers[0].db_metric_handle, &handle, after, before, STORAGE_PRIORITY_LOW); !rd->tiers[0].query_ops->is_finished(&handle);) {
+        STORAGE_POINT sp = rd->tiers[0].query_ops->next_metric(&handle);
         points_read++;
 
         if (unlikely(storage_point_is_empty(sp))) {
@@ -138,7 +138,7 @@ NETDATA_DOUBLE exporting_calculate_value_from_stored_data(
         sum += sp.sum;
         counter += sp.count;
     }
-    rd->tiers[0]->query_ops->finalize(&handle);
+    rd->tiers[0].query_ops->finalize(&handle);
     global_statistics_exporters_query_completed(points_read);
 
     if (unlikely(!counter)) {

--- a/exporting/process_data.c
+++ b/exporting/process_data.c
@@ -397,7 +397,7 @@ int simple_connector_end_batch(struct instance *instance)
     struct simple_connector_buffer *last_buffer = simple_connector_data->last_buffer;
 
     if (!last_buffer->buffer) {
-        last_buffer->buffer = buffer_create(0);
+        last_buffer->buffer = buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
     }
 
     if (last_buffer->used) {
@@ -419,7 +419,7 @@ int simple_connector_end_batch(struct instance *instance)
     if (last_buffer->header)
         buffer_flush(last_buffer->header);
     else
-        last_buffer->header = buffer_create(0);
+        last_buffer->header = buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
 
     if (instance->prepare_header)
         instance->prepare_header(instance);

--- a/exporting/prometheus/prometheus.c
+++ b/exporting/prometheus/prometheus.c
@@ -317,7 +317,7 @@ void format_host_labels_prometheus(struct instance *instance, RRDHOST *host)
         return;
 
     if (!instance->labels_buffer)
-        instance->labels_buffer = buffer_create(1024);
+        instance->labels_buffer = buffer_create(1024, &netdata_buffers_statistics.buffers_exporters);
 
     struct format_prometheus_label_callback tmp = {
         .instance = instance,

--- a/exporting/prometheus/remote_write/remote_write.c
+++ b/exporting/prometheus/remote_write/remote_write.c
@@ -104,7 +104,7 @@ int init_prometheus_remote_write_instance(struct instance *instance)
     instance->prepare_header = prometheus_remote_write_prepare_header;
     instance->check_response = process_prometheus_remote_write_response;
 
-    instance->buffer = (void *)buffer_create(0);
+    instance->buffer = (void *)buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
 
     if (uv_mutex_init(&instance->mutex))
         return 1;

--- a/exporting/send_data.c
+++ b/exporting/send_data.c
@@ -64,7 +64,7 @@ void simple_connector_receive_response(int *sock, struct instance *instance)
 {
     static BUFFER *response = NULL;
     if (!response)
-        response = buffer_create(4096);
+        response = buffer_create(4096, &netdata_buffers_statistics.buffers_exporters);
 
     struct stats *stats = &instance->stats;
 #ifdef ENABLE_HTTPS

--- a/exporting/send_internal_metrics.c
+++ b/exporting/send_internal_metrics.c
@@ -65,7 +65,7 @@ void send_internal_metrics(struct instance *instance)
 
     if (!stats->initialized) {
         char id[RRD_ID_LENGTH_MAX + 1];
-        BUFFER *family = buffer_create(0);
+        BUFFER *family = buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
 
         buffer_sprintf(family, "exporting_%s", instance->config.name);
 

--- a/health/health.c
+++ b/health/health.c
@@ -459,8 +459,8 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
     BUFFER *warn_alarms, *crit_alarms;
     active_alerts_t *active_alerts = callocz(ACTIVE_ALARMS_LIST_EXAMINE, sizeof(active_alerts_t));
 
-    warn_alarms = buffer_create(NETDATA_WEB_RESPONSE_INITIAL_SIZE);
-    crit_alarms = buffer_create(NETDATA_WEB_RESPONSE_INITIAL_SIZE);
+    warn_alarms = buffer_create(NETDATA_WEB_RESPONSE_INITIAL_SIZE, &netdata_buffers_statistics.buffers_health);
+    crit_alarms = buffer_create(NETDATA_WEB_RESPONSE_INITIAL_SIZE, &netdata_buffers_statistics.buffers_health);
 
     foreach_rrdcalc_in_rrdhost_read(host, rc) {
         if(unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
@@ -517,7 +517,7 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
 
     char *edit_command = ae->source ? health_edit_command_from_source(ae_source(ae)) : strdupz("UNKNOWN=0=UNKNOWN");
 
-    BUFFER *wb = buffer_create(8192);
+    BUFFER *wb = buffer_create(8192, &netdata_buffers_statistics.buffers_health);
     bool ok = prepare_command(wb,
                               exec,
                               recipient,

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -73,7 +73,7 @@ inline void health_label_log_save(RRDHOST *host) {
     health_log_rotate(host);
 
     if(unlikely(host->health.health_log_fp)) {
-        BUFFER *wb = buffer_create(1024);
+        BUFFER *wb = buffer_create(1024, &netdata_buffers_statistics.buffers_health);
 
         rrdlabels_to_buffer(localhost->rrdlabels, wb, "", "=", "", "\t ", NULL, NULL, NULL, NULL);
         char *write = (char *) buffer_tostring(wb);
@@ -182,8 +182,10 @@ static inline ssize_t health_alarm_log_read(RRDHOST *host, FILE *fp, const char 
     size_t line = 0, len = 0;
     ssize_t loaded = 0, updated = 0, errored = 0, duplicate = 0;
 
-    DICTIONARY *all_rrdcalcs = dictionary_create(
-        DICT_OPTION_NAME_LINK_DONT_CLONE | DICT_OPTION_VALUE_LINK_DONT_CLONE | DICT_OPTION_DONT_OVERWRITE_VALUE);
+    DICTIONARY *all_rrdcalcs = dictionary_create_advanced(
+        DICT_OPTION_NAME_LINK_DONT_CLONE | DICT_OPTION_VALUE_LINK_DONT_CLONE | DICT_OPTION_DONT_OVERWRITE_VALUE,
+        &dictionary_stats_category_rrdhealth);
+
     RRDCALC *rc;
     foreach_rrdcalc_in_rrdhost_read(host, rc) {
         dictionary_set(all_rrdcalcs, rrdcalc_name(rc), rc, sizeof(*rc));

--- a/libnetdata/arrayalloc/arrayalloc.c
+++ b/libnetdata/arrayalloc/arrayalloc.c
@@ -144,10 +144,10 @@ static void arrayalloc_init(ARAL *ar) {
 
 #ifdef NETDATA_INTERNAL_CHECKS
 static inline void arrayalloc_free_validate_internal_check(ARAL *ar, ARAL_FREE *fr) {
-    if(fr->size < ar->internal.element_size)
+    if(unlikely(fr->size < ar->internal.element_size))
         fatal("ARRAYALLOC: free item of size %zu, less than the expected element size %zu", fr->size, ar->internal.element_size);
 
-    if(fr->size % ar->internal.element_size)
+    if(unlikely(fr->size % ar->internal.element_size))
         fatal("ARRAYALLOC: free item of size %zu is not multiple to element size %zu", fr->size, ar->internal.element_size);
 }
 #else
@@ -234,13 +234,13 @@ static void arrayalloc_add_page(ARAL *ar TRACE_ALLOCATIONS_FUNCTION_DEFINITION_P
     arrayalloc_free_validate_internal_check(ar, fr);
 }
 
-static void arrayalloc_lock(ARAL *ar) {
-    if(!ar->internal.lockless)
+static inline void arrayalloc_lock(ARAL *ar) {
+    if(likely(!ar->internal.lockless))
         netdata_spinlock_lock(&ar->internal.spinlock);
 }
 
-static void arrayalloc_unlock(ARAL *ar) {
-    if(!ar->internal.lockless)
+static inline void arrayalloc_unlock(ARAL *ar) {
+    if(likely(!ar->internal.lockless))
         netdata_spinlock_unlock(&ar->internal.spinlock);
 }
 

--- a/libnetdata/buffer/buffer.h
+++ b/libnetdata/buffer/buffer.h
@@ -15,6 +15,7 @@ typedef struct web_buffer {
     uint8_t options;		// options related to the content
     time_t date;    		// the timestamp this content has been generated
     time_t expires;			// the timestamp this content expires
+    size_t *statistics;
 } BUFFER;
 
 // options
@@ -61,7 +62,7 @@ void buffer_rrd_value(BUFFER *wb, NETDATA_DOUBLE value);
 void buffer_date(BUFFER *wb, int year, int month, int day, int hours, int minutes, int seconds);
 void buffer_jsdate(BUFFER *wb, int year, int month, int day, int hours, int minutes, int seconds);
 
-BUFFER *buffer_create(size_t size);
+BUFFER *buffer_create(size_t size, size_t *statistics);
 void buffer_free(BUFFER *b);
 void buffer_increase(BUFFER *b, size_t free_size_required);
 

--- a/libnetdata/circular_buffer/circular_buffer.c
+++ b/libnetdata/circular_buffer/circular_buffer.c
@@ -1,7 +1,7 @@
 #include "../libnetdata.h"
 
 struct circular_buffer *cbuffer_new(size_t initial, size_t max, size_t *statistics) {
-    struct circular_buffer *buf = mallocz(sizeof(*buf));
+    struct circular_buffer *buf = mallocz(sizeof(struct circular_buffer));
     buf->size = initial;
     buf->data = mallocz(initial);
     buf->write = 0;
@@ -10,14 +10,14 @@ struct circular_buffer *cbuffer_new(size_t initial, size_t max, size_t *statisti
     buf->statistics = statistics;
 
     if(buf->statistics)
-        __atomic_add_fetch(buf->statistics, sizeof(*buf) + buf->size, __ATOMIC_RELAXED);
+        __atomic_add_fetch(buf->statistics, sizeof(struct circular_buffer) + buf->size, __ATOMIC_RELAXED);
 
     return buf;
 }
 
 void cbuffer_free(struct circular_buffer *buf) {
-    if(buf->statistics)
-        __atomic_sub_fetch(buf->statistics, sizeof(*buf) + buf->size, __ATOMIC_RELAXED);
+    if(buf && buf->statistics)
+        __atomic_sub_fetch(buf->statistics, sizeof(struct circular_buffer) + buf->size, __ATOMIC_RELAXED);
 
     freez(buf->data);
     freez(buf);
@@ -55,7 +55,7 @@ static int cbuffer_realloc_unsafe(struct circular_buffer *buf) {
     buf->size = new_size;
 
     if(buf->statistics)
-        __atomic_sub_fetch(buf->statistics, new_size - old_size, __ATOMIC_RELAXED);
+        __atomic_add_fetch(buf->statistics, new_size - old_size, __ATOMIC_RELAXED);
 
     return 0;
 }

--- a/libnetdata/circular_buffer/circular_buffer.c
+++ b/libnetdata/circular_buffer/circular_buffer.c
@@ -1,16 +1,24 @@
 #include "../libnetdata.h"
 
-struct circular_buffer *cbuffer_new(size_t initial, size_t max) {
-    struct circular_buffer *result = mallocz(sizeof(*result));
-    result->size = initial;
-    result->data = mallocz(initial);
-    result->write = 0;
-    result->read = 0;
-    result->max_size = max;
-    return result;
+struct circular_buffer *cbuffer_new(size_t initial, size_t max, size_t *statistics) {
+    struct circular_buffer *buf = mallocz(sizeof(*buf));
+    buf->size = initial;
+    buf->data = mallocz(initial);
+    buf->write = 0;
+    buf->read = 0;
+    buf->max_size = max;
+    buf->statistics = statistics;
+
+    if(buf->statistics)
+        __atomic_add_fetch(buf->statistics, sizeof(*buf) + buf->size, __ATOMIC_RELAXED);
+
+    return buf;
 }
 
 void cbuffer_free(struct circular_buffer *buf) {
+    if(buf->statistics)
+        __atomic_sub_fetch(buf->statistics, sizeof(*buf) + buf->size, __ATOMIC_RELAXED);
+
     freez(buf->data);
     freez(buf);
 }
@@ -19,6 +27,8 @@ static int cbuffer_realloc_unsafe(struct circular_buffer *buf) {
     // Check that we can grow
     if (buf->size >= buf->max_size)
         return 1;
+
+    size_t old_size = buf->size;
     size_t new_size = buf->size * 2;
     if (new_size > buf->max_size)
         new_size = buf->max_size;
@@ -43,6 +53,10 @@ static int cbuffer_realloc_unsafe(struct circular_buffer *buf) {
     freez(buf->data);
     buf->data = new_data;
     buf->size = new_size;
+
+    if(buf->statistics)
+        __atomic_sub_fetch(buf->statistics, new_size - old_size, __ATOMIC_RELAXED);
+
     return 0;
 }
 

--- a/libnetdata/circular_buffer/circular_buffer.h
+++ b/libnetdata/circular_buffer/circular_buffer.h
@@ -5,10 +5,11 @@
 
 struct circular_buffer {
     size_t size, write, read, max_size;
+    size_t *statistics;
     char *data;
 };
 
-struct circular_buffer *cbuffer_new(size_t initial, size_t max);
+struct circular_buffer *cbuffer_new(size_t initial, size_t max, size_t *statistics);
 void cbuffer_free(struct circular_buffer *buf);
 int cbuffer_add_unsafe(struct circular_buffer *buf, const char *d, size_t d_len);
 void cbuffer_remove_unsafe(struct circular_buffer *buf, size_t num);

--- a/libnetdata/dictionary/dictionary.c
+++ b/libnetdata/dictionary/dictionary.c
@@ -260,7 +260,7 @@ static inline void pointer_del(DICTIONARY *dict __maybe_unused, DICTIONARY_ITEM 
 
 static inline void DICTIONARY_STATS_PLUS_MEMORY(DICTIONARY *dict, size_t key_size, size_t item_size, size_t value_size) {
     if(key_size)
-        __atomic_fetch_add(&dict->stats->memory.indexed, (long)key_size, __ATOMIC_RELAXED);
+        __atomic_fetch_add(&dict->stats->memory.index, (long)JUDYHS_INDEX_SIZE_ESTIMATE(key_size), __ATOMIC_RELAXED);
 
     if(item_size)
         __atomic_fetch_add(&dict->stats->memory.dict, (long)item_size, __ATOMIC_RELAXED);
@@ -270,7 +270,7 @@ static inline void DICTIONARY_STATS_PLUS_MEMORY(DICTIONARY *dict, size_t key_siz
 }
 static inline void DICTIONARY_STATS_MINUS_MEMORY(DICTIONARY *dict, size_t key_size, size_t item_size, size_t value_size) {
     if(key_size)
-        __atomic_fetch_sub(&dict->stats->memory.indexed, (long)key_size, __ATOMIC_RELAXED);
+        __atomic_fetch_sub(&dict->stats->memory.index, (long)JUDYHS_INDEX_SIZE_ESTIMATE(key_size), __ATOMIC_RELAXED);
 
     if(item_size)
         __atomic_fetch_sub(&dict->stats->memory.dict, (long)item_size, __ATOMIC_RELAXED);
@@ -380,7 +380,7 @@ size_t dictionary_referenced_items(DICTIONARY *dict) {
 
 long int dictionary_stats_for_registry(DICTIONARY *dict) {
     if(unlikely(!dict)) return 0;
-    return (dict->stats->memory.indexed + dict->stats->memory.dict);
+    return (dict->stats->memory.index + dict->stats->memory.dict);
 }
 void dictionary_version_increment(DICTIONARY *dict) {
     __atomic_fetch_add(&dict->version, 1, __ATOMIC_SEQ_CST);

--- a/libnetdata/dictionary/dictionary.h
+++ b/libnetdata/dictionary/dictionary.h
@@ -91,7 +91,7 @@ struct dictionary_stats {
 
     // memory
     struct {
-        long indexed;               // bytes of keys indexed (indication of the index size)
+        long index;               // bytes of keys indexed (indication of the index size)
         long values;                // bytes of caller structures
         long dict;                  // bytes of the structures dictionary needs
     } memory;

--- a/libnetdata/eval/eval.c
+++ b/libnetdata/eval/eval.c
@@ -1126,7 +1126,7 @@ EVAL_EXPRESSION *expression_parse(const char *string, const char **failed_at, in
         return NULL;
     }
 
-    BUFFER *out = buffer_create(1024);
+    BUFFER *out = buffer_create(1024, NULL);
     print_parsed_as_node(out, op, &err);
     if(err != EVAL_ERROR_OK) {
         error("failed to re-generate expression '%s' with reason: %s", string, expression_strerror(err));
@@ -1141,7 +1141,7 @@ EVAL_EXPRESSION *expression_parse(const char *string, const char **failed_at, in
     exp->parsed_as = strdupz(buffer_tostring(out));
     buffer_free(out);
 
-    exp->error_msg = buffer_create(100);
+    exp->error_msg = buffer_create(100, NULL);
     exp->nodes = (void *)op;
 
     return exp;

--- a/libnetdata/json/json.c
+++ b/libnetdata/json/json.c
@@ -90,7 +90,7 @@ jsmntok_t *json_tokenise(char *js, size_t len, size_t *count)
  */
 int json_callback_print(JSON_ENTRY *e)
 {
-    BUFFER *wb=buffer_create(300);
+    BUFFER *wb=buffer_create(300, NULL);
 
     buffer_sprintf(wb,"%s = ", e->name);
     char txt[50];

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -11,6 +11,8 @@ extern "C" {
 #include <config.h>
 #endif
 
+#define JUDYHS_INDEX_SIZE_ESTIMATE(key_bytes) (((key_bytes) + sizeof(Word_t) - 1) / sizeof(Word_t) * 4)
+
 #if defined(NETDATA_DEV_MODE) && !defined(NETDATA_INTERNAL_CHECKS)
 #define NETDATA_INTERNAL_CHECKS 1
 #endif

--- a/libnetdata/onewayalloc/onewayalloc.h
+++ b/libnetdata/onewayalloc/onewayalloc.h
@@ -16,4 +16,6 @@ void onewayalloc_freez(ONEWAYALLOC *owa, const void *ptr);
 
 void *onewayalloc_doublesize(ONEWAYALLOC *owa, const void *src, size_t oldsize);
 
+size_t onewayalloc_allocated_memory(void);
+
 #endif // ONEWAYALLOC_H

--- a/libnetdata/string/string.c
+++ b/libnetdata/string/string.c
@@ -56,14 +56,29 @@ static struct string_hashtable {
 #define string_stats_atomic_decrement(var) __atomic_sub_fetch(&string_base.var, 1, __ATOMIC_RELAXED)
 
 void string_statistics(size_t *inserts, size_t *deletes, size_t *searches, size_t *entries, size_t *references, size_t *memory, size_t *duplications, size_t *releases) {
-    *inserts = string_base.inserts;
-    *deletes = string_base.deletes;
-    *searches = string_base.searches;
-    *entries = (size_t)string_base.entries;
-    *references = (size_t)string_base.active_references;
-    *memory = (size_t)string_base.memory;
-    *duplications = string_base.duplications;
-    *releases = string_base.releases;
+    if(inserts)
+        *inserts = string_base.inserts;
+
+    if(deletes)
+        *deletes = string_base.deletes;
+
+    if(searches)
+        *searches = string_base.searches;
+
+    if(entries)
+        *entries = (size_t)string_base.entries;
+
+    if(references)
+        *references = (size_t)string_base.active_references;
+
+    if(memory)
+        *memory = (size_t)string_base.memory;
+
+    if(duplications)
+        *duplications = string_base.duplications;
+
+    if(releases)
+        *releases = string_base.releases;
 }
 
 #define string_entry_acquire(se) __atomic_add_fetch(&((se)->refcount), 1, __ATOMIC_SEQ_CST);
@@ -186,7 +201,7 @@ static inline STRING *string_index_insert(const char *str, size_t length) {
         *ptr = string;
         string_base.inserts++;
         string_base.entries++;
-        string_base.memory += (long)mem_size;
+        string_base.memory += (long)(mem_size + length * 3); // x3 for Judy
     }
     else {
         // the item is already in the index
@@ -240,7 +255,7 @@ static inline void string_index_delete(STRING *string) {
         size_t mem_size = sizeof(STRING) + string->length;
         string_base.deletes++;
         string_base.entries--;
-        string_base.memory -= (long)mem_size;
+        string_base.memory -= (long)(mem_size + string->length * 3); // x3 for Judy
         freez(string);
     }
 

--- a/libnetdata/string/string.c
+++ b/libnetdata/string/string.c
@@ -201,7 +201,7 @@ static inline STRING *string_index_insert(const char *str, size_t length) {
         *ptr = string;
         string_base.inserts++;
         string_base.entries++;
-        string_base.memory += (long)(mem_size + length * 3); // x3 for Judy
+        string_base.memory += (long)(mem_size + JUDYHS_INDEX_SIZE_ESTIMATE(length));
     }
     else {
         // the item is already in the index
@@ -255,7 +255,7 @@ static inline void string_index_delete(STRING *string) {
         size_t mem_size = sizeof(STRING) + string->length;
         string_base.deletes++;
         string_base.entries--;
-        string_base.memory -= (long)(mem_size + string->length * 3); // x3 for Judy
+        string_base.memory -= (long)(mem_size + JUDYHS_INDEX_SIZE_ESTIMATE(string->length));
         freez(string);
     }
 

--- a/libnetdata/worker_utilization/worker_utilization.h
+++ b/libnetdata/worker_utilization/worker_utilization.h
@@ -15,6 +15,7 @@ typedef enum {
     WORKER_METRIC_INCREMENTAL_TOTAL = 4,
 } WORKER_METRIC_TYPE;
 
+size_t workers_allocated_memory(void);
 void worker_register(const char *name);
 void worker_register_job_name(size_t job_id, const char *name);
 void worker_register_job_custom_metric(size_t job_id, const char *name, const char *units, WORKER_METRIC_TYPE type);

--- a/ml/Query.h
+++ b/ml/Query.h
@@ -8,19 +8,19 @@ namespace ml {
 class Query {
 public:
     Query(RRDDIM *RD) : RD(RD), Initialized(false) {
-        Ops = RD->tiers[0]->query_ops;
+        Ops = RD->tiers[0].query_ops;
     }
 
     time_t latestTime() {
-        return Ops->latest_time_s(RD->tiers[0]->db_metric_handle);
+        return Ops->latest_time_s(RD->tiers[0].db_metric_handle);
     }
 
     time_t oldestTime() {
-        return Ops->oldest_time_s(RD->tiers[0]->db_metric_handle);
+        return Ops->oldest_time_s(RD->tiers[0].db_metric_handle);
     }
 
     void init(time_t AfterT, time_t BeforeT) {
-        Ops->init(RD->tiers[0]->db_metric_handle, &Handle, AfterT, BeforeT, STORAGE_PRIORITY_BEST_EFFORT);
+        Ops->init(RD->tiers[0].db_metric_handle, &Handle, AfterT, BeforeT, STORAGE_PRIORITY_BEST_EFFORT);
         Initialized = true;
         points_read = 0;
     }

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -357,7 +357,7 @@ inline int parser_action(PARSER *parser, char *input)
 
 #ifdef NETDATA_INTERNAL_CHECKS
     if(rc == PARSER_RC_ERROR) {
-        BUFFER *wb = buffer_create(PLUGINSD_LINE_MAX);
+        BUFFER *wb = buffer_create(PLUGINSD_LINE_MAX, NULL);
         for(size_t i = 0; i < num_words ;i++) {
             if(i) buffer_fast_strcat(wb, " ", 1);
 

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -44,6 +44,8 @@ void receiver_state_free(struct receiver_state *rpt) {
     if(rpt->system_info)
         rrdhost_system_info_free(rpt->system_info);
 
+    __atomic_add_fetch(&netdata_buffers_statistics.buffers_streaming, sizeof(*rpt), __ATOMIC_RELAXED);
+
     freez(rpt);
 }
 

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -44,7 +44,7 @@ void receiver_state_free(struct receiver_state *rpt) {
     if(rpt->system_info)
         rrdhost_system_info_free(rpt->system_info);
 
-    __atomic_add_fetch(&netdata_buffers_statistics.buffers_streaming, sizeof(*rpt), __ATOMIC_RELAXED);
+    __atomic_sub_fetch(&netdata_buffers_statistics.rrdhost_receivers, sizeof(*rpt), __ATOMIC_RELAXED);
 
     freez(rpt);
 }

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -170,7 +170,7 @@ static struct replication_query *replication_query_prepare(
         d->rda = dictionary_acquired_item_dup(rd_dfe.dict, rd_dfe.item);
         d->rd = rd;
 
-        q->ops->init(rd->tiers[0]->db_metric_handle, &d->handle, q->query.after, q->query.before,
+        q->ops->init(rd->tiers[0].db_metric_handle, &d->handle, q->query.after, q->query.before,
                      q->query.locked_data_collection ? STORAGE_PRIORITY_HIGH : STORAGE_PRIORITY_LOW);
         d->enabled = true;
         d->skip = false;

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -1553,6 +1553,7 @@ static void *replication_worker_thread(void *ptr) {
 
     while(service_running(SERVICE_REPLICATION)) {
         if(unlikely(replication_execute_next_pending_request() == REQUEST_QUEUE_EMPTY)) {
+            sender_thread_buffer_free();
             worker_is_busy(WORKER_JOB_WAIT);
             worker_is_idle();
             sleep_usec(1 * USEC_PER_SEC);
@@ -1697,6 +1698,7 @@ void *replication_thread_main(void *ptr __maybe_unused) {
             else if(replication_globals.unsafe.pending > 0) {
                 if(replication_globals.unsafe.sender_resets == last_sender_resets) {
                     timeout = 1000 * USEC_PER_MS;
+                    sender_thread_buffer_free();
                 }
                 else {
                     // there are pending requests waiting to be executed,

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -1593,14 +1593,14 @@ void *replication_thread_main(void *ptr __maybe_unused) {
         threads = 1;
     }
 
-    if(threads > 1) {
+    if(--threads) {
         replication_globals.main_thread.threads = threads;
         replication_globals.main_thread.threads_ptrs = mallocz(threads * sizeof(netdata_thread_t *));
         __atomic_add_fetch(&replication_buffers_allocated, threads * sizeof(netdata_thread_t *), __ATOMIC_RELAXED);
 
-        for(int i = 1; i < threads ;i++) {
+        for(int i = 0; i < threads ;i++) {
             char tag[NETDATA_THREAD_TAG_MAX + 1];
-            snprintfz(tag, NETDATA_THREAD_TAG_MAX, "REPLAY[%d]", i + 1);
+            snprintfz(tag, NETDATA_THREAD_TAG_MAX, "REPLAY[%d]", i + 2);
             replication_globals.main_thread.threads_ptrs[i] = mallocz(sizeof(netdata_thread_t));
             __atomic_add_fetch(&replication_buffers_allocated, sizeof(netdata_thread_t), __ATOMIC_RELAXED);
             netdata_thread_create(replication_globals.main_thread.threads_ptrs[i], tag,

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -1691,15 +1691,16 @@ void *replication_thread_main(void *ptr __maybe_unused) {
             // the timeout also defines now frequently we will traverse all the pending requests
             // when the outbound buffers of all senders is full
             usec_t timeout;
-            if(slow)
+            if(slow) {
                 // no work to be done, wait for a request to come in
                 timeout = 1000 * USEC_PER_MS;
+                sender_thread_buffer_free();
+            }
 
             else if(replication_globals.unsafe.pending > 0) {
-                if(replication_globals.unsafe.sender_resets == last_sender_resets) {
+                if(replication_globals.unsafe.sender_resets == last_sender_resets)
                     timeout = 1000 * USEC_PER_MS;
-                    sender_thread_buffer_free();
-                }
+
                 else {
                     // there are pending requests waiting to be executed,
                     // but none could be executed at this time.

--- a/streaming/replication.h
+++ b/streaming/replication.h
@@ -30,4 +30,7 @@ void replication_sender_delete_pending_requests(struct sender_state *sender);
 void replication_add_request(struct sender_state *sender, const char *chart_id, time_t after, time_t before, bool start_streaming);
 void replication_recalculate_buffer_used_ratio_unsafe(struct sender_state *s);
 
+size_t replication_allocated_memory(void);
+size_t replication_allocated_buffers(void);
+
 #endif /* REPLICATION_H */

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -1069,7 +1069,7 @@ static void stream_capabilities_to_string(BUFFER *wb, STREAM_CAPABILITIES caps) 
 }
 
 void log_receiver_capabilities(struct receiver_state *rpt) {
-    BUFFER *wb = buffer_create(100);
+    BUFFER *wb = buffer_create(100, NULL);
     stream_capabilities_to_string(wb, rpt->capabilities);
 
     info("STREAM %s [receive from [%s]:%s]: established link with negotiated capabilities: %s",
@@ -1079,7 +1079,7 @@ void log_receiver_capabilities(struct receiver_state *rpt) {
 }
 
 void log_sender_capabilities(struct sender_state *s) {
-    BUFFER *wb = buffer_create(100);
+    BUFFER *wb = buffer_create(100, NULL);
     stream_capabilities_to_string(wb, s->capabilities);
 
     info("STREAM %s [send to %s]: established link with negotiated capabilities: %s",

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -515,7 +515,7 @@ bool destinations_init_add_one(char *entry, void *data) {
     struct rrdpush_destinations *d = callocz(1, sizeof(struct rrdpush_destinations));
     d->destination = string_strdupz(entry);
 
-    __atomic_add_fetch(&netdata_buffers_statistics.buffers_streaming, sizeof(struct rrdpush_destinations), __ATOMIC_RELAXED);
+    __atomic_add_fetch(&netdata_buffers_statistics.rrdhost_senders, sizeof(struct rrdpush_destinations), __ATOMIC_RELAXED);
 
     DOUBLE_LINKED_LIST_APPEND_UNSAFE(t->list, d, prev, next);
 
@@ -547,7 +547,7 @@ void rrdpush_destinations_free(RRDHOST *host) {
         DOUBLE_LINKED_LIST_REMOVE_UNSAFE(host->destinations, tmp, prev, next);
         string_freez(tmp->destination);
         freez(tmp);
-        __atomic_sub_fetch(&netdata_buffers_statistics.buffers_streaming, sizeof(struct rrdpush_destinations), __ATOMIC_RELAXED);
+        __atomic_sub_fetch(&netdata_buffers_statistics.rrdhost_senders, sizeof(struct rrdpush_destinations), __ATOMIC_RELAXED);
     }
 
     host->destinations = NULL;
@@ -638,8 +638,8 @@ int rrdpush_receiver_thread_spawn(struct web_client *w, char *url) {
     rpt->capabilities = STREAM_CAP_INVALID;
     rpt->hops = 1;
 
-    __atomic_add_fetch(&netdata_buffers_statistics.buffers_streaming, sizeof(*rpt), __ATOMIC_RELAXED);
-    __atomic_sub_fetch(&netdata_buffers_statistics.rrdhost_allocations_size, sizeof(struct rrdhost_system_info), __ATOMIC_RELAXED);
+    __atomic_add_fetch(&netdata_buffers_statistics.rrdhost_receivers, sizeof(*rpt), __ATOMIC_RELAXED);
+    __atomic_add_fetch(&netdata_buffers_statistics.rrdhost_allocations_size, sizeof(struct rrdhost_system_info), __ATOMIC_RELAXED);
 
     rpt->system_info = callocz(1, sizeof(struct rrdhost_system_info));
     rpt->system_info->hops = rpt->hops;

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -373,6 +373,7 @@ bool rrdset_push_chart_definition_now(RRDSET *st) {
     BUFFER *wb = sender_start(host->sender);
     rrdpush_send_chart_definition(wb, st);
     sender_commit(host->sender, wb);
+    sender_thread_buffer_free();
 
     return true;
 }
@@ -437,6 +438,8 @@ void rrdpush_send_host_labels(RRDHOST *host) {
     buffer_sprintf(wb, "OVERWRITE %s\n", "labels");
 
     sender_commit(host->sender, wb);
+
+    sender_thread_buffer_free();
 }
 
 void rrdpush_claimed_id(RRDHOST *host)
@@ -454,6 +457,8 @@ void rrdpush_claimed_id(RRDHOST *host)
 
     rrdhost_aclk_state_unlock(host);
     sender_commit(host->sender, wb);
+
+    sender_thread_buffer_free();
 }
 
 int connect_to_one_of_destinations(

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -189,12 +189,12 @@ struct sender_state {
     struct {
         size_t buffer_used_percentage;          // the current utilization of the sending buffer
         usec_t last_flush_time_ut;              // the last time the sender flushed the sending buffer in USEC
-        bool buffer_recreate;                   // true when the sender buffer should be re-created
+        time_t last_buffer_recreate_s;          // true when the sender buffer should be re-created
     } atomic;
 };
 
-#define rrdpush_sender_buffer_recreate_check(sender) __atomic_load_n(&(sender)->atomic.buffer_recreate, __ATOMIC_RELAXED)
-#define rrdpush_sender_buffer_recreate_set(sender, value) __atomic_store_n(&(sender)->atomic.buffer_recreate, value, __ATOMIC_RELAXED)
+#define rrdpush_sender_last_buffer_recreate_get(sender) __atomic_load_n(&(sender)->atomic.last_buffer_recreate_s, __ATOMIC_RELAXED)
+#define rrdpush_sender_last_buffer_recreate_set(sender, value) __atomic_store_n(&(sender)->atomic.last_buffer_recreate_s, value, __ATOMIC_RELAXED)
 
 #define rrdpush_sender_replication_buffer_full_set(sender, value) __atomic_store_n(&((sender)->replication.atomic.reached_max), value, __ATOMIC_SEQ_CST)
 #define rrdpush_sender_replication_buffer_full_get(sender) __atomic_load_n(&((sender)->replication.atomic.reached_max), __ATOMIC_SEQ_CST)

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -342,6 +342,8 @@ int32_t stream_capabilities_to_vn(uint32_t caps);
 void receiver_state_free(struct receiver_state *rpt);
 bool stop_streaming_receiver(RRDHOST *host, const char *reason);
 
+void sender_thread_buffer_free(void);
+
 #include "replication.h"
 
 #endif //NETDATA_RRDPUSH_H

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -10,7 +10,7 @@
 
 #define CONNECTED_TO_SIZE 100
 #define CBUFFER_INITIAL_SIZE (16 * 1024)
-#define THREAD_BUFFER_INITIAL_SIZE (CBUFFER_INITIAL_SIZE * 4)
+#define THREAD_BUFFER_INITIAL_SIZE (CBUFFER_INITIAL_SIZE / 4)
 
 // ----------------------------------------------------------------------------
 // obsolete versions - do not use anymore
@@ -131,8 +131,8 @@ struct decompressor_state {
     // Metric transmission: collector threads asynchronously fill the buffer, sender thread uses it.
 
 typedef enum {
-    SENDER_FLAG_OVERFLOW    = (1 << 0), // The buffer has been overflown
-    SENDER_FLAG_COMPRESSION = (1 << 1), // The stream needs to have and has compression
+    SENDER_FLAG_OVERFLOW     = (1 << 0), // The buffer has been overflown
+    SENDER_FLAG_COMPRESSION  = (1 << 1), // The stream needs to have and has compression
 } SENDER_FLAGS;
 
 struct sender_state {
@@ -189,8 +189,12 @@ struct sender_state {
     struct {
         size_t buffer_used_percentage;          // the current utilization of the sending buffer
         usec_t last_flush_time_ut;              // the last time the sender flushed the sending buffer in USEC
+        bool buffer_recreate;                   // true when the sender buffer should be re-created
     } atomic;
 };
+
+#define rrdpush_sender_buffer_recreate_check(sender) __atomic_load_n(&(sender)->atomic.buffer_recreate, __ATOMIC_RELAXED)
+#define rrdpush_sender_buffer_recreate_set(sender, value) __atomic_store_n(&(sender)->atomic.buffer_recreate, value, __ATOMIC_RELAXED)
 
 #define rrdpush_sender_replication_buffer_full_set(sender, value) __atomic_store_n(&((sender)->replication.atomic.reached_max), value, __ATOMIC_SEQ_CST)
 #define rrdpush_sender_replication_buffer_full_get(sender) __atomic_load_n(&((sender)->replication.atomic.reached_max), __ATOMIC_SEQ_CST)
@@ -296,7 +300,6 @@ void rrdpush_destinations_free(RRDHOST *host);
 
 BUFFER *sender_start(struct sender_state *s);
 void sender_commit(struct sender_state *s, BUFFER *wb);
-void sender_cancel(struct sender_state *s);
 int rrdpush_init();
 bool rrdpush_receiver_needs_dbengine();
 int configured_as_parent();

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -10,7 +10,7 @@
 
 #define CONNECTED_TO_SIZE 100
 #define CBUFFER_INITIAL_SIZE (16 * 1024)
-#define THREAD_BUFFER_INITIAL_SIZE (CBUFFER_INITIAL_SIZE / 4)
+#define THREAD_BUFFER_INITIAL_SIZE (CBUFFER_INITIAL_SIZE / 2)
 
 // ----------------------------------------------------------------------------
 // obsolete versions - do not use anymore

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -57,7 +57,7 @@ BUFFER *sender_start(struct sender_state *s __maybe_unused) {
     }
 
     if(!sender_thread_buffer) {
-        sender_thread_buffer = buffer_create(THREAD_BUFFER_INITIAL_SIZE);
+        sender_thread_buffer = buffer_create(THREAD_BUFFER_INITIAL_SIZE, &netdata_buffers_statistics.buffers_streaming);
         sender_thread_buffer_recreate = false;
     }
 
@@ -932,7 +932,7 @@ void execute_commands(struct sender_state *s) {
                 tmp->received_ut = now_realtime_usec();
                 tmp->sender = s;
                 tmp->transaction = string_strdupz(transaction);
-                BUFFER *wb = buffer_create(PLUGINSD_LINE_MAX + 1);
+                BUFFER *wb = buffer_create(PLUGINSD_LINE_MAX + 1, &netdata_buffers_statistics.buffers_functions);
 
                 int code = rrd_call_function_async(s->host, wb, timeout, function, stream_execute_function_callback, tmp);
                 if(code != HTTP_RESP_OK) {
@@ -1271,7 +1271,7 @@ void *rrdpush_sender_thread(void *ptr) {
                 last_reset_time_t = now_t;
                 size_t max = s->host->sender->buffer->max_size;
                 cbuffer_free(s->host->sender->buffer);
-                s->host->sender->buffer = cbuffer_new(CBUFFER_INITIAL_SIZE, max);
+                s->host->sender->buffer = cbuffer_new(CBUFFER_INITIAL_SIZE, max, &netdata_buffers_statistics.buffers_streaming);
                 sender_thread_buffer_recreate = true;
             }
         }

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -1271,7 +1271,7 @@ void *rrdpush_sender_thread(void *ptr) {
                 last_reset_time_t = now_t;
                 size_t max = s->host->sender->buffer->max_size;
                 cbuffer_free(s->host->sender->buffer);
-                s->host->sender->buffer = cbuffer_new(CBUFFER_INITIAL_SIZE, max, &netdata_buffers_statistics.buffers_streaming);
+                s->host->sender->buffer = cbuffer_new(CBUFFER_INITIAL_SIZE, max, &netdata_buffers_statistics.cbuffers_streaming);
                 sender_thread_buffer_recreate = true;
             }
         }

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -264,6 +264,8 @@ static void rrdpush_sender_cbuffer_recreate_timed(struct sender_state *s, time_t
         s->buffer = cbuffer_new(CBUFFER_INITIAL_SIZE, max, &netdata_buffers_statistics.cbuffers_streaming);
     }
 
+    sender_thread_buffer_free();
+
     if(!have_mutex)
         netdata_mutex_unlock(&s->mutex);
 }

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -191,6 +191,7 @@ void rrdpush_sender_send_this_host_variable_now(RRDHOST *host, const RRDVAR_ACQU
         BUFFER *wb = sender_start(host->sender);
         rrdpush_sender_add_host_variable_to_buffer(wb, rva);
         sender_commit(host->sender, wb);
+        sender_thread_buffer_free();
     }
 }
 
@@ -219,6 +220,7 @@ static void rrdpush_sender_thread_send_custom_host_variables(RRDHOST *host) {
         int ret = rrdvar_walkthrough_read(host->rrdvars, rrdpush_sender_thread_custom_host_variables_callback, &tmp);
         (void)ret;
         sender_commit(host->sender, wb);
+        sender_thread_buffer_free();
 
         debug(D_STREAM, "RRDVAR sent %d VARIABLES", ret);
     }
@@ -897,6 +899,7 @@ void stream_execute_function_callback(BUFFER *func_wb, int code, void *data) {
         pluginsd_function_result_end_to_buffer(wb);
 
         sender_commit(s, wb);
+        sender_thread_buffer_free();
 
         internal_error(true, "STREAM %s [send to %s] FUNCTION transaction %s sending back response (%zu bytes, %llu usec).",
                        rrdhost_hostname(s->host), s->connected_to,

--- a/web/api/badges/web_buffer_svg.c
+++ b/web/api/badges/web_buffer_svg.c
@@ -913,7 +913,7 @@ int web_client_api_request_v1_badge(RRDHOST *host, struct web_client *w, char *u
         if(!strcmp(name, "chart")) chart = value;
         else if(!strcmp(name, "dimension") || !strcmp(name, "dim") || !strcmp(name, "dimensions") || !strcmp(name, "dims")) {
             if(!dimensions)
-                dimensions = buffer_create(100);
+                dimensions = buffer_create(100, &netdata_buffers_statistics.buffers_api);
 
             buffer_strcat(dimensions, "|");
             buffer_strcat(dimensions, value);

--- a/web/api/health/health_cmdapi.c
+++ b/web/api/health/health_cmdapi.c
@@ -196,7 +196,7 @@ int web_client_api_request_v1_mgmt_health(RRDHOST *host, struct web_client *w, c
     w->response.data = wb;
     buffer_no_cacheable(w->response.data);
     if (ret == HTTP_RESP_OK && config_changed) {
-        BUFFER *jsonb = buffer_create(200);
+        BUFFER *jsonb = buffer_create(200, &netdata_buffers_statistics.buffers_health);
         health_silencers2json(jsonb);
         health_silencers2file(jsonb);
         buffer_free(jsonb);

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -1550,7 +1550,7 @@ void rrdr_fill_tier_gap_from_smaller_tiers(RRDDIM *rd, size_t tier, time_t now_s
     if(unlikely(tier >= storage_tiers)) return;
     if(storage_tiers_backfill[tier] == RRD_BACKFILL_NONE) return;
 
-    struct rrddim_tier *t = rd->tiers[tier];
+    struct rrddim_tier *t = &rd->tiers[tier];
     if(unlikely(!t)) return;
 
     time_t latest_time_s = t->query_ops->latest_time_s(t->db_metric_handle);
@@ -1567,14 +1567,14 @@ void rrdr_fill_tier_gap_from_smaller_tiers(RRDDIM *rd, size_t tier, time_t now_s
 
     // for each lower tier
     for(int read_tier = (int)tier - 1; read_tier >= 0 ; read_tier--){
-        time_t smaller_tier_first_time = rd->tiers[read_tier]->query_ops->oldest_time_s(rd->tiers[read_tier]->db_metric_handle);
-        time_t smaller_tier_last_time = rd->tiers[read_tier]->query_ops->latest_time_s(rd->tiers[read_tier]->db_metric_handle);
+        time_t smaller_tier_first_time = rd->tiers[read_tier].query_ops->oldest_time_s(rd->tiers[read_tier].db_metric_handle);
+        time_t smaller_tier_last_time = rd->tiers[read_tier].query_ops->latest_time_s(rd->tiers[read_tier].db_metric_handle);
         if(smaller_tier_last_time <= latest_time_s) continue;  // it is as bad as we are
 
         long after_wanted = (latest_time_s < smaller_tier_first_time) ? smaller_tier_first_time : latest_time_s;
         long before_wanted = smaller_tier_last_time;
 
-        struct rrddim_tier *tmp = rd->tiers[read_tier];
+        struct rrddim_tier *tmp = &rd->tiers[read_tier];
         tmp->query_ops->init(tmp->db_metric_handle, &handle, after_wanted, before_wanted, STORAGE_PRIORITY_HIGH);
 
         size_t points_read = 0;

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -312,7 +312,7 @@ inline int web_client_api_request_v1_alarm_count(RRDHOST *host, struct web_clien
             else if (!strcmp("CLEAR", value)) status = RRDCALC_STATUS_CLEAR;
         }
         else if(!strcmp(name, "context") || !strcmp(name, "ctx")) {
-            if(!contexts) contexts = buffer_create(255);
+            if(!contexts) contexts = buffer_create(255, &netdata_buffers_statistics.buffers_api);
             buffer_strcat(contexts, "|");
             buffer_strcat(contexts, value);
         }
@@ -460,7 +460,7 @@ static int web_client_api_request_v1_context(RRDHOST *host, struct web_client *w
         else if(!strcmp(name, "chart_label_key")) chart_label_key = value;
         else if(!strcmp(name, "chart_labels_filter")) chart_labels_filter = value;
         else if(!strcmp(name, "dimension") || !strcmp(name, "dim") || !strcmp(name, "dimensions") || !strcmp(name, "dims")) {
-            if(!dimensions) dimensions = buffer_create(100);
+            if(!dimensions) dimensions = buffer_create(100, &netdata_buffers_statistics.buffers_api);
             buffer_strcat(dimensions, "|");
             buffer_strcat(dimensions, value);
         }
@@ -521,7 +521,7 @@ static int web_client_api_request_v1_contexts(RRDHOST *host, struct web_client *
         else if(!strcmp(name, "chart_label_key")) chart_label_key = value;
         else if(!strcmp(name, "chart_labels_filter")) chart_labels_filter = value;
         else if(!strcmp(name, "dimension") || !strcmp(name, "dim") || !strcmp(name, "dimensions") || !strcmp(name, "dims")) {
-            if(!dimensions) dimensions = buffer_create(100);
+            if(!dimensions) dimensions = buffer_create(100, &netdata_buffers_statistics.buffers_api);
             buffer_strcat(dimensions, "|");
             buffer_strcat(dimensions, value);
         }
@@ -638,7 +638,7 @@ inline int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, c
         else if(!strcmp(name, "chart_labels_filter")) chart_labels_filter = value;
         else if(!strcmp(name, "chart")) chart = value;
         else if(!strcmp(name, "dimension") || !strcmp(name, "dim") || !strcmp(name, "dimensions") || !strcmp(name, "dims")) {
-            if(!dimensions) dimensions = buffer_create(100);
+            if(!dimensions) dimensions = buffer_create(100, &netdata_buffers_statistics.buffers_api);
             buffer_strcat(dimensions, "|");
             buffer_strcat(dimensions, value);
         }

--- a/web/server/web_client_cache.c
+++ b/web/server/web_client_cache.c
@@ -65,13 +65,15 @@ static void web_client_free(struct web_client *w) {
     }
 #endif
     freez(w);
+    __atomic_sub_fetch(&netdata_buffers_statistics.buffers_web, sizeof(struct web_client), __ATOMIC_RELAXED);
 }
 
 static struct web_client *web_client_alloc(void) {
     struct web_client *w = callocz(1, sizeof(struct web_client));
-    w->response.data = buffer_create(NETDATA_WEB_RESPONSE_INITIAL_SIZE);
-    w->response.header = buffer_create(NETDATA_WEB_RESPONSE_HEADER_SIZE);
-    w->response.header_output = buffer_create(NETDATA_WEB_RESPONSE_HEADER_SIZE);
+    __atomic_add_fetch(&netdata_buffers_statistics.buffers_web, sizeof(struct web_client), __ATOMIC_RELAXED);
+    w->response.data = buffer_create(NETDATA_WEB_RESPONSE_INITIAL_SIZE, &netdata_buffers_statistics.buffers_web);
+    w->response.header = buffer_create(NETDATA_WEB_RESPONSE_HEADER_SIZE, &netdata_buffers_statistics.buffers_web);
+    w->response.header_output = buffer_create(NETDATA_WEB_RESPONSE_HEADER_SIZE, &netdata_buffers_statistics.buffers_web);
     return w;
 }
 

--- a/web/server/web_server.c
+++ b/web/server/web_server.c
@@ -37,7 +37,7 @@ LISTEN_SOCKETS api_sockets = {
 };
 
 void debug_sockets() {
-	BUFFER *wb = buffer_create(256 * sizeof(char));
+	BUFFER *wb = buffer_create(256 * sizeof(char), NULL);
 	int i;
 
 	for(i = 0 ; i < (int)api_sockets.opened ; i++) {


### PR DESCRIPTION
Goal: break-down memory allocations by high level function, so that we can all understand where memory goes.

- [x] categorize dictionaries according to their function (hosts, rrdset/rrddim, health, functions, contexts, etc)
- [x] categorize all long-running `BUFFER`s
- [x] track query targets caching
- [x] track `rrdset_done()` RDA structures
- [x] track streaming buffers
- [x] track db mode alloc/ram/save/map memory allocations
- [x] track onewayalloc
- [x] track workers
- [x] track replication
- [x] unify JudyHS index size estimation

Example chart:

![image](https://user-images.githubusercontent.com/2662304/213314612-cbe6988c-dfc6-4557-be56-a3e418771db4.png)

## Problems solved

1. There was a tiny memory leak on db modes other than dbengine, when a dimension is no longer collected
2. replication buffers were maintained after replication finished
3. streaming sender buffers were never reset / emptied
4. metasync was checking all nodes every 30 secs
5. A couple of JudyGet have been eliminated since immediately after them we were doing JudyIns
6. dbengine shutdown some times was happening in parallel with the last extent flush - fixed it
7. renaming of threads with PR #14289 had a side effect, crashing replication on exit because of an out of bounds array access - fixed it.