### PR TITLE
Parse alert configs written in YAML

### DIFF
--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -669,17 +669,17 @@ void rrdcalc_add_from_rrdcalctemplate(RRDHOST *host, RRDCALCTEMPLATE *rt, RRDSET
 
 int rrdcalc_add_from_config(RRDHOST *host, RRDCALC *rc) {
     if(!rc->chart) {
-        error("Health configuration for alarm '%s' does not have a chart", rrdcalc_name(rc));
+        log_health("Health configuration for alarm '%s' does not have a chart", rrdcalc_name(rc));
         return 0;
     }
 
     if(!rc->update_every) {
-        error("Health configuration for alarm '%s.%s' has no frequency (parameter 'every'). Ignoring it.", rrdcalc_chart_name(rc), rrdcalc_name(rc));
+        log_health("Health configuration for alarm '%s.%s' has no frequency (parameter 'every'). Ignoring it.", rrdcalc_chart_name(rc), rrdcalc_name(rc));
         return 0;
     }
 
     if(!RRDCALC_HAS_DB_LOOKUP(rc) && !rc->calculation && !rc->warning && !rc->critical) {
-        error("Health configuration for alarm '%s.%s' is useless (no db lookup, no calculation, no warning and no critical expressions)", rrdcalc_chart_name(rc), rrdcalc_name(rc));
+        log_health("Health configuration for alarm '%s.%s' is useless (no db lookup, no calculation, no warning and no critical expressions)", rrdcalc_chart_name(rc), rrdcalc_name(rc));
         return 0;
     }
 

--- a/health/health.d/load.conf
+++ b/health/health.d/load.conf
@@ -1,69 +1,40 @@
-
 # you can disable an alarm notification by setting the 'to' line to: silent
-
+---
+# the chart or context the alerts operate on
+alerting_rules:
+ - on: system.load
+   category:
+    class: Latency
+    type: System
+    component: Network
+   hosts: "*"
+   os: linux
+   calc: "($load_cpu_number == nan) ? (nan) : ($this)"
+   every: 1m
+   units: load
+   delay: down 15m multiplier 1.5 max 1h
+   to: sysadmin
+   alerts:
 # Calculate the base trigger point for the load average alarms.
 # This is the maximum number of CPU's in the system over the past 1
 # minute, with a special case for a single CPU of setting the trigger at 2.
-    alarm: load_cpu_number
-       on: system.load
-    class: Utilization
-     type: System
-component: Load
-       os: linux
-    hosts: *
-     calc: ($active_processors == nan or $active_processors == 0) ? (nan) : ( ($active_processors < 2) ? ( 2 ) : ( $active_processors ) )
-    units: cpus
-    every: 1m
-     info: number of active CPU cores in the system
-
+    - alert: load_cpu_number
+      on: system.load
+      calc: "($active_processors == nan or $active_processors == 0) ? (nan) : ( ($active_processors < 2) ? ( 2 ) : ( $active_processors ) )"
+      units: cpus
+      info: number of active CPU cores in the system
 # Send alarms if the load average is unusually high.
 # These intentionally _do not_ calculate the average over the sampled
 # time period because the values being checked already are averages.
-
-    alarm: load_average_15
-       on: system.load
-    class: Utilization
-     type: System
-component: Load
-       os: linux
-    hosts: *
-   lookup: max -1m unaligned of load15
-     calc: ($load_cpu_number == nan) ? (nan) : ($this)
-    units: load
-    every: 1m
-     warn: ($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 175 : 200)
-    delay: down 15m multiplier 1.5 max 1h
-     info: system fifteen-minute load average
-       to: sysadmin
-
-    alarm: load_average_5
-       on: system.load
-    class: Utilization
-     type: System
-component: Load
-       os: linux
-    hosts: *
-   lookup: max -1m unaligned of load5
-     calc: ($load_cpu_number == nan) ? (nan) : ($this)
-    units: load
-    every: 1m
-     warn: ($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 350 : 400)
-    delay: down 15m multiplier 1.5 max 1h
-     info: system five-minute load average
-       to: sysadmin
-
-    alarm: load_average_1
-       on: system.load
-    class: Utilization
-     type: System
-component: Load
-       os: linux
-    hosts: *
-   lookup: max -1m unaligned of load1
-     calc: ($load_cpu_number == nan) ? (nan) : ($this)
-    units: load
-    every: 1m
-     warn: ($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 700 : 800)
-    delay: down 15m multiplier 1.5 max 1h
-     info: system one-minute load average
-       to: sysadmin
+    - alert: load_average_15
+      lookup: max -1m unaligned of load15
+      warn: "($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 175 : 200)"
+      info: system fifteen-minute load average
+    - alert: load_average_5
+      lookup: max -1m unaligned of load5
+      warn: "($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 350 : 400)"
+      info: system five-minute load average
+    - alert: load_average_1
+      lookup: max -1m unaligned of load1
+      warn: "($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 700 : 800)"
+      info: system one-minute load average

--- a/health/health.d/load.conf
+++ b/health/health.d/load.conf
@@ -19,7 +19,6 @@ alerting_rules:
 # This is the maximum number of CPU's in the system over the past 1
 # minute, with a special case for a single CPU of setting the trigger at 2.
     - alert: load_cpu_number
-      on: system.load
       calc: "($active_processors == nan or $active_processors == 0) ? (nan) : ( ($active_processors < 2) ? ( 2 ) : ( $active_processors ) )"
       units: cpus
       info: number of active CPU cores in the system

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -1778,16 +1778,14 @@ void health_yaml_config_parse_node(yaml_document_t *document_p, yaml_node_t *nod
                 health_config_store_key(doc_cfg, (const char *)key->data.scalar.value, (const char *)node->data.scalar.value);
 			break;
 		case YAML_SEQUENCE_NODE:
-			yaml_node_item_t *i_node;
-			for (i_node = node->data.sequence.items.start; i_node < node->data.sequence.items.top; i_node++) {
+			for (yaml_node_item_t *i_node = node->data.sequence.items.start; i_node < node->data.sequence.items.top; i_node++) {
 				next_node_p = yaml_document_get_node(document_p, *i_node);
 				if (next_node_p)
 					health_yaml_config_parse_node(document_p, next_node_p, doc_cfg, sec_cfg, key, host);
 			}
 			break;
 		case YAML_MAPPING_NODE:
-			yaml_node_pair_t *i_node_p;
-			for (i_node_p = node->data.mapping.pairs.start; i_node_p < node->data.mapping.pairs.top; i_node_p++) {
+			for (yaml_node_pair_t *i_node_p = node->data.mapping.pairs.start; i_node_p < node->data.mapping.pairs.top; i_node_p++) {
 				key_node_p = yaml_document_get_node(document_p, i_node_p->key);
 				next_node_p = yaml_document_get_node(document_p, i_node_p->value);
                 health_yaml_config_parse_node(document_p, next_node_p, doc_cfg, sec_cfg, key_node_p, host);

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -5,6 +5,7 @@
 #define HEALTH_CONF_MAX_LINE 4096
 
 #define HEALTH_ALARM_KEY "alarm"
+#define HEALTH_ALERT_KEY "alert"
 #define HEALTH_TEMPLATE_KEY "template"
 #define HEALTH_ON_KEY "on"
 #define HEALTH_HOST_KEY "hosts"
@@ -424,40 +425,572 @@ static inline void strip_quotes(char *s) {
 
 static inline void alert_config_free(struct alert_config *cfg)
 {
-    string_freez(cfg->alarm);
-    string_freez(cfg->template_key);
-    string_freez(cfg->os);
-    string_freez(cfg->host);
-    string_freez(cfg->on);
-    string_freez(cfg->families);
-    string_freez(cfg->plugin);
-    string_freez(cfg->module);
-    string_freez(cfg->charts);
-    string_freez(cfg->lookup);
-    string_freez(cfg->calc);
-    string_freez(cfg->warn);
-    string_freez(cfg->crit);
-    string_freez(cfg->every);
-    string_freez(cfg->green);
-    string_freez(cfg->red);
-    string_freez(cfg->exec);
-    string_freez(cfg->to);
-    string_freez(cfg->units);
-    string_freez(cfg->info);
-    string_freez(cfg->classification);
-    string_freez(cfg->component);
-    string_freez(cfg->type);
-    string_freez(cfg->delay);
-    string_freez(cfg->options);
-    string_freez(cfg->repeat);
-    string_freez(cfg->host_labels);
-    string_freez(cfg->p_db_lookup_dimensions);
-    string_freez(cfg->p_db_lookup_method);
-    freez(cfg);
+    string_freez(cfg->alarm);                  cfg->alarm = NULL;
+    string_freez(cfg->template_key);           cfg->template_key = NULL;
+    string_freez(cfg->os);                     cfg->os = NULL;
+    string_freez(cfg->host);                   cfg->host = NULL;
+    string_freez(cfg->on);                     cfg->on = NULL;
+    string_freez(cfg->families);               cfg->families = NULL;
+    string_freez(cfg->plugin);                 cfg->plugin = NULL;
+    string_freez(cfg->module);                 cfg->module = NULL;
+    string_freez(cfg->charts);                 cfg->charts = NULL;
+    string_freez(cfg->lookup);                 cfg->lookup = NULL;
+    string_freez(cfg->calc);                   cfg->calc=NULL;
+    string_freez(cfg->warn);                   cfg->warn = NULL;
+    string_freez(cfg->crit);                   cfg->crit = NULL;
+    string_freez(cfg->every);                  cfg->every = NULL;
+    string_freez(cfg->green);                  cfg->green = NULL;
+    string_freez(cfg->red);                    cfg->red = NULL;
+    string_freez(cfg->exec);                   cfg->exec = NULL;
+    string_freez(cfg->to);                     cfg->to = NULL;
+    string_freez(cfg->units);                  cfg->units = NULL;
+    string_freez(cfg->info);                   cfg->info = NULL;
+    string_freez(cfg->classification);         cfg->classification = NULL;
+    string_freez(cfg->component);              cfg->component = NULL;
+    string_freez(cfg->type);                   cfg->type = NULL;
+    string_freez(cfg->delay);                  cfg->delay = NULL;
+    string_freez(cfg->options);                cfg->options = NULL;
+    string_freez(cfg->repeat);                 cfg->repeat = NULL;
+    string_freez(cfg->host_labels);            cfg->host_labels = NULL;
+    string_freez(cfg->p_db_lookup_dimensions); cfg->p_db_lookup_dimensions = NULL;
+    string_freez(cfg->p_db_lookup_method);     cfg->p_db_lookup_method = NULL;
+}
+
+void health_config_store_key(struct alert_config *cfg, const char *key, const char *value) {
+    static uint32_t
+            hash_alarm = 0,
+            hash_alert = 0,
+            hash_template = 0,
+            hash_os = 0,
+            hash_on = 0,
+            hash_host = 0,
+            hash_families = 0,
+            hash_plugin = 0,
+            hash_module = 0,
+            hash_charts = 0,
+            hash_calc = 0,
+            hash_green = 0,
+            hash_red = 0,
+            hash_warn = 0,
+            hash_crit = 0,
+            hash_exec = 0,
+            hash_every = 0,
+            hash_lookup = 0,
+            hash_units = 0,
+            hash_info = 0,
+            hash_class = 0,
+            hash_component = 0,
+            hash_type = 0,
+            hash_recipient = 0,
+            hash_delay = 0,
+            hash_options = 0,
+            hash_repeat = 0,
+            hash_host_label = 0;
+
+    if(unlikely(!hash_alarm)) {
+        hash_alarm = simple_uhash(HEALTH_ALARM_KEY);
+        hash_alert = simple_uhash(HEALTH_ALERT_KEY);
+        hash_template = simple_uhash(HEALTH_TEMPLATE_KEY);
+        hash_on = simple_uhash(HEALTH_ON_KEY);
+        hash_os = simple_uhash(HEALTH_OS_KEY);
+        hash_host = simple_uhash(HEALTH_HOST_KEY);
+        hash_families = simple_uhash(HEALTH_FAMILIES_KEY);
+        hash_plugin = simple_uhash(HEALTH_PLUGIN_KEY);
+        hash_module = simple_uhash(HEALTH_MODULE_KEY);
+        hash_charts = simple_uhash(HEALTH_CHARTS_KEY);
+        hash_calc = simple_uhash(HEALTH_CALC_KEY);
+        hash_lookup = simple_uhash(HEALTH_LOOKUP_KEY);
+        hash_green = simple_uhash(HEALTH_GREEN_KEY);
+        hash_red = simple_uhash(HEALTH_RED_KEY);
+        hash_warn = simple_uhash(HEALTH_WARN_KEY);
+        hash_crit = simple_uhash(HEALTH_CRIT_KEY);
+        hash_exec = simple_uhash(HEALTH_EXEC_KEY);
+        hash_every = simple_uhash(HEALTH_EVERY_KEY);
+        hash_units = simple_hash(HEALTH_UNITS_KEY);
+        hash_info = simple_hash(HEALTH_INFO_KEY);
+        hash_class = simple_uhash(HEALTH_CLASS_KEY);
+        hash_component = simple_uhash(HEALTH_COMPONENT_KEY);
+        hash_type = simple_uhash(HEALTH_TYPE_KEY);
+        hash_recipient = simple_hash(HEALTH_RECIPIENT_KEY);
+        hash_delay = simple_uhash(HEALTH_DELAY_KEY);
+        hash_options = simple_uhash(HEALTH_OPTIONS_KEY);
+        hash_repeat = simple_uhash(HEALTH_REPEAT_KEY);
+        hash_host_label = simple_uhash(HEALTH_HOST_LABEL_KEY);
+    }
+
+    uint32_t hash = simple_uhash(key);
+
+    if(hash == hash_alarm && !strcasecmp(key, HEALTH_ALARM_KEY))
+        cfg->alarm = string_strdupz(value);
+    else if(hash == hash_alert && !strcasecmp(key, HEALTH_ALERT_KEY))
+        cfg->alarm = string_strdupz(value);
+    else if (hash == hash_template && !strcasecmp(key, HEALTH_TEMPLATE_KEY))
+        cfg->template_key = string_strdupz(value);
+    else if (hash == hash_on && !strcasecmp(key, HEALTH_ON_KEY))
+        cfg->on = string_strdupz(value);
+    else if (hash == hash_os && !strcasecmp(key, HEALTH_OS_KEY))
+        cfg->os = string_strdupz(value);
+    else if (hash == hash_host && !strcasecmp(key, HEALTH_HOST_KEY))
+        cfg->host = string_strdupz(value);
+    else if (hash == hash_families && !strcasecmp(key, HEALTH_FAMILIES_KEY))
+        cfg->families = string_strdupz(value);
+    else if (hash == hash_plugin && !strcasecmp(key, HEALTH_PLUGIN_KEY))
+        cfg->plugin = string_strdupz(value);
+    else if (hash == hash_module && !strcasecmp(key, HEALTH_MODULE_KEY))
+        cfg->module = string_strdupz(value);
+    else if (hash == hash_charts && !strcasecmp(key, HEALTH_CHARTS_KEY))
+        cfg->charts = string_strdupz(value);
+    else if (hash == hash_calc && !strcasecmp(key, HEALTH_CALC_KEY))
+        cfg->calc = string_strdupz(value);
+    else if (hash == hash_lookup && !strcasecmp(key, HEALTH_LOOKUP_KEY))
+        cfg->lookup = string_strdupz(value);
+    else if (hash == hash_green && !strcasecmp(key, HEALTH_GREEN_KEY))
+        cfg->green = string_strdupz(value);
+    else if (hash == hash_red && !strcasecmp(key, HEALTH_RED_KEY))
+        cfg->red = string_strdupz(value);
+    else if (hash == hash_warn && !strcasecmp(key, HEALTH_WARN_KEY))
+        cfg->warn = string_strdupz(value);
+    else if (hash == hash_crit && !strcasecmp(key, HEALTH_CRIT_KEY))
+        cfg->crit = string_strdupz(value);
+    else if (hash == hash_exec && !strcasecmp(key, HEALTH_EXEC_KEY))
+        cfg->exec = string_strdupz(value);
+    else if (hash == hash_every && !strcasecmp(key, HEALTH_EVERY_KEY))
+        cfg->every = string_strdupz(value);
+    else if (hash == hash_units && !strcasecmp(key, HEALTH_UNITS_KEY))
+        cfg->units = string_strdupz(value);
+    else if (hash == hash_info && !strcasecmp(key, HEALTH_INFO_KEY))
+        cfg->info = string_strdupz(value);
+    else if (hash == hash_class && !strcasecmp(key, HEALTH_CLASS_KEY))
+        cfg->classification = string_strdupz(value);
+    else if (hash == hash_component && !strcasecmp(key, HEALTH_COMPONENT_KEY))
+        cfg->component = string_strdupz(value);
+    else if (hash == hash_type && !strcasecmp(key, HEALTH_TYPE_KEY))
+        cfg->type = string_strdupz(value);
+    else if (hash == hash_recipient && !strcasecmp(key, HEALTH_RECIPIENT_KEY))
+        cfg->to = string_strdupz(value);
+    else if (hash == hash_delay && !strcasecmp(key, HEALTH_DELAY_KEY))
+        cfg->delay = string_strdupz(value);
+    else if (hash == hash_options && !strcasecmp(key, HEALTH_OPTIONS_KEY))
+        cfg->options = string_strdupz(value);
+    else if (hash == hash_repeat && !strcasecmp(key, HEALTH_REPEAT_KEY))
+        cfg->repeat = string_strdupz(value);
+    else if (hash == hash_host_label && !strcasecmp(key, HEALTH_HOST_LABEL_KEY))
+        cfg->host_labels = string_strdupz(value);
+}
+
+void health_create_alert_from_config(struct alert_config *doc_cfg, struct alert_config *sec_cfg, RRDHOST *host, char *filename, size_t line)
+{
+    if (!sec_cfg->on && doc_cfg->on) sec_cfg->on = string_dup(doc_cfg->on);
+    if (!sec_cfg->os && doc_cfg->os) sec_cfg->os = string_dup(doc_cfg->os);
+    if (!sec_cfg->host && doc_cfg->host) sec_cfg->host = string_dup(doc_cfg->host);
+    if (!sec_cfg->families && doc_cfg->families) sec_cfg->families = string_dup(doc_cfg->families);
+    if (!sec_cfg->plugin && doc_cfg->plugin) sec_cfg->plugin = string_dup(doc_cfg->plugin);
+    if (!sec_cfg->module && doc_cfg->module) sec_cfg->module = string_dup(doc_cfg->module);
+    if (!sec_cfg->charts && doc_cfg->charts) sec_cfg->charts = string_dup(doc_cfg->charts);
+    if (!sec_cfg->calc && doc_cfg->calc) sec_cfg->calc = string_dup(doc_cfg->calc);
+    if (!sec_cfg->lookup && doc_cfg->lookup) sec_cfg->lookup = string_dup(doc_cfg->lookup);
+    if (!sec_cfg->green && doc_cfg->green) sec_cfg->green = string_dup(doc_cfg->green);
+    if (!sec_cfg->red && doc_cfg->red) sec_cfg->red = string_dup(doc_cfg->red);
+    if (!sec_cfg->warn && doc_cfg->warn) sec_cfg->warn = string_dup(doc_cfg->warn);
+    if (!sec_cfg->crit && doc_cfg->crit) sec_cfg->crit = string_dup(doc_cfg->crit);
+    if (!sec_cfg->exec && doc_cfg->exec) sec_cfg->exec = string_dup(doc_cfg->exec);
+    if (!sec_cfg->every && doc_cfg->every) sec_cfg->every = string_dup(doc_cfg->every);
+    if (!sec_cfg->units && doc_cfg->units) sec_cfg->units = string_dup(doc_cfg->units);
+    if (!sec_cfg->info && doc_cfg->info) sec_cfg->info = string_dup(doc_cfg->info);
+    if (!sec_cfg->classification && doc_cfg->classification) sec_cfg->classification = string_dup(doc_cfg->classification);
+    if (!sec_cfg->component && doc_cfg->component) sec_cfg->component = string_dup(doc_cfg->component);
+    if (!sec_cfg->type && doc_cfg->type) sec_cfg->type = string_dup(doc_cfg->type);
+    if (!sec_cfg->to && doc_cfg->to) sec_cfg->to = string_dup(doc_cfg->to);
+    if (!sec_cfg->delay && doc_cfg->delay) sec_cfg->delay = string_dup(doc_cfg->delay);
+    if (!sec_cfg->options && doc_cfg->options) sec_cfg->options = string_dup(doc_cfg->options);
+    if (!sec_cfg->repeat && doc_cfg->repeat) sec_cfg->repeat = string_dup(doc_cfg->repeat);
+    if (!sec_cfg->host_labels && doc_cfg->host_labels) sec_cfg->host_labels = string_dup(doc_cfg->host_labels);
+
+    RRDCALC *rc = NULL;
+    RRDCALCTEMPLATE *rt = NULL;
+
+    if (sec_cfg->os) {
+        SIMPLE_PATTERN *os_pattern = simple_pattern_create(string2str(sec_cfg->os), NULL, SIMPLE_PATTERN_EXACT, true);
+
+        if(!simple_pattern_matches_string(os_pattern, host->os)) {
+            if(rc)
+                debug(D_HEALTH, "HEALTH on '%s' ignoring alarm '%s' defined at %zu@%s: host O/S does not match '%s'", rrdhost_hostname(host), rrdcalc_name(rc), line, filename, string2str(sec_cfg->os));
+
+            if(rt)
+                debug(D_HEALTH, "HEALTH on '%s' ignoring template '%s' defined at %zu@%s: host O/S does not match '%s'", rrdhost_hostname(host), rrdcalctemplate_name(rt), line, filename, string2str(sec_cfg->os));
+
+            simple_pattern_free(os_pattern);
+            return;
+        }
+        simple_pattern_free(os_pattern);
+    }
+
+    if (sec_cfg->host) {
+        SIMPLE_PATTERN *host_pattern = simple_pattern_create(string2str(sec_cfg->host), NULL, SIMPLE_PATTERN_EXACT, true);
+
+        if(!simple_pattern_matches_string(host_pattern, host->hostname)) {
+            if(rc)
+                debug(D_HEALTH, "HEALTH on '%s' ignoring alarm '%s' defined at %zu@%s: hostname does not match '%s'", rrdhost_hostname(host), rrdcalc_name(rc), line, filename, string2str(sec_cfg->host));
+
+            if(rt)
+                debug(D_HEALTH, "HEALTH on '%s' ignoring template '%s' defined at %zu@%s: hostname does not match '%s'", rrdhost_hostname(host), rrdcalctemplate_name(rt), line, filename, string2str(sec_cfg->host));
+
+            simple_pattern_free(host_pattern);
+            return;
+        }
+        simple_pattern_free(host_pattern);
+    }
+
+
+    if (sec_cfg->template_key) {
+        if (simple_pattern_matches(conf_enabled_alarms, string2str(sec_cfg->template_key))) {
+            rt = callocz(1, sizeof(RRDCALCTEMPLATE));
+
+            {
+                char *tmp = strdupz(string2str(sec_cfg->template_key));
+                if(rrdvar_fix_name(tmp))
+                    error("Health configuration renamed template '%s' to '%s'", string2str(sec_cfg->template_key), tmp);
+
+                rt->name = string_strdupz(tmp);
+                freez(tmp);
+            }
+
+            //rt->source = health_source_file(line, filename); TODO
+            rt->green = NAN;
+            rt->red = NAN;
+            rt->delay_multiplier = (float)1.0;
+            rt->warn_repeat_every = host->health.health_default_warn_repeat_every;
+            rt->crit_repeat_every = host->health.health_default_crit_repeat_every;
+            //ignore_this = 0;
+        }
+    } else if (sec_cfg->alarm) {
+        if (simple_pattern_matches(conf_enabled_alarms, string2str(sec_cfg->alarm))) {
+            rc = callocz(1, sizeof(RRDCALC));
+            rc->next_event_id = 1;
+
+            {
+                char *tmp = strdupz(string2str(sec_cfg->alarm));
+                if(rrdvar_fix_name(tmp))
+                    error("Health configuration renamed alarm '%s' to '%s'", string2str(sec_cfg->alarm), tmp);
+
+                rc->name = string_strdupz(tmp);
+                freez(tmp);
+            }
+
+            //rc->source = health_source_file(line, filename); TODO
+            rc->green = NAN;
+            rc->red = NAN;
+            rc->value = NAN;
+            rc->old_value = NAN;
+            rc->delay_multiplier = 1.0;
+            rc->old_status = RRDCALC_STATUS_UNINITIALIZED;
+            rc->warn_repeat_every = host->health.health_default_warn_repeat_every;
+            rc->crit_repeat_every = host->health.health_default_crit_repeat_every;
+            //ignore_this = 0;
+        }
+    }
+
+    if (sec_cfg->on) {
+        if (rc) {
+            rc->chart = string_dup(sec_cfg->on);
+        } else if (rt) {
+            rt->context = string_dup(sec_cfg->on);
+        }
+    } else {
+        //required field, free rc/rt and exit
+    }
+
+    if (sec_cfg->classification) {
+        //strip_quotes
+        if (rc)
+            rc->classification = string_dup(sec_cfg->classification);
+        else if (rt)
+            rt->classification = string_dup(sec_cfg->classification);
+    }
+    if (sec_cfg->component) {
+        if (rc)
+            rc->component = string_dup(sec_cfg->component);
+        else if (rt)
+            rt->component = string_dup(sec_cfg->component);
+    }
+    if (sec_cfg->type) {
+        if (rc)
+            rc->type = string_dup(sec_cfg->type);
+        else if (rt)
+            rt->type = string_dup(sec_cfg->type);
+    }
+
+    if (sec_cfg->lookup) {
+        if (rc) {
+            health_parse_db_lookup(line, filename, (char *)string2str(sec_cfg->lookup), &rc->group, &rc->after, &rc->before,
+                        &rc->update_every, &rc->options, &rc->dimensions, &rc->foreach_dimension);
+
+            if(rc->foreach_dimension)
+                rc->foreach_dimension_pattern = health_pattern_from_foreach(rrdcalc_foreachdim(rc));
+
+            if (rc->after) {
+                if (rc->dimensions)
+                    sec_cfg->p_db_lookup_dimensions = string_dup(rc->dimensions);
+                if (rc->group)
+                    sec_cfg->p_db_lookup_method = string_strdupz(time_grouping_method2string(rc->group));
+                sec_cfg->p_db_lookup_options = rc->options;
+                sec_cfg->p_db_lookup_after = rc->after;
+                sec_cfg->p_db_lookup_before = rc->before;
+                sec_cfg->p_update_every = rc->update_every;
+            }
+        } else if (rt) {
+            health_parse_db_lookup(line, filename, (char *)string2str(sec_cfg->lookup), &rt->group, &rt->after, &rt->before,
+                        &rt->update_every, &rt->options, &rt->dimensions, &rt->foreach_dimension);
+
+            if(rt->foreach_dimension)
+                rt->foreach_dimension_pattern = health_pattern_from_foreach(rrdcalctemplate_foreachdim(rt));
+
+            if (rt->after) {
+                if (rt->dimensions)
+                    sec_cfg->p_db_lookup_dimensions = string_dup(rt->dimensions);
+
+                if (rt->group)
+                    sec_cfg->p_db_lookup_method = string_strdupz(time_grouping_method2string(rt->group));
+
+                sec_cfg->p_db_lookup_options = rt->options;
+                sec_cfg->p_db_lookup_after = rt->after;
+                sec_cfg->p_db_lookup_before = rt->before;
+                sec_cfg->p_update_every = rt->update_every;
+            }
+        }
+    }
+    if (sec_cfg->every) {
+        if (rc) {
+            if(!config_parse_duration(string2str(sec_cfg->every), &rc->update_every))
+                error("Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' cannot parse duration: '%s'.",
+                      line, filename, rrdcalc_name(rc), "every", string2str(sec_cfg->every));
+            sec_cfg->p_update_every = rc->update_every;
+        } else if (rt) {
+            if(!config_parse_duration(string2str(sec_cfg->every), &rt->update_every))
+                error("Health configuration at line %zu of file '%s' for template '%s' at key '%s' cannot parse duration: '%s'.",
+                      line, filename, rrdcalctemplate_name(rt), "every", string2str(sec_cfg->every));
+            sec_cfg->p_update_every = rt->update_every;
+        }
+    }
+    if(sec_cfg->green) {
+        if (rc) {
+            char *e;
+            rc->green = str2ndd(string2str(sec_cfg->green), &e);
+            if(e && *e) {
+                error("Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' leaves this string unmatched: '%s'.",
+                      line, filename, rrdcalc_name(rc), "green", e);
+            }
+        } else if (rt) {
+            char *e;
+            rt->green = str2ndd(string2str(sec_cfg->green), &e);
+            if(e && *e) {
+                error("Health configuration at line %zu of file '%s' for template '%s' at key '%s' leaves this string unmatched: '%s'.",
+                      line, filename, rrdcalc_name(rt), "green", e);
+            }
+        }
+    }
+    if(sec_cfg->red) {
+        if (rc) {
+            char *e;
+            rc->red = str2ndd(string2str(sec_cfg->red), &e);
+            if(e && *e) {
+                error("Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' leaves this string unmatched: '%s'.",
+                      line, filename, rrdcalc_name(rc), "red", e);
+            }
+        } else if (rt) {
+            char *e;
+            rt->red = str2ndd(string2str(sec_cfg->red), &e);
+            if(e && *e) {
+                error("Health configuration at line %zu of file '%s' for template '%s' at key '%s' leaves this string unmatched: '%s'.",
+                      line, filename, rrdcalc_name(rt), "red", e);
+            }
+        }
+    }
+    if (sec_cfg->calc) {
+        if (rc) {
+            const char *failed_at = NULL;
+            int error = 0;
+            rc->calculation = expression_parse(string2str(sec_cfg->calc), &failed_at, &error);
+            if(!rc->calculation) {
+                log_health("Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' has unparse-able expression '%s': %s at '%s'",
+                      line, filename, rrdcalctemplate_name(rc), "calc", string2str(sec_cfg->calc), expression_strerror(error), failed_at);
+            }
+            parse_variables_and_store_in_health_rrdvars((char *)string2str(sec_cfg->calc), HEALTH_CONF_MAX_LINE);
+        } else if (rt) {
+            const char *failed_at = NULL;
+            int error = 0;
+            rt->calculation = expression_parse(string2str(sec_cfg->calc), &failed_at, &error);
+            if(!rt->calculation) {
+                log_health("Health configuration at line %zu of file '%s' for template '%s' at key '%s' has unparse-able expression '%s': %s at '%s'",
+                      line, filename, rrdcalctemplate_name(rt), "calc", string2str(sec_cfg->calc), expression_strerror(error), failed_at);
+            }
+            parse_variables_and_store_in_health_rrdvars((char *)string2str(sec_cfg->calc), HEALTH_CONF_MAX_LINE);
+        }
+    }
+    if (sec_cfg->warn) {
+        if (rc) {
+            const char *failed_at = NULL;
+            int error = 0;
+            rc->warning = expression_parse(string2str(sec_cfg->warn), &failed_at, &error);
+            if(!rc->warning) {
+                error("Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' has unparse-able expression '%s': %s at '%s'",
+                      line, filename, rrdcalc_name(rc), "warn", string2str(sec_cfg->warn), expression_strerror(error), failed_at);
+            }
+            parse_variables_and_store_in_health_rrdvars((char *)string2str(sec_cfg->warn), HEALTH_CONF_MAX_LINE);
+        } else if (rt) {
+            const char *failed_at = NULL;
+            int error = 0;
+            rt->warning = expression_parse(string2str(sec_cfg->warn), &failed_at, &error);
+            if(!rt->warning) {
+                error("Health configuration at line %zu of file '%s' for template '%s' at key '%s' has unparse-able expression '%s': %s at '%s'",
+                      line, filename, rrdcalc_name(rt), "warn", string2str(sec_cfg->warn), expression_strerror(error), failed_at);
+            }
+            parse_variables_and_store_in_health_rrdvars((char *)string2str(sec_cfg->warn), HEALTH_CONF_MAX_LINE);
+        }
+    }
+    if (sec_cfg->crit) {
+        if (rc) {
+            const char *failed_at = NULL;
+            int error = 0;
+            rc->critical = expression_parse(string2str(sec_cfg->crit), &failed_at, &error);
+            if(!rc->warning) {
+                error("Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' has unparse-able expression '%s': %s at '%s'",
+                      line, filename, rrdcalc_name(rc), "crit", string2str(sec_cfg->crit), expression_strerror(error), failed_at);
+            }
+            parse_variables_and_store_in_health_rrdvars((char *)string2str(sec_cfg->crit), HEALTH_CONF_MAX_LINE);
+        } else if (rt) {
+            const char *failed_at = NULL;
+            int error = 0;
+            rt->critical = expression_parse(string2str(sec_cfg->crit), &failed_at, &error);
+            if(!rt->warning) {
+                error("Health configuration at line %zu of file '%s' for template '%s' at key '%s' has unparse-able expression '%s': %s at '%s'",
+                      line, filename, rrdcalc_name(rt), "crit", string2str(sec_cfg->crit), expression_strerror(error), failed_at);
+            }
+            parse_variables_and_store_in_health_rrdvars((char *)string2str(sec_cfg->crit), HEALTH_CONF_MAX_LINE);
+        }
+    }
+    if (sec_cfg->exec) {
+        if (rc) {
+            rc->exec = string_dup(sec_cfg->exec);
+        } else if (rt) {
+            rt->exec = string_dup(sec_cfg->exec);
+        }
+    }
+    if (sec_cfg->to) {
+        if (rc) {
+            rc->recipient = string_dup(sec_cfg->to);
+        } else if (rt) {
+            rt->recipient = string_dup(sec_cfg->to);
+        }
+    }
+    if (sec_cfg->units) {
+        if (rc) {
+            rc->units = string_dup(sec_cfg->units);
+        } else if (rt) {
+            rt->units = string_dup(sec_cfg->units);
+        }
+    }
+    if (sec_cfg->info) {
+        if (rc) {
+            rc->info = string_dup(sec_cfg->info);
+            rc->original_info = string_dup(sec_cfg->info);
+        } else if (rt) {
+            rt->info = string_dup(sec_cfg->info);
+        }
+    }
+    if (sec_cfg->delay) {
+        if (rc) {
+            health_parse_delay(line, filename, (char *)string2str(sec_cfg->delay), &rc->delay_up_duration, &rc->delay_down_duration, &rc->delay_max_duration, &rc->delay_multiplier);
+        } else if (rt) {
+            health_parse_delay(line, filename, (char *)string2str(sec_cfg->delay), &rt->delay_up_duration, &rt->delay_down_duration, &rt->delay_max_duration, &rt->delay_multiplier);
+        }
+    }
+    if (sec_cfg->options) {
+        if (rc) {
+            rc->options |= health_parse_options((char *)string2str(sec_cfg->options));
+        } else if (rt) {
+            rt->options |= health_parse_options((char *)string2str(sec_cfg->options));
+        }
+    }
+    if (sec_cfg->repeat) {
+        if (rc) {
+            health_parse_repeat(line, filename, (char *)string2str(sec_cfg->repeat), &rc->warn_repeat_every, &rc->crit_repeat_every);
+        } else if (rt) {
+            health_parse_repeat(line, filename, (char *)string2str(sec_cfg->repeat), &rt->warn_repeat_every, &rt->crit_repeat_every);
+        }
+    }
+    if (sec_cfg->host_labels) {
+        char *tmp = simple_pattern_trim_around_equal((char *)string2str(sec_cfg->host_labels));
+        if (rc) {
+            rc->host_labels = string_strdupz(tmp);
+            rc->host_labels_pattern = simple_pattern_create(rrdcalc_host_labels(rc), NULL, SIMPLE_PATTERN_EXACT, true);
+        } else if (rt) {
+            rt->host_labels = string_strdupz(tmp);
+            rt->host_labels_pattern = simple_pattern_create(rrdcalc_host_labels(rt), NULL, SIMPLE_PATTERN_EXACT, true);
+        }
+        freez(tmp);
+    }
+    if(sec_cfg->plugin) {
+        if (rc) {
+            string_freez(rc->plugin_match);
+            simple_pattern_free(rc->plugin_pattern);
+
+            rc->plugin_match = string_dup(sec_cfg->plugin);
+            rc->plugin_pattern = simple_pattern_create(rrdcalc_plugin_match(rc), NULL, SIMPLE_PATTERN_EXACT, true);
+        } else if (rt) {
+            string_freez(rt->plugin_match);
+            simple_pattern_free(rt->plugin_pattern);
+
+            rt->plugin_match = string_dup(sec_cfg->plugin);
+            rt->plugin_pattern = simple_pattern_create(rrdcalc_plugin_match(rt), NULL, SIMPLE_PATTERN_EXACT, true);
+        }
+    }
+    if(sec_cfg->module) {
+        if (rc) {
+            string_freez(rc->module_match);
+            simple_pattern_free(rc->module_pattern);
+
+            rc->module_match = string_dup(sec_cfg->module);
+            rc->module_pattern = simple_pattern_create(rrdcalc_module_match(rc), NULL, SIMPLE_PATTERN_EXACT, true);
+        } else if (rt) {
+            string_freez(rt->module_match);
+            simple_pattern_free(rt->module_pattern);
+
+            rt->module_match = string_dup(sec_cfg->module);
+            rt->module_pattern = simple_pattern_create(rrdcalc_module_match(rt), NULL, SIMPLE_PATTERN_EXACT, true);
+        }
+    }
+    if (sec_cfg->families) {
+        if (rt) {
+            string_freez(rt->family_match);
+            simple_pattern_free(rt->family_pattern);
+
+            rt->family_match = string_dup(sec_cfg->families);
+            rt->family_pattern = simple_pattern_create(rrdcalctemplate_family_match(rt), NULL, SIMPLE_PATTERN_EXACT,
+                                                       true);
+        }
+    }
+    if (sec_cfg->charts) {
+        if (rt) {
+            string_freez(rt->charts_match);
+            simple_pattern_free(rt->charts_pattern);
+
+            rt->charts_match = string_dup(sec_cfg->charts);
+            rt->charts_pattern = simple_pattern_create(rrdcalctemplate_charts_match(rt), NULL, SIMPLE_PATTERN_EXACT,
+                                                       true);
+        }
+    }
+
+    if (rc) {
+        alert_hash_and_store_config(rc->config_hash_id, sec_cfg, 1);//fix
+        rrdcalc_add_from_config(host, rc);
+    } else if (rt) {
+        rrdcalctemplate_add_from_config(host, rt);
+    }
 }
 
 int sql_store_hashes = 1;
-static int health_readfile(const char *filename, void *data) {
+static int health_legacy_readfile(const char *filename, void *data) {
     RRDHOST *host = (RRDHOST *)data;
 
     debug(D_HEALTH, "Health configuration reading file '%s'", filename);
@@ -1219,6 +1752,103 @@ static int health_readfile(const char *filename, void *data) {
         alert_config_free(alert_cfg);
 
     fclose(fp);
+    return 1;
+}
+
+void health_yaml_config_parse_node(yaml_document_t *document_p, yaml_node_t *node, struct alert_config *doc_cfg, struct alert_config *sec_cfg, yaml_node_t *key, RRDHOST *host)
+{
+    static int working_config = 0;
+	yaml_node_t *next_node_p, *key_node_p;
+
+    switch (node->type) {
+		case YAML_NO_NODE:
+			break;
+		case YAML_SCALAR_NODE:
+            if (!strcmp((char *)key->data.scalar.value, "template") || !strcmp((char *)key->data.scalar.value, "alert")) { //change this if to be if in section alerts:
+                if (working_config == 1) {
+                    health_create_alert_from_config(doc_cfg, sec_cfg, host, "todo", 1);
+                    alert_config_free(sec_cfg);
+                } else {
+                    working_config = 1;
+                }
+            }
+            if (working_config == 1)
+                health_config_store_key(sec_cfg, (const char *)key->data.scalar.value, (const char *)node->data.scalar.value);
+            else
+                health_config_store_key(doc_cfg, (const char *)key->data.scalar.value, (const char *)node->data.scalar.value);
+			break;
+		case YAML_SEQUENCE_NODE:
+			yaml_node_item_t *i_node;
+			for (i_node = node->data.sequence.items.start; i_node < node->data.sequence.items.top; i_node++) {
+				next_node_p = yaml_document_get_node(document_p, *i_node);
+				if (next_node_p)
+					health_yaml_config_parse_node(document_p, next_node_p, doc_cfg, sec_cfg, key, host);
+			}
+			break;
+		case YAML_MAPPING_NODE:
+			yaml_node_pair_t *i_node_p;
+			for (i_node_p = node->data.mapping.pairs.start; i_node_p < node->data.mapping.pairs.top; i_node_p++) {
+				key_node_p = yaml_document_get_node(document_p, i_node_p->key);
+				next_node_p = yaml_document_get_node(document_p, i_node_p->value);
+                health_yaml_config_parse_node(document_p, next_node_p, doc_cfg, sec_cfg, key_node_p, host);
+			}
+			break;
+		default:
+			break;
+	}
+}
+
+void health_yaml_config_handle_document(yaml_document_t *document_p, RRDHOST *host)
+{
+    yaml_node_t *node = yaml_document_get_root_node(document_p);
+
+    struct alert_config *doc_alert_cfg = NULL;
+    struct alert_config *sec_alert_cfg = NULL;
+    doc_alert_cfg = callocz(1, sizeof(struct alert_config));
+    sec_alert_cfg = callocz(1, sizeof(struct alert_config));
+
+	health_yaml_config_parse_node(document_p, node, doc_alert_cfg, sec_alert_cfg, NULL, host);
+    health_create_alert_from_config(doc_alert_cfg, sec_alert_cfg, host, "todo", 1);
+    alert_config_free(sec_alert_cfg);
+    alert_config_free(doc_alert_cfg);
+    freez(sec_alert_cfg);
+    freez(doc_alert_cfg);
+}
+
+static int health_readfile(const char *filename, void *data) {
+    RRDHOST *host = (RRDHOST *)data;
+
+    yaml_parser_t parser;
+    yaml_document_t document;
+    FILE *fp;
+    int yaml_error = 0;
+
+    fp = fopen(filename, "r");
+    yaml_parser_initialize(&parser);
+    yaml_parser_set_input_file(&parser, fp);
+
+    int done = 0;
+	while (!done)
+	{
+		if (!yaml_parser_load(&parser, &document)) {
+			yaml_error = 1;
+			break;
+		}
+
+		done = (!yaml_document_get_root_node(&document));
+
+		if (!done)
+			health_yaml_config_handle_document(&document, host);
+
+		yaml_document_delete(&document);
+	}
+
+	yaml_parser_delete(&parser);
+
+    if (yaml_error == 1) {
+        fclose(fp);
+        health_legacy_readfile(filename, host);
+    }
     return 1;
 }
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR adds a way to parse an alert configuration written in YAML. For the purpose of this, the `load.conf` file was converted like below, which mostly is to discuss what/how we want it:

```yaml
# you can disable an alarm notification by setting the 'to' line to: silent
---
# the chart or context the alerts operate on
alerting_rules:
 - on: system.load
   category:
    class: Latency
    type: System
    component: Network
   hosts: "*"
   os: linux
   calc: "($load_cpu_number == nan) ? (nan) : ($this)"
   every: 1m
   units: load
   delay: down 15m multiplier 1.5 max 1h
   to: sysadmin
   alerts:
# Calculate the base trigger point for the load average alarms.
# This is the maximum number of CPU's in the system over the past 1
# minute, with a special case for a single CPU of setting the trigger at 2.
    - alert: load_cpu_number
      calc: "($active_processors == nan or $active_processors == 0) ? (nan) : ( ($active_processors < 2) ? ( 2 ) : ( $active_processors ) )"
      units: cpus
      info: number of active CPU cores in the system
# Send alarms if the load average is unusually high.
# These intentionally _do not_ calculate the average over the sampled
# time period because the values being checked already are averages.
    - alert: load_average_15
      lookup: max -1m unaligned of load15
      warn: "($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 175 : 200)"
      info: system fifteen-minute load average
    - alert: load_average_5
      lookup: max -1m unaligned of load5
      warn: "($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 350 : 400)"
      info: system five-minute load average
    - alert: load_average_1
      lookup: max -1m unaligned of load1
      warn: "($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 700 : 800)"
      info: system one-minute load average
```

There are no new fields than we have now, no checks on actual fields, no support for sequences, they will be done when we decide on the final format we want.

The basic idea is to combine "similar" alerts into one document, having a global part with repeated fields. In the above example, e.g. `calc` will be applied to all alerts except `load_cpu_number` which has it's own `calc` field. We can discuss.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Running the PR now, should create `load_cpu_number`, `load_average_15`, `load_average_5` and `load_average_1`.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
