### PR TITLE
Guard for null host when sending node instances

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -870,6 +870,11 @@ void aclk_send_node_instances()
             uuid_unparse_lower(list->host_id, host_id);
 
             RRDHOST *host = rrdhost_find_by_guid(host_id);
+            if (unlikely(!host)) {
+                freez((void*)node_state_update.node_id);
+                freez(query);
+                continue;
+            }
             node_state_update.capabilities = aclk_get_node_instance_capas(host);
 
             rrdhost_aclk_state_lock(localhost);

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -49,7 +49,7 @@ static int column_exists_in_table(const char *table, const char *column)
 }
 
 const char *database_migrate_v1_v2[] = {
-    "ALTER TABLE host ADD hops INTEGER;",
+    "ALTER TABLE host ADD hops INTEGER NOT NULL DEFAULT 0;",
     NULL
 };
 

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -771,7 +771,7 @@ failed:
 }
 
 #define SQL_GET_NODE_INSTANCE_LIST "select ni.node_id, ni.host_id, h.hostname " \
-    "from node_instance ni, host h where ni.host_id = h.host_id;"
+    "from node_instance ni, host h where ni.host_id = h.host_id AND h.hops >=0;"
 
 struct node_instance_list *get_node_list(void)
 {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #14637 

For some reason, in the user's case on the linked issue (thanks a lot @wmertens for the help!), his `host` table included an entry with a host with no hops information (empty), as long with the proper localhost one.

This likely because of a combination of db migration (updating from an old version) and the creation of a new guid.

If this happens, then `aclk_send_node_instances` will load the bad entry, but `rrdhost_find_by_guid` won't return any `host` for it. This PR just adds a check for NULL `host` there, as well as making sure to load only entries with hops >=0 from db in `get_node_list`. Either of those should fix the crash.

It also add a default value to hops when migrating, similar to what we have when creating the table.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Without this PR, on a claimed agent, make `hops` entry in `hosts` table, e.g. `-1`. It should crash. With this PR it should not.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
