### PR TITLE
Create index for health log migration

### DIFF
--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -244,6 +244,8 @@ static int do_migration_v8_v9(sqlite3 *database, const char *name)
     sqlite3_exec_monitored(database, sql, 0, 0, NULL);
     snprintfz(sql, 2047, "CREATE INDEX IF NOT EXISTS health_log_d_ind_3 ON health_log_detail (transition_id);");
     sqlite3_exec_monitored(database, sql, 0, 0, NULL);
+    snprintfz(sql, 2047, "CREATE INDEX IF NOT EXISTS health_log_d_ind_4 ON health_log_detail (health_log_id);");
+    sqlite3_exec_monitored(database, sql, 0, 0, NULL);
 
     snprintfz(sql, 2047, "ALTER TABLE alert_hash ADD source text;");
     sqlite3_exec_monitored(database, sql, 0, 0, NULL);

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -61,6 +61,7 @@ const char *database_config[] = {
     "CREATE INDEX IF NOT EXISTS health_log_d_ind_1 ON health_log_detail (unique_id);",
     "CREATE INDEX IF NOT EXISTS health_log_d_ind_2 ON health_log_detail (global_id);",
     "CREATE INDEX IF NOT EXISTS health_log_d_ind_3 ON health_log_detail (transition_id);",
+    "CREATE INDEX IF NOT EXISTS health_log_d_ind_4 ON health_log_detail (health_log_id);",
     //TODO more indexes
 
     NULL


### PR DESCRIPTION
##### Summary
- Create index to help speedup migration during startup when a lot of tables need to be migrated

