### PR TITLE
Add support for acquire/release operations on RRDSETs

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1368,6 +1368,11 @@ void rrdset_update_heterogeneous_flag(RRDSET *st);
 time_t rrdset_set_update_every_s(RRDSET *st, time_t update_every_s);
 
 RRDSET *rrdset_find(RRDHOST *host, const char *id);
+
+RRDSET_ACQUIRED *rrdset_find_and_acquire(RRDHOST *host, const char *id);
+RRDSET *rrdset_acquired_to_rrdset(RRDSET_ACQUIRED *rsa);
+void rrdset_acquired_release(RRDSET_ACQUIRED *rsa);
+
 #define rrdset_find_localhost(id) rrdset_find(localhost, id)
 /* This will not return charts that are archived */
 static inline RRDSET *rrdset_find_active_localhost(const char *id)

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1260,6 +1260,10 @@ extern RRDHOST *localhost;
 extern DICTIONARY *rrdhost_root_index;
 size_t rrdhost_hosts_available(void);
 
+RRDHOST_ACQUIRED *rrdhost_find_and_acquire(const char *machine_guid);
+RRDHOST *rrdhost_acquired_to_rrdhost(RRDHOST_ACQUIRED *rha);
+void rrdhost_acquired_release(RRDHOST_ACQUIRED *rha);
+
 // ----------------------------------------------------------------------------
 
 #define rrdhost_foreach_read(var) \

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -320,7 +320,7 @@ inline RRDDIM *rrddim_find(RRDSET *st, const char *id) {
 }
 
 inline RRDDIM_ACQUIRED *rrddim_find_and_acquire(RRDSET *st, const char *id) {
-    debug(D_RRD_CALLS, "rrddim_find() for chart %s, dimension %s", rrdset_name(st), id);
+    debug(D_RRD_CALLS, "rrddim_find_and_acquire() for chart %s, dimension %s", rrdset_name(st), id);
 
     return (RRDDIM_ACQUIRED *)dictionary_get_and_acquire_item(st->rrddim_root_index, id);
 }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -78,6 +78,26 @@ static inline void rrdhost_init() {
     }
 }
 
+RRDHOST_ACQUIRED *rrdhost_find_and_acquire(const char *machine_guid) {
+    debug(D_RRD_CALLS, "rrdhost_find_and_acquire() host %s", id);
+
+    return (RRDHOST_ACQUIRED *)dictionary_get_and_acquire_item(rrdhost_root_index, machine_guid);
+}
+
+RRDHOST *rrdhost_acquired_to_rrdhost(RRDHOST_ACQUIRED *rha) {
+    if(unlikely(!rha))
+        return NULL;
+
+    return (RRDHOST *) dictionary_acquired_item_value((const DICTIONARY_ITEM *)rha);
+}
+
+void rrdhost_acquired_release(RRDHOST_ACQUIRED *rha) {
+    if(unlikely(!rha))
+        return;
+
+    dictionary_acquired_item_release(rrdhost_root_index, (const DICTIONARY_ITEM *)rha);
+}
+
 // ----------------------------------------------------------------------------
 // RRDHOST index by UUID
 

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -79,7 +79,7 @@ static inline void rrdhost_init() {
 }
 
 RRDHOST_ACQUIRED *rrdhost_find_and_acquire(const char *machine_guid) {
-    debug(D_RRD_CALLS, "rrdhost_find_and_acquire() host %s", id);
+    debug(D_RRD_CALLS, "rrdhost_find_and_acquire() host %s", machine_guid);
 
     return (RRDHOST_ACQUIRED *)dictionary_get_and_acquire_item(rrdhost_root_index, machine_guid);
 }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -480,7 +480,7 @@ inline RRDSET *rrdset_find_byname(RRDHOST *host, const char *name) {
 }
 
 RRDSET_ACQUIRED *rrdset_find_and_acquire(RRDHOST *host, const char *id) {
-    debug(D_RRD_CALLS, "rrddim_find_and_acquire() for host %s, chart %s", rrdhost_name(host), id);
+    debug(D_RRD_CALLS, "rrdset_find_and_acquire() for host %s, chart %s", rrdhost_name(host), id);
 
     return (RRDSET_ACQUIRED *)dictionary_get_and_acquire_item(host->rrdset_root_index, id);
 }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -480,7 +480,7 @@ inline RRDSET *rrdset_find_byname(RRDHOST *host, const char *name) {
 }
 
 RRDSET_ACQUIRED *rrdset_find_and_acquire(RRDHOST *host, const char *id) {
-    debug(D_RRD_CALLS, "rrdset_find_and_acquire() for host %s, chart %s", rrdhost_name(host), id);
+    debug(D_RRD_CALLS, "rrdset_find_and_acquire() for host %s, chart %s", rrdhost_hostname(host), id);
 
     return (RRDSET_ACQUIRED *)dictionary_get_and_acquire_item(host->rrdset_root_index, id);
 }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -479,6 +479,27 @@ inline RRDSET *rrdset_find_byname(RRDHOST *host, const char *name) {
     return(st);
 }
 
+RRDSET_ACQUIRED *rrdset_find_and_acquire(RRDHOST *host, const char *id) {
+    debug(D_RRD_CALLS, "rrddim_find_and_acquire() for host %s, chart %s", rrdhost_name(host), id);
+
+    return (RRDSET_ACQUIRED *)dictionary_get_and_acquire_item(host->rrdset_root_index, id);
+}
+
+RRDSET *rrdset_acquired_to_rrdset(RRDSET_ACQUIRED *rsa) {
+    if(unlikely(!rsa))
+        return NULL;
+
+    return (RRDSET *) dictionary_acquired_item_value((const DICTIONARY_ITEM *)rsa);
+}
+
+void rrdset_acquired_release(RRDSET_ACQUIRED *rsa) {
+    if(unlikely(!rsa))
+        return;
+
+    RRDSET *rs = rrdset_acquired_to_rrdset(rsa);
+    dictionary_acquired_item_release(rs->rrdhost->rrdset_root_index, (const DICTIONARY_ITEM *)rsa);
+}
+
 // ----------------------------------------------------------------------------
 // RRDSET - rename charts
 

--- a/ml/ml-private.h
+++ b/ml/ml-private.h
@@ -124,7 +124,7 @@ enum ml_training_result {
 
 typedef struct {
     // Chart/dimension we want to train
-    STRING *host_id;
+    char machine_guid[GUID_LEN + 1];
     STRING *chart_id;
     STRING *dimension_id;
 

--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -268,7 +268,7 @@ ml_queue_pop(ml_queue_t *q)
     netdata_mutex_lock(&q->mutex);
 
     ml_training_request_t req = {
-        NULL, // host_id
+        {'\0'}, // machine_guid
         NULL, // chart id
         NULL, // dimension id
         0, // current time
@@ -783,14 +783,14 @@ ml_dimension_schedule_for_training(ml_dimension_t *dim, time_t curr_time)
     }
 
     if (schedule_for_training) {
-        ml_training_request_t req = {
-            string_dup(dim->rd->rrdset->rrdhost->hostname),
-            string_dup(dim->rd->rrdset->id),
-            string_dup(dim->rd->id),
-            curr_time,
-            rrddim_first_entry_s(dim->rd),
-            rrddim_last_entry_s(dim->rd),
-        };
+        ml_training_request_t req;
+
+        memcpy(req.machine_guid, dim->rd->rrdset->rrdhost->machine_guid, GUID_LEN + 1);
+        req.chart_id = string_dup(dim->rd->rrdset->id);
+        req.dimension_id = string_dup(dim->rd->id);
+        req.request_time = curr_time;
+        req.first_entry_on_request = rrddim_first_entry_s(dim->rd);
+        req.last_entry_on_request = rrddim_last_entry_s(dim->rd);
 
         ml_host_t *host = (ml_host_t *) dim->rd->rrdset->rrdhost->ml_host;
         ml_queue_push(host->training_queue, req);
@@ -1022,36 +1022,45 @@ ml_host_detect_once(ml_host_t *host)
 }
 
 typedef struct {
+    RRDHOST_ACQUIRED *acq_rh;
     RRDSET_ACQUIRED *acq_rs;
     RRDDIM_ACQUIRED *acq_rd;
     ml_dimension_t *dim;
 } ml_acquired_dimension_t;
 
 static ml_acquired_dimension_t
-ml_acquired_dimension_get(STRING *host_id, STRING *chart_id, STRING *dimension_id)
+ml_acquired_dimension_get(char *machine_guid, STRING *chart_id, STRING *dimension_id)
 {
+    RRDHOST_ACQUIRED *acq_rh = NULL;
     RRDSET_ACQUIRED *acq_rs = NULL;
     RRDDIM_ACQUIRED *acq_rd = NULL;
     ml_dimension_t *dim = NULL;
 
-    RRDHOST *rh = rrdhost_find_by_hostname(string2str(host_id));
-    if (rh) {
-        acq_rs = rrdset_find_and_acquire(rh, string2str(chart_id));
-        if (acq_rs) {
-            RRDSET *rs = rrdset_acquired_to_rrdset(acq_rs);
-            if (rs) {
-                acq_rd = rrddim_find_and_acquire(rs, string2str(dimension_id));
-                if (acq_rd) {
-                    RRDDIM *rd = rrddim_acquired_to_rrddim(acq_rd);
-                    if (rd)
-                        dim = (ml_dimension_t *) rd->ml_dimension;
+    rrd_rdlock();
+
+    acq_rh = rrdhost_find_and_acquire(machine_guid);
+    if (acq_rh) {
+        RRDHOST *rh = rrdhost_acquired_to_rrdhost(acq_rh);
+        if (rh && !rrdhost_flag_check(rh, RRDHOST_FLAG_ORPHAN | RRDHOST_FLAG_ARCHIVED)) {
+            acq_rs = rrdset_find_and_acquire(rh, string2str(chart_id));
+            if (acq_rs) {
+                RRDSET *rs = rrdset_acquired_to_rrdset(acq_rs);
+                if (rs && !rrdset_flag_check(rs, RRDSET_FLAG_ARCHIVED | RRDSET_FLAG_OBSOLETE)) {
+                    acq_rd = rrddim_find_and_acquire(rs, string2str(dimension_id));
+                    if (acq_rd) {
+                        RRDDIM *rd = rrddim_acquired_to_rrddim(acq_rd);
+                        if (rd)
+                            dim = (ml_dimension_t *) rd->ml_dimension;
+                    }
                 }
             }
         }
     }
 
+    rrd_unlock();
+
     ml_acquired_dimension_t acq_dim = {
-        acq_rs, acq_rd, dim
+        acq_rh, acq_rs, acq_rd, dim
     };
 
     return acq_dim;
@@ -1065,6 +1074,9 @@ ml_acquired_dimension_release(ml_acquired_dimension_t acq_dim)
 
     if (acq_dim.acq_rs)
         rrdset_acquired_release(acq_dim.acq_rs);
+
+    if (acq_dim.acq_rh)
+        rrdhost_acquired_release(acq_dim.acq_rh);
 }
 
 static enum ml_training_result
@@ -1391,7 +1403,7 @@ static void *ml_train_main(void *arg) {
 
         // we know this thread has been cancelled, when the queue starts
         // returning "null" requests without blocking on queue's pop().
-        if (training_req.host_id == NULL)
+        if (training_req.chart_id == NULL)
             break;
 
         size_t queue_size = ml_queue_size(training_thread->training_queue) + 1;
@@ -1406,13 +1418,12 @@ static void *ml_train_main(void *arg) {
         {
             worker_is_busy(WORKER_TRAIN_ACQUIRE_DIMENSION);
             ml_acquired_dimension_t acq_dim = ml_acquired_dimension_get(
-                training_req.host_id,
+                training_req.machine_guid,
                 training_req.chart_id,
                 training_req.dimension_id);
 
             training_res = ml_acquired_dimension_train(training_thread, acq_dim, training_req);
 
-            string_freez(training_req.host_id);
             string_freez(training_req.chart_id);
             string_freez(training_req.dimension_id);
 


### PR DESCRIPTION
##### Summary

- Adds support for acquiring/releasing RRDHOSTs and RRDSETs,
- Uses aforementioned functionality in ML,
- Skip training requests from obsolete/archived hosts & charts.

Fixes a non-deterministic crash that would occur when child agents
disconnected from a parent with a low cleanup threshold.

##### Test Plan

- CI jobs.

Fixes #14941