### PR TITLE
Add collectors list to learn temporarily

### DIFF
--- a/collectors/COLLECTORS.md
+++ b/collectors/COLLECTORS.md
@@ -3,6 +3,9 @@ title: "Supported collectors list"
 description: "Netdata gathers real-time metrics from hundreds of data sources using collectors. Most require zero configuration and are pre-configured out of the box."
 custom_edit_url: "https://github.com/netdata/netdata/edit/master/collectors/COLLECTORS.md"
 sidebar_label: "Supported collectors list"
+learn_status: "Published"
+learn_topic_type: "Tasks"
+learn_rel_path: "References/Collectors"
 -->
 
 # Supported collectors list


### PR DESCRIPTION
This will be changed when the new integrations page is launched.  Also, it needs to be the main page when expanding the contents, not just another page in there (@tkatsoulas will do that)
