### PR TITLE
Add .NET info

### DIFF
--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -4512,7 +4512,7 @@ netdataDashboard.context = {
     },
 
     // ------------------------------------------------------------------------
-    // WMI (NET Framework)
+    // WMI (NET Framework: Exception)
 
     'netframework.clrexception_thrown': {
         info: 'The exceptions includes both .NET exceptions and unmanaged exceptions that are converted into .NET exceptions.'
@@ -4524,6 +4524,17 @@ netdataDashboard.context = {
 
     'netframework.clrexception_finally': {
         info: 'The metric counts only the finally blocks executed for an exception; finally blocks on normal code paths are not counted by this counter.'
+    },
+
+    // ------------------------------------------------------------------------
+    // WMI (NET Framework: Interop)
+
+    'netframework.clrinterop_com_callable_wrapper': {
+        info: 'A COM callable wrappers (CCW) is a proxy for a managed object being referenced from an unmanaged COM client.'
+    },
+
+    'netframework.clrinterop_stubs_created': {
+        info: 'The Stubs are responsible for marshaling arguments and return values from managed to unmanaged code, and vice versa, during a COM interop call or a platform invoke call.'
     },
 
     // ------------------------------------------------------------------------

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -4515,7 +4515,7 @@ netdataDashboard.context = {
     // WMI (NET Framework: Exception)
 
     'netframework.clrexception_thrown': {
-        info: 'The exceptions includes both .NET exceptions and unmanaged exceptions that are converted into .NET exceptions.'
+        info: 'The exceptions include both .NET exceptions and unmanaged exceptions that are converted into .NET exceptions.'
     },
 
     'netframework.clrexception_filters': {
@@ -4574,7 +4574,7 @@ netdataDashboard.context = {
     // WMI (NET Framework: Memory)
 
     'netframework.clrmemory_heap_size': {
-        info: 'The metric does not indicate the current number of bytes allocated.'
+        info: 'The metric shows maximum bytes that can be allocated, but it does not indicate the current number of bytes allocated.'
     },
 
     'netframework.clrmemory_promoted': {

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -4522,18 +4522,18 @@ netdataDashboard.context = {
         info: 'An exception filter evaluates regardless of whether an exception is handled.'
     },
 
-    'netframework.clrexception_finally': {
+    'netframework.clrexception_finallys': {
         info: 'The metric counts only the finally blocks executed for an exception; finally blocks on normal code paths are not counted by this counter.'
     },
 
     // ------------------------------------------------------------------------
     // WMI (NET Framework: Interop)
 
-    'netframework.clrinterop_com_callable_wrapper': {
+    'netframework.clrinterop_com_callable_wrappers': {
         info: 'A COM callable wrappers (CCW) is a proxy for a managed object being referenced from an unmanaged COM client.'
     },
 
-    'netframework.clrinterop_stubs_created': {
+    'netframework.clrinterop_interop_stubs_created': {
         info: 'The Stubs are responsible for marshaling arguments and return values from managed to unmanaged code, and vice versa, during a COM interop call or a platform invoke call.'
     },
 
@@ -4548,7 +4548,7 @@ netdataDashboard.context = {
         info: 'The metric is updated at the end of every JIT compilation phase. A JIT compilation phase occurs when a method and its dependencies are compiled.'
     },
 
-    'netframework.clrjit_standard_failure': {
+    'netframework.clrjit_standard_failures': {
         info: 'The failure can occur if the MSIL cannot be verified or if there is an internal error in the JIT compiler.'
     },
 

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -4538,6 +4538,21 @@ netdataDashboard.context = {
     },
 
     // ------------------------------------------------------------------------
+    // WMI (NET Framework: JIT)
+
+    'netframework.clrjit_methods': {
+        info: 'The metric does not include pre-JIT-compiled methods.'
+    },
+
+    'netframework.clrjit_time': {
+        info: 'The metric is updated at the end of every JIT compilation phase. A JIT compilation phase occurs when a method and its dependencies are compiled.'
+    },
+
+    'netframework.clrjit_standard_failure': {
+        info: 'The failure can occur if the MSIL cannot be verified or if there is an internal error in the JIT compiler.'
+    },
+
+    // ------------------------------------------------------------------------
     // APACHE
 
     'apache.connections': {

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -4564,6 +4564,13 @@ netdataDashboard.context = {
     },
 
     // ------------------------------------------------------------------------
+    // WMI (NET Framework: Locks and Threads)
+
+    'netframework.clrlocksandthreads_recognized_threads': {
+        info: 'Displays the total number of threads that have been recognized by the runtime since the application started. These threads are associated with a corresponding managed thread object. The runtime does not create these threads, but they have run inside the runtime at least once.'
+    },
+
+    // ------------------------------------------------------------------------
     // APACHE
 
     'apache.connections': {

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -4553,6 +4553,17 @@ netdataDashboard.context = {
     },
 
     // ------------------------------------------------------------------------
+    // WMI (NET Framework: Loading)
+
+    'netframework.clrloading_loader_heap_size': {
+        info: 'The memory committed by the class loader across all application domains is the physical space reserved in the disk paging file.'
+    },
+
+    'netframework.clrloading_assemblies_loaded': {
+        info: 'If the assembly is loaded as domain-neutral from multiple application domains, the metric is incremented only once.'
+    },
+
+    // ------------------------------------------------------------------------
     // APACHE
 
     'apache.connections': {

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -4512,6 +4512,21 @@ netdataDashboard.context = {
     },
 
     // ------------------------------------------------------------------------
+    // WMI (NET Framework)
+
+    'netframework.clrexception_thrown': {
+        info: 'The exceptions includes both .NET exceptions and unmanaged exceptions that are converted into .NET exceptions.'
+    },
+
+    'netframework.clrexception_filters': {
+        info: 'An exception filter evaluates regardless of whether an exception is handled.'
+    },
+
+    'netframework.clrexception_finally': {
+        info: 'The metric counts only the finally blocks executed for an exception; finally blocks on normal code paths are not counted by this counter.'
+    },
+
+    // ------------------------------------------------------------------------
     // APACHE
 
     'apache.connections': {

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -609,6 +609,12 @@ netdataDashboard.menu = {
         info: undefined
     },
 
+    'netframework': {
+        title: '.NET Framework',
+        icon: '<i class="fas fa-laptop-code"></i>',
+        info: undefined
+    },
+
     'perf': {
         title: 'Perf Counters',
         icon: '<i class="fas fa-tachometer-alt"></i>',

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -4571,6 +4571,41 @@ netdataDashboard.context = {
     },
 
     // ------------------------------------------------------------------------
+    // WMI (NET Framework: Memory)
+
+    'netframework.clrmemory_heap_size': {
+        info: 'The metric does not indicate the current number of bytes allocated.'
+    },
+
+    'netframework.clrmemory_promoted': {
+        info: 'Memory is promoted when it survives a garbage collection.'
+    },
+
+    'netframework.clrmemory_number_gc_handles': {
+        info: 'Garbage collection handles are handles to resources external to the common language runtime and the managed environment.'
+    },
+
+    'netframework.clrmemory_induced_gc': {
+        info: 'The metric is updated when an explicit call to GC.Collect happens.'
+    },
+
+    'netframework.clrmemory_number_sink_blocks_in_use': {
+        info: 'Synchronization blocks are per-object data structures allocated for storing synchronization information. They hold weak references to managed objects and must be scanned by the garbage collector.'
+    },
+
+    'netframework.clrmemory_committed': {
+        info: 'Committed memory is the physical memory for which space has been reserved in the disk paging file.'
+    },
+
+    'netframework.clrmemory_reserved': {
+        info: 'Reserved memory is the virtual memory space reserved for the application when no disk or main memory pages have been used.'
+    },
+
+    'netframework.clrmemory_gc_time': {
+        info: 'Displays the percentage of time that was spent performing a garbage collection in the last sample.'
+    },
+
+    // ------------------------------------------------------------------------
     // APACHE
 
     'apache.connections': {


### PR DESCRIPTION
##### Summary
Current PR is blocked by https://github.com/netdata/go.d.plugin/pull/1055

This PR is bringing detailed information for some metrics delivered for our users.

![Screenshot_20230203_200706](https://user-images.githubusercontent.com/49162938/216700960-209b5786-f38b-4342-9b88-a728db40dd24.png)

Reviewers we do not have a proper icon for .NET in our [source](https://fontawesome.com/search?o=a&m=free), so I selected a generic one. I am accepting all suggestions to improve the icon.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
