### PR TITLE
Skip alert template variables from alert snapshots

### DIFF
--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -980,6 +980,8 @@ void aclk_push_alert_snapshot_event(struct aclk_database_worker_config *wc, stru
 
     RRDHOST *host = wc->host;
     uint32_t cnt = 0;
+    char uuid_str[GUID_LEN + 1];
+    uuid_unparse_lower_fix(&host->host_uuid, uuid_str);
 
     netdata_rwlock_rdlock(&host->health_log.alarm_log_rwlock);
 
@@ -993,6 +995,9 @@ void aclk_push_alert_snapshot_event(struct aclk_database_worker_config *wc, stru
             continue;
 
         if (have_recent_alarm(host, ae->alarm_id, ae->unique_id))
+            continue;
+
+        if (is_event_from_alert_variable_config(ae->unique_id, uuid_str))
             continue;
 
         cnt++;
@@ -1022,6 +1027,9 @@ void aclk_push_alert_snapshot_event(struct aclk_database_worker_config *wc, stru
                 continue;
 
             if (have_recent_alarm(host, ae->alarm_id, ae->unique_id))
+                continue;
+
+            if (is_event_from_alert_variable_config(ae->unique_id, uuid_str))
                 continue;
 
             cnt++;

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -980,7 +980,7 @@ void aclk_push_alert_snapshot_event(struct aclk_database_worker_config *wc, stru
 
     RRDHOST *host = wc->host;
     uint32_t cnt = 0;
-    char uuid_str[GUID_LEN + 1];
+    char uuid_str[UUID_STR_LEN];
     uuid_unparse_lower_fix(&host->host_uuid, uuid_str);
 
     netdata_rwlock_rdlock(&host->health_log.alarm_log_rwlock);


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Continuing from #14325, this PR also adds the same check to alert snapshots, so alert templates that are actually variables will not be transmitted through alert snapshot events.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

A bit tricky to test, but with `conversation log` enabled, when a snapshot is triggered (mess a bit with sequence numbers in `aclk_alert_` table, or manually call `aclk_process_send_alarm_snapshot` from health main loop, in e.g. the 10th loop), check if alerts such as `load_cpu_number` or `interface_speed` appear in the snapshot message (they should not).

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
