### PR TITLE
Fix coverity issue 394862 - Argument cannot be negative

### DIFF
--- a/claim/claim.c
+++ b/claim/claim.c
@@ -253,16 +253,17 @@ bool netdata_random_session_id_generate(void) {
         netdata_log_error("Cannot create random session id file '%s'.", filename);
         ret = false;
     }
+    else {
+        if (write(fd, guid, UUID_STR_LEN - 1) != UUID_STR_LEN - 1) {
+            netdata_log_error("Cannot write the random session id file '%s'.", filename);
+            ret = false;
+        }
 
-    if(write(fd, guid, UUID_STR_LEN - 1) != UUID_STR_LEN - 1) {
-        netdata_log_error("Cannot write the random session id file '%s'.", filename);
-        ret = false;
+        ssize_t rc = write(fd, "\n", 1);
+        (void)rc;
+
+        close(fd);
     }
-
-    ssize_t rc = write(fd, "\n", 1);
-    (void)rc;
-
-    close(fd);
 
     if(ret && (!netdata_random_session_id_filename || strcmp(netdata_random_session_id_filename, filename) != 0)) {
         freez(netdata_random_session_id_filename);

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -257,11 +257,8 @@ bool netdata_random_session_id_generate(void) {
         if (write(fd, guid, UUID_STR_LEN - 1) != UUID_STR_LEN - 1) {
             netdata_log_error("Cannot write the random session id file '%s'.", filename);
             ret = false;
-        }
-
-        ssize_t rc = write(fd, "\n", 1);
-        (void)rc;
-
+        } else
+            (void) write(fd, "\n", 1);
         close(fd);
     }
 


### PR DESCRIPTION
##### Summary
Avoid attempt to write to the file if the open command fails


