### PR TITLE
Load/Store ML models

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -255,7 +255,7 @@ static void sql_delete_aclk_table_list(char *host_guid)
     if (unlikely(rc != SQLITE_OK))
         error_report("Failed to finalize statement to clean up aclk tables, rc = %d", rc);
 
-    rc = db_execute(buffer_tostring(sql));
+    rc = db_execute(db_meta, buffer_tostring(sql));
     if (unlikely(rc))
         error("Failed to drop unused ACLK tables");
 
@@ -294,7 +294,7 @@ static int sql_maint_aclk_sync_database(void *data __maybe_unused, int argc __ma
 {
     char sql[512];
     snprintfz(sql,511, SQL_ALERT_CLEANUP, (char *) argv[0], ACLK_DELETE_ACK_ALERTS_INTERNAL);
-    if (unlikely(db_execute(sql)))
+    if (unlikely(db_execute(db_meta, sql)))
         error_report("Failed to clean stale ACLK alert entries");
     return 0;
 }
@@ -491,12 +491,12 @@ void sql_create_aclk_table(RRDHOST *host __maybe_unused, uuid_t *host_uuid __may
     char sql[ACLK_SYNC_QUERY_SIZE];
 
     snprintfz(sql, ACLK_SYNC_QUERY_SIZE-1, TABLE_ACLK_ALERT, uuid_str);
-    rc = db_execute(sql);
+    rc = db_execute(db_meta, sql);
     if (unlikely(rc))
         error_report("Failed to create ACLK alert table for host %s", host ? rrdhost_hostname(host) : host_guid);
     else {
         snprintfz(sql, ACLK_SYNC_QUERY_SIZE -1, INDEX_ACLK_ALERT, uuid_str, uuid_str);
-        rc = db_execute(sql);
+        rc = db_execute(db_meta, sql);
         if (unlikely(rc))
             error_report("Failed to create ACLK alert table index for host %s", host ? string2str(host->hostname) : host_guid);
     }

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -510,13 +510,13 @@ skip:
 }
 // Return 0 OK
 // Return 1 Failed
-int db_execute(const char *cmd)
+int db_execute(sqlite3 *db, const char *cmd)
 {
     int rc;
     int cnt = 0;
     while (cnt < SQL_MAX_RETRY) {
         char *err_msg;
-        rc = sqlite3_exec_monitored(db_meta, cmd, 0, 0, &err_msg);
+        rc = sqlite3_exec_monitored(db, cmd, 0, 0, &err_msg);
         if (rc != SQLITE_OK) {
             error_report("Failed to execute '%s', rc = %d (%s) -- attempt %d", cmd, rc, err_msg, cnt);
             sqlite3_free(err_msg);

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -55,7 +55,7 @@ int bind_text_null(sqlite3_stmt *res, int position, const char *text, bool can_b
 int prepare_statement(sqlite3 *database, const char *query, sqlite3_stmt **statement);
 int execute_insert(sqlite3_stmt *res);
 int exec_statement_with_uuid(const char *sql, uuid_t *uuid);
-int db_execute(const char *cmd);
+int db_execute(sqlite3 *database, const char *cmd);
 void initialize_thread_key_pool(void);
 
 // Look up functions

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -25,12 +25,12 @@ int sql_create_health_log_table(RRDHOST *host) {
 
     snprintfz(command, MAX_HEALTH_SQL_SIZE, SQL_CREATE_HEALTH_LOG_TABLE(uuid_str));
 
-    rc = db_execute(command);
+    rc = db_execute(db_meta, command);
     if (unlikely(rc))
         error_report("HEALTH [%s]: SQLite error during creation of health log table", rrdhost_hostname(host));
     else {
         snprintfz(command, MAX_HEALTH_SQL_SIZE, "CREATE INDEX IF NOT EXISTS health_log_index_%s ON health_log_%s (unique_id); ", uuid_str, uuid_str);
-        rc = db_execute(command);
+        rc = db_execute(db_meta, command);
         if (unlikely(unlikely(rc)))
             error_report("HEALTH [%s]: SQLite error during creation of health log table index", rrdhost_hostname(host));
     }

--- a/database/sqlite/sqlite_metadata.h
+++ b/database/sqlite/sqlite_metadata.h
@@ -14,6 +14,7 @@ void metadata_sync_shutdown_prepare(void);
 void metaqueue_delete_dimension_uuid(uuid_t *uuid);
 void metaqueue_store_claim_id(uuid_t *host_uuid, uuid_t *claim_uuid);
 void metaqueue_host_update_info(RRDHOST *host);
+void metaqueue_ml_load_models(RRDDIM *rd);
 void migrate_localhost(uuid_t *host_uuid);
 void metadata_queue_load_host_context(RRDHOST *host);
 

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -624,7 +624,7 @@ void open_all_log_files() {
 // error log throttling
 
 time_t error_log_throttle_period = 1200;
-unsigned long error_log_errors_per_period = 999999;
+unsigned long error_log_errors_per_period = 200;
 unsigned long error_log_errors_per_period_backup = 0;
 
 int error_log_limit(int reset) {

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -624,7 +624,7 @@ void open_all_log_files() {
 // error log throttling
 
 time_t error_log_throttle_period = 1200;
-unsigned long error_log_errors_per_period = 200;
+unsigned long error_log_errors_per_period = 999999;
 unsigned long error_log_errors_per_period_backup = 0;
 
 int error_log_limit(int reset) {

--- a/ml/Config.cc
+++ b/ml/Config.cc
@@ -45,7 +45,7 @@ void ml_config_load(ml_config_t *cfg) {
 
     size_t num_training_threads = config_get_number(config_section_ml, "num training threads", 4);
 
-    bool enable_statistics_charts = config_get_boolean(config_section_ml, "enable statistics charts", false);
+    bool enable_statistics_charts = config_get_boolean(config_section_ml, "enable statistics charts", true);
 
     /*
      * Clamp
@@ -87,9 +87,15 @@ void ml_config_load(ml_config_t *cfg) {
 
     cfg->enable_anomaly_detection = enable_anomaly_detection;
 
+#if 0
     cfg->max_train_samples = max_train_samples;
     cfg->min_train_samples = min_train_samples;
     cfg->train_every = train_every;
+ #else
+    cfg->max_train_samples = 60;
+    cfg->min_train_samples = 30;
+    cfg->train_every = 60;
+ #endif
 
     cfg->num_models_to_use = num_models_to_use;
 

--- a/ml/Config.cc
+++ b/ml/Config.cc
@@ -28,7 +28,7 @@ void ml_config_load(ml_config_t *cfg) {
     unsigned max_train_samples = config_get_number(config_section_ml, "maximum num samples to train", 4 * 3600);
     unsigned min_train_samples = config_get_number(config_section_ml, "minimum num samples to train", 1 * 900);
     unsigned train_every = config_get_number(config_section_ml, "train every", 1 * 3600);
-    unsigned num_models_to_use = config_get_number(config_section_ml, "number of models per dimension", 8);
+    unsigned num_models_to_use = config_get_number(config_section_ml, "number of models per dimension", 1);
 
     unsigned diff_n = config_get_number(config_section_ml, "num samples to diff", 1);
     unsigned smooth_n = config_get_number(config_section_ml, "num samples to smooth", 3);
@@ -89,15 +89,9 @@ void ml_config_load(ml_config_t *cfg) {
 
     cfg->enable_anomaly_detection = enable_anomaly_detection;
 
-#if 0
     cfg->max_train_samples = max_train_samples;
     cfg->min_train_samples = min_train_samples;
     cfg->train_every = train_every;
- #else
-    cfg->max_train_samples = 60;
-    cfg->min_train_samples = 30;
-    cfg->train_every = 60;
- #endif
 
     cfg->num_models_to_use = num_models_to_use;
 

--- a/ml/Config.cc
+++ b/ml/Config.cc
@@ -28,7 +28,7 @@ void ml_config_load(ml_config_t *cfg) {
     unsigned max_train_samples = config_get_number(config_section_ml, "maximum num samples to train", 4 * 3600);
     unsigned min_train_samples = config_get_number(config_section_ml, "minimum num samples to train", 1 * 900);
     unsigned train_every = config_get_number(config_section_ml, "train every", 1 * 3600);
-    unsigned num_models_to_use = config_get_number(config_section_ml, "number of models per dimension", 1);
+    unsigned num_models_to_use = config_get_number(config_section_ml, "number of models per dimension", 8);
 
     unsigned diff_n = config_get_number(config_section_ml, "num samples to diff", 1);
     unsigned smooth_n = config_get_number(config_section_ml, "num samples to smooth", 3);
@@ -44,6 +44,7 @@ void ml_config_load(ml_config_t *cfg) {
     time_t anomaly_detection_query_duration = config_get_number(config_section_ml, "anomaly detection grouping duration", 5 * 60);
 
     size_t num_training_threads = config_get_number(config_section_ml, "num training threads", 4);
+    size_t flush_models_batch_size = config_get_number(config_section_ml, "flush models batch size", 128);
 
     bool enable_statistics_charts = config_get_boolean(config_section_ml, "enable statistics charts", true);
 
@@ -69,6 +70,7 @@ void ml_config_load(ml_config_t *cfg) {
     anomaly_detection_query_duration = clamp<time_t>(anomaly_detection_query_duration, 60, 15 * 60);
 
     num_training_threads = clamp<size_t>(num_training_threads, 1, 128);
+    flush_models_batch_size = clamp<size_t>(flush_models_batch_size, 8, 512);
 
     /*
      * Validate
@@ -123,6 +125,7 @@ void ml_config_load(ml_config_t *cfg) {
     cfg->stream_anomaly_detection_charts = config_get_boolean(config_section_ml, "stream anomaly detection charts", true);
 
     cfg->num_training_threads = num_training_threads;
+    cfg->flush_models_batch_size = flush_models_batch_size;
 
     cfg->enable_statistics_charts = enable_statistics_charts;
 }

--- a/ml/ml-dummy.c
+++ b/ml/ml-dummy.c
@@ -92,6 +92,11 @@ bool ml_dimension_is_anomalous(RRDDIM *rd, time_t curr_time, double value, bool 
     return false;
 }
 
+int ml_dimension_load_models(RRDDIM *rd) {
+    UNUSED(rd);
+    return 0;
+}
+
 void ml_update_global_statistics_charts(uint64_t models_consulted) {
     UNUSED(models_consulted);
 }

--- a/ml/ml-private.h
+++ b/ml/ml-private.h
@@ -320,6 +320,7 @@ typedef struct {
     std::atomic<bool> detection_stop;
 
     size_t num_training_threads;
+    size_t flush_models_batch_size;
 
     std::vector<ml_training_thread_t> training_threads;
     std::atomic<bool> training_stop;

--- a/ml/ml-private.h
+++ b/ml/ml-private.h
@@ -247,6 +247,11 @@ typedef struct {
 } ml_host_t;
 
 typedef struct {
+    uuid_t metric_uuid;
+    ml_kmeans_t kmeans;
+} ml_model_info_t;
+
+typedef struct {
     size_t id;
     netdata_thread_t nd_thread;
     netdata_mutex_t nd_mutex;
@@ -257,6 +262,8 @@ typedef struct {
     calculated_number_t *training_cns;
     calculated_number_t *scratch_training_cns;
     std::vector<DSample> training_samples;
+
+    std::vector<ml_model_info_t> pending_model_info;
 
     RRDSET *queue_stats_rs;
     RRDDIM *queue_stats_queue_size_rd;

--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -643,26 +643,6 @@ bind_fail:
     return 1;
 }
 
-int ml_dimension_update_models(RRDDIM *rd) {
-    ml_dimension_t *dim = (ml_dimension_t *) rd->ml_dimension;
-    if (!dim)
-        return 0;
-
-    netdata_mutex_lock(&dim->mutex);
-    std::vector<ml_kmeans_t> V = dim->km_contexts;
-    time_t before = dim->kmeans.before - (Cfg.num_models_to_use * Cfg.train_every);
-    netdata_mutex_unlock(&dim->mutex);
-
-    for (const ml_kmeans_t &km: V) {
-        int rc = ml_dimension_add_model(&rd->metric_uuid, &km);
-        if (rc)
-            return rc;
-    }
-
-    ml_dimension_delete_models(&dim->rd->metric_uuid, before);
-    return 0;
-}
-
 static enum ml_training_result
 ml_dimension_train_model(ml_training_thread_t *training_thread, ml_dimension_t *dim, const ml_training_request_t &training_request)
 {

--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -19,6 +19,7 @@
 #define WORKER_TRAIN_FLUSH_MODELS      7
 
 static sqlite3 *db = NULL;
+static netdata_mutex_t db_mutex = NETDATA_MUTEX_INITIALIZER;
 
 /*
  * Functions to convert enums to strings
@@ -1476,7 +1477,9 @@ static void *ml_train_main(void *arg) {
 
         if (training_thread->pending_model_info.size() >= Cfg.flush_models_batch_size) {
             worker_is_busy(WORKER_TRAIN_FLUSH_MODELS);
+            netdata_mutex_lock(&db_mutex);
             ml_flush_pending_models(training_thread);
+            netdata_mutex_unlock(&db_mutex);
             continue;
         }
 

--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -625,6 +625,10 @@ int ml_dimension_load_models(RRDDIM *rd) {
         dim->km_contexts.push_back(km);
     }
 
+    if (!dim->km_contexts.empty()) {
+        dim->ts = TRAINING_STATUS_TRAINED;
+    }
+
     netdata_mutex_unlock(&dim->mutex);
 
     if (unlikely(rc != SQLITE_DONE))

--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -16,7 +16,7 @@
 #define WORKER_TRAIN_UPDATE_MODELS     4
 #define WORKER_TRAIN_RELEASE_DIMENSION 5
 #define WORKER_TRAIN_UPDATE_HOST       6
-#define WORKER_TRAIN_LOAD_MODELS       7
+#define WORKER_TRAIN_FLUSH_MODELS      7
 
 static sqlite3 *db = NULL;
 
@@ -406,7 +406,7 @@ ml_dimension_calculated_numbers(ml_training_thread_t *training_thread, ml_dimens
 
 const char *db_models_create_table =
     "CREATE TABLE IF NOT EXISTS models("
-    "    dim_id BLOB, dim_str TEXT, after INT, before INT,"
+    "    dim_id BLOB, after INT, before INT,"
     "    min_dist REAL, max_dist REAL,"
     "    c00 REAL, c01 REAL, c02 REAL, c03 REAL, c04 REAL, c05 REAL,"
     "    c10 REAL, c11 REAL, c12 REAL, c13 REAL, c14 REAL, c15 REAL,"
@@ -415,26 +415,26 @@ const char *db_models_create_table =
 
 const char *db_models_add_model =
     "INSERT OR REPLACE INTO models("
-    "    dim_id, dim_str, after, before,"
+    "    dim_id, after, before,"
     "    min_dist, max_dist,"
     "    c00, c01, c02, c03, c04, c05,"
     "    c10, c11, c12, c13, c14, c15)"
     "VALUES("
-    "    @dim_id, @dim_str, @after, @before,"
+    "    @dim_id, @after, @before,"
     "    @min_dist, @max_dist,"
     "    @c00, @c01, @c02, @c03, @c04, @c05,"
     "    @c10, @c11, @c12, @c13, @c14, @c15);";
 
 const char *db_models_load =
     "SELECT * FROM models "
-    "WHERE dim_id == @dim_id AND after >= @after ORDER BY before ASC;";
+    "WHERE dim_id = @dim_id AND after >= @after ORDER BY before ASC;";
 
 const char *db_models_delete =
     "DELETE FROM models "
     "WHERE dim_id = @dim_id AND before < @before;";
 
 static int
-ml_dimension_add_model(ml_dimension_t *dim)
+ml_dimension_add_model(const uuid_t *metric_uuid, const ml_kmeans_t *km)
 {
     static __thread sqlite3_stmt *res = NULL;
     int param = 0;
@@ -453,36 +453,30 @@ ml_dimension_add_model(ml_dimension_t *dim)
         }
     }
 
-    rc = sqlite3_bind_blob(res, ++param, &dim->rd->metric_uuid, sizeof(dim->rd->metric_uuid), SQLITE_STATIC);
+    rc = sqlite3_bind_blob(res, ++param, metric_uuid, sizeof(*metric_uuid), SQLITE_STATIC);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    char id[1024];
-    snprintfz(id, 1024 - 1, "%s.%s", rrdset_id(dim->rd->rrdset), rrddim_id(dim->rd));
-    rc = sqlite3_bind_text(res, ++param, id, -1, SQLITE_STATIC);
+    rc = sqlite3_bind_int(res, ++param, (int) km->after);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = sqlite3_bind_int(res, ++param, (int) dim->kmeans.after);
+    rc = sqlite3_bind_int(res, ++param, (int) km->before);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = sqlite3_bind_int(res, ++param, (int) dim->kmeans.before);
+    rc = sqlite3_bind_double(res, ++param, km->min_dist);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = sqlite3_bind_double(res, ++param, dim->kmeans.min_dist);
+    rc = sqlite3_bind_double(res, ++param, km->max_dist);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = sqlite3_bind_double(res, ++param, dim->kmeans.max_dist);
-    if (unlikely(rc != SQLITE_OK))
-        goto bind_fail;
+    if (km->cluster_centers.size() != 2)
+        fatal("Expected 2 cluster centers, got %zu", km->cluster_centers.size());
 
-    if (dim->kmeans.cluster_centers.size() != 2)
-        fatal("Expected 2 cluster centers, got %zu", dim->kmeans.cluster_centers.size());
-
-    for (const DSample &ds : dim->kmeans.cluster_centers) {
+    for (const DSample &ds : km->cluster_centers) {
         if (ds.size() != 6)
             fatal("Expected dsample with 6 dimensions, got %ld", ds.size());
 
@@ -513,7 +507,7 @@ bind_fail:
 }
 
 static int
-ml_dimension_delete_models(ml_dimension_t *dim)
+ml_dimension_delete_models(const uuid_t *metric_uuid, time_t before)
 {
     static __thread sqlite3_stmt *res = NULL;
     int rc = 0;
@@ -532,11 +526,11 @@ ml_dimension_delete_models(ml_dimension_t *dim)
         }
     }
 
-    rc = sqlite3_bind_blob(res, ++param, &dim->rd->metric_uuid, sizeof(dim->rd->metric_uuid), SQLITE_STATIC);
+    rc = sqlite3_bind_blob(res, ++param, metric_uuid, sizeof(*metric_uuid), SQLITE_STATIC);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = sqlite3_bind_int(res, ++param, (int) dim->kmeans.before - (Cfg.num_models_to_use * Cfg.train_every));
+    rc = sqlite3_bind_int(res, ++param, (int) before);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
@@ -558,8 +552,18 @@ bind_fail:
     return 1;
 }
 
-static int
-ml_dimension_load_models(ml_dimension_t *dim) {
+int ml_dimension_load_models(RRDDIM *rd) {
+    ml_dimension_t *dim = (ml_dimension_t *) rd->ml_dimension;
+    if (!dim)
+        return 0;
+
+    netdata_mutex_lock(&dim->mutex);
+    bool is_empty = dim->km_contexts.empty();
+    netdata_mutex_unlock(&dim->mutex);
+
+    if (!is_empty)
+        return 0;
+
     std::vector<ml_kmeans_t> V;
 
     static __thread sqlite3_stmt *res = NULL;
@@ -586,6 +590,8 @@ ml_dimension_load_models(ml_dimension_t *dim) {
     rc = sqlite3_bind_int(res, ++param, now_realtime_usec() - (Cfg.num_models_to_use * Cfg.max_train_samples));
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
+
+    netdata_mutex_lock(&dim->mutex);
 
     dim->km_contexts.reserve(Cfg.num_models_to_use);
     while ((rc = sqlite3_step_monitored(res)) == SQLITE_ROW) {
@@ -618,6 +624,8 @@ ml_dimension_load_models(ml_dimension_t *dim) {
         dim->km_contexts.push_back(km);
     }
 
+    netdata_mutex_unlock(&dim->mutex);
+
     if (unlikely(rc != SQLITE_DONE))
         error_report("Failed to load models, rc = %d", rc);
 
@@ -635,22 +643,24 @@ bind_fail:
     return 1;
 }
 
-static int
-ml_dimension_update_models(ml_dimension_t *dim)
-{
-    int rc;
+int ml_dimension_update_models(RRDDIM *rd) {
+    ml_dimension_t *dim = (ml_dimension_t *) rd->ml_dimension;
+    if (!dim)
+        return 0;
 
-    if (dim->km_contexts.empty()) {
-        rc = ml_dimension_load_models(dim);
+    netdata_mutex_lock(&dim->mutex);
+    std::vector<ml_kmeans_t> V = dim->km_contexts;
+    time_t before = dim->kmeans.before - (Cfg.num_models_to_use * Cfg.train_every);
+    netdata_mutex_unlock(&dim->mutex);
+
+    for (const ml_kmeans_t &km: V) {
+        int rc = ml_dimension_add_model(&rd->metric_uuid, &km);
         if (rc)
             return rc;
     }
 
-    rc = ml_dimension_add_model(dim);
-    if (rc)
-        return rc;
-
-    return ml_dimension_delete_models(dim);
+    ml_dimension_delete_models(&dim->rd->metric_uuid, before);
+    return 0;
 }
 
 static enum ml_training_result
@@ -704,21 +714,9 @@ ml_dimension_train_model(ml_training_thread_t *training_thread, ml_dimension_t *
     }
 
     // update models
+    worker_is_busy(WORKER_TRAIN_UPDATE_MODELS);
     {
         netdata_mutex_lock(&dim->mutex);
-
-        // temporarily disable sqlite operations because they interfere with
-        // training scheduling on busy parents
-        #if 0
-        worker_is_busy(WORKER_TRAIN_LOAD_MODELS);
-
-        int rc = ml_dimension_update_models(dim);
-        if (rc) {
-            error("Failed to update models for %s [%u, %u]", rrddim_id(dim->rd), dim->kmeans.after, dim->kmeans.before);
-        }
-        #endif
-
-        worker_is_busy(WORKER_TRAIN_UPDATE_MODELS);
 
         if (dim->km_contexts.size() < Cfg.num_models_to_use) {
             dim->km_contexts.push_back(std::move(dim->kmeans));
@@ -746,6 +744,12 @@ ml_dimension_train_model(ml_training_thread_t *training_thread, ml_dimension_t *
         dim->ts = TRAINING_STATUS_TRAINED;
         dim->tr = training_response;
         dim->last_training_time = rrddim_last_entry_s(dim->rd);
+
+        // Add the newly generated model to the list of pending models to flush
+        ml_model_info_t model_info;
+        uuid_copy(model_info.metric_uuid, dim->rd->metric_uuid);
+        model_info.kmeans = dim->km_contexts.back();
+        training_thread->pending_model_info.push_back(model_info);
 
         netdata_mutex_unlock(&dim->mutex);
     }
@@ -1352,6 +1356,8 @@ void ml_dimension_new(RRDDIM *rd)
     dim->km_contexts.reserve(Cfg.num_models_to_use);
 
     rd->ml_dimension = (rrd_ml_dimension_t *) dim;
+
+    metaqueue_ml_load_models(rd);
 }
 
 void ml_dimension_delete(RRDDIM *rd)
@@ -1380,6 +1386,25 @@ bool ml_dimension_is_anomalous(RRDDIM *rd, time_t curr_time, double value, bool 
     return is_anomalous;
 }
 
+static int ml_flush_pending_models(ml_training_thread_t *training_thread) {
+    (void) db_execute(db, "BEGIN TRANSACTION;");
+    
+    for (const auto &pending_model: training_thread->pending_model_info) {
+        int rc = ml_dimension_add_model(&pending_model.metric_uuid, pending_model.id.c_str(), &pending_model.kmeans);
+        if (rc)
+            return rc;
+
+        rc = ml_dimension_delete_models(&pending_model.metric_uuid, pending_model.kmeans.before - (Cfg.num_models_to_use * Cfg.train_every));
+        if (rc)
+            return rc;
+    }
+
+    (void) db_execute(db, "COMMIT TRANSACTION;");
+
+    training_thread->pending_model_info.clear();
+    return 0;
+}
+
 static void *ml_train_main(void *arg) {
     ml_training_thread_t *training_thread = (ml_training_thread_t *) arg;
 
@@ -1392,9 +1417,9 @@ static void *ml_train_main(void *arg) {
     worker_register_job_name(WORKER_TRAIN_QUERY, "query");
     worker_register_job_name(WORKER_TRAIN_KMEANS, "kmeans");
     worker_register_job_name(WORKER_TRAIN_UPDATE_MODELS, "update models");
-    worker_register_job_name(WORKER_TRAIN_LOAD_MODELS, "load models");
     worker_register_job_name(WORKER_TRAIN_RELEASE_DIMENSION, "release");
     worker_register_job_name(WORKER_TRAIN_UPDATE_HOST, "update host");
+    worker_register_job_name(WORKER_TRAIN_FLUSH_MODELS, "flush models");
 
     while (!Cfg.training_stop) {
         worker_is_busy(WORKER_TRAIN_QUEUE_POP);
@@ -1468,6 +1493,12 @@ static void *ml_train_main(void *arg) {
             }
 
             netdata_mutex_unlock(&training_thread->nd_mutex);
+        }
+
+        if (training_thread->pending_model_info.size() >= 128) {
+            worker_is_busy(WORKER_TRAIN_FLUSH_MODELS);
+            ml_flush_pending_models(training_thread);
+            continue;
         }
 
         worker_is_idle();

--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -1367,7 +1367,7 @@ bool ml_dimension_is_anomalous(RRDDIM *rd, time_t curr_time, double value, bool 
 
 static int ml_flush_pending_models(ml_training_thread_t *training_thread) {
     (void) db_execute(db, "BEGIN TRANSACTION;");
-    
+
     for (const auto &pending_model: training_thread->pending_model_info) {
         int rc = ml_dimension_add_model(&pending_model.metric_uuid, &pending_model.kmeans);
         if (rc)

--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -1137,10 +1137,9 @@ ml_detect_main(void *arg)
                     training_stats.consumed_ut /= training_stats.num_popped_items;
                     training_stats.remaining_ut /= training_stats.num_popped_items;
                 } else {
-                    training_stats.queue_size = 0;
-                    training_stats.allotted_ut = 0;
+                    training_stats.queue_size = ml_queue_size(training_thread->training_queue);
                     training_stats.consumed_ut = 0;
-                    training_stats.remaining_ut = 0;
+                    training_stats.remaining_ut = training_stats.allotted_ut;
 
                     training_stats.training_result_ok = 0;
                     training_stats.training_result_invalid_query_time_range = 0;

--- a/ml/ml.h
+++ b/ml/ml.h
@@ -36,6 +36,8 @@ void ml_dimension_new(RRDDIM *rd);
 void ml_dimension_delete(RRDDIM *rd);
 bool ml_dimension_is_anomalous(RRDDIM *rd, time_t curr_time, double value, bool exists);
 
+int ml_dimension_load_models(RRDDIM *rd);
+
 void ml_update_global_statistics_charts(uint64_t models_consulted);
 
 #ifdef __cplusplus


### PR DESCRIPTION
##### Summary

- The metasync queue is used to load models when a dimension is created,
- The training thread batches models to save and flushes them with a single transaction.

##### Test Plan

- CI jobs
- Local parent with 200 children
- Set the desired `number of models per dimension` under the `[ml] config section, let the agent run for a sufficient time, restart the agent.