### PR TITLE
Allow overriding pipename from env

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -936,6 +936,8 @@ DAEMON_FILES = \
     daemon/static_threads.c \
     daemon/commands.c \
     daemon/commands.h \
+    daemon/pipename.c \
+    daemon/pipename.h \
     daemon/unit_test.c \
     daemon/unit_test.h \
     $(NULL)
@@ -1140,6 +1142,8 @@ endif
 
 NETDATACLI_FILES = \
     daemon/commands.h \
+    daemon/pipename.c \
+    daemon/pipename.h \
     libnetdata/buffer/buffer.c \
     libnetdata/buffer/buffer.h \
     cli/cli.c \

--- a/cli/cli.c
+++ b/cli/cli.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "cli.h"
+#include "daemon/pipename.h"
 
 void error_int(int is_collector __maybe_unused, const char *prefix __maybe_unused, const char *file __maybe_unused, const char *function __maybe_unused, const unsigned long line __maybe_unused, const char *fmt, ... ) {
     FILE *fp = stderr;
@@ -288,7 +289,9 @@ int main(int argc, char **argv)
     }
 
     req.data = buffer_create(128, NULL);
-    uv_pipe_connect(&req, &client_pipe, PIPENAME, connect_cb);
+
+    const char *pipename = daemon_pipename();
+    uv_pipe_connect(&req, &client_pipe, pipename, connect_cb);
 
     uv_run(loop, UV_RUN_DEFAULT);
 

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -644,14 +644,18 @@ static void command_thread(void *arg)
         command_thread_error = ret;
         goto error_after_pipe_init;
     }
-    (void)uv_fs_unlink(loop, &req, PIPENAME, NULL);
+
+    const char *pipename = daemon_pipename();
+
+    (void)uv_fs_unlink(loop, &req, pipename, NULL);
     uv_fs_req_cleanup(&req);
-    ret = uv_pipe_bind(&server_pipe, PIPENAME);
+    ret = uv_pipe_bind(&server_pipe, pipename);
     if (ret) {
         error("uv_pipe_bind(): %s", uv_strerror(ret));
         command_thread_error = ret;
         goto error_after_pipe_bind;
     }
+
     ret = uv_listen((uv_stream_t *)&server_pipe, SOMAXCONN, connection_cb);
     if (ret) {
         /* Fallback to backlog of 1 */

--- a/daemon/commands.h
+++ b/daemon/commands.h
@@ -3,12 +3,6 @@
 #ifndef NETDATA_COMMANDS_H
 #define NETDATA_COMMANDS_H 1
 
-#ifdef _WIN32
-# define PIPENAME "\\\\?\\pipe\\netdata-cli"
-#else
-# define PIPENAME "/tmp/netdata-ipc"
-#endif
-
 #define MAX_COMMAND_LENGTH 4096
 #define MAX_EXIT_STATUS_LENGTH 23 /* Can't ever be bigger than "X-18446744073709551616" */
 

--- a/daemon/common.h
+++ b/daemon/common.h
@@ -89,6 +89,7 @@
 #include "static_threads.h"
 #include "signals.h"
 #include "commands.h"
+#include "pipename.h"
 #include "analytics.h"
 
 // global netdata daemon variables

--- a/daemon/pipename.c
+++ b/daemon/pipename.c
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "pipename.h"
+
+#include <stdlib.h>
+
+const char *daemon_pipename(void) {
+    const char *pipename = getenv("NETDATA_PIPENAME");
+    if (pipename)
+        return pipename;
+
+#ifdef _WIN32
+    return "\\\\?\\pipe\\netdata-cli";
+#else
+    return "/tmp/netdata-ipc";
+#endif
+}

--- a/daemon/pipename.h
+++ b/daemon/pipename.h
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef DAEMON_PIPENAME_H
+#define DAEMON_PIPENAME_H
+
+const char *daemon_pipename(void);
+
+#endif /* DAEMON_PIPENAME_H */


### PR DESCRIPTION
This in turn will allow us to target specific agent processes running with the commands cli.

##### Summary

This in turn will allow us to target a specific agent process when running the netdatacli binary.

##### Test Plan

1. Build/Install the agent in two different locations.
2. Start each agent with a unique `NETDATA_PIPENAME` path environment variable.
3. Use (either) netdatacli to control the desired agent process by specifying the appropriate `NETDATA_PIPENAME`.

##### Additional Information

This is meant for easing automation on our side and not for end-users.