### PR TITLE
Re-add link from install page to DEB/RPM package documentation.

### DIFF
--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -23,21 +23,21 @@ To install Netdata in minutes on your platform:
 2. You will be presented with an empty space, and a prompt to "Connect Nodes" with the install command for each platform
 3. Select the platform you want to install Netdata to, copy and paste the script into your node's terminal, and run it
 
-Upon installation completing successfully, you should be able to see the node live in your Netdata Space and live charts 
+Upon installation completing successfully, you should be able to see the node live in your Netdata Space and live charts
 in the Overview tab. [Read more about the cloud features](https://github.com/netdata/netdata/blob/master/docs/quickstart/infrastructure.md).
 
-Where you go from here is based on your use case, immediate needs, and experience with monitoring and troubleshooting, 
+Where you go from here is based on your use case, immediate needs, and experience with monitoring and troubleshooting,
 but we have some hints on what you might want to do next.
 
 ### What's next?
 
-Explore our [general advanced installation options and troubleshooting](#advanced-installation-options-and-troubleshooting), specific options 
+Explore our [general advanced installation options and troubleshooting](#advanced-installation-options-and-troubleshooting), specific options
 for the [single line installer](#install-on-linux-with-one-line-installer), or [other installation methods](#other-installation-methods).
 
 #### Agent user interface
 
 To access the UI provided by the locally installed agent, open a browser and navigate to `http://NODE:19999`, replacing `NODE` with either `localhost` or
-the hostname/IP address of the remote node. You can also read more about 
+the hostname/IP address of the remote node. You can also read more about
 [the agent dashboard](https://github.com/netdata/netdata/blob/master/web/gui/README.md).
 
 #### Configuration
@@ -56,7 +56,7 @@ or read about its requirements to configure your endpoint to publish metrics in 
 #### Alarms & notifications
 
 Netdata comes with hundreds of preconfigured alarms, designed by our monitoring gurus in parallel with our open-source
-community, but you may want to [edit alarms](https://github.com/netdata/netdata/blob/master/health/REFERENCE.md) or 
+community, but you may want to [edit alarms](https://github.com/netdata/netdata/blob/master/health/REFERENCE.md) or
 [enable notifications](https://github.com/netdata/netdata/blob/master/docs/monitor/enable-notifications.md) to customize your Netdata experience.
 
 #### Make your deployment production ready
@@ -64,10 +64,10 @@ community, but you may want to [edit alarms](https://github.com/netdata/netdata/
 Go through our [deployment strategies](https://github.com/netdata/netdata/edit/master/docs/category-overview-pages/deployment-strategies.md),
 for suggested configuration changes for production deployments.
 
-## Install on Linux with one-line installer 
+## Install on Linux with one-line installer
 
 The **recommended** way to install Netdata on a Linux node (physical, virtual, container, IoT) is our one-line
-[kickstart script](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/kickstart.md).  
+[kickstart script](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/kickstart.md).
 This script automatically installs dependencies and builds Netdata from its source code.
 
 To install, copy the script, paste it into your node's terminal, and hit `Enter` to begin the installation process.
@@ -86,8 +86,8 @@ To install, copy the script, paste it into your node's terminal, and hit `Enter`
 </Tabs>
 
 :::note
-If you plan to also claim the node to Netdata Cloud, 
-make sure to replace `YOUR_CLAIM_TOKEN` with the claim token of your space, 
+If you plan to also claim the node to Netdata Cloud,
+make sure to replace `YOUR_CLAIM_TOKEN` with the claim token of your space,
 and `YOUR_ROOM_ID` with the ID of the room you are willing to claim to.
 You can leave the room id blank to have your node claimed to the default "All nodes" room.
 :::
@@ -100,15 +100,15 @@ troubleshooting with Netdata.
 <InstallRegexLink>
   <InstallBoxRegexLink
     to="[](https://github.com/netdata/netdata/blob/master/packaging/docker/README.md)"
-    os="Run with Docker" 
+    os="Run with Docker"
     svg="docker" />
   <InstallBoxRegexLink
     to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/kubernetes.md)"
-    os="Deploy on Kubernetes" 
+    os="Deploy on Kubernetes"
     svg="kubernetes" />
    <InstallBoxRegexLink
     to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/macos.md)"
-    os="Install on macOS" 
+    os="Install on macOS"
     svg="macos" />
   <InstallBoxRegexLink
     to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/packages.md)"
@@ -116,14 +116,14 @@ troubleshooting with Netdata.
     svg="linux" />
   <InstallBoxRegexLink
     to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/manual.md)"
-    os="Linux from Git" 
+    os="Linux from Git"
     svg="linux" />
   <InstallBoxRegexLink
     to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/source.md)"
     os="Linux from source"
     svg="linux" />
   <InstallBoxRegexLink
-    to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/offline.md)" 
+    to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/offline.md)"
     os="Linux for offline nodes"
     svg="linux" />
 </InstallRegexLink>
@@ -135,7 +135,7 @@ troubleshooting with Netdata.
 - [Linux from source](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/source.md)
 - [Linux for offline nodes](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/offline.md)
 
-The full list of all installation methods for various systems is available in [Netdata Learn](https://learn.netdata.cloud), 
+The full list of all installation methods for various systems is available in [Netdata Learn](https://learn.netdata.cloud),
 under [Installation](https://github.com/netdata/netdata/blob/master/docs/category-overview-pages/installation-overview.md).
 
 ## Advanced installation options and troubleshooting

--- a/packaging/installer/README.md
+++ b/packaging/installer/README.md
@@ -111,6 +111,10 @@ troubleshooting with Netdata.
     os="Install on macOS" 
     svg="macos" />
   <InstallBoxRegexLink
+    to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/packages.md)"
+    os="Native DEB/RPM packages"
+    svg="linux" />
+  <InstallBoxRegexLink
     to="[](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/manual.md)"
     os="Linux from Git" 
     svg="linux" />


### PR DESCRIPTION
##### Summary

It somehow got dropped during the docs reorganization.

##### Test Plan

na

##### Additional Information

This also cleans up the numerous instances of trailing whitespace in the install document.