### PR TITLE
increase RRD_ID_LENGTH_MAX to 1000

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -188,7 +188,7 @@ extern time_t rrdset_free_obsolete_time_s;
 extern int libuv_worker_threads;
 extern bool ieee754_doubles;
 
-#define RRD_ID_LENGTH_MAX 200
+#define RRD_ID_LENGTH_MAX 1000
 
 typedef long long total_number;
 #define TOTAL_NUMBER_FORMAT "%lld"


### PR DESCRIPTION
##### Summary

Fixes: #14730
Fixes: #14515

This change affects only memory mode `save`: Netdata fails to use `save` and fallbacks to `ram` for charts with id > 200.

##### Test Plan

Update existing install and ensure that:

- no metrics lost
- no additional memory usage
- charts with id > 200 can be created

For memory mode `dbengine`.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
