### PR TITLE
uuid_compare() replaced with uuid_memcmp()

### DIFF
--- a/database/contexts/instance.c
+++ b/database/contexts/instance.c
@@ -137,7 +137,7 @@ static bool rrdinstance_conflict_callback(const DICTIONARY_ITEM *item __maybe_un
                    "RRDINSTANCE: '%s' cannot change id to '%s'",
                    string2str(ri->id), string2str(ri_new->id));
 
-    if(uuid_compare(ri->uuid, ri_new->uuid) != 0) {
+    if(uuid_memcmp(&ri->uuid, &ri_new->uuid) != 0) {
 #ifdef NETDATA_INTERNAL_CHECKS
         char uuid1[UUID_STR_LEN], uuid2[UUID_STR_LEN];
         uuid_unparse(ri->uuid, uuid1);
@@ -156,7 +156,7 @@ static bool rrdinstance_conflict_callback(const DICTIONARY_ITEM *item __maybe_un
     }
 
 #ifdef NETDATA_INTERNAL_CHECKS
-    if(ri->rrdset && uuid_compare(ri->uuid, ri->rrdset->chart_uuid) != 0) {
+    if(ri->rrdset && uuid_memcmp(&ri->uuid, &ri->rrdset->chart_uuid) != 0) {
         char uuid1[UUID_STR_LEN], uuid2[UUID_STR_LEN];
         uuid_unparse(ri->uuid, uuid1);
         uuid_unparse(ri->rrdset->chart_uuid, uuid2);

--- a/database/contexts/metric.c
+++ b/database/contexts/metric.c
@@ -108,7 +108,7 @@ static bool rrdmetric_conflict_callback(const DICTIONARY_ITEM *item __maybe_unus
                    "RRDMETRIC: '%s' cannot change id to '%s'",
                    string2str(rm->id), string2str(rm_new->id));
 
-    if(uuid_compare(rm->uuid, rm_new->uuid) != 0) {
+    if(uuid_memcmp(&rm->uuid, &rm_new->uuid) != 0) {
 #ifdef NETDATA_INTERNAL_CHECKS
         char uuid1[UUID_STR_LEN], uuid2[UUID_STR_LEN];
         uuid_unparse(rm->uuid, uuid1);
@@ -150,7 +150,7 @@ static bool rrdmetric_conflict_callback(const DICTIONARY_ITEM *item __maybe_unus
     }
 
 #ifdef NETDATA_INTERNAL_CHECKS
-    if(rm->rrddim && uuid_compare(rm->uuid, rm->rrddim->metric_uuid) != 0) {
+    if(rm->rrddim && uuid_memcmp(&rm->uuid, &rm->rrddim->metric_uuid) != 0) {
         char uuid1[UUID_STR_LEN], uuid2[UUID_STR_LEN];
         uuid_unparse(rm->uuid, uuid1);
         uuid_unparse(rm_new->uuid, uuid2);

--- a/database/contexts/rrdcontext.c
+++ b/database/contexts/rrdcontext.c
@@ -212,7 +212,7 @@ static RRDHOST *rrdhost_find_by_node_id(const char *node_id) {
     dfe_start_read(rrdhost_root_index, host) {
         if(!host->node_id) continue;
 
-        if(uuid_compare(uuid, *host->node_id) == 0)
+        if(uuid_memcmp(&uuid, host->node_id) == 0)
             break;
     }
     dfe_done(host);

--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -99,11 +99,6 @@ inline TIME_RANGE_COMPARE is_page_in_time_range(time_t page_first_time_s, time_t
     return PAGE_IS_IN_RANGE;
 }
 
-static int journal_metric_uuid_compare(const void *key, const void *metric)
-{
-    return memcmp(key, &(((struct journal_metric_list *) metric)->uuid), sizeof(uuid_t));
-}
-
 static inline struct page_details *pdc_find_page_for_time(
         Pcvoid_t PArray,
         time_t wanted_time_s,

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -927,11 +927,6 @@ struct uuid_first_time_s {
     size_t df_index_oldest;
 };
 
-static int journal_metric_compare(const void *key, const void *metric)
-{
-    return uuid_compare(*(uuid_t *) key, ((struct journal_metric_list *) metric)->uuid);
-}
-
 struct rrdengine_datafile *datafile_release_and_acquire_next_for_retention(struct rrdengine_instance *ctx, struct rrdengine_datafile *datafile) {
 
     uv_rwlock_rdlock(&ctx->datafiles.rwlock);
@@ -987,7 +982,10 @@ void find_uuid_first_time(
             if (uuid_original_entry->df_matched > 3 || uuid_original_entry->pages_found > 5)
                 continue;
 
-            struct journal_metric_list *live_entry = bsearch(uuid_original_entry->uuid,uuid_list,journal_metric_count,sizeof(*uuid_list), journal_metric_compare);
+            struct journal_metric_list *live_entry =
+                    bsearch(uuid_original_entry->uuid,uuid_list,journal_metric_count,
+                            sizeof(*uuid_list), journal_metric_uuid_compare);
+
             if (!live_entry) {
                 // Not found in this journal
                 not_matching_bsearches++;

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -515,4 +515,8 @@ static inline time_t max_acceptable_collected_time(void) {
 
 void datafile_delete(struct rrdengine_instance *ctx, struct rrdengine_datafile *datafile, bool update_retention, bool worker);
 
+static inline int journal_metric_uuid_compare(const void *key, const void *metric) {
+    return uuid_memcmp((uuid_t *)key, &(((struct journal_metric_list *) metric)->uuid));
+}
+
 #endif /* NETDATA_RRDENGINE_H */

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -161,7 +161,7 @@ STORAGE_METRIC_HANDLE *rrdeng_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE 
     }
 
 #ifdef NETDATA_INTERNAL_CHECKS
-    if(uuid_compare(rd->metric_uuid, *mrg_metric_uuid(main_mrg, metric)) != 0) {
+    if(uuid_memcmp(&rd->metric_uuid, mrg_metric_uuid(main_mrg, metric)) != 0) {
         char uuid1[UUID_STR_LEN + 1];
         char uuid2[UUID_STR_LEN + 1];
 

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -91,7 +91,7 @@ static inline RRDHOST *find_host_by_node_id(char *node_id)
     rrd_rdlock();
     RRDHOST *host, *ret = NULL;
     rrdhost_foreach_read(host) {
-        if (host->node_id && !(uuid_compare(*host->node_id, node_uuid))) {
+        if (host->node_id && !(uuid_memcmp(host->node_id, &node_uuid))) {
             ret = host;
             break;
         }

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -133,7 +133,7 @@ int should_send_to_cloud(RRDHOST *host, ALARM_ENTRY *ae)
         goto done;
     }
 
-    if (uuid_compare(ae->config_hash_id, config_hash_id)) {
+    if (uuid_memcmp(&ae->config_hash_id, &config_hash_id)) {
         send = 1;
         goto done;
     }

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -779,7 +779,7 @@ struct node_instance_list *get_node_list(void)
             node_list[row].live = (host && (host == localhost || host->receiver
                                             || !(rrdhost_flag_check(host, RRDHOST_FLAG_ORPHAN)))) ? 1 : 0;
             node_list[row].hops = (host && host->system_info) ? host->system_info->hops :
-                                  uuid_compare(*host_id, localhost->host_uuid) ? 1 : 0;
+                                  uuid_memcmp(host_id, &localhost->host_uuid) ? 1 : 0;
             node_list[row].hostname =
                 sqlite3_column_bytes(res, 2) ? strdupz((char *)sqlite3_column_text(res, 2)) : NULL;
         }

--- a/libnetdata/inlined.h
+++ b/libnetdata/inlined.h
@@ -510,4 +510,8 @@ static inline int read_single_signed_number_file(const char *filename, long long
     return 0;
 }
 
+static inline int uuid_memcmp(const uuid_t *uu1, const uuid_t *uu2) {
+    return memcmp(uu1, uu2, sizeof(uuid_t));
+}
+
 #endif //NETDATA_INLINED_H


### PR DESCRIPTION
- [x] BUGFIX: left-over of PR #14750 to use memcmp() instead of uuid_compare() when calculating the retention of the metrics during db rotation
- [x] replace `uuid_compare()` with `uuid_memcmp()` everywhere where the order is not important but equality is
