### PR TITLE
Add an option to the kickstart script to override distro detection.

### DIFF
--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -105,6 +105,7 @@ The `kickstart.sh` script accepts a number of optional parameters to control how
 - `--claim-proxy`: Specify a proxy to use when connecting to the cloud in the form of `http://[user:pass@]host:ip` for an HTTP(S) proxy.
   See [connecting through a proxy](https://github.com/netdata/netdata/blob/master/claim/README.md#connect-through-a-proxy) for details.
 - `--claim-url`: Specify a URL to use when connecting to the cloud. Defaults to `https://api.netdata.cloud`.
+- `--override-distro`: Override the distro detection logic and assume the system is using a specific Linux distribution and release. Takes a single argument consisting of the values of the `ID`, `VERSION_ID`, and `VERSION_CODENAME` fields from `/etc/os-release` for the desired distribution.
 
 
 Additionally, the following environment variables may be used to further customize how the script runs (most users


### PR DESCRIPTION
##### Summary

This consists of a single new option `--distro-override` which takes a single argument consisting of the values of the `ID`, `VERSION_ID`, and `VERSION_CODENAME` fields from the os-release file for the target distribution, separated by `:`. The codename part is optional for non-DEB distros, in which case the final `:` may be left off. The distro name is processed just like if we got it out of `/etc/os-release`, and thus any aliases our code already supports are also supported for this option. Additionally, the distro name and codename are automatically converted to lower case. For example:

- For Debian 11: `debian:11:bullseye`
- For Fedora 37: `fedora:37` or `Fedora:37`
- For RHEL 9: `rhel:9` or `RHEL:9` or `almalinux:9` or `CentOS:9`

This option allows for better handling of platforms that are ABI-compatible derivatives of our supported platforms, both in that it allows users to install with native packages on them, and in that it allows us to better test such setups.

A warning will be printed when this option is used so that users are duly informed that installing with this option is not officially supported and may not work. An additional warning is printed when attempting to install native packages with this option, directing users to open a feature request if their system works with our native packages but requires this option to be set.

Documentation is intentionally left sparse. This is intended to be something we instruct users to use when they ask us about support for specific platforms, not as something they just go and decide to use on their own.

##### Test Plan

Testing can be done by simply using the copy of the kickstart script from this PR. Testing should involve the usual checks required when testing the kickstart script (testing clean installs, testing on systems with existing installs, etc), but with the new `--distro-override` option with various values that differ from the actual system. It is recommended that testing be conducted using the `--dry-run` option initially.

##### Additional Information

Resolves: https://github.com/netdata/netdata/issues/14586