### PR TITLE
Handle conffiles for DEB packages explicitly instead of automatically.

### DIFF
--- a/contrib/debian/conffiles
+++ b/contrib/debian/conffiles
@@ -1,0 +1,4 @@
+/etc/default/netdata
+/etc/init.d/netdata
+/etc/logrotate.d/netdata
+/etc/netdata/netdata.conf

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -127,6 +127,11 @@ override_dh_installlogrotate:
 	cp system/logrotate/netdata debian/netdata.logrotate
 	dh_installlogrotate
 
+override_dh_installdeb:
+	dh_installdeb
+	@echo "Recreating conffiles without auto-adding /etc files"
+	@cp $(CURDIR)/debian/conffiles $(CURDIR)/debian/netdata/DEBIAN/conffiles
+
 override_dh_clean:
 	dh_clean
 


### PR DESCRIPTION
##### Summary

By default, DEB package tooling blindly assumes that any files under `/etc` are configuration files and thus should be handled specially during updates and removals. This is usually correct behavior, but we install a couple of things in `/etc/netdata` for convenience reasons that should not be handled this way, so we need to override this behavior and explicitly specify the list of files to treat as config files.

This is the second attempt at fixing this, as the previous one broke things horribly.

##### Test Plan

1. [Build native packages locally](https://github.com/netdata/netdata/blob/master/packaging/building-native-packages-locally.md) for your test environment.
2. Run the following steps in a clean test environment to confirm that files that should not be conffiles are not in fact conffiles:
    1. Install the netdata package from step 1 in a clean test environment.
    2. Uninstall the netdata package _without_ using `apt-get purge` or the `--purge` option.
    3. Manually remove `/etc/netdata`.
    4. Install the netdata package from step 1 again.
    5. Confirm that `/etc/netdata/.install-type` and `/etc/netdata/edit-config` exist.
3. Run the following steps in a clean test environment to confirm that files that should be confifiles are in fact conffiles:
    1. Install the netdata package from step 1 in a clean test environment.
    2. Edit `/etc/netdata/netdata.conf`.
    3. Reinstall the netdata package from step 1.
    4. Confirm that the changes made to `/etc/netdata/netdata.conf` are still there.

Without the changes in this PR, the first test case outlined above should fail, while the second should pass.

With the changes in this PR, both of the test cases outlined above should pass.

Additional testing can be done by inspecting the `conffiles` file in the control archive within the DEB package built in step 1 above (the package can be split out into the control and data archives by running `ar x` on it, the relevant file will be in the `control` archive file that this extracts from the package). It’s contents should exactly match the contents of `contrib/debian/conffiles` from the source tree.

##### Additional Information

Fixes: #13732 