### PR TITLE
Fix intermittent permissions issues in some Docker builds.

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -51,6 +51,7 @@ RUN mkdir -p /app/usr/sbin/ \
     mv /usr/sbin/netdatacli    /app/usr/sbin/ && \
     mv packaging/docker/run.sh        /app/usr/sbin/ && \
     mv packaging/docker/health.sh     /app/usr/sbin/ && \
+    mkdir -p /deps/etc && \
     cp -rp /deps/etc /app/usr/local/etc && \
     chmod -R o+rX /app && \
     chmod +x /app/usr/sbin/run.sh

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -51,7 +51,8 @@ RUN mkdir -p /app/usr/sbin/ \
     mv /usr/sbin/netdatacli    /app/usr/sbin/ && \
     mv packaging/docker/run.sh        /app/usr/sbin/ && \
     mv packaging/docker/health.sh     /app/usr/sbin/ && \
-    cp -rp /deps/* /app/usr/local/ && \
+    cp -rp /deps/etc /app/usr/local/etc && \
+    chmod -R o+rX /app && \
     chmod +x /app/usr/sbin/run.sh
 
 #####################################################################

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -21,6 +21,8 @@ if [ ! "${DISABLE_TELEMETRY:-0}" -eq 0 ] ||
   touch /etc/netdata/.opt-out-from-anonymous-statistics
 fi
 
+chmod o+rX / # Needed to fix permissions issues in some cases.
+
 BALENA_PGID=$(stat -c %g /var/run/balena.sock 2>/dev/null || true)
 DOCKER_PGID=$(stat -c %g /var/run/docker.sock 2>/dev/null || true)
 


### PR DESCRIPTION
##### Summary

Some builds using Podman/Buildah in place of Docker for the build process seem to leave strange permissions in the resultant containers. This adds code to handle those issues and fix them so that the containers still work.

##### Test Plan

Confirm that containers still work correctly with this PR (can’t really test the specific problem case this is fixing as nobody else seems to be able to reproduce it).

##### Additional Information

Fixes: #14237