### PR TITLE
Use a single health log table

### DIFF
--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1661,6 +1661,12 @@ int test_sqlite(void) {
         return 1;
     }
 
+    rc = sqlite3_exec_monitored(db_meta, "UPDATE MINE SET id1=now_usec();", 0, 0, NULL);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr,"Failed to test SQLite: Update with now_usec() failed\n");
+        return 1;
+    }
+
     BUFFER *sql = buffer_create(ACLK_SYNC_QUERY_SIZE, NULL);
     char *uuid_str = "0000_000";
 

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1661,7 +1661,13 @@ int test_sqlite(void) {
         return 1;
     }
 
-    rc = sqlite3_exec_monitored(db_meta, "UPDATE MINE SET id1=now_usec();", 0, 0, NULL);
+    rc = sqlite3_create_function(db_meta, "now_usec", 1, SQLITE_ANY, 0, sqlite_now_usec, 0, 0);
+    if (unlikely(rc != SQLITE_OK)) {
+        fprintf(stderr, "Failed to register internal now_usec function");
+        return 1;
+    }
+
+    rc = sqlite3_exec_monitored(db_meta, "UPDATE MINE SET id1=now_usec(0);", 0, 0, NULL);
     if (rc != SQLITE_OK) {
         fprintf(stderr,"Failed to test SQLite: Update with now_usec() failed\n");
         return 1;

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -53,10 +53,14 @@ uint32_t rrdcalc_get_unique_id(RRDHOST *host, STRING *chart, STRING *name, uint3
         alarm_id = ae->alarm_id;
 
     else {
-        if (unlikely(!host->health_log.next_alarm_id))
-            host->health_log.next_alarm_id = (uint32_t)now_realtime_sec();
+        alarm_id = sql_get_alarm_id(host, chart, name);
 
-        alarm_id = host->health_log.next_alarm_id++;
+        if (!alarm_id) {
+            if (unlikely(!host->health_log.next_alarm_id))
+                host->health_log.next_alarm_id = (uint32_t)now_realtime_sec();
+
+            alarm_id = host->health_log.next_alarm_id++;
+        }
     }
 
     netdata_rwlock_unlock(&host->health_log.alarm_log_rwlock);

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -34,6 +34,7 @@ inline const char *rrdcalc_status2string(RRDCALC_STATUS status) {
     }
 }
 
+//TODO: add to get alarm_ids from sql
 uint32_t rrdcalc_get_unique_id(RRDHOST *host, STRING *chart, STRING *name, uint32_t *next_event_id) {
     netdata_rwlock_rdlock(&host->health_log.alarm_log_rwlock);
 

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -34,7 +34,6 @@ inline const char *rrdcalc_status2string(RRDCALC_STATUS status) {
     }
 }
 
-//TODO: add to get alarm_ids from sql
 uint32_t rrdcalc_get_unique_id(RRDHOST *host, STRING *chart, STRING *name, uint32_t *next_event_id) {
     netdata_rwlock_rdlock(&host->health_log.alarm_log_rwlock);
 

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -52,7 +52,7 @@ uint32_t rrdcalc_get_unique_id(RRDHOST *host, STRING *chart, STRING *name, uint3
         alarm_id = ae->alarm_id;
 
     else {
-        alarm_id = sql_get_alarm_id(host, chart, name);
+        alarm_id = sql_get_alarm_id(host, chart, name, next_event_id);
 
         if (!alarm_id) {
             if (unlikely(!host->health_log.next_alarm_id))

--- a/database/rrdcalc.h
+++ b/database/rrdcalc.h
@@ -211,6 +211,7 @@ struct alert_config {
     STRING *repeat;
     STRING *host_labels;
     STRING *chart_labels;
+    STRING *source;
 
     STRING *p_db_lookup_dimensions;
     STRING *p_db_lookup_method;

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -27,11 +27,19 @@ static inline void uuid_unparse_lower_fix(uuid_t *uuid, char *out)
     out[23] = '_';
 }
 
+static inline int uuid_parse_fix(char *in, uuid_t uuid)
+{
+    in[8] = '-';
+    in[13] = '-';
+    in[18] = '-';
+    in[23] = '-';
+    return uuid_parse(in, uuid);
+}
+
 static inline int claimed()
 {
     return localhost->aclk_state.claimed_id != NULL;
 }
-
 
 #define TABLE_ACLK_ALERT "CREATE TABLE IF NOT EXISTS aclk_alert_%s (sequence_id INTEGER PRIMARY KEY, " \
         "alert_unique_id, date_created, date_submitted, date_cloud_ack, filtered_alert_unique_id NOT NULL, " \

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -87,6 +87,8 @@ struct aclk_sync_host_config {
     char uuid_str[UUID_STR_LEN];
     char node_id[UUID_STR_LEN];
     char *alerts_snapshot_uuid;        // will contain the snapshot_uuid value if snapshot was requested
+    uint64_t alerts_log_first_sequence_id;
+    uint64_t alerts_log_last_sequence_id;
 };
 
 extern sqlite3 *db_meta;

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -274,10 +274,10 @@ void aclk_push_alert_event(struct aclk_sync_host_config *wc)
 
     buffer_sprintf(sql, "select aa.sequence_id, hl.unique_id, hl.alarm_id, hl.config_hash_id, hl.updated_by_id, hl.when_key, " \
         " hl.duration, hl.non_clear_duration, hl.flags, hl.exec_run_timestamp, hl.delay_up_to_timestamp, hl.name,  " \
-        " hl.chart, hl.family, hl.exec, hl.recipient, hl.source, hl.units, hl.info, hl.exec_code, hl.new_status,  " \
+        " hl.chart, hl.family, hl.exec, hl.recipient, ha.source, hl.units, hl.info, hl.exec_code, hl.new_status,  " \
         " hl.old_status, hl.delay, hl.new_value, hl.old_value, hl.last_repeat, hl.chart_context, hl.transition_id, hl.alarm_event_id  " \
-        " from health_log hl, aclk_alert_%s aa " \
-        " where hl.unique_id = aa.alert_unique_id and aa.date_submitted is null and host_id = @host_id " \
+        " from health_log hl, aclk_alert_%s aa, alert_hash ha " \
+        " where hl.unique_id = aa.alert_unique_id and hl.config_hash_id = ha.hash_id and aa.date_submitted is null and host_id = @host_id " \
         " order by aa.sequence_id asc limit %d;", wc->uuid_str, limit);
 
     rc = sqlite3_prepare_v2(db_meta, buffer_tostring(sql), -1, &res, 0);

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -318,7 +318,7 @@ void aclk_push_alert_event(struct aclk_sync_host_config *wc)
 
         // Try to create tables
         if (wc->host)
-            sql_create_health_log_table(wc->host);
+            sql_create_health_log_table(); //might remove
 
         BUFFER *sql_fix = buffer_create(1024, &netdata_buffers_statistics.buffers_sqlite);
         buffer_sprintf(sql_fix, TABLE_ACLK_ALERT, wc->uuid_str);

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -283,10 +283,6 @@ void aclk_push_alert_event(struct aclk_sync_host_config *wc)
     rc = sqlite3_prepare_v2(db_meta, buffer_tostring(sql), -1, &res, 0);
     if (rc != SQLITE_OK) {
 
-        // Try to create tables
-        if (wc->host)
-            sql_create_health_log_table(); //might remove
-
         BUFFER *sql_fix = buffer_create(1024, &netdata_buffers_statistics.buffers_sqlite);
         buffer_sprintf(sql_fix, TABLE_ACLK_ALERT, wc->uuid_str);
         rc = db_execute(db_meta, buffer_tostring(sql_fix));

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -337,7 +337,8 @@ void aclk_push_alert_event(struct aclk_sync_host_config *wc)
         alarm_log.timezone = strdupz(rrdhost_abbrev_timezone(wc->host));
         alarm_log.exec_path = sqlite3_column_bytes(res, 14) > 0 ? strdupz((char *)sqlite3_column_text(res, 14)) :
                                                                   strdupz((char *)string2str(wc->host->health.health_default_exec));
-        alarm_log.conf_source = strdupz((char *)sqlite3_column_text(res, 16));
+
+        alarm_log.conf_source = sqlite3_column_bytes(res, 16) > 0 ? strdupz((char *)sqlite3_column_text(res, 16)) : strdupz("");
 
         char *edit_command = sqlite3_column_bytes(res, 16) > 0 ?
                                  health_edit_command_from_source((char *)sqlite3_column_text(res, 16)) :

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -228,7 +228,7 @@ static int do_migration_v8_v9(sqlite3 *database, const char *name)
               "flags int, exec_run_timestamp int, delay_up_to_timestamp int, name text, chart text, family text, exec text, " \
               "recipient text, units text, info text, exec_code int, new_status real, old_status real, delay int, " \
               "new_value double, old_value double, last_repeat int, chart_context text, " \
-              "transition_id blob, insert_mark_timestamp int);");
+              "transition_id blob, global_id int);");
     sqlite3_exec_monitored(database, sql, 0, 0, NULL);
 
     snprintfz(sql, 2047, "CREATE INDEX IF NOT EXISTS health_log_index ON health_log (unique_id);");

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -218,12 +218,6 @@ static int do_migration_v8_v9(sqlite3 *database, const char *name)
     UNUSED(name);
     info("Running database migration %s", name);
 
-    //create a single health log table
-    if (sql_create_health_log_table() == 1) {
-        error_report("Failed to create health_log table needed for migration");
-        return 1;
-    }
-
     char sql[256];
     int rc;
     sqlite3_stmt *res = NULL;

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -226,12 +226,18 @@ static int do_migration_v8_v9(sqlite3 *database, const char *name)
     snprintfz(sql, 2047, "CREATE TABLE IF NOT EXISTS health_log (host_id blob, unique_id int, alarm_id int, alarm_event_id int, " \
               "config_hash_id blob, updated_by_id int, updates_id int, when_key int, duration int, non_clear_duration int, " \
               "flags int, exec_run_timestamp int, delay_up_to_timestamp int, name text, chart text, family text, exec text, " \
-              "recipient text, source text, units text, info text, exec_code int, new_status real, old_status real, delay int, " \
-              "new_value double, old_value double, last_repeat int, class text, component text, type text, chart_context text, " \
+              "recipient text, units text, info text, exec_code int, new_status real, old_status real, delay int, " \
+              "new_value double, old_value double, last_repeat int, chart_context text, " \
               "transition_id blob, insert_mark_timestamp int);");
     sqlite3_exec_monitored(database, sql, 0, 0, NULL);
 
     snprintfz(sql, 2047, "CREATE INDEX IF NOT EXISTS health_log_index ON health_log (unique_id);");
+    sqlite3_exec_monitored(database, sql, 0, 0, NULL);
+
+    snprintfz(sql, 255, "ALTER TABLE alert_hash ADD source text;");
+    sqlite3_exec_monitored(database, sql, 0, 0, NULL);
+
+    snprintfz(sql, 2047, "CREATE INDEX IF NOT EXISTS alert_hash_index ON alert_hash (hash_id);");
     sqlite3_exec_monitored(database, sql, 0, 0, NULL);
 
     DICTIONARY *dict_tables = dictionary_create(DICT_OPTION_NONE);

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -235,7 +235,7 @@ static int do_migration_v8_v9(sqlite3 *database, const char *name)
               "updated_by_id int, updates_id int, when_key int, duration int, non_clear_duration int, " \
               "flags int, exec_run_timestamp int, delay_up_to_timestamp int, " \
               "info text, exec_code int, new_status real, old_status real, delay int, " \
-              "new_value double, old_value double, last_repeat int, transition_id blob, global_id int);");
+              "new_value double, old_value double, last_repeat int, transition_id blob, global_id int, host_id blob);");
     sqlite3_exec_monitored(database, sql, 0, 0, NULL);
 
     snprintfz(sql, 2047, "CREATE INDEX IF NOT EXISTS health_log_d_ind_1 ON health_log_detail (unique_id);");
@@ -278,6 +278,9 @@ static int do_migration_v8_v9(sqlite3 *database, const char *name)
     }
     dfe_done(table);
     dictionary_destroy(dict_tables);
+
+    snprintfz(sql, 2047, "ALTER TABLE health_log_detail DROP COLUMN host_id;");
+    sqlite3_exec_monitored(database, sql, 0, 0, NULL);
 
     return 0;
 }

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -259,7 +259,7 @@ static int do_migration_v8_v9(sqlite3 *database, const char *name)
 
     rc = sqlite3_finalize(res);
     if (unlikely(rc != SQLITE_OK))
-        error_report("DES Failed to finalize statement when copying health_log tables, rc = %d", rc);
+        error_report("Failed to finalize statement when copying health_log tables, rc = %d", rc);
 
     char *table = NULL;
     dfe_start_read(dict_tables, table) {

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -223,15 +223,27 @@ static int do_migration_v8_v9(sqlite3 *database, const char *name)
     sqlite3_stmt *res = NULL;
 
     //create the health_log table and it's index
-    snprintfz(sql, 2047, "CREATE TABLE IF NOT EXISTS health_log (host_id blob, unique_id int, alarm_id int, alarm_event_id int, " \
-              "config_hash_id blob, updated_by_id int, updates_id int, when_key int, duration int, non_clear_duration int, " \
-              "flags int, exec_run_timestamp int, delay_up_to_timestamp int, name text, chart text, family text, exec text, " \
-              "recipient text, units text, info text, exec_code int, new_status real, old_status real, delay int, " \
-              "new_value double, old_value double, last_repeat int, chart_context text, " \
-              "transition_id blob, global_id int);");
+    snprintfz(sql, 2047, "CREATE TABLE IF NOT EXISTS health_log (health_log_id INTEGER PRIMARY KEY, host_id blob, alarm_id int, " \
+              "config_hash_id blob, name text, chart text, family text, recipient text, units text, exec text, " \
+              "chart_context text, last_transition_id blob, UNIQUE (host_id, alarm_id)) ;");
     sqlite3_exec_monitored(database, sql, 0, 0, NULL);
 
-    snprintfz(sql, 2047, "CREATE INDEX IF NOT EXISTS health_log_index ON health_log (unique_id);");
+    //TODO indexes
+    snprintfz(sql, 2047, "CREATE INDEX IF NOT EXISTS health_log_ind_1 ON health_log (host_id);");
+    sqlite3_exec_monitored(database, sql, 0, 0, NULL);
+
+    snprintfz(sql, 2047, "CREATE TABLE IF NOT EXISTS health_log_detail (health_log_id int, unique_id int, alarm_id int, alarm_event_id int, " \
+              "updated_by_id int, updates_id int, when_key int, duration int, non_clear_duration int, " \
+              "flags int, exec_run_timestamp int, delay_up_to_timestamp int, " \
+              "info text, exec_code int, new_status real, old_status real, delay int, " \
+              "new_value double, old_value double, last_repeat int, transition_id blob, global_id int);");
+    sqlite3_exec_monitored(database, sql, 0, 0, NULL);
+
+    snprintfz(sql, 2047, "CREATE INDEX IF NOT EXISTS health_log_d_ind_1 ON health_log_detail (unique_id);");
+    sqlite3_exec_monitored(database, sql, 0, 0, NULL);
+    snprintfz(sql, 2047, "CREATE INDEX IF NOT EXISTS health_log_d_ind_2 ON health_log_detail (global_id);");
+    sqlite3_exec_monitored(database, sql, 0, 0, NULL);
+    snprintfz(sql, 2047, "CREATE INDEX IF NOT EXISTS health_log_d_ind_3 ON health_log_detail (transition_id);");
     sqlite3_exec_monitored(database, sql, 0, 0, NULL);
 
     snprintfz(sql, 255, "ALTER TABLE alert_hash ADD source text;");

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -215,7 +215,6 @@ static int do_migration_v7_v8(sqlite3 *database, const char *name)
 
 static int do_migration_v8_v9(sqlite3 *database, const char *name)
 {
-    UNUSED(name);
     info("Running database migration %s", name);
 
     char sql[2048];
@@ -280,6 +279,7 @@ static int do_migration_v8_v9(sqlite3 *database, const char *name)
     dfe_done(table);
     dictionary_destroy(dict_tables);
 
+    info("Completed database migration %s", name);
     return 0;
 }
 

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -346,7 +346,7 @@ static void sqlite_uuid_parse(sqlite3_context *context, int argc, sqlite3_value 
     sqlite3_result_blob(context, &uuid, sizeof(uuid_t), SQLITE_TRANSIENT);
 }
 
-static void sqlite_now_usec(sqlite3_context *context, int argc, sqlite3_value **argv)
+void sqlite_now_usec(sqlite3_context *context, int argc, sqlite3_value **argv)
 {
     if (argc != 1 ){
         sqlite3_result_null(context);
@@ -360,7 +360,6 @@ static void sqlite_now_usec(sqlite3_context *context, int argc, sqlite3_value **
 
     sqlite3_result_int64(context, (sqlite_int64) now_realtime_usec());
 }
-
 
 /*
  * Initialize the SQLite database

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -430,6 +430,14 @@ int sql_init_database(db_check_action_type_t rebuild, int memory)
     char buf[1024 + 1] = "";
     const char *list[2] = { buf, NULL };
 
+    rc = sqlite3_create_function(db_meta, "u2h", 1, SQLITE_ANY | SQLITE_DETERMINISTIC, 0, sqlite_uuid_parse, 0, 0);
+    if (unlikely(rc != SQLITE_OK))
+        error_report("Failed to register internal u2h function");
+
+    rc = sqlite3_create_function(db_meta, "now_usec", 1, SQLITE_ANY, 0, sqlite_now_usec, 0, 0);
+    if (unlikely(rc != SQLITE_OK))
+        error_report("Failed to register internal now_usec function");
+
     int target_version = DB_METADATA_VERSION;
 
     if (likely(!memory))
@@ -479,14 +487,6 @@ int sql_init_database(db_check_action_type_t rebuild, int memory)
 
     initialize_thread_key_pool();
 
-    rc = sqlite3_create_function(db_meta, "u2h", 1, SQLITE_ANY | SQLITE_DETERMINISTIC, 0, sqlite_uuid_parse, 0, 0);
-    if (unlikely(rc != SQLITE_OK))
-        error_report("Failed to register internal u2h function");
-
-
-    rc = sqlite3_create_function(db_meta, "now_usec", 1, SQLITE_ANY, 0, sqlite_now_usec, 0, 0);
-    if (unlikely(rc != SQLITE_OK))
-        error_report("Failed to register internal now_usec function");
     return 0;
 }
 

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -32,7 +32,9 @@ const char *database_config[] = {
     "every text, units text, calc text, families text, plugin text, module text, charts text, green text, "
     "red text, warn text, crit text, exec text, to_key text, info text, delay text, options text, "
     "repeat text, host_labels text, p_db_lookup_dimensions text, p_db_lookup_method text, p_db_lookup_options int, "
-    "p_db_lookup_after int, p_db_lookup_before int, p_update_every int);",
+    "p_db_lookup_after int, p_db_lookup_before int, p_update_every int, source text);",
+
+    "CREATE INDEX IF NOT EXISTS alert_hash_index ON alert_hash (hash_id);",
 
     "CREATE TABLE IF NOT EXISTS host_info(host_id blob, system_key text NOT NULL, system_value text NOT NULL, "
     "date_created INT, PRIMARY KEY(host_id, system_key));",
@@ -46,9 +48,8 @@ const char *database_config[] = {
     "CREATE TABLE IF NOT EXISTS health_log (host_id blob, unique_id int, alarm_id int, alarm_event_id int, "
     "config_hash_id blob, updated_by_id int, updates_id int, when_key int, duration int, non_clear_duration int, "
     "flags int, exec_run_timestamp int, delay_up_to_timestamp int, name text, chart text, family text, exec text, "
-    "recipient text, source text, units text, info text, exec_code int, new_status real, old_status real, delay int, "
-    "new_value double, old_value double, last_repeat int, class text, component text, type text, chart_context text, "
-    "transition_id blob, insert_mark_timestamp int);",
+    "recipient text, units text, info text, exec_code int, new_status real, old_status real, delay int, "
+    "new_value double, old_value double, last_repeat int, chart_context text, transition_id blob, insert_mark_timestamp int);",
 
     "CREATE INDEX IF NOT EXISTS health_log_index ON health_log (unique_id);",
 

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -2,6 +2,7 @@
 
 #include "sqlite_functions.h"
 #include "sqlite_db_migration.h"
+#include "uuid.h"
 
 #define DB_METADATA_VERSION 9
 
@@ -371,6 +372,16 @@ void sqlite_now_usec(sqlite3_context *context, int argc, sqlite3_value **argv)
     sqlite3_result_int64(context, (sqlite_int64) now_realtime_usec());
 }
 
+void sqlite_uuid_random(sqlite3_context *context, int argc, sqlite3_value **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    uuid_t uuid;
+    uuid_generate_random(uuid);
+    sqlite3_result_blob(context, &uuid, sizeof(uuid_t), SQLITE_TRANSIENT);
+}
+
 /*
  * Initialize the SQLite database
  * Return 0 on success
@@ -446,6 +457,10 @@ int sql_init_database(db_check_action_type_t rebuild, int memory)
     rc = sqlite3_create_function(db_meta, "now_usec", 1, SQLITE_ANY, 0, sqlite_now_usec, 0, 0);
     if (unlikely(rc != SQLITE_OK))
         error_report("Failed to register internal now_usec function");
+
+    rc = sqlite3_create_function(db_meta, "uuid_random", 1, SQLITE_ANY, 0, sqlite_uuid_random, 0, 0);
+    if (unlikely(rc != SQLITE_OK))
+        error_report("Failed to register internal uuid_random function");
 
     int target_version = DB_METADATA_VERSION;
 

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -50,7 +50,7 @@ const char *database_config[] = {
     "chart_context text, last_transition_id blob, UNIQUE (host_id, alarm_id)) ;",
 
     //TODO indexes
-    "CREATE INDEX IF NOT EXISTS health_log_hid_index ON health_log (host_id);",
+    "CREATE INDEX IF NOT EXISTS health_log_ind_1 ON health_log (host_id);",
 
     "CREATE TABLE IF NOT EXISTS health_log_detail (health_log_id int, unique_id int, alarm_id int, alarm_event_id int, "
     "updated_by_id int, updates_id int, when_key int, duration int, non_clear_duration int, "
@@ -58,9 +58,9 @@ const char *database_config[] = {
     "info text, exec_code int, new_status real, old_status real, delay int, "
     "new_value double, old_value double, last_repeat int, transition_id blob, global_id int);",
 
-    "CREATE INDEX IF NOT EXISTS health_log_d_uid_index ON health_log_detail (unique_id);",
-    "CREATE INDEX IF NOT EXISTS health_log_d_gid_index ON health_log_detail (global_id);",
-    "CREATE INDEX IF NOT EXISTS health_log_d_tid_index ON health_log_detail (transition_id);",
+    "CREATE INDEX IF NOT EXISTS health_log_d_ind_1 ON health_log_detail (unique_id);",
+    "CREATE INDEX IF NOT EXISTS health_log_d_ind_2 ON health_log_detail (global_id);",
+    "CREATE INDEX IF NOT EXISTS health_log_d_ind_3 ON health_log_detail (transition_id);",
     //TODO more indexes
 
     NULL

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -49,7 +49,7 @@ const char *database_config[] = {
     "config_hash_id blob, updated_by_id int, updates_id int, when_key int, duration int, non_clear_duration int, "
     "flags int, exec_run_timestamp int, delay_up_to_timestamp int, name text, chart text, family text, exec text, "
     "recipient text, units text, info text, exec_code int, new_status real, old_status real, delay int, "
-    "new_value double, old_value double, last_repeat int, chart_context text, transition_id blob, insert_mark_timestamp int);",
+    "new_value double, old_value double, last_repeat int, chart_context text, transition_id blob, global_id int);",
 
     "CREATE INDEX IF NOT EXISTS health_log_index ON health_log (unique_id);",
 

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -43,6 +43,15 @@ const char *database_config[] = {
     "CREATE TRIGGER IF NOT EXISTS ins_host AFTER INSERT ON host BEGIN INSERT INTO node_instance (host_id, date_created)"
       " SELECT new.host_id, unixepoch() WHERE new.host_id NOT IN (SELECT host_id FROM node_instance); END;",
 
+    "CREATE TABLE IF NOT EXISTS health_log (host_id blob, unique_id int, alarm_id int, alarm_event_id int, "
+    "config_hash_id blob, updated_by_id int, updates_id int, when_key int, duration int, non_clear_duration int, "
+    "flags int, exec_run_timestamp int, delay_up_to_timestamp int, name text, chart text, family text, exec text, "
+    "recipient text, source text, units text, info text, exec_code int, new_status real, old_status real, delay int, "
+    "new_value double, old_value double, last_repeat int, class text, component text, type text, chart_context text, "
+    "transition_id blob, insert_mark_timestamp int);",
+
+    "CREATE INDEX IF NOT EXISTS health_log_index ON health_log (unique_id);",
+
     NULL
 };
 

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -45,13 +45,21 @@ const char *database_config[] = {
     "CREATE TRIGGER IF NOT EXISTS ins_host AFTER INSERT ON host BEGIN INSERT INTO node_instance (host_id, date_created)"
       " SELECT new.host_id, unixepoch() WHERE new.host_id NOT IN (SELECT host_id FROM node_instance); END;",
 
-    "CREATE TABLE IF NOT EXISTS health_log (host_id blob, unique_id int, alarm_id int, alarm_event_id int, "
-    "config_hash_id blob, updated_by_id int, updates_id int, when_key int, duration int, non_clear_duration int, "
-    "flags int, exec_run_timestamp int, delay_up_to_timestamp int, name text, chart text, family text, exec text, "
-    "recipient text, units text, info text, exec_code int, new_status real, old_status real, delay int, "
-    "new_value double, old_value double, last_repeat int, chart_context text, transition_id blob, global_id int);",
+    "CREATE TABLE IF NOT EXISTS health_log (health_log_id INTEGER PRIMARY KEY, host_id blob, alarm_id int, "
+    "config_hash_id blob, name text, chart text, family text, recipient text, units text, exec text, "
+    "chart_context text, last_transition_id blob, UNIQUE (host_id, alarm_id)) ;",
 
-    "CREATE INDEX IF NOT EXISTS health_log_index ON health_log (unique_id);",
+    //TODO indexes
+
+    "CREATE TABLE IF NOT EXISTS health_log_detail (health_log_id int, unique_id int, alarm_id int, alarm_event_id int, "
+    "updated_by_id int, updates_id int, when_key int, duration int, non_clear_duration int, "
+    "flags int, exec_run_timestamp int, delay_up_to_timestamp int, "
+    "info text, exec_code int, new_status real, old_status real, delay int, "
+    "new_value double, old_value double, last_repeat int, transition_id blob, global_id int);",
+
+    "CREATE INDEX IF NOT EXISTS health_log_d_uid_index ON health_log_detail (unique_id);",
+    "CREATE INDEX IF NOT EXISTS health_log_d_gid_index ON health_log_detail (global_id);",
+    //TODO more indexes
 
     NULL
 };

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -2,7 +2,6 @@
 
 #include "sqlite_functions.h"
 #include "sqlite_db_migration.h"
-#include "uuid.h"
 
 #define DB_METADATA_VERSION 9
 
@@ -458,7 +457,7 @@ int sql_init_database(db_check_action_type_t rebuild, int memory)
     if (unlikely(rc != SQLITE_OK))
         error_report("Failed to register internal now_usec function");
 
-    rc = sqlite3_create_function(db_meta, "uuid_random", 1, SQLITE_ANY, 0, sqlite_uuid_random, 0, 0);
+    rc = sqlite3_create_function(db_meta, "uuid_random", 0, SQLITE_ANY, 0, sqlite_uuid_random, 0, 0);
     if (unlikely(rc != SQLITE_OK))
         error_report("Failed to register internal uuid_random function");
 

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -50,6 +50,7 @@ const char *database_config[] = {
     "chart_context text, last_transition_id blob, UNIQUE (host_id, alarm_id)) ;",
 
     //TODO indexes
+    "CREATE INDEX IF NOT EXISTS health_log_hid_index ON health_log (host_id);",
 
     "CREATE TABLE IF NOT EXISTS health_log_detail (health_log_id int, unique_id int, alarm_id int, alarm_event_id int, "
     "updated_by_id int, updates_id int, when_key int, duration int, non_clear_duration int, "
@@ -59,6 +60,7 @@ const char *database_config[] = {
 
     "CREATE INDEX IF NOT EXISTS health_log_d_uid_index ON health_log_detail (unique_id);",
     "CREATE INDEX IF NOT EXISTS health_log_d_gid_index ON health_log_detail (global_id);",
+    "CREATE INDEX IF NOT EXISTS health_log_d_tid_index ON health_log_detail (transition_id);",
     //TODO more indexes
 
     NULL

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -78,4 +78,5 @@ void invalidate_node_instances(uuid_t *host_id, uuid_t *claim_id);
 int sql_metadata_cache_stats(int op);
 
 void sql_drop_table(const char *table);
+void sqlite_now_usec(sqlite3_context *context, int argc, sqlite3_value **argv);
 #endif //NETDATA_SQLITE_FUNCTIONS_H

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -77,4 +77,5 @@ void invalidate_node_instances(uuid_t *host_id, uuid_t *claim_id);
 // Provide statistics
 int sql_metadata_cache_stats(int op);
 
+void sql_drop_table(const char *table);
 #endif //NETDATA_SQLITE_FUNCTIONS_H

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -1620,7 +1620,7 @@ int health_migrate_old_health_log_table(char *table) {
     return 1;
 }
 
-#define SQL_GET_ALARM_ID "select alarm_id from health_log where host = @host_id and chart = @chart and name = @name"
+#define SQL_GET_ALARM_ID "select alarm_id from health_log where host_id = @host_id and chart = @chart and name = @name"
 uint32_t sql_get_alarm_id(RRDHOST *host, STRING *chart, STRING *name)
 {
     int rc = 0, alarm_id = 0;

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -477,7 +477,7 @@ void sql_health_alarm_log_cleanup_not_claimed(RRDHOST *host, size_t rotate_every
 /* Health related SQL queries
    Cleans up the health_log_detail table on a claimed host
 */
-#define SQL_CLEANUP_HEALTH_LOG_DETAIL_CLAIMED(guid, limit) "DELETE from health_log_detail WHERE unique_id NOT IN (SELECT filtered_alert_unique_id FROM aclk_alert_%s) AND unique_id IN (SELECT hld.unique_id FROM health_log hl, health_log_detail hld WHERE host_id = ?2 AND hl.health_log_id = hld.health_log_id) ORDER BY unique_id asc LIMIT %lu);", guid, limit
+#define SQL_CLEANUP_HEALTH_LOG_DETAIL_CLAIMED(guid, limit) "DELETE from health_log_detail WHERE unique_id NOT IN (SELECT filtered_alert_unique_id FROM aclk_alert_%s) AND unique_id IN (SELECT hld.unique_id FROM health_log hl, health_log_detail hld WHERE host_id = ?2 AND hl.health_log_id = hld.health_log_id) ORDER BY unique_id asc LIMIT %lu;", guid, limit
 void sql_health_alarm_log_cleanup_claimed(RRDHOST *host, size_t rotate_every) {
     sqlite3_stmt *res = NULL;
     int rc;

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "sqlite_health.h"
-#include "libnetdata/string/string.h"
 #include "sqlite_functions.h"
 #include "sqlite_db_migration.h"
 

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -385,46 +385,6 @@ void sql_health_alarm_log_count(RRDHOST *host) {
 }
 
 /* Health related SQL queries
-   Cleans up the health_log table
-*/
-#define SQL_CLEANUP_HEALTH_LOG(limit) "DELETE FROM health_log WHERE health_log_id not in (select health_log_id from health_log_detail) and host_id = @host_id ORDER BY alarm_id ASC LIMIT %lu;", limit
-void sql_health_alarm_log_cleanup_main_health_log(RRDHOST *host, size_t rotate_every)
-{
-    sqlite3_stmt *res = NULL;
-    int rc;
-    char command[MAX_HEALTH_SQL_SIZE + 1];
-
-    if (unlikely(!db_meta)) {
-        if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
-            error_report("Database has not been initialized");
-        return;
-    }
-
-    snprintfz(command, MAX_HEALTH_SQL_SIZE, SQL_CLEANUP_HEALTH_LOG((unsigned long int) (host->health.health_log_entries_written - rotate_every)));
-
-    rc = sqlite3_prepare_v2(db_meta, command, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to prepare statement to cleanup health log table");
-        return;
-    }
-
-    rc = sqlite3_bind_blob(res, 1, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind host_id for SQL_CLEANUP_HEALTH_LOG.");
-        sqlite3_finalize(res);
-        return;
-    }
-
-    rc = sqlite3_step_monitored(res);
-    if (unlikely(rc != SQLITE_DONE))
-        error_report("Failed to cleanup health log table, rc = %d", rc);
-
-    rc = sqlite3_finalize(res);
-    if (unlikely(rc != SQLITE_OK))
-        error_report("Failed to finalize the prepared statement to cleanup health log table");
-}
-
-/* Health related SQL queries
    Cleans up the health_log_detail table on a non-claimed host
 */
 #define SQL_CLEANUP_HEALTH_LOG_DETAIL_NOT_CLAIMED(limit) "DELETE FROM health_log_detail where health_log_id in (select health_log_id from health_log where host_id = @host_id) ORDER BY unique_id ASC LIMIT %lu;", limit
@@ -551,8 +511,6 @@ void sql_health_alarm_log_cleanup(RRDHOST *host) {
         sql_health_alarm_log_cleanup_not_claimed(host, rotate_every);
     } else
         sql_health_alarm_log_cleanup_claimed(host, rotate_every);
-
-    sql_health_alarm_log_cleanup_main_health_log(host, rotate_every);
 }
 
 #define SQL_INJECT_REMOVED "insert into health_log_detail (health_log_id, unique_id, alarm_id, alarm_event_id, updated_by_id, updates_id, when_key, duration, non_clear_duration, flags, exec_run_timestamp, delay_up_to_timestamp, info, exec_code, new_status, old_status, delay, new_value, old_value, last_repeat, transition_id, global_id) select health_log_id, ?1, ?2, ?3, 0, ?4, unixepoch(), 0, 0, flags, exec_run_timestamp, unixepoch(), info, exec_code, -2, new_status, delay, NULL, new_value, 0, ?5, now_usec(0) from health_log_detail where unique_id = ?6 and transition_id = ?7;"

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -1502,7 +1502,11 @@ int health_migrate_old_health_log_table(char *table) {
 
     //table should contain guid. We need to
     //keep it in the new table along with it's data
-    //health_log_UUID
+    //health_log_XXXXXXXX_XXXX_XXXX_XXXX_XXXXXXXXXXXX
+    if (strnlen(table, 46) != 46) {
+        return 0;
+    }
+
     char *uuid_from_table = strdupz(table + 11);
     uuid_t uuid;
     if (uuid_parse_fix(uuid_from_table, uuid)) {
@@ -1511,7 +1515,6 @@ int health_migrate_old_health_log_table(char *table) {
     }
 
     int rc;
-
     char command[MAX_HEALTH_SQL_SIZE + 1];
     sqlite3_stmt *res = NULL;
     snprintfz(command, MAX_HEALTH_SQL_SIZE, SQL_COPY_HEALTH_LOG(table));

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -476,7 +476,7 @@ void sql_health_alarm_log_cleanup_not_claimed(RRDHOST *host, size_t rotate_every
 /* Health related SQL queries
    Cleans up the health_log_detail table on a claimed host
 */
-#define SQL_CLEANUP_HEALTH_LOG_DETAIL_CLAIMED(guid, limit) "DELETE from health_log_detail WHERE unique_id NOT IN (SELECT filtered_alert_unique_id FROM aclk_alert_%s) AND unique_id IN (SELECT hld.unique_id FROM health_log hl, health_log_detail hld WHERE host_id = ?2 AND hl.health_log_id = hld.health_log_id) ORDER BY unique_id asc LIMIT %lu;", guid, limit
+#define SQL_CLEANUP_HEALTH_LOG_DETAIL_CLAIMED(guid, limit) "DELETE from health_log_detail WHERE unique_id NOT IN (SELECT filtered_alert_unique_id FROM aclk_alert_%s) AND unique_id IN (SELECT hld.unique_id FROM health_log hl, health_log_detail hld WHERE hl.host_id = ?1 AND hl.health_log_id = hld.health_log_id) and health_log_id in (SELECT health_log_id FROM health_log WHERE host_id = ?2) ORDER BY unique_id asc LIMIT %lu;", guid, limit
 void sql_health_alarm_log_cleanup_claimed(RRDHOST *host, size_t rotate_every) {
     sqlite3_stmt *res = NULL;
     int rc;

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -1490,11 +1490,10 @@ void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *
     buffer_free(command);
 }
 
-//MUST MAKE SURE THERE IS A TRANSACTION_ID FOR ALL
 #define SQL_COPY_HEALTH_LOG(table) "INSERT OR IGNORE INTO health_log (host_id, alarm_id, config_hash_id, name, chart, family, exec, recipient, units, chart_context) SELECT ?1, alarm_id, config_hash_id, name, chart, family, exec, recipient, units, chart_context from %s;", table
-#define SQL_COPY_HEALTH_LOG_DETAIL(table) "INSERT INTO health_log_detail (unique_id, alarm_id, alarm_event_id, updated_by_id, updates_id, when_key, duration, non_clear_duration, flags, exec_run_timestamp, delay_up_to_timestamp, info, exec_code, new_status, old_status, delay, new_value, old_value, last_repeat, transition_id, global_id) SELECT unique_id, alarm_id, alarm_event_id, updated_by_id, updates_id, when_key, duration, non_clear_duration, flags, exec_run_timestamp, delay_up_to_timestamp, info, exec_code, new_status, old_status, delay, new_value, old_value, last_repeat, transition_id, now_usec(1) from %s;", table
+#define SQL_COPY_HEALTH_LOG_DETAIL(table) "INSERT INTO health_log_detail (unique_id, alarm_id, alarm_event_id, updated_by_id, updates_id, when_key, duration, non_clear_duration, flags, exec_run_timestamp, delay_up_to_timestamp, info, exec_code, new_status, old_status, delay, new_value, old_value, last_repeat, transition_id, global_id, host_id) SELECT unique_id, alarm_id, alarm_event_id, updated_by_id, updates_id, when_key, duration, non_clear_duration, flags, exec_run_timestamp, delay_up_to_timestamp, info, exec_code, new_status, old_status, delay, new_value, old_value, last_repeat, transition_id, now_usec(1), ?1 from %s;", table
 #define SQL_UPDATE_HEALTH_LOG_DETAIL_TRANSITION_ID "update health_log_detail set transition_id = uuid_random() where transition_id is null;"
-#define SQL_UPDATE_HEALTH_LOG_DETAIL_HEALTH_LOG_ID "update health_log_detail set health_log_id = (select health_log_id from health_log where host_id = ?1 and alarm_id = health_log_detail.alarm_id);"
+#define SQL_UPDATE_HEALTH_LOG_DETAIL_HEALTH_LOG_ID "update health_log_detail set health_log_id = (select health_log_id from health_log where host_id = ?1 and alarm_id = health_log_detail.alarm_id) where health_log_id is null and host_id = ?2;"
 #define SQL_UPDATE_HEALTH_LOG_LAST_TRANSITION_ID "update health_log set last_transition_id = (select transition_id from health_log_detail where health_log_id = health_log.health_log_id and alarm_id = health_log.alarm_id group by (alarm_id) having max(alarm_event_id)) where host_id = ?1;"
 int health_migrate_old_health_log_table(char *table) {
     if (!table)
@@ -1551,12 +1550,21 @@ int health_migrate_old_health_log_table(char *table) {
         return 0;
     }
 
+    rc = sqlite3_bind_blob(res, 1, &uuid, sizeof(uuid), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        rc = sqlite3_finalize(res);
+        if (unlikely(rc != SQLITE_OK))
+            error_report("Failed to reset statement to copy health log detail, rc = %d", rc);
+        return 0;
+    }
+
     rc = execute_insert(res);
     if (unlikely(rc != SQLITE_DONE)) {
         error_report("Failed to execute SQL_COPY_HEALTH_LOG_DETAIL, rc = %d", rc);
         rc = sqlite3_finalize(res);
         if (unlikely(rc != SQLITE_OK))
             error_report("Failed to reset statement to copy health log detail table, rc = %d", rc);
+        return 0;
     }
 
     //update transition ids
@@ -1572,6 +1580,7 @@ int health_migrate_old_health_log_table(char *table) {
         rc = sqlite3_finalize(res);
         if (unlikely(rc != SQLITE_OK))
             error_report("Failed to reset statement to update health log detail table with transition ids, rc = %d", rc);
+        return 0;
     }
 
     //update health_log_id
@@ -1582,6 +1591,14 @@ int health_migrate_old_health_log_table(char *table) {
     }
 
     rc = sqlite3_bind_blob(res, 1, &uuid, sizeof(uuid), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        rc = sqlite3_finalize(res);
+        if (unlikely(rc != SQLITE_OK))
+            error_report("Failed to reset statement to update health log detail with health log ids, rc = %d", rc);
+        return 0;
+    }
+
+    rc = sqlite3_bind_blob(res, 2, &uuid, sizeof(uuid), SQLITE_STATIC);
     if (unlikely(rc != SQLITE_OK)) {
         rc = sqlite3_finalize(res);
         if (unlikely(rc != SQLITE_OK))

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -82,7 +82,7 @@ failed:
     "config_hash_id, updated_by_id, updates_id, when_key, duration, non_clear_duration, flags, " \
     "exec_run_timestamp, delay_up_to_timestamp, name, chart, family, exec, recipient, " \
     "units, info, exec_code, new_status, old_status, delay, new_value, old_value, last_repeat, " \
-    "chart_context, transition_id, insert_mark_timestamp) values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);"
+    "chart_context, transition_id, global_id) values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,now_usec(0));"
 
 void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae) {
     sqlite3_stmt *res = NULL;
@@ -269,12 +269,6 @@ void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae) {
     }
 
     rc = sqlite3_bind_blob(res, 29, &ae->transition_id, sizeof(ae->transition_id), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind transition_id parameter for SQL_INSERT_HEALTH_LOG");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 30, now_monotonic_usec());
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to bind transition_id parameter for SQL_INSERT_HEALTH_LOG");
         goto failed;
@@ -476,10 +470,10 @@ void sql_health_alarm_log_cleanup(RRDHOST *host) {
 }
 
 #define SQL_INJECT_REMOVED "insert into health_log (host_id, unique_id, alarm_id, alarm_event_id, config_hash_id, updated_by_id, updates_id, when_key, duration, non_clear_duration, flags, exec_run_timestamp, " \
-"delay_up_to_timestamp, name, chart, family, exec, recipient, units, info, exec_code, new_status, old_status, delay, new_value, old_value, last_repeat, chart_context, transition_id, insert_mark_timestamp) " \
+"delay_up_to_timestamp, name, chart, family, exec, recipient, units, info, exec_code, new_status, old_status, delay, new_value, old_value, last_repeat, chart_context, transition_id, global_id) " \
 "select host_id, ?1, ?2, ?3, config_hash_id, 0, ?4, unixepoch(), 0, 0, flags, exec_run_timestamp, " \
-"unixepoch(), name, chart, family, exec, recipient, units, info, exec_code, -2, new_status, delay, NULL, new_value, 0, chart_context, ?5, ?6 " \
-"from health_log where unique_id = ?7 and host_id = ?8;"
+"unixepoch(), name, chart, family, exec, recipient, units, info, exec_code, -2, new_status, delay, NULL, new_value, 0, chart_context, ?5, now_usec(0) " \
+"from health_log where unique_id = ?6 and host_id = ?7;"
 #define SQL_INJECT_REMOVED_UPDATE "update health_log set flags = flags | ?1, updated_by_id = ?2 where unique_id = ?3 and host_id = ?4;"
 void sql_inject_removed_status(RRDHOST *host, uint32_t alarm_id, uint32_t alarm_event_id, uint32_t unique_id, uint32_t max_unique_id)
 {
@@ -528,19 +522,13 @@ void sql_inject_removed_status(RRDHOST *host, uint32_t alarm_id, uint32_t alarm_
         goto failed;
     }
 
-    rc = sqlite3_bind_int64(res, 6, now_monotonic_usec());
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind transition_id parameter for SQL_INJECT_REMOVED");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 7, (sqlite3_int64) unique_id);
+    rc = sqlite3_bind_int64(res, 6, (sqlite3_int64) unique_id);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to bind unique_id parameter for SQL_INJECT_REMOVED");
         goto failed;
     }
 
-    rc = sqlite3_bind_blob(res, 8, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
+    rc = sqlite3_bind_blob(res, 7, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to bind host_id parameter for SQL_INJECT_REMOVED.");
         goto failed;
@@ -1379,98 +1367,16 @@ void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *
     buffer_free(command);
 }
 
-#define SQL_COPY_HEALTH_LOG_UPDATE_FOR_MARK "update health_log set insert_mark_timestamp = ?1 where unique_id = ?2 and alarm_id = ?3 and host_id = ?4"
-void health_migrate_old_health_log_table_mark_update(uuid_t *uuid, uint32_t alarm_id, uint32_t unique_id) {
-    int rc;
-    sqlite3_stmt *res = NULL;
-
-    if (!alarm_id || !unique_id)
-        return;
-
-    rc = sqlite3_prepare_v2(db_meta, SQL_COPY_HEALTH_LOG_UPDATE_FOR_MARK, -1, &res, 0);
-    if (rc != SQLITE_OK) {
-        error_report("Failed to prepare statement when trying to update during inject removed event");
-        return;
-    }
-
-    rc = sqlite3_bind_int64(res, 1, (sqlite3_int64) now_monotonic_usec());
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind flags parameter for SQL_COPY_HEALTH_LOG_UPDATE_FOR_MARK");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 2, (sqlite3_int64) unique_id);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind max_unique_id parameter for SQL_COPY_HEALTH_LOG_UPDATE_FOR_MARK");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 3, (sqlite3_int64) alarm_id);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind unique_id parameter for SQL_COPY_HEALTH_LOG_UPDATE_FOR_MARK");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_blob(res, 4, uuid, sizeof(*uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind host_id parameter for SQL_INJECT_REMOVED.");
-        goto failed;
-    }
-
-    rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE)) {
-        error_report("HEALTH [N/A]: Failed to execute SQL_INJECT_REMOVED_UPDATE, rc = %d", rc);
-        goto failed;
-    }
-
-failed:
-    if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
-        error_report("HEALTH [N/A]: Failed to finalize the prepared statement for injecting removed event.");
-}
-
-
-#define SQL_COPY_HEALTH_LOG_SELECT_FOR_MARK "select unique_id, alarm_id from health_log where host_id = @host_id"
-void health_migrate_old_health_log_table_mark(uuid_t *uuid) {
-    sqlite3_stmt *res = NULL;
-
-    int rc = sqlite3_prepare_v2(db_meta, SQL_COPY_HEALTH_LOG_SELECT_FOR_MARK, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to prepare statement to select health entries for mark, rc = %d", rc);
-        return;
-    }
-
-    rc = sqlite3_bind_blob(res, 1, uuid, sizeof(*uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind uuid to select health entries for mark, rc = %d", rc);
-        rc = sqlite3_finalize(res);
-        if (unlikely(rc != SQLITE_OK))
-            error_report("Failed to reset statement to select health entries for mark, rc = %d", rc);
-        return;
-    }
-
-    while (sqlite3_step_monitored(res) == SQLITE_ROW) {
-        uint32_t alarm_id, unique_id;
-
-        unique_id = (uint32_t) sqlite3_column_int64(res, 0);
-        alarm_id = (uint32_t) sqlite3_column_int64(res, 1);
-        health_migrate_old_health_log_table_mark_update (uuid, alarm_id, unique_id);
-    }
-
-    rc = sqlite3_finalize(res);
-     if (unlikely(rc != SQLITE_OK))
-         error_report("Failed to finalize the statement");
-}
-
 #define SQL_COPY_HEALTH_LOG(table) "INSERT INTO health_log (host_id, unique_id, alarm_id, alarm_event_id, " \
     "config_hash_id, updated_by_id, updates_id, when_key, duration, non_clear_duration, flags, " \
     "exec_run_timestamp, delay_up_to_timestamp, name, chart, family, exec, recipient, " \
     "units, info, exec_code, new_status, old_status, delay, new_value, old_value, last_repeat, " \
-    "chart_context, transition_id) " \
+    "chart_context, transition_id, global_id) " \
     "SELECT ?1, unique_id, alarm_id, alarm_event_id, " \
     "config_hash_id, updated_by_id, updates_id, when_key, duration, non_clear_duration, flags, " \
     "exec_run_timestamp, delay_up_to_timestamp, name, chart, family, exec, recipient, " \
     "units, info, exec_code, new_status, old_status, delay, new_value, old_value, last_repeat, " \
-    "chart_context, transition_id from %s; ", table
+    "chart_context, transition_id, now_usec(1) from %s; ", table
 int health_migrate_old_health_log_table(char *table) {
     if (!table)
         return 0;
@@ -1512,8 +1418,6 @@ int health_migrate_old_health_log_table(char *table) {
             error_report("Failed to reset statement to copy health log table, rc = %d", rc);
         freez(uuid_from_table);
     }
-
-    health_migrate_old_health_log_table_mark(&uuid);
 
     return 1;
 }

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -1639,11 +1639,14 @@ int health_migrate_old_health_log_table(char *table) {
     return 1;
 }
 
-#define SQL_GET_ALARM_ID "select alarm_id from health_log where host_id = @host_id and chart = @chart and name = @name"
-uint32_t sql_get_alarm_id(RRDHOST *host, STRING *chart, STRING *name)
+#define SQL_GET_ALARM_ID "select alarm_id, health_log_id from health_log where host_id = @host_id and chart = @chart and name = @name"
+#define SQL_GET_EVENT_ID "select max(alarm_event_id) + 1 from health_log_detail where health_log_id = @health_log_id and alarm_id = @alarm_id"
+uint32_t sql_get_alarm_id(RRDHOST *host, STRING *chart, STRING *name, uint32_t *next_event_id)
 {
-    int rc = 0, alarm_id = 0;
+    int rc = 0;
     sqlite3_stmt *res = NULL;
+    uint32_t alarm_id = 0;
+    uint64_t health_log_id = 0;
 
     rc = sqlite3_prepare_v2(db_meta, SQL_GET_ALARM_ID, -1, &res, 0);
     if (rc != SQLITE_OK) {
@@ -1674,11 +1677,42 @@ uint32_t sql_get_alarm_id(RRDHOST *host, STRING *chart, STRING *name)
 
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
         alarm_id = (uint32_t) sqlite3_column_int64(res, 0);
+        health_log_id = (uint64_t) sqlite3_column_int64(res, 1);
     }
 
      rc = sqlite3_finalize(res);
      if (unlikely(rc != SQLITE_OK))
          error_report("Failed to finalize the statement while getting an alarm id.");
+
+     if (alarm_id) {
+         rc = sqlite3_prepare_v2(db_meta, SQL_GET_EVENT_ID, -1, &res, 0);
+         if (rc != SQLITE_OK) {
+             error_report("Failed to prepare statement when trying to get an event id");
+             return alarm_id;
+         }
+
+         rc = sqlite3_bind_int64(res, 1, (sqlite3_int64) health_log_id);
+         if (unlikely(rc != SQLITE_OK)) {
+             error_report("Failed to bind host_id parameter for SQL_GET_EVENT_ID.");
+             sqlite3_finalize(res);
+             return alarm_id;
+         }
+
+         rc = sqlite3_bind_int64(res, 2, (sqlite3_int64) alarm_id);
+         if (unlikely(rc != SQLITE_OK)) {
+             error_report("Failed to bind char parameter for SQL_GET_EVENT_ID.");
+             sqlite3_finalize(res);
+             return alarm_id;
+         }
+
+         while (sqlite3_step_monitored(res) == SQLITE_ROW) {
+             *next_event_id = (uint32_t) sqlite3_column_int64(res, 0);
+         }
+
+         rc = sqlite3_finalize(res);
+         if (unlikely(rc != SQLITE_OK))
+             error_report("Failed to finalize the statement while getting an alarm id.");
+     }
 
      return alarm_id;
 }

--- a/database/sqlite/sqlite_health.h
+++ b/database/sqlite/sqlite_health.h
@@ -17,5 +17,5 @@ void sql_aclk_alert_clean_dead_entries(RRDHOST *host);
 int sql_health_get_last_executed_event(RRDHOST *host, ALARM_ENTRY *ae, RRDCALC_STATUS *last_executed_status);
 void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *chart);
 int health_migrate_old_health_log_table(char *table);
-uint32_t sql_get_alarm_id(RRDHOST *host, STRING *chart, STRING *name);
+uint32_t sql_get_alarm_id(RRDHOST *host, STRING *chart, STRING *name, uint32_t *next_event_id);
 #endif //NETDATA_SQLITE_HEALTH_H

--- a/database/sqlite/sqlite_health.h
+++ b/database/sqlite/sqlite_health.h
@@ -7,7 +7,7 @@
 
 extern sqlite3 *db_meta;
 void sql_health_alarm_log_load(RRDHOST *host);
-int sql_create_health_log_table(RRDHOST *host);
+int sql_create_health_log_table(void);
 void sql_health_alarm_log_update(RRDHOST *host, ALARM_ENTRY *ae);
 void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae);
 void sql_health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae);
@@ -16,4 +16,5 @@ int alert_hash_and_store_config(uuid_t hash_id, struct alert_config *cfg, int st
 void sql_aclk_alert_clean_dead_entries(RRDHOST *host);
 int sql_health_get_last_executed_event(RRDHOST *host, ALARM_ENTRY *ae, RRDCALC_STATUS *last_executed_status);
 void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *chart);
+int health_migrate_old_health_log_table(char *table);
 #endif //NETDATA_SQLITE_HEALTH_H

--- a/database/sqlite/sqlite_health.h
+++ b/database/sqlite/sqlite_health.h
@@ -17,4 +17,5 @@ void sql_aclk_alert_clean_dead_entries(RRDHOST *host);
 int sql_health_get_last_executed_event(RRDHOST *host, ALARM_ENTRY *ae, RRDCALC_STATUS *last_executed_status);
 void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *chart);
 int health_migrate_old_health_log_table(char *table);
+uint32_t sql_get_alarm_id(RRDHOST *host, STRING *chart, STRING *name);
 #endif //NETDATA_SQLITE_HEALTH_H

--- a/health/health.c
+++ b/health/health.c
@@ -789,7 +789,6 @@ static void initialize_health(RRDHOST *host)
 
     // TODO: This needs to go to the metadata thread
     // Health should wait before accessing the table (needs to be created by the metadata thread)
-    sql_create_health_log_table();
     sql_health_alarm_log_load(host);
 
     // ------------------------------------------------------------------------

--- a/health/health.c
+++ b/health/health.c
@@ -789,7 +789,7 @@ static void initialize_health(RRDHOST *host)
 
     // TODO: This needs to go to the metadata thread
     // Health should wait before accessing the table (needs to be created by the metadata thread)
-    sql_create_health_log_table(host);
+    sql_create_health_log_table();
     sql_health_alarm_log_load(host);
 
     // ------------------------------------------------------------------------

--- a/health/health.c
+++ b/health/health.c
@@ -638,7 +638,7 @@ static inline void health_alarm_log_process(RRDHOST *host) {
             ||
            ((ae->new_status == RRDCALC_STATUS_REMOVED) &&
            (ae->flags & HEALTH_ENTRY_FLAG_SAVED) &&
-           (ae->when + 3600 < now_realtime_sec())))
+           (ae->when + 86400 < now_realtime_sec())))
             {
 
             if (ae == host->health_log.alarms) {

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -498,6 +498,7 @@ static inline void alert_config_free(struct alert_config *cfg)
     string_freez(cfg->p_db_lookup_dimensions);
     string_freez(cfg->p_db_lookup_method);
     string_freez(cfg->chart_labels);
+    string_freez(cfg->source);
     freez(cfg);
 }
 
@@ -672,6 +673,7 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg = callocz(1, sizeof(struct alert_config));
 
                 alert_cfg->alarm = string_dup(rc->name);
+                alert_cfg->source = health_source_file(line, filename);
                 ignore_this = 0;
             } else {
                 rc = NULL;
@@ -718,6 +720,7 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg = callocz(1, sizeof(struct alert_config));
 
                 alert_cfg->template_key = string_dup(rt->name);
+                alert_cfg->source = health_source_file(line, filename);
                 ignore_this = 0;
             } else {
                 rt = NULL;


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR changes health to use a single `health_log` table, instead of a table for each host.

The PR will update database to version 9 and will move data from all the `health_log_XXXX` tables to the new one. A new `host_id` column is added, which is the host's `host_uuid`.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

After this PR all of health functionality (including cleaning up and cloud connectivity) should remain as before.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
