### PR TITLE
Assorted installer code cleanup.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1396,21 +1396,9 @@ try_package_install() {
       uninstall_subcmd="remove"
       ;;
     amzn)
-      if command -v dnf > /dev/null; then
-        pm_cmd="dnf"
-        repo_subcmd="makecache"
-      else
-        pm_cmd="yum"
-      fi
+      common_rpm_opts
+      common_dnf_opts
       repo_prefix="amazonlinux/${SYSVERSION}"
-      pkg_type="rpm"
-      pkg_suffix=".noarch"
-      pkg_vsep="-"
-      pkg_install_opts="${interactive_opts}"
-      repo_update_opts="${interactive_opts}"
-      uninstall_subcmd="remove"
-      INSTALL_TYPE="binpkg-rpm"
-      NATIVE_VERSION="${INSTALL_VERSION:+"-${INSTALL_VERSION}.${SYSARCH}"}"
       ;;
     *)
       warning "We do not provide native packages for ${DISTRO}."

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1352,6 +1352,26 @@ check_special_native_deps() {
   fi
 }
 
+common_rpm_opts() {
+  pkg_type="rpm"
+  pkg_suffix=".noarch"
+  pkg_vsep="-"
+  INSTALL_TYPE="binpkg-rpm"
+  NATIVE_VERSION="${INSTALL_VERSION:+"-${INSTALL_VERSION}.${SYSARCH}"}"
+}
+
+common_dnf_opts() {
+  if command -v dnf > /dev/null; then
+    pm_cmd="dnf"
+    repo_subcmd="makecache"
+  else
+    pm_cmd="yum"
+  fi
+  pkg_install_opts="${interactive_opts}"
+  repo_update_opts="${interactive_opts}"
+  uninstall_subcmd="remove"
+}
+
 try_package_install() {
   failed_refresh_msg="Failed to refresh repository metadata. ${BADNET_MSG} or by misconfiguration of one or more rpackage repositories in the system package manager configuration."
 
@@ -1390,97 +1410,38 @@ try_package_install() {
   fi
 
   case "${DISTRO_COMPAT_NAME}" in
-    debian)
+    debian|ubuntu)
       needs_early_refresh=1
       pm_cmd="apt-get"
       repo_subcmd="update"
-      repo_prefix="debian/${SYSCODENAME}"
       pkg_type="deb"
-      pkg_suffix="+debian${SYSVERSION}_all"
       pkg_vsep="_"
       pkg_install_opts="${interactive_opts}"
       repo_update_opts="${interactive_opts}"
       uninstall_subcmd="purge"
-      INSTALL_TYPE="binpkg-deb"
-      NATIVE_VERSION="${INSTALL_VERSION:+"=${INSTALL_VERSION}"}"
-      ;;
-    ubuntu)
-      needs_early_refresh=1
-      pm_cmd="apt-get"
-      repo_subcmd="update"
-      repo_prefix="ubuntu/${SYSCODENAME}"
-      pkg_type="deb"
-      pkg_suffix="+ubuntu${SYSVERSION}_all"
-      pkg_vsep="_"
-      pkg_install_opts="${interactive_opts}"
-      repo_update_opts="${interactive_opts}"
-      uninstall_subcmd="purge"
+      repo_prefix="${DISTRO_COMPAT_NAME}/${SYSCODENAME}"
+      pkg_suffix="+${DISTRO_COMPAT_NAME}${SYSVERSION}_all"
       INSTALL_TYPE="binpkg-deb"
       NATIVE_VERSION="${INSTALL_VERSION:+"=${INSTALL_VERSION}"}"
       ;;
     centos)
-      if command -v dnf > /dev/null; then
-        pm_cmd="dnf"
-        repo_subcmd="makecache"
-      else
-        pm_cmd="yum"
-      fi
+      common_rpm_opts
+      common_dnf_opts
       repo_prefix="el/${SYSVERSION}"
-      pkg_type="rpm"
-      pkg_suffix=".noarch"
-      pkg_vsep="-"
-      pkg_install_opts="${interactive_opts}"
-      repo_update_opts="${interactive_opts}"
-      uninstall_subcmd="remove"
-      INSTALL_TYPE="binpkg-rpm"
-      NATIVE_VERSION="${INSTALL_VERSION:+"-${INSTALL_VERSION}.${SYSARCH}"}"
       ;;
-    fedora)
-      if command -v dnf > /dev/null; then
-        pm_cmd="dnf"
-        repo_subcmd="makecache"
-      else
-        pm_cmd="yum"
-      fi
-      repo_prefix="fedora/${SYSVERSION}"
-      pkg_type="rpm"
-      pkg_suffix=".noarch"
-      pkg_vsep="-"
-      pkg_install_opts="${interactive_opts}"
-      repo_update_opts="${interactive_opts}"
-      uninstall_subcmd="remove"
-      INSTALL_TYPE="binpkg-rpm"
-      NATIVE_VERSION="${INSTALL_VERSION:+"-${INSTALL_VERSION}.${SYSARCH}"}"
+    fedora|ol)
+      common_rpm_opts
+      common_dnf_opts
+      repo_prefix="${DISTRO_COMPAT_NAME}/${SYSVERSION}"
       ;;
     opensuse)
+      common_rpm_opts
       pm_cmd="zypper"
       repo_subcmd="--gpg-auto-import-keys refresh"
       repo_prefix="opensuse/${SYSVERSION}"
-      pkg_type="rpm"
-      pkg_suffix=".noarch"
-      pkg_vsep="-"
       pkg_install_opts="${interactive_opts} --allow-unsigned-rpm"
       repo_update_opts=""
       uninstall_subcmd="remove"
-      INSTALL_TYPE="binpkg-rpm"
-      NATIVE_VERSION="${INSTALL_VERSION:+"-${INSTALL_VERSION}.${SYSARCH}"}"
-      ;;
-    ol)
-      if command -v dnf > /dev/null; then
-        pm_cmd="dnf"
-        repo_subcmd="makecache"
-      else
-        pm_cmd="yum"
-      fi
-      repo_prefix="ol/${SYSVERSION}"
-      pkg_type="rpm"
-      pkg_suffix=".noarch"
-      pkg_vsep="-"
-      pkg_install_opts="${interactive_opts}"
-      repo_update_opts="${interactive_opts}"
-      uninstall_subcmd="remove"
-      INSTALL_TYPE="binpkg-rpm"
-      NATIVE_VERSION="${INSTALL_VERSION:+"-${INSTALL_VERSION}.${SYSARCH}"}"
       ;;
     amzn)
       if command -v dnf > /dev/null; then

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -678,11 +678,6 @@ get_system_info() {
 
       case "${DISTRO_COMPAT_NAME}" in
         centos|ol) SYSVERSION=$(echo "$SYSVERSION" | cut -d'.' -f1) ;;
-        ubuntu|debian)
-          if [ -z "${SYSCODENAME}" ]; then
-            fatal "Could not determine ${DISTRO} release code name. This is required information on these systems." F0511
-          fi
-          ;;
       esac
       ;;
     Darwin)

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -715,7 +715,7 @@ update_binpkg() {
 
   DISTRO="${ID}"
 
-  supported_compat_names="debian ubuntu centos fedora opensuse ol"
+  supported_compat_names="debian ubuntu centos fedora opensuse ol amzn"
 
   if str_in_list "${DISTRO}" "${supported_compat_names}"; then
     DISTRO_COMPAT_NAME="${DISTRO}"
@@ -751,7 +751,7 @@ update_binpkg() {
       pkg_installed_check="dpkg -s"
       INSTALL_TYPE="binpkg-deb"
       ;;
-    centos|fedora|ol)
+    centos|fedora|ol|amzn)
       if command -v dnf > /dev/null; then
         pm_cmd="dnf"
         repo_subcmd="makecache"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -21,7 +21,7 @@
 #  - TMPDIR (set to a usable temporary directory)
 #  - NETDATA_NIGHTLIES_BASEURL (set the base url for downloading the dist tarball)
 #
-# Copyright: 2018-2020 Netdata Inc.
+# Copyright: 2018-2023 Netdata Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 # Author: Paweł Krupa <paulfantom@gmail.com>
@@ -804,11 +804,10 @@ update_binpkg() {
 # Simple function to encapsulate original updater behavior.
 update_legacy() {
   set_tarball_urls "${RELEASE_CHANNEL}" "${IS_NETDATA_STATIC_BINARY}"
-  if [ "${IS_NETDATA_STATIC_BINARY}" = "yes" ]; then
-    update_static && exit 0
-  else
-    update_build && exit 0
-  fi
+  case "${IS_NETDATA_STATIC_BINARY}" in
+    yes) update_static && exit 0 ;;
+    *) update_build && exit 0 ;;
+  esac
 }
 
 logfile=
@@ -879,9 +878,7 @@ while [ -n "${1}" ]; do
         disable_netdata_updater
         exit $?
         ;;
-    *)
-        fatal "Unrecognized option ${1}" U001A
-        ;;
+    *) fatal "Unrecognized option ${1}" U001A ;;
   esac
 
   shift 1
@@ -923,9 +920,7 @@ case "${INSTALL_TYPE}" in
       set_tarball_urls "${RELEASE_CHANNEL}" "${IS_NETDATA_STATIC_BINARY}"
       update_static && exit 0
       ;;
-    *binpkg*)
-      update_binpkg && exit 0
-      ;;
+    *binpkg*) update_binpkg && exit 0 ;;
     "") # Fallback case for no `.install-type` file. This just works like the old install type detection.
       validate_environment_file
       update_legacy
@@ -939,10 +934,6 @@ case "${INSTALL_TYPE}" in
         fatal "This script does not support updating custom installations without valid environment files." U0012
       fi
       ;;
-    oci)
-      fatal "This script does not support updating Netdata inside our official Docker containers, please instead update the container itself." U0013
-      ;;
-    *)
-      fatal "Unrecognized installation type (${INSTALL_TYPE}), unable to update." U0014
-      ;;
+    oci) fatal "This script does not support updating Netdata inside our official Docker containers, please instead update the container itself." U0013 ;;
+    *) fatal "Unrecognized installation type (${INSTALL_TYPE}), unable to update." U0014 ;;
 esac

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -225,9 +225,8 @@ enable_netdata_updater() {
       ;;
     "crontab")
       if [ -d "/etc/cron.d" ]; then
-        cat > "/etc/cron.d/netdata-updater" <<-EOF
-	2 57 * * * root ${NETDATA_PREFIX}/netdata-updater.sh
-	EOF
+        [ -f "/etc/cron.d/netdata-updater" ] && rm -f "/etc/cron.d/netdata-updater"
+        install -p -m 0644 -o 0 -g 0 "${NETDATA_PREFIX}/usr/lib/system/cron/netdata-updater-daily" "/etc/cron.d/netdata-updater-daily"
 
         info "Auto-updating has been ENABLED through cron, using a crontab at /etc/cron.d/netdata-updater\n"
         info "If the update process fails and you have email notifications set up correctly for cron on this system, you should receive an email notification of the failure."
@@ -262,6 +261,7 @@ disable_netdata_updater() {
 
   if [ -d /etc/cron.d ]; then
     rm -f /etc/cron.d/netdata-updater
+    rm -f /etc/cron.d/netdata-updater-daily
   fi
 
   info "Auto-updates have been DISABLED."

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -715,7 +715,7 @@ update_binpkg() {
 
   DISTRO="${ID}"
 
-  supported_compat_names="debian ubuntu centos fedora opensuse"
+  supported_compat_names="debian ubuntu centos fedora opensuse ol"
 
   if str_in_list "${DISTRO}" "${supported_compat_names}"; then
     DISTRO_COMPAT_NAME="${DISTRO}"
@@ -742,7 +742,7 @@ update_binpkg() {
   fi
 
   case "${DISTRO_COMPAT_NAME}" in
-    debian)
+    debian|ubuntu)
       pm_cmd="apt-get"
       repo_subcmd="update"
       upgrade_cmd="--only-upgrade install"
@@ -751,29 +751,7 @@ update_binpkg() {
       pkg_installed_check="dpkg -s"
       INSTALL_TYPE="binpkg-deb"
       ;;
-    ubuntu)
-      pm_cmd="apt-get"
-      repo_subcmd="update"
-      upgrade_cmd="--only-upgrade install"
-      pkg_install_opts="${interactive_opts}"
-      repo_update_opts="${interactive_opts}"
-      pkg_installed_check="dpkg -s"
-      INSTALL_TYPE="binpkg-deb"
-      ;;
-    centos)
-      if command -v dnf > /dev/null; then
-        pm_cmd="dnf"
-        repo_subcmd="makecache"
-      else
-        pm_cmd="yum"
-      fi
-      upgrade_cmd="upgrade"
-      pkg_install_opts="${interactive_opts}"
-      repo_update_opts="${interactive_opts}"
-      pkg_installed_check="rpm -q"
-      INSTALL_TYPE="binpkg-rpm"
-      ;;
-    fedora)
+    centos|fedora|ol)
       if command -v dnf > /dev/null; then
         pm_cmd="dnf"
         repo_subcmd="makecache"


### PR DESCRIPTION
##### Summary

Most of this is internal restructuring of the kickstart.sh and netdata-updater.sh code to make it easier to read and maintain. It additionally includes the following fixes in the updater code:

- The updater script now properly works for native packages on Oracle Linux and Amazon Linux (it previously would crash).
- When using a crontab for scheduling auto updates, we now use the one installed under `/usr/lib/netdata/system` instead of hard-coding it into the updater script. This eases maintenance of this scheduling method (as it ensures what users likely find in the repo is what gets used).

##### Test Plan

Preliminary testing simply consists of confirming passing CI.

Applied testing of the kickstart changes should focus on confirming that the `--native-only`, `--static-only`, and `--build-only` options all work correctly still, and that native package installs still work correctly on our supported platforms.

Applied testing of the updater code will require passing `--no-updater-self-update` to the script and running it by hand in a number of cases. The primary cases to check are updates on systems that are using native packages, especially Oracle Linux and Amazon Linux (which do not work correctly without the changes in this PR).

##### Additional Information

Users should see no functional changes other than the updater now working correctly with native packages on Oracle Linux.