### PR TITLE
Only queue an alert to the cloud when it's inserted

### DIFF
--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -1046,7 +1046,7 @@ void aclk_push_alarm_checkpoint(RRDHOST *host __maybe_unused)
 
     if (rrdhost_flag_check(host, RRDHOST_FLAG_ACLK_STREAM_ALERTS)) {
         //postpone checkpoint send
-        wc->alert_checkpoint_req++;
+        wc->alert_checkpoint_req+=3;
         log_access("ACLK REQ [%s (N/A)]: ALERTS CHECKPOINT POSTPONED", rrdhost_hostname(host));
         return;
     }

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -354,8 +354,14 @@ void sql_health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae)
 {
     if (ae->flags & HEALTH_ENTRY_FLAG_SAVED)
         sql_health_alarm_log_update(host, ae);
-    else
+    else {
         sql_health_alarm_log_insert(host, ae);
+#ifdef ENABLE_ACLK
+        if (netdata_cloud_setting) {
+            sql_queue_alarm_to_aclk(host, ae, 0);
+        }
+#endif
+    }
 }
 
 /* Health related SQL queries

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -5,14 +5,7 @@
 // ----------------------------------------------------------------------------
 
 inline void health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae) {
-
     sql_health_alarm_log_save(host, ae);
-
-#ifdef ENABLE_ACLK
-    if (netdata_cloud_setting) {
-        sql_queue_alarm_to_aclk(host, ae, 0);
-    }
-#endif
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR changes when an alert is queued to the cloud. Before this change, an alert event would be tried to be queued when both created, and updated. There is no need to try to queue it when it's updated.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Ensure basic alert to cloud functionality.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
