### PR TITLE
Add Collector log

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -4850,6 +4850,7 @@ void *reader_main(void *arg __maybe_unused) {
 
 int main(int argc, char **argv) {
     // debug_flags = D_PROCFILE;
+    stderror = stderr;
 
     clocks_init();
 

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -174,9 +174,9 @@ static enum cgroups_systemd_setting cgroups_detect_systemd(const char *exec)
     }
 
     if (ret == -1) {
-        error("Failed to get the output of \"%s\"", exec);
+        collector_error("Failed to get the output of \"%s\"", exec);
     } else if (ret == 0) {
-        info("Cannot get the output of \"%s\" within %"PRId64" seconds", exec, (int64_t)timeout.tv_sec);
+        collector_info("Cannot get the output of \"%s\" within %"PRId64" seconds", exec, (int64_t)timeout.tv_sec);
     } else {
         while (fgets(buf, MAXSIZE_PROC_CMDLINE, fp_child_output) != NULL) {
             if ((begin = strstr(buf, SYSTEMD_HIERARCHY_STRING))) {
@@ -214,7 +214,7 @@ static enum cgroups_type cgroups_try_detect_version()
     FILE *fp_child_input;
     FILE *fp_child_output = netdata_popen("grep cgroup /proc/filesystems", &command_pid, &fp_child_input);
     if (!fp_child_output) {
-        error("popen failed");
+        collector_error("popen failed");
         return CGROUPS_AUTODETECT_FAIL;
     }
     while (fgets(buf, MAXSIZE_PROC_CMDLINE, fp_child_output) != NULL) {
@@ -258,12 +258,12 @@ static enum cgroups_type cgroups_try_detect_version()
     //    check kernel command line flag that can override that setting
     FILE *fp = fopen("/proc/cmdline", "r");
     if (!fp) {
-        error("Error reading kernel boot commandline parameters");
+        collector_error("Error reading kernel boot commandline parameters");
         return CGROUPS_AUTODETECT_FAIL;
     }
 
     if (!fgets(buf, MAXSIZE_PROC_CMDLINE, fp)) {
-        error("couldn't read all cmdline params into buffer");
+        collector_error("couldn't read all cmdline params into buffer");
         fclose(fp);
         return CGROUPS_AUTODETECT_FAIL;
     }
@@ -271,7 +271,7 @@ static enum cgroups_type cgroups_try_detect_version()
     fclose(fp);
 
     if (strstr(buf, "systemd.unified_cgroup_hierarchy=0")) {
-        info("cgroups v2 (unified cgroups) is available but are disabled on this system.");
+        collector_info("cgroups v2 (unified cgroups) is available but are disabled on this system.");
         return CGROUPS_V1;
     }
     return CGROUPS_V2;
@@ -311,7 +311,7 @@ void read_cgroup_plugin_configuration() {
     if(cgroup_use_unified_cgroups == CONFIG_BOOLEAN_AUTO)
         cgroup_use_unified_cgroups = (cgroups_try_detect_version() == CGROUPS_V2);
 
-    info("use unified cgroups %s", cgroup_use_unified_cgroups ? "true" : "false");
+    collector_info("use unified cgroups %s", cgroup_use_unified_cgroups ? "true" : "false");
 
     cgroup_containers_chart_priority = (int)config_get_number("plugin:cgroups", "containers priority", cgroup_containers_chart_priority);
     if(cgroup_containers_chart_priority < 1)
@@ -361,7 +361,7 @@ void read_cgroup_plugin_configuration() {
         mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "cpuacct");
         if(!mi) mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "cpuacct");
         if(!mi) {
-            error("CGROUP: cannot find cpuacct mountinfo. Assuming default: /sys/fs/cgroup/cpuacct");
+            collector_error("CGROUP: cannot find cpuacct mountinfo. Assuming default: /sys/fs/cgroup/cpuacct");
             s = "/sys/fs/cgroup/cpuacct";
         }
         else s = mi->mount_point;
@@ -371,7 +371,7 @@ void read_cgroup_plugin_configuration() {
         mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "cpuset");
         if(!mi) mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "cpuset");
         if(!mi) {
-            error("CGROUP: cannot find cpuset mountinfo. Assuming default: /sys/fs/cgroup/cpuset");
+            collector_error("CGROUP: cannot find cpuset mountinfo. Assuming default: /sys/fs/cgroup/cpuset");
             s = "/sys/fs/cgroup/cpuset";
         }
         else s = mi->mount_point;
@@ -381,7 +381,7 @@ void read_cgroup_plugin_configuration() {
         mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "blkio");
         if(!mi) mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "blkio");
         if(!mi) {
-            error("CGROUP: cannot find blkio mountinfo. Assuming default: /sys/fs/cgroup/blkio");
+            collector_error("CGROUP: cannot find blkio mountinfo. Assuming default: /sys/fs/cgroup/blkio");
             s = "/sys/fs/cgroup/blkio";
         }
         else s = mi->mount_point;
@@ -391,7 +391,7 @@ void read_cgroup_plugin_configuration() {
         mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "memory");
         if(!mi) mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "memory");
         if(!mi) {
-            error("CGROUP: cannot find memory mountinfo. Assuming default: /sys/fs/cgroup/memory");
+            collector_error("CGROUP: cannot find memory mountinfo. Assuming default: /sys/fs/cgroup/memory");
             s = "/sys/fs/cgroup/memory";
         }
         else s = mi->mount_point;
@@ -401,7 +401,7 @@ void read_cgroup_plugin_configuration() {
         mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "devices");
         if(!mi) mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "devices");
         if(!mi) {
-            error("CGROUP: cannot find devices mountinfo. Assuming default: /sys/fs/cgroup/devices");
+            collector_error("CGROUP: cannot find devices mountinfo. Assuming default: /sys/fs/cgroup/devices");
             s = "/sys/fs/cgroup/devices";
         }
         else s = mi->mount_point;
@@ -433,7 +433,7 @@ void read_cgroup_plugin_configuration() {
             if(mi) debug(D_CGROUP, "found unified cgroup root using mountsource info, with path: '%s'", mi->mount_point);
         }
         if(!mi) {
-            error("CGROUP: cannot find cgroup2 mountinfo. Assuming default: /sys/fs/cgroup");
+            collector_error("CGROUP: cannot find cgroup2 mountinfo. Assuming default: /sys/fs/cgroup");
             s = "/sys/fs/cgroup";
         }
         else s = mi->mount_point;
@@ -575,13 +575,13 @@ void netdata_cgroup_ebpf_initialize_shm()
 {
     shm_fd_cgroup_ebpf = shm_open(NETDATA_SHARED_MEMORY_EBPF_CGROUP_NAME, O_CREAT | O_RDWR, 0660);
     if (shm_fd_cgroup_ebpf < 0) {
-        error("Cannot initialize shared memory used by cgroup and eBPF, integration won't happen.");
+        collector_error("Cannot initialize shared memory used by cgroup and eBPF, integration won't happen.");
         return;
     }
 
     size_t length = sizeof(netdata_ebpf_cgroup_shm_header_t) + cgroup_root_max * sizeof(netdata_ebpf_cgroup_shm_body_t);
     if (ftruncate(shm_fd_cgroup_ebpf, length)) {
-        error("Cannot set size for shared memory.");
+        collector_error("Cannot set size for shared memory.");
         goto end_init_shm;
     }
 
@@ -590,7 +590,7 @@ void netdata_cgroup_ebpf_initialize_shm()
                                                                        shm_fd_cgroup_ebpf, 0);
 
     if (!shm_cgroup_ebpf.header) {
-        error("Cannot map shared memory used between cgroup and eBPF, integration won't happen");
+        collector_error("Cannot map shared memory used between cgroup and eBPF, integration won't happen");
         goto end_init_shm;
     }
     shm_cgroup_ebpf.body = (netdata_ebpf_cgroup_shm_body_t *) ((char *)shm_cgroup_ebpf.header +
@@ -604,7 +604,7 @@ void netdata_cgroup_ebpf_initialize_shm()
         return;
     }
 
-    error("Cannot create semaphore, integration between eBPF and cgroup won't happen");
+    collector_error("Cannot create semaphore, integration between eBPF and cgroup won't happen");
     munmap(shm_cgroup_ebpf.header, length);
 
 end_init_shm:
@@ -1077,7 +1077,7 @@ static inline void cgroup_read_cpuacct_stat(struct cpuacct_stat *cp) {
         unsigned long i, lines = procfile_lines(ff);
 
         if(unlikely(lines < 1)) {
-            error("CGROUP: file '%s' should have 1+ lines.", cp->filename);
+            collector_error("CGROUP: file '%s' should have 1+ lines.", cp->filename);
             cp->updated = 0;
             return;
         }
@@ -1123,7 +1123,7 @@ static inline void cgroup_read_cpuacct_cpu_stat(struct cpuacct_cpu_throttling *c
 
     unsigned long lines = procfile_lines(ff);
     if (unlikely(lines < 3)) {
-        error("CGROUP: file '%s' should have 3 lines.", cp->filename);
+        collector_error("CGROUP: file '%s' should have 3 lines.", cp->filename);
         cp->updated = 0;
         return;
     }
@@ -1180,7 +1180,7 @@ static inline void cgroup2_read_cpuacct_cpu_stat(struct cpuacct_stat *cp, struct
     unsigned long lines = procfile_lines(ff);
 
     if (unlikely(lines < 3)) {
-        error("CGROUP: file '%s' should have at least 3 lines.", cp->filename);
+        collector_error("CGROUP: file '%s' should have at least 3 lines.", cp->filename);
         cp->updated = 0;
         return;
     }
@@ -1261,7 +1261,7 @@ static inline void cgroup_read_cpuacct_usage(struct cpuacct_usage *ca) {
         }
 
         if(unlikely(procfile_lines(ff) < 1)) {
-            error("CGROUP: file '%s' should have 1+ lines but has %zu.", ca->filename, procfile_lines(ff));
+            collector_error("CGROUP: file '%s' should have 1+ lines but has %zu.", ca->filename, procfile_lines(ff));
             ca->updated = 0;
             return;
         }
@@ -1326,7 +1326,7 @@ static inline void cgroup_read_blkio(struct blkio *io) {
         unsigned long i, lines = procfile_lines(ff);
 
         if(unlikely(lines < 1)) {
-            error("CGROUP: file '%s' should have 1+ lines.", io->filename);
+            collector_error("CGROUP: file '%s' should have 1+ lines.", io->filename);
             io->updated = 0;
             return;
         }
@@ -1398,7 +1398,7 @@ static inline void cgroup2_read_blkio(struct blkio *io, unsigned int word_offset
             unsigned long i, lines = procfile_lines(ff);
 
             if (unlikely(lines < 1)) {
-                error("CGROUP: file '%s' should have 1+ lines.", io->filename);
+                collector_error("CGROUP: file '%s' should have 1+ lines.", io->filename);
                 io->updated = 0;
                 return;
             }
@@ -1442,7 +1442,7 @@ static inline void cgroup2_read_pressure(struct pressure *res) {
 
         size_t lines = procfile_lines(ff);
         if (lines < 1) {
-            error("CGROUP: file '%s' should have 1+ lines.", res->filename);
+            collector_error("CGROUP: file '%s' should have 1+ lines.", res->filename);
             res->updated = 0;
             return;
         }
@@ -1499,7 +1499,7 @@ static inline void cgroup_read_memory(struct memory *mem, char parent_cg_is_unif
         unsigned long i, lines = procfile_lines(ff);
 
         if(unlikely(lines < 1)) {
-            error("CGROUP: file '%s' should have 1+ lines.", mem->filename_detailed);
+            collector_error("CGROUP: file '%s' should have 1+ lines.", mem->filename_detailed);
             mem->updated_detailed = 0;
             goto memory_next;
         }
@@ -1669,7 +1669,7 @@ static inline void read_cgroup_network_interfaces(struct cgroup *cg) {
     FILE *fp_child_input, *fp_child_output;
     (void)netdata_popen_raw_default_flags_and_environment(&cgroup_pid, &fp_child_input, &fp_child_output, cgroups_network_interface_script, "--cgroup", cgroup_identifier);
     if(!fp_child_output) {
-        error("CGROUP: cannot popen(%s --cgroup \"%s\", \"r\").", cgroups_network_interface_script, cgroup_identifier);
+        collector_error("CGROUP: cannot popen(%s --cgroup \"%s\", \"r\").", cgroups_network_interface_script, cgroup_identifier);
         return;
     }
 
@@ -1687,12 +1687,12 @@ static inline void read_cgroup_network_interfaces(struct cgroup *cg) {
             }
 
             if(!*s) {
-                error("CGROUP: empty host interface returned by script");
+                collector_error("CGROUP: empty host interface returned by script");
                 continue;
             }
 
             if(!*t) {
-                error("CGROUP: empty guest interface returned by script");
+                collector_error("CGROUP: empty guest interface returned by script");
                 continue;
             }
 
@@ -1702,7 +1702,7 @@ static inline void read_cgroup_network_interfaces(struct cgroup *cg) {
             i->next = cg->interfaces;
             cg->interfaces = i;
 
-            info("CGROUP: cgroup '%s' has network interface '%s' as '%s'", cg->id, i->host_device, i->container_device);
+            collector_info("CGROUP: cgroup '%s' has network interface '%s' as '%s'", cg->id, i->host_device, i->container_device);
 
             // register a device rename to proc_net_dev.c
             netdev_rename_device_add(
@@ -1875,7 +1875,7 @@ static inline void discovery_rename_cgroup(struct cgroup *cg) {
     FILE *fp_child_input, *fp_child_output;
     (void)netdata_popen_raw_default_flags_and_environment(&cgroup_pid, &fp_child_input, &fp_child_output, cgroups_rename_script, cg->id, cg->intermediate_id);
     if (!fp_child_output) {
-        error("CGROUP: cannot popen(%s \"%s\", \"r\").", cgroups_rename_script, cg->intermediate_id);
+        collector_error("CGROUP: cannot popen(%s \"%s\", \"r\").", cgroups_rename_script, cg->intermediate_id);
         cg->pending_renames = 0;
         cg->processed = 1;
         return;
@@ -2034,14 +2034,14 @@ static inline void discovery_find_cgroup_in_dir_callback(const char *dir) {
     }
 
     if (cgroup_root_count >= cgroup_root_max) {
-        info("CGROUP: maximum number of cgroups reached (%d). Not adding cgroup '%s'", cgroup_root_count, dir);
+        collector_info("CGROUP: maximum number of cgroups reached (%d). Not adding cgroup '%s'", cgroup_root_count, dir);
         return;
     }
 
     if (cgroup_max_depth > 0) {
         int depth = calc_cgroup_depth(dir);
         if (depth > cgroup_max_depth) {
-            info("CGROUP: '%s' is too deep (%d, while max is %d)", dir, depth, cgroup_max_depth);
+            collector_info("CGROUP: '%s' is too deep (%d, while max is %d)", dir, depth, cgroup_max_depth);
             return;
         }
     }
@@ -2066,7 +2066,7 @@ static inline int discovery_find_dir_in_subdirs(const char *base, const char *th
 
     DIR *dir = opendir(this);
     if(!dir) {
-        error("CGROUP: cannot read directory '%s'", base);
+        collector_error("CGROUP: cannot read directory '%s'", base);
         return ret;
     }
     ret = 1;
@@ -2550,7 +2550,7 @@ static inline void discovery_find_all_cgroups_v1() {
     if (cgroup_enable_cpuacct_stat || cgroup_enable_cpuacct_usage) {
         if (discovery_find_dir_in_subdirs(cgroup_cpuacct_base, NULL, discovery_find_cgroup_in_dir_callback) == -1) {
             cgroup_enable_cpuacct_stat = cgroup_enable_cpuacct_usage = CONFIG_BOOLEAN_NO;
-            error("CGROUP: disabled cpu statistics.");
+            collector_error("CGROUP: disabled cpu statistics.");
         }
     }
 
@@ -2560,7 +2560,7 @@ static inline void discovery_find_all_cgroups_v1() {
             cgroup_enable_blkio_io = cgroup_enable_blkio_ops = cgroup_enable_blkio_throttle_io =
                 cgroup_enable_blkio_throttle_ops = cgroup_enable_blkio_merged_ops = cgroup_enable_blkio_queued_ops =
                     CONFIG_BOOLEAN_NO;
-            error("CGROUP: disabled blkio statistics.");
+            collector_error("CGROUP: disabled blkio statistics.");
         }
     }
 
@@ -2568,14 +2568,14 @@ static inline void discovery_find_all_cgroups_v1() {
         if (discovery_find_dir_in_subdirs(cgroup_memory_base, NULL, discovery_find_cgroup_in_dir_callback) == -1) {
             cgroup_enable_memory = cgroup_enable_detailed_memory = cgroup_enable_swap = cgroup_enable_memory_failcnt =
                 CONFIG_BOOLEAN_NO;
-            error("CGROUP: disabled memory statistics.");
+            collector_error("CGROUP: disabled memory statistics.");
         }
     }
 
     if (cgroup_search_in_devices) {
         if (discovery_find_dir_in_subdirs(cgroup_devices_base, NULL, discovery_find_cgroup_in_dir_callback) == -1) {
             cgroup_search_in_devices = 0;
-            error("CGROUP: disabled devices statistics.");
+            collector_error("CGROUP: disabled devices statistics.");
         }
     }
 }
@@ -2583,7 +2583,7 @@ static inline void discovery_find_all_cgroups_v1() {
 static inline void discovery_find_all_cgroups_v2() {
     if (discovery_find_dir_in_subdirs(cgroup_unified_base, NULL, discovery_find_cgroup_in_dir_callback) == -1) {
         cgroup_unified_exist = CONFIG_BOOLEAN_NO;
-        error("CGROUP: disabled unified cgroups statistics.");
+        collector_error("CGROUP: disabled unified cgroups statistics.");
     }
 }
 
@@ -2651,7 +2651,7 @@ static int discovery_is_cgroup_duplicate(struct cgroup *cg) {
    struct cgroup *c;
    for (c = discovered_cgroup_root; c; c = c->discovered_next) {
        if (c != cg && c->enabled && c->hash_chart == cg->hash_chart && !strcmp(c->chart_id, cg->chart_id)) {
-           error("CGROUP: chart id '%s' already exists with id '%s' and is enabled and available. Disabling cgroup with id '%s'.", cg->chart_id, c->id, cg->id);
+           collector_error("CGROUP: chart id '%s' already exists with id '%s' and is enabled and available. Disabling cgroup with id '%s'.", cg->chart_id, c->id, cg->id);
            return 1;
        }
    }
@@ -2686,7 +2686,7 @@ static inline void discovery_process_cgroup(struct cgroup *cg) {
     cg->processed = 1;
 
     if ((strlen(cg->chart_id) + strlen(cgroup_chart_id_prefix)) >= RRD_ID_LENGTH_MAX) {
-        info("cgroup '%s' (chart id '%s') disabled because chart_id exceeds the limit (RRD_ID_LENGTH_MAX)", cg->id, cg->chart_id);
+        collector_info("cgroup '%s' (chart id '%s') disabled because chart_id exceeds the limit (RRD_ID_LENGTH_MAX)", cg->id, cg->chart_id);
         return;
     }
 
@@ -3573,7 +3573,7 @@ static inline void update_cpu_limits(char **filename, unsigned long long *value,
         else ret = -1;
 
         if(ret) {
-            error("Cannot refresh cgroup %s cpu limit by reading '%s'. Will not update its limit anymore.", cg->id, *filename);
+            collector_error("Cannot refresh cgroup %s cpu limit by reading '%s'. Will not update its limit anymore.", cg->id, *filename);
             freez(*filename);
             *filename = NULL;
         }
@@ -3597,7 +3597,7 @@ static inline void update_cpu_limits2(struct cgroup *cg) {
         unsigned long lines = procfile_lines(ff);
 
         if (unlikely(lines < 1)) {
-            error("CGROUP: file '%s' should have 1 lines.", cg->filename_cpu_cfs_quota);
+            collector_error("CGROUP: file '%s' should have 1 lines.", cg->filename_cpu_cfs_quota);
             return;
         }
 
@@ -3614,7 +3614,7 @@ static inline void update_cpu_limits2(struct cgroup *cg) {
         return;
 
 cpu_limits2_err:
-        error("Cannot refresh cgroup %s cpu limit by reading '%s'. Will not update its limit anymore.", cg->id, cg->filename_cpu_cfs_quota);
+        collector_error("Cannot refresh cgroup %s cpu limit by reading '%s'. Will not update its limit anymore.", cg->id, cg->filename_cpu_cfs_quota);
         freez(cg->filename_cpu_cfs_quota);
         cg->filename_cpu_cfs_quota = NULL;
 
@@ -3626,7 +3626,7 @@ static inline int update_memory_limits(char **filename, const RRDSETVAR_ACQUIRED
         if(unlikely(!*chart_var)) {
             *chart_var = rrdsetvar_custom_chart_variable_add_and_acquire(cg->st_mem_usage, chart_var_name);
             if(!*chart_var) {
-                error("Cannot create cgroup %s chart variable '%s'. Will not update its limit anymore.", cg->id, chart_var_name);
+                collector_error("Cannot create cgroup %s chart variable '%s'. Will not update its limit anymore.", cg->id, chart_var_name);
                 freez(*filename);
                 *filename = NULL;
             }
@@ -3635,7 +3635,7 @@ static inline int update_memory_limits(char **filename, const RRDSETVAR_ACQUIRED
         if(*filename && *chart_var) {
             if(!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) {
                 if(read_single_number_file(*filename, value)) {
-                    error("Cannot refresh cgroup %s memory limit by reading '%s'. Will not update its limit anymore.", cg->id, *filename);
+                    collector_error("Cannot refresh cgroup %s memory limit by reading '%s'. Will not update its limit anymore.", cg->id, *filename);
                     freez(*filename);
                     *filename = NULL;
                 }
@@ -3647,7 +3647,7 @@ static inline int update_memory_limits(char **filename, const RRDSETVAR_ACQUIRED
                 char buffer[30 + 1];
                 int ret = read_file(*filename, buffer, 30);
                 if(ret) {
-                    error("Cannot refresh cgroup %s memory limit by reading '%s'. Will not update its limit anymore.", cg->id, *filename);
+                    collector_error("Cannot refresh cgroup %s memory limit by reading '%s'. Will not update its limit anymore.", cg->id, *filename);
                     freez(*filename);
                     *filename = NULL;
                     return 0;
@@ -3756,7 +3756,7 @@ void update_cgroup_charts(int update_every) {
                 if(unlikely(!cg->chart_var_cpu_limit)) {
                     cg->chart_var_cpu_limit = rrdsetvar_custom_chart_variable_add_and_acquire(cg->st_cpu, "cpu_limit");
                     if(!cg->chart_var_cpu_limit) {
-                        error("Cannot create cgroup %s chart variable 'cpu_limit'. Will not update its limit anymore.", cg->id);
+                        collector_error("Cannot create cgroup %s chart variable 'cpu_limit'. Will not update its limit anymore.", cg->id);
                         if(cg->filename_cpuset_cpus) freez(cg->filename_cpuset_cpus);
                         cg->filename_cpuset_cpus = NULL;
                         if(cg->filename_cpu_cfs_period) freez(cg->filename_cpu_cfs_period);
@@ -4148,7 +4148,7 @@ void update_cgroup_charts(int update_every) {
                     if(likely(ff && procfile_lines(ff) && !strncmp(procfile_word(ff, 0), "MemTotal", 8)))
                         ram_total = str2ull(procfile_word(ff, 1)) * 1024;
                     else {
-                        error("Cannot read file %s. Will not update cgroup %s RAM limit anymore.", filename, cg->id);
+                        collector_error("Cannot read file %s. Will not update cgroup %s RAM limit anymore.", filename, cg->id);
                         freez(cg->filename_memory_limit);
                         cg->filename_memory_limit = NULL;
                     }
@@ -4782,19 +4782,19 @@ static void cgroup_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-    info("cleaning up...");
+    collector_info("cleaning up...");
 
     usec_t max = 2 * USEC_PER_SEC, step = 50000;
 
     if (!discovery_thread.exited) {
-        info("stopping discovery thread worker");
+        collector_info("stopping discovery thread worker");
         uv_mutex_lock(&discovery_thread.mutex);
         discovery_thread.start_discovery = 1;
         uv_cond_signal(&discovery_thread.cond_var);
         uv_mutex_unlock(&discovery_thread.mutex);
     }
 
-    info("waiting for discovery thread to finish...");
+    collector_info("waiting for discovery thread to finish...");
     
     while (!discovery_thread.exited && max > 0) {
         max -= step;
@@ -4833,7 +4833,7 @@ void *cgroups_main(void *ptr) {
     netdata_cgroup_ebpf_initialize_shm();
 
     if (uv_mutex_init(&cgroup_root_mutex)) {
-        error("CGROUP: cannot initialize mutex for the main cgroup list");
+        collector_error("CGROUP: cannot initialize mutex for the main cgroup list");
         goto exit;
     }
 
@@ -4842,17 +4842,17 @@ void *cgroups_main(void *ptr) {
     discovery_thread.exited = 0;
 
     if (uv_mutex_init(&discovery_thread.mutex)) {
-        error("CGROUP: cannot initialize mutex for discovery thread");
+        collector_error("CGROUP: cannot initialize mutex for discovery thread");
         goto exit;
     }
     if (uv_cond_init(&discovery_thread.cond_var)) {
-        error("CGROUP: cannot initialize conditional variable for discovery thread");
+        collector_error("CGROUP: cannot initialize conditional variable for discovery thread");
         goto exit;
     }
 
     int error = uv_thread_create(&discovery_thread.thread, cgroup_discovery_worker, NULL);
     if (error) {
-        error("CGROUP: cannot create thread worker. uv_thread_create(): %s", uv_strerror(error));
+        collector_error("CGROUP: cannot create thread worker. uv_thread_create(): %s", uv_strerror(error));
         goto exit;
     }
     uv_thread_set_name_np(discovery_thread.thread, "PLUGIN[cgroups]");

--- a/collectors/cups.plugin/cups_plugin.c
+++ b/collectors/cups.plugin/cups_plugin.c
@@ -222,6 +222,7 @@ void reset_metrics() {
 }
 
 int main(int argc, char **argv) {
+    stderror = stderr;
     clocks_init();
 
     // ------------------------------------------------------------------------

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -181,7 +181,7 @@ static void calculate_values_and_show_charts(
 
 #ifdef NETDATA_INTERNAL_CHECKS
     if(unlikely(btotal != bavail + breserved_root + bused))
-        error("DISKSPACE: disk block statistics for '%s' (disk '%s') do not sum up: total = %llu, available = %llu, reserved = %llu, used = %llu", mi->mount_point, disk, (unsigned long long)btotal, (unsigned long long)bavail, (unsigned long long)breserved_root, (unsigned long long)bused);
+        collector_error("DISKSPACE: disk block statistics for '%s' (disk '%s') do not sum up: total = %llu, available = %llu, reserved = %llu, used = %llu", mi->mount_point, disk, (unsigned long long)btotal, (unsigned long long)bavail, (unsigned long long)breserved_root, (unsigned long long)bused);
 #endif
 
     // --------------------------------------------------------------------------
@@ -200,7 +200,7 @@ static void calculate_values_and_show_charts(
 
 #ifdef NETDATA_INTERNAL_CHECKS
     if(unlikely(btotal != bavail + breserved_root + bused))
-        error("DISKSPACE: disk inode statistics for '%s' (disk '%s') do not sum up: total = %llu, available = %llu, reserved = %llu, used = %llu", mi->mount_point, disk, (unsigned long long)ftotal, (unsigned long long)favail, (unsigned long long)freserved_root, (unsigned long long)fused);
+        collector_error("DISKSPACE: disk inode statistics for '%s' (disk '%s') do not sum up: total = %llu, available = %llu, reserved = %llu, used = %llu", mi->mount_point, disk, (unsigned long long)ftotal, (unsigned long long)favail, (unsigned long long)freserved_root, (unsigned long long)fused);
 #endif
 
     int rendered = 0;
@@ -348,23 +348,23 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
             struct stat bs;
 
             if(stat(mi->mount_point, &bs) == -1) {
-                error("DISKSPACE: Cannot stat() mount point '%s' (disk '%s', filesystem '%s', root '%s')."
-                      , mi->mount_point
-                      , disk
-                      , mi->filesystem?mi->filesystem:""
-                      , mi->root?mi->root:""
-                );
+                collector_error("DISKSPACE: Cannot stat() mount point '%s' (disk '%s', filesystem '%s', root '%s')."
+                               , mi->mount_point
+                               , disk
+                               , mi->filesystem?mi->filesystem:""
+                               , mi->root?mi->root:""
+                               );
                 def_space = CONFIG_BOOLEAN_NO;
                 def_inodes = CONFIG_BOOLEAN_NO;
             }
             else {
                 if((bs.st_mode & S_IFMT) != S_IFDIR) {
-                    error("DISKSPACE: Mount point '%s' (disk '%s', filesystem '%s', root '%s') is not a directory."
-                          , mi->mount_point
-                          , disk
-                          , mi->filesystem?mi->filesystem:""
-                          , mi->root?mi->root:""
-                    );
+                    collector_error("DISKSPACE: Mount point '%s' (disk '%s', filesystem '%s', root '%s') is not a directory."
+                                   , mi->mount_point
+                                   , disk
+                                   , mi->filesystem?mi->filesystem:""
+                                   , mi->root?mi->root:""
+                                   );
                     def_space = CONFIG_BOOLEAN_NO;
                     def_inodes = CONFIG_BOOLEAN_NO;
                 }
@@ -430,12 +430,12 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
 
     if (statvfs(mi->mount_point, &buff_statvfs) < 0) {
         if(!m->shown_error) {
-            error("DISKSPACE: failed to statvfs() mount point '%s' (disk '%s', filesystem '%s', root '%s')"
-                  , mi->mount_point
-                  , disk
-                  , mi->filesystem?mi->filesystem:""
-                  , mi->root?mi->root:""
-            );
+            collector_error("DISKSPACE: failed to statvfs() mount point '%s' (disk '%s', filesystem '%s', root '%s')"
+                            , mi->mount_point
+                            , disk
+                            , mi->filesystem?mi->filesystem:""
+                            , mi->root?mi->root:""
+                            );
             m->shown_error = 1;
         }
         return;
@@ -463,12 +463,12 @@ static inline void do_slow_disk_space_stats(struct basic_mountinfo *mi, int upda
     struct statvfs buff_statvfs;
     if (statvfs(mi->mount_point, &buff_statvfs) < 0) {
         if(!m->shown_error) {
-            error("DISKSPACE: failed to statvfs() mount point '%s' (disk '%s', filesystem '%s', root '%s')"
-                  , mi->mount_point
-                  , mi->persistent_id
-                  , mi->filesystem?mi->filesystem:""
-                  , mi->root?mi->root:""
-            );
+            collector_error("DISKSPACE: failed to statvfs() mount point '%s' (disk '%s', filesystem '%s', root '%s')"
+                            , mi->mount_point
+                            , mi->persistent_id
+                            , mi->filesystem?mi->filesystem:""
+                            , mi->root?mi->root:""
+                           );
             m->shown_error = 1;
         }
         return;
@@ -482,7 +482,7 @@ static void diskspace_slow_worker_cleanup(void *ptr)
 {
     UNUSED(ptr);
 
-    info("cleaning up...");
+    collector_info("cleaning up...");
 
     worker_unregister();
 }
@@ -583,7 +583,7 @@ static void diskspace_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-    info("cleaning up...");
+    collector_info("cleaning up...");
 
     if (diskspace_slow_thread) {
         netdata_thread_join(*diskspace_slow_thread, NULL);

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -2165,6 +2165,7 @@ static void ebpf_manage_pid(pid_t pid)
  */
 int main(int argc, char **argv)
 {
+    stderror = stderr;
     clocks_init();
     main_thread_id = gettid();
 

--- a/collectors/freebsd.plugin/freebsd_devstat.c
+++ b/collectors/freebsd.plugin/freebsd_devstat.c
@@ -116,7 +116,7 @@ static void disks_cleanup() {
     struct disk *dm = disks_root, *last = NULL;
     while(dm) {
         if (unlikely(!dm->updated)) {
-            // info("Removing disk '%s', linked after '%s'", dm->name, last?last->name:"ROOT");
+            // collector_info("Removing disk '%s', linked after '%s'", dm->name, last?last->name:"ROOT");
 
             if (disks_last_used == dm)
                 disks_last_used = last;
@@ -728,28 +728,28 @@ int do_kern_devstat(int update_every, usec_t dt) {
 
         if (unlikely(common_error)) {
             do_system_io = 0;
-            error("DISABLED: system.io chart");
+            collector_error("DISABLED: system.io chart");
             do_io = 0;
-            error("DISABLED: disk.* charts");
+            collector_error("DISABLED: disk.* charts");
             do_ops = 0;
-            error("DISABLED: disk_ops.* charts");
+            collector_error("DISABLED: disk_ops.* charts");
             do_qops = 0;
-            error("DISABLED: disk_qops.* charts");
+            collector_error("DISABLED: disk_qops.* charts");
             do_util = 0;
-            error("DISABLED: disk_util.* charts");
+            collector_error("DISABLED: disk_util.* charts");
             do_iotime = 0;
-            error("DISABLED: disk_iotime.* charts");
+            collector_error("DISABLED: disk_iotime.* charts");
             do_await = 0;
-            error("DISABLED: disk_await.* charts");
+            collector_error("DISABLED: disk_await.* charts");
             do_avagsz = 0;
-            error("DISABLED: disk_avgsz.* charts");
+            collector_error("DISABLED: disk_avgsz.* charts");
             do_svctm = 0;
-            error("DISABLED: disk_svctm.* charts");
-            error("DISABLED: kern.devstat module");
+            collector_error("DISABLED: disk_svctm.* charts");
+            collector_error("DISABLED: kern.devstat module");
             return 1;
         }
     } else {
-        error("DISABLED: kern.devstat module");
+        collector_error("DISABLED: kern.devstat module");
         return 1;
     }
 

--- a/collectors/freebsd.plugin/freebsd_getifaddrs.c
+++ b/collectors/freebsd.plugin/freebsd_getifaddrs.c
@@ -73,7 +73,7 @@ static void network_interfaces_cleanup() {
     struct cgroup_network_interface *ifm = network_interfaces_root, *last = NULL;
     while(ifm) {
         if (unlikely(!ifm->updated)) {
-            // info("Removing network interface '%s', linked after '%s'", ifm->name, last?last->name:"ROOT");
+            // collector_info("Removing network interface '%s', linked after '%s'", ifm->name, last?last->name:"ROOT");
 
             if (network_interfaces_last_used == ifm)
                 network_interfaces_last_used = last;
@@ -193,26 +193,26 @@ int do_getifaddrs(int update_every, usec_t dt) {
         struct ifaddrs *ifap;
 
         if (unlikely(getifaddrs(&ifap))) {
-            error("FREEBSD: getifaddrs() failed");
+            collector_error("FREEBSD: getifaddrs() failed");
             do_bandwidth_net = 0;
-            error("DISABLED: system.net chart");
+            collector_error("DISABLED: system.net chart");
             do_packets_net = 0;
-            error("DISABLED: system.packets chart");
+            collector_error("DISABLED: system.packets chart");
             do_bandwidth_ipv4 = 0;
-            error("DISABLED: system.ipv4 chart");
+            collector_error("DISABLED: system.ipv4 chart");
             do_bandwidth_ipv6 = 0;
-            error("DISABLED: system.ipv6 chart");
+            collector_error("DISABLED: system.ipv6 chart");
             do_bandwidth = 0;
-            error("DISABLED: net.* charts");
+            collector_error("DISABLED: net.* charts");
             do_packets = 0;
-            error("DISABLED: net_packets.* charts");
+            collector_error("DISABLED: net_packets.* charts");
             do_errors = 0;
-            error("DISABLED: net_errors.* charts");
+            collector_error("DISABLED: net_errors.* charts");
             do_drops = 0;
-            error("DISABLED: net_drops.* charts");
+            collector_error("DISABLED: net_drops.* charts");
             do_events = 0;
-            error("DISABLED: net_events.* charts");
-            error("DISABLED: getifaddrs module");
+            collector_error("DISABLED: net_events.* charts");
+            collector_error("DISABLED: getifaddrs module");
             return 1;
         } else {
 #define IFA_DATA(s) (((struct if_data *)ifa->ifa_data)->ifi_ ## s)
@@ -589,7 +589,7 @@ int do_getifaddrs(int update_every, usec_t dt) {
             freeifaddrs(ifap);
         }
     } else {
-        error("DISABLED: getifaddrs module");
+        collector_error("DISABLED: getifaddrs module");
         return 1;
     }
 

--- a/collectors/freebsd.plugin/freebsd_getmntinfo.c
+++ b/collectors/freebsd.plugin/freebsd_getmntinfo.c
@@ -54,7 +54,7 @@ static void mount_points_cleanup() {
     struct mount_point *m = mount_points_root, *last = NULL;
     while(m) {
         if (unlikely(!m->updated)) {
-            // info("Removing mount point '%s', linked after '%s'", m->name, last?last->name:"ROOT");
+            // collector_info("Removing mount point '%s', linked after '%s'", m->name, last?last->name:"ROOT");
 
             if (mount_points_last_used == m)
                 mount_points_last_used = last;
@@ -163,12 +163,12 @@ int do_getmntinfo(int update_every, usec_t dt) {
 
         // there is no mount info in sysctl MIBs
         if (unlikely(!(mntsize = getmntinfo(&mntbuf, MNT_NOWAIT)))) {
-            error("FREEBSD: getmntinfo() failed");
+            collector_error("FREEBSD: getmntinfo() failed");
             do_space = 0;
-            error("DISABLED: disk_space.* charts");
+            collector_error("DISABLED: disk_space.* charts");
             do_inodes = 0;
-            error("DISABLED: disk_inodes.* charts");
-            error("DISABLED: getmntinfo module");
+            collector_error("DISABLED: disk_inodes.* charts");
+            collector_error("DISABLED: getmntinfo module");
             return 1;
         } else {
             int i;
@@ -289,7 +289,7 @@ int do_getmntinfo(int update_every, usec_t dt) {
             }
         }
     } else {
-        error("DISABLED: getmntinfo module");
+        collector_error("DISABLED: getmntinfo module");
         return 1;
     }
 

--- a/collectors/freebsd.plugin/freebsd_ipfw.c
+++ b/collectors/freebsd.plugin/freebsd_ipfw.c
@@ -6,11 +6,11 @@
 
 #define FREE_MEM_THRESHOLD 10000 // number of unused chunks that trigger memory freeing
 
-#define COMMON_IPFW_ERROR() error("DISABLED: ipfw.packets chart"); \
-                            error("DISABLED: ipfw.bytes chart"); \
-                            error("DISABLED: ipfw.dyn_active chart"); \
-                            error("DISABLED: ipfw.dyn_expired chart"); \
-                            error("DISABLED: ipfw.mem chart");
+#define COMMON_IPFW_ERROR() collector_error("DISABLED: ipfw.packets chart"); \
+                            collector_error("DISABLED: ipfw.bytes chart"); \
+                            collector_error("DISABLED: ipfw.dyn_active chart"); \
+                            collector_error("DISABLED: ipfw.dyn_expired chart"); \
+                            collector_error("DISABLED: ipfw.mem chart");
 
 // --------------------------------------------------------------------------------------------------------------------
 // ipfw
@@ -83,8 +83,8 @@ int do_ipfw(int update_every, usec_t dt) {
         if (unlikely(ipfw_socket == -1))
             ipfw_socket = socket(AF_INET, SOCK_RAW, IPPROTO_RAW);
         if (unlikely(ipfw_socket == -1)) {
-            error("FREEBSD: can't get socket for ipfw configuration");
-            error("FREEBSD: run netdata as root to get access to ipfw data");
+            collector_error("FREEBSD: can't get socket for ipfw configuration");
+            collector_error("FREEBSD: run netdata as root to get access to ipfw data");
             COMMON_IPFW_ERROR();
             return 1;
         }
@@ -100,7 +100,7 @@ int do_ipfw(int update_every, usec_t dt) {
         error = getsockopt(ipfw_socket, IPPROTO_IP, IP_FW3, op3, optlen);
         if (error)
             if (errno != ENOMEM) {
-                error("FREEBSD: ipfw socket reading error");
+                collector_error("FREEBSD: ipfw socket reading error");
                 COMMON_IPFW_ERROR();
                 return 1;
             }
@@ -113,7 +113,7 @@ int do_ipfw(int update_every, usec_t dt) {
             op3->opcode = IP_FW_XGET;
             error = getsockopt(ipfw_socket, IPPROTO_IP, IP_FW3, op3, optlen);
             if (error) {
-                error("FREEBSD: ipfw socket reading error");
+                collector_error("FREEBSD: ipfw socket reading error");
                 COMMON_IPFW_ERROR();
                 return 1;
             }
@@ -352,7 +352,7 @@ int do_ipfw(int update_every, usec_t dt) {
 
     return 0;
 #else
-    error("FREEBSD: ipfw charts supported for FreeBSD 11.0 and newer releases only");
+    collector_error("FREEBSD: ipfw charts supported for FreeBSD 11.0 and newer releases only");
     COMMON_IPFW_ERROR();
     return 1;
 #endif

--- a/collectors/freebsd.plugin/freebsd_kstat_zfs.c
+++ b/collectors/freebsd.plugin/freebsd_kstat_zfs.c
@@ -238,9 +238,9 @@ int do_kstat_zfs_misc_zio_trim(int update_every, usec_t dt) {
                  GETSYSCTL_SIMPLE("kstat.zfs.misc.zio_trim.success", mib_success, success) ||
                  GETSYSCTL_SIMPLE("kstat.zfs.misc.zio_trim.failed", mib_failed, failed) ||
                  GETSYSCTL_SIMPLE("kstat.zfs.misc.zio_trim.unsupported", mib_unsupported, unsupported))) {
-        error("DISABLED: zfs.trim_bytes chart");
-        error("DISABLED: zfs.trim_success chart");
-        error("DISABLED: kstat.zfs.misc.zio_trim module");
+        collector_error("DISABLED: zfs.trim_bytes chart");
+        collector_error("DISABLED: zfs.trim_success chart");
+        collector_error("DISABLED: kstat.zfs.misc.zio_trim module");
         return 1;
      } else {
 

--- a/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -96,17 +96,17 @@ int freebsd_plugin_init()
 {
     system_pagesize = getpagesize();
     if (system_pagesize <= 0) {
-        error("FREEBSD: can't get system page size");
+        collector_error("FREEBSD: can't get system page size");
         return 1;
     }
 
     if (unlikely(GETSYSCTL_BY_NAME("kern.smp.cpus", number_of_cpus))) {
-        error("FREEBSD: can't get number of cpus");
+        collector_error("FREEBSD: can't get number of cpus");
         return 1;
     }
 
     if (unlikely(!number_of_cpus)) {
-        error("FREEBSD: wrong number of cpus");
+        collector_error("FREEBSD: wrong number of cpus");
         return 1;
     }
 
@@ -126,8 +126,8 @@ int do_vm_loadavg(int update_every, usec_t dt){
         struct loadavg sysload;
 
         if (unlikely(GETSYSCTL_SIMPLE("vm.loadavg", mib, sysload))) {
-            error("DISABLED: system.load chart");
-            error("DISABLED: vm.loadavg module");
+            collector_error("DISABLED: system.load chart");
+            collector_error("DISABLED: vm.loadavg module");
             return 1;
         } else {
             static RRDSET *st = NULL;
@@ -185,12 +185,12 @@ int do_vm_vmtotal(int update_every, usec_t dt) {
 
         if (unlikely(GETSYSCTL_SIMPLE("vm.vmtotal", mib, vmtotal_data))) {
             do_all_processes = 0;
-            error("DISABLED: system.active_processes chart");
+            collector_error("DISABLED: system.active_processes chart");
             do_processes = 0;
-            error("DISABLED: system.processes chart");
+            collector_error("DISABLED: system.processes chart");
             do_mem_real = 0;
-            error("DISABLED: mem.real chart");
-            error("DISABLED: vm.vmtotal module");
+            collector_error("DISABLED: mem.real chart");
+            collector_error("DISABLED: vm.vmtotal module");
             return 1;
         } else {
             if (likely(do_all_processes)) {
@@ -277,7 +277,7 @@ int do_vm_vmtotal(int update_every, usec_t dt) {
             }
         }
     } else {
-        error("DISABLED: vm.vmtotal module");
+        collector_error("DISABLED: vm.vmtotal module");
         return 1;
     }
 
@@ -290,17 +290,17 @@ int do_kern_cp_time(int update_every, usec_t dt) {
     (void)dt;
 
     if (unlikely(CPUSTATES != 5)) {
-        error("FREEBSD: There are %d CPU states (5 was expected)", CPUSTATES);
-        error("DISABLED: system.cpu chart");
-        error("DISABLED: kern.cp_time module");
+        collector_error("FREEBSD: There are %d CPU states (5 was expected)", CPUSTATES);
+        collector_error("DISABLED: system.cpu chart");
+        collector_error("DISABLED: kern.cp_time module");
         return 1;
     } else {
         static int mib[2] = {0, 0};
         long cp_time[CPUSTATES];
 
         if (unlikely(GETSYSCTL_SIMPLE("kern.cp_time", mib, cp_time))) {
-            error("DISABLED: system.cpu chart");
-            error("DISABLED: kern.cp_time module");
+            collector_error("DISABLED: system.cpu chart");
+            collector_error("DISABLED: kern.cp_time module");
             return 1;
         } else {
             static RRDSET *st = NULL;
@@ -348,9 +348,9 @@ int do_kern_cp_times(int update_every, usec_t dt) {
     (void)dt;
 
     if (unlikely(CPUSTATES != 5)) {
-        error("FREEBSD: There are %d CPU states (5 was expected)", CPUSTATES);
-        error("DISABLED: cpu.cpuXX charts");
-        error("DISABLED: kern.cp_times module");
+        collector_error("FREEBSD: There are %d CPU states (5 was expected)", CPUSTATES);
+        collector_error("DISABLED: cpu.cpuXX charts");
+        collector_error("DISABLED: kern.cp_times module");
         return 1;
     } else {
         static int mib[2] = {0, 0};
@@ -361,8 +361,8 @@ int do_kern_cp_times(int update_every, usec_t dt) {
         if(unlikely(number_of_cpus != old_number_of_cpus))
             pcpu_cp_time = reallocz(pcpu_cp_time, sizeof(cp_time) * number_of_cpus);
         if (unlikely(GETSYSCTL_WSIZE("kern.cp_times", mib, pcpu_cp_time, sizeof(cp_time) * number_of_cpus))) {
-            error("DISABLED: cpu.cpuXX charts");
-            error("DISABLED: kern.cp_times module");
+            collector_error("DISABLED: cpu.cpuXX charts");
+            collector_error("DISABLED: kern.cp_times module");
             return 1;
         } else {
             int i;
@@ -449,8 +449,8 @@ int do_dev_cpu_temperature(int update_every, usec_t dt) {
         if (unlikely(!(mib[i * 4])))
             sprintf(char_mib, "dev.cpu.%d.temperature", i);
         if (unlikely(getsysctl_simple(char_mib, &mib[i * 4], 4, &pcpu_temperature[i], sizeof(int)))) {
-            error("DISABLED: cpu.temperature chart");
-            error("DISABLED: dev.cpu.temperature module");
+            collector_error("DISABLED: cpu.temperature chart");
+            collector_error("DISABLED: dev.cpu.temperature module");
             return 1;
         }
     }
@@ -505,8 +505,8 @@ int do_dev_cpu_0_freq(int update_every, usec_t dt) {
     int cpufreq;
 
     if (unlikely(GETSYSCTL_SIMPLE("dev.cpu.0.freq", mib, cpufreq))) {
-        error("DISABLED: cpu.scaling_cur_freq chart");
-        error("DISABLED: dev.cpu.0.freq module");
+        collector_error("DISABLED: cpu.scaling_cur_freq chart");
+        collector_error("DISABLED: dev.cpu.0.freq module");
         return 1;
     } else {
         static RRDSET *st = NULL;
@@ -547,9 +547,9 @@ int do_hw_intcnt(int update_every, usec_t dt) {
     size_t intrcnt_size = 0;
 
     if (unlikely(GETSYSCTL_SIZE("hw.intrcnt", mib_hw_intrcnt, intrcnt_size))) {
-        error("DISABLED: system.intr chart");
-        error("DISABLED: system.interrupts chart");
-        error("DISABLED: hw.intrcnt module");
+        collector_error("DISABLED: system.intr chart");
+        collector_error("DISABLED: system.interrupts chart");
+        collector_error("DISABLED: hw.intrcnt module");
         return 1;
     } else {
         unsigned long nintr = 0;
@@ -560,9 +560,9 @@ int do_hw_intcnt(int update_every, usec_t dt) {
         if (unlikely(nintr != old_nintr))
             intrcnt = reallocz(intrcnt, nintr * sizeof(u_long));
         if (unlikely(GETSYSCTL_WSIZE("hw.intrcnt", mib_hw_intrcnt, intrcnt, nintr * sizeof(u_long)))) {
-            error("DISABLED: system.intr chart");
-            error("DISABLED: system.interrupts chart");
-            error("DISABLED: hw.intrcnt module");
+            collector_error("DISABLED: system.intr chart");
+            collector_error("DISABLED: system.interrupts chart");
+            collector_error("DISABLED: hw.intrcnt module");
             return 1;
         } else {
             unsigned long long totalintr = 0;
@@ -602,17 +602,17 @@ int do_hw_intcnt(int update_every, usec_t dt) {
             static char *intrnames = NULL;
 
             if (unlikely(GETSYSCTL_SIZE("hw.intrnames", mib_hw_intrnames, size))) {
-                error("DISABLED: system.intr chart");
-                error("DISABLED: system.interrupts chart");
-                error("DISABLED: hw.intrcnt module");
+                collector_error("DISABLED: system.intr chart");
+                collector_error("DISABLED: system.interrupts chart");
+                collector_error("DISABLED: hw.intrcnt module");
                 return 1;
             } else {
                 if (unlikely(nintr != old_nintr))
                     intrnames = reallocz(intrnames, size);
                 if (unlikely(GETSYSCTL_WSIZE("hw.intrnames", mib_hw_intrnames, intrnames, size))) {
-                    error("DISABLED: system.intr chart");
-                    error("DISABLED: system.interrupts chart");
-                    error("DISABLED: hw.intrcnt module");
+                    collector_error("DISABLED: system.intr chart");
+                    collector_error("DISABLED: system.interrupts chart");
+                    collector_error("DISABLED: hw.intrcnt module");
                     return 1;
                 } else {
                     static RRDSET *st_interrupts = NULL;
@@ -666,8 +666,8 @@ int do_vm_stats_sys_v_intr(int update_every, usec_t dt) {
     u_int int_number;
 
     if (unlikely(GETSYSCTL_SIMPLE("vm.stats.sys.v_intr", mib, int_number))) {
-        error("DISABLED: system.dev_intr chart");
-        error("DISABLED: vm.stats.sys.v_intr module");
+        collector_error("DISABLED: system.dev_intr chart");
+        collector_error("DISABLED: vm.stats.sys.v_intr module");
         return 1;
     } else {
         static RRDSET *st = NULL;
@@ -707,8 +707,8 @@ int do_vm_stats_sys_v_soft(int update_every, usec_t dt) {
     u_int soft_intr_number;
 
     if (unlikely(GETSYSCTL_SIMPLE("vm.stats.sys.v_soft", mib, soft_intr_number))) {
-        error("DISABLED: system.dev_intr chart");
-        error("DISABLED: vm.stats.sys.v_soft module");
+        collector_error("DISABLED: system.dev_intr chart");
+        collector_error("DISABLED: vm.stats.sys.v_soft module");
         return 1;
     } else {
         static RRDSET *st = NULL;
@@ -748,8 +748,8 @@ int do_vm_stats_sys_v_swtch(int update_every, usec_t dt) {
     u_int ctxt_number;
 
     if (unlikely(GETSYSCTL_SIMPLE("vm.stats.sys.v_swtch", mib, ctxt_number))) {
-        error("DISABLED: system.ctxt chart");
-        error("DISABLED: vm.stats.sys.v_swtch module");
+        collector_error("DISABLED: system.ctxt chart");
+        collector_error("DISABLED: vm.stats.sys.v_swtch module");
         return 1;
     } else {
         static RRDSET *st = NULL;
@@ -789,8 +789,8 @@ int do_vm_stats_sys_v_forks(int update_every, usec_t dt) {
     u_int forks_number;
 
     if (unlikely(GETSYSCTL_SIMPLE("vm.stats.vm.v_forks", mib, forks_number))) {
-        error("DISABLED: system.forks chart");
-        error("DISABLED: vm.stats.sys.v_swtch module");
+        collector_error("DISABLED: system.forks chart");
+        collector_error("DISABLED: vm.stats.sys.v_swtch module");
         return 1;
     } else {
 
@@ -834,8 +834,8 @@ int do_vm_swap_info(int update_every, usec_t dt) {
     static int mib[3] = {0, 0, 0};
 
     if (unlikely(getsysctl_mib("vm.swap_info", mib, 2))) {
-        error("DISABLED: system.swap chart");
-        error("DISABLED: vm.swap_info module");
+        collector_error("DISABLED: system.swap chart");
+        collector_error("DISABLED: vm.swap_info module");
         return 1;
     } else {
         int i;
@@ -852,15 +852,15 @@ int do_vm_swap_info(int update_every, usec_t dt) {
             size = sizeof(xsw);
             if (unlikely(sysctl(mib, 3, &xsw, &size, NULL, 0) == -1 )) {
                 if (unlikely(errno != ENOENT)) {
-                    error("FREEBSD: sysctl(%s...) failed: %s", "vm.swap_info", strerror(errno));
-                    error("DISABLED: system.swap chart");
-                    error("DISABLED: vm.swap_info module");
+                    collector_error("FREEBSD: sysctl(%s...) failed: %s", "vm.swap_info", strerror(errno));
+                    collector_error("DISABLED: system.swap chart");
+                    collector_error("DISABLED: vm.swap_info module");
                     return 1;
                 } else {
                     if (unlikely(size != sizeof(xsw))) {
-                        error("FREEBSD: sysctl(%s...) expected %lu, got %lu", "vm.swap_info", (unsigned long)sizeof(xsw), (unsigned long)size);
-                        error("DISABLED: system.swap chart");
-                        error("DISABLED: vm.swap_info module");
+                        collector_error("FREEBSD: sysctl(%s...) expected %lu, got %lu", "vm.swap_info", (unsigned long)sizeof(xsw), (unsigned long)size);
+                        collector_error("DISABLED: system.swap chart");
+                        collector_error("DISABLED: vm.swap_info module");
                         return 1;
                     } else break;
                 }
@@ -932,8 +932,8 @@ int do_system_ram(int update_every, usec_t dt) {
 #endif
                  GETSYSCTL_SIMPLE("vfs.bufspace",                 mib_vfs_bufspace,     vfs_bufspace_count) ||
                  GETSYSCTL_SIMPLE("vm.stats.vm.v_free_count",     mib_free_count,     vmmeter_data.v_free_count))) {
-        error("DISABLED: system.ram chart");
-        error("DISABLED: system.ram module");
+        collector_error("DISABLED: system.ram chart");
+        collector_error("DISABLED: system.ram module");
         return 1;
     } else {
         static RRDSET *st = NULL, *st_mem_available = NULL;
@@ -1026,8 +1026,8 @@ int do_vm_stats_sys_v_swappgs(int update_every, usec_t dt) {
 
     if (unlikely(GETSYSCTL_SIMPLE("vm.stats.vm.v_swappgsin", mib_swappgsin, vmmeter_data.v_swappgsin) ||
                  GETSYSCTL_SIMPLE("vm.stats.vm.v_swappgsout", mib_swappgsout, vmmeter_data.v_swappgsout))) {
-        error("DISABLED: system.swapio chart");
-        error("DISABLED: vm.stats.vm.v_swappgs module");
+        collector_error("DISABLED: system.swapio chart");
+        collector_error("DISABLED: vm.stats.vm.v_swappgs module");
         return 1;
     } else {
         static RRDSET *st = NULL;
@@ -1074,8 +1074,8 @@ int do_vm_stats_sys_v_pgfaults(int update_every, usec_t dt) {
                  GETSYSCTL_SIMPLE("vm.stats.vm.v_cow_faults", mib_cow_faults, vmmeter_data.v_cow_faults) ||
                  GETSYSCTL_SIMPLE("vm.stats.vm.v_cow_optim",  mib_cow_optim,  vmmeter_data.v_cow_optim) ||
                  GETSYSCTL_SIMPLE("vm.stats.vm.v_intrans",    mib_intrans,    vmmeter_data.v_intrans))) {
-        error("DISABLED: mem.pgfaults chart");
-        error("DISABLED: vm.stats.vm.v_pgfaults module");
+        collector_error("DISABLED: mem.pgfaults chart");
+        collector_error("DISABLED: vm.stats.vm.v_pgfaults module");
         return 1;
     } else {
         static RRDSET *st = NULL;
@@ -1131,9 +1131,9 @@ int do_kern_ipc_sem(int update_every, usec_t dt) {
     } ipc_sem = {0, 0, 0};
 
     if (unlikely(GETSYSCTL_SIMPLE("kern.ipc.semmni", mib_semmni, ipc_sem.semmni))) {
-        error("DISABLED: system.ipc_semaphores chart");
-        error("DISABLED: system.ipc_semaphore_arrays chart");
-        error("DISABLED: kern.ipc.sem module");
+        collector_error("DISABLED: system.ipc_semaphores chart");
+        collector_error("DISABLED: system.ipc_semaphore_arrays chart");
+        collector_error("DISABLED: kern.ipc.sem module");
         return 1;
     } else {
         static struct semid_kernel *ipc_sem_data = NULL;
@@ -1145,9 +1145,9 @@ int do_kern_ipc_sem(int update_every, usec_t dt) {
             old_semmni = ipc_sem.semmni;
         }
         if (unlikely(GETSYSCTL_WSIZE("kern.ipc.sema", mib_sema, ipc_sem_data, sizeof(struct semid_kernel) * ipc_sem.semmni))) {
-            error("DISABLED: system.ipc_semaphores chart");
-            error("DISABLED: system.ipc_semaphore_arrays chart");
-            error("DISABLED: kern.ipc.sem module");
+            collector_error("DISABLED: system.ipc_semaphores chart");
+            collector_error("DISABLED: system.ipc_semaphore_arrays chart");
+            collector_error("DISABLED: kern.ipc.sem module");
             return 1;
         } else {
             int i;
@@ -1223,9 +1223,9 @@ int do_kern_ipc_shm(int update_every, usec_t dt) {
     } ipc_shm = {0, 0, 0};
 
     if (unlikely(GETSYSCTL_SIMPLE("kern.ipc.shmmni", mib_shmmni, ipc_shm.shmmni))) {
-        error("DISABLED: system.ipc_shared_mem_segs chart");
-        error("DISABLED: system.ipc_shared_mem_size chart");
-        error("DISABLED: kern.ipc.shmmodule");
+        collector_error("DISABLED: system.ipc_shared_mem_segs chart");
+        collector_error("DISABLED: system.ipc_shared_mem_size chart");
+        collector_error("DISABLED: kern.ipc.shmmodule");
         return 1;
     } else {
         static struct shmid_kernel *ipc_shm_data = NULL;
@@ -1238,9 +1238,9 @@ int do_kern_ipc_shm(int update_every, usec_t dt) {
         }
         if (unlikely(
                 GETSYSCTL_WSIZE("kern.ipc.shmsegs", mib_shmsegs, ipc_shm_data, sizeof(struct shmid_kernel) * ipc_shm.shmmni))) {
-            error("DISABLED: system.ipc_shared_mem_segs chart");
-            error("DISABLED: system.ipc_shared_mem_size chart");
-            error("DISABLED: kern.ipc.shmmodule");
+            collector_error("DISABLED: system.ipc_shared_mem_segs chart");
+            collector_error("DISABLED: system.ipc_shared_mem_size chart");
+            collector_error("DISABLED: kern.ipc.shmmodule");
             return 1;
         } else {
             unsigned long i;
@@ -1318,10 +1318,10 @@ int do_kern_ipc_msq(int update_every, usec_t dt) {
     } ipc_msq = {0, 0, 0, 0, 0};
 
     if (unlikely(GETSYSCTL_SIMPLE("kern.ipc.msgmni", mib_msgmni, ipc_msq.msgmni))) {
-        error("DISABLED: system.ipc_msq_queues chart");
-        error("DISABLED: system.ipc_msq_messages chart");
-        error("DISABLED: system.ipc_msq_size chart");
-        error("DISABLED: kern.ipc.msg module");
+        collector_error("DISABLED: system.ipc_msq_queues chart");
+        collector_error("DISABLED: system.ipc_msq_messages chart");
+        collector_error("DISABLED: system.ipc_msq_size chart");
+        collector_error("DISABLED: kern.ipc.msg module");
         return 1;
     } else {
         static struct msqid_kernel *ipc_msq_data = NULL;
@@ -1334,10 +1334,10 @@ int do_kern_ipc_msq(int update_every, usec_t dt) {
         }
         if (unlikely(
                 GETSYSCTL_WSIZE("kern.ipc.msqids", mib_msqids, ipc_msq_data, sizeof(struct msqid_kernel) * ipc_msq.msgmni))) {
-            error("DISABLED: system.ipc_msq_queues chart");
-            error("DISABLED: system.ipc_msq_messages chart");
-            error("DISABLED: system.ipc_msq_size chart");
-            error("DISABLED: kern.ipc.msg module");
+            collector_error("DISABLED: system.ipc_msq_queues chart");
+            collector_error("DISABLED: system.ipc_msq_messages chart");
+            collector_error("DISABLED: system.ipc_msq_size chart");
+            collector_error("DISABLED: kern.ipc.msg module");
             return 1;
         } else {
             int i;
@@ -1520,11 +1520,11 @@ int do_net_isr(int update_every, usec_t dt) {
         }
         if (unlikely(common_error)) {
             do_netisr = 0;
-            error("DISABLED: system.softnet_stat chart");
+            collector_error("DISABLED: system.softnet_stat chart");
             do_netisr_per_core = 0;
-            error("DISABLED: system.cpuX_softnet_stat chart");
+            collector_error("DISABLED: system.cpuX_softnet_stat chart");
             common_error = 0;
-            error("DISABLED: net.isr module");
+            collector_error("DISABLED: net.isr module");
             return 1;
         } else {
             unsigned long i, n;
@@ -1554,7 +1554,7 @@ int do_net_isr(int update_every, usec_t dt) {
             }
         }
     } else {
-        error("DISABLED: net.isr module");
+        collector_error("DISABLED: net.isr module");
         return 1;
     }
 
@@ -1662,8 +1662,8 @@ int do_net_inet_tcp_states(int update_every, usec_t dt) {
 
     // see http://net-snmp.sourceforge.net/docs/mibs/tcp.html
     if (unlikely(GETSYSCTL_SIMPLE("net.inet.tcp.states", mib, tcps_states))) {
-        error("DISABLED: ipv4.tcpsock chart");
-        error("DISABLED: net.inet.tcp.states module");
+        collector_error("DISABLED: ipv4.tcpsock chart");
+        collector_error("DISABLED: net.inet.tcp.states module");
         return 1;
     } else {
         static RRDSET *st = NULL;
@@ -1726,22 +1726,22 @@ int do_net_inet_tcp_stats(int update_every, usec_t dt) {
 
         if (unlikely(GETSYSCTL_SIMPLE("net.inet.tcp.stats", mib, tcpstat))) {
             do_tcp_packets = 0;
-            error("DISABLED: ipv4.tcppackets chart");
+            collector_error("DISABLED: ipv4.tcppackets chart");
             do_tcp_errors = 0;
-            error("DISABLED: ipv4.tcperrors  chart");
+            collector_error("DISABLED: ipv4.tcperrors  chart");
             do_tcp_handshake = 0;
-            error("DISABLED: ipv4.tcphandshake  chart");
+            collector_error("DISABLED: ipv4.tcphandshake  chart");
             do_tcpext_connaborts = 0;
-            error("DISABLED: ipv4.tcpconnaborts  chart");
+            collector_error("DISABLED: ipv4.tcpconnaborts  chart");
             do_tcpext_ofo = 0;
-            error("DISABLED: ipv4.tcpofo chart");
+            collector_error("DISABLED: ipv4.tcpofo chart");
             do_tcpext_syncookies = 0;
-            error("DISABLED: ipv4.tcpsyncookies chart");
+            collector_error("DISABLED: ipv4.tcpsyncookies chart");
             do_tcpext_listen = 0;
-            error("DISABLED: ipv4.tcplistenissues chart");
+            collector_error("DISABLED: ipv4.tcplistenissues chart");
             do_ecn = 0;
-            error("DISABLED: ipv4.ecnpkts chart");
-            error("DISABLED: net.inet.tcp.stats module");
+            collector_error("DISABLED: ipv4.ecnpkts chart");
+            collector_error("DISABLED: net.inet.tcp.stats module");
             return 1;
         } else {
             if (likely(do_tcp_packets)) {
@@ -2035,7 +2035,7 @@ int do_net_inet_tcp_stats(int update_every, usec_t dt) {
 
         }
     } else {
-        error("DISABLED: net.inet.tcp.stats module");
+        collector_error("DISABLED: net.inet.tcp.stats module");
         return 1;
     }
 
@@ -2060,10 +2060,10 @@ int do_net_inet_udp_stats(int update_every, usec_t dt) {
 
         if (unlikely(GETSYSCTL_SIMPLE("net.inet.udp.stats", mib, udpstat))) {
             do_udp_packets = 0;
-            error("DISABLED: ipv4.udppackets chart");
+            collector_error("DISABLED: ipv4.udppackets chart");
             do_udp_errors = 0;
-            error("DISABLED: ipv4.udperrors chart");
-            error("DISABLED: net.inet.udp.stats module");
+            collector_error("DISABLED: ipv4.udperrors chart");
+            collector_error("DISABLED: net.inet.udp.stats module");
             return 1;
         } else {
             if (likely(do_udp_packets)) {
@@ -2134,7 +2134,7 @@ int do_net_inet_udp_stats(int update_every, usec_t dt) {
             }
         }
     } else {
-        error("DISABLED: net.inet.udp.stats module");
+        collector_error("DISABLED: net.inet.udp.stats module");
         return 1;
     }
 
@@ -2163,12 +2163,12 @@ int do_net_inet_icmp_stats(int update_every, usec_t dt) {
 
         if (unlikely(GETSYSCTL_SIMPLE("net.inet.icmp.stats", mib, icmpstat))) {
             do_icmp_packets = 0;
-            error("DISABLED: ipv4.icmp chart");
+            collector_error("DISABLED: ipv4.icmp chart");
             do_icmp_errors = 0;
-            error("DISABLED: ipv4.icmp_errors chart");
+            collector_error("DISABLED: ipv4.icmp_errors chart");
             do_icmpmsg = 0;
-            error("DISABLED: ipv4.icmpmsg chart");
-            error("DISABLED: net.inet.icmp.stats module");
+            collector_error("DISABLED: ipv4.icmpmsg chart");
+            collector_error("DISABLED: net.inet.icmp.stats module");
             return 1;
         } else {
             int i;
@@ -2275,7 +2275,7 @@ int do_net_inet_icmp_stats(int update_every, usec_t dt) {
             }
         }
     } else {
-        error("DISABLED: net.inet.icmp.stats module");
+        collector_error("DISABLED: net.inet.icmp.stats module");
         return 1;
     }
 
@@ -2302,14 +2302,14 @@ int do_net_inet_ip_stats(int update_every, usec_t dt) {
 
         if (unlikely(GETSYSCTL_SIMPLE("net.inet.ip.stats", mib, ipstat))) {
             do_ip_packets = 0;
-            error("DISABLED: ipv4.packets chart");
+            collector_error("DISABLED: ipv4.packets chart");
             do_ip_fragsout = 0;
-            error("DISABLED: ipv4.fragsout chart");
+            collector_error("DISABLED: ipv4.fragsout chart");
             do_ip_fragsin = 0;
-            error("DISABLED: ipv4.fragsin chart");
+            collector_error("DISABLED: ipv4.fragsin chart");
             do_ip_errors = 0;
-            error("DISABLED: ipv4.errors chart");
-            error("DISABLED: net.inet.ip.stats module");
+            collector_error("DISABLED: ipv4.errors chart");
+            collector_error("DISABLED: net.inet.ip.stats module");
             return 1;
         } else {
             if (likely(do_ip_packets)) {
@@ -2456,7 +2456,7 @@ int do_net_inet_ip_stats(int update_every, usec_t dt) {
             }
         }
     } else {
-        error("DISABLED: net.inet.ip.stats module");
+        collector_error("DISABLED: net.inet.ip.stats module");
         return 1;
     }
 
@@ -2486,14 +2486,14 @@ int do_net_inet6_ip6_stats(int update_every, usec_t dt) {
 
         if (unlikely(GETSYSCTL_SIMPLE("net.inet6.ip6.stats", mib, ip6stat))) {
             do_ip6_packets = 0;
-            error("DISABLED: ipv6.packets chart");
+            collector_error("DISABLED: ipv6.packets chart");
             do_ip6_fragsout = 0;
-            error("DISABLED: ipv6.fragsout chart");
+            collector_error("DISABLED: ipv6.fragsout chart");
             do_ip6_fragsin = 0;
-            error("DISABLED: ipv6.fragsin chart");
+            collector_error("DISABLED: ipv6.fragsin chart");
             do_ip6_errors = 0;
-            error("DISABLED: ipv6.errors chart");
-            error("DISABLED: net.inet6.ip6.stats module");
+            collector_error("DISABLED: ipv6.errors chart");
+            collector_error("DISABLED: net.inet6.ip6.stats module");
             return 1;
         } else {
             if (do_ip6_packets == CONFIG_BOOLEAN_YES || (do_ip6_packets == CONFIG_BOOLEAN_AUTO &&
@@ -2674,7 +2674,7 @@ int do_net_inet6_ip6_stats(int update_every, usec_t dt) {
             }
         }
     } else {
-        error("DISABLED: net.inet6.ip6.stats module");
+        collector_error("DISABLED: net.inet6.ip6.stats module");
         return 1;
     }
 
@@ -2711,20 +2711,20 @@ int do_net_inet6_icmp6_stats(int update_every, usec_t dt) {
 
         if (unlikely(GETSYSCTL_SIMPLE("net.inet6.icmp6.stats", mib, icmp6stat))) {
             do_icmp6 = 0;
-            error("DISABLED: ipv6.icmp chart");
+            collector_error("DISABLED: ipv6.icmp chart");
             do_icmp6_redir = 0;
-            error("DISABLED: ipv6.icmpredir chart");
+            collector_error("DISABLED: ipv6.icmpredir chart");
             do_icmp6_errors = 0;
-            error("DISABLED: ipv6.icmperrors chart");
+            collector_error("DISABLED: ipv6.icmperrors chart");
             do_icmp6_echos = 0;
-            error("DISABLED: ipv6.icmpechos chart");
+            collector_error("DISABLED: ipv6.icmpechos chart");
             do_icmp6_router = 0;
-            error("DISABLED: ipv6.icmprouter chart");
+            collector_error("DISABLED: ipv6.icmprouter chart");
             do_icmp6_neighbor = 0;
-            error("DISABLED: ipv6.icmpneighbor chart");
+            collector_error("DISABLED: ipv6.icmpneighbor chart");
             do_icmp6_types = 0;
-            error("DISABLED: ipv6.icmptypes chart");
-            error("DISABLED: net.inet6.icmp6.stats module");
+            collector_error("DISABLED: ipv6.icmptypes chart");
+            collector_error("DISABLED: net.inet6.icmp6.stats module");
             return 1;
         } else {
             int i;
@@ -3054,7 +3054,7 @@ int do_net_inet6_icmp6_stats(int update_every, usec_t dt) {
             }
         }
     } else {
-        error("DISABLED: net.inet6.icmp6.stats module");
+        collector_error("DISABLED: net.inet6.icmp6.stats module");
         return 1;
     }
 

--- a/collectors/freebsd.plugin/plugin_freebsd.c
+++ b/collectors/freebsd.plugin/plugin_freebsd.c
@@ -78,7 +78,7 @@ static void freebsd_main_cleanup(void *ptr)
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-    info("cleaning up...");
+    collector_info("cleaning up...");
 
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }

--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -775,7 +775,7 @@ _ipmimonitoring_sensors (struct ipmi_monitoring_ipmi_config *ipmi_config)
     int rv = -1;
 
     if (!(ctx = ipmi_monitoring_ctx_create ())) {
-        error("ipmi_monitoring_ctx_create()");
+        collector_error("ipmi_monitoring_ctx_create()");
         goto cleanup;
     }
 
@@ -784,8 +784,8 @@ _ipmimonitoring_sensors (struct ipmi_monitoring_ipmi_config *ipmi_config)
         if (ipmi_monitoring_ctx_sdr_cache_directory (ctx,
                 sdr_cache_directory) < 0)
         {
-            error("ipmi_monitoring_ctx_sdr_cache_directory(): %s\n",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error("ipmi_monitoring_ctx_sdr_cache_directory(): %s\n",
+                            ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
     }
@@ -796,8 +796,8 @@ _ipmimonitoring_sensors (struct ipmi_monitoring_ipmi_config *ipmi_config)
         if (ipmi_monitoring_ctx_sensor_config_file (ctx,
                 sensor_config_file) < 0)
         {
-            error( "ipmi_monitoring_ctx_sensor_config_file(): %s\n",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_ctx_sensor_config_file(): %s\n",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
     }
@@ -805,8 +805,8 @@ _ipmimonitoring_sensors (struct ipmi_monitoring_ipmi_config *ipmi_config)
     {
         if (ipmi_monitoring_ctx_sensor_config_file (ctx, NULL) < 0)
         {
-            error( "ipmi_monitoring_ctx_sensor_config_file(): %s\n",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_ctx_sensor_config_file(): %s\n",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
     }
@@ -851,8 +851,8 @@ _ipmimonitoring_sensors (struct ipmi_monitoring_ipmi_config *ipmi_config)
                 NULL,
                 NULL)) < 0)
         {
-            error( "ipmi_monitoring_sensor_readings_by_record_id(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sensor_readings_by_record_id(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
     }
@@ -867,8 +867,8 @@ _ipmimonitoring_sensors (struct ipmi_monitoring_ipmi_config *ipmi_config)
                 NULL,
                 NULL)) < 0)
         {
-            error( "ipmi_monitoring_sensor_readings_by_record_id(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sensor_readings_by_record_id(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
     }
@@ -883,8 +883,8 @@ _ipmimonitoring_sensors (struct ipmi_monitoring_ipmi_config *ipmi_config)
                 NULL,
                 NULL)) < 0)
         {
-            error( "ipmi_monitoring_sensor_readings_by_sensor_type(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sensor_readings_by_sensor_type(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
     }
@@ -920,58 +920,57 @@ _ipmimonitoring_sensors (struct ipmi_monitoring_ipmi_config *ipmi_config)
 
         if ((record_id = ipmi_monitoring_sensor_read_record_id (ctx)) < 0)
         {
-            error( "ipmi_monitoring_sensor_read_record_id(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sensor_read_record_id(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
 
         if ((sensor_number = ipmi_monitoring_sensor_read_sensor_number (ctx)) < 0)
         {
-            error( "ipmi_monitoring_sensor_read_sensor_number(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sensor_read_sensor_number(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
 
         if ((sensor_type = ipmi_monitoring_sensor_read_sensor_type (ctx)) < 0)
         {
-            error( "ipmi_monitoring_sensor_read_sensor_type(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sensor_read_sensor_type(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
 
         if (!(sensor_name = ipmi_monitoring_sensor_read_sensor_name (ctx)))
         {
-            error( "ipmi_monitoring_sensor_read_sensor_name(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sensor_read_sensor_name(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
 
         if ((sensor_state = ipmi_monitoring_sensor_read_sensor_state (ctx)) < 0)
         {
-            error( "ipmi_monitoring_sensor_read_sensor_state(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sensor_read_sensor_state(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
 
         if ((sensor_units = ipmi_monitoring_sensor_read_sensor_units (ctx)) < 0)
         {
-            error( "ipmi_monitoring_sensor_read_sensor_units(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sensor_read_sensor_units(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
 
 #ifdef NETDATA_COMMENTED
         if ((sensor_bitmask_type = ipmi_monitoring_sensor_read_sensor_bitmask_type (ctx)) < 0)
         {
-            error( "ipmi_monitoring_sensor_read_sensor_bitmask_type(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sensor_read_sensor_bitmask_type(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
         if ((sensor_bitmask = ipmi_monitoring_sensor_read_sensor_bitmask (ctx)) < 0)
         {
-            error(
-                   "ipmi_monitoring_sensor_read_sensor_bitmask(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error("ipmi_monitoring_sensor_read_sensor_bitmask(): %s",
+                            ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
 
@@ -986,8 +985,8 @@ _ipmimonitoring_sensors (struct ipmi_monitoring_ipmi_config *ipmi_config)
 
         if ((sensor_reading_type = ipmi_monitoring_sensor_read_sensor_reading_type (ctx)) < 0)
         {
-            error( "ipmi_monitoring_sensor_read_sensor_reading_type(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sensor_read_sensor_reading_type(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
 
@@ -996,8 +995,8 @@ _ipmimonitoring_sensors (struct ipmi_monitoring_ipmi_config *ipmi_config)
 #ifdef NETDATA_COMMENTED
         if ((event_reading_type_code = ipmi_monitoring_sensor_read_event_reading_type_code (ctx)) < 0)
         {
-            error( "ipmi_monitoring_sensor_read_event_reading_type_code(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sensor_read_event_reading_type_code(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
 #endif // NETDATA_COMMENTED
@@ -1131,7 +1130,7 @@ _ipmimonitoring_sel (struct ipmi_monitoring_ipmi_config *ipmi_config)
 
     if (!(ctx = ipmi_monitoring_ctx_create ()))
     {
-        error("ipmi_monitoring_ctx_create()");
+        collector_error("ipmi_monitoring_ctx_create()");
         goto cleanup;
     }
 
@@ -1140,8 +1139,8 @@ _ipmimonitoring_sel (struct ipmi_monitoring_ipmi_config *ipmi_config)
         if (ipmi_monitoring_ctx_sdr_cache_directory (ctx,
                 sdr_cache_directory) < 0)
         {
-            error( "ipmi_monitoring_ctx_sdr_cache_directory(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_ctx_sdr_cache_directory(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
     }
@@ -1152,8 +1151,8 @@ _ipmimonitoring_sel (struct ipmi_monitoring_ipmi_config *ipmi_config)
         if (ipmi_monitoring_ctx_sel_config_file (ctx,
                 sel_config_file) < 0)
         {
-            error( "ipmi_monitoring_ctx_sel_config_file(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_ctx_sel_config_file(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
     }
@@ -1161,8 +1160,8 @@ _ipmimonitoring_sel (struct ipmi_monitoring_ipmi_config *ipmi_config)
     {
         if (ipmi_monitoring_ctx_sel_config_file (ctx, NULL) < 0)
         {
-            error( "ipmi_monitoring_ctx_sel_config_file(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_ctx_sel_config_file(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
     }
@@ -1192,8 +1191,8 @@ _ipmimonitoring_sel (struct ipmi_monitoring_ipmi_config *ipmi_config)
                 NULL,
                 NULL)) < 0)
         {
-            error( "ipmi_monitoring_sel_by_record_id(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sel_by_record_id(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
     }
@@ -1208,8 +1207,8 @@ _ipmimonitoring_sel (struct ipmi_monitoring_ipmi_config *ipmi_config)
                 NULL,
                 NULL)) < 0)
         {
-            error( "ipmi_monitoring_sel_by_sensor_type(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sel_by_sensor_type(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
     }
@@ -1225,8 +1224,8 @@ _ipmimonitoring_sel (struct ipmi_monitoring_ipmi_config *ipmi_config)
                 NULL,
                 NULL)) < 0)
         {
-            error( "ipmi_monitoring_sel_by_sensor_type(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sel_by_sensor_type(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
     }
@@ -1241,8 +1240,8 @@ _ipmimonitoring_sel (struct ipmi_monitoring_ipmi_config *ipmi_config)
                 NULL,
                 NULL)) < 0)
         {
-            error( "ipmi_monitoring_sel_by_record_id(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sel_by_record_id(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
     }
@@ -1281,29 +1280,29 @@ _ipmimonitoring_sel (struct ipmi_monitoring_ipmi_config *ipmi_config)
 
         if ((record_id = ipmi_monitoring_sel_read_record_id (ctx)) < 0)
         {
-            error( "ipmi_monitoring_sel_read_record_id(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sel_read_record_id(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
 
         if ((record_type = ipmi_monitoring_sel_read_record_type (ctx)) < 0)
         {
-            error( "ipmi_monitoring_sel_read_record_type(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sel_read_record_type(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
 
         if ((record_type_class = ipmi_monitoring_sel_read_record_type_class (ctx)) < 0)
         {
-            error( "ipmi_monitoring_sel_read_record_type_class(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sel_read_record_type_class(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
 
         if ((sel_state = ipmi_monitoring_sel_read_sel_state (ctx)) < 0)
         {
-            error( "ipmi_monitoring_sel_read_sel_state(): %s",
-                    ipmi_monitoring_ctx_errormsg (ctx));
+            collector_error( "ipmi_monitoring_sel_read_sel_state(): %s",
+                             ipmi_monitoring_ctx_errormsg (ctx));
             goto cleanup;
         }
 
@@ -1334,8 +1333,8 @@ _ipmimonitoring_sel (struct ipmi_monitoring_ipmi_config *ipmi_config)
 
             if (ipmi_monitoring_sel_read_timestamp (ctx, &timestamp) < 0)
             {
-                error( "ipmi_monitoring_sel_read_timestamp(): %s",
-                        ipmi_monitoring_ctx_errormsg (ctx));
+                collector_error( "ipmi_monitoring_sel_read_timestamp(): %s",
+                                 ipmi_monitoring_ctx_errormsg (ctx));
                 goto cleanup;
             }
 
@@ -1363,36 +1362,36 @@ _ipmimonitoring_sel (struct ipmi_monitoring_ipmi_config *ipmi_config)
 
             if (!(sensor_name = ipmi_monitoring_sel_read_sensor_name (ctx)))
             {
-                error( "ipmi_monitoring_sel_read_sensor_name(): %s",
-                        ipmi_monitoring_ctx_errormsg (ctx));
+                collector_error( "ipmi_monitoring_sel_read_sensor_name(): %s",
+                                 ipmi_monitoring_ctx_errormsg (ctx));
                 goto cleanup;
             }
 
             if ((sensor_type = ipmi_monitoring_sel_read_sensor_type (ctx)) < 0)
             {
-                error( "ipmi_monitoring_sel_read_sensor_type(): %s",
-                        ipmi_monitoring_ctx_errormsg (ctx));
+                collector_error( "ipmi_monitoring_sel_read_sensor_type(): %s",
+                                 ipmi_monitoring_ctx_errormsg (ctx));
                 goto cleanup;
             }
 
             if ((sensor_number = ipmi_monitoring_sel_read_sensor_number (ctx)) < 0)
             {
-                error( "ipmi_monitoring_sel_read_sensor_number(): %s",
-                        ipmi_monitoring_ctx_errormsg (ctx));
+                collector_error( "ipmi_monitoring_sel_read_sensor_number(): %s",
+                                 ipmi_monitoring_ctx_errormsg (ctx));
                 goto cleanup;
             }
 
             if ((event_direction = ipmi_monitoring_sel_read_event_direction (ctx)) < 0)
             {
-                error( "ipmi_monitoring_sel_read_event_direction(): %s",
-                        ipmi_monitoring_ctx_errormsg (ctx));
+                collector_error( "ipmi_monitoring_sel_read_event_direction(): %s",
+                                 ipmi_monitoring_ctx_errormsg (ctx));
                 goto cleanup;
             }
 
             if ((event_type_code = ipmi_monitoring_sel_read_event_type_code (ctx)) < 0)
             {
-                error( "ipmi_monitoring_sel_read_event_type_code(): %s",
-                        ipmi_monitoring_ctx_errormsg (ctx));
+                collector_error( "ipmi_monitoring_sel_read_event_type_code(): %s",
+                                 ipmi_monitoring_ctx_errormsg (ctx));
                 goto cleanup;
             }
 
@@ -1401,29 +1400,29 @@ _ipmimonitoring_sel (struct ipmi_monitoring_ipmi_config *ipmi_config)
                     &event_data2,
                     &event_data3) < 0)
             {
-                error( "ipmi_monitoring_sel_read_event_data(): %s",
-                        ipmi_monitoring_ctx_errormsg (ctx));
+                collector_error( "ipmi_monitoring_sel_read_event_data(): %s",
+                                 ipmi_monitoring_ctx_errormsg (ctx));
                 goto cleanup;
             }
 
             if ((event_offset_type = ipmi_monitoring_sel_read_event_offset_type (ctx)) < 0)
             {
-                error( "ipmi_monitoring_sel_read_event_offset_type(): %s",
-                        ipmi_monitoring_ctx_errormsg (ctx));
+                collector_error( "ipmi_monitoring_sel_read_event_offset_type(): %s",
+                                 ipmi_monitoring_ctx_errormsg (ctx));
                 goto cleanup;
             }
 
             if ((event_offset = ipmi_monitoring_sel_read_event_offset (ctx)) < 0)
             {
-                error( "ipmi_monitoring_sel_read_event_offset(): %s",
-                        ipmi_monitoring_ctx_errormsg (ctx));
+                collector_error( "ipmi_monitoring_sel_read_event_offset(): %s",
+                                 ipmi_monitoring_ctx_errormsg (ctx));
                 goto cleanup;
             }
 
             if (!(event_offset_string = ipmi_monitoring_sel_read_event_offset_string (ctx)))
             {
-                error( "ipmi_monitoring_sel_read_event_offset_string(): %s",
-                        ipmi_monitoring_ctx_errormsg (ctx));
+                collector_error( "ipmi_monitoring_sel_read_event_offset_string(): %s",
+                                 ipmi_monitoring_ctx_errormsg (ctx));
                 goto cleanup;
             }
 
@@ -1464,8 +1463,8 @@ _ipmimonitoring_sel (struct ipmi_monitoring_ipmi_config *ipmi_config)
             {
                 if ((manufacturer_id = ipmi_monitoring_sel_read_manufacturer_id (ctx)) < 0)
                 {
-                    error( "ipmi_monitoring_sel_read_manufacturer_id(): %s",
-                            ipmi_monitoring_ctx_errormsg (ctx));
+                    collector_error( "ipmi_monitoring_sel_read_manufacturer_id(): %s",
+                                     ipmi_monitoring_ctx_errormsg (ctx));
                     goto cleanup;
                 }
 
@@ -1474,8 +1473,8 @@ _ipmimonitoring_sel (struct ipmi_monitoring_ipmi_config *ipmi_config)
 
             if ((oem_data_len = ipmi_monitoring_sel_read_oem_data (ctx, oem_data, 1024)) < 0)
             {
-                error( "ipmi_monitoring_sel_read_oem_data(): %s",
-                        ipmi_monitoring_ctx_errormsg (ctx));
+                collector_error( "ipmi_monitoring_sel_read_oem_data(): %s",
+                                 ipmi_monitoring_ctx_errormsg (ctx));
                 goto cleanup;
             }
 
@@ -1780,7 +1779,7 @@ int main (int argc, char **argv) {
             continue;
         }
 
-        error("freeipmi.plugin: ignoring parameter '%s'", argv[i]);
+        collector_error("freeipmi.plugin: ignoring parameter '%s'", argv[i]);
     }
 
     errno = 0;
@@ -1789,7 +1788,7 @@ int main (int argc, char **argv) {
         netdata_update_every = freq;
 
     else if(freq)
-        error("update frequency %d seconds is too small for IPMI. Using %d.", freq, netdata_update_every);
+        collector_error("update frequency %d seconds is too small for IPMI. Using %d.", freq, netdata_update_every);
 
 
     // ------------------------------------------------------------------------
@@ -1814,7 +1813,7 @@ int main (int argc, char **argv) {
     if(debug) fprintf(stderr, "freeipmi.plugin: IPMI minimum update frequency was calculated to %d seconds.\n", freq);
 
     if(freq > netdata_update_every) {
-        info("enforcing minimum data collection frequency, calculated to %d seconds.", freq);
+        collector_info("enforcing minimum data collection frequency, calculated to %d seconds.", freq);
         netdata_update_every = freq;
     }
 

--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -1596,6 +1596,7 @@ int host_is_local(const char *host)
 }
 
 int main (int argc, char **argv) {
+    stderror = stderr;
     clocks_init();
 
     // ------------------------------------------------------------------------

--- a/collectors/idlejitter.plugin/plugin_idlejitter.c
+++ b/collectors/idlejitter.plugin/plugin_idlejitter.c
@@ -10,7 +10,7 @@ static void cpuidlejitter_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-    info("cleaning up...");
+    collector_info("cleaning up...");
 
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }

--- a/collectors/macos.plugin/macos_fw.c
+++ b/collectors/macos.plugin/macos_fw.c
@@ -84,14 +84,14 @@ int do_macos_iokit(int update_every, usec_t dt) {
 
     /* Get ports and services for drive statistics. */
     if (unlikely(IOMainPort(bootstrap_port, &main_port))) {
-        error("MACOS: IOMasterPort() failed");
+        collector_error("MACOS: IOMasterPort() failed");
         do_io = 0;
-        error("DISABLED: system.io");
+        collector_error("DISABLED: system.io");
     /* Get the list of all drive objects. */
     } else if (unlikely(IOServiceGetMatchingServices(main_port, IOServiceMatching("IOBlockStorageDriver"), &drive_list))) {
-        error("MACOS: IOServiceGetMatchingServices() failed");
+        collector_error("MACOS: IOServiceGetMatchingServices() failed");
         do_io = 0;
-        error("DISABLED: system.io");
+        collector_error("DISABLED: system.io");
     } else {
         while ((drive = IOIteratorNext(drive_list)) != 0) {
             properties = 0;
@@ -126,9 +126,9 @@ int do_macos_iokit(int update_every, usec_t dt) {
             /* Obtain the properties for this drive object. */
             if (unlikely(IORegistryEntryCreateCFProperties(drive, (CFMutableDictionaryRef *)&properties, kCFAllocatorDefault, 0))) {
                 IOObjectRelease(drive);
-                error("MACOS: IORegistryEntryCreateCFProperties() failed");
+                collector_error("MACOS: IORegistryEntryCreateCFProperties() failed");
                 do_io = 0;
-                error("DISABLED: system.io");
+                collector_error("DISABLED: system.io");
                 break;
             } else if (likely(properties)) {
                 /* Obtain the statistics from the drive properties. */
@@ -413,11 +413,11 @@ int do_macos_iokit(int update_every, usec_t dt) {
     if (likely(do_space || do_inodes)) {
         // there is no mount info in sysctl MIBs
         if (unlikely(!(mntsize = getmntinfo(&mntbuf, MNT_NOWAIT)))) {
-            error("MACOS: getmntinfo() failed");
+            collector_error("MACOS: getmntinfo() failed");
             do_space = 0;
-            error("DISABLED: disk_space.X");
+            collector_error("DISABLED: disk_space.X");
             do_inodes = 0;
-            error("DISABLED: disk_inodes.X");
+            collector_error("DISABLED: disk_inodes.X");
         } else {
             for (i = 0; i < mntsize; i++) {
                 if (mntbuf[i].f_flags == MNT_RDONLY ||
@@ -500,9 +500,9 @@ int do_macos_iokit(int update_every, usec_t dt) {
 
     if (likely(do_bandwidth)) {
         if (unlikely(getifaddrs(&ifap))) {
-            error("MACOS: getifaddrs()");
+            collector_error("MACOS: getifaddrs()");
             do_bandwidth = 0;
-            error("DISABLED: system.ipv4");
+            collector_error("DISABLED: system.ipv4");
         } else {
             for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
                 if (ifa->ifa_addr->sa_family != AF_LINK)

--- a/collectors/macos.plugin/macos_mach_smi.c
+++ b/collectors/macos.plugin/macos_mach_smi.c
@@ -41,16 +41,16 @@ int do_macos_mach_smi(int update_every, usec_t dt) {
 
     if (likely(do_cpu)) {
         if (unlikely(HOST_CPU_LOAD_INFO_COUNT != 4)) {
-            error("MACOS: There are %d CPU states (4 was expected)", HOST_CPU_LOAD_INFO_COUNT);
+            collector_error("MACOS: There are %d CPU states (4 was expected)", HOST_CPU_LOAD_INFO_COUNT);
             do_cpu = 0;
-            error("DISABLED: system.cpu");
+            collector_error("DISABLED: system.cpu");
         } else {
             count = HOST_CPU_LOAD_INFO_COUNT;
             kr = host_statistics(host, HOST_CPU_LOAD_INFO, (host_info_t)cp_time, &count);
             if (unlikely(kr != KERN_SUCCESS)) {
-                error("MACOS: host_statistics() failed: %s", mach_error_string(kr));
+                collector_error("MACOS: host_statistics() failed: %s", mach_error_string(kr));
                 do_cpu = 0;
-                error("DISABLED: system.cpu");
+                collector_error("DISABLED: system.cpu");
             } else {
 
                 st = rrdset_find_active_bytype_localhost("system", "cpu");
@@ -95,13 +95,13 @@ int do_macos_mach_smi(int update_every, usec_t dt) {
         kr = host_statistics(host, HOST_VM_INFO, (host_info_t)&vm_statistics, &count);
 #endif
         if (unlikely(kr != KERN_SUCCESS)) {
-            error("MACOS: host_statistics64() failed: %s", mach_error_string(kr));
+            collector_error("MACOS: host_statistics64() failed: %s", mach_error_string(kr));
             do_ram = 0;
-            error("DISABLED: system.ram");
+            collector_error("DISABLED: system.ram");
             do_swapio = 0;
-            error("DISABLED: system.swapio");
+            collector_error("DISABLED: system.swapio");
             do_pgfaults = 0;
-            error("DISABLED: mem.pgfaults");
+            collector_error("DISABLED: mem.pgfaults");
         } else {
             if (likely(do_ram)) {
                 st = rrdset_find_active_localhost("system.ram");

--- a/collectors/macos.plugin/macos_sysctl.c
+++ b/collectors/macos.plugin/macos_sysctl.c
@@ -222,7 +222,7 @@ int do_macos_sysctl(int update_every, usec_t dt) {
         if (likely(do_loadavg)) {
             if (unlikely(GETSYSCTL_BY_NAME("vm.loadavg", sysload))) {
                 do_loadavg = 0;
-                error("DISABLED: system.load");
+                collector_error("DISABLED: system.load");
             } else {
 
                 st = rrdset_find_active_bytype_localhost("system", "load");
@@ -260,7 +260,7 @@ int do_macos_sysctl(int update_every, usec_t dt) {
     if (likely(do_swap)) {
         if (unlikely(GETSYSCTL_BY_NAME("vm.swapusage", swap_usage))) {
             do_swap = 0;
-            error("DISABLED: system.swap");
+            collector_error("DISABLED: system.swap");
         } else {
             st = rrdset_find_active_localhost("system.swap");
             if (unlikely(!st)) {
@@ -298,15 +298,15 @@ int do_macos_sysctl(int update_every, usec_t dt) {
         mib[4] = NET_RT_IFLIST2;
         mib[5] = 0;
         if (unlikely(sysctl(mib, 6, NULL, &size, NULL, 0))) {
-            error("MACOS: sysctl(%s...) failed: %s", "net interfaces", strerror(errno));
+            collector_error("MACOS: sysctl(%s...) failed: %s", "net interfaces", strerror(errno));
             do_bandwidth = 0;
-            error("DISABLED: system.ipv4");
+            collector_error("DISABLED: system.ipv4");
         } else {
             ifstatdata = reallocz(ifstatdata, size);
             if (unlikely(sysctl(mib, 6, ifstatdata, &size, NULL, 0) < 0)) {
-                error("MACOS: sysctl(%s...) failed: %s", "net interfaces", strerror(errno));
+                collector_error("MACOS: sysctl(%s...) failed: %s", "net interfaces", strerror(errno));
                 do_bandwidth = 0;
-                error("DISABLED: system.ipv4");
+                collector_error("DISABLED: system.ipv4");
             } else {
                 lim = ifstatdata + size;
                 iftot.ift_ibytes = iftot.ift_obytes = 0;
@@ -353,19 +353,19 @@ int do_macos_sysctl(int update_every, usec_t dt) {
     if (likely(do_tcp_packets || do_tcp_errors || do_tcp_handshake || do_tcpext_connaborts || do_tcpext_ofo || do_tcpext_syscookies || do_ecn)) {
         if (unlikely(GETSYSCTL_BY_NAME("net.inet.tcp.stats", tcpstat))){
             do_tcp_packets = 0;
-            error("DISABLED: ipv4.tcppackets");
+            collector_error("DISABLED: ipv4.tcppackets");
             do_tcp_errors = 0;
-            error("DISABLED: ipv4.tcperrors");
+            collector_error("DISABLED: ipv4.tcperrors");
             do_tcp_handshake = 0;
-            error("DISABLED: ipv4.tcphandshake");
+            collector_error("DISABLED: ipv4.tcphandshake");
             do_tcpext_connaborts = 0;
-            error("DISABLED: ipv4.tcpconnaborts");
+            collector_error("DISABLED: ipv4.tcpconnaborts");
             do_tcpext_ofo = 0;
-            error("DISABLED: ipv4.tcpofo");
+            collector_error("DISABLED: ipv4.tcpofo");
             do_tcpext_syscookies = 0;
-            error("DISABLED: ipv4.tcpsyncookies");
+            collector_error("DISABLED: ipv4.tcpsyncookies");
             do_ecn = 0;
-            error("DISABLED: ipv4.ecnpkts");
+            collector_error("DISABLED: ipv4.ecnpkts");
         } else {
             if (likely(do_tcp_packets)) {
                 st = rrdset_find_active_localhost("ipv4.tcppackets");
@@ -597,9 +597,9 @@ int do_macos_sysctl(int update_every, usec_t dt) {
     if (likely(do_udp_packets || do_udp_errors)) {
         if (unlikely(GETSYSCTL_BY_NAME("net.inet.udp.stats", udpstat))) {
             do_udp_packets = 0;
-            error("DISABLED: ipv4.udppackets");
+            collector_error("DISABLED: ipv4.udppackets");
             do_udp_errors = 0;
-            error("DISABLED: ipv4.udperrors");
+            collector_error("DISABLED: ipv4.udperrors");
         } else {
             if (likely(do_udp_packets)) {
                 st = rrdset_find_active_localhost("ipv4.udppackets");
@@ -673,10 +673,10 @@ int do_macos_sysctl(int update_every, usec_t dt) {
     if (likely(do_icmp_packets || do_icmpmsg)) {
         if (unlikely(GETSYSCTL_BY_NAME("net.inet.icmp.stats", icmpstat))) {
             do_icmp_packets = 0;
-            error("DISABLED: ipv4.icmp");
-            error("DISABLED: ipv4.icmp_errors");
+            collector_error("DISABLED: ipv4.icmp");
+            collector_error("DISABLED: ipv4.icmp_errors");
             do_icmpmsg = 0;
-            error("DISABLED: ipv4.icmpmsg");
+            collector_error("DISABLED: ipv4.icmpmsg");
         } else {
             for (i = 0; i <= ICMP_MAXTYPE; i++) {
                 icmp_total.msgs_in += icmpstat.icps_inhist[i];
@@ -777,13 +777,13 @@ int do_macos_sysctl(int update_every, usec_t dt) {
     if (likely(do_ip_packets || do_ip_fragsout || do_ip_fragsin || do_ip_errors)) {
         if (unlikely(GETSYSCTL_BY_NAME("net.inet.ip.stats", ipstat))) {
             do_ip_packets = 0;
-            error("DISABLED: ipv4.packets");
+            collector_error("DISABLED: ipv4.packets");
             do_ip_fragsout = 0;
-            error("DISABLED: ipv4.fragsout");
+            collector_error("DISABLED: ipv4.fragsout");
             do_ip_fragsin = 0;
-            error("DISABLED: ipv4.fragsin");
+            collector_error("DISABLED: ipv4.fragsin");
             do_ip_errors = 0;
-            error("DISABLED: ipv4.errors");
+            collector_error("DISABLED: ipv4.errors");
         } else {
             if (likely(do_ip_packets)) {
                 st = rrdset_find_active_localhost("ipv4.packets");
@@ -919,13 +919,13 @@ int do_macos_sysctl(int update_every, usec_t dt) {
     if (likely(do_ip6_packets || do_ip6_fragsout || do_ip6_fragsin || do_ip6_errors)) {
         if (unlikely(GETSYSCTL_BY_NAME("net.inet6.ip6.stats", ip6stat))) {
             do_ip6_packets = 0;
-            error("DISABLED: ipv6.packets");
+            collector_error("DISABLED: ipv6.packets");
             do_ip6_fragsout = 0;
-            error("DISABLED: ipv6.fragsout");
+            collector_error("DISABLED: ipv6.fragsout");
             do_ip6_fragsin = 0;
-            error("DISABLED: ipv6.fragsin");
+            collector_error("DISABLED: ipv6.fragsin");
             do_ip6_errors = 0;
-            error("DISABLED: ipv6.errors");
+            collector_error("DISABLED: ipv6.errors");
         } else {
             if (do_ip6_packets == CONFIG_BOOLEAN_YES || (do_ip6_packets == CONFIG_BOOLEAN_AUTO &&
                                                          (ip6stat.ip6s_localout ||
@@ -1096,7 +1096,7 @@ int do_macos_sysctl(int update_every, usec_t dt) {
     if (likely(do_icmp6 || do_icmp6_redir || do_icmp6_errors || do_icmp6_echos || do_icmp6_router || do_icmp6_neighbor || do_icmp6_types)) {
         if (unlikely(GETSYSCTL_BY_NAME("net.inet6.icmp6.stats", icmp6stat))) {
             do_icmp6 = 0;
-            error("DISABLED: ipv6.icmp");
+            collector_error("DISABLED: ipv6.icmp");
         } else {
             for (i = 0; i <= ICMP6_MAXTYPE; i++) {
                 icmp6_total.msgs_in += icmp6stat.icp6s_inhist[i];
@@ -1392,7 +1392,7 @@ int do_macos_sysctl(int update_every, usec_t dt) {
     if (likely(do_uptime)) {
         if (unlikely(GETSYSCTL_BY_NAME("kern.boottime", boot_time))) {
             do_uptime = 0;
-            error("DISABLED: system.uptime");
+            collector_error("DISABLED: system.uptime");
         } else {
             clock_gettime(CLOCK_REALTIME, &cur_time);
             st = rrdset_find_active_localhost("system.uptime");

--- a/collectors/macos.plugin/plugin_macos.c
+++ b/collectors/macos.plugin/plugin_macos.c
@@ -32,7 +32,7 @@ static void macos_main_cleanup(void *ptr)
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-    info("cleaning up...");
+    collector_info("cleaning up...");
 
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }

--- a/collectors/nfacct.plugin/plugin_nfacct.c
+++ b/collectors/nfacct.plugin/plugin_nfacct.c
@@ -92,14 +92,14 @@ static int nfstat_init(int update_every) {
 
     nfstat_root.mnl  = mnl_socket_open(NETLINK_NETFILTER);
     if(!nfstat_root.mnl) {
-        error("NFSTAT: mnl_socket_open() failed");
+        collector_error("NFSTAT: mnl_socket_open() failed");
         return 1;
     }
 
     nfstat_root.seq = (unsigned int)now_realtime_sec() - 1;
 
     if(mnl_socket_bind(nfstat_root.mnl, 0, MNL_SOCKET_AUTOPID) < 0) {
-        error("NFSTAT: mnl_socket_bind() failed");
+        collector_error("NFSTAT: mnl_socket_bind() failed");
         return 1;
     }
     nfstat_root.portid = mnl_socket_get_portid(nfstat_root.mnl);
@@ -132,7 +132,7 @@ static int nfct_stats_attr_cb(const struct nlattr *attr, void *data) {
         return MNL_CB_OK;
 
     if (mnl_attr_validate(attr, MNL_TYPE_U32) < 0) {
-        error("NFSTAT: mnl_attr_validate() failed");
+        collector_error("NFSTAT: mnl_attr_validate() failed");
         return MNL_CB_ERROR;
     }
 
@@ -173,7 +173,7 @@ static int nfstat_collect_conntrack() {
 
     // send the request
     if(mnl_socket_sendto(nfstat_root.mnl, nfstat_root.nlh, nfstat_root.nlh->nlmsg_len) < 0) {
-        error("NFSTAT: mnl_socket_sendto() failed");
+        collector_error("NFSTAT: mnl_socket_sendto() failed");
         return 1;
     }
 
@@ -193,7 +193,7 @@ static int nfstat_collect_conntrack() {
 
     // verify we run without issues
     if (ret == -1) {
-        error("NFSTAT: error communicating with kernel. This plugin can only work when netdata runs as root.");
+        collector_error("NFSTAT: error communicating with kernel. This plugin can only work when netdata runs as root.");
         return 1;
     }
 
@@ -209,7 +209,7 @@ static int nfexp_stats_attr_cb(const struct nlattr *attr, void *data)
         return MNL_CB_OK;
 
     if (mnl_attr_validate(attr, MNL_TYPE_U32) < 0) {
-        error("NFSTAT EXP: mnl_attr_validate() failed");
+        collector_error("NFSTAT EXP: mnl_attr_validate() failed");
         return MNL_CB_ERROR;
     }
 
@@ -245,7 +245,7 @@ static int nfstat_collect_conntrack_expectations() {
 
     // send the request
     if(mnl_socket_sendto(nfstat_root.mnl, nfstat_root.nlh, nfstat_root.nlh->nlmsg_len) < 0) {
-        error("NFSTAT: mnl_socket_sendto() failed");
+        collector_error("NFSTAT: mnl_socket_sendto() failed");
         return 1;
     }
 
@@ -265,7 +265,7 @@ static int nfstat_collect_conntrack_expectations() {
 
     // verify we run without issues
     if (ret == -1) {
-        error("NFSTAT: error communicating with kernel. This plugin can only work when netdata runs as root.");
+        collector_error("NFSTAT: error communicating with kernel. This plugin can only work when netdata runs as root.");
         return 1;
     }
 
@@ -561,7 +561,7 @@ static int nfacct_init(int update_every) {
 
     nfacct_root.nfacct_buffer = nfacct_alloc();
     if(!nfacct_root.nfacct_buffer) {
-        error("nfacct.plugin: nfacct_alloc() failed.");
+        collector_error("nfacct.plugin: nfacct_alloc() failed.");
         return 0;
     }
 
@@ -569,12 +569,12 @@ static int nfacct_init(int update_every) {
 
     nfacct_root.mnl  = mnl_socket_open(NETLINK_NETFILTER);
     if(!nfacct_root.mnl) {
-        error("nfacct.plugin: mnl_socket_open() failed");
+        collector_error("nfacct.plugin: mnl_socket_open() failed");
         return 1;
     }
 
     if(mnl_socket_bind(nfacct_root.mnl, 0, MNL_SOCKET_AUTOPID) < 0) {
-        error("nfacct.plugin: mnl_socket_bind() failed");
+        collector_error("nfacct.plugin: mnl_socket_bind() failed");
         return 1;
     }
     nfacct_root.portid = mnl_socket_get_portid(nfacct_root.mnl);
@@ -586,7 +586,7 @@ static int nfacct_callback(const struct nlmsghdr *nlh, void *data) {
     (void)data;
 
     if(nfacct_nlmsg_parse_payload(nlh, nfacct_root.nfacct_buffer) < 0) {
-        error("NFACCT: nfacct_nlmsg_parse_payload() failed.");
+        collector_error("NFACCT: nfacct_nlmsg_parse_payload() failed.");
         return MNL_CB_OK;
     }
 
@@ -612,13 +612,13 @@ static int nfacct_collect() {
     nfacct_root.seq++;
     nfacct_root.nlh = nfacct_nlmsg_build_hdr(nfacct_root.buf, NFNL_MSG_ACCT_GET, NLM_F_DUMP, (uint32_t)nfacct_root.seq);
     if(!nfacct_root.nlh) {
-        error("NFACCT: nfacct_nlmsg_build_hdr() failed");
+        collector_error("NFACCT: nfacct_nlmsg_build_hdr() failed");
         return 1;
     }
 
     // send the request
     if(mnl_socket_sendto(nfacct_root.mnl, nfacct_root.nlh, nfacct_root.nlh->nlmsg_len) < 0) {
-        error("NFACCT: mnl_socket_sendto() failed");
+        collector_error("NFACCT: mnl_socket_sendto() failed");
         return 1;
     }
 
@@ -638,7 +638,7 @@ static int nfacct_collect() {
 
     // verify we run without issues
     if (ret == -1) {
-        error("NFACCT: error communicating with kernel. This plugin can only work when netdata runs as root.");
+        collector_error("NFACCT: error communicating with kernel. This plugin can only work when netdata runs as root.");
         return 1;
     }
 
@@ -740,7 +740,7 @@ void nfacct_signals()
 
     for (i = 0; signals[i]; i++) {
         if(sigaction(signals[i], &sa, NULL) == -1)
-            error("Cannot add the handler to signal %d", signals[i]);
+            collector_error("Cannot add the handler to signal %d", signals[i]);
     }
 }
 
@@ -814,7 +814,7 @@ int main(int argc, char **argv) {
             exit(1);
         }
 
-        error("nfacct.plugin: ignoring parameter '%s'", argv[i]);
+        collector_error("nfacct.plugin: ignoring parameter '%s'", argv[i]);
     }
 
     nfacct_signals();
@@ -824,7 +824,7 @@ int main(int argc, char **argv) {
     if(freq >= netdata_update_every)
         netdata_update_every = freq;
     else if(freq)
-        error("update frequency %d seconds is too small for NFACCT. Using %d.", freq, netdata_update_every);
+        collector_error("update frequency %d seconds is too small for NFACCT. Using %d.", freq, netdata_update_every);
 
     if (debug)
         fprintf(stderr, "nfacct.plugin: calling nfacct_init()\n");
@@ -883,5 +883,5 @@ int main(int argc, char **argv) {
         if(now_monotonic_sec() - started_t > 14400) break;
     }
 
-    info("NFACCT process exiting");
+    collector_info("NFACCT process exiting");
 }

--- a/collectors/nfacct.plugin/plugin_nfacct.c
+++ b/collectors/nfacct.plugin/plugin_nfacct.c
@@ -745,6 +745,7 @@ void nfacct_signals()
 }
 
 int main(int argc, char **argv) {
+    stderror = stderr;
     clocks_init();
 
     // ------------------------------------------------------------------------

--- a/collectors/perf.plugin/perf_plugin.c
+++ b/collectors/perf.plugin/perf_plugin.c
@@ -1283,6 +1283,7 @@ void parse_command_line(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+    stderror = stderr;
     clocks_init();
 
     // ------------------------------------------------------------------------

--- a/collectors/perf.plugin/perf_plugin.c
+++ b/collectors/perf.plugin/perf_plugin.c
@@ -294,15 +294,15 @@ static int perf_init() {
             if(unlikely(fd < 0)) {
                 switch errno {
                     case EACCES:
-                        error("Cannot access to the PMU: Permission denied");
+                        collector_error("Cannot access to the PMU: Permission denied");
                         break;
                     case EBUSY:
-                        error("Another event already has exclusive access to the PMU");
+                        collector_error("Another event already has exclusive access to the PMU");
                         break;
                     default:
-                        error("Cannot open perf event");
+                        collector_error("Cannot open perf event");
                 }
-                error("Disabling event %u", current_event->id);
+                collector_error("Disabling event %u", current_event->id);
                 current_event->disabled = 1;
             }
 
@@ -346,7 +346,7 @@ static void reenable_events() {
             if(ioctl(current_fd, PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP) == -1
                || ioctl(current_fd, PERF_EVENT_IOC_ENABLE, PERF_IOC_FLAG_GROUP) == -1)
             {
-                error("Cannot reenable event group");
+                collector_error("Cannot reenable event group");
             }
         }
     }
@@ -388,7 +388,7 @@ static int perf_collect() {
                 current_event->updated = 1;
             }
             else {
-                error("Cannot update value for event %u", current_event->id);
+                collector_error("Cannot update value for event %u", current_event->id);
                 return 1;
             }
         }
@@ -1272,11 +1272,11 @@ void parse_command_line(int argc, char **argv) {
             exit(1);
         }
 
-        error("ignoring parameter '%s'", argv[i]);
+        collector_error("ignoring parameter '%s'", argv[i]);
     }
 
     if(!plugin_enabled){
-        info("no charts enabled - nothing to do.");
+        collector_info("no charts enabled - nothing to do.");
         printf("DISABLE\n");
         exit(1);
     }
@@ -1305,7 +1305,7 @@ int main(int argc, char **argv) {
     if(freq >= update_every)
         update_every = freq;
     else if(freq)
-        error("update frequency %d seconds is too small for PERF. Using %d.", freq, update_every);
+        collector_error("update frequency %d seconds is too small for PERF. Using %d.", freq, update_every);
 
     if(unlikely(debug)) fprintf(stderr, "perf.plugin: calling perf_init()\n");
     int perf = !perf_init();
@@ -1349,6 +1349,6 @@ int main(int argc, char **argv) {
         if(now_monotonic_sec() - started_t > 14400) break;
     }
 
-    info("process exiting");
+    collector_info("process exiting");
     perf_free();
 }

--- a/collectors/proc.plugin/ipc.c
+++ b/collectors/proc.plugin/ipc.c
@@ -82,7 +82,7 @@ static inline int ipc_sem_get_limits(struct ipc_limits *lim) {
         ff = procfile_open(filename, NULL, PROCFILE_FLAG_DEFAULT);
         if(unlikely(!ff)) {
             if(unlikely(!error_shown)) {
-                error("IPC: Cannot open file '%s'.", filename);
+                collector_error("IPC: Cannot open file '%s'.", filename);
                 error_shown = 1;
             }
             goto ipc;
@@ -92,7 +92,7 @@ static inline int ipc_sem_get_limits(struct ipc_limits *lim) {
     ff = procfile_readall(ff);
     if(unlikely(!ff)) {
         if(unlikely(!error_shown)) {
-            error("IPC: Cannot read file '%s'.", filename);
+            collector_error("IPC: Cannot read file '%s'.", filename);
             error_shown = 1;
         }
         goto ipc;
@@ -108,7 +108,7 @@ static inline int ipc_sem_get_limits(struct ipc_limits *lim) {
     }
     else {
         if(unlikely(!error_shown)) {
-            error("IPC: Invalid content in file '%s'.", filename);
+            collector_error("IPC: Invalid content in file '%s'.", filename);
             error_shown = 1;
         }
         goto ipc;
@@ -122,7 +122,7 @@ ipc:
         union semun arg = {.array = (ushort *) &seminfo};
 
         if(unlikely(semctl(0, 0, IPC_INFO, arg) < 0)) {
-            error("IPC: Failed to read '%s' and request IPC_INFO with semctl().", filename);
+            collector_error("IPC: Failed to read '%s' and request IPC_INFO with semctl().", filename);
             goto error;
         }
 
@@ -166,7 +166,7 @@ static inline int ipc_sem_get_status(struct ipc_status *st) {
         /* kernel not configured for semaphores */
         static int error_shown = 0;
         if(unlikely(!error_shown)) {
-            error("IPC: kernel is not configured for semaphores");
+            collector_error("IPC: kernel is not configured for semaphores");
             error_shown = 1;
         }
         st->semusz = 0;
@@ -195,7 +195,7 @@ int ipc_msq_get_info(char *msg_filename, struct message_queue **message_queue_ro
     size_t words = 0;
 
     if(unlikely(lines < 2)) {
-        error("Cannot read %s. Expected 2 or more lines, read %zu.", procfile_filename(ff), lines);
+        collector_error("Cannot read %s. Expected 2 or more lines, read %zu.", procfile_filename(ff), lines);
         return 1;
     }
 
@@ -205,7 +205,7 @@ int ipc_msq_get_info(char *msg_filename, struct message_queue **message_queue_ro
         words = procfile_linewords(ff, l);
         if(unlikely(words < 2)) continue;
         if(unlikely(words < 14)) {
-            error("Cannot read %s line. Expected 14 params, read %zu.", procfile_filename(ff), words);
+            collector_error("Cannot read %s line. Expected 14 params, read %zu.", procfile_filename(ff), words);
             continue;
         }
 
@@ -250,7 +250,7 @@ int ipc_shm_get_info(char *shm_filename, struct shm_stats *shm) {
     size_t words = 0;
 
     if(unlikely(lines < 2)) {
-        error("Cannot read %s. Expected 2 or more lines, read %zu.", procfile_filename(ff), lines);
+        collector_error("Cannot read %s. Expected 2 or more lines, read %zu.", procfile_filename(ff), lines);
         return 1;
     }
 
@@ -263,7 +263,7 @@ int ipc_shm_get_info(char *shm_filename, struct shm_stats *shm) {
         words = procfile_linewords(ff, l);
         if(unlikely(words < 2)) continue;
         if(unlikely(words < 16)) {
-            error("Cannot read %s line. Expected 16 params, read %zu.", procfile_filename(ff), words);
+            collector_error("Cannot read %s line. Expected 16 params, read %zu.", procfile_filename(ff), words);
             continue;
         }
 
@@ -306,11 +306,11 @@ int do_ipc(int update_every, usec_t dt) {
 
         // make sure it works
         if(ipc_sem_get_limits(&limits) == -1) {
-            error("unable to fetch semaphore limits");
+            collector_error("unable to fetch semaphore limits");
             do_sem = CONFIG_BOOLEAN_NO;
         }
         else if(ipc_sem_get_status(&status) == -1) {
-            error("unable to fetch semaphore statistics");
+            collector_error("unable to fetch semaphore statistics");
             do_sem = CONFIG_BOOLEAN_NO;
         }
         else {
@@ -362,7 +362,7 @@ int do_ipc(int update_every, usec_t dt) {
         }
 
         if(unlikely(do_sem == CONFIG_BOOLEAN_NO && do_msg == CONFIG_BOOLEAN_NO)) {
-            error("ipc module disabled");
+            collector_error("ipc module disabled");
             return 1;
         }
     }
@@ -370,7 +370,7 @@ int do_ipc(int update_every, usec_t dt) {
     if(likely(do_sem != CONFIG_BOOLEAN_NO)) {
         if(unlikely(read_limits_next < 0)) {
             if(unlikely(ipc_sem_get_limits(&limits) == -1)) {
-                error("Unable to fetch semaphore limits.");
+                collector_error("Unable to fetch semaphore limits.");
             }
             else {
                 if(semaphores_max) rrdvar_custom_host_variable_set(localhost, semaphores_max, limits.semmns);
@@ -386,7 +386,7 @@ int do_ipc(int update_every, usec_t dt) {
             read_limits_next--;
 
         if(unlikely(ipc_sem_get_status(&status) == -1)) {
-            error("Unable to get semaphore statistics");
+            collector_error("Unable to get semaphore statistics");
             return 0;
         }
 
@@ -478,8 +478,8 @@ int do_ipc(int update_every, usec_t dt) {
             long long dimensions_num = rrdset_number_of_dimensions(st_msq_messages);
 
             if(unlikely(dimensions_num > dimensions_limit)) {
-                info("Message queue statistics has been disabled");
-                info("There are %lld dimensions in memory but limit was set to %lld", dimensions_num, dimensions_limit);
+                collector_info("Message queue statistics has been disabled");
+                collector_info("There are %lld dimensions in memory but limit was set to %lld", dimensions_num, dimensions_limit);
                 rrdset_is_obsolete(st_msq_messages);
                 rrdset_is_obsolete(st_msq_bytes);
                 st_msq_messages = NULL;
@@ -487,11 +487,11 @@ int do_ipc(int update_every, usec_t dt) {
                 do_msg = CONFIG_BOOLEAN_NO;
             }
             else if(unlikely(!message_queue_root)) {
-                info("Making chart %s (%s) obsolete since it does not have any dimensions", rrdset_name(st_msq_messages), rrdset_id(st_msq_messages));
+                collector_info("Making chart %s (%s) obsolete since it does not have any dimensions", rrdset_name(st_msq_messages), rrdset_id(st_msq_messages));
                 rrdset_is_obsolete(st_msq_messages);
                 st_msq_messages = NULL;
 
-                info("Making chart %s (%s) obsolete since it does not have any dimensions", rrdset_name(st_msq_bytes), rrdset_id(st_msq_bytes));
+                collector_info("Making chart %s (%s) obsolete since it does not have any dimensions", rrdset_name(st_msq_bytes), rrdset_id(st_msq_bytes));
                 rrdset_is_obsolete(st_msq_bytes);
                 st_msq_bytes = NULL;
             }

--- a/collectors/proc.plugin/plugin_proc.c
+++ b/collectors/proc.plugin/plugin_proc.c
@@ -86,7 +86,7 @@ static void proc_main_cleanup(void *ptr)
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-    info("cleaning up...");
+    collector_info("cleaning up...");
 
     if (netdev_thread) {
         netdata_thread_join(*netdev_thread, NULL);

--- a/collectors/proc.plugin/proc_interrupts.c
+++ b/collectors/proc.plugin/proc_interrupts.c
@@ -78,7 +78,7 @@ int do_proc_interrupts(int update_every, usec_t dt) {
     size_t words = procfile_linewords(ff, 0);
 
     if(unlikely(!lines)) {
-        error("Cannot read /proc/interrupts, zero lines reported.");
+        collector_error("Cannot read /proc/interrupts, zero lines reported.");
         return 1;
     }
 
@@ -93,7 +93,7 @@ int do_proc_interrupts(int update_every, usec_t dt) {
     }
 
     if(unlikely(!cpus)) {
-        error("PLUGIN: PROC_INTERRUPTS: Cannot find the number of CPUs in /proc/interrupts");
+        collector_error("PLUGIN: PROC_INTERRUPTS: Cannot find the number of CPUs in /proc/interrupts");
         return 1;
     }
 

--- a/collectors/proc.plugin/proc_loadavg.c
+++ b/collectors/proc.plugin/proc_loadavg.c
@@ -32,11 +32,11 @@ int do_proc_loadavg(int update_every, usec_t dt) {
     }
 
     if(unlikely(procfile_lines(ff) < 1)) {
-        error("/proc/loadavg has no lines.");
+        collector_error("/proc/loadavg has no lines.");
         return 1;
     }
     if(unlikely(procfile_linewords(ff, 0) < 6)) {
-        error("/proc/loadavg has less than 6 words in it.");
+        collector_error("/proc/loadavg has less than 6 words in it.");
         return 1;
     }
 

--- a/collectors/proc.plugin/proc_mdstat.c
+++ b/collectors/proc.plugin/proc_mdstat.c
@@ -135,7 +135,7 @@ int do_proc_mdstat(int update_every, usec_t dt)
     size_t words = 0;
 
     if (unlikely(lines < 2)) {
-        error("Cannot read /proc/mdstat. Expected 2 or more lines, read %zu.", lines);
+        collector_error("Cannot read /proc/mdstat. Expected 2 or more lines, read %zu.", lines);
         return 1;
     }
 
@@ -212,7 +212,7 @@ int do_proc_mdstat(int update_every, usec_t dt)
 
             s = procfile_lineword(ff, l, words - 2);
             if (unlikely(s[0] != '[')) {
-                error("Cannot read /proc/mdstat raid health status. Unexpected format: missing opening bracket.");
+                collector_error("Cannot read /proc/mdstat raid health status. Unexpected format: missing opening bracket.");
                 continue;
             }
             str_total = ++s;
@@ -227,7 +227,7 @@ int do_proc_mdstat(int update_every, usec_t dt)
                 s++;
             }
             if (unlikely(str_total[0] == '\0' || !str_inuse || str_inuse[0] == '\0')) {
-                error("Cannot read /proc/mdstat raid health status. Unexpected format.");
+                collector_error("Cannot read /proc/mdstat raid health status. Unexpected format.");
                 continue;
             }
 
@@ -260,7 +260,7 @@ int do_proc_mdstat(int update_every, usec_t dt)
                 continue;
 
             if (unlikely(words < 7)) {
-                error("Cannot read /proc/mdstat line. Expected 7 params, read %zu.", words);
+                collector_error("Cannot read /proc/mdstat line. Expected 7 params, read %zu.", words);
                 continue;
             }
 
@@ -326,9 +326,9 @@ int do_proc_mdstat(int update_every, usec_t dt)
                     raid->mismatch_cnt_filename = strdupz(filename);
                 }
                 if (unlikely(read_single_number_file(raid->mismatch_cnt_filename, &raid->mismatch_cnt))) {
-                    error("Cannot read file '%s'", raid->mismatch_cnt_filename);
+                    collector_error("Cannot read file '%s'", raid->mismatch_cnt_filename);
                     do_mismatch = CONFIG_BOOLEAN_NO;
-                    error("Monitoring for mismatch count has been disabled");
+                    collector_error("Monitoring for mismatch count has been disabled");
                     break;
                 }
             }

--- a/collectors/proc.plugin/proc_net_netstat.c
+++ b/collectors/proc.plugin/proc_net_netstat.c
@@ -97,7 +97,7 @@ static void parse_line_pair(procfile *ff_netstat, ARL_BASE *base, size_t header_
     size_t w;
 
     if(unlikely(vwords > hwords)) {
-        error("File /proc/net/netstat on header line %zu has %zu words, but on value line %zu has %zu words.", header_line, hwords, values_line, vwords);
+        collector_error("File /proc/net/netstat on header line %zu has %zu words, but on value line %zu has %zu words.", header_line, hwords, values_line, vwords);
         vwords = hwords;
     }
 
@@ -366,7 +366,7 @@ static void do_proc_net_snmp6(int update_every) {
         size_t words = procfile_linewords(ff_snmp6, l);
         if (unlikely(words < 2)) {
             if (unlikely(words)) {
-                error("Cannot read /proc/net/snmp6 line %zu. Expected 2 params, read %zu.", l, words);
+                collector_error("Cannot read /proc/net/snmp6 line %zu. Expected 2 params, read %zu.", l, words);
                 continue;
             }
         }
@@ -1678,7 +1678,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             words = procfile_linewords(ff_netstat, l);
             if(unlikely(words < 2)) {
-                error("Cannot read /proc/net/netstat IpExt line. Expected 2+ params, read %zu.", words);
+                collector_error("Cannot read /proc/net/netstat IpExt line. Expected 2+ params, read %zu.", words);
                 continue;
             }
 
@@ -1690,7 +1690,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             words = procfile_linewords(ff_netstat, l);
             if(unlikely(words < 2)) {
-                error("Cannot read /proc/net/netstat TcpExt line. Expected 2+ params, read %zu.", words);
+                collector_error("Cannot read /proc/net/netstat TcpExt line. Expected 2+ params, read %zu.", words);
                 continue;
             }
 
@@ -1721,13 +1721,13 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
             size_t h = l++;
 
             if(strcmp(procfile_lineword(ff_snmp, l, 0), "Ip") != 0) {
-                error("Cannot read Ip line from /proc/net/snmp.");
+                collector_error("Cannot read Ip line from /proc/net/snmp.");
                 break;
             }
 
             words = procfile_linewords(ff_snmp, l);
             if(words < 3) {
-                error("Cannot read /proc/net/snmp Ip line. Expected 3+ params, read %zu.", words);
+                collector_error("Cannot read /proc/net/snmp Ip line. Expected 3+ params, read %zu.", words);
                 continue;
             }
 
@@ -1741,13 +1741,13 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
             size_t h = l++;
 
             if(strcmp(procfile_lineword(ff_snmp, l, 0), "Icmp") != 0) {
-                error("Cannot read Icmp line from /proc/net/snmp.");
+                collector_error("Cannot read Icmp line from /proc/net/snmp.");
                 break;
             }
 
             words = procfile_linewords(ff_snmp, l);
             if(words < 3) {
-                error("Cannot read /proc/net/snmp Icmp line. Expected 3+ params, read %zu.", words);
+                collector_error("Cannot read /proc/net/snmp Icmp line. Expected 3+ params, read %zu.", words);
                 continue;
             }
 
@@ -1761,13 +1761,13 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
             size_t h = l++;
 
             if(strcmp(procfile_lineword(ff_snmp, l, 0), "IcmpMsg") != 0) {
-                error("Cannot read IcmpMsg line from /proc/net/snmp.");
+                collector_error("Cannot read IcmpMsg line from /proc/net/snmp.");
                 break;
             }
 
             words = procfile_linewords(ff_snmp, l);
             if(words < 2) {
-                error("Cannot read /proc/net/snmp IcmpMsg line. Expected 2+ params, read %zu.", words);
+                collector_error("Cannot read /proc/net/snmp IcmpMsg line. Expected 2+ params, read %zu.", words);
                 continue;
             }
 
@@ -1781,13 +1781,13 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
             size_t h = l++;
 
             if(strcmp(procfile_lineword(ff_snmp, l, 0), "Tcp") != 0) {
-                error("Cannot read Tcp line from /proc/net/snmp.");
+                collector_error("Cannot read Tcp line from /proc/net/snmp.");
                 break;
             }
 
             words = procfile_linewords(ff_snmp, l);
             if(words < 3) {
-                error("Cannot read /proc/net/snmp Tcp line. Expected 3+ params, read %zu.", words);
+                collector_error("Cannot read /proc/net/snmp Tcp line. Expected 3+ params, read %zu.", words);
                 continue;
             }
 
@@ -1801,13 +1801,13 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
             size_t h = l++;
 
             if(strcmp(procfile_lineword(ff_snmp, l, 0), "Udp") != 0) {
-                error("Cannot read Udp line from /proc/net/snmp.");
+                collector_error("Cannot read Udp line from /proc/net/snmp.");
                 break;
             }
 
             words = procfile_linewords(ff_snmp, l);
             if(words < 3) {
-                error("Cannot read /proc/net/snmp Udp line. Expected 3+ params, read %zu.", words);
+                collector_error("Cannot read /proc/net/snmp Udp line. Expected 3+ params, read %zu.", words);
                 continue;
             }
 
@@ -1821,13 +1821,13 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
             size_t h = l++;
 
             if(strcmp(procfile_lineword(ff_snmp, l, 0), "UdpLite") != 0) {
-                error("Cannot read UdpLite line from /proc/net/snmp.");
+                collector_error("Cannot read UdpLite line from /proc/net/snmp.");
                 break;
             }
 
             words = procfile_linewords(ff_snmp, l);
             if(words < 3) {
-                error("Cannot read /proc/net/snmp UdpLite line. Expected 3+ params, read %zu.", words);
+                collector_error("Cannot read /proc/net/snmp UdpLite line. Expected 3+ params, read %zu.", words);
                 continue;
             }
 

--- a/collectors/proc.plugin/proc_net_rpc_nfs.c
+++ b/collectors/proc.plugin/proc_net_rpc_nfs.c
@@ -183,7 +183,7 @@ int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
 
         if(do_net == 1 && strcmp(type, "net") == 0) {
             if(words < 5) {
-                error("%s line of /proc/net/rpc/nfs has %zu words, expected %d", type, words, 5);
+                collector_error("%s line of /proc/net/rpc/nfs has %zu words, expected %d", type, words, 5);
                 continue;
             }
 
@@ -198,7 +198,7 @@ int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
         }
         else if(do_rpc == 1 && strcmp(type, "rpc") == 0) {
             if(words < 4) {
-                error("%s line of /proc/net/rpc/nfs has %zu words, expected %d", type, words, 6);
+                collector_error("%s line of /proc/net/rpc/nfs has %zu words, expected %d", type, words, 6);
                 continue;
             }
 
@@ -224,7 +224,7 @@ int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
 
             if(sum == 0ULL) {
                 if(!proc2_warning) {
-                    error("Disabling /proc/net/rpc/nfs v2 procedure calls chart. It seems unused on this machine. It will be enabled automatically when found with data in it.");
+                    collector_error("Disabling /proc/net/rpc/nfs v2 procedure calls chart. It seems unused on this machine. It will be enabled automatically when found with data in it.");
                     proc2_warning = 1;
                 }
                 do_proc2 = 0;
@@ -245,7 +245,7 @@ int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
 
             if(sum == 0ULL) {
                 if(!proc3_warning) {
-                    info("Disabling /proc/net/rpc/nfs v3 procedure calls chart. It seems unused on this machine. It will be enabled automatically when found with data in it.");
+                    collector_info("Disabling /proc/net/rpc/nfs v3 procedure calls chart. It seems unused on this machine. It will be enabled automatically when found with data in it.");
                     proc3_warning = 1;
                 }
                 do_proc3 = 0;
@@ -266,7 +266,7 @@ int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
 
             if(sum == 0ULL) {
                 if(!proc4_warning) {
-                    info("Disabling /proc/net/rpc/nfs v4 procedure calls chart. It seems unused on this machine. It will be enabled automatically when found with data in it.");
+                    collector_info("Disabling /proc/net/rpc/nfs v4 procedure calls chart. It seems unused on this machine. It will be enabled automatically when found with data in it.");
                     proc4_warning = 1;
                 }
                 do_proc4 = 0;

--- a/collectors/proc.plugin/proc_net_rpc_nfsd.c
+++ b/collectors/proc.plugin/proc_net_rpc_nfsd.c
@@ -282,7 +282,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
 
         if(do_rc == 1 && strcmp(type, "rc") == 0) {
             if(unlikely(words < 4)) {
-                error("%s line of /proc/net/rpc/nfsd has %zu words, expected %d", type, words, 4);
+                collector_error("%s line of /proc/net/rpc/nfsd has %zu words, expected %d", type, words, 4);
                 continue;
             }
 
@@ -296,7 +296,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
         }
         else if(do_fh == 1 && strcmp(type, "fh") == 0) {
             if(unlikely(words < 6)) {
-                error("%s line of /proc/net/rpc/nfsd has %zu words, expected %d", type, words, 6);
+                collector_error("%s line of /proc/net/rpc/nfsd has %zu words, expected %d", type, words, 6);
                 continue;
             }
 
@@ -309,7 +309,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
         }
         else if(do_io == 1 && strcmp(type, "io") == 0) {
             if(unlikely(words < 3)) {
-                error("%s line of /proc/net/rpc/nfsd has %zu words, expected %d", type, words, 3);
+                collector_error("%s line of /proc/net/rpc/nfsd has %zu words, expected %d", type, words, 3);
                 continue;
             }
 
@@ -322,7 +322,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
         }
         else if(do_th == 1 && strcmp(type, "th") == 0) {
             if(unlikely(words < 13)) {
-                error("%s line of /proc/net/rpc/nfsd has %zu words, expected %d", type, words, 13);
+                collector_error("%s line of /proc/net/rpc/nfsd has %zu words, expected %d", type, words, 13);
                 continue;
             }
 
@@ -335,7 +335,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
         }
         else if(do_net == 1 && strcmp(type, "net") == 0) {
             if(unlikely(words < 5)) {
-                error("%s line of /proc/net/rpc/nfsd has %zu words, expected %d", type, words, 5);
+                collector_error("%s line of /proc/net/rpc/nfsd has %zu words, expected %d", type, words, 5);
                 continue;
             }
 
@@ -350,7 +350,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
         }
         else if(do_rpc == 1 && strcmp(type, "rpc") == 0) {
             if(unlikely(words < 6)) {
-                error("%s line of /proc/net/rpc/nfsd has %zu words, expected %d", type, words, 6);
+                collector_error("%s line of /proc/net/rpc/nfsd has %zu words, expected %d", type, words, 6);
                 continue;
             }
 
@@ -377,7 +377,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
 
             if(sum == 0ULL) {
                 if(!proc2_warning) {
-                    error("Disabling /proc/net/rpc/nfsd v2 procedure calls chart. It seems unused on this machine. It will be enabled automatically when found with data in it.");
+                    collector_error("Disabling /proc/net/rpc/nfsd v2 procedure calls chart. It seems unused on this machine. It will be enabled automatically when found with data in it.");
                     proc2_warning = 1;
                 }
                 do_proc2 = 0;
@@ -398,7 +398,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
 
             if(sum == 0ULL) {
                 if(!proc3_warning) {
-                    info("Disabling /proc/net/rpc/nfsd v3 procedure calls chart. It seems unused on this machine. It will be enabled automatically when found with data in it.");
+                    collector_info("Disabling /proc/net/rpc/nfsd v3 procedure calls chart. It seems unused on this machine. It will be enabled automatically when found with data in it.");
                     proc3_warning = 1;
                 }
                 do_proc3 = 0;
@@ -419,7 +419,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
 
             if(sum == 0ULL) {
                 if(!proc4_warning) {
-                    info("Disabling /proc/net/rpc/nfsd v4 procedure calls chart. It seems unused on this machine. It will be enabled automatically when found with data in it.");
+                    collector_info("Disabling /proc/net/rpc/nfsd v4 procedure calls chart. It seems unused on this machine. It will be enabled automatically when found with data in it.");
                     proc4_warning = 1;
                 }
                 do_proc4 = 0;
@@ -440,7 +440,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
 
             if(sum == 0ULL) {
                 if(!proc4ops_warning) {
-                    info("Disabling /proc/net/rpc/nfsd v4 operations chart. It seems unused on this machine. It will be enabled automatically when found with data in it.");
+                    collector_info("Disabling /proc/net/rpc/nfsd v4 operations chart. It seems unused on this machine. It will be enabled automatically when found with data in it.");
                     proc4ops_warning = 1;
                 }
                 do_proc4ops = 0;

--- a/collectors/proc.plugin/proc_net_sctp_snmp.c
+++ b/collectors/proc.plugin/proc_net_sctp_snmp.c
@@ -113,7 +113,7 @@ int do_proc_net_sctp_snmp(int update_every, usec_t dt) {
     for(l = 0; l < lines ;l++) {
         size_t words = procfile_linewords(ff, l);
         if(unlikely(words < 2)) {
-            if(unlikely(words)) error("Cannot read /proc/net/sctp/snmp line %zu. Expected 2 params, read %zu.", l, words);
+            if(unlikely(words)) collector_error("Cannot read /proc/net/sctp/snmp line %zu. Expected 2 params, read %zu.", l, words);
             continue;
         }
 

--- a/collectors/proc.plugin/proc_net_softnet_stat.c
+++ b/collectors/proc.plugin/proc_net_softnet_stat.c
@@ -40,7 +40,7 @@ int do_proc_net_softnet_stat(int update_every, usec_t dt) {
     size_t words = procfile_linewords(ff, 0), w;
 
     if(unlikely(!lines || !words)) {
-        error("Cannot read /proc/net/softnet_stat, %zu lines and %zu columns reported.", lines, words);
+        collector_error("Cannot read /proc/net/softnet_stat, %zu lines and %zu columns reported.", lines, words);
         return 1;
     }
 

--- a/collectors/proc.plugin/proc_net_stat_conntrack.c
+++ b/collectors/proc.plugin/proc_net_stat_conntrack.c
@@ -69,7 +69,7 @@ int do_proc_net_stat_conntrack(int update_every, usec_t dt) {
         for(l = 1; l < lines ;l++) {
             size_t words = procfile_linewords(ff, l);
             if(unlikely(words < 17)) {
-                if(unlikely(words)) error("Cannot read /proc/net/stat/nf_conntrack line. Expected 17 params, read %zu.", words);
+                if(unlikely(words)) collector_error("Cannot read /proc/net/stat/nf_conntrack line. Expected 17 params, read %zu.", words);
                 continue;
             }
 

--- a/collectors/proc.plugin/proc_net_stat_synproxy.c
+++ b/collectors/proc.plugin/proc_net_stat_synproxy.c
@@ -34,7 +34,7 @@ int do_proc_net_stat_synproxy(int update_every, usec_t dt) {
     // make sure we have 3 lines
     size_t lines = procfile_lines(ff), l;
     if(unlikely(lines < 2)) {
-        error("/proc/net/stat/synproxy has %zu lines, expected no less than 2. Disabling it.", lines);
+        collector_error("/proc/net/stat/synproxy has %zu lines, expected no less than 2. Disabling it.", lines);
         return 1;
     }
 

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -112,7 +112,7 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
 
         ff_lines = procfile_lines(ff);
         if(unlikely(!ff_lines)) {
-            error("PLUGIN: PROC_PAGETYPEINFO: Cannot read %s, zero lines reported.", ff_path);
+            collector_error("PLUGIN: PROC_PAGETYPEINFO: Cannot read %s, zero lines reported.", ff_path);
             return 1;
         }
 
@@ -135,21 +135,21 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
             pagelines_cnt++;
         }
         if (pagelines_cnt == 0) {
-            error("PLUGIN: PROC_PAGETYPEINFO: Unable to parse any valid line in %s", ff_path);
+            collector_error("PLUGIN: PROC_PAGETYPEINFO: Unable to parse any valid line in %s", ff_path);
             return 1;
         }
 
         // 4th line is the "Free pages count per migrate type at order". Just subtract these 8 words.
         pageorders_cnt = procfile_linewords(ff, 3);
         if (pageorders_cnt < 9) {
-            error("PLUGIN: PROC_PAGETYPEINFO: Unable to parse Line 4 of %s", ff_path);
+            collector_error("PLUGIN: PROC_PAGETYPEINFO: Unable to parse Line 4 of %s", ff_path);
             return 1;
         }
 
         pageorders_cnt -= 9;
 
         if (pageorders_cnt > MAX_PAGETYPE_ORDER) {
-            error("PLUGIN: PROC_PAGETYPEINFO: pageorder found (%lu) is higher than max %d",
+            collector_error("PLUGIN: PROC_PAGETYPEINFO: pageorder found (%lu) is higher than max %d",
                   (long unsigned int) pageorders_cnt, MAX_PAGETYPE_ORDER);
             return 1;
         }
@@ -158,7 +158,7 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
         if (!pagelines) {
             pagelines = callocz(pagelines_cnt, sizeof(struct pageline));
             if (!pagelines) {
-                error("PLUGIN: PROC_PAGETYPEINFO: Cannot allocate %lu pagelines of %lu B",
+                collector_error("PLUGIN: PROC_PAGETYPEINFO: Cannot allocate %lu pagelines of %lu B",
                       (long unsigned int) pagelines_cnt, (long unsigned int) sizeof(struct pageline));
                 return 1;
             }
@@ -291,8 +291,8 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
         size_t words = procfile_linewords(ff, l);
 
         if (words != 7+pageorders_cnt) {
-            error("PLUGIN: PROC_PAGETYPEINFO: Unable to read line %lu, %lu words found instead of %lu",
-                  l+1, (long unsigned int) words, (long unsigned int) 7+pageorders_cnt);
+            collector_error("PLUGIN: PROC_PAGETYPEINFO: Unable to read line %lu, %lu words found instead of %lu",
+                            l+1, (long unsigned int) words, (long unsigned int) 7+pageorders_cnt);
             break;
         }
 

--- a/collectors/proc.plugin/proc_pressure.c
+++ b/collectors/proc.plugin/proc_pressure.c
@@ -171,7 +171,7 @@ int do_proc_pressure(int update_every, usec_t dt) {
 
             ff = procfile_open(filename, " =", PROCFILE_FLAG_DEFAULT);
             if (unlikely(!ff)) {
-                error("Cannot read pressure information from %s.", filename);
+                collector_error("Cannot read pressure information from %s.", filename);
                 fail_count++;
                 continue;
             }
@@ -186,7 +186,7 @@ int do_proc_pressure(int update_every, usec_t dt) {
 
         size_t lines = procfile_lines(ff);
         if (unlikely(lines < 1)) {
-            error("%s has no lines.", procfile_filename(ff));
+            collector_error("%s has no lines.", procfile_filename(ff));
             fail_count++;
             continue;
         }

--- a/collectors/proc.plugin/proc_self_mountinfo.c
+++ b/collectors/proc.plugin/proc_self_mountinfo.c
@@ -253,7 +253,7 @@ struct mountinfo *mountinfo_read(int do_statvfs) {
         for(minor = major; *minor && *minor != ':' ;minor++) ;
 
         if(unlikely(!*minor)) {
-            error("Cannot parse major:minor on '%s' at line %lu of '%s'", major, l + 1, filename);
+            collector_error("Cannot parse major:minor on '%s' at line %lu of '%s'", major, l + 1, filename);
             freez(mi);
             continue;
         }
@@ -443,7 +443,7 @@ struct mountinfo *mountinfo_read(int do_statvfs) {
 
 #ifdef NETDATA_INTERNAL_CHECKS
                     if(unlikely(!mi)) {
-                        error("Mount point '%s' not found in /proc/self/mountinfo", mnt->mnt_dir);
+                        collector_error("Mount point '%s' not found in /proc/self/mountinfo", mnt->mnt_dir);
                     }
 #endif
                 }

--- a/collectors/proc.plugin/proc_softirqs.c
+++ b/collectors/proc.plugin/proc_softirqs.c
@@ -75,7 +75,7 @@ int do_proc_softirqs(int update_every, usec_t dt) {
     size_t words = procfile_linewords(ff, 0);
 
     if(unlikely(!lines)) {
-        error("Cannot read /proc/softirqs, zero lines reported.");
+        collector_error("Cannot read /proc/softirqs, zero lines reported.");
         return 1;
     }
 
@@ -90,7 +90,7 @@ int do_proc_softirqs(int update_every, usec_t dt) {
     }
 
     if(unlikely(!cpus)) {
-        error("PLUGIN: PROC_SOFTIRQS: Cannot find the number of CPUs in /proc/softirqs");
+        collector_error("PLUGIN: PROC_SOFTIRQS: Cannot find the number of CPUs in /proc/softirqs");
         return 1;
     }
 

--- a/collectors/proc.plugin/proc_spl_kstat_zfs.c
+++ b/collectors/proc.plugin/proc_spl_kstat_zfs.c
@@ -140,7 +140,7 @@ int do_proc_spl_kstat_zfs_arcstats(int update_every, usec_t dt) {
     if(likely(!do_zfs_stats)) {
         DIR *dir = opendir(dirname);
         if(unlikely(!dir)) {
-            error("Cannot read directory '%s'", dirname);
+            collector_error("Cannot read directory '%s'", dirname);
             return 1;
         }
 
@@ -177,7 +177,7 @@ int do_proc_spl_kstat_zfs_arcstats(int update_every, usec_t dt) {
     for(l = 0; l < lines ;l++) {
         size_t words = procfile_linewords(ff, l);
         if(unlikely(words < 3)) {
-            if(unlikely(words)) error("Cannot read " ZFS_PROC_ARCSTATS " line %zu. Expected 3 params, read %zu.", l, words);
+            if(unlikely(words)) collector_error("Cannot read " ZFS_PROC_ARCSTATS " line %zu. Expected 3 params, read %zu.", l, words);
             continue;
         }
 
@@ -330,7 +330,7 @@ int do_proc_spl_kstat_zfs_pool_state(int update_every, usec_t dt)
     if (likely(do_zfs_pool_state)) {
         DIR *dir = opendir(dirname);
         if (unlikely(!dir)) {
-            error("Cannot read directory '%s'", dirname);
+            collector_error("Cannot read directory '%s'", dirname);
             return 1;
         }
 
@@ -394,7 +394,7 @@ int do_proc_spl_kstat_zfs_pool_state(int update_every, usec_t dt)
                         char *c = strchr(state, '\n');
                         if (c)
                             *c = '\0';
-                        error("ZFS POOLS: Undefined state %s for zpool %s, disabling the chart", state, de->d_name);
+                        collector_error("ZFS POOLS: Undefined state %s for zpool %s, disabling the chart", state, de->d_name);
                     }
                 }
             }
@@ -404,7 +404,7 @@ int do_proc_spl_kstat_zfs_pool_state(int update_every, usec_t dt)
     }
 
     if (do_zfs_pool_state && pool_found && !state_file_found) {
-        info("ZFS POOLS: State files not found. Disabling the module.");
+        collector_info("ZFS POOLS: State files not found. Disabling the module.");
         do_zfs_pool_state = 0;
     }
 

--- a/collectors/proc.plugin/proc_stat.c
+++ b/collectors/proc.plugin/proc_stat.c
@@ -69,7 +69,7 @@ static int read_per_core_files(struct cpu_chart *all_cpu_charts, size_t len, siz
         if(unlikely(f->fd == -1)) {
             f->fd = open(f->filename, O_RDONLY);
             if (unlikely(f->fd == -1)) {
-                error("Cannot open file '%s'", f->filename);
+                collector_error("Cannot open file '%s'", f->filename);
                 continue;
             }
         }
@@ -78,7 +78,7 @@ static int read_per_core_files(struct cpu_chart *all_cpu_charts, size_t len, siz
         if(unlikely(ret < 0)) {
             // cannot read that file
 
-            error("Cannot read file '%s'", f->filename);
+            collector_error("Cannot read file '%s'", f->filename);
             close(f->fd);
             f->fd = -1;
             continue;
@@ -94,7 +94,7 @@ static int read_per_core_files(struct cpu_chart *all_cpu_charts, size_t len, siz
                 f->fd = -1;
             }
             else if(lseek(f->fd, 0, SEEK_SET) == -1) {
-                error("Cannot seek in file '%s'", f->filename);
+                collector_error("Cannot seek in file '%s'", f->filename);
                 close(f->fd);
                 f->fd = -1;
             }
@@ -133,14 +133,14 @@ static int read_per_core_time_in_state_files(struct cpu_chart *all_cpu_charts, s
             tsf->ff = procfile_open(tsf->filename, " \t:", PROCFILE_FLAG_DEFAULT);
             if(unlikely(!tsf->ff))
             {
-                error("Cannot open file '%s'", tsf->filename);
+                collector_error("Cannot open file '%s'", tsf->filename);
                 continue;
             }
         }
 
         tsf->ff = procfile_readall(tsf->ff);
         if(unlikely(!tsf->ff)) {
-            error("Cannot read file '%s'", tsf->filename);
+            collector_error("Cannot read file '%s'", tsf->filename);
             procfile_close(tsf->ff);
             tsf->ff = NULL;
             continue;
@@ -179,7 +179,7 @@ static int read_per_core_time_in_state_files(struct cpu_chart *all_cpu_charts, s
 
                 words = procfile_linewords(tsf->ff, l);
                 if(unlikely(words < 2)) {
-                    error("Cannot read time_in_state line. Expected 2 params, read %zu.", words);
+                    collector_error("Cannot read time_in_state line. Expected 2 params, read %zu.", words);
                     continue;
                 }
                 frequency = str2ull(procfile_lineword(tsf->ff, l, 0));
@@ -273,11 +273,11 @@ static void* wake_cpu_thread(void* core) {
     thread = pthread_self();
     if(unlikely(pthread_setaffinity_np(thread, sizeof(cpu_set_t), &cpu_set))) {
         if(unlikely(errors < 8)) {
-            error("Cannot set CPU affinity for core %d", *(int*)core);
+            collector_error("Cannot set CPU affinity for core %d", *(int*)core);
             errors++;
         }
         else if(unlikely(errors < 9)) {
-            error("CPU affinity errors are disabled");
+            collector_error("CPU affinity errors are disabled");
             errors++;
         }
     }
@@ -312,14 +312,14 @@ static int read_schedstat(char *schedstat_filename, struct per_core_cpuidle_char
         if(likely(row_key[0] == 'c' && row_key[1] == 'p' && row_key[2] == 'u')) {
             words = procfile_linewords(ff, l);
             if(unlikely(words < 10)) {
-                error("Cannot read /proc/schedstat cpu line. Expected 9 params, read %zu.", words);
+                collector_error("Cannot read /proc/schedstat cpu line. Expected 9 params, read %zu.", words);
                 return 1;
             }
             cores_found++;
 
             size_t core = str2ul(&row_key[3]);
             if(unlikely(core >= cores_found)) {
-                error("Core %zu found but no more than %zu cores were expected.", core, cores_found);
+                collector_error("Core %zu found but no more than %zu cores were expected.", core, cores_found);
                 return 1;
             }
 
@@ -343,7 +343,7 @@ static int read_one_state(char *buf, const char *filename, int *fd) {
 
     if(unlikely(ret <= 0)) {
         // cannot read that file
-        error("Cannot read file '%s'", filename);
+        collector_error("Cannot read file '%s'", filename);
         close(*fd);
         *fd = -1;
         return 0;
@@ -359,7 +359,7 @@ static int read_one_state(char *buf, const char *filename, int *fd) {
             *fd = -1;
         }
         else if(lseek(*fd, 0, SEEK_SET) == -1) {
-            error("Cannot seek in file '%s'", filename);
+            collector_error("Cannot seek in file '%s'", filename);
             close(*fd);
             *fd = -1;
         }
@@ -413,14 +413,14 @@ static int read_cpuidle_states(char *cpuidle_name_filename , char *cpuidle_time_
 
             int fd = open(filename, O_RDONLY, 0666);
             if(unlikely(fd == -1)) {
-                error("Cannot open file '%s'", filename);
+                collector_error("Cannot open file '%s'", filename);
                 cc->rescan_cpu_states = 1;
                 return 1;
             }
 
             ssize_t r = read(fd, name_buf, 50);
             if(unlikely(r < 1)) {
-                error("Cannot read file '%s'", filename);
+                collector_error("Cannot read file '%s'", filename);
                 close(fd);
                 cc->rescan_cpu_states = 1;
                 return 1;
@@ -445,7 +445,7 @@ static int read_cpuidle_states(char *cpuidle_name_filename , char *cpuidle_time_
         if(unlikely(cs->time_fd == -1)) {
             cs->time_fd = open(cs->time_filename, O_RDONLY);
             if (unlikely(cs->time_fd == -1)) {
-                error("Cannot open file '%s'", cs->time_filename);
+                collector_error("Cannot open file '%s'", cs->time_filename);
                 cc->rescan_cpu_states = 1;
                 return 1;
             }
@@ -585,7 +585,7 @@ int do_proc_stat(int update_every, usec_t dt) {
         if(likely(row_key[0] == 'c' && row_key[1] == 'p' && row_key[2] == 'u')) {
             words = procfile_linewords(ff, l);
             if(unlikely(words < 9)) {
-                error("Cannot read /proc/stat cpu line. Expected 9 params, read %zu.", words);
+                collector_error("Cannot read /proc/stat cpu line. Expected 9 params, read %zu.", words);
                 continue;
             }
 
@@ -930,7 +930,7 @@ int do_proc_stat(int update_every, usec_t dt) {
                 if(r > 0 && !accurate_freq_is_used) {
                     accurate_freq_is_used = 1;
                     snprintfz(filename, FILENAME_MAX, time_in_state_filename, "cpu*");
-                    info("cpufreq is using %s", filename);
+                    collector_info("cpufreq is using %s", filename);
                 }
             }
             if (r < 1) {
@@ -938,7 +938,7 @@ int do_proc_stat(int update_every, usec_t dt) {
                 if(accurate_freq_is_used) {
                     accurate_freq_is_used = 0;
                     snprintfz(filename, FILENAME_MAX, scaling_cur_freq_filename, "cpu*");
-                    info("cpufreq fell back to %s", filename);
+                    collector_info("cpufreq fell back to %s", filename);
                 }
             }
 
@@ -993,13 +993,13 @@ int do_proc_stat(int update_every, usec_t dt) {
                     }
                 }
                 else
-                    error("Cannot read current process affinity");
+                    collector_error("Cannot read current process affinity");
 
                 // These threads are very ephemeral and don't need to have a specific name
                 if(unlikely(pthread_create(&thread, NULL, wake_cpu_thread, (void *)&core)))
-                    error("Cannot create wake_cpu_thread");
+                    collector_error("Cannot create wake_cpu_thread");
                 else if(unlikely(pthread_join(thread, NULL)))
-                    error("Cannot join wake_cpu_thread");
+                    collector_error("Cannot join wake_cpu_thread");
                 cpu_states_updated = 1;
             }
         }

--- a/collectors/proc.plugin/proc_vmstat.c
+++ b/collectors/proc.plugin/proc_vmstat.c
@@ -100,7 +100,7 @@ int do_proc_vmstat(int update_every, usec_t dt) {
     for(l = 0; l < lines ;l++) {
         size_t words = procfile_linewords(ff, l);
         if(unlikely(words < 2)) {
-            if(unlikely(words)) error("Cannot read /proc/vmstat line %zu. Expected 2 params, read %zu.", l, words);
+            if(unlikely(words)) collector_error("Cannot read /proc/vmstat line %zu. Expected 2 params, read %zu.", l, words);
             continue;
         }
 

--- a/collectors/proc.plugin/sys_block_zram.c
+++ b/collectors/proc.plugin/sys_block_zram.c
@@ -144,17 +144,17 @@ static int init_devices(DICTIONARY *devices, unsigned int zram_id, int update_ev
         snprintfz(filename, FILENAME_MAX, "/dev/%s", de->d_name);
         if (unlikely(stat(filename, &st) != 0))
         {
-            error("ZRAM : Unable to stat %s: %s", filename, strerror(errno));
+            collector_error("ZRAM : Unable to stat %s: %s", filename, strerror(errno));
             continue;
         }
         if (major(st.st_rdev) == zram_id)
         {
-            info("ZRAM : Found device %s", filename);
+            collector_info("ZRAM : Found device %s", filename);
             snprintfz(filename, FILENAME_MAX, "/sys/block/%s/mm_stat", de->d_name);
             ff = procfile_open(filename, " \t:", PROCFILE_FLAG_DEFAULT);
             if (ff == NULL)
             {
-                error("ZRAM : Failed to open %s: %s", filename, strerror(errno));
+                collector_error("ZRAM : Failed to open %s: %s", filename, strerror(errno));
                 continue;
             }
             device.file = ff;
@@ -170,7 +170,7 @@ static int init_devices(DICTIONARY *devices, unsigned int zram_id, int update_ev
 static void free_device(DICTIONARY *dict, const char *name)
 {
     ZRAM_DEVICE *d = (ZRAM_DEVICE*)dictionary_get(dict, name);
-    info("ZRAM : Disabling monitoring of device %s", name);
+    collector_info("ZRAM : Disabling monitoring of device %s", name);
     rrdset_obsolete_and_pointer_null(d->st_usage);
     rrdset_obsolete_and_pointer_null(d->st_savings);
     rrdset_obsolete_and_pointer_null(d->st_alloc_efficiency);
@@ -252,7 +252,7 @@ int do_sys_block_zram(int update_every, usec_t dt) {
         ff = procfile_open("/proc/devices", " \t:", PROCFILE_FLAG_DEFAULT);
         if (ff == NULL)
         {
-            error("Cannot read /proc/devices");
+            collector_error("Cannot read /proc/devices");
             return 1;
         }
         ff = procfile_readall(ff);

--- a/collectors/proc.plugin/sys_class_infiniband.c
+++ b/collectors/proc.plugin/sys_class_infiniband.c
@@ -200,7 +200,7 @@ static struct ibport {
 #define GEN_DO_HWCOUNTER_READ(NAME, GRP, DESC, DIR, PORT, HW, ...)                                                     \
     if (HW->file_##NAME) {                                                                                             \
         if (read_single_number_file(HW->file_##NAME, (unsigned long long *)&HW->NAME)) {                               \
-            error("cannot read iface '%s' hwcounter '" #HW "'", PORT->name);                                           \
+            collector_error("cannot read iface '%s' hwcounter '" #HW "'", PORT->name);                                           \
             HW->file_##NAME = NULL;                                                                                    \
         }                                                                                                              \
     }
@@ -469,7 +469,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
                 snprintfz(buffer, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "rate");
                 char buffer_rate[65];
                 if (read_file(buffer, buffer_rate, 64)) {
-                    error("Unable to read '%s'", buffer);
+                    collector_error("Unable to read '%s'", buffer);
                     p->width = 1;
                 } else {
                     char *buffer_width = strstr(buffer_rate, "(");
@@ -480,12 +480,11 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
                 }
 
                 if (!p->discovered)
-                    info(
-                        "Infiniband card %s port %s at speed %" PRIu64 " width %" PRIu64 "",
-                        dev_dent->d_name,
-                        port_dent->d_name,
-                        p->speed,
-                        p->width);
+                    collector_info("Infiniband card %s port %s at speed %" PRIu64 " width %" PRIu64 "",
+                                   dev_dent->d_name,
+                                   port_dent->d_name,
+                                   p->speed,
+                                   p->width);
 
                 p->discovered = 1;
             }
@@ -511,7 +510,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
 #define GEN_DO_COUNTER_READ(NAME, GRP, DESC, DIR, PORT, ...)                                                           \
     if (PORT->file_##NAME) {                                                                                           \
         if (read_single_number_file(PORT->file_##NAME, (unsigned long long *)&PORT->NAME)) {                           \
-            error("cannot read iface '%s' counter '" #NAME "'", PORT->name);                                           \
+            collector_error("cannot read iface '%s' counter '" #NAME "'", PORT->name);                                           \
             PORT->file_##NAME = NULL;                                                                                  \
         }                                                                                                              \
     }
@@ -650,7 +649,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
 
                     // Unknown vendor, should not happen
                     else {
-                        error(
+                        collector_error(
                             "Unmanaged vendor for '%s', do_hwerrors should have been set to no. Please report this bug",
                             port->name);
                         port->do_hwerrors = CONFIG_BOOLEAN_NO;
@@ -686,7 +685,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
 
                     // Unknown vendor, should not happen
                     else {
-                        error(
+                        collector_error(
                             "Unmanaged vendor for '%s', do_hwpackets should have been set to no. Please report this bug",
                             port->name);
                         port->do_hwpackets = CONFIG_BOOLEAN_NO;

--- a/collectors/proc.plugin/sys_class_power_supply.c
+++ b/collectors/proc.plugin/sys_class_power_supply.c
@@ -137,7 +137,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
 
     DIR *dir = opendir(dirname);
     if(unlikely(!dir)) {
-        error("Cannot read directory '%s'", dirname);
+        collector_error("Cannot read directory '%s'", dirname);
         return 1;
     }
 
@@ -247,7 +247,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                 if(unlikely(ps->capacity->fd == -1)) {
                     ps->capacity->fd = open(ps->capacity->filename, O_RDONLY, 0666);
                     if(unlikely(ps->capacity->fd == -1)) {
-                        error("Cannot open file '%s'", ps->capacity->filename);
+                        collector_error("Cannot open file '%s'", ps->capacity->filename);
                         power_supply_free(ps);
                         ps = NULL;
                     }
@@ -257,7 +257,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                 {
                     ssize_t r = read(ps->capacity->fd, buffer, 30);
                     if(unlikely(r < 1)) {
-                        error("Cannot read file '%s'", ps->capacity->filename);
+                        collector_error("Cannot read file '%s'", ps->capacity->filename);
                         power_supply_free(ps);
                         ps = NULL;
                     }
@@ -270,7 +270,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                             ps->capacity->fd = -1;
                         }
                         else if(unlikely(lseek(ps->capacity->fd, 0, SEEK_SET) == -1)) {
-                            error("Cannot seek in file '%s'", ps->capacity->filename);
+                            collector_error("Cannot seek in file '%s'", ps->capacity->filename);
                             close(ps->capacity->fd);
                             ps->capacity->fd = -1;
                         }
@@ -292,7 +292,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                             if(unlikely(pd->fd == -1)) {
                                 pd->fd = open(pd->filename, O_RDONLY, 0666);
                                 if(unlikely(pd->fd == -1)) {
-                                    error("Cannot open file '%s'", pd->filename);
+                                    collector_error("Cannot open file '%s'", pd->filename);
                                     read_error = 1;
                                     power_supply_free(ps);
                                     break;
@@ -301,7 +301,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
 
                             ssize_t r = read(pd->fd, buffer, 30);
                             if(unlikely(r < 1)) {
-                                error("Cannot read file '%s'", pd->filename);
+                                collector_error("Cannot read file '%s'", pd->filename);
                                 read_error = 1;
                                 power_supply_free(ps);
                                 break;
@@ -314,7 +314,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                                 pd->fd = -1;
                             }
                             else if(unlikely(lseek(pd->fd, 0, SEEK_SET) == -1)) {
-                                error("Cannot seek in file '%s'", pd->filename);
+                                collector_error("Cannot seek in file '%s'", pd->filename);
                                 close(pd->fd);
                                 pd->fd = -1;
                             }

--- a/collectors/proc.plugin/sys_devices_system_edac_mc.c
+++ b/collectors/proc.plugin/sys_devices_system_edac_mc.c
@@ -30,7 +30,7 @@ static void find_all_mc() {
 
     DIR *dir = opendir(dirname);
     if(unlikely(!dir)) {
-        error("Cannot read ECC memory errors directory '%s'", dirname);
+        collector_error("Cannot read ECC memory errors directory '%s'", dirname);
         return;
     }
 

--- a/collectors/proc.plugin/sys_devices_system_node.c
+++ b/collectors/proc.plugin/sys_devices_system_node.c
@@ -19,7 +19,7 @@ static int find_all_nodes() {
 
     DIR *dir = opendir(dirname);
     if(!dir) {
-        error("Cannot read NUMA node directory '%s'", dirname);
+        collector_error("Cannot read NUMA node directory '%s'", dirname);
         return 0;
     }
 
@@ -134,7 +134,7 @@ int do_proc_sys_devices_system_node(int update_every, usec_t dt) {
 
                     if(unlikely(words < 2)) {
                         if(unlikely(words))
-                            error("Cannot read %s numastat line %zu. Expected 2 params, read %zu.", m->name, l, words);
+                            collector_error("Cannot read %s numastat line %zu. Expected 2 params, read %zu.", m->name, l, words);
                         continue;
                     }
 

--- a/collectors/proc.plugin/sys_fs_btrfs.c
+++ b/collectors/proc.plugin/sys_fs_btrfs.c
@@ -90,7 +90,7 @@ static inline void btrfs_free_disk(BTRFS_DISK *d) {
 }
 
 static inline void btrfs_free_node(BTRFS_NODE *node) {
-    // info("BTRFS: destroying '%s'", node->id);
+    // collector_info("BTRFS: destroying '%s'", node->id);
 
     if(node->st_allocation_disks)
         rrdset_is_obsolete(node->st_allocation_disks);
@@ -136,7 +136,7 @@ static inline int find_btrfs_disks(BTRFS_NODE *node, const char *path) {
     DIR *dir = opendir(path);
     if (!dir) {
         if(!node->logged_error) {
-            error("BTRFS: Cannot open directory '%s'.", path);
+            collector_error("BTRFS: Cannot open directory '%s'.", path);
             node->logged_error = 1;
         }
         return 1;
@@ -149,7 +149,7 @@ static inline int find_btrfs_disks(BTRFS_NODE *node, const char *path) {
             || !strcmp(de->d_name, ".")
             || !strcmp(de->d_name, "..")
                 ) {
-            // info("BTRFS: ignoring '%s'", de->d_name);
+            // collector_info("BTRFS: ignoring '%s'", de->d_name);
             continue;
         }
 
@@ -200,13 +200,13 @@ static inline int find_btrfs_disks(BTRFS_NODE *node, const char *path) {
         // update the values
 
         if(read_single_number_file(d->size_filename, &d->size) != 0) {
-            error("BTRFS: failed to read '%s'", d->size_filename);
+            collector_error("BTRFS: failed to read '%s'", d->size_filename);
             d->exists = 0;
             continue;
         }
 
         if(read_single_number_file(d->hw_sector_size_filename, &d->hw_sector_size) != 0) {
-            error("BTRFS: failed to read '%s'", d->hw_sector_size_filename);
+            collector_error("BTRFS: failed to read '%s'", d->hw_sector_size_filename);
             d->exists = 0;
             continue;
         }
@@ -257,7 +257,7 @@ static inline int find_all_btrfs_pools(const char *path) {
     DIR *dir = opendir(path);
     if (!dir) {
         if(!logged_error) {
-            error("BTRFS: Cannot open directory '%s'.", path);
+            collector_error("BTRFS: Cannot open directory '%s'.", path);
             logged_error = 1;
         }
         return 1;
@@ -271,7 +271,7 @@ static inline int find_all_btrfs_pools(const char *path) {
            || !strcmp(de->d_name, "..")
            || !strcmp(de->d_name, "features")
                 ) {
-            // info("BTRFS: ignoring '%s'", de->d_name);
+            // collector_info("BTRFS: ignoring '%s'", de->d_name);
             continue;
         }
 
@@ -285,7 +285,7 @@ static inline int find_all_btrfs_pools(const char *path) {
 
         // did we find it?
         if(node) {
-            // info("BTRFS: already exists '%s'", de->d_name);
+            // collector_info("BTRFS: already exists '%s'", de->d_name);
             node->exists = 1;
 
             // update the disk sizes
@@ -295,7 +295,7 @@ static inline int find_all_btrfs_pools(const char *path) {
             continue;
         }
 
-        // info("BTRFS: adding '%s'", de->d_name);
+        // collector_info("BTRFS: adding '%s'", de->d_name);
 
         // not found, create it
         node = callocz(sizeof(BTRFS_NODE), 1);
@@ -309,7 +309,7 @@ static inline int find_all_btrfs_pools(const char *path) {
 
             snprintfz(filename, FILENAME_MAX, "%s/%s/label", path, de->d_name);
             if(read_file(filename, label, FILENAME_MAX) != 0) {
-                error("BTRFS: failed to read '%s'", filename);
+                collector_error("BTRFS: failed to read '%s'", filename);
                 btrfs_free_node(node);
                 continue;
             }
@@ -326,21 +326,21 @@ static inline int find_all_btrfs_pools(const char *path) {
 
         //snprintfz(filename, FILENAME_MAX, "%s/%s/sectorsize", path, de->d_name);
         //if(read_single_number_file(filename, &node->sectorsize) != 0) {
-        //    error("BTRFS: failed to read '%s'", filename);
+        //    collector_error("BTRFS: failed to read '%s'", filename);
         //    btrfs_free_node(node);
         //    continue;
         //}
 
         //snprintfz(filename, FILENAME_MAX, "%s/%s/nodesize", path, de->d_name);
         //if(read_single_number_file(filename, &node->nodesize) != 0) {
-        //    error("BTRFS: failed to read '%s'", filename);
+        //    collector_error("BTRFS: failed to read '%s'", filename);
         //    btrfs_free_node(node);
         //    continue;
         //}
 
         //snprintfz(filename, FILENAME_MAX, "%s/%s/quota_override", path, de->d_name);
         //if(read_single_number_file(filename, &node->quota_override) != 0) {
-        //    error("BTRFS: failed to read '%s'", filename);
+        //    collector_error("BTRFS: failed to read '%s'", filename);
         //    btrfs_free_node(node);
         //    continue;
         //}
@@ -351,7 +351,7 @@ static inline int find_all_btrfs_pools(const char *path) {
         #define init_btrfs_allocation_field(FIELD) {\
             snprintfz(filename, FILENAME_MAX, "%s/%s/allocation/" #FIELD, path, de->d_name); \
             if(read_single_number_file(filename, &node->allocation_ ## FIELD) != 0) {\
-                error("BTRFS: failed to read '%s'", filename);\
+                collector_error("BTRFS: failed to read '%s'", filename);\
                 btrfs_free_node(node);\
                 continue;\
             }\
@@ -362,7 +362,7 @@ static inline int find_all_btrfs_pools(const char *path) {
         #define init_btrfs_allocation_section_field(SECTION, FIELD) {\
             snprintfz(filename, FILENAME_MAX, "%s/%s/allocation/" #SECTION "/" #FIELD, path, de->d_name); \
             if(read_single_number_file(filename, &node->allocation_ ## SECTION ## _ ## FIELD) != 0) {\
-                error("BTRFS: failed to read '%s'", filename);\
+                collector_error("BTRFS: failed to read '%s'", filename);\
                 btrfs_free_node(node);\
                 continue;\
             }\
@@ -411,7 +411,7 @@ static inline int find_all_btrfs_pools(const char *path) {
         // --------------------------------------------------------------------
         // link it
 
-        // info("BTRFS: linking '%s'", node->id);
+        // collector_info("BTRFS: linking '%s'", node->id);
         node->next = nodes;
         nodes = node;
     }
@@ -505,7 +505,7 @@ int do_sys_fs_btrfs(int update_every, usec_t dt) {
                  || collect_btrfs_allocation_section_field(metadata, disk_used) != 0
                  || collect_btrfs_allocation_section_field(system, disk_total) != 0
                  || collect_btrfs_allocation_section_field(system, disk_used) != 0) {
-                error("BTRFS: failed to collect physical disks allocation for '%s'", node->id);
+                collector_error("BTRFS: failed to collect physical disks allocation for '%s'", node->id);
                 // make it refresh btrfs at the next iteration
                 refresh_delta = refresh_every;
                 continue;
@@ -515,7 +515,7 @@ int do_sys_fs_btrfs(int update_every, usec_t dt) {
         if(do_allocation_data != CONFIG_BOOLEAN_NO) {
             if (collect_btrfs_allocation_section_field(data, total_bytes) != 0
                 || collect_btrfs_allocation_section_field(data, bytes_used) != 0) {
-                error("BTRFS: failed to collect allocation/data for '%s'", node->id);
+                collector_error("BTRFS: failed to collect allocation/data for '%s'", node->id);
                 // make it refresh btrfs at the next iteration
                 refresh_delta = refresh_every;
                 continue;
@@ -527,7 +527,7 @@ int do_sys_fs_btrfs(int update_every, usec_t dt) {
                 || collect_btrfs_allocation_section_field(metadata, bytes_used) != 0
                 || collect_btrfs_allocation_field(global_rsv_size) != 0
                     ) {
-                error("BTRFS: failed to collect allocation/metadata for '%s'", node->id);
+                collector_error("BTRFS: failed to collect allocation/metadata for '%s'", node->id);
                 // make it refresh btrfs at the next iteration
                 refresh_delta = refresh_every;
                 continue;
@@ -537,7 +537,7 @@ int do_sys_fs_btrfs(int update_every, usec_t dt) {
         if(do_allocation_system != CONFIG_BOOLEAN_NO) {
             if (collect_btrfs_allocation_section_field(system, total_bytes) != 0
                 || collect_btrfs_allocation_section_field(system, bytes_used) != 0) {
-                error("BTRFS: failed to collect allocation/system for '%s'", node->id);
+                collector_error("BTRFS: failed to collect allocation/system for '%s'", node->id);
                 // make it refresh btrfs at the next iteration
                 refresh_delta = refresh_every;
                 continue;

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -142,14 +142,14 @@ struct slabinfo *read_file_slabinfo() {
     if(unlikely(!ff)) {
         ff = procfile_reopen(ff, PLUGIN_SLABINFO_PROCFILE, " ,:" , PROCFILE_FLAG_DEFAULT);
         if(unlikely(!ff)) {
-            error("<- Cannot open file '%s", PLUGIN_SLABINFO_PROCFILE);
+            collector_error("<- Cannot open file '%s", PLUGIN_SLABINFO_PROCFILE);
             exit(1);
         }
     }
 
     ff = procfile_readall(ff);
     if(unlikely(!ff)) {
-        error("<- Cannot read file '%s'", PLUGIN_SLABINFO_PROCFILE);
+        collector_error("<- Cannot read file '%s'", PLUGIN_SLABINFO_PROCFILE);
         exit(0);
     }
 
@@ -351,7 +351,7 @@ int main(int argc, char **argv) {
             n = (int) str2l(argv[i]);
             if (n > 0) {
                 if (n >= UPDATE_EVERY_MAX) {
-                    error("Invalid interval value: %s", argv[i]);
+                    collector_error("Invalid interval value: %s", argv[i]);
                     exit(1);
                 }
                 freq = n;
@@ -384,7 +384,7 @@ int main(int argc, char **argv) {
     if(freq >= update_every)
         update_every = freq;
     else if(freq)
-        error("update frequency %d seconds is too small for slabinfo. Using %d.", freq, update_every);
+        collector_error("update frequency %d seconds is too small for slabinfo. Using %d.", freq, update_every);
 
 
     // Call the main function. Time drift to be added

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -336,6 +336,7 @@ void usage(void) {
 }
 
 int main(int argc, char **argv) {
+    stderror = stderr;
     clocks_init();
 
     program_name = argv[0];

--- a/collectors/tc.plugin/plugin_tc.c
+++ b/collectors/tc.plugin/plugin_tc.c
@@ -89,7 +89,7 @@ static bool tc_class_conflict_callback(const DICTIONARY_ITEM *item __maybe_unuse
     struct tc_class *c = old_value; (void)c;
     struct tc_class *new_c = new_value; (void)new_c;
 
-    error("TC: class '%s' is already in device '%s'. Ignoring duplicate.", dictionary_acquired_item_name(item), string2str(d->id));
+    collector_error("TC: class '%s' is already in device '%s'. Ignoring duplicate.", dictionary_acquired_item_name(item), string2str(d->id));
 
     tc_class_free_callback(item, new_value, data);
 
@@ -277,7 +277,7 @@ static inline void tc_device_commit(struct tc_device *d) {
     }
 
     if(unlikely(updated_classes && updated_qdiscs)) {
-        error("TC: device '%s' has active both classes (%d) and qdiscs (%d). Will render only qdiscs.", string2str(d->id), updated_classes, updated_qdiscs);
+        collector_error("TC: device '%s' has active both classes (%d) and qdiscs (%d). Will render only qdiscs.", string2str(d->id), updated_classes, updated_qdiscs);
 
         // set all classes to !updated
         dfe_start_read(d->classes, c) {
@@ -353,7 +353,7 @@ static inline void tc_device_commit(struct tc_device *d) {
         }
 
         //if(unlikely(!c->hasparent)) {
-        //    if(root) error("TC: multiple root class/qdisc for device '%s' (old: '%s', new: '%s')", d->id, root->id, c->id);
+        //    if(root) collector_error("TC: multiple root class/qdisc for device '%s' (old: '%s', new: '%s')", d->id, root->id, c->id);
         //    root = c;
         //    debug(D_TC_LOOP, "TC: found root class/qdisc '%s'", root->id);
         //}
@@ -856,14 +856,14 @@ static void tc_main_cleanup(void *ptr) {
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-    info("cleaning up...");
+    collector_info("cleaning up...");
 
     if(tc_child_pid) {
-        info("TC: killing with SIGTERM tc-qos-helper process %d", tc_child_pid);
+        collector_info("TC: killing with SIGTERM tc-qos-helper process %d", tc_child_pid);
         if(killpid(tc_child_pid) != -1) {
             siginfo_t info;
 
-            info("TC: waiting for tc plugin child process pid %d to exit...", tc_child_pid);
+            collector_info("TC: waiting for tc plugin child process pid %d to exit...", tc_child_pid);
             waitid(P_PID, (id_t) tc_child_pid, &info, WEXITED);
         }
 
@@ -940,7 +940,7 @@ void *tc_main(void *ptr) {
 
         fp_child_output = netdata_popen(command, (pid_t *)&tc_child_pid, &fp_child_input);
         if(unlikely(!fp_child_output)) {
-            error("TC: Cannot popen(\"%s\", \"r\").", command);
+            collector_error("TC: Cannot popen(\"%s\", \"r\").", command);
             goto cleanup;
         }
 
@@ -1169,7 +1169,7 @@ void *tc_main(void *ptr) {
         if(code == 1 || code == 127) {
             // 1 = DISABLE
             // 127 = cannot even run it
-            error("TC: tc-qos-helper.sh exited with code %d. Disabling it.", code);
+            collector_error("TC: tc-qos-helper.sh exited with code %d. Disabling it.", code);
             goto cleanup;
         }
 

--- a/collectors/xenstat.plugin/xenstat_plugin.c
+++ b/collectors/xenstat.plugin/xenstat_plugin.c
@@ -920,6 +920,7 @@ static void xenstat_send_domain_metrics() {
 }
 
 int main(int argc, char **argv) {
+    stderror = stderr;
     clocks_init();
 
     // ------------------------------------------------------------------------

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -206,25 +206,22 @@ You can send commands during runtime via [netdatacli](/cli/README.md).
 
 ## Log files
 
-Netdata uses 3 log files:
+Netdata uses 4 log files:
 
 1.  `error.log`
-2.  `access.log`
-3.  `debug.log`
+2.  `collector.log`
+3.  `access.log`
+4.  `debug.log`
 
-Any of them can be disabled by setting it to `/dev/null` or `none` in `netdata.conf`. By default `error.log` and
-`access.log` are enabled. `debug.log` is only enabled if debugging/tracing is also enabled (Netdata needs to be compiled
-with debugging enabled).
+Any of them can be disabled by setting it to `/dev/null` or `none` in `netdata.conf`. By default `error.log`,
+`collector.log`, and `access.log` are enabled. `debug.log` is only enabled if debugging/tracing is also enabled
+(Netdata needs to be compiled with debugging enabled).
 
 Log files are stored in `/var/log/netdata/` by default.
 
 ### error.log
 
-The `error.log` is the `stderr` of the `netdata` daemon and all external plugins
-run by `netdata`.
-
-So if any process, in the Netdata process tree, writes anything to its standard error,
-it will appear in `error.log`.
+The `error.log` is the `stderr` of the `netdata` daemon .
 
 For most Netdata programs (including standard external plugins shipped by netdata), the following lines may appear:
 
@@ -238,6 +235,15 @@ So, when auto-detection of data collection fail, `ERROR` lines are logged and th
 program continues to run.
 
 When a Netdata program cannot run at all, a `FATAL` line is logged.
+
+### collector.log
+
+The `collector.log` is the `stderr` of all external plugins run by `netdata`.
+
+So if any process, in the Netdata process tree, writes anything to its standard error,
+it will appear in `collector.log`.
+
+Data stored inside this file follows pattern already described for `error.log`.
 
 ### access.log
 

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -238,7 +238,8 @@ When a Netdata program cannot run at all, a `FATAL` line is logged.
 
 ### collector.log
 
-The `collector.log` is the `stderr` of all external plugins run by `netdata`.
+The `collector.log` is the `stderr` of all [colectors](https://github.com/netdata/netdata/blob/master/collectors/COLLECTORS.md)
+ run by `netdata`.
 
 So if any process, in the Netdata process tree, writes anything to its standard error,
 it will appear in `collector.log`.

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -238,7 +238,7 @@ When a Netdata program cannot run at all, a `FATAL` line is logged.
 
 ### collector.log
 
-The `collector.log` is the `stderr` of all [colectors](https://github.com/netdata/netdata/blob/master/collectors/COLLECTORS.md)
+The `collector.log` is the `stderr` of all [collectors](https://github.com/netdata/netdata/blob/master/collectors/COLLECTORS.md)
  run by `netdata`.
 
 So if any process, in the Netdata process tree, writes anything to its standard error,

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -3780,7 +3780,7 @@ static int read_thread_cpu_time_from_proc_stat(pid_t pid __maybe_unused, kernel_
 
     // (re)open the procfile to the new filename
     bool set_quotes = (ff == NULL) ? true : false;
-    ff = procfile_reopen(ff, filename, NULL, PROCFILE_FLAG_DEFAULT);
+    ff = procfile_reopen(ff, filename, NULL, PROCFILE_FLAG_ERROR_ON_ERROR_LOG);
     if(unlikely(!ff)) return -1;
 
     if(set_quotes)

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1300,6 +1300,8 @@ int main(int argc, char **argv) {
     usec_t started_ut = now_monotonic_usec();
     usec_t last_ut = started_ut;
     const char *prev_msg = NULL;
+    // Initialize stderror avoiding coredump when info() or error() is called
+    stderror = stderr;
 
     int i;
     int config_loaded = 0;

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -808,6 +808,9 @@ static void log_init(void) {
     snprintfz(filename, FILENAME_MAX, "%s/error.log", netdata_configured_log_dir);
     stderr_filename    = config_get(CONFIG_SECTION_LOGS, "error",  filename);
 
+    snprintfz(filename, FILENAME_MAX, "%s/collector.log", netdata_configured_log_dir);
+    stdcollector_filename = config_get(CONFIG_SECTION_LOGS, "collector", filename);
+
     snprintfz(filename, FILENAME_MAX, "%s/access.log", netdata_configured_log_dir);
     stdaccess_filename = config_get(CONFIG_SECTION_LOGS, "access", filename);
 

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -791,8 +791,8 @@ void info_int( const char *file __maybe_unused, const char *function __maybe_unu
 
     va_start( args, fmt );
 #ifdef NETDATA_INTERNAL_CHECKS
-    fprintf(
-        stderror, "%s: %s INFO  : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, netdata_thread_tag(), line, file, function);
+    fprintf(stderror, "%s: %s INFO  : %s : (%04lu@%-20.20s:%-15.15s): ",
+            date, program_name, netdata_thread_tag(), line, file, function);
 #else
     fprintf(stderror, "%s: %s INFO  : %s : ", date, program_name, netdata_thread_tag());
 #endif
@@ -864,8 +864,8 @@ void error_limit_int(ERROR_LIMIT *erl, const char *prefix, const char *file __ma
 
     va_start( args, fmt );
 #ifdef NETDATA_INTERNAL_CHECKS
-    fprintf(
-        stderror, "%s: %s %-5.5s : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, prefix, netdata_thread_tag(), line, file, function);
+    fprintf(stderror, "%s: %s %-5.5s : %s : (%04lu@%-20.20s:%-15.15s): ",
+            date, program_name, prefix, netdata_thread_tag(), line, file, function);
 #else
     fprintf(stderror, "%s: %s %-5.5s : %s : ", date, program_name, prefix, netdata_thread_tag());
 #endif
@@ -873,15 +873,16 @@ void error_limit_int(ERROR_LIMIT *erl, const char *prefix, const char *file __ma
     va_end( args );
 
     if(erl->count > 1)
-        fprintf(
-            stderror, " (similar messages repeated %zu times in the last %llu secs)", erl->count, (unsigned long long)(erl->last_logged ? now - erl->last_logged : 0));
+        fprintf(stderror, " (similar messages repeated %zu times in the last %llu secs)",
+                erl->count, (unsigned long long)(erl->last_logged ? now - erl->last_logged : 0));
 
     if(erl->sleep_ut)
         fprintf(stderror, " (sleeping for %llu microseconds every time this happens)", erl->sleep_ut);
 
     if(__errno) {
         char buf[1024];
-        fprintf(stderror, " (errno %d, %s)\n", __errno, strerror_result(strerror_r(__errno, buf, 1023), buf));
+        fprintf(stderror,
+                " (errno %d, %s)\n", __errno, strerror_result(strerror_r(__errno, buf, 1023), buf));
         errno = 0;
     }
     else
@@ -918,8 +919,8 @@ void error_int(const char *prefix, const char *file __maybe_unused, const char *
 
     va_start( args, fmt );
 #ifdef NETDATA_INTERNAL_CHECKS
-    fprintf(
-        stderror, "%s: %s %-5.5s : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, prefix, netdata_thread_tag(), line, file, function);
+    fprintf(stderror, "%s: %s %-5.5s : %s : (%04lu@%-20.20s:%-15.15s): ",
+            date, program_name, prefix, netdata_thread_tag(), line, file, function);
 #else
     fprintf(stderror, "%s: %s %-5.5s : %s : ", date, program_name, prefix, netdata_thread_tag());
 #endif
@@ -928,7 +929,8 @@ void error_int(const char *prefix, const char *file __maybe_unused, const char *
 
     if(__errno) {
         char buf[1024];
-        fprintf(stderror, " (errno %d, %s)\n", __errno, strerror_result(strerror_r(__errno, buf, 1023), buf));
+        fprintf(stderror,
+                " (errno %d, %s)\n", __errno, strerror_result(strerror_r(__errno, buf, 1023), buf));
         errno = 0;
     }
     else
@@ -984,8 +986,8 @@ void fatal_int( const char *file, const char *function, const unsigned long line
 
     va_start( args, fmt );
 #ifdef NETDATA_INTERNAL_CHECKS
-    fprintf(
-        stderror, "%s: %s FATAL : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, thread_tag, line, file, function);
+    fprintf(stderror,
+            "%s: %s FATAL : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, thread_tag, line, file, function);
 #else
     fprintf(stderror, "%s: %s FATAL : %s : ", date, program_name, thread_tag);
 #endif

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -899,9 +899,10 @@ void error_limit_int(ERROR_LIMIT *erl, const char *prefix, const char *file __ma
     log_unlock();
 }
 
-void error_int(const char *prefix, const char *file __maybe_unused, const char *function __maybe_unused, const unsigned long line __maybe_unused, const char *fmt, ... ) {
+void error_int(int is_collector, const char *prefix, const char *file __maybe_unused, const char *function __maybe_unused, const unsigned long line __maybe_unused, const char *fmt, ... ) {
     // save a copy of errno - just in case this function generates a new error
     int __errno = errno;
+    FILE *fp = (is_collector) ? stderr : stderror;
 
     va_list args;
 
@@ -924,22 +925,22 @@ void error_int(const char *prefix, const char *file __maybe_unused, const char *
 
     va_start( args, fmt );
 #ifdef NETDATA_INTERNAL_CHECKS
-    fprintf(stderror, "%s: %s %-5.5s : %s : (%04lu@%-20.20s:%-15.15s): ",
+    fprintf(fp, "%s: %s %-5.5s : %s : (%04lu@%-20.20s:%-15.15s): ",
             date, program_name, prefix, netdata_thread_tag(), line, file, function);
 #else
-    fprintf(stderror, "%s: %s %-5.5s : %s : ", date, program_name, prefix, netdata_thread_tag());
+    fprintf(fp, "%s: %s %-5.5s : %s : ", date, program_name, prefix, netdata_thread_tag());
 #endif
-    vfprintf(stderror, fmt, args );
+    vfprintf(fp, fmt, args );
     va_end( args );
 
     if(__errno) {
         char buf[1024];
-        fprintf(stderror,
+        fprintf(fp,
                 " (errno %d, %s)\n", __errno, strerror_result(strerror_r(__errno, buf, 1023), buf));
         errno = 0;
     }
     else
-        fputc('\n', stderror);
+        fputc('\n', fp);
 
     log_unlock();
 }

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -14,6 +14,7 @@ uint64_t debug_flags = 0;
 
 int access_log_syslog = 1;
 int error_log_syslog = 1;
+int collector_log_syslog = 1;
 int output_log_syslog = 1;  // debug log
 int health_log_syslog = 1;
 
@@ -22,6 +23,9 @@ FILE *stdaccess = NULL;
 
 int stdhealth_fd = -1;
 FILE *stdhealth = NULL;
+
+int stdcollector_fd = -1;
+FILE *stdcollector = NULL;
 
 const char *stdaccess_filename = NULL;
 const char *stderr_filename = NULL;
@@ -577,6 +581,9 @@ void reopen_all_log_files() {
     if(stderr_filename)
         open_log_file(STDERR_FILENO, stderr, stderr_filename, &error_log_syslog, 0, NULL);
 
+    if(stdcollector_filename)
+        stdcollector = open_log_file(stdcollector_fd, stdcollector, stdcollector_filename, &collector_log_syslog, 1, &stdcollector_fd);
+
 #ifdef ENABLE_ACLK
     if (aclklog_enabled)
         aclklog = open_log_file(aclklog_fd, aclklog, aclklog_filename, NULL, 0, &aclklog_fd);
@@ -595,6 +602,8 @@ void open_all_log_files() {
 
     open_log_file(STDOUT_FILENO, stdout, stdout_filename, &output_log_syslog, 0, NULL);
     open_log_file(STDERR_FILENO, stderr, stderr_filename, &error_log_syslog, 0, NULL);
+
+    stdcollector = open_log_file(stdcollector_fd, stdcollector, stdcollector_filename, &collector_log_syslog, 1, &stdcollector_fd);
 
 #ifdef ENABLE_ACLK
     if(aclklog_enabled)

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -25,7 +25,7 @@ int stdhealth_fd = -1;
 FILE *stdhealth = NULL;
 
 int stdcollector_fd = -1;
-FILE *stdcollector = NULL;
+FILE *stderror = NULL;
 
 const char *stdaccess_filename = NULL;
 const char *stderr_filename = NULL;
@@ -582,7 +582,7 @@ void reopen_all_log_files() {
         open_log_file(STDERR_FILENO, stderr, stdcollector_filename, &collector_log_syslog, 0, NULL);
 
     if(stderr_filename)
-        stdcollector = open_log_file(stdcollector_fd, stdcollector, stderr_filename, &error_log_syslog, 1, &stdcollector_fd);
+        stderror = open_log_file(stdcollector_fd, stderror, stderr_filename, &error_log_syslog, 1, &stdcollector_fd);
 
 #ifdef ENABLE_ACLK
     if (aclklog_enabled)
@@ -603,7 +603,7 @@ void open_all_log_files() {
     open_log_file(STDOUT_FILENO, stdout, stdout_filename, &output_log_syslog, 0, NULL);
     open_log_file(STDERR_FILENO, stderr, stdcollector_filename, &collector_log_syslog, 0, NULL);
 
-    stdcollector = open_log_file(stdcollector_fd, stdcollector, stderr_filename, &error_log_syslog, 1, &stdcollector_fd);
+    stderror = open_log_file(stdcollector_fd, stderror, stderr_filename, &error_log_syslog, 1, &stdcollector_fd);
 
 #ifdef ENABLE_ACLK
     if(aclklog_enabled)
@@ -626,7 +626,7 @@ int error_log_limit(int reset) {
     static time_t start = 0;
     static unsigned long counter = 0, prevented = 0;
 
-    // fprintf(stdcollector, "FLOOD: counter=%lu, allowed=%lu, backup=%lu, period=%llu\n", counter, error_log_errors_per_period, error_log_errors_per_period_backup, (unsigned long long)error_log_throttle_period);
+    // fprintf(stderror, "FLOOD: counter=%lu, allowed=%lu, backup=%lu, period=%llu\n", counter, error_log_errors_per_period, error_log_errors_per_period_backup, (unsigned long long)error_log_throttle_period);
 
     // do not throttle if the period is 0
     if(error_log_throttle_period == 0)
@@ -648,7 +648,7 @@ int error_log_limit(int reset) {
             char date[LOG_DATE_LENGTH];
             log_date(date, LOG_DATE_LENGTH, now_realtime_sec());
             fprintf(
-                stdcollector,
+                stderror,
                 "%s: %s LOG FLOOD PROTECTION reset for process '%s' "
                 "(prevented %lu logs in the last %"PRId64" seconds).\n",
                 date,
@@ -671,7 +671,7 @@ int error_log_limit(int reset) {
             char date[LOG_DATE_LENGTH];
             log_date(date, LOG_DATE_LENGTH, now_realtime_sec());
             fprintf(
-                stdcollector,
+                stderror,
                 "%s: %s LOG FLOOD PROTECTION resuming logging from process '%s' "
                 "(prevented %lu logs in the last %"PRId64" seconds).\n",
                 date,
@@ -695,7 +695,7 @@ int error_log_limit(int reset) {
             char date[LOG_DATE_LENGTH];
             log_date(date, LOG_DATE_LENGTH, now_realtime_sec());
             fprintf(
-                stdcollector,
+                stderror,
                 "%s: %s LOG FLOOD PROTECTION too many logs (%lu logs in %"PRId64" seconds, threshold is set to %lu logs "
                 "in %"PRId64" seconds). Preventing more logs from process '%s' for %"PRId64" seconds.\n",
                 date,
@@ -791,14 +791,15 @@ void info_int( const char *file __maybe_unused, const char *function __maybe_unu
 
     va_start( args, fmt );
 #ifdef NETDATA_INTERNAL_CHECKS
-    fprintf(stdcollector, "%s: %s INFO  : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, netdata_thread_tag(), line, file, function);
+    fprintf(
+        stderror, "%s: %s INFO  : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, netdata_thread_tag(), line, file, function);
 #else
-    fprintf(stdcollector, "%s: %s INFO  : %s : ", date, program_name, netdata_thread_tag());
+    fprintf(stderror, "%s: %s INFO  : %s : ", date, program_name, netdata_thread_tag());
 #endif
-    vfprintf( stdcollector, fmt, args );
+    vfprintf(stderror, fmt, args );
     va_end( args );
 
-    fputc('\n', stdcollector);
+    fputc('\n', stderror);
 
     log_unlock();
 }
@@ -863,26 +864,28 @@ void error_limit_int(ERROR_LIMIT *erl, const char *prefix, const char *file __ma
 
     va_start( args, fmt );
 #ifdef NETDATA_INTERNAL_CHECKS
-    fprintf(stdcollector, "%s: %s %-5.5s : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, prefix, netdata_thread_tag(), line, file, function);
+    fprintf(
+        stderror, "%s: %s %-5.5s : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, prefix, netdata_thread_tag(), line, file, function);
 #else
-    fprintf(stdcollector, "%s: %s %-5.5s : %s : ", date, program_name, prefix, netdata_thread_tag());
+    fprintf(stderror, "%s: %s %-5.5s : %s : ", date, program_name, prefix, netdata_thread_tag());
 #endif
-    vfprintf( stdcollector, fmt, args );
+    vfprintf(stderror, fmt, args );
     va_end( args );
 
     if(erl->count > 1)
-        fprintf(stdcollector, " (similar messages repeated %zu times in the last %llu secs)", erl->count, (unsigned long long)(erl->last_logged ? now - erl->last_logged : 0));
+        fprintf(
+            stderror, " (similar messages repeated %zu times in the last %llu secs)", erl->count, (unsigned long long)(erl->last_logged ? now - erl->last_logged : 0));
 
     if(erl->sleep_ut)
-        fprintf(stdcollector, " (sleeping for %llu microseconds every time this happens)", erl->sleep_ut);
+        fprintf(stderror, " (sleeping for %llu microseconds every time this happens)", erl->sleep_ut);
 
     if(__errno) {
         char buf[1024];
-        fprintf(stdcollector, " (errno %d, %s)\n", __errno, strerror_result(strerror_r(__errno, buf, 1023), buf));
+        fprintf(stderror, " (errno %d, %s)\n", __errno, strerror_result(strerror_r(__errno, buf, 1023), buf));
         errno = 0;
     }
     else
-        fputc('\n', stdcollector);
+        fputc('\n', stderror);
 
     erl->last_logged = now;
     erl->count = 0;
@@ -915,20 +918,21 @@ void error_int(const char *prefix, const char *file __maybe_unused, const char *
 
     va_start( args, fmt );
 #ifdef NETDATA_INTERNAL_CHECKS
-    fprintf(stdcollector, "%s: %s %-5.5s : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, prefix, netdata_thread_tag(), line, file, function);
+    fprintf(
+        stderror, "%s: %s %-5.5s : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, prefix, netdata_thread_tag(), line, file, function);
 #else
-    fprintf(stdcollector, "%s: %s %-5.5s : %s : ", date, program_name, prefix, netdata_thread_tag());
+    fprintf(stderror, "%s: %s %-5.5s : %s : ", date, program_name, prefix, netdata_thread_tag());
 #endif
-    vfprintf( stdcollector, fmt, args );
+    vfprintf(stderror, fmt, args );
     va_end( args );
 
     if(__errno) {
         char buf[1024];
-        fprintf(stdcollector, " (errno %d, %s)\n", __errno, strerror_result(strerror_r(__errno, buf, 1023), buf));
+        fprintf(stderror, " (errno %d, %s)\n", __errno, strerror_result(strerror_r(__errno, buf, 1023), buf));
         errno = 0;
     }
     else
-        fputc('\n', stdcollector);
+        fputc('\n', stderror);
 
     log_unlock();
 }
@@ -948,7 +952,7 @@ static void print_call_stack(void) {
 
     nptrs = backtrace(buffer, BT_BUF_SIZE);
     if(nptrs)
-        backtrace_symbols_fd(buffer, nptrs, fileno(stdcollector));
+        backtrace_symbols_fd(buffer, nptrs, fileno(stderror));
 }
 #endif
 
@@ -980,15 +984,16 @@ void fatal_int( const char *file, const char *function, const unsigned long line
 
     va_start( args, fmt );
 #ifdef NETDATA_INTERNAL_CHECKS
-    fprintf(stdcollector, "%s: %s FATAL : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, thread_tag, line, file, function);
+    fprintf(
+        stderror, "%s: %s FATAL : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, thread_tag, line, file, function);
 #else
-    fprintf(stdcollector, "%s: %s FATAL : %s : ", date, program_name, thread_tag);
+    fprintf(stderror, "%s: %s FATAL : %s : ", date, program_name, thread_tag);
 #endif
-    vfprintf( stdcollector, fmt, args );
+    vfprintf(stderror, fmt, args );
     va_end( args );
 
     perror(" # ");
-    fputc('\n', stdcollector);
+    fputc('\n', stderror);
 
     log_unlock();
 

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -773,9 +773,10 @@ void debug_int( const char *file, const char *function, const unsigned long line
 // ----------------------------------------------------------------------------
 // info log
 
-void info_int( const char *file __maybe_unused, const char *function __maybe_unused, const unsigned long line __maybe_unused, const char *fmt, ... )
+void info_int( int is_collector, const char *file __maybe_unused, const char *function __maybe_unused, const unsigned long line __maybe_unused, const char *fmt, ... )
 {
     va_list args;
+    FILE *fp = (is_collector) ? stderr : stderror;
 
     log_lock();
 
@@ -796,15 +797,15 @@ void info_int( const char *file __maybe_unused, const char *function __maybe_unu
 
     va_start( args, fmt );
 #ifdef NETDATA_INTERNAL_CHECKS
-    fprintf(stderror, "%s: %s INFO  : %s : (%04lu@%-20.20s:%-15.15s): ",
+    fprintf(fp, "%s: %s INFO  : %s : (%04lu@%-20.20s:%-15.15s): ",
             date, program_name, netdata_thread_tag(), line, file, function);
 #else
-    fprintf(stderror, "%s: %s INFO  : %s : ", date, program_name, netdata_thread_tag());
+    fprintf(fp, "%s: %s INFO  : %s : ", date, program_name, netdata_thread_tag());
 #endif
-    vfprintf(stderror, fmt, args );
+    vfprintf(fp, fmt, args );
     va_end( args );
 
-    fputc('\n', stderror);
+    fputc('\n', fp);
 
     log_unlock();
 }

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -581,8 +581,11 @@ void reopen_all_log_files() {
     if(stdcollector_filename)
         open_log_file(STDERR_FILENO, stderr, stdcollector_filename, &collector_log_syslog, 0, NULL);
 
-    if(stderr_filename)
+    if(stderr_filename) {
+        log_lock();
         stderror = open_log_file(stdcollector_fd, stderror, stderr_filename, &error_log_syslog, 1, &stdcollector_fd);
+        log_unlock();
+    }
 
 #ifdef ENABLE_ACLK
     if (aclklog_enabled)
@@ -603,7 +606,9 @@ void open_all_log_files() {
     open_log_file(STDOUT_FILENO, stdout, stdout_filename, &output_log_syslog, 0, NULL);
     open_log_file(STDERR_FILENO, stderr, stdcollector_filename, &collector_log_syslog, 0, NULL);
 
+    log_lock();
     stderror = open_log_file(stdcollector_fd, NULL, stderr_filename, &error_log_syslog, 1, &stdcollector_fd);
+    log_unlock();
 
 #ifdef ENABLE_ACLK
     if(aclklog_enabled)

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -28,6 +28,7 @@ const char *stderr_filename = NULL;
 const char *stdout_filename = NULL;
 const char *facility_log = NULL;
 const char *stdhealth_filename = NULL;
+const char *stdcollector_filename = NULL;
 
 #ifdef ENABLE_ACLK
 const char *aclklog_filename = NULL;

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -578,11 +578,11 @@ void reopen_all_log_files() {
     if(stdout_filename)
         open_log_file(STDOUT_FILENO, stdout, stdout_filename, &output_log_syslog, 0, NULL);
 
-    if(stderr_filename)
-        open_log_file(STDERR_FILENO, stderr, stderr_filename, &error_log_syslog, 0, NULL);
-
     if(stdcollector_filename)
-        stdcollector = open_log_file(stdcollector_fd, stdcollector, stdcollector_filename, &collector_log_syslog, 1, &stdcollector_fd);
+        open_log_file(STDERR_FILENO, stderr, stdcollector_filename, &collector_log_syslog, 0, NULL);
+
+    if(stderr_filename)
+        stdcollector = open_log_file(stdcollector_fd, stdcollector, stderr_filename, &error_log_syslog, 1, &stdcollector_fd);
 
 #ifdef ENABLE_ACLK
     if (aclklog_enabled)
@@ -601,9 +601,9 @@ void open_all_log_files() {
     open_log_file(STDIN_FILENO, stdin, "/dev/null", NULL, 0, NULL);
 
     open_log_file(STDOUT_FILENO, stdout, stdout_filename, &output_log_syslog, 0, NULL);
-    open_log_file(STDERR_FILENO, stderr, stderr_filename, &error_log_syslog, 0, NULL);
+    open_log_file(STDERR_FILENO, stderr, stdcollector_filename, &collector_log_syslog, 0, NULL);
 
-    stdcollector = open_log_file(stdcollector_fd, stdcollector, stdcollector_filename, &collector_log_syslog, 1, &stdcollector_fd);
+    stdcollector = open_log_file(stdcollector_fd, stdcollector, stderr_filename, &error_log_syslog, 1, &stdcollector_fd);
 
 #ifdef ENABLE_ACLK
     if(aclklog_enabled)
@@ -780,7 +780,7 @@ void info_int( const char *file __maybe_unused, const char *function __maybe_unu
         return;
     }
 
-    if(error_log_syslog) {
+    if(collector_log_syslog) {
         va_start( args, fmt );
         vsyslog(LOG_INFO,  fmt, args );
         va_end( args );
@@ -852,7 +852,7 @@ void error_limit_int(ERROR_LIMIT *erl, const char *prefix, const char *file __ma
         return;
     }
 
-    if(error_log_syslog) {
+    if(collector_log_syslog) {
         va_start( args, fmt );
         vsyslog(LOG_ERR,  fmt, args );
         va_end( args );
@@ -904,7 +904,7 @@ void error_int(const char *prefix, const char *file __maybe_unused, const char *
         return;
     }
 
-    if(error_log_syslog) {
+    if(collector_log_syslog) {
         va_start( args, fmt );
         vsyslog(LOG_ERR,  fmt, args );
         va_end( args );
@@ -959,7 +959,7 @@ void fatal_int( const char *file, const char *function, const unsigned long line
     const char *thread_tag;
     char os_threadname[NETDATA_THREAD_NAME_MAX + 1];
 
-    if(error_log_syslog) {
+    if(collector_log_syslog) {
         va_start( args, fmt );
         vsyslog(LOG_CRIT,  fmt, args );
         va_end( args );

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -603,7 +603,7 @@ void open_all_log_files() {
     open_log_file(STDOUT_FILENO, stdout, stdout_filename, &output_log_syslog, 0, NULL);
     open_log_file(STDERR_FILENO, stderr, stdcollector_filename, &collector_log_syslog, 0, NULL);
 
-    stderror = open_log_file(stdcollector_fd, stderror, stderr_filename, &error_log_syslog, 1, &stdcollector_fd);
+    stderror = open_log_file(stdcollector_fd, NULL, stderr_filename, &error_log_syslog, 1, &stdcollector_fd);
 
 #ifdef ENABLE_ACLK
     if(aclklog_enabled)

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -626,7 +626,7 @@ int error_log_limit(int reset) {
     static time_t start = 0;
     static unsigned long counter = 0, prevented = 0;
 
-    // fprintf(stderr, "FLOOD: counter=%lu, allowed=%lu, backup=%lu, period=%llu\n", counter, error_log_errors_per_period, error_log_errors_per_period_backup, (unsigned long long)error_log_throttle_period);
+    // fprintf(stdcollector, "FLOOD: counter=%lu, allowed=%lu, backup=%lu, period=%llu\n", counter, error_log_errors_per_period, error_log_errors_per_period_backup, (unsigned long long)error_log_throttle_period);
 
     // do not throttle if the period is 0
     if(error_log_throttle_period == 0)
@@ -648,7 +648,7 @@ int error_log_limit(int reset) {
             char date[LOG_DATE_LENGTH];
             log_date(date, LOG_DATE_LENGTH, now_realtime_sec());
             fprintf(
-                stderr,
+                stdcollector,
                 "%s: %s LOG FLOOD PROTECTION reset for process '%s' "
                 "(prevented %lu logs in the last %"PRId64" seconds).\n",
                 date,
@@ -671,7 +671,7 @@ int error_log_limit(int reset) {
             char date[LOG_DATE_LENGTH];
             log_date(date, LOG_DATE_LENGTH, now_realtime_sec());
             fprintf(
-                stderr,
+                stdcollector,
                 "%s: %s LOG FLOOD PROTECTION resuming logging from process '%s' "
                 "(prevented %lu logs in the last %"PRId64" seconds).\n",
                 date,
@@ -695,7 +695,7 @@ int error_log_limit(int reset) {
             char date[LOG_DATE_LENGTH];
             log_date(date, LOG_DATE_LENGTH, now_realtime_sec());
             fprintf(
-                stderr,
+                stdcollector,
                 "%s: %s LOG FLOOD PROTECTION too many logs (%lu logs in %"PRId64" seconds, threshold is set to %lu logs "
                 "in %"PRId64" seconds). Preventing more logs from process '%s' for %"PRId64" seconds.\n",
                 date,
@@ -791,14 +791,14 @@ void info_int( const char *file __maybe_unused, const char *function __maybe_unu
 
     va_start( args, fmt );
 #ifdef NETDATA_INTERNAL_CHECKS
-    fprintf(stderr, "%s: %s INFO  : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, netdata_thread_tag(), line, file, function);
+    fprintf(stdcollector, "%s: %s INFO  : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, netdata_thread_tag(), line, file, function);
 #else
-    fprintf(stderr, "%s: %s INFO  : %s : ", date, program_name, netdata_thread_tag());
+    fprintf(stdcollector, "%s: %s INFO  : %s : ", date, program_name, netdata_thread_tag());
 #endif
-    vfprintf( stderr, fmt, args );
+    vfprintf( stdcollector, fmt, args );
     va_end( args );
 
-    fputc('\n', stderr);
+    fputc('\n', stdcollector);
 
     log_unlock();
 }
@@ -863,26 +863,26 @@ void error_limit_int(ERROR_LIMIT *erl, const char *prefix, const char *file __ma
 
     va_start( args, fmt );
 #ifdef NETDATA_INTERNAL_CHECKS
-    fprintf(stderr, "%s: %s %-5.5s : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, prefix, netdata_thread_tag(), line, file, function);
+    fprintf(stdcollector, "%s: %s %-5.5s : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, prefix, netdata_thread_tag(), line, file, function);
 #else
-    fprintf(stderr, "%s: %s %-5.5s : %s : ", date, program_name, prefix, netdata_thread_tag());
+    fprintf(stdcollector, "%s: %s %-5.5s : %s : ", date, program_name, prefix, netdata_thread_tag());
 #endif
-    vfprintf( stderr, fmt, args );
+    vfprintf( stdcollector, fmt, args );
     va_end( args );
 
     if(erl->count > 1)
-        fprintf(stderr, " (similar messages repeated %zu times in the last %llu secs)", erl->count, (unsigned long long)(erl->last_logged ? now - erl->last_logged : 0));
+        fprintf(stdcollector, " (similar messages repeated %zu times in the last %llu secs)", erl->count, (unsigned long long)(erl->last_logged ? now - erl->last_logged : 0));
 
     if(erl->sleep_ut)
-        fprintf(stderr, " (sleeping for %llu microseconds every time this happens)", erl->sleep_ut);
+        fprintf(stdcollector, " (sleeping for %llu microseconds every time this happens)", erl->sleep_ut);
 
     if(__errno) {
         char buf[1024];
-        fprintf(stderr, " (errno %d, %s)\n", __errno, strerror_result(strerror_r(__errno, buf, 1023), buf));
+        fprintf(stdcollector, " (errno %d, %s)\n", __errno, strerror_result(strerror_r(__errno, buf, 1023), buf));
         errno = 0;
     }
     else
-        fputc('\n', stderr);
+        fputc('\n', stdcollector);
 
     erl->last_logged = now;
     erl->count = 0;
@@ -915,20 +915,20 @@ void error_int(const char *prefix, const char *file __maybe_unused, const char *
 
     va_start( args, fmt );
 #ifdef NETDATA_INTERNAL_CHECKS
-    fprintf(stderr, "%s: %s %-5.5s : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, prefix, netdata_thread_tag(), line, file, function);
+    fprintf(stdcollector, "%s: %s %-5.5s : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, prefix, netdata_thread_tag(), line, file, function);
 #else
-    fprintf(stderr, "%s: %s %-5.5s : %s : ", date, program_name, prefix, netdata_thread_tag());
+    fprintf(stdcollector, "%s: %s %-5.5s : %s : ", date, program_name, prefix, netdata_thread_tag());
 #endif
-    vfprintf( stderr, fmt, args );
+    vfprintf( stdcollector, fmt, args );
     va_end( args );
 
     if(__errno) {
         char buf[1024];
-        fprintf(stderr, " (errno %d, %s)\n", __errno, strerror_result(strerror_r(__errno, buf, 1023), buf));
+        fprintf(stdcollector, " (errno %d, %s)\n", __errno, strerror_result(strerror_r(__errno, buf, 1023), buf));
         errno = 0;
     }
     else
-        fputc('\n', stderr);
+        fputc('\n', stdcollector);
 
     log_unlock();
 }
@@ -948,7 +948,7 @@ static void print_call_stack(void) {
 
     nptrs = backtrace(buffer, BT_BUF_SIZE);
     if(nptrs)
-        backtrace_symbols_fd(buffer, nptrs, fileno(stderr));
+        backtrace_symbols_fd(buffer, nptrs, fileno(stdcollector));
 }
 #endif
 
@@ -980,15 +980,15 @@ void fatal_int( const char *file, const char *function, const unsigned long line
 
     va_start( args, fmt );
 #ifdef NETDATA_INTERNAL_CHECKS
-    fprintf(stderr, "%s: %s FATAL : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, thread_tag, line, file, function);
+    fprintf(stdcollector, "%s: %s FATAL : %s : (%04lu@%-20.20s:%-15.15s): ", date, program_name, thread_tag, line, file, function);
 #else
-    fprintf(stderr, "%s: %s FATAL : %s : ", date, program_name, thread_tag);
+    fprintf(stdcollector, "%s: %s FATAL : %s : ", date, program_name, thread_tag);
 #endif
-    vfprintf( stderr, fmt, args );
+    vfprintf( stdcollector, fmt, args );
     va_end( args );
 
     perror(" # ");
-    fputc('\n', stderr);
+    fputc('\n', stdcollector);
 
     log_unlock();
 

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -62,7 +62,7 @@ extern int stdhealth_fd;
 extern FILE *stdhealth;
 
 extern int stdcollector_fd;
-extern FILE *stdcollector;
+extern FILE *stderror;
 
 extern const char *stdaccess_filename;
 extern const char *stderr_filename;

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -110,7 +110,7 @@ typedef struct error_with_limit {
 
 #ifdef NETDATA_INTERNAL_CHECKS
 #define debug(type, args...) do { if(unlikely(debug_flags & type)) debug_int(__FILE__, __FUNCTION__, __LINE__, ##args); } while(0)
-#define internal_error(condition, args...) do { if(unlikely(condition)) error_int("IERR", __FILE__, __FUNCTION__, __LINE__, ##args); } while(0)
+#define internal_error(condition, args...) do { if(unlikely(condition)) error_int(0, "IERR", __FILE__, __FUNCTION__, __LINE__, ##args); } while(0)
 #define internal_fatal(condition, args...) do { if(unlikely(condition)) fatal_int(__FILE__, __FUNCTION__, __LINE__, ##args); } while(0)
 #else
 #define debug(type, args...) debug_dummy()
@@ -119,8 +119,10 @@ typedef struct error_with_limit {
 #endif
 
 #define info(args...)    info_int(__FILE__, __FUNCTION__, __LINE__, ##args)
-#define infoerr(args...) error_int("INFO", __FILE__, __FUNCTION__, __LINE__, ##args)
-#define error(args...)   error_int("ERROR", __FILE__, __FUNCTION__, __LINE__, ##args)
+#define infoerr(args...) error_int(0, "INFO", __FILE__, __FUNCTION__, __LINE__, ##args)
+#define error(args...)   error_int(0, "ERROR", __FILE__, __FUNCTION__, __LINE__, ##args)
+#define collector_infoerr(args...) error_int(1, "INFO", __FILE__, __FUNCTION__, __LINE__, ##args)
+#define collector_error(args...)   error_int(1, "ERROR", __FILE__, __FUNCTION__, __LINE__, ##args)
 #define error_limit(erl, args...)   error_limit_int(erl, "ERROR", __FILE__, __FUNCTION__, __LINE__, ##args)
 #define fatal(args...)   fatal_int(__FILE__, __FUNCTION__, __LINE__, ##args)
 #define fatal_assert(expr) ((expr) ? (void)(0) : fatal_int(__FILE__, __FUNCTION__, __LINE__, "Assertion `%s' failed", #expr))
@@ -128,7 +130,7 @@ typedef struct error_with_limit {
 void send_statistics(const char *action, const char *action_result, const char *action_data);
 void debug_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(4, 5);
 void info_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(4, 5);
-void error_int( const char *prefix, const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(5, 6);
+void error_int( int is_collector, const char *prefix, const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(6, 7);
 void error_limit_int(ERROR_LIMIT *erl, const char *prefix, const char *file __maybe_unused, const char *function __maybe_unused, unsigned long line __maybe_unused, const char *fmt, ... ) PRINTFLIKE(6, 7);;
 void fatal_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) NORETURN PRINTFLIKE(4, 5);
 void log_access( const char *fmt, ... ) PRINTFLIKE(1, 2);

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -118,7 +118,8 @@ typedef struct error_with_limit {
 #define internal_fatal(args...) debug_dummy()
 #endif
 
-#define info(args...)    info_int(__FILE__, __FUNCTION__, __LINE__, ##args)
+#define info(args...)    info_int(0, __FILE__, __FUNCTION__, __LINE__, ##args)
+#define collector_info(args...)    info_int(1, __FILE__, __FUNCTION__, __LINE__, ##args)
 #define infoerr(args...) error_int(0, "INFO", __FILE__, __FUNCTION__, __LINE__, ##args)
 #define error(args...)   error_int(0, "ERROR", __FILE__, __FUNCTION__, __LINE__, ##args)
 #define collector_infoerr(args...) error_int(1, "INFO", __FILE__, __FUNCTION__, __LINE__, ##args)
@@ -129,7 +130,7 @@ typedef struct error_with_limit {
 
 void send_statistics(const char *action, const char *action_result, const char *action_data);
 void debug_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(4, 5);
-void info_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(4, 5);
+void info_int( int is_collector, const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(5, 6);
 void error_int( int is_collector, const char *prefix, const char *file, const char *function, const unsigned long line, const char *fmt, ... ) PRINTFLIKE(6, 7);
 void error_limit_int(ERROR_LIMIT *erl, const char *prefix, const char *file __maybe_unused, const char *function __maybe_unused, unsigned long line __maybe_unused, const char *fmt, ... ) PRINTFLIKE(6, 7);;
 void fatal_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) NORETURN PRINTFLIKE(4, 5);

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -61,6 +61,9 @@ extern FILE *stdaccess;
 extern int stdhealth_fd;
 extern FILE *stdhealth;
 
+extern int stdcollector_fd;
+extern FILE *stdcollector;
+
 extern const char *stdaccess_filename;
 extern const char *stderr_filename;
 extern const char *stdout_filename;

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -65,6 +65,7 @@ extern const char *stdaccess_filename;
 extern const char *stderr_filename;
 extern const char *stdout_filename;
 extern const char *stdhealth_filename;
+extern const char *stdcollector_filename;
 extern const char *facility_log;
 
 #ifdef ENABLE_ACLK

--- a/libnetdata/procfile/procfile.c
+++ b/libnetdata/procfile/procfile.c
@@ -296,7 +296,8 @@ procfile *procfile_readall(procfile *ff) {
         debug(D_PROCFILE, "Reading file '%s', from position %zd with length %zd", procfile_filename(ff), s, (ssize_t)(ff->size - s));
         r = read(ff->fd, &ff->data[s], ff->size - s);
         if(unlikely(r == -1)) {
-            if(unlikely(!(ff->flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) error(PF_PREFIX ": Cannot read from file '%s' on fd %d", procfile_filename(ff), ff->fd);
+            if(unlikely(!(ff->flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) collector_error(PF_PREFIX ": Cannot read from file '%s' on fd %d", procfile_filename(ff), ff->fd);
+            else if(unlikely(ff->flags & PROCFILE_FLAG_ERROR_ON_ERROR_LOG)) error(PF_PREFIX ": Cannot read from file '%s' on fd %d", procfile_filename(ff), ff->fd);
             procfile_close(ff);
             return NULL;
         }
@@ -306,7 +307,8 @@ procfile *procfile_readall(procfile *ff) {
 
     // debug(D_PROCFILE, "Rewinding file '%s'", ff->filename);
     if(unlikely(lseek(ff->fd, 0, SEEK_SET) == -1)) {
-        if(unlikely(!(ff->flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) error(PF_PREFIX ": Cannot rewind on file '%s'.", procfile_filename(ff));
+        if(unlikely(!(ff->flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) collector_error(PF_PREFIX ": Cannot rewind on file '%s'.", procfile_filename(ff));
+        else if(unlikely(ff->flags & PROCFILE_FLAG_ERROR_ON_ERROR_LOG)) error(PF_PREFIX ": Cannot rewind on file '%s'.", procfile_filename(ff));
         procfile_close(ff);
         return NULL;
     }
@@ -403,7 +405,8 @@ procfile *procfile_open(const char *filename, const char *separators, uint32_t f
 
     int fd = open(filename, procfile_open_flags, 0666);
     if(unlikely(fd == -1)) {
-        if(unlikely(!(flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) error(PF_PREFIX ": Cannot open file '%s'", filename);
+        if(unlikely(!(flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) collector_error(PF_PREFIX ": Cannot open file '%s'", filename);
+        else if(unlikely(flags & PROCFILE_FLAG_ERROR_ON_ERROR_LOG)) error(PF_PREFIX ": Cannot open file '%s'", filename);
         return NULL;
     }
 

--- a/libnetdata/procfile/procfile.h
+++ b/libnetdata/procfile/procfile.h
@@ -34,8 +34,9 @@ typedef struct {
 // ----------------------------------------------------------------------------
 // The procfile
 
-#define PROCFILE_FLAG_DEFAULT             0x00000000
-#define PROCFILE_FLAG_NO_ERROR_ON_FILE_IO 0x00000001
+#define PROCFILE_FLAG_DEFAULT             0x00000000 // To store inside `collector.log`
+#define PROCFILE_FLAG_NO_ERROR_ON_FILE_IO 0x00000001 // Do not store nothing
+#define PROCFILE_FLAG_ERROR_ON_ERROR_LOG  0x00000002 // Store inside `error.log`
 
 typedef enum __attribute__ ((__packed__)) procfile_separator {
     PF_CHAR_IS_SEPARATOR,

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -76,6 +76,7 @@ RUN mkdir -p /opt/src /var/log/netdata && \
     ln -sf /dev/stdout /var/log/netdata/access.log && \
     ln -sf /dev/stdout /var/log/netdata/debug.log && \
     ln -sf /dev/stderr /var/log/netdata/error.log && \
+    ln -sf /dev/stderr /var/log/netdata/collector.log && \
     # Add netdata user
     addgroup -g ${NETDATA_GID} -S "${DOCKER_GRP}" && \
     adduser -S -H -s /usr/sbin/nologin -u ${NETDATA_GID} -h /etc/netdata -G "${DOCKER_GRP}" "${DOCKER_USR}"

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -76,7 +76,7 @@ RUN mkdir -p /opt/src /var/log/netdata && \
     ln -sf /dev/stdout /var/log/netdata/access.log && \
     ln -sf /dev/stdout /var/log/netdata/debug.log && \
     ln -sf /dev/stderr /var/log/netdata/error.log && \
-    ln -sf /dev/stderr /var/log/netdata/collector.log && \
+    ln -sf /dev/stdout /var/log/netdata/collector.log && \
     # Add netdata user
     addgroup -g ${NETDATA_GID} -S "${DOCKER_GRP}" && \
     adduser -S -H -s /usr/sbin/nologin -u ${NETDATA_GID} -h /etc/netdata -G "${DOCKER_GRP}" "${DOCKER_USR}"

--- a/web/api/formatters/charts2json.c
+++ b/web/api/formatters/charts2json.c
@@ -10,7 +10,7 @@ const char* get_release_channel() {
     if (use_stable == -1) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s/.environment", netdata_configured_user_config_dir);
-        procfile *ff = procfile_open(filename, "=", PROCFILE_FLAG_DEFAULT);
+        procfile *ff = procfile_open(filename, "=", PROCFILE_FLAG_ERROR_ON_ERROR_LOG);
         if (ff) {
             procfile_set_quotes(ff, "'\"");
             ff = procfile_readall(ff);


### PR DESCRIPTION
##### Summary
Fixes https://github.com/netdata/netdata/issues/13823
Fixes #6038 

This PR has the main goal to separate `collector logs` from `error.log` simplifying netdata debug, development, and mainly helping users to find proper issues with collectors.

Some of `streaming` logs are going to be redirect for new `collector.log`, this is because our stream works like a collector (it uses the same protocol to communicate), but I did not redirect everything with this PR, because I understand this is not the main goal.
##### Test Plan

1. Compile this branch
2. Start netdata
3. Verify that errors delivered by collectors are going to new `collector.log`.

##### Additional Information
This PR is moving logs from external and internal collectors to `collector.log`.

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? collectors
- Can they see the change or is it an under the hood? If they can see it, where? Yes, they will have separated logs for collectors.
- How is the user impacted by the change?  Simplify search for errors.
- What are there any benefits of the change?  Users have separated logs to report error for us.
</details>
