### PR TITLE
Re-index when machine guid changes

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -123,9 +123,11 @@ static inline RRDHOST *rrdhost_index_add_hostname(RRDHOST *host) {
         rrdhost_option_set(host, RRDHOST_OPTION_INDEXED_HOSTNAME);
     else {
         //have the same hostname but it's not the same host
-        //keep the new one
-        rrdhost_index_del_hostname(ret_hostname);
-        rrdhost_index_add_hostname(host);
+        //keep the new one only if the old one is orphan or archived
+        if (rrdhost_flag_check(ret_hostname, RRDHOST_FLAG_ORPHAN) || rrdhost_flag_check(ret_hostname, RRDHOST_FLAG_ARCHIVED)) {
+            rrdhost_index_del_hostname(ret_hostname);
+            rrdhost_index_add_hostname(host);
+        }
     }
 
     return host;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -104,20 +104,6 @@ inline RRDHOST *rrdhost_find_by_hostname(const char *hostname) {
     return dictionary_get(rrdhost_root_index_hostname, hostname);
 }
 
-static inline RRDHOST *rrdhost_index_add_hostname(RRDHOST *host) {
-    if(!host->hostname) return host;
-
-    RRDHOST *ret_hostname = dictionary_set(rrdhost_root_index_hostname, rrdhost_hostname(host), host, sizeof(RRDHOST));
-    if(ret_hostname == host)
-        rrdhost_option_set(host, RRDHOST_OPTION_INDEXED_HOSTNAME);
-    else {
-        rrdhost_option_clear(host, RRDHOST_OPTION_INDEXED_HOSTNAME);
-        error("RRDHOST: %s() host with hostname '%s' is already indexed", __FUNCTION__, rrdhost_hostname(host));
-    }
-
-    return host;
-}
-
 static inline void rrdhost_index_del_hostname(RRDHOST *host) {
     if(unlikely(!host->hostname)) return;
 
@@ -127,6 +113,22 @@ static inline void rrdhost_index_del_hostname(RRDHOST *host) {
 
         rrdhost_option_clear(host, RRDHOST_OPTION_INDEXED_HOSTNAME);
     }
+}
+
+static inline RRDHOST *rrdhost_index_add_hostname(RRDHOST *host) {
+    if(!host->hostname) return host;
+
+    RRDHOST *ret_hostname = dictionary_set(rrdhost_root_index_hostname, rrdhost_hostname(host), host, sizeof(RRDHOST));
+    if(ret_hostname == host)
+        rrdhost_option_set(host, RRDHOST_OPTION_INDEXED_HOSTNAME);
+    else {
+        //have the same hostname but it's not the same host
+        //keep the new one
+        rrdhost_index_del_hostname(ret_hostname);
+        rrdhost_index_add_hostname(host);
+    }
+
+    return host;
 }
 
 // ----------------------------------------------------------------------------
@@ -582,6 +584,8 @@ static void rrdhost_update(RRDHOST *host
     if(strcmp(rrdhost_hostname(host), hostname) != 0) {
         info("Host '%s' has been renamed to '%s'. If this is not intentional it may mean multiple hosts are using the same machine_guid.", rrdhost_hostname(host), hostname);
         rrdhost_init_hostname(host, hostname, true);
+    } else {
+        rrdhost_index_add_hostname(host);
     }
 
     if(strcmp(rrdhost_program_name(host), program_name) != 0) {

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1042,6 +1042,22 @@ static inline void web_client_api_request_v1_info_summary_alarm_statuses(RRDHOST
     buffer_json_object_close(wb);
 }
 
+static inline void web_client_api_request_v1_info_mirrored_hosts_status(BUFFER *wb, RRDHOST *host) {
+    buffer_json_add_array_item_object(wb);
+
+    buffer_json_member_add_string(wb, "hostname", rrdhost_hostname(host));
+    buffer_json_member_add_uint64(wb, "hops", host->system_info ? host->system_info->hops : (host == localhost) ? 0 : 1);
+    buffer_json_member_add_boolean(wb, "reachable", (host == localhost || !rrdhost_flag_check(host, RRDHOST_FLAG_ORPHAN)));
+
+    buffer_json_member_add_string(wb, "guid", host->machine_guid);
+    buffer_json_member_add_uuid(wb, "node_id", host->node_id);
+    rrdhost_aclk_state_lock(host);
+    buffer_json_member_add_string(wb, "claim_id", host->aclk_state.claimed_id);
+    rrdhost_aclk_state_unlock(host);
+
+    buffer_json_object_close(wb);
+}
+
 static inline void web_client_api_request_v1_info_mirrored_hosts(BUFFER *wb) {
     RRDHOST *host;
 
@@ -1054,22 +1070,17 @@ static inline void web_client_api_request_v1_info_mirrored_hosts(BUFFER *wb) {
 
     buffer_json_member_add_array(wb, "mirrored_hosts_status");
     rrdhost_foreach_read(host) {
-        buffer_json_add_array_item_object(wb);
-
-        buffer_json_member_add_string(wb, "hostname", rrdhost_hostname(host));
-        buffer_json_member_add_uint64(wb, "hops", host->system_info ? host->system_info->hops : (host == localhost) ? 0 : 1);
-        buffer_json_member_add_boolean(wb, "reachable", (host == localhost || !rrdhost_flag_check(host, RRDHOST_FLAG_ORPHAN)));
-
-        buffer_json_member_add_string(wb, "guid", host->machine_guid);
-        buffer_json_member_add_uuid(wb, "node_id", host->node_id);
-        rrdhost_aclk_state_lock(host);
-        buffer_json_member_add_string(wb, "claim_id", host->aclk_state.claimed_id);
-        rrdhost_aclk_state_unlock(host);
-
-        buffer_json_object_close(wb);
+        if ((host == localhost || !rrdhost_flag_check(host, RRDHOST_FLAG_ORPHAN))) {
+            web_client_api_request_v1_info_mirrored_hosts_status(wb, host);
+        }
+    }
+    rrdhost_foreach_read(host) {
+        if ((host != localhost && rrdhost_flag_check(host, RRDHOST_FLAG_ORPHAN))) {
+            web_client_api_request_v1_info_mirrored_hosts_status(wb, host);
+        }
     }
     buffer_json_array_close(wb);
-
+    
     rrd_unlock();
 }
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1080,7 +1080,7 @@ static inline void web_client_api_request_v1_info_mirrored_hosts(BUFFER *wb) {
         }
     }
     buffer_json_array_close(wb);
-    
+
     rrd_unlock();
 }
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #14293 

This PR tries to fix the above issue. 

We keep a dictionary of hosts, based on hostname, on `rrdhost_root_index_hostname`. This is populated on parent startup, from children info previously connected to the parent (even if not currently connected).

If a child was previously connected with guid X, then changed and connected with Y, the dictionary will only keep a link to the host with guid X, and will not store the one with Y. As such, when requesting /host/child which streams with guid Y there will be nothing there.

This PR just overwrites the dictionary. Assuming X is added to the dictionary during startup, then Y is streaming, the dictionary will delete X and keep Y.

The PR also sorts the list of `mirrored_hosts_status` according to their reachability. This is to make dashboard display the Live badge on children that have guid changed.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Setup a parent/child.
Stop the child and change it's guid.
Start the child again.
The dashboard on the parent should show metrics from the child.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->

This can help in cases where an child agent on a node is wiped and re-installed. The parent should now display the child's metrics.

</details>
