### PR TITLE
Check for source field when requesting /api/v1/alarm_log

### DIFF
--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -1345,7 +1345,7 @@ void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *
         if (sqlite3_column_type(res, 31) != SQLITE_NULL)
             uuid_unparse_lower(*((uuid_t *) sqlite3_column_blob(res, 31)), transition_id);
 
-        char *edit_command = health_edit_command_from_source((char *)sqlite3_column_text(res, 17));
+        char *edit_command = sqlite3_column_bytes(res, 17) > 0 ? health_edit_command_from_source((char *)sqlite3_column_text(res, 17)) : strdupz("UNKNOWN=0=UNKNOWN");
 
         if (count)
             buffer_sprintf(wb, ",");
@@ -1415,7 +1415,7 @@ void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *
             sqlite3_column_text(res, 15) ? (const char *) sqlite3_column_text(res, 15) : string2str(host->health.health_default_exec),
             sqlite3_column_text(res, 16) ? (const char *) sqlite3_column_text(res, 16) : string2str(host->health.health_default_recipient),
             sqlite3_column_int(res, 20),
-            sqlite3_column_text(res, 17),
+            sqlite3_column_text(res, 17) ? (const char *) sqlite3_column_text(res, 17) : (char *) "Unknown",
             edit_command,
             sqlite3_column_text(res, 18),
             (long unsigned int)sqlite3_column_int64(res, 6),


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #15304 

Adds a check for the `source` field when `api/v1/alarm_log` is requested. Will also investigate the missing field in a separate PR.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

To trigger the issue:

While an agent is running, update the `source` field of table `alert_hash` to NULL for a couple of alerts (that are running on the system). Request `http://localhost:19999/api/v1/alarm_log`. Without this PR there is a crash, with this PR there is not.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
