### PR TITLE
interrupt callback on api/v1/data

### DIFF
--- a/database/contexts/internal.h
+++ b/database/contexts/internal.h
@@ -218,7 +218,7 @@ typedef struct rrdinstance {
     STRING *title;
     STRING *units;
     STRING *family;
-    uint32_t priority;
+    uint32_t priority:24;
     RRDSET_TYPE chart_type;
 
     RRD_FLAGS flags;                    // flags related to this instance

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -319,7 +319,7 @@ typedef struct storage_collect_handle {
 struct rrddim_tier {
     STORAGE_POINT virtual_point;
     STORAGE_ENGINE_BACKEND backend;
-    size_t tier_grouping;
+    uint32_t tier_grouping;
     time_t next_point_end_time_s;
     STORAGE_METRIC_HANDLE *db_metric_handle;        // the metric handle inside the database
     STORAGE_COLLECT_HANDLE *db_collection_handle;   // the data collection handle
@@ -1135,7 +1135,7 @@ struct rrdhost {
         RRD_MEMORY_MODE mode;                       // the db mode for this tier
         STORAGE_ENGINE *eng;                        // the storage engine API for this tier
         STORAGE_INSTANCE *instance;                 // the db instance for this tier
-        size_t tier_grouping;                       // tier 0 iterations aggregated on this tier
+        uint32_t tier_grouping;                     // tier 0 iterations aggregated on this tier
     } db[RRD_STORAGE_TIERS];
 
     struct rrdhost_system_info *system_info;        // information collected from the host environment

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -713,6 +713,8 @@ static inline int web_client_api_request_v1_data(RRDHOST *host, struct web_clien
             .labels = chart_labels_filter,
             .query_source = QUERY_SOURCE_API_DATA,
             .priority = STORAGE_PRIORITY_NORMAL,
+            .interrupt_callback = web_client_interrupt_callback,
+            .interrupt_callback_data = w,
     };
     qt = query_target_create(&qtr);
 


### PR DESCRIPTION
- [x] Added forgotten interrupt callback to `/api/v1/data`.
- [x] context priority size set to 24 bits, to save 8 bytes per instance in contexts