### PR TITLE
Comment out default `role_recipients_*` values

### DIFF
--- a/health/notifications/health_alarm_notify.conf
+++ b/health/notifications/health_alarm_notify.conf
@@ -956,365 +956,365 @@ custom_sender() {
 # generic system alarms
 # CPU, disks, network interfaces, entropy, etc
 
-role_recipients_email[sysadmin]="${DEFAULT_RECIPIENT_EMAIL}"
+# role_recipients_email[sysadmin]="${DEFAULT_RECIPIENT_EMAIL}"
 
-role_recipients_hangouts[sysadmin]="${DEFAULT_RECIPIENT_HANGOUTS}"
+# role_recipients_hangouts[sysadmin]="${DEFAULT_RECIPIENT_HANGOUTS}"
 
-role_recipients_pushover[sysadmin]="${DEFAULT_RECIPIENT_PUSHOVER}"
+# role_recipients_pushover[sysadmin]="${DEFAULT_RECIPIENT_PUSHOVER}"
 
-role_recipients_pushbullet[sysadmin]="${DEFAULT_RECIPIENT_PUSHBULLET}"
+# role_recipients_pushbullet[sysadmin]="${DEFAULT_RECIPIENT_PUSHBULLET}"
 
-role_recipients_telegram[sysadmin]="${DEFAULT_RECIPIENT_TELEGRAM}"
+# role_recipients_telegram[sysadmin]="${DEFAULT_RECIPIENT_TELEGRAM}"
 
-role_recipients_slack[sysadmin]="${DEFAULT_RECIPIENT_SLACK}"
+# role_recipients_slack[sysadmin]="${DEFAULT_RECIPIENT_SLACK}"
 
-role_recipients_alerta[sysadmin]="${DEFAULT_RECIPIENT_ALERTA}"
+# role_recipients_alerta[sysadmin]="${DEFAULT_RECIPIENT_ALERTA}"
 
-role_recipients_flock[sysadmin]="${DEFAULT_RECIPIENT_FLOCK}"
+# role_recipients_flock[sysadmin]="${DEFAULT_RECIPIENT_FLOCK}"
 
-role_recipients_discord[sysadmin]="${DEFAULT_RECIPIENT_DISCORD}"
+# role_recipients_discord[sysadmin]="${DEFAULT_RECIPIENT_DISCORD}"
 
-role_recipients_hipchat[sysadmin]="${DEFAULT_RECIPIENT_HIPCHAT}"
+# role_recipients_hipchat[sysadmin]="${DEFAULT_RECIPIENT_HIPCHAT}"
 
-role_recipients_twilio[sysadmin]="${DEFAULT_RECIPIENT_TWILIO}"
+# role_recipients_twilio[sysadmin]="${DEFAULT_RECIPIENT_TWILIO}"
 
-role_recipients_messagebird[sysadmin]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
+# role_recipients_messagebird[sysadmin]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
 
-role_recipients_kavenegar[sysadmin]="${DEFAULT_RECIPIENT_KAVENEGAR}"
+# role_recipients_kavenegar[sysadmin]="${DEFAULT_RECIPIENT_KAVENEGAR}"
 
-role_recipients_pd[sysadmin]="${DEFAULT_RECIPIENT_PD}"
+# role_recipients_pd[sysadmin]="${DEFAULT_RECIPIENT_PD}"
 
-role_recipients_fleep[sysadmin]="${DEFAULT_RECIPIENT_FLEEP}"
+# role_recipients_fleep[sysadmin]="${DEFAULT_RECIPIENT_FLEEP}"
 
-role_recipients_irc[sysadmin]="${DEFAULT_RECIPIENT_IRC}"
+# role_recipients_irc[sysadmin]="${DEFAULT_RECIPIENT_IRC}"
 
-role_recipients_syslog[sysadmin]="${DEFAULT_RECIPIENT_SYSLOG}"
+# role_recipients_syslog[sysadmin]="${DEFAULT_RECIPIENT_SYSLOG}"
 
-role_recipients_prowl[sysadmin]="${DEFAULT_RECIPIENT_PROWL}"
+# role_recipients_prowl[sysadmin]="${DEFAULT_RECIPIENT_PROWL}"
 
-role_recipients_awssns[sysadmin]="${DEFAULT_RECIPIENT_AWSSNS}"
+# role_recipients_awssns[sysadmin]="${DEFAULT_RECIPIENT_AWSSNS}"
 
-role_recipients_custom[sysadmin]="${DEFAULT_RECIPIENT_CUSTOM}"
+# role_recipients_custom[sysadmin]="${DEFAULT_RECIPIENT_CUSTOM}"
 
-role_recipients_msteams[sysadmin]="${DEFAULT_RECIPIENT_MSTEAMS}"
+# role_recipients_msteams[sysadmin]="${DEFAULT_RECIPIENT_MSTEAMS}"
 
-role_recipients_rocketchat[sysadmin]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
+# role_recipients_rocketchat[sysadmin]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
 
-role_recipients_dynatrace[sysadmin]="${DEFAULT_RECIPIENT_DYNATRACE}"
+# role_recipients_dynatrace[sysadmin]="${DEFAULT_RECIPIENT_DYNATRACE}"
 
-role_recipients_opsgenie[sysadmin]="${DEFAULT_RECIPIENT_OPSGENIE}"
+# role_recipients_opsgenie[sysadmin]="${DEFAULT_RECIPIENT_OPSGENIE}"
 
-role_recipients_matrix[sysadmin]="${DEFAULT_RECIPIENT_MATRIX}"
+# role_recipients_matrix[sysadmin]="${DEFAULT_RECIPIENT_MATRIX}"
 
-role_recipients_stackpulse[sysadmin]="${DEFAULT_RECIPIENT_STACKPULSE}"
+# role_recipients_stackpulse[sysadmin]="${DEFAULT_RECIPIENT_STACKPULSE}"
 
-role_recipients_gotify[sysadmin]="${DEFAULT_RECIPIENT_GOTIFY}"
+# role_recipients_gotify[sysadmin]="${DEFAULT_RECIPIENT_GOTIFY}"
 
-role_recipients_ntfy[sysadmin]="${DEFAULT_RECIPIENT_NTFY}"
+# role_recipients_ntfy[sysadmin]="${DEFAULT_RECIPIENT_NTFY}"
 
 # -----------------------------------------------------------------------------
 # DNS related alarms
 
-role_recipients_email[domainadmin]="${DEFAULT_RECIPIENT_EMAIL}"
+# role_recipients_email[domainadmin]="${DEFAULT_RECIPIENT_EMAIL}"
 
-role_recipients_hangouts[domainadmin]="${DEFAULT_RECIPIENT_HANGOUTS}"
+# role_recipients_hangouts[domainadmin]="${DEFAULT_RECIPIENT_HANGOUTS}"
 
-role_recipients_pushover[domainadmin]="${DEFAULT_RECIPIENT_PUSHOVER}"
+# role_recipients_pushover[domainadmin]="${DEFAULT_RECIPIENT_PUSHOVER}"
 
-role_recipients_pushbullet[domainadmin]="${DEFAULT_RECIPIENT_PUSHBULLET}"
+# role_recipients_pushbullet[domainadmin]="${DEFAULT_RECIPIENT_PUSHBULLET}"
 
-role_recipients_telegram[domainadmin]="${DEFAULT_RECIPIENT_TELEGRAM}"
+# role_recipients_telegram[domainadmin]="${DEFAULT_RECIPIENT_TELEGRAM}"
 
-role_recipients_slack[domainadmin]="${DEFAULT_RECIPIENT_SLACK}"
+# role_recipients_slack[domainadmin]="${DEFAULT_RECIPIENT_SLACK}"
 
-role_recipients_alerta[domainadmin]="${DEFAULT_RECIPIENT_ALERTA}"
+# role_recipients_alerta[domainadmin]="${DEFAULT_RECIPIENT_ALERTA}"
 
-role_recipients_flock[domainadmin]="${DEFAULT_RECIPIENT_FLOCK}"
+# role_recipients_flock[domainadmin]="${DEFAULT_RECIPIENT_FLOCK}"
 
-role_recipients_discord[domainadmin]="${DEFAULT_RECIPIENT_DISCORD}"
+# role_recipients_discord[domainadmin]="${DEFAULT_RECIPIENT_DISCORD}"
 
-role_recipients_hipchat[domainadmin]="${DEFAULT_RECIPIENT_HIPCHAT}"
+# role_recipients_hipchat[domainadmin]="${DEFAULT_RECIPIENT_HIPCHAT}"
 
-role_recipients_twilio[domainadmin]="${DEFAULT_RECIPIENT_TWILIO}"
+# role_recipients_twilio[domainadmin]="${DEFAULT_RECIPIENT_TWILIO}"
 
-role_recipients_messagebird[domainadmin]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
+# role_recipients_messagebird[domainadmin]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
 
-role_recipients_kavenegar[domainadmin]="${DEFAULT_RECIPIENT_KAVENEGAR}"
+# role_recipients_kavenegar[domainadmin]="${DEFAULT_RECIPIENT_KAVENEGAR}"
 
-role_recipients_pd[domainadmin]="${DEFAULT_RECIPIENT_PD}"
+# role_recipients_pd[domainadmin]="${DEFAULT_RECIPIENT_PD}"
 
-role_recipients_fleep[domainadmin]="${DEFAULT_RECIPIENT_FLEEP}"
+# role_recipients_fleep[domainadmin]="${DEFAULT_RECIPIENT_FLEEP}"
 
-role_recipients_irc[domainadmin]="${DEFAULT_RECIPIENT_IRC}"
+# role_recipients_irc[domainadmin]="${DEFAULT_RECIPIENT_IRC}"
 
-role_recipients_syslog[domainadmin]="${DEFAULT_RECIPIENT_SYSLOG}"
+# role_recipients_syslog[domainadmin]="${DEFAULT_RECIPIENT_SYSLOG}"
 
-role_recipients_prowl[domainadmin]="${DEFAULT_RECIPIENT_PROWL}"
+# role_recipients_prowl[domainadmin]="${DEFAULT_RECIPIENT_PROWL}"
 
-role_recipients_awssns[domainadmin]="${DEFAULT_RECIPIENT_AWSSNS}"
+# role_recipients_awssns[domainadmin]="${DEFAULT_RECIPIENT_AWSSNS}"
 
-role_recipients_custom[domainadmin]="${DEFAULT_RECIPIENT_CUSTOM}"
+# role_recipients_custom[domainadmin]="${DEFAULT_RECIPIENT_CUSTOM}"
 
-role_recipients_msteams[domainadmin]="${DEFAULT_RECIPIENT_MSTEAMS}"
+# role_recipients_msteams[domainadmin]="${DEFAULT_RECIPIENT_MSTEAMS}"
 
-role_recipients_rocketchat[domainadmin]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
+# role_recipients_rocketchat[domainadmin]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
 
-role_recipients_sms[domainadmin]="${DEFAULT_RECIPIENT_SMS}"
+# role_recipients_sms[domainadmin]="${DEFAULT_RECIPIENT_SMS}"
 
-role_recipients_dynatrace[domainadmin]="${DEFAULT_RECIPIENT_DYNATRACE}"
+# role_recipients_dynatrace[domainadmin]="${DEFAULT_RECIPIENT_DYNATRACE}"
 
-role_recipients_opsgenie[domainadmin]="${DEFAULT_RECIPIENT_OPSGENIE}"
+# role_recipients_opsgenie[domainadmin]="${DEFAULT_RECIPIENT_OPSGENIE}"
 
-role_recipients_matrix[domainadmin]="${DEFAULT_RECIPIENT_MATRIX}"
+# role_recipients_matrix[domainadmin]="${DEFAULT_RECIPIENT_MATRIX}"
 
-role_recipients_stackpulse[domainadmin]="${DEFAULT_RECIPIENT_STACKPULSE}"
+# role_recipients_stackpulse[domainadmin]="${DEFAULT_RECIPIENT_STACKPULSE}"
 
-role_recipients_gotify[domainadmin]="${DEFAULT_RECIPIENT_GOTIFY}"
+# role_recipients_gotify[domainadmin]="${DEFAULT_RECIPIENT_GOTIFY}"
 
-role_recipients_ntfy[domainadmin]="${DEFAULT_RECIPIENT_NTFY}"
+# role_recipients_ntfy[domainadmin]="${DEFAULT_RECIPIENT_NTFY}"
 
 # -----------------------------------------------------------------------------
 # database servers alarms
 # mysql, redis, memcached, postgres, etc
 
-role_recipients_email[dba]="${DEFAULT_RECIPIENT_EMAIL}"
+# role_recipients_email[dba]="${DEFAULT_RECIPIENT_EMAIL}"
 
-role_recipients_hangouts[dba]="${DEFAULT_RECIPIENT_HANGOUTS}"
+# role_recipients_hangouts[dba]="${DEFAULT_RECIPIENT_HANGOUTS}"
 
-role_recipients_pushover[dba]="${DEFAULT_RECIPIENT_PUSHOVER}"
+# role_recipients_pushover[dba]="${DEFAULT_RECIPIENT_PUSHOVER}"
 
-role_recipients_pushbullet[dba]="${DEFAULT_RECIPIENT_PUSHBULLET}"
+# role_recipients_pushbullet[dba]="${DEFAULT_RECIPIENT_PUSHBULLET}"
 
-role_recipients_telegram[dba]="${DEFAULT_RECIPIENT_TELEGRAM}"
+# role_recipients_telegram[dba]="${DEFAULT_RECIPIENT_TELEGRAM}"
 
-role_recipients_slack[dba]="${DEFAULT_RECIPIENT_SLACK}"
+# role_recipients_slack[dba]="${DEFAULT_RECIPIENT_SLACK}"
 
-role_recipients_alerta[dba]="${DEFAULT_RECIPIENT_ALERTA}"
+# role_recipients_alerta[dba]="${DEFAULT_RECIPIENT_ALERTA}"
 
-role_recipients_flock[dba]="${DEFAULT_RECIPIENT_FLOCK}"
+# role_recipients_flock[dba]="${DEFAULT_RECIPIENT_FLOCK}"
 
-role_recipients_discord[dba]="${DEFAULT_RECIPIENT_DISCORD}"
+# role_recipients_discord[dba]="${DEFAULT_RECIPIENT_DISCORD}"
 
-role_recipients_hipchat[dba]="${DEFAULT_RECIPIENT_HIPCHAT}"
+# role_recipients_hipchat[dba]="${DEFAULT_RECIPIENT_HIPCHAT}"
 
-role_recipients_twilio[dba]="${DEFAULT_RECIPIENT_TWILIO}"
+# role_recipients_twilio[dba]="${DEFAULT_RECIPIENT_TWILIO}"
 
-role_recipients_messagebird[dba]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
+# role_recipients_messagebird[dba]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
 
-role_recipients_kavenegar[dba]="${DEFAULT_RECIPIENT_KAVENEGAR}"
+# role_recipients_kavenegar[dba]="${DEFAULT_RECIPIENT_KAVENEGAR}"
 
-role_recipients_pd[dba]="${DEFAULT_RECIPIENT_PD}"
+# role_recipients_pd[dba]="${DEFAULT_RECIPIENT_PD}"
 
-role_recipients_fleep[dba]="${DEFAULT_RECIPIENT_FLEEP}"
+# role_recipients_fleep[dba]="${DEFAULT_RECIPIENT_FLEEP}"
 
-role_recipients_irc[dba]="${DEFAULT_RECIPIENT_IRC}"
+# role_recipients_irc[dba]="${DEFAULT_RECIPIENT_IRC}"
 
-role_recipients_syslog[dba]="${DEFAULT_RECIPIENT_SYSLOG}"
+# role_recipients_syslog[dba]="${DEFAULT_RECIPIENT_SYSLOG}"
 
-role_recipients_prowl[dba]="${DEFAULT_RECIPIENT_PROWL}"
+# role_recipients_prowl[dba]="${DEFAULT_RECIPIENT_PROWL}"
 
-role_recipients_awssns[dba]="${DEFAULT_RECIPIENT_AWSSNS}"
+# role_recipients_awssns[dba]="${DEFAULT_RECIPIENT_AWSSNS}"
 
-role_recipients_custom[dba]="${DEFAULT_RECIPIENT_CUSTOM}"
+# role_recipients_custom[dba]="${DEFAULT_RECIPIENT_CUSTOM}"
 
-role_recipients_msteams[dba]="${DEFAULT_RECIPIENT_MSTEAMS}"
+# role_recipients_msteams[dba]="${DEFAULT_RECIPIENT_MSTEAMS}"
 
-role_recipients_rocketchat[dba]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
+# role_recipients_rocketchat[dba]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
 
-role_recipients_sms[dba]="${DEFAULT_RECIPIENT_SMS}"
+# role_recipients_sms[dba]="${DEFAULT_RECIPIENT_SMS}"
 
-role_recipients_dynatrace[dba]="${DEFAULT_RECIPIENT_DYNATRACE}"
+# role_recipients_dynatrace[dba]="${DEFAULT_RECIPIENT_DYNATRACE}"
 
-role_recipients_opsgenie[dba]="${DEFAULT_RECIPIENT_OPSGENIE}"
+# role_recipients_opsgenie[dba]="${DEFAULT_RECIPIENT_OPSGENIE}"
 
-role_recipients_matrix[dba]="${DEFAULT_RECIPIENT_MATRIX}"
+# role_recipients_matrix[dba]="${DEFAULT_RECIPIENT_MATRIX}"
 
-role_recipients_stackpulse[dba]="${DEFAULT_RECIPIENT_STACKPULSE}"
+# role_recipients_stackpulse[dba]="${DEFAULT_RECIPIENT_STACKPULSE}"
 
-role_recipients_gotify[dba]="${DEFAULT_RECIPIENT_GOTIFY}"
+# role_recipients_gotify[dba]="${DEFAULT_RECIPIENT_GOTIFY}"
 
-role_recipients_ntfy[dba]="${DEFAULT_RECIPIENT_NTFY}"
+# role_recipients_ntfy[dba]="${DEFAULT_RECIPIENT_NTFY}"
 
 # -----------------------------------------------------------------------------
 # web servers alarms
 # apache, nginx, lighttpd, etc
 
-role_recipients_email[webmaster]="${DEFAULT_RECIPIENT_EMAIL}"
+# role_recipients_email[webmaster]="${DEFAULT_RECIPIENT_EMAIL}"
 
-role_recipients_hangouts[webmaster]="${DEFAULT_RECIPIENT_HANGOUTS}"
+# role_recipients_hangouts[webmaster]="${DEFAULT_RECIPIENT_HANGOUTS}"
 
-role_recipients_pushover[webmaster]="${DEFAULT_RECIPIENT_PUSHOVER}"
+# role_recipients_pushover[webmaster]="${DEFAULT_RECIPIENT_PUSHOVER}"
 
-role_recipients_pushbullet[webmaster]="${DEFAULT_RECIPIENT_PUSHBULLET}"
+# role_recipients_pushbullet[webmaster]="${DEFAULT_RECIPIENT_PUSHBULLET}"
 
-role_recipients_telegram[webmaster]="${DEFAULT_RECIPIENT_TELEGRAM}"
+# role_recipients_telegram[webmaster]="${DEFAULT_RECIPIENT_TELEGRAM}"
 
-role_recipients_slack[webmaster]="${DEFAULT_RECIPIENT_SLACK}"
+# role_recipients_slack[webmaster]="${DEFAULT_RECIPIENT_SLACK}"
 
-role_recipients_alerta[webmaster]="${DEFAULT_RECIPIENT_ALERTA}"
+# role_recipients_alerta[webmaster]="${DEFAULT_RECIPIENT_ALERTA}"
 
-role_recipients_flock[webmaster]="${DEFAULT_RECIPIENT_FLOCK}"
+# role_recipients_flock[webmaster]="${DEFAULT_RECIPIENT_FLOCK}"
 
-role_recipients_discord[webmaster]="${DEFAULT_RECIPIENT_DISCORD}"
+# role_recipients_discord[webmaster]="${DEFAULT_RECIPIENT_DISCORD}"
 
-role_recipients_hipchat[webmaster]="${DEFAULT_RECIPIENT_HIPCHAT}"
+# role_recipients_hipchat[webmaster]="${DEFAULT_RECIPIENT_HIPCHAT}"
 
-role_recipients_twilio[webmaster]="${DEFAULT_RECIPIENT_TWILIO}"
+# role_recipients_twilio[webmaster]="${DEFAULT_RECIPIENT_TWILIO}"
 
-role_recipients_messagebird[webmaster]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
+# role_recipients_messagebird[webmaster]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
 
-role_recipients_kavenegar[webmaster]="${DEFAULT_RECIPIENT_KAVENEGAR}"
+# role_recipients_kavenegar[webmaster]="${DEFAULT_RECIPIENT_KAVENEGAR}"
 
-role_recipients_pd[webmaster]="${DEFAULT_RECIPIENT_PD}"
+# role_recipients_pd[webmaster]="${DEFAULT_RECIPIENT_PD}"
 
-role_recipients_fleep[webmaster]="${DEFAULT_RECIPIENT_FLEEP}"
+# role_recipients_fleep[webmaster]="${DEFAULT_RECIPIENT_FLEEP}"
 
-role_recipients_irc[webmaster]="${DEFAULT_RECIPIENT_IRC}"
+# role_recipients_irc[webmaster]="${DEFAULT_RECIPIENT_IRC}"
 
-role_recipients_syslog[webmaster]="${DEFAULT_RECIPIENT_SYSLOG}"
+# role_recipients_syslog[webmaster]="${DEFAULT_RECIPIENT_SYSLOG}"
 
-role_recipients_prowl[webmaster]="${DEFAULT_RECIPIENT_PROWL}"
+# role_recipients_prowl[webmaster]="${DEFAULT_RECIPIENT_PROWL}"
 
-role_recipients_awssns[webmaster]="${DEFAULT_RECIPIENT_AWSSNS}"
+# role_recipients_awssns[webmaster]="${DEFAULT_RECIPIENT_AWSSNS}"
 
-role_recipients_custom[webmaster]="${DEFAULT_RECIPIENT_CUSTOM}"
+# role_recipients_custom[webmaster]="${DEFAULT_RECIPIENT_CUSTOM}"
 
-role_recipients_msteams[webmaster]="${DEFAULT_RECIPIENT_MSTEAMS}"
+# role_recipients_msteams[webmaster]="${DEFAULT_RECIPIENT_MSTEAMS}"
 
-role_recipients_rocketchat[webmaster]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
+# role_recipients_rocketchat[webmaster]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
 
-role_recipients_sms[webmaster]="${DEFAULT_RECIPIENT_SMS}"
+# role_recipients_sms[webmaster]="${DEFAULT_RECIPIENT_SMS}"
 
-role_recipients_dynatrace[webmaster]="${DEFAULT_RECIPIENT_DYNATRACE}"
+# role_recipients_dynatrace[webmaster]="${DEFAULT_RECIPIENT_DYNATRACE}"
 
-role_recipients_opsgenie[webmaster]="${DEFAULT_RECIPIENT_OPSGENIE}"
+# role_recipients_opsgenie[webmaster]="${DEFAULT_RECIPIENT_OPSGENIE}"
 
-role_recipients_matrix[webmaster]="${DEFAULT_RECIPIENT_MATRIX}"
+# role_recipients_matrix[webmaster]="${DEFAULT_RECIPIENT_MATRIX}"
 
-role_recipients_stackpulse[webmaster]="${DEFAULT_RECIPIENT_STACKPULSE}"
+# role_recipients_stackpulse[webmaster]="${DEFAULT_RECIPIENT_STACKPULSE}"
 
-role_recipients_gotify[webmaster]="${DEFAULT_RECIPIENT_GOTIFY}"
+# role_recipients_gotify[webmaster]="${DEFAULT_RECIPIENT_GOTIFY}"
 
-role_recipients_ntfy[webmaster]="${DEFAULT_RECIPIENT_NTFY}"
+# role_recipients_ntfy[webmaster]="${DEFAULT_RECIPIENT_NTFY}"
 
 # -----------------------------------------------------------------------------
 # proxy servers alarms
 # squid, etc
 
-role_recipients_email[proxyadmin]="${DEFAULT_RECIPIENT_EMAIL}"
+# role_recipients_email[proxyadmin]="${DEFAULT_RECIPIENT_EMAIL}"
 
-role_recipients_hangouts[proxyadmin]="${DEFAULT_RECIPIENT_HANGOUTS}"
+# role_recipients_hangouts[proxyadmin]="${DEFAULT_RECIPIENT_HANGOUTS}"
 
-role_recipients_pushover[proxyadmin]="${DEFAULT_RECIPIENT_PUSHOVER}"
+# role_recipients_pushover[proxyadmin]="${DEFAULT_RECIPIENT_PUSHOVER}"
 
-role_recipients_pushbullet[proxyadmin]="${DEFAULT_RECIPIENT_PUSHBULLET}"
+# role_recipients_pushbullet[proxyadmin]="${DEFAULT_RECIPIENT_PUSHBULLET}"
 
-role_recipients_telegram[proxyadmin]="${DEFAULT_RECIPIENT_TELEGRAM}"
+# role_recipients_telegram[proxyadmin]="${DEFAULT_RECIPIENT_TELEGRAM}"
 
-role_recipients_slack[proxyadmin]="${DEFAULT_RECIPIENT_SLACK}"
+# role_recipients_slack[proxyadmin]="${DEFAULT_RECIPIENT_SLACK}"
 
-role_recipients_alerta[proxyadmin]="${DEFAULT_RECIPIENT_ALERTA}"
+# role_recipients_alerta[proxyadmin]="${DEFAULT_RECIPIENT_ALERTA}"
 
-role_recipients_flock[proxyadmin]="${DEFAULT_RECIPIENT_FLOCK}"
+# role_recipients_flock[proxyadmin]="${DEFAULT_RECIPIENT_FLOCK}"
 
-role_recipients_discord[proxyadmin]="${DEFAULT_RECIPIENT_DISCORD}"
+# role_recipients_discord[proxyadmin]="${DEFAULT_RECIPIENT_DISCORD}"
 
-role_recipients_hipchat[proxyadmin]="${DEFAULT_RECIPIENT_HIPCHAT}"
+# role_recipients_hipchat[proxyadmin]="${DEFAULT_RECIPIENT_HIPCHAT}"
 
-role_recipients_twilio[proxyadmin]="${DEFAULT_RECIPIENT_TWILIO}"
+# role_recipients_twilio[proxyadmin]="${DEFAULT_RECIPIENT_TWILIO}"
 
-role_recipients_messagebird[proxyadmin]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
+# role_recipients_messagebird[proxyadmin]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
 
-role_recipients_kavenegar[proxyadmin]="${DEFAULT_RECIPIENT_KAVENEGAR}"
+# role_recipients_kavenegar[proxyadmin]="${DEFAULT_RECIPIENT_KAVENEGAR}"
 
-role_recipients_pd[proxyadmin]="${DEFAULT_RECIPIENT_PD}"
+# role_recipients_pd[proxyadmin]="${DEFAULT_RECIPIENT_PD}"
 
-role_recipients_fleep[proxyadmin]="${DEFAULT_RECIPIENT_FLEEP}"
+# role_recipients_fleep[proxyadmin]="${DEFAULT_RECIPIENT_FLEEP}"
 
-role_recipients_irc[proxyadmin]="${DEFAULT_RECIPIENT_IRC}"
+# role_recipients_irc[proxyadmin]="${DEFAULT_RECIPIENT_IRC}"
 
-role_recipients_syslog[proxyadmin]="${DEFAULT_RECIPIENT_SYSLOG}"
+# role_recipients_syslog[proxyadmin]="${DEFAULT_RECIPIENT_SYSLOG}"
 
-role_recipients_prowl[proxyadmin]="${DEFAULT_RECIPIENT_PROWL}"
+# role_recipients_prowl[proxyadmin]="${DEFAULT_RECIPIENT_PROWL}"
 
-role_recipients_awssns[proxyadmin]="${DEFAULT_RECIPIENT_AWSSNS}"
+# role_recipients_awssns[proxyadmin]="${DEFAULT_RECIPIENT_AWSSNS}"
 
-role_recipients_custom[proxyadmin]="${DEFAULT_RECIPIENT_CUSTOM}"
+# role_recipients_custom[proxyadmin]="${DEFAULT_RECIPIENT_CUSTOM}"
 
-role_recipients_msteams[proxyadmin]="${DEFAULT_RECIPIENT_MSTEAMS}"
+# role_recipients_msteams[proxyadmin]="${DEFAULT_RECIPIENT_MSTEAMS}"
 
-role_recipients_rocketchat[proxyadmin]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
+# role_recipients_rocketchat[proxyadmin]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
 
-role_recipients_sms[proxyadmin]="${DEFAULT_RECIPIENT_SMS}"
+# role_recipients_sms[proxyadmin]="${DEFAULT_RECIPIENT_SMS}"
 
-role_recipients_dynatrace[proxyadmin]="${DEFAULT_RECIPIENT_DYNATRACE}"
+# role_recipients_dynatrace[proxyadmin]="${DEFAULT_RECIPIENT_DYNATRACE}"
 
-role_recipients_opsgenie[proxyadmin]="${DEFAULT_RECIPIENT_OPSGENIE}"
+# role_recipients_opsgenie[proxyadmin]="${DEFAULT_RECIPIENT_OPSGENIE}"
 
-role_recipients_matrix[proxyadmin]="${DEFAULT_RECIPIENT_MATRIX}"
+# role_recipients_matrix[proxyadmin]="${DEFAULT_RECIPIENT_MATRIX}"
 
-role_recipients_stackpulse[proxyadmin]="${DEFAULT_RECIPIENT_STACKPULSE}"
+# role_recipients_stackpulse[proxyadmin]="${DEFAULT_RECIPIENT_STACKPULSE}"
 
-role_recipients_gotify[proxyadmin]="${DEFAULT_RECIPIENT_GOTIFY}"
+# role_recipients_gotify[proxyadmin]="${DEFAULT_RECIPIENT_GOTIFY}"
 
-role_recipients_ntfy[proxyadmin]="${DEFAULT_RECIPIENT_NTFY}"
+# role_recipients_ntfy[proxyadmin]="${DEFAULT_RECIPIENT_NTFY}"
 
 # -----------------------------------------------------------------------------
 # peripheral devices
 # UPS, photovoltaics, etc
 
-role_recipients_email[sitemgr]="${DEFAULT_RECIPIENT_EMAIL}"
+# role_recipients_email[sitemgr]="${DEFAULT_RECIPIENT_EMAIL}"
 
-role_recipients_hangouts[sitemgr]="${DEFAULT_RECIPIENT_HANGOUTS}"
+# role_recipients_hangouts[sitemgr]="${DEFAULT_RECIPIENT_HANGOUTS}"
 
-role_recipients_pushover[sitemgr]="${DEFAULT_RECIPIENT_PUSHOVER}"
+# role_recipients_pushover[sitemgr]="${DEFAULT_RECIPIENT_PUSHOVER}"
 
-role_recipients_pushbullet[sitemgr]="${DEFAULT_RECIPIENT_PUSHBULLET}"
+# role_recipients_pushbullet[sitemgr]="${DEFAULT_RECIPIENT_PUSHBULLET}"
 
-role_recipients_telegram[sitemgr]="${DEFAULT_RECIPIENT_TELEGRAM}"
+# role_recipients_telegram[sitemgr]="${DEFAULT_RECIPIENT_TELEGRAM}"
 
-role_recipients_slack[sitemgr]="${DEFAULT_RECIPIENT_SLACK}"
+# role_recipients_slack[sitemgr]="${DEFAULT_RECIPIENT_SLACK}"
 
-role_recipients_alerta[sitemgr]="${DEFAULT_RECIPIENT_ALERTA}"
+# role_recipients_alerta[sitemgr]="${DEFAULT_RECIPIENT_ALERTA}"
 
-role_recipients_flock[sitemgr]="${DEFAULT_RECIPIENT_FLOCK}"
+# role_recipients_flock[sitemgr]="${DEFAULT_RECIPIENT_FLOCK}"
 
-role_recipients_discord[sitemgr]="${DEFAULT_RECIPIENT_DISCORD}"
+# role_recipients_discord[sitemgr]="${DEFAULT_RECIPIENT_DISCORD}"
 
-role_recipients_hipchat[sitemgr]="${DEFAULT_RECIPIENT_HIPCHAT}"
+# role_recipients_hipchat[sitemgr]="${DEFAULT_RECIPIENT_HIPCHAT}"
 
-role_recipients_twilio[sitemgr]="${DEFAULT_RECIPIENT_TWILIO}"
+# role_recipients_twilio[sitemgr]="${DEFAULT_RECIPIENT_TWILIO}"
 
-role_recipients_messagebird[sitemgr]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
+# role_recipients_messagebird[sitemgr]="${DEFAULT_RECIPIENT_MESSAGEBIRD}"
 
-role_recipients_kavenegar[sitemgr]="${DEFAULT_RECIPIENT_KAVENEGAR}"
+# role_recipients_kavenegar[sitemgr]="${DEFAULT_RECIPIENT_KAVENEGAR}"
 
-role_recipients_pd[sitemgr]="${DEFAULT_RECIPIENT_PD}"
+# role_recipients_pd[sitemgr]="${DEFAULT_RECIPIENT_PD}"
 
-role_recipients_fleep[sitemgr]="${DEFAULT_RECIPIENT_FLEEP}"
+# role_recipients_fleep[sitemgr]="${DEFAULT_RECIPIENT_FLEEP}"
 
-role_recipients_syslog[sitemgr]="${DEFAULT_RECIPIENT_SYSLOG}"
+# role_recipients_syslog[sitemgr]="${DEFAULT_RECIPIENT_SYSLOG}"
 
-role_recipients_prowl[sitemgr]="${DEFAULT_RECIPIENT_PROWL}"
+# role_recipients_prowl[sitemgr]="${DEFAULT_RECIPIENT_PROWL}"
 
-role_recipients_awssns[sitemgr]="${DEFAULT_RECIPIENT_AWSSNS}"
+# role_recipients_awssns[sitemgr]="${DEFAULT_RECIPIENT_AWSSNS}"
 
-role_recipients_custom[sitemgr]="${DEFAULT_RECIPIENT_CUSTOM}"
+# role_recipients_custom[sitemgr]="${DEFAULT_RECIPIENT_CUSTOM}"
 
-role_recipients_msteams[sitemgr]="${DEFAULT_RECIPIENT_MSTEAMS}"
+# role_recipients_msteams[sitemgr]="${DEFAULT_RECIPIENT_MSTEAMS}"
 
-role_recipients_rocketchat[sitemgr]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
+# role_recipients_rocketchat[sitemgr]="${DEFAULT_RECIPIENT_ROCKETCHAT}"
 
-role_recipients_sms[sitemgr]="${DEFAULT_RECIPIENT_SMS}"
+# role_recipients_sms[sitemgr]="${DEFAULT_RECIPIENT_SMS}"
 
-role_recipients_dynatrace[sitemgr]="${DEFAULT_RECIPIENT_DYNATRACE}"
+# role_recipients_dynatrace[sitemgr]="${DEFAULT_RECIPIENT_DYNATRACE}"
 
-role_recipients_opsgenie[sitemgr]="${DEFAULT_RECIPIENT_OPSGENIE}"
+# role_recipients_opsgenie[sitemgr]="${DEFAULT_RECIPIENT_OPSGENIE}"
 
-role_recipients_matrix[sitemgr]="${DEFAULT_RECIPIENT_MATRIX}"
+# role_recipients_matrix[sitemgr]="${DEFAULT_RECIPIENT_MATRIX}"
 
-role_recipients_stackpulse[sitemgr]="${DEFAULT_RECIPIENT_STACKPULSE}"
+# role_recipients_stackpulse[sitemgr]="${DEFAULT_RECIPIENT_STACKPULSE}"
 
-role_recipients_gotify[sitemgr]="${DEFAULT_RECIPIENT_GOTIFY}"
+# role_recipients_gotify[sitemgr]="${DEFAULT_RECIPIENT_GOTIFY}"
 
-role_recipients_ntfy[sitemgr]="${DEFAULT_RECIPIENT_NTFY}"
+# role_recipients_ntfy[sitemgr]="${DEFAULT_RECIPIENT_NTFY}"


### PR DESCRIPTION
##### Summary

Fixes #5887

As discussed on that issue, I was recently affected by the issue that was mentioned, and the solution suggested initially worked for me. However, I wondered if there was a better way to fix this.

What this PR does is comment out the default `role_recipients_*` configuration in the `health_alarm_notify.conf` file. The reason for this is that if those values are left in place, and someone is using a custom copy of `health_alarm_notify.conf` that doesn't overwrite these values, then this default value will always be used as this file is evaluated first by `alarm-notify.sh`.

However, `alarm-notify.sh` falls back to the relevant `DEFAULT_RECIPIENT_*` variable if these values aren't set. This means that the current behaviour is maintained, but it allows someone to either overwrite the relevant `DEFAULT_RECIPIENT_` variable or use a custom `role_recipients_` variable for a specific category of service.

##### Test Plan

The most basic test is to have a custom `health_alarm_notify.conf` file (for example, in `/etc/netdata`):

```
SEND_EMAIL="YES"
EMAIL_SENDER="netdata@example.com"
DEFAULT_RECIPIENT_EMAIL="sysadmin@example.com"
```

Before these changes are implemented, all emails will go to `root` of the server that is running Netdata, because `role_recipients_email[sysadmin]` (for example) is set by the original `health_alarm_notify.conf` file, but is not subsequently overwritten by our custom configuration.

Once the change has been implemented, Netdata will correctly send emails to `sysadmin@example.com` as the `alarm-notify.sh` script will refer back to `DEFAULT_RECIPIENT_EMAIL` if the relevant `role_recipients_email` value is not set.

You can also test this when subsequently overwriting the `role_recipients_email` array:

```
SEND_EMAIL="YES"
EMAIL_SENDER="netdata@example.com"
DEFAULT_RECIPIENT_EMAIL="sysadmin@example.com"
role_recipients_email[sysadmin]="recipient@example.com"
```

In this case, the Netdata notification is correctly sent to `recipient@example.com`.

##### Additional Information

I believe the comments in #5887 explain the issue and hopefully the steps above help with explaining why this change is necessary.

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->

- The area of Netdata affected by this change is the notification configuration and alarm sending process
- This change is under the hood, and is only relevant to those customising their notification configuration
- A user with a non-standard `health_alarm_notify.conf` file can now correctly receive notifications, which may have been silently disappearing before
</details>
