### PR TITLE
Fix incorrect response format

### DIFF
--- a/web/api/netdata-swagger.json
+++ b/web/api/netdata-swagger.json
@@ -3828,162 +3828,161 @@
           },
           "alarms": {
             "type": "object",
-            "properties": {
-              "chart-name.alarm-name": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "name": {
-                    "type": "string",
-                    "description": "Full alarm name."
-                  },
-                  "chart": {
-                    "type": "string"
-                  },
-                  "family": {
-                    "type": "string"
-                  },
-                  "active": {
-                    "type": "boolean",
-                    "description": "Will be false only if the alarm is disabled in the configuration."
-                  },
-                  "disabled": {
-                    "type": "boolean",
-                    "description": "Whether the health check for this alarm has been disabled via a health command API DISABLE command."
-                  },
-                  "silenced": {
-                    "type": "boolean",
-                    "description": "Whether notifications for this alarm have been silenced via a health command API SILENCE command."
-                  },
-                  "exec": {
-                    "type": "string"
-                  },
-                  "recipient": {
-                    "type": "string"
-                  },
-                  "source": {
-                    "type": "string"
-                  },
-                  "units": {
-                    "type": "string"
-                  },
-                  "info": {
-                    "type": "string"
-                  },
-                  "status": {
-                    "type": "string"
-                  },
-                  "last_status_change": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "last_updated": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "next_update": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "update_every": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "delay_up_duration": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "delay_down_duration": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "delay_max_duration": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "delay_multiplier": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "delay": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "delay_up_to_timestamp": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "value_string": {
-                    "type": "string"
-                  },
-                  "no_clear_notification": {
-                    "type": "boolean"
-                  },
-                  "lookup_dimensions": {
-                    "type": "string"
-                  },
-                  "db_after": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "db_before": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "lookup_method": {
-                    "type": "string"
-                  },
-                  "lookup_after": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "lookup_before": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "lookup_options": {
-                    "type": "string"
-                  },
-                  "calc": {
-                    "type": "string"
-                  },
-                  "calc_parsed": {
-                    "type": "string"
-                  },
-                  "warn": {
-                    "type": "string"
-                  },
-                  "warn_parsed": {
-                    "type": "string"
-                  },
-                  "crit": {
-                    "type": "string"
-                  },
-                  "crit_parsed": {
-                    "type": "string"
-                  },
-                  "warn_repeat_every": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "crit_repeat_every": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "green": {
-                    "type": "string",
-                    "format": "nullable"
-                  },
-                  "red": {
-                    "type": "string",
-                    "format": "nullable"
-                  },
-                  "value": {
-                    "type": "number"
-                  }
+            "description": "The keys in this dictionary are made from `chart` and `name` parameters of the associated data, separated by a dot.",
+            "additionalProperties": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Full alarm name."
+                },
+                "chart": {
+                  "type": "string"
+                },
+                "family": {
+                  "type": "string"
+                },
+                "active": {
+                  "type": "boolean",
+                  "description": "Will be false only if the alarm is disabled in the configuration."
+                },
+                "disabled": {
+                  "type": "boolean",
+                  "description": "Whether the health check for this alarm has been disabled via a health command API DISABLE command."
+                },
+                "silenced": {
+                  "type": "boolean",
+                  "description": "Whether notifications for this alarm have been silenced via a health command API SILENCE command."
+                },
+                "exec": {
+                  "type": "string"
+                },
+                "recipient": {
+                  "type": "string"
+                },
+                "source": {
+                  "type": "string"
+                },
+                "units": {
+                  "type": "string"
+                },
+                "info": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                },
+                "last_status_change": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "last_updated": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "next_update": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "update_every": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "delay_up_duration": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "delay_down_duration": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "delay_max_duration": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "delay_multiplier": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "delay": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "delay_up_to_timestamp": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "value_string": {
+                  "type": "string"
+                },
+                "no_clear_notification": {
+                  "type": "boolean"
+                },
+                "lookup_dimensions": {
+                  "type": "string"
+                },
+                "db_after": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "db_before": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "lookup_method": {
+                  "type": "string"
+                },
+                "lookup_after": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "lookup_before": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "lookup_options": {
+                  "type": "string"
+                },
+                "calc": {
+                  "type": "string"
+                },
+                "calc_parsed": {
+                  "type": "string"
+                },
+                "warn": {
+                  "type": "string"
+                },
+                "warn_parsed": {
+                  "type": "string"
+                },
+                "crit": {
+                  "type": "string"
+                },
+                "crit_parsed": {
+                  "type": "string"
+                },
+                "warn_repeat_every": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "crit_repeat_every": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "green": {
+                  "type": "string",
+                  "format": "nullable"
+                },
+                "red": {
+                  "type": "string",
+                  "format": "nullable"
+                },
+                "value": {
+                  "type": "number"
                 }
               }
             }

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -2832,122 +2832,122 @@ components:
           format: int32
         alarms:
           type: object
-          properties:
-            chart-name.alarm-name:
-              type: object
-              properties:
-                id:
-                  type: integer
-                  format: int32
-                name:
-                  type: string
-                  description: Full alarm name.
-                chart:
-                  type: string
-                family:
-                  type: string
-                active:
-                  type: boolean
-                  description: Will be false only if the alarm is disabled in the
-                    configuration.
-                disabled:
-                  type: boolean
-                  description: Whether the health check for this alarm has been disabled
-                    via a health command API DISABLE command.
-                silenced:
-                  type: boolean
-                  description: Whether notifications for this alarm have been silenced via
-                    a health command API SILENCE command.
-                exec:
-                  type: string
-                recipient:
-                  type: string
-                source:
-                  type: string
-                units:
-                  type: string
-                info:
-                  type: string
-                status:
-                  type: string
-                last_status_change:
-                  type: integer
-                  format: int32
-                last_updated:
-                  type: integer
-                  format: int32
-                next_update:
-                  type: integer
-                  format: int32
-                update_every:
-                  type: integer
-                  format: int32
-                delay_up_duration:
-                  type: integer
-                  format: int32
-                delay_down_duration:
-                  type: integer
-                  format: int32
-                delay_max_duration:
-                  type: integer
-                  format: int32
-                delay_multiplier:
-                  type: integer
-                  format: int32
-                delay:
-                  type: integer
-                  format: int32
-                delay_up_to_timestamp:
-                  type: integer
-                  format: int32
-                value_string:
-                  type: string
-                no_clear_notification:
-                  type: boolean
-                lookup_dimensions:
-                  type: string
-                db_after:
-                  type: integer
-                  format: int32
-                db_before:
-                  type: integer
-                  format: int32
-                lookup_method:
-                  type: string
-                lookup_after:
-                  type: integer
-                  format: int32
-                lookup_before:
-                  type: integer
-                  format: int32
-                lookup_options:
-                  type: string
-                calc:
-                  type: string
-                calc_parsed:
-                  type: string
-                warn:
-                  type: string
-                warn_parsed:
-                  type: string
-                crit:
-                  type: string
-                crit_parsed:
-                  type: string
-                warn_repeat_every:
-                  type: integer
-                  format: int32
-                crit_repeat_every:
-                  type: integer
-                  format: int32
-                green:
-                  type: string
-                  format: nullable
-                red:
-                  type: string
-                  format: nullable
-                value:
-                  type: number
+          description: The keys in this dictionary are made from `chart` and `name` parameters of the associated data, separated by a dot.
+          additionalProperties:
+            type: object
+            properties:
+              id:
+                type: integer
+                format: int32
+              name:
+                type: string
+                description: Full alarm name.
+              chart:
+                type: string
+              family:
+                type: string
+              active:
+                type: boolean
+                description: Will be false only if the alarm is disabled in the
+                  configuration.
+              disabled:
+                type: boolean
+                description: Whether the health check for this alarm has been disabled
+                  via a health command API DISABLE command.
+              silenced:
+                type: boolean
+                description: Whether notifications for this alarm have been silenced via
+                  a health command API SILENCE command.
+              exec:
+                type: string
+              recipient:
+                type: string
+              source:
+                type: string
+              units:
+                type: string
+              info:
+                type: string
+              status:
+                type: string
+              last_status_change:
+                type: integer
+                format: int32
+              last_updated:
+                type: integer
+                format: int32
+              next_update:
+                type: integer
+                format: int32
+              update_every:
+                type: integer
+                format: int32
+              delay_up_duration:
+                type: integer
+                format: int32
+              delay_down_duration:
+                type: integer
+                format: int32
+              delay_max_duration:
+                type: integer
+                format: int32
+              delay_multiplier:
+                type: integer
+                format: int32
+              delay:
+                type: integer
+                format: int32
+              delay_up_to_timestamp:
+                type: integer
+                format: int32
+              value_string:
+                type: string
+              no_clear_notification:
+                type: boolean
+              lookup_dimensions:
+                type: string
+              db_after:
+                type: integer
+                format: int32
+              db_before:
+                type: integer
+                format: int32
+              lookup_method:
+                type: string
+              lookup_after:
+                type: integer
+                format: int32
+              lookup_before:
+                type: integer
+                format: int32
+              lookup_options:
+                type: string
+              calc:
+                type: string
+              calc_parsed:
+                type: string
+              warn:
+                type: string
+              warn_parsed:
+                type: string
+              crit:
+                type: string
+              crit_parsed:
+                type: string
+              warn_repeat_every:
+                type: integer
+                format: int32
+              crit_repeat_every:
+                type: integer
+                format: int32
+              green:
+                type: string
+                format: nullable
+              red:
+                type: string
+                format: nullable
+              value:
+                type: number
     alarm_log_entry:
       type: object
       properties:


### PR DESCRIPTION
##### Summary

Made a change to the swagger YAML file so it now correctly describes the format of the response to the `api/v1/alarms` endpoint. The `alarms` parameter in this response actually returns a map/dictionary, with the keys determined by the chart/name parameters of the alarm - but the docs said that it returned a single sub-object named `chart-name.alarm-name`. If you run this through a code generator, or otherwise just read it literally, this is misleading.

##### Test Plan
N/A (as far as I'm aware?)

##### Additional Information
This was only an issue for me because I ran the YAML through [OpenAPI Generator](https://openapi-generator.tech/) and it gave me some erroneous model classes because of this issue.


| Before | After |
|--|--|
| ![firefox_oztcDiXDji](https://github.com/netdata/netdata/assets/20978454/6167ecd4-3749-465d-a9c1-454122411072) | ![firefox_N9NP2xv3uP](https://github.com/netdata/netdata/assets/20978454/a7e3c54c-4026-4051-9e47-901f9bbd8f71) |

<details> <summary>For users: How does this change affect me?</summary>

More accurate docs!
