### PR TITLE
Remove availability from required fields on metric level

### DIFF
--- a/collectors/metadata/schemas/single-module.json
+++ b/collectors/metadata/schemas/single-module.json
@@ -537,7 +537,6 @@
                   },
                   "required": [
                     "name",
-                    "availability",
                     "description",
                     "unit",
                     "chart_type",


### PR DESCRIPTION
##### Summary

As discussed, we don't really need to add it in every metric if it is empty. We have the top level availability list, if that is empty, then we can just not look for this entry in each metric.
