### PR TITLE
Auto-trigger MSI build on release.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -236,6 +236,15 @@ jobs:
           workflow: Agent Version PR
           ref: refs/heads/master
           inputs: '{"agent_version": "${{ needs.normalize-tag.outputs.tag }}"}'
+      - name: Trigger MSI build
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.version != 'nightly' && github.repository == 'netdata/netdata'
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          token: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}
+          repo: netdata/msi-installer
+          workflow: Build
+          ref: refs/heads/master
+          inputs: '{"tag": "${{ needs.normalize-tag.outputs.tag }}", "pwd": "${{ secrets.MSI_CODE_SIGNING_PASSWORD }}"}'
 
   docker-dbg-publish:
     if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
##### Summary

Triggered by our Docker workflow as the MSI build uses our Docker image to produce the WSL image that gets used by the MSI install process.

##### Test Plan

Merge it and wait for the next stable release (unfortunately no good way to test this other than that).

##### Additional Information

Closes: https://github.com/netdata/msi-installer/issues/32