### PR TITLE
Fix handling of plugin ownership in static builds.

### DIFF
--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -165,7 +165,7 @@ run find /opt/netdata -type d -exec chmod go+rx '{}' \+
 run chown -R ${NETDATA_USER}:${NETDATA_GROUP} /opt/netdata/var
 
 if [ -d /opt/netdata/usr/libexec/netdata/plugins.d/ebpf.d ]; then
-  run chwon -R root:${NETDATA_GROUP} /opt/netdata/usr/libexec/netdata/plugins.d/ebpf.d
+  run chown -R root:${NETDATA_GROUP} /opt/netdata/usr/libexec/netdata/plugins.d/ebpf.d
 fi
 
 # -----------------------------------------------------------------------------

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -164,11 +164,15 @@ run chmod g+rx,o+rx /opt
 run find /opt/netdata -type d -exec chmod go+rx '{}' \+
 run chown -R ${NETDATA_USER}:${NETDATA_GROUP} /opt/netdata/var
 
+if [ -d /opt/netdata/usr/libexec/netdata/plugins.d/ebpf.d ]; then
+  run chwon -R root:${NETDATA_GROUP} /opt/netdata/usr/libexec/netdata/plugins.d/ebpf.d
+fi
+
 # -----------------------------------------------------------------------------
 
 progress "changing plugins ownership and permissions"
 
-for x in apps.plugin perf.plugin slabinfo.plugin debugfs.plugin freeipmi.plugin ioping cgroup-network ebpf.plugin nfacct.plugin xenstat.plugin python.d.plugin charts.d.plugin go.d.plugin; do
+for x in apps.plugin perf.plugin slabinfo.plugin debugfs.plugin freeipmi.plugin ioping cgroup-network ebpf.plugin nfacct.plugin xenstat.plugin python.d.plugin charts.d.plugin go.d.plugin ioping.plugin cgroup-network-helper.sh; do
   f="usr/libexec/netdata/plugins.d/${x}"
   if [ -f "${f}" ]; then
     run chown root:${NETDATA_GROUP} "${f}"

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -168,6 +168,13 @@ run chown -R ${NETDATA_USER}:${NETDATA_GROUP} /opt/netdata/var
 
 progress "changing plugins ownership and permissions"
 
+for x in apps.plugin perf.plugin slabinfo.plugin debugfs.plugin freeipmi.plugin ioping cgroup-network ebpf.plugin nfacct.plugin xenstat.plugin python.d.plugin charts.d.plugin go.d.plugin; do
+  f="usr/libexec/netdata/plugins.d/${x}"
+  if [ -f "${f}" ]; then
+    run chown root:${NETDATA_GROUP} "${f}"
+  fi
+done
+
 if command -v setcap >/dev/null 2>&1; then
     run setcap "cap_dac_read_search,cap_sys_ptrace=ep" "usr/libexec/netdata/plugins.d/apps.plugin"
     run setcap "cap_dac_read_search=ep" "usr/libexec/netdata/plugins.d/slabinfo.plugin"
@@ -183,7 +190,6 @@ if command -v setcap >/dev/null 2>&1; then
 else
   for x in apps.plugin perf.plugin slabinfo.plugin debugfs.plugin; do
     f="usr/libexec/netdata/plugins.d/${x}"
-    run chown root:${NETDATA_GROUP} "${f}"
     run chmod 4750 "${f}"
   done
 fi
@@ -192,7 +198,6 @@ for x in freeipmi.plugin ioping cgroup-network ebpf.plugin nfacct.plugin xenstat
   f="usr/libexec/netdata/plugins.d/${x}"
 
   if [ -f "${f}" ]; then
-    run chown root:${NETDATA_GROUP} "${f}"
     run chmod 4750 "${f}"
   fi
 done


### PR DESCRIPTION
##### Summary

Just change ownership on everything, instead of only on those plugins we set file capabilities or SUID on.

##### Test Plan

Testing should be done using static builds created from this PR. When installing on a system that does not have the Netdata user or group, the plugins from such a static build should still have correct file ownership.

##### Additional Information

Fixes: https://github.com/netdata/netdata/issues/15228