### PR TITLE
exporting: change priority to synchronous when calculating value

### DIFF
--- a/exporting/process_data.c
+++ b/exporting/process_data.c
@@ -126,7 +126,7 @@ NETDATA_DOUBLE exporting_calculate_value_from_stored_data(
     size_t counter = 0;
     NETDATA_DOUBLE sum = 0;
 
-    for (storage_engine_query_init(rd->tiers[0].backend, rd->tiers[0].db_metric_handle, &handle, after, before, STORAGE_PRIORITY_LOW); !storage_engine_query_is_finished(&handle);) {
+    for (storage_engine_query_init(rd->tiers[0].backend, rd->tiers[0].db_metric_handle, &handle, after, before, STORAGE_PRIORITY_SYNCHRONOUS); !storage_engine_query_is_finished(&handle);) {
         STORAGE_POINT sp = storage_engine_query_next_metric(&handle);
         points_read++;
 


### PR DESCRIPTION
##### Summary

Fixes: #15272



##### Test Plan

Tested on a parent instance with ~250 children, 1.3M metrics. 

Without this change, it takes 2-5 minutes to process `/api/v1/allmetrics?format=prometheus_all_hosts`.

After this change - 10-20 seconds.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
