### PR TITLE
send EXIT before exiting in freeipmi and debugfs plugins

### DIFF
--- a/collectors/debugfs.plugin/debugfs_plugin.c
+++ b/collectors/debugfs.plugin/debugfs_plugin.c
@@ -240,5 +240,7 @@ int main(int argc, char **argv)
         }
     }
 
+    fprintf(stdout, "EXIT\n");
+    fflush(stdout);
     return 0;
 }

--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -1857,4 +1857,6 @@ int main (int argc, char **argv) {
             fflush(stdout);
             exit(0);
         }
+    }
 }
+

--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -1852,6 +1852,9 @@ int main (int argc, char **argv) {
         fflush(stdout);
 
         // restart check (14400 seconds)
-        if(now_monotonic_sec() - started_t > 14400) exit(0);
-    }
+        if (now_monotonic_sec() - started_t > 14400) {
+            fprintf(stdout, "EXIT\n");
+            fflush(stdout);
+            exit(0);
+        }
 }


### PR DESCRIPTION
##### Summary

The same change we [did for charts.d.plugin](https://github.com/netdata/netdata/pull/14680).

---

Sometimes external processes become a zombie. This is likely because Netdata's main process doesn't handle `SIGCHLD` (this signal is simply ignored) and we rely on the read parser to fail. But sometimes it doesn't work and the parser gets stuck in [parser_next->fgets()](https://github.com/netdata/netdata/blob/cfc91853eb8ed17572076e9ebc26a40d40391402/libnetdata/parser/parser.c#L127-L129).

Some external plugins periodically exit (e.g. freeipmi every 4 hours, debugfs every 24 hours), and every time they exit there is a chance to get a zombie process 🧟 

This PR addresses only this case, the (alleged) root cause (ignoring `SIGCHLD`) will be fixed in #15113.

##### Test Plan

ci.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
