### PR TITLE
freeipmi: add availability status chart and alarm

### DIFF
--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -1823,8 +1823,6 @@ int main (int argc, char **argv) {
 
     if(debug) fprintf(stderr, "freeipmi.plugin: starting data collection\n");
 
-    static bool create_avail_chart = true;
-
     time_t started_t = now_monotonic_sec();
 
     size_t iteration = 0;
@@ -1835,19 +1833,20 @@ int main (int argc, char **argv) {
     for(iteration = 0; 1 ; iteration++) {
         usec_t dt = heartbeat_next(&hb, step);
 
-        if (create_avail_chart) {
-            create_avail_chart = false;
+        if (iteration) {
+            if (iteration == 1) {
+                fprintf(
+                    stdout,
+                    "CHART netdata.freeipmi_availability_status '' 'Plugin availability status' 'status' plugins netdata.plugin_availability_status line 146000 %d\n"
+                    "DIMENSION available '' absolute 1 1\n",
+                    netdata_update_every);
+            }
             fprintf(
                 stdout,
-                "CHART netdata.freeipmi_availability_status '' 'Plugin availability status' 'status' plugins netdata.plugin_availability_status line 146000 %d\n"
-                "DIMENSION available '' absolute 1 1\n",
-                netdata_update_every);
+                "BEGIN netdata.freeipmi_availability_status\n"
+                "SET available = 1\n"
+                "END\n");
         }
-        fprintf(
-            stdout,
-            "BEGIN netdata.freeipmi_availability_status\n"
-            "SET available = 1\n"
-            "END\n");
 
         if(debug && iteration)
             fprintf(stderr, "freeipmi.plugin: iteration %zu, dt %llu usec, sensors collected %zu, sensors sent to netdata %zu \n"

--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -1823,6 +1823,8 @@ int main (int argc, char **argv) {
 
     if(debug) fprintf(stderr, "freeipmi.plugin: starting data collection\n");
 
+    static bool create_avail_chart = true;
+
     time_t started_t = now_monotonic_sec();
 
     size_t iteration = 0;
@@ -1832,6 +1834,20 @@ int main (int argc, char **argv) {
     heartbeat_init(&hb);
     for(iteration = 0; 1 ; iteration++) {
         usec_t dt = heartbeat_next(&hb, step);
+
+        if (create_avail_chart) {
+            create_avail_chart = false;
+            fprintf(
+                stdout,
+                "CHART netdata.freeipmi_availability_status '' 'Plugin availability status' 'status' plugins netdata.plugin_availability_status line 146000 %d\n"
+                "DIMENSION available '' absolute 1 1\n",
+                netdata_update_every);
+        }
+        fprintf(
+            stdout,
+            "BEGIN netdata.freeipmi_availability_status\n"
+            "SET available = 1\n"
+            "END\n");
 
         if(debug && iteration)
             fprintf(stderr, "freeipmi.plugin: iteration %zu, dt %llu usec, sensors collected %zu, sensors sent to netdata %zu \n"

--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -69,6 +69,7 @@ dist_healthconfig_DATA = \
     health.d/nvme.conf \
     health.d/nut.conf \
     health.d/pihole.conf \
+    health.d/plugin.conf \
     health.d/ping.conf \
     health.d/postgres.conf \
     health.d/portcheck.conf \

--- a/health/health.d/plugin.conf
+++ b/health/health.d/plugin.conf
@@ -1,4 +1,4 @@
- template: plugin.availability_status
+ template: plugin_availability_status
        on: netdata.plugin_availability_status
     class: Errors
      type: Netdata

--- a/health/health.d/plugin.conf
+++ b/health/health.d/plugin.conf
@@ -1,0 +1,11 @@
+ template: plugin.availability_status
+       on: netdata.plugin_availability_status
+    class: Errors
+     type: Netdata
+     calc: $now - $last_collected_t
+    units: seconds ago
+    every: 10s
+     warn: $this > (($status >= $WARNING)  ? ($update_every) : (20 * $update_every))
+    delay: down 5m multiplier 1.5 max 1h
+     info: amount of time that ${label:_collect_plugin} did not report metrics
+       to: sysadmin

--- a/health/health.d/plugin.conf
+++ b/health/health.d/plugin.conf
@@ -7,5 +7,5 @@
     every: 10s
      warn: $this > (($status >= $WARNING)  ? ($update_every) : (20 * $update_every))
     delay: down 5m multiplier 1.5 max 1h
-     info: amount of time that ${label:_collect_plugin} did not report metrics
+     info: the amount of time that ${label:_collect_plugin} did not report its availability status
        to: sysadmin


### PR DESCRIPTION
##### Summary

Fixes: netdata/netdata-cloud#840

This PR adds:

- availability status chart to freeipmi.plugin.
- plugin availability status alarm.

##### Test Plan

Install this branch, check the chart and the alarm.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
