### PR TITLE
Fix the ingest script for bundling v2 dashboard to include license

### DIFF
--- a/web/gui/bundle_dashboard_v2.py
+++ b/web/gui/bundle_dashboard_v2.py
@@ -29,7 +29,8 @@ MAKEFILETEMPLATE = '''
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 
 dist_noinst_DATA = \\
-    $(srcdir)/README.md
+    $(srcdir)/README.md \\
+    $(srcdir)/LICENSE.md
 
 webv2dir=$(webdir)/v2
 


### PR DESCRIPTION
##### Summary

Fix the ingest script for bundling v2 dashboard to include the license

Closes  https://github.com/netdata/netdata/issues/15454
##### Test Plan

Ingest a new dashboard, make sure that the build process passes and the license is included in the tarball
