### PR TITLE
zfspool: add suspended state

### DIFF
--- a/collectors/proc.plugin/proc_spl_kstat_zfs.c
+++ b/collectors/proc.plugin/proc_spl_kstat_zfs.c
@@ -369,6 +369,7 @@ int do_proc_spl_kstat_zfs_pool_state(int update_every, usec_t dt)
                 pool->offline = 0;
                 pool->removed = 0;
                 pool->unavail = 0;
+                pool->suspended = 0;
 
                 char filename[FILENAME_MAX + 1];
                 snprintfz(filename, FILENAME_MAX, "%s/%s/state", dirname, de->d_name);

--- a/collectors/proc.plugin/proc_spl_kstat_zfs.c
+++ b/collectors/proc.plugin/proc_spl_kstat_zfs.c
@@ -216,6 +216,7 @@ struct zfs_pool {
     RRDDIM *rd_offline;
     RRDDIM *rd_removed;
     RRDDIM *rd_unavail;
+    RRDDIM *rd_suspended;
 
     int updated;
     int disabled;
@@ -226,6 +227,7 @@ struct zfs_pool {
     int offline;
     int removed;
     int unavail;
+    int suspended;
 };
 
 struct deleted_zfs_pool {
@@ -248,6 +250,7 @@ void disable_zfs_pool_state(struct zfs_pool *pool)
     pool->rd_offline = NULL;
     pool->rd_removed = NULL;
     pool->rd_unavail = NULL;
+    pool->rd_suspended = NULL;
 
     pool->disabled = 1;
 }
@@ -285,6 +288,7 @@ int update_zfs_pool_state_chart(const DICTIONARY_ITEM *item, void *pool_p, void 
                 pool->rd_offline = rrddim_add(pool->st, "offline", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
                 pool->rd_removed = rrddim_add(pool->st, "removed", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
                 pool->rd_unavail = rrddim_add(pool->st, "unavail", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+                pool->rd_suspended = rrddim_add(pool->st, "suspended", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
 
                 rrdlabels_add(pool->st->rrdlabels, "pool", name, RRDLABEL_SRC_AUTO);
             }
@@ -295,6 +299,7 @@ int update_zfs_pool_state_chart(const DICTIONARY_ITEM *item, void *pool_p, void 
             rrddim_set_by_pointer(pool->st, pool->rd_offline, pool->offline);
             rrddim_set_by_pointer(pool->st, pool->rd_removed, pool->removed);
             rrddim_set_by_pointer(pool->st, pool->rd_unavail, pool->unavail);
+            rrddim_set_by_pointer(pool->st, pool->rd_suspended, pool->suspended);
             rrdset_done(pool->st);
         }
     } else {
@@ -387,6 +392,8 @@ int do_proc_spl_kstat_zfs_pool_state(int update_every, usec_t dt)
                         pool->removed = 1;
                     } else if (!strcmp(state, "UNAVAIL\n")) {
                         pool->unavail = 1;
+                    } else if (!strcmp(state, "SUSPENDED\n")) {
+                        pool->suspended = 1;
                     } else {
                         disable_zfs_pool_state(pool);
 


### PR DESCRIPTION
##### Summary

This PR adds the missing ZFS pool state (suspended), somehow we missed it. It was added in https://github.com/openzfs/zfs/commit/f0ed6c744872ec6dc4838947ffc597f4d141864a.

##### Test Plan

Test on a system with ZFS

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
