### PR TITLE
Update the "Deploy Kubernetes monitoring with Netdata" doc

### DIFF
--- a/packaging/installer/methods/kubernetes.md
+++ b/packaging/installer/methods/kubernetes.md
@@ -19,7 +19,7 @@ To see what our Netdata Cloud Kubernetes visualizations have to offer, read the 
 
 By following these directions, you will use Netdata's [Helm chart](https://github.com/netdata/helmchart/blob/master/charts/netdata/README.md) to create a Kubernetes monitoring deployment on your cluster.
 
-The Helm chart installs one `parent` pod for storing metrics and managing alarm notifications, plus an additional
+The [Netdata Helm chart](https://github.com/netdata/helmchart/blob/master/charts/netdata/README.md) installs one `parent` pod for storing metrics and managing alarm notifications, plus an additional
 `child` pod for every node in the cluster, responsible for collecting metrics from the node, Kubernetes control planes,
 pods/containers, and [supported application-specific
 metrics](https://github.com/netdata/helmchart#service-discovery-and-supported-services).

--- a/packaging/installer/methods/kubernetes.md
+++ b/packaging/installer/methods/kubernetes.md
@@ -15,7 +15,7 @@ import TabItem from '@theme/TabItem';
 
 This document details how to install Netdata on an existing Kubernetes (k8s) cluster, and connect it to Netdata Cloud.  
 
-To see what our Netdata Cloud Kubernetes visualizations have to offer, read the[Kubernetes visualizations Concept](https://github.com/netdata/netdata/blob/master/docs/cloud/visualize/kubernetes.md)
+To see what our Netdata Cloud Kubernetes visualizations have to offer, read the [Kubernetes visualizations Concept](https://github.com/netdata/netdata/blob/master/docs/cloud/visualize/kubernetes.md)
 
 By following these directions, you will use Netdata's [Helm chart](https://github.com/netdata/helmchart/blob/master/charts/netdata/README.md) to create a Kubernetes monitoring deployment on your cluster.
 

--- a/packaging/installer/methods/kubernetes.md
+++ b/packaging/installer/methods/kubernetes.md
@@ -11,9 +11,11 @@ learn_rel_path: "Installation"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This document details how to install Netdata on an existing Kubernetes (k8s) cluster. By following these directions, you
-will use Netdata's [Helm chart](https://github.com/netdata/helmchart) to create a Kubernetes monitoring deployment on
-your cluster.
+This document details how to install Netdata on an existing Kubernetes (k8s) cluster, and claim it to Netdata Cloud.  
+
+To see what our Netdata Cloud Kubernetes visualizations have to offer, read the[Kubernetes visualizations Concept](https://github.com/netdata/netdata/blob/master/docs/cloud/visualize/kubernetes.md)
+
+By following these directions, you will use Netdata's [Helm chart](https://github.com/netdata/helmchart/blob/master/charts/netdata/README.md) to create a Kubernetes monitoring deployment on your cluster.
 
 The Helm chart installs one `parent` pod for storing metrics and managing alarm notifications, plus an additional
 `child` pod for every node in the cluster, responsible for collecting metrics from the node, Kubernetes control planes,
@@ -33,9 +35,15 @@ To deploy Kubernetes monitoring with Netdata, you need:
 
 ## Deploy Netdata on your Kubernetes Cluster
 
+<<<<<<< HEAD
 To start [Kubernetes monitoring](https://github.com/netdata/netdata/blob/master/docs/cloud/visualize/kubernetes.md), you must first install Netdata, and then
 [connect](https://github.com/netdata/netdata/blob/master/claim/README.md) your Kubernetes cluster to [Netdata Cloud](https://app.netdata.cloud). The connection process securely
 connects your Kubernetes cluster to stream metrics data to Netdata Cloud, enabling Kubernetes-specific visualizations like the health map and time-series composite charts.
+=======
+First, you need to install Netdata, and then connect your Kubernetes cluster to [Netdata Cloud](https://app.netdata.cloud). The connection process securely
+connects your Kubernetes cluster to stream metrics data to Netdata Cloud, enabling Kubernetes-specific visualizations
+like the health map and time-series composite charts.
+>>>>>>> 7824ceadb (Suggestions from code review)
 
 <Tabs groupId="installation_type">
 <TabItem value="new_installations" label="New Installations">
@@ -52,25 +60,17 @@ connects your Kubernetes cluster to stream metrics data to Netdata Cloud, enabli
 
   ```bash
   helm install netdata netdata/netdata 
-  --set parent.claiming.enabled="true" 
-  --set parent.claiming.token=YOUR_CLAIM_TOKEN 
-  --set parent.claiming.rooms=YOUR_ROOM_ID_A,YOUR_ROOM_ID_B 
-  --set child.claiming.enabled=true 
-  --set child.claiming.token=YOUR_CLAIM_TOKEN 
-  --set child.claiming.rooms=YOUR_ROOM_ID_A,YOUR_ROOM_ID_B
   ```
 
   :::note
-  If you plan to also Claim the node to Netdata Cloud,
-  make sure to replace `YOUR_CLAIM_TOKEN` with the claim token of your space,
-  and `YOUR_ROOM_ID` with the ID of the room you are willing to claim to.
+  If you plan to Claim the node to Netdata Cloud, you can find the command with the right parameters by clicking the "Add Nodes" button in your Space's "Nodes" view.
   :::
+
+  For more installation options, please read our [Netdata Helm chart for Kubernetes](https://github.com/netdata/helmchart/blob/master/charts/netdata/README.md) reference.
 
 #### Expected Result
 
 Run `kubectl get services` and `kubectl get pods` to confirm that your cluster now runs a `netdata` service, one parent pod, and multiple child pods.
-
-You've now installed Netdata on your Kubernetes cluster and claimed it to your Netdata Space.
 
 </TabItem>
 <TabItem value="existing_installations" label="Existing Installations">

--- a/packaging/installer/methods/kubernetes.md
+++ b/packaging/installer/methods/kubernetes.md
@@ -33,9 +33,9 @@ To deploy Kubernetes monitoring with Netdata, you need:
 
 ## Deploy Netdata on your Kubernetes Cluster
 
-To start [Kubernetes monitoring](https://learn.netdata.cloud/docs/cloud/visualize/kubernetes/), you must first install Netdata, and then
-[connect](/claim/README.md) your Kubernetes cluster to [Netdata Cloud](https://app.netdata.cloud). The connection process securely connects your Kubernetes cluster to stream metrics data to Netdata Cloud, enabling Kubernetes-specific visualizations
-like the health map and time-series composite charts.
+To start [Kubernetes monitoring](https://github.com/netdata/netdata/blob/master/docs/cloud/visualize/kubernetes.md), you must first install Netdata, and then
+[connect](https://github.com/netdata/netdata/blob/master/claim/README.md) your Kubernetes cluster to [Netdata Cloud](https://app.netdata.cloud). The connection process securely
+connects your Kubernetes cluster to stream metrics data to Netdata Cloud, enabling Kubernetes-specific visualizations like the health map and time-series composite charts.
 
 <Tabs groupId="installation_type">
 <TabItem value="new_installations" label="New Installations">
@@ -144,8 +144,7 @@ in Netdata, in addition to more guides and resources.
 Read up on the various configuration options in the [Helm chart
 documentation](https://github.com/netdata/helmchart#configuration) if you need to tweak your Kubernetes monitoring.
 
-Your first option is to create an `override.yml` file, if you haven't created one already for
-[connect](#connect-your-kubernetes-cluster-to-netdata-cloud), then apply the new configuration to your cluster with `helm
+Your first option is to create an `override.yml` file, if you haven't created one already upon [deploying](#deploy-netdata-on-your-kubernetes-cluster), then apply the new configuration to your cluster with `helm
 upgrade`.
 
 ```bash
@@ -165,8 +164,7 @@ Netdata's [service discovery](https://github.com/netdata/agent-service-discovery
 of the Helm chart installation, finds what services are running in a cluster's containers and automatically collects
 service-level metrics from them.
 
-Service discovery supports [popular applications](https://github.com/netdata/helmchart#applications) and [Prometheus
-endpoints](https://github.com/netdata/helmchart#prometheus-endpoints).
+Service discovery supports [popular applications](https://github.com/netdata/helmchart#applications) and [Prometheus endpoints](https://github.com/netdata/helmchart#prometheus-endpoints).
 
 If your cluster runs services on non-default ports or uses non-default names, you may need to configure service
 discovery to start collecting metrics from your services. You have to edit the default ConfigMap that is shipped with
@@ -178,8 +176,7 @@ First, copy the default file to your administrative system.
 curl https://raw.githubusercontent.com/netdata/helmchart/master/charts/netdata/sdconfig/child.yml -o child.yml
 ```
 
-Edit the new `child.yml` file according to your needs. See the [Helm chart
-configuration](https://github.com/netdata/helmchart#configuration) and the file itself for details.
+Edit the new `child.yml` file according to your needs. See the [Helm chart configuration](https://github.com/netdata/helmchart#configuration) and the file itself for details.
 
 You can then run `helm upgrade` with the `--set-file` argument to use your configured `child.yml` file instead of the
 default, changing the path if you copied it elsewhere.
@@ -209,18 +206,10 @@ helm upgrade netdata netdata/netdata
 
 ## What's next?
 
-[Start Kubernetes monitoring](https://github.com/netdata/netdata/blob/master/docs/cloud/visualize/kubernetes.md) in Netdata Cloud, which
-comes with meaningful visualizations out of the box. 
-
-Read our guide, [_Kubernetes monitoring with Netdata: Overview and
-visualizations_](https://github.com/netdata/netdata/blob/master/docs/guides/monitor/kubernetes-k8s-netdata.md), for a complete walkthrough of Netdata's Kubernetes
-monitoring capabilities, including a health map of every container in your infrastructure, aggregated resource
-utilization metrics, and application metrics.
+[Start Kubernetes monitoring](https://github.com/netdata/netdata/blob/master/docs/cloud/visualize/kubernetes.md) in Netdata Cloud, which comes with meaningful visualizations out of the box.
 
 ### Related reference documentation
 
 - [Netdata Cloud · Kubernetes monitoring](https://github.com/netdata/netdata/blob/master/docs/cloud/visualize/kubernetes.md)
 - [Netdata Helm chart](https://github.com/netdata/helmchart)
 - [Netdata service discovery](https://github.com/netdata/agent-service-discovery/)
-
-

--- a/packaging/installer/methods/kubernetes.md
+++ b/packaging/installer/methods/kubernetes.md
@@ -13,11 +13,7 @@ import TabItem from '@theme/TabItem';
 
 # Deploy Kubernetes monitoring with Netdata
 
-This document details how to install Netdata on an existing Kubernetes (k8s) cluster, and connect it to Netdata Cloud.  
-
-To see what our Netdata Cloud Kubernetes visualizations have to offer, read the [Kubernetes visualizations Concept](https://github.com/netdata/netdata/blob/master/docs/cloud/visualize/kubernetes.md)
-
-By following these directions, you will use Netdata's [Helm chart](https://github.com/netdata/helmchart/blob/master/charts/netdata/README.md) to create a Kubernetes monitoring deployment on your cluster.
+This document details how to install Netdata on an existing Kubernetes (k8s) cluster, and connect it to Netdata Cloud. Read our [Kubernetes visualizations](https://github.com/netdata/netdata/blob/master/docs/cloud/visualize/kubernetes.md) documentation, to see what you will get.
 
 The [Netdata Helm chart](https://github.com/netdata/helmchart/blob/master/charts/netdata/README.md) installs one `parent` pod for storing metrics and managing alarm notifications, plus an additional
 `child` pod for every node in the cluster, responsible for collecting metrics from the node, Kubernetes control planes,
@@ -37,9 +33,8 @@ To deploy Kubernetes monitoring with Netdata, you need:
 
 ## Deploy Netdata on your Kubernetes Cluster
 
-First, you need to install Netdata, and then connect your Kubernetes cluster to [Netdata Cloud](https://app.netdata.cloud). 
-The connection process securely connects your Kubernetes cluster to stream metrics data to Netdata Cloud, enabling Kubernetes-specific visualizations
-like the health map and time-series composite charts.
+First, you need to add the Netdata helm repository, and then install Netdata.  
+The installation process securely connects your Kubernetes cluster to stream metrics data to Netdata Cloud, enabling Kubernetes-specific visualizations like the health map and time-series composite charts.
 
 <Tabs groupId="installation_type">
 <TabItem value="new_installations" label="New Installations">
@@ -61,7 +56,7 @@ like the health map and time-series composite charts.
   ```
 
   > :bookmark_tabs: Note
-  > 
+  >  
   > If you plan to Connect the node to Netdata Cloud, you can find the command with the right parameters by clicking the "Add Nodes" button in your Space's "Nodes" view.
 
   For more installation options, please read our [Netdata Helm chart for Kubernetes](https://github.com/netdata/helmchart/blob/master/charts/netdata/README.md) reference.
@@ -110,14 +105,14 @@ On an existing installation, in order to Connect it to Netdata Cloud you will ne
   ```
 
   > :bookmark_tabs: Note
-  > 
+  >  
   > Make sure to replace `YOUR_CLAIM_TOKEN` with the claim token of your space,
   > and `YOUR_ROOM_ID` with the ID of the room you are willing to connect to.
 
   These settings connect your `parent`/`child` nodes to Netdata Cloud and store more metrics in the nodes' time-series databases.
 
   > :bookmark_tabs: Info
-  > 
+  >  
   > These override settings, along with the Helm chart's defaults, will retain an hour's worth of metrics (`history = 3600`, or `3600 seconds`) on each child node. Based on your metrics retention needs, and the resources available on your cluster, you may want to increase the `history` setting.
 
 3. To apply these new settings, run:

--- a/packaging/installer/methods/kubernetes.md
+++ b/packaging/installer/methods/kubernetes.md
@@ -11,6 +11,8 @@ learn_rel_path: "Installation"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+# Deploy Kubernetes monitoring with Netdata
+
 This document details how to install Netdata on an existing Kubernetes (k8s) cluster, and connect it to Netdata Cloud.  
 
 To see what our Netdata Cloud Kubernetes visualizations have to offer, read the[Kubernetes visualizations Concept](https://github.com/netdata/netdata/blob/master/docs/cloud/visualize/kubernetes.md)
@@ -36,17 +38,24 @@ To deploy Kubernetes monitoring with Netdata, you need:
 ## Deploy Netdata on your Kubernetes Cluster
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 To start [Kubernetes monitoring](https://github.com/netdata/netdata/blob/master/docs/cloud/visualize/kubernetes.md), you must first install Netdata, and then
 [connect](https://github.com/netdata/netdata/blob/master/claim/README.md) your Kubernetes cluster to [Netdata Cloud](https://app.netdata.cloud). The connection process securely
 connects your Kubernetes cluster to stream metrics data to Netdata Cloud, enabling Kubernetes-specific visualizations like the health map and time-series composite charts.
 =======
 First, you need to install Netdata, and then connect your Kubernetes cluster to [Netdata Cloud](https://app.netdata.cloud). The connection process securely
 connects your Kubernetes cluster to stream metrics data to Netdata Cloud, enabling Kubernetes-specific visualizations
+=======
+First, you need to install Netdata, and then connect your Kubernetes cluster to [Netdata Cloud](https://app.netdata.cloud). 
+The connection process securely connects your Kubernetes cluster to stream metrics data to Netdata Cloud, enabling Kubernetes-specific visualizations
+>>>>>>> 634c765d1 (Make the file GitHub friendly)
 like the health map and time-series composite charts.
 >>>>>>> 7824ceadb (Suggestions from code review)
 
 <Tabs groupId="installation_type">
 <TabItem value="new_installations" label="New Installations">
+
+<h3> Install Netdata via the <code>helm install</code> command </h3>
 
 #### Steps
 
@@ -62,9 +71,9 @@ like the health map and time-series composite charts.
   helm install netdata netdata/netdata 
   ```
 
-  :::note
-  If you plan to Connect the node to Netdata Cloud, you can find the command with the right parameters by clicking the "Add Nodes" button in your Space's "Nodes" view.
-  :::
+  > :bookmark_tabs: Note
+  > 
+  > If you plan to Connect the node to Netdata Cloud, you can find the command with the right parameters by clicking the "Add Nodes" button in your Space's "Nodes" view.
 
   For more installation options, please read our [Netdata Helm chart for Kubernetes](https://github.com/netdata/helmchart/blob/master/charts/netdata/README.md) reference.
 
@@ -74,6 +83,8 @@ Run `kubectl get services` and `kubectl get pods` to confirm that your cluster n
 
 </TabItem>
 <TabItem value="existing_installations" label="Existing Installations">
+
+<h3> Connect an existing Netdata installation to Netdata Cloud </h3>
 
 On an existing installation, in order to Connect it to Netdata Cloud you will need to override the configuration values by running the `helm upgrade` command and provide a file with the values to override.
 
@@ -109,16 +120,16 @@ On an existing installation, in order to Connect it to Netdata Cloud you will ne
             enabled = no
   ```
 
-   These settings connect your `parent`/`child` nodes to Netdata Cloud and store more metrics in the nodes' time-series databases.
+  > :bookmark_tabs: Note
+  > 
+  > Make sure to replace `YOUR_CLAIM_TOKEN` with the claim token of your space,
+  > and `YOUR_ROOM_ID` with the ID of the room you are willing to connect to.
 
-  :::note
-  Make sure to replace `YOUR_CLAIM_TOKEN` with the claim token of your space,
-  and `YOUR_ROOM_ID` with the ID of the room you are willing to connect to.
-  :::
+  These settings connect your `parent`/`child` nodes to Netdata Cloud and store more metrics in the nodes' time-series databases.
 
-  :::info
-  These override settings, along with the Helm chart's defaults, will retain an hour's worth of metrics (`history = 3600`, or `3600 seconds`) on each child node. Based on your metrics retention needs, and the resources available on your cluster, you may want to increase the `history` setting.
-  :::
+  > :bookmark_tabs: Info
+  > 
+  > These override settings, along with the Helm chart's defaults, will retain an hour's worth of metrics (`history = 3600`, or `3600 seconds`) on each child node. Based on your metrics retention needs, and the resources available on your cluster, you may want to increase the `history` setting.
 
 3. To apply these new settings, run:
 

--- a/packaging/installer/methods/kubernetes.md
+++ b/packaging/installer/methods/kubernetes.md
@@ -11,7 +11,7 @@ learn_rel_path: "Installation"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This document details how to install Netdata on an existing Kubernetes (k8s) cluster, and claim it to Netdata Cloud.  
+This document details how to install Netdata on an existing Kubernetes (k8s) cluster, and connect it to Netdata Cloud.  
 
 To see what our Netdata Cloud Kubernetes visualizations have to offer, read the[Kubernetes visualizations Concept](https://github.com/netdata/netdata/blob/master/docs/cloud/visualize/kubernetes.md)
 
@@ -31,7 +31,7 @@ To deploy Kubernetes monitoring with Netdata, you need:
     difference](https://kubernetes.io/docs/tasks/tools/install-kubectl/#before-you-begin) of your cluster, on an
     administrative system.
 - The [Helm package manager](https://helm.sh/) v3.0.0 or newer on the same administrative system.
-- A Netdata Cloud account with a Space to claim the cluster to.
+- A Netdata Cloud account with a Space to connect the cluster to.
 
 ## Deploy Netdata on your Kubernetes Cluster
 
@@ -63,7 +63,7 @@ like the health map and time-series composite charts.
   ```
 
   :::note
-  If you plan to Claim the node to Netdata Cloud, you can find the command with the right parameters by clicking the "Add Nodes" button in your Space's "Nodes" view.
+  If you plan to Connect the node to Netdata Cloud, you can find the command with the right parameters by clicking the "Add Nodes" button in your Space's "Nodes" view.
   :::
 
   For more installation options, please read our [Netdata Helm chart for Kubernetes](https://github.com/netdata/helmchart/blob/master/charts/netdata/README.md) reference.
@@ -75,7 +75,7 @@ Run `kubectl get services` and `kubectl get pods` to confirm that your cluster n
 </TabItem>
 <TabItem value="existing_installations" label="Existing Installations">
 
-On an existing installation, in order to Claim it to Netdata Cloud you will need to override the configuration values by running the `helm upgrade` command and provide a file with the values to override.
+On an existing installation, in order to Connect it to Netdata Cloud you will need to override the configuration values by running the `helm upgrade` command and provide a file with the values to override.
 
 #### Steps
 
@@ -113,7 +113,7 @@ On an existing installation, in order to Claim it to Netdata Cloud you will need
 
   :::note
   Make sure to replace `YOUR_CLAIM_TOKEN` with the claim token of your space,
-  and `YOUR_ROOM_ID` with the ID of the room you are willing to claim to.
+  and `YOUR_ROOM_ID` with the ID of the room you are willing to connect to.
   :::
 
   :::info

--- a/packaging/installer/methods/kubernetes.md
+++ b/packaging/installer/methods/kubernetes.md
@@ -57,7 +57,7 @@ The installation process securely connects your Kubernetes cluster to stream met
 
   > :bookmark_tabs: Note
   >  
-  > If you plan to Connect the node to Netdata Cloud, you can find the command with the right parameters by clicking the "Add Nodes" button in your Space's "Nodes" view.
+  > If you plan to connect the node to Netdata Cloud, you can find the command with the right parameters by clicking the "Add Nodes" button in your Space's "Nodes" view.
 
   For more installation options, please read our [Netdata Helm chart for Kubernetes](https://github.com/netdata/helmchart/blob/master/charts/netdata/README.md) reference.
 
@@ -70,7 +70,7 @@ Run `kubectl get services` and `kubectl get pods` to confirm that your cluster n
 
 <h3> Connect an existing Netdata installation to Netdata Cloud </h3>
 
-On an existing installation, in order to Connect it to Netdata Cloud you will need to override the configuration values by running the `helm upgrade` command and provide a file with the values to override.
+On an existing installation, in order to connect it to Netdata Cloud you will need to override the configuration values by running the `helm upgrade` command and provide a file with the values to override.
 
 #### Steps
 

--- a/packaging/installer/methods/kubernetes.md
+++ b/packaging/installer/methods/kubernetes.md
@@ -37,20 +37,9 @@ To deploy Kubernetes monitoring with Netdata, you need:
 
 ## Deploy Netdata on your Kubernetes Cluster
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-To start [Kubernetes monitoring](https://github.com/netdata/netdata/blob/master/docs/cloud/visualize/kubernetes.md), you must first install Netdata, and then
-[connect](https://github.com/netdata/netdata/blob/master/claim/README.md) your Kubernetes cluster to [Netdata Cloud](https://app.netdata.cloud). The connection process securely
-connects your Kubernetes cluster to stream metrics data to Netdata Cloud, enabling Kubernetes-specific visualizations like the health map and time-series composite charts.
-=======
-First, you need to install Netdata, and then connect your Kubernetes cluster to [Netdata Cloud](https://app.netdata.cloud). The connection process securely
-connects your Kubernetes cluster to stream metrics data to Netdata Cloud, enabling Kubernetes-specific visualizations
-=======
 First, you need to install Netdata, and then connect your Kubernetes cluster to [Netdata Cloud](https://app.netdata.cloud). 
 The connection process securely connects your Kubernetes cluster to stream metrics data to Netdata Cloud, enabling Kubernetes-specific visualizations
->>>>>>> 634c765d1 (Make the file GitHub friendly)
 like the health map and time-series composite charts.
->>>>>>> 7824ceadb (Suggestions from code review)
 
 <Tabs groupId="installation_type">
 <TabItem value="new_installations" label="New Installations">


### PR DESCRIPTION
##### Summary

This PR is related with netdata/documentation#22, it includes:

- [X] Applied the Task template, (Prerequisites, Numbered Steps, Expected Results)
- [X] Grouped the two cases, "New Installations" and "Existing Installations" in a Tab element, and renamed the section to "Deploy Netdata on your Kubernetes Cluster". I judged that the "Install the Netdata Helm chart" section could be renamed to just "Add the Netdata Helm repository" as a step for new installations, and then proceed to install as normal
- [X] Added the Cloud options to the scripts, along with the proper messages in the two cases
- [X] Fixed all the links in the file to be absolute GitHub links