### PR TITLE
Assorted shellcheck cleanup.

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+disable=SC2317

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,1 +1,3 @@
+#!/bin/sh
+# shellcheck disable=SC2034
 disable=SC2317

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -788,7 +788,7 @@ copy_libbpf() {
 }
 
 bundle_libbpf() {
-  if { [ -n "${NETDATA_DISABLE_EBPF}" ] && [ ${NETDATA_DISABLE_EBPF} = 1 ]; } || [ "$(uname -s)" != Linux ]; then
+  if { [ -n "${NETDATA_DISABLE_EBPF}" ] && [ "${NETDATA_DISABLE_EBPF}" = 1 ]; } || [ "$(uname -s)" != Linux ]; then
     return 0
   fi
 
@@ -822,14 +822,14 @@ bundle_libbpf() {
       rm -rf "${tmp}"; then
       run_ok "libbpf built and prepared."
     else
-      if [ -n "${NETDATA_DISABLE_EBPF}" ] && [ ${NETDATA_DISABLE_EBPF} = 0 ]; then
+      if [ -n "${NETDATA_DISABLE_EBPF}" ] && [ "${NETDATA_DISABLE_EBPF}" = 0 ]; then
         fatal "failed to build libbpf." I0005
       else
         run_failed "Failed to build libbpf. eBPF support will be disabled"
       fi
     fi
   else
-    if [ -n "${NETDATA_DISABLE_EBPF}" ] && [ ${NETDATA_DISABLE_EBPF} = 0 ]; then
+    if [ -n "${NETDATA_DISABLE_EBPF}" ] && [ "${NETDATA_DISABLE_EBPF}" = 0 ]; then
       fatal "Failed to fetch sources for libbpf." I0006
     else
       run_failed "Unable to fetch sources for libbpf. eBPF support will be disabled"
@@ -846,7 +846,7 @@ copy_co_re() {
 }
 
 bundle_ebpf_co_re() {
-  if { [ -n "${NETDATA_DISABLE_EBPF}" ] && [ ${NETDATA_DISABLE_EBPF} = 1 ]; } || [ "$(uname -s)" != Linux ]; then
+  if { [ -n "${NETDATA_DISABLE_EBPF}" ] && [ "${NETDATA_DISABLE_EBPF}" = 1 ]; } || [ "$(uname -s)" != Linux ]; then
     return 0
   fi
 
@@ -869,7 +869,7 @@ bundle_ebpf_co_re() {
       rm -rf "${tmp}"; then
       run_ok "libbpf built and prepared."
     else
-      if [ -n "${NETDATA_DISABLE_EBPF}" ] && [ ${NETDATA_DISABLE_EBPF} = 0 ]; then
+      if [ -n "${NETDATA_DISABLE_EBPF}" ] && [ "${NETDATA_DISABLE_EBPF}" = 0 ]; then
         fatal "Failed to get eBPF CO-RE files." I0007
       else
         run_failed "Failed to get eBPF CO-RE files. eBPF support will be disabled"
@@ -878,7 +878,7 @@ bundle_ebpf_co_re() {
       fi
     fi
   else
-    if [ -n "${NETDATA_DISABLE_EBPF}" ] && [ ${NETDATA_DISABLE_EBPF} = 0 ]; then
+    if [ -n "${NETDATA_DISABLE_EBPF}" ] && [ "${NETDATA_DISABLE_EBPF}" = 0 ]; then
       fatal "Failed to fetch eBPF CO-RE files." I0008
     else
       run_failed "Failed to fetch eBPF CO-RE files. eBPF support will be disabled"

--- a/packaging/installer/dependencies/centos.sh
+++ b/packaging/installer/dependencies/centos.sh
@@ -96,7 +96,7 @@ check_flags() {
 
 validate_tree_centos() {
   local opts=
-  export local package_manager=
+  package_manager=
   if [[ "${NON_INTERACTIVE}" == "1" ]]; then
     echo >&2 "Running in non-interactive mode"
     opts="-y"

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -400,7 +400,7 @@ get_group(){
   if command -v getent > /dev/null 2>&1; then
     getent group "${1:-""}"
   else
-    cat /etc/group | grep "^${1}:" 
+    grep "^${1}:" /etc/group
   fi
 }
 
@@ -589,7 +589,7 @@ install_netdata_service() {
         echo >&2 "Note: To explicitly enable netdata automatic start, set 'netdata_enable' to 'YES' in /etc/rc.conf"
         echo >&2 ""
 
-        return ${myret}
+        return "${myret}"
 
       elif issystemd; then
         # systemd is running on this system

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -1376,6 +1376,7 @@ validate_tree_freebsd() {
   echo >&2 " > Checking for gmake ..."
   if ! pkg query %n-%v | grep -q gmake; then
     if prompt "gmake is required to build on FreeBSD and is not installed. Shall I install it?"; then
+      # shellcheck disable=2086
       run ${sudo} pkg install ${opts} gmake
     fi
   fi
@@ -1425,13 +1426,16 @@ validate_tree_centos() {
     echo >&2 " > Checking for config-manager ..."
     if ! run ${sudo} dnf config-manager --help; then
       if prompt "config-manager not found, shall I install it?"; then
+        # shellcheck disable=2086
         run ${sudo} dnf ${opts} install 'dnf-command(config-manager)'
       fi
     fi
 
     echo >&2 " > Checking for CRB ..."
+    # shellcheck disable=2086
     if ! run dnf ${sudo} repolist | grep CRB; then
       if prompt "CRB not found, shall I install it?"; then
+        # shellcheck disable=2086
         run ${sudo} dnf ${opts} config-manager --set-enabled crb
       fi
     fi
@@ -1439,24 +1443,29 @@ validate_tree_centos() {
     echo >&2 " > Checking for config-manager ..."
     if ! run ${sudo} yum config-manager --help; then
       if prompt "config-manager not found, shall I install it?"; then
+        # shellcheck disable=2086
         run ${sudo} yum ${opts} install 'dnf-command(config-manager)'
       fi
     fi
 
     echo >&2 " > Checking for PowerTools ..."
+    # shellcheck disable=2086
     if ! run yum ${sudo} repolist | grep PowerTools; then
       if prompt "PowerTools not found, shall I install it?"; then
+        # shellcheck disable=2086
         run ${sudo} yum ${opts} config-manager --set-enabled powertools
       fi
     fi
 
     echo >&2 " > Updating libarchive ..."
+    # shellcheck disable=2086
     run ${sudo} yum ${opts} install libarchive
 
   elif [[ "${version}" =~ ^7(\..*)?$ ]]; then
     echo >&2 " > Checking for EPEL ..."
     if ! rpm -qa | grep epel-release > /dev/null; then
       if prompt "EPEL not found, shall I install it?"; then
+        # shellcheck disable=2086
         run ${sudo} yum ${opts} install epel-release
       fi
     fi
@@ -1465,6 +1474,7 @@ validate_tree_centos() {
     echo >&2 " > Checking for Okay ..."
     if ! rpm -qa | grep okay > /dev/null; then
       if prompt "okay not found, shall I install it?"; then
+        # shellcheck disable=2086
         run ${sudo} yum ${opts} install http://repo.okay.com.mx/centos/6/x86_64/release/okay-release-1-3.el6.noarch.rpm
       fi
     fi
@@ -1627,7 +1637,7 @@ install_equo() {
 PACMAN_DB_SYNCED=0
 validate_install_pacman() {
 
-  if [ ${PACMAN_DB_SYNCED} -eq 0 ]; then
+  if [ "${PACMAN_DB_SYNCED}" -eq 0 ]; then
     echo >&2 " > Running pacman -Sy to sync the database"
     local x
     x=$(pacman -Sy)

--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -239,15 +239,18 @@ if [ -x "$(command -v apt-get)" ] && [ "${INSTALL_TYPE}" = "binpkg-deb" ]; then
   if dpkg -s netdata > /dev/null; then
     echo "Found netdata native installation"
     if user_input "Do you want to remove netdata? "; then
+      # shellcheck disable=SC2086
       apt-get remove netdata ${FLAG}
     fi
     if dpkg -s netdata-repo-edge > /dev/null; then
       if user_input "Do you want to remove netdata-repo-edge? "; then
+        # shellcheck disable=SC2086
         apt-get remove netdata-repo-edge ${FLAG}
       fi
     fi
     if dpkg -s netdata-repo > /dev/null; then
       if user_input "Do you want to remove netdata-repo? "; then
+        # shellcheck disable=SC2086
         apt-get remove netdata-repo ${FLAG}
       fi
     fi
@@ -257,15 +260,18 @@ elif [ -x "$(command -v dnf)" ] && [ "${INSTALL_TYPE}" = "binpkg-rpm" ]; then
   if rpm -q netdata > /dev/null; then
     echo "Found netdata native installation."
     if user_input "Do you want to remove netdata? "; then
+      # shellcheck disable=SC2086
       dnf remove netdata ${FLAG}
     fi
     if rpm -q netdata-repo-edge > /dev/null; then
       if user_input "Do you want to remove netdata-repo-edge? "; then
+        # shellcheck disable=SC2086
         dnf remove netdata-repo-edge ${FLAG}
       fi
     fi
     if rpm -q netdata-repo > /dev/null; then
       if user_input "Do you want to remove netdata-repo? "; then
+        # shellcheck disable=SC2086
         dnf remove netdata-repo ${FLAG}
       fi
     fi
@@ -275,15 +281,18 @@ elif [ -x "$(command -v yum)" ] && [ "${INSTALL_TYPE}" = "binpkg-rpm" ]; then
   if rpm -q netdata > /dev/null; then
     echo "Found netdata native installation."
     if user_input "Do you want to remove netdata? "; then
+      # shellcheck disable=SC2086
       yum remove netdata ${FLAG}
     fi
     if rpm -q netdata-repo-edge > /dev/null; then
       if user_input "Do you want to remove netdata-repo-edge? "; then
+        # shellcheck disable=SC2086
         yum remove netdata-repo-edge ${FLAG}
       fi
     fi
     if rpm -q netdata-repo > /dev/null; then
       if user_input "Do you want to remove netdata-repo? "; then
+        # shellcheck disable=SC2086
         yum remove netdata-repo ${FLAG}
       fi
     fi
@@ -296,15 +305,18 @@ elif [ -x "$(command -v zypper)" ] && [ "${INSTALL_TYPE}" = "binpkg-rpm" ]; then
   if zypper search -i netdata > /dev/null; then
     echo "Found netdata native installation."
     if user_input "Do you want to remove netdata? "; then
+      # shellcheck disable=SC2086
       zypper ${FLAG} remove netdata
     fi
     if zypper search -i netdata-repo-edge > /dev/null; then
       if user_input "Do you want to remove netdata-repo-edge? "; then
+        # shellcheck disable=SC2086
         zypper ${FLAG} remove netdata-repo-edge
       fi
     fi
     if zypper search -i netdata-repo > /dev/null; then
       if user_input "Do you want to remove netdata-repo? "; then
+        # shellcheck disable=SC2086
         zypper ${FLAG} remove netdata-repo
       fi
     fi

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -179,7 +179,7 @@ dir_should_be_link() {
   fi
 
   run ln -s "${t}" "${d}"
-  cd "${old}"
+  cd "${old}" || true
 }
 
 dir_should_be_link . bin sbin

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -265,7 +265,7 @@ install_systemd_service() {
         warning "Failed to reload systemd unit files."
     fi
 
-    if ! systemctl ${ENABLE} netdata; then
+    if ! systemctl "${ENABLE}" netdata; then
         warning "Failed to ${ENABLE} Netdata service."
     fi
   fi


### PR DESCRIPTION
##### Summary

- Add a config file for shellcheck to disable dead code checks. They have an extremely high false positive rate due to how frequently we are making indirect calls to functions, and on the rare occasions when they do flag actual dead code, the impact of said dead code is usually almost nonexistent.
- Fix all the issues reported by shellcheck in the installer code. This should make it easier to review related PRs.

##### Test Plan

n/a