### PR TITLE
Remove netdatacli response size limitation

### DIFF
--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -130,7 +130,7 @@ static cmd_status_t cmd_help_execute(char *args, char **message)
              "aclk-state [json]\n"
              "    Returns current state of ACLK and Cloud connection. (optionally in json).\n"
              "dumpconfig\n"
-             "    Returns the current netdata.conf\n"
+             "    Returns the current netdata.conf on stdout.\n"
              "version\n"
              "    Returns the netdata version.\n",
              MAX_COMMAND_LENGTH - 1);

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -47,6 +47,7 @@ static cmd_status_t cmd_write_config_execute(char *args, char **message);
 static cmd_status_t cmd_ping_execute(char *args, char **message);
 static cmd_status_t cmd_aclk_state(char *args, char **message);
 static cmd_status_t cmd_version(char *args, char **message);
+static cmd_status_t cmd_dumpconfig(char *args, char **message);
 
 static command_info_t command_info_array[] = {
         {"help", cmd_help_execute, CMD_TYPE_HIGH_PRIORITY},                  // show help menu
@@ -61,7 +62,8 @@ static command_info_t command_info_array[] = {
         {"write-config", cmd_write_config_execute, CMD_TYPE_ORTHOGONAL},
         {"ping", cmd_ping_execute, CMD_TYPE_ORTHOGONAL},
         {"aclk-state", cmd_aclk_state, CMD_TYPE_ORTHOGONAL},
-        {"version", cmd_version, CMD_TYPE_ORTHOGONAL}
+        {"version", cmd_version, CMD_TYPE_ORTHOGONAL},
+        {"dumpconfig", cmd_dumpconfig, CMD_TYPE_ORTHOGONAL}
 };
 
 /* Mutexes for commands of type CMD_TYPE_ORTHOGONAL */
@@ -127,6 +129,8 @@ static cmd_status_t cmd_help_execute(char *args, char **message)
              "    Return with 'pong' if agent is alive.\n"
              "aclk-state [json]\n"
              "    Returns current state of ACLK and Cloud connection. (optionally in json).\n"
+             "dumpconfig\n"
+             "    Returns the current netdata.conf\n"
              "version\n"
              "    Returns the netdata version.\n",
              MAX_COMMAND_LENGTH - 1);
@@ -327,6 +331,17 @@ static cmd_status_t cmd_version(char *args, char **message)
 
     *message = strdupz(version);
 
+    return CMD_STATUS_SUCCESS;
+}
+
+static cmd_status_t cmd_dumpconfig(char *args, char **message)
+{
+    (void)args;
+
+    BUFFER *wb = buffer_create(1024, NULL);
+    config_generate(wb, 0);
+    *message = strdupz(buffer_tostring(wb));
+    buffer_free(wb);
     return CMD_STATUS_SUCCESS;
 }
 

--- a/daemon/commands.h
+++ b/daemon/commands.h
@@ -26,7 +26,7 @@ typedef enum cmd {
     CMD_PING,
     CMD_ACLK_STATE,
     CMD_VERSION,
-    CMND_DUMPCONFIG,
+    CMD_DUMPCONFIG,
     CMD_TOTAL_COMMANDS
 } cmd_t;
 

--- a/daemon/commands.h
+++ b/daemon/commands.h
@@ -26,6 +26,7 @@ typedef enum cmd {
     CMD_PING,
     CMD_ACLK_STATE,
     CMD_VERSION,
+    CMND_DUMPCONFIG,
     CMD_TOTAL_COMMANDS
 } cmd_t;
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1435,6 +1435,15 @@ int main(int argc, char **argv) {
                             sql_init_database(DB_CHECK_INTEGRITY, 0);
                             return 0;
                         }
+                        if(strcmp(optarg, "dumpconfig") == 0) {
+                            BUFFER *wb = buffer_create(1024, NULL);
+                            load_netdata_conf(NULL, 0);
+                            post_conf_load(&user);
+                            config_generate(wb, 0);
+                            fprintf(stdout, "%s",buffer_tostring(wb));
+                            buffer_free(wb);
+                            return 0;
+                        }
 
                         if(strcmp(optarg, "sqlite-fix") == 0) {
                             sql_init_database(DB_CHECK_FIX_DB, 0);

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1435,15 +1435,6 @@ int main(int argc, char **argv) {
                             sql_init_database(DB_CHECK_INTEGRITY, 0);
                             return 0;
                         }
-                        if(strcmp(optarg, "dumpconfig") == 0) {
-                            BUFFER *wb = buffer_create(1024, NULL);
-                            load_netdata_conf(NULL, 0);
-                            post_conf_load(&user);
-                            config_generate(wb, 0);
-                            fprintf(stdout, "%s",buffer_tostring(wb));
-                            buffer_free(wb);
-                            return 0;
-                        }
 
                         if(strcmp(optarg, "sqlite-fix") == 0) {
                             sql_init_database(DB_CHECK_FIX_DB, 0);

--- a/libnetdata/buffer/buffer.h
+++ b/libnetdata/buffer/buffer.h
@@ -152,6 +152,35 @@ static inline void _buffer_json_depth_pop(BUFFER *wb) {
     wb->json.depth--;
 }
 
+static inline void buffer_fast_charcat(BUFFER *wb, const char c) {
+
+    buffer_need_bytes(wb, 2);
+    *(&wb->buffer[wb->len]) = c;
+    wb->len += 1;
+    wb->buffer[wb->len] = '\0';
+
+    buffer_overflow_check(wb);
+}
+
+static inline void buffer_fast_rawcat(BUFFER *wb, const char *txt, size_t len) {
+    if(unlikely(!txt || !*txt || !len)) return;
+
+    buffer_need_bytes(wb, len + 1);
+
+    const char *t = txt;
+    const char *e = &txt[len];
+
+    char *d = &wb->buffer[wb->len];
+
+    while(t != e)
+        *d++ = *t++;
+
+    wb->len += len;
+    wb->buffer[wb->len] = '\0';
+
+    buffer_overflow_check(wb);
+}
+
 static inline void buffer_fast_strcat(BUFFER *wb, const char *txt, size_t len) {
     if(unlikely(!txt || !*txt || !len)) return;
 


### PR DESCRIPTION
##### Summary

- Removes the 4K char response size limitation
- Add a `netdatacli dumpconfig` command to get the current `netdata.conf`

Fixes #14755
