### PR TITLE
Stop training thread from processing training requests once cancelled.

### DIFF
--- a/ml/Queue.h
+++ b/ml/Queue.h
@@ -32,8 +32,15 @@ public:
         while (Q.empty()) {
             pthread_cond_wait(&CV, M.inner());
 
-            if (Exit)
-                pthread_exit(nullptr);
+            if (Exit) {
+                // This should happen only when we are destroying a host.
+                // Callers should use a flag dedicated to checking if we
+                // are about to delete the host or exit the agent. The original
+                // implementation would call pthread_exit which would cause
+                // the queue's mutex to be destroyed twice (and fail on the
+                // 2nd time)
+                return { T(), 0 };
+            }
         }
 
         T V = Q.front();


### PR DESCRIPTION
##### Summary

Without these changes, it was possible to delete the host while the ML threads were still running. With this change, we ensure that the training thread keeps processing training requests only as long as the ML threads have not been cancelled.

##### Test Plan

Connect/disconnect a child with short host cleanup period. The agent should not crash.

