### PR TITLE
fix: detect the host os in k8s on non-docker cri

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -96,6 +96,11 @@ if [ "${CONTAINER}" = "unknown" ]; then
     CONT_DETECTION="dockerenv"
   fi
 
+  if [ -n "${KUBERNETES_SERVICE_HOST}" ]; then
+    CONTAINER="container"
+    CONT_DETECTION="kubernetes"
+  fi
+
 fi
 
 # -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary

After migration to Kubernetes CRI containerd netdata-child no longer correctly detects the host OS. It ends up with a situation in that I'm having a host OS like `Alpine Linux` instead of `Amazon Linux`:

<img width="277" alt="image" src="https://user-images.githubusercontent.com/14999928/224027119-2c315962-766c-473a-8b8b-f178525e5f2d.png">


As a solution is to provide detection that the container is running in Kubernetes, it allows you to detect the host OS even running in different Kubernetes CRI.

##### Test Plan

n/a

##### Additional Information

n/a
