### PR TITLE
Use spinlock in host and chart

### DIFF
--- a/database/contexts/api_v2.c
+++ b/database/contexts/api_v2.c
@@ -405,7 +405,7 @@ static FTS_MATCH rrdcontext_to_json_v2_full_text_search(struct rrdcontext_to_jso
 
         if(ri->rrdset) {
             RRDSET *st = ri->rrdset;
-            netdata_rwlock_rdlock(&st->alerts.rwlock);
+            rw_spinlock_read_lock(&st->alerts.spinlock);
             for (RRDCALC *rcl = st->alerts.base; rcl; rcl = rcl->next) {
                 if(unlikely(full_text_search_string(&ctl->q.fts, q, rcl->name))) {
                     matched = FTS_MATCHED_ALERT;
@@ -417,7 +417,7 @@ static FTS_MATCH rrdcontext_to_json_v2_full_text_search(struct rrdcontext_to_jso
                     break;
                 }
             }
-            netdata_rwlock_unlock(&st->alerts.rwlock);
+            rw_spinlock_read_unlock(&st->alerts.spinlock);
         }
     }
     dfe_done(ri);
@@ -430,7 +430,7 @@ static bool rrdcontext_matches_alert(struct rrdcontext_to_json_v2_data *ctl, RRD
     dfe_start_read(rc->rrdinstances, ri) {
         if(ri->rrdset) {
             RRDSET *st = ri->rrdset;
-            netdata_rwlock_rdlock(&st->alerts.rwlock);
+            rw_spinlock_read_lock(&st->alerts.spinlock);
             for (RRDCALC *rcl = st->alerts.base; rcl; rcl = rcl->next) {
                 if(ctl->alerts.alert_name_pattern && !simple_pattern_matches_string(ctl->alerts.alert_name_pattern, rcl->name))
                     continue;
@@ -488,7 +488,7 @@ static bool rrdcontext_matches_alert(struct rrdcontext_to_json_v2_data *ctl, RRD
                     dictionary_set(ctl->alerts.alert_instances, key, &z, sizeof(z));
                 }
             }
-            netdata_rwlock_unlock(&st->alerts.rwlock);
+            rw_spinlock_read_unlock(&st->alerts.spinlock);
         }
     }
     dfe_done(ri);

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1106,7 +1106,7 @@ typedef struct alarm_log {
     unsigned int count;
     unsigned int max;
     ALARM_ENTRY *alarms;
-    netdata_rwlock_t alarm_log_rwlock;
+    RW_SPINLOCK alarm_log_rwlock;
 } ALARM_LOG;
 
 typedef struct health {

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -886,7 +886,7 @@ struct rrdset {
     const RRDFAMILY_ACQUIRED *rrdfamily;            // pointer to RRDFAMILY dictionary item, this chart belongs to
 
     struct {
-        netdata_rwlock_t rwlock;                    // protection for RRDCALC *base
+        RW_SPINLOCK spinlock;                       // protection for RRDCALC *base
         RRDCALC *base;                              // double linked list of RRDCALC related to this RRDSET
     } alerts;
 
@@ -1106,7 +1106,7 @@ typedef struct alarm_log {
     unsigned int count;
     unsigned int max;
     ALARM_ENTRY *alarms;
-    RW_SPINLOCK alarm_log_rwlock;
+    RW_SPINLOCK spinlock;
 } ALARM_LOG;
 
 typedef struct health {

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -62,7 +62,7 @@ inline const char *rrdcalc_status2string(RRDCALC_STATUS status) {
 }
 
 uint32_t rrdcalc_get_unique_id(RRDHOST *host, STRING *chart, STRING *name, uint32_t *next_event_id, uuid_t *config_hash_id) {
-    netdata_rwlock_rdlock(&host->health_log.alarm_log_rwlock);
+    netdata_rwlock_rdlock(&host->health_log.spinlock);
 
     // re-use old IDs, by looking them up in the alarm log
     ALARM_ENTRY *ae = NULL;
@@ -89,7 +89,7 @@ uint32_t rrdcalc_get_unique_id(RRDHOST *host, STRING *chart, STRING *name, uint3
         }
     }
 
-    netdata_rwlock_unlock(&host->health_log.alarm_log_rwlock);
+    netdata_rwlock_unlock(&host->health_log.spinlock);
     return alarm_id;
 }
 
@@ -212,9 +212,9 @@ static void rrdcalc_link_to_rrdset(RRDSET *st, RRDCALC *rc) {
     rc->last_status_change = now_realtime_sec();
     rc->rrdset = st;
 
-    netdata_rwlock_wrlock(&st->alerts.rwlock);
+    rw_spinlock_write_lock(&st->alerts.spinlock);
     DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(st->alerts.base, rc, prev, next);
-    netdata_rwlock_unlock(&st->alerts.rwlock);
+    rw_spinlock_write_unlock(&st->alerts.spinlock);
 
     if(rc->update_every < rc->rrdset->update_every) {
         netdata_log_error("Health alarm '%s.%s' has update every %d, less than chart update every %d. Setting alarm update frequency to %d.", rrdset_id(rc->rrdset), rrdcalc_name(rc), rc->update_every, rc->rrdset->update_every, rc->rrdset->update_every);
@@ -362,12 +362,12 @@ static void rrdcalc_unlink_from_rrdset(RRDCALC *rc, bool having_ll_wrlock) {
     // unlink it
 
     if(!having_ll_wrlock)
-        netdata_rwlock_wrlock(&st->alerts.rwlock);
+        rw_spinlock_write_lock(&st->alerts.spinlock);
 
     DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(st->alerts.base, rc, prev, next);
 
     if(!having_ll_wrlock)
-        netdata_rwlock_unlock(&st->alerts.rwlock);
+        rw_spinlock_write_unlock(&st->alerts.spinlock);
 
     rc->rrdset = NULL;
 
@@ -808,7 +808,7 @@ void rrdcalc_delete_alerts_not_matching_host_labels_from_all_hosts() {
 
 void rrdcalc_unlink_all_rrdset_alerts(RRDSET *st) {
     RRDCALC *rc, *last = NULL;
-    netdata_rwlock_wrlock(&st->alerts.rwlock);
+    rw_spinlock_write_lock(&st->alerts.spinlock);
     while((rc = st->alerts.base)) {
         if(last == rc) {
             netdata_log_error("RRDCALC: malformed list of alerts linked to chart - cannot cleanup - giving up.");
@@ -827,7 +827,7 @@ void rrdcalc_unlink_all_rrdset_alerts(RRDSET *st) {
         }
 
     }
-    netdata_rwlock_unlock(&st->alerts.rwlock);
+    rw_spinlock_write_unlock(&st->alerts.spinlock);
 }
 
 void rrdcalc_delete_all(RRDHOST *host) {

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -62,7 +62,7 @@ inline const char *rrdcalc_status2string(RRDCALC_STATUS status) {
 }
 
 uint32_t rrdcalc_get_unique_id(RRDHOST *host, STRING *chart, STRING *name, uint32_t *next_event_id, uuid_t *config_hash_id) {
-    netdata_rwlock_rdlock(&host->health_log.spinlock);
+    rw_spinlock_read_lock(&host->health_log.spinlock);
 
     // re-use old IDs, by looking them up in the alarm log
     ALARM_ENTRY *ae = NULL;
@@ -89,7 +89,7 @@ uint32_t rrdcalc_get_unique_id(RRDHOST *host, STRING *chart, STRING *name, uint3
         }
     }
 
-    netdata_rwlock_unlock(&host->health_log.spinlock);
+    rw_spinlock_read_unlock(&host->health_log.spinlock);
     return alarm_id;
 }
 

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1260,7 +1260,6 @@ void rrdhost_free___while_having_rrd_wrlock(RRDHOST *host, bool force) {
     string_freez(host->health.health_default_recipient);
     string_freez(host->registry_hostname);
     simple_pattern_free(host->rrdpush_send_charts_matching);
-    netdata_rwlock_destroy(&host->health_log.alarm_log_rwlock);
     freez(host->node_id);
 
     rrdfamily_index_destroy(host);

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -143,7 +143,7 @@ static void rrdset_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
                 | RRDSET_FLAG_SENDER_REPLICATION_FINISHED
                 ;
 
-    netdata_rwlock_init(&st->alerts.rwlock);
+    rw_spinlock_init(&st->alerts.spinlock);
 
     if(st->rrd_memory_mode == RRD_MEMORY_MODE_SAVE || st->rrd_memory_mode == RRD_MEMORY_MODE_MAP) {
         if(!rrdset_memory_load_or_create_map_save(st, st->rrd_memory_mode)) {
@@ -262,8 +262,6 @@ static void rrdset_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, v
 
     // ------------------------------------------------------------------------
     // free it
-
-    netdata_rwlock_destroy(&st->alerts.rwlock);
 
     string_freez(st->id);
     string_freez(st->name);

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -789,7 +789,7 @@ void sql_health_alarm_log_load(RRDHOST *host) {
     }
     foreach_rrdcalc_in_rrdhost_done(rc);
 
-    netdata_rwlock_rdlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_read_lock(&host->health_log.alarm_log_rwlock);
 
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
         ALARM_ENTRY *ae = NULL;
@@ -947,7 +947,7 @@ void sql_health_alarm_log_load(RRDHOST *host) {
         loaded++;
     }
 
-    netdata_rwlock_unlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_read_unlock(&host->health_log.alarm_log_rwlock);
 
     dictionary_destroy(all_rrdcalcs);
     all_rrdcalcs = NULL;

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -789,7 +789,7 @@ void sql_health_alarm_log_load(RRDHOST *host) {
     }
     foreach_rrdcalc_in_rrdhost_done(rc);
 
-    rw_spinlock_read_lock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_read_lock(&host->health_log.spinlock);
 
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
         ALARM_ENTRY *ae = NULL;
@@ -947,7 +947,7 @@ void sql_health_alarm_log_load(RRDHOST *host) {
         loaded++;
     }
 
-    rw_spinlock_read_unlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_read_unlock(&host->health_log.spinlock);
 
     dictionary_destroy(all_rrdcalcs);
     all_rrdcalcs = NULL;

--- a/health/health.c
+++ b/health/health.c
@@ -346,13 +346,13 @@ static void health_reload_host(RRDHOST *host) {
     rrdcalctemplate_delete_all(host);
 
     // invalidate all previous entries in the alarm log
-    rw_spinlock_read_lock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_read_lock(&host->health_log.spinlock);
     ALARM_ENTRY *t;
     for(t = host->health_log.alarms ; t ; t = t->next) {
         if(t->new_status != RRDCALC_STATUS_REMOVED)
             t->flags |= HEALTH_ENTRY_FLAG_UPDATED;
     }
-    rw_spinlock_read_unlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_read_unlock(&host->health_log.spinlock);
 
     // reset all thresholds to all charts
     RRDSET *st;
@@ -632,7 +632,7 @@ static inline void health_alarm_log_process(RRDHOST *host) {
     uint32_t first_waiting = (host->health_log.alarms)?host->health_log.alarms->unique_id:0;
     time_t now = now_realtime_sec();
 
-    rw_spinlock_read_lock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_read_lock(&host->health_log.spinlock);
 
     ALARM_ENTRY *ae;
     for(ae = host->health_log.alarms; ae && ae->unique_id >= host->health_last_processed_id; ae = ae->next) {
@@ -648,13 +648,13 @@ static inline void health_alarm_log_process(RRDHOST *host) {
         }
     }
 
-    rw_spinlock_read_unlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_read_unlock(&host->health_log.spinlock);
 
     // remember this for the next iteration
     host->health_last_processed_id = first_waiting;
 
     //delete those that are updated, no in progress execution, and is not repeating
-    rw_spinlock_write_lock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_write_lock(&host->health_log.spinlock);
 
     ALARM_ENTRY *prev = NULL, *next = NULL;
     for(ae = host->health_log.alarms; ae ; ae = next) {
@@ -686,7 +686,7 @@ static inline void health_alarm_log_process(RRDHOST *host) {
             prev = ae;
     }
 
-    rw_spinlock_write_unlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_write_unlock(&host->health_log.spinlock);
 }
 
 static inline int rrdcalc_isrunnable(RRDCALC *rc, time_t now, time_t *next_run) {
@@ -815,7 +815,7 @@ static void initialize_health(RRDHOST *host)
     conf_enabled_alarms = simple_pattern_create(config_get(CONFIG_SECTION_HEALTH, "enabled alarms", "*"), NULL,
                                                 SIMPLE_PATTERN_EXACT, true);
 
-    rw_spinlock_init(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_init(&host->health_log.spinlock);
 
     char filename[FILENAME_MAX + 1];
 

--- a/health/health.c
+++ b/health/health.c
@@ -346,13 +346,13 @@ static void health_reload_host(RRDHOST *host) {
     rrdcalctemplate_delete_all(host);
 
     // invalidate all previous entries in the alarm log
-    netdata_rwlock_rdlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_read_lock(&host->health_log.alarm_log_rwlock);
     ALARM_ENTRY *t;
     for(t = host->health_log.alarms ; t ; t = t->next) {
         if(t->new_status != RRDCALC_STATUS_REMOVED)
             t->flags |= HEALTH_ENTRY_FLAG_UPDATED;
     }
-    netdata_rwlock_unlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_read_unlock(&host->health_log.alarm_log_rwlock);
 
     // reset all thresholds to all charts
     RRDSET *st;
@@ -632,7 +632,7 @@ static inline void health_alarm_log_process(RRDHOST *host) {
     uint32_t first_waiting = (host->health_log.alarms)?host->health_log.alarms->unique_id:0;
     time_t now = now_realtime_sec();
 
-    netdata_rwlock_rdlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_read_lock(&host->health_log.alarm_log_rwlock);
 
     ALARM_ENTRY *ae;
     for(ae = host->health_log.alarms; ae && ae->unique_id >= host->health_last_processed_id; ae = ae->next) {
@@ -648,13 +648,13 @@ static inline void health_alarm_log_process(RRDHOST *host) {
         }
     }
 
-    netdata_rwlock_unlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_read_unlock(&host->health_log.alarm_log_rwlock);
 
     // remember this for the next iteration
     host->health_last_processed_id = first_waiting;
 
     //delete those that are updated, no in progress execution, and is not repeating
-    netdata_rwlock_wrlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_write_lock(&host->health_log.alarm_log_rwlock);
 
     ALARM_ENTRY *prev = NULL, *next = NULL;
     for(ae = host->health_log.alarms; ae ; ae = next) {
@@ -686,7 +686,7 @@ static inline void health_alarm_log_process(RRDHOST *host) {
             prev = ae;
     }
 
-    netdata_rwlock_unlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_write_unlock(&host->health_log.alarm_log_rwlock);
 }
 
 static inline int rrdcalc_isrunnable(RRDCALC *rc, time_t now, time_t *next_run) {
@@ -815,7 +815,7 @@ static void initialize_health(RRDHOST *host)
     conf_enabled_alarms = simple_pattern_create(config_get(CONFIG_SECTION_HEALTH, "enabled alarms", "*"), NULL,
                                                 SIMPLE_PATTERN_EXACT, true);
 
-    netdata_rwlock_init(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_init(&host->health_log.alarm_log_rwlock);
 
     char filename[FILENAME_MAX + 1];
 

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -94,14 +94,14 @@ inline void health_alarm_log_add_entry(
     __atomic_add_fetch(&host->health_transitions, 1, __ATOMIC_RELAXED);
 
     // link it
-    netdata_rwlock_wrlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_write_lock(&host->health_log.alarm_log_rwlock);
     ae->next = host->health_log.alarms;
     host->health_log.alarms = ae;
     host->health_log.count++;
-    netdata_rwlock_unlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_write_unlock(&host->health_log.alarm_log_rwlock);
 
     // match previous alarms
-    netdata_rwlock_rdlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_read_lock(&host->health_log.alarm_log_rwlock);
     ALARM_ENTRY *t;
     for(t = host->health_log.alarms ; t ; t = t->next) {
         if(t != ae && t->alarm_id == ae->alarm_id) {
@@ -121,7 +121,7 @@ inline void health_alarm_log_add_entry(
             break;
         }
     }
-    netdata_rwlock_unlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_read_unlock(&host->health_log.alarm_log_rwlock);
 
     health_alarm_log_save(host, ae);
 }
@@ -145,7 +145,7 @@ inline void health_alarm_log_free_one_nochecks_nounlink(ALARM_ENTRY *ae) {
 }
 
 inline void health_alarm_log_free(RRDHOST *host) {
-    netdata_rwlock_wrlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_write_lock(&host->health_log.alarm_log_rwlock);
 
     ALARM_ENTRY *ae;
     while((ae = host->health_log.alarms)) {
@@ -153,5 +153,5 @@ inline void health_alarm_log_free(RRDHOST *host) {
         health_alarm_log_free_one_nochecks_nounlink(ae);
     }
 
-    netdata_rwlock_unlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_write_unlock(&host->health_log.alarm_log_rwlock);
 }

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -94,14 +94,14 @@ inline void health_alarm_log_add_entry(
     __atomic_add_fetch(&host->health_transitions, 1, __ATOMIC_RELAXED);
 
     // link it
-    rw_spinlock_write_lock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_write_lock(&host->health_log.spinlock);
     ae->next = host->health_log.alarms;
     host->health_log.alarms = ae;
     host->health_log.count++;
-    rw_spinlock_write_unlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_write_unlock(&host->health_log.spinlock);
 
     // match previous alarms
-    rw_spinlock_read_lock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_read_lock(&host->health_log.spinlock);
     ALARM_ENTRY *t;
     for(t = host->health_log.alarms ; t ; t = t->next) {
         if(t != ae && t->alarm_id == ae->alarm_id) {
@@ -121,7 +121,7 @@ inline void health_alarm_log_add_entry(
             break;
         }
     }
-    rw_spinlock_read_unlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_read_unlock(&host->health_log.spinlock);
 
     health_alarm_log_save(host, ae);
 }
@@ -145,7 +145,7 @@ inline void health_alarm_log_free_one_nochecks_nounlink(ALARM_ENTRY *ae) {
 }
 
 inline void health_alarm_log_free(RRDHOST *host) {
-    rw_spinlock_write_lock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_write_lock(&host->health_log.spinlock);
 
     ALARM_ENTRY *ae;
     while((ae = host->health_log.alarms)) {
@@ -153,5 +153,5 @@ inline void health_alarm_log_free(RRDHOST *host) {
         health_alarm_log_free_one_nochecks_nounlink(ae);
     }
 
-    rw_spinlock_write_unlock(&host->health_log.alarm_log_rwlock);
+    rw_spinlock_write_unlock(&host->health_log.spinlock);
 }

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -615,7 +615,7 @@ static void query_target_summary_alerts_v2(BUFFER *wb, QUERY_TARGET *qt, const c
         QUERY_INSTANCE *qi = query_instance(qt, c);
         RRDSET *st = rrdinstance_acquired_rrdset(qi->ria);
         if (st) {
-            netdata_rwlock_rdlock(&st->alerts.rwlock);
+            rw_spinlock_read_lock(&st->alerts.spinlock);
             if (st->alerts.base) {
                 for (RRDCALC *rc = st->alerts.base; rc; rc = rc->next) {
                     z = dictionary_set(dict, string2str(rc->name), NULL, sizeof(*z));
@@ -642,7 +642,7 @@ static void query_target_summary_alerts_v2(BUFFER *wb, QUERY_TARGET *qt, const c
                     }
                 }
             }
-            netdata_rwlock_unlock(&st->alerts.rwlock);
+            rw_spinlock_read_unlock(&st->alerts.spinlock);
         }
     }
     dfe_start_read(dict, z)
@@ -931,7 +931,7 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb) {
 static void rrdset_rrdcalc_entries_v2(BUFFER *wb, RRDINSTANCE_ACQUIRED *ria) {
     RRDSET *st = rrdinstance_acquired_rrdset(ria);
     if(st) {
-        netdata_rwlock_rdlock(&st->alerts.rwlock);
+        rw_spinlock_read_lock(&st->alerts.spinlock);
         if(st->alerts.base) {
             buffer_json_member_add_object(wb, "alerts");
             for(RRDCALC *rc = st->alerts.base; rc ;rc = rc->next) {
@@ -946,7 +946,7 @@ static void rrdset_rrdcalc_entries_v2(BUFFER *wb, RRDINSTANCE_ACQUIRED *ria) {
             }
             buffer_json_object_close(wb);
         }
-        netdata_rwlock_unlock(&st->alerts.rwlock);
+        rw_spinlock_read_unlock(&st->alerts.spinlock);
     }
 }
 

--- a/web/api/formatters/rrdset2json.c
+++ b/web/api/formatters/rrdset2json.c
@@ -120,7 +120,7 @@ void rrdset2json(RRDSET *st, BUFFER *wb, size_t *dimensions_count, size_t *memor
         buffer_strcat(wb, ",\n\t\t\t\"alarms\": {\n");
         size_t alarms = 0;
         RRDCALC *rc;
-        netdata_rwlock_rdlock(&st->alerts.rwlock);
+        rw_spinlock_read_lock(&st->alerts.spinlock);
         DOUBLE_LINKED_LIST_FOREACH_FORWARD(st->alerts.base, rc, prev, next) {
             buffer_sprintf(
                 wb,
@@ -136,7 +136,7 @@ void rrdset2json(RRDSET *st, BUFFER *wb, size_t *dimensions_count, size_t *memor
 
             alarms++;
         }
-        netdata_rwlock_unlock(&st->alerts.rwlock);
+        rw_spinlock_read_unlock(&st->alerts.spinlock);
         buffer_sprintf(wb,
                        "\n\t\t\t}"
         );


### PR DESCRIPTION
##### Summary

Use the new rw_spinlock to reduce the memory needed by rrdhost and rrdset by 32 bytes

Chart is now 448 bytes and host is at 896 (previously 480 and 928 respectively)

