### PR TITLE
Add missing entries in README.md

### DIFF
--- a/collectors/plugins.d/README.md
+++ b/collectors/plugins.d/README.md
@@ -19,8 +19,8 @@ from external processes, thus allowing Netdata to use **external plugins**.
 |[apps.plugin](/collectors/apps.plugin/README.md)|`C`|linux, freebsd|monitors the whole process tree on Linux and FreeBSD and breaks down system resource usage by **process**, **user** and **user group**.|
 |[charts.d.plugin](/collectors/charts.d.plugin/README.md)|`BASH`|all|a **plugin orchestrator** for data collection modules written in `BASH` v4+.|
 |[cups.plugin](/collectors/cups.plugin/README.md)|`C`|all|monitors **CUPS**|
-|[ebpf.plugin](/collectors/ebpf.plugin/README.md)|`C`|linux|monitors different metrics on environments using kernel internal functions.|
-|[go.d.plugin](https://github.com/netdata/go.d.plugin/)|`C`|all|monitors different services running on host.|
+|[ebpf.plugin](https:/.github.com/netdata/netdata/blob/master/collectors/ebpf.plugin/README.md)|`C`|linux|monitors different metrics on environments using kernel internal functions.|
+|[go.d.plugin](https://github.com/netdata/go.d.plugin/)|`GO`|all|collects metrics from the system, applications, or third-party APIs.|
 |[ioping.plugin](/collectors/ioping.plugin/README.md)|`C`|all|measures disk latency.|
 |[freeipmi.plugin](/collectors/freeipmi.plugin/README.md)|`C`|linux|collects metrics from enterprise hardware sensors, on Linux servers.|
 |[nfacct.plugin](/collectors/nfacct.plugin/README.md)|`C`|linux|collects netfilter firewall, connection tracker and accounting metrics using `libmnl` and `libnetfilter_acct`.|

--- a/collectors/plugins.d/README.md
+++ b/collectors/plugins.d/README.md
@@ -20,6 +20,7 @@ from external processes, thus allowing Netdata to use **external plugins**.
 |[charts.d.plugin](/collectors/charts.d.plugin/README.md)|`BASH`|all|a **plugin orchestrator** for data collection modules written in `BASH` v4+.|
 |[cups.plugin](/collectors/cups.plugin/README.md)|`C`|all|monitors **CUPS**|
 |[ebpf.plugin](/collectors/ebpf.plugin/README.md)|`C`|linux|monitors different metrics on environments using kernel internal functions.|
+|[go.d.plugin](https://github.com/netdata/go.d.plugin/)|`C`|all|monitors different services running on host.|
 |[ioping.plugin](/collectors/ioping.plugin/README.md)|`C`|all|measures disk latency.|
 |[freeipmi.plugin](/collectors/freeipmi.plugin/README.md)|`C`|linux|collects metrics from enterprise hardware sensors, on Linux servers.|
 |[nfacct.plugin](/collectors/nfacct.plugin/README.md)|`C`|linux|collects netfilter firewall, connection tracker and accounting metrics using `libmnl` and `libnetfilter_acct`.|

--- a/collectors/plugins.d/README.md
+++ b/collectors/plugins.d/README.md
@@ -19,6 +19,7 @@ from external processes, thus allowing Netdata to use **external plugins**.
 |[apps.plugin](/collectors/apps.plugin/README.md)|`C`|linux, freebsd|monitors the whole process tree on Linux and FreeBSD and breaks down system resource usage by **process**, **user** and **user group**.|
 |[charts.d.plugin](/collectors/charts.d.plugin/README.md)|`BASH`|all|a **plugin orchestrator** for data collection modules written in `BASH` v4+.|
 |[cups.plugin](/collectors/cups.plugin/README.md)|`C`|all|monitors **CUPS**|
+|[ebpf.plugin](/collectors/ebpf.plugin/README.md)|`C`|linux|monitors different metrics on environments using kernel internal functions.|
 |[ioping.plugin](/collectors/ioping.plugin/README.md)|`C`|all|measures disk latency.|
 |[freeipmi.plugin](/collectors/freeipmi.plugin/README.md)|`C`|linux|collects metrics from enterprise hardware sensors, on Linux servers.|
 |[nfacct.plugin](/collectors/nfacct.plugin/README.md)|`C`|linux|collects netfilter firewall, connection tracker and accounting metrics using `libmnl` and `libnetfilter_acct`.|

--- a/collectors/plugins.d/README.md
+++ b/collectors/plugins.d/README.md
@@ -20,7 +20,7 @@ from external processes, thus allowing Netdata to use **external plugins**.
 |[charts.d.plugin](/collectors/charts.d.plugin/README.md)|`BASH`|all|a **plugin orchestrator** for data collection modules written in `BASH` v4+.|
 |[cups.plugin](/collectors/cups.plugin/README.md)|`C`|all|monitors **CUPS**|
 |[ebpf.plugin](https:/.github.com/netdata/netdata/blob/master/collectors/ebpf.plugin/README.md)|`C`|linux|monitors different metrics on environments using kernel internal functions.|
-|[go.d.plugin](https://github.com/netdata/go.d.plugin/)|`GO`|all|collects metrics from the system, applications, or third-party APIs.|
+|[go.d.plugin](https://github.com/netdata/go.d.plugin/blob/master/README.md)|`GO`|all|collects metrics from the system, applications, or third-party APIs.|
 |[ioping.plugin](/collectors/ioping.plugin/README.md)|`C`|all|measures disk latency.|
 |[freeipmi.plugin](/collectors/freeipmi.plugin/README.md)|`C`|linux|collects metrics from enterprise hardware sensors, on Linux servers.|
 |[nfacct.plugin](/collectors/nfacct.plugin/README.md)|`C`|linux|collects netfilter firewall, connection tracker and accounting metrics using `libmnl` and `libnetfilter_acct`.|


### PR DESCRIPTION
##### Summary
Fixes netdata/learn#1298

Our plugins.d documentation does not have entries for `ebpf.plugin` and `go.d.plugin`, this PR is fixing this.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
