### PR TITLE
Fix handling of no data in platform EOL checks.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -92,7 +92,7 @@ include:
     distro: debian
     version: "12"
     base_image: debian:bookworm
-    eol_check: false
+    eol_check: true
     env_prep: |
       apt-get update
     jsonc_removal: |

--- a/.github/scripts/platform-impending-eol.py
+++ b/.github/scripts/platform-impending-eol.py
@@ -17,18 +17,25 @@ LEAD_DAYS = datetime.timedelta(days=30)
 DISTRO = sys.argv[1]
 RELEASE = sys.argv[2]
 
+EXIT_NOT_IMPENDING = 0
+EXIT_IMPENDING = 1
+EXIT_NO_DATA = 2
+EXIT_FAILURE = 3
 
 with urllib.request.urlopen(f'{ URL_BASE }/{ DISTRO }/{ RELEASE }.json') as response:
     match response.status:
         case 200:
             data = json.load(response)
         case 404:
-            sys.exit(f'No data available for { DISTRO } { RELEASE }.')
+            print(f'No data available for { DISTRO } { RELEASE }.', file=sys.stderr)
+            sys.exit(EXIT_NO_DATA)
         case _:
-            sys.exit(
+            print(
                 f'Failed to retrieve data for { DISTRO } { RELEASE } ' +
-                f'(status: { response.status }).'
+                f'(status: { response.status }).',
+                file=sys.stderr
             )
+            sys.exit(EXIT_FAILURE)
 
 eol = datetime.date.fromisoformat(data['eol'])
 
@@ -36,6 +43,6 @@ offset = abs(eol - NOW)
 
 if offset <= LEAD_DAYS:
     print(data['eol'])
-    sys.exit(2)
+    sys.exit(EXIT_IMPENDING)
 else:
-    sys.exit(0)
+    sys.exit(EXIT_NOT_IMPENDING)

--- a/.github/workflows/platform-eol-check.yml
+++ b/.github/workflows/platform-eol-check.yml
@@ -54,9 +54,13 @@ jobs:
           d="$(.github/scripts/platform-impending-eol.py ${{ matrix.distro }} ${{ matrix.release }})"
           case $? in
             0) echo "pending=false" >> "${GITHUB_OUTPUT}" ;;
-            2)
+            1)
               echo "pending=true" >> "${GITHUB_OUTPUT}"
               echo "date=${d}" >> "${GITHUB_OUTPUT}"
+              ;;
+            2)
+              echo "pending=false" >> "${GITHUB_OUTPUT}"
+              echo "::info::No EOL information found for ${{ matrix.distro }} ${{ matrix.release }}"
               ;;
             *)
               echo "::error::Failed to check EOL date for ${{ matrix.distro }} ${{ matrix.release }}"


### PR DESCRIPTION
##### Summary

Instead of failing the check job if https://endoflife.date has no data, act as if the platform is not EOL, but log a warning about the situation.

Also, re-enable EOL checking for Debian that was unintentionally blanket-disabled by #14603 

##### Test Plan

n/a