### PR TITLE
Explicitly ask for gzip decompression in static archive header.

### DIFF
--- a/packaging/makeself/jobs/99-makeself.install.sh
+++ b/packaging/makeself/jobs/99-makeself.install.sh
@@ -70,6 +70,7 @@ run "${NETDATA_MAKESELF_PATH}/makeself.sh" \
   --complevel 9 \
   --notemp \
   --needroot \
+  --untar-extra "-z" \
   --target "${NETDATA_INSTALL_PATH}" \
   --header "${NETDATA_MAKESELF_PATH}/makeself-header.sh" \
   --lsm "${NETDATA_MAKESELF_PATH}/makeself.lsm.tmp" \


### PR DESCRIPTION
##### Summary

This should allow static builds to install correctly on platforms that do not provide a copy of tar that does auto-detection of the archive’s compression type, such as some builds of OpenWRT.

##### Test Plan

To test, create a static build from this PR (run `packaging/makeself/build-static.sh` with the target CPU architecture as it’s only argument) and attempt to install the resultant static build archive by hand (simply run it on the target system) on a system that does not auto-detect compression of archives passed to `tar`.

##### Additional Information

Fixes: https://github.com/netdata/netdata/issues/9517 (probably)