### PR TITLE
Add support for Wolf SSL

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -755,6 +755,14 @@ if MQTT_WSS_DEBUG
 libmqttwebsockets_a_CFLAGS += -DMQTT_WSS_DEBUG
 endif
 
+if ENABLE_HTTPS_WITH_OPENSSL
+libmqttwebsockets_a_CFLAGS += -DENABLE_HTTPS_WITH_OPENSSL=1
+endif
+
+if ENABLE_HTTPS_WITH_WOLFSSL
+libmqttwebsockets_a_CFLAGS += -DENABLE_HTTPS_WITH_WOLFSSL=1
+endif
+
 mqtt_websockets/src/mqtt_wss_client.$(OBJEXT) : CFLAGS += -Wno-unused-result
 
 ACLK_PROTO_DEFINITIONS = \

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -62,11 +62,7 @@ struct aclk_shared_state aclk_shared_state = {
 };
 
 #ifdef MQTT_WSS_DEBUG
-#if defined(ENABLE_HTTPS_WITH_OPENSSL)
-#include <openssl/ssl.h>
-#elif defined(ENABLE_HTTPS_WITH_WOLFSSL)
-#include <wolfssl/openssl/ssl.h>
-#endif
+#include "libnetdata/socket/security.h"
 #define DEFAULT_SSKEYLOGFILE_NAME "SSLKEYLOGFILE"
 const char *ssl_log_filename = NULL;
 FILE *ssl_log_file = NULL;

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -62,9 +62,9 @@ struct aclk_shared_state aclk_shared_state = {
 };
 
 #ifdef MQTT_WSS_DEBUG
-#if defined(OPENSSL_VERSION_NUMBER)
+#if defined(ENABLE_HTTPS_WITH_OPENSSL)
 #include <openssl/ssl.h>
-#elif defined(WOLFSSL_VERSION)
+#elif defined(ENABLE_HTTPS_WITH_WOLFSSL)
 #include <wolfssl/openssl/ssl.h>
 #endif
 #define DEFAULT_SSKEYLOGFILE_NAME "SSLKEYLOGFILE"

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -64,6 +64,8 @@ struct aclk_shared_state aclk_shared_state = {
 #ifdef MQTT_WSS_DEBUG
 #if defined(OPENSSL_VERSION_NUMBER)
 #include <openssl/ssl.h>
+#elif defined(WOLFSSL_VERSION)
+#include <wolfssl/openssl/ssl.h>
 #endif
 #define DEFAULT_SSKEYLOGFILE_NAME "SSLKEYLOGFILE"
 const char *ssl_log_filename = NULL;

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -62,7 +62,9 @@ struct aclk_shared_state aclk_shared_state = {
 };
 
 #ifdef MQTT_WSS_DEBUG
+#if defined(OPENSSL_VERSION_NUMBER)
 #include <openssl/ssl.h>
+#endif
 #define DEFAULT_SSKEYLOGFILE_NAME "SSLKEYLOGFILE"
 const char *ssl_log_filename = NULL;
 FILE *ssl_log_file = NULL;

--- a/aclk/https_client.c
+++ b/aclk/https_client.c
@@ -528,7 +528,7 @@ int https_request(https_req_t *request, https_req_response_t *response) {
     }
     ctx->request = request;
 
-    ctx->ssl_ctx = security_initialize_openssl_client();
+    ctx->ssl_ctx = security_initialize_ssl_client();
     if (ctx->ssl_ctx==NULL) {
         error("Cannot allocate SSL context");
         goto exit_sock;

--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -57,7 +57,7 @@ unsigned int register_spacing = 0; /* not used if probing */
 char *driver_device = NULL;     /* not used if probing */
 
 /* Out-of-band Communication Configuration */
-int protocol_version = -1; //IPMI_MONITORING_PROTOCOL_VERSION_1_5; /* or -1 for default */
+int impi_mon_protocol_version = -1; //IPMI_MONITORING_PROTOCOL_VERSION_1_5; /* or -1 for default */
 char *username = "foousername";
 char *password = "foopassword";
 unsigned char *ipmi_k_g = NULL;
@@ -134,7 +134,7 @@ _init_ipmi_config (struct ipmi_monitoring_ipmi_config *ipmi_config)
     ipmi_config->register_spacing = register_spacing;
     ipmi_config->driver_device = driver_device;
 
-    ipmi_config->protocol_version = protocol_version;
+    ipmi_config->protocol_version = impi_mon_protocol_version;
     ipmi_config->username = username;
     ipmi_config->password = password;
     ipmi_config->k_g = ipmi_k_g;
@@ -1734,8 +1734,8 @@ int main (int argc, char **argv) {
         }
         else if(strcmp("driver-type", argv[i]) == 0) {
             if (hostname) {
-                protocol_version=parse_outofband_driver_type(argv[++i]);
-                if(debug) fprintf(stderr, "freeipmi.plugin: outband protocol version set to '%d'\n", protocol_version);
+                impi_mon_protocol_version =parse_outofband_driver_type(argv[++i]);
+                if(debug) fprintf(stderr, "freeipmi.plugin: outband protocol version set to '%d'\n", impi_mon_protocol_version);
             }
             else {
                 driver_type=parse_inband_driver_type(argv[++i]);
@@ -1748,7 +1748,7 @@ int main (int argc, char **argv) {
                     fprintf(
                         stderr,
                         "freeipmi.plugin: noauthcodecheck workaround flag is ignored for inband configuration\n");
-            } else if (protocol_version < 0 || protocol_version == IPMI_MONITORING_PROTOCOL_VERSION_1_5) {
+            } else if (impi_mon_protocol_version < 0 || impi_mon_protocol_version == IPMI_MONITORING_PROTOCOL_VERSION_1_5) {
                 workaround_flags |= IPMI_MONITORING_WORKAROUND_FLAGS_PROTOCOL_VERSION_1_5_NO_AUTH_CODE_CHECK;
                 if (debug)
                     fprintf(stderr, "freeipmi.plugin: noauthcodecheck workaround flag enabled\n");

--- a/configure.ac
+++ b/configure.ac
@@ -172,6 +172,12 @@ AC_ARG_ENABLE(
     [enable_compression="detect"]
 )
 AC_ARG_ENABLE(
+    [wolfssl],
+    [AS_HELP_STRING([--enable-wolfssl], [Enable WolfSSL support with WolfSSL @<:@default no@:>@])],
+    [enable_wolfssl="yes"],
+    [enable_wolfssl="no"]
+)
+AC_ARG_ENABLE(
     [dbengine],
     [AS_HELP_STRING([--disable-dbengine], [disable netdata dbengine @<:@default autodetect@:>@])],
     ,
@@ -502,6 +508,18 @@ OPTIONAL_UUID_CFLAGS="${UUID_CFLAGS}"
 OPTIONAL_UUID_LIBS="${UUID_LIBS}"
 
 # -----------------------------------------------------------------------------
+# WolfSSL Cryptography and SSL/TLS Toolkit
+
+AC_CHECK_LIB(
+    [wolfssl],
+    [wolfSSL_Init],
+    [WOLFSSL_LIBS="-lwolfssl"]
+)
+
+test -z "${WOLFSSL_LIBS}" -a "${enable_wolfssl}" = "yes" || \
+    AC_DEFINE([HAVE_WOLFSSL], [1], [libwolfssl availability])
+
+# -----------------------------------------------------------------------------
 # OpenSSL Cryptography and SSL/TLS Toolkit
 
 AC_CHECK_LIB(
@@ -574,11 +592,11 @@ AC_SUBST([LIBJUDY_CFLAGS])
 
 JUDY_CFLAGS="-I \$(abs_top_srcdir)/libnetdata/libjudy/src"
 
-test "${enable_https}" = "yes" -a -z "${SSL_LIBS}" && \
-    AC_MSG_ERROR([OpenSSL required for HTTPS but not found. Try installing 'libssl-dev' or 'openssl-devel'.])
+test "${enable_https}" = "yes" -a -z "${SSL_LIBS}" -a -z "${WOLFSSL_LIBS}" && \
+    AC_MSG_ERROR([OpenSSL or WolfSSL are required for HTTPS but not found. Try installing 'libssl-dev', 'openssl-devel', or 'libwolfssl-dev'.])
 
-test "${enable_dbengine}" = "yes" -a -z "${SSL_LIBS}" && \
-    AC_MSG_ERROR([OpenSSL required for DBENGINE but not found. Try installing 'libssl-dev' or 'openssl-devel'.])
+test "${enable_dbengine}" = "yes" -a -z "${SSL_LIBS}" -a -z "${WOLFSSL_LIBS}" && \
+    AC_MSG_ERROR([OpenSSL or WolfSSL are required for HTTPS but not found. Try installing 'libssl-dev', 'openssl-devel', or 'libwolfssl-dev'.])
 
 AC_MSG_CHECKING([if netdata dbengine should be used])
 if test "${enable_dbengine}" != "no" -a "${UV_LIBS}" -a "${LZ4_LIBS}" -a "${SSL_LIBS}"; then
@@ -595,12 +613,17 @@ AC_MSG_RESULT([${enable_dbengine}])
 AM_CONDITIONAL([ENABLE_DBENGINE], [test "${enable_dbengine}" = "yes"])
 
 AC_MSG_CHECKING([if netdata https should be used])
-if test "${enable_https}" != "no" -a "${SSL_LIBS}"; then
+if test "${enable_https}" = "yes" -a "${SSL_LIBS}" -o "${WOLFSSL_LIBS}"; then
     enable_https="yes"
     AC_DEFINE([ENABLE_HTTPS], [1], [netdata HTTPS usability])
-    AC_DEFINE([ENABLE_HTTPS_WITH_OPENSSL], [1], [netdata HTTPS linked with OpenSSL])
     OPTIONAL_SSL_CFLAGS="${SSL_CFLAGS}"
-    OPTIONAL_SSL_LIBS="${SSL_LIBS}"
+    if test "${enable_wolfssl}" = "no"; then
+        AC_DEFINE([ENABLE_HTTPS_WITH_OPENSSL], [1], [netdata HTTPS linked with OpenSSL])
+        OPTIONAL_SSL_LIBS="${SSL_LIBS}"
+    else
+        AC_DEFINE([ENABLE_HTTPS_WITH_WOLFSSL], [1], [netdata HTTPS linked with WolfSSL])
+        OPTIONAL_SSL_LIBS="${WOLFSSL_LIBS}"
+    fi
 else
     enable_https="no"
 fi
@@ -872,10 +895,14 @@ if test "$enable_cloud" != "no"; then
         can_enable_ng="no"
     fi
     AC_MSG_CHECKING([if SSL available for ACLK])
-    if test -n "${SSL_LIBS}"; then
+    if test -n "${SSL_LIBS}" -o -n "${WOLFSSL_LIBS}"; then
         AC_MSG_RESULT([yes])
         OPTIONAL_SSL_CFLAGS="${SSL_CFLAGS}"
-        OPTIONAL_SSL_LIBS="${SSL_LIBS}"
+        if test "${enable_wolfssl}" = "no"; then
+            OPTIONAL_SSL_LIBS="${SSL_LIBS}"
+        else
+            OPTIONAL_SSL_LIBS="${WOLFSSL_LIBS}"
+        fi
     else
         AC_MSG_RESULT([no])
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -598,6 +598,7 @@ AC_MSG_CHECKING([if netdata https should be used])
 if test "${enable_https}" != "no" -a "${SSL_LIBS}"; then
     enable_https="yes"
     AC_DEFINE([ENABLE_HTTPS], [1], [netdata HTTPS usability])
+    AC_DEFINE([ENABLE_HTTPS_WITH_OPENSSL], [1], [netdata HTTPS linked with OpenSSL])
     OPTIONAL_SSL_CFLAGS="${SSL_CFLAGS}"
     OPTIONAL_SSL_LIBS="${SSL_LIBS}"
 else

--- a/configure.ac
+++ b/configure.ac
@@ -629,6 +629,8 @@ else
 fi
 AC_MSG_RESULT([${enable_https}])
 AM_CONDITIONAL([ENABLE_HTTPS], [test "${enable_https}" = "yes"])
+AM_CONDITIONAL([ENABLE_HTTPS_WITH_WOLFSSL], [test "${enable_wolfssl}" = "yes"])
+AM_CONDITIONAL([ENABLE_HTTPS_WITH_OPENSSL], [test "${enable_wolfssl}" = "no"])
 
 AC_MSG_CHECKING([if netdata compression should be used])
 if test "${enable_compression}" != "no"; then
@@ -1384,18 +1386,6 @@ PKG_CHECK_MODULES(
 )
 
 PKG_CHECK_MODULES(
-    [LIBWOLFSSL],
-    [libwolfssl],
-    [AC_CHECK_LIB(
-        [wolfssl],
-        [wolfSSL_connect],
-        [have_libwolfssl=yes],
-        [have_libwolfssl=no]
-    )],
-    [have_libwolfssl=no]
-)
-
-PKG_CHECK_MODULES(
     [LIBCURL],
     [libcurl],
     [AC_CHECK_LIB(
@@ -1430,7 +1420,7 @@ test "${enable_exporting_kinesis}" = "yes" -a "${have_libaws_cpp_sdk_core}" != "
 test "${enable_exporting_kinesis}" = "yes" -a "${have_libcurl}" != "yes" && \
     AC_MSG_ERROR([libcurl required but not found])
 
-test "${enable_exporting_kinesis}" = "yes" -a "${have_libssl}" != "yes" -a "${have_libwolfssl}" != "yes" && \
+test "${enable_exporting_kinesis}" = "yes" -a "${have_libssl}" != "yes" -a "${enable_wolfssl}" != "yes" && \
     AC_MSG_ERROR([libssl required but not found])
 
 test "${enable_exporting_kinesis}" = "yes" -a "${have_libcrypto}" != "yes" && \
@@ -1441,7 +1431,7 @@ if test "${enable_exporting_kinesis}" != "no" -a "${have_libaws_cpp_sdk_kinesis}
                                             -a "${have_libaws_cpp_sdk_core}" = "yes" \
                                             -a "${have_libcurl}" = "yes" \
                                             -a \("${have_libssl}" = "yes" \
-                                            -o "${have_libwolfssl}" = "yes"\) \
+                                            -o "${enable_wolfssl}" = "yes"\) \
                                             -a "${have_libcrypto}" = "yes"; then
     enable_exporting_kinesis="yes"
     AC_DEFINE([HAVE_KINESIS], [1], [libaws-cpp-sdk-kinesis usability])
@@ -1739,6 +1729,13 @@ CFLAGS="${originalCFLAGS} ${OPTIONAL_LTO_CFLAGS} ${OPTIONAL_PROTOBUF_CFLAGS} ${O
     ${OPTIONAL_ACLK_CFLAGS} ${OPTIONAL_ML_CFLAGS} ${OPTIONAL_OS_DEP_CFLAGS}"
 
 CXXFLAGS="${CFLAGS} ${OPTIONAL_KINESIS_CXXFLAGS} ${CPP_STD_FLAG}"
+if test "${enable_https}" = "yes"; then
+    if test "${enable_wolfssl}" = "no"; then
+        CFLAGS="${CFLAGS} -DENABLE_HTTPS_WITH_OPENSSL=1"
+    else
+        CFLAGS="${CFLAGS} -DENABLE_HTTPS_WITH_WOLFSSL=1"
+    fi
+fi
 
 CPPFLAGS="\
 	-DVARLIB_DIR=\"\\\"${varlibdir}\\\"\" \

--- a/configure.ac
+++ b/configure.ac
@@ -1384,6 +1384,18 @@ PKG_CHECK_MODULES(
 )
 
 PKG_CHECK_MODULES(
+    [LIBWOLFSSL],
+    [libwolfssl],
+    [AC_CHECK_LIB(
+        [wolfssl],
+        [wolfSSL_connect],
+        [have_libwolfssl=yes],
+        [have_libwolfssl=no]
+    )],
+    [have_libwolfssl=no]
+)
+
+PKG_CHECK_MODULES(
     [LIBCURL],
     [libcurl],
     [AC_CHECK_LIB(
@@ -1418,7 +1430,7 @@ test "${enable_exporting_kinesis}" = "yes" -a "${have_libaws_cpp_sdk_core}" != "
 test "${enable_exporting_kinesis}" = "yes" -a "${have_libcurl}" != "yes" && \
     AC_MSG_ERROR([libcurl required but not found])
 
-test "${enable_exporting_kinesis}" = "yes" -a "${have_libssl}" != "yes" && \
+test "${enable_exporting_kinesis}" = "yes" -a "${have_libssl}" != "yes" -a "${have_libwolfssl}" != "yes" && \
     AC_MSG_ERROR([libssl required but not found])
 
 test "${enable_exporting_kinesis}" = "yes" -a "${have_libcrypto}" != "yes" && \
@@ -1428,14 +1440,21 @@ AC_MSG_CHECKING([if kinesis exporting connector should be enabled])
 if test "${enable_exporting_kinesis}" != "no" -a "${have_libaws_cpp_sdk_kinesis}" = "yes" \
                                             -a "${have_libaws_cpp_sdk_core}" = "yes" \
                                             -a "${have_libcurl}" = "yes" \
-                                            -a "${have_libssl}" = "yes" \
+                                            -a \("${have_libssl}" = "yes" \
+                                            -o "${have_libwolfssl}" = "yes"\) \
                                             -a "${have_libcrypto}" = "yes"; then
     enable_exporting_kinesis="yes"
     AC_DEFINE([HAVE_KINESIS], [1], [libaws-cpp-sdk-kinesis usability])
-    OPTIONAL_KINESIS_CFLAGS="${LIBCRYPTO_CFLAGS} ${LIBSSL_CFLAGS} ${LIBCURL_CFLAGS}"
     OPTIONAL_KINESIS_CXXFLAGS="${AWS_CPP_SDK_KINESIS_CFLAGS} ${AWS_CPP_SDK_CORE_CFLAGS}"
-    OPTIONAL_KINESIS_LIBS="${AWS_CPP_SDK_KINESIS_LIBS} ${AWS_CPP_SDK_CORE_LIBS} \
-                           ${LIBCRYPTO_LIBS} ${LIBSSL_LIBS} ${LIBCURL_LIBS}"
+    OPTIONAL_KINESIS_CFLAGS="${LIBCURL_CFLAGS}"
+    OPTIONAL_KINESIS_LIBS="${AWS_CPP_SDK_KINESIS_LIBS} ${AWS_CPP_SDK_CORE_LIBS}"
+    if test "${enable_wolfssl}" = "no"; then
+        OPTIONAL_KINESIS_CFLAGS="${LIBCRYPTO_CFLAGS} ${LIBSSL_CFLAGS} ${OPTIONAL_KINESIS_CFLAGS} "
+        OPTIONAL_KINESIS_LIBS="${OPTIONAL_KINESIS_LIBS} ${LIBCRYPTO_LIBS} ${LIBSSL_LIBS} ${LIBCURL_LIBS}"
+    else
+        OPTIONAL_KINESIS_CFLAGS="${LIBWOLFSSL_CFLAGS} ${OPTIONAL_KINESIS_CFLAGS} "
+        OPTIONAL_KINESIS_LIBS="${OPTIONAL_KINESIS_LIBS} ${LIBWOLFSSL_LIBS} ${LIBCURL_LIBS}"
+    fi
 else
     enable_exporting_kinesis="no"
 fi

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -834,7 +834,7 @@ static void security_init(){
     tls_version    = config_get(CONFIG_SECTION_WEB, "tls version",  "1.3");
     tls_ciphers    = config_get(CONFIG_SECTION_WEB, "tls ciphers",  "none");
 
-    security_openssl_library();
+    security_start_ssl_library();
 }
 #endif
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -479,7 +479,7 @@ void netdata_cleanup_and_exit(int ret) {
 
 #ifdef ENABLE_HTTPS
     delta_shutdown_time("free openssl structures");
-    security_clean_openssl();
+    security_clean_ssl();
 #endif
 
     delta_shutdown_time("remove incomplete shutdown file");

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -9,6 +9,7 @@
 #include <fcntl.h>
 #include <lz4.h>
 #include <Judy.h>
+#include "../../libnetdata/libnetdata.h"
 #include "daemon/common.h"
 #include "../rrd.h"
 #include "rrddiskprotocol.h"

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -9,13 +9,6 @@
 #include <fcntl.h>
 #include <lz4.h>
 #include <Judy.h>
-#if defined(ENABLE_HTTPS_WITH_OPENSSL)
-#include <openssl/sha.h>
-#include <openssl/evp.h>
-#elif defined(ENABLE_HTTPS_WITH_WOLFSSL)
-#include <wolfssl/openssl/sha.h>
-#include <wolfssl/openssl/evp.h>
-#endif
 #include "daemon/common.h"
 #include "../rrd.h"
 #include "rrddiskprotocol.h"

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -12,6 +12,9 @@
 #if defined(OPENSSL_VERSION_NUMBER)
 #include <openssl/sha.h>
 #include <openssl/evp.h>
+#elif defined(WOLFSSL_VERSION)
+#include <wolfssl/openssl/sha.h>
+#include <wolfssl/openssl/evp.h>
 #endif
 #include "daemon/common.h"
 #include "../rrd.h"

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -9,10 +9,10 @@
 #include <fcntl.h>
 #include <lz4.h>
 #include <Judy.h>
-#if defined(OPENSSL_VERSION_NUMBER)
+#if defined(ENABLE_HTTPS_WITH_OPENSSL)
 #include <openssl/sha.h>
 #include <openssl/evp.h>
-#elif defined(WOLFSSL_VERSION)
+#elif defined(ENABLE_HTTPS_WITH_WOLFSSL)
 #include <wolfssl/openssl/sha.h>
 #include <wolfssl/openssl/evp.h>
 #endif

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -9,8 +9,10 @@
 #include <fcntl.h>
 #include <lz4.h>
 #include <Judy.h>
+#if defined(OPENSSL_VERSION_NUMBER)
 #include <openssl/sha.h>
 #include <openssl/evp.h>
+#endif
 #include "daemon/common.h"
 #include "../rrd.h"
 #include "rrddiskprotocol.h"

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -32,7 +32,7 @@ static void security_info_callback(const SSL *ssl, int where, int ret __maybe_un
  *
  * Starts the openssl library for the Netdata.
  */
-void security_openssl_library()
+void security_start_ssl_library()
 {
 #if defined(OPENSSL_VERSION_NUMBER)
 #if OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110
@@ -48,6 +48,9 @@ void security_openssl_library()
         error("SSL library cannot be initialized.");
     }
 #endif // OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110
+#elif defined(LIBWOLFSSL_VERSION_STRING)
+    if (wolfSSL_Init() != SSL_SUCCESS)
+        error("Cannot initialize WolfSSL library.");
 #endif // defined(ENABLE_HTTPS_WITH_OPENSSL)
 }
 

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -155,13 +155,13 @@ SSL_CTX *security_initialize_ssl_client() {
 }
 
 /**
- * Initialize OpenSSL server
+ * Initialize SSL server
  *
- * Starts the server context with TLS 1.2 and load the certificate.
+ * Starts the server context with TLS and load the certificate.
  *
  * @return It returns the context on success or NULL otherwise
  */
-static SSL_CTX * security_initialize_openssl_server() {
+static SSL_CTX *security_initialize_ssl_server() {
     SSL_CTX *ctx;
     char lerror[512];
 	static int netdata_id_context = 1;
@@ -177,7 +177,7 @@ static SSL_CTX * security_initialize_openssl_server() {
     SSL_CTX_use_certificate_file(ctx, netdata_ssl_security_cert, SSL_FILETYPE_PEM);
 #else
     ctx = SSL_CTX_new(TLS_server_method());
-    if (!ctx) {
+if (!ctx) {
 		error("Cannot create a new SSL context, netdata won't encrypt communication");
         return NULL;
     }
@@ -227,7 +227,7 @@ void security_start_ssl(int selector) {
                 if (stat(netdata_ssl_security_key, &statbuf) || stat(netdata_ssl_security_cert, &statbuf))
                     info("To use encryption it is necessary to set \"ssl certificate\" and \"ssl key\" in [web] !\n");
                 else {
-                    netdata_ssl_srv_ctx = security_initialize_openssl_server();
+                    netdata_ssl_srv_ctx = security_initialize_ssl_server();
                     SSL_CTX_set_mode(netdata_ssl_srv_ctx, SSL_MODE_ENABLE_PARTIAL_WRITE);
                 }
             }

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -257,7 +257,7 @@ void security_start_ssl(int selector) {
  *
  * Clean all the allocated contexts from netdata.
  */
-void security_clean_openssl()
+void security_clean_ssl()
 {
     if (netdata_ssl_srv_ctx) {
         SSL_CTX_free(netdata_ssl_srv_ctx);
@@ -273,6 +273,8 @@ void security_clean_openssl()
 
 #if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110)
     ERR_free_strings();
+#elif defined(LIBWOLFSSL_VERSION_STRING)
+    wolfSSL_Cleanup();
 #endif
 }
 

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -89,16 +89,16 @@ int tls_select_version(const char *lversion) {
 #endif
 
 /**
- * OpenSSL common options
+ * SSL common options
  *
  * Clients and SERVER have common options, this function is responsible to set them in the context.
  *
  * @param ctx the initialized SSL context.
  * @param side 0 means server, and 1 client.
  */
-void security_openssl_common_options(SSL_CTX *ctx, int side) {
+void security_ssl_common_options(SSL_CTX *ctx, int side) {
     if (!side) {
-#if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_110)
+#if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_110) || defined(ENABLE_HTTPS_WITH_WOLFSSL)
         int version =  tls_select_version(tls_version) ;
 #endif
 #if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110)
@@ -184,7 +184,7 @@ static SSL_CTX * security_initialize_openssl_server() {
 
     SSL_CTX_use_certificate_chain_file(ctx, netdata_ssl_security_cert);
 #endif // defined(OPENSSL_VERSION_NUMBER)
-    security_openssl_common_options(ctx, 0);
+    security_ssl_common_options(ctx, 0);
 
     SSL_CTX_use_PrivateKey_file(ctx, netdata_ssl_security_key,SSL_FILETYPE_PEM);
 

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -23,7 +23,11 @@ int netdata_ssl_validate_server =  NETDATA_SSL_VALID_CERTIFICATE;
 static void security_info_callback(const SSL *ssl, int where, int ret __maybe_unused) {
     (void)ssl;
     if (where & SSL_CB_ALERT) {
+#if defined(ENABLE_HTTPS_WITH_OPENSSL)
         debug(D_WEB_CLIENT,"SSL INFO CALLBACK %s %s", SSL_alert_type_string(ret), SSL_alert_desc_string_long(ret));
+#else
+        debug(D_WEB_CLIENT,"SSL INFO CALLBACK %s", SSL_alert_desc_string_long(ret));
+#endif
     }
 }
 
@@ -133,7 +137,7 @@ SSL_CTX *security_initialize_ssl_client() {
         SSL_CTX_set_options (ctx,SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_COMPRESSION);
 #else
 #if defined(LIBWOLFSSL_VERSION_STRING)
-        if (netdata_validate_server == NETDATA_SSL_INVALID_CERTIFICATE)
+        if (netdata_ssl_validate_server == NETDATA_SSL_INVALID_CERTIFICATE)
             wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, 0);
 #endif
         SSL_CTX_set_min_proto_version(ctx, TLS1_VERSION);

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -136,7 +136,7 @@ SSL_CTX *security_initialize_ssl_client() {
 #if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110)
         SSL_CTX_set_options (ctx,SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_COMPRESSION);
 #else
-#if defined(LIBWOLFSSL_VERSION_STRING)
+#if defined(ENABLE_HTTPS_WITH_WOLFSSL)
         if (netdata_ssl_validate_server == NETDATA_SSL_INVALID_CERTIFICATE)
             wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, 0);
 #endif

--- a/libnetdata/socket/security.h
+++ b/libnetdata/socket/security.h
@@ -27,6 +27,7 @@
 #if defined(ENABLE_HTTPS_WITH_OPENSSL)
 #  include <openssl/ssl.h>
 #  include <openssl/err.h>
+#  include <openssl/sha.h>
 #  include <openssl/evp.h>
 #  include <openssl/pem.h>
 #  if (SSLEAY_VERSION_NUMBER >= OPENSSL_VERSION_097) && (OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110)
@@ -44,6 +45,9 @@
 #include <wolfssl/openssl/ssl.h>
 #include <wolfssl/ssl.h>
 #include <wolfssl/error-ssl.h>
+
+#include <wolfssl/openssl/sha.h>
+#include <wolfssl/openssl/evp.h>
 #endif // ENABLE_HTTPS_WITH_OPENSSL
 
 struct netdata_ssl {

--- a/libnetdata/socket/security.h
+++ b/libnetdata/socket/security.h
@@ -24,18 +24,20 @@
 #define OPENSSL_VERSION_111 0x10101000L
 #define OPENSSL_VERSION_300 0x30000000L
 
+#if defined(ENABLE_HTTPS_WITH_OPENSSL)
 #  include <openssl/ssl.h>
 #  include <openssl/err.h>
 #  include <openssl/evp.h>
 #  include <openssl/pem.h>
 #  if (SSLEAY_VERSION_NUMBER >= OPENSSL_VERSION_097) && (OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110)
 #   include <openssl/conf.h>
-#  endif
+#  endif // SSLEAY_VERSION_NUMBER
 
 #if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_300
 #include <openssl/core_names.h>
 #include <openssl/decoder.h>
-#endif
+#endif // OPENSSL_VERSION_NUMBER
+#endif // ENABLE_HTTPS_WITH_OPENSSL
 
 struct netdata_ssl {
     SSL *conn; //SSL connection

--- a/libnetdata/socket/security.h
+++ b/libnetdata/socket/security.h
@@ -59,7 +59,7 @@ extern int netdata_ssl_validate_server;
 int ssl_security_location_for_context(SSL_CTX *ctx,char *file,char *path);
 
 void security_start_ssl_library();
-void security_clean_openssl();
+void security_clean_ssl();
 void security_start_ssl(int selector);
 int security_process_accept(SSL *ssl,int msg);
 int security_test_certificate(SSL *ssl);

--- a/libnetdata/socket/security.h
+++ b/libnetdata/socket/security.h
@@ -63,7 +63,7 @@ void security_clean_openssl();
 void security_start_ssl(int selector);
 int security_process_accept(SSL *ssl,int msg);
 int security_test_certificate(SSL *ssl);
-SSL_CTX * security_initialize_openssl_client();
+SSL_CTX *security_initialize_ssl_client();
 
 # endif //ENABLE_HTTPS
 #endif //NETDATA_SECURITY_H

--- a/libnetdata/socket/security.h
+++ b/libnetdata/socket/security.h
@@ -37,6 +37,10 @@
 #include <openssl/core_names.h>
 #include <openssl/decoder.h>
 #endif // OPENSSL_VERSION_NUMBER
+#elif defined(ENABLE_HTTPS_WITH_WOLFSSL)
+#include <wolfssl/options.h>
+#include <wolfssl/ssl.h>
+#include <wolfssl/openssl/ssl.h>
 #endif // ENABLE_HTTPS_WITH_OPENSSL
 
 struct netdata_ssl {

--- a/libnetdata/socket/security.h
+++ b/libnetdata/socket/security.h
@@ -58,7 +58,7 @@ extern const char *tls_ciphers;
 extern int netdata_ssl_validate_server;
 int ssl_security_location_for_context(SSL_CTX *ctx,char *file,char *path);
 
-void security_openssl_library();
+void security_start_ssl_library();
 void security_clean_openssl();
 void security_start_ssl(int selector);
 int security_process_accept(SSL *ssl,int msg);

--- a/libnetdata/socket/security.h
+++ b/libnetdata/socket/security.h
@@ -38,9 +38,12 @@
 #include <openssl/decoder.h>
 #endif // OPENSSL_VERSION_NUMBER
 #elif defined(ENABLE_HTTPS_WITH_WOLFSSL)
+#include <wolfssl/version.h>
 #include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 #include <wolfssl/openssl/ssl.h>
+#include <wolfssl/ssl.h>
+#include <wolfssl/error-ssl.h>
 #endif // ENABLE_HTTPS_WITH_OPENSSL
 
 struct netdata_ssl {

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -213,6 +213,7 @@ USAGE: ${PROGRAM} [options]
   --enable-plugin-freeipmi   Enable the FreeIPMI plugin. Default: enable it when libipmimonitoring is available.
   --disable-plugin-freeipmi  Explicitly disable the FreeIPMI plugin.
   --disable-https            Explicitly disable TLS support.
+  --enable-wolfssl           Explicitly use WolfSSL instead the default (OpenSSL).
   --disable-dbengine         Explicitly disable DB engine support.
   --enable-plugin-nfacct     Enable nfacct plugin. Default: enable it when libmnl and libnetfilter_acct are available.
   --disable-plugin-nfacct    Explicitly disable the nfacct plugin.
@@ -358,6 +359,10 @@ while [ -n "${1}" ]; do
       ;;
     "--build-json-c")
       NETDATA_BUILD_JSON_C=1
+      ;;
+    "--enable-wolfssl")
+      NETDATA_ENABLE_WOLFSSL=1
+      NETDATA_CONFIGURE_OPTIONS="${NETDATA_CONFIGURE_OPTIONS//--enable-wolfssl/} --enable-wolfssl"
       ;;
     "--install-prefix")
       NETDATA_PREFIX="${2}/netdata"


### PR DESCRIPTION
##### Summary
Fixes https://github.com/netdata/netdata/issues/6509

##### Test Plan

1. Before to compile and test this branch, it is necessary to install `wolfssl` on your system. The default compilation of the library won't allow everything necessary to have `ACLK debug messages` and `cloud`, to fix this I compiled it using the following options:

```sh
# ./autogen.sh
# CFLAGS="-DOPENSSL_EXTRA -DHAVE_SECRET_CALLBACK -DWOLFSSL_TRUST_PEER_CERT" ./configure --prefix=/usr --enable-all --enable-static --enable-iopool --enable-secure-renegotiation --enable-sni
# make  CFLAGS="-DOPENSSL_EXTRA -DHAVE_SECRET_CALLBACK -DWOLFSSL_TRUST_PEER_CERT"
# make install
# ldconfig
```

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
