### PR TITLE
do not report dimensions that failed to be queried

### DIFF
--- a/web/api/formatters/csv/csv.c
+++ b/web/api/formatters/csv/csv.c
@@ -12,6 +12,7 @@ void rrdr2csv(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, const 
     // print the csv header
     for(c = 0, i = 0; c < used ; c++) {
         if(unlikely(r->od[c] & RRDR_DIMENSION_HIDDEN)) continue;
+        if(unlikely(!(r->od[c] & RRDR_DIMENSION_SELECTED))) continue;
         if(unlikely((options & RRDR_OPTION_NONZERO) && !(r->od[c] & RRDR_DIMENSION_NONZERO))) continue;
 
         if(!i) {
@@ -32,6 +33,7 @@ void rrdr2csv(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, const 
         // print the --- line after header
         for(c = 0, i = 0; c < used ;c++) {
             if(unlikely(r->od[c] & RRDR_DIMENSION_HIDDEN)) continue;
+            if(unlikely(!(r->od[c] & RRDR_DIMENSION_SELECTED))) continue;
             if(unlikely((options & RRDR_OPTION_NONZERO) && !(r->od[c] & RRDR_DIMENSION_NONZERO))) continue;
 
             if(!i) {
@@ -89,6 +91,8 @@ void rrdr2csv(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, const 
         if(unlikely(options & RRDR_OPTION_PERCENTAGE)) {
             total = 0;
             for(c = 0; c < used ;c++) {
+                if(unlikely(!(r->od[c] & RRDR_DIMENSION_SELECTED))) continue;
+
                 NETDATA_DOUBLE n = cn[c];
 
                 if(likely((options & RRDR_OPTION_ABSOLUTE) && n < 0))
@@ -104,6 +108,7 @@ void rrdr2csv(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, const 
         // for each dimension
         for(c = 0; c < used ;c++) {
             if(unlikely(r->od[c] & RRDR_DIMENSION_HIDDEN)) continue;
+            if(unlikely(!(r->od[c] & RRDR_DIMENSION_SELECTED))) continue;
             if(unlikely((options & RRDR_OPTION_NONZERO) && !(r->od[c] & RRDR_DIMENSION_NONZERO))) continue;
 
             buffer_strcat(wb, separator);

--- a/web/api/formatters/json/json.c
+++ b/web/api/formatters/json/json.c
@@ -111,6 +111,7 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
     // print the header lines
     for(c = 0, i = 0; c < used ; c++) {
         if(unlikely(r->od[c] & RRDR_DIMENSION_HIDDEN)) continue;
+        if(unlikely(!(r->od[c] & RRDR_DIMENSION_SELECTED))) continue;
         if(unlikely((options & RRDR_OPTION_NONZERO) && !(r->od[c] & RRDR_DIMENSION_NONZERO))) continue;
 
         buffer_fast_strcat(wb, pre_label, pre_label_len);
@@ -215,6 +216,8 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
         if(unlikely(options & RRDR_OPTION_PERCENTAGE)) {
             total = 0;
             for(c = 0; c < used ;c++) {
+                if(unlikely(!(r->od[c] & RRDR_DIMENSION_SELECTED))) continue;
+
                 NETDATA_DOUBLE n;
                 if(unlikely(options & RRDR_OPTION_INTERNAL_AR))
                     n = ar[c];
@@ -234,6 +237,7 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
         // for each dimension
         for(c = 0; c < used ;c++) {
             if(unlikely(r->od[c] & RRDR_DIMENSION_HIDDEN)) continue;
+            if(unlikely(!(r->od[c] & RRDR_DIMENSION_SELECTED))) continue;
             if(unlikely((options & RRDR_OPTION_NONZERO) && !(r->od[c] & RRDR_DIMENSION_NONZERO))) continue;
 
             NETDATA_DOUBLE n;

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -131,6 +131,7 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
 
     for(c = 0, i = 0; c < query_used ; c++) {
         if(unlikely(r->od[c] & RRDR_DIMENSION_HIDDEN)) continue;
+        if(unlikely(!(r->od[c] & RRDR_DIMENSION_SELECTED))) continue;
         if(unlikely((options & RRDR_OPTION_NONZERO) && !(r->od[c] & RRDR_DIMENSION_NONZERO))) continue;
 
         if(i) buffer_strcat(wb, ", ");
@@ -155,6 +156,7 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
 
     for(c = 0, i = 0; c < query_used ; c++) {
         if(unlikely(r->od[c] & RRDR_DIMENSION_HIDDEN)) continue;
+        if(unlikely(!(r->od[c] & RRDR_DIMENSION_SELECTED))) continue;
         if(unlikely((options & RRDR_OPTION_NONZERO) && !(r->od[c] & RRDR_DIMENSION_NONZERO))) continue;
 
         if(i) buffer_strcat(wb, ", ");
@@ -260,9 +262,8 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
         for (c = 0, i = 0; c < query_used; c++) {
             QUERY_METRIC *qm = &qt->query.array[c];
 
-            if (unlikely(r->od[c] & RRDR_DIMENSION_HIDDEN))
-                continue;
-
+            if (unlikely(r->od[c] & RRDR_DIMENSION_HIDDEN)) continue;
+            if (unlikely(!(r->od[c] & RRDR_DIMENSION_SELECTED))) continue;
             if (unlikely((options & RRDR_OPTION_NONZERO) && !(r->od[c] & RRDR_DIMENSION_NONZERO)))
                 continue;
 
@@ -295,8 +296,8 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
                 for (c = 0, i = 0; c < query_used; c++) {
                     QUERY_METRIC *qm = &qt->query.array[c];
 
-                    if (unlikely(r->od[c] & RRDR_DIMENSION_HIDDEN))
-                        continue;
+                    if (unlikely(r->od[c] & RRDR_DIMENSION_HIDDEN)) continue;
+                    if (unlikely(!(r->od[c] & RRDR_DIMENSION_SELECTED))) continue;
                     if (unlikely((options & RRDR_OPTION_NONZERO) && !(r->od[c] & RRDR_DIMENSION_NONZERO)))
                         continue;
 
@@ -351,6 +352,8 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
         if(unlikely(options & RRDR_OPTION_PERCENTAGE)) {
             total = 0;
             for(c = 0; c < query_used ;c++) {
+                if(unlikely(!(r->od[c] & RRDR_DIMENSION_SELECTED))) continue;
+
                 NETDATA_DOUBLE *cn = &r->v[ (rrdr_rows(r) - 1) * r->d ];
                 NETDATA_DOUBLE n = cn[c];
 
@@ -365,6 +368,7 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS 
 
         for(c = 0, i = 0; c < query_used ;c++) {
             if(unlikely(r->od[c] & RRDR_DIMENSION_HIDDEN)) continue;
+            if(unlikely(!(r->od[c] & RRDR_DIMENSION_SELECTED))) continue;
             if(unlikely((options & RRDR_OPTION_NONZERO) && !(r->od[c] & RRDR_DIMENSION_NONZERO))) continue;
 
             if(i) buffer_strcat(wb, ", ");

--- a/web/api/formatters/value/value.c
+++ b/web/api/formatters/value/value.c
@@ -22,6 +22,7 @@ inline NETDATA_DOUBLE rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all
     if(unlikely(options & RRDR_OPTION_PERCENTAGE)) {
         total = 0;
         for (c = 0; c < used; c++) {
+            if(unlikely(!(r->od[c] & RRDR_DIMENSION_SELECTED))) continue;
             NETDATA_DOUBLE n = cn[c];
 
             if(likely((options & RRDR_OPTION_ABSOLUTE) && n < 0))
@@ -37,6 +38,7 @@ inline NETDATA_DOUBLE rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all
     // for each dimension
     for (c = 0; c < used; c++) {
         if(unlikely(r->od[c] & RRDR_DIMENSION_HIDDEN)) continue;
+        if(unlikely(!(r->od[c] & RRDR_DIMENSION_SELECTED))) continue;
         if(unlikely((options & RRDR_OPTION_NONZERO) && !(r->od[c] & RRDR_DIMENSION_NONZERO))) continue;
 
         NETDATA_DOUBLE n = cn[c];

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -2275,6 +2275,7 @@ RRDR *rrd2rrdr(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
         if(ops[c]) {
             r->od[c] |= RRDR_DIMENSION_SELECTED;
             rrd2rrdr_query_execute(r, c, ops[c]);
+            continue;
         }
 
         global_statistics_rrdr_query_completed(
@@ -2385,15 +2386,23 @@ RRDR *rrd2rrdr(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
     // free all resources used by the grouping method
     r->internal.grouping_free(r);
 
-    // when all the dimensions are zero, we should return all of them
-    if(unlikely((qt->window.options & RRDR_OPTION_NONZERO) && !dimensions_nonzero && !(r->result_options & RRDR_RESULT_OPTION_CANCEL))) {
-        // all the dimensions are zero
-        // mark them as NONZERO to send them all
-        for(size_t c = 0, max = qt->query.used; c < max ; c++) {
-            if(unlikely(r->od[c] & RRDR_DIMENSION_HIDDEN)) continue;
-            r->od[c] |= RRDR_DIMENSION_NONZERO;
+    if(likely(dimensions_used)) {
+        // when all the dimensions are zero, we should return all of them
+        if (unlikely((qt->window.options & RRDR_OPTION_NONZERO) && !dimensions_nonzero &&
+                     !(r->result_options & RRDR_RESULT_OPTION_CANCEL))) {
+            // all the dimensions are zero
+            // mark them as NONZERO to send them all
+            for (size_t c = 0, max = qt->query.used; c < max; c++) {
+                if (unlikely(r->od[c] & RRDR_DIMENSION_HIDDEN)) continue;
+                if (unlikely(!(r->od[c] & RRDR_DIMENSION_SELECTED))) continue;
+                r->od[c] |= RRDR_DIMENSION_NONZERO;
+            }
         }
+
+        return r;
     }
 
-    return r;
+    // we couldn't query any dimension
+    rrdr_free(owa, r);
+    return NULL;
 }

--- a/web/api/queries/weights.c
+++ b/web/api/queries/weights.c
@@ -541,6 +541,9 @@ NETDATA_DOUBLE *rrd2rrdr_ks2(
     if(unlikely(r->od[0] & RRDR_DIMENSION_HIDDEN))
         goto cleanup;
 
+    if(unlikely(!(r->od[0] & RRDR_DIMENSION_SELECTED)))
+        goto cleanup;
+
     if(unlikely(!(r->od[0] & RRDR_DIMENSION_NONZERO)))
         goto cleanup;
 


### PR DESCRIPTION
When the metrics registry believes there is retention for a dimension, but the dimension does not have any data for the desired timeframe, the current query engine returns garbage (random data that happened to be in memory).

This PR, removes such dimensions from the response, and if all the dimensions of the query are like that, it reports a query failure.