### PR TITLE
Fix coverity issues

### DIFF
--- a/database/engine/cache.c
+++ b/database/engine/cache.c
@@ -1946,7 +1946,7 @@ time_t pgc_page_update_every_s(PGC_PAGE *page) {
 
 time_t pgc_page_fix_update_every(PGC_PAGE *page, time_t update_every_s) {
     if(page->update_every_s == 0)
-        page->update_every_s = update_every_s;
+        page->update_every_s = (uint32_t) update_every_s;
 
     return page->update_every_s;
 }

--- a/database/engine/journalfile.c
+++ b/database/engine/journalfile.c
@@ -40,7 +40,7 @@ static void update_metric_retention_and_granularity_by_uuid(
                 .section = (Word_t) ctx,
                 .first_time_s = first_time_s,
                 .last_time_s = last_time_s,
-                .latest_update_every_s = update_every_s
+                .latest_update_every_s = (uint32_t) update_every_s
         };
         uuid_copy(entry.uuid, *uuid);
         metric = mrg_metric_add_and_acquire(main_mrg, entry, &added);
@@ -617,7 +617,7 @@ static void journalfile_restore_extent_metadata(struct rrdengine_instance *ctx, 
                     .section = (Word_t)ctx,
                     .first_time_s = vd.start_time_s,
                     .last_time_s = vd.end_time_s,
-                    .latest_update_every_s = vd.update_every_s,
+                    .latest_update_every_s = (uint32_t) vd.update_every_s,
             };
             uuid_copy(entry.uuid, *temp_id);
 
@@ -1128,7 +1128,7 @@ void *journalfile_v2_write_data_page(struct journal_v2_header *j2_header, void *
     data_page->delta_end_s = (uint32_t) (page_info->end_time_s - (time_t) (j2_header->start_time_ut) / USEC_PER_SEC);
     data_page->extent_index = page_info->extent_index;
 
-    data_page->update_every_s = page_info->update_every_s;
+    data_page->update_every_s = (uint32_t) page_info->update_every_s;
     data_page->page_length = (uint16_t) (ei ? ei->page_length : page_info->page_length);
     data_page->type = 0;
 

--- a/database/engine/metric.c
+++ b/database/engine/metric.c
@@ -412,10 +412,10 @@ void mrg_metric_expand_retention(MRG *mrg __maybe_unused, METRIC *metric, time_t
         metric->latest_time_s_clean = last_time_s;
 
         if(likely(update_every_s))
-            metric->latest_update_every_s = update_every_s;
+            metric->latest_update_every_s = (uint32_t) update_every_s;
     }
     else if(unlikely(!metric->latest_update_every_s && update_every_s))
-        metric->latest_update_every_s = update_every_s;
+        metric->latest_update_every_s = (uint32_t) update_every_s;
 
     metric_has_retention_unsafe(mrg, metric);
     netdata_spinlock_unlock(&metric->spinlock);
@@ -578,7 +578,7 @@ bool mrg_metric_set_update_every(MRG *mrg __maybe_unused, METRIC *metric, time_t
         return false;
 
     netdata_spinlock_lock(&metric->spinlock);
-    metric->latest_update_every_s = update_every_s;
+    metric->latest_update_every_s = (uint32_t) update_every_s;
     netdata_spinlock_unlock(&metric->spinlock);
 
     return true;
@@ -590,7 +590,7 @@ bool mrg_metric_set_update_every_s_if_zero(MRG *mrg __maybe_unused, METRIC *metr
 
     netdata_spinlock_lock(&metric->spinlock);
     if(!metric->latest_update_every_s)
-        metric->latest_update_every_s = update_every_s;
+        metric->latest_update_every_s = (uint32_t) update_every_s;
     netdata_spinlock_unlock(&metric->spinlock);
 
     return true;

--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -310,7 +310,7 @@ static size_t get_page_list_from_pgc(PGC *cache, METRIC *metric, struct rrdengin
             pd->first_time_s = page_start_time_s;
             pd->last_time_s = page_end_time_s;
             pd->page_length = page_length;
-            pd->update_every_s = page_update_every_s;
+            pd->update_every_s = (uint32_t) page_update_every_s;
             pd->page = (open_cache_mode) ? NULL : page;
             pd->status |= tags;
 
@@ -581,7 +581,7 @@ static size_t get_page_list_from_journal_v2(struct rrdengine_instance *ctx, METR
                         .metric_id = metric_id,
                         .start_time_s = page_first_time_s,
                         .end_time_s = page_last_time_s,
-                        .update_every_s = page_update_every_s,
+                        .update_every_s = (uint32_t) page_update_every_s,
                         .data = datafile,
                         .size = 0,
                         .custom_data = (uint8_t *) &ei,
@@ -635,7 +635,7 @@ void add_page_details_from_journal_v2(PGC_PAGE *page, void *JudyL_pptr) {
     pd->last_time_s = pgc_page_end_time_s(page);
     pd->datafile.ptr = datafile;
     pd->page_length = ei->page_length;
-    pd->update_every_s = pgc_page_update_every_s(page);
+    pd->update_every_s = (uint32_t) pgc_page_update_every_s(page);
     pd->metric_id = metric_id;
     pd->status |= PDC_PAGE_DISK_PENDING | PDC_PAGE_SOURCE_JOURNAL_V2 | PDC_PAGE_DATAFILE_ACQUIRED;
 }
@@ -924,7 +924,8 @@ struct pgc_page *pg_cache_lookup_next(
         else {
             if (unlikely(page_update_every_s <= 0 || page_update_every_s > 86400)) {
                 __atomic_add_fetch(&rrdeng_cache_efficiency_stats.pages_invalid_update_every_fixed, 1, __ATOMIC_RELAXED);
-                pd->update_every_s = page_update_every_s = pgc_page_fix_update_every(page, last_update_every_s);
+                page_update_every_s = pgc_page_fix_update_every(page, last_update_every_s);
+                pd->update_every_s = (uint32_t) page_update_every_s;
             }
 
             size_t entries_by_size = page_entries_by_size(page_length, CTX_POINT_SIZE_BYTES(ctx));
@@ -1009,7 +1010,7 @@ void pgc_open_add_hot_page(Word_t section, Word_t metric_id, time_t start_time_s
             .metric_id = metric_id,
             .start_time_s = start_time_s,
             .end_time_s =  end_time_s,
-            .update_every_s = update_every_s,
+            .update_every_s = (uint32_t) update_every_s,
             .size = 0,
             .data = datafile,
             .custom_data = (uint8_t *) &ext_io_data,

--- a/database/engine/pdc.c
+++ b/database/engine/pdc.c
@@ -835,7 +835,7 @@ static void epdl_extent_loading_error_log(struct rrdengine_instance *ctx, EPDL *
         uuid_unparse_lower(descr->uuid, uuid);
         used_descr = true;
     }
-    else if (epdl) {
+    else {
         struct page_details *pd = NULL;
 
         Word_t start = 0;
@@ -855,7 +855,7 @@ static void epdl_extent_loading_error_log(struct rrdengine_instance *ctx, EPDL *
         }
     }
 
-    if(!used_epdl && !used_descr && epdl && epdl->pdc) {
+    if(!used_epdl && !used_descr && epdl->pdc) {
         start_time_s = epdl->pdc->start_time_s;
         end_time_s = epdl->pdc->end_time_s;
     }
@@ -1059,7 +1059,7 @@ static bool epdl_populate_pages_from_extent_data(
                 .metric_id = metric_id,
                 .start_time_s = vd.start_time_s,
                 .end_time_s = vd.end_time_s,
-                .update_every_s = vd.update_every_s,
+                .update_every_s = (uint32_t) vd.update_every_s,
                 .size = (size_t) ((page_data == DBENGINE_EMPTY_PAGE) ? 0 : vd.page_length),
                 .data = page_data
         };

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -371,7 +371,7 @@ static void rrdeng_store_metric_create_new_page(struct rrdeng_collect_handle *ha
             .end_time_s = point_in_time_s,
             .size = data_size,
             .data = data,
-            .update_every_s = update_every_s,
+            .update_every_s = (uint32_t) update_every_s,
             .hot = true
     };
 

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1981,8 +1981,8 @@ time_t rrdset_set_update_every_s(RRDSET *st, time_t update_every_s) {
     internal_error(true, "RRDSET '%s' switching update every from %d to %d",
                    rrdset_id(st), (int)st->update_every, (int)update_every_s);
 
-    time_t prev_update_every_s = st->update_every;
-    st->update_every = update_every_s;
+    time_t prev_update_every_s = (time_t) st->update_every;
+    st->update_every = (int) update_every_s;
 
     // switch update every to the storage engine
     RRDDIM *rd;
@@ -1992,7 +1992,7 @@ time_t rrdset_set_update_every_s(RRDSET *st, time_t update_every_s) {
                 rd->tiers[tier].collect_ops->change_collection_frequency(rd->tiers[tier].db_collection_handle, (int)(st->rrdhost->db[tier].tier_grouping * st->update_every));
         }
 
-        assert(rd->update_every == prev_update_every_s &&
+        assert(rd->update_every == (int) prev_update_every_s &&
                "chart's update every differs from the update every of its dimensions");
         rd->update_every = st->update_every;
     }

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -1419,7 +1419,7 @@ static void *metadata_unittest_threads(void)
             unittest_queue_metadata,
             &tu);
     }
-    uv_async_send(&metasync_worker.async);
+    (void) uv_async_send(&metasync_worker.async);
     sleep_usec(seconds_to_run * USEC_PER_SEC);
 
     __atomic_store_n(&tu.join, 1, __ATOMIC_RELAXED);

--- a/libnetdata/circular_buffer/circular_buffer.c
+++ b/libnetdata/circular_buffer/circular_buffer.c
@@ -16,7 +16,10 @@ struct circular_buffer *cbuffer_new(size_t initial, size_t max, size_t *statisti
 }
 
 void cbuffer_free(struct circular_buffer *buf) {
-    if(buf && buf->statistics)
+    if (unlikely(!buf))
+        return;
+
+    if(buf->statistics)
         __atomic_sub_fetch(buf->statistics, sizeof(struct circular_buffer) + buf->size, __ATOMIC_RELAXED);
 
     freez(buf->data);


### PR DESCRIPTION
Possibly fix the following coverity issues 

382921 Use of 32-bit time_it
382924 Use of 32-bit time_it
382927 Use of 32-bit time_it
382928 Use of 32-bit time_it
382932 Use of 32-bit time_it
382933 Use of 32-bit time_it
382950 Use of 32-bit time_it
382990 Dereference null return value
383123 Dereference after null check
382952 Use of 32-bit time_it
382906 Use of 32-bit time_it
382908 Use of 32-bit time_it
382912 Use of 32-bit time_it
382914 Use of 32-bit time_it
382917 Use of 32-bit time_it
382918 Use of 32-bit time_it
382919 Use of 32-bit time_it
381508 Unchecked return value
382965 Dereference after null check
