### PR TITLE
Misc SSL improvements 3

### DIFF
--- a/web/server/static/static-threaded.c
+++ b/web/server/static/static-threaded.c
@@ -351,9 +351,8 @@ static int web_server_rcv_callback(POLLINFO *pi, short int *events) {
         ret = -1;
         goto cleanup;
     } else if (unlikely(bytes == 0)) {
-        if(unlikely(w->ifd == fd && web_client_has_ssl_wait_receive(w))) {
+        if(unlikely(w->ifd == fd && web_client_has_ssl_wait_receive(w)))
             *events |= POLLIN;
-        }
 
         if(unlikely(w->ofd == fd && web_client_has_ssl_wait_send(w)))
             *events |= POLLOUT;

--- a/web/server/static/static-threaded.c
+++ b/web/server/static/static-threaded.c
@@ -293,9 +293,6 @@ static int web_server_rcv_callback(POLLINFO *pi, short int *events) {
     struct web_client *w = (struct web_client *)pi->data;
     int fd = pi->fd;
 
-    web_client_disable_wait_receive(w);
-    web_client_disable_wait_send(w);
-
     ssize_t bytes;
     bytes = web_client_receive(w);
 
@@ -354,10 +351,11 @@ static int web_server_rcv_callback(POLLINFO *pi, short int *events) {
         ret = -1;
         goto cleanup;
     } else if (unlikely(bytes == 0)) {
-        if(unlikely(w->ifd == fd && web_client_has_wait_receive(w)))
+        if(unlikely(w->ifd == fd && web_client_has_ssl_wait_receive(w))) {
             *events |= POLLIN;
+        }
 
-        if(unlikely(w->ofd == fd && web_client_has_wait_send(w)))
+        if(unlikely(w->ofd == fd && web_client_has_ssl_wait_send(w)))
             *events |= POLLOUT;
     }
 

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1528,7 +1528,8 @@ void web_client_process_request(struct web_client *w) {
                 // wait for more data
                 // set to normal to prevent web_server_rcv_callback
                 // from going into stream mode
-                w->mode = WEB_CLIENT_MODE_NORMAL;
+                if (w->mode == WEB_CLIENT_MODE_STREAM)
+                    w->mode = WEB_CLIENT_MODE_NORMAL;
                 return;
             }
             break;

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -41,12 +41,12 @@ static inline int web_client_crock_socket(struct web_client *w) {
 static inline void web_client_enable_wait_from_ssl(struct web_client *w, int bytes) {
     int ssl_err = SSL_get_error(w->ssl.conn, bytes);
     if (ssl_err == SSL_ERROR_WANT_READ)
-        web_client_enable_wait_receive(w);
+        web_client_enable_ssl_wait_receive(w);
     else if (ssl_err == SSL_ERROR_WANT_WRITE)
-        web_client_enable_wait_send(w);
-    else if (ssl_err) {
-        web_client_disable_wait_receive(w);
-        web_client_disable_wait_send(w);
+        web_client_enable_ssl_wait_send(w);
+    else {
+        web_client_disable_ssl_wait_receive(w);
+        web_client_disable_ssl_wait_send(w);
     }
 }
 
@@ -955,7 +955,6 @@ static inline HTTP_VALIDATION http_request_validate(struct web_client *w) {
                 return HTTP_VALIDATION_NOT_SUPPORTED;
             }
         }
-
         web_client_enable_wait_receive(w);
         return HTTP_VALIDATION_INCOMPLETE;
     }

--- a/web/server/web_client.h
+++ b/web/server/web_client.h
@@ -71,6 +71,9 @@ typedef enum web_client_flags {
     WEB_CLIENT_FLAG_DONT_CLOSE_SOCKET = 1 << 9, // don't close the socket when cleaning up (static-threaded web server)
 
     WEB_CLIENT_CHUNKED_TRANSFER = 1 << 10, // chunked transfer (used with zlib compression)
+
+    WEB_CLIENT_FLAG_SSL_WAIT_RECEIVE = 1 << 11, // if set, we are waiting more input data from an ssl conn
+    WEB_CLIENT_FLAG_SSL_WAIT_SEND = 1 << 12,    // if set, we have data to send to the client from an ssl conn
 } WEB_CLIENT_FLAGS;
 
 #define web_client_flag_check(w, flag) ((w)->flags & (flag))
@@ -99,6 +102,14 @@ typedef enum web_client_flags {
 #define web_client_has_wait_send(w) web_client_flag_check(w, WEB_CLIENT_FLAG_WAIT_SEND)
 #define web_client_enable_wait_send(w) web_client_flag_set(w, WEB_CLIENT_FLAG_WAIT_SEND)
 #define web_client_disable_wait_send(w) web_client_flag_clear(w, WEB_CLIENT_FLAG_WAIT_SEND)
+
+#define web_client_has_ssl_wait_receive(w) web_client_flag_check(w, WEB_CLIENT_FLAG_SSL_WAIT_RECEIVE)
+#define web_client_enable_ssl_wait_receive(w) web_client_flag_set(w, WEB_CLIENT_FLAG_SSL_WAIT_RECEIVE)
+#define web_client_disable_ssl_wait_receive(w) web_client_flag_clear(w, WEB_CLIENT_FLAG_SSL_WAIT_RECEIVE)
+
+#define web_client_has_ssl_wait_send(w) web_client_flag_check(w, WEB_CLIENT_FLAG_SSL_WAIT_SEND)
+#define web_client_enable_ssl_wait_send(w) web_client_flag_set(w, WEB_CLIENT_FLAG_SSL_WAIT_SEND)
+#define web_client_disable_ssl_wait_send(w) web_client_flag_clear(w, WEB_CLIENT_FLAG_SSL_WAIT_SEND)
 
 #define web_client_set_tcp(w) web_client_flag_set(w, WEB_CLIENT_FLAG_TCP_CLIENT)
 #define web_client_set_unix(w) web_client_flag_set(w, WEB_CLIENT_FLAG_UNIX_CLIENT)


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR is based on the previous one, but takes a more conservative approach, to solve an issue where a very very long api call on a slow connection won't get through (@dimko :bow: ).

It uses 2 new flags specific to SSL, to indicate to wait for receive or send instead of using the existing ones.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Tested (on a remote machine over VPN):

* A very long api call (~12kb) that during read will be split in more than 2 reads, both over SSL and normal connection.
* Attempts to STREAM with an initial message that is broken over 2 reads, over SSL and normal connections.
* General dashboard usability.

Made sure no high cpu usage appeared on the parent during these tests.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
