### PR TITLE
Schedule node info to the cloud after child connection

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -1221,9 +1221,9 @@ void add_aclk_host_labels(void) {
 #endif
 }
 
-void aclk_queue_node_info(RRDHOST *host) {
+void aclk_queue_node_info(RRDHOST *host, bool immediate)
+{
     struct aclk_sync_host_config *wc = (struct aclk_sync_host_config *) host->aclk_sync_host_config;
-    if (likely(wc)) {
-        wc->node_info_send = 1;
-    }
+    if (likely(wc))
+        wc->node_info_send_time = (host == localhost || immediate) ? 1 : now_realtime_sec();
 }

--- a/aclk/aclk.h
+++ b/aclk/aclk.h
@@ -54,6 +54,6 @@ void aclk_send_bin_msg(char *msg, size_t msg_len, enum aclk_topics subtopic, con
 char *aclk_state(void);
 char *aclk_state_json(void);
 void add_aclk_host_labels(void);
-void aclk_queue_node_info(RRDHOST *host);
+void aclk_queue_node_info(RRDHOST *host, bool immediate);
 
 #endif /* ACLK_H */

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1348,7 +1348,7 @@ void rrdhost_set_is_parent_label(int count) {
         //queue a node info
 #ifdef ENABLE_ACLK
         if (netdata_cloud_setting) {
-            aclk_queue_node_info(localhost);
+            aclk_queue_node_info(localhost, false);
         }
 #endif
     }

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -90,7 +90,7 @@ enum {
 
 static int create_host_callback(void *data, int argc, char **argv, char **column)
 {
-    UNUSED(data);
+    int *number_of_chidren = data;
     UNUSED(argc);
     UNUSED(column);
 
@@ -131,6 +131,8 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
     );
     if (likely(host))
         host->rrdlabels = sql_load_host_labels((uuid_t *)argv[IDX_HOST_ID]);
+
+    (*number_of_chidren)++;
 
 #ifdef NETDATA_INTERNAL_CHECKS
     char node_str[UUID_STR_LEN] = "<none>";
@@ -520,7 +522,8 @@ void sql_create_aclk_table(RRDHOST *host __maybe_unused, uuid_t *host_uuid __may
     wc->host = host;
     strcpy(wc->uuid_str, uuid_str);
     wc->alert_updates = 0;
-    wc->node_info_send_time = now_realtime_sec();
+    time_t now = now_realtime_sec();
+    wc->node_info_send_time = (host == localhost || NULL == localhost) ? now - 25 : now;
 #endif
 }
 
@@ -544,16 +547,22 @@ void sql_aclk_sync_init(void)
     }
 
     info("Creating archived hosts");
-    rc = sqlite3_exec_monitored(db_meta, SQL_FETCH_ALL_HOSTS, create_host_callback, NULL, &err_msg);
+    int number_of_children = 0;
+    rc = sqlite3_exec_monitored(db_meta, SQL_FETCH_ALL_HOSTS, create_host_callback, &number_of_children, &err_msg);
 
     if (rc != SQLITE_OK) {
         error_report("SQLite error when loading archived hosts, rc = %d (%s)", rc, err_msg);
         sqlite3_free(err_msg);
     }
+
+    info("Created %d archived hosts", number_of_children);
     // Trigger host context load for hosts that have been created
     metadata_queue_load_host_context(NULL);
 
 #ifdef ENABLE_ACLK
+    if (!number_of_children)
+        aclk_queue_node_info(localhost, true);
+
     rc = sqlite3_exec_monitored(db_meta, SQL_FETCH_ALL_INSTANCES,aclk_config_parameters, NULL,&err_msg);
 
     if (rc != SQLITE_OK) {

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -520,7 +520,7 @@ void sql_create_aclk_table(RRDHOST *host __maybe_unused, uuid_t *host_uuid __may
     wc->host = host;
     strcpy(wc->uuid_str, uuid_str);
     wc->alert_updates = 0;
-    wc->node_info_send = 1;
+    wc->node_info_send_time = now_realtime_sec();
 #endif
 }
 

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -72,7 +72,7 @@ struct aclk_database_cmdqueue {
 struct aclk_sync_host_config {
     RRDHOST *host;
     int alert_updates;
-    int node_info_send;
+    time_t node_info_send_time;
     time_t node_collectors_send;
     char uuid_str[UUID_STR_LEN];
     char node_id[UUID_STR_LEN];

--- a/database/sqlite/sqlite_aclk_node.c
+++ b/database/sqlite/sqlite_aclk_node.c
@@ -73,8 +73,6 @@ static void build_node_info(char *node_id __maybe_unused)
         return;
     }
 
-    wc->node_info_send = 1;
-
     rrd_rdlock();
     node_info.node_id = wc->node_id;
     node_info.claim_id = get_agent_claimid();
@@ -148,20 +146,22 @@ void aclk_check_node_info_and_collectors(void)
 
     dfe_start_reentrant(rrdhost_root_index, host) {
 
+        struct aclk_sync_host_config *wc = host->aclk_sync_host_config;
+        if (unlikely(!wc))
+            continue;
+
         if (unlikely(rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD))) {
             info("ACLK: 'host:%s' not sending node info, context load is pending", rrdhost_hostname(host));
             continue;
         }
 
-        struct aclk_sync_host_config *wc = host->aclk_sync_host_config;
+        if (wc->node_info_send_time && wc->node_info_send_time + 5 > now_realtime_sec())
+            internal_error(true, "ACLK SYNC: NOT TIME YET TO SEND info for %s, %ld", rrdhost_hostname(host), now_realtime_sec() - wc->node_info_send_time);
 
-        if (unlikely(!wc))
-            continue;
-
-        if (wc->node_info_send) {
+        if (wc->node_info_send_time && wc->node_info_send_time + 30 < now_realtime_sec()) {
+            wc->node_info_send_time = 0;
             build_node_info(strdupz(wc->node_id));
             internal_error(true, "ACLK SYNC: Sending node info for %s", rrdhost_hostname(host));
-            wc->node_info_send = 0;
         }
 
         if (wc->node_collectors_send && wc->node_collectors_send + 30 < now_realtime_sec()) {

--- a/database/sqlite/sqlite_aclk_node.c
+++ b/database/sqlite/sqlite_aclk_node.c
@@ -155,9 +155,6 @@ void aclk_check_node_info_and_collectors(void)
             continue;
         }
 
-        if (wc->node_info_send_time && wc->node_info_send_time + 5 > now_realtime_sec())
-            internal_error(true, "ACLK SYNC: NOT TIME YET TO SEND info for %s, %ld", rrdhost_hostname(host), now_realtime_sec() - wc->node_info_send_time);
-
         if (wc->node_info_send_time && wc->node_info_send_time + 30 < now_realtime_sec()) {
             wc->node_info_send_time = 0;
             build_node_info(strdupz(wc->node_id));

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -892,6 +892,10 @@ static void restore_host_context(void *arg)
 
     rrdhost_flag_clear(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD | RRDHOST_FLAG_CONTEXT_LOAD_IN_PROGRESS);
 
+#ifdef ENABLE_ACLK
+    aclk_queue_node_info(host, false);
+#endif
+
     internal_error(true, "METADATA: 'host:%s' context load in %0.2f ms", rrdhost_hostname(host),
         (double)(ended_ut - started_ut) / USEC_PER_MS);
 

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -437,7 +437,7 @@ static void rrdpush_receiver_replication_reset(RRDHOST *host) {
     rrdhost_receiver_replicating_charts_zero(host);
 }
 
-bool rrdhost_set_receiver(RRDHOST *host, struct receiver_state *rpt) {
+static bool rrdhost_set_receiver(RRDHOST *host, struct receiver_state *rpt) {
     bool signal_rrdcontext = false;
     bool set_this = false;
 
@@ -472,6 +472,7 @@ bool rrdhost_set_receiver(RRDHOST *host, struct receiver_state *rpt) {
         rrdpush_receiver_replication_reset(host);
 
         rrdhost_flag_clear(rpt->host, RRDHOST_FLAG_RRDPUSH_RECEIVER_DISCONNECTED);
+        aclk_queue_node_info(rpt->host, true);
 
         set_this = true;
     }


### PR DESCRIPTION
##### Summary
Resolve a timing issue when announcing the capabilities of a child when connecting to cloud via ACLK

During agent startup the capabilities of a child are not known (since the child is not connected and may not connect). The node information related to the child needs to reach the cloud though, based on stored metadata. 

When the child eventually connects the information needs to be updated

Fixes: #14783
