### PR TITLE
Consistently start the agent as root and rely on it to drop privileges properly.

### DIFF
--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -628,6 +628,17 @@ static const char *verify_required_directory(const char *dir)
     return dir;
 }
 
+static const char *verify_or_create_required_directory(const char *dir) {
+    int result = 0
+
+    result = mkdir(dir, 0755)
+
+    if (result != 0 && errno != EEXIST)
+        fatal("Cannot create required directory '%s'", dir);
+
+    return verify_required_directory(dir);
+}
+
 /*
  * This is called after the rrdinit
  * These values will be sent on the START event
@@ -823,11 +834,11 @@ void set_global_environment()
     setenv("NETDATA_STOCK_CONFIG_DIR", verify_required_directory(netdata_configured_stock_config_dir), 1);
     setenv("NETDATA_PLUGINS_DIR", verify_required_directory(netdata_configured_primary_plugins_dir), 1);
     setenv("NETDATA_WEB_DIR", verify_required_directory(netdata_configured_web_dir), 1);
-    setenv("NETDATA_CACHE_DIR", verify_required_directory(netdata_configured_cache_dir), 1);
-    setenv("NETDATA_LIB_DIR", verify_required_directory(netdata_configured_varlib_dir), 1);
-    setenv("NETDATA_LOCK_DIR", netdata_configured_lock_dir, 1);
-    setenv("NETDATA_LOG_DIR", verify_required_directory(netdata_configured_log_dir), 1);
-    setenv("HOME", verify_required_directory(netdata_configured_home_dir), 1);
+    setenv("NETDATA_CACHE_DIR", verify_or_create_required_directory(netdata_configured_cache_dir), 1);
+    setenv("NETDATA_LIB_DIR", verify_or_create_required_directory(netdata_configured_varlib_dir), 1);
+    setenv("NETDATA_LOCK_DIR", verify_or_create_required_directory(netdata_configured_lock_dir), 1);
+    setenv("NETDATA_LOG_DIR", verify_or_create_required_directory(netdata_configured_log_dir), 1);
+    setenv("HOME", verify_or_create_required_directory(netdata_configured_home_dir), 1);
     setenv("NETDATA_HOST_PREFIX", netdata_configured_host_prefix, 1);
 
     {

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -629,9 +629,9 @@ static const char *verify_required_directory(const char *dir)
 }
 
 static const char *verify_or_create_required_directory(const char *dir) {
-    int result = 0
+    int result;
 
-    result = mkdir(dir, 0755)
+    result = mkdir(dir, 0755);
 
     if (result != 0 && errno != EEXIST)
         fatal("Cannot create required directory '%s'", dir);

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -96,7 +96,7 @@ int become_user(const char *username, int pid_fd) {
     uid_t uid = pw->pw_uid;
     gid_t gid = pw->pw_gid;
 
-    prepare_required_directories(uid, gid)
+    prepare_required_directories(uid, gid);
 
     if(pidfile[0]) {
         if(chown(pidfile, uid, gid) == -1)
@@ -492,7 +492,7 @@ int become_daemon(int dont_fork, const char *user)
         else debug(D_SYSTEM, "Successfully became user '%s'.", user);
     }
     else {
-        prepare_required_directories(getuid(), getgid())
+        prepare_required_directories(getuid(), getgid());
     }
 
     if(pidfd != -1)

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -78,6 +78,7 @@ void prepare_required_directories(uid_t uid, gid_t gid) {
     create_needed_dir(netdata_configured_cache_dir, uid, gid);
     create_needed_dir(netdata_configured_varlib_dir, uid, gid);
     create_needed_dir(netdata_configured_lock_dir, uid, gid);
+    create_needed_dir(netdata_configured_log_dir, uid, gid);
     create_needed_dir(claimingdirectory, uid, gid);
 
     clean_directory(netdata_configured_lock_dir);

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -43,19 +43,10 @@ static void chown_open_file(int fd, uid_t uid, gid_t gid) {
     }
 }
 
-void create_needed_dir(const char *dir, uid_t uid, gid_t gid)
+void change_dir_ownership(const char *dir, uid_t uid, gid_t gid)
 {
-    // attempt to create the directory
-    if(mkdir(dir, 0755) == 0) {
-        // we created it
-
-        // chown it to match the required user
-        if(chown(dir, uid, gid) == -1)
-            error("Cannot chown directory '%s' to %u:%u", dir, (unsigned int)uid, (unsigned int)gid);
-    }
-    else if(errno != EEXIST)
-        // log an error only if the directory does not exist
-        error("Cannot create directory '%s'", dir);
+    if (chown(dir, uid, gid) == -1)
+        error("Cannot chown directory '%s' to %u:%u", dir, (unsigned int)uid, (unsigned int)gid);
 }
 
 void clean_directory(char *dirname)
@@ -75,11 +66,11 @@ void clean_directory(char *dirname)
 }
 
 void prepare_required_directories(uid_t uid, gid_t gid) {
-    create_needed_dir(netdata_configured_cache_dir, uid, gid);
-    create_needed_dir(netdata_configured_varlib_dir, uid, gid);
-    create_needed_dir(netdata_configured_lock_dir, uid, gid);
-    create_needed_dir(netdata_configured_log_dir, uid, gid);
-    create_needed_dir(claimingdirectory, uid, gid);
+    change_dir_ownership(netdata_configured_cache_dir, uid, gid);
+    change_dir_ownership(netdata_configured_varlib_dir, uid, gid);
+    change_dir_ownership(netdata_configured_lock_dir, uid, gid);
+    change_dir_ownership(netdata_configured_log_dir, uid, gid);
+    change_dir_ownership(claimingdirectory, uid, gid);
 
     clean_directory(netdata_configured_lock_dir);
 }

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -74,6 +74,15 @@ void clean_directory(char *dirname)
     closedir(dir);
 }
 
+void prepare_required_directories(uid_t uid, gid_t gid) {
+    create_needed_dir(netdata_configured_cache_dir, uid, gid);
+    create_needed_dir(netdata_configured_varlib_dir, uid, gid);
+    create_needed_dir(netdata_configured_lock_dir, uid, gid);
+    create_needed_dir(claimingdirectory, uid, gid);
+
+    clean_directory(netdata_configured_lock_dir);
+}
+
 int become_user(const char *username, int pid_fd) {
     int am_i_root = (getuid() == 0)?1:0;
 
@@ -86,12 +95,7 @@ int become_user(const char *username, int pid_fd) {
     uid_t uid = pw->pw_uid;
     gid_t gid = pw->pw_gid;
 
-    create_needed_dir(netdata_configured_cache_dir, uid, gid);
-    create_needed_dir(netdata_configured_varlib_dir, uid, gid);
-    create_needed_dir(netdata_configured_lock_dir, uid, gid);
-    create_needed_dir(claimingdirectory, uid, gid);
-
-    clean_directory(netdata_configured_lock_dir);
+    prepare_required_directories(uid, gid)
 
     if(pidfile[0]) {
         if(chown(pidfile, uid, gid) == -1)
@@ -487,12 +491,7 @@ int become_daemon(int dont_fork, const char *user)
         else debug(D_SYSTEM, "Successfully became user '%s'.", user);
     }
     else {
-        create_needed_dir(netdata_configured_cache_dir, getuid(), getgid());
-        create_needed_dir(netdata_configured_varlib_dir, getuid(), getgid());
-        create_needed_dir(netdata_configured_lock_dir, getuid(), getgid());
-        create_needed_dir(claimingdirectory, getuid(), getgid());
-
-        clean_directory(netdata_configured_lock_dir);
+        prepare_required_directories(getuid(), getgid())
     }
 
     if(pidfd != -1)

--- a/system/openrc/init.d/netdata.in
+++ b/system/openrc/init.d/netdata.in
@@ -15,7 +15,6 @@ command_prefix="@sbindir_POST@"
 command="${command_prefix}/netdata"
 command_args="-P ${NETDATA_PIDFILE} ${NETDATA_EXTRA_ARGS}"
 command_args_foreground="-D"
-start_stop_daemon_args="-u ${NETDATA_OWNER}"
 
 depend() {
     use logger
@@ -24,7 +23,7 @@ depend() {
 }
 
 start_pre() {
-    checkpath -o ${NETDATA_OWNER} -d @localstatedir_POST@/cache/netdata @localstatedir_POST@/run/netdata
+    checkpath -o ${NETDATA_OWNER} -d @localstatedir_POST@/run/netdata
 
     if [ -z "${supervisor}" ]; then
         pidfile="${NETDATA_PIDFILE}"

--- a/system/runit/run.in
+++ b/system/runit/run.in
@@ -3,14 +3,10 @@
 piddir="@localstatedir_POST@/run/netdata/netdata.pid"
 pidfile="${piddir}/netdata.pid"
 
-cachedir="@localstatedir_POST@/cache/netdata"
-
 command="@sbindir_POST@/netdata"
 command_args="-P ${pidfile} -D"
 
 [ ! -d "${piddir}" ] && mkdir -p "${piddir}"
-[ ! -d "${cachedir}" ] && mkdir -p "${cachedir}"
 chown -R @netdata_user_POST@ "${piddir}"
-chown -R @netdata_user_POST@ "${cachedir}"
 
 exec ${command} ${command_args}

--- a/system/systemd/netdata.service.in
+++ b/system/systemd/netdata.service.in
@@ -7,8 +7,7 @@ After=network.target httpd.service squid.service nfs-server.service mysqld.servi
 
 [Service]
 Type=simple
-User=@netdata_user_POST@
-Group=netdata
+User=root
 RuntimeDirectory=netdata
 RuntimeDirectoryMode=0775
 PIDFile=/run/netdata/netdata.pid

--- a/system/systemd/netdata.service.v235.in
+++ b/system/systemd/netdata.service.v235.in
@@ -7,8 +7,7 @@ After=network.target httpd.service squid.service nfs-server.service mysqld.servi
 
 [Service]
 Type=simple
-User=@netdata_user_POST@
-Group=netdata
+User=root
 RuntimeDirectory=netdata
 CacheDirectory=netdata
 StateDirectory=netdata


### PR DESCRIPTION
##### Summary

This ensures that we consistently start the agent as root when running as a system service and properly trust it to drop privileges during startup (which it does in fact do correctly). It also updates the relevant scripts to trust the agent to create required directories itself, as starting as root lets it do so properly.

This also tidies up handling of the preparation of required directories during startup, and adds our log directory to the list of directories we attempt to create if it does not exist.

##### Test Plan

Testing requires installing the agent from this PR on a variety of different systems and confirming that it starts up correctly.

##### Additional Information

Fixes: https://github.com/netdata/netdata/issues/9701, plus a bunch of other issues we keep seeing intermittently regarding handling of require directories on startup.