### PR TITLE
diskspace: don't collect inodes on msdosfs

### DIFF
--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -6,6 +6,7 @@
 
 #define DEFAULT_EXCLUDED_PATHS "/proc/* /sys/* /var/run/user/* /run/user/* /snap/* /var/lib/docker/*"
 #define DEFAULT_EXCLUDED_FILESYSTEMS "*gvfs *gluster* *s3fs *ipfs *davfs2 *httpfs *sshfs *gdfs *moosefs fusectl autofs"
+#define DEFAULT_EXCLUDED_FILESYSTEMS_INODES "msdosfs"
 #define CONFIG_SECTION_DISKSPACE "plugin:proc:diskspace"
 
 #define MAX_STAT_USEC 10000LU
@@ -294,6 +295,7 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
 
     static SIMPLE_PATTERN *excluded_mountpoints = NULL;
     static SIMPLE_PATTERN *excluded_filesystems = NULL;
+    static SIMPLE_PATTERN *excluded_filesystems_inodes = NULL;
 
     usec_t slow_timeout = MAX_STAT_USEC * update_every;
 
@@ -308,12 +310,22 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
         }
 
         excluded_mountpoints = simple_pattern_create(
-                config_get(CONFIG_SECTION_DISKSPACE, "exclude space metrics on paths", DEFAULT_EXCLUDED_PATHS), NULL,
-                mode, true);
+            config_get(CONFIG_SECTION_DISKSPACE, "exclude space metrics on paths", DEFAULT_EXCLUDED_PATHS),
+            NULL,
+            mode,
+            true);
 
         excluded_filesystems = simple_pattern_create(
-                config_get(CONFIG_SECTION_DISKSPACE, "exclude space metrics on filesystems",
-                           DEFAULT_EXCLUDED_FILESYSTEMS), NULL, SIMPLE_PATTERN_EXACT, true);
+            config_get(CONFIG_SECTION_DISKSPACE, "exclude space metrics on filesystems", DEFAULT_EXCLUDED_FILESYSTEMS),
+            NULL,
+            SIMPLE_PATTERN_EXACT,
+            true);
+
+        excluded_filesystems_inodes = simple_pattern_create(
+            config_get(CONFIG_SECTION_DISKSPACE, "exclude inode metrics on filesystems", DEFAULT_EXCLUDED_FILESYSTEMS_INODES),
+            NULL,
+            SIMPLE_PATTERN_EXACT,
+            true);
 
         dict_mountpoints = dictionary_create_advanced(DICT_OPTION_NONE, &dictionary_stats_category_collectors, 0);
     }
@@ -334,6 +346,9 @@ static inline void do_disk_space_stats(struct mountinfo *mi, int update_every) {
 
         if(unlikely(simple_pattern_matches(excluded_filesystems, mi->filesystem))) {
             def_space = CONFIG_BOOLEAN_NO;
+            def_inodes = CONFIG_BOOLEAN_NO;
+        }
+        if (unlikely(simple_pattern_matches(excluded_filesystems_inodes, mi->filesystem))) {
             def_inodes = CONFIG_BOOLEAN_NO;
         }
 

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -6,7 +6,7 @@
 
 #define DEFAULT_EXCLUDED_PATHS "/proc/* /sys/* /var/run/user/* /run/user/* /snap/* /var/lib/docker/*"
 #define DEFAULT_EXCLUDED_FILESYSTEMS "*gvfs *gluster* *s3fs *ipfs *davfs2 *httpfs *sshfs *gdfs *moosefs fusectl autofs"
-#define DEFAULT_EXCLUDED_FILESYSTEMS_INODES "msdosfs"
+#define DEFAULT_EXCLUDED_FILESYSTEMS_INODES "msdosfs msdos vfat overlayfs aufs* *unionfs"
 #define CONFIG_SECTION_DISKSPACE "plugin:proc:diskspace"
 
 #define MAX_STAT_USEC 10000LU


### PR DESCRIPTION
##### Summary

Fixes: #14804

Related [discussion on Discord](https://discord.com/channels/847502280503590932/1072639867785334876/1072639867785334876).

After this PR Netdata will ignore collecting inode stats for mount points with `msdosfs` filesystem.

Implemented by adding the `exclude inode metrics on filesystems` configuration option with default value `msdosfs msdos vfat overlayfs aufs* *unionfs`.

##### Test Plan

Use `exclude inode metrics on filesystems` to disable inode metrics for configured filesystems.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
