### PR TITLE
fix config generation for plugins

### DIFF
--- a/libnetdata/config/appconfig.c
+++ b/libnetdata/config/appconfig.c
@@ -831,7 +831,7 @@ void appconfig_generate(struct config *root, BUFFER *wb, int only_changed)
                   "#\n"
                   "\n# global netdata configuration\n");
 
-    for(i = 0; i <= 16 ;i++) {
+    for(i = 0; i <= 17 ;i++) {
         appconfig_wrlock(root);
         for(co = root->first_section; co ; co = co->next) {
             if(!strcmp(co->name, CONFIG_SECTION_GLOBAL))                 pri = 0;


### PR DESCRIPTION
##### Summary

This PR fixes the problem introduced in [#14874](https://github.com/netdata/netdata/pull/14874/commits/595074251fb22db333458b384ef50668123b8ee7) - `appconfig_generate()` skips all `[plugins:*]` sections.

##### Test Plan

Check the `/netdata.conf` endpoint.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
