### PR TITLE
fix double host prefix when reading ZFS pools state

### DIFF
--- a/collectors/proc.plugin/proc_spl_kstat_zfs.c
+++ b/collectors/proc.plugin/proc_spl_kstat_zfs.c
@@ -366,8 +366,7 @@ int do_proc_spl_kstat_zfs_pool_state(int update_every, usec_t dt)
                 pool->unavail = 0;
 
                 char filename[FILENAME_MAX + 1];
-                snprintfz(
-                    filename, FILENAME_MAX, "%s%s/%s/state", netdata_configured_host_prefix, dirname, de->d_name);
+                snprintfz(filename, FILENAME_MAX, "%s/%s/state", dirname, de->d_name);
 
                 char state[STATE_SIZE + 1];
                 int ret = read_file(filename, state, STATE_SIZE);


### PR DESCRIPTION
##### Summary

The issue was [reported on Discord](https://discord.com/channels/847502280503590932/1090805963444985896/1090805963444985896).

We don't need the host prefix here

https://github.com/netdata/netdata/blob/0ac8f7c4f0278cdeac5172ee715d0c590a947f3a/collectors/proc.plugin/proc_spl_kstat_zfs.c#L370



because `dirname` already has it.

https://github.com/netdata/netdata/blob/0ac8f7c4f0278cdeac5172ee715d0c590a947f3a/collectors/proc.plugin/proc_spl_kstat_zfs.c#L322-L323

##### Test Plan

Install netdata on a server with ZFS, check pools charts.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
