### PR TITLE
Install the correct systemd unit file on older RPM systems.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -344,7 +344,7 @@ install -m 750 -p packaging/installer/netdata-uninstaller.sh \
 # Install netdata service
 
 install -m 755 -d "${RPM_BUILD_ROOT}%{_unitdir}"
-%if 0%{?centos_ver} != 7 && 0%{?amzn} != 2
+%if 0%{?centos_ver} != 7 && 0%{?amazon_linux} != 2
 install -m 644 -p system/systemd/netdata.service "${RPM_BUILD_ROOT}%{_unitdir}/netdata.service"
 %else
 install -m 644 -p system/systemd/netdata.service.v235 "${RPM_BUILD_ROOT}%{_unitdir}/netdata.service"

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -344,7 +344,7 @@ install -m 750 -p packaging/installer/netdata-uninstaller.sh \
 # Install netdata service
 
 install -m 755 -d "${RPM_BUILD_ROOT}%{_unitdir}"
-%if 0%?{centos_ver} != 7 && 0%?{amzn} != 2
+%if 0%{?centos_ver} != 7 && 0%{?amzn} != 2
 install -m 644 -p system/systemd/netdata.service "${RPM_BUILD_ROOT}%{_unitdir}/netdata.service"
 %else
 install -m 644 -p system/systemd/netdata.service.v235 "${RPM_BUILD_ROOT}%{_unitdir}/netdata.service"

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -342,8 +342,13 @@ install -m 750 -p packaging/installer/netdata-uninstaller.sh \
 
 # ###########################################################
 # Install netdata service
+
 install -m 755 -d "${RPM_BUILD_ROOT}%{_unitdir}"
+%if 0%?{centos_ver} != 7 && 0%?{amzn} != 2
 install -m 644 -p system/systemd/netdata.service "${RPM_BUILD_ROOT}%{_unitdir}/netdata.service"
+%else
+install -m 644 -p system/systemd/netdata.service.v235 "${RPM_BUILD_ROOT}%{_unitdir}/netdata.service"
+%endif
 install -m 755 -d "${RPM_BUILD_ROOT}%{_presetdir}"
 install -m 644 -p system/systemd/50-netdata.preset "${RPM_BUILD_ROOT}%{_presetdir}/50-netdata.preset"
 


### PR DESCRIPTION
##### Summary

CentOS 7 and derivatives need the pre-v235 systemd unit files, not the modern ones.

##### Test Plan

Packages built from this PR install the correct unit files, and the agent starts up correctly.

##### Additional Information

Fixes: #15236