### PR TITLE
fix  #14841 Exception funktion call Rados.mon_command()

### DIFF
--- a/collectors/python.d.plugin/ceph/ceph.chart.py
+++ b/collectors/python.d.plugin/ceph/ceph.chart.py
@@ -331,7 +331,7 @@ class Service(SimpleService):
         return json.loads(self.cluster.mon_command(json.dumps({
             'prefix': 'df',
             'format': 'json'
-        }), '')[1].decode('utf-8'))
+        }), b'')[1].decode('utf-8'))
 
     def _get_osd_df(self):
         """
@@ -341,7 +341,7 @@ class Service(SimpleService):
         return json.loads(self.cluster.mon_command(json.dumps({
             'prefix': 'osd df',
             'format': 'json'
-        }), '')[1].decode('utf-8').replace('-nan', '"-nan"'))
+        }), b'')[1].decode('utf-8').replace('-nan', '"-nan"'))
 
     def _get_osd_perf(self):
         """
@@ -351,7 +351,7 @@ class Service(SimpleService):
         return json.loads(self.cluster.mon_command(json.dumps({
             'prefix': 'osd perf',
             'format': 'json'
-        }), '')[1].decode('utf-8'))
+        }), b'')[1].decode('utf-8'))
 
     def _get_osd_pool_stats(self):
         """
@@ -363,7 +363,7 @@ class Service(SimpleService):
         return json.loads(self.cluster.mon_command(json.dumps({
             'prefix': 'osd pool stats',
             'format': 'json'
-        }), '')[1].decode('utf-8'))
+        }), b'')[1].decode('utf-8'))
 
 
 def get_osd_perf_infos(osd_perf):


### PR DESCRIPTION
##### Summary

Fix Exception TypeError: Argument 'inbuf' has incorrect type (expected bytes, got str) in ceph.chart.py
function call  Rados.mon_command()

```python
Reproduce exception:
    >>> import rados, json
    >>> cluster = rados.Rados(conffile='/etc/ceph/ceph.conf', conf=dict(keyring='/etc/ceph/ceph.client.admin.keyring'))
    >>> cluster.connect()
    >>> json.loads(cluster.mon_command(json.dumps({'prefix': 'df', 'format': 'json'}), '')[1])
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    TypeError: Argument 'inbuf' has incorrect type (expected bytes, got str)
```

##### Additional Information

related librados documenation: https://docs.ceph.com/en/latest/rados/api/python/#rados.Rados.mon_command

example from ceph docs:

```python
    import json
    c = Rados(conffile='/etc/ceph/ceph.conf')
    c.connect()
    cmd = json.dumps({"prefix": "osd safe-to-destroy", "ids": ["2"], "format": "json"})
    c.mon_command(cmd, b'')

```
