### PR TITLE
Reject child when context is loading

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -693,12 +693,13 @@ RRDHOST *rrdhost_find_or_create(
 
     RRDHOST *host = rrdhost_find_by_guid(guid);
     if (unlikely(host && host->rrd_memory_mode != mode && rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED))) {
-        /* If a legacy memory mode instantiates all dbengine state must be discarded to avoid inconsistencies */
-        error("Archived host '%s' has memory mode '%s', but the wanted one is '%s'. Discarding archived state.",
-              rrdhost_hostname(host), rrd_memory_mode_name(host->rrd_memory_mode), rrd_memory_mode_name(mode));
 
         if (likely(!archived && rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD)))
             return host;
+
+        /* If a legacy memory mode instantiates all dbengine state must be discarded to avoid inconsistencies */
+        error("Archived host '%s' has memory mode '%s', but the wanted one is '%s'. Discarding archived state.",
+              rrdhost_hostname(host), rrd_memory_mode_name(host->rrd_memory_mode), rrd_memory_mode_name(mode));
 
         rrd_wrlock();
         rrdhost_free___while_having_rrd_wrlock(host, true);

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -697,6 +697,9 @@ RRDHOST *rrdhost_find_or_create(
         error("Archived host '%s' has memory mode '%s', but the wanted one is '%s'. Discarding archived state.",
               rrdhost_hostname(host), rrd_memory_mode_name(host->rrd_memory_mode), rrd_memory_mode_name(mode));
 
+        if (likely(!archived && rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD)))
+            return host;
+
         rrd_wrlock();
         rrdhost_free___while_having_rrd_wrlock(host, true);
         host = NULL;


### PR DESCRIPTION
##### Summary
There is a crash possibility if we have a parent / child setup as follows: 

- Parent is set to "mode = dbengine" 
- Child is set to "default memory mode = ram"  in stream.conf

When restarting the parent, upon child connection there might be a crash. 

This is because the parent might have a context load in progress and the switch (in this case) to "ram" will attempt to recreate the host with the new memory mode causing corruption.

This PR attempts to fix it by rejecting the child connection until the context load has finished loading.

