### PR TITLE
Add Amazon Linux 2 to CI and platform support.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -74,6 +74,17 @@ include:
         - el/8Server
         - el/8Client
 
+  - distro: amazonlinux
+    version: "2"
+    packages:
+      type: rpm
+      repo_distro: amazonlinux/2
+      arches:
+        - x86_64
+        - aarch64
+    test:
+      ebpf-core: false
+
   - distro: centos
     version: "7"
     eol_check: false

--- a/.github/scripts/ci-support-pkgs.sh
+++ b/.github/scripts/ci-support-pkgs.sh
@@ -5,10 +5,13 @@
 
 set -e
 
-if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/fedora-release ] || [ -f /etc/almalinux-release ]; then
-    # Alma, Fedora, CentOS, Redhat
-    dnf install -y procps-ng cronie cronie-anacron || yum install -y procps-ng cronie cronie-anacron
-elif [ -f /etc/arch-release ]; then
-    # Arch
-    pacman -S --noconfirm cronie
-fi
+. /etc/os-release
+
+case "${ID}" in
+    amzn|almalinux|centos|fedora)
+        dnf install -y procps-ng cronie cronie-anacron || yum install -y procps-ng cronie cronie-anacron
+        ;;
+    arch)
+        pacman -S --noconfirm cronie
+        ;;
+esac

--- a/.github/scripts/pkg-test.sh
+++ b/.github/scripts/pkg-test.sh
@@ -127,7 +127,7 @@ case "${DISTRO}" in
     install_centos
     ;;
   amazonlinux)
-    install_amazon
+    install_amazon_linux
     ;;
   opensuse)
     install_suse_like

--- a/.github/scripts/pkg-test.sh
+++ b/.github/scripts/pkg-test.sh
@@ -13,7 +13,7 @@ install_debian_like() {
   apt-get update
 
   # Install Netdata
-  apt-get install -y /netdata/artifacts/netdata_"${VERSION}"*_*.deb || exit 1
+  apt-get install -y "/netdata/artifacts/netdata_${VERSION}*_*.deb" || exit 1
 
   # Install testing tools
   apt-get install -y --no-install-recommends curl "${netcat}" jq || exit 1
@@ -28,7 +28,7 @@ install_fedora_like() {
   pkg_version="$(echo "${VERSION}" | tr - .)"
 
   # Install Netdata
-  "$PKGMGR" install -y /netdata/artifacts/netdata-"${pkg_version}"-*.rpm
+  "$PKGMGR" install -y "/netdata/artifacts/netdata-${pkg_version}-*.rpm" || exit 1
 
   # Install testing tools
   "$PKGMGR" install -y curl nc jq || exit 1
@@ -50,9 +50,10 @@ install_centos() {
   "$PKGMGR" install -y epel-release || exit 1
 
   # Install Netdata
-  "$PKGMGR" install -y /netdata/artifacts/netdata-"${pkg_version}"-*.rpm
+  "$PKGMGR" install -y "/netdata/artifacts/netdata-${pkg_version}-*.rpm" || exit 1
 
   # Install testing tools
+  # shellcheck disable=SC2086
   "$PKGMGR" install -y ${opts} curl nc jq || exit 1
 }
 
@@ -62,9 +63,10 @@ install_amazon_linux() {
   pkg_version="$(echo "${VERSION}" | tr - .)"
 
   # Install Netdata
-  "$PKGMGR" install -y "/netdata/artifacts/netdata-${pkg_version}-*.rpm"
+  "$PKGMGR" install -y "/netdata/artifacts/netdata-${pkg_version}-*.rpm" || exit 1
 
   # Install testing tools
+  # shellcheck disable=SC2086
   "$PKGMGR" install -y ${opts} curl nc jq || exit 1
 }
 
@@ -75,7 +77,7 @@ install_suse_like() {
   pkg_version="$(echo "${VERSION}" | tr - .)"
 
   # Install Netdata
-  zypper install -y --allow-unsigned-rpm /netdata/artifacts/netdata-"${pkg_version}"-*.rpm
+  zypper install -y --allow-unsigned-rpm "/netdata/artifacts/netdata-${pkg_version}-*.rpm" || exit 1
 
   # Install testing tools
   zypper install -y --no-recommends curl netcat-openbsd jq || exit 1

--- a/.github/scripts/pkg-test.sh
+++ b/.github/scripts/pkg-test.sh
@@ -13,7 +13,8 @@ install_debian_like() {
   apt-get update
 
   # Install Netdata
-  apt-get install -y "/netdata/artifacts/netdata_${VERSION}*_*.deb" || exit 1
+  # Strange quoting is required here so that glob matching works.
+  apt-get install -y /netdata/artifacts/netdata_"${VERSION}"*_*.deb || exit 1
 
   # Install testing tools
   apt-get install -y --no-install-recommends curl "${netcat}" jq || exit 1
@@ -28,7 +29,8 @@ install_fedora_like() {
   pkg_version="$(echo "${VERSION}" | tr - .)"
 
   # Install Netdata
-  "$PKGMGR" install -y "/netdata/artifacts/netdata-${pkg_version}-*.rpm" || exit 1
+  # Strange quoting is required here so that glob matching works.
+  "$PKGMGR" install -y /netdata/artifacts/netdata-"${pkg_version}"-*.rpm || exit 1
 
   # Install testing tools
   "$PKGMGR" install -y curl nc jq || exit 1
@@ -50,7 +52,8 @@ install_centos() {
   "$PKGMGR" install -y epel-release || exit 1
 
   # Install Netdata
-  "$PKGMGR" install -y "/netdata/artifacts/netdata-${pkg_version}-*.rpm" || exit 1
+  # Strange quoting is required here so that glob matching works.
+  "$PKGMGR" install -y /netdata/artifacts/netdata-"${pkg_version}"-*.rpm || exit 1
 
   # Install testing tools
   # shellcheck disable=SC2086
@@ -63,7 +66,8 @@ install_amazon_linux() {
   pkg_version="$(echo "${VERSION}" | tr - .)"
 
   # Install Netdata
-  "$PKGMGR" install -y "/netdata/artifacts/netdata-${pkg_version}-*.rpm" || exit 1
+  # Strange quoting is required here so that glob matching works.
+  "$PKGMGR" install -y /netdata/artifacts/netdata-"${pkg_version}"-*.rpm || exit 1
 
   # Install testing tools
   # shellcheck disable=SC2086
@@ -77,7 +81,8 @@ install_suse_like() {
   pkg_version="$(echo "${VERSION}" | tr - .)"
 
   # Install Netdata
-  zypper install -y --allow-unsigned-rpm "/netdata/artifacts/netdata-${pkg_version}-*.rpm" || exit 1
+  # Strange quoting is required here so that glob matching works.
+  zypper install -y --allow-unsigned-rpm /netdata/artifacts/netdata-"${pkg_version}"-*.rpm || exit 1
 
   # Install testing tools
   zypper install -y --no-recommends curl netcat-openbsd jq || exit 1

--- a/.github/scripts/pkg-test.sh
+++ b/.github/scripts/pkg-test.sh
@@ -56,6 +56,18 @@ install_centos() {
   "$PKGMGR" install -y ${opts} curl nc jq || exit 1
 }
 
+install_amazon_linux() {
+  PKGMGR="$( (command -v dnf > /dev/null && echo "dnf") || echo "yum")"
+
+  pkg_version="$(echo "${VERSION}" | tr - .)"
+
+  # Install Netdata
+  "$PKGMGR" install -y /netdata/artifacts/netdata-"${pkg_version}"-*.rpm
+
+  # Install testing tools
+  "$PKGMGR" install -y ${opts} curl nc jq || exit 1
+}
+
 install_suse_like() {
   # Using a glob pattern here because I can't reliably determine what the
   # resulting package name will be (TODO: There must be a better way!)
@@ -113,6 +125,9 @@ case "${DISTRO}" in
     ;;
   centos | rockylinux | almalinux)
     install_centos
+    ;;
+  amazonlinux)
+    install_amazon
     ;;
   opensuse)
     install_suse_like

--- a/.github/scripts/pkg-test.sh
+++ b/.github/scripts/pkg-test.sh
@@ -62,7 +62,7 @@ install_amazon_linux() {
   pkg_version="$(echo "${VERSION}" | tr - .)"
 
   # Install Netdata
-  "$PKGMGR" install -y /netdata/artifacts/netdata-"${pkg_version}"-*.rpm
+  "$PKGMGR" install -y "/netdata/artifacts/netdata-${pkg_version}-*.rpm"
 
   # Install testing tools
   "$PKGMGR" install -y ${opts} curl nc jq || exit 1

--- a/.github/scripts/run-updater-check.sh
+++ b/.github/scripts/run-updater-check.sh
@@ -2,6 +2,7 @@
 
 echo ">>> Installing CI support packages..."
 /netdata/.github/scripts/ci-support-pkgs.sh
+mkdir -p /etc/cron.daily # Needed to make auto-update checking work correctly on some platforms.
 echo ">>> Installing Netdata..."
 /netdata/packaging/installer/kickstart.sh --dont-wait --build-only --disable-telemetry || exit 1
 echo "::group::>>> Pre-Update Environment File Contents"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1018,13 +1018,14 @@ if [ ! -f "${NETDATA_PREFIX}/etc/netdata/.installer-cleanup-of-stock-configs-don
   (find -L "${NETDATA_PREFIX}/etc/netdata" -type f -not -path '*/\.*' -not -path "${NETDATA_PREFIX}/etc/netdata/orig/*" \( -name '*.conf.old' -o -name '*.conf' -o -name '*.conf.orig' -o -name '*.conf.installer_backup.*' \)) | while IFS= read -r  x; do
     if [ -f "${x}" ]; then
       # find it relative filename
-      f=$("$x" | sed "${NETDATA_PREFIX}/etc/netdata/")
+      p="$(echo "${NETDATA_PREFIX}/etc/netdata" | sed -e 's/\//\\\//')"
+      f="$(echo "${x}" | sed -e "s/${p}//")"
 
       # find the stock filename
-      t=$("${f}" | sed ".conf.installer_backup.*/.conf")
-      t=$("${t}" | sed ".conf.old/.conf")
-      t=$("${t}" | sed ".conf.orig/.conf")
-      t=$("${t}" | sed "orig//")
+      t="$(echo "${f}" | sed -e 's/\.conf\.installer_backup\..*/\.conf/')"
+      t="$(echo "${t}" | sed -e 's/\.conf\.old/\.conf/')"
+      t="$(echo "${t}" | sed -e 's/\.conf\.orig/\.conf/')"
+      t="$(echo "${t}" | sed -e 's/orig//')"
 
       if [ -z "${md5sum}" ] || [ ! -x "${md5sum}" ]; then
         # we don't have md5sum - keep it

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -88,13 +88,14 @@ platforms that we officially support ourselves to the intermediate tier. Our [st
 expected to work on these platforms if available. Source-based installs are expected to work on these platforms
 with minimal user effort.
 
-| Platform      | Version | Official Native Packages | Notes                                                                   |
-|---------------|---------|--------------------------|-------------------------------------------------------------------------|
-| Alpine Linux  | 3.16    | No                       |                                                                         |
-| Alpine Linux  | 3.15    | No                       |                                                                         |
-| Alpine Linux  | 3.14    | No                       |                                                                         |
-| Arch Linux    | Latest  | No                       | We officially recommend the community packages available for Arch Linux |
-| Manjaro Linux | Latest  | No                       | We officially recommend the community packages available for Arch Linux |
+| Platform      | Version | Official Native Packages | Notes                                                                                                |
+|---------------|---------|--------------------------|------------------------------------------------------------------------------------------------------|
+| Alpine Linux  | 3.16    | No                       |                                                                                                      |
+| Alpine Linux  | 3.15    | No                       |                                                                                                      |
+| Alpine Linux  | 3.14    | No                       |                                                                                                      |
+| Amazon Linux  | 2       | x86\_64, AArch64         | Scheduled for promotion to Core tier at some point after the release of v1.39.0 of the Netdata Agent |
+| Arch Linux    | Latest  | No                       | We officially recommend the community packages available for Arch Linux                              |
+| Manjaro Linux | Latest  | No                       | We officially recommend the community packages available for Arch Linux                              |
 
 ### Community
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -667,7 +667,7 @@ get_system_info() {
         warning "Distribution auto-detection overridden by user. This is not guaranteed to work, and is not officially supported."
       fi
 
-      supported_compat_names="debian ubuntu centos fedora opensuse ol arch"
+      supported_compat_names="debian ubuntu centos fedora opensuse ol amzn arch"
 
       if str_in_list "${DISTRO}" "${supported_compat_names}"; then
           DISTRO_COMPAT_NAME="${DISTRO}"
@@ -1274,7 +1274,7 @@ pkg_installed() {
           dpkg-query --show --showformat '${Status}' "${1}" 2>&1 | cut -f 1 -d ' ' | grep -q '^install$'
           return $?
           ;;
-        centos|fedora|opensuse|ol)
+        centos|fedora|opensuse|ol|amzn)
           rpm -q "${1}" > /dev/null 2>&1
           return $?
           ;;
@@ -1318,7 +1318,7 @@ netdata_avail_check() {
       env DEBIAN_FRONTEND=noninteractive apt-cache policy netdata | grep -q repo.netdata.cloud/repos/;
       return $?
       ;;
-    centos|fedora|ol)
+    centos|fedora|ol|amzn)
       # shellcheck disable=SC2086
       ${pm_cmd} search --nogpgcheck -v netdata | grep -qE 'Repo *: netdata(-edge)?$'
       return $?
@@ -1471,6 +1471,23 @@ try_package_install() {
         pm_cmd="yum"
       fi
       repo_prefix="ol/${SYSVERSION}"
+      pkg_type="rpm"
+      pkg_suffix=".noarch"
+      pkg_vsep="-"
+      pkg_install_opts="${interactive_opts}"
+      repo_update_opts="${interactive_opts}"
+      uninstall_subcmd="remove"
+      INSTALL_TYPE="binpkg-rpm"
+      NATIVE_VERSION="${INSTALL_VERSION:+"-${INSTALL_VERSION}.${SYSARCH}"}"
+      ;;
+    amzn)
+      if command -v dnf > /dev/null; then
+        pm_cmd="dnf"
+        repo_subcmd="makecache"
+      else
+        pm_cmd="yum"
+      fi
+      repo_prefix="amazonlinux/${SYSVERSION}"
       pkg_type="rpm"
       pkg_suffix=".noarch"
       pkg_vsep="-"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -838,8 +838,8 @@ ndtmpdir=
 
 trap cleanup EXIT
 
-if [ -t 2 ]; then
-  # we are running on a terminal
+if [ -t 2 ] || [ "${GITHUB_ACTIONS}" ]; then
+  # we are running on a terminal or under CI
   # open fd 3 and send it to stderr
   exec 3>&2
 else

--- a/packaging/repoconfig/netdata-edge.repo.al
+++ b/packaging/repoconfig/netdata-edge.repo.al
@@ -1,0 +1,21 @@
+[netdata-edge]
+name=Netdata Edge
+baseurl=https://repo.netdata.cloud/repos/edge/amazonlinux/$releasever/$basearch
+repo_gpgcheck=1
+gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
+enabled=1
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+priority=50
+
+[netdata-repoconfig]
+name=Netdata Repository Config
+baseurl=https://repo.netdata.cloud/repos/repoconfig/amazonlinux/$releasever/$basearch
+repo_gpgcheck=1
+gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
+enabled=1
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+priority=50

--- a/packaging/repoconfig/netdata-repo.spec
+++ b/packaging/repoconfig/netdata-repo.spec
@@ -16,6 +16,8 @@ Source4:        netdata.repo.centos
 Source5:        netdata-edge.repo.centos
 Source6:        netdata.repo.ol
 Source7:        netdata-edge.repo.ol
+Source8:        netdata.repo.al
+Source9:        netdata-edge.repo.al
 
 BuildArch:      noarch
 
@@ -43,8 +45,13 @@ install -pm 644 %{SOURCE3} ./netdata-edge.repo
 %endif
 
 %if 0%{?centos_ver}
+%if 0%{?amzn2} # Amazon Linux 2 looks like CentOS, but with extra macros.
+install -pm 644 %{SOURCE8} ./netdata.repo
+install -pm 644 %{SOURCE9} ./netdata-edge.repo
+%else
 install -pm 644 %{SOURCE4} ./netdata.repo
 install -pm 644 %{SOURCE5} ./netdata-edge.repo
+%endif
 %endif
 
 %if 0%{?oraclelinux}

--- a/packaging/repoconfig/netdata-repo.spec
+++ b/packaging/repoconfig/netdata-repo.spec
@@ -45,7 +45,8 @@ install -pm 644 %{SOURCE3} ./netdata-edge.repo
 %endif
 
 %if 0%{?centos_ver}
-%if 0%{?amzn2} # Amazon Linux 2 looks like CentOS, but with extra macros.
+# Amazon Linux 2 looks like CentOS, but with extra macros.
+%if 0%{?amzn2}
 install -pm 644 %{SOURCE8} ./netdata.repo
 install -pm 644 %{SOURCE9} ./netdata-edge.repo
 %else

--- a/packaging/repoconfig/netdata.repo.al
+++ b/packaging/repoconfig/netdata.repo.al
@@ -1,0 +1,21 @@
+[netdata]
+name=Netdata
+baseurl=https://repo.netdata.cloud/repos/stable/amazonlinux/$releasever/$basearch
+repo_gpgcheck=1
+gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
+enabled=1
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+priority=50
+
+[netdata-repoconfig]
+name=Netdata Repository Config
+baseurl=https://repo.netdata.cloud/repos/repoconfig/amazonlinux/$releasever/$basearch
+repo_gpgcheck=1
+gpgcheck=1
+gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
+enabled=1
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+priority=50


### PR DESCRIPTION
##### Summary

This initial PR adds it in the Intermediate support tier due to the limited testing so far. The plan is to migrate it to Core tier once we have solid evidence that it works reliably, likely some time after the release of v1.39.0.

##### Test Plan

New CI passes on this PR.

Any further testing requires this to be merged and wait for nightlies to be published.

##### Additional Information

Resolves: https://github.com/netdata/netdata/issues/14199

This also includes a number of other minor bug fixes, mostly related to the installer and updater code.