### PR TITLE
Add deploy-on key to monitored instance

### DIFF
--- a/collectors/metadata/schemas/definitions.json
+++ b/collectors/metadata/schemas/definitions.json
@@ -22,6 +22,11 @@
         "icon_filename": {
           "type": "string",
           "description": "The filename of the integration's icon, as sourced from https://github.com/netdata/website/tree/master/themes/tailwind/static/img."
+        },
+        "deploy-on": {
+          "type": "string",
+          "description": "This is a tag that indicates where this integration can be deployed. Add it only if this integration is inside categories of the `Deploy` master category. That way the automation will know to add the proper command.",
+          "oneOf": ["linux","macos","docker","k8s"]
         }
       },
       "required": [


### PR DESCRIPTION
##### Summary

This is a feature I learned more about today, I will try and explain it best I can so we can review this.

there will be this kind of section:

![image](https://github.com/netdata/netdata/assets/70198089/5f3b8f72-734e-49db-bf15-a5c8b516f769)

with integrations inside, only showing:

![image](https://github.com/netdata/netdata/assets/70198089/3772a0e9-559d-4c35-bfc9-42056b28d09e)

But, we want to also show this on `Data-collection` integrations too.

From my understanding it should be underneath a heading of setup, so in md format (app will have tabs probably):

```md

## Setup

### Deploy and Connect

Run the script below on your node's terminal

...
...

### Prerequisites

.
.
.

```

This will be the case for any integrations that will show up both in the deploy section, and the data collection section. (from my understanding an example would be proc.plugin modules)

So we need an optional field that we can then replace with the proper data FE expects.

That field will need to be present for both module integration yamls, and virtual integrations.

@Ferroin we will discuss what we will need to replace this tag with in the template once this is merged.