### PR TITLE
feat(python.plugin):Postfix  queue json and log metrics

### DIFF
--- a/collectors/python.d.plugin/postfix/Makefile.inc
+++ b/collectors/python.d.plugin/postfix/Makefile.inc
@@ -6,6 +6,8 @@
 
 # install these files
 dist_python_DATA       += postfix/postfix.chart.py
+dist_python_DATA       += postfix/postfix_j.chart.py
+dist_python_DATA       += postfix/postfix_log.chart.py
 dist_pythonconfig_DATA += postfix/postfix.conf
 
 # do not install these files, but include them in the distribution

--- a/collectors/python.d.plugin/postfix/Makefile.inc
+++ b/collectors/python.d.plugin/postfix/Makefile.inc
@@ -9,6 +9,8 @@ dist_python_DATA       += postfix/postfix.chart.py
 dist_python_DATA       += postfix/postfix_j.chart.py
 dist_python_DATA       += postfix/postfix_log.chart.py
 dist_pythonconfig_DATA += postfix/postfix.conf
+dist_pythonconfig_DATA += postfix/postfix_j.conf
+dist_pythonconfig_DATA += postfix/postfix_log.conf
 
 # do not install these files, but include them in the distribution
 dist_noinst_DATA       += postfix/README.md postfix/Makefile.inc

--- a/collectors/python.d.plugin/postfix/postfix_j.chart.py
+++ b/collectors/python.d.plugin/postfix/postfix_j.chart.py
@@ -22,14 +22,14 @@ ORDER = [
 CHARTS = {
     # count of emails in the active queue
     'qactiveemails': {
-        'options': [None, 'Postfix Active Queue Emails', 'emails', 'queue', 'postfix.qactiveemails', 'line'],
+        'options': [None, 'Active Queue Emails', 'emails', 'queue', 'postfix.qactiveemails', 'line'],
         'lines': [
             ['active_emails', None, 'absolute']
         ]
     },
     # count of emails in the deferred queue with delay_reson = 'temporary failure'
     'qtemporaryfails': {
-        'options': [None, 'Postfix Deferred Queue Failures', 'emails', 'queue', 'postfix.qtemporaryfails', 'line'],
+        'options': [None, 'Deferred Queue Failures', 'emails', 'queue', 'postfix.qtemporaryfails', 'line'],
         'lines': [
             ['temporary_failures', None, 'absolute']
         ]
@@ -38,7 +38,7 @@ CHARTS = {
     # only those datapoints within 2*SD from the mean are considered to avoid skewing the distribution 
     #   by outliers ( all messages that have been in the queue for a considerable amount of time )
     'qdelay': {
-        'options': [None, 'Postfix Queue Mean Delay', 'seconds', 'queue', 'postfix.qdelay', 'line'],
+        'options': [None, 'Queue Mean Delay', 'seconds', 'queue', 'postfix.qdelay', 'line'],
         'lines': [
             ['delay', None, 'absolute']
         ]
@@ -47,7 +47,7 @@ CHARTS = {
     # only those messages which have a delay within a specified time window, messages failed a long time ago are not considered
     #   window can be specified in the config file, default 40min
     'qwdelay': {
-        'options': [None, 'Postfix Queue Mean Delay', 'seconds', 'queue', 'postfix.qwdelay', 'line'],
+        'options': [None, 'Queue Mean Delay in Window', 'seconds', 'queue', 'postfix.qwdelay', 'line'],
         'lines': [
             ['wdelay', None, 'absolute']
         ]

--- a/collectors/python.d.plugin/postfix/postfix_j.chart.py
+++ b/collectors/python.d.plugin/postfix/postfix_j.chart.py
@@ -15,26 +15,41 @@ POSTQUEUE_COMMAND = 'postqueue -j'
 ORDER = [
     'qactiveemails',
     'qtemporaryfails',
-    'qmeandelay',
+    'qdelay',
+    'qwdelay',
 ]
 
 CHARTS = {
+    # count of emails in the active queue
     'qactiveemails': {
         'options': [None, 'Postfix Active Queue Emails', 'emails', 'queue', 'postfix.qactiveemails', 'line'],
         'lines': [
             ['active_emails', None, 'absolute']
         ]
     },
+    # count of emails in the deferred queue with delay_reson = 'temporary failure'
     'qtemporaryfails': {
         'options': [None, 'Postfix Deferred Queue Failures', 'emails', 'queue', 'postfix.qtemporaryfails', 'line'],
         'lines': [
             ['temporary_failures', None, 'absolute']
         ]
     },
-    'qmeandelay': {
-        'options': [None, 'Postfix Queue Mean Delay', 'seconds', 'queue', 'postfix.qmeandelay', 'line'],
+    # average delay of all messages either in the active queue or in the deferred queue with status 'temporary failure'
+    # only those datapoints within 2*SD from the mean are considered to avoid skewing the distribution 
+    #   by outliers ( all messages that have been in the queue for a considerable amount of time )
+    'qdelay': {
+        'options': [None, 'Postfix Queue Mean Delay', 'seconds', 'queue', 'postfix.qdelay', 'line'],
         'lines': [
-            ['mean_delay', None, 'absolute']
+            ['delay', None, 'absolute']
+        ]
+    },
+    # average delay of all messages either in the active queue or in the deferred queue with status 'temporary failure'
+    # only those messages which have a delay within a specified time window, messages failed a long time ago are not considered
+    #   window can be specified in the config file, default 40min
+    'qwdelay': {
+        'options': [None, 'Postfix Queue Mean Delay', 'seconds', 'queue', 'postfix.qwdelay', 'line'],
+        'lines': [
+            ['wdelay', None, 'absolute']
         ]
     }
 }
@@ -46,10 +61,12 @@ class Service(ExecutableService):
         self.order = ORDER
         self.definitions = CHARTS
         self.command = POSTQUEUE_COMMAND
+        self.delay_window = float(self.configuration.get('delay_window_span', 2400))
         self.data = { 
                         'active_emails' : 0,
                         'temp_fail' : 0,
-                        'total_delay' : [ ]
+                        'delay' : 0.0,
+                        'wdelay' : 0.0
                     }
 
     def _get_data(self):
@@ -58,55 +75,74 @@ class Service(ExecutableService):
         :return: dict
         """
 
+        self.data = dict({
+                        'active_emails' : 0,
+                        'temp_fail' : 0,
+                        'total_delay' : 0.0
+                    })
+
+        delays = list()
+        wdelays = list()
 
         try:
 
-	        raw = self._get_raw_data()
+            raw = self._get_raw_data()
+
 	
-	        if not raw:
-	            return None
+            if not raw:
+                return None
 	
-	        epoch_now = calendar.timegm(time.gmtime())
+            epoch_now = calendar.timegm(time.gmtime())
 	
-	        for line in raw:
-	            jdata = json.load(self._get_raw_data(raw))
+            for line in raw:
+                jdata = json.loads(line)
+
+                if not jdata:
+                    continue
 	
-	            if not jdata:
-	                continue
-	
-	            if jdata['queue_name'] != 'active' \
-	                and not ( jdata['queue_name'] == 'deferred' \
-	                          jdata['delay_reason'] == 'temporary_failure') :
-	'
-	                # for now only collecting stats for active messages 
-	                #   and temporary failures
-	                continue
-	        
+                if jdata['queue_name'] != 'active' \
+                    and not ( jdata['queue_name'] == 'deferred' \
+                            and jdata['recipients'][0]['delay_reason'] == 'temporary failure' ) :
+	            # for now only collecting stats for active messages 
+	            #   and temporary failures
+                    continue
+
 	            
-	            self.data['total_delay'].append(epoch_now - jdata['arrival_time'])
+                delay = epoch_now - jdata['arrival_time']
+                delays.append(delay)
+                if delay <= self.delay_window:
+                    wdelays.append(delay)
+
+                if jdata['queue_name'] == 'active':
+                    self.data['active_emails'] += 1
+                    continue
 	
-	            if jdata['queue_name'] == 'active':
-	                self.data['active_emails'] += 1
-	                continue
+                if 'delay_reason' in jdata['recipients'][0] and jdata['recipients'][0]['delay_reason'] == 'temporary failure':
+                    self.data['temp_fail'] += 1
 	
-	            if jdata['delay_reason'] == 'temporary failure':
-	                self.data['temp_fail'] += 1
-	
-	
-            mean = stat.mean(self.data['total_delay'])
-            sd = stat.pstdev(self.data['total_delay'])
-            
-            lower = mean - 2*sd
-            upper = mean + 2*sd
-            
-            final_fail = [ x for x in self.data['temp_fail'] if x >= lower and x <= upper ]
-            
-            return { 
-                'active_emails' : self.data['active_emails'],
-                'temporary_failures' : self.data['temp_fail'],
-                'mean_delay' : stat.mean(final_fail)
-            }
 
         except (ValueError, AttributeError):
             return None
+	
+        # ensure atleast one datapoint
+        if len(delays) <=0:
+            delays.append(0)
+        if len(wdelays) <=0:
+            wdelays.append(0)
+
+        mean = stat.mean(delays)
+        sd = stat.pstdev(delays)
+        
+        lower = mean - 2*sd
+        upper = mean + 2*sd
+            
+        # only data 2*SD from mean
+        final_fail = [ x for x in delays if x >= lower and x <= upper ]
+            
+        return dict({ 
+            'active_emails' : self.data['active_emails'],
+            'temporary_failures' : self.data['temp_fail'],
+            'delay' : stat.mean(final_fail),
+            'wdelay' : stat.mean(wdelays)
+        })
 

--- a/collectors/python.d.plugin/postfix/postfix_j.chart.py
+++ b/collectors/python.d.plugin/postfix/postfix_j.chart.py
@@ -91,7 +91,7 @@ class Service(ExecutableService):
 
             if not raw:
                 return None
-	
+
             epoch_now = calendar.timegm(time.gmtime())
 	
             for line in raw:

--- a/collectors/python.d.plugin/postfix/postfix_j.chart.py
+++ b/collectors/python.d.plugin/postfix/postfix_j.chart.py
@@ -35,7 +35,7 @@ CHARTS = {
         ]
     },
     # average delay of all messages either in the active queue or in the deferred queue with status 'temporary failure'
-    # only those datapoints within 2*SD from the mean are considered to avoid skewing the distribution 
+    # only those datapoints within 2*SD from the mean are considered to avoid skewing the distribution
     #   by outliers ( all messages that have been in the queue for a considerable amount of time )
     'qdelay': {
         'options': [None, 'Queue Mean Delay', 'seconds', 'queue', 'postfix.qdelay', 'line'],
@@ -62,7 +62,7 @@ class Service(ExecutableService):
         self.definitions = CHARTS
         self.command = POSTQUEUE_COMMAND
         self.delay_window = float(self.configuration.get('delay_window_span', 2400))
-        self.data = { 
+        self.data = {
                         'active_emails' : 0,
                         'temp_fail' : 0,
                         'delay' : 0.0,
@@ -88,7 +88,7 @@ class Service(ExecutableService):
 
             raw = self._get_raw_data()
 
-	
+
             if not raw:
                 return None
 	
@@ -103,7 +103,7 @@ class Service(ExecutableService):
                 if jdata['queue_name'] != 'active' \
                     and not ( jdata['queue_name'] == 'deferred' \
                             and jdata['recipients'][0]['delay_reason'] == 'temporary failure' ) :
-	            # for now only collecting stats for active messages 
+	            # for now only collecting stats for active messages
 	            #   and temporary failures
                     continue
 
@@ -139,7 +139,7 @@ class Service(ExecutableService):
         # only data 2*SD from mean
         final_fail = [ x for x in delays if x >= lower and x <= upper ]
             
-        return dict({ 
+        return dict({
             'active_emails' : self.data['active_emails'],
             'temporary_failures' : self.data['temp_fail'],
             'delay' : stat.mean(final_fail),

--- a/collectors/python.d.plugin/postfix/postfix_j.chart.py
+++ b/collectors/python.d.plugin/postfix/postfix_j.chart.py
@@ -93,21 +93,21 @@ class Service(ExecutableService):
                 return None
 
             epoch_now = calendar.timegm(time.gmtime())
-	
+
             for line in raw:
                 jdata = json.loads(line)
 
                 if not jdata:
                     continue
-	
+
                 if jdata['queue_name'] != 'active' \
                     and not ( jdata['queue_name'] == 'deferred' \
                             and jdata['recipients'][0]['delay_reason'] == 'temporary failure' ) :
-	            # for now only collecting stats for active messages
-	            #   and temporary failures
+                # for now only collecting stats for active messages
+                #   and temporary failures
                     continue
 
-	            
+
                 delay = epoch_now - jdata['arrival_time']
                 delays.append(delay)
                 if delay <= self.delay_window:
@@ -116,14 +116,14 @@ class Service(ExecutableService):
                 if jdata['queue_name'] == 'active':
                     self.data['active_emails'] += 1
                     continue
-	
+
                 if 'delay_reason' in jdata['recipients'][0] and jdata['recipients'][0]['delay_reason'] == 'temporary failure':
                     self.data['temp_fail'] += 1
-	
+
 
         except (ValueError, AttributeError):
             return None
-	
+
         # ensure atleast one datapoint
         if len(delays) <=0:
             delays.append(0)
@@ -138,7 +138,7 @@ class Service(ExecutableService):
             
         # only data 2*SD from mean
         final_fail = [ x for x in delays if x >= lower and x <= upper ]
-            
+
         return dict({
             'active_emails' : self.data['active_emails'],
             'temporary_failures' : self.data['temp_fail'],

--- a/collectors/python.d.plugin/postfix/postfix_j.chart.py
+++ b/collectors/python.d.plugin/postfix/postfix_j.chart.py
@@ -132,10 +132,10 @@ class Service(ExecutableService):
 
         mean = stat.mean(delays)
         sd = stat.pstdev(delays)
-        
+
         lower = mean - 2*sd
         upper = mean + 2*sd
-            
+
         # only data 2*SD from mean
         final_fail = [ x for x in delays if x >= lower and x <= upper ]
 

--- a/collectors/python.d.plugin/postfix/postfix_j.chart.py
+++ b/collectors/python.d.plugin/postfix/postfix_j.chart.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+# Description: postfix netdata python.d module
+# Author: Pawel Krupa (paulfantom)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import json
+import time
+import calendar
+import statistics as stat
+
+from bases.FrameworkServices.ExecutableService import ExecutableService
+
+POSTQUEUE_COMMAND = 'postqueue -j'
+
+ORDER = [
+    'qactiveemails',
+    'qtemporaryfails',
+    'qmeandelay',
+]
+
+CHARTS = {
+    'qactiveemails': {
+        'options': [None, 'Postfix Active Queue Emails', 'emails', 'queue', 'postfix.qactiveemails', 'line'],
+        'lines': [
+            ['active_emails', None, 'absolute']
+        ]
+    },
+    'qtemporaryfails': {
+        'options': [None, 'Postfix Deferred Queue Failures', 'emails', 'queue', 'postfix.qtemporaryfails', 'line'],
+        'lines': [
+            ['temporary_failures', None, 'absolute']
+        ]
+    },
+    'qmeandelay': {
+        'options': [None, 'Postfix Queue Mean Delay', 'seconds', 'queue', 'postfix.qmeandelay', 'line'],
+        'lines': [
+            ['mean_delay', None, 'absolute']
+        ]
+    }
+}
+
+
+class Service(ExecutableService):
+    def __init__(self, configuration=None, name=None):
+        ExecutableService.__init__(self, configuration=configuration, name=name)
+        self.order = ORDER
+        self.definitions = CHARTS
+        self.command = POSTQUEUE_COMMAND
+        self.data = { 
+                        'active_emails' : 0,
+                        'temp_fail' : 0,
+                        'total_delay' : [ ]
+                    }
+
+    def _get_data(self):
+        """
+        Format data received from shell command
+        :return: dict
+        """
+
+
+        try:
+
+	        raw = self._get_raw_data()
+	
+	        if not raw:
+	            return None
+	
+	        epoch_now = calendar.timegm(time.gmtime())
+	
+	        for line in raw:
+	            jdata = json.load(self._get_raw_data(raw))
+	
+	            if not jdata:
+	                continue
+	
+	            if jdata['queue_name'] != 'active' \
+	                and not ( jdata['queue_name'] == 'deferred' \
+	                          jdata['delay_reason'] == 'temporary_failure') :
+	'
+	                # for now only collecting stats for active messages 
+	                #   and temporary failures
+	                continue
+	        
+	            
+	            self.data['total_delay'].append(epoch_now - jdata['arrival_time'])
+	
+	            if jdata['queue_name'] == 'active':
+	                self.data['active_emails'] += 1
+	                continue
+	
+	            if jdata['delay_reason'] == 'temporary failure':
+	                self.data['temp_fail'] += 1
+	
+	
+            mean = stat.mean(self.data['total_delay'])
+            sd = stat.pstdev(self.data['total_delay'])
+            
+            lower = mean - 2*sd
+            upper = mean + 2*sd
+            
+            final_fail = [ x for x in self.data['temp_fail'] if x >= lower and x <= upper ]
+            
+            return { 
+                'active_emails' : self.data['active_emails'],
+                'temporary_failures' : self.data['temp_fail'],
+                'mean_delay' : stat.mean(final_fail)
+            }
+
+        except (ValueError, AttributeError):
+            return None
+

--- a/collectors/python.d.plugin/postfix/postfix_j.conf
+++ b/collectors/python.d.plugin/postfix/postfix_j.conf
@@ -1,0 +1,73 @@
+# netdata python.d.plugin configuration for postfix
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# postfix is slow, so once every 10 seconds
+update_every: 30
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# penalty indicates whether to apply penalty to update_every in case of failures.
+# Penalty will increase every 5 failed updates in a row. Maximum penalty is 10 minutes.
+# penalty: yes
+
+# autodetection_retry sets the job re-check interval in seconds.
+# The job is not deleted if check fails.
+# Attempts to start the job are made once every autodetection_retry.
+# This feature is disabled by default.
+# autodetection_retry: 0
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname            # the JOB's name as it will appear at the
+#                             # dashboard (by default is the job_name)
+#                             # JOBs sharing a name are mutually exclusive
+#     update_every: 1         # the JOB's data collection frequency
+#     priority: 60000         # the JOB's order on the dashboard
+#     penalty: yes            # the JOB's penalty
+#     autodetection_retry: 0  # the JOB's re-check interval in seconds
+#
+# Additionally to the above, postfix also supports the following:
+#
+#     command: 'postqueue -p' # the command to run
+#
+
+# ----------------------------------------------------------------------
+# AUTO-DETECTION JOBS
+
+local:
+  delay_window_span: 2400
+  command: 'postqueue -j'

--- a/collectors/python.d.plugin/postfix/postfix_log.chart.py
+++ b/collectors/python.d.plugin/postfix/postfix_log.chart.py
@@ -66,7 +66,7 @@ class Service(LogService):
         self.definitions = CHARTS
         self.re = DELAY_REGEX
         self.reSent = re.compile(r'status=sent')
-        self.reFailure = re.compile(r'status=temporary failure')
+        self.reFailure = re.compile(r'status=deferred \(temporary failure\)')
         self.log_path = self.configuration.get('log_path', '/var/log/mail.log')
         self.delay_window = float(self.configuration.get('delay_window_span', 2400))
         self.data = {

--- a/collectors/python.d.plugin/postfix/postfix_log.chart.py
+++ b/collectors/python.d.plugin/postfix/postfix_log.chart.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+# Description: Postfix delivery delay netdata python.d module
+# Author: Daniel Morante (tuaris)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import re
+import statistics as stat
+
+from bases.FrameworkServices.LogService import LogService
+
+DELAY_REGEX = 'delay=([-+]?[0-9]*\.?[0-9]+),'
+
+ORDER = ['emails', 'sent', 'failures', 'delay']
+
+CHARTS = {
+    'emails': {
+        'options': [None, 'Emails Processed', 'emails', 'delivery', 'postfix.total_emails', 'line'],
+        'lines': [
+            ['emails', None, 'absolute'],
+        ]
+    },
+    'sent': {
+        'options': [None, 'Emails Sent', 'emails', 'delivery', 'postfix.sent', 'line'],
+        'lines': [
+            ['sent', None, 'absolute'],
+        ]
+    },
+    'failures': {
+        'options': [None, 'Temporary Failures', 'emails', 'delivery', 'postfix.failures', 'line'],
+        'lines': [
+            ['failures', None, 'absolute'],
+        ]
+    },
+    'delay': {
+        'options': [None, 'Average Mail Delay', 'seconds', 'delivery', 'postfix.delay', 'line'],
+        'lines': [
+            ['seconds', None, 'absolute'],
+        ]
+    }
+
+}
+
+
+class Service(LogService):
+    def __init__(self, configuration=None, name=None):
+        LogService.__init__(self, configuration=configuration, name=name)
+        self.order = ORDER
+        self.definitions = CHARTS
+        self.re = DELAY_REGEX
+        self.reSent = re.compile(r'status=sent')
+        self.reFailure = re.compile(r'status=temporary failure')
+        self.log_path = self.configuration.get('log_path', '/var/log/maillog')
+        self.data = {
+                        'emails' : 0,
+                        'sent' : 0,
+                        'failures' : 0,
+                        'delay' : 0.0
+                    }
+
+    def check(self):
+        if not LogService.check(self):
+            return False
+
+        if not self.re:
+            self.error("regex not specified")
+            return False
+
+        try:
+            self.re = re.compile(self.re)
+        except re.error as err:
+            self.error("regex compile error: ", err)
+            return False
+
+        return True
+
+    def get_data(self):
+        """
+        :return: dict
+        """
+        raw = self._get_raw_data()
+        delays = list()
+
+        if not raw:
+            return None
+
+        for line in raw:
+            match = self.re.search(line)
+            if match:
+                self.data['emails'} += 1
+                delay = match.group(1)
+
+                if not(self.reSent.search(line) or self.reFailure.search(line)):
+                    continue
+
+                delays.append(float(delay))
+
+                if self.reSent.search(line):
+                    self.data['sent'] += 1
+                    continue
+
+                if self.reFailure.search(line):
+                    self.data['failures'] += 1
+
+            else:
+                continue
+
+        mean = stat.mean(delays)
+        sd = stat.pstdev(delays)
+        lower = mean-2*sd
+        upper = mean+2*sd
+
+        delay_pop = [ x for x in delays if x >= lower and x<= upper ]
+
+        self.data['delay'] = stat.mean(delay_pop)
+
+        return self.data

--- a/collectors/python.d.plugin/postfix/postfix_log.chart.py
+++ b/collectors/python.d.plugin/postfix/postfix_log.chart.py
@@ -91,7 +91,7 @@ class Service(LogService):
         self.reFilterRelay = re.compile(f'relay={filter_relay}')
 
 
-        if type(delay_windows) != list:
+        if isinstance(delay_windows, list) is False:
             delay_windows = [delay_windows]
 
         self.delay_windows = list()

--- a/collectors/python.d.plugin/postfix/postfix_log.conf
+++ b/collectors/python.d.plugin/postfix/postfix_log.conf
@@ -69,5 +69,8 @@ update_every: 60
 # AUTO-DETECTION JOBS
 
 local:
-  delay_window_span: 2400
+  delay_window_span: [2400, 10800]
   log_path: /var/log/mail.log
+  relay: pbfilter
+  email_counter_relay: pbfilter
+  

--- a/collectors/python.d.plugin/postfix/postfix_log.conf
+++ b/collectors/python.d.plugin/postfix/postfix_log.conf
@@ -1,0 +1,73 @@
+# netdata python.d.plugin configuration for postfix
+#
+# This file is in YaML format. Generally the format is:
+#
+# name: value
+#
+# There are 2 sections:
+#  - global variables
+#  - one or more JOBS
+#
+# JOBS allow you to collect values from multiple sources.
+# Each source will have its own set of charts.
+#
+# JOB parameters have to be indented (using spaces only, example below).
+
+# ----------------------------------------------------------------------
+# Global Variables
+# These variables set the defaults for all JOBs, however each JOB
+# may define its own, overriding the defaults.
+
+# update_every sets the default data collection frequency.
+# If unset, the python.d.plugin default is used.
+# postfix is slow, so once every 10 seconds
+update_every: 60
+
+# priority controls the order of charts at the netdata dashboard.
+# Lower numbers move the charts towards the top of the page.
+# If unset, the default for python.d.plugin is used.
+# priority: 60000
+
+# penalty indicates whether to apply penalty to update_every in case of failures.
+# Penalty will increase every 5 failed updates in a row. Maximum penalty is 10 minutes.
+# penalty: yes
+
+# autodetection_retry sets the job re-check interval in seconds.
+# The job is not deleted if check fails.
+# Attempts to start the job are made once every autodetection_retry.
+# This feature is disabled by default.
+# autodetection_retry: 0
+
+# ----------------------------------------------------------------------
+# JOBS (data collection sources)
+#
+# The default JOBS share the same *name*. JOBS with the same name
+# are mutually exclusive. Only one of them will be allowed running at
+# any time. This allows autodetection to try several alternatives and
+# pick the one that works.
+#
+# Any number of jobs is supported.
+#
+# All python.d.plugin JOBS (for all its modules) support a set of
+# predefined parameters. These are:
+#
+# job_name:
+#     name: myname            # the JOB's name as it will appear at the
+#                             # dashboard (by default is the job_name)
+#                             # JOBs sharing a name are mutually exclusive
+#     update_every: 1         # the JOB's data collection frequency
+#     priority: 60000         # the JOB's order on the dashboard
+#     penalty: yes            # the JOB's penalty
+#     autodetection_retry: 0  # the JOB's re-check interval in seconds
+#
+# Additionally to the above, postfix also supports the following:
+#
+#     command: 'postqueue -p' # the command to run
+#
+
+# ----------------------------------------------------------------------
+# AUTO-DETECTION JOBS
+
+local:
+  delay_window_span: 2400
+  log_path: /var/log/mail.log


### PR DESCRIPTION
##### Summary
added 2 python.d modules
- postfix_j - ExecutableService that invokes the "postqueue - j" command and extracts the following charts
> active queue email count, deferred queue failure count, average mail deplay.=, average mail delay within a window

-  postfix_log - LogService reads the mail logs and extracts data from the status line for each email processed and collects the following metrics
> count emails processed, count emails sent, count emails failed (only temp fails), average delay (after eliminating outliers), average delay within a specified time window from the current time.

##### Test Plan
1. adjusted time window for windowed delay, 
2. temp fail retries are not considered when outside time window for windowed delay
3. causing failed sends (temporary fails) are counted
4. test to ensure non temp fails (like connection timeouts) were not counted in temp fails
5. for average delay only times within 2*SD of the mean are considered
6. verify accuracy of all counts


