### PR TITLE
add validation step before using Azure metadata (AZURE_IMDS_DATA) 

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -474,7 +474,7 @@ if [ "${VIRTUALIZATION}" != "none" ] && command -v curl > /dev/null 2>&1; then
     # Try Azure IMDS
     if [ "${CLOUD_TYPE}" = "unknown" ]; then
       AZURE_IMDS_DATA="$(curl --fail -s --connect-timeout 1 -m 3 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-10-01")"
-      if [ -n "${AZURE_IMDS_DATA}" ]; then
+      if [ -n "${AZURE_IMDS_DATA}" ] && echo "${AZURE_IMDS_DATA}" | grep -sq azEnvironment; then
         CLOUD_TYPE="Azure"
         CLOUD_INSTANCE_TYPE="$(curl --fail -s --connect-timeout 1 -m 3 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2021-10-01&format=text")"
         CLOUD_INSTANCE_REGION="$(curl --fail -s --connect-timeout 1 -m 3 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance/compute/location?api-version=2021-10-01&format=text")"


### PR DESCRIPTION
##### Summary

Some instances return data and 200 to the following query:

https://github.com/netdata/netdata/blob/4da956f37476e791d319a33962f440f00efa2ed2/daemon/system-info.sh#L475-L476


<details>
<summary>Unexpected output example</summary>

```bash
curl --fail -s --connect-timeout 1 -m 3 -H "Metadata: true" --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-10-01"
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html xmlns="http://www.w3.org/1999/xhtml">
<head>
<meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
<meta content="no-cache" http-equiv="Pragma" />
<title>Waiting...</title>
<script type="text/javascript">
var pageName = '/';
top.location.replace(pageName);
</script>
</head>
<body> </body>
</html>
```


</details>

This PR adds an additional data validation step before considering the host to be an Azure cloud host.

##### Test Plan

Test on an Azure cloud VM and on an instance that returns unexpected data.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
