### PR TITLE
fix arch detection on i386 (native packages)

### DIFF
--- a/contrib/debian/install_go.sh
+++ b/contrib/debian/install_go.sh
@@ -36,30 +36,13 @@ download_go() {
 }
 
 install_go() {
-	ARCH_MAP=(
-		'i386::386'
-		'i686::386'
-		'x86_64::amd64'
-		'aarch64::arm64'
-		'armv64::arm64'
-		'armv6l::arm'
-		'armv7l::arm'
-		'armv5tel::arm'
-	)
-
 	if [ -z "${NETDATA_DISABLE_GO+x}" ]; then
-		echo >&2 "Install go.d.plugin"
-		ARCH="${DEB_TARGET_ARCH}"
-		OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+	  ARCH="${DEB_TARGET_ARCH}"
+	  ARCH=${ARCH#i} # i386 => 386
+	  OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 
-		for index in "${ARCH_MAP[@]}" ; do
-			KEY="${index%%::*}"
-			VALUE="${index##*::}"
-			if [ "$KEY" = "$ARCH" ]; then
-				ARCH="${VALUE}"
-				break
-			fi
-		done
+		echo >&2 "Install go.d.plugin (ARCH=${ARCH}, OS=${OS})"
+
 		tmp=$(mktemp -d /tmp/netdata-go-XXXXXX)
 		GO_PACKAGE_BASENAME="go.d.plugin-${GO_PACKAGE_VERSION}.${OS}-${ARCH}.tar.gz"
 		download_go "https://github.com/netdata/go.d.plugin/releases/download/${GO_PACKAGE_VERSION}/${GO_PACKAGE_BASENAME}" "${tmp}/${GO_PACKAGE_BASENAME}"

--- a/contrib/debian/install_go.sh
+++ b/contrib/debian/install_go.sh
@@ -7,75 +7,75 @@ LIBEXEC_DIR="$3"
 # ############################################################
 # Package Go within netdata (TBD: Package it separately)
 safe_sha256sum() {
-	# Within the context of the installer, we only use -c option that is common between the two commands
-	# We will have to reconsider if we start non-common options
-	if command -v sha256sum >/dev/null 2>&1; then
-		sha256sum $@
-	elif command -v shasum >/dev/null 2>&1; then
-		shasum -a 256 $@
-	else
-		fatal "I could not find a suitable checksum binary to use"
-	fi
+  # Within the context of the installer, we only use -c option that is common between the two commands
+  # We will have to reconsider if we start non-common options
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum $@
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 $@
+  else
+    fatal "I could not find a suitable checksum binary to use"
+  fi
 }
 
 download_go() {
-	url="${1}"
-	dest="${2}"
+  url="${1}"
+  dest="${2}"
 
-	if command -v curl >/dev/null 2>&1; then
-		curl -sSL --connect-timeout 10 --retry 3 "${url}" > "${dest}"
-	elif command -v wget >/dev/null 2>&1; then
-		wget -T 15 -O - "${url}" > "${dest}"
-	else
-		echo >&2
-		echo >&2 "Downloading go.d plugin from '${url}' failed because of missing mandatory packages."
-		echo >&2 "Either add packages or disable it by issuing '--disable-go' in the installer"
-		echo >&2
-		exit 1
-	fi
+  if command -v curl >/dev/null 2>&1; then
+    curl -sSL --connect-timeout 10 --retry 3 "${url}" >"${dest}"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -T 15 -O - "${url}" >"${dest}"
+  else
+    echo >&2
+    echo >&2 "Downloading go.d plugin from '${url}' failed because of missing mandatory packages."
+    echo >&2 "Either add packages or disable it by issuing '--disable-go' in the installer"
+    echo >&2
+    exit 1
+  fi
 }
 
 install_go() {
-	if [ -z "${NETDATA_DISABLE_GO+x}" ]; then
-	  ARCH="${DEB_TARGET_ARCH}"
-	  ARCH=${ARCH#i} # i386 => 386
-	  OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+  if [ -z "${NETDATA_DISABLE_GO+x}" ]; then
+    ARCH="${DEB_TARGET_ARCH}"
+    ARCH=${ARCH#i} # i386 => 386
+    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 
-		echo >&2 "Install go.d.plugin (ARCH=${ARCH}, OS=${OS})"
+    echo >&2 "Install go.d.plugin (ARCH=${ARCH}, OS=${OS})"
 
-		tmp=$(mktemp -d /tmp/netdata-go-XXXXXX)
-		GO_PACKAGE_BASENAME="go.d.plugin-${GO_PACKAGE_VERSION}.${OS}-${ARCH}.tar.gz"
-		download_go "https://github.com/netdata/go.d.plugin/releases/download/${GO_PACKAGE_VERSION}/${GO_PACKAGE_BASENAME}" "${tmp}/${GO_PACKAGE_BASENAME}"
-		download_go "https://github.com/netdata/go.d.plugin/releases/download/${GO_PACKAGE_VERSION}/config.tar.gz" "${tmp}/config.tar.gz"
+    tmp=$(mktemp -d /tmp/netdata-go-XXXXXX)
+    GO_PACKAGE_BASENAME="go.d.plugin-${GO_PACKAGE_VERSION}.${OS}-${ARCH}.tar.gz"
+    download_go "https://github.com/netdata/go.d.plugin/releases/download/${GO_PACKAGE_VERSION}/${GO_PACKAGE_BASENAME}" "${tmp}/${GO_PACKAGE_BASENAME}"
+    download_go "https://github.com/netdata/go.d.plugin/releases/download/${GO_PACKAGE_VERSION}/config.tar.gz" "${tmp}/config.tar.gz"
 
-		if [ ! -f "${tmp}/${GO_PACKAGE_BASENAME}" ] || [ ! -f "${tmp}/config.tar.gz" ] || [ ! -s "${tmp}/config.tar.gz" ] || [ ! -s "${tmp}/${GO_PACKAGE_BASENAME}" ]; then
-			echo >&2 "Either check the error or consider disabling it by issuing '--disable-go' in the installer"
-			echo >&2
-			return 1
-		fi
+    if [ ! -f "${tmp}/${GO_PACKAGE_BASENAME}" ] || [ ! -f "${tmp}/config.tar.gz" ] || [ ! -s "${tmp}/config.tar.gz" ] || [ ! -s "${tmp}/${GO_PACKAGE_BASENAME}" ]; then
+      echo >&2 "Either check the error or consider disabling it by issuing '--disable-go' in the installer"
+      echo >&2
+      return 1
+    fi
 
-		grep "${GO_PACKAGE_BASENAME}\$" "packaging/go.d.checksums" > "${tmp}/sha256sums.txt" 2>/dev/null
-		grep "config.tar.gz" "packaging/go.d.checksums" >> "${tmp}/sha256sums.txt" 2>/dev/null
+    grep "${GO_PACKAGE_BASENAME}\$" "packaging/go.d.checksums" >"${tmp}/sha256sums.txt" 2>/dev/null
+    grep "config.tar.gz" "packaging/go.d.checksums" >>"${tmp}/sha256sums.txt" 2>/dev/null
 
-		# Checksum validation
-		if ! (cd "${tmp}" && safe_sha256sum -c "sha256sums.txt"); then
+    # Checksum validation
+    if ! (cd "${tmp}" && safe_sha256sum -c "sha256sums.txt"); then
 
-			echo >&2 "go.d plugin checksum validation failure."
-			echo >&2 "Either check the error or consider disabling it by issuing '--disable-go' in the installer"
-			echo >&2
+      echo >&2 "go.d plugin checksum validation failure."
+      echo >&2 "Either check the error or consider disabling it by issuing '--disable-go' in the installer"
+      echo >&2
 
-			echo "go.d.plugin package files checksum validation failed."
-			exit 1
-		fi
+      echo "go.d.plugin package files checksum validation failed."
+      exit 1
+    fi
 
-		# Install files
-		tar -xf "${tmp}/config.tar.gz" -C "${LIB_DIR}/conf.d/"
-		tar xf "${tmp}/${GO_PACKAGE_BASENAME}"
-		mv "${GO_PACKAGE_BASENAME/\.tar\.gz/}" "${LIBEXEC_DIR}/plugins.d/go.d.plugin"
+    # Install files
+    tar -xf "${tmp}/config.tar.gz" -C "${LIB_DIR}/conf.d/"
+    tar xf "${tmp}/${GO_PACKAGE_BASENAME}"
+    mv "${GO_PACKAGE_BASENAME/\.tar\.gz/}" "${LIBEXEC_DIR}/plugins.d/go.d.plugin"
 
-		rm -rf "${tmp}"
-	fi
-	return 0
+    rm -rf "${tmp}"
+  fi
+  return 0
 }
 
 install_go

--- a/contrib/debian/install_go.sh
+++ b/contrib/debian/install_go.sh
@@ -49,7 +49,7 @@ install_go() {
 
 	if [ -z "${NETDATA_DISABLE_GO+x}" ]; then
 		echo >&2 "Install go.d.plugin"
-		ARCH=$(uname -m)
+		ARCH="${DEB_TARGET_ARCH}"
 		OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 
 		for index in "${ARCH_MAP[@]}" ; do

--- a/contrib/debian/install_go.sh
+++ b/contrib/debian/install_go.sh
@@ -38,7 +38,7 @@ download_go() {
 install_go() {
   ARCH_MAP=(
     'i386::386'
-    'armhf::arm64'
+    'armhf::arm'
   )
   if [ -z "${NETDATA_DISABLE_GO+x}" ]; then
     ARCH="${DEB_TARGET_ARCH}"

--- a/contrib/debian/install_go.sh
+++ b/contrib/debian/install_go.sh
@@ -36,9 +36,22 @@ download_go() {
 }
 
 install_go() {
+  ARCH_MAP=(
+    'i386::386'
+    'armhf::arm64'
+  )
   if [ -z "${NETDATA_DISABLE_GO+x}" ]; then
     ARCH="${DEB_TARGET_ARCH}"
-    ARCH=${ARCH#i} # i386 => 386
+
+    for index in "${ARCH_MAP[@]}" ; do
+      KEY="${index%%::*}"
+      VALUE="${index##*::}"
+      if [ "$KEY" = "$ARCH" ]; then
+        ARCH="${VALUE}"
+        break
+      fi
+    done
+
     OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 
     echo >&2 "Install go.d.plugin (ARCH=${ARCH}, OS=${OS})"

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -393,9 +393,10 @@ install_go() {
 	)
 
 	if [ -z "${NETDATA_DISABLE_GO+x}" ]; then
-		echo >&2 "Install go.d.plugin"
-		ARCH=$(uname -m)
+		ARCH="%{_arch}"
 		OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+
+		echo >&2 "Install go.d.plugin (ARCH=${ARCH}, OS=${OS})"
 
 		for index in "${ARCH_MAP[@]}" ; do
 			KEY="${index%%::*}"


### PR DESCRIPTION
##### Summary

Fixes: https://github.com/netdata/netdata/issues/15194

> **Note** hide whitespace changes when reviewing

This PR doesn't fix the wrong `Binary architecture` (PREBUILT_ARCH in .install-type), it is x86_64.

##### Test Plan

ci, check ci logs

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
