### PR TITLE
api v2 nodes for streaming statuses

### DIFF
--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -1467,9 +1467,11 @@ PARSER_RC pluginsd_replay_end(char **words, size_t num_words, void *user)
         time_t started = st->rrdhost->receiver->replication_first_time_t;
         time_t current = ((PARSER_USER_OBJECT *) user)->replay.end_time;
 
-        if(started && current > started)
+        if(started && current > started) {
+            host->rrdpush_receiver_replication_percent = (NETDATA_DOUBLE) (current - started) * 100.0 / (NETDATA_DOUBLE) (now - started);
             worker_set_metric(WORKER_RECEIVER_JOB_REPLICATION_COMPLETION,
-                          (NETDATA_DOUBLE)(current - started) * 100.0 / (NETDATA_DOUBLE)(now - started));
+                              host->rrdpush_receiver_replication_percent);
+        }
     }
 
     ((PARSER_USER_OBJECT *) user)->replay.start_time = 0;
@@ -1509,7 +1511,8 @@ PARSER_RC pluginsd_replay_end(char **words, size_t num_words, void *user)
 
         pluginsd_set_chart_from_parent(user, NULL, PLUGINSD_KEYWORD_REPLAY_END);
 
-        worker_set_metric(WORKER_RECEIVER_JOB_REPLICATION_COMPLETION, 100.0);
+        host->rrdpush_receiver_replication_percent = 100.0;
+        worker_set_metric(WORKER_RECEIVER_JOB_REPLICATION_COMPLETION, host->rrdpush_receiver_replication_percent);
 
         return PARSER_RC_OK;
     }

--- a/database/contexts/api_v2.c
+++ b/database/contexts/api_v2.c
@@ -354,63 +354,10 @@ static ssize_t rrdcontext_to_json_v2_add_host(void *data, RRDHOST *host, bool qu
 
             time_t now = now_realtime_sec();
             buffer_json_member_add_object(wb, "status");
-
-            size_t receiver_hops = host->system_info ? host->system_info->hops : (host == localhost) ? 0 : 1;
-            buffer_json_member_add_object(wb, "collection");
-            buffer_json_member_add_uint64(wb, "hops", receiver_hops);
-            buffer_json_member_add_boolean(wb, "online", host == localhost || !rrdhost_flag_check(host, RRDHOST_FLAG_ORPHAN | RRDHOST_FLAG_RRDPUSH_RECEIVER_DISCONNECTED));
-            buffer_json_member_add_boolean(wb, "replicating", rrdhost_receiver_replicating_charts(host));
-            if(host != localhost && host->receiver) {
-                buffer_json_member_add_object(wb, "source");
-
-                char buf[1024 + 1];
-                snprintfz(buf, 1024, "%s:%s", host->receiver->client_ip ? host->receiver->client_ip : "", host->receiver->client_port ? host->receiver->client_port : "");
-                buffer_json_member_add_string(wb, "connection", buf);
-                stream_capabilities_to_json_array(wb, host->receiver->capabilities, "capabilities");
-
-                buffer_json_object_close(wb);
+            {
+                rrdhost_receiver_to_json(wb, host, "collection", now);
+                rrdhost_sender_to_json(wb, host, "streaming", now);
             }
-            buffer_json_object_close(wb); // collection
-
-            bool sender_connected = rrdhost_flag_check(host, RRDHOST_FLAG_RRDPUSH_SENDER_CONNECTED);
-            buffer_json_member_add_object(wb, "streaming");
-            buffer_json_member_add_uint64(wb, "hops", host->sender ? host->sender->hops : receiver_hops + 1);
-            buffer_json_member_add_boolean(wb, "online", sender_connected);
-            buffer_json_member_add_boolean(wb, "replicating", sender_connected && rrdhost_sender_replicating_charts(host));
-
-            if(host->sender) {
-                buffer_json_member_add_object(wb, "destination");
-                buffer_json_member_add_string(wb, "connected_to", sender_connected ? host->sender->connected_to : "");
-                stream_capabilities_to_json_array(wb, sender_connected ? host->sender->capabilities : 0, "capabilities");
-
-                buffer_json_member_add_array(wb, "candidates");
-                struct rrdpush_destinations *d;
-                for(d = host->destinations ; d ; d = d->next) {
-                    buffer_json_add_array_item_object(wb);
-
-                    if(d->ssl) {
-                        char buf[1024 + 1];
-                        snprintfz(buf, 1024, "%s:SSL", string2str(d->destination));
-                        buffer_json_member_add_string(wb, "destination", buf);
-                    }
-                    else
-                        buffer_json_member_add_string(wb, "destination", string2str(d->destination));
-
-                    buffer_json_member_add_time_t(wb, "last_check", d->last_attempt);
-                    buffer_json_member_add_time_t(wb, "last_check_secs_ago", now - d->last_attempt);
-                    buffer_json_member_add_string(wb, "last_error", d->last_error);
-                    buffer_json_member_add_string(wb, "last_handshake", stream_handshake_error_to_string(d->last_handshake));
-                    buffer_json_member_add_time_t(wb, "next_check", d->postpone_reconnection_until);
-                    buffer_json_member_add_time_t(wb, "next_check_in_secs", (d->postpone_reconnection_until > now) ? d->postpone_reconnection_until - now : 0);
-                    buffer_json_object_close(wb);
-                }
-                buffer_json_array_close(wb);
-
-                buffer_json_object_close(wb); // destination
-            }
-
-            buffer_json_object_close(wb); // streaming
-
             buffer_json_object_close(wb); // status
         }
 

--- a/database/contexts/rrdcontext.h
+++ b/database/contexts/rrdcontext.h
@@ -531,15 +531,24 @@ static inline bool query_has_group_by_aggregation_percentage(QUERY_TARGET *qt) {
     // we need to send back "raw" output with "count"
     // otherwise, we need to send back "raw" output with "hidden"
 
+    bool last_is_percentage = false;
+
     for(int g = 0; g < MAX_QUERY_GROUP_BY_PASSES ;g++) {
+        if(qt->request.group_by[g].group_by == RRDR_GROUP_BY_NONE)
+            break;
+
         if(qt->request.group_by[g].group_by & RRDR_GROUP_BY_PERCENTAGE_OF_INSTANCE)
+            // backwards compatibility
             return false;
 
         if(qt->request.group_by[g].aggregation == RRDR_GROUP_BY_FUNCTION_PERCENTAGE)
-            return true;
+            last_is_percentage = true;
+
+        else
+            last_is_percentage = false;
     }
 
-    return false;
+    return last_is_percentage;
 }
 
 static inline bool query_target_has_percentage_of_group(QUERY_TARGET *qt) {

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1150,9 +1150,11 @@ struct rrdhost {
     struct rrdpush_destinations *destination;       // the current destination from the above list
     SIMPLE_PATTERN *rrdpush_send_charts_matching;   // pattern to match the charts to be sent
 
+    const char *rrdpush_last_receiver_exit_reason;
     time_t rrdpush_seconds_to_replicate;            // max time we want to replicate from the child
     time_t rrdpush_replication_step;                // seconds per replication step
     size_t rrdpush_receiver_replicating_charts;     // the number of charts currently being replicated from a child
+    NETDATA_DOUBLE rrdpush_receiver_replication_percent; // the % of replication completion
 
     // the following are state information for the threading
     // streaming metrics from this netdata to an upstream netdata

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -340,6 +340,7 @@ int is_legacy = 1;
 
     host->rrdpush_seconds_to_replicate = rrdpush_seconds_to_replicate;
     host->rrdpush_replication_step = rrdpush_replication_step;
+    host->rrdpush_receiver_replication_percent = 100.0;
 
     switch(memory_mode) {
         default:

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -423,6 +423,58 @@ static void rrdpush_receiver_replication_reset(RRDHOST *host) {
     rrdhost_receiver_replicating_charts_zero(host);
 }
 
+void rrdhost_receiver_to_json(BUFFER *wb, RRDHOST *host, const char *key, time_t now __maybe_unused) {
+    size_t receiver_hops = host->system_info ? host->system_info->hops : (host == localhost) ? 0 : 1;
+
+    netdata_mutex_lock(&host->receiver_lock);
+
+    buffer_json_member_add_object(wb, key);
+    buffer_json_member_add_uint64(wb, "hops", receiver_hops);
+
+    bool online = host == localhost || !rrdhost_flag_check(host, RRDHOST_FLAG_ORPHAN | RRDHOST_FLAG_RRDPUSH_RECEIVER_DISCONNECTED);
+    buffer_json_member_add_boolean(wb, "online", online);
+
+    if(host->child_connect_time || host->child_disconnected_time) {
+        time_t since = MAX(host->child_connect_time, host->child_disconnected_time);
+        buffer_json_member_add_time_t(wb, "since", since);
+        buffer_json_member_add_time_t(wb, "age", now - since);
+    }
+
+    if(!online && host->rrdpush_last_receiver_exit_reason)
+        buffer_json_member_add_string(wb, "reason", host->rrdpush_last_receiver_exit_reason);
+
+    buffer_json_member_add_object(wb, "replication");
+    {
+        size_t instances = rrdhost_receiver_replicating_charts(host);
+        buffer_json_member_add_boolean(wb, "in_progress", instances);
+        buffer_json_member_add_double(wb, "completion", host->rrdpush_receiver_replication_percent);
+        buffer_json_member_add_uint64(wb, "instances", instances);
+    }
+    buffer_json_object_close(wb);
+
+    if(host != localhost && host->receiver) {
+        buffer_json_member_add_object(wb, "source");
+        {
+
+            char buf[1024 + 1];
+            SOCKET_PEERS peers = socket_peers(host->receiver->fd);
+            bool ssl = SSL_connection(&host->receiver->ssl);
+
+            snprintfz(buf, 1024, "[%s]:%d%s", peers.local.ip, peers.local.port, ssl ? ":SSL" : "");
+            buffer_json_member_add_string(wb, "local", buf);
+
+            snprintfz(buf, 1024, "[%s]:%d%s", peers.peer.ip, peers.peer.port, ssl ? ":SSL" : "");
+            buffer_json_member_add_string(wb, "remote", buf);
+
+            stream_capabilities_to_json_array(wb, host->receiver->capabilities, "capabilities");
+        }
+        buffer_json_object_close(wb);
+    }
+    buffer_json_object_close(wb); // collection
+
+    netdata_mutex_unlock(&host->receiver_lock);
+}
+
 static bool rrdhost_set_receiver(RRDHOST *host, struct receiver_state *rpt) {
     bool signal_rrdcontext = false;
     bool set_this = false;
@@ -496,6 +548,7 @@ static void rrdhost_clear_receiver(struct receiver_state *rpt) {
 
             rrdhost_flag_set(host, RRDHOST_FLAG_ORPHAN);
             host->receiver = NULL;
+            host->rrdpush_last_receiver_exit_reason = rpt->exit.reason;
         }
 
         netdata_mutex_unlock(&host->receiver_lock);
@@ -544,6 +597,18 @@ bool stop_streaming_receiver(RRDHOST *host, const char *reason) {
     netdata_mutex_unlock(&host->receiver_lock);
 
     return ret;
+}
+
+static void rrdpush_send_error_on_taken_over_connection(struct receiver_state *rpt, const char *msg) {
+    send_timeout(
+#ifdef ENABLE_HTTPS
+            &rpt->ssl,
+#endif
+            rpt->fd,
+            (char *)msg,
+            strlen(msg),
+            0,
+            5);
 }
 
 void rrdpush_receive_log_status(struct receiver_state *rpt, const char *msg, const char *status) {
@@ -677,11 +742,13 @@ static void rrdpush_receive(struct receiver_state *rpt)
 
         if(!host) {
             rrdpush_receive_log_status(rpt, "failed to find/create host structure", "INTERNAL ERROR DROPPING CONNECTION");
+            rrdpush_send_error_on_taken_over_connection(rpt, START_STREAMING_ERROR_INTERNAL_ERROR);
             goto cleanup;
         }
 
         if (unlikely(rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD))) {
             rrdpush_receive_log_status(rpt, "host is initializing", "INITIALIZATION IN PROGRESS RETRY LATER");
+            rrdpush_send_error_on_taken_over_connection(rpt, START_STREAMING_ERROR_INITIALIZATION);
             goto cleanup;
         }
 
@@ -690,8 +757,14 @@ static void rrdpush_receive(struct receiver_state *rpt)
 
         if(!rrdhost_set_receiver(host, rpt)) {
             rrdpush_receive_log_status(rpt, "host is already served by another receiver", "DUPLICATE RECEIVER DROPPING CONNECTION");
+            rrdpush_send_error_on_taken_over_connection(rpt, START_STREAMING_ERROR_ALREADY_STREAMING);
             goto cleanup;
         }
+
+        // test - to be removed
+        rrdpush_receive_log_status(rpt, "host is initializing", "INITIALIZATION IN PROGRESS RETRY LATER");
+        rrdpush_send_error_on_taken_over_connection(rpt, START_STREAMING_ERROR_INITIALIZATION);
+        goto cleanup;
     }
 
 #ifdef NETDATA_INTERNAL_CHECKS

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -760,11 +760,6 @@ static void rrdpush_receive(struct receiver_state *rpt)
             rrdpush_send_error_on_taken_over_connection(rpt, START_STREAMING_ERROR_ALREADY_STREAMING);
             goto cleanup;
         }
-
-        // test - to be removed
-        rrdpush_receive_log_status(rpt, "host is initializing", "INITIALIZATION IN PROGRESS RETRY LATER");
-        rrdpush_send_error_on_taken_over_connection(rpt, START_STREAMING_ERROR_INITIALIZATION);
-        goto cleanup;
     }
 
 #ifdef NETDATA_INTERNAL_CHECKS

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -443,16 +443,16 @@ void rrdhost_receiver_to_json(BUFFER *wb, RRDHOST *host, const char *key, time_t
     if(!online && host->rrdpush_last_receiver_exit_reason)
         buffer_json_member_add_string(wb, "reason", host->rrdpush_last_receiver_exit_reason);
 
-    buffer_json_member_add_object(wb, "replication");
-    {
-        size_t instances = rrdhost_receiver_replicating_charts(host);
-        buffer_json_member_add_boolean(wb, "in_progress", instances);
-        buffer_json_member_add_double(wb, "completion", host->rrdpush_receiver_replication_percent);
-        buffer_json_member_add_uint64(wb, "instances", instances);
-    }
-    buffer_json_object_close(wb);
-
     if(host != localhost && host->receiver) {
+        buffer_json_member_add_object(wb, "replication");
+        {
+            size_t instances = rrdhost_receiver_replicating_charts(host);
+            buffer_json_member_add_boolean(wb, "in_progress", instances);
+            buffer_json_member_add_double(wb, "completion", host->rrdpush_receiver_replication_percent);
+            buffer_json_member_add_uint64(wb, "instances", instances);
+        }
+        buffer_json_object_close(wb); // replication
+
         buffer_json_member_add_object(wb, "source");
         {
 
@@ -468,7 +468,7 @@ void rrdhost_receiver_to_json(BUFFER *wb, RRDHOST *host, const char *key, time_t
 
             stream_capabilities_to_json_array(wb, host->receiver->capabilities, "capabilities");
         }
-        buffer_json_object_close(wb);
+        buffer_json_object_close(wb); // source
     }
     buffer_json_object_close(wb); // collection
 

--- a/web/api/formatters/json/json.c
+++ b/web/api/formatters/json/json.c
@@ -248,8 +248,8 @@ void rrdr2json_v2(RRDR *r, BUFFER *wb) {
     QUERY_TARGET *qt = r->internal.qt;
     RRDR_OPTIONS options = qt->window.options;
 
-    bool send_fourth_number = query_target_aggregatable(qt);
-    bool fourth_number_is_vh = send_fourth_number && r->vh && query_has_group_by_aggregation_percentage(qt);
+    bool send_count = query_target_aggregatable(qt);
+    bool send_hidden = send_count && r->vh && query_has_group_by_aggregation_percentage(qt);
 
     buffer_json_member_add_object(wb, "result");
 
@@ -267,16 +267,17 @@ void rrdr2json_v2(RRDR *r, BUFFER *wb) {
     buffer_json_array_close(wb); // labels
 
     buffer_json_member_add_object(wb, "point");
-    buffer_json_member_add_uint64(wb, "value", 0);
-    buffer_json_member_add_uint64(wb, "arp", 1);
-    buffer_json_member_add_uint64(wb, "pa", 2);
-    if(send_fourth_number) {
-        if(fourth_number_is_vh)
-            buffer_json_member_add_uint64(wb, "hidden", 3);
-        else
-            buffer_json_member_add_uint64(wb, "count", 3);
+    {
+        size_t point_count = 0;
+        buffer_json_member_add_uint64(wb, "value", point_count++);
+        buffer_json_member_add_uint64(wb, "arp", point_count++);
+        buffer_json_member_add_uint64(wb, "pa", point_count++);
+        if (send_count)
+            buffer_json_member_add_uint64(wb, "count", point_count++);
+        if (send_hidden)
+            buffer_json_member_add_uint64(wb, "hidden", point_count++);
     }
-    buffer_json_object_close(wb);
+    buffer_json_object_close(wb); // point
 
     buffer_json_member_add_array(wb, "data");
     if(i) {
@@ -290,7 +291,7 @@ void rrdr2json_v2(RRDR *r, BUFFER *wb) {
         // for each line in the array
         for (i = start; i != end; i += step) {
             NETDATA_DOUBLE *cn = &r->v[ i * r->d ];
-            NETDATA_DOUBLE *ch = fourth_number_is_vh ? &r->vh[i * r->d ] : NULL;
+            NETDATA_DOUBLE *ch = send_hidden ? &r->vh[i * r->d ] : NULL;
             RRDR_VALUE_FLAGS *co = &r->o[ i * r->d ];
             NETDATA_DOUBLE *ar = &r->ar[ i * r->d ];
             uint32_t *gbc = &r->gbc [ i * r->d ];
@@ -330,12 +331,10 @@ void rrdr2json_v2(RRDR *r, BUFFER *wb) {
                 buffer_json_add_array_item_uint64(wb, o);
 
                 // add the count
-                if(send_fourth_number) {
-                    if(fourth_number_is_vh)
-                        buffer_json_add_array_item_double(wb, ch[d]);
-                    else
-                        buffer_json_add_array_item_uint64(wb, gbc[d]);
-                }
+                if(send_count)
+                    buffer_json_add_array_item_uint64(wb, gbc[d]);
+                if(send_hidden)
+                    buffer_json_add_array_item_double(wb, ch[d]);
 
                 buffer_json_array_close(wb); // point
             }


### PR DESCRIPTION
- [x] enrich the `/api/v2/nodes` endpoint for status information and statistics about streaming
- [x] avoid race condition in case senders or receivers are disconnected or reconnected during `/api/v2/nodes` query
- [x] handling of the last 3 cases that were unhandled for letting children know the error condition of parents #15113 
- [x] in `/api/v2/data` when `aggregation=percentage` and `options=raw` return 5 values per point (count and hidden)
- [x] in `/api/v2/data` when `aggregation=percentage` is not at the last grouping, do the percentage calculation normally.