### PR TITLE
disable apps_group_file_descriptors_utilization alarm

### DIFF
--- a/health/health.d/file_descriptors.conf
+++ b/health/health.d/file_descriptors.conf
@@ -20,6 +20,7 @@
      type: System
 component: Process
        os: linux
+   module: !* *
     hosts: *
    lookup: max -1m unaligned foreach *
     units: %


### PR DESCRIPTION
##### Summary

[Reported on Discord](https://discord.com/channels/847502280503590932/847502280503590935/1130797853481127996)

> there seems to be a new metric "Apps File Descriptors Limit" i am getting blasted with useless alerts that ssh gets peaks of 700% no logged events except cronjobs.

I guess we have a problem in our fd limit calculations, this PR disabled the alarm until the calculation is fixed

##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
