### PR TITLE
add validation step before using GCP metadata

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -462,7 +462,7 @@ if [ "${VIRTUALIZATION}" != "none" ] && command -v curl > /dev/null 2>&1; then
 
     # Try GCE computeMetadata v1
     if [ "${CLOUD_TYPE}" = "unknown" ]; then
-      if data="$(curl --fail -s --connect-timeout 1 -m 3 --noproxy "*" -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1")" && echo "$data" | grep -sq computeMetadata; then
+      if curl --fail -s --connect-timeout 1 -m 3 --noproxy "*" -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1" | grep -sq computeMetadata; then
         CLOUD_TYPE="GCP"
         CLOUD_INSTANCE_TYPE="$(curl --fail -s --connect-timeout 1 -m 3 --noproxy "*" -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/machine-type")"
         [ -n "$CLOUD_INSTANCE_TYPE" ] && CLOUD_INSTANCE_TYPE=$(basename "$CLOUD_INSTANCE_TYPE")

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -462,7 +462,7 @@ if [ "${VIRTUALIZATION}" != "none" ] && command -v curl > /dev/null 2>&1; then
 
     # Try GCE computeMetadata v1
     if [ "${CLOUD_TYPE}" = "unknown" ]; then
-      if [ -n "$(curl --fail -s --connect-timeout 1 -m 3 --noproxy "*" -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1")" ]; then
+      if data="$(curl --fail -s --connect-timeout 1 -m 3 --noproxy "*" -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1")" && echo "$data" | grep -sq computeMetadata; then
         CLOUD_TYPE="GCP"
         CLOUD_INSTANCE_TYPE="$(curl --fail -s --connect-timeout 1 -m 3 --noproxy "*" -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/machine-type")"
         [ -n "$CLOUD_INSTANCE_TYPE" ] && CLOUD_INSTANCE_TYPE=$(basename "$CLOUD_INSTANCE_TYPE")


### PR DESCRIPTION
##### Summary

Reported on [Discord](https://discord.com/channels/847502280503590932/1088195686706716682).

An instance returns unexpected data and 200 to the following query:

https://github.com/netdata/netdata/blob/4da956f37476e791d319a33962f440f00efa2ed2/daemon/system-info.sh#L465

The instance (!)

> has no relation to Google or any other cloud provider. It's a VM on my own Proxmox machine

Response:

```
<html><head><title>metadata.google.internal</title></head><body><h1>metadata.google.internal</h1><p>Coming soon.</p></body></html>
```


</details>

This PR adds an additional data validation step before considering the host to be a GCP cloud host.

##### Test Plan

Test on a GCP VM and on an instance that returns unexpected data.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
