### PR TITLE
Clean up install method list in bug report template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -51,12 +51,11 @@ body:
         Describe the method in the "Additional info" section if you chose "other".
       options:
         - "kickstart.sh"
-        - "kickstart-static64.sh"
-        - "native binary packages (.deb/.rpm)"
-        - "from git"
-        - "from source"
         - "docker"
         - "helmchart (kubernetes)"
+        - "manual setup of official DEB/RPM packages"
+        - "from git"
+        - "from source"
         - "other"
     validations:
       required: true


### PR DESCRIPTION
##### Summary

This tidies up the list of installation methods in our bug report issue template.

- Remove `kickstart-static64.sh`, as it’s not actually been a thing for more than a year now.
- Remove `native packages (deb/rpm)`, as it’s a consistent source of confusion. The original intent seems to be using this for our official packages, except that they’re mostly just covered under `kickstart.sh` as most users are using them, and many people seem to be getting confused by this and using it for installs done through the system package manager even if they are not our official packages.
- Move the `from git` and `from source` options to the bottom of the list. These are uncommon scenarios, so they should logically be sorted last.
- Add an option indicating manual setup of our official packages. This is to specifically cover the case of users manually setting up the repos instead of relying on the kickstart script for installs.

##### Test Plan

n/a