### PR TITLE
Decode url before checking for question mark

### DIFF
--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -2296,7 +2296,7 @@ void web_client_decode_path_and_query_string(struct web_client *w, const char *p
             buffer_strcat(w->url_path_decoded, buffer);
             *question_mark_start = c;
         } else {
-            buffer_strcat(w->url_query_string_decoded, buffer);
+            buffer_strcat(w->url_query_string_decoded, "");
             buffer_strcat(w->url_path_decoded, buffer);
         }
     }

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -2260,7 +2260,6 @@ ssize_t web_client_receive(struct web_client *w)
     return(bytes);
 }
 
-
 void web_client_decode_path_and_query_string(struct web_client *w, const char *path_and_query_string) {
     char buffer[NETDATA_WEB_REQUEST_URL_SIZE + 2];
     buffer[0] = '\0';
@@ -2282,32 +2281,24 @@ void web_client_decode_path_and_query_string(struct web_client *w, const char *p
     }
     else {
         // in non-stream mode, there is a path
-
         // FIXME - the way this is implemented, query string params never accept the symbol &, not even encoded as %26
         // To support the symbol & in query string params, we need to turn the url_query_string_decoded into a
         // dictionary and decode each of the parameters individually.
         // OR: in url_query_string_decoded use as separator a control character that cannot appear in the URL.
 
-        char path_and_query_string_decoded[NETDATA_WEB_REQUEST_URL_SIZE + 2];
-        url_decode_r(path_and_query_string_decoded, path_and_query_string, NETDATA_WEB_REQUEST_URL_SIZE + 1);
+        url_decode_r(buffer, path_and_query_string, NETDATA_WEB_REQUEST_URL_SIZE + 1);
 
-        char *question_mark_start = strchr(path_and_query_string_decoded, '?');
-        if (question_mark_start)
-            strncpyz(buffer, question_mark_start, NETDATA_WEB_REQUEST_URL_SIZE + 1);
-
-        buffer[NETDATA_WEB_REQUEST_URL_SIZE + 1] = '\0';
-        buffer_strcat(w->url_query_string_decoded, buffer);
-
+        char *question_mark_start = strchr(buffer, '?');
         if (question_mark_start) {
+            buffer_strcat(w->url_query_string_decoded, question_mark_start);
             char c = *question_mark_start;
             *question_mark_start = '\0';
-            strncpyz(buffer, path_and_query_string_decoded, NETDATA_WEB_REQUEST_URL_SIZE + 1);
+            buffer_strcat(w->url_path_decoded, buffer);
             *question_mark_start = c;
-        } else
-            strncpyz(buffer, path_and_query_string_decoded, NETDATA_WEB_REQUEST_URL_SIZE + 1);
-
-        buffer[NETDATA_WEB_REQUEST_URL_SIZE + 1] = '\0';
-        buffer_strcat(w->url_path_decoded, buffer);
+        } else {
+            buffer_strcat(w->url_query_string_decoded, buffer);
+            buffer_strcat(w->url_path_decoded, buffer);
+        }
     }
 }
 

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -2288,9 +2288,12 @@ void web_client_decode_path_and_query_string(struct web_client *w, const char *p
         // dictionary and decode each of the parameters individually.
         // OR: in url_query_string_decoded use as separator a control character that cannot appear in the URL.
 
-        char *question_mark_start = strchr(path_and_query_string, '?');
+        char path_and_query_string_decoded[NETDATA_WEB_REQUEST_URL_SIZE + 2];
+        url_decode_r(path_and_query_string_decoded, path_and_query_string, NETDATA_WEB_REQUEST_URL_SIZE + 1);
+
+        char *question_mark_start = strchr(path_and_query_string_decoded, '?');
         if (question_mark_start)
-            url_decode_r(buffer, question_mark_start, NETDATA_WEB_REQUEST_URL_SIZE + 1);
+            strncpyz(buffer, question_mark_start, NETDATA_WEB_REQUEST_URL_SIZE + 1);
 
         buffer[NETDATA_WEB_REQUEST_URL_SIZE + 1] = '\0';
         buffer_strcat(w->url_query_string_decoded, buffer);
@@ -2298,10 +2301,10 @@ void web_client_decode_path_and_query_string(struct web_client *w, const char *p
         if (question_mark_start) {
             char c = *question_mark_start;
             *question_mark_start = '\0';
-            url_decode_r(buffer, path_and_query_string, NETDATA_WEB_REQUEST_URL_SIZE + 1);
+            strncpyz(buffer, path_and_query_string_decoded, NETDATA_WEB_REQUEST_URL_SIZE + 1);
             *question_mark_start = c;
         } else
-            url_decode_r(buffer, path_and_query_string, NETDATA_WEB_REQUEST_URL_SIZE + 1);
+            strncpyz(buffer, path_and_query_string_decoded, NETDATA_WEB_REQUEST_URL_SIZE + 1);
 
         buffer[NETDATA_WEB_REQUEST_URL_SIZE + 1] = '\0';
         buffer_strcat(w->url_path_decoded, buffer);


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #15344 

Decode the url string before checking for a question mark. Each part of the url (before and after question mark) would be decoded after the check.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Besides checking the case of #15344, tests should include proper dashboard functionality, charts, data, as well as cloud connectivity for anything weird.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
