### PR TITLE
Support installing extra packages in Docker images at runtime.

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -114,7 +114,7 @@ RUN chown -R root:root \
 ENV NETDATA_LISTENER_PORT 19999
 EXPOSE $NETDATA_LISTENER_PORT
 
-ENV NETDATA_EXTRA_APK_PACKAGES="apcupsd libvirt-daemon lm-sensors msmtp netcat-openbsd"
+ENV NETDATA_EXTRA_APK_PACKAGES=""
 
 ENTRYPOINT ["/usr/sbin/run.sh"]
 

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -114,6 +114,8 @@ RUN chown -R root:root \
 ENV NETDATA_LISTENER_PORT 19999
 EXPOSE $NETDATA_LISTENER_PORT
 
+ENV NETDATA_EXTRA_APK_PACKAGES="apcupsd libvirt-daemon lm-sensors msmtp netcat-openbsd"
+
 ENTRYPOINT ["/usr/sbin/run.sh"]
 
 HEALTHCHECK --interval=60s --timeout=10s --retries=3 CMD /usr/sbin/health.sh

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -136,6 +136,20 @@ Additionally, for each stable release, three tags are pushed, one with the full 
 that would match that tag (for example, if `v1.30.1` were to be published, the `v1.30` tag would be updated to
 point to that instead of `v1.30.0`).
 
+## Adding extra packages at runtime
+
+By default, the official Netdata container images do not include a number of optional runtime dependencies. You
+can add these dependencies, or any other APK packages, at runtime by listing them in the environment variable
+`NETDATA_EXTRA_APK_PACKAGES`.
+
+Commonly useful packages include:
+
+- `apcupsd`: For monitoring APC UPS devices.
+- `libvirt-daemon`: For resolving cgroup names for libvirt domains.
+- `lm-sensors`: For monitoring hardware sensors.
+- `msmtp`: For email alert support.
+- `netcat-openbsd`: For IRC alert support.
+
 ## Health Checks
 
 Our Docker image provides integrated support for health checks through the standard Docker interfaces.

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -67,4 +67,19 @@ if [ -n "${NETDATA_CLAIM_URL}" ] && [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ ! -f /v
                              -daemon-not-running
 fi
 
+if [ -n "${NETDATA_EXTRA_APK_PACKAGES}" ]; then
+  echo "Fetching APK repository metadata."
+  if ! apk update; then
+    NETDATA_FAILED_APK_UPDATE=1
+    echo "Failed to fetch APK repository metadata."
+  fi
+fi
+
+if [ -n "${NETDATA_EXTRA_APK_PACKAES}" ] && [ -z "${NETDATA_FAILED_APK_UPDATE}" ]; then
+  echo "Installing supplementary packages."
+  if ! apk add --no-cache --no-interactive "${NETDATA_EXTRA_APK_PACKAGES}"; then
+    echo "Failed to install supplementary packages."
+  fi
+fi
+
 exec /usr/sbin/netdata -u "${DOCKER_USR}" -D -s /host -p "${NETDATA_LISTENER_PORT}" "$@"

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -70,15 +70,13 @@ fi
 if [ -n "${NETDATA_EXTRA_APK_PACKAGES}" ]; then
   echo "Fetching APK repository metadata."
   if ! apk update; then
-    NETDATA_FAILED_APK_UPDATE=1
     echo "Failed to fetch APK repository metadata."
-  fi
-fi
-
-if [ -n "${NETDATA_EXTRA_APK_PACKAES}" ] && [ -z "${NETDATA_FAILED_APK_UPDATE}" ]; then
-  echo "Installing supplementary packages."
-  if ! apk add --no-cache --no-interactive "${NETDATA_EXTRA_APK_PACKAGES}"; then
-    echo "Failed to install supplementary packages."
+  else
+    echo "Installing supplementary packages."
+    # shellcheck disable=SC2086
+    if ! apk add --no-cache ${NETDATA_EXTRA_APK_PACKAGES}; then
+      echo "Failed to install supplementary packages."
+    fi
   fi
 fi
 


### PR DESCRIPTION
##### Summary

This enables users to pull in additional packages more easily if they need to. It also allows us to drop optional runtime dependencies from our base images without making life significantly more difficult for users who actually need them, ultimately resulting in smaller base images for our containers.

This is handled via a new environment variable called `NETDATA_EXTRA_APK_PACKAGES`. If this is defined, then the entrypoint code will update APK repositories and attempt to install the packages listed in this variable before starting the agent.

Once Netdata v1.39 is released, we will be removing said optional runtime packages to actually shrink the image sizes. The initial list of candidate packages is apcupsd, libvirt-daemon, lm-sensors, msmtp, and netcat-openbsd. Once we transition to Alpine 3.17, nut and freeipmi will be added to the list (both require special handling currently, so we can’t easily exclude them).

##### Test Plan

All tests should be done using Docker images built from this PR.

There are two relevant cases to check:

1. Starting a container normally, in which case it should behave identically to our currently published container images.
2. Starting a container with additional packages that are not normally part of the container listed in `NETDATA_EXTRA_APK_PACKAGES` (I used htop for this purpose, as it has essentially no dependencies so it installs quickly, and it’s very easy to check for). In this case, you should get messages (almost) just like the first case, but the container should have the additional packages installed as well as what would normally be there.

##### Additional Information

Fixes: #8805