### PR TITLE
Link statically libnetfilter_acct into our static builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -952,17 +952,7 @@ AC_CHECK_HEADER(
     [have_nfnetlink_conntrack=no]
 )
 
-PKG_CHECK_MODULES(
-    [NFACCT],
-    [libnetfilter_acct],
-    [AC_CHECK_LIB(
-        [netfilter_acct],
-        [nfacct_alloc],
-        [have_libnetfilter_acct=yes],
-        [have_libnetfilter_acct=no]
-    )],
-    [have_libnetfilter_acct=no]
-)
+LIBS="${LIBS} -lmnl"
 
 PKG_CHECK_MODULES(
     [LIBMNL],
@@ -974,6 +964,22 @@ PKG_CHECK_MODULES(
         [have_libmnl=no]
     )],
     [have_libmnl=no]
+)
+
+
+LIBS="${LIBS}"
+
+PKG_CHECK_MODULES(
+    [NFACCT],
+    [libnetfilter_acct],
+    AC_SEARCH_LIBS(
+        [nfacct_alloc],
+        [netfilter_acct libnetfilter_acct],
+        [have_libnetfilter_acct=yes],
+        [have_libnetfilter_acct=no],
+        [${LIBS} -L/libnetfilter-acct-static/lib/libnetfilter_acct.a]
+    )],
+    [have_libnetfilter_acct=no]
 )
 
 test "${enable_plugin_nfacct}" = "yes" -a "${have_nfnetlink_conntrack}" != "yes" && \

--- a/configure.ac
+++ b/configure.ac
@@ -952,6 +952,7 @@ AC_CHECK_HEADER(
     [have_nfnetlink_conntrack=no]
 )
 
+LIBS_BAK="${LIBS}"
 LIBS="${LIBS} -lmnl"
 
 PKG_CHECK_MODULES(
@@ -981,6 +982,8 @@ PKG_CHECK_MODULES(
     )],
     [have_libnetfilter_acct=no]
 )
+
+LIBS="${LIBS_BAK}"
 
 test "${enable_plugin_nfacct}" = "yes" -a "${have_nfnetlink_conntrack}" != "yes" && \
     AC_MSG_ERROR([nfnetlink_conntrack.h required but not found or too old])

--- a/packaging/makeself/functions.sh
+++ b/packaging/makeself/functions.sh
@@ -61,16 +61,7 @@ fetch() {
 
     set -e
     cd "${NETDATA_MAKESELF_PATH}/tmp"
-
-    case ${2} in
-      *.tar.gz)
-        run tar -zxpf "${tar}";;
-      *.tar.bz2)
-        run tar -xjf "${tar}";;
-      *)
-        echo "ERROR: unsupported file format"
-        exit 1;;
-    esac
+    run tar -axpf "${tar}"
     cd -
 
     CACHE_HIT=0

--- a/packaging/makeself/functions.sh
+++ b/packaging/makeself/functions.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: GPL-3.0-or-latergit clean
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 # -----------------------------------------------------------------------------
 

--- a/packaging/makeself/functions.sh
+++ b/packaging/makeself/functions.sh
@@ -30,15 +30,7 @@ set -euo pipefail
 
 fetch() {
   local dir="${1}" url="${2}" sha256="${3}" key="${4}"
-  case ${2} in
-    *.tar.gz)
-      local tar="${dir}.tar.gz";;
-    *.tar.bz2)
-      local tar="${dir}.tar.bz2";;
-    *)
-      echo "ERROR: unsupported file format"
-      exit 1;;
-  esac
+  local tar="$(basename "${2}")"
   local cache="${NETDATA_SOURCE_PATH}/artifacts/cache/${BUILDARCH}/${key}"
 
   if [ -d "${NETDATA_MAKESELF_PATH}/tmp/${dir}" ]; then

--- a/packaging/makeself/functions.sh
+++ b/packaging/makeself/functions.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-License-Identifier: GPL-3.0-or-latergit clean
 
 # -----------------------------------------------------------------------------
 
@@ -30,7 +30,15 @@ set -euo pipefail
 
 fetch() {
   local dir="${1}" url="${2}" sha256="${3}" key="${4}"
-  local tar="${dir}.tar.gz"
+  case ${2} in
+    *.tar.gz)
+      local tar="${dir}.tar.gz";;
+    *.tar.bz2)
+      local tar="${dir}.tar.bz2";;
+    *)
+      echo "ERROR: unsupported file format"
+      exit 1;;
+  esac
   local cache="${NETDATA_SOURCE_PATH}/artifacts/cache/${BUILDARCH}/${key}"
 
   if [ -d "${NETDATA_MAKESELF_PATH}/tmp/${dir}" ]; then
@@ -58,10 +66,19 @@ fetch() {
         echo >&2 "expected: ${sha256}, got $(sha256sum "${NETDATA_MAKESELF_PATH}/tmp/${tar}")"
         exit 1
     fi
-    set -e
 
+    set -e
     cd "${NETDATA_MAKESELF_PATH}/tmp"
-    run tar -zxpf "${tar}"
+
+    case ${2} in
+      *.tar.gz)
+        run tar -zxpf "${tar}";;
+      *.tar.bz2)
+        run tar -xjf "${tar}";;
+      *)
+        echo "ERROR: unsupported file format"
+        exit 1;;
+    esac
     cd -
 
     CACHE_HIT=0

--- a/packaging/makeself/functions.sh
+++ b/packaging/makeself/functions.sh
@@ -30,7 +30,8 @@ set -euo pipefail
 
 fetch() {
   local dir="${1}" url="${2}" sha256="${3}" key="${4}"
-  local tar="$(basename "${2}")"
+  local tar
+  tar="$(basename "${2}")"
   local cache="${NETDATA_SOURCE_PATH}/artifacts/cache/${BUILDARCH}/${key}"
 
   if [ -d "${NETDATA_MAKESELF_PATH}/tmp/${dir}" ]; then

--- a/packaging/makeself/jobs/50-libnetfilter_acct-1.0.3.install.sh
+++ b/packaging/makeself/jobs/50-libnetfilter_acct-1.0.3.install.sh
@@ -15,7 +15,7 @@ version="1.0.3"
 export CFLAGS="-I/usr/include/libmnl -pipe"
 export LDFLAGS="-static -L/usr/lib -lmnl"
 export PKG_CONFIG="pkg-config --static"
-export PKG_CONFIG_PATH="/usr/lib/pkgconfig/libmnl.pc"
+export PKG_CONFIG_PATH="/usr/lib/pkgconfig"
 
 fetch "libnetfilter_acct-${version}" "https://www.netfilter.org/projects/libnetfilter_acct/files/libnetfilter_acct-${version}.tar.bz2" \
     4250ceef3efe2034f4ac05906c3ee427db31b9b0a2df41b2744f4bf79a959a1a libnetfilter_acct

--- a/packaging/makeself/jobs/50-libnetfilter_acct-1.0.3.install.sh
+++ b/packaging/makeself/jobs/50-libnetfilter_acct-1.0.3.install.sh
@@ -13,7 +13,7 @@ version="1.0.3"
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::building libnetfilter_acct" || true
 
 export CFLAGS="-I/usr/include/libmnl -pipe"
-export LDFLAGS="-static -L/usr/lib/libmnl"
+export LDFLAGS="-static -L/usr/lib -lmnl"
 export PKG_CONFIG="pkg-config --static"
 export PKG_CONFIG_PATH="/usr/lib/pkgconfig/libmnl.pc"
 

--- a/packaging/makeself/jobs/50-libnetfilter_acct-1.0.3.install.sh
+++ b/packaging/makeself/jobs/50-libnetfilter_acct-1.0.3.install.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 # Install the libnetfilter_acct and it's dependency libmnl
-# 
+#
 
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
@@ -27,7 +27,7 @@ if [ "${CACHE_HIT:-0}" -eq 0 ]; then
         --exec-prefix="/libnetfilter-acct-static"
 
     run make clean
-    run make -j "$(nproc)" 
+    run make -j "$(nproc)"
 fi
 
 run make install

--- a/packaging/makeself/jobs/50-libnetfilter_acct-1.0.3.install.sh
+++ b/packaging/makeself/jobs/50-libnetfilter_acct-1.0.3.install.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Install the libnetfilter_acct and it's dependency libmnl
+# 
+
+# shellcheck source=packaging/makeself/functions.sh
+. "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
+
+version="1.0.3"
+
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::building libnetfilter_acct" || true
+
+export CFLAGS="-I/usr/include/libmnl -pipe"
+export LDFLAGS="-static -L/usr/lib/libmnl"
+export PKG_CONFIG="pkg-config --static"
+export PKG_CONFIG_PATH="/usr/lib/pkgconfig/libmnl.pc"
+
+fetch "libnetfilter_acct-${version}" "https://www.netfilter.org/projects/libnetfilter_acct/files/libnetfilter_acct-${version}.tar.bz2" \
+    4250ceef3efe2034f4ac05906c3ee427db31b9b0a2df41b2744f4bf79a959a1a libnetfilter_acct
+
+
+if [ "${CACHE_HIT:-0}" -eq 0 ]; then
+    run ./configure \
+        --prefix="/libnetfilter-acct-static" \
+        --disable-dependency-tracking \
+        --enable-static
+    
+    run make clean
+    run make -j "$(nproc)" 
+fi
+
+run make install
+
+store_cache libnetfilter_acct "${NETDATA_MAKESELF_PATH}/tmp/libnetfilter_acct-${version}"
+
+
+# shellcheck disable=SC2015
+[ "${GITHUB_ACTIONS}" = "true" ] && echo "::endgroup::" || true

--- a/packaging/makeself/jobs/50-libnetfilter_acct-1.0.3.install.sh
+++ b/packaging/makeself/jobs/50-libnetfilter_acct-1.0.3.install.sh
@@ -12,7 +12,7 @@ version="1.0.3"
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::building libnetfilter_acct" || true
 
-export CFLAGS="-I/usr/include/libmnl -pipe"
+export CFLAGS="-static -I/usr/include/libmnl -pipe"
 export LDFLAGS="-static -L/usr/lib -lmnl"
 export PKG_CONFIG="pkg-config --static"
 export PKG_CONFIG_PATH="/usr/lib/pkgconfig"
@@ -24,9 +24,8 @@ fetch "libnetfilter_acct-${version}" "https://www.netfilter.org/projects/libnetf
 if [ "${CACHE_HIT:-0}" -eq 0 ]; then
     run ./configure \
         --prefix="/libnetfilter-acct-static" \
-        --disable-dependency-tracking \
-        --enable-static
-    
+        --exec-prefix="/libnetfilter-acct-static"
+
     run make clean
     run make -j "$(nproc)" 
 fi

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -12,7 +12,7 @@ else
   export CFLAGS="-static -O1 -pipe -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include -I/libnetfilter-acct-static/include/libnetfilter_acct -I/usr/include/libmnl"
 fi
 
-export LDFLAGS="-static -L/openssl-static/lib -L/libnetfilter-acct-static/lib -L/usr/lib -lmnl"
+export LDFLAGS="-static -L/openssl-static/lib -L/libnetfilter-acct-static/lib -lnetfilter_acct -L/usr/lib -lmnl"
 
 # We export this to 'yes', installer sets this to .environment.
 # The updater consumes this one, so that it can tell whether it should update a static install or a non-static one
@@ -20,6 +20,7 @@ export IS_NETDATA_STATIC_BINARY="yes"
 
 # Set eBPF LIBC to "static" to bundle the `-static` variant of the kernel-collector
 export EBPF_LIBC="static"
+export PKG_CONFIG="pkg-config --static"
 export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig:/libnetfilter-acct-static/lib/pkgconfig:/usr/lib/pkgconfig"
 
 # Set correct CMake flags for building against non-System OpenSSL

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -7,9 +7,9 @@
 cd "${NETDATA_SOURCE_PATH}" || exit 1
 
 if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
-  export CFLAGS="-static -O2 -I/openssl-static/include -I/libnetfilter-acct-static/include -I/usr/include/libmnl -pipe"
+  export CFLAGS="-static -O2 -I/openssl-static/include -I/libnetfilter-acct-static/include/libnetfilter_acct -I/usr/include/libmnl -pipe"
 else
-  export CFLAGS="-static -O1 -pipe -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include -I/libnetfilter-acct-static/include -I/usr/include/libmnl"
+  export CFLAGS="-static -O1 -pipe -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include -I/libnetfilter-acct-static/include/libnetfilter_acct -I/usr/include/libmnl"
 fi
 
 export LDFLAGS="-static -L/openssl-static/lib -L/libnetfilter-acct-static/lib -L/usr/lib -lmnl"

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -7,12 +7,12 @@
 cd "${NETDATA_SOURCE_PATH}" || exit 1
 
 if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
-  export CFLAGS="-static -O2 -I/openssl-static/include -pipe"
+  export CFLAGS="-static -O2 -I/openssl-static/include -I/libnetfilter-acct-static/include -pipe"
 else
-  export CFLAGS="-static -O1 -pipe -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include"
+  export CFLAGS="-static -O1 -pipe -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include -I/libnetfilter-acct-static/include"
 fi
 
-export LDFLAGS="-static -L/openssl-static/lib"
+export LDFLAGS="-static -L/openssl-static/lib -L/libnetfilter-acct-static/lib"
 
 # We export this to 'yes', installer sets this to .environment.
 # The updater consumes this one, so that it can tell whether it should update a static install or a non-static one
@@ -20,7 +20,7 @@ export IS_NETDATA_STATIC_BINARY="yes"
 
 # Set eBPF LIBC to "static" to bundle the `-static` variant of the kernel-collector
 export EBPF_LIBC="static"
-export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig"
+export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig:/libnetfilter-acct-static/lib/pkgconfig"
 
 # Set correct CMake flags for building against non-System OpenSSL
 # See: https://github.com/warmcat/libwebsockets/blob/master/READMEs/README.build.md

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -7,12 +7,12 @@
 cd "${NETDATA_SOURCE_PATH}" || exit 1
 
 if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
-  export CFLAGS="-static -O2 -I/openssl-static/include -I/libnetfilter-acct-static/include -pipe"
+  export CFLAGS="-static -O2 -I/openssl-static/include -I/libnetfilter-acct-static/include -I/usr/include/libmnl -pipe"
 else
-  export CFLAGS="-static -O1 -pipe -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include -I/libnetfilter-acct-static/include"
+  export CFLAGS="-static -O1 -pipe -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include -I/libnetfilter-acct-static/include -I/usr/include/libmnl"
 fi
 
-export LDFLAGS="-static -L/openssl-static/lib -L/libnetfilter-acct-static/lib"
+export LDFLAGS="-static -L/openssl-static/lib -L/libnetfilter-acct-static/lib -L/usr/lib -lmnl"
 
 # We export this to 'yes', installer sets this to .environment.
 # The updater consumes this one, so that it can tell whether it should update a static install or a non-static one
@@ -20,7 +20,7 @@ export IS_NETDATA_STATIC_BINARY="yes"
 
 # Set eBPF LIBC to "static" to bundle the `-static` variant of the kernel-collector
 export EBPF_LIBC="static"
-export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig:/libnetfilter-acct-static/lib/pkgconfig"
+export PKG_CONFIG_PATH="/openssl-static/lib/pkgconfig:/libnetfilter-acct-static/lib/pkgconfig:/usr/lib/pkgconfig"
 
 # Set correct CMake flags for building against non-System OpenSSL
 # See: https://github.com/warmcat/libwebsockets/blob/master/READMEs/README.build.md


### PR DESCRIPTION
##### Summary

In this PR we bundle the `nfacct` dependencies `libnetfilter_acct` as static lib from source archives and `libmnl` as static lib from the alpines' packages (regular package manager) into our Netdata static binaries

Changelog:

* `packaging/makeself/functions.sh`: change the `fetch` function to also be able to fetch any tars (previous could fetch only `tar.gz`)
* `configure.ac`: Reorganize the tests to bundle the `nfacct` plugin, the previous one only checked in the system libs, we amended those to also check for our static bundle.
* `packaging/makeself/jobs/50-libnetfilter_acct-1.0.3.install.sh`: Include a new job to create a static bundle of the `libnetfilter_acct`
* `packaging/makeself/jobs/70-netdata-git.install.sh`: Amend the Netdata's static build job to statically link the  `libmnl` from installed by the package manager and the newly added `libnetfilter_acct` static custom created static lib.

Signed-off-by: Tasos Katsoulas <tasos@netdata.cloud>



##### Test Plan

- [x] CI checks
- [x] Check that the static netdata binary includes `nffact` plugin (at least for `x86-64` and `amrv7l`)
       Install the static artifacts from this PR either in `x86-64` or/and `amrv7l` system and test the nfacct plugin.
- [x] Check that the changes in the `configure.ac` don't break the build from source in a system with the dependencies installed .
       Compile from source is a system that has installed the `libnetfilter_acct` and `libmnl` libs, Check that the netdata has the nfacct plugin up and running.

##### Additional Information

1. References to docs: https://learn.netdata.cloud/docs/agent/collectors/nfacct.plugin
2. **Important**, can't figure out why the charts of the nffact.plugin, doesn't appear in my test system but If I try to execute the nfacct.plugin in debug mode I can see that it works and tries to collect metrics.

Resolves: #14367 