### PR TITLE
Indicate what root privileges are needed for in kickstart.sh.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -492,7 +492,7 @@ run_as_root() {
   confirm_root_support
 
   if [ "$(id -u)" -ne "0" ]; then
-    printf >&2 "Root privileges required to run %s" "${@}"
+    printf >&2 "Root privileges required to run %s\n" "${@}"
   fi
 
   run ${ROOTCMD} "${@}"

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -801,6 +801,7 @@ uninstall() {
       return 0
     else
       progress "Found existing netdata-uninstaller. Running it.."
+      # shellcheck disable=SC2086
       if ! run_script "${uninstaller}" ${FLAGS}; then
         warning "Uninstaller failed. Some parts of Netdata may still be present on the system."
       fi
@@ -814,6 +815,7 @@ uninstall() {
       progress "Downloading netdata-uninstaller ..."
       download "${uninstaller_url}" "${tmpdir}/netdata-uninstaller.sh"
       chmod +x "${tmpdir}/netdata-uninstaller.sh"
+      # shellcheck disable=SC2086
       if ! run_script "${tmpdir}/netdata-uninstaller.sh" ${FLAGS}; then
         warning "Uninstaller failed. Some parts of Netdata may still be present on the system."
       fi
@@ -1225,16 +1227,16 @@ set_auto_updates() {
     if [ "${DRY_RUN}" -eq 1 ]; then
       progress "Would have attempted to enable automatic updates."
     # This first case is for catching using a new kickstart script with an old build. It can be safely removed after v1.34.0 is released.
-    elif ! grep -q '\-\-enable-auto-updates' ${updater}; then
+    elif ! grep -q '\-\-enable-auto-updates' "${updater}"; then
       echo
-    elif ! run_as_root ${updater} --enable-auto-updates "${NETDATA_AUTO_UPDATE_TYPE}"; then
+    elif ! run_as_root "${updater}" --enable-auto-updates "${NETDATA_AUTO_UPDATE_TYPE}"; then
       warning "Failed to enable auto updates. Netdata will still work, but you will need to update manually."
     fi
   else
     if [ "${DRY_RUN}" -eq 1 ]; then
       progress "Would have attempted to disable automatic updates."
     else
-      run_as_root ${updater} --disable-auto-updates
+      run_as_root "${updater}" --disable-auto-updates
     fi
   fi
 }

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -397,7 +397,7 @@ success_banner() {
 cleanup() {
   if [ -z "${NO_CLEANUP}" ] && [ -n "${tmpdir}" ]; then
     cd || true
-    ${ROOTCMD} rm -rf "${tmpdir}"
+    run_as_root rm -rf "${tmpdir}"
   fi
 }
 
@@ -486,6 +486,16 @@ run() {
   fi
 
   return ${ret}
+}
+
+run_as_root() {
+  confirm_root_support
+
+  if [ "$(id -u)" -ne "0" ]; then
+    printf >&2 "Root privileges required to run %s" "${@}"
+  fi
+
+  run ${ROOTCMD} "${@}"
 }
 
 run_script() {
@@ -849,7 +859,7 @@ detect_existing_install() {
   if [ -n "${ndprefix}" ]; then
     typefile="${ndprefix}/etc/netdata/.install-type"
     if [ -r "${typefile}" ]; then
-      ${ROOTCMD} sh -c "cat \"${typefile}\" > \"${tmpdir}/install-type\""
+      run_as_root sh -c "cat \"${typefile}\" > \"${tmpdir}/install-type\""
       # shellcheck disable=SC1090,SC1091
       . "${tmpdir}/install-type"
     else
@@ -859,7 +869,7 @@ detect_existing_install() {
     envfile="${ndprefix}/etc/netdata/.environment"
     if [ "${INSTALL_TYPE}" = "unknown" ] || [ "${INSTALL_TYPE}" = "custom" ]; then
       if [ -r "${envfile}" ]; then
-        ${ROOTCMD} sh -c "cat \"${envfile}\" > \"${tmpdir}/environment\""
+        run_as_root sh -c "cat \"${envfile}\" > \"${tmpdir}/environment\""
         # shellcheck disable=SC1091
         . "${tmpdir}/environment"
         if [ -n "${NETDATA_IS_STATIC_INSTALL}" ]; then
@@ -1013,30 +1023,30 @@ soft_disable_cloud() {
 
   cloud_prefix="${INSTALL_PREFIX}/var/lib/netdata/cloud.d"
 
-  run ${ROOTCMD} mkdir -p "${cloud_prefix}"
+  run_as_root mkdir -p "${cloud_prefix}"
 
   cat > "${tmpdir}/cloud.conf" << EOF
 [global]
   enabled = no
 EOF
 
-  run ${ROOTCMD} cp "${tmpdir}/cloud.conf" "${cloud_prefix}/cloud.conf"
+  run_as_root cp "${tmpdir}/cloud.conf" "${cloud_prefix}/cloud.conf"
 
   if [ -z "${NETDATA_NO_START}" ]; then
     case "${SYSTYPE}" in
-      Darwin) run ${ROOTCMD} launchctl kickstart -k com.github.netdata ;;
-      FreeBSD) run ${ROOTCMD} service netdata restart ;;
+      Darwin) run_as_root launchctl kickstart -k com.github.netdata ;;
+      FreeBSD) run_as_root service netdata restart ;;
       Linux)
-        initpath="$(${ROOTCMD} readlink /proc/1/exe)"
+        initpath="$(run_as_root readlink /proc/1/exe)"
 
         if command -v service > /dev/null 2>&1; then
-          run ${ROOTCMD} service netdata restart
+          run_as_root service netdata restart
         elif command -v rc-service > /dev/null 2>&1; then
-          run ${ROOTCMD} rc-service netdata restart
+          run_as_root rc-service netdata restart
         elif [ "$(basename "${initpath}" 2> /dev/null)" = "systemd" ]; then
-          run ${ROOTCMD} systemctl restart netdata
+          run_as_root systemctl restart netdata
         elif [ -f /etc/init.d/netdata ]; then
-          run ${ROOTCMD} /etc/init.d/netdata restart
+          run_as_root /etc/init.d/netdata restart
         fi
         ;;
     esac
@@ -1135,7 +1145,7 @@ claim() {
   fi
 
   # shellcheck disable=SC2086
-  run ${ROOTCMD} "${NETDATA_CLAIM_PATH}" -token="${NETDATA_CLAIM_TOKEN}" -rooms="${NETDATA_CLAIM_ROOMS}" -url="${NETDATA_CLAIM_URL}" ${NETDATA_CLAIM_EXTRA}
+  run_as_root "${NETDATA_CLAIM_PATH}" -token="${NETDATA_CLAIM_TOKEN}" -rooms="${NETDATA_CLAIM_ROOMS}" -url="${NETDATA_CLAIM_URL}" ${NETDATA_CLAIM_EXTRA}
   case $? in
     0)
       progress "Successfully claimed node"
@@ -1217,14 +1227,14 @@ set_auto_updates() {
     # This first case is for catching using a new kickstart script with an old build. It can be safely removed after v1.34.0 is released.
     elif ! grep -q '\-\-enable-auto-updates' ${updater}; then
       echo
-    elif ! ${ROOTCMD} ${updater} --enable-auto-updates "${NETDATA_AUTO_UPDATE_TYPE}"; then
+    elif ! run_as_root ${updater} --enable-auto-updates "${NETDATA_AUTO_UPDATE_TYPE}"; then
       warning "Failed to enable auto updates. Netdata will still work, but you will need to update manually."
     fi
   else
     if [ "${DRY_RUN}" -eq 1 ]; then
       progress "Would have attempted to disable automatic updates."
     else
-      ${ROOTCMD} ${updater} --disable-auto-updates
+      run_as_root ${updater} --disable-auto-updates
     fi
   fi
 }
@@ -1314,7 +1324,7 @@ check_special_native_deps() {
         progress "EPEL is available, attempting to install so that required dependencies are available."
 
         # shellcheck disable=SC2086
-        if ! run ${ROOTCMD} env ${env} ${pm_cmd} install ${pkg_install_opts} epel-release; then
+        if ! run_as_root env ${env} ${pm_cmd} install ${pkg_install_opts} epel-release; then
           warning "Failed to install EPEL, even though it is required to install native packages on this system."
           return 1
         fi
@@ -1494,21 +1504,21 @@ try_package_install() {
 
     if [ -n "${needs_early_refresh}" ]; then
       # shellcheck disable=SC2086
-      if ! run ${ROOTCMD} env ${env} ${pm_cmd} ${repo_subcmd} ${repo_update_opts}; then
+      if ! run_as_root env ${env} ${pm_cmd} ${repo_subcmd} ${repo_update_opts}; then
         warning "${failed_refresh_msg}"
         return 2
       fi
     fi
 
     # shellcheck disable=SC2086
-    if ! run ${ROOTCMD} env ${env} ${pm_cmd} install ${pkg_install_opts} "${tmpdir}/${repoconfig_file}"; then
+    if ! run_as_root env ${env} ${pm_cmd} install ${pkg_install_opts} "${tmpdir}/${repoconfig_file}"; then
       warning "Failed to install repository configuration package."
       return 2
     fi
 
     if [ -n "${repo_subcmd}" ]; then
       # shellcheck disable=SC2086
-      if ! run ${ROOTCMD} env ${env} ${pm_cmd} ${repo_subcmd} ${repo_update_opts}; then
+      if ! run_as_root env ${env} ${pm_cmd} ${repo_subcmd} ${repo_update_opts}; then
         fatal "${failed_refresh_msg}" F0205
       fi
     fi
@@ -1529,7 +1539,7 @@ try_package_install() {
     if [ -z "${NO_CLEANUP}" ]; then
       progress "Attempting to uninstall repository configuration package."
       # shellcheck disable=SC2086
-      run ${ROOTCMD} env ${env} ${pm_cmd} ${uninstall_subcmd} ${pkg_install_opts} "${repoconfig_name}"
+      run_as_root env ${env} ${pm_cmd} ${uninstall_subcmd} ${pkg_install_opts} "${repoconfig_name}"
     fi
     return 2
   fi
@@ -1539,23 +1549,23 @@ try_package_install() {
     if [ -z "${NO_CLEANUP}" ]; then
       progress "Attempting to uninstall repository configuration package."
       # shellcheck disable=SC2086
-      run ${ROOTCMD} env ${env} ${pm_cmd} ${uninstall_subcmd} ${pkg_install_opts} "${repoconfig_name}"
+      run_as_root env ${env} ${pm_cmd} ${uninstall_subcmd} ${pkg_install_opts} "${repoconfig_name}"
     fi
     return 2
   fi
 
   if [ "${NETDATA_DISABLE_TELEMETRY}" -eq 1 ]; then
-    run ${ROOTCMD} mkdir -p "/etc/netdata"
-    run ${ROOTCMD} touch "/etc/netdata/.opt-out-from-anonymous-statistics"
+    run_as_root mkdir -p "/etc/netdata"
+    run_as_root touch "/etc/netdata/.opt-out-from-anonymous-statistics"
   fi
 
   # shellcheck disable=SC2086
-  if ! run ${ROOTCMD} env ${env} ${pm_cmd} install ${pkg_install_opts} "netdata${NATIVE_VERSION}"; then
+  if ! run_as_root env ${env} ${pm_cmd} install ${pkg_install_opts} "netdata${NATIVE_VERSION}"; then
     warning "Failed to install Netdata package."
     if [ -z "${NO_CLEANUP}" ]; then
       progress "Attempting to uninstall repository configuration package."
       # shellcheck disable=SC2086
-      run ${ROOTCMD} env ${env} ${pm_cmd} ${uninstall_subcmd} ${pkg_install_opts} "${repoconfig_name}"
+      run_as_root env ${env} ${pm_cmd} ${uninstall_subcmd} ${pkg_install_opts} "${repoconfig_name}"
     fi
     return 2
   fi
@@ -1648,7 +1658,7 @@ try_static_install() {
 
   progress "Installing netdata"
   # shellcheck disable=SC2086
-  if ! run ${ROOTCMD} sh "${tmpdir}/${netdata_agent}" ${opts} -- ${NETDATA_INSTALLER_OPTIONS}; then
+  if ! run_as_root sh "${tmpdir}/${netdata_agent}" ${opts} -- ${NETDATA_INSTALLER_OPTIONS}; then
     warning "Failed to install static build of Netdata on ${SYSARCH}."
     run rm -rf /opt/netdata
     return 2
@@ -1657,16 +1667,16 @@ try_static_install() {
   if [ "${DRY_RUN}" -ne 1 ]; then
   install_type_file="/opt/netdata/etc/netdata/.install-type"
     if [ -f "${install_type_file}" ]; then
-      ${ROOTCMD} sh -c "cat \"${install_type_file}\" > \"${tmpdir}/install-type\""
-      ${ROOTCMD} chown "$(id -u)":"$(id -g)" "${tmpdir}/install-type"
+      run_as_root sh -c "cat \"${install_type_file}\" > \"${tmpdir}/install-type\""
+      run_as_root chown "$(id -u)":"$(id -g)" "${tmpdir}/install-type"
       # shellcheck disable=SC1090,SC1091
       . "${tmpdir}/install-type"
       cat > "${tmpdir}/install-type" <<- EOF
 	INSTALL_TYPE='kickstart-static'
 	PREBUILT_ARCH='${PREBUILT_ARCH}'
 	EOF
-      ${ROOTCMD} chown netdata:netdata "${tmpdir}/install-type"
-      ${ROOTCMD} cp "${tmpdir}/install-type" "${install_type_file}"
+      run_as_root chown netdata:netdata "${tmpdir}/install-type"
+      run_as_root cp "${tmpdir}/install-type" "${install_type_file}"
     fi
   fi
 }
@@ -1719,14 +1729,8 @@ install_local_build_dependencies() {
     opts="--dont-wait --non-interactive"
   fi
 
-  if [ "${SYSTYPE}" = "Darwin" ]; then
-    sudo=""
-  else
-    sudo="${ROOTCMD}"
-  fi
-
   # shellcheck disable=SC2086
-  if ! run ${sudo} "${bash}" "${tmpdir}/install-required-packages.sh" ${opts} netdata; then
+  if ! run_as_root "${bash}" "${tmpdir}/install-required-packages.sh" ${opts} netdata; then
     warning "Failed to install all required packages, but installation might still be possible."
   fi
 }

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -492,7 +492,7 @@ run_as_root() {
   confirm_root_support
 
   if [ "$(id -u)" -ne "0" ]; then
-    printf >&2 "Root privileges required to run %s\n" "${@}"
+    printf >&2 "Root privileges required to run %s\n" "${*}"
   fi
 
   run ${ROOTCMD} "${@}"


### PR DESCRIPTION
##### Summary

Instead of just blindly prompting the user for root privileges when they are needed in the kickstart script, print a message about _why_ we need root privileges. This improves transparency for users about why they are being prompted.

##### Test Plan

Run the kickstart script from this PR as a non-root user. You should see messages about root privileges being required for specific commands as those commands are run.