### PR TITLE
fix(proc.plugin): add cpu label to per core util% charts

### DIFF
--- a/collectors/proc.plugin/proc_stat.c
+++ b/collectors/proc.plugin/proc_stat.c
@@ -712,6 +712,12 @@ int do_proc_stat(int update_every, usec_t dt) {
                     cpu_chart->rd_idle       = rrddim_add(cpu_chart->st, "idle",       NULL, multiplier, divisor, RRD_ALGORITHM_PCENT_OVER_DIFF_TOTAL);
                     rrddim_hide(cpu_chart->st, "idle");
 
+                    if (core > 0) {
+                        char cpu_core[50 + 1];
+                        snprintfz(cpu_core, 50, "cpu%d", core - 1);
+                        rrdlabels_add(cpu_chart->st->rrdlabels, "cpu", cpu_core, RRDLABEL_SRC_AUTO);
+                    }
+
                     if(unlikely(core == 0 && cpus_var == NULL))
                         cpus_var = rrdvar_custom_host_variable_add_and_acquire(localhost, "active_processors");
                 }


### PR DESCRIPTION
##### Summary

ssia

##### Test Plan

Install this branch, and check 

- "system.cpu" chart should have no "cpu" label.
- "cpu.cpu" charts should have "cpu" label.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
