### PR TITLE
Make yamls pass the schema, and use decided temporary naming scheme

### DIFF
--- a/collectors/apps.plugin/multi_metadata.yaml
+++ b/collectors/apps.plugin/multi_metadata.yaml
@@ -1,7 +1,74 @@
 name: apps.plugin
 modules:
-  - module_name: system
-    plugin_name: apps.plugin
+  - meta:
+      plugin_name: apps.plugin
+      module_name: system
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: apps system
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -24,8 +91,75 @@ modules:
                 - name: sleeping_uninterruptible
                 - name: zombie
                 - name: stopped
-  - module_name: apps
-    plugin_name: apps.plugin
+  - meta:
+      plugin_name: apps.plugin
+      module_name: apps
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: apps apps
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -188,8 +322,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: a dimension per app group
-  - module_name: groups
-    plugin_name: apps.plugin
+  - meta:
+      plugin_name: apps.plugin
+      module_name: groups
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: apps groups
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -352,8 +553,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: a dimension per user group
-  - module_name: users
-    plugin_name: apps.plugin
+  - meta:
+      plugin_name: apps.plugin
+      module_name: users
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: apps users
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -516,8 +784,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: a dimension per user
-  - module_name: netdata
-    plugin_name: apps.plugin
+  - meta:
+      plugin_name: apps.plugin
+      module_name: netdata
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: apps netdata
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:

--- a/collectors/apps.plugin/multi_metadata.yaml
+++ b/collectors/apps.plugin/multi_metadata.yaml
@@ -11,9 +11,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -37,9 +35,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -49,26 +45,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -102,9 +87,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -128,9 +111,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -140,26 +121,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -333,9 +303,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -359,9 +327,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -371,26 +337,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -564,9 +519,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -590,9 +543,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -602,26 +553,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -795,9 +735,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -821,9 +759,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -833,26 +769,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:

--- a/collectors/cgroups.plugin/multi_metadata.yaml
+++ b/collectors/cgroups.plugin/multi_metadata.yaml
@@ -1,7 +1,74 @@
 name: cgroups.plugin
 modules:
-  - module_name: /sys/fs/cgroup
-    plugin_name: cgroups.plugin
+  - meta:
+      plugin_name: cgroups.plugin
+      module_name: /sys/fs/cgroup
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: cgroups /sys/fs/cgroup
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: cgroup_10min_cpu_usage
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cgroups.conf
@@ -504,8 +571,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: time
-  - module_name: /proc/net/dev
-    plugin_name: cgroups.plugin
+  - meta:
+      plugin_name: cgroups.plugin
+      module_name: /proc/net/dev
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: cgroups /proc/net/dev
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: cgroup_1m_received_packets_rate
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cgroups.conf
@@ -727,8 +861,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: mtu
-  - module_name: systemd
-    plugin_name: cgroups.plugin
+  - meta:
+      plugin_name: cgroups.plugin
+      module_name: systemd
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: cgroups systemd
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:

--- a/collectors/cgroups.plugin/multi_metadata.yaml
+++ b/collectors/cgroups.plugin/multi_metadata.yaml
@@ -11,9 +11,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -37,9 +35,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -49,26 +45,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: cgroup_10min_cpu_usage
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cgroups.conf
@@ -582,9 +567,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -608,9 +591,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -620,26 +601,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: cgroup_1m_received_packets_rate
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cgroups.conf
@@ -872,9 +842,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -898,9 +866,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -910,26 +876,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:

--- a/collectors/charts.d.plugin/ap/metadata.yaml
+++ b/collectors/charts.d.plugin/ap/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: ap
-plugin_name: charts.d.plugin
+meta:
+  plugin_name: charts.d.plugin
+  module_name: ap
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: charts.d ap
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/charts.d.plugin/ap/metadata.yaml
+++ b/collectors/charts.d.plugin/ap/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/charts.d.plugin/apcupsd/metadata.yaml
+++ b/collectors/charts.d.plugin/apcupsd/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: apcupsd
-plugin_name: charts.d.plugin
+meta:
+  plugin_name: charts.d.plugin
+  module_name: apcupsd
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: charts.d apcupsd
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts:
   - name: apcupsd_ups_charge
     link: https://github.com/netdata/netdata/blob/master/health/health.d/apcupsd.conf

--- a/collectors/charts.d.plugin/apcupsd/metadata.yaml
+++ b/collectors/charts.d.plugin/apcupsd/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts:
   - name: apcupsd_ups_charge
     link: https://github.com/netdata/netdata/blob/master/health/health.d/apcupsd.conf

--- a/collectors/charts.d.plugin/libreswan/metadata.yaml
+++ b/collectors/charts.d.plugin/libreswan/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/charts.d.plugin/libreswan/metadata.yaml
+++ b/collectors/charts.d.plugin/libreswan/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: libreswan
-plugin_name: charts.d.plugin
+meta:
+  plugin_name: charts.d.plugin
+  module_name: libreswan
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: charts.d libreswan
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/charts.d.plugin/nut/metadata.yaml
+++ b/collectors/charts.d.plugin/nut/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: nut
-plugin_name: charts.d.plugin
+meta:
+  plugin_name: charts.d.plugin
+  module_name: nut
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: charts.d nut
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts:
   - name: nut_ups_charge
     link: https://github.com/netdata/netdata/blob/master/health/health.d/nut.conf

--- a/collectors/charts.d.plugin/nut/metadata.yaml
+++ b/collectors/charts.d.plugin/nut/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts:
   - name: nut_ups_charge
     link: https://github.com/netdata/netdata/blob/master/health/health.d/nut.conf

--- a/collectors/charts.d.plugin/opensips/metadata.yaml
+++ b/collectors/charts.d.plugin/opensips/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/charts.d.plugin/opensips/metadata.yaml
+++ b/collectors/charts.d.plugin/opensips/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: opensips
-plugin_name: charts.d.plugin
+meta:
+  plugin_name: charts.d.plugin
+  module_name: opensips
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: charts.d opensips
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/charts.d.plugin/sensors/metadata.yaml
+++ b/collectors/charts.d.plugin/sensors/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/charts.d.plugin/sensors/metadata.yaml
+++ b/collectors/charts.d.plugin/sensors/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: sensors
-plugin_name: charts.d.plugin
+meta:
+  plugin_name: charts.d.plugin
+  module_name: sensors
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: charts.d sensors
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/cups.plugin/metadata.yaml
+++ b/collectors/cups.plugin/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/cups.plugin/metadata.yaml
+++ b/collectors/cups.plugin/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: cups.plugin
-plugin_name: cups.plugin
+meta:
+  plugin_name: cups.plugin
+  module_name: cups.plugin
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: cups
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/debugfs.plugin/multi_metadata.yaml
+++ b/collectors/debugfs.plugin/multi_metadata.yaml
@@ -11,9 +11,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -37,9 +35,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -49,26 +45,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -142,9 +127,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -168,9 +151,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -180,26 +161,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:

--- a/collectors/debugfs.plugin/multi_metadata.yaml
+++ b/collectors/debugfs.plugin/multi_metadata.yaml
@@ -1,7 +1,74 @@
 name: debugfs.plugin
 modules:
-  - module_name: /sys/kernel/debug/extfrag
-    plugin_name: debugfs.plugin
+  - meta:
+      plugin_name: debugfs.plugin
+      module_name: /sys/kernel/debug/extfrag
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: debugfs /sys/kernel/debug/extfrag
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -64,8 +131,75 @@ modules:
                 - name: order8
                 - name: order9
                 - name: order10
-  - module_name: /sys/kernel/debug/zswap
-    plugin_name: debugfs.plugin
+  - meta:
+      plugin_name: debugfs.plugin
+      module_name: /sys/kernel/debug/zswap
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: debugfs /sys/kernel/debug/zswap
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:

--- a/collectors/diskspace.plugin/metadata.yaml
+++ b/collectors/diskspace.plugin/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts:
   - name: disk_space_usage
     link: https://github.com/netdata/netdata/blob/master/health/health.d/disks.conf

--- a/collectors/diskspace.plugin/metadata.yaml
+++ b/collectors/diskspace.plugin/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: diskspace.plugin
-plugin_name: diskspace.plugin
+meta:
+  plugin_name: diskspace.plugin
+  module_name: diskspace.plugin
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: diskspace
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts:
   - name: disk_space_usage
     link: https://github.com/netdata/netdata/blob/master/health/health.d/disks.conf

--- a/collectors/ebpf.plugin/multi_metadata.yaml
+++ b/collectors/ebpf.plugin/multi_metadata.yaml
@@ -11,9 +11,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -37,9 +35,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -49,26 +45,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -182,9 +167,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -208,9 +191,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -220,26 +201,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -382,9 +352,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -408,9 +376,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -420,26 +386,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -469,9 +424,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -495,9 +448,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -507,26 +458,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -556,9 +496,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -582,9 +520,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -594,26 +530,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -737,9 +662,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -763,9 +686,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -775,26 +696,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -844,9 +754,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -870,9 +778,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -882,26 +788,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -931,9 +826,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -957,9 +850,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -969,26 +860,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -1059,9 +939,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1085,9 +963,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1097,26 +973,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -1162,9 +1027,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1188,9 +1051,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1200,26 +1061,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -1470,9 +1320,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1496,9 +1344,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1508,26 +1354,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -1645,9 +1480,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1671,9 +1504,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1683,26 +1514,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -1764,9 +1584,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1790,9 +1608,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1802,26 +1618,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -1930,9 +1735,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1956,9 +1759,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1968,26 +1769,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -2017,9 +1807,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -2043,9 +1831,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -2055,26 +1841,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -2112,9 +1887,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -2138,9 +1911,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -2150,26 +1921,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -2494,9 +2254,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -2520,9 +2278,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -2532,26 +2288,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:

--- a/collectors/ebpf.plugin/multi_metadata.yaml
+++ b/collectors/ebpf.plugin/multi_metadata.yaml
@@ -1,7 +1,74 @@
 name: ebpf.plugin
 modules:
-  - module_name: filedescriptor
-    plugin_name: ebpf.plugin
+  - meta:
+      plugin_name: ebpf.plugin
+      module_name: filedescriptor
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: ebpf filedescriptor
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -104,8 +171,75 @@ modules:
               dimensions:
                 - name: open
                 - name: close
-  - module_name: processes
-    plugin_name: ebpf.plugin
+  - meta:
+      plugin_name: ebpf.plugin
+      module_name: processes
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: ebpf processes
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -237,8 +371,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: a dimension per systemd service
-  - module_name: disk
-    plugin_name: ebpf.plugin
+  - meta:
+      plugin_name: ebpf.plugin
+      module_name: disk
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: ebpf disk
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -257,8 +458,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: latency
-  - module_name: hardirq
-    plugin_name: ebpf.plugin
+  - meta:
+      plugin_name: ebpf.plugin
+      module_name: hardirq
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: ebpf hardirq
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -277,8 +545,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: hardirq names
-  - module_name: cachestat
-    plugin_name: ebpf.plugin
+  - meta:
+      plugin_name: ebpf.plugin
+      module_name: cachestat
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: ebpf cachestat
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -391,8 +726,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: miss
-  - module_name: sync
-    plugin_name: ebpf.plugin
+  - meta:
+      plugin_name: ebpf.plugin
+      module_name: sync
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: ebpf sync
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -431,8 +833,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: sync_file_range
-  - module_name: mdflush
-    plugin_name: ebpf.plugin
+  - meta:
+      plugin_name: ebpf.plugin
+      module_name: mdflush
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: ebpf mdflush
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -451,8 +920,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: disk
-  - module_name: swap
-    plugin_name: ebpf.plugin
+  - meta:
+      plugin_name: ebpf.plugin
+      module_name: swap
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: ebpf swap
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -512,8 +1048,75 @@ modules:
               dimensions:
                 - name: write
                 - name: read
-  - module_name: oomkill
-    plugin_name: ebpf.plugin
+  - meta:
+      plugin_name: ebpf.plugin
+      module_name: oomkill
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: ebpf oomkill
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -548,8 +1151,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: a dimension per app group
-  - module_name: socket
-    plugin_name: ebpf.plugin
+  - meta:
+      plugin_name: ebpf.plugin
+      module_name: socket
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: ebpf socket
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -789,8 +1459,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: received
-  - module_name: dcstat
-    plugin_name: ebpf.plugin
+  - meta:
+      plugin_name: ebpf.plugin
+      module_name: dcstat
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: ebpf dcstat
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -897,8 +1634,75 @@ modules:
                 - name: reference
                 - name: slow
                 - name: miss
-  - module_name: filesystem
-    plugin_name: ebpf.plugin
+  - meta:
+      plugin_name: ebpf.plugin
+      module_name: filesystem
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: ebpf filesystem
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -949,8 +1753,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: latency period
-  - module_name: shm
-    plugin_name: ebpf.plugin
+  - meta:
+      plugin_name: ebpf.plugin
+      module_name: shm
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: ebpf shm
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -1048,8 +1919,75 @@ modules:
                 - name: at
                 - name: dt
                 - name: ctl
-  - module_name: softirq
-    plugin_name: ebpf.plugin
+  - meta:
+      plugin_name: ebpf.plugin
+      module_name: softirq
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: ebpf softirq
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -1068,8 +2006,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: soft IRQs
-  - module_name: mount
-    plugin_name: ebpf.plugin
+  - meta:
+      plugin_name: ebpf.plugin
+      module_name: mount
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: ebpf mount
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -1096,8 +2101,75 @@ modules:
               dimensions:
                 - name: mount
                 - name: umount
-  - module_name: vfs
-    plugin_name: ebpf.plugin
+  - meta:
+      plugin_name: ebpf.plugin
+      module_name: vfs
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: ebpf vfs
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -1411,8 +2483,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: a dimension per app group
-  - module_name: process
-    plugin_name: ebpf.plugin
+  - meta:
+      plugin_name: ebpf.plugin
+      module_name: process
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: ebpf process
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:

--- a/collectors/freebsd.plugin/multi_metadata.yaml
+++ b/collectors/freebsd.plugin/multi_metadata.yaml
@@ -11,9 +11,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -37,9 +35,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -49,26 +45,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: load_cpu_number
         link: https://github.com/netdata/netdata/blob/master/health/health.d/load.conf
@@ -115,9 +100,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -141,9 +124,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -153,26 +134,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -215,9 +185,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -241,9 +209,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -253,26 +219,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: 10min_cpu_usage
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cpu.conf
@@ -336,9 +291,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -362,9 +315,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -374,26 +325,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -423,9 +363,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -449,9 +387,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -461,26 +397,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -510,9 +435,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -536,9 +459,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -548,26 +469,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -603,9 +513,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -629,9 +537,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -641,26 +547,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -690,9 +585,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -716,9 +609,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -728,26 +619,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -777,9 +657,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -803,9 +681,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -815,26 +691,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -870,9 +735,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -896,9 +759,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -908,26 +769,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -958,9 +808,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -984,9 +832,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -996,26 +842,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: ram_in_use
         link: https://github.com/netdata/netdata/blob/master/health/health.d/ram.conf
@@ -1073,9 +908,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1099,9 +932,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1111,26 +942,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: 30min_ram_swapped_out
         link: https://github.com/netdata/netdata/blob/master/health/health.d/swap.conf
@@ -1166,9 +986,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1192,9 +1010,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1204,26 +1020,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -1257,9 +1062,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1283,9 +1086,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1295,26 +1096,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: semaphores_used
         link: https://github.com/netdata/netdata/blob/master/health/health.d/ipc.conf
@@ -1355,9 +1145,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1381,9 +1169,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1393,26 +1179,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -1448,9 +1223,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1474,9 +1247,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1486,26 +1257,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -1548,9 +1308,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1574,9 +1332,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1586,26 +1342,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -1635,9 +1380,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1661,9 +1404,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1673,26 +1414,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: 1min_netdev_backlog_exceeded
         link: https://github.com/netdata/netdata/blob/master/health/health.d/softnet.conf
@@ -1751,9 +1481,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1777,9 +1505,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1789,26 +1515,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: 10min_disk_utilization
         link: https://github.com/netdata/netdata/blob/master/health/health.d/disks.conf
@@ -1910,9 +1625,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1936,9 +1649,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1948,26 +1659,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -1997,9 +1697,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -2023,9 +1721,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -2035,26 +1731,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: 1m_ipv4_tcp_resets_sent
         link: https://github.com/netdata/netdata/blob/master/health/health.d/tcp_resets.conf
@@ -2159,9 +1844,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -2185,9 +1868,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -2197,26 +1878,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: 1m_ipv4_udp_receive_buffer_errors
         link: https://github.com/netdata/netdata/blob/master/health/health.d/udp_errors.conf
@@ -2262,9 +1932,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -2288,9 +1956,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -2300,26 +1966,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -2367,9 +2022,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -2393,9 +2046,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -2405,26 +2056,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -2484,9 +2124,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -2510,9 +2148,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -2522,26 +2158,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -2603,9 +2228,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -2629,9 +2252,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -2641,26 +2262,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -2755,9 +2365,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -2781,9 +2389,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -2793,26 +2399,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -2867,9 +2462,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -2893,9 +2486,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -2905,26 +2496,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: interface_speed
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
@@ -3089,9 +2669,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -3115,9 +2693,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -3127,26 +2703,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: disk_space_usage
         link: https://github.com/netdata/netdata/blob/master/health/health.d/disks.conf
@@ -3196,9 +2761,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -3222,9 +2785,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -3234,26 +2795,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: zfs_memory_throttle
         link: https://github.com/netdata/netdata/blob/master/health/health.d/zfs.conf

--- a/collectors/freebsd.plugin/multi_metadata.yaml
+++ b/collectors/freebsd.plugin/multi_metadata.yaml
@@ -1,7 +1,74 @@
 name: freebsd.plugin
 modules:
-  - module_name: vm.loadavg
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: vm.loadavg
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd vm.loadavg
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: load_cpu_number
         link: https://github.com/netdata/netdata/blob/master/health/health.d/load.conf
@@ -37,8 +104,75 @@ modules:
                 - name: load1
                 - name: load5
                 - name: load15
-  - module_name: vm.vmtotal
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: vm.vmtotal
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd vm.vmtotal
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -70,8 +204,75 @@ modules:
               chart_type: area
               dimensions:
                 - name: used
-  - module_name: kern.cp_time
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: kern.cp_time
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd kern.cp_time
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: 10min_cpu_usage
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cpu.conf
@@ -124,8 +325,75 @@ modules:
                 - name: user
                 - name: interrupt
                 - name: idle
-  - module_name: dev.cpu.temperature
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: dev.cpu.temperature
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd dev.cpu.temperature
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -144,8 +412,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: a dimension per core
-  - module_name: dev.cpu.0.freq
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: dev.cpu.0.freq
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd dev.cpu.0.freq
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -164,8 +499,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: frequency
-  - module_name: hw.intrcnt
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: hw.intrcnt
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd hw.intrcnt
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -190,8 +592,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: a dimension per interrupt
-  - module_name: vm.stats.sys.v_intr
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: vm.stats.sys.v_intr
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd vm.stats.sys.v_intr
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -210,8 +679,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: interrupts
-  - module_name: vm.stats.sys.v_soft
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: vm.stats.sys.v_soft
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd vm.stats.sys.v_soft
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -230,8 +766,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: interrupts
-  - module_name: vm.stats.sys.v_swtch
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: vm.stats.sys.v_swtch
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd vm.stats.sys.v_swtch
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -256,8 +859,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: started
-  - module_name: vm.swap_info
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: vm.swap_info
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd vm.swap_info
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -277,8 +947,75 @@ modules:
               dimensions:
                 - name: free
                 - name: used
-  - module_name: system.ram
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: system.ram
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd system.ram
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: ram_in_use
         link: https://github.com/netdata/netdata/blob/master/health/health.d/ram.conf
@@ -325,8 +1062,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: avail
-  - module_name: vm.stats.vm.v_swappgs
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: vm.stats.vm.v_swappgs
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd vm.stats.vm.v_swappgs
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: 30min_ram_swapped_out
         link: https://github.com/netdata/netdata/blob/master/health/health.d/swap.conf
@@ -351,8 +1155,75 @@ modules:
               dimensions:
                 - name: io
                 - name: out
-  - module_name: vm.stats.vm.v_pgfaults
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: vm.stats.vm.v_pgfaults
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd vm.stats.vm.v_pgfaults
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -375,8 +1246,75 @@ modules:
                 - name: cow
                 - name: cow_optimized
                 - name: in_transit
-  - module_name: kern.ipc.sem
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: kern.ipc.sem
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd kern.ipc.sem
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: semaphores_used
         link: https://github.com/netdata/netdata/blob/master/health/health.d/ipc.conf
@@ -406,8 +1344,75 @@ modules:
               chart_type: area
               dimensions:
                 - name: arrays
-  - module_name: kern.ipc.shm
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: kern.ipc.shm
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd kern.ipc.shm
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -432,8 +1437,75 @@ modules:
               chart_type: area
               dimensions:
                 - name: allocated
-  - module_name: kern.ipc.msq
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: kern.ipc.msq
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd kern.ipc.msq
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -465,8 +1537,75 @@ modules:
               dimensions:
                 - name: allocated
                 - name: used
-  - module_name: uptime
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: uptime
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd uptime
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -485,8 +1624,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: uptime
-  - module_name: net.isr
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: net.isr
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd net.isr
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: 1min_netdev_backlog_exceeded
         link: https://github.com/netdata/netdata/blob/master/health/health.d/softnet.conf
@@ -534,8 +1740,75 @@ modules:
                 - name: hybrid_dispatched
                 - name: qdrops
                 - name: queued
-  - module_name: devstat
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: devstat
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd devstat
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: 10min_disk_utilization
         link: https://github.com/netdata/netdata/blob/master/health/health.d/disks.conf
@@ -626,8 +1899,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: svctm
-  - module_name: net.inet.tcp.states
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: net.inet.tcp.states
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd net.inet.tcp.states
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -646,8 +1986,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: connections
-  - module_name: net.inet.tcp.stats
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: net.inet.tcp.stats
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd net.inet.tcp.stats
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: 1m_ipv4_tcp_resets_sent
         link: https://github.com/netdata/netdata/blob/master/health/health.d/tcp_resets.conf
@@ -741,8 +2148,75 @@ modules:
                 - name: InECT1Pkts
                 - name: OutECT0Pkts
                 - name: OutECT1Pkts
-  - module_name: net.inet.udp.stats
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: net.inet.udp.stats
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd net.inet.udp.stats
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: 1m_ipv4_udp_receive_buffer_errors
         link: https://github.com/netdata/netdata/blob/master/health/health.d/udp_errors.conf
@@ -777,8 +2251,75 @@ modules:
                 - name: RcvbufErrors
                 - name: InCsumErrors
                 - name: IgnoredMulti
-  - module_name: net.inet.icmp.stats
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: net.inet.icmp.stats
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd net.inet.icmp.stats
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -815,8 +2356,75 @@ modules:
                 - name: OutEchoReps
                 - name: InEchos
                 - name: OutEchos
-  - module_name: net.inet.ip.stats
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: net.inet.ip.stats
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd net.inet.ip.stats
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -865,8 +2473,75 @@ modules:
                 - name: OutNoRoutes
                 - name: InAddrErrors
                 - name: InUnknownProtos
-  - module_name: net.inet6.ip6.stats
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: net.inet6.ip6.stats
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd net.inet6.ip6.stats
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -917,8 +2592,75 @@ modules:
                 - name: InTruncatedPkts
                 - name: InNoRoutes
                 - name: OutNoRoutes
-  - module_name: net.inet6.icmp6.stats
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: net.inet6.icmp6.stats
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd net.inet6.icmp6.stats
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -1002,8 +2744,75 @@ modules:
                 - name: OutType133
                 - name: OutType135
                 - name: OutType143
-  - module_name: ipfw
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: ipfw
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd ipfw
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -1047,8 +2856,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: a dimension per dynamic rule
-  - module_name: getifaddrs
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: getifaddrs
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd getifaddrs
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: interface_speed
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
@@ -1202,8 +3078,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: collisions
-  - module_name: getmntinfo
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: getmntinfo
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd getmntinfo
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: disk_space_usage
         link: https://github.com/netdata/netdata/blob/master/health/health.d/disks.conf
@@ -1242,8 +3185,75 @@ modules:
                 - name: avail
                 - name: used
                 - name: reserved_for_root
-  - module_name: zfs
-    plugin_name: freebsd.plugin
+  - meta:
+      plugin_name: freebsd.plugin
+      module_name: zfs
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freebsd zfs
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: zfs_memory_throttle
         link: https://github.com/netdata/netdata/blob/master/health/health.d/zfs.conf

--- a/collectors/freeipmi.plugin/multi_metadata.yaml
+++ b/collectors/freeipmi.plugin/multi_metadata.yaml
@@ -11,9 +11,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -37,9 +35,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -49,26 +45,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -98,9 +83,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -124,9 +107,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -136,26 +117,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: ipmi_sensor_state
         link: https://github.com/netdata/netdata/blob/master/health/health.d/ipmi.conf

--- a/collectors/freeipmi.plugin/multi_metadata.yaml
+++ b/collectors/freeipmi.plugin/multi_metadata.yaml
@@ -1,7 +1,74 @@
 name: freeipmi.plugin
 modules:
-  - module_name: sel
-    plugin_name: freeipmi.plugin
+  - meta:
+      plugin_name: freeipmi.plugin
+      module_name: sel
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freeipmi sel
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -20,8 +87,75 @@ modules:
               chart_type: area
               dimensions:
                 - name: events
-  - module_name: sensors
-    plugin_name: freeipmi.plugin
+  - meta:
+      plugin_name: freeipmi.plugin
+      module_name: sensors
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: freeipmi sensors
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: ipmi_sensor_state
         link: https://github.com/netdata/netdata/blob/master/health/health.d/ipmi.conf

--- a/collectors/idlejitter.plugin/metadata.yaml
+++ b/collectors/idlejitter.plugin/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/idlejitter.plugin/metadata.yaml
+++ b/collectors/idlejitter.plugin/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: idlejitter.plugin
-plugin_name: idlejitter.plugin
+meta:
+  plugin_name: idlejitter.plugin
+  module_name: idlejitter.plugin
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: idlejitter
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/ioping.plugin/metadata.yaml
+++ b/collectors/ioping.plugin/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: ioping.plugin
-plugin_name: ioping.plugin
+meta:
+  plugin_name: ioping.plugin
+  module_name: ioping.plugin
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: ioping
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/ioping.plugin/metadata.yaml
+++ b/collectors/ioping.plugin/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/macos.plugin/multi_metadata.yaml
+++ b/collectors/macos.plugin/multi_metadata.yaml
@@ -11,9 +11,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -37,9 +35,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -49,26 +45,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: 10min_cpu_usage
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cpu.conf
@@ -166,9 +151,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -192,9 +175,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -204,26 +185,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: load_cpu_number
         link: https://github.com/netdata/netdata/blob/master/health/health.d/load.conf
@@ -552,9 +522,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -578,9 +546,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -590,26 +556,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: 10min_disk_utilization
         link: https://github.com/netdata/netdata/blob/master/health/health.d/disks.conf

--- a/collectors/macos.plugin/multi_metadata.yaml
+++ b/collectors/macos.plugin/multi_metadata.yaml
@@ -1,7 +1,74 @@
 name: macos.plugin
 modules:
-  - module_name: mach_smi
-    plugin_name: macos.plugin
+  - meta:
+      plugin_name: macos.plugin
+      module_name: mach_smi
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: macos mach_smi
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: 10min_cpu_usage
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cpu.conf
@@ -88,8 +155,75 @@ modules:
                 - name: zero_fill
                 - name: reactivate
                 - name: purge
-  - module_name: sysctl
-    plugin_name: macos.plugin
+  - meta:
+      plugin_name: macos.plugin
+      module_name: sysctl
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: macos sysctl
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: load_cpu_number
         link: https://github.com/netdata/netdata/blob/master/health/health.d/load.conf
@@ -407,8 +541,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: uptime
-  - module_name: iokit
-    plugin_name: macos.plugin
+  - meta:
+      plugin_name: macos.plugin
+      module_name: iokit
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: macos iokit
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: 10min_disk_utilization
         link: https://github.com/netdata/netdata/blob/master/health/health.d/disks.conf

--- a/collectors/nfacct.plugin/metadata.yaml
+++ b/collectors/nfacct.plugin/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: nfacct.plugin
-plugin_name: nfacct.plugin
+meta:
+  plugin_name: nfacct.plugin
+  module_name: nfacct.plugin
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: nfacct
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/nfacct.plugin/metadata.yaml
+++ b/collectors/nfacct.plugin/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/perf.plugin/metadata.yaml
+++ b/collectors/perf.plugin/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: perf.plugin
-plugin_name: perf.plugin
+meta:
+  plugin_name: perf.plugin
+  module_name: perf.plugin
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: perf
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/perf.plugin/metadata.yaml
+++ b/collectors/perf.plugin/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/proc.plugin/multi_metadata.yaml
+++ b/collectors/proc.plugin/multi_metadata.yaml
@@ -1,7 +1,74 @@
 name: proc.plugin
 modules:
-  - module_name: /proc/stat
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/stat
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/stat
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: 10min_cpu_usage
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cpu.conf
@@ -115,8 +182,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: a dimension per c-state
-  - module_name: /proc/sys/kernel/random/entropy_avail
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/sys/kernel/random/entropy_avail
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/sys/kernel/random/entropy_avail
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -135,8 +269,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: entropy
-  - module_name: /proc/uptime
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/uptime
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/uptime
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -155,8 +356,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: uptime
-  - module_name: /proc/vmstat
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/vmstat
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/vmstat
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: 30min_ram_swapped_out
         link: https://github.com/netdata/netdata/blob/master/health/health.d/swap.conf
@@ -297,8 +565,75 @@ modules:
                 - name: hint_faults
                 - name: hint_faults_local
                 - name: pages_migrated
-  - module_name: /proc/interrupts
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/interrupts
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/interrupts
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -329,8 +664,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: a dimension per device
-  - module_name: /proc/loadavg
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/loadavg
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/loadavg
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: load_cpu_number
         link: https://github.com/netdata/netdata/blob/master/health/health.d/load.conf
@@ -372,8 +774,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: active
-  - module_name: /proc/pressure
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/pressure
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/pressure
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -470,8 +939,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: time
-  - module_name: /proc/softirqs
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/softirqs
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/softirqs
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -502,8 +1038,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: a dimension per softirq
-  - module_name: /proc/net/softnet_stat
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/net/softnet_stat
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/net/softnet_stat
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: 1min_netdev_backlog_exceeded
         link: https://github.com/netdata/netdata/blob/master/health/health.d/softnet.conf
@@ -553,8 +1156,75 @@ modules:
                 - name: squeezed
                 - name: received_rps
                 - name: flow_limit_count
-  - module_name: /proc/meminfo
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/meminfo
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/meminfo
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: ram_in_use
         link: https://github.com/netdata/netdata/blob/master/health/health.d/ram.conf
@@ -660,8 +1330,75 @@ modules:
               dimensions:
                 - name: anonymous
                 - name: shmem
-  - module_name: /proc/pagetypeinfo
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/pagetypeinfo
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/pagetypeinfo
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -696,8 +1433,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: a dimension per pagesize
-  - module_name: /sys/devices/system/edac/mc
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /sys/devices/system/edac/mc
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /sys/devices/system/edac/mc
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: 1hour_ecc_memory_correctable
         link: https://github.com/netdata/netdata/blob/master/health/health.d/memory.conf
@@ -732,8 +1536,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: a dimension per mem controller
-  - module_name: /sys/devices/system/node
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /sys/devices/system/node
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /sys/devices/system/node
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -759,8 +1630,75 @@ modules:
                 - name: foreign
                 - name: interleave
                 - name: other
-  - module_name: /sys/kernel/mm/ksm
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /sys/kernel/mm/ksm
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /sys/kernel/mm/ksm
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -795,8 +1733,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: savings
-  - module_name: /sys/block/zram
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /sys/block/zram
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /sys/block/zram
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -837,8 +1842,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: percent
-  - module_name: ipc
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: ipc
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc ipc
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: semaphores_used
         link: https://github.com/netdata/netdata/blob/master/health/health.d/ipc.conf
@@ -892,8 +1964,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: bytes
-  - module_name: /proc/diskstats
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/diskstats
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/diskstats
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: 10min_disk_utilization
         link: https://github.com/netdata/netdata/blob/master/health/health.d/disks.conf
@@ -1108,8 +2247,75 @@ modules:
               dimensions:
                 - name: hits
                 - name: misses
-  - module_name: /proc/mdstat
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/mdstat
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/mdstat
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: mdstat_last_collected
         link: https://github.com/netdata/netdata/blob/master/health/health.d/mdstat.conf
@@ -1193,8 +2399,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: available
-  - module_name: /proc/net/dev
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/net/dev
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/net/dev
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: interface_speed
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
@@ -1389,8 +2662,75 @@ modules:
                 - name: frames
                 - name: collisions
                 - name: carrier
-  - module_name: /proc/net/wireless
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/net/wireless
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/net/wireless
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -1449,8 +2789,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: missed_beacons
-  - module_name: /sys/class/infiniband
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /sys/class/infiniband
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /sys/class/infiniband
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -1538,8 +2945,75 @@ modules:
                 - name: RoCE_slow_restart
                 - name: RoCE_slow_restart_congestion
                 - name: RoCE_slow_restart_count
-  - module_name: /proc/net/netstat
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/net/netstat
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/net/netstat
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: 1m_tcp_syn_queue_drops
         link: https://github.com/netdata/netdata/blob/master/health/health.d/tcp_listen.conf
@@ -2066,8 +3540,75 @@ modules:
                 - name: InECT1Pkts
                 - name: InECT0Pkts
                 - name: InCEPkts
-  - module_name: /proc/net/sockstat
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/net/sockstat
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/net/sockstat
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -2137,8 +3678,75 @@ modules:
               chart_type: area
               dimensions:
                 - name: mem
-  - module_name: /proc/net/sockstat6
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/net/sockstat6
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/net/sockstat6
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -2181,8 +3789,75 @@ modules:
               chart_type: line
               dimensions:
                 - name: inuse
-  - module_name: /proc/net/ip_vs_stats
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/net/ip_vs_stats
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/net/ip_vs_stats
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -2215,8 +3890,75 @@ modules:
               dimensions:
                 - name: received
                 - name: sent
-  - module_name: /proc/net/rpc/nfs
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/net/rpc/nfs
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/net/rpc/nfs
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -2262,8 +4004,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: a dimension per proc4 call
-  - module_name: /proc/net/rpc/nfsd
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/net/rpc/nfsd
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/net/rpc/nfsd
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -2342,8 +4151,75 @@ modules:
               chart_type: stacked
               dimensions:
                 - name: a dimension per proc4 operation
-  - module_name: /proc/net/sctp/snmp
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/net/sctp/snmp
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/net/sctp/snmp
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -2392,8 +4268,75 @@ modules:
               dimensions:
                 - name: reassembled
                 - name: fragmented
-  - module_name: /proc/net/stat/nf_conntrack
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/net/stat/nf_conntrack
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/net/stat/nf_conntrack
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -2453,8 +4396,75 @@ modules:
                 - name: error_failed
                 - name: drop
                 - name: early_drop
-  - module_name: /proc/net/stat/synproxy
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/net/stat/synproxy
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/net/stat/synproxy
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:
@@ -2487,8 +4497,75 @@ modules:
                 - name: valid
                 - name: invalid
                 - name: retransmits
-  - module_name: /proc/spl/kstat/zfs
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/spl/kstat/zfs
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/spl/kstat/zfs
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: zfs_pool_state_warn
         link: https://github.com/netdata/netdata/blob/master/health/health.d/zfs.conf
@@ -2520,8 +4597,75 @@ modules:
                 - name: removed
                 - name: unavail
                 - name: suspended
-  - module_name: /proc/spl/kstat/zfs/arcstats
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /proc/spl/kstat/zfs/arcstats
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /proc/spl/kstat/zfs/arcstats
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: zfs_memory_throttle
         link: https://github.com/netdata/netdata/blob/master/health/health.d/zfs.conf
@@ -2731,8 +4875,75 @@ modules:
               dimensions:
                 - name: current
                 - name: max
-  - module_name: /sys/fs/btrfs
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /sys/fs/btrfs
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /sys/fs/btrfs
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts:
       - name: btrfs_allocated
         link: https://github.com/netdata/netdata/blob/master/health/health.d/btrfs.conf
@@ -2862,8 +5073,75 @@ modules:
                 - name: flush_errs
                 - name: corruption_errs
                 - name: generation_errs
-  - module_name: /sys/class/power_supply
-    plugin_name: proc.plugin
+  - meta:
+      plugin_name: proc.plugin
+      module_name: /sys/class/power_supply
+      alternative_monitored_instances: []
+      monitored_instance:
+        name: proc /sys/class/power_supply
+        link: ''
+        categories: []
+        icon_filename: ''
+      related_resources:
+        integrations:
+          list:
+            - plugin_name: ''
+              module_name: ''
+      info_provided_to_referring_integrations:
+        description: ''
+      keywords: []
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: ''
+        method_description: ''
+      supported_platforms:
+        include: []
+        exclude: []
+      multi-instance: true
+      additional_permissions:
+        description: ''
+      default_behavior:
+        auto_detection:
+          description: ''
+        limits:
+          description: ''
+        performance_impact:
+          description: ''
+    setup:
+      prerequisites:
+        list:
+          - title: ''
+            description: ''
+      configuration:
+        file:
+          name: ''
+          description: ''
+        options:
+          description: ''
+          folding:
+            title: ''
+            enabled: true
+          list:
+            - name: ''
+              default_value: ''
+              description: ''
+              required: false
+        examples:
+          folding:
+            enabled: true
+            title: ''
+          list:
+            - name: ''
+              folding:
+                enabled: false
+              description: ''
+              config: ''
+    troubleshooting:
+      problems:
+        list:
+          - name: ''
+            description: ''
     alerts: []
     metrics:
       folding:

--- a/collectors/proc.plugin/multi_metadata.yaml
+++ b/collectors/proc.plugin/multi_metadata.yaml
@@ -11,9 +11,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -37,9 +35,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -49,26 +45,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: 10min_cpu_usage
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cpu.conf
@@ -193,9 +178,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -219,9 +202,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -231,26 +212,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -280,9 +250,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -306,9 +274,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -318,26 +284,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -367,9 +322,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -393,9 +346,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -405,26 +356,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: 30min_ram_swapped_out
         link: https://github.com/netdata/netdata/blob/master/health/health.d/swap.conf
@@ -576,9 +516,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -602,9 +540,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -614,26 +550,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -675,9 +600,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -701,9 +624,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -713,26 +634,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: load_cpu_number
         link: https://github.com/netdata/netdata/blob/master/health/health.d/load.conf
@@ -785,9 +695,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -811,9 +719,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -823,26 +729,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -950,9 +845,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -976,9 +869,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -988,26 +879,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -1049,9 +929,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1075,9 +953,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1087,26 +963,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: 1min_netdev_backlog_exceeded
         link: https://github.com/netdata/netdata/blob/master/health/health.d/softnet.conf
@@ -1167,9 +1032,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1193,9 +1056,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1205,26 +1066,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: ram_in_use
         link: https://github.com/netdata/netdata/blob/master/health/health.d/ram.conf
@@ -1341,9 +1191,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1367,9 +1215,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1379,26 +1225,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -1444,9 +1279,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1470,9 +1303,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1482,26 +1313,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: 1hour_ecc_memory_correctable
         link: https://github.com/netdata/netdata/blob/master/health/health.d/memory.conf
@@ -1547,9 +1367,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1573,9 +1391,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1585,26 +1401,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -1641,9 +1446,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1667,9 +1470,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1679,26 +1480,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -1744,9 +1534,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1770,9 +1558,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1782,26 +1568,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -1853,9 +1628,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -1879,9 +1652,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -1891,26 +1662,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: semaphores_used
         link: https://github.com/netdata/netdata/blob/master/health/health.d/ipc.conf
@@ -1975,9 +1735,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -2001,9 +1759,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -2013,26 +1769,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: 10min_disk_utilization
         link: https://github.com/netdata/netdata/blob/master/health/health.d/disks.conf
@@ -2258,9 +2003,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -2284,9 +2027,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -2296,26 +2037,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: mdstat_last_collected
         link: https://github.com/netdata/netdata/blob/master/health/health.d/mdstat.conf
@@ -2410,9 +2140,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -2436,9 +2164,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -2448,26 +2174,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: interface_speed
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
@@ -2673,9 +2388,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -2699,9 +2412,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -2711,26 +2422,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -2800,9 +2500,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -2826,9 +2524,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -2838,26 +2534,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -2956,9 +2641,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -2982,9 +2665,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -2994,26 +2675,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: 1m_tcp_syn_queue_drops
         link: https://github.com/netdata/netdata/blob/master/health/health.d/tcp_listen.conf
@@ -3551,9 +3221,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -3577,9 +3245,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -3589,26 +3255,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -3689,9 +3344,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -3715,9 +3368,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -3727,26 +3378,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -3800,9 +3440,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -3826,9 +3464,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -3838,26 +3474,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -3901,9 +3526,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -3927,9 +3550,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -3939,26 +3560,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -4015,9 +3625,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -4041,9 +3649,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -4053,26 +3659,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -4162,9 +3757,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -4188,9 +3781,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -4200,26 +3791,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -4279,9 +3859,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -4305,9 +3883,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -4317,26 +3893,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -4407,9 +3972,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -4433,9 +3996,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -4445,26 +4006,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:
@@ -4508,9 +4058,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -4534,9 +4082,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -4546,26 +4092,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: zfs_pool_state_warn
         link: https://github.com/netdata/netdata/blob/master/health/health.d/zfs.conf
@@ -4608,9 +4143,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -4634,9 +4167,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -4646,26 +4177,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: zfs_memory_throttle
         link: https://github.com/netdata/netdata/blob/master/health/health.d/zfs.conf
@@ -4886,9 +4406,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -4912,9 +4430,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -4924,26 +4440,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts:
       - name: btrfs_allocated
         link: https://github.com/netdata/netdata/blob/master/health/health.d/btrfs.conf
@@ -5084,9 +4589,7 @@ modules:
         icon_filename: ''
       related_resources:
         integrations:
-          list:
-            - plugin_name: ''
-              module_name: ''
+          list: []
       info_provided_to_referring_integrations:
         description: ''
       keywords: []
@@ -5110,9 +4613,7 @@ modules:
           description: ''
     setup:
       prerequisites:
-        list:
-          - title: ''
-            description: ''
+        list: []
       configuration:
         file:
           name: ''
@@ -5122,26 +4623,15 @@ modules:
           folding:
             title: ''
             enabled: true
-          list:
-            - name: ''
-              default_value: ''
-              description: ''
-              required: false
+          list: []
         examples:
           folding:
             enabled: true
             title: ''
-          list:
-            - name: ''
-              folding:
-                enabled: false
-              description: ''
-              config: ''
+          list: []
     troubleshooting:
       problems:
-        list:
-          - name: ''
-            description: ''
+        list: []
     alerts: []
     metrics:
       folding:

--- a/collectors/python.d.plugin/adaptec_raid/metadata.yaml
+++ b/collectors/python.d.plugin/adaptec_raid/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts:
   - name: adaptec_raid_ld_status
     link: https://github.com/netdata/netdata/blob/master/health/health.d/adaptec_raid.conf

--- a/collectors/python.d.plugin/adaptec_raid/metadata.yaml
+++ b/collectors/python.d.plugin/adaptec_raid/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: adaptec_raid
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: adaptec_raid
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d adaptec_raid
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts:
   - name: adaptec_raid_ld_status
     link: https://github.com/netdata/netdata/blob/master/health/health.d/adaptec_raid.conf

--- a/collectors/python.d.plugin/alarms/metadata.yaml
+++ b/collectors/python.d.plugin/alarms/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/alarms/metadata.yaml
+++ b/collectors/python.d.plugin/alarms/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: alarms
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: alarms
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d alarms
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/am2320/metadata.yaml
+++ b/collectors/python.d.plugin/am2320/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/am2320/metadata.yaml
+++ b/collectors/python.d.plugin/am2320/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: am2320
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: am2320
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d am2320
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/anomalies/metadata.yaml
+++ b/collectors/python.d.plugin/anomalies/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: anomalies
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: anomalies
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d anomalies
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts:
   - name: anomalies_anomaly_probabilities
     link: https://github.com/netdata/netdata/blob/master/health/health.d/anomalies.conf

--- a/collectors/python.d.plugin/anomalies/metadata.yaml
+++ b/collectors/python.d.plugin/anomalies/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts:
   - name: anomalies_anomaly_probabilities
     link: https://github.com/netdata/netdata/blob/master/health/health.d/anomalies.conf

--- a/collectors/python.d.plugin/beanstalk/metadata.yaml
+++ b/collectors/python.d.plugin/beanstalk/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: beanstalk
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: beanstalk
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d beanstalk
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts:
   - name: beanstalk_server_buried_jobs
     link: https://github.com/netdata/netdata/blob/master/health/health.d/beanstalkd.conf

--- a/collectors/python.d.plugin/beanstalk/metadata.yaml
+++ b/collectors/python.d.plugin/beanstalk/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts:
   - name: beanstalk_server_buried_jobs
     link: https://github.com/netdata/netdata/blob/master/health/health.d/beanstalkd.conf

--- a/collectors/python.d.plugin/bind_rndc/metadata.yaml
+++ b/collectors/python.d.plugin/bind_rndc/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: bind_rndc
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: bind_rndc
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d bind_rndc
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/bind_rndc/metadata.yaml
+++ b/collectors/python.d.plugin/bind_rndc/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/boinc/metadata.yaml
+++ b/collectors/python.d.plugin/boinc/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts:
   - name: boinc_total_tasks
     link: https://github.com/netdata/netdata/blob/master/health/health.d/boinc.conf

--- a/collectors/python.d.plugin/boinc/metadata.yaml
+++ b/collectors/python.d.plugin/boinc/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: boinc
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: boinc
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d boinc
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts:
   - name: boinc_total_tasks
     link: https://github.com/netdata/netdata/blob/master/health/health.d/boinc.conf

--- a/collectors/python.d.plugin/ceph/metadata.yaml
+++ b/collectors/python.d.plugin/ceph/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/ceph/metadata.yaml
+++ b/collectors/python.d.plugin/ceph/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: ceph
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: ceph
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d ceph
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/changefinder/metadata.yaml
+++ b/collectors/python.d.plugin/changefinder/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: changefinder
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: changefinder
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d changefinder
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/changefinder/metadata.yaml
+++ b/collectors/python.d.plugin/changefinder/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/dovecot/metadata.yaml
+++ b/collectors/python.d.plugin/dovecot/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: dovecot
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: dovecot
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d dovecot
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/dovecot/metadata.yaml
+++ b/collectors/python.d.plugin/dovecot/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/exim/metadata.yaml
+++ b/collectors/python.d.plugin/exim/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/exim/metadata.yaml
+++ b/collectors/python.d.plugin/exim/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: exim
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: exim
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d exim
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/fail2ban/metadata.yaml
+++ b/collectors/python.d.plugin/fail2ban/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/fail2ban/metadata.yaml
+++ b/collectors/python.d.plugin/fail2ban/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: fail2ban
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: fail2ban
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d fail2ban
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/gearman/metadata.yaml
+++ b/collectors/python.d.plugin/gearman/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/gearman/metadata.yaml
+++ b/collectors/python.d.plugin/gearman/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: gearman
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: gearman
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d gearman
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/go_expvar/metadata.yaml
+++ b/collectors/python.d.plugin/go_expvar/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/go_expvar/metadata.yaml
+++ b/collectors/python.d.plugin/go_expvar/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: go_expvar
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: go_expvar
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d go_expvar
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/haproxy/metadata.yaml
+++ b/collectors/python.d.plugin/haproxy/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts:
   - name: haproxy_backend_server_status
     link: https://github.com/netdata/netdata/blob/master/health/health.d/haproxy.conf

--- a/collectors/python.d.plugin/haproxy/metadata.yaml
+++ b/collectors/python.d.plugin/haproxy/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: haproxy
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: haproxy
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d haproxy
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts:
   - name: haproxy_backend_server_status
     link: https://github.com/netdata/netdata/blob/master/health/health.d/haproxy.conf

--- a/collectors/python.d.plugin/hddtemp/metadata.yaml
+++ b/collectors/python.d.plugin/hddtemp/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/hddtemp/metadata.yaml
+++ b/collectors/python.d.plugin/hddtemp/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: hddtemp
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: hddtemp
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d hddtemp
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/hpssa/metadata.yaml
+++ b/collectors/python.d.plugin/hpssa/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: hpssa
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: hpssa
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d hpssa
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/hpssa/metadata.yaml
+++ b/collectors/python.d.plugin/hpssa/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/icecast/metadata.yaml
+++ b/collectors/python.d.plugin/icecast/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: icecast
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: icecast
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d icecast
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/icecast/metadata.yaml
+++ b/collectors/python.d.plugin/icecast/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/ipfs/metadata.yaml
+++ b/collectors/python.d.plugin/ipfs/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: ipfs
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: ipfs
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d ipfs
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/ipfs/metadata.yaml
+++ b/collectors/python.d.plugin/ipfs/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/litespeed/metadata.yaml
+++ b/collectors/python.d.plugin/litespeed/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/litespeed/metadata.yaml
+++ b/collectors/python.d.plugin/litespeed/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: litespeed
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: litespeed
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d litespeed
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/megacli/metadata.yaml
+++ b/collectors/python.d.plugin/megacli/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts:
   - name: megacli_adapter_state
     link: https://github.com/netdata/netdata/blob/master/health/health.d/megacli.conf

--- a/collectors/python.d.plugin/megacli/metadata.yaml
+++ b/collectors/python.d.plugin/megacli/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: megacli
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: megacli
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d megacli
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts:
   - name: megacli_adapter_state
     link: https://github.com/netdata/netdata/blob/master/health/health.d/megacli.conf

--- a/collectors/python.d.plugin/memcached/metadata.yaml
+++ b/collectors/python.d.plugin/memcached/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts:
   - name: memcached_cache_memory_usage
     link: https://github.com/netdata/netdata/blob/master/health/health.d/memcached.conf

--- a/collectors/python.d.plugin/memcached/metadata.yaml
+++ b/collectors/python.d.plugin/memcached/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: memcached
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: memcached
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d memcached
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts:
   - name: memcached_cache_memory_usage
     link: https://github.com/netdata/netdata/blob/master/health/health.d/memcached.conf

--- a/collectors/python.d.plugin/monit/metadata.yaml
+++ b/collectors/python.d.plugin/monit/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: monit
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: monit
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d monit
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/monit/metadata.yaml
+++ b/collectors/python.d.plugin/monit/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/nsd/metadata.yaml
+++ b/collectors/python.d.plugin/nsd/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: nsd
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: nsd
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d nsd
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/nsd/metadata.yaml
+++ b/collectors/python.d.plugin/nsd/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/nvidia_smi/metadata.yaml
+++ b/collectors/python.d.plugin/nvidia_smi/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: nvidia_smi
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: nvidia_smi
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d nvidia_smi
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/nvidia_smi/metadata.yaml
+++ b/collectors/python.d.plugin/nvidia_smi/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/openldap/metadata.yaml
+++ b/collectors/python.d.plugin/openldap/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/openldap/metadata.yaml
+++ b/collectors/python.d.plugin/openldap/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: openldap
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: openldap
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d openldap
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/oracledb/metadata.yaml
+++ b/collectors/python.d.plugin/oracledb/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: oracledb
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: oracledb
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d oracledb
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/oracledb/metadata.yaml
+++ b/collectors/python.d.plugin/oracledb/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/postfix/metadata.yaml
+++ b/collectors/python.d.plugin/postfix/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/postfix/metadata.yaml
+++ b/collectors/python.d.plugin/postfix/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: postfix
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: postfix
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d postfix
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/puppet/metadata.yaml
+++ b/collectors/python.d.plugin/puppet/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/puppet/metadata.yaml
+++ b/collectors/python.d.plugin/puppet/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: puppet
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: puppet
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d puppet
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/rethinkdbs/metadata.yaml
+++ b/collectors/python.d.plugin/rethinkdbs/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: rethinkdbs
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: rethinkdbs
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d rethinkdbs
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/rethinkdbs/metadata.yaml
+++ b/collectors/python.d.plugin/rethinkdbs/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/retroshare/metadata.yaml
+++ b/collectors/python.d.plugin/retroshare/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/retroshare/metadata.yaml
+++ b/collectors/python.d.plugin/retroshare/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: retroshare
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: retroshare
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d retroshare
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/riakkv/metadata.yaml
+++ b/collectors/python.d.plugin/riakkv/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts:
   - name: riakkv_1h_kv_get_mean_latency
     link: https://github.com/netdata/netdata/blob/master/health/health.d/riakkv.conf

--- a/collectors/python.d.plugin/riakkv/metadata.yaml
+++ b/collectors/python.d.plugin/riakkv/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: riakkv
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: riakkv
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d riakkv
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts:
   - name: riakkv_1h_kv_get_mean_latency
     link: https://github.com/netdata/netdata/blob/master/health/health.d/riakkv.conf

--- a/collectors/python.d.plugin/samba/metadata.yaml
+++ b/collectors/python.d.plugin/samba/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/samba/metadata.yaml
+++ b/collectors/python.d.plugin/samba/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: samba
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: samba
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d samba
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/sensors/metadata.yaml
+++ b/collectors/python.d.plugin/sensors/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: sensors
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: sensors
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d sensors
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/sensors/metadata.yaml
+++ b/collectors/python.d.plugin/sensors/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/smartd_log/metadata.yaml
+++ b/collectors/python.d.plugin/smartd_log/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: smartd_log
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: smartd_log
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d smartd_log
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/smartd_log/metadata.yaml
+++ b/collectors/python.d.plugin/smartd_log/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/spigotmc/metadata.yaml
+++ b/collectors/python.d.plugin/spigotmc/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/spigotmc/metadata.yaml
+++ b/collectors/python.d.plugin/spigotmc/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: spigotmc
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: spigotmc
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d spigotmc
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/squid/metadata.yaml
+++ b/collectors/python.d.plugin/squid/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/squid/metadata.yaml
+++ b/collectors/python.d.plugin/squid/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: squid
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: squid
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d squid
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/tomcat/metadata.yaml
+++ b/collectors/python.d.plugin/tomcat/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/tomcat/metadata.yaml
+++ b/collectors/python.d.plugin/tomcat/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: tomcat
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: tomcat
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d tomcat
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/tor/metadata.yaml
+++ b/collectors/python.d.plugin/tor/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: tor
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: tor
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d tor
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/tor/metadata.yaml
+++ b/collectors/python.d.plugin/tor/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/traefik/metadata.yaml
+++ b/collectors/python.d.plugin/traefik/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/traefik/metadata.yaml
+++ b/collectors/python.d.plugin/traefik/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: traefik
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: traefik
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d traefik
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/uwsgi/metadata.yaml
+++ b/collectors/python.d.plugin/uwsgi/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: uwsgi
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: uwsgi
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d uwsgi
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/uwsgi/metadata.yaml
+++ b/collectors/python.d.plugin/uwsgi/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/varnish/metadata.yaml
+++ b/collectors/python.d.plugin/varnish/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/varnish/metadata.yaml
+++ b/collectors/python.d.plugin/varnish/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: varnish
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: varnish
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d varnish
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/w1sensor/metadata.yaml
+++ b/collectors/python.d.plugin/w1sensor/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/w1sensor/metadata.yaml
+++ b/collectors/python.d.plugin/w1sensor/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: w1sensor
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: w1sensor
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d w1sensor
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/zscores/metadata.yaml
+++ b/collectors/python.d.plugin/zscores/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/python.d.plugin/zscores/metadata.yaml
+++ b/collectors/python.d.plugin/zscores/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: zscores
-plugin_name: python.d.plugin
+meta:
+  plugin_name: python.d.plugin
+  module_name: zscores
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: python.d zscores
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/slabinfo.plugin/metadata.yaml
+++ b/collectors/slabinfo.plugin/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/slabinfo.plugin/metadata.yaml
+++ b/collectors/slabinfo.plugin/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: slabinfo.plugin
-plugin_name: slabinfo.plugin
+meta:
+  plugin_name: slabinfo.plugin
+  module_name: slabinfo.plugin
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: slabinfo
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/tc.plugin/metadata.yaml
+++ b/collectors/tc.plugin/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: tc.plugin
-plugin_name: tc.plugin
+meta:
+  plugin_name: tc.plugin
+  module_name: tc.plugin
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: tc
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/tc.plugin/metadata.yaml
+++ b/collectors/tc.plugin/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/timex.plugin/metadata.yaml
+++ b/collectors/timex.plugin/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/timex.plugin/metadata.yaml
+++ b/collectors/timex.plugin/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: timex.plugin
-plugin_name: timex.plugin
+meta:
+  plugin_name: timex.plugin
+  module_name: timex.plugin
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: timex
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:

--- a/collectors/xenstat.plugin/metadata.yaml
+++ b/collectors/xenstat.plugin/metadata.yaml
@@ -9,9 +9,7 @@ meta:
     icon_filename: ''
   related_resources:
     integrations:
-      list:
-        - plugin_name: ''
-          module_name: ''
+      list: []
   info_provided_to_referring_integrations:
     description: ''
   keywords: []
@@ -35,9 +33,7 @@ overview:
       description: ''
 setup:
   prerequisites:
-    list:
-      - title: ''
-        description: ''
+    list: []
   configuration:
     file:
       name: ''
@@ -47,26 +43,15 @@ setup:
       folding:
         title: ''
         enabled: true
-      list:
-        - name: ''
-          default_value: ''
-          description: ''
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
         title: ''
-      list:
-        - name: ''
-          folding:
-            enabled: false
-          description: ''
-          config: ''
+      list: []
 troubleshooting:
   problems:
-    list:
-      - name: ''
-        description: ''
+    list: []
 alerts: []
 metrics:
   folding:

--- a/collectors/xenstat.plugin/metadata.yaml
+++ b/collectors/xenstat.plugin/metadata.yaml
@@ -1,5 +1,72 @@
-module_name: xenstat.plugin
-plugin_name: xenstat.plugin
+meta:
+  plugin_name: xenstat.plugin
+  module_name: xenstat.plugin
+  alternative_monitored_instances: []
+  monitored_instance:
+    name: xenstat
+    link: ''
+    categories: []
+    icon_filename: ''
+  related_resources:
+    integrations:
+      list:
+        - plugin_name: ''
+          module_name: ''
+  info_provided_to_referring_integrations:
+    description: ''
+  keywords: []
+  most_popular: false
+overview:
+  data_collection:
+    metrics_description: ''
+    method_description: ''
+  supported_platforms:
+    include: []
+    exclude: []
+  multi-instance: true
+  additional_permissions:
+    description: ''
+  default_behavior:
+    auto_detection:
+      description: ''
+    limits:
+      description: ''
+    performance_impact:
+      description: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''
+troubleshooting:
+  problems:
+    list:
+      - name: ''
+        description: ''
 alerts: []
 metrics:
   folding:


### PR DESCRIPTION
##### Summary

As discussed, yaml files should pass the schema, and a naming scheme should be in place to tackle the empty yamls.

For single module yaml files we use just module name without `.plugin`

and for multi module yaml files we use plugin name without `.plugin` + module name

In contrast to https://github.com/netdata/netdata/blob/f4805f8053a49fd627a89f4ec328c37b2d75167e/collectors/metadata/single-module-template.yaml I make lists here actually empty. I understand that template needs to be a bit human friendly in giving examples, but these yamls should have empty info in them.