### PR TITLE
bearer improvements

### DIFF
--- a/aclk/aclk_capas.c
+++ b/aclk/aclk_capas.c
@@ -4,7 +4,7 @@
 
 #include "ml/ml.h"
 
-#define HTTP_API_V2_VERSION 5
+#define HTTP_API_V2_VERSION 6
 
 const struct capability *aclk_get_agent_capas()
 {

--- a/claim/claim.c
+++ b/claim/claim.c
@@ -458,6 +458,7 @@ int api_v2_claim(struct web_client *w, char *url) {
     if(can_be_claimed)
         buffer_json_member_add_string(wb, "key_filename", netdata_random_session_id_get_filename());
 
+    buffer_json_agents_v2(wb, NULL, now_s, false, false);
     buffer_json_finalize(wb);
 
     return HTTP_RESP_OK;

--- a/daemon/common.c
+++ b/daemon/common.c
@@ -182,8 +182,14 @@ CLOUD_STATUS buffer_json_cloud_status(BUFFER *wb, time_t now_s) {
             buffer_json_member_add_time_t(wb, "next_in", next_connect - now_s);
         }
 
-        if (status != CLOUD_STATUS_DISABLED && cloud_base_url())
+        if (cloud_base_url())
             buffer_json_member_add_string(wb, "url", cloud_base_url());
+
+        char *claim_id = get_agent_claimid();
+        if(claim_id) {
+            buffer_json_member_add_string(wb, "claim_id", claim_id);
+            freez(claim_id);
+        }
     }
     buffer_json_object_close(wb); // cloud
 

--- a/database/contexts/rrdcontext.h
+++ b/database/contexts/rrdcontext.h
@@ -647,7 +647,7 @@ typedef enum __attribute__ ((__packed__)) {
 int rrdcontext_to_json_v2(BUFFER *wb, struct api_v2_contexts_request *req, CONTEXTS_V2_MODE mode);
 
 RRDCONTEXT_TO_JSON_OPTIONS rrdcontext_to_json_parse_options(char *o);
-void buffer_json_agents_array_v2(BUFFER *wb, struct query_timings *timings, time_t now_s, bool info);
+void buffer_json_agents_v2(BUFFER *wb, struct query_timings *timings, time_t now_s, bool info, bool array);
 void buffer_json_node_add_v2(BUFFER *wb, RRDHOST *host, size_t ni, usec_t duration_ut, bool status);
 void buffer_json_query_timings(BUFFER *wb, const char *key, struct query_timings *timings);
 void buffer_json_cloud_timings(BUFFER *wb, const char *key, struct query_timings *timings);

--- a/registry/registry.c
+++ b/registry/registry.c
@@ -163,6 +163,15 @@ void registry_update_cloud_base_url() {
 int registry_request_hello_json(RRDHOST *host, struct web_client *w) {
     registry_json_header(host, w, "hello", REGISTRY_STATUS_OK);
 
+    if(host->node_id)
+        buffer_json_member_add_uuid(w->response.data, "node_id", host->node_id);
+
+    char *claim_id = get_agent_claimid();
+    if(claim_id) {
+        buffer_json_member_add_string(w->response.data, "claim_id", claim_id);
+        freez(claim_id);
+    }
+
     buffer_json_member_add_string(w->response.data, "registry", registry.registry_to_announce);
     buffer_json_member_add_string(w->response.data, "cloud_base_url", registry.cloud_base_url);
     buffer_json_member_add_boolean(w->response.data, "anonymous_statistics", netdata_anonymous_statistics_enabled);
@@ -172,6 +181,10 @@ int registry_request_hello_json(RRDHOST *host, struct web_client *w) {
     dfe_start_read(rrdhost_root_index, h) {
         buffer_json_add_array_item_object(w->response.data);
         buffer_json_member_add_string(w->response.data, "machine_guid", h->machine_guid);
+
+        if(h->node_id)
+            buffer_json_member_add_uuid(w->response.data, "node_id", h->node_id);
+
         buffer_json_member_add_string(w->response.data, "hostname", rrdhost_registry_hostname(h));
         buffer_json_object_close(w->response.data);
     }

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -1570,7 +1570,7 @@ void rrdr_json_wrapper_end2(RRDR *r, BUFFER *wb) {
     }
     buffer_json_object_close(wb); // view
 
-    buffer_json_agents_array_v2(wb, &r->internal.qt->timings, 0, false);
+    buffer_json_agents_v2(wb, &r->internal.qt->timings, 0, false, true);
     buffer_json_cloud_timings(wb, "timings", &r->internal.qt->timings);
     buffer_json_finalize(wb);
 }

--- a/web/api/queries/weights.c
+++ b/web/api/queries/weights.c
@@ -936,7 +936,7 @@ static size_t registered_results_to_json_multinode_no_group_by(
 
     buffer_json_object_close(wb); //dictionaries
 
-    buffer_json_agents_array_v2(wb, &qwd->timings, 0, false);
+    buffer_json_agents_v2(wb, &qwd->timings, 0, false, true);
     buffer_json_member_add_uint64(wb, "correlated_dimensions", total_dimensions);
     buffer_json_member_add_uint64(wb, "total_dimensions_count", examined_dimensions);
     buffer_json_finalize(wb);
@@ -1067,7 +1067,7 @@ static size_t registered_results_to_json_multinode_group_by(
     dfe_done(aw);
     buffer_json_array_close(wb); // result
 
-    buffer_json_agents_array_v2(wb, &qwd->timings, 0, false);
+    buffer_json_agents_v2(wb, &qwd->timings, 0, false, true);
     buffer_json_member_add_uint64(wb, "correlated_dimensions", total_dimensions);
     buffer_json_member_add_uint64(wb, "total_dimensions_count", examined_dimensions);
     buffer_json_finalize(wb);

--- a/web/api/web_api.c
+++ b/web/api/web_api.c
@@ -43,7 +43,7 @@ int web_client_api_request_vX(RRDHOST *host, struct web_client *w, char *url_pat
     for(int i = 0; api_commands[i].command ; i++) {
         if(unlikely(hash == api_commands[i].hash && !strcmp(url_path_endpoint, api_commands[i].command))) {
             if(unlikely(!web_client_check_acl_and_bearer(w, api_commands[i].acl)))
-                return web_client_permission_denied(w);
+                return web_client_bearer_required(w);
 
             char *query_string = (char *)buffer_tostring(w->url_query_string_decoded);
 

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -18,6 +18,14 @@ inline int web_client_permission_denied(struct web_client *w) {
     return HTTP_RESP_FORBIDDEN;
 }
 
+inline int web_client_bearer_required(struct web_client *w) {
+    w->response.data->content_type = CT_TEXT_PLAIN;
+    buffer_flush(w->response.data);
+    buffer_strcat(w->response.data, "An authorization bearer is required to access the resource.");
+    w->response.code = HTTP_RESP_UNAUTHORIZED;
+    return HTTP_RESP_UNAUTHORIZED;
+}
+
 static inline int bad_request_multiple_dashboard_versions(struct web_client *w) {
     w->response.data->content_type = CT_TEXT_PLAIN;
     buffer_flush(w->response.data);

--- a/web/server/web_client.h
+++ b/web/server/web_client.h
@@ -199,6 +199,7 @@ struct web_client {
 };
 
 int web_client_permission_denied(struct web_client *w);
+int web_client_bearer_required(struct web_client *w);
 
 ssize_t web_client_send(struct web_client *w);
 ssize_t web_client_receive(struct web_client *w);


### PR DESCRIPTION
- [x] authentication tokens are now removed when they expire
- [x] cloud status in `/api/v2/info` now reports claim id
- [x] `/api/v2/claim` now includes both claim_id and agent info
- [x] `/api/v2/bearer_get_token` now verifies machine_guid, node_id and claim_id
- [x] `/api/v2/bearer_protection` also verifies UUIDs like above
- [x] ACLK `http_api_v2` capability increased from version 5 to 6
- [x] bearer protected APIs now respond with 401 (unauthorized), not 403 (forbidden) when no valid bearer is supplied.