### PR TITLE
Use vector allocation whenever is possible (eBPF)

### DIFF
--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -457,6 +457,35 @@ char *btf_path = NULL;
 
 /*****************************************************************
  *
+ *  FUNCTIONS USED TO ALLOCATE APPS/CGROUP MEMORIES (ARAL)
+ *
+ *****************************************************************/
+
+/**
+ * Allocate PID ARAL
+ *
+ * Allocate memory using ARAL functions to speed up processing.
+ *
+ * @param name the internal name used for allocated region.
+ * @param size size of each element inside allocated space
+ *
+ * @return It returns the address on success and NULL otherwise.
+ */
+ARAL *ebpf_allocate_pid_aral(char *name, size_t size)
+{
+    static size_t max_elements = NETDATA_EBPF_ALLOC_MAX_PID;
+    if (max_elements < NETDATA_EBPF_ALLOC_MIN_ELEMENTS) {
+        error("Number of elements given is too small, adjusting it for %d", NETDATA_EBPF_ALLOC_MIN_ELEMENTS);
+        max_elements = NETDATA_EBPF_ALLOC_MIN_ELEMENTS;
+    }
+
+    return aral_create(name, size,
+        0, max_elements,
+        NULL, NULL, NULL, false, false);
+}
+
+/*****************************************************************
+ *
  *  FUNCTIONS USED TO CLEAN MEMORY AND OPERATE SYSTEM FILES
  *
  *****************************************************************/

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -292,6 +292,7 @@ void ebpf_write_chart_obsolete(char *type, char *id, char *title, char *units, c
                                       char *charttype, char *context, int order, int update_every);
 void write_histogram_chart(char *family, char *name, const netdata_idx_t *hist, char **dimensions, uint32_t end);
 void ebpf_update_disabled_plugin_stats(ebpf_module_t *em);
+ARAL *ebpf_allocate_pid_aral(char *name, size_t size);
 extern ebpf_filesystem_partitions_t localfs[];
 extern ebpf_sync_syscalls_t local_syscalls[];
 extern int ebpf_exit_plugin;

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -22,13 +22,10 @@ void ebpf_aral_init(void)
         max_elements = NETDATA_EBPF_ALLOC_MIN_ELEMENTS;
     }
 
-    ebpf_aral_apps_pid_stat = aral_create("ebpf-pid_stat", sizeof(struct ebpf_pid_stat),
-                                          0, max_elements,
-                                          NULL, NULL, NULL, false, false);
+    ebpf_aral_apps_pid_stat = ebpf_allocate_pid_aral("ebpf-pid_stat", sizeof(struct ebpf_pid_stat));
 
-    ebpf_aral_process_stat = aral_create("ebpf-proc_stat", sizeof(ebpf_process_stat_t),
-                                          0, max_elements,
-                                          NULL, NULL, NULL, false, false);
+    ebpf_aral_process_stat = ebpf_allocate_pid_aral("ebpf-proc_stat", sizeof(ebpf_process_stat_t));
+
 #ifdef NETDATA_DEV_MODE
     info("Plugin is using ARAL with values %d", NETDATA_EBPF_ALLOC_MAX_PID);
 #endif

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -1054,7 +1054,7 @@ void cleanup_variables_from_other_threads(uint32_t pid)
 
     // Clean shm structure
     if (shm_pid) {
-        freez(shm_pid[pid]);
+        ebpf_shm_release(shm_pid[pid]);
         shm_pid[pid] = NULL;
     }
 }

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -1030,7 +1030,7 @@ void cleanup_variables_from_other_threads(uint32_t pid)
 
     // Clean directory cache structure
     if (dcstat_pid) {
-        freez(dcstat_pid[pid]);
+        ebpf_dcstat_release(dcstat_pid[pid]);
         dcstat_pid[pid] = NULL;
     }
 

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -1018,7 +1018,7 @@ void cleanup_variables_from_other_threads(uint32_t pid)
 {
     // Clean socket structures
     if (socket_bandwidth_curr) {
-        freez(socket_bandwidth_curr[pid]);
+        ebpf_socket_release(socket_bandwidth_curr[pid]);
         socket_bandwidth_curr[pid] = NULL;
     }
 

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -1042,7 +1042,7 @@ void cleanup_variables_from_other_threads(uint32_t pid)
 
     // Clean vfs structure
     if (vfs_pid) {
-        freez(vfs_pid[pid]);
+        ebpf_vfs_release(vfs_pid[pid]);
         vfs_pid[pid] = NULL;
     }
 

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -1048,7 +1048,7 @@ void cleanup_variables_from_other_threads(uint32_t pid)
 
     // Clean fd structure
     if (fd_pid) {
-        freez(fd_pid[pid]);
+        ebpf_fd_release(fd_pid[pid]);
         fd_pid[pid] = NULL;
     }
 

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -1024,7 +1024,7 @@ void cleanup_variables_from_other_threads(uint32_t pid)
 
     // Clean cachestat structure
     if (cachestat_pid) {
-        freez(cachestat_pid[pid]);
+        ebpf_cachestat_release(cachestat_pid[pid]);
         cachestat_pid[pid] = NULL;
     }
 

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -1214,9 +1214,8 @@ static void ebpf_cachestat_allocate_global_vectors(int apps)
     if (apps) {
         cachestat_pid = callocz((size_t)pid_max, sizeof(netdata_publish_cachestat_t *));
         ebpf_cachestat_aral_init();
+        cachestat_vector = callocz((size_t)ebpf_nprocs, sizeof(netdata_cachestat_pid_t));
     }
-
-    cachestat_vector = callocz((size_t)ebpf_nprocs, sizeof(netdata_cachestat_pid_t));
 
     cachestat_values = callocz((size_t)ebpf_nprocs, sizeof(netdata_idx_t));
 

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -387,7 +387,7 @@ static inline void ebpf_cachestat_aral_init()
 /**
  * eBPF publish cachestat get
  *
- * Get an netdata_publish_cachestat_t entry to be used with a specific PID.
+ * Get a netdata_publish_cachestat_t entry to be used with a specific PID.
  *
  * @return it returns the address on success.
  */

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -546,7 +546,7 @@ static void cachestat_fill_pid(uint32_t current_pid, netdata_cachestat_pid_t *pu
 {
     netdata_publish_cachestat_t *curr = cachestat_pid[current_pid];
     if (!curr) {
-        curr = callocz(1, sizeof(netdata_publish_cachestat_t));
+        curr = ebpf_publish_cachestat_get();
         cachestat_pid[current_pid] = curr;
 
         cachestat_save_pid_values(curr, publish);

--- a/collectors/ebpf.plugin/ebpf_cachestat.h
+++ b/collectors/ebpf.plugin/ebpf_cachestat.h
@@ -82,6 +82,7 @@ typedef struct netdata_publish_cachestat {
 } netdata_publish_cachestat_t;
 
 void *ebpf_cachestat_thread(void *ptr);
+void ebpf_cachestat_release(netdata_publish_cachestat_t *stat);
 
 extern struct config cachestat_config;
 extern netdata_ebpf_targets_t cachestat_targets[];

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -476,7 +476,7 @@ static void dcstat_fill_pid(uint32_t current_pid, netdata_dcstat_pid_t *publish)
 {
     netdata_publish_dcstat_t *curr = dcstat_pid[current_pid];
     if (!curr) {
-        curr = callocz(1, sizeof(netdata_publish_dcstat_t));
+        curr = ebpf_publish_dcstat_get();
         dcstat_pid[current_pid] = curr;
     }
 
@@ -1108,8 +1108,10 @@ static void ebpf_create_filesystem_charts(int update_every)
  */
 static void ebpf_dcstat_allocate_global_vectors(int apps)
 {
-    if (apps)
+    if (apps) {
+        ebpf_dcstat_aral_init();
         dcstat_pid = callocz((size_t)pid_max, sizeof(netdata_publish_dcstat_t *));
+    }
 
     dcstat_vector = callocz((size_t)ebpf_nprocs, sizeof(netdata_dcstat_pid_t));
     dcstat_values = callocz((size_t)ebpf_nprocs, sizeof(netdata_idx_t));

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -338,7 +338,7 @@ static void ebpf_dcstat_exit(void *ptr)
  *****************************************************************/
 
 /**
- * eBPF Cachestat Aral init
+ * eBPF directory cache Aral init
  *
  * Initiallize array allocator that will be used when integration with apps is enabled.
  */

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -1111,9 +1111,9 @@ static void ebpf_dcstat_allocate_global_vectors(int apps)
     if (apps) {
         ebpf_dcstat_aral_init();
         dcstat_pid = callocz((size_t)pid_max, sizeof(netdata_publish_dcstat_t *));
+        dcstat_vector = callocz((size_t)ebpf_nprocs, sizeof(netdata_dcstat_pid_t));
     }
 
-    dcstat_vector = callocz((size_t)ebpf_nprocs, sizeof(netdata_dcstat_pid_t));
     dcstat_values = callocz((size_t)ebpf_nprocs, sizeof(netdata_idx_t));
 
     memset(dcstat_counter_aggregated_data, 0, NETDATA_DCSTAT_IDX_END * sizeof(netdata_syscall_stat_t));

--- a/collectors/ebpf.plugin/ebpf_dcstat.h
+++ b/collectors/ebpf.plugin/ebpf_dcstat.h
@@ -75,6 +75,7 @@ typedef struct netdata_publish_dcstat {
 
 void *ebpf_dcstat_thread(void *ptr);
 void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr);
+void ebpf_dcstat_release(netdata_publish_dcstat_t *stat);
 extern struct config dcstat_config;
 extern netdata_ebpf_targets_t dc_targets[];
 extern ebpf_local_maps_t dcstat_maps[];

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -1117,9 +1117,8 @@ static void ebpf_fd_allocate_global_vectors(int apps)
     if (apps) {
         ebpf_fd_aral_init();
         fd_pid = callocz((size_t)pid_max, sizeof(netdata_fd_stat_t *));
+        fd_vector = callocz((size_t)ebpf_nprocs, sizeof(netdata_fd_stat_t));
     }
-
-    fd_vector = callocz((size_t)ebpf_nprocs, sizeof(netdata_fd_stat_t));
 
     fd_values = callocz((size_t)ebpf_nprocs, sizeof(netdata_idx_t));
 }

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -523,7 +523,7 @@ static void fd_fill_pid(uint32_t current_pid, netdata_fd_stat_t *publish)
 {
     netdata_fd_stat_t *curr = fd_pid[current_pid];
     if (!curr) {
-        curr = callocz(1, sizeof(netdata_fd_stat_t));
+        curr = ebpf_fd_stat_get();
         fd_pid[current_pid] = curr;
     }
 
@@ -1114,8 +1114,10 @@ static void ebpf_create_fd_global_charts(ebpf_module_t *em)
  */
 static void ebpf_fd_allocate_global_vectors(int apps)
 {
-    if (apps)
+    if (apps) {
+        ebpf_fd_aral_init();
         fd_pid = callocz((size_t)pid_max, sizeof(netdata_fd_stat_t *));
+    }
 
     fd_vector = callocz((size_t)ebpf_nprocs, sizeof(netdata_fd_stat_t));
 

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -3,6 +3,10 @@
 #include "ebpf.h"
 #include "ebpf_fd.h"
 
+// ----------------------------------------------------------------------------
+// ARAL vectors used to speed up processing
+ARAL *ebpf_aral_fd_pid;
+
 static char *fd_dimension_names[NETDATA_FD_SYSCALL_END] = { "open", "close" };
 static char *fd_id_names[NETDATA_FD_SYSCALL_END] = { "do_sys_open",  "__close_fd" };
 
@@ -392,6 +396,46 @@ static void ebpf_fd_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
     ebpf_fd_free(em);
+}
+
+/*****************************************************************
+ *
+ *  ARAL FUNCTIONS
+ *
+ *****************************************************************/
+
+/**
+ * eBPF file descriptor Aral init
+ *
+ * Initiallize array allocator that will be used when integration with apps is enabled.
+ */
+static inline void ebpf_fd_aral_init()
+{
+    ebpf_aral_fd_pid = ebpf_allocate_pid_aral("ebpf-fd", sizeof(netdata_fd_stat_t));
+}
+
+/**
+ * eBPF publish file descriptor get
+ *
+ * Get a netdata_fd_stat_t entry to be used with a specific PID.
+ *
+ * @return it returns the address on success.
+ */
+netdata_fd_stat_t *ebpf_fd_stat_get(void)
+{
+    netdata_fd_stat_t *target = aral_mallocz(ebpf_aral_fd_pid);
+    memset(target, 0, sizeof(netdata_fd_stat_t));
+    return target;
+}
+
+/**
+ * eBPF file descriptor release
+ *
+ * @param stat Release a target after usage.
+ */
+void ebpf_fd_release(netdata_fd_stat_t *stat)
+{
+    aral_freez(ebpf_aral_fd_pid, stat);
 }
 
 /*****************************************************************

--- a/collectors/ebpf.plugin/ebpf_fd.h
+++ b/collectors/ebpf.plugin/ebpf_fd.h
@@ -80,6 +80,7 @@ enum fd_close_syscall {
 
 void *ebpf_fd_thread(void *ptr);
 void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr);
+void ebpf_fd_release(netdata_fd_stat_t *stat);
 extern struct config fd_config;
 extern netdata_fd_stat_t **fd_pid;
 extern netdata_ebpf_targets_t fd_targets[];

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -399,7 +399,7 @@ static void shm_fill_pid(uint32_t current_pid, netdata_publish_shm_t *publish)
 {
     netdata_publish_shm_t *curr = shm_pid[current_pid];
     if (!curr) {
-        curr = callocz(1, sizeof(netdata_publish_shm_t));
+        curr = ebpf_shm_stat_get( );
         shm_pid[current_pid] = curr;
     }
 
@@ -989,10 +989,11 @@ void ebpf_shm_create_apps_charts(struct ebpf_module *em, void *ptr)
  */
 static void ebpf_shm_allocate_global_vectors(int apps)
 {
-    if (apps)
+    if (apps) {
+        ebpf_shm_aral_init();
         shm_pid = callocz((size_t)pid_max, sizeof(netdata_publish_shm_t *));
-
-    shm_vector = callocz((size_t)ebpf_nprocs, sizeof(netdata_publish_shm_t));
+        shm_vector = callocz((size_t)ebpf_nprocs, sizeof(netdata_publish_shm_t));
+    }
 
     shm_values = callocz((size_t)ebpf_nprocs, sizeof(netdata_idx_t));
 

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -336,7 +336,7 @@ static void ebpf_shm_exit(void *ptr)
  */
 static inline void ebpf_shm_aral_init()
 {
-    ebpf_aral_shm_pid = ebpf_allocate_pid_aral("ebpf-fd", sizeof(netdata_publish_shm_t));
+    ebpf_aral_shm_pid = ebpf_allocate_pid_aral("ebpf-shm", sizeof(netdata_publish_shm_t));
 }
 
 /**

--- a/collectors/ebpf.plugin/ebpf_shm.h
+++ b/collectors/ebpf.plugin/ebpf_shm.h
@@ -54,6 +54,7 @@ extern netdata_publish_shm_t **shm_pid;
 
 void *ebpf_shm_thread(void *ptr);
 void ebpf_shm_create_apps_charts(struct ebpf_module *em, void *ptr);
+void ebpf_shm_release(netdata_publish_shm_t *stat);
 extern netdata_ebpf_targets_t shm_targets[];
 
 extern struct config shm_config;

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -2271,7 +2271,7 @@ void ebpf_socket_fill_publish_apps(uint32_t current_pid, ebpf_bandwidth_t *eb)
 {
     ebpf_socket_publish_apps_t *curr = socket_bandwidth_curr[current_pid];
     if (!curr) {
-        curr = callocz(1, sizeof(ebpf_socket_publish_apps_t));
+        curr = ebpf_socket_stat_get();
         socket_bandwidth_curr[current_pid] = curr;
     }
 
@@ -2991,10 +2991,11 @@ static void ebpf_socket_allocate_global_vectors(int apps)
     memset(socket_publish_aggregated, 0 ,NETDATA_MAX_SOCKET_VECTOR * sizeof(netdata_publish_syscall_t));
     socket_hash_values = callocz(ebpf_nprocs, sizeof(netdata_idx_t));
 
-    if (apps)
+    if (apps) {
+        ebpf_socket_aral_init();
         socket_bandwidth_curr = callocz((size_t)pid_max, sizeof(ebpf_socket_publish_apps_t *));
-
-    bandwidth_vector = callocz((size_t)ebpf_nprocs, sizeof(ebpf_bandwidth_t));
+        bandwidth_vector = callocz((size_t)ebpf_nprocs, sizeof(ebpf_bandwidth_t));
+    }
 
     socket_values = callocz((size_t)ebpf_nprocs, sizeof(netdata_socket_t));
     if (network_viewer_opt.enabled) {

--- a/collectors/ebpf.plugin/ebpf_socket.h
+++ b/collectors/ebpf.plugin/ebpf_socket.h
@@ -363,6 +363,7 @@ void update_listen_table(uint16_t value, uint16_t proto, netdata_passive_connect
 void parse_network_viewer_section(struct config *cfg);
 void ebpf_fill_ip_list(ebpf_network_viewer_ip_list_t **out, ebpf_network_viewer_ip_list_t *in, char *table);
 void parse_service_name_section(struct config *cfg);
+void ebpf_socket_release(ebpf_socket_publish_apps_t *stat);
 
 extern ebpf_socket_publish_apps_t **socket_bandwidth_curr;
 extern struct config socket_config;

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -819,7 +819,7 @@ static void vfs_fill_pid(uint32_t current_pid, netdata_publish_vfs_t *publish)
 {
     netdata_publish_vfs_t *curr = vfs_pid[current_pid];
     if (!curr) {
-        curr = callocz(1, sizeof(netdata_publish_vfs_t));
+        curr = ebpf_vfs_get();
         vfs_pid[current_pid] = curr;
     }
 
@@ -1869,14 +1869,16 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
  */
 static void ebpf_vfs_allocate_global_vectors(int apps)
 {
+    if (apps) {
+        ebpf_vfs_aral_init();
+        vfs_pid = callocz((size_t)pid_max, sizeof(netdata_publish_vfs_t *));
+        vfs_vector = callocz(ebpf_nprocs, sizeof(netdata_publish_vfs_t));
+    }
+
     memset(vfs_aggregated_data, 0, sizeof(vfs_aggregated_data));
     memset(vfs_publish_aggregated, 0, sizeof(vfs_publish_aggregated));
 
     vfs_hash_values = callocz(ebpf_nprocs, sizeof(netdata_idx_t));
-    vfs_vector = callocz(ebpf_nprocs, sizeof(netdata_publish_vfs_t));
-
-    if (apps)
-        vfs_pid = callocz((size_t)pid_max, sizeof(netdata_publish_vfs_t *));
 }
 
 /*****************************************************************

--- a/collectors/ebpf.plugin/ebpf_vfs.h
+++ b/collectors/ebpf.plugin/ebpf_vfs.h
@@ -168,6 +168,7 @@ extern netdata_publish_vfs_t **vfs_pid;
 
 void *ebpf_vfs_thread(void *ptr);
 void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr);
+void ebpf_vfs_release(netdata_publish_vfs_t *stat);
 extern netdata_ebpf_targets_t vfs_targets[];
 
 extern struct config vfs_config;


### PR DESCRIPTION
##### Summary
This PR is modifying threads to use `ARAL` instead our `callocz`/`freez` pair. 

##### Test Plan
1. Compile this branch.
2. Start netdata. 
3. Wait few minutes to take a look in plugin behavior. Everything should run normally. 

##### Additional Information
It is not necessary to run on different kernels.
After changes `coverity` is reporting errors due this [code](https://github.com/netdata/netdata/blob/59a1a528e3e42e90eda83f7cfe7b04fe8a00e60d/libnetdata/locks/locks.c#L303-L307). @stelfrag my current understanding  is that `coverity` is reporting a false positive, please, let me know if I am wrong.


<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? ebpf.plugin
- Can they see the change or is it an under the hood? If they can see it, where? No.
- How is the user impacted by the change?  A faster plugin
- What are there any benefits of the change? Plugin will not call syscalls with high frequency on busy environments.
</details>
