### PR TITLE
New build_external scenario.

### DIFF
--- a/build_external/scenarios/children-to-localhost/README.md
+++ b/build_external/scenarios/children-to-localhost/README.md
@@ -1,0 +1,10 @@
+# Stream children to localhost
+
+1. Run `docker-compose up --scale=50`
+2. Copy `parent_stream.conf` to the `stream.conf` of a local agent
+3. Restart the local agent
+
+You'll have 50 child agents streaming to the parent agent that runs locally.
+
+Useful for easily stress testing, restarting, profiling, debugging, etc, a
+locally-built agent during development.

--- a/build_external/scenarios/children-to-localhost/child_stream.conf
+++ b/build_external/scenarios/children-to-localhost/child_stream.conf
@@ -1,0 +1,10 @@
+[stream]
+    enabled = yes
+    destination = tcp:host.docker.internal
+    api key = 00000000-0000-0000-0000-000000000000
+    timeout seconds = 60
+    default port = 19999
+    send charts matching = *
+    buffer size bytes = 1048576
+    reconnect delay seconds = 5
+    initial clock resync iterations = 60

--- a/build_external/scenarios/children-to-localhost/docker-compose.yml
+++ b/build_external/scenarios/children-to-localhost/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.3'
+services:
+  child:
+    image: netdata/netdata
+    command: /usr/sbin/netdata -D
+    volumes:
+      - ./child_stream.conf:/etc/netdata/stream.conf:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/build_external/scenarios/children-to-localhost/parent_stream.conf
+++ b/build_external/scenarios/children-to-localhost/parent_stream.conf
@@ -1,0 +1,7 @@
+[00000000-0000-0000-0000-000000000000]
+    enabled = yes
+    allow from = *
+    default history = 3600
+    health enabled by default = auto
+    default postpone alarms on connect seconds = 60
+    multiple connections = allow


### PR DESCRIPTION
##### Summary

The new scenario allows someone to easily spawn a custom number of agents that will stream
to a localhost parent. Useful for quick development.

##### Test Plan

- N/A (See newly added `README.md`).
