### PR TITLE
cgroups.plugin: add image label

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1898,19 +1898,21 @@ static inline void discovery_rename_cgroup(struct cgroup *cg) {
             break;
     }
 
-    if(cg->pending_renames || cg->processed) return;
-    if(!new_name || !*new_name || *new_name == '\n') return;
-    if(!(new_name = trim(new_name))) return;
+    if (cg->pending_renames || cg->processed)
+        return;
+    if (!new_name || !*new_name || *new_name == '\n')
+        return;
+    if (!(new_name = trim(new_name)))
+        return;
 
     char *name = new_name;
-    if (!strncmp(new_name, "k8s_", 4)) {
-        if(!cg->chart_labels) cg->chart_labels = rrdlabels_create();
 
-        // read the new labels and remove the obsolete ones
-        rrdlabels_unmark_all(cg->chart_labels);
-        name = k8s_parse_resolved_name_and_labels(cg->chart_labels, new_name);
-        rrdlabels_remove_all_unmarked(cg->chart_labels);
-    }
+    if (!cg->chart_labels)
+        cg->chart_labels = rrdlabels_create();
+    // read the new labels and remove the obsolete ones
+    rrdlabels_unmark_all(cg->chart_labels);
+    name = k8s_parse_resolved_name_and_labels(cg->chart_labels, new_name);
+    rrdlabels_remove_all_unmarked(cg->chart_labels);
 
     freez(cg->chart_title);
     cg->chart_title = cgroup_title_strdupz(name);
@@ -2713,13 +2715,18 @@ static inline void discovery_process_cgroup(struct cgroup *cg) {
         return;
     }
 
-    worker_is_busy(WORKER_DISCOVERY_PROCESS_NETWORK);
-    read_cgroup_network_interfaces(cg);
     if (!cg->chart_labels)
         cg->chart_labels = rrdlabels_create();
+
     if (!k8s_is_kubepod(cg)) {
         rrdlabels_add(cg->chart_labels, "cgroup_name", cg->chart_id, RRDLABEL_SRC_AUTO);
+        if (!dictionary_get(cg->chart_labels, "image")) {
+            rrdlabels_add(cg->chart_labels, "image", "", RRDLABEL_SRC_AUTO);
+        }
     }
+
+    worker_is_busy(WORKER_DISCOVERY_PROCESS_NETWORK);
+    read_cgroup_network_interfaces(cg);
 }
 
 static inline void discovery_find_all_cgroups() {

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1769,7 +1769,7 @@ static inline void substitute_dots_in_id(char *s) {
 // ----------------------------------------------------------------------------
 // parse k8s labels
 
-char *k8s_parse_resolved_name_and_labels(DICTIONARY *labels, char *data) {
+char *cgroup_parse_resolved_name_and_labels(DICTIONARY *labels, char *data) {
     // the first word, up to the first space is the name
     char *name = mystrsep(&data, " ");
 
@@ -1911,7 +1911,7 @@ static inline void discovery_rename_cgroup(struct cgroup *cg) {
         cg->chart_labels = rrdlabels_create();
     // read the new labels and remove the obsolete ones
     rrdlabels_unmark_all(cg->chart_labels);
-    name = k8s_parse_resolved_name_and_labels(cg->chart_labels, new_name);
+    name = cgroup_parse_resolved_name_and_labels(cg->chart_labels, new_name);
     rrdlabels_remove_all_unmarked(cg->chart_labels);
 
     freez(cg->chart_title);

--- a/collectors/cgroups.plugin/sys_fs_cgroup.h
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.h
@@ -39,6 +39,6 @@ typedef struct netdata_ebpf_cgroup_shm {
 
 #include "../proc.plugin/plugin_proc.h"
 
-char *k8s_parse_resolved_name_and_labels(DICTIONARY *labels, char *data);
+char *cgroup_parse_resolved_name_and_labels(DICTIONARY *labels, char *data);
 
 #endif //NETDATA_SYS_FS_CGROUP_H

--- a/collectors/cgroups.plugin/tests/test_cgroups_plugin.c
+++ b/collectors/cgroups.plugin/tests/test_cgroups_plugin.c
@@ -33,7 +33,7 @@ static int read_label_callback(const char *name, const char *value, RRDLABEL_SRC
   return 1;
 }
 
-static void test_k8s_parse_resolved_name(void **state)
+static void test_cgroup_parse_resolved_name(void **state)
 {
     UNUSED(state);
 
@@ -96,7 +96,7 @@ static void test_k8s_parse_resolved_name(void **state)
     for (int i = 0; test_data[i].data != NULL; i++) {
         char *data = strdup(test_data[i].data);
 
-        char *name = k8s_parse_resolved_name_and_labels(labels, data);
+        char *name = cgroup_parse_resolved_name_and_labels(labels, data);
 
         assert_string_equal(name, test_data[i].name);
 
@@ -122,10 +122,10 @@ static void test_k8s_parse_resolved_name(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(test_k8s_parse_resolved_name),
+        cmocka_unit_test(test_cgroup_parse_resolved_name),
     };
 
-    int test_res = cmocka_run_group_tests_name("test_k8s_parse_resolved_name", tests, NULL, NULL);
+    int test_res = cmocka_run_group_tests_name("test_cgroup_parse_resolved_name", tests, NULL, NULL);
 
     return test_res;
 }

--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -519,9 +519,6 @@ static inline void netdev_rename_cgroup(struct netdev *d, struct netdev_rename *
     d->chart_family = strdupz("net");
 
     rrdlabels_copy(d->chart_labels, r->chart_labels);
-    if (strncmp(r->ctx_prefix, "k8s", 3)) {
-        rrdlabels_add(d->chart_labels, "cgroup_name", r->container_name, RRDLABEL_SRC_AUTO);
-    }
 
     d->priority = NETDATA_CHART_PRIO_CGROUP_NET_IFACE;
     d->flipped = 1;


### PR DESCRIPTION
##### Summary

Fixes: #14799

This PR adds the `image` label to all cgroups except k8s.

- for docker/podman cgroups: the "image" label value is the actual image name.
- the rest: the "image" label value is "" (no value, Netdata replaces it with `[none]`).

<details>
<summary>Cloud screenshot</summary>

<img width="1265" alt="Screenshot 2023-04-07 at 16 22 02" src="https://user-images.githubusercontent.com/22274335/230616136-6e31b2f9-43ad-44c1-ba14-1739ac26b0eb.png">

</details>


##### Test Plan

Test on:

- a host with docker and not docker container
- a k8s host


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
