### PR TITLE
Address issues on `EC2` (eBPF).

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -4790,6 +4790,7 @@ static void cgroup_main_cleanup(void *ptr) {
     }
 
     if (shm_cgroup_ebpf.header) {
+        shm_cgroup_ebpf.header->cgroup_root_count = 0;
         munmap(shm_cgroup_ebpf.header, shm_cgroup_ebpf.header->body_length);
     }
 

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -2349,10 +2349,9 @@ int main(int argc, char **argv)
         if (em->enabled || !i) {
             st->thread = mallocz(sizeof(netdata_thread_t));
             em->thread_id = i;
-            st->enabled = NETDATA_THREAD_EBPF_RUNNING;
             netdata_thread_create(st->thread, st->name, NETDATA_THREAD_OPTION_DEFAULT, st->start_routine, em);
         } else {
-            st->enabled = NETDATA_THREAD_EBPF_STOPPED;
+            em->enabled = NETDATA_THREAD_EBPF_NOT_RUNNING;
         }
     }
 

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -1044,7 +1044,7 @@ void ebpf_global_labels(netdata_syscall_stat_t *is, netdata_publish_syscall_t *p
 
         pio[i].dimension = dim[i];
         pio[i].name = name[i];
-        pio[i].algorithm = strdupz(ebpf_algorithms[algorithm[i]]);
+        pio[i].algorithm = ebpf_algorithms[algorithm[i]];
         if (publish_prev) {
             publish_prev->next = &pio[i];
         }

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -453,6 +453,7 @@ ebpf_plugin_stats_t plugin_statistics = {.core = 0, .legacy = 0, .running = 0, .
 struct btf *default_btf = NULL;
 struct cachestat_bpf *cachestat_bpf_obj = NULL;
 struct dc_bpf *dc_bpf_obj = NULL;
+struct fd_bpf *fd_bpf_obj = NULL;
 #else
 void *default_btf = NULL;
 #endif
@@ -565,8 +566,7 @@ static void ebpf_unload_unique_maps()
 
         ebpf_unload_legacy_code(ebpf_modules[i].objects, ebpf_modules[i].probe_links);
         switch (i) {
-            case EBPF_MODULE_CACHESTAT_IDX:
-            {
+            case EBPF_MODULE_CACHESTAT_IDX: {
 #ifdef LIBBPF_MAJOR_VERSION
                 if (cachestat_bpf_obj)
                     cachestat_bpf__destroy(cachestat_bpf_obj);
@@ -577,6 +577,13 @@ static void ebpf_unload_unique_maps()
 #ifdef LIBBPF_MAJOR_VERSION
                 if (dc_bpf_obj)
                     dc_bpf__destroy(dc_bpf_obj);
+#endif
+                break;
+            }
+            case EBPF_MODULE_FD_IDX: {
+#ifdef LIBBPF_MAJOR_VERSION
+                if (fd_bpf_obj)
+                    fd_bpf__destroy(fd_bpf_obj);
 #endif
                 break;
             }

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -516,7 +516,6 @@ static void ebpf_exit()
     printf("DISABLE\n");
 
     if (shm_ebpf_cgroup.header) {
-        munmap(shm_ebpf_cgroup.header, shm_ebpf_cgroup.header->body_length);
         shm_unlink(NETDATA_SHARED_MEMORY_EBPF_CGROUP_NAME);
     }
 

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -455,6 +455,7 @@ struct cachestat_bpf *cachestat_bpf_obj = NULL;
 struct dc_bpf *dc_bpf_obj = NULL;
 struct fd_bpf *fd_bpf_obj = NULL;
 struct mount_bpf *mount_bpf_obj = NULL;
+struct shm_bpf *shm_bpf_obj = NULL;
 #else
 void *default_btf = NULL;
 #endif
@@ -594,6 +595,12 @@ static void ebpf_unload_unique_maps()
                     mount_bpf__destroy(mount_bpf_obj);
 #endif
                 break;
+            }
+            case EBPF_MODULE_SHM_IDX: {
+#ifdef LIBBPF_MAJOR_VERSION
+                if (shm_bpf_obj)
+                    shm_bpf__destroy(shm_bpf_obj);
+#endif
             }
             case EBPF_MODULE_PROCESS_IDX:
             case EBPF_MODULE_DISK_IDX:

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -536,6 +536,7 @@ static void ebpf_exit()
 
     pthread_mutex_lock(&mutex_cgroup_shm);
     if (shm_ebpf_cgroup.header) {
+        ebpf_unmap_cgroup_shared_memory();
         shm_unlink(NETDATA_SHARED_MEMORY_EBPF_CGROUP_NAME);
     }
     pthread_mutex_unlock(&mutex_cgroup_shm);

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -2349,6 +2349,7 @@ int main(int argc, char **argv)
         if (em->enabled || !i) {
             st->thread = mallocz(sizeof(netdata_thread_t));
             em->thread_id = i;
+            em->enabled = NETDATA_THREAD_EBPF_RUNNING;
             netdata_thread_create(st->thread, st->name, NETDATA_THREAD_OPTION_DEFAULT, st->start_routine, em);
         } else {
             em->enabled = NETDATA_THREAD_EBPF_NOT_RUNNING;

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -457,6 +457,7 @@ struct fd_bpf *fd_bpf_obj = NULL;
 struct mount_bpf *mount_bpf_obj = NULL;
 struct shm_bpf *shm_bpf_obj = NULL;
 struct socket_bpf *socket_bpf_obj = NULL;
+struct swap_bpf *bpf_obj = NULL;
 #else
 void *default_btf = NULL;
 #endif
@@ -608,6 +609,13 @@ static void ebpf_unload_unique_maps()
 #ifdef LIBBPF_MAJOR_VERSION
                 if (socket_bpf_obj)
                     socket_bpf__destroy(socket_bpf_obj);
+#endif
+                break;
+            }
+            case EBPF_MODULE_SWAP_IDX: {
+#ifdef LIBBPF_MAJOR_VERSION
+                if (bpf_obj)
+                    swap_bpf__destroy(bpf_obj);
 #endif
                 break;
             }

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -515,10 +515,12 @@ static void ebpf_exit()
 #endif
     printf("DISABLE\n");
 
+    pthread_mutex_lock(&mutex_cgroup_shm);
     if (shm_ebpf_cgroup.header) {
         munmap(shm_ebpf_cgroup.header, shm_ebpf_cgroup.header->body_length);
         shm_unlink(NETDATA_SHARED_MEMORY_EBPF_CGROUP_NAME);
     }
+    pthread_mutex_unlock(&mutex_cgroup_shm);
 
     exit(0);
 }

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -32,7 +32,6 @@ int main_thread_id = 0;
 pthread_mutex_t lock;
 pthread_mutex_t ebpf_exit_cleanup;
 pthread_mutex_t collect_data_mutex;
-pthread_cond_t collect_data_cond_var;
 
 ebpf_module_t ebpf_modules[] = {
     { .thread_name = "process", .config_name = "process", .enabled = 0, .start_routine = ebpf_process_thread,
@@ -1395,21 +1394,12 @@ static void read_local_addresses()
  * Start Pthread Variable
  *
  * This function starts all pthread variables.
- *
- * @return It returns 0 on success and -1.
  */
-int ebpf_start_pthread_variables()
+void ebpf_start_pthread_variables()
 {
     pthread_mutex_init(&lock, NULL);
     pthread_mutex_init(&ebpf_exit_cleanup, NULL);
     pthread_mutex_init(&collect_data_mutex, NULL);
-
-    if (pthread_cond_init(&collect_data_cond_var, NULL)) {
-        error("Cannot start conditional variable to control Apps charts.");
-        return -1;
-    }
-
-    return 0;
 }
 
 /**
@@ -2273,10 +2263,7 @@ int main(int argc, char **argv)
     signal(SIGTERM, ebpf_stop_threads);
     signal(SIGPIPE, ebpf_stop_threads);
 
-    if (ebpf_start_pthread_variables()) {
-        error("Cannot start mutex to control overall charts.");
-        ebpf_exit();
-    }
+    ebpf_start_pthread_variables();
 
     netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
     if(verify_netdata_host_prefix() == -1) ebpf_exit(6);

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -2531,7 +2531,9 @@ int main(int argc, char **argv)
                 cleanup_exited_pids();
                 collect_data_for_all_processes(process_pid_fd);
             }
+            pthread_mutex_lock(&lock);
             ebpf_create_apps_charts(apps_groups_root_target);
+            pthread_mutex_unlock(&lock);
             pthread_mutex_unlock(&collect_data_mutex);
         }
         pthread_mutex_unlock(&ebpf_exit_cleanup);

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -639,6 +639,22 @@ static void ebpf_unload_unique_maps()
     }
 }
 
+/**
+ * Unload filesystem maps
+ *
+ * This function unload all BPF maps from filesystem thread.
+ */
+static void ebpf_unload_filesystems()
+{
+    if (ebpf_modules[EBPF_MODULE_FILESYSTEM_IDX].enabled == NETDATA_THREAD_EBPF_NOT_RUNNING)
+        return;
+
+    int i;
+    for (i = 0; localfs[i].filesystem != NULL; i++) {
+        ebpf_unload_legacy_code(localfs[i].objects, localfs[i].probe_links);
+    }
+}
+
 int ebpf_exit_plugin = 0;
 /**
  * Close the collector gracefully
@@ -681,6 +697,7 @@ static void ebpf_stop_threads(int sig)
 
     pthread_mutex_lock(&ebpf_exit_cleanup);
     ebpf_unload_unique_maps();
+    ebpf_unload_filesystems();
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
     ebpf_exit();

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -452,6 +452,7 @@ ebpf_plugin_stats_t plugin_statistics = {.core = 0, .legacy = 0, .running = 0, .
 #ifdef LIBBPF_MAJOR_VERSION
 struct btf *default_btf = NULL;
 struct cachestat_bpf *cachestat_bpf_obj = NULL;
+struct dc_bpf *dc_bpf_obj = NULL;
 #else
 void *default_btf = NULL;
 #endif
@@ -569,6 +570,13 @@ static void ebpf_unload_unique_maps()
 #ifdef LIBBPF_MAJOR_VERSION
                 if (cachestat_bpf_obj)
                     cachestat_bpf__destroy(cachestat_bpf_obj);
+#endif
+                break;
+            }
+            case EBPF_MODULE_DCSTAT_IDX: {
+#ifdef LIBBPF_MAJOR_VERSION
+                if (dc_bpf_obj)
+                    dc_bpf__destroy(dc_bpf_obj);
 #endif
                 break;
             }

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -565,7 +565,9 @@ static void ebpf_unload_unique_maps()
     int i;
     for (i = 0; ebpf_modules[i].thread_name; i++) {
         if (ebpf_modules[i].enabled != NETDATA_THREAD_EBPF_STOPPED) {
-            error("Cannot unload maps for thread %s, because it is not stopped.", ebpf_modules[i].thread_name);
+            if (ebpf_modules[i].enabled != NETDATA_THREAD_EBPF_NOT_RUNNING)
+                error("Cannot unload maps for thread %s, because it is not stopped.", ebpf_modules[i].thread_name);
+
             continue;
         }
 

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -456,6 +456,7 @@ struct dc_bpf *dc_bpf_obj = NULL;
 struct fd_bpf *fd_bpf_obj = NULL;
 struct mount_bpf *mount_bpf_obj = NULL;
 struct shm_bpf *shm_bpf_obj = NULL;
+struct socket_bpf *socket_bpf_obj = NULL;
 #else
 void *default_btf = NULL;
 #endif
@@ -601,6 +602,14 @@ static void ebpf_unload_unique_maps()
                 if (shm_bpf_obj)
                     shm_bpf__destroy(shm_bpf_obj);
 #endif
+                break;
+            }
+            case EBPF_MODULE_SOCKET_IDX: {
+#ifdef LIBBPF_MAJOR_VERSION
+                if (socket_bpf_obj)
+                    socket_bpf__destroy(socket_bpf_obj);
+#endif
+                break;
             }
             case EBPF_MODULE_PROCESS_IDX:
             case EBPF_MODULE_DISK_IDX:

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -516,6 +516,7 @@ static void ebpf_exit()
     printf("DISABLE\n");
 
     if (shm_ebpf_cgroup.header) {
+        munmap(shm_ebpf_cgroup.header, shm_ebpf_cgroup.header->body_length);
         shm_unlink(NETDATA_SHARED_MEMORY_EBPF_CGROUP_NAME);
     }
 

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -564,14 +564,11 @@ static void ebpf_stop_threads(int sig)
         return;
     }
     only_one = 1;
-    for (i = 0; ebpf_threads[i].name != NULL; i++) {
-        if (ebpf_threads[i].enabled != NETDATA_THREAD_EBPF_STOPPED)
-            netdata_thread_cancel(*ebpf_threads[i].thread);
-    }
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
     ebpf_exit_plugin = 1;
     usec_t max = USEC_PER_SEC, step = 100000;
+    i = EBPF_OPTION_ALL_CHARTS;
     while (i && max) {
         max -= step;
         sleep_usec(step);

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -458,6 +458,7 @@ struct mount_bpf *mount_bpf_obj = NULL;
 struct shm_bpf *shm_bpf_obj = NULL;
 struct socket_bpf *socket_bpf_obj = NULL;
 struct swap_bpf *bpf_obj = NULL;
+struct vfs_bpf *vfs_bpf_obj = NULL;
 #else
 void *default_btf = NULL;
 #endif
@@ -616,6 +617,13 @@ static void ebpf_unload_unique_maps()
 #ifdef LIBBPF_MAJOR_VERSION
                 if (bpf_obj)
                     swap_bpf__destroy(bpf_obj);
+#endif
+                break;
+            }
+            case EBPF_MODULE_VFS_IDX: {
+#ifdef LIBBPF_MAJOR_VERSION
+                if (vfs_bpf_obj)
+                    vfs_bpf__destroy(vfs_bpf_obj);
 #endif
                 break;
             }

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -454,6 +454,7 @@ struct btf *default_btf = NULL;
 struct cachestat_bpf *cachestat_bpf_obj = NULL;
 struct dc_bpf *dc_bpf_obj = NULL;
 struct fd_bpf *fd_bpf_obj = NULL;
+struct mount_bpf *mount_bpf_obj = NULL;
 #else
 void *default_btf = NULL;
 #endif
@@ -584,6 +585,13 @@ static void ebpf_unload_unique_maps()
 #ifdef LIBBPF_MAJOR_VERSION
                 if (fd_bpf_obj)
                     fd_bpf__destroy(fd_bpf_obj);
+#endif
+                break;
+            }
+            case EBPF_MODULE_MOUNT_IDX: {
+#ifdef LIBBPF_MAJOR_VERSION
+                if (mount_bpf_obj)
+                    mount_bpf__destroy(mount_bpf_obj);
 #endif
                 break;
             }

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -536,7 +536,6 @@ static void ebpf_exit()
 
     pthread_mutex_lock(&mutex_cgroup_shm);
     if (shm_ebpf_cgroup.header) {
-        munmap(shm_ebpf_cgroup.header, shm_ebpf_cgroup.header->body_length);
         shm_unlink(NETDATA_SHARED_MEMORY_EBPF_CGROUP_NAME);
     }
     pthread_mutex_unlock(&mutex_cgroup_shm);

--- a/collectors/ebpf.plugin/ebpf.d.conf
+++ b/collectors/ebpf.plugin/ebpf.d.conf
@@ -55,7 +55,7 @@
     disk = no
     fd = yes
     filesystem = no
-    hardirq = yes
+    hardirq = no
     mdflush = no
     mount = yes
     oomkill = yes

--- a/collectors/ebpf.plugin/ebpf.d.conf
+++ b/collectors/ebpf.plugin/ebpf.d.conf
@@ -55,14 +55,14 @@
     disk = no
     fd = yes
     filesystem = no
-    hardirq = no
+    hardirq = yes
     mdflush = no
     mount = yes
     oomkill = yes
     process = yes
     shm = yes
     socket = no
-    softirq = no
+    softirq = yes
     sync = yes
     swap = yes
     vfs = no

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -174,7 +174,6 @@ extern int isrh;
 extern char *ebpf_plugin_dir;
 
 extern pthread_mutex_t collect_data_mutex;
-extern pthread_cond_t collect_data_cond_var;
 
 // Common functions
 void ebpf_global_labels(netdata_syscall_stat_t *is,

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -183,6 +183,7 @@ extern int ebpf_nprocs;
 extern int running_on_kernel;
 extern int isrh;
 extern char *ebpf_plugin_dir;
+extern int process_pid_fd;
 
 extern pthread_mutex_t collect_data_mutex;
 

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -51,6 +51,7 @@ extern struct dc_bpf *dc_bpf_obj;
 extern struct fd_bpf *fd_bpf_obj;
 extern struct mount_bpf *mount_bpf_obj;
 extern struct shm_bpf *shm_bpf_obj;
+extern struct socket_bpf *socket_bpf_obj;
 #endif
 
 typedef struct netdata_syscall_stat {

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -50,6 +50,7 @@ extern struct cachestat_bpf *cachestat_bpf_obj;
 extern struct dc_bpf *dc_bpf_obj;
 extern struct fd_bpf *fd_bpf_obj;
 extern struct mount_bpf *mount_bpf_obj;
+extern struct shm_bpf *shm_bpf_obj;
 #endif
 
 typedef struct netdata_syscall_stat {

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -49,6 +49,7 @@
 extern struct cachestat_bpf *cachestat_bpf_obj;
 extern struct dc_bpf *dc_bpf_obj;
 extern struct fd_bpf *fd_bpf_obj;
+extern struct mount_bpf *mount_bpf_obj;
 #endif
 
 typedef struct netdata_syscall_stat {

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -243,8 +243,6 @@ void ebpf_create_charts_on_apps(char *name,
 
 void write_end_chart();
 
-void ebpf_cleanup_publish_syscall(netdata_publish_syscall_t *nps);
-
 int ebpf_enable_tracepoint(ebpf_tracepoint_t *tp);
 int ebpf_disable_tracepoint(ebpf_tracepoint_t *tp);
 uint32_t ebpf_enable_tracepoints(ebpf_tracepoint_t *tps);

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -47,6 +47,7 @@
 #include "includes/vfs.skel.h"
 
 extern struct cachestat_bpf *cachestat_bpf_obj;
+extern struct dc_bpf *dc_bpf_obj;
 #endif
 
 typedef struct netdata_syscall_stat {

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -111,7 +111,8 @@ typedef struct ebpf_tracepoint {
 enum ebpf_threads_status {
     NETDATA_THREAD_EBPF_RUNNING,
     NETDATA_THREAD_EBPF_STOPPING,
-    NETDATA_THREAD_EBPF_STOPPED
+    NETDATA_THREAD_EBPF_STOPPED,
+    NETDATA_THREAD_EBPF_NOT_RUNNING
 };
 
 // Copied from musl header

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -36,6 +36,17 @@
 #define NETDATA_EBPF_OLD_CONFIG_FILE "ebpf.conf"
 #define NETDATA_EBPF_CONFIG_FILE "ebpf.d.conf"
 
+#ifdef LIBBPF_MAJOR_VERSION // BTF code
+#include "includes/cachestat.skel.h"
+#include "includes/dc.skel.h"
+#include "includes/fd.skel.h"
+#include "includes/mount.skel.h"
+#include "includes/shm.skel.h"
+#include "includes/socket.skel.h"
+#include "includes/swap.skel.h"
+#include "includes/vfs.skel.h"
+#endif
+
 typedef struct netdata_syscall_stat {
     unsigned long bytes;               // total number of bytes
     uint64_t call;                     // total number of calls

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -45,6 +45,8 @@
 #include "includes/socket.skel.h"
 #include "includes/swap.skel.h"
 #include "includes/vfs.skel.h"
+
+extern struct cachestat_bpf *cachestat_bpf_obj;
 #endif
 
 typedef struct netdata_syscall_stat {

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -108,13 +108,6 @@ typedef struct ebpf_tracepoint {
     char *event;
 } ebpf_tracepoint_t;
 
-enum ebpf_threads_status {
-    NETDATA_THREAD_EBPF_RUNNING,
-    NETDATA_THREAD_EBPF_STOPPING,
-    NETDATA_THREAD_EBPF_STOPPED,
-    NETDATA_THREAD_EBPF_NOT_RUNNING
-};
-
 // Copied from musl header
 #ifndef offsetof
 #if __GNUC__ > 3

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -53,6 +53,7 @@ extern struct mount_bpf *mount_bpf_obj;
 extern struct shm_bpf *shm_bpf_obj;
 extern struct socket_bpf *socket_bpf_obj;
 extern struct swap_bpf *bpf_obj;
+extern struct vfs_bpf *vfs_bpf_obj;
 #endif
 
 typedef struct netdata_syscall_stat {

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -48,6 +48,7 @@
 
 extern struct cachestat_bpf *cachestat_bpf_obj;
 extern struct dc_bpf *dc_bpf_obj;
+extern struct fd_bpf *fd_bpf_obj;
 #endif
 
 typedef struct netdata_syscall_stat {

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -52,6 +52,7 @@ extern struct fd_bpf *fd_bpf_obj;
 extern struct mount_bpf *mount_bpf_obj;
 extern struct shm_bpf *shm_bpf_obj;
 extern struct socket_bpf *socket_bpf_obj;
+extern struct swap_bpf *bpf_obj;
 #endif
 
 typedef struct netdata_syscall_stat {

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -12,6 +12,7 @@ ARAL *ebpf_aral_socket_pid = NULL;
 ARAL *ebpf_aral_cachestat_pid = NULL;
 ARAL *ebpf_aral_dcstat_pid = NULL;
 ARAL *ebpf_aral_vfs_pid = NULL;
+ARAL *ebpf_aral_fd_pid = NULL;
 
 // ----------------------------------------------------------------------------
 // Global vectors used with apps
@@ -20,6 +21,7 @@ netdata_publish_cachestat_t **cachestat_pid = NULL;
 netdata_publish_dcstat_t **dcstat_pid = NULL;
 netdata_publish_swap_t **swap_pid = NULL;
 netdata_publish_vfs_t **vfs_pid = NULL;
+netdata_fd_stat_t **fd_pid = NULL;
 
 /**
  * eBPF ARAL Init
@@ -255,6 +257,46 @@ netdata_publish_vfs_t *ebpf_vfs_get(void)
 void ebpf_vfs_release(netdata_publish_vfs_t *stat)
 {
     aral_freez(ebpf_aral_vfs_pid, stat);
+}
+
+/*****************************************************************
+ *
+ *  FD ARAL FUNCTIONS
+ *
+ *****************************************************************/
+
+/**
+ * eBPF file descriptor Aral init
+ *
+ * Initiallize array allocator that will be used when integration with apps is enabled.
+ */
+void ebpf_fd_aral_init()
+{
+    ebpf_aral_fd_pid = ebpf_allocate_pid_aral(NETDATA_EBPF_FD_ARAL_NAME, sizeof(netdata_fd_stat_t));
+}
+
+/**
+ * eBPF publish file descriptor get
+ *
+ * Get a netdata_fd_stat_t entry to be used with a specific PID.
+ *
+ * @return it returns the address on success.
+ */
+netdata_fd_stat_t *ebpf_fd_stat_get(void)
+{
+    netdata_fd_stat_t *target = aral_mallocz(ebpf_aral_fd_pid);
+    memset(target, 0, sizeof(netdata_fd_stat_t));
+    return target;
+}
+
+/**
+ * eBPF file descriptor release
+ *
+ * @param stat Release a target after usage.
+ */
+void ebpf_fd_release(netdata_fd_stat_t *stat)
+{
+    aral_freez(ebpf_aral_fd_pid, stat);
 }
 
 // ----------------------------------------------------------------------------

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -11,6 +11,7 @@ ARAL *ebpf_aral_process_stat = NULL;
 ARAL *ebpf_aral_socket_pid = NULL;
 ARAL *ebpf_aral_cachestat_pid = NULL;
 ARAL *ebpf_aral_dcstat_pid = NULL;
+ARAL *ebpf_aral_vfs_pid = NULL;
 
 // ----------------------------------------------------------------------------
 // Global vectors used with apps
@@ -18,6 +19,7 @@ ebpf_socket_publish_apps_t **socket_bandwidth_curr = NULL;
 netdata_publish_cachestat_t **cachestat_pid = NULL;
 netdata_publish_dcstat_t **dcstat_pid = NULL;
 netdata_publish_swap_t **swap_pid = NULL;
+netdata_publish_vfs_t **vfs_pid = NULL;
 
 /**
  * eBPF ARAL Init
@@ -213,6 +215,46 @@ netdata_publish_dcstat_t *ebpf_publish_dcstat_get(void)
 void ebpf_dcstat_release(netdata_publish_dcstat_t *stat)
 {
     aral_freez(ebpf_aral_dcstat_pid, stat);
+}
+
+/*****************************************************************
+ *
+ *  VFS ARAL FUNCTIONS
+ *
+ *****************************************************************/
+
+/**
+ * eBPF VFS Aral init
+ *
+ * Initiallize array allocator that will be used when integration with apps is enabled.
+ */
+void ebpf_vfs_aral_init()
+{
+    ebpf_aral_vfs_pid = ebpf_allocate_pid_aral(NETDATA_EBPF_VFS_ARAL_NAME, sizeof(netdata_publish_vfs_t));
+}
+
+/**
+ * eBPF publish VFS get
+ *
+ * Get a netdata_publish_vfs_t entry to be used with a specific PID.
+ *
+ * @return it returns the address on success.
+ */
+netdata_publish_vfs_t *ebpf_vfs_get(void)
+{
+    netdata_publish_vfs_t *target = aral_mallocz(ebpf_aral_vfs_pid);
+    memset(target, 0, sizeof(netdata_publish_vfs_t));
+    return target;
+}
+
+/**
+ * eBPF VFS release
+ *
+ * @param stat Release a target after usage.
+ */
+void ebpf_vfs_release(netdata_publish_vfs_t *stat)
+{
+    aral_freez(ebpf_aral_vfs_pid, stat);
 }
 
 // ----------------------------------------------------------------------------

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -8,6 +8,7 @@
 // ARAL vectors used to speed up processing
 ARAL *ebpf_aral_apps_pid_stat = NULL;
 ARAL *ebpf_aral_process_stat = NULL;
+ARAL *ebpf_aral_socket_pid = NULL;
 
 /**
  * eBPF ARAL Init
@@ -55,6 +56,12 @@ void ebpf_pid_stat_release(struct ebpf_pid_stat *stat)
     aral_freez(ebpf_aral_apps_pid_stat, stat);
 }
 
+/*****************************************************************
+ *
+ *  PROCESS ARAL FUNCTIONS
+ *
+ *****************************************************************/
+
 /**
  * eBPF process stat get
  *
@@ -77,6 +84,46 @@ ebpf_process_stat_t *ebpf_process_stat_get(void)
 void ebpf_process_stat_release(ebpf_process_stat_t *stat)
 {
     aral_freez(ebpf_aral_process_stat, stat);
+}
+
+/*****************************************************************
+ *
+ *  SOCKET ARAL FUNCTIONS
+ *
+ *****************************************************************/
+
+/**
+ * eBPF socket Aral init
+ *
+ * Initiallize array allocator that will be used when integration with apps is enabled.
+ */
+void ebpf_socket_aral_init()
+{
+    ebpf_aral_socket_pid = ebpf_allocate_pid_aral(NETDATA_EBPF_SOCKET_ARAL_NAME, sizeof(ebpf_socket_publish_apps_t));
+}
+
+/**
+ * eBPF socket get
+ *
+ * Get a ebpf_socket_publish_apps_t entry to be used with a specific PID.
+ *
+ * @return it returns the address on success.
+ */
+ebpf_socket_publish_apps_t *ebpf_socket_stat_get(void)
+{
+    ebpf_socket_publish_apps_t *target = aral_mallocz(ebpf_aral_socket_pid);
+    memset(target, 0, sizeof(ebpf_socket_publish_apps_t));
+    return target;
+}
+
+/**
+ * eBPF socket release
+ *
+ * @param stat Release a target after usage.
+ */
+void ebpf_socket_release(ebpf_socket_publish_apps_t *stat)
+{
+    aral_freez(ebpf_aral_socket_pid, stat);
 }
 
 // ----------------------------------------------------------------------------

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -24,6 +24,7 @@ netdata_publish_swap_t **swap_pid = NULL;
 netdata_publish_vfs_t **vfs_pid = NULL;
 netdata_fd_stat_t **fd_pid = NULL;
 netdata_publish_shm_t **shm_pid = NULL;
+ebpf_process_stat_t **global_process_stats = NULL;
 
 /**
  * eBPF ARAL Init

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -14,6 +14,8 @@ ARAL *ebpf_aral_cachestat_pid = NULL;
 // ----------------------------------------------------------------------------
 // Global vectors used with apps
 ebpf_socket_publish_apps_t **socket_bandwidth_curr = NULL;
+netdata_publish_cachestat_t **cachestat_pid = NULL;
+
 
 /**
  * eBPF ARAL Init

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -13,6 +13,7 @@ ARAL *ebpf_aral_cachestat_pid = NULL;
 ARAL *ebpf_aral_dcstat_pid = NULL;
 ARAL *ebpf_aral_vfs_pid = NULL;
 ARAL *ebpf_aral_fd_pid = NULL;
+ARAL *ebpf_aral_shm_pid = NULL;
 
 // ----------------------------------------------------------------------------
 // Global vectors used with apps
@@ -22,6 +23,7 @@ netdata_publish_dcstat_t **dcstat_pid = NULL;
 netdata_publish_swap_t **swap_pid = NULL;
 netdata_publish_vfs_t **vfs_pid = NULL;
 netdata_fd_stat_t **fd_pid = NULL;
+netdata_publish_shm_t **shm_pid = NULL;
 
 /**
  * eBPF ARAL Init
@@ -297,6 +299,46 @@ netdata_fd_stat_t *ebpf_fd_stat_get(void)
 void ebpf_fd_release(netdata_fd_stat_t *stat)
 {
     aral_freez(ebpf_aral_fd_pid, stat);
+}
+
+/*****************************************************************
+ *
+ *  SHM ARAL FUNCTIONS
+ *
+ *****************************************************************/
+
+/**
+ * eBPF shared memory Aral init
+ *
+ * Initiallize array allocator that will be used when integration with apps is enabled.
+ */
+void ebpf_shm_aral_init()
+{
+    ebpf_aral_shm_pid = ebpf_allocate_pid_aral(NETDATA_EBPF_SHM_ARAL_NAME, sizeof(netdata_publish_shm_t));
+}
+
+/**
+ * eBPF shared memory get
+ *
+ * Get a netdata_publish_shm_t entry to be used with a specific PID.
+ *
+ * @return it returns the address on success.
+ */
+netdata_publish_shm_t *ebpf_shm_stat_get(void)
+{
+    netdata_publish_shm_t *target = aral_mallocz(ebpf_aral_shm_pid);
+    memset(target, 0, sizeof(netdata_publish_shm_t));
+    return target;
+}
+
+/**
+ * eBPF shared memory release
+ *
+ * @param stat Release a target after usage.
+ */
+void ebpf_shm_release(netdata_publish_shm_t *stat)
+{
+    aral_freez(ebpf_aral_shm_pid, stat);
 }
 
 // ----------------------------------------------------------------------------

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -9,6 +9,7 @@
 ARAL *ebpf_aral_apps_pid_stat = NULL;
 ARAL *ebpf_aral_process_stat = NULL;
 ARAL *ebpf_aral_socket_pid = NULL;
+ARAL *ebpf_aral_cachestat_pid = NULL;
 
 /**
  * eBPF ARAL Init
@@ -124,6 +125,46 @@ ebpf_socket_publish_apps_t *ebpf_socket_stat_get(void)
 void ebpf_socket_release(ebpf_socket_publish_apps_t *stat)
 {
     aral_freez(ebpf_aral_socket_pid, stat);
+}
+
+/*****************************************************************
+ *
+ *  CACHESTAT ARAL FUNCTIONS
+ *
+ *****************************************************************/
+
+/**
+ * eBPF Cachestat Aral init
+ *
+ * Initiallize array allocator that will be used when integration with apps is enabled.
+ */
+void ebpf_cachestat_aral_init()
+{
+    ebpf_aral_cachestat_pid = ebpf_allocate_pid_aral(NETDATA_EBPF_CACHESTAT_ARAL_NAME, sizeof(netdata_publish_cachestat_t));
+}
+
+/**
+ * eBPF publish cachestat get
+ *
+ * Get a netdata_publish_cachestat_t entry to be used with a specific PID.
+ *
+ * @return it returns the address on success.
+ */
+netdata_publish_cachestat_t *ebpf_publish_cachestat_get(void)
+{
+    netdata_publish_cachestat_t *target = aral_mallocz(ebpf_aral_cachestat_pid);
+    memset(target, 0, sizeof(netdata_publish_cachestat_t));
+    return target;
+}
+
+/**
+ * eBPF cachestat release
+ *
+ * @param stat Release a target after usage.
+ */
+void ebpf_cachestat_release(netdata_publish_cachestat_t *stat)
+{
+    aral_freez(ebpf_aral_cachestat_pid, stat);
 }
 
 // ----------------------------------------------------------------------------

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -11,6 +11,10 @@ ARAL *ebpf_aral_process_stat = NULL;
 ARAL *ebpf_aral_socket_pid = NULL;
 ARAL *ebpf_aral_cachestat_pid = NULL;
 
+// ----------------------------------------------------------------------------
+// Global vectors used with apps
+ebpf_socket_publish_apps_t **socket_bandwidth_curr = NULL;
+
 /**
  * eBPF ARAL Init
  *

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -17,6 +17,7 @@ ARAL *ebpf_aral_dcstat_pid = NULL;
 ebpf_socket_publish_apps_t **socket_bandwidth_curr = NULL;
 netdata_publish_cachestat_t **cachestat_pid = NULL;
 netdata_publish_dcstat_t **dcstat_pid = NULL;
+netdata_publish_swap_t **swap_pid = NULL;
 
 /**
  * eBPF ARAL Init

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -10,12 +10,13 @@ ARAL *ebpf_aral_apps_pid_stat = NULL;
 ARAL *ebpf_aral_process_stat = NULL;
 ARAL *ebpf_aral_socket_pid = NULL;
 ARAL *ebpf_aral_cachestat_pid = NULL;
+ARAL *ebpf_aral_dcstat_pid = NULL;
 
 // ----------------------------------------------------------------------------
 // Global vectors used with apps
 ebpf_socket_publish_apps_t **socket_bandwidth_curr = NULL;
 netdata_publish_cachestat_t **cachestat_pid = NULL;
-
+netdata_publish_dcstat_t **dcstat_pid = NULL;
 
 /**
  * eBPF ARAL Init
@@ -171,6 +172,46 @@ netdata_publish_cachestat_t *ebpf_publish_cachestat_get(void)
 void ebpf_cachestat_release(netdata_publish_cachestat_t *stat)
 {
     aral_freez(ebpf_aral_cachestat_pid, stat);
+}
+
+/*****************************************************************
+ *
+ *  DCSTAT ARAL FUNCTIONS
+ *
+ *****************************************************************/
+
+/**
+ * eBPF directory cache Aral init
+ *
+ * Initiallize array allocator that will be used when integration with apps is enabled.
+ */
+void ebpf_dcstat_aral_init()
+{
+    ebpf_aral_dcstat_pid = ebpf_allocate_pid_aral(NETDATA_EBPF_DCSTAT_ARAL_NAME, sizeof(netdata_publish_dcstat_t));
+}
+
+/**
+ * eBPF publish dcstat get
+ *
+ * Get a netdata_publish_dcstat_t entry to be used with a specific PID.
+ *
+ * @return it returns the address on success.
+ */
+netdata_publish_dcstat_t *ebpf_publish_dcstat_get(void)
+{
+    netdata_publish_dcstat_t *target = aral_mallocz(ebpf_aral_dcstat_pid);
+    memset(target, 0, sizeof(netdata_publish_dcstat_t));
+    return target;
+}
+
+/**
+ * eBPF dcstat release
+ *
+ * @param stat Release a target after usage.
+ */
+void ebpf_dcstat_release(netdata_publish_dcstat_t *stat)
+{
+    aral_freez(ebpf_aral_dcstat_pid, stat);
 }
 
 // ----------------------------------------------------------------------------

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -221,6 +221,7 @@ extern netdata_publish_dcstat_t **dcstat_pid;
 extern netdata_publish_swap_t **swap_pid;
 extern netdata_publish_vfs_t **vfs_pid;
 extern netdata_fd_stat_t **fd_pid;
+extern netdata_publish_shm_t **shm_pid;
 
 // The default value is at least 32 times smaller than maximum number of PIDs allowed on system,
 // this is only possible because we are using ARAL (https://github.com/netdata/netdata/tree/master/libnetdata/aral).
@@ -259,6 +260,11 @@ extern ARAL *ebpf_aral_fd_pid;
 void ebpf_fd_aral_init();
 netdata_fd_stat_t *ebpf_fd_stat_get(void);
 void ebpf_fd_release(netdata_fd_stat_t *stat);
+
+extern ARAL *ebpf_aral_shm_pid;
+void ebpf_shm_aral_init();
+netdata_publish_shm_t *ebpf_shm_stat_get(void);
+void ebpf_shm_release(netdata_publish_shm_t *stat);
 
 // ARAL Section end
 

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -220,6 +220,7 @@ extern netdata_publish_cachestat_t **cachestat_pid;
 extern netdata_publish_dcstat_t **dcstat_pid;
 extern netdata_publish_swap_t **swap_pid;
 extern netdata_publish_vfs_t **vfs_pid;
+extern netdata_fd_stat_t **fd_pid;
 
 // The default value is at least 32 times smaller than maximum number of PIDs allowed on system,
 // this is only possible because we are using ARAL (https://github.com/netdata/netdata/tree/master/libnetdata/aral).
@@ -249,10 +250,15 @@ void ebpf_dcstat_aral_init();
 netdata_publish_dcstat_t *ebpf_publish_dcstat_get(void);
 void ebpf_dcstat_release(netdata_publish_dcstat_t *stat);
 
-ARAL *ebpf_aral_vfs_pid;
+extern ARAL *ebpf_aral_vfs_pid;
 void ebpf_vfs_aral_init();
 netdata_publish_vfs_t *ebpf_vfs_get(void);
 void ebpf_vfs_release(netdata_publish_vfs_t *stat);
+
+extern ARAL *ebpf_aral_fd_pid;
+void ebpf_fd_aral_init();
+netdata_fd_stat_t *ebpf_fd_stat_get(void);
+void ebpf_fd_release(netdata_fd_stat_t *stat);
 
 // ARAL Section end
 

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -218,6 +218,7 @@ void collect_data_for_all_processes(int tbl_pid_stats_fd);
 extern ebpf_process_stat_t **global_process_stats;
 extern netdata_publish_cachestat_t **cachestat_pid;
 extern netdata_publish_dcstat_t **dcstat_pid;
+extern netdata_publish_swap_t **swap_pid;
 
 // The default value is at least 32 times smaller than maximum number of PIDs allowed on system,
 // this is only possible because we are using ARAL (https://github.com/netdata/netdata/tree/master/libnetdata/aral).

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -226,10 +226,18 @@ extern netdata_publish_dcstat_t **dcstat_pid;
 #endif
 #define NETDATA_EBPF_ALLOC_MIN_ELEMENTS 256
 
+// ARAL Sectiion
 extern void ebpf_aral_init(void);
 
 extern ebpf_process_stat_t *ebpf_process_stat_get(void);
 extern void ebpf_process_stat_release(ebpf_process_stat_t *stat);
+
+extern ARAL *ebpf_aral_socket_pid;
+void ebpf_socket_aral_init();
+ebpf_socket_publish_apps_t *ebpf_socket_stat_get(void);
+void ebpf_socket_release(ebpf_socket_publish_apps_t *stat);
+
+// ARAL Section end
 
 #include "libnetdata/threads/threads.h"
 

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -219,6 +219,7 @@ extern ebpf_process_stat_t **global_process_stats;
 extern netdata_publish_cachestat_t **cachestat_pid;
 extern netdata_publish_dcstat_t **dcstat_pid;
 extern netdata_publish_swap_t **swap_pid;
+extern netdata_publish_vfs_t **vfs_pid;
 
 // The default value is at least 32 times smaller than maximum number of PIDs allowed on system,
 // this is only possible because we are using ARAL (https://github.com/netdata/netdata/tree/master/libnetdata/aral).
@@ -247,6 +248,11 @@ extern ARAL *ebpf_aral_dcstat_pid;
 void ebpf_dcstat_aral_init();
 netdata_publish_dcstat_t *ebpf_publish_dcstat_get(void);
 void ebpf_dcstat_release(netdata_publish_dcstat_t *stat);
+
+ARAL *ebpf_aral_vfs_pid;
+void ebpf_vfs_aral_init();
+netdata_publish_vfs_t *ebpf_vfs_get(void);
+void ebpf_vfs_release(netdata_publish_vfs_t *stat);
 
 // ARAL Section end
 

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -242,6 +242,11 @@ void ebpf_cachestat_aral_init();
 netdata_publish_cachestat_t *ebpf_publish_cachestat_get(void);
 void ebpf_cachestat_release(netdata_publish_cachestat_t *stat);
 
+extern ARAL *ebpf_aral_dcstat_pid;
+void ebpf_dcstat_aral_init();
+netdata_publish_dcstat_t *ebpf_publish_dcstat_get(void);
+void ebpf_dcstat_release(netdata_publish_dcstat_t *stat);
+
 // ARAL Section end
 
 // Threads integrated with apps

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -244,6 +244,10 @@ void ebpf_cachestat_release(netdata_publish_cachestat_t *stat);
 
 // ARAL Section end
 
+// Threads integrated with apps
+extern ebpf_socket_publish_apps_t **socket_bandwidth_curr;
+// Threads integrated with apps
+
 #include "libnetdata/threads/threads.h"
 
 // ARAL variables

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -237,6 +237,11 @@ void ebpf_socket_aral_init();
 ebpf_socket_publish_apps_t *ebpf_socket_stat_get(void);
 void ebpf_socket_release(ebpf_socket_publish_apps_t *stat);
 
+extern ARAL *ebpf_aral_cachestat_pid;
+void ebpf_cachestat_aral_init();
+netdata_publish_cachestat_t *ebpf_publish_cachestat_get(void);
+void ebpf_cachestat_release(netdata_publish_cachestat_t *stat);
+
 // ARAL Section end
 
 #include "libnetdata/threads/threads.h"

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -50,8 +50,6 @@ static char *account_page[NETDATA_CACHESTAT_ACCOUNT_DIRTY_END] ={ "account_page_
                                                                   "__set_page_dirty", "__folio_mark_dirty"  };
 
 #ifdef LIBBPF_MAJOR_VERSION
-#include "includes/cachestat.skel.h" // BTF code
-
 static struct cachestat_bpf *bpf_obj = NULL;
 
 /**

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -44,8 +44,6 @@ static char *account_page[NETDATA_CACHESTAT_ACCOUNT_DIRTY_END] ={ "account_page_
                                                                   "__set_page_dirty", "__folio_mark_dirty"  };
 
 #ifdef LIBBPF_MAJOR_VERSION
-static struct cachestat_bpf *bpf_obj = NULL;
-
 /**
  * Disable probe
  *
@@ -335,10 +333,6 @@ static void ebpf_cachestat_free(ebpf_module_t *em)
     freez(cachestat_vector);
     freez(cachestat_values);
 
-#ifdef LIBBPF_MAJOR_VERSION
-    if (bpf_obj)
-        cachestat_bpf__destroy(bpf_obj);
-#endif
     pthread_mutex_lock(&ebpf_exit_cleanup);
     em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
@@ -1232,11 +1226,11 @@ static int ebpf_cachestat_load_bpf(ebpf_module_t *em)
     }
 #ifdef LIBBPF_MAJOR_VERSION
     else {
-        bpf_obj = cachestat_bpf__open();
-        if (!bpf_obj)
+        cachestat_bpf_obj = cachestat_bpf__open();
+        if (!cachestat_bpf_obj)
             ret = -1;
         else
-            ret = ebpf_cachestat_load_and_attach(bpf_obj, em);
+            ret = ebpf_cachestat_load_and_attach(cachestat_bpf_obj, em);
     }
 #endif
 

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -3,10 +3,6 @@
 #include "ebpf.h"
 #include "ebpf_cachestat.h"
 
-// ----------------------------------------------------------------------------
-// ARAL vectors used to speed up processing
-ARAL *ebpf_aral_cachestat_pid = NULL;
-
 netdata_publish_cachestat_t **cachestat_pid;
 
 static char *cachestat_counter_dimension_name[NETDATA_CACHESTAT_END] = { "ratio", "dirty", "hit",
@@ -362,46 +358,6 @@ static void ebpf_cachestat_exit(void *ptr)
     ebpf_module_t *em = (ebpf_module_t *)ptr;
 
     ebpf_cachestat_free(em);
-}
-
-/*****************************************************************
- *
- *  ARAL FUNCTIONS
- *
- *****************************************************************/
-
-/**
- * eBPF Cachestat Aral init
- *
- * Initiallize array allocator that will be used when integration with apps is enabled.
- */
-static inline void ebpf_cachestat_aral_init()
-{
-    ebpf_aral_cachestat_pid = ebpf_allocate_pid_aral(NETDATA_EBPF_CACHESTAT_ARAL_NAME, sizeof(netdata_publish_cachestat_t));
-}
-
-/**
- * eBPF publish cachestat get
- *
- * Get a netdata_publish_cachestat_t entry to be used with a specific PID.
- *
- * @return it returns the address on success.
- */
-netdata_publish_cachestat_t *ebpf_publish_cachestat_get(void)
-{
-    netdata_publish_cachestat_t *target = aral_mallocz(ebpf_aral_cachestat_pid);
-    memset(target, 0, sizeof(netdata_publish_cachestat_t));
-    return target;
-}
-
-/**
- * eBPF cachestat release
- *
- * @param stat Release a target after usage.
- */
-void ebpf_cachestat_release(netdata_publish_cachestat_t *stat)
-{
-    aral_freez(ebpf_aral_cachestat_pid, stat);
 }
 
 /*****************************************************************

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -1313,7 +1313,6 @@ void *ebpf_cachestat_thread(void *ptr)
     ebpf_update_pid_table(&cachestat_maps[NETDATA_CACHESTAT_PID_STATS], em);
 
     if (ebpf_cachestat_set_internal_value()) {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endcachestat;
     }
 
@@ -1321,7 +1320,6 @@ void *ebpf_cachestat_thread(void *ptr)
     ebpf_adjust_thread_load(em, default_btf);
 #endif
     if (ebpf_cachestat_load_bpf(em)) {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endcachestat;
     }
 

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -340,8 +340,6 @@ static void ebpf_cachestat_free(ebpf_module_t *em)
     em->thread->enabled = NETDATA_THREAD_EBPF_STOPPING;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
-    ebpf_cleanup_publish_syscall(cachestat_counter_publish_aggregated);
-
     freez(cachestat_vector);
     freez(cachestat_values);
 

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -3,8 +3,6 @@
 #include "ebpf.h"
 #include "ebpf_cachestat.h"
 
-netdata_publish_cachestat_t **cachestat_pid;
-
 static char *cachestat_counter_dimension_name[NETDATA_CACHESTAT_END] = { "ratio", "dirty", "hit",
                                                                          "miss" };
 static netdata_syscall_stat_t cachestat_counter_aggregated_data[NETDATA_CACHESTAT_END];

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -337,7 +337,7 @@ static inline int ebpf_cachestat_load_and_attach(struct cachestat_bpf *obj, ebpf
 static void ebpf_cachestat_free(ebpf_module_t *em)
 {
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPING;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
     freez(cachestat_vector);
@@ -348,7 +348,7 @@ static void ebpf_cachestat_free(ebpf_module_t *em)
         cachestat_bpf__destroy(bpf_obj);
 #endif
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -1313,7 +1313,7 @@ void *ebpf_cachestat_thread(void *ptr)
     ebpf_update_pid_table(&cachestat_maps[NETDATA_CACHESTAT_PID_STATS], em);
 
     if (ebpf_cachestat_set_internal_value()) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endcachestat;
     }
 
@@ -1321,7 +1321,7 @@ void *ebpf_cachestat_thread(void *ptr)
     ebpf_adjust_thread_load(em, default_btf);
 #endif
     if (ebpf_cachestat_load_bpf(em)) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endcachestat;
     }
 

--- a/collectors/ebpf.plugin/ebpf_cgroup.c
+++ b/collectors/ebpf.plugin/ebpf_cgroup.c
@@ -263,11 +263,13 @@ void ebpf_reset_updated_var()
 void ebpf_parse_cgroup_shm_data()
 {
     static int previous = 0;
+    pthread_mutex_lock(&mutex_cgroup_shm);
+    if (ebpf_exit_plugin)
+        return;
+
     if (shm_ebpf_cgroup.header) {
         sem_wait(shm_sem_ebpf_cgroup);
         int i, end = shm_ebpf_cgroup.header->cgroup_root_count;
-
-        pthread_mutex_lock(&mutex_cgroup_shm);
 
         ebpf_remove_cgroup_target_update_list();
 
@@ -285,10 +287,10 @@ void ebpf_parse_cgroup_shm_data()
 #ifdef NETDATA_DEV_MODE
         error("Updating cgroup %d (Previous: %d, Current: %d)", send_cgroup_chart, previous, shm_ebpf_cgroup.header->cgroup_root_count);
 #endif
-        pthread_mutex_unlock(&mutex_cgroup_shm);
-
         sem_post(shm_sem_ebpf_cgroup);
     }
+    pthread_mutex_unlock(&mutex_cgroup_shm);
+
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/collectors/ebpf.plugin/ebpf_cgroup.c
+++ b/collectors/ebpf.plugin/ebpf_cgroup.c
@@ -263,7 +263,7 @@ void ebpf_reset_updated_var()
 void ebpf_parse_cgroup_shm_data()
 {
     static int previous = 0;
-    if (ebpf_exit_plugin || !shm_ebpf_cgroup.header)
+    if (ebpf_exit_plugin || !shm_ebpf_cgroup.header || shm_sem_ebpf_cgroup == SEM_FAILED)
         return;
 
     struct timespec ts;

--- a/collectors/ebpf.plugin/ebpf_cgroup.c
+++ b/collectors/ebpf.plugin/ebpf_cgroup.c
@@ -81,7 +81,7 @@ void ebpf_map_cgroup_shared_memory()
         return;
     }
 
-    netdata_ebpf_cgroup_shm_t *mapped_memory = (netdata_ebpf_cgroup_shm_header_t *)ebpf_cgroup_map_shm_locally(shm_fd_ebpf_cgroup, length);
+    netdata_ebpf_cgroup_shm_t *mapped_memory = (netdata_ebpf_cgroup_shm_t *)ebpf_cgroup_map_shm_locally(shm_fd_ebpf_cgroup, length);
     if (!mapped_memory) {
         limit_try = NETDATA_EBPF_CGROUP_MAX_TRIES + 1;
         return;

--- a/collectors/ebpf.plugin/ebpf_cgroup.h
+++ b/collectors/ebpf.plugin/ebpf_cgroup.h
@@ -64,6 +64,7 @@ void ebpf_map_cgroup_shared_memory();
 void ebpf_parse_cgroup_shm_data();
 void ebpf_create_charts_on_systemd(char *id, char *title, char *units, char *family, char *charttype, int order,
                                           char *algorithm, char *context, char *module, int update_every);
+void *ebpf_cgroup_integration(void *ptr);
 extern int send_cgroup_chart;
 
 #endif /* NETDATA_EBPF_CGROUP_H */

--- a/collectors/ebpf.plugin/ebpf_cgroup.h
+++ b/collectors/ebpf.plugin/ebpf_cgroup.h
@@ -65,6 +65,7 @@ void ebpf_parse_cgroup_shm_data();
 void ebpf_create_charts_on_systemd(char *id, char *title, char *units, char *family, char *charttype, int order,
                                           char *algorithm, char *context, char *module, int update_every);
 void *ebpf_cgroup_integration(void *ptr);
+void ebpf_unmap_cgroup_shared_memory();
 extern int send_cgroup_chart;
 
 #endif /* NETDATA_EBPF_CGROUP_H */

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -298,7 +298,7 @@ void ebpf_dcstat_clean_names()
 static void ebpf_dcstat_free(ebpf_module_t *em )
 {
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPING;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
     freez(dcstat_vector);
@@ -312,7 +312,7 @@ static void ebpf_dcstat_free(ebpf_module_t *em )
 #endif
 
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -1186,7 +1186,7 @@ void *ebpf_dcstat_thread(void *ptr)
     ebpf_adjust_thread_load(em, default_btf);
 #endif
     if (ebpf_dcstat_load_bpf(em)) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto enddcstat;
     }
 

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -44,8 +44,6 @@ netdata_ebpf_targets_t dc_targets[] = { {.name = "lookup_fast", .mode = EBPF_LOA
                                         {.name = NULL, .mode = EBPF_LOAD_TRAMPOLINE}};
 
 #ifdef LIBBPF_MAJOR_VERSION
-static struct dc_bpf *bpf_obj = NULL;
-
 /**
  * Disable probe
  *
@@ -298,11 +296,6 @@ static void ebpf_dcstat_free(ebpf_module_t *em )
     freez(dcstat_values);
 
     ebpf_dcstat_clean_names();
-
-#ifdef LIBBPF_MAJOR_VERSION
-    if (bpf_obj)
-        dc_bpf__destroy(bpf_obj);
-#endif
 
     pthread_mutex_lock(&ebpf_exit_cleanup);
     em->enabled = NETDATA_THREAD_EBPF_STOPPED;
@@ -1101,11 +1094,11 @@ static int ebpf_dcstat_load_bpf(ebpf_module_t *em)
     }
 #ifdef LIBBPF_MAJOR_VERSION
     else {
-        bpf_obj = dc_bpf__open();
-        if (!bpf_obj)
+        dc_bpf_obj = dc_bpf__open();
+        if (!dc_bpf_obj)
             ret = -1;
         else
-            ret = ebpf_dc_load_and_attach(bpf_obj, em);
+            ret = ebpf_dc_load_and_attach(dc_bpf_obj, em);
     }
 #endif
 

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -3,16 +3,11 @@
 #include "ebpf.h"
 #include "ebpf_dcstat.h"
 
-// ----------------------------------------------------------------------------
-// ARAL vectors used to speed up processing
-ARAL *ebpf_aral_dcstat_pid = NULL;
-
 static char *dcstat_counter_dimension_name[NETDATA_DCSTAT_IDX_END] = { "ratio", "reference", "slow", "miss" };
 static netdata_syscall_stat_t dcstat_counter_aggregated_data[NETDATA_DCSTAT_IDX_END];
 static netdata_publish_syscall_t dcstat_counter_publish_aggregated[NETDATA_DCSTAT_IDX_END];
 
 netdata_dcstat_pid_t *dcstat_vector = NULL;
-netdata_publish_dcstat_t **dcstat_pid = NULL;
 
 static netdata_idx_t dcstat_hash_values[NETDATA_DCSTAT_IDX_END];
 static netdata_idx_t *dcstat_values = NULL;
@@ -325,46 +320,6 @@ static void ebpf_dcstat_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
     ebpf_dcstat_free(em);
-}
-
-/*****************************************************************
- *
- *  ARAL FUNCTIONS
- *
- *****************************************************************/
-
-/**
- * eBPF directory cache Aral init
- *
- * Initiallize array allocator that will be used when integration with apps is enabled.
- */
-static inline void ebpf_dcstat_aral_init()
-{
-    ebpf_aral_dcstat_pid = ebpf_allocate_pid_aral(NETDATA_EBPF_DCSTAT_ARAL_NAME, sizeof(netdata_publish_dcstat_t));
-}
-
-/**
- * eBPF publish dcstat get
- *
- * Get a netdata_publish_dcstat_t entry to be used with a specific PID.
- *
- * @return it returns the address on success.
- */
-netdata_publish_dcstat_t *ebpf_publish_dcstat_get(void)
-{
-    netdata_publish_dcstat_t *target = aral_mallocz(ebpf_aral_dcstat_pid);
-    memset(target, 0, sizeof(netdata_publish_dcstat_t));
-    return target;
-}
-
-/**
- * eBPF dcstat release
- *
- * @param stat Release a target after usage.
- */
-void ebpf_dcstat_release(netdata_publish_dcstat_t *stat)
-{
-    aral_freez(ebpf_aral_dcstat_pid, stat);
 }
 
 /*****************************************************************

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -49,8 +49,6 @@ netdata_ebpf_targets_t dc_targets[] = { {.name = "lookup_fast", .mode = EBPF_LOA
                                         {.name = NULL, .mode = EBPF_LOAD_TRAMPOLINE}};
 
 #ifdef LIBBPF_MAJOR_VERSION
-#include "includes/dc.skel.h" // BTF code
-
 static struct dc_bpf *bpf_obj = NULL;
 
 /**

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -1186,7 +1186,6 @@ void *ebpf_dcstat_thread(void *ptr)
     ebpf_adjust_thread_load(em, default_btf);
 #endif
     if (ebpf_dcstat_load_bpf(em)) {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto enddcstat;
     }
 

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -304,8 +304,6 @@ static void ebpf_dcstat_free(ebpf_module_t *em )
     freez(dcstat_vector);
     freez(dcstat_values);
 
-    ebpf_cleanup_publish_syscall(dcstat_counter_publish_aggregated);
-
     ebpf_dcstat_clean_names();
 
 #ifdef LIBBPF_MAJOR_VERSION

--- a/collectors/ebpf.plugin/ebpf_disk.c
+++ b/collectors/ebpf.plugin/ebpf_disk.c
@@ -761,25 +761,21 @@ void *ebpf_disk_thread(void *ptr)
     em->maps = disk_maps;
 
     if (ebpf_disk_enable_tracepoints()) {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto enddisk;
     }
 
     avl_init_lock(&disk_tree, ebpf_compare_disks);
     if (read_local_disks()) {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto enddisk;
     }
 
     if (pthread_mutex_init(&plot_mutex, NULL)) {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         error("Cannot initialize local mutex");
         goto enddisk;
     }
 
     em->probe_links = ebpf_load_program(ebpf_plugin_dir, em, running_on_kernel, isrh, &em->objects);
     if (!em->probe_links) {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto enddisk;
     }
 

--- a/collectors/ebpf.plugin/ebpf_disk.c
+++ b/collectors/ebpf.plugin/ebpf_disk.c
@@ -429,7 +429,7 @@ static void ebpf_cleanup_disk_list()
 static void ebpf_disk_free(ebpf_module_t *em)
 {
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPING;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
     ebpf_disk_disable_tracepoints();
@@ -444,7 +444,7 @@ static void ebpf_disk_free(ebpf_module_t *em)
     ebpf_cleanup_disk_list();
 
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -761,25 +761,25 @@ void *ebpf_disk_thread(void *ptr)
     em->maps = disk_maps;
 
     if (ebpf_disk_enable_tracepoints()) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto enddisk;
     }
 
     avl_init_lock(&disk_tree, ebpf_compare_disks);
     if (read_local_disks()) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto enddisk;
     }
 
     if (pthread_mutex_init(&plot_mutex, NULL)) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         error("Cannot initialize local mutex");
         goto enddisk;
     }
 
     em->probe_links = ebpf_load_program(ebpf_plugin_dir, em, running_on_kernel, isrh, &em->objects);
     if (!em->probe_links) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto enddisk;
     }
 

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -1141,7 +1141,6 @@ static int ebpf_fd_load_bpf(ebpf_module_t *em)
     if (em->load & EBPF_LOAD_LEGACY) {
         em->probe_links = ebpf_load_program(ebpf_plugin_dir, em, running_on_kernel, isrh, &em->objects);
         if (!em->probe_links) {
-            em->enabled = CONFIG_BOOLEAN_NO;
             ret = -1;
         }
     }
@@ -1181,7 +1180,6 @@ void *ebpf_fd_thread(void *ptr)
     ebpf_adjust_thread_load(em, default_btf);
 #endif
     if (ebpf_fd_load_bpf(em))  {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endfd;
     }
 

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -368,7 +368,7 @@ static inline int ebpf_fd_load_and_attach(struct fd_bpf *obj, ebpf_module_t *em)
 static void ebpf_fd_free(ebpf_module_t *em)
 {
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPING;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
     freez(fd_values);
@@ -380,7 +380,7 @@ static void ebpf_fd_free(ebpf_module_t *em)
 #endif
 
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -1181,7 +1181,7 @@ void *ebpf_fd_thread(void *ptr)
     ebpf_adjust_thread_load(em, default_btf);
 #endif
     if (ebpf_fd_load_bpf(em))  {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endfd;
     }
 

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -371,7 +371,6 @@ static void ebpf_fd_free(ebpf_module_t *em)
     em->thread->enabled = NETDATA_THREAD_EBPF_STOPPING;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
-    ebpf_cleanup_publish_syscall(fd_publish_aggregated);
     freez(fd_values);
     freez(fd_vector);
 

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -3,10 +3,6 @@
 #include "ebpf.h"
 #include "ebpf_fd.h"
 
-// ----------------------------------------------------------------------------
-// ARAL vectors used to speed up processing
-ARAL *ebpf_aral_fd_pid = NULL;
-
 static char *fd_dimension_names[NETDATA_FD_SYSCALL_END] = { "open", "close" };
 static char *fd_id_names[NETDATA_FD_SYSCALL_END] = { "do_sys_open",  "__close_fd" };
 
@@ -40,7 +36,6 @@ static netdata_idx_t fd_hash_values[NETDATA_FD_COUNTER];
 static netdata_idx_t *fd_values = NULL;
 
 netdata_fd_stat_t *fd_vector = NULL;
-netdata_fd_stat_t **fd_pid = NULL;
 
 netdata_ebpf_targets_t fd_targets[] = { {.name = "open", .mode = EBPF_LOAD_TRAMPOLINE},
                                         {.name = "close", .mode = EBPF_LOAD_TRAMPOLINE},
@@ -393,46 +388,6 @@ static void ebpf_fd_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
     ebpf_fd_free(em);
-}
-
-/*****************************************************************
- *
- *  ARAL FUNCTIONS
- *
- *****************************************************************/
-
-/**
- * eBPF file descriptor Aral init
- *
- * Initiallize array allocator that will be used when integration with apps is enabled.
- */
-static inline void ebpf_fd_aral_init()
-{
-    ebpf_aral_fd_pid = ebpf_allocate_pid_aral(NETDATA_EBPF_FD_ARAL_NAME, sizeof(netdata_fd_stat_t));
-}
-
-/**
- * eBPF publish file descriptor get
- *
- * Get a netdata_fd_stat_t entry to be used with a specific PID.
- *
- * @return it returns the address on success.
- */
-netdata_fd_stat_t *ebpf_fd_stat_get(void)
-{
-    netdata_fd_stat_t *target = aral_mallocz(ebpf_aral_fd_pid);
-    memset(target, 0, sizeof(netdata_fd_stat_t));
-    return target;
-}
-
-/**
- * eBPF file descriptor release
- *
- * @param stat Release a target after usage.
- */
-void ebpf_fd_release(netdata_fd_stat_t *stat)
-{
-    aral_freez(ebpf_aral_fd_pid, stat);
 }
 
 /*****************************************************************

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -47,8 +47,6 @@ netdata_ebpf_targets_t fd_targets[] = { {.name = "open", .mode = EBPF_LOAD_TRAMP
                                         {.name = NULL, .mode = EBPF_LOAD_TRAMPOLINE}};
 
 #ifdef LIBBPF_MAJOR_VERSION
-#include "includes/fd.skel.h" // BTF code
-
 static struct fd_bpf *bpf_obj = NULL;
 
 /**

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -42,8 +42,6 @@ netdata_ebpf_targets_t fd_targets[] = { {.name = "open", .mode = EBPF_LOAD_TRAMP
                                         {.name = NULL, .mode = EBPF_LOAD_TRAMPOLINE}};
 
 #ifdef LIBBPF_MAJOR_VERSION
-static struct fd_bpf *bpf_obj = NULL;
-
 /**
  * Disable probe
  *
@@ -366,11 +364,6 @@ static void ebpf_fd_free(ebpf_module_t *em)
 
     freez(fd_values);
     freez(fd_vector);
-
-#ifdef LIBBPF_MAJOR_VERSION
-    if (bpf_obj)
-        fd_bpf__destroy(bpf_obj);
-#endif
 
     pthread_mutex_lock(&ebpf_exit_cleanup);
     em->enabled = NETDATA_THREAD_EBPF_STOPPED;
@@ -1099,11 +1092,11 @@ static int ebpf_fd_load_bpf(ebpf_module_t *em)
     }
 #ifdef LIBBPF_MAJOR_VERSION
     else {
-        bpf_obj = fd_bpf__open();
-        if (!bpf_obj)
+        fd_bpf_obj = fd_bpf__open();
+        if (!fd_bpf_obj)
             ret = -1;
         else
-            ret = ebpf_fd_load_and_attach(bpf_obj, em);
+            ret = ebpf_fd_load_and_attach(fd_bpf_obj, em);
     }
 #endif
 

--- a/collectors/ebpf.plugin/ebpf_fd.h
+++ b/collectors/ebpf.plugin/ebpf_fd.h
@@ -85,7 +85,6 @@ void *ebpf_fd_thread(void *ptr);
 void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr);
 void ebpf_fd_release(netdata_fd_stat_t *stat);
 extern struct config fd_config;
-extern netdata_fd_stat_t **fd_pid;
 extern netdata_ebpf_targets_t fd_targets[];
 
 #endif /* NETDATA_EBPF_FD_H */

--- a/collectors/ebpf.plugin/ebpf_filesystem.c
+++ b/collectors/ebpf.plugin/ebpf_filesystem.c
@@ -568,7 +568,6 @@ void *ebpf_filesystem_thread(void *ptr)
         if (em->optional)
             info("Netdata cannot monitor the filesystems used on this host.");
 
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endfilesystem;
     }
 

--- a/collectors/ebpf.plugin/ebpf_filesystem.c
+++ b/collectors/ebpf.plugin/ebpf_filesystem.c
@@ -329,7 +329,7 @@ void ebpf_filesystem_cleanup_ebpf_data()
 static void ebpf_filesystem_free(ebpf_module_t *em)
 {
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPING;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
     ebpf_filesystem_cleanup_ebpf_data();
@@ -338,7 +338,7 @@ static void ebpf_filesystem_free(ebpf_module_t *em)
     freez(filesystem_hash_values);
 
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -568,7 +568,7 @@ void *ebpf_filesystem_thread(void *ptr)
         if (em->optional)
             info("Netdata cannot monitor the filesystems used on this host.");
 
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endfilesystem;
     }
 

--- a/collectors/ebpf.plugin/ebpf_filesystem.c
+++ b/collectors/ebpf.plugin/ebpf_filesystem.c
@@ -332,8 +332,6 @@ static void ebpf_filesystem_free(ebpf_module_t *em)
     em->thread->enabled = NETDATA_THREAD_EBPF_STOPPING;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
-    ebpf_cleanup_publish_syscall(filesystem_publish_aggregated);
-
     ebpf_filesystem_cleanup_ebpf_data();
     if (dimensions)
         ebpf_histogram_dimension_cleanup(dimensions, NETDATA_EBPF_HIST_MAX_BINS);

--- a/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -556,13 +556,11 @@ void *ebpf_hardirq_thread(void *ptr)
     em->maps = hardirq_maps;
 
     if (ebpf_enable_tracepoints(hardirq_tracepoints) == 0) {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endhardirq;
     }
 
     em->probe_links = ebpf_load_program(ebpf_plugin_dir, em, running_on_kernel, isrh, &em->objects);
     if (!em->probe_links) {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endhardirq;
     }
 

--- a/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -390,7 +390,9 @@ static int hardirq_read_latency_map(int mapfd)
 
 static void hardirq_read_latency_static_map(int mapfd)
 {
-    hardirq_ebpf_static_val_t hardirq_ebpf_static_vals[ebpf_nprocs + 1];
+    static hardirq_ebpf_static_val_t *hardirq_ebpf_static_vals = NULL;
+    if (!hardirq_ebpf_static_vals)
+        hardirq_ebpf_static_vals = callocz(ebpf_nprocs + 1, sizeof(hardirq_ebpf_static_val_t));
 
     uint32_t i;
     for (i = 0; i < HARDIRQ_EBPF_STATIC_END; i++) {

--- a/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -314,7 +314,9 @@ static int hardirq_parse_interrupts(char *irq_name, int irq)
  */
 static int hardirq_read_latency_map(int mapfd)
 {
-    hardirq_ebpf_static_val_t hardirq_ebpf_vals[ebpf_nprocs + 1];
+    static hardirq_ebpf_static_val_t *hardirq_ebpf_vals = NULL;
+    if (!hardirq_ebpf_vals)
+        hardirq_ebpf_vals = callocz(ebpf_nprocs + 1, sizeof(hardirq_ebpf_static_val_t));
 
     hardirq_ebpf_key_t key = {};
     hardirq_ebpf_key_t next_key = {};

--- a/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -489,9 +489,12 @@ static inline void hardirq_write_static_dims()
 
 /**
 * Main loop for this collector.
+ *
+ * @param em the main thread structure.
 */
 static void hardirq_collector(ebpf_module_t *em)
 {
+    memset(&hardirq_pub, 0, sizeof(hardirq_pub));
     avl_init_lock(&hardirq_pub, hardirq_val_cmp);
     ebpf_hardirq_aral_init();
 

--- a/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -188,14 +188,14 @@ void ebpf_hardirq_release(hardirq_val_t *stat)
 static void ebpf_hardirq_free(ebpf_module_t *em)
 {
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPING;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
     for (int i = 0; hardirq_tracepoints[i].class != NULL; i++) {
         ebpf_disable_tracepoint(&hardirq_tracepoints[i]);
     }
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -556,13 +556,13 @@ void *ebpf_hardirq_thread(void *ptr)
     em->maps = hardirq_maps;
 
     if (ebpf_enable_tracepoints(hardirq_tracepoints) == 0) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endhardirq;
     }
 
     em->probe_links = ebpf_load_program(ebpf_plugin_dir, em, running_on_kernel, isrh, &em->objects);
     if (!em->probe_links) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endhardirq;
     }
 

--- a/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -187,10 +187,6 @@ void ebpf_hardirq_release(hardirq_val_t *stat)
  */
 static void ebpf_hardirq_free(ebpf_module_t *em)
 {
-    pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
-    pthread_mutex_unlock(&ebpf_exit_cleanup);
-
     for (int i = 0; hardirq_tracepoints[i].class != NULL; i++) {
         ebpf_disable_tracepoint(&hardirq_tracepoints[i]);
     }

--- a/collectors/ebpf.plugin/ebpf_mdflush.c
+++ b/collectors/ebpf.plugin/ebpf_mdflush.c
@@ -247,24 +247,19 @@ void *ebpf_mdflush_thread(void *ptr)
 
     char *md_flush_request = ebpf_find_symbol("md_flush_request");
     if (!md_flush_request) {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         error("Cannot monitor MD devices, because md is not loaded.");
-    }
-    freez(md_flush_request);
-
-    if (em->enabled == NETDATA_THREAD_EBPF_STOPPED) {
         goto endmdflush;
     }
 
     em->probe_links = ebpf_load_program(ebpf_plugin_dir, em, running_on_kernel, isrh, &em->objects);
     if (!em->probe_links) {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endmdflush;
     }
 
     mdflush_collector(em);
 
 endmdflush:
+    freez(md_flush_request);
     ebpf_update_disabled_plugin_stats(em);
 
     netdata_thread_cleanup_pop(1);

--- a/collectors/ebpf.plugin/ebpf_mdflush.c
+++ b/collectors/ebpf.plugin/ebpf_mdflush.c
@@ -46,7 +46,7 @@ static void ebpf_mdflush_free(ebpf_module_t *em)
 {
     freez(mdflush_ebpf_vals);
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -247,12 +247,12 @@ void *ebpf_mdflush_thread(void *ptr)
 
     char *md_flush_request = ebpf_find_symbol("md_flush_request");
     if (!md_flush_request) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         error("Cannot monitor MD devices, because md is not loaded.");
     }
     freez(md_flush_request);
 
-    if (em->thread->enabled == NETDATA_THREAD_EBPF_STOPPED) {
+    if (em->enabled == NETDATA_THREAD_EBPF_STOPPED) {
         goto endmdflush;
     }
 

--- a/collectors/ebpf.plugin/ebpf_mount.c
+++ b/collectors/ebpf.plugin/ebpf_mount.c
@@ -25,8 +25,6 @@ netdata_ebpf_targets_t mount_targets[] = { {.name = "mount", .mode = EBPF_LOAD_T
                                            {.name = NULL, .mode = EBPF_LOAD_TRAMPOLINE}};
 
 #ifdef LIBBPF_MAJOR_VERSION
-static struct mount_bpf *bpf_obj = NULL;
-
 /*****************************************************************
  *
  *  BTF FUNCTIONS
@@ -223,11 +221,6 @@ static inline int ebpf_mount_load_and_attach(struct mount_bpf *obj, ebpf_module_
  */
 static void ebpf_mount_free(ebpf_module_t *em)
 {
-#ifdef LIBBPF_MAJOR_VERSION
-    if (bpf_obj)
-        mount_bpf__destroy(bpf_obj);
-#endif
-
     pthread_mutex_lock(&ebpf_exit_cleanup);
     em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
@@ -388,11 +381,11 @@ static int ebpf_mount_load_bpf(ebpf_module_t *em)
     }
 #ifdef LIBBPF_MAJOR_VERSION
     else {
-        bpf_obj = mount_bpf__open();
-        if (!bpf_obj)
+        mount_bpf_obj = mount_bpf__open();
+        if (!mount_bpf_obj)
             ret = -1;
         else
-            ret = ebpf_mount_load_and_attach(bpf_obj, em);
+            ret = ebpf_mount_load_and_attach(mount_bpf_obj, em);
     }
 #endif
 

--- a/collectors/ebpf.plugin/ebpf_mount.c
+++ b/collectors/ebpf.plugin/ebpf_mount.c
@@ -226,7 +226,7 @@ static inline int ebpf_mount_load_and_attach(struct mount_bpf *obj, ebpf_module_
 static void ebpf_mount_free(ebpf_module_t *em)
 {
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPING;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
 #ifdef LIBBPF_MAJOR_VERSION
@@ -235,7 +235,7 @@ static void ebpf_mount_free(ebpf_module_t *em)
 #endif
 
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -429,7 +429,7 @@ void *ebpf_mount_thread(void *ptr)
     ebpf_adjust_thread_load(em, default_btf);
 #endif
     if (ebpf_mount_load_bpf(em)) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endmount;
     }
 

--- a/collectors/ebpf.plugin/ebpf_mount.c
+++ b/collectors/ebpf.plugin/ebpf_mount.c
@@ -225,10 +225,6 @@ static inline int ebpf_mount_load_and_attach(struct mount_bpf *obj, ebpf_module_
  */
 static void ebpf_mount_free(ebpf_module_t *em)
 {
-    pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
-    pthread_mutex_unlock(&ebpf_exit_cleanup);
-
 #ifdef LIBBPF_MAJOR_VERSION
     if (bpf_obj)
         mount_bpf__destroy(bpf_obj);
@@ -389,7 +385,6 @@ static int ebpf_mount_load_bpf(ebpf_module_t *em)
     if (em->load & EBPF_LOAD_LEGACY) {
         em->probe_links = ebpf_load_program(ebpf_plugin_dir, em, running_on_kernel, isrh, &em->objects);
         if (!em->probe_links) {
-            em->enabled = CONFIG_BOOLEAN_NO;
             ret = -1;
         }
     }
@@ -429,7 +424,6 @@ void *ebpf_mount_thread(void *ptr)
     ebpf_adjust_thread_load(em, default_btf);
 #endif
     if (ebpf_mount_load_bpf(em)) {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endmount;
     }
 

--- a/collectors/ebpf.plugin/ebpf_mount.c
+++ b/collectors/ebpf.plugin/ebpf_mount.c
@@ -25,8 +25,6 @@ netdata_ebpf_targets_t mount_targets[] = { {.name = "mount", .mode = EBPF_LOAD_T
                                            {.name = NULL, .mode = EBPF_LOAD_TRAMPOLINE}};
 
 #ifdef LIBBPF_MAJOR_VERSION
-#include "includes/mount.skel.h" // BTF code
-
 static struct mount_bpf *bpf_obj = NULL;
 
 /*****************************************************************

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -47,7 +47,7 @@ static void oomkill_cleanup(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -364,29 +364,29 @@ void *ebpf_oomkill_thread(void *ptr)
     if (unlikely(!ebpf_all_pids || !em->apps_charts)) {
         // When we are not running integration with apps, we won't fill necessary variables for this thread to run, so
         // we need to disable it.
-        if (em->thread->enabled)
+        if (em->enabled)
             info("%s apps integration is completely disabled.", NETDATA_DEFAULT_OOM_DISABLED_MSG);
 
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     } else if (running_on_kernel < NETDATA_EBPF_KERNEL_4_14) {
-        if (em->thread->enabled)
+        if (em->enabled)
             info("%s kernel does not have necessary tracepoints.", NETDATA_DEFAULT_OOM_DISABLED_MSG);
 
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     }
 
-    if (em->thread->enabled == NETDATA_THREAD_EBPF_STOPPED) {
+    if (em->enabled == NETDATA_THREAD_EBPF_STOPPED) {
         goto endoomkill;
     }
 
     if (ebpf_enable_tracepoints(oomkill_tracepoints) == 0) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endoomkill;
     }
 
     em->probe_links = ebpf_load_program(ebpf_plugin_dir, em, running_on_kernel, isrh, &em->objects);
     if (!em->probe_links) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endoomkill;
     }
 

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -1032,8 +1032,7 @@ void ebpf_process_update_cgroup_algorithm()
     int i;
     for (i = 0; i < NETDATA_KEY_PUBLISH_PROCESS_END; i++)  {
         netdata_publish_syscall_t *ptr = &process_publish_aggregated[i];
-        freez(ptr->algorithm);
-        ptr->algorithm = strdupz(ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
+        ptr->algorithm = ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX];
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -42,8 +42,6 @@ static netdata_idx_t *process_hash_values = NULL;
 static netdata_syscall_stat_t process_aggregated_data[NETDATA_KEY_PUBLISH_PROCESS_END];
 static netdata_publish_syscall_t process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_END];
 
-ebpf_process_stat_t **global_process_stats = NULL;
-
 int process_enabled = 0;
 bool publish_internal_metrics = true;
 

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -705,7 +705,7 @@ static void ebpf_process_exit(void *ptr)
     ebpf_process_disable_tracepoints();
 
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 }
 

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -700,7 +700,6 @@ static void ebpf_process_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
 
-    ebpf_cleanup_publish_syscall(process_publish_aggregated);
     freez(process_hash_values);
 
     ebpf_process_disable_tracepoints();

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -1055,7 +1055,7 @@ static void process_collector(ebpf_module_t *em)
             pthread_mutex_lock(&lock);
             ebpf_send_statistic_data();
 
-            if (thread_enabled) {
+            if (thread_enabled == NETDATA_THREAD_EBPF_RUNNING) {
                 if (publish_global) {
                     ebpf_process_send_data(em);
                 }
@@ -1207,7 +1207,7 @@ void *ebpf_process_thread(void *ptr)
         process_aggregated_data, process_publish_aggregated, process_dimension_names, process_id_names,
         algorithms, NETDATA_KEY_PUBLISH_PROCESS_END);
 
-    if (process_enabled) {
+    if (process_enabled == NETDATA_THREAD_EBPF_RUNNING) {
         ebpf_create_global_charts(em);
     }
 

--- a/collectors/ebpf.plugin/ebpf_process.h
+++ b/collectors/ebpf.plugin/ebpf_process.h
@@ -39,7 +39,7 @@
 #define NETDATA_SYSTEMD_PROCESS_EXIT_CONTEXT "services.task_exit"
 #define NETDATA_SYSTEMD_PROCESS_ERROR_CONTEXT "services.task_error"
 
-#define NETDATA_EBPF_CGROUP_UPDATE 30
+#define NETDATA_EBPF_CGROUP_UPDATE 60
 
 // Statistical information
 enum netdata_ebpf_thread_stats{

--- a/collectors/ebpf.plugin/ebpf_process.h
+++ b/collectors/ebpf.plugin/ebpf_process.h
@@ -39,7 +39,7 @@
 #define NETDATA_SYSTEMD_PROCESS_EXIT_CONTEXT "services.task_exit"
 #define NETDATA_SYSTEMD_PROCESS_ERROR_CONTEXT "services.task_error"
 
-#define NETDATA_EBPF_CGROUP_UPDATE 60
+#define NETDATA_EBPF_CGROUP_UPDATE 30
 
 // Statistical information
 enum netdata_ebpf_thread_stats{

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -292,7 +292,7 @@ static inline int ebpf_shm_load_and_attach(struct shm_bpf *obj, ebpf_module_t *e
 static void ebpf_shm_free(ebpf_module_t *em)
 {
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPING;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
     freez(shm_vector);
@@ -304,7 +304,7 @@ static void ebpf_shm_free(ebpf_module_t *em)
 #endif
 
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -1089,7 +1089,7 @@ void *ebpf_shm_thread(void *ptr)
     ebpf_adjust_thread_load(em, default_btf);
 #endif
     if (ebpf_shm_load_bpf(em)) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endshm;
     }
 

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -1049,7 +1049,6 @@ static int ebpf_shm_load_bpf(ebpf_module_t *em)
     if (em->load & EBPF_LOAD_LEGACY) {
         em->probe_links = ebpf_load_program(ebpf_plugin_dir, em, running_on_kernel, isrh, &em->objects);
         if (!em->probe_links) {
-            em->enabled = CONFIG_BOOLEAN_NO;
             ret = -1;
         }
     }
@@ -1089,7 +1088,6 @@ void *ebpf_shm_thread(void *ptr)
     ebpf_adjust_thread_load(em, default_btf);
 #endif
     if (ebpf_shm_load_bpf(em)) {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endshm;
     }
 

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -295,8 +295,6 @@ static void ebpf_shm_free(ebpf_module_t *em)
     em->thread->enabled = NETDATA_THREAD_EBPF_STOPPING;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
-    ebpf_cleanup_publish_syscall(shm_publish_aggregated);
-
     freez(shm_vector);
     freez(shm_values);
 

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -39,8 +39,6 @@ netdata_ebpf_targets_t shm_targets[] = { {.name = "shmget", .mode = EBPF_LOAD_TR
                                          {.name = NULL, .mode = EBPF_LOAD_TRAMPOLINE}};
 
 #ifdef LIBBPF_MAJOR_VERSION
-static struct shm_bpf *bpf_obj = NULL;
-
 /*****************************************************************
  *
  *  BTF FUNCTIONS
@@ -283,17 +281,8 @@ static inline int ebpf_shm_load_and_attach(struct shm_bpf *obj, ebpf_module_t *e
  */
 static void ebpf_shm_free(ebpf_module_t *em)
 {
-    pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
-    pthread_mutex_unlock(&ebpf_exit_cleanup);
-
     freez(shm_vector);
     freez(shm_values);
-
-#ifdef LIBBPF_MAJOR_VERSION
-    if (bpf_obj)
-        shm_bpf__destroy(bpf_obj);
-#endif
 
     pthread_mutex_lock(&ebpf_exit_cleanup);
     em->enabled = NETDATA_THREAD_EBPF_STOPPED;
@@ -1006,11 +995,11 @@ static int ebpf_shm_load_bpf(ebpf_module_t *em)
     }
 #ifdef LIBBPF_MAJOR_VERSION
     else {
-        bpf_obj = shm_bpf__open();
-        if (!bpf_obj)
+        shm_bpf_obj = shm_bpf__open();
+        if (!shm_bpf_obj)
             ret = -1;
         else
-            ret = ebpf_shm_load_and_attach(bpf_obj, em);
+            ret = ebpf_shm_load_and_attach(shm_bpf_obj, em);
     }
 #endif
 

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -45,8 +45,6 @@ netdata_ebpf_targets_t shm_targets[] = { {.name = "shmget", .mode = EBPF_LOAD_TR
                                          {.name = NULL, .mode = EBPF_LOAD_TRAMPOLINE}};
 
 #ifdef LIBBPF_MAJOR_VERSION
-#include "includes/shm.skel.h"
-
 static struct shm_bpf *bpf_obj = NULL;
 
 /*****************************************************************

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -3,10 +3,6 @@
 #include "ebpf.h"
 #include "ebpf_shm.h"
 
-// ----------------------------------------------------------------------------
-// ARAL vectors used to speed up processing
-ARAL *ebpf_aral_shm_pid = NULL;
-
 static char *shm_dimension_name[NETDATA_SHM_END] = { "get", "at", "dt", "ctl" };
 static netdata_syscall_stat_t shm_aggregated_data[NETDATA_SHM_END];
 static netdata_publish_syscall_t shm_publish_aggregated[NETDATA_SHM_END];
@@ -15,8 +11,6 @@ netdata_publish_shm_t *shm_vector = NULL;
 
 static netdata_idx_t shm_hash_values[NETDATA_SHM_END];
 static netdata_idx_t *shm_values = NULL;
-
-netdata_publish_shm_t **shm_pid = NULL;
 
 struct config shm_config = { .first_section = NULL,
     .last_section = NULL,
@@ -317,46 +311,6 @@ static void ebpf_shm_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
     ebpf_shm_free(em);
-}
-
-/*****************************************************************
- *
- *  ARAL FUNCTIONS
- *
- *****************************************************************/
-
-/**
- * eBPF shared memory Aral init
- *
- * Initiallize array allocator that will be used when integration with apps is enabled.
- */
-static inline void ebpf_shm_aral_init()
-{
-    ebpf_aral_shm_pid = ebpf_allocate_pid_aral(NETDATA_EBPF_SHM_ARAL_NAME, sizeof(netdata_publish_shm_t));
-}
-
-/**
- * eBPF shared memory get
- *
- * Get a netdata_publish_shm_t entry to be used with a specific PID.
- *
- * @return it returns the address on success.
- */
-netdata_publish_shm_t *ebpf_shm_stat_get(void)
-{
-    netdata_publish_shm_t *target = aral_mallocz(ebpf_aral_shm_pid);
-    memset(target, 0, sizeof(netdata_publish_shm_t));
-    return target;
-}
-
-/**
- * eBPF shared memory release
- *
- * @param stat Release a target after usage.
- */
-void ebpf_shm_release(netdata_publish_shm_t *stat)
-{
-    aral_freez(ebpf_aral_shm_pid, stat);
 }
 
 /*****************************************************************

--- a/collectors/ebpf.plugin/ebpf_shm.h
+++ b/collectors/ebpf.plugin/ebpf_shm.h
@@ -53,8 +53,6 @@ enum shm_counters {
     NETDATA_SHM_END
 };
 
-extern netdata_publish_shm_t **shm_pid;
-
 void *ebpf_shm_thread(void *ptr);
 void ebpf_shm_create_apps_charts(struct ebpf_module *em, void *ptr);
 void ebpf_shm_release(netdata_publish_shm_t *stat);

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -61,7 +61,6 @@ static netdata_idx_t *socket_hash_values = NULL;
 static netdata_syscall_stat_t socket_aggregated_data[NETDATA_MAX_SOCKET_VECTOR];
 static netdata_publish_syscall_t socket_publish_aggregated[NETDATA_MAX_SOCKET_VECTOR];
 
-ebpf_socket_publish_apps_t **socket_bandwidth_curr = NULL;
 static ebpf_bandwidth_t *bandwidth_vector = NULL;
 
 pthread_mutex_t nv_mutex;

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -585,10 +585,12 @@ static void clean_hostnames(ebpf_network_viewer_hostname_list_t *hostnames)
  */
 void ebpf_cleanup_publish_syscall(netdata_publish_syscall_t *nps)
 {
+    /*
     while (nps) {
         freez(nps->algorithm);
         nps = nps->next;
     }
+     */
 }
 
 /**

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -650,7 +650,6 @@ static void ebpf_socket_free(ebpf_module_t *em )
     clean_hostnames(network_viewer_opt.included_hostnames);
     clean_hostnames(network_viewer_opt.excluded_hostnames);
      */
-    ebpf_modules[EBPF_MODULE_SOCKET_IDX].enabled = 0;
 
     pthread_mutex_destroy(&nv_mutex);
 
@@ -3957,7 +3956,6 @@ void *ebpf_socket_thread(void *ptr)
     parse_table_size_options(&socket_config);
 
     if (pthread_mutex_init(&nv_mutex, NULL)) {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         error("Cannot initialize local mutex");
         goto endsocket;
     }
@@ -3980,7 +3978,6 @@ void *ebpf_socket_thread(void *ptr)
     ebpf_adjust_thread_load(em, default_btf);
 #endif
     if (ebpf_socket_load_bpf(em)) {
-        em->enabled = CONFIG_BOOLEAN_NO;
         pthread_mutex_unlock(&lock);
         goto endsocket;
     }

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -579,21 +579,6 @@ static void clean_hostnames(ebpf_network_viewer_hostname_list_t *hostnames)
 }
 
 /**
- * Cleanup publish syscall
- *
- * @param nps list of structures to clean
- */
-void ebpf_cleanup_publish_syscall(netdata_publish_syscall_t *nps)
-{
-    /*
-    while (nps) {
-        freez(nps->algorithm);
-        nps = nps->next;
-    }
-     */
-}
-
-/**
  * Clean port Structure
  *
  * Clean the allocated list.
@@ -650,7 +635,6 @@ static void ebpf_socket_free(ebpf_module_t *em )
     }
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
-    ebpf_cleanup_publish_syscall(socket_publish_aggregated);
     freez(socket_hash_values);
 
     freez(bandwidth_vector);

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -7,7 +7,6 @@
 
 // ----------------------------------------------------------------------------
 // ARAL vectors used to speed up processing
-ARAL *ebpf_aral_socket_pid = NULL;
 
 /*****************************************************************
  *
@@ -430,46 +429,6 @@ static inline int ebpf_socket_load_and_attach(struct socket_bpf *obj, ebpf_modul
     return ret;
 }
 #endif
-
-/*****************************************************************
- *
- *  ARAL FUNCTIONS
- *
- *****************************************************************/
-
-/**
- * eBPF socket Aral init
- *
- * Initiallize array allocator that will be used when integration with apps is enabled.
- */
-static inline void ebpf_socket_aral_init()
-{
-    ebpf_aral_socket_pid = ebpf_allocate_pid_aral(NETDATA_EBPF_SOCKET_ARAL_NAME, sizeof(ebpf_socket_publish_apps_t));
-}
-
-/**
- * eBPF socket get
- *
- * Get a ebpf_socket_publish_apps_t entry to be used with a specific PID.
- *
- * @return it returns the address on success.
- */
-ebpf_socket_publish_apps_t *ebpf_socket_stat_get(void)
-{
-    ebpf_socket_publish_apps_t *target = aral_mallocz(ebpf_aral_socket_pid);
-    memset(target, 0, sizeof(ebpf_socket_publish_apps_t));
-    return target;
-}
-
-/**
- * eBPF socket release
- *
- * @param stat Release a target after usage.
- */
-void ebpf_socket_release(ebpf_socket_publish_apps_t *stat)
-{
-    aral_freez(ebpf_aral_socket_pid, stat);
-}
 
 /*****************************************************************
  *

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -628,7 +628,7 @@ static void clean_ip_structure(ebpf_network_viewer_ip_list_t **clean)
 static void ebpf_socket_free(ebpf_module_t *em )
 {
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPING;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
     /* We can have thousands of sockets to clean, so we are transferring
@@ -662,7 +662,7 @@ static void ebpf_socket_free(ebpf_module_t *em )
 #endif
 
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -3957,7 +3957,7 @@ void *ebpf_socket_thread(void *ptr)
     parse_table_size_options(&socket_config);
 
     if (pthread_mutex_init(&nv_mutex, NULL)) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         error("Cannot initialize local mutex");
         goto endsocket;
     }

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -101,8 +101,6 @@ struct netdata_static_thread socket_threads = {
 };
 
 #ifdef LIBBPF_MAJOR_VERSION
-#include "includes/socket.skel.h" // BTF code
-
 static struct socket_bpf *bpf_obj = NULL;
 
 /**

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -2824,8 +2824,7 @@ void ebpf_socket_update_cgroup_algorithm()
     int i;
     for (i = 0; i < NETDATA_MAX_SOCKET_VECTOR; i++) {
         netdata_publish_syscall_t *ptr = &socket_publish_aggregated[i];
-        freez(ptr->algorithm);
-        ptr->algorithm = strdupz(ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
+        ptr->algorithm = ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX];
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf_socket.h
+++ b/collectors/ebpf.plugin/ebpf_socket.h
@@ -366,9 +366,7 @@ void update_listen_table(uint16_t value, uint16_t proto, netdata_passive_connect
 void parse_network_viewer_section(struct config *cfg);
 void ebpf_fill_ip_list(ebpf_network_viewer_ip_list_t **out, ebpf_network_viewer_ip_list_t *in, char *table);
 void parse_service_name_section(struct config *cfg);
-void ebpf_socket_release(ebpf_socket_publish_apps_t *stat);
 
-extern ebpf_socket_publish_apps_t **socket_bandwidth_curr;
 extern struct config socket_config;
 extern netdata_ebpf_targets_t socket_targets[];
 

--- a/collectors/ebpf.plugin/ebpf_softirq.c
+++ b/collectors/ebpf.plugin/ebpf_softirq.c
@@ -209,13 +209,11 @@ void *ebpf_softirq_thread(void *ptr)
     em->maps = softirq_maps;
 
     if (ebpf_enable_tracepoints(softirq_tracepoints) == 0) {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endsoftirq;
     }
 
     em->probe_links = ebpf_load_program(ebpf_plugin_dir, em, running_on_kernel, isrh, &em->objects);
     if (!em->probe_links) {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endsoftirq;
     }
 

--- a/collectors/ebpf.plugin/ebpf_softirq.c
+++ b/collectors/ebpf.plugin/ebpf_softirq.c
@@ -64,7 +64,7 @@ static softirq_ebpf_val_t *softirq_ebpf_vals = NULL;
 static void ebpf_softirq_free(ebpf_module_t *em)
 {
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPING;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
     for (int i = 0; softirq_tracepoints[i].class != NULL; i++) {
@@ -73,7 +73,7 @@ static void ebpf_softirq_free(ebpf_module_t *em)
     freez(softirq_ebpf_vals);
 
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -209,13 +209,13 @@ void *ebpf_softirq_thread(void *ptr)
     em->maps = softirq_maps;
 
     if (ebpf_enable_tracepoints(softirq_tracepoints) == 0) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endsoftirq;
     }
 
     em->probe_links = ebpf_load_program(ebpf_plugin_dir, em, running_on_kernel, isrh, &em->objects);
     if (!em->probe_links) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endsoftirq;
     }
 

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -225,7 +225,7 @@ static inline int ebpf_swap_load_and_attach(struct swap_bpf *obj, ebpf_module_t 
 static void ebpf_swap_free(ebpf_module_t *em)
 {
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPING;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
     freez(swap_vector);
@@ -236,7 +236,7 @@ static void ebpf_swap_free(ebpf_module_t *em)
         swap_bpf__destroy(bpf_obj);
 #endif
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -827,7 +827,7 @@ void *ebpf_swap_thread(void *ptr)
     ebpf_adjust_thread_load(em, default_btf);
 #endif
    if (ebpf_swap_load_bpf(em)) {
-       em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+       em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endswap;
     }
 

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -37,8 +37,6 @@ netdata_ebpf_targets_t swap_targets[] = { {.name = "swap_readpage", .mode = EBPF
                                            {.name = NULL, .mode = EBPF_LOAD_TRAMPOLINE}};
 
 #ifdef LIBBPF_MAJOR_VERSION
-static struct swap_bpf *bpf_obj = NULL;
-
 /**
  * Disable probe
  *
@@ -220,17 +218,9 @@ static inline int ebpf_swap_load_and_attach(struct swap_bpf *obj, ebpf_module_t 
  */
 static void ebpf_swap_free(ebpf_module_t *em)
 {
-    pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
-    pthread_mutex_unlock(&ebpf_exit_cleanup);
-
     freez(swap_vector);
     freez(swap_values);
 
-#ifdef LIBBPF_MAJOR_VERSION
-    if (bpf_obj)
-        swap_bpf__destroy(bpf_obj);
-#endif
     pthread_mutex_lock(&ebpf_exit_cleanup);
     em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -39,8 +39,6 @@ netdata_ebpf_targets_t swap_targets[] = { {.name = "swap_readpage", .mode = EBPF
                                            {.name = NULL, .mode = EBPF_LOAD_TRAMPOLINE}};
 
 #ifdef LIBBPF_MAJOR_VERSION
-#include "includes/swap.skel.h" // BTF code
-
 static struct swap_bpf *bpf_obj = NULL;
 
 /**

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -7,12 +7,10 @@ static char *swap_dimension_name[NETDATA_SWAP_END] = { "read", "write" };
 static netdata_syscall_stat_t swap_aggregated_data[NETDATA_SWAP_END];
 static netdata_publish_syscall_t swap_publish_aggregated[NETDATA_SWAP_END];
 
-netdata_publish_swap_t *swap_vector = NULL;
-
 static netdata_idx_t swap_hash_values[NETDATA_SWAP_END];
 static netdata_idx_t *swap_values = NULL;
 
-netdata_publish_swap_t **swap_pid = NULL;
+netdata_publish_swap_t *swap_vector = NULL;
 
 struct config swap_config = { .first_section = NULL,
     .last_section = NULL,

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -827,7 +827,6 @@ void *ebpf_swap_thread(void *ptr)
     ebpf_adjust_thread_load(em, default_btf);
 #endif
    if (ebpf_swap_load_bpf(em)) {
-       em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endswap;
     }
 

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -228,8 +228,6 @@ static void ebpf_swap_free(ebpf_module_t *em)
     em->thread->enabled = NETDATA_THREAD_EBPF_STOPPING;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
-    ebpf_cleanup_publish_syscall(swap_publish_aggregated);
-
     freez(swap_vector);
     freez(swap_values);
 

--- a/collectors/ebpf.plugin/ebpf_swap.h
+++ b/collectors/ebpf.plugin/ebpf_swap.h
@@ -42,8 +42,6 @@ enum swap_counters {
     NETDATA_SWAP_END
 };
 
-extern netdata_publish_swap_t **swap_pid;
-
 void *ebpf_swap_thread(void *ptr);
 void ebpf_swap_create_apps_charts(struct ebpf_module *em, void *ptr);
 

--- a/collectors/ebpf.plugin/ebpf_sync.c
+++ b/collectors/ebpf.plugin/ebpf_sync.c
@@ -204,10 +204,6 @@ void ebpf_sync_cleanup_objects()
  */
 static void ebpf_sync_free(ebpf_module_t *em)
 {
-    pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
-    pthread_mutex_unlock(&ebpf_exit_cleanup);
-
 #ifdef LIBBPF_MAJOR_VERSION
     ebpf_sync_cleanup_objects();
 #endif
@@ -523,7 +519,6 @@ void *ebpf_sync_thread(void *ptr)
     ebpf_adjust_thread_load(em, default_btf);
 #endif
     if (ebpf_sync_initialize_syscall(em)) {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endsync;
     }
 

--- a/collectors/ebpf.plugin/ebpf_sync.c
+++ b/collectors/ebpf.plugin/ebpf_sync.c
@@ -205,7 +205,7 @@ void ebpf_sync_cleanup_objects()
 static void ebpf_sync_free(ebpf_module_t *em)
 {
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPING;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
 #ifdef LIBBPF_MAJOR_VERSION
@@ -213,7 +213,7 @@ static void ebpf_sync_free(ebpf_module_t *em)
 #endif
 
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -523,7 +523,7 @@ void *ebpf_sync_thread(void *ptr)
     ebpf_adjust_thread_load(em, default_btf);
 #endif
     if (ebpf_sync_initialize_syscall(em)) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endsync;
     }
 

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -442,7 +442,7 @@ void ebpf_vfs_release(netdata_publish_vfs_t *stat)
 static void ebpf_vfs_free(ebpf_module_t *em)
 {
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPING;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 
     freez(vfs_hash_values);
@@ -454,7 +454,7 @@ static void ebpf_vfs_free(ebpf_module_t *em)
 #endif
 
     pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+    em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
 }
 
@@ -1946,7 +1946,7 @@ void *ebpf_vfs_thread(void *ptr)
     ebpf_adjust_thread_load(em, default_btf);
 #endif
     if (ebpf_vfs_load_bpf(em)) {
-        em->thread->enabled = NETDATA_THREAD_EBPF_STOPPED;
+        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endvfs;
     }
 

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -1946,7 +1946,6 @@ void *ebpf_vfs_thread(void *ptr)
     ebpf_adjust_thread_load(em, default_btf);
 #endif
     if (ebpf_vfs_load_bpf(em)) {
-        em->enabled = NETDATA_THREAD_EBPF_STOPPED;
         goto endvfs;
     }
 

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -50,8 +50,6 @@ netdata_ebpf_targets_t vfs_targets[] = { {.name = "vfs_write", .mode = EBPF_LOAD
                                          {.name = NULL, .mode = EBPF_LOAD_TRAMPOLINE}};
 
 #ifdef LIBBPF_MAJOR_VERSION
-#include "includes/vfs.skel.h" // BTF code
-
 static struct vfs_bpf *bpf_obj = NULL;
 
 /**

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -45,8 +45,6 @@ netdata_ebpf_targets_t vfs_targets[] = { {.name = "vfs_write", .mode = EBPF_LOAD
                                          {.name = NULL, .mode = EBPF_LOAD_TRAMPOLINE}};
 
 #ifdef LIBBPF_MAJOR_VERSION
-static struct vfs_bpf *bpf_obj = NULL;
-
 /**
  * Disable probe
  *
@@ -394,17 +392,8 @@ static inline int ebpf_vfs_load_and_attach(struct vfs_bpf *obj, ebpf_module_t *e
  */
 static void ebpf_vfs_free(ebpf_module_t *em)
 {
-    pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
-    pthread_mutex_unlock(&ebpf_exit_cleanup);
-
     freez(vfs_hash_values);
     freez(vfs_vector);
-
-#ifdef LIBBPF_MAJOR_VERSION
-    if (bpf_obj)
-        vfs_bpf__destroy(bpf_obj);
-#endif
 
     pthread_mutex_lock(&ebpf_exit_cleanup);
     em->enabled = NETDATA_THREAD_EBPF_STOPPED;
@@ -1864,11 +1853,11 @@ static int ebpf_vfs_load_bpf(ebpf_module_t *em)
     }
 #ifdef LIBBPF_MAJOR_VERSION
     else {
-        bpf_obj = vfs_bpf__open();
-        if (!bpf_obj)
+        vfs_bpf_obj = vfs_bpf__open();
+        if (!vfs_bpf_obj)
             ret = -1;
         else
-            ret = ebpf_vfs_load_and_attach(bpf_obj, em);
+            ret = ebpf_vfs_load_and_attach(vfs_bpf_obj, em);
     }
 #endif
 

--- a/collectors/ebpf.plugin/ebpf_vfs.h
+++ b/collectors/ebpf.plugin/ebpf_vfs.h
@@ -167,8 +167,6 @@ enum netdata_vfs_calls_name {
     NETDATA_VFS_END_LIST
 };
 
-extern netdata_publish_vfs_t **vfs_pid;
-
 void *ebpf_vfs_thread(void *ptr);
 void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr);
 void ebpf_vfs_release(netdata_publish_vfs_t *stat);

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -441,7 +441,7 @@ void ebpf_update_stats(ebpf_plugin_stats_t *report, ebpf_module_t *em)
     report->threads++;
 
     // It is not necessary to report more information.
-    if (!em->enabled)
+    if (em->enabled != NETDATA_THREAD_EBPF_RUNNING)
         return;
 
     report->running++;

--- a/libnetdata/ebpf/ebpf.h
+++ b/libnetdata/ebpf/ebpf.h
@@ -260,10 +260,17 @@ typedef enum netdata_apps_integration_flags {
 #define NETDATA_EBPF_STAT_DIMENSION_MEMORY "memory"
 #define NETDATA_EBPF_STAT_DIMENSION_ARAL "aral"
 
+enum ebpf_threads_status {
+    NETDATA_THREAD_EBPF_RUNNING,
+    NETDATA_THREAD_EBPF_STOPPING,
+    NETDATA_THREAD_EBPF_STOPPED,
+    NETDATA_THREAD_EBPF_NOT_RUNNING
+};
+
 typedef struct ebpf_module {
     const char *thread_name;
     const char *config_name;
-    int enabled;
+    enum ebpf_threads_status enabled;
     void *(*start_routine)(void *);
     int update_every;
     int global_charts;


### PR DESCRIPTION
##### Summary
Fixes https://github.com/netdata/netdata/issues/14892

This PR started with a goal to fix an issue on EC2 related to 100% CPU usage, but after to have access for a host with the issue it was possible to detect other issues and after stress system I am rewriting part of the code avoiding issues that were hidden on the specific environment.

This PR is also cleaning up some code simplifying internal algorithm.

The majority of the PR consists of code movement that helps to speed up plugin clean up process and it also avoids possible `SIGABRT` and `SIGSEGV`.
##### Test Plan

1. Compile PR
2. Take a look in CPU usage for eBPF.plugin
3. Verify if other threads are running as expected.

##### Additional Information
Next table shows difference collection results from the same VM where the issue was detected:

| Branch | Apps CPU usage | HardIRQ Latency | 
|------------|--------------------------|---------------------------|
|https://github.com/netdata/netdata/pull/14897 | [old_pr_cpu.txt](https://github.com/netdata/netdata/files/11223598/old_pr_cpu.txt) | Not necessary |
|This Branch |[new_pr_cpu.txt](https://github.com/netdata/netdata/files/11223606/new_pr_cpu.txt) | [hardirq.txt](https://github.com/netdata/netdata/files/11223607/hardirq.txt) |

To be sure we were not missing nothing, I also tested this PR on :

| Linux Distribution | Kernel Version | APPs CPU usage|
|----------------------------|-----------------------|-------------------------|
| Slackware current | 6.1.24 |[slackware_6_1_24.txt](https://github.com/netdata/netdata/files/11296499/slackware_6_1_24.txt)  |
| Arch Linux | 6.2.11 |[arch_6_2_11.txt](https://github.com/netdata/netdata/files/11296520/arch_6_2_11.txt)  | 
| Gentoo | 6.1.19 | [gentoo_6_1_19.txt](https://github.com/netdata/netdata/files/11255537/gentoo_6_1_19.txt) | 
| Ubuntu 22.04 | 5.15.0-1031-aws  | [ubuntu_ec2.txt](https://github.com/netdata/netdata/files/11255588/ubuntu_ec2.txt) |Ubuntu 22.04 | 5.15.0-56-generic | [ubuntu_5_15_0.txt](https://github.com/netdata/netdata/files/11298295/ubuntu_5_15_0.txt) | 
| Alma 9 | 5.14.0-162.23.1.el9_1.x86_64 | [alma9_5_14.txt](https://github.com/netdata/netdata/files/11257099/alma9_5_14.txt) |
|Debian 5.10 | 5.10.0-21-amd64 |[debian_5_10.txt](https://github.com/netdata/netdata/files/11299626/debian_5_10.txt) |
| Oracle 8.6 | 5.4.17-2136.318.7.1.el8uek.x86_64 |[oracle_5_4.txt](https://github.com/netdata/netdata/files/11299949/oracle_5_4.txt) |
| Alma 8 | 4.18.0-425.19.2.el8_7.x86_64 | [alma_4_18.txt](https://github.com/netdata/netdata/files/11300099/alma_4_18.txt) | 
| Ubuntu 18.04 | 4.15.0-204-generic|[ubuntu_4_15.txt](https://github.com/netdata/netdata/files/11301960/ubuntu_4_15.txt) |
| Slackware current | 4.14.290 | [slackware_4_14.txt](https://github.com/netdata/netdata/files/11302556/slackware_4_14.txt) |
| CentOS 3.10| 3.10.0-1160.71.1.el7.x86_64 | [centos_3_10.txt](https://github.com/netdata/netdata/files/11302667/centos_3_10.txt) |

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? ebpf.plugin
- Can they see the change or is it an under the hood? If they can see it, where? Only on distributions with eBPF having high CPU usage, after this PR it will have small cpu usage.
- How is the user impacted by the change?  A plugin with better performance
- What are there any benefits of the change? Netdata will use few resources
-->
</details>