### PR TITLE
Address log issue

### DIFF
--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -606,9 +606,7 @@ void open_all_log_files() {
     open_log_file(STDOUT_FILENO, stdout, stdout_filename, &output_log_syslog, 0, NULL);
     open_log_file(STDERR_FILENO, stderr, stdcollector_filename, &collector_log_syslog, 0, NULL);
 
-    log_lock();
     stderror = open_log_file(stdcollector_fd, NULL, stderr_filename, &error_log_syslog, 1, &stdcollector_fd);
-    log_unlock();
 
 #ifdef ENABLE_ACLK
     if(aclklog_enabled)

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -582,9 +582,7 @@ void reopen_all_log_files() {
         open_log_file(STDERR_FILENO, stderr, stdcollector_filename, &collector_log_syslog, 0, NULL);
 
     if(stderr_filename) {
-        log_lock();
         stderror = open_log_file(stdcollector_fd, stderror, stderr_filename, &error_log_syslog, 1, &stdcollector_fd);
-        log_unlock();
     }
 
 #ifdef ENABLE_ACLK

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -634,7 +634,7 @@ int error_log_limit(int reset) {
     static time_t start = 0;
     static unsigned long counter = 0, prevented = 0;
 
-    FILE *fp = (!stderror) ? stderr : stderror;
+    FILE *fp = stderror;
 
     // fprintf(fp, "FLOOD: counter=%lu, allowed=%lu, backup=%lu, period=%llu\n", counter, error_log_errors_per_period, error_log_errors_per_period_backup, (unsigned long long)error_log_throttle_period);
 
@@ -781,7 +781,7 @@ void debug_int( const char *file, const char *function, const unsigned long line
 void info_int( int is_collector, const char *file __maybe_unused, const char *function __maybe_unused, const unsigned long line __maybe_unused, const char *fmt, ... )
 {
     va_list args;
-    FILE *fp = (is_collector || !stderror) ? stderr : stderror;
+    FILE *fp = (is_collector) ? stderr : stderror;
 
     log_lock();
 
@@ -841,7 +841,7 @@ static const char *strerror_result_string(const char *a, const char *b) { (void)
 #endif
 
 void error_limit_int(ERROR_LIMIT *erl, const char *prefix, const char *file __maybe_unused, const char *function __maybe_unused, const unsigned long line __maybe_unused, const char *fmt, ... ) {
-    FILE *fp = (!stderror) ? stderr : stderror;
+    FILE *fp = stderror;
 
     if(erl->sleep_ut)
         sleep_usec(erl->sleep_ut);
@@ -910,7 +910,7 @@ void error_limit_int(ERROR_LIMIT *erl, const char *prefix, const char *file __ma
 void error_int(int is_collector, const char *prefix, const char *file __maybe_unused, const char *function __maybe_unused, const unsigned long line __maybe_unused, const char *fmt, ... ) {
     // save a copy of errno - just in case this function generates a new error
     int __errno = errno;
-    FILE *fp = (is_collector || !stderror) ? stderr : stderror;
+    FILE *fp = (is_collector) ? stderr : stderror;
 
     va_list args;
 
@@ -975,7 +975,7 @@ static void print_call_stack(void) {
 #endif
 
 void fatal_int( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) {
-    FILE *fp = (!stderror) ? stderr : stderror;
+    FILE *fp = stderror;
 
     // save a copy of errno - just in case this function generates a new error
     int __errno = errno;

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -582,7 +582,11 @@ void reopen_all_log_files() {
         open_log_file(STDERR_FILENO, stderr, stdcollector_filename, &collector_log_syslog, 0, NULL);
 
     if(stderr_filename) {
-        stderror = open_log_file(stdcollector_fd, stderror, stderr_filename, &error_log_syslog, 1, &stdcollector_fd);
+        // Netdata starts using stderr and if it has success to open file it redirects
+        FILE *fp = open_log_file(stdcollector_fd, stderror, stderr_filename,
+                                 &error_log_syslog, 1, &stdcollector_fd);
+        if (fp)
+            stderror = fp;
     }
 
 #ifdef ENABLE_ACLK
@@ -604,7 +608,10 @@ void open_all_log_files() {
     open_log_file(STDOUT_FILENO, stdout, stdout_filename, &output_log_syslog, 0, NULL);
     open_log_file(STDERR_FILENO, stderr, stdcollector_filename, &collector_log_syslog, 0, NULL);
 
-    stderror = open_log_file(stdcollector_fd, NULL, stderr_filename, &error_log_syslog, 1, &stdcollector_fd);
+    // Netdata starts using stderr and if it has success to open file it redirects
+    FILE *fp = open_log_file(stdcollector_fd, NULL, stderr_filename, &error_log_syslog, 1, &stdcollector_fd);
+    if (fp)
+        stderror = fp;
 
 #ifdef ENABLE_ACLK
     if(aclklog_enabled)


### PR DESCRIPTION
##### Summary
@stelfrag send me the following error report:

```sh
#0  futex_wait (private=0, expected=2, futex_word=0x56026eae3ae0 <log_mutex>) at ../sysdeps/nptl/futex-internal.h:146
#1  __GI___lll_lock_wait (futex=futex@entry=0x56026eae3ae0 <log_mutex>, private=0) at ./nptl/lowlevellock.c:49
#2  0x00007f8ed2064082 in lll_mutex_lock_optimized (mutex=0x56026eae3ae0 <log_mutex>) at ./nptl/pthread_mutex_lock.c:48
#3  ___pthread_mutex_lock (mutex=0x56026eae3ae0 <log_mutex>) at ./nptl/pthread_mutex_lock.c:93
#4  0x000056026e08b9cf in __netdata_mutex_lock (mutex=0x56026eae3ae0 <log_mutex>) at libnetdata/locks/locks.c:84
#5  0x000056026e08c72a in log_lock () at libnetdata/log/log.c:490
#6  0x000056026e08dae2 in error_int (is_collector=0, prefix=0x56026e82b1e7 "ERROR", file=0x56026e82b1d2 "libnetdata/log/log.c", function=0x56026e82b5c8 <__FUNCTION__.6> "open_log_file", line=533, 
    fmt=0x56026e82b1a0 "Cannot open file '%s'. Leaving %d to its default.") at libnetdata/log/log.c:914
#7  0x000056026e08c964 in open_log_file (fd=-1, fp=0x0, filename=0x56026fd6c200 "/home/stelios/netdata-journal/netdata/var/log/netdata/error.log", enabled_syslog=0x56026eac1a40 <error_log_syslog>, is_stdaccess=1, 
    fd_ptr=0x56026eac1a58 <stdcollector_fd>) at libnetdata/log/log.c:533
#8  0x000056026e08cdf6 in open_all_log_files () at libnetdata/log/log.c:610
#9  0x000056026e05156d in main (argc=4, argv=0x7fff13f8fd48) at daemon/main.c:1909
```

On my local environment I could not recreate the issue, but considering the code above I am proposing a solution and also simplifying the algorithm.

##### Test Plan

1. Compile this branch
2. Start netdata let it running few seconds and stop it. 
3. You should have all logs filled  correctly without a zombie process.

@stelfrag, please, retest on your environment.

##### Additional Information


<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? agent
- Can they see the change or is it an under the hood? If they can see it, where? It is not possible to replicate everywhere, but if user had agent core as a zombie proxy, they should not get this neither has a coredump.
- How is the user impacted by the change? Avoid issues with core.
- What are there any benefits of the change? A stable agent.
</details>
