### PR TITLE
feat: add OpsGenie alert levels to payload

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2321,13 +2321,21 @@ EOF
 # Opsgenie sender
 
 send_opsgenie() {
-  local payload httpcode oldv currv
+  local payload httpcode oldv currv priority
   [ "${SEND_OPSGENIE}" != "YES" ] && return 1
 
   if [ -z "${OPSGENIE_API_KEY}" ] ; then
     info "Can't send Opsgenie notification, because OPSGENIE_API_KEY is not defined"
     return 1
   fi
+
+  # Priority for OpsGenie alert
+  case "${status}" in
+  CRITICAL) priority="P1" ;; # Critical is P1
+  WARNING) priority="P3" ;; # Warning is P3
+  CLEAR) priority="P5" ;; # Clear is P5
+  *) priority="P3" ;; # OpsGenie's default alert level is P3
+  esac
 
   # We are sending null when values are nan to avoid errors while JSON message is parsed
   [ "${old_value}" != "nan" ] && oldv="${old_value}" ||  oldv="null"
@@ -2343,6 +2351,7 @@ send_opsgenie() {
     "when": ${when},
     "name" : "${name}",
     "family" : "${family}",
+    "priority" : "${priority}",
     "status" : "${status}",
     "old_status" : "${old_status}",
     "value" : ${currv},

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -2329,7 +2329,7 @@ send_opsgenie() {
     return 1
   fi
 
-  # Priority for OpsGenie alert
+  # Priority for OpsGenie alert (https://support.atlassian.com/opsgenie/docs/update-alert-priority-level/)
   case "${status}" in
   CRITICAL) priority="P1" ;; # Critical is P1
   WARNING) priority="P3" ;; # Warning is P3


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

From reading [this comment](https://github.com/netdata/netdata/issues/9858#issuecomment-687116258) I was expecting the opsgenie integration to correctly set the level based on the alert severity. However, it does not set this property which results in all alerts defaulting to priority P3.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

This is a minor change that **I HAVE NOT TESTED** as I am not well setup to build from source. If necessary I can attempt to setup a dev environemnt, however, hopefully someone from the team can quickly validate my PR & test it (provided this change is desired).

##### Additional Information

- This change affects the OpsGenie alert behavior in `health/notifications/*`.
- This will change the default priority on OpsGenie for any users of the integration. This means `WARN` level will remain the same but `CLEAR` and `CRITICAL` will change. I suspect not many people are using the current behaviour as it results in Medium alerts being created when a Netdata alert is `CLEAR`'d.
