### PR TITLE
Update libbpf version

### DIFF
--- a/packaging/current_libbpf.checksums
+++ b/packaging/current_libbpf.checksums
@@ -1,1 +1,1 @@
-97d0b6d5b86ae473883aadcba4fcecf47f608f5d0eb3dbb75eb2dbde271f0046  v1.2_netdata.tar.gz
+1bdb6dbc6d4d4fe8187ecceee92b820d0003ab26848a6064e37a6bc6401919c2  v1.2.p_netdata.tar.gz

--- a/packaging/current_libbpf.version
+++ b/packaging/current_libbpf.version
@@ -1,1 +1,1 @@
-1.2_netdata
+1.2.p_netdata


### PR DESCRIPTION
##### Summary
Fix https://github.com/netdata/netdata/issues/15245

This PR is bringing a libbpf version with a [patch](https://github.com/netdata/libbpf/commit/99078942257d49ea272806df5e291301bd7fef68) that allows to run on Debian 10 again.

##### Test Plan

1. Compile this branch
2. Start netdata
3. Wait around 20 seconds and run the following commands:

```sh
root@debian10:/etc/netdata# grep libbpf /var/log/netdata/* > debian_4_19_logs.txt
root@debian10:/etc/netdata# curl -o debian_4_19_threads.txt  "http://localhost:19999/api/v1/data?chart=netdata.ebpf_threads&after=-30"
``` 

You should not have any `libbpf` error and threads needs to be loaded with success.

##### Additional Information

This branch was tested on:

| Linux Distribution | Environment | Kernel version | Logs | Threads |
|----------------------------|---------------------|----------------------|-----------|-------------|
|Slackware current | Bare metal | 6.1.35 | [slackware_logs_6_1.txt](https://github.com/netdata/netdata/files/11875378/slackware_logs_6_1.txt) | [slackware_threads_6_1.txt](https://github.com/netdata/netdata/files/11875379/slackware_threads_6_1.txt) | 
| Arch Linux | Libvrt VM| 6.3.9 | [arch_6_3_logs.txt](https://github.com/netdata/netdata/files/11876275/arch_6_3_logs.txt) | [arch_6_3_threads.txt](https://github.com/netdata/netdata/files/11876276/arch_6_3_threads.txt) | 
| Ubuntu 22.04 | Libvirt VM | 5.15 | [ubuntu_5_15_logs.txt](https://github.com/netdata/netdata/files/11876535/ubuntu_5_15_logs.txt) | [ubuntu_5_15_threads.txt](https://github.com/netdata/netdata/files/11876536/ubuntu_5_15_threads.txt) |
|Alma 9 |  Libvirt VM| 5.14.0-284.11.1.el9_2.x86_64  | [alma_5_14_logs.txt](https://github.com/netdata/netdata/files/11876792/alma_5_14_logs.txt) | [alma_5_14_threads.txt](https://github.com/netdata/netdata/files/11876793/alma_5_14_threads.txt) | 
| Debian 11 | Libvirtt | 5.10 | [debian_5_10_logs.txt](https://github.com/netdata/netdata/files/11876585/debian_5_10_logs.txt) | [debian_5_10_threads.txt](https://github.com/netdata/netdata/files/11876586/debian_5_10_threads.txt) | 
| Ubuntu 20.04 | Libvirt VM | 5.4 | [ubuntu_5_4_logs.txt](https://github.com/netdata/netdata/files/11876316/ubuntu_5_4_logs.txt) | [ubuntu_5_4_threads.txt](https://github.com/netdata/netdata/files/11876317/ubuntu_5_4_threads.txt) | 
|Debian 10 | Libvrt VM| 4.19 | [debian_4_19_logs.txt](https://github.com/netdata/netdata/files/11875385/debian_4_19_logs.txt) | [debian_4_19_threads.txt](https://github.com/netdata/netdata/files/11875386/debian_4_19_threads.txt) | 
|Alma 8 | Libvirt VM | 4.18.0-477.13.1.el8_8.x86_64 | [alma_4_18_logs.txt](https://github.com/netdata/netdata/files/11876889/alma_4_18_logs.txt) | [alma_4_18_threads.txt](https://github.com/netdata/netdata/files/11876890/alma_4_18_threads.txt) | 
| Slackware current | Qemu | 4.14 | [slackware_logs_4_14.txt](https://github.com/netdata/netdata/files/11876846/slackware_logs_4_14.txt) | [slackware_threads_4_14.txt](https://github.com/netdata/netdata/files/11876847/slackware_threads_4_14.txt) | 

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? eBPF.plugin and libbpf
- Can they see the change or is it an under the hood? If they can see it, where? When they run on Debian 10
- How is the user impacted by the change?  No more error logs.
- What are there any benefits of the change?  We will support another distribution.
</details>
