### PR TITLE
Update journal v2

### DIFF
--- a/database/engine/journalfile.h
+++ b/database/engine/journalfile.h
@@ -59,9 +59,9 @@ static inline uint64_t journalfile_current_size(struct rrdengine_journalfile *jo
 
 // Journal v2 structures
 
-#define JOURVAL_V2_MAGIC           (0x01221019)
-#define JOURVAL_V2_REBUILD_MAGIC   (0x00221019)
-#define JOURVAL_V2_SKIP_MAGIC      (0x02221019)
+#define JOURVAL_V2_MAGIC           (0x01230317)
+#define JOURVAL_V2_REBUILD_MAGIC   (0x00230317)
+#define JOURVAL_V2_SKIP_MAGIC      (0x02230317)
 
 struct journal_v2_block_trailer {
     union {
@@ -93,13 +93,14 @@ struct journal_page_list {
 };
 
 // UUID_LIST
-// 32 bytes
+// 36 bytes
 struct journal_metric_list {
     uuid_t uuid;
-    uint32_t entries;         // Number of entries
-    uint32_t page_offset;     // OFFSET that contains entries * struct( journal_page_list )
+    uint32_t entries;           // Number of entries
+    uint32_t page_offset;       // OFFSET that contains entries * struct( journal_page_list )
     uint32_t delta_start_s;     // Min time of metric
     uint32_t delta_end_s;       // Max time of metric  (to be used to populate page_index)
+    uint32_t update_every_s;    // Last update every for this metric in this journal (last page collected)
 };
 
 // 16 bytes

--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -101,7 +101,7 @@ inline TIME_RANGE_COMPARE is_page_in_time_range(time_t page_first_time_s, time_t
 
 static int journal_metric_uuid_compare(const void *key, const void *metric)
 {
-    return uuid_compare(*(uuid_t *) key, ((struct journal_metric_list *) metric)->uuid);
+    return memcmp(key, &(((struct journal_metric_list *) metric)->uuid), sizeof(uuid_t));
 }
 
 static inline struct page_details *pdc_find_page_for_time(

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -49,7 +49,6 @@ const char *database_config[] = {
 const char *database_cleanup[] = {
     "DELETE FROM chart WHERE chart_id NOT IN (SELECT chart_id FROM dimension);",
     "DELETE FROM host WHERE host_id NOT IN (SELECT host_id FROM chart);",
-    "DELETE FROM chart_label WHERE chart_id NOT IN (SELECT chart_id FROM chart);",
     "DELETE FROM node_instance WHERE host_id NOT IN (SELECT host_id FROM host);",
     "DELETE FROM host_info WHERE host_id NOT IN (SELECT host_id FROM host);",
     "DELETE FROM host_label WHERE host_id NOT IN (SELECT host_id FROM host);",


### PR DESCRIPTION
New version of the journal v2

- Keep the latest update every in the metric directory list
  This will make populating the metric registry faster (vs having to jump to the last page per metric to fetch the latest update every)
- Use memcmp to sort and search metric UUIDs
  - Faster scan of the v2 journal files during queries
- Skip chart label cleanup during startup (will be done later) 
 
When applied, this PR will do a full rebuild of the existing journal v2 files
