### PR TITLE
Remove Fedora 36 from CI and platform support.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -164,13 +164,6 @@ include:
       repo_distro: fedora/37
     test:
       ebpf-core: true
-  - <<: *fedora
-    version: "36"
-    packages:
-      <<: *fedora_packages
-      repo_distro: fedora/36
-    test:
-      ebpf-core: true
 
   - &opensuse
     distro: opensuse

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -68,7 +68,6 @@ to work on these platforms with minimal user effort.
 | Debian                   | 10.x           | x86\_64, i386, ARMv7, AArch64          |                                                                                                                                                    |
 | Fedora                   | 38             | x86\_64, AArch64                       |                                                                                                                                                    |
 | Fedora                   | 37             | x86\_64, AArch64                       |                                                                                                                                                    |
-| Fedora                   | 36             | x86\_64, AArch64                       |                                                                                                                                                    |
 | openSUSE                 | Leap 15.4      | x86\_64, AArch64                       |                                                                                                                                                    |
 | Oracle Linux             | 9.x            | x86\_64, AArch64                       |                                                                                                                                                    |
 | Oracle Linux             | 8.x            | x86\_64, AArch64                       |                                                                                                                                                    |
@@ -158,13 +157,11 @@ This is a list of platforms that we have supported in the recent past but no lon
 | Platform     | Version   | Notes                |
 |--------------|-----------|----------------------|
 | Alpine Linux | 3.13      | EOL as of 2022-11-01 |
-| Alpine Linux | 3.12      | EOL as of 2022-05-01 |
 | Debian       | 9.x       | EOL as of 2022-06-30 |
+| Fedora       | 36        | EOL as of 2023-05-18 |
 | Fedora       | 35        | EOL as of 2022-12-13 |
-| Fedora       | 34        | EOL as of 2022-06-07 |
 | openSUSE     | Leap 15.3 | EOL as of 2022-12-01 |
 | Ubuntu       | 21.10     | EOL as of 2022-07-31 |
-| Ubuntu       | 21.04     | EOL as of 2022-01-01 |
 | Ubuntu       | 18.04     | EOL as of 2023-04-02 |
 
 ## Static builds


### PR DESCRIPTION
##### Summary

It goes EOL upstream on 2023-05-18.

##### Test Plan

n/a

##### Additional Information

First part of: https://github.com/netdata/netdata/issues/14911