### PR TITLE
Make external plugins a category page in learn

### DIFF
--- a/collectors/plugins.d/README.md
+++ b/collectors/plugins.d/README.md
@@ -4,7 +4,7 @@ custom_edit_url: "https://github.com/netdata/netdata/edit/master/collectors/plug
 sidebar_label: "External plugins"
 learn_status: "Published"
 learn_topic_type: "References"
-learn_rel_path: "Developers"
+learn_rel_path: "Developers/External plugins"
 -->
 
 # External plugins


### PR DESCRIPTION
The directory needs to appear in the learn_rel_path