### PR TITLE
Fix conditionals for claim-only case in kickstart.sh.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -959,9 +959,9 @@ handle_existing_install() {
           failmsg="We do not support trying to update or claim installations when we cannot determine the install type. You will need to uninstall the existing install using the same method you used to install it to proceed. ${claimonly_notice}"
           promptmsg="Attempting to update an existing install is not officially supported. It may work, but it also might break your system. ${claimonly_notice} Are you sure you want to continue?"
         fi
-        if [ "${INTERACTIVE}" -eq 0 ] && [ "${NETDATA_CLAIM_ONLY}" -eq 0 ]; then
+        if [ "${INTERACTIVE}" -eq 0 ] && [ "${ACTION}" != "claim" ]; then
           fatal "${failmsg}" F0106
-        elif [ "${INTERACTIVE}" -eq 1 ] && [ "${NETDATA_CLAIM_ONLY}" -eq 0 ]; then
+        elif [ "${INTERACTIVE}" -eq 1 ] && [ "${ACTION}" != "claim" ]; then
           if confirm "${promptmsg}"; then
             progress "OK, continuing"
           else


### PR DESCRIPTION
##### Summary

These should have been updated as part of #13896, but somehow got missed there.

##### Test Plan

Run the kickstart script interactively on a system with an existing install.

Without this PR, the output should include a line with a message like `kickstart.sh: 964: [: Illegal number:`

With this PR, that line should be absent.

##### Additional Information

Based on a report from @shyamvalsan on Slack.