### PR TITLE
Fix coverity 393183 & 393182

### DIFF
--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -309,6 +309,8 @@ void aclk_push_alert_event(struct aclk_sync_host_config *wc)
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to bind host_id for pushing alert event.");
         sqlite3_finalize(res);
+        buffer_free(sql);
+        freez(claim_id);
         return;
     }
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Small fix for coverity reports 393182 & 393183:

```
** CID 393183:  Resource leaks  (RESOURCE_LEAK)
/database/sqlite/sqlite_aclk_alert.c: 312 in aclk_push_alert_event()
306         }
307     
308         rc = sqlite3_bind_blob(res, 1, &wc->host->host_uuid, sizeof(wc->host->host_uuid), SQLITE_STATIC);
309         if (unlikely(rc != SQLITE_OK)) {
310             error_report("Failed to bind host_id for pushing alert event.");
311             sqlite3_finalize(res);
>>>     CID 393183:  Resource leaks  (RESOURCE_LEAK)
>>>     Variable "sql" going out of scope leaks the storage it points to.
312             return;
313         }
314     
315         uint64_t first_sequence_id = 0;
316         uint64_t last_sequence_id = 0;
317     

** CID 393182:  Resource leaks  (RESOURCE_LEAK)
/database/sqlite/sqlite_aclk_alert.c: 312 in aclk_push_alert_event()


________________________________________________________________________________________________________
*** CID 393182:  Resource leaks  (RESOURCE_LEAK)
/database/sqlite/sqlite_aclk_alert.c: 312 in aclk_push_alert_event()
306         }
307     
308         rc = sqlite3_bind_blob(res, 1, &wc->host->host_uuid, sizeof(wc->host->host_uuid), SQLITE_STATIC);
309         if (unlikely(rc != SQLITE_OK)) {
310             error_report("Failed to bind host_id for pushing alert event.");
311             sqlite3_finalize(res);
>>>     CID 393182:  Resource leaks  (RESOURCE_LEAK)
>>>     Variable "claim_id" going out of scope leaks the storage it points to.
312             return;
313         }
314     
315         uint64_t first_sequence_id = 0;
316         uint64_t last_sequence_id = 0;
317     
```
