### PR TITLE
Upgrade TLS (Web and H2o)

### DIFF
--- a/httpd/http_server.c
+++ b/httpd/http_server.c
@@ -76,6 +76,9 @@ static int ssl_init()
 
     SSL_CTX_set_options(accept_ctx.ssl_ctx, SSL_OP_NO_SSLv2);
 
+    SSL_CTX_set_min_proto_version(accept_ctx.ssl_ctx, TLS1_2_VERSION);
+    SSL_CTX_set_max_proto_version(accept_ctx.ssl_ctx, TLS_MAX_VERSION);
+
     /* load certificate and private key */
     if (SSL_CTX_use_PrivateKey_file(accept_ctx.ssl_ctx, key_fn, SSL_FILETYPE_PEM) != 1) {
         error("Could not load server key from \"%s\"", key_fn);

--- a/httpd/http_server.c
+++ b/httpd/http_server.c
@@ -76,8 +76,10 @@ static int ssl_init()
 
     SSL_CTX_set_options(accept_ctx.ssl_ctx, SSL_OP_NO_SSLv2);
 
+#if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_110
     SSL_CTX_set_min_proto_version(accept_ctx.ssl_ctx, TLS1_2_VERSION);
     SSL_CTX_set_max_proto_version(accept_ctx.ssl_ctx, TLS_MAX_VERSION);
+#endif
 
     /* load certificate and private key */
     if (SSL_CTX_use_PrivateKey_file(accept_ctx.ssl_ctx, key_fn, SSL_FILETYPE_PEM) != 1) {

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -95,7 +95,11 @@ void security_openssl_common_options(SSL_CTX *ctx, int side) {
 #if OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110
         SSL_CTX_set_options (ctx,SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_COMPRESSION);
 #else
-        SSL_CTX_set_min_proto_version(ctx, TLS1_VERSION);
+        if (version < TLS1_2_VERSION) {
+            info("An old TLS version selected was selected, netdata is upgrading for TLS 1.2");
+            version = TLS1_2_VERSION;
+        }
+        SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
         SSL_CTX_set_max_proto_version(ctx, version);
 
         if(tls_ciphers  && strcmp(tls_ciphers, "none") != 0) {

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -131,7 +131,7 @@ SSL_CTX * security_initialize_openssl_client() {
 #if OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110
         SSL_CTX_set_options (ctx,SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_COMPRESSION);
 #else
-        SSL_CTX_set_min_proto_version(ctx, TLS1_VERSION);
+        SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
 # if defined(TLS_MAX_VERSION)
         SSL_CTX_set_max_proto_version(ctx, TLS_MAX_VERSION);
 # elif defined(TLS1_3_VERSION)

--- a/libnetdata/socket/security.h
+++ b/libnetdata/socket/security.h
@@ -9,7 +9,7 @@
 # define NETDATA_SSL_OPTIONAL 16             //Flag to define the HTTP request
 # define NETDATA_SSL_FORCE 32                //We only accepts HTTPS request
 # define NETDATA_SSL_INVALID_CERTIFICATE 64  //Accepts invalid certificate
-# define NETDATA_SSL_VALID_CERTIFICATE 128  //Accepts invalid certificate
+# define NETDATA_SSL_VALID_CERTIFICATE 128  //Accepts valid certificate
 # define NETDATA_SSL_PROXY_HTTPS 256        //Proxy is using HTTPS
 
 #define NETDATA_SSL_CONTEXT_SERVER 0


### PR DESCRIPTION
##### Summary
One of issues we have to address to reach our main goal (https://github.com/netdata/netdata/issues/15069) is to force agents to use at least `TLS 1.2`. As first step in this direction this PR is modifying our web servers to select the newest TLS versions.

##### Test Plan

1. Compile this branch
2. Set certificate inside `netdata.conf`:
```sh
[web]
        ssl key = /etc/netdata/ssl/key.pem
        ssl certificate = /etc/netdata/ssl/cert.pem
[httpd]
      enabled = yes
        ssl = yes
        ssl key = /etc/netdata/ssl/key.pem
        ssl certificate = /etc/netdata/ssl/cert.pem
```
3. Test dashboard access.
4. Compile branch on client and test streaming.

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? web servers
- Can they see the change or is it an under the hood? If they can see it, where? This is not transparent for users
- How is the user impacted by the change? A more safety software
- What are there any benefits of the change? users will not use deprecated TLS protocols
</details>
