### PR TITLE
Add sbindir_POST template for v235 service file

### DIFF
--- a/system/netdata.service.v235.in
+++ b/system/netdata.service.v235.in
@@ -7,7 +7,7 @@ After=network.target httpd.service squid.service nfs-server.service mysqld.servi
 
 [Service]
 Type=simple
-User=netdata
+User=@netdata_user_POST@
 Group=netdata
 RuntimeDirectory=netdata
 CacheDirectory=netdata
@@ -18,7 +18,7 @@ StateDirectoryMode=0755
 CacheDirectoryMode=0755
 LogsDirectoryMode=2750
 EnvironmentFile=-/etc/default/netdata
-ExecStart=/usr/sbin/netdata -D $EXTRA_OPTS
+ExecStart=@sbindir_POST@/netdata -D $EXTRA_OPTS
 
 # saving a big db on slow disks may need some time
 TimeoutStopSec=150


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #14292 

Adds the template of `sbindir_POST` to `netdata.service.v235.in`. This affects static installs in e.g. Centos 7 (with such version of systemd), where then, the service file will try to run `/usr/sbin/netdata` instead of `/opt/netdata/usr/sbin/`

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Compile this PR, even in a local prefix. After the compile check the contents of `system/netdata.service` and `system/netdata.service.v235`. The `ExecStart` line should have the proper path.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
