### PR TITLE
Optimizations part 2

### DIFF
--- a/collectors/plugins.d/gperf-config.txt
+++ b/collectors/plugins.d/gperf-config.txt
@@ -1,43 +1,52 @@
+%struct-type
+%omit-struct-type
+%define hash-function-name gperf_keyword_hash_function
+%define lookup-function-name gperf_lookup_keyword
+%define word-array-name gperf_keywords
+%define constants-prefix GPERF_PARSER_
+%define slot-name keyword
+%global-table
+%null-strings
 PARSER_KEYWORD;
 %%
 #
 # Plugins Only Keywords
 #
-FLUSH,                  pluginsd_flush,                             PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 1
-DISABLE,                pluginsd_disable,                           PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 2
-EXIT,                   pluginsd_exit,                              PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 3
-HOST,                   pluginsd_host,                              PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 4
-HOST_DEFINE,            pluginsd_host_define,                       PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 5
-HOST_DEFINE_END,        pluginsd_host_define_end,                   PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 6
-HOST_LABEL,             pluginsd_host_labels,                       PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 7
+FLUSH,                  97, PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 1
+DISABLE,                98, PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 2
+EXIT,                   99, PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 3
+HOST,                   71, PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 4
+HOST_DEFINE,            72, PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 5
+HOST_DEFINE_END,        73, PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 6
+HOST_LABEL,             74, PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 7
 #
 # Common keywords
 #
-BEGIN,                  pluginsd_begin,                             PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 8
-CHART,                  pluginsd_chart,                             PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 9
-CLABEL,                 pluginsd_clabel,                            PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 10
-CLABEL_COMMIT,          pluginsd_clabel_commit,                     PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 11
-DIMENSION,              pluginsd_dimension,                         PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 12
-END,                    pluginsd_end,                               PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 13
-FUNCTION,               pluginsd_function,                          PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 14
-FUNCTION_RESULT_BEGIN,  pluginsd_function_result_begin,             PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 15
-LABEL,                  pluginsd_label,                             PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 16
-OVERWRITE,              pluginsd_overwrite,                         PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 17
-SET,                    pluginsd_set,                               PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 18
-VARIABLE,               pluginsd_variable,                          PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 19
+BEGIN,                  12, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 8
+CHART,                  32, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 9
+CLABEL,                 34, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 10
+CLABEL_COMMIT,          35, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 11
+DIMENSION,              31, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 12
+END,                    13, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 13
+FUNCTION,               41, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 14
+FUNCTION_RESULT_BEGIN,  42, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 15
+LABEL,                  51, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 16
+OVERWRITE,              52, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 17
+SET,                    11, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 18
+VARIABLE,               53, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 19
 #
 # Streaming only keywords
 #
-CLAIMED_ID,             streaming_claimed_id,                       PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 20
-BEGIN2,                 pluginsd_begin_v2,                          PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 21
-SET2,                   pluginsd_set_v2,                            PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 22
-END2,                   pluginsd_end_v2,                            PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 23
+CLAIMED_ID,             61, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 20
+BEGIN2,                  2, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 21
+SET2,                    1, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 22
+END2,                    3, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 23
 #
 # Streaming Replication keywords
 #
-CHART_DEFINITION_END,   pluginsd_chart_definition_end,              PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 24
-RBEGIN,                 pluginsd_replay_begin,                      PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 25
-RDSTATE,                pluginsd_replay_rrddim_collection_state,    PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 26
-REND,                   pluginsd_replay_end,                        PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 27
-RSET,                   pluginsd_replay_set,                        PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 28
-RSSTATE,                pluginsd_replay_rrdset_collection_state,    PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 29
+CHART_DEFINITION_END,   33, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 24
+RBEGIN,                 22, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 25
+RDSTATE,                23, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 26
+REND,                   25, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 27
+RSET,                   21, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 28
+RSSTATE,                24, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 29

--- a/collectors/plugins.d/gperf-hashtable.h
+++ b/collectors/plugins.d/gperf-hashtable.h
@@ -1,6 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
 /* ANSI-C code produced by gperf version 3.1 */
-/* Command-line: gperf --multiple-iterations=1000 --hash-function-name=gperf_keyword_hash_function --lookup-function-name=gperf_lookup_keyword --word-array-name=gperf_keywords --constants-prefix=GPERF_PARSER_ --struct-type --slot-name=keyword --global-table --null-strings --omit-struct-type --output-file=gperf-hashtable.h gperf-config.txt  */
+/* Command-line: gperf --multiple-iterations=1000 --output-file=gperf-hashtable.h gperf-config.txt  */
 /* Computed positions: -k'1-2' */
 
 #if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
@@ -83,66 +82,66 @@ gperf_keyword_hash_function (register const char *str, register size_t len)
 static PARSER_KEYWORD gperf_keywords[] =
   {
     {(char*)0}, {(char*)0}, {(char*)0}, {(char*)0},
-#line 9 "gperf-config.txt"
-    {"HOST",                   pluginsd_host,                              PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 4},
-#line 42 "gperf-config.txt"
-    {"RSET",                   pluginsd_replay_set,                        PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 28},
-#line 17 "gperf-config.txt"
-    {"CHART",                  pluginsd_chart,                             PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 9},
-    {(char*)0},
-#line 43 "gperf-config.txt"
-    {"RSSTATE",                pluginsd_replay_rrdset_collection_state,    PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 29},
-#line 40 "gperf-config.txt"
-    {"RDSTATE",                pluginsd_replay_rrddim_collection_state,    PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 26},
-#line 12 "gperf-config.txt"
-    {"HOST_LABEL",             pluginsd_host_labels,                       PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 7},
-#line 10 "gperf-config.txt"
-    {"HOST_DEFINE",            pluginsd_host_define,                       PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 5},
-#line 26 "gperf-config.txt"
-    {"SET",                    pluginsd_set,                               PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 18},
-#line 33 "gperf-config.txt"
-    {"SET2",                   pluginsd_set_v2,                            PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 22},
-#line 41 "gperf-config.txt"
-    {"REND",                   pluginsd_replay_end,                        PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 27},
-#line 11 "gperf-config.txt"
-    {"HOST_DEFINE_END",        pluginsd_host_define_end,                   PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 6},
 #line 18 "gperf-config.txt"
-    {"CLABEL",                 pluginsd_clabel,                            PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 10},
-#line 39 "gperf-config.txt"
-    {"RBEGIN",                 pluginsd_replay_begin,                      PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 25},
-#line 6 "gperf-config.txt"
-    {"FLUSH",                  pluginsd_flush,                             PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 1},
-#line 22 "gperf-config.txt"
-    {"FUNCTION",               pluginsd_function,                          PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 14},
-#line 31 "gperf-config.txt"
-    {"CLAIMED_ID",             streaming_claimed_id,                       PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 20},
-#line 38 "gperf-config.txt"
-    {"CHART_DEFINITION_END",   pluginsd_chart_definition_end,              PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 24},
-#line 25 "gperf-config.txt"
-    {"OVERWRITE",              pluginsd_overwrite,                         PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 17},
-#line 19 "gperf-config.txt"
-    {"CLABEL_COMMIT",          pluginsd_clabel_commit,                     PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 11},
-#line 16 "gperf-config.txt"
-    {"BEGIN",                  pluginsd_begin,                             PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 8},
-#line 32 "gperf-config.txt"
-    {"BEGIN2",                 pluginsd_begin_v2,                          PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 21},
+    {"HOST",                   71, PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 4},
+#line 51 "gperf-config.txt"
+    {"RSET",                   21, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 28},
+#line 26 "gperf-config.txt"
+    {"CHART",                  32, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 9},
+    {(char*)0},
+#line 52 "gperf-config.txt"
+    {"RSSTATE",                24, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 29},
+#line 49 "gperf-config.txt"
+    {"RDSTATE",                23, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 26},
 #line 21 "gperf-config.txt"
-    {"END",                    pluginsd_end,                               PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 13},
-#line 34 "gperf-config.txt"
-    {"END2",                   pluginsd_end_v2,                            PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 23},
-#line 7 "gperf-config.txt"
-    {"DISABLE",                pluginsd_disable,                           PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 2},
-#line 24 "gperf-config.txt"
-    {"LABEL",                  pluginsd_label,                             PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 16},
+    {"HOST_LABEL",             74, PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 7},
+#line 19 "gperf-config.txt"
+    {"HOST_DEFINE",            72, PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 5},
+#line 35 "gperf-config.txt"
+    {"SET",                    11, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 18},
+#line 42 "gperf-config.txt"
+    {"SET2",                    1, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 22},
+#line 50 "gperf-config.txt"
+    {"REND",                   25, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 27},
 #line 20 "gperf-config.txt"
-    {"DIMENSION",              pluginsd_dimension,                         PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 12},
-#line 8 "gperf-config.txt"
-    {"EXIT",                   pluginsd_exit,                              PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 3},
-#line 23 "gperf-config.txt"
-    {"FUNCTION_RESULT_BEGIN",  pluginsd_function_result_begin,             PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 15},
-    {(char*)0}, {(char*)0}, {(char*)0},
+    {"HOST_DEFINE_END",        73, PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 6},
 #line 27 "gperf-config.txt"
-    {"VARIABLE",               pluginsd_variable,                          PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 19}
+    {"CLABEL",                 34, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 10},
+#line 48 "gperf-config.txt"
+    {"RBEGIN",                 22, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 25},
+#line 15 "gperf-config.txt"
+    {"FLUSH",                  97, PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 1},
+#line 31 "gperf-config.txt"
+    {"FUNCTION",               41, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 14},
+#line 40 "gperf-config.txt"
+    {"CLAIMED_ID",             61, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 20},
+#line 47 "gperf-config.txt"
+    {"CHART_DEFINITION_END",   33, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 24},
+#line 34 "gperf-config.txt"
+    {"OVERWRITE",              52, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 17},
+#line 28 "gperf-config.txt"
+    {"CLABEL_COMMIT",          35, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 11},
+#line 25 "gperf-config.txt"
+    {"BEGIN",                  12, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 8},
+#line 41 "gperf-config.txt"
+    {"BEGIN2",                  2, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 21},
+#line 30 "gperf-config.txt"
+    {"END",                    13, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 13},
+#line 43 "gperf-config.txt"
+    {"END2",                    3, PARSER_INIT_STREAMING,                       WORKER_PARSER_FIRST_JOB + 23},
+#line 16 "gperf-config.txt"
+    {"DISABLE",                98, PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 2},
+#line 33 "gperf-config.txt"
+    {"LABEL",                  51, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 16},
+#line 29 "gperf-config.txt"
+    {"DIMENSION",              31, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 12},
+#line 17 "gperf-config.txt"
+    {"EXIT",                   99, PARSER_INIT_PLUGINSD,                       WORKER_PARSER_FIRST_JOB + 3},
+#line 32 "gperf-config.txt"
+    {"FUNCTION_RESULT_BEGIN",  42, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 15},
+    {(char*)0}, {(char*)0}, {(char*)0},
+#line 36 "gperf-config.txt"
+    {"VARIABLE",               53, PARSER_INIT_PLUGINSD|PARSER_INIT_STREAMING, WORKER_PARSER_FIRST_JOB + 19}
   };
 
 PARSER_KEYWORD *

--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -2026,6 +2026,100 @@ PARSER *parser_init(struct parser_user_object *user, FILE *fp_input, FILE *fp_ou
     return parser;
 }
 
+PARSER_RC parser_execute(PARSER *parser, PARSER_KEYWORD *keyword, char **words, size_t num_words) {
+    switch(keyword->id) {
+        case 1:
+            return pluginsd_set_v2(words, num_words, parser);
+
+        case 2:
+            return pluginsd_begin_v2(words, num_words, parser);
+
+        case 3:
+            return pluginsd_end_v2(words, num_words, parser);
+
+        case 11:
+            return pluginsd_set(words, num_words, parser);
+
+        case 12:
+            return pluginsd_begin(words, num_words, parser);
+
+        case 13:
+            return pluginsd_end(words, num_words, parser);
+
+        case 21:
+            return pluginsd_replay_set(words, num_words, parser);
+
+        case 22:
+            return pluginsd_replay_begin(words, num_words, parser);
+
+        case 23:
+            return pluginsd_replay_rrddim_collection_state(words, num_words, parser);
+
+        case 24:
+            return pluginsd_replay_rrdset_collection_state(words, num_words, parser);
+
+        case 25:
+            return pluginsd_replay_end(words, num_words, parser);
+
+        case 31:
+            return pluginsd_dimension(words, num_words, parser);
+
+        case 32:
+            return pluginsd_chart(words, num_words, parser);
+
+        case 33:
+            return pluginsd_chart_definition_end(words, num_words, parser);
+
+        case 34:
+            return pluginsd_clabel(words, num_words, parser);
+
+        case 35:
+            return pluginsd_clabel_commit(words, num_words, parser);
+
+        case 41:
+            return pluginsd_function(words, num_words, parser);
+
+        case 42:
+            return pluginsd_function_result_begin(words, num_words, parser);
+
+        case 51:
+            return pluginsd_label(words, num_words, parser);
+
+        case 52:
+            return pluginsd_overwrite(words, num_words, parser);
+
+        case 53:
+            return pluginsd_variable(words, num_words, parser);
+
+        case 61:
+            return streaming_claimed_id(words, num_words, parser);
+
+        case 71:
+            return pluginsd_host(words, num_words, parser);
+
+        case 72:
+            return pluginsd_host_define(words, num_words, parser);
+
+        case 73:
+            return pluginsd_host_define_end(words, num_words, parser);
+
+        case 74:
+            return pluginsd_host_labels(words, num_words, parser);
+
+        case 97:
+            return pluginsd_flush(words, num_words, parser);
+
+        case 98:
+            return pluginsd_disable(words, num_words, parser);
+
+        case 99:
+            return pluginsd_exit(words, num_words, parser);
+
+        default:
+            fatal("Unknown keyword '%s' with id %zu", keyword->keyword, keyword->id);
+    }
+}
+
 #include "gperf-hashtable.h"
 
 void parser_init_repertoire(PARSER *parser, PARSER_REPERTOIRE repertoire) {

--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -1973,6 +1973,8 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp_plugi
 
     rrd_collector_started();
 
+    size_t count = 0;
+
     // this keeps the parser with its current value
     // so, parser needs to be allocated before pushing it
     netdata_thread_cleanup_push(pluginsd_process_thread_cleanup, parser);
@@ -1984,11 +1986,8 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp_plugi
             break;
     }
 
-    // free parser with the pop function
-    netdata_thread_cleanup_pop(1);
-
     cd->unsafe.enabled = parser->user.enabled;
-    size_t count = parser->user.data_collections_count;
+    count = parser->user.data_collections_count;
 
     if (likely(count)) {
         cd->successful_collections += count;
@@ -1996,6 +1995,9 @@ inline size_t pluginsd_process(RRDHOST *host, struct plugind *cd, FILE *fp_plugi
     }
     else
         cd->serial_failures++;
+
+    // free parser with the pop function
+    netdata_thread_cleanup_pop(1);
 
     return count;
 }

--- a/collectors/plugins.d/pluginsd_parser.h
+++ b/collectors/plugins.d/pluginsd_parser.h
@@ -32,7 +32,7 @@ typedef PARSER_RC (*keyword_function)(char **words, size_t num_words, struct par
 
 typedef struct parser_keyword {
     char *keyword;
-    keyword_function func;
+    size_t id;
     PARSER_REPERTOIRE repertoire;
     size_t worker_job_id;
 } PARSER_KEYWORD;
@@ -113,6 +113,14 @@ typedef struct parser {
 
 } PARSER;
 
+PARSER *parser_init(struct parser_user_object *user, FILE *fp_input, FILE *fp_output, int fd, PARSER_INPUT_TYPE flags, void *ssl);
+void parser_init_repertoire(PARSER *parser, PARSER_REPERTOIRE repertoire);
+void parser_destroy(PARSER *working_parser);
+void pluginsd_cleanup_v2(PARSER *parser);
+void inflight_functions_init(PARSER *parser);
+void pluginsd_keywords_init(PARSER *parser, PARSER_REPERTOIRE repertoire);
+PARSER_RC parser_execute(PARSER *parser, PARSER_KEYWORD *keyword, char **words, size_t num_words);
+
 static inline int find_first_keyword(const char *src, char *dst, int dst_size, bool *isspace_map) {
     const char *s = src, *keyword_start;
 
@@ -181,7 +189,8 @@ static inline int parser_action(PARSER *parser, char *input) {
     PARSER_KEYWORD *t = parser_find_keyword(parser, command);
     if(likely(t)) {
         worker_is_busy(t->worker_job_id);
-        rc = (*t->func)(words, num_words, parser);
+        rc = parser_execute(parser, t, words, num_words);
+        // rc = (*t->func)(words, num_words, parser);
         worker_is_idle();
     }
     else
@@ -206,12 +215,5 @@ static inline int parser_action(PARSER *parser, char *input) {
 
     return (rc == PARSER_RC_ERROR || rc == PARSER_RC_STOP);
 }
-
-PARSER *parser_init(struct parser_user_object *user, FILE *fp_input, FILE *fp_output, int fd, PARSER_INPUT_TYPE flags, void *ssl);
-void parser_init_repertoire(PARSER *parser, PARSER_REPERTOIRE repertoire);
-void parser_destroy(PARSER *working_parser);
-void pluginsd_cleanup_v2(PARSER *parser);
-void inflight_functions_init(PARSER *parser);
-void pluginsd_keywords_init(PARSER *parser, PARSER_REPERTOIRE repertoire);
 
 #endif //NETDATA_PLUGINSD_PARSER_H

--- a/daemon/common.c
+++ b/daemon/common.c
@@ -58,6 +58,9 @@ long get_netdata_cpus(void) {
 
     processors = cores_user_configured;
 
+    if(processors < 1)
+        processors = 1;
+
     return processors;
 }
 

--- a/database/contexts/context.c
+++ b/database/contexts/context.c
@@ -80,7 +80,7 @@ static void rrdcontext_insert_callback(const DICTIONARY_ITEM *item __maybe_unuse
     }
 
     rrdinstances_create_in_rrdcontext(rc);
-    netdata_mutex_init(&rc->mutex);
+    spinlock_init(&rc->spinlock);
 
     // signal the react callback to do the job
     rrd_flag_set_updated(rc, RRD_FLAG_UPDATE_REASON_NEW_OBJECT);
@@ -91,7 +91,6 @@ static void rrdcontext_delete_callback(const DICTIONARY_ITEM *item __maybe_unuse
     RRDCONTEXT *rc = (RRDCONTEXT *)value;
 
     rrdinstances_destroy_from_rrdcontext(rc);
-    netdata_mutex_destroy(&rc->mutex);
     rrdcontext_freez(rc);
 }
 

--- a/database/contexts/internal.h
+++ b/database/contexts/internal.h
@@ -250,6 +250,8 @@ typedef struct rrdcontext {
     uint32_t priority;
     RRDSET_TYPE chart_type;
 
+    SPINLOCK spinlock;
+
     RRD_FLAGS flags;
     time_t first_time_s;
     time_t last_time_s;
@@ -278,8 +280,6 @@ typedef struct rrdcontext {
     struct {
         uint32_t metrics;               // the number of metrics in this context
     } stats;
-
-    netdata_mutex_t mutex;
 } RRDCONTEXT;
 
 
@@ -356,8 +356,8 @@ static inline void rrdcontext_release(RRDCONTEXT_ACQUIRED *rca) {
 void rrdcontext_recalculate_context_retention(RRDCONTEXT *rc, RRD_FLAGS reason, bool worker_jobs);
 void rrdcontext_recalculate_host_retention(RRDHOST *host, RRD_FLAGS reason, bool worker_jobs);
 
-#define rrdcontext_lock(rc) netdata_mutex_lock(&((rc)->mutex))
-#define rrdcontext_unlock(rc) netdata_mutex_unlock(&((rc)->mutex))
+#define rrdcontext_lock(rc) spinlock_lock(&((rc)->spinlock))
+#define rrdcontext_unlock(rc) spinlock_unlock(&((rc)->spinlock))
 
 void rrdinstance_trigger_updates(RRDINSTANCE *ri, const char *function);
 void rrdcontext_trigger_updates(RRDCONTEXT *rc, const char *function);

--- a/database/engine/journalfile.c
+++ b/database/engine/journalfile.c
@@ -215,8 +215,11 @@ static struct journal_v2_header *journalfile_v2_mounted_data_get(struct rrdengin
 
             madvise_dontfork(journalfile->mmap.data, journalfile->mmap.size);
             madvise_dontdump(journalfile->mmap.data, journalfile->mmap.size);
+
+            // let the kernel know that we don't want read-ahead on this file
+            madvise_random(journalfile->mmap.data, journalfile->mmap.size);
+
 //            madvise_willneed(journalfile->mmap.data, journalfile->v2.size_of_directory);
-//            madvise_random(journalfile->mmap.data, journalfile->mmap.size);
 //            madvise_dontneed(journalfile->mmap.data, journalfile->mmap.size);
 
             spinlock_lock(&journalfile->v2.spinlock);

--- a/database/engine/journalfile.c
+++ b/database/engine/journalfile.c
@@ -180,6 +180,7 @@ static void njfv2idx_remove(struct rrdengine_datafile *datafile) {
     rw_spinlock_write_lock(&datafile->ctx->njfv2idx.spinlock);
 
     int rc = JudyLDel(&datafile->ctx->njfv2idx.JudyL, datafile->journalfile->njfv2idx.indexed_as, PJE0);
+    (void)rc;
     internal_fatal(!rc, "DBENGINE: NJFV2IDX cannot remove entry");
 
     datafile->journalfile->njfv2idx.indexed_as = 0;

--- a/database/engine/metric.c
+++ b/database/engine/metric.c
@@ -311,7 +311,7 @@ static inline bool acquired_metric_del(MRG *mrg, METRIC *metric) {
 // ----------------------------------------------------------------------------
 // public API
 
-inline MRG *mrg_create(size_t partitions) {
+inline MRG *mrg_create(ssize_t partitions) {
     if(partitions < 1)
         partitions = get_netdata_cpus();
 

--- a/database/engine/metric.c
+++ b/database/engine/metric.c
@@ -28,27 +28,16 @@ struct metric {
 static struct aral_statistics mrg_aral_statistics;
 
 struct mrg {
-    ARAL *aral[MRG_PARTITIONS];
+    size_t partitions;
 
-    struct pgc_index {
-        MRG_CACHE_LINE_PADDING(0);
+    struct mrg_partition {
+        ARAL *aral;                 // not protected by our spinlock - it has its own
 
         RW_SPINLOCK rw_spinlock;
-
-        MRG_CACHE_LINE_PADDING(1);
-
-        Pvoid_t uuid_judy;          // each UUID has a JudyL of sections (tiers)
-
-        MRG_CACHE_LINE_PADDING(2);
+        Pvoid_t uuid_judy;          // JudyHS: each UUID has a JudyL of sections (tiers)
 
         struct mrg_statistics stats;
-
-        MRG_CACHE_LINE_PADDING(3);
-    } index[MRG_PARTITIONS];
-
-#ifdef NETDATA_INTERNAL_CHECKS
-    size_t entries_per_partition[MRG_PARTITIONS];
-#endif
+    } index[];
 };
 
 static inline void MRG_STATS_DUPLICATE_ADD(MRG *mrg, size_t partition) {
@@ -59,20 +48,12 @@ static inline void MRG_STATS_ADDED_METRIC(MRG *mrg, size_t partition) {
     mrg->index[partition].stats.entries++;
     mrg->index[partition].stats.additions++;
     mrg->index[partition].stats.size += sizeof(METRIC);
-
-#ifdef NETDATA_INTERNAL_CHECKS
-    __atomic_add_fetch(&mrg->entries_per_partition[partition], 1, __ATOMIC_RELAXED);
-#endif
 }
 
 static inline void MRG_STATS_DELETED_METRIC(MRG *mrg, size_t partition) {
     mrg->index[partition].stats.entries--;
     mrg->index[partition].stats.size -= sizeof(METRIC);
     mrg->index[partition].stats.deletions++;
-
-#ifdef NETDATA_INTERNAL_CHECKS
-    __atomic_sub_fetch(&mrg->entries_per_partition[partition], 1, __ATOMIC_RELAXED);
-#endif
 }
 
 static inline void MRG_STATS_SEARCH_HIT(MRG *mrg, size_t partition) {
@@ -87,18 +68,13 @@ static inline void MRG_STATS_DELETE_MISS(MRG *mrg, size_t partition) {
     mrg->index[partition].stats.delete_misses++;
 }
 
-static inline void mrg_index_read_lock(MRG *mrg, size_t partition) {
-    rw_spinlock_read_lock(&mrg->index[partition].rw_spinlock);
-}
-static inline void mrg_index_read_unlock(MRG *mrg, size_t partition) {
-    rw_spinlock_read_unlock(&mrg->index[partition].rw_spinlock);
-}
-static inline void mrg_index_write_lock(MRG *mrg, size_t partition) {
-    rw_spinlock_write_lock(&mrg->index[partition].rw_spinlock);
-}
-static inline void mrg_index_write_unlock(MRG *mrg, size_t partition) {
-    rw_spinlock_write_unlock(&mrg->index[partition].rw_spinlock);
-}
+#define mrg_index_read_lock(mrg, partition) rw_spinlock_read_lock(&(mrg)->index[partition].rw_spinlock)
+#define mrg_index_read_unlock(mrg, partition) rw_spinlock_read_unlock(&(mrg)->index[partition].rw_spinlock)
+#define mrg_index_write_lock(mrg, partition) rw_spinlock_write_lock(&(mrg)->index[partition].rw_spinlock)
+#define mrg_index_write_unlock(mrg, partition) rw_spinlock_write_unlock(&(mrg)->index[partition].rw_spinlock)
+
+#define metric_lock(metric) spinlock_lock(&(metric)->spinlock)
+#define metric_unlock(metric) spinlock_unlock(&(metric)->spinlock)
 
 static inline void mrg_stats_size_judyl_change(MRG *mrg, size_t mem_before_judyl, size_t mem_after_judyl, size_t partition) {
     if(mem_after_judyl > mem_before_judyl)
@@ -117,7 +93,8 @@ static inline void mrg_stats_size_judyhs_removed_uuid(MRG *mrg, size_t partition
 
 static inline size_t uuid_partition(MRG *mrg __maybe_unused, uuid_t *uuid) {
     uint8_t *u = (uint8_t *)uuid;
-    return u[UUID_SZ - 1] % MRG_PARTITIONS;
+    size_t *n = (size_t *)&u[UUID_SZ - sizeof(size_t)];
+    return *n % mrg->partitions;
 }
 
 static inline bool metric_has_retention_unsafe(MRG *mrg __maybe_unused, METRIC *metric) {
@@ -142,7 +119,7 @@ static inline REFCOUNT metric_acquire(MRG *mrg __maybe_unused, METRIC *metric, b
     REFCOUNT refcount;
 
     if(!having_spinlock)
-        spinlock_lock(&metric->spinlock);
+        metric_lock(metric);
 
     if(unlikely(metric->refcount < 0))
         fatal("METRIC: refcount is %d (negative) during acquire", metric->refcount);
@@ -153,7 +130,7 @@ static inline REFCOUNT metric_acquire(MRG *mrg __maybe_unused, METRIC *metric, b
     metric_has_retention_unsafe(mrg, metric);
 
     if(!having_spinlock)
-        spinlock_unlock(&metric->spinlock);
+        metric_unlock(metric);
 
     if(refcount == 1)
         __atomic_add_fetch(&mrg->index[partition].stats.entries_referenced, 1, __ATOMIC_RELAXED);
@@ -168,7 +145,7 @@ static inline bool metric_release_and_can_be_deleted(MRG *mrg __maybe_unused, ME
     size_t partition = metric->partition;
     REFCOUNT refcount;
 
-    spinlock_lock(&metric->spinlock);
+    metric_lock(metric);
 
     if(unlikely(metric->refcount <= 0))
         fatal("METRIC: refcount is %d (zero or negative) during release", metric->refcount);
@@ -178,7 +155,7 @@ static inline bool metric_release_and_can_be_deleted(MRG *mrg __maybe_unused, ME
     if(likely(metric_has_retention_unsafe(mrg, metric) || refcount != 0))
         ret = false;
 
-    spinlock_unlock(&metric->spinlock);
+    metric_unlock(metric);
 
     if(unlikely(!refcount))
         __atomic_sub_fetch(&mrg->index[partition].stats.entries_referenced, 1, __ATOMIC_RELAXED);
@@ -191,7 +168,7 @@ static inline bool metric_release_and_can_be_deleted(MRG *mrg __maybe_unused, ME
 static inline METRIC *metric_add_and_acquire(MRG *mrg, MRG_ENTRY *entry, bool *ret) {
     size_t partition = uuid_partition(mrg, &entry->uuid);
 
-    METRIC *allocation = aral_mallocz(mrg->aral[partition]);
+    METRIC *allocation = aral_mallocz(mrg->index[partition].aral);
 
     mrg_index_write_lock(mrg, partition);
 
@@ -224,7 +201,7 @@ static inline METRIC *metric_add_and_acquire(MRG *mrg, MRG_ENTRY *entry, bool *r
         if(ret)
             *ret = false;
 
-        aral_freez(mrg->aral[partition], allocation);
+        aral_freez(mrg->index[partition].aral, allocation);
 
         return metric;
     }
@@ -326,7 +303,7 @@ static inline bool acquired_metric_del(MRG *mrg, METRIC *metric) {
 
     mrg_index_write_unlock(mrg, partition);
 
-    aral_freez(mrg->aral[partition], metric);
+    aral_freez(mrg->index[partition].aral, metric);
 
     return true;
 }
@@ -334,22 +311,20 @@ static inline bool acquired_metric_del(MRG *mrg, METRIC *metric) {
 // ----------------------------------------------------------------------------
 // public API
 
-inline MRG *mrg_create(void) {
-    MRG *mrg = callocz(1, sizeof(MRG));
+inline MRG *mrg_create(size_t partitions) {
+    if(partitions < 1)
+        partitions = get_netdata_cpus();
 
-    for(size_t i = 0; i < MRG_PARTITIONS ; i++) {
+    MRG *mrg = callocz(1, sizeof(MRG) + sizeof(struct mrg_partition) * partitions);
+    mrg->partitions = partitions;
+
+    for(size_t i = 0; i < mrg->partitions ; i++) {
         rw_spinlock_init(&mrg->index[i].rw_spinlock);
 
         char buf[ARAL_MAX_NAME + 1];
         snprintfz(buf, ARAL_MAX_NAME, "mrg[%zu]", i);
 
-        mrg->aral[i] = aral_create(buf,
-                                   sizeof(METRIC),
-                                   0,
-                                   16384,
-                                   &mrg_aral_statistics,
-                                   NULL, NULL, false,
-                                   false);
+        mrg->index[i].aral = aral_create(buf, sizeof(METRIC), 0, 16384, &mrg_aral_statistics, NULL, NULL, false, false);
     }
 
     return mrg;
@@ -415,10 +390,10 @@ inline bool mrg_metric_set_first_time_s(MRG *mrg __maybe_unused, METRIC *metric,
     if(unlikely(first_time_s < 0))
         return false;
 
-    spinlock_lock(&metric->spinlock);
+    metric_lock(metric);
     metric->first_time_s = first_time_s;
     metric_has_retention_unsafe(mrg, metric);
-    spinlock_unlock(&metric->spinlock);
+    metric_unlock(metric);
 
     return true;
 }
@@ -443,7 +418,7 @@ inline void mrg_metric_expand_retention(MRG *mrg __maybe_unused, METRIC *metric,
     if(unlikely(!first_time_s && !last_time_s && !update_every_s))
         return;
 
-    spinlock_lock(&metric->spinlock);
+    metric_lock(metric);
 
     if(unlikely(first_time_s && (!metric->first_time_s || first_time_s < metric->first_time_s)))
         metric->first_time_s = first_time_s;
@@ -458,7 +433,7 @@ inline void mrg_metric_expand_retention(MRG *mrg __maybe_unused, METRIC *metric,
         metric->latest_update_every_s = (uint32_t) update_every_s;
 
     metric_has_retention_unsafe(mrg, metric);
-    spinlock_unlock(&metric->spinlock);
+    metric_unlock(metric);
 }
 
 inline bool mrg_metric_set_first_time_s_if_bigger(MRG *mrg __maybe_unused, METRIC *metric, time_t first_time_s) {
@@ -466,13 +441,13 @@ inline bool mrg_metric_set_first_time_s_if_bigger(MRG *mrg __maybe_unused, METRI
 
     bool ret = false;
 
-    spinlock_lock(&metric->spinlock);
+    metric_lock(metric);
     if(first_time_s > metric->first_time_s) {
         metric->first_time_s = first_time_s;
         ret = true;
     }
     metric_has_retention_unsafe(mrg, metric);
-    spinlock_unlock(&metric->spinlock);
+    metric_unlock(metric);
 
     return ret;
 }
@@ -480,7 +455,7 @@ inline bool mrg_metric_set_first_time_s_if_bigger(MRG *mrg __maybe_unused, METRI
 inline time_t mrg_metric_get_first_time_s(MRG *mrg __maybe_unused, METRIC *metric) {
     time_t first_time_s;
 
-    spinlock_lock(&metric->spinlock);
+    metric_lock(metric);
 
     if(unlikely(!metric->first_time_s)) {
         if(metric->latest_time_s_clean)
@@ -492,13 +467,13 @@ inline time_t mrg_metric_get_first_time_s(MRG *mrg __maybe_unused, METRIC *metri
 
     first_time_s = metric->first_time_s;
 
-    spinlock_unlock(&metric->spinlock);
+    metric_unlock(metric);
 
     return first_time_s;
 }
 
 inline void mrg_metric_get_retention(MRG *mrg __maybe_unused, METRIC *metric, time_t *first_time_s, time_t *last_time_s, time_t *update_every_s) {
-    spinlock_lock(&metric->spinlock);
+    metric_lock(metric);
 
     if(unlikely(!metric->first_time_s)) {
         if(metric->latest_time_s_clean)
@@ -512,7 +487,7 @@ inline void mrg_metric_get_retention(MRG *mrg __maybe_unused, METRIC *metric, ti
     *last_time_s = MAX(metric->latest_time_s_clean, metric->latest_time_s_hot);
     *update_every_s = metric->latest_update_every_s;
 
-    spinlock_unlock(&metric->spinlock);
+    metric_unlock(metric);
 }
 
 inline bool mrg_metric_set_clean_latest_time_s(MRG *mrg __maybe_unused, METRIC *metric, time_t latest_time_s) {
@@ -521,7 +496,7 @@ inline bool mrg_metric_set_clean_latest_time_s(MRG *mrg __maybe_unused, METRIC *
     if(unlikely(latest_time_s < 0))
         return false;
 
-    spinlock_lock(&metric->spinlock);
+    metric_lock(metric);
 
 //    internal_fatal(latest_time_s > max_acceptable_collected_time(),
 //                   "DBENGINE METRIC: metric latest time is in the future");
@@ -535,7 +510,7 @@ inline bool mrg_metric_set_clean_latest_time_s(MRG *mrg __maybe_unused, METRIC *
         metric->first_time_s = latest_time_s;
 
     metric_has_retention_unsafe(mrg, metric);
-    spinlock_unlock(&metric->spinlock);
+    metric_unlock(metric);
     return true;
 }
 
@@ -573,7 +548,7 @@ inline bool mrg_metric_zero_disk_retention(MRG *mrg __maybe_unused, METRIC *metr
         if (min_first_time_s == LONG_MAX)
             min_first_time_s = 0;
 
-        spinlock_lock(&metric->spinlock);
+        metric_lock(metric);
         if (--countdown && !min_first_time_s && metric->latest_time_s_hot)
             do_again = true;
         else {
@@ -585,7 +560,7 @@ inline bool mrg_metric_zero_disk_retention(MRG *mrg __maybe_unused, METRIC *metr
 
             ret = metric_has_retention_unsafe(mrg, metric);
         }
-        spinlock_unlock(&metric->spinlock);
+        metric_unlock(metric);
     } while(do_again);
 
     return ret;
@@ -600,22 +575,22 @@ inline bool mrg_metric_set_hot_latest_time_s(MRG *mrg __maybe_unused, METRIC *me
     if(unlikely(latest_time_s < 0))
         return false;
 
-    spinlock_lock(&metric->spinlock);
+    metric_lock(metric);
     metric->latest_time_s_hot = latest_time_s;
 
     if(unlikely(!metric->first_time_s))
         metric->first_time_s = latest_time_s;
 
     metric_has_retention_unsafe(mrg, metric);
-    spinlock_unlock(&metric->spinlock);
+    metric_unlock(metric);
     return true;
 }
 
 inline time_t mrg_metric_get_latest_time_s(MRG *mrg __maybe_unused, METRIC *metric) {
     time_t max;
-    spinlock_lock(&metric->spinlock);
+    metric_lock(metric);
     max = MAX(metric->latest_time_s_clean, metric->latest_time_s_hot);
-    spinlock_unlock(&metric->spinlock);
+    metric_unlock(metric);
     return max;
 }
 
@@ -625,9 +600,9 @@ inline bool mrg_metric_set_update_every(MRG *mrg __maybe_unused, METRIC *metric,
     if(update_every_s <= 0)
         return false;
 
-    spinlock_lock(&metric->spinlock);
+    metric_lock(metric);
     metric->latest_update_every_s = (uint32_t) update_every_s;
-    spinlock_unlock(&metric->spinlock);
+    metric_unlock(metric);
 
     return true;
 }
@@ -638,10 +613,10 @@ inline bool mrg_metric_set_update_every_s_if_zero(MRG *mrg __maybe_unused, METRI
     if(update_every_s <= 0)
         return false;
 
-    spinlock_lock(&metric->spinlock);
+    metric_lock(metric);
     if(!metric->latest_update_every_s)
         metric->latest_update_every_s = (uint32_t) update_every_s;
-    spinlock_unlock(&metric->spinlock);
+    metric_unlock(metric);
 
     return true;
 }
@@ -649,16 +624,16 @@ inline bool mrg_metric_set_update_every_s_if_zero(MRG *mrg __maybe_unused, METRI
 inline time_t mrg_metric_get_update_every_s(MRG *mrg __maybe_unused, METRIC *metric) {
     time_t update_every_s;
 
-    spinlock_lock(&metric->spinlock);
+    metric_lock(metric);
     update_every_s = metric->latest_update_every_s;
-    spinlock_unlock(&metric->spinlock);
+    metric_unlock(metric);
 
     return update_every_s;
 }
 
 inline bool mrg_metric_set_writer(MRG *mrg, METRIC *metric) {
     bool done = false;
-    spinlock_lock(&metric->spinlock);
+    metric_lock(metric);
     if(!metric->writer) {
         metric->writer = gettid();
         __atomic_add_fetch(&mrg->index[metric->partition].stats.writers, 1, __ATOMIC_RELAXED);
@@ -666,19 +641,19 @@ inline bool mrg_metric_set_writer(MRG *mrg, METRIC *metric) {
     }
     else
         __atomic_add_fetch(&mrg->index[metric->partition].stats.writers_conflicts, 1, __ATOMIC_RELAXED);
-    spinlock_unlock(&metric->spinlock);
+    metric_unlock(metric);
     return done;
 }
 
 inline bool mrg_metric_clear_writer(MRG *mrg, METRIC *metric) {
     bool done = false;
-    spinlock_lock(&metric->spinlock);
+    metric_lock(metric);
     if(metric->writer) {
         metric->writer = 0;
         __atomic_sub_fetch(&mrg->index[metric->partition].stats.writers, 1, __ATOMIC_RELAXED);
         done = true;
     }
-    spinlock_unlock(&metric->spinlock);
+    metric_unlock(metric);
     return done;
 }
 
@@ -734,7 +709,7 @@ inline void mrg_update_metric_retention_and_granularity_by_uuid(
 inline void mrg_get_statistics(MRG *mrg, struct mrg_statistics *s) {
     memset(s, 0, sizeof(struct mrg_statistics));
 
-    for(int i = 0; i < MRG_PARTITIONS ;i++) {
+    for(size_t i = 0; i < mrg->partitions ;i++) {
         s->entries += __atomic_load_n(&mrg->index[i].stats.entries, __ATOMIC_RELAXED);
         s->entries_referenced += __atomic_load_n(&mrg->index[i].stats.entries_referenced, __ATOMIC_RELAXED);
         s->entries_with_retention += __atomic_load_n(&mrg->index[i].stats.entries_with_retention, __ATOMIC_RELAXED);
@@ -808,7 +783,7 @@ static void *mrg_stress(void *ptr) {
 }
 
 int mrg_unittest(void) {
-    MRG *mrg = mrg_create();
+    MRG *mrg = mrg_create(0);
     METRIC *m1_t0, *m2_t0, *m3_t0, *m4_t0;
     METRIC *m1_t1, *m2_t1, *m3_t1, *m4_t1;
     bool ret;
@@ -889,7 +864,7 @@ int mrg_unittest(void) {
         fatal("DBENGINE METRIC: invalid entries counter");
 
     size_t entries = 1000000;
-    size_t threads = MRG_PARTITIONS / 3 + 1;
+    size_t threads = mrg->partitions / 3 + 1;
     size_t tiers = 3;
     size_t run_for_secs = 5;
     info("preparing stress test of %zu entries...", entries);

--- a/database/engine/metric.c
+++ b/database/engine/metric.c
@@ -726,7 +726,7 @@ inline void mrg_get_statistics(MRG *mrg, struct mrg_statistics *s) {
         s->writers_conflicts += __atomic_load_n(&mrg->index[i].stats.writers_conflicts, __ATOMIC_RELAXED);
     }
 
-    s->size += sizeof(MRG);
+    s->size += sizeof(MRG) + sizeof(struct mrg_partition) * mrg->partitions;
 }
 
 // ----------------------------------------------------------------------------

--- a/database/engine/metric.h
+++ b/database/engine/metric.h
@@ -3,8 +3,6 @@
 
 #include "../rrd.h"
 
-#define MRG_PARTITIONS 10
-
 #define MRG_CACHE_LINE_PADDING(x) uint8_t padding##x[64]
 
 typedef struct metric METRIC;
@@ -19,9 +17,10 @@ typedef struct mrg_entry {
 } MRG_ENTRY;
 
 struct mrg_statistics {
-    // non-atomic - under a write lock
+    // --- non-atomic --- under a write lock
+
     size_t entries;
-    size_t size;                // total memory used, with indexing
+    size_t size;    // total memory used, with indexing
 
     size_t additions;
     size_t additions_duplicate;
@@ -30,9 +29,10 @@ struct mrg_statistics {
     size_t delete_having_retention_or_referenced;
     size_t delete_misses;
 
-    // atomic - multiple readers / writers
-
     MRG_CACHE_LINE_PADDING(0);
+
+    // --- atomic --- multiple readers / writers
+
     size_t entries_referenced;
 
     MRG_CACHE_LINE_PADDING(1);
@@ -50,7 +50,7 @@ struct mrg_statistics {
     size_t writers_conflicts;
 };
 
-MRG *mrg_create(void);
+MRG *mrg_create(size_t partitions);
 void mrg_destroy(MRG *mrg);
 
 METRIC *mrg_metric_dup(MRG *mrg, METRIC *metric);

--- a/database/engine/metric.h
+++ b/database/engine/metric.h
@@ -50,7 +50,7 @@ struct mrg_statistics {
     size_t writers_conflicts;
 };
 
-MRG *mrg_create(size_t partitions);
+MRG *mrg_create(ssize_t partitions);
 void mrg_destroy(MRG *mrg);
 
 METRIC *mrg_metric_dup(MRG *mrg, METRIC *metric);

--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -1083,7 +1083,7 @@ size_t dynamic_extent_cache_size(void) {
 
 void pgc_and_mrg_initialize(void)
 {
-    main_mrg = mrg_create();
+    main_mrg = mrg_create(0);
 
     size_t target_cache_size = (size_t)default_rrdeng_page_cache_mb * 1024ULL * 1024ULL;
     size_t main_cache_size = (target_cache_size / 100) * 95;

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -1079,8 +1079,8 @@ static void rrdeng_populate_mrg(struct rrdengine_instance *ctx) {
     if(cpus > (size_t)libuv_worker_threads)
         cpus = (size_t)libuv_worker_threads;
 
-    if(cpus >= MRG_PARTITIONS / 2)
-        cpus = MRG_PARTITIONS / 2 - 1;
+    if(cpus >= (size_t)get_netdata_cpus() / 2)
+        cpus = get_netdata_cpus()/ 2 - 1;
 
     if(cpus < 1)
         cpus = 1;

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -1072,15 +1072,15 @@ static void rrdeng_populate_mrg(struct rrdengine_instance *ctx) {
         datafiles++;
     uv_rwlock_rdunlock(&ctx->datafiles.rwlock);
 
-    size_t cpus = get_netdata_cpus() / storage_tiers;
-    if(cpus > datafiles)
-        cpus = datafiles;
+    ssize_t cpus = (ssize_t)get_netdata_cpus() / (ssize_t)storage_tiers;
+    if(cpus > (ssize_t)datafiles)
+        cpus = (ssize_t)datafiles;
 
-    if(cpus > (size_t)libuv_worker_threads)
-        cpus = (size_t)libuv_worker_threads;
+    if(cpus > (ssize_t)libuv_worker_threads)
+        cpus = (ssize_t)libuv_worker_threads;
 
-    if(cpus >= (size_t)get_netdata_cpus() / 2)
-        cpus = get_netdata_cpus()/ 2 - 1;
+    if(cpus >= (ssize_t)get_netdata_cpus() / 2)
+        cpus = (ssize_t)(get_netdata_cpus() / 2 - 1);
 
     if(cpus < 1)
         cpus = 1;

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -1752,6 +1752,7 @@ void sql_health_alarm_log2json_v3(BUFFER *wb, DICTIONARY *alert_instances, time_
     char sql[512];
     sqlite3_stmt *res = NULL;
     int rc;
+    BUFFER *command = NULL;
 
     if (unlikely(!alert_instances))
         return;
@@ -1823,7 +1824,7 @@ void sql_health_alarm_log2json_v3(BUFFER *wb, DICTIONARY *alert_instances, time_
         error_report("Failed to finalize statement for sql_health_alarm_log2json_v3 temp table population");
     }
 
-    BUFFER *command = buffer_create(MAX_HEALTH_SQL_SIZE, NULL);
+    command = buffer_create(MAX_HEALTH_SQL_SIZE, NULL);
 
     buffer_sprintf(command, SQL_SEARCH_ALERT_LOG, alert_instances);
 

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -282,27 +282,26 @@ static void receiver_set_exit_reason(struct receiver_state *rpt, STREAM_HANDSHAK
         rpt->exit.reason = reason;
 }
 
-static inline bool receiver_should_continue(struct receiver_state *rpt) {
+static inline bool receiver_should_stop(struct receiver_state *rpt) {
     static __thread size_t counter = 0;
 
     if(unlikely(rpt->exit.shutdown)) {
         receiver_set_exit_reason(rpt, STREAM_HANDSHAKE_DISCONNECT_SHUTDOWN, false);
-        return false;
+        return true;
     }
-
-    // check every 1000 lines read
-    if((counter++ % 1000) != 0) return true;
 
     if(unlikely(!service_running(SERVICE_STREAMING))) {
         receiver_set_exit_reason(rpt, STREAM_HANDSHAKE_DISCONNECT_NETDATA_EXIT, false);
-        return false;
+        return true;
     }
 
-    netdata_thread_testcancel();
+    if(unlikely((counter++ % 1000) == 0)) {
+        // check every 1000 lines read
+        netdata_thread_testcancel();
+        rpt->last_msg_t = now_monotonic_sec();
+    }
 
-    rpt->last_msg_t = now_monotonic_sec();
-
-    return true;
+    return false;
 }
 
 static size_t streaming_parser(struct receiver_state *rpt, struct plugind *cd, int fd, void *ssl) {
@@ -346,7 +345,7 @@ static size_t streaming_parser(struct receiver_state *rpt, struct plugind *cd, i
 
     size_t read_buffer_start = 0;
     char buffer[PLUGINSD_LINE_MAX + 2] = "";
-    while(receiver_should_continue(rpt)) {
+    while(!receiver_should_stop(rpt)) {
 
         if(!receiver_next_line(rpt, buffer, PLUGINSD_LINE_MAX + 2, &read_buffer_start)) {
             bool have_new_data = compressed_connection ? receiver_read_compressed(rpt) : receiver_read_uncompressed(rpt);

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -306,7 +306,7 @@ static inline bool receiver_should_continue(struct receiver_state *rpt) {
 }
 
 static size_t streaming_parser(struct receiver_state *rpt, struct plugind *cd, int fd, void *ssl) {
-    size_t result;
+    size_t result = 0;
 
     PARSER *parser = NULL;
     {

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -1096,7 +1096,7 @@ void replication_set_next_point_in_time(time_t after, size_t unique_id) {
 // ----------------------------------------------------------------------------
 // replication sort entry management
 
-static struct replication_sort_entry *replication_sort_entry_create(struct replication_request *rq) {
+static inline struct replication_sort_entry *replication_sort_entry_create(struct replication_request *rq) {
     struct replication_sort_entry *rse = aral_mallocz(replication_globals.aral_rse);
     __atomic_add_fetch(&replication_globals.atomic.memory, sizeof(struct replication_sort_entry), __ATOMIC_RELAXED);
 
@@ -1120,7 +1120,7 @@ static void replication_sort_entry_destroy(struct replication_sort_entry *rse) {
 }
 
 static void replication_sort_entry_add(struct replication_request *rq) {
-    if(rrdpush_sender_replication_buffer_full_get(rq->sender)) {
+    if(unlikely(rrdpush_sender_replication_buffer_full_get(rq->sender))) {
         rq->indexed_in_judy = false;
         rq->not_indexed_buffer_full = true;
         rq->not_indexed_preprocessing = false;

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -249,7 +249,7 @@ struct sender_state {
     size_t not_connected_loops;
     // Metrics are collected asynchronously by collector threads calling rrdset_done_push(). This can also trigger
     // the lazy creation of the sender thread - both cases (buffer access and thread creation) are guarded here.
-    netdata_mutex_t mutex;
+    SPINLOCK spinlock;
     struct circular_buffer *buffer;
     char read_buffer[PLUGINSD_LINE_MAX + 1];
     ssize_t read_len;
@@ -295,6 +295,9 @@ struct sender_state {
         time_t last_buffer_recreate_s;          // true when the sender buffer should be re-created
     } atomic;
 };
+
+#define sender_lock(sender) spinlock_lock(&(sender)->spinlock)
+#define sender_unlock(sender) spinlock_unlock(&(sender)->spinlock)
 
 #define rrdpush_sender_pipe_has_pending_data(sender) __atomic_load_n(&(sender)->atomic.pending_data, __ATOMIC_RELAXED)
 #define rrdpush_sender_pipe_set_pending_data(sender) __atomic_store_n(&(sender)->atomic.pending_data, true, __ATOMIC_RELAXED)

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -100,7 +100,7 @@ void sender_commit(struct sender_state *s, BUFFER *wb, STREAM_TRAFFIC_TYPE type)
     if(unlikely(!src || !src_len))
         return;
 
-    netdata_mutex_lock(&s->mutex);
+    sender_lock(s);
 
 //    FILE *fp = fopen("/tmp/stream.txt", "a");
 //    fprintf(fp,
@@ -156,7 +156,7 @@ void sender_commit(struct sender_state *s, BUFFER *wb, STREAM_TRAFFIC_TYPE type)
                           rrdhost_hostname(s->host), s->connected_to);
 
                     deactivate_compression(s);
-                    netdata_mutex_unlock(&s->mutex);
+                    sender_unlock(s);
                     return;
                 }
             }
@@ -189,7 +189,7 @@ void sender_commit(struct sender_state *s, BUFFER *wb, STREAM_TRAFFIC_TYPE type)
         signal_sender = true;
     }
 
-    netdata_mutex_unlock(&s->mutex);
+    sender_unlock(s);
 
     if(signal_sender)
         rrdpush_signal_sender_to_wake_up(s);
@@ -273,7 +273,7 @@ static void rrdpush_sender_cbuffer_recreate_timed(struct sender_state *s, time_t
         return;
 
     if(!have_mutex)
-        netdata_mutex_lock(&s->mutex);
+        sender_lock(s);
 
     rrdpush_sender_last_buffer_recreate_set(s, now_s);
     last_reset_time_s = now_s;
@@ -287,20 +287,20 @@ static void rrdpush_sender_cbuffer_recreate_timed(struct sender_state *s, time_t
     sender_thread_buffer_free();
 
     if(!have_mutex)
-        netdata_mutex_unlock(&s->mutex);
+        sender_unlock(s);
 }
 
 static void rrdpush_sender_cbuffer_flush(RRDHOST *host) {
     rrdpush_sender_set_flush_time(host->sender);
 
-    netdata_mutex_lock(&host->sender->mutex);
+    sender_lock(host->sender);
 
     // flush the output buffer from any data it may have
     cbuffer_flush(host->sender->buffer);
     rrdpush_sender_cbuffer_recreate_timed(host->sender, now_monotonic_sec(), true, true);
     replication_recalculate_buffer_used_ratio_unsafe(host->sender);
 
-    netdata_mutex_unlock(&host->sender->mutex);
+    sender_unlock(host->sender);
 }
 
 static void rrdpush_sender_charts_and_replication_reset(RRDHOST *host) {
@@ -821,7 +821,7 @@ static ssize_t attempt_to_send(struct sender_state *s) {
     struct circular_buffer *cb = s->buffer;
 #endif
 
-    netdata_mutex_lock(&s->mutex);
+    sender_lock(s);
     char *chunk;
     size_t outstanding = cbuffer_next_unsafe(s->buffer, &chunk);
     debug(D_STREAM, "STREAM: Sending data. Buffer r=%zu w=%zu s=%zu, next chunk=%zu", cb->read, cb->write, cb->size, outstanding);
@@ -853,7 +853,7 @@ static ssize_t attempt_to_send(struct sender_state *s) {
         debug(D_STREAM, "STREAM: send() returned 0 -> no error but no transmission");
 
     replication_recalculate_buffer_used_ratio_unsafe(s);
-    netdata_mutex_unlock(&s->mutex);
+    sender_unlock(s);
 
     return ret;
 }
@@ -1093,7 +1093,7 @@ static bool rrdhost_set_sender(RRDHOST *host) {
     if(unlikely(!host->sender)) return false;
 
     bool ret = false;
-    netdata_mutex_lock(&host->sender->mutex);
+    sender_lock(host->sender);
     if(!host->sender->tid) {
         rrdhost_flag_clear(host, RRDHOST_FLAG_RRDPUSH_SENDER_CONNECTED | RRDHOST_FLAG_RRDPUSH_SENDER_READY_4_METRICS);
         rrdhost_flag_set(host, RRDHOST_FLAG_RRDPUSH_SENDER_SPAWN);
@@ -1103,7 +1103,7 @@ static bool rrdhost_set_sender(RRDHOST *host) {
         host->sender->exit.reason = STREAM_HANDSHAKE_NEVER;
         ret = true;
     }
-    netdata_mutex_unlock(&host->sender->mutex);
+    sender_unlock(host->sender);
 
     rrdpush_reset_destinations_postpone_time(host);
 
@@ -1164,7 +1164,7 @@ static void rrdpush_sender_thread_cleanup_callback(void *ptr) {
 
     RRDHOST *host = s->host;
 
-    netdata_mutex_lock(&host->sender->mutex);
+    sender_lock(host->sender);
     info("STREAM %s [send]: sending thread exits %s",
          rrdhost_hostname(host),
          host->sender->exit.reason != STREAM_HANDSHAKE_NEVER ? stream_handshake_error_to_string(host->sender->exit.reason) : "");
@@ -1173,7 +1173,7 @@ static void rrdpush_sender_thread_cleanup_callback(void *ptr) {
     rrdpush_sender_pipe_close(host, host->sender->rrdpush_sender_pipe, false);
 
     rrdhost_clear_sender___while_having_sender_mutex(host);
-    netdata_mutex_unlock(&host->sender->mutex);
+    sender_unlock(host->sender);
 
     freez(s->pipe_buffer);
     freez(s);
@@ -1343,14 +1343,14 @@ void *rrdpush_sender_thread(void *ptr) {
             continue;
         }
 
-        netdata_mutex_lock(&s->mutex);
+        sender_lock(s);
         size_t outstanding = cbuffer_next_unsafe(s->buffer, NULL);
         size_t available = cbuffer_available_size_unsafe(s->buffer);
         if (unlikely(!outstanding)) {
             rrdpush_sender_pipe_clear_pending_data(s);
             rrdpush_sender_cbuffer_recreate_timed(s, now_s, true, false);
         }
-        netdata_mutex_unlock(&s->mutex);
+        sender_unlock(s);
 
         worker_set_metric(WORKER_SENDER_JOB_BUFFER_RATIO, (NETDATA_DOUBLE)(s->buffer->max_size - available) * 100.0 / (NETDATA_DOUBLE)s->buffer->max_size);
 

--- a/web/rtc/webrtc.c
+++ b/web/rtc/webrtc.c
@@ -367,7 +367,7 @@ cleanup:
 // ----------------------------------------------------------------------------
 // webrtc data channel
 
-static void myOpenCallback(int id, void *user_ptr) {
+static void myOpenCallback(int id __maybe_unused, void *user_ptr) {
     webrtc_set_thread_name();
 
     WEBRTC_DC *chan = user_ptr;
@@ -378,7 +378,7 @@ static void myOpenCallback(int id, void *user_ptr) {
     chan->open = true;
 }
 
-static void myClosedCallback(int id, void *user_ptr) {
+static void myClosedCallback(int id __maybe_unused, void *user_ptr) {
     webrtc_set_thread_name();
 
     WEBRTC_DC *chan = user_ptr;
@@ -397,7 +397,7 @@ static void myClosedCallback(int id, void *user_ptr) {
     freez(chan);
 }
 
-static void myErrorCallback(int id, const char *error, void *user_ptr) {
+static void myErrorCallback(int id __maybe_unused, const char *error, void *user_ptr) {
     webrtc_set_thread_name();
 
     WEBRTC_DC *chan = user_ptr;
@@ -406,7 +406,7 @@ static void myErrorCallback(int id, const char *error, void *user_ptr) {
     error("WEBRTC[%d],DC[%d]: ERROR: '%s'", chan->conn->pc, chan->dc, error);
 }
 
-static void myMessageCallback(int id, const char *message, int size, void *user_ptr) {
+static void myMessageCallback(int id __maybe_unused, const char *message, int size, void *user_ptr) {
     webrtc_set_thread_name();
 
     WEBRTC_DC *chan = user_ptr;
@@ -441,7 +441,7 @@ static void myMessageCallback(int id, const char *message, int size, void *user_
 //    }
 //}
 
-static void myDataChannelCallback(int pc, int dc, void *user_ptr) {
+static void myDataChannelCallback(int pc __maybe_unused, int dc, void *user_ptr) {
     webrtc_set_thread_name();
 
     WEBRTC_CONN *conn = user_ptr;


### PR DESCRIPTION
improvement on #15267 that was reverted.

- [x] everything of #15267 
- [x] there was an invalid memory access on free'd memory, that was leading to strange crashes
- [x] an unsigned number was going negative and the number of threads calculated went infinite, so netdata was crashing on startup while trying to populate MRG.
- [x] reverted `madvise()` random for jnfv2 files to reduce I/O on slow disks during journal v2 scans.
- [x] fixed replication shutdown sequence (it has to be stopped after streaming to prevent crashes if replication commands are received during shutdown)
- [x] faster `service_running()` checking without atomic operations
- [x] streaming sender now uses a spinlock instead of a mutex to protect the streaming buffer
- [x] rrdcontext now uses a spinlock instead of a mutex
- [x] there was a left-over `select()` statement that was crashing netdata when the socket number was above 1024. This was visible on busy parents since yesterday's change to fortify netdata source.
