### PR TITLE
Ethtool collector

### DIFF
--- a/collectors/python.d.plugin/ethtool/Makefile.inc
+++ b/collectors/python.d.plugin/ethtool/Makefile.inc
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# THIS IS NOT A COMPLETE Makefile
+# IT IS INCLUDED BY ITS PARENT'S Makefile.am
+# IT IS REQUIRED TO REFERENCE ALL FILES RELATIVE TO THE PARENT
+
+# install these files
+dist_python_DATA       += ethtool/ethtool.chart.py
+dist_pythonconfig_DATA += ethtool/ethtool.conf
+
+# do not install these files, but include them in the distribution
+dist_noinst_DATA       += ethtool/README.md ethtool/Makefile.inc
+

--- a/collectors/python.d.plugin/ethtool/README.md
+++ b/collectors/python.d.plugin/ethtool/README.md
@@ -1,0 +1,66 @@
+<!--
+title: "Nvidia GPU monitoring with Netdata"
+custom_edit_url: https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/nvidia_smi/README.md
+sidebar_label: "Nvidia GPUs"
+-->
+
+# Network with ethtool monitoring with Netdata
+
+Monitors performance metrics (bandwidth, number of packets discarded etc.) using `ethtool` cli tool.
+
+> **Warning**: this collector does not work when the Netdata Agent is [running in a container](https://learn.netdata.cloud/docs/agent/packaging/docker).
+
+
+## Requirements and Notes
+
+-   You must have the `nvidia-smi` tool installed and your NVIDIA GPU(s) must support the tool. Mostly the newer high end models used for AI / ML and Crypto or Pro range, read more about [ethtool](https://mymellanox.force.com/mellanoxcommunity/s/article/understanding-mlx5-ethtool-counters).
+-   You must enable this plugin, as its disabled by default due to minor performance issues:
+    ```bash
+    cd /etc/netdata   # Replace this path with your Netdata config directory, if different
+    sudo ./edit-config python.d.conf
+    ```
+    Remove the '#' before ethtool so it reads: `ethtool: yes`.
+
+-   On some systems when the GPU is idle the `nvidia-smi` tool unloads and there is added latency again when it is next queried. If you are running GPUs under constant workload this isn't likely to be an issue.
+-   Currently the `nvidia-smi` tool is being queried via cli. Updating the plugin to use the nvidia c/c++ API directly should resolve this issue. See discussion here: <https://github.com/netdata/netdata/pull/4357>
+-   Contributions are welcome.
+-   Make sure `netdata` user can execute `/usr/bin/nvidia-smi` or wherever your binary is.
+-   If `nvidia-smi` process [is not killed after netdata restart](https://github.com/netdata/netdata/issues/7143) you need to off `loop_mode`.
+-   `poll_seconds` is how often in seconds the tool is polled for as an integer.
+
+## Charts
+
+It produces the following charts:
+
+-   PCI Express Bandwidth Utilization in `KiB/s`
+-   Fan Speed in `percentage`
+-   GPU Utilization in `percentage`
+-   Memory Bandwidth Utilization in `percentage`
+-   Encoder/Decoder Utilization in `percentage`
+-   Memory Usage in `MiB`
+-   Temperature in `celsius`
+-   Clock Frequencies in `MHz`
+-   Power Utilization in `Watts`
+-   Memory Used by Each Process in `MiB`
+-   Memory Used by Each User in `MiB`
+-   Number of User on GPU in `num`
+
+## Configuration
+
+Edit the `python.d/nvidia_smi.conf` configuration file using `edit-config` from the Netdata [config
+directory](/docs/configure/nodes.md), which is typically at `/etc/netdata`.
+
+```bash
+cd /etc/netdata   # Replace this path with your Netdata config directory, if different
+sudo ./edit-config python.d/nvidia_smi.conf
+```
+
+Sample:
+
+```yaml
+loop_mode    : yes
+poll_seconds : 1
+exclude_zero_memory_users : yes
+```
+
+

--- a/collectors/python.d.plugin/ethtool/ethtool.chart.py
+++ b/collectors/python.d.plugin/ethtool/ethtool.chart.py
@@ -29,77 +29,42 @@ def device_charts(devs):
     for d in devs:
         fam = d.id
 
-        order.append('dev_{0}_rx_bw'.format(d.id))
+        order.append('dev_{0}_bw'.format(d.id))
         charts.update(
             {
-                'dev_{0}_rx_bw'.format(d.id): {
-                    'options': [None, 'Rx Bandwidth Gb/s', 'absolute', fam,
-                                'ethtool.dev_rx_bandwidth', 'line'],
+                'dev_{0}_bw'.format(d.id): {
+                    'options': [None, 'Bandwidth Gb/s', 'absolute', fam,
+                                'ethtool.dev_bandwidth', 'line'],
                     'lines': [
-                        ['dev_{0}_rx_bw'.format(d.id), 'device {0}'.format(d.id)],
+                        ['dev_{0}_rx_bw'.format(d.id), 'rx device'],
+                        ['dev_{0}_tx_bw'.format(d.id), 'tx device'],
                     ]
                 }
             }
         )
 
-        order.append('dev_{0}_rx_bw_util'.format(d.id))
+        order.append('dev_{0}_bw_util'.format(d.id))
         charts.update(
             {
-                'dev_{0}_rx_bw_util'.format(d.id): {
-                    'options': [None, 'Rx Bandwidth Percentage', 'percentage', fam,
-                                'ethtool.dev_rx_bandwidth_util', 'line'],
+                'dev_{0}_bw_util'.format(d.id): {
+                    'options': [None, 'Bandwidth Percentage', 'percentage', fam,
+                                'ethtool.dev_bandwidth_util', 'line'],
                     'lines': [
-                        ['dev_{0}_rx_bw_util'.format(d.id), 'device {0}'.format(d.id)],
+                        ['dev_{0}_rx_bw_util'.format(d.id), 'rx util'],
+                        ['dev_{0}_tx_bw_util'.format(d.id), 'tx util'],
                     ]
                 }
             }
         )
 
-        order.append('dev_{0}_rx_packets_lost'.format(d.id))
+        order.append('dev_{0}_packets_lost'.format(d.id))
         charts.update(
             {
-                'dev_{0}_rx_packets_lost'.format(d.id): {
-                    'options': [None, 'Rx lost packets', 'lost packets', fam, 'ethtool.packets_lost', 'line'],
+                'dev_{0}_packets_lost'.format(d.id): {
+                    'options': [None, 'Lost packets', 'Lost packets', fam, 'ethtool.packets_lost', 'line'],
                     'lines': [
-                        ['dev_{0}_rx_packets_lost'.format(d.id), 'adapter {0}'.format(d.id)],
-                    ]
-                }
-            }
-        )
-
-        order.append('dev_{0}_tx_bw'.format(d.id))
-        charts.update(
-            {
-                'dev_{0}_tx_bw'.format(d.id): {
-                    'options': [None, 'Tx Bandwidth Gb/s', 'absolute', fam,
-                                'ethtool.dev_rx_bandwidth', 'line'],
-                    'lines': [
-                        ['dev_{0}_tx_bw'.format(d.id), 'device {0}'.format(d.id)],
-                    ]
-                }
-            }
-        )
-
-        order.append('dev_{0}_tx_bw_util'.format(d.id))
-        charts.update(
-            {
-                'dev_{0}_tx_bw_util'.format(d.id): {
-                    'options': [None, 'Tx Bandwidth Percentage', 'percentage', fam,
-                                'ethtool.dev_rx_bandwidth_util', 'line'],
-                    'lines': [
-                        ['dev_{0}_tx_bw_util'.format(d.id), 'device {0}'.format(d.id)],
-                    ]
-                }
-            }
-        )
-
-        order.append('dev_{0}_tx_packets_lost'.format(d.id))
-        charts.update(
-            {
-                'dev_{0}_tx_packets_lost'.format(d.id): {
-                    'options': [None, 'Tx lost packets', 'Tx lost packets', fam, 'ethtool.packets_lost', 'line'],
-                    'lines': [
-                        ['dev_{0}_tx_packets_lost'.format(d.id), 'adapter {0}'.format(d.id)],
+                        ['dev_{0}_rx_packets_lost'.format(d.id), 'rx lost packets'],
+                        ['dev_{0}_tx_packets_lost'.format(d.id), 'tx lost packets'],
                     ]
                 }
             }
@@ -111,25 +76,23 @@ def device_charts(devs):
 class Metrics:
     def __init__(self, device_id, rx_bytes, rx_bw, rx_bw_util, rx_discards_phy, tx_bytes, tx_bw, tx_bw_util, tx_discards_phy, update_time):
         self.id = device_id
+        self.rx_bytes = rx_bytes
         self.rx_discards_phy = rx_discards_phy
         self.rx_bw = rx_bw
         self.rx_bw_util = rx_bw_util
-        self.rx_bytes = rx_bytes
+        self.tx_bytes = tx_bytes
         self.tx_discards_phy = tx_discards_phy
         self.tx_bw = tx_bw
         self.tx_bw_util = tx_bw_util
-        self.tx_bytes = tx_bytes
         self.update_time = update_time
 
     def data(self):
         return {
-            'dev_{0}_rx_bytes'.format(self.id): self.rx_bytes,
             'dev_{0}_rx_bw'.format(self.id): self.rx_bw,
-            'dev_{0}_rx_bw_util'.format(self.id): self.rx_bw_util,
-            'dev_{0}_rx_packets_lost'.format(self.id): self.rx_discards_phy,
-            'dev_{0}_tx_bytes'.format(self.id): self.tx_bytes,
             'dev_{0}_tx_bw'.format(self.id): self.tx_bw,
+            'dev_{0}_rx_bw_util'.format(self.id): self.rx_bw_util,
             'dev_{0}_tx_bw_util'.format(self.id): self.tx_bw_util,
+            'dev_{0}_rx_packets_lost'.format(self.id): self.rx_discards_phy,
             'dev_{0}_tx_packets_lost'.format(self.id): self.tx_discards_phy,
         }
 
@@ -172,7 +135,7 @@ class Service(ExecutableService):
             nb_sec = (last_update - self.metrics[name].update_time).total_seconds()
             self.debug(' rx_bytes {0} last_rx_bytes {1} nb seconds {2}'.format(rx_bytes, self.metrics[name].rx_bytes, nb_sec))
             # Calculation of the bandwidth in Gb/s
-            rx_bw = int((rx_bytes - self.metrics[name].rx_bytes) / nb_sec) * 8 / (1000*1000*1000)
+            rx_bw = int((rx_bytes - self.metrics[name].rx_bytes) / nb_sec * 8 / (1000*1000*1000))
             rx_bw_util = rx_bw / self.max_bw_per_device[name] * 100
             tx_bw = int((tx_bytes - self.metrics[name].tx_bytes) / nb_sec * 8 / (1000*1000*1000))
             tx_bw_util = int(tx_bw / self.max_bw_per_device[name] * 100)

--- a/collectors/python.d.plugin/ethtool/ethtool.chart.py
+++ b/collectors/python.d.plugin/ethtool/ethtool.chart.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+# Description: nvidia-smi netdata python.d module
+# Original Author: Steven Noonan (tycho)
+# Author: Ilya Mashchenko (ilyam8)
+# User Memory Stat Author: Guido Scatena (scatenag)
+
+import datetime
+import re
+
+from bases.FrameworkServices.ExecutableService import ExecutableService
+from bases.collection import find_binary
+
+disabled_by_default = True
+
+ETHTOOL = 'ethtool'
+
+RX_BW = 'rx_bw'
+TX_BW = 'tx_bw'
+
+ORDER = [
+    RX_BW,
+    TX_BW,
+]
+
+RE_BATTERY = re.compile(
+    r'BBU Capacity Info for Adapter: ([0-9]+) Relative State of Charge: ([0-9]+) % Cycle Count: ([0-9]+)'
+)
+
+# def ethernet_charts(device):
+#     order = [
+#         'bytes_received',
+#     ]
+
+#     charts = {
+#         'bytes_received': {
+#             'options': [None, 'RX Bytes', 'Bytes', "{0}".format(device.id), 'ethtool.bytes_received', 'line'],
+#             'lines': [
+#                 ['dev_{0}_bytes_received'.format(device.id), 'received', 'absolute', 1, 1],
+#             ]
+#         },
+#     }
+
+#     return order, charts
+
+class Ethtool :
+    def __init__(self, num, raw):
+        self.raw = raw
+        self.num = num
+
+    def data(self):
+        data = {
+            'bytes_received' : 0,
+            'bytes_lost' :0,
+        }
+        return dict(('gpu{0}_{1}'.format(self.num, k), v) for k, v in data.items())
+
+
+def device_charts(devs):
+    order = list()
+    charts = dict()
+
+    for d in devs:
+        order.append('dev_{0}_bytes_received'.format(d.id))
+        charts.update(
+            {
+                'dev_{0}_bytes_received'.format(d.id): {
+                    'options': [None, 'Bytes received', 'absolute', 'network_device',
+                                'ethtool.dev_bytes_received', 'line'],
+                    'lines': [
+                        ['dev_{0}_bytes_received'.format(d.id), 'device {0}'.format(d.id)],
+                    ]
+                }
+            }
+        )
+
+    for d in devs:
+        order.append('dev_{0}_bytes_lost'.format(d.id))
+        charts.update(
+            {
+                'dev_{0}_bytes_lost'.format(d.id): {
+                    'options': [None, 'Bytes lost', 'bytes lost', 'network_device', 'ethtool.dev_bytes_lost', 'line'],
+                    'lines': [
+                        ['dev_{0}_bytes_lost'.format(d.id), 'adapter {0}'.format(d.id)],
+                    ]
+                }
+            }
+        )
+
+    return order, charts
+
+
+class Metrics:
+    def __init__(self, device_id, bytes_received, rx_discards_phy):
+        self.id = device_id
+        self.bytes_received = bytes_received
+        self.rx_discards_phy = rx_discards_phy
+
+    def data(self):
+        return {
+            'dev_{0}_bytes_received'.format(self.id): self.bytes_received,
+            'dev_{0}_bytes_lost'.format(self.id): self.rx_discards_phy,
+        }
+
+def format_data(raw_data, name):
+    rx_bytes_received = 0
+    rx_discards_phy = 0
+    for line in raw_data :
+        if 'rx_bytes_phy' in line.split(':')[0] :
+            rx_bytes_received = line.split(':')[1]
+        if 'rx_discards_phy' in line.split(':')[0] :
+            rx_discards_phy = line.split(':')[1]
+    return Metrics(name, rx_bytes_received, rx_discards_phy)
+
+
+class Service(ExecutableService):
+    def __init__(self, configuration=None, name=None):
+        ExecutableService.__init__(self, configuration=configuration, name=name)
+        self.order = list()
+        self.definitions = dict()
+        self.s = find_binary('sudo')
+        self.ethtool = find_binary('ethtool')
+        self.ethtool_info =  [self.ethtool, '-S']
+        self.devices = self.find_devices()
+        
+    def find_devices(self):
+        #TODO implement method to find all devices
+        # for the moment hardcoded
+        ifconfig = find_binary('ifconfig')
+        command = [ifconfig, '-s']
+        raw_data = self._get_raw_data(command=command)
+        device_names = []
+        for line in raw_data:
+            name = line.split()[0]
+            if name == 'Iface':
+                continue
+            elif name == "ens1f0":
+            # else :
+                device_names.append(name)
+        return device_names
+
+    def check(self):
+        self.debug('------ check my ethtool service ')
+        if not self.devices:
+            self.error('Not devices found "{0}" output'.format(' '.join(self.ethtool_info)))
+            return False
+
+        data = []
+        for d in self.devices:
+            command = self.ethtool_info.copy()
+            command.append(d)
+            raw_data = self._get_raw_data(command=command)
+            data.append(format_data(raw_data, d))
+            break # WIP
+
+        o, c = device_charts(data)
+        self.order.extend(o)
+        self.definitions.update(c)
+        return True
+
+    def get_ethtool_data(self):
+        data = dict()
+
+        for d in self.devices:
+            command = self.ethtool_info.copy()
+            command.append(d)
+            start = datetime.datetime.now()
+            raw_data = self._get_raw_data(command=command)
+            end = datetime.datetime.now()
+            self.debug('------ Get raw data at {0} finish at {1} elapsed {2}'.format(start, end, end - start))
+            data.update(format_data(raw_data, d).data())
+
+        return data
+
+    def get_data(self):
+        data = dict()
+        data.update(self.get_ethtool_data())
+        return data or None
+

--- a/collectors/python.d.plugin/ethtool/ethtool.chart.py
+++ b/collectors/python.d.plugin/ethtool/ethtool.chart.py
@@ -74,13 +74,28 @@ def device_charts(devs):
         )
 
     for d in devs:
-        order.append('dev_{0}_bytes_lost'.format(d.id))
+        order.append('dev_{0}_rx_bw'.format(d.id))
         charts.update(
             {
-                'dev_{0}_bytes_lost'.format(d.id): {
-                    'options': [None, 'Bytes lost', 'bytes lost', 'network_device', 'ethtool.dev_bytes_lost', 'line'],
+                'dev_{0}_rx_bw'.format(d.id): {
+                    'options': [None, 'Rx Bandwidth Bytes/sec', 'absolute', 'network_device',
+                                'ethtool.dev_rx_bandwidth', 'line'],
                     'lines': [
-                        ['dev_{0}_bytes_lost'.format(d.id), 'adapter {0}'.format(d.id)],
+                        ['dev_{0}_rx_bw'.format(d.id), 'device {0}'.format(d.id)],
+                    ]
+                }
+            }
+        )
+
+
+    for d in devs:
+        order.append('dev_{0}_packets_lost'.format(d.id))
+        charts.update(
+            {
+                'dev_{0}_packets_lost'.format(d.id): {
+                    'options': [None, 'Lost packets', 'Lost packets', 'network_device', 'ethtool.packets_lost', 'line'],
+                    'lines': [
+                        ['dev_{0}_packets_lost'.format(d.id), 'adapter {0}'.format(d.id)],
                     ]
                 }
             }
@@ -90,53 +105,75 @@ def device_charts(devs):
 
 
 class Metrics:
-    def __init__(self, device_id, bytes_received, rx_discards_phy):
+    def __init__(self, device_id, bytes_received, rx_bw, rx_discards_phy):
         self.id = device_id
         self.bytes_received = bytes_received
         self.rx_discards_phy = rx_discards_phy
+        self.rx_bw = rx_bw
 
     def data(self):
         return {
             'dev_{0}_bytes_received'.format(self.id): self.bytes_received,
-            'dev_{0}_bytes_lost'.format(self.id): self.rx_discards_phy,
+            'dev_{0}_rx_bw'.format(self.id): self.rx_bw,
+            'dev_{0}_packets_lost'.format(self.id): self.rx_discards_phy,
         }
-
-def format_data(raw_data, name):
-    rx_bytes_received = 0
-    rx_discards_phy = 0
-    for line in raw_data :
-        if 'rx_bytes_phy' in line.split(':')[0] :
-            rx_bytes_received = line.split(':')[1]
-        if 'rx_discards_phy' in line.split(':')[0] :
-            rx_discards_phy = line.split(':')[1]
-    return Metrics(name, rx_bytes_received, rx_discards_phy)
 
 
 class Service(ExecutableService):
     def __init__(self, configuration=None, name=None):
         ExecutableService.__init__(self, configuration=configuration, name=name)
+        self.dev_filter = self.configuration.get('dev_filter','')
         self.order = list()
         self.definitions = dict()
         self.s = find_binary('sudo')
         self.ethtool = find_binary('ethtool')
         self.ethtool_info =  [self.ethtool, '-S']
         self.devices = self.find_devices()
+        self.last_update = 0
+        self.start_rx_bytes_received = 0
+        self.last_rx_bytes_received = 0
         
+
+        
+    def format_data(self, raw_data, name, last_update):
+        rx_bytes_received = 0
+        rx_discards_phy = 0
+        for line in raw_data :
+            if 'rx_bytes_phy' in line.split(':')[0] :
+                rx_bytes_received = int(line.split(':')[1])
+            if 'rx_discards_phy' in line.split(':')[0] :
+                rx_discards_phy = int(line.split(':')[1])
+
+        if self.last_update == 0 :
+            rx_bw = 0
+            self.start_rx_bytes_received = rx_bytes_received
+            self.debug('init rx bw and last update start rx bytes received {}'.format(self.start_rx_bytes_received))
+        else:
+            nb_sec = (last_update - self.last_update).total_seconds()
+            self.debug(' rx_bytes_received {0} last_rx_bytes_received {1} nb seconds {2}'.format(rx_bytes_received, self.last_rx_bytes_received, nb_sec))
+            rx_bw = int((rx_bytes_received - self.last_rx_bytes_received) / nb_sec)
+        self.last_rx_bytes_received = rx_bytes_received
+        self.last_update = last_update
+        toto = Metrics(name, self.last_rx_bytes_received, rx_bw, rx_discards_phy)
+        self.debug('last_rx_bytes_received {}'.format(self.last_rx_bytes_received))
+        self.debug('toto {}'.format(toto.data()))
+        return toto
+
     def find_devices(self):
-        #TODO implement method to find all devices
-        # for the moment hardcoded
-        ifconfig = find_binary('ifconfig')
-        command = [ifconfig, '-s']
+        ls = find_binary('ls')
+        command = [ls, '/sys/class/net']
         raw_data = self._get_raw_data(command=command)
-        device_names = []
-        for line in raw_data:
-            name = line.split()[0]
-            if name == 'Iface':
-                continue
-            elif name == "ens1f0":
-            # else :
-                device_names.append(name)
-        return device_names
+        device_names = [s.rstrip() for s in raw_data ]
+        devices_filtered = []
+        # Filter devices according to the parameter set in the conf file
+        if self.dev_filter:
+            for device in device_names:
+                if self.dev_filter in device :
+                    devices_filtered.append(device)
+        else:
+            devices_filtered = device_names
+
+        return devices_filtered
 
     def check(self):
         self.debug('------ check my ethtool service ')
@@ -148,9 +185,10 @@ class Service(ExecutableService):
         for d in self.devices:
             command = self.ethtool_info.copy()
             command.append(d)
+            current_time = datetime.datetime.now()
             raw_data = self._get_raw_data(command=command)
-            data.append(format_data(raw_data, d))
-            break # WIP
+            data.append(self.format_data(raw_data, d, current_time))
+            
 
         o, c = device_charts(data)
         self.order.extend(o)
@@ -158,16 +196,15 @@ class Service(ExecutableService):
         return True
 
     def get_ethtool_data(self):
+        self.debug('------ get_ethtool data my ethtool service ')
         data = dict()
 
         for d in self.devices:
             command = self.ethtool_info.copy()
             command.append(d)
-            start = datetime.datetime.now()
+            current_time = datetime.datetime.now()
             raw_data = self._get_raw_data(command=command)
-            end = datetime.datetime.now()
-            self.debug('------ Get raw data at {0} finish at {1} elapsed {2}'.format(start, end, end - start))
-            data.update(format_data(raw_data, d).data())
+            data.update(self.format_data(raw_data, d, current_time).data())
 
         return data
 

--- a/collectors/python.d.plugin/ethtool/ethtool.chart.py
+++ b/collectors/python.d.plugin/ethtool/ethtool.chart.py
@@ -60,25 +60,13 @@ def device_charts(devs):
     charts = dict()
 
     for d in devs:
-        order.append('dev_{0}_bytes_received'.format(d.id))
-        charts.update(
-            {
-                'dev_{0}_bytes_received'.format(d.id): {
-                    'options': [None, 'Bytes received', 'absolute', 'network_device',
-                                'ethtool.dev_bytes_received', 'line'],
-                    'lines': [
-                        ['dev_{0}_bytes_received'.format(d.id), 'device {0}'.format(d.id)],
-                    ]
-                }
-            }
-        )
+        fam = d.id
 
-    for d in devs:
         order.append('dev_{0}_rx_bw'.format(d.id))
         charts.update(
             {
                 'dev_{0}_rx_bw'.format(d.id): {
-                    'options': [None, 'Rx Bandwidth Bytes/sec', 'absolute', 'network_device',
+                    'options': [None, 'Rx Bandwidth Bytes/sec', 'absolute', fam,
                                 'ethtool.dev_rx_bandwidth', 'line'],
                     'lines': [
                         ['dev_{0}_rx_bw'.format(d.id), 'device {0}'.format(d.id)],
@@ -88,12 +76,11 @@ def device_charts(devs):
         )
 
 
-    for d in devs:
         order.append('dev_{0}_packets_lost'.format(d.id))
         charts.update(
             {
                 'dev_{0}_packets_lost'.format(d.id): {
-                    'options': [None, 'Lost packets', 'Lost packets', 'network_device', 'ethtool.packets_lost', 'line'],
+                    'options': [None, 'Lost packets', 'Lost packets', fam, 'ethtool.packets_lost', 'line'],
                     'lines': [
                         ['dev_{0}_packets_lost'.format(d.id), 'adapter {0}'.format(d.id)],
                     ]
@@ -105,15 +92,13 @@ def device_charts(devs):
 
 
 class Metrics:
-    def __init__(self, device_id, bytes_received, rx_bw, rx_discards_phy):
+    def __init__(self, device_id, rx_bw, rx_discards_phy):
         self.id = device_id
-        self.bytes_received = bytes_received
         self.rx_discards_phy = rx_discards_phy
         self.rx_bw = rx_bw
 
     def data(self):
         return {
-            'dev_{0}_bytes_received'.format(self.id): self.bytes_received,
             'dev_{0}_rx_bw'.format(self.id): self.rx_bw,
             'dev_{0}_packets_lost'.format(self.id): self.rx_discards_phy,
         }
@@ -154,7 +139,7 @@ class Service(ExecutableService):
             rx_bw = int((rx_bytes_received - self.last_rx_bytes_received) / nb_sec)
         self.last_rx_bytes_received = rx_bytes_received
         self.last_update = last_update
-        toto = Metrics(name, self.last_rx_bytes_received, rx_bw, rx_discards_phy)
+        toto = Metrics(name, rx_bw, rx_discards_phy)
         self.debug('last_rx_bytes_received {}'.format(self.last_rx_bytes_received))
         self.debug('toto {}'.format(toto.data()))
         return toto

--- a/collectors/python.d.plugin/ethtool/ethtool.conf
+++ b/collectors/python.d.plugin/ethtool/ethtool.conf
@@ -1,0 +1,68 @@
+# netdata python.d.plugin configuration for nvidia_smi
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# update_every: 1
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# penalty indicates whether to apply penalty to update_every in case of failures.
+# Penalty will increase every 5 failed updates in a row. Maximum penalty is 10 minutes.
+# penalty: yes
+
+# autodetection_retry sets the job re-check interval in seconds.
+# The job is not deleted if check fails.
+# Attempts to start the job are made once every autodetection_retry.
+# This feature is disabled by default.
+# autodetection_retry: 0
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname            # the JOB's name as it will appear at the
+#                             # dashboard (by default is the job_name)
+#                             # JOBs sharing a name are mutually exclusive
+#     update_every: 1         # the JOB's data collection frequency
+#     priority: 60000         # the JOB's order on the dashboard
+#     penalty: yes            # the JOB's penalty
+#     autodetection_retry: 0  # the JOB's re-check interval in seconds
+#
+# Additionally to the above, example also supports the following:
+#
+# loop_mode: yes/no                 # default is yes. If set to yes `nvidia-smi` is executed in a separate thread using `-l` option.
+# poll_seconds: SECONDS             # default is 1. Sets the frequency of seconds the nvidia-smi tool is polled in loop mode.
+# exclude_zero_memory_users: yes/no # default is no. Whether to collect users metrics with 0Mb memory allocation.
+#
+# ----------------------------------------------------------------------

--- a/collectors/python.d.plugin/ethtool/ethtool.conf
+++ b/collectors/python.d.plugin/ethtool/ethtool.conf
@@ -64,5 +64,8 @@
 # loop_mode: yes/no                 # default is yes. If set to yes `nvidia-smi` is executed in a separate thread using `-l` option.
 # poll_seconds: SECONDS             # default is 1. Sets the frequency of seconds the nvidia-smi tool is polled in loop mode.
 # exclude_zero_memory_users: yes/no # default is no. Whether to collect users metrics with 0Mb memory allocation.
+ethtool:
+    name: "Ethernet metrics"      # the JOB's name as it will appear on the dashboard
+    dev_filter: "enp66s"          # device filter to gather data only for devices that passes this filter
 #
 # ----------------------------------------------------------------------


### PR DESCRIPTION
##### Summary
Add an ethtool collector to retrieve especially the bandwidth of Mellanox boards. Indeed there was no existing plugin that supported the Mellanox connect-X5 or connect-X6. The ethtool tool gives the number of bytes received. Given this value the collector calculates the bandwidth in Gib/s and give also a percentage of the bandwidth used according to the capabilities of the board. Besides this collector provides also number of packet loss in reception and transmission. This could be useful to detect a bottleneck on a server.

##### Test Plan
This collector have been tested on a connect-X5 and connect-X6 on cent OS servers. As long as the ethtool is installed, this collector should give its metrics.


