### PR TITLE
Fix coverity issues

### DIFF
--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -1245,7 +1245,7 @@ void *netdata_ipmi_collection_thread(void *ptr) {
                 t->state.sel.last_iteration_ut = 0;
             }
 
-            return ptr;
+            break;
         }
 
         spinlock_lock(&t->spinlock);

--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -518,7 +518,7 @@ static int netdata_get_ipmi_sel_events_count(struct ipmi_monitoring_ipmi_config 
         goto cleanup;
     }
 
-    netdata_update_ipmi_sel_events_count(state, sel_count >= 0 ? sel_count : 0);
+    netdata_update_ipmi_sel_events_count(state, sel_count);
 
     rv = 0;
 

--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -972,7 +972,7 @@ static void netdata_update_ipmi_sensor_reading(
             .sensor_state = sensor_state,
             .sensor_units = sensor_units,
             .sensor_reading_type = sensor_reading_type,
-            .sensor_name = strdupz(sensor_name ? sensor_name : ""),
+            .sensor_name = strdupz(sensor_name),
             .component = netdata_sensor_name_to_component(sensor_name),
             .do_state = !excluded_state,
             .do_metric = !excluded_metric,

--- a/registry/registry_init.c
+++ b/registry/registry_init.c
@@ -48,6 +48,8 @@ void registry_db_stats(void) {
 
 void registry_generate_curl_urls(void) {
     FILE *fp = fopen("/tmp/registry.curl", "w+");
+    if (unlikely(!fp))
+        return;
 
     REGISTRY_PERSON *p;
     dfe_start_read(registry.persons, p) {

--- a/web/api/web_api_v2.c
+++ b/web/api/web_api_v2.c
@@ -103,11 +103,11 @@ static bool verify_agent_uuids(const char *machine_guid, const char *node_id, co
         return false;
 
     char *agent_claim_id = get_agent_claimid();
-    if(!agent_claim_id || strcmp(claim_id, agent_claim_id) != 0)
-        return false;
+
+    bool not_verified = (!agent_claim_id || strcmp(claim_id, agent_claim_id) != 0);
     freez(agent_claim_id);
 
-    if(!localhost->node_id)
+    if(not_verified || !localhost->node_id)
         return false;
 
     char buf[UUID_STR_LEN];


### PR DESCRIPTION
##### Summary
Issues in coverity

* CID 395493:  Control flow issues  (DEADCODE)
  - /collectors/freeipmi.plugin/freeipmi_plugin.c: 970 in netdata_update_ipmi_sensor_reading()
* CID 395492:  Null pointer dereferences  (NULL_RETURNS)
  - /registry/registry_init.c: 60 in registry_generate_curl_urls()
* CID 395491:  Control flow issues  (DEADCODE)
  - /collectors/freeipmi.plugin/freeipmi_plugin.c: 1256 in netdata_ipmi_collection_thread()
* CID 395490:  Control flow issues  (DEADCODE)
   - /collectors/freeipmi.plugin/freeipmi_plugin.c: 521 in netdata_get_ipmi_sel_events_count()
* CID 395487:  Resource leaks  (RESOURCE_LEAK)
   - /web/api/web_api_v2.c: 107 in verify_agent_uuids()


