### PR TITLE
generates dual ksy for njfv2 + fix for padding after page blocks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.c	diff=cpp
 *.h	diff=cpp
+*.ksy.in linguist-language=ksy

--- a/.gitignore
+++ b/.gitignore
@@ -231,3 +231,7 @@ Session.*.vim
 # Judy stuff
 JudyLTables.c
 judyltablesgen
+
+# m4 generated ksys
+database/engine/journalfile_v2.ksy
+database/engine/journalfile_v2_virtmemb.ksy

--- a/Makefile.am
+++ b/Makefile.am
@@ -78,6 +78,7 @@ dist_noinst_DATA = \
     packaging/protobuf.checksums \
     packaging/protobuf.version \
     packaging/version \
+    database/engine/journalfile_v2.ksy.in \
     $(NULL)
 
 # until integrated within build
@@ -562,7 +563,7 @@ if ENABLE_DBENGINE
         $(NULL)
 
     BUILT_SOURCES += $(RRD_PLUGIN_KSY_BUILTFILES)
-	CLEANFILES += $(RRD_PLUGIN_KSY_BUILTFILES)
+    CLEANFILES += $(RRD_PLUGIN_KSY_BUILTFILES)
 
 database/engine/journalfile_v2.ksy: $(abs_top_srcdir)/database/engine/journalfile_v2.ksy.in
 	m4 $(abs_top_srcdir)/database/engine/journalfile_v2.ksy.in > $@

--- a/Makefile.am
+++ b/Makefile.am
@@ -555,6 +555,20 @@ if ENABLE_DBENGINE
         database/engine/pdc.c \
         database/engine/pdc.h \
         $(NULL)
+    
+    RRD_PLUGIN_KSY_BUILTFILES = \
+        database/engine/journalfile_v2.ksy \
+        database/engine/journalfile_v2_virtmemb.ksy \
+        $(NULL)
+
+    BUILT_SOURCES += $(RRD_PLUGIN_KSY_BUILTFILES)
+	CLEANFILES += $(RRD_PLUGIN_KSY_BUILTFILES)
+
+database/engine/journalfile_v2.ksy: $(abs_top_srcdir)/database/engine/journalfile_v2.ksy.in
+	m4 $(abs_top_srcdir)/database/engine/journalfile_v2.ksy.in > $@
+
+database/engine/journalfile_v2_virtmemb.ksy: $(abs_top_srcdir)/database/engine/journalfile_v2.ksy.in
+	m4 -DVIRT_MEMBERS $(abs_top_srcdir)/database/engine/journalfile_v2.ksy.in > $@
 endif
 
 API_PLUGIN_FILES = \

--- a/database/engine/journalfile_v2.ksy.in
+++ b/database/engine/journalfile_v2.ksy.in
@@ -1,6 +1,9 @@
 meta:
-  id: netdata_journalfile_v2
+  id: journalfile_v2`'ifdef(`VIRT_MEMBERS',`_virtmemb')
   endian: le
+  application: netdata
+  file-extension: njfv2
+  license: GPL-3.0-or-later
 
 seq:
   - id: journal_v2_header
@@ -24,7 +27,6 @@ seq:
   - id: journal_file_trailer
     type: journal_v2_block_trailer
 
-
 types:
   journal_v2_metric_list:
     seq:
@@ -38,11 +40,13 @@ types:
         type: u4
       - id: delta_end_s
         type: u4
-    instances:
+ifdef(`VIRT_MEMBERS',
+`    instances:
       page_block:
         type: journal_v2_page_block
         io: _root._io
         pos: page_offset
+')dnl
   journal_v2_page_hdr:
     seq:
       - id: crc
@@ -69,11 +73,13 @@ types:
         type: u1
       - id: reserved
         type: u1
-    instances:
+ifdef(`VIRT_MEMBERS',
+`    instances:
       extent:
         io: _root._io
         type: journal_v2_extent_list
         pos: _root.journal_v2_header.extent_offset + (extent_idx * 16)
+')dnl
   journal_v2_header:
     seq:
       - id: magic
@@ -106,11 +112,13 @@ types:
         type: u4
       - id: data
         type: u8
-    instances:
+ifdef(`VIRT_MEMBERS',
+`    instances:
       trailer:
         io: _root._io
         type: journal_v2_block_trailer
         pos: _root._io.size - 4
+')dnl
   journal_v2_block_trailer:
     seq:
       - id: checksum

--- a/database/engine/journalfile_v2.ksy.in
+++ b/database/engine/journalfile_v2.ksy.in
@@ -22,7 +22,10 @@ seq:
   - id: metric_trailer
     type: journal_v2_block_trailer
   - id: page_blocs
-    type: jounral_v2_page_blocs
+    type: journal_v2_page_block
+    repeat: expr
+    repeat-expr: _root.journal_v2_header.metric_count
+  - id: padding
     size: _root._io.size - _root._io.pos - 4
   - id: journal_file_trailer
     type: journal_v2_block_trailer
@@ -145,8 +148,3 @@ ifdef(`VIRT_MEMBERS',
         repeat-expr: hdr.entries
       - id: block_trailer
         type: journal_v2_block_trailer
-  jounral_v2_page_blocs:
-    seq:
-      - id: blocs
-        type: journal_v2_page_block
-        repeat: eos


### PR DESCRIPTION
##### Summary
During small chat with Stelios I decided to make it possible to view the file directly in sequence (without virtual members) to be able to do that and not loose the ability to have also the better view I used m4 macros to generate 2 `.ksy` versions from one source during build.

There will be 2 generated files during build:
- `database/engine/journalfile_v2.ksy` - this will be more akin to using hex editor where there is list of structures saved in order, useful when debugging file corruption etc.
- `database/engine/journalfile_v2_virtmemb.ksy` - this is what we had until now where there are virtual members allowing to jump trough file. For example `journal_v2_metric_list` has member `page_ofsset` which points to a page later stored much later in file. Therefore there is virtual member `page_block` which allows to inspect that page in place (although it is not physically following `delta_end_s`. This helps understanding interconnections in the data and how they relate to each other.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
