### PR TITLE
Reduce service exit

### DIFF
--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -487,6 +487,12 @@ static void ebpf_exit()
     error("Good bye world! I was PID %d", main_thread_id);
 #endif
     printf("DISABLE\n");
+
+    if (!shm_ebpf_cgroup.header) {
+        munmap(shm_ebpf_cgroup.header, shm_ebpf_cgroup.header->body_length);
+        shm_unlink(NETDATA_SHARED_MEMORY_EBPF_CGROUP_NAME);
+    }
+
     exit(0);
 }
 

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -483,7 +483,10 @@ static void ebpf_exit()
     if (unlink(filename))
         error("Cannot remove PID file %s", filename);
 
-    ebpf_exit_plugin = 2;
+#ifdef NETDATA_INTERNAL_CHECKS
+    error("Good bye world! I was PID %d", main_thread_id);
+#endif
+    exit(0);
 }
 
 /**
@@ -2253,10 +2256,8 @@ int main(int argc, char **argv)
     heartbeat_t hb;
     heartbeat_init(&hb);
     //Plugin will be killed when it receives a signal
-    while (ebpf_exit_plugin != 2) {
+    while (!ebpf_exit_plugin) {
         (void)heartbeat_next(&hb, step);
-        if (ebpf_exit_plugin == 2)
-            break;
 
         // We are using a small heartbeat time to wake up thread,
         // but we should not update so frequently the shared memory data
@@ -2268,6 +2269,8 @@ int main(int argc, char **argv)
             ebpf_parse_cgroup_shm_data();
         }
     }
+
+    ebpf_stop_threads(0);
 
     return 0;
 }

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -486,6 +486,7 @@ static void ebpf_exit()
 #ifdef NETDATA_INTERNAL_CHECKS
     error("Good bye world! I was PID %d", main_thread_id);
 #endif
+    printf("DISABLE\n");
     exit(0);
 }
 

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -488,9 +488,9 @@ static void ebpf_exit()
 #endif
     printf("DISABLE\n");
 
-    if (!shm_ebpf_cgroup.header) {
-        shm_unlink(NETDATA_SHARED_MEMORY_EBPF_CGROUP_NAME);
+    if (shm_ebpf_cgroup.header) {
         munmap(shm_ebpf_cgroup.header, shm_ebpf_cgroup.header->body_length);
+        shm_unlink(NETDATA_SHARED_MEMORY_EBPF_CGROUP_NAME);
     }
 
     exit(0);

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -489,8 +489,8 @@ static void ebpf_exit()
     printf("DISABLE\n");
 
     if (!shm_ebpf_cgroup.header) {
-        munmap(shm_ebpf_cgroup.header, shm_ebpf_cgroup.header->body_length);
         shm_unlink(NETDATA_SHARED_MEMORY_EBPF_CGROUP_NAME);
+        munmap(shm_ebpf_cgroup.header, shm_ebpf_cgroup.header->body_length);
     }
 
     exit(0);

--- a/collectors/ebpf.plugin/ebpf.d.conf
+++ b/collectors/ebpf.plugin/ebpf.d.conf
@@ -50,7 +50,7 @@
 # When plugin detects that system has support to BTF, it enables integration with apps.plugin.
 #
 [ebpf programs]
-    cachestat = no
+    cachestat = yes
     dcstat = no
     disk = no
     fd = yes
@@ -60,10 +60,10 @@
     mount = yes
     oomkill = yes
     process = yes
-    shm = no
-    socket = yes
+    shm = yes
+    socket = no
     softirq = yes
     sync = yes
-    swap = no
-    vfs = yes
+    swap = yes
+    vfs = no
     network connections = no

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -1067,13 +1067,15 @@ static void cachestat_collector(ebpf_module_t *em)
     int update_every = em->update_every;
     heartbeat_t hb;
     heartbeat_init(&hb);
-    usec_t step = update_every * USEC_PER_SEC;
+    int counter = update_every - 1;
     //This will be cancelled by its parent
     while (!ebpf_exit_plugin) {
-        (void)heartbeat_next(&hb, step);
-        if (ebpf_exit_plugin)
-            break;
+        (void)heartbeat_next(&hb, USEC_PER_SEC);
 
+        if (ebpf_exit_plugin || ++counter != update_every)
+            continue;
+
+        counter = 0;
         netdata_apps_integration_flags_t apps = em->apps_charts;
         ebpf_cachestat_read_global_table();
         pthread_mutex_lock(&collect_data_mutex);

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -985,12 +985,14 @@ static void dcstat_collector(ebpf_module_t *em)
     int update_every = em->update_every;
     heartbeat_t hb;
     heartbeat_init(&hb);
-    usec_t step = update_every * USEC_PER_SEC;
+    int counter = update_every - 1;
     while (!ebpf_exit_plugin) {
-        (void)heartbeat_next(&hb, step);
-        if (ebpf_exit_plugin)
-            break;
+        (void)heartbeat_next(&hb, USEC_PER_SEC);
 
+        if (ebpf_exit_plugin || ++counter != update_every)
+            continue;
+
+        counter = 0;
         netdata_apps_integration_flags_t apps = em->apps_charts;
         ebpf_dc_read_global_table();
         pthread_mutex_lock(&collect_data_mutex);

--- a/collectors/ebpf.plugin/ebpf_disk.c
+++ b/collectors/ebpf.plugin/ebpf_disk.c
@@ -689,12 +689,14 @@ static void disk_collector(ebpf_module_t *em)
     int update_every = em->update_every;
     heartbeat_t hb;
     heartbeat_init(&hb);
-    usec_t step = update_every * USEC_PER_SEC;
+    int counter = update_every - 1;
     while (!ebpf_exit_plugin) {
-        (void)heartbeat_next(&hb, step);
-        if (ebpf_exit_plugin)
-            break;
+        (void)heartbeat_next(&hb, USEC_PER_SEC);
 
+        if (ebpf_exit_plugin || ++counter != update_every)
+            continue;
+
+        counter = 0;
         read_hard_disk_tables(disk_maps[NETDATA_DISK_READ].map_fd);
         pthread_mutex_lock(&lock);
         ebpf_remove_pointer_from_plot_disk(em);

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -924,12 +924,15 @@ static void fd_collector(ebpf_module_t *em)
     int cgroups = em->cgroup_charts;
     heartbeat_t hb;
     heartbeat_init(&hb);
-    usec_t step = em->update_every * USEC_PER_SEC;
+    int update_every = em->update_every;
+    int counter = update_every - 1;
     while (!ebpf_exit_plugin) {
-        (void)heartbeat_next(&hb, step);
-        if (ebpf_exit_plugin)
-            break;
+        (void)heartbeat_next(&hb, USEC_PER_SEC);
 
+        if (ebpf_exit_plugin || ++counter != update_every)
+            continue;
+
+        counter = 0;
         netdata_apps_integration_flags_t apps = em->apps_charts;
         ebpf_fd_read_global_table();
         pthread_mutex_lock(&collect_data_mutex);

--- a/collectors/ebpf.plugin/ebpf_filesystem.c
+++ b/collectors/ebpf.plugin/ebpf_filesystem.c
@@ -502,12 +502,14 @@ static void filesystem_collector(ebpf_module_t *em)
     int update_every = em->update_every;
     heartbeat_t hb;
     heartbeat_init(&hb);
-    usec_t step = update_every * USEC_PER_SEC;
+    int counter = update_every - 1;
     while (!ebpf_exit_plugin) {
-        (void)heartbeat_next(&hb, step);
-        if (ebpf_exit_plugin)
-            break;
+        (void)heartbeat_next(&hb, USEC_PER_SEC);
 
+        if (ebpf_exit_plugin || ++counter != update_every)
+            continue;
+
+        counter = 0;
         ebpf_filesystem_read_hash(em);
         pthread_mutex_lock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -396,13 +396,16 @@ static void hardirq_collector(ebpf_module_t *em)
     // loop and read from published data until ebpf plugin is closed.
     heartbeat_t hb;
     heartbeat_init(&hb);
-    usec_t step = em->update_every * USEC_PER_SEC;
+    int update_every = em->update_every;
+    int counter = update_every - 1;
     //This will be cancelled by its parent
     while (!ebpf_exit_plugin) {
-        (void)heartbeat_next(&hb, step);
-        if (ebpf_exit_plugin)
-            break;
+        (void)heartbeat_next(&hb, USEC_PER_SEC);
 
+        if (ebpf_exit_plugin || ++counter != update_every)
+            continue;
+
+        counter = 0;
         hardirq_reader();
         pthread_mutex_lock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_mount.c
+++ b/collectors/ebpf.plugin/ebpf_mount.c
@@ -316,12 +316,14 @@ static void mount_collector(ebpf_module_t *em)
 
     heartbeat_t hb;
     heartbeat_init(&hb);
-    usec_t step = em->update_every * USEC_PER_SEC;
+    int update_every = em->update_every;
+    int counter = update_every - 1;
     while (!ebpf_exit_plugin) {
-        (void)heartbeat_next(&hb, step);
-        if (ebpf_exit_plugin)
-            break;
+        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        if (ebpf_exit_plugin || ++counter != update_every)
+            continue;
 
+        counter = 0;
         ebpf_mount_read_global_table();
         pthread_mutex_lock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -296,12 +296,13 @@ static void oomkill_collector(ebpf_module_t *em)
     // loop and read until ebpf plugin is closed.
     heartbeat_t hb;
     heartbeat_init(&hb);
-    usec_t step = update_every * USEC_PER_SEC;
+    int counter = update_every - 1;
     while (!ebpf_exit_plugin) {
-        (void)heartbeat_next(&hb, step);
-        if (ebpf_exit_plugin)
-            break;
+        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        if (!ebpf_exit_plugin || ++counter != update_every)
+            continue;
 
+        counter = 0;
         pthread_mutex_lock(&collect_data_mutex);
         pthread_mutex_lock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -847,12 +847,13 @@ static void shm_collector(ebpf_module_t *em)
     int update_every = em->update_every;
     heartbeat_t hb;
     heartbeat_init(&hb);
-    usec_t step = update_every * USEC_PER_SEC;
+    int counter = update_every - 1;
     while (!ebpf_exit_plugin) {
-        (void)heartbeat_next(&hb, step);
-        if (ebpf_exit_plugin)
-            break;
+        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        if (ebpf_exit_plugin || ++counter != update_every)
+            continue;
 
+        counter = 0;
         netdata_apps_integration_flags_t apps = em->apps_charts;
         ebpf_shm_read_global_table();
         pthread_mutex_lock(&collect_data_mutex);

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -2882,12 +2882,12 @@ static void socket_collector(ebpf_module_t *em)
 
         counter = 0;
         netdata_apps_integration_flags_t socket_apps_enabled = em->apps_charts;
-        pthread_mutex_lock(&collect_data_mutex);
         if (socket_global_enabled) {
             read_listen_table();
             read_hash_global_tables();
         }
 
+        pthread_mutex_lock(&collect_data_mutex);
         if (socket_apps_enabled)
             ebpf_socket_update_apps_data();
 

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -2151,17 +2151,15 @@ static void read_listen_table()
 void *ebpf_socket_read_hash(void *ptr)
 {
     netdata_thread_cleanup_push(ebpf_socket_cleanup, ptr);
-    ebpf_module_t *em = (ebpf_module_t *)ptr;
 
     heartbeat_t hb;
     heartbeat_init(&hb);
-    usec_t step = NETDATA_SOCKET_READ_SLEEP_MS * em->update_every;
     int fd_ipv4 = socket_maps[NETDATA_SOCKET_TABLE_IPV4].map_fd;
     int fd_ipv6 = socket_maps[NETDATA_SOCKET_TABLE_IPV6].map_fd;
     while (!ebpf_exit_plugin) {
-        (void)heartbeat_next(&hb, step);
+        (void)heartbeat_next(&hb, USEC_PER_SEC);
         if (ebpf_exit_plugin)
-            break;
+           continue;
 
         pthread_mutex_lock(&nv_mutex);
         ebpf_read_socket_hash_table(fd_ipv4, AF_INET);
@@ -2854,10 +2852,9 @@ static void ebpf_socket_send_cgroup_data(int update_every)
 /**
  * Main loop for this collector.
  *
- * @param step the number of microseconds used with heart beat
  * @param em   the structure with thread information
  */
-static void socket_collector(usec_t step, ebpf_module_t *em)
+static void socket_collector(ebpf_module_t *em)
 {
     heartbeat_t hb;
     heartbeat_init(&hb);
@@ -2877,11 +2874,13 @@ static void socket_collector(usec_t step, ebpf_module_t *em)
 
     int socket_global_enabled = em->global_charts;
     int update_every = em->update_every;
+    int counter = update_every - 1;
     while (!ebpf_exit_plugin) {
-        (void)heartbeat_next(&hb, step);
-        if (ebpf_exit_plugin)
-            break;
+        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        if (ebpf_exit_plugin || ++counter != update_every)
+            continue;
 
+        counter = 0;
         netdata_apps_integration_flags_t socket_apps_enabled = em->apps_charts;
         pthread_mutex_lock(&collect_data_mutex);
         if (socket_global_enabled) {
@@ -3968,7 +3967,7 @@ void *ebpf_socket_thread(void *ptr)
 
     pthread_mutex_unlock(&lock);
 
-    socket_collector((usec_t)(em->update_every * USEC_PER_SEC), em);
+    socket_collector(em);
 
 endsocket:
     ebpf_update_disabled_plugin_stats(em);

--- a/collectors/ebpf.plugin/ebpf_softirq.c
+++ b/collectors/ebpf.plugin/ebpf_softirq.c
@@ -169,13 +169,15 @@ static void softirq_collector(ebpf_module_t *em)
     // loop and read from published data until ebpf plugin is closed.
     heartbeat_t hb;
     heartbeat_init(&hb);
-    usec_t step = em->update_every * USEC_PER_SEC;
+    int update_every = em->update_every;
+    int counter = update_every - 1;
     //This will be cancelled by its parent
     while (!ebpf_exit_plugin) {
-        (void)heartbeat_next(&hb, step);
-        if (ebpf_exit_plugin)
-            break;
+        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        if (ebpf_exit_plugin || ++counter != update_every)
+            continue;
 
+        counter = 0;
         softirq_read_latency_map();
         pthread_mutex_lock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -661,12 +661,13 @@ static void swap_collector(ebpf_module_t *em)
     int update_every = em->update_every;
     heartbeat_t hb;
     heartbeat_init(&hb);
-    usec_t step = update_every * USEC_PER_SEC;
+    int counter = update_every - 1;
     while (!ebpf_exit_plugin) {
-        (void)heartbeat_next(&hb, step);
-        if (ebpf_exit_plugin)
-            break;
+        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        if (ebpf_exit_plugin || ++counter != update_every)
+            continue;
 
+        counter = 0;
         netdata_apps_integration_flags_t apps = em->apps_charts;
         ebpf_swap_read_global_table();
         pthread_mutex_lock(&collect_data_mutex);

--- a/collectors/ebpf.plugin/ebpf_sync.c
+++ b/collectors/ebpf.plugin/ebpf_sync.c
@@ -398,12 +398,14 @@ static void sync_collector(ebpf_module_t *em)
 {
     heartbeat_t hb;
     heartbeat_init(&hb);
-    usec_t step = em->update_every * USEC_PER_SEC;
+    int update_every = em->update_every;
+    int counter = update_every - 1;
     while (!ebpf_exit_plugin) {
-        (void)heartbeat_next(&hb, step);
-        if (ebpf_exit_plugin)
-            break;
+        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        if (ebpf_exit_plugin || ++counter != update_every)
+            continue;
 
+        counter = 0;
         ebpf_sync_read_global_table();
         pthread_mutex_lock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -1470,12 +1470,14 @@ static void vfs_collector(ebpf_module_t *em)
     int cgroups = em->cgroup_charts;
     heartbeat_t hb;
     heartbeat_init(&hb);
-    usec_t step = em->update_every * USEC_PER_SEC;
+    int update_every = em->update_every;
+    int counter = update_every - 1;
     while (!ebpf_exit_plugin) {
-        (void)heartbeat_next(&hb, step);
-        if (ebpf_exit_plugin)
-            break;
+        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        if (ebpf_exit_plugin || ++counter != update_every)
+            continue;
 
+        counter = 0;
         netdata_apps_integration_flags_t apps = em->apps_charts;
         ebpf_vfs_read_global_table();
         pthread_mutex_lock(&collect_data_mutex);


### PR DESCRIPTION
##### Summary
This PR reduces the following events :

```sh
8)
MAIN : SERVICE CONTROL: the following 1 service(s) [ COLLECTORS ] take too long to exit: 'PD[ebpf]' (97538); giving up on them...
```

on user hosts. With these changes eBPF will close faster, because new default options won't be expensive to host and it is checking more frequently status to close.

##### Test Plan

1. Compile branch
2. start netdata and wait few minutes.
3. Stop netdata and take a look in `error.log`.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
