### PR TITLE
configure extent cache size

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1112,7 +1112,11 @@ static void get_netdata_configured_variables() {
     // get default Database Engine page cache size in MiB
 
     default_rrdeng_page_cache_mb = (int) config_get_number(CONFIG_SECTION_DB, "dbengine page cache size MB", default_rrdeng_page_cache_mb);
+    default_rrdeng_extent_cache_mb = (int) config_get_number(CONFIG_SECTION_DB, "dbengine extent cache size MB", default_rrdeng_extent_cache_mb);
     db_engine_journal_check = config_get_boolean(CONFIG_SECTION_DB, "dbengine enable journal integrity check", CONFIG_BOOLEAN_NO);
+
+    if(default_rrdeng_extent_cache_mb < 0)
+        default_rrdeng_extent_cache_mb = 0;
 
     if(default_rrdeng_page_cache_mb < RRDENG_MIN_PAGE_CACHE_SIZE_MB) {
         error("Invalid page cache size %d given. Defaulting to %d.", default_rrdeng_page_cache_mb, RRDENG_MIN_PAGE_CACHE_SIZE_MB);

--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -1069,6 +1069,8 @@ void pgc_and_mrg_initialize(void)
         main_cache_size = target_cache_size - extent_cache_size;
     }
 
+    extent_cache_size += (size_t)(default_rrdeng_extent_cache_mb * 1024ULL * 1024ULL);
+
     main_cache = pgc_create(
             "main_cache",
             main_cache_size,

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -41,8 +41,10 @@ int default_multidb_disk_quota_mb = 256;
 
 #if defined(ENV32BIT)
 int default_rrdeng_page_cache_mb = 16;
+int default_rrdeng_extent_cache_mb = 0;
 #else
 int default_rrdeng_page_cache_mb = 32;
+int default_rrdeng_extent_cache_mb = 0;
 #endif
 
 // ----------------------------------------------------------------------------

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -13,6 +13,7 @@
 #define RRDENG_FD_BUDGET_PER_INSTANCE (50)
 
 extern int default_rrdeng_page_cache_mb;
+extern int default_rrdeng_extent_cache_mb;
 extern int db_engine_journal_check;
 extern int default_rrdeng_disk_quota_mb;
 extern int default_multidb_disk_quota_mb;


### PR DESCRIPTION
This PR allows users to configure the extent cache size of dbengine.

Users may need to configure the extent cache size to control the number of I/O operations on very busy servers.