### PR TITLE
Build judyltablesgen for host when cross-compiling

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -524,12 +524,14 @@ libnetdata/libjudy/src/JudyL/libjudy_a-j__udyLGet.$(OBJEXT) : CFLAGS +=  -DJUDYG
 noinst_PROGRAMS = judyltablesgen
 
 judyltablesgen_SOURCES = libnetdata/libjudy/src/JudyL/JudyLTablesGen.c
-judyltablesgen_CFLAGS = $(LIBJUDY_CFLAGS) -DJUDYL -I$(abs_top_srcdir)/libnetdata/libjudy/src -I$(abs_top_srcdir)/libnetdata/libjudy/src/JudyCommon -Wno-sign-compare -Wno-implicit-fallthrough
+judyltablesgen_CFLAGS = $(LIBJUDY_CFLAGS) $(BUILD_CFLAGS) -DJUDYL -I$(abs_top_srcdir)/libnetdata/libjudy/src -I$(abs_top_srcdir)/libnetdata/libjudy/src/JudyCommon -Wno-sign-compare -Wno-implicit-fallthrough -Wno-format -Wno-format-security
+judyltablesgen_LDFLAGS = $(BUILD_LDFLAGS)
 
-$(builddir)/judyltablesgen$(EXEEXT) : CFLAGS += -Wno-format -Wno-format-security
+$(builddir)/judyltablesgen$(BUILD_EXEEXT) :
+	$(CC_FOR_BUILD) $(judyltablesgen_CFLAGS) $(judyltablesgen_LDFLAGS) $(judyltablesgen_SOURCES) -o judyltablesgen$(BUILD_EXEEXT)
 
-JudyLTables.c: $(abs_top_srcdir)/libnetdata/libjudy/src/JudyL/JudyLTablesGen.c $(builddir)/judyltablesgen$(EXEEXT)
-	$(builddir)/judyltablesgen$(EXEEXT)
+JudyLTables.c: $(abs_top_srcdir)/libnetdata/libjudy/src/JudyL/JudyLTablesGen.c $(builddir)/judyltablesgen$(BUILD_EXEEXT)
+	$(builddir)/judyltablesgen$(BUILD_EXEEXT)
 
 libjudy_a-JudyLTables.$(OBJEXT) : CFLAGS += -I$(abs_top_srcdir)/libnetdata/libjudy/src/JudyL
 

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,8 @@ else
   AC_CHECK_TOOL([AR], [ar])
 fi
 
+AX_PROG_CC_FOR_BUILD
+
 # -----------------------------------------------------------------------------
 # configurable options
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->
Fixes #14185

This proposes a small and self-contained change to (a) the initialization of autoconf and (b) the specific build recipes for certain artifacts within libjudy that must be unconditionally compiled for the host architecture (it is a generator for more sources and so will be executed on the build host) even when cross-compiling for a different target architecture.

This change is designed in such a way that, when building natively, there should be no net difference in behavior.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->
This change affects the very earliest phase of the build process, and the only watermark for its success or failure is whether it consistently produces the desired objects for all possible build targets. I have only been able to test the two specific native (x86_64-pc-linux-gnu) and cross (mipsel-openwrt-linux-gnu) compilation cases myself.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
Unless you happen to be cross-compiling Netdata from source (or maybe are a Gentoo user with crossdev), it does not affect you. The change should not be noticeable outside of these very special circumstances.
</details>
