### PR TITLE
Provide necessary permission for the kickstart to run the netdata-updater script

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1217,7 +1217,7 @@ set_auto_updates() {
     if [ "${DRY_RUN}" -eq 1 ]; then
       progress "Would have attempted to enable automatic updates."
     # This first case is for catching using a new kickstart script with an old build. It can be safely removed after v1.34.0 is released.
-    elif ! run_as_root grep -q -- --enable-auto-updates "${updater}"; then
+    elif ! run_as_root grep -q '\-\-enable-auto-updates' "${updater}"; then
       echo
     elif ! run_as_root "${updater}" --enable-auto-updates "${NETDATA_AUTO_UPDATE_TYPE}"; then
       warning "Failed to enable auto updates. Netdata will still work, but you will need to update manually."

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -745,7 +745,7 @@ confirm() {
 update() {
   updater="${ndprefix}/usr/libexec/netdata/netdata-updater.sh"
 
-  if run_as_root [ -x "${updater}" ]; then
+  if run_as_root test -x "${updater}"; then
     if [ "${DRY_RUN}" -eq 1 ]; then
       progress "Would attempt to update existing installation by running the updater script located at: ${updater}"
       return 0
@@ -1204,9 +1204,9 @@ claim() {
 # ======================================================================
 # Auto-update handling code.
 set_auto_updates() {
-  if run_as_root [ -x "${INSTALL_PREFIX}/usr/libexec/netdata/netdata-updater.sh" ]; then
+  if run_as_root test -x "${INSTALL_PREFIX}/usr/libexec/netdata/netdata-updater.sh"; then
     updater="${INSTALL_PREFIX}/usr/libexec/netdata/netdata-updater.sh"
-  elif run_as_root  [ -x "${INSTALL_PREFIX}/netdata/usr/libexec/netdata/netdata-updater.sh" ]; then
+  elif run_as_root test -x "${INSTALL_PREFIX}/netdata/usr/libexec/netdata/netdata-updater.sh"; then
     updater="${INSTALL_PREFIX}/netdata/usr/libexec/netdata/netdata-updater.sh"
   else
     warning "Could not find netdata-updater.sh. This means that auto-updates cannot (currently) be enabled on this system. See https://learn.netdata.cloud/docs/agent/packaging/installer/update for more information about updating Netdata."
@@ -1217,7 +1217,7 @@ set_auto_updates() {
     if [ "${DRY_RUN}" -eq 1 ]; then
       progress "Would have attempted to enable automatic updates."
     # This first case is for catching using a new kickstart script with an old build. It can be safely removed after v1.34.0 is released.
-    elif ! run_as_root grep -q '\-\-enable-auto-updates' "${updater}"; then
+    elif ! run_as_root grep -q -- --enable-auto-updates "${updater}"; then
       echo
     elif ! run_as_root "${updater}" --enable-auto-updates "${NETDATA_AUTO_UPDATE_TYPE}"; then
       warning "Failed to enable auto updates. Netdata will still work, but you will need to update manually."

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -745,7 +745,7 @@ confirm() {
 update() {
   updater="${ndprefix}/usr/libexec/netdata/netdata-updater.sh"
 
-  if [ -x "${updater}" ]; then
+  if run_as_root [ -x "${updater}" ]; then
     if [ "${DRY_RUN}" -eq 1 ]; then
       progress "Would attempt to update existing installation by running the updater script located at: ${updater}"
       return 0
@@ -1204,9 +1204,9 @@ claim() {
 # ======================================================================
 # Auto-update handling code.
 set_auto_updates() {
-  if [ -x "${INSTALL_PREFIX}/usr/libexec/netdata/netdata-updater.sh" ]; then
+  if run_as_root [ -x "${INSTALL_PREFIX}/usr/libexec/netdata/netdata-updater.sh" ]; then
     updater="${INSTALL_PREFIX}/usr/libexec/netdata/netdata-updater.sh"
-  elif [ -x "${INSTALL_PREFIX}/netdata/usr/libexec/netdata/netdata-updater.sh" ]; then
+  elif run_as_root  [-x "${INSTALL_PREFIX}/netdata/usr/libexec/netdata/netdata-updater.sh" ]; then
     updater="${INSTALL_PREFIX}/netdata/usr/libexec/netdata/netdata-updater.sh"
   else
     warning "Could not find netdata-updater.sh. This means that auto-updates cannot (currently) be enabled on this system. See https://learn.netdata.cloud/docs/agent/packaging/installer/update for more information about updating Netdata."
@@ -1217,7 +1217,7 @@ set_auto_updates() {
     if [ "${DRY_RUN}" -eq 1 ]; then
       progress "Would have attempted to enable automatic updates."
     # This first case is for catching using a new kickstart script with an old build. It can be safely removed after v1.34.0 is released.
-    elif ! grep -q '\-\-enable-auto-updates' "${updater}"; then
+    elif ! run_as_root grep -q '\-\-enable-auto-updates' "${updater}"; then
       echo
     elif ! run_as_root "${updater}" --enable-auto-updates "${NETDATA_AUTO_UPDATE_TYPE}"; then
       warning "Failed to enable auto updates. Netdata will still work, but you will need to update manually."

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1206,7 +1206,7 @@ claim() {
 set_auto_updates() {
   if run_as_root [ -x "${INSTALL_PREFIX}/usr/libexec/netdata/netdata-updater.sh" ]; then
     updater="${INSTALL_PREFIX}/usr/libexec/netdata/netdata-updater.sh"
-  elif run_as_root  [-x "${INSTALL_PREFIX}/netdata/usr/libexec/netdata/netdata-updater.sh" ]; then
+  elif run_as_root  [ -x "${INSTALL_PREFIX}/netdata/usr/libexec/netdata/netdata-updater.sh" ]; then
     updater="${INSTALL_PREFIX}/netdata/usr/libexec/netdata/netdata-updater.sh"
   else
     warning "Could not find netdata-updater.sh. This means that auto-updates cannot (currently) be enabled on this system. See https://learn.netdata.cloud/docs/agent/packaging/installer/update for more information about updating Netdata."


### PR DESCRIPTION
##### Summary

At the moment the updater script on the native packages is installed with ownership `root netdata` . Kickstart need to have root access to verify the existence of the netdata-updater script and run it.

##### Test Plan

Download kickstart script from this PR. 

1. Make an installation with any kind of native packages
2. Verify that the automatic updates are enabled.

Further testing. 

~Enforce other auto update types
`--auto-update-type               Specify a particular scheduling type for auto-updates (valid types: systemd, interval, 
crontab)`~


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
