### PR TITLE
Fix context unittest coredump

### DIFF
--- a/database/engine/datafile.c
+++ b/database/engine/datafile.c
@@ -379,8 +379,8 @@ static int scan_data_files_cmp(const void *a, const void *b)
 /* Returns number of datafiles that were loaded or < 0 on error */
 static int scan_data_files(struct rrdengine_instance *ctx)
 {
-    int ret, matched_files, failed_to_load;
-    unsigned tier, no, i;
+    int ret, matched_files, failed_to_load, i;
+    unsigned tier, no;
     uv_fs_t req;
     uv_dirent_t dent;
     struct rrdengine_datafile **datafiles, *datafile;

--- a/database/sqlite/sqlite_context.c
+++ b/database/sqlite/sqlite_context.c
@@ -489,6 +489,8 @@ int ctx_unittest(void)
     uuid_t host_uuid;
     uuid_generate(host_uuid);
 
+    initialize_thread_key_pool();
+
     int rc = sql_init_context_database(1);
 
     if (rc != SQLITE_OK)

--- a/database/sqlite/sqlite_context.c
+++ b/database/sqlite/sqlite_context.c
@@ -117,7 +117,6 @@ void sql_close_context_database(void)
     rc = sqlite3_close_v2(db_context_meta);
     if (unlikely(rc != SQLITE_OK))
         error_report("Error %d while closing the context SQLite database, %s", rc, sqlite3_errstr(rc));
-    return;
 }
 
 //
@@ -243,8 +242,6 @@ failed:
     rc = sqlite3_reset(res);
     if (rc != SQLITE_OK)
         error_report("Failed to reset statement that fetches chart label data, rc = %d", rc);
-
-    return;
 }
 
 // CONTEXT LIST
@@ -431,11 +428,11 @@ int ctx_delete_context(uuid_t *host_uuid, VERSIONED_CONTEXT_DATA *context_data)
     if (rc_stored != SQLITE_DONE)
         error_report("Failed to delete context %s, rc = %d", context_data->id, rc_stored);
 #ifdef NETDATA_INTERNAL_CHECKS
-     else {
-         char host_uuid_str[UUID_STR_LEN];
-         uuid_unparse_lower(*host_uuid, host_uuid_str);
-         info("%s: Deleted context %s under host %s", __FUNCTION__ , context_data->id, host_uuid_str);
-     }
+    else {
+        char host_uuid_str[UUID_STR_LEN];
+        uuid_unparse_lower(*host_uuid, host_uuid_str);
+        info("%s: Deleted context %s under host %s", __FUNCTION__, context_data->id, host_uuid_str);
+    }
 #endif
 
 skip_delete:

--- a/database/sqlite/sqlite_context.c
+++ b/database/sqlite/sqlite_context.c
@@ -556,6 +556,7 @@ int ctx_unittest(void)
     freez((void *)context_data.title);
     freez((void *)context_data.chart_type);
     freez((void *)context_data.family);
+    freez((void *)context_data.units);
 
     // The list should be empty
     info("List context start after delete");

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -156,6 +156,12 @@ static void release_statement(void *statement)
         error_report("Failed to finalize statement, rc = %d", rc);
 }
 
+void initialize_thread_key_pool(void)
+{
+    for (int i = 0; i < MAX_PREPARED_STATEMENTS; i++)
+        (void)pthread_key_create(&key_pool[i], release_statement);
+}
+
 int prepare_statement(sqlite3 *database, const char *query, sqlite3_stmt **statement)
 {
     static __thread uint32_t keys_used = 0;
@@ -448,8 +454,7 @@ int sql_init_database(db_check_action_type_t rebuild, int memory)
 
     info("SQLite database initialization completed");
 
-    for (int i = 0; i < MAX_PREPARED_STATEMENTS; i++)
-        (void)pthread_key_create(&key_pool[i], release_statement);
+    initialize_thread_key_pool();
 
     rc = sqlite3_create_function(db_meta, "u2h", 1, SQLITE_ANY | SQLITE_DETERMINISTIC, 0, sqlite_uuid_parse, 0, 0);
     if (unlikely(rc != SQLITE_OK))

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -56,6 +56,7 @@ int prepare_statement(sqlite3 *database, const char *query, sqlite3_stmt **state
 int execute_insert(sqlite3_stmt *res);
 int exec_statement_with_uuid(const char *sql, uuid_t *uuid);
 void db_execute(const char *cmd);
+void initialize_thread_key_pool(void);
 
 // Look up functions
 int get_node_id(uuid_t *host_id, uuid_t *node_id);


### PR DESCRIPTION
Minor cleanup and fix a core dump when running `netdata -W ctxtest`


```
#0  0x000055dd17705898 in ?? ()
#1  0x00007f16cfe89644 in ?? () from /lib/x86_64-linux-gnu/libcrypto.so.3
#2  0x00007f16cfe8d8e2 in OPENSSL_thread_stop () from /lib/x86_64-linux-gnu/libcrypto.so.3
#3  0x00007f16cfe8d945 in OPENSSL_cleanup () from /lib/x86_64-linux-gnu/libcrypto.so.3
#4  0x00007f16cf5a2a56 in __cxa_finalize (d=0x7f16d010b000) at ./stdlib/cxa_finalize.c:83
#5  0x00007f16cfd820f7 in ?? () from /lib/x86_64-linux-gnu/libcrypto.so.3
#6  0x00007ffe95aa7c00 in ?? ()
#7  0x00007f16d015124e in _dl_fini () at ./elf/dl-fini.c:142
```


