### PR TITLE
Fix bundling of eBPF legacy code for DEB packages.

### DIFF
--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -151,7 +151,7 @@ override_dh_install:
 	#
 	if [ $(HAVE_EBPF) -eq 1 ]; then \
 		mkdir -p $(TOP)-ebpf-code-legacy/usr/libexec/netdata/plugins.d/; \
-		packaging/bundle-ebpf.sh . ${TOP}-ebpf-code-legacy/usr/libexec/netdata/plugins.d/; \
+		packaging/bundle-ebpf.sh . ${TOP}-ebpf-code-legacy/usr/libexec/netdata/plugins.d/ force; \
 	fi
 
 	# Install go to it's own package directory

--- a/packaging/bundle-ebpf.sh
+++ b/packaging/bundle-ebpf.sh
@@ -2,15 +2,16 @@
 
 SRCDIR="${1}"
 PLUGINDIR="${2}"
+FORCE="${3}"
 
 EBPF_VERSION="$(cat "${SRCDIR}/packaging/ebpf.version")"
 EBPF_TARBALL="netdata-kernel-collector-glibc-${EBPF_VERSION}.tar.xz"
 
-if [ -x "${PLUGINDIR}/ebpf.plugin" ] ; then
+if [ -x "${PLUGINDIR}/ebpf.plugin" ] || [ "${FORCE}" = "force" ]; then
     mkdir -p "${SRCDIR}/tmp/ebpf"
     curl -sSL --connect-timeout 10 --retry 3 "https://github.com/netdata/kernel-collector/releases/download/${EBPF_VERSION}/${EBPF_TARBALL}" > "${EBPF_TARBALL}" || exit 1
     grep "${EBPF_TARBALL}" "${SRCDIR}/packaging/ebpf.checksums" | sha256sum -c - || exit 1
-    tar -xaf "${EBPF_TARBALL}" -C "${SRCDIR}/tmp/ebpf" || exit 1
+    tar -xvaf "${EBPF_TARBALL}" -C "${SRCDIR}/tmp/ebpf" || exit 1
     if [ ! -d "${PLUGINDIR}/ebpf.d" ];then
         mkdir "${PLUGINDIR}/ebpf.d"
     fi


### PR DESCRIPTION
##### Summary

The legacy code was not being bundled properly due to an oversight in bundling script.

##### Test Plan

Testing can be done by simply building the DEB packages locally and then running `dpkg -c` on the `netdata-ebpf-code-legacy` package to see the list of included files.

Without these changes, the package should only include a few directories and the documentation files.

With these changes, the package should include all of the eBPF programs as well as the documentation files.