### PR TITLE
Add keys to integrations schema, categories, icon path, plus some fixes

### DIFF
--- a/collectors/metadata/schemas/definitions.json
+++ b/collectors/metadata/schemas/definitions.json
@@ -1,5 +1,36 @@
 {
   "definitions": {
+    "category": {
+      "type": "object",
+      "description": "Category object, with an entry per category depth.",
+      "properties": {
+        "level_0": {
+          "type": "string",
+          "oneOf": [
+            {
+              "enum": [
+                "data-collection"
+              ]
+            }
+          ]
+        },
+        "level_1": {
+          "type": "string",
+          "oneOf": [
+            {
+              "enum": [
+                "databases",
+                "web-servers",
+                "message-brokers",
+                "hardware-and-sensors",
+                "operating-systems",
+                "containers-and-vms"
+              ]
+            }
+          ]
+        }
+      }
+    },
     "alerts": {
       "type": "array",
       "description": "The list of configured alerts shipped with Netdata for this collector.",

--- a/collectors/metadata/schemas/definitions.json
+++ b/collectors/metadata/schemas/definitions.json
@@ -2,10 +2,11 @@
   "definitions": {
     "category": {
       "type": "object",
-      "description": "Category object, with an entry per category depth.",
+      "description": "Category and subcategory of the collector/monitored instance.",
       "properties": {
-        "level_0": {
+        "level0": {
           "type": "string",
+          "description": "Category name",
           "oneOf": [
             {
               "enum": [
@@ -14,8 +15,9 @@
             }
           ]
         },
-        "level_1": {
+        "level1": {
           "type": "string",
+          "description": "Subcategory name",
           "oneOf": [
             {
               "enum": [

--- a/collectors/metadata/schemas/single-module.json
+++ b/collectors/metadata/schemas/single-module.json
@@ -13,7 +13,7 @@
     },
     "categories": {
       "type": "array",
-      "description": "An array defining the category the integration falls on.",
+      "description": "An array defining the categories the integration falls into.",
       "items": {
         "$ref": "#/$defs/_categories"
       }
@@ -35,7 +35,7 @@
           },
           "categories": {
             "type": "array",
-            "description": "An array defining the category the integration falls on.",
+            "description": "An array defining the categories the integration falls into.",
             "items": {
               "$ref": "#/$defs/_categories"
             }

--- a/collectors/metadata/schemas/single-module.json
+++ b/collectors/metadata/schemas/single-module.json
@@ -15,7 +15,7 @@
       "type": "array",
       "description": "An array defining the categories the integration falls into.",
       "items": {
-        "$ref": "#/$defs/_category"
+        "$ref": "./definitions.json#/definitions/category"
       }
     },
     "icon_path": {
@@ -37,7 +37,7 @@
             "type": "array",
             "description": "An array defining the categories the integration falls into.",
             "items": {
-              "$ref": "#/$defs/_category"
+              "$ref": "./definitions.json#/definitions/category"
             }
           },
           "icon_path": {
@@ -456,37 +456,6 @@
     "metrics"
   ],
   "$defs": {
-    "_category": {
-      "type": "object",
-      "description": "Category object, with an entry per category depth.",
-      "properties": {
-        "path0": {
-          "type": "string",
-          "oneOf": [
-            {
-              "enum": [
-                "data-collection"
-              ]
-            }
-          ]
-        },
-        "path1": {
-          "type": "string",
-          "oneOf": [
-            {
-              "enum": [
-                "databases",
-                "web-servers",
-                "message-brokers",
-                "hardware-and-sensors",
-                "operating-systems",
-                "containers-and-vms"
-              ]
-            }
-          ]
-        }
-      }
-    },
     "_monitored_instance": {
       "type": "object",
       "description": "Information about the monitored instance (metrics source).",

--- a/collectors/metadata/schemas/single-module.json
+++ b/collectors/metadata/schemas/single-module.json
@@ -15,7 +15,7 @@
       "type": "array",
       "description": "An array defining the categories the integration falls into.",
       "items": {
-        "$ref": "#/$defs/_categories"
+        "$ref": "#/$defs/_category"
       }
     },
     "icon_path": {
@@ -37,7 +37,7 @@
             "type": "array",
             "description": "An array defining the categories the integration falls into.",
             "items": {
-              "$ref": "#/$defs/_categories"
+              "$ref": "#/$defs/_category"
             }
           },
           "icon_path": {
@@ -456,7 +456,7 @@
     "metrics"
   ],
   "$defs": {
-    "_categories": {
+    "_category": {
       "type": "object",
       "description": "Category object, with an entry per category depth.",
       "properties": {

--- a/collectors/metadata/schemas/single-module.json
+++ b/collectors/metadata/schemas/single-module.json
@@ -56,14 +56,16 @@
               "type": "array",
               "description": "Only supported OS/platforms. Platforms supported by Netdata will be ignored, only those listed are considered supported.",
               "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 2
               }
             },
             "exclude": {
               "type": "array",
               "description": "Unsupported OS/platforms. The result set is all platforms supported by Netdata except for those excluded.",
               "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 2
               }
             }
           },

--- a/collectors/metadata/schemas/single-module.json
+++ b/collectors/metadata/schemas/single-module.json
@@ -11,13 +11,45 @@
       "type": "string",
       "description": "Module name (e.g. apache, /proc/stat, httpcheck). It usually has the same name as the module configuration file (external plugin) or the section name in netdata.conf (internal plugin)."
     },
+    "categories": {
+      "type": "array",
+      "description": "An array defining the category the integration falls on.",
+      "items": {
+        "$ref": "#/$defs/_categories"
+      }
+    },
+    "icon_path": {
+      "type": "string",
+      "description": "path to the integration's icon"
+    },
     "monitored_instance": {
       "$ref": "#/$defs/_monitored_instance"
     },
     "alternative_monitored_instances": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/_monitored_instance"
+        "type": "object",
+        "properties": {
+          "monitored_instance": {
+            "$ref": "#/$defs/_monitored_instance"
+          },
+          "categories": {
+            "type": "array",
+            "description": "An array defining the category the integration falls on.",
+            "items": {
+              "$ref": "#/$defs/_categories"
+            }
+          },
+          "icon_path": {
+            "type": "string",
+            "description": "path to the integration's icon"
+          }
+        },
+        "required": [
+          "monitored_instance",
+          "icon_path",
+          "categories"
+        ]
       }
     },
     "keywords": {
@@ -410,6 +442,8 @@
   "required": [
     "plugin_name",
     "module_name",
+    "categories",
+    "icon_path",
     "monitored_instance",
     "alternative_monitored_instances",
     "keywords",
@@ -422,6 +456,37 @@
     "metrics"
   ],
   "$defs": {
+    "_categories": {
+      "type": "object",
+      "description": "Category object, with an entry per category depth.",
+      "properties": {
+        "path0": {
+          "type": "string",
+          "oneOf": [
+            {
+              "enum": [
+                "data-collection"
+              ]
+            }
+          ]
+        },
+        "path1": {
+          "type": "string",
+          "oneOf": [
+            {
+              "enum": [
+                "databases",
+                "web-servers",
+                "message-brokers",
+                "hardware-and-sensors",
+                "operating-systems",
+                "containers-and-vms"
+              ]
+            }
+          ]
+        }
+      }
+    },
     "_monitored_instance": {
       "type": "object",
       "description": "Information about the monitored instance (metrics source).",
@@ -433,46 +498,11 @@
         "link": {
           "description": "Link to the monitored instance official website if any.",
           "type": "string"
-        },
-        "categories": {
-          "type": "array",
-          "description": "An array defining the category the integration falls on.",
-          "items": {
-            "type": "object",
-            "properties": {
-              "path0": {
-                "type": "string",
-                "oneOf": [
-                  {
-                    "enum": [
-                      "data-collection"
-                    ]
-                  }
-                ]
-              },
-              "path1": {
-                "type": "string",
-                "oneOf": [
-                  {
-                    "enum": [
-                      "databases",
-                      "web-servers",
-                      "message-brokers",
-                      "hardware-and-sensors",
-                      "operating-systems",
-                      "containers-and-vms"
-                    ]
-                  }
-                ]
-              }
-            }
-          }
         }
       },
       "required": [
         "name",
-        "link",
-        "categories"
+        "link"
       ]
     }
   }

--- a/collectors/metadata/schemas/single-module.json
+++ b/collectors/metadata/schemas/single-module.json
@@ -431,11 +431,46 @@
         "link": {
           "description": "Link to the monitored instance official website if any.",
           "type": "string"
+        },
+        "categories": {
+          "type": "array",
+          "description": "An array defining the category the integration falls on.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "path0": {
+                "type": "string",
+                "oneOf": [
+                  {
+                    "enum": [
+                      "data-collection"
+                    ]
+                  }
+                ]
+              },
+              "path1": {
+                "type": "string",
+                "oneOf": [
+                  {
+                    "enum": [
+                      "databases",
+                      "web-servers",
+                      "message-brokers",
+                      "hardware-and-sensors",
+                      "operating-systems",
+                      "containers-and-vms"
+                    ]
+                  }
+                ]
+              }
+            }
+          }
         }
       },
       "required": [
         "name",
-        "link"
+        "link",
+        "categories"
       ]
     }
   }

--- a/collectors/metadata/single-module-template.yaml
+++ b/collectors/metadata/single-module-template.yaml
@@ -4,10 +4,19 @@ monitored_instance:
   name: ""
   link: ""
 alternative_monitored_instances:
-  - name: ""
-    link: ""
+  - monitored_instance:
+      name: ""
+      link: ""
+    categories:
+      - level0: data-collection
+        level1: containers-and-vms
+    icon_path: ""
 keywords:
   - ""
+categories:
+  - level0: data-collection
+    level1: databases
+icon_path: ""
 overview:
   data_collection:
     metrics_description: ""


### PR DESCRIPTION
##### Summary

- As per yesterday's discussion, we want categories and icon path both on integration level and inside virtual integrations.
  - I added some example categories, but I think we will add to this schemas `enum` entries as the structure grows. That goes for path levels too, if we need a third one, then we will add it. For level0 I have added only data collection, as this is what the schema is about, maybe we need deploy, but I am not sure.

  We need a way to limit people on assigning just the categories we want, but we want that for every level of the "category path".

  So, if the path is data-collection/web-servers you want to have different values allowed for first level data-collection and different for second level.
 
- Let's discuss and agree in this PR where these images are going to be stored, so I can update the description a bit (saying that there will be a static string and we will give only relative path from that), but also try and update the four already written yamls in go.d.plugin.

  Do we got a directory with icons to begin with, or some will need to be made with photoshop etc?
- I made some changes to the supported OS fields about minLength (as we find more error prone fields we can update accordingly, for now this is the field needing this minLength addition). 
