### PR TITLE
Properly handle service type detection failures when installing as a system service.

### DIFF
--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -644,7 +644,7 @@ detect_linux_svc_type() {
 install_linux_service() {
   t="$(detect_linux_svc_type)"
 
-  if [ -z "${t}" ]; then
+  if [ -z "${t}" ] || [ "${t}" = 'detect' ]; then
     exit 2
   fi
 
@@ -654,7 +654,7 @@ install_linux_service() {
 linux_cmds() {
   t="$(detect_linux_svc_type)"
 
-  if [ -z "${t}" ]; then
+  if [ -z "${t}" ] || [ "${t}" = 'detect' ]; then
     exit 2
   fi
 


### PR DESCRIPTION
##### Summary

This fixes a relatively minor bug in our handling of system service installation, making sure the code properly bails out if autodetection failed. There should be no behavioral changes from a user perspective other than eliminating some error messages.

##### Test Plan

Attempt to install the agent in a container using a local build or static build.

When not using this branch, a handful of error messages such as `/usr/libexec/netdata/install-service.sh: line 651: install_detect_service: command not found` and `/usr/libexec/netdata/install-service.sh: line 661: detect_cmds: command not found` should be seen near the end of the output (you may have to scroll up to see them).

When using this branch, none of those error messages should be present.