### PR TITLE
Update the Get started doc

### DIFF
--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -65,27 +65,27 @@ troubleshooting with Netdata.
 
 <Install>
   <InstallBox
-    to="https://github.com/netdata/netdata/blob/master/packaging/docker/README.md"
+    to="[](https://github.com/netdata/netdata/blob/master/packaging/docker/README.md)"
     os="Run with Docker" 
     svg="docker" />
   <InstallBox
-    to="https://github.com/netdata/netdata/blob/master/packaging/installer/methods/kubernetes.md"
+    to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/kubernetes.md)"
     os="Deploy on Kubernetes" 
     svg="kubernetes" />
    <InstallBox
-    to="https://github.com/netdata/netdata/blob/master/packaging/installer/methods/macos.md"
+    to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/macos.md)"
     os="Install on macOS" 
     svg="macos" />
   <InstallBox
-    to="https://github.com/netdata/netdata/blob/master/packaging/installer/methods/manual.md"
+    to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/manual.md)"
     os="Linux from Git" 
     svg="linux" />
   <InstallBox
-    to="https://github.com/netdata/netdata/blob/master/packaging/installer/methods/source.md"
+    to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/source.md)"
     os="Linux from source"
     svg="linux" />
   <InstallBox
-    to="https://github.com/netdata/netdata/blob/master/packaging/installer/methods/offline.md" 
+    to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/offline.md)" 
     os="Linux for offline nodes"
     svg="linux" />
 </Install>

--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -25,11 +25,13 @@ Docker), and many other operating systems (FreeBSD, macOS), with no `sudo` requi
 
 To install Netdata in minutes on your platform:
 
-1. Visit https://app.netdata.cloud/
-2. You will be presented with an empty space, and a prompt with the install command for each platform
+1. Sign up to https://app.netdata.cloud/
+2. You will be presented with an empty space, and a prompt to "Connect Nodes" with the install command for each platform
 3. Select the platform you want to install Netdata to, copy and paste the script into your node's terminal, and run it
 
 Upon installation completing successfully, you should be able to see the node live in your Netdata Space!
+
+Continue reading for more advanced instructions and installation options.
 
 ## Install on Linux with one-line installer 
 

--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -125,4 +125,4 @@ community, but you may want to [edit alarms](https://github.com/netdata/netdata/
 
 ### Make your deployment production ready
 
-Both [securing](https://github.com/netdata/netdata/blob/master/docs/configure/secure-nodes.md) and [replication](https://github.com/netdata/netdata/blob/master/streaming/README.md) are strongly recommended.
+Both [securing Netdata](https://github.com/netdata/netdata/blob/master/docs/configure/secure-nodes.md) and [setting up replication](https://github.com/netdata/netdata/blob/master/streaming/README.md) are strongly recommended.

--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -106,14 +106,13 @@ to [interact with charts](https://github.com/netdata/netdata/blob/master/docs/da
 ### Configuration
 
 Discover the recommended way to [configure Netdata's settings or behavior](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md) using our built-in
-`edit-config` script, then apply that knowledge to mission-critical tweaks, such as [changing how long Netdata stores
-metrics](https://github.com/netdata/netdata/blob/master/docs/store/change-metrics-storage.md).
+`edit-config` script, then apply that knowledge to mission-critical tweaks, such as [changing how long Netdata stores metrics](https://github.com/netdata/netdata/blob/master/docs/store/change-metrics-storage.md).
 
 ### Data collection
 
 If Netdata didn't autodetect all the hardware, containers, services, or applications running on your node, you should
-learn more about [how data collectors work](https://github.com/netdata/netdata/blob/master/docs/collect/how-collectors-work.md). If there's a [supported
-collector](https://github.com/netdata/netdata/blob/master/collectors/COLLECTORS.md) for metrics you need, [configure the collector](https://github.com/netdata/netdata/blob/master/docs/collect/enable-configure.md)
+learn more about [how data collectors work](https://github.com/netdata/netdata/blob/master/docs/collect/how-collectors-work.md). 
+If there's a [supported collector](https://github.com/netdata/netdata/blob/master/collectors/COLLECTORS.md) for metrics you need, [configure the collector](https://github.com/netdata/netdata/blob/master/docs/collect/enable-configure.md)
 or read about its requirements to configure your endpoint to publish metrics in the correct format and endpoint.
 
 ### Alarms & notifications
@@ -124,8 +123,7 @@ community, but you may want to [edit alarms](https://github.com/netdata/netdata/
 
 ### Need to monitor multiple nodes in one place?
 
-For robust multi-node monitoring from a single interface, consider [Netdata
-Cloud](https://app.netdata.cloud/), which streams, aggregates, and visualizes metrics from any number of
+For robust multi-node monitoring from a single interface, consider [Netdata Cloud](https://app.netdata.cloud/), which streams, aggregates, and visualizes metrics from any number of
 nodes. It's all the same out-of-the-box, zero-configuration functionality of the open-source monitoring agent, but for
 any number of distributed nodes, _entirely for free_.
 

--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -119,8 +119,8 @@ or read about its requirements to configure your endpoint to publish metrics in 
 ### Alarms & notifications
 
 Netdata comes with hundreds of preconfigured alarms, designed by our monitoring gurus in parallel with our open-source
-community, but you may want to [edit alarms](https://github.com/netdata/netdata/blob/master/docs/monitor/configure-alarms.md) or [enable
-notifications](https://github.com/netdata/netdata/blob/master/docs/monitor/enable-notifications.md) to customize your Netdata experience.
+community, but you may want to [edit alarms](https://github.com/netdata/netdata/blob/master/docs/monitor/configure-alarms.md) or 
+[enable notifications](https://github.com/netdata/netdata/blob/master/docs/monitor/enable-notifications.md) to customize your Netdata experience.
 
 ### Need to monitor multiple nodes in one place?
 

--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -1,4 +1,4 @@
----
+<!--
 title: "Install Netdata"
 description: "Download and install the open-source Netdata monitoring agent on physical/virtual servers, Linux (Ubuntu/Debian/CentOS/etc), Docker, Kubernetes, and many others, often with one command."
 sidebar_label: "Install Netdata"
@@ -6,12 +6,12 @@ custom_edit_url: "https://github.com/netdata/netdata/edit/master/docs/get-starte
 learn_status: "Published"
 learn_topic_type: "Tasks"
 learn_rel_path: "Getting started"
----
+-->
 
-import { OneLineInstallWget } from '@site/src/components/OneLineInstall/'
+import { OneLineInstallWget, OneLineInstallCurl } from '@site/src/components/OneLineInstall/'
 import { Install, InstallBox } from '@site/src/components/Install/'
-
-# Get started with Netdata
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 Netdata is a free and open-source (FOSS) monitoring agent that collects thousands of hardware and software metrics from
 any physical or virtual system (we call them _nodes_). These metrics are organized in an easy-to-use and -navigate interface.
@@ -23,15 +23,40 @@ Netdata runs permanently on all your physical/virtual servers, containers, cloud
 runs on Linux distributions (Ubuntu, Debian, CentOS, and more), container/microservice platforms (Kubernetes clusters,
 Docker), and many other operating systems (FreeBSD, macOS), with no `sudo` required.
 
+To install Netdata in minutes on your platform:
+
+1. Visit https://app.netdata.cloud/
+2. You will be presented with an empty space, and a prompt with the install command for each platform
+3. Select the platform you want to install Netdata to, copy and paste the script into your node's terminal, and run it
+
+Upon installation completing successfully, you should be able to see the node live in your Netdata Space!
+
 ## Install on Linux with one-line installer 
 
 The **recommended** way to install Netdata on a Linux node (physical, virtual, container, IoT) is our one-line
-[kickstart script](/packaging/installer/methods/kickstart.md). This script automatically installs dependencies and
-builds Netdata from its source code.
+[kickstart script](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/kickstart.md).  
+This script automatically installs dependencies and builds Netdata from its source code.
 
-Copy the script, paste it into your node's terminal, and hit `Enter` to begin the installation process.
+To install, copy the script, paste it into your node's terminal, and hit `Enter` to begin the installation process.
 
-<OneLineInstallWget />
+ <Tabs>
+  <TabItem value="wget" label=<code>wget</code>>
+
+  <OneLineInstallWget/>
+
+  </TabItem>
+  <TabItem value="curl" label=<code>curl</code>>
+
+  <OneLineInstallCurl/>
+
+  </TabItem>
+</Tabs>
+
+:::note
+If you plan to also Claim the node to Netdata Cloud, 
+make sure to replace `YOUR_CLAIM_TOKEN` with the claim token of your space, 
+and `YOUR_ROOM_ID` with the ID of the room you are willing to claim to.
+:::
 
 Jump down to [what's next](#whats-next) to learn how to view your new dashboard and take your next steps monitoring and
 troubleshooting with Netdata.
@@ -40,27 +65,27 @@ troubleshooting with Netdata.
 
 <Install>
   <InstallBox
-    to="/docs/agent/packaging/docker"
+    to="https://github.com/netdata/netdata/blob/master/packaging/docker/README.md"
     os="Run with Docker" 
     svg="docker" />
   <InstallBox
-    to="/docs/agent/packaging/installer/methods/kubernetes"
+    to="https://github.com/netdata/netdata/blob/master/packaging/installer/methods/kubernetes.md"
     os="Deploy on Kubernetes" 
     svg="kubernetes" />
    <InstallBox
-    to="/docs/agent/packaging/installer/methods/macos"
+    to="https://github.com/netdata/netdata/blob/master/packaging/installer/methods/macos.md"
     os="Install on macOS" 
     svg="macos" />
   <InstallBox
-    to="/docs/agent/packaging/installer/methods/manual"
+    to="https://github.com/netdata/netdata/blob/master/packaging/installer/methods/manual.md"
     os="Linux from Git" 
     svg="linux" />
   <InstallBox
-    to="/docs/agent/packaging/installer/methods/source"
+    to="https://github.com/netdata/netdata/blob/master/packaging/installer/methods/source.md"
     os="Linux from source"
     svg="linux" />
   <InstallBox
-    to="/docs/agent/packaging/installer/methods/offline" 
+    to="https://github.com/netdata/netdata/blob/master/packaging/installer/methods/offline.md" 
     os="Linux for offline nodes"
     svg="linux" />
 </Install>
@@ -75,35 +100,35 @@ Where you go from here is based on your use case, immediate needs, and experienc
 
 ### Dashboard
 
-Learn more about [how the dashboard works](/docs/dashboard/how-dashboard-works.mdx), or dive directly into the many ways
-to [interact with charts](/docs/dashboard/interact-charts.mdx).
+Learn more about [how the dashboard works](https://github.com/netdata/netdata/blob/master/docs/dashboard/how-dashboard-works.mdx), or dive directly into the many ways
+to [interact with charts](https://github.com/netdata/netdata/blob/master/docs/dashboard/interact-charts.mdx).
 
 ### Configuration
 
-Discover the recommended way to [configure Netdata's settings or behavior](/docs/configure/nodes.md) using our built-in
+Discover the recommended way to [configure Netdata's settings or behavior](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md) using our built-in
 `edit-config` script, then apply that knowledge to mission-critical tweaks, such as [changing how long Netdata stores
-metrics](/docs/store/change-metrics-storage.md).
+metrics](https://github.com/netdata/netdata/blob/master/docs/store/change-metrics-storage.md).
 
 ### Data collection
 
 If Netdata didn't autodetect all the hardware, containers, services, or applications running on your node, you should
-learn more about [how data collectors work](/docs/collect/how-collectors-work.md). If there's a [supported
-collector](/collectors/COLLECTORS.md) for metrics you need, [configure the collector](/docs/collect/enable-configure.md)
+learn more about [how data collectors work](https://github.com/netdata/netdata/blob/master/docs/collect/how-collectors-work.md). If there's a [supported
+collector](https://github.com/netdata/netdata/blob/master/collectors/COLLECTORS.md) for metrics you need, [configure the collector](https://github.com/netdata/netdata/blob/master/docs/collect/enable-configure.md)
 or read about its requirements to configure your endpoint to publish metrics in the correct format and endpoint.
 
 ### Alarms & notifications
 
 Netdata comes with hundreds of preconfigured alarms, designed by our monitoring gurus in parallel with our open-source
-community, but you may want to [edit alarms](/docs/monitor/configure-alarms.md) or [enable
-notifications](/docs/monitor/enable-notifications.md) to customize your Netdata experience.
+community, but you may want to [edit alarms](https://github.com/netdata/netdata/blob/master/docs/monitor/configure-alarms.md) or [enable
+notifications](https://github.com/netdata/netdata/blob/master/docs/monitor/enable-notifications.md) to customize your Netdata experience.
 
 ### Need to monitor multiple nodes in one place?
 
 For robust multi-node monitoring from a single interface, consider [Netdata
-Cloud](https://learn.netdata.cloud/docs/cloud), which streams, aggregates, and visualizes metrics from any number of
+Cloud](https://app.netdata.cloud/), which streams, aggregates, and visualizes metrics from any number of
 nodes. It's all the same out-of-the-box, zero-configuration functionality of the open-source monitoring agent, but for
 any number of distributed nodes, _entirely for free_.
 
 There is an alternative for those who aren't interested in using Netdata Cloud, albeit with some required configuration.
-Each node can [stream](/streaming/README.md) its metrics to any other node, and the default
-[registry](/registry/README.md) is configurable to create a private "network" of Netdata dashboards.
+Each node can [stream](https://github.com/netdata/netdata/blob/master/streaming/README.md) its metrics to any other node, and the default
+[registry](https://github.com/netdata/netdata/blob/master/registry/README.md) is configurable to create a private "network" of Netdata dashboards.

--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -9,7 +9,7 @@ learn_rel_path: "Getting started"
 -->
 
 import { OneLineInstallWget, OneLineInstallCurl } from '@site/src/components/OneLineInstall/'
-import { Install, InstallBox } from '@site/src/components/Install/'
+import { InstallRegexLink, InstallBoxRegexLink } from '@site/src/components/InstallRegexLink/'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -63,32 +63,32 @@ troubleshooting with Netdata.
 
 ## Other installation options
 
-<Install>
-  <InstallBox
+<InstallRegexLink>
+  <InstallBoxRegexLink
     to="[](https://github.com/netdata/netdata/blob/master/packaging/docker/README.md)"
     os="Run with Docker" 
     svg="docker" />
-  <InstallBox
+  <InstallBoxRegexLink
     to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/kubernetes.md)"
     os="Deploy on Kubernetes" 
     svg="kubernetes" />
-   <InstallBox
+   <InstallBoxRegexLink
     to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/macos.md)"
     os="Install on macOS" 
     svg="macos" />
-  <InstallBox
+  <InstallBoxRegexLink
     to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/manual.md)"
     os="Linux from Git" 
     svg="linux" />
-  <InstallBox
+  <InstallBoxRegexLink
     to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/source.md)"
     os="Linux from source"
     svg="linux" />
-  <InstallBox
+  <InstallBoxRegexLink
     to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/offline.md)" 
     os="Linux for offline nodes"
     svg="linux" />
-</Install>
+</InstallRegexLink>
 
 
 ## What's next?

--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -123,12 +123,6 @@ Netdata comes with hundreds of preconfigured alarms, designed by our monitoring 
 community, but you may want to [edit alarms](https://github.com/netdata/netdata/blob/master/docs/monitor/configure-alarms.md) or 
 [enable notifications](https://github.com/netdata/netdata/blob/master/docs/monitor/enable-notifications.md) to customize your Netdata experience.
 
-### Need to monitor multiple nodes in one place?
+### Make your deployment production ready
 
-For robust multi-node monitoring from a single interface, consider [Netdata Cloud](https://app.netdata.cloud/), which streams, aggregates, and visualizes metrics from any number of
-nodes. It's all the same out-of-the-box, zero-configuration functionality of the open-source monitoring agent, but for
-any number of distributed nodes, _entirely for free_.
-
-There is an alternative for those who aren't interested in using Netdata Cloud, albeit with some required configuration.
-Each node can [stream](https://github.com/netdata/netdata/blob/master/streaming/README.md) its metrics to any other node, and the default
-[registry](https://github.com/netdata/netdata/blob/master/registry/README.md) is configurable to create a private "network" of Netdata dashboards.
+Both [securing](https://github.com/netdata/netdata/blob/master/docs/configure/secure-nodes.md) and [replication](https://github.com/netdata/netdata/blob/master/streaming/README.md) are strongly recommended.


### PR DESCRIPTION
##### Summary

This PR is related with https://github.com/netdata/documentation/issues/22, it includes:

- [X] Added a section called "Install Netdata", providing a very quick route to installing and claiming from the Cloud
- [X] The `wget` and `curl` options were put into tabs that Docusaurus provides
- [X] Fixed broken links with the proper (from now on) absolute github links
- [X] A note has been added to instruct the user to change the placeholders if he intends to claim to the Cloud
- [X] Find a way to not have absolute raw links inside the install option boxes 👉 https://github.com/netdata/learn/pull/1292

What else could be changed:

- Do we need the top section "Get started with Netdata"? (Same information should be living at the introduction document)
- ~~Should we rename the file's title to "Install Netdata"?~~ Already done due to naming conflict with the category this file lives at Learn
- Should we add another box in the "other installation options" for the "Install Netdata with kickstart.sh" page? (we have a link to it, but as a reference to the kickstart script)
