### PR TITLE
add note about not needing to have room id

### DIFF
--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -55,9 +55,10 @@ To install, copy the script, paste it into your node's terminal, and hit `Enter`
 </Tabs>
 
 :::note
-If you plan to also Claim the node to Netdata Cloud, 
+If you plan to also claim the node to Netdata Cloud, 
 make sure to replace `YOUR_CLAIM_TOKEN` with the claim token of your space, 
 and `YOUR_ROOM_ID` with the ID of the room you are willing to claim to.
+You can leave the room id blank to have your node claimed to the default "All nodes" room.
 :::
 
 Jump down to [what's next](#whats-next) to learn how to view your new dashboard and take your next steps monitoring and


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

It's actually hard to find the room id for the default "All nodes" space so we should make it very clear that you dont need a room id to just claim a node into the default "All nodes" room.

For example in the all nodes we dont even show the room id in the app:

![image](https://user-images.githubusercontent.com/2178292/215811073-0f93189d-74fd-4bc4-8c97-56e1e343fbb1.png)

So i think for most users defaulting to having them need to find a room id could end up being confusing.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
