### PR TITLE
Fix kernel test script

### DIFF
--- a/packaging/check-kernel-config.sh
+++ b/packaging/check-kernel-config.sh
@@ -62,7 +62,7 @@ if [ -n "${CONFIG_PATH}" ]; then
   for required_config in ${REQUIRED_CONFIG}; do
     # Fix issue https://github.com/netdata/netdata/issues/14668
     # if ! "${GREP}" -q "CONFIG_${required_config}=y" "${CONFIG_PATH}"; then
-    if "${CAT}" "${CONFIG_PATH}" | "${GREP}" -q "CONFIG_${required_config}=y" >&2 /dev/null ;then
+    if ! { "${CAT}" "${CONFIG_PATH}" | "${GREP}" -q "CONFIG_${required_config}=y" >&2 >/dev/null; } ;then
       echo >&2 " Missing Kernel Config: ${required_config}"
       exit 1
     fi

--- a/packaging/check-kernel-config.sh
+++ b/packaging/check-kernel-config.sh
@@ -51,15 +51,18 @@ fi
 
 if [ -n "${CONFIG_PATH}" ]; then
   GREP='grep'
+  CAT='cat'
 
   if echo "${CONFIG_PATH}" | grep -q '.gz'; then
-    GREP='zgrep'
+    CAT='zcat'
   fi
 
   REQUIRED_CONFIG="KPROBES KPROBES_ON_FTRACE HAVE_KPROBES BPF BPF_SYSCALL BPF_JIT"
 
   for required_config in ${REQUIRED_CONFIG}; do
-    if ! "${GREP}" -q "CONFIG_${required_config}=y" "${CONFIG_PATH}"; then
+    # Fix issue https://github.com/netdata/netdata/issues/14668
+    # if ! "${GREP}" -q "CONFIG_${required_config}=y" "${CONFIG_PATH}"; then
+    if "${CAT}" "${CONFIG_PATH}" | "${GREP}" -q "CONFIG_${required_config}=y" >&2 /dev/null ;then
       echo >&2 " Missing Kernel Config: ${required_config}"
       exit 1
     fi


### PR DESCRIPTION
##### Summary
Fixes https://github.com/netdata/netdata/issues/14668

This PR is fixing current bug reported when script run on `Gentoo Linux`.

##### Test Plan

1. Verify `shellcheck` is not reporting error on CI.
2. Compile on your system and check that you do not have warnings.

##### Additional Information
This PR addresses only installation, so it is not necessary to test on different kernels, neither to take a look on charts.

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? Installer
- Can they see the change or is it an under the hood? If they can see it, where? During installation on Gentoo.
- How is the user impacted by the change? On `Gentoo` users won't have issue to install. 
- What are there any benefits of the change? A better support on distribution where issues where happening.
</details>