### PR TITLE
fix unlocked registry access and add hostname to search response

### DIFF
--- a/registry/registry_internals.c
+++ b/registry/registry_internals.c
@@ -209,7 +209,7 @@ REGISTRY_PERSON *registry_request_delete(const char *person_guid, char *machine_
 }
 
 
-REGISTRY_MACHINE *registry_request_machine(const char *person_guid, char *request_machine) {
+REGISTRY_MACHINE *registry_request_machine(const char *person_guid, char *request_machine, STRING **hostname) {
     char pbuf[GUID_LEN + 1];
     char mbuf[GUID_LEN + 1];
 
@@ -239,8 +239,10 @@ REGISTRY_MACHINE *registry_request_machine(const char *person_guid, char *reques
 
     // make sure the user has access
     for(REGISTRY_PERSON_URL *pu = p->person_urls; pu ;pu = pu->next)
-        if(pu->machine == m)
+        if(pu->machine == m) {
+            *hostname = string_dup(pu->machine_name);
             return m;
+        }
 
     return NULL;
 }

--- a/registry/registry_internals.h
+++ b/registry/registry_internals.h
@@ -72,7 +72,7 @@ extern struct registry registry;
 // REGISTRY LOW-LEVEL REQUESTS (in registry-internals.c)
 REGISTRY_PERSON *registry_request_access(const char *person_guid, char *machine_guid, char *url, char *name, time_t when);
 REGISTRY_PERSON *registry_request_delete(const char *person_guid, char *machine_guid, char *url, char *delete_url, time_t when);
-REGISTRY_MACHINE *registry_request_machine(const char *person_guid, char *request_machine);
+REGISTRY_MACHINE *registry_request_machine(const char *person_guid, char *request_machine, STRING **hostname);
 
 // REGISTRY LOG (in registry_log.c)
 void registry_log(char action, REGISTRY_PERSON *p, REGISTRY_MACHINE *m, STRING *u, const char *name);


### PR DESCRIPTION
- [x] fix bug that the registry was accessed unlocked and netdata was giving a fatal on dictionaries
- [x] added hostname to `/api/v1/registry?action=search`.