### PR TITLE
update http response code descriptions

### DIFF
--- a/libnetdata/buffer/buffer.h
+++ b/libnetdata/buffer/buffer.h
@@ -61,6 +61,11 @@ typedef enum __attribute__ ((__packed__)) {
     CT_IMAGE_ICNS,
     CT_IMAGE_BMP,
     CT_PROMETHEUS,
+    CT_AUDIO_MPEG,
+    CT_AUDIO_OGG,
+    CT_VIDEO_MP4,
+    CT_APPLICATION_PDF,
+    CT_APPLICATION_ZIP,
 } HTTP_CONTENT_TYPE;
 
 typedef struct web_buffer {

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -743,7 +743,7 @@ const char *web_content_type_to_string(HTTP_CONTENT_TYPE content_type) {
             return "application/json; charset=utf-8";
 
         case CT_APPLICATION_X_JAVASCRIPT:
-            return "application/x-javascript; charset=utf-8";
+            return "application/javascript; charset=utf-8";
 
         case CT_TEXT_CSS:
             return "text/css; charset=utf-8";
@@ -796,35 +796,159 @@ const char *web_content_type_to_string(HTTP_CONTENT_TYPE content_type) {
         case CT_PROMETHEUS:
             return "text/plain; version=0.0.4";
 
+        case CT_AUDIO_MPEG:
+            return "audio/mpeg";
+
+        case CT_AUDIO_OGG:
+            return "audio/ogg";
+
+        case CT_VIDEO_MP4:
+            return "video/mp4";
+
+        case CT_APPLICATION_PDF:
+            return "application/pdf";
+
+        case CT_APPLICATION_ZIP:
+            return "application/zip";
+
         default:
         case CT_TEXT_PLAIN:
             return "text/plain; charset=utf-8";
     }
 }
 
-
 const char *web_response_code_to_string(int code) {
     switch(code) {
-        case HTTP_RESP_OK:
+        case 100:
+            return "Continue";
+        case 101:
+            return "Switching Protocols";
+        case 102:
+            return "Processing";
+        case 103:
+            return "Early Hints";
+
+        case 200:
             return "OK";
+        case 201:
+            return "Created";
+        case 202:
+            return "Accepted";
+        case 203:
+            return "Non-Authoritative Information";
+        case 204:
+            return "No Content";
+        case 205:
+            return "Reset Content";
+        case 206:
+            return "Partial Content";
+        case 207:
+            return "Multi-Status";
+        case 208:
+            return "Already Reported";
+        case 226:
+            return "IM Used";
 
-        case HTTP_RESP_MOVED_PERM:
+        case 300:
+            return "Multiple Choices";
+        case 301:
             return "Moved Permanently";
-
-        case HTTP_RESP_REDIR_TEMP:
+        case 302:
+            return "Found";
+        case 303:
+            return "See Other";
+        case 304:
+            return "Not Modified";
+        case 305:
+            return "Use Proxy";
+        case 306:
+            return "Switch Proxy";
+        case 307:
             return "Temporary Redirect";
+        case 308:
+            return "Permanent Redirect";
 
-        case HTTP_RESP_BAD_REQUEST:
+        case 400:
             return "Bad Request";
-
-        case HTTP_RESP_FORBIDDEN:
+        case 401:
+            return "Unauthorized";
+        case 402:
+            return "Payment Required";
+        case 403:
             return "Forbidden";
-
-        case HTTP_RESP_NOT_FOUND:
+        case 404:
             return "Not Found";
+        case 405:
+            return "Method Not Allowed";
+        case 406:
+            return "Not Acceptable";
+        case 407:
+            return "Proxy Authentication Required";
+        case 408:
+            return "Request Timeout";
+        case 409:
+            return "Conflict";
+        case 410:
+            return "Gone";
+        case 411:
+            return "Length Required";
+        case 412:
+            return "Precondition Failed";
+        case 413:
+            return "Payload Too Large";
+        case 414:
+            return "URI Too Long";
+        case 415:
+            return "Unsupported Media Type";
+        case 416:
+            return "Range Not Satisfiable";
+        case 417:
+            return "Expectation Failed";
+        case 418:
+            return "I'm a teapot";
+        case 421:
+            return "Misdirected Request";
+        case 422:
+            return "Unprocessable Entity";
+        case 423:
+            return "Locked";
+        case 424:
+            return "Failed Dependency";
+        case 425:
+            return "Too Early";
+        case 426:
+            return "Upgrade Required";
+        case 428:
+            return "Precondition Required";
+        case 429:
+            return "Too Many Requests";
+        case 431:
+            return "Request Header Fields Too Large";
+        case 451:
+            return "Unavailable For Legal Reasons";
 
-        case HTTP_RESP_PRECOND_FAIL:
-            return "Preconditions Failed";
+        case 500:
+            return "Internal Server Error";
+        case 501:
+            return "Not Implemented";
+        case 502:
+            return "Bad Gateway";
+        case 503:
+            return "Service Unavailable";
+        case 504:
+            return "Gateway Timeout";
+        case 505:
+            return "HTTP Version Not Supported";
+        case 506:
+            return "Variant Also Negotiates";
+        case 507:
+            return "Insufficient Storage";
+        case 508:
+            return "Loop Detected";
+        case 510:
+            return "Not Extended";
+        case 511:
+            return "Network Authentication Required";
 
         default:
             if(code >= 100 && code < 200)
@@ -837,7 +961,7 @@ const char *web_response_code_to_string(int code) {
                 return "Redirection";
 
             if(code >= 400 && code < 500)
-                return "Bad Request";
+                return "Client Error";
 
             if(code >= 500 && code < 600)
                 return "Server Error";


### PR DESCRIPTION
There was an incomplete list of naming http response code, resulting in strange http responses like, `401 Bad Request`.
updated netdata to the current http/1.1 specs.