### PR TITLE
Fix handling of logrotate on static installs.

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -845,10 +845,18 @@ restart_netdata() {
 # install netdata logrotate
 
 install_netdata_logrotate() {
+  prefix="${1}"
+
+  if [ -n "${prefix}" ]; then
+    src="${prefix}/system/logrotate/netdata"
+  else
+    src="system/logrotate/netdata"
+  fi
+
   if [ "${UID}" -eq 0 ]; then
     if [ -d /etc/logrotate.d ]; then
       if [ ! -f /etc/logrotate.d/netdata ]; then
-        run cp system/logrotate/netdata /etc/logrotate.d/netdata
+        run cp "${src}" /etc/logrotate.d/netdata
       fi
 
       if [ -f /etc/logrotate.d/netdata ]; then

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -138,7 +138,7 @@ fi
 # -----------------------------------------------------------------------------
 progress "Install logrotate configuration for netdata"
 
-install_netdata_logrotate || run_failed "Cannot install logrotate file for netdata."
+install_netdata_logrotate "${NETDATA_PREFIX}" || run_failed "Cannot install logrotate file for netdata."
 
 # -----------------------------------------------------------------------------
 progress "Telemetry configuration"


### PR DESCRIPTION
##### Summary

It was broken by https://github.com/netdata/netdata/pull/14544.

##### Test Plan

Try installing a static build.

If built from the master branch, it should fail to install a logrotate configuration.

If built from this PR, it should correctly install logrotate configuration.

##### Additional Information

Fixes: #14786.