### PR TITLE
ci: disable clang format

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -38,17 +38,17 @@ jobs:
           else
             echo "run=false" >> "${GITHUB_OUTPUT}"
           fi
-      - name: Check files for clang-format
-        id: clangformat
-        run: |
-          if [ "${{ contains(github.event.pull_request.labels.*.name, 'run-ci/clang-format') }}" = "true" ]; then
-            echo "run=true" >> "${GITHUB_OUTPUT}"
-          elif git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '\.cpp$|\.cxx$|\.c$|\.hpp$|\.hxx$|\.h$' ; then
-            echo "run=true" >> "${GITHUB_OUTPUT}"
-            echo 'C/C++ code has changed, need to run clang-format.'
-          else
-            echo "run=false" >> "${GITHUB_OUTPUT}"
-          fi
+      # - name: Check files for clang-format
+      #   id: clangformat
+      #   run: |
+      #     if [ "${{ contains(github.event.pull_request.labels.*.name, 'run-ci/clang-format') }}" = "true" ]; then
+      #       echo "run=true" >> "${GITHUB_OUTPUT}"
+      #     elif git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '\.cpp$|\.cxx$|\.c$|\.hpp$|\.hxx$|\.h$' ; then
+      #       echo "run=true" >> "${GITHUB_OUTPUT}"
+      #       echo 'C/C++ code has changed, need to run clang-format.'
+      #     else
+      #       echo "run=false" >> "${GITHUB_OUTPUT}"
+      #     fi
       - name: Check files for eslint
         id: eslint
         run: |


### PR DESCRIPTION
##### Summary

Because no one formats .c files and this check always fails.

##### Test Plan

Not needed

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
