### PR TITLE
Remove alpine 3.14 from the ci

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -36,9 +36,6 @@ include:
   - <<: *alpine
     version: "3.15"
     eol_check: true
-  - <<: *alpine
-    version: "3.14"
-    eol_check: true
 
   - distro: archlinux
     version: latest

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -94,7 +94,6 @@ with minimal user effort.
 |---------------|---------|--------------------------|------------------------------------------------------------------------------------------------------|
 | Alpine Linux  | 3.16    | No                       |                                                                                                      |
 | Alpine Linux  | 3.15    | No                       |                                                                                                      |
-| Alpine Linux  | 3.14    | No                       |                                                                                                      |
 | Amazon Linux  | 2023    | x86\_64, AArch64         | Scheduled for promotion to Core tier at some point after the release of v1.39.0 of the Netdata Agent |
 | Amazon Linux  | 2       | x86\_64, AArch64         | Scheduled for promotion to Core tier at some point after the release of v1.39.0 of the Netdata Agent |
 | Arch Linux    | Latest  | No                       | We officially recommend the community packages available for Arch Linux                              |
@@ -157,6 +156,7 @@ This is a list of platforms that we have supported in the recent past but no lon
 
 | Platform     | Version   | Notes                |
 |--------------|-----------|----------------------|
+| Alpine Linux | 3.14      | EOL as of 2023-05-01 |
 | Alpine Linux | 3.13      | EOL as of 2022-11-01 |
 | Alpine Linux | 3.12      | EOL as of 2022-05-01 |
 | Debian       | 9.x       | EOL as of 2022-06-30 |


### PR DESCRIPTION
##### Summary

EOL of Alpine 3.14 during May, 

Closes https://github.com/netdata/netdata/issues/14852
Do not merge this PR until 2023-05-01

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
