### PR TITLE
New alerts endpoint

### DIFF
--- a/database/contexts/rrdcontext.h
+++ b/database/contexts/rrdcontext.h
@@ -301,54 +301,6 @@ typedef struct query_target_request {
     void *interrupt_callback_data;
 } QUERY_TARGET_REQUEST;
 
-//typedef struct alert_target_request {
-//    size_t version;
-//
-//    const char *scope_nodes;
-//    const char *scope_contexts;
-//
-//    // selecting / filtering metrics to be queried
-//    RRDHOST *host;                      // the host to be queried (can be NULL, hosts will be used)
-//    RRDCONTEXT_ACQUIRED *rca;           // the context to be queried (can be NULL)
-//    RRDINSTANCE_ACQUIRED *ria;          // the instance to be queried (can be NULL)
-//    RRDMETRIC_ACQUIRED *rma;            // the metric to be queried (can be NULL)
-//    RRDSET *st;                         // the chart to be queried (NULL, for context queries)
-//    const char *nodes;                  // hosts simple pattern
-//    const char *contexts;               // contexts simple pattern (context queries)
-//    const char *instances;                 // charts simple pattern (for context queries)
-//    const char *dimensions;             // dimensions simple pattern
-//    const char *chart_label_key;        // select only the chart having this label key
-//    const char *labels;                 // select only the charts having this combo of label key:value
-//    const char *alerts;                 // select only the charts having this combo of alert name:status
-//
-//    time_t after;                       // the requested timeframe
-//    time_t before;                      // the requested timeframe
-//    size_t points;                      // the requested number of points to be returned
-//
-//    uint32_t format;                    // DATASOURCE_FORMAT
-//    RRDR_OPTIONS options;
-//    time_t timeout_ms;                     // the timeout of the query in milliseconds
-//
-//    size_t tier;
-//    QUERY_SOURCE query_source;
-//    STORAGE_PRIORITY priority;
-//
-//    // resampling metric values across time
-//    time_t resampling_time;
-//
-//    // grouping metric values across time
-//    RRDR_TIME_GROUPING time_group_method;
-//    const char *time_group_options;
-//
-//    // group by across multiple time-series
-//    struct group_by_pass group_by[MAX_QUERY_GROUP_BY_PASSES];
-//
-//    usec_t received_ut;
-//
-//    qt_interrupt_callback_t interrupt_callback;
-//    void *interrupt_callback_data;
-//} ALERT_TARGET_REQUEST;
-
 #define GROUP_BY_MAX_LABEL_KEYS 10
 
 struct query_tier_statistics {

--- a/database/contexts/rrdcontext.h
+++ b/database/contexts/rrdcontext.h
@@ -301,6 +301,54 @@ typedef struct query_target_request {
     void *interrupt_callback_data;
 } QUERY_TARGET_REQUEST;
 
+//typedef struct alert_target_request {
+//    size_t version;
+//
+//    const char *scope_nodes;
+//    const char *scope_contexts;
+//
+//    // selecting / filtering metrics to be queried
+//    RRDHOST *host;                      // the host to be queried (can be NULL, hosts will be used)
+//    RRDCONTEXT_ACQUIRED *rca;           // the context to be queried (can be NULL)
+//    RRDINSTANCE_ACQUIRED *ria;          // the instance to be queried (can be NULL)
+//    RRDMETRIC_ACQUIRED *rma;            // the metric to be queried (can be NULL)
+//    RRDSET *st;                         // the chart to be queried (NULL, for context queries)
+//    const char *nodes;                  // hosts simple pattern
+//    const char *contexts;               // contexts simple pattern (context queries)
+//    const char *instances;                 // charts simple pattern (for context queries)
+//    const char *dimensions;             // dimensions simple pattern
+//    const char *chart_label_key;        // select only the chart having this label key
+//    const char *labels;                 // select only the charts having this combo of label key:value
+//    const char *alerts;                 // select only the charts having this combo of alert name:status
+//
+//    time_t after;                       // the requested timeframe
+//    time_t before;                      // the requested timeframe
+//    size_t points;                      // the requested number of points to be returned
+//
+//    uint32_t format;                    // DATASOURCE_FORMAT
+//    RRDR_OPTIONS options;
+//    time_t timeout_ms;                     // the timeout of the query in milliseconds
+//
+//    size_t tier;
+//    QUERY_SOURCE query_source;
+//    STORAGE_PRIORITY priority;
+//
+//    // resampling metric values across time
+//    time_t resampling_time;
+//
+//    // grouping metric values across time
+//    RRDR_TIME_GROUPING time_group_method;
+//    const char *time_group_options;
+//
+//    // group by across multiple time-series
+//    struct group_by_pass group_by[MAX_QUERY_GROUP_BY_PASSES];
+//
+//    usec_t received_ut;
+//
+//    qt_interrupt_callback_t interrupt_callback;
+//    void *interrupt_callback_data;
+//} ALERT_TARGET_REQUEST;
+
 #define GROUP_BY_MAX_LABEL_KEYS 10
 
 struct query_tier_statistics {
@@ -475,6 +523,27 @@ struct api_v2_contexts_request {
     void *interrupt_callback_data;
 };
 
+struct api_v2_alerts_request {
+    char *scope_nodes;
+    char *scope_contexts;
+    char *nodes;
+    char *contexts;
+    char *config_hash;
+    char *state;
+    SIMPLE_PATTERN *config_hash_pattern;
+    char *transition_id;
+    time_t alert_id;
+    uint32_t last;
+    char *alert_name;
+    SIMPLE_PATTERN *alert_name_pattern;
+    ALERT_OPTIONS options;
+    time_t after;
+    time_t before;
+    char *q;
+};
+
+ssize_t get_alert_index(Pvoid_t JudyHS, uuid_t *uuid);
+
 typedef enum __attribute__ ((__packed__)) {
     CONTEXTS_V2_DEBUG           = (1 << 0),
     CONTEXTS_V2_MINIFY          = (1 << 1),
@@ -490,6 +559,7 @@ typedef enum __attribute__ ((__packed__)) {
 } CONTEXTS_V2_OPTIONS;
 
 int rrdcontext_to_json_v2(BUFFER *wb, struct api_v2_contexts_request *req, CONTEXTS_V2_OPTIONS options);
+int alerts_to_json_v2(BUFFER *wb, struct api_v2_alerts_request *req, CONTEXTS_V2_OPTIONS options);
 
 RRDCONTEXT_TO_JSON_OPTIONS rrdcontext_to_json_parse_options(char *o);
 void buffer_json_agents_array_v2(BUFFER *wb, struct query_timings *timings, time_t now_s, bool info);

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1014,6 +1014,7 @@ struct alarm_entry {
     uint32_t unique_id;
     uint32_t alarm_id;
     uint32_t alarm_event_id;
+    usec_t global_id;
     uuid_t config_hash_id;
     uuid_t transition_id;
 

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -281,6 +281,7 @@ static void rrdcalc_link_to_rrdset(RRDSET *st, RRDCALC *rc) {
         0,
         rrdcalc_isrepeating(rc)?HEALTH_ENTRY_FLAG_IS_REPEATING:0);
 
+    rc->ae = ae;
     health_alarm_log_add_entry(host, ae);
 }
 
@@ -324,6 +325,7 @@ static void rrdcalc_unlink_from_rrdset(RRDCALC *rc, bool having_ll_wrlock) {
             0,
             0);
 
+        rc->ae = ae;
         health_alarm_log_add_entry(host, ae);
     }
 

--- a/database/rrdcalc.h
+++ b/database/rrdcalc.h
@@ -136,6 +136,7 @@ struct rrdcalc {
     int delay_up_current;           // the current up notification delay duration
     int delay_down_current;         // the current down notification delay duration
     int delay_last;                 // the last delay we used
+    ALARM_ENTRY *ae;                // last alarm entry
 
     // ------------------------------------------------------------------------
     // variables this alarm exposes to the rest of the alarms

--- a/database/rrdcalctemplate.h
+++ b/database/rrdcalctemplate.h
@@ -10,6 +10,7 @@
 // based on their context.
 struct rrdcalctemplate {
     uuid_t config_hash_id;
+    uuid_t transition_id;
 
     STRING *name;
 

--- a/database/rrdcalctemplate.h
+++ b/database/rrdcalctemplate.h
@@ -10,7 +10,6 @@
 // based on their context.
 struct rrdcalctemplate {
     uuid_t config_hash_id;
-    uuid_t transition_id;
 
     STRING *name;
 

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -923,10 +923,10 @@ void sql_health_alarm_log_load(RRDHOST *host) {
         else
             ae->chart_context = NULL;
 
-         if (sqlite3_column_type(res, 31) != SQLITE_NULL)
-            uuid_copy(ae->transition_id, *((uuid_t *) sqlite3_column_blob(res, 31)));
+        if (sqlite3_column_type(res, 31) != SQLITE_NULL)
+            uuid_copy(ae->transition_id, *((uuid_t *)sqlite3_column_blob(res, 31)));
 
-         if (sqlite3_column_type(res, 32) != SQLITE_NULL)
+        if (sqlite3_column_type(res, 32) != SQLITE_NULL)
             ae->global_id = sqlite3_column_int64(res, 32);
 
         char value_string[100 + 1];

--- a/database/sqlite/sqlite_health.h
+++ b/database/sqlite/sqlite_health.h
@@ -18,4 +18,5 @@ int sql_health_get_last_executed_event(RRDHOST *host, ALARM_ENTRY *ae, RRDCALC_S
 void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *chart);
 int health_migrate_old_health_log_table(char *table);
 uint32_t sql_get_alarm_id(RRDHOST *host, STRING *chart, STRING *name, uint32_t *next_event_id);
+void sql_health_alarm_log2json_v2(RRDHOST *host, BUFFER *wb, uint32_t alert_id, char *chart, time_t after, time_t before, uint32_t top);
 #endif //NETDATA_SQLITE_HEALTH_H

--- a/health/health.c
+++ b/health/health.c
@@ -1128,6 +1128,7 @@ void *health_main(void *ptr) {
                             rc->last_status_change = now;
                             rc->last_updated = now;
                             rc->value = NAN;
+//                            uuid_copy(rc->transition_id, ae->transition_id);
 
 #ifdef ENABLE_ACLK
                             if (netdata_cloud_enabled)
@@ -1396,6 +1397,7 @@ void *health_main(void *ptr) {
                         rc->last_status_change = now;
                         rc->old_status = rc->status;
                         rc->status = status;
+                        rc->ae = ae;
                     }
 
                     rc->last_updated = now;

--- a/health/health.c
+++ b/health/health.c
@@ -1128,7 +1128,7 @@ void *health_main(void *ptr) {
                             rc->last_status_change = now;
                             rc->last_updated = now;
                             rc->value = NAN;
-//                            uuid_copy(rc->transition_id, ae->transition_id);
+                            rc->ae = ae;
 
 #ifdef ENABLE_ACLK
                             if (netdata_cloud_enabled)
@@ -1475,6 +1475,7 @@ void *health_main(void *ptr) {
                             ae->flags |= HEALTH_ENTRY_RUN_ONCE;
                         }
                         rc->run_flags |= RRDCALC_FLAG_RUN_ONCE;
+                        rc->ae = ae;
                         health_process_notifications(host, ae);
                         debug(D_HEALTH, "Notification sent for the repeating alarm %u.", ae->alarm_id);
                         health_alarm_wait_for_execution(ae);

--- a/health/health.h
+++ b/health/health.h
@@ -40,6 +40,8 @@ void health_reload(void);
 
 void health_aggregate_alarms(RRDHOST *host, BUFFER *wb, BUFFER* context, RRDCALC_STATUS status);
 void health_alarms2json(RRDHOST *host, BUFFER *wb, int all);
+void health_alert2json(RRDHOST *host, BUFFER *wb, ALERT_OPTIONS all, Pvoid_t JudyHS, time_t after, time_t before, uint32_t top);
+void health_alert2json_conf(RRDHOST *host, BUFFER *wb, ALERT_OPTIONS all);
 void health_alarms_values2json(RRDHOST *host, BUFFER *wb, int all);
 
 void health_api_v1_chart_variables2json(RRDSET *st, BUFFER *buf);

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -167,6 +167,63 @@ static inline void health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC
     buffer_strcat(wb, "\t\t}");
 }
 
+
+static inline void health_alerts_rrdcalc2json_nolock(RRDHOST *host __maybe_unused, BUFFER *wb,
+                                                     RRDCALC *rc, ALERT_OPTIONS options __maybe_unused,
+                                                     Pvoid_t JudyHS, time_t after, time_t before, uint32_t top)
+{
+    ssize_t idx= get_alert_index(JudyHS, &rc->config_hash_id);
+    // If not in index then skip it
+    if (idx < 0)
+        return;
+
+    char value_string[100 + 1];
+    format_value_and_unit(value_string, 100, rc->value, rrdcalc_units(rc), -1);
+
+
+    char hash_id[UUID_STR_LEN];
+    uuid_unparse_lower(rc->config_hash_id, hash_id);
+
+    buffer_json_add_array_item_object(wb);
+    if ((!after || after <= rc->last_updated) && (!before || before >= rc->last_updated)) {
+
+            buffer_json_member_add_uint64(wb, "li", (size_t) idx);
+
+            char trans_uuid_str[UUID_STR_LEN];
+            if (rc->ae) {
+                uuid_unparse_lower(rc->ae->transition_id, trans_uuid_str);
+                buffer_json_member_add_string(wb, "transition_id", trans_uuid_str);
+            }
+            else
+                buffer_json_member_add_quoted_string(wb, "transition_id", "NULL");
+
+            buffer_json_member_add_uint64(wb, "id", rc->id); // instance_id on query
+
+            buffer_json_member_add_string(wb, "status", rrdcalc_status2string(rc->status));
+            buffer_json_member_add_uint64(wb, "last_status_change", (unsigned long)rc->last_status_change);
+            buffer_json_member_add_uint64(wb, "last_updated", (unsigned long)rc->last_updated);
+            buffer_json_member_add_uint64(wb, "next_update", (unsigned long)rc->next_update);
+            buffer_json_member_add_uint64(wb, "delay_up_to_timestamp", (unsigned long)rc->delay_up_to_timestamp);
+
+            buffer_json_member_add_string(wb, "value_string", value_string);
+            buffer_json_member_add_uint64(wb, "last_repeat", (unsigned long)rc->last_repeat);
+            buffer_json_member_add_uint64(wb, "times_repeat", (unsigned long)rc->times_repeat);
+            buffer_json_member_add_uint64(wb, "db_after", (unsigned long)rc->db_after);
+            buffer_json_member_add_uint64(wb, "db_before", (unsigned long)rc->db_before);
+
+            buffer_json_member_add_double(wb, "green", rc->green);
+            buffer_json_member_add_double(wb, "red", rc->red);
+            buffer_json_member_add_double(wb, "value", rc->value);
+
+            if (options & ALERT_OPTION_HISTORY) {
+                buffer_json_member_add_array(wb, "transitions");
+                sql_health_alarm_log2json_v2(host, wb, rc->id, NULL, after, before, top);
+                buffer_json_array_close(wb);
+            }
+    }
+    buffer_json_object_close(wb); // array entry
+}
+
 //void health_rrdcalctemplate2json_nolock(BUFFER *wb, RRDCALCTEMPLATE *rt) {
 //
 //}
@@ -232,6 +289,37 @@ static void health_alarms2json_fill_alarms(RRDHOST *host, BUFFER *wb, int all, v
         i++;
     }
     foreach_rrdcalc_in_rrdhost_done(rc);
+}
+
+static void health_alerts2json_fill_alarms(
+    RRDHOST *host,
+    BUFFER *wb,
+    ALERT_OPTIONS all,
+    Pvoid_t JudyHS,
+    time_t after,
+    time_t before,
+    uint32_t top,
+    void (*fp)(RRDHOST *, BUFFER *, RRDCALC *, ALERT_OPTIONS, Pvoid_t , time_t, time_t, uint32_t))
+{
+    RRDCALC *rc;
+    foreach_rrdcalc_in_rrdhost_read(host, rc) {
+        if(unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
+            continue;
+
+        if (unlikely(!rrdset_is_available_for_exporting_and_alarms(rc->rrdset)))
+            continue;
+
+        if(likely((all & ALERT_OPTION_ACTIVE) && !(rc->status == RRDCALC_STATUS_WARNING || rc->status == RRDCALC_STATUS_CRITICAL)))
+            continue;
+
+        fp(host, wb, rc, all, JudyHS, after, before, top);
+    }
+    foreach_rrdcalc_in_rrdhost_done(rc);
+}
+
+void health_alert2json(RRDHOST *host, BUFFER *wb, ALERT_OPTIONS options, Pvoid_t JudyHS, time_t after, time_t before, uint32_t top)
+{
+    health_alerts2json_fill_alarms(host, wb, options, JudyHS, after, before, top, health_alerts_rrdcalc2json_nolock);
 }
 
 void health_alarms2json(RRDHOST *host, BUFFER *wb, int all) {

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -216,7 +216,7 @@ static inline void health_alerts_rrdcalc2json_nolock(RRDHOST *host __maybe_unuse
             buffer_json_member_add_double(wb, "red", rc->red);
             buffer_json_member_add_double(wb, "value", rc->value);
 
-            if (options & ALERT_OPTION_HISTORY) {
+            if (options & ALERT_OPTION_INSTANCES) {
                 buffer_json_member_add_array(wb, "transitions");
                 sql_health_alarm_log2json_v2(host, wb, rc->id, NULL, after, before, top);
                 buffer_json_array_close(wb);

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -193,11 +193,12 @@ static inline void health_alerts_rrdcalc2json_nolock(RRDHOST *host __maybe_unuse
             if (rc->ae) {
                 uuid_unparse_lower(rc->ae->transition_id, trans_uuid_str);
                 buffer_json_member_add_string(wb, "transition_id", trans_uuid_str);
+                buffer_json_member_add_uint64(wb, "gi", rc->ae->global_id);
             }
-            else
+            else {
                 buffer_json_member_add_quoted_string(wb, "transition_id", "NULL");
-
-            buffer_json_member_add_uint64(wb, "id", rc->id); // instance_id on query
+                buffer_json_member_add_quoted_string(wb, "gi", "NULL");
+            }
 
             buffer_json_member_add_string(wb, "status", rrdcalc_status2string(rc->status));
             buffer_json_member_add_uint64(wb, "last_status_change", (unsigned long)rc->last_status_change);

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -47,6 +47,7 @@ inline ALARM_ENTRY* health_create_alarm_entry(
     uuid_copy(ae->config_hash_id, *((uuid_t *) config_hash_id));
 
     uuid_generate_random(ae->transition_id);
+    ae->global_id = now_realtime_usec();
 
     ae->family = string_dup(family);
     ae->classification = string_dup(class);

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -51,6 +51,14 @@ typedef enum rrdr_options {
     RRDR_OPTION_INTERNAL_AR          = (1 << 31), // internal use only, to let the formatters know we want to render the anomaly rate
 } RRDR_OPTIONS;
 
+typedef enum alert_options {
+    ALERT_OPTION_MINIFY          = (1 << 0), // remove JSON spaces and newlines from JSON output
+    ALERT_OPTION_ACTIVE          = (1 << 1), // Only active alerts
+    ALERT_OPTION_CONFIG          = (1 << 2), // Include config
+    ALERT_OPTION_TRANSITIONS     = (1 << 3), // Include transitions
+    ALERT_OPTION_HISTORY         = (1 << 4), // Include alert history
+} ALERT_OPTIONS;
+
 typedef enum __attribute__ ((__packed__)) rrdr_value_flag {
 
     // IMPORTANT:

--- a/web/api/queries/rrdr.h
+++ b/web/api/queries/rrdr.h
@@ -56,7 +56,7 @@ typedef enum alert_options {
     ALERT_OPTION_ACTIVE          = (1 << 1), // Only active alerts
     ALERT_OPTION_CONFIG          = (1 << 2), // Include config
     ALERT_OPTION_TRANSITIONS     = (1 << 3), // Include transitions
-    ALERT_OPTION_HISTORY         = (1 << 4), // Include alert history
+    ALERT_OPTION_INSTANCES       = (1 << 4), // Include alert instances
 } ALERT_OPTIONS;
 
 typedef enum __attribute__ ((__packed__)) rrdr_value_flag {

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -59,7 +59,7 @@ static struct {
      , {"active"           , 0    , ALERT_OPTION_ACTIVE}
      , {"config"           , 0    , ALERT_OPTION_CONFIG}
      , {"transitions"      , 0    , ALERT_OPTION_TRANSITIONS}
-     , {"history"          , 0    , ALERT_OPTION_HISTORY}
+     , {"instances"        , 0    , ALERT_OPTION_INSTANCES}
     , {NULL                , 0    , 0}
 };
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -53,6 +53,19 @@ static struct {
 static struct {
     const char *name;
     uint32_t hash;
+    ALERT_OPTIONS value;
+} api_v2_alert_options[] = {
+      {"minify"            , 0    , ALERT_OPTION_MINIFY}
+     , {"active"           , 0    , ALERT_OPTION_ACTIVE}
+     , {"config"           , 0    , ALERT_OPTION_CONFIG}
+     , {"transitions"      , 0    , ALERT_OPTION_TRANSITIONS}
+     , {"history"          , 0    , ALERT_OPTION_HISTORY}
+    , {NULL                , 0    , 0}
+};
+
+static struct {
+    const char *name;
+    uint32_t hash;
     DATASOURCE_FORMAT value;
 } api_v1_data_formats[] = {
         {  DATASOURCE_FORMAT_DATATABLE_JSON , 0 , DATASOURCE_DATATABLE_JSON}
@@ -93,6 +106,9 @@ void web_client_api_v1_init(void) {
 
     for(i = 0; api_v1_data_options[i].name ; i++)
         api_v1_data_options[i].hash = simple_hash(api_v1_data_options[i].name);
+
+    for(i = 0; api_v2_alert_options[i].name ; i++)
+        api_v2_alert_options[i].hash = simple_hash(api_v2_alert_options[i].name);
 
     for(i = 0; api_v1_data_formats[i].name ; i++)
         api_v1_data_formats[i].hash = simple_hash(api_v1_data_formats[i].name);
@@ -186,6 +202,26 @@ inline RRDR_OPTIONS web_client_api_request_v1_data_options(char *o) {
         for(i = 0; api_v1_data_options[i].name ; i++) {
             if (unlikely(hash == api_v1_data_options[i].hash && !strcmp(tok, api_v1_data_options[i].name))) {
                 ret |= api_v1_data_options[i].value;
+                break;
+            }
+        }
+    }
+
+    return ret;
+}
+
+inline ALERT_OPTIONS web_client_api_request_v2_alert_options(char *o) {
+    ALERT_OPTIONS ret = 0x00000000;
+    char *tok;
+
+    while(o && *o && (tok = strsep_skip_consecutive_separators(&o, ", |"))) {
+        if(!*tok) continue;
+
+        uint32_t hash = simple_hash(tok);
+        int i;
+        for(i = 0; api_v2_alert_options[i].name ; i++) {
+            if (unlikely(hash == api_v2_alert_options[i].hash && !strcmp(tok, api_v2_alert_options[i].name))) {
+                ret |= api_v2_alert_options[i].value;
                 break;
             }
         }

--- a/web/api/web_api_v1.h
+++ b/web/api/web_api_v1.h
@@ -8,6 +8,7 @@
 struct web_client;
 
 RRDR_OPTIONS web_client_api_request_v1_data_options(char *o);
+ALERT_OPTIONS web_client_api_request_v2_alert_options(char *o);
 void web_client_api_request_v1_data_options_to_buffer_json_array(BUFFER *wb, const char *key, RRDR_OPTIONS options);
 void web_client_api_request_v1_data_options_to_string(char *buf, size_t size, RRDR_OPTIONS options);
 

--- a/web/api/web_api_v2.c
+++ b/web/api/web_api_v2.c
@@ -426,7 +426,7 @@ static int web_client_api_request_v2_alerts(RRDHOST *host __maybe_unused, struct
     w->response.data->content_type = CT_APPLICATION_JSON;
     buffer_json_initialize( w->response.data, "\"", "\"", 0, true, alert_options & ALERT_OPTION_MINIFY);
 
-    if (alert_options & ALERT_OPTION_HISTORY && !req.last)
+    if (alert_options & ALERT_OPTION_INSTANCES && !req.last)
         req.last = 1;
 
     req.options = alert_options;

--- a/web/api/web_api_v2.c
+++ b/web/api/web_api_v2.c
@@ -358,6 +358,84 @@ cleanup:
     return ret;
 }
 
+static int web_client_api_request_v2_alerts(RRDHOST *host __maybe_unused, struct web_client *w, char *url)
+{
+    time_t after = 0;
+    time_t before = 0;
+    struct api_v2_alerts_request req = { 0 };
+
+    CONTEXTS_V2_OPTIONS options =  CONTEXTS_V2_CONTEXTS | CONTEXTS_V2_NODES;
+    ALERT_OPTIONS alert_options = 0;
+
+    while(url) {
+        char *value = strsep_skip_consecutive_separators(&url, "&");
+        if(!value || !*value) continue;
+
+        char *name = strsep_skip_consecutive_separators(&value, "=");
+        if(!name || !*name) continue;
+        if(!value || !*value) continue;
+
+        // name and value are now the parameters
+        // they are not null and not empty
+
+        if (!strcmp(name, "scope_nodes")) {
+            req.scope_nodes = value;
+            options |= CONTEXTS_V2_NODES;
+        }
+        else if (!strcmp(name, "nodes")) {
+            req.nodes = value;
+            options |= CONTEXTS_V2_NODES;
+        }
+        else if (!strcmp(name, "scope_contexts")) {
+            req.scope_contexts = value;
+            options |= CONTEXTS_V2_CONTEXTS;
+        }
+        else if (!strcmp(name, "instance_id"))
+            req.alert_id = (time_t)strtoul(value, NULL, 0);
+        else if (!strcmp(name, "last"))
+            req.last = strtoul(value, NULL, 0);
+        else if (!strcmp(name, "transition_id")) {
+            req.transition_id = value;
+        } else if (!strcmp(name, "alert_name")) {
+            req.alert_name = value;
+            req.alert_name_pattern = string_to_simple_pattern(value);
+        } else if (!strcmp(name, "config_hash")) {
+            req.config_hash = value;
+            req.config_hash_pattern = string_to_simple_pattern(value);
+        } else if (!strcmp(name, "contexts")) {
+            req.contexts = value;
+            options |= CONTEXTS_V2_CONTEXTS;
+        } else if (!strcmp(name, "state")) {
+            req.state = value;  // all | warning | critical, clear, undefined, uninitialiazed
+        } else if (!strcmp(name, "q"))
+            req.q = value;
+        else if (!strcmp(name, "after"))
+            after = (time_t)strtoul(value, NULL, 0);
+        else if (!strcmp(name, "before"))
+            before = (time_t)strtoul(value, NULL, 0);
+        else if (!strcmp(name, "output")) {
+            // config, instances, transitions
+            alert_options |= web_client_api_request_v2_alert_options(value);
+        }
+
+        // TODO: All states and special "ACTIVE"
+    }
+
+    buffer_flush(w->response.data);
+    buffer_no_cacheable(w->response.data);
+    w->response.data->content_type = CT_APPLICATION_JSON;
+    buffer_json_initialize( w->response.data, "\"", "\"", 0, true, alert_options & ALERT_OPTION_MINIFY);
+
+    if (alert_options & ALERT_OPTION_HISTORY && !req.last)
+        req.last = 1;
+
+    req.options = alert_options;
+    req.after = after;
+    req.before = before;
+
+    return alerts_to_json_v2(w->response.data, &req, options);
+}
+
 static int web_client_api_request_v2_webrtc(RRDHOST *host __maybe_unused, struct web_client *w, char *url __maybe_unused) {
     return webrtc_new_connection(w->post_payload, w->response.data);
 }
@@ -373,6 +451,7 @@ static struct web_api_command api_commands_v2[] = {
         {"q", 0, WEB_CLIENT_ACL_DASHBOARD_ACLK_WEBRTC, web_client_api_request_v2_q},
 
         {"rtc_offer", 0, WEB_CLIENT_ACL_DASHBOARD | WEB_CLIENT_ACL_ACLK, web_client_api_request_v2_webrtc},
+        {"alerts", 0, WEB_CLIENT_ACL_DASHBOARD_ACLK_WEBRTC, web_client_api_request_v2_alerts},
 
         // terminator
         {NULL, 0, WEB_CLIENT_ACL_NONE, NULL},


### PR DESCRIPTION
##### Summary
This PR introduces the first iteration of the new `/api/v2/alerts` endpoint (not currently in use)

Parameters currently supported

- [x] scope_nodes and scope_contexts like with all /api/v2 calls.
- [x] alert_name to select all alerts with this name (simple pattern)
- [x] config_hash to select all alerts with this configuration
- [x] before and after to select all the alerts that have been in the wanted states during that period.
- [x] last which returns the last X transitions from before (or now).

---
Parameters affecting output: 
by default only the alerts short definition is returned.

- [x] output=config which includes the configuration of the alerts selected.
- [x] output=instances which returns all the instances of the alerts, together with their values.
- [x] output=transitions which returns the history of each alert instance between after and before.
- [ ] instance_id to select only the specific alert
- [ ] transition_id to select only the alert that has this transition
- [ ] state can be all (default), warning, critical, clear, undefined, uninitialized

