### PR TITLE
Accept all=true for alarms api v1 call

### DIFF
--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -261,8 +261,8 @@ int web_client_api_request_v1_alarms_select (char *url) {
         char *value = mystrsep(&url, "&");
         if (!value || !*value) continue;
 
-        if(!strcmp(value, "all")) all = 1;
-        else if(!strcmp(value, "active")) all = 0;
+        if(!strcmp(value, "all") || !strcmp(value, "all=true")) all = 1;
+        else if(!strcmp(value, "active") || !strcmp(value, "active=true")) all = 0;
     }
 
     return all;


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #14754 

Accept `/api/v1/alarms?all=true` to show all alerts via the api call, instead of just `?all`.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Check if `http://localhost:19999/api/v1/alarms?all=true` shows all alerts.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
