### PR TITLE
fix: fix the cmake config error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,7 +350,7 @@ ENDIF()
 
 # -----------------------------------------------------------------------------
 # Detect ml dependencies
-file(STRINGS "${CMAKE_SOURCE_DIR}/config.h" DEFINE_ENABLE_ML REGEX "^#define ENABLE_ML 1$")
+file(STRINGS "${GENERATED_CONFIG_H}" DEFINE_ENABLE_ML REGEX "^#define ENABLE_ML 1$")
 IF(DEFINE_ENABLE_ML MATCHES ".+" AND
    EXISTS "${CMAKE_SOURCE_DIR}/ml/dlib/dlib/all/source.cpp")
     set(ENABLE_ML True)
@@ -953,6 +953,7 @@ set(MQTT_WEBSOCKETS_FILES
         mqtt_websockets/c-rbuf/src/ringbuffer.c
         mqtt_websockets/c-rbuf/include/ringbuffer.h
         mqtt_websockets/c-rbuf/src/ringbuffer_internal.h
+        mqtt_websockets/c_rhash/src/c_rhash.c
         )
 
 set(SPAWN_PLUGIN_FILES
@@ -1267,6 +1268,7 @@ list(APPEND NETDATA_FILES ${ACLK_FILES} ${ACLK_PROTO_BUILT_SRCS} ${ACLK_PROTO_BU
 include_directories(BEFORE ${CMAKE_SOURCE_DIR}/aclk/aclk-schemas)
 include_directories(BEFORE ${CMAKE_SOURCE_DIR}/mqtt_websockets/src/include)
 include_directories(BEFORE ${CMAKE_SOURCE_DIR}/mqtt_websockets/c-rbuf/include)
+include_directories(BEFORE ${CMAKE_SOURCE_DIR}/mqtt_websockets/c_rhash/include)
 
 ADD_LIBRARY(mqttwebsockets STATIC
             ${MQTT_WEBSOCKETS_FILES})
@@ -1277,7 +1279,7 @@ target_compile_options(mqttwebsockets PUBLIC
                         -DMQTT_WSS_CPUSTATS)
 
 target_include_directories(mqttwebsockets PUBLIC
-             ${CMAKE_SOURCE_DIR}/aclk/helpers)
+             ${CMAKE_SOURCE_DIR}/aclk/helpers ${GENERATED_CONFIG_H_DIR})
 
 set(NETDATA_COMMON_LIBRARIES ${NETDATA_COMMON_LIBRARIES} mqttwebsockets)
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR addresses two problems that were preventing the project from building using cmake:

- Corrected the location of the config.h file used by the MQTT library and CMakeLists.txt:353 to ensure that it is included correctly during the build process.
- Added support for building the c_hash library and including its configuration in the build process for both the MQTT library and netdata executor.

These changes should make it easier for developers to set up and build the project using cmake. 

Note that the issue of having to run cmake twice to generate the config.h file is not addressed in this PR.
- Firstly run `cmake` that generator the config,h file in CMAKE_BIND_DIR but the cmake can't found it,
- then re-run the `cmake` again, the configuration done.  

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
