### PR TITLE
Add hardening options to CFLAGS by default if they are available.

### DIFF
--- a/build_external/clean-install-arch-debug.Dockerfile
+++ b/build_external/clean-install-arch-debug.Dockerfile
@@ -45,8 +45,8 @@ RUN rm -rf autom4te.cache
 RUN rm -rf .git/
 RUN find . -type f >/opt/netdata/manifest
 
-RUN CFLAGS="-Og -g -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1\
-    -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1 ${EXTRA_CFLAGS}" ./netdata-installer.sh --require-cloud --disable-lto
+RUN CFLAGS="-Og -g -ggdb -Wall -Wextra -Wformat-signedness -DNETDATA_INTERNAL_CHECKS=1\
+    -DNETDATA_VERIFY_LOCKS=1 ${EXTRA_CFLAGS}" ./netdata-installer.sh --require-cloud --disable-lto
 
 RUN ln -sf /dev/stdout /var/log/netdata/access.log
 RUN ln -sf /dev/stdout /var/log/netdata/debug.log

--- a/build_external/clean-install-arch-extras.Dockerfile
+++ b/build_external/clean-install-arch-extras.Dockerfile
@@ -45,8 +45,8 @@ RUN rm -rf autom4te.cache
 RUN rm -rf .git/
 RUN find . -type f >/opt/netdata/manifest
 
-RUN CFLAGS="-Og -g -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1\
-    -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1 ${EXTRA_CFLAGS}" ./netdata-installer.sh --require-cloud --disable-lto
+RUN CFLAGS="-Og -g -ggdb -Wall -Wextra -Wformat-signedness -DNETDATA_INTERNAL_CHECKS=1\
+    -DNETDATA_VERIFY_LOCKS=1 ${EXTRA_CFLAGS}" ./netdata-installer.sh --require-cloud --disable-lto
 
 RUN ln -sf /dev/stdout /var/log/netdata/access.log
 RUN ln -sf /dev/stdout /var/log/netdata/debug.log

--- a/build_external/clean-install-arch.Dockerfile
+++ b/build_external/clean-install-arch.Dockerfile
@@ -44,8 +44,8 @@ RUN rm -rf autom4te.cache
 RUN rm -rf .git/
 RUN find . -type f >/opt/netdata/manifest
 
-RUN CFLAGS="-O1 -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1\
-    -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1 ${EXTRA_CFLAGS}" ./netdata-installer.sh --disable-lto
+RUN CFLAGS="-O1 -ggdb -Wall -Wextra -Wformat-signedness -DNETDATA_INTERNAL_CHECKS=1\
+    -DNETDATA_VERIFY_LOCKS=1 ${EXTRA_CFLAGS}" ./netdata-installer.sh --disable-lto
 
 RUN ln -sf /dev/stdout /var/log/netdata/access.log
 RUN ln -sf /dev/stdout /var/log/netdata/debug.log

--- a/build_external/clean-install.Dockerfile
+++ b/build_external/clean-install.Dockerfile
@@ -26,8 +26,8 @@ RUN rm -rf autom4te.cache
 RUN rm -rf .git/
 RUN find . -type f >/opt/netdata/manifest
 
-RUN CFLAGS="-O1 -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1\
-    -D_FORTIFY_SOURCE=2 -DNETDATA_VERIFY_LOCKS=1 ${EXTRA_CFLAGS}" ./netdata-installer.sh --disable-lto
+RUN CFLAGS="-O1 -ggdb -Wall -Wextra -Wformat-signedness -DNETDATA_INTERNAL_CHECKS=1\
+    -DNETDATA_VERIFY_LOCKS=1 ${EXTRA_CFLAGS}" ./netdata-installer.sh --disable-lto
 
 RUN ln -sf /dev/stdout /var/log/netdata/access.log
 RUN ln -sf /dev/stdout /var/log/netdata/debug.log

--- a/configure.ac
+++ b/configure.ac
@@ -378,6 +378,25 @@ AM_CONDITIONAL([LINUX], [test "${build_target}" = "linux"])
 AC_MSG_RESULT([Host OS: ${build_target}])
 
 # -----------------------------------------------------------------------------
+# hardening
+
+HARDENING_CFLAGS=""
+
+if ! echo "${originalCFLAGS}" | grep -q '-fstack-protector'; then
+    AX_CHECK_COMPILE_FLAG(
+        [-fstack-protector-strong],
+        [HARDENING_CFLAGS="${HARDENING_CFLAGS} -fstack-protector-strong"],
+        [AX_CHECK_COMPILE_FLAG(
+            [-fstack-protector],
+            [HARDENING_CFLAGS="${HARDENING_CFLAGS} -fstack-protector"],
+            ,
+            [-Werror],
+        )],
+        [-Werror],
+    )
+fi
+
+# -----------------------------------------------------------------------------
 # backtrace
 
 AC_SEARCH_LIBS([backtrace], [execinfo], [AC_DEFINE([HAVE_BACKTRACE], [1], [backtrace availability])])
@@ -1724,7 +1743,7 @@ CFLAGS="${originalCFLAGS} ${OPTIONAL_LTO_CFLAGS} ${OPTIONAL_PROTOBUF_CFLAGS} ${O
     ${OPTIONAL_LIBCAP_CFLAGS} ${OPTIONAL_IPMIMONITORING_CFLAGS} ${OPTIONAL_CUPS_CFLAGS} ${OPTIONAL_XENSTAT_FLAGS} \
     ${OPTIONAL_KINESIS_CFLAGS} ${OPTIONAL_PUBSUB_CFLAGS} ${OPTIONAL_PROMETHEUS_REMOTE_WRITE_CFLAGS} \
     ${OPTIONAL_MONGOC_CFLAGS} ${LWS_CFLAGS} ${OPTIONAL_JSONC_STATIC_CFLAGS} ${OPTIONAL_YAML_STATIC_CFLAGS} ${OPTIONAL_BPF_CFLAGS} ${JUDY_CFLAGS} \
-    ${OPTIONAL_ACLK_CFLAGS} ${OPTIONAL_ML_CFLAGS} ${OPTIONAL_OS_DEP_CFLAGS} ${HTTPD_CFLAGS}"
+    ${OPTIONAL_ACLK_CFLAGS} ${OPTIONAL_ML_CFLAGS} ${OPTIONAL_OS_DEP_CFLAGS} ${HTTPD_CFLAGS} ${HARDENING_CFLAGS}"
 
 CXXFLAGS="${CFLAGS} ${OPTIONAL_KINESIS_CXXFLAGS} ${CPP_STD_FLAG}"
 

--- a/configure.ac
+++ b/configure.ac
@@ -414,6 +414,36 @@ if ! echo "${originalCFLAGS}" | grep -q '-mbranch-protection'; then
     )
 fi
 
+if ! echo "${originalCFLAGS}" | grep -q '-D_FORTIFY_SOURCE'; then
+    # This complex set of checks is needed because there is no clean
+    # way to verify _FORTIFY_SOURCE support without having to check for
+    # the required compiler builtins.
+    AC_CHECK_DECLS(
+        [__builtin_constant_p, __builtin_object_size, __builtin___memcpy_chk, __builtin___memmove_chk, __builtin___mempcpy_chk,
+         __builtin___memset_chk, __builtin___snprintf_chk, __builtin___sprintf_chk, __builtin___stpcpy_chk, __builtin___strcat_chk,
+         __builtin___strcpy_chk, __builtin___strncat_chk, __builtin___strncpy_chk, __builtin___vsnprintf_chk, __builtin___vsprintf_chk],
+        [HAVE_FORTIFY_SOURCE=2]
+    )
+
+    if test "x${HAVE_FORTIFY_SOURCE}" = "x2"; then
+        AC_CHECK_DECL(
+            __builtin_dynamic_object_size,
+            [AX_CHECK_COMPILE_FLAG(
+                [-D_FORTIFY_SOURCE=3],
+                [HARDENING_CFLAGS="${HARDENING_CFLAGS} -D_FORTIFY_SOURCE=3"],
+                ,
+                [-Werror],
+            )],
+            [AX_CHECK_COMPILE_FLAG(
+                [-D_FORTIFY_SOURCE=2],
+                [HARDENING_CFLAGS="${HARDENING_CFLAGS} -D_FORTIFY_SOURCE=2"],
+                ,
+                [-Werror],
+            )],
+        )
+    fi
+fi
+
 # -----------------------------------------------------------------------------
 # backtrace
 

--- a/configure.ac
+++ b/configure.ac
@@ -396,6 +396,24 @@ if ! echo "${originalCFLAGS}" | grep -q '-fstack-protector'; then
     )
 fi
 
+if ! echo "${originalCFLAGS}" | grep -q '-fcf-protection'; then
+    AX_CHECK_COMPILE_FLAG(
+        [-fcf-protection=full],
+        [HARDENING_CFLAGS="${HARDENING_CFLAGS} -fcf-protection=full"],
+        ,
+        [-Werror],
+    )
+fi
+
+if ! echo "${originalCFLAGS}" | grep -q '-mbranch-protection'; then
+    AX_CHECK_COMPILE_FLAG(
+        [-mbranch-protection=standard],
+        [HARDENING_CFLAGS="${HARDENING_CFLAGS} -mbranch-protection=standard"],
+        ,
+        [-Werror],
+    )
+fi
+
 # -----------------------------------------------------------------------------
 # backtrace
 

--- a/configure.ac
+++ b/configure.ac
@@ -396,6 +396,15 @@ if ! echo "${originalCFLAGS}" | grep -q '-fstack-protector'; then
     )
 fi
 
+if ! echo "${originalCFLAGS}" | grep -q '-fno-stack-clash-protection'; then
+    AX_CHECK_COMPILE_FLAG(
+        [-fstack-clash-protection],
+        [HARDENING_CFLAGS="${HARDENING_CFLAGS} -fstack-clash-protection"],
+        ,
+        [-Werror],
+    )
+fi
+
 if ! echo "${originalCFLAGS}" | grep -q '-fcf-protection'; then
     AX_CHECK_COMPILE_FLAG(
         [-fcf-protection=full],

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -9,7 +9,7 @@ cd "${NETDATA_SOURCE_PATH}" || exit 1
 if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
   export CFLAGS="-static -O2 -I/openssl-static/include -I/libnetfilter-acct-static/include/libnetfilter_acct -I/usr/include/libmnl -pipe"
 else
-  export CFLAGS="-static -O1 -pipe -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include -I/libnetfilter-acct-static/include/libnetfilter_acct -I/usr/include/libmnl"
+  export CFLAGS="-static -O1 -pipe -ggdb -Wall -Wextra -Wformat-signedness -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include -I/libnetfilter-acct-static/include/libnetfilter_acct -I/usr/include/libmnl"
 fi
 
 export LDFLAGS="-static -L/openssl-static/lib -L/libnetfilter-acct-static/lib -lnetfilter_acct -L/usr/lib -lmnl"

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -9,7 +9,7 @@ cd "${NETDATA_SOURCE_PATH}" || exit 1
 if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
   export CFLAGS="-static -O2 -I/openssl-static/include -I/libnetfilter-acct-static/include/libnetfilter_acct -I/usr/include/libmnl -pipe"
 else
-  export CFLAGS="-static -O1 -pipe -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -D_FORTIFY_SOURCE=2 -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include -I/libnetfilter-acct-static/include/libnetfilter_acct -I/usr/include/libmnl"
+  export CFLAGS="-static -O1 -pipe -ggdb -Wall -Wextra -Wformat-signedness -fstack-protector-all -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include -I/libnetfilter-acct-static/include/libnetfilter_acct -I/usr/include/libmnl"
 fi
 
 export LDFLAGS="-static -L/openssl-static/lib -L/libnetfilter-acct-static/lib -lnetfilter_acct -L/usr/lib -lmnl"


### PR DESCRIPTION
##### Summary

This adds checks to our configure script to enable a number of hardening features if they are available (and not overridden by the user), improving the baseline security of the Netdata Agent on many systems.

Currently adds:

- `-fstack-protector`/`-fstack-protector-strong`: This enables stack smashing protection, a form of buffer overflow protection designed to protect against exploits that overwrite parts of the stack. Support is largely ubiquitous and this is enabled by default in the compiler configuration on a vast majority of systems, so this change is unlikely to have a significant impact, but is being done anyway for the sake of correctness.
- `-fstack-clash-protection`: This enables a set of changes to how stack allocations are performed, making it more difficult to bypass the protections made by `-fstack-protector`. Support is relatively common, but this is not enabled by default on as many systems as `-fstack-protector` is so it is likely to have a practical impact for us to enable it.
- `-fcf-protection=full`: This enables Control Flow Integrity support, a hardware-assisted mechanism to avoid exploitation of ROP gadgets, which in turn protects against a whole category of exploits. Support is relatively new (only available since GCC 12 and Clang 9, and it requires build time options for those compilers for it to be available) and requires associated hardware support (which the compiler will check for before making use of this functionality). Overhead is comparatively low, but due to how new it is it’s not enabled on most platforms. Currently requires a recent 64-bit x86 CPU to gain any benefit, but other platforms may add similar functionality in the future.
- `-mbranch-protection=standard`: This enables hardware-assisted branch protection, which is conceptually similar to Control Flow Integrity. Much like `-fcf-protection`, this is relatively new and requires hardware support (but will be handled correctly by the compiler if such support is lacking). Currently requires a 64-bit ARM CPU to gain any benefit, but other platforms may add similar functionality in the future.
- `-D_FORTIFY_SOURCE=2`/`-D_FORTIFY_SOURCE=3`: These macros enable additional compile and runtime checking around functions that copy memory. They require both libc support (glibc fully supports them, some musl systems do as well but not all) and compiler support (a long list of compiler builtins is required), but supplying them when the libc support is lacking is safe. The checking provided by these options is generally low risk and low overhead, while providing a nontrivial improvement to security and also catching some questionable code at compile time.

##### Test Plan

Preliminary testing involves confirming that CI passes on this PR.

Full testing involves comparing performance of builds created with this PR to builds created using the master branch on the same systems and confirming that the performance overhead is acceptable (I expect it will be, but we still need to confirm this).

##### Additional Information

Relevant to: #15069 

Further things to consider for future investigation:

- `-z RELRO` and `-z NOW` linker flags.
- `-fvtable-verify` C++ compiler flag.