### PR TITLE
Fix coverity issues

### DIFF
--- a/claim/claim.c
+++ b/claim/claim.c
@@ -257,8 +257,10 @@ bool netdata_random_session_id_generate(void) {
         if (write(fd, guid, UUID_STR_LEN - 1) != UUID_STR_LEN - 1) {
             netdata_log_error("Cannot write the random session id file '%s'.", filename);
             ret = false;
-        } else
-            (void) write(fd, "\n", 1);
+        } else {
+            ssize_t bytes = write(fd, "\n", 1);
+            UNUSED(bytes);
+        }
         close(fd);
     }
 

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -363,7 +363,7 @@ static size_t streaming_parser(struct receiver_state *rpt, struct plugind *cd, i
         }
     }
 
-    result = parser ? parser->user.data_collections_count : 0;
+    result = parser->user.data_collections_count;
 
     // free parser with the pop function
     netdata_thread_cleanup_pop(1);


### PR DESCRIPTION
##### Summary
* CID 394449:  Null pointer dereferences  (REVERSE_INULL)
  - /streaming/receiver.c: 366 in streaming_parser()
  Null-checking "parser" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
* Fix a compilation warning -- properly handle a `write()` return status
