### PR TITLE
Fix platform EOL checks to properly return success.

### DIFF
--- a/.github/scripts/platform-impending-eol.py
+++ b/.github/scripts/platform-impending-eol.py
@@ -22,17 +22,27 @@ EXIT_IMPENDING = 1
 EXIT_NO_DATA = 2
 EXIT_FAILURE = 3
 
-with urllib.request.urlopen(f'{ URL_BASE }/{ DISTRO }/{ RELEASE }.json') as response:
-    match response.status:
-        case 200:
-            data = json.load(response)
+try:
+    with urllib.request.urlopen(f'{ URL_BASE }/{ DISTRO }/{ RELEASE }.json') as response:
+        match response.status:
+            case 200:
+                data = json.load(response)
+            case _:
+                print(
+                    f'Failed to retrieve data for { DISTRO } { RELEASE } ' +
+                    f'(status: { response.status }).',
+                    file=sys.stderr
+                )
+                sys.exit(EXIT_FAILURE)
+except urllib.error.HTTPError as e:
+    match e.code:
         case 404:
             print(f'No data available for { DISTRO } { RELEASE }.', file=sys.stderr)
             sys.exit(EXIT_NO_DATA)
         case _:
             print(
                 f'Failed to retrieve data for { DISTRO } { RELEASE } ' +
-                f'(status: { response.status }).',
+                f'(status: { e.code }).',
                 file=sys.stderr
             )
             sys.exit(EXIT_FAILURE)

--- a/.github/workflows/platform-eol-check.yml
+++ b/.github/workflows/platform-eol-check.yml
@@ -50,6 +50,7 @@ jobs:
       # Actually check the EOL date for the platform.
       - name: Check EOL Date
         id: check
+        shell: sh {0}
         run: |
           d="$(.github/scripts/platform-impending-eol.py ${{ matrix.distro }} ${{ matrix.release }})"
           case $? in


### PR DESCRIPTION
##### Summary

- Handle error cases correctly in the Python script.
- Don’t run with `set -e` for the actual check step, because we need the exit code passed on correctly to interpret the output.

##### Test Plan

n/a