### PR TITLE
Fix TYPO in README.md

### DIFF
--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -557,4 +557,4 @@ Caddyfile.
 ## Publish a test image to your own repository
 
 At Netdata, we provide multiple ways of testing your Docker images using your own repositories.
-You may either use the command line tools available or take advantage of our GitHub Acions infrastructure.
+You may either use the command line tools available or take advantage of our GitHub Actions infrastructure.


### PR DESCRIPTION
##### Summary
Correct spelling in `packaging/docker/README.md` from `Github Acions` to `Github Actions`


##### Test Plan

Double checked the spelling of the word in the dictionary.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
Correct spelling in `packaging/docker/README.md` from `Github Acions` to `Github Actions`. 
Typo's and grammatical errors in documentation can give project a non-professional perception.

</details>
