### PR TITLE
Temporarily remove platform EOL check for Debian 12

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -92,7 +92,7 @@ include:
     distro: debian
     version: "12"
     base_image: debian:bookworm
-    eol_check: true
+    eol_check: false
     env_prep: |
       apt-get update
     jsonc_removal: |


### PR DESCRIPTION
##### Summary

Approximately we know the EOL of Debian 12 (not officially announced yet) but the repo we have utilized  https://endoflife.date/ doesn't contain it, we temporarily disable this check.
