### PR TITLE
Fix broken Alma Linux entries in build matrix generation.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -45,7 +45,6 @@ include:
   - &alma
     distro: almalinux
     version: "9"
-    base_image: almalinux
     jsonc_removal: |
       dnf remove -y json-c-devel
     packages: &alma_packages


### PR DESCRIPTION
##### Summary

We don’t need special handling for Alma’s images, so we should not have a `base_iamge` key for it.

##### Test Plan

CI for Alma Linux works correctly on this PR.

##### Additional Information

Fixes a bug introduced by https://github.com/netdata/netdata/pull/14529