### PR TITLE
Make the introduction a category link

### DIFF
--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -5,8 +5,9 @@ custom_edit_url: "https://github.com/netdata/netdata/blob/master/docs/getting-st
 learn_status: "Published"
 sidebar_position: "1"
 learn_topic_type: "Getting started"
-learn_rel_path: "Getting started"
+learn_rel_path: "Slugs"
 learn_docs_purpose: "Present netdata in a nutshell"
+slug: "/getting-started"
 -->
 
 ## What is Netdata ?


### PR DESCRIPTION
To achieve this, we:

- add a metadata called "slug" 👉 `slug: "/getting-started"`, this is to change the link that leads to the file, so nobody can find it by it's actual path in Learn
- we move the file (so it is not accessible further down in the same menu) to a folder where all the "slugs" will live in the future

This action also requires a 
```json
       "link": {
        "type": "doc",
        "id": "slugs/introduction"
      },
```

to be added inside the sidebars.json, in the same depth as the category's label. The id marks the location of the file in Learn, it is not related to it's link, as we have changed it with the slug metadata.