### PR TITLE
Attempt to more aggressively skip CI jobs on PRs if those jobs are irrelevant to the PR.

### DIFF
--- a/.github/workflows/build-dummy.yml
+++ b/.github/workflows/build-dummy.yml
@@ -37,8 +37,6 @@ jobs:
   build-dist: # Build the distribution tarball and store it as an artifact.
     name: Build Distribution Tarball
     runs-on: ubuntu-latest
-    outputs:
-      distfile: ${{ steps.build.outputs.distfile }}
     steps:
       - run: echo 'NOT REQUIRED'
 
@@ -74,27 +72,6 @@ jobs:
           matrix="$(.github/scripts/gen-matrix-build.py)"
           echo "Generated matrix: ${matrix}"
           echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
-      - name: Failure Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_COLOR: 'danger'
-          SLACK_FOOTER: ''
-          SLACK_ICON_EMOJI: ':github-actions:'
-          SLACK_TITLE: 'Build matrix preparation failed:'
-          SLACK_USERNAME: 'GitHub Actions'
-          SLACK_MESSAGE: |-
-              ${{ github.repository }}: Failed to prepare build matrix for build checks.
-              Checkout: ${{ steps.checkout.outcome }}
-              Prepare tools: ${{ steps.prepare.outcome }}
-              Read build matrix: ${{ steps.set-matrix.outcome }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: >-
-          ${{
-            failure()
-            && startsWith(github.ref, 'refs/heads/master')
-            && github.event_name != 'pull_request'
-            && github.repository == 'netdata/netdata'
-          }}
 
   prepare-test-images: # Prepare the test environments for our build checks. This also checks dependency handling code for each tested environment.
     name: Prepare Test Environments

--- a/.github/workflows/build-dummy.yml
+++ b/.github/workflows/build-dummy.yml
@@ -1,0 +1,164 @@
+---
+# Ci code for building release artifacts.
+#
+# This workflow exists so we can require these checks to pass, but skip
+# them on PRs that have nothing to do with the source code.
+name: Build
+on:
+  pull_request: # PR checks only validate the build and generate artifacts for testing.
+    paths-ignore: # This MUST be kept in-sync with the paths-ignore key for the build-dummy.yml workflow.
+      - '**.c'
+      - '**.cc'
+      - '**.h'
+      - '**.hh'
+      - '**.in'
+      - '!netdata.spec.in'
+      - 'configure.ac'
+      - 'netdata-installer.sh'
+      - '**/Makefile*'
+      - 'Makefile*'
+      - '.github/workflows/build.yml'
+      - '.github/scripts/build-static.sh'
+      - '.github/scripts/get-static-cache-key.sh'
+      - '.github/scripts/gen-matrix-build.py'
+      - '.github/scripts/run-updater-check.sh'
+      - 'build/**'
+      - 'packaging/makeself/**'
+      - 'packaging/installer/**'
+      - 'aclk/aclk-schemas/'
+      - 'ml/dlib/'
+      - 'mqtt_websockets'
+      - 'web/server/h2o/libh2o'
+      - '!**.md'
+concurrency: # This keeps multiple instances of the job from running concurrently for the same ref and event type.
+  group: build-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+jobs:
+  build-dist: # Build the distribution tarball and store it as an artifact.
+    name: Build Distribution Tarball
+    runs-on: ubuntu-latest
+    outputs:
+      distfile: ${{ steps.build.outputs.distfile }}
+    steps:
+      - run: echo 'NOT REQUIRED'
+
+  build-static: # Build the static binary archives, and store them as artifacts.
+    name: Build Static
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch:
+          - x86_64
+          - armv7l
+          - aarch64
+          - ppc64le
+    steps:
+      - run: echo 'NOT REQUIRED'
+
+  matrix: # Generate the shared build matrix for our build tests.
+    name: Prepare Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v3
+      - name: Prepare tools
+        id: prepare
+        run: |
+          sudo apt-get update && sudo apt-get install -y python3-ruamel.yaml
+      - name: Read build matrix
+        id: set-matrix
+        run: |
+          matrix="$(.github/scripts/gen-matrix-build.py)"
+          echo "Generated matrix: ${matrix}"
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+      - name: Failure Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: 'danger'
+          SLACK_FOOTER: ''
+          SLACK_ICON_EMOJI: ':github-actions:'
+          SLACK_TITLE: 'Build matrix preparation failed:'
+          SLACK_USERNAME: 'GitHub Actions'
+          SLACK_MESSAGE: |-
+              ${{ github.repository }}: Failed to prepare build matrix for build checks.
+              Checkout: ${{ steps.checkout.outcome }}
+              Prepare tools: ${{ steps.prepare.outcome }}
+              Read build matrix: ${{ steps.set-matrix.outcome }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: >-
+          ${{
+            failure()
+            && startsWith(github.ref, 'refs/heads/master')
+            && github.event_name != 'pull_request'
+            && github.repository == 'netdata/netdata'
+          }}
+
+  prepare-test-images: # Prepare the test environments for our build checks. This also checks dependency handling code for each tested environment.
+    name: Prepare Test Environments
+    runs-on: ubuntu-latest
+    needs:
+      - matrix
+    env:
+      RETRY_DELAY: 300
+    strategy:
+      # Unlike the actual build tests, this completes _very_ fast (average of about 3 minutes for each job), so we
+      # just run everything in parallel instead lof limiting job concurrency.
+      fail-fast: false
+      matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
+    steps:
+      - run: echo 'NOT REQUIRED'
+
+  source-build: # Test various source build arrangements.
+    name: Test Source Build
+    runs-on: ubuntu-latest
+    needs:
+      - matrix
+      - prepare-test-images
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
+    steps:
+      - run: echo 'NOT REQUIRED'
+
+  updater-check: # Test the generated dist archive using the updater code.
+    name: Test Generated Distfile and Updater Code
+    runs-on: ubuntu-latest
+    needs:
+      - build-dist
+      - matrix
+      - prepare-test-images
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
+    steps:
+      - run: echo 'NOT REQUIRED'
+
+  prepare-upload: # Consolidate the artifacts for uploading or releasing.
+    name: Prepare Artifacts
+    runs-on: ubuntu-latest
+    needs:
+      - build-dist
+      - build-static
+    steps:
+      - run: echo 'NOT REQUIRED'
+
+  artifact-verification-dist: # Verify the regular installer works with the consolidated artifacts.
+    name: Test Consolidated Artifacts (Source)
+    runs-on: ubuntu-latest
+    needs:
+      - prepare-upload
+    steps:
+      - run: echo 'NOT REQUIRED'
+
+  artifact-verification-static: # Verify the static installer works with the consolidated artifacts.
+    name: Test Consolidated Artifacts (Static)
+    runs-on: ubuntu-latest
+    needs:
+      - prepare-upload
+    steps:
+      - run: echo 'NOT REQUIRED'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,31 @@ on:
   push: # Master branch checks only validate the build and generate artifacts for testing.
     branches:
       - master
-  pull_request: null # PR checks only validate the build and generate artifacts for testing.
+  pull_request: # PR checks only validate the build and generate artifacts for testing.
+    paths: # This MUST be kept in-sync with the paths-ignore key for the build-dummy.yml workflow.
+      - '**.c'
+      - '**.cc'
+      - '**.h'
+      - '**.hh'
+      - '**.in'
+      - '!netdata.spec.in'
+      - 'configure.ac'
+      - 'netdata-installer.sh'
+      - '**/Makefile*'
+      - 'Makefile*'
+      - '.github/workflows/build.yml'
+      - '.github/scripts/build-static.sh'
+      - '.github/scripts/get-static-cache-key.sh'
+      - '.github/scripts/gen-matrix-build.py'
+      - '.github/scripts/run-updater-check.sh'
+      - 'build/**'
+      - 'packaging/makeself/**'
+      - 'packaging/installer/**'
+      - 'aclk/aclk-schemas/'
+      - 'ml/dlib/'
+      - 'mqtt_websockets'
+      - 'web/server/h2o/libh2o'
+      - '!**.md'
   workflow_dispatch: # Dispatch runs build and validate, then push to the appropriate storage location.
     inputs:
       type:

--- a/.github/workflows/checks-dummy.yml
+++ b/.github/workflows/checks-dummy.yml
@@ -1,0 +1,42 @@
+---
+name: Checks
+on:
+  pull_request:
+    paths-ignore: # This MUST be kept in sync with the paths key for the checks.yml workflow.
+      - '**.c'
+      - '**.cc'
+      - '**.h'
+      - '**.hh'
+      - '**.in'
+      - '!netdata.spec.in'
+      - 'configure.ac'
+      - '**/Makefile*'
+      - 'Makefile*'
+      - '.gitignore'
+      - '.github/workflows/checks.yml'
+      - 'build/**'
+      - 'aclk/aclk-schemas/'
+      - 'ml/dlib/'
+      - 'mqtt_websockets'
+      - 'web/server/h2o/libh2o'
+env:
+  DISABLE_TELEMETRY: 1
+concurrency:
+  group: checks-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  libressl-checks:
+    name: LibreSSL
+    runs-on: ubuntu-latest
+    steps:
+      - run: "echo 'NOT REQUIRED'"
+  clang-checks:
+    name: Clang
+    runs-on: ubuntu-latest
+    steps:
+      - run: "echo 'NOT REQUIRED'"
+  gitignore-check:
+    name: .gitignore
+    runs-on: ubuntu-latest
+    steps:
+      - run: "echo 'NOT REQUIRED'"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,9 +2,43 @@
 name: Checks
 on:
   push:
+    paths:
+      - '**.c'
+      - '**.cc'
+      - '**.h'
+      - '**.hh'
+      - '**.in'
+      - '!netdata.spec.in'
+      - 'configure.ac'
+      - '**/Makefile*'
+      - 'Makefile*'
+      - '.gitignore'
+      - '.github/workflows/checks.yml'
+      - 'build/**'
+      - 'aclk/aclk-schemas/'
+      - 'ml/dlib/'
+      - 'mqtt_websockets'
+      - 'web/server/h2o/libh2o'
     branches:
       - master
-  pull_request: null
+  pull_request:
+    paths: # This MUST be kept in-sync with the paths-ignore key for the checks-dummy.yml workflow.
+      - '**.c'
+      - '**.cc'
+      - '**.h'
+      - '**.hh'
+      - '**.in'
+      - '!netdata.spec.in'
+      - 'configure.ac'
+      - '**/Makefile*'
+      - 'Makefile*'
+      - '.gitignore'
+      - '.github/workflows/checks.yml'
+      - 'build/**'
+      - 'aclk/aclk-schemas/'
+      - 'ml/dlib/'
+      - 'mqtt_websockets'
+      - 'web/server/h2o/libh2o'
 env:
   DISABLE_TELEMETRY: 1
 concurrency:

--- a/.github/workflows/docker-dummy.yml
+++ b/.github/workflows/docker-dummy.yml
@@ -1,0 +1,51 @@
+---
+name: Docker
+on:
+  pull_request:
+    paths: # This MUST be kept in-sync with the paths key for the dummy.yml workflow.
+      - '**.c'
+      - '**.cc'
+      - '**.h'
+      - '**.hh'
+      - '**.in'
+      - '!netdata.spec.in'
+      - '.dockerignore'
+      - 'configure.ac'
+      - 'netdata-installer.sh'
+      - '**/Makefile*'
+      - 'Makefile*'
+      - '.github/workflows/docker.yml'
+      - '.github/scripts/docker-test.sh'
+      - 'build/**'
+      - 'packaging/docker/**'
+      - 'packaging/installer/**'
+      - 'aclk/aclk-schemas/'
+      - 'ml/dlib/'
+      - 'mqtt_websockets'
+      - 'web/server/h2o/libh2o'
+      - '!**.md'
+env:
+  DISABLE_TELEMETRY: 1
+concurrency:
+  group: docker-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+jobs:
+  docker-test:
+    name: Docker Runtime Test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'NOT REQUIRED'
+
+  docker-ci:
+    name: Docker Alt Arch Builds
+    needs: docker-test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platforms:
+          - linux/i386
+          - linux/arm/v7
+          - linux/arm64
+          - linux/ppc64le
+    steps:
+      - run: echo 'NOT REQUIRED'

--- a/.github/workflows/docker-dummy.yml
+++ b/.github/workflows/docker-dummy.yml
@@ -2,7 +2,7 @@
 name: Docker
 on:
   pull_request:
-    paths: # This MUST be kept in-sync with the paths key for the dummy.yml workflow.
+    paths-ignore: # This MUST be kept in-sync with the paths key for the dummy.yml workflow.
       - '**.c'
       - '**.cc'
       - '**.h'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,29 @@ on:
   push:
     branches:
       - master
-  pull_request: null
+  pull_request:
+    paths: # This MUST be kept in-sync with the paths-ignore key for the docker-dummy.yml workflow.
+      - '**.c'
+      - '**.cc'
+      - '**.h'
+      - '**.hh'
+      - '**.in'
+      - '!netdata.spec.in'
+      - '.dockerignore'
+      - 'configure.ac'
+      - 'netdata-installer.sh'
+      - '**/Makefile*'
+      - 'Makefile*'
+      - '.github/workflows/docker.yml'
+      - '.github/scripts/docker-test.sh'
+      - 'build/**'
+      - 'packaging/docker/**'
+      - 'packaging/installer/**'
+      - 'aclk/aclk-schemas/'
+      - 'ml/dlib/'
+      - 'mqtt_websockets'
+      - 'web/server/h2o/libh2o'
+      - '!**.md'
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/packaging-dummy.yml
+++ b/.github/workflows/packaging-dummy.yml
@@ -11,7 +11,7 @@ on:
       - reopened
       - labeled
       - synchronize
-    paths: # This MUST be kept in-sync with the paths key for the packaging.yml workflow.
+    paths-ignore: # This MUST be kept in-sync with the paths key for the packaging.yml workflow.
       - '**.c'
       - '**.cc'
       - '**.h'

--- a/.github/workflows/packaging-dummy.yml
+++ b/.github/workflows/packaging-dummy.yml
@@ -65,36 +65,6 @@ jobs:
           fi
           echo "Generated matrix: ${matrix}"
           echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
-      - name: Failure Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_COLOR: 'danger'
-          SLACK_ICON_EMOJI: ':github-actions:'
-          SLACK_TITLE: 'Package Build matrix generation failed:'
-          SLACK_USERNAME: 'GitHub Actions'
-          SLACK_MESSAGE: |-
-              ${{ github.repository }}: Failed to generate build matrix for package build.
-              Checkout: ${{ steps.checkout.outcome }}
-              Prepare Tools: ${{ steps.prepare.outcome }}
-              Read Build Matrix: ${{ steps.set-matrix.outcome }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: >-
-          ${{
-            failure()
-            && github.event_name != 'pull_request'
-            && startsWith(github.ref, 'refs/heads/master')
-            && github.repository == 'netdata/netdata'
-          }}
-
-  version-check:
-    name: Version check
-    runs-on: ubuntu-latest
-    outputs:
-      repo: ${{ steps.check-version.outputs.repo }}
-      version: ${{ steps.check-version.outputs.version }}
-      retention: ${{ steps.check-version.outputs.retention }}
-    steps:
-      - run: echo 'NOT REQUIRED'
 
   build:
     name: Build
@@ -103,7 +73,6 @@ jobs:
       DOCKER_CLI_EXPERIMENTAL: enabled
     needs:
       - matrix
-      - version-check
     strategy:
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
       fail-fast: false

--- a/.github/workflows/packaging-dummy.yml
+++ b/.github/workflows/packaging-dummy.yml
@@ -1,0 +1,112 @@
+---
+# Handles building of binary packages for the agent.
+#
+# This workflow exists so that we can make these required checks but
+# still skip running them on PRs where they are not relevant.
+name: Packages
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - labeled
+      - synchronize
+    paths: # This MUST be kept in-sync with the paths key for the packaging.yml workflow.
+      - '**.c'
+      - '**.cc'
+      - '**.h'
+      - '**.hh'
+      - '**.in'
+      - 'netdata.spec.in'
+      - 'configure.ac'
+      - '**/Makefile*'
+      - 'Makefile*'
+      - '.github/workflows/packaging.yml'
+      - '.github/scripts/gen-matrix-packaging.py'
+      - '.github/scripts/pkg-test.sh'
+      - 'build/**'
+      - 'packaging/*.sh'
+      - 'packaging/*.checksums'
+      - 'packaging/*.version'
+      - 'contrib/debian/**'
+      - 'aclk/aclk-schemas/'
+      - 'ml/dlib/'
+      - 'mqtt_websockets'
+      - 'web/server/h2o/libh2o'
+      - '!**.md'
+env:
+  DISABLE_TELEMETRY: 1
+  REPO_PREFIX: netdata/netdata
+concurrency:
+  group: packages-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+jobs:
+  matrix:
+    name: Prepare Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v3
+      - name: Prepare tools
+        id: prepare
+        run: |
+          sudo apt-get update && sudo apt-get install -y python3-ruamel.yaml
+      - name: Read build matrix
+        id: set-matrix
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] && \
+             [ "${{ !contains(github.event.pull_request.labels.*.name, 'run-ci/packaging') }}" = "true" ]; then
+            matrix="$(.github/scripts/gen-matrix-packaging.py 1)"
+          else
+            matrix="$(.github/scripts/gen-matrix-packaging.py 0)"
+          fi
+          echo "Generated matrix: ${matrix}"
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+      - name: Failure Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_COLOR: 'danger'
+          SLACK_ICON_EMOJI: ':github-actions:'
+          SLACK_TITLE: 'Package Build matrix generation failed:'
+          SLACK_USERNAME: 'GitHub Actions'
+          SLACK_MESSAGE: |-
+              ${{ github.repository }}: Failed to generate build matrix for package build.
+              Checkout: ${{ steps.checkout.outcome }}
+              Prepare Tools: ${{ steps.prepare.outcome }}
+              Read Build Matrix: ${{ steps.set-matrix.outcome }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: >-
+          ${{
+            failure()
+            && github.event_name != 'pull_request'
+            && startsWith(github.ref, 'refs/heads/master')
+            && github.repository == 'netdata/netdata'
+          }}
+
+  version-check:
+    name: Version check
+    runs-on: ubuntu-latest
+    outputs:
+      repo: ${{ steps.check-version.outputs.repo }}
+      version: ${{ steps.check-version.outputs.version }}
+      retention: ${{ steps.check-version.outputs.retention }}
+    steps:
+      - run: echo 'NOT REQUIRED'
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: enabled
+    needs:
+      - matrix
+      - version-check
+    strategy:
+      matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
+      fail-fast: false
+      max-parallel: 8
+    steps:
+      - run: echo 'NOT REQUIRED'

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -8,6 +8,29 @@ on:
       - reopened
       - labeled
       - synchronize
+    paths: # This MUST be kept in-sync with the paths-ignore key for the packaging-dummy.yml workflow.
+      - '**.c'
+      - '**.cc'
+      - '**.h'
+      - '**.hh'
+      - '**.in'
+      - 'netdata.spec.in'
+      - 'configure.ac'
+      - '**/Makefile*'
+      - 'Makefile*'
+      - '.github/workflows/packaging.yml'
+      - '.github/scripts/gen-matrix-packaging.py'
+      - '.github/scripts/pkg-test.sh'
+      - 'build/**'
+      - 'packaging/*.sh'
+      - 'packaging/*.checksums'
+      - 'packaging/*.version'
+      - 'contrib/debian/**'
+      - 'aclk/aclk-schemas/'
+      - 'ml/dlib/'
+      - 'mqtt_websockets'
+      - 'web/server/h2o/libh2o'
+      - '!**.md'
     branches:
       - master
   push:


### PR DESCRIPTION
##### Summary

The goal here is to reduce how much CI time is taken up by things like PRs that only fix documentation or simply tweak configuration files, which generally do not require build checks at all. Long-term, this should reduce usage of GHA runners, allowing all CI to complete faster, as well as avoiding blocking PRs due to failing build checks that have nothing to do with the PR.

This modifies the following workflows so that they won’t run unless relevant files are changed:

- `build.yml`
- `checks.yml`
- `docker.yml`
- `packaging.yml`

Relevant files in this case are those that impact the result of running at least one of the jobs in the workflow.

Additionally, secondary workflows are added to run with the same name when these workflows do not run, ensuring that we can still flag the jobs as required checks despite them not always running.

##### Test Plan

Merge it and see if things work (trivial revert if they don’t, and no good way to test this without merging it).

##### Additional Information

Assuming this is accepted, I plan to do a followup PR to help make some sanity checks on the path filtering expressions used in the modified workflows.