### PR TITLE
Fix infinite redirection loop

### DIFF
--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1307,7 +1307,7 @@ static inline int web_client_switch_host(RRDHOST *host, struct web_client *w, ch
             protocol = "http";
 #endif
             url_host = (!w->forwarded_host[0])?w->server_host:w->forwarded_host;
-            buffer_sprintf(w->response.header, "Location: %s://%s%s/\r\n", protocol, url_host, w->last_url);
+            buffer_sprintf(w->response.header, "Location: %s://%s%s/%s\r\n", protocol, url_host, w->decoded_url, w->decoded_query_string);
             buffer_strcat(w->response.data, "Permanent redirect");
             return HTTP_RESP_REDIR_PERM;
         }


### PR DESCRIPTION
##### Summary

Fixes infinite redirection loop when user is trying to browse an URL like:
`https://parent.netdata.host/host/child.netdata.host?`

##### Test Plan

0. Set up a pair of parent and child (streaming) netdata hosts with self-hosted dashboard.
1. Try to open child node's page at the parent node's dashboard using an URL that contains query string but no ending slash: `https://parent.netdata.host/host/child.netdata.host?`
2. Make sure that previous step doesn't cause infinite redirection loop.

##### Additional Information

I've managed to open mentioned URL when I was trying to get the "Visited Nodes" in self-hosted dashboard to work properly (_the `/api/v1/info` request when clicking any node out of the "Visited Nodes" lacks `XMLHttpRequest.withCredentials` and doesn't keep the authorization, but that's an another issue_) and netdata sent me to the infinite loop of adding ending slashes:
```
https://parent.netdata.host/host/child.netdata.host?
https://parent.netdata.host/host/child.netdata.host?/
https://parent.netdata.host/host/child.netdata.host?//
https://parent.netdata.host/host/child.netdata.host?///
https://parent.netdata.host/host/child.netdata.host?////
(and so on)
```

The solution is adding the ending slash to the actual URL path instead of putting it after the full URL that could contain the query path.

<details> <summary>For users: How does this change affect me?</summary>
This PR prevents users from getting stuck in an infinite redirection loop.
</details>
