### PR TITLE
Fix issues in sync thread (eBPF plugin)

### DIFF
--- a/collectors/ebpf.plugin/ebpf.d.conf
+++ b/collectors/ebpf.plugin/ebpf.d.conf
@@ -68,7 +68,7 @@
     shm = yes
     socket = no
     softirq = yes
-    sync = yes
+    sync = no
     swap = yes
     vfs = no
     network connections = no

--- a/collectors/ebpf.plugin/ebpf.d.conf
+++ b/collectors/ebpf.plugin/ebpf.d.conf
@@ -68,7 +68,7 @@
     shm = yes
     socket = no
     softirq = yes
-    sync = no
+    sync = yes
     swap = yes
     vfs = no
     network connections = no

--- a/collectors/ebpf.plugin/ebpf_sync.c
+++ b/collectors/ebpf.plugin/ebpf_sync.c
@@ -460,7 +460,7 @@ static void ebpf_send_sync_chart(char *id,
  */
 static void sync_send_data()
 {
-    if (local_syscalls[NETDATA_SYNC_FSYNC_IDX].enabled || local_syscalls[NETDATA_SYNC_FDATASYNC_IDX].enabled) {
+    if (local_syscalls[NETDATA_SYNC_FSYNC_IDX].enabled && local_syscalls[NETDATA_SYNC_FDATASYNC_IDX].enabled) {
         ebpf_send_sync_chart(NETDATA_EBPF_FILE_SYNC_CHART, NETDATA_SYNC_FSYNC_IDX, NETDATA_SYNC_FDATASYNC_IDX);
     }
 
@@ -469,7 +469,7 @@ static void sync_send_data()
                                         sync_counter_publish_aggregated[NETDATA_SYNC_MSYNC_IDX].dimension,
                                         sync_hash_values[NETDATA_SYNC_MSYNC_IDX]);
 
-    if (local_syscalls[NETDATA_SYNC_SYNC_IDX].enabled || local_syscalls[NETDATA_SYNC_SYNCFS_IDX].enabled) {
+    if (local_syscalls[NETDATA_SYNC_SYNC_IDX].enabled && local_syscalls[NETDATA_SYNC_SYNCFS_IDX].enabled) {
         ebpf_send_sync_chart(NETDATA_EBPF_SYNC_CHART, NETDATA_SYNC_SYNC_IDX, NETDATA_SYNC_SYNCFS_IDX);
     }
 
@@ -555,7 +555,7 @@ static void ebpf_create_sync_chart(char *id,
  */
 static void ebpf_create_sync_charts(int update_every)
 {
-    if (local_syscalls[NETDATA_SYNC_FSYNC_IDX].enabled || local_syscalls[NETDATA_SYNC_FDATASYNC_IDX].enabled)
+    if (local_syscalls[NETDATA_SYNC_FSYNC_IDX].enabled && local_syscalls[NETDATA_SYNC_FDATASYNC_IDX].enabled)
         ebpf_create_sync_chart(NETDATA_EBPF_FILE_SYNC_CHART,
                                "Monitor calls for <code>fsync(2)</code> and <code>fdatasync(2)</code>.", 21300,
                                NETDATA_SYNC_FSYNC_IDX, NETDATA_SYNC_FDATASYNC_IDX, update_every);
@@ -565,7 +565,7 @@ static void ebpf_create_sync_charts(int update_every)
                                "Monitor calls for <code>msync(2)</code>.", 21301,
                                NETDATA_SYNC_MSYNC_IDX, NETDATA_SYNC_MSYNC_IDX, update_every);
 
-    if (local_syscalls[NETDATA_SYNC_SYNC_IDX].enabled || local_syscalls[NETDATA_SYNC_SYNCFS_IDX].enabled)
+    if (local_syscalls[NETDATA_SYNC_SYNC_IDX].enabled && local_syscalls[NETDATA_SYNC_SYNCFS_IDX].enabled)
         ebpf_create_sync_chart(NETDATA_EBPF_SYNC_CHART,
                                "Monitor calls for <code>sync(2)</code> and <code>syncfs(2)</code>.", 21302,
                                NETDATA_SYNC_SYNC_IDX, NETDATA_SYNC_SYNCFS_IDX, update_every);

--- a/collectors/ebpf.plugin/ebpf_sync.c
+++ b/collectors/ebpf.plugin/ebpf_sync.c
@@ -403,7 +403,7 @@ static int ebpf_sync_initialize_syscall(ebpf_module_t *em)
  */
 static void ebpf_sync_read_global_table(int maps_per_core)
 {
-    netdata_idx_t stored[ebpf_nprocs];
+    netdata_idx_t stored[NETDATA_MAX_PROCESSOR];
     uint32_t idx = NETDATA_SYNC_CALL;
     int i;
     for (i = 0; local_syscalls[i].syscall; i++) {

--- a/collectors/ebpf.plugin/ebpf_sync.c
+++ b/collectors/ebpf.plugin/ebpf_sync.c
@@ -349,6 +349,7 @@ static int ebpf_sync_initialize_syscall(ebpf_module_t *em)
     for (i = 0; local_syscalls[i].syscall; i++) {
         ebpf_sync_syscalls_t *w = &local_syscalls[i];
         w->sync_maps = local_syscalls[i].sync_maps;
+        em->maps = local_syscalls[i].sync_maps;
         if (w->enabled) {
             if (em->load & EBPF_LOAD_LEGACY) {
                 if (ebpf_sync_load_legacy(w, em))
@@ -616,7 +617,6 @@ void *ebpf_sync_thread(void *ptr)
     netdata_thread_cleanup_push(ebpf_sync_exit, ptr);
 
     ebpf_module_t *em = (ebpf_module_t *)ptr;
-    em->maps = sync_maps;
 
     ebpf_set_sync_maps();
     ebpf_sync_parse_syscalls();


### PR DESCRIPTION
##### Summary
Fixes https://github.com/netdata/netdata/issues/15103

This PR is fixing issued found in Rocky Linux, more details will come after tests to be sure other distributions are not affected.

##### Test Plan

1. Compile branch
2. Enable `sync` thread before to run:
```sh
$ cd /etc/netdata
$ ./edit-config ebpf.d.conf
[ebpf programs]
    sync = yes
```
3. Start netdata, because `sync` thread is enabled by default. 
4. Wait few minutes and query https://localhost:19999/api/v1/data?chart=mem.file_sync&after=-30 . You should have data for this thread.

##### Additional Information
This PR was tested on:

| Hardware | Linux distribution | Kernel | File | 
|----------------|----------------------------|-----------|-------|
|Bare metal | Slackware Current |6.1.31 | [slackware_6_1.txt](https://github.com/netdata/netdata/files/11711180/slackware_6_1.txt) |
|Vagrant | Arch Linux | 6.3.6-arch1-1 | [arck_6_3.txt](https://github.com/netdata/netdata/files/11711188/arck_6_3.txt) | 
|Vagrant | Ubuntu 22.04 | 5.15.0-69-generic |  [ubuntu_5_15.txt](https://github.com/netdata/netdata/files/11713207/ubuntu_5_15.txt) |
|Vagrant | Oracle 8.6 | 5.15.0-101.103.2.1.el8uek.x86_64 | [oracle_5_15.txt](https://github.com/netdata/netdata/files/11715066/oracle_5_15.txt) | 
|Vagrant | Oracle 9 |  5.14.0-284.11.1.el9_2.x86_64 | [oracle_5_14.txt](https://github.com/netdata/netdata/files/11715344/oracle_5_14.txt) | 
|VMWare | Rocky 9.2 | 5.14.0-284.11.1.el9_2.x86_64 | [rocky_5_14.txt](https://github.com/netdata/netdata/files/11711186/rocky_5_14.txt) | 
|Vagrant | Alma 9 | 5.14.0-284.11.1.el9_2.x86_64 | [alma_5_14.txt](https://github.com/netdata/netdata/files/11715981/alma_5_14.txt)  |
| Vagrant | Corel 9| 5.14.0-319.el9.x86_64 | [corel_5_14.txt](https://github.com/netdata/netdata/files/11713572/corel_5_14.txt) | 
| Vagrant | Debian 11 | 5.10.0-22-amd64 | [debian_5_10.txt](https://github.com/netdata/netdata/files/11713667/debian_5_10.txt) | 
| Vagrant | Ubuntu 20.04 | 5.4.0-146-generic | [ubuntu_5_4.txt](https://github.com/netdata/netdata/files/11713456/ubuntu_5_4.txt) | 
|Qemu | Slackware current | 5.4.210 | [slackware_5_4.txt](https://github.com/netdata/netdata/files/11715714/slackware_5_4.txt) |
|Vagrant | Alma 8.6 | 4.18.0-477.13.1.el8_8.x86_64 | [alma_4_18.txt](https://github.com/netdata/netdata/files/11716448/alma_4_18.txt) | 
|Qemu | Slackware current | 4.14.290 | [slackware_4_14.txt](https://github.com/netdata/netdata/files/11715713/slackware_4_14.txt) | 

You can get all logs using [this](https://github.com/netdata/netdata/files/11724741/artifacts.zip) link.


<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
