### PR TITLE
fix python version check to work for 3.10 and above

### DIFF
--- a/collectors/python.d.plugin/anomalies/anomalies.chart.py
+++ b/collectors/python.d.plugin/anomalies/anomalies.chart.py
@@ -58,8 +58,7 @@ class Service(SimpleService):
         self.collected_dims = {'probability': set(), 'anomaly': set()}
 
     def check(self):
-        python_version = float('{}.{}'.format(sys.version_info[0], sys.version_info[1]))
-        if python_version < 3.6:
+        if not (sys.version_info[0] >= 3 and sys.version_info[1] >= 6):
             self.error("anomalies collector only works with Python>=3.6")
         if len(self.host_charts_dict[self.host]) > 0:
             _ = get_allmetrics_async(host_charts_dict=self.host_charts_dict, protocol=self.protocol, user=self.username, pwd=self.password)


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes: #14561

Where the python version check was incorrectly rejecting python 3.10 and higher due to how the float() was casting "10" to "1".

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

New logic tested as per below: 

```python
for sys_version_info in [(2,7),(3,4),(3,5),(3,6),(3,7),(3,10),(3,11),(3,12)]:
    if not (sys_version_info[0] >= 3 and sys_version_info[1] >= 6):
        print(f'{sys_version_info} = unsupported')
    else:
        print(f'{sys_version_info} = supported')
"""
(2, 7) = unsupported
(3, 4) = unsupported
(3, 5) = unsupported
(3, 6) = supported
(3, 7) = supported
(3, 10) = supported
(3, 11) = supported
(3, 12) = supported
"""
```

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
