### PR TITLE
/api/v2/data percentage calculation on grouped queries

### DIFF
--- a/web/api/queries/query.h
+++ b/web/api/queries/query.h
@@ -85,6 +85,7 @@ typedef enum rrdr_group_by_function {
     RRDR_GROUP_BY_FUNCTION_MIN,
     RRDR_GROUP_BY_FUNCTION_MAX,
     RRDR_GROUP_BY_FUNCTION_SUM,
+    RRDR_GROUP_BY_FUNCTION_PERCENTAGE,
 } RRDR_GROUP_BY_FUNCTION;
 
 RRDR_GROUP_BY_FUNCTION group_by_aggregate_function_parse(const char *s);


### PR DESCRIPTION
`/api/v2/data` has a group method called `percentage-of-instance`.

It turns out that it is useful to calculate the percentage over any type of grouping, not just `instance`.

This PR adds `aggregation=percentage` which can be used instead of `min`, `max`, `avg`, `sum`, etc to calculate the percentage of the sum of values of the selected time-series over the sum of the values of all available time-series for any given group.
