### PR TITLE
Category overview pages

### DIFF
--- a/docs/category-overview-pages/concepts-overview.md
+++ b/docs/category-overview-pages/concepts-overview.md
@@ -1,0 +1,10 @@
+<!--
+title: "Concepts"
+sidebar_label: "Concepts"
+custom_edit_url: "https://github.com/netdata/netdata/blob/master/docs/category-overview-pages/concepts-overview.md"
+learn_status: "Published"
+learn_rel_path: "Concepts"
+sidebar_position: 10
+-->
+
+This category will help you understand how key features and components work in Netdata.

--- a/docs/category-overview-pages/developers-overview.md
+++ b/docs/category-overview-pages/developers-overview.md
@@ -1,0 +1,10 @@
+<!--
+title: "Developers"
+sidebar_label: "Developers"
+custom_edit_url: "https://github.com/netdata/netdata/blob/master/docs/category-overview-pages/developers-overview.md"
+learn_status: "Published"
+learn_rel_path: "Developers"
+sidebar_position: 60
+-->
+
+In this category you will find information that will aid you while developing with Netdata.

--- a/docs/category-overview-pages/getting-started-overview.md
+++ b/docs/category-overview-pages/getting-started-overview.md
@@ -1,0 +1,10 @@
+<!--
+title: "Getting Started"
+sidebar_label: "Getting Started"
+custom_edit_url: "https://github.com/netdata/netdata/blob/master/docs/category-overview-pages/getting-started-overview.md"
+learn_status: "Published"
+learn_rel_path: "Getting Started"
+sidebar_position: 1
+-->
+
+In this category you can get to grips with what Netdata has to offer, and how you can install it to your system.

--- a/docs/category-overview-pages/installation-overview.md
+++ b/docs/category-overview-pages/installation-overview.md
@@ -1,0 +1,10 @@
+<!--
+title: "Installation"
+sidebar_label: "Installation"
+custom_edit_url: "https://github.com/netdata/netdata/blob/master/docs/category-overview-pages/installation-overview.md"
+learn_status: "Published"
+learn_rel_path: "Installation"
+sidebar_position: 20
+-->
+
+In this category you can find instructions on all the possible ways you can install Netdata on your deployment.

--- a/docs/category-overview-pages/operations-overview.md
+++ b/docs/category-overview-pages/operations-overview.md
@@ -1,0 +1,10 @@
+<!--
+title: "Operations"
+sidebar_label: "Operations"
+custom_edit_url: "https://github.com/netdata/netdata/blob/master/docs/category-overview-pages/operations-overview.md"
+learn_status: "Published"
+learn_rel_path: "Operations"
+sidebar_position: 40
+-->
+
+In this category you will find all the instructions on "operations" you can perform with Netdata, whether that would be using the Anomaly Advisor to surface any potential unexpected behavior, or how to interact with the charts etc.

--- a/docs/category-overview-pages/references-overview.md
+++ b/docs/category-overview-pages/references-overview.md
@@ -1,0 +1,10 @@
+<!--
+title: "References"
+sidebar_label: "References"
+custom_edit_url: "https://github.com/netdata/netdata/blob/master/docs/category-overview-pages/references-overview.md"
+learn_status: "Published"
+learn_rel_path: "References"
+sidebar_position: 50
+-->
+
+In this category you will find reference documentation about Netdata's components and structural blocks.

--- a/docs/category-overview-pages/setup-overview.md
+++ b/docs/category-overview-pages/setup-overview.md
@@ -1,0 +1,10 @@
+<!--
+title: "Setup"
+sidebar_label: "Setup"
+custom_edit_url: "https://github.com/netdata/netdata/blob/master/docs/category-overview-pages/setup-overview.md"
+learn_status: "Published"
+learn_rel_path: "Setup"
+sidebar_position: 30
+-->
+
+In this category you will find instructions on how to configure and setup Netdata to suit your needs.

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -1,6 +1,6 @@
 <!--
 title: "Introduction"
-sidebar_label: "Getting started"
+sidebar_label: "Introduction"
 custom_edit_url: "https://github.com/netdata/netdata/blob/master/docs/getting-started/introduction.md"
 learn_status: "Published"
 sidebar_position: "1"


### PR DESCRIPTION
##### Summary

This is the PR that along with https://github.com/netdata/learn/pull/1329 will allow us to use the pages introduced as the page that comes up when one clicks a category in Learn.

---

The way this works, is:

We will keep all the files for "category overview pages" (let's call them like this for now) in one folder under `docs/category-overview-pages`.

If we only had the automatic sidebar, then folders not having an overview page will show up with a lowercase label, same as the category's folder name.

So, in the files introduced, we specify the `sidebar_label` and `learn_rel_path` to be exactly the same value as the category we want to cover.

By doing this, the category then gets controlled by it's overview file now, in terms of `sidebar_label` and `sidebar_position`.

For example, for the "Getting Started" category overview page we have a document with the following metadata:

```markdown
<!--
title: "Getting Started"
sidebar_label: "Getting Started"
custom_edit_url: "https://github.com/netdata/netdata/blob/master/docs/category-overview-pages/getting-started-overview.md"
learn_status: "Published"
learn_rel_path: "Getting Started"
sidebar_position: 1
-->
```

Then the ingest script will rename this file to .mdx and whatever `sidebar_label` says, in this case `getting-started` (converting everything to lowercase and spaces to dashes) and place it inside the `getting-started` directory. So we have `getting-started/getting-started.mdx`
