### PR TITLE
Use curl from static builds if no system-wide copy exists.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -78,6 +78,8 @@ else
   INTERACTIVE=1
 fi
 
+CURL="$(PATH="${PATH}:/opt/netdata/bin" command -v curl 2>/dev/null && true)"
+
 # ======================================================================
 # Shared messages used in multiple places throughout the script.
 
@@ -299,8 +301,8 @@ telemetry_event() {
 EOF
 )"
 
-  if command -v curl > /dev/null 2>&1; then
-    curl --silent -o /dev/null -X POST --max-time 2 --header "Content-Type: application/json" -d "${REQ_BODY}" "${TELEMETRY_URL}" > /dev/null
+  if [ -n "${CURL}" ]; then
+    "${CURL}" --silent -o /dev/null -X POST --max-time 2 --header "Content-Type: application/json" -d "${REQ_BODY}" "${TELEMETRY_URL}" > /dev/null
   elif command -v wget > /dev/null 2>&1; then
     wget -q -O - --no-check-certificate \
     --method POST \
@@ -562,8 +564,8 @@ check_for_remote_file() {
 
   if echo "${url}" | grep -Eq "^file:///"; then
     [ -e "${url#file://}" ] || return 1
-  elif command -v curl > /dev/null 2>&1; then
-    curl --output /dev/null --silent --head --fail "${url}" || return 1
+  elif [ -n "${CURL}" ]; then
+    "${CURL}" --output /dev/null --silent --head --fail "${url}" || return 1
   elif command -v wget > /dev/null 2>&1; then
     wget -S --spider "${url}" 2>&1 | grep -q 'HTTP/1.1 200 OK' || return 1
   else
@@ -577,8 +579,8 @@ download() {
 
   if echo "${url}" | grep -Eq "^file:///"; then
     run cp "${url#file://}" "${dest}" || return 1
-  elif command -v curl > /dev/null 2>&1; then
-    run curl --fail -q -sSL --connect-timeout 10 --retry 3 --output "${dest}" "${url}" || return 1
+  elif [ -n "${CURL}" ]; then
+    run "${CURL}" --fail -q -sSL --connect-timeout 10 --retry 3 --output "${dest}" "${url}" || return 1
   elif command -v wget > /dev/null 2>&1; then
     run wget -T 15 -O "${dest}" "${url}" || return 1
   else
@@ -589,8 +591,8 @@ download() {
 get_redirect() {
   url="${1}"
 
-  if command -v curl > /dev/null 2>&1; then
-    run sh -c "curl ${url} -s -L -I -o /dev/null -w '%{url_effective}' | grep -o '[^/]*$'" || return 1
+  if [ -n "${CURL}" ]; then
+    run sh -c "${CURL} ${url} -s -L -I -o /dev/null -w '%{url_effective}' | grep -o '[^/]*$'" || return 1
   elif command -v wget > /dev/null 2>&1; then
     run sh -c "wget --max-redirect=0 ${url} 2>&1 | grep Location | cut -d ' ' -f2  | grep -o '[^/]*$'" || return 1
   else

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -341,11 +341,20 @@ create_tmp_directory() {
   fi
 }
 
+check_for_curl() {
+  if [ -z "${curl}" ]; then
+    curl="$(PATH="${PATH}:/opt/netdata/bin" command -v curl 2>/dev/null && true)"
+  fi
+}
+
 _safe_download() {
   url="${1}"
   dest="${2}"
-  if command -v curl > /dev/null 2>&1; then
-    curl -sSL --connect-timeout 10 --retry 3 "${url}" > "${dest}"
+
+  check_for_curl
+
+  if [ -n "${curl}" ]; then
+    "${curl}" -sSL --connect-timeout 10 --retry 3 "${url}" > "${dest}"
     return $?
   elif command -v wget > /dev/null 2>&1; then
     wget -T 15 -O - "${url}" > "${dest}"
@@ -375,8 +384,10 @@ get_netdata_latest_tag() {
   url="${1}/latest"
   dest="${2}"
 
-  if command -v curl >/dev/null 2>&1; then
-    tag=$(curl "${url}" -s -L -I -o /dev/null -w '%{url_effective}' | grep -m 1 -o '[^/]*$')
+  check_for_curl
+
+  if [ -n "${curl}" ]; then
+    tag=$("${curl}" "${url}" -s -L -I -o /dev/null -w '%{url_effective}' | grep -m 1 -o '[^/]*$')
   elif command -v wget >/dev/null 2>&1; then
     tag=$(wget --max-redirect=0 "${url}" 2>&1 | grep Location | cut -d ' ' -f2 | grep -m 1 -o '[^/]*$')
   else


### PR DESCRIPTION
##### Summary

Instead of immediately falling back to wget, try using curl from a static build if it is installed. This provides better behavior in a number of cases and also makes the static builds more self-contained.

##### Test Plan

Initial testing should confirm that there is no change in behavior in cases where there is nostatic build installed.

The other key test here is to install a static build (ideally in a container), uninstall any copy of wget/curl, and then attempt to run the kickstart script from this PR, which should work correctly despite the lack of a system-copy of curl or wget.

##### Additional Information

Fixes #14401