### PR TITLE
Check on parents the microseconds delta sent by agents

### DIFF
--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -148,8 +148,11 @@ PARSER_RC pluginsd_begin(char **words, size_t num_words, void *user)
     ((PARSER_USER_OBJECT *)user)->st = st;
 
     usec_t microseconds = 0;
-    if (microseconds_txt && *microseconds_txt)
-        microseconds = str2ull(microseconds_txt);
+    if (microseconds_txt && *microseconds_txt) {
+        long long t = str2ll(microseconds_txt, NULL);
+        if(t >= 0)
+            microseconds = t;
+    }
 
 #ifdef NETDATA_LOG_REPLICATION_REQUESTS
     if(st->replay.log_next_data_collection) {


### PR DESCRIPTION
Old versions of netdata sometimes send invalid microseconds delta at the BEGIN streaming command.

- [x] check streaming BEGIN microseconds for negative values