### PR TITLE
/api/v2/data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -796,8 +796,12 @@ set(WEB_PLUGIN_FILES
         )
 
 set(API_PLUGIN_FILES
+        web/api/web_api.c
+        web/api/web_api.h
         web/api/web_api_v1.c
         web/api/web_api_v1.h
+        web/api/web_api_v2.c
+        web/api/web_api_v2.h
         web/api/badges/web_buffer_svg.c
         web/api/badges/web_buffer_svg.h
         web/api/exporters/allmetrics.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -628,8 +628,12 @@ API_PLUGIN_FILES = \
     web/api/formatters/rrdset2json.h \
     web/api/health/health_cmdapi.c \
     web/api/health/health_cmdapi.h \
+    web/api/web_api.c \
+    web/api/web_api.h \
     web/api/web_api_v1.c \
     web/api/web_api_v1.h \
+    web/api/web_api_v2.c \
+    web/api/web_api_v2.h \
     $(NULL)
 
 STREAMING_PLUGIN_FILES = \

--- a/daemon/common.h
+++ b/daemon/common.h
@@ -58,7 +58,7 @@
 #include "exporting/exporting_engine.h"
 
 // the netdata API
-#include "web/api/web_api_v1.h"
+#include "web/server/web_client.h"
 
 // all data collection plugins
 #include "collectors/all.h"

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -285,6 +285,8 @@ void rrdlabels_add_pair(DICTIONARY *dict, const char *string, RRDLABEL_SRC ls);
 void rrdlabels_get_value_to_buffer_or_null(DICTIONARY *labels, BUFFER *wb, const char *key, const char *quote, const char *null);
 void rrdlabels_value_to_buffer_array_item_or_null(DICTIONARY *labels, BUFFER *wb, const char *key);
 void rrdlabels_get_value_strdup_or_null(DICTIONARY *labels, char **value, const char *key);
+void rrdlabels_get_value_strcpyz(DICTIONARY *labels, char *dst, size_t dst_len, const char *key);
+STRING *rrdlabels_get_value_string_dup(DICTIONARY *labels, const char *key);
 void rrdlabels_flush(DICTIONARY *labels_dict);
 
 void rrdlabels_unmark_all(DICTIONARY *labels);

--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -2318,7 +2318,7 @@ void query_target_release(QUERY_TARGET *qt) {
         qm->link.host = NULL;
         qm->link.rca = NULL;
         qm->link.rma = NULL;
-        qm->link.qi = NULL;
+        qm->link.query_instance_id = 0;
     }
 
     // release the metrics
@@ -2538,8 +2538,8 @@ static void query_target_add_metric(QUERY_TARGET_LOCALS *qtl, RRDMETRIC_ACQUIRED
 
             qm->link.host = qtl->host;
             qm->link.rca = qtl->rca;
-            qm->link.qi = qi;
             qm->link.rma = rma;
+            qm->link.query_instance_id = qi->slot;
 
             qm->dimension.id = string_dup(rm->id);
             qm->dimension.name = string_dup(rm->name);
@@ -2626,7 +2626,8 @@ static void query_target_add_instance(QUERY_TARGET_LOCALS *qtl, RRDINSTANCE_ACQU
     }
 
     QUERY_INSTANCE *qi = &qt->instances.array[qt->instances.used];
-    qi->slot = qt->instances.used++;
+    qi->slot = qt->instances.used;
+    qt->instances.used++;
     qi->ria = rrdinstance_acquired_dup(ria);
     qi->queried = 0;
 

--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -401,6 +401,10 @@ bool rrdmetric_acquired_belongs_to_instance(RRDMETRIC_ACQUIRED *rma, RRDINSTANCE
     return rm->ri == ri;
 }
 
+time_t rrdinstance_acquired_update_every(RRDINSTANCE_ACQUIRED *ria) {
+    RRDINSTANCE *ri = rrdinstance_acquired_value(ria);
+    return ri->update_every_s;
+}
 time_t rrdmetric_acquired_first_entry(RRDMETRIC_ACQUIRED *rma) {
     RRDMETRIC *rm = rrdmetric_acquired_value(rma);
     return rm->first_time_s;

--- a/database/rrdcontext.c
+++ b/database/rrdcontext.c
@@ -2517,6 +2517,10 @@ static void query_target_add_metric(QUERY_TARGET_LOCALS *qtl, RRDMETRIC_ACQUIRED
             }
             QUERY_METRIC *qm = &qt->query.array[qt->query.used++];
 
+            qm->grouped_as.slot = 0;
+            qm->grouped_as.id = NULL;
+            qm->grouped_as.name = NULL;
+
             qm->plan.used = 0;
             qm->dimension.options = options;
 

--- a/database/rrdcontext.h
+++ b/database/rrdcontext.h
@@ -168,8 +168,8 @@ typedef struct query_metric {
     struct {
         RRDHOST *host;
         RRDCONTEXT_ACQUIRED *rca;
-        QUERY_INSTANCE *qi;
         RRDMETRIC_ACQUIRED *rma;
+        size_t query_instance_id;
     } link;
 
     struct {
@@ -296,6 +296,16 @@ typedef struct query_target {
     } hosts;
 
 } QUERY_TARGET;
+
+static inline NEVERNULL QUERY_METRIC *query_metric(QUERY_TARGET *qt, size_t id) {
+    internal_fatal(id >= qt->query.used, "QUERY: invalid query metric id");
+    return &qt->query.array[id];
+}
+
+static inline NEVERNULL QUERY_INSTANCE *query_instance(QUERY_TARGET *qt, size_t query_instance_id) {
+    internal_fatal(query_instance_id >= qt->instances.used, "QUERY: invalid query instance id");
+    return &qt->instances.array[query_instance_id];
+}
 
 void query_target_free(void);
 void query_target_release(QUERY_TARGET *qt);

--- a/database/rrdcontext.h
+++ b/database/rrdcontext.h
@@ -142,6 +142,12 @@ typedef struct query_plan_entry {
 
 #define QUERY_PLANS_MAX (RRD_STORAGE_TIERS * 2)
 
+typedef struct query_host {
+    size_t slot;
+    RRDHOST *host;
+    size_t queried;
+} QUERY_HOST;
+
 typedef struct query_instance {
     size_t slot;
     RRDINSTANCE_ACQUIRED *ria;
@@ -166,7 +172,7 @@ typedef struct query_metric {
     } plan;
 
     struct {
-        RRDHOST *host;
+        size_t query_host_id;
         RRDCONTEXT_ACQUIRED *rca;
         RRDMETRIC_ACQUIRED *rma;
         size_t query_instance_id;
@@ -289,13 +295,18 @@ typedef struct query_target {
     } contexts;
 
     struct {
-        RRDHOST **array;
+        QUERY_HOST *array;
         uint32_t used;                      // how many items of the array are used
         uint32_t size;                      // the size of the array
         SIMPLE_PATTERN *pattern;
     } hosts;
 
 } QUERY_TARGET;
+
+static inline NEVERNULL QUERY_HOST *query_host(QUERY_TARGET *qt, size_t id) {
+    internal_fatal(id >= qt->hosts.used, "QUERY: invalid query host id");
+    return &qt->hosts.array[id];
+}
 
 static inline NEVERNULL QUERY_METRIC *query_metric(QUERY_TARGET *qt, size_t id) {
     internal_fatal(id >= qt->query.used, "QUERY: invalid query metric id");

--- a/database/rrdcontext.h
+++ b/database/rrdcontext.h
@@ -26,11 +26,16 @@ typedef struct rrdcontext_acquired RRDCONTEXT_ACQUIRED;
 const char *rrdmetric_acquired_id(RRDMETRIC_ACQUIRED *rma);
 const char *rrdmetric_acquired_name(RRDMETRIC_ACQUIRED *rma);
 NETDATA_DOUBLE rrdmetric_acquired_last_stored_value(RRDMETRIC_ACQUIRED *rma);
+time_t rrdmetric_acquired_first_entry(RRDMETRIC_ACQUIRED *rma);
+time_t rrdmetric_acquired_last_entry(RRDMETRIC_ACQUIRED *rma);
+bool rrdmetric_acquired_belongs_to_instance(RRDMETRIC_ACQUIRED *rma, RRDINSTANCE_ACQUIRED *ria);
 
 const char *rrdinstance_acquired_id(RRDINSTANCE_ACQUIRED *ria);
 const char *rrdinstance_acquired_name(RRDINSTANCE_ACQUIRED *ria);
 DICTIONARY *rrdinstance_acquired_labels(RRDINSTANCE_ACQUIRED *ria);
 DICTIONARY *rrdinstance_acquired_functions(RRDINSTANCE_ACQUIRED *ria);
+
+bool rrdinstance_acquired_belongs_to_context(RRDINSTANCE_ACQUIRED *ria, RRDCONTEXT_ACQUIRED *rca);
 
 // ----------------------------------------------------------------------------
 // public API for rrdhost
@@ -67,6 +72,7 @@ int rrdcontexts_to_json(RRDHOST *host, BUFFER *wb, time_t after, time_t before, 
 // public API for rrdcontexts
 
 const char *rrdcontext_acquired_id(RRDCONTEXT_ACQUIRED *rca);
+bool rrdcontext_acquired_belongs_to_host(RRDCONTEXT_ACQUIRED *rca, RRDHOST *host);
 
 // ----------------------------------------------------------------------------
 // public API for rrddims
@@ -172,6 +178,8 @@ typedef struct query_metric {
 #define MAX_QUERY_TARGET_ID_LENGTH 255
 
 typedef struct query_target_request {
+    size_t version;
+
     // selecting / filtering metrics to be queried
     RRDHOST *host;                      // the host to be queried (can be NULL, hosts will be used)
     RRDCONTEXT_ACQUIRED *rca;           // the context to be queried (can be NULL)

--- a/database/rrdcontext.h
+++ b/database/rrdcontext.h
@@ -34,6 +34,7 @@ const char *rrdinstance_acquired_id(RRDINSTANCE_ACQUIRED *ria);
 const char *rrdinstance_acquired_name(RRDINSTANCE_ACQUIRED *ria);
 DICTIONARY *rrdinstance_acquired_labels(RRDINSTANCE_ACQUIRED *ria);
 DICTIONARY *rrdinstance_acquired_functions(RRDINSTANCE_ACQUIRED *ria);
+RRDHOST *rrdinstance_acquired_host(RRDINSTANCE_ACQUIRED *ria);
 
 bool rrdinstance_acquired_belongs_to_context(RRDINSTANCE_ACQUIRED *ria, RRDCONTEXT_ACQUIRED *rca);
 time_t rrdinstance_acquired_update_every(RRDINSTANCE_ACQUIRED *ria);
@@ -141,6 +142,14 @@ typedef struct query_plan_entry {
 
 #define QUERY_PLANS_MAX (RRD_STORAGE_TIERS * 2)
 
+typedef struct query_instance {
+    size_t slot;
+    RRDINSTANCE_ACQUIRED *ria;
+    STRING *id_fqdn;
+    STRING *name_fqdn;
+    size_t queried;             // number of dimensions queried
+} QUERY_INSTANCE;
+
 typedef struct query_metric {
     struct query_metric_tier {
         struct storage_engine *eng;
@@ -159,7 +168,7 @@ typedef struct query_metric {
     struct {
         RRDHOST *host;
         RRDCONTEXT_ACQUIRED *rca;
-        RRDINSTANCE_ACQUIRED *ria;
+        QUERY_INSTANCE *qi;
         RRDMETRIC_ACQUIRED *rma;
     } link;
 
@@ -168,11 +177,6 @@ typedef struct query_metric {
         STRING *name;
         RRDR_DIMENSION_FLAGS options;
     } dimension;
-
-    struct {
-        STRING *id;
-        STRING *name;
-    } chart;
 
     struct {
         size_t slot;
@@ -269,7 +273,7 @@ typedef struct query_target {
     } metrics;
 
     struct {
-        RRDINSTANCE_ACQUIRED **array;
+        QUERY_INSTANCE *array;
         uint32_t used;                      // how many items of the array are used
         uint32_t size;                      // the size of the array
         SIMPLE_PATTERN *pattern;

--- a/database/rrdcontext.h
+++ b/database/rrdcontext.h
@@ -36,6 +36,7 @@ DICTIONARY *rrdinstance_acquired_labels(RRDINSTANCE_ACQUIRED *ria);
 DICTIONARY *rrdinstance_acquired_functions(RRDINSTANCE_ACQUIRED *ria);
 
 bool rrdinstance_acquired_belongs_to_context(RRDINSTANCE_ACQUIRED *ria, RRDCONTEXT_ACQUIRED *rca);
+time_t rrdinstance_acquired_update_every(RRDINSTANCE_ACQUIRED *ria);
 
 // ----------------------------------------------------------------------------
 // public API for rrdhost

--- a/database/rrdcontext.h
+++ b/database/rrdcontext.h
@@ -174,6 +174,12 @@ typedef struct query_metric {
         STRING *name;
     } chart;
 
+    struct {
+        size_t slot;
+        STRING *id;
+        STRING *name;
+    } grouped_as;
+
 } QUERY_METRIC;
 
 #define MAX_QUERY_TARGET_ID_LENGTH 255

--- a/database/rrdlabels.c
+++ b/database/rrdlabels.c
@@ -677,6 +677,31 @@ void rrdlabels_get_value_strdup_or_null(DICTIONARY *labels, char **value, const 
     dictionary_acquired_item_release(labels, acquired_item);
 }
 
+void rrdlabels_get_value_strcpyz(DICTIONARY *labels, char *dst, size_t dst_len, const char *key) {
+    const DICTIONARY_ITEM *acquired_item = dictionary_get_and_acquire_item(labels, key);
+    RRDLABEL *lb = dictionary_acquired_item_value(acquired_item);
+
+    if(lb && lb->label_value)
+        strncpyz(dst, string2str(lb->label_value), dst_len);
+    else
+        dst[0] = '\0';
+
+    dictionary_acquired_item_release(labels, acquired_item);
+}
+
+STRING *rrdlabels_get_value_string_dup(DICTIONARY *labels, const char *key) {
+    const DICTIONARY_ITEM *acquired_item = dictionary_get_and_acquire_item(labels, key);
+    RRDLABEL *lb = dictionary_acquired_item_value(acquired_item);
+
+    STRING *ret = NULL;
+    if(lb && lb->label_value)
+        ret = string_dup(lb->label_value);
+
+    dictionary_acquired_item_release(labels, acquired_item);
+
+    return ret;
+}
+
 // ----------------------------------------------------------------------------
 // rrdlabels_unmark_all()
 // remove labels RRDLABEL_FLAG_OLD and RRDLABEL_FLAG_NEW from all dictionary items

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -186,11 +186,16 @@ struct sender_state {
     } replication;
 
     struct {
+        bool pending_data;
         size_t buffer_used_percentage;          // the current utilization of the sending buffer
         usec_t last_flush_time_ut;              // the last time the sender flushed the sending buffer in USEC
         time_t last_buffer_recreate_s;          // true when the sender buffer should be re-created
     } atomic;
 };
+
+#define rrdpush_sender_pipe_has_pending_data(sender) __atomic_load_n(&(sender)->atomic.pending_data, __ATOMIC_RELAXED)
+#define rrdpush_sender_pipe_set_pending_data(sender) __atomic_store_n(&(sender)->atomic.pending_data, true, __ATOMIC_RELAXED)
+#define rrdpush_sender_pipe_clear_pending_data(sender) __atomic_store_n(&(sender)->atomic.pending_data, false, __ATOMIC_RELAXED)
 
 #define rrdpush_sender_last_buffer_recreate_get(sender) __atomic_load_n(&(sender)->atomic.last_buffer_recreate_s, __ATOMIC_RELAXED)
 #define rrdpush_sender_last_buffer_recreate_set(sender, value) __atomic_store_n(&(sender)->atomic.last_buffer_recreate_s, value, __ATOMIC_RELAXED)

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -178,8 +178,16 @@ void sender_commit(struct sender_state *s, BUFFER *wb) {
 
     replication_recalculate_buffer_used_ratio_unsafe(s);
 
+    bool signal_sender = false;
+    if(!rrdpush_sender_pipe_has_pending_data(s)) {
+        rrdpush_sender_pipe_set_pending_data(s);
+        signal_sender = true;
+    }
+
     netdata_mutex_unlock(&s->mutex);
-    rrdpush_signal_sender_to_wake_up(s);
+
+    if(signal_sender)
+        rrdpush_signal_sender_to_wake_up(s);
 }
 
 static inline void rrdpush_sender_add_host_variable_to_buffer(BUFFER *wb, const RRDVAR_ACQUIRED *rva) {
@@ -1016,7 +1024,6 @@ void execute_commands(struct sender_state *s) {
 }
 
 struct rrdpush_sender_thread_data {
-    struct sender_state *sender_state;
     RRDHOST *host;
     char *pipe_buffer;
 };
@@ -1249,7 +1256,6 @@ void *rrdpush_sender_thread(void *ptr) {
 
     struct rrdpush_sender_thread_data *thread_data = callocz(1, sizeof(struct rrdpush_sender_thread_data));
     thread_data->pipe_buffer = mallocz(pipe_buffer_size);
-    thread_data->sender_state = s;
     thread_data->host = s->host;
 
     netdata_thread_cleanup_push(rrdpush_sender_thread_cleanup_callback, thread_data);
@@ -1305,8 +1311,10 @@ void *rrdpush_sender_thread(void *ptr) {
         netdata_mutex_lock(&s->mutex);
         size_t outstanding = cbuffer_next_unsafe(s->buffer, NULL);
         size_t available = cbuffer_available_size_unsafe(s->buffer);
-        if (unlikely(!outstanding))
+        if (unlikely(!outstanding)) {
+            rrdpush_sender_pipe_clear_pending_data(s);
             rrdpush_sender_cbuffer_recreate_timed(s, now_s, true, false);
+        }
         netdata_mutex_unlock(&s->mutex);
 
         worker_set_metric(WORKER_SENDER_JOB_BUFFER_RATIO, (NETDATA_DOUBLE)(s->buffer->max_size - available) * 100.0 / (NETDATA_DOUBLE)s->buffer->max_size);

--- a/web/api/formatters/csv/csv.c
+++ b/web/api/formatters/csv/csv.c
@@ -125,12 +125,12 @@ void rrdr2csv(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, const 
                     n = n * 100 / total;
 
                     if(unlikely(set_min_max)) {
-                        r->min = r->max = n;
+                        r->view.min = r->view.max = n;
                         set_min_max = 0;
                     }
 
-                    if(n < r->min) r->min = n;
-                    if(n > r->max) r->max = n;
+                    if(n < r->view.min) r->view.min = n;
+                    if(n > r->view.max) r->view.max = n;
                 }
 
                 buffer_print_netdata_double(wb, n);

--- a/web/api/formatters/csv/csv.c
+++ b/web/api/formatters/csv/csv.c
@@ -5,9 +5,8 @@
 
 void rrdr2csv(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, const char *startline, const char *separator, const char *endline, const char *betweenlines) {
     //info("RRD2CSV(): %s: BEGIN", r->st->id);
-    QUERY_TARGET *qt = r->internal.qt;
     long c, i;
-    const long used = qt->query.used;
+    const long used = (long)r->d;
 
     // print the csv header
     for(c = 0, i = 0; c < used ; c++) {
@@ -22,7 +21,7 @@ void rrdr2csv(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, const 
         }
         buffer_strcat(wb, separator);
         if(options & RRDR_OPTION_LABEL_QUOTES) buffer_strcat(wb, "\"");
-        buffer_strcat(wb, string2str(qt->query.array[c].dimension.name));
+        buffer_strcat(wb, string2str(r->dn[c]));
         if(options & RRDR_OPTION_LABEL_QUOTES) buffer_strcat(wb, "\"");
         i++;
     }

--- a/web/api/formatters/json/json.c
+++ b/web/api/formatters/json/json.c
@@ -154,6 +154,7 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
         NETDATA_DOUBLE *cn = &r->v[ i * r->d ];
         RRDR_VALUE_FLAGS *co = &r->o[ i * r->d ];
         NETDATA_DOUBLE *ar = &r->ar[ i * r->d ];
+        uint32_t *gbc = &r->gbc [ i * r->d ];
 
         time_t now = r->t[i];
 
@@ -217,7 +218,9 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
                 if(unlikely(!(r->od[c] & RRDR_DIMENSION_QUERIED))) continue;
 
                 NETDATA_DOUBLE n;
-                if(unlikely(options & RRDR_OPTION_INTERNAL_AR))
+                if(unlikely(options & RRDR_OPTION_INTERNAL_GBC))
+                    n = gbc[c];
+                else if(unlikely(options & RRDR_OPTION_INTERNAL_AR))
                     n = ar[c];
                 else
                     n = cn[c];
@@ -238,7 +241,9 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
                 continue;
 
             NETDATA_DOUBLE n;
-            if(unlikely(options & RRDR_OPTION_INTERNAL_AR))
+            if(unlikely(options & RRDR_OPTION_INTERNAL_GBC))
+                n = gbc[c];
+            else if(unlikely(options & RRDR_OPTION_INTERNAL_AR))
                 n = ar[c];
             else
                 n = cn[c];
@@ -248,7 +253,7 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
             if(unlikely( options & RRDR_OPTION_OBJECTSROWS ))
                 buffer_sprintf(wb, "%s%s%s: ", kq, string2str(r->dn[c]), kq);
 
-            if(co[c] & RRDR_VALUE_EMPTY && !(options & RRDR_OPTION_INTERNAL_AR)) {
+            if(co[c] & RRDR_VALUE_EMPTY && !(options & (RRDR_OPTION_INTERNAL_AR | RRDR_OPTION_INTERNAL_GBC))) {
                 if(unlikely(options & RRDR_OPTION_NULL2ZERO))
                     buffer_fast_strcat(wb, "0", 1);
                 else

--- a/web/api/formatters/json/json.c
+++ b/web/api/formatters/json/json.c
@@ -104,9 +104,8 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
     // -------------------------------------------------------------------------
     // print the JSON header
 
-    QUERY_TARGET *qt = r->internal.qt;
     long c, i;
-    const long used = qt->query.used;
+    const long used = (long)r->d;
 
     // print the header lines
     for(c = 0, i = 0; c < used ; c++) {
@@ -114,7 +113,7 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
             continue;
 
         buffer_fast_strcat(wb, pre_label, pre_label_len);
-        buffer_strcat(wb, string2str(qt->query.array[c].dimension.name));
+        buffer_strcat(wb, string2str(r->dn[c]));
         buffer_fast_strcat(wb, post_label, post_label_len);
         i++;
     }
@@ -247,7 +246,7 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
             buffer_fast_strcat(wb, pre_value, pre_value_len);
 
             if(unlikely( options & RRDR_OPTION_OBJECTSROWS ))
-                buffer_sprintf(wb, "%s%s%s: ", kq, string2str(qt->query.array[c].dimension.name), kq);
+                buffer_sprintf(wb, "%s%s%s: ", kq, string2str(r->dn[c]), kq);
 
             if(co[c] & RRDR_VALUE_EMPTY && !(options & RRDR_OPTION_INTERNAL_AR)) {
                 if(unlikely(options & RRDR_OPTION_NULL2ZERO))

--- a/web/api/formatters/json/json.c
+++ b/web/api/formatters/json/json.c
@@ -42,7 +42,7 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
         strcpy(post_value,         "}");
         strcpy(post_line,          "]}");
         snprintfz(data_begin, 100, "\n  ],\n    %srows%s:\n [\n", kq, kq);
-        strcpy(finish,             "\n  ]\n }");
+        strcpy(finish,             "\n        ]\n    }");
 
         snprintfz(overflow_annotation, 200, ",{%sv%s:%sRESET OR OVERFLOW%s},{%sv%s:%sThe counters have been wrapped.%s}", kq, kq, sq, sq, kq, kq, sq, sq);
         snprintfz(normal_annotation,   200, ",{%sv%s:null},{%sv%s:null}", kq, kq, kq, kq);
@@ -69,9 +69,9 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
             dates_with_new = 0;
         }
         if( options & RRDR_OPTION_OBJECTSROWS )
-            strcpy(pre_date, "   {");
+            strcpy(pre_date, "            {");
         else
-            strcpy(pre_date, "   [");
+            strcpy(pre_date, "            [");
         strcpy(pre_label,  ",\"");
         strcpy(post_label, "\"");
         strcpy(pre_value,  ",");
@@ -79,10 +79,10 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
             strcpy(post_line, "}");
         else
             strcpy(post_line, "]");
-        snprintfz(data_begin, 100, "],\n  %sdata%s:[\n", kq, kq);
-        strcpy(finish,             "\n  ]\n }");
+        snprintfz(data_begin, 100, "],\n        %sdata%s:[\n", kq, kq);
+        strcpy(finish,             "\n        ]\n    }");
 
-        buffer_sprintf(wb, "{\n  %slabels%s:[", kq, kq);
+        buffer_sprintf(wb, "{\n        %slabels%s:[", kq, kq);
         buffer_sprintf(wb, "%stime%s", sq, sq);
 
         if( options & RRDR_OPTION_OBJECTSROWS )
@@ -262,12 +262,12 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
                     n = n * 100 / total;
 
                     if(unlikely(set_min_max)) {
-                        r->min = r->max = n;
+                        r->view.min = r->view.max = n;
                         set_min_max = 0;
                     }
 
-                    if(n < r->min) r->min = n;
-                    if(n > r->max) r->max = n;
+                    if(n < r->view.min) r->view.min = n;
+                    if(n > r->view.max) r->view.max = n;
                 }
 
                 buffer_print_netdata_double(wb, n);

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -569,8 +569,15 @@ void rrdr_json_wrapper_begin2(RRDR *r, BUFFER *wb, DATASOURCE_FORMAT format, RRD
                             buffer_json_member_add_time_t(wb, "first_entry", first_entry_s);
                             buffer_json_member_add_time_t(wb, "last_entry", last_entry_s ? last_entry_s : now_s);
 
-                            if(qm && options & RRDR_OPTION_SHOW_PLAN)
-                                jsonwrap_query_metric_plan(wb, qm);
+                            if(qm) {
+                                if(qm->dimension.options & RRDR_DIMENSION_GROUPED) {
+                                    // buffer_json_member_add_string(wb, "grouped_as_id", string2str(qm->grouped_as.id));
+                                    buffer_json_member_add_string(wb, "grouped_as", string2str(qm->grouped_as.name));
+                                }
+
+                                if(options & RRDR_OPTION_SHOW_PLAN)
+                                    jsonwrap_query_metric_plan(wb, qm);
+                            }
                         }
                         buffer_json_object_close(wb); // metric
                     }

--- a/web/api/formatters/json_wrapper.h
+++ b/web/api/formatters/json_wrapper.h
@@ -11,6 +11,7 @@ typedef void (*wrapper_end_t)(RRDR *r, BUFFER *wb, DATASOURCE_FORMAT format, RRD
 
 void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, DATASOURCE_FORMAT format, RRDR_OPTIONS options, bool string_value, RRDR_TIME_GROUPING group_method);
 void rrdr_json_wrapper_anomaly_rates(RRDR *r, BUFFER *wb, DATASOURCE_FORMAT format, RRDR_OPTIONS options, bool string_value);
+void rrdr_json_wrapper_group_by_count(RRDR *r, BUFFER *wb, DATASOURCE_FORMAT format, RRDR_OPTIONS options, bool string_value);
 void rrdr_json_wrapper_end(RRDR *r, BUFFER *wb, DATASOURCE_FORMAT format, RRDR_OPTIONS options, bool string_value);
 
 void rrdr_json_wrapper_begin2(RRDR *r, BUFFER *wb, DATASOURCE_FORMAT format, RRDR_OPTIONS options, bool string_value, RRDR_TIME_GROUPING group_method);

--- a/web/api/formatters/json_wrapper.h
+++ b/web/api/formatters/json_wrapper.h
@@ -6,10 +6,13 @@
 #include "rrd2json.h"
 #include "web/api/queries/query.h"
 
+typedef void (*wrapper_begin_t)(RRDR *r, BUFFER *wb, DATASOURCE_FORMAT format, RRDR_OPTIONS options, bool string_value, RRDR_TIME_GROUPING group_method);
+typedef void (*wrapper_end_t)(RRDR *r, BUFFER *wb, DATASOURCE_FORMAT format, RRDR_OPTIONS options, bool string_value);
 
-void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, int string_value,
-                             RRDR_TIME_GROUPING group_method);
-void rrdr_json_wrapper_anomaly_rates(RRDR *r, BUFFER *wb, uint32_t format, uint32_t options, int string_value);
-void rrdr_json_wrapper_end(RRDR *r, BUFFER *wb, uint32_t format, uint32_t options, int string_value);
+void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb, DATASOURCE_FORMAT format, RRDR_OPTIONS options, bool string_value, RRDR_TIME_GROUPING group_method);
+void rrdr_json_wrapper_anomaly_rates(RRDR *r, BUFFER *wb, DATASOURCE_FORMAT format, RRDR_OPTIONS options, bool string_value);
+void rrdr_json_wrapper_end(RRDR *r, BUFFER *wb, DATASOURCE_FORMAT format, RRDR_OPTIONS options, bool string_value);
+
+void rrdr_json_wrapper_begin2(RRDR *r, BUFFER *wb, DATASOURCE_FORMAT format, RRDR_OPTIONS options, bool string_value, RRDR_TIME_GROUPING group_method);
 
 #endif //NETDATA_API_FORMATTER_JSON_WRAPPER_H

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -169,6 +169,7 @@ RRDR *data_query_group_by(RRDR *r) {
         int pos = -1, *set;
         QUERY_METRIC *qm = query_metric(qt, c);
         QUERY_INSTANCE *qi = query_instance(qt, qm->link.query_instance_id);
+        QUERY_HOST *qh = query_host(qt, qm->link.query_host_id);
 
         switch(qt->request.group_by) {
             default:
@@ -195,11 +196,11 @@ RRDR *data_query_group_by(RRDR *r) {
                 break;
 
             case RRDR_GROUP_BY_NODE:
-                set = dictionary_set(groups, qm->link.host->machine_guid, &pos, sizeof(int));
+                set = dictionary_set(groups, qh->host->machine_guid, &pos, sizeof(int));
                 if(*set == -1) {
                     *set = pos = added++;
-                    entries[pos].id = string_strdupz(qm->link.host->machine_guid);
-                    entries[pos].name = string_dup(qm->link.host->hostname);
+                    entries[pos].id = string_strdupz(qh->host->machine_guid);
+                    entries[pos].name = string_dup(qh->host->hostname);
                 }
                 else
                     pos = *set;

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -3,6 +3,22 @@
 #ifndef NETDATA_RRD2JSON_H
 #define NETDATA_RRD2JSON_H 1
 
+// type of JSON generations
+typedef enum {
+    DATASOURCE_JSON             = 0,
+    DATASOURCE_DATATABLE_JSON   = 1,
+    DATASOURCE_DATATABLE_JSONP  = 2,
+    DATASOURCE_SSV              = 3,
+    DATASOURCE_CSV              = 4,
+    DATASOURCE_JSONP            = 5,
+    DATASOURCE_TSV              = 6,
+    DATASOURCE_HTML             = 7,
+    DATASOURCE_JS_ARRAY         = 8,
+    DATASOURCE_SSV_COMMA        = 9,
+    DATASOURCE_CSV_JSON_ARRAY   = 10,
+    DATASOURCE_CSV_MARKDOWN     = 11,
+} DATASOURCE_FORMAT;
+
 #include "web/api/web_api_v1.h"
 
 #include "web/api/exporters/allmetrics.h"
@@ -23,22 +39,6 @@
 
 #define API_RELATIVE_TIME_MAX (3 * 365 * 86400)
 
-// type of JSON generations
-typedef enum {
-    DATASOURCE_JSON             = 0,
-    DATASOURCE_DATATABLE_JSON   = 1,
-    DATASOURCE_DATATABLE_JSONP  = 2,
-    DATASOURCE_SSV              = 3,
-    DATASOURCE_CSV              = 4,
-    DATASOURCE_JSONP            = 5,
-    DATASOURCE_TSV              = 6,
-    DATASOURCE_HTML             = 7,
-    DATASOURCE_JS_ARRAY         = 8,
-    DATASOURCE_SSV_COMMA        = 9,
-    DATASOURCE_CSV_JSON_ARRAY   = 10,
-    DATASOURCE_CSV_MARKDOWN     = 11,
-} DATASOURCE_FORMAT;
-
 #define DATASOURCE_FORMAT_JSON "json"
 #define DATASOURCE_FORMAT_DATATABLE_JSON "datatable"
 #define DATASOURCE_FORMAT_DATATABLE_JSONP "datasource"
@@ -53,7 +53,7 @@ typedef enum {
 #define DATASOURCE_FORMAT_CSV_MARKDOWN "markdown"
 
 void rrd_stats_api_v1_chart(RRDSET *st, BUFFER *wb);
-const char *rrdr_format_to_string(uint32_t format);
+const char *rrdr_format_to_string(DATASOURCE_FORMAT format);
 
 int data_query_execute(ONEWAYALLOC *owa, BUFFER *wb, struct query_target *qt, time_t *latest_timestamp);
 

--- a/web/api/formatters/ssv/ssv.c
+++ b/web/api/formatters/ssv/ssv.c
@@ -20,12 +20,12 @@ void rrdr2ssv(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, const char *prefix, con
         NETDATA_DOUBLE v = rrdr2value(r, i, options, &all_values_are_null, NULL);
 
         if(likely(i != start)) {
-            if(r->min > v) r->min = v;
-            if(r->max < v) r->max = v;
+            if(r->view.min > v) r->view.min = v;
+            if(r->view.max < v) r->view.max = v;
         }
         else {
-            r->min = v;
-            r->max = v;
+            r->view.min = v;
+            r->view.max = v;
         }
 
         if(likely(i != start))

--- a/web/api/formatters/value/value.c
+++ b/web/api/formatters/value/value.c
@@ -49,12 +49,12 @@ inline NETDATA_DOUBLE rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all
             n = n * 100 / total;
 
             if(unlikely(set_min_max)) {
-                r->min = r->max = n;
+                r->view.min = r->view.max = n;
                 set_min_max = 0;
             }
 
-            if(n < r->min) r->min = n;
-            if(n > r->max) r->max = n;
+            if(n < r->view.min) r->view.min = n;
+            if(n > r->view.max) r->view.max = n;
         }
 
         if(unlikely(init)) {
@@ -140,14 +140,14 @@ QUERY_VALUE rrdmetric2value(RRDHOST *host,
     }
     else {
         qv = (QUERY_VALUE) {
-                .after = r->after,
-                .before = r->before,
-                .points_read = r->internal.db_points_read,
-                .result_points = r->internal.result_points_generated,
+                .after = r->view.after,
+                .before = r->view.before,
+                .points_read = r->stats.db_points_read,
+                .result_points = r->stats.result_points_generated,
         };
 
         for(size_t t = 0; t < storage_tiers ;t++)
-            qv.storage_points_per_tier[t] = r->internal.tier_points_read[t];
+            qv.storage_points_per_tier[t] = r->stats.tier_points_read[t];
 
         long i = (!(options & RRDR_OPTION_REVERSED))?(long)rrdr_rows(r) - 1:0;
         int all_values_are_null = 0;

--- a/web/api/formatters/value/value.c
+++ b/web/api/formatters/value/value.c
@@ -110,6 +110,7 @@ QUERY_VALUE rrdmetric2value(RRDHOST *host,
                             size_t tier, time_t timeout, QUERY_SOURCE query_source, STORAGE_PRIORITY priority
 ) {
     QUERY_TARGET_REQUEST qtr = {
+            .version = 1,
             .host = host,
             .rca = rca,
             .ria = ria,

--- a/web/api/queries/average/average.c
+++ b/web/api/queries/average/average.c
@@ -11,30 +11,30 @@ struct grouping_average {
 };
 
 void grouping_create_average(RRDR *r, const char *options __maybe_unused) {
-    r->internal.grouping_data = onewayalloc_callocz(r->internal.owa, 1, sizeof(struct grouping_average));
+    r->grouping.data = onewayalloc_callocz(r->internal.owa, 1, sizeof(struct grouping_average));
 }
 
 // resets when switches dimensions
 // so, clear everything to restart
 void grouping_reset_average(RRDR *r) {
-    struct grouping_average *g = (struct grouping_average *)r->internal.grouping_data;
+    struct grouping_average *g = (struct grouping_average *)r->grouping.data;
     g->sum = 0;
     g->count = 0;
 }
 
 void grouping_free_average(RRDR *r) {
-    onewayalloc_freez(r->internal.owa, r->internal.grouping_data);
-    r->internal.grouping_data = NULL;
+    onewayalloc_freez(r->internal.owa, r->grouping.data);
+    r->grouping.data = NULL;
 }
 
 void grouping_add_average(RRDR *r, NETDATA_DOUBLE value) {
-    struct grouping_average *g = (struct grouping_average *)r->internal.grouping_data;
+    struct grouping_average *g = (struct grouping_average *)r->grouping.data;
     g->sum += value;
     g->count++;
 }
 
 NETDATA_DOUBLE grouping_flush_average(RRDR *r,  RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
-    struct grouping_average *g = (struct grouping_average *)r->internal.grouping_data;
+    struct grouping_average *g = (struct grouping_average *)r->grouping.data;
 
     NETDATA_DOUBLE value;
 
@@ -43,12 +43,9 @@ NETDATA_DOUBLE grouping_flush_average(RRDR *r,  RRDR_VALUE_FLAGS *rrdr_value_opt
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
     }
     else {
-        if(unlikely(r->internal.resampling_group != 1)) {
-            if (unlikely(r->result_options & RRDR_RESULT_OPTION_VARIABLE_STEP))
-                value = g->sum / g->count / r->internal.resampling_divisor;
-            else
-                value = g->sum / r->internal.resampling_divisor;
-        } else
+        if(unlikely(r->grouping.resampling_group != 1))
+            value = g->sum / r->grouping.resampling_divisor;
+        else
             value = g->sum / g->count;
     }
 

--- a/web/api/queries/countif/countif.c
+++ b/web/api/queries/countif/countif.c
@@ -38,7 +38,7 @@ static size_t countif_greaterequal(NETDATA_DOUBLE v, NETDATA_DOUBLE target) {
 
 void grouping_create_countif(RRDR *r, const char *options __maybe_unused) {
     struct grouping_countif *g = onewayalloc_callocz(r->internal.owa, 1, sizeof(struct grouping_countif));
-    r->internal.grouping_data = g;
+    r->grouping.data = g;
 
     if(options && *options) {
         // skip any leading spaces
@@ -100,24 +100,24 @@ void grouping_create_countif(RRDR *r, const char *options __maybe_unused) {
 // resets when switches dimensions
 // so, clear everything to restart
 void grouping_reset_countif(RRDR *r) {
-    struct grouping_countif *g = (struct grouping_countif *)r->internal.grouping_data;
+    struct grouping_countif *g = (struct grouping_countif *)r->grouping.data;
     g->matched = 0;
     g->count = 0;
 }
 
 void grouping_free_countif(RRDR *r) {
-    onewayalloc_freez(r->internal.owa, r->internal.grouping_data);
-    r->internal.grouping_data = NULL;
+    onewayalloc_freez(r->internal.owa, r->grouping.data);
+    r->grouping.data = NULL;
 }
 
 void grouping_add_countif(RRDR *r, NETDATA_DOUBLE value) {
-    struct grouping_countif *g = (struct grouping_countif *)r->internal.grouping_data;
+    struct grouping_countif *g = (struct grouping_countif *)r->grouping.data;
     g->matched += g->comparison(value, g->target);
     g->count++;
 }
 
 NETDATA_DOUBLE grouping_flush_countif(RRDR *r,  RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
-    struct grouping_countif *g = (struct grouping_countif *)r->internal.grouping_data;
+    struct grouping_countif *g = (struct grouping_countif *)r->grouping.data;
 
     NETDATA_DOUBLE value;
 

--- a/web/api/queries/des/des.c
+++ b/web/api/queries/des/des.c
@@ -35,13 +35,13 @@ static inline NETDATA_DOUBLE window(RRDR *r, struct grouping_des *g) {
     (void)g;
 
     NETDATA_DOUBLE points;
-    if(r->group == 1) {
+    if(r->view.group == 1) {
         // provide a running DES
-        points = (NETDATA_DOUBLE)r->internal.points_wanted;
+        points = (NETDATA_DOUBLE)r->grouping.points_wanted;
     }
     else {
         // provide a SES with flush points
-        points = (NETDATA_DOUBLE)r->group;
+        points = (NETDATA_DOUBLE)r->view.group;
     }
 
     // https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
@@ -76,13 +76,13 @@ void grouping_create_des(RRDR *r, const char *options __maybe_unused) {
     g->level = 0.0;
     g->trend = 0.0;
     g->count = 0;
-    r->internal.grouping_data = g;
+    r->grouping.data = g;
 }
 
 // resets when switches dimensions
 // so, clear everything to restart
 void grouping_reset_des(RRDR *r) {
-    struct grouping_des *g = (struct grouping_des *)r->internal.grouping_data;
+    struct grouping_des *g = (struct grouping_des *)r->grouping.data;
     g->level = 0.0;
     g->trend = 0.0;
     g->count = 0;
@@ -92,12 +92,12 @@ void grouping_reset_des(RRDR *r) {
 }
 
 void grouping_free_des(RRDR *r) {
-    onewayalloc_freez(r->internal.owa, r->internal.grouping_data);
-    r->internal.grouping_data = NULL;
+    onewayalloc_freez(r->internal.owa, r->grouping.data);
+    r->grouping.data = NULL;
 }
 
 void grouping_add_des(RRDR *r, NETDATA_DOUBLE value) {
-    struct grouping_des *g = (struct grouping_des *)r->internal.grouping_data;
+    struct grouping_des *g = (struct grouping_des *)r->grouping.data;
 
     if(likely(g->count > 0)) {
         // we have at least a number so far
@@ -124,7 +124,7 @@ void grouping_add_des(RRDR *r, NETDATA_DOUBLE value) {
 }
 
 NETDATA_DOUBLE grouping_flush_des(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
-    struct grouping_des *g = (struct grouping_des *)r->internal.grouping_data;
+    struct grouping_des *g = (struct grouping_des *)r->grouping.data;
 
     if(unlikely(!g->count || !netdata_double_isnumber(g->level))) {
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;

--- a/web/api/queries/incremental_sum/incremental_sum.c
+++ b/web/api/queries/incremental_sum/incremental_sum.c
@@ -12,25 +12,25 @@ struct grouping_incremental_sum {
 };
 
 void grouping_create_incremental_sum(RRDR *r, const char *options __maybe_unused) {
-    r->internal.grouping_data = onewayalloc_callocz(r->internal.owa, 1, sizeof(struct grouping_incremental_sum));
+    r->grouping.data = onewayalloc_callocz(r->internal.owa, 1, sizeof(struct grouping_incremental_sum));
 }
 
 // resets when switches dimensions
 // so, clear everything to restart
 void grouping_reset_incremental_sum(RRDR *r) {
-    struct grouping_incremental_sum *g = (struct grouping_incremental_sum *)r->internal.grouping_data;
+    struct grouping_incremental_sum *g = (struct grouping_incremental_sum *)r->grouping.data;
     g->first = 0;
     g->last = 0;
     g->count = 0;
 }
 
 void grouping_free_incremental_sum(RRDR *r) {
-    onewayalloc_freez(r->internal.owa, r->internal.grouping_data);
-    r->internal.grouping_data = NULL;
+    onewayalloc_freez(r->internal.owa, r->grouping.data);
+    r->grouping.data = NULL;
 }
 
 void grouping_add_incremental_sum(RRDR *r, NETDATA_DOUBLE value) {
-    struct grouping_incremental_sum *g = (struct grouping_incremental_sum *)r->internal.grouping_data;
+    struct grouping_incremental_sum *g = (struct grouping_incremental_sum *)r->grouping.data;
 
     if(unlikely(!g->count)) {
         g->first = value;
@@ -43,7 +43,7 @@ void grouping_add_incremental_sum(RRDR *r, NETDATA_DOUBLE value) {
 }
 
 NETDATA_DOUBLE grouping_flush_incremental_sum(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
-    struct grouping_incremental_sum *g = (struct grouping_incremental_sum *)r->internal.grouping_data;
+    struct grouping_incremental_sum *g = (struct grouping_incremental_sum *)r->grouping.data;
 
     NETDATA_DOUBLE value;
 

--- a/web/api/queries/max/max.c
+++ b/web/api/queries/max/max.c
@@ -11,24 +11,24 @@ struct grouping_max {
 };
 
 void grouping_create_max(RRDR *r, const char *options __maybe_unused) {
-    r->internal.grouping_data = onewayalloc_callocz(r->internal.owa, 1, sizeof(struct grouping_max));
+    r->grouping.data = onewayalloc_callocz(r->internal.owa, 1, sizeof(struct grouping_max));
 }
 
 // resets when switches dimensions
 // so, clear everything to restart
 void grouping_reset_max(RRDR *r) {
-    struct grouping_max *g = (struct grouping_max *)r->internal.grouping_data;
+    struct grouping_max *g = (struct grouping_max *)r->grouping.data;
     g->max = 0;
     g->count = 0;
 }
 
 void grouping_free_max(RRDR *r) {
-    onewayalloc_freez(r->internal.owa, r->internal.grouping_data);
-    r->internal.grouping_data = NULL;
+    onewayalloc_freez(r->internal.owa, r->grouping.data);
+    r->grouping.data = NULL;
 }
 
 void grouping_add_max(RRDR *r, NETDATA_DOUBLE value) {
-    struct grouping_max *g = (struct grouping_max *)r->internal.grouping_data;
+    struct grouping_max *g = (struct grouping_max *)r->grouping.data;
 
     if(!g->count || fabsndd(value) > fabsndd(g->max)) {
         g->max = value;
@@ -37,7 +37,7 @@ void grouping_add_max(RRDR *r, NETDATA_DOUBLE value) {
 }
 
 NETDATA_DOUBLE grouping_flush_max(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
-    struct grouping_max *g = (struct grouping_max *)r->internal.grouping_data;
+    struct grouping_max *g = (struct grouping_max *)r->grouping.data;
 
     NETDATA_DOUBLE value;
 

--- a/web/api/queries/median/median.c
+++ b/web/api/queries/median/median.c
@@ -14,7 +14,7 @@ struct grouping_median {
 };
 
 void grouping_create_median_internal(RRDR *r, const char *options, NETDATA_DOUBLE def) {
-    long entries = r->group;
+    long entries = r->view.group;
     if(entries < 10) entries = 10;
 
     struct grouping_median *g = (struct grouping_median *)onewayalloc_callocz(r->internal.owa, 1, sizeof(struct grouping_median));
@@ -30,7 +30,7 @@ void grouping_create_median_internal(RRDR *r, const char *options, NETDATA_DOUBL
     }
 
     g->percent = g->percent / 100.0;
-    r->internal.grouping_data = g;
+    r->grouping.data = g;
 }
 
 void grouping_create_median(RRDR *r, const char *options) {
@@ -64,20 +64,20 @@ void grouping_create_trimmed_median25(RRDR *r, const char *options) {
 // resets when switches dimensions
 // so, clear everything to restart
 void grouping_reset_median(RRDR *r) {
-    struct grouping_median *g = (struct grouping_median *)r->internal.grouping_data;
+    struct grouping_median *g = (struct grouping_median *)r->grouping.data;
     g->next_pos = 0;
 }
 
 void grouping_free_median(RRDR *r) {
-    struct grouping_median *g = (struct grouping_median *)r->internal.grouping_data;
+    struct grouping_median *g = (struct grouping_median *)r->grouping.data;
     if(g) onewayalloc_freez(r->internal.owa, g->series);
 
-    onewayalloc_freez(r->internal.owa, r->internal.grouping_data);
-    r->internal.grouping_data = NULL;
+    onewayalloc_freez(r->internal.owa, r->grouping.data);
+    r->grouping.data = NULL;
 }
 
 void grouping_add_median(RRDR *r, NETDATA_DOUBLE value) {
-    struct grouping_median *g = (struct grouping_median *)r->internal.grouping_data;
+    struct grouping_median *g = (struct grouping_median *)r->grouping.data;
 
     if(unlikely(g->next_pos >= g->series_size)) {
         g->series = onewayalloc_doublesize( r->internal.owa, g->series, g->series_size * sizeof(NETDATA_DOUBLE));
@@ -88,7 +88,7 @@ void grouping_add_median(RRDR *r, NETDATA_DOUBLE value) {
 }
 
 NETDATA_DOUBLE grouping_flush_median(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
-    struct grouping_median *g = (struct grouping_median *)r->internal.grouping_data;
+    struct grouping_median *g = (struct grouping_median *)r->grouping.data;
 
     size_t available_slots = g->next_pos;
     NETDATA_DOUBLE value;

--- a/web/api/queries/min/min.c
+++ b/web/api/queries/min/min.c
@@ -11,24 +11,24 @@ struct grouping_min {
 };
 
 void grouping_create_min(RRDR *r, const char *options __maybe_unused) {
-    r->internal.grouping_data = onewayalloc_callocz(r->internal.owa, 1, sizeof(struct grouping_min));
+    r->grouping.data = onewayalloc_callocz(r->internal.owa, 1, sizeof(struct grouping_min));
 }
 
 // resets when switches dimensions
 // so, clear everything to restart
 void grouping_reset_min(RRDR *r) {
-    struct grouping_min *g = (struct grouping_min *)r->internal.grouping_data;
+    struct grouping_min *g = (struct grouping_min *)r->grouping.data;
     g->min = 0;
     g->count = 0;
 }
 
 void grouping_free_min(RRDR *r) {
-    onewayalloc_freez(r->internal.owa, r->internal.grouping_data);
-    r->internal.grouping_data = NULL;
+    onewayalloc_freez(r->internal.owa, r->grouping.data);
+    r->grouping.data = NULL;
 }
 
 void grouping_add_min(RRDR *r, NETDATA_DOUBLE value) {
-    struct grouping_min *g = (struct grouping_min *)r->internal.grouping_data;
+    struct grouping_min *g = (struct grouping_min *)r->grouping.data;
 
     if(!g->count || fabsndd(value) < fabsndd(g->min)) {
         g->min = value;
@@ -37,7 +37,7 @@ void grouping_add_min(RRDR *r, NETDATA_DOUBLE value) {
 }
 
 NETDATA_DOUBLE grouping_flush_min(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
-    struct grouping_min *g = (struct grouping_min *)r->internal.grouping_data;
+    struct grouping_min *g = (struct grouping_min *)r->grouping.data;
 
     NETDATA_DOUBLE value;
 

--- a/web/api/queries/percentile/percentile.c
+++ b/web/api/queries/percentile/percentile.c
@@ -14,7 +14,7 @@ struct grouping_percentile {
 };
 
 static void grouping_create_percentile_internal(RRDR *r, const char *options, NETDATA_DOUBLE def) {
-    long entries = r->group;
+    long entries = r->view.group;
     if(entries < 10) entries = 10;
 
     struct grouping_percentile *g = (struct grouping_percentile *)onewayalloc_callocz(r->internal.owa, 1, sizeof(struct grouping_percentile));
@@ -30,7 +30,7 @@ static void grouping_create_percentile_internal(RRDR *r, const char *options, NE
     }
 
     g->percent = g->percent / 100.0;
-    r->internal.grouping_data = g;
+    r->grouping.data = g;
 }
 
 void grouping_create_percentile25(RRDR *r, const char *options) {
@@ -64,20 +64,20 @@ void grouping_create_percentile99(RRDR *r, const char *options) {
 // resets when switches dimensions
 // so, clear everything to restart
 void grouping_reset_percentile(RRDR *r) {
-    struct grouping_percentile *g = (struct grouping_percentile *)r->internal.grouping_data;
+    struct grouping_percentile *g = (struct grouping_percentile *)r->grouping.data;
     g->next_pos = 0;
 }
 
 void grouping_free_percentile(RRDR *r) {
-    struct grouping_percentile *g = (struct grouping_percentile *)r->internal.grouping_data;
+    struct grouping_percentile *g = (struct grouping_percentile *)r->grouping.data;
     if(g) onewayalloc_freez(r->internal.owa, g->series);
 
-    onewayalloc_freez(r->internal.owa, r->internal.grouping_data);
-    r->internal.grouping_data = NULL;
+    onewayalloc_freez(r->internal.owa, r->grouping.data);
+    r->grouping.data = NULL;
 }
 
 void grouping_add_percentile(RRDR *r, NETDATA_DOUBLE value) {
-    struct grouping_percentile *g = (struct grouping_percentile *)r->internal.grouping_data;
+    struct grouping_percentile *g = (struct grouping_percentile *)r->grouping.data;
 
     if(unlikely(g->next_pos >= g->series_size)) {
         g->series = onewayalloc_doublesize( r->internal.owa, g->series, g->series_size * sizeof(NETDATA_DOUBLE));
@@ -88,7 +88,7 @@ void grouping_add_percentile(RRDR *r, NETDATA_DOUBLE value) {
 }
 
 NETDATA_DOUBLE grouping_flush_percentile(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
-    struct grouping_percentile *g = (struct grouping_percentile *)r->internal.grouping_data;
+    struct grouping_percentile *g = (struct grouping_percentile *)r->grouping.data;
 
     NETDATA_DOUBLE value;
     size_t available_slots = g->next_pos;

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -659,6 +659,78 @@ static void rrdr_set_grouping_function(RRDR *r, RRDR_TIME_GROUPING group_method)
     }
 }
 
+RRDR_GROUP_BY group_by_parse(const char *s) {
+    if(strcmp(s, "dimension") == 0)
+        return RRDR_GROUP_BY_DIMENSION;
+
+    if(strcmp(s, "node") == 0)
+        return RRDR_GROUP_BY_NODE;
+
+    if(strcmp(s, "instance") == 0)
+        return RRDR_GROUP_BY_INSTANCE;
+
+    if(strcmp(s, "label") == 0)
+        return RRDR_GROUP_BY_LABEL;
+
+    return RRDR_GROUP_BY_DIMENSION;
+}
+
+const char *group_by_to_string(RRDR_GROUP_BY group_by) {
+    switch(group_by) {
+        default:
+        case RRDR_GROUP_BY_DIMENSION:
+            return "dimension";
+
+        case RRDR_GROUP_BY_NODE:
+            return "node";
+
+        case RRDR_GROUP_BY_INSTANCE:
+            return "instance";
+
+        case RRDR_GROUP_BY_LABEL:
+            return "label";
+    }
+}
+
+RRDR_GROUP_BY_FUNCTION group_by_function_parse(const char *s) {
+    if(strcmp(s, "sum-count") == 0)
+        return RRDR_GROUP_BY_FUNCTION_SUM_COUNT;
+
+    if(strcmp(s, "average") == 0)
+        return RRDR_GROUP_BY_FUNCTION_AVERAGE;
+
+    if(strcmp(s, "min") == 0)
+        return RRDR_GROUP_BY_FUNCTION_MIN;
+
+    if(strcmp(s, "max") == 0)
+        return RRDR_GROUP_BY_FUNCTION_MAX;
+
+    if(strcmp(s, "sum") == 0)
+        return RRDR_GROUP_BY_FUNCTION_SUM;
+
+    return RRDR_GROUP_BY_FUNCTION_AVERAGE;
+}
+
+const char *group_by_function_to_string(RRDR_GROUP_BY_FUNCTION group_by_function) {
+    switch(group_by_function) {
+        default:
+        case RRDR_GROUP_BY_FUNCTION_AVERAGE:
+            return "average";
+
+        case RRDR_GROUP_BY_FUNCTION_SUM_COUNT:
+            return "sum-count";
+
+        case RRDR_GROUP_BY_FUNCTION_MIN:
+            return "min";
+
+        case RRDR_GROUP_BY_FUNCTION_MAX:
+            return "max";
+
+        case RRDR_GROUP_BY_FUNCTION_SUM:
+            return "sum";
+    }
+}
+
 // ----------------------------------------------------------------------------
 // helpers to find our way in RRDR
 

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -2237,6 +2237,7 @@ RRDR *rrd2rrdr_legacy(
         STORAGE_PRIORITY priority) {
 
     QUERY_TARGET_REQUEST qtr = {
+            .version = 1,
             .st = st,
             .points = points,
             .after = after,

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -2349,6 +2349,7 @@ RRDR *rrd2rrdr(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
             r->od[c] |= RRDR_DIMENSION_QUERIED;
             r->di[c] = string_dup(qt->query.array[c].dimension.id);
             r->dn[c] = string_dup(qt->query.array[c].dimension.name);
+            qt->query.array[c].link.qi->queried++;
             rrd2rrdr_query_execute(r, c, ops[c]);
         }
         else

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -2268,7 +2268,7 @@ RRDR *rrd2rrdr(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
     // qt.window members are the WANTED ones.
     // qt.request members are the REQUESTED ones.
 
-    RRDR *r = rrdr_create(owa, qt);
+    RRDR *r = rrdr_create(owa, qt, qt->query.used, qt->window.points);
     if(unlikely(!r)) {
         internal_error(true, "QUERY: cannot create RRDR for %s, after=%ld, before=%ld, points=%zu",
                        qt->id, qt->window.after, qt->window.before, qt->window.points);
@@ -2347,6 +2347,8 @@ RRDR *rrd2rrdr(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
 
         if(ops[c]) {
             r->od[c] |= RRDR_DIMENSION_QUERIED;
+            r->di[c] = string_dup(qt->query.array[c].dimension.id);
+            r->dn[c] = string_dup(qt->query.array[c].dimension.name);
             rrd2rrdr_query_execute(r, c, ops[c]);
         }
         else

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -2334,6 +2334,7 @@ RRDR *rrd2rrdr(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
     for(size_t c = 0, max = qt->query.used; c < max ; c++) {
         QUERY_METRIC *qm = query_metric(qt, c);
         QUERY_INSTANCE *qi = query_instance(qt, qm->link.query_instance_id);
+        QUERY_HOST *qh = query_host(qt, qm->link.query_host_id);
 
         if(queries_prepared < max) {
             // preload another query
@@ -2351,7 +2352,9 @@ RRDR *rrd2rrdr(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
             r->od[c] |= RRDR_DIMENSION_QUERIED;
             r->di[c] = string_dup(qm->dimension.id);
             r->dn[c] = string_dup(qm->dimension.name);
+
             qi->queried++;
+            qh->queried++;
 
             rrd2rrdr_query_execute(r, c, ops[c]);
         }

--- a/web/api/queries/query.h
+++ b/web/api/queries/query.h
@@ -54,10 +54,14 @@ const char *time_grouping_tostring(RRDR_TIME_GROUPING group);
 
 typedef enum rrdr_group_by {
     RRDR_GROUP_BY_UNDEFINED = 0,
+    RRDR_GROUP_BY_DIMENSION,
     RRDR_GROUP_BY_NODE,
     RRDR_GROUP_BY_INSTANCE,
     RRDR_GROUP_BY_LABEL,
 } RRDR_GROUP_BY;
+
+RRDR_GROUP_BY group_by_parse(const char *s);
+const char *group_by_to_string(RRDR_GROUP_BY group_by);
 
 typedef enum rrdr_group_by_function {
     RRDR_GROUP_BY_FUNCTION_AVERAGE,
@@ -66,6 +70,9 @@ typedef enum rrdr_group_by_function {
     RRDR_GROUP_BY_FUNCTION_SUM,
     RRDR_GROUP_BY_FUNCTION_SUM_COUNT,
 } RRDR_GROUP_BY_FUNCTION;
+
+RRDR_GROUP_BY_FUNCTION group_by_function_parse(const char *s);
+const char *group_by_function_to_string(RRDR_GROUP_BY_FUNCTION group_by_function);
 
 #ifdef __cplusplus
 }

--- a/web/api/queries/query.h
+++ b/web/api/queries/query.h
@@ -53,7 +53,7 @@ RRDR_TIME_GROUPING time_grouping_parse(const char *name, RRDR_TIME_GROUPING def)
 const char *time_grouping_tostring(RRDR_TIME_GROUPING group);
 
 typedef enum rrdr_group_by {
-    RRDR_GROUP_BY_UNDEFINED = 0,
+    RRDR_GROUP_BY_NONE = 0,
     RRDR_GROUP_BY_DIMENSION,
     RRDR_GROUP_BY_NODE,
     RRDR_GROUP_BY_INSTANCE,

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -61,21 +61,25 @@ static void rrdr_dump(RRDR *r)
 inline void rrdr_free(ONEWAYALLOC *owa, RRDR *r) {
     if(unlikely(!r)) return;
 
+    for(size_t d = 0; d < r->d ;d++) {
+        string_freez(r->di[d]);
+        string_freez(r->dn[d]);
+    }
+
     query_target_release(r->internal.qt);
     onewayalloc_freez(owa, r->t);
     onewayalloc_freez(owa, r->v);
     onewayalloc_freez(owa, r->o);
     onewayalloc_freez(owa, r->od);
+    onewayalloc_freez(owa, r->di);
+    onewayalloc_freez(owa, r->dn);
     onewayalloc_freez(owa, r->ar);
     onewayalloc_freez(owa, r);
 }
 
-RRDR *rrdr_create(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
+RRDR *rrdr_create(ONEWAYALLOC *owa, QUERY_TARGET *qt, size_t dimensions, size_t points) {
     if(unlikely(!qt || !qt->query.used || !qt->window.points))
         return NULL;
-
-    size_t dimensions = qt->query.used;
-    size_t points = qt->window.points;
 
     // create the rrdr
     RRDR *r = onewayalloc_callocz(owa, 1, sizeof(RRDR));
@@ -84,15 +88,17 @@ RRDR *rrdr_create(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
 
     r->before = qt->window.before;
     r->after = qt->window.after;
-    r->internal.points_wanted = qt->window.points;
+    r->internal.points_wanted = points;
     r->d = (int)dimensions;
     r->n = (int)points;
 
     r->t = onewayalloc_callocz(owa, points, sizeof(time_t));
     r->v = onewayalloc_mallocz(owa, points * dimensions * sizeof(NETDATA_DOUBLE));
     r->o = onewayalloc_mallocz(owa, points * dimensions * sizeof(RRDR_VALUE_FLAGS));
-    r->ar = onewayalloc_mallocz(owa, points * dimensions * sizeof(NETDATA_DOUBLE));
     r->od = onewayalloc_mallocz(owa, dimensions * sizeof(RRDR_DIMENSION_FLAGS));
+    r->ar = onewayalloc_mallocz(owa, points * dimensions * sizeof(NETDATA_DOUBLE));
+    r->di = onewayalloc_callocz(owa, dimensions, sizeof(STRING *));
+    r->dn = onewayalloc_callocz(owa, dimensions, sizeof(STRING *));
 
     r->group = 1;
     r->update_every = 1;

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -86,9 +86,9 @@ RRDR *rrdr_create(ONEWAYALLOC *owa, QUERY_TARGET *qt, size_t dimensions, size_t 
     r->internal.owa = owa;
     r->internal.qt = qt;
 
-    r->before = qt->window.before;
-    r->after = qt->window.after;
-    r->internal.points_wanted = points;
+    r->view.before = qt->window.before;
+    r->view.after = qt->window.after;
+    r->grouping.points_wanted = points;
     r->d = (int)dimensions;
     r->n = (int)points;
 
@@ -100,8 +100,8 @@ RRDR *rrdr_create(ONEWAYALLOC *owa, QUERY_TARGET *qt, size_t dimensions, size_t 
     r->di = onewayalloc_callocz(owa, dimensions, sizeof(STRING *));
     r->dn = onewayalloc_callocz(owa, dimensions, sizeof(STRING *));
 
-    r->group = 1;
-    r->update_every = 1;
+    r->view.group = 1;
+    r->view.update_every = 1;
 
     return r;
 }

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -74,6 +74,7 @@ inline void rrdr_free(ONEWAYALLOC *owa, RRDR *r) {
     onewayalloc_freez(owa, r->di);
     onewayalloc_freez(owa, r->dn);
     onewayalloc_freez(owa, r->ar);
+    onewayalloc_freez(owa, r->gbc);
     onewayalloc_freez(owa, r);
 }
 

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -45,6 +45,7 @@ typedef enum rrdr_options {
 
     // internal ones - not to be exposed to the API
     RRDR_OPTION_INTERNAL_AR     = 0x10000000, // internal use only, to let the formatters we want to render the anomaly rate
+    RRDR_OPTION_INTERNAL_GBC    = 0x20000000, // internal use only, to let the formatters we want to render the group by count
     RRDR_OPTION_HEALTH_RSRVD1   = 0x80000000, // reserved for RRDCALC_OPTION_NO_CLEAR_NOTIFICATION
 } RRDR_OPTIONS;
 

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -58,7 +58,8 @@ typedef enum rrdr_dimension_flag {
     RRDR_DIMENSION_DEFAULT  = 0x00,
     RRDR_DIMENSION_HIDDEN   = 0x04, // the dimension is hidden (not to be presented to callers)
     RRDR_DIMENSION_NONZERO  = 0x08, // the dimension is non zero (contains non-zero values)
-    RRDR_DIMENSION_QUERIED = 0x10, // the dimension is selected for evaluation in this RRDR
+    RRDR_DIMENSION_QUERIED  = 0x10, // the dimension is selected for evaluation in this RRDR
+    RRDR_DIMENSION_GROUPED  = 0x20, // the dimension has been grouped in this RRDR
 } RRDR_DIMENSION_FLAGS;
 
 // RRDR result options
@@ -80,10 +81,14 @@ typedef struct rrdresult {
 
     RRDR_DIMENSION_FLAGS *od; // the options for the dimensions
 
+    STRING **di;              // array of d dimension names
+    STRING **dn;              // array of d dimension names
+
     time_t *t;                // array of n timestamps
     NETDATA_DOUBLE *v;        // array n x d values
     RRDR_VALUE_FLAGS *o;      // array n x d options for each value returned
     NETDATA_DOUBLE *ar;       // array n x d of anomaly rates (0 - 100)
+    uint32_t *gbc;            // array n x d of group by count
 
     size_t group;             // how many collected values were grouped for each row
     time_t update_every;      // what is the suggested update frequency in seconds
@@ -130,7 +135,7 @@ typedef struct rrdresult {
 
 #include "database/rrd.h"
 void rrdr_free(ONEWAYALLOC *owa, RRDR *r);
-RRDR *rrdr_create(ONEWAYALLOC *owa, struct query_target *qt);
+RRDR *rrdr_create(ONEWAYALLOC *owa, struct query_target *qt, size_t dimensions, size_t points);
 
 #include "../web_api_v1.h"
 #include "web/api/queries/query.h"

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -48,86 +48,86 @@ typedef enum rrdr_options {
     RRDR_OPTION_HEALTH_RSRVD1   = 0x80000000, // reserved for RRDCALC_OPTION_NO_CLEAR_NOTIFICATION
 } RRDR_OPTIONS;
 
-typedef enum rrdr_value_flag {
-    RRDR_VALUE_NOTHING      = 0x00, // no flag set (a good default)
-    RRDR_VALUE_EMPTY        = 0x01, // the database value is empty
-    RRDR_VALUE_RESET        = 0x02, // the database value is marked as reset (overflown)
+typedef enum __attribute__ ((__packed__)) rrdr_value_flag {
+    RRDR_VALUE_NOTHING      = 0,            // no flag set (a good default)
+    RRDR_VALUE_EMPTY        = (1 << 0),     // the database value is empty
+    RRDR_VALUE_RESET        = (1 << 1),     // the database value is marked as reset (overflown)
 } RRDR_VALUE_FLAGS;
 
-typedef enum rrdr_dimension_flag {
-    RRDR_DIMENSION_DEFAULT  = 0x00,
-    RRDR_DIMENSION_HIDDEN   = 0x04, // the dimension is hidden (not to be presented to callers)
-    RRDR_DIMENSION_NONZERO  = 0x08, // the dimension is non zero (contains non-zero values)
-    RRDR_DIMENSION_QUERIED  = 0x10, // the dimension is selected for evaluation in this RRDR
-    RRDR_DIMENSION_GROUPED  = 0x20, // the dimension has been grouped in this RRDR
+typedef enum __attribute__ ((__packed__)) rrdr_dimension_flag {
+    RRDR_DIMENSION_DEFAULT  = 0,
+    RRDR_DIMENSION_HIDDEN   = (1 << 0), // the dimension is hidden (not to be presented to callers)
+    RRDR_DIMENSION_NONZERO  = (1 << 1), // the dimension is non zero (contains non-zero values)
+    RRDR_DIMENSION_QUERIED  = (1 << 2), // the dimension is selected for evaluation in this RRDR
+    RRDR_DIMENSION_GROUPED  = (1 << 3), // the dimension has been grouped in this RRDR
 } RRDR_DIMENSION_FLAGS;
 
 // RRDR result options
-typedef enum rrdr_result_flags {
-    RRDR_RESULT_OPTION_ABSOLUTE      = 0x00000001, // the query uses absolute time-frames
-                                                   // (can be cached by browsers and proxies)
-    RRDR_RESULT_OPTION_RELATIVE      = 0x00000002, // the query uses relative time-frames
-                                                   // (should not to be cached by browsers and proxies)
-    RRDR_RESULT_OPTION_VARIABLE_STEP = 0x00000004, // the query uses variable-step time-frames
-    RRDR_RESULT_OPTION_CANCEL        = 0x00000008, // the query needs to be cancelled
-} RRDR_RESULT_OPTIONS;
+typedef enum __attribute__ ((__packed__)) rrdr_result_flags {
+    RRDR_RESULT_FLAG_ABSOLUTE      = (1 << 0), // the query uses absolute time-frames
+                                               // (can be cached by browsers and proxies)
+    RRDR_RESULT_FLAG_RELATIVE      = (1 << 1), // the query uses relative time-frames
+                                               // (should not to be cached by browsers and proxies)
+    RRDR_RESULT_FLAG_CANCEL        = (1 << 2), // the query needs to be cancelled
+} RRDR_RESULT_FLAGS;
 
 typedef struct rrdresult {
-    RRDR_RESULT_OPTIONS result_options; // RRDR_RESULT_OPTION_*
-
     size_t d;                 // the number of dimensions
-    size_t n;                 // the number of values in the arrays
-    size_t rows;              // the number of rows used
+    size_t n;                 // the number of values in the arrays (number of points per dimension)
+    size_t rows;              // the number of actual rows used
 
     RRDR_DIMENSION_FLAGS *od; // the options for the dimensions
 
-    STRING **di;              // array of d dimension names
+    STRING **di;              // array of d dimension ids
     STRING **dn;              // array of d dimension names
 
     time_t *t;                // array of n timestamps
     NETDATA_DOUBLE *v;        // array n x d values
     RRDR_VALUE_FLAGS *o;      // array n x d options for each value returned
     NETDATA_DOUBLE *ar;       // array n x d of anomaly rates (0 - 100)
-    uint32_t *gbc;            // array n x d of group by count
+    uint32_t *gbc;            // array n x d of group by count - NOT ALLOCATED when RRDR is created
 
-    size_t group;             // how many collected values were grouped for each row
-    time_t update_every;      // what is the suggested update frequency in seconds
-
-    NETDATA_DOUBLE min;
-    NETDATA_DOUBLE max;
-
-    time_t before;
-    time_t after;
-
-    // internal rrd2rrdr() members below this point
     struct {
-        ONEWAYALLOC *owa;                   // the allocator used
-        struct query_target *qt;            // the QUERY_TARGET
+        size_t group;         // how many collected values were grouped for each row - NEEDED BY GROUPING FUNCTIONS
+        time_t after;
+        time_t before;
+        time_t update_every;  // what is the suggested update frequency in seconds
+        NETDATA_DOUBLE min;   // updated by the formatters
+        NETDATA_DOUBLE max;   // updated by the formatters
+        RRDR_RESULT_FLAGS flags; // RRDR_RESULT_FLAG_*
+        RRDR_OPTIONS options; // RRDR_OPTION_* (as run by the query)
+    } view;
 
-        RRDR_OPTIONS query_options;         // RRDR_OPTION_* (as run by the query)
+    struct {
+        size_t db_points_read;
+        size_t result_points_generated;
+        size_t tier_points_read[RRD_STORAGE_TIERS];
+    } stats;
+
+    struct {
+        void *data;                         // the internal data of the grouping function
+
+        // grouping function pointers
+        void (*create)(struct rrdresult *r, const char *options);
+        void (*reset)(struct rrdresult *r);
+        void (*free)(struct rrdresult *r);
+        void (*add)(struct rrdresult *r, NETDATA_DOUBLE value);
+        NETDATA_DOUBLE (*flush)(struct rrdresult *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
+
+        TIER_QUERY_FETCH tier_query_fetch;  // which value to use from STORAGE_POINT
 
         size_t points_wanted;               // used by SES and DES
         size_t resampling_group;            // used by AVERAGE
         NETDATA_DOUBLE resampling_divisor;  // used by AVERAGE
+    } grouping;
 
-        // grouping function pointers
-        void (*grouping_create)(struct rrdresult *r, const char *options);
-        void (*grouping_reset)(struct rrdresult *r);
-        void (*grouping_free)(struct rrdresult *r);
-        void (*grouping_add)(struct rrdresult *r, NETDATA_DOUBLE value);
-        NETDATA_DOUBLE (*grouping_flush)(struct rrdresult *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr);
-
-        TIER_QUERY_FETCH tier_query_fetch;  // which value to use from STORAGE_POINT
-        void *grouping_data;                // the internal data of the grouping function
+    struct {
+        ONEWAYALLOC *owa;           // the allocator used
+        struct query_target *qt;    // the QUERY_TARGET
 
 #ifdef NETDATA_INTERNAL_CHECKS
         const char *log;
 #endif
-
-        // statistics
-        size_t db_points_read;
-        size_t result_points_generated;
-        size_t tier_points_read[RRD_STORAGE_TIERS];
     } internal;
 } RRDR;
 

--- a/web/api/queries/ses/ses.c
+++ b/web/api/queries/ses/ses.c
@@ -29,13 +29,13 @@ static inline NETDATA_DOUBLE window(RRDR *r, struct grouping_ses *g) {
     (void)g;
 
     NETDATA_DOUBLE points;
-    if(r->group == 1) {
+    if(r->view.group == 1) {
         // provide a running DES
-        points = (NETDATA_DOUBLE)r->internal.points_wanted;
+        points = (NETDATA_DOUBLE)r->grouping.points_wanted;
     }
     else {
         // provide a SES with flush points
-        points = (NETDATA_DOUBLE)r->group;
+        points = (NETDATA_DOUBLE)r->view.group;
     }
 
     return (points > (NETDATA_DOUBLE)max_window_size) ? (NETDATA_DOUBLE)max_window_size : points;
@@ -52,24 +52,24 @@ void grouping_create_ses(RRDR *r, const char *options __maybe_unused) {
     struct grouping_ses *g = (struct grouping_ses *)onewayalloc_callocz(r->internal.owa, 1, sizeof(struct grouping_ses));
     set_alpha(r, g);
     g->level = 0.0;
-    r->internal.grouping_data = g;
+    r->grouping.data = g;
 }
 
 // resets when switches dimensions
 // so, clear everything to restart
 void grouping_reset_ses(RRDR *r) {
-    struct grouping_ses *g = (struct grouping_ses *)r->internal.grouping_data;
+    struct grouping_ses *g = (struct grouping_ses *)r->grouping.data;
     g->level = 0.0;
     g->count = 0;
 }
 
 void grouping_free_ses(RRDR *r) {
-    onewayalloc_freez(r->internal.owa, r->internal.grouping_data);
-    r->internal.grouping_data = NULL;
+    onewayalloc_freez(r->internal.owa, r->grouping.data);
+    r->grouping.data = NULL;
 }
 
 void grouping_add_ses(RRDR *r, NETDATA_DOUBLE value) {
-    struct grouping_ses *g = (struct grouping_ses *)r->internal.grouping_data;
+    struct grouping_ses *g = (struct grouping_ses *)r->grouping.data;
 
     if(unlikely(!g->count))
         g->level = value;
@@ -79,7 +79,7 @@ void grouping_add_ses(RRDR *r, NETDATA_DOUBLE value) {
 }
 
 NETDATA_DOUBLE grouping_flush_ses(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
-    struct grouping_ses *g = (struct grouping_ses *)r->internal.grouping_data;
+    struct grouping_ses *g = (struct grouping_ses *)r->grouping.data;
 
     if(unlikely(!g->count || !netdata_double_isnumber(g->level))) {
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;

--- a/web/api/queries/stddev/stddev.c
+++ b/web/api/queries/stddev/stddev.c
@@ -15,23 +15,23 @@ struct grouping_stddev {
 };
 
 void grouping_create_stddev(RRDR *r, const char *options __maybe_unused) {
-    r->internal.grouping_data = onewayalloc_callocz(r->internal.owa, 1, sizeof(struct grouping_stddev));
+    r->grouping.data = onewayalloc_callocz(r->internal.owa, 1, sizeof(struct grouping_stddev));
 }
 
 // resets when switches dimensions
 // so, clear everything to restart
 void grouping_reset_stddev(RRDR *r) {
-    struct grouping_stddev *g = (struct grouping_stddev *)r->internal.grouping_data;
+    struct grouping_stddev *g = (struct grouping_stddev *)r->grouping.data;
     g->count = 0;
 }
 
 void grouping_free_stddev(RRDR *r) {
-    onewayalloc_freez(r->internal.owa, r->internal.grouping_data);
-    r->internal.grouping_data = NULL;
+    onewayalloc_freez(r->internal.owa, r->grouping.data);
+    r->grouping.data = NULL;
 }
 
 void grouping_add_stddev(RRDR *r, NETDATA_DOUBLE value) {
-    struct grouping_stddev *g = (struct grouping_stddev *)r->internal.grouping_data;
+    struct grouping_stddev *g = (struct grouping_stddev *)r->grouping.data;
 
     g->count++;
 
@@ -62,7 +62,7 @@ static inline NETDATA_DOUBLE stddev(struct grouping_stddev *g) {
 }
 
 NETDATA_DOUBLE grouping_flush_stddev(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
-    struct grouping_stddev *g = (struct grouping_stddev *)r->internal.grouping_data;
+    struct grouping_stddev *g = (struct grouping_stddev *)r->grouping.data;
 
     NETDATA_DOUBLE value;
 
@@ -89,7 +89,7 @@ NETDATA_DOUBLE grouping_flush_stddev(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_optio
 
 // https://en.wikipedia.org/wiki/Coefficient_of_variation
 NETDATA_DOUBLE grouping_flush_coefficient_of_variation(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
-    struct grouping_stddev *g = (struct grouping_stddev *)r->internal.grouping_data;
+    struct grouping_stddev *g = (struct grouping_stddev *)r->grouping.data;
 
     NETDATA_DOUBLE value;
 
@@ -122,7 +122,7 @@ NETDATA_DOUBLE grouping_flush_coefficient_of_variation(RRDR *r, RRDR_VALUE_FLAGS
  * Mean = average
  *
 NETDATA_DOUBLE grouping_flush_mean(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
-    struct grouping_stddev *g = (struct grouping_stddev *)r->internal.grouping_data;
+    struct grouping_stddev *g = (struct grouping_stddev *)r->grouping.grouping_data;
 
     NETDATA_DOUBLE value;
 
@@ -149,7 +149,7 @@ NETDATA_DOUBLE grouping_flush_mean(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options
  * It is not advised to use this version of variance directly
  *
 NETDATA_DOUBLE grouping_flush_variance(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
-    struct grouping_stddev *g = (struct grouping_stddev *)r->internal.grouping_data;
+    struct grouping_stddev *g = (struct grouping_stddev *)r->grouping.grouping_data;
 
     NETDATA_DOUBLE value;
 

--- a/web/api/queries/sum/sum.c
+++ b/web/api/queries/sum/sum.c
@@ -11,30 +11,30 @@ struct grouping_sum {
 };
 
 void grouping_create_sum(RRDR *r, const char *options __maybe_unused) {
-    r->internal.grouping_data = onewayalloc_callocz(r->internal.owa, 1, sizeof(struct grouping_sum));
+    r->grouping.data = onewayalloc_callocz(r->internal.owa, 1, sizeof(struct grouping_sum));
 }
 
 // resets when switches dimensions
 // so, clear everything to restart
 void grouping_reset_sum(RRDR *r) {
-    struct grouping_sum *g = (struct grouping_sum *)r->internal.grouping_data;
+    struct grouping_sum *g = (struct grouping_sum *)r->grouping.data;
     g->sum = 0;
     g->count = 0;
 }
 
 void grouping_free_sum(RRDR *r) {
-    onewayalloc_freez(r->internal.owa, r->internal.grouping_data);
-    r->internal.grouping_data = NULL;
+    onewayalloc_freez(r->internal.owa, r->grouping.data);
+    r->grouping.data = NULL;
 }
 
 void grouping_add_sum(RRDR *r, NETDATA_DOUBLE value) {
-    struct grouping_sum *g = (struct grouping_sum *)r->internal.grouping_data;
+    struct grouping_sum *g = (struct grouping_sum *)r->grouping.data;
     g->sum += value;
     g->count++;
 }
 
 NETDATA_DOUBLE grouping_flush_sum(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
-    struct grouping_sum *g = (struct grouping_sum *)r->internal.grouping_data;
+    struct grouping_sum *g = (struct grouping_sum *)r->grouping.data;
 
     NETDATA_DOUBLE value;
 

--- a/web/api/queries/trimmed_mean/trimmed_mean.c
+++ b/web/api/queries/trimmed_mean/trimmed_mean.c
@@ -14,7 +14,7 @@ struct grouping_trimmed_mean {
 };
 
 static void grouping_create_trimmed_mean_internal(RRDR *r, const char *options, NETDATA_DOUBLE def) {
-    long entries = r->group;
+    long entries = r->view.group;
     if(entries < 10) entries = 10;
 
     struct grouping_trimmed_mean *g = (struct grouping_trimmed_mean *)onewayalloc_callocz(r->internal.owa, 1, sizeof(struct grouping_trimmed_mean));
@@ -30,7 +30,7 @@ static void grouping_create_trimmed_mean_internal(RRDR *r, const char *options, 
     }
 
     g->percent = 1.0 - ((g->percent / 100.0) * 2.0);
-    r->internal.grouping_data = g;
+    r->grouping.data = g;
 }
 
 void grouping_create_trimmed_mean1(RRDR *r, const char *options) {
@@ -61,20 +61,20 @@ void grouping_create_trimmed_mean25(RRDR *r, const char *options) {
 // resets when switches dimensions
 // so, clear everything to restart
 void grouping_reset_trimmed_mean(RRDR *r) {
-    struct grouping_trimmed_mean *g = (struct grouping_trimmed_mean *)r->internal.grouping_data;
+    struct grouping_trimmed_mean *g = (struct grouping_trimmed_mean *)r->grouping.data;
     g->next_pos = 0;
 }
 
 void grouping_free_trimmed_mean(RRDR *r) {
-    struct grouping_trimmed_mean *g = (struct grouping_trimmed_mean *)r->internal.grouping_data;
+    struct grouping_trimmed_mean *g = (struct grouping_trimmed_mean *)r->grouping.data;
     if(g) onewayalloc_freez(r->internal.owa, g->series);
 
-    onewayalloc_freez(r->internal.owa, r->internal.grouping_data);
-    r->internal.grouping_data = NULL;
+    onewayalloc_freez(r->internal.owa, r->grouping.data);
+    r->grouping.data = NULL;
 }
 
 void grouping_add_trimmed_mean(RRDR *r, NETDATA_DOUBLE value) {
-    struct grouping_trimmed_mean *g = (struct grouping_trimmed_mean *)r->internal.grouping_data;
+    struct grouping_trimmed_mean *g = (struct grouping_trimmed_mean *)r->grouping.data;
 
     if(unlikely(g->next_pos >= g->series_size)) {
         g->series = onewayalloc_doublesize( r->internal.owa, g->series, g->series_size * sizeof(NETDATA_DOUBLE));
@@ -85,7 +85,7 @@ void grouping_add_trimmed_mean(RRDR *r, NETDATA_DOUBLE value) {
 }
 
 NETDATA_DOUBLE grouping_flush_trimmed_mean(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
-    struct grouping_trimmed_mean *g = (struct grouping_trimmed_mean *)r->internal.grouping_data;
+    struct grouping_trimmed_mean *g = (struct grouping_trimmed_mean *)r->grouping.data;
 
     NETDATA_DOUBLE value;
     size_t available_slots = g->next_pos;

--- a/web/api/queries/weights.c
+++ b/web/api/queries/weights.c
@@ -498,10 +498,10 @@ NETDATA_DOUBLE *rrd2rrdr_ks2(
         goto cleanup;
 
     stats->db_queries++;
-    stats->result_points += r->internal.result_points_generated;
-    stats->db_points += r->internal.db_points_read;
+    stats->result_points += r->stats.result_points_generated;
+    stats->db_points += r->stats.db_points_read;
     for(size_t tr = 0; tr < storage_tiers ; tr++)
-        stats->db_points_per_tier[tr] += r->internal.tier_points_read[tr];
+        stats->db_points_per_tier[tr] += r->stats.tier_points_read[tr];
 
     if(r->d != 1) {
         error("WEIGHTS: on query '%s' expected 1 dimension in RRDR but got %zu", r->internal.qt->id, r->d);

--- a/web/api/queries/weights.c
+++ b/web/api/queries/weights.c
@@ -477,6 +477,7 @@ NETDATA_DOUBLE *rrd2rrdr_ks2(
     NETDATA_DOUBLE *ret = NULL;
 
     QUERY_TARGET_REQUEST qtr = {
+            .version = 1,
             .host = host,
             .rca = rca,
             .ria = ria,

--- a/web/api/web_api.c
+++ b/web/api/web_api.c
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "web_api.h"
+
+int web_client_api_request_vX(RRDHOST *host, struct web_client *w, char *url, struct web_api_command *api_commands) {
+    if(unlikely(!url || !*url)) {
+        buffer_flush(w->response.data);
+        buffer_sprintf(w->response.data, "Which API command?");
+        return HTTP_RESP_BAD_REQUEST;
+    }
+
+    uint32_t hash = simple_hash(url);
+
+    for(int i = 0; api_commands[i].command ; i++) {
+        if(unlikely(hash == api_commands[i].hash && !strcmp(url, api_commands[i].command))) {
+            if(unlikely(api_commands[i].acl != WEB_CLIENT_ACL_NOCHECK) && !(w->acl & api_commands[i].acl))
+                return web_client_permission_denied(w);
+
+            return api_commands[i].callback(host, w, (w->decoded_query_string + 1));
+        }
+    }
+
+    buffer_flush(w->response.data);
+    buffer_strcat(w->response.data, "Unsupported API command: ");
+    buffer_strcat_htmlescape(w->response.data, url);
+    return HTTP_RESP_NOT_FOUND;
+}

--- a/web/api/web_api.h
+++ b/web/api/web_api.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_WEB_API_H
+#define NETDATA_WEB_API_H 1
+
+#include "daemon/common.h"
+#include "web/api/badges/web_buffer_svg.h"
+#include "web/api/formatters/rrd2json.h"
+#include "web/api/health/health_cmdapi.h"
+#include "web/api/queries/weights.h"
+
+struct web_api_command {
+    const char *command;
+    uint32_t hash;
+    WEB_CLIENT_ACL acl;
+    int (*callback)(RRDHOST *host, struct web_client *w, char *url);
+};
+
+struct web_client;
+
+int web_client_api_request_vX(RRDHOST *host, struct web_client *w, char *url, struct web_api_command *api_commands);
+
+static inline void fix_google_param(char *s) {
+    if(unlikely(!s || !*s)) return;
+
+    for( ; *s ;s++) {
+        if(!isalnum(*s) && *s != '.' && *s != '_' && *s != '-')
+            *s = '_';
+    }
+}
+
+#include "web_api_v1.h"
+#include "web_api_v2.h"
+
+#endif //NETDATA_WEB_API_H

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -712,6 +712,7 @@ static inline int web_client_api_request_v1_data(RRDHOST *host, struct web_clien
     long      group_time = (group_time_str && *group_time_str)?str2l(group_time_str):0;
 
     QUERY_TARGET_REQUEST qtr = {
+            .version = 1,
             .after = after,
             .before = before,
             .host = host,

--- a/web/api/web_api_v1.h
+++ b/web/api/web_api_v1.h
@@ -3,11 +3,9 @@
 #ifndef NETDATA_WEB_API_V1_H
 #define NETDATA_WEB_API_V1_H 1
 
-#include "daemon/common.h"
-#include "web/api/badges/web_buffer_svg.h"
-#include "web/api/formatters/rrd2json.h"
-#include "web/api/health/health_cmdapi.h"
-#include "web/api/queries/weights.h"
+#include "web_api.h"
+
+struct web_client;
 
 RRDR_OPTIONS web_client_api_request_v1_data_options(char *o);
 void web_client_api_request_v1_data_options_to_buffer_json_array(BUFFER *wb, const char *key, RRDR_OPTIONS options);
@@ -24,7 +22,6 @@ int web_client_api_request_v1_alarm_variables(RRDHOST *host, struct web_client *
 int web_client_api_request_v1_alarm_count(RRDHOST *host, struct web_client *w, char *url);
 int web_client_api_request_v1_charts(RRDHOST *host, struct web_client *w, char *url);
 int web_client_api_request_v1_chart(RRDHOST *host, struct web_client *w, char *url);
-int web_client_api_request_v1_data(RRDHOST *host, struct web_client *w, char *url);
 int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *w, char *url);
 int web_client_api_request_v1_info(RRDHOST *host, struct web_client *w, char *url);
 int web_client_api_request_v1(RRDHOST *host, struct web_client *w, char *url);

--- a/web/api/web_api_v2.c
+++ b/web/api/web_api_v2.c
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "web_api_v2.h"
+
+
+static inline int web_client_api_request_v2_data(RRDHOST *host, struct web_client *w, char *url) {
+    debug(D_WEB_CLIENT, "%llu: API v1 data with URL '%s'", w->id, url);
+
+    int ret = HTTP_RESP_BAD_REQUEST;
+
+    buffer_flush(w->response.data);
+
+    char    *google_version = "0.6",
+            *google_reqId = "0",
+            *google_sig = "0",
+            *google_out = "json",
+            *responseHandler = NULL,
+            *outFileName = NULL;
+
+    time_t last_timestamp_in_data = 0, google_timestamp = 0;
+
+    char *hosts = NULL;
+    char *contexts = NULL;
+    char *charts = NULL;
+    char *dimensions = NULL;
+    char *before_str = NULL;
+    char *after_str = NULL;
+    char *resampling_time_str = NULL;
+    char *points_str = NULL;
+    char *timeout_str = NULL;
+    char *chart_label_key = NULL;
+    char *chart_labels_filter = NULL;
+    char *time_group_options = NULL;
+    char *tier_str = NULL;
+    char *group_by_key = NULL;
+    size_t tier = 0;
+    RRDR_TIME_GROUPING time_group = RRDR_GROUPING_AVERAGE;
+    RRDR_GROUP_BY group_by = RRDR_GROUP_BY_DIMENSION;
+    RRDR_GROUP_BY_FUNCTION group_by_function = RRDR_GROUP_BY_FUNCTION_AVERAGE;
+    DATASOURCE_FORMAT format = DATASOURCE_JSON;
+    RRDR_OPTIONS options = 0;
+
+    while(url) {
+        char *value = mystrsep(&url, "&");
+        if(!value || !*value) continue;
+
+        char *name = mystrsep(&value, "=");
+        if(!name || !*name) continue;
+        if(!value || !*value) continue;
+
+        // name and value are now the parameters
+        // they are not null and not empty
+
+        if(!strcmp(name, "hosts")) hosts = value;
+        else if(!strcmp(name, "contexts")) contexts = value;
+        else if(!strcmp(name, "charts")) charts = value;
+        else if(!strcmp(name, "dimensions")) dimensions = value;
+        else if(!strcmp(name, "after")) after_str = value;
+        else if(!strcmp(name, "before")) before_str = value;
+        else if(!strcmp(name, "points")) points_str = value;
+        else if(!strcmp(name, "timeout")) timeout_str = value;
+        else if(!strcmp(name, "group_by")) group_by = group_by_parse(value);
+        else if(!strcmp(name, "group_by_function")) group_by_function = group_by_function_parse(value);
+        else if(!strcmp(name, "format")) format = web_client_api_request_v1_data_format(value);
+        else if(!strcmp(name, "options")) options |= web_client_api_request_v1_data_options(value);
+        else if(!strcmp(name, "time_group")) time_group = time_grouping_parse(value, RRDR_GROUPING_AVERAGE);
+        else if(!strcmp(name, "time_group_options")) time_group_options = value;
+        else if(!strcmp(name, "resampling_time")) resampling_time_str = value;
+        else if(!strcmp(name, "tier")) tier_str = value;
+        else if(!strcmp(name, "chart_label_key")) chart_label_key = value;
+        else if(!strcmp(name, "chart_labels_filter")) chart_labels_filter = value;
+        else if(!strcmp(name, "callback")) responseHandler = value;
+        else if(!strcmp(name, "filename")) outFileName = value;
+        else if(!strcmp(name, "tqx")) {
+            // parse Google Visualization API options
+            // https://developers.google.com/chart/interactive/docs/dev/implementing_data_source
+            char *tqx_name, *tqx_value;
+
+            while(value) {
+                tqx_value = mystrsep(&value, ";");
+                if(!tqx_value || !*tqx_value) continue;
+
+                tqx_name = mystrsep(&tqx_value, ":");
+                if(!tqx_name || !*tqx_name) continue;
+                if(!tqx_value || !*tqx_value) continue;
+
+                if(!strcmp(tqx_name, "version"))
+                    google_version = tqx_value;
+                else if(!strcmp(tqx_name, "reqId"))
+                    google_reqId = tqx_value;
+                else if(!strcmp(tqx_name, "sig")) {
+                    google_sig = tqx_value;
+                    google_timestamp = strtoul(google_sig, NULL, 0);
+                }
+                else if(!strcmp(tqx_name, "out")) {
+                    google_out = tqx_value;
+                    format = web_client_api_request_v1_data_google_format(google_out);
+                }
+                else if(!strcmp(tqx_name, "responseHandler"))
+                    responseHandler = tqx_value;
+                else if(!strcmp(tqx_name, "outFileName"))
+                    outFileName = tqx_value;
+            }
+        }
+    }
+
+    // validate the google parameters given
+    fix_google_param(google_out);
+    fix_google_param(google_sig);
+    fix_google_param(google_reqId);
+    fix_google_param(google_version);
+    fix_google_param(responseHandler);
+    fix_google_param(outFileName);
+
+    if(tier_str && *tier_str) {
+        tier = str2ul(tier_str);
+        if(tier < storage_tiers)
+            options |= RRDR_OPTION_SELECTED_TIER;
+        else
+            tier = 0;
+    }
+
+    RRDSET *st = NULL;
+    ONEWAYALLOC *owa = onewayalloc_create(0);
+    QUERY_TARGET *qt = NULL;
+
+    if(!is_valid_sp(charts) && !is_valid_sp(contexts)) {
+        buffer_sprintf(w->response.data, "No chart or context is given.");
+        goto cleanup;
+    }
+
+    if(charts && !contexts) {
+        // check if this is a specific chart
+        st = rrdset_find(host, charts);
+        if (!st) st = rrdset_find_byname(host, charts);
+    }
+
+    long long before = (before_str && *before_str)?str2l(before_str):0;
+    long long after  = (after_str  && *after_str) ?str2l(after_str):-600;
+    int       points = (points_str && *points_str)?str2i(points_str):0;
+    int       timeout = (timeout_str && *timeout_str)?str2i(timeout_str): 0;
+    long      group_time = (resampling_time_str && *resampling_time_str) ? str2l(resampling_time_str) : 0;
+
+    QUERY_TARGET_REQUEST qtr = {
+            .after = after,
+            .before = before,
+            .host = (hosts && *hosts) ? NULL : host,
+            .st = st,
+            .hosts = hosts,
+            .contexts = contexts,
+            .charts = charts,
+            .dimensions = dimensions,
+            .timeout = timeout,
+            .points = points,
+            .format = format,
+            .options = options,
+            .group_by = group_by,
+            .group_by_key = group_by_key,
+            .group_by_function = group_by_function,
+            .time_group_method = time_group,
+            .time_group_options = time_group_options,
+            .resampling_time = group_time,
+            .tier = tier,
+            .chart_label_key = chart_label_key,
+            .charts_labels_filter = chart_labels_filter,
+            .query_source = QUERY_SOURCE_API_DATA,
+            .priority = STORAGE_PRIORITY_NORMAL,
+    };
+    qt = query_target_create(&qtr);
+
+    if(!qt || !qt->query.used) {
+        buffer_sprintf(w->response.data, "No metrics where matched to query.");
+        ret = HTTP_RESP_NOT_FOUND;
+        goto cleanup;
+    }
+
+    if (timeout) {
+        struct timeval now;
+        now_realtime_timeval(&now);
+        int inqueue = (int)dt_usec(&w->tv_in, &now) / 1000;
+        timeout -= inqueue;
+        if (timeout <= 0) {
+            buffer_flush(w->response.data);
+            buffer_strcat(w->response.data, "Query timeout exceeded");
+            ret = HTTP_RESP_BACKEND_FETCH_FAILED;
+            goto cleanup;
+        }
+    }
+
+    if(outFileName && *outFileName) {
+        buffer_sprintf(w->response.header, "Content-Disposition: attachment; filename=\"%s\"\r\n", outFileName);
+        debug(D_WEB_CLIENT, "%llu: generating outfilename header: '%s'", w->id, outFileName);
+    }
+
+    if(format == DATASOURCE_DATATABLE_JSONP) {
+        if(responseHandler == NULL)
+            responseHandler = "google.visualization.Query.setResponse";
+
+        debug(D_WEB_CLIENT_ACCESS, "%llu: GOOGLE JSON/JSONP: version = '%s', reqId = '%s', sig = '%s', out = '%s', responseHandler = '%s', outFileName = '%s'",
+              w->id, google_version, google_reqId, google_sig, google_out, responseHandler, outFileName
+        );
+
+        buffer_sprintf(
+                w->response.data,
+                "%s({version:'%s',reqId:'%s',status:'ok',sig:'%"PRId64"',table:",
+                responseHandler,
+                google_version,
+                google_reqId,
+                (int64_t)st->last_updated.tv_sec);
+    }
+    else if(format == DATASOURCE_JSONP) {
+        if(responseHandler == NULL)
+            responseHandler = "callback";
+
+        buffer_strcat(w->response.data, responseHandler);
+        buffer_strcat(w->response.data, "(");
+    }
+
+    ret = data_query_execute(owa, w->response.data, qt, &last_timestamp_in_data);
+
+    if(format == DATASOURCE_DATATABLE_JSONP) {
+        if(google_timestamp < last_timestamp_in_data)
+            buffer_strcat(w->response.data, "});");
+
+        else {
+            // the client already has the latest data
+            buffer_flush(w->response.data);
+            buffer_sprintf(w->response.data,
+                           "%s({version:'%s',reqId:'%s',status:'error',errors:[{reason:'not_modified',message:'Data not modified'}]});",
+                           responseHandler, google_version, google_reqId);
+        }
+    }
+    else if(format == DATASOURCE_JSONP)
+        buffer_strcat(w->response.data, ");");
+
+    cleanup:
+    if(qt && qt->used) {
+        internal_error(true, "QUERY_TARGET: left non-released on query '%s'", qt->id);
+        query_target_release(qt);
+    }
+    onewayalloc_destroy(owa);
+    return ret;
+}
+
+
+
+static struct web_api_command api_commands_v2[] = {
+        {"data", 0, WEB_CLIENT_ACL_DASHBOARD | WEB_CLIENT_ACL_ACLK, web_client_api_request_v2_data},
+
+        // terminator
+        {NULL, 0, WEB_CLIENT_ACL_NONE, NULL},
+};
+
+inline int web_client_api_request_v2(RRDHOST *host, struct web_client *w, char *url) {
+    static int initialized = 0;
+
+    if(unlikely(initialized == 0)) {
+        initialized = 1;
+
+        for(int i = 0; api_commands_v2[i].command ; i++)
+            api_commands_v2[i].hash = simple_hash(api_commands_v2[i].command);
+    }
+
+    return web_client_api_request_vX(host, w, url, api_commands_v2);
+}

--- a/web/api/web_api_v2.c
+++ b/web/api/web_api_v2.c
@@ -55,6 +55,8 @@ static inline int web_client_api_request_v2_data(RRDHOST *host, struct web_clien
         else if(!strcmp(name, "contexts")) contexts = value;
         else if(!strcmp(name, "instances")) instances = value;
         else if(!strcmp(name, "dimensions")) dimensions = value;
+            // else if(!strcmp(name, "chart_label_key")) chart_label_key = value;
+        else if(!strcmp(name, "labels")) chart_labels_filter = value;
         else if(!strcmp(name, "after")) after_str = value;
         else if(!strcmp(name, "before")) before_str = value;
         else if(!strcmp(name, "points")) points_str = value;
@@ -65,10 +67,8 @@ static inline int web_client_api_request_v2_data(RRDHOST *host, struct web_clien
         else if(!strcmp(name, "options")) options |= web_client_api_request_v1_data_options(value);
         else if(!strcmp(name, "time_group")) time_group = time_grouping_parse(value, RRDR_GROUPING_AVERAGE);
         else if(!strcmp(name, "time_group_options")) time_group_options = value;
-        else if(!strcmp(name, "resampling_time")) resampling_time_str = value;
+        else if(!strcmp(name, "time_resampling")) resampling_time_str = value;
         else if(!strcmp(name, "tier")) tier_str = value;
-        else if(!strcmp(name, "chart_label_key")) chart_label_key = value;
-        else if(!strcmp(name, "chart_labels_filter")) chart_labels_filter = value;
         else if(!strcmp(name, "callback")) responseHandler = value;
         else if(!strcmp(name, "filename")) outFileName = value;
         else if(!strcmp(name, "tqx")) {

--- a/web/api/web_api_v2.c
+++ b/web/api/web_api_v2.c
@@ -35,10 +35,10 @@ static inline int web_client_api_request_v2_data(RRDHOST *host, struct web_clien
     char *group_by_key = NULL;
     size_t tier = 0;
     RRDR_TIME_GROUPING time_group = RRDR_GROUPING_AVERAGE;
-    RRDR_GROUP_BY group_by = RRDR_GROUP_BY_NONE;
+    RRDR_GROUP_BY group_by = RRDR_GROUP_BY_DIMENSION;
     RRDR_GROUP_BY_FUNCTION group_by_function = RRDR_GROUP_BY_FUNCTION_AVERAGE;
     DATASOURCE_FORMAT format = DATASOURCE_JSON;
-    RRDR_OPTIONS options = 0;
+    RRDR_OPTIONS options = RRDR_OPTION_JSON_WRAP | RRDR_OPTION_RETURN_JWAR | RRDR_OPTION_VIRTUAL_POINTS;
 
     while(url) {
         char *value = mystrsep(&url, "&");
@@ -62,6 +62,7 @@ static inline int web_client_api_request_v2_data(RRDHOST *host, struct web_clien
         else if(!strcmp(name, "points")) points_str = value;
         else if(!strcmp(name, "timeout")) timeout_str = value;
         else if(!strcmp(name, "group_by")) group_by = group_by_parse(value);
+        else if(!strcmp(name, "group_by_key")) group_by_key = value;
         else if(!strcmp(name, "group_by_function")) group_by_function = group_by_function_parse(value);
         else if(!strcmp(name, "format")) format = web_client_api_request_v1_data_format(value);
         else if(!strcmp(name, "options")) options |= web_client_api_request_v1_data_options(value);
@@ -111,6 +112,9 @@ static inline int web_client_api_request_v2_data(RRDHOST *host, struct web_clien
     fix_google_param(google_version);
     fix_google_param(responseHandler);
     fix_google_param(outFileName);
+
+    if(group_by != RRDR_GROUP_BY_DIMENSION)
+        options |= RRDR_OPTION_ABSOLUTE;
 
     if(tier_str && *tier_str) {
         tier = str2ul(tier_str);

--- a/web/api/web_api_v2.c
+++ b/web/api/web_api_v2.c
@@ -35,7 +35,7 @@ static inline int web_client_api_request_v2_data(RRDHOST *host, struct web_clien
     char *group_by_key = NULL;
     size_t tier = 0;
     RRDR_TIME_GROUPING time_group = RRDR_GROUPING_AVERAGE;
-    RRDR_GROUP_BY group_by = RRDR_GROUP_BY_DIMENSION;
+    RRDR_GROUP_BY group_by = RRDR_GROUP_BY_NONE;
     RRDR_GROUP_BY_FUNCTION group_by_function = RRDR_GROUP_BY_FUNCTION_AVERAGE;
     DATASOURCE_FORMAT format = DATASOURCE_JSON;
     RRDR_OPTIONS options = 0;

--- a/web/api/web_api_v2.c
+++ b/web/api/web_api_v2.c
@@ -21,7 +21,7 @@ static inline int web_client_api_request_v2_data(RRDHOST *host, struct web_clien
 
     char *hosts = NULL;
     char *contexts = NULL;
-    char *charts = NULL;
+    char *instances = NULL;
     char *dimensions = NULL;
     char *before_str = NULL;
     char *after_str = NULL;
@@ -53,7 +53,7 @@ static inline int web_client_api_request_v2_data(RRDHOST *host, struct web_clien
 
         if(!strcmp(name, "hosts")) hosts = value;
         else if(!strcmp(name, "contexts")) contexts = value;
-        else if(!strcmp(name, "charts")) charts = value;
+        else if(!strcmp(name, "instances")) instances = value;
         else if(!strcmp(name, "dimensions")) dimensions = value;
         else if(!strcmp(name, "after")) after_str = value;
         else if(!strcmp(name, "before")) before_str = value;
@@ -124,17 +124,6 @@ static inline int web_client_api_request_v2_data(RRDHOST *host, struct web_clien
     ONEWAYALLOC *owa = onewayalloc_create(0);
     QUERY_TARGET *qt = NULL;
 
-    if(!is_valid_sp(charts) && !is_valid_sp(contexts)) {
-        buffer_sprintf(w->response.data, "No chart or context is given.");
-        goto cleanup;
-    }
-
-    if(charts && !contexts) {
-        // check if this is a specific chart
-        st = rrdset_find(host, charts);
-        if (!st) st = rrdset_find_byname(host, charts);
-    }
-
     long long before = (before_str && *before_str)?str2l(before_str):0;
     long long after  = (after_str  && *after_str) ?str2l(after_str):-600;
     int       points = (points_str && *points_str)?str2i(points_str):0;
@@ -142,13 +131,14 @@ static inline int web_client_api_request_v2_data(RRDHOST *host, struct web_clien
     long      group_time = (resampling_time_str && *resampling_time_str) ? str2l(resampling_time_str) : 0;
 
     QUERY_TARGET_REQUEST qtr = {
+            .version = 2,
             .after = after,
             .before = before,
             .host = (hosts && *hosts) ? NULL : host,
             .st = st,
             .hosts = hosts,
             .contexts = contexts,
-            .charts = charts,
+            .charts = instances,
             .dimensions = dimensions,
             .timeout = timeout,
             .points = points,

--- a/web/api/web_api_v2.h
+++ b/web/api/web_api_v2.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_WEB_API_V2_H
+#define NETDATA_WEB_API_V2_H 1
+
+#include "web_api.h"
+
+struct web_client;
+
+int web_client_api_request_v2(RRDHOST *host, struct web_client *w, char *url);
+
+#endif //NETDATA_WEB_API_V2_H

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -533,7 +533,9 @@ int web_client_api_request(RRDHOST *host, struct web_client *w, char *url)
     char *tok = mystrsep(&url, "/");
     if(tok && *tok) {
         debug(D_WEB_CLIENT, "%llu: Searching for API version '%s'.", w->id, tok);
-        if(strcmp(tok, "v1") == 0)
+        if(strcmp(tok, "v2") == 0)
+            return web_client_api_request_v2(host, w, url);
+        else if(strcmp(tok, "v1") == 0)
             return web_client_api_request_v1(host, w, url);
         else {
             buffer_flush(w->response.data);

--- a/web/server/web_client.h
+++ b/web/server/web_client.h
@@ -211,6 +211,8 @@ char *strip_control_characters(char *url);
 
 int web_client_socket_is_now_used_for_streaming(struct web_client *w);
 
+#include "web/api/web_api_v1.h"
+#include "web/api/web_api_v2.h"
 #include "daemon/common.h"
 
 #endif


### PR DESCRIPTION
This PR adds an `/api/v2/data` endpoint to Netdata, offering the following:

- [x] multi-host queries
- [x] multi-context queries
- [x] multi-instance queries
- [x] multi-dimension queries
- [x] all "multi" parameters are implemented using simple patterns
- [x] group by dimension, instance, node, label are supported, so that the agent aggregates all the data into a small set of result data
- [x] new `jsonwrap` object, providing additional information for the dashboard:
   - [x] ready to use lists for the on-chart drop downs, for nodes, instances, dimensions
   - [x] counters on all of them to show the number of queried metrics per item (per instance, per label, per host, per dimension name)