### PR TITLE
Fixes required to make the agent work without crashes on MacOS

### DIFF
--- a/database/engine/journalfile.c
+++ b/database/engine/journalfile.c
@@ -213,10 +213,10 @@ static bool journalfile_v2_mounted_data_unmount(struct rrdengine_journalfile *jo
     return unmounted;
 }
 
-void journalfile_v2_data_unmount_cleanup(time_t now_s) {
+void journalfile_v2_data_unmount_cleanup(time_t now_s, int storage_tiers) {
     // DO NOT WAIT ON ANY LOCK!!!
 
-    for(size_t tier = 0; tier < RRD_STORAGE_TIERS ;tier++) {
+    for(size_t tier = 0; tier < storage_tiers ;tier++) {
         struct rrdengine_instance *ctx = multidb_ctx[tier];
         if(!ctx) continue;
 

--- a/database/engine/journalfile.h
+++ b/database/engine/journalfile.h
@@ -152,6 +152,6 @@ size_t journalfile_v2_data_size_get(struct rrdengine_journalfile *journalfile);
 void journalfile_v2_data_set(struct rrdengine_journalfile *journalfile, int fd, void *journal_data, uint32_t journal_data_size);
 struct journal_v2_header *journalfile_v2_data_acquire(struct rrdengine_journalfile *journalfile, size_t *data_size, time_t wanted_first_time_s, time_t wanted_last_time_s);
 void journalfile_v2_data_release(struct rrdengine_journalfile *journalfile);
-void journalfile_v2_data_unmount_cleanup(time_t now_s);
+void journalfile_v2_data_unmount_cleanup(time_t now_s, int storage_tiers);
 
 #endif /* NETDATA_JOURNALFILE_H */

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -1487,7 +1487,7 @@ void timer_cb(uv_timer_t* handle) {
         time_t now_s = now_monotonic_sec();
         if(now_s - last_run_s >= 10) {
             last_run_s = now_s;
-            journalfile_v2_data_unmount_cleanup(now_s);
+            journalfile_v2_data_unmount_cleanup(now_s, storage_tiers);
         }
     }
 


### PR DESCRIPTION
##### Summary

The agent would crash on startup on MacOS systems because:

1. The default soft limit of open file descriptors was too low,
2. `journalfile_v2_mounted_data_unmount()` would iterate tiers that have not been initialized.

##### Test Plan

- CI jobs
- Build the agent and run it on MacOS.