### PR TITLE
Fix how we are handling system services in RPM packages.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -34,6 +34,9 @@ AutoReqProv: yes
 %define _libexecdir /usr/libexec
 %define _libdir /usr/lib
 
+# Fedora doesn’t define this, but other distros do
+%{!?_presetdir:%global _presetdir %{_libdir}/systemd/system-preset}
+
 # Redefine centos_ver to standardize on a single macro
 %{?rhel:%global centos_ver %rhel}
 
@@ -290,6 +293,8 @@ install -m 755 -d "${RPM_BUILD_ROOT}%{_localstatedir}/lib/%{name}/registry"
 # Install netdata service
 install -m 755 -d "${RPM_BUILD_ROOT}%{_unitdir}"
 install -m 644 -p system/systemd/netdata.service "${RPM_BUILD_ROOT}%{_unitdir}/netdata.service"
+install -m 755 -d "${RPM_BUILD_ROOT}%{_presetdir}"
+install -m 644 -p system/systemd/50-netdata.preset "${RPM_BUILD_ROOT}%{_presetdir}/50-netdata.preset"
 
 # ############################################################
 # Package Go within netdata (TBD: Package it separately)
@@ -445,6 +450,7 @@ rm -rf "${RPM_BUILD_ROOT}"
 %{_sbindir}/netdata-claim.sh
 
 %{_unitdir}/netdata.service
+%{_presetdir}/50-netdata.preset
 
 %defattr(0750,root,netdata,0750)
 

--- a/system/Makefile.am
+++ b/system/Makefile.am
@@ -113,6 +113,7 @@ nodist_libsyssystemd_DATA = \
 
 dist_libsyssystemd_DATA = \
     systemd/netdata-updater.timer \
+    systemd/50-netdata.preset
     $(NULL)
 
 dist_noinst_DATA = \

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -237,6 +237,8 @@ get_systemd_service_dir() {
 
 install_systemd_service() {
   SRCFILE="${SVC_SOURCE}/systemd/netdata.service"
+  PRESET_FILE="${SVC_SOURCE}/systemd/50-netdata.preset"
+  SVCDIR="$(get_systemd_service_dir)"
 
   if [ "$(systemctl --version | head -n 1 | cut -f 2 -d ' ')" -le 235 ]; then
     SRCFILE="${SVC_SOURCE}/systemd/netdata.service.v235"
@@ -255,18 +257,24 @@ install_systemd_service() {
   fi
 
   info "Installing systemd service..."
-  if ! install -p -m 0644 -o 0 -g 0 "${SRCFILE}" "$(get_systemd_service_dir)/netdata.service"; then
+  if ! install -p -m 0644 -o 0 -g 0 "${SRCFILE}" "${SVCDIR}/netdata.service"; then
     error "Failed to install systemd service file."
     exit 4
   fi
 
+  if [ -f "${PRESET_FILE}" ]; then
+    if ! install -p -m 0644 -o 0 -g 0 "${PRESET_FILE}" "${SVCDIR}-preset/50-netdata.preset"; then
+      warning "Failed to install netdata preset file."
+    fi
+  fi
+
   if [ "$(check_systemd)" = "YES" ]; then
     if ! systemctl daemon-reload; then
-        warning "Failed to reload systemd unit files."
+      warning "Failed to reload systemd unit files."
     fi
 
     if ! systemctl "${ENABLE}" netdata; then
-        warning "Failed to ${ENABLE} Netdata service."
+      warning "Failed to ${ENABLE} Netdata service."
     fi
   fi
 }

--- a/system/systemd/50-netdata.preset
+++ b/system/systemd/50-netdata.preset
@@ -1,0 +1,1 @@
+enable netdata.service


### PR DESCRIPTION
##### Summary

- Completely drop the old non-systemd init handling code. None of the platforms we support actually use this, so it’s dead code at this point.
- Rely on the platform-provided macros for service handling, instead of doing our own thing. These do the right thing in 99.99% of cases, and behave how we actually need them to.
- Don’t depend on systemd at runtime. The macros handle this correctly, and nothing we actually do _needs_ systemd at runtime.
- Actually follow packaging guidelines for upgrades. In particular, only restart the agent if it’s already running (instead of unconditionally), and don’t enable it if it’s disabled.
- Just put the macro invocations down in the actual scriptlets, instead of using complicated nested macro definitions to compute things ahead of time. This makes the code _much_ easier to understand.

##### Test Plan

Preliminary testing involves confirming all packaging CI passes on this PR. In particular, openSUSE _should_ pass here.

Secondary testing involves [building the packages locally](https://github.com/netdata/netdata/blob/master/packaging/building-native-packages-locally.md), installing them in VMs (or containers that are actually running systemd), and confirming that the service gets installed correctly.

##### Additional Information

Fixes: #11460

Prerequisite for #14771 and #14453

Likely fixes a bunch of unreported bugs as well.