### PR TITLE
Docs, shorten too long titles, and add a description below

### DIFF
--- a/collectors/ioping.plugin/README.md
+++ b/collectors/ioping.plugin/README.md
@@ -1,16 +1,6 @@
-<!--
-title: "Monitor latency for directories/files/devices (ioping.plugin)"
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/collectors/ioping.plugin/README.md"
-sidebar_label: "Latency monitoring (ioping.plugin)"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Integrations/Monitor/QoS"
--->
+# Monitor I/O latency using ioping.plugin
 
-# Monitor latency for directories/files/devices (ioping.plugin)
-
-The ioping plugin supports monitoring latency for any number of directories/files/devices,
-by pinging them with `ioping`.
+The ioping plugin supports monitoring I/O latency for any number of directories/files/devices, by pinging them with `ioping`.
 
 A recent version of `ioping` is required (one that supports option `-N`).
 The supplied plugin can install it, by running:

--- a/collectors/python.d.plugin/zscores/README.md
+++ b/collectors/python.d.plugin/zscores/README.md
@@ -1,16 +1,6 @@
-<!--
-title: "zscores"
-description: "Use statistical anomaly detection to narrow your focus and shorten root cause analysis."
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/collectors/python.d.plugin/zscores/README.md"
-sidebar_label: "zscores"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Integrations/Monitor/Netdata"
--->
+# Basic anomaly detection using Z-scores
 
-# Z-Scores - basic anomaly detection for your key metrics and charts
-
-Smoothed, rolling [Z-Scores](https://en.wikipedia.org/wiki/Standard_score) for selected metrics or charts.
+By using smoothed, rolling [Z-Scores](https://en.wikipedia.org/wiki/Standard_score) for selected metrics or charts you can narrow down your focus and shorten root cause analysis.
 
 This collector uses the [Netdata rest api](https://github.com/netdata/netdata/blob/master/web/api/README.md) to get the `mean` and `stddev`
 for each dimension on specified charts over a time range (defined by `train_secs` and `offset_secs`). For each dimension

--- a/docs/guides/collect-apache-nginx-web-logs.md
+++ b/docs/guides/collect-apache-nginx-web-logs.md
@@ -1,20 +1,8 @@
-<!--
-title: "Monitor Nginx or Apache web server log files with Netdata"
-sidebar_label: "Monitor Nginx or Apache web server log files with Netdata"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/collect-apache-nginx-web-logs.md
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Miscellaneous"
--->
+# Monitor Nginx or Apache web server log files
 
-# Monitor Nginx or Apache web server log files with Netdata
+Parsing web server log files with Netdata, revealing the volume of redirects, requests and other metrics, can give you a better overview of your infrastructure.
 
-Log files have been a critical resource for developers and system administrators who want to understand the health and
-performance of their web servers, and Netdata is taking important steps to make them even more valuable.
-
-By parsing web server log files with Netdata, and seeing the volume of redirects, requests, or server errors over time,
-you can better understand what's happening on your infrastructure. Too many bad requests? Maybe a recent deploy missed a
-few small SVG icons. Too many requests? Time to batten down the hatches—it's a DDoS.
+Too many bad requests? Maybe a recent deploy missed a few small SVG icons. Too many requests? Time to batten down the hatches—it's a DDoS.
 
 You can use the [LTSV log format](http://ltsv.org/), track TLS and cipher usage, and the whole parser is faster than
 ever. In one test on a system with SSD storage, the collector consistently parsed the logs for 200,000 requests in

--- a/docs/guides/monitor/kubernetes-k8s-netdata.md
+++ b/docs/guides/monitor/kubernetes-k8s-netdata.md
@@ -1,14 +1,6 @@
-<!--
-title: "Kubernetes monitoring with Netdata: Overview and visualizations"
-sidebar_label: "Kubernetes monitoring with Netdata: Overview and visualizations"
-description: "Learn how to navigate Netdata's Kubernetes monitoring features for visualizing the health and performance of a Kubernetes cluster with per-second granularity."
-image: /img/seo/guides/monitor/kubernetes-k8s-netdata.png
-custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/monitor/kubernetes-k8s-netdata.md
-learn_status: "Published"
-learn_rel_path: "Miscellaneous"
--->
+# Kubernetes monitoring with Netdata
 
-# Kubernetes monitoring with Netdata: Overview and visualizations
+This document gives an overview of what visualizations Netdata provides on Kubernetes deployments.
 
 At Netdata, we've built Kubernetes monitoring tools that add visibility without complexity while also helping you
 actively troubleshoot anomalies or outages. This guide walks you through each of the visualizations and offers best

--- a/docs/guides/monitor/lamp-stack.md
+++ b/docs/guides/monitor/lamp-stack.md
@@ -1,15 +1,8 @@
-<!--
-title: "LAMP stack monitoring (Linux, Apache, MySQL, PHP) with Netdata"
-sidebar_label: "LAMP stack monitoring (Linux, Apache, MySQL, PHP) with Netdata"
-description: "Set up robust LAMP stack monitoring (Linux, Apache, MySQL, PHP) in just a few minutes using a free, open-source monitoring tool that collects metrics every second."
-image: /img/seo/guides/monitor/lamp-stack.png
-custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/monitor/lamp-stack.md
-learn_status: "Published"
-learn_rel_path: "Miscellaneous"
--->
 import { OneLineInstallWget } from '@site/src/components/OneLineInstall/'
 
-# LAMP stack monitoring (Linux, Apache, MySQL, PHP) with Netdata
+# LAMP stack monitoring with Netdata
+
+Set up robust LAMP stack monitoring (Linux, Apache, MySQL, PHP) in a few minutes using Netdata.
 
 The LAMP stack is the "hello world" for deploying dynamic web applications. It's fast, flexible, and reliable, which
 means a developer or sysadmin won't go far in their career without interacting with the stack and its services.

--- a/docs/guides/monitor/raspberry-pi-anomaly-detection.md
+++ b/docs/guides/monitor/raspberry-pi-anomaly-detection.md
@@ -1,14 +1,6 @@
-<!--
-title: "Unsupervised anomaly detection for Raspberry Pi monitoring"
-sidebar_label: "Unsupervised anomaly detection for Raspberry Pi monitoring"
-description: "Use a low-overhead machine learning algorithm and an open-source monitoring tool to detect anomalous metrics on a Raspberry Pi."
-image: /img/seo/guides/monitor/raspberry-pi-anomaly-detection.png
-custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/monitor/raspberry-pi-anomaly-detection.md
-learn_status: "Published"
-learn_rel_path: "Miscellaneous"
--->
+# Anomaly detection for RPi monitoring
 
-# Unsupervised anomaly detection for Raspberry Pi monitoring
+Learn how to use a low-overhead machine learning algorithm alongside Netdata to detect anomalous metrics on a Raspberry Pi.
 
 We love IoT and edge at Netdata, we also love machine learning. Even better if we can combine the two to ease the pain
 of monitoring increasingly complex systems.

--- a/docs/guides/using-host-labels.md
+++ b/docs/guides/using-host-labels.md
@@ -1,18 +1,12 @@
-<!--
-title: "Use host labels to organize systems, metrics, and alarms"
-sidebar_label: "Use host labels to organize systems, metrics, and alarms"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/using-host-labels.md
-learn_status: "Published"
-learn_rel_path: "Operations"
--->
+# Using host labels to organize your metrics
 
-# Use host labels to organize systems, metrics, and alarms
+When you use Netdata to monitor and troubleshoot an entire infrastructure, you need sophisticated ways of keeping everything organized.
 
-When you use Netdata to monitor and troubleshoot an entire infrastructure, whether that's dozens or hundreds of systems,
-you need sophisticated ways of keeping everything organized. You need alarms that adapt to the system's purpose, or
-whether the parent or child in a streaming setup. You need properly-labeled metrics archiving so you can sort,
-correlate, and mash-up your data to your heart's content. You need to keep tabs on ephemeral Docker containers in a
-Kubernetes cluster.
+Some of the scenarios that host labels can be extremely useful are:
+
+- You need alarms that adapt to the system's purpose
+- You need properly-labeled metrics archiving so you can sort, correlate, and mash-up your data to your heart's content.
+- You need to keep tabs on ephemeral Docker containers in a Kubernetes cluster.
 
 You need **host labels**: a powerful new way of organizing your Netdata-monitored systems. We introduced host labels in
 [v1.20 of Netdata](https://blog.netdata.cloud/posts/release-1.20/), and they come pre-configured out of the box.

--- a/packaging/building-native-packages-locally.md
+++ b/packaging/building-native-packages-locally.md
@@ -1,14 +1,6 @@
-<!--
-title: "How to build native (DEB/RPM) packages locally for testing"
-sidebar_label: "How to build native (DEB/RPM) packages locally for testing"
-description: Instructions for developers who need to build native packages locally for testing.
-custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/building-native-packages-locally.md
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Installation/Package maintainers"
--->
+# Build native (DEB/RPM) packages for testing
 
-# How to build native (DEB/RPM) packages locally for testing
+This document provides instructions for developers who need to build native packages locally for testing.
 
 ## Requirements
 


### PR DESCRIPTION
##### Summary

This is related to https://github.com/netdata/learn/issues/1507

It addresses documents that had too long a title. I added below the title one line of description, to lot lose information from the doc, look at the child issues referenced in the issue above.