### PR TITLE
Initialize machine GUID earlier in the agent startup sequence

### DIFF
--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -354,16 +354,16 @@ void analytics_alarms_notifications(void)
     buffer_free(b);
 }
 
-void analytics_get_install_type(void)
+static void analytics_get_install_type(struct rrdhost_system_info *system_info)
 {
-    if (localhost->system_info->install_type == NULL) {
+    if (system_info->install_type == NULL) {
         analytics_set_data_str(&analytics_data.netdata_install_type, "unknown");
     } else {
-        analytics_set_data_str(&analytics_data.netdata_install_type, localhost->system_info->install_type);
+        analytics_set_data_str(&analytics_data.netdata_install_type, system_info->install_type);
     }
 
-    if (localhost->system_info->prebuilt_dist != NULL) {
-        analytics_set_data_str(&analytics_data.netdata_prebuilt_distro, localhost->system_info->prebuilt_dist);
+    if (system_info->prebuilt_dist != NULL) {
+        analytics_set_data_str(&analytics_data.netdata_prebuilt_distro, system_info->prebuilt_dist);
     }
 }
 
@@ -632,7 +632,7 @@ static const char *verify_required_directory(const char *dir)
  * This is called after the rrdinit
  * These values will be sent on the START event
  */
-void set_late_global_environment()
+void set_late_global_environment(struct rrdhost_system_info *system_info)
 {
     analytics_set_data(&analytics_data.netdata_config_stream_enabled, default_rrdpush_enabled ? "true" : "false");
     analytics_set_data_str(&analytics_data.netdata_config_memory_mode, (char *)rrd_memory_mode_name(default_rrd_memory_mode));
@@ -676,7 +676,7 @@ void set_late_global_environment()
         buffer_free(bi);
     }
 
-    analytics_get_install_type();
+    analytics_get_install_type(system_info);
 }
 
 void get_system_timezone(void)

--- a/daemon/analytics.h
+++ b/daemon/analytics.h
@@ -74,7 +74,7 @@ struct analytics_data {
     bool exporting_enabled;
 };
 
-void set_late_global_environment(void);
+void set_late_global_environment(struct rrdhost_system_info *system_info);
 void analytics_free_data(void);
 void set_global_environment(void);
 void send_statistics(const char *action, const char *action_result, const char *action_data);

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -2025,6 +2025,7 @@ int main(int argc, char **argv) {
     struct rrdhost_system_info *system_info = callocz(1, sizeof(struct rrdhost_system_info));
     __atomic_sub_fetch(&netdata_buffers_statistics.rrdhost_allocations_size, sizeof(struct rrdhost_system_info), __ATOMIC_RELAXED);
     get_system_info(system_info);
+    (void) registry_get_this_machine_guid();
     system_info->hops = 0;
     get_install_type(&system_info->install_type, &system_info->prebuilt_arch, &system_info->prebuilt_dist);
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -2031,8 +2031,10 @@ int main(int argc, char **argv) {
 
     delta_startup_time("initialize RRD structures");
 
-    if(rrd_init(netdata_configured_hostname, system_info, false))
+    if(rrd_init(netdata_configured_hostname, system_info, false)) {
+        set_late_global_environment(system_info);
         fatal("Cannot initialize localhost instance with name '%s'.", netdata_configured_hostname);
+    }
 
     delta_startup_time("check for incomplete shutdown");
 
@@ -2074,8 +2076,7 @@ int main(int argc, char **argv) {
 
     netdata_zero_metrics_enabled = config_get_boolean_ondemand(CONFIG_SECTION_DB, "enable zero metrics", CONFIG_BOOLEAN_NO);
 
-    set_late_global_environment();
-
+    set_late_global_environment(system_info);
     for (i = 0; static_threads[i].name != NULL ; i++) {
         struct netdata_static_thread *st = &static_threads[i];
 

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -921,8 +921,10 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
     rrdhost_init();
 
     if (unlikely(sql_init_database(DB_CHECK_NONE, system_info ? 0 : 1))) {
-        if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
+        if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
+            set_late_global_environment(system_info);
             fatal("Failed to initialize SQLite");
+        }
         info("Skipping SQLITE metadata initialization since memory mode is not dbengine");
     }
 


### PR DESCRIPTION
##### Summary
If the agent fails to initialize before the localhost is created, the machine GUID remains uninitialized and ends up as 
`0000000`s in the collected statistics. This PR allows for proper distinct count of agents that fail to initialize. 
