### PR TITLE
minor - add capability signifying this agent can speak apiv2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -886,6 +886,8 @@ set(ACLK_ALWAYS_BUILD
         aclk/aclk_proxy.h
         aclk/aclk.c
         aclk/aclk.h
+        aclk/aclk_capas.c
+        aclk/aclk_capas.h
         )
 
 set(ACLK_FILES
@@ -909,8 +911,6 @@ set(ACLK_FILES
         aclk/aclk_alarm_api.h
         aclk/aclk_contexts_api.c
         aclk/aclk_contexts_api.h
-        aclk/aclk_capas.c
-        aclk/aclk_capas.h
         aclk/schema-wrappers/connection.cc
         aclk/schema-wrappers/connection.h
         aclk/schema-wrappers/node_connection.cc

--- a/Makefile.am
+++ b/Makefile.am
@@ -696,8 +696,6 @@ ACLK_FILES = \
     aclk/aclk_alarm_api.h \
     aclk/aclk_contexts_api.c \
     aclk/aclk_contexts_api.h \
-    aclk/aclk_capas.c \
-    aclk/aclk_capas.h \
     aclk/helpers/mqtt_wss_pal.h \
     aclk/helpers/ringbuffer_pal.h \
     aclk/schema-wrappers/connection.cc \
@@ -843,6 +841,8 @@ ACLK_ALWAYS_BUILD_FILES = \
     aclk/aclk_proxy.h \
     aclk/aclk.c \
     aclk/aclk.h \
+    aclk/aclk_capas.c \
+    aclk/aclk_capas.h \
     $(NULL)
 
 SPAWN_PLUGIN_FILES = \

--- a/Makefile.am
+++ b/Makefile.am
@@ -758,7 +758,6 @@ ACLK_PROTO_DEFINITIONS = \
     aclk/aclk-schemas/proto/aclk/v1/lib.proto \
     aclk/aclk-schemas/proto/agent/v1/disconnect.proto \
     aclk/aclk-schemas/proto/agent/v1/connection.proto \
-    aclk/aclk-schemas/proto/agent/v1/cmds.proto \
     aclk/aclk-schemas/proto/alarm/v1/config.proto \
     aclk/aclk-schemas/proto/alarm/v1/stream.proto \
     aclk/aclk-schemas/proto/nodeinstance/connection/v1/connection.proto \
@@ -772,8 +771,6 @@ dist_noinst_DATA += $(ACLK_PROTO_DEFINITIONS)
 
 ACLK_PROTO_BUILT_FILES = aclk/aclk-schemas/proto/agent/v1/connection.pb.cc \
     aclk/aclk-schemas/proto/agent/v1/connection.pb.h \
-    aclk/aclk-schemas/proto/agent/v1/cmds.pb.cc \
-    aclk/aclk-schemas/proto/agent/v1/cmds.pb.h \
     aclk/aclk-schemas/proto/nodeinstance/connection/v1/connection.pb.cc \
     aclk/aclk-schemas/proto/nodeinstance/connection/v1/connection.pb.h \
     aclk/aclk-schemas/proto/nodeinstance/create/v1/creation.pb.cc \
@@ -816,10 +813,6 @@ aclk/aclk-schemas/proto/aclk/v1/lib.pb.h: aclk/aclk-schemas/proto/aclk/v1/lib.pr
 
 aclk/aclk-schemas/proto/agent/v1/disconnect.pb.cc \
 aclk/aclk-schemas/proto/agent/v1/disconnect.pb.h: aclk/aclk-schemas/proto/agent/v1/disconnect.proto
-	$(PROTOC) -I=aclk/aclk-schemas --cpp_out=$(builddir)/aclk/aclk-schemas $^
-
-aclk/aclk-schemas/proto/agent/v1/cmds.pb.cc \
-aclk/aclk-schemas/proto/agent/v1/cmds.pb.h: aclk/aclk-schemas/proto/agent/v1/cmds.proto
 	$(PROTOC) -I=aclk/aclk-schemas --cpp_out=$(builddir)/aclk/aclk-schemas $^
 
 aclk/aclk-schemas/proto/alarm/v1/config.pb.cc \

--- a/Makefile.am
+++ b/Makefile.am
@@ -758,6 +758,7 @@ ACLK_PROTO_DEFINITIONS = \
     aclk/aclk-schemas/proto/aclk/v1/lib.proto \
     aclk/aclk-schemas/proto/agent/v1/disconnect.proto \
     aclk/aclk-schemas/proto/agent/v1/connection.proto \
+    aclk/aclk-schemas/proto/agent/v1/cmds.proto \
     aclk/aclk-schemas/proto/alarm/v1/config.proto \
     aclk/aclk-schemas/proto/alarm/v1/stream.proto \
     aclk/aclk-schemas/proto/nodeinstance/connection/v1/connection.proto \
@@ -771,6 +772,8 @@ dist_noinst_DATA += $(ACLK_PROTO_DEFINITIONS)
 
 ACLK_PROTO_BUILT_FILES = aclk/aclk-schemas/proto/agent/v1/connection.pb.cc \
     aclk/aclk-schemas/proto/agent/v1/connection.pb.h \
+    aclk/aclk-schemas/proto/agent/v1/cmds.pb.cc \
+    aclk/aclk-schemas/proto/agent/v1/cmds.pb.h \
     aclk/aclk-schemas/proto/nodeinstance/connection/v1/connection.pb.cc \
     aclk/aclk-schemas/proto/nodeinstance/connection/v1/connection.pb.h \
     aclk/aclk-schemas/proto/nodeinstance/create/v1/creation.pb.cc \
@@ -813,6 +816,10 @@ aclk/aclk-schemas/proto/aclk/v1/lib.pb.h: aclk/aclk-schemas/proto/aclk/v1/lib.pr
 
 aclk/aclk-schemas/proto/agent/v1/disconnect.pb.cc \
 aclk/aclk-schemas/proto/agent/v1/disconnect.pb.h: aclk/aclk-schemas/proto/agent/v1/disconnect.proto
+	$(PROTOC) -I=aclk/aclk-schemas --cpp_out=$(builddir)/aclk/aclk-schemas $^
+
+aclk/aclk-schemas/proto/agent/v1/cmds.pb.cc \
+aclk/aclk-schemas/proto/agent/v1/cmds.pb.h: aclk/aclk-schemas/proto/agent/v1/cmds.proto
 	$(PROTOC) -I=aclk/aclk-schemas --cpp_out=$(builddir)/aclk/aclk-schemas $^
 
 aclk/aclk-schemas/proto/alarm/v1/config.pb.cc \

--- a/aclk/aclk_capas.c
+++ b/aclk/aclk_capas.c
@@ -38,12 +38,14 @@ struct capability *aclk_get_node_instance_capas(RRDHOST *host)
         { .name = "http_api_v2", .version = 1,                     .enabled = 1 },
         { .name = NULL,          .version = 0,                     .enabled = 0 }
     };
-    if (host == localhost || (host->receiver && stream_has_capability(host->receiver, STREAM_CAP_FUNCTIONS))) {
-        ni_caps[4].version = 1;
-        ni_caps[4].enabled = 1;
-    }
 
     struct capability *ret = mallocz(sizeof(ni_caps));
     memcpy(ret, ni_caps, sizeof(ni_caps));
+
+    if (host == localhost || (host->receiver && stream_has_capability(host->receiver, STREAM_CAP_FUNCTIONS))) {
+        ret[4].version = 1;
+        ret[4].enabled = 1;
+    }
+
     return ret;
 }

--- a/aclk/aclk_capas.c
+++ b/aclk/aclk_capas.c
@@ -7,13 +7,14 @@
 const struct capability *aclk_get_agent_capas()
 {
     static struct capability agent_capabilities[] = {
-        { .name = "json",  .version = 2, .enabled = 0 },
-        { .name = "proto", .version = 1, .enabled = 1 },
-        { .name = "ml",    .version = 0, .enabled = 0 },
-        { .name = "mc",    .version = 0, .enabled = 0 },
-        { .name = "ctx",   .version = 1, .enabled = 1 },
-        { .name = "funcs", .version = 1, .enabled = 1 },
-        { .name = NULL,    .version = 0, .enabled = 0 }
+        { .name = "json",        .version = 2, .enabled = 0 },
+        { .name = "proto",       .version = 1, .enabled = 1 },
+        { .name = "ml",          .version = 0, .enabled = 0 },
+        { .name = "mc",          .version = 0, .enabled = 0 },
+        { .name = "ctx",         .version = 1, .enabled = 1 },
+        { .name = "funcs",       .version = 1, .enabled = 1 },
+        { .name = "http_api_v2", .version = 1, .enabled = 1 },
+        { .name = NULL,          .version = 0, .enabled = 0 }
     };
     agent_capabilities[2].version = ml_capable() ? 1 : 0;
     agent_capabilities[2].enabled = ml_enabled(localhost);
@@ -27,14 +28,15 @@ const struct capability *aclk_get_agent_capas()
 struct capability *aclk_get_node_instance_capas(RRDHOST *host)
 {
     struct capability ni_caps[] = {
-        { .name = "proto", .version = 1,                     .enabled = 1 },
-        { .name = "ml",    .version = ml_capable(),          .enabled = ml_enabled(host) },
+        { .name = "proto",       .version = 1,                     .enabled = 1 },
+        { .name = "ml",          .version = ml_capable(),          .enabled = ml_enabled(host) },
         { .name = "mc",
           .version = enable_metric_correlations ? metric_correlations_version : 0,
           .enabled = enable_metric_correlations },
-        { .name = "ctx",   .version = 1,                     .enabled = 1 },
-        { .name = "funcs", .version = 0,                     .enabled = 0 },
-        { .name = NULL,    .version = 0,                     .enabled = 0 }
+        { .name = "ctx",         .version = 1,                     .enabled = 1 },
+        { .name = "funcs",       .version = 0,                     .enabled = 0 },
+        { .name = "http_api_v2", .version = 1,                     .enabled = 1 },
+        { .name = NULL,          .version = 0,                     .enabled = 0 }
     };
     if (host == localhost || (host->receiver && stream_has_capability(host->receiver, STREAM_CAP_FUNCTIONS))) {
         ni_caps[4].version = 1;

--- a/database/contexts/api_v2.c
+++ b/database/contexts/api_v2.c
@@ -2,6 +2,7 @@
 
 #include "internal.h"
 
+#include "aclk/aclk_capas.h"
 
 // ----------------------------------------------------------------------------
 // /api/v2/contexts API
@@ -292,23 +293,20 @@ static ssize_t rrdcontext_to_json_v2_add_host(void *data, RRDHOST *host, bool qu
             buffer_json_member_add_array(wb, "services");
             buffer_json_array_close(wb);
 
-            buffer_json_member_add_array(wb, "capabilities");
-            buffer_json_add_array_item_object(wb);
-            buffer_json_member_add_string(wb, "name", "funcs");
-            buffer_json_member_add_uint64(wb, "version", 1);
-            buffer_json_member_add_boolean(wb, "enabled", true);
-            buffer_json_object_close(wb);
-            buffer_json_add_array_item_object(wb);
-            buffer_json_member_add_string(wb, "name", "mc");
-            buffer_json_member_add_uint64(wb, "version", 1);
-            buffer_json_member_add_boolean(wb, "enabled", true);
-            buffer_json_object_close(wb);
-            buffer_json_add_array_item_object(wb);
-            buffer_json_member_add_string(wb, "name", "ml");
-            buffer_json_member_add_uint64(wb, "version", 1);
-            buffer_json_member_add_boolean(wb, "enabled", true);
-            buffer_json_object_close(wb);
+            buffer_json_member_add_array(wb, "nodeInstanceCapabilities");
+
+            struct capability *capas = aclk_get_node_instance_capas(host);
+            struct capability *capa = capas;
+            while(capa->name != NULL) {
+                buffer_json_add_array_item_object(wb);
+                buffer_json_member_add_string(wb, "name", capa->name);
+                buffer_json_member_add_uint64(wb, "version", capa->version);
+                buffer_json_member_add_boolean(wb, "enabled", capa->enabled);
+                buffer_json_object_close(wb);
+                capa++;
+            }
             buffer_json_array_close(wb);
+            freez(capas);
 
             web_client_api_request_v1_info_summary_alarm_statuses(host, wb, "alarmCounters");
 


### PR DESCRIPTION
##### Summary

Small PR - title is pretty much all that can be said about it.

Added as agent and node_instance capa (as each node_instance can be queried about using v2 if agent speaks v2)
Not added to node capas as we do not know currently whether child can speak v2 api by itself

Fixes #14800

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
