### PR TITLE
Fix kickstart and updater not working with BusyBox wget

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -302,12 +302,21 @@ EOF
   if command -v curl > /dev/null 2>&1; then
     curl --silent -o /dev/null -X POST --max-time 2 --header "Content-Type: application/json" -d "${REQ_BODY}" "${TELEMETRY_URL}" > /dev/null
   elif command -v wget > /dev/null 2>&1; then
-    wget -q -O - --no-check-certificate \
-    --method POST \
-    --timeout=1 \
-    --header 'Content-Type: application/json' \
-    --body-data "${REQ_BODY}" \
-     "${TELEMETRY_URL}" > /dev/null
+    if wget --help 2>&1 | grep BusyBox > /dev/null 2>&1; then
+      # BusyBox-compatible version of wget, there is no --no-check-certificate option
+      wget -q -O - \
+      -T 1 \
+      --header 'Content-Type: application/json' \
+      --post-data "${REQ_BODY}" \
+      "${TELEMETRY_URL}" > /dev/null
+    else
+      wget -q -O - --no-check-certificate \
+      --method POST \
+      --timeout=1 \
+      --header 'Content-Type: application/json' \
+      --body-data "${REQ_BODY}" \
+      "${TELEMETRY_URL}" > /dev/null
+    fi
   fi
 }
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -601,7 +601,7 @@ get_redirect() {
   if command -v curl > /dev/null 2>&1; then
     run sh -c "curl ${url} -s -L -I -o /dev/null -w '%{url_effective}' | grep -o '[^/]*$'" || return 1
   elif command -v wget > /dev/null 2>&1; then
-    run sh -c "wget -S -O /dev/null ${url} 2>&1 | grep Location | head -n 1 | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -d ' ' -f2  | grep -o '[^/]*$'" || return 1
+    run sh -c "wget -S -O /dev/null ${url} 2>&1 | grep -m 1 Location | grep -o '[^/]*$'" || return 1
   else
     fatal "${ERROR_F0003}" F0003
   fi

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -592,7 +592,7 @@ get_redirect() {
   if command -v curl > /dev/null 2>&1; then
     run sh -c "curl ${url} -s -L -I -o /dev/null -w '%{url_effective}' | grep -o '[^/]*$'" || return 1
   elif command -v wget > /dev/null 2>&1; then
-    run sh -c "wget --max-redirect=0 ${url} 2>&1 | grep Location | cut -d ' ' -f2  | grep -o '[^/]*$'" || return 1
+    run sh -c "wget -S -O /dev/null ${url} 2>&1 | grep Location | head -n 1 | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -d ' ' -f2  | grep -o '[^/]*$'" || return 1
   else
     fatal "${ERROR_F0003}" F0003
   fi

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -378,7 +378,7 @@ get_netdata_latest_tag() {
   if command -v curl >/dev/null 2>&1; then
     tag=$(curl "${url}" -s -L -I -o /dev/null -w '%{url_effective}' | grep -m 1 -o '[^/]*$')
   elif command -v wget >/dev/null 2>&1; then
-    tag=$(wget --max-redirect=0 "${url}" 2>&1 | grep Location | cut -d ' ' -f2 | grep -m 1 -o '[^/]*$')
+    tag=$(wget -S -O /dev/null "${url}" 2>&1 | grep -m 1 Location | grep -o '[^/]*$')
   else
     fatal "I need curl or wget to proceed, but neither of them are available on this system." U0006
   fi


### PR DESCRIPTION
##### Summary
Fixes https://github.com/netdata/netdata/issues/14346 .

##### Test Plan

1. Ensure you are only using BusyBox `wget` and no other versions of it or of `curl` exist in your PATH (a Docker Alpine image can be used for this purpose). 
2. Try to run 

```
wget -O /tmp/kickstart.sh https://raw.githubusercontent.com/Dim-P/netdata/fix-kickstart-wget/packaging/installer/kickstart.sh && sh /tmp/kickstart.sh --static-only
``` 

and confirm it works as expected (including a correct call of `telemetry_event()` ).
4. Next, try to run 
```
wget -O /tmp/netdata-updater.sh https://raw.githubusercontent.com/Dim-P/netdata/fix-kickstart-wget/packaging/installer/netdata-updater.sh && sh /tmp/netdata-updater.sh --not-running-from-cron --no-updater-self-update --force-update
```
and confirm updater works as expected.
5. Finally, repeat all the above steps on a setup where GNU `wget` or `curl` exist to ensure the changes don't break any existing functionality.