### PR TITLE
Fix Azure IMDS

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -468,11 +468,11 @@ if [ "${VIRTUALIZATION}" != "none" ] && command -v curl > /dev/null 2>&1; then
 
     # Try Azure IMDS
     if [ "${CLOUD_TYPE}" = "unknown" ]; then
-      AZURE_IMDS_DATA="$(curl --fail -s --connect-timeout 1 -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-10-01")"
+      AZURE_IMDS_DATA="$(curl --fail -s --connect-timeout 1 -m 3 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-10-01")"
       if [ -n "${AZURE_IMDS_DATA}" ]; then
         CLOUD_TYPE="Azure"
-        CLOUD_INSTANCE_TYPE="$(curl --fail -s --connect-timeout 1 -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2021-10-01&format=text")"
-        CLOUD_INSTANCE_REGION="$(curl --fail -s --connect-timeout 1 -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance/compute/location?api-version=2021-10-01&format=text")"
+        CLOUD_INSTANCE_TYPE="$(curl --fail -s --connect-timeout 1 -m 3 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2021-10-01&format=text")"
+        CLOUD_INSTANCE_REGION="$(curl --fail -s --connect-timeout 1 -m 3 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance/compute/location?api-version=2021-10-01&format=text")"
       fi
     fi
   fi

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -466,7 +466,6 @@ if [ "${VIRTUALIZATION}" != "none" ] && command -v curl > /dev/null 2>&1; then
       fi
     fi
 
-    # TODO: needs to be tested in Microsoft Azure
     # Try Azure IMDS
     if [ "${CLOUD_TYPE}" = "unknown" ]; then
       AZURE_IMDS_DATA="$(curl --fail -s --connect-timeout 1 -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-10-01")"

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -469,11 +469,11 @@ if [ "${VIRTUALIZATION}" != "none" ] && command -v curl > /dev/null 2>&1; then
     # TODO: needs to be tested in Microsoft Azure
     # Try Azure IMDS
     if [ "${CLOUD_TYPE}" = "unknown" ]; then
-      AZURE_IMDS_DATA="$(curl --fail -s -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-10-01")"
+      AZURE_IMDS_DATA="$(curl --fail -s --connect-timeout 1 -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-10-01")"
       if [ -n "${AZURE_IMDS_DATA}" ]; then
         CLOUD_TYPE="Azure"
-        CLOUD_INSTANCE_TYPE="$(curl --fail -s -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2021-10-01&format=text")"
-        CLOUD_INSTANCE_REGION="$(curl --fail -s -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance/compute/location?api-version=2021-10-01&format=text")"
+        CLOUD_INSTANCE_TYPE="$(curl --fail -s --connect-timeout 1 -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2021-10-01&format=text")"
+        CLOUD_INSTANCE_REGION="$(curl --fail -s --connect-timeout 1 -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance/compute/location?api-version=2021-10-01&format=text")"
       fi
     fi
   fi

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -468,14 +468,14 @@ if [ "${VIRTUALIZATION}" != "none" ] && command -v curl > /dev/null 2>&1; then
 
     # TODO: needs to be tested in Microsoft Azure
     # Try Azure IMDS
-    # if [ "${CLOUD_TYPE}" = "unknown" ]; then
-    #   AZURE_IMDS_DATA="$(curl --fail -s -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance?version=2021-10-01")"
-    #   if [ -n "${AZURE_IMDS_DATA}" ]; then
-    #     CLOUD_TYPE="Azure"
-    #     CLOUD_INSTANCE_TYPE="$(curl --fail -s -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance/compute/vmSize?version=2021-10-01&format=text")"
-    #     CLOUD_INSTANCE_REGION="$(curl --fail -s -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance/compute/location?version=2021-10-01&format=text")"
-    #   fi
-    # fi
+    if [ "${CLOUD_TYPE}" = "unknown" ]; then
+      AZURE_IMDS_DATA="$(curl --fail -s -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-10-01")"
+      if [ -n "${AZURE_IMDS_DATA}" ]; then
+        CLOUD_TYPE="Azure"
+        CLOUD_INSTANCE_TYPE="$(curl --fail -s -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2021-10-01&format=text")"
+        CLOUD_INSTANCE_REGION="$(curl --fail -s -m 5 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance/compute/location?api-version=2021-10-01&format=text")"
+      fi
+    fi
   fi
 fi
 


### PR DESCRIPTION
##### Summary
Fix Azure IMDS to ensure Netdata can detect that it is an Azure instance and the flavor and region

##### Test Plan

Tested locally on an Azure instance

```
NETDATA_INSTANCE_CLOUD_TYPE=Azure
NETDATA_INSTANCE_CLOUD_INSTANCE_TYPE=Standard_B1s
NETDATA_INSTANCE_CLOUD_INSTANCE_REGION=northeurope
```

##### Additional Information

Describe the PR affects users: 
- Which area of Netdata is affected by the change? 

The node is displayed as Azure cloud node with the respective flavor on Netdata UI

- Can they see the change or is it an under the hood? If they can see it, where?

On the Netdata UI, in the nodes tab

- How is the user impacted by the change? 

The user now gets more information about the node

- What are there any benefits of the change? 

Same answer as above.
