### PR TITLE
Restrict ebpf dep in DEB package to amd64 only.

### DIFF
--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -35,7 +35,7 @@ Architecture: any
 Depends: openssl,
          ${misc:Depends},
          ${shlibs:Depends},
-         netdata-plugin-ebpf,
+         netdata-plugin-ebpf [amd64],
          netdata-plugin-apps,
          netdata-plugin-pythond,
          netdata-plugin-go,


### PR DESCRIPTION
##### Summary

Without this, our DEB packages are broken on non-amd64 platforms.

##### Test Plan

CI passes on this PR