### PR TITLE
Update the bundled version of makeself used to create static builds.

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -185,7 +185,10 @@ jobs:
           reporter: github-pr-check
           path: "."
           pattern: "*.sh*"
-          exclude: "./.git/*"
+          exclude: |
+            ./.git/*
+            packaging/makeself/makeself.sh
+            packaging/makeself/makeself-header.sh
 
   yamllint:
     name: yamllint

--- a/packaging/makeself/jobs/99-makeself.install.sh
+++ b/packaging/makeself/jobs/99-makeself.install.sh
@@ -61,6 +61,14 @@ run rm "${NETDATA_INSTALL_PATH}/sbin" \
   "${NETDATA_INSTALL_PATH}/usr/local"
 
 # -----------------------------------------------------------------------------
+# ensure required directories actually exist
+
+for dir in var/lib/netdata var/cache/netdata var/log/netdata ; do
+    run mkdir -p "${NETDATA_INSTALL_PATH}/${dir}"
+    run touch "${NETDATA_INSTALL_PATH}/${dir}/.keep"
+done
+
+# -----------------------------------------------------------------------------
 # create the makeself archive
 
 run sed "s|NETDATA_VERSION|${VERSION}|g" < "${NETDATA_MAKESELF_PATH}/makeself.lsm" > "${NETDATA_MAKESELF_PATH}/makeself.lsm.tmp"

--- a/packaging/makeself/makeself-header.sh
+++ b/packaging/makeself/makeself-header.sh
@@ -1,9 +1,10 @@
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-License-Identifier: GPL-2.0-or-later
 # shellcheck shell=sh
 # shellcheck disable=SC2154,SC2039
 cat << EOF  > "$archname"
 #!/bin/sh
 # This script was generated using Makeself $MS_VERSION
+# The license covering this archive and its contents, if any, is wholly independent of the Makeself license (GPL)
 
 ORIG_UMASK=\`umask\`
 if test "$KEEP_UMASK" = n; then
@@ -12,22 +13,31 @@ fi
 
 CRCsum="$CRCsum"
 MD5="$MD5sum"
+SHA="$SHAsum"
+SIGNATURE="$Signature"
 TMPROOT=\${TMPDIR:=/tmp}
-USER_PWD="\$PWD"; export USER_PWD
+USER_PWD="\$PWD"
+export USER_PWD
+ARCHIVE_DIR=\`dirname "\$0"\`
+export ARCHIVE_DIR
 
 label="$LABEL"
 script="$SCRIPT"
 scriptargs="$SCRIPTARGS"
+cleanup_script="${CLEANUP_SCRIPT}"
 licensetxt="$LICENSE"
-helpheader='$HELPHEADER'
+helpheader="${HELPHEADER}"
 targetdir="$archdirname"
 filesizes="$filesizes"
+totalsize="$totalsize"
 keep="$KEEP"
 nooverwrite="$NOOVERWRITE"
 quiet="n"
 accept="n"
 nodiskspace="n"
 export_conf="$EXPORT_CONF"
+decrypt_cmd="$DECRYPT_CMD"
+skip="$SKIP"
 
 print_cmd_arg=""
 if type printf > /dev/null; then
@@ -43,6 +53,11 @@ if test -d /usr/xpg4/bin; then
     export PATH
 fi
 
+if test -d /usr/sfw/bin; then
+    PATH=\$PATH:/usr/sfw/bin
+    export PATH
+fi
+
 unset CDPATH
 
 MS_Printf()
@@ -52,8 +67,14 @@ MS_Printf()
 
 MS_PrintLicense()
 {
+  PAGER=\${PAGER:=more}
   if test x"\$licensetxt" != x; then
-    echo "\$licensetxt"
+    PAGER_PATH=\`exec <&- 2>&-; which \$PAGER || command -v \$PAGER || type \$PAGER\`
+    if test -x "\$PAGER_PATH"; then
+      echo "\$licensetxt" | \$PAGER
+    else
+      echo "\$licensetxt"
+    fi
     if test x"\$accept" != xy; then
       while true
       do
@@ -74,7 +95,7 @@ MS_PrintLicense()
 MS_diskspace()
 {
 	(
-	df -kP "\$1" | tail -1 | awk '{ if (\$4 ~ /%/) {print \$3} else {print \$4} }'
+	df -k "\$1" | tail -1 | awk '{ if (\$4 ~ /%/) {print \$3} else {print \$4} }'
 	)
 }
 
@@ -82,15 +103,20 @@ MS_dd()
 {
     blocks=\`expr \$3 / 1024\`
     bytes=\`expr \$3 % 1024\`
-    dd if="\$1" ibs=\$2 skip=1 obs=1024 conv=sync 2> /dev/null | \\
-    { test \$blocks -gt 0 && dd ibs=1024 obs=1024 count=\$blocks ; \\
-      test \$bytes  -gt 0 && dd ibs=1 obs=1024 count=\$bytes ; } 2> /dev/null
+    # Test for ibs, obs and conv feature
+    if dd if=/dev/zero of=/dev/null count=1 ibs=512 obs=512 conv=sync 2> /dev/null; then
+        dd if="\$1" ibs=\$2 skip=1 obs=1024 conv=sync 2> /dev/null | \\
+        { test \$blocks -gt 0 && dd ibs=1024 obs=1024 count=\$blocks ; \\
+          test \$bytes  -gt 0 && dd ibs=1 obs=1024 count=\$bytes ; } 2> /dev/null
+    else
+        dd if="\$1" bs=\$2 skip=1 2> /dev/null
+    fi
 }
 
 MS_dd_Progress()
 {
     if test x"\$noprogress" = xy; then
-        MS_dd \$@
+        MS_dd "\$@"
         return \$?
     fi
     file="\$1"
@@ -104,7 +130,7 @@ MS_dd_Progress()
     blocks=\`expr \$length / \$bsize\`
     bytes=\`expr \$length % \$bsize\`
     (
-        dd ibs=\$offset skip=1 2>/dev/null
+        dd ibs=\$offset skip=1 count=1 2>/dev/null
         pos=\`expr \$pos \+ \$bsize\`
         MS_Printf "     0%% " 1>&2
         if test \$blocks -gt 0; then
@@ -134,32 +160,66 @@ MS_dd_Progress()
 MS_Help()
 {
     cat << EOH >&2
-\${helpheader}Makeself version $MS_VERSION
+Makeself version $MS_VERSION
  1) Getting help or info about \$0 :
   \$0 --help   Print this message
   \$0 --info   Print embedded info : title, default target directory, embedded script ...
   \$0 --lsm    Print embedded lsm entry (or no LSM)
   \$0 --list   Print the list of files in the archive
   \$0 --check  Checks integrity of the archive
+  \$0 --verify-sig key Verify signature agains a provided key id
 
  2) Running \$0 :
   \$0 [options] [--] [additional arguments to embedded script]
   with following options (in that order)
   --confirm             Ask before running embedded script
-  --quiet		Do not print anything except error messages
+  --quiet               Do not print anything except error messages
   --accept              Accept the license
-  --noexec              Do not run embedded script
+  --noexec              Do not run embedded script (implies --noexec-cleanup)
+  --noexec-cleanup      Do not run embedded cleanup script
   --keep                Do not erase target directory after running
-			the embedded script
+                        the embedded script
   --noprogress          Do not show the progress during the decompression
   --nox11               Do not spawn an xterm
-  --nochown             Do not give the extracted files to the current user
+  --nochown             Do not give the target folder to the current user
+  --chown               Give the target folder to the current user recursively
   --nodiskspace         Do not check for available disk space
-  --target dir          Extract directly to a target directory
-                        directory path can be either absolute or relative
+  --target dir          Extract directly to a target directory (absolute or relative)
+                        This directory may undergo recursive chown (see --nochown).
   --tar arg1 [arg2 ...] Access the contents of the archive through the tar command
-  --                    Following arguments will be passed to the embedded script
+  --ssl-pass-src src    Use the given src as the source of password to decrypt the data
+                        using OpenSSL. See "PASS PHRASE ARGUMENTS" in man openssl.
+                        Default is to prompt the user to enter decryption password
+                        on the current terminal.
+  --cleanup-args args   Arguments to the cleanup script. Wrap in quotes to provide
+                        multiple arguments.
+  --                    Following arguments will be passed to the embedded script\${helpheader}
 EOH
+}
+
+MS_Verify_Sig()
+{
+    GPG_PATH=\`exec <&- 2>&-; which gpg || command -v gpg || type gpg\`
+    MKTEMP_PATH=\`exec <&- 2>&-; which mktemp || command -v mktemp || type mktemp\`
+    test -x "\$GPG_PATH" || GPG_PATH=\`exec <&- 2>&-; which gpg || command -v gpg || type gpg\`
+    test -x "\$MKTEMP_PATH" || MKTEMP_PATH=\`exec <&- 2>&-; which mktemp || command -v mktemp || type mktemp\`
+	offset=\`head -n "\$skip" "\$1" | wc -c | sed "s/ //g"\`
+    temp_sig=\`mktemp -t XXXXX\`
+    echo \$SIGNATURE | base64 --decode > "\$temp_sig"
+    gpg_output=\`MS_dd "\$1" \$offset \$totalsize | LC_ALL=C "\$GPG_PATH" --verify "\$temp_sig" - 2>&1\`
+    gpg_res=\$?
+    rm -f "\$temp_sig"
+    if test \$gpg_res -eq 0 && test \`echo \$gpg_output | grep -c Good\` -eq 1; then
+        if test \`echo \$gpg_output | grep -c \$sig_key\` -eq 1; then
+            test x"\$quiet" = xn && echo "GPG signature is good" >&2
+        else
+            echo "GPG Signature key does not match" >&2
+            exit 2
+        fi
+    else
+        test x"\$quiet" = xn && echo "GPG signature failed to verify" >&2
+        exit 2
+    fi
 }
 
 MS_Check()
@@ -169,18 +229,44 @@ MS_Check()
 	MD5_ARG=""
     MD5_PATH=\`exec <&- 2>&-; which md5sum || command -v md5sum || type md5sum\`
     test -x "\$MD5_PATH" || MD5_PATH=\`exec <&- 2>&-; which md5 || command -v md5 || type md5\`
-	test -x "\$MD5_PATH" || MD5_PATH=\`exec <&- 2>&-; which digest || command -v digest || type digest\`
+    test -x "\$MD5_PATH" || MD5_PATH=\`exec <&- 2>&-; which digest || command -v digest || type digest\`
     PATH="\$OLD_PATH"
+
+    SHA_PATH=\`exec <&- 2>&-; which shasum || command -v shasum || type shasum\`
+    test -x "\$SHA_PATH" || SHA_PATH=\`exec <&- 2>&-; which sha256sum || command -v sha256sum || type sha256sum\`
 
     if test x"\$quiet" = xn; then
 		MS_Printf "Verifying archive integrity..."
     fi
-    offset=\`head -n $SKIP "\$1" | wc -c | tr -d " "\`
+    offset=\`head -n "\$skip" "\$1" | wc -c | sed "s/ //g"\`
+    fsize=\`cat "\$1" | wc -c | sed "s/ //g"\`
+    if test \$totalsize -ne \`expr \$fsize - \$offset\`; then
+        echo " Unexpected archive size." >&2
+        exit 2
+    fi
     verb=\$2
     i=1
     for s in \$filesizes
     do
 		crc=\`echo \$CRCsum | cut -d" " -f\$i\`
+		if test -x "\$SHA_PATH"; then
+			if test x"\`basename \$SHA_PATH\`" = xshasum; then
+				SHA_ARG="-a 256"
+			fi
+			sha=\`echo \$SHA | cut -d" " -f\$i\`
+			if test x"\$sha" = x0000000000000000000000000000000000000000000000000000000000000000; then
+				test x"\$verb" = xy && echo " \$1 does not contain an embedded SHA256 checksum." >&2
+			else
+				shasum=\`MS_dd_Progress "\$1" \$offset \$s | eval "\$SHA_PATH \$SHA_ARG" | cut -b-64\`;
+				if test x"\$shasum" != x"\$sha"; then
+					echo "Error in SHA256 checksums: \$shasum is different from \$sha" >&2
+					exit 2
+				elif test x"\$quiet" = xn; then
+					MS_Printf " SHA256 checksums are OK." >&2
+				fi
+				crc="0000000000";
+			fi
+		fi
 		if test -x "\$MD5_PATH"; then
 			if test x"\`basename \$MD5_PATH\`" = xdigest; then
 				MD5_ARG="-a md5"
@@ -193,8 +279,8 @@ MS_Check()
 				if test x"\$md5sum" != x"\$md5"; then
 					echo "Error in MD5 checksums: \$md5sum is different from \$md5" >&2
 					exit 2
-				else
-					test x"\$verb" = xy && MS_Printf " MD5 checksums are OK." >&2
+				elif test x"\$quiet" = xn; then
+					MS_Printf " MD5 checksums are OK." >&2
 				fi
 				crc="0000000000"; verb=n
 			fi
@@ -203,11 +289,11 @@ MS_Check()
 			test x"\$verb" = xy && echo " \$1 does not contain a CRC checksum." >&2
 		else
 			sum1=\`MS_dd_Progress "\$1" \$offset \$s | CMD_ENV=xpg4 cksum | awk '{print \$1}'\`
-			if test x"\$sum1" = x"\$crc"; then
-				test x"\$verb" = xy && MS_Printf " CRC checksums are OK." >&2
-			else
+			if test x"\$sum1" != x"\$crc"; then
 				echo "Error in checksums: \$sum1 is different from \$crc" >&2
-				exit 2;
+				exit 2
+			elif test x"\$quiet" = xn; then
+				MS_Printf " CRC checksums are OK." >&2
 			fi
 		fi
 		i=\`expr \$i + 1\`
@@ -218,13 +304,43 @@ MS_Check()
     fi
 }
 
+MS_Decompress()
+{
+    if test x"\$decrypt_cmd" != x""; then
+        { eval "\$decrypt_cmd" || echo " ... Decryption failed." >&2; } | eval "$GUNZIP_CMD"
+    else
+        eval "$GUNZIP_CMD"
+    fi
+    
+    if test \$? -ne 0; then
+        echo " ... Decompression failed." >&2
+    fi
+}
+
 UnTAR()
 {
     if test x"\$quiet" = xn; then
-		tar \$1vf - $UNTAR_EXTRA 2>&1 || { echo " ... Extraction failed." > /dev/tty; kill -15 \$$; }
+		tar \$1vf - $UNTAR_EXTRA 2>&1 || { echo " ... Extraction failed." >&2; kill -15 \$$; }
     else
-		tar \$1f - $UNTAR_EXTRA 2>&1 || { echo Extraction failed. > /dev/tty; kill -15 \$$; }
+		tar \$1f - $UNTAR_EXTRA 2>&1 || { echo Extraction failed. >&2; kill -15 \$$; }
     fi
+}
+
+MS_exec_cleanup() {
+    if test x"\$cleanup" = xy && test x"\$cleanup_script" != x""; then
+        cleanup=n
+        cd "\$tmpdir"
+        eval "\"\$cleanup_script\" \$scriptargs \$cleanupargs"
+    fi
+}
+
+MS_cleanup()
+{
+    echo 'Signal caught, cleaning up' >&2
+    MS_exec_cleanup
+    cd "\$TMPROOT"
+    rm -rf "\$tmpdir"
+    eval \$finish; exit 15
 }
 
 finish=true
@@ -232,8 +348,11 @@ xterm_loop=
 noprogress=$NOPROGRESS
 nox11=$NOX11
 copy=$COPY
-ownership=y
+ownership=$OWNERSHIP
 verbose=n
+cleanup=y
+cleanupargs=
+sig_key=
 
 initargs="\$@"
 
@@ -258,8 +377,11 @@ do
 	echo Target directory: "\$targetdir"
 	echo Uncompressed size: $USIZE KB
 	echo Compression: $COMPRESS
+	if test x"$ENCRYPT" != x""; then
+	    echo Encryption: $ENCRYPT
+	fi
 	echo Date of packaging: $DATE
-	echo Built with Makeself version $MS_VERSION on $OSTYPE
+	echo Built with Makeself version $MS_VERSION
 	echo Build command was: "$MS_COMMAND"
 	if test x"\$script" != x; then
 	    echo Script run after extraction:
@@ -282,15 +404,17 @@ do
 	echo LABEL=\"\$label\"
 	echo SCRIPT=\"\$script\"
 	echo SCRIPTARGS=\"\$scriptargs\"
+    echo CLEANUPSCRIPT=\"\$cleanup_script\"
 	echo archdirname=\"$archdirname\"
 	echo KEEP=$KEEP
 	echo NOOVERWRITE=$NOOVERWRITE
 	echo COMPRESS=$COMPRESS
 	echo filesizes=\"\$filesizes\"
+    echo totalsize=\"\$totalsize\"
 	echo CRCsum=\"\$CRCsum\"
-	echo MD5sum=\"\$MD5\"
-	echo OLDUSIZE=$USIZE
-	echo OLDSKIP=$((SKIP + 1))
+	echo MD5sum=\"\$MD5sum\"
+	echo SHAsum=\"\$SHAsum\"
+	echo SKIP=\"\$skip\"
 	exit 0
 	;;
     --lsm)
@@ -303,21 +427,21 @@ EOLSM
 	;;
     --list)
 	echo Target directory: \$targetdir
-	offset=\`head -n $SKIP "\$0" | wc -c | tr -d " "\`
+	offset=\`head -n "\$skip" "\$0" | wc -c | sed "s/ //g"\`
 	for s in \$filesizes
 	do
-	    MS_dd "\$0" \$offset \$s | eval "$GUNZIP_CMD" | UnTAR t
+	    MS_dd "\$0" \$offset \$s | MS_Decompress | UnTAR t
 	    offset=\`expr \$offset + \$s\`
 	done
 	exit 0
 	;;
 	--tar)
-	offset=\`head -n $SKIP "\$0" | wc -c | tr -d " "\`
+	offset=\`head -n "\$skip" "\$0" | wc -c | sed "s/ //g"\`
 	arg1="\$2"
-    if ! shift 2; then MS_Help; exit 1; fi
+    shift 2 || { MS_Help; exit 1; }
 	for s in \$filesizes
 	do
-	    MS_dd "\$0" \$offset \$s | eval "$GUNZIP_CMD" | tar "\$arg1" - "\$@"
+	    MS_dd "\$0" \$offset \$s | MS_Decompress | tar "\$arg1" - "\$@"
 	    offset=\`expr \$offset + \$s\`
 	done
 	exit 0
@@ -326,22 +450,32 @@ EOLSM
 	MS_Check "\$0" y
 	exit 0
 	;;
+    --verify-sig)
+    sig_key="\$2"
+    shift 2 || { MS_Help; exit 1; }
+    MS_Verify_Sig "\$0"
+    ;;
     --confirm)
 	verbose=y
 	shift
 	;;
 	--noexec)
 	script=""
+    cleanup_script=""
 	shift
 	;;
+    --noexec-cleanup)
+    cleanup_script=""
+    shift
+    ;;
     --keep)
 	keep=y
 	shift
 	;;
     --target)
 	keep=y
-	targetdir=\${2:-.}
-    if ! shift 2; then MS_Help; exit 1; fi
+	targetdir="\${2:-.}"
+    shift 2 || { MS_Help; exit 1; }
 	;;
     --noprogress)
 	noprogress=y
@@ -355,6 +489,10 @@ EOLSM
 	ownership=n
 	shift
 	;;
+    --chown)
+        ownership=y
+        shift
+        ;;
     --nodiskspace)
 	nodiskspace=y
 	shift
@@ -370,6 +508,18 @@ EOLSM
 	copy=phase2
 	shift
 	;;
+	--ssl-pass-src)
+	if test x"$ENCRYPT" != x"openssl"; then
+	    echo "Invalid option --ssl-pass-src: \$0 was not encrypted with OpenSSL!" >&2
+	    exit 1
+	fi
+	decrypt_cmd="\$decrypt_cmd -pass \$2"
+    shift 2 || { MS_Help; exit 1; }
+	;;
+    --cleanup-args)
+    cleanupargs="\$2"
+    shift 2 || { MS_Help; exit 1; }
+    ;;
     --)
 	shift
 	break ;;
@@ -390,7 +540,7 @@ fi
 
 if test x"$NEED_ROOT" = xy -a \`id -u\` -ne 0; then
 	echo "Administrative privileges required for this archive (use su or sudo)" >&2
-	exit 1
+	exit 1	
 fi
 
 if test x"\$copy" \!= xphase2; then
@@ -399,7 +549,7 @@ fi
 
 case "\$copy" in
 copy)
-    tmpdir=\$TMPROOT/makeself.\$RANDOM.\`date +"%y%m%d%H%M%S"\`.\$\$
+    tmpdir="\$TMPROOT"/makeself.\$RANDOM.\`date +"%y%m%d%H%M%S"\`.\$\$
     mkdir "\$tmpdir" || {
 	echo "Could not create temporary directory \$tmpdir" >&2
 	exit 1
@@ -409,6 +559,7 @@ copy)
     cp "\$0" "\$SCRIPT_COPY"
     chmod +x "\$SCRIPT_COPY"
     cd "\$TMPROOT"
+    export USER_PWD="\$tmpdir"
     exec "\$SCRIPT_COPY" --phase2 -- \$initargs
     ;;
 phase2)
@@ -417,7 +568,7 @@ phase2)
 esac
 
 if test x"\$nox11" = xn; then
-    if tty -s; then                 # Do we have a terminal?
+    if test -t 1; then  # Do we have a terminal on stdout?
 	:
     else
         if test x"\$DISPLAY" != x -a x"\$xterm_loop" = x; then  # No, but do we have X?
@@ -429,11 +580,11 @@ if test x"\$nox11" = xn; then
                         break
                     fi
                 done
-                chmod a+x \$0 || echo Please add execution rights on \$0
+                chmod a+x \$0 || echo Please add execution rights on \$0 >&2
                 if test \`echo "\$0" | cut -c1\` = "/"; then # Spawn a terminal!
-                    exec \$XTERM -title "\$label" -e "\$0" --xwin "\$initargs"
+                    exec \$XTERM -e "\$0 --xwin \$initargs"
                 else
-                    exec \$XTERM -title "\$label" -e "./\$0" --xwin "\$initargs"
+                    exec \$XTERM -e "./\$0 --xwin \$initargs"
                 fi
             fi
         fi
@@ -457,7 +608,7 @@ else
 	tmpdir="\$TMPROOT/selfgz\$\$\$RANDOM"
 	dashp=""
     fi
-    mkdir \$dashp \$tmpdir || {
+    mkdir \$dashp "\$tmpdir" || {
 	echo 'Cannot create target directory' \$tmpdir >&2
 	echo 'You should try option --target dir' >&2
 	eval \$finish
@@ -469,7 +620,7 @@ location="\`pwd\`"
 if test x"\$SETUP_NOCHECK" != x1; then
     MS_Check "\$0"
 fi
-offset=\`head -n $SKIP "\$0" | wc -c | tr -d " "\`
+offset=\`head -n "\$skip" "\$0" | wc -c | sed "s/ //g"\`
 
 if test x"\$verbose" = xy; then
 	MS_Printf "About to extract $USIZE KB in \$tmpdir ... Proceed ? [Y/n] "
@@ -480,15 +631,21 @@ if test x"\$verbose" = xy; then
 fi
 
 if test x"\$quiet" = xn; then
-	MS_Printf "Uncompressing \$label"
+    # Decrypting with openssl will ask for password,
+    # the prompt needs to start on new line
+	if test x"$ENCRYPT" = x"openssl"; then
+	    echo "Decrypting and uncompressing \$label..."
+	else
+        MS_Printf "Uncompressing \$label"
+	fi
 fi
 res=3
 if test x"\$keep" = xn; then
-    trap 'echo Signal caught, cleaning up >&2; cd \$TMPROOT; /bin/rm -rf \$tmpdir; eval \$finish; exit 15' 1 2 3 15
+    trap MS_cleanup 1 2 3 15
 fi
 
 if test x"\$nodiskspace" = xn; then
-    leftspace=\`MS_diskspace \$tmpdir\`
+    leftspace=\`MS_diskspace "\$tmpdir"\`
     if test -n "\$leftspace"; then
         if test "\$leftspace" -lt $USIZE; then
             echo
@@ -504,7 +661,7 @@ fi
 
 for s in \$filesizes
 do
-    if MS_dd_Progress "\$0" \$offset \$s | eval "$GUNZIP_CMD" | ( cd "\$tmpdir"; umask \$ORIG_UMASK ; UnTAR xp ) 1>/dev/null; then
+    if MS_dd_Progress "\$0" \$offset \$s | MS_Decompress | ( cd "\$tmpdir"; umask \$ORIG_UMASK ; UnTAR xp ) 1>/dev/null; then
 		if test x"\$ownership" = xy; then
 			(cd "\$tmpdir"; chown -R \`id -u\` .;  chgrp -R \`id -g\` .)
 		fi
@@ -531,6 +688,7 @@ if test x"\$script" != x; then
         MS_KEEP="\$KEEP"
         MS_NOOVERWRITE="\$NOOVERWRITE"
         MS_COMPRESS="\$COMPRESS"
+        MS_CLEANUP="\$cleanup"
         export MS_BUNDLE MS_LABEL MS_SCRIPT MS_SCRIPTARGS
         export MS_ARCHDIRNAME MS_KEEP MS_NOOVERWRITE MS_COMPRESS
     fi
@@ -548,9 +706,12 @@ if test x"\$script" != x; then
 		test x"\$verbose" = xy && echo "The program '\$script' returned an error code (\$res)" >&2
     fi
 fi
+
+MS_exec_cleanup
+
 if test x"\$keep" = xn; then
-    cd \$TMPROOT
-    /bin/rm -rf \$tmpdir
+    cd "\$TMPROOT"
+    rm -rf "\$tmpdir"
 fi
 eval \$finish; exit \$res
 EOF

--- a/packaging/makeself/makeself-license.txt
+++ b/packaging/makeself/makeself-license.txt
@@ -4,7 +4,7 @@
   |   '-'   '-'   '-'   '-'   real-time performance monitoring, done right!
   +----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+--->
 
-  (C) Copyright 2017, Costa Tsaousis
+  (C) Copyright 2017-2023, Costa Tsaousis
   All rights reserved
   Released under GPL v3+
 
@@ -24,13 +24,10 @@
    - /etc/logrotate.d/netdata
 
   # SYSTEM INIT
-  This file will be installed if this system runs with systemd:
-
-   - /lib/systemd/system/netdata.service
-
-   or, for older CentOS, Debian/Ubuntu or OpenRC Gentoo:
-
-   - /etc/init.d/netdata         will be created
+  If a supported init system is detected, appropriate configuration will be
+  installed to allow Netdata to run as a system service. We currently support
+  systemd, OpenRC, LSB init scripts, and traditional init.d setups, as well as
+  having experimental support for runit.
 
 
   This package can also update a netdata installation that has been

--- a/packaging/makeself/makeself.lsm
+++ b/packaging/makeself/makeself.lsm
@@ -10,7 +10,7 @@ Description:    netdata is a system for distributed real-time performance and he
 Keywords:       real-time performance and health monitoring
 Author:         Costa Tsaousis (costa@tsaousis.gr)
 Maintained-by:  Costa Tsaousis (costa@tsaousis.gr)
-Original-site:  https://my-netdata.io/
+Original-site:  https://netdata.cloud/
 Platform:       Unix
 Copying-policy: GPL
 End

--- a/packaging/makeself/makeself.sh
+++ b/packaging/makeself/makeself.sh
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
+# shellcheck disable=SC2209,SC2006,SC2016,SC2034,SC2086,SC2003,SC2268,SC1090,SC2002,SC2046
+#
 # Makeself version 2.5.x
 #  by Stephane Peter <megastep@megastep.org>
 #

--- a/packaging/makeself/makeself.sh
+++ b/packaging/makeself/makeself.sh
@@ -1,85 +1,29 @@
 #!/bin/sh
-# SPDX-License-Identifier: GPL-3.0-or-later
 #
-# Makeself version 2.3.x
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Makeself version 2.5.x
 #  by Stephane Peter <megastep@megastep.org>
 #
 # Utility to create self-extracting tar.gz archives.
 # The resulting archive is a file holding the tar.gz archive with
 # a small Shell script stub that uncompresses the archive to a temporary
-# directory and then executes a given script from within that directory.
+# directory and then executes a given script from withing that directory.
 #
-# Makeself home page: http://makeself.io/
+# Makeself home page: https://makeself.io/ - Version history available on GitHub
 #
-# Version 2.0 is a rewrite of version 1.0 to make the code easier to read and maintain.
-#
-# Version history :
-# - 1.0 : Initial public release
-# - 1.1 : The archive can be passed parameters that will be passed on to
-#         the embedded script, thanks to John C. Quillan
-# - 1.2 : Package distribution, bzip2 compression, more command line options,
-#         support for non-temporary archives. Ideas thanks to Francois Petitjean
-# - 1.3 : More patches from Bjarni R. Einarsson and Francois Petitjean:
-#         Support for no compression (--nocomp), script is no longer mandatory,
-#         automatic launch in an xterm, optional verbose output, and -target
-#         archive option to indicate where to extract the files.
-# - 1.4 : Improved UNIX compatibility (Francois Petitjean)
-#         Automatic integrity checking, support of LSM files (Francois Petitjean)
-# - 1.5 : Many bugfixes. Optionally disable xterm spawning.
-# - 1.5.1 : More bugfixes, added archive options -list and -check.
-# - 1.5.2 : Cosmetic changes to inform the user of what's going on with big
-#           archives (Quake III demo)
-# - 1.5.3 : Check for validity of the DISPLAY variable before launching an xterm.
-#           More verbosity in xterms and check for embedded command's return value.
-#           Bugfix for Debian 2.0 systems that have a different "print" command.
-# - 1.5.4 : Many bugfixes. Print out a message if the extraction failed.
-# - 1.5.5 : More bugfixes. Added support for SETUP_NOCHECK environment variable to
-#           bypass checksum verification of archives.
-# - 1.6.0 : Compute MD5 checksums with the md5sum command (patch from Ryan Gordon)
-# - 2.0   : Brand new rewrite, cleaner architecture, separated header and UNIX ports.
-# - 2.0.1 : Added --copy
-# - 2.1.0 : Allow multiple tarballs to be stored in one archive, and incremental updates.
-#           Added --nochown for archives
-#           Stopped doing redundant checksums when not necessary
-# - 2.1.1 : Work around insane behavior from certain Linux distros with no 'uncompress' command
-#           Cleaned up the code to handle error codes from compress. Simplified the extraction code.
-# - 2.1.2 : Some bug fixes. Use head -n to avoid problems.
-# - 2.1.3 : Bug fixes with command line when spawning terminals.
-#           Added --tar for archives, allowing to give arbitrary arguments to tar on the contents of the archive.
-#           Added --noexec to prevent execution of embedded scripts.
-#           Added --nomd5 and --nocrc to avoid creating checksums in archives.
-#           Added command used to create the archive in --info output.
-#           Run the embedded script through eval.
-# - 2.1.4 : Fixed --info output.
-#           Generate random directory name when extracting files to . to avoid problems. (Jason Trent)
-#           Better handling of errors with wrong permissions for the directory containing the files. (Jason Trent)
-#           Avoid some race conditions (Ludwig Nussel)
-#           Unset the $CDPATH variable to avoid problems if it is set. (Debian)
-#           Better handling of dot files in the archive directory.
-# - 2.1.5 : Made the md5sum detection consistent with the header code.
-#           Check for the presence of the archive directory
-#           Added --encrypt for symmetric encryption through gpg (Eric Windisch)
-#           Added support for the digest command on Solaris 10 for MD5 checksums
-#           Check for available disk space before extracting to the target directory (Andreas Schweitzer)
-#           Allow extraction to run asynchronously (patch by Peter Hatch)
-#           Use file descriptors internally to avoid error messages (patch by Kay Tiong Khoo)
-# - 2.1.6 : Replaced one dot per file progress with a realtime progress percentage and a spinning cursor (Guy Baconniere)
-#           Added --noprogress to prevent showing the progress during the decompression (Guy Baconniere)
-#           Added --target dir to allow extracting directly to a target directory (Guy Baconniere)
-# - 2.2.0 : Many bugfixes, updates and contributions from users. Check out the project page on Github for the details.
-# - 2.3.0 : Option to specify packaging date to enable byte-for-byte reproducibility. (Marc Pawlowsky)
-#
-# (C) 1998-2017 by Stephane Peter <megastep@megastep.org>
+# (C) 1998-2023 by Stephane Peter <megastep@megastep.org>
 #
 # This software is released under the terms of the GNU GPL version 2 and above
 # Please read the license at http://www.gnu.org/copyleft/gpl.html
+# Self-extracting archives created with this script are explictly NOT released under the term of the GPL
 #
 
-MS_VERSION=2.3.1
+MS_VERSION=2.5.0
 MS_COMMAND="$0"
 unset CDPATH
 
-for f in "${1+"$@"}"; do
+for f in ${1+"$@"}; do
     MS_COMMAND="$MS_COMMAND \\\\
     \\\"$f\\\""
 done
@@ -94,30 +38,46 @@ fi
 
 MS_Usage()
 {
-    echo "Usage: $0 [params] archive_dir file_name label startup_script [args]"
-    echo "params can be one or more of the following :"
+    echo "Usage: $0 [args] archive_dir file_name label startup_script [script_args]"
+    echo "args can be one or more of the following :"
     echo "    --version | -v     : Print out Makeself version number and exit"
     echo "    --help | -h        : Print out this help message"
     echo "    --tar-quietly      : Suppress verbose output from the tar command"
     echo "    --quiet | -q       : Do not print any messages other than errors."
     echo "    --gzip             : Compress using gzip (default if detected)"
     echo "    --pigz             : Compress with pigz"
+    echo "    --zstd             : Compress with zstd"
     echo "    --bzip2            : Compress using bzip2 instead of gzip"
     echo "    --pbzip2           : Compress using pbzip2 instead of gzip"
+    echo "    --bzip3            : Compress using bzip3 instead of gzip"
     echo "    --xz               : Compress using xz instead of gzip"
     echo "    --lzo              : Compress using lzop instead of gzip"
     echo "    --lz4              : Compress using lz4 instead of gzip"
     echo "    --compress         : Compress using the UNIX 'compress' command"
-    echo "    --complevel lvl    : Compression level for gzip pigz xz lzo lz4 bzip2 and pbzip2 (default 9)"
+    echo "    --complevel lvl    : Compression level for gzip pigz zstd xz lzo lz4 bzip2 pbzip2 and bzip3 (default 9)"
+    echo "    --threads thds     : Number of threads to be used by compressors that support parallelization."
+    echo "                         Omit to use compressor's default. Most useful (and required) for opting"
+    echo "                         into xz's threading, usually with '--threads=0' for all available cores."
+    echo "                         pbzip2 and pigz are parallel by default, and setting this value allows"
+    echo "                         limiting the number of threads they use."
     echo "    --base64           : Instead of compressing, encode the data using base64"
     echo "    --gpg-encrypt      : Instead of compressing, encrypt the data using GPG"
     echo "    --gpg-asymmetric-encrypt-sign"
     echo "                       : Instead of compressing, asymmetrically encrypt and sign the data using GPG"
     echo "    --gpg-extra opt    : Append more options to the gpg command line"
     echo "    --ssl-encrypt      : Instead of compressing, encrypt the data using OpenSSL"
+    echo "    --ssl-passwd pass  : Use the given password to encrypt the data using OpenSSL"
+    echo "    --ssl-pass-src src : Use the given src as the source of password to encrypt the data"
+    echo "                         using OpenSSL. See \"PASS PHRASE ARGUMENTS\" in man openssl."
+    echo "                         If this option is not supplied, the user will be asked to enter"
+    echo "                         encryption password on the current terminal."
+    echo "    --ssl-no-md        : Do not use \"-md\" option not supported by older OpenSSL."
+    echo "    --nochown          : Do not give the target folder to the current user (default)"
+    echo "    --chown            : Give the target folder to the current user recursively"
     echo "    --nocomp           : Do not compress the data"
-    echo "    --notemp           : The archive will create archive_dir in the"
-    echo "                         current directory and uncompress in ./archive_dir"
+    echo "    --notemp           : The archive will create archive_dir in the current directory"
+    echo "                         and uncompress in ./archive_dir"
+    echo "                         Note: persistent archives do not strictly require a startup_script"
     echo "    --needroot         : Check that the root user is extracting the archive before proceeding"
     echo "    --copy             : Upon extraction, the archive will first copy itself to"
     echo "                         a temporary directory"
@@ -125,19 +85,23 @@ MS_Usage()
     echo "                         The label and startup scripts will then be ignored"
     echo "    --target dir       : Extract directly to a target directory"
     echo "                         directory path can be either absolute or relative"
-    echo "    --nooverwrite      : Do not extract the archive if the specified target directory exists"
     echo "    --current          : Files will be extracted to the current directory"
-    echo "                         Both --current and --target imply --notemp"
+    echo "                         Both --current and --target imply --notemp, and do not require a startup_script"
+    echo "    --nooverwrite      : Do not extract the archive if the specified target directory exists"
+    echo "    --tar-format opt   : Specify a tar archive format (default is ustar)"
     echo "    --tar-extra opt    : Append more options to the tar command line"
     echo "    --untar-extra opt  : Append more options to the during the extraction of the tar archive"
     echo "    --nomd5            : Don't calculate an MD5 for archive"
     echo "    --nocrc            : Don't calculate a CRC for archive"
+    echo "    --sha256           : Compute a SHA256 checksum for the archive"
     echo "    --header file      : Specify location of the header script"
+    echo "    --cleanup file     : Specify a cleanup script that executes on interrupt and when finished successfully."
     echo "    --follow           : Follow the symlinks in the archive"
     echo "    --noprogress       : Do not show the progress during the decompression"
     echo "    --nox11            : Disable automatic spawn of a xterm"
     echo "    --nowait           : Do not wait for user input after executing embedded"
     echo "                         program from an xterm"
+    echo "    --sign passphrase  : Signature private key to sign the package with"
     echo "    --lsm file         : LSM file describing the package"
     echo "    --license file     : Append a license file"
     echo "    --help-header file : Add a header to the archive's --help output"
@@ -154,12 +118,21 @@ MS_Usage()
 }
 
 # Default settings
-if type gzip 2>&1 > /dev/null; then
+if type gzip >/dev/null 2>&1; then
     COMPRESS=gzip
+elif type compress >/dev/null 2>&1; then
+    COMPRESS=compress
 else
-    COMPRESS=Unix
+    echo "ERROR: missing commands: gzip, compress" >&2
+    MS_Usage
 fi
+ENCRYPT=n
+PASSWD=""
+PASSWD_SRC=""
+OPENSSL_NO_MD=n
 COMPRESS_LEVEL=9
+DEFAULT_THREADS=123456 # Sentinel value
+THREADS=$DEFAULT_THREADS
 KEEP=n
 CURRENT=n
 NOX11=n
@@ -171,15 +144,21 @@ QUIET=n
 NOPROGRESS=n
 COPY=none
 NEED_ROOT=n
-TAR_ARGS=cvf
+TAR_ARGS=rvf
+TAR_FORMAT=ustar
 TAR_EXTRA=""
 GPG_EXTRA=""
 DU_ARGS=-ks
 HEADER=`dirname "$0"`/makeself-header.sh
+SIGNATURE=""
 TARGETDIR=""
 NOOVERWRITE=n
 DATE=`LC_ALL=C date`
 EXPORT_CONF=n
+SHA256=n
+OWNERSHIP=n
+SIGN=n
+GPG_PASSPHRASE=""
 
 # LSM file stuff
 LSM_CMD="echo No LSM. >> \"\$archname\""
@@ -195,6 +174,10 @@ do
 	COMPRESS=pbzip2
 	shift
 	;;
+    --bzip3)
+	COMPRESS=bzip3
+	shift
+	;;
     --bzip2)
 	COMPRESS=bzip2
 	shift
@@ -204,9 +187,13 @@ do
 	shift
 	;;
     --pigz)
-	COMPRESS=pigz
-	shift
-	;;
+    	COMPRESS=pigz
+    	shift
+    	;;
+    --zstd)
+    	COMPRESS=zstd
+    	shift
+    	;;
     --xz)
 	COMPRESS=xz
 	shift
@@ -220,7 +207,7 @@ do
 	shift
 	;;
     --compress)
-	COMPRESS=Unix
+	COMPRESS=compress
 	shift
 	;;
     --base64)
@@ -232,24 +219,48 @@ do
 	shift
 	;;
     --gpg-asymmetric-encrypt-sign)
-  COMPRESS=gpg-asymmetric
-  shift
-  ;;
+	COMPRESS=gpg-asymmetric
+	shift
+	;;
     --gpg-extra)
-  GPG_EXTRA="$2"
-  if ! shift 2; then MS_Help; exit 1; fi
-  ;;
+	GPG_EXTRA="$2"
+    shift 2 || { MS_Usage; exit 1; }
+	;;
     --ssl-encrypt)
-  COMPRESS=openssl
-  shift
-  ;;
+	ENCRYPT=openssl
+ 	shift
+	;;
+    --ssl-passwd)
+	PASSWD=$2
+    shift 2 || { MS_Usage; exit 1; }
+	;;
+    --ssl-pass-src)
+	PASSWD_SRC=$2
+    shift 2 || { MS_Usage; exit 1; }
+	;;
+    --ssl-no-md)
+	OPENSSL_NO_MD=y
+	shift
+	;;
     --nocomp)
 	COMPRESS=none
 	shift
 	;;
     --complevel)
 	COMPRESS_LEVEL="$2"
-	if ! shift 2; then MS_Help; exit 1; fi
+    shift 2 || { MS_Usage; exit 1; }
+	;;
+    --threads)
+	THREADS="$2"
+    shift 2 || { MS_Usage; exit 1; }
+	;;
+    --nochown)
+	OWNERSHIP=n
+	shift
+	;;
+    --chown)
+	OWNERSHIP=y
+	shift
 	;;
     --notemp)
 	KEEP=y
@@ -264,19 +275,28 @@ do
 	KEEP=y
 	shift
 	;;
+    --tar-format)
+	    TAR_FORMAT="$2"
+        shift 2 || { MS_Usage; exit 1; }
+    ;;
     --tar-extra)
-	TAR_EXTRA="$2"
-        if ! shift 2; then MS_Help; exit 1; fi
-        ;;
+	    TAR_EXTRA="$2"
+        shift 2 || { MS_Usage; exit 1; }
+    ;;
     --untar-extra)
         UNTAR_EXTRA="$2"
-        if ! shift 2; then MS_Help; exit 1; fi
+        shift 2 || { MS_Usage; exit 1; }
         ;;
     --target)
-	TARGETDIR="$2"
-	KEEP=y
-        if ! shift 2; then MS_Help; exit 1; fi
-	;;
+	  TARGETDIR="$2"
+	  KEEP=y
+    shift 2 || { MS_Usage; exit 1; }
+ 	  ;;
+    --sign)
+    SIGN=y
+    GPG_PASSPHRASE="$2"
+    shift 2 || { MS_Usage; exit 1; }
+    ;;
     --nooverwrite)
         NOOVERWRITE=y
 	shift
@@ -287,14 +307,19 @@ do
 	;;
     --header)
 	HEADER="$2"
-        if ! shift 2; then MS_Help; exit 1; fi
+    shift 2 || { MS_Usage; exit 1; }
 	;;
+    --cleanup)
+    CLEANUP_SCRIPT="$2"
+    shift 2 || { MS_Usage; exit 1; }
+    ;;
     --license)
-        LICENSE=`cat $2`
-        if ! shift 2; then MS_Help; exit 1; fi
+        # We need to escape all characters having a special meaning in double quotes
+        LICENSE=$(sed 's/\\/\\\\/g; s/"/\\\"/g; s/`/\\\`/g; s/\$/\\\$/g' "$2")
+        shift 2 || { MS_Usage; exit 1; }
 	;;
     --follow)
-	TAR_ARGS=cvhf
+	TAR_ARGS=rvhf
 	DU_ARGS=-ksL
 	shift
 	;;
@@ -314,6 +339,10 @@ do
 	NOMD5=y
 	shift
 	;;
+    --sha256)
+        SHA256=y
+        shift
+        ;;
     --nocrc)
 	NOCRC=y
 	shift
@@ -323,16 +352,16 @@ do
 	shift
 	;;
     --lsm)
-	LSM_CMD="cat \"$2\" >> \"\$archname\""
-    if ! shift 2; then MS_Help; exit 1; fi
+	LSM_CMD="awk 1 \"$2\" >> \"\$archname\""
+    shift 2 || { MS_Usage; exit 1; }
 	;;
     --packaging-date)
 	DATE="$2"
-	if ! shift 2; then MS_Help; exit 1; fi
+    shift 2 || { MS_Usage; exit 1; }
         ;;
     --help-header)
 	HELPHEADER=`sed -e "s/'/'\\\\\''/g" $2`
-    if ! shift 2; then MS_Help; exit 1; fi
+    shift 2 || { MS_Usage; exit 1; }
 	[ -n "$HELPHEADER" ] && HELPHEADER="$HELPHEADER
 "
     ;;
@@ -378,43 +407,44 @@ fi
 archname="$2"
 
 if test "$QUIET" = "y" || test "$TAR_QUIETLY" = "y"; then
-    if test "$TAR_ARGS" = "cvf"; then
-	TAR_ARGS="cf"
-    elif test "$TAR_ARGS" = "cvhf";then
-	TAR_ARGS="chf"
+    if test "$TAR_ARGS" = "rvf"; then
+	    TAR_ARGS="rf"
+    elif test "$TAR_ARGS" = "rvhf"; then
+	    TAR_ARGS="rhf"
     fi
 fi
 
 if test "$APPEND" = y; then
     if test $# -lt 2; then
-	MS_Usage
+    	MS_Usage
     fi
 
     # Gather the info from the original archive
     OLDENV=`sh "$archname" --dumpconf`
     if test $? -ne 0; then
-	echo "Unable to update archive: $archname" >&2
-	exit 1
+	    echo "Unable to update archive: $archname" >&2
+	    exit 1
     else
-	eval "$OLDENV"
+	    eval "$OLDENV"
+	    OLDSKIP=`expr $SKIP + 1`
     fi
 else
     if test "$KEEP" = n -a $# = 3; then
-	echo "ERROR: Making a temporary archive with no embedded command does not make sense!" >&2
-	echo >&2
-	MS_Usage
+	    echo "ERROR: Making a temporary archive with no embedded command does not make sense!" >&2
+    	echo >&2
+    	MS_Usage
     fi
     # We don't want to create an absolute directory unless a target directory is defined
     if test "$CURRENT" = y; then
-	archdirname="."
-    elif test x$TARGETDIR != x; then
-	archdirname="$TARGETDIR"
+	    archdirname="."
+    elif test x"$TARGETDIR" != x; then
+	    archdirname="$TARGETDIR"
     else
-	archdirname=`basename "$1"`
+	    archdirname=`basename "$1"`
     fi
 
     if test $# -lt 3; then
-	MS_Usage
+	    MS_Usage
     fi
 
     LABEL="$3"
@@ -434,13 +464,36 @@ gzip)
     GZIP_CMD="gzip -c$COMPRESS_LEVEL"
     GUNZIP_CMD="gzip -cd"
     ;;
-pigz)
+pigz) 
     GZIP_CMD="pigz -$COMPRESS_LEVEL"
+    if test $THREADS -ne $DEFAULT_THREADS; then # Leave as the default if threads not indicated
+        GZIP_CMD="$GZIP_CMD --processes $THREADS"
+    fi
     GUNZIP_CMD="gzip -cd"
+    ;;
+zstd)
+    GZIP_CMD="zstd -$COMPRESS_LEVEL"
+    if test $THREADS -ne $DEFAULT_THREADS; then # Leave as the default if threads not indicated
+        GZIP_CMD="$GZIP_CMD --threads=$THREADS"
+    fi
+    GUNZIP_CMD="zstd -cd"
     ;;
 pbzip2)
     GZIP_CMD="pbzip2 -c$COMPRESS_LEVEL"
+    if test $THREADS -ne $DEFAULT_THREADS; then # Leave as the default if threads not indicated
+        GZIP_CMD="$GZIP_CMD -p$THREADS"
+    fi
     GUNZIP_CMD="bzip2 -d"
+    ;;
+bzip3)
+    # Map the compression level to a block size in MiB as 2^(level-1).
+    BZ3_COMPRESS_LEVEL=`echo "2^($COMPRESS_LEVEL-1)" | bc`
+    GZIP_CMD="bzip3 -b$BZ3_COMPRESS_LEVEL"
+    if test $THREADS -ne $DEFAULT_THREADS; then # Leave as the default if threads not indicated
+        GZIP_CMD="$GZIP_CMD -j$THREADS"
+    fi
+    JOBS=`echo "10-$COMPRESS_LEVEL" | bc`
+    GUNZIP_CMD="bzip3 -dj$JOBS"
     ;;
 bzip2)
     GZIP_CMD="bzip2 -$COMPRESS_LEVEL"
@@ -448,6 +501,10 @@ bzip2)
     ;;
 xz)
     GZIP_CMD="xz -c$COMPRESS_LEVEL"
+    # Must opt-in by specifying a value since not all versions of xz support threads
+    if test $THREADS -ne $DEFAULT_THREADS; then 
+        GZIP_CMD="$GZIP_CMD --threads=$THREADS"
+    fi
     GUNZIP_CMD="xz -d"
     ;;
 lzo)
@@ -460,23 +517,21 @@ lz4)
     ;;
 base64)
     GZIP_CMD="base64"
-    GUNZIP_CMD="base64 -d -i"
+    GUNZIP_CMD="base64 --decode -i -"
     ;;
 gpg)
     GZIP_CMD="gpg $GPG_EXTRA -ac -z$COMPRESS_LEVEL"
     GUNZIP_CMD="gpg -d"
+    ENCRYPT="gpg"
     ;;
 gpg-asymmetric)
     GZIP_CMD="gpg $GPG_EXTRA -z$COMPRESS_LEVEL -es"
     GUNZIP_CMD="gpg --yes -d"
+    ENCRYPT="gpg"
     ;;
-openssl)
-    GZIP_CMD="openssl aes-256-cbc -a -salt -md sha256"
-    GUNZIP_CMD="openssl aes-256-cbc -d -a -md sha256"
-    ;;
-Unix)
-    GZIP_CMD="compress -cf"
-    GUNZIP_CMD="exec 2>&-; uncompress -c || test \\\$? -eq 2 || gzip -cd"
+compress)
+    GZIP_CMD="compress -fc"
+    GUNZIP_CMD="(type compress >/dev/null 2>&1 && compress -fcd || gzip -cd)"
     ;;
 none)
     GZIP_CMD="cat"
@@ -484,29 +539,48 @@ none)
     ;;
 esac
 
-tmpfile="${TMPDIR:=/tmp}/mkself$$"
+if test x"$ENCRYPT" = x"openssl"; then
+    if test x"$APPEND" = x"y"; then
+        echo "Appending to existing archive is not compatible with OpenSSL encryption." >&2
+    fi
+    
+    ENCRYPT_CMD="openssl enc -aes-256-cbc -salt"
+    DECRYPT_CMD="openssl enc -aes-256-cbc -d"
+    
+    if test x"$OPENSSL_NO_MD" != x"y"; then
+        ENCRYPT_CMD="$ENCRYPT_CMD -md sha256"
+        DECRYPT_CMD="$DECRYPT_CMD -md sha256"
+    fi
+
+    if test -n "$PASSWD_SRC"; then
+        ENCRYPT_CMD="$ENCRYPT_CMD -pass $PASSWD_SRC"
+    elif test -n "$PASSWD"; then 
+        ENCRYPT_CMD="$ENCRYPT_CMD -pass pass:$PASSWD"
+    fi
+fi
+
+tmpfile="${TMPDIR:-/tmp}/mkself$$"
 
 if test -f "$HEADER"; then
 	oldarchname="$archname"
 	archname="$tmpfile"
 	# Generate a fake header to count its lines
 	SKIP=0
-    . "$HEADER"
-    SKIP=`cat "$tmpfile" |wc -l`
+	. "$HEADER"
+	SKIP=`cat "$tmpfile" |wc -l`
 	# Get rid of any spaces
 	SKIP=`expr $SKIP`
 	rm -f "$tmpfile"
-    if test "$QUIET" = "n";then
-	echo Header is $SKIP lines long >&2
-    fi
-
+	if test "$QUIET" = "n"; then
+		echo "Header is $SKIP lines long" >&2
+	fi
 	archname="$oldarchname"
 else
     echo "Unable to open header file: $HEADER" >&2
     exit 1
 fi
 
-if test "$QUIET" = "n";then
+if test "$QUIET" = "n"; then
     echo
 fi
 
@@ -525,36 +599,101 @@ if test "." = "$archdirname"; then
 fi
 
 test -d "$archdir" || { echo "Error: $archdir does not exist."; rm -f "$tmpfile"; exit 1; }
-if test "$QUIET" = "n";then
-   echo About to compress $USIZE KB of data...
-   echo Adding files to archive named \"$archname\"...
+if test "$QUIET" = "n"; then
+   echo "About to compress $USIZE KB of data..."
+   echo "Adding files to archive named \"$archname\"..."
 fi
-exec 3<> "$tmpfile"
-( cd "$archdir" && ( tar $TAR_EXTRA -$TAR_ARGS - . | eval "$GZIP_CMD" >&3 ) ) || \
-    { echo Aborting: archive directory not found or temporary file: "$tmpfile" could not be created.; exec 3>&-; rm -f "$tmpfile"; exit 1; }
-exec 3>&- # try to close the archive
+
+# See if we have GNU tar
+TAR=`exec <&- 2>&-; which gtar || command -v gtar || type gtar`
+test -x "$TAR" || TAR=`exec <&- 2>&-; which bsdtar || command -v bsdtar || type bsdtar`
+test -x "$TAR" || TAR=tar
+
+tmparch="${TMPDIR:-/tmp}/mkself$$.tar"
+(
+    if test "$APPEND" = "y"; then
+        tail -n "+$OLDSKIP" "$archname" | eval "$GUNZIP_CMD" > "$tmparch"
+    fi
+    cd "$archdir"
+    # "Determining if a directory is empty"
+    # https://www.etalabs.net/sh_tricks.html
+    find . \
+        \( \
+        ! -type d \
+        -o \
+        \( -links 2 -exec sh -c '
+            is_empty () (
+                cd "$1"
+                set -- .[!.]* ; test -f "$1" && return 1
+                set -- ..?* ; test -f "$1" && return 1
+                set -- * ; test -f "$1" && return 1
+                return 0
+            )
+            is_empty "$0"' {} \; \
+        \) \
+        \) -print \
+        | LC_ALL=C sort \
+        | sed 's/./\\&/g' \
+        | xargs $TAR $TAR_EXTRA --format $TAR_FORMAT -$TAR_ARGS "$tmparch"
+) || {
+    echo "ERROR: failed to create temporary archive: $tmparch"
+    rm -f "$tmparch" "$tmpfile"
+    exit 1
+}
+
+USIZE=`du $DU_ARGS "$tmparch" | awk '{print $1}'`
+
+eval "$GZIP_CMD" <"$tmparch" >"$tmpfile" || {
+    echo "ERROR: failed to create temporary file: $tmpfile"
+    rm -f "$tmparch" "$tmpfile"
+    exit 1
+}
+rm -f "$tmparch"
+
+if test x"$ENCRYPT" = x"openssl"; then
+    echo "About to encrypt archive \"$archname\"..."
+    { eval "$ENCRYPT_CMD -in $tmpfile -out ${tmpfile}.enc" && mv -f ${tmpfile}.enc $tmpfile; } || \
+        { echo Aborting: could not encrypt temporary file: "$tmpfile".; rm -f "$tmpfile"; exit 1; }
+fi
 
 fsize=`cat "$tmpfile" | wc -c | tr -d " "`
 
 # Compute the checksums
 
+shasum=0000000000000000000000000000000000000000000000000000000000000000
 md5sum=00000000000000000000000000000000
 crcsum=0000000000
 
 if test "$NOCRC" = y; then
-	if test "$QUIET" = "n";then
+	if test "$QUIET" = "n"; then
 		echo "skipping crc at user request"
 	fi
 else
-	crcsum=`cat "$tmpfile" | CMD_ENV=xpg4 cksum | sed -e 's/ /Z/' -e 's/	/Z/' | cut -dZ -f1`
-	if test "$QUIET" = "n";then
+	crcsum=`CMD_ENV=xpg4 cksum < "$tmpfile" | sed -e 's/ /Z/' -e 's/	/Z/' | cut -dZ -f1`
+	if test "$QUIET" = "n"; then
 		echo "CRC: $crcsum"
 	fi
 fi
 
+if test "$SHA256" = y; then
+	SHA_PATH=`exec <&- 2>&-; which shasum || command -v shasum || type shasum`
+	if test -x "$SHA_PATH"; then
+		shasum=`eval "$SHA_PATH -a 256" < "$tmpfile" | cut -b-64`
+	else
+		SHA_PATH=`exec <&- 2>&-; which sha256sum || command -v sha256sum || type sha256sum`
+		shasum=`eval "$SHA_PATH" < "$tmpfile" | cut -b-64`
+	fi
+	if test "$QUIET" = "n"; then
+		if test -x "$SHA_PATH"; then
+			echo "SHA256: $shasum"
+		else
+			echo "SHA256: none, SHA command not found"
+		fi
+	fi
+fi
 if test "$NOMD5" = y; then
-	if test "$QUIET" = "n";then
-		echo "skipping md5sum at user request"
+	if test "$QUIET" = "n"; then
+		echo "Skipping md5sum at user request"
 	fi
 else
 	# Try to locate a MD5 binary
@@ -569,53 +708,71 @@ else
 		if test `basename ${MD5_PATH}`x = digestx; then
 			MD5_ARG="-a md5"
 		fi
-		md5sum=`cat "$tmpfile" | eval "$MD5_PATH $MD5_ARG" | cut -b-32`;
-		if test "$QUIET" = "n";then
+		md5sum=`eval "$MD5_PATH $MD5_ARG" < "$tmpfile" | cut -b-32`
+		if test "$QUIET" = "n"; then
 			echo "MD5: $md5sum"
 		fi
 	else
-		if test "$QUIET" = "n";then
+		if test "$QUIET" = "n"; then
 			echo "MD5: none, MD5 command not found"
 		fi
 	fi
 fi
+if test "$SIGN" = y; then
+    GPG_PATH=`exec <&- 2>&-; which gpg || command -v gpg || type gpg`
+    if test -x "$GPG_PATH"; then
+        SIGNATURE=`$GPG_PATH --pinentry-mode=loopback --batch --yes $GPG_EXTRA --passphrase "$GPG_PASSPHRASE" --output - --detach-sig $tmpfile | base64 | tr -d \\\\n`
+        if test "$QUIET" = "n"; then
+            echo "Signature: $SIGNATURE"
+        fi
+    else
+        echo "Missing gpg command" >&2
+    fi
+fi
+
+totalsize=0
+for size in $fsize;
+do
+    totalsize=`expr $totalsize + $size`
+done
 
 if test "$APPEND" = y; then
     mv "$archname" "$archname".bak || exit
 
     # Prepare entry for new archive
-    filesizes="$filesizes $fsize"
-    CRCsum="$CRCsum $crcsum"
-    MD5sum="$MD5sum $md5sum"
-    USIZE=`expr $USIZE + $OLDUSIZE`
+    filesizes="$fsize"
+    CRCsum="$crcsum"
+    MD5sum="$md5sum"
+    SHAsum="$shasum"
+    Signature="$SIGNATURE"
     # Generate the header
     . "$HEADER"
-    # Append the original data
-    tail -n +$OLDSKIP "$archname".bak >> "$archname"
     # Append the new data
     cat "$tmpfile" >> "$archname"
 
     chmod +x "$archname"
     rm -f "$archname".bak
-    if test "$QUIET" = "n";then
-	echo Self-extractable archive \"$archname\" successfully updated.
+    if test "$QUIET" = "n"; then
+    	echo "Self-extractable archive \"$archname\" successfully updated."
     fi
 else
     filesizes="$fsize"
     CRCsum="$crcsum"
     MD5sum="$md5sum"
+    SHAsum="$shasum"
+    Signature="$SIGNATURE"
 
     # Generate the header
     . "$HEADER"
 
     # Append the compressed tar data after the stub
-    if test "$QUIET" = "n";then
-	echo
+    if test "$QUIET" = "n"; then
+    	echo
     fi
     cat "$tmpfile" >> "$archname"
     chmod +x "$archname"
-    if test "$QUIET" = "n";then
-	echo Self-extractable archive \"$archname\" successfully created.
+    if test "$QUIET" = "n"; then
+    	echo Self-extractable archive \"$archname\" successfully created.
     fi
 fi
 rm -f "$tmpfile"


### PR DESCRIPTION
##### Summary

This syncs our bundled version of makeself with [the latest upstream release](https://github.com/megastep/makeself/releases/tag/release-2.5.0), as we’ve been using a version that is almost six years out of date. The update should significantly improve compatibility on more exotic Linux systems.

It also updates the metadata we embed in the archive itself to better reflect the current state of the project.

##### Test Plan

Testing consists of creating static builds locally from this PR and verifying that they install correctly.

##### Additional Information

Fixes: https://github.com/netdata/netdata/issues/9517 (probably), and likely a number of other issues related to static installs.