### PR TITLE
health: fix windows alarms for vnodes

### DIFF
--- a/health/health.d/windows.conf
+++ b/health/health.d/windows.conf
@@ -6,7 +6,7 @@
     class: Utilization
      type: Windows
 component: CPU
-       os: linux
+       os: *
     hosts: *
    lookup: average -10m unaligned match-names of dpc,user,privileged,interrupt
     units: %
@@ -25,7 +25,7 @@ component: CPU
     class: Utilization
      type: Windows
 component: Memory
-       os: linux
+       os: *
     hosts: *
      calc: ($used) * 100 / ($used + $available)
     units: %
@@ -44,7 +44,7 @@ component: Memory
     class: Errors
      type: Windows
 component: Network
-       os: linux
+       os: *
     hosts: *
    lookup: sum -10m unaligned absolute match-names of inbound
     units: packets
@@ -59,7 +59,7 @@ component: Network
     class: Errors
      type: Windows
 component: Network
-       os: linux
+       os: *
     hosts: *
    lookup: sum -10m unaligned absolute match-names of outbound
     units: packets
@@ -74,7 +74,7 @@ component: Network
     class: Errors
      type: Windows
 component: Network
-       os: linux
+       os: *
     hosts: *
    lookup: sum -10m unaligned absolute match-names of inbound
     units: packets
@@ -89,7 +89,7 @@ component: Network
     class: Errors
      type: Windows
 component: Network
-       os: linux
+       os: *
     hosts: *
    lookup: sum -10m unaligned absolute match-names of outbound
     units: packets
@@ -107,7 +107,7 @@ component: Network
     class: Utilization
      type: Windows
 component: Disk
-       os: linux
+       os: *
     hosts: *
      calc: ($used) * 100 / ($used + $free)
     units: %

--- a/health/health.d/windows.conf
+++ b/health/health.d/windows.conf
@@ -40,7 +40,7 @@ component: Memory
 ## Network
 
  template: windows_inbound_packets_discarded
-       on: windows.net_discarded
+       on: windows.net_nic_discarded
     class: Errors
      type: Windows
 component: Network
@@ -55,7 +55,7 @@ component: Network
        to: sysadmin
 
  template: windows_outbound_packets_discarded
-       on: windows.net_discarded
+       on: windows.net_nic_discarded
     class: Errors
      type: Windows
 component: Network
@@ -70,7 +70,7 @@ component: Network
        to: sysadmin
 
  template: windows_inbound_packets_errors
-       on: windows.net_errors
+       on: windows.net_nic_errors
     class: Errors
      type: Windows
 component: Network
@@ -85,7 +85,7 @@ component: Network
        to: sysadmin
 
  template: windows_outbound_packets_errors
-       on: windows.net_errors
+       on: windows.net_nic_errors
     class: Errors
      type: Windows
 component: Network
@@ -103,7 +103,7 @@ component: Network
 ## Disk
 
  template: windows_disk_in_use
-       on: windows.logical_disk_utilization
+       on: windows.logical_disk_space_usage
     class: Utilization
      type: Windows
 component: Disk


### PR DESCRIPTION
##### Summary

Fixes: #15369

We shouldn't use the `os` filter because `os` is an empty string for virtual nodes.

##### Test Plan

Tested with win11 vnode.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
