### PR TITLE
eBPF new charts (user ring)

### DIFF
--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -964,7 +964,7 @@ void ebpf_statistic_create_aral_chart(char *name, ebpf_module_t *em)
                          "bytes",
                          NETDATA_EBPF_FAMILY,
                          NETDATA_EBPF_CHART_TYPE_STACKED,
-                         NULL,
+                         "netdata.ebpf_aral_stat_size",
                          priority++,
                          em->update_every,
                          NETDATA_EBPF_MODULE_NAME_PROCESS);
@@ -979,7 +979,7 @@ void ebpf_statistic_create_aral_chart(char *name, ebpf_module_t *em)
                          "calls",
                          NETDATA_EBPF_FAMILY,
                          NETDATA_EBPF_CHART_TYPE_STACKED,
-                         NULL,
+                         "netdata.ebpf_aral_stat_alloc",
                          priority++,
                          em->update_every,
                          NETDATA_EBPF_MODULE_NAME_PROCESS);

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -446,7 +446,8 @@ ebpf_network_viewer_options_t network_viewer_opt;
 
 // Statistic
 ebpf_plugin_stats_t plugin_statistics = {.core = 0, .legacy = 0, .running = 0, .threads = 0, .tracepoints = 0,
-                                         .probes = 0, .retprobes = 0, .trampolines = 0};
+                                         .probes = 0, .retprobes = 0, .trampolines = 0, .memlock_kern = 0,
+                                         .hash_tables = 0};
 
 #ifdef LIBBPF_MAJOR_VERSION
 struct btf *default_btf = NULL;

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -143,6 +143,7 @@ enum ebpf_threads_status {
 // Statistics charts
 #define NETDATA_EBPF_THREADS "ebpf_threads"
 #define NETDATA_EBPF_LOAD_METHOD "ebpf_load_methods"
+#define NETDATA_EBPF_KERNEL_MEMORY "ebpf_kernel_memory"
 
 // Log file
 #define NETDATA_DEVELOPER_LOG_FILE "developer.log"

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -144,6 +144,7 @@ enum ebpf_threads_status {
 #define NETDATA_EBPF_THREADS "ebpf_threads"
 #define NETDATA_EBPF_LOAD_METHOD "ebpf_load_methods"
 #define NETDATA_EBPF_KERNEL_MEMORY "ebpf_kernel_memory"
+#define NETDATA_EBPF_HASH_TABLES_LOADED "ebpf_hash_tables_count"
 
 // Log file
 #define NETDATA_DEVELOPER_LOG_FILE "developer.log"

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -6,8 +6,8 @@
 
 // ----------------------------------------------------------------------------
 // ARAL vectors used to speed up processing
-ARAL *ebpf_aral_apps_pid_stat;
-ARAL *ebpf_aral_process_stat;
+ARAL *ebpf_aral_apps_pid_stat = NULL;
+ARAL *ebpf_aral_process_stat = NULL;
 
 /**
  * eBPF ARAL Init
@@ -22,9 +22,9 @@ void ebpf_aral_init(void)
         max_elements = NETDATA_EBPF_ALLOC_MIN_ELEMENTS;
     }
 
-    ebpf_aral_apps_pid_stat = ebpf_allocate_pid_aral("ebpf-pid_stat", sizeof(struct ebpf_pid_stat));
+    ebpf_aral_apps_pid_stat = ebpf_allocate_pid_aral("ebpf_pid_stat", sizeof(struct ebpf_pid_stat));
 
-    ebpf_aral_process_stat = ebpf_allocate_pid_aral("ebpf-proc_stat", sizeof(ebpf_process_stat_t));
+    ebpf_aral_process_stat = ebpf_allocate_pid_aral(NETDATA_EBPF_PROC_ARAL_NAME, sizeof(ebpf_process_stat_t));
 
 #ifdef NETDATA_DEV_MODE
     info("Plugin is using ARAL with values %d", NETDATA_EBPF_ALLOC_MAX_PID);

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -228,11 +228,14 @@ extern netdata_publish_dcstat_t **dcstat_pid;
 
 extern void ebpf_aral_init(void);
 
-extern struct ebpf_pid_stat *ebpf_target_get(void);
-
 extern ebpf_process_stat_t *ebpf_process_stat_get(void);
 extern void ebpf_process_stat_release(ebpf_process_stat_t *stat);
 
 #include "libnetdata/threads/threads.h"
+
+// ARAL variables
+extern ARAL *ebpf_aral_apps_pid_stat;
+extern ARAL *ebpf_aral_process_stat;
+#define NETDATA_EBPF_PROC_ARAL_NAME "ebpf_proc_stat"
 
 #endif /* NETDATA_EBPF_APPS_H */

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -1136,8 +1136,10 @@ static void cachestat_collector(ebpf_module_t *em)
         if (apps & NETDATA_EBPF_APPS_FLAG_CHART_CREATED)
             ebpf_cache_send_apps_data(apps_groups_root_target);
 
+#ifdef NETDATA_DEV_MODE
         if (ebpf_aral_cachestat_pid)
             ebpf_send_data_aral_chart(ebpf_aral_cachestat_pid, em);
+#endif
 
         if (cgroups)
             ebpf_cachestat_send_cgroup_data(update_every);
@@ -1339,8 +1341,10 @@ void *ebpf_cachestat_thread(void *ptr)
     ebpf_update_stats(&plugin_statistics, em);
     ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
     ebpf_create_memory_charts(em);
+#ifdef NETDATA_DEV_MODE
     if (ebpf_aral_cachestat_pid)
         ebpf_statistic_create_aral_chart(NETDATA_EBPF_CACHESTAT_ARAL_NAME, em);
+#endif
 
     pthread_mutex_unlock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -1334,7 +1334,7 @@ void *ebpf_cachestat_thread(void *ptr)
 
     pthread_mutex_lock(&lock);
     ebpf_update_stats(&plugin_statistics, em);
-    ebpf_update_kernel_memory(&plugin_statistics, cachestat_maps);
+    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
     ebpf_create_memory_charts(em);
     pthread_mutex_unlock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -381,7 +381,7 @@ static void ebpf_cachestat_exit(void *ptr)
  */
 static inline void ebpf_cachestat_aral_init()
 {
-    ebpf_aral_cachestat_pid = ebpf_allocate_pid_aral("ebpf-cachestat", sizeof(netdata_publish_cachestat_t));
+    ebpf_aral_cachestat_pid = ebpf_allocate_pid_aral(NETDATA_EBPF_CACHESTAT_ARAL_NAME, sizeof(netdata_publish_cachestat_t));
 }
 
 /**
@@ -1133,8 +1133,10 @@ static void cachestat_collector(ebpf_module_t *em)
 
         cachestat_send_global(&publish);
 
-        if (apps & NETDATA_EBPF_APPS_FLAG_CHART_CREATED)
+        if (apps & NETDATA_EBPF_APPS_FLAG_CHART_CREATED) {
             ebpf_cache_send_apps_data(apps_groups_root_target);
+            ebpf_send_data_aral_chart(ebpf_aral_cachestat_pid, em);
+        }
 
         if (cgroups)
             ebpf_cachestat_send_cgroup_data(update_every);
@@ -1336,6 +1338,7 @@ void *ebpf_cachestat_thread(void *ptr)
     ebpf_update_stats(&plugin_statistics, em);
     ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
     ebpf_create_memory_charts(em);
+    ebpf_statistic_create_aral_chart(NETDATA_EBPF_CACHESTAT_ARAL_NAME, em);
     pthread_mutex_unlock(&lock);
 
     cachestat_collector(em);

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -1334,6 +1334,7 @@ void *ebpf_cachestat_thread(void *ptr)
 
     pthread_mutex_lock(&lock);
     ebpf_update_stats(&plugin_statistics, em);
+    ebpf_update_kernel_memory(&plugin_statistics, cachestat_maps);
     ebpf_create_memory_charts(em);
     pthread_mutex_unlock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -1334,7 +1334,7 @@ void *ebpf_cachestat_thread(void *ptr)
 
     pthread_mutex_lock(&lock);
     ebpf_update_stats(&plugin_statistics, em);
-    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
+    ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
     ebpf_create_memory_charts(em);
     pthread_mutex_unlock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_cachestat.h
+++ b/collectors/ebpf.plugin/ebpf_cachestat.h
@@ -33,6 +33,9 @@
 #define NETDATA_SYSTEMD_CACHESTAT_HIT_FILE_CONTEXT "services.cachestat_hits"
 #define NETDATA_SYSTEMD_CACHESTAT_MISS_FILES_CONTEXT "services.cachestat_misses"
 
+// ARAL Name
+#define NETDATA_EBPF_CACHESTAT_ARAL_NAME "ebpf_cachestat"
+
 // variables
 enum cachestat_counters {
     NETDATA_KEY_CALLS_ADD_TO_PAGE_CACHE_LRU,

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -1201,6 +1201,7 @@ void *ebpf_dcstat_thread(void *ptr)
     pthread_mutex_lock(&lock);
     ebpf_create_filesystem_charts(em->update_every);
     ebpf_update_stats(&plugin_statistics, em);
+    ebpf_update_kernel_memory(&plugin_statistics, dcstat_maps);
     pthread_mutex_unlock(&lock);
 
     dcstat_collector(em);

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -344,7 +344,7 @@ static void ebpf_dcstat_exit(void *ptr)
  */
 static inline void ebpf_dcstat_aral_init()
 {
-    ebpf_aral_dcstat_pid = ebpf_allocate_pid_aral("ebpf-dcstat", sizeof(netdata_publish_dcstat_t));
+    ebpf_aral_dcstat_pid = ebpf_allocate_pid_aral(NETDATA_EBPF_DCSTAT_ARAL_NAME, sizeof(netdata_publish_dcstat_t));
 }
 
 /**
@@ -1053,6 +1053,9 @@ static void dcstat_collector(ebpf_module_t *em)
         if (apps & NETDATA_EBPF_APPS_FLAG_CHART_CREATED)
             ebpf_dcache_send_apps_data(apps_groups_root_target);
 
+        if (ebpf_aral_dcstat_pid)
+            ebpf_send_data_aral_chart(ebpf_aral_dcstat_pid, em);
+
         if (cgroups)
             ebpf_dc_send_cgroup_data(update_every);
 
@@ -1202,6 +1205,9 @@ void *ebpf_dcstat_thread(void *ptr)
     ebpf_create_filesystem_charts(em->update_every);
     ebpf_update_stats(&plugin_statistics, em);
     ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
+    if (ebpf_aral_dcstat_pid)
+        ebpf_statistic_create_aral_chart(NETDATA_EBPF_DCSTAT_ARAL_NAME, em);
+
     pthread_mutex_unlock(&lock);
 
     dcstat_collector(em);

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -1201,7 +1201,7 @@ void *ebpf_dcstat_thread(void *ptr)
     pthread_mutex_lock(&lock);
     ebpf_create_filesystem_charts(em->update_every);
     ebpf_update_stats(&plugin_statistics, em);
-    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
+    ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     dcstat_collector(em);

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -1201,7 +1201,7 @@ void *ebpf_dcstat_thread(void *ptr)
     pthread_mutex_lock(&lock);
     ebpf_create_filesystem_charts(em->update_every);
     ebpf_update_stats(&plugin_statistics, em);
-    ebpf_update_kernel_memory(&plugin_statistics, dcstat_maps);
+    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     dcstat_collector(em);

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -1053,8 +1053,10 @@ static void dcstat_collector(ebpf_module_t *em)
         if (apps & NETDATA_EBPF_APPS_FLAG_CHART_CREATED)
             ebpf_dcache_send_apps_data(apps_groups_root_target);
 
+#ifdef NETDATA_DEV_MODE
         if (ebpf_aral_dcstat_pid)
             ebpf_send_data_aral_chart(ebpf_aral_dcstat_pid, em);
+#endif
 
         if (cgroups)
             ebpf_dc_send_cgroup_data(update_every);
@@ -1205,8 +1207,10 @@ void *ebpf_dcstat_thread(void *ptr)
     ebpf_create_filesystem_charts(em->update_every);
     ebpf_update_stats(&plugin_statistics, em);
     ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
+#ifdef NETDATA_DEV_MODE
     if (ebpf_aral_dcstat_pid)
         ebpf_statistic_create_aral_chart(NETDATA_EBPF_DCSTAT_ARAL_NAME, em);
+#endif
 
     pthread_mutex_unlock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -5,7 +5,7 @@
 
 // ----------------------------------------------------------------------------
 // ARAL vectors used to speed up processing
-ARAL *ebpf_aral_dcstat_pid;
+ARAL *ebpf_aral_dcstat_pid = NULL;
 
 static char *dcstat_counter_dimension_name[NETDATA_DCSTAT_IDX_END] = { "ratio", "reference", "slow", "miss" };
 static netdata_syscall_stat_t dcstat_counter_aggregated_data[NETDATA_DCSTAT_IDX_END];

--- a/collectors/ebpf.plugin/ebpf_dcstat.h
+++ b/collectors/ebpf.plugin/ebpf_dcstat.h
@@ -28,6 +28,9 @@
 #define NETDATA_SYSTEMD_DC_NOT_CACHE_CONTEXT "services.dc_not_cache"
 #define NETDATA_SYSTEMD_DC_NOT_FOUND_CONTEXT "services.dc_not_found"
 
+// ARAL name
+#define NETDATA_EBPF_DCSTAT_ARAL_NAME "ebpf_dcstat"
+
 enum directory_cache_indexes {
     NETDATA_DCSTAT_IDX_RATIO,
     NETDATA_DCSTAT_IDX_REFERENCE,

--- a/collectors/ebpf.plugin/ebpf_disk.c
+++ b/collectors/ebpf.plugin/ebpf_disk.c
@@ -792,6 +792,7 @@ void *ebpf_disk_thread(void *ptr)
 
     pthread_mutex_lock(&lock);
     ebpf_update_stats(&plugin_statistics, em);
+    ebpf_update_kernel_memory(&plugin_statistics, disk_maps);
     pthread_mutex_unlock(&lock);
 
     disk_collector(em);

--- a/collectors/ebpf.plugin/ebpf_disk.c
+++ b/collectors/ebpf.plugin/ebpf_disk.c
@@ -792,7 +792,7 @@ void *ebpf_disk_thread(void *ptr)
 
     pthread_mutex_lock(&lock);
     ebpf_update_stats(&plugin_statistics, em);
-    ebpf_update_kernel_memory(&plugin_statistics, disk_maps);
+    ebpf_update_kernel_memory_with_vector(&plugin_statistics, disk_maps);
     pthread_mutex_unlock(&lock);
 
     disk_collector(em);

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -1193,7 +1193,7 @@ void *ebpf_fd_thread(void *ptr)
     pthread_mutex_lock(&lock);
     ebpf_create_fd_global_charts(em);
     ebpf_update_stats(&plugin_statistics, em);
-    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
+    ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     fd_collector(em);

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -983,8 +983,10 @@ static void fd_collector(ebpf_module_t *em)
         if (apps)
             read_apps_table();
 
+#ifdef NETDATA_DEV_MODE
         if (ebpf_aral_fd_pid)
             ebpf_send_data_aral_chart(ebpf_aral_fd_pid, em);
+#endif
 
         if (cgroups)
             ebpf_update_fd_cgroup();
@@ -1197,8 +1199,10 @@ void *ebpf_fd_thread(void *ptr)
     ebpf_create_fd_global_charts(em);
     ebpf_update_stats(&plugin_statistics, em);
     ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
+#ifdef NETDATA_DEV_MODE
     if (ebpf_aral_fd_pid)
         ebpf_statistic_create_aral_chart(NETDATA_EBPF_FD_ARAL_NAME, em);
+#endif
 
     pthread_mutex_unlock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -1193,6 +1193,7 @@ void *ebpf_fd_thread(void *ptr)
     pthread_mutex_lock(&lock);
     ebpf_create_fd_global_charts(em);
     ebpf_update_stats(&plugin_statistics, em);
+    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     fd_collector(em);

--- a/collectors/ebpf.plugin/ebpf_fd.h
+++ b/collectors/ebpf.plugin/ebpf_fd.h
@@ -33,6 +33,9 @@
 #define NETDATA_SYSTEMD_FD_CLOSE_CONTEXT "services.fd_close"
 #define NETDATA_SYSTEMD_FD_CLOSE_ERR_CONTEXT "services.fd_close_error"
 
+// ARAL name
+#define NETDATA_EBPF_FD_ARAL_NAME "ebpf_fd"
+
 typedef struct netdata_fd_stat {
     uint32_t open_call;                    // Open syscalls (open and openat)
     uint32_t close_call;                   // Close syscall (close)

--- a/collectors/ebpf.plugin/ebpf_filesystem.c
+++ b/collectors/ebpf.plugin/ebpf_filesystem.c
@@ -182,6 +182,9 @@ int ebpf_filesystem_initialize_ebpf_data(ebpf_module_t *em)
                 return -1;
             }
             efp->flags |= NETDATA_FILESYSTEM_FLAG_HAS_PARTITION;
+            pthread_mutex_lock(&lock);
+            ebpf_update_kernel_memory(&plugin_statistics, &fs_maps[i], EBPF_ACTION_STAT_ADD);
+            pthread_mutex_unlock(&lock);
 
             // Nedeed for filesystems like btrfs
             if ((efp->flags & NETDATA_FILESYSTEM_FILL_ADDRESS_TABLE) && (efp->addresses.function)) {

--- a/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -391,6 +391,7 @@ static void hardirq_collector(ebpf_module_t *em)
     hardirq_create_charts(em->update_every);
     hardirq_create_static_dims();
     ebpf_update_stats(&plugin_statistics, em);
+    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     // loop and read from published data until ebpf plugin is closed.

--- a/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -391,7 +391,7 @@ static void hardirq_collector(ebpf_module_t *em)
     hardirq_create_charts(em->update_every);
     hardirq_create_static_dims();
     ebpf_update_stats(&plugin_statistics, em);
-    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
+    ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     // loop and read from published data until ebpf plugin is closed.

--- a/collectors/ebpf.plugin/ebpf_mdflush.c
+++ b/collectors/ebpf.plugin/ebpf_mdflush.c
@@ -208,7 +208,7 @@ static void mdflush_collector(ebpf_module_t *em)
     pthread_mutex_lock(&lock);
     mdflush_create_charts(update_every);
     ebpf_update_stats(&plugin_statistics, em);
-    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
+    ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     // loop and read from published data until ebpf plugin is closed.

--- a/collectors/ebpf.plugin/ebpf_mdflush.c
+++ b/collectors/ebpf.plugin/ebpf_mdflush.c
@@ -208,6 +208,7 @@ static void mdflush_collector(ebpf_module_t *em)
     pthread_mutex_lock(&lock);
     mdflush_create_charts(update_every);
     ebpf_update_stats(&plugin_statistics, em);
+    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     // loop and read from published data until ebpf plugin is closed.

--- a/collectors/ebpf.plugin/ebpf_mount.c
+++ b/collectors/ebpf.plugin/ebpf_mount.c
@@ -442,7 +442,7 @@ void *ebpf_mount_thread(void *ptr)
     pthread_mutex_lock(&lock);
     ebpf_create_mount_charts(em->update_every);
     ebpf_update_stats(&plugin_statistics, em);
-    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
+    ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     mount_collector(em);

--- a/collectors/ebpf.plugin/ebpf_mount.c
+++ b/collectors/ebpf.plugin/ebpf_mount.c
@@ -442,6 +442,7 @@ void *ebpf_mount_thread(void *ptr)
     pthread_mutex_lock(&lock);
     ebpf_create_mount_charts(em->update_every);
     ebpf_update_stats(&plugin_statistics, em);
+    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     mount_collector(em);

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -392,7 +392,7 @@ void *ebpf_oomkill_thread(void *ptr)
 
     pthread_mutex_lock(&lock);
     ebpf_update_stats(&plugin_statistics, em);
-    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
+    ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     oomkill_collector(em);

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -392,6 +392,7 @@ void *ebpf_oomkill_thread(void *ptr)
 
     pthread_mutex_lock(&lock);
     ebpf_update_stats(&plugin_statistics, em);
+    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     oomkill_collector(em);

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -1206,7 +1206,7 @@ void *ebpf_process_thread(void *ptr)
     }
 
     ebpf_update_stats(&plugin_statistics, em);
-    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
+    ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
     ebpf_create_statistic_charts(em);
 
     pthread_mutex_unlock(&lock);

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -1128,8 +1128,10 @@ static void process_collector(ebpf_module_t *em)
                     ebpf_process_send_apps_data(apps_groups_root_target, em);
                 }
 
+#ifdef NETDATA_DEV_MODE
                 if (ebpf_aral_process_stat)
                     ebpf_send_data_aral_chart(ebpf_aral_process_stat, em);
+#endif
 
                 if (cgroups && shm_ebpf_cgroup.header) {
                     ebpf_process_send_cgroup_data(em);
@@ -1275,8 +1277,10 @@ void *ebpf_process_thread(void *ptr)
     ebpf_update_stats(&plugin_statistics, em);
     ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
 
+#ifdef NETDATA_DEV_MODE
     if (ebpf_aral_process_stat)
         ebpf_statistic_create_aral_chart(NETDATA_EBPF_PROC_ARAL_NAME, em);
+#endif
 
     ebpf_create_statistic_charts(em);
 

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -1128,6 +1128,9 @@ static void process_collector(ebpf_module_t *em)
                     ebpf_process_send_apps_data(apps_groups_root_target, em);
                 }
 
+                if (ebpf_aral_process_stat)
+                    ebpf_send_data_aral_chart(ebpf_aral_process_stat, em);
+
                 if (cgroups && shm_ebpf_cgroup.header) {
                     ebpf_process_send_cgroup_data(em);
                 }
@@ -1271,6 +1274,10 @@ void *ebpf_process_thread(void *ptr)
 
     ebpf_update_stats(&plugin_statistics, em);
     ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
+
+    if (ebpf_aral_process_stat)
+        ebpf_statistic_create_aral_chart(NETDATA_EBPF_PROC_ARAL_NAME, em);
+
     ebpf_create_statistic_charts(em);
 
     pthread_mutex_unlock(&lock);

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -1206,6 +1206,7 @@ void *ebpf_process_thread(void *ptr)
     }
 
     ebpf_update_stats(&plugin_statistics, em);
+    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
     ebpf_create_statistic_charts(em);
 
     pthread_mutex_unlock(&lock);

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -458,9 +458,9 @@ static inline void ebpf_create_statistic_load_chart(ebpf_module_t *em)
 }
 
 /**
- * Create chart for Load Thread
+ * Create chart for Kernel Memory
  *
- * Write to standard output current values for load mode.
+ * Write to standard output current values for allocated memory.
  *
  * @param em a pointer to the structure with the default values.
  */

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -917,8 +917,10 @@ static void shm_collector(ebpf_module_t *em)
             ebpf_shm_send_apps_data(apps_groups_root_target);
         }
 
+#ifdef NETDATA_DEV_MODE
         if (ebpf_aral_shm_pid)
             ebpf_send_data_aral_chart(ebpf_aral_shm_pid, em);
+#endif
 
         if (cgroups) {
             ebpf_shm_send_cgroup_data(update_every);
@@ -1114,8 +1116,10 @@ void *ebpf_shm_thread(void *ptr)
     ebpf_create_shm_charts(em->update_every);
     ebpf_update_stats(&plugin_statistics, em);
     ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
+#ifdef NETDATA_DEV_MODE
     if (ebpf_aral_shm_pid)
         ebpf_statistic_create_aral_chart(NETDATA_EBPF_SHM_ARAL_NAME, em);
+#endif
 
     pthread_mutex_unlock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -1110,6 +1110,7 @@ void *ebpf_shm_thread(void *ptr)
     pthread_mutex_lock(&lock);
     ebpf_create_shm_charts(em->update_every);
     ebpf_update_stats(&plugin_statistics, em);
+    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     shm_collector(em);

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -1110,7 +1110,7 @@ void *ebpf_shm_thread(void *ptr)
     pthread_mutex_lock(&lock);
     ebpf_create_shm_charts(em->update_every);
     ebpf_update_stats(&plugin_statistics, em);
-    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
+    ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     shm_collector(em);

--- a/collectors/ebpf.plugin/ebpf_shm.h
+++ b/collectors/ebpf.plugin/ebpf_shm.h
@@ -27,6 +27,9 @@
 #define NETDATA_SYSTEMD_SHM_DT_CONTEXT "services.shmdt"
 #define NETDATA_SYSTEMD_SHM_CTL_CONTEXT "services.shmctl"
 
+// ARAL name
+#define NETDATA_EBPF_SHM_ARAL_NAME "ebpf_shm"
+
 typedef struct netdata_publish_shm {
     uint64_t get;
     uint64_t at;

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -4009,6 +4009,7 @@ void *ebpf_socket_thread(void *ptr)
     ebpf_create_global_charts(em);
 
     ebpf_update_stats(&plugin_statistics, em);
+    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
 
     pthread_mutex_unlock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -2948,8 +2948,10 @@ static void socket_collector(ebpf_module_t *em)
         if (socket_apps_enabled & NETDATA_EBPF_APPS_FLAG_CHART_CREATED)
             ebpf_socket_send_apps_data(em, apps_groups_root_target);
 
+#ifdef NETDATA_DEV_MODE
         if (ebpf_aral_socket_pid)
             ebpf_send_data_aral_chart(ebpf_aral_socket_pid, em);
+#endif
 
         if (cgroups)
             ebpf_socket_send_cgroup_data(update_every);
@@ -4014,8 +4016,10 @@ void *ebpf_socket_thread(void *ptr)
     ebpf_update_stats(&plugin_statistics, em);
     ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
 
+#ifdef NETDATA_DEV_MODE
     if (ebpf_aral_socket_pid)
         ebpf_statistic_create_aral_chart(NETDATA_EBPF_SOCKET_ARAL_NAME, em);
+#endif
 
     pthread_mutex_unlock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -4009,7 +4009,7 @@ void *ebpf_socket_thread(void *ptr)
     ebpf_create_global_charts(em);
 
     ebpf_update_stats(&plugin_statistics, em);
-    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
+    ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
 
     pthread_mutex_unlock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -7,7 +7,7 @@
 
 // ----------------------------------------------------------------------------
 // ARAL vectors used to speed up processing
-ARAL *ebpf_aral_socket_pid;
+ARAL *ebpf_aral_socket_pid = NULL;
 
 /*****************************************************************
  *
@@ -446,7 +446,7 @@ static inline int ebpf_socket_load_and_attach(struct socket_bpf *obj, ebpf_modul
  */
 static inline void ebpf_socket_aral_init()
 {
-    ebpf_aral_socket_pid = ebpf_allocate_pid_aral("ebpf-socket", sizeof(ebpf_socket_publish_apps_t));
+    ebpf_aral_socket_pid = ebpf_allocate_pid_aral(NETDATA_EBPF_SOCKET_ARAL_NAME, sizeof(ebpf_socket_publish_apps_t));
 }
 
 /**
@@ -2948,6 +2948,9 @@ static void socket_collector(ebpf_module_t *em)
         if (socket_apps_enabled & NETDATA_EBPF_APPS_FLAG_CHART_CREATED)
             ebpf_socket_send_apps_data(em, apps_groups_root_target);
 
+        if (ebpf_aral_socket_pid)
+            ebpf_send_data_aral_chart(ebpf_aral_socket_pid, em);
+
         if (cgroups)
             ebpf_socket_send_cgroup_data(update_every);
 
@@ -4010,6 +4013,9 @@ void *ebpf_socket_thread(void *ptr)
 
     ebpf_update_stats(&plugin_statistics, em);
     ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
+
+    if (ebpf_aral_socket_pid)
+        ebpf_statistic_create_aral_chart(NETDATA_EBPF_SOCKET_ARAL_NAME, em);
 
     pthread_mutex_unlock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_socket.h
+++ b/collectors/ebpf.plugin/ebpf_socket.h
@@ -160,6 +160,9 @@ typedef enum ebpf_socket_idx {
 #define NETDATA_SERVICES_SOCKET_UDP_RECV_CONTEXT "services.net_udp_recv"
 #define NETDATA_SERVICES_SOCKET_UDP_SEND_CONTEXT "services.net_udp_send"
 
+// ARAL name
+#define NETDATA_EBPF_SOCKET_ARAL_NAME "ebpf_socket"
+
 typedef struct ebpf_socket_publish_apps {
     // Data read
     uint64_t bytes_sent;            // Bytes sent

--- a/collectors/ebpf.plugin/ebpf_softirq.c
+++ b/collectors/ebpf.plugin/ebpf_softirq.c
@@ -164,7 +164,7 @@ static void softirq_collector(ebpf_module_t *em)
     softirq_create_charts(em->update_every);
     softirq_create_dims();
     ebpf_update_stats(&plugin_statistics, em);
-    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
+    ebpf_update_kernel_memory_with_vector_with_vector(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     // loop and read from published data until ebpf plugin is closed.

--- a/collectors/ebpf.plugin/ebpf_softirq.c
+++ b/collectors/ebpf.plugin/ebpf_softirq.c
@@ -164,6 +164,7 @@ static void softirq_collector(ebpf_module_t *em)
     softirq_create_charts(em->update_every);
     softirq_create_dims();
     ebpf_update_stats(&plugin_statistics, em);
+    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     // loop and read from published data until ebpf plugin is closed.

--- a/collectors/ebpf.plugin/ebpf_softirq.c
+++ b/collectors/ebpf.plugin/ebpf_softirq.c
@@ -164,7 +164,7 @@ static void softirq_collector(ebpf_module_t *em)
     softirq_create_charts(em->update_every);
     softirq_create_dims();
     ebpf_update_stats(&plugin_statistics, em);
-    ebpf_update_kernel_memory_with_vector_with_vector(&plugin_statistics, em->maps);
+    ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     // loop and read from published data until ebpf plugin is closed.

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -842,6 +842,7 @@ void *ebpf_swap_thread(void *ptr)
     pthread_mutex_lock(&lock);
     ebpf_create_swap_charts(em->update_every);
     ebpf_update_stats(&plugin_statistics, em);
+    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     swap_collector(em);

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -842,7 +842,7 @@ void *ebpf_swap_thread(void *ptr)
     pthread_mutex_lock(&lock);
     ebpf_create_swap_charts(em->update_every);
     ebpf_update_stats(&plugin_statistics, em);
-    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
+    ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     swap_collector(em);

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -1956,7 +1956,7 @@ void *ebpf_vfs_thread(void *ptr)
     pthread_mutex_lock(&lock);
     ebpf_create_global_charts(em);
     ebpf_update_stats(&plugin_statistics, em);
-    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
+    ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     vfs_collector(em);

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -1956,6 +1956,7 @@ void *ebpf_vfs_thread(void *ptr)
     pthread_mutex_lock(&lock);
     ebpf_create_global_charts(em);
     ebpf_update_stats(&plugin_statistics, em);
+    ebpf_update_kernel_memory(&plugin_statistics, em->maps);
     pthread_mutex_unlock(&lock);
 
     vfs_collector(em);

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -1528,8 +1528,10 @@ static void vfs_collector(ebpf_module_t *em)
         if (apps)
             ebpf_vfs_read_apps();
 
+#ifdef NETDATA_DEV_MODE
         if (ebpf_aral_vfs_pid)
             ebpf_send_data_aral_chart(ebpf_aral_vfs_pid, em);
+#endif
 
         if (cgroups)
             read_update_vfs_cgroup();
@@ -1960,8 +1962,10 @@ void *ebpf_vfs_thread(void *ptr)
     ebpf_create_global_charts(em);
     ebpf_update_stats(&plugin_statistics, em);
     ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps);
+#ifdef NETDATA_DEV_MODE
     if (ebpf_aral_vfs_pid)
         ebpf_statistic_create_aral_chart(NETDATA_EBPF_VFS_ARAL_NAME, em);
+#endif
 
     pthread_mutex_unlock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_vfs.h
+++ b/collectors/ebpf.plugin/ebpf_vfs.h
@@ -69,6 +69,9 @@
 #define NETDATA_SYSTEMD_VFS_FSYNC_CONTEXT "services.vfs_fsync"
 #define NETDATA_SYSTEMD_VFS_FSYNC_ERROR_CONTEXT "services.vfs_fsync_error"
 
+// ARAL name
+#define NETDATA_EBPF_VFS_ARAL_NAME "ebpf_vfs"
+
 typedef struct netdata_publish_vfs {
     uint64_t pid_tgid;
     uint32_t pid;

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -497,7 +497,8 @@ void ebpf_update_kernel_memory(ebpf_plugin_stats_t *report, ebpf_local_maps_t *m
                 report->memlock_kern += memsize;
                 report->hash_tables += 1;
 #ifdef NETDATA_DEV_MODE
-                info("Hash table %s (FD = %d) is consuming %lu bytes", map->name, fd, memsize);
+                info("Hash table %u: %s (FD = %d) is consuming %lu bytes totalizing %lu bytes",
+                     report->hash_tables, map->name, fd, memsize, report->memlock_kern);
 #endif
                 break;
             }

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -489,6 +489,7 @@ void ebpf_update_kernel_memory(ebpf_plugin_stats_t *report, ebpf_local_maps_t *m
         if (!strncmp(memlock, cmp, length)) {
             uint64_t memsize = (uint64_t) str2l(procfile_lineword(ff, i,1));
             report->memlock_kern += memsize;
+            report->hash_tables += 1;
 #ifdef NETDATA_DEV_MODE
             info("Hash table %s (FD = %d) is consuming %lu bytes", map->name, fd, memsize);
 #endif

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -454,6 +454,51 @@ void ebpf_update_stats(ebpf_plugin_stats_t *report, ebpf_module_t *em)
     ebpf_stats_targets(report, em->targets);
 }
 
+/**
+ * Update Kernel memory
+ *
+ * This algorithm is an adaptation of https://elixir.bootlin.com/linux/v6.1.14/source/tools/bpf/bpftool/common.c#L402
+ * to get 'memlock' data.
+ *
+ * @param report  the output structure
+ * @param fd      the file descriptor that function needs to get information
+ */
+void ebpf_update_kernel_memory(ebpf_plugin_stats_t *report, ebpf_local_maps_t *map)
+{
+    int fd = map->map_fd;
+    if (fd == ND_EBPF_MAP_FD_NOT_INITIALIZED)
+        return;
+
+    char filename[FILENAME_MAX+1];
+    snprintfz(filename, FILENAME_MAX, "/proc/self/fdinfo/%d", fd);
+    procfile *ff = procfile_open(filename, " \t", PROCFILE_FLAG_DEFAULT);
+    if(unlikely(!ff)) {
+        error("Cannot open %s", filename);
+        return;
+    }
+
+    ff = procfile_readall(ff);
+    if(unlikely(!ff))
+        return;
+
+    unsigned long i, lines = procfile_lines(ff);
+    char *memlock = { "memlock" };
+    size_t length = strlen(memlock);
+    for(i = 0; i < lines ; i++) {
+        char *cmp = procfile_lineword(ff, i,0);
+        if (!strncmp(memlock, cmp, length)) {
+            uint64_t memsize = (uint64_t) str2l(procfile_lineword(ff, i,1));
+            report->memlock_kern += memsize;
+#ifdef NETDATA_DEV_MODE
+            info("Hash table %s (FD = %d) is consuming %lu bytes", map->name, fd, memsize);
+#endif
+            break;
+        }
+    }
+
+    procfile_close(ff);
+}
+
 //----------------------------------------------------------------------------------------------------------------------
 
 void ebpf_update_pid_table(ebpf_local_maps_t *pid, ebpf_module_t *em)

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -461,7 +461,68 @@ void ebpf_update_stats(ebpf_plugin_stats_t *report, ebpf_module_t *em)
  * to get 'memlock' data and update report.
  *
  * @param report  the output structure
- * @param maps    pointer to maps. Last map must fish with name = NULL
+ * @param map     pointer to a map.
+ * @param action  What action will be done with this map.
+ */
+void ebpf_update_kernel_memory(ebpf_plugin_stats_t *report, ebpf_local_maps_t *map, ebpf_stats_action_t action)
+{
+    char filename[FILENAME_MAX+1];
+    snprintfz(filename, FILENAME_MAX, "/proc/self/fdinfo/%d", map->map_fd);
+    procfile *ff = procfile_open(filename, " \t", PROCFILE_FLAG_DEFAULT);
+    if(unlikely(!ff)) {
+        error("Cannot open %s", filename);
+        return;
+    }
+
+    ff = procfile_readall(ff);
+    if(unlikely(!ff))
+        return;
+
+    unsigned long j, lines = procfile_lines(ff);
+    char *memlock = { "memlock" };
+    size_t length = strlen(memlock);
+    for (j = 0; j < lines ; j++) {
+        char *cmp = procfile_lineword(ff, j,0);
+        if (!strncmp(memlock, cmp, length)) {
+            uint64_t memsize = (uint64_t) str2l(procfile_lineword(ff, j,1));
+            switch (action) {
+                case EBPF_ACTION_STAT_ADD: {
+                    report->memlock_kern += memsize;
+                    report->hash_tables += 1;
+#ifdef NETDATA_DEV_MODE
+                    info("Hash table %u: %s (FD = %d) is consuming %lu bytes totalizing %lu bytes",
+                         report->hash_tables, map->name, map->map_fd, memsize, report->memlock_kern);
+#endif
+                    break;
+                }
+                case EBPF_ACTION_STAT_REMOVE: {
+                    report->memlock_kern -= memsize;
+                    report->hash_tables -= 1;
+#ifdef NETDATA_DEV_MODE
+                    info("Hash table %s (FD = %d) was removed releasing %lu bytes, now we have %u tables loaded totalizing %lu bytes.",
+                         map->name, map->map_fd, memsize, report->hash_tables, report->memlock_kern);
+#endif
+                    break;
+                }
+                default: {
+                    break;
+                }
+            }
+            break;
+        }
+    }
+
+    procfile_close(ff);
+}
+
+/**
+ * Update Kernel memory with memory
+ *
+ * This algorithm is an adaptation of https://elixir.bootlin.com/linux/v6.1.14/source/tools/bpf/bpftool/common.c#L402
+ * to get 'memlock' data and update report.
+ *
+ * @param report  the output structure
+ * @param map     pointer to a map. Last map must fish with name = NULL
  */
 void ebpf_update_kernel_memory_with_vector(ebpf_plugin_stats_t *report, ebpf_local_maps_t *maps)
 {
@@ -475,36 +536,7 @@ void ebpf_update_kernel_memory_with_vector(ebpf_plugin_stats_t *report, ebpf_loc
         if (fd == ND_EBPF_MAP_FD_NOT_INITIALIZED)
             continue;
 
-        char filename[FILENAME_MAX+1];
-        snprintfz(filename, FILENAME_MAX, "/proc/self/fdinfo/%d", fd);
-        procfile *ff = procfile_open(filename, " \t", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff)) {
-            error("Cannot open %s", filename);
-            return;
-        }
-
-        ff = procfile_readall(ff);
-        if(unlikely(!ff))
-            return;
-
-        unsigned long j, lines = procfile_lines(ff);
-        char *memlock = { "memlock" };
-        size_t length = strlen(memlock);
-        for (j = 0; j < lines ; j++) {
-            char *cmp = procfile_lineword(ff, j,0);
-            if (!strncmp(memlock, cmp, length)) {
-                uint64_t memsize = (uint64_t) str2l(procfile_lineword(ff, j,1));
-                report->memlock_kern += memsize;
-                report->hash_tables += 1;
-#ifdef NETDATA_DEV_MODE
-                info("Hash table %u: %s (FD = %d) is consuming %lu bytes totalizing %lu bytes",
-                     report->hash_tables, map->name, fd, memsize, report->memlock_kern);
-#endif
-                break;
-            }
-        }
-
-        procfile_close(ff);
+        ebpf_update_kernel_memory(report, map, EBPF_ACTION_STAT_ADD);
     }
 }
 

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -455,15 +455,15 @@ void ebpf_update_stats(ebpf_plugin_stats_t *report, ebpf_module_t *em)
 }
 
 /**
- * Update Kernel memory
+ * Update Kernel memory with memory
  *
  * This algorithm is an adaptation of https://elixir.bootlin.com/linux/v6.1.14/source/tools/bpf/bpftool/common.c#L402
- * to get 'memlock' data.
+ * to get 'memlock' data and update report.
  *
  * @param report  the output structure
- * @param maps    pointers to maps
+ * @param maps    pointer to maps. Last map must fish with name = NULL
  */
-void ebpf_update_kernel_memory(ebpf_plugin_stats_t *report, ebpf_local_maps_t *maps)
+void ebpf_update_kernel_memory_with_vector(ebpf_plugin_stats_t *report, ebpf_local_maps_t *maps)
 {
     if (!maps)
         return;

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -480,10 +480,9 @@ void ebpf_update_kernel_memory(ebpf_plugin_stats_t *report, ebpf_local_maps_t *m
 
     unsigned long j, lines = procfile_lines(ff);
     char *memlock = { "memlock" };
-    size_t length = strlen(memlock);
     for (j = 0; j < lines ; j++) {
         char *cmp = procfile_lineword(ff, j,0);
-        if (!strncmp(memlock, cmp, length)) {
+        if (!strncmp(memlock, cmp, 7)) {
             uint64_t memsize = (uint64_t) str2l(procfile_lineword(ff, j,1));
             switch (action) {
                 case EBPF_ACTION_STAT_ADD: {

--- a/libnetdata/ebpf/ebpf.h
+++ b/libnetdata/ebpf/ebpf.h
@@ -244,6 +244,11 @@ typedef struct ebpf_plugin_stats {
     uint32_t hash_tables; // Number of hash tables used on the system.
 } ebpf_plugin_stats_t;
 
+typedef enum ebpf_stats_action {
+    EBPF_ACTION_STAT_ADD,
+    EBPF_ACTION_STAT_REMOVE,
+} ebpf_stats_action_t;
+
 typedef enum netdata_apps_integration_flags {
     NETDATA_EBPF_APPS_FLAG_NO,
     NETDATA_EBPF_APPS_FLAG_YES,
@@ -373,5 +378,6 @@ int ebpf_is_function_inside_btf(struct btf *file, char *function);
 #endif
 
 void ebpf_update_kernel_memory_with_vector(ebpf_plugin_stats_t *report, ebpf_local_maps_t *maps);
+void ebpf_update_kernel_memory(ebpf_plugin_stats_t *report, ebpf_local_maps_t *map, ebpf_stats_action_t action);
 
 #endif /* NETDATA_EBPF_H */

--- a/libnetdata/ebpf/ebpf.h
+++ b/libnetdata/ebpf/ebpf.h
@@ -10,6 +10,7 @@
 #include <linux/btf.h>
 #endif
 #include <stdlib.h> // Necessary for stdtoul
+#include "libnetdata/aral/aral.h"
 
 #define NETDATA_DEBUGFS "/sys/kernel/debug/tracing/"
 #define NETDATA_KALLSYMS "/proc/kallsyms"
@@ -255,6 +256,10 @@ typedef enum netdata_apps_integration_flags {
     NETDATA_EBPF_APPS_FLAG_CHART_CREATED
 } netdata_apps_integration_flags_t;
 
+#define NETDATA_EBPF_CHART_MEM_LENGTH 48
+#define NETDATA_EBPF_STAT_DIMENSION_MEMORY "memory"
+#define NETDATA_EBPF_STAT_DIMENSION_ARAL "aral"
+
 typedef struct ebpf_module {
     const char *thread_name;
     const char *config_name;
@@ -280,6 +285,10 @@ typedef struct ebpf_module {
     struct bpf_link **probe_links;
     struct bpf_object *objects;
     struct netdata_static_thread *thread;
+
+    // charts
+    char memory_usage[NETDATA_EBPF_CHART_MEM_LENGTH];
+    char memory_allocations[NETDATA_EBPF_CHART_MEM_LENGTH];
 } ebpf_module_t;
 
 int ebpf_get_kernel_version();
@@ -379,5 +388,7 @@ int ebpf_is_function_inside_btf(struct btf *file, char *function);
 
 void ebpf_update_kernel_memory_with_vector(ebpf_plugin_stats_t *report, ebpf_local_maps_t *maps);
 void ebpf_update_kernel_memory(ebpf_plugin_stats_t *report, ebpf_local_maps_t *map, ebpf_stats_action_t action);
+void ebpf_statistic_create_aral_chart(char *name, ebpf_module_t *em);
+void ebpf_send_data_aral_chart(ARAL *memory, ebpf_module_t *em);
 
 #endif /* NETDATA_EBPF_H */

--- a/libnetdata/ebpf/ebpf.h
+++ b/libnetdata/ebpf/ebpf.h
@@ -238,6 +238,9 @@ typedef struct ebpf_plugin_stats {
     uint32_t retprobes;   // Number of kretprobes loaded
     uint32_t tracepoints; // Number of tracepoints used
     uint32_t trampolines; // Number of trampolines used
+
+    uint64_t memlock_kern; // The same information reported by bpftool, but it is not accurated
+                           // https://lore.kernel.org/linux-mm/20230112155326.26902-5-laoar.shao@gmail.com/T/
 } ebpf_plugin_stats_t;
 
 typedef enum netdata_apps_integration_flags {

--- a/libnetdata/ebpf/ebpf.h
+++ b/libnetdata/ebpf/ebpf.h
@@ -372,6 +372,6 @@ struct btf *ebpf_load_btf_file(char *path, char *filename);
 int ebpf_is_function_inside_btf(struct btf *file, char *function);
 #endif
 
-void ebpf_update_kernel_memory(ebpf_plugin_stats_t *report, ebpf_local_maps_t *map);
+void ebpf_update_kernel_memory(ebpf_plugin_stats_t *report, ebpf_local_maps_t *maps);
 
 #endif /* NETDATA_EBPF_H */

--- a/libnetdata/ebpf/ebpf.h
+++ b/libnetdata/ebpf/ebpf.h
@@ -241,6 +241,7 @@ typedef struct ebpf_plugin_stats {
 
     uint64_t memlock_kern; // The same information reported by bpftool, but it is not accurated
                            // https://lore.kernel.org/linux-mm/20230112155326.26902-5-laoar.shao@gmail.com/T/
+    uint32_t hash_tables; // Number of hash tables used on the system.
 } ebpf_plugin_stats_t;
 
 typedef enum netdata_apps_integration_flags {

--- a/libnetdata/ebpf/ebpf.h
+++ b/libnetdata/ebpf/ebpf.h
@@ -372,6 +372,6 @@ struct btf *ebpf_load_btf_file(char *path, char *filename);
 int ebpf_is_function_inside_btf(struct btf *file, char *function);
 #endif
 
-void ebpf_update_kernel_memory(ebpf_plugin_stats_t *report, ebpf_local_maps_t *maps);
+void ebpf_update_kernel_memory_with_vector(ebpf_plugin_stats_t *report, ebpf_local_maps_t *maps);
 
 #endif /* NETDATA_EBPF_H */

--- a/libnetdata/ebpf/ebpf.h
+++ b/libnetdata/ebpf/ebpf.h
@@ -371,4 +371,6 @@ struct btf *ebpf_load_btf_file(char *path, char *filename);
 int ebpf_is_function_inside_btf(struct btf *file, char *function);
 #endif
 
+void ebpf_update_kernel_memory(ebpf_plugin_stats_t *report, ebpf_local_maps_t *map);
+
 #endif /* NETDATA_EBPF_H */

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -4921,7 +4921,23 @@ netdataDashboard.context = {
         info: 'Show number of threads loaded using legacy code (independent binary) or <code>CO-RE (Compile Once Run Everywhere)</code>.'
     },
 
-    // ------------------------------------------------------------------------
+    'netdata.ebpf_kernel_memory': {
+        info: 'Show amount of memory allocated inside kernel ring for hash tables. This chart shows the same information displayed by command `bpftool map show`.'
+    },
+
+    'netdata.ebpf_hash_tables_count': {
+        info: 'Show total number of hash tables loaded by eBPF.plugin`.'
+    },
+
+    'netdata.ebpf_aral_stat_size': {
+        info: 'Show total memory allocated for the specific ARAL.'
+    },
+
+    'netdata.ebpf_aral_stat_alloc': {
+        info: 'Show total memory of calls to get a specific region of memory inside an ARAL region.'
+    },
+
+// ------------------------------------------------------------------------
     // RETROSHARE
 
     'retroshare.bandwidth': {


### PR DESCRIPTION
##### Summary
This PR is adding metrics to monitor how eBPF.plugin memory usage. The new metrics will show:

- Total memory allocated for hash table (Same algorithm used by `bpftool`).
- Charts to monitor calls to allocate ARAL and memory allocated per ARAL.

This PR is also renaming ARAL regions to match what is shown on user dashboard.

##### Test Plan
1. Compile this branch with CFLAG `NETDATA_DEV_MODE`
2. Modify your configuration file `/etc/netdata/ebpf.d.conf` and enable integration between eBPF and apps:
```sh
[global]
    apps = yes
    cgroups = yes

```
3. Take a look if charts are shown inside `Netdata Monitoring`.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? ebpf.plugin
- Can they see the change or is it an under the hood? If they can see it, where? They will see only when compile with CFLAG `NETDATA_DEV_MODE`
- How is the user impacted by the change? We have conditions to monitor and understanding possible issue with memory allocation.
- What are there any benefits of the change?  An easy way to address issue and understanding memory consumption. 
</details>