### PR TITLE
Fix random crash on agent shutdown

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -589,7 +589,8 @@ void netdata_cgroup_ebpf_initialize_shm()
                                                                        PROT_READ | PROT_WRITE, MAP_SHARED,
                                                                        shm_fd_cgroup_ebpf, 0);
 
-    if (!shm_cgroup_ebpf.header) {
+    if (unlikely(MAP_FAILED == shm_cgroup_ebpf.header)) {
+        shm_cgroup_ebpf.header = NULL;
         collector_error("Cannot map shared memory used between cgroup and eBPF, integration won't happen");
         goto end_init_shm;
     }
@@ -606,6 +607,7 @@ void netdata_cgroup_ebpf_initialize_shm()
 
     collector_error("Cannot create semaphore, integration between eBPF and cgroup won't happen");
     munmap(shm_cgroup_ebpf.header, length);
+    shm_cgroup_ebpf.header = NULL;
 
 end_init_shm:
     close(shm_fd_cgroup_ebpf);


### PR DESCRIPTION

An agent running as non root / EBPF disabled, sometimes crashes during shutdown at

```
#0  cgroup_main_cleanup (ptr=0x559dad6a88d8) at collectors/cgroups.plugin/sys_fs_cgroup.c:4772
4772	        munmap(shm_cgroup_ebpf.header, shm_cgroup_ebpf.header->body_length);
```

The reason is that the agent will not be able to setup a semaphore (when running `netdata_cgroup_ebpf_initialize_shm`) 
and it logs the following message in `collector.log`

```
Cannot create semaphore, integration between eBPF and cgroup won't happen
```

This will also remove the MMAPed area pointed by `shm_cgroup_ebpf.header`  but during the cgroups cleanup (`cgroup_main_cleanup`)  a second attempt to munmap the memory area results in a crash.

