### PR TITLE
If a child is not streaming, send to the cloud last known version instead of unknown

### DIFF
--- a/database/sqlite/sqlite_aclk_node.c
+++ b/database/sqlite/sqlite_aclk_node.c
@@ -80,7 +80,7 @@ void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_dat
     char *host_version = NULL;
     if (host != localhost) {
         netdata_mutex_lock(&host->receiver_lock);
-        host_version = strdupz(host->receiver && host->receiver->program_version ? host->receiver->program_version : "unknown");
+        host_version = strdupz(host->receiver && host->receiver->program_version ? host->receiver->program_version : rrdhost_program_version(host));
         netdata_mutex_unlock(&host->receiver_lock);
     }
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Currently, if a parent is claimed to the cloud, but one or more children are not currently connected, the parent will advertise the children's versions as `unknown`.

![image](https://user-images.githubusercontent.com/1905463/223080261-30bce155-7942-4fc7-8563-f47835d3ce3d.png)

This creates a bit of confusion on the nodes tab on the cloud.

This change just affects the version we send if the child is not streaming, and it's the last known we've stored in the db.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Create a parent/child and claim the parent. When child is online version should be correctly reported. Stop both and only start the parent. Without this PR the version reported for the child would be `unknown`. Using this PR the version reported in the same situation should be the last known from the child.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
