### PR TITLE
Update tor.chart.py

### DIFF
--- a/collectors/python.d.plugin/tor/tor.chart.py
+++ b/collectors/python.d.plugin/tor/tor.chart.py
@@ -17,6 +17,7 @@ except ImportError:
     STEM_AVAILABLE = False
 
 DEF_PORT = 'default'
+DEF_ADDR = '127.0.0.1'
 
 ORDER = [
     'traffic',
@@ -41,6 +42,7 @@ class Service(SimpleService):
         self.order = ORDER
         self.definitions = CHARTS
         self.port = self.configuration.get('control_port', DEF_PORT)
+        self.addr = self.configuration.get('control_addr', DEF_ADDR)
         self.password = self.configuration.get('password')
         self.use_socket = isinstance(self.port, str) and self.port != DEF_PORT and not self.port.isdigit()
         self.conn = None
@@ -78,7 +80,7 @@ class Service(SimpleService):
 
     def connect_via_port(self):
         try:
-            self.conn = stem.control.Controller.from_port(port=self.port)
+            self.conn = stem.control.Controller.from_port(address=self.addr, port=self.port)
         except (stem.SocketError, ValueError) as error:
             self.error(error)
 

--- a/collectors/python.d.plugin/tor/tor.conf
+++ b/collectors/python.d.plugin/tor/tor.conf
@@ -61,6 +61,7 @@
 #
 # Additionally to the above, tor plugin also supports the following:
 #
+#     control_addr: 'port'    # tor control IP address (defaults to '127.0.0.1')
 #     control_port: 'port'    # tor control port
 #     password: 'password'    # tor control password
 #
@@ -71,6 +72,7 @@
 # local_tcp:
 #  name: 'local'
 #  control_port: 9051
+#  control_addr: 127.0.0.1
 #  password: <password>
 #
 # local_socket:

--- a/collectors/python.d.plugin/tor/tor.conf
+++ b/collectors/python.d.plugin/tor/tor.conf
@@ -61,7 +61,7 @@
 #
 # Additionally to the above, tor plugin also supports the following:
 #
-#     control_addr: 'port'    # tor control IP address (defaults to '127.0.0.1')
+#     control_addr: 'address' # tor control IP address (defaults to '127.0.0.1')
 #     control_port: 'port'    # tor control port
 #     password: 'password'    # tor control password
 #


### PR DESCRIPTION
Added an "control_addr" configuration option for ControlPort, which allows reaching it from a container outside (the host indeed). Defaults to 127.0.0.1.

##### Summary

I needed to monitor my Tor relay from the host OS, while Tor is running in an nspawn container with a minimal install. The current plugins makes the assumption that Tor control port is only run on 127.0.0.1, thus on the same host. This address cannot be mapped onto the container network interface so I slightly modified the plugin to include a new configuration option "control_addr" to be able to set another address.

##### Test Plan

To test the changes, you have to modify:
1. Tor configuration file `/etc/torrc` (in container for me)
2. Netdata configuration file `/etc/netdata/python.d/tor.conf` (in host)

Change Tor control port option to listen on any interface (this can also be done using nyx):

`ControlPort=0.0.0.0:9051`

Insert the new option into Netdata configuration file:

```
local_tcp:
 name: 'local'
 control_addr: '192.168.x.x'
 control_port: 9051
 password: 'TheBigPassWord'
```
Restart Tor then Netdata, check that Tor data are still collected. NB: you can use nyx console to change the Tor option without restarting Tor.

##### Additional Information

This change allows monitoring Tor from another host, because Tor has been set up to run inside a container or even a remote host.

<details> <summary>For users: How does this change affect me?</summary>
If Tor is running on the same host as Netdata, no change will be visible since the default address is still 127.0.0.1.
If Tor is running on another host, users have to update their configuration files as explained above to be able to monitor it.
</details>
