### PR TITLE
Fix crash when child connects

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1226,7 +1226,8 @@ void rrdhost_free___while_having_rrd_wrlock(RRDHOST *host, bool force) {
     rrdfamily_index_destroy(host);
     rrdfunctions_destroy(host);
     rrdvariables_destroy(host->rrdvars);
-    rrdvariables_destroy(health_rrdvars);
+    if (host == localhost)
+        rrdvariables_destroy(health_rrdvars);
 
     rrdhost_destroy_rrdcontexts(host);
 

--- a/database/rrdvar.c
+++ b/database/rrdvar.c
@@ -94,7 +94,7 @@ DICTIONARY *rrdvariables_create(void) {
 }
 
 DICTIONARY *health_rrdvariables_create(void) {
-    DICTIONARY *dict = dictionary_create_advanced(DICT_OPTION_SINGLE_THREADED, &dictionary_stats_category_rrdhealth, 0);
+    DICTIONARY *dict = dictionary_create_advanced(DICT_OPTION_NONE, &dictionary_stats_category_rrdhealth, 0);
 
     dictionary_register_insert_callback(dict, rrdvar_insert_callback, NULL);
     dictionary_register_delete_callback(dict, rrdvar_delete_callback, NULL);

--- a/health/health.c
+++ b/health/health.c
@@ -947,8 +947,8 @@ static void health_execute_delayed_initializations(RRDHOST *host) {
             }
             foreach_rrdcalctemplate_done(rt);
 
-            if(health_variable_check(health_rrdvars, st, rd))
-                    rrdvar_store_for_chart(host, st);
+            if (health_variable_check(health_rrdvars, st, rd))
+                rrdvar_store_for_chart(host, st);
         }
         rrddim_foreach_done(rd);
     }


### PR DESCRIPTION
Fix an issue with children with different memory mode from the parent that reconnect and destroy a global health
dictionary that causes a memory corruption / crash.

Fixes #14481