### PR TITLE
Fix two issues with the edit-config script.

### DIFF
--- a/system/edit-config
+++ b/system/edit-config
@@ -44,7 +44,7 @@ abspath() {
       echo "$(cd "$(dirname "${1}")" && /usr/bin/env PWD= pwd -P)/$(basename "${1}")"
     else
       mkdir -p "${script_dir}/$(dirname "${1}")"
-      echo "${script_dir}/$(dirname "${1}")"
+      echo "${script_dir}/${1}"
     fi
   else
     echo "${script_dir}/${1}"

--- a/system/edit-config
+++ b/system/edit-config
@@ -34,10 +34,20 @@ error() {
 }
 
 abspath() {
-  if [ -d "${1}" ]; then
+  if [ -d "${1}/" ]; then
     echo "$(cd "${1}" && /usr/bin/env PWD= pwd -P)/"
-  else
+  elif [ -f "${1}" ]; then
     echo "$(cd "$(dirname "${1}")" && /usr/bin/env PWD= pwd -P)/$(basename "${1}")"
+  elif echo "${1}" | grep -q '/'; then
+    if echo "${1}" | grep -q '^/'; then
+      mkdir -p "$(dirname "${1}")"
+      echo "$(cd "$(dirname "${1}")" && /usr/bin/env PWD= pwd -P)/$(basename "${1}")"
+    else
+      mkdir -p "${script_dir}/$(dirname "${1}")"
+      echo "${script_dir}/$(dirname "${1}")"
+    fi
+  else
+    echo "${script_dir}/${1}"
   fi
 }
 


### PR DESCRIPTION
##### Summary

- If asked to edit a file in a sub-directory of the config directory but that sub-directory does not exist, create it. This is needed for sanity reasons WRT some of our other packaging code.
- If passed a relative path which does not resolve to an absolute path under the config directory, just prefix it with the config directory path instead. This fixes an issue reported by a user.

##### Test Plan

Two specific test cases:

1. Try to edit a file in a sub-directory of `/etc/netdata` when that sub-directory does not exist. It should be automatically created.
2. Try to edit a file under `/etc/netdata` without using a full path when you’re not in `/etc/netdata`. It should work correctly now.

##### Additional Information

Fixes: #14384
