### PR TITLE
collector meta: restrict chart_type to known values

### DIFF
--- a/collectors/metadata/schemas/single-module.json
+++ b/collectors/metadata/schemas/single-module.json
@@ -304,7 +304,8 @@
                       "default_value": {
                         "type": [
                           "string",
-                          "number"
+                          "number",
+                          "boolean"
                         ],
                         "description": "Default value. Leave empty if none."
                       },

--- a/collectors/metadata/schemas/single-module.json
+++ b/collectors/metadata/schemas/single-module.json
@@ -540,7 +540,12 @@
                     },
                     "chart_type": {
                       "type": "string",
-                      "description": "Metric description (chart type)."
+                      "description": "Metric description (chart type).",
+                      "enum": [
+                        "line",
+                        "area",
+                        "stacked"
+                      ]
                     },
                     "dimensions": {
                       "type": "array",


### PR DESCRIPTION
##### Summary

This PR:

 - restricts metrics.scopes.metrics.chart_type values.
 - allows config option default value to be boolean

##### Test Plan

Not needed

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
