### PR TITLE
Release acquired dimensions

### DIFF
--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -529,8 +529,10 @@ static inline PARSER_RC pluginsd_chart(char **words, size_t num_words, PARSER *p
 
     if (likely(st)) {
         if (options && *options) {
-            if (strstr(options, "obsolete"))
+            if (strstr(options, "obsolete")) {
+                pluginsd_rrdset_cleanup(st);
                 rrdset_is_obsolete(st);
+            }
             else
                 rrdset_isnot_obsolete(st);
 


### PR DESCRIPTION
Fixes #15268
##### Summary
- When a chart is obsoleted (e.g from an external collector) release the acquired dimensions to allow proper chart cleanup

This would make the cleanup incomplete as the chart dimensions would not be deleted (thought to be still in use). Additional code may be needed in the service cleanup (as commented in the linked issue) to make this process more robust.
