### PR TITLE
Add Docker instructions to enable Nvidia GPUs

### DIFF
--- a/collectors/python.d.plugin/nvidia_smi/README.md
+++ b/collectors/python.d.plugin/nvidia_smi/README.md
@@ -148,7 +148,7 @@ docker run -d --name=netdata \
   netdata/netdata
 ```
 
-### Troubleshooting
+### Docker Troubleshooting
 To troubleshoot `nvidia-smi` in a docker container, first confirm that `nvidia-smi` is working on the host system. If that is working correctly, run `docker exec -it netdata nvidia-smi` to confirm it's working within the docker container. If `nvidia-smi` is fuctioning both inside and outside of the container, confirm that `nvidia-smi: yes` is uncommented in `python.d.conf`.
 ```bash
 docker exec -it netdata bash

--- a/collectors/python.d.plugin/nvidia_smi/README.md
+++ b/collectors/python.d.plugin/nvidia_smi/README.md
@@ -11,9 +11,6 @@ learn_rel_path: "Integrations/Monitor/Devices"
 
 Monitors performance metrics (memory usage, fan speed, pcie bandwidth utilization, temperature, etc.) using `nvidia-smi` cli tool.
 
-> **Warning**: this collector does not work when the Netdata Agent is [running in a container](https://github.com/netdata/netdata/blob/master/packaging/docker/README.md).
-
-
 ## Requirements and Notes
 
 -   You must have the `nvidia-smi` tool installed and your NVIDIA GPU(s) must support the tool. Mostly the newer high end models used for AI / ML and Crypto or Pro range, read more about [nvidia_smi](https://developer.nvidia.com/nvidia-system-management-interface).
@@ -87,3 +84,74 @@ Now you can manually run the `nvidia_smi` module in debug mode:
 ./python.d.plugin nvidia_smi debug trace
 ```
 
+## Docker
+
+GPU monitoring in a docker container is possible with [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) installed on the host system, and `gcompat` added to the `NETDATA_EXTRA_APK_PACKAGES` environment variable.
+
+Sample `docker-compose.yml`
+```yaml
+version: '3'
+services:
+  netdata:
+    image: netdata/netdata
+    container_name: netdata
+    hostname: example.com # set to fqdn of host
+    ports:
+      - 19999:19999
+    restart: unless-stopped
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - apparmor:unconfined
+    environment:
+      - NETDATA_EXTRA_APK_PACKAGES=gcompat
+    volumes:
+      - netdataconfig:/etc/netdata
+      - netdatalib:/var/lib/netdata
+      - netdatacache:/var/cache/netdata
+      - /etc/passwd:/host/etc/passwd:ro
+      - /etc/group:/host/etc/group:ro
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /etc/os-release:/host/etc/os-release:ro
+    deploy:
+      resources:
+        reservations:
+          devices:
+          - driver: nvidia
+            count: all
+            capabilities: [gpu]
+
+volumes:
+  netdataconfig:
+  netdatalib:
+  netdatacache:
+```
+
+Sample `docker run`
+```yaml
+docker run -d --name=netdata \
+  -p 19999:19999 \
+  -e NETDATA_EXTRA_APK_PACKAGES=gcompat \
+  -v netdataconfig:/etc/netdata \
+  -v netdatalib:/var/lib/netdata \
+  -v netdatacache:/var/cache/netdata \
+  -v /etc/passwd:/host/etc/passwd:ro \
+  -v /etc/group:/host/etc/group:ro \
+  -v /proc:/host/proc:ro \
+  -v /sys:/host/sys:ro \
+  -v /etc/os-release:/host/etc/os-release:ro \
+  --restart unless-stopped \
+  --cap-add SYS_PTRACE \
+  --security-opt apparmor=unconfined \
+  --gpus all \
+  netdata/netdata
+```
+
+### Troubleshooting
+To troubleshoot `nvidia-smi` in a docker container, first confirm that `nvidia-smi` is working on the host system. If that is working correctly, run `docker exec -it netdata nvidia-smi` to confirm it's working within the docker container. If `nvidia-smi` is fuctioning both inside and outside of the container, confirm that `nvidia-smi: yes` is uncommented in `python.d.conf`.
+```bash
+docker exec -it netdata bash
+cd /etc/netdata
+./edit-config python.d.conf
+```


### PR DESCRIPTION
##### Summary
These instructions allow for Nvidia GPU monitoring inside of a docker container. The `gcompat` apk adds a glibc library for binaries linked against glibc, like Nvidia drivers, which don't natively work with musl distributions like Alpine. 

Fixes #4736 

##### Test Plan
I have tested this on x86_x64 using `netdata/netdata:latest` but I don't have access to any other architectures with an Nvidia GPU. If anyone with other architectures and Nvidia GPUs could test these configs, it would be appreciated.

##### Additional Information
The use of Alpine as a Netdata docker base creates a problem for users wanting to monitor Nvidia GPUs in a container. Nvidia drivers and binaries like `nvidia-smi` require glibc. These instructions show how to add `gcompat` to a netdata docker container, and the standard way to add a GPU to a docker containers according to docker documentation.

<details> <summary>For users: How does this change affect me?</summary>
- Allows the monitoring of Nvidia GPUs within a docker container
- Updates documentation to share working configs
- No changes to Netdata itself are required for this to work
- Only docker users with Nvidia GPUs would adapt their configs
</details>
