### PR TITLE
Update smartd_log.conf

### DIFF
--- a/collectors/python.d.plugin/smartd_log/smartd_log.conf
+++ b/collectors/python.d.plugin/smartd_log/smartd_log.conf
@@ -63,6 +63,7 @@
 #
 #    log_path: '/path/to/smartd_logs'    # path to smartd log files. Default is /var/log/smartd
 #    exclude_disks: 'PATTERN1 PATTERN2'  # space separated patterns. If the pattern is in the drive name, the module will not collect data for it.
+#    age: 30                             # time in minutes since the last dump to file. If smartd has not dumped data within this time the job exits.
 #
 # ----------------------------------------------------------------------
 


### PR DESCRIPTION
##### Summary
Documents the age parameter which must be used to prevent the job from exiting if the user dumps attributes less often than the default 30 minutes.

##### Test Plan
None

##### Additional Information
I only dump attributes to file every 3 hours and I was pulling my hair out trying to figure out why Netdata would sometimes show a chart for this plugin and sometimes not. The only time it showed data happened to be if I restarted Netdata within 30mins of smartd dumping attributes to file but the charts stopped working beyond that because the age check kills the job.