### PR TITLE
move not really related props single-module.json -> definitions.json

### DIFF
--- a/collectors/metadata/schemas/definitions.json
+++ b/collectors/metadata/schemas/definitions.json
@@ -1,0 +1,189 @@
+{
+  "definitions": {
+    "alerts": {
+      "type": "array",
+      "description": "The list of configured alerts shipped with Netdata for this collector.",
+      "items": {
+        "type": "object",
+        "description": "Information about the configured alert.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Alert's 'alarm' or 'template' value (https://learn.netdata.cloud/docs/alerting/health-configuration-reference#alarm-line-alarm-or-template)."
+          },
+          "link": {
+            "type": "string",
+            "description": "Link to github .conf file that this alert originates from"
+          },
+          "metric": {
+            "type": "string",
+            "description": "Alert's 'on' value (https://learn.netdata.cloud/docs/alerting/health-configuration-reference#alarm-line-on)."
+          },
+          "info": {
+            "type": "string",
+            "description": "Alert's 'info' value (https://learn.netdata.cloud/docs/alerting/health-configuration-reference#alarm-line-info)."
+          },
+          "os": {
+            "type": "string",
+            "description": "Alert's 'os' value (https://learn.netdata.cloud/docs/alerting/health-configuration-reference#alarm-line-os)."
+          }
+        },
+        "required": [
+          "name",
+          "link",
+          "metric",
+          "info"
+        ]
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "description": "Collected metrics grouped by scope. The scope defines the instance that the metric belongs to. An instance is uniquely identified by a set of labels.",
+      "properties": {
+        "folding": {
+          "$ref": "#/definitions/folding"
+        },
+        "description": {
+          "type": "string",
+          "description": "General description of collected metrics/scopes."
+        },
+        "availability": {
+          "type": "array",
+          "description": "Metrics collection availability conditions. Some metrics are only available when certain conditions are met. For example, Apache exposes additional metrics when Extended status is configured, Consul exposes different set of metrics depends on its mode. This field should list the available conditions that will later be matched for each of the metrics.",
+          "items": {
+            "type": "string",
+            "description": "Availability condition name."
+          }
+        },
+        "scopes": {
+          "type": "array",
+          "description": "List of scopes and their metrics.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Scope name."
+              },
+              "description": {
+                "type": "string",
+                "description": "Scope description."
+              },
+              "labels": {
+                "type": "array",
+                "description": "Label set of the scope.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Label name."
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Label description."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "description"
+                  ]
+                }
+              },
+              "metrics": {
+                "type": "array",
+                "description": "List of collected metrics (chart contexts) in the scope.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Metric name (chart context)."
+                    },
+                    "availability": {
+                      "type": "array",
+                      "description": "Metric collection availability conditions. An empty list means that it is available for all conditions defined in 'metrics.availability'.",
+                      "items": {
+                        "type": "string",
+                        "description": "Availability condition name."
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Metric description (chart title)."
+                    },
+                    "unit": {
+                      "type": "string",
+                      "description": "Metric description (chart unit)."
+                    },
+                    "chart_type": {
+                      "type": "string",
+                      "description": "Metric description (chart type)."
+                    },
+                    "dimensions": {
+                      "type": "array",
+                      "description": "",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "Dimension name."
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "description",
+                    "unit",
+                    "chart_type",
+                    "dimensions"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "name",
+              "description",
+              "labels",
+              "metrics"
+            ]
+          }
+        }
+      },
+      "required": [
+        "folding",
+        "description",
+        "availability",
+        "scopes"
+      ]
+    },
+    "folding": {
+      "type": "object",
+      "description": "Content folding settings.",
+      "properties": {
+        "title": {
+          "description": "Folded content summary title",
+          "type": "string"
+        },
+        "enabled": {
+          "description": "Determines if this content should be folded",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "title",
+        "enabled"
+      ]
+    },
+    "non-empty-string": {
+      "type": "string",
+      "minLength": 2
+    }
+  }
+}

--- a/collectors/metadata/schemas/single-module.json
+++ b/collectors/metadata/schemas/single-module.json
@@ -208,7 +208,7 @@
                   "description": "Optional common information about options."
                 },
                 "folding": {
-                  "$ref": "#/$defs/_folding"
+                  "$ref": "./definitions.json#/definitions/folding"
                 },
                 "list": {
                   "type": "array",
@@ -270,7 +270,7 @@
                         "description": "Example name."
                       },
                       "folding": {
-                        "$ref": "#/$defs/_folding"
+                        "$ref": "./definitions.json#/definitions/folding"
                       },
                       "description": {
                         "type": "string",
@@ -399,167 +399,10 @@
       ]
     },
     "alerts": {
-      "type": "array",
-      "description": "The list of configured alerts shipped with Netdata for this collector.",
-      "items": {
-        "type": "object",
-        "description": "Information about the configured alert.",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "Alert's 'alarm' or 'template' value (https://learn.netdata.cloud/docs/alerting/health-configuration-reference#alarm-line-alarm-or-template)."
-          },
-          "link": {
-            "type": "string",
-            "description": "Link to github .conf file that this alert originates from"
-          },
-          "metric": {
-            "type": "string",
-            "description": "Alert's 'on' value (https://learn.netdata.cloud/docs/alerting/health-configuration-reference#alarm-line-on)."
-          },
-          "info": {
-            "type": "string",
-            "description": "Alert's 'info' value (https://learn.netdata.cloud/docs/alerting/health-configuration-reference#alarm-line-info)."
-          },
-          "os": {
-            "type": "string",
-            "description": "Alert's 'os' value (https://learn.netdata.cloud/docs/alerting/health-configuration-reference#alarm-line-os)."
-          }
-        },
-        "required": [
-          "name",
-          "link",
-          "metric",
-          "info"
-        ]
-      }
+      "$ref": "./definitions.json#/definitions/alerts"
     },
     "metrics": {
-      "type": "object",
-      "description": "Collected metrics grouped by scope. The scope defines the instance that the metric belongs to. An instance is uniquely identified by a set of labels.",
-      "properties": {
-        "folding": {
-          "$ref": "#/$defs/_folding"
-        },
-        "description": {
-          "type": "string",
-          "description": "General description of collected metrics/scopes."
-        },
-        "availability": {
-          "type": "array",
-          "description": "Metrics collection availability conditions. Some metrics are only available when certain conditions are met. For example, Apache exposes additional metrics when Extended status is configured, Consul exposes different set of metrics depends on its mode. This field should list the available conditions that will later be matched for each of the metrics.",
-          "items": {
-            "type": "string",
-            "description": "Availability condition name."
-          }
-        },
-        "scopes": {
-          "type": "array",
-          "description": "List of scopes and their metrics.",
-          "items": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "Scope name."
-              },
-              "description": {
-                "type": "string",
-                "description": "Scope description."
-              },
-              "labels": {
-                "type": "array",
-                "description": "Label set of the scope.",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "Label name."
-                    },
-                    "description": {
-                      "type": "string",
-                      "description": "Label description."
-                    }
-                  },
-                  "required": [
-                    "name",
-                    "description"
-                  ]
-                }
-              },
-              "metrics": {
-                "type": "array",
-                "description": "List of collected metrics (chart contexts) in the scope.",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string",
-                      "description": "Metric name (chart context)."
-                    },
-                    "availability": {
-                      "type": "array",
-                      "description": "Metric collection availability conditions. An empty list means that it is available for all conditions defined in 'metrics.availability'.",
-                      "items": {
-                        "type": "string",
-                        "description": "Availability condition name."
-                      }
-                    },
-                    "description": {
-                      "type": "string",
-                      "description": "Metric description (chart title)."
-                    },
-                    "unit": {
-                      "type": "string",
-                      "description": "Metric description (chart unit)."
-                    },
-                    "chart_type": {
-                      "type": "string",
-                      "description": "Metric description (chart type)."
-                    },
-                    "dimensions": {
-                      "type": "array",
-                      "description": "",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "description": "Dimension name."
-                          }
-                        },
-                        "required": [
-                          "name"
-                        ]
-                      }
-                    }
-                  },
-                  "required": [
-                    "name",
-                    "description",
-                    "unit",
-                    "chart_type",
-                    "dimensions"
-                  ]
-                }
-              }
-            },
-            "required": [
-              "name",
-              "description",
-              "labels",
-              "metrics"
-            ]
-          }
-        }
-      },
-      "required": [
-        "folding",
-        "description",
-        "availability",
-        "scopes"
-      ]
+      "$ref": "./definitions.json#/definitions/metrics"
     }
   },
   "required": [
@@ -593,24 +436,6 @@
       "required": [
         "name",
         "link"
-      ]
-    },
-    "_folding": {
-      "type": "object",
-      "description": "Content folding settings.",
-      "properties": {
-        "title": {
-          "description": "Folded content summary title",
-          "type": "string"
-        },
-        "enabled": {
-          "description": "Determines if this content should be folded",
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "title",
-        "enabled"
       ]
     }
   }


### PR DESCRIPTION
##### Summary

ssia, so we don't need to change  single-module.json if we want to [add another category](https://github.com/netdata/netdata/pull/15365).

##### Test Plan

tested locally, schemas are valid

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
