### PR TITLE
Officially support OpenWRT through static builds

### DIFF
--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -120,7 +120,7 @@ platforms, but may require some extra effort from users.
 | macOS        | 11         | No                       | Currently only works for Intel-based hardware. Requires Homebrew for dependencies.                        |
 | macOS        | 10.15      | No                       | Requires Homebrew for dependencies.                                                                       |
 | openSUSE     | Tumbleweed | No                       |                                                                                                           |
-| OpenWRT      | Latest     | No                       | See our [OpenWRT installation instructions.](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/openwrt.md) |
+| OpenWrt      | Latest     | No                       | See our [OpenWrt installation instructions.](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/openwrt.md) |
 
 ## Third-party supported platforms
 

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -120,6 +120,7 @@ platforms, but may require some extra effort from users.
 | macOS        | 11         | No                       | Currently only works for Intel-based hardware. Requires Homebrew for dependencies.                        |
 | macOS        | 10.15      | No                       | Requires Homebrew for dependencies.                                                                       |
 | openSUSE     | Tumbleweed | No                       |                                                                                                           |
+| OpenWRT      | Latest     | No                       | See our [OpenWRT installation instructions.](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/openwrt.md) |
 
 ## Third-party supported platforms
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -584,7 +584,7 @@ check_for_remote_file() {
   elif [ -n "${CURL}" ]; then
     "${CURL}" --output /dev/null --silent --head --fail "${url}" || return 1
   elif command -v wget > /dev/null 2>&1; then
-    wget -S --spider "${url}" 2>&1 | grep -q 'HTTP/1.1 200 OK' || return 1
+    wget -q --spider "${url}" || return 1
   else
     fatal "${ERROR_F0003}" F0003
   fi
@@ -611,7 +611,7 @@ get_redirect() {
   if [ -n "${CURL}" ]; then
     run sh -c "${CURL} ${url} -s -L -I -o /dev/null -w '%{url_effective}' | grep -o '[^/]*$'" || return 1
   elif command -v wget > /dev/null 2>&1; then
-    run sh -c "wget -S -O /dev/null ${url} 2>&1 | grep -m 1 Location | grep -o '[^/]*$'" || return 1
+    run sh -c "wget -O /dev/null ${url} 2>&1 | grep -m 1 -o 'tag.[^ ]*' | grep -o [^/]*$" || return 1
   else
     fatal "${ERROR_F0003}" F0003
   fi

--- a/packaging/installer/methods/openwrt.md
+++ b/packaging/installer/methods/openwrt.md
@@ -42,7 +42,7 @@ opkg install shadow
 opkg install logrotate
 ```
 
-Finally, proceed with the Netdata installation using the [kickstart.sh one line installer](https://learn.netdata.cloud/docs/installation/installation-methods/one-line-installer-kickstart.sh) method. The installer should complete successfully and it should start Netdata.
+Finally, proceed with the Netdata installation using the [kickstart.sh one line installer](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/kickstart.md) method. The installer should complete successfully and it should start Netdata.
 
 OpenWrt keeps cron jobs configuration in `/etc/crontabs/root`, so the Netdata installer cannot enable automatic updates during the installation process. To enable them manually, run the following commands:
 ```sh

--- a/packaging/installer/methods/openwrt.md
+++ b/packaging/installer/methods/openwrt.md
@@ -17,11 +17,11 @@ learn_rel_path: "Installation/Install on specific environments"
 > PR](https://github.com/netdata/netdata/edit/master/packaging/installer/methods/openwrt.md) with your recommended
 > improvements or changes. Thank you!
 
-Since PRs [#14822](https://github.com/netdata/netdata/pull/14822) and [#14994](https://github.com/netdata/netdata/pull/14994), it is possible to install Netdata static builds on OpenWrt using [kickstart.sh](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/kickstart.md). However, some extra steps are required to ensure a successful Netdata install, with features such as log rotation and automatic updates working correctly.
+Since PRs [#14822](https://github.com/netdata/netdata/pull/14822) and [#14994](https://github.com/netdata/netdata/pull/14994), it is possible to install Netdata static builds on OpenWrt using our [one line kickstart.sh installer](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/kickstart.md). However, some extra steps are required to ensure a successful Netdata install, with features such as log rotation and automatic updates working correctly.
 
 A new installation of OpenWrt [may not offer enough space](https://forum.openwrt.org/t/howto-resizing-root-partition-on-x86/140631#the-root-cause-1) for the Netdata static builds to be decompressed and for the installation to be completed successfully. In that case, the root partition and the root filesystem may need to be expanded. A comprehensive guide on how to accomplish that on x86 can be found [here](https://forum.openwrt.org/t/howto-resizing-root-partition-on-x86/140631#the-root-cause-1).
 
-As of Netdata version `v1.39.0`, at least 300MB of space are required for the root filesystem, if `dbengine` is disabled. If `dbengine` is used to store metrics locally, a larger root partition is required.
+As of Netdata version `v1.39.0`, at least 250MB of free space[^1] is required for static builds to be installed successfully, if Netdata is to be used with [dbengine disabled](https://learn.netdata.cloud/docs/deployment-in-production/streaming-and-replication/database-modes-for-parent-child-setups#which-database-mode-to-use). If `dbengine` is used to store metrics locally, a larger root partition is required.
 
 Once there is enough space for the installation, proceed with installing `bash`: 
 ```sh
@@ -58,3 +58,6 @@ crontab -e
 
 # Restart the cron service
 /etc/init.d/cron restart
+```
+
+[^1]: For space-constrained devices, [a stripped-down version of Netdata](https://openwrt.org/packages/pkgdata/netdata) is offered and maintained by the OpenWrt community.

--- a/packaging/installer/methods/openwrt.md
+++ b/packaging/installer/methods/openwrt.md
@@ -1,0 +1,60 @@
+<!--
+title: "Install Netdata on OpenWRT"
+description: "Install Netdata on OpenWRT to monitor the health and performance of routers with thousands of real-time, per-second metrics."
+custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/methods/openwrt.md
+sidebar_label: "OpenWRT"
+learn_status: "Published"
+learn_rel_path: "Installation/Install on specific environments"
+-->
+
+# Install Netdata on OpenWRT
+
+> 💡 This document may not be completely up-to-date. Please double-check the
+> details of the installation process before proceeding, particularly in 
+> places where specific software or package versions are mentioned.
+>
+> You can help improve this document by [submitting a
+> PR](https://github.com/netdata/netdata/edit/master/packaging/installer/methods/openwrt.md) with your recommended
+> improvements or changes. Thank you!
+
+Since PRs [#14822](https://github.com/netdata/netdata/pull/14822) and [#14994](https://github.com/netdata/netdata/pull/14994), it is possible to install Netdata static builds on OpenWRT using [kickstart.sh](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/kickstart.md). However, some extra steps are required to ensure a successful Netdata install, with features such as log rotation and automatic updates working correctly.
+
+A new installation of OpenWRT [may not offer enough space](https://forum.openwrt.org/t/howto-resizing-root-partition-on-x86/140631#the-root-cause-1) for the Netdata static builds to be decompressed and for the installation to be completed successfully. In that case, the root partition and the root filesystem may need to be expanded. A comprehensive guide on how to accomplish that on x86 can be found [here](https://forum.openwrt.org/t/howto-resizing-root-partition-on-x86/140631#the-root-cause-1).
+
+As of Netdata version `v1.39.0`, at least 300MB of space are required for the root filesystem, if `dbengine` is disabled. If `dbengine` is used to store metrics locally, a larger root partition is required.
+
+Once there is enough space for the installation, proceed with installing `bash`: 
+```sh
+opkg update && opkg install bash
+```
+
+For proper user and group management during the installation process, the following packages are required: 
+```sh
+opkg install shadow-groupadd shadow-groupdel shadow-useradd shadow-userdel  shadow-usermod
+```
+or to install all packages of the `shadow` group:
+```sh
+opkg install shadow
+```
+
+`logrotate` package is also missing from the default OpenWRT image, so to install it:
+```sh
+opkg install logrotate
+```
+
+Finally, proceed with the Netdata installation using the [kickstart.sh one line installer](https://learn.netdata.cloud/docs/installation/installation-methods/one-line-installer-kickstart.sh) method. The installer should complete successfully and it should start Netdata.
+
+OpenWRT keeps cron jobs configuration in `/etc/crontabs/root`, so the Netdata installer cannot enable automatic updates during the installation process. To enable them manually, run the following commands:
+```sh
+# Enable the cron service 
+/etc/init.d/cron enable
+
+# Edit cron jobs configuration using vi
+crontab -e 
+
+# Add your desired configuration for netdata-updater.sh 
+# It is recommended to have it scheduled to run daily:
+# 0 5 * * * /opt/netdata/usr/libexec/netdata/netdata-updater.sh
+
+# Restart the cron service
+/etc/init.d/cron restart

--- a/packaging/installer/methods/openwrt.md
+++ b/packaging/installer/methods/openwrt.md
@@ -1,13 +1,13 @@
 <!--
-title: "Install Netdata on OpenWRT"
-description: "Install Netdata on OpenWRT to monitor the health and performance of routers with thousands of real-time, per-second metrics."
+title: "Install Netdata on OpenWrt"
+description: "Install Netdata on OpenWrt to monitor the health and performance of routers with thousands of real-time, per-second metrics."
 custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/methods/openwrt.md
-sidebar_label: "OpenWRT"
+sidebar_label: "OpenWrt"
 learn_status: "Published"
 learn_rel_path: "Installation/Install on specific environments"
 -->
 
-# Install Netdata on OpenWRT
+# Install Netdata on OpenWrt
 
 > 💡 This document may not be completely up-to-date. Please double-check the
 > details of the installation process before proceeding, particularly in 
@@ -17,9 +17,9 @@ learn_rel_path: "Installation/Install on specific environments"
 > PR](https://github.com/netdata/netdata/edit/master/packaging/installer/methods/openwrt.md) with your recommended
 > improvements or changes. Thank you!
 
-Since PRs [#14822](https://github.com/netdata/netdata/pull/14822) and [#14994](https://github.com/netdata/netdata/pull/14994), it is possible to install Netdata static builds on OpenWRT using [kickstart.sh](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/kickstart.md). However, some extra steps are required to ensure a successful Netdata install, with features such as log rotation and automatic updates working correctly.
+Since PRs [#14822](https://github.com/netdata/netdata/pull/14822) and [#14994](https://github.com/netdata/netdata/pull/14994), it is possible to install Netdata static builds on OpenWrt using [kickstart.sh](https://github.com/netdata/netdata/blob/master/packaging/installer/methods/kickstart.md). However, some extra steps are required to ensure a successful Netdata install, with features such as log rotation and automatic updates working correctly.
 
-A new installation of OpenWRT [may not offer enough space](https://forum.openwrt.org/t/howto-resizing-root-partition-on-x86/140631#the-root-cause-1) for the Netdata static builds to be decompressed and for the installation to be completed successfully. In that case, the root partition and the root filesystem may need to be expanded. A comprehensive guide on how to accomplish that on x86 can be found [here](https://forum.openwrt.org/t/howto-resizing-root-partition-on-x86/140631#the-root-cause-1).
+A new installation of OpenWrt [may not offer enough space](https://forum.openwrt.org/t/howto-resizing-root-partition-on-x86/140631#the-root-cause-1) for the Netdata static builds to be decompressed and for the installation to be completed successfully. In that case, the root partition and the root filesystem may need to be expanded. A comprehensive guide on how to accomplish that on x86 can be found [here](https://forum.openwrt.org/t/howto-resizing-root-partition-on-x86/140631#the-root-cause-1).
 
 As of Netdata version `v1.39.0`, at least 300MB of space are required for the root filesystem, if `dbengine` is disabled. If `dbengine` is used to store metrics locally, a larger root partition is required.
 
@@ -37,14 +37,14 @@ or to install all packages of the `shadow` group:
 opkg install shadow
 ```
 
-`logrotate` package is also missing from the default OpenWRT image, so to install it:
+`logrotate` package is also missing from the default OpenWrt image, so to install it:
 ```sh
 opkg install logrotate
 ```
 
 Finally, proceed with the Netdata installation using the [kickstart.sh one line installer](https://learn.netdata.cloud/docs/installation/installation-methods/one-line-installer-kickstart.sh) method. The installer should complete successfully and it should start Netdata.
 
-OpenWRT keeps cron jobs configuration in `/etc/crontabs/root`, so the Netdata installer cannot enable automatic updates during the installation process. To enable them manually, run the following commands:
+OpenWrt keeps cron jobs configuration in `/etc/crontabs/root`, so the Netdata installer cannot enable automatic updates during the installation process. To enable them manually, run the following commands:
 ```sh
 # Enable the cron service 
 /etc/init.d/cron enable

--- a/packaging/maintainers/README.md
+++ b/packaging/maintainers/README.md
@@ -49,7 +49,7 @@ This page tracks the package maintainers for Netdata, for various operating syst
 | Embedded Linux | Netdata Version | Maintainer | Related URL |
 | :-: | :-: | :-: | :-- |
 | ASUSTOR NAS | ? | William Lin | https://www.asustor.com/apps/app_detail?id=532 |
-| OpenWRT | Release | @nitroshift | [openwrt package](https://github.com/openwrt/packages/tree/master/admin/netdata) |
+| OpenWrt | Release | @nitroshift | [openwrt package](https://github.com/openwrt/packages/tree/master/admin/netdata) |
 | ReadyNAS | Release | @NAStools | https://github.com/nastools/netdata |
 | QNAP | Release | QNAP_Stephane | https://forum.qnap.com/viewtopic.php?t=121518 |
 | DietPi | Release | @Fourdee | https://github.com/Fourdee/DietPi |

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -204,7 +204,7 @@ fi
 progress "fix permissions"
 
 run chmod g+rx,o+rx /opt
-run chown -R ${NETDATA_USER}:${NETDATA_GROUP} /opt/netdata
+run find /opt/netdata -type f -o -type d -exec chown -h ${NETDATA_USER}:${NETDATA_GROUP} {} +
 
 # -----------------------------------------------------------------------------
 

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -102,7 +102,7 @@ if [ ! -f "etc/netdata/.installer-cleanup-of-stock-configs-done" ]; then
 fi
 
 # -----------------------------------------------------------------------------
-progress "Attempt to create user/group netdata/netadata"
+progress "Attempt to create user/group netdata/netdata"
 
 NETDATA_WANTED_GROUPS="docker nginx varnish haproxy adm nsd proxy squid ceph nobody I2C"
 NETDATA_ADDED_TO_GROUPS=""


### PR DESCRIPTION
##### Summary
This PR fixes some outstanding issues to make static builds work on OpenWRT. 

Closes https://github.com/netdata/netdata/issues/9517 .

A ~~blog post or a~~ new OpenWRT Learn page might be required to go out with this PR, since there are some prerequisites that users need to be aware of, before they attempt to install Netdata. Namingly:

- `bash` needs to be manually installed: `opkg update && opkg install bash`
- There is not enough space on the default OpenWRT image for the static builds to be decompressed, so the root partition and filesystem need to be resized. A good "how to" guide can be found here: https://forum.openwrt.org/t/howto-resizing-root-partition-on-x86/140631 (might need to resize the image first, e.g. `qemu-img resize openwrt-22.03.4-x86-64-generic-ext4-combined.img +200M` in my case) . 
- Some common commands used by `kickstart.sh` for user and group management like `usermod` are missing, but can be made available by installing the `shadow` category packages: `opkg update && opkg install shadow`. 

Issues to be resolved:

- [x] Fix `wget` calls in `kickstart.sh` to be compatible with OpenWRT's [wget package](https://github.com/openwrt/packages/tree/openwrt-22.03/net/wget) .
- [x] Fix user add and group add type errors, such as: `Failed to add user netdata to group adm` errors (**note**: cannot be fixed, document how-to on new Learn page).
- [x] Fix SSL certificates `no such file or directory` error, when `chown -R netdata:netdata /opt/netdata/` is run.
- [ ] ~~Fix service manager errors.~~ This seems to be a separate bug, not specifically associated to this PR.
- [x] Fix auto-updates errors (**note**: cannot be fixed, document how-to on new Learn page).
- [x] `logrotate` errors (**note**: cannot be fixed, document how-to on new Learn page).

##### Test Plan

- Follow the new guide on [how to install Netdata on OpenWrt](https://github.com/Dim-P/netdata/blob/fix-openwrt-static-builds/packaging/installer/methods/openwrt.md) and confirm there are no issues. You will need to use [the kickstart.sh script from this PR](https://github.com/Dim-P/netdata/blob/fix-openwrt-static-builds/packaging/installer/kickstart.sh).
- Test the changed `kickstart.sh` script on platforms other than OpenWrt to ensure `wget` still works correctly.
- Test the changed [install-or-update.sh](https://github.com/Dim-P/netdata/blob/fix-openwrt-static-builds/packaging/makeself/install-or-update.sh) script on platforms other than OpenWrt to ensure fixing of permissions works correctly.
