### PR TITLE
Fix handling of users and groups on install.

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -919,7 +919,7 @@ portable_add_user() {
 
   # Check if user exists
   if command -v getent > /dev/null 2>&1; then
-    if ! getent passwd "${username}" > /dev/null 2>&1; then
+    if getent passwd "${username}" > /dev/null 2>&1; then
         echo >&2 "User '${username}' already exists."
         return 0
     fi

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -918,32 +918,29 @@ portable_add_user() {
   [ -z "${homedir}" ] && homedir="/tmp"
 
   # Check if user exists
-  if cut -d ':' -f 1 < /etc/passwd | grep "^${username}$" 1> /dev/null 2>&1; then
-    echo >&2 "User '${username}' already exists."
-    return 0
+  if command -v getent > /dev/null 2>&1; then
+    if ! getent passwd "${username}" > /dev/null 2>&1; then
+        echo >&2 "User '${username}' already exists."
+        return 0
+    fi
+  else
+    if cut -d ':' -f 1 < /etc/passwd | grep "^${username}$" 1> /dev/null 2>&1; then
+        echo >&2 "User '${username}' already exists."
+        return 0
+    fi
   fi
 
   echo >&2 "Adding ${username} user account with home ${homedir} ..."
 
   nologin="$(command -v nologin || echo '/bin/false')"
 
-  # Linux
   if command -v useradd 1> /dev/null 2>&1; then
     run useradd -r -g "${username}" -c "${username}" -s "${nologin}" --no-create-home -d "${homedir}" "${username}" && return 0
-  fi
-
-  # FreeBSD
-  if command -v pw 1> /dev/null 2>&1; then
+  elif command -v pw 1> /dev/null 2>&1; then
     run pw useradd "${username}" -d "${homedir}" -g "${username}" -s "${nologin}" && return 0
-  fi
-
-  # BusyBox
-  if command -v adduser 1> /dev/null 2>&1; then
+  elif command -v adduser 1> /dev/null 2>&1; then
     run adduser -h "${homedir}" -s "${nologin}" -D -G "${username}" "${username}" && return 0
-  fi
-
-  # mac OS
-  if command -v sysadminctl 1> /dev/null 2>&1; then
+  elif command -v sysadminctl 1> /dev/null 2>&1; then
     run sysadminctl -addUser "${username}" && return 0
   fi
 
@@ -966,20 +963,11 @@ portable_add_group() {
   # Linux
   if command -v groupadd 1> /dev/null 2>&1; then
     run groupadd -r "${groupname}" && return 0
-  fi
-
-  # FreeBSD
-  if command -v pw 1> /dev/null 2>&1; then
+  elif command -v pw 1> /dev/null 2>&1; then
     run pw groupadd "${groupname}" && return 0
-  fi
-
-  # BusyBox
-  if command -v addgroup 1> /dev/null 2>&1; then
+  elif command -v addgroup 1> /dev/null 2>&1; then
     run addgroup "${groupname}" && return 0
-  fi
-
-  # mac OS
-  if command -v dseditgroup 1> /dev/null 2>&1; then
+  elif command -v dseditgroup 1> /dev/null 2>&1; then
     dseditgroup -o create "${groupname}" && return 0
   fi
 
@@ -1010,20 +998,11 @@ portable_add_user_to_group() {
     # Linux
     if command -v usermod 1> /dev/null 2>&1; then
       run usermod -a -G "${groupname}" "${username}" && return 0
-    fi
-
-    # FreeBSD
-    if command -v pw 1> /dev/null 2>&1; then
+    elif command -v pw 1> /dev/null 2>&1; then
       run pw groupmod "${groupname}" -m "${username}" && return 0
-    fi
-
-    # BusyBox
-    if command -v addgroup 1> /dev/null 2>&1; then
+    elif command -v addgroup 1> /dev/null 2>&1; then
       run addgroup "${username}" "${groupname}" && return 0
-    fi
-
-    # mac OS
-    if command -v dseditgroup 1> /dev/null 2>&1; then
+    elif command -v dseditgroup 1> /dev/null 2>&1; then
       dseditgroup -u "${username}" "${groupname}" && return 0
     fi
 


### PR DESCRIPTION
##### Summary

- Use `getent` when possible to check if user exists. This makes us correctly find an existing user on systems which use mechanisms other than just flat files for defining users.
- When adding a user, adding a group, or adding a user to a group, only try the first supported command we find, instead of trying each one we find in sequence until one works.  This prevents us from incorrectly making multiple attempts to do these operations when we should not do so.

##### Test Plan

This should only affect static builds and local installs. Basic testing involves just checking that we install correctly. Ideally we should also test on systems that use mechanisms other than a flat password file for defining system users, but I do not believe any of us at Netdata actually have such a system to test on, so this part may have to go untested.

##### Additional Information

Fixes: #14490