### PR TITLE
Send an EOF from charts.d.plugin before exit

### DIFF
--- a/collectors/charts.d.plugin/charts.d.plugin.in
+++ b/collectors/charts.d.plugin/charts.d.plugin.in
@@ -32,6 +32,7 @@ chartsd_cleanup() {
 		[ $debug -eq 1 ] && echo >&2 "$PROGRAM_NAME: cleaning up temporary directory $TMP_DIR ..."
 		rm -rf "$TMP_DIR"
 	fi
+	echo "EOF"
 	exit 0
 }
 trap chartsd_cleanup EXIT QUIT HUP INT TERM

--- a/collectors/charts.d.plugin/charts.d.plugin.in
+++ b/collectors/charts.d.plugin/charts.d.plugin.in
@@ -32,7 +32,7 @@ chartsd_cleanup() {
 		[ $debug -eq 1 ] && echo >&2 "$PROGRAM_NAME: cleaning up temporary directory $TMP_DIR ..."
 		rm -rf "$TMP_DIR"
 	fi
-	echo "EOF"
+	echo ""
 	exit 0
 }
 trap chartsd_cleanup EXIT QUIT HUP INT TERM

--- a/collectors/charts.d.plugin/charts.d.plugin.in
+++ b/collectors/charts.d.plugin/charts.d.plugin.in
@@ -32,7 +32,7 @@ chartsd_cleanup() {
 		[ $debug -eq 1 ] && echo >&2 "$PROGRAM_NAME: cleaning up temporary directory $TMP_DIR ..."
 		rm -rf "$TMP_DIR"
 	fi
-	echo ""
+	echo "EXIT"
 	exit 0
 }
 trap chartsd_cleanup EXIT QUIT HUP INT TERM

--- a/collectors/plugins.d/plugins_d.h
+++ b/collectors/plugins.d/plugins_d.h
@@ -43,6 +43,8 @@
 #define PLUGINSD_KEYWORD_HOST_LABEL             "HOST_LABEL"
 #define PLUGINSD_KEYWORD_HOST                   "HOST"
 
+#define PLUGINSD_KEYWORD_EXIT                   "EXIT"
+
 #define PLUGINS_FUNCTIONS_TIMEOUT_DEFAULT 10 // seconds
 
 #define PLUGINSD_LINE_MAX_SSL_READ 512

--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -1901,6 +1901,12 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp_plugi
     return count;
 }
 
+PARSER_RC pluginsd_exit(char **words __maybe_unused, size_t num_words __maybe_unused, void *user __maybe_unused)
+{
+    info("PLUGINSD: plugin called EXIT.");
+    return PARSER_RC_STOP;
+}
+
 static void pluginsd_keywords_init_internal(PARSER *parser, PLUGINSD_KEYWORDS types, void (*add_func)(PARSER *parser, char *keyword, keyword_function func)) {
 
     if (types & PARSER_INIT_PLUGINSD) {
@@ -1911,6 +1917,8 @@ static void pluginsd_keywords_init_internal(PARSER *parser, PLUGINSD_KEYWORDS ty
         add_func(parser, PLUGINSD_KEYWORD_HOST_DEFINE_END, pluginsd_host_define_end);
         add_func(parser, PLUGINSD_KEYWORD_HOST_LABEL, pluginsd_host_labels);
         add_func(parser, PLUGINSD_KEYWORD_HOST, pluginsd_host);
+
+        add_func(parser, PLUGINSD_KEYWORD_EXIT, pluginsd_exit);
     }
 
     if (types & (PARSER_INIT_PLUGINSD | PARSER_INIT_STREAMING)) {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #14531 

This PR adds a last will EOF when a charts.d.plugin script exits.

It appears that under some cases, `fgets` in parser will trigger at the exact moment the script is asked to exit, cleans up `/tmp` and exits. `fgets` then will wait forever. The EOF here just makes sure `fgets` will receive something before the script exits.

The issue is more apparent when there are a lot of different charts.d.plugin scripts that are restarted at the same time.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Many many thanks to @vobruba-martin for helping with this!!

Not really easy to reproduce. We've tested this on @vobruba-martin's setup and it seems to fix the issue. I don't expect it to cause any side effects, but for testing, e.g. the example charts.d.plugin, make sure it restart correctly.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
