### PR TITLE
Sync dashboards

### DIFF
--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -586,26 +586,32 @@ netdataDashboard.menu = {
     },
 
     'mssql': {
-        title: 'MS SQL Server',
+        title: 'SQL Server',
         icon: '<i class="fas fa-database"></i>',
         info: undefined
     },
 
     'ad': {
-        title: 'AD Domain Service',
+        title: 'Active Directory',
         icon: '<i class="fab fa-windows"></i>',
         info: undefined
     },
 
     'adcs': {
-        title: 'AD Certification Service',
+        title: 'Certification Service',
         icon: '<i class="fab fa-windows"></i>',
         info: undefined
     },
 
     'adfs': {
-        title: 'AD Federation Service',
+        title: 'Federation Service',
         icon: '<i class="fab fa-windows"></i>',
+        info: undefined
+    },
+
+    'exchange': {
+        title: 'Exchange',
+        icon: '<i class="fab envelope"></i>',
         info: undefined
     },
 


### PR DESCRIPTION
##### Summary
This PR is syncing local dashboard with current cloud dashboard (https://github.com/netdata/cloud-frontend/pull/4082).

##### Test Plan
1. Copy this file for a host that is monitoring Exchange and reload local dashboard.

##### Additional Information


<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? Dashboard
- Can they see the change or is it an under the hood? If they can see it, where? Only when they are using `go.d.plugin` and monitoring a windows host.
- How is the user impacted by the change?  It should not have a direct impact.
- What are there any benefits of the change? When users access local dashboard they will have same names used with cloud dashbooard.
</details>