### PR TITLE
Get update every from page

### DIFF
--- a/database/engine/datafile.c
+++ b/database/engine/datafile.c
@@ -379,8 +379,8 @@ static int scan_data_files_cmp(const void *a, const void *b)
 /* Returns number of datafiles that were loaded or < 0 on error */
 static int scan_data_files(struct rrdengine_instance *ctx)
 {
-    int ret;
-    unsigned tier, no, matched_files, i,failed_to_load;
+    int ret, matched_files, failed_to_load;
+    unsigned tier, no, i;
     uv_fs_t req;
     uv_dirent_t dent;
     struct rrdengine_datafile **datafiles, *datafile;


### PR DESCRIPTION
Currently the initial calculation for the update every for a metric per journal file is not correct because it is based on the 
min / max retention for the metric and the number of entries in that journal file for the metric.

This PR accesses the metric metadata for the last page stored in the journal and fetches the update every as stored there.
