### PR TITLE
local-listener using libnetdata

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -283,6 +283,7 @@ CGROUP_NETWORK_FILES = \
 
 LOCAL_LISTENERS_FILES = \
     collectors/plugins.d/local_listeners.c \
+    $(LIBNETDATA_FILES) \
     $(NULL)
 
 DISKSPACE_PLUGIN_FILES = \
@@ -1213,6 +1214,7 @@ if ENABLE_PLUGIN_LOCAL_LISTENERS
     plugins_PROGRAMS += local-listeners
     local_listeners_SOURCES = $(LOCAL_LISTENERS_FILES)
     local_listeners_LDADD = \
+        $(NETDATA_COMMON_LIBS) \
         $(NULL)
 endif
 

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -781,7 +781,7 @@ void debug_int( const char *file, const char *function, const unsigned long line
 void info_int( int is_collector, const char *file __maybe_unused, const char *function __maybe_unused, const unsigned long line __maybe_unused, const char *fmt, ... )
 {
     va_list args;
-    FILE *fp = (is_collector) ? stderr : stderror;
+    FILE *fp = (is_collector || !stderror) ? stderr : stderror;
 
     log_lock();
 
@@ -910,7 +910,7 @@ void error_limit_int(ERROR_LIMIT *erl, const char *prefix, const char *file __ma
 void error_int(int is_collector, const char *prefix, const char *file __maybe_unused, const char *function __maybe_unused, const unsigned long line __maybe_unused, const char *fmt, ... ) {
     // save a copy of errno - just in case this function generates a new error
     int __errno = errno;
-    FILE *fp = (is_collector) ? stderr : stderror;
+    FILE *fp = (is_collector || !stderror) ? stderr : stderror;
 
     va_list args;
 


### PR DESCRIPTION
- [x] local-listener is now linked against libnetdata
- [x] when the list of listening sockets is huge, this version removes items from the hash table as soon as they are used, so the speed over time increases.