### PR TITLE
dont log error on opening .environment

### DIFF
--- a/web/api/formatters/charts2json.c
+++ b/web/api/formatters/charts2json.c
@@ -10,7 +10,7 @@ const char* get_release_channel() {
     if (use_stable == -1) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s/.environment", netdata_configured_user_config_dir);
-        procfile *ff = procfile_open(filename, "=", PROCFILE_FLAG_ERROR_ON_ERROR_LOG);
+        procfile *ff = procfile_open(filename, "=", PROCFILE_FLAG_NO_ERROR_ON_FILE_IO);
         if (ff) {
             procfile_set_quotes(ff, "'\"");
             ff = procfile_readall(ff);


### PR DESCRIPTION
##### Summary

There is no `.environment` if using native packages. 

We try to open this file on startup

=>

```
netdata ERROR : MAIN : PROCFILE: Cannot open file '/etc/netdata/.environment' (errno 2, No such file or directory)
```

Having this line is [confusing for users](https://community.netdata.cloud/t/non-existent-environment-file/4381). This PR fixes it.

##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
