### PR TITLE
Handle conffiles for DEB packages explicitly instead of automatically.

### DIFF
--- a/contrib/debian/netdata.conffiles
+++ b/contrib/debian/netdata.conffiles
@@ -1,0 +1,4 @@
+/etc/default/netdata
+/etc/init.d/netdata
+/etc/logrotate.d/netdata
+/etc/netdata/netdata.conf

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -127,6 +127,25 @@ override_dh_installlogrotate:
 	cp system/logrotate/netdata debian/netdata.logrotate
 	dh_installlogrotate
 
+override_dh_installdeb:
+	dh_installdeb
+	@echo "Recreating conffiles without auto-adding /etc files"
+	@for dir in ${CURDIR}/debian/*/DEBIAN; do \
+	    PKG=$$(basename $$(dirname $$dir)); \
+	    FILES=""; \
+	    if [ -f ${CURDIR}/debian/conffiles ]; then \
+	        FILES="${CURDIR}/debian/conffiles"; \
+	    fi; \
+	    if [ -f ${CURDIR}/debian/$${PKG}.conffiles ]; then \
+	        FILES="$$FILES ${CURDIR}/debian/$${PKG}.conffiles"; \
+	    fi; \
+	    if [ -n "$$FILES" ]; then \
+	        cat $$FILES | sort -u > $$dir/conffiles; \
+	    elif [ -f $$dir/conffiles ]; then \
+	        rm $$dir/conffiles; \
+	    fi; \
+	done
+
 override_dh_clean:
 	dh_clean
 


### PR DESCRIPTION
##### Summary

By default, DEB package tooling blindly assumes that any files under `/etc` are configuration files and thus should be handled specially during updates and removals. This is usually correct behavior, but we install a couple of things in `/etc/netdata` for convenience reasons that should not be handled this way, so we need to override this behavior and explicitly specify the list of files to treat as config files.

##### Test Plan

1. [Build native packages locally](https://github.com/netdata/netdata/blob/master/packaging/building-native-packages-locally.md) for your test environment.
2. Install the netdata package from step 1 in a clean test environment.
3. Uninstall the netdata package _without_ using `apt-get purge` or the `--purge` option.
4. Manually remove `/etc/netdata`.
5. Install the netdata package from step 1 again.

Without the changes in this PR, `/etc/netdata/.install-type` and `/etc/netdata/edit-config` should not exist after step 5.

With the changes in this PR, both of the above-mentioned files should exist after this PR (but `/etc/netdata/netdata.conf` should not).

##### Additional Information

Fixes: #13732 