### PR TITLE
Speed up eBPF exit before to bring functions

### DIFF
--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -561,7 +561,8 @@ static void ebpf_exit()
 #ifdef NETDATA_INTERNAL_CHECKS
     error("Good bye world! I was PID %d", main_thread_id);
 #endif
-    printf("DISABLE\n");
+    fprintf(stdout, "EXIT\n");
+    fflush(stdout);
 
     pthread_mutex_lock(&mutex_cgroup_shm);
     if (shm_ebpf_cgroup.header) {

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -704,6 +704,9 @@ static void ebpf_unload_filesystems()
 
     int i;
     for (i = 0; localfs[i].filesystem != NULL; i++) {
+        if (!localfs[i].objects)
+            continue;
+
         ebpf_unload_legacy_code(localfs[i].objects, localfs[i].probe_links);
     }
 }

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -632,7 +632,7 @@ static void ebpf_unload_unique_maps()
     int i;
     for (i = 0; ebpf_modules[i].thread_name; i++) {
         // These threads are cleaned with other functions
-        if (i > EBPF_MODULE_SOCKET_IDX && i < EBPF_MODULE_DISK_IDX)
+        if (i > EBPF_MODULE_SOCKET_IDX && i < EBPF_MODULE_MOUNT_IDX)
             continue;
 
         if (ebpf_modules[i].enabled != NETDATA_THREAD_EBPF_STOPPED) {

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -632,8 +632,7 @@ static void ebpf_unload_unique_maps()
     int i;
     for (i = 0; ebpf_modules[i].thread_name; i++) {
         // These threads are cleaned with other functions
-        if ((i > EBPF_MODULE_SOCKET_IDX && i < EBPF_MODULE_VFS_IDX) ||
-            i == EBPF_MODULE_FILESYSTEM_IDX)
+        if (i > EBPF_MODULE_SOCKET_IDX && i < EBPF_MODULE_DISK_IDX)
             continue;
 
         if (ebpf_modules[i].enabled != NETDATA_THREAD_EBPF_STOPPED) {
@@ -677,13 +676,7 @@ static void ebpf_unload_unique_maps()
 #endif
                 break;
             }
-            case EBPF_MODULE_VFS_IDX: {
-#ifdef LIBBPF_MAJOR_VERSION
-                if (vfs_bpf_obj)
-                    vfs_bpf__destroy(vfs_bpf_obj);
-#endif
-                break;
-            }
+            case EBPF_MODULE_VFS_IDX:
             case EBPF_MODULE_SWAP_IDX:
             case EBPF_MODULE_DCSTAT_IDX:
             case EBPF_MODULE_PROCESS_IDX:

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -632,7 +632,7 @@ static void ebpf_unload_unique_maps()
     int i;
     for (i = 0; ebpf_modules[i].thread_name; i++) {
         // These threads are cleaned with other functions
-        if ((i > EBPF_MODULE_SOCKET_IDX && i < EBPF_MODULE_SWAP_IDX) ||
+        if ((i > EBPF_MODULE_SOCKET_IDX && i < EBPF_MODULE_VFS_IDX) ||
             i == EBPF_MODULE_FILESYSTEM_IDX)
             continue;
 
@@ -677,13 +677,6 @@ static void ebpf_unload_unique_maps()
 #endif
                 break;
             }
-            case EBPF_MODULE_SWAP_IDX: {
-#ifdef LIBBPF_MAJOR_VERSION
-                if (bpf_obj)
-                    swap_bpf__destroy(bpf_obj);
-#endif
-                break;
-            }
             case EBPF_MODULE_VFS_IDX: {
 #ifdef LIBBPF_MAJOR_VERSION
                 if (vfs_bpf_obj)
@@ -691,6 +684,7 @@ static void ebpf_unload_unique_maps()
 #endif
                 break;
             }
+            case EBPF_MODULE_SWAP_IDX:
             case EBPF_MODULE_DCSTAT_IDX:
             case EBPF_MODULE_PROCESS_IDX:
             case EBPF_MODULE_CACHESTAT_IDX:

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -2672,7 +2672,7 @@ int main(int argc, char **argv)
         (void)heartbeat_next(&hb, step);
 
         pthread_mutex_lock(&ebpf_exit_cleanup);
-        if (ebpf_modules[i].enabled == NETDATA_THREAD_EBPF_RUNNING && process_pid_fd != -1) {
+        if (process_pid_fd != -1) {
             pthread_mutex_lock(&collect_data_mutex);
             if (++update_apps_list == update_apps_every) {
                 update_apps_list = 0;

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -605,6 +605,10 @@ static void ebpf_unload_unique_maps()
 {
     int i;
     for (i = 0; ebpf_modules[i].thread_name; i++) {
+        // These threads are cleaned with other functions
+        if (i == EBPF_MODULE_SYNC_IDX || i == EBPF_MODULE_FILESYSTEM_IDX)
+            continue;
+
         if (ebpf_modules[i].enabled != NETDATA_THREAD_EBPF_STOPPED) {
             if (ebpf_modules[i].enabled != NETDATA_THREAD_EBPF_NOT_RUNNING)
                 error("Cannot unload maps for thread %s, because it is not stopped.", ebpf_modules[i].thread_name);

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -606,9 +606,8 @@ static void ebpf_unload_unique_maps()
     int i;
     for (i = 0; ebpf_modules[i].thread_name; i++) {
         // These threads are cleaned with other functions
-        if (i == EBPF_MODULE_SYNC_IDX ||
-            i == EBPF_MODULE_FILESYSTEM_IDX ||
-            i == EBPF_MODULE_CACHESTAT_IDX)
+        if ((i > EBPF_MODULE_SOCKET_IDX && i < EBPF_MODULE_SWAP_IDX) ||
+            i == EBPF_MODULE_FILESYSTEM_IDX)
             continue;
 
         if (ebpf_modules[i].enabled != NETDATA_THREAD_EBPF_STOPPED) {
@@ -624,13 +623,6 @@ static void ebpf_unload_unique_maps()
         }
 
         switch (i) {
-            case EBPF_MODULE_DCSTAT_IDX: {
-#ifdef LIBBPF_MAJOR_VERSION
-                if (dc_bpf_obj)
-                    dc_bpf__destroy(dc_bpf_obj);
-#endif
-                break;
-            }
             case EBPF_MODULE_FD_IDX: {
 #ifdef LIBBPF_MAJOR_VERSION
                 if (fd_bpf_obj)
@@ -673,6 +665,7 @@ static void ebpf_unload_unique_maps()
 #endif
                 break;
             }
+            case EBPF_MODULE_DCSTAT_IDX:
             case EBPF_MODULE_PROCESS_IDX:
             case EBPF_MODULE_CACHESTAT_IDX:
             case EBPF_MODULE_DISK_IDX:

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -612,7 +612,11 @@ static void ebpf_unload_unique_maps()
             continue;
         }
 
-        ebpf_unload_legacy_code(ebpf_modules[i].objects, ebpf_modules[i].probe_links);
+        if (ebpf_modules[i].load == EBPF_LOAD_LEGACY) {
+            ebpf_unload_legacy_code(ebpf_modules[i].objects, ebpf_modules[i].probe_links);
+            continue;
+        }
+
         switch (i) {
             case EBPF_MODULE_CACHESTAT_IDX: {
 #ifdef LIBBPF_MAJOR_VERSION

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -632,7 +632,7 @@ static void ebpf_unload_unique_maps()
     int i;
     for (i = 0; ebpf_modules[i].thread_name; i++) {
         // These threads are cleaned with other functions
-        if (i > EBPF_MODULE_SOCKET_IDX && i < EBPF_MODULE_MOUNT_IDX)
+        if (i > EBPF_MODULE_SOCKET_IDX && i < EBPF_MODULE_HARDIRQ_IDX)
             continue;
 
         if (ebpf_modules[i].enabled != NETDATA_THREAD_EBPF_STOPPED) {
@@ -648,20 +648,6 @@ static void ebpf_unload_unique_maps()
         }
 
         switch (i) {
-            case EBPF_MODULE_FD_IDX: {
-#ifdef LIBBPF_MAJOR_VERSION
-                if (fd_bpf_obj)
-                    fd_bpf__destroy(fd_bpf_obj);
-#endif
-                break;
-            }
-            case EBPF_MODULE_MOUNT_IDX: {
-#ifdef LIBBPF_MAJOR_VERSION
-                if (mount_bpf_obj)
-                    mount_bpf__destroy(mount_bpf_obj);
-#endif
-                break;
-            }
             case EBPF_MODULE_SHM_IDX: {
 #ifdef LIBBPF_MAJOR_VERSION
                 if (shm_bpf_obj)
@@ -676,6 +662,8 @@ static void ebpf_unload_unique_maps()
 #endif
                 break;
             }
+            case EBPF_MODULE_MOUNT_IDX:
+            case EBPF_MODULE_FD_IDX:
             case EBPF_MODULE_VFS_IDX:
             case EBPF_MODULE_SWAP_IDX:
             case EBPF_MODULE_DCSTAT_IDX:

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -694,7 +694,8 @@ static void ebpf_unload_unique_maps()
 static void ebpf_unload_filesystems()
 {
     if (ebpf_modules[EBPF_MODULE_FILESYSTEM_IDX].enabled == NETDATA_THREAD_EBPF_NOT_RUNNING ||
-        ebpf_modules[EBPF_MODULE_SYNC_IDX].enabled == NETDATA_THREAD_EBPF_RUNNING)
+        ebpf_modules[EBPF_MODULE_FILESYSTEM_IDX].enabled == NETDATA_THREAD_EBPF_RUNNING ||
+        ebpf_modules[EBPF_MODULE_FILESYSTEM_IDX].load != EBPF_LOAD_LEGACY)
         return;
 
     int i;
@@ -711,7 +712,8 @@ static void ebpf_unload_filesystems()
 static void ebpf_unload_sync()
 {
     if (ebpf_modules[EBPF_MODULE_SYNC_IDX].enabled == NETDATA_THREAD_EBPF_NOT_RUNNING ||
-        ebpf_modules[EBPF_MODULE_SYNC_IDX].enabled == NETDATA_THREAD_EBPF_RUNNING)
+        ebpf_modules[EBPF_MODULE_SYNC_IDX].enabled == NETDATA_THREAD_EBPF_RUNNING ||
+        ebpf_modules[EBPF_MODULE_SYNC_IDX].load != EBPF_LOAD_LEGACY)
         return;
 
     int i;

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -632,7 +632,7 @@ static void ebpf_unload_unique_maps()
     int i;
     for (i = 0; ebpf_modules[i].thread_name; i++) {
         // These threads are cleaned with other functions
-        if (i > EBPF_MODULE_SOCKET_IDX && i < EBPF_MODULE_HARDIRQ_IDX)
+        if (i > EBPF_MODULE_SOCKET_IDX && i < EBPF_MODULE_OOMKILL_IDX)
             continue;
 
         if (ebpf_modules[i].enabled != NETDATA_THREAD_EBPF_STOPPED) {

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -632,7 +632,7 @@ static void ebpf_unload_unique_maps()
     int i;
     for (i = 0; ebpf_modules[i].thread_name; i++) {
         // These threads are cleaned with other functions
-        if (i > EBPF_MODULE_SOCKET_IDX && i < EBPF_MODULE_OOMKILL_IDX)
+        if (i > EBPF_MODULE_SOCKET_IDX)
             continue;
 
         if (ebpf_modules[i].enabled != NETDATA_THREAD_EBPF_STOPPED) {
@@ -647,36 +647,13 @@ static void ebpf_unload_unique_maps()
             continue;
         }
 
-        switch (i) {
-            case EBPF_MODULE_SHM_IDX: {
+        if (i == EBPF_MODULE_SOCKET_IDX) {
 #ifdef LIBBPF_MAJOR_VERSION
-                if (shm_bpf_obj)
-                    shm_bpf__destroy(shm_bpf_obj);
+            if (socket_bpf_obj)
+                socket_bpf__destroy(socket_bpf_obj);
 #endif
-                break;
-            }
-            case EBPF_MODULE_SOCKET_IDX: {
-#ifdef LIBBPF_MAJOR_VERSION
-                if (socket_bpf_obj)
-                    socket_bpf__destroy(socket_bpf_obj);
-#endif
-                break;
-            }
-            case EBPF_MODULE_MOUNT_IDX:
-            case EBPF_MODULE_FD_IDX:
-            case EBPF_MODULE_VFS_IDX:
-            case EBPF_MODULE_SWAP_IDX:
-            case EBPF_MODULE_DCSTAT_IDX:
-            case EBPF_MODULE_PROCESS_IDX:
-            case EBPF_MODULE_CACHESTAT_IDX:
-            case EBPF_MODULE_DISK_IDX:
-            case EBPF_MODULE_HARDIRQ_IDX:
-            case EBPF_MODULE_SOFTIRQ_IDX:
-            case EBPF_MODULE_OOMKILL_IDX:
-            case EBPF_MODULE_MDFLUSH_IDX:
-            default:
-                continue;
         }
+
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -606,7 +606,9 @@ static void ebpf_unload_unique_maps()
     int i;
     for (i = 0; ebpf_modules[i].thread_name; i++) {
         // These threads are cleaned with other functions
-        if (i == EBPF_MODULE_SYNC_IDX || i == EBPF_MODULE_FILESYSTEM_IDX)
+        if (i == EBPF_MODULE_SYNC_IDX ||
+            i == EBPF_MODULE_FILESYSTEM_IDX ||
+            i == EBPF_MODULE_CACHESTAT_IDX)
             continue;
 
         if (ebpf_modules[i].enabled != NETDATA_THREAD_EBPF_STOPPED) {
@@ -622,13 +624,6 @@ static void ebpf_unload_unique_maps()
         }
 
         switch (i) {
-            case EBPF_MODULE_CACHESTAT_IDX: {
-#ifdef LIBBPF_MAJOR_VERSION
-                if (cachestat_bpf_obj)
-                    cachestat_bpf__destroy(cachestat_bpf_obj);
-#endif
-                break;
-            }
             case EBPF_MODULE_DCSTAT_IDX: {
 #ifdef LIBBPF_MAJOR_VERSION
                 if (dc_bpf_obj)
@@ -679,6 +674,7 @@ static void ebpf_unload_unique_maps()
                 break;
             }
             case EBPF_MODULE_PROCESS_IDX:
+            case EBPF_MODULE_CACHESTAT_IDX:
             case EBPF_MODULE_DISK_IDX:
             case EBPF_MODULE_HARDIRQ_IDX:
             case EBPF_MODULE_SOFTIRQ_IDX:

--- a/collectors/ebpf.plugin/ebpf_disk.c
+++ b/collectors/ebpf.plugin/ebpf_disk.c
@@ -435,17 +435,18 @@ static void ebpf_cleanup_disk_list()
 }
 
 /**
- * DISK Free
+ * Disk exit.
  *
- * Cleanup variables after child threads to stop
+ * Cancel child and exit.
  *
  * @param ptr thread data.
  */
-static void ebpf_disk_free(ebpf_module_t *em)
+static void ebpf_disk_exit(void *ptr)
 {
-    pthread_mutex_lock(&ebpf_exit_cleanup);
-    em->enabled = NETDATA_THREAD_EBPF_STOPPING;
-    pthread_mutex_unlock(&ebpf_exit_cleanup);
+    ebpf_module_t *em = (ebpf_module_t *)ptr;
+
+    if (em->objects)
+        ebpf_unload_legacy_code(em->objects, em->probe_links);
 
     ebpf_disk_disable_tracepoints();
 
@@ -461,19 +462,6 @@ static void ebpf_disk_free(ebpf_module_t *em)
     pthread_mutex_lock(&ebpf_exit_cleanup);
     em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);
-}
-
-/**
- * Disk exit.
- *
- * Cancel child and exit.
- *
- * @param ptr thread data.
- */
-static void ebpf_disk_exit(void *ptr)
-{
-    ebpf_module_t *em = (ebpf_module_t *)ptr;
-    ebpf_disk_free(em);
 }
 
 /*****************************************************************

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -52,6 +52,10 @@ static netdata_publish_syscall_t oomkill_publish_aggregated = {.name = "oomkill"
 static void oomkill_cleanup(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
+
+    if (em->objects)
+        ebpf_unload_legacy_code(em->objects, em->probe_links);
+
     pthread_mutex_lock(&ebpf_exit_cleanup);
     em->enabled = NETDATA_THREAD_EBPF_STOPPED;
     pthread_mutex_unlock(&ebpf_exit_cleanup);


### PR DESCRIPTION
##### Summary
This PR is bringing first steps to fix [this](https://github.com/netdata/netdata/pull/15174#issuecomment-1586727435) and [this](https://github.com/netdata/netdata/pull/15146#issuecomment-1586317539) comment. The final solution will come with next PR that will bring functions for eBPF.

##### Test Plan

1. Remove your `/etc/netdata/ebpf.d.conf`
2. Compile this branch
3. Start netdata and stop netdata while you are working or you have a server running receiving requests, you should have less messages like `take too long to exit: 'PD[ebpf]'`, but they are not completely over yet.

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? eBPF.plugin
- Can they see the change or is it an under the hood? If they can see it, where? eBPF will close faster
- How is the user impacted by the change? Speed up service exit.
- What are there any benefits of the change? We need less time to restart netdata.
</details>
