### PR TITLE
Only try to enable _FORTIFY_SOURCE if the user has not disabled optimizations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -434,7 +434,7 @@ if ! echo "${originalCFLAGS}" | grep -q '-D_FORTIFY_SOURCE'; then
         [HAVE_FORTIFY_SOURCE=2]
     )
 
-    if test "x${HAVE_FORTIFY_SOURCE}" = "x2"; then
+    if test "x${HAVE_FORTIFY_SOURCE}" = "x2" && echo "${originalCFLAGS}" | grep -qv '-O0'; then
         AC_CHECK_DECL(
             __builtin_dynamic_object_size,
             [AX_CHECK_COMPILE_FLAG(


### PR DESCRIPTION
##### Summary

Glibc’s `_FORTIFY_SOURCE` functionality requires at least minimal compiler optimizations to be enabled for it to work correctly. This PR skips automatically adding `-D_FORTIFY_SOURCE` being added to the compiler flags if optimization is explicitly disabled.

##### Test Plan

Build Netdata with `-O0 -Werror` in the CFLAGS.

Without this PR, the build should fail with a warning similar to `warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O)`.

With this PR, the build should complete correctly.