### PR TITLE
Add nvidia smi pci bandwidth percent collector

### DIFF
--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -57,10 +57,21 @@ ORDER = [
 POWER_STATES = ['P' + str(i) for i in range(0, 16)]
 
 # PCI Transfer data rate in gigabits per second (Gb/s) per generation
-PCI_SPEED = [2.5, 5, 8, 16, 32]
+PCI_SPEED = {
+  "1": 2.5, 
+  "2": 5, 
+  "3": 8, 
+  "4": 16,
+  "5": 32
+}
 # PCI encoding per generation
-PCI_ENCODING = [2/10, 2/10, 2/130, 2/130, 2/130]
-
+PCI_ENCODING = {
+  "1": 2/10, 
+  "2": 2/10, 
+  "3": 2/130, 
+  "4": 2/130,
+  "5": 2/130
+}
 def gpu_charts(gpu):
     fam = gpu.full_name()
 
@@ -341,7 +352,7 @@ class GPU:
         return self.root.find('pci').find('pci_gpu_link_info').find('link_widths').find('max_link_width').text.split('x')[0]
 
     def pci_bw_max(self):
-        link_gen = int(self.pci_link_gen())
+        link_gen = self.pci_link_gen()
         link_width = int(self.pci_link_width())
         # Maximum PCIe Bandwidth = SPEED * WIDTH * (1 - ENCODING) - 1Gb/s.
         # see details https://enterprise-support.nvidia.com/s/article/understanding-pcie-configuration-for-maximum-performance

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -35,11 +35,9 @@ POWER_STATE = 'power_state'
 PROCESSES_MEM = 'processes_mem'
 USER_MEM = 'user_mem'
 USER_NUM = 'user_num'
-PCI_GEN = 'pci_gen'
 
 ORDER = [
     PCI_BANDWIDTH,
-    PCI_GEN,
     FAN_SPEED,
     GPU_UTIL,
     MEM_UTIL,
@@ -154,12 +152,6 @@ def gpu_charts(gpu):
             'lines': [
                 ['user_num', 'users'],
             ]
-        },
-        PCI_GEN: {
-            'options': [None, 'PCI Generation', 'num', fam, 'nvidia_smi.pci_gen', 'line'],
-            'lines': [
-                ['pci_link_gen', 'gen', 'absolute', 1, 1],
-             ]
         },
     }
 
@@ -469,7 +461,6 @@ class GPU:
             'sm_clock': self.sm_clock(),
             'mem_clock': self.mem_clock(),
             'power_draw': self.power_draw(),
-            'pci_link_gen': self.pci_link_gen(),
         }
 
         for v in POWER_STATES:

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -22,6 +22,7 @@ EMPTY_ROW_LIMIT = 500
 POLLER_BREAK_ROW = '</nvidia_smi_log>'
 
 PCI_BANDWIDTH = 'pci_bandwidth'
+PCI_BANDWIDTH_PERCENT = 'pci_bandwidth_percent'
 FAN_SPEED = 'fan_speed'
 GPU_UTIL = 'gpu_utilization'
 MEM_UTIL = 'mem_utilization'
@@ -38,6 +39,7 @@ USER_NUM = 'user_num'
 
 ORDER = [
     PCI_BANDWIDTH,
+    PCI_BANDWIDTH_PERCENT,
     FAN_SPEED,
     GPU_UTIL,
     MEM_UTIL,
@@ -58,17 +60,17 @@ POWER_STATES = ['P' + str(i) for i in range(0, 16)]
 
 # PCI Transfer data rate in gigabits per second (Gb/s) per generation
 PCI_SPEED = {
-  "1": 2.5, 
-  "2": 5, 
-  "3": 8, 
+  "1": 2.5,
+  "2": 5,
+  "3": 8,
   "4": 16,
   "5": 32
 }
 # PCI encoding per generation
 PCI_ENCODING = {
-  "1": 2/10, 
-  "2": 2/10, 
-  "3": 2/130, 
+  "1": 2/10,
+  "2": 2/10,
+  "3": 2/130,
   "4": 2/130,
   "5": 2/130
 }
@@ -81,6 +83,11 @@ def gpu_charts(gpu):
             'lines': [
                 ['rx_util', 'rx', 'absolute', 1, 1],
                 ['tx_util', 'tx', 'absolute', 1, -1],
+            ]
+        },
+        PCI_BANDWIDTH_PERCENT: {
+            'options': [None, 'PCI Express Bandwidth Percent', 'percentage', fam, 'nvidia_smi.pci_bandwidth_percent', 'area'],
+            'lines': [
                 ['rx_util_percent', 'rx_percent'],
                 ['tx_util_percent', 'tx_percent'],
             ]
@@ -354,6 +361,8 @@ class GPU:
     def pci_bw_max(self):
         link_gen = self.pci_link_gen()
         link_width = int(self.pci_link_width())
+        if link_gen not in PCI_SPEED or link_gen not in PCI_ENCODING or not link_width:
+            return None
         # Maximum PCIe Bandwidth = SPEED * WIDTH * (1 - ENCODING) - 1Gb/s.
         # see details https://enterprise-support.nvidia.com/s/article/understanding-pcie-configuration-for-maximum-performance
         # return max bandwidth in kilobytes per second (kB/s)
@@ -455,8 +464,6 @@ class GPU:
         data = {
             'rx_util': self.rx_util(),
             'tx_util': self.tx_util(),
-            'rx_util_percent': str(int(int(self.rx_util())*100/self.pci_bw_max())),
-            'tx_util_percent': str(int(int(self.tx_util())*100/self.pci_bw_max())),
             'fan_speed': self.fan_speed(),
             'gpu_util': self.gpu_util(),
             'memory_util': self.memory_util(),
@@ -473,6 +480,14 @@ class GPU:
             'mem_clock': self.mem_clock(),
             'power_draw': self.power_draw(),
         }
+
+        if self.pci_bw_max() is None or self.pci_bw_max() == 0:
+            data['rx_util_percent'] = 0
+            data['tx_util_percent'] = 0
+        else :
+            data['rx_util_percent'] = str(int(int(self.rx_util())*100/self.pci_bw_max()))
+            data['tx_util_percent'] = str(int(int(self.tx_util())*100/self.pci_bw_max()))
+
 
         for v in POWER_STATES:
             data['power_state_' + v.lower()] = 0

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -61,6 +61,7 @@ POWER_STATES = ['P' + str(i) for i in range(0, 16)]
 
 def gpu_charts(gpu):
     fam = gpu.full_name()
+    pci_bw_max = gpu.pci_bw_max()
 
     charts = {
         PCI_BANDWIDTH: {
@@ -68,6 +69,8 @@ def gpu_charts(gpu):
             'lines': [
                 ['rx_util', 'rx', 'absolute', 1, 1],
                 ['tx_util', 'tx', 'absolute', 1, -1],
+                ['rx_util_percent', 'rx_percent'],
+                ['tx_util_percent', 'tx_percent'],
             ]
         },
         FAN_SPEED: {
@@ -342,6 +345,12 @@ class GPU:
     def pci_link_width(self):
         return self.root.find('pci').find('pci_gpu_link_info').find('link_widths').find('current_link_width').text.split('x')[0]
 
+    def pci_bw_max(self):
+        link_gen = int(self.pci_link_gen())
+        link_width = int(self.pci_link_width())
+        # return max bandwidth in kB/s
+        return link_gen * 250 * 1024 * link_width
+
     @handle_attr_error
     def rx_util(self):
         return self.root.find('pci').find('rx_util').text.split()[0]
@@ -438,6 +447,8 @@ class GPU:
         data = {
             'rx_util': self.rx_util(),
             'tx_util': self.tx_util(),
+            'rx_util_percent': str(int(int(self.rx_util())/self.pci_bw_max())),
+            'tx_util_percent': str(int(int(self.tx_util())/self.pci_bw_max())),
             'fan_speed': self.fan_speed(),
             'gpu_util': self.gpu_util(),
             'memory_util': self.memory_util(),

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -338,11 +338,11 @@ class GPU:
 
     @handle_attr_error
     def pci_link_gen(self):
-        return self.root.find('pci').find('pci_gpu_link_info').find('pcie_gen').find('current_link_gen').text
+        return self.root.find('pci').find('pci_gpu_link_info').find('pcie_gen').find('max_link_gen').text
 
     @handle_attr_error
     def pci_link_width(self):
-        return self.root.find('pci').find('pci_gpu_link_info').find('link_widths').find('current_link_width').text.split('x')[0]
+        return self.root.find('pci').find('pci_gpu_link_info').find('link_widths').find('max_link_width').text.split('x')[0]
 
     def pci_bw_max(self):
         link_gen = int(self.pci_link_gen())
@@ -446,8 +446,8 @@ class GPU:
         data = {
             'rx_util': self.rx_util(),
             'tx_util': self.tx_util(),
-            'rx_util_percent': str(int(int(self.rx_util())/self.pci_bw_max())),
-            'tx_util_percent': str(int(int(self.tx_util())/self.pci_bw_max())),
+            'rx_util_percent': str(int(int(self.rx_util())*100/self.pci_bw_max())),
+            'tx_util_percent': str(int(int(self.tx_util())*100/self.pci_bw_max())),
             'fan_speed': self.fan_speed(),
             'gpu_util': self.gpu_util(),
             'memory_util': self.memory_util(),

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -483,7 +483,6 @@ class GPU:
 
         pci_bw_max = self.pci_bw_max()
         if not pci_bw_max:
-            ...
             data['rx_util_percent'] = 0
             data['tx_util_percent'] = 0
         else :

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -61,7 +61,6 @@ POWER_STATES = ['P' + str(i) for i in range(0, 16)]
 
 def gpu_charts(gpu):
     fam = gpu.full_name()
-    pci_bw_max = gpu.pci_bw_max()
 
     charts = {
         PCI_BANDWIDTH: {

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -35,9 +35,11 @@ POWER_STATE = 'power_state'
 PROCESSES_MEM = 'processes_mem'
 USER_MEM = 'user_mem'
 USER_NUM = 'user_num'
+PCI_GEN = 'pci_gen'
 
 ORDER = [
     PCI_BANDWIDTH,
+    PCI_GEN,
     FAN_SPEED,
     GPU_UTIL,
     MEM_UTIL,
@@ -146,6 +148,12 @@ def gpu_charts(gpu):
             'lines': [
                 ['user_num', 'users'],
             ]
+        },
+        PCI_GEN: {
+            'options': [None, 'PCI Generation', 'num', fam, 'nvidia_smi.pci_gen', 'line'],
+            'lines': [
+                ['pci_link_gen', 'gen', 'absolute', 1, 1],
+             ]
         },
     }
 
@@ -327,6 +335,14 @@ class GPU:
         return 'gpu{0} {1}'.format(self.num, self.name())
 
     @handle_attr_error
+    def pci_link_gen(self):
+        return self.root.find('pci').find('pci_gpu_link_info').find('pcie_gen').find('current_link_gen').text
+
+    @handle_attr_error
+    def pci_link_width(self):
+        return self.root.find('pci').find('pci_gpu_link_info').find('link_widths').find('current_link_width').text.split('x')[0]
+
+    @handle_attr_error
     def rx_util(self):
         return self.root.find('pci').find('rx_util').text.split()[0]
 
@@ -437,6 +453,7 @@ class GPU:
             'sm_clock': self.sm_clock(),
             'mem_clock': self.mem_clock(),
             'power_draw': self.power_draw(),
+            'pci_link_gen': self.pci_link_gen(),
         }
 
         for v in POWER_STATES:

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -481,7 +481,9 @@ class GPU:
             'power_draw': self.power_draw(),
         }
 
-        if self.pci_bw_max() is None or self.pci_bw_max() == 0:
+        pci_bw_max = self.pci_bw_max()
+        if not pci_bw_max:
+            ...
             data['rx_util_percent'] = 0
             data['tx_util_percent'] = 0
         else :

--- a/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
+++ b/collectors/python.d.plugin/nvidia_smi/nvidia_smi.chart.py
@@ -58,6 +58,10 @@ ORDER = [
 # https://docs.nvidia.com/gameworks/content/gameworkslibrary/coresdk/nvapi/group__gpupstate.html
 POWER_STATES = ['P' + str(i) for i in range(0, 16)]
 
+# PCI Transfer data rate in gigabits per second (Gb/s) per generation
+PCI_SPEED = [2.5, 5, 8, 16, 32]
+# PCI encoding per generation
+PCI_ENCODING = [2/10, 2/10, 2/130, 2/130, 2/130]
 
 def gpu_charts(gpu):
     fam = gpu.full_name()
@@ -347,8 +351,10 @@ class GPU:
     def pci_bw_max(self):
         link_gen = int(self.pci_link_gen())
         link_width = int(self.pci_link_width())
-        # return max bandwidth in kB/s
-        return link_gen * 250 * 1024 * link_width
+        # Maximum PCIe Bandwidth = SPEED * WIDTH * (1 - ENCODING) - 1Gb/s.
+        # see details https://enterprise-support.nvidia.com/s/article/understanding-pcie-configuration-for-maximum-performance
+        # return max bandwidth in kilobytes per second (kB/s)
+        return (PCI_SPEED[link_gen] * link_width * (1- PCI_ENCODING[link_gen]) - 1) * 1000 * 1000 / 8
 
     @handle_attr_error
     def rx_util(self):


### PR DESCRIPTION
##### Summary
This change enables the calculation of the PCIE bandwidth in percent.  

##### Test Plan

Tested manually on two different machines. One with a GPU Quadro RTX 4000 and the other one with GPU RTX  A4500
##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->
To have a quick overview about the pcie bandwidth available, I though it was useful to have the values of TX/RX bandwidth in percent. To do so it calculates the maximum theoretical bandwidth thanks to the pcie generation and width given by nvidia-smi, thus the value in percent can be deduced.

<details> <summary>For users: metric netdata_nvidia_smi_pci_bandwidth_KiB_persec_average enhanced  </summary>

It changes the nvidia-smi plugin only. And two dimensions _rx_percent_ and _tx_percent_ have been added to the _netdata_nvidia_smi_pci_bandwidth_KiB_persec_average_ metric.

</details>
