### PR TITLE
Don’t try to use tput in edit-config unless it’s installed.

### DIFF
--- a/system/edit-config
+++ b/system/edit-config
@@ -163,7 +163,7 @@ list_files() {
   check_directories
   handle_container
 
-  if test -t; then
+  if test -t && command -v tput > /dev/null 2>&1; then
     width="$(tput cols)"
   fi
 


### PR DESCRIPTION
##### Summary

This allows `edit-config --list` to work if there is no usable `tput` command.

##### Test Plan

This can be tested by attempting to run `edit-config --list` in an environment that does not have ncurses installed. This is likely most easily done by installing a static build in an Alpine container, and manually copying in the `edit-config` script form this PR for testing.

Using the version of the `edit-config` script in the master branch, running `edit-config --list` will fail in such an environment.

With the changes in this PR, it should instead work, but will only list the config files in one column instead of using multiple columns based on the terminal size.

##### Additional Information

Issue originally reported by @cakrit on Slack.