### PR TITLE
Fix multiline

### DIFF
--- a/collectors/apps.plugin/multi_metadata.yaml
+++ b/collectors/apps.plugin/multi_metadata.yaml
@@ -3,7 +3,6 @@ modules:
   - meta:
       plugin_name: apps.plugin
       module_name: system
-      alternative_monitored_instances: []
       monitored_instance:
         name: apps system
         link: ''
@@ -79,7 +78,6 @@ modules:
   - meta:
       plugin_name: apps.plugin
       module_name: apps
-      alternative_monitored_instances: []
       monitored_instance:
         name: apps apps
         link: ''
@@ -295,7 +293,6 @@ modules:
   - meta:
       plugin_name: apps.plugin
       module_name: groups
-      alternative_monitored_instances: []
       monitored_instance:
         name: apps groups
         link: ''
@@ -511,7 +508,6 @@ modules:
   - meta:
       plugin_name: apps.plugin
       module_name: users
-      alternative_monitored_instances: []
       monitored_instance:
         name: apps users
         link: ''
@@ -727,7 +723,6 @@ modules:
   - meta:
       plugin_name: apps.plugin
       module_name: netdata
-      alternative_monitored_instances: []
       monitored_instance:
         name: apps netdata
         link: ''

--- a/collectors/cgroups.plugin/multi_metadata.yaml
+++ b/collectors/cgroups.plugin/multi_metadata.yaml
@@ -3,7 +3,6 @@ modules:
   - meta:
       plugin_name: cgroups.plugin
       module_name: /sys/fs/cgroup
-      alternative_monitored_instances: []
       monitored_instance:
         name: cgroups /sys/fs/cgroup
         link: ''
@@ -559,7 +558,6 @@ modules:
   - meta:
       plugin_name: cgroups.plugin
       module_name: /proc/net/dev
-      alternative_monitored_instances: []
       monitored_instance:
         name: cgroups /proc/net/dev
         link: ''
@@ -614,25 +612,19 @@ modules:
       - name: cgroup_1m_received_packets_rate
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cgroups.conf
         metric: cgroup.net_packets
-        info: average number of packets received by the network interface ${label:device}
-          over the last minute
+        info: average number of packets received by the network interface ${label:device} over the last minute
       - name: cgroup_10s_received_packets_storm
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cgroups.conf
         metric: cgroup.net_packets
-        info: ratio of average number of received packets for the network interface
-          ${label:device} over the last 10 seconds, compared to the rate over the
-          last minute
+        info: ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, compared to the rate over the last minute
       - name: k8s_cgroup_1m_received_packets_rate
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cgroups.conf
         metric: k8s.cgroup.net_packets
-        info: average number of packets received by the network interface ${label:device}
-          over the last minute
+        info: average number of packets received by the network interface ${label:device} over the last minute
       - name: k8s_cgroup_10s_received_packets_storm
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cgroups.conf
         metric: k8s.cgroup.net_packets
-        info: ratio of average number of received packets for the network interface
-          ${label:device} over the last 10 seconds, compared to the rate over the
-          last minute
+        info: ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, compared to the rate over the last minute
     metrics:
       folding:
         title: Metrics
@@ -837,7 +829,6 @@ modules:
   - meta:
       plugin_name: cgroups.plugin
       module_name: systemd
-      alternative_monitored_instances: []
       monitored_instance:
         name: cgroups systemd
         link: ''

--- a/collectors/charts.d.plugin/ap/metadata.yaml
+++ b/collectors/charts.d.plugin/ap/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: charts.d.plugin
   module_name: ap
-  alternative_monitored_instances: []
   monitored_instance:
     name: charts.d ap
     link: ''

--- a/collectors/charts.d.plugin/apcupsd/metadata.yaml
+++ b/collectors/charts.d.plugin/apcupsd/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: charts.d.plugin
   module_name: apcupsd
-  alternative_monitored_instances: []
   monitored_instance:
     name: charts.d apcupsd
     link: ''

--- a/collectors/charts.d.plugin/libreswan/metadata.yaml
+++ b/collectors/charts.d.plugin/libreswan/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: charts.d.plugin
   module_name: libreswan
-  alternative_monitored_instances: []
   monitored_instance:
     name: charts.d libreswan
     link: ''

--- a/collectors/charts.d.plugin/nut/metadata.yaml
+++ b/collectors/charts.d.plugin/nut/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: charts.d.plugin
   module_name: nut
-  alternative_monitored_instances: []
   monitored_instance:
     name: charts.d nut
     link: ''

--- a/collectors/charts.d.plugin/opensips/metadata.yaml
+++ b/collectors/charts.d.plugin/opensips/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: charts.d.plugin
   module_name: opensips
-  alternative_monitored_instances: []
   monitored_instance:
     name: charts.d opensips
     link: ''

--- a/collectors/charts.d.plugin/sensors/metadata.yaml
+++ b/collectors/charts.d.plugin/sensors/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: charts.d.plugin
   module_name: sensors
-  alternative_monitored_instances: []
   monitored_instance:
     name: charts.d sensors
     link: ''

--- a/collectors/cups.plugin/metadata.yaml
+++ b/collectors/cups.plugin/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: cups.plugin
   module_name: cups.plugin
-  alternative_monitored_instances: []
   monitored_instance:
     name: cups
     link: ''

--- a/collectors/debugfs.plugin/multi_metadata.yaml
+++ b/collectors/debugfs.plugin/multi_metadata.yaml
@@ -3,7 +3,6 @@ modules:
   - meta:
       plugin_name: debugfs.plugin
       module_name: /sys/kernel/debug/extfrag
-      alternative_monitored_instances: []
       monitored_instance:
         name: debugfs /sys/kernel/debug/extfrag
         link: ''
@@ -119,7 +118,6 @@ modules:
   - meta:
       plugin_name: debugfs.plugin
       module_name: /sys/kernel/debug/zswap
-      alternative_monitored_instances: []
       monitored_instance:
         name: debugfs /sys/kernel/debug/zswap
         link: ''
@@ -216,8 +214,7 @@ modules:
               dimensions:
                 - name: limit
             - name: system.zswap_written_back_raw_bytes
-              description: Zswap uncomressed bytes written back when pool limit was
-                reached
+              description: Zswap uncomressed bytes written back when pool limit was reached
               unit: "bytes/s"
               chart_type: area
               dimensions:

--- a/collectors/diskspace.plugin/metadata.yaml
+++ b/collectors/diskspace.plugin/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: diskspace.plugin
   module_name: diskspace.plugin
-  alternative_monitored_instances: []
   monitored_instance:
     name: diskspace
     link: ''

--- a/collectors/ebpf.plugin/multi_metadata.yaml
+++ b/collectors/ebpf.plugin/multi_metadata.yaml
@@ -3,7 +3,6 @@ modules:
   - meta:
       plugin_name: ebpf.plugin
       module_name: filedescriptor
-      alternative_monitored_instances: []
       monitored_instance:
         name: ebpf filedescriptor
         link: ''
@@ -159,7 +158,6 @@ modules:
   - meta:
       plugin_name: ebpf.plugin
       module_name: processes
-      alternative_monitored_instances: []
       monitored_instance:
         name: ebpf processes
         link: ''
@@ -344,7 +342,6 @@ modules:
   - meta:
       plugin_name: ebpf.plugin
       module_name: disk
-      alternative_monitored_instances: []
       monitored_instance:
         name: ebpf disk
         link: ''
@@ -416,7 +413,6 @@ modules:
   - meta:
       plugin_name: ebpf.plugin
       module_name: hardirq
-      alternative_monitored_instances: []
       monitored_instance:
         name: ebpf hardirq
         link: ''
@@ -488,7 +484,6 @@ modules:
   - meta:
       plugin_name: ebpf.plugin
       module_name: cachestat
-      alternative_monitored_instances: []
       monitored_instance:
         name: ebpf cachestat
         link: ''
@@ -654,7 +649,6 @@ modules:
   - meta:
       plugin_name: ebpf.plugin
       module_name: sync
-      alternative_monitored_instances: []
       monitored_instance:
         name: ebpf sync
         link: ''
@@ -707,12 +701,9 @@ modules:
         list: []
     alerts:
       - name: sync_freq
-        link: |
-          https://github.com/netdata/netdata/blob/master/health/health.d/synchronization.conf
+        link: https://github.com/netdata/netdata/blob/master/health/health.d/synchronization.conf
         metric: mem.sync
-        info: number of sync() system calls. Every call causes all pending modifications
-          to filesystem metadata and cached file data to be written to the underlying
-          filesystems.
+        info: number of sync() system calls. Every call causes all pending modifications to filesystem metadata and cached file data to be written to the underlying filesystems.
     metrics:
       folding:
         title: Metrics
@@ -753,7 +744,6 @@ modules:
   - meta:
       plugin_name: ebpf.plugin
       module_name: mdflush
-      alternative_monitored_instances: []
       monitored_instance:
         name: ebpf mdflush
         link: ''
@@ -825,7 +815,6 @@ modules:
   - meta:
       plugin_name: ebpf.plugin
       module_name: swap
-      alternative_monitored_instances: []
       monitored_instance:
         name: ebpf swap
         link: ''
@@ -938,7 +927,6 @@ modules:
   - meta:
       plugin_name: ebpf.plugin
       module_name: oomkill
-      alternative_monitored_instances: []
       monitored_instance:
         name: ebpf oomkill
         link: ''
@@ -1026,7 +1014,6 @@ modules:
   - meta:
       plugin_name: ebpf.plugin
       module_name: socket
-      alternative_monitored_instances: []
       monitored_instance:
         name: ebpf socket
         link: ''
@@ -1319,7 +1306,6 @@ modules:
   - meta:
       plugin_name: ebpf.plugin
       module_name: dcstat
-      alternative_monitored_instances: []
       monitored_instance:
         name: ebpf dcstat
         link: ''
@@ -1479,7 +1465,6 @@ modules:
   - meta:
       plugin_name: ebpf.plugin
       module_name: filesystem
-      alternative_monitored_instances: []
       monitored_instance:
         name: ebpf filesystem
         link: ''
@@ -1583,7 +1568,6 @@ modules:
   - meta:
       plugin_name: ebpf.plugin
       module_name: shm
-      alternative_monitored_instances: []
       monitored_instance:
         name: ebpf shm
         link: ''
@@ -1734,7 +1718,6 @@ modules:
   - meta:
       plugin_name: ebpf.plugin
       module_name: softirq
-      alternative_monitored_instances: []
       monitored_instance:
         name: ebpf softirq
         link: ''
@@ -1806,7 +1789,6 @@ modules:
   - meta:
       plugin_name: ebpf.plugin
       module_name: mount
-      alternative_monitored_instances: []
       monitored_instance:
         name: ebpf mount
         link: ''
@@ -1886,7 +1868,6 @@ modules:
   - meta:
       plugin_name: ebpf.plugin
       module_name: vfs
-      alternative_monitored_instances: []
       monitored_instance:
         name: ebpf vfs
         link: ''
@@ -2253,7 +2234,6 @@ modules:
   - meta:
       plugin_name: ebpf.plugin
       module_name: process
-      alternative_monitored_instances: []
       monitored_instance:
         name: ebpf process
         link: ''

--- a/collectors/freebsd.plugin/multi_metadata.yaml
+++ b/collectors/freebsd.plugin/multi_metadata.yaml
@@ -3,7 +3,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: vm.loadavg
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd vm.loadavg
         link: ''
@@ -97,7 +96,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: vm.vmtotal
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd vm.vmtotal
         link: ''
@@ -186,7 +184,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: kern.cp_time
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd kern.cp_time
         link: ''
@@ -241,8 +238,7 @@ modules:
       - name: 10min_cpu_usage
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cpu.conf
         metric: system.cpu
-        info: average CPU utilization over the last 10 minutes (excluding iowait,
-          nice and steal)
+        info: average CPU utilization over the last 10 minutes (excluding iowait, nice and steal)
         os: "linux"
       - name: 10min_cpu_iowait
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cpu.conf
@@ -297,7 +293,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: dev.cpu.temperature
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd dev.cpu.temperature
         link: ''
@@ -369,7 +364,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: dev.cpu.0.freq
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd dev.cpu.0.freq
         link: ''
@@ -441,7 +435,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: hw.intrcnt
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd hw.intrcnt
         link: ''
@@ -519,7 +512,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: vm.stats.sys.v_intr
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd vm.stats.sys.v_intr
         link: ''
@@ -591,7 +583,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: vm.stats.sys.v_soft
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd vm.stats.sys.v_soft
         link: ''
@@ -663,7 +654,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: vm.stats.sys.v_swtch
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd vm.stats.sys.v_swtch
         link: ''
@@ -741,7 +731,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: vm.swap_info
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd vm.swap_info
         link: ''
@@ -819,7 +808,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: system.ram
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd system.ram
         link: ''
@@ -884,14 +872,12 @@ modules:
       - name: ram_available
         link: https://github.com/netdata/netdata/blob/master/health/health.d/ram.conf
         metric: mem.available
-        info: percentage of estimated amount of RAM available for userspace processes,
-          without causing swapping
+        info: percentage of estimated amount of RAM available for userspace processes, without causing swapping
         os: "linux"
       - name: ram_available
         link: https://github.com/netdata/netdata/blob/master/health/health.d/ram.conf
         metric: mem.available
-        info: percentage of estimated amount of RAM available for userspace processes,
-          without causing swapping
+        info: percentage of estimated amount of RAM available for userspace processes, without causing swapping
         os: "freebsd"
     metrics:
       folding:
@@ -925,7 +911,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: vm.stats.vm.v_swappgs
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd vm.stats.vm.v_swappgs
         link: ''
@@ -1003,7 +988,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: vm.stats.vm.v_pgfaults
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd vm.stats.vm.v_pgfaults
         link: ''
@@ -1079,7 +1063,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: kern.ipc.sem
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd kern.ipc.sem
         link: ''
@@ -1167,7 +1150,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: kern.ipc.shm
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd kern.ipc.shm
         link: ''
@@ -1245,7 +1227,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: kern.ipc.msq
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd kern.ipc.msq
         link: ''
@@ -1330,7 +1311,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: uptime
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd uptime
         link: ''
@@ -1402,7 +1382,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: net.isr
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd net.isr
         link: ''
@@ -1457,21 +1436,17 @@ modules:
       - name: 1min_netdev_backlog_exceeded
         link: https://github.com/netdata/netdata/blob/master/health/health.d/softnet.conf
         metric: system.softnet_stat
-        info: average number of dropped packets in the last minute due to exceeded
-          net.core.netdev_max_backlog
+        info: average number of dropped packets in the last minute due to exceeded net.core.netdev_max_backlog
         os: "linux"
       - name: 1min_netdev_budget_ran_outs
         link: https://github.com/netdata/netdata/blob/master/health/health.d/softnet.conf
         metric: system.softnet_stat
-        info: average number of times ksoftirq ran out of sysctl net.core.netdev_budget
-          or net.core.netdev_budget_usecs with work remaining over the last minute
-          (this can be a cause for dropped packets)
+        info: average number of times ksoftirq ran out of sysctl net.core.netdev_budget or net.core.netdev_budget_usecs with work remaining over the last minute (this can be a cause for dropped packets)
         os: "linux"
       - name: 10min_netisr_backlog_exceeded
         link: https://github.com/netdata/netdata/blob/master/health/health.d/softnet.conf
         metric: system.softnet_stat
-        info: average number of drops in the last minute due to exceeded sysctl net.route.netisr_maxqlen
-          (this can be a cause for dropped packets)
+        info: average number of drops in the last minute due to exceeded sysctl net.route.netisr_maxqlen (this can be a cause for dropped packets)
         os: "freebsd"
     metrics:
       folding:
@@ -1509,7 +1484,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: devstat
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd devstat
         link: ''
@@ -1564,8 +1538,7 @@ modules:
       - name: 10min_disk_utilization
         link: https://github.com/netdata/netdata/blob/master/health/health.d/disks.conf
         metric: disk.util
-        info: average percentage of time ${label:device} disk was busy over the last
-          10 minutes
+        info: average percentage of time ${label:device} disk was busy over the last 10 minutes
         os: "linux freebsd"
     metrics:
       folding:
@@ -1653,7 +1626,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: net.inet.tcp.states
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd net.inet.tcp.states
         link: ''
@@ -1730,7 +1702,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: net.inet.tcp.stats
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd net.inet.tcp.stats
         link: ''
@@ -1790,9 +1761,7 @@ modules:
       - name: 10s_ipv4_tcp_resets_sent
         link: https://github.com/netdata/netdata/blob/master/health/health.d/tcp_resets.conf
         metric: ipv4.tcphandshake
-        info: average number of sent TCP RESETS over the last 10 seconds. This can
-          indicate a port scan, or that a service running on this host has crashed.
-          Netdata will not send a clear notification for this alarm.
+        info: average number of sent TCP RESETS over the last 10 seconds. This can indicate a port scan, or that a service running on this host has crashed. Netdata will not send a clear notification for this alarm.
         os: "linux"
       - name: 1m_ipv4_tcp_resets_received
         link: https://github.com/netdata/netdata/blob/master/health/health.d/tcp_resets.conf
@@ -1802,9 +1771,7 @@ modules:
       - name: 10s_ipv4_tcp_resets_received
         link: https://github.com/netdata/netdata/blob/master/health/health.d/tcp_resets.conf
         metric: ipv4.tcphandshake
-        info: average number of received TCP RESETS over the last 10 seconds. This
-          can be an indication that a service this host needs has crashed. Netdata
-          will not send a clear notification for this alarm.
+        info: average number of received TCP RESETS over the last 10 seconds. This can be an indication that a service this host needs has crashed. Netdata will not send a clear notification for this alarm.
         os: "linux freebsd"
     metrics:
       folding:
@@ -1884,7 +1851,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: net.inet.udp.stats
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd net.inet.udp.stats
         link: ''
@@ -1977,7 +1943,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: net.inet.icmp.stats
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd net.inet.icmp.stats
         link: ''
@@ -2067,7 +2032,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: net.inet.ip.stats
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd net.inet.ip.stats
         link: ''
@@ -2169,7 +2133,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: net.inet6.ip6.stats
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd net.inet6.ip6.stats
         link: ''
@@ -2273,7 +2236,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: net.inet6.icmp6.stats
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd net.inet6.icmp6.stats
         link: ''
@@ -2410,7 +2372,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: ipfw
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd ipfw
         link: ''
@@ -2507,7 +2468,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: getifaddrs
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd getifaddrs
         link: ''
@@ -2567,75 +2527,62 @@ modules:
       - name: 1m_received_traffic_overflow
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.net
-        info: average inbound utilization for the network interface ${label:device}
-          over the last minute
+        info: average inbound utilization for the network interface ${label:device} over the last minute
         os: "linux"
       - name: 1m_sent_traffic_overflow
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.net
-        info: average outbound utilization for the network interface ${label:device}
-          over the last minute
+        info: average outbound utilization for the network interface ${label:device} over the last minute
         os: "linux"
       - name: inbound_packets_dropped_ratio
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info: ratio of inbound dropped packets for the network interface ${label:device}
-          over the last 10 minutes
+        info: ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
         os: "linux"
       - name: outbound_packets_dropped_ratio
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info: ratio of outbound dropped packets for the network interface ${label:device}
-          over the last 10 minutes
+        info: ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
         os: "linux"
       - name: wifi_inbound_packets_dropped_ratio
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info: ratio of inbound dropped packets for the network interface ${label:device}
-          over the last 10 minutes
+        info: ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
         os: "linux"
       - name: wifi_outbound_packets_dropped_ratio
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info: ratio of outbound dropped packets for the network interface ${label:device}
-          over the last 10 minutes
+        info: ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
         os: "linux"
       - name: 1m_received_packets_rate
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info: average number of packets received by the network interface ${label:device}
-          over the last minute
+        info: average number of packets received by the network interface ${label:device} over the last minute
         os: "linux freebsd"
       - name: 10s_received_packets_storm
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info: ratio of average number of received packets for the network interface
-          ${label:device} over the last 10 seconds, compared to the rate over the
-          last minute
+        info: ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, compared to the rate over the last minute
         os: "linux freebsd"
       - name: interface_inbound_errors
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.errors
-        info: number of inbound errors for the network interface ${label:device} in
-          the last 10 minutes
+        info: number of inbound errors for the network interface ${label:device} in the last 10 minutes
         os: "freebsd"
       - name: interface_outbound_errors
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.errors
-        info: number of outbound errors for the network interface ${label:device}
-          in the last 10 minutes
+        info: number of outbound errors for the network interface ${label:device} in the last 10 minutes
         os: "freebsd"
       - name: inbound_packets_dropped
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.drops
-        info: number of inbound dropped packets for the network interface ${label:device}
-          in the last 10 minutes
+        info: number of inbound dropped packets for the network interface ${label:device} in the last 10 minutes
         os: "linux"
       - name: outbound_packets_dropped
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.drops
-        info: number of outbound dropped packets for the network interface ${label:device}
-          in the last 10 minutes
+        info: number of outbound dropped packets for the network interface ${label:device} in the last 10 minutes
         os: "linux"
     metrics:
       folding:
@@ -2721,7 +2668,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: getmntinfo
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd getmntinfo
         link: ''
@@ -2813,7 +2759,6 @@ modules:
   - meta:
       plugin_name: freebsd.plugin
       module_name: zfs
-      alternative_monitored_instances: []
       monitored_instance:
         name: freebsd zfs
         link: ''

--- a/collectors/freeipmi.plugin/multi_metadata.yaml
+++ b/collectors/freeipmi.plugin/multi_metadata.yaml
@@ -3,7 +3,6 @@ modules:
   - meta:
       plugin_name: freeipmi.plugin
       module_name: sel
-      alternative_monitored_instances: []
       monitored_instance:
         name: freeipmi sel
         link: ''
@@ -75,7 +74,6 @@ modules:
   - meta:
       plugin_name: freeipmi.plugin
       module_name: sensors
-      alternative_monitored_instances: []
       monitored_instance:
         name: freeipmi sensors
         link: ''

--- a/collectors/idlejitter.plugin/metadata.yaml
+++ b/collectors/idlejitter.plugin/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: idlejitter.plugin
   module_name: idlejitter.plugin
-  alternative_monitored_instances: []
   monitored_instance:
     name: idlejitter
     link: ''

--- a/collectors/ioping.plugin/metadata.yaml
+++ b/collectors/ioping.plugin/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: ioping.plugin
   module_name: ioping.plugin
-  alternative_monitored_instances: []
   monitored_instance:
     name: ioping
     link: ''

--- a/collectors/macos.plugin/multi_metadata.yaml
+++ b/collectors/macos.plugin/multi_metadata.yaml
@@ -3,7 +3,6 @@ modules:
   - meta:
       plugin_name: macos.plugin
       module_name: mach_smi
-      alternative_monitored_instances: []
       monitored_instance:
         name: macos mach_smi
         link: ''
@@ -58,8 +57,7 @@ modules:
       - name: 10min_cpu_usage
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cpu.conf
         metric: system.cpu
-        info: average CPU utilization over the last 10 minutes (excluding iowait,
-          nice and steal)
+        info: average CPU utilization over the last 10 minutes (excluding iowait, nice and steal)
         os: "linux"
       - name: 10min_cpu_iowait
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cpu.conf
@@ -148,7 +146,6 @@ modules:
   - meta:
       plugin_name: macos.plugin
       module_name: sysctl
-      alternative_monitored_instances: []
       monitored_instance:
         name: macos sysctl
         link: ''
@@ -233,9 +230,7 @@ modules:
       - name: 10s_ipv4_tcp_resets_sent
         link: https://github.com/netdata/netdata/blob/master/health/health.d/tcp_resets.conf
         metric: ipv4.tcphandshake
-        info: average number of sent TCP RESETS over the last 10 seconds. This can
-          indicate a port scan, or that a service running on this host has crashed.
-          Netdata will not send a clear notification for this alarm.
+        info: average number of sent TCP RESETS over the last 10 seconds. This can indicate a port scan, or that a service running on this host has crashed. Netdata will not send a clear notification for this alarm.
         os: "linux"
       - name: 1m_ipv4_tcp_resets_received
         link: https://github.com/netdata/netdata/blob/master/health/health.d/tcp_resets.conf
@@ -245,9 +240,7 @@ modules:
       - name: 10s_ipv4_tcp_resets_received
         link: https://github.com/netdata/netdata/blob/master/health/health.d/tcp_resets.conf
         metric: ipv4.tcphandshake
-        info: average number of received TCP RESETS over the last 10 seconds. This
-          can be an indication that a service this host needs has crashed. Netdata
-          will not send a clear notification for this alarm.
+        info: average number of received TCP RESETS over the last 10 seconds. This can be an indication that a service this host needs has crashed. Netdata will not send a clear notification for this alarm.
         os: "linux freebsd"
       - name: 1m_ipv4_udp_receive_buffer_errors
         link: https://github.com/netdata/netdata/blob/master/health/health.d/udp_errors.conf
@@ -541,7 +534,6 @@ modules:
   - meta:
       plugin_name: macos.plugin
       module_name: iokit
-      alternative_monitored_instances: []
       monitored_instance:
         name: macos iokit
         link: ''
@@ -596,8 +588,7 @@ modules:
       - name: 10min_disk_utilization
         link: https://github.com/netdata/netdata/blob/master/health/health.d/disks.conf
         metric: disk.util
-        info: average percentage of time ${label:device} disk was busy over the last
-          10 minutes
+        info: average percentage of time ${label:device} disk was busy over the last 10 minutes
         os: "linux freebsd"
       - name: disk_space_usage
         link: https://github.com/netdata/netdata/blob/master/health/health.d/disks.conf
@@ -617,75 +608,62 @@ modules:
       - name: 1m_received_traffic_overflow
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.net
-        info: average inbound utilization for the network interface ${label:device}
-          over the last minute
+        info: average inbound utilization for the network interface ${label:device} over the last minute
         os: "linux"
       - name: 1m_sent_traffic_overflow
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.net
-        info: average outbound utilization for the network interface ${label:device}
-          over the last minute
+        info: average outbound utilization for the network interface ${label:device} over the last minute
         os: "linux"
       - name: inbound_packets_dropped_ratio
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info: ratio of inbound dropped packets for the network interface ${label:device}
-          over the last 10 minutes
+        info: ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
         os: "linux"
       - name: outbound_packets_dropped_ratio
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info: ratio of outbound dropped packets for the network interface ${label:device}
-          over the last 10 minutes
+        info: ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
         os: "linux"
       - name: wifi_inbound_packets_dropped_ratio
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info: ratio of inbound dropped packets for the network interface ${label:device}
-          over the last 10 minutes
+        info: ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
         os: "linux"
       - name: wifi_outbound_packets_dropped_ratio
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info: ratio of outbound dropped packets for the network interface ${label:device}
-          over the last 10 minutes
+        info: ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
         os: "linux"
       - name: 1m_received_packets_rate
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info: average number of packets received by the network interface ${label:device}
-          over the last minute
+        info: average number of packets received by the network interface ${label:device} over the last minute
         os: "linux freebsd"
       - name: 10s_received_packets_storm
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info: ratio of average number of received packets for the network interface
-          ${label:device} over the last 10 seconds, compared to the rate over the
-          last minute
+        info: ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, compared to the rate over the last minute
         os: "linux freebsd"
       - name: interface_inbound_errors
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.errors
-        info: number of inbound errors for the network interface ${label:device} in
-          the last 10 minutes
+        info: number of inbound errors for the network interface ${label:device} in the last 10 minutes
         os: "freebsd"
       - name: interface_outbound_errors
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.errors
-        info: number of outbound errors for the network interface ${label:device}
-          in the last 10 minutes
+        info: number of outbound errors for the network interface ${label:device} in the last 10 minutes
         os: "freebsd"
       - name: inbound_packets_dropped
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.drops
-        info: number of inbound dropped packets for the network interface ${label:device}
-          in the last 10 minutes
+        info: number of inbound dropped packets for the network interface ${label:device} in the last 10 minutes
         os: "linux"
       - name: outbound_packets_dropped
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.drops
-        info: number of outbound dropped packets for the network interface ${label:device}
-          in the last 10 minutes
+        info: number of outbound dropped packets for the network interface ${label:device} in the last 10 minutes
         os: "linux"
     metrics:
       folding:

--- a/collectors/nfacct.plugin/metadata.yaml
+++ b/collectors/nfacct.plugin/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: nfacct.plugin
   module_name: nfacct.plugin
-  alternative_monitored_instances: []
   monitored_instance:
     name: nfacct
     link: ''

--- a/collectors/perf.plugin/metadata.yaml
+++ b/collectors/perf.plugin/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: perf.plugin
   module_name: perf.plugin
-  alternative_monitored_instances: []
   monitored_instance:
     name: perf
     link: ''

--- a/collectors/proc.plugin/multi_metadata.yaml
+++ b/collectors/proc.plugin/multi_metadata.yaml
@@ -3,7 +3,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/stat
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/stat
         link: ''
@@ -58,8 +57,7 @@ modules:
       - name: 10min_cpu_usage
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cpu.conf
         metric: system.cpu
-        info: average CPU utilization over the last 10 minutes (excluding iowait,
-          nice and steal)
+        info: average CPU utilization over the last 10 minutes (excluding iowait, nice and steal)
         os: "linux"
       - name: 10min_cpu_iowait
         link: https://github.com/netdata/netdata/blob/master/health/health.d/cpu.conf
@@ -175,7 +173,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/sys/kernel/random/entropy_avail
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/sys/kernel/random/entropy_avail
         link: ''
@@ -252,7 +249,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/uptime
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/uptime
         link: ''
@@ -324,7 +320,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/vmstat
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/vmstat
         link: ''
@@ -518,7 +513,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/interrupts
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/interrupts
         link: ''
@@ -602,7 +596,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/loadavg
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/loadavg
         link: ''
@@ -706,7 +699,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/pressure
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/pressure
         link: ''
@@ -856,7 +848,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/softirqs
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/softirqs
         link: ''
@@ -940,7 +931,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/net/softnet_stat
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/net/softnet_stat
         link: ''
@@ -995,21 +985,17 @@ modules:
       - name: 1min_netdev_backlog_exceeded
         link: https://github.com/netdata/netdata/blob/master/health/health.d/softnet.conf
         metric: system.softnet_stat
-        info: average number of dropped packets in the last minute due to exceeded
-          net.core.netdev_max_backlog
+        info: average number of dropped packets in the last minute due to exceeded net.core.netdev_max_backlog
         os: "linux"
       - name: 1min_netdev_budget_ran_outs
         link: https://github.com/netdata/netdata/blob/master/health/health.d/softnet.conf
         metric: system.softnet_stat
-        info: average number of times ksoftirq ran out of sysctl net.core.netdev_budget
-          or net.core.netdev_budget_usecs with work remaining over the last minute
-          (this can be a cause for dropped packets)
+        info: average number of times ksoftirq ran out of sysctl net.core.netdev_budget or net.core.netdev_budget_usecs with work remaining over the last minute (this can be a cause for dropped packets)
         os: "linux"
       - name: 10min_netisr_backlog_exceeded
         link: https://github.com/netdata/netdata/blob/master/health/health.d/softnet.conf
         metric: system.softnet_stat
-        info: average number of drops in the last minute due to exceeded sysctl net.route.netisr_maxqlen
-          (this can be a cause for dropped packets)
+        info: average number of drops in the last minute due to exceeded sysctl net.route.netisr_maxqlen (this can be a cause for dropped packets)
         os: "freebsd"
     metrics:
       folding:
@@ -1049,7 +1035,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/meminfo
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/meminfo
         link: ''
@@ -1114,14 +1099,12 @@ modules:
       - name: ram_available
         link: https://github.com/netdata/netdata/blob/master/health/health.d/ram.conf
         metric: mem.available
-        info: percentage of estimated amount of RAM available for userspace processes,
-          without causing swapping
+        info: percentage of estimated amount of RAM available for userspace processes, without causing swapping
         os: "linux"
       - name: ram_available
         link: https://github.com/netdata/netdata/blob/master/health/health.d/ram.conf
         metric: mem.available
-        info: percentage of estimated amount of RAM available for userspace processes,
-          without causing swapping
+        info: percentage of estimated amount of RAM available for userspace processes, without causing swapping
         os: "freebsd"
       - name: used_swap
         link: https://github.com/netdata/netdata/blob/master/health/health.d/swap.conf
@@ -1224,7 +1207,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/pagetypeinfo
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/pagetypeinfo
         link: ''
@@ -1312,7 +1294,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /sys/devices/system/edac/mc
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /sys/devices/system/edac/mc
         link: ''
@@ -1400,7 +1381,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /sys/devices/system/node
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /sys/devices/system/node
         link: ''
@@ -1479,7 +1459,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /sys/kernel/mm/ksm
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /sys/kernel/mm/ksm
         link: ''
@@ -1567,7 +1546,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /sys/block/zram
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /sys/block/zram
         link: ''
@@ -1661,7 +1639,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: ipc
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc ipc
         link: ''
@@ -1773,7 +1750,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/diskstats
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/diskstats
         link: ''
@@ -1833,20 +1809,16 @@ modules:
       - name: 10min_disk_utilization
         link: https://github.com/netdata/netdata/blob/master/health/health.d/disks.conf
         metric: disk.util
-        info: average percentage of time ${label:device} disk was busy over the last
-          10 minutes
+        info: average percentage of time ${label:device} disk was busy over the last 10 minutes
         os: "linux freebsd"
       - name: bcache_cache_dirty
         link: https://github.com/netdata/netdata/blob/master/health/health.d/bcache.conf
         metric: disk.bcache_cache_alloc
-        info: percentage of cache space used for dirty data and metadata (this usually
-          means your SSD cache is too small)
+        info: percentage of cache space used for dirty data and metadata (this usually means your SSD cache is too small)
       - name: bcache_cache_errors
         link: https://github.com/netdata/netdata/blob/master/health/health.d/bcache.conf
         metric: disk.bcache_cache_read_races
-        info: number of times data was read from the cache, the bucket was reused
-          and invalidated in the last 10 minutes (when this occurs the data is reread
-          from the backing device)
+        info: number of times data was read from the cache, the bucket was reused and invalidated in the last 10 minutes (when this occurs the data is reread from the backing device)
     metrics:
       folding:
         title: Metrics
@@ -2050,7 +2022,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/mdstat
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/mdstat
         link: ''
@@ -2109,13 +2080,11 @@ modules:
       - name: mdstat_disks
         link: https://github.com/netdata/netdata/blob/master/health/health.d/mdstat.conf
         metric: md.disks
-        info: number of devices in the down state for the ${label:device} ${label:raid_level}
-          array. Any number > 0 indicates that the array is degraded.
+        info: number of devices in the down state for the ${label:device} ${label:raid_level} array. Any number > 0 indicates that the array is degraded.
       - name: mdstat_mismatch_cnt
         link: https://github.com/netdata/netdata/blob/master/health/health.d/mdstat.conf
         metric: md.mismatch_cnt
-        info: number of unsynchronized blocks for the ${label:device} ${label:raid_level}
-          array
+        info: number of unsynchronized blocks for the ${label:device} ${label:raid_level} array
       - name: mdstat_nonredundant_last_collected
         link: https://github.com/netdata/netdata/blob/master/health/health.d/mdstat.conf
         metric: md.nonredundant
@@ -2188,7 +2157,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/net/dev
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/net/dev
         link: ''
@@ -2248,81 +2216,67 @@ modules:
       - name: 1m_received_traffic_overflow
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.net
-        info: average inbound utilization for the network interface ${label:device}
-          over the last minute
+        info: average inbound utilization for the network interface ${label:device} over the last minute
         os: "linux"
       - name: 1m_sent_traffic_overflow
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.net
-        info: average outbound utilization for the network interface ${label:device}
-          over the last minute
+        info: average outbound utilization for the network interface ${label:device} over the last minute
         os: "linux"
       - name: inbound_packets_dropped_ratio
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info: ratio of inbound dropped packets for the network interface ${label:device}
-          over the last 10 minutes
+        info: ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
         os: "linux"
       - name: outbound_packets_dropped_ratio
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info: ratio of outbound dropped packets for the network interface ${label:device}
-          over the last 10 minutes
+        info: ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
         os: "linux"
       - name: wifi_inbound_packets_dropped_ratio
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info: ratio of inbound dropped packets for the network interface ${label:device}
-          over the last 10 minutes
+        info: ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
         os: "linux"
       - name: wifi_outbound_packets_dropped_ratio
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info: ratio of outbound dropped packets for the network interface ${label:device}
-          over the last 10 minutes
+        info: ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
         os: "linux"
       - name: 1m_received_packets_rate
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info: average number of packets received by the network interface ${label:device}
-          over the last minute
+        info: average number of packets received by the network interface ${label:device} over the last minute
         os: "linux freebsd"
       - name: 10s_received_packets_storm
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info: ratio of average number of received packets for the network interface
-          ${label:device} over the last 10 seconds, compared to the rate over the
-          last minute
+        info: ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, compared to the rate over the last minute
         os: "linux freebsd"
       - name: interface_inbound_errors
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.errors
-        info: number of inbound errors for the network interface ${label:device} in
-          the last 10 minutes
+        info: number of inbound errors for the network interface ${label:device} in the last 10 minutes
         os: "freebsd"
       - name: interface_outbound_errors
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.errors
-        info: number of outbound errors for the network interface ${label:device}
-          in the last 10 minutes
+        info: number of outbound errors for the network interface ${label:device} in the last 10 minutes
         os: "freebsd"
       - name: inbound_packets_dropped
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.drops
-        info: number of inbound dropped packets for the network interface ${label:device}
-          in the last 10 minutes
+        info: number of inbound dropped packets for the network interface ${label:device} in the last 10 minutes
         os: "linux"
       - name: outbound_packets_dropped
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.drops
-        info: number of outbound dropped packets for the network interface ${label:device}
-          in the last 10 minutes
+        info: number of outbound dropped packets for the network interface ${label:device} in the last 10 minutes
         os: "linux"
       - name: 10min_fifo_errors
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.fifo
-        info: number of FIFO errors for the network interface ${label:device} in the
-          last 10 minutes
+        info: number of FIFO errors for the network interface ${label:device} in the last 10 minutes
         os: "linux"
     metrics:
       folding:
@@ -2443,7 +2397,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/net/wireless
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/net/wireless
         link: ''
@@ -2513,31 +2466,25 @@ modules:
               dimensions:
                 - name: status
             - name: wireless.link_quality
-              description: Overall quality of the link. This is an aggregate value,
-                and depends on the driver and hardware.
+              description: Overall quality of the link. This is an aggregate value, and depends on the driver and hardware.
               unit: "value"
               chart_type: line
               dimensions:
                 - name: link_quality
             - name: wireless.signal_level
-              description: The signal level is the wireless signal power level received
-                by the wireless client. The closer the value is to 0, the stronger
-                the signal.
+              description: The signal level is the wireless signal power level received by the wireless client. The closer the value is to 0, the stronger the signal.
               unit: "dBm"
               chart_type: line
               dimensions:
                 - name: signal_level
             - name: wireless.noise_level
-              description: The noise level indicates the amount of background noise
-                in your environment. The closer the value to 0, the greater the noise
-                level.
+              description: The noise level indicates the amount of background noise in your environment. The closer the value to 0, the greater the noise level.
               unit: "dBm"
               chart_type: line
               dimensions:
                 - name: noise_level
             - name: wireless.discarded_packets
-              description: Packet discarded in the wireless adapter due to wireless
-                specific problems.
+              description: Packet discarded in the wireless adapter due to wireless specific problems.
               unit: "packets/s"
               chart_type: line
               dimensions:
@@ -2555,7 +2502,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /sys/class/infiniband
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /sys/class/infiniband
         link: ''
@@ -2696,7 +2642,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/net/netstat
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/net/netstat
         link: ''
@@ -2751,14 +2696,12 @@ modules:
       - name: 1m_tcp_syn_queue_drops
         link: https://github.com/netdata/netdata/blob/master/health/health.d/tcp_listen.conf
         metric: ip.tcp_syn_queue
-        info: average number of SYN requests was dropped due to the full TCP SYN queue
-          over the last minute (SYN cookies were not enabled)
+        info: average number of SYN requests was dropped due to the full TCP SYN queue over the last minute (SYN cookies were not enabled)
         os: "linux"
       - name: 1m_tcp_syn_queue_cookies
         link: https://github.com/netdata/netdata/blob/master/health/health.d/tcp_listen.conf
         metric: ip.tcp_syn_queue
-        info: average number of sent SYN cookies due to the full TCP SYN queue over
-          the last minute
+        info: average number of sent SYN cookies due to the full TCP SYN queue over the last minute
         os: "linux"
       - name: 1m_tcp_accept_queue_overflows
         link: https://github.com/netdata/netdata/blob/master/health/health.d/tcp_listen.conf
@@ -2768,8 +2711,7 @@ modules:
       - name: 1m_tcp_accept_queue_drops
         link: https://github.com/netdata/netdata/blob/master/health/health.d/tcp_listen.conf
         metric: ip.tcp_accept_queue
-        info: average number of dropped packets in the TCP accept queue over the last
-          minute
+        info: average number of dropped packets in the TCP accept queue over the last minute
         os: "linux"
       - name: tcp_connections
         link: https://github.com/netdata/netdata/blob/master/health/health.d/tcp_conn.conf
@@ -2784,9 +2726,7 @@ modules:
       - name: 10s_ipv4_tcp_resets_sent
         link: https://github.com/netdata/netdata/blob/master/health/health.d/tcp_resets.conf
         metric: ipv4.tcphandshake
-        info: average number of sent TCP RESETS over the last 10 seconds. This can
-          indicate a port scan, or that a service running on this host has crashed.
-          Netdata will not send a clear notification for this alarm.
+        info: average number of sent TCP RESETS over the last 10 seconds. This can indicate a port scan, or that a service running on this host has crashed. Netdata will not send a clear notification for this alarm.
         os: "linux"
       - name: 1m_ipv4_tcp_resets_received
         link: https://github.com/netdata/netdata/blob/master/health/health.d/tcp_resets.conf
@@ -2796,9 +2736,7 @@ modules:
       - name: 10s_ipv4_tcp_resets_received
         link: https://github.com/netdata/netdata/blob/master/health/health.d/tcp_resets.conf
         metric: ipv4.tcphandshake
-        info: average number of received TCP RESETS over the last 10 seconds. This
-          can be an indication that a service this host needs has crashed. Netdata
-          will not send a clear notification for this alarm.
+        info: average number of received TCP RESETS over the last 10 seconds. This can be an indication that a service this host needs has crashed. Netdata will not send a clear notification for this alarm.
         os: "linux freebsd"
       - name: 1m_ipv4_udp_receive_buffer_errors
         link: https://github.com/netdata/netdata/blob/master/health/health.d/udp_errors.conf
@@ -3293,7 +3231,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/net/sockstat
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/net/sockstat
         link: ''
@@ -3426,7 +3363,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/net/sockstat6
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/net/sockstat6
         link: ''
@@ -3522,7 +3458,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/net/ip_vs_stats
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/net/ip_vs_stats
         link: ''
@@ -3608,7 +3543,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/net/rpc/nfs
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/net/rpc/nfs
         link: ''
@@ -3707,7 +3641,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/net/rpc/nfsd
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/net/rpc/nfsd
         link: ''
@@ -3839,7 +3772,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/net/sctp/snmp
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/net/sctp/snmp
         link: ''
@@ -3941,7 +3873,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/net/stat/nf_conntrack
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/net/stat/nf_conntrack
         link: ''
@@ -4059,7 +3990,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/net/stat/synproxy
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/net/stat/synproxy
         link: ''
@@ -4145,7 +4075,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/spl/kstat/zfs
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/spl/kstat/zfs
         link: ''
@@ -4233,7 +4162,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /proc/spl/kstat/zfs/arcstats
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /proc/spl/kstat/zfs/arcstats
         link: ''
@@ -4495,7 +4423,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /sys/fs/btrfs
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /sys/fs/btrfs
         link: ''
@@ -4683,7 +4610,6 @@ modules:
   - meta:
       plugin_name: proc.plugin
       module_name: /sys/class/power_supply
-      alternative_monitored_instances: []
       monitored_instance:
         name: proc /sys/class/power_supply
         link: ''
@@ -4736,8 +4662,7 @@ modules:
         list: []
     alerts:
       - name: linux_power_supply_capacity
-        link: |
-          https://github.com/netdata/netdata/blob/master/health/health.d/linux_power_supply.conf
+        link: https://github.com/netdata/netdata/blob/master/health/health.d/linux_power_supply.conf
         metric: powersupply.capacity
         info: percentage of remaining power supply capacity
     metrics:

--- a/collectors/python.d.plugin/adaptec_raid/metadata.yaml
+++ b/collectors/python.d.plugin/adaptec_raid/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: adaptec_raid
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d adaptec_raid
     link: ''

--- a/collectors/python.d.plugin/alarms/metadata.yaml
+++ b/collectors/python.d.plugin/alarms/metadata.yaml
@@ -1,143 +1,53 @@
 meta:
   plugin_name: python.d.plugin
   module_name: alarms
-  alternative_monitored_instances: []
   monitored_instance:
-    name: Netdata Agent Alarms
-    link: "https://github.com/netdata/netdata/blob/master/health/REFERENCE.md#alarm-statuses"
-    categories:
-      - data-collection.notifications
-    icon_filename: ""
+    name: python.d alarms
+    link: ''
+    categories: []
+    icon_filename: ''
   related_resources:
     integrations:
       list: []
   info_provided_to_referring_integrations:
-    description: "Monitor Netdata Agent alarm statuses."
-  keywords:
-    - notification monitoring
-    - alerts
-    - agent alerts
+    description: ''
+  keywords: []
   most_popular: false
 overview:
   data_collection:
-    metrics_description: |
-      This collector monitors the statuses of the alarms the Netdata Agent produces and will display them as integer values in a chart.
-    method_description: |
-      It uses the `/api/v1/alarms?all` endpoint of the Agent, and creates a dimension per alarm.
+    metrics_description: ''
+    method_description: ''
   supported_platforms:
     include: []
     exclude: []
   multi-instance: true
   additional_permissions:
-    description: ""
+    description: ''
   default_behavior:
     auto_detection:
-      description: |
-        It discovers instances of Netdata running on localhost, and gathers metrics from `http://127.0.0.1:19999/api/v1/alarms?all`. `CLEAR` status is mapped to `0`, `WARNING` to `1` and `CRITICAL` to `2`. Also, by default all alarms produced will be monitored.
+      description: ''
     limits:
-      description: ""
+      description: ''
     performance_impact:
-      description: ""
+      description: ''
 setup:
   prerequisites:
-    list:
-      - title: Enable the collector
-        description: |
-          You can enable the collector by going to your [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md#the-netdata-config-directory), use the `edit-config` script to edit `python.d.conf` and set the attribute `alarms: yes`.
-
-          After this change, save the file and [restart Netdata](https://github.com/netdata/netdata/blob/master/docs/configure/start-stop-restart.md).
+    list: []
   configuration:
     file:
-      name: "python.d/alarms.conf"
+      name: ''
+      description: ''
     options:
-      description: "The following options can be defined globally: update_every, priority, penalty, autodetection_retry."
+      description: ''
       folding:
-        title: "Config options"
+        title: ''
         enabled: true
-      list:
-        - name: update_every
-          description: Data collection frequency.
-          default_value: 10
-          required: false
-        - name: priority
-          description: |
-            Priority of the chart, lower values bring the chart to the top of the page.
-          default_value: 60000
-          required: false
-        - name: penalty
-          description: |
-            Apply a penalty to `update_every` in case of failures. Penalty will increase every 5 failed updates in a row, Max penalty is 10 min.
-          default_value: yes
-          required: false
-        - name: autodetection_retry
-          description: Re-check interval in seconds. Zero means not to schedule re-check.
-          default_value: 0
-          required: false
-        - name: url
-          description: The URL to fetch data from.
-          default_value: http://127.0.0.1:19999/api/v1/alarms?all
-          required: true
-        - name: status_map
-          description: Mapping for the alarm statuses to numbers.
-          default_value: |
-            ```yaml
-            CLEAR: 0
-            WARNING: 1
-            CRITICAL: 2
-            ```
-          required: false
-        - name: collect_alarm_values
-          description: If set to true, will include a chart with calculated alarm values.
-          default_value: "false"
-          required: false
-        - name: alarm_status_chart_type
-          description: Defines the type of chart (e.g. line or stacked)
-          default_value: line
-          required: false
-        - name: alarm_contains_words
-          description: Comma separated list of words to filter alarm names for.
-          default_value: ""
-          required: false
-        - name: alarm_excludes_words
-          description: Comma separated list of words to exclude based on alarm name.
-          default_value: ""
-          required: false
+      list: []
     examples:
       folding:
         enabled: true
-        title: "Config"
-      list:
-        - name: Basic
-          description: A basic example configuration
-          folding:
-            enabled: false
-          config: |
-            local:
-              url: 'http://127.0.0.1:19999/api/v1/alarms?all'
-        - name: Custom mappings, filters and update frequency
-          description: |
-            This example uses custom mappings for the statuses, filters to include only alarms having `cpu` or `load` in their names, while also making the update frequency 5 seconds.
-          config: |
-            update_every: 5
-            local:
-              url: 'http://127.0.0.1:19999/api/v1/alarms?all'
-              status_map:
-                CLEAR: 0
-                WARNING: 5
-                CRITICAL: 10
-              alarm_contains_words: 'cpu,load'
-
-        - name: Multi-instance
-          description: |
-            > **Note**: When you define multiple jobs, their names must be unique.
-
-            Collecting metrics from local and remote instances.
-          config: |
-            local:
-              url: 'http://127.0.0.1:19999/api/v1/alarms?all'
-
-            remote:
-              url: 'http://192.0.2.1:19999/api/v1/alarms?all'
+        title: ''
+      list: []
 troubleshooting:
   problems:
     list: []
@@ -150,7 +60,7 @@ metrics:
   availability: []
   scopes:
     - name: global
-      description: "These metrics apply to each Netdata Agent that is monitored with this collector."
+      description: ""
       labels: []
       metrics:
         - name: alarms.status
@@ -160,7 +70,7 @@ metrics:
           dimensions:
             - name: a dimension per alarm
         - name: alarms.status
-          description: Alarm Values, available only when `collect_alarm_values` is set to `true`
+          description: Alarm Values
           unit: "value"
           chart_type: line
           dimensions:

--- a/collectors/python.d.plugin/alarms/metadata.yaml
+++ b/collectors/python.d.plugin/alarms/metadata.yaml
@@ -65,7 +65,7 @@ setup:
           default_value: 60000
           required: false
         - name: penalty
-          description:
+          description: |
             Apply a penalty to `update_every` in case of failures. Penalty will increase every 5 failed updates in a row, Max penalty is 10 min.
           default_value: yes
           required: false

--- a/collectors/python.d.plugin/alarms/metadata.yaml
+++ b/collectors/python.d.plugin/alarms/metadata.yaml
@@ -3,52 +3,141 @@ meta:
   module_name: alarms
   alternative_monitored_instances: []
   monitored_instance:
-    name: python.d alarms
-    link: ''
-    categories: []
-    icon_filename: ''
+    name: Netdata Agent Alarms
+    link: "https://github.com/netdata/netdata/blob/master/health/REFERENCE.md#alarm-statuses"
+    categories:
+      - data-collection.notifications
+    icon_filename: ""
   related_resources:
     integrations:
       list: []
   info_provided_to_referring_integrations:
-    description: ''
-  keywords: []
+    description: "Monitor Netdata Agent alarm statuses."
+  keywords:
+    - notification monitoring
+    - alerts
+    - agent alerts
   most_popular: false
 overview:
   data_collection:
-    metrics_description: ''
-    method_description: ''
+    metrics_description: |
+      This collector monitors the statuses of the alarms the Netdata Agent produces and will display them as integer values in a chart.
+    method_description: |
+      It uses the `/api/v1/alarms?all` endpoint of the Agent, and creates a dimension per alarm.
   supported_platforms:
     include: []
     exclude: []
   multi-instance: true
   additional_permissions:
-    description: ''
+    description: ""
   default_behavior:
     auto_detection:
-      description: ''
+      description: |
+        It discovers instances of Netdata running on localhost, and gathers metrics from `http://127.0.0.1:19999/api/v1/alarms?all`. `CLEAR` status is mapped to `0`, `WARNING` to `1` and `CRITICAL` to `2`. Also, by default all alarms produced will be monitored.
     limits:
-      description: ''
+      description: ""
     performance_impact:
-      description: ''
+      description: ""
 setup:
   prerequisites:
-    list: []
+    list:
+      - title: Enable the collector
+        description: |
+          You can enable the collector by going to your [config directory](https://github.com/netdata/netdata/blob/master/docs/configure/nodes.md#the-netdata-config-directory), use the `edit-config` script to edit `python.d.conf` and set the attribute `alarms: yes`.
+
+          After this change, save the file and [restart Netdata](https://github.com/netdata/netdata/blob/master/docs/configure/start-stop-restart.md).
   configuration:
     file:
-      name: ''
-      description: ''
+      name: "python.d/alarms.conf"
     options:
-      description: ''
+      description: "The following options can be defined globally: update_every, priority, penalty, autodetection_retry."
       folding:
-        title: ''
+        title: "Config options"
         enabled: true
-      list: []
+      list:
+        - name: update_every
+          description: Data collection frequency.
+          default_value: 10
+          required: false
+        - name: priority
+          description: |
+            Priority of the chart, lower values bring the chart to the top of the page.
+          default_value: 60000
+          required: false
+        - name: penalty
+          description:
+            Apply a penalty to `update_every` in case of failures. Penalty will increase every 5 failed updates in a row, Max penalty is 10 min.
+          default_value: yes
+          required: false
+        - name: autodetection_retry
+          description: Re-check interval in seconds. Zero means not to schedule re-check.
+          default_value: 0
+          required: false
+        - name: url
+          description: The URL to fetch data from.
+          default_value: http://127.0.0.1:19999/api/v1/alarms?all
+          required: true
+        - name: status_map
+          description: Mapping for the alarm statuses to numbers.
+          default_value: |
+            ```yaml
+            CLEAR: 0
+            WARNING: 1
+            CRITICAL: 2
+            ```
+          required: false
+        - name: collect_alarm_values
+          description: If set to true, will include a chart with calculated alarm values.
+          default_value: "false"
+          required: false
+        - name: alarm_status_chart_type
+          description: Defines the type of chart (e.g. line or stacked)
+          default_value: line
+          required: false
+        - name: alarm_contains_words
+          description: Comma separated list of words to filter alarm names for.
+          default_value: ""
+          required: false
+        - name: alarm_excludes_words
+          description: Comma separated list of words to exclude based on alarm name.
+          default_value: ""
+          required: false
     examples:
       folding:
         enabled: true
-        title: ''
-      list: []
+        title: "Config"
+      list:
+        - name: Basic
+          description: A basic example configuration
+          folding:
+            enabled: false
+          config: |
+            local:
+              url: 'http://127.0.0.1:19999/api/v1/alarms?all'
+        - name: Custom mappings, filters and update frequency
+          description: |
+            This example uses custom mappings for the statuses, filters to include only alarms having `cpu` or `load` in their names, while also making the update frequency 5 seconds.
+          config: |
+            update_every: 5
+            local:
+              url: 'http://127.0.0.1:19999/api/v1/alarms?all'
+              status_map:
+                CLEAR: 0
+                WARNING: 5
+                CRITICAL: 10
+              alarm_contains_words: 'cpu,load'
+
+        - name: Multi-instance
+          description: |
+            > **Note**: When you define multiple jobs, their names must be unique.
+
+            Collecting metrics from local and remote instances.
+          config: |
+            local:
+              url: 'http://127.0.0.1:19999/api/v1/alarms?all'
+
+            remote:
+              url: 'http://192.0.2.1:19999/api/v1/alarms?all'
 troubleshooting:
   problems:
     list: []
@@ -61,7 +150,7 @@ metrics:
   availability: []
   scopes:
     - name: global
-      description: ""
+      description: "These metrics apply to each Netdata Agent that is monitored with this collector."
       labels: []
       metrics:
         - name: alarms.status
@@ -71,7 +160,7 @@ metrics:
           dimensions:
             - name: a dimension per alarm
         - name: alarms.status
-          description: Alarm Values
+          description: Alarm Values, available only when `collect_alarm_values` is set to `true`
           unit: "value"
           chart_type: line
           dimensions:

--- a/collectors/python.d.plugin/am2320/metadata.yaml
+++ b/collectors/python.d.plugin/am2320/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: am2320
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d am2320
     link: ''

--- a/collectors/python.d.plugin/anomalies/metadata.yaml
+++ b/collectors/python.d.plugin/anomalies/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: anomalies
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d anomalies
     link: ''

--- a/collectors/python.d.plugin/beanstalk/metadata.yaml
+++ b/collectors/python.d.plugin/beanstalk/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: beanstalk
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d beanstalk
     link: ''
@@ -56,9 +55,7 @@ alerts:
   - name: beanstalk_server_buried_jobs
     link: https://github.com/netdata/netdata/blob/master/health/health.d/beanstalkd.conf
     metric: beanstalk.current_jobs
-    info: number of buried jobs across all tubes. You need to manually kick them so
-      they can be processed. Presence of buried jobs in a tube does not affect new
-      jobs.
+    info: number of buried jobs across all tubes. You need to manually kick them so they can be processed. Presence of buried jobs in a tube does not affect new jobs.
 metrics:
   folding:
     title: Metrics

--- a/collectors/python.d.plugin/bind_rndc/metadata.yaml
+++ b/collectors/python.d.plugin/bind_rndc/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: bind_rndc
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d bind_rndc
     link: ''

--- a/collectors/python.d.plugin/boinc/metadata.yaml
+++ b/collectors/python.d.plugin/boinc/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: boinc
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d boinc
     link: ''

--- a/collectors/python.d.plugin/ceph/metadata.yaml
+++ b/collectors/python.d.plugin/ceph/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: ceph
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d ceph
     link: ''

--- a/collectors/python.d.plugin/changefinder/metadata.yaml
+++ b/collectors/python.d.plugin/changefinder/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: changefinder
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d changefinder
     link: ''

--- a/collectors/python.d.plugin/dovecot/metadata.yaml
+++ b/collectors/python.d.plugin/dovecot/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: dovecot
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d dovecot
     link: ''

--- a/collectors/python.d.plugin/exim/metadata.yaml
+++ b/collectors/python.d.plugin/exim/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: exim
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d exim
     link: ''

--- a/collectors/python.d.plugin/fail2ban/metadata.yaml
+++ b/collectors/python.d.plugin/fail2ban/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: fail2ban
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d fail2ban
     link: ''

--- a/collectors/python.d.plugin/gearman/metadata.yaml
+++ b/collectors/python.d.plugin/gearman/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: gearman
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d gearman
     link: ''

--- a/collectors/python.d.plugin/go_expvar/metadata.yaml
+++ b/collectors/python.d.plugin/go_expvar/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: go_expvar
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d go_expvar
     link: ''

--- a/collectors/python.d.plugin/haproxy/metadata.yaml
+++ b/collectors/python.d.plugin/haproxy/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: haproxy
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d haproxy
     link: ''

--- a/collectors/python.d.plugin/hddtemp/metadata.yaml
+++ b/collectors/python.d.plugin/hddtemp/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: hddtemp
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d hddtemp
     link: ''

--- a/collectors/python.d.plugin/hpssa/metadata.yaml
+++ b/collectors/python.d.plugin/hpssa/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: hpssa
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d hpssa
     link: ''

--- a/collectors/python.d.plugin/icecast/metadata.yaml
+++ b/collectors/python.d.plugin/icecast/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: icecast
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d icecast
     link: ''

--- a/collectors/python.d.plugin/ipfs/metadata.yaml
+++ b/collectors/python.d.plugin/ipfs/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: ipfs
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d ipfs
     link: ''

--- a/collectors/python.d.plugin/litespeed/metadata.yaml
+++ b/collectors/python.d.plugin/litespeed/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: litespeed
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d litespeed
     link: ''

--- a/collectors/python.d.plugin/megacli/metadata.yaml
+++ b/collectors/python.d.plugin/megacli/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: megacli
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d megacli
     link: ''
@@ -68,8 +67,7 @@ alerts:
   - name: megacli_bbu_relative_charge
     link: https://github.com/netdata/netdata/blob/master/health/health.d/megacli.conf
     metric: megacli.bbu_relative_charge
-    info: average battery backup unit (BBU) relative state of charge over the last
-      10 seconds
+    info: average battery backup unit (BBU) relative state of charge over the last 10 seconds
   - name: megacli_bbu_cycle_count
     link: https://github.com/netdata/netdata/blob/master/health/health.d/megacli.conf
     metric: megacli.bbu_cycle_count

--- a/collectors/python.d.plugin/memcached/metadata.yaml
+++ b/collectors/python.d.plugin/memcached/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: memcached
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d memcached
     link: ''
@@ -60,13 +59,11 @@ alerts:
   - name: memcached_cache_fill_rate
     link: https://github.com/netdata/netdata/blob/master/health/health.d/memcached.conf
     metric: memcached.cache
-    info: average rate the cache fills up (positive), or frees up (negative) space
-      over the last hour
+    info: average rate the cache fills up (positive), or frees up (negative) space over the last hour
   - name: memcached_out_of_cache_space_time
     link: https://github.com/netdata/netdata/blob/master/health/health.d/memcached.conf
     metric: memcached.cache
-    info: estimated time the cache will run out of space if the system continues to
-      add data at the same rate as the past hour
+    info: estimated time the cache will run out of space if the system continues to add data at the same rate as the past hour
 metrics:
   folding:
     title: Metrics

--- a/collectors/python.d.plugin/monit/metadata.yaml
+++ b/collectors/python.d.plugin/monit/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: monit
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d monit
     link: ''

--- a/collectors/python.d.plugin/nsd/metadata.yaml
+++ b/collectors/python.d.plugin/nsd/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: nsd
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d nsd
     link: ''

--- a/collectors/python.d.plugin/nvidia_smi/metadata.yaml
+++ b/collectors/python.d.plugin/nvidia_smi/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: nvidia_smi
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d nvidia_smi
     link: ''

--- a/collectors/python.d.plugin/openldap/metadata.yaml
+++ b/collectors/python.d.plugin/openldap/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: openldap
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d openldap
     link: ''

--- a/collectors/python.d.plugin/oracledb/metadata.yaml
+++ b/collectors/python.d.plugin/oracledb/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: oracledb
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d oracledb
     link: ''

--- a/collectors/python.d.plugin/postfix/metadata.yaml
+++ b/collectors/python.d.plugin/postfix/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: postfix
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d postfix
     link: ''

--- a/collectors/python.d.plugin/puppet/metadata.yaml
+++ b/collectors/python.d.plugin/puppet/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: puppet
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d puppet
     link: ''

--- a/collectors/python.d.plugin/rethinkdbs/metadata.yaml
+++ b/collectors/python.d.plugin/rethinkdbs/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: rethinkdbs
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d rethinkdbs
     link: ''

--- a/collectors/python.d.plugin/retroshare/metadata.yaml
+++ b/collectors/python.d.plugin/retroshare/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: retroshare
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d retroshare
     link: ''

--- a/collectors/python.d.plugin/riakkv/metadata.yaml
+++ b/collectors/python.d.plugin/riakkv/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: riakkv
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d riakkv
     link: ''
@@ -56,25 +55,19 @@ alerts:
   - name: riakkv_1h_kv_get_mean_latency
     link: https://github.com/netdata/netdata/blob/master/health/health.d/riakkv.conf
     metric: riak.kv.latency.get
-    info: average time between reception of client GET request and subsequent response
-      to client over the last hour
+    info: average time between reception of client GET request and subsequent response to client over the last hour
   - name: riakkv_kv_get_slow
     link: https://github.com/netdata/netdata/blob/master/health/health.d/riakkv.conf
     metric: riak.kv.latency.get
-    info: average time between reception of client GET request and subsequent response
-      to the client over the last 3 minutes, compared to the average over the last
-      hour
+    info: average time between reception of client GET request and subsequent response to the client over the last 3 minutes, compared to the average over the last hour
   - name: riakkv_1h_kv_put_mean_latency
     link: https://github.com/netdata/netdata/blob/master/health/health.d/riakkv.conf
     metric: riak.kv.latency.put
-    info: average time between reception of client PUT request and subsequent response
-      to the client over the last hour
+    info: average time between reception of client PUT request and subsequent response to the client over the last hour
   - name: riakkv_kv_put_slow
     link: https://github.com/netdata/netdata/blob/master/health/health.d/riakkv.conf
     metric: riak.kv.latency.put
-    info: average time between reception of client PUT request and subsequent response
-      to the client over the last 3 minutes, compared to the average over the last
-      hour
+    info: average time between reception of client PUT request and subsequent response to the client over the last 3 minutes, compared to the average over the last hour
   - name: riakkv_vm_high_process_count
     link: https://github.com/netdata/netdata/blob/master/health/health.d/riakkv.conf
     metric: riak.vm
@@ -129,8 +122,7 @@ metrics:
             - name: gets
             - name: puts
         - name: riak.kv.latency.get
-          description: Time between reception of a client GET request and subsequent
-            response to client
+          description: Time between reception of a client GET request and subsequent response to client
           unit: "ms"
           chart_type: line
           dimensions:
@@ -140,8 +132,7 @@ metrics:
             - name: '99'
             - name: '100'
         - name: riak.kv.latency.put
-          description: Time between reception of a client PUT request and subsequent
-            response to client
+          description: Time between reception of a client PUT request and subsequent response to client
           unit: "ms"
           chart_type: line
           dimensions:
@@ -236,8 +227,7 @@ metrics:
             - name: allocated
             - name: used
         - name: riak.kv.siblings_encountered.get
-          description: Number of siblings encountered during GET operations by this
-            node during the past minute
+          description: Number of siblings encountered during GET operations by this node during the past minute
           unit: "siblings"
           chart_type: line
           dimensions:
@@ -257,8 +247,7 @@ metrics:
             - name: '99'
             - name: '100'
         - name: riak.search.vnodeq_size
-          description: Number of unprocessed messages in the vnode message queues
-            of Search on this node in the past minute
+          description: Number of unprocessed messages in the vnode message queues of Search on this node in the past minute
           unit: "messages"
           chart_type: line
           dimensions:
@@ -302,8 +291,7 @@ metrics:
             - name: get
             - name: put
         - name: riak.search.index
-          description: Number of writes to Search failed due to bad data format by
-            reason
+          description: Number of writes to Search failed due to bad data format by reason
           unit: "writes"
           chart_type: line
           dimensions:

--- a/collectors/python.d.plugin/samba/metadata.yaml
+++ b/collectors/python.d.plugin/samba/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: samba
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d samba
     link: ''

--- a/collectors/python.d.plugin/sensors/metadata.yaml
+++ b/collectors/python.d.plugin/sensors/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: sensors
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d sensors
     link: ''

--- a/collectors/python.d.plugin/smartd_log/metadata.yaml
+++ b/collectors/python.d.plugin/smartd_log/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: smartd_log
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d smartd_log
     link: ''

--- a/collectors/python.d.plugin/spigotmc/metadata.yaml
+++ b/collectors/python.d.plugin/spigotmc/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: spigotmc
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d spigotmc
     link: ''

--- a/collectors/python.d.plugin/squid/metadata.yaml
+++ b/collectors/python.d.plugin/squid/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: squid
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d squid
     link: ''

--- a/collectors/python.d.plugin/tomcat/metadata.yaml
+++ b/collectors/python.d.plugin/tomcat/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: tomcat
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d tomcat
     link: ''

--- a/collectors/python.d.plugin/tor/metadata.yaml
+++ b/collectors/python.d.plugin/tor/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: tor
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d tor
     link: ''

--- a/collectors/python.d.plugin/traefik/metadata.yaml
+++ b/collectors/python.d.plugin/traefik/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: traefik
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d traefik
     link: ''

--- a/collectors/python.d.plugin/uwsgi/metadata.yaml
+++ b/collectors/python.d.plugin/uwsgi/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: uwsgi
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d uwsgi
     link: ''

--- a/collectors/python.d.plugin/varnish/metadata.yaml
+++ b/collectors/python.d.plugin/varnish/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: varnish
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d varnish
     link: ''

--- a/collectors/python.d.plugin/w1sensor/metadata.yaml
+++ b/collectors/python.d.plugin/w1sensor/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: w1sensor
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d w1sensor
     link: ''

--- a/collectors/python.d.plugin/zscores/metadata.yaml
+++ b/collectors/python.d.plugin/zscores/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: python.d.plugin
   module_name: zscores
-  alternative_monitored_instances: []
   monitored_instance:
     name: python.d zscores
     link: ''

--- a/collectors/slabinfo.plugin/metadata.yaml
+++ b/collectors/slabinfo.plugin/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: slabinfo.plugin
   module_name: slabinfo.plugin
-  alternative_monitored_instances: []
   monitored_instance:
     name: slabinfo
     link: ''

--- a/collectors/tc.plugin/metadata.yaml
+++ b/collectors/tc.plugin/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: tc.plugin
   module_name: tc.plugin
-  alternative_monitored_instances: []
   monitored_instance:
     name: tc
     link: ''

--- a/collectors/timex.plugin/metadata.yaml
+++ b/collectors/timex.plugin/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: timex.plugin
   module_name: timex.plugin
-  alternative_monitored_instances: []
   monitored_instance:
     name: timex
     link: ''
@@ -56,8 +55,7 @@ alerts:
   - name: system_clock_sync_state
     link: https://github.com/netdata/netdata/blob/master/health/health.d/timex.conf
     metric: system.clock_sync_state
-    info: when set to 0, the system kernel believes the system clock is not properly
-      synchronized to a reliable server
+    info: when set to 0, the system kernel believes the system clock is not properly synchronized to a reliable server
     os: "linux"
 metrics:
   folding:

--- a/collectors/xenstat.plugin/metadata.yaml
+++ b/collectors/xenstat.plugin/metadata.yaml
@@ -1,7 +1,6 @@
 meta:
   plugin_name: xenstat.plugin
   module_name: xenstat.plugin
-  alternative_monitored_instances: []
   monitored_instance:
     name: xenstat
     link: ''


### PR DESCRIPTION
##### Summary

As discussed, I ran the script to generate multiline strings in one line, and also removed the `alternative_monitored_instances`. 

Ignore the past two commits, they are overwritten by the last commit. 

yamllint of course is expected to fail.
