### PR TITLE
fix(freeipmi): set sensor state on every reading

### DIFF
--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -942,6 +942,8 @@ static void netdata_update_ipmi_sensor_reading(
             sn->last_collected_metric_ut = state->sensors.now_ut;
         }
 
+        sn->sensor_state = sensor_state;
+
         sn->last_collected_state_ut = state->sensors.now_ut;
 
         dictionary_acquired_item_release(state->sensors.dict, item);


### PR DESCRIPTION
##### Summary

We set the value the first time the sensor appears and never update it after that. This PR fixes this problem.

##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
