### PR TITLE
Memory management eBPF

### DIFF
--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -435,9 +435,6 @@ ebpf_sync_syscalls_t local_syscalls[] = {
 };
 
 
-// Link with apps.plugin
-ebpf_process_stat_t *global_process_stat = NULL;
-
 // Link with cgroup.plugin
 netdata_ebpf_cgroup_shm_t shm_ebpf_cgroup = {NULL, NULL};
 int shm_fd_ebpf_cgroup = -1;
@@ -1387,7 +1384,6 @@ static void ebpf_allocate_common_vectors()
     }
 
     ebpf_all_pids = callocz((size_t)pid_max, sizeof(struct ebpf_pid_stat *));
-    global_process_stat = callocz((size_t)ebpf_nprocs, sizeof(ebpf_process_stat_t));
 }
 
 /**

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -876,9 +876,9 @@ void ebpf_create_chart(char *type,
  * @param module    chart module name, this is the eBPF thread.
  */
 void ebpf_create_charts_on_apps(char *id, char *title, char *units, char *family, char *charttype, int order,
-                                char *algorithm, struct target *root, int update_every, char *module)
+                                char *algorithm, struct ebpf_target *root, int update_every, char *module)
 {
-    struct target *w;
+    struct ebpf_target *w;
     ebpf_write_chart_cmd(NETDATA_APPS_FAMILY, id, title, units, family, charttype, NULL, order,
                          update_every, module);
 

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -1386,7 +1386,7 @@ static void ebpf_allocate_common_vectors()
         return;
     }
 
-    all_pids = callocz((size_t)pid_max, sizeof(struct pid_stat *));
+    ebpf_all_pids = callocz((size_t)pid_max, sizeof(struct ebpf_pid_stat *));
     global_process_stat = callocz((size_t)ebpf_nprocs, sizeof(ebpf_process_stat_t));
 }
 

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -1384,6 +1384,7 @@ static void ebpf_allocate_common_vectors()
     }
 
     ebpf_all_pids = callocz((size_t)pid_max, sizeof(struct ebpf_pid_stat *));
+    ebpf_aral_init();
 }
 
 /**

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -264,7 +264,7 @@ void ebpf_pid_file(char *filename, size_t length);
 
 // Common variables
 extern int debug_enabled;
-extern struct pid_stat *root_of_pids;
+extern struct ebpf_pid_stat *ebpf_root_of_pids;
 extern ebpf_cgroup_target_t *ebpf_cgroup_pids;
 extern char *ebpf_algorithms[];
 extern struct config collector_config;

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -235,7 +235,7 @@ void ebpf_create_charts_on_apps(char *name,
                                        char *charttype,
                                        int order,
                                        char *algorithm,
-                                       struct target *root,
+                                       struct ebpf_target *root,
                                        int update_every,
                                        char *module);
 

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -268,7 +268,6 @@ extern struct ebpf_pid_stat *ebpf_root_of_pids;
 extern ebpf_cgroup_target_t *ebpf_cgroup_pids;
 extern char *ebpf_algorithms[];
 extern struct config collector_config;
-extern ebpf_process_stat_t *global_process_stat;
 extern netdata_ebpf_cgroup_shm_t shm_ebpf_cgroup;
 extern int shm_fd_ebpf_cgroup;
 extern sem_t *shm_sem_ebpf_cgroup;

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -273,7 +273,7 @@ extern netdata_ebpf_cgroup_shm_t shm_ebpf_cgroup;
 extern int shm_fd_ebpf_cgroup;
 extern sem_t *shm_sem_ebpf_cgroup;
 extern pthread_mutex_t mutex_cgroup_shm;
-extern size_t all_pids_count;
+extern size_t ebpf_all_pids_count;
 extern ebpf_plugin_stats_t plugin_statistics;
 #ifdef LIBBPF_MAJOR_VERSION
 extern struct btf *default_btf;

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -49,7 +49,7 @@ int ebpf_read_hash_table(void *ep, int fd, uint32_t pid)
  *
  * @return
  */
-size_t read_bandwidth_statistic_using_pid_on_target(ebpf_bandwidth_t **ep, int fd, struct pid_on_target *pids)
+size_t read_bandwidth_statistic_using_pid_on_target(ebpf_bandwidth_t **ep, int fd, struct ebpf_pid_on_target *pids)
 {
     size_t count = 0;
     while (pids) {
@@ -129,10 +129,10 @@ size_t zero_all_targets(struct ebpf_target *root)
         count++;
 
         if (unlikely(w->root_pid)) {
-            struct pid_on_target *pid_on_target = w->root_pid;
+            struct ebpf_pid_on_target *pid_on_target = w->root_pid;
 
             while (pid_on_target) {
-                struct pid_on_target *pid_on_target_to_free = pid_on_target;
+                struct ebpf_pid_on_target *pid_on_target_to_free = pid_on_target;
                 pid_on_target = pid_on_target->next;
                 freez(pid_on_target_to_free);
             }
@@ -1073,7 +1073,7 @@ static inline void aggregate_pid_on_target(struct ebpf_target *w, struct ebpf_pi
     }
 
     w->processes++;
-    struct pid_on_target *pid_on_target = mallocz(sizeof(struct pid_on_target));
+    struct ebpf_pid_on_target *pid_on_target = mallocz(sizeof(struct ebpf_pid_on_target));
     pid_on_target->pid = p->pid;
     pid_on_target->next = w->root_pid;
     w->root_pid = pid_on_target;

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -519,7 +519,7 @@ static inline struct ebpf_pid_stat *get_pid_entry(pid_t pid)
     if (unlikely(ebpf_all_pids[pid]))
         return ebpf_all_pids[pid];
 
-    struct ebpf_pid_stat *p = callocz(1, sizeof(struct ebpf_pid_stat));
+    struct ebpf_pid_stat *p = ebpf_pid_stat_get();
 
     if (likely(ebpf_root_of_pids))
         ebpf_root_of_pids->prev = p;
@@ -941,7 +941,7 @@ static inline void del_pid_entry(pid_t pid)
     freez(p->io_filename);
     freez(p->cmdline_filename);
     freez(p->cmdline);
-    freez(p);
+    ebpf_pid_stat_release(p);
 
     ebpf_all_pids[pid] = NULL;
     ebpf_all_pids_count--;

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -1069,7 +1069,7 @@ void cleanup_exited_pids()
             p = p->next;
 
             // Clean process structure
-            freez(global_process_stats[r]);
+            ebpf_process_stat_release(global_process_stats[r]);
             global_process_stats[r] = NULL;
 
             cleanup_variables_from_other_threads(r);
@@ -1183,13 +1183,13 @@ void collect_data_for_all_processes(int tbl_pid_stats_fd)
         key = pids->pid;
         ebpf_process_stat_t *w = global_process_stats[key];
         if (!w) {
-            w = callocz(1, sizeof(ebpf_process_stat_t));
+            w = ebpf_process_stat_get();
             global_process_stats[key] = w;
         }
 
         if (bpf_map_lookup_elem(tbl_pid_stats_fd, &key, w)) {
             // Clean Process structures
-            freez(w);
+            ebpf_process_stat_release(w);
             global_process_stats[key] = NULL;
 
             cleanup_variables_from_other_threads(key);

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -5,6 +5,46 @@
 #include "ebpf_apps.h"
 
 // ----------------------------------------------------------------------------
+// ARAL vectors used to speed up processing
+ARAL *ebpf_aral_apps_pid_stat;
+
+/**
+ * eBPF ARAL Init
+ *
+ * Initiallize array allocator that will be used when integration with apps and ebpf is created.
+ */
+void ebpf_aral_init(void)
+{
+    ebpf_aral_apps_pid_stat = aral_create("ebpf-pid_stat", sizeof(struct ebpf_pid_stat),
+                                          0, NETDATA_EBPF_ALLOC_MAX_PID,
+                                          NULL, NULL, NULL, false, false);
+}
+
+/**
+ * eBPF pid stat get
+ *
+ * Get a ebpf_pid_stat entry to be used with a specific PID.
+ *
+ * @return it returns the address on success.
+ */
+struct ebpf_pid_stat *ebpf_pid_stat_get(void)
+{
+    struct ebpf_pid_stat *target = aral_mallocz(ebpf_aral_apps_pid_stat);
+    memset(target, 0, sizeof(struct ebpf_pid_stat));
+    return target;
+}
+
+/**
+ * eBPF target release
+ *
+ * @param stat Release a target after usage.
+ */
+void ebpf_pid_stat_release(struct ebpf_pid_stat *stat)
+{
+    aral_freez(ebpf_aral_apps_pid_stat, stat);
+}
+
+// ----------------------------------------------------------------------------
 // internal flags
 // handled in code (automatically set)
 

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -7,6 +7,7 @@
 // ----------------------------------------------------------------------------
 // ARAL vectors used to speed up processing
 ARAL *ebpf_aral_apps_pid_stat;
+ARAL *ebpf_aral_process_stat;
 
 /**
  * eBPF ARAL Init
@@ -16,6 +17,10 @@ ARAL *ebpf_aral_apps_pid_stat;
 void ebpf_aral_init(void)
 {
     ebpf_aral_apps_pid_stat = aral_create("ebpf-pid_stat", sizeof(struct ebpf_pid_stat),
+                                          0, NETDATA_EBPF_ALLOC_MAX_PID,
+                                          NULL, NULL, NULL, false, false);
+
+    ebpf_aral_process_stat = aral_create("ebpf-proc_stat", sizeof(ebpf_process_stat_t),
                                           0, NETDATA_EBPF_ALLOC_MAX_PID,
                                           NULL, NULL, NULL, false, false);
 }
@@ -42,6 +47,30 @@ struct ebpf_pid_stat *ebpf_pid_stat_get(void)
 void ebpf_pid_stat_release(struct ebpf_pid_stat *stat)
 {
     aral_freez(ebpf_aral_apps_pid_stat, stat);
+}
+
+/**
+ * eBPF process stat get
+ *
+ * Get a ebpf_pid_stat entry to be used with a specific PID.
+ *
+ * @return it returns the address on success.
+ */
+ebpf_process_stat_t *ebpf_process_stat_get(void)
+{
+    ebpf_process_stat_t *target = aral_mallocz(ebpf_aral_process_stat);
+    memset(target, 0, sizeof(ebpf_process_stat_t));
+    return target;
+}
+
+/**
+ * eBPF process release
+ *
+ * @param stat Release a target after usage.
+ */
+void ebpf_process_stat_release(ebpf_process_stat_t *stat)
+{
+    aral_freez(ebpf_aral_process_stat, stat);
 }
 
 // ----------------------------------------------------------------------------

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -190,7 +190,7 @@ struct ebpf_target *get_apps_groups_target(struct ebpf_target **agrt, const char
     // find if it already exists
     struct ebpf_target *w, *last = *agrt;
     for (w = *agrt; w; w = w->next) {
-        if (w->idhash == hash && strncmp(nid, w->id, MAX_NAME) == 0)
+        if (w->idhash == hash && strncmp(nid, w->id, EBPF_MAX_NAME) == 0)
             return w;
 
         last = w;
@@ -216,17 +216,17 @@ struct ebpf_target *get_apps_groups_target(struct ebpf_target **agrt, const char
             target->id, target->target->id);
 
     w = callocz(1, sizeof(struct ebpf_target));
-    strncpyz(w->id, nid, MAX_NAME);
+    strncpyz(w->id, nid, EBPF_MAX_NAME);
     w->idhash = simple_hash(w->id);
 
     if (unlikely(!target))
         // copy the name
-        strncpyz(w->name, name, MAX_NAME);
+        strncpyz(w->name, name, EBPF_MAX_NAME);
     else
         // copy the id
-        strncpyz(w->name, nid, MAX_NAME);
+        strncpyz(w->name, nid, EBPF_MAX_NAME);
 
-    strncpyz(w->compare, nid, MAX_COMPARE_NAME);
+    strncpyz(w->compare, nid, EBPF_MAX_COMPARE_NAME);
     size_t len = strlen(w->compare);
     if (w->compare[len - 1] == '*') {
         w->compare[len - 1] = '\0';
@@ -345,8 +345,6 @@ int ebpf_read_apps_groups_conf(struct ebpf_target **agdt, struct ebpf_target **a
 // ----------------------------------------------------------------------------
 // string lengths
 
-#define MAX_COMPARE_NAME 100
-#define MAX_NAME 100
 #define MAX_CMDLINE 16384
 
 struct ebpf_pid_stat **ebpf_all_pids = NULL;    // to avoid allocations, we pre-allocate the
@@ -640,7 +638,7 @@ static inline int read_proc_pid_stat(struct ebpf_pid_stat *p, void *ptr)
                 debug_log("\tJust added %d (%s)", p->pid, comm);
         }
 
-        strncpyz(p->comm, comm, MAX_COMPARE_NAME);
+        strncpyz(p->comm, comm, EBPF_MAX_COMPARE_NAME);
 
         // /proc/<pid>/cmdline
         if (likely(proc_pid_cmdline_is_needed))

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -1043,9 +1043,6 @@ void cleanup_exited_pids()
             freez(global_process_stats[r]);
             global_process_stats[r] = NULL;
 
-            freez(current_apps_data[r]);
-            current_apps_data[r] = NULL;
-
             cleanup_variables_from_other_threads(r);
 
             del_pid_entry(r);
@@ -1165,9 +1162,6 @@ void collect_data_for_all_processes(int tbl_pid_stats_fd)
             // Clean Process structures
             freez(w);
             global_process_stats[key] = NULL;
-
-            freez(current_apps_data[key]);
-            current_apps_data[key] = NULL;
 
             cleanup_variables_from_other_threads(key);
 

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -16,6 +16,12 @@ ARAL *ebpf_aral_process_stat;
  */
 void ebpf_aral_init(void)
 {
+    size_t max_elements = NETDATA_EBPF_ALLOC_MAX_PID;
+    if (max_elements < NETDATA_EBPF_ALLOC_MIN_ELEMENTS) {
+        error("Number of elements given is too small, adjusting it for %d", NETDATA_EBPF_ALLOC_MIN_ELEMENTS);
+        max_elements = NETDATA_EBPF_ALLOC_MIN_ELEMENTS;
+    }
+
     ebpf_aral_apps_pid_stat = aral_create("ebpf-pid_stat", sizeof(struct ebpf_pid_stat),
                                           0, NETDATA_EBPF_ALLOC_MAX_PID,
                                           NULL, NULL, NULL, false, false);

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -23,11 +23,11 @@ void ebpf_aral_init(void)
     }
 
     ebpf_aral_apps_pid_stat = aral_create("ebpf-pid_stat", sizeof(struct ebpf_pid_stat),
-                                          0, NETDATA_EBPF_ALLOC_MAX_PID,
+                                          0, max_elements,
                                           NULL, NULL, NULL, false, false);
 
     ebpf_aral_process_stat = aral_create("ebpf-proc_stat", sizeof(ebpf_process_stat_t),
-                                          0, NETDATA_EBPF_ALLOC_MAX_PID,
+                                          0, max_elements,
                                           NULL, NULL, NULL, false, false);
 #ifdef NETDATA_DEV_MODE
     info("Plugin is using ARAL with values %d", NETDATA_EBPF_ALLOC_MAX_PID);

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -23,6 +23,9 @@ void ebpf_aral_init(void)
     ebpf_aral_process_stat = aral_create("ebpf-proc_stat", sizeof(ebpf_process_stat_t),
                                           0, NETDATA_EBPF_ALLOC_MAX_PID,
                                           NULL, NULL, NULL, false, false);
+#ifdef NETDATA_DEV_MODE
+    info("Plugin is using ARAL with values %d", NETDATA_EBPF_ALLOC_MAX_PID);
+#endif
 }
 
 /**

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -47,7 +47,7 @@ struct pid_fd {
     int fd;
 };
 
-struct target {
+struct ebpf_target {
     char compare[MAX_COMPARE_NAME + 1];
     uint32_t comparehash;
     size_t comparelen;
@@ -57,9 +57,6 @@ struct target {
 
     char name[MAX_NAME + 1];
 
-    uid_t uid;
-    gid_t gid;
-
     // Changes made to simplify integration between apps and eBPF.
     netdata_publish_cachestat_t cachestat;
     netdata_publish_dcstat_t dcstat;
@@ -68,57 +65,8 @@ struct target {
     netdata_fd_stat_t fd;
     netdata_publish_shm_t shm;
 
-    /* These variables are not necessary for eBPF collector
-    kernel_uint_t minflt;
-    kernel_uint_t cminflt;
-    kernel_uint_t majflt;
-    kernel_uint_t cmajflt;
-    kernel_uint_t utime;
-    kernel_uint_t stime;
-    kernel_uint_t gtime;
-    kernel_uint_t cutime;
-    kernel_uint_t cstime;
-    kernel_uint_t cgtime;
-    kernel_uint_t num_threads;
-    // kernel_uint_t rss;
-
-    kernel_uint_t status_vmsize;
-    kernel_uint_t status_vmrss;
-    kernel_uint_t status_vmshared;
-    kernel_uint_t status_rssfile;
-    kernel_uint_t status_rssshmem;
-    kernel_uint_t status_vmswap;
-
-    kernel_uint_t io_logical_bytes_read;
-    kernel_uint_t io_logical_bytes_written;
-    // kernel_uint_t io_read_calls;
-    // kernel_uint_t io_write_calls;
-    kernel_uint_t io_storage_bytes_read;
-    kernel_uint_t io_storage_bytes_written;
-    // kernel_uint_t io_cancelled_write_bytes;
-
-    int *target_fds;
-    int target_fds_size;
-
-    kernel_uint_t openfiles;
-    kernel_uint_t openpipes;
-    kernel_uint_t opensockets;
-    kernel_uint_t openinotifies;
-    kernel_uint_t openeventfds;
-    kernel_uint_t opentimerfds;
-    kernel_uint_t opensignalfds;
-    kernel_uint_t openeventpolls;
-    kernel_uint_t openother;
-    */
-
     kernel_uint_t starttime;
     kernel_uint_t collected_starttime;
-
-    /*
-    kernel_uint_t uptime_min;
-    kernel_uint_t uptime_sum;
-    kernel_uint_t uptime_max;
-    */
 
     unsigned int processes; // how many processes have been merged to this
     int exposed;            // if set, we have sent this to netdata
@@ -130,14 +78,14 @@ struct target {
 
     struct pid_on_target *root_pid; // list of aggregated pids for target debugging
 
-    struct target *target; // the one that will be reported to netdata
-    struct target *next;
+    struct ebpf_target *target; // the one that will be reported to netdata
+    struct ebpf_target *next;
 };
 
-extern struct target *apps_groups_default_target;
-extern struct target *apps_groups_root_target;
-extern struct target *users_root_target;
-extern struct target *groups_root_target;
+extern struct ebpf_target *apps_groups_default_target;
+extern struct ebpf_target *apps_groups_root_target;
+extern struct ebpf_target *users_root_target;
+extern struct ebpf_target *groups_root_target;
 
 struct ebpf_pid_stat {
     int32_t pid;
@@ -164,9 +112,9 @@ struct ebpf_pid_stat {
 
     // each process gets a unique number
 
-    struct target *target;       // app_groups.conf targets
-    struct target *user_target;  // uid based targets
-    struct target *group_target; // gid based targets
+    struct ebpf_target *target;       // app_groups.conf targets
+    struct ebpf_target *user_target;  // uid based targets
+    struct ebpf_target *group_target; // gid based targets
 
     usec_t stat_collected_usec;
     usec_t last_stat_collected_usec;
@@ -260,14 +208,14 @@ static inline void debug_log_int(const char *fmt, ...)
 //
 extern struct ebpf_pid_stat **all_pids;
 
-int ebpf_read_apps_groups_conf(struct target **apps_groups_default_target,
-                                      struct target **apps_groups_root_target,
-                                      const char *path,
-                                      const char *file);
+int ebpf_read_apps_groups_conf(struct ebpf_target **apps_groups_default_target,
+                               struct ebpf_target **apps_groups_root_target,
+                               const char *path,
+                               const char *file);
 
-void clean_apps_groups_target(struct target *apps_groups_root_target);
+void clean_apps_groups_target(struct ebpf_target *apps_groups_root_target);
 
-size_t zero_all_targets(struct target *root);
+size_t zero_all_targets(struct ebpf_target *root);
 
 int am_i_running_as_root();
 

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -34,21 +34,21 @@
 #include "ebpf_swap.h"
 #include "ebpf_vfs.h"
 
-#define MAX_COMPARE_NAME 100
-#define MAX_NAME 100
+#define EBPF_MAX_COMPARE_NAME 100
+#define EBPF_MAX_NAME 100
 
 // ----------------------------------------------------------------------------
 // pid_stat
 //
 struct ebpf_target {
-    char compare[MAX_COMPARE_NAME + 1];
+    char compare[EBPF_MAX_COMPARE_NAME + 1];
     uint32_t comparehash;
     size_t comparelen;
 
-    char id[MAX_NAME + 1];
+    char id[EBPF_MAX_NAME + 1];
     uint32_t idhash;
 
-    char name[MAX_NAME + 1];
+    char name[EBPF_MAX_NAME + 1];
 
     // Changes made to simplify integration between apps and eBPF.
     netdata_publish_cachestat_t cachestat;
@@ -82,7 +82,7 @@ extern struct ebpf_target *groups_root_target;
 
 struct ebpf_pid_stat {
     int32_t pid;
-    char comm[MAX_COMPARE_NAME + 1];
+    char comm[EBPF_MAX_COMPARE_NAME + 1];
     char *cmdline;
 
     uint32_t log_thrown;

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -69,7 +69,7 @@ struct ebpf_target {
     int starts_with; // if set, the compare string matches only the
                      // beginning of the command
 
-    struct pid_on_target *root_pid; // list of aggregated pids for target debugging
+    struct ebpf_pid_on_target *root_pid; // list of aggregated pids for target debugging
 
     struct ebpf_target *target; // the one that will be reported to netdata
     struct ebpf_target *next;
@@ -127,9 +127,9 @@ struct ebpf_pid_stat {
 //
 // - Each entry in /etc/apps_groups.conf creates a target.
 // - Each user and group used by a process in the system, creates a target.
-struct pid_on_target {
+struct ebpf_pid_on_target {
     int32_t pid;
-    struct pid_on_target *next;
+    struct ebpf_pid_on_target *next;
 };
 
 // ----------------------------------------------------------------------------
@@ -210,9 +210,9 @@ int get_pid_comm(pid_t pid, size_t n, char *dest);
 
 size_t read_processes_statistic_using_pid_on_target(ebpf_process_stat_t **ep,
                                                            int fd,
-                                                           struct pid_on_target *pids);
+                                                           struct ebpf_pid_on_target *pids);
 
-size_t read_bandwidth_statistic_using_pid_on_target(ebpf_bandwidth_t **ep, int fd, struct pid_on_target *pids);
+size_t read_bandwidth_statistic_using_pid_on_target(ebpf_bandwidth_t **ep, int fd, struct ebpf_pid_on_target *pids);
 
 void collect_data_for_all_processes(int tbl_pid_stats_fd);
 

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -227,7 +227,6 @@ size_t read_bandwidth_statistic_using_pid_on_target(ebpf_bandwidth_t **ep, int f
 void collect_data_for_all_processes(int tbl_pid_stats_fd);
 
 extern ebpf_process_stat_t **global_process_stats;
-extern ebpf_process_publish_apps_t **current_apps_data;
 extern netdata_publish_cachestat_t **cachestat_pid;
 extern netdata_publish_dcstat_t **dcstat_pid;
 

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -189,7 +189,7 @@ static inline void debug_log_int(const char *fmt, ...)
 // ----------------------------------------------------------------------------
 // Exported variabled and functions
 //
-extern struct ebpf_pid_stat **all_pids;
+extern struct ebpf_pid_stat **ebpf_all_pids;
 
 int ebpf_read_apps_groups_conf(struct ebpf_target **apps_groups_default_target,
                                struct ebpf_target **apps_groups_root_target,

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -3,17 +3,6 @@
 #ifndef NETDATA_EBPF_APPS_H
 #define NETDATA_EBPF_APPS_H 1
 
-// The default value is at least 32 times smaller than maximum number of PIDs allowed on system,
-// this is only possible because we are using ARAL (https://github.com/netdata/netdata/tree/master/libnetdata/aral).
-#ifndef NETDATA_EBPF_ALLOC_MAX_PID
-# define NETDATA_EBPF_ALLOC_MAX_PID 1024
-#endif
-
-extern ARAL *ebpf_aral_apps_pid_stat;
-void ebpf_aral_init(void);
-struct ebpf_pid_stat *ebpf_target_get(void);
-
-#include "libnetdata/threads/threads.h"
 #include "libnetdata/locks/locks.h"
 #include "libnetdata/avl/avl.h"
 #include "libnetdata/clocks/clocks.h"
@@ -229,5 +218,20 @@ void collect_data_for_all_processes(int tbl_pid_stats_fd);
 extern ebpf_process_stat_t **global_process_stats;
 extern netdata_publish_cachestat_t **cachestat_pid;
 extern netdata_publish_dcstat_t **dcstat_pid;
+
+// The default value is at least 32 times smaller than maximum number of PIDs allowed on system,
+// this is only possible because we are using ARAL (https://github.com/netdata/netdata/tree/master/libnetdata/aral).
+#ifndef NETDATA_EBPF_ALLOC_MAX_PID
+# define NETDATA_EBPF_ALLOC_MAX_PID 1024
+#endif
+
+extern void ebpf_aral_init(void);
+
+extern struct ebpf_pid_stat *ebpf_target_get(void);
+
+extern ebpf_process_stat_t *ebpf_process_stat_get(void);
+extern void ebpf_process_stat_release(ebpf_process_stat_t *stat);
+
+#include "libnetdata/threads/threads.h"
 
 #endif /* NETDATA_EBPF_APPS_H */

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -224,6 +224,7 @@ extern netdata_publish_dcstat_t **dcstat_pid;
 #ifndef NETDATA_EBPF_ALLOC_MAX_PID
 # define NETDATA_EBPF_ALLOC_MAX_PID 1024
 #endif
+#define NETDATA_EBPF_ALLOC_MIN_ELEMENTS 256
 
 extern void ebpf_aral_init(void);
 

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -3,6 +3,16 @@
 #ifndef NETDATA_EBPF_APPS_H
 #define NETDATA_EBPF_APPS_H 1
 
+// The default value is at least 32 times smaller than maximum number of PIDs allowed on system,
+// this is only possible because we are using ARAL (https://github.com/netdata/netdata/tree/master/libnetdata/aral).
+#ifndef NETDATA_EBPF_ALLOC_MAX_PID
+# define NETDATA_EBPF_ALLOC_MAX_PID 1024
+#endif
+
+extern ARAL *ebpf_aral_apps_pid_stat;
+void ebpf_aral_init(void);
+struct ebpf_pid_stat *ebpf_target_get(void);
+
 #include "libnetdata/threads/threads.h"
 #include "libnetdata/locks/locks.h"
 #include "libnetdata/avl/avl.h"

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -40,13 +40,6 @@
 // ----------------------------------------------------------------------------
 // pid_stat
 //
-// structure to store data for each process running
-// see: man proc for the description of the fields
-
-struct pid_fd {
-    int fd;
-};
-
 struct ebpf_target {
     char compare[MAX_COMPARE_NAME + 1];
     uint32_t comparehash;
@@ -97,9 +90,6 @@ struct ebpf_pid_stat {
     // char state;
     int32_t ppid;
 
-    struct pid_fd *fds; // array of fds it uses
-    size_t fds_size;    // the size of the fds array
-
     int children_count;              // number of processes directly referencing this
     unsigned char keep : 1;          // 1 when we need to keep this process in memory even after it exited
     int keeploops;                   // increases by 1 every time keep is 1 and updated 0
@@ -118,13 +108,6 @@ struct ebpf_pid_stat {
 
     usec_t stat_collected_usec;
     usec_t last_stat_collected_usec;
-
-    usec_t io_collected_usec;
-    usec_t last_io_collected_usec;
-
-    kernel_uint_t uptime;
-
-    char *fds_dirname; // the full directory name in /proc/PID/fd
 
     char *stat_filename;
     char *status_filename;
@@ -152,7 +135,7 @@ struct pid_on_target {
 // ----------------------------------------------------------------------------
 // Structures used to read information from kernel ring
 typedef struct ebpf_process_stat {
-    uint64_t pid_tgid;
+    uint64_t pid_tgid; // This cannot be removed, because it is used inside kernel ring.
     uint32_t pid;
 
     //Counter

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -521,7 +521,7 @@ static void read_apps_table()
 {
     netdata_cachestat_pid_t *cv = cachestat_vector;
     uint32_t key;
-    struct pid_stat *pids = root_of_pids;
+    struct ebpf_pid_stat *pids = ebpf_root_of_pids;
     int fd = cachestat_maps[NETDATA_CACHESTAT_PID_STATS].map_fd;
     size_t length = sizeof(netdata_cachestat_pid_t)*ebpf_nprocs;
     while (pids) {

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -589,7 +589,7 @@ static void ebpf_update_cachestat_cgroup()
  */
 void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
 {
-    struct target *root = ptr;
+    struct ebpf_target *root = ptr;
     ebpf_create_charts_on_apps(NETDATA_CACHESTAT_HIT_RATIO_CHART,
                                "Hit ratio",
                                EBPF_COMMON_DIMENSION_PERCENTAGE,
@@ -720,9 +720,9 @@ void ebpf_cachestat_sum_pids(netdata_publish_cachestat_t *publish, struct pid_on
  *
  * @param root the target list.
 */
-void ebpf_cache_send_apps_data(struct target *root)
+void ebpf_cache_send_apps_data(struct ebpf_target *root)
 {
-    struct target *w;
+    struct ebpf_target *w;
     collected_number value;
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_CACHESTAT_HIT_RATIO_CHART);

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -694,7 +694,7 @@ static void cachestat_send_global(netdata_publish_cachestat_t *publish)
  * @param publish  output structure.
  * @param root     structure with listed IPs
  */
-void ebpf_cachestat_sum_pids(netdata_publish_cachestat_t *publish, struct pid_on_target *root)
+void ebpf_cachestat_sum_pids(netdata_publish_cachestat_t *publish, struct ebpf_pid_on_target *root)
 {
     memcpy(&publish->prev, &publish->current,sizeof(publish->current));
     memset(&publish->current, 0, sizeof(publish->current));

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -342,7 +342,7 @@ static void ebpf_dcstat_exit(void *ptr)
  */
 void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr)
 {
-    struct target *root = ptr;
+    struct ebpf_target *root = ptr;
     ebpf_create_charts_on_apps(NETDATA_DC_HIT_CHART,
                                "Percentage of files inside directory cache",
                                EBPF_COMMON_DIMENSION_PERCENTAGE,
@@ -563,9 +563,9 @@ void ebpf_dcstat_sum_pids(netdata_publish_dcstat_t *publish, struct pid_on_targe
  *
  * @param root the target list.
 */
-void ebpf_dcache_send_apps_data(struct target *root)
+void ebpf_dcache_send_apps_data(struct ebpf_target *root)
 {
-    struct target *w;
+    struct ebpf_target *w;
     collected_number value;
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_DC_HIT_CHART);

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -448,7 +448,7 @@ static void read_apps_table()
 {
     netdata_dcstat_pid_t *cv = dcstat_vector;
     uint32_t key;
-    struct pid_stat *pids = root_of_pids;
+    struct ebpf_pid_stat *pids = ebpf_root_of_pids;
     int fd = dcstat_maps[NETDATA_DCSTAT_PID_STATS].map_fd;
     size_t length = sizeof(netdata_dcstat_pid_t)*ebpf_nprocs;
     while (pids) {

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -540,7 +540,7 @@ static void ebpf_dc_read_global_table()
  * @param publish  output structure.
  * @param root     structure with listed IPs
  */
-void ebpf_dcstat_sum_pids(netdata_publish_dcstat_t *publish, struct pid_on_target *root)
+void ebpf_dcstat_sum_pids(netdata_publish_dcstat_t *publish, struct ebpf_pid_on_target *root)
 {
     memset(&publish->curr, 0, sizeof(netdata_dcstat_pid_t));
     netdata_dcstat_pid_t *dst = &publish->curr;

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -593,9 +593,9 @@ static void ebpf_fd_sum_pids(netdata_fd_stat_t *fd, struct pid_on_target *root)
  * @param em   the structure with thread information
  * @param root the target list.
 */
-void ebpf_fd_send_apps_data(ebpf_module_t *em, struct target *root)
+void ebpf_fd_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 {
-    struct target *w;
+    struct ebpf_target *w;
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             ebpf_fd_sum_pids(&w->fd, w->root_pid);
@@ -972,7 +972,7 @@ static void fd_collector(ebpf_module_t *em)
  */
 void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr)
 {
-    struct target *root = ptr;
+    struct ebpf_target *root = ptr;
     ebpf_create_charts_on_apps(NETDATA_SYSCALL_APPS_FILE_OPEN,
                                "Number of open files",
                                EBPF_COMMON_DIMENSION_CALL,

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -495,7 +495,7 @@ static void read_apps_table()
 {
     netdata_fd_stat_t *fv = fd_vector;
     uint32_t key;
-    struct pid_stat *pids = root_of_pids;
+    struct ebpf_pid_stat *pids = ebpf_root_of_pids;
     int fd = fd_maps[NETDATA_FD_PID_STATS].map_fd;
     size_t length = sizeof(netdata_fd_stat_t) * ebpf_nprocs;
     while (pids) {

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -560,7 +560,7 @@ static void ebpf_update_fd_cgroup()
  * @param fd   the output
  * @param root list of pids
  */
-static void ebpf_fd_sum_pids(netdata_fd_stat_t *fd, struct pid_on_target *root)
+static void ebpf_fd_sum_pids(netdata_fd_stat_t *fd, struct ebpf_pid_on_target *root)
 {
     uint32_t open_call = 0;
     uint32_t close_call = 0;

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -361,7 +361,7 @@ void *ebpf_oomkill_thread(void *ptr)
     em->maps = oomkill_maps;
 
 #define NETDATA_DEFAULT_OOM_DISABLED_MSG "Disabling OOMKILL thread, because"
-    if (unlikely(!all_pids || !em->apps_charts)) {
+    if (unlikely(!ebpf_all_pids || !em->apps_charts)) {
         // When we are not running integration with apps, we won't fill necessary variables for this thread to run, so
         // we need to disable it.
         if (em->thread->enabled)

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -58,7 +58,7 @@ static void oomkill_write_data(int32_t *keys, uint32_t total)
     for (w = apps_groups_root_target; w != NULL; w = w->next) {
         if (likely(w->exposed && w->processes)) {
             bool was_oomkilled = false;
-            struct pid_on_target *pids = w->root_pid;
+            struct ebpf_pid_on_target *pids = w->root_pid;
             while (pids) {
                 uint32_t j;
                 for (j = 0; j < total; j++) {

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -54,7 +54,7 @@ static void oomkill_cleanup(void *ptr)
 static void oomkill_write_data(int32_t *keys, uint32_t total)
 {
     // for each app, see if it was OOM killed. record as 1 if so otherwise 0.
-    struct target *w;
+    struct ebpf_target *w;
     for (w = apps_groups_root_target; w != NULL; w = w->next) {
         if (likely(w->exposed && w->processes)) {
             bool was_oomkilled = false;
@@ -334,7 +334,7 @@ static void oomkill_collector(ebpf_module_t *em)
  */
 void ebpf_oomkill_create_apps_charts(struct ebpf_module *em, void *ptr)
 {
-    struct target *root = ptr;
+    struct ebpf_target *root = ptr;
     ebpf_create_charts_on_apps(NETDATA_OOMKILL_CHART,
                                "OOM kills",
                                EBPF_COMMON_DIMENSION_KILLS,

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -171,7 +171,7 @@ void ebpf_process_remove_pids()
         uint32_t pid = pids->pid;
         ebpf_process_stat_t *w = global_process_stats[pid];
         if (w) {
-            freez(w);
+            ebpf_process_stat_release(w);
             global_process_stats[pid] = NULL;
             bpf_map_delete_elem(pid_fd, &pid);
         }

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -166,7 +166,7 @@ long long ebpf_process_sum_values_for_pids(struct pid_on_target *root, size_t of
  */
 void ebpf_process_remove_pids()
 {
-    struct pid_stat *pids = root_of_pids;
+    struct ebpf_pid_stat *pids = ebpf_root_of_pids;
     int pid_fd = process_maps[NETDATA_PROCESS_PID_TABLE].map_fd;
     while (pids) {
         uint32_t pid = pids->pid;
@@ -288,7 +288,7 @@ static void read_hash_global_tables()
  */
 static void ebpf_process_update_apps_data()
 {
-    struct pid_stat *pids = root_of_pids;
+    struct ebpf_pid_stat *pids = ebpf_root_of_pids;
     while (pids) {
         uint32_t current_pid = pids->pid;
         ebpf_process_stat_t *ps = global_process_stats[current_pid];

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -43,7 +43,6 @@ static netdata_syscall_stat_t process_aggregated_data[NETDATA_KEY_PUBLISH_PROCES
 static netdata_publish_syscall_t process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_END];
 
 ebpf_process_stat_t **global_process_stats = NULL;
-ebpf_process_publish_apps_t **current_apps_data = NULL;
 
 int process_enabled = 0;
 bool publish_internal_metrics = true;
@@ -138,7 +137,6 @@ static void ebpf_process_send_data(ebpf_module_t *em)
  * Sum values for pid
  *
  * @param root the structure with all available PIDs
- *
  * @param offset the address that we are reading
  *
  * @return it returns the sum of all PIDs
@@ -148,9 +146,10 @@ long long ebpf_process_sum_values_for_pids(struct ebpf_pid_on_target *root, size
     long long ret = 0;
     while (root) {
         int32_t pid = root->pid;
-        ebpf_process_publish_apps_t *w = current_apps_data[pid];
+        ebpf_process_stat_t *w = global_process_stats[pid];
         if (w) {
-            ret += get_value_from_structure((char *)w, offset);
+            uint32_t *value = (uint32_t *)((char *)w + offset);
+            ret += *value;
         }
 
         root = root->next;
@@ -194,7 +193,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_PROCESS);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_publish_apps_t, create_process));
+            value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t, create_process));
             write_chart_dimension(w->name, value);
         }
     }
@@ -203,7 +202,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_THREAD);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_publish_apps_t, create_thread));
+            value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t, create_thread));
             write_chart_dimension(w->name, value);
         }
     }
@@ -212,8 +211,8 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_EXIT);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_publish_apps_t,
-                                                                           call_do_exit));
+            value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t,
+                                                                           exit_call));
             write_chart_dimension(w->name, value);
         }
     }
@@ -222,8 +221,8 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_CLOSE);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_publish_apps_t,
-                                                                           call_release_task));
+            value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t,
+                                                                           release_call));
             write_chart_dimension(w->name, value);
         }
     }
@@ -233,7 +232,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
         write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_ERROR);
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed && w->processes)) {
-                value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_publish_apps_t,
+                value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t,
                                                                                task_err));
                 write_chart_dimension(w->name, value);
             }
@@ -281,38 +280,6 @@ static void read_hash_global_tables()
 
     process_aggregated_data[NETDATA_KEY_PUBLISH_PROCESS_FORK].ecall = res[NETDATA_KEY_ERROR_DO_FORK];
     process_aggregated_data[NETDATA_KEY_PUBLISH_PROCESS_CLONE].ecall = res[NETDATA_KEY_ERROR_SYS_CLONE];
-}
-
-/**
- * Read the hash table and store data to allocated vectors.
- */
-static void ebpf_process_update_apps_data()
-{
-    struct ebpf_pid_stat *pids = ebpf_root_of_pids;
-    while (pids) {
-        uint32_t current_pid = pids->pid;
-        ebpf_process_stat_t *ps = global_process_stats[current_pid];
-        if (!ps) {
-            pids = pids->next;
-            continue;
-        }
-
-        ebpf_process_publish_apps_t *cad = current_apps_data[current_pid];
-        if (!cad) {
-            cad = callocz(1, sizeof(ebpf_process_publish_apps_t));
-            current_apps_data[current_pid] = cad;
-        }
-
-        //Read data
-        cad->call_do_exit = ps->exit_call;
-        cad->call_release_task = ps->release_call;
-        cad->create_process = ps->create_process;
-        cad->create_thread = ps->create_thread;
-
-        cad->task_err = ps->task_err;
-
-        pids = pids->next;
-    }
 }
 
 /**
@@ -1080,10 +1047,6 @@ static void process_collector(ebpf_module_t *em)
 
             ebpf_create_apps_charts(apps_groups_root_target);
             if (ebpf_all_pids_count > 0) {
-                if (apps_enabled) {
-                    ebpf_process_update_apps_data();
-                }
-
                 if (cgroups && shm_ebpf_cgroup.header) {
                     ebpf_update_process_cgroup();
                 }
@@ -1133,7 +1096,6 @@ static void ebpf_process_allocate_global_vectors(size_t length)
     process_hash_values = callocz(ebpf_nprocs, sizeof(netdata_idx_t));
 
     global_process_stats = callocz((size_t)pid_max, sizeof(ebpf_process_stat_t *));
-    current_apps_data = callocz((size_t)pid_max, sizeof(ebpf_process_publish_apps_t *));
 }
 
 static void change_syscalls()

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -186,9 +186,9 @@ void ebpf_process_remove_pids()
  *
  * @param root the target list.
  */
-void ebpf_process_send_apps_data(struct target *root, ebpf_module_t *em)
+void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
 {
-    struct target *w;
+    struct ebpf_target *w;
     collected_number value;
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_PROCESS);
@@ -532,7 +532,7 @@ static void ebpf_create_statistic_charts(ebpf_module_t *em)
  */
 void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
 {
-    struct target *root = ptr;
+    struct ebpf_target *root = ptr;
     ebpf_create_charts_on_apps(NETDATA_SYSCALL_APPS_TASK_PROCESS,
                                "Process started",
                                EBPF_COMMON_DIMENSION_CALL,
@@ -591,12 +591,12 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
  *
  * @param root a pointer for the targets.
  */
-static void ebpf_create_apps_charts(struct target *root)
+static void ebpf_create_apps_charts(struct ebpf_target *root)
 {
     if (unlikely(!all_pids))
         return;
 
-    struct target *w;
+    struct ebpf_target *w;
     int newly_added = 0;
 
     for (w = root; w; w = w->next) {

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -593,7 +593,7 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
  */
 static void ebpf_create_apps_charts(struct ebpf_target *root)
 {
-    if (unlikely(!all_pids))
+    if (unlikely(!ebpf_all_pids))
         return;
 
     struct ebpf_target *w;
@@ -1079,7 +1079,7 @@ static void process_collector(ebpf_module_t *em)
             pthread_mutex_lock(&collect_data_mutex);
 
             ebpf_create_apps_charts(apps_groups_root_target);
-            if (all_pids_count > 0) {
+            if (ebpf_all_pids_count > 0) {
                 if (apps_enabled) {
                     ebpf_process_update_apps_data();
                 }

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -143,7 +143,7 @@ static void ebpf_process_send_data(ebpf_module_t *em)
  *
  * @return it returns the sum of all PIDs
  */
-long long ebpf_process_sum_values_for_pids(struct pid_on_target *root, size_t offset)
+long long ebpf_process_sum_values_for_pids(struct ebpf_pid_on_target *root, size_t offset)
 {
     long long ret = 0;
     while (root) {
@@ -604,7 +604,7 @@ static void ebpf_create_apps_charts(struct ebpf_target *root)
             continue;
 
         if (unlikely(w->processes && (debug_enabled || w->debug_enabled))) {
-            struct pid_on_target *pid_on_target;
+            struct ebpf_pid_on_target *pid_on_target;
 
             fprintf(
                 stderr, "ebpf.plugin: target '%s' has aggregated %u process%s:", w->name, w->processes,

--- a/collectors/ebpf.plugin/ebpf_process.h
+++ b/collectors/ebpf.plugin/ebpf_process.h
@@ -85,17 +85,6 @@ typedef enum netdata_publish_process {
     NETDATA_KEY_PUBLISH_PROCESS_END
 } netdata_publish_process_t;
 
-typedef struct ebpf_process_publish_apps {
-    // Number of calls during the last read
-    uint64_t call_do_exit;
-    uint64_t call_release_task;
-    uint64_t create_process;
-    uint64_t create_thread;
-
-    // Number of errors during the last read
-    uint64_t task_err;
-} ebpf_process_publish_apps_t;
-
 enum ebpf_process_tables {
     NETDATA_PROCESS_PID_TABLE,
     NETDATA_PROCESS_GLOBAL_TABLE,

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -487,7 +487,7 @@ static void ebpf_shm_read_global_table()
 /**
  * Sum values for all targets.
  */
-static void ebpf_shm_sum_pids(netdata_publish_shm_t *shm, struct pid_on_target *root)
+static void ebpf_shm_sum_pids(netdata_publish_shm_t *shm, struct ebpf_pid_on_target *root)
 {
     while (root) {
         int32_t pid = root->pid;

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -411,7 +411,7 @@ static void read_apps_table()
 {
     netdata_publish_shm_t *cv = shm_vector;
     uint32_t key;
-    struct pid_stat *pids = root_of_pids;
+    struct ebpf_pid_stat *pids = ebpf_root_of_pids;
     int fd = shm_maps[NETDATA_PID_SHM_TABLE].map_fd;
     size_t length = sizeof(netdata_publish_shm_t)*ebpf_nprocs;
     while (pids) {

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -513,9 +513,9 @@ static void ebpf_shm_sum_pids(netdata_publish_shm_t *shm, struct pid_on_target *
  *
  * @param root the target list.
 */
-void ebpf_shm_send_apps_data(struct target *root)
+void ebpf_shm_send_apps_data(struct ebpf_target *root)
 {
-    struct target *w;
+    struct ebpf_target *w;
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             ebpf_shm_sum_pids(&w->shm, w->root_pid);
@@ -895,7 +895,7 @@ static void shm_collector(ebpf_module_t *em)
  */
 void ebpf_shm_create_apps_charts(struct ebpf_module *em, void *ptr)
 {
-    struct target *root = ptr;
+    struct ebpf_target *root = ptr;
     ebpf_create_charts_on_apps(NETDATA_SHMGET_CHART,
                                "Calls to syscall <code>shmget(2)</code>.",
                                EBPF_COMMON_DIMENSION_CALL,

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -958,7 +958,7 @@ static void ebpf_socket_send_data(ebpf_module_t *em)
  *
  * @return it returns the sum of all PIDs
  */
-long long ebpf_socket_sum_values_for_pids(struct pid_on_target *root, size_t offset)
+long long ebpf_socket_sum_values_for_pids(struct ebpf_pid_on_target *root, size_t offset)
 {
     long long ret = 0;
     while (root) {

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -980,11 +980,11 @@ long long ebpf_socket_sum_values_for_pids(struct pid_on_target *root, size_t off
  * @param em   the structure with thread information
  * @param root the target list.
  */
-void ebpf_socket_send_apps_data(ebpf_module_t *em, struct target *root)
+void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 {
     UNUSED(em);
 
-    struct target *w;
+    struct ebpf_target *w;
     collected_number value;
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V4);
@@ -1217,7 +1217,7 @@ static void ebpf_create_global_charts(ebpf_module_t *em)
  */
 void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
 {
-    struct target *root = ptr;
+    struct ebpf_target *root = ptr;
     int order = 20080;
     ebpf_create_charts_on_apps(NETDATA_NET_APPS_CONNECTION_TCP_V4,
                                "Calls to tcp_v4_connection", EBPF_COMMON_DIMENSION_CONNECTIONS,

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -2275,7 +2275,7 @@ static void ebpf_socket_update_apps_data()
     int fd = socket_maps[NETDATA_SOCKET_TABLE_BANDWIDTH].map_fd;
     ebpf_bandwidth_t *eb = bandwidth_vector;
     uint32_t key;
-    struct pid_stat *pids = root_of_pids;
+    struct ebpf_pid_stat *pids = ebpf_root_of_pids;
     while (pids) {
         key = pids->pid;
 

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -410,7 +410,7 @@ static void ebpf_swap_read_global_table()
  * @param swap
  * @param root
  */
-static void ebpf_swap_sum_pids(netdata_publish_swap_t *swap, struct pid_on_target *root)
+static void ebpf_swap_sum_pids(netdata_publish_swap_t *swap, struct ebpf_pid_on_target *root)
 {
     uint64_t local_read = 0;
     uint64_t local_write = 0;

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -435,9 +435,9 @@ static void ebpf_swap_sum_pids(netdata_publish_swap_t *swap, struct pid_on_targe
  *
  * @param root the target list.
 */
-void ebpf_swap_send_apps_data(struct target *root)
+void ebpf_swap_send_apps_data(struct ebpf_target *root)
 {
-    struct target *w;
+    struct ebpf_target *w;
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             ebpf_swap_sum_pids(&w->swap, w->root_pid);
@@ -707,7 +707,7 @@ static void swap_collector(ebpf_module_t *em)
  */
 void ebpf_swap_create_apps_charts(struct ebpf_module *em, void *ptr)
 {
-    struct target *root = ptr;
+    struct ebpf_target *root = ptr;
     ebpf_create_charts_on_apps(NETDATA_MEM_SWAP_READ_CHART,
                                "Calls to function <code>swap_readpage</code>.",
                                EBPF_COMMON_DIMENSION_CALL,

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -341,7 +341,7 @@ static void read_apps_table()
 {
     netdata_publish_swap_t *cv = swap_vector;
     uint32_t key;
-    struct pid_stat *pids = root_of_pids;
+    struct ebpf_pid_stat *pids = ebpf_root_of_pids;
     int fd = swap_maps[NETDATA_PID_SWAP_TABLE].map_fd;
     size_t length = sizeof(netdata_publish_swap_t)*ebpf_nprocs;
     while (pids) {

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -540,7 +540,7 @@ static void ebpf_vfs_read_global_table()
  * @param swap output structure
  * @param root link list with structure to be used
  */
-static void ebpf_vfs_sum_pids(netdata_publish_vfs_t *vfs, struct pid_on_target *root)
+static void ebpf_vfs_sum_pids(netdata_publish_vfs_t *vfs, struct ebpf_pid_on_target *root)
 {
     netdata_publish_vfs_t accumulator;
     memset(&accumulator, 0, sizeof(accumulator));

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -606,9 +606,9 @@ static void ebpf_vfs_sum_pids(netdata_publish_vfs_t *vfs, struct pid_on_target *
  * @param em   the structure with thread information
  * @param root the target list.
  */
-void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct target *root)
+void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 {
-    struct target *w;
+    struct ebpf_target *w;
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             ebpf_vfs_sum_pids(&w->vfs, w->root_pid);
@@ -1683,7 +1683,7 @@ static void ebpf_create_global_charts(ebpf_module_t *em)
  **/
 void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
 {
-    struct target *root = ptr;
+    struct ebpf_target *root = ptr;
 
     ebpf_create_charts_on_apps(NETDATA_SYSCALL_APPS_FILE_DELETED,
                                "Files deleted",

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -787,7 +787,7 @@ static void vfs_fill_pid(uint32_t current_pid, netdata_publish_vfs_t *publish)
  */
 static void ebpf_vfs_read_apps()
 {
-    struct pid_stat *pids = root_of_pids;
+    struct ebpf_pid_stat *pids = ebpf_root_of_pids;
     netdata_publish_vfs_t *vv = vfs_vector;
     int fd = vfs_maps[NETDATA_VFS_PID].map_fd;
     size_t length = sizeof(netdata_publish_vfs_t) * ebpf_nprocs;

--- a/libnetdata/libnetdata.c
+++ b/libnetdata/libnetdata.c
@@ -225,10 +225,6 @@ void posix_memfree(void *ptr) {
     libc_free(ptr);
 }
 
-#define MALLOC_ALIGNMENT (sizeof(uintptr_t) * 2)
-#define size_t_atomic_count(op, var, size) __atomic_## op ##_fetch(&(var), size, __ATOMIC_RELAXED)
-#define size_t_atomic_bytes(op, var, size) __atomic_## op ##_fetch(&(var), ((size) % MALLOC_ALIGNMENT)?((size) + MALLOC_ALIGNMENT - ((size) % MALLOC_ALIGNMENT)):(size), __ATOMIC_RELAXED)
-
 struct malloc_header_signature {
     uint32_t magic;
     uint32_t size;

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -32,6 +32,9 @@ extern "C" {
 #define OS_FREEBSD 2
 #define OS_MACOS   3
 
+#define MALLOC_ALIGNMENT (sizeof(uintptr_t) * 2)
+#define size_t_atomic_count(op, var, size) __atomic_## op ##_fetch(&(var), size, __ATOMIC_RELAXED)
+#define size_t_atomic_bytes(op, var, size) __atomic_## op ##_fetch(&(var), ((size) % MALLOC_ALIGNMENT)?((size) + MALLOC_ALIGNMENT - ((size) % MALLOC_ALIGNMENT)):(size), __ATOMIC_RELAXED)
 
 // ----------------------------------------------------------------------------
 // system include files for all netdata C programs


### PR DESCRIPTION
##### Summary
This PR is bringing first step to improve memory management for eBPF before we bring new charts, to reach this goal we are modifying:

- Compatibility that existed when codes were copied from `apps` to `ebpf` to do an independent integration. Now we have inside structures variables that are really used.
- Unification of structures and eliminating necessity to have double structures.
- Reducing processing time removing calls. To do this we are removing `callocz`/`freez`  and now we are using our `ARAL` .

This PR is only modifying `user ring` code and other PRs will come to complement this. With these changes on my environment we saved 10% of memory after to modify only one thread:

##### This PR
![current](https://user-images.githubusercontent.com/49162938/217625665-e218e054-0a05-4077-8301-ff49e6533199.png)
##### Current master
![master](https://user-images.githubusercontent.com/49162938/217625658-2d89c6f7-ab13-40ea-aafd-93e8b2201a24.png)

##### Test Plan

1. Modify your `/etc/netdata/ebpf.d/process.conf` with the following configuration:
```sh
[global]
#    ebpf load mode = entry
#    apps = yes
#    cgroups = no
#    update every = 10
#    pid table size = 32768
    collect pid = all
```
This will force plugin to use more memory.

2. Modify `/etc/netdata/ebpf.conf` to have integration with apps enabled:
```sh
[global]
    apps = yes
```
3. Compile master branch.
4. Run `netdata` and take a look in the amount of memory required for plugin.
5. After few minutes, compile this PR and repeat step 3.
6. Finally compile netdata with `-DNETDATA_EBPF_ALLOC_MAX_PID=CONST` with another `CONST` value and retest.

##### Additional Information
Before the commit https://github.com/netdata/netdata/pull/14462/commits/bf8a48d8903b2cf9c027315f2e4887e7ba724b1c I ran a test with only `20` values for `NETDATA_EBPF_ALLOC_MAX_PID` and plugin worked, the low limit was set to avoid negative values or "small" numbers.

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? eBPF.plugin
- Can they see the change or is it an under the hood? If they can see it, where? Yes, plugin will use less memory when integration with apps is enabled
- How is the user impacted by the change?  A plugin will use less resources from host.
- What are there any benefits of the change? We are using less resources to provide the same results.
</details>