### PR TITLE
use real-time clock for http response headers

### DIFF
--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -197,7 +197,6 @@ static int http_api_v2(struct aclk_query_thread *query_thr, aclk_query_t query) 
         z_buffer = NULL;
     }
 
-    w->response.data->date = w->timings.tv_ready.tv_sec;
     web_client_build_http_header(w);
     local_buffer = buffer_create(NETDATA_WEB_RESPONSE_INITIAL_SIZE, &netdata_buffers_statistics.buffers_aclk);
     local_buffer->content_type = CT_APPLICATION_JSON;

--- a/web/api/badges/web_buffer_svg.c
+++ b/web/api/badges/web_buffer_svg.c
@@ -1055,7 +1055,8 @@ int web_client_api_request_v1_badge(RRDHOST *host, struct web_client *w, char *u
     if(rc) {
         if (refresh > 0) {
             buffer_sprintf(w->response.header, "Refresh: %d\r\n", refresh);
-            w->response.data->expires = now_realtime_sec() + refresh;
+            w->response.data->date = now_realtime_sec();
+            w->response.data->expires = w->response.data->date + refresh;
         }
         else buffer_no_cacheable(w->response.data);
 


### PR DESCRIPTION
The agent was using internally the monotonic clock which was accidentally used for rendering http response headers.
Fixed it.