### PR TITLE
Fix non-interactive options for apt-get and zypper.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1424,7 +1424,7 @@ try_package_install() {
       if [ "${INTERACTIVE}" = "0" ]; then
         install_subcmd="--non-interactive --no-gpg-checks install"
       else
-        install_subcmd="install"
+        install_subcmd="--no-gpg-checks install"
       fi
       common_rpm_opts
       pm_cmd="zypper"

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1318,7 +1318,7 @@ check_special_native_deps() {
         progress "EPEL is available, attempting to install so that required dependencies are available."
 
         # shellcheck disable=SC2086
-        if ! run_as_root env ${env} ${pm_cmd} install ${pkg_install_opts} epel-release; then
+        if ! run_as_root env ${env} ${pm_cmd} ${install_subcmd} ${pkg_install_opts} epel-release; then
           warning "Failed to install EPEL, even though it is required to install native packages on this system."
           return 1
         fi
@@ -1338,12 +1338,16 @@ common_rpm_opts() {
 }
 
 common_dnf_opts() {
+  if [ "${INTERACTIVE}" = "0" ]; then
+    interactive_opts="-y"
+  fi
   if command -v dnf > /dev/null; then
     pm_cmd="dnf"
     repo_subcmd="makecache"
   else
     pm_cmd="yum"
   fi
+  install_subcmd="install"
   pkg_install_opts="${interactive_opts}"
   repo_update_opts="${interactive_opts}"
   uninstall_subcmd="remove"
@@ -1378,16 +1382,18 @@ try_package_install() {
     release=""
   fi
 
-  if [ "${INTERACTIVE}" = "0" ]; then
-    interactive_opts="-y"
-    env="DEBIAN_FRONTEND=noninteractive"
-  else
-    interactive_opts=""
-    env=""
-  fi
+  interactive_opts=""
+  env=""
 
   case "${DISTRO_COMPAT_NAME}" in
     debian|ubuntu)
+      if [ "${INTERACTIVE}" = "0" ]; then
+        install_subcmd="-o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold install"
+        interactive_opts="-y"
+        env="DEBIAN_FRONTEND=noninteractive"
+      else
+        install_subcmd="install"
+      fi
       needs_early_refresh=1
       pm_cmd="apt-get"
       repo_subcmd="update"
@@ -1415,6 +1421,11 @@ try_package_install() {
       repo_prefix="${DISTRO_COMPAT_NAME}/${SYSVERSION}"
       ;;
     opensuse)
+      if [ "${INTERACTIVE}" = "0" ]; then
+        install_subcmd="--non-interactive --no-gpg-checks install"
+      else
+        install_subcmd="install"
+      fi
       common_rpm_opts
       pm_cmd="zypper"
       repo_subcmd="--gpg-auto-import-keys refresh"
@@ -1485,7 +1496,7 @@ try_package_install() {
     fi
 
     # shellcheck disable=SC2086
-    if ! run_as_root env ${env} ${pm_cmd} install ${pkg_install_opts} "${tmpdir}/${repoconfig_file}"; then
+    if ! run_as_root env ${env} ${pm_cmd} ${install_subcmd} ${pkg_install_opts} "${tmpdir}/${repoconfig_file}"; then
       warning "Failed to install repository configuration package."
       return 2
     fi
@@ -1534,7 +1545,7 @@ try_package_install() {
   fi
 
   # shellcheck disable=SC2086
-  if ! run_as_root env ${env} ${pm_cmd} install ${pkg_install_opts} "netdata${NATIVE_VERSION}"; then
+  if ! run_as_root env ${env} ${pm_cmd} ${install_subcmd} ${pkg_install_opts} "netdata${NATIVE_VERSION}"; then
     warning "Failed to install Netdata package."
     if [ -z "${NO_CLEANUP}" ]; then
       progress "Attempting to uninstall repository configuration package."
@@ -1547,7 +1558,7 @@ try_package_install() {
   if [ -n "${explicitly_install_native_plugins}" ]; then
     progress "Installing external plugins."
     # shellcheck disable=SC2086
-    if ! run_as_root env ${env} ${pm_cmd} install ${DEFAULT_PLUGIN_PACKAGES}; then
+    if ! run_as_root env ${env} ${pm_cmd} ${install_subcmd} ${DEFAULT_PLUGIN_PACKAGES}; then
       warning "Failed to install external plugin packages. Some collectors may not be available."
     fi
   fi

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -749,11 +749,11 @@ update_binpkg() {
   case "${DISTRO_COMPAT_NAME}" in
     debian|ubuntu)
       if [ "${INTERACTIVE}" = "0" ]; then
-        upgrade_cmd='-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --only-upgrade install'
+        upgrade_subcmd="-o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold --only-upgrade install"
         interactive_opts="-y"
         env="DEBIAN_FRONTEND=noninteractive"
       else
-        upgrade_cmd="--only-upgrade install"
+        upgrade_subcmd="--only-upgrade install"
       fi
       pm_cmd="apt-get"
       repo_subcmd="update"
@@ -772,7 +772,7 @@ update_binpkg() {
       else
         pm_cmd="yum"
       fi
-      upgrade_cmd="upgrade"
+      upgrade_subcmd="upgrade"
       pkg_install_opts="${interactive_opts}"
       repo_update_opts="${interactive_opts}"
       pkg_installed_check="rpm -q"
@@ -780,9 +780,9 @@ update_binpkg() {
       ;;
     opensuse)
       if [ "${INTERACTIVE}" = "0" ]; then
-        upgrade_cmd="--non-interactive update"
+        upgrade_subcmd="--non-interactive update"
       else
-        upgrade_cmd="update"
+        upgrade_subcmd="update"
       fi
       pm_cmd="zypper"
       repo_subcmd="--gpg-auto-import-keys refresh"
@@ -805,7 +805,7 @@ update_binpkg() {
   for repopkg in netdata-repo netdata-repo-edge; do
     if ${pkg_installed_check} ${repopkg} > /dev/null 2>&1; then
       # shellcheck disable=SC2086
-      env ${env} ${pm_cmd} ${upgrade_cmd} ${pkg_install_opts} ${repopkg} >&3 2>&3 || fatal "Failed to update Netdata repository config." U000D
+      env ${env} ${pm_cmd} ${upgrade_subcmd} ${pkg_install_opts} ${repopkg} >&3 2>&3 || fatal "Failed to update Netdata repository config." U000D
       # shellcheck disable=SC2086
       if [ -n "${repo_subcmd}" ]; then
         env ${env} ${pm_cmd} ${repo_subcmd} ${repo_update_opts} >&3 2>&3 || fatal "Failed to update repository metadata." U000E
@@ -814,7 +814,7 @@ update_binpkg() {
   done
 
   # shellcheck disable=SC2086
-  env ${env} ${pm_cmd} ${upgrade_cmd} ${pkg_install_opts} netdata >&3 2>&3 || fatal "Failed to update Netdata package." U000F
+  env ${env} ${pm_cmd} ${upgrade_subcmd} ${pkg_install_opts} netdata >&3 2>&3 || fatal "Failed to update Netdata package." U000F
   [ -n "${logfile}" ] && rm "${logfile}" && logfile=
   return 0
 }

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -743,25 +743,29 @@ update_binpkg() {
     esac
   fi
 
-  if [ "${INTERACTIVE}" = "0" ]; then
-    interactive_opts="-y"
-    env="DEBIAN_FRONTEND=noninteractive"
-  else
-    interactive_opts=""
-    env=""
-  fi
+  interactive_opts=""
+  env=""
 
   case "${DISTRO_COMPAT_NAME}" in
     debian|ubuntu)
+      if [ "${INTERACTIVE}" = "0" ]; then
+        upgrade_cmd='-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --only-upgrade install'
+        interactive_opts="-y"
+        env="DEBIAN_FRONTEND=noninteractive"
+      else
+        upgrade_cmd="--only-upgrade install"
+      fi
       pm_cmd="apt-get"
       repo_subcmd="update"
-      upgrade_cmd="--only-upgrade install"
       pkg_install_opts="${interactive_opts}"
       repo_update_opts="${interactive_opts}"
       pkg_installed_check="dpkg -s"
       INSTALL_TYPE="binpkg-deb"
       ;;
     centos|fedora|ol|amzn)
+      if [ "${INTERACTIVE}" = "0" ]; then
+        interactive_opts="-y"
+      fi
       if command -v dnf > /dev/null; then
         pm_cmd="dnf"
         repo_subcmd="makecache"
@@ -775,10 +779,14 @@ update_binpkg() {
       INSTALL_TYPE="binpkg-rpm"
       ;;
     opensuse)
+      if [ "${INTERACTIVE}" = "0" ]; then
+        upgrade_cmd="--non-interactive update"
+      else
+        upgrade_cmd="update"
+      fi
       pm_cmd="zypper"
       repo_subcmd="--gpg-auto-import-keys refresh"
-      upgrade_cmd="update"
-      pkg_install_opts="${interactive_opts}"
+      pkg_install_opts=""
       repo_update_opts=""
       pkg_installed_check="rpm -q"
       INSTALL_TYPE="binpkg-rpm"


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->
Modify netdata-updater.sh and kickstart.sh adding force-confdef and force-confold to apt-get so that non-interactive runs and replacing `zypper install -y` by `zypper --non-interactive install`.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

`netdata-updater.sh --non-interactive --not-running-from-cron`
`kickstart.sh --non-interactive`

##### Additional Information

- APT updater error (from discord discussion)
```
[/tmp/netdata-kickstart-2mxUecrtAY]# //usr/libexec/netdata/netdata-updater.sh --non-interactive --not-running-from-cron 
Tue Jun 20 18:31:06 CEST 2023 : INFO: netdata-updater.sh:         [LOG TRUNCATED]        
Reading package lists... Done
Reading package lists... Done
Building dependency tree       
Reading state information... Done
netdata-repo is already the newest version (2-1).
0 upgraded, 0 newly installed, 0 to remove and 116 not upgraded.
1 not fully installed or removed.
After this operation, 0 B of additional disk space will be used.
Setting up netdata (1.39.0) ...

Configuration file '/etc/netdata/netdata.conf'
 ==> Modified (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** netdata.conf (Y/I/N/O/D/Z) [default=N] ? 
```
- zypper modifications
  - non-interactive option, from man ↓
  ```
  It’s recommended to use the --non-interactive global option instead. Global options are passed before the command (zypper --non-interactive COMMAND ...). Unlike the no-confirm command option, the global option can be used together with any zypper command.
  ```
  - without `--no-gpg-checks` ↓
 
```
[/tmp/netdata-kickstart-m4PtvKXlcO]# env zypper --non-interactive install --allow-unsigned-rpm /tmp/netdata-kickstart-m4PtvKXlcO/netdata-repo-edge-2-1.noarch.rpm
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following NEW package is going to be installed:
  netdata-repo-edge

1 new package to install.
Overall download size: 6.7 KiB. Already cached: 0 B. After the operation, additional 479.0 B will be used.
Continue? [y/n/v/...? shows all options] (y): y
Retrieving: netdata-repo-edge-2-1.noarch (Plain RPM files cache)                                                                                                           (1/1),   6.7 KiB
netdata-repo-edge-2-1.noarch.rpm:
    Header V4 RSA/SHA512 Signature, key ID f9177b5265f56346: NOKEY

warning: /var/tmp/zypp.hRKBI9/zypper/_tmpRPMcache_/%CLI%/netdata-repo-edge-2-1.noarch.rpm: Header V4 RSA/SHA512 Signature, key ID 65f56346: NOKEY
Looking for gpg key ID 65F56346 in cache /var/cache/zypp/pubkeys.
Repository Plain RPM files cache does not define additional 'gpgkey=' URLs.
netdata-repo-edge-2-1.noarch (Plain RPM files cache): Signature verification failed [4-Signatures public key is not available]
Abort, retry, ignore? [a/r/i] (a): a
Problem occurred during or after installation or removal of packages:
Installation has been aborted as directed.
Please see the above error message for a hint.
 FAILED

 WARNING  Failed to install repository configuration package.

 WARNING  Could not install native binary packages, falling back to alternative installation method.

  ```

<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->
  <!--
<details> <summary>For users: How does this change affect me?</summary>

Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 

</details>
-->