### PR TITLE
Change H1 of collector docs to separate from the website

### DIFF
--- a/collectors/charts.d.plugin/ap/README.md
+++ b/collectors/charts.d.plugin/ap/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Remotes/Devices"
 -->
 
-# Access point monitoring with Netdata
+# Access point collector
 
 The `ap` collector visualizes data related to access points.
 

--- a/collectors/charts.d.plugin/apcupsd/README.md
+++ b/collectors/charts.d.plugin/apcupsd/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Remotes/Devices"
 -->
 
-# APC UPS monitoring with Netdata
+# APC UPS collector
 
 Monitors different APC UPS models and retrieves status information using `apcaccess` tool.
 

--- a/collectors/charts.d.plugin/libreswan/README.md
+++ b/collectors/charts.d.plugin/libreswan/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Networking"
 -->
 
-# Libreswan IPSec tunnel monitoring with Netdata
+# Libreswan IPSec tunnel collector
 
 Collects bytes-in, bytes-out and uptime for all established libreswan IPSEC tunnels.
 

--- a/collectors/charts.d.plugin/nut/README.md
+++ b/collectors/charts.d.plugin/nut/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Remotes/Devices"
 -->
 
-# UPS/PDU monitoring with Netdata
+# UPS/PDU collector
 
 Collects UPS data for all power devices configured in the system.
 

--- a/collectors/charts.d.plugin/opensips/README.md
+++ b/collectors/charts.d.plugin/opensips/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Networking"
 -->
 
-# OpenSIPS monitoring with Netdata
+# OpenSIPS collector
 
 ## Configuration
 

--- a/collectors/charts.d.plugin/sensors/README.md
+++ b/collectors/charts.d.plugin/sensors/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Devices"
 -->
 
-# Linux machine sensors monitoring with Netdata
+# Linux machine sensors collector
 
 Use this collector when `lm-sensors` doesn't work on your device (e.g. for RPi temperatures). 
 For all other cases use the [Python collector](https://github.com/netdata/netdata/blob/master/collectors/python.d.plugin/sensors), which supports multiple 

--- a/collectors/ebpf.plugin/README.md
+++ b/collectors/ebpf.plugin/README.md
@@ -8,7 +8,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/System metrics"
 -->
 
-# Kernel traces/metrics (eBPF) monitoring with Netdata
+# Kernel traces/metrics (eBPF) collector
 
 The Netdata Agent provides many [eBPF](https://ebpf.io/what-is-ebpf/) programs to help you troubleshoot and debug how applications interact with the Linux kernel. The `ebpf.plugin` uses [tracepoints, trampoline, and2 kprobes](#how-netdata-collects-data-using-probes-and-tracepoints) to collect a wide array of high value data about the host that would otherwise be impossible to capture. 
 

--- a/collectors/python.d.plugin/adaptec_raid/README.md
+++ b/collectors/python.d.plugin/adaptec_raid/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Hardware"
 -->
 
-# Adaptec RAID controller monitoring with Netdata
+# Adaptec RAID controller collector
 
 Collects logical and physical devices metrics using `arcconf` command-line utility.
 

--- a/collectors/python.d.plugin/beanstalk/README.md
+++ b/collectors/python.d.plugin/beanstalk/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Message brokers"
 -->
 
-# Beanstalk monitoring with Netdata
+# Beanstalk collector
 
 Provides server and tube-level statistics.
 

--- a/collectors/python.d.plugin/bind_rndc/README.md
+++ b/collectors/python.d.plugin/bind_rndc/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# ISC Bind monitoring with Netdata
+# ISC Bind collector
 
 Collects Name server summary performance statistics using `rndc` tool.
 

--- a/collectors/python.d.plugin/boinc/README.md
+++ b/collectors/python.d.plugin/boinc/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Distributed computing"
 -->
 
-# BOINC monitoring with Netdata
+# BOINC collector
 
 Monitors task counts for the Berkeley Open Infrastructure Networking Computing (BOINC) distributed computing client using the same RPC interface that the BOINC monitoring GUI does.
 

--- a/collectors/python.d.plugin/ceph/README.md
+++ b/collectors/python.d.plugin/ceph/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Storage"
 -->
 
-# CEPH monitoring with Netdata
+# CEPH collector
 
 Monitors the ceph cluster usage and consumption data of a server, and produces:
 

--- a/collectors/python.d.plugin/dovecot/README.md
+++ b/collectors/python.d.plugin/dovecot/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# Dovecot monitoring with Netdata
+# Dovecot collector
 
 Provides statistics information from Dovecot server.
 

--- a/collectors/python.d.plugin/exim/README.md
+++ b/collectors/python.d.plugin/exim/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# Exim monitoring with Netdata
+# Exim collector
 
 Simple module executing `exim -bpc` to grab exim queue.
 This command can take a lot of time to finish its execution thus it is not recommended to run it every second.

--- a/collectors/python.d.plugin/fail2ban/README.md
+++ b/collectors/python.d.plugin/fail2ban/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Apps"
 -->
 
-# Fail2ban monitoring with Netdata
+# Fail2ban collector
 
 Monitors the fail2ban log file to show all bans for all active jails.
 

--- a/collectors/python.d.plugin/gearman/README.md
+++ b/collectors/python.d.plugin/gearman/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Distributed computing"
 -->
 
-# Gearman monitoring with Netdata
+# Gearman collector
 
 Monitors Gearman worker statistics. A chart is shown for each job as well as one showing a summary of all workers.
 

--- a/collectors/python.d.plugin/go_expvar/README.md
+++ b/collectors/python.d.plugin/go_expvar/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Application Performance Monitoring"
 -->
 
-# Go applications monitoring with Netdata
+# Go applications collector
 
 Monitors Go application that exposes its metrics with the use of `expvar` package from the Go standard library.  The package produces charts for Go runtime memory statistics and optionally any number of custom charts.
 

--- a/collectors/python.d.plugin/haproxy/README.md
+++ b/collectors/python.d.plugin/haproxy/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# HAProxy monitoring with Netdata
+# HAProxy collector
 
 Monitors frontend and backend metrics such as bytes in, bytes out, sessions current, sessions in queue current.
 And health metrics such as backend servers status (server check should be used).

--- a/collectors/python.d.plugin/hddtemp/README.md
+++ b/collectors/python.d.plugin/hddtemp/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Hardware"
 -->
 
-# Hard drive temperature monitoring with Netdata
+# Hard drive temperature collector
 
 Monitors disk temperatures from one or more `hddtemp` daemons.
 

--- a/collectors/python.d.plugin/hpssa/README.md
+++ b/collectors/python.d.plugin/hpssa/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Storage"
 -->
 
-# HP Smart Storage Arrays monitoring with Netdata
+# HP Smart Storage Arrays collector
 
 Monitors controller, cache module, logical and physical drive state and temperature using `ssacli` tool.
 

--- a/collectors/python.d.plugin/icecast/README.md
+++ b/collectors/python.d.plugin/icecast/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Networking"
 -->
 
-# Icecast monitoring with Netdata
+# Icecast collector
 
 Monitors the number of listeners for active sources.
 

--- a/collectors/python.d.plugin/ipfs/README.md
+++ b/collectors/python.d.plugin/ipfs/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Storage"
 -->
 
-# IPFS monitoring with Netdata
+# IPFS collector
 
 Collects [`IPFS`](https://ipfs.io) basic information like file system bandwidth, peers and repo metrics.
 

--- a/collectors/python.d.plugin/litespeed/README.md
+++ b/collectors/python.d.plugin/litespeed/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Application Performance Monitoring"
 -->
 
-# LiteSpeed monitoring with Netdata
+# LiteSpeed collector
 
 Collects web server performance metrics for network, connection, requests, and cache.  
 

--- a/collectors/python.d.plugin/megacli/README.md
+++ b/collectors/python.d.plugin/megacli/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Devices"
 -->
 
-# MegaRAID controller monitoring with Netdata
+# MegaRAID controller collector
 
 Collects adapter, physical drives and battery stats using `megacli` command-line tool.
 

--- a/collectors/python.d.plugin/memcached/README.md
+++ b/collectors/python.d.plugin/memcached/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Databases"
 -->
 
-# Memcached monitoring with Netdata
+# Memcached collector
 
 Collects memory-caching system performance metrics. It reads server response to stats command ([stats interface](https://github.com/memcached/memcached/wiki/Commands#stats)).
 

--- a/collectors/python.d.plugin/monit/README.md
+++ b/collectors/python.d.plugin/monit/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Storage"
 -->
 
-# Monit monitoring with Netdata
+# Monit collector
 
 Monit monitoring module. Data is grabbed from stats XML interface (exists for a long time, but not mentioned in official
 documentation). Mostly this plugin shows statuses of monit targets, i.e.

--- a/collectors/python.d.plugin/nsd/README.md
+++ b/collectors/python.d.plugin/nsd/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Networking"
 -->
 
-# NSD monitoring with Netdata
+# NSD collector
 
 Uses the `nsd-control stats_noreset` command to provide `nsd` statistics.
 

--- a/collectors/python.d.plugin/nvidia_smi/README.md
+++ b/collectors/python.d.plugin/nvidia_smi/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Devices"
 -->
 
-# Nvidia GPU monitoring with Netdata
+# Nvidia GPU collector
 
 Monitors performance metrics (memory usage, fan speed, pcie bandwidth utilization, temperature, etc.) using `nvidia-smi` cli tool.
 

--- a/collectors/python.d.plugin/openldap/README.md
+++ b/collectors/python.d.plugin/openldap/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Networking"
 -->
 
-# OpenLDAP monitoring with Netdata
+# OpenLDAP collector
 
 Provides statistics information from openldap (slapd) server.
 Statistics are taken from LDAP monitoring interface. Manual page, slapd-monitor(5) is available.

--- a/collectors/python.d.plugin/oracledb/README.md
+++ b/collectors/python.d.plugin/oracledb/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Databases"
 -->
 
-# OracleDB monitoring with Netdata
+# OracleDB collector
 
 Monitors the performance and health metrics of the Oracle database.
 

--- a/collectors/python.d.plugin/postfix/README.md
+++ b/collectors/python.d.plugin/postfix/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# Postfix monitoring with Netdata
+# Postfix collector
 
 Monitors MTA email queue statistics using [postqueue](http://www.postfix.org/postqueue.1.html) tool.
 

--- a/collectors/python.d.plugin/puppet/README.md
+++ b/collectors/python.d.plugin/puppet/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Provisioning tools"
 -->
 
-# Puppet monitoring with Netdata
+# Puppet collector
 
 Monitor status of Puppet Server and Puppet DB.
 

--- a/collectors/python.d.plugin/rethinkdbs/README.md
+++ b/collectors/python.d.plugin/rethinkdbs/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Databases"
 -->
 
-# RethinkDB monitoring with Netdata
+# RethinkDB collector
 
 Collects database server and cluster statistics.
 

--- a/collectors/python.d.plugin/retroshare/README.md
+++ b/collectors/python.d.plugin/retroshare/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Apm"
 -->
 
-# RetroShare monitoring with Netdata
+# RetroShare collector
 
 Monitors application bandwidth, peers and DHT metrics. 
 

--- a/collectors/python.d.plugin/riakkv/README.md
+++ b/collectors/python.d.plugin/riakkv/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Databases"
 -->
 
-# Riak KV monitoring with Netdata
+# Riak KV collector
 
 Collects database stats from `/stats` endpoint.
 

--- a/collectors/python.d.plugin/samba/README.md
+++ b/collectors/python.d.plugin/samba/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Apps"
 -->
 
-# Samba monitoring with Netdata
+# Samba collector
 
 Monitors the performance metrics of Samba file sharing using `smbstatus` command-line tool.
 

--- a/collectors/python.d.plugin/sensors/README.md
+++ b/collectors/python.d.plugin/sensors/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Devices"
 -->
 
-# Linux machine sensors monitoring with Netdata
+# Linux machine sensors collector
 
 Reads system sensors information (temperature, voltage, electric current, power, etc.).
 

--- a/collectors/python.d.plugin/smartd_log/README.md
+++ b/collectors/python.d.plugin/smartd_log/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Devices"
 -->
 
-# Storage devices monitoring with Netdata
+# Storage devices collector
 
 Monitors `smartd` log files to collect HDD/SSD S.M.A.R.T attributes.
 

--- a/collectors/python.d.plugin/spigotmc/README.md
+++ b/collectors/python.d.plugin/spigotmc/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# SpigotMC monitoring with Netdata
+# SpigotMC collector
 
 Performs basic monitoring for Spigot Minecraft servers.
 

--- a/collectors/python.d.plugin/squid/README.md
+++ b/collectors/python.d.plugin/squid/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# Squid monitoring with Netdata
+# Squid collector
 
 Monitors one or more squid instances depending on configuration.
 

--- a/collectors/python.d.plugin/tomcat/README.md
+++ b/collectors/python.d.plugin/tomcat/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# Apache Tomcat monitoring with Netdata
+# Apache Tomcat collector
 
 Presents memory utilization of tomcat containers.
 

--- a/collectors/python.d.plugin/tor/README.md
+++ b/collectors/python.d.plugin/tor/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Apps"
 -->
 
-# Tor monitoring with Netdata
+# Tor collector
 
 Connects to the Tor control port to collect traffic statistics.
 

--- a/collectors/python.d.plugin/traefik/README.md
+++ b/collectors/python.d.plugin/traefik/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# Traefik monitoring with Netdata
+# Traefik collector
 
 Uses the `health` API to provide statistics.
 

--- a/collectors/python.d.plugin/uwsgi/README.md
+++ b/collectors/python.d.plugin/uwsgi/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# uWSGI monitoring with Netdata
+# uWSGI collector
 
 Monitors performance metrics exposed by [`Stats Server`](https://uwsgi-docs.readthedocs.io/en/latest/StatsServer.html).
 

--- a/collectors/python.d.plugin/varnish/README.md
+++ b/collectors/python.d.plugin/varnish/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Webapps"
 -->
 
-# Varnish Cache monitoring with Netdata
+# Varnish Cache collector
 
 Provides HTTP accelerator global, Backends (VBE) and Storages (SMF, SMA, MSE) statistics using `varnishstat` tool.
 

--- a/collectors/python.d.plugin/w1sensor/README.md
+++ b/collectors/python.d.plugin/w1sensor/README.md
@@ -7,7 +7,7 @@ learn_topic_type: "References"
 learn_rel_path: "Integrations/Monitor/Remotes/Devices"
 -->
 
-# 1-Wire Sensors monitoring with Netdata
+# 1-Wire Sensors collector
 
 Monitors sensor temperature.
 

--- a/collectors/statsd.plugin/asterisk.md
+++ b/collectors/statsd.plugin/asterisk.md
@@ -6,7 +6,7 @@ learn_status: "Published"
 learn_rel_path: "Integrations/Monitor/VoIP"
 -->
 
-# Asterisk monitoring with Netdata
+# Asterisk collector
 
 Monitors [Asterisk](https://www.asterisk.org/) dialplan application's statistics.
 

--- a/collectors/statsd.plugin/k6.md
+++ b/collectors/statsd.plugin/k6.md
@@ -6,7 +6,7 @@ learn_status: "Published"
 learn_rel_path: "Integrations/Monitor/apps"
 -->
 
-# K6 load test monitoring with Netdata
+# K6 load test collector
 
 Monitors the impact of load testing experiments performed with [K6](https://k6.io/).
 


### PR DESCRIPTION
"XYZ monitoring with Netdata" is now reserved for www.netdata.cloud.

Collector documentation titles must be "XYZ collector"
