### PR TITLE
Better support running the Docker entrypoint code as a non-root user.

### DIFF
--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -12,6 +12,16 @@ import TabItem from '@theme/TabItem';
 
 # Install Netdata with Docker
 
+## Limitations running the Agent in Docker
+
+We do not officially support running our Docker images with the Docker CLI `--user` option or the Docker Compose
+`user:` parameter. Such usage will usually still work, but some features will not be available when run this
+way. Note that the agent will drop privileges appropriately inside the container during startup, meaning that even
+when run without these options almost nothing in the container will actually run with an effective UID of 0.
+
+Our POWER8+ Docker images do not support our FreeIPMI collector. This is a technical limitation in FreeIPMI itself,
+and unfortunately not something we can realistically work around.
+
 ## Create a new Netdata Agent container
 
 You can create a new Agent container using either `docker run` or `docker-compose`. After using any method, you can

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -23,27 +23,51 @@ fi
 
 chmod o+rX / 2>/dev/null || echo "Unable to change permissions without errors."
 
-BALENA_PGID=$(stat -c %g /var/run/balena.sock 2>/dev/null || true)
-DOCKER_PGID=$(stat -c %g /var/run/docker.sock 2>/dev/null || true)
+if [ "${EUID}" -eq 0 ]; then
+  if [ -n "${NETDATA_EXTRA_APK_PACKAGES}" ]; then
+    echo >&2 "WARNING: Netdata’s Docker images have switched from Alpine to Debian as a base platform. Supplementary package support is now handled through the NETDATA_EXTRA_DEB_PACKAGES variable instead of NETDATA_EXTRA_APK_PACKAGES."
+    echo >&2 "WARNING: The container will still run, but supplementary packages listed in NETDATA_EXTRA_APK_PACKAGES will not be installed."
+    echo >&2 "WARNING: To remove these messages, either undefine NETDATA_EXTRA_APK_PACKAGES, or define it to an empty string."
+  fi
 
-re='^[0-9]+$'
-if [[ $BALENA_PGID =~ $re ]]; then
-  echo "Netdata detected balena-engine.sock"
-  DOCKER_HOST='/var/run/balena-engine.sock'
-  PGID="$BALENA_PGID"
-elif [[ $DOCKER_PGID =~ $re ]]; then
-  echo "Netdata detected docker.sock"
-  DOCKER_HOST="/var/run/docker.sock"
-  PGID="$DOCKER_PGID"
-fi
-export PGID
-export DOCKER_HOST
+  if [ -n "${NETDATA_EXTRA_DEB_PACKAGES}" ]; then
+    echo "Fetching APT repository metadata."
+    if ! apt-get update; then
+      echo "Failed to fetch APT repository metadata."
+    else
+      echo "Installing supplementary packages."
+      export DEBIAN_FRONTEND="noninteractive"
+      # shellcheck disable=SC2086
+      if ! apt-get install -y --no-install-recommends ${NETDATA_EXTRA_DEB_PACKAGES}; then
+        echo "Failed to install supplementary packages."
+      fi
+    fi
+  fi
 
-if [ -n "${PGID}" ]; then
-  echo "Creating docker group ${PGID}"
-  addgroup --gid "${PGID}" "docker" || echo >&2 "Could not add group docker with ID ${PGID}, its already there probably"
-  echo "Assign netdata user to docker group ${PGID}"
-  usermod --append --groups "docker" "${DOCKER_USR}" || echo >&2 "Could not add netdata user to group docker with ID ${PGID}"
+  BALENA_PGID=$(stat -c %g /var/run/balena.sock 2>/dev/null || true)
+  DOCKER_PGID=$(stat -c %g /var/run/docker.sock 2>/dev/null || true)
+
+  re='^[0-9]+$'
+  if [[ $BALENA_PGID =~ $re ]]; then
+    echo "Netdata detected balena-engine.sock"
+    DOCKER_HOST='/var/run/balena-engine.sock'
+    PGID="$BALENA_PGID"
+  elif [[ $DOCKER_PGID =~ $re ]]; then
+    echo "Netdata detected docker.sock"
+    DOCKER_HOST="/var/run/docker.sock"
+    PGID="$DOCKER_PGID"
+  fi
+  export PGID
+  export DOCKER_HOST
+
+  if [ -n "${PGID}" ]; then
+    echo "Creating docker group ${PGID}"
+    addgroup --gid "${PGID}" "docker" || echo >&2 "Could not add group docker with ID ${PGID}, its already there probably"
+    echo "Assign netdata user to docker group ${PGID}"
+    usermod --append --groups "docker" "${DOCKER_USR}" || echo >&2 "Could not add netdata user to group docker with ID ${PGID}"
+  fi
+else
+  echo >&2 "WARNING: Entrypoint started as non-root user. This is not officially supported and some features may not be available."
 fi
 
 # Needed to read Proxmox VMs and (LXC) containers configuration files (name resolution + CPU and memory limits)
@@ -95,26 +119,6 @@ if [ -n "${NETDATA_CLAIM_URL}" ] && [ -n "${NETDATA_CLAIM_TOKEN}" ] && [ ! -f /v
                              ${NETDATA_CLAIM_PROXY:+-proxy="${NETDATA_CLAIM_PROXY}"} \
                              ${NETDATA_EXTRA_CLAIM_OPTS} \
                              -daemon-not-running
-fi
-
-if [ -n "${NETDATA_EXTRA_APK_PACKAGES}" ]; then
-  echo >&2 "WARNING: Netdata’s Docker images have switched from Alpine to Debian as a base platform. Supplementary package support is now handled through the NETDATA_EXTRA_DEB_PACKAGES variable instead of NETDATA_EXTRA_APK_PACKAGES."
-  echo >&2 "WARNING: The container will still run, but supplementary packages listed in NETDATA_EXTRA_APK_PACKAGES will not be installed."
-  echo >&2 "WARNING: To remove these messages, either undefine NETDATA_EXTRA_APK_PACKAGES, or define it to an empty string."
-fi
-
-if [ -n "${NETDATA_EXTRA_DEB_PACKAGES}" ]; then
-  echo "Fetching APT repository metadata."
-  if ! apt-get update; then
-    echo "Failed to fetch APT repository metadata."
-  else
-    echo "Installing supplementary packages."
-    export DEBIAN_FRONTEND="noninteractive"
-    # shellcheck disable=SC2086
-    if ! apt-get install -y --no-install-recommends ${NETDATA_EXTRA_DEB_PACKAGES}; then
-      echo "Failed to install supplementary packages."
-    fi
-  fi
 fi
 
 exec /usr/sbin/netdata -u "${DOCKER_USR}" -D -s /host -p "${NETDATA_LISTENER_PORT}" "$@"


### PR DESCRIPTION
##### Summary

Users can override what user ID is used inside of a container when creating the container. We don’t technically properly support this, but we should also ideally not _break_ such usage either as there are legitimate use-cases for it. This moves code that will only work when run as root inside the container inside a conditional in our entrypoint script so that it doesn’t break things otherwise.

##### Test Plan

Basic testing involves confirming that Docker images built from this branch still start when run with the `--user` option set to some user other than root.

##### Additional Info

This re-adds the section in our Docker documentation about limitations inherent to our Docker images which was completely dropped for some reason.