### PR TITLE
Pass node_id and config_hash vars when queueing alert configurations

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -584,7 +584,7 @@ void aclk_push_alert_config(const char *node_id, const char *config_hash)
     if (unlikely(!aclk_sync_config.initialized))
         return;
 
-    queue_aclk_sync_cmd(ACLK_DATABASE_PUSH_ALERT_CONFIG, node_id, config_hash);
+    queue_aclk_sync_cmd(ACLK_DATABASE_PUSH_ALERT_CONFIG, strdupz(node_id), strdupz(config_hash));
 }
 
 void aclk_push_node_alert_snapshot(const char *node_id)

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -644,12 +644,14 @@ int aclk_push_alert_config_event(char *node_id __maybe_unused, char *config_hash
 
     if (unlikely(!host)) {
         freez(config_hash);
+        freez(node_id);
         return 1;
     }
 
     wc = (struct aclk_sync_host_config *)host->aclk_sync_host_config;
     if (unlikely(!wc)) {
         freez(config_hash);
+        freez(node_id);
         return 1;
     }
 
@@ -734,7 +736,6 @@ int aclk_push_alert_config_event(char *node_id __maybe_unused, char *config_hash
     if (likely(p_alarm_config.cfg_hash)) {
         log_access("ACLK RES [%s (%s)]: Sent alert config %s.", wc->node_id, wc->host ? rrdhost_hostname(wc->host) : "N/A", config_hash);
         aclk_send_provide_alarm_cfg(&p_alarm_config);
-        freez((char *) config_hash);
         freez(p_alarm_config.cfg_hash);
         destroy_aclk_alarm_configuration(&alarm_config);
     }
@@ -746,6 +747,8 @@ bind_fail:
     if (unlikely(rc != SQLITE_OK))
         error_report("Failed to reset statement when pushing alarm config hash, rc = %d", rc);
 
+    freez(config_hash);
+    freez(node_id);
 #endif
     return rc;
 }


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Copy `node_id` and `config_hash` when passing them to queue to send alert configurations to cloud.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Create a unique new alert configuration (or just copy one and slightly change a field). Make sure when an alert from this configuration is sent to the cloud, that when the alert configuration is requested, it is sent from agent. Typically the following should be in `access.log`:

```
Request to send alert config 3867ec1d-198e-2759-1939-4940ee889ba2.
Sent alert config 3867ec1d-198e-2759-1939-4940ee889ba2.
```

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
