### PR TITLE
Fix handling of permissions in static installs.

### DIFF
--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -204,7 +204,8 @@ fi
 progress "fix permissions"
 
 run chmod g+rx,o+rx /opt
-run chown -R ${NETDATA_USER}:${NETDATA_GROUP} /opt/netdata
+run find /opt/netdata -type d -exec chmod go+rx '{}' \+
+run chown -R ${NETDATA_USER}:${NETDATA_GROUP} /opt/netdata/var
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
##### Summary

This how we handle permissions on static installs. Specifically it:

- Ensures that directories all have correct permissions instead of only being accessible to their owners.
- Only forces ownership by `netdata:netdata` for the things that actually need it, closing a bunch of potential attack vectors resulting from things being writable by the `netdata` user that should not be.

##### Test Plan

Confirm that CI passes on this PR and that static builds created from this branch have correct permissions.

##### Additional Information

Fixes: #15036