### PR TITLE
add `netdata_generic_machine_id`

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -300,7 +300,8 @@ telemetry_event() {
     "system_kernel_name": "${KERNEL_NAME}",
     "system_kernel_version": "$(uname -r)",
     "system_architecture": "$(uname -m)",
-    "system_total_ram": "${TOTAL_RAM:-unknown}"
+    "system_total_ram": "${TOTAL_RAM:-unknown}",
+    "netdata_generic_machine_id": "${DISTINCT_ID}"
   }
 }
 EOF


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

- add `netdata_generic_machine_id` as a new event property for installer telemetry events.
- this is just duplicating the generated distinct_id into the new `netdata_generic_machine_id` for now but this will allow more flexibility in future and will help with backend processing of these events etc. 

Related to [this work](https://github.com/netdata/product/issues/3171). 

This will allow us to use the new `netdata_generic_machine_id` as a useful identifier for telemetry events to help with monitoring health from agent installs to agent telemetry events etc.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
