### PR TITLE
Simplify loop in alert checkpoint

### DIFF
--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -1038,6 +1038,7 @@ static inline int compare_active_alerts(const void * a, const void * b) {
         return strcmp(active_alerts_a->name, active_alerts_b->name);
 }
 
+#define BATCH_ALLOCATED 10
 void aclk_push_alarm_checkpoint(RRDHOST *host __maybe_unused)
 {
 #ifdef ENABLE_ACLK
@@ -1047,7 +1048,6 @@ void aclk_push_alarm_checkpoint(RRDHOST *host __maybe_unused)
         return;
     }
 
-    //TODO: make sure all pending events are sent.
     if (rrdhost_flag_check(host, RRDHOST_FLAG_ACLK_STREAM_ALERTS)) {
         //postpone checkpoint send
         wc->alert_checkpoint_req++;
@@ -1055,13 +1055,11 @@ void aclk_push_alarm_checkpoint(RRDHOST *host __maybe_unused)
         return;
     }
 
-    //TODO: lock rc here, or make sure it's called when health decides
-    //count them
     RRDCALC *rc;
     uint32_t cnt = 0;
     size_t len = 0;
-    active_alerts_t *active_alerts = NULL;
 
+    active_alerts_t *active_alerts = callocz(BATCH_ALLOCATED, sizeof(active_alerts_t));
     foreach_rrdcalc_in_rrdhost_read(host, rc) {
         if(unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
             continue;
@@ -1069,32 +1067,20 @@ void aclk_push_alarm_checkpoint(RRDHOST *host __maybe_unused)
         if (rc->status == RRDCALC_STATUS_WARNING ||
             rc->status == RRDCALC_STATUS_CRITICAL) {
 
+            if (cnt && !(cnt % BATCH_ALLOCATED)) {
+                active_alerts = reallocz(active_alerts, (BATCH_ALLOCATED * ((cnt / BATCH_ALLOCATED) + 1)) * sizeof(active_alerts_t));
+            }
+
+            active_alerts[cnt].name = (char *)rrdcalc_name(rc);
+            len += string_strlen(rc->name);
+            active_alerts[cnt].chart = (char *)rrdcalc_chart_name(rc);
+            len += string_strlen(rc->chart);
+            active_alerts[cnt].status = rc->status;
+            len++;
             cnt++;
         }
     }
     foreach_rrdcalc_in_rrdhost_done(rc);
-
-    if (cnt) {
-        active_alerts = callocz(cnt, sizeof(active_alerts_t));
-        cnt = 0;
-        foreach_rrdcalc_in_rrdhost_read(host, rc) {
-            if(unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
-                continue;
-
-            if (rc->status == RRDCALC_STATUS_WARNING ||
-                rc->status == RRDCALC_STATUS_CRITICAL) {
-
-                active_alerts[cnt].name = (char *)rrdcalc_name(rc);
-                len += string_strlen(rc->name);
-                active_alerts[cnt].chart = (char *)rrdcalc_chart_name(rc);
-                len += string_strlen(rc->chart);
-                active_alerts[cnt].status = rc->status;
-                len++;
-                cnt++;
-            }
-        }
-        foreach_rrdcalc_in_rrdhost_done(rc);
-    }
 
     BUFFER *alarms_to_hash;
     if (cnt) {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

A small PR to simplify the loop in alerts checkpoint. Instead of doing 2 loops (one to count rcs, one to gather them) it does one. As suggested by @stelfrag, it could happen that the count changes between loops (due to changes in rrdsets).

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Claim an agent to the cloud. Raise some alerts, and wait 15 minutes after start. Check the access.log which should indicate an incoming request for a checkpoint, and a subsequent sending. There should not be a snapshot following this exchange.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
