### PR TITLE
fix(debugfs/zswap): don't collect metrics if Zswap is disabled

### DIFF
--- a/collectors/debugfs.plugin/debugfs_zswap.c
+++ b/collectors/debugfs.plugin/debugfs_zswap.c
@@ -250,7 +250,7 @@ int zswap_collect_data(struct netdata_zswap_metric *metric)
     char filename[FILENAME_MAX + 1];
     snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, metric->filename);
 
-    if (read_single_number_file(filename, &metric->value)) {
+    if (read_single_number_file(filename, (unsigned long long *)&metric->value)) {
         error("Cannot read file %s", filename);
         return 1;
     }


### PR DESCRIPTION
##### Summary


ssia, gather Zswap status from `/sys/module/zswap/parameters/enabled`.

Additionally, this PR simplifies the `zswap_collect_data()` function.

##### Test Plan

- test with disabled Zswap => no Zswap charts.
- test with enabled Zswap => Zswap charts.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
