### PR TITLE
sqlite_health.c: remove `uuid.h` include

### DIFF
--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -3,7 +3,6 @@
 #include "sqlite_health.h"
 #include "sqlite_functions.h"
 #include "sqlite_db_migration.h"
-#include "uuid.h"
 
 #define MAX_HEALTH_SQL_SIZE 2048
 #define sqlite3_bind_string_or_null(res,key,param) ((key) ? sqlite3_bind_text(res, param, string2str(key), -1, SQLITE_STATIC) : sqlite3_bind_null(res, param))


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->
The `sqlite_health.c` file was recently changed to add `#include "uuid.h"`, however the library must be accessed as `uuid/uuid.h` on macOS. This PR aims to fix the issue. Spotted in https://github.com/Homebrew/homebrew-core/pull/133756.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Netdata's existing tests should be able to check this, however I'm unsure if there exists a macOS building/testing pipeline here. I have verified that this change works by patching Netdata and building it locally via Homebrew. It is also possible to test that the build is successful on Homebrew CI (in PR https://github.com/Homebrew/homebrew-core/pull/133756) with this change.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
This change affects a specific file (sqlite_health.c) in Netdata, and solves a build error on macOS. There should not be any impact on users except that Netdata successfully builds on macOS with this change.
</details>
