### PR TITLE
Document CetusGuard as a Docker socket proxy solution

### DIFF
--- a/collectors/cgroups.plugin/README.md
+++ b/collectors/cgroups.plugin/README.md
@@ -120,8 +120,8 @@ container names. To do this, ensure `podman system service` is running and Netda
 to `/run/podman/podman.sock` (the default permissions as specified by upstream are `0600`, with owner `root`, so you
 will have to adjust the configuration).
 
-[docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy) can also be used to give Netdata restricted
-access to the socket. Note that `PODMAN_HOST` in Netdata's environment should be set to the proxy's URL in this case.
+[CetusGuard](https://github.com/hectorm/cetusguard) can also be used to give Netdata restricted access to the socket.
+Note that `PODMAN_HOST` in Netdata's environment should be set to the proxy's URL in this case.
 
 ### Charts with zero metrics
 

--- a/collectors/cgroups.plugin/README.md
+++ b/collectors/cgroups.plugin/README.md
@@ -120,8 +120,9 @@ container names. To do this, ensure `podman system service` is running and Netda
 to `/run/podman/podman.sock` (the default permissions as specified by upstream are `0600`, with owner `root`, so you
 will have to adjust the configuration).
 
-[CetusGuard](https://github.com/hectorm/cetusguard) can also be used to give Netdata restricted access to the socket.
-Note that `PODMAN_HOST` in Netdata's environment should be set to the proxy's URL in this case.
+[Docker Socket Proxy (HAProxy)](https://github.com/Tecnativa/docker-socket-proxy) or [CetusGuard](https://github.com/hectorm/cetusguard)
+can also be used to give Netdata restricted access to the socket. Note that `PODMAN_HOST` in Netdata's environment should
+be set to the proxy's URL in this case.
 
 ### Charts with zero metrics
 

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -331,16 +331,16 @@ your machine from within the container. Please read the following carefully.
 #### Docker socket proxy (safest option)
 
 Deploy a Docker socket proxy that accepts and filters out requests using something like
-[HAProxy](https://github.com/netdata/netdata/blob/master/docs/Running-behind-haproxy.md) so that it restricts connections to read-only access to the CONTAINERS
+[HAProxy](https://github.com/netdata/netdata/blob/master/docs/Running-behind-haproxy.md) or
+[CetusGuard](https://github.com/hectorm/cetusguard) so that it restricts connections to read-only access to the `/containers`
 endpoint.
 
 The reason it's safer to expose the socket to the proxy is because Netdata has a TCP port exposed outside the Docker
 network. Access to the proxy container is limited to only within the network.
 
-Below is [an example repository (and image)](https://github.com/Tecnativa/docker-socket-proxy) that provides a proxy to
-the socket.
+Below is an example using CetusGuard, a tool that provides a proxy to the socket and can filter the API calls.
 
-You run the Docker Socket Proxy in its own Docker Compose file and leave it on a private network that you can add to
+You can run the socket proxy in its own Docker Compose file and leave it on a private network that you can add to
 other services that require access.
 
 ```yaml
@@ -352,13 +352,18 @@ services:
     ports:
       - 19999:19999
     environment:
-      - DOCKER_HOST=proxy:2375
-  proxy:
-    image: tecnativa/docker-socket-proxy
+      - DOCKER_HOST=cetusguard:2375
+  cetusguard:
+    image: hectorm/cetusguard:v1
+    read_only: true
     volumes:
-     - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     environment:
-      - CONTAINERS=1
+      CETUSGUARD_BACKEND_ADDR: "unix:///var/run/docker.sock"
+      CETUSGUARD_FRONTEND_ADDR: "tcp://:2375"
+      CETUSGUARD_RULES: |
+        ! Inspect a container
+        GET %API_PREFIX_CONTAINERS%/%CONTAINER_ID_OR_NAME%/json
 
 ```
 **Note:** Replace `2375` with the port of your proxy.


### PR DESCRIPTION
##### Summary

I'm a heavy Netdata user and have the need to deploy it securely on Docker. Given how critical it is to give a service access to the socket, I've recently developed [CetusGuard](https://github.com/hectorm/cetusguard), a Docker socket proxy that has no dependencies, is distributed in an image built from scratch and allows to define narrower filtering rules than the currently proposed solution.

A complete example of a Netdata deployment with CetusGuard can be found [here](https://github.com/hectorm/cetusguard/blob/master/examples/compose/compose.netdata.yml).

I'm not quite sure whether the best approach to this PR is to add CetusGuard as an alternative to the current solution or to replace it. I have chosen the second option because CetusGuard covers this use case completely.
