### PR TITLE
Remove duplicate category from categories.yaml

### DIFF
--- a/integrations/categories.yaml
+++ b/integrations/categories.yaml
@@ -117,11 +117,6 @@
       description: ""
       most-popular: false
       children: []
-    - id: data-collection.containers-vms
-      name: Containers & VMs
-      description: ""
-      most-popular: false
-      children: []
     - id: data-collection.ci-cd-systems
       name: CI/CD Systems
       description: ""


### PR DESCRIPTION
##### Summary

As discussed, this is a duplicate category, as long as we don't render empty categories, we should be fine about using the categories in this yaml, we can clean them up post-release, but this one was wrong from the start, thus this PR