### PR TITLE
Percentage of group aggregatable at cloud - fixed for backwards compatibility

### DIFF
--- a/aclk/aclk_capas.c
+++ b/aclk/aclk_capas.c
@@ -13,7 +13,7 @@ const struct capability *aclk_get_agent_capas()
         { .name = "mc",          .version = 0, .enabled = 0 },
         { .name = "ctx",         .version = 1, .enabled = 1 },
         { .name = "funcs",       .version = 1, .enabled = 1 },
-        { .name = "http_api_v2", .version = 1, .enabled = 1 },
+        { .name = "http_api_v2", .version = 3, .enabled = 1 },
         { .name = "health",      .version = 1, .enabled = 0 },
         { .name = "req_cancel",  .version = 1, .enabled = 1 },
         { .name = NULL,          .version = 0, .enabled = 0 }
@@ -39,7 +39,7 @@ struct capability *aclk_get_node_instance_capas(RRDHOST *host)
           .enabled = enable_metric_correlations },
         { .name = "ctx",         .version = 1,                     .enabled = 1 },
         { .name = "funcs",       .version = 0,                     .enabled = 0 },
-        { .name = "http_api_v2", .version = 2,                     .enabled = 1 },
+        { .name = "http_api_v2", .version = 3,                     .enabled = 1 },
         { .name = "health",      .version = 1,                     .enabled = host->health.health_enabled },
         { .name = "req_cancel",  .version = 1,                     .enabled = 1 },
         { .name = NULL,          .version = 0,                     .enabled = 0 }

--- a/database/contexts/rrdcontext.h
+++ b/database/contexts/rrdcontext.h
@@ -524,6 +524,24 @@ bool rrdcontext_retention_match(RRDCONTEXT_ACQUIRED *rca, time_t after, time_t b
 
 #define query_target_aggregatable(qt) ((qt)->window.options & RRDR_OPTION_RETURN_RAW)
 
+static inline bool query_has_group_by_aggregation_percentage(QUERY_TARGET *qt) {
+
+    // backwards compatibility
+    // If the request was made with group_by = "percentage-of-instance"
+    // we need to send back "raw" output with "count"
+    // otherwise, we need to send back "raw" output with "hidden"
+
+    for(int g = 0; g < MAX_QUERY_GROUP_BY_PASSES ;g++) {
+        if(qt->request.group_by[g].group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE)
+            return false;
+
+        if(qt->request.group_by[g].aggregation == RRDR_GROUP_BY_FUNCTION_PERCENTAGE)
+            return true;
+    }
+
+    return false;
+}
+
 static inline bool query_target_has_percentage_of_group(QUERY_TARGET *qt) {
     for(size_t g = 0; g < MAX_QUERY_GROUP_BY_PASSES ;g++) {
         if (qt->request.group_by[g].group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE)

--- a/web/api/formatters/json/json.c
+++ b/web/api/formatters/json/json.c
@@ -270,8 +270,12 @@ void rrdr2json_v2(RRDR *r, BUFFER *wb) {
     buffer_json_member_add_uint64(wb, "value", 0);
     buffer_json_member_add_uint64(wb, "arp", 1);
     buffer_json_member_add_uint64(wb, "pa", 2);
-    if(expose_gbc)
-        buffer_json_member_add_uint64(wb, "count", 3);
+    if(expose_gbc) {
+        if(r->vh)
+            buffer_json_member_add_uint64(wb, "hidden", 3);
+        else
+            buffer_json_member_add_uint64(wb, "count", 3);
+    }
     buffer_json_object_close(wb);
 
     buffer_json_member_add_array(wb, "data");
@@ -286,6 +290,7 @@ void rrdr2json_v2(RRDR *r, BUFFER *wb) {
         // for each line in the array
         for (i = start; i != end; i += step) {
             NETDATA_DOUBLE *cn = &r->v[ i * r->d ];
+            NETDATA_DOUBLE *ch = (r->vh) ? &r->vh[ i * r->d ] : NULL;
             RRDR_VALUE_FLAGS *co = &r->o[ i * r->d ];
             NETDATA_DOUBLE *ar = &r->ar[ i * r->d ];
             uint32_t *gbc = &r->gbc [ i * r->d ];
@@ -325,8 +330,12 @@ void rrdr2json_v2(RRDR *r, BUFFER *wb) {
                 buffer_json_add_array_item_uint64(wb, o);
 
                 // add the count
-                if(expose_gbc)
-                    buffer_json_add_array_item_uint64(wb, gbc[d]);
+                if(expose_gbc) {
+                    if(ch)
+                        buffer_json_add_array_item_double(wb, ch[d]);
+                    else
+                        buffer_json_add_array_item_uint64(wb, gbc[d]);
+                }
 
                 buffer_json_array_close(wb); // point
             }

--- a/web/api/formatters/json/json.c
+++ b/web/api/formatters/json/json.c
@@ -244,12 +244,30 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
     //info("RRD2JSON(): %s: END", r->st->id);
 }
 
+static bool query_has_group_by_aggregation_percentage(QUERY_TARGET *qt) {
+
+    // backwards compatibility
+    // If the request was made with group_by = "percentage-of-instance"
+    // we need to send back "raw" output with "count"
+    // otherwise, we need to send back "raw" output with "hidden"
+
+    for(int g = 0; g < MAX_QUERY_GROUP_BY_PASSES ;g++) {
+        if(qt->request.group_by[g].group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE)
+            return false;
+
+        if(qt->request.group_by[g].aggregation == RRDR_GROUP_BY_FUNCTION_PERCENTAGE)
+            return true;
+    }
+
+    return false;
+}
 
 void rrdr2json_v2(RRDR *r, BUFFER *wb) {
     QUERY_TARGET *qt = r->internal.qt;
     RRDR_OPTIONS options = qt->window.options;
 
-    bool expose_gbc = query_target_aggregatable(qt);
+    bool send_fourth_number = query_target_aggregatable(qt);
+    bool fourth_number_is_vh = send_fourth_number && r->vh && query_has_group_by_aggregation_percentage(qt);
 
     buffer_json_member_add_object(wb, "result");
 
@@ -270,8 +288,8 @@ void rrdr2json_v2(RRDR *r, BUFFER *wb) {
     buffer_json_member_add_uint64(wb, "value", 0);
     buffer_json_member_add_uint64(wb, "arp", 1);
     buffer_json_member_add_uint64(wb, "pa", 2);
-    if(expose_gbc) {
-        if(r->vh)
+    if(send_fourth_number) {
+        if(fourth_number_is_vh)
             buffer_json_member_add_uint64(wb, "hidden", 3);
         else
             buffer_json_member_add_uint64(wb, "count", 3);
@@ -290,7 +308,7 @@ void rrdr2json_v2(RRDR *r, BUFFER *wb) {
         // for each line in the array
         for (i = start; i != end; i += step) {
             NETDATA_DOUBLE *cn = &r->v[ i * r->d ];
-            NETDATA_DOUBLE *ch = (r->vh) ? &r->vh[ i * r->d ] : NULL;
+            NETDATA_DOUBLE *ch = fourth_number_is_vh ? &r->vh[i * r->d ] : NULL;
             RRDR_VALUE_FLAGS *co = &r->o[ i * r->d ];
             NETDATA_DOUBLE *ar = &r->ar[ i * r->d ];
             uint32_t *gbc = &r->gbc [ i * r->d ];
@@ -330,8 +348,8 @@ void rrdr2json_v2(RRDR *r, BUFFER *wb) {
                 buffer_json_add_array_item_uint64(wb, o);
 
                 // add the count
-                if(expose_gbc) {
-                    if(ch)
+                if(send_fourth_number) {
+                    if(fourth_number_is_vh)
                         buffer_json_add_array_item_double(wb, ch[d]);
                     else
                         buffer_json_add_array_item_uint64(wb, gbc[d]);

--- a/web/api/formatters/json/json.c
+++ b/web/api/formatters/json/json.c
@@ -244,24 +244,6 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
     //info("RRD2JSON(): %s: END", r->st->id);
 }
 
-static bool query_has_group_by_aggregation_percentage(QUERY_TARGET *qt) {
-
-    // backwards compatibility
-    // If the request was made with group_by = "percentage-of-instance"
-    // we need to send back "raw" output with "count"
-    // otherwise, we need to send back "raw" output with "hidden"
-
-    for(int g = 0; g < MAX_QUERY_GROUP_BY_PASSES ;g++) {
-        if(qt->request.group_by[g].group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE)
-            return false;
-
-        if(qt->request.group_by[g].aggregation == RRDR_GROUP_BY_FUNCTION_PERCENTAGE)
-            return true;
-    }
-
-    return false;
-}
-
 void rrdr2json_v2(RRDR *r, BUFFER *wb) {
     QUERY_TARGET *qt = r->internal.qt;
     RRDR_OPTIONS options = qt->window.options;

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -87,7 +87,7 @@ int rrdset2value_api_v1(
 );
 
 static inline bool rrdr_dimension_should_be_exposed(RRDR_DIMENSION_FLAGS rrdr_dim_flags, RRDR_OPTIONS options) {
-    if(unlikely(options & RRDR_OPTION_RETURN_RAW))
+    if(unlikely((options & RRDR_OPTION_RETURN_RAW) && (rrdr_dim_flags & RRDR_DIMENSION_QUERIED)))
         return true;
 
     if(unlikely(rrdr_dim_flags & RRDR_DIMENSION_HIDDEN)) return false;

--- a/web/api/netdata-swagger.yaml
+++ b/web/api/netdata-swagger.yaml
@@ -241,6 +241,7 @@ paths:
             A comma separated list of the groupings required.
             All possible values can be combined together, except `selected`. If `selected` is given in the list, all others are ignored.
             The order they are placed in the list is currently ignored.
+            This parameter is also accepted as `group_by[0]` and `group_by[1]` when multiple grouping passes are required.
           required: false
           schema:
             type: array
@@ -261,6 +262,7 @@ paths:
           in: query
           description: |
             A comma separated list of the label keys to group by their values. The order of the labels in the list is respected.
+            This parameter is also accepted as `group_by_label[0]` and `group_by_label[1]` when multiple grouping passes are required.
           required: false
           schema:
             type: string
@@ -271,6 +273,7 @@ paths:
           description: |
             The aggregation function to apply when grouping metrics together.
             When option `raw` is given, `average` and `avg` behave like `sum` and the caller is expected to calculate the average.
+            This parameter is also accepted as `aggregation[0]` and `aggregation[1]` when multiple grouping passes are required.
           required: false
           schema:
             type: string
@@ -280,6 +283,7 @@ paths:
               - avg
               - average
               - sum
+              - percentage
             default: average
         - $ref: '#/components/parameters/scopeNodes'
         - $ref: '#/components/parameters/scopeContexts'
@@ -2741,8 +2745,13 @@ components:
               type: integer
             count:
               description: |
-                The number of metrics aggregated into this point. This exists only when the option `raw` is given to the query.
+                The number of metrics aggregated into this point.
+                This exists only when the option `raw` is given to the query and the final aggregation point is NOT `percentage`.
               type: integer
+            hidden:
+              description: |
+                The sum of the non-selected dimensions aggregated for this group item point.
+                This exists only when the option `raw` is given to the query and the final aggregation method is `percentage`.
         data:
           type: array
           items:

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -3168,7 +3168,10 @@ static void rrdr2rrdr_group_by_partial_trimming(RRDR *r) {
 }
 
 static void rrdr2rrdr_group_by_calculate_percentage_of_group(RRDR *r) {
-    if(!r->vh || query_target_aggregatable(r->internal.qt))
+    if(!r->vh)
+        return;
+
+    if(query_target_aggregatable(r->internal.qt) && query_has_group_by_aggregation_percentage(r->internal.qt))
         return;
 
     for(size_t i = 0; i < r->n ;i++) {


### PR DESCRIPTION
Improvement over #15109 (which was reverted with #15122) to not break backwards compatibility  of `percentage-of-instance`.

Now the output generated by `/api/v2/data` changes when `aggregation = "percentage"` is requested, but does not change when `group_by = "percentage-of-instance"` is requested, making sure that consumers of previous versions of the API still work.