### PR TITLE
Replace `info` macro with a less generic name

### DIFF
--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -335,7 +335,7 @@ int aclk_get_otp_challenge(url_t *target, const char *agent_id, unsigned char **
     }
     buffer_free(url);
 
-    info ("ACLK_OTP Got Challenge from Cloud");
+    netdata_log_info("ACLK_OTP Got Challenge from Cloud");
 
     json_object *json = json_tokener_parse(resp.payload);
     if (!json) {
@@ -414,7 +414,7 @@ int aclk_send_otp_response(const char *agent_id, const unsigned char *response, 
             aclk_parse_otp_error(resp.payload);
         goto cleanup_response;
     }
-    info ("ACLK_OTP Got Password from Cloud");
+    netdata_log_info("ACLK_OTP Got Password from Cloud");
 
     if (parse_passwd_response(resp.payload, mqtt_auth)){
         error("Error parsing response of password endpoint");
@@ -871,7 +871,7 @@ int aclk_get_env(aclk_env_t *env, const char* aclk_hostname, int aclk_port) {
         return 5;
     }
 
-    info("Getting Cloud /env successful");
+    netdata_log_info("Getting Cloud /env successful");
 
     https_req_response_free(&resp);
     buffer_free(buf);

--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -357,7 +357,7 @@ void *aclk_query_main_thread(void *ptr)
 #define TASK_LEN_MAX 22
 void aclk_query_threads_start(struct aclk_query_threads *query_threads, mqtt_wss_client client)
 {
-    info("Starting %d query threads.", query_threads->count);
+    netdata_log_info("Starting %d query threads.", query_threads->count);
 
     char thread_name[TASK_LEN_MAX];
     query_threads->thread_list = callocz(query_threads->count, sizeof(struct aclk_query_thread));

--- a/aclk/aclk_rx_msgs.c
+++ b/aclk/aclk_rx_msgs.c
@@ -399,10 +399,10 @@ int handle_disconnect_req(const char *msg, size_t msg_len)
         error("Cloud Banned This Agent!");
         aclk_disable_runtime = 1;
     }
-    info("Cloud requested disconnect (EC=%u, \"%s\")", (unsigned int)cmd->error_code, cmd->error_description);
+    netdata_log_info("Cloud requested disconnect (EC=%u, \"%s\")", (unsigned int)cmd->error_code, cmd->error_description);
     if (cmd->reconnect_after_s > 0) {
         aclk_block_until = now_monotonic_sec() + cmd->reconnect_after_s;
-        info(
+        netdata_log_info(
             "Cloud asks not to reconnect for %u seconds. We shall honor that request",
             (unsigned int)cmd->reconnect_after_s);
     }

--- a/aclk/https_client.c
+++ b/aclk/https_client.c
@@ -524,7 +524,7 @@ int https_request(https_req_t *request, https_req_response_t *response) {
             error("Proxy didn't return 200 OK (got %d)", ctx->parse_ctx.http_code);
             goto exit_sock;
         }
-        info("Proxy accepted CONNECT upgrade");
+        netdata_log_info("Proxy accepted CONNECT upgrade");
     }
     ctx->request = request;
 
@@ -584,7 +584,7 @@ int https_request(https_req_t *request, https_req_response_t *response) {
         // only exact data without affixed 0x00
         ((char*)response->payload)[response->payload_size] = 0; // mallocz(response->payload_size + 1);
     }
-    info("HTTPS \"%s\" request to \"%s\" finished with HTTP code: %d", http_req_type_to_str(ctx->request->request_type), ctx->request->host, response->http_code);
+    netdata_log_info("HTTPS \"%s\" request to \"%s\" finished with HTTP code: %d", http_req_type_to_str(ctx->request->request_type), ctx->request->host, response->http_code);
 
     rc = 0;
 

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -83,16 +83,16 @@ void claim_agent(char *claiming_arguments)
               cloud_base_url,
               claiming_arguments);
 
-    info("Executing agent claiming command 'netdata-claim.sh'");
+    netdata_log_info("Executing agent claiming command 'netdata-claim.sh'");
     fp_child_output = netdata_popen(command_buffer, &command_pid, &fp_child_input);
     if(!fp_child_output) {
         error("Cannot popen(\"%s\").", command_buffer);
         return;
     }
-    info("Waiting for claiming command to finish.");
+    netdata_log_info("Waiting for claiming command to finish.");
     while (fgets(command_buffer, CLAIMING_COMMAND_LENGTH, fp_child_output) != NULL) {;}
     exit_code = netdata_pclose(fp_child_input, fp_child_output, command_pid);
-    info("Agent claiming command returned with code %d", exit_code);
+    netdata_log_info("Agent claiming command returned with code %d", exit_code);
     if (0 == exit_code) {
         load_claiming_state();
         return;
@@ -148,7 +148,7 @@ void load_claiming_state(void)
     }
     if (aclk_connected)
     {
-        info("Agent was already connected to Cloud - forcing reconnection under new credentials");
+        netdata_log_info("Agent was already connected to Cloud - forcing reconnection under new credentials");
         aclk_kill_link = 1;
     }
     aclk_disable_runtime = 0;
@@ -174,13 +174,13 @@ void load_claiming_state(void)
     rrdhost_aclk_state_unlock(localhost);
 
     if (!claimed_id) {
-        info("Unable to load '%s', setting state to AGENT_UNCLAIMED", filename);
+        netdata_log_info("Unable to load '%s', setting state to AGENT_UNCLAIMED", filename);
         return;
     }
 
     freez(claimed_id);
 
-    info("File '%s' was found. Setting state to AGENT_CLAIMED.", filename);
+    netdata_log_info("File '%s' was found. Setting state to AGENT_CLAIMED.", filename);
     netdata_cloud_enabled = appconfig_get_boolean(&cloud_config, CONFIG_SECTION_GLOBAL, "enabled", 1);
 #endif
 }
@@ -202,7 +202,7 @@ void load_cloud_conf(int silent)
 
     ret = appconfig_load(&cloud_config, filename, 1, NULL);
     if(!ret && !silent) {
-        info("CONFIG: cannot load cloud config '%s'. Running with internal defaults.", filename);
+        netdata_log_info("CONFIG: cannot load cloud config '%s'. Running with internal defaults.", filename);
     }
     freez(filename);
 }

--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -1470,7 +1470,7 @@ static inline int read_proc_pid_stat(struct pid_stat *p, void *ptr) {
 
     if(enable_guest_charts) {
         enable_guest_charts = 0;
-        info("Guest charts aren't supported by FreeBSD");
+        netdata_log_info("Guest charts aren't supported by FreeBSD");
     }
 #else
     pid_incremental_rate(stat, p->minflt,  str2kernel_uint_t(procfile_lineword(ff, 0,  9)));
@@ -4184,28 +4184,28 @@ static void parse_args(int argc, char **argv)
     if(freq > 0) update_every = freq;
 
     if(read_apps_groups_conf(user_config_dir, "groups")) {
-        info("Cannot read process groups configuration file '%s/apps_groups.conf'. Will try '%s/apps_groups.conf'", user_config_dir, stock_config_dir);
+        netdata_log_info("Cannot read process groups configuration file '%s/apps_groups.conf'. Will try '%s/apps_groups.conf'", user_config_dir, stock_config_dir);
 
         if(read_apps_groups_conf(stock_config_dir, "groups")) {
             error("Cannot read process groups '%s/apps_groups.conf'. There are no internal defaults. Failing.", stock_config_dir);
             exit(1);
         }
         else
-            info("Loaded config file '%s/apps_groups.conf'", stock_config_dir);
+            netdata_log_info("Loaded config file '%s/apps_groups.conf'", stock_config_dir);
     }
     else
-        info("Loaded config file '%s/apps_groups.conf'", user_config_dir);
+        netdata_log_info("Loaded config file '%s/apps_groups.conf'", user_config_dir);
 }
 
 static int am_i_running_as_root() {
     uid_t uid = getuid(), euid = geteuid();
 
     if(uid == 0 || euid == 0) {
-        if(debug_enabled) info("I am running with escalated privileges, uid = %u, euid = %u.", uid, euid);
+        if(debug_enabled) netdata_log_info("I am running with escalated privileges, uid = %u, euid = %u.", uid, euid);
         return 1;
     }
 
-    if(debug_enabled) info("I am not running with escalated privileges, uid = %u, euid = %u.", uid, euid);
+    if(debug_enabled) netdata_log_info("I am not running with escalated privileges, uid = %u, euid = %u.", uid, euid);
     return 0;
 }
 
@@ -4217,7 +4217,7 @@ static int check_capabilities() {
         return 0;
     }
     else if(debug_enabled)
-        info("Received my capabilities from the system.");
+        netdata_log_info("Received my capabilities from the system.");
 
     int ret = 1;
 
@@ -4232,7 +4232,7 @@ static int check_capabilities() {
             ret = 0;
         }
         else if(debug_enabled)
-            info("apps.plugin runs with CAP_DAC_READ_SEARCH.");
+            netdata_log_info("apps.plugin runs with CAP_DAC_READ_SEARCH.");
     }
 
     cfv = CAP_CLEAR;
@@ -4246,7 +4246,7 @@ static int check_capabilities() {
             ret = 0;
         }
         else if(debug_enabled)
-            info("apps.plugin runs with CAP_SYS_PTRACE.");
+            netdata_log_info("apps.plugin runs with CAP_SYS_PTRACE.");
     }
 
     cap_free(caps);
@@ -5300,23 +5300,23 @@ int main(int argc, char **argv) {
 
     user_config_dir = getenv("NETDATA_USER_CONFIG_DIR");
     if(user_config_dir == NULL) {
-        // info("NETDATA_CONFIG_DIR is not passed from netdata");
+        // netdata_log_info("NETDATA_CONFIG_DIR is not passed from netdata");
         user_config_dir = CONFIG_DIR;
     }
-    // else info("Found NETDATA_USER_CONFIG_DIR='%s'", user_config_dir);
+    // else netdata_log_info("Found NETDATA_USER_CONFIG_DIR='%s'", user_config_dir);
 
     stock_config_dir = getenv("NETDATA_STOCK_CONFIG_DIR");
     if(stock_config_dir == NULL) {
-        // info("NETDATA_CONFIG_DIR is not passed from netdata");
+        // netdata_log_info("NETDATA_CONFIG_DIR is not passed from netdata");
         stock_config_dir = LIBCONFIG_DIR;
     }
-    // else info("Found NETDATA_USER_CONFIG_DIR='%s'", user_config_dir);
+    // else netdata_log_info("Found NETDATA_USER_CONFIG_DIR='%s'", user_config_dir);
 
 #ifdef NETDATA_INTERNAL_CHECKS
     if(debug_flags != 0) {
         struct rlimit rl = { RLIM_INFINITY, RLIM_INFINITY };
         if(setrlimit(RLIMIT_CORE, &rl) != 0)
-            info("Cannot request unlimited core dumps for debugging... Proceeding anyway...");
+            netdata_log_info("Cannot request unlimited core dumps for debugging... Proceeding anyway...");
 #ifdef HAVE_SYS_PRCTL_H
         prctl(PR_SET_DUMPABLE, 1, 0, 0, 0);
 #endif
@@ -5356,7 +5356,7 @@ int main(int argc, char **argv) {
 #endif
     }
 
-    info("started on pid %d", getpid());
+    netdata_log_info("started on pid %d", getpid());
 
     snprintfz(all_user_ids.filename, FILENAME_MAX, "%s/etc/passwd", netdata_configured_host_prefix);
     debug_log("passwd file: '%s'", all_user_ids.filename);

--- a/collectors/cups.plugin/cups_plugin.c
+++ b/collectors/cups.plugin/cups_plugin.c
@@ -438,5 +438,5 @@ int main(int argc, char **argv) {
     }
 
     httpClose(http);
-    info("CUPS process exiting");
+    netdata_log_info("CUPS process exiting");
 }

--- a/collectors/debugfs.plugin/debugfs_plugin.c
+++ b/collectors/debugfs.plugin/debugfs_plugin.c
@@ -176,7 +176,7 @@ int main(int argc, char **argv)
 
     stock_config_dir = getenv("NETDATA_STOCK_CONFIG_DIR");
     if (stock_config_dir == NULL) {
-        // info("NETDATA_CONFIG_DIR is not passed from netdata");
+        // netdata_log_info("NETDATA_CONFIG_DIR is not passed from netdata");
         stock_config_dir = LIBCONFIG_DIR;
     }
 
@@ -235,7 +235,7 @@ int main(int argc, char **argv)
                 enabled++;
         }
         if (!enabled) {
-            info("all modules are disabled, exiting...");
+            netdata_log_info("all modules are disabled, exiting...");
             return 1;
         }
     }

--- a/collectors/debugfs.plugin/debugfs_zswap.c
+++ b/collectors/debugfs.plugin/debugfs_zswap.c
@@ -383,7 +383,7 @@ int do_debugfs_zswap(int update_every, const char *name)
     static int check_if_enabled = 1;
 
     if (likely(check_if_enabled && debugfs_is_zswap_enabled())) {
-        info("Zswap is disabled");
+        netdata_log_info("Zswap is disabled");
         return 1;
     }
 

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -727,7 +727,7 @@ static void ebpf_stop_threads(int sig)
         if (ebpf_modules[i].enabled == NETDATA_THREAD_EBPF_RUNNING) {
             netdata_thread_cancel(*ebpf_modules[i].thread->thread);
 #ifdef NETDATA_DEV_MODE
-            info("Sending cancel for thread %s", ebpf_modules[i].thread_name);
+            netdata_log_info("Sending cancel for thread %s", ebpf_modules[i].thread_name);
 #endif
         }
     }
@@ -736,7 +736,7 @@ static void ebpf_stop_threads(int sig)
     pthread_mutex_lock(&mutex_cgroup_shm);
     netdata_thread_cancel(*cgroup_integration_thread.thread);
 #ifdef NETDATA_DEV_MODE
-    info("Sending cancel for thread %s", cgroup_integration_thread.name);
+    netdata_log_info("Sending cancel for thread %s", cgroup_integration_thread.name);
 #endif
     pthread_mutex_unlock(&mutex_cgroup_shm);
 
@@ -2135,11 +2135,11 @@ static void ebpf_parse_args(int argc, char **argv)
         freq = EBPF_DEFAULT_UPDATE_EVERY;
 
     if (load_collector_config(ebpf_user_config_dir, &disable_apps, &disable_cgroups, freq)) {
-        info(
+        netdata_log_info(
             "Does not have a configuration file inside `%s/ebpf.d.conf. It will try to load stock file.",
             ebpf_user_config_dir);
         if (load_collector_config(ebpf_stock_config_dir, &disable_apps, &disable_cgroups, freq)) {
-            info("Does not have a stock file. It is starting with default options.");
+            netdata_log_info("Does not have a stock file. It is starting with default options.");
         }
     }
 
@@ -2154,112 +2154,112 @@ static void ebpf_parse_args(int argc, char **argv)
             case EBPF_MODULE_PROCESS_IDX: {
                 select_threads |= 1<<EBPF_MODULE_PROCESS_IDX;
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF enabling \"PROCESS\" charts, because it was started with the option \"[-]-process\".");
+                netdata_log_info("EBPF enabling \"PROCESS\" charts, because it was started with the option \"[-]-process\".");
 #endif
                 break;
             }
             case EBPF_MODULE_SOCKET_IDX: {
                 select_threads |= 1<<EBPF_MODULE_SOCKET_IDX;
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF enabling \"NET\" charts, because it was started with the option \"[-]-net\".");
+                netdata_log_info("EBPF enabling \"NET\" charts, because it was started with the option \"[-]-net\".");
 #endif
                 break;
             }
             case EBPF_MODULE_CACHESTAT_IDX: {
                 select_threads |= 1<<EBPF_MODULE_CACHESTAT_IDX;
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF enabling \"CACHESTAT\" charts, because it was started with the option \"[-]-cachestat\".");
+                netdata_log_info("EBPF enabling \"CACHESTAT\" charts, because it was started with the option \"[-]-cachestat\".");
 #endif
                 break;
             }
             case EBPF_MODULE_SYNC_IDX: {
                 select_threads |= 1<<EBPF_MODULE_SYNC_IDX;
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF enabling \"SYNC\" chart, because it was started with the option \"[-]-sync\".");
+                netdata_log_info("EBPF enabling \"SYNC\" chart, because it was started with the option \"[-]-sync\".");
 #endif
                 break;
             }
             case EBPF_MODULE_DCSTAT_IDX: {
                 select_threads |= 1<<EBPF_MODULE_DCSTAT_IDX;
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF enabling \"DCSTAT\" charts, because it was started with the option \"[-]-dcstat\".");
+                netdata_log_info("EBPF enabling \"DCSTAT\" charts, because it was started with the option \"[-]-dcstat\".");
 #endif
                 break;
             }
             case EBPF_MODULE_SWAP_IDX: {
                 select_threads |= 1<<EBPF_MODULE_SWAP_IDX;
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF enabling \"SWAP\" chart, because it was started with the option \"[-]-swap\".");
+                netdata_log_info("EBPF enabling \"SWAP\" chart, because it was started with the option \"[-]-swap\".");
 #endif
                 break;
             }
             case EBPF_MODULE_VFS_IDX: {
                 select_threads |= 1<<EBPF_MODULE_VFS_IDX;
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF enabling \"VFS\" chart, because it was started with the option \"[-]-vfs\".");
+                netdata_log_info("EBPF enabling \"VFS\" chart, because it was started with the option \"[-]-vfs\".");
 #endif
                 break;
             }
             case EBPF_MODULE_FILESYSTEM_IDX: {
                 select_threads |= 1<<EBPF_MODULE_FILESYSTEM_IDX;
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF enabling \"FILESYSTEM\" chart, because it was started with the option \"[-]-filesystem\".");
+                netdata_log_info("EBPF enabling \"FILESYSTEM\" chart, because it was started with the option \"[-]-filesystem\".");
 #endif
                 break;
             }
             case EBPF_MODULE_DISK_IDX: {
                 select_threads |= 1<<EBPF_MODULE_DISK_IDX;
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF enabling \"DISK\" chart, because it was started with the option \"[-]-disk\".");
+                netdata_log_info("EBPF enabling \"DISK\" chart, because it was started with the option \"[-]-disk\".");
 #endif
                 break;
             }
             case EBPF_MODULE_MOUNT_IDX: {
                 select_threads |= 1<<EBPF_MODULE_MOUNT_IDX;
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF enabling \"MOUNT\" chart, because it was started with the option \"[-]-mount\".");
+                netdata_log_info("EBPF enabling \"MOUNT\" chart, because it was started with the option \"[-]-mount\".");
 #endif
                 break;
             }
             case EBPF_MODULE_FD_IDX: {
                 select_threads |= 1<<EBPF_MODULE_FD_IDX;
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF enabling \"FILEDESCRIPTOR\" chart, because it was started with the option \"[-]-filedescriptor\".");
+                netdata_log_info("EBPF enabling \"FILEDESCRIPTOR\" chart, because it was started with the option \"[-]-filedescriptor\".");
 #endif
                 break;
             }
             case EBPF_MODULE_HARDIRQ_IDX: {
                 select_threads |= 1<<EBPF_MODULE_HARDIRQ_IDX;
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF enabling \"HARDIRQ\" chart, because it was started with the option \"[-]-hardirq\".");
+                netdata_log_info("EBPF enabling \"HARDIRQ\" chart, because it was started with the option \"[-]-hardirq\".");
 #endif
                 break;
             }
             case EBPF_MODULE_SOFTIRQ_IDX: {
                 select_threads |= 1<<EBPF_MODULE_SOFTIRQ_IDX;
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF enabling \"SOFTIRQ\" chart, because it was started with the option \"[-]-softirq\".");
+                netdata_log_info("EBPF enabling \"SOFTIRQ\" chart, because it was started with the option \"[-]-softirq\".");
 #endif
                 break;
             }
             case EBPF_MODULE_OOMKILL_IDX: {
                 select_threads |= 1<<EBPF_MODULE_OOMKILL_IDX;
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF enabling \"OOMKILL\" chart, because it was started with the option \"[-]-oomkill\".");
+                netdata_log_info("EBPF enabling \"OOMKILL\" chart, because it was started with the option \"[-]-oomkill\".");
 #endif
                 break;
             }
             case EBPF_MODULE_SHM_IDX: {
                 select_threads |= 1<<EBPF_MODULE_SHM_IDX;
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF enabling \"SHM\" chart, because it was started with the option \"[-]-shm\".");
+                netdata_log_info("EBPF enabling \"SHM\" chart, because it was started with the option \"[-]-shm\".");
 #endif
                 break;
             }
             case EBPF_MODULE_MDFLUSH_IDX: {
                 select_threads |= 1<<EBPF_MODULE_MDFLUSH_IDX;
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF enabling \"MDFLUSH\" chart, because it was started with the option \"[-]-mdflush\".");
+                netdata_log_info("EBPF enabling \"MDFLUSH\" chart, because it was started with the option \"[-]-mdflush\".");
 #endif
                 break;
             }
@@ -2267,7 +2267,7 @@ static void ebpf_parse_args(int argc, char **argv)
                 disable_apps = 0;
                 disable_cgroups = 0;
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF running with all chart groups, because it was started with the option \"[-]-all\".");
+                netdata_log_info("EBPF running with all chart groups, because it was started with the option \"[-]-all\".");
 #endif
                 break;
             }
@@ -2283,28 +2283,28 @@ static void ebpf_parse_args(int argc, char **argv)
                 disable_apps = 1;
                 disable_cgroups = 1;
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF running with global chart group, because it was started with the option  \"[-]-global\".");
+                netdata_log_info("EBPF running with global chart group, because it was started with the option  \"[-]-global\".");
 #endif
                 break;
             }
             case EBPF_OPTION_RETURN_MODE: {
                 ebpf_set_thread_mode(MODE_RETURN);
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF running in \"RETURN\" mode, because it was started with the option \"[-]-return\".");
+                netdata_log_info("EBPF running in \"RETURN\" mode, because it was started with the option \"[-]-return\".");
 #endif
                 break;
             }
             case EBPF_OPTION_LEGACY: {
                 ebpf_set_load_mode(EBPF_LOAD_LEGACY, EBPF_LOADED_FROM_USER);
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF running with \"LEGACY\" code, because it was started with the option \"[-]-legacy\".");
+                netdata_log_info("EBPF running with \"LEGACY\" code, because it was started with the option \"[-]-legacy\".");
 #endif
                 break;
             }
             case EBPF_OPTION_CORE: {
                 ebpf_set_load_mode(EBPF_LOAD_CORE, EBPF_LOADED_FROM_USER);
 #ifdef NETDATA_INTERNAL_CHECKS
-                info("EBPF running with \"CO-RE\" code, because it was started with the option \"[-]-core\".");
+                netdata_log_info("EBPF running with \"CO-RE\" code, because it was started with the option \"[-]-core\".");
 #endif
                 break;
             }
@@ -2361,7 +2361,7 @@ unittest:
     // Load apps_groups.conf
     if (ebpf_read_apps_groups_conf(
             &apps_groups_default_target, &apps_groups_root_target, ebpf_user_config_dir, "groups")) {
-        info("Cannot read process groups configuration file '%s/apps_groups.conf'. Will try '%s/apps_groups.conf'",
+        netdata_log_info("Cannot read process groups configuration file '%s/apps_groups.conf'. Will try '%s/apps_groups.conf'",
              ebpf_user_config_dir, ebpf_stock_config_dir);
         if (ebpf_read_apps_groups_conf(
                 &apps_groups_default_target, &apps_groups_root_target, ebpf_stock_config_dir, "groups")) {
@@ -2370,7 +2370,7 @@ unittest:
             ebpf_exit();
         }
     } else
-        info("Loaded config file '%s/apps_groups.conf'", ebpf_user_config_dir);
+        netdata_log_info("Loaded config file '%s/apps_groups.conf'", ebpf_user_config_dir);
 }
 
 /*****************************************************************

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -44,7 +44,7 @@ void ebpf_aral_init(void)
     ebpf_aral_process_stat = ebpf_allocate_pid_aral(NETDATA_EBPF_PROC_ARAL_NAME, sizeof(ebpf_process_stat_t));
 
 #ifdef NETDATA_DEV_MODE
-    info("Plugin is using ARAL with values %d", NETDATA_EBPF_ALLOC_MAX_PID);
+    netdata_log_info("Plugin is using ARAL with values %d", NETDATA_EBPF_ALLOC_MAX_PID);
 #endif
 }
 

--- a/collectors/ebpf.plugin/ebpf_cgroup.c
+++ b/collectors/ebpf.plugin/ebpf_cgroup.c
@@ -303,7 +303,7 @@ void ebpf_parse_cgroup_shm_data()
     sem_post(shm_sem_ebpf_cgroup);
     pthread_mutex_unlock(&mutex_cgroup_shm);
 #ifdef NETDATA_DEV_MODE
-    info("Updating cgroup %d (Previous: %d, Current: %d)",
+    netdata_log_info("Updating cgroup %d (Previous: %d, Current: %d)",
          send_cgroup_chart, previous, shm_ebpf_cgroup.header->cgroup_root_count);
 #endif
 

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -195,7 +195,7 @@ netdata_ebpf_program_loaded_t ebpf_dc_update_load(ebpf_module_t *em)
         return EBPF_LOAD_TRAMPOLINE;
 
     if (em->targets[NETDATA_DC_TARGET_LOOKUP_FAST].mode != EBPF_LOAD_RETPROBE)
-        info("When your kernel was compiled the symbol %s was modified, instead to use `trampoline`, the plugin will use `probes`.",
+        netdata_log_info("When your kernel was compiled the symbol %s was modified, instead to use `trampoline`, the plugin will use `probes`.",
              dc_optional_name[NETDATA_DC_TARGET_LOOKUP_FAST].function_to_attach);
 
     return EBPF_LOAD_RETPROBE;

--- a/collectors/ebpf.plugin/ebpf_disk.c
+++ b/collectors/ebpf.plugin/ebpf_disk.c
@@ -311,7 +311,7 @@ static void update_disk_table(char *name, int major, int minor, time_t current_t
         error("Internal error, cannot insert the AVL tree.");
 
 #ifdef NETDATA_INTERNAL_CHECKS
-    info("The Latency is monitoring the hard disk %s (Major = %d, Minor = %d, Device = %u)", name, major, minor,w->dev);
+    netdata_log_info("The Latency is monitoring the hard disk %s (Major = %d, Minor = %d, Device = %u)", name, major, minor,w->dev);
 #endif
 
     w->flags |= NETDATA_DISK_IS_HERE;

--- a/collectors/ebpf.plugin/ebpf_filesystem.c
+++ b/collectors/ebpf.plugin/ebpf_filesystem.c
@@ -685,7 +685,7 @@ void *ebpf_filesystem_thread(void *ptr)
 
     if (ebpf_update_partitions(em)) {
         if (em->optional)
-            info("Netdata cannot monitor the filesystems used on this host.");
+            netdata_log_info("Netdata cannot monitor the filesystems used on this host.");
 
         goto endfilesystem;
     }

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -379,14 +379,14 @@ void *ebpf_oomkill_thread(void *ptr)
         // we need to disable it.
         pthread_mutex_lock(&ebpf_exit_cleanup);
         if (em->enabled)
-            info("%s apps integration is completely disabled.", NETDATA_DEFAULT_OOM_DISABLED_MSG);
+            netdata_log_info("%s apps integration is completely disabled.", NETDATA_DEFAULT_OOM_DISABLED_MSG);
         pthread_mutex_unlock(&ebpf_exit_cleanup);
 
         goto endoomkill;
     } else if (running_on_kernel < NETDATA_EBPF_KERNEL_4_14) {
         pthread_mutex_lock(&ebpf_exit_cleanup);
         if (em->enabled)
-            info("%s kernel does not have necessary tracepoints.", NETDATA_DEFAULT_OOM_DISABLED_MSG);
+            netdata_log_info("%s kernel does not have necessary tracepoints.", NETDATA_DEFAULT_OOM_DISABLED_MSG);
         pthread_mutex_unlock(&ebpf_exit_cleanup);
 
         goto endoomkill;

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -1844,7 +1844,7 @@ static void fill_last_nv_dimension(netdata_socket_plot_t *ptr, int is_outbound)
     fill_resolved_name(ptr, hostname,  10 + NETDATA_DOTS_PROTOCOL_COMBINED_LENGTH, service_name, is_outbound);
 
 #ifdef NETDATA_INTERNAL_CHECKS
-    info("Last %s dimension added: ID = %u, IP = OTHER, NAME = %s, DIM1 = %s, DIM2 = %s, DIM3 = %s",
+    netdata_log_info("Last %s dimension added: ID = %u, IP = OTHER, NAME = %s, DIM1 = %s, DIM2 = %s, DIM3 = %s",
          (is_outbound)?"outbound":"inbound", network_viewer_opt.max_dim - 1, ptr->resolved_name,
          ptr->dimension_recv, ptr->dimension_sent, ptr->dimension_retransmit);
 #endif
@@ -1932,7 +1932,7 @@ static void store_socket_inside_avl(netdata_vector_plot_t *out, netdata_socket_t
 #ifdef NETDATA_INTERNAL_CHECKS
         char iptext[INET6_ADDRSTRLEN];
         if (inet_ntop(family, &w->index.daddr.addr8, iptext, sizeof(iptext)))
-            info("New %s dimension added: ID = %u, IP = %s, NAME = %s, DIM1 = %s, DIM2 = %s, DIM3 = %s",
+            netdata_log_info("New %s dimension added: ID = %u, IP = %s, NAME = %s, DIM1 = %s, DIM2 = %s, DIM3 = %s",
                  (out == &inbound_vectors)?"inbound":"outbound", curr, iptext, w->resolved_name,
                  w->dimension_recv, w->dimension_sent, w->dimension_retransmit);
 #endif
@@ -2120,7 +2120,7 @@ void update_listen_table(uint16_t value, uint16_t proto, netdata_passive_connect
     fill_nv_port_list(w, value, proto, in);
 
 #ifdef NETDATA_INTERNAL_CHECKS
-    info("The network viewer is monitoring inbound connections for port %u", ntohs(value));
+    netdata_log_info("The network viewer is monitoring inbound connections for port %u", ntohs(value));
 #endif
 }
 
@@ -3044,14 +3044,14 @@ static inline void fill_port_list(ebpf_network_viewer_port_list_t **out, ebpf_ne
             uint16_t cmp_last = ntohs(move->last);
             if (cmp_first <= first && first <= cmp_last  &&
                 cmp_first <= last && last <= cmp_last ) {
-                info("The range/value (%u, %u) is inside the range/value (%u, %u) already inserted, it will be ignored.",
+                netdata_log_info("The range/value (%u, %u) is inside the range/value (%u, %u) already inserted, it will be ignored.",
                      first, last, cmp_first, cmp_last);
                 freez(in->value);
                 freez(in);
                 return;
             } else if (first <= cmp_first && cmp_first <= last  &&
                        first <= cmp_last && cmp_last <= last) {
-                info("The range (%u, %u) is bigger than previous range (%u, %u) already inserted, the previous will be ignored.",
+                netdata_log_info("The range (%u, %u) is bigger than previous range (%u, %u) already inserted, the previous will be ignored.",
                      first, last, cmp_first, cmp_last);
                 freez(move->value);
                 move->value = in->value;
@@ -3071,7 +3071,7 @@ static inline void fill_port_list(ebpf_network_viewer_port_list_t **out, ebpf_ne
     }
 
 #ifdef NETDATA_INTERNAL_CHECKS
-    info("Adding values %s( %u, %u) to %s port list used on network viewer",
+    netdata_log_info("Adding values %s( %u, %u) to %s port list used on network viewer",
          in->value, ntohs(in->first), ntohs(in->last),
          (*out == network_viewer_opt.included_port)?"included":"excluded");
 #endif
@@ -3091,7 +3091,7 @@ static void parse_service_list(void **out, char *service)
         serv = getservbyname((const char *)service, "udp");
 
     if (!serv) {
-        info("Cannot resolv the service '%s' with protocols TCP and UDP, it will be ignored", service);
+        netdata_log_info("Cannot resolv the service '%s' with protocols TCP and UDP, it will be ignored", service);
         return;
     }
 
@@ -3301,7 +3301,7 @@ void ebpf_fill_ip_list(ebpf_network_viewer_ip_list_t **out, ebpf_network_viewer_
         while (move) {
             if (in->ver == move->ver &&
                 ebpf_is_ip_inside_range(&move->first, &move->last, &in->first, &in->last, in->ver)) {
-                info("The range/value (%s) is inside the range/value (%s) already inserted, it will be ignored.",
+                netdata_log_info("The range/value (%s) is inside the range/value (%s) already inserted, it will be ignored.",
                      in->value, move->value);
                 freez(in->value);
                 freez(in);
@@ -3319,14 +3319,14 @@ void ebpf_fill_ip_list(ebpf_network_viewer_ip_list_t **out, ebpf_network_viewer_
 #ifdef NETDATA_INTERNAL_CHECKS
     char first[256], last[512];
     if (in->ver == AF_INET) {
-        info("Adding values %s: (%u - %u) to %s IP list \"%s\" used on network viewer",
+        netdata_log_info("Adding values %s: (%u - %u) to %s IP list \"%s\" used on network viewer",
              in->value, in->first.addr32[0], in->last.addr32[0],
              (*out == network_viewer_opt.included_ips)?"included":"excluded",
              table);
     } else {
         if (inet_ntop(AF_INET6, in->first.addr8, first, INET6_ADDRSTRLEN) &&
             inet_ntop(AF_INET6, in->last.addr8, last, INET6_ADDRSTRLEN))
-            info("Adding values %s - %s to %s IP list \"%s\" used on network viewer",
+            netdata_log_info("Adding values %s - %s to %s IP list \"%s\" used on network viewer",
                  first, last,
                  (*out == network_viewer_opt.included_ips)?"included":"excluded",
                  table);
@@ -3373,7 +3373,7 @@ static void ebpf_parse_ip_list(void **out, char *ip)
         select = (*end == '/') ? 0 : 1;
         *end++ = '\0';
         if (*end == '!') {
-            info("The exclusion cannot be in the second part of the range %s, it will be ignored.", ipdup);
+            netdata_log_info("The exclusion cannot be in the second part of the range %s, it will be ignored.", ipdup);
             goto cleanipdup;
         }
 
@@ -3384,7 +3384,7 @@ static void ebpf_parse_ip_list(void **out, char *ip)
 
             select = (int) str2i(end);
             if (select < NETDATA_MINIMUM_IPV4_CIDR || select > NETDATA_MAXIMUM_IPV4_CIDR) {
-                info("The specified CIDR %s is not valid, the IP %s will be ignored.", end, ip);
+                netdata_log_info("The specified CIDR %s is not valid, the IP %s will be ignored.", end, ip);
                 goto cleanipdup;
             }
 
@@ -3400,7 +3400,7 @@ static void ebpf_parse_ip_list(void **out, char *ip)
                 ipv4_convert.s_addr = ipv4_test;
                 char ipv4_msg[INET_ADDRSTRLEN];
                 if(inet_ntop(AF_INET, &ipv4_convert, ipv4_msg, INET_ADDRSTRLEN))
-                    info("The network value of CIDR %s was updated for %s .", ipdup, ipv4_msg);
+                    netdata_log_info("The network value of CIDR %s was updated for %s .", ipdup, ipv4_msg);
             }
         } else { // Range
             select = ip2nl(first.addr8, ip, AF_INET, ipdup);
@@ -3413,7 +3413,7 @@ static void ebpf_parse_ip_list(void **out, char *ip)
         }
 
         if (htonl(first.addr32[0]) > htonl(last.addr32[0])) {
-            info("The specified range %s is invalid, the second address is smallest than the first, it will be ignored.",
+            netdata_log_info("The specified range %s is invalid, the second address is smallest than the first, it will be ignored.",
                  ipdup);
             goto cleanipdup;
         }
@@ -3427,7 +3427,7 @@ static void ebpf_parse_ip_list(void **out, char *ip)
         } else if (*end == '-') {
             *end++ = 0x00;
             if (*end == '!') {
-                info("The exclusion cannot be in the second part of the range %s, it will be ignored.", ipdup);
+                netdata_log_info("The exclusion cannot be in the second part of the range %s, it will be ignored.", ipdup);
                 goto cleanipdup;
             }
 
@@ -3441,13 +3441,13 @@ static void ebpf_parse_ip_list(void **out, char *ip)
         } else { // CIDR
             *end++ = 0x00;
             if (*end == '!') {
-                info("The exclusion cannot be in the second part of the range %s, it will be ignored.", ipdup);
+                netdata_log_info("The exclusion cannot be in the second part of the range %s, it will be ignored.", ipdup);
                 goto cleanipdup;
             }
 
             select = str2i(end);
             if (select < 0 || select > 128) {
-                info("The CIDR %s is not valid, the address %s will be ignored.", end, ip);
+                netdata_log_info("The CIDR %s is not valid, the address %s will be ignored.", end, ip);
                 goto cleanipdup;
             }
 
@@ -3469,14 +3469,14 @@ static void ebpf_parse_ip_list(void **out, char *ip)
 
                 char ipv6_msg[INET6_ADDRSTRLEN];
                 if(inet_ntop(AF_INET6, &ipv6_convert, ipv6_msg, INET6_ADDRSTRLEN))
-                    info("The network value of CIDR %s was updated for %s .", ipdup, ipv6_msg);
+                    netdata_log_info("The network value of CIDR %s was updated for %s .", ipdup, ipv6_msg);
             }
         }
 
         if ((be64toh(*(uint64_t *)&first.addr32[2]) > be64toh(*(uint64_t *)&last.addr32[2]) &&
              !memcmp(first.addr32, last.addr32, 2*sizeof(uint32_t))) ||
             (be64toh(*(uint64_t *)&first.addr32) > be64toh(*(uint64_t *)&last.addr32)) ) {
-            info("The specified range %s is invalid, the second address is smallest than the first, it will be ignored.",
+            netdata_log_info("The specified range %s is invalid, the second address is smallest than the first, it will be ignored.",
                  ipdup);
             goto cleanipdup;
         }
@@ -3580,7 +3580,7 @@ static void parse_port_list(void **out, char *range)
     if (likely(*end)) {
         *end++ = '\0';
         if (*end == '!') {
-            info("The exclusion cannot be in the second part of the range, the range %s will be ignored.", copied);
+            netdata_log_info("The exclusion cannot be in the second part of the range, the range %s will be ignored.", copied);
             freez(copied);
             return;
         }
@@ -3591,7 +3591,7 @@ static void parse_port_list(void **out, char *range)
 
     first = str2i((const char *)range);
     if (first < NETDATA_MINIMUM_PORT_VALUE || first > NETDATA_MAXIMUM_PORT_VALUE) {
-        info("The first port %d of the range \"%s\" is invalid and it will be ignored!", first, copied);
+        netdata_log_info("The first port %d of the range \"%s\" is invalid and it will be ignored!", first, copied);
         freez(copied);
         return;
     }
@@ -3600,13 +3600,13 @@ static void parse_port_list(void **out, char *range)
         last = first;
 
     if (last < NETDATA_MINIMUM_PORT_VALUE || last > NETDATA_MAXIMUM_PORT_VALUE) {
-        info("The second port %d of the range \"%s\" is invalid and the whole range will be ignored!", last, copied);
+        netdata_log_info("The second port %d of the range \"%s\" is invalid and the whole range will be ignored!", last, copied);
         freez(copied);
         return;
     }
 
     if (first > last) {
-        info("The specified order %s is wrong, the smallest value is always the first, it will be ignored!", copied);
+        netdata_log_info("The specified order %s is wrong, the smallest value is always the first, it will be ignored!", copied);
         freez(copied);
         return;
     }
@@ -3646,7 +3646,7 @@ static void read_max_dimension(struct config *cfg)
 
     maxdim /= 2;
     if (!maxdim) {
-        info("The number of dimensions is too small (%u), we are setting it to minimum 2", network_viewer_opt.max_dim);
+        netdata_log_info("The number of dimensions is too small (%u), we are setting it to minimum 2", network_viewer_opt.max_dim);
         network_viewer_opt.max_dim = 1;
         return;
     }
@@ -3714,7 +3714,7 @@ static void link_hostname(ebpf_network_viewer_hostname_list_t **out, ebpf_networ
         ebpf_network_viewer_hostname_list_t *move = *out;
         for (; move->next ; move = move->next ) {
             if (move->hash == in->hash && !strcmp(move->value, in->value)) {
-                info("The hostname %s was already inserted, it will be ignored.", in->value);
+                netdata_log_info("The hostname %s was already inserted, it will be ignored.", in->value);
                 freez(in->value);
                 simple_pattern_free(in->value_pattern);
                 freez(in);
@@ -3727,7 +3727,7 @@ static void link_hostname(ebpf_network_viewer_hostname_list_t **out, ebpf_networ
         *out = in;
     }
 #ifdef NETDATA_INTERNAL_CHECKS
-    info("Adding value %s to %s hostname list used on network viewer",
+    netdata_log_info("Adding value %s to %s hostname list used on network viewer",
          in->value,
          (*out == network_viewer_opt.included_hostnames)?"included":"excluded");
 #endif
@@ -3806,7 +3806,7 @@ void parse_network_viewer_section(struct config *cfg)
         value = appconfig_get(cfg, EBPF_NETWORK_VIEWER_SECTION, EBPF_CONFIG_HOSTNAMES, NULL);
         link_hostnames(value);
     } else {
-        info("Name resolution is disabled, collector will not parser \"hostnames\" list.");
+        netdata_log_info("Name resolution is disabled, collector will not parser \"hostnames\" list.");
     }
 
     value = appconfig_get(cfg, EBPF_NETWORK_VIEWER_SECTION,
@@ -3845,7 +3845,7 @@ static void link_dimension_name(char *port, uint32_t hash, char *value)
     } else {
         for (; names->next; names = names->next) {
             if (names->port == w->port) {
-                info("Duplicated definition for a service, the name %s will be ignored. ", names->name);
+                netdata_log_info("Duplicated definition for a service, the name %s will be ignored. ", names->name);
                 freez(names->name);
                 names->name = w->name;
                 names->hash = w->hash;
@@ -3857,7 +3857,7 @@ static void link_dimension_name(char *port, uint32_t hash, char *value)
     }
 
 #ifdef NETDATA_INTERNAL_CHECKS
-    info("Adding values %s( %u) to dimension name list used on network viewer", w->name, htons(w->port));
+    netdata_log_info("Adding values %s( %u) to dimension name list used on network viewer", w->name, htons(w->port));
 #endif
 }
 

--- a/collectors/ebpf.plugin/ebpf_sync.c
+++ b/collectors/ebpf.plugin/ebpf_sync.c
@@ -373,7 +373,7 @@ static int ebpf_sync_initialize_syscall(ebpf_module_t *em)
                         }
                     }
                 } else {
-                    info("Cannot find syscall %s we are not going to monitor it.", syscall);
+                    netdata_log_info("Cannot find syscall %s we are not going to monitor it.", syscall);
                     w->enabled = false;
                 }
 

--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -1017,7 +1017,7 @@ static inline PARSER_RC pluginsd_flush(char **words __maybe_unused, size_t num_w
 }
 
 static inline PARSER_RC pluginsd_disable(char **words __maybe_unused, size_t num_words __maybe_unused, PARSER *parser) {
-    info("PLUGINSD: plugin called DISABLE. Disabling it.");
+    netdata_log_info("PLUGINSD: plugin called DISABLE. Disabling it.");
     parser->user.enabled = 0;
     return PARSER_RC_STOP;
 }
@@ -1796,7 +1796,7 @@ static inline PARSER_RC pluginsd_end_v2(char **words __maybe_unused, size_t num_
 }
 
 static inline PARSER_RC pluginsd_exit(char **words __maybe_unused, size_t num_words __maybe_unused, PARSER *parser __maybe_unused) {
-    info("PLUGINSD: plugin called EXIT.");
+    netdata_log_info("PLUGINSD: plugin called EXIT.");
     return PARSER_RC_STOP;
 }
 
@@ -2173,7 +2173,7 @@ int pluginsd_parser_unittest(void) {
     }
     usec_t ended = now_realtime_usec();
 
-    info("Parsed %zu lines in %0.2f secs, %0.2f klines/sec", count,
+    netdata_log_info("Parsed %zu lines in %0.2f secs, %0.2f klines/sec", count,
          (double)(ended - started) / (double)USEC_PER_SEC,
          (double)count / ((double)(ended - started) / (double)USEC_PER_SEC) / 1000.0);
 

--- a/collectors/timex.plugin/plugin_timex.c
+++ b/collectors/timex.plugin/plugin_timex.c
@@ -37,7 +37,7 @@ static void timex_main_cleanup(void *ptr)
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-    info("cleaning up...");
+    netdata_log_info("cleaning up...");
 
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
@@ -57,7 +57,7 @@ void *timex_main(void *ptr)
     int do_offset = config_get_boolean(CONFIG_SECTION_TIMEX, "time offset", CONFIG_BOOLEAN_YES);
 
     if (unlikely(do_sync == CONFIG_BOOLEAN_NO && do_offset == CONFIG_BOOLEAN_NO)) {
-        info("No charts to show");
+        netdata_log_info("No charts to show");
         goto exit;
     }
 

--- a/collectors/xenstat.plugin/xenstat_plugin.c
+++ b/collectors/xenstat.plugin/xenstat_plugin.c
@@ -1066,7 +1066,7 @@ int main(int argc, char **argv) {
 
     libxl_ctx_free(ctx);
     xenstat_uninit(xhandle);
-    info("XENSTAT process exiting");
+    netdata_log_info("XENSTAT process exiting");
     
     return 0;
 }

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -314,7 +314,7 @@ void analytics_alarms_notifications(void)
         sizeof(char) * (strlen(netdata_configured_primary_plugins_dir) + strlen("alarm-notify.sh dump_methods") + 2));
     sprintf(script, "%s/%s", netdata_configured_primary_plugins_dir, "alarm-notify.sh");
     if (unlikely(access(script, R_OK) != 0)) {
-        info("Alarm notify script %s not found.", script);
+        netdata_log_info("Alarm notify script %s not found.", script);
         freez(script);
         return;
     }
@@ -709,13 +709,13 @@ void get_system_timezone(void)
     // use the TZ variable
     if (tz && *tz && *tz != ':') {
         timezone = tz;
-        info("TIMEZONE: using TZ variable '%s'", timezone);
+        netdata_log_info("TIMEZONE: using TZ variable '%s'", timezone);
     }
 
     // use the contents of /etc/timezone
     if (!timezone && !read_file("/etc/timezone", buffer, FILENAME_MAX)) {
         timezone = buffer;
-        info("TIMEZONE: using the contents of /etc/timezone");
+        netdata_log_info("TIMEZONE: using the contents of /etc/timezone");
     }
 
     // read the link /etc/localtime
@@ -731,7 +731,7 @@ void get_system_timezone(void)
             char *s = strstr(buffer, cmp);
             if (s && s[cmp_len]) {
                 timezone = &s[cmp_len];
-                info("TIMEZONE: using the link of /etc/localtime: '%s'", timezone);
+                netdata_log_info("TIMEZONE: using the link of /etc/localtime: '%s'", timezone);
             }
         } else
             buffer[0] = '\0';
@@ -751,14 +751,14 @@ void get_system_timezone(void)
             else {
                 buffer[FILENAME_MAX] = '\0';
                 timezone = buffer;
-                info("TIMEZONE: using strftime(): '%s'", timezone);
+                netdata_log_info("TIMEZONE: using strftime(): '%s'", timezone);
             }
         }
     }
 
     if (timezone && *timezone) {
         // make sure it does not have illegal characters
-        // info("TIMEZONE: fixing '%s'", timezone);
+        // netdata_log_info("TIMEZONE: fixing '%s'", timezone);
 
         size_t len = strlen(timezone);
         char tmp[len + 1];
@@ -774,7 +774,7 @@ void get_system_timezone(void)
         *d = '\0';
         strncpyz(buffer, tmp, len);
         timezone = buffer;
-        info("TIMEZONE: fixed as '%s'", timezone);
+        netdata_log_info("TIMEZONE: fixed as '%s'", timezone);
     }
 
     if (!timezone || !*timezone)
@@ -955,7 +955,7 @@ void send_statistics(const char *action, const char *action_result, const char *
             sprintf(as_script, "%s/%s", netdata_configured_primary_plugins_dir, "anonymous-statistics.sh");
             if (unlikely(access(as_script, R_OK) != 0)) {
                 netdata_anonymous_statistics_enabled = 0;
-                info("Anonymous statistics script %s not found.", as_script);
+                netdata_log_info("Anonymous statistics script %s not found.", as_script);
                 freez(as_script);
             } else {
                 netdata_anonymous_statistics_enabled = 1;
@@ -1026,7 +1026,7 @@ void send_statistics(const char *action, const char *action_result, const char *
         analytics_data.netdata_config_oom_score,
         analytics_data.netdata_prebuilt_distro);
 
-    info("%s '%s' '%s' '%s'", as_script, action, action_result, action_data);
+    netdata_log_info("%s '%s' '%s' '%s'", as_script, action, action_result, action_data);
 
     FILE *fp_child_input;
     FILE *fp_child_output = netdata_popen(command_to_run, &command_pid, &fp_child_input);

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -143,7 +143,7 @@ static cmd_status_t cmd_reload_health_execute(char *args, char **message)
     (void)message;
 
     error_log_limit_unlimited();
-    info("COMMAND: Reloading HEALTH configuration.");
+    netdata_log_info("COMMAND: Reloading HEALTH configuration.");
     health_reload();
     error_log_limit_reset();
 
@@ -156,9 +156,9 @@ static cmd_status_t cmd_save_database_execute(char *args, char **message)
     (void)message;
 
     error_log_limit_unlimited();
-    info("COMMAND: Saving databases.");
+    netdata_log_info("COMMAND: Saving databases.");
     rrdhost_save_all();
-    info("COMMAND: Databases saved.");
+    netdata_log_info("COMMAND: Databases saved.");
     error_log_limit_reset();
 
     return CMD_STATUS_SUCCESS;
@@ -170,7 +170,7 @@ static cmd_status_t cmd_reopen_logs_execute(char *args, char **message)
     (void)message;
 
     error_log_limit_unlimited();
-    info("COMMAND: Reopening all log files.");
+    netdata_log_info("COMMAND: Reopening all log files.");
     reopen_all_log_files();
     error_log_limit_reset();
 
@@ -183,7 +183,7 @@ static cmd_status_t cmd_exit_execute(char *args, char **message)
     (void)message;
 
     error_log_limit_unlimited();
-    info("COMMAND: Cleaning up to exit.");
+    netdata_log_info("COMMAND: Cleaning up to exit.");
     netdata_cleanup_and_exit(0);
     exit(0);
 
@@ -205,12 +205,12 @@ static cmd_status_t cmd_reload_claiming_state_execute(char *args, char **message
     (void)args;
     (void)message;
 #if defined(DISABLE_CLOUD) || !defined(ENABLE_ACLK)
-    info("The claiming feature has been explicitly disabled");
+    netdata_log_info("The claiming feature has been explicitly disabled");
     *message = strdupz("This agent cannot be claimed, it was built without support for Cloud");
     return CMD_STATUS_FAILURE;
 #endif
     error_log_limit_unlimited();
-    info("COMMAND: Reloading Agent Claiming configuration.");
+    netdata_log_info("COMMAND: Reloading Agent Claiming configuration.");
     load_claiming_state();
     registry_update_cloud_base_url();
     rrdpush_send_claimed_id(localhost);
@@ -221,7 +221,7 @@ static cmd_status_t cmd_reload_claiming_state_execute(char *args, char **message
 static cmd_status_t cmd_reload_labels_execute(char *args, char **message)
 {
     (void)args;
-    info("COMMAND: reloading host labels.");
+    netdata_log_info("COMMAND: reloading host labels.");
     reload_host_labels();
 
     BUFFER *wb = buffer_create(10, NULL);
@@ -272,7 +272,7 @@ static cmd_status_t cmd_read_config_execute(char *args, char **message)
 static cmd_status_t cmd_write_config_execute(char *args, char **message)
 {
     UNUSED(message);
-    info("write-config %s", args);
+    netdata_log_info("write-config %s", args);
     size_t n = strlen(args);
     char *separator = strchr(args,'|');
     if (separator == NULL)
@@ -296,7 +296,7 @@ static cmd_status_t cmd_write_config_execute(char *args, char **message)
     struct config *tmp_config = strcmp(conf_file, "cloud") ? &netdata_config : &cloud_config;
 
     appconfig_set(tmp_config, temp + offset + 1, temp + offset2 + 1, temp + offset3 + 1);
-    info("write-config conf_file=%s section=%s key=%s value=%s",conf_file, temp + offset + 1, temp + offset2 + 1,
+    netdata_log_info("write-config conf_file=%s section=%s key=%s value=%s",conf_file, temp + offset + 1, temp + offset2 + 1,
          temp + offset3 + 1);
     freez(temp);
     return CMD_STATUS_SUCCESS;
@@ -313,7 +313,7 @@ static cmd_status_t cmd_ping_execute(char *args, char **message)
 
 static cmd_status_t cmd_aclk_state(char *args, char **message)
 {
-    info("COMMAND: Reopening aclk/cloud state.");
+    netdata_log_info("COMMAND: Reopening aclk/cloud state.");
     if (strstr(args, "json"))
         *message = aclk_state_json();
     else
@@ -409,7 +409,7 @@ static void pipe_write_cb(uv_write_t* req, int status)
     uv_close((uv_handle_t *)client, pipe_close_cb);
     --clients;
     buffer_free(client->data);
-    info("Command Clients = %u\n", clients);
+    netdata_log_info("Command Clients = %u\n", clients);
 }
 
 static inline void add_char_to_command_reply(BUFFER *reply_string, unsigned *reply_string_size, char character)
@@ -534,9 +534,9 @@ static void pipe_read_cb(uv_stream_t *client, ssize_t nread, const uv_buf_t *buf
     struct command_context *cmd_ctx = (struct command_context *)client;
 
     if (0 == nread) {
-        info("%s: Zero bytes read by command pipe.", __func__);
+        netdata_log_info("%s: Zero bytes read by command pipe.", __func__);
     } else if (UV_EOF == nread) {
-        info("EOF found in command pipe.");
+        netdata_log_info("EOF found in command pipe.");
         parse_commands(cmd_ctx);
     } else if (nread < 0) {
         error("%s: %s", __func__, uv_strerror(nread));
@@ -559,7 +559,7 @@ static void pipe_read_cb(uv_stream_t *client, ssize_t nread, const uv_buf_t *buf
     if (nread < 0 && UV_EOF != nread) {
         uv_close((uv_handle_t *)client, pipe_close_cb);
         --clients;
-        info("Command Clients = %u\n", clients);
+        netdata_log_info("Command Clients = %u\n", clients);
     }
 }
 
@@ -595,7 +595,7 @@ static void connection_cb(uv_stream_t *server, int status)
     }
 
     ++clients;
-    info("Command Clients = %u\n", clients);
+    netdata_log_info("Command Clients = %u\n", clients);
     /* Start parsing a new command */
     cmd_ctx->command_string_size = 0;
     cmd_ctx->command_string[0] = '\0';
@@ -605,7 +605,7 @@ static void connection_cb(uv_stream_t *server, int status)
         error("uv_read_start(): %s", uv_strerror(ret));
         uv_close((uv_handle_t *)client, pipe_close_cb);
         --clients;
-        info("Command Clients = %u\n", clients);
+        netdata_log_info("Command Clients = %u\n", clients);
         return;
     }
 }
@@ -659,7 +659,7 @@ static void command_thread(void *arg)
     ret = uv_listen((uv_stream_t *)&server_pipe, SOMAXCONN, connection_cb);
     if (ret) {
         /* Fallback to backlog of 1 */
-        info("uv_listen() failed with backlog = %d, falling back to backlog = 1.", SOMAXCONN);
+        netdata_log_info("uv_listen() failed with backlog = %d, falling back to backlog = 1.", SOMAXCONN);
         ret = uv_listen((uv_stream_t *)&server_pipe, 1, connection_cb);
     }
     if (ret) {
@@ -677,12 +677,12 @@ static void command_thread(void *arg)
         uv_run(loop, UV_RUN_DEFAULT);
     }
     /* cleanup operations of the event loop */
-    info("Shutting down command event loop.");
+    netdata_log_info("Shutting down command event loop.");
     uv_close((uv_handle_t *)&async, NULL);
     uv_close((uv_handle_t*)&server_pipe, NULL);
     uv_run(loop, UV_RUN_DEFAULT); /* flush all libuv handles */
 
-    info("Shutting down command loop complete.");
+    netdata_log_info("Shutting down command loop complete.");
     fatal_assert(0 == uv_loop_close(loop));
     freez(loop);
 
@@ -718,7 +718,7 @@ void commands_init(void)
     if (command_server_initialized)
         return;
 
-    info("Initializing command server.");
+    netdata_log_info("Initializing command server.");
     for (i = 0 ; i < CMD_TOTAL_COMMANDS ; ++i) {
         fatal_assert(0 == uv_mutex_init(&command_lock_array[i]));
     }
@@ -758,7 +758,7 @@ void commands_exit(void)
         return;
 
     command_thread_shutdown = 1;
-    info("Shutting down command server.");
+    netdata_log_info("Shutting down command server.");
     /* wake up event loop */
     fatal_assert(0 == uv_async_send(&async));
     fatal_assert(0 == uv_thread_join(&thread));
@@ -767,6 +767,6 @@ void commands_exit(void)
         uv_mutex_destroy(&command_lock_array[i]);
     }
     uv_rwlock_destroy(&exclusive_rwlock);
-    info("Command server has stopped.");
+    netdata_log_info("Command server has stopped.");
     command_server_initialized = 0;
 }

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -121,7 +121,7 @@ int become_user(const char *username, int pid_fd) {
     gid_t gid = pw->pw_gid;
 
     if (am_i_root)
-        info("I am root, so checking permissions");
+        netdata_log_info("I am root, so checking permissions");
 
     prepare_required_directories(uid, gid);
 
@@ -234,11 +234,11 @@ static void oom_score_adj(void) {
     if(s && *s && (isdigit(*s) || *s == '-' || *s == '+'))
         wanted_score = atoll(s);
     else if(s && !strcmp(s, "keep")) {
-        info("Out-Of-Memory (OOM) kept as-is (running with %d)", (int) old_score);
+        netdata_log_info("Out-Of-Memory (OOM) kept as-is (running with %d)", (int) old_score);
         return;
     }
     else {
-        info("Out-Of-Memory (OOM) score not changed due to non-numeric setting: '%s' (running with %d)", s, (int)old_score);
+        netdata_log_info("Out-Of-Memory (OOM) score not changed due to non-numeric setting: '%s' (running with %d)", s, (int)old_score);
         return;
     }
 
@@ -253,7 +253,7 @@ static void oom_score_adj(void) {
     }
 
     if(old_score == wanted_score) {
-        info("Out-Of-Memory (OOM) score is already set to the wanted value %d", (int)old_score);
+        netdata_log_info("Out-Of-Memory (OOM) score is already set to the wanted value %d", (int)old_score);
         return;
     }
 
@@ -269,7 +269,7 @@ static void oom_score_adj(void) {
             if(read_single_signed_number_file("/proc/self/oom_score_adj", &final_score))
                 error("Adjusted my Out-Of-Memory (OOM) score to %d, but cannot verify it.", (int)wanted_score);
             else if(final_score == wanted_score)
-                info("Adjusted my Out-Of-Memory (OOM) score from %d to %d.", (int)old_score, (int)final_score);
+                netdata_log_info("Adjusted my Out-Of-Memory (OOM) score from %d to %d.", (int)old_score, (int)final_score);
             else
                 error("Adjusted my Out-Of-Memory (OOM) score from %d to %d, but it has been set to %d.", (int)old_score, (int)wanted_score, (int)final_score);
             analytics_report_oom_score(final_score);
@@ -355,19 +355,19 @@ static void sched_getscheduler_report(void) {
                         return;
                     }
                     else {
-                        info("Running with process scheduling policy '%s', priority %d", scheduler_defaults[i].name, param.sched_priority);
+                        netdata_log_info("Running with process scheduling policy '%s', priority %d", scheduler_defaults[i].name, param.sched_priority);
                     }
                 }
                 else if(scheduler_defaults[i].flags & SCHED_FLAG_USE_NICE) {
                     #ifdef HAVE_GETPRIORITY
                     int n = getpriority(PRIO_PROCESS, 0);
-                    info("Running with process scheduling policy '%s', nice level %d", scheduler_defaults[i].name, n);
+                    netdata_log_info("Running with process scheduling policy '%s', nice level %d", scheduler_defaults[i].name, n);
                     #else // !HAVE_GETPRIORITY
-                    info("Running with process scheduling policy '%s'", scheduler_defaults[i].name);
+                    netdata_log_info("Running with process scheduling policy '%s'", scheduler_defaults[i].name);
                     #endif // !HAVE_GETPRIORITY
                 }
                 else {
-                    info("Running with process scheduling policy '%s'", scheduler_defaults[i].name);
+                    netdata_log_info("Running with process scheduling policy '%s'", scheduler_defaults[i].name);
                 }
 
                 return;
@@ -436,7 +436,7 @@ static void sched_setscheduler_set(void) {
             error("Cannot adjust netdata scheduling policy to %s (%d), with priority %d. Falling back to nice.", name, policy, priority);
         }
         else {
-            info("Adjusted netdata scheduling policy to %s (%d), with priority %d.", name, policy, priority);
+            netdata_log_info("Adjusted netdata scheduling policy to %s (%d), with priority %d.", name, policy, priority);
             if(!(flags & SCHED_FLAG_USE_NICE))
                 goto report;
         }

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -4123,7 +4123,7 @@ static void global_statistics_cleanup(void *ptr)
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-    info("cleaning up...");
+    netdata_log_info("cleaning up...");
 
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
@@ -4194,7 +4194,7 @@ static void global_statistics_workers_cleanup(void *ptr)
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-    info("cleaning up...");
+    netdata_log_info("cleaning up...");
 
     worker_utilization_finish();
 
@@ -4238,7 +4238,7 @@ static void global_statistics_sqlite3_cleanup(void *ptr)
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-    info("cleaning up...");
+    netdata_log_info("cleaning up...");
 
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -265,7 +265,7 @@ static bool service_wait_exit(SERVICE_TYPE service, usec_t timeout_ut) {
 
                 buffer_flush(service_list);
                 service_to_buffer(service_list, running_services);
-                info("SERVICE CONTROL: waiting for the following %zu services [ %s] to exit: %s",
+                netdata_log_info("SERVICE CONTROL: waiting for the following %zu services [ %s] to exit: %s",
                      running, buffer_tostring(service_list),
                      running <= 10 ? buffer_tostring(thread_list) : "");
             }
@@ -280,7 +280,7 @@ static bool service_wait_exit(SERVICE_TYPE service, usec_t timeout_ut) {
     if(running) {
         buffer_flush(service_list);
         service_to_buffer(service_list, running_services);
-        info("SERVICE CONTROL: "
+        netdata_log_info("SERVICE CONTROL: "
              "the following %zu service(s) [ %s] take too long to exit: %s; "
              "giving up on them...",
              running, buffer_tostring(service_list),
@@ -297,9 +297,9 @@ static bool service_wait_exit(SERVICE_TYPE service, usec_t timeout_ut) {
     {                                                   \
         usec_t now_ut = now_monotonic_usec();           \
         if(prev_msg)                                    \
-            info("NETDATA SHUTDOWN: in %7llu ms, %s%s - next: %s", (now_ut - last_ut) / USEC_PER_MS, (timeout)?"(TIMEOUT) ":"", prev_msg, msg); \
+            netdata_log_info("NETDATA SHUTDOWN: in %7llu ms, %s%s - next: %s", (now_ut - last_ut) / USEC_PER_MS, (timeout)?"(TIMEOUT) ":"", prev_msg, msg); \
         else                                            \
-            info("NETDATA SHUTDOWN: next: %s", msg);    \
+            netdata_log_info("NETDATA SHUTDOWN: next: %s", msg);    \
         last_ut = now_ut;                               \
         prev_msg = msg;                                 \
         timeout = false;                                \
@@ -314,7 +314,7 @@ void netdata_cleanup_and_exit(int ret) {
     bool timeout = false;
 
     error_log_limit_unlimited();
-    info("NETDATA SHUTDOWN: initializing shutdown with code %d...", ret);
+    netdata_log_info("NETDATA SHUTDOWN: initializing shutdown with code %d...", ret);
 
     send_statistics("EXIT", ret?"ERROR":"OK","-");
 
@@ -494,7 +494,7 @@ void netdata_cleanup_and_exit(int ret) {
     delta_shutdown_time("exit");
 
     usec_t ended_ut = now_monotonic_usec();
-    info("NETDATA SHUTDOWN: completed in %llu ms - netdata is now exiting - bye bye...", (ended_ut - started_ut) / USEC_PER_MS);
+    netdata_log_info("NETDATA SHUTDOWN: completed in %llu ms - netdata is now exiting - bye bye...", (ended_ut - started_ut) / USEC_PER_MS);
     exit(ret);
 }
 
@@ -641,7 +641,7 @@ static void set_nofile_limit(struct rlimit *rl) {
         return;
     }
 
-    info("resources control: allowed file descriptors: soft = %zu, max = %zu",
+    netdata_log_info("resources control: allowed file descriptors: soft = %zu, max = %zu",
          (size_t) rl->rlim_cur, (size_t) rl->rlim_max);
 
     // make the soft/hard limits equal
@@ -668,10 +668,10 @@ void cancel_main_threads() {
     for (i = 0; static_threads[i].name != NULL ; i++) {
         if (static_threads[i].enabled == NETDATA_MAIN_THREAD_RUNNING) {
             if (static_threads[i].thread) {
-                info("EXIT: Stopping main thread: %s", static_threads[i].name);
+                netdata_log_info("EXIT: Stopping main thread: %s", static_threads[i].name);
                 netdata_thread_cancel(*static_threads[i].thread);
             } else {
-                info("EXIT: No thread running (marking as EXITED): %s", static_threads[i].name);
+                netdata_log_info("EXIT: No thread running (marking as EXITED): %s", static_threads[i].name);
                 static_threads[i].enabled = NETDATA_MAIN_THREAD_EXITED;
             }
             found++;
@@ -682,7 +682,7 @@ void cancel_main_threads() {
 
     while(found && max > 0) {
         max -= step;
-        info("Waiting %d threads to finish...", found);
+        netdata_log_info("Waiting %d threads to finish...", found);
         sleep_usec(step);
         found = 0;
         for (i = 0; static_threads[i].name != NULL ; i++) {
@@ -698,7 +698,7 @@ void cancel_main_threads() {
         }
     }
     else
-        info("All threads finished.");
+        netdata_log_info("All threads finished.");
 
     for (i = 0; static_threads[i].name != NULL ; i++)
         freez(static_threads[i].thread);
@@ -1185,7 +1185,7 @@ static void get_netdata_configured_variables() {
     // https://github.com/netdata/netdata/pull/11222#issuecomment-868367920 for more information.
     if (rrdset_free_obsolete_time_s < 10) {
         rrdset_free_obsolete_time_s = 10;
-        info("The \"cleanup obsolete charts after seconds\" option was set to 10 seconds.");
+        netdata_log_info("The \"cleanup obsolete charts after seconds\" option was set to 10 seconds.");
         config_set_number(CONFIG_SECTION_DB, "cleanup obsolete charts after secs", rrdset_free_obsolete_time_s);
     }
 
@@ -1221,13 +1221,13 @@ int load_netdata_conf(char *filename, char overwrite_used) {
 
         ret = config_load(filename, overwrite_used, NULL);
         if(!ret) {
-            info("CONFIG: cannot load user config '%s'. Will try the stock version.", filename);
+            netdata_log_info("CONFIG: cannot load user config '%s'. Will try the stock version.", filename);
             freez(filename);
 
             filename = strdupz_path_subpath(netdata_configured_stock_config_dir, "netdata.conf");
             ret = config_load(filename, overwrite_used, NULL);
             if(!ret)
-                info("CONFIG: cannot load stock config '%s'. Running with internal defaults.", filename);
+                netdata_log_info("CONFIG: cannot load stock config '%s'. Running with internal defaults.", filename);
         }
 
         freez(filename);
@@ -1247,14 +1247,14 @@ int get_system_info(struct rrdhost_system_info *system_info) {
     script = mallocz(sizeof(char) * (strlen(netdata_configured_primary_plugins_dir) + strlen("system-info.sh") + 2));
     sprintf(script, "%s/%s", netdata_configured_primary_plugins_dir, "system-info.sh");
     if (unlikely(access(script, R_OK) != 0)) {
-        info("System info script %s not found.",script);
+        netdata_log_info("System info script %s not found.",script);
         freez(script);
         return 1;
     }
 
     pid_t command_pid;
 
-    info("Executing %s", script);
+    netdata_log_info("Executing %s", script);
 
     FILE *fp_child_input;
     FILE *fp_child_output = netdata_popen(script, &command_pid, &fp_child_input);
@@ -1275,10 +1275,10 @@ int get_system_info(struct rrdhost_system_info *system_info) {
                 coverity_remove_taint(value);
 
                 if(unlikely(rrdhost_set_system_info_variable(system_info, line, value))) {
-                    info("Unexpected environment variable %s=%s", line, value);
+                    netdata_log_info("Unexpected environment variable %s=%s", line, value);
                 }
                 else {
-                    info("%s=%s", line, value);
+                    netdata_log_info("%s=%s", line, value);
                     setenv(line, value, 1);
                 }
             }
@@ -1327,9 +1327,9 @@ void post_conf_load(char **user)
     {                                                   \
         usec_t now_ut = now_monotonic_usec();           \
         if(prev_msg)                                    \
-            info("NETDATA STARTUP: in %7llu ms, %s - next: %s", (now_ut - last_ut) / USEC_PER_MS, prev_msg, msg); \
+            netdata_log_info("NETDATA STARTUP: in %7llu ms, %s - next: %s", (now_ut - last_ut) / USEC_PER_MS, prev_msg, msg); \
         else                                            \
-            info("NETDATA STARTUP: next: %s", msg);    \
+            netdata_log_info("NETDATA STARTUP: next: %s", msg);    \
         last_ut = now_ut;                               \
         prev_msg = msg;                                 \
     }
@@ -1349,7 +1349,7 @@ int main(int argc, char **argv) {
     usec_t started_ut = now_monotonic_usec();
     usec_t last_ut = started_ut;
     const char *prev_msg = NULL;
-    // Initialize stderror avoiding coredump when info() or error() is called
+    // Initialize stderror avoiding coredump when netdata_log_info() or error() is called
     stderror = stderr;
 
     int i;
@@ -2018,7 +2018,7 @@ int main(int argc, char **argv) {
     if(become_daemon(dont_fork, user) == -1)
         fatal("Cannot daemonize myself.");
 
-    info("netdata started on pid %d.", getpid());
+    netdata_log_info("netdata started on pid %d.", getpid());
 
     delta_startup_time("initialize threads after fork");
 
@@ -2124,7 +2124,7 @@ int main(int argc, char **argv) {
     delta_startup_time("ready");
 
     usec_t ready_ut = now_monotonic_usec();
-    info("NETDATA STARTUP: completed in %llu ms. Enjoy real-time performance monitoring!", (ready_ut - started_ut) / USEC_PER_MS);
+    netdata_log_info("NETDATA STARTUP: completed in %llu ms. Enjoy real-time performance monitoring!", (ready_ut - started_ut) / USEC_PER_MS);
     netdata_ready = true;
 
     send_statistics("START", "-",  "-");

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -40,7 +40,7 @@ static void svc_rrddim_obsolete_to_archive(RRDDIM *rd) {
 
     const char *cache_filename = rrddim_cache_filename(rd);
     if(cache_filename) {
-        info("Deleting dimension file '%s'.", cache_filename);
+        netdata_log_info("Deleting dimension file '%s'.", cache_filename);
         if (unlikely(unlink(cache_filename) == -1))
             error("Cannot delete dimension file '%s'", cache_filename);
     }
@@ -91,7 +91,7 @@ static bool svc_rrdset_archive_obsolete_dimensions(RRDSET *st, bool all_dimensio
                     )) {
 
             if(dictionary_acquired_item_references(rd_dfe.item) == 1) {
-                info("Removing obsolete dimension '%s' (%s) of '%s' (%s).", rrddim_name(rd), rrddim_id(rd), rrdset_name(st), rrdset_id(st));
+                netdata_log_info("Removing obsolete dimension '%s' (%s) of '%s' (%s).", rrddim_name(rd), rrddim_id(rd), rrdset_name(st), rrdset_id(st));
                 svc_rrddim_obsolete_to_archive(rd);
             }
             else
@@ -227,7 +227,7 @@ restart_after_removal:
         if(!rrdhost_should_be_removed(host, protected_host, now))
             continue;
 
-        info("Host '%s' with machine guid '%s' is obsolete - cleaning up.", rrdhost_hostname(host), host->machine_guid);
+        netdata_log_info("Host '%s' with machine guid '%s' is obsolete - cleaning up.", rrdhost_hostname(host), host->machine_guid);
 
         if (rrdhost_option_check(host, RRDHOST_OPTION_DELETE_ORPHAN_HOST)
             /* don't delete multi-host DB host files */

--- a/daemon/signals.c
+++ b/daemon/signals.c
@@ -130,7 +130,7 @@ static void reap_child(pid_t pid) {
         if (errno != ECHILD)
             error("SIGNAL: waitid(%d): failed to wait for child", pid);
         else
-            info("SIGNAL: waitid(%d): failed - it seems the child is already reaped", pid);
+            netdata_log_info("SIGNAL: waitid(%d): failed - it seems the child is already reaped", pid);
         return;
     }
     else if (i.si_pid == 0) {
@@ -141,25 +141,25 @@ static void reap_child(pid_t pid) {
 
     switch (i.si_code) {
         case CLD_EXITED:
-            info("SIGNAL: reap_child(%d) exited with code: %d", pid, i.si_status);
+            netdata_log_info("SIGNAL: reap_child(%d) exited with code: %d", pid, i.si_status);
             break;
         case CLD_KILLED:
-            info("SIGNAL: reap_child(%d) killed by signal: %d", pid, i.si_status);
+            netdata_log_info("SIGNAL: reap_child(%d) killed by signal: %d", pid, i.si_status);
             break;
         case CLD_DUMPED:
-            info("SIGNAL: reap_child(%d) dumped core by signal: %d", pid, i.si_status);
+            netdata_log_info("SIGNAL: reap_child(%d) dumped core by signal: %d", pid, i.si_status);
             break;
         case CLD_STOPPED:
-            info("SIGNAL: reap_child(%d) stopped by signal: %d", pid, i.si_status);
+            netdata_log_info("SIGNAL: reap_child(%d) stopped by signal: %d", pid, i.si_status);
             break;
         case CLD_TRAPPED:
-            info("SIGNAL: reap_child(%d) trapped by signal: %d", pid, i.si_status);
+            netdata_log_info("SIGNAL: reap_child(%d) trapped by signal: %d", pid, i.si_status);
             break;
         case CLD_CONTINUED:
-            info("SIGNAL: reap_child(%d) continued by signal: %d", pid, i.si_status);
+            netdata_log_info("SIGNAL: reap_child(%d) continued by signal: %d", pid, i.si_status);
             break;
         default:
-            info("SIGNAL: reap_child(%d) gave us a SIGCHLD with code %d and status %d.", pid, i.si_code, i.si_status);
+            netdata_log_info("SIGNAL: reap_child(%d) gave us a SIGCHLD with code %d and status %d.", pid, i.si_code, i.si_status);
             break;
     }
 }
@@ -204,28 +204,28 @@ void signals_handle(void) {
                         switch (signals_waiting[i].action) {
                             case NETDATA_SIGNAL_RELOAD_HEALTH:
                                 error_log_limit_unlimited();
-                                info("SIGNAL: Received %s. Reloading HEALTH configuration...", name);
+                                netdata_log_info("SIGNAL: Received %s. Reloading HEALTH configuration...", name);
                                 error_log_limit_reset();
                                 execute_command(CMD_RELOAD_HEALTH, NULL, NULL);
                                 break;
 
                             case NETDATA_SIGNAL_SAVE_DATABASE:
                                 error_log_limit_unlimited();
-                                info("SIGNAL: Received %s. Saving databases...", name);
+                                netdata_log_info("SIGNAL: Received %s. Saving databases...", name);
                                 error_log_limit_reset();
                                 execute_command(CMD_SAVE_DATABASE, NULL, NULL);
                                 break;
 
                             case NETDATA_SIGNAL_REOPEN_LOGS:
                                 error_log_limit_unlimited();
-                                info("SIGNAL: Received %s. Reopening all log files...", name);
+                                netdata_log_info("SIGNAL: Received %s. Reopening all log files...", name);
                                 error_log_limit_reset();
                                 execute_command(CMD_REOPEN_LOGS, NULL, NULL);
                                 break;
 
                             case NETDATA_SIGNAL_EXIT_CLEANLY:
                                 error_log_limit_unlimited();
-                                info("SIGNAL: Received %s. Cleaning up to exit...", name);
+                                netdata_log_info("SIGNAL: Received %s. Cleaning up to exit...", name);
                                 commands_exit();
                                 netdata_cleanup_and_exit(0);
                                 exit(0);
@@ -240,7 +240,7 @@ void signals_handle(void) {
                                 break;
 
                             default:
-                                info("SIGNAL: Received %s. No signal handler configured. Ignoring it.", name);
+                                netdata_log_info("SIGNAL: Received %s. No signal handler configured. Ignoring it.", name);
                                 break;
                         }
                     }

--- a/database/contexts/rrdcontext.c
+++ b/database/contexts/rrdcontext.c
@@ -241,7 +241,7 @@ void rrdcontext_hub_checkpoint_command(void *ptr) {
     }
 
     if(rrdhost_flag_check(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS)) {
-        info("RRDCONTEXT: received checkpoint command for claim id '%s', node id '%s', while node '%s' has an active context streaming.",
+        netdata_log_info("RRDCONTEXT: received checkpoint command for claim id '%s', node id '%s', while node '%s' has an active context streaming.",
               cmd->claim_id, cmd->node_id, rrdhost_hostname(host));
 
         // disable it temporarily, so that our worker will not attempt to send messages in parallel

--- a/database/engine/cache.c
+++ b/database/engine/cache.c
@@ -2090,7 +2090,7 @@ void pgc_open_cache_to_journal_v2(PGC *cache, Word_t section, unsigned datafile_
 
     struct section_pages *sp = *section_pages_pptr;
     if(!spinlock_trylock(&sp->migration_to_v2_spinlock)) {
-        info("DBENGINE: migration to journal v2 for datafile %u is postponed, another jv2 indexer is already running for this section", datafile_fileno);
+        netdata_log_info("DBENGINE: migration to journal v2 for datafile %u is postponed, another jv2 indexer is already running for this section", datafile_fileno);
         pgc_ll_unlock(cache, &cache->hot);
         return;
     }
@@ -2353,7 +2353,7 @@ void *unittest_stress_test_collector(void *ptr) {
     heartbeat_init(&hb);
 
     while(!__atomic_load_n(&pgc_uts.stop, __ATOMIC_RELAXED)) {
-        // info("COLLECTOR %zu: collecting metrics %zu to %zu, from %ld to %lu", id, metric_start, metric_end, start_time_t, start_time_t + pgc_uts.points_per_page);
+        // netdata_log_info("COLLECTOR %zu: collecting metrics %zu to %zu, from %ld to %lu", id, metric_start, metric_end, start_time_t, start_time_t + pgc_uts.points_per_page);
 
         netdata_thread_disable_cancelability();
 
@@ -2483,7 +2483,7 @@ void *unittest_stress_test_service(void *ptr) {
 }
 
 static void unittest_stress_test_save_dirty_page_callback(PGC *cache __maybe_unused, PGC_ENTRY *entries_array __maybe_unused, PGC_PAGE **pages_array __maybe_unused, size_t entries __maybe_unused) {
-    // info("SAVE %zu pages", entries);
+    // netdata_log_info("SAVE %zu pages", entries);
     if(!pgc_uts.stop) {
         usec_t t = pgc_uts.time_per_flush_ut;
 
@@ -2623,7 +2623,7 @@ void unittest_stress_test(void) {
         if(stats.events_flush_critical > old_stats.events_flush_critical)
             flushing_status = "F";
 
-        info("PGS %5zuk +%4zuk/-%4zuk "
+        netdata_log_info("PGS %5zuk +%4zuk/-%4zuk "
              "| RF %5zuk "
              "| HOT %5zuk +%4zuk -%4zuk "
              "| DRT %s %5zuk +%4zuk -%4zuk "
@@ -2649,7 +2649,7 @@ void unittest_stress_test(void) {
 #endif
              );
     }
-    info("Waiting for threads to stop...");
+    netdata_log_info("Waiting for threads to stop...");
     __atomic_store_n(&pgc_uts.stop, true, __ATOMIC_RELAXED);
 
     netdata_thread_join(service_thread, NULL);

--- a/database/engine/datafile.c
+++ b/database/engine/datafile.c
@@ -338,7 +338,7 @@ static int load_data_file(struct rrdengine_datafile *datafile)
         ctx_fs_error(ctx);
         return fd;
     }
-    info("DBENGINE: initializing data file \"%s\".", path);
+    netdata_log_info("DBENGINE: initializing data file \"%s\".", path);
 
     ret = check_file_properties(file, &file_size, sizeof(struct rrdeng_df_sb));
     if (ret)
@@ -354,7 +354,7 @@ static int load_data_file(struct rrdengine_datafile *datafile)
     datafile->file = file;
     datafile->pos = file_size;
 
-    info("DBENGINE: data file \"%s\" initialized (size:%"PRIu64").", path, file_size);
+    netdata_log_info("DBENGINE: data file \"%s\" initialized (size:%"PRIu64").", path, file_size);
     return 0;
 
     error:
@@ -398,7 +398,7 @@ static int scan_data_files(struct rrdengine_instance *ctx)
         ctx_fs_error(ctx);
         return ret;
     }
-    info("DBENGINE: found %d files in path %s", ret, ctx->config.dbfiles_path);
+    netdata_log_info("DBENGINE: found %d files in path %s", ret, ctx->config.dbfiles_path);
 
     datafiles = callocz(MIN(ret, MAX_DATAFILES), sizeof(*datafiles));
     for (matched_files = 0 ; UV_EOF != uv_fs_scandir_next(&req, &dent) && matched_files < MAX_DATAFILES ; ) {
@@ -445,12 +445,12 @@ static int scan_data_files(struct rrdengine_instance *ctx)
             ret = journalfile_unlink(journalfile);
             if (!ret) {
                 journalfile_v1_generate_path(datafile, path, sizeof(path));
-                info("DBENGINE: deleted journal file \"%s\".", path);
+                netdata_log_info("DBENGINE: deleted journal file \"%s\".", path);
             }
             ret = unlink_data_file(datafile);
             if (!ret) {
                 generate_datafilepath(datafile, path, sizeof(path));
-                info("DBENGINE: deleted data file \"%s\".", path);
+                netdata_log_info("DBENGINE: deleted data file \"%s\".", path);
             }
             freez(journalfile);
             freez(datafile);
@@ -479,14 +479,14 @@ int create_new_datafile_pair(struct rrdengine_instance *ctx, bool having_lock)
     int ret;
     char path[RRDENG_PATH_MAX];
 
-    info("DBENGINE: creating new data and journal files in path %s", ctx->config.dbfiles_path);
+    netdata_log_info("DBENGINE: creating new data and journal files in path %s", ctx->config.dbfiles_path);
     datafile = datafile_alloc_and_init(ctx, 1, fileno);
     ret = create_data_file(datafile);
     if(ret)
         goto error_after_datafile;
 
     generate_datafilepath(datafile, path, sizeof(path));
-    info("DBENGINE: created data file \"%s\".", path);
+    netdata_log_info("DBENGINE: created data file \"%s\".", path);
 
     journalfile = journalfile_alloc_and_init(datafile);
     ret = journalfile_create(journalfile, datafile);
@@ -494,7 +494,7 @@ int create_new_datafile_pair(struct rrdengine_instance *ctx, bool having_lock)
         goto error_after_journalfile;
 
     journalfile_v1_generate_path(datafile, path, sizeof(path));
-    info("DBENGINE: created journal file \"%s\".", path);
+    netdata_log_info("DBENGINE: created journal file \"%s\".", path);
 
     ctx_current_disk_space_increase(ctx, datafile->pos + journalfile->unsafe.pos);
     datafile_list_insert(ctx, datafile, having_lock);
@@ -524,7 +524,7 @@ int init_data_files(struct rrdengine_instance *ctx)
         error("DBENGINE: failed to scan path \"%s\".", ctx->config.dbfiles_path);
         return ret;
     } else if (0 == ret) {
-        info("DBENGINE: data files not found, creating in path \"%s\".", ctx->config.dbfiles_path);
+        netdata_log_info("DBENGINE: data files not found, creating in path \"%s\".", ctx->config.dbfiles_path);
         ctx->atomic.last_fileno = 0;
         ret = create_new_datafile_pair(ctx, false);
         if (ret) {
@@ -552,7 +552,7 @@ void finalize_data_files(struct rrdengine_instance *ctx)
     logged = false;
     while(__atomic_load_n(&ctx->atomic.extents_currently_being_flushed, __ATOMIC_RELAXED)) {
         if(!logged) {
-            info("Waiting for inflight flush to finish on tier %d...", ctx->config.tier);
+            netdata_log_info("Waiting for inflight flush to finish on tier %d...", ctx->config.tier);
             logged = true;
         }
         sleep_usec(100 * USEC_PER_MS);
@@ -566,7 +566,7 @@ void finalize_data_files(struct rrdengine_instance *ctx)
         size_t iterations = 100;
         while(!datafile_acquire_for_deletion(datafile) && datafile != ctx->datafiles.first->prev && --iterations > 0) {
             if(!logged) {
-                info("Waiting to acquire data file %u of tier %d to close it...", datafile->fileno, ctx->config.tier);
+                netdata_log_info("Waiting to acquire data file %u of tier %d to close it...", datafile->fileno, ctx->config.tier);
                 logged = true;
             }
             sleep_usec(100 * USEC_PER_MS);
@@ -583,7 +583,7 @@ void finalize_data_files(struct rrdengine_instance *ctx)
                 spinlock_unlock(&datafile->writers.spinlock);
                 uv_rwlock_wrunlock(&ctx->datafiles.rwlock);
                 if(!logged) {
-                    info("Waiting for writers to data file %u of tier %d to finish...", datafile->fileno, ctx->config.tier);
+                    netdata_log_info("Waiting for writers to data file %u of tier %d to finish...", datafile->fileno, ctx->config.tier);
                     logged = true;
                 }
                 sleep_usec(100 * USEC_PER_MS);

--- a/database/engine/metric.c
+++ b/database/engine/metric.c
@@ -867,7 +867,7 @@ int mrg_unittest(void) {
     size_t threads = mrg->partitions / 3 + 1;
     size_t tiers = 3;
     size_t run_for_secs = 5;
-    info("preparing stress test of %zu entries...", entries);
+    netdata_log_info("preparing stress test of %zu entries...", entries);
     struct mrg_stress t = {
             .mrg = mrg,
             .entries = entries,
@@ -880,7 +880,7 @@ int mrg_unittest(void) {
         t.array[i].after = now / 3;
         t.array[i].before = now / 2;
     }
-    info("stress test is populating MRG with 3 tiers...");
+    netdata_log_info("stress test is populating MRG with 3 tiers...");
     for(size_t i = 0; i < entries ;i++) {
         struct mrg_stress_entry *e = &t.array[i];
         for(size_t tier = 1; tier <= tiers ;tier++) {
@@ -893,7 +893,7 @@ int mrg_unittest(void) {
                     e->before);
         }
     }
-    info("stress test ready to run...");
+    netdata_log_info("stress test ready to run...");
 
     usec_t started_ut = now_monotonic_usec();
 
@@ -920,7 +920,7 @@ int mrg_unittest(void) {
     struct mrg_statistics stats;
     mrg_get_statistics(mrg, &stats);
 
-    info("DBENGINE METRIC: did %zu additions, %zu duplicate additions, "
+    netdata_log_info("DBENGINE METRIC: did %zu additions, %zu duplicate additions, "
          "%zu deletions, %zu wrong deletions, "
          "%zu successful searches, %zu wrong searches, "
          "in %llu usecs",
@@ -929,13 +929,13 @@ int mrg_unittest(void) {
         stats.search_hits, stats.search_misses,
         ended_ut - started_ut);
 
-    info("DBENGINE METRIC: updates performance: %0.2fk/sec total, %0.2fk/sec/thread",
+    netdata_log_info("DBENGINE METRIC: updates performance: %0.2fk/sec total, %0.2fk/sec/thread",
          (double)t.updates / (double)((ended_ut - started_ut) / USEC_PER_SEC) / 1000.0,
          (double)t.updates / (double)((ended_ut - started_ut) / USEC_PER_SEC) / 1000.0 / threads);
 
     mrg_destroy(mrg);
 
-    info("DBENGINE METRIC: all tests passed!");
+    netdata_log_info("DBENGINE METRIC: all tests passed!");
 
     return 0;
 }

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -1085,7 +1085,7 @@ static void rrdeng_populate_mrg(struct rrdengine_instance *ctx) {
     if(cpus < 1)
         cpus = 1;
 
-    info("DBENGINE: populating retention to MRG from %zu journal files of tier %d, using %zd threads...", datafiles, ctx->config.tier, cpus);
+    netdata_log_info("DBENGINE: populating retention to MRG from %zu journal files of tier %d, using %zd threads...", datafiles, ctx->config.tier, cpus);
 
     if(datafiles > 2) {
         struct rrdengine_datafile *datafile;
@@ -1126,7 +1126,7 @@ void rrdeng_readiness_wait(struct rrdengine_instance *ctx) {
     ctx->loading.populate_mrg.array = NULL;
     ctx->loading.populate_mrg.size = 0;
 
-    info("DBENGINE: tier %d is ready for data collection and queries", ctx->config.tier);
+    netdata_log_info("DBENGINE: tier %d is ready for data collection and queries", ctx->config.tier);
 }
 
 bool rrdeng_is_legacy(STORAGE_INSTANCE *db_instance) {
@@ -1218,16 +1218,16 @@ int rrdeng_exit(struct rrdengine_instance *ctx) {
     bool logged = false;
     while(__atomic_load_n(&ctx->atomic.collectors_running, __ATOMIC_RELAXED) && !unittest_running) {
         if(!logged) {
-            info("DBENGINE: waiting for collectors to finish on tier %d...", (ctx->config.legacy) ? -1 : ctx->config.tier);
+            netdata_log_info("DBENGINE: waiting for collectors to finish on tier %d...", (ctx->config.legacy) ? -1 : ctx->config.tier);
             logged = true;
         }
         sleep_usec(100 * USEC_PER_MS);
     }
 
-    info("DBENGINE: flushing main cache for tier %d", (ctx->config.legacy) ? -1 : ctx->config.tier);
+    netdata_log_info("DBENGINE: flushing main cache for tier %d", (ctx->config.legacy) ? -1 : ctx->config.tier);
     pgc_flush_all_hot_and_dirty_pages(main_cache, (Word_t)ctx);
 
-    info("DBENGINE: shutting down tier %d", (ctx->config.legacy) ? -1 : ctx->config.tier);
+    netdata_log_info("DBENGINE: shutting down tier %d", (ctx->config.legacy) ? -1 : ctx->config.tier);
     struct completion completion = {};
     completion_init(&completion);
     rrdeng_enq_cmd(ctx, RRDENG_OPCODE_CTX_SHUTDOWN, NULL, &completion, STORAGE_PRIORITY_BEST_EFFORT, NULL, NULL);

--- a/database/engine/rrdenginelib.c
+++ b/database/engine/rrdenginelib.c
@@ -65,7 +65,7 @@ int open_file_for_io(char *path, int flags, uv_file *file, int direct)
             fatal_assert(req.result >= 0);
             *file = req.result;
 #ifdef __APPLE__
-            info("Disabling OS X caching for file \"%s\".", path);
+            netdata_log_info("Disabling OS X caching for file \"%s\".", path);
             fcntl(fd, F_NOCACHE, 1);
 #endif
             --direct; /* break the loop */
@@ -90,7 +90,7 @@ int is_legacy_child(const char *machine_guid)
         snprintfz(dbengine_file, FILENAME_MAX, "%s/%s/dbengine", netdata_configured_cache_dir, machine_guid);
         int rc = uv_fs_stat(NULL, &stat_req, dbengine_file, NULL);
         if (likely(rc == 0 && ((stat_req.statbuf.st_mode & S_IFMT) == S_IFDIR))) {
-            //info("Found legacy engine folder \"%s\"", dbengine_file);
+            //netdata_log_info("Found legacy engine folder \"%s\"", dbengine_file);
             return 1;
         }
     }
@@ -143,12 +143,12 @@ int compute_multidb_diskspace()
         int rc = count_legacy_children(netdata_configured_cache_dir);
         if (likely(rc >= 0)) {
             computed_multidb_disk_quota_mb = (rc + 1) * default_rrdeng_disk_quota_mb;
-            info("Found %d legacy dbengines, setting multidb diskspace to %dMB", rc, computed_multidb_disk_quota_mb);
+            netdata_log_info("Found %d legacy dbengines, setting multidb diskspace to %dMB", rc, computed_multidb_disk_quota_mb);
 
             fp = fopen(multidb_disk_space_file, "w");
             if (likely(fp)) {
                 fprintf(fp, "%d", computed_multidb_disk_quota_mb);
-                info("Created file '%s' to store the computed value", multidb_disk_space_file);
+                netdata_log_info("Created file '%s' to store the computed value", multidb_disk_space_file);
                 fclose(fp);
             } else
                 error("Failed to store the default multidb disk quota size on '%s'", multidb_disk_space_file);

--- a/database/ram/rrddim_mem.c
+++ b/database/ram/rrddim_mem.c
@@ -353,7 +353,7 @@ void rrddim_query_init(STORAGE_METRIC_HANDLE *db_metric_handle, struct storage_e
     h->slot_timestamp = rrddim_slot2time(db_metric_handle, h->slot);
     h->last_timestamp = rrddim_slot2time(db_metric_handle, h->last_slot);
 
-    // info("RRDDIM QUERY INIT: start %ld, end %ld, next %ld, first %ld, last %ld, dt %ld", start_time, end_time, h->next_timestamp, h->slot_timestamp, h->last_timestamp, h->dt);
+    // netdata_log_info("RRDDIM QUERY INIT: start %ld, end %ld, next %ld, first %ld, last %ld, dt %ld", start_time, end_time, h->next_timestamp, h->slot_timestamp, h->last_timestamp, h->dt);
 
     __atomic_add_fetch(&rrddim_db_memory_size, sizeof(struct mem_query_handle), __ATOMIC_RELAXED);
     handle->handle = (STORAGE_QUERY_HANDLE *)h;

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -246,7 +246,7 @@ void rrdcalctemplate_add_from_config(RRDHOST *host, RRDCALCTEMPLATE *rt) {
     if(added)
         freez(rt);
     else {
-        info("Health configuration template '%s' already exists for host '%s'.", rrdcalctemplate_name(rt), rrdhost_hostname(host));
+        netdata_log_info("Health configuration template '%s' already exists for host '%s'.", rrdcalctemplate_name(rt), rrdhost_hostname(host));
         rrdcalctemplate_free_unused_rrdcalctemplate_loaded_from_config(rt);
     }
 }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -521,7 +521,7 @@ int is_legacy = 1;
 
     // ------------------------------------------------------------------------
 
-    info("Host '%s' (at registry as '%s') with guid '%s' initialized"
+    netdata_log_info("Host '%s' (at registry as '%s') with guid '%s' initialized"
                  ", os '%s'"
                  ", timezone '%s'"
                  ", tags '%s'"
@@ -612,21 +612,21 @@ static void rrdhost_update(RRDHOST *host
     host->registry_hostname = string_strdupz((registry_hostname && *registry_hostname)?registry_hostname:hostname);
 
     if(strcmp(rrdhost_hostname(host), hostname) != 0) {
-        info("Host '%s' has been renamed to '%s'. If this is not intentional it may mean multiple hosts are using the same machine_guid.", rrdhost_hostname(host), hostname);
+        netdata_log_info("Host '%s' has been renamed to '%s'. If this is not intentional it may mean multiple hosts are using the same machine_guid.", rrdhost_hostname(host), hostname);
         rrdhost_init_hostname(host, hostname, true);
     } else {
         rrdhost_index_add_hostname(host);
     }
 
     if(strcmp(rrdhost_program_name(host), program_name) != 0) {
-        info("Host '%s' switched program name from '%s' to '%s'", rrdhost_hostname(host), rrdhost_program_name(host), program_name);
+        netdata_log_info("Host '%s' switched program name from '%s' to '%s'", rrdhost_hostname(host), rrdhost_program_name(host), program_name);
         STRING *t = host->program_name;
         host->program_name = string_strdupz(program_name);
         string_freez(t);
     }
 
     if(strcmp(rrdhost_program_version(host), program_version) != 0) {
-        info("Host '%s' switched program version from '%s' to '%s'", rrdhost_hostname(host), rrdhost_program_version(host), program_version);
+        netdata_log_info("Host '%s' switched program version from '%s' to '%s'", rrdhost_hostname(host), rrdhost_program_version(host), program_version);
         STRING *t = host->program_version;
         host->program_version = string_strdupz(program_version);
         string_freez(t);
@@ -685,7 +685,7 @@ static void rrdhost_update(RRDHOST *host
         ml_host_new(host);
         
         rrdhost_load_rrdcontext_data(host);
-        info("Host %s is not in archived mode anymore", rrdhost_hostname(host));
+        netdata_log_info("Host %s is not in archived mode anymore", rrdhost_hostname(host));
     }
 
     spinlock_unlock(&host->rrdhost_update_lock);
@@ -973,7 +973,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
             set_late_global_environment(system_info);
             fatal("Failed to initialize SQLite");
         }
-        info("Skipping SQLITE metadata initialization since memory mode is not dbengine");
+        netdata_log_info("Skipping SQLITE metadata initialization since memory mode is not dbengine");
     }
 
     if (unlikely(sql_init_context_database(system_info ? 0 : 1))) {
@@ -988,11 +988,11 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
         rrdpush_init();
 
         if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE || rrdpush_receiver_needs_dbengine()) {
-            info("DBENGINE: Initializing ...");
+            netdata_log_info("DBENGINE: Initializing ...");
             dbengine_init(hostname);
         }
         else {
-            info("DBENGINE: Not initializing ...");
+            netdata_log_info("DBENGINE: Not initializing ...");
             storage_tiers = 1;
         }
 
@@ -1153,7 +1153,7 @@ void rrdhost_free___while_having_rrd_wrlock(RRDHOST *host, bool force) {
     if(!host) return;
 
     if (netdata_exit || force) {
-        info("RRD: 'host:%s' freeing memory...", rrdhost_hostname(host));
+        netdata_log_info("RRD: 'host:%s' freeing memory...", rrdhost_hostname(host));
 
         // ------------------------------------------------------------------------
         // first remove it from the indexes, so that it will not be discoverable
@@ -1213,7 +1213,7 @@ void rrdhost_free___while_having_rrd_wrlock(RRDHOST *host, bool force) {
 #endif
 
     if (!netdata_exit && !force) {
-        info("RRD: 'host:%s' is now in archive mode...", rrdhost_hostname(host));
+        netdata_log_info("RRD: 'host:%s' is now in archive mode...", rrdhost_hostname(host));
         rrdhost_flag_set(host, RRDHOST_FLAG_ARCHIVED | RRDHOST_FLAG_ORPHAN);
         return;
     }
@@ -1283,7 +1283,7 @@ void rrd_finalize_collection_for_all_hosts(void) {
 void rrdhost_save_charts(RRDHOST *host) {
     if(!host) return;
 
-    info("RRD: 'host:%s' saving / closing database...", rrdhost_hostname(host));
+    netdata_log_info("RRD: 'host:%s' saving / closing database...", rrdhost_hostname(host));
 
     RRDSET *st;
 
@@ -1470,7 +1470,7 @@ void reload_host_labels(void) {
 }
 
 void rrdhost_finalize_collection(RRDHOST *host) {
-    info("RRD: 'host:%s' stopping data collection...", rrdhost_hostname(host));
+    netdata_log_info("RRD: 'host:%s' stopping data collection...", rrdhost_hostname(host));
 
     RRDSET *st;
     rrdset_foreach_read(st, host)
@@ -1484,7 +1484,7 @@ void rrdhost_finalize_collection(RRDHOST *host) {
 void rrdhost_delete_charts(RRDHOST *host) {
     if(!host) return;
 
-    info("RRD: 'host:%s' deleting disk files...", rrdhost_hostname(host));
+    netdata_log_info("RRD: 'host:%s' deleting disk files...", rrdhost_hostname(host));
 
     RRDSET *st;
 
@@ -1506,7 +1506,7 @@ void rrdhost_delete_charts(RRDHOST *host) {
 void rrdhost_cleanup_charts(RRDHOST *host) {
     if(!host) return;
 
-    info("RRD: 'host:%s' cleaning up disk files...", rrdhost_hostname(host));
+    netdata_log_info("RRD: 'host:%s' cleaning up disk files...", rrdhost_hostname(host));
 
     RRDSET *st;
     uint32_t rrdhost_delete_obsolete_charts = rrdhost_option_check(host, RRDHOST_OPTION_DELETE_OBSOLETE_CHARTS);
@@ -1533,7 +1533,7 @@ void rrdhost_cleanup_charts(RRDHOST *host) {
 // RRDHOST - save all hosts to disk
 
 void rrdhost_save_all(void) {
-    info("RRD: saving databases [%zu hosts(s)]...", rrdhost_hosts_available());
+    netdata_log_info("RRD: saving databases [%zu hosts(s)]...", rrdhost_hosts_available());
 
     rrd_rdlock();
 
@@ -1548,7 +1548,7 @@ void rrdhost_save_all(void) {
 // RRDHOST - save or delete all hosts from disk
 
 void rrdhost_cleanup_all(void) {
-    info("RRD: cleaning up database [%zu hosts(s)]...", rrdhost_hosts_available());
+    netdata_log_info("RRD: cleaning up database [%zu hosts(s)]...", rrdhost_hosts_available());
 
     rrd_rdlock();
 

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -385,7 +385,7 @@ static void aclk_synchronization(void *arg __maybe_unused)
     config->timer_req.data = config;
     fatal_assert(0 == uv_timer_start(&config->timer_req, timer_cb, TIMER_PERIOD_MS, TIMER_PERIOD_MS));
 
-    info("Starting ACLK synchronization thread");
+    netdata_log_info("Starting ACLK synchronization thread");
 
     config->cleanup_after = now_realtime_sec() + ACLK_DATABASE_CLEANUP_FIRST;
     config->initialized = true;
@@ -462,7 +462,7 @@ static void aclk_synchronization(void *arg __maybe_unused)
 
     worker_unregister();
     service_exits();
-    info("ACLK SYNC: Shutting down ACLK synchronization event loop");
+    netdata_log_info("ACLK SYNC: Shutting down ACLK synchronization event loop");
 }
 
 static void aclk_synchronization_init(void)
@@ -543,7 +543,7 @@ void sql_aclk_sync_init(void)
         return;
     }
 
-    info("Creating archived hosts");
+    netdata_log_info("Creating archived hosts");
     int number_of_children = 0;
     rc = sqlite3_exec_monitored(db_meta, SQL_FETCH_ALL_HOSTS, create_host_callback, &number_of_children, &err_msg);
 
@@ -552,7 +552,7 @@ void sql_aclk_sync_init(void)
         sqlite3_free(err_msg);
     }
 
-    info("Created %d archived hosts", number_of_children);
+    netdata_log_info("Created %d archived hosts", number_of_children);
     // Trigger host context load for hosts that have been created
     metadata_queue_load_host_context(NULL);
 
@@ -568,7 +568,7 @@ void sql_aclk_sync_init(void)
     }
     aclk_synchronization_init();
 
-    info("ACLK sync initialization completed");
+    netdata_log_info("ACLK sync initialization completed");
 #endif
 }
 

--- a/database/sqlite/sqlite_aclk_node.c
+++ b/database/sqlite/sqlite_aclk_node.c
@@ -172,7 +172,7 @@ void aclk_check_node_info_and_collectors(void)
     dfe_done(host);
 
     if(pending)
-        info("ACLK: %zu nodes are pending for contexts to load, skipped sending node info for them", pending);
+        netdata_log_info("ACLK: %zu nodes are pending for contexts to load, skipped sending node info for them", pending);
 }
 
 #endif

--- a/database/sqlite/sqlite_context.c
+++ b/database/sqlite/sqlite_context.c
@@ -43,7 +43,7 @@ int sql_init_context_database(int memory)
         return 1;
     }
 
-    info("SQLite database %s initialization", sqlite_database);
+    netdata_log_info("SQLite database %s initialization", sqlite_database);
 
     char buf[1024 + 1] = "";
     const char *list[2] = { buf, NULL };
@@ -112,7 +112,7 @@ void sql_close_context_database(void)
     if (unlikely(!db_context_meta))
         return;
 
-    info("Closing context SQLite database");
+    netdata_log_info("Closing context SQLite database");
 
     rc = sqlite3_close_v2(db_context_meta);
     if (unlikely(rc != SQLITE_OK))
@@ -431,7 +431,7 @@ int ctx_delete_context(uuid_t *host_uuid, VERSIONED_CONTEXT_DATA *context_data)
     else {
         char host_uuid_str[UUID_STR_LEN];
         uuid_unparse_lower(*host_uuid, host_uuid_str);
-        info("%s: Deleted context %s under host %s", __FUNCTION__, context_data->id, host_uuid_str);
+        netdata_log_info("%s: Deleted context %s under host %s", __FUNCTION__, context_data->id, host_uuid_str);
     }
 #endif
 
@@ -463,7 +463,7 @@ int sql_context_cache_stats(int op)
 static void dict_ctx_get_context_list_cb(VERSIONED_CONTEXT_DATA *context_data, void *data)
 {
     (void)data;
-    info("   Context id = %s "
+    netdata_log_info("   Context id = %s "
          "version = %"PRIu64" "
          "title = %s "
          "chart_type = %s "
@@ -512,48 +512,48 @@ int ctx_unittest(void)
     context_data.version  = now_realtime_usec();
 
     if (likely(!ctx_store_context(&host_uuid, &context_data)))
-        info("Entry %s inserted", context_data.id);
+        netdata_log_info("Entry %s inserted", context_data.id);
     else
-        info("Entry %s not inserted", context_data.id);
+        netdata_log_info("Entry %s not inserted", context_data.id);
 
     if (likely(!ctx_store_context(&host_uuid, &context_data)))
-        info("Entry %s inserted", context_data.id);
+        netdata_log_info("Entry %s inserted", context_data.id);
     else
-        info("Entry %s not inserted", context_data.id);
+        netdata_log_info("Entry %s not inserted", context_data.id);
 
     // This will change end time
     context_data.first_time_s = 1657781000;
     context_data.last_time_s  = 1657782001;
     if (likely(!ctx_update_context(&host_uuid, &context_data)))
-        info("Entry %s updated", context_data.id);
+        netdata_log_info("Entry %s updated", context_data.id);
     else
-        info("Entry %s not updated", context_data.id);
-    info("List context start after insert");
+        netdata_log_info("Entry %s not updated", context_data.id);
+    netdata_log_info("List context start after insert");
     ctx_get_context_list(&host_uuid, dict_ctx_get_context_list_cb, NULL);
-    info("List context end after insert");
+    netdata_log_info("List context end after insert");
 
     // This will change start time
     context_data.first_time_s = 1657782000;
     context_data.last_time_s  = 1657782001;
     if (likely(!ctx_update_context(&host_uuid, &context_data)))
-        info("Entry %s updated", context_data.id);
+        netdata_log_info("Entry %s updated", context_data.id);
     else
-        info("Entry %s not updated", context_data.id);
+        netdata_log_info("Entry %s not updated", context_data.id);
 
     // This will list one entry
-    info("List context start after insert");
+    netdata_log_info("List context start after insert");
     ctx_get_context_list(&host_uuid, dict_ctx_get_context_list_cb, NULL);
-    info("List context end after insert");
+    netdata_log_info("List context end after insert");
 
-    info("List context start after insert");
+    netdata_log_info("List context start after insert");
     ctx_get_context_list(&host_uuid, dict_ctx_get_context_list_cb, NULL);
-    info("List context end after insert");
+    netdata_log_info("List context end after insert");
 
     // This will delete the entry
     if (likely(!ctx_delete_context(&host_uuid, &context_data)))
-        info("Entry %s deleted", context_data.id);
+        netdata_log_info("Entry %s deleted", context_data.id);
     else
-        info("Entry %s not deleted", context_data.id);
+        netdata_log_info("Entry %s not deleted", context_data.id);
 
     freez((void *)context_data.id);
     freez((void *)context_data.title);
@@ -562,9 +562,9 @@ int ctx_unittest(void)
     freez((void *)context_data.units);
 
     // The list should be empty
-    info("List context start after delete");
+    netdata_log_info("List context start after delete");
     ctx_get_context_list(&host_uuid, dict_ctx_get_context_list_cb, NULL);
-    info("List context end after delete");
+    netdata_log_info("List context end after delete");
 
     sql_close_context_database();
 

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -22,7 +22,7 @@ int table_exists_in_database(const char *table)
 
     int rc = sqlite3_exec_monitored(db_meta, sql, return_int_cb, (void *) &exists, &err_msg);
     if (rc != SQLITE_OK) {
-        info("Error checking table existence; %s", err_msg);
+        netdata_log_info("Error checking table existence; %s", err_msg);
         sqlite3_free(err_msg);
     }
 
@@ -40,7 +40,7 @@ static int column_exists_in_table(const char *table, const char *column)
 
     int rc = sqlite3_exec_monitored(db_meta, sql, return_int_cb, (void *) &exists, &err_msg);
     if (rc != SQLITE_OK) {
-        info("Error checking column existence; %s", err_msg);
+        netdata_log_info("Error checking column existence; %s", err_msg);
         sqlite3_free(err_msg);
     }
 
@@ -82,7 +82,7 @@ const char *database_migrate_v5_v6[] = {
 static int do_migration_v1_v2(sqlite3 *database, const char *name)
 {
     UNUSED(name);
-    info("Running \"%s\" database migration", name);
+    netdata_log_info("Running \"%s\" database migration", name);
 
     if (table_exists_in_database("host") && !column_exists_in_table("host", "hops"))
         return init_database_batch(database, DB_CHECK_NONE, 0, &database_migrate_v1_v2[0]);
@@ -92,7 +92,7 @@ static int do_migration_v1_v2(sqlite3 *database, const char *name)
 static int do_migration_v2_v3(sqlite3 *database, const char *name)
 {
     UNUSED(name);
-    info("Running \"%s\" database migration", name);
+    netdata_log_info("Running \"%s\" database migration", name);
 
     if (table_exists_in_database("host") && !column_exists_in_table("host", "memory_mode"))
         return init_database_batch(database, DB_CHECK_NONE, 0, &database_migrate_v2_v3[0]);
@@ -102,7 +102,7 @@ static int do_migration_v2_v3(sqlite3 *database, const char *name)
 static int do_migration_v3_v4(sqlite3 *database, const char *name)
 {
     UNUSED(name);
-    info("Running database migration %s", name);
+    netdata_log_info("Running database migration %s", name);
 
     char sql[256];
 
@@ -134,7 +134,7 @@ static int do_migration_v3_v4(sqlite3 *database, const char *name)
 static int do_migration_v4_v5(sqlite3 *database, const char *name)
 {
     UNUSED(name);
-    info("Running \"%s\" database migration", name);
+    netdata_log_info("Running \"%s\" database migration", name);
 
     return init_database_batch(database, DB_CHECK_NONE, 0, &database_migrate_v4_v5[0]);
 }
@@ -142,7 +142,7 @@ static int do_migration_v4_v5(sqlite3 *database, const char *name)
 static int do_migration_v5_v6(sqlite3 *database, const char *name)
 {
     UNUSED(name);
-    info("Running \"%s\" database migration", name);
+    netdata_log_info("Running \"%s\" database migration", name);
 
     return init_database_batch(database, DB_CHECK_NONE, 0, &database_migrate_v5_v6[0]);
 }
@@ -150,7 +150,7 @@ static int do_migration_v5_v6(sqlite3 *database, const char *name)
 static int do_migration_v6_v7(sqlite3 *database, const char *name)
 {
     UNUSED(name);
-    info("Running \"%s\" database migration", name);
+    netdata_log_info("Running \"%s\" database migration", name);
 
     char sql[256];
 
@@ -184,7 +184,7 @@ static int do_migration_v6_v7(sqlite3 *database, const char *name)
 static int do_migration_v7_v8(sqlite3 *database, const char *name)
 {
     UNUSED(name);
-    info("Running database migration %s", name);
+    netdata_log_info("Running database migration %s", name);
 
     char sql[256];
 
@@ -215,7 +215,7 @@ static int do_migration_v7_v8(sqlite3 *database, const char *name)
 
 static int do_migration_v8_v9(sqlite3 *database, const char *name)
 {
-    info("Running database migration %s", name);
+    netdata_log_info("Running database migration %s", name);
 
     char sql[2048];
     int rc;
@@ -291,7 +291,7 @@ static int do_migration_noop(sqlite3 *database, const char *name)
 {
     UNUSED(database);
     UNUSED(name);
-    info("Running database migration %s", name);
+    netdata_log_info("Running database migration %s", name);
     return 0;
 }
 
@@ -308,16 +308,16 @@ static int migrate_database(sqlite3 *database, int target_version, char *db_name
 
     int rc = sqlite3_exec_monitored(database, "PRAGMA user_version;", return_int_cb, (void *) &user_version, &err_msg);
     if (rc != SQLITE_OK) {
-        info("Error checking the %s database version; %s", db_name, err_msg);
+        netdata_log_info("Error checking the %s database version; %s", db_name, err_msg);
         sqlite3_free(err_msg);
     }
 
     if (likely(user_version == target_version)) {
-        info("%s database version is %d (no migration needed)", db_name, target_version);
+        netdata_log_info("%s database version is %d (no migration needed)", db_name, target_version);
         return target_version;
     }
 
-    info("Database version is %d, current version is %d. Running migration for %s ...", user_version, target_version, db_name);
+    netdata_log_info("Database version is %d, current version is %d. Running migration for %s ...", user_version, target_version, db_name);
     for (int i = user_version; i < target_version && migration_list[i].func; i++) {
         rc = (migration_list[i].func)(database, migration_list[i].name);
         if (unlikely(rc)) {

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -387,7 +387,7 @@ void sql_health_alarm_log_count(RRDHOST *host) {
     if (unlikely(rc != SQLITE_OK))
         error_report("Failed to finalize the prepared statement to count health log entries from db");
 
-    info("HEALTH [%s]: Table health_log_detail contains %lu entries.", rrdhost_hostname(host), (unsigned long int) host->health.health_log_entries_written);
+    netdata_log_info("HEALTH [%s]: Table health_log_detail contains %lu entries.", rrdhost_hostname(host), (unsigned long int) host->health.health_log_entries_written);
 }
 
 /* Health related SQL queries

--- a/exporting/aws_kinesis/aws_kinesis.c
+++ b/exporting/aws_kinesis/aws_kinesis.c
@@ -7,7 +7,7 @@
  */
 void aws_kinesis_cleanup(struct instance *instance)
 {
-    info("EXPORTING: cleaning up instance %s ...", instance->config.name);
+    netdata_log_info("EXPORTING: cleaning up instance %s ...", instance->config.name);
     kinesis_shutdown(instance->connector_specific_data);
 
     freez(instance->connector_specific_data);
@@ -21,7 +21,7 @@ void aws_kinesis_cleanup(struct instance *instance)
         freez(connector_specific_config);
     }
 
-    info("EXPORTING: instance %s exited", instance->config.name);
+    netdata_log_info("EXPORTING: instance %s exited", instance->config.name);
     instance->exited = 1;
 }
 

--- a/exporting/check_filters.c
+++ b/exporting/check_filters.c
@@ -29,10 +29,10 @@ int rrdhost_is_exportable(struct instance *instance, RRDHOST *host)
 
         if (!instance->config.hosts_pattern || simple_pattern_matches(instance->config.hosts_pattern, host_name)) {
             *flags |= RRDHOST_FLAG_EXPORTING_SEND;
-            info("enabled exporting of host '%s' for instance '%s'", host_name, instance->config.name);
+            netdata_log_info("enabled exporting of host '%s' for instance '%s'", host_name, instance->config.name);
         } else {
             *flags |= RRDHOST_FLAG_EXPORTING_DONT_SEND;
-            info("disabled exporting of host '%s' for instance '%s'", host_name, instance->config.name);
+            netdata_log_info("disabled exporting of host '%s' for instance '%s'", host_name, instance->config.name);
         }
     }
 

--- a/exporting/clean_connectors.c
+++ b/exporting/clean_connectors.c
@@ -46,7 +46,7 @@ void clean_instance(struct instance *instance)
  */
 void simple_connector_cleanup(struct instance *instance)
 {
-    info("EXPORTING: cleaning up instance %s ...", instance->config.name);
+    netdata_log_info("EXPORTING: cleaning up instance %s ...", instance->config.name);
 
     struct simple_connector_data *simple_connector_data =
         (struct simple_connector_data *)instance->connector_specific_data;
@@ -77,6 +77,6 @@ void simple_connector_cleanup(struct instance *instance)
         (struct simple_connector_config *)instance->config.connector_specific_config;
     freez(simple_connector_config);
 
-    info("EXPORTING: instance %s exited", instance->config.name);
+    netdata_log_info("EXPORTING: instance %s exited", instance->config.name);
     instance->exited = 1;
 }

--- a/exporting/exporting_engine.c
+++ b/exporting/exporting_engine.c
@@ -124,7 +124,7 @@ static void exporting_main_cleanup(void *ptr)
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
 
-    info("cleaning up...");
+    netdata_log_info("cleaning up...");
 
     if (!engine) {
         static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
@@ -139,17 +139,17 @@ static void exporting_main_cleanup(void *ptr)
     for (struct instance *instance = engine->instance_root; instance; instance = instance->next) {
         if (!instance->exited) {
             found++;
-            info("stopping worker for instance %s", instance->config.name);
+            netdata_log_info("stopping worker for instance %s", instance->config.name);
             uv_mutex_unlock(&instance->mutex);
             instance->data_is_ready = 1;
             uv_cond_signal(&instance->cond_var);
         } else
-            info("found stopped worker for instance %s", instance->config.name);
+            netdata_log_info("found stopped worker for instance %s", instance->config.name);
     }
 
     while (found && max > 0) {
         max -= step;
-        info("Waiting %d exporting connectors to finish...", found);
+        netdata_log_info("Waiting %d exporting connectors to finish...", found);
         sleep_usec(step);
         found = 0;
 
@@ -178,7 +178,7 @@ void *exporting_main(void *ptr)
 
     engine = read_exporting_config();
     if (!engine) {
-        info("EXPORTING: no exporting connectors configured");
+        netdata_log_info("EXPORTING: no exporting connectors configured");
         goto cleanup;
     }
 

--- a/exporting/mongodb/mongodb.c
+++ b/exporting/mongodb/mongodb.c
@@ -229,7 +229,7 @@ int format_batch_mongodb(struct instance *instance)
  */
 void mongodb_cleanup(struct instance *instance)
 {
-    info("EXPORTING: cleaning up instance %s ...", instance->config.name);
+    netdata_log_info("EXPORTING: cleaning up instance %s ...", instance->config.name);
 
     struct mongodb_specific_data *connector_specific_data =
         (struct mongodb_specific_data *)instance->connector_specific_data;
@@ -261,7 +261,7 @@ void mongodb_cleanup(struct instance *instance)
     freez(connector_specific_config->collection);
     freez(connector_specific_config);
 
-    info("EXPORTING: instance %s exited", instance->config.name);
+    netdata_log_info("EXPORTING: instance %s exited", instance->config.name);
     instance->exited = 1;
 
     return;

--- a/exporting/prometheus/prometheus.c
+++ b/exporting/prometheus/prometheus.c
@@ -244,7 +244,7 @@ inline char *prometheus_units_copy(char *d, const char *s, size_t usable, int sh
         uint32_t hash = simple_hash(s);
         for (i = 0; units[i].newunit; i++) {
             if (unlikely(hash == units[i].hash && !strcmp(s, units[i].newunit))) {
-                // info("matched extension for filename '%s': '%s'", filename, last_dot);
+                // netdata_log_info("matched extension for filename '%s': '%s'", filename, last_dot);
                 s = units[i].oldunit;
                 sorig = s;
                 break;

--- a/exporting/pubsub/pubsub.c
+++ b/exporting/pubsub/pubsub.c
@@ -64,7 +64,7 @@ int init_pubsub_instance(struct instance *instance)
  */
 void clean_pubsub_instance(struct instance *instance)
 {
-    info("EXPORTING: cleaning up instance %s ...", instance->config.name);
+    netdata_log_info("EXPORTING: cleaning up instance %s ...", instance->config.name);
 
     struct pubsub_specific_data *connector_specific_data =
         (struct pubsub_specific_data *)instance->connector_specific_data;
@@ -80,7 +80,7 @@ void clean_pubsub_instance(struct instance *instance)
     freez(connector_specific_config->topic_id);
     freez(connector_specific_config);
 
-    info("EXPORTING: instance %s exited", instance->config.name);
+    netdata_log_info("EXPORTING: instance %s exited", instance->config.name);
     instance->exited = 1;
 
     return;

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -211,13 +211,13 @@ struct engine *read_exporting_config()
 
     exporting_config_exists = appconfig_load(&exporting_config, filename, 0, NULL);
     if (!exporting_config_exists) {
-        info("CONFIG: cannot load user exporting config '%s'. Will try the stock version.", filename);
+        netdata_log_info("CONFIG: cannot load user exporting config '%s'. Will try the stock version.", filename);
         freez(filename);
 
         filename = strdupz_path_subpath(netdata_configured_stock_config_dir, EXPORTING_CONF);
         exporting_config_exists = appconfig_load(&exporting_config, filename, 0, NULL);
         if (!exporting_config_exists)
-            info("CONFIG: cannot load stock exporting config '%s'. Running with internal defaults.", filename);
+            netdata_log_info("CONFIG: cannot load stock exporting config '%s'. Running with internal defaults.", filename);
     }
 
     freez(filename);
@@ -276,10 +276,10 @@ struct engine *read_exporting_config()
     }
 
     while (get_connector_instance(&local_ci)) {
-        info("Processing connector instance (%s)", local_ci.instance_name);
+        netdata_log_info("Processing connector instance (%s)", local_ci.instance_name);
 
         if (exporter_get_boolean(local_ci.instance_name, "enabled", 0)) {
-            info(
+            netdata_log_info(
                 "Instance (%s) on connector (%s) is enabled and scheduled for activation",
                 local_ci.instance_name, local_ci.connector_name);
 
@@ -290,11 +290,11 @@ struct engine *read_exporting_config()
             tmp_ci_list_prev = tmp_ci_list;
             instances_to_activate++;
         } else
-            info("Instance (%s) on connector (%s) is not enabled", local_ci.instance_name, local_ci.connector_name);
+            netdata_log_info("Instance (%s) on connector (%s) is not enabled", local_ci.instance_name, local_ci.connector_name);
     }
 
     if (unlikely(!instances_to_activate)) {
-        info("No connector instances to activate");
+        netdata_log_info("No connector instances to activate");
         return NULL;
     }
 
@@ -313,7 +313,7 @@ struct engine *read_exporting_config()
         char *instance_name;
         char *default_destination = "localhost";
 
-        info("Instance %s on %s", tmp_ci_list->local_ci.instance_name, tmp_ci_list->local_ci.connector_name);
+        netdata_log_info("Instance %s on %s", tmp_ci_list->local_ci.instance_name, tmp_ci_list->local_ci.connector_name);
 
         if (tmp_ci_list->exporting_type == EXPORTING_CONNECTOR_TYPE_UNKNOWN) {
             error("Unknown exporting connector type");
@@ -381,7 +381,7 @@ struct engine *read_exporting_config()
         tmp_instance->config.options = exporting_parse_data_source(data_source, tmp_instance->config.options);
         if (EXPORTING_OPTIONS_DATA_SOURCE(tmp_instance->config.options) != EXPORTING_SOURCE_DATA_AS_COLLECTED &&
             tmp_instance->config.update_every % localhost->rrd_update_every)
-            info(
+            netdata_log_info(
                 "The update interval %d for instance %s is not a multiple of the database update interval %d. "
                 "Metric values will deviate at different points in time.",
                 tmp_instance->config.update_every, tmp_instance->config.name, localhost->rrd_update_every);
@@ -488,7 +488,7 @@ struct engine *read_exporting_config()
 #endif
 
 #ifdef NETDATA_INTERNAL_CHECKS
-        info(
+        netdata_log_info(
             "     Dest=[%s], upd=[%d], buffer=[%d] timeout=[%ld] options=[%u]",
             tmp_instance->config.destination,
             tmp_instance->config.update_every,

--- a/exporting/send_data.c
+++ b/exporting/send_data.c
@@ -303,7 +303,7 @@ void simple_connector_worker(void *instance_p)
 
                     if(netdata_ssl_open(&connector_specific_data->ssl, netdata_ssl_exporting_ctx, sock)) {
                         if(netdata_ssl_connect(&connector_specific_data->ssl)) {
-                            info("Exporting established a SSL connection.");
+                            netdata_log_info("Exporting established a SSL connection.");
 
                             struct timeval tv;
                             tv.tv_sec = timeout.tv_sec / 4;

--- a/health/health.c
+++ b/health/health.c
@@ -287,7 +287,7 @@ static void health_silencers_init(void) {
                 if (copied == (length* sizeof(char))) {
                     str[length] = 0x00;
                     json_parse(str, NULL, health_silencers_json_read_callback);
-                    info("Parsed health silencers file %s", silencers_filename);
+                    netdata_log_info("Parsed health silencers file %s", silencers_filename);
                 } else {
                     error("Cannot read the data from health silencers file %s", silencers_filename);
                 }
@@ -302,7 +302,7 @@ static void health_silencers_init(void) {
         }
         fclose(fd);
     } else {
-        info("Cannot open the file %s, so Netdata will work with the default health configuration.",silencers_filename);
+        netdata_log_info("Cannot open the file %s, so Netdata will work with the default health configuration.",silencers_filename);
     }
 }
 
@@ -775,7 +775,7 @@ static void health_main_cleanup(void *ptr) {
 
     struct netdata_static_thread *static_thread = (struct netdata_static_thread *)ptr;
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITING;
-    info("cleaning up...");
+    netdata_log_info("cleaning up...");
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 
     log_health("Health thread ended.");
@@ -915,7 +915,7 @@ static int update_disabled_silenced(RRDHOST *host, RRDCALC *rc) {
     }
 
     if (rrdcalc_flags_old != rc->run_flags) {
-        info("Alarm silencing changed for host '%s' alarm '%s': Disabled %s->%s Silenced %s->%s",
+        netdata_log_info("Alarm silencing changed for host '%s' alarm '%s': Disabled %s->%s Silenced %s->%s",
              rrdhost_hostname(host),
              rrdcalc_name(rc),
              (rrdcalc_flags_old & RRDCALC_FLAG_DISABLED)?"true":"false",

--- a/httpd/http_server.c
+++ b/httpd/http_server.c
@@ -88,7 +88,7 @@ static int ssl_init()
 
     h2o_ssl_register_alpn_protocols(accept_ctx.ssl_ctx, h2o_http2_alpn_protocols);
 
-    info("SSL support enabled");
+    netdata_log_info("SSL support enabled");
 
     return 0;
 }

--- a/libnetdata/adaptive_resortable_list/adaptive_resortable_list.c
+++ b/libnetdata/adaptive_resortable_list/adaptive_resortable_list.c
@@ -78,16 +78,16 @@ void arl_begin(ARL_BASE *base) {
         // do these checks after the ARL has been sorted
 
         if(unlikely(base->relinkings > (base->expected + base->allocated)))
-            info("ARL '%s' has %zu relinkings with %zu expected and %zu allocated entries. Is the source changing so fast?"
+            netdata_log_info("ARL '%s' has %zu relinkings with %zu expected and %zu allocated entries. Is the source changing so fast?"
                  , base->name, base->relinkings, base->expected, base->allocated);
 
         if(unlikely(base->slow > base->fast))
-            info("ARL '%s' has %zu fast searches and %zu slow searches. Is the source really changing so fast?"
+            netdata_log_info("ARL '%s' has %zu fast searches and %zu slow searches. Is the source really changing so fast?"
                  , base->name, base->fast, base->slow);
 
         /*
         if(unlikely(base->iteration % 60 == 0)) {
-            info("ARL '%s' statistics: iteration %zu, expected %zu, wanted %zu, allocated %zu, fred %zu, relinkings %zu, found %zu, added %zu, fast %zu, slow %zu"
+            netdata_log_info("ARL '%s' statistics: iteration %zu, expected %zu, wanted %zu, allocated %zu, fred %zu, relinkings %zu, found %zu, added %zu, fast %zu, slow %zu"
                  , base->name
                  , base->iteration
                  , base->expected
@@ -242,7 +242,7 @@ int arl_find_or_create_and_relink(ARL_BASE *base, const char *s, const char *val
 
 #ifdef NETDATA_INTERNAL_CHECKS
     if(unlikely(base->iteration % 60 == 0 && e->flags & ARL_ENTRY_FLAG_FOUND))
-        info("ARL '%s': entry '%s' is already found. Did you forget to call arl_begin()?", base->name, s);
+        netdata_log_info("ARL '%s': entry '%s' is already found. Did you forget to call arl_begin()?", base->name, s);
 #endif
 
     e->flags |= ARL_ENTRY_FLAG_FOUND;

--- a/libnetdata/adaptive_resortable_list/adaptive_resortable_list.h
+++ b/libnetdata/adaptive_resortable_list/adaptive_resortable_list.h
@@ -94,7 +94,7 @@ static inline int arl_check(ARL_BASE *base, const char *keyword, const char *val
 
 #ifdef NETDATA_INTERNAL_CHECKS
     if(unlikely((base->fast + base->slow) % (base->expected + base->allocated) == 0 && (base->fast + base->slow) > (base->expected + base->allocated) * base->iteration))
-        info("ARL '%s': Did you forget to call arl_begin()?", base->name);
+        netdata_log_info("ARL '%s': Did you forget to call arl_begin()?", base->name);
 #endif
 
     // it should be the first entry (pointed by base->next_keyword)

--- a/libnetdata/aral/aral.c
+++ b/libnetdata/aral/aral.c
@@ -192,7 +192,7 @@ static void aral_delete_leftover_files(const char *name, const char *path, const
             continue;
 
         snprintfz(full_path, FILENAME_MAX, "%s/%s", path, de->d_name);
-        info("ARAL: '%s' removing left-over file '%s'", name, full_path);
+        netdata_log_info("ARAL: '%s' removing left-over file '%s'", name, full_path);
         if(unlikely(unlink(full_path) == -1))
             error("ARAL: '%s' cannot delete file '%s'", name, full_path);
     }
@@ -756,7 +756,7 @@ ARAL *aral_create(const char *name, size_t element_size, size_t initial_page_ele
               ar->config.name, ar->config.requested_element_size, sizeof(uintptr_t), ARAL_NATURAL_ALIGNMENT,
               ar->config.element_size, ar->config.page_ptr_offset);
 
-    //info("ARAL: element size %zu, sizeof(uintptr_t) %zu, natural alignment %zu, final element size %zu, page_ptr_offset %zu",
+    //netdata_log_info("ARAL: element size %zu, sizeof(uintptr_t) %zu, natural alignment %zu, final element size %zu, page_ptr_offset %zu",
     //      ar->element_size, sizeof(uintptr_t), ARAL_NATURAL_ALIGNMENT, ar->internal.element_size, ar->internal.page_ptr_offset);
 
 
@@ -1056,7 +1056,7 @@ int aral_stress_test(size_t threads, size_t elements, size_t seconds) {
         __atomic_add_fetch(&auc.errors, 1, __ATOMIC_RELAXED);
     }
 
-    info("ARAL: did %zu malloc, %zu free, "
+    netdata_log_info("ARAL: did %zu malloc, %zu free, "
          "using %zu threads, in %llu usecs",
          auc.ar->aral_lock.user_malloc_operations,
          auc.ar->aral_lock.user_free_operations,

--- a/libnetdata/clocks/clocks.c
+++ b/libnetdata/clocks/clocks.c
@@ -433,11 +433,11 @@ inline collected_number uptime_msec(char *filename){
 
         if(delta <= 1000 && uptime_boottime != 0) {
             procfile_close(read_proc_uptime_ff);
-            info("Using now_boottime_usec() for uptime (dt is %lld ms)", delta);
+            netdata_log_info("Using now_boottime_usec() for uptime (dt is %lld ms)", delta);
             use_boottime = 1;
         }
         else if(uptime_proc != 0) {
-            info("Using /proc/uptime for uptime (dt is %lld ms)", delta);
+            netdata_log_info("Using /proc/uptime for uptime (dt is %lld ms)", delta);
             use_boottime = 0;
         }
         else {

--- a/libnetdata/config/appconfig.c
+++ b/libnetdata/config/appconfig.c
@@ -653,7 +653,7 @@ int appconfig_load(struct config *root, char *filename, int overwrite_used, cons
 
     FILE *fp = fopen(filename, "r");
     if(!fp) {
-        // info("CONFIG: cannot open file '%s'. Using internal defaults.", filename);
+        // netdata_log_info("CONFIG: cannot open file '%s'. Using internal defaults.", filename);
         return 0;
     }
 

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -183,7 +183,7 @@ static int kernel_is_rejected()
         if (read_file("/proc/version", version_string, VERSION_STRING_LEN)) {
             struct utsname uname_buf;
             if (!uname(&uname_buf)) {
-                info("Cannot check kernel version");
+                netdata_log_info("Cannot check kernel version");
                 return 0;
             }
             version_string_len =
@@ -230,7 +230,7 @@ static int kernel_is_rejected()
     while ((reject_string_len = getline(&reject_string, &buf_len, kernel_reject_list) - 1) > 0) {
         if (version_string_len >= reject_string_len) {
             if (!strncmp(version_string, reject_string, reject_string_len)) {
-                info("A buggy kernel is detected");
+                netdata_log_info("A buggy kernel is detected");
                 fclose(kernel_reject_list);
                 freez(reject_string);
                 return 1;
@@ -496,7 +496,7 @@ void ebpf_update_kernel_memory(ebpf_plugin_stats_t *report, ebpf_local_maps_t *m
                     report->memlock_kern += memsize;
                     report->hash_tables += 1;
 #ifdef NETDATA_DEV_MODE
-                    info("Hash table %u: %s (FD = %d) is consuming %lu bytes totalizing %lu bytes",
+                    netdata_log_info("Hash table %u: %s (FD = %d) is consuming %lu bytes totalizing %lu bytes",
                          report->hash_tables, map->name, map->map_fd, memsize, report->memlock_kern);
 #endif
                     break;
@@ -505,7 +505,7 @@ void ebpf_update_kernel_memory(ebpf_plugin_stats_t *report, ebpf_local_maps_t *m
                     report->memlock_kern -= memsize;
                     report->hash_tables -= 1;
 #ifdef NETDATA_DEV_MODE
-                    info("Hash table %s (FD = %d) was removed releasing %lu bytes, now we have %u tables loaded totalizing %lu bytes.",
+                    netdata_log_info("Hash table %s (FD = %d) was removed releasing %lu bytes, now we have %u tables loaded totalizing %lu bytes.",
                          map->name, map->map_fd, memsize, report->hash_tables, report->memlock_kern);
 #endif
                     break;
@@ -570,7 +570,7 @@ void ebpf_update_map_size(struct bpf_map *map, ebpf_local_maps_t *lmap, ebpf_mod
     if (lmap->user_input && lmap->user_input != lmap->internal_input) {
         define_size = lmap->internal_input;
 #ifdef NETDATA_INTERNAL_CHECKS
-        info("Changing map %s from size %u to %u ", map_name, lmap->internal_input, lmap->user_input);
+        netdata_log_info("Changing map %s from size %u to %u ", map_name, lmap->internal_input, lmap->user_input);
 #endif
     } else if (((lmap->type & apps_type) == apps_type) && (!em->apps_charts) && (!em->cgroup_charts)) {
         lmap->user_input = ND_EBPF_DEFAULT_MIN_PID;
@@ -878,7 +878,7 @@ struct bpf_link **ebpf_load_program(char *plugins_dir, ebpf_module_t *em, int kv
     size_t count_programs =  ebpf_count_programs(*obj);
 
 #ifdef NETDATA_INTERNAL_CHECKS
-    info("eBPF program %s loaded with success!", lpath);
+    netdata_log_info("eBPF program %s loaded with success!", lpath);
 #endif
 
     return ebpf_attach_programs(*obj, count_programs, em->names);
@@ -1107,7 +1107,7 @@ struct btf *ebpf_load_btf_file(char *path, char *filename)
     snprintfz(fullpath, PATH_MAX, "%s/%s", path, filename);
     struct btf *ret = ebpf_parse_btf_file(fullpath);
     if (!ret)
-        info("Your environment does not have BTF file %s/%s. The plugin will work with 'legacy' code.",
+        netdata_log_info("Your environment does not have BTF file %s/%s. The plugin will work with 'legacy' code.",
              path, filename);
 
     return ret;
@@ -1259,7 +1259,7 @@ void ebpf_update_module_using_config(ebpf_module_t *modules, netdata_ebpf_load_m
         modules->maps_per_core = CONFIG_BOOLEAN_NO;
 
 #ifdef NETDATA_DEV_MODE
-    info("The thread %s was configured with: mode = %s; update every = %d; apps = %s; cgroup = %s; ebpf type format = %s; ebpf co-re tracing = %s; collect pid = %s; maps per core = %s",
+    netdata_log_info("The thread %s was configured with: mode = %s; update every = %d; apps = %s; cgroup = %s; ebpf type format = %s; ebpf co-re tracing = %s; collect pid = %s; maps per core = %s",
          modules->thread_name,
          load_mode,
          modules->update_every,

--- a/libnetdata/json/json.c
+++ b/libnetdata/json/json.c
@@ -124,7 +124,7 @@ int json_callback_print(JSON_ENTRY *e)
             buffer_strcat(wb,"NULL");
             break;
     }
-    info("JSON: %s", buffer_tostring(wb));
+    netdata_log_info("JSON: %s", buffer_tostring(wb));
     buffer_free(wb);
     return 0;
 }
@@ -323,7 +323,7 @@ size_t json_walk_array(char *js, jsmntok_t *t, size_t nest, size_t start, JSON_E
     for(i = 0; i < size ; i++) {
         ne.pos = i;
         if (strlen(e->name) > JSON_NAME_LEN  - 24 || strlen(e->fullname) > JSON_FULLNAME_LEN -24) {
-            info("JSON: JSON walk_array ignoring element with name:%s fullname:%s",e->name, e->fullname);
+            netdata_log_info("JSON: JSON walk_array ignoring element with name:%s fullname:%s",e->name, e->fullname);
             continue;
         }
         snprintfz(ne.name, JSON_NAME_LEN, "%s[%lu]", e->name, i);

--- a/libnetdata/libnetdata.c
+++ b/libnetdata/libnetdata.c
@@ -1043,7 +1043,7 @@ void netdata_fix_chart_id(char *s) {
 }
 
 static int memory_file_open(const char *filename, size_t size) {
-    // info("memory_file_open('%s', %zu", filename, size);
+    // netdata_log_info("memory_file_open('%s', %zu", filename, size);
 
     int fd = open(filename, O_RDWR | O_CREAT | O_NOATIME, 0664);
     if (fd != -1) {
@@ -1127,7 +1127,7 @@ inline int madvise_mergeable(void *mem __maybe_unused, size_t len __maybe_unused
 
 void *netdata_mmap(const char *filename, size_t size, int flags, int ksm, bool read_only, int *open_fd)
 {
-    // info("netdata_mmap('%s', %zu", filename, size);
+    // netdata_log_info("netdata_mmap('%s', %zu", filename, size);
 
     // MAP_SHARED is used in memory mode map
     // MAP_PRIVATE is used in memory mode ram and save
@@ -1177,9 +1177,9 @@ void *netdata_mmap(const char *filename, size_t size, int flags, int ksm, bool r
         if(fd != -1 && fd_for_mmap == -1) {
             if (lseek(fd, 0, SEEK_SET) == 0) {
                 if (read(fd, mem, size) != (ssize_t) size)
-                    info("Cannot read from file '%s'", filename);
+                    netdata_log_info("Cannot read from file '%s'", filename);
             }
-            else info("Cannot seek to beginning of file '%s'.", filename);
+            else netdata_log_info("Cannot seek to beginning of file '%s'.", filename);
         }
 
         // madvise_sequential(mem, size);
@@ -1321,14 +1321,14 @@ int recursively_delete_dir(const char *path, const char *reason) {
             continue;
         }
 
-        info("Deleting %s file '%s'", reason?reason:"", fullpath);
+        netdata_log_info("Deleting %s file '%s'", reason?reason:"", fullpath);
         if(unlikely(unlink(fullpath) == -1))
             error("Cannot delete %s file '%s'", reason?reason:"", fullpath);
         else
             ret++;
     }
 
-    info("Deleting empty directory '%s'", path);
+    netdata_log_info("Deleting empty directory '%s'", path);
     if(unlikely(rmdir(path) == -1))
         error("Cannot delete empty directory '%s'", path);
     else
@@ -1399,7 +1399,7 @@ int verify_netdata_host_prefix() {
         goto failed;
 
     if(netdata_configured_host_prefix && *netdata_configured_host_prefix)
-        info("Using host prefix directory '%s'", netdata_configured_host_prefix);
+        netdata_log_info("Using host prefix directory '%s'", netdata_configured_host_prefix);
 
     return 0;
 
@@ -1921,7 +1921,7 @@ void timing_action(TIMING_ACTION action, TIMING_STEP step) {
                 );
             }
 
-            info("TIMINGS REPORT:\n%sTIMINGS REPORT:                        total # %10zu, t %11.2f ms",
+            netdata_log_info("TIMINGS REPORT:\n%sTIMINGS REPORT:                        total # %10zu, t %11.2f ms",
                  buffer_tostring(wb), total_reqs, (double)total_usec / USEC_PER_MS);
 
             memcpy(timings2, timings3, sizeof(timings2));

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -555,7 +555,7 @@ static FILE *open_log_file(int fd, FILE *fp, const char *filename, int *enabled_
             if(fd_ptr) *fd_ptr = fd;
             return fp;
         }
-        // info("dup2() new fd %d to old fd %d for '%s'", f, fd, filename);
+        // netdata_log_info("dup2() new fd %d to old fd %d for '%s'", f, fd, filename);
         close(f);
     }
     else fd = f;

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -118,7 +118,7 @@ typedef struct error_with_limit {
 #define internal_fatal(args...) debug_dummy()
 #endif
 
-#define info(args...)    info_int(0, __FILE__, __FUNCTION__, __LINE__, ##args)
+#define netdata_log_info(args...)    info_int(0, __FILE__, __FUNCTION__, __LINE__, ##args)
 #define collector_info(args...)    info_int(1, __FILE__, __FUNCTION__, __LINE__, ##args)
 #define infoerr(args...) error_int(0, "INFO", __FILE__, __FUNCTION__, __LINE__, ##args)
 #define error(args...)   error_int(0, "ERROR", __FILE__, __FUNCTION__, __LINE__, ##args)

--- a/libnetdata/onewayalloc/onewayalloc.c
+++ b/libnetdata/onewayalloc/onewayalloc.c
@@ -195,7 +195,7 @@ void onewayalloc_destroy(ONEWAYALLOC *owa) {
 
     OWA_PAGE *head = (OWA_PAGE *)owa;
 
-    //info("OWA: %zu allocations of %zu total bytes, in %zu pages of %zu total bytes",
+    //netdata_log_info("OWA: %zu allocations of %zu total bytes, in %zu pages of %zu total bytes",
     //     head->stats_mallocs_made, head->stats_mallocs_size,
     //     head->stats_pages, head->stats_pages_size);
 

--- a/libnetdata/popen/popen.c
+++ b/libnetdata/popen/popen.c
@@ -140,7 +140,7 @@ static int popene_internal(volatile pid_t *pidptr, char **env, uint8_t flags, FI
     // create a string to be logged about the command we are running
     char command_to_be_logged[2048];
     convert_argv_to_string(command_to_be_logged, sizeof(command_to_be_logged), spawn_argv);
-    // info("custom_popene() running command: %s", command_to_be_logged);
+    // netdata_log_info("custom_popene() running command: %s", command_to_be_logged);
 
     int ret = 0;     // success by default
     int attr_rc = 1; // failure by default
@@ -406,11 +406,11 @@ int netdata_pclose(FILE *fp_child_input, FILE *fp_child_output, pid_t pid) {
 
             case CLD_KILLED:
                 if(info.si_status == SIGTERM) {
-                    info("child pid %d killed by SIGTERM", info.si_pid);
+                    netdata_log_info("child pid %d killed by SIGTERM", info.si_pid);
                     return(0);
                 }
                 else if(info.si_status == SIGPIPE) {
-                    info("child pid %d killed by SIGPIPE.", info.si_pid);
+                    netdata_log_info("child pid %d killed by SIGPIPE.", info.si_pid);
                     return(0);
                 }
                 else {

--- a/libnetdata/procfile/procfile.c
+++ b/libnetdata/procfile/procfile.c
@@ -410,7 +410,7 @@ procfile *procfile_open(const char *filename, const char *separators, uint32_t f
         return NULL;
     }
 
-    // info("PROCFILE: opened '%s' on fd %d", filename, fd);
+    // netdata_log_info("PROCFILE: opened '%s' on fd %d", filename, fd);
 
     size_t size = (unlikely(procfile_adaptive_initial_allocation)) ? procfile_max_allocation : PROCFILE_INCREMENT_BUFFER;
     procfile *ff = mallocz(sizeof(procfile) + size);
@@ -435,7 +435,7 @@ procfile *procfile_reopen(procfile *ff, const char *filename, const char *separa
     if(unlikely(!ff)) return procfile_open(filename, separators, flags);
 
     if(likely(ff->fd != -1)) {
-        // info("PROCFILE: closing fd %d", ff->fd);
+        // netdata_log_info("PROCFILE: closing fd %d", ff->fd);
         close(ff->fd);
     }
 
@@ -445,7 +445,7 @@ procfile *procfile_reopen(procfile *ff, const char *filename, const char *separa
         return NULL;
     }
 
-    // info("PROCFILE: opened '%s' on fd %d", filename, ff->fd);
+    // netdata_log_info("PROCFILE: opened '%s' on fd %d", filename, ff->fd);
 
     //strncpyz(ff->filename, filename, FILENAME_MAX);
     freez(ff->filename);

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -585,7 +585,7 @@ void netdata_ssl_initialize_ctx(int selector) {
             if(!netdata_ssl_web_server_ctx) {
                 struct stat statbuf;
                 if (stat(netdata_ssl_security_key, &statbuf) || stat(netdata_ssl_security_cert, &statbuf))
-                    info("To use encryption it is necessary to set \"ssl certificate\" and \"ssl key\" in [web] !\n");
+                    netdata_log_info("To use encryption it is necessary to set \"ssl certificate\" and \"ssl key\" in [web] !\n");
                 else {
                     netdata_ssl_web_server_ctx = netdata_ssl_create_server_ctx(
                             SSL_MODE_ENABLE_PARTIAL_WRITE |
@@ -705,13 +705,13 @@ int ssl_security_location_for_context(SSL_CTX *ctx, char *file, char *path) {
     int load_custom = 1, load_default = 1;
     if (file || path) {
         if(!SSL_CTX_load_verify_locations(ctx, file, path)) {
-            info("Netdata can not verify custom CAfile or CApath for parent's SSL certificate, so it will use the default OpenSSL configuration to validate certificates!");
+            netdata_log_info("Netdata can not verify custom CAfile or CApath for parent's SSL certificate, so it will use the default OpenSSL configuration to validate certificates!");
             load_custom = 0;
         }
     }
 
     if(!SSL_CTX_set_default_verify_paths(ctx)) {
-        info("Can not verify default OpenSSL configuration to validate certificates!");
+        netdata_log_info("Can not verify default OpenSSL configuration to validate certificates!");
         load_default = 0;
     }
 

--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -588,7 +588,7 @@ static inline int bind_to_this(LISTEN_SOCKETS *sockets, const char *definition, 
                 struct sockaddr_in *sin = (struct sockaddr_in *) rp->ai_addr;
                 inet_ntop(AF_INET, &sin->sin_addr, rip, INET_ADDRSTRLEN);
                 rport = ntohs(sin->sin_port);
-                // info("Attempting to listen on IPv4 '%s' ('%s'), port %d ('%s'), socktype %d", rip, ip, rport, port, socktype);
+                // netdata_log_info("Attempting to listen on IPv4 '%s' ('%s'), port %d ('%s'), socktype %d", rip, ip, rport, port, socktype);
                 fd = create_listen_socket4(socktype, rip, rport, listen_backlog);
                 break;
             }
@@ -597,7 +597,7 @@ static inline int bind_to_this(LISTEN_SOCKETS *sockets, const char *definition, 
                 struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *) rp->ai_addr;
                 inet_ntop(AF_INET6, &sin6->sin6_addr, rip, INET6_ADDRSTRLEN);
                 rport = ntohs(sin6->sin6_port);
-                // info("Attempting to listen on IPv6 '%s' ('%s'), port %d ('%s'), socktype %d", rip, ip, rport, port, socktype);
+                // netdata_log_info("Attempting to listen on IPv6 '%s' ('%s'), port %d ('%s'), socktype %d", rip, ip, rport, port, socktype);
                 fd = create_listen_socket6(socktype, scope_id, rip, rport, listen_backlog);
                 break;
             }
@@ -660,7 +660,7 @@ int listen_sockets_setup(LISTEN_SOCKETS *sockets) {
     if(sockets->failed) {
         size_t i;
         for(i = 0; i < sockets->opened ;i++)
-            info("LISTENER: Listen socket %s opened successfully.", sockets->fds_names[i]);
+            netdata_log_info("LISTENER: Listen socket %s opened successfully.", sockets->fds_names[i]);
     }
 
     return (int)sockets->opened;
@@ -810,7 +810,7 @@ int connect_to_this_ip46(int protocol, int socktype, const char *host, uint32_t 
             errno = 0;
             if(connect(fd, ai->ai_addr, ai->ai_addrlen) < 0) {
                 if(errno == EALREADY || errno == EINPROGRESS) {
-                    info("Waiting for connection to ip %s port %s to be established", hostBfr, servBfr);
+                    netdata_log_info("Waiting for connection to ip %s port %s to be established", hostBfr, servBfr);
 
                     // Convert 'struct timeval' to milliseconds for poll():
                     int timeout_milliseconds = timeout->tv_sec * 1000 + timeout->tv_usec / 1000;
@@ -824,7 +824,7 @@ int connect_to_this_ip46(int protocol, int socktype, const char *host, uint32_t 
                         // poll() completed normally. We can check the revents to see what happened
                         if (fds[0].revents & POLLOUT) {
                             // connect() completed successfully, socket is writable.
-                            info("connect() to ip %s port %s completed successfully", hostBfr, servBfr);
+                            netdata_log_info("connect() to ip %s port %s completed successfully", hostBfr, servBfr);
                         }
                         else {
                             // This means that the socket is in error. We will close it and set fd to -1
@@ -1349,7 +1349,7 @@ inline POLLINFO *poll_add_fd(POLLJOB *p
     if(unlikely(fd < 0)) return NULL;
 
     //if(p->limit && p->used >= p->limit) {
-    //    info("Max sockets limit reached (%zu sockets), dropping connection", p->used);
+    //    netdata_log_info("Max sockets limit reached (%zu sockets), dropping connection", p->used);
     //    close(fd);
     //    return NULL;
     //}
@@ -1533,7 +1533,7 @@ int poll_default_rcv_callback(POLLINFO *pi, short int *events) {
             }
         } else if (rc) {
             // data received
-            info("POLLFD: internal error: poll_default_rcv_callback() is discarding %zd bytes received on socket %d", rc, pi->fd);
+            netdata_log_info("POLLFD: internal error: poll_default_rcv_callback() is discarding %zd bytes received on socket %d", rc, pi->fd);
         }
     } while (rc != -1);
 
@@ -1543,7 +1543,7 @@ int poll_default_rcv_callback(POLLINFO *pi, short int *events) {
 int poll_default_snd_callback(POLLINFO *pi, short int *events) {
     *events &= ~POLLOUT;
 
-    info("POLLFD: internal error: poll_default_snd_callback(): nothing to send on socket %d", pi->fd);
+    netdata_log_info("POLLFD: internal error: poll_default_snd_callback(): nothing to send on socket %d", pi->fd);
     return 0;
 }
 
@@ -1773,7 +1773,7 @@ void poll_events(LISTEN_SOCKETS *sockets
         );
 
         pi->data = data;
-        info("POLLFD: LISTENER: listening on '%s'", (sockets->fds_names[i])?sockets->fds_names[i]:"UNKNOWN");
+        netdata_log_info("POLLFD: LISTENER: listening on '%s'", (sockets->fds_names[i])?sockets->fds_names[i]:"UNKNOWN");
     }
 
     int listen_sockets_active = 1;
@@ -1814,7 +1814,7 @@ void poll_events(LISTEN_SOCKETS *sockets
         // enable or disable the TCP listening sockets, based on the current number of sockets used and the limit set
         if((listen_sockets_active && (p.limit && p.used >= p.limit)) || (!listen_sockets_active && (!p.limit || p.used < p.limit))) {
             listen_sockets_active = !listen_sockets_active;
-            info("%s listening sockets (used TCP sockets %zu, max allowed for this worker %zu)", (listen_sockets_active)?"ENABLING":"DISABLING", p.used, p.limit);
+            netdata_log_info("%s listening sockets (used TCP sockets %zu, max allowed for this worker %zu)", (listen_sockets_active)?"ENABLING":"DISABLING", p.used, p.limit);
             for (i = 0; i <= p.max; i++) {
                 if(p.inf[i].flags & POLLINFO_FLAG_SERVER_SOCKET && p.inf[i].socktype == SOCK_STREAM) {
                     p.fds[i].events = (short int) ((listen_sockets_active) ? POLLIN : 0);
@@ -1962,7 +1962,7 @@ void poll_events(LISTEN_SOCKETS *sockets
 
                 if(likely(pi->flags & POLLINFO_FLAG_CLIENT_SOCKET)) {
                     if (unlikely(pi->send_count == 0 && p.complete_request_timeout > 0 && (now - pi->connected_t) >= p.complete_request_timeout)) {
-                        info("POLLFD: LISTENER: client slot %zu (fd %d) from %s port %s has not sent a complete request in %zu seconds - closing it. "
+                        netdata_log_info("POLLFD: LISTENER: client slot %zu (fd %d) from %s port %s has not sent a complete request in %zu seconds - closing it. "
                               , i
                               , pi->fd
                               , pi->client_ip ? pi->client_ip : "<undefined-ip>"
@@ -1972,7 +1972,7 @@ void poll_events(LISTEN_SOCKETS *sockets
                         poll_close_fd(pi);
                     }
                     else if(unlikely(pi->recv_count && p.idle_timeout > 0 && now - ((pi->last_received_t > pi->last_sent_t) ? pi->last_received_t : pi->last_sent_t) >= p.idle_timeout )) {
-                        info("POLLFD: LISTENER: client slot %zu (fd %d) from %s port %s is idle for more than %zu seconds - closing it. "
+                        netdata_log_info("POLLFD: LISTENER: client slot %zu (fd %d) from %s port %s is idle for more than %zu seconds - closing it. "
                               , i
                               , pi->fd
                               , pi->client_ip ? pi->client_ip : "<undefined-ip>"

--- a/libnetdata/storage_number/storage_number.c
+++ b/libnetdata/storage_number/storage_number.c
@@ -52,7 +52,7 @@ bool is_system_ieee754_double(void) {
 
         if(*ptr != tests[i].i && (tests[i].original == tests[i].d || (isnan(tests[i].original) && isnan(tests[i].d)))) {
             if(!logged)
-                info("IEEE754: test #%zu, value " NETDATA_DOUBLE_FORMAT_G " is represented in this system as %lX, but it was expected as %lX",
+                netdata_log_info("IEEE754: test #%zu, value " NETDATA_DOUBLE_FORMAT_G " is represented in this system as %lX, but it was expected as %lX",
                      i+1, tests[i].original, *ptr, tests[i].i);
             errors++;
         }
@@ -60,14 +60,14 @@ bool is_system_ieee754_double(void) {
 
     if(!errors && sizeof(NETDATA_DOUBLE) == sizeof(uint64_t)) {
         if(!logged)
-            info("IEEE754: system is using IEEE754 DOUBLE PRECISION values");
+            netdata_log_info("IEEE754: system is using IEEE754 DOUBLE PRECISION values");
 
         logged = true;
         return true;
     }
     else {
         if(!logged)
-            info("IEEE754: system is NOT compatible with IEEE754 DOUBLE PRECISION values");
+            netdata_log_info("IEEE754: system is NOT compatible with IEEE754 DOUBLE PRECISION values");
 
         logged = true;
         return false;

--- a/libnetdata/threads/threads.c
+++ b/libnetdata/threads/threads.c
@@ -152,7 +152,7 @@ void netdata_threads_init_after_fork(size_t stacksize) {
         if(i != 0)
             error("pthread_attr_setstacksize() to %zu bytes, failed with code %d.", stacksize, i);
         else
-            info("Set threads stack size to %zu bytes", stacksize);
+            netdata_log_info("Set threads stack size to %zu bytes", stacksize);
     }
     else
         error("Invalid pthread stacksize %zu", stacksize);
@@ -173,7 +173,7 @@ static void thread_cleanup(void *ptr) {
     }
 
     if(!(netdata_thread->options & NETDATA_THREAD_OPTION_DONT_LOG_CLEANUP))
-        info("thread with task id %d finished", gettid());
+        netdata_log_info("thread with task id %d finished", gettid());
 
     sender_thread_buffer_free();
     rrdset_thread_rda_free();
@@ -207,7 +207,7 @@ static void thread_set_name_np(NETDATA_THREAD *nt) {
         if (ret != 0)
             error("cannot set pthread name of %d to %s. ErrCode: %d", gettid(), threadname, ret);
         else
-            info("set name of thread %d to %s", gettid(), threadname);
+            netdata_log_info("set name of thread %d to %s", gettid(), threadname);
 
     }
 }
@@ -230,7 +230,7 @@ void uv_thread_set_name_np(uv_thread_t ut, const char* name) {
     thread_name_get(true);
 
     if (ret)
-        info("cannot set libuv thread name to %s. Err: %d", threadname, ret);
+        netdata_log_info("cannot set libuv thread name to %s. Err: %d", threadname, ret);
 }
 
 void os_thread_get_current_name_np(char threadname[NETDATA_THREAD_NAME_MAX + 1])
@@ -247,7 +247,7 @@ static void *netdata_thread_init(void *ptr) {
     netdata_thread = (NETDATA_THREAD *)ptr;
 
     if(!(netdata_thread->options & NETDATA_THREAD_OPTION_DONT_LOG_STARTUP))
-        info("thread created with task id %d", gettid());
+        netdata_log_info("thread created with task id %d", gettid());
 
     if(pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0)
         error("cannot set pthread cancel type to DEFERRED.");

--- a/registry/registry_init.c
+++ b/registry/registry_init.c
@@ -11,7 +11,7 @@ int registry_init(void) {
         registry.enabled = config_get_boolean(CONFIG_SECTION_REGISTRY, "enabled", 0);
     }
     else {
-        info("Registry is disabled - use the central netdata");
+        netdata_log_info("Registry is disabled - use the central netdata");
         config_set_boolean(CONFIG_SECTION_REGISTRY, "enabled", 0);
         registry.enabled = 0;
     }

--- a/registry/registry_internals.c
+++ b/registry/registry_internals.c
@@ -13,7 +13,7 @@ struct registry registry;
 int regenerate_guid(const char *guid, char *result) {
     uuid_t uuid;
     if(unlikely(uuid_parse(guid, uuid) == -1)) {
-        info("Registry: GUID '%s' is not a valid GUID.", guid);
+        netdata_log_info("Registry: GUID '%s' is not a valid GUID.", guid);
         return -1;
     }
     else {
@@ -21,7 +21,7 @@ int regenerate_guid(const char *guid, char *result) {
 
 #ifdef NETDATA_INTERNAL_CHECKS
         if(strcmp(guid, result) != 0)
-            info("GUID '%s' and re-generated GUID '%s' differ!", guid, result);
+            netdata_log_info("GUID '%s' and re-generated GUID '%s' differ!", guid, result);
 #endif /* NETDATA_INTERNAL_CHECKS */
     }
 
@@ -84,7 +84,7 @@ REGISTRY_PERSON_URL *registry_verify_request(char *person_guid, char *machine_gu
     char pbuf[GUID_LEN + 1], mbuf[GUID_LEN + 1];
 
     if(!person_guid || !*person_guid || !machine_guid || !*machine_guid || !url || !*url) {
-        info("Registry Request Verification: invalid request! person: '%s', machine '%s', url '%s'", person_guid?person_guid:"UNSET", machine_guid?machine_guid:"UNSET", url?url:"UNSET");
+        netdata_log_info("Registry Request Verification: invalid request! person: '%s', machine '%s', url '%s'", person_guid?person_guid:"UNSET", machine_guid?machine_guid:"UNSET", url?url:"UNSET");
         return NULL;
     }
 
@@ -93,14 +93,14 @@ REGISTRY_PERSON_URL *registry_verify_request(char *person_guid, char *machine_gu
 
     // make sure the person GUID is valid
     if(regenerate_guid(person_guid, pbuf) == -1) {
-        info("Registry Request Verification: invalid person GUID, person: '%s', machine '%s', url '%s'", person_guid, machine_guid, url);
+        netdata_log_info("Registry Request Verification: invalid person GUID, person: '%s', machine '%s', url '%s'", person_guid, machine_guid, url);
         return NULL;
     }
     person_guid = pbuf;
 
     // make sure the machine GUID is valid
     if(regenerate_guid(machine_guid, mbuf) == -1) {
-        info("Registry Request Verification: invalid machine GUID, person: '%s', machine '%s', url '%s'", person_guid, machine_guid, url);
+        netdata_log_info("Registry Request Verification: invalid machine GUID, person: '%s', machine '%s', url '%s'", person_guid, machine_guid, url);
         return NULL;
     }
     machine_guid = mbuf;
@@ -108,7 +108,7 @@ REGISTRY_PERSON_URL *registry_verify_request(char *person_guid, char *machine_gu
     // make sure the machine exists
     REGISTRY_MACHINE *m = registry_machine_find(machine_guid);
     if(!m) {
-        info("Registry Request Verification: machine not found, person: '%s', machine '%s', url '%s'", person_guid, machine_guid, url);
+        netdata_log_info("Registry Request Verification: machine not found, person: '%s', machine '%s', url '%s'", person_guid, machine_guid, url);
         return NULL;
     }
     if(mm) *mm = m;
@@ -116,18 +116,18 @@ REGISTRY_PERSON_URL *registry_verify_request(char *person_guid, char *machine_gu
     // make sure the person exist
     REGISTRY_PERSON *p = registry_person_find(person_guid);
     if(!p) {
-        info("Registry Request Verification: person not found, person: '%s', machine '%s', url '%s'", person_guid, machine_guid, url);
+        netdata_log_info("Registry Request Verification: person not found, person: '%s', machine '%s', url '%s'", person_guid, machine_guid, url);
         return NULL;
     }
     if(pp) *pp = p;
 
     REGISTRY_PERSON_URL *pu = registry_person_url_index_find(p, url);
     if(!pu) {
-        info("Registry Request Verification: URL not found for person, person: '%s', machine '%s', url '%s'", person_guid, machine_guid, url);
+        netdata_log_info("Registry Request Verification: URL not found for person, person: '%s', machine '%s', url '%s'", person_guid, machine_guid, url);
         return NULL;
     }
     //else if (pu->machine != m) {
-    //    info("Registry Request Verification: Machine mismatch: person: '%s', machine requested='%s' <> loaded='%s', url '%s'", person_guid, machine_guid, pu->machine->guid, url);
+    //    netdata_log_info("Registry Request Verification: Machine mismatch: person: '%s', machine requested='%s' <> loaded='%s', url '%s'", person_guid, machine_guid, pu->machine->guid, url);
     //    return NULL;
     //}
 
@@ -178,7 +178,7 @@ REGISTRY_PERSON *registry_request_delete(char *person_guid, char *machine_guid, 
     // make sure the user is not deleting the url it uses
     /*
     if(!strcmp(delete_url, pu->url->url)) {
-        info("Registry Delete Request: delete URL is the one currently accessed, person: '%s', machine '%s', url '%s', delete url '%s'"
+        netdata_log_info("Registry Delete Request: delete URL is the one currently accessed, person: '%s', machine '%s', url '%s', delete url '%s'"
              , p->guid, m->guid, pu->url->url, delete_url);
         return NULL;
     }
@@ -186,7 +186,7 @@ REGISTRY_PERSON *registry_request_delete(char *person_guid, char *machine_guid, 
 
     REGISTRY_PERSON_URL *dpu = registry_person_url_index_find(p, delete_url);
     if(!dpu) {
-        info("Registry Delete Request: URL not found for person: '%s', machine '%s', url '%s', delete url '%s'", p->guid
+        netdata_log_info("Registry Delete Request: URL not found for person: '%s', machine '%s', url '%s', delete url '%s'", p->guid
              , m->guid, pu->url->url, delete_url);
         return NULL;
     }
@@ -230,7 +230,7 @@ REGISTRY_MACHINE *registry_request_machine(char *person_guid, char *machine_guid
 
     // make sure the machine GUID is valid
     if(regenerate_guid(request_machine, mbuf) == -1) {
-        info("Registry Machine URLs request: invalid machine GUID, person: '%s', machine '%s', url '%s', request machine '%s'", p->guid, m->guid, pu->url->url, request_machine);
+        netdata_log_info("Registry Machine URLs request: invalid machine GUID, person: '%s', machine '%s', url '%s', request machine '%s'", p->guid, m->guid, pu->url->url, request_machine);
         return NULL;
     }
     request_machine = mbuf;
@@ -238,7 +238,7 @@ REGISTRY_MACHINE *registry_request_machine(char *person_guid, char *machine_guid
     // make sure the machine exists
     m = registry_machine_find(request_machine);
     if(!m) {
-        info("Registry Machine URLs request: machine not found, person: '%s', machine '%s', url '%s', request machine '%s'", p->guid, machine_guid, pu->url->url, request_machine);
+        netdata_log_info("Registry Machine URLs request: machine not found, person: '%s', machine '%s', url '%s', request machine '%s'", p->guid, machine_guid, pu->url->url, request_machine);
         return NULL;
     }
 

--- a/registry/registry_machine.c
+++ b/registry/registry_machine.c
@@ -67,7 +67,7 @@ REGISTRY_MACHINE *registry_machine_get(const char *machine_guid, time_t when) {
         // validate it is a GUID
         char buf[GUID_LEN + 1];
         if(unlikely(regenerate_guid(machine_guid, buf) == -1))
-            info("Registry: machine guid '%s' is not a valid guid. Ignoring it.", machine_guid);
+            netdata_log_info("Registry: machine guid '%s' is not a valid guid. Ignoring it.", machine_guid);
         else {
             machine_guid = buf;
             m = registry_machine_find(machine_guid);

--- a/registry/registry_person.c
+++ b/registry/registry_person.c
@@ -153,7 +153,7 @@ REGISTRY_PERSON *registry_person_allocate(const char *person_guid, time_t when) 
                 break;
             }
             else
-                info("Registry: generated person guid '%s' found in the registry. Retrying...", p->guid);
+                netdata_log_info("Registry: generated person guid '%s' found in the registry. Retrying...", p->guid);
         }
     }
     else
@@ -187,7 +187,7 @@ REGISTRY_PERSON *registry_person_get(const char *person_guid, time_t when) {
         char buf[GUID_LEN + 1];
         // validate it is a GUID
         if(unlikely(regenerate_guid(person_guid, buf) == -1))
-            info("Registry: person guid '%s' is not a valid guid. Ignoring it.", person_guid);
+            netdata_log_info("Registry: person guid '%s' is not a valid guid. Ignoring it.", person_guid);
         else {
             person_guid = buf;
             p = registry_person_find(person_guid);

--- a/spawn/spawn.c
+++ b/spawn/spawn.c
@@ -235,7 +235,7 @@ void spawn_init(void)
     struct completion completion;
     int error;
 
-    info("Initializing spawn client.");
+    netdata_log_info("Initializing spawn client.");
 
     init_spawn_cmd_queue();
 
@@ -268,15 +268,15 @@ void spawn_init(void)
             char cmd[64];
             sprintf(cmd, "echo CONCURRENT_STRESS_TEST %d 1>&2", j * CONCURRENT_SPAWNS + i + 1);
             serial[i] = spawn_enq_cmd(cmd);
-            info("Queued command %s for spawning.", cmd);
+            netdata_log_info("Queued command %s for spawning.", cmd);
         }
         int exit_status;
         time_t exec_run_timestamp;
         for (int i = 0; i < CONCURRENT_SPAWNS; ++i) {
-            info("Started waiting for serial %llu exit status %d run timestamp %llu.", serial[i], exit_status,
+            netdata_log_info("Started waiting for serial %llu exit status %d run timestamp %llu.", serial[i], exit_status,
                  exec_run_timestamp);
             spawn_wait_cmd(serial[i], &exit_status, &exec_run_timestamp);
-            info("Finished waiting for serial %llu exit status %d run timestamp %llu.", serial[i], exit_status,
+            netdata_log_info("Finished waiting for serial %llu exit status %d run timestamp %llu.", serial[i], exit_status,
                  exec_run_timestamp);
         }
     }

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -533,7 +533,7 @@ void rrdpush_receive_log_status(struct receiver_state *rpt, const char *msg, con
                           (rpt->hostname && *rpt->hostname) ? rpt->hostname : "-",
                           status);
 
-    info("STREAM '%s' [receive from [%s]:%s]: "
+    netdata_log_info("STREAM '%s' [receive from [%s]:%s]: "
           "%s. "
           "STATUS: %s%s%s%s"
           , rpt->hostname
@@ -671,7 +671,7 @@ static void rrdpush_receive(struct receiver_state *rpt)
     }
 
 #ifdef NETDATA_INTERNAL_CHECKS
-    info("STREAM '%s' [receive from [%s]:%s]: "
+    netdata_log_info("STREAM '%s' [receive from [%s]:%s]: "
          "client willing to stream metrics for host '%s' with machine_guid '%s': "
          "update every = %d, history = %d, memory mode = %s, health %s,%s tags '%s'"
          , rpt->hostname
@@ -717,7 +717,7 @@ static void rrdpush_receive(struct receiver_state *rpt)
 #endif
 
     {
-        // info("STREAM %s [receive from [%s]:%s]: initializing communication...", rrdhost_hostname(rpt->host), rpt->client_ip, rpt->client_port);
+        // netdata_log_info("STREAM %s [receive from [%s]:%s]: initializing communication...", rrdhost_hostname(rpt->host), rpt->client_ip, rpt->client_port);
         char initial_response[HTTP_HEADER_SIZE];
         if (stream_has_capability(rpt, STREAM_CAP_VCAPS)) {
             log_receiver_capabilities(rpt);
@@ -817,7 +817,7 @@ static void rrdpush_receiver_thread_cleanup(void *ptr) {
 
     rrdhost_clear_receiver(rpt);
 
-    info("STREAM '%s' [receive from [%s]:%s]: "
+    netdata_log_info("STREAM '%s' [receive from [%s]:%s]: "
          "receive thread ended (task id %d)"
     , rpt->hostname ? rpt->hostname : "-"
     , rpt->client_ip ? rpt->client_ip : "-", rpt->client_port ? rpt->client_port : "-"
@@ -838,7 +838,7 @@ void *rrdpush_receiver_thread(void *ptr) {
 
     struct receiver_state *rpt = (struct receiver_state *)ptr;
     rpt->tid = gettid();
-    info("STREAM %s [%s]:%s: receive thread created (task id %d)", rpt->hostname, rpt->client_ip, rpt->client_port, rpt->tid);
+    netdata_log_info("STREAM %s [%s]:%s: receive thread created (task id %d)", rpt->hostname, rpt->client_ip, rpt->client_port, rpt->tid);
 
     rrdpush_receive(rpt);
 

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -1606,7 +1606,7 @@ static void verify_all_hosts_charts_are_streaming_now(void) {
     dfe_done(host);
 
     size_t executed = __atomic_load_n(&replication_globals.atomic.executed, __ATOMIC_RELAXED);
-    info("REPLICATION SUMMARY: finished, executed %zu replication requests, %zu charts pending replication",
+    netdata_log_info("REPLICATION SUMMARY: finished, executed %zu replication requests, %zu charts pending replication",
          executed - replication_globals.main_thread.last_executed, errors);
     replication_globals.main_thread.last_executed = executed;
 }

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -57,12 +57,12 @@ static void load_stream_conf() {
     errno = 0;
     char *filename = strdupz_path_subpath(netdata_configured_user_config_dir, "stream.conf");
     if(!appconfig_load(&stream_config, filename, 0, NULL)) {
-        info("CONFIG: cannot load user config '%s'. Will try stock config.", filename);
+        netdata_log_info("CONFIG: cannot load user config '%s'. Will try stock config.", filename);
         freez(filename);
 
         filename = strdupz_path_subpath(netdata_configured_stock_config_dir, "stream.conf");
         if(!appconfig_load(&stream_config, filename, 0, NULL))
-            info("CONFIG: cannot load stock config '%s'. Running with internal defaults.", filename);
+            netdata_log_info("CONFIG: cannot load stock config '%s'. Running with internal defaults.", filename);
     }
     freez(filename);
 }
@@ -156,7 +156,7 @@ int rrdpush_init() {
     netdata_ssl_validate_certificate_sender = !appconfig_get_boolean(&stream_config, CONFIG_SECTION_STREAM, "ssl skip certificate verification", !netdata_ssl_validate_certificate);
 
     if(!netdata_ssl_validate_certificate_sender)
-        info("SSL: streaming senders will skip SSL certificates verification.");
+        netdata_log_info("SSL: streaming senders will skip SSL certificates verification.");
 
     netdata_ssl_ca_path = appconfig_get(&stream_config, CONFIG_SECTION_STREAM, "CApath", NULL);
     netdata_ssl_ca_file = appconfig_get(&stream_config, CONFIG_SECTION_STREAM, "CAfile", NULL);
@@ -485,7 +485,7 @@ RRDSET_STREAM_BUFFER rrdset_push_metric_initialize(RRDSET *st, time_t wall_clock
         return (RRDSET_STREAM_BUFFER) { .wb = NULL, };
     }
     else if(unlikely(host_flags & RRDHOST_FLAG_RRDPUSH_SENDER_LOGGED_STATUS)) {
-        info("STREAM %s [send]: sending metrics to parent...", rrdhost_hostname(host));
+        netdata_log_info("STREAM %s [send]: sending metrics to parent...", rrdhost_hostname(host));
         rrdhost_flag_clear(host, RRDHOST_FLAG_RRDPUSH_SENDER_LOGGED_STATUS);
     }
 
@@ -588,7 +588,7 @@ int connect_to_one_of_destinations(
         if(d->postpone_reconnection_until > now)
             continue;
 
-        info(
+        netdata_log_info(
             "STREAM %s: connecting to '%s' (default port: %d)...",
             rrdhost_hostname(host),
             string2str(d->destination),
@@ -645,7 +645,7 @@ bool destinations_init_add_one(char *entry, void *data) {
     DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(t->list, d, prev, next);
 
     t->count++;
-    info("STREAM: added streaming destination No %d: '%s' to host '%s'", t->count, string2str(d->destination), rrdhost_hostname(t->host));
+    netdata_log_info("STREAM: added streaming destination No %d: '%s' to host '%s'", t->count, string2str(d->destination), rrdhost_hostname(t->host));
 
     return false; // we return false, so that we will get all defined destinations
 }
@@ -882,7 +882,7 @@ int rrdpush_receiver_thread_spawn(struct web_client *w, char *decoded_query_stri
                 rpt->capabilities = convert_stream_version_to_capabilities(1, NULL, false);
 
             if (unlikely(rrdhost_set_system_info_variable(rpt->system_info, name, value))) {
-                info("STREAM '%s' [receive from [%s]:%s]: "
+                netdata_log_info("STREAM '%s' [receive from [%s]:%s]: "
                      "request has parameter '%s' = '%s', which is not used."
                      , (rpt->hostname && *rpt->hostname) ? rpt->hostname : "-"
                      , rpt->client_ip, rpt->client_port
@@ -1155,7 +1155,7 @@ int rrdpush_receiver_thread_spawn(struct web_client *w, char *decoded_query_stri
             // we can proceed with this connection
             receiver_stale = false;
 
-            info("STREAM '%s' [receive from [%s]:%s]: "
+            netdata_log_info("STREAM '%s' [receive from [%s]:%s]: "
                  "stopped previous stale receiver to accept this one."
                  , rpt->hostname
                  , rpt->client_ip, rpt->client_port
@@ -1310,7 +1310,7 @@ void log_receiver_capabilities(struct receiver_state *rpt) {
     BUFFER *wb = buffer_create(100, NULL);
     stream_capabilities_to_string(wb, rpt->capabilities);
 
-    info("STREAM %s [receive from [%s]:%s]: established link with negotiated capabilities: %s",
+    netdata_log_info("STREAM %s [receive from [%s]:%s]: established link with negotiated capabilities: %s",
          rrdhost_hostname(rpt->host), rpt->client_ip, rpt->client_port, buffer_tostring(wb));
 
     buffer_free(wb);
@@ -1320,7 +1320,7 @@ void log_sender_capabilities(struct sender_state *s) {
     BUFFER *wb = buffer_create(100, NULL);
     stream_capabilities_to_string(wb, s->capabilities);
 
-    info("STREAM %s [send to %s]: established link with negotiated capabilities: %s",
+    netdata_log_info("STREAM %s [send to %s]: established link with negotiated capabilities: %s",
          rrdhost_hostname(s->host), s->connected_to, buffer_tostring(wb));
 
     buffer_free(wb);

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -111,7 +111,7 @@ void sender_commit(struct sender_state *s, BUFFER *wb, STREAM_TRAFFIC_TYPE type)
 //    fclose(fp);
 
     if(unlikely(s->buffer->max_size < (src_len + 1) * SENDER_BUFFER_ADAPT_TO_TIMES_MAX_SIZE)) {
-        info("STREAM %s [send to %s]: max buffer size of %zu is too small for a data message of size %zu. Increasing the max buffer size to %d times the max data message size.",
+        netdata_log_info("STREAM %s [send to %s]: max buffer size of %zu is too small for a data message of size %zu. Increasing the max buffer size to %d times the max data message size.",
               rrdhost_hostname(s->host), s->connected_to, s->buffer->max_size, buffer_strlen(wb) + 1, SENDER_BUFFER_ADAPT_TO_TIMES_MAX_SIZE);
 
         s->buffer->max_size = (src_len + 1) * SENDER_BUFFER_ADAPT_TO_TIMES_MAX_SIZE;
@@ -585,7 +585,7 @@ static bool rrdpush_sender_thread_connect_to_parent(RRDHOST *host, int default_p
         return false;
     }
 
-    // info("STREAM %s [send to %s]: initializing communication...", rrdhost_hostname(host), s->connected_to);
+    // netdata_log_info("STREAM %s [send to %s]: initializing communication...", rrdhost_hostname(host), s->connected_to);
 
     // reset our capabilities to default
     s->capabilities = stream_our_capabilities(host, true);
@@ -1165,7 +1165,7 @@ static void rrdpush_sender_thread_cleanup_callback(void *ptr) {
     RRDHOST *host = s->host;
 
     sender_lock(host->sender);
-    info("STREAM %s [send]: sending thread exits %s",
+    netdata_log_info("STREAM %s [send]: sending thread exits %s",
          rrdhost_hostname(host),
          host->sender->exit.reason != STREAM_HANDSHAKE_NEVER ? stream_handshake_error_to_string(host->sender->exit.reason) : "");
 
@@ -1251,7 +1251,7 @@ void *rrdpush_sender_thread(void *ptr) {
 
     rrdpush_initialize_ssl_ctx(s->host);
 
-    info("STREAM %s [send]: thread created (task id %d)", rrdhost_hostname(s->host), gettid());
+    netdata_log_info("STREAM %s [send]: thread created (task id %d)", rrdhost_hostname(s->host), gettid());
 
     s->timeout = (int)appconfig_get_number(
         &stream_config, CONFIG_SECTION_STREAM, "timeout seconds", 600);
@@ -1324,7 +1324,7 @@ void *rrdpush_sender_thread(void *ptr) {
             s->replication.oldest_request_after_t = 0;
 
             rrdhost_flag_set(s->host, RRDHOST_FLAG_RRDPUSH_SENDER_READY_4_METRICS);
-            info("STREAM %s [send to %s]: enabling metrics streaming...", rrdhost_hostname(s->host), s->connected_to);
+            netdata_log_info("STREAM %s [send to %s]: enabling metrics streaming...", rrdhost_hostname(s->host), s->connected_to);
 
             continue;
         }

--- a/web/api/formatters/csv/csv.c
+++ b/web/api/formatters/csv/csv.c
@@ -4,7 +4,7 @@
 #include "csv.h"
 
 void rrdr2csv(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, const char *startline, const char *separator, const char *endline, const char *betweenlines) {
-    //info("RRD2CSV(): %s: BEGIN", r->st->id);
+    //netdata_log_info("RRD2CSV(): %s: BEGIN", r->st->id);
     long c, i;
     const long used = (long)r->d;
 
@@ -104,5 +104,5 @@ void rrdr2csv(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, const 
 
         buffer_strcat(wb, endline);
     }
-    //info("RRD2CSV(): %s: END", r->st->id);
+    //netdata_log_info("RRD2CSV(): %s: END", r->st->id);
 }

--- a/web/api/formatters/json/json.c
+++ b/web/api/formatters/json/json.c
@@ -6,7 +6,7 @@
 #define JSON_DATES_TIMESTAMP 2
 
 void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
-    //info("RRD2JSON(): %s: BEGIN", r->st->id);
+    //netdata_log_info("RRD2JSON(): %s: BEGIN", r->st->id);
     int row_annotations = 0, dates, dates_with_new = 0;
     char kq[2] = "",                        // key quote
             sq[2] = "",                     // string quote
@@ -241,7 +241,7 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
     }
 
     buffer_strcat(wb, finish);
-    //info("RRD2JSON(): %s: END", r->st->id);
+    //netdata_log_info("RRD2JSON(): %s: END", r->st->id);
 }
 
 void rrdr2json_v2(RRDR *r, BUFFER *wb) {

--- a/web/api/formatters/ssv/ssv.c
+++ b/web/api/formatters/ssv/ssv.c
@@ -3,7 +3,7 @@
 #include "ssv.h"
 
 void rrdr2ssv(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, const char *prefix, const char *separator, const char *suffix) {
-    //info("RRD2SSV(): %s: BEGIN", r->st->id);
+    //netdata_log_info("RRD2SSV(): %s: BEGIN", r->st->id);
     long i;
 
     buffer_strcat(wb, prefix);
@@ -41,5 +41,5 @@ void rrdr2ssv(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, const char *prefix, con
             buffer_print_netdata_double(wb, v);
     }
     buffer_strcat(wb, suffix);
-    //info("RRD2SSV(): %s: END", r->st->id);
+    //netdata_log_info("RRD2SSV(): %s: END", r->st->id);
 }

--- a/web/api/health/health_cmdapi.c
+++ b/web/api/health/health_cmdapi.c
@@ -96,7 +96,7 @@ void health_silencers2file(BUFFER *wb) {
     if(fd) {
         size_t written = (size_t)fprintf(fd, "%s", wb->buffer) ;
         if (written == wb->len ) {
-            info("Silencer changes written to %s", silencers_filename);
+            netdata_log_info("Silencer changes written to %s", silencers_filename);
         }
         fclose(fd);
         return;

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -1627,7 +1627,7 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
                 new_point.sp.start_time_s = last1_point.sp.end_time_s;
                 new_point.sp.end_time_s   = now_end_time;
 //
-//                if(debug_this) info("QUERY: is finished() returned true");
+//                if(debug_this) netdata_log_info("QUERY: is finished() returned true");
 //
                 break;
             }
@@ -1687,7 +1687,7 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
                 query_point_set_id(new_point, ops->db_total_points_read);
 
 //                if(debug_this)
-//                    info("QUERY: got point %zu, from time %ld to %ld   //   now from %ld to %ld   //   query from %ld to %ld",
+//                    netdata_log_info("QUERY: got point %zu, from time %ld to %ld   //   now from %ld to %ld   //   query from %ld to %ld",
 //                         new_point.id, new_point.start_time, new_point.end_time, now_start_time, now_end_time, after_wanted, before_wanted);
 //
                 // get the right value from the point we got
@@ -2158,7 +2158,7 @@ bool rrdr_relative_window_to_absolute(time_t *after, time_t *before, time_t *now
 #define query_debug_log_init() BUFFER *debug_log = buffer_create(1000)
 #define query_debug_log(args...) buffer_sprintf(debug_log, ##args)
 #define query_debug_log_fin() { \
-        info("QUERY: '%s', after:%ld, before:%ld, duration:%ld, points:%zu, res:%ld - wanted => after:%ld, before:%ld, points:%zu, group:%zu, granularity:%ld, resgroup:%ld, resdiv:" NETDATA_DOUBLE_FORMAT_AUTO " %s", qt->id, after_requested, before_requested, before_requested - after_requested, points_requested, resampling_time_requested, after_wanted, before_wanted, points_wanted, group, query_granularity, resampling_group, resampling_divisor, buffer_tostring(debug_log)); \
+        netdata_log_info("QUERY: '%s', after:%ld, before:%ld, duration:%ld, points:%zu, res:%ld - wanted => after:%ld, before:%ld, points:%zu, group:%zu, granularity:%ld, resgroup:%ld, resdiv:" NETDATA_DOUBLE_FORMAT_AUTO " %s", qt->id, after_requested, before_requested, before_requested - after_requested, points_requested, resampling_time_requested, after_wanted, before_wanted, points_wanted, group, query_granularity, resampling_group, resampling_divisor, buffer_tostring(debug_log)); \
         buffer_free(debug_log); \
         debug_log = NULL; \
     }

--- a/web/api/queries/weights.c
+++ b/web/api/queries/weights.c
@@ -1447,7 +1447,7 @@ static void rrdset_metric_correlations_volume(
     merge_query_value_to_stats(&highlight_countif, stats, 1);
 
     if(!netdata_double_isnumber(highlight_countif.value)) {
-        info("WEIGHTS: highlighted countif query failed, but highlighted average worked - strange...");
+        netdata_log_info("WEIGHTS: highlighted countif query failed, but highlighted average worked - strange...");
         return;
     }
 

--- a/web/api/tests/valid_urls.c
+++ b/web/api/tests/valid_urls.c
@@ -46,7 +46,7 @@ void repr(char *result, int result_size, char const *buf, int size)
 
 ssize_t send(int sockfd, const void *buf, size_t len, int flags)
 {
-    info("Mocking send: %zu bytes\n", len);
+    netdata_log_info("Mocking send: %zu bytes\n", len);
     (void)sockfd;
     (void)buf;
     (void)flags;

--- a/web/api/tests/web_api.c
+++ b/web/api/tests/web_api.c
@@ -46,7 +46,7 @@ void repr(char *result, int result_size, char const *buf, int size)
 
 ssize_t send(int sockfd, const void *buf, size_t len, int flags)
 {
-    info("Mocking send: %zu bytes\n", len);
+    netdata_log_info("Mocking send: %zu bytes\n", len);
     (void)sockfd;
     (void)buf;
     (void)flags;
@@ -85,7 +85,7 @@ int __wrap_web_client_api_request_v1(RRDHOST *host, struct web_client *w, char *
 {
     char url_repr[160];
     repr(url_repr, sizeof(url_repr), url, strlen(url));
-    info("web_client_api_request_v1(url=\"%s\")\n", url_repr);
+    netdata_log_info("web_client_api_request_v1(url=\"%s\")\n", url_repr);
     check_expected_ptr(host);
     check_expected_ptr(w);
     check_expected_ptr(url_repr);
@@ -302,7 +302,7 @@ static void api_info(void **state)
 
     char buffer_repr[1024];
     repr(buffer_repr, sizeof(buffer_repr), def->instance->response.data->buffer,def->prefix_len);
-    info("Buffer contains: %s [first %zu]", buffer_repr,def->prefix_len);
+    netdata_log_info("Buffer contains: %s [first %zu]", buffer_repr,def->prefix_len);
     if (def->prefix_len == def->full_len) {
         expect_value(__wrap_web_client_api_request_v1, host, localhost);
         expect_value(__wrap_web_client_api_request_v1, w, def->instance);

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -200,7 +200,7 @@ char *get_mgmt_api_key(void) {
     return guid;
 
 temp_key:
-    info("You can still continue to use the alarm management API using the authorization token %s during this Netdata session only.", guid);
+    netdata_log_info("You can still continue to use the alarm management API using the authorization token %s during this Netdata session only.", guid);
     return guid;
 }
 

--- a/web/rtc/webrtc.c
+++ b/web/rtc/webrtc.c
@@ -25,7 +25,7 @@ static void webrtc_log(rtcLogLevel level, const char *message) {
             break;
 
         case RTC_LOG_INFO:
-            info("WEBRTC: %s", message);
+            netdata_log_info("WEBRTC: %s", message);
             break;
 
         default:

--- a/web/server/static/static-threaded.c
+++ b/web/server/static/static-threaded.c
@@ -394,7 +394,7 @@ cleanup:
 static void socket_listen_main_static_threaded_worker_cleanup(void *ptr) {
     worker_private = (struct web_server_static_threaded_worker *)ptr;
 
-    info("stopped after %zu connects, %zu disconnects (max concurrent %zu), %zu receptions and %zu sends",
+    netdata_log_info("stopped after %zu connects, %zu disconnects (max concurrent %zu), %zu receptions and %zu sends",
             worker_private->connected,
             worker_private->disconnected,
             worker_private->max_concurrent,
@@ -462,16 +462,16 @@ static void socket_listen_main_static_threaded_cleanup(void *ptr) {
 //    for(i = 1; i < static_threaded_workers_count; i++) {
 //        if(static_workers_private_data[i].running) {
 //            found++;
-//            info("stopping worker %d", i + 1);
+//            netdata_log_info("stopping worker %d", i + 1);
 //            netdata_thread_cancel(static_workers_private_data[i].thread);
 //        }
 //        else
-//            info("found stopped worker %d", i + 1);
+//            netdata_log_info("found stopped worker %d", i + 1);
 //    }
 //
 //    while(found && max > 0) {
 //        max -= step;
-//        info("Waiting %d static web threads to finish...", found);
+//        netdata_log_info("Waiting %d static web threads to finish...", found);
 //        sleep_usec(step);
 //        found = 0;
 //
@@ -485,10 +485,10 @@ static void socket_listen_main_static_threaded_cleanup(void *ptr) {
 //    if(found)
 //        error("%d static web threads are taking too long to finish. Giving up.", found);
 
-    info("closing all web server sockets...");
+    netdata_log_info("closing all web server sockets...");
     listen_sockets_close(&api_sockets);
 
-    info("all static web threads stopped.");
+    netdata_log_info("all static web threads stopped.");
     static_thread->enabled = NETDATA_MAIN_THREAD_EXITED;
 }
 
@@ -502,7 +502,7 @@ void *socket_listen_main_static_threaded(void *ptr) {
     netdata_ssl_validate_certificate = !config_get_boolean(CONFIG_SECTION_WEB, "ssl skip certificate verification", !netdata_ssl_validate_certificate);
 
     if(!netdata_ssl_validate_certificate_sender)
-        info("SSL: web server will skip SSL certificates verification.");
+        netdata_log_info("SSL: web server will skip SSL certificates verification.");
 
 #ifdef ENABLE_HTTPS
     netdata_ssl_initialize_ctx(NETDATA_SSL_WEB_SERVER_CTX);
@@ -514,7 +514,7 @@ void *socket_listen_main_static_threaded(void *ptr) {
     int def_thread_count = MIN(get_netdata_cpus(), 6);
 
     if (!strcmp(config_get(CONFIG_SECTION_WEB, "mode", ""),"single-threaded")) {
-                info("Running web server with one thread, because mode is single-threaded");
+                netdata_log_info("Running web server with one thread, because mode is single-threaded");
                 config_set(CONFIG_SECTION_WEB, "mode", "static-threaded");
                 def_thread_count = 1;
     }
@@ -526,7 +526,7 @@ void *socket_listen_main_static_threaded(void *ptr) {
     // See https://github.com/netdata/netdata/issues/11081#issuecomment-831998240 for more details
     if (OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110) {
         static_threaded_workers_count = 1;
-        info("You are running an OpenSSL older than 1.1.0, web server will not enable multithreading.");
+        netdata_log_info("You are running an OpenSSL older than 1.1.0, web server will not enable multithreading.");
     }
 #endif
 
@@ -546,7 +546,7 @@ void *socket_listen_main_static_threaded(void *ptr) {
         char tag[50 + 1];
         snprintfz(tag, 50, "WEB[%d]", i+1);
 
-        info("starting worker %d", i+1);
+        netdata_log_info("starting worker %d", i+1);
         netdata_thread_create(&static_workers_private_data[i].thread, tag, NETDATA_THREAD_OPTION_DEFAULT,
                               socket_listen_main_static_threaded_worker, (void *)&static_workers_private_data[i]);
     }

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -285,7 +285,7 @@ static struct {
 };
 
 static inline uint8_t contenttype_for_filename(const char *filename) {
-    // info("checking filename '%s'", filename);
+    // netdata_log_info("checking filename '%s'", filename);
 
     static int initialized = 0;
     int i;
@@ -306,22 +306,22 @@ static inline uint8_t contenttype_for_filename(const char *filename) {
     }
 
     if(unlikely(!last_dot || !*last_dot || !last_dot[1])) {
-        // info("no extension for filename '%s'", filename);
+        // netdata_log_info("no extension for filename '%s'", filename);
         return CT_APPLICATION_OCTET_STREAM;
     }
     last_dot++;
 
-    // info("extension for filename '%s' is '%s'", filename, last_dot);
+    // netdata_log_info("extension for filename '%s' is '%s'", filename, last_dot);
 
     uint32_t hash = simple_hash(last_dot);
     for(i = 0; mime_types[i].extension ; i++) {
         if(unlikely(hash == mime_types[i].hash && !strcmp(last_dot, mime_types[i].extension))) {
-            // info("matched extension for filename '%s': '%s'", filename, last_dot);
+            // netdata_log_info("matched extension for filename '%s': '%s'", filename, last_dot);
             return mime_types[i].contenttype;
         }
     }
 
-    // info("not matched extension for filename '%s': '%s'", filename, last_dot);
+    // netdata_log_info("not matched extension for filename '%s': '%s'", filename, last_dot);
     return CT_APPLICATION_OCTET_STREAM;
 }
 
@@ -1017,7 +1017,7 @@ static inline HTTP_VALIDATION http_request_validate(struct web_client *w) {
         is_it_valid = url_is_request_complete(s, &s[last_pos], w->header_parse_last_size, &w->post_payload, &w->post_payload_size);
         if(!is_it_valid) {
             if(w->header_parse_tries > HTTP_REQ_MAX_HEADER_FETCH_TRIES) {
-                info("Disabling slow client after %zu attempts to read the request (%zu bytes received)", w->header_parse_tries, buffer_strlen(w->response.data));
+                netdata_log_info("Disabling slow client after %zu attempts to read the request (%zu bytes received)", w->header_parse_tries, buffer_strlen(w->response.data));
                 w->header_parse_tries = 0;
                 w->header_parse_last_size = 0;
                 web_client_disable_wait_receive(w);


### PR DESCRIPTION
I apologise in advance for the gigantic PR.

##### Summary
The `info` macro is terribly generic, and can cause compilation problems with other software.

In particular, newer versions of Protobuf (22+) pull in Abseil, which defines an `info` function[^1] that is broken by the `info` macro defined in `libnetdata/log/log.h`.

This change will help unblock us at Homebrew, where we are trying to switch our packages to using a newer version of `protobuf`.[^2]

[^1]: https://github.com/abseil/abseil-cpp/blob/e6c09ae4b2acd421a29706f86e66eaa422262ad0/absl/strings/internal/cordz_update_scope.h#L61
[^2]: https://github.com/Homebrew/homebrew-core/pull/133746

##### Test Plan

I successfully built v1.40.0 with a backported version of this patch using the netdata [Homebrew formula](https://github.com/Homebrew/homebrew-core/blob/467a1c240301f7179830aeb762ba3baf1e79cecd/Formula/netdata.rb). This build would have failed if I failed to change an instance of the `info` macro to `netdata_log_info`. Similarly, it is very likely that making this change where it was not appropriate would've caused a build failure too.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
This will unblock building against newer versions of Protobuf, which presumably will happen at some point.  
<!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>