### PR TITLE
Send alert chart labels config key to cloud

### DIFF
--- a/aclk/schema-wrappers/alarm_config.cc
+++ b/aclk/schema-wrappers/alarm_config.cc
@@ -48,6 +48,8 @@ void destroy_aclk_alarm_configuration(struct aclk_alarm_configuration *cfg)
     freez(cfg->p_db_lookup_dimensions);
     freez(cfg->p_db_lookup_method);
     freez(cfg->p_db_lookup_options);
+
+    freez(cfg->chart_labels);
 }
 
 char *generate_provide_alarm_configuration(size_t *len, struct provide_alarm_configuration *data)
@@ -126,6 +128,9 @@ char *generate_provide_alarm_configuration(size_t *len, struct provide_alarm_con
     if (data->cfg.p_db_lookup_options)
         cfg->set_p_db_lookup_options(data->cfg.p_db_lookup_options);
     cfg->set_p_update_every(data->cfg.p_update_every);
+
+    if (data->cfg.chart_labels)
+        cfg->set_chart_labels(data->cfg.chart_labels);
 
     *len = PROTO_COMPAT_MSG_SIZE(msg);
     char *bin = (char*)mallocz(*len);

--- a/aclk/schema-wrappers/alarm_config.h
+++ b/aclk/schema-wrappers/alarm_config.h
@@ -50,6 +50,8 @@ struct aclk_alarm_configuration {
     char *p_db_lookup_method;
     char *p_db_lookup_options;
     int32_t p_update_every;
+
+    char *chart_labels;
 };
 
 void destroy_aclk_alarm_configuration(struct aclk_alarm_configuration *cfg);

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -523,7 +523,7 @@ void aclk_send_alarm_configuration(char *config_hash)
 #define SQL_SELECT_ALERT_CONFIG "SELECT alarm, template, on_key, class, type, component, os, hosts, plugin," \
     "module, charts, families, lookup, every, units, green, red, calc, warn, crit, to_key, exec, delay, repeat, info," \
     "options, host_labels, p_db_lookup_dimensions, p_db_lookup_method, p_db_lookup_options, p_db_lookup_after," \
-    "p_db_lookup_before, p_update_every FROM alert_hash WHERE hash_id = @hash_id;"
+    "p_db_lookup_before, p_update_every, chart_labels FROM alert_hash WHERE hash_id = @hash_id;"
 int aclk_push_alert_config_event(char *node_id __maybe_unused, char *config_hash __maybe_unused)
 {
     int rc = 0;
@@ -623,6 +623,8 @@ int aclk_push_alert_config_event(char *node_id __maybe_unused, char *config_hash
         }
 
         alarm_config.p_update_every = sqlite3_column_int(res, 32);
+
+        alarm_config.chart_labels = sqlite3_column_bytes(res, 33) > 0 ? strdupz((char *)sqlite3_column_text(res, 33)) : NULL;
 
         p_alarm_config.cfg_hash = strdupz((char *) config_hash);
         p_alarm_config.cfg = alarm_config;

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -78,6 +78,10 @@ const char *database_migrate_v5_v6[] = {
     NULL
 };
 
+const char *database_migrate_v9_v10[] = {
+    "ALTER TABLE alert_hash ADD chart_labels TEXT;",
+    NULL
+};
 
 static int do_migration_v1_v2(sqlite3 *database, const char *name)
 {
@@ -287,6 +291,16 @@ static int do_migration_v8_v9(sqlite3 *database, const char *name)
     return 0;
 }
 
+static int do_migration_v9_v10(sqlite3 *database, const char *name)
+{
+    UNUSED(name);
+    info("Running \"%s\" database migration", name);
+
+    if (table_exists_in_database("alert_hash") && !column_exists_in_table("alert_hash", "chart_labels"))
+        return init_database_batch(database, DB_CHECK_NONE, 0, &database_migrate_v9_v10[0]);
+    return 0;
+}
+
 static int do_migration_noop(sqlite3 *database, const char *name)
 {
     UNUSED(database);
@@ -339,6 +353,7 @@ DATABASE_FUNC_MIGRATION_LIST migration_action[] = {
     {.name = "v6 to v7",  .func = do_migration_v6_v7},
     {.name = "v7 to v8",  .func = do_migration_v7_v8},
     {.name = "v8 to v9",  .func = do_migration_v8_v9},
+    {.name = "v9 to v10",  .func = do_migration_v9_v10},
     // the terminator of this array
     {.name = NULL, .func = NULL}
 };

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -3,7 +3,7 @@
 #include "sqlite_functions.h"
 #include "sqlite_db_migration.h"
 
-#define DB_METADATA_VERSION 9
+#define DB_METADATA_VERSION 10
 
 const char *database_config[] = {
     "CREATE TABLE IF NOT EXISTS host(host_id BLOB PRIMARY KEY, hostname TEXT NOT NULL, "
@@ -32,7 +32,7 @@ const char *database_config[] = {
     "every text, units text, calc text, families text, plugin text, module text, charts text, green text, "
     "red text, warn text, crit text, exec text, to_key text, info text, delay text, options text, "
     "repeat text, host_labels text, p_db_lookup_dimensions text, p_db_lookup_method text, p_db_lookup_options int, "
-    "p_db_lookup_after int, p_db_lookup_before int, p_update_every int, source text);",
+    "p_db_lookup_after int, p_db_lookup_before int, p_update_every int, source text, chart_labels text);",
 
     "CREATE INDEX IF NOT EXISTS alert_hash_index ON alert_hash (hash_id);",
 

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -975,8 +975,8 @@ void sql_health_alarm_log_load(RRDHOST *host) {
     "on_key, class, component, type, os, hosts, lookup, every, units, calc, families, plugin, module, " \
     "charts, green, red, warn, crit, exec, to_key, info, delay, options, repeat, host_labels, " \
     "p_db_lookup_dimensions, p_db_lookup_method, p_db_lookup_options, p_db_lookup_after, " \
-    "p_db_lookup_before, p_update_every, source) values (?1,unixepoch(),?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12," \
-    "?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26,?27,?28,?29,?30,?31,?32,?33,?34,?35);"
+    "p_db_lookup_before, p_update_every, source, chart_labels) values (?1,unixepoch(),?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12," \
+    "?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26,?27,?28,?29,?30,?31,?32,?33,?34,?35,?36);"
 
 int sql_store_alert_config_hash(uuid_t *hash_id, struct alert_config *cfg)
 {
@@ -1157,6 +1157,10 @@ int sql_store_alert_config_hash(uuid_t *hash_id, struct alert_config *cfg)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->source, ++param);
+    if (unlikely(rc != SQLITE_OK))
+        goto bind_fail;
+
+    rc = sqlite3_bind_string_or_null(res, cfg->chart_labels, ++param);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR sends the `chart labels` key of alerts configuration to the cloud.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

* Install this PR, but not start it yet. Claim it to staging. Enable the conversation log of aclk.
* Create a custom version of e.g. `disks.conf`.
* Cloud should request this new configuration (i.e. in access.log notice a `Request to send alert config`)
* In aclk.log there should be the agent's response which should contain the `chart_labels`, i.e. `Request to send alert config`

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
