### PR TITLE
Add cakrit as docs and md codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@ collectors/cups.plugin/ @thiagoftsm
 exporting/ @thiagoftsm
 daemon/ @thiagoftsm @vkalintiris
 database/ @thiagoftsm @vkalintiris
-docs/ @tkatsoulas @andrewm4894
+docs/ @tkatsoulas @andrewm4894 @cakrit
 health/ @thiagoftsm @vkalintiris @MrZammler
 health/health.d/ @thiagoftsm @MrZammler
 health/notifications/ @Ferroin @thiagoftsm @MrZammler
@@ -35,8 +35,8 @@ web/gui/ @jacekkolasa
 
 # Ownership by filetype (overwrites ownership by directory)
 *.am @Ferroin @tkatsoulas
-*.md @tkatsoulas @andrewm4894
-*.mdx @tkatsoulas @andrewm4894
+*.md @tkatsoulas @andrewm4894 @cakrit
+*.mdx @tkatsoulas @andrewm4894 @cakrit
 Dockerfile* @Ferroin @tkatsoulas
 
 # Ownership of specific files


### PR DESCRIPTION
Owning docs now, we'll remove @tkatsoulas at some point. 