### PR TITLE
Address issue with Thanos Receiver

### DIFF
--- a/exporting/prometheus/prometheus.c
+++ b/exporting/prometheus/prometheus.c
@@ -470,10 +470,12 @@ static void generate_as_collected_prom_metric(BUFFER *wb, struct gen_parameters 
     if (!homogeneous)
         buffer_sprintf(wb, "_%s", p->dimension);
 
-    buffer_sprintf(wb, "%s{chart=\"%s\",family=\"%s\"", p->suffix, p->chart, p->family);
+    buffer_sprintf(wb, "%s{chart=\"%s\"", p->suffix, p->chart);
 
     if (homogeneous)
         buffer_sprintf(wb, ",dimension=\"%s\"", p->dimension);
+
+    buffer_sprintf(wb, "family=\"%s\"", p->family);
 
     buffer_sprintf(wb, "%s} ", p->labels);
 

--- a/exporting/prometheus/prometheus.c
+++ b/exporting/prometheus/prometheus.c
@@ -713,30 +713,30 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
                             if (output_options & PROMETHEUS_OUTPUT_TIMESTAMPS)
                                 buffer_sprintf(
                                     wb,
-                                    "%s_%s%s%s{chart=\"%s\",family=\"%s\",dimension=\"%s\"%s} " NETDATA_DOUBLE_FORMAT
+                                    "%s_%s%s%s{chart=\"%s\",dimension=\"%s\",family=\"%s\"%s} " NETDATA_DOUBLE_FORMAT
                                     " %llu\n",
                                     prefix,
                                     context,
                                     units,
                                     suffix,
                                     chart,
-                                    family,
                                     dimension,
+                                    family,
                                     labels,
                                     value,
                                     last_time * MSEC_PER_SEC);
                             else
                                 buffer_sprintf(
                                     wb,
-                                    "%s_%s%s%s{chart=\"%s\",family=\"%s\",dimension=\"%s\"%s} " NETDATA_DOUBLE_FORMAT
+                                    "%s_%s%s%s{chart=\"%s\",dimension=\"%s\",family=\"%s\"%s} " NETDATA_DOUBLE_FORMAT
                                     "\n",
                                     prefix,
                                     context,
                                     units,
                                     suffix,
                                     chart,
-                                    family,
                                     dimension,
+                                    family,
                                     labels,
                                     value);
                         }

--- a/exporting/prometheus/prometheus.c
+++ b/exporting/prometheus/prometheus.c
@@ -475,9 +475,7 @@ static void generate_as_collected_prom_metric(BUFFER *wb, struct gen_parameters 
     if (homogeneous)
         buffer_sprintf(wb, ",dimension=\"%s\"", p->dimension);
 
-    buffer_sprintf(wb, "family=\"%s\"", p->family);
-
-    buffer_sprintf(wb, "%s} ", p->labels);
+    buffer_sprintf(wb, ",family=\"%s\"%s} ", p->family, p->labels);
 
     if (prometheus_collector)
         buffer_sprintf(


### PR DESCRIPTION
##### Summary
Fixes #14482 

According our user [investigation](https://github.com/netdata/netdata/issues/14482#issuecomment-1427543026) reorder current labels is enough to fix current issue we have, so this PR is inverting order we are presenting labels.

##### Test Plan
1. Compile this Branch
2. Access http://localhost:19999/api/v1/allmetrics?format=prometheus and confirm you have labels sorted:

```sh
netdata_netdata_statsd_events_events_persec_average{chart="netdata.statsd_events",dimension="gauges",family="statsd"} 0.0000000 1684933603000
netdata_netdata_statsd_events_events_persec_average{chart="netdata.statsd_events",dimension="counters",family="statsd"} 0.0000000 1684933603000
netdata_netdata_statsd_events_events_persec_average{chart="netdata.statsd_events",dimension="timers",family="statsd"} 0.0000000 1684933603000
netdata_netdata_statsd_events_events_persec_average{chart="netdata.statsd_events",dimension="meters",family="statsd"} 0.0000000 1684933603000
netdata_netdata_statsd_events_events_persec_average{chart="netdata.statsd_events",dimension="histograms",family="statsd"} 0.0000000 1684933603000
netdata_netdata_statsd_events_events_persec_average{chart="netdata.statsd_events",dimension="sets",family="statsd"} 0.0000000 1684933603000
netdata_netdata_statsd_events_events_persec_average{chart="netdata.statsd_events",dimension="dictionaries",family="statsd"} 0.0000000 1684933603000
netdata_netdata_statsd_events_events_persec_average{chart="netdata.statsd_events",dimension="unknown",family="statsd"} 0.0000000 1684933603000
netdata_netdata_statsd_events_events_persec_average{chart="netdata.statsd_events",dimension="errors",family="statsd"} 0.0000000 1684933603000
```

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? Exporter
- Can they see the change or is it an under the hood? If they can see it, where? Yes, when they are using Prometheus exporter
- How is the user impacted by the change?  We won't have more issues with Thanos
- What are there any benefits of the change? Netdata will be fully compatible with another software.
</details>
