### PR TITLE
fix setting go.d.plugin capabilities

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1434,15 +1434,18 @@ install_go() {
     run chown "root:${NETDATA_GROUP}" "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin"
   fi
   run chmod 0750 "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin"
-  if command -v setcap 1>/dev/null 2>&1; then
-    run setcap "cap_net_admin+epi cap_net_raw=eip" "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin"
-  fi
   rm -rf "${tmp}"
 
   [ -n "${GITHUB_ACTIONS}" ] && echo "::endgroup::"
 }
 
 install_go
+
+if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin" ]; then
+  if command -v setcap 1>/dev/null 2>&1; then
+    run setcap "cap_net_admin+epi cap_net_raw=eip" "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin"
+  fi
+fi
 
 should_install_ebpf() {
   if [ "${NETDATA_DISABLE_EBPF:=0}" -eq 1 ]; then

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -106,6 +106,9 @@ RUN chown -R root:root \
     if [ -f /usr/libexec/netdata/plugins.d/freeipmi.plugin ]; then \
         chmod 4755 /usr/libexec/netdata/plugins.d/freeipmi.plugin; \
     fi && \
+    if [ -f /usr/libexec/netdata/plugins.d/go.d.plugin ] && command -v setcap 1>/dev/null 2>&1; then \
+        setcap "cap_net_raw=eip" /usr/libexec/netdata/plugins.d/go.d.plugin 2>/dev/null; \
+    fi && \
     # Group write permissions due to: https://github.com/netdata/netdata/pull/6543
     find /var/lib/netdata /var/cache/netdata -type d -exec chmod 0770 {} \; && \
     find /var/lib/netdata /var/cache/netdata -type f -exec chmod 0660 {} \; && \


### PR DESCRIPTION
##### Summary

Capabilities needed for go.d.plugin:

1. cap_net_admin (wireguard)
2. cap_net_raw (ping)

This PR:
- Sets 1. and 2. on every netdata-installer.sh run (caps get reset on every update [somewhere here](https://github.com/netdata/netdata/blob/8fdeec2e85cf5b1de742d672c57e2c0f276e8867/netdata-installer.sh#L1210-L1214)).
- Sets 2. in dockerized Netdata. Setting both 1. and 2. here didn't work. `setcap` was successful, but: 

```bash
bash-5.1# getcap go.d.plugin
go.d.plugin cap_net_admin,cap_net_raw=eip
bash-5.1# ./go.d.plugin -d -m ping
bash: ./go.d.plugin: Operation not permitted
```

##### Test Plan

- Install and check go.d.plugin capabilities; Reinstall and check go.d.plugin capabilities.
- Check if go.d/ping works in Docker container.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
