### PR TITLE
Rename generic `error` function

### DIFF
--- a/aclk/aclk_otp.c
+++ b/aclk/aclk_otp.c
@@ -38,7 +38,7 @@ struct auth_data {
 
 #define PARSE_ENV_JSON_CHK_TYPE(it, type, name)                                                                        \
     if (json_object_get_type(json_object_iter_peek_value(it)) != type) {                                               \
-        error("value of key \"%s\" should be %s", name, #type);                                                        \
+        netdata_log_error("value of key \"%s\" should be %s", name, #type);                                            \
         goto exit;                                                                                                     \
     }
 
@@ -55,7 +55,7 @@ static int parse_passwd_response(const char *json_str, struct auth_data *auth) {
 
     json = json_tokener_parse(json_str);
     if (!json) {
-        error("JSON-C failed to parse the payload of http response of /env endpoint");
+        netdata_log_error("JSON-C failed to parse the payload of http response of /env endpoint");
         return 1;
     }
 
@@ -88,26 +88,26 @@ static int parse_passwd_response(const char *json_str, struct auth_data *auth) {
             PARSE_ENV_JSON_CHK_TYPE(&it, json_type_array, JSON_KEY_TOPICS)
 
             if (aclk_generate_topic_cache(json_object_iter_peek_value(&it))) {
-                error("Failed to generate topic cache!");
+                netdata_log_error("Failed to generate topic cache!");
                 goto exit;
             }
             json_object_iter_next(&it);
             continue;
         }
-        error("Unknown key \"%s\" in passwd response payload. Ignoring", json_object_iter_peek_name(&it));
+        netdata_log_error("Unknown key \"%s\" in passwd response payload. Ignoring", json_object_iter_peek_name(&it));
         json_object_iter_next(&it);
     }
 
     if (!auth->client_id) {
-        error(JSON_KEY_CLIENTID " is compulsory key in /password response");
+        netdata_log_error(JSON_KEY_CLIENTID " is compulsory key in /password response");
         goto exit;
     }
     if (!auth->passwd) {
-        error(JSON_KEY_PASS " is compulsory in /password response");
+        netdata_log_error(JSON_KEY_PASS " is compulsory in /password response");
         goto exit;
     }
     if (!auth->username) {
-        error(JSON_KEY_USER " is compulsory in /password response");
+        netdata_log_error(JSON_KEY_USER " is compulsory in /password response");
         goto exit;
     }
 
@@ -126,11 +126,11 @@ exit:
 static const char *get_json_str_by_path(json_object *json, const char *path) {
     json_object *ptr;
     if (json_pointer_get(json, path, &ptr)) {
-        error("Missing compulsory key \"%s\" in error response", path);
+        netdata_log_error("Missing compulsory key \"%s\" in error response", path);
         return NULL;
     }
     if (json_object_get_type(ptr) != json_type_string) {
-        error("Value of Key \"%s\" in error response should be string", path);
+        netdata_log_error("Value of Key \"%s\" in error response should be string", path);
         return NULL;
     }
     return json_object_get_string(ptr);
@@ -147,7 +147,7 @@ static int aclk_parse_otp_error(const char *json_str) {
 
     json = json_tokener_parse(json_str);
     if (!json) {
-        error("JSON-C failed to parse the payload of http response of /env endpoint");
+        netdata_log_error("JSON-C failed to parse the payload of http response of /env endpoint");
         return 1;
     }
 
@@ -163,7 +163,7 @@ static int aclk_parse_otp_error(const char *json_str) {
     // optional field
     if (!json_pointer_get(json, "/" JSON_KEY_ERTRY, &ptr)) {
         if (json_object_get_type(ptr) != json_type_boolean) {
-            error("Error response Key " "/" JSON_KEY_ERTRY " should be of boolean type");
+            netdata_log_error("Error response Key " "/" JSON_KEY_ERTRY " should be of boolean type");
             goto exit;
         }
         block_retry = json_object_get_boolean(ptr);
@@ -172,7 +172,7 @@ static int aclk_parse_otp_error(const char *json_str) {
     // optional field
     if (!json_pointer_get(json, "/" JSON_KEY_EDELAY, &ptr)) {
         if (json_object_get_type(ptr) != json_type_int) {
-            error("Error response Key " "/" JSON_KEY_EDELAY " should be of integer type");
+            netdata_log_error("Error response Key " "/" JSON_KEY_EDELAY " should be of integer type");
             goto exit;
         }
         backoff = json_object_get_int(ptr);
@@ -184,7 +184,7 @@ static int aclk_parse_otp_error(const char *json_str) {
     if (backoff > 0)
         aclk_block_until = now_monotonic_sec() + backoff;
 
-    error("Cloud returned EC=\"%s\", Msg-Key:\"%s\", Msg:\"%s\", BlockRetry:%s, Backoff:%ds (-1 unset by cloud)", ec, ek, emsg, block_retry > 0 ? "true" : "false", backoff);
+    netdata_log_error("Cloud returned EC=\"%s\", Msg-Key:\"%s\", Msg:\"%s\", BlockRetry:%s, Backoff:%ds (-1 unset by cloud)", ec, ek, emsg, block_retry > 0 ? "true" : "false", backoff);
     rc = 0;
 exit:
     json_object_put(json);
@@ -205,7 +205,7 @@ static int aclk_parse_otp_error(const char *json_str) {
 
     json = json_tokener_parse(json_str);
     if (!json) {
-        error("JSON-C failed to parse the payload of http response of /env endpoint");
+        netdata_log_error("JSON-C failed to parse the payload of http response of /env endpoint");
         return 1;
     }
 
@@ -236,7 +236,7 @@ static int aclk_parse_otp_error(const char *json_str) {
         }
         if (!strcmp(json_object_iter_peek_name(&it), JSON_KEY_EDELAY)) {
             if (json_object_get_type(json_object_iter_peek_value(&it)) != json_type_int) {
-                error("value of key " JSON_KEY_EDELAY " should be integer");
+                netdata_log_error("value of key " JSON_KEY_EDELAY " should be integer");
                 goto exit;
             }
 
@@ -246,7 +246,7 @@ static int aclk_parse_otp_error(const char *json_str) {
         }
         if (!strcmp(json_object_iter_peek_name(&it), JSON_KEY_ERTRY)) {
             if (json_object_get_type(json_object_iter_peek_value(&it)) != json_type_boolean) {
-                error("value of key " JSON_KEY_ERTRY " should be integer");
+                netdata_log_error("value of key " JSON_KEY_ERTRY " should be integer");
                 goto exit;
             }
 
@@ -254,7 +254,7 @@ static int aclk_parse_otp_error(const char *json_str) {
             json_object_iter_next(&it);
             continue;
         }
-        error("Unknown key \"%s\" in error response payload. Ignoring", json_object_iter_peek_name(&it));
+        netdata_log_error("Unknown key \"%s\" in error response payload. Ignoring", json_object_iter_peek_name(&it));
         json_object_iter_next(&it);
     }
 
@@ -264,7 +264,7 @@ static int aclk_parse_otp_error(const char *json_str) {
     if (backoff > 0)
         aclk_block_until = now_monotonic_sec() + backoff;
 
-    error("Cloud returned EC=\"%s\", Msg-Key:\"%s\", Msg:\"%s\", BlockRetry:%s, Backoff:%ds (-1 unset by cloud)", ec, ek, emsg, block_retry > 0 ? "true" : "false", backoff);
+    netdata_log_error("Cloud returned EC=\"%s\", Msg-Key:\"%s\", Msg:\"%s\", BlockRetry:%s, Backoff:%ds (-1 unset by cloud)", ec, ek, emsg, block_retry > 0 ? "true" : "false", backoff);
     rc = 0;
 exit:
     json_object_put(json);
@@ -301,7 +301,7 @@ inline static int base64_decode_helper(unsigned char *out, int *outl, const unsi
     EVP_DecodeFinal(ctx, remaining_data, &remainder);
     EVP_ENCODE_CTX_free(ctx);
     if (remainder) {
-        error("Unexpected data at EVP_DecodeFinal");
+        netdata_log_error("Unexpected data at EVP_DecodeFinal");
         return 1;
     }
     return 0;
@@ -322,12 +322,12 @@ int aclk_get_otp_challenge(url_t *target, const char *agent_id, unsigned char **
     req.url = (char *)buffer_tostring(url);
 
     if (aclk_https_request(&req, &resp)) {
-        error ("ACLK_OTP Challenge failed");
+        netdata_log_error("ACLK_OTP Challenge failed");
         buffer_free(url);
         return 1;
     }
     if (resp.http_code != 200) {
-        error ("ACLK_OTP Challenge HTTP code not 200 OK (got %d)", resp.http_code);
+        netdata_log_error("ACLK_OTP Challenge HTTP code not 200 OK (got %d)", resp.http_code);
         buffer_free(url);
         if (resp.payload_size)
             aclk_parse_otp_error(resp.payload);
@@ -339,32 +339,32 @@ int aclk_get_otp_challenge(url_t *target, const char *agent_id, unsigned char **
 
     json_object *json = json_tokener_parse(resp.payload);
     if (!json) {
-        error ("Couldn't parse HTTP GET challenge payload");
+        netdata_log_error("Couldn't parse HTTP GET challenge payload");
         goto cleanup_resp;
     }
     json_object *challenge_json;
     if (!json_object_object_get_ex(json, "challenge", &challenge_json)) {
-        error ("No key named \"challenge\" in the returned JSON");
+        netdata_log_error("No key named \"challenge\" in the returned JSON");
         goto cleanup_json;
     }
     if (!json_object_is_type(challenge_json, json_type_string)) {
-        error ("\"challenge\" is not a string JSON type");
+        netdata_log_error("\"challenge\" is not a string JSON type");
         goto cleanup_json;
     }
     const char *challenge_base64;
     if (!(challenge_base64 = json_object_get_string(challenge_json))) {
-        error("Failed to extract challenge from JSON object");
+        netdata_log_error("Failed to extract challenge from JSON object");
         goto cleanup_json;
     }
     if (strlen(challenge_base64) != CHALLENGE_LEN_BASE64) {
-        error("Received Challenge has unexpected length of %zu (expected %d)", strlen(challenge_base64), CHALLENGE_LEN_BASE64);
+        netdata_log_error("Received Challenge has unexpected length of %zu (expected %d)", strlen(challenge_base64), CHALLENGE_LEN_BASE64);
         goto cleanup_json;
     }
 
     *challenge = mallocz((CHALLENGE_LEN_BASE64 / 4) * 3);
     base64_decode_helper(*challenge, challenge_bytes, (const unsigned char*)challenge_base64, strlen(challenge_base64));
     if (*challenge_bytes != CHALLENGE_LEN) {
-        error("Unexpected challenge length of %d instead of %d", *challenge_bytes, CHALLENGE_LEN);
+        netdata_log_error("Unexpected challenge length of %d instead of %d", *challenge_bytes, CHALLENGE_LEN);
         freez(*challenge);
         *challenge = NULL;
         goto cleanup_json;
@@ -405,11 +405,11 @@ int aclk_send_otp_response(const char *agent_id, const unsigned char *response, 
     req.payload_size = strlen(req.payload);
 
     if (aclk_https_request(&req, &resp)) {
-        error ("ACLK_OTP Password error trying to post result to password");
+        netdata_log_error("ACLK_OTP Password error trying to post result to password");
         goto cleanup_buffers;
     }
     if (resp.http_code != 201) {
-        error ("ACLK_OTP Password HTTP code not 201 Created (got %d)", resp.http_code);
+        netdata_log_error("ACLK_OTP Password HTTP code not 201 Created (got %d)", resp.http_code);
         if (resp.payload_size)
             aclk_parse_otp_error(resp.payload);
         goto cleanup_response;
@@ -417,7 +417,7 @@ int aclk_send_otp_response(const char *agent_id, const unsigned char *response, 
     netdata_log_info("ACLK_OTP Got Password from Cloud");
 
     if (parse_passwd_response(resp.payload, mqtt_auth)){
-        error("Error parsing response of password endpoint");
+        netdata_log_error("Error parsing response of password endpoint");
         goto cleanup_response;
     }
 
@@ -470,7 +470,7 @@ static int private_decrypt(RSA *p_key, unsigned char * enc_data, int data_len, u
     {
         char err[512];
         ERR_error_string_n(ERR_get_error(), err, sizeof(err));
-        error("Decryption of the challenge failed: %s", err);
+        netdata_log_error("Decryption of the challenge failed: %s", err);
     }
     return result;
 }
@@ -486,13 +486,13 @@ int aclk_get_mqtt_otp(RSA *p_key, char **mqtt_id, char **mqtt_usr, char **mqtt_p
 
     char *agent_id = get_agent_claimid();
     if (agent_id == NULL) {
-        error("Agent was not claimed - cannot perform challenge/response");
+        netdata_log_error("Agent was not claimed - cannot perform challenge/response");
         return 1;
     }
 
     // Get Challenge
     if (aclk_get_otp_challenge(target, agent_id, &challenge, &challenge_bytes)) {
-        error("Error getting challenge");
+        netdata_log_error("Error getting challenge");
         freez(agent_id);
         return 1;
     }
@@ -501,7 +501,7 @@ int aclk_get_mqtt_otp(RSA *p_key, char **mqtt_id, char **mqtt_usr, char **mqtt_p
     unsigned char *response_plaintext;
     int response_plaintext_bytes = private_decrypt(p_key, challenge, challenge_bytes, &response_plaintext);
     if (response_plaintext_bytes < 0) {
-        error ("Couldn't decrypt the challenge received");
+        netdata_log_error("Couldn't decrypt the challenge received");
         freez(response_plaintext);
         freez(challenge);
         freez(agent_id);
@@ -512,7 +512,7 @@ int aclk_get_mqtt_otp(RSA *p_key, char **mqtt_id, char **mqtt_usr, char **mqtt_p
     // Encode and Send Challenge
     struct auth_data data = { .client_id = NULL, .passwd = NULL, .username = NULL };
     if (aclk_send_otp_response(agent_id, response_plaintext, response_plaintext_bytes, target, &data)) {
-        error("Error getting response");
+        netdata_log_error("Error getting response");
         freez(response_plaintext);
         freez(agent_id);
         return 1;
@@ -549,12 +549,12 @@ static int parse_json_env_transport(json_object *json, aclk_transport_desc_t *tr
         if (!strcmp(json_object_iter_peek_name(&it), JSON_KEY_TRP_TYPE)) {
             PARSE_ENV_JSON_CHK_TYPE(&it, json_type_string, JSON_KEY_TRP_TYPE)
             if (trp->type != ACLK_TRP_UNKNOWN) {
-                error(JSON_KEY_TRP_TYPE " set already");
+                netdata_log_error(JSON_KEY_TRP_TYPE " set already");
                 goto exit;
             }
             trp->type = aclk_transport_type_t_from_str(json_object_get_string(json_object_iter_peek_value(&it)));
             if (trp->type == ACLK_TRP_UNKNOWN) {
-                error(JSON_KEY_TRP_TYPE " unknown type \"%s\"", json_object_get_string(json_object_iter_peek_value(&it)));
+                netdata_log_error(JSON_KEY_TRP_TYPE " unknown type \"%s\"", json_object_get_string(json_object_iter_peek_value(&it)));
                 goto exit;
             }
             json_object_iter_next(&it);
@@ -564,25 +564,25 @@ static int parse_json_env_transport(json_object *json, aclk_transport_desc_t *tr
         if (!strcmp(json_object_iter_peek_name(&it), JSON_KEY_TRP_ENDPOINT)) {
             PARSE_ENV_JSON_CHK_TYPE(&it, json_type_string, JSON_KEY_TRP_ENDPOINT)
             if (trp->endpoint) {
-                error(JSON_KEY_TRP_ENDPOINT " set already");
+                netdata_log_error(JSON_KEY_TRP_ENDPOINT " set already");
                 goto exit;
             }
             trp->endpoint = strdupz(json_object_get_string(json_object_iter_peek_value(&it)));
             json_object_iter_next(&it);
             continue;
         }
-        
-        error ("unknown JSON key in dictionary (\"%s\")", json_object_iter_peek_name(&it));
+
+        netdata_log_error("unknown JSON key in dictionary (\"%s\")", json_object_iter_peek_name(&it));
         json_object_iter_next(&it);
     }
 
     if (!trp->endpoint) {
-        error (JSON_KEY_TRP_ENDPOINT " is missing from JSON dictionary");
+        netdata_log_error(JSON_KEY_TRP_ENDPOINT " is missing from JSON dictionary");
         goto exit;
     }
 
     if (trp->type == ACLK_TRP_UNKNOWN) {
-        error ("transport type not set");
+        netdata_log_error("transport type not set");
         goto exit;
     }
 
@@ -598,7 +598,7 @@ static int parse_json_env_transports(json_object *json_array, aclk_env_t *env) {
     json_object *obj;
 
     if (env->transports) {
-        error("transports have been set already");
+        netdata_log_error("transports have been set already");
         return 1;
     }
 
@@ -610,7 +610,7 @@ static int parse_json_env_transports(json_object *json_array, aclk_env_t *env) {
         trp = callocz(1, sizeof(aclk_transport_desc_t));
         obj = json_object_array_get_idx(json_array, i);
         if (parse_json_env_transport(obj, trp)) {
-            error("error parsing transport idx %d", (int)i);
+            netdata_log_error("error parsing transport idx %d", (int)i);
             freez(trp);
             return 1;
         }
@@ -626,14 +626,14 @@ static int parse_json_env_transports(json_object *json_array, aclk_env_t *env) {
 static int parse_json_backoff_int(struct json_object_iterator *it, int *out, const char* name, int min, int max) {
     if (!strcmp(json_object_iter_peek_name(it), name)) {
         if (json_object_get_type(json_object_iter_peek_value(it)) != json_type_int) {
-            error("Could not parse \"%s\". Not an integer as expected.", name);
+            netdata_log_error("Could not parse \"%s\". Not an integer as expected.", name);
             return MATCHED_ERROR;
         }
 
         *out = json_object_get_int(json_object_iter_peek_value(it));
 
         if (*out < min || *out > max) {
-            error("Value of \"%s\"=%d out of range (%d-%d).", name, *out, min, max);
+            netdata_log_error("Value of \"%s\"=%d out of range (%d-%d).", name, *out, min, max);
             return MATCHED_ERROR;
         }
 
@@ -675,7 +675,7 @@ static int parse_json_backoff(json_object *json, aclk_backoff_t *backoff) {
             continue;
         }
 
-        error ("unknown JSON key in dictionary (\"%s\")", json_object_iter_peek_name(&it));
+        netdata_log_error("unknown JSON key in dictionary (\"%s\")", json_object_iter_peek_name(&it));
         json_object_iter_next(&it);
     }
 
@@ -687,7 +687,7 @@ static int parse_json_env_caps(json_object *json, aclk_env_t *env) {
     const char *str;
 
     if (env->capabilities) {
-        error("transports have been set already");
+        netdata_log_error("transports have been set already");
         return 1;
     }
 
@@ -702,12 +702,12 @@ static int parse_json_env_caps(json_object *json, aclk_env_t *env) {
     for (size_t i = 0; i < env->capability_count; i++) {
         obj = json_object_array_get_idx(json, i);
         if (json_object_get_type(obj) != json_type_string) {
-            error("Capability at index %d not a string!", (int)i);
+            netdata_log_error("Capability at index %d not a string!", (int)i);
             return 1;
         }
         str = json_object_get_string(obj);
         if (!str) {
-            error("Error parsing capabilities");
+            netdata_log_error("Error parsing capabilities");
             return 1;
         }
         env->capabilities[i] = strdupz(str);
@@ -723,7 +723,7 @@ static int parse_json_env(const char *json_str, aclk_env_t *env) {
 
     json = json_tokener_parse(json_str);
     if (!json) {
-        error("JSON-C failed to parse the payload of http response of /env endpoint");
+        netdata_log_error("JSON-C failed to parse the payload of http response of /env endpoint");
         return 1;
     }
 
@@ -734,7 +734,7 @@ static int parse_json_env(const char *json_str, aclk_env_t *env) {
         if (!strcmp(json_object_iter_peek_name(&it), JSON_KEY_AUTH_ENDPOINT)) {
             PARSE_ENV_JSON_CHK_TYPE(&it, json_type_string, JSON_KEY_AUTH_ENDPOINT)
             if (env->auth_endpoint) {
-                error("authEndpoint set already");
+                netdata_log_error("authEndpoint set already");
                 goto exit;
             }
             env->auth_endpoint = strdupz(json_object_get_string(json_object_iter_peek_value(&it)));
@@ -745,7 +745,7 @@ static int parse_json_env(const char *json_str, aclk_env_t *env) {
         if (!strcmp(json_object_iter_peek_name(&it), JSON_KEY_ENC)) {
             PARSE_ENV_JSON_CHK_TYPE(&it, json_type_string, JSON_KEY_ENC)
             if (env->encoding != ACLK_ENC_UNKNOWN) {
-                error(JSON_KEY_ENC " set already");
+                netdata_log_error(JSON_KEY_ENC " set already");
                 goto exit;
             }
             env->encoding = aclk_encoding_type_t_from_str(json_object_get_string(json_object_iter_peek_value(&it)));
@@ -768,7 +768,7 @@ static int parse_json_env(const char *json_str, aclk_env_t *env) {
 
             if (parse_json_backoff(json_object_iter_peek_value(&it), &env->backoff)) {
                 env->backoff.base = 0;
-                error("Error parsing Backoff parameters in env");
+                netdata_log_error("Error parsing Backoff parameters in env");
                 goto exit;
             }
 
@@ -780,7 +780,7 @@ static int parse_json_env(const char *json_str, aclk_env_t *env) {
             PARSE_ENV_JSON_CHK_TYPE(&it, json_type_array, JSON_KEY_CAPS)
 
             if (parse_json_env_caps(json_object_iter_peek_value(&it), env)) {
-                error("Error parsing capabilities list");
+                netdata_log_error("Error parsing capabilities list");
                 goto exit;
             }
 
@@ -788,25 +788,25 @@ static int parse_json_env(const char *json_str, aclk_env_t *env) {
             continue;
         }
 
-        error ("unknown JSON key in dictionary (\"%s\")", json_object_iter_peek_name(&it));
+        netdata_log_error("unknown JSON key in dictionary (\"%s\")", json_object_iter_peek_name(&it));
         json_object_iter_next(&it);
     }
 
     // Check all compulsory keys have been set
     if (env->transport_count < 1) {
-        error("env has to return at least one transport");
+        netdata_log_error("env has to return at least one transport");
         goto exit;
     }
     if (!env->auth_endpoint) {
-        error(JSON_KEY_AUTH_ENDPOINT " is compulsory");
+        netdata_log_error(JSON_KEY_AUTH_ENDPOINT " is compulsory");
         goto exit;
     }
     if (env->encoding == ACLK_ENC_UNKNOWN) {
-        error(JSON_KEY_ENC " is compulsory");
+        netdata_log_error(JSON_KEY_ENC " is compulsory");
         goto exit;
     }
     if (!env->backoff.base) {
-        error(JSON_KEY_BACKOFF " is compulsory");
+        netdata_log_error(JSON_KEY_BACKOFF " is compulsory");
         goto exit;
     }
 
@@ -830,7 +830,7 @@ int aclk_get_env(aclk_env_t *env, const char* aclk_hostname, int aclk_port) {
     char *agent_id = get_agent_claimid();
     if (agent_id == NULL)
     {
-        error("Agent was not claimed - cannot perform challenge/response");
+        netdata_log_error("Agent was not claimed - cannot perform challenge/response");
         buffer_free(buf);
         return 1;
     }
@@ -843,13 +843,13 @@ int aclk_get_env(aclk_env_t *env, const char* aclk_hostname, int aclk_port) {
     req.port = aclk_port;
     req.url = buf->buffer;
     if (aclk_https_request(&req, &resp)) {
-        error("Error trying to contact env endpoint");
+        netdata_log_error("Error trying to contact env endpoint");
         https_req_response_free(&resp);
         buffer_free(buf);
         return 2;
     }
     if (resp.http_code != 200) {
-        error("The HTTP code not 200 OK (Got %d)", resp.http_code);
+        netdata_log_error("The HTTP code not 200 OK (Got %d)", resp.http_code);
         if (resp.payload_size)
             aclk_parse_otp_error(resp.payload);
         https_req_response_free(&resp);
@@ -858,14 +858,14 @@ int aclk_get_env(aclk_env_t *env, const char* aclk_hostname, int aclk_port) {
     }
 
     if (!resp.payload || !resp.payload_size) {
-        error("Unexpected empty payload as response to /env call");
+        netdata_log_error("Unexpected empty payload as response to /env call");
         https_req_response_free(&resp);
         buffer_free(buf);
         return 4;
     }
 
     if (parse_json_env(resp.payload, env)) {
-        error ("error parsing /env message");
+        netdata_log_error("error parsing /env message");
         https_req_response_free(&resp);
         buffer_free(buf);
         return 5;

--- a/aclk/aclk_proxy.c
+++ b/aclk/aclk_proxy.c
@@ -85,7 +85,7 @@ static inline void safe_log_proxy_error(char *str, const char *proxy)
 {
     char *log = strdupz(proxy);
     safe_log_proxy_censor(log);
-    error("%s Provided Value:\"%s\"", str, log);
+    netdata_log_error("%s Provided Value:\"%s\"", str, log);
     freez(log);
 }
 

--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -164,7 +164,7 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query) 
                 w->response.zinitialized = true;
                 w->response.zoutput = true;
             } else
-                error("Failed to initialize zlib. Proceeding without compression.");
+                netdata_log_error("Failed to initialize zlib. Proceeding without compression.");
         }
     }
 
@@ -177,9 +177,9 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query) 
             z_ret = deflate(&w->response.zstream, Z_FINISH);
             if(z_ret < 0) {
                 if(w->response.zstream.msg)
-                    error("Error compressing body. ZLIB error: \"%s\"", w->response.zstream.msg);
+                    netdata_log_error("Error compressing body. ZLIB error: \"%s\"", w->response.zstream.msg);
                 else
-                    error("Unknown error during zlib compression.");
+                    netdata_log_error("Unknown error during zlib compression.");
                 retval = 1;
                 w->response.code = 500;
                 aclk_http_msg_v2_err(query_thr->client, query->callback_topic, query->msg_id, w->response.code, CLOUD_EC_ZLIB_ERROR, CLOUD_EMSG_ZLIB_ERROR, NULL, 0);
@@ -366,7 +366,7 @@ void aclk_query_threads_start(struct aclk_query_threads *query_threads, mqtt_wss
         query_threads->thread_list[i].client = client;
 
         if(unlikely(snprintfz(thread_name, TASK_LEN_MAX, "ACLK_QRY[%d]", i) < 0))
-            error("snprintf encoding error");
+            netdata_log_error("snprintf encoding error");
         netdata_thread_create(
             &query_threads->thread_list[i].thread, thread_name, NETDATA_THREAD_OPTION_JOINABLE, aclk_query_main_thread,
             &query_threads->thread_list[i]);

--- a/aclk/aclk_query_queue.c
+++ b/aclk/aclk_query_queue.c
@@ -27,7 +27,7 @@ static inline int _aclk_queue_query(aclk_query_t query)
     if (aclk_query_queue.block_push) {
         ACLK_QUEUE_UNLOCK;
         if(service_running(SERVICE_ACLK | ABILITY_DATA_QUERIES))
-            error("Query Queue is blocked from accepting new requests. This is normally the case when ACLK prepares to shutdown.");
+            netdata_log_error("Query Queue is blocked from accepting new requests. This is normally the case when ACLK prepares to shutdown.");
         aclk_query_free(query);
         return 1;
     }
@@ -67,7 +67,7 @@ aclk_query_t aclk_queue_pop(void)
     if (aclk_query_queue.block_push) {
         ACLK_QUEUE_UNLOCK;
         if(service_running(SERVICE_ACLK | ABILITY_DATA_QUERIES))
-            error("POP Query Queue is blocked from accepting new requests. This is normally the case when ACLK prepares to shutdown.");
+            netdata_log_error("POP Query Queue is blocked from accepting new requests. This is normally the case when ACLK prepares to shutdown.");
         return NULL;
     }
 

--- a/aclk/aclk_query_queue.h
+++ b/aclk/aclk_query_queue.h
@@ -79,7 +79,7 @@ void aclk_queue_unlock(void);
     if (likely(query->data.bin_payload.payload)) {                                                                     \
         aclk_queue_query(query);                                                                                       \
     } else {                                                                                                           \
-        error("Failed to generate payload (%s)", __FUNCTION__);                                                        \
+        netdata_log_error("Failed to generate payload (%s)", __FUNCTION__);                                            \
         aclk_query_free(query);                                                                                        \
     }
 

--- a/aclk/aclk_stats.c
+++ b/aclk/aclk_stats.c
@@ -193,7 +193,7 @@ static void aclk_stats_query_threads(uint32_t *queries_per_thread)
 
         for (int i = 0; i < aclk_stats_cfg.query_thread_count; i++) {
             if (snprintfz(dim_name, MAX_DIM_NAME, "Query %d", i) < 0)
-                error("snprintf encoding error");
+                netdata_log_error("snprintf encoding error");
             aclk_qt_data[i].dim = rrddim_add(st, dim_name, NULL, 1, localhost->rrd_update_every, RRD_ALGORITHM_ABSOLUTE);
         }
     }
@@ -463,7 +463,7 @@ void aclk_stats_msg_puback(uint16_t id)
 
     if (unlikely(!pub_time[id])) {
         ACLK_STATS_UNLOCK;
-        error("Received PUBACK for unknown message?!");
+        netdata_log_error("Received PUBACK for unknown message?!");
         return;
     }
 

--- a/aclk/aclk_tx_msgs.c
+++ b/aclk/aclk_tx_msgs.c
@@ -32,7 +32,7 @@ uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, s
     const char *topic = aclk_get_topic(subtopic);
 
     if (unlikely(!topic)) {
-        error("Couldn't get topic. Aborting message send.");
+        netdata_log_error("Couldn't get topic. Aborting message send.");
         return 0;
     }
 
@@ -61,7 +61,7 @@ static int aclk_send_message_with_bin_payload(mqtt_wss_client client, json_objec
     int len;
 
     if (unlikely(!topic || topic[0] != '/')) {
-        error ("Full topic required!");
+        netdata_log_error("Full topic required!");
         json_object_put(msg);
         return HTTP_RESP_INTERNAL_SERVER_ERROR;
     }
@@ -172,7 +172,7 @@ void aclk_http_msg_v2_err(mqtt_wss_client client, const char *topic, const char 
     json_object_object_add(msg, "error-description", tmp);
 
     if (aclk_send_message_with_bin_payload(client, msg, topic, payload, payload_len)) {
-        error("Failed to send cancellation message for http reply %zu %s", payload_len, payload);
+        netdata_log_error("Failed to send cancellation message for http reply %zu %s", payload_len, payload);
     }
 }
 
@@ -220,7 +220,7 @@ uint16_t aclk_send_agent_connection_update(mqtt_wss_client client, int reachable
 
     rrdhost_aclk_state_lock(localhost);
     if (unlikely(!localhost->aclk_state.claimed_id)) {
-        error("Internal error. Should not come here if not claimed");
+        netdata_log_error("Internal error. Should not come here if not claimed");
         rrdhost_aclk_state_unlock(localhost);
         return 0;
     }
@@ -233,7 +233,7 @@ uint16_t aclk_send_agent_connection_update(mqtt_wss_client client, int reachable
     rrdhost_aclk_state_unlock(localhost);
 
     if (!msg) {
-        error("Error generating agent::v1::UpdateAgentConnection payload");
+        netdata_log_error("Error generating agent::v1::UpdateAgentConnection payload");
         return 0;
     }
 
@@ -255,7 +255,7 @@ char *aclk_generate_lwt(size_t *size) {
 
     rrdhost_aclk_state_lock(localhost);
     if (unlikely(!localhost->aclk_state.claimed_id)) {
-        error("Internal error. Should not come here if not claimed");
+        netdata_log_error("Internal error. Should not come here if not claimed");
         rrdhost_aclk_state_unlock(localhost);
         return NULL;
     }
@@ -265,7 +265,7 @@ char *aclk_generate_lwt(size_t *size) {
     rrdhost_aclk_state_unlock(localhost);
 
     if (!msg)
-        error("Error generating agent::v1::UpdateAgentConnection payload for LWT");
+        netdata_log_error("Error generating agent::v1::UpdateAgentConnection payload for LWT");
 
     return msg;
 }

--- a/aclk/aclk_util.c
+++ b/aclk/aclk_util.c
@@ -185,7 +185,7 @@ static void topic_generate_final(struct aclk_topic *t) {
 
     rrdhost_aclk_state_lock(localhost);
     if (unlikely(!localhost->aclk_state.claimed_id)) {
-        error("This should never be called if agent not claimed");
+        netdata_log_error("This should never be called if agent not claimed");
         rrdhost_aclk_state_unlock(localhost);
         return;
     }
@@ -214,7 +214,7 @@ static int topic_cache_add_topic(struct json_object *json, struct aclk_topic *to
     while (!json_object_iter_equal(&it, &itEnd)) {
         if (!strcmp(json_object_iter_peek_name(&it), JSON_TOPIC_KEY_NAME)) {
             if (json_object_get_type(json_object_iter_peek_value(&it)) != json_type_string) {
-                error("topic dictionary key \"" JSON_TOPIC_KEY_NAME "\" is expected to be json_type_string");
+                netdata_log_error("topic dictionary key \"" JSON_TOPIC_KEY_NAME "\" is expected to be json_type_string");
                 return 1;
             }
             topic->topic_id = topic_name_to_id(json_object_get_string(json_object_iter_peek_value(&it)));
@@ -226,7 +226,7 @@ static int topic_cache_add_topic(struct json_object *json, struct aclk_topic *to
         }
         if (!strcmp(json_object_iter_peek_name(&it), JSON_TOPIC_KEY_TOPIC)) {
             if (json_object_get_type(json_object_iter_peek_value(&it)) != json_type_string) {
-                error("topic dictionary key \"" JSON_TOPIC_KEY_TOPIC "\" is expected to be json_type_string");
+                netdata_log_error("topic dictionary key \"" JSON_TOPIC_KEY_TOPIC "\" is expected to be json_type_string");
                 return 1;
             }
             topic->topic_recvd = strdupz(json_object_get_string(json_object_iter_peek_value(&it)));
@@ -234,12 +234,12 @@ static int topic_cache_add_topic(struct json_object *json, struct aclk_topic *to
             continue;
         }
 
-        error("topic dictionary has Unknown/Unexpected key \"%s\" in topic description. Ignoring!", json_object_iter_peek_name(&it));
+        netdata_log_error("topic dictionary has Unknown/Unexpected key \"%s\" in topic description. Ignoring!", json_object_iter_peek_name(&it));
         json_object_iter_next(&it);
     }
 
     if (!topic->topic_recvd) {
-        error("topic dictionary Missig compulsory key %s", JSON_TOPIC_KEY_TOPIC);
+        netdata_log_error("topic dictionary Missig compulsory key %s", JSON_TOPIC_KEY_TOPIC);
         return 1;
     }
 
@@ -255,7 +255,7 @@ int aclk_generate_topic_cache(struct json_object *json)
 
     size_t array_size = json_object_array_length(json);
     if (!array_size) {
-        error("Empty topic list!");
+        netdata_log_error("Empty topic list!");
         return 1;
     }
 
@@ -267,19 +267,19 @@ int aclk_generate_topic_cache(struct json_object *json)
     for (size_t i = 0; i < array_size; i++) {
         obj = json_object_array_get_idx(json, i);
         if (json_object_get_type(obj) != json_type_object) {
-            error("expected json_type_object");
+            netdata_log_error("expected json_type_object");
             return 1;
         }
         aclk_topic_cache[i] = callocz(1, sizeof(struct aclk_topic));
         if (topic_cache_add_topic(obj, aclk_topic_cache[i])) {
-            error("failed to parse topic @idx=%d", (int)i);
+            netdata_log_error("failed to parse topic @idx=%d", (int)i);
             return 1;
         }
     }
 
     for (int i = 0; compulsory_topics[i] != ACLK_TOPICID_UNKNOWN; i++) {
         if (!aclk_get_topic(compulsory_topics[i])) {
-            error("missing compulsory topic \"%s\" in password response from cloud", topic_id_to_name(compulsory_topics[i]));
+            netdata_log_error("missing compulsory topic \"%s\" in password response from cloud", topic_id_to_name(compulsory_topics[i]));
             return 1;
         }
     }
@@ -295,7 +295,7 @@ int aclk_generate_topic_cache(struct json_object *json)
 const char *aclk_get_topic(enum aclk_topics topic)
 {
     if (!aclk_topic_cache) {
-        error("Topic cache not initialized");
+        netdata_log_error("Topic cache not initialized");
         return NULL;
     }
 
@@ -303,7 +303,7 @@ const char *aclk_get_topic(enum aclk_topics topic)
         if (aclk_topic_cache[i]->topic_id == topic)
             return aclk_topic_cache[i]->topic;
     }
-    error("Unknown topic");
+    netdata_log_error("Unknown topic");
     return NULL;
 }
 
@@ -315,7 +315,7 @@ const char *aclk_get_topic(enum aclk_topics topic)
 const char *aclk_topic_cache_iterate(aclk_topic_cache_iter_t *iter)
 {
     if (!aclk_topic_cache) {
-        error("Topic cache not initialized when %s was called.", __FUNCTION__);
+        netdata_log_error("Topic cache not initialized when %s was called.", __FUNCTION__);
         return NULL;
     }
 

--- a/aclk/schema-wrappers/alarm_stream.cc
+++ b/aclk/schema-wrappers/alarm_stream.cc
@@ -59,7 +59,7 @@ static alarms::v1::AlarmStatus aclk_alarm_status_to_proto(enum aclk_alarm_status
         case aclk_alarm_status::ALARM_STATUS_CRITICAL:
             return alarms::v1::ALARM_STATUS_CRITICAL;
         default:
-            error("Unknown alarm status");
+            netdata_log_error("Unknown alarm status");
             return alarms::v1::ALARM_STATUS_UNKNOWN;
     }
 }

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -50,7 +50,7 @@ extern struct registry registry;
 CLAIM_AGENT_RESPONSE claim_agent(const char *claiming_arguments, bool force, const char **msg)
 {
     if (!force || !netdata_cloud_enabled) {
-        error("Refusing to claim agent -> cloud functionality has been disabled");
+        netdata_log_error("Refusing to claim agent -> cloud functionality has been disabled");
         return CLAIM_AGENT_CLOUD_DISABLED;
     }
 
@@ -88,7 +88,7 @@ CLAIM_AGENT_RESPONSE claim_agent(const char *claiming_arguments, bool force, con
     netdata_log_info("Executing agent claiming command 'netdata-claim.sh'");
     fp_child_output = netdata_popen(command_buffer, &command_pid, &fp_child_input);
     if(!fp_child_output) {
-        error("Cannot popen(\"%s\").", command_buffer);
+        netdata_log_error("Cannot popen(\"%s\").", command_buffer);
         return CLAIM_AGENT_CANNOT_EXECUTE_CLAIM_SCRIPT;
     }
     netdata_log_info("Waiting for claiming command to finish.");
@@ -100,19 +100,19 @@ CLAIM_AGENT_RESPONSE claim_agent(const char *claiming_arguments, bool force, con
         return CLAIM_AGENT_OK;
     }
     if (exit_code < 0) {
-        error("Agent claiming command failed to complete its run.");
+        netdata_log_error("Agent claiming command failed to complete its run.");
         return CLAIM_AGENT_CLAIM_SCRIPT_FAILED;
     }
     errno = 0;
     unsigned maximum_known_exit_code = sizeof(claiming_errors) / sizeof(claiming_errors[0]) - 1;
 
     if ((unsigned)exit_code > maximum_known_exit_code) {
-        error("Agent failed to be claimed with an unknown error.");
+        netdata_log_error("Agent failed to be claimed with an unknown error.");
         return CLAIM_AGENT_CLAIM_SCRIPT_RETURNED_INVALID_CODE;
     }
 
-    error("Agent failed to be claimed with the following error message:");
-    error("\"%s\"", claiming_errors[exit_code]);
+    netdata_log_error("Agent failed to be claimed with the following error message:");
+    netdata_log_error("\"%s\"", claiming_errors[exit_code]);
 
     if(msg) *msg = claiming_errors[exit_code];
 
@@ -167,7 +167,7 @@ void load_claiming_state(void)
     long bytes_read;
     char *claimed_id = read_by_filename(filename, &bytes_read);
     if(claimed_id && uuid_parse(claimed_id, uuid)) {
-        error("claimed_id \"%s\" doesn't look like valid UUID", claimed_id);
+        netdata_log_error("claimed_id \"%s\" doesn't look like valid UUID", claimed_id);
         freez(claimed_id);
         claimed_id = NULL;
     }
@@ -250,12 +250,12 @@ bool netdata_random_session_id_generate(void) {
     // save it
     int fd = open(filename, O_WRONLY|O_CREAT|O_TRUNC, 640);
     if(fd == -1) {
-        error("Cannot create random session id file '%s'.", filename);
+        netdata_log_error("Cannot create random session id file '%s'.", filename);
         ret = false;
     }
 
     if(write(fd, guid, UUID_STR_LEN - 1) != UUID_STR_LEN - 1) {
-        error("Cannot write the random session id file '%s'.", filename);
+        netdata_log_error("Cannot write the random session id file '%s'.", filename);
         ret = false;
     }
 

--- a/cli/cli.c
+++ b/cli/cli.c
@@ -32,7 +32,7 @@ void *callocz_int(size_t nmemb, size_t size, const char *file __maybe_unused, co
 {
     void *p = calloc(nmemb, size);
     if (unlikely(!p)) {
-        error("Cannot allocate %zu bytes of memory.", nmemb * size);
+        netdata_log_error("Cannot allocate %zu bytes of memory.", nmemb * size);
         exit(1);
     }
     return p;
@@ -42,7 +42,7 @@ void *mallocz_int(size_t size, const char *file __maybe_unused, const char *func
 {
     void *p = malloc(size);
     if (unlikely(!p)) {
-        error("Cannot allocate %zu bytes of memory.", size);
+        netdata_log_error("Cannot allocate %zu bytes of memory.", size);
         exit(1);
     }
     return p;
@@ -52,7 +52,7 @@ void *reallocz_int(void *ptr, size_t size, const char *file __maybe_unused, cons
 {
     void *p = realloc(ptr, size);
     if (unlikely(!p)) {
-        error("Cannot allocate %zu bytes of memory.", size);
+        netdata_log_error("Cannot allocate %zu bytes of memory.", size);
         exit(1);
     }
     return p;
@@ -70,7 +70,7 @@ void freez(void *ptr) {
 void *mallocz(size_t size) {
     void *p = malloc(size);
     if (unlikely(!p)) {
-        error("Cannot allocate %zu bytes of memory.", size);
+        netdata_log_error("Cannot allocate %zu bytes of memory.", size);
         exit(1);
     }
     return p;
@@ -79,7 +79,7 @@ void *mallocz(size_t size) {
 void *callocz(size_t nmemb, size_t size) {
     void *p = calloc(nmemb, size);
     if (unlikely(!p)) {
-        error("Cannot allocate %zu bytes of memory.", nmemb * size);
+        netdata_log_error("Cannot allocate %zu bytes of memory.", nmemb * size);
         exit(1);
     }
     return p;
@@ -88,7 +88,7 @@ void *callocz(size_t nmemb, size_t size) {
 void *reallocz(void *ptr, size_t size) {
     void *p = realloc(ptr, size);
     if (unlikely(!p)) {
-        error("Cannot allocate %zu bytes of memory.", size);
+        netdata_log_error("Cannot allocate %zu bytes of memory.", size);
         exit(1);
     }
     return p;

--- a/collectors/cups.plugin/cups_plugin.c
+++ b/collectors/cups.plugin/cups_plugin.c
@@ -104,7 +104,7 @@ void parse_command_line(int argc, char **argv) {
     if (freq >= netdata_update_every) {
         netdata_update_every = freq;
     } else if (freq) {
-        error("update frequency %d seconds is too small for CUPS. Using %d.", freq, netdata_update_every);
+        netdata_log_error("update frequency %d seconds is too small for CUPS. Using %d.", freq, netdata_update_every);
     }
 }
 
@@ -275,7 +275,7 @@ int main(int argc, char **argv) {
             httpClose(http);
             http = httpConnect2(cupsServer(), ippPort(), NULL, AF_UNSPEC, cupsEncryption(), 0, netdata_update_every * 1000, NULL);
             if(http == NULL) {
-                error("cups daemon is not running. Exiting!");
+                netdata_log_error("cups daemon is not running. Exiting!");
                 exit(1);
             }
         }
@@ -321,7 +321,7 @@ int main(int argc, char **argv) {
                         fprintf(stderr, "printer state is missing for destination %s", curr_dest->name);
                     break;
                 default:
-                    error("Unknown printer state (%d) found.", printer_state);
+                    netdata_log_error("Unknown printer state (%d) found.", printer_state);
                     break;
             }
 
@@ -364,7 +364,7 @@ int main(int argc, char **argv) {
                     global_job_metrics.size_processing += curr_job->size;
                     break;
                 default:
-                    error("Unsupported job state (%u) found.", curr_job->state);
+                    netdata_log_error("Unsupported job state (%u) found.", curr_job->state);
                     break;
             }
         }

--- a/collectors/debugfs.plugin/debugfs_plugin.c
+++ b/collectors/debugfs.plugin/debugfs_plugin.c
@@ -30,18 +30,18 @@ static int debugfs_check_capabilities()
 {
     cap_t caps = cap_get_proc();
     if (!caps) {
-        error("Cannot get current capabilities.");
+        netdata_log_error("Cannot get current capabilities.");
         return 0;
     }
 
     int ret = 1;
     cap_flag_value_t cfv = CAP_CLEAR;
     if (cap_get_flag(caps, CAP_DAC_READ_SEARCH, CAP_EFFECTIVE, &cfv) == -1) {
-        error("Cannot find if CAP_DAC_READ_SEARCH is effective.");
+        netdata_log_error("Cannot find if CAP_DAC_READ_SEARCH is effective.");
         ret = 0;
     } else {
         if (cfv != CAP_SET) {
-            error("debugfs.plugin should run with CAP_DAC_READ_SEARCH.");
+            netdata_log_error("debugfs.plugin should run with CAP_DAC_READ_SEARCH.");
             ret = 0;
         }
     }
@@ -186,7 +186,7 @@ int main(int argc, char **argv)
     if (!debugfs_check_capabilities() && !debugfs_am_i_running_as_root() && !debugfs_check_sys_permission()) {
         uid_t uid = getuid(), euid = geteuid();
 #ifdef HAVE_CAPABILITY
-        error(
+        netdata_log_error(
             "debugfs.plugin should either run as root (now running with uid %u, euid %u) or have special capabilities. "
             "Without these, debugfs.plugin cannot access /sys/kernel/debug. "
             "To enable capabilities run: sudo setcap cap_dac_read_search,cap_sys_ptrace+ep %s; "
@@ -197,7 +197,7 @@ int main(int argc, char **argv)
             argv[0],
             argv[0]);
 #else
-        error(
+        netdata_log_error(
             "debugfs.plugin should either run as root (now running with uid %u, euid %u) or have special capabilities. "
             "Without these, debugfs.plugin cannot access /sys/kernel/debug."
             "Your system does not support capabilities. "

--- a/collectors/debugfs.plugin/debugfs_zswap.c
+++ b/collectors/debugfs.plugin/debugfs_zswap.c
@@ -251,7 +251,7 @@ int zswap_collect_data(struct netdata_zswap_metric *metric)
     snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, metric->filename);
 
     if (read_single_number_file(filename, (unsigned long long *)&metric->value)) {
-        error("Cannot read file %s", filename);
+        netdata_log_error("Cannot read file %s", filename);
         return 1;
     }
 

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -557,7 +557,7 @@ ARAL *ebpf_allocate_pid_aral(char *name, size_t size)
 {
     static size_t max_elements = NETDATA_EBPF_ALLOC_MAX_PID;
     if (max_elements < NETDATA_EBPF_ALLOC_MIN_ELEMENTS) {
-        error("Number of elements given is too small, adjusting it for %d", NETDATA_EBPF_ALLOC_MIN_ELEMENTS);
+        netdata_log_error("Number of elements given is too small, adjusting it for %d", NETDATA_EBPF_ALLOC_MIN_ELEMENTS);
         max_elements = NETDATA_EBPF_ALLOC_MIN_ELEMENTS;
     }
 
@@ -593,7 +593,7 @@ static inline void ebpf_check_before2go()
     }
 
     if (i) {
-        error("eBPF cannot unload all threads on time, but it will go away");
+        netdata_log_error("eBPF cannot unload all threads on time, but it will go away");
     }
 }
 
@@ -614,10 +614,10 @@ static void ebpf_exit()
     char filename[FILENAME_MAX + 1];
     ebpf_pid_file(filename, FILENAME_MAX);
     if (unlink(filename))
-        error("Cannot remove PID file %s", filename);
+        netdata_log_error("Cannot remove PID file %s", filename);
 
 #ifdef NETDATA_INTERNAL_CHECKS
-    error("Good bye world! I was PID %d", main_thread_id);
+    netdata_log_error("Good bye world! I was PID %d", main_thread_id);
 #endif
     fprintf(stdout, "EXIT\n");
     fflush(stdout);
@@ -670,7 +670,7 @@ static void ebpf_unload_unique_maps()
 
         if (ebpf_modules[i].enabled != NETDATA_THREAD_EBPF_STOPPED) {
             if (ebpf_modules[i].enabled != NETDATA_THREAD_EBPF_NOT_RUNNING)
-                error("Cannot unload maps for thread %s, because it is not stopped.", ebpf_modules[i].thread_name);
+                netdata_log_error("Cannot unload maps for thread %s, because it is not stopped.", ebpf_modules[i].thread_name);
 
             continue;
         }
@@ -1605,7 +1605,7 @@ static void read_local_addresses()
 {
     struct ifaddrs *ifaddr, *ifa;
     if (getifaddrs(&ifaddr) == -1) {
-        error("Cannot get the local IP addresses, it is no possible to do separation between inbound and outbound connections");
+        netdata_log_error("Cannot get the local IP addresses, it is no possible to do separation between inbound and outbound connections");
         return;
     }
 
@@ -1714,7 +1714,7 @@ static inline void how_to_load(char *ptr)
     else if (!strcasecmp(ptr, EBPF_CFG_LOAD_MODE_DEFAULT))
         ebpf_set_thread_mode(MODE_ENTRY);
     else
-        error("the option %s for \"ebpf load mode\" is not a valid option.", ptr);
+        netdata_log_error("the option %s for \"ebpf load mode\" is not a valid option.", ptr);
 }
 
 /**
@@ -2051,7 +2051,7 @@ void set_global_variables()
     ebpf_nprocs = (int)sysconf(_SC_NPROCESSORS_ONLN);
     if (ebpf_nprocs < 0) {
         ebpf_nprocs = NETDATA_MAX_PROCESSOR;
-        error("Cannot identify number of process, using default value %d", ebpf_nprocs);
+        netdata_log_error("Cannot identify number of process, using default value %d", ebpf_nprocs);
     }
 
     isrh = get_redhat_release();
@@ -2080,12 +2080,12 @@ static inline void ebpf_load_thread_config()
 int ebpf_check_conditions()
 {
     if (!has_condition_to_run(running_on_kernel)) {
-        error("The current collector cannot run on this kernel.");
+        netdata_log_error("The current collector cannot run on this kernel.");
         return -1;
     }
 
     if (!am_i_running_as_root()) {
-        error(
+        netdata_log_error(
             "ebpf.plugin should either run as root (now running with uid %u, euid %u) or have special capabilities..",
             (unsigned int)getuid(), (unsigned int)geteuid());
         return -1;
@@ -2105,7 +2105,7 @@ int ebpf_adjust_memory_limit()
 {
     struct rlimit r = { RLIM_INFINITY, RLIM_INFINITY };
     if (setrlimit(RLIMIT_MEMLOCK, &r)) {
-        error("Setrlimit(RLIMIT_MEMLOCK)");
+        netdata_log_error("Setrlimit(RLIMIT_MEMLOCK)");
         return -1;
     }
 
@@ -2398,7 +2398,7 @@ unittest:
              ebpf_user_config_dir, ebpf_stock_config_dir);
         if (ebpf_read_apps_groups_conf(
                 &apps_groups_default_target, &apps_groups_root_target, ebpf_stock_config_dir, "groups")) {
-            error("Cannot read process groups '%s/apps_groups.conf'. There are no internal defaults. Failing.",
+            netdata_log_error("Cannot read process groups '%s/apps_groups.conf'. There are no internal defaults. Failing.",
                   ebpf_stock_config_dir);
             ebpf_exit();
         }
@@ -2445,7 +2445,7 @@ static char *ebpf_get_process_name(pid_t pid)
 
     procfile *ff = procfile_open(filename, " \t", PROCFILE_FLAG_DEFAULT);
     if(unlikely(!ff)) {
-        error("Cannot open %s", filename);
+        netdata_log_error("Cannot open %s", filename);
         return name;
     }
 

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -35,7 +35,7 @@ void ebpf_aral_init(void)
 {
     size_t max_elements = NETDATA_EBPF_ALLOC_MAX_PID;
     if (max_elements < NETDATA_EBPF_ALLOC_MIN_ELEMENTS) {
-        error("Number of elements given is too small, adjusting it for %d", NETDATA_EBPF_ALLOC_MIN_ELEMENTS);
+        netdata_log_error("Number of elements given is too small, adjusting it for %d", NETDATA_EBPF_ALLOC_MIN_ELEMENTS);
         max_elements = NETDATA_EBPF_ALLOC_MIN_ELEMENTS;
     }
 
@@ -652,7 +652,7 @@ int ebpf_read_apps_groups_conf(struct ebpf_target **agdt, struct ebpf_target **a
             // add this target
             struct ebpf_target *n = get_apps_groups_target(agrt, s, w, name);
             if (!n) {
-                error("Cannot create target '%s' (line %zu, word %zu)", s, line, word);
+                netdata_log_error("Cannot create target '%s' (line %zu, word %zu)", s, line, word);
                 continue;
             }
 
@@ -755,32 +755,32 @@ static inline void debug_log_dummy(void)
 static inline int managed_log(struct ebpf_pid_stat *p, uint32_t log, int status)
 {
     if (unlikely(!status)) {
-        // error("command failed log %u, errno %d", log, errno);
+        // netdata_log_error("command failed log %u, errno %d", log, errno);
 
         if (unlikely(debug_enabled || errno != ENOENT)) {
             if (unlikely(debug_enabled || !(p->log_thrown & log))) {
                 p->log_thrown |= log;
                 switch (log) {
                     case PID_LOG_IO:
-                        error(
+                        netdata_log_error(
                             "Cannot process %s/proc/%d/io (command '%s')", netdata_configured_host_prefix, p->pid,
                             p->comm);
                         break;
 
                     case PID_LOG_STATUS:
-                        error(
+                        netdata_log_error(
                             "Cannot process %s/proc/%d/status (command '%s')", netdata_configured_host_prefix, p->pid,
                             p->comm);
                         break;
 
                     case PID_LOG_CMDLINE:
-                        error(
+                        netdata_log_error(
                             "Cannot process %s/proc/%d/cmdline (command '%s')", netdata_configured_host_prefix, p->pid,
                             p->comm);
                         break;
 
                     case PID_LOG_FDS:
-                        error(
+                        netdata_log_error(
                             "Cannot process entries in %s/proc/%d/fd (command '%s')", netdata_configured_host_prefix,
                             p->pid, p->comm);
                         break;
@@ -789,14 +789,14 @@ static inline int managed_log(struct ebpf_pid_stat *p, uint32_t log, int status)
                         break;
 
                     default:
-                        error("unhandled error for pid %d, command '%s'", p->pid, p->comm);
+                        netdata_log_error("unhandled error for pid %d, command '%s'", p->pid, p->comm);
                         break;
                 }
             }
         }
         errno = 0;
     } else if (unlikely(p->log_thrown & log)) {
-        // error("unsetting log %u on pid %d", log, p->pid);
+        // netdata_log_error("unsetting log %u on pid %d", log, p->pid);
         p->log_thrown &= ~log;
     }
 
@@ -1005,7 +1005,7 @@ static inline int read_proc_pid_stat(struct ebpf_pid_stat *p, void *ptr)
 static inline int collect_data_for_pid(pid_t pid, void *ptr)
 {
     if (unlikely(pid < 0 || pid > pid_max)) {
-        error("Invalid pid %d read (expected %d to %d). Ignoring process.", pid, 0, pid_max);
+        netdata_log_error("Invalid pid %d read (expected %d to %d). Ignoring process.", pid, 0, pid_max);
         return 0;
     }
 
@@ -1020,7 +1020,7 @@ static inline int collect_data_for_pid(pid_t pid, void *ptr)
 
     // check its parent pid
     if (unlikely(p->ppid < 0 || p->ppid > pid_max)) {
-        error("Pid %d (command '%s') states invalid parent pid %d. Using 0.", pid, p->comm, p->ppid);
+        netdata_log_error("Pid %d (command '%s') states invalid parent pid %d. Using 0.", pid, p->comm, p->ppid);
         p->ppid = 0;
     }
 
@@ -1220,7 +1220,7 @@ static inline void del_pid_entry(pid_t pid)
     struct ebpf_pid_stat *p = ebpf_all_pids[pid];
 
     if (unlikely(!p)) {
-        error("attempted to free pid %d that is not allocated.", pid);
+        netdata_log_error("attempted to free pid %d that is not allocated.", pid);
         return;
     }
 
@@ -1403,7 +1403,7 @@ static inline void aggregate_pid_on_target(struct ebpf_target *w, struct ebpf_pi
     }
 
     if (unlikely(!w)) {
-        error("pid %d %s was left without a target!", p->pid, p->comm);
+        netdata_log_error("pid %d %s was left without a target!", p->pid, p->comm);
         return;
     }
 

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -1220,7 +1220,7 @@ static int ebpf_cachestat_set_internal_value()
     }
 
     if (!address.addr) {
-        error("%s cachestat.", NETDATA_EBPF_DEFAULT_FNT_NOT_FOUND);
+        netdata_log_error("%s cachestat.", NETDATA_EBPF_DEFAULT_FNT_NOT_FOUND);
         return -1;
     }
 
@@ -1261,7 +1261,7 @@ static int ebpf_cachestat_load_bpf(ebpf_module_t *em)
 #endif
 
     if (ret)
-        error("%s %s", EBPF_DEFAULT_ERROR_MSG, em->thread_name);
+        netdata_log_error("%s %s", EBPF_DEFAULT_ERROR_MSG, em->thread_name);
 
     return ret;
 }

--- a/collectors/ebpf.plugin/ebpf_cgroup.c
+++ b/collectors/ebpf.plugin/ebpf_cgroup.c
@@ -28,7 +28,7 @@ static inline void *ebpf_cgroup_map_shm_locally(int fd, size_t length)
 
     value =  mmap(NULL, length, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     if (!value) {
-        error("Cannot map shared memory used between eBPF and cgroup, integration between processes won't happen");
+        netdata_log_error("Cannot map shared memory used between eBPF and cgroup, integration between processes won't happen");
         close(shm_fd_ebpf_cgroup);
         shm_fd_ebpf_cgroup = -1;
         shm_unlink(NETDATA_SHARED_MEMORY_EBPF_CGROUP_NAME);
@@ -71,7 +71,7 @@ void ebpf_map_cgroup_shared_memory()
         shm_fd_ebpf_cgroup = shm_open(NETDATA_SHARED_MEMORY_EBPF_CGROUP_NAME, O_RDWR, 0660);
         if (shm_fd_ebpf_cgroup < 0) {
             if (limit_try == NETDATA_EBPF_CGROUP_MAX_TRIES)
-                error("Shared memory was not initialized, integration between processes won't happen.");
+                netdata_log_error("Shared memory was not initialized, integration between processes won't happen.");
 
             return;
         }
@@ -103,7 +103,7 @@ void ebpf_map_cgroup_shared_memory()
     shm_sem_ebpf_cgroup = sem_open(NETDATA_NAMED_SEMAPHORE_EBPF_CGROUP_NAME, O_CREAT, 0660, 1);
 
     if (shm_sem_ebpf_cgroup == SEM_FAILED) {
-        error("Cannot create semaphore, integration between eBPF and cgroup won't happen");
+        netdata_log_error("Cannot create semaphore, integration between eBPF and cgroup won't happen");
         limit_try = NETDATA_EBPF_CGROUP_MAX_TRIES + 1;
         munmap(ebpf_mapped_memory, length);
         shm_ebpf_cgroup.header = NULL;

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -1112,7 +1112,7 @@ static int ebpf_dcstat_load_bpf(ebpf_module_t *em)
 #endif
 
     if (ret)
-        error("%s %s", EBPF_DEFAULT_ERROR_MSG, em->thread_name);
+        netdata_log_error("%s %s", EBPF_DEFAULT_ERROR_MSG, em->thread_name);
 
     return ret;
 }

--- a/collectors/ebpf.plugin/ebpf_disk.c
+++ b/collectors/ebpf.plugin/ebpf_disk.c
@@ -341,7 +341,7 @@ static void update_disk_table(char *name, int major, int minor, time_t current_t
     netdata_ebpf_disks_t *check;
     check = (netdata_ebpf_disks_t *) avl_insert_lock(&disk_tree, (avl_t *)w);
     if (check != w)
-        error("Internal error, cannot insert the AVL tree.");
+        netdata_log_error("Internal error, cannot insert the AVL tree.");
 
 #ifdef NETDATA_INTERNAL_CHECKS
     netdata_log_info("The Latency is monitoring the hard disk %s (Major = %d, Minor = %d, Device = %u)", name, major, minor,w->dev);
@@ -424,12 +424,12 @@ static void ebpf_disk_disable_tracepoints()
     char *default_message = { "Cannot disable the tracepoint" };
     if (!was_block_issue_enabled) {
         if (ebpf_disable_tracing_values(tracepoint_block_type, tracepoint_block_issue))
-            error("%s %s/%s.", default_message, tracepoint_block_type, tracepoint_block_issue);
+            netdata_log_error("%s %s/%s.", default_message, tracepoint_block_type, tracepoint_block_issue);
     }
 
     if (!was_block_rq_complete_enabled) {
         if (ebpf_disable_tracing_values(tracepoint_block_type, tracepoint_block_rq_complete))
-            error("%s %s/%s.", default_message, tracepoint_block_type, tracepoint_block_rq_complete);
+            netdata_log_error("%s %s/%s.", default_message, tracepoint_block_type, tracepoint_block_rq_complete);
     }
 }
 
@@ -845,7 +845,7 @@ void *ebpf_disk_thread(void *ptr)
     }
 
     if (pthread_mutex_init(&plot_mutex, NULL)) {
-        error("Cannot initialize local mutex");
+        netdata_log_error("Cannot initialize local mutex");
         goto enddisk;
     }
 

--- a/collectors/ebpf.plugin/ebpf_disk.c
+++ b/collectors/ebpf.plugin/ebpf_disk.c
@@ -814,7 +814,7 @@ static int ebpf_disk_load_bpf(ebpf_module_t *em)
 #endif
 
     if (ret)
-        error("%s %s", EBPF_DEFAULT_ERROR_MSG, em->thread_name);
+        netdata_log_error("%s %s", EBPF_DEFAULT_ERROR_MSG, em->thread_name);
 
     return ret;
 }

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -326,7 +326,7 @@ static inline int ebpf_fd_load_and_attach(struct fd_bpf *obj, ebpf_module_t *em)
     netdata_ebpf_program_loaded_t test = mt[NETDATA_FD_SYSCALL_OPEN].mode;
 
     if (ebpf_fd_set_target_values()) {
-        error("%s file descriptor.", NETDATA_EBPF_DEFAULT_FNT_NOT_FOUND);
+        netdata_log_error("%s file descriptor.", NETDATA_EBPF_DEFAULT_FNT_NOT_FOUND);
         return -1;
     }
 
@@ -1125,7 +1125,7 @@ static int ebpf_fd_load_bpf(ebpf_module_t *em)
 #endif
 
     if (ret)
-        error("%s %s", EBPF_DEFAULT_ERROR_MSG, em->thread_name);
+        netdata_log_error("%s %s", EBPF_DEFAULT_ERROR_MSG, em->thread_name);
 
     return ret;
 }

--- a/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -406,7 +406,7 @@ static int hardirq_read_latency_map(int mapfd)
 
             avl_t *check = avl_insert_lock(&hardirq_pub, (avl_t *)v);
             if (check != (avl_t *)v) {
-                error("Internal error, cannot insert the AVL tree.");
+                netdata_log_error("Internal error, cannot insert the AVL tree.");
             }
         }
 

--- a/collectors/ebpf.plugin/ebpf_mdflush.c
+++ b/collectors/ebpf.plugin/ebpf_mdflush.c
@@ -241,7 +241,7 @@ static void mdflush_read_count_map(int maps_per_core)
         if (v_is_new) {
             avl_t *check = avl_insert_lock(&mdflush_pub, (avl_t *)v);
             if (check != (avl_t *)v) {
-                error("Internal error, cannot insert the AVL tree.");
+                netdata_log_error("Internal error, cannot insert the AVL tree.");
             }
         }
     }
@@ -384,7 +384,7 @@ void *ebpf_mdflush_thread(void *ptr)
 
     char *md_flush_request = ebpf_find_symbol("md_flush_request");
     if (!md_flush_request) {
-        error("Cannot monitor MD devices, because md is not loaded.");
+        netdata_log_error("Cannot monitor MD devices, because md is not loaded.");
         goto endmdflush;
     }
 

--- a/collectors/ebpf.plugin/ebpf_mdflush.c
+++ b/collectors/ebpf.plugin/ebpf_mdflush.c
@@ -393,7 +393,7 @@ void *ebpf_mdflush_thread(void *ptr)
     ebpf_adjust_thread_load(em, default_btf);
 #endif
     if (ebpf_mdflush_load_bpf(em)) {
-        error("Cannot load eBPF software.");
+        netdata_log_error("Cannot load eBPF software.");
         goto endmdflush;
     }
 

--- a/collectors/ebpf.plugin/ebpf_mount.c
+++ b/collectors/ebpf.plugin/ebpf_mount.c
@@ -408,7 +408,7 @@ static int ebpf_mount_load_bpf(ebpf_module_t *em)
 #endif
 
     if (ret)
-        error("%s %s", EBPF_DEFAULT_ERROR_MSG, em->thread_name);
+        netdata_log_error("%s %s", EBPF_DEFAULT_ERROR_MSG, em->thread_name);
 
     return ret;
 }

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -259,7 +259,7 @@ static uint32_t oomkill_read_data(int32_t *keys)
         if (unlikely(test < 0)) {
             // since there's only 1 thread doing these deletions, it should be
             // impossible to get this condition.
-            error("key unexpectedly not available for deletion.");
+            netdata_log_error("key unexpectedly not available for deletion.");
         }
     }
 

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -683,17 +683,17 @@ static void ebpf_process_disable_tracepoints()
     char *default_message = { "Cannot disable the tracepoint" };
     if (!was_sched_process_exit_enabled) {
         if (ebpf_disable_tracing_values(tracepoint_sched_type, tracepoint_sched_process_exit))
-            error("%s %s/%s.", default_message, tracepoint_sched_type, tracepoint_sched_process_exit);
+            netdata_log_error("%s %s/%s.", default_message, tracepoint_sched_type, tracepoint_sched_process_exit);
     }
 
     if (!was_sched_process_exec_enabled) {
         if (ebpf_disable_tracing_values(tracepoint_sched_type, tracepoint_sched_process_exec))
-            error("%s %s/%s.", default_message, tracepoint_sched_type, tracepoint_sched_process_exec);
+            netdata_log_error("%s %s/%s.", default_message, tracepoint_sched_type, tracepoint_sched_process_exec);
     }
 
     if (!was_sched_process_fork_enabled) {
         if (ebpf_disable_tracing_values(tracepoint_sched_type, tracepoint_sched_process_fork))
-            error("%s %s/%s.", default_message, tracepoint_sched_type, tracepoint_sched_process_fork);
+            netdata_log_error("%s %s/%s.", default_message, tracepoint_sched_type, tracepoint_sched_process_fork);
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -1037,7 +1037,7 @@ static int ebpf_shm_load_bpf(ebpf_module_t *em)
 
 
     if (ret)
-        error("%s %s", EBPF_DEFAULT_ERROR_MSG, em->thread_name);
+        netdata_log_error("%s %s", EBPF_DEFAULT_ERROR_MSG, em->thread_name);
 
     return ret;
 }

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -1927,7 +1927,7 @@ static void store_socket_inside_avl(netdata_vector_plot_t *out, netdata_socket_t
         netdata_socket_plot_t *check ;
         check = (netdata_socket_plot_t *) avl_insert_lock(&out->tree, (avl_t *)w);
         if (check != w)
-            error("Internal error, cannot insert the AVL tree.");
+            netdata_log_error("Internal error, cannot insert the AVL tree.");
 
 #ifdef NETDATA_INTERNAL_CHECKS
         char iptext[INET6_ADDRSTRLEN];
@@ -3165,7 +3165,7 @@ static inline in_addr_t ipv4_network(in_addr_t addr, int prefix)
 static inline int ip2nl(uint8_t *dst, char *ip, int domain, char *source)
 {
     if (inet_pton(domain, ip, dst) <= 0) {
-        error("The address specified (%s) is invalid ", source);
+        netdata_log_error("The address specified (%s) is invalid ", source);
         return -1;
     }
 
@@ -3639,7 +3639,7 @@ static void read_max_dimension(struct config *cfg)
                                         EBPF_MAXIMUM_DIMENSIONS,
                                         NETDATA_NV_CAP_VALUE);
     if (maxdim < 0) {
-        error("'maximum dimensions = %d' must be a positive number, Netdata will change for default value %ld.",
+        netdata_log_error("'maximum dimensions = %d' must be a positive number, Netdata will change for default value %ld.",
               maxdim, NETDATA_NV_CAP_VALUE);
         maxdim = NETDATA_NV_CAP_VALUE;
     }
@@ -3827,7 +3827,7 @@ static void link_dimension_name(char *port, uint32_t hash, char *value)
 {
     int test = str2i(port);
     if (test < NETDATA_MINIMUM_PORT_VALUE || test > NETDATA_MAXIMUM_PORT_VALUE){
-        error("The dimension given (%s = %s) has an invalid value and it will be ignored.", port, value);
+        netdata_log_error("The dimension given (%s = %s) has an invalid value and it will be ignored.", port, value);
         return;
     }
 
@@ -3950,7 +3950,7 @@ static int ebpf_socket_load_bpf(ebpf_module_t *em)
 #endif
 
     if (ret) {
-        error("%s %s", EBPF_DEFAULT_ERROR_MSG, em->thread_name);
+        netdata_log_error("%s %s", EBPF_DEFAULT_ERROR_MSG, em->thread_name);
     }
 
     return ret;
@@ -3975,7 +3975,7 @@ void *ebpf_socket_thread(void *ptr)
     parse_table_size_options(&socket_config);
 
     if (pthread_mutex_init(&nv_mutex, NULL)) {
-        error("Cannot initialize local mutex");
+        netdata_log_error("Cannot initialize local mutex");
         goto endsocket;
     }
 

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -818,7 +818,7 @@ static int ebpf_swap_load_bpf(ebpf_module_t *em)
 #endif
 
     if (ret)
-        error("%s %s", EBPF_DEFAULT_ERROR_MSG, em->thread_name);
+        netdata_log_error("%s %s", EBPF_DEFAULT_ERROR_MSG, em->thread_name);
 
     return ret;
 }

--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -94,7 +94,7 @@ static void pluginsd_worker_thread_handle_success(struct plugind *cd) {
     }
 
     if (cd->serial_failures > SERIAL_FAILURES_THRESHOLD) {
-        error("PLUGINSD: 'host:'%s', '%s' (pid %d) does not generate useful output, "
+        netdata_log_error("PLUGINSD: 'host:'%s', '%s' (pid %d) does not generate useful output, "
               "although it reports success (exits with 0)."
               "We have tried to collect something %zu times - unsuccessfully. Disabling it.",
               rrdhost_hostname(cd->host), cd->fullfilename, cd->unsafe.pid, cd->serial_failures);
@@ -112,14 +112,14 @@ static void pluginsd_worker_thread_handle_error(struct plugind *cd, int worker_r
     }
 
     if (!cd->successful_collections) {
-        error("PLUGINSD: 'host:%s', '%s' (pid %d) exited with error code %d and haven't collected any data. Disabling it.",
+        netdata_log_error("PLUGINSD: 'host:%s', '%s' (pid %d) exited with error code %d and haven't collected any data. Disabling it.",
               rrdhost_hostname(cd->host), cd->fullfilename, cd->unsafe.pid, worker_ret_code);
         plugin_set_disabled(cd);
         return;
     }
 
     if (cd->serial_failures <= SERIAL_FAILURES_THRESHOLD) {
-        error("PLUGINSD: 'host:%s', '%s' (pid %d) exited with error code %d, but has given useful output in the past (%zu times). %s",
+        netdata_log_error("PLUGINSD: 'host:%s', '%s' (pid %d) exited with error code %d, but has given useful output in the past (%zu times). %s",
               rrdhost_hostname(cd->host), cd->fullfilename, cd->unsafe.pid, worker_ret_code, cd->successful_collections,
               plugin_is_enabled(cd) ? "Waiting a bit before starting it again." : "Will not start it again - it is disabled.");
         sleep((unsigned int)(cd->update_every * 10));
@@ -127,7 +127,7 @@ static void pluginsd_worker_thread_handle_error(struct plugind *cd, int worker_r
     }
 
     if (cd->serial_failures > SERIAL_FAILURES_THRESHOLD) {
-        error("PLUGINSD: 'host:%s', '%s' (pid %d) exited with error code %d, but has given useful output in the past (%zu times)."
+        netdata_log_error("PLUGINSD: 'host:%s', '%s' (pid %d) exited with error code %d, but has given useful output in the past (%zu times)."
               "We tried to restart it %zu times, but it failed to generate data. Disabling it.",
               rrdhost_hostname(cd->host), cd->fullfilename, cd->unsafe.pid, worker_ret_code,
               cd->successful_collections, cd->serial_failures);
@@ -153,7 +153,7 @@ static void *pluginsd_worker_thread(void *arg) {
         FILE *fp_child_output = netdata_popen(cd->cmd, &cd->unsafe.pid, &fp_child_input);
 
         if (unlikely(!fp_child_input || !fp_child_output)) {
-            error("PLUGINSD: 'host:%s', cannot popen(\"%s\", \"r\").", rrdhost_hostname(cd->host), cd->cmd);
+            netdata_log_error("PLUGINSD: 'host:%s', cannot popen(\"%s\", \"r\").", rrdhost_hostname(cd->host), cd->cmd);
             break;
         }
 
@@ -235,7 +235,7 @@ void *pluginsd_main(void *ptr)
             if (unlikely(!dir)) {
                 if (directory_errors[idx] != errno) {
                     directory_errors[idx] = errno;
-                    error("cannot open plugins directory '%s'", directory_name);
+                    netdata_log_error("cannot open plugins directory '%s'", directory_name);
                 }
                 continue;
             }

--- a/collectors/plugins.d/pluginsd_parser.h
+++ b/collectors/plugins.d/pluginsd_parser.h
@@ -209,8 +209,8 @@ static inline int parser_action(PARSER *parser, char *input) {
             buffer_fast_strcat(wb, "\"", 1);
         }
 
-        error("PLUGINSD: parser_action('%s') failed on line %zu: { %s } (quotes added to show parsing)",
-              command, parser->line, buffer_tostring(wb));
+        netdata_log_error("PLUGINSD: parser_action('%s') failed on line %zu: { %s } (quotes added to show parsing)",
+                          command, parser->line, buffer_tostring(wb));
 
         buffer_free(wb);
     }

--- a/collectors/timex.plugin/plugin_timex.c
+++ b/collectors/timex.plugin/plugin_timex.c
@@ -79,7 +79,7 @@ void *timex_main(void *ptr)
         prev_sync_state = sync_state;
 
         if (non_seq_failure) {
-            error("Cannot get clock synchronization state");
+            netdata_log_error("Cannot get clock synchronization state");
             continue;
         }
 

--- a/collectors/xenstat.plugin/xenstat_plugin.c
+++ b/collectors/xenstat.plugin/xenstat_plugin.c
@@ -178,7 +178,7 @@ static struct domain_metrics *domain_metrics_free(struct domain_metrics *d) {
     }
 
     if(unlikely(!cur)) {
-        error("XENSTAT: failed to free domain metrics.");
+        netdata_log_error("XENSTAT: failed to free domain metrics.");
         return NULL;
     }
 
@@ -242,7 +242,7 @@ static int vcpu_metrics_collect(struct domain_metrics *d, xenstat_domain *domain
         vcpu = xenstat_domain_vcpu(domain, i);
 
         if(unlikely(!vcpu)) {
-            error("XENSTAT: cannot get VCPU statistics.");
+            netdata_log_error("XENSTAT: cannot get VCPU statistics.");
             return 1;
         }
 
@@ -288,7 +288,7 @@ static int vbd_metrics_collect(struct domain_metrics *d, xenstat_domain *domain)
         vbd = xenstat_domain_vbd(domain, i);
 
         if(unlikely(!vbd)) {
-            error("XENSTAT: cannot get VBD statistics.");
+            netdata_log_error("XENSTAT: cannot get VBD statistics.");
             return 1;
         }
 
@@ -336,7 +336,7 @@ static int network_metrics_collect(struct domain_metrics *d, xenstat_domain *dom
         network = xenstat_domain_network(domain, i);
 
         if(unlikely(!network)) {
-            error("XENSTAT: cannot get network statistics.");
+            netdata_log_error("XENSTAT: cannot get network statistics.");
             return 1;
         }
 
@@ -368,7 +368,7 @@ static int xenstat_collect(xenstat_handle *xhandle, libxl_ctx *ctx, libxl_dominf
 
     xenstat_node *node = xenstat_get_node(xhandle, XENSTAT_ALL);
     if (unlikely(!node)) {
-        error("XENSTAT: failed to retrieve statistics from libxenstat.");
+        netdata_log_error("XENSTAT: failed to retrieve statistics from libxenstat.");
         return 1;
     }
 
@@ -388,7 +388,7 @@ static int xenstat_collect(xenstat_handle *xhandle, libxl_ctx *ctx, libxl_dominf
         // get domain UUID
         unsigned int id = xenstat_domain_id(domain);
         if(unlikely(libxl_domain_info(ctx, info, id))) {
-            error("XENSTAT: cannot get domain info.");
+            netdata_log_error("XENSTAT: cannot get domain info.");
         }
         else {
             snprintfz(uuid, LIBXL_UUID_FMTLEN, LIBXL_UUID_FMT "\n", LIBXL_UUID_BYTES(info->uuid));
@@ -989,7 +989,7 @@ int main(int argc, char **argv) {
             exit(1);
         }
 
-        error("xenstat.plugin: ignoring parameter '%s'", argv[i]);
+        netdata_log_error("xenstat.plugin: ignoring parameter '%s'", argv[i]);
     }
 
     errno = 0;
@@ -997,7 +997,7 @@ int main(int argc, char **argv) {
     if(freq >= netdata_update_every)
         netdata_update_every = freq;
     else if(freq)
-        error("update frequency %d seconds is too small for XENSTAT. Using %d.", freq, netdata_update_every);
+        netdata_log_error("update frequency %d seconds is too small for XENSTAT. Using %d.", freq, netdata_update_every);
 
     // ------------------------------------------------------------------------
     // initialize xen API handles
@@ -1008,13 +1008,13 @@ int main(int argc, char **argv) {
     if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: calling xenstat_init()\n");
     xhandle = xenstat_init();
     if (xhandle == NULL) {
-        error("XENSTAT: failed to initialize xenstat library.");
+        netdata_log_error("XENSTAT: failed to initialize xenstat library.");
         return 1;
     }
 
     if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: calling libxl_ctx_alloc()\n");
     if (libxl_ctx_alloc(&ctx, LIBXL_VERSION, 0, NULL)) {
-        error("XENSTAT: failed to initialize xl context.");
+        netdata_log_error("XENSTAT: failed to initialize xl context.");
         xenstat_uninit(xhandle);
         return 1;
     }

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -1035,11 +1035,11 @@ void send_statistics(const char *action, const char *action_result, const char *
         char *s = fgets(buffer, 4, fp_child_output);
         int exit_code = netdata_pclose(fp_child_input, fp_child_output, command_pid);
         if (exit_code)
-            error("Execution of anonymous statistics script returned %d.", exit_code);
+            netdata_log_error("Execution of anonymous statistics script returned %d.", exit_code);
         if (s && strncmp(buffer, "200", 3))
-            error("Execution of anonymous statistics script returned http code %s.", buffer);
+            netdata_log_error("Execution of anonymous statistics script returned http code %s.", buffer);
     } else {
-        error("Failed to run anonymous statistics script %s.", as_script);
+        netdata_log_error("Failed to run anonymous statistics script %s.", as_script);
     }
     freez(command_to_run);
 }

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -42,7 +42,7 @@ static void svc_rrddim_obsolete_to_archive(RRDDIM *rd) {
     if(cache_filename) {
         netdata_log_info("Deleting dimension file '%s'.", cache_filename);
         if (unlikely(unlink(cache_filename) == -1))
-            error("Cannot delete dimension file '%s'", cache_filename);
+            netdata_log_error("Cannot delete dimension file '%s'", cache_filename);
     }
 
     if (rd->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {

--- a/daemon/signals.c
+++ b/daemon/signals.c
@@ -59,7 +59,7 @@ void signals_block(void) {
     sigfillset(&sigset);
 
     if(pthread_sigmask(SIG_BLOCK, &sigset, NULL) == -1)
-        error("SIGNAL: Could not block signals for threads");
+        netdata_log_error("SIGNAL: Could not block signals for threads");
 }
 
 void signals_unblock(void) {
@@ -67,7 +67,7 @@ void signals_unblock(void) {
     sigfillset(&sigset);
 
     if(pthread_sigmask(SIG_UNBLOCK, &sigset, NULL) == -1) {
-        error("SIGNAL: Could not unblock signals for threads");
+        netdata_log_error("SIGNAL: Could not unblock signals for threads");
     }
 }
 
@@ -91,7 +91,7 @@ void signals_init(void) {
         }
 
         if(sigaction(signals_waiting[i].signo, &sa, NULL) == -1)
-            error("SIGNAL: Failed to change signal handler for: %s", signals_waiting[i].name);
+            netdata_log_error("SIGNAL: Failed to change signal handler for: %s", signals_waiting[i].name);
     }
 }
 
@@ -104,7 +104,7 @@ void signals_restore_SIGCHLD(void)
     sa.sa_handler = signal_handler;
 
     if(sigaction(SIGCHLD, &sa, NULL) == -1)
-        error("SIGNAL: Failed to change signal handler for: SIGCHLD");
+        netdata_log_error("SIGNAL: Failed to change signal handler for: SIGCHLD");
 }
 
 void signals_reset(void) {
@@ -116,7 +116,7 @@ void signals_reset(void) {
     int i;
     for (i = 0; signals_waiting[i].action != NETDATA_SIGNAL_END_OF_LIST; i++) {
         if(sigaction(signals_waiting[i].signo, &sa, NULL) == -1)
-            error("SIGNAL: Failed to reset signal handler for: %s", signals_waiting[i].name);
+            netdata_log_error("SIGNAL: Failed to reset signal handler for: %s", signals_waiting[i].name);
     }
 }
 
@@ -128,14 +128,14 @@ static void reap_child(pid_t pid) {
     debug(D_CHILDS, "SIGNAL: reap_child(%d)...", pid);
     if (netdata_waitid(P_PID, (id_t)pid, &i, WEXITED|WNOHANG) == -1) {
         if (errno != ECHILD)
-            error("SIGNAL: waitid(%d): failed to wait for child", pid);
+            netdata_log_error("SIGNAL: waitid(%d): failed to wait for child", pid);
         else
             netdata_log_info("SIGNAL: waitid(%d): failed - it seems the child is already reaped", pid);
         return;
     }
     else if (i.si_pid == 0) {
         // Process didn't exit, this shouldn't happen.
-        error("SIGNAL: waitid(%d): reports pid 0 - child has not exited", pid);
+        netdata_log_error("SIGNAL: waitid(%d): reports pid 0 - child has not exited", pid);
         return;
     }
 
@@ -248,6 +248,6 @@ void signals_handle(void) {
             }
         }
         else
-            error("SIGNAL: pause() returned but it was not interrupted by a signal.");
+            netdata_log_error("SIGNAL: pause() returned but it was not interrupted by a signal.");
     }
 }

--- a/database/contexts/api_v1.c
+++ b/database/contexts/api_v1.c
@@ -356,7 +356,7 @@ static inline int rrdcontext_to_json_callback(const DICTIONARY_ITEM *item, void 
 
 int rrdcontext_to_json(RRDHOST *host, BUFFER *wb, time_t after, time_t before, RRDCONTEXT_TO_JSON_OPTIONS options, const char *context, SIMPLE_PATTERN *chart_label_key, SIMPLE_PATTERN *chart_labels_filter, SIMPLE_PATTERN *chart_dimensions) {
     if(!host->rrdctx.contexts) {
-        error("%s(): request for host '%s' that does not have rrdcontexts initialized.", __FUNCTION__, rrdhost_hostname(host));
+        netdata_log_error("%s(): request for host '%s' that does not have rrdcontexts initialized.", __FUNCTION__, rrdhost_hostname(host));
         return HTTP_RESP_NOT_FOUND;
     }
 
@@ -393,7 +393,7 @@ int rrdcontext_to_json(RRDHOST *host, BUFFER *wb, time_t after, time_t before, R
 
 int rrdcontexts_to_json(RRDHOST *host, BUFFER *wb, time_t after, time_t before, RRDCONTEXT_TO_JSON_OPTIONS options, SIMPLE_PATTERN *chart_label_key, SIMPLE_PATTERN *chart_labels_filter, SIMPLE_PATTERN *chart_dimensions) {
     if(!host->rrdctx.contexts) {
-        error("%s(): request for host '%s' that does not have rrdcontexts initialized.", __FUNCTION__, rrdhost_hostname(host));
+        netdata_log_error("%s(): request for host '%s' that does not have rrdcontexts initialized.", __FUNCTION__, rrdhost_hostname(host));
         return HTTP_RESP_NOT_FOUND;
     }
 

--- a/database/contexts/context.c
+++ b/database/contexts/context.c
@@ -33,7 +33,7 @@ static void rrdcontext_insert_callback(const DICTIONARY_ITEM *item __maybe_unuse
         // we are loading data from the SQL database
 
         if(rc->version)
-            error("RRDCONTEXT: context '%s' is already initialized with version %"PRIu64", but it is loaded again from SQL with version %"PRIu64"", string2str(rc->id), rc->version, rc->hub.version);
+            netdata_log_error("RRDCONTEXT: context '%s' is already initialized with version %"PRIu64", but it is loaded again from SQL with version %"PRIu64"", string2str(rc->id), rc->version, rc->hub.version);
 
         // IMPORTANT
         // replace all string pointers in rc->hub with our own versions

--- a/database/contexts/instance.c
+++ b/database/contexts/instance.c
@@ -407,13 +407,13 @@ inline void rrdinstance_from_rrdset(RRDSET *st) {
 #define rrdset_get_rrdinstance(st) rrdset_get_rrdinstance_with_trace(st, __FUNCTION__);
 static inline RRDINSTANCE *rrdset_get_rrdinstance_with_trace(RRDSET *st, const char *function) {
     if(unlikely(!st->rrdinstance)) {
-        error("RRDINSTANCE: RRDSET '%s' is not linked to an RRDINSTANCE at %s()", rrdset_id(st), function);
+        netdata_log_error("RRDINSTANCE: RRDSET '%s' is not linked to an RRDINSTANCE at %s()", rrdset_id(st), function);
         return NULL;
     }
 
     RRDINSTANCE *ri = rrdinstance_acquired_value(st->rrdinstance);
     if(unlikely(!ri)) {
-        error("RRDINSTANCE: RRDSET '%s' lost its link to an RRDINSTANCE at %s()", rrdset_id(st), function);
+        netdata_log_error("RRDINSTANCE: RRDSET '%s' lost its link to an RRDINSTANCE at %s()", rrdset_id(st), function);
         return NULL;
     }
 

--- a/database/contexts/metric.c
+++ b/database/contexts/metric.c
@@ -263,13 +263,13 @@ void rrdmetric_from_rrddim(RRDDIM *rd) {
 #define rrddim_get_rrdmetric(rd) rrddim_get_rrdmetric_with_trace(rd, __FUNCTION__)
 static inline RRDMETRIC *rrddim_get_rrdmetric_with_trace(RRDDIM *rd, const char *function) {
     if(unlikely(!rd->rrdmetric)) {
-        error("RRDMETRIC: RRDDIM '%s' is not linked to an RRDMETRIC at %s()", rrddim_id(rd), function);
+        netdata_log_error("RRDMETRIC: RRDDIM '%s' is not linked to an RRDMETRIC at %s()", rrddim_id(rd), function);
         return NULL;
     }
 
     RRDMETRIC *rm = rrdmetric_acquired_value(rd->rrdmetric);
     if(unlikely(!rm)) {
-        error("RRDMETRIC: RRDDIM '%s' lost the link to its RRDMETRIC at %s()", rrddim_id(rd), function);
+        netdata_log_error("RRDMETRIC: RRDDIM '%s' lost the link to its RRDMETRIC at %s()", rrddim_id(rd), function);
         return NULL;
     }
 

--- a/database/contexts/query_target.c
+++ b/database/contexts/query_target.c
@@ -895,12 +895,12 @@ static ssize_t query_node_add(void *data, RRDHOST *host, bool queryable_host) {
 
     // is the chart given valid?
     if(unlikely(qtl->st && (!qtl->st->rrdinstance || !qtl->st->rrdcontext))) {
-        error("QUERY TARGET: RRDSET '%s' given, but it is not linked to rrdcontext structures. Linking it now.", rrdset_name(qtl->st));
+        netdata_log_error("QUERY TARGET: RRDSET '%s' given, but it is not linked to rrdcontext structures. Linking it now.", rrdset_name(qtl->st));
         rrdinstance_from_rrdset(qtl->st);
 
         if(unlikely(qtl->st && (!qtl->st->rrdinstance || !qtl->st->rrdcontext))) {
-            error("QUERY TARGET: RRDSET '%s' given, but failed to be linked to rrdcontext structures. Switching to context query.",
-                  rrdset_name(qtl->st));
+            netdata_log_error("QUERY TARGET: RRDSET '%s' given, but failed to be linked to rrdcontext structures. Switching to context query.",
+                              rrdset_name(qtl->st));
 
             if (!is_valid_sp(qtl->instances))
                 qtl->instances = rrdset_name(qtl->st);
@@ -1098,7 +1098,7 @@ QUERY_TARGET *query_target_create(QUERY_TARGET_REQUEST *qtr) {
         }
         else if (unlikely(host != qtl.st->rrdhost)) {
             // Oops! A different host!
-            error("QUERY TARGET: RRDSET '%s' given does not belong to host '%s'. Switching query host to '%s'",
+            netdata_log_error("QUERY TARGET: RRDSET '%s' given does not belong to host '%s'. Switching query host to '%s'",
                   rrdset_name(qtl.st), rrdhost_hostname(host), rrdhost_hostname(qtl.st->rrdhost));
             host = qtl.st->rrdhost;
         }

--- a/database/contexts/rrdcontext.c
+++ b/database/contexts/rrdcontext.c
@@ -224,25 +224,26 @@ void rrdcontext_hub_checkpoint_command(void *ptr) {
     struct ctxs_checkpoint *cmd = ptr;
 
     if(!rrdhost_check_our_claim_id(cmd->claim_id)) {
-        error("RRDCONTEXT: received checkpoint command for claim_id '%s', node id '%s', but this is not our claim id. Ours '%s', received '%s'. Ignoring command.",
-              cmd->claim_id, cmd->node_id,
-              localhost->aclk_state.claimed_id?localhost->aclk_state.claimed_id:"NOT SET",
-              cmd->claim_id);
+        netdata_log_error("RRDCONTEXT: received checkpoint command for claim_id '%s', node id '%s', but this is not our claim id. Ours '%s', received '%s'. Ignoring command.",
+                          cmd->claim_id, cmd->node_id,
+                          localhost->aclk_state.claimed_id?localhost->aclk_state.claimed_id:"NOT SET",
+                          cmd->claim_id);
 
         return;
     }
 
     RRDHOST *host = rrdhost_find_by_node_id(cmd->node_id);
     if(!host) {
-        error("RRDCONTEXT: received checkpoint command for claim id '%s', node id '%s', but there is no node with such node id here. Ignoring command.",
-              cmd->claim_id, cmd->node_id);
+        netdata_log_error("RRDCONTEXT: received checkpoint command for claim id '%s', node id '%s', but there is no node with such node id here. Ignoring command.",
+                          cmd->claim_id,
+                          cmd->node_id);
 
         return;
     }
 
     if(rrdhost_flag_check(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS)) {
         netdata_log_info("RRDCONTEXT: received checkpoint command for claim id '%s', node id '%s', while node '%s' has an active context streaming.",
-              cmd->claim_id, cmd->node_id, rrdhost_hostname(host));
+                         cmd->claim_id, cmd->node_id, rrdhost_hostname(host));
 
         // disable it temporarily, so that our worker will not attempt to send messages in parallel
         rrdhost_flag_clear(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS);
@@ -251,8 +252,8 @@ void rrdcontext_hub_checkpoint_command(void *ptr) {
     uint64_t our_version_hash = rrdcontext_version_hash(host);
 
     if(cmd->version_hash != our_version_hash) {
-        error("RRDCONTEXT: received version hash %"PRIu64" for host '%s', does not match our version hash %"PRIu64". Sending snapshot of all contexts.",
-              cmd->version_hash, rrdhost_hostname(host), our_version_hash);
+        netdata_log_error("RRDCONTEXT: received version hash %"PRIu64" for host '%s', does not match our version hash %"PRIu64". Sending snapshot of all contexts.",
+                          cmd->version_hash, rrdhost_hostname(host), our_version_hash);
 
 #ifdef ENABLE_ACLK
         // prepare the snapshot
@@ -285,25 +286,25 @@ void rrdcontext_hub_stop_streaming_command(void *ptr) {
     struct stop_streaming_ctxs *cmd = ptr;
 
     if(!rrdhost_check_our_claim_id(cmd->claim_id)) {
-        error("RRDCONTEXT: received stop streaming command for claim_id '%s', node id '%s', but this is not our claim id. Ours '%s', received '%s'. Ignoring command.",
-              cmd->claim_id, cmd->node_id,
-              localhost->aclk_state.claimed_id?localhost->aclk_state.claimed_id:"NOT SET",
-              cmd->claim_id);
+        netdata_log_error("RRDCONTEXT: received stop streaming command for claim_id '%s', node id '%s', but this is not our claim id. Ours '%s', received '%s'. Ignoring command.",
+                          cmd->claim_id, cmd->node_id,
+                          localhost->aclk_state.claimed_id?localhost->aclk_state.claimed_id:"NOT SET",
+                          cmd->claim_id);
 
         return;
     }
 
     RRDHOST *host = rrdhost_find_by_node_id(cmd->node_id);
     if(!host) {
-        error("RRDCONTEXT: received stop streaming command for claim id '%s', node id '%s', but there is no node with such node id here. Ignoring command.",
-              cmd->claim_id, cmd->node_id);
+        netdata_log_error("RRDCONTEXT: received stop streaming command for claim id '%s', node id '%s', but there is no node with such node id here. Ignoring command.",
+                          cmd->claim_id, cmd->node_id);
 
         return;
     }
 
     if(!rrdhost_flag_check(host, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS)) {
-        error("RRDCONTEXT: received stop streaming command for claim id '%s', node id '%s', but node '%s' does not have active context streaming. Ignoring command.",
-              cmd->claim_id, cmd->node_id, rrdhost_hostname(host));
+        netdata_log_error("RRDCONTEXT: received stop streaming command for claim id '%s', node id '%s', but node '%s' does not have active context streaming. Ignoring command.",
+                          cmd->claim_id, cmd->node_id, rrdhost_hostname(host));
 
         return;
     }

--- a/database/contexts/worker.c
+++ b/database/contexts/worker.c
@@ -350,7 +350,8 @@ void rrdcontext_delete_from_sql_unsafe(RRDCONTEXT *rc) {
 
     // delete it from SQL
     if(ctx_delete_context(&rc->rrdhost->host_uuid, &rc->hub) != 0)
-        error("RRDCONTEXT: failed to delete context '%s' version %"PRIu64" from SQL.", rc->hub.id, rc->hub.version);
+        netdata_log_error("RRDCONTEXT: failed to delete context '%s' version %"PRIu64" from SQL.",
+                          rc->hub.id, rc->hub.version);
 }
 
 static void rrdcontext_garbage_collect_single_host(RRDHOST *host, bool worker_jobs) {
@@ -374,11 +375,11 @@ static void rrdcontext_garbage_collect_single_host(RRDHOST *host, bool worker_jo
                                         if(rrdmetric_should_be_deleted(rm)) {
                                             if(worker_jobs) worker_is_busy(WORKER_JOB_CLEANUP_DELETE);
                                             if(!dictionary_del(ri->rrdmetrics, string2str(rm->id)))
-                                                error("RRDCONTEXT: metric '%s' of instance '%s' of context '%s' of host '%s', failed to be deleted from rrdmetrics dictionary.",
-                                                      string2str(rm->id),
-                                                      string2str(ri->id),
-                                                      string2str(rc->id),
-                                                      rrdhost_hostname(host));
+                                                netdata_log_error("RRDCONTEXT: metric '%s' of instance '%s' of context '%s' of host '%s', failed to be deleted from rrdmetrics dictionary.",
+                                                                  string2str(rm->id),
+                                                                  string2str(ri->id),
+                                                                  string2str(rc->id),
+                                                                  rrdhost_hostname(host));
                                             else
                                                 internal_error(
                                                         true,
@@ -394,10 +395,10 @@ static void rrdcontext_garbage_collect_single_host(RRDHOST *host, bool worker_jo
                             if(rrdinstance_should_be_deleted(ri)) {
                                 if(worker_jobs) worker_is_busy(WORKER_JOB_CLEANUP_DELETE);
                                 if(!dictionary_del(rc->rrdinstances, string2str(ri->id)))
-                                    error("RRDCONTEXT: instance '%s' of context '%s' of host '%s', failed to be deleted from rrdmetrics dictionary.",
-                                          string2str(ri->id),
-                                          string2str(rc->id),
-                                          rrdhost_hostname(host));
+                                    netdata_log_error("RRDCONTEXT: instance '%s' of context '%s' of host '%s', failed to be deleted from rrdmetrics dictionary.",
+                                                      string2str(ri->id),
+                                                      string2str(rc->id),
+                                                      rrdhost_hostname(host));
                                 else
                                     internal_error(
                                             true,
@@ -415,7 +416,7 @@ static void rrdcontext_garbage_collect_single_host(RRDHOST *host, bool worker_jo
                     rrdcontext_delete_from_sql_unsafe(rc);
 
                     if(!dictionary_del(host->rrdctx.contexts, string2str(rc->id)))
-                        error("RRDCONTEXT: context '%s' of host '%s', failed to be deleted from rrdmetrics dictionary.",
+                        netdata_log_error("RRDCONTEXT: context '%s' of host '%s', failed to be deleted from rrdmetrics dictionary.",
                               string2str(rc->id),
                               rrdhost_hostname(host));
                     else
@@ -844,7 +845,7 @@ void rrdcontext_message_send_unsafe(RRDCONTEXT *rc, bool snapshot __maybe_unused
         rrdcontext_delete_from_sql_unsafe(rc);
 
     else if (ctx_store_context(&rc->rrdhost->host_uuid, &rc->hub) != 0)
-        error("RRDCONTEXT: failed to save context '%s' version %"PRIu64" to SQL.", rc->hub.id, rc->hub.version);
+        netdata_log_error("RRDCONTEXT: failed to save context '%s' version %"PRIu64" to SQL.", rc->hub.id, rc->hub.version);
 }
 
 static bool check_if_cloud_version_changed_unsafe(RRDCONTEXT *rc, bool sending __maybe_unused) {
@@ -1021,8 +1022,8 @@ static void rrdcontext_dispatch_queued_contexts_to_hub(RRDHOST *host, usec_t now
 
                         // delete it from the master dictionary
                         if(!dictionary_del(host->rrdctx.contexts, string2str(rc->id)))
-                            error("RRDCONTEXT: '%s' of host '%s' failed to be deleted from rrdcontext dictionary.",
-                                  string2str(id), rrdhost_hostname(host));
+                            netdata_log_error("RRDCONTEXT: '%s' of host '%s' failed to be deleted from rrdcontext dictionary.",
+                                              string2str(id), rrdhost_hostname(host));
 
                         string_freez(id);
                     }

--- a/database/engine/cache.c
+++ b/database/engine/cache.c
@@ -1847,7 +1847,7 @@ void pgc_destroy(PGC *cache) {
     free_all_unreferenced_clean_pages(cache);
 
     if(PGC_REFERENCED_PAGES(cache))
-        error("DBENGINE CACHE: there are %zu referenced cache pages - leaving the cache allocated", PGC_REFERENCED_PAGES(cache));
+        netdata_log_error("DBENGINE CACHE: there are %zu referenced cache pages - leaving the cache allocated", PGC_REFERENCED_PAGES(cache));
     else {
         pointer_destroy_index(cache);
 

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -733,7 +733,7 @@ static void after_extent_write_datafile_io(uv_fs_t *uv_fs_request) {
 
     if (uv_fs_request->result < 0) {
         ctx_io_error(ctx);
-        error("DBENGINE: %s: uv_fs_write(): %s", __func__, uv_strerror((int)uv_fs_request->result));
+        netdata_log_error("DBENGINE: %s: uv_fs_write(): %s", __func__, uv_strerror((int)uv_fs_request->result));
     }
 
     journalfile_v1_extent_write(ctx, xt_io_descr->datafile, xt_io_descr->wal, &rrdeng_main.loop);
@@ -1643,14 +1643,14 @@ bool rrdeng_dbengine_spawn(struct rrdengine_instance *ctx __maybe_unused) {
 
         ret = uv_loop_init(&rrdeng_main.loop);
         if (ret) {
-            error("DBENGINE: uv_loop_init(): %s", uv_strerror(ret));
+            netdata_log_error("DBENGINE: uv_loop_init(): %s", uv_strerror(ret));
             return false;
         }
         rrdeng_main.loop.data = &rrdeng_main;
 
         ret = uv_async_init(&rrdeng_main.loop, &rrdeng_main.async, async_cb);
         if (ret) {
-            error("DBENGINE: uv_async_init(): %s", uv_strerror(ret));
+            netdata_log_error("DBENGINE: uv_async_init(): %s", uv_strerror(ret));
             fatal_assert(0 == uv_loop_close(&rrdeng_main.loop));
             return false;
         }
@@ -1658,7 +1658,7 @@ bool rrdeng_dbengine_spawn(struct rrdengine_instance *ctx __maybe_unused) {
 
         ret = uv_timer_init(&rrdeng_main.loop, &rrdeng_main.timer);
         if (ret) {
-            error("DBENGINE: uv_timer_init(): %s", uv_strerror(ret));
+            netdata_log_error("DBENGINE: uv_timer_init(): %s", uv_strerror(ret));
             uv_close((uv_handle_t *)&rrdeng_main.async, NULL);
             fatal_assert(0 == uv_loop_close(&rrdeng_main.loop));
             return false;

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -247,7 +247,7 @@ STORAGE_COLLECT_HANDLE *rrdeng_store_metric_init(STORAGE_METRIC_HANDLE *db_metri
         is_1st_metric_writer = false;
         char uuid[UUID_STR_LEN + 1];
         uuid_unparse(*mrg_metric_uuid(main_mrg, metric), uuid);
-        error("DBENGINE: metric '%s' is already collected and should not be collected twice - expect gaps on the charts", uuid);
+        netdata_log_error("DBENGINE: metric '%s' is already collected and should not be collected twice - expect gaps on the charts", uuid);
     }
 
     metric = mrg_metric_dup(main_mrg, metric);
@@ -312,7 +312,7 @@ static bool page_has_only_empty_metrics(struct rrdeng_collect_handle *handle) {
         default: {
             static bool logged = false;
             if(!logged) {
-                error("DBENGINE: cannot check page for nulls on unknown page type id %d", (mrg_metric_ctx(handle->metric))->config.page_type);
+                netdata_log_error("DBENGINE: cannot check page for nulls on unknown page type id %d", (mrg_metric_ctx(handle->metric))->config.page_type);
                 logged = true;
             }
             return false;
@@ -908,7 +908,7 @@ STORAGE_POINT rrdeng_load_metric_next(struct storage_engine_query_handle *rrddim
         default: {
             static bool logged = false;
             if(!logged) {
-                error("DBENGINE: unknown page type %d found. Cannot decode it. Ignoring its metrics.", handle->ctx->config.page_type);
+                netdata_log_error("DBENGINE: unknown page type %d found. Cannot decode it. Ignoring its metrics.", handle->ctx->config.page_type);
                 logged = true;
             }
             storage_point_empty(sp, sp.start_time_s, sp.end_time_s);
@@ -986,7 +986,7 @@ bool rrdeng_metric_retention_by_uuid(STORAGE_INSTANCE *db_instance, uuid_t *dim_
 {
     struct rrdengine_instance *ctx = (struct rrdengine_instance *)db_instance;
     if (unlikely(!ctx)) {
-        error("DBENGINE: invalid STORAGE INSTANCE to %s()", __FUNCTION__);
+        netdata_log_error("DBENGINE: invalid STORAGE INSTANCE to %s()", __FUNCTION__);
         return false;
     }
 
@@ -1160,7 +1160,7 @@ int rrdeng_init(struct rrdengine_instance **ctxp, const char *dbfiles_path,
     /* reserve RRDENG_FD_BUDGET_PER_INSTANCE file descriptors for this instance */
     rrd_stat_atomic_add(&rrdeng_reserved_file_descriptors, RRDENG_FD_BUDGET_PER_INSTANCE);
     if (rrdeng_reserved_file_descriptors > max_open_files) {
-        error(
+        netdata_log_error(
             "Exceeded the budget of available file descriptors (%u/%u), cannot create new dbengine instance.",
             (unsigned)rrdeng_reserved_file_descriptors,
             (unsigned)max_open_files);

--- a/database/engine/rrdenginelib.c
+++ b/database/engine/rrdenginelib.c
@@ -14,12 +14,12 @@ int check_file_properties(uv_file file, uint64_t *file_size, size_t min_size)
     fatal_assert(req.result == 0);
     s = req.ptr;
     if (!(s->st_mode & S_IFREG)) {
-        error("Not a regular file.\n");
+        netdata_log_error("Not a regular file.\n");
         uv_fs_req_cleanup(&req);
         return UV_EINVAL;
     }
     if (s->st_size < min_size) {
-        error("File length is too short.\n");
+        netdata_log_error("File length is too short.\n");
         uv_fs_req_cleanup(&req);
         return UV_EINVAL;
     }
@@ -56,9 +56,9 @@ int open_file_for_io(char *path, int flags, uv_file *file, int direct)
         fd = uv_fs_open(NULL, &req, path, current_flags, S_IRUSR | S_IWUSR, NULL);
         if (fd < 0) {
             if ((direct) && (UV_EINVAL == fd)) {
-                error("File \"%s\" does not support direct I/O, falling back to buffered I/O.", path);
+                netdata_log_error("File \"%s\" does not support direct I/O, falling back to buffered I/O.", path);
             } else {
-                error("Failed to open file \"%s\".", path);
+                netdata_log_error("Failed to open file \"%s\".", path);
                 --direct; /* break the loop */
             }
         } else {
@@ -107,7 +107,7 @@ int count_legacy_children(char *dbfiles_path)
     ret = uv_fs_scandir(NULL, &req, dbfiles_path, 0, NULL);
     if (ret < 0) {
         uv_fs_req_cleanup(&req);
-        error("uv_fs_scandir(%s): %s", dbfiles_path, uv_strerror(ret));
+        netdata_log_error("uv_fs_scandir(%s): %s", dbfiles_path, uv_strerror(ret));
         return ret;
     }
 
@@ -134,7 +134,7 @@ int compute_multidb_diskspace()
         fclose(fp);
         if (unlikely(rc != 1 || computed_multidb_disk_quota_mb < RRDENG_MIN_DISK_SPACE_MB)) {
             errno = 0;
-            error("File '%s' contains invalid input, it will be rebuild", multidb_disk_space_file);
+            netdata_log_error("File '%s' contains invalid input, it will be rebuild", multidb_disk_space_file);
             computed_multidb_disk_quota_mb = -1;
         }
     }
@@ -151,7 +151,7 @@ int compute_multidb_diskspace()
                 netdata_log_info("Created file '%s' to store the computed value", multidb_disk_space_file);
                 fclose(fp);
             } else
-                error("Failed to store the default multidb disk quota size on '%s'", multidb_disk_space_file);
+                netdata_log_error("Failed to store the default multidb disk quota size on '%s'", multidb_disk_space_file);
         }
         else
             computed_multidb_disk_quota_mb = default_rrdeng_disk_quota_mb;

--- a/database/engine/rrdenginelib.h
+++ b/database/engine/rrdenginelib.h
@@ -53,7 +53,7 @@ static inline void modify_bit(unsigned *x, unsigned pos, uint8_t val)
         *x |= 1U << pos;
         break;
     default:
-        error("modify_bit() called with invalid argument.");
+        netdata_log_error("modify_bit() called with invalid argument.");
         break;
     }
 }

--- a/database/ram/rrddim_mem.c
+++ b/database/ram/rrddim_mem.c
@@ -283,7 +283,7 @@ static inline size_t rrddim_time2slot(STORAGE_METRIC_HANDLE *db_metric_handle, t
     }
 
     if(unlikely(ret >= entries)) {
-        error("INTERNAL ERROR: rrddim_time2slot() on %s returns values outside entries", rrddim_name(rd));
+        netdata_log_error("INTERNAL ERROR: rrddim_time2slot() on %s returns values outside entries", rrddim_name(rd));
         ret = entries - 1;
     }
 
@@ -304,7 +304,7 @@ static inline time_t rrddim_slot2time(STORAGE_METRIC_HANDLE *db_metric_handle, s
     size_t update_every  = mh->update_every_s;
 
     if(slot >= entries) {
-        error("INTERNAL ERROR: caller of rrddim_slot2time() gives invalid slot %zu", slot);
+        netdata_log_error("INTERNAL ERROR: caller of rrddim_slot2time() gives invalid slot %zu", slot);
         slot = entries - 1;
     }
 
@@ -314,14 +314,14 @@ static inline time_t rrddim_slot2time(STORAGE_METRIC_HANDLE *db_metric_handle, s
         ret = last_entry_s - (time_t)(update_every * (last_slot - slot));
 
     if(unlikely(ret < first_entry_s)) {
-        error("INTERNAL ERROR: rrddim_slot2time() on dimension '%s' of chart '%s' returned time (%ld) too far in the past (before first_entry_s %ld) for slot %zu",
+        netdata_log_error("INTERNAL ERROR: rrddim_slot2time() on dimension '%s' of chart '%s' returned time (%ld) too far in the past (before first_entry_s %ld) for slot %zu",
               rrddim_name(rd), rrdset_id(rd->rrdset), ret, first_entry_s, slot);
 
         ret = first_entry_s;
     }
 
     if(unlikely(ret > last_entry_s)) {
-        error("INTERNAL ERROR: rrddim_slot2time() on dimension '%s' of chart '%s' returned time (%ld) too far into the future (after last_entry_s %ld) for slot %zu",
+        netdata_log_error("INTERNAL ERROR: rrddim_slot2time() on dimension '%s' of chart '%s' returned time (%ld) too far into the future (after last_entry_s %ld) for slot %zu",
               rrddim_name(rd), rrdset_id(rd->rrdset), ret, last_entry_s, slot);
 
         ret = last_entry_s;

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -148,7 +148,7 @@ char *rrdhost_cache_dir_for_rrdset_alloc(RRDHOST *host, const char *id) {
     if(host->rrd_memory_mode == RRD_MEMORY_MODE_MAP || host->rrd_memory_mode == RRD_MEMORY_MODE_SAVE) {
         int r = mkdir(ret, 0775);
         if(r != 0 && errno != EEXIST)
-            error("Cannot create directory '%s'", ret);
+            netdata_log_error("Cannot create directory '%s'", ret);
     }
 
     return ret;

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -223,17 +223,17 @@ static size_t rrdcalctemplate_key(char *dst, size_t dst_len, const char *name, c
 
 void rrdcalctemplate_add_from_config(RRDHOST *host, RRDCALCTEMPLATE *rt) {
     if(unlikely(!rt->context)) {
-        error("Health configuration for template '%s' does not have a context", rrdcalctemplate_name(rt));
+        netdata_log_error("Health configuration for template '%s' does not have a context", rrdcalctemplate_name(rt));
         return;
     }
 
     if(unlikely(!rt->update_every)) {
-        error("Health configuration for template '%s' has no frequency (parameter 'every'). Ignoring it.", rrdcalctemplate_name(rt));
+        netdata_log_error("Health configuration for template '%s' has no frequency (parameter 'every'). Ignoring it.", rrdcalctemplate_name(rt));
         return;
     }
 
     if(unlikely(!RRDCALCTEMPLATE_HAS_DB_LOOKUP(rt) && !rt->calculation && !rt->warning && !rt->critical)) {
-        error("Health configuration for template '%s' is useless (no calculation, no warning and no critical evaluation)", rrdcalctemplate_name(rt));
+        netdata_log_error("Health configuration for template '%s' is useless (no calculation, no warning and no critical evaluation)", rrdcalctemplate_name(rt));
         return;
     }
 

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -102,10 +102,10 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
         }
 
         if(!initialized)
-            error("Failed to initialize all db tiers for chart '%s', dimension '%s", rrdset_name(st), rrddim_name(rd));
+            netdata_log_error("Failed to initialize all db tiers for chart '%s', dimension '%s", rrdset_name(st), rrddim_name(rd));
 
         if(!rd->tiers[0].db_metric_handle)
-            error("Failed to initialize the first db tier for chart '%s', dimension '%s", rrdset_name(st), rrddim_name(rd));
+            netdata_log_error("Failed to initialize the first db tier for chart '%s', dimension '%s", rrdset_name(st), rrddim_name(rd));
     }
 
     // initialize data collection for all tiers
@@ -120,7 +120,7 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
         }
 
         if(!initialized)
-            error("Failed to initialize data collection for all db tiers for chart '%s', dimension '%s", rrdset_name(st), rrddim_name(rd));
+            netdata_log_error("Failed to initialize data collection for all db tiers for chart '%s', dimension '%s", rrdset_name(st), rrddim_name(rd));
     }
 
     if(rrdset_number_of_dimensions(st) != 0) {
@@ -499,7 +499,7 @@ int rrddim_hide(RRDSET *st, const char *id) {
 
     RRDDIM *rd = rrddim_find(st, id);
     if(unlikely(!rd)) {
-        error("Cannot find dimension with id '%s' on stats '%s' (%s) on host '%s'.", id, rrdset_name(st), rrdset_id(st), rrdhost_hostname(host));
+        netdata_log_error("Cannot find dimension with id '%s' on stats '%s' (%s) on host '%s'.", id, rrdset_name(st), rrdset_id(st), rrdhost_hostname(host));
         return 1;
     }
     if (!rrddim_flag_check(rd, RRDDIM_FLAG_META_HIDDEN)) {
@@ -518,7 +518,7 @@ int rrddim_unhide(RRDSET *st, const char *id) {
     RRDHOST *host = st->rrdhost;
     RRDDIM *rd = rrddim_find(st, id);
     if(unlikely(!rd)) {
-        error("Cannot find dimension with id '%s' on stats '%s' (%s) on host '%s'.", id, rrdset_name(st), rrdset_id(st), rrdhost_hostname(host));
+        netdata_log_error("Cannot find dimension with id '%s' on stats '%s' (%s) on host '%s'.", id, rrdset_name(st), rrdset_id(st), rrdhost_hostname(host));
         return 1;
     }
     if (rrddim_flag_check(rd, RRDDIM_FLAG_META_HIDDEN)) {
@@ -582,7 +582,7 @@ collected_number rrddim_set(RRDSET *st, const char *id, collected_number value) 
     RRDHOST *host = st->rrdhost;
     RRDDIM *rd = rrddim_find(st, id);
     if(unlikely(!rd)) {
-        error("Cannot find dimension with id '%s' on stats '%s' (%s) on host '%s'.", id, rrdset_name(st), rrdset_id(st), rrdhost_hostname(host));
+        netdata_log_error("Cannot find dimension with id '%s' on stats '%s' (%s) on host '%s'.", id, rrdset_name(st), rrdset_id(st), rrdhost_hostname(host));
         return 0;
     }
 
@@ -711,12 +711,12 @@ bool rrddim_memory_load_or_create_map_save(RRDSET *st, RRDDIM *rd, RRD_MEMORY_MO
         reset = 1;
     }
     else if(rd_on_file->memsize != size) {
-        error("File %s does not have the desired size, expected %lu but found %lu. Clearing it.", fullfilename, size, (unsigned long int) rd_on_file->memsize);
+        netdata_log_error("File %s does not have the desired size, expected %lu but found %lu. Clearing it.", fullfilename, size, (unsigned long int) rd_on_file->memsize);
         memset(rd_on_file, 0, size);
         reset = 1;
     }
     else if(rd_on_file->update_every != st->update_every) {
-        error("File %s does not have the same update frequency, expected %d but found %d. Clearing it.", fullfilename, st->update_every, rd_on_file->update_every);
+        netdata_log_error("File %s does not have the same update frequency, expected %d but found %d. Clearing it.", fullfilename, st->update_every, rd_on_file->update_every);
         memset(rd_on_file, 0, size);
         reset = 1;
     }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -977,7 +977,7 @@ void dbengine_init(char *hostname) {
 #else
     storage_tiers = config_get_number(CONFIG_SECTION_DB, "storage tiers", 1);
     if(storage_tiers != 1) {
-        error("DBENGINE is not available on '%s', so only 1 database tier can be supported.", hostname);
+        netdata_log_error("DBENGINE is not available on '%s', so only 1 database tier can be supported.", hostname);
         storage_tiers = 1;
         config_set_number(CONFIG_SECTION_DB, "storage tiers", storage_tiers);
     }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -116,7 +116,8 @@ static inline RRDHOST *rrdhost_index_add_by_guid(RRDHOST *host) {
         rrdhost_option_set(host, RRDHOST_OPTION_INDEXED_MACHINE_GUID);
     else {
         rrdhost_option_clear(host, RRDHOST_OPTION_INDEXED_MACHINE_GUID);
-        error("RRDHOST: %s() host with machine guid '%s' is already indexed", __FUNCTION__, host->machine_guid);
+        netdata_log_error("RRDHOST: %s() host with machine guid '%s' is already indexed",
+                          __FUNCTION__, host->machine_guid);
     }
 
     return host;
@@ -125,7 +126,8 @@ static inline RRDHOST *rrdhost_index_add_by_guid(RRDHOST *host) {
 static void rrdhost_index_del_by_guid(RRDHOST *host) {
     if(rrdhost_option_check(host, RRDHOST_OPTION_INDEXED_MACHINE_GUID)) {
         if(!dictionary_del(rrdhost_root_index, host->machine_guid))
-            error("RRDHOST: %s() failed to delete machine guid '%s' from index", __FUNCTION__, host->machine_guid);
+            netdata_log_error("RRDHOST: %s() failed to delete machine guid '%s' from index",
+                              __FUNCTION__, host->machine_guid);
 
         rrdhost_option_clear(host, RRDHOST_OPTION_INDEXED_MACHINE_GUID);
     }
@@ -146,7 +148,8 @@ static inline void rrdhost_index_del_hostname(RRDHOST *host) {
 
     if(rrdhost_option_check(host, RRDHOST_OPTION_INDEXED_HOSTNAME)) {
         if(!dictionary_del(rrdhost_root_index_hostname, rrdhost_hostname(host)))
-            error("RRDHOST: %s() failed to delete hostname '%s' from index", __FUNCTION__, rrdhost_hostname(host));
+            netdata_log_error("RRDHOST: %s() failed to delete hostname '%s' from index",
+                              __FUNCTION__, rrdhost_hostname(host));
 
         rrdhost_option_clear(host, RRDHOST_OPTION_INDEXED_HOSTNAME);
     }
@@ -303,7 +306,8 @@ static RRDHOST *rrdhost_create(
     debug(D_RRDHOST, "Host '%s': adding with guid '%s'", hostname, guid);
 
     if(memory_mode == RRD_MEMORY_MODE_DBENGINE && !dbengine_enabled) {
-        error("memory mode 'dbengine' is not enabled, but host '%s' is configured for it. Falling back to 'alloc'", hostname);
+        netdata_log_error("memory mode 'dbengine' is not enabled, but host '%s' is configured for it. Falling back to 'alloc'",
+                          hostname);
         memory_mode = RRD_MEMORY_MODE_ALLOC;
     }
 
@@ -387,7 +391,7 @@ int is_legacy = 1;
              (host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && is_legacy))) {
             int r = mkdir(host->cache_dir, 0775);
             if(r != 0 && errno != EEXIST)
-                error("Host '%s': cannot create directory '%s'", rrdhost_hostname(host), host->cache_dir);
+                netdata_log_error("Host '%s': cannot create directory '%s'", rrdhost_hostname(host), host->cache_dir);
         }
     }
 
@@ -413,7 +417,7 @@ int is_legacy = 1;
         ret = mkdir(dbenginepath, 0775);
 
         if (ret != 0 && errno != EEXIST)
-            error("Host '%s': cannot create directory '%s'", rrdhost_hostname(host), dbenginepath);
+            netdata_log_error("Host '%s': cannot create directory '%s'", rrdhost_hostname(host), dbenginepath);
         else
             ret = 0; // succeed
 
@@ -454,9 +458,8 @@ int is_legacy = 1;
         }
 
         if (ret) { // check legacy or multihost initialization success
-            error(
-                "Host '%s': cannot initialize host with machine guid '%s'. Failed to initialize DB engine at '%s'.",
-                rrdhost_hostname(host), host->machine_guid, host->cache_dir);
+            netdata_log_error("Host '%s': cannot initialize host with machine guid '%s'. Failed to initialize DB engine at '%s'.",
+                              rrdhost_hostname(host), host->machine_guid, host->cache_dir);
 
             rrd_wrlock();
             rrdhost_free___while_having_rrd_wrlock(host, true);
@@ -504,7 +507,8 @@ int is_legacy = 1;
 
     RRDHOST *t = rrdhost_index_add_by_guid(host);
     if(t != host) {
-        error("Host '%s': cannot add host with machine guid '%s' to index. It already exists as host '%s' with machine guid '%s'.", rrdhost_hostname(host), host->machine_guid, rrdhost_hostname(t), t->machine_guid);
+        netdata_log_error("Host '%s': cannot add host with machine guid '%s' to index. It already exists as host '%s' with machine guid '%s'.",
+                          rrdhost_hostname(host), host->machine_guid, rrdhost_hostname(t), t->machine_guid);
         rrdhost_free___while_having_rrd_wrlock(host, true);
         rrd_unlock();
         return NULL;
@@ -633,19 +637,23 @@ static void rrdhost_update(RRDHOST *host
     }
 
     if(host->rrd_update_every != update_every)
-        error("Host '%s' has an update frequency of %d seconds, but the wanted one is %d seconds. "
-              "Restart netdata here to apply the new settings.",
-              rrdhost_hostname(host), host->rrd_update_every, update_every);
+        netdata_log_error("Host '%s' has an update frequency of %d seconds, but the wanted one is %d seconds. "
+                          "Restart netdata here to apply the new settings.",
+                          rrdhost_hostname(host), host->rrd_update_every, update_every);
 
     if(host->rrd_memory_mode != mode)
-        error("Host '%s' has memory mode '%s', but the wanted one is '%s'. "
-              "Restart netdata here to apply the new settings.",
-              rrdhost_hostname(host), rrd_memory_mode_name(host->rrd_memory_mode), rrd_memory_mode_name(mode));
+        netdata_log_error("Host '%s' has memory mode '%s', but the wanted one is '%s'. "
+                          "Restart netdata here to apply the new settings.",
+                          rrdhost_hostname(host),
+                          rrd_memory_mode_name(host->rrd_memory_mode),
+                          rrd_memory_mode_name(mode));
 
     else if(host->rrd_memory_mode != RRD_MEMORY_MODE_DBENGINE && host->rrd_history_entries < history)
-        error("Host '%s' has history of %d entries, but the wanted one is %ld entries. "
-              "Restart netdata here to apply the new settings.",
-              rrdhost_hostname(host), host->rrd_history_entries, history);
+        netdata_log_error("Host '%s' has history of %d entries, but the wanted one is %ld entries. "
+                          "Restart netdata here to apply the new settings.",
+                          rrdhost_hostname(host),
+                          host->rrd_history_entries,
+                          history);
 
     // update host tags
     rrdhost_init_tags(host, tags);
@@ -725,8 +733,10 @@ RRDHOST *rrdhost_find_or_create(
             return host;
 
         /* If a legacy memory mode instantiates all dbengine state must be discarded to avoid inconsistencies */
-        error("Archived host '%s' has memory mode '%s', but the wanted one is '%s'. Discarding archived state.",
-              rrdhost_hostname(host), rrd_memory_mode_name(host->rrd_memory_mode), rrd_memory_mode_name(mode));
+        netdata_log_error("Archived host '%s' has memory mode '%s', but the wanted one is '%s'. Discarding archived state.",
+                          rrdhost_hostname(host),
+                          rrd_memory_mode_name(host->rrd_memory_mode),
+                          rrd_memory_mode_name(mode));
 
         rrd_wrlock();
         rrdhost_free___while_having_rrd_wrlock(host, true);
@@ -834,18 +844,18 @@ void dbengine_init(char *hostname) {
     if (read_num > 0 && read_num <= MAX_PAGES_PER_EXTENT)
         rrdeng_pages_per_extent = read_num;
     else {
-        error("Invalid dbengine pages per extent %u given. Using %u.", read_num, rrdeng_pages_per_extent);
+        netdata_log_error("Invalid dbengine pages per extent %u given. Using %u.", read_num, rrdeng_pages_per_extent);
         config_set_number(CONFIG_SECTION_DB, "dbengine pages per extent", rrdeng_pages_per_extent);
     }
 
     storage_tiers = config_get_number(CONFIG_SECTION_DB, "storage tiers", storage_tiers);
     if(storage_tiers < 1) {
-        error("At least 1 storage tier is required. Assuming 1.");
+        netdata_log_error("At least 1 storage tier is required. Assuming 1.");
         storage_tiers = 1;
         config_set_number(CONFIG_SECTION_DB, "storage tiers", storage_tiers);
     }
     if(storage_tiers > RRD_STORAGE_TIERS) {
-        error("Up to %d storage tier are supported. Assuming %d.", RRD_STORAGE_TIERS, RRD_STORAGE_TIERS);
+        netdata_log_error("Up to %d storage tier are supported. Assuming %d.", RRD_STORAGE_TIERS, RRD_STORAGE_TIERS);
         storage_tiers = RRD_STORAGE_TIERS;
         config_set_number(CONFIG_SECTION_DB, "storage tiers", storage_tiers);
     }
@@ -867,7 +877,7 @@ void dbengine_init(char *hostname) {
 
         int ret = mkdir(dbenginepath, 0775);
         if (ret != 0 && errno != EEXIST) {
-            error("DBENGINE on '%s': cannot create directory '%s'", hostname, dbenginepath);
+            netdata_log_error("DBENGINE on '%s': cannot create directory '%s'", hostname, dbenginepath);
             break;
         }
 
@@ -887,7 +897,9 @@ void dbengine_init(char *hostname) {
             if(grouping_iterations < 2) {
                 grouping_iterations = 2;
                 config_set_number(CONFIG_SECTION_DB, dbengineconfig, grouping_iterations);
-                error("DBENGINE on '%s': 'dbegnine tier %zu update every iterations' cannot be less than 2. Assuming 2.", hostname, tier);
+                netdata_log_error("DBENGINE on '%s': 'dbegnine tier %zu update every iterations' cannot be less than 2. Assuming 2.",
+                                  hostname,
+                                  tier);
             }
 
             snprintfz(dbengineconfig, 200, "dbengine tier %zu backfill", tier);
@@ -896,7 +908,7 @@ void dbengine_init(char *hostname) {
             else if(strcmp(bf, "full") == 0) backfill = RRD_BACKFILL_FULL;
             else if(strcmp(bf, "none") == 0) backfill = RRD_BACKFILL_NONE;
             else {
-                error("DBENGINE: unknown backfill value '%s', assuming 'new'", bf);
+                netdata_log_error("DBENGINE: unknown backfill value '%s', assuming 'new'", bf);
                 config_set(CONFIG_SECTION_DB, dbengineconfig, "new");
                 backfill = RRD_BACKFILL_NEW;
             }
@@ -907,7 +919,10 @@ void dbengine_init(char *hostname) {
 
         if(tier > 0 && get_tier_grouping(tier) > 65535) {
             storage_tiers_grouping_iterations[tier] = 1;
-            error("DBENGINE on '%s': dbengine tier %zu gives aggregation of more than 65535 points of tier 0. Disabling tiers above %zu", hostname, tier, tier);
+            netdata_log_error("DBENGINE on '%s': dbengine tier %zu gives aggregation of more than 65535 points of tier 0. Disabling tiers above %zu",
+                              hostname,
+                              tier,
+                              tier);
             break;
         }
 
@@ -935,16 +950,21 @@ void dbengine_init(char *hostname) {
             netdata_thread_join(tiers_init[tier].thread, &ptr);
 
         if(tiers_init[tier].ret != 0) {
-            error("DBENGINE on '%s': Failed to initialize multi-host database tier %zu on path '%s'",
-                  hostname, tiers_init[tier].tier, tiers_init[tier].path);
+            netdata_log_error("DBENGINE on '%s': Failed to initialize multi-host database tier %zu on path '%s'",
+                              hostname,
+                              tiers_init[tier].tier,
+                              tiers_init[tier].path);
         }
         else if(created_tiers == tier)
             created_tiers++;
     }
 
     if(created_tiers && created_tiers < storage_tiers) {
-        error("DBENGINE on '%s': Managed to create %zu tiers instead of %zu. Continuing with %zu available.",
-              hostname, created_tiers, storage_tiers, created_tiers);
+        netdata_log_error("DBENGINE on '%s': Managed to create %zu tiers instead of %zu. Continuing with %zu available.",
+                          hostname,
+                          created_tiers,
+                          storage_tiers,
+                          created_tiers);
         storage_tiers = created_tiers;
     }
     else if(!created_tiers)
@@ -998,13 +1018,13 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
 
         if (!dbengine_enabled) {
             if (storage_tiers > 1) {
-                error("dbengine is not enabled, but %zu tiers have been requested. Resetting tiers to 1",
-                      storage_tiers);
+                netdata_log_error("dbengine is not enabled, but %zu tiers have been requested. Resetting tiers to 1",
+                                  storage_tiers);
                 storage_tiers = 1;
             }
 
             if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
-                error("dbengine is not enabled, but it has been given as the default db mode. Resetting db mode to alloc");
+                netdata_log_error("dbengine is not enabled, but it has been given as the default db mode. Resetting db mode to alloc");
                 default_rrd_memory_mode = RRD_MEMORY_MODE_ALLOC;
             }
         }
@@ -1412,7 +1432,7 @@ static void rrdhost_load_config_labels(void) {
     int status = config_load(NULL, 1, CONFIG_SECTION_HOST_LABEL);
     if(!status) {
         char *filename = CONFIG_DIR "/" CONFIG_FILENAME;
-        error("RRDLABEL: Cannot reload the configuration file '%s', using labels in memory", filename);
+        netdata_log_error("RRDLABEL: Cannot reload the configuration file '%s', using labels in memory", filename);
     }
 
     struct section *co = appconfig_get_section(&netdata_config, CONFIG_SECTION_HOST_LABEL);
@@ -1432,7 +1452,7 @@ static void rrdhost_load_kubernetes_labels(void) {
     sprintf(label_script, "%s/%s", netdata_configured_primary_plugins_dir, "get-kubernetes-labels.sh");
 
     if (unlikely(access(label_script, R_OK) != 0)) {
-        error("Kubernetes pod label fetching script %s not found.",label_script);
+        netdata_log_error("Kubernetes pod label fetching script %s not found.",label_script);
         return;
     }
 
@@ -1450,7 +1470,8 @@ static void rrdhost_load_kubernetes_labels(void) {
     // Non-zero exit code means that all the script output is error messages. We've shown already any message that didn't include a ':'
     // Here we'll inform with an ERROR that the script failed, show whatever (if anything) was added to the list of labels, free the memory and set the return to null
     int rc = netdata_pclose(fp_child_input, fp_child_output, pid);
-    if(rc) error("%s exited abnormally. Failed to get kubernetes labels.", label_script);
+    if(rc)
+        netdata_log_error("%s exited abnormally. Failed to get kubernetes labels.", label_script);
 }
 
 void reload_host_labels(void) {

--- a/database/rrdlabels.c
+++ b/database/rrdlabels.c
@@ -571,7 +571,7 @@ static void labels_add_already_sanitized(DICTIONARY *dict, const char *key, cons
 
 void rrdlabels_add(DICTIONARY *dict, const char *name, const char *value, RRDLABEL_SRC ls) {
     if(!dict) {
-        error("%s(): called with NULL dictionary.", __FUNCTION__ );
+        netdata_log_error("%s(): called with NULL dictionary.", __FUNCTION__ );
         return;
     }
 
@@ -580,7 +580,7 @@ void rrdlabels_add(DICTIONARY *dict, const char *name, const char *value, RRDLAB
     rrdlabels_sanitize_value(v, value, RRDLABELS_MAX_VALUE_LENGTH);
 
     if(!*n) {
-        error("%s: cannot add name '%s' (value '%s') which is sanitized as empty string", __FUNCTION__, name, value);
+        netdata_log_error("%s: cannot add name '%s' (value '%s') which is sanitized as empty string", __FUNCTION__, name, value);
         return;
     }
 
@@ -621,7 +621,7 @@ static const char *get_quoted_string_up_to(char *dst, size_t dst_size, const cha
 
 void rrdlabels_add_pair(DICTIONARY *dict, const char *string, RRDLABEL_SRC ls) {
     if(!dict) {
-        error("%s(): called with NULL dictionary.", __FUNCTION__ );
+        netdata_log_error("%s(): called with NULL dictionary.", __FUNCTION__ );
         return;
     }
 

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -842,10 +842,10 @@ void rrdset_delete_files(RRDSET *st) {
         if(cache_filename) {
             netdata_log_info("Deleting chart header file '%s'.", cache_filename);
             if (unlikely(unlink(cache_filename) == -1))
-                error("Cannot delete chart header file '%s'", cache_filename);
+                netdata_log_error("Cannot delete chart header file '%s'", cache_filename);
         }
         else
-            error("Cannot find the cache filename of chart '%s'", rrdset_id(st));
+            netdata_log_error("Cannot find the cache filename of chart '%s'", rrdset_id(st));
     }
 
     rrddim_foreach_read(rd, st) {
@@ -854,7 +854,7 @@ void rrdset_delete_files(RRDSET *st) {
 
         netdata_log_info("Deleting dimension file '%s'.", cache_filename);
         if(unlikely(unlink(cache_filename) == -1))
-            error("Cannot delete dimension file '%s'", cache_filename);
+            netdata_log_error("Cannot delete dimension file '%s'", cache_filename);
     }
     rrddim_foreach_done(rd);
 
@@ -873,7 +873,7 @@ void rrdset_delete_obsolete_dimensions(RRDSET *st) {
             if(!cache_filename) continue;
             netdata_log_info("Deleting dimension file '%s'.", cache_filename);
             if(unlikely(unlink(cache_filename) == -1))
-                error("Cannot delete dimension file '%s'", cache_filename);
+                netdata_log_error("Cannot delete dimension file '%s'", cache_filename);
         }
     }
     rrddim_foreach_done(rd);
@@ -1538,7 +1538,7 @@ void rrdset_timed_done(RRDSET *st, struct timeval now, bool pending_rrdset_next)
     }
 
     if (unlikely(rrdset_flags & RRDSET_FLAG_OBSOLETE)) {
-        error("Chart '%s' has the OBSOLETE flag set, but it is collected.", rrdset_id(st));
+        netdata_log_error("Chart '%s' has the OBSOLETE flag set, but it is collected.", rrdset_id(st));
         rrdset_isnot_obsolete(st);
     }
 
@@ -1685,7 +1685,7 @@ void rrdset_timed_done(RRDSET *st, struct timeval now, bool pending_rrdset_next)
             collected_total += rd->collector.collected_value;
 
             if(unlikely(rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE))) {
-                error("Dimension %s in chart '%s' has the OBSOLETE flag set, but it is collected.", rrddim_name(rd), rrdset_id(st));
+                netdata_log_error("Dimension %s in chart '%s' has the OBSOLETE flag set, but it is collected.", rrddim_name(rd), rrdset_id(st));
                 rrddim_isnot_obsolete(st, rd);
             }
         }
@@ -2166,15 +2166,15 @@ bool rrdset_memory_load_or_create_map_save(RRDSET *st, RRD_MEMORY_MODE memory_mo
         memset(st_on_file, 0, size);
     }
     else if(strncmp(st_on_file->id, rrdset_id(st), RRD_ID_LENGTH_MAX_V019) != 0) {
-        error("File '%s' contents are not for chart '%s'. Clearing it.", fullfilename, rrdset_id(st));
+        netdata_log_error("File '%s' contents are not for chart '%s'. Clearing it.", fullfilename, rrdset_id(st));
         memset(st_on_file, 0, size);
     }
     else if(st_on_file->memsize != size || st_on_file->entries != st->db.entries) {
-        error("File '%s' does not have the desired size. Clearing it.", fullfilename);
+        netdata_log_error("File '%s' does not have the desired size. Clearing it.", fullfilename);
         memset(st_on_file, 0, size);
     }
     else if(st_on_file->update_every != st->update_every) {
-        error("File '%s' does not have the desired granularity. Clearing it.", fullfilename);
+        netdata_log_error("File '%s' does not have the desired granularity. Clearing it.", fullfilename);
         memset(st_on_file, 0, size);
     }
     else if((now_s - st_on_file->last_updated.tv_sec) > (long)st->update_every * (long)st->db.entries) {
@@ -2182,7 +2182,7 @@ bool rrdset_memory_load_or_create_map_save(RRDSET *st, RRD_MEMORY_MODE memory_mo
         memset(st_on_file, 0, size);
     }
     else if(st_on_file->last_updated.tv_sec > now_s + st->update_every) {
-        error("File '%s' refers to the future by %zd secs. Resetting it to now.", fullfilename, (ssize_t)(st_on_file->last_updated.tv_sec - now_s));
+        netdata_log_error("File '%s' refers to the future by %zd secs. Resetting it to now.", fullfilename, (ssize_t)(st_on_file->last_updated.tv_sec - now_s));
         st_on_file->last_updated.tv_sec = now_s;
     }
 

--- a/database/rrdsetvar.c
+++ b/database/rrdsetvar.c
@@ -262,8 +262,13 @@ void rrdsetvar_custom_chart_variable_set(RRDSET *st, const RRDSETVAR_ACQUIRED *r
     RRDSETVAR *rs = dictionary_acquired_item_value((const DICTIONARY_ITEM *)rsa);
 
     if(rs->type != RRDVAR_TYPE_CALCULATED || !(rs->flags & RRDVAR_FLAG_CUSTOM_CHART_VAR) || !(rs->flags & RRDVAR_FLAG_ALLOCATED)) {
-        error("RRDSETVAR: requested to set variable '%s' of chart '%s' on host '%s' to value " NETDATA_DOUBLE_FORMAT
-            " but the variable is not a custom chart one (it has options 0x%x, value pointer %p). Ignoring request.", string2str(rs->name), rrdset_id(st), rrdhost_hostname(st->rrdhost), value, (uint32_t)rs->flags, rs->value);
+        netdata_log_error("RRDSETVAR: requested to set variable '%s' of chart '%s' on host '%s' to value " NETDATA_DOUBLE_FORMAT
+                          " but the variable is not a custom chart one (it has options 0x%x, value pointer %p). Ignoring request.",
+                          string2str(rs->name),
+                          rrdset_id(st),
+                          rrdhost_hostname(st->rrdhost),
+                          value,
+                          (uint32_t)rs->flags, rs->value);
     }
     else {
         NETDATA_DOUBLE *v = rs->value;

--- a/database/rrdvar.c
+++ b/database/rrdvar.c
@@ -175,7 +175,7 @@ void rrdvar_custom_host_variable_set(RRDHOST *host, const RRDVAR_ACQUIRED *rva, 
     if(unlikely(!host->rrdvars || !rva)) return; // when health is not enabled
 
     if(rrdvar_type(rva) != RRDVAR_TYPE_CALCULATED || !(rrdvar_flags(rva) & (RRDVAR_FLAG_CUSTOM_HOST_VAR | RRDVAR_FLAG_ALLOCATED)))
-        error("requested to set variable '%s' to value " NETDATA_DOUBLE_FORMAT " but the variable is not a custom one.", rrdvar_name(rva), value);
+        netdata_log_error("requested to set variable '%s' to value " NETDATA_DOUBLE_FORMAT " but the variable is not a custom one.", rrdvar_name(rva), value);
     else {
         RRDVAR *rv = dictionary_acquired_item_value((const DICTIONARY_ITEM *)rva);
         NETDATA_DOUBLE *v = rv->value;
@@ -228,7 +228,7 @@ NETDATA_DOUBLE rrdvar2number(const RRDVAR_ACQUIRED *rva) {
         }
 
         default:
-            error("I don't know how to convert RRDVAR type %u to NETDATA_DOUBLE", rv->type);
+            netdata_log_error("I don't know how to convert RRDVAR type %u to NETDATA_DOUBLE", rv->type);
             return NAN;
     }
 }

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -257,7 +257,7 @@ static void sql_delete_aclk_table_list(char *host_guid)
 
     rc = db_execute(db_meta, buffer_tostring(sql));
     if (unlikely(rc))
-        error("Failed to drop unused ACLK tables");
+        netdata_log_error("Failed to drop unused ACLK tables");
 
 fail:
     buffer_free(sql);

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -950,7 +950,7 @@ static void cleanup_finished_threads(struct host_context_load_thread *hclt, size
            || (wait && __atomic_load_n(&(hclt[index].busy), __ATOMIC_ACQUIRE))) {
            int rc = uv_thread_join(&(hclt[index].thread));
            if (rc)
-                error("Failed to join thread, rc = %d",rc);
+               netdata_log_error("Failed to join thread, rc = %d",rc);
            __atomic_store_n(&(hclt[index].busy), false, __ATOMIC_RELEASE);
            __atomic_store_n(&(hclt[index].finished), false, __ATOMIC_RELEASE);
        }
@@ -1244,21 +1244,21 @@ static void metadata_event_loop(void *arg)
     loop = wc->loop = mallocz(sizeof(uv_loop_t));
     ret = uv_loop_init(loop);
     if (ret) {
-        error("uv_loop_init(): %s", uv_strerror(ret));
+        netdata_log_error("uv_loop_init(): %s", uv_strerror(ret));
         goto error_after_loop_init;
     }
     loop->data = wc;
 
     ret = uv_async_init(wc->loop, &wc->async, async_cb);
     if (ret) {
-        error("uv_async_init(): %s", uv_strerror(ret));
+        netdata_log_error("uv_async_init(): %s", uv_strerror(ret));
         goto error_after_async_init;
     }
     wc->async.data = wc;
 
     ret = uv_timer_init(loop, &wc->timer_req);
     if (ret) {
-        error("uv_timer_init(): %s", uv_strerror(ret));
+        netdata_log_error("uv_timer_init(): %s", uv_strerror(ret));
         goto error_after_timer_init;
     }
     wc->timer_req.data = wc;

--- a/exporting/aws_kinesis/aws_kinesis.c
+++ b/exporting/aws_kinesis/aws_kinesis.c
@@ -54,7 +54,8 @@ int init_aws_kinesis_instance(struct instance *instance)
 
     instance->buffer = (void *)buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
     if (!instance->buffer) {
-        error("EXPORTING: cannot create buffer for AWS Kinesis exporting connector instance %s", instance->config.name);
+        netdata_log_error("EXPORTING: cannot create buffer for AWS Kinesis exporting connector instance %s",
+                          instance->config.name);
         return 1;
     }
     if (uv_mutex_init(&instance->mutex))
@@ -72,7 +73,7 @@ int init_aws_kinesis_instance(struct instance *instance)
     instance->connector_specific_data = (void *)connector_specific_data;
 
     if (!strcmp(connector_specific_config->stream_name, "")) {
-        error("stream name is a mandatory Kinesis parameter but it is not configured");
+        netdata_log_error("stream name is a mandatory Kinesis parameter but it is not configured");
         return 1;
     }
 
@@ -174,10 +175,11 @@ void aws_kinesis_connector_worker(void *instance_p)
             if (unlikely(kinesis_get_result(
                     connector_specific_data->request_outcomes, error_message, &sent_bytes, &lost_bytes))) {
                 // oops! we couldn't send (all or some of the) data
-                error("EXPORTING: %s", error_message);
-                error(
-                    "EXPORTING: failed to write data to external database '%s'. Willing to write %zu bytes, wrote %zu bytes.",
-                    instance->config.destination, sent_bytes, sent_bytes - lost_bytes);
+                netdata_log_error("EXPORTING: %s", error_message);
+                netdata_log_error("EXPORTING: failed to write data to external database '%s'. Willing to write %zu bytes, wrote %zu bytes.",
+                                  instance->config.destination,
+                                  sent_bytes,
+                                  sent_bytes - lost_bytes);
 
                 stats->transmission_failures++;
                 stats->data_lost_events++;

--- a/exporting/exporting_engine.c
+++ b/exporting/exporting_engine.c
@@ -183,7 +183,7 @@ void *exporting_main(void *ptr)
     }
 
     if (init_connectors(engine) != 0) {
-        error("EXPORTING: cannot initialize exporting connectors");
+        netdata_log_error("EXPORTING: cannot initialize exporting connectors");
         send_statistics("EXPORTING_START", "FAIL", "-");
         goto cleanup;
     }

--- a/exporting/exporting_engine.h
+++ b/exporting/exporting_engine.h
@@ -307,7 +307,7 @@ static inline void disable_instance(struct instance *instance)
     instance->disabled = 1;
     instance->scheduled = 0;
     uv_mutex_unlock(&instance->mutex);
-    error("EXPORTING: Instance %s disabled", instance->config.name);
+    netdata_log_error("EXPORTING: Instance %s disabled", instance->config.name);
 }
 
 #include "exporting/prometheus/prometheus.h"

--- a/exporting/graphite/graphite.c
+++ b/exporting/graphite/graphite.c
@@ -49,7 +49,7 @@ int init_graphite_instance(struct instance *instance)
 
     instance->buffer = (void *)buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
     if (!instance->buffer) {
-        error("EXPORTING: cannot create buffer for graphite exporting connector instance %s", instance->config.name);
+        netdata_log_error("EXPORTING: cannot create buffer for graphite exporting connector instance %s", instance->config.name);
         return 1;
     }
 

--- a/exporting/init_connectors.c
+++ b/exporting/init_connectors.c
@@ -85,14 +85,14 @@ int init_connectors(struct engine *engine)
 #endif
                 break;
             default:
-                error("EXPORTING: unknown exporting connector type");
+                netdata_log_error("EXPORTING: unknown exporting connector type");
                 return 1;
         }
 
         // dispatch the instance worker thread
         int error = uv_thread_create(&instance->thread, instance->worker, instance);
         if (error) {
-            error("EXPORTING: cannot create thread worker. uv_thread_create(): %s", uv_strerror(error));
+            netdata_log_error("EXPORTING: cannot create thread worker. uv_thread_create(): %s", uv_strerror(error));
             return 1;
         }
         char threadname[NETDATA_THREAD_NAME_MAX + 1];
@@ -113,7 +113,7 @@ static size_t base64_encode(unsigned char *input, size_t input_size, char *outpu
                            "abcdefghijklmnopqrstuvwxyz"
                            "0123456789+/";
     if ((input_size / 3 + 1) * 4 >= output_size) {
-        error("Output buffer for encoding size=%zu is not large enough for %zu-bytes input", output_size, input_size);
+        netdata_log_error("Output buffer for encoding size=%zu is not large enough for %zu-bytes input", output_size, input_size);
         return 0;
     }
     size_t count = 0;
@@ -123,7 +123,7 @@ static size_t base64_encode(unsigned char *input, size_t input_size, char *outpu
         output[1] = lookup[(value >> 12) & 0x3f];
         output[2] = lookup[(value >> 6) & 0x3f];
         output[3] = lookup[value & 0x3f];
-        //error("Base-64 encode (%04x) -> %c %c %c %c\n", value, output[0], output[1], output[2], output[3]);
+        //netdata_log_error("Base-64 encode (%04x) -> %c %c %c %c\n", value, output[0], output[1], output[2], output[3]);
         output += 4;
         input += 3;
         input_size -= 3;
@@ -136,7 +136,7 @@ static size_t base64_encode(unsigned char *input, size_t input_size, char *outpu
             output[1] = lookup[(value >> 6) & 0x3f];
             output[2] = lookup[value & 0x3f];
             output[3] = '=';
-            //error("Base-64 encode (%06x) -> %c %c %c %c\n", (value>>2)&0xffff, output[0], output[1], output[2], output[3]);
+            //netdata_log_error("Base-64 encode (%06x) -> %c %c %c %c\n", (value>>2)&0xffff, output[0], output[1], output[2], output[3]);
             count += 4;
             output[4] = '\0';
             break;
@@ -146,7 +146,7 @@ static size_t base64_encode(unsigned char *input, size_t input_size, char *outpu
             output[1] = lookup[value & 0x3f];
             output[2] = '=';
             output[3] = '=';
-            //error("Base-64 encode (%06x) -> %c %c %c %c\n", value, output[0], output[1], output[2], output[3]);
+            //netdata_log_error("Base-64 encode (%06x) -> %c %c %c %c\n", value, output[0], output[1], output[2], output[3]);
             count += 4;
             output[4] = '\0';
             break;

--- a/exporting/json/json.c
+++ b/exporting/json/json.c
@@ -39,7 +39,7 @@ int init_json_instance(struct instance *instance)
 
     instance->buffer = (void *)buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
     if (!instance->buffer) {
-        error("EXPORTING: cannot create buffer for json exporting connector instance %s", instance->config.name);
+        netdata_log_error("EXPORTING: cannot create buffer for json exporting connector instance %s", instance->config.name);
         return 1;
     }
 

--- a/exporting/opentsdb/opentsdb.c
+++ b/exporting/opentsdb/opentsdb.c
@@ -46,7 +46,7 @@ int init_opentsdb_telnet_instance(struct instance *instance)
 
     instance->buffer = (void *)buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
     if (!instance->buffer) {
-        error("EXPORTING: cannot create buffer for opentsdb telnet exporting connector instance %s", instance->config.name);
+        netdata_log_error("EXPORTING: cannot create buffer for opentsdb telnet exporting connector instance %s", instance->config.name);
         return 1;
     }
 
@@ -102,7 +102,7 @@ int init_opentsdb_http_instance(struct instance *instance)
 
     instance->buffer = (void *)buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
     if (!instance->buffer) {
-        error("EXPORTING: cannot create buffer for opentsdb HTTP exporting connector instance %s", instance->config.name);
+        netdata_log_error("EXPORTING: cannot create buffer for opentsdb HTTP exporting connector instance %s", instance->config.name);
         return 1;
     }
 

--- a/exporting/process_data.c
+++ b/exporting/process_data.c
@@ -170,7 +170,7 @@ void start_batch_formatting(struct engine *engine)
         if (instance->scheduled) {
             uv_mutex_lock(&instance->mutex);
             if (instance->start_batch_formatting && instance->start_batch_formatting(instance) != 0) {
-                error("EXPORTING: cannot start batch formatting for %s", instance->config.name);
+                netdata_log_error("EXPORTING: cannot start batch formatting for %s", instance->config.name);
                 disable_instance(instance);
             }
         }
@@ -189,7 +189,7 @@ void start_host_formatting(struct engine *engine, RRDHOST *host)
         if (instance->scheduled) {
             if (rrdhost_is_exportable(instance, host)) {
                 if (instance->start_host_formatting && instance->start_host_formatting(instance, host) != 0) {
-                    error("EXPORTING: cannot start host formatting for %s", instance->config.name);
+                    netdata_log_error("EXPORTING: cannot start host formatting for %s", instance->config.name);
                     disable_instance(instance);
                 }
             } else {
@@ -211,7 +211,7 @@ void start_chart_formatting(struct engine *engine, RRDSET *st)
         if (instance->scheduled && !instance->skip_host) {
             if (rrdset_is_exportable(instance, st)) {
                 if (instance->start_chart_formatting && instance->start_chart_formatting(instance, st) != 0) {
-                    error("EXPORTING: cannot start chart formatting for %s", instance->config.name);
+                    netdata_log_error("EXPORTING: cannot start chart formatting for %s", instance->config.name);
                     disable_instance(instance);
                 }
             } else {
@@ -232,7 +232,7 @@ void metric_formatting(struct engine *engine, RRDDIM *rd)
     for (struct instance *instance = engine->instance_root; instance; instance = instance->next) {
         if (instance->scheduled && !instance->skip_host && !instance->skip_chart) {
             if (instance->metric_formatting && instance->metric_formatting(instance, rd) != 0) {
-                error("EXPORTING: cannot format metric for %s", instance->config.name);
+                netdata_log_error("EXPORTING: cannot format metric for %s", instance->config.name);
                 disable_instance(instance);
                 continue;
             }
@@ -252,7 +252,7 @@ void end_chart_formatting(struct engine *engine, RRDSET *st)
     for (struct instance *instance = engine->instance_root; instance; instance = instance->next) {
         if (instance->scheduled && !instance->skip_host && !instance->skip_chart) {
             if (instance->end_chart_formatting && instance->end_chart_formatting(instance, st) != 0) {
-                error("EXPORTING: cannot end chart formatting for %s", instance->config.name);
+                netdata_log_error("EXPORTING: cannot end chart formatting for %s", instance->config.name);
                 disable_instance(instance);
                 continue;
             }
@@ -271,8 +271,8 @@ void variables_formatting(struct engine *engine, RRDHOST *host)
 {
     for (struct instance *instance = engine->instance_root; instance; instance = instance->next) {
         if (instance->scheduled && !instance->skip_host && should_send_variables(instance)) {
-            if (instance->variables_formatting && instance->variables_formatting(instance, host) != 0){ 
-                error("EXPORTING: cannot format variables for %s", instance->config.name);
+            if (instance->variables_formatting && instance->variables_formatting(instance, host) != 0){
+                netdata_log_error("EXPORTING: cannot format variables for %s", instance->config.name);
                 disable_instance(instance);
                 continue;
             }
@@ -293,7 +293,7 @@ void end_host_formatting(struct engine *engine, RRDHOST *host)
     for (struct instance *instance = engine->instance_root; instance; instance = instance->next) {
         if (instance->scheduled && !instance->skip_host) {
             if (instance->end_host_formatting && instance->end_host_formatting(instance, host) != 0) {
-                error("EXPORTING: cannot end host formatting for %s", instance->config.name);
+                netdata_log_error("EXPORTING: cannot end host formatting for %s", instance->config.name);
                 disable_instance(instance);
                 continue;
             }
@@ -312,7 +312,7 @@ void end_batch_formatting(struct engine *engine)
     for (struct instance *instance = engine->instance_root; instance; instance = instance->next) {
         if (instance->scheduled) {
             if (instance->end_batch_formatting && instance->end_batch_formatting(instance) != 0) {
-                error("EXPORTING: cannot end batch formatting for %s", instance->config.name);
+                netdata_log_error("EXPORTING: cannot end batch formatting for %s", instance->config.name);
                 disable_instance(instance);
                 continue;
             }

--- a/exporting/prometheus/remote_write/remote_write.c
+++ b/exporting/prometheus/remote_write/remote_write.c
@@ -386,7 +386,7 @@ int format_batch_prometheus_remote_write(struct instance *instance)
     size_t data_size = get_write_request_size(connector_specific_data->write_request);
 
     if (unlikely(!data_size)) {
-        error("EXPORTING: write request size is out of range");
+        netdata_log_error("EXPORTING: write request size is out of range");
         return 1;
     }
 
@@ -394,7 +394,7 @@ int format_batch_prometheus_remote_write(struct instance *instance)
 
     buffer_need_bytes(buffer, data_size);
     if (unlikely(pack_and_clear_write_request(connector_specific_data->write_request, buffer->buffer, &data_size))) {
-        error("EXPORTING: cannot pack write request");
+        netdata_log_error("EXPORTING: cannot pack write request");
         return 1;
     }
     buffer->len = data_size;

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -176,7 +176,7 @@ inline EXPORTING_OPTIONS exporting_parse_data_source(const char *data_source, EX
         exporting_options |= EXPORTING_SOURCE_DATA_SUM;
         exporting_options &= ~(EXPORTING_OPTIONS_SOURCE_BITS ^ EXPORTING_SOURCE_DATA_SUM);
     } else {
-        error("EXPORTING: invalid data data_source method '%s'.", data_source);
+        netdata_log_error("EXPORTING: invalid data data_source method '%s'.", data_source);
     }
 
     return exporting_options;
@@ -316,34 +316,34 @@ struct engine *read_exporting_config()
         netdata_log_info("Instance %s on %s", tmp_ci_list->local_ci.instance_name, tmp_ci_list->local_ci.connector_name);
 
         if (tmp_ci_list->exporting_type == EXPORTING_CONNECTOR_TYPE_UNKNOWN) {
-            error("Unknown exporting connector type");
+            netdata_log_error("Unknown exporting connector type");
             goto next_connector_instance;
         }
 
 #ifndef ENABLE_PROMETHEUS_REMOTE_WRITE
         if (tmp_ci_list->exporting_type == EXPORTING_CONNECTOR_TYPE_PROMETHEUS_REMOTE_WRITE) {
-            error("Prometheus Remote Write support isn't compiled");
+            netdata_log_error("Prometheus Remote Write support isn't compiled");
             goto next_connector_instance;
         }
 #endif
 
 #ifndef HAVE_KINESIS
         if (tmp_ci_list->exporting_type == EXPORTING_CONNECTOR_TYPE_KINESIS) {
-            error("AWS Kinesis support isn't compiled");
+            netdata_log_error("AWS Kinesis support isn't compiled");
             goto next_connector_instance;
         }
 #endif
 
 #ifndef ENABLE_EXPORTING_PUBSUB
         if (tmp_ci_list->exporting_type == EXPORTING_CONNECTOR_TYPE_PUBSUB) {
-            error("Google Cloud Pub/Sub support isn't compiled");
+            netdata_log_error("Google Cloud Pub/Sub support isn't compiled");
             goto next_connector_instance;
         }
 #endif
 
 #ifndef HAVE_MONGOC
         if (tmp_ci_list->exporting_type == EXPORTING_CONNECTOR_TYPE_MONGODB) {
-            error("MongoDB support isn't compiled");
+            netdata_log_error("MongoDB support isn't compiled");
             goto next_connector_instance;
         }
 #endif

--- a/exporting/send_data.c
+++ b/exporting/send_data.c
@@ -96,14 +96,14 @@ void simple_connector_receive_response(int *sock, struct instance *instance)
             stats->receptions++;
         }
         else if (r == 0) {
-            error("EXPORTING: '%s' closed the socket", instance->config.destination);
+            netdata_log_error("EXPORTING: '%s' closed the socket", instance->config.destination);
             close(*sock);
             *sock = -1;
         }
         else {
             // failed to receive data
             if (errno != EAGAIN && errno != EWOULDBLOCK) {
-                error("EXPORTING: cannot receive data from '%s'.", instance->config.destination);
+                netdata_log_error("EXPORTING: cannot receive data from '%s'.", instance->config.destination);
             }
         }
 
@@ -182,7 +182,7 @@ void simple_connector_send_buffer(
         buffer_flush(buffer);
     } else {
         // oops! we couldn't send (all or some of the) data
-        error(
+        netdata_log_error(
             "EXPORTING: failed to write data to '%s'. Willing to write %zu bytes, wrote %zd bytes. Will re-connect.",
             instance->config.destination,
             buffer_len,
@@ -299,7 +299,7 @@ void simple_connector_worker(void *instance_p)
             if (exporting_tls_is_enabled(instance->config.type, options) && sock != -1) {
                 if (netdata_ssl_exporting_ctx) {
                     if (sock_delnonblock(sock) < 0)
-                        error("Exporting cannot remove the non-blocking flag from socket %d", sock);
+                        netdata_log_error("Exporting cannot remove the non-blocking flag from socket %d", sock);
 
                     if(netdata_ssl_open(&connector_specific_data->ssl, netdata_ssl_exporting_ctx, sock)) {
                         if(netdata_ssl_connect(&connector_specific_data->ssl)) {
@@ -313,7 +313,7 @@ void simple_connector_worker(void *instance_p)
                                 tv.tv_sec = 2;
 
                             if (setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof(tv)))
-                                error("Cannot set timeout to socket %d, this can block communication", sock);
+                                netdata_log_error("Cannot set timeout to socket %d, this can block communication", sock);
                         }
                     }
                 }
@@ -340,7 +340,7 @@ void simple_connector_worker(void *instance_p)
                 connector_specific_data->buffer,
                 buffered_metrics);
         } else {
-            error("EXPORTING: failed to update '%s'", instance->config.destination);
+            netdata_log_error("EXPORTING: failed to update '%s'", instance->config.destination);
             stats->transmission_failures++;
 
             // increment the counter we check for data loss

--- a/health/health.c
+++ b/health/health.c
@@ -289,20 +289,20 @@ static void health_silencers_init(void) {
                     json_parse(str, NULL, health_silencers_json_read_callback);
                     netdata_log_info("Parsed health silencers file %s", silencers_filename);
                 } else {
-                    error("Cannot read the data from health silencers file %s", silencers_filename);
+                    netdata_log_error("Cannot read the data from health silencers file %s", silencers_filename);
                 }
                 freez(str);
             }
         } else {
-            error(
-                "Health silencers file %s has the size %" PRId64 " that is out of range[ 1 , %d ]. Aborting read.",
-                silencers_filename,
-                (int64_t)length,
-                HEALTH_SILENCERS_MAX_FILE_LEN);
+            netdata_log_error("Health silencers file %s has the size %" PRId64 " that is out of range[ 1 , %d ]. Aborting read.",
+                              silencers_filename,
+                              (int64_t)length,
+                              HEALTH_SILENCERS_MAX_FILE_LEN);
         }
         fclose(fd);
     } else {
-        netdata_log_info("Cannot open the file %s, so Netdata will work with the default health configuration.",silencers_filename);
+        netdata_log_info("Cannot open the file %s, so Netdata will work with the default health configuration.",
+                         silencers_filename);
     }
 }
 
@@ -589,7 +589,7 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
         enqueue_alarm_notify_in_progress(ae);
         health_alarm_log_save(host, ae);
     } else {
-        error("Failed to format command arguments");
+        netdata_log_error("Failed to format command arguments");
     }
 
     buffer_free(wb);
@@ -803,7 +803,10 @@ static void initialize_health(RRDHOST *host)
 
     long n = config_get_number(CONFIG_SECTION_HEALTH, "in memory max health log entries", host->health_log.max);
     if(n < 10) {
-        error("Host '%s': health configuration has invalid max log entries %ld. Using default %u", rrdhost_hostname(host), n, host->health_log.max);
+        netdata_log_error("Host '%s': health configuration has invalid max log entries %ld. Using default %u",
+                          rrdhost_hostname(host),
+                          n,
+                          host->health_log.max);
         config_set_number(CONFIG_SECTION_HEALTH, "in memory max health log entries", (long)host->health_log.max);
     }
     else

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -61,36 +61,36 @@ static inline int health_parse_delay(
 
         if(!strcasecmp(key, "up")) {
             if (!config_parse_duration(value, delay_up_duration)) {
-                error("Health configuration at line %zu of file '%s': invalid value '%s' for '%s' keyword",
-                        line, filename, value, key);
+                netdata_log_error("Health configuration at line %zu of file '%s': invalid value '%s' for '%s' keyword",
+                                  line, filename, value, key);
             }
             else given_up = 1;
         }
         else if(!strcasecmp(key, "down")) {
             if (!config_parse_duration(value, delay_down_duration)) {
-                error("Health configuration at line %zu of file '%s': invalid value '%s' for '%s' keyword",
-                        line, filename, value, key);
+                netdata_log_error("Health configuration at line %zu of file '%s': invalid value '%s' for '%s' keyword",
+                                  line, filename, value, key);
             }
             else given_down = 1;
         }
         else if(!strcasecmp(key, "multiplier")) {
             *delay_multiplier = strtof(value, NULL);
             if(isnan(*delay_multiplier) || isinf(*delay_multiplier) || islessequal(*delay_multiplier, 0)) {
-                error("Health configuration at line %zu of file '%s': invalid value '%s' for '%s' keyword",
-                        line, filename, value, key);
+                netdata_log_error("Health configuration at line %zu of file '%s': invalid value '%s' for '%s' keyword",
+                                  line, filename, value, key);
             }
             else given_multiplier = 1;
         }
         else if(!strcasecmp(key, "max")) {
             if (!config_parse_duration(value, delay_max_duration)) {
-                error("Health configuration at line %zu of file '%s': invalid value '%s' for '%s' keyword",
-                        line, filename, value, key);
+                netdata_log_error("Health configuration at line %zu of file '%s': invalid value '%s' for '%s' keyword",
+                                  line, filename, value, key);
             }
             else given_max = 1;
         }
         else {
-            error("Health configuration at line %zu of file '%s': unknown keyword '%s'",
-                    line, filename, key);
+            netdata_log_error("Health configuration at line %zu of file '%s': unknown keyword '%s'",
+                              line, filename, key);
         }
     }
 
@@ -136,7 +136,7 @@ static inline uint32_t health_parse_options(const char *s) {
             if(!strcasecmp(buf, "no-clear-notification") || !strcasecmp(buf, "no-clear"))
                 options |= RRDCALC_OPTION_NO_CLEAR_NOTIFICATION;
             else
-                error("Ignoring unknown alarm option '%s'", buf);
+                netdata_log_error("Ignoring unknown alarm option '%s'", buf);
         }
     }
 
@@ -171,14 +171,14 @@ static inline int health_parse_repeat(
         }
         if(!strcasecmp(key, "warning")) {
             if (!config_parse_duration(value, (int*)warn_repeat_every)) {
-                error("Health configuration at line %zu of file '%s': invalid value '%s' for '%s' keyword",
-                      line, file, value, key);
+                netdata_log_error("Health configuration at line %zu of file '%s': invalid value '%s' for '%s' keyword",
+                                  line, file, value, key);
             }
         }
         else if(!strcasecmp(key, "critical")) {
             if (!config_parse_duration(value, (int*)crit_repeat_every)) {
-                error("Health configuration at line %zu of file '%s': invalid value '%s' for '%s' keyword",
-                      line, file, value, key);
+                netdata_log_error("Health configuration at line %zu of file '%s': invalid value '%s' for '%s' keyword",
+                                  line, file, value, key);
             }
         }
     }
@@ -326,14 +326,14 @@ static inline int health_parse_db_lookup(
     while(*s && !isspace(*s)) s++;
     while(*s && isspace(*s)) *s++ = '\0';
     if(!*s) {
-        error("Health configuration invalid chart calculation at line %zu of file '%s': expected group method followed by the 'after' time, but got '%s'",
-                line, filename, key);
+        netdata_log_error("Health configuration invalid chart calculation at line %zu of file '%s': expected group method followed by the 'after' time, but got '%s'",
+                          line, filename, key);
         return 0;
     }
 
     if((*group_method = time_grouping_parse(key, RRDR_GROUPING_UNDEFINED)) == RRDR_GROUPING_UNDEFINED) {
-        error("Health configuration at line %zu of file '%s': invalid group method '%s'",
-                line, filename, key);
+        netdata_log_error("Health configuration at line %zu of file '%s': invalid group method '%s'",
+                          line, filename, key);
         return 0;
     }
 
@@ -343,8 +343,8 @@ static inline int health_parse_db_lookup(
     while(*s && isspace(*s)) *s++ = '\0';
 
     if(!config_parse_duration(key, after)) {
-        error("Health configuration at line %zu of file '%s': invalid duration '%s' after group method",
-                line, filename, key);
+        netdata_log_error("Health configuration at line %zu of file '%s': invalid duration '%s' after group method",
+                          line, filename, key);
         return 0;
     }
 
@@ -364,8 +364,8 @@ static inline int health_parse_db_lookup(
             while(*s && isspace(*s)) *s++ = '\0';
 
             if (!config_parse_duration(value, before)) {
-                error("Health configuration at line %zu of file '%s': invalid duration '%s' for '%s' keyword",
-                        line, filename, value, key);
+                netdata_log_error("Health configuration at line %zu of file '%s': invalid duration '%s' for '%s' keyword",
+                                  line, filename, value, key);
             }
         }
         else if(!strcasecmp(key, HEALTH_EVERY_KEY)) {
@@ -374,8 +374,8 @@ static inline int health_parse_db_lookup(
             while(*s && isspace(*s)) *s++ = '\0';
 
             if (!config_parse_duration(value, every)) {
-                error("Health configuration at line %zu of file '%s': invalid duration '%s' for '%s' keyword",
-                        line, filename, value, key);
+                netdata_log_error("Health configuration at line %zu of file '%s': invalid duration '%s' for '%s' keyword",
+                                  line, filename, value, key);
             }
         }
         else if(!strcasecmp(key, "absolute") || !strcasecmp(key, "abs") || !strcasecmp(key, "absolute_sum")) {
@@ -422,8 +422,8 @@ static inline int health_parse_db_lookup(
             break;
         }
         else {
-            error("Health configuration at line %zu of file '%s': unknown keyword '%s'",
-                    line, filename, key);
+            netdata_log_error("Health configuration at line %zu of file '%s': unknown keyword '%s'",
+                              line, filename, key);
         }
     }
 
@@ -574,7 +574,7 @@ static int health_readfile(const char *filename, void *data) {
 
     FILE *fp = fopen(filename, "r");
     if(!fp) {
-        error("Health configuration cannot read file '%s'.", filename);
+        netdata_log_error("Health configuration cannot read file '%s'.", filename);
         return 0;
     }
 
@@ -598,7 +598,8 @@ static int health_readfile(const char *filename, void *data) {
             if(append < HEALTH_CONF_MAX_LINE)
                 continue;
             else {
-                error("Health configuration has too long multi-line at line %zu of file '%s'.", line, filename);
+                netdata_log_error("Health configuration has too long multi-line at line %zu of file '%s'.",
+                                  line, filename);
             }
         }
         append = 0;
@@ -606,7 +607,8 @@ static int health_readfile(const char *filename, void *data) {
         char *key = s;
         while(*s && *s != ':') s++;
         if(!*s) {
-            error("Health configuration has invalid line %zu of file '%s'. It does not contain a ':'. Ignoring it.", line, filename);
+            netdata_log_error("Health configuration has invalid line %zu of file '%s'. It does not contain a ':'. Ignoring it.",
+                              line, filename);
             continue;
         }
         *s = '\0';
@@ -617,12 +619,14 @@ static int health_readfile(const char *filename, void *data) {
         value = trim_all(value);
 
         if(!key) {
-            error("Health configuration has invalid line %zu of file '%s'. Keyword is empty. Ignoring it.", line, filename);
+            netdata_log_error("Health configuration has invalid line %zu of file '%s'. Keyword is empty. Ignoring it.",
+                              line, filename);
             continue;
         }
 
         if(!value) {
-            error("Health configuration has invalid line %zu of file '%s'. value is empty. Ignoring it.", line, filename);
+            netdata_log_error("Health configuration has invalid line %zu of file '%s'. value is empty. Ignoring it.",
+                              line, filename);
             continue;
         }
 
@@ -654,7 +658,7 @@ static int health_readfile(const char *filename, void *data) {
                 {
                     char *tmp = strdupz(value);
                     if(rrdvar_fix_name(tmp))
-                        error("Health configuration renamed alarm '%s' to '%s'", value, tmp);
+                        netdata_log_error("Health configuration renamed alarm '%s' to '%s'", value, tmp);
 
                     rc->name = string_strdupz(tmp);
                     freez(tmp);
@@ -704,7 +708,7 @@ static int health_readfile(const char *filename, void *data) {
                 {
                     char *tmp = strdupz(value);
                     if(rrdvar_fix_name(tmp))
-                        error("Health configuration renamed template '%s' to '%s'", value, tmp);
+                        netdata_log_error("Health configuration renamed template '%s' to '%s'", value, tmp);
 
                     rt->name = string_strdupz(tmp);
                     freez(tmp);
@@ -766,8 +770,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->on = string_strdupz(value);
                 if(rc->chart) {
                     if(strcmp(rrdcalc_chart_name(rc), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                                line, filename, rrdcalc_name(rc), key, rrdcalc_chart_name(rc), value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                                          line, filename, rrdcalc_name(rc), key, rrdcalc_chart_name(rc), value, value);
 
                     string_freez(rc->chart);
                 }
@@ -779,8 +783,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->classification = string_strdupz(value);
                 if(rc->classification) {
                     if(strcmp(rrdcalc_classification(rc), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                                line, filename, rrdcalc_name(rc), key, rrdcalc_classification(rc), value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                                          line, filename, rrdcalc_name(rc), key, rrdcalc_classification(rc), value, value);
 
                     string_freez(rc->classification);
                 }
@@ -792,7 +796,7 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->component = string_strdupz(value);
                 if(rc->component) {
                     if(strcmp(rrdcalc_component(rc), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                        netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
                                 line, filename, rrdcalc_name(rc), key, rrdcalc_component(rc), value, value);
 
                     string_freez(rc->component);
@@ -805,8 +809,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->type = string_strdupz(value);
                 if(rc->type) {
                     if(strcmp(rrdcalc_type(rc), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                                line, filename, rrdcalc_name(rc), key, rrdcalc_type(rc), value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                                          line, filename, rrdcalc_name(rc), key, rrdcalc_type(rc), value, value);
 
                     string_freez(rc->type);
                 }
@@ -834,8 +838,8 @@ static int health_readfile(const char *filename, void *data) {
             else if(hash == hash_every && !strcasecmp(key, HEALTH_EVERY_KEY)) {
                 alert_cfg->every = string_strdupz(value);
                 if(!config_parse_duration(value, &rc->update_every))
-                    error("Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' cannot parse duration: '%s'.",
-                            line, filename, rrdcalc_name(rc), key, value);
+                    netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' cannot parse duration: '%s'.",
+                                      line, filename, rrdcalc_name(rc), key, value);
                 alert_cfg->p_update_every = rc->update_every;
             }
             else if(hash == hash_green && !strcasecmp(key, HEALTH_GREEN_KEY)) {
@@ -843,8 +847,8 @@ static int health_readfile(const char *filename, void *data) {
                 char *e;
                 rc->green = str2ndd(value, &e);
                 if(e && *e) {
-                    error("Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' leaves this string unmatched: '%s'.",
-                            line, filename, rrdcalc_name(rc), key, e);
+                    netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' leaves this string unmatched: '%s'.",
+                                      line, filename, rrdcalc_name(rc), key, e);
                 }
             }
             else if(hash == hash_red && !strcasecmp(key, HEALTH_RED_KEY)) {
@@ -852,8 +856,8 @@ static int health_readfile(const char *filename, void *data) {
                 char *e;
                 rc->red = str2ndd(value, &e);
                 if(e && *e) {
-                    error("Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' leaves this string unmatched: '%s'.",
-                            line, filename, rrdcalc_name(rc), key, e);
+                    netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' leaves this string unmatched: '%s'.",
+                                      line, filename, rrdcalc_name(rc), key, e);
                 }
             }
             else if(hash == hash_calc && !strcasecmp(key, HEALTH_CALC_KEY)) {
@@ -862,8 +866,8 @@ static int health_readfile(const char *filename, void *data) {
                 int error = 0;
                 rc->calculation = expression_parse(value, &failed_at, &error);
                 if(!rc->calculation) {
-                    error("Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' has unparse-able expression '%s': %s at '%s'",
-                            line, filename, rrdcalc_name(rc), key, value, expression_strerror(error), failed_at);
+                    netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' has unparse-able expression '%s': %s at '%s'",
+                                      line, filename, rrdcalc_name(rc), key, value, expression_strerror(error), failed_at);
                 }
                 parse_variables_and_store_in_health_rrdvars(value, HEALTH_CONF_MAX_LINE);
             }
@@ -873,8 +877,8 @@ static int health_readfile(const char *filename, void *data) {
                 int error = 0;
                 rc->warning = expression_parse(value, &failed_at, &error);
                 if(!rc->warning) {
-                    error("Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' has unparse-able expression '%s': %s at '%s'",
-                            line, filename, rrdcalc_name(rc), key, value, expression_strerror(error), failed_at);
+                    netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' has unparse-able expression '%s': %s at '%s'",
+                                      line, filename, rrdcalc_name(rc), key, value, expression_strerror(error), failed_at);
                 }
                 parse_variables_and_store_in_health_rrdvars(value, HEALTH_CONF_MAX_LINE);
             }
@@ -884,8 +888,8 @@ static int health_readfile(const char *filename, void *data) {
                 int error = 0;
                 rc->critical = expression_parse(value, &failed_at, &error);
                 if(!rc->critical) {
-                    error("Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' has unparse-able expression '%s': %s at '%s'",
-                            line, filename, rrdcalc_name(rc), key, value, expression_strerror(error), failed_at);
+                    netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' at key '%s' has unparse-able expression '%s': %s at '%s'",
+                                      line, filename, rrdcalc_name(rc), key, value, expression_strerror(error), failed_at);
                 }
                 parse_variables_and_store_in_health_rrdvars(value, HEALTH_CONF_MAX_LINE);
             }
@@ -893,8 +897,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->exec = string_strdupz(value);
                 if(rc->exec) {
                     if(strcmp(rrdcalc_exec(rc), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                                line, filename, rrdcalc_name(rc), key, rrdcalc_exec(rc), value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                                          line, filename, rrdcalc_name(rc), key, rrdcalc_exec(rc), value, value);
 
                     string_freez(rc->exec);
                 }
@@ -904,8 +908,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->to = string_strdupz(value);
                 if(rc->recipient) {
                     if(strcmp(rrdcalc_recipient(rc), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                                line, filename, rrdcalc_name(rc), key, rrdcalc_recipient(rc), value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                                          line, filename, rrdcalc_name(rc), key, rrdcalc_recipient(rc), value, value);
 
                     string_freez(rc->recipient);
                 }
@@ -917,8 +921,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->units = string_strdupz(value);
                 if(rc->units) {
                     if(strcmp(rrdcalc_units(rc), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                                line, filename, rrdcalc_name(rc), key, rrdcalc_units(rc), value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                                          line, filename, rrdcalc_name(rc), key, rrdcalc_units(rc), value, value);
 
                     string_freez(rc->units);
                 }
@@ -930,8 +934,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->info = string_strdupz(value);
                 if(rc->info) {
                     if(strcmp(rrdcalc_info(rc), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                                line, filename, rrdcalc_name(rc), key, rrdcalc_info(rc), value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                                          line, filename, rrdcalc_name(rc), key, rrdcalc_info(rc), value, value);
 
                     string_freez(rc->info);
                     string_freez(rc->original_info);
@@ -957,8 +961,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->host_labels = string_strdupz(value);
                 if(rc->host_labels) {
                     if(strcmp(rrdcalc_host_labels(rc), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'.",
-                              line, filename, rrdcalc_name(rc), key, value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'.",
+                                          line, filename, rrdcalc_name(rc), key, value, value);
 
                     string_freez(rc->host_labels);
                     simple_pattern_free(rc->host_labels_pattern);
@@ -992,8 +996,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->chart_labels = string_strdupz(value);
                 if(rc->chart_labels) {
                     if(strcmp(rrdcalc_chart_labels(rc), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'.",
-                              line, filename, rrdcalc_name(rc), key, value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'.",
+                                          line, filename, rrdcalc_name(rc), key, value, value);
 
                     string_freez(rc->chart_labels);
                     simple_pattern_free(rc->chart_labels_pattern);
@@ -1010,8 +1014,8 @@ static int health_readfile(const char *filename, void *data) {
                                                                 true);
             }
             else {
-                error("Health configuration at line %zu of file '%s' for alarm '%s' has unknown key '%s'.",
-                        line, filename, rrdcalc_name(rc), key);
+                netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' has unknown key '%s'.",
+                                  line, filename, rrdcalc_name(rc), key);
             }
         }
         else if(rt) {
@@ -1019,8 +1023,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->on = string_strdupz(value);
                 if(rt->context) {
                     if(strcmp(string2str(rt->context), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for template '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                                line, filename, rrdcalctemplate_name(rt), key, string2str(rt->context), value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for template '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                                          line, filename, rrdcalctemplate_name(rt), key, string2str(rt->context), value, value);
 
                     string_freez(rt->context);
                 }
@@ -1032,8 +1036,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->classification = string_strdupz(value);
                 if(rt->classification) {
                     if(strcmp(rrdcalctemplate_classification(rt), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                              line, filename, rrdcalctemplate_name(rt), key, rrdcalctemplate_classification(rt), value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                                          line, filename, rrdcalctemplate_name(rt), key, rrdcalctemplate_classification(rt), value, value);
 
                     string_freez(rt->classification);
                 }
@@ -1045,8 +1049,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->component = string_strdupz(value);
                 if(rt->component) {
                     if(strcmp(rrdcalctemplate_component(rt), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                              line, filename, rrdcalctemplate_name(rt), key, rrdcalctemplate_component(rt), value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                                          line, filename, rrdcalctemplate_name(rt), key, rrdcalctemplate_component(rt), value, value);
 
                     string_freez(rt->component);
                 }
@@ -1058,8 +1062,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->type = string_strdupz(value);
                 if(rt->type) {
                     if(strcmp(rrdcalctemplate_type(rt), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                              line, filename, rrdcalctemplate_name(rt), key, rrdcalctemplate_type(rt), value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for alarm '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                                          line, filename, rrdcalctemplate_name(rt), key, rrdcalctemplate_type(rt), value, value);
 
                     string_freez(rt->type);
                 }
@@ -1125,8 +1129,8 @@ static int health_readfile(const char *filename, void *data) {
             else if(hash == hash_every && !strcasecmp(key, HEALTH_EVERY_KEY)) {
                 alert_cfg->every = string_strdupz(value);
                 if(!config_parse_duration(value, &rt->update_every))
-                    error("Health configuration at line %zu of file '%s' for template '%s' at key '%s' cannot parse duration: '%s'.",
-                            line, filename, rrdcalctemplate_name(rt), key, value);
+                    netdata_log_error("Health configuration at line %zu of file '%s' for template '%s' at key '%s' cannot parse duration: '%s'.",
+                                      line, filename, rrdcalctemplate_name(rt), key, value);
                 alert_cfg->p_update_every = rt->update_every;
             }
             else if(hash == hash_green && !strcasecmp(key, HEALTH_GREEN_KEY)) {
@@ -1134,8 +1138,8 @@ static int health_readfile(const char *filename, void *data) {
                 char *e;
                 rt->green = str2ndd(value, &e);
                 if(e && *e) {
-                    error("Health configuration at line %zu of file '%s' for template '%s' at key '%s' leaves this string unmatched: '%s'.",
-                            line, filename, rrdcalctemplate_name(rt), key, e);
+                    netdata_log_error("Health configuration at line %zu of file '%s' for template '%s' at key '%s' leaves this string unmatched: '%s'.",
+                                      line, filename, rrdcalctemplate_name(rt), key, e);
                 }
             }
             else if(hash == hash_red && !strcasecmp(key, HEALTH_RED_KEY)) {
@@ -1143,8 +1147,8 @@ static int health_readfile(const char *filename, void *data) {
                 char *e;
                 rt->red = str2ndd(value, &e);
                 if(e && *e) {
-                    error("Health configuration at line %zu of file '%s' for template '%s' at key '%s' leaves this string unmatched: '%s'.",
-                            line, filename, rrdcalctemplate_name(rt), key, e);
+                    netdata_log_error("Health configuration at line %zu of file '%s' for template '%s' at key '%s' leaves this string unmatched: '%s'.",
+                                      line, filename, rrdcalctemplate_name(rt), key, e);
                 }
             }
             else if(hash == hash_calc && !strcasecmp(key, HEALTH_CALC_KEY)) {
@@ -1153,8 +1157,8 @@ static int health_readfile(const char *filename, void *data) {
                 int error = 0;
                 rt->calculation = expression_parse(value, &failed_at, &error);
                 if(!rt->calculation) {
-                    error("Health configuration at line %zu of file '%s' for template '%s' at key '%s' has unparse-able expression '%s': %s at '%s'",
-                            line, filename, rrdcalctemplate_name(rt), key, value, expression_strerror(error), failed_at);
+                    netdata_log_error("Health configuration at line %zu of file '%s' for template '%s' at key '%s' has unparse-able expression '%s': %s at '%s'",
+                                      line, filename, rrdcalctemplate_name(rt), key, value, expression_strerror(error), failed_at);
                 }
                 parse_variables_and_store_in_health_rrdvars(value, HEALTH_CONF_MAX_LINE);
             }
@@ -1164,8 +1168,8 @@ static int health_readfile(const char *filename, void *data) {
                 int error = 0;
                 rt->warning = expression_parse(value, &failed_at, &error);
                 if(!rt->warning) {
-                    error("Health configuration at line %zu of file '%s' for template '%s' at key '%s' has unparse-able expression '%s': %s at '%s'",
-                            line, filename, rrdcalctemplate_name(rt), key, value, expression_strerror(error), failed_at);
+                    netdata_log_error("Health configuration at line %zu of file '%s' for template '%s' at key '%s' has unparse-able expression '%s': %s at '%s'",
+                                      line, filename, rrdcalctemplate_name(rt), key, value, expression_strerror(error), failed_at);
                 }
                 parse_variables_and_store_in_health_rrdvars(value, HEALTH_CONF_MAX_LINE);
             }
@@ -1175,8 +1179,8 @@ static int health_readfile(const char *filename, void *data) {
                 int error = 0;
                 rt->critical = expression_parse(value, &failed_at, &error);
                 if(!rt->critical) {
-                    error("Health configuration at line %zu of file '%s' for template '%s' at key '%s' has unparse-able expression '%s': %s at '%s'",
-                            line, filename, rrdcalctemplate_name(rt), key, value, expression_strerror(error), failed_at);
+                    netdata_log_error("Health configuration at line %zu of file '%s' for template '%s' at key '%s' has unparse-able expression '%s': %s at '%s'",
+                                      line, filename, rrdcalctemplate_name(rt), key, value, expression_strerror(error), failed_at);
                 }
                 parse_variables_and_store_in_health_rrdvars(value, HEALTH_CONF_MAX_LINE);
             }
@@ -1184,8 +1188,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->exec = string_strdupz(value);
                 if(rt->exec) {
                     if(strcmp(rrdcalctemplate_exec(rt), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for template '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                                line, filename, rrdcalctemplate_name(rt), key, rrdcalctemplate_exec(rt), value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for template '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                                          line, filename, rrdcalctemplate_name(rt), key, rrdcalctemplate_exec(rt), value, value);
 
                     string_freez(rt->exec);
                 }
@@ -1195,8 +1199,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->to = string_strdupz(value);
                 if(rt->recipient) {
                     if(strcmp(rrdcalctemplate_recipient(rt), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for template '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                                line, filename, rrdcalctemplate_name(rt), key, rrdcalctemplate_recipient(rt), value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for template '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                                          line, filename, rrdcalctemplate_name(rt), key, rrdcalctemplate_recipient(rt), value, value);
 
                     string_freez(rt->recipient);
                 }
@@ -1208,8 +1212,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->units = string_strdupz(value);
                 if(rt->units) {
                     if(strcmp(rrdcalctemplate_units(rt), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for template '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                                line, filename, rrdcalctemplate_name(rt), key, rrdcalctemplate_units(rt), value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for template '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                                          line, filename, rrdcalctemplate_name(rt), key, rrdcalctemplate_units(rt), value, value);
 
                     string_freez(rt->units);
                 }
@@ -1221,8 +1225,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->info = string_strdupz(value);
                 if(rt->info) {
                     if(strcmp(rrdcalctemplate_info(rt), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for template '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                                line, filename, rrdcalctemplate_name(rt), key, rrdcalctemplate_info(rt), value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for template '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                                          line, filename, rrdcalctemplate_name(rt), key, rrdcalctemplate_info(rt), value, value);
 
                     string_freez(rt->info);
                 }
@@ -1246,8 +1250,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->host_labels = string_strdupz(value);
                 if(rt->host_labels) {
                     if(strcmp(rrdcalctemplate_host_labels(rt), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for template '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                              line, filename, rrdcalctemplate_name(rt), key, rrdcalctemplate_host_labels(rt), value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for template '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                                          line, filename, rrdcalctemplate_name(rt), key, rrdcalctemplate_host_labels(rt), value, value);
 
                     string_freez(rt->host_labels);
                     simple_pattern_free(rt->host_labels_pattern);
@@ -1266,8 +1270,8 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->chart_labels = string_strdupz(value);
                 if(rt->chart_labels) {
                     if(strcmp(rrdcalctemplate_chart_labels(rt), value) != 0)
-                        error("Health configuration at line %zu of file '%s' for template '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
-                              line, filename, rrdcalctemplate_name(rt), key, rrdcalctemplate_chart_labels(rt), value, value);
+                        netdata_log_error("Health configuration at line %zu of file '%s' for template '%s' has key '%s' twice, once with value '%s' and later with value '%s'. Using ('%s').",
+                                          line, filename, rrdcalctemplate_name(rt), key, rrdcalctemplate_chart_labels(rt), value, value);
 
                     string_freez(rt->chart_labels);
                     simple_pattern_free(rt->chart_labels_pattern);
@@ -1284,13 +1288,13 @@ static int health_readfile(const char *filename, void *data) {
                                                                 SIMPLE_PATTERN_EXACT, true);
             }
             else {
-                error("Health configuration at line %zu of file '%s' for template '%s' has unknown key '%s'.",
-                        line, filename, rrdcalctemplate_name(rt), key);
+                netdata_log_error("Health configuration at line %zu of file '%s' for template '%s' has unknown key '%s'.",
+                                  line, filename, rrdcalctemplate_name(rt), key);
             }
         }
         else {
-            error("Health configuration at line %zu of file '%s' has unknown key '%s'. Expected either '" HEALTH_ALARM_KEY "' or '" HEALTH_TEMPLATE_KEY "'.",
-                    line, filename, key);
+            netdata_log_error("Health configuration at line %zu of file '%s' has unknown key '%s'. Expected either '" HEALTH_ALARM_KEY "' or '" HEALTH_TEMPLATE_KEY "'.",
+                              line, filename, key);
         }
     }
 

--- a/libnetdata/aral/aral.c
+++ b/libnetdata/aral/aral.c
@@ -194,7 +194,7 @@ static void aral_delete_leftover_files(const char *name, const char *path, const
         snprintfz(full_path, FILENAME_MAX, "%s/%s", path, de->d_name);
         netdata_log_info("ARAL: '%s' removing left-over file '%s'", name, full_path);
         if(unlikely(unlink(full_path) == -1))
-            error("ARAL: '%s' cannot delete file '%s'", name, full_path);
+            netdata_log_error("ARAL: '%s' cannot delete file '%s'", name, full_path);
     }
 
     closedir(dir);
@@ -324,7 +324,7 @@ void aral_del_page___no_lock_needed(ARAL *ar, ARAL_PAGE *page TRACE_ALLOCATIONS_
         netdata_munmap(page->data, page->size);
 
         if (unlikely(unlink(page->filename) == 1))
-            error("Cannot delete file '%s'", page->filename);
+            netdata_log_error("Cannot delete file '%s'", page->filename);
 
         freez((void *)page->filename);
 
@@ -764,7 +764,7 @@ ARAL *aral_create(const char *name, size_t element_size, size_t initial_page_ele
         ar->config.initial_page_elements = 2;
 
     if(ar->config.mmap.enabled && (!ar->config.mmap.cache_dir || !*ar->config.mmap.cache_dir)) {
-        error("ARAL: '%s' mmap cache directory is not configured properly, disabling mmap.", ar->config.name);
+        netdata_log_error("ARAL: '%s' mmap cache directory is not configured properly, disabling mmap.", ar->config.name);
         ar->config.mmap.enabled = false;
         internal_fatal(true, "ARAL: '%s' mmap cache directory is not configured properly", ar->config.name);
     }

--- a/libnetdata/buffer/buffer.c
+++ b/libnetdata/buffer/buffer.c
@@ -367,8 +367,8 @@ static int buffer_expect(BUFFER *wb, const char *expected) {
     const char *generated = buffer_tostring(wb);
 
     if(strcmp(generated, expected) != 0) {
-        error("BUFFER: mismatch.\nGenerated:\n%s\nExpected:\n%s\n",
-              generated, expected);
+        netdata_log_error("BUFFER: mismatch.\nGenerated:\n%s\nExpected:\n%s\n",
+                          generated, expected);
         return 1;
     }
 
@@ -385,8 +385,8 @@ static int buffer_uint64_roundtrip(BUFFER *wb, NUMBER_ENCODING encoding, uint64_
 
     uint64_t v = str2ull_encoded(buffer_tostring(wb));
     if(v != value) {
-        error("BUFFER: string '%s' does resolves to %llu, expected %llu",
-              buffer_tostring(wb), (unsigned long long)v, (unsigned long long)value);
+        netdata_log_error("BUFFER: string '%s' does resolves to %llu, expected %llu",
+                          buffer_tostring(wb), (unsigned long long)v, (unsigned long long)value);
         errors++;
     }
     buffer_flush(wb);
@@ -403,8 +403,8 @@ static int buffer_int64_roundtrip(BUFFER *wb, NUMBER_ENCODING encoding, int64_t 
 
     int64_t v = str2ll_encoded(buffer_tostring(wb));
     if(v != value) {
-        error("BUFFER: string '%s' does resolves to %lld, expected %lld",
-              buffer_tostring(wb), (long long)v, (long long)value);
+        netdata_log_error("BUFFER: string '%s' does resolves to %lld, expected %lld",
+                          buffer_tostring(wb), (long long)v, (long long)value);
         errors++;
     }
     buffer_flush(wb);
@@ -421,8 +421,8 @@ static int buffer_double_roundtrip(BUFFER *wb, NUMBER_ENCODING encoding, NETDATA
 
     NETDATA_DOUBLE v = str2ndd_encoded(buffer_tostring(wb), NULL);
     if(v != value) {
-        error("BUFFER: string '%s' does resolves to %.12f, expected %.12f",
-              buffer_tostring(wb), v, value);
+        netdata_log_error("BUFFER: string '%s' does resolves to %.12f, expected %.12f",
+                          buffer_tostring(wb), v, value);
         errors++;
     }
     buffer_flush(wb);

--- a/libnetdata/clocks/clocks.c
+++ b/libnetdata/clocks/clocks.c
@@ -14,7 +14,7 @@ usec_t clock_realtime_resolution = 1000;
 inline int clock_gettime(clockid_t clk_id __maybe_unused, struct timespec *ts) {
     struct timeval tv;
     if(unlikely(gettimeofday(&tv, NULL) == -1)) {
-        error("gettimeofday() failed.");
+        netdata_log_error("gettimeofday() failed.");
         return -1;
     }
     ts->tv_sec = tv.tv_sec;
@@ -79,7 +79,7 @@ void clocks_init(void) {
 inline time_t now_sec(clockid_t clk_id) {
     struct timespec ts;
     if(unlikely(clock_gettime(clk_id, &ts) == -1)) {
-        error("clock_gettime(%d, &timespec) failed.", clk_id);
+        netdata_log_error("clock_gettime(%d, &timespec) failed.", clk_id);
         return 0;
     }
     return ts.tv_sec;
@@ -88,7 +88,7 @@ inline time_t now_sec(clockid_t clk_id) {
 inline usec_t now_usec(clockid_t clk_id) {
     struct timespec ts;
     if(unlikely(clock_gettime(clk_id, &ts) == -1)) {
-        error("clock_gettime(%d, &timespec) failed.", clk_id);
+        netdata_log_error("clock_gettime(%d, &timespec) failed.", clk_id);
         return 0;
     }
     return (usec_t)ts.tv_sec * USEC_PER_SEC + (ts.tv_nsec % NSEC_PER_SEC) / NSEC_PER_USEC;
@@ -98,7 +98,7 @@ inline int now_timeval(clockid_t clk_id, struct timeval *tv) {
     struct timespec ts;
 
     if(unlikely(clock_gettime(clk_id, &ts) == -1)) {
-        error("clock_gettime(%d, &timespec) failed.", clk_id);
+        netdata_log_error("clock_gettime(%d, &timespec) failed.", clk_id);
         tv->tv_sec = 0;
         tv->tv_usec = 0;
         return -1;
@@ -200,30 +200,27 @@ void sleep_to_absolute_time(usec_t usec) {
             if (ret == EINVAL) {
                 if (!einval_printed) {
                     einval_printed++;
-                    error(
-                        "Invalid time given to clock_nanosleep(): clockid = %d, tv_sec = %lld, tv_nsec = %ld",
-                        clock,
-                        (long long)req.tv_sec,
-                        req.tv_nsec);
+                    netdata_log_error("Invalid time given to clock_nanosleep(): clockid = %d, tv_sec = %lld, tv_nsec = %ld",
+                                      clock,
+                                      (long long)req.tv_sec,
+                                      req.tv_nsec);
                 }
             } else if (ret == ENOTSUP) {
                 if (!enotsup_printed) {
                     enotsup_printed++;
-                    error(
-                        "Invalid clock id given to clock_nanosleep(): clockid = %d, tv_sec = %lld, tv_nsec = %ld",
-                        clock,
-                        (long long)req.tv_sec,
-                        req.tv_nsec);
+                    netdata_log_error("Invalid clock id given to clock_nanosleep(): clockid = %d, tv_sec = %lld, tv_nsec = %ld",
+                                      clock,
+                                      (long long)req.tv_sec,
+                                      req.tv_nsec);
                 }
             } else {
                 if (!eunknown_printed) {
                     eunknown_printed++;
-                    error(
-                        "Unknown return value %d from clock_nanosleep(): clockid = %d, tv_sec = %lld, tv_nsec = %ld",
-                        ret,
-                        clock,
-                        (long long)req.tv_sec,
-                        req.tv_nsec);
+                    netdata_log_error("Unknown return value %d from clock_nanosleep(): clockid = %d, tv_sec = %lld, tv_nsec = %ld",
+                                      ret,
+                                      clock,
+                                      (long long)req.tv_sec,
+                                      req.tv_nsec);
                 }
             }
             sleep_usec(usec);
@@ -384,7 +381,7 @@ void sleep_usec_with_now(usec_t usec, usec_t started_ut) {
             }
         }
         else {
-            error("Cannot nanosleep() for %llu microseconds.", usec);
+            netdata_log_error("Cannot nanosleep() for %llu microseconds.", usec);
             break;
         }
     }
@@ -394,7 +391,7 @@ static inline collected_number uptime_from_boottime(void) {
 #ifdef CLOCK_BOOTTIME_IS_AVAILABLE
     return (collected_number)(now_boottime_usec() / USEC_PER_MS);
 #else
-    error("uptime cannot be read from CLOCK_BOOTTIME on this system.");
+    netdata_log_error("uptime cannot be read from CLOCK_BOOTTIME on this system.");
     return 0;
 #endif
 }
@@ -410,11 +407,11 @@ static inline collected_number read_proc_uptime(char *filename) {
     if(unlikely(!read_proc_uptime_ff)) return 0;
 
     if(unlikely(procfile_lines(read_proc_uptime_ff) < 1)) {
-        error("/proc/uptime has no lines.");
+        netdata_log_error("/proc/uptime has no lines.");
         return 0;
     }
     if(unlikely(procfile_linewords(read_proc_uptime_ff, 0) < 1)) {
-        error("/proc/uptime has less than 1 word in it.");
+        netdata_log_error("/proc/uptime has less than 1 word in it.");
         return 0;
     }
 
@@ -441,7 +438,7 @@ inline collected_number uptime_msec(char *filename){
             use_boottime = 0;
         }
         else {
-            error("Cannot find any way to read uptime on this system.");
+            netdata_log_error("Cannot find any way to read uptime on this system.");
             return 1;
         }
     }

--- a/libnetdata/dictionary/dictionary.c
+++ b/libnetdata/dictionary/dictionary.c
@@ -952,7 +952,7 @@ static int item_check_and_acquire_advanced(DICTIONARY *dict, DICTIONARY_ITEM *it
             if (having_index_lock) {
                 // delete it from the hashtable
                 if(hashtable_delete_unsafe(dict, item_get_name(item), item->key_len, item) == 0)
-                    error("DICTIONARY: INTERNAL ERROR VIEW: tried to delete item with name '%s', name_len %u that is not in the index", item_get_name(item), (KEY_LEN_TYPE)(item->key_len - 1));
+                    netdata_log_error("DICTIONARY: INTERNAL ERROR VIEW: tried to delete item with name '%s', name_len %u that is not in the index", item_get_name(item), (KEY_LEN_TYPE)(item->key_len - 1));
                 else
                     pointer_del(dict, item);
 
@@ -1065,8 +1065,8 @@ static size_t hashtable_destroy_unsafe(DICTIONARY *dict) {
     JError_t J_Error;
     Word_t ret = JudyHSFreeArray(&dict->index.JudyHSArray, &J_Error);
     if(unlikely(ret == (Word_t) JERR)) {
-        error("DICTIONARY: Cannot destroy JudyHS, JU_ERRNO_* == %u, ID == %d",
-              JU_ERRNO(&J_Error), JU_ERRID(&J_Error));
+        netdata_log_error("DICTIONARY: Cannot destroy JudyHS, JU_ERRNO_* == %u, ID == %d",
+                          JU_ERRNO(&J_Error), JU_ERRID(&J_Error));
     }
 
     debug(D_DICTIONARY, "Dictionary: hash table freed %lu bytes", ret);
@@ -1079,8 +1079,8 @@ static inline void **hashtable_insert_unsafe(DICTIONARY *dict, const char *name,
     JError_t J_Error;
     Pvoid_t *Rc = JudyHSIns(&dict->index.JudyHSArray, (void *)name, name_len, &J_Error);
     if (unlikely(Rc == PJERR)) {
-        error("DICTIONARY: Cannot insert entry with name '%s' to JudyHS, JU_ERRNO_* == %u, ID == %d",
-              name, JU_ERRNO(&J_Error), JU_ERRID(&J_Error));
+        netdata_log_error("DICTIONARY: Cannot insert entry with name '%s' to JudyHS, JU_ERRNO_* == %u, ID == %d",
+                          name, JU_ERRNO(&J_Error), JU_ERRID(&J_Error));
     }
 
     // if *Rc == 0, new item added to the array
@@ -1100,8 +1100,9 @@ static inline int hashtable_delete_unsafe(DICTIONARY *dict, const char *name, si
     JError_t J_Error;
     int ret = JudyHSDel(&dict->index.JudyHSArray, (void *)name, name_len, &J_Error);
     if(unlikely(ret == JERR)) {
-        error("DICTIONARY: Cannot delete entry with name '%s' from JudyHS, JU_ERRNO_* == %u, ID == %d", name,
-              JU_ERRNO(&J_Error), JU_ERRID(&J_Error));
+        netdata_log_error("DICTIONARY: Cannot delete entry with name '%s' from JudyHS, JU_ERRNO_* == %u, ID == %d",
+                          name,
+                          JU_ERRNO(&J_Error), JU_ERRID(&J_Error));
         return 0;
     }
 
@@ -1573,7 +1574,9 @@ static bool dict_item_del(DICTIONARY *dict, const char *name, ssize_t name_len) 
     }
     else {
         if(hashtable_delete_unsafe(dict, name, name_len, item) == 0)
-            error("DICTIONARY: INTERNAL ERROR: tried to delete item with name '%s', name_len %zd that is not in the index", name, name_len - 1);
+            netdata_log_error("DICTIONARY: INTERNAL ERROR: tried to delete item with name '%s', name_len %zd that is not in the index",
+                              name,
+                              name_len - 1);
         else
             pointer_del(dict, item);
 
@@ -1668,7 +1671,7 @@ static DICTIONARY_ITEM *dict_item_add_or_reset_value_and_acquire(DICTIONARY *dic
                 // view dictionary
                 // the item is already there and can be used
                 if(item->shared != master_item->shared)
-                    error("DICTIONARY: changing the master item on a view is not supported. The previous item will remain. To change the key of an item in a view, delete it and add it again.");
+                    netdata_log_error("DICTIONARY: changing the master item on a view is not supported. The previous item will remain. To change the key of an item in a view, delete it and add it again.");
             }
             else {
                 // master dictionary
@@ -2555,8 +2558,8 @@ void thread_cache_destroy(void) {
     JError_t J_Error;
     Word_t ret = JudyHSFreeArray(&thread_cache_judy_array, &J_Error);
     if(unlikely(ret == (Word_t) JERR)) {
-        error("THREAD_CACHE: Cannot destroy JudyHS, JU_ERRNO_* == %u, ID == %d",
-              JU_ERRNO(&J_Error), JU_ERRID(&J_Error));
+        netdata_log_error("THREAD_CACHE: Cannot destroy JudyHS, JU_ERRNO_* == %u, ID == %d",
+                          JU_ERRNO(&J_Error), JU_ERRID(&J_Error));
     }
 
     internal_error(true, "THREAD_CACHE: hash table freed %lu bytes", ret);

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -477,7 +477,7 @@ void ebpf_update_kernel_memory(ebpf_plugin_stats_t *report, ebpf_local_maps_t *m
     snprintfz(filename, FILENAME_MAX, "/proc/self/fdinfo/%d", map->map_fd);
     procfile *ff = procfile_open(filename, " \t", PROCFILE_FLAG_DEFAULT);
     if(unlikely(!ff)) {
-        error("Cannot open %s", filename);
+        netdata_log_error("Cannot open %s", filename);
         return;
     }
 
@@ -613,7 +613,7 @@ void ebpf_update_map_size(struct bpf_map *map, ebpf_local_maps_t *lmap, ebpf_mod
 void ebpf_update_map_type(struct bpf_map *map, ebpf_local_maps_t *w)
 {
     if (bpf_map__set_type(map, w->map_type)) {
-        error("Cannot modify map type for %s", w->name);
+        netdata_log_error("Cannot modify map type for %s", w->name);
     }
 }
 
@@ -794,7 +794,7 @@ void ebpf_update_controller(int fd, ebpf_module_t *em)
     for (key = NETDATA_CONTROLLER_APPS_ENABLED; key < end; key++) {
         int ret = bpf_map_update_elem(fd, &key, &values[key], 0);
         if (ret)
-            error("Add key(%u) for controller table failed.", key);
+            netdata_log_error("Add key(%u) for controller table failed.", key);
     }
 }
 
@@ -867,7 +867,7 @@ struct bpf_link **ebpf_load_program(char *plugins_dir, ebpf_module_t *em, int kv
     ebpf_update_legacy_map(*obj, em);
 
     if (bpf_object__load(*obj)) {
-        error("ERROR: loading BPF object file failed %s\n", lpath);
+        netdata_log_error("ERROR: loading BPF object file failed %s\n", lpath);
         bpf_object__close(*obj);
         return NULL;
     }
@@ -891,7 +891,7 @@ char *ebpf_find_symbol(char *search)
     snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, NETDATA_KALLSYMS);
     procfile *ff = procfile_open(filename, " \t", PROCFILE_FLAG_DEFAULT);
     if(unlikely(!ff)) {
-        error("Cannot open %s%s", netdata_configured_host_prefix, NETDATA_KALLSYMS);
+        netdata_log_error("Cannot open %s%s", netdata_configured_host_prefix, NETDATA_KALLSYMS);
         return ret;
     }
 
@@ -1295,7 +1295,7 @@ void ebpf_update_module(ebpf_module_t *em, struct btf *btf_file, int kver, int i
     if (!ebpf_load_config(em->cfg, filename)) {
         ebpf_mount_config_name(filename, FILENAME_MAX, ebpf_stock_config_dir, em->config_file);
         if (!ebpf_load_config(em->cfg, filename)) {
-            error("Cannot load the ebpf configuration file %s", em->config_file);
+            netdata_log_error("Cannot load the ebpf configuration file %s", em->config_file);
             return;
         }
         // If user defined data globally, we will have here EBPF_LOADED_FROM_USER, we need to consider this, to avoid
@@ -1512,7 +1512,7 @@ int ebpf_is_tracepoint_enabled(char *subsys, char *eventname)
 static int ebpf_change_tracing_values(char *subsys, char *eventname, char *value)
 {
     if (strcmp("0", value) && strcmp("1", value)) {
-        error("Invalid value given to either enable or disable a tracepoint.");
+        netdata_log_error("Invalid value given to either enable or disable a tracepoint.");
         return -1;
     }
 

--- a/libnetdata/eval/eval.c
+++ b/libnetdata/eval/eval.c
@@ -1129,14 +1129,14 @@ EVAL_EXPRESSION *expression_parse(const char *string, const char **failed_at, in
 
     if(!op) {
         unsigned long pos = s - string + 1;
-        error("failed to parse expression '%s': %s at character %lu (i.e.: '%s').", string, expression_strerror(err), pos, s);
+        netdata_log_error("failed to parse expression '%s': %s at character %lu (i.e.: '%s').", string, expression_strerror(err), pos, s);
         return NULL;
     }
 
     BUFFER *out = buffer_create(1024, NULL);
     print_parsed_as_node(out, op, &err);
     if(err != EVAL_ERROR_OK) {
-        error("failed to re-generate expression '%s' with reason: %s", string, expression_strerror(err));
+        netdata_log_error("failed to re-generate expression '%s' with reason: %s", string, expression_strerror(err));
         eval_node_free(op);
         buffer_free(out);
         return NULL;

--- a/libnetdata/health/health.c
+++ b/libnetdata/health/health.c
@@ -73,7 +73,7 @@ SILENCER *health_silencers_addparam(SILENCER *silencer, char *key, char *value) 
                 ) {
             silencer = create_silencer();
             if(!silencer) {
-                error("Cannot add a new silencer to Netdata");
+                netdata_log_error("Cannot add a new silencer to Netdata");
                 return NULL;
             }
         }

--- a/libnetdata/json/json.c
+++ b/libnetdata/json/json.c
@@ -22,13 +22,13 @@ int json_tokens = JSON_TOKENS;
 #ifdef ENABLE_JSONC
 json_object *json_tokenise(char *js) {
     if(!js) {
-        error("JSON: json string is empty.");
+        netdata_log_error("JSON: json string is empty.");
         return NULL;
     }
 
     json_object *token = json_tokener_parse(js);
     if(!token) {
-        error("JSON: Invalid json string.");
+        netdata_log_error("JSON: Invalid json string.");
         return NULL;
     }
 
@@ -39,7 +39,7 @@ jsmntok_t *json_tokenise(char *js, size_t len, size_t *count)
 {
     int n = json_tokens;
     if(!js || !len) {
-        error("JSON: json string is empty.");
+        netdata_log_error("JSON: json string is empty.");
         return NULL;
     }
 
@@ -62,12 +62,12 @@ jsmntok_t *json_tokenise(char *js, size_t len, size_t *count)
     }
 
     if (ret == JSMN_ERROR_INVAL) {
-        error("JSON: Invalid json string.");
+        netdata_log_error("JSON: Invalid json string.");
         freez(tokens);
         return NULL;
     }
     else if (ret == JSMN_ERROR_PART) {
-        error("JSON: Truncated JSON string.");
+        netdata_log_error("JSON: Truncated JSON string.");
         freez(tokens);
         return NULL;
     }

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -601,7 +601,7 @@ char *find_and_replace(const char *src, const char *find, const char *replace, c
 #define UNUSED_FUNCTION(x) UNUSED_##x
 #endif
 
-#define error_report(x, args...) do { errno = 0; error(x, ##args); } while(0)
+#define error_report(x, args...) do { errno = 0; netdata_log_error(x, ##args); } while(0)
 
 // Taken from linux kernel
 #define BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2*!!(condition)]))

--- a/libnetdata/locks/locks.c
+++ b/libnetdata/locks/locks.c
@@ -33,7 +33,7 @@ inline void netdata_thread_disable_cancelability(void) {
         int ret = pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &old);
 
         if(ret != 0)
-            error("THREAD_CANCELABILITY: pthread_setcancelstate() on thread %s returned error %d",
+            netdata_log_error("THREAD_CANCELABILITY: pthread_setcancelstate() on thread %s returned error %d",
                   netdata_thread_tag(), ret);
 
         netdata_thread_first_cancelability = old;
@@ -46,9 +46,9 @@ inline void netdata_thread_enable_cancelability(void) {
     if(unlikely(netdata_thread_nested_disables < 1)) {
         internal_fatal(true, "THREAD_CANCELABILITY: trying to enable cancelability, but it was not not disabled");
 
-        error("THREAD_CANCELABILITY: netdata_thread_enable_cancelability(): invalid thread cancelability count %d "
-              "on thread %s - results will be undefined - please report this!",
-            netdata_thread_nested_disables, netdata_thread_tag());
+        netdata_log_error("THREAD_CANCELABILITY: netdata_thread_enable_cancelability(): invalid thread cancelability count %d "
+                          "on thread %s - results will be undefined - please report this!",
+                          netdata_thread_nested_disables, netdata_thread_tag());
 
         netdata_thread_nested_disables = 1;
     }
@@ -57,15 +57,18 @@ inline void netdata_thread_enable_cancelability(void) {
         int old = 1;
         int ret = pthread_setcancelstate(netdata_thread_first_cancelability, &old);
         if(ret != 0)
-            error("THREAD_CANCELABILITY: pthread_setcancelstate() on thread %s returned error %d", netdata_thread_tag(), ret);
+            netdata_log_error("THREAD_CANCELABILITY: pthread_setcancelstate() on thread %s returned error %d",
+                              netdata_thread_tag(),
+                              ret);
         else {
             if(old != PTHREAD_CANCEL_DISABLE) {
                 internal_fatal(true, "THREAD_CANCELABILITY: invalid old state cancelability");
 
-                error("THREAD_CANCELABILITY: netdata_thread_enable_cancelability(): old thread cancelability "
-                      "on thread %s was changed, expected DISABLED (%d), found %s (%d) - please report this!",
-                      netdata_thread_tag(), PTHREAD_CANCEL_DISABLE,
-                      (old == PTHREAD_CANCEL_ENABLE) ? "ENABLED" : "UNKNOWN", old);
+                netdata_log_error("THREAD_CANCELABILITY: netdata_thread_enable_cancelability(): old thread cancelability "
+                                  "on thread %s was changed, expected DISABLED (%d), found %s (%d) - please report this!",
+                                  netdata_thread_tag(), PTHREAD_CANCEL_DISABLE,
+                                  (old == PTHREAD_CANCEL_ENABLE) ? "ENABLED" : "UNKNOWN",
+                                  old);
             }
         }
     }
@@ -79,14 +82,14 @@ inline void netdata_thread_enable_cancelability(void) {
 int __netdata_mutex_init(netdata_mutex_t *mutex) {
     int ret = pthread_mutex_init(mutex, NULL);
     if(unlikely(ret != 0))
-        error("MUTEX_LOCK: failed to initialize (code %d).", ret);
+        netdata_log_error("MUTEX_LOCK: failed to initialize (code %d).", ret);
     return ret;
 }
 
 int __netdata_mutex_destroy(netdata_mutex_t *mutex) {
     int ret = pthread_mutex_destroy(mutex);
     if(unlikely(ret != 0))
-        error("MUTEX_LOCK: failed to destroy (code %d).", ret);
+        netdata_log_error("MUTEX_LOCK: failed to destroy (code %d).", ret);
     return ret;
 }
 
@@ -96,7 +99,7 @@ int __netdata_mutex_lock(netdata_mutex_t *mutex) {
     int ret = pthread_mutex_lock(mutex);
     if(unlikely(ret != 0)) {
         netdata_thread_enable_cancelability();
-        error("MUTEX_LOCK: failed to get lock (code %d)", ret);
+        netdata_log_error("MUTEX_LOCK: failed to get lock (code %d)", ret);
     }
     else
         netdata_locks_acquired_mutexes++;
@@ -119,7 +122,7 @@ int __netdata_mutex_trylock(netdata_mutex_t *mutex) {
 int __netdata_mutex_unlock(netdata_mutex_t *mutex) {
     int ret = pthread_mutex_unlock(mutex);
     if(unlikely(ret != 0))
-        error("MUTEX_LOCK: failed to unlock (code %d).", ret);
+        netdata_log_error("MUTEX_LOCK: failed to unlock (code %d).", ret);
     else {
         netdata_locks_acquired_mutexes--;
         netdata_thread_enable_cancelability();
@@ -211,14 +214,14 @@ int netdata_mutex_unlock_debug(const char *file __maybe_unused, const char *func
 int __netdata_rwlock_destroy(netdata_rwlock_t *rwlock) {
     int ret = pthread_rwlock_destroy(&rwlock->rwlock_t);
     if(unlikely(ret != 0))
-        error("RW_LOCK: failed to destroy lock (code %d)", ret);
+        netdata_log_error("RW_LOCK: failed to destroy lock (code %d)", ret);
     return ret;
 }
 
 int __netdata_rwlock_init(netdata_rwlock_t *rwlock) {
     int ret = pthread_rwlock_init(&rwlock->rwlock_t, NULL);
     if(unlikely(ret != 0))
-        error("RW_LOCK: failed to initialize lock (code %d)", ret);
+        netdata_log_error("RW_LOCK: failed to initialize lock (code %d)", ret);
     return ret;
 }
 
@@ -228,7 +231,7 @@ int __netdata_rwlock_rdlock(netdata_rwlock_t *rwlock) {
     int ret = pthread_rwlock_rdlock(&rwlock->rwlock_t);
     if(unlikely(ret != 0)) {
         netdata_thread_enable_cancelability();
-        error("RW_LOCK: failed to obtain read lock (code %d)", ret);
+        netdata_log_error("RW_LOCK: failed to obtain read lock (code %d)", ret);
     }
     else
         netdata_locks_acquired_rwlocks++;
@@ -241,7 +244,7 @@ int __netdata_rwlock_wrlock(netdata_rwlock_t *rwlock) {
 
     int ret = pthread_rwlock_wrlock(&rwlock->rwlock_t);
     if(unlikely(ret != 0)) {
-        error("RW_LOCK: failed to obtain write lock (code %d)", ret);
+        netdata_log_error("RW_LOCK: failed to obtain write lock (code %d)", ret);
         netdata_thread_enable_cancelability();
     }
     else
@@ -253,7 +256,7 @@ int __netdata_rwlock_wrlock(netdata_rwlock_t *rwlock) {
 int __netdata_rwlock_unlock(netdata_rwlock_t *rwlock) {
     int ret = pthread_rwlock_unlock(&rwlock->rwlock_t);
     if(unlikely(ret != 0))
-        error("RW_LOCK: failed to release lock (code %d)", ret);
+        netdata_log_error("RW_LOCK: failed to release lock (code %d)", ret);
     else {
         netdata_thread_enable_cancelability();
         netdata_locks_acquired_rwlocks--;

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -530,7 +530,7 @@ static FILE *open_log_file(int fd, FILE *fp, const char *filename, int *enabled_
     else {
         f = open(filename, O_WRONLY | O_APPEND | O_CREAT, 0664);
         if(f == -1) {
-            error("Cannot open file '%s'. Leaving %d to its default.", filename, fd);
+            netdata_log_error("Cannot open file '%s'. Leaving %d to its default.", filename, fd);
             if(fd_ptr) *fd_ptr = fd;
             return fp;
         }
@@ -550,7 +550,7 @@ static FILE *open_log_file(int fd, FILE *fp, const char *filename, int *enabled_
         // it automatically closes
         int t = dup2(f, fd);
         if (t == -1) {
-            error("Cannot dup2() new fd %d to old fd %d for '%s'", f, fd, filename);
+            netdata_log_error("Cannot dup2() new fd %d to old fd %d for '%s'", f, fd, filename);
             close(f);
             if(fd_ptr) *fd_ptr = fd;
             return fp;
@@ -563,10 +563,10 @@ static FILE *open_log_file(int fd, FILE *fp, const char *filename, int *enabled_
     if(!fp) {
         fp = fdopen(fd, "a");
         if (!fp)
-            error("Cannot fdopen() fd %d ('%s')", fd, filename);
+            netdata_log_error("Cannot fdopen() fd %d ('%s')", fd, filename);
         else {
             if (setvbuf(fp, NULL, _IOLBF, 0) != 0)
-                error("Cannot set line buffering on fd %d ('%s')", fd, filename);
+                netdata_log_error("Cannot set line buffering on fd %d ('%s')", fd, filename);
         }
     }
 

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -121,7 +121,7 @@ typedef struct error_with_limit {
 #define netdata_log_info(args...)    info_int(0, __FILE__, __FUNCTION__, __LINE__, ##args)
 #define collector_info(args...)    info_int(1, __FILE__, __FUNCTION__, __LINE__, ##args)
 #define infoerr(args...) error_int(0, "INFO", __FILE__, __FUNCTION__, __LINE__, ##args)
-#define error(args...)   error_int(0, "ERROR", __FILE__, __FUNCTION__, __LINE__, ##args)
+#define netdata_log_error(args...)   error_int(0, "ERROR", __FILE__, __FUNCTION__, __LINE__, ##args)
 #define collector_infoerr(args...) error_int(1, "INFO", __FILE__, __FUNCTION__, __LINE__, ##args)
 #define collector_error(args...)   error_int(1, "ERROR", __FILE__, __FUNCTION__, __LINE__, ##args)
 #define error_limit(erl, args...)   error_limit_int(erl, "ERROR", __FILE__, __FUNCTION__, __LINE__, ##args)

--- a/libnetdata/onewayalloc/onewayalloc.c
+++ b/libnetdata/onewayalloc/onewayalloc.c
@@ -176,7 +176,7 @@ void onewayalloc_freez(ONEWAYALLOC *owa __maybe_unused, const void *ptr __maybe_
 
     // not found - it is not ours
     // let's free it with the system allocator
-    error("ONEWAYALLOC: request to free address 0x%p that is not allocated by this OWA", ptr);
+    netdata_log_error("ONEWAYALLOC: request to free address 0x%p that is not allocated by this OWA", ptr);
 #endif
 
     return;

--- a/libnetdata/os.c
+++ b/libnetdata/os.c
@@ -28,7 +28,7 @@ long get_system_cpus_with_cache(bool cache, bool for_netdata) {
     bool error = false;
 
     if (unlikely(GETSYSCTL_BY_NAME(HW_CPU_NAME, tmp_processors)))
-        error = true;
+        netdata_log_error = true;
     else
         processors[index] = tmp_processors;
 
@@ -36,7 +36,7 @@ long get_system_cpus_with_cache(bool cache, bool for_netdata) {
         processors[index] = 1;
 
         if(error)
-            error("Assuming system has %d processors.", processors[index]);
+            netdata_log_error("Assuming system has %d processors.", processors[index]);
     }
 
     return processors[index];
@@ -49,14 +49,14 @@ long get_system_cpus_with_cache(bool cache, bool for_netdata) {
     procfile *ff = procfile_open(filename, NULL, PROCFILE_FLAG_DEFAULT);
     if(!ff) {
         processors[index] = 1;
-        error("Cannot open file '%s'. Assuming system has %ld processors.", filename, processors[index]);
+        netdata_log_error("Cannot open file '%s'. Assuming system has %ld processors.", filename, processors[index]);
         return processors[index];
     }
 
     ff = procfile_readall(ff);
     if(!ff) {
         processors[index] = 1;
-        error("Cannot open file '%s'. Assuming system has %ld processors.", filename, processors[index]);
+        netdata_log_error("Cannot open file '%s'. Assuming system has %ld processors.", filename, processors[index]);
         return processors[index];
     }
 
@@ -93,7 +93,7 @@ pid_t get_system_pid_max(void) {
 
         if (unlikely(GETSYSCTL_BY_NAME("kern.pid_max", tmp_pid_max))) {
             pid_max = 99999;
-            error("Assuming system's maximum pid is %d.", pid_max);
+            netdata_log_error("Assuming system's maximum pid is %d.", pid_max);
         } else {
             pid_max = tmp_pid_max;
         }
@@ -110,12 +110,12 @@ pid_t get_system_pid_max(void) {
 
     unsigned long long max = 0;
     if(read_single_number_file(filename, &max) != 0) {
-        error("Cannot open file '%s'. Assuming system supports %d pids.", filename, pid_max);
+        netdata_log_error("Cannot open file '%s'. Assuming system supports %d pids.", filename, pid_max);
         return pid_max;
     }
 
     if(!max) {
-        error("Cannot parse file '%s'. Assuming system supports %d pids.", filename, pid_max);
+        netdata_log_error("Cannot parse file '%s'. Assuming system supports %d pids.", filename, pid_max);
         return pid_max;
     }
 
@@ -130,7 +130,7 @@ void get_system_HZ(void) {
     long ticks;
 
     if ((ticks = sysconf(_SC_CLK_TCK)) == -1) {
-        error("Cannot get system clock ticks");
+        netdata_log_error("Cannot get system clock ticks");
     }
 
     system_hz = (unsigned int) ticks;
@@ -197,11 +197,11 @@ int getsysctl_by_name(const char *name, void *ptr, size_t len) {
     size_t nlen = len;
 
     if (unlikely(sysctlbyname(name, ptr, &nlen, NULL, 0) == -1)) {
-        error("FREEBSD: sysctl(%s...) failed: %s", name, strerror(errno));
+        netdata_log_error("FREEBSD: sysctl(%s...) failed: %s", name, strerror(errno));
         return 1;
     }
     if (unlikely(nlen != len)) {
-        error("FREEBSD: sysctl(%s...) expected %lu, got %lu", name, (unsigned long)len, (unsigned long)nlen);
+        netdata_log_error("FREEBSD: sysctl(%s...) expected %lu, got %lu", name, (unsigned long)len, (unsigned long)nlen);
         return 1;
     }
     return 0;
@@ -215,11 +215,11 @@ int getsysctl_simple(const char *name, int *mib, size_t miblen, void *ptr, size_
             return 1;
 
     if (unlikely(sysctl(mib, miblen, ptr, &nlen, NULL, 0) == -1)) {
-        error("FREEBSD: sysctl(%s...) failed: %s", name, strerror(errno));
+        netdata_log_error("FREEBSD: sysctl(%s...) failed: %s", name, strerror(errno));
         return 1;
     }
     if (unlikely(nlen != len)) {
-        error("FREEBSD: sysctl(%s...) expected %lu, got %lu", name, (unsigned long)len, (unsigned long)nlen);
+        netdata_log_error("FREEBSD: sysctl(%s...) expected %lu, got %lu", name, (unsigned long)len, (unsigned long)nlen);
         return 1;
     }
 
@@ -234,11 +234,11 @@ int getsysctl(const char *name, int *mib, size_t miblen, void *ptr, size_t *len)
             return 1;
 
     if (unlikely(sysctl(mib, miblen, ptr, len, NULL, 0) == -1)) {
-        error("FREEBSD: sysctl(%s...) failed: %s", name, strerror(errno));
+        netdata_log_error("FREEBSD: sysctl(%s...) failed: %s", name, strerror(errno));
         return 1;
     }
     if (unlikely(ptr != NULL && nlen != *len)) {
-        error("FREEBSD: sysctl(%s...) expected %lu, got %lu", name, (unsigned long)*len, (unsigned long)nlen);
+        netdata_log_error("FREEBSD: sysctl(%s...) expected %lu, got %lu", name, (unsigned long)*len, (unsigned long)nlen);
         return 1;
     }
 
@@ -249,11 +249,11 @@ int getsysctl_mib(const char *name, int *mib, size_t len) {
     size_t nlen = len;
 
     if (unlikely(sysctlnametomib(name, mib, &nlen) == -1)) {
-        error("FREEBSD: sysctl(%s...) failed: %s", name, strerror(errno));
+        netdata_log_error("FREEBSD: sysctl(%s...) failed: %s", name, strerror(errno));
         return 1;
     }
     if (unlikely(nlen != len)) {
-        error("FREEBSD: sysctl(%s...) expected %lu, got %lu", name, (unsigned long)len, (unsigned long)nlen);
+        netdata_log_error("FREEBSD: sysctl(%s...) expected %lu, got %lu", name, (unsigned long)len, (unsigned long)nlen);
         return 1;
     }
     return 0;
@@ -274,11 +274,11 @@ int getsysctl_by_name(const char *name, void *ptr, size_t len) {
     size_t nlen = len;
 
     if (unlikely(sysctlbyname(name, ptr, &nlen, NULL, 0) == -1)) {
-        error("MACOS: sysctl(%s...) failed: %s", name, strerror(errno));
+        netdata_log_error("MACOS: sysctl(%s...) failed: %s", name, strerror(errno));
         return 1;
     }
     if (unlikely(nlen != len)) {
-        error("MACOS: sysctl(%s...) expected %lu, got %lu", name, (unsigned long)len, (unsigned long)nlen);
+        netdata_log_error("MACOS: sysctl(%s...) expected %lu, got %lu", name, (unsigned long)len, (unsigned long)nlen);
         return 1;
     }
     return 0;

--- a/libnetdata/procfile/procfile.c
+++ b/libnetdata/procfile/procfile.c
@@ -297,7 +297,8 @@ procfile *procfile_readall(procfile *ff) {
         r = read(ff->fd, &ff->data[s], ff->size - s);
         if(unlikely(r == -1)) {
             if(unlikely(!(ff->flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) collector_error(PF_PREFIX ": Cannot read from file '%s' on fd %d", procfile_filename(ff), ff->fd);
-            else if(unlikely(ff->flags & PROCFILE_FLAG_ERROR_ON_ERROR_LOG)) error(PF_PREFIX ": Cannot read from file '%s' on fd %d", procfile_filename(ff), ff->fd);
+            else if(unlikely(ff->flags & PROCFILE_FLAG_ERROR_ON_ERROR_LOG))
+                netdata_log_error(PF_PREFIX ": Cannot read from file '%s' on fd %d", procfile_filename(ff), ff->fd);
             procfile_close(ff);
             return NULL;
         }
@@ -308,7 +309,8 @@ procfile *procfile_readall(procfile *ff) {
     // debug(D_PROCFILE, "Rewinding file '%s'", ff->filename);
     if(unlikely(lseek(ff->fd, 0, SEEK_SET) == -1)) {
         if(unlikely(!(ff->flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) collector_error(PF_PREFIX ": Cannot rewind on file '%s'.", procfile_filename(ff));
-        else if(unlikely(ff->flags & PROCFILE_FLAG_ERROR_ON_ERROR_LOG)) error(PF_PREFIX ": Cannot rewind on file '%s'.", procfile_filename(ff));
+        else if(unlikely(ff->flags & PROCFILE_FLAG_ERROR_ON_ERROR_LOG))
+            netdata_log_error(PF_PREFIX ": Cannot rewind on file '%s'.", procfile_filename(ff));
         procfile_close(ff);
         return NULL;
     }
@@ -406,7 +408,8 @@ procfile *procfile_open(const char *filename, const char *separators, uint32_t f
     int fd = open(filename, procfile_open_flags, 0666);
     if(unlikely(fd == -1)) {
         if(unlikely(!(flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) collector_error(PF_PREFIX ": Cannot open file '%s'", filename);
-        else if(unlikely(flags & PROCFILE_FLAG_ERROR_ON_ERROR_LOG)) error(PF_PREFIX ": Cannot open file '%s'", filename);
+        else if(unlikely(flags & PROCFILE_FLAG_ERROR_ON_ERROR_LOG))
+            netdata_log_error(PF_PREFIX ": Cannot open file '%s'", filename);
         return NULL;
     }
 

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -429,7 +429,7 @@ void netdata_ssl_initialize_openssl() {
 #else
 
     if (OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG, NULL) != 1) {
-        error("SSL library cannot be initialized.");
+        netdata_log_error("SSL library cannot be initialized.");
     }
 
 #endif
@@ -516,7 +516,7 @@ static SSL_CTX * netdata_ssl_create_server_ctx(unsigned long mode) {
 #if OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110
 	ctx = SSL_CTX_new(SSLv23_server_method());
     if (!ctx) {
-		error("Cannot create a new SSL context, netdata won't encrypt communication");
+		netdata_log_error("Cannot create a new SSL context, netdata won't encrypt communication");
         return NULL;
     }
 
@@ -524,7 +524,7 @@ static SSL_CTX * netdata_ssl_create_server_ctx(unsigned long mode) {
 #else
     ctx = SSL_CTX_new(TLS_server_method());
     if (!ctx) {
-		error("Cannot create a new SSL context, netdata won't encrypt communication");
+        netdata_log_error("Cannot create a new SSL context, netdata won't encrypt communication");
         return NULL;
     }
 
@@ -539,7 +539,7 @@ static SSL_CTX * netdata_ssl_create_server_ctx(unsigned long mode) {
 
     if(tls_ciphers  && strcmp(tls_ciphers, "none") != 0) {
         if (!SSL_CTX_set_cipher_list(ctx, tls_ciphers)) {
-            error("SSL error. cannot set the cipher list");
+            netdata_log_error("SSL error. cannot set the cipher list");
         }
     }
 #endif
@@ -548,7 +548,7 @@ static SSL_CTX * netdata_ssl_create_server_ctx(unsigned long mode) {
 
     if (!SSL_CTX_check_private_key(ctx)) {
         ERR_error_string_n(ERR_get_error(),lerror,sizeof(lerror));
-		error("SSL cannot check the private key: %s",lerror);
+        netdata_log_error("SSL cannot check the private key: %s",lerror);
         SSL_CTX_free(ctx);
         return NULL;
     }
@@ -680,7 +680,7 @@ int security_test_certificate(SSL *ssl) {
     {
         char error[512];
         ERR_error_string_n(ERR_get_error(), error, sizeof(error));
-        error("SSL RFC4158 check:  We have a invalid certificate, the tests result with %ld and message %s", status, error);
+        netdata_log_error("SSL RFC4158 check:  We have a invalid certificate, the tests result with %ld and message %s", status, error);
         ret = -1;
     } else {
         ret = 0;

--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -124,7 +124,7 @@ int sock_setnonblock(int fd) {
 
     int ret = fcntl(fd, F_SETFL, flags);
     if(ret < 0)
-        error("Failed to set O_NONBLOCK on socket %d", fd);
+        netdata_log_error("Failed to set O_NONBLOCK on socket %d", fd);
 
     return ret;
 }
@@ -137,7 +137,7 @@ int sock_delnonblock(int fd) {
 
     int ret = fcntl(fd, F_SETFL, flags);
     if(ret < 0)
-        error("Failed to remove O_NONBLOCK on socket %d", fd);
+        netdata_log_error("Failed to remove O_NONBLOCK on socket %d", fd);
 
     return ret;
 }
@@ -146,7 +146,7 @@ int sock_setreuse(int fd, int reuse) {
     int ret = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
 
     if(ret == -1)
-        error("Failed to set SO_REUSEADDR on socket %d", fd);
+        netdata_log_error("Failed to set SO_REUSEADDR on socket %d", fd);
 
     return ret;
 }
@@ -157,7 +157,7 @@ int sock_setreuse_port(int fd, int reuse) {
 #ifdef SO_REUSEPORT
     ret = setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &reuse, sizeof(reuse));
     if(ret == -1 && errno != ENOPROTOOPT)
-        error("failed to set SO_REUSEPORT on socket %d", fd);
+        netdata_log_error("failed to set SO_REUSEPORT on socket %d", fd);
 #else
     ret = -1;
 #endif
@@ -171,7 +171,7 @@ int sock_enlarge_in(int fd) {
     ret = setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &bs, sizeof(bs));
 
     if(ret == -1)
-        error("Failed to set SO_RCVBUF on socket %d", fd);
+        netdata_log_error("Failed to set SO_RCVBUF on socket %d", fd);
 
     return ret;
 }
@@ -181,7 +181,7 @@ int sock_enlarge_out(int fd) {
     ret = setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &bs, sizeof(bs));
 
     if(ret == -1)
-        error("Failed to set SO_SNDBUF on socket %d", fd);
+        netdata_log_error("Failed to set SO_SNDBUF on socket %d", fd);
 
     return ret;
 }
@@ -220,7 +220,7 @@ int create_listen_socket_unix(const char *path, int listen_backlog) {
 
     sock = socket(AF_UNIX, SOCK_STREAM, 0);
     if(sock < 0) {
-        error("LISTENER: UNIX socket() on path '%s' failed.", path);
+        netdata_log_error("LISTENER: UNIX socket() on path '%s' failed.", path);
         return -1;
     }
 
@@ -234,22 +234,22 @@ int create_listen_socket_unix(const char *path, int listen_backlog) {
 
     errno = 0;
     if (unlink(path) == -1 && errno != ENOENT)
-        error("LISTENER: failed to remove existing (probably obsolete or left-over) file on UNIX socket path '%s'.", path);
+        netdata_log_error("LISTENER: failed to remove existing (probably obsolete or left-over) file on UNIX socket path '%s'.", path);
 
     if(bind (sock, (struct sockaddr *) &name, sizeof (name)) < 0) {
         close(sock);
-        error("LISTENER: UNIX bind() on path '%s' failed.", path);
+        netdata_log_error("LISTENER: UNIX bind() on path '%s' failed.", path);
         return -1;
     }
 
     // we have to chmod this to 0777 so that the client will be able
     // to read from and write to this socket.
     if(chmod(path, 0777) == -1)
-        error("LISTENER: failed to chmod() socket file '%s'.", path);
+        netdata_log_error("LISTENER: failed to chmod() socket file '%s'.", path);
 
     if(listen(sock, listen_backlog) < 0) {
         close(sock);
-        error("LISTENER: UNIX listen() on path '%s' failed.", path);
+        netdata_log_error("LISTENER: UNIX listen() on path '%s' failed.", path);
         return -1;
     }
 
@@ -264,7 +264,7 @@ int create_listen_socket4(int socktype, const char *ip, uint16_t port, int liste
 
     sock = socket(AF_INET, socktype, 0);
     if(sock < 0) {
-        error("LISTENER: IPv4 socket() on ip '%s' port %d, socktype %d failed.", ip, port, socktype);
+        netdata_log_error("LISTENER: IPv4 socket() on ip '%s' port %d, socktype %d failed.", ip, port, socktype);
         return -1;
     }
 
@@ -280,20 +280,20 @@ int create_listen_socket4(int socktype, const char *ip, uint16_t port, int liste
 
     int ret = inet_pton(AF_INET, ip, (void *)&name.sin_addr.s_addr);
     if(ret != 1) {
-        error("LISTENER: Failed to convert IP '%s' to a valid IPv4 address.", ip);
+        netdata_log_error("LISTENER: Failed to convert IP '%s' to a valid IPv4 address.", ip);
         close(sock);
         return -1;
     }
 
     if(bind (sock, (struct sockaddr *) &name, sizeof (name)) < 0) {
         close(sock);
-        error("LISTENER: IPv4 bind() on ip '%s' port %d, socktype %d failed.", ip, port, socktype);
+        netdata_log_error("LISTENER: IPv4 bind() on ip '%s' port %d, socktype %d failed.", ip, port, socktype);
         return -1;
     }
 
     if(socktype == SOCK_STREAM && listen(sock, listen_backlog) < 0) {
         close(sock);
-        error("LISTENER: IPv4 listen() on ip '%s' port %d, socktype %d failed.", ip, port, socktype);
+        netdata_log_error("LISTENER: IPv4 listen() on ip '%s' port %d, socktype %d failed.", ip, port, socktype);
         return -1;
     }
 
@@ -309,7 +309,7 @@ int create_listen_socket6(int socktype, uint32_t scope_id, const char *ip, int p
 
     sock = socket(AF_INET6, socktype, 0);
     if (sock < 0) {
-        error("LISTENER: IPv6 socket() on ip '%s' port %d, socktype %d, failed.", ip, port, socktype);
+        netdata_log_error("LISTENER: IPv6 socket() on ip '%s' port %d, socktype %d, failed.", ip, port, socktype);
         return -1;
     }
 
@@ -320,7 +320,7 @@ int create_listen_socket6(int socktype, uint32_t scope_id, const char *ip, int p
 
     /* IPv6 only */
     if(setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (void*)&ipv6only, sizeof(ipv6only)) != 0)
-        error("LISTENER: Cannot set IPV6_V6ONLY on ip '%s' port %d, socktype %d.", ip, port, socktype);
+        netdata_log_error("LISTENER: Cannot set IPV6_V6ONLY on ip '%s' port %d, socktype %d.", ip, port, socktype);
 
     struct sockaddr_in6 name;
     memset(&name, 0, sizeof(struct sockaddr_in6));
@@ -330,7 +330,7 @@ int create_listen_socket6(int socktype, uint32_t scope_id, const char *ip, int p
 
     int ret = inet_pton(AF_INET6, ip, (void *)&name.sin6_addr.s6_addr);
     if(ret != 1) {
-        error("LISTENER: Failed to convert IP '%s' to a valid IPv6 address.", ip);
+        netdata_log_error("LISTENER: Failed to convert IP '%s' to a valid IPv6 address.", ip);
         close(sock);
         return -1;
     }
@@ -339,13 +339,13 @@ int create_listen_socket6(int socktype, uint32_t scope_id, const char *ip, int p
 
     if (bind (sock, (struct sockaddr *) &name, sizeof (name)) < 0) {
         close(sock);
-        error("LISTENER: IPv6 bind() on ip '%s' port %d, socktype %d failed.", ip, port, socktype);
+        netdata_log_error("LISTENER: IPv6 bind() on ip '%s' port %d, socktype %d failed.", ip, port, socktype);
         return -1;
     }
 
     if (socktype == SOCK_STREAM && listen(sock, listen_backlog) < 0) {
         close(sock);
-        error("LISTENER: IPv6 listen() on ip '%s' port %d, socktype %d failed.", ip, port, socktype);
+        netdata_log_error("LISTENER: IPv6 listen() on ip '%s' port %d, socktype %d failed.", ip, port, socktype);
         return -1;
     }
 
@@ -355,7 +355,7 @@ int create_listen_socket6(int socktype, uint32_t scope_id, const char *ip, int p
 
 static inline int listen_sockets_add(LISTEN_SOCKETS *sockets, int fd, int family, int socktype, const char *protocol, const char *ip, uint16_t port, int acl_flags) {
     if(sockets->opened >= MAX_LISTEN_FDS) {
-        error("LISTENER: Too many listening sockets. Failed to add listening %s socket at ip '%s' port %d, protocol %s, socktype %d", protocol, ip, port, protocol, socktype);
+        netdata_log_error("LISTENER: Too many listening sockets. Failed to add listening %s socket at ip '%s' port %d, protocol %s, socktype %d", protocol, ip, port, protocol, socktype);
         close(fd);
         return -1;
     }
@@ -485,7 +485,7 @@ static inline int bind_to_this(LISTEN_SOCKETS *sockets, const char *definition, 
         protocol_str = "unix";
         int fd = create_listen_socket_unix(path, listen_backlog);
         if (fd == -1) {
-            error("LISTENER: Cannot create unix socket '%s'", path);
+            netdata_log_error("LISTENER: Cannot create unix socket '%s'", path);
             sockets->failed++;
         } else {
             acl_flags = WEB_CLIENT_ACL_DASHBOARD | WEB_CLIENT_ACL_REGISTRY | WEB_CLIENT_ACL_BADGE | WEB_CLIENT_ACL_MGMT | WEB_CLIENT_ACL_NETDATACONF | WEB_CLIENT_ACL_STREAMING | WEB_CLIENT_ACL_SSL_DEFAULT;
@@ -551,7 +551,7 @@ static inline int bind_to_this(LISTEN_SOCKETS *sockets, const char *definition, 
     if(*interface) {
         scope_id = if_nametoindex(interface);
         if(!scope_id)
-            error("LISTENER: Cannot find a network interface named '%s'. Continuing with limiting the network interface", interface);
+            netdata_log_error("LISTENER: Cannot find a network interface named '%s'. Continuing with limiting the network interface", interface);
     }
 
     if(!*ip || *ip == '*' || !strcmp(ip, "any") || !strcmp(ip, "all"))
@@ -571,7 +571,7 @@ static inline int bind_to_this(LISTEN_SOCKETS *sockets, const char *definition, 
 
     int r = getaddrinfo(ip, port, &hints, &result);
     if (r != 0) {
-        error("LISTENER: getaddrinfo('%s', '%s'): %s\n", ip, port, gai_strerror(r));
+        netdata_log_error("LISTENER: getaddrinfo('%s', '%s'): %s\n", ip, port, gai_strerror(r));
         return -1;
     }
 
@@ -608,7 +608,7 @@ static inline int bind_to_this(LISTEN_SOCKETS *sockets, const char *definition, 
         }
 
         if (fd == -1) {
-            error("LISTENER: Cannot bind to ip '%s', port %d", rip, rport);
+            netdata_log_error("LISTENER: Cannot bind to ip '%s', port %d", rip, rport);
             sockets->failed++;
         }
         else {
@@ -630,7 +630,7 @@ int listen_sockets_setup(LISTEN_SOCKETS *sockets) {
     long long int old_port = sockets->default_port;
     long long int new_port = appconfig_get_number(sockets->config, sockets->config_section, "default port", sockets->default_port);
     if(new_port < 1 || new_port > 65535) {
-        error("LISTENER: Invalid listen port %lld given. Defaulting to %lld.", new_port, old_port);
+        netdata_log_error("LISTENER: Invalid listen port %lld given. Defaulting to %lld.", new_port, old_port);
         sockets->default_port = (uint16_t) appconfig_set_number(sockets->config, sockets->config_section, "default port", old_port);
     }
     else sockets->default_port = (uint16_t)new_port;
@@ -677,13 +677,13 @@ int listen_sockets_setup(LISTEN_SOCKETS *sockets) {
 static inline int connect_to_unix(const char *path, struct timeval *timeout) {
     int fd = socket(AF_UNIX, SOCK_STREAM, 0);
     if(fd == -1) {
-        error("Failed to create UNIX socket() for '%s'", path);
+        netdata_log_error("Failed to create UNIX socket() for '%s'", path);
         return -1;
     }
 
     if(timeout) {
         if(setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, (char *) timeout, sizeof(struct timeval)) < 0)
-            error("Failed to set timeout on UNIX socket '%s'", path);
+            netdata_log_error("Failed to set timeout on UNIX socket '%s'", path);
     }
 
     struct sockaddr_un addr;
@@ -692,7 +692,7 @@ static inline int connect_to_unix(const char *path, struct timeval *timeout) {
     strncpy(addr.sun_path, path, sizeof(addr.sun_path)-1);
 
     if (connect(fd, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
-        error("Cannot connect to UNIX socket on path '%s'.", path);
+        netdata_log_error("Cannot connect to UNIX socket on path '%s'.", path);
         close(fd);
         return -1;
     }
@@ -723,7 +723,7 @@ int connect_to_this_ip46(int protocol, int socktype, const char *host, uint32_t 
 
     int ai_err = getaddrinfo(host, service, &hints, &ai_head);
     if (ai_err != 0) {
-        error("Cannot resolve host '%s', port '%s': %s", host, service, gai_strerror(ai_err));
+        netdata_log_error("Cannot resolve host '%s', port '%s': %s", host, service, gai_strerror(ai_err));
         return -1;
     }
 
@@ -804,7 +804,7 @@ int connect_to_this_ip46(int protocol, int socktype, const char *host, uint32_t 
         if(fd != -1) {
             if(timeout) {
                 if(setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, (char *) timeout, sizeof(struct timeval)) < 0)
-                    error("Failed to set timeout on the socket to ip '%s' port '%s'", hostBfr, servBfr);
+                    netdata_log_error("Failed to set timeout on the socket to ip '%s' port '%s'", hostBfr, servBfr);
             }
 
             errno = 0;
@@ -828,26 +828,26 @@ int connect_to_this_ip46(int protocol, int socktype, const char *host, uint32_t 
                         }
                         else {
                             // This means that the socket is in error. We will close it and set fd to -1
-                            error("Failed to connect to '%s', port '%s'.", hostBfr, servBfr);
+                            netdata_log_error("Failed to connect to '%s', port '%s'.", hostBfr, servBfr);
                             close(fd);
                             fd = -1;
                         }
                     }
                     else if (ret == 0) {
                         // poll() timed out, the connection is not established within the specified timeout.
-                        error("Timed out while connecting to '%s', port '%s'.", hostBfr, servBfr);
+                        netdata_log_error("Timed out while connecting to '%s', port '%s'.", hostBfr, servBfr);
                         close(fd);
                         fd = -1;
                     }
                     else {
                         // poll() returned an error.
-                        error("Failed to connect to '%s', port '%s'. poll() returned %d", hostBfr, servBfr, ret);
+                        netdata_log_error("Failed to connect to '%s', port '%s'. poll() returned %d", hostBfr, servBfr, ret);
                         close(fd);
                         fd = -1;
                     }
                 }
                 else {
-                    error("Failed to connect to '%s', port '%s'", hostBfr, servBfr);
+                    netdata_log_error("Failed to connect to '%s', port '%s'", hostBfr, servBfr);
                     close(fd);
                     fd = -1;
                 }
@@ -933,14 +933,14 @@ int connect_to_this(const char *definition, int default_port, struct timeval *ti
     debug(D_CONNECT_TO, "Attempting connection to host = '%s', service = '%s', interface = '%s', protocol = %d (tcp = %d, udp = %d)", host, service, interface, protocol, IPPROTO_TCP, IPPROTO_UDP);
 
     if(!*host) {
-        error("Definition '%s' does not specify a host.", definition);
+        netdata_log_error("Definition '%s' does not specify a host.", definition);
         return -1;
     }
 
     if(*interface) {
         scope_id = if_nametoindex(interface);
         if(!scope_id)
-            error("Cannot find a network interface named '%s'. Continuing with limiting the network interface", interface);
+            netdata_log_error("Cannot find a network interface named '%s'. Continuing with limiting the network interface", interface);
     }
 
     if(!*service)
@@ -1125,7 +1125,7 @@ ssize_t send_timeout(int sockfd, void *buf, size_t len, int flags, int timeout) 
             return netdata_ssl_write(ssl, buf, len);
         }
         else {
-            error("cannot write to SSL connection - connection is not ready.");
+            netdata_log_error("cannot write to SSL connection - connection is not ready.");
             return -1;
         }
     }
@@ -1204,7 +1204,7 @@ int connection_allowed(int fd, char *client_ip, char *client_host, size_t hostsi
         if (err != 0 ||
             (err = getnameinfo((struct sockaddr *)&sadr, addrlen, client_host, (socklen_t)hostsize,
                               NULL, 0, NI_NAMEREQD)) != 0) {
-            error("Incoming %s on '%s' does not match a numeric pattern, and host could not be resolved (err=%s)",
+            netdata_log_error("Incoming %s on '%s' does not match a numeric pattern, and host could not be resolved (err=%s)",
                   patname, client_ip, gai_strerror(err));
             if (hostsize >= 8)
                 strcpy(client_host,"UNKNOWN");
@@ -1212,7 +1212,7 @@ int connection_allowed(int fd, char *client_ip, char *client_host, size_t hostsi
         }
         struct addrinfo *addr_infos = NULL;
         if (getaddrinfo(client_host, NULL, NULL, &addr_infos) !=0 ) {
-            error("LISTENER: cannot validate hostname '%s' from '%s' by resolving it",
+            netdata_log_error("LISTENER: cannot validate hostname '%s' from '%s' by resolving it",
                   client_host, client_ip);
             if (hostsize >= 8)
                 strcpy(client_host,"UNKNOWN");
@@ -1240,7 +1240,7 @@ int connection_allowed(int fd, char *client_ip, char *client_host, size_t hostsi
             scan = scan->ai_next;
         }
         if (!validated) {
-            error("LISTENER: Cannot validate '%s' as ip of '%s', not listed in DNS", client_ip, client_host);
+            netdata_log_error("LISTENER: Cannot validate '%s' as ip of '%s', not listed in DNS", client_ip, client_host);
             if (hostsize >= 8)
                 strcpy(client_host,"UNKNOWN");
         }
@@ -1266,7 +1266,7 @@ int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *clien
     if (likely(nfd >= 0)) {
         if (getnameinfo((struct sockaddr *)&sadr, addrlen, client_ip, (socklen_t)ipsize,
                         client_port, (socklen_t)portsize, NI_NUMERICHOST | NI_NUMERICSERV) != 0) {
-            error("LISTENER: cannot getnameinfo() on received client connection.");
+            netdata_log_error("LISTENER: cannot getnameinfo() on received client connection.");
             strncpyz(client_ip, "UNKNOWN", ipsize);
             strncpyz(client_port, "UNKNOWN", portsize);
         }
@@ -1308,7 +1308,7 @@ int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *clien
         }
         if (!connection_allowed(nfd, client_ip, client_host, hostsize, access_list, "connection", allow_dns)) {
             errno = 0;
-            error("Permission denied for client '%s', port '%s'", client_ip, client_port);
+            netdata_log_error("Permission denied for client '%s', port '%s'", client_ip, client_port);
             close(nfd);
             nfd = -1;
             errno = EPERM;
@@ -1316,7 +1316,7 @@ int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *clien
     }
 #ifdef HAVE_ACCEPT4
     else if (errno == ENOSYS)
-        error("netdata has been compiled with the assumption that the system has the accept4() call, but it is not here. Recompile netdata like this: ./configure --disable-accept4 ...");
+        netdata_log_error("netdata has been compiled with the assumption that the system has the accept4() call, but it is not here. Recompile netdata like this: ./configure --disable-accept4 ...");
 #endif
 
     return nfd;
@@ -1457,7 +1457,7 @@ inline void poll_close_fd(POLLINFO *pi) {
 
         if(likely(!(pi->flags & POLLINFO_FLAG_DONT_CLOSE))) {
             if(close(pf->fd) == -1)
-                error("Failed to close() poll_events() socket %d", pf->fd);
+                netdata_log_error("Failed to close() poll_events() socket %d", pf->fd);
         }
     }
 
@@ -1507,14 +1507,14 @@ void *poll_default_add_callback(POLLINFO *pi, short int *events, void *data) {
     (void)events;
     (void)data;
 
-    // error("POLLFD: internal error: poll_default_add_callback() called");
+    // netdata_log_error("POLLFD: internal error: poll_default_add_callback() called");
 
     return NULL;
 }
 
 void poll_default_del_callback(POLLINFO *pi) {
     if(pi->data)
-        error("POLLFD: internal error: del_callback_default() called with data pointer - possible memory leak");
+        netdata_log_error("POLLFD: internal error: del_callback_default() called with data pointer - possible memory leak");
 }
 
 int poll_default_rcv_callback(POLLINFO *pi, short int *events) {
@@ -1528,7 +1528,7 @@ int poll_default_rcv_callback(POLLINFO *pi, short int *events) {
         if (rc < 0) {
             // read failed
             if (errno != EWOULDBLOCK && errno != EAGAIN) {
-                error("POLLFD: poll_default_rcv_callback(): recv() failed with %zd.", rc);
+                netdata_log_error("POLLFD: poll_default_rcv_callback(): recv() failed with %zd.", rc);
                 return -1;
             }
         } else if (rc) {
@@ -1565,7 +1565,7 @@ static void poll_events_cleanup(void *data) {
 }
 
 static int poll_process_error(POLLINFO *pi, struct pollfd *pf, short int revents) {
-    error("POLLFD: LISTENER: received %s %s %s on socket at slot %zu (fd %d) client '%s' port '%s' expecting %s %s %s, having %s %s %s"
+    netdata_log_error("POLLFD: LISTENER: received %s %s %s on socket at slot %zu (fd %d) client '%s' port '%s' expecting %s %s %s, having %s %s %s"
           , revents & POLLERR  ? "POLLERR" : ""
           , revents & POLLHUP  ? "POLLHUP" : ""
           , revents & POLLNVAL ? "POLLNVAL" : ""
@@ -1673,7 +1673,7 @@ static int poll_process_new_tcp_connection(POLLJOB *p, POLLINFO *pi, struct poll
                       p->used, p->limit);
         }
         else if(unlikely(errno != EWOULDBLOCK && errno != EAGAIN))
-            error("POLLFD: LISTENER: accept() failed.");
+            netdata_log_error("POLLFD: LISTENER: accept() failed.");
 
     }
     else {
@@ -1720,7 +1720,7 @@ void poll_events(LISTEN_SOCKETS *sockets
         , size_t max_tcp_sockets
 ) {
     if(!sockets || !sockets->opened) {
-        error("POLLFD: internal error: no listening sockets are opened");
+        netdata_log_error("POLLFD: internal error: no listening sockets are opened");
         return;
     }
 
@@ -1827,7 +1827,7 @@ void poll_events(LISTEN_SOCKETS *sockets
         time_t now = now_boottime_sec();
 
         if(unlikely(retval == -1)) {
-            error("POLLFD: LISTENER: poll() failed while waiting on %zu sockets.", p.max + 1);
+            netdata_log_error("POLLFD: LISTENER: poll() failed while waiting on %zu sockets.", p.max + 1);
             break;
         }
         else if(unlikely(!retval)) {
@@ -1885,7 +1885,7 @@ void poll_events(LISTEN_SOCKETS *sockets
                             conns[conns_max++] = i;
                         }
                         else
-                            error("POLLFD: LISTENER: server slot %zu (fd %d) connection from %s port %s using unhandled socket type %d."
+                            netdata_log_error("POLLFD: LISTENER: server slot %zu (fd %d) connection from %s port %s using unhandled socket type %d."
                                  , i
                                  , pi->fd
                                  , pi->client_ip ? pi->client_ip : "<undefined-ip>"
@@ -1894,7 +1894,7 @@ void poll_events(LISTEN_SOCKETS *sockets
                             );
                     }
                     else
-                        error("POLLFD: LISTENER: client slot %zu (fd %d) data from %s port %s using flags %08X is neither client nor server."
+                        netdata_log_error("POLLFD: LISTENER: client slot %zu (fd %d) data from %s port %s using flags %08X is neither client nor server."
                               , i
                               , pi->fd
                               , pi->client_ip ? pi->client_ip : "<undefined-ip>"
@@ -1903,7 +1903,7 @@ void poll_events(LISTEN_SOCKETS *sockets
                         );
                 }
                 else
-                    error("POLLFD: LISTENER: socket slot %zu (fd %d) client %s port %s unhandled event id %d."
+                    netdata_log_error("POLLFD: LISTENER: socket slot %zu (fd %d) client %s port %s unhandled event id %d."
                       , i
                       , pi->fd
                       , pi->client_ip ? pi->client_ip : "<undefined-ip>"

--- a/libnetdata/storage_number/storage_number.c
+++ b/libnetdata/storage_number/storage_number.c
@@ -121,7 +121,7 @@ storage_number pack_storage_number(NETDATA_DOUBLE value, SN_FLAGS flags) {
 
         if(n > (NETDATA_DOUBLE)0x00ffffff) {
             #ifdef NETDATA_INTERNAL_CHECKS
-            error("Number " NETDATA_DOUBLE_FORMAT " is too big.", value);
+            netdata_log_error("Number " NETDATA_DOUBLE_FORMAT " is too big.", value);
             #endif
             r += 0x00ffffff;
             return r;

--- a/libnetdata/string/string.c
+++ b/libnetdata/string/string.c
@@ -240,7 +240,7 @@ static inline void string_index_delete(STRING *string) {
         JError_t J_Error;
         int ret = JudyHSDel(&string_base.JudyHSArray, (void *)string->str, string->length, &J_Error);
         if (unlikely(ret == JERR)) {
-            error(
+            netdata_log_error(
                 "STRING: Cannot delete entry with name '%s' from JudyHS, JU_ERRNO_* == %u, ID == %d",
                 string->str,
                 JU_ERRNO(&J_Error),
@@ -250,7 +250,7 @@ static inline void string_index_delete(STRING *string) {
     }
 
     if (unlikely(!deleted))
-        error("STRING: tried to delete '%s' that is not in the index. Ignoring it.", string->str);
+        netdata_log_error("STRING: tried to delete '%s' that is not in the index. Ignoring it.", string->str);
     else {
         size_t mem_size = sizeof(STRING) + string->length;
         string_base.deletes++;

--- a/libnetdata/threads/threads.c
+++ b/libnetdata/threads/threads.c
@@ -150,12 +150,12 @@ void netdata_threads_init_after_fork(size_t stacksize) {
     if(netdata_threads_attr && stacksize > (size_t)PTHREAD_STACK_MIN) {
         i = pthread_attr_setstacksize(netdata_threads_attr, stacksize);
         if(i != 0)
-            error("pthread_attr_setstacksize() to %zu bytes, failed with code %d.", stacksize, i);
+            netdata_log_error("pthread_attr_setstacksize() to %zu bytes, failed with code %d.", stacksize, i);
         else
             netdata_log_info("Set threads stack size to %zu bytes", stacksize);
     }
     else
-        error("Invalid pthread stacksize %zu", stacksize);
+        netdata_log_error("Invalid pthread stacksize %zu", stacksize);
 }
 
 // ----------------------------------------------------------------------------
@@ -169,7 +169,7 @@ void service_exits(void);
 static void thread_cleanup(void *ptr) {
     if(netdata_thread != ptr) {
         NETDATA_THREAD *info = (NETDATA_THREAD *)ptr;
-        error("THREADS: internal error - thread local variable does not match the one passed to this function. Expected thread '%s', passed thread '%s'", netdata_thread->tag, info->tag);
+        netdata_log_error("THREADS: internal error - thread local variable does not match the one passed to this function. Expected thread '%s', passed thread '%s'", netdata_thread->tag, info->tag);
     }
 
     if(!(netdata_thread->options & NETDATA_THREAD_OPTION_DONT_LOG_CLEANUP))
@@ -205,7 +205,7 @@ static void thread_set_name_np(NETDATA_THREAD *nt) {
 #endif
 
         if (ret != 0)
-            error("cannot set pthread name of %d to %s. ErrCode: %d", gettid(), threadname, ret);
+            netdata_log_error("cannot set pthread name of %d to %s. ErrCode: %d", gettid(), threadname, ret);
         else
             netdata_log_info("set name of thread %d to %s", gettid(), threadname);
 
@@ -250,10 +250,10 @@ static void *netdata_thread_init(void *ptr) {
         netdata_log_info("thread created with task id %d", gettid());
 
     if(pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL) != 0)
-        error("cannot set pthread cancel type to DEFERRED.");
+        netdata_log_error("cannot set pthread cancel type to DEFERRED.");
 
     if(pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL) != 0)
-        error("cannot set pthread cancel state to ENABLE.");
+        netdata_log_error("cannot set pthread cancel state to ENABLE.");
 
     thread_set_name_np(ptr);
 
@@ -275,13 +275,13 @@ int netdata_thread_create(netdata_thread_t *thread, const char *tag, NETDATA_THR
 
     int ret = pthread_create(thread, netdata_threads_attr, netdata_thread_init, info);
     if(ret != 0)
-        error("failed to create new thread for %s. pthread_create() failed with code %d", tag, ret);
+        netdata_log_error("failed to create new thread for %s. pthread_create() failed with code %d", tag, ret);
 
     else {
         if (!(options & NETDATA_THREAD_OPTION_JOINABLE)) {
             int ret2 = pthread_detach(*thread);
             if (ret2 != 0)
-                error("cannot request detach of newly created %s thread. pthread_detach() failed with code %d", tag, ret2);
+                netdata_log_error("cannot request detach of newly created %s thread. pthread_detach() failed with code %d", tag, ret2);
         }
     }
 
@@ -298,9 +298,9 @@ int netdata_thread_cancel(netdata_thread_t thread) {
     int ret = pthread_cancel(thread);
     if(ret != 0)
 #ifdef NETDATA_INTERNAL_CHECKS
-        error("cannot cancel thread. pthread_cancel() failed with code %d at %d@%s, function %s()", ret, line, file, function);
+        netdata_log_error("cannot cancel thread. pthread_cancel() failed with code %d at %d@%s, function %s()", ret, line, file, function);
 #else
-        error("cannot cancel thread. pthread_cancel() failed with code %d.", ret);
+        netdata_log_error("cannot cancel thread. pthread_cancel() failed with code %d.", ret);
 #endif
 
     return ret;
@@ -312,7 +312,7 @@ int netdata_thread_cancel(netdata_thread_t thread) {
 int netdata_thread_join(netdata_thread_t thread, void **retval) {
     int ret = pthread_join(thread, retval);
     if(ret != 0)
-        error("cannot join thread. pthread_join() failed with code %d.", ret);
+        netdata_log_error("cannot join thread. pthread_join() failed with code %d.", ret);
 
     return ret;
 }
@@ -320,7 +320,7 @@ int netdata_thread_join(netdata_thread_t thread, void **retval) {
 int netdata_thread_detach(pthread_t thread) {
     int ret = pthread_detach(thread);
     if(ret != 0)
-        error("cannot detach thread. pthread_detach() failed with code %d.", ret);
+        netdata_log_error("cannot detach thread. pthread_detach() failed with code %d.", ret);
 
     return ret;
 }

--- a/libnetdata/worker_utilization/worker_utilization.c
+++ b/libnetdata/worker_utilization/worker_utilization.c
@@ -118,7 +118,7 @@ void worker_register_job_custom_metric(size_t job_id, const char *name, const ch
     if(unlikely(!worker)) return;
 
     if(unlikely(job_id >= WORKER_UTILIZATION_MAX_JOB_TYPES)) {
-        error("WORKER_UTILIZATION: job_id %zu is too big. Max is %zu", job_id, (size_t)(WORKER_UTILIZATION_MAX_JOB_TYPES - 1));
+        netdata_log_error("WORKER_UTILIZATION: job_id %zu is too big. Max is %zu", job_id, (size_t)(WORKER_UTILIZATION_MAX_JOB_TYPES - 1));
         return;
     }
 
@@ -127,7 +127,7 @@ void worker_register_job_custom_metric(size_t job_id, const char *name, const ch
 
     if(worker->per_job_type[job_id].name) {
         if(strcmp(string2str(worker->per_job_type[job_id].name), name) != 0 || worker->per_job_type[job_id].type != type || strcmp(string2str(worker->per_job_type[job_id].units), units) != 0)
-            error("WORKER_UTILIZATION: duplicate job registration: worker '%s' job id %zu is '%s', ignoring the later '%s'", worker->workname, job_id, string2str(worker->per_job_type[job_id].name), name);
+            netdata_log_error("WORKER_UTILIZATION: duplicate job registration: worker '%s' job id %zu is '%s', ignoring the later '%s'", worker->workname, job_id, string2str(worker->per_job_type[job_id].name), name);
         return;
     }
 

--- a/ml/Config.cc
+++ b/ml/Config.cc
@@ -83,7 +83,7 @@ void ml_config_load(ml_config_t *cfg) {
      */
 
     if (min_train_samples >= max_train_samples) {
-        error("invalid min/max train samples found (%u >= %u)", min_train_samples, max_train_samples);
+        netdata_log_error("invalid min/max train samples found (%u >= %u)", min_train_samples, max_train_samples);
 
         min_train_samples = 1 * 3600;
         max_train_samples = 6 * 3600;

--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -1390,7 +1390,7 @@ void ml_host_get_models(RRDHOST *rh, BUFFER *wb)
     UNUSED(wb);
 
     // TODO: To be implemented
-    error("Fetching KMeans models is not supported yet");
+    netdata_log_error("Fetching KMeans models is not supported yet");
 }
 
 void ml_chart_new(RRDSET *rs)
@@ -1519,11 +1519,11 @@ static void ml_flush_pending_models(ml_training_thread_t *training_thread) {
 
     // try to rollback transaction if we got any failures
     if (rc) {
-        error("Trying to rollback ML transaction because it failed with rc=%d, op_no=%d", rc, op_no);
+        netdata_log_error("Trying to rollback ML transaction because it failed with rc=%d, op_no=%d", rc, op_no);
         op_no++;
         rc = db_execute(db, "ROLLBACK;");
         if (rc)
-            error("ML transaction rollback failed with rc=%d", rc);
+            netdata_log_error("ML transaction rollback failed with rc=%d", rc);
     }
 
     training_thread->pending_model_info.clear();

--- a/registry/registry_internals.c
+++ b/registry/registry_internals.c
@@ -270,7 +270,7 @@ static inline int is_machine_guid_blacklisted(const char *guid) {
     if(!strcmp(guid, "8a795b0c-2311-11e6-8563-000c295076a6")
        || !strcmp(guid, "4aed1458-1c3e-11e6-a53f-000c290fc8f5")
             ) {
-        error("Blacklisted machine GUID '%s' found.", guid);
+        netdata_log_error("Blacklisted machine GUID '%s' found.", guid);
         return 1;
     }
 
@@ -292,11 +292,11 @@ char *registry_get_this_machine_guid(void) {
     if(fd != -1) {
         char buf[GUID_LEN + 1];
         if(read(fd, buf, GUID_LEN) != GUID_LEN)
-            error("Failed to read machine GUID from '%s'", registry.machine_guid_filename);
+            netdata_log_error("Failed to read machine GUID from '%s'", registry.machine_guid_filename);
         else {
             buf[GUID_LEN] = '\0';
             if(regenerate_guid(buf, guid) == -1) {
-                error("Failed to validate machine GUID '%s' from '%s'. Ignoring it - this might mean this netdata will appear as duplicate in the registry.",
+                netdata_log_error("Failed to validate machine GUID '%s' from '%s'. Ignoring it - this might mean this netdata will appear as duplicate in the registry.",
                         buf, registry.machine_guid_filename);
 
                 guid[0] = '\0';

--- a/registry/registry_person.c
+++ b/registry/registry_person.c
@@ -34,7 +34,7 @@ inline REGISTRY_PERSON_URL *registry_person_url_index_add(REGISTRY_PERSON *p, RE
     debug(D_REGISTRY, "Registry: registry_person_url_index_add('%s', '%s')", p->guid, pu->url->url);
     REGISTRY_PERSON_URL *tpu = (REGISTRY_PERSON_URL *)avl_insert(&(p->person_urls), (avl_t *)(pu));
     if(tpu != pu)
-        error("Registry: registry_person_url_index_add('%s', '%s') already exists as '%s'", p->guid, pu->url->url, tpu->url->url);
+        netdata_log_error("Registry: registry_person_url_index_add('%s', '%s') already exists as '%s'", p->guid, pu->url->url, tpu->url->url);
 
     return tpu;
 }
@@ -43,9 +43,9 @@ inline REGISTRY_PERSON_URL *registry_person_url_index_del(REGISTRY_PERSON *p, RE
     debug(D_REGISTRY, "Registry: registry_person_url_index_del('%s', '%s')", p->guid, pu->url->url);
     REGISTRY_PERSON_URL *tpu = (REGISTRY_PERSON_URL *)avl_remove(&(p->person_urls), (avl_t *)(pu));
     if(!tpu)
-        error("Registry: registry_person_url_index_del('%s', '%s') deleted nothing", p->guid, pu->url->url);
+        netdata_log_error("Registry: registry_person_url_index_del('%s', '%s') deleted nothing", p->guid, pu->url->url);
     else if(tpu != pu)
-        error("Registry: registry_person_url_index_del('%s', '%s') deleted wrong URL '%s'", p->guid, pu->url->url, tpu->url->url);
+        netdata_log_error("Registry: registry_person_url_index_del('%s', '%s') deleted wrong URL '%s'", p->guid, pu->url->url, tpu->url->url);
 
     return tpu;
 }
@@ -78,7 +78,7 @@ REGISTRY_PERSON_URL *registry_person_url_allocate(REGISTRY_PERSON *p, REGISTRY_M
     debug(D_REGISTRY, "registry_person_url_allocate('%s', '%s', '%s'): indexing URL in person", p->guid, m->guid, u->url);
     REGISTRY_PERSON_URL *tpu = registry_person_url_index_add(p, pu);
     if(tpu != pu) {
-        error("Registry: Attempted to add duplicate person url '%s' with name '%s' to person '%s'", u->url, name, p->guid);
+        netdata_log_error("Registry: Attempted to add duplicate person url '%s' with name '%s' to person '%s'", u->url, name, p->guid);
         freez(pu);
         pu = tpu;
     }

--- a/registry/registry_url.c
+++ b/registry/registry_url.c
@@ -50,7 +50,7 @@ REGISTRY_URL *registry_url_get(const char *url, size_t urllen) {
         debug(D_REGISTRY, "Registry: registry_url_get('%s'): indexing it", url);
         n = registry_url_index_add(u);
         if(n != u) {
-            error("INTERNAL ERROR: registry_url_get(): url '%s' already exists in the registry as '%s'", u->url, n->url);
+            netdata_log_error("INTERNAL ERROR: registry_url_get(): url '%s' already exists in the registry as '%s'", u->url, n->url);
             freez(u);
             u = n;
         }
@@ -72,11 +72,11 @@ void registry_url_unlink(REGISTRY_URL *u) {
         debug(D_REGISTRY, "Registry: registry_url_unlink('%s'): No more links for this URL", u->url);
         REGISTRY_URL *n = registry_url_index_del(u);
         if(!n) {
-            error("INTERNAL ERROR: registry_url_unlink('%s'): cannot find url in index", u->url);
+            netdata_log_error("INTERNAL ERROR: registry_url_unlink('%s'): cannot find url in index", u->url);
         }
         else {
             if(n != u) {
-                error("INTERNAL ERROR: registry_url_unlink('%s'): deleted different url '%s'", u->url, n->url);
+                netdata_log_error("INTERNAL ERROR: registry_url_unlink('%s'): deleted different url '%s'", u->url, n->url);
             }
 
             registry.urls_memory -= sizeof(REGISTRY_URL) + n->len; // no need for +1, 1 is already in REGISTRY_URL

--- a/spawn/spawn.c
+++ b/spawn/spawn.c
@@ -219,7 +219,7 @@ int create_spawn_server(uv_loop_t *loop, uv_pipe_t *spawn_channel, uv_process_t 
 
     ret = uv_spawn(loop, process, &options); /* execute the netdata binary again as the netdata user */
     if (0 != ret) {
-        error("uv_spawn (process: \"%s\") (user: %s) failed (%s).", exepath, user, uv_strerror(ret));
+        netdata_log_error("uv_spawn (process: \"%s\") (user: %s) failed (%s).", exepath, user, uv_strerror(ret));
         fatal("Cannot start netdata without the spawn server.");
     }
 
@@ -242,7 +242,7 @@ void spawn_init(void)
     completion_init(&completion);
     error = uv_thread_create(&thread, spawn_client, &completion);
     if (error) {
-        error("uv_thread_create(): %s", uv_strerror(error));
+        netdata_log_error("uv_thread_create(): %s", uv_strerror(error));
         goto after_error;
     }
     /* wait for spawn client thread to initialize */
@@ -253,7 +253,7 @@ void spawn_init(void)
     if (spawn_thread_error) {
         error = uv_thread_join(&thread);
         if (error) {
-            error("uv_thread_create(): %s", uv_strerror(error));
+            netdata_log_error("uv_thread_create(): %s", uv_strerror(error));
         }
         goto after_error;
     }
@@ -285,5 +285,5 @@ void spawn_init(void)
     return;
 
     after_error:
-    error("Failed to initialize spawn service. The alarms notifications will not be spawned.");
+        netdata_log_error("Failed to initialize spawn service. The alarms notifications will not be spawned.");
 }

--- a/spawn/spawn_client.c
+++ b/spawn/spawn_client.c
@@ -106,7 +106,7 @@ static void on_pipe_read(uv_stream_t* pipe, ssize_t nread, const uv_buf_t* buf)
     } else if (UV_EOF == nread) {
         netdata_log_info("EOF found in spawn pipe.");
     } else if (nread < 0) {
-        error("%s: %s", __func__, uv_strerror(nread));
+        netdata_log_error("%s: %s", __func__, uv_strerror(nread));
     }
 
     if (nread < 0) { /* stop stream due to EOF or error */
@@ -176,7 +176,7 @@ void spawn_client(void *arg)
     loop = mallocz(sizeof(uv_loop_t));
     ret = uv_loop_init(loop);
     if (ret) {
-        error("uv_loop_init(): %s", uv_strerror(ret));
+        netdata_log_error("uv_loop_init(): %s", uv_strerror(ret));
         spawn_thread_error = ret;
         goto error_after_loop_init;
     }
@@ -185,14 +185,14 @@ void spawn_client(void *arg)
     spawn_async.data = NULL;
     ret = uv_async_init(loop, &spawn_async, async_cb);
     if (ret) {
-        error("uv_async_init(): %s", uv_strerror(ret));
+        netdata_log_error("uv_async_init(): %s", uv_strerror(ret));
         spawn_thread_error = ret;
         goto error_after_async_init;
     }
 
     ret = uv_pipe_init(loop, &spawn_channel, 1);
     if (ret) {
-        error("uv_pipe_init(): %s", uv_strerror(ret));
+        netdata_log_error("uv_pipe_init(): %s", uv_strerror(ret));
         spawn_thread_error = ret;
         goto error_after_pipe_init;
     }
@@ -200,7 +200,7 @@ void spawn_client(void *arg)
 
     ret = create_spawn_server(loop, &spawn_channel, &process);
     if (ret) {
-        error("Failed to fork spawn server process.");
+        netdata_log_error("Failed to fork spawn server process.");
         spawn_thread_error = ret;
         goto error_after_spawn_server;
     }

--- a/streaming/compression.c
+++ b/streaming/compression.c
@@ -52,7 +52,7 @@ size_t rrdpush_compress(struct compressor_state *state, const char *data, size_t
         return 0;
 
     if(unlikely(size > COMPRESSION_MAX_MSG_SIZE)) {
-        error("RRDPUSH COMPRESS: Compression Failed - Message size %lu above compression buffer limit: %d",
+        netdata_log_error("RRDPUSH COMPRESS: Compression Failed - Message size %lu above compression buffer limit: %d",
               (long unsigned int)size, COMPRESSION_MAX_MSG_SIZE);
         return 0;
     }
@@ -83,7 +83,7 @@ size_t rrdpush_compress(struct compressor_state *state, const char *data, size_t
         1);
 
     if (compressed_data_size < 0) {
-        error("Data compression error: %ld", compressed_data_size);
+        netdata_log_error("Data compression error: %ld", compressed_data_size);
         return 0;
     }
 
@@ -125,7 +125,7 @@ size_t rrdpush_decompress(struct decompressor_state *state, const char *compress
             );
 
     if (unlikely(decompressed_size < 0)) {
-        error("RRDPUSH DECOMPRESS: decompressor returned negative decompressed bytes: %ld", decompressed_size);
+        netdata_log_error("RRDPUSH DECOMPRESS: decompressor returned negative decompressed bytes: %ld", decompressed_size);
         return 0;
     }
 

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -799,7 +799,7 @@ static bool send_replay_chart_cmd(struct replication_request_details *r, const c
 
     ssize_t ret = r->caller.callback(buffer, r->caller.data);
     if (ret < 0) {
-        error("REPLAY ERROR: 'host:%s/chart:%s' failed to send replication request to child (error %zd)",
+        netdata_log_error("REPLAY ERROR: 'host:%s/chart:%s' failed to send replication request to child (error %zd)",
               rrdhost_hostname(r->host), rrdset_id(r->st), ret);
         return false;
     }
@@ -1860,7 +1860,7 @@ void *replication_thread_main(void *ptr __maybe_unused) {
 
     int threads = config_get_number(CONFIG_SECTION_DB, "replication threads", 1);
     if(threads < 1 || threads > MAX_REPLICATION_THREADS) {
-        error("replication threads given %d is invalid, resetting to 1", threads);
+        netdata_log_error("replication threads given %d is invalid, resetting to 1", threads);
         threads = 1;
     }
 

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -148,7 +148,7 @@ int rrdpush_init() {
 #endif
 
     if(default_rrdpush_enabled && (!default_rrdpush_destination || !*default_rrdpush_destination || !default_rrdpush_api_key || !*default_rrdpush_api_key)) {
-        error("STREAM [send]: cannot enable sending thread - information is missing.");
+        netdata_log_error("STREAM [send]: cannot enable sending thread - information is missing.");
         default_rrdpush_enabled = 0;
     }
 
@@ -479,7 +479,7 @@ RRDSET_STREAM_BUFFER rrdset_push_metric_initialize(RRDSET *st, time_t wall_clock
 
         if(unlikely(!(host_flags & RRDHOST_FLAG_RRDPUSH_SENDER_LOGGED_STATUS))) {
             rrdhost_flag_set(host, RRDHOST_FLAG_RRDPUSH_SENDER_LOGGED_STATUS);
-            error("STREAM %s [send]: not ready - collected metrics are not sent to parent.", rrdhost_hostname(host));
+            netdata_log_error("STREAM %s [send]: not ready - collected metrics are not sent to parent.", rrdhost_hostname(host));
         }
 
         return (RRDSET_STREAM_BUFFER) { .wb = NULL, };
@@ -727,7 +727,7 @@ static void rrdpush_sender_thread_spawn(RRDHOST *host) {
         snprintfz(tag, NETDATA_THREAD_TAG_MAX, THREAD_TAG_STREAM_SENDER "[%s]", rrdhost_hostname(host));
 
         if(netdata_thread_create(&host->rrdpush_sender_thread, tag, NETDATA_THREAD_OPTION_DEFAULT, rrdpush_sender_thread, (void *) host->sender))
-            error("STREAM %s [send]: failed to create new thread for client.", rrdhost_hostname(host));
+            netdata_log_error("STREAM %s [send]: failed to create new thread for client.", rrdhost_hostname(host));
         else
             rrdhost_flag_set(host, RRDHOST_FLAG_RRDPUSH_SENDER_SPAWN);
     }
@@ -1075,7 +1075,7 @@ int rrdpush_receiver_thread_spawn(struct web_client *w, char *decoded_query_stri
 #endif
                 rpt->fd, initial_response, strlen(initial_response), 0, 60) != (ssize_t)strlen(initial_response)) {
 
-            error("STREAM '%s' [receive from [%s]:%s]: "
+            netdata_log_error("STREAM '%s' [receive from [%s]:%s]: "
                   "failed to reply."
                   , rpt->hostname
                   , rpt->client_ip, rpt->client_port

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -581,7 +581,7 @@ static bool rrdpush_sender_thread_connect_to_parent(RRDHOST *host, int default_p
     );
 
     if(unlikely(s->rrdpush_sender_socket == -1)) {
-        // error("STREAM %s [send to %s]: could not connect to parent node at this time.", rrdhost_hostname(host), host->rrdpush_send_destination);
+        // netdata_log_error("STREAM %s [send to %s]: could not connect to parent node at this time.", rrdhost_hostname(host), host->rrdpush_send_destination);
         return false;
     }
 

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -74,9 +74,9 @@ static inline void rrdpush_sender_thread_close_socket(RRDHOST *host);
 */
 static inline void deactivate_compression(struct sender_state *s) {
     worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_NO_COMPRESSION);
-    error("STREAM_COMPRESSION: Compression returned error, disabling it.");
+    netdata_log_error("STREAM_COMPRESSION: Compression returned error, disabling it.");
     s->flags &= ~SENDER_FLAG_COMPRESSION;
-    error("STREAM %s [send to %s]: Restarting connection without compression.", rrdhost_hostname(s->host), s->connected_to);
+    netdata_log_error("STREAM %s [send to %s]: Restarting connection without compression.", rrdhost_hostname(s->host), s->connected_to);
     rrdpush_sender_thread_close_socket(s->host);
 }
 #endif
@@ -146,13 +146,13 @@ void sender_commit(struct sender_state *s, BUFFER *wb, STREAM_TRAFFIC_TYPE type)
             char *dst;
             size_t dst_len = rrdpush_compress(&s->compressor, src, size_to_compress, &dst);
             if (!dst_len) {
-                error("STREAM %s [send to %s]: COMPRESSION failed. Resetting compressor and re-trying",
+                netdata_log_error("STREAM %s [send to %s]: COMPRESSION failed. Resetting compressor and re-trying",
                       rrdhost_hostname(s->host), s->connected_to);
 
                 rrdpush_compressor_reset(&s->compressor);
                 dst_len = rrdpush_compress(&s->compressor, src, size_to_compress, &dst);
                 if(!dst_len) {
-                    error("STREAM %s [send to %s]: COMPRESSION failed again. Deactivating compression",
+                    netdata_log_error("STREAM %s [send to %s]: COMPRESSION failed again. Deactivating compression",
                           rrdhost_hostname(s->host), s->connected_to);
 
                     deactivate_compression(s);
@@ -509,7 +509,7 @@ static inline bool rrdpush_sender_validate_response(RRDHOST *host, struct sender
 
     char buf[LOG_DATE_LENGTH];
     log_date(buf, LOG_DATE_LENGTH, host->destination->postpone_reconnection_until);
-    error("STREAM %s [send to %s]: %s - will retry in %ld secs, at %s",
+    netdata_log_error("STREAM %s [send to %s]: %s - will retry in %ld secs, at %s",
           rrdhost_hostname(host), s->connected_to, error, delay, buf);
 
     return false;
@@ -541,7 +541,7 @@ static bool rrdpush_sender_connect_ssl(struct sender_state *s) {
             // certificate is not valid
 
             worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_SSL_ERROR);
-            error("SSL: closing the stream connection, because the server SSL certificate is not valid.");
+            netdata_log_error("SSL: closing the stream connection, because the server SSL certificate is not valid.");
             rrdpush_sender_thread_close_socket(host);
             host->destination->reason = STREAM_HANDSHAKE_ERROR_INVALID_CERTIFICATE;
             host->destination->postpone_reconnection_until = now_realtime_sec() + 5 * 60;
@@ -551,7 +551,7 @@ static bool rrdpush_sender_connect_ssl(struct sender_state *s) {
         return true;
     }
 
-    error("SSL: failed to establish connection.");
+    netdata_log_error("SSL: failed to establish connection.");
     return false;
 
 #else
@@ -720,7 +720,7 @@ static bool rrdpush_sender_thread_connect_to_parent(RRDHOST *host, int default_p
     if(bytes <= 0) { // timeout is 0
         worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_TIMEOUT);
         rrdpush_sender_thread_close_socket(host);
-        error("STREAM %s [send to %s]: failed to send HTTP header to remote netdata.", rrdhost_hostname(host), s->connected_to);
+        netdata_log_error("STREAM %s [send to %s]: failed to send HTTP header to remote netdata.", rrdhost_hostname(host), s->connected_to);
         host->destination->reason = STREAM_HANDSHAKE_ERROR_SEND_TIMEOUT;
         host->destination->postpone_reconnection_until = now_realtime_sec() + 1 * 60;
         return false;
@@ -739,17 +739,17 @@ static bool rrdpush_sender_thread_connect_to_parent(RRDHOST *host, int default_p
     if(bytes <= 0) { // timeout is 0
         worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_TIMEOUT);
         rrdpush_sender_thread_close_socket(host);
-        error("STREAM %s [send to %s]: remote netdata does not respond.", rrdhost_hostname(host), s->connected_to);
+        netdata_log_error("STREAM %s [send to %s]: remote netdata does not respond.", rrdhost_hostname(host), s->connected_to);
         host->destination->reason = STREAM_HANDSHAKE_ERROR_RECEIVE_TIMEOUT;
         host->destination->postpone_reconnection_until = now_realtime_sec() + 30;
         return false;
     }
 
     if(sock_setnonblock(s->rrdpush_sender_socket) < 0)
-        error("STREAM %s [send to %s]: cannot set non-blocking mode for socket.", rrdhost_hostname(host), s->connected_to);
+        netdata_log_error("STREAM %s [send to %s]: cannot set non-blocking mode for socket.", rrdhost_hostname(host), s->connected_to);
 
     if(sock_enlarge_out(s->rrdpush_sender_socket) < 0)
-        error("STREAM %s [send to %s]: cannot enlarge the socket buffer.", rrdhost_hostname(host), s->connected_to);
+        netdata_log_error("STREAM %s [send to %s]: cannot enlarge the socket buffer.", rrdhost_hostname(host), s->connected_to);
 
     http[bytes] = '\0';
     debug(D_STREAM, "Response to sender from far end: %s", http);
@@ -846,7 +846,7 @@ static ssize_t attempt_to_send(struct sender_state *s) {
     else if (ret == -1) {
         worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_SEND_ERROR);
         debug(D_STREAM, "STREAM: Send failed - closing socket...");
-        error("STREAM %s [send to %s]: failed to send metrics - closing connection - we have sent %zu bytes on this connection.",  rrdhost_hostname(s->host), s->connected_to, s->sent_bytes_on_this_connection);
+        netdata_log_error("STREAM %s [send to %s]: failed to send metrics - closing connection - we have sent %zu bytes on this connection.",  rrdhost_hostname(s->host), s->connected_to, s->sent_bytes_on_this_connection);
         rrdpush_sender_thread_close_socket(s->host);
     }
     else
@@ -886,11 +886,11 @@ static ssize_t attempt_read(struct sender_state *s) {
 
     if (ret == 0 || errno == ECONNRESET) {
         worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_PARENT_CLOSED);
-        error("STREAM %s [send to %s]: connection closed by far end.", rrdhost_hostname(s->host), s->connected_to);
+        netdata_log_error("STREAM %s [send to %s]: connection closed by far end.", rrdhost_hostname(s->host), s->connected_to);
     }
     else {
         worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_RECEIVE_ERROR);
-        error("STREAM %s [send to %s]: error during receive (%zd) - closing connection.", rrdhost_hostname(s->host), s->connected_to, ret);
+        netdata_log_error("STREAM %s [send to %s]: error during receive (%zd) - closing connection.", rrdhost_hostname(s->host), s->connected_to, ret);
     }
 
     rrdpush_sender_thread_close_socket(s->host);
@@ -962,7 +962,7 @@ void execute_commands(struct sender_state *s) {
             char *function = get_word(words, num_words, 3);
 
             if(!transaction || !*transaction || !timeout_s || !*timeout_s || !function || !*function) {
-                error("STREAM %s [send to %s] %s execution command is incomplete (transaction = '%s', timeout = '%s', function = '%s'). Ignoring it.",
+                netdata_log_error("STREAM %s [send to %s] %s execution command is incomplete (transaction = '%s', timeout = '%s', function = '%s'). Ignoring it.",
                       rrdhost_hostname(s->host), s->connected_to,
                       keyword,
                       transaction?transaction:"(unset)",
@@ -995,7 +995,7 @@ void execute_commands(struct sender_state *s) {
             const char *before = get_word(words, num_words, 4);
 
             if (!chart_id || !start_streaming || !after || !before) {
-                error("STREAM %s [send to %s] %s command is incomplete"
+                netdata_log_error("STREAM %s [send to %s] %s command is incomplete"
                       " (chart=%s, start_streaming=%s, after=%s, before=%s)",
                       rrdhost_hostname(s->host), s->connected_to,
                       keyword,
@@ -1013,7 +1013,7 @@ void execute_commands(struct sender_state *s) {
             }
         }
         else {
-            error("STREAM %s [send to %s] received unknown command over connection: %s", rrdhost_hostname(s->host), s->connected_to, words[0]?words[0]:"(unset)");
+            netdata_log_error("STREAM %s [send to %s] received unknown command over connection: %s", rrdhost_hostname(s->host), s->connected_to, words[0]?words[0]:"(unset)");
         }
 
         worker_is_busy(WORKER_SENDER_JOB_EXECUTE);
@@ -1044,7 +1044,7 @@ static bool rrdpush_sender_pipe_close(RRDHOST *host, int *pipe_fds, bool reopen)
     int new_pipe_fds[2];
     if(reopen) {
         if(pipe(new_pipe_fds) != 0) {
-            error("STREAM %s [send]: cannot create required pipe.", rrdhost_hostname(host));
+            netdata_log_error("STREAM %s [send]: cannot create required pipe.", rrdhost_hostname(host));
             new_pipe_fds[PIPE_READ] = -1;
             new_pipe_fds[PIPE_WRITE] = -1;
             ret = false;
@@ -1084,7 +1084,7 @@ void rrdpush_signal_sender_to_wake_up(struct sender_state *s) {
 
     // signal the sender there are more data
     if (pipe_fd != -1 && write(pipe_fd, " ", 1) == -1) {
-        error("STREAM %s [send]: cannot write to internal pipe.", rrdhost_hostname(host));
+        netdata_log_error("STREAM %s [send]: cannot write to internal pipe.", rrdhost_hostname(host));
         rrdpush_sender_pipe_close(host, s->rrdpush_sender_pipe, true);
     }
 }
@@ -1238,13 +1238,13 @@ void *rrdpush_sender_thread(void *ptr) {
     if(!rrdhost_has_rrdpush_sender_enabled(s->host) || !s->host->rrdpush_send_destination ||
        !*s->host->rrdpush_send_destination || !s->host->rrdpush_send_api_key ||
        !*s->host->rrdpush_send_api_key) {
-        error("STREAM %s [send]: thread created (task id %d), but host has streaming disabled.",
+        netdata_log_error("STREAM %s [send]: thread created (task id %d), but host has streaming disabled.",
               rrdhost_hostname(s->host), gettid());
         return NULL;
     }
 
     if(!rrdhost_set_sender(s->host)) {
-        error("STREAM %s [send]: thread created (task id %d), but there is another sender running for this host.",
+        netdata_log_error("STREAM %s [send]: thread created (task id %d), but there is another sender running for this host.",
               rrdhost_hostname(s->host), gettid());
         return NULL;
     }
@@ -1282,7 +1282,7 @@ void *rrdpush_sender_thread(void *ptr) {
         pipe_buffer_size = 10 * 1024;
 
     if(!rrdpush_sender_pipe_close(s->host, s->rrdpush_sender_pipe, true)) {
-        error("STREAM %s [send]: cannot create inter-thread communication pipe. Disabling streaming.",
+        netdata_log_error("STREAM %s [send]: cannot create inter-thread communication pipe. Disabling streaming.",
               rrdhost_hostname(s->host));
         return NULL;
     }
@@ -1338,7 +1338,7 @@ void *rrdpush_sender_thread(void *ptr) {
             !rrdpush_sender_replicating_charts(s)
         )) {
             worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_TIMEOUT);
-            error("STREAM %s [send to %s]: could not send metrics for %d seconds - closing connection - we have sent %zu bytes on this connection via %zu send attempts.", rrdhost_hostname(s->host), s->connected_to, s->timeout, s->sent_bytes_on_this_connection, s->send_attempts);
+            netdata_log_error("STREAM %s [send to %s]: could not send metrics for %d seconds - closing connection - we have sent %zu bytes on this connection via %zu send attempts.", rrdhost_hostname(s->host), s->connected_to, s->timeout, s->sent_bytes_on_this_connection, s->send_attempts);
             rrdpush_sender_thread_close_socket(s->host);
             continue;
         }
@@ -1359,7 +1359,7 @@ void *rrdpush_sender_thread(void *ptr) {
 
         if(unlikely(s->rrdpush_sender_pipe[PIPE_READ] == -1)) {
             if(!rrdpush_sender_pipe_close(s->host, s->rrdpush_sender_pipe, true)) {
-                error("STREAM %s [send]: cannot create inter-thread communication pipe. Disabling streaming.",
+                netdata_log_error("STREAM %s [send]: cannot create inter-thread communication pipe. Disabling streaming.",
                       rrdhost_hostname(s->host));
                 rrdpush_sender_thread_close_socket(s->host);
                 break;
@@ -1411,7 +1411,7 @@ void *rrdpush_sender_thread(void *ptr) {
         // Only errors from poll() are internal, but try restarting the connection
         if(unlikely(poll_rc == -1)) {
             worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_POLL_ERROR);
-            error("STREAM %s [send to %s]: failed to poll(). Closing socket.", rrdhost_hostname(s->host), s->connected_to);
+            netdata_log_error("STREAM %s [send to %s]: failed to poll(). Closing socket.", rrdhost_hostname(s->host), s->connected_to);
             rrdpush_sender_pipe_close(s->host, s->rrdpush_sender_pipe, true);
             rrdpush_sender_thread_close_socket(s->host);
             continue;
@@ -1433,7 +1433,7 @@ void *rrdpush_sender_thread(void *ptr) {
             debug(D_STREAM, "STREAM: Data added to send buffer (current buffer chunk %zu bytes)...", outstanding);
 
             if (read(fds[Collector].fd, thread_data->pipe_buffer, pipe_buffer_size) == -1)
-                error("STREAM %s [send to %s]: cannot read from internal pipe.", rrdhost_hostname(s->host), s->connected_to);
+                netdata_log_error("STREAM %s [send to %s]: cannot read from internal pipe.", rrdhost_hostname(s->host), s->connected_to);
         }
 
         // Read as much as possible to fill the buffer, split into full lines for execution.
@@ -1461,7 +1461,7 @@ void *rrdpush_sender_thread(void *ptr) {
 
             if(error) {
                 rrdpush_sender_pipe_close(s->host, s->rrdpush_sender_pipe, true);
-                error("STREAM %s [send to %s]: restarting internal pipe: %s.",
+                netdata_log_error("STREAM %s [send to %s]: restarting internal pipe: %s.",
                       rrdhost_hostname(s->host), s->connected_to, error);
             }
         }
@@ -1478,7 +1478,7 @@ void *rrdpush_sender_thread(void *ptr) {
 
             if(unlikely(error)) {
                 worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_SOCKET_ERROR);
-                error("STREAM %s [send to %s]: restarting connection: %s - %zu bytes transmitted.",
+                netdata_log_error("STREAM %s [send to %s]: restarting connection: %s - %zu bytes transmitted.",
                       rrdhost_hostname(s->host), s->connected_to, error, s->sent_bytes_on_this_connection);
                 rrdpush_sender_thread_close_socket(s->host);
             }
@@ -1488,7 +1488,7 @@ void *rrdpush_sender_thread(void *ptr) {
         if(unlikely(s->flags & SENDER_FLAG_OVERFLOW)) {
             worker_is_busy(WORKER_SENDER_JOB_DISCONNECT_OVERFLOW);
             errno = 0;
-            error("STREAM %s [send to %s]: buffer full (allocated %zu bytes) after sending %zu bytes. Restarting connection",
+            netdata_log_error("STREAM %s [send to %s]: buffer full (allocated %zu bytes) after sending %zu bytes. Restarting connection",
                   rrdhost_hostname(s->host), s->connected_to, s->buffer->size, s->sent_bytes_on_this_connection);
             rrdpush_sender_thread_close_socket(s->host);
         }

--- a/tests/profile/benchmark-procfile-parser.c
+++ b/tests/profile/benchmark-procfile-parser.c
@@ -207,7 +207,7 @@ procfile *procfile_readall1(procfile *ff) {
         debug(D_PROCFILE, "Reading file '%s', from position %zd with length %zd", procfile_filename(ff), s, (ssize_t)(ff->size - s));
         r = read(ff->fd, &ff->data[s], ff->size - s);
         if(unlikely(r == -1)) {
-            if(unlikely(!(ff->flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) error(PF_PREFIX ": Cannot read from file '%s' on fd %d", procfile_filename(ff), ff->fd);
+            if(unlikely(!(ff->flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) netdata_log_error(PF_PREFIX ": Cannot read from file '%s' on fd %d", procfile_filename(ff), ff->fd);
             procfile_close(ff);
             return NULL;
         }
@@ -217,7 +217,7 @@ procfile *procfile_readall1(procfile *ff) {
 
     // debug(D_PROCFILE, "Rewinding file '%s'", ff->filename);
     if(unlikely(lseek(ff->fd, 0, SEEK_SET) == -1)) {
-        if(unlikely(!(ff->flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) error(PF_PREFIX ": Cannot rewind on file '%s'.", procfile_filename(ff));
+        if(unlikely(!(ff->flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) netdata_log_error(PF_PREFIX ": Cannot rewind on file '%s'.", procfile_filename(ff));
         procfile_close(ff);
         return NULL;
     }

--- a/tests/profile/test-eval.c
+++ b/tests/profile/test-eval.c
@@ -231,7 +231,7 @@ NETDATA_DOUBLE evaluate(EVAL_NODE *op, int depth) {
 			break;
 
 		default:
-			error("I don't know how to handle operator '%c'", op->operator);
+			netdata_log_error("I don't know how to handle operator '%c'", op->operator);
 			r = 0;
 			break;
 	}

--- a/web/api/formatters/csv/csv.c
+++ b/web/api/formatters/csv/csv.c
@@ -79,7 +79,8 @@ void rrdr2csv(RRDR *r, BUFFER *wb, uint32_t format, RRDR_OPTIONS options, const 
         else {
             // generate the local date time
             struct tm tmbuf, *tm = localtime_r(&now, &tmbuf);
-            if(!tm) { error("localtime() failed."); continue; }
+            if(!tm) {
+                netdata_log_error("localtime() failed."); continue; }
             buffer_date(wb, tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec);
         }
 

--- a/web/api/formatters/json/json.c
+++ b/web/api/formatters/json/json.c
@@ -159,7 +159,8 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
         if(dates == JSON_DATES_JS) {
             // generate the local date time
             struct tm tmbuf, *tm = localtime_r(&now, &tmbuf);
-            if(!tm) { error("localtime_r() failed."); continue; }
+            if(!tm) {
+                netdata_log_error("localtime_r() failed."); continue; }
 
             if(likely(i != start)) buffer_fast_strcat(wb, ",\n", 2);
             buffer_fast_strcat(wb, pre_date, pre_date_len);

--- a/web/api/health/health_cmdapi.c
+++ b/web/api/health/health_cmdapi.c
@@ -101,7 +101,7 @@ void health_silencers2file(BUFFER *wb) {
         fclose(fd);
         return;
     }
-    error("Silencer changes could not be written to %s. Error %s", silencers_filename, strerror(errno));
+    netdata_log_error("Silencer changes could not be written to %s. Error %s", silencers_filename, strerror(errno));
 }
 
 /**

--- a/web/api/queries/weights.c
+++ b/web/api/queries/weights.c
@@ -1244,7 +1244,7 @@ static double kstwo(
         return NAN;
 
     if(unlikely(base_size != baseline_points - 1 || high_size != highlight_points - 1)) {
-        error("Metric correlations: internal error - calculate_pairs_diff() returns the wrong number of entries");
+        netdata_log_error("Metric correlations: internal error - calculate_pairs_diff() returns the wrong number of entries");
         return NAN;
     }
 
@@ -1292,7 +1292,7 @@ NETDATA_DOUBLE *rrd2rrdr_ks2(
         stats->db_points_per_tier[tr] += r->internal.qt->db.tiers[tr].points;
 
     if(r->d != 1 || r->internal.qt->query.used != 1) {
-        error("WEIGHTS: on query '%s' expected 1 dimension in RRDR but got %zu r->d and %zu qt->query.used",
+        netdata_log_error("WEIGHTS: on query '%s' expected 1 dimension in RRDR but got %zu r->d and %zu qt->query.used",
               r->internal.qt->id, r->d, (size_t)r->internal.qt->query.used);
         goto cleanup;
     }
@@ -1368,11 +1368,11 @@ static void rrdset_metric_correlations_ks2(
 
         // these conditions should never happen, but still let's check
         if(unlikely(prob < 0.0)) {
-            error("Metric correlations: kstwo() returned a negative number: %f", prob);
+            netdata_log_error("Metric correlations: kstwo() returned a negative number: %f", prob);
             prob = -prob;
         }
         if(unlikely(prob > 1.0)) {
-            error("Metric correlations: kstwo() returned a number above 1.0: %f", prob);
+            netdata_log_error("Metric correlations: kstwo() returned a number above 1.0: %f", prob);
             prob = 1.0;
         }
 

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -161,11 +161,11 @@ char *get_mgmt_api_key(void) {
     if(fd != -1) {
         char buf[GUID_LEN + 1];
         if(read(fd, buf, GUID_LEN) != GUID_LEN)
-            error("Failed to read management API key from '%s'", api_key_filename);
+            netdata_log_error("Failed to read management API key from '%s'", api_key_filename);
         else {
             buf[GUID_LEN] = '\0';
             if(regenerate_guid(buf, guid) == -1) {
-                error("Failed to validate management API key '%s' from '%s'.",
+                netdata_log_error("Failed to validate management API key '%s' from '%s'.",
                       buf, api_key_filename);
 
                 guid[0] = '\0';
@@ -185,12 +185,12 @@ char *get_mgmt_api_key(void) {
         // save it
         fd = open(api_key_filename, O_WRONLY|O_CREAT|O_TRUNC, 444);
         if(fd == -1) {
-            error("Cannot create unique management API key file '%s'. Please adjust config parameter 'netdata management api key file' to a proper path and file.", api_key_filename);
+            netdata_log_error("Cannot create unique management API key file '%s'. Please adjust config parameter 'netdata management api key file' to a proper path and file.", api_key_filename);
             goto temp_key;
         }
 
         if(write(fd, guid, GUID_LEN) != GUID_LEN) {
-            error("Cannot write the unique management API key file '%s'. Please adjust config parameter 'netdata management api key file' to a proper path and file with enough space left.", api_key_filename);
+            netdata_log_error("Cannot write the unique management API key file '%s'. Please adjust config parameter 'netdata management api key file' to a proper path and file with enough space left.", api_key_filename);
             close(fd);
             goto temp_key;
         }
@@ -973,7 +973,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
             else if(vhash == hash_search && !strcmp(value, "search")) action = 'S';
             else if(vhash == hash_switch && !strcmp(value, "switch")) action = 'W';
 #ifdef NETDATA_INTERNAL_CHECKS
-            else error("unknown registry action '%s'", value);
+            else netdata_log_error("unknown registry action '%s'", value);
 #endif /* NETDATA_INTERNAL_CHECKS */
         }
 /*
@@ -1003,7 +1003,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
                 to_person_guid = value;
         }
 #ifdef NETDATA_INTERNAL_CHECKS
-        else error("unused registry URL parameter '%s' with value '%s'", name, value);
+        else netdata_log_error("unused registry URL parameter '%s' with value '%s'", name, value);
 #endif /* NETDATA_INTERNAL_CHECKS */
     }
 
@@ -1028,7 +1028,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
     switch(action) {
         case 'A':
             if(unlikely(!machine_guid || !machine_url || !url_name)) {
-                error("Invalid registry request - access requires these parameters: machine ('%s'), url ('%s'), name ('%s')", machine_guid ? machine_guid : "UNSET", machine_url ? machine_url : "UNSET", url_name ? url_name : "UNSET");
+                netdata_log_error("Invalid registry request - access requires these parameters: machine ('%s'), url ('%s'), name ('%s')", machine_guid ? machine_guid : "UNSET", machine_url ? machine_url : "UNSET", url_name ? url_name : "UNSET");
                 buffer_flush(w->response.data);
                 buffer_strcat(w->response.data, "Invalid registry Access request.");
                 return HTTP_RESP_BAD_REQUEST;
@@ -1039,7 +1039,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
 
         case 'D':
             if(unlikely(!machine_guid || !machine_url || !delete_url)) {
-                error("Invalid registry request - delete requires these parameters: machine ('%s'), url ('%s'), delete_url ('%s')", machine_guid?machine_guid:"UNSET", machine_url?machine_url:"UNSET", delete_url?delete_url:"UNSET");
+                netdata_log_error("Invalid registry request - delete requires these parameters: machine ('%s'), url ('%s'), delete_url ('%s')", machine_guid?machine_guid:"UNSET", machine_url?machine_url:"UNSET", delete_url?delete_url:"UNSET");
                 buffer_flush(w->response.data);
                 buffer_strcat(w->response.data, "Invalid registry Delete request.");
                 return HTTP_RESP_BAD_REQUEST;
@@ -1050,7 +1050,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
 
         case 'S':
             if(unlikely(!machine_guid || !machine_url || !search_machine_guid)) {
-                error("Invalid registry request - search requires these parameters: machine ('%s'), url ('%s'), for ('%s')", machine_guid?machine_guid:"UNSET", machine_url?machine_url:"UNSET", search_machine_guid?search_machine_guid:"UNSET");
+                netdata_log_error("Invalid registry request - search requires these parameters: machine ('%s'), url ('%s'), for ('%s')", machine_guid?machine_guid:"UNSET", machine_url?machine_url:"UNSET", search_machine_guid?search_machine_guid:"UNSET");
                 buffer_flush(w->response.data);
                 buffer_strcat(w->response.data, "Invalid registry Search request.");
                 return HTTP_RESP_BAD_REQUEST;
@@ -1061,7 +1061,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
 
         case 'W':
             if(unlikely(!machine_guid || !machine_url || !to_person_guid)) {
-                error("Invalid registry request - switching identity requires these parameters: machine ('%s'), url ('%s'), to ('%s')", machine_guid?machine_guid:"UNSET", machine_url?machine_url:"UNSET", to_person_guid?to_person_guid:"UNSET");
+                netdata_log_error("Invalid registry request - switching identity requires these parameters: machine ('%s'), url ('%s'), to ('%s')", machine_guid?machine_guid:"UNSET", machine_url?machine_url:"UNSET", to_person_guid?to_person_guid:"UNSET");
                 buffer_flush(w->response.data);
                 buffer_strcat(w->response.data, "Invalid registry Switch request.");
                 return HTTP_RESP_BAD_REQUEST;

--- a/web/rtc/webrtc.c
+++ b/web/rtc/webrtc.c
@@ -21,7 +21,7 @@ static void webrtc_log(rtcLogLevel level, const char *message) {
         case RTC_LOG_WARNING:
         case RTC_LOG_ERROR:
         case RTC_LOG_FATAL:
-            error("WEBRTC: %s", message);
+            netdata_log_error("WEBRTC: %s", message);
             break;
 
         case RTC_LOG_INFO:
@@ -263,7 +263,7 @@ static size_t webrtc_send_in_chunks(WEBRTC_DC *chan, const char *data, size_t si
             total_message_size = -total_message_size;
 
         if(rtcSendMessage(chan->dc, send_buffer, total_message_size) != RTC_ERR_SUCCESS)
-            error("WEBRTC[%d],DC[%d]: failed to send LZ4 chunk %zu of %zu", chan->conn->pc, chan->dc, chunk, total_chunks);
+            netdata_log_error("WEBRTC[%d],DC[%d]: failed to send LZ4 chunk %zu of %zu", chan->conn->pc, chan->dc, chunk, total_chunks);
         else
             internal_error(true, "WEBRTC[%d],DC[%d]: sent chunk %zu of %zu, size %zu (total %d)",
                            chan->conn->pc, chan->dc, chunk, total_chunks, message_size, total_message_size);
@@ -403,7 +403,7 @@ static void myErrorCallback(int id __maybe_unused, const char *error, void *user
     WEBRTC_DC *chan = user_ptr;
     internal_fatal(chan->dc != id, "WEBRTC[%d],DC[%d]: dc mismatch, expected %d, got %d", chan->conn->pc, chan->dc, chan->dc, id);
 
-    error("WEBRTC[%d],DC[%d]: ERROR: '%s'", chan->conn->pc, chan->dc, error);
+    netdata_log_error("WEBRTC[%d],DC[%d]: ERROR: '%s'", chan->conn->pc, chan->dc, error);
 }
 
 static void myMessageCallback(int id __maybe_unused, const char *message, int size, void *user_ptr) {
@@ -464,19 +464,19 @@ static void myDataChannelCallback(int pc __maybe_unused, int dc, void *user_ptr)
     chan->label = strdupz(label);
 
     if(rtcSetOpenCallback(dc, myOpenCallback) != RTC_ERR_SUCCESS)
-        error("WEBRTC[%d],DC[%d]: rtcSetOpenCallback() failed.", conn->pc, chan->dc);
+        netdata_log_error("WEBRTC[%d],DC[%d]: rtcSetOpenCallback() failed.", conn->pc, chan->dc);
 
     if(rtcSetClosedCallback(dc, myClosedCallback) != RTC_ERR_SUCCESS)
-        error("WEBRTC[%d],DC[%d]: rtcSetClosedCallback() failed.", conn->pc, chan->dc);
+        netdata_log_error("WEBRTC[%d],DC[%d]: rtcSetClosedCallback() failed.", conn->pc, chan->dc);
 
     if(rtcSetErrorCallback(dc, myErrorCallback) != RTC_ERR_SUCCESS)
-        error("WEBRTC[%d],DC[%d]: rtcSetErrorCallback() failed.", conn->pc, chan->dc);
+        netdata_log_error("WEBRTC[%d],DC[%d]: rtcSetErrorCallback() failed.", conn->pc, chan->dc);
 
     if(rtcSetMessageCallback(dc, myMessageCallback) != RTC_ERR_SUCCESS)
-        error("WEBRTC[%d],DC[%d]: rtcSetMessageCallback() failed.", conn->pc, chan->dc);
+        netdata_log_error("WEBRTC[%d],DC[%d]: rtcSetMessageCallback() failed.", conn->pc, chan->dc);
 
 //    if(rtcSetAvailableCallback(dc, myAvailableCallback) != RTC_ERR_SUCCESS)
-//        error("WEBRTC[%d],DC[%d]: rtcSetAvailableCallback() failed.", conn->pc, chan->dc);
+//        netdata_log_error("WEBRTC[%d],DC[%d]: rtcSetAvailableCallback() failed.", conn->pc, chan->dc);
 
     internal_error(true, "WEBRTC[%d],DC[%d]: new data channel with label '%s'", chan->conn->pc, chan->dc, chan->label);
 }
@@ -671,29 +671,29 @@ int webrtc_new_connection(const char *sdp, BUFFER *wb) {
     rtcSetUserPointer(conn->pc, conn);
 
     if(rtcSetLocalDescriptionCallback(conn->pc, myDescriptionCallback) != RTC_ERR_SUCCESS)
-        error("WEBRTC[%d]: rtcSetLocalDescriptionCallback() failed", conn->pc);
+        netdata_log_error("WEBRTC[%d]: rtcSetLocalDescriptionCallback() failed", conn->pc);
 
     if(rtcSetLocalCandidateCallback(conn->pc, myCandidateCallback) != RTC_ERR_SUCCESS)
-        error("WEBRTC[%d]: rtcSetLocalCandidateCallback() failed", conn->pc);
+        netdata_log_error("WEBRTC[%d]: rtcSetLocalCandidateCallback() failed", conn->pc);
 
     if(rtcSetStateChangeCallback(conn->pc, myStateChangeCallback) != RTC_ERR_SUCCESS)
-        error("WEBRTC[%d]: rtcSetStateChangeCallback() failed", conn->pc);
+        netdata_log_error("WEBRTC[%d]: rtcSetStateChangeCallback() failed", conn->pc);
 
     if(rtcSetGatheringStateChangeCallback(conn->pc, myGatheringStateCallback) != RTC_ERR_SUCCESS)
-        error("WEBRTC[%d]: rtcSetGatheringStateChangeCallback() failed", conn->pc);
+        netdata_log_error("WEBRTC[%d]: rtcSetGatheringStateChangeCallback() failed", conn->pc);
 
     if(rtcSetDataChannelCallback(conn->pc, myDataChannelCallback) != RTC_ERR_SUCCESS)
-        error("WEBRTC[%d]: rtcSetDataChannelCallback() failed", conn->pc);
+        netdata_log_error("WEBRTC[%d]: rtcSetDataChannelCallback() failed", conn->pc);
 
     // initialize the handshake
     internal_error(true, "WEBRTC[%d]: setting remote sdp: %s", conn->pc, sdp);
     if(rtcSetRemoteDescription(conn->pc, sdp, "offer") != RTC_ERR_SUCCESS)
-        error("WEBRTC[%d]: rtcSetRemoteDescription() failed", conn->pc);
+        netdata_log_error("WEBRTC[%d]: rtcSetRemoteDescription() failed", conn->pc);
 
     // initiate the handshake process
     if(conn->config.disableAutoNegotiation) {
         if(rtcSetLocalDescription(conn->pc, NULL) != RTC_ERR_SUCCESS)
-            error("WEBRTC[%d]: rtcSetLocalDescription() failed", conn->pc);
+            netdata_log_error("WEBRTC[%d]: rtcSetLocalDescription() failed", conn->pc);
     }
 
     bool logged = false;

--- a/web/server/h2o/http_server.c
+++ b/web/server/h2o/http_server.c
@@ -78,11 +78,11 @@ static int ssl_init()
 
     /* load certificate and private key */
     if (SSL_CTX_use_PrivateKey_file(accept_ctx.ssl_ctx, key_fn, SSL_FILETYPE_PEM) != 1) {
-        error("Could not load server key from \"%s\"", key_fn);
+        netdata_log_error("Could not load server key from \"%s\"", key_fn);
         return -1;
     }
     if (SSL_CTX_use_certificate_file(accept_ctx.ssl_ctx, cert_fn, SSL_FILETYPE_PEM) != 1) {
-        error("Could not load certificate from \"%s\"", cert_fn);
+        netdata_log_error("Could not load certificate from \"%s\"", cert_fn);
         return -1;
     }
 
@@ -318,14 +318,14 @@ void *h2o_main(void *ptr) {
     accept_ctx.hosts = config.hosts;
 
     if (create_listener(bind_addr, bind_port) != 0) {
-        error("failed to create listener %s:%d", bind_addr, bind_port);
+        netdata_log_error("failed to create listener %s:%d", bind_addr, bind_port);
         return NULL;
     }
 
     while (service_running(SERVICE_HTTPD)) {
         int rc = h2o_evloop_run(ctx.loop, POLL_INTERVAL);
         if (rc < 0 && errno != EINTR) {
-            error("h2o_evloop_run returned (%d) with errno other than EINTR. Aborting", rc);
+            netdata_log_error("h2o_evloop_run returned (%d) with errno other than EINTR. Aborting", rc);
             break;
         }
     } 

--- a/web/server/static/static-threaded.c
+++ b/web/server/static/static-threaded.c
@@ -180,7 +180,7 @@ static int web_server_file_write_callback(POLLINFO *pi, short int *events) {
     (void)events;
 
     worker_is_busy(WORKER_JOB_WRITE_FILE);
-    error("Writing to web files is not supported!");
+    netdata_log_error("Writing to web files is not supported!");
     worker_is_idle();
 
     return -1;
@@ -325,7 +325,7 @@ static int web_server_rcv_callback(POLLINFO *pi, short int *events) {
                     if(fpi)
                         w->pollinfo_filecopy_slot = fpi->slot;
                     else {
-                        error("Failed to add filecopy fd. Closing client.");
+                        netdata_log_error("Failed to add filecopy fd. Closing client.");
                         ret = -1;
                         goto cleanup;
                     }
@@ -483,7 +483,7 @@ static void socket_listen_main_static_threaded_cleanup(void *ptr) {
 //    }
 //
 //    if(found)
-//        error("%d static web threads are taking too long to finish. Giving up.", found);
+//        netdata_log_error("%d static web threads are taking too long to finish. Giving up.", found);
 
     netdata_log_info("closing all web server sockets...");
     listen_sockets_close(&api_sockets);


### PR DESCRIPTION
##### Summary
This PR proceeds with changes started when we merge PR https://github.com/netdata/netdata/pull/15266.

The reasons are the same that other PR was made.
##### Test Plan

1. Compile this branch and let it running.
2. Now review if nothing is missed running inside branch.

```sh
$ grep -r "error(" *| less
```

We should have netdata running and our code (please, ignore submodules) should not have any `error` function.
##### Additional Information
To make this PR I used `CLion` to rename functions, and after this I used `grep` and `git diff` to check that everything was renamed properly.

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? the whole code.
- Can they see the change or is it an under the hood? If they can see it, where? No, this affects more package maintainers.
- How is the user impacted by the change? They will have maintainers releasing packages faster.
- What are there any benefits of the change? We will not affect other software compilation.
</details>
