### PR TITLE
Add a scheduled CI job to flag supported platforms going EOL upstream.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -1,6 +1,6 @@
 # This defines the full set of distros we run CI on.
 ---
-platform_map: # map packaging architectures to docker platforms
+platform_map:  # map packaging architectures to docker platforms
   aarch64: linux/arm64/v8
   amd64: linux/amd64
   arm64: linux/arm64/v8
@@ -8,7 +8,7 @@ platform_map: # map packaging architectures to docker platforms
   armhfp: linux/arm/v7
   i386: linux/i386
   x86_64: linux/amd64
-arch_order: # sort order for per-architecture jobs in CI
+arch_order:  # sort order for per-architecture jobs in CI
   - amd64
   - x86_64
   - i386
@@ -20,6 +20,7 @@ include:
   - &alpine
     distro: alpine
     version: edge
+    eol_check: false
     env_prep: |
       apk add -U bash
     jsonc_removal: |
@@ -28,15 +29,20 @@ include:
       ebpf-core: true
   - <<: *alpine
     version: "3.17"
+    eol_check: true
   - <<: *alpine
     version: "3.16"
+    eol_check: true
   - <<: *alpine
     version: "3.15"
+    eol_check: true
   - <<: *alpine
     version: "3.14"
+    eol_check: true
 
   - distro: archlinux
     version: latest
+    eol_check: false
     env_prep: |
       pacman --noconfirm -Syu && pacman --noconfirm -Sy grep libffi
     test:
@@ -47,6 +53,7 @@ include:
     version: "9"
     jsonc_removal: |
       dnf remove -y json-c-devel
+    eol_check: true
     packages: &alma_packages
       type: rpm
       repo_distro: el/9
@@ -69,6 +76,7 @@ include:
 
   - distro: centos
     version: "7"
+    eol_check: false
     packages:
       type: rpm
       repo_distro: el/7
@@ -84,6 +92,7 @@ include:
     distro: debian
     version: "12"
     base_image: debian:bookworm
+    eol_check: true
     env_prep: |
       apt-get update
     jsonc_removal: |
@@ -118,6 +127,7 @@ include:
   - &fedora
     distro: fedora
     version: "37"
+    eol_check: true
     jsonc_removal: |
       dnf remove -y json-c-devel
     packages: &fedora_packages
@@ -139,6 +149,7 @@ include:
   - &opensuse
     distro: opensuse
     version: "15.4"
+    eol_check: true
     base_image: opensuse/leap:15.4
     jsonc_removal: |
       zypper rm -y libjson-c-devel
@@ -154,6 +165,7 @@ include:
   - &oracle
     distro: oraclelinux
     version: "8"
+    eol_check: true
     jsonc_removal: |
       dnf remove -y json-c-devel
     packages: &oracle_packages
@@ -173,6 +185,7 @@ include:
   - &ubuntu
     distro: ubuntu
     version: "22.10"
+    eol_check: true
     env_prep: |
       rm -f /etc/apt/apt.conf.d/docker && apt-get update
     jsonc_removal: |

--- a/.github/scripts/gen-matrix-eol-check.py
+++ b/.github/scripts/gen-matrix-eol-check.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+'''Generate the build matrix for the EOL check jobs.'''
+
+import json
+
+from ruamel.yaml import YAML
+
+yaml = YAML(typ='safe')
+entries = list()
+
+with open('.github/data/distros.yml') as f:
+    data = yaml.load(f)
+
+for item in data['include']:
+    if 'eol_check' in item and item['eol_check']:
+        entries.append({
+            'distro': item['distro'],
+            'release': item['version'],
+        })
+
+entries.sort(key=lambda k: (k['distro'], k['release']))
+matrix = json.dumps({'include': entries}, sort_keys=True)
+print(matrix)

--- a/.github/scripts/platform-impending-eol.py
+++ b/.github/scripts/platform-impending-eol.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+'''Check if a given distro is going to be EOL soon.
+
+   This queries the public API of https://endoflife.date to fetch EOL dates.
+
+   ‘soon’ is defined by LEAD_DAYS, currently 30 days.'''
+
+import datetime
+import json
+import sys
+import urllib.request
+
+URL_BASE = 'https://endoflife.date/api'
+NOW = datetime.date.today()
+LEAD_DAYS = datetime.timedelta(days=30)
+
+DISTRO = sys.argv[1]
+RELEASE = sys.argv[2]
+
+
+with urllib.request.urlopen(f'{ URL_BASE }/{ DISTRO }/{ RELEASE }.json') as response:
+    match response.status:
+        case 200:
+            data = json.load(response)
+        case 404:
+            sys.exit(f'No data available for { DISTRO } { RELEASE }.')
+        case _:
+            sys.exit(
+                f'Failed to retrieve data for { DISTRO } { RELEASE } ' +
+                f'(status: { response.status }).'
+            )
+
+eol = datetime.date.fromisoformat(data['eol'])
+
+offset = abs(eol - NOW)
+
+if offset <= LEAD_DAYS:
+    print(data['eol'])
+    sys.exit(2)
+else:
+    sys.exit(0)

--- a/.github/workflows/platform-eol-check.yml
+++ b/.github/workflows/platform-eol-check.yml
@@ -80,6 +80,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -e
           count=$(gh issue list -R netdata/netdata -s all -S '${{ steps.title.outputs.title }} in:title' --json 'id' -q '. | length')
           if [ "${count}" -ge 1 ]; then
             echo 'exists=true' >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/platform-eol-check.yml
+++ b/.github/workflows/platform-eol-check.yml
@@ -89,7 +89,7 @@ jobs:
       # If the platform is near EOL and there is no existing issue, create one.
       - name: Create EOL Issue
         id: create-issue
-        if: steps.check.outputs.pending == 'true' && steps.existing.outputs.exists == 'true'
+        if: steps.check.outputs.pending == 'true' && steps.existing.outputs.exists == 'false'
         uses: imjohnbo/issue-bot@v3
         with:
           assignees: Ferroin, tkatsoulas

--- a/.github/workflows/platform-eol-check.yml
+++ b/.github/workflows/platform-eol-check.yml
@@ -1,0 +1,108 @@
+---
+# Auto-generate issues for EOL of platforms that are approaching their EOL date.
+# Uses https://endoflife.date and their new API to check for EOL dates.
+#
+# Issues are created when the EOL date is within the next 30 days.
+name: Check Platform EOL
+on:  # Run weekly and whenever manually triggered
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch: null
+concurrency:  # Simple single-instance concurrency.
+  group: eol-check-${{ github.repository }}
+  cancel-in-progress: true
+jobs:
+  # Prepare the build matrix.
+  # This uses output from .github/scripts/gen-matrix-eol-check.py
+  matrix:
+    name: Prepare Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v3
+      - name: Prepare tools
+        id: prepare
+        run: |
+          sudo apt-get update && sudo apt-get install -y python3-ruamel.yaml
+      - name: Read build matrix
+        id: set-matrix
+        run: |
+          matrix="$(.github/scripts/gen-matrix-eol-check.py)"
+          echo "Generated matrix: ${matrix}"
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+
+  eol-check:
+    name: EOL Check
+    runs-on: ubuntu-latest
+    needs:
+      - matrix
+    strategy:
+      matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
+      fail-fast: false  # We want to check everything, so don’t bail on the first failure.
+      max-parallel: 2  # Cap of two jobs at a time to limit impact on other CI.
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v3
+      # Actually check the EOL date for the platform.
+      - name: Check EOL Date
+        id: check
+        run: |
+          d="$(.github/scripts/platform-impending-eol.py ${{ matrix.distro }} ${{ matrix.release }})"
+          case $? in
+            0) echo "pending=false" >> "${GITHUB_OUTPUT}" ;;
+            2)
+              echo "pending=true" >> "${GITHUB_OUTPUT}"
+              echo "date=${d}" >> "${GITHUB_OUTPUT}"
+              ;;
+            *)
+              echo "::error::Failed to check EOL date for ${{ matrix.distro }} ${{ matrix.release }}"
+              exit 1
+              ;;
+          esac
+      # Figure out the issue title.
+      # This is it’s own step so we only have to set it in one place.
+      - name: Determine Issue Title
+        id: title
+        if: steps.check.outputs.pending == 'true'
+        run: |
+          echo "title=[Platform EOL]: ${{ matrix.full_name }} will be EOL soon." >> "${GITHUB_OUTPUT}"
+      # Check if there is an existing issue in the repo for the platform EOL.
+      # The actual command line to make the check is unfortunately complicated because
+      # GitHub think that it’s sensible to exit with a status of 0 if there no results
+      # for a search.
+      - name: Check for Existing Issue
+        id: existing
+        if: steps.check.outputs.pending == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          count=$(gh issue list -R netdata/netdata -s all -S '${{ steps.title.outputs.title }} in:title' --json 'id' -q '. | length')
+          if [ "${count}" -ge 1 ]; then
+            echo 'exists=true' >> "${GITHUB_OUTPUT}"
+          else
+            echo 'exists=false' >> "${GITHUB_OUTPUT}"
+          fi
+      # If the platform is near EOL and there is no existing issue, create one.
+      - name: Create EOL Issue
+        id: create-issue
+        if: steps.check.outputs.pending == 'true' && steps.existing.outputs.exists == 'true'
+        uses: imjohnbo/issue-bot@v3
+        with:
+          assignees: Ferroin, tkatsoulas
+          labels: area/packaging, needs triage
+          title: ${{ steps.title.outputs.title }}
+          body: |
+            Based on information from https://endoflife.date/${{ matrix.distro }},
+            upstream support for ${{ matrix.full_name }} will be ending
+            on ${{ steps.check.outputs.date }}. A PR should be created
+            to remove this platform from our platform support document,
+            CI, and packaging code.
+
+            - [ ]: Remove platform from `packaging/PLATFORM_SUPPORT.md`
+            - [ ]: Remove platform from `.github/data/distros.yml`
+            - [ ]: Remove platform package builder from helper-images repo (if applicable).
+            - [ ]: Verify any other platform support code that needs to be cleaned up.


### PR DESCRIPTION
##### Summary

By default, it runs at 03:00 UTC every Monday, and checks the upstream EOL date for each platform we support that needs such checking. If the platform will be EOL upstream within the next 30 days, an issue is opened flagging the platform for removal from CI and our support document and auto-assigned to the agent SRE team members.

The workflow can also be manually triggered (mostly intended for testing).

Data about upstream EOL dates is retrieved from https://endoflife.date via their new public API. Happily, our own definition of what consititutes EOL for our purposes matches up 1:1 with how they categorize platforms as EOL, so the code handling this is relatively simple.

The original idea was to open a PR instead with the required changes, but correctly handling the required changes is actually nontrivial to automate, so I decided to just do an issue instead.

##### Test Plan

Confirm that actionlint flags no issues with the new workflow.

Beyond that, merge it and see what happens. This is not critical code, it can’t really break anything, and it’s trivial to remove it again if there are significant issues.

##### Additional Information

Credit to @tkatsoulas for the original idea on this one.