### PR TITLE
Invert order in remote write

### DIFF
--- a/exporting/prometheus/remote_write/remote_write_request.cc
+++ b/exporting/prometheus/remote_write/remote_write_request.cc
@@ -45,15 +45,15 @@ void add_host_info(
     label->set_name("__name__");
     label->set_value(name);
 
-    label = timeseries->add_labels();
-    label->set_name("instance");
-    label->set_value(instance);
-
     if (application) {
         label = timeseries->add_labels();
         label->set_name("application");
         label->set_value(application);
     }
+
+    label = timeseries->add_labels();
+    label->set_name("instance");
+    label->set_value(instance);
 
     if (version) {
         label = timeseries->add_labels();

--- a/exporting/prometheus/remote_write/remote_write_request.cc
+++ b/exporting/prometheus/remote_write/remote_write_request.cc
@@ -118,15 +118,15 @@ void add_metric(
     label->set_name("chart");
     label->set_value(chart);
 
-    label = timeseries->add_labels();
-    label->set_name("family");
-    label->set_value(family);
-
     if (dimension) {
         label = timeseries->add_labels();
         label->set_name("dimension");
         label->set_value(dimension);
     }
+
+    label = timeseries->add_labels();
+    label->set_name("family");
+    label->set_value(family);
 
     label = timeseries->add_labels();
     label->set_name("instance");


### PR DESCRIPTION
##### Summary
Fix https://github.com/netdata/netdata/issues/14482

After to adjust order for Prometheus, this PR is reordering labels for remote writer.

![Screenshot_20230524_162511](https://github.com/netdata/netdata/assets/49162938/84bc5db0-6683-4a5e-8f3d-caaaeb2c542f)


##### Test Plan

1. Configure remote write inside `/etc/netdata/exporting.conf`:
```sh
[exporting:global]
    enabled = yes
    send configured labels = yes
    send automatic labels = yes
    send variables = yes

[prometheus_remote_write:my_prometheus_remote_write_instance]
    enabled = yes
    destination = localhost:9201
    remote write URL path = /write
    update every = 3
    data source = raw
    send charts matching = *
```
2. Compile this branch
3. Start netdata
4. Start prometheus

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? prometheus remote writer
- Can they see the change or is it an under the hood? If they can see it, where? Only when exporting
- How is the user impacted by the change?  Users running Thanos won't have metrics ignored;
- What are there any benefits of the change?  Compatibility with Thanos
</details>
