### PR TITLE
collector meta schema: global config examples folding + per example

### DIFF
--- a/collectors/metadata/schemas/definitions.json
+++ b/collectors/metadata/schemas/definitions.json
@@ -203,16 +203,33 @@
       "description": "Content folding settings.",
       "properties": {
         "title": {
-          "description": "Folded content summary title",
+          "description": "Folded content summary title.",
           "type": "string"
         },
         "enabled": {
-          "description": "Determines if this content should be folded",
+          "description": "Determines if this content should be folded.",
           "type": "boolean"
         }
       },
       "required": [
         "title",
+        "enabled"
+      ]
+    },
+    "folding_relaxed": {
+      "type": "object",
+      "description": "Content folding settings with optional title.",
+      "properties": {
+        "title": {
+          "description": "Folded content summary title.",
+          "type": "string"
+        },
+        "enabled": {
+          "description": "Determines if this content should be folded.",
+          "type": "boolean"
+        }
+      },
+      "required": [
         "enabled"
       ]
     },

--- a/collectors/metadata/schemas/single-module.json
+++ b/collectors/metadata/schemas/single-module.json
@@ -332,6 +332,9 @@
               "type": "object",
               "description": "Configuration examples. The more examples the better!",
               "properties": {
+                "folding": {
+                  "$ref": "./definitions.json#/definitions/folding"
+                },
                 "list": {
                   "type": "array",
                   "description": "List of configuration examples.",
@@ -343,7 +346,7 @@
                         "description": "Example name."
                       },
                       "folding": {
-                        "$ref": "./definitions.json#/definitions/folding"
+                        "$ref": "./definitions.json#/definitions/folding_relaxed"
                       },
                       "description": {
                         "type": "string",
@@ -364,6 +367,7 @@
                 }
               },
               "required": [
+                "folding",
                 "list"
               ]
             }

--- a/collectors/metadata/schemas/single-module.json
+++ b/collectors/metadata/schemas/single-module.json
@@ -358,7 +358,6 @@
                       }
                     },
                     "required": [
-                      "folding",
                       "name",
                       "description",
                       "config"

--- a/collectors/metadata/single-module-template.yaml
+++ b/collectors/metadata/single-module-template.yaml
@@ -53,11 +53,13 @@ setup:
           description: ""
           required: false
     examples:
+      folding:
+        enabled: true
+        title: ""
       list:
         - name: ""
           folding:
-            enabled: true
-            title: ""
+            enabled: false
           description: ""
           config: ""
 troubleshooting:


### PR DESCRIPTION
##### Summary

The current schema forces you to add `folding.{title, enabled}` to every example

<details>
<summary>screenshot</summary>

<img width="719" alt="Screenshot 2023-07-14 at 15 50 11" src="https://github.com/netdata/netdata/assets/22274335/b5e2e75a-6ef0-4e82-98ab-b0537c354764">

</details>

It is not needed because we want

-  **only one** example to be unfolded
- all folded the same title


The better way is to have global folding for config examples and (optionally) disable the one we need. Folding title overwriting is supported too (but optional).

<details>
<summary>screenshot</summary>

<img width="756" alt="Screenshot 2023-07-14 at 15 52 37" src="https://github.com/netdata/netdata/assets/22274335/5cd050f6-99db-4800-83f9-184b2933ca10">

</details>

##### Test Plan

Use single-module-template.yaml to validate the schema.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
