### PR TITLE
replicating gaps

### DIFF
--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -871,6 +871,7 @@ STORAGE_POINT rrdeng_load_metric_next(struct storage_engine_query_handle *rrddim
         // We need to get a new page
 
         if (!rrdeng_load_page_next(rrddim_handle, false)) {
+            handle->now_s = rrddim_handle->end_time_s;
             storage_point_empty(sp, handle->now_s - handle->dt_s, handle->now_s);
             goto prepare_for_next_iteration;
         }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1543,9 +1543,6 @@ void rrdset_timed_done(RRDSET *st, struct timeval now, bool pending_rrdset_next)
         // calculate the proper last_collected_time, using usec_since_last_update
         last_collect_ut = rrdset_update_last_collected_time(st);
     }
-    if (unlikely(st->rrd_memory_mode == RRD_MEMORY_MODE_NONE)) {
-        goto after_first_database_work;
-    }
 
     // if this set has not been updated in the past
     // we fake the last_update time to be = now - usec_since_last_update
@@ -1608,7 +1605,6 @@ void rrdset_timed_done(RRDSET *st, struct timeval now, bool pending_rrdset_next)
         }
     }
 
-after_first_database_work:
     st->counter_done++;
 
     if(stream_buffer.wb && !stream_buffer.v2)
@@ -1669,9 +1665,6 @@ after_first_database_work:
     }
     rrddim_foreach_done(rd);
     rda_slots = dimensions;
-
-    if (unlikely(st->rrd_memory_mode == RRD_MEMORY_MODE_NONE))
-        goto after_second_database_work;
 
     rrdset_debug(st, "last_collect_ut = %0.3" NETDATA_DOUBLE_MODIFIER " (last collection time)", (NETDATA_DOUBLE)last_collect_ut/USEC_PER_SEC);
     rrdset_debug(st, "now_collect_ut  = %0.3" NETDATA_DOUBLE_MODIFIER " (current collection time)", (NETDATA_DOUBLE)now_collect_ut/USEC_PER_SEC);

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1879,7 +1879,6 @@ void rrdset_timed_done(RRDSET *st, struct timeval now, bool pending_rrdset_next)
             , has_reset_value
     );
 
-after_second_database_work:
     for(dim_id = 0, rda = rda_base ; dim_id < rda_slots ; ++dim_id, ++rda) {
         rd = rda->rd;
         if(unlikely(!rd)) continue;


### PR DESCRIPTION
instead of sending RBEGIN/REND without points, jump to the end of the gap on every replication step.

Unfortunately we don't know at which time exactly the gap finishes, when it finishes outside the query boundaries, but this PR should skip gaps that are within the query executed.

Fix a bug during replication when a child node is set to memory node NONE and the stream connection has INTERPOLATE capability

Fixes #14479