### PR TITLE
health: fix evaluating expression with `nan`

### DIFF
--- a/libnetdata/eval/eval.c
+++ b/libnetdata/eval/eval.c
@@ -213,13 +213,6 @@ static inline NETDATA_DOUBLE eval_value(EVAL_EXPRESSION *exp, EVAL_VALUE *v, int
             break;
     }
 
-    if(likely(!*error)) {
-        if(unlikely(isnan(n)))
-            *error = EVAL_ERROR_VALUE_IS_NAN;
-        else if(unlikely(isinf(n)))
-            *error = EVAL_ERROR_VALUE_IS_INFINITE;
-    }
-
     return n;
 }
 


### PR DESCRIPTION
##### Summary

Without this change, all alarms that use `nan` in any expression (calc, warn, crit) have UNDEFINED state.

The issue was added in #15257. 

##### Test Plan

Install this PR and check for alarms that didn't work before (e.g. system load, systemd units).

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
