### PR TITLE
Skip adding special labels from charts

### DIFF
--- a/exporting/exporting_engine.h
+++ b/exporting/exporting_engine.h
@@ -26,6 +26,8 @@ typedef enum exporting_options {
     EXPORTING_OPTION_SEND_AUTOMATIC_LABELS  = (1 << 4),
     EXPORTING_OPTION_USE_TLS                = (1 << 5),
 
+    EXPORTING_OPTION_PREFER_CHART_LABELS    = (1 << 6),
+
     EXPORTING_OPTION_SEND_NAMES             = (1 << 16),
     EXPORTING_OPTION_SEND_VARIABLES         = (1 << 17)
 } EXPORTING_OPTIONS;

--- a/exporting/prometheus/prometheus.c
+++ b/exporting/prometheus/prometheus.c
@@ -342,8 +342,28 @@ static int format_prometheus_chart_label_callback(const char *name, const char *
 
     (void)ls;
 
-    if (name[0] == '_' )
-        return 1;
+    switch (name[0]) {
+        case '_':
+            return 1;
+        case 'c':
+            if (!strcmp(name, "chart"))
+                return 1;
+            break;
+        case 'd':
+            if (!strcmp(name, "dimension"))
+                return 1;
+            break;
+        case 'f':
+            if (!strcmp(name, "family"))
+                return 1;
+            break;
+        case 'i':
+            if (!strcmp(name, "instance"))
+                return 1;
+            break;
+        default:
+            break;
+    }
 
     char k[PROMETHEUS_ELEMENT_MAX + 1];
     char v[PROMETHEUS_ELEMENT_MAX + 1];

--- a/exporting/prometheus/prometheus.c
+++ b/exporting/prometheus/prometheus.c
@@ -354,8 +354,7 @@ static int check_existing_label(BUFFER *b, const char *name, int keepExistingLab
         b->len -= matchEnd - match;
     } else if (unlikely(match == b->buffer)) {
         // Match is the only label in the buffer, set length to 0.
-        match[0] = '\0';
-        b->len = 0;
+        buffer_reset(b);
     } else {
         // Matched label is the last label, just reduce the length.
         if (likely(*(match - 1) == ',')) {

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -263,7 +263,7 @@ struct engine *read_exporting_config()
         else
             prometheus_exporter_instance->config.options &= ~EXPORTING_OPTION_SEND_AUTOMATIC_LABELS;
 
-        if (prometheus_config_get_boolean("prefer chart labels", CONFIG_BOOLEAN_NO))
+        if (prometheus_config_get_boolean("prefer external chart labels", CONFIG_BOOLEAN_NO))
             prometheus_exporter_instance->config.options |= EXPORTING_OPTION_PREFER_CHART_LABELS;
         else
             prometheus_exporter_instance->config.options &= ~EXPORTING_OPTION_PREFER_CHART_LABELS;

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -263,6 +263,11 @@ struct engine *read_exporting_config()
         else
             prometheus_exporter_instance->config.options &= ~EXPORTING_OPTION_SEND_AUTOMATIC_LABELS;
 
+        if (prometheus_config_get_boolean("prefer chart labels", CONFIG_BOOLEAN_NO))
+            prometheus_exporter_instance->config.options |= EXPORTING_OPTION_PREFER_CHART_LABELS;
+        else
+            prometheus_exporter_instance->config.options &= ~EXPORTING_OPTION_PREFER_CHART_LABELS;
+
         prometheus_exporter_instance->config.charts_pattern = simple_pattern_create(
                 prometheus_config_get("send charts matching", "*"),
                 NULL,


### PR DESCRIPTION
##### Summary

#15099 introduced a bug for metrics utilizing label names that conflict with existing 'special' names: chart, dimension, family, instance.

This bug results in duplicate labels, which Prometheus will reject on intake.

My fix here is simply to ignore adding the chart label if the name matches an existing special name. However, one may prefer to overwrite the existing label, so I am not sure if this should be the final fix.

##### Test Plan

1. Compile Branch and start netdata.
2. Download a coredns binary. One may use the sample Corefile below as a basic configuration. 
3. Run coredns like `./coredns -conf ./conf`. This starts coredns to listen on port 1053.
4. Make a visit or two to the server: `dig @127.0.0.1 -p 1053 example.com`
5. Check the chart labels. I am grepping for 'requests_total' as this is the coredns metric which utilizes a 'family' label. `https://localhost:19999/api/v1/allmetrics?format=prometheus | grep 'requests_total'` 

Below is the sample coredns configuration to have a basic running coredns:
```
(snip) {
    prometheus
    log
    errors
}

.:1053 {
    whoami
    import snip
}
```

##### Additional Information

As mentioned above, there are some consequences which may not be preferred. Namely whether the chart label should override the existing label, or vice versa. That said, the current implementation is broken because it results in duplicate labels which cannot be imported into Prometheus so some decision needs to be made.
