### PR TITLE
use mCPU in k8s cgroup cpu charts title

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -3676,7 +3676,10 @@ void update_cgroup_charts(int update_every) {
 
         if(likely(cg->cpuacct_stat.updated && cg->cpuacct_stat.enabled == CONFIG_BOOLEAN_YES)) {
             if(unlikely(!cg->st_cpu)) {
-                snprintfz(title, CHART_TITLE_MAX, "CPU Usage (100%% = 1 core)");
+                snprintfz(
+                    title,
+                    CHART_TITLE_MAX,
+                    k8s_is_kubepod(cg) ? "CPU Usage (100%% = 1000 mCores)" : "CPU Usage (100%% = 1 core)");
 
                 cg->st_cpu = rrdset_create_localhost(
                         cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
@@ -3879,7 +3882,11 @@ void update_cgroup_charts(int update_every) {
             unsigned int i;
 
             if(unlikely(!cg->st_cpu_per_core)) {
-                snprintfz(title, CHART_TITLE_MAX, "CPU Usage (100%% = 1 core) Per Core");
+                snprintfz(
+                    title,
+                    CHART_TITLE_MAX,
+                    k8s_is_kubepod(cg) ? "CPU Usage (100%% = 1000 mCores) Per Core" :
+                                         "CPU Usage (100%% = 1 core) Per Core");
 
                 cg->st_cpu_per_core = rrdset_create_localhost(
                         cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -3679,7 +3679,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(
                     title,
                     CHART_TITLE_MAX,
-                    k8s_is_kubepod(cg) ? "CPU Usage (100%% = 1000 mCores)" : "CPU Usage (100%% = 1 core)");
+                    k8s_is_kubepod(cg) ? "CPU Usage (100%% = 1000 mCPU)" : "CPU Usage (100%% = 1 core)");
 
                 cg->st_cpu = rrdset_create_localhost(
                         cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
@@ -3885,7 +3885,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(
                     title,
                     CHART_TITLE_MAX,
-                    k8s_is_kubepod(cg) ? "CPU Usage (100%% = 1000 mCores) Per Core" :
+                    k8s_is_kubepod(cg) ? "CPU Usage (100%% = 1000 mCPU) Per Core" :
                                          "CPU Usage (100%% = 1 core) Per Core");
 
                 cg->st_cpu_per_core = rrdset_create_localhost(


### PR DESCRIPTION
##### Summary

Because it is more native in K8s. Requested by @M4itee.

##### Test Plan

ci

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
