### PR TITLE
turn error() to internal_error()

### DIFF
--- a/database/ram/rrddim_mem.c
+++ b/database/ram/rrddim_mem.c
@@ -411,7 +411,7 @@ void rrddim_query_finalize(struct storage_engine_query_handle *handle) {
     struct mem_query_handle *h = (struct mem_query_handle*)handle->handle;
     struct mem_metric_handle *mh = (struct mem_metric_handle *)h->db_metric_handle;
     if(!rrddim_query_is_finished(handle))
-        error("QUERY: query for chart '%s' dimension '%s' has been stopped unfinished", rrdset_id(mh->rd->rrdset), rrddim_name(mh->rd));
+        internal_error(true, "QUERY: query for chart '%s' dimension '%s' has been stopped unfinished", rrdset_id(mh->rd->rrdset), rrddim_name(mh->rd));
 #endif
     freez(handle->handle);
     __atomic_sub_fetch(&rrddim_db_memory_size, sizeof(struct mem_query_handle), __ATOMIC_RELAXED);

--- a/database/ram/rrddim_mem.c
+++ b/database/ram/rrddim_mem.c
@@ -410,8 +410,11 @@ void rrddim_query_finalize(struct storage_engine_query_handle *handle) {
 #ifdef NETDATA_INTERNAL_CHECKS
     struct mem_query_handle *h = (struct mem_query_handle*)handle->handle;
     struct mem_metric_handle *mh = (struct mem_metric_handle *)h->db_metric_handle;
-    if(!rrddim_query_is_finished(handle))
-        internal_error(true, "QUERY: query for chart '%s' dimension '%s' has been stopped unfinished", rrdset_id(mh->rd->rrdset), rrddim_name(mh->rd));
+
+    internal_error(!rrddim_query_is_finished(handle),
+                   "QUERY: query for chart '%s' dimension '%s' has been stopped unfinished",
+                   rrdset_id(mh->rd->rrdset), rrddim_name(mh->rd));
+
 #endif
     freez(handle->handle);
     __atomic_sub_fetch(&rrddim_db_memory_size, sizeof(struct mem_query_handle), __ATOMIC_RELAXED);


### PR DESCRIPTION
Now that the query engine expands the duration of the queries to satisfy the plans, rrddim modes (`alloc`, `ram`, `save`, `map`) complain about unfinished queries.

Eventually, this statement can be eliminated altogether.