### PR TITLE
Update static build packages

### DIFF
--- a/packaging/makeself/jobs/20-openssl.install.sh
+++ b/packaging/makeself/jobs/20-openssl.install.sh
@@ -29,7 +29,7 @@ if [ -d "${cache}" ]; then
   CACHE_HIT=1
 else
   echo "No cached copy of build directory for openssl found, fetching sources instead."
-  run git clone --branch "${version}" --single-branch --depth 1 git://git.openssl.org/openssl.git "${NETDATA_MAKESELF_PATH}/tmp/openssl"
+  run git clone --branch "${version}" --single-branch --depth 1 https://github.com/openssl/openssl.git "${NETDATA_MAKESELF_PATH}/tmp/openssl"
   CACHE_HIT=0
 fi
 

--- a/packaging/makeself/jobs/50-curl-7.87.0.install.sh
+++ b/packaging/makeself/jobs/50-curl-7.87.0.install.sh
@@ -4,13 +4,13 @@
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
-version="7.82.0"
+version="7.87.0"
 
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Building cURL" || true
 
 fetch "curl-${version}" "https://curl.haxx.se/download/curl-${version}.tar.gz" \
-    910cc5fe279dc36e2cca534172c94364cf3fcf7d6494ba56e6c61a390881ddce curl
+    8a063d664d1c23d35526b87a2bf15514962ffdd8ef7fd40519191b3c23e39548 curl
 
 export CFLAGS="-I/openssl-static/include -pipe"
 export LDFLAGS="-static -L/openssl-static/lib"

--- a/packaging/makeself/jobs/50-ioping-1.3.install.sh
+++ b/packaging/makeself/jobs/50-ioping-1.3.install.sh
@@ -4,13 +4,13 @@
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 
-version='1.2'
+version='1.3'
 
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Building ioping" || true
 
 fetch "ioping-${version}" "https://github.com/koct9i/ioping/archive/v${version}.tar.gz" \
-    d3e4497c653a1e96df67c72ce2b70da18e9f5e3b93179a5bb57a6e30ceacfa75 ioping
+    7aa48e70aaa766bc112dea57ebbe56700626871052380709df3a26f46766e8c8 ioping
 
 export CFLAGS="-static -pipe"
 

--- a/packaging/makeself/openssl.version
+++ b/packaging/makeself/openssl.version
@@ -1,1 +1,1 @@
-OpenSSL_1_1_1-stable
+OpenSSL_1_1_1s

--- a/packaging/makeself/openssl.version
+++ b/packaging/makeself/openssl.version
@@ -1,1 +1,1 @@
-OpenSSL_1_1_1n
+OpenSSL_1_1_1-stable

--- a/packaging/makeself/openssl.version
+++ b/packaging/makeself/openssl.version
@@ -1,1 +1,1 @@
-OpenSSL_1_1_1s
+OpenSSL_1_1_1t


### PR DESCRIPTION

##### Summary

* bump openssl to v1.1.1t
* bump ioping to v1.3
* bump curl to v7.87

Future work:
-  Add a lifecycle process to update these packages
- Bump openssl to v3.X

Note:

We didn't update bash, static package build for `armv7l` didn't finish successfully (nee to double down on that)

##### Test Plan

openssl:

- [x]  [Configure (TLS)](https://learn.netdata.cloud/docs/agent/web/server#enabling-tls-support) and access local dashboard via https
- [x]  Setup [Parent (TLS)](https://learn.netdata.cloud/docs/agent/streaming#securing-streaming-communications) and verify its working (during streaming)

Ioping:

- [x]  Setup a job

Curl:

- [x]  verify that it is installed and use it

General:

- [ ] Open issue: Bump openssl to v3.X
- [ ] Update CI docs if needed 


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
