### PR TITLE
Fix compilation on BSD

### DIFF
--- a/libnetdata/os.c
+++ b/libnetdata/os.c
@@ -28,7 +28,7 @@ long get_system_cpus_with_cache(bool cache, bool for_netdata) {
     bool error = false;
 
     if (unlikely(GETSYSCTL_BY_NAME(HW_CPU_NAME, tmp_processors)))
-        netdata_log_error = true;
+        error = true;
     else
         processors[index] = tmp_processors;
 


### PR DESCRIPTION
##### Summar
Fix compilation on FreeBSD after we merge a PR renaming generic functions

##### Test Plan

1. Compile this branch on FreeBSD

##### Additional Information


<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? FreeBSD clients
- Can they see the change or is it an under the hood? If they can see it, where? yes, they can compile. 
- How is the user impacted by the change? We fix an issue created when a PR was merged.
- What are there any benefits of the change?  Netdata will compile again on FreeBSD
</details>
