### PR TITLE
Remove equality when deciding how to use point

### DIFF
--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -1476,7 +1476,7 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
             count_same_end_time = 0;
 
             // decide how to use this point
-            if(likely(new_point.end_time <= now_end_time)) { // likely to favor tier0
+            if(likely(new_point.end_time < now_end_time)) { // likely to favor tier0
                 // this db point ends before our now_end_time
 
                 if(likely(new_point.end_time >= now_start_time)) { // likely to favor tier0


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Removes an equal sign from a comparison in query.c

It appears that `<=` will return one extra point when querying. It is mostly apparent in health (thanks @dimko for raising the issue).

For example in an alert that states e.g. `sum -3s abs of rand1,rand2` it will read back 4 points instead of 3.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Will be tested from @dimko as well.

Needs a chart with a couple of dimensions, with static values (to be easier to check). Create an alert with a lookup of e.g. `sum -3s abs of rand1,rand2` on that chart, and check the value.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
