### PR TITLE
Assorted improvements to OpenRC support.

### DIFF
--- a/system/Makefile.am
+++ b/system/Makefile.am
@@ -9,6 +9,7 @@ CLEANFILES = \
     launchd/netdata.plist \
     logrotate/netdata \
     lsb/init.d/netdata \
+    openrc/conf.d/netdata \
     openrc/init.d/netdata \
     systemd/netdata.service \
     systemd/netdata.service.v235 \
@@ -37,6 +38,7 @@ libsyslsbdir=$(libsysdir)/lsb
 libsyslsbinitddir=$(libsyslsbdir)/init.d
 libsysopenrcdir=$(libsysdir)/openrc
 libsysopenrcinitddir=$(libsysopenrcdir)/init.d
+libsysopenrcconfddir=$(libsysopenrcdir)/conf.d
 libsyssystemddir=$(libsysdir)/systemd
 
 # Explicitly install directories to avoid permission issues due to umask
@@ -51,6 +53,7 @@ install-exec-local:
 	$(INSTALL) -d $(DESTDIR)$(libsyslsbinitddir)
 	$(INSTALL) -d $(DESTDIR)$(libsyssystemddir)
 	$(INSTALL) -d $(DESTDIR)$(libsysopenrcinitddir)
+	$(INSTALL) -d $(DESTDIR)$(libsysopenrcconfddir)
 
 libexecnetdatadir=$(libexecdir)/netdata
 nodist_libexecnetdata_SCRIPTS = \
@@ -85,6 +88,10 @@ nodist_libsysopenrcinitd_DATA = \
     openrc/init.d/netdata \
     $(NULL)
 
+nodist_libsysopenrcconfd_DATA = \
+    openrc/conf.d/netdata \
+    $(NULL)
+
 nodist_libsyssystemd_DATA = \
     systemd/netdata.service \
     systemd/netdata.service.v235 \
@@ -104,6 +111,7 @@ dist_noinst_DATA = \
     launchd/netdata.plist.in \
     logrotate/netdata.in \
     lsb/init.d/netdata.in \
+    openrc/conf.d/netdata.in \
     openrc/init.d/netdata.in \
     systemd/netdata.service.in \
     systemd/netdata.service.v235.in \

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -290,6 +290,9 @@ _check_openrc() {
   # if there is no /etc/init.d, it's not OpenRC
   [ ! -d /etc/init.d ] && echo "NO" && return 0
 
+  # if there is no /etc/conf.d, it's not OpenRC
+  [ ! -d /etc/conf.d ] && echo "NO" && return 0
+
   # if there is no rc-update command, it's not OpenRC
   [ -z "$(command -v rc-update 2>/dev/null || true)" ] && echo "NO" && return 0
 
@@ -342,6 +345,12 @@ disable_openrc() {
 
 install_openrc_service() {
   install_generic_service openrc/init.d OpenRC /etc/init.d/netdata enable_openrc disable_openrc
+
+  info "Installing OpenRC configuration file."
+
+  if ! install -p -m 0755 -o 0 -g 0 "${SVC_SOURCE}/openrc/conf.d/netdata" "/etc/conf.d/netdata"; then
+    warning "Failed to install configuration file, however the service will still work."
+  fi
 }
 
 openrc_cmds() {

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -346,10 +346,12 @@ disable_openrc() {
 install_openrc_service() {
   install_generic_service openrc/init.d OpenRC /etc/init.d/netdata enable_openrc disable_openrc
 
-  info "Installing OpenRC configuration file."
+  if [ ! -f /etc/conf.d/netdata ]; then
+    info "Installing OpenRC configuration file."
 
-  if ! install -p -m 0755 -o 0 -g 0 "${SVC_SOURCE}/openrc/conf.d/netdata" "/etc/conf.d/netdata"; then
-    warning "Failed to install configuration file, however the service will still work."
+    if ! install -p -m 0755 -o 0 -g 0 "${SVC_SOURCE}/openrc/conf.d/netdata" "/etc/conf.d/netdata"; then
+        warning "Failed to install configuration file, however the service will still work."
+    fi
   fi
 }
 

--- a/system/openrc/conf.d/netdata.in
+++ b/system/openrc/conf.d/netdata.in
@@ -1,0 +1,24 @@
+# The user netdata is configured to run as.
+# If you edit its configuration file to set a different user, set it
+# here too, to have its files switch ownership
+NETDATA_OWNER="@netdata_user_POST@:@netdata_user_POST@"
+
+# How long to wait for the agent to save it's database during shutdown.
+NETDATA_WAIT_EXIT_TIMEOUT=60
+
+# If set to 1, force an exit if we time out waiting for the agent to
+# save it's database during shutdown.
+NETDATA_FORCE_EXIT=0
+
+# If set to 1, use netdatacli when sending commands to the agent.
+# This should not be needed in most cases, but it can sometimes help
+# work around issues.
+#NETDATA_USE_NETDATACLI=1
+
+# Specify the path to the pidfile to be used when running in the
+# background.
+NETDATA_PIDFILE="@localstatedir_POST@/run/netdata/netdata.pid"
+
+# Uncomment the below line to run Netdata under OpenRC's native process
+# supervision.
+#supervisor="supervise-daemon"

--- a/system/openrc/init.d/netdata.in
+++ b/system/openrc/init.d/netdata.in
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 NETDATA_OWNER="@netdata_user_POST@:@netdata_user_POST@"
-NETDATA_WAIT_EXIT_TIMEOUT=60
 NETDATA_PIDFILE="@localstatedir_POST@/run/netdata/netdata.pid"
 
 extra_started_commands="reload rotate save"
@@ -11,11 +10,6 @@ command="${command_prefix}/netdata"
 command_args="-P ${NETDATA_PIDFILE} ${NETDATA_EXTRA_ARGS}"
 command_args_foreground="-D"
 start_stop_daemon_args="-u ${NETDATA_OWNER}"
-if [ "${NETDATA_FORCE_EXIT}" -eq 1 ]; then
-    retry="TERM/${NETDATA_WAIT_EXIT_TIMEOUT}/KILL/1"
-else
-    retry="TERM/${NETDATA_WAIT_EXIT_TIMEOUT}"
-fi
 
 depend() {
     use logger
@@ -28,6 +22,14 @@ start_pre() {
 
     if [ -z "${supervisor}" ]; then
         pidfile="${NETDATA_PIDFILE}"
+    fi
+}
+
+stop_pre() {
+    if [ "0${NETDATA_FORCE_EXIT}" -eq 1 ]; then
+        retry="TERM/${NETDATA_WAIT_EXIT_TIMEOUT:-60}/KILL/1"
+    else
+        retry="TERM/${NETDATA_WAIT_EXIT_TIMEOUT:-60}"
     fi
 }
 

--- a/system/openrc/init.d/netdata.in
+++ b/system/openrc/init.d/netdata.in
@@ -4,7 +4,13 @@
 NETDATA_OWNER="@netdata_user_POST@:@netdata_user_POST@"
 NETDATA_PIDFILE="@localstatedir_POST@/run/netdata/netdata.pid"
 
+description="Run the Netdata system monitoring agent."
+
 extra_started_commands="reload rotate save"
+description_reload="Reload health configuration."
+description_rotate="Reopen log files."
+description_save="Force sync of database to disk."
+
 command_prefix="@sbindir_POST@"
 command="${command_prefix}/netdata"
 command_args="-P ${NETDATA_PIDFILE} ${NETDATA_EXTRA_ARGS}"

--- a/system/openrc/init.d/netdata.in
+++ b/system/openrc/init.d/netdata.in
@@ -1,25 +1,9 @@
 #!/sbin/openrc-run
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# The user netdata is configured to run as.
-# If you edit its configuration file to set a different
-# user, set it here too, to have its files switch ownership
-: "${NETDATA_OWNER:=@netdata_user_POST@:@netdata_user_POST@}"
-
-# The timeout in seconds to wait for netdata
-# to save its database on disk and exit.
-: "${NETDATA_WAIT_EXIT_TIMEOUT:=60}"
-
-# When set to 1, if netdata does not exit in
-# NETDATA_WAIT_EXIT_TIMEOUT, we will force it
-# to exit.
-: "${NETDATA_FORCE_EXIT:=0}"
-
-# When set to 1, we use netdatacli for reload/rotate/save commands instead of s-s-d.
-: "${NETDATA_USE_NETDATACLI:=0}"
-
-# Specifies the pidfile to use when running in the background.
-: "${NETDATA_PIDFILE:=@localstatedir_POST@/run/netdata/netdata.pid}"
+NETDATA_OWNER="@netdata_user_POST@:@netdata_user_POST@"
+NETDATA_WAIT_EXIT_TIMEOUT=60
+NETDATA_PIDFILE="@localstatedir_POST@/run/netdata/netdata.pid"
 
 extra_started_commands="reload rotate save"
 command_prefix="@sbindir_POST@"


### PR DESCRIPTION
##### Summary

- Add `/etc/conf.d/netdata`. Files under `/etc/conf.d` are the standard mechanism for service configuration with OpenRC, and get sourced as part of running the service script. By providing this file, we can document various options in a place that the user will actually find them instead of relying on the user to find them themselves.
- Fix handling of the shutdown retry schedule. It needs to be handled after the `conf.d` file gets loaded (thus should be in a `stop_pre` hook), and it should properly handle variables not being defined.
- Add a proper description for the service and for the non-standard service commands we provide.

##### Test Plan

Testing can be done on Alpine, Gentoo, or some other system that uses OpenRC as it’s init system. 

The new conf.d file can be checked by looking for the new `/etc/conf.d/netdata` file that installing should add.

The retry schedule handling cannot be readily tested, as it requires the agent to behave in certain ways that cannot be synthetically induced with any degree of reliability.

##### Additional Information

