### PR TITLE
Prevent core dump when the agent is performing a quick shutdown

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -656,9 +656,12 @@ void cancel_main_threads() {
     int i, found = 0;
     usec_t max = 5 * USEC_PER_SEC, step = 100000;
     for (i = 0; static_threads[i].name != NULL ; i++) {
-        if(static_threads[i].enabled == NETDATA_MAIN_THREAD_RUNNING) {
-            info("EXIT: Stopping main thread: %s", static_threads[i].name);
-            netdata_thread_cancel(*static_threads[i].thread);
+        if (static_threads[i].enabled == NETDATA_MAIN_THREAD_RUNNING) {
+            if (static_threads[i].thread) {
+                info("EXIT: Stopping main thread: %s", static_threads[i].name);
+                netdata_thread_cancel(*static_threads[i].thread);
+            } else
+                info("EXIT: No thread running: %s", static_threads[i].name);
             found++;
         }
     }

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -660,8 +660,10 @@ void cancel_main_threads() {
             if (static_threads[i].thread) {
                 info("EXIT: Stopping main thread: %s", static_threads[i].name);
                 netdata_thread_cancel(*static_threads[i].thread);
-            } else
-                info("EXIT: No thread running: %s", static_threads[i].name);
+            } else {
+                info("EXIT: No thread running (marking as EXITED): %s", static_threads[i].name);
+                static_threads[i].enabled = NETDATA_MAIN_THREAD_EXITED;
+            }
             found++;
         }
     }

--- a/database/sqlite/sqlite_context.c
+++ b/database/sqlite/sqlite_context.c
@@ -449,6 +449,10 @@ skip_delete:
 int sql_context_cache_stats(int op)
 {
     int count, dummy;
+
+    if (unlikely(!db_context_meta))
+        return 0;
+
     netdata_thread_disable_cancelability();
     sqlite3_db_status(db_context_meta, op, &count, &dummy, 0);
     netdata_thread_enable_cancelability();

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -950,6 +950,10 @@ int bind_text_null(sqlite3_stmt *res, int position, const char *text, bool can_b
 int sql_metadata_cache_stats(int op)
 {
     int count, dummy;
+
+    if (unlikely(!db_meta))
+        return 0;
+
     netdata_thread_disable_cancelability();
     sqlite3_db_status(db_meta, op, &count, &dummy, 0);
     netdata_thread_enable_cancelability();

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -1272,6 +1272,9 @@ void metadata_sync_shutdown(void)
 
 void metadata_sync_shutdown_prepare(void)
 {
+    if (unlikely(!metasync_worker.loop))
+        return;
+
     struct metadata_cmd cmd;
     memset(&cmd, 0, sizeof(cmd));
 


### PR DESCRIPTION
This happens when the agent faces a initialization failure and issues a shutdown

Attempting to cancel threads not initialized
e.g.
```
#0  cancel_main_threads () at daemon/main.c:662
662	                netdata_thread_cancel(*static_threads[i].thread);
[Current thread is 1 (Thread 0x7f874397ecc0 (LWP 1495531))]
(gdb) p static_threads[i].thread
$1 = (netdata_thread_t *) 0x0
```

and

Attempting a metadata event loop shutdown that is not active yet

```
#0  0x00007f76710cc44f in uv_async_send () from /lib/x86_64-linux-gnu/libuv.so.1
#1  0x000055babf6ddebc in metadata_enq_cmd (wc=0x55babfd72e80 <metasync_worker>, cmd=0x7fff8dc9d380) at database/sqlite/sqlite_metadata.c:777
#2  0x000055babf6df9f9 in metadata_sync_shutdown_prepare () at database/sqlite/sqlite_metadata.c:1291
#3  0x000055babf5ef80d in netdata_cleanup_and_exit (ret=1) at daemon/main.c:389
#4  0x000055babf63030d in fatal_int (file=0x55babfb95d1d "database/rrdhost.c", function=0x55babfb97238 <__FUNCTION__.11> "rrd_init", line=934, fmt=0x55babfb967f2 "Failed to initialize SQLite") at libnetdata/log/log.c:1040
#5  0x000055babf6bbf33 in rrd_init (hostname=0x55bac0150f20 "futura", system_info=0x55bac015a310, unittest=false) at database/rrdhost.c:934
#6  0x000055babf5f66cb in main (argc=2, argv=0x7fff8dca1bf8) at daemon/main.c:2018
```
----


Easy way to test this is by going to `_install_path_/var/cache/netdata` and changing temporarily the 
permissions of the `netdata-meta.db` file e.g. remove all permissions to make it unreadable

Start the agent before and after applying this PR


