### PR TITLE
Replace `/docs` links with GitHub links

### DIFF
--- a/docs/cloud/insights/metric-correlations.md
+++ b/docs/cloud/insights/metric-correlations.md
@@ -53,7 +53,7 @@ Behind the scenes, Netdata will aggregate the raw data as needed such that arbit
 
 ### Data
 
-Netdata is different from typical observability agents since, in addition to just collecting raw metric values, it will by default also assign an "[Anomaly Bit](/docs/agent/ml#anomaly-bit)" related to each collected metric each second. This bit will be 0 for "normal" and 1 for "anomalous". This means that each metric also natively has an "[Anomaly Rate](/docs/agent/ml#anomaly-rate)" associated with it and, as such, MC can be run against the raw metric values or their corresponding anomaly rates.
+Netdata is different from typical observability agents since, in addition to just collecting raw metric values, it will by default also assign an "[Anomaly Bit](https://github.com/netdata/netdata/tree/master/ml#anomaly-bit---100--anomalous-0--normal)" related to each collected metric each second. This bit will be 0 for "normal" and 1 for "anomalous". This means that each metric also natively has an "[Anomaly Rate](https://github.com/netdata/netdata/tree/master/ml#anomaly-rate---averageanomaly-bit)" associated with it and, as such, MC can be run against the raw metric values or their corresponding anomaly rates.
 
 **Note**: Read more [here](https://github.com/netdata/netdata/blob/master/ml/README.md) to learn more about the native anomaly detection features within netdata.
 

--- a/docs/cloud/visualize/dashboards.md
+++ b/docs/cloud/visualize/dashboards.md
@@ -27,7 +27,7 @@ dashboards](https://user-images.githubusercontent.com/1153921/108529360-a2145d00
 In the modal, give your new dashboard a name, and click **+ Add**.
 
 Click the **Add Chart** button to add your first chart card. From the dropdown, select either *All Nodes** or a specific
-node. If you select **All Nodes**, you will add a [composite chart](/docs/cloud/visualize/overview#composite-charts) to
+node. If you select **All Nodes**, you will add a [composite chart](https://github.com/netdata/netdata/blob/master/docs/cloud/visualize/overview.md) to
 your new dashboard. Next, select the context. You'll see a preview of the chart before you finish adding it.
 
 The **Add Text** button creates a new card with user-defined text, which you can use to describe or document a
@@ -46,7 +46,7 @@ of any number of **cards**, which can contain charts or text.
 ### Chart cards
 
 Click the **Add Chart** button to add your first chart card. From the dropdown, select either *All Nodes** or a specific
-node. If you select **All Nodes**, you will add a [composite chart](/docs/cloud/visualize/overview#composite-charts) to
+node. If you select **All Nodes**, you will add a [composite chart](https://github.com/netdata/netdata/blob/master/docs/cloud/visualize/overview.md) to
 your new dashboard. Next, select the context. You'll see a preview of the chart before you finish adding it.
 
 The charts you add to any dashboard are fully interactive, just like the charts in an Agent dashboard or a single node's

--- a/docs/cloud/visualize/interact-new-charts.md
+++ b/docs/cloud/visualize/interact-new-charts.md
@@ -193,7 +193,7 @@ following:
 :::
 
 For more details on each, you can refer to our Agent's HTTP API details
-on [Data Queries - Data Grouping](/docs/agent/web/api/queries#data-grouping).
+on [Data Queries - Data Grouping](https://github.com/netdata/netdata/blob/master/web/api/queries/README.md#data-grouping).
 
 ### Reset to defaults
 

--- a/docs/cloud/visualize/nodes.md
+++ b/docs/cloud/visualize/nodes.md
@@ -35,5 +35,5 @@ need to configure those nodes to collect from additional data sources. See our [
 to learn how to use dozens of pre-installed collectors that can instantly collect from your favorite services and applications.
 
 If you want to see up to 30 days of historical metrics in Cloud (and more on individual node dashboards), read about [changing how long Netdata stores metrics](https://github.com/netdata/netdata/blob/master/docs/store/change-metrics-storage.md). Also, see our
-[calculator](/docs/store/change-metrics-storage#calculate-the-system-resources-RAM-disk-space-needed-to-store-metrics)
+[calculator](https://github.com/netdata/netdata/blob/master/docs/store/change-metrics-storage.md#calculate-the-system-resources-ram-disk-space-needed-to-store-metrics)
 for finding the disk and RAM you need to store metrics for a certain period of time.

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -14,7 +14,7 @@ node_ via individual Netdata Agents. If you want to deploy a new alarm across yo
 files.
 
 ## Edit health configuration files
-
+https://learn.netdata.cloud/docs/agent/ml 
 You can configure the Agent's health watchdog service by editing files in two locations:
 
 - The `[health]` section in `netdata.conf`. By editing the daemon's behavior, you can disable health monitoring

--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -14,7 +14,7 @@ node_ via individual Netdata Agents. If you want to deploy a new alarm across yo
 files.
 
 ## Edit health configuration files
-https://learn.netdata.cloud/docs/agent/ml 
+
 You can configure the Agent's health watchdog service by editing files in two locations:
 
 - The `[health]` section in `netdata.conf`. By editing the daemon's behavior, you can disable health monitoring


### PR DESCRIPTION
##### Summary

Related to https://github.com/netdata/learn/issues/1522\

This PR replaces `/docs/...` links with proper GitHub links, so the ingest can parse them.