### PR TITLE
Python Dependency Migration - OracleDB Python Module

### DIFF
--- a/collectors/python.d.plugin/oracledb/README.md
+++ b/collectors/python.d.plugin/oracledb/README.md
@@ -13,8 +13,7 @@ Monitors the performance and health metrics of the Oracle database.
 
 ## Requirements
 
--   `cx_Oracle` package.
--   Oracle Client (using `cx_Oracle` requires Oracle Client libraries to be installed).
+-   `oracledb` package.
 
 It produces following charts:
 
@@ -53,18 +52,13 @@ It produces following charts:
 
 To use the Oracle module do the following:
 
-1.  Install `cx_Oracle` package ([link](https://cx-oracle.readthedocs.io/en/latest/user_guide/installation.html)).
-
-2.  Install Oracle Client libraries
-    ([link](https://cx-oracle.readthedocs.io/en/latest/user_guide/installation.html#install-oracle-client)).
+1.  Install `oracledb` package ([link](https://python-oracledb.readthedocs.io/en/latest/user_guide/installation.html)).
 
 3.  Create a read-only `netdata` user with proper access to your Oracle Database Server.
 
 Connect to your Oracle database with an administrative user and execute:
 
 ```
-ALTER SESSION SET "_ORACLE_SCRIPT"=true;
-
 CREATE USER netdata IDENTIFIED BY <PASSWORD>;
 
 GRANT CONNECT TO netdata;
@@ -85,14 +79,13 @@ sudo ./edit-config python.d/oracledb.conf
 local:
   user: 'netdata'
   password: 'secret'
-  server: 'localhost:1521'
-  service: 'XE'
+  cs: '(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=adb.us-ashburn-1.oraclecloud.com))(connect_data=(service_name=sdf98789f98sfs98f_projectid_low.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))'
+
 
 remote:
   user: 'netdata'
   password: 'secret'
-  server: '10.0.0.1:1521'
-  service: 'XE'
+  cs: '(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=adb.us-ashburn-1.oraclecloud.com))(connect_data=(service_name=sdf98789f98sfs98f_projectid_low.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))'
 ```
 
 All parameters are required. Without them module will fail to start.

--- a/collectors/python.d.plugin/oracledb/README.md
+++ b/collectors/python.d.plugin/oracledb/README.md
@@ -65,8 +65,6 @@ GRANT CONNECT TO netdata;
 GRANT SELECT_CATALOG_ROLE TO netdata;
 ```
 
-3.  Get or create a [data source name](https://python-oracledb.readthedocs.io/en/latest/user_guide/connection_handling.html#connection-strings) for your database.
-
 ## Configuration
 
 Edit the `python.d/oracledb.conf` configuration file using `edit-config` from the Netdata [config
@@ -81,13 +79,15 @@ sudo ./edit-config python.d/oracledb.conf
 local:
   user: 'netdata'
   password: 'secret'
-  dsn: '(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=adb.us-ashburn-1.oraclecloud.com))(connect_data=(service_name=sdf98789f98sfs98f_projectid_low.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))'
+  server: 'localhost:1521'
+  service: 'XE'
 
 
 remote:
   user: 'netdata'
   password: 'secret'
-  dsn: '(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=adb.us-ashburn-1.oraclecloud.com))(connect_data=(service_name=sdf98789f98sfs98f_projectid_low.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))'
+  server: '10.0.0.1:1521'
+  service: 'XE'
 ```
 
 All parameters are required. Without them module will fail to start.

--- a/collectors/python.d.plugin/oracledb/README.md
+++ b/collectors/python.d.plugin/oracledb/README.md
@@ -65,7 +65,7 @@ GRANT CONNECT TO netdata;
 GRANT SELECT_CATALOG_ROLE TO netdata;
 ```
 
-4.  Get or create a [data source name](https://python-oracledb.readthedocs.io/en/latest/user_guide/connection_handling.html#connection-strings) for your database.
+3.  Get or create a [data source name](https://python-oracledb.readthedocs.io/en/latest/user_guide/connection_handling.html#connection-strings) for your database.
 
 ## Configuration
 

--- a/collectors/python.d.plugin/oracledb/README.md
+++ b/collectors/python.d.plugin/oracledb/README.md
@@ -54,7 +54,7 @@ To use the Oracle module do the following:
 
 1.  Install `oracledb` package ([link](https://python-oracledb.readthedocs.io/en/latest/user_guide/installation.html)).
 
-3.  Create a read-only `netdata` user with proper access to your Oracle Database Server.
+2.  Create a read-only `netdata` user with proper access to your Oracle Database Server.
 
 Connect to your Oracle database with an administrative user and execute:
 

--- a/collectors/python.d.plugin/oracledb/README.md
+++ b/collectors/python.d.plugin/oracledb/README.md
@@ -58,12 +58,14 @@ To use the Oracle module do the following:
 
 Connect to your Oracle database with an administrative user and execute:
 
-```
+```SQL
 CREATE USER netdata IDENTIFIED BY <PASSWORD>;
 
 GRANT CONNECT TO netdata;
 GRANT SELECT_CATALOG_ROLE TO netdata;
 ```
+
+4.  Get or create a [data source name](https://python-oracledb.readthedocs.io/en/latest/user_guide/connection_handling.html#connection-strings) for your database.
 
 ## Configuration
 
@@ -79,13 +81,13 @@ sudo ./edit-config python.d/oracledb.conf
 local:
   user: 'netdata'
   password: 'secret'
-  cs: '(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=adb.us-ashburn-1.oraclecloud.com))(connect_data=(service_name=sdf98789f98sfs98f_projectid_low.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))'
+  dsn: '(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=adb.us-ashburn-1.oraclecloud.com))(connect_data=(service_name=sdf98789f98sfs98f_projectid_low.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))'
 
 
 remote:
   user: 'netdata'
   password: 'secret'
-  cs: '(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=adb.us-ashburn-1.oraclecloud.com))(connect_data=(service_name=sdf98789f98sfs98f_projectid_low.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))'
+  dsn: '(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=adb.us-ashburn-1.oraclecloud.com))(connect_data=(service_name=sdf98789f98sfs98f_projectid_low.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))'
 ```
 
 All parameters are required. Without them module will fail to start.

--- a/collectors/python.d.plugin/oracledb/oracledb.chart.py
+++ b/collectors/python.d.plugin/oracledb/oracledb.chart.py
@@ -318,7 +318,7 @@ class Service(SimpleService):
         self.definitions = deepcopy(CHARTS)
         self.user = configuration.get('user')
         self.password = configuration.get('password')
-        self.cs = configuration.get('cs')
+        self.dsn = configuration.get('dsn')
         self.alive = False
         self.conn = None
         self.active_tablespaces = set()
@@ -329,7 +329,7 @@ class Service(SimpleService):
             self.conn = None
 
         try:
-            self.conn = cx_Oracle.connect(user=self.user, password=self.password, dsn=self.cs)
+            self.conn = cx_Oracle.connect(user=self.user, password=self.password, dsn=self.dsn)
         except cx_Oracle.DatabaseError as error:
             self.error(error)
             return False
@@ -348,9 +348,9 @@ class Service(SimpleService):
         if not all([
             self.user,
             self.password,
-            self.cs
+            self.dsn
         ]):
-            self.error("one of these parameters is not specified: user, password, cs")
+            self.error("one of these parameters is not specified: user, password, dsn")
             return False
 
         if not self.connect():

--- a/collectors/python.d.plugin/oracledb/oracledb.chart.py
+++ b/collectors/python.d.plugin/oracledb/oracledb.chart.py
@@ -336,7 +336,6 @@ class Service(SimpleService):
         if self.conn:
             self.conn.close()
             self.conn = None
-        
         if HAS_ORACLE_NEW:
             try:
                 self.conn = cx_Oracle.connect(f'{self.user}/{self.password}@tcps://{self.server}/{self.service}')

--- a/collectors/python.d.plugin/oracledb/oracledb.conf
+++ b/collectors/python.d.plugin/oracledb/oracledb.conf
@@ -63,8 +63,9 @@
 #
 #     user: username          # the username for the user account. Required.
 #     password: password      # the password for the user account. Required.
-#     dsn: data source name   # the data source name or connection string for
-#                             # the database. (See docs for more) Required.
+#     server: localhost:1521  # the IP address or hostname (and port) of the Oracle Database Server. Required.
+#     service: XE             # the Oracle Database service name. Required. To view the services available on your server,
+#                               run this query: `select SERVICE_NAME from gv$session where sid in (select sid from V$MYSTAT)`.
 #
 # ----------------------------------------------------------------------
 # AUTO-DETECTION JOBS
@@ -73,9 +74,11 @@
 #local:
 #  user: 'netdata'
 #  password: 'secret'
-#  dsn: '(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=adb.us-ashburn-1.oraclecloud.com))(connect_data=(service_name=sdf98789f98sfs98f_projectid_low.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))'
+#  server: 'localhost:1521'
+#  service: 'XE'
 
 #remote:
 #  user: 'netdata'
 #  password: 'secret'
-#  dsn: '(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=adb.us-ashburn-1.oraclecloud.com))(connect_data=(service_name=sdf98789f98sfs98f_projectid_low.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))'
+#  server: '10.0.0.1:1521'
+#  service: 'XE'

--- a/collectors/python.d.plugin/oracledb/oracledb.conf
+++ b/collectors/python.d.plugin/oracledb/oracledb.conf
@@ -63,8 +63,8 @@
 #
 #     user: username          # the username for the user account. Required.
 #     password: password      # the password for the user account. Required.
-#     cs: connection string   # the data source name or connection 
-#                             # string for the database. Required.
+#     dsn: data source name   # the data source name or connection string for
+#                             # the database. (See docs for more) Required.
 #
 # ----------------------------------------------------------------------
 # AUTO-DETECTION JOBS
@@ -73,9 +73,9 @@
 #local:
 #  user: 'netdata'
 #  password: 'secret'
-#  cs: '(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=adb.us-ashburn-1.oraclecloud.com))(connect_data=(service_name=sdf98789f98sfs98f_projectid_low.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))'
+#  dsn: '(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=adb.us-ashburn-1.oraclecloud.com))(connect_data=(service_name=sdf98789f98sfs98f_projectid_low.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))'
 
 #remote:
 #  user: 'netdata'
 #  password: 'secret'
-#  cs: '(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=adb.us-ashburn-1.oraclecloud.com))(connect_data=(service_name=sdf98789f98sfs98f_projectid_low.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))'
+#  dsn: '(description= (retry_count=20)(retry_delay=3)(address=(protocol=tcps)(port=1521)(host=adb.us-ashburn-1.oraclecloud.com))(connect_data=(service_name=sdf98789f98sfs98f_projectid_low.adb.oraclecloud.com))(security=(ssl_server_dn_match=yes)))'


### PR DESCRIPTION
##### Summary
Removes the Python module's requirement of [cx_Oracle](https://cx-oracle.readthedocs.io/en/latest/index.html) which requires users to install and manually configure Oracle Client Libraries. Oracle suggests new projects and users install and use [python-oracledb](https://python-oracledb.readthedocs.io/en/latest/index.html) which is what this merge does. Additionally, this merge allows for support of the newer and faster TLS connections in addition to the old mTLS connections.

##### Test Plan

This code was developed and run on an Oracle server running a Netdata Agent and has been confirmed to work. Individual database connection components and queries were confirmed to work on both a TLS server and mTLS server, both running 21c.

##### Breaking Changes

This new module update will **not** break the functionality of existing oracledb module users if installed. It requires a new Python library when initially installed, although safely excepts import errors that occur here if the old library is installed. The config remains the same except for an updated SQL query for finding your database's service name.

<details><summary>View Original Message</summary>
<p>
##### Summary
Removes the Python module's requirement of [cx_Oracle](https://cx-oracle.readthedocs.io/en/latest/index.html) which requires users to install and manually configure Oracle Client Libraries. Oracle suggests new projects and users install and use [python-oracledb](https://python-oracledb.readthedocs.io/en/latest/index.html) which is what this merge does. Additionally, the DB login method has been updated to use data source names, or connection strings, as Oracle recommends as well.

##### Test Plan

This code was developed and run on an Oracle server running a Netdata Agent and has been confirmed to work. 

##### Breaking Changes

This new module update **will** break the functionality of existing oracledb module users if installed. It requires a new Python library and changes to the config, although the entire migration/setup process can easily be completed in under a minute compared to the original module's more tedious manual installation process to install Oracle Client Libraries, which were poorly documented for some operating systems.
</p>
</details> 