### PR TITLE
Metadata cleanup improvements

### DIFF
--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -63,7 +63,6 @@ const char *database_config[] = {
 };
 
 const char *database_cleanup[] = {
-    "DELETE FROM chart WHERE chart_id NOT IN (SELECT chart_id FROM dimension);",
     "DELETE FROM host WHERE host_id NOT IN (SELECT host_id FROM chart);",
     "DELETE FROM node_instance WHERE host_id NOT IN (SELECT host_id FROM host);",
     "DELETE FROM host_info WHERE host_id NOT IN (SELECT host_id FROM host);",

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -49,7 +49,7 @@
 
 #define METADATA_CMD_Q_MAX_SIZE (1024)              // Max queue size; callers will block until there is room
 #define METADATA_MAINTENANCE_FIRST_CHECK (1800)     // Maintenance first run after agent startup in seconds
-#define METADATA_MAINTENANCE_RETRY (60)             // Retry run if already running or last run did actual work
+#define METADATA_MAINTENANCE_REPEAT (60)            // Repeat if last run for dimensions, charts, labels needs more work
 #define METADATA_HEALTH_LOG_INTERVAL (3600)         // Repeat maintenance for health
 #define METADATA_DIM_CHECK_INTERVAL (3600)          // Repeat maintenance for dimensions
 #define METADATA_CHART_CHECK_INTERVAL (3600)        // Repeat maintenance for charts
@@ -751,7 +751,7 @@ static bool run_cleanup_loop(
 #define SQL_CHECK_CHART_EXISTENCE_IN_DIMENSION "SELECT count(1) FROM dimension WHERE chart_id = @chart_id"
 #define SQL_CHECK_CHART_EXISTENCE_IN_CHART "SELECT count(1) FROM chart WHERE chart_id = @chart_id"
 
-static bool chart_can_be_deleted(uuid_t(*chart_uuid), bool check_in_dimension)
+static bool chart_can_be_deleted(uuid_t *chart_uuid, bool check_in_dimension)
 {
     int rc, result = 1;
     sqlite3_stmt *res = NULL;
@@ -834,9 +834,9 @@ static void check_dimension_metadata(struct metadata_wc *wc)
 
     now = now_realtime_sec();
     if (total_deleted > 0 || runtime_exceeded)
-        next_execution_t = now + METADATA_MAINTENANCE_RETRY;
+        next_execution_t = now + METADATA_MAINTENANCE_REPEAT;
     else {
-        last_row_id= 0;
+        last_row_id = 0;
         next_execution_t = now + METADATA_DIM_CHECK_INTERVAL;
     }
 
@@ -893,7 +893,7 @@ static void check_chart_metadata(struct metadata_wc *wc)
 
     now = now_realtime_sec();
     if (total_deleted > 0 || runtime_exceeded)
-        next_execution_t = now + METADATA_MAINTENANCE_RETRY;
+        next_execution_t = now + METADATA_MAINTENANCE_REPEAT;
     else {
         last_row_id = 0;
         next_execution_t = now + METADATA_CHART_CHECK_INTERVAL;
@@ -953,7 +953,7 @@ static void check_label_metadata(struct metadata_wc *wc)
 
     now = now_realtime_sec();
     if (total_deleted > 0 || runtime_exceeded)
-        next_execution_t = now + METADATA_MAINTENANCE_RETRY;
+        next_execution_t = now + METADATA_MAINTENANCE_REPEAT;
     else {
         last_row_id = 0;
         next_execution_t = now + METADATA_LABEL_CHECK_INTERVAL;

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -820,9 +820,18 @@ static void check_dimension_metadata(struct metadata_wc *wc)
 
     internal_error(true, "METADATA: Checking dimensions starting after row %"PRIu64, last_row_id);
 
-    bool runtime_exceeded = run_cleanup_loop(res, wc, dimension_can_be_deleted, delete_dimension_uuid,
-        &total_checked, &total_deleted, METADATA_RUNTIME_THRESHOLD,
-        MAX_METADATA_CLEANUP, &last_row_id, false, false);
+    bool runtime_exceeded = run_cleanup_loop(
+        res,
+        wc,
+        dimension_can_be_deleted,
+        delete_dimension_uuid,
+        &total_checked,
+        &total_deleted,
+        METADATA_RUNTIME_THRESHOLD,
+        MAX_METADATA_CLEANUP,
+        &last_row_id,
+        false,
+        false);
 
     now = now_realtime_sec();
     if (total_deleted > 0 || runtime_exceeded)
@@ -833,10 +842,10 @@ static void check_dimension_metadata(struct metadata_wc *wc)
     }
 
     netdata_log_info(
-        "METADATA: Dimensions checked %u, deleted %u -- will resume after row %" PRIu64 " in %lld seconds",
+        "METADATA: Dimensions checked %u, deleted %u. Checks will %s in %lld seconds",
         total_checked,
         total_deleted,
-        last_row_id,
+        last_row_id ? "resume" : "restart",
         (long long)(next_execution_t - now));
 
     rc = sqlite3_finalize(res);
@@ -866,9 +875,18 @@ static void check_chart_metadata(struct metadata_wc *wc)
 
     internal_error(true, "METADATA: Checking charts starting after row %"PRIu64, last_row_id);
 
-    bool runtime_exceeded = run_cleanup_loop(res, wc, chart_can_be_deleted, delete_chart_uuid,
-                                             &total_checked, &total_deleted, METADATA_RUNTIME_THRESHOLD,
-                                             MAX_METADATA_CLEANUP, &last_row_id, true, false);
+    bool runtime_exceeded = run_cleanup_loop(
+        res,
+        wc,
+        chart_can_be_deleted,
+        delete_chart_uuid,
+        &total_checked,
+        &total_deleted,
+        METADATA_RUNTIME_THRESHOLD,
+        MAX_METADATA_CLEANUP,
+        &last_row_id,
+        true,
+        false);
 
     now = now_realtime_sec();
     if (total_deleted > 0 || runtime_exceeded)
@@ -878,10 +896,11 @@ static void check_chart_metadata(struct metadata_wc *wc)
         next_execution_t = now + METADATA_CHART_CHECK_INTERVAL;
     }
 
-    netdata_log_info("METADATA: Charts checked %u, deleted %u -- will resume after row %" PRIu64 " in %lld seconds",
+    netdata_log_info(
+        "METADATA: Charts checked %u, deleted %u. Checks will %s in %lld seconds",
         total_checked,
         total_deleted,
-        last_row_id,
+        last_row_id ? "resume" : "restart",
         (long long)(next_execution_t - now));
 
     rc = sqlite3_finalize(res);
@@ -912,9 +931,18 @@ static void check_label_metadata(struct metadata_wc *wc)
 
     internal_error(true,"METADATA: Checking charts labels starting after row %"PRIu64, last_row_id);
 
-    bool runtime_exceeded = run_cleanup_loop(res, wc, chart_can_be_deleted, delete_chart_uuid,
-                                             &total_checked, &total_deleted, METADATA_RUNTIME_THRESHOLD,
-                                             MAX_METADATA_CLEANUP, &last_row_id, false, true);
+    bool runtime_exceeded = run_cleanup_loop(
+        res,
+        wc,
+        chart_can_be_deleted,
+        delete_chart_uuid,
+        &total_checked,
+        &total_deleted,
+        METADATA_RUNTIME_THRESHOLD,
+        MAX_METADATA_CLEANUP,
+        &last_row_id,
+        false,
+        true);
 
     now = now_realtime_sec();
     if (total_deleted > 0 || runtime_exceeded)
@@ -925,10 +953,10 @@ static void check_label_metadata(struct metadata_wc *wc)
     }
 
     netdata_log_info(
-        "METADATA: Charts labels checked %u, deleted %u -- will resume after row %" PRIu64 " in %lld seconds",
+        "METADATA: Chart labels checked %u, deleted %u. Checks will %s in %lld seconds",
         total_checked,
         total_deleted,
-        last_row_id,
+        last_row_id ? "resume" : "restart",
         (long long)(next_execution_t - now));
 
     rc = sqlite3_finalize(res);

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -48,7 +48,7 @@
 #define DELETE_MISSING_NODE_INSTANCES "DELETE FROM node_instance WHERE host_id NOT IN (SELECT host_id FROM host);"
 
 #define METADATA_CMD_Q_MAX_SIZE (1024)              // Max queue size; callers will block until there is room
-#define METADATA_MAINTENANCE_FIRST_CHECK (3600)     // Maintenance first run after agent startup in seconds
+#define METADATA_MAINTENANCE_FIRST_CHECK (1800)     // Maintenance first run after agent startup in seconds
 #define METADATA_MAINTENANCE_RETRY (60)             // Retry run if already running or last run did actual work
 #define METADATA_HEALTH_LOG_INTERVAL (3600)         // Repeat maintenance for health
 #define METADATA_DIM_CHECK_INTERVAL (3600)          // Repeat maintenance for dimensions
@@ -977,6 +977,10 @@ static void cleanup_health_log(struct metadata_wc *wc)
     static time_t next_execution_t = 0;
 
     time_t now = now_realtime_sec();
+
+    if (!next_execution_t)
+        next_execution_t = now + METADATA_MAINTENANCE_FIRST_CHECK;
+
     if (next_execution_t && next_execution_t > now)
         return;
 

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -36,6 +36,8 @@
         "VALUES (@dim_id, @chart_id, @id, @name, @multiplier, @divisor, @algorithm, @options);"
 
 #define SELECT_DIMENSION_LIST "SELECT dim_id, rowid FROM dimension WHERE rowid > @row_id"
+#define SELECT_CHART_LIST "SELECT chart_id, rowid FROM chart WHERE rowid > @row_id"
+#define SELECT_CHART_LABEL_LIST "SELECT chart_id, rowid FROM chart_label WHERE rowid > @row_id"
 
 #define SQL_STORE_HOST_SYSTEM_INFO_VALUES "INSERT OR REPLACE INTO host_info (host_id, system_key, system_value, date_created) VALUES " \
     "(@uuid, @name, @value, unixepoch())"
@@ -48,12 +50,18 @@
 #define METADATA_CMD_Q_MAX_SIZE (1024)              // Max queue size; callers will block until there is room
 #define METADATA_MAINTENANCE_FIRST_CHECK (1800)     // Maintenance first run after agent startup in seconds
 #define METADATA_MAINTENANCE_RETRY (60)             // Retry run if already running or last run did actual work
-#define METADATA_MAINTENANCE_INTERVAL (3600)        // Repeat maintenance after latest successful
+#define METADATA_MAINTENANCE_REPEAT (60)            // Repeat time for main task
+#define METADATA_HEALTH_LOG_INTERVAL (3600)         // Repeat maintenance for health
+#define METADATA_DIM_CHECK_INTERVAL (3600)          // Repeat maintenance for dimensions
+#define METADATA_CHART_CHECK_INTERVAL (3600)        // Repeat maintenance for charts
+#define METADATA_LABEL_CHECK_INTERVAL (3600)        // Repeat maintenance for labels
+#define METADATA_RUNTIME_THRESHOLD (5)              // Run time threshold for cleanup task
 
 #define METADATA_HOST_CHECK_FIRST_CHECK (5)         // First check for pending metadata
 #define METADATA_HOST_CHECK_INTERVAL (30)           // Repeat check for pending metadata
 #define METADATA_HOST_CHECK_IMMEDIATE (5)           // Repeat immediate run because we have more metadata to write
-
+#define METADATA_FREE_PAGES_THRESHOLD_PC (5)        // Percentage of free pages to trigger vacuum
+#define METADATA_FREE_PAGES_VACUUM_PC (10)          // Percentage of free pages to vacuum
 #define MAX_METADATA_CLEANUP (500)                  // Maximum metadata write operations (e.g  deletes before retrying)
 #define METADATA_MAX_BATCH_SIZE (512)               // Maximum commands to execute before running the event loop
 
@@ -103,7 +111,9 @@ struct metadata_wc {
     time_t check_hosts_after;
     volatile unsigned queue_size;
     METADATA_FLAG flags;
-    uint64_t row_id;
+//    uint64_t dimension_row_id;
+//    uint64_t chart_row_id;
+//    uint64_t chart_label_row_id;
     struct completion init_complete;
     /* FIFO command queue */
     uv_mutex_t cmd_mutex;
@@ -252,7 +262,7 @@ failed:
     return rc != SQLITE_DONE;
 }
 
-static void delete_dimension_uuid(uuid_t *dimension_uuid)
+static void delete_dimension_uuid(uuid_t *dimension_uuid, bool flag __maybe_unused)
 {
     static __thread sqlite3_stmt *res = NULL;
     int rc;
@@ -650,7 +660,7 @@ bind_fail:
     return 1;
 }
 
-static bool dimension_can_be_deleted(uuid_t *dim_uuid __maybe_unused)
+static bool dimension_can_be_deleted(uuid_t *dim_uuid __maybe_unused, bool flag __maybe_unused)
 {
 #ifdef ENABLE_DBENGINE
     if(dbengine_enabled) {
@@ -675,8 +685,130 @@ static bool dimension_can_be_deleted(uuid_t *dim_uuid __maybe_unused)
 #endif
 }
 
+int get_pragma_value(sqlite3 *database, const char *sql)
+{
+    sqlite3_stmt *res = NULL;
+    int rc = sqlite3_prepare_v2(database, sql, -1, &res, 0);
+    if (unlikely(rc != SQLITE_OK))
+        return -1;
+
+    int result = -1;
+    rc = sqlite3_step_monitored(res);
+    if (likely(rc == SQLITE_ROW))
+        result = sqlite3_column_int(res, 0);
+
+    rc = sqlite3_finalize(res);
+    (void) rc;
+
+    return result;
+}
+
+
+int get_free_page_count(sqlite3 *database)
+{
+    return get_pragma_value(database, "PRAGMA freelist_count");
+}
+
+int get_database_page_count(sqlite3 *database)
+{
+    return get_pragma_value(database, "PRAGMA page_count");
+}
+
+static bool run_cleanup_loop(
+    sqlite3_stmt *res,
+    struct metadata_wc *wc,
+    bool (*check_cb)(uuid_t *uuid, bool check_flag __maybe_unused),
+    void (*action_cb)(uuid_t *uuid, bool action_flag __maybe_unused),
+    uint32_t *total_checked,
+    uint32_t *total_deleted,
+    uint32_t run_threshold,
+    uint32_t cleanup_threshold,
+    uint64_t *row_id,
+    bool check_flag,
+    bool action_flag)
+{
+
+    if (unlikely(metadata_flag_check(wc, METADATA_FLAG_SHUTDOWN)))
+        return true;
+
+    int rc = sqlite3_bind_int64(res, 1, (sqlite3_int64) *row_id);
+    if (unlikely(rc != SQLITE_OK))
+        return true;
+
+    time_t start_running = now_monotonic_sec();
+    bool time_expired = false;
+    while (!time_expired && sqlite3_step_monitored(res) == SQLITE_ROW && *total_deleted < cleanup_threshold) {
+        if (unlikely(metadata_flag_check(wc, METADATA_FLAG_SHUTDOWN)))
+            break;
+
+        *row_id = sqlite3_column_int64(res, 1);
+        rc = check_cb((uuid_t *)sqlite3_column_blob(res, 0), check_flag);
+
+        if (rc == true) {
+            action_cb((uuid_t *)sqlite3_column_blob(res, 0), action_flag);
+            (*total_deleted)++;
+        }
+
+        (*total_checked)++;
+        time_expired = ((now_monotonic_sec() - start_running) > run_threshold);
+    }
+    return time_expired;
+}
+
+
+#define SQL_CHECK_CHART_EXISTENCE_IN_DIMENSION "SELECT count(1) FROM dimension WHERE chart_id = @chart_id"
+#define SQL_CHECK_CHART_EXISTENCE_IN_CHART "SELECT count(1) FROM chart WHERE chart_id = @chart_id"
+
+static bool chart_can_be_deleted(uuid_t(*chart_uuid), bool check_in_dimension)
+{
+    int rc, result = 1;
+    sqlite3_stmt *res = NULL;
+
+    if (check_in_dimension)
+        rc = sqlite3_prepare_v2(db_meta, SQL_CHECK_CHART_EXISTENCE_IN_DIMENSION, -1, &res, 0);
+    else
+        rc = sqlite3_prepare_v2(db_meta, SQL_CHECK_CHART_EXISTENCE_IN_CHART, -1, &res, 0);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to prepare statement to check for chart existence, rc = %d", rc);
+        return 0;
+    }
+
+    rc = sqlite3_bind_blob(res, 1, chart_uuid, sizeof(*chart_uuid), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind chart uuid parameter, rc = %d", rc);
+        goto skip;
+    }
+
+    rc = sqlite3_step_monitored(res);
+    if (likely(rc == SQLITE_ROW))
+        result = sqlite3_column_int(res, 0);
+
+skip:
+    rc = sqlite3_finalize(res);
+    if (unlikely(rc != SQLITE_OK))
+        error_report("Failed to finalize statement that checks chart uuid existence rc = %d", rc);
+    return result == 0;
+}
+
+#define SQL_DELETE_CHART_BY_UUID        "DELETE FROM chart WHERE chart_id = @chart_id"
+#define SQL_DELETE_CHART_LABEL_BY_UUID  "DELETE FROM chart_label WHERE chart_id = @chart_id"
+
+static void delete_chart_uuid(uuid_t(*chart_uuid), bool label_only)
+{
+    if (label_only == false)
+        (void) exec_statement_with_uuid(SQL_DELETE_CHART_BY_UUID, chart_uuid);
+    (void) exec_statement_with_uuid(SQL_DELETE_CHART_LABEL_BY_UUID, chart_uuid);
+}
+
 static void check_dimension_metadata(struct metadata_wc *wc)
 {
+    static time_t next_execution_t = 0;
+    static uint64_t last_row_id = 0;
+
+    time_t now = now_realtime_sec();
+    if (next_execution_t && next_execution_t > now)
+        return;
+
     int rc;
     sqlite3_stmt *res = NULL;
 
@@ -686,47 +818,142 @@ static void check_dimension_metadata(struct metadata_wc *wc)
         return;
     }
 
-    rc = sqlite3_bind_int64(res, 1,  (sqlite3_int64) wc->row_id);
+    uint32_t total_checked = 0;
+    uint32_t total_deleted = 0;
+
+    internal_error(true, "METADATA: Checking dimensions starting after row %"PRIu64, last_row_id);
+
+    bool runtime_exceeded = run_cleanup_loop(res, wc, dimension_can_be_deleted, delete_dimension_uuid,
+        &total_checked, &total_deleted, METADATA_RUNTIME_THRESHOLD,
+        MAX_METADATA_CLEANUP, &last_row_id, false, false);
+
+    now = now_realtime_sec();
+    if (total_deleted > 0 || runtime_exceeded)
+        next_execution_t = now + METADATA_MAINTENANCE_RETRY;
+    else {
+        last_row_id= 0;
+        next_execution_t = now + METADATA_DIM_CHECK_INTERVAL;
+    }
+
+    internal_error(
+        true,
+        "METADATA: Dimensions checked %u, deleted %u -- will resume after row %" PRIu64 " in %lld seconds",
+        total_checked,
+        total_deleted,
+        last_row_id,
+        (long long)(next_execution_t - now));
+
+    rc = sqlite3_finalize(res);
+    if (unlikely(rc != SQLITE_OK))
+        error_report("Failed to finalize the prepared statement to check dimensions");
+}
+
+static void check_chart_metadata(struct metadata_wc *wc)
+{
+    static time_t next_execution_t = 0;
+    static uint64_t last_row_id = 0;
+
+    time_t now = now_realtime_sec();
+    if (next_execution_t && next_execution_t > now)
+        return;
+
+    sqlite3_stmt *res = NULL;
+
+    int rc = sqlite3_prepare_v2(db_meta, SELECT_CHART_LIST, -1, &res, 0);
     if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to row parameter");
-        goto skip_run;
+        error_report("Failed to prepare statement to fetch charts");
+        return;
     }
 
     uint32_t total_checked = 0;
     uint32_t total_deleted= 0;
-    uint64_t last_row_id = wc->row_id;
 
-    netdata_log_info("METADATA: Checking dimensions starting after row %"PRIu64, wc->row_id);
+    internal_error(true, "METADATA: Checking charts starting after row %"PRIu64, last_row_id);
 
-    while (sqlite3_step_monitored(res) == SQLITE_ROW && total_deleted < MAX_METADATA_CLEANUP) {
-        if (unlikely(metadata_flag_check(wc, METADATA_FLAG_SHUTDOWN)))
-            break;
+    bool runtime_exceeded = run_cleanup_loop(res, wc, chart_can_be_deleted, delete_chart_uuid,
+                                             &total_checked, &total_deleted, METADATA_RUNTIME_THRESHOLD,
+                                             MAX_METADATA_CLEANUP, &last_row_id, true, false);
 
-        last_row_id = sqlite3_column_int64(res, 1);
-        rc = dimension_can_be_deleted((uuid_t *)sqlite3_column_blob(res, 0));
-        if (rc == true) {
-            delete_dimension_uuid((uuid_t *)sqlite3_column_blob(res, 0));
-            total_deleted++;
-        }
-        total_checked++;
+    now = now_realtime_sec();
+    if (total_deleted > 0 || runtime_exceeded)
+        next_execution_t = now + METADATA_MAINTENANCE_RETRY;
+    else {
+        last_row_id = 0;
+        next_execution_t = now + METADATA_CHART_CHECK_INTERVAL;
     }
-    wc->row_id = last_row_id;
-    time_t now = now_realtime_sec();
-    if (total_deleted > 0) {
-        wc->check_metadata_after = now + METADATA_MAINTENANCE_RETRY;
-    } else
-        wc->row_id = 0;
-    netdata_log_info("METADATA: Checked %u, deleted %u -- will resume after row %"PRIu64" in %lld seconds", total_checked, total_deleted, wc->row_id,
-         (long long)(wc->check_metadata_after - now));
 
-skip_run:
+    internal_error(
+        true,
+        "METADATA: Charts checked %u, deleted %u -- will resume after row %" PRIu64 " in %lld seconds",
+        total_checked,
+        total_deleted,
+        last_row_id,
+        (long long)(next_execution_t - now));
+
     rc = sqlite3_finalize(res);
     if (unlikely(rc != SQLITE_OK))
-        error_report("Failed to finalize the prepared statement when reading dimensions");
+        error_report("Failed to finalize the prepared statement when reading charts");
 }
 
-static void cleanup_health_log(void)
+static void check_label_metadata(struct metadata_wc *wc)
 {
+    static time_t next_execution_t = 0;
+    static uint64_t last_row_id = 0;
+
+    time_t now = now_realtime_sec();
+    if (next_execution_t && next_execution_t > now)
+        return;
+
+    int rc;
+    sqlite3_stmt *res = NULL;
+
+    rc = sqlite3_prepare_v2(db_meta, SELECT_CHART_LABEL_LIST, -1, &res, 0);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to prepare statement to fetch charts");
+        return;
+    }
+
+    uint32_t total_checked = 0;
+    uint32_t total_deleted= 0;
+
+    internal_error(true,"METADATA: Checking charts labels starting after row %"PRIu64, last_row_id);
+
+    bool runtime_exceeded = run_cleanup_loop(res, wc, chart_can_be_deleted, delete_chart_uuid,
+                                             &total_checked, &total_deleted, METADATA_RUNTIME_THRESHOLD,
+                                             MAX_METADATA_CLEANUP, &last_row_id, false, true);
+
+    now = now_realtime_sec();
+    if (total_deleted > 0 || runtime_exceeded)
+        next_execution_t = now + METADATA_MAINTENANCE_RETRY;
+    else {
+        last_row_id = 0;
+        next_execution_t = now + METADATA_LABEL_CHECK_INTERVAL;
+    }
+
+    internal_error(
+        true,
+        "METADATA: Charts labels checked %u, deleted %u -- will resume after row %" PRIu64 " in %lld seconds",
+        total_checked,
+        total_deleted,
+        last_row_id,
+        (long long)(next_execution_t - now));
+
+    rc = sqlite3_finalize(res);
+    if (unlikely(rc != SQLITE_OK))
+        error_report("Failed to finalize the prepared statement when checking charts");
+}
+
+
+static void cleanup_health_log(struct metadata_wc *wc)
+{
+    static time_t next_execution_t = 0;
+
+    time_t now = now_realtime_sec();
+    if (next_execution_t && next_execution_t > now)
+        return;
+
+    next_execution_t = now + METADATA_HEALTH_LOG_INTERVAL;
+
     RRDHOST *host;
 
     bool is_claimed = claimed();
@@ -734,8 +961,16 @@ static void cleanup_health_log(void)
         if (rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED))
             continue;
         sql_health_alarm_log_cleanup(host, is_claimed);
+        if (unlikely(metadata_flag_check(wc, METADATA_FLAG_SHUTDOWN)))
+            break;
     }
     dfe_done(host);
+
+    if (unlikely(metadata_flag_check(wc, METADATA_FLAG_SHUTDOWN)))
+        return;
+
+    (void) db_execute(db_meta,"DELETE FROM health_log WHERE host_id NOT IN (SELECT host_id FROM host)");
+    (void) db_execute(db_meta,"DELETE FROM health_log_detail WHERE health_log_id NOT IN (SELECT health_log_id FROM health_log)");
 }
 
 //
@@ -870,7 +1105,7 @@ static void timer_cb(uv_timer_t* handle)
    if (wc->check_metadata_after && wc->check_metadata_after < now) {
        cmd.opcode = METADATA_MAINTENANCE;
        if (!metadata_enq_cmd_noblock(wc, &cmd))
-           wc->check_metadata_after = now + METADATA_MAINTENANCE_INTERVAL;
+           wc->check_metadata_after = now + METADATA_MAINTENANCE_REPEAT;
    }
 
    if (wc->check_hosts_after && wc->check_hosts_after < now) {
@@ -894,8 +1129,33 @@ static void start_metadata_cleanup(uv_work_t *req)
 
     worker_is_busy(UV_EVENT_METADATA_CLEANUP);
     struct metadata_wc *wc = req->data;
+
     check_dimension_metadata(wc);
-    cleanup_health_log();
+    check_chart_metadata(wc);
+    check_label_metadata(wc);
+    cleanup_health_log(wc);
+
+    if (unlikely(metadata_flag_check(wc, METADATA_FLAG_SHUTDOWN))) {
+       worker_is_idle();
+       return;
+    }
+
+    int free_pages = get_free_page_count(db_meta);
+    int total_pages = get_database_page_count(db_meta);
+    if (free_pages > (total_pages * METADATA_FREE_PAGES_THRESHOLD_PC / 100)) {
+       char sql[512];
+       int do_free_pages = (int) (free_pages * METADATA_FREE_PAGES_VACUUM_PC / 100);
+
+       internal_error(true,
+           "METADATA: Total pages %d, free pages %d -- attempting to release %d pages",
+           total_pages,
+           free_pages,
+           do_free_pages);
+
+       snprintfz(sql, 511, "PRAGMA incremental_vacuum(%d)", do_free_pages);
+       (void) db_execute(db_meta, sql);
+    }
+
     (void) sqlite3_wal_checkpoint(db_meta, NULL);
     worker_is_idle();
 }
@@ -1277,7 +1537,9 @@ static void metadata_event_loop(void *arg)
     wc->check_hosts_after    = now_realtime_sec() + METADATA_HOST_CHECK_FIRST_CHECK;
 
     int shutdown = 0;
-    wc->row_id = 0;
+//    wc->dimension_row_id = 0;
+//    wc->chart_row_id = 0;
+//    wc->chart_label_row_id = 0;
     completion_mark_complete(&wc->init_complete);
     BUFFER *work_buffer = buffer_create(1024, &netdata_buffers_statistics.buffers_sqlite);
     struct scan_metadata_payload *data;
@@ -1320,8 +1582,8 @@ static void metadata_event_loop(void *arg)
                 }
                 case METADATA_DEL_DIMENSION:
                     uuid = (uuid_t *) cmd.param[0];
-                    if (likely(dimension_can_be_deleted(uuid)))
-                        delete_dimension_uuid(uuid);
+                    if (likely(dimension_can_be_deleted(uuid, false)))
+                        delete_dimension_uuid(uuid, false);
                     freez(uuid);
                     break;
                 case METADATA_STORE_CLAIM_ID:

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -48,7 +48,7 @@
 #define DELETE_MISSING_NODE_INSTANCES "DELETE FROM node_instance WHERE host_id NOT IN (SELECT host_id FROM host);"
 
 #define METADATA_CMD_Q_MAX_SIZE (1024)              // Max queue size; callers will block until there is room
-#define METADATA_MAINTENANCE_FIRST_CHECK (1800)     // Maintenance first run after agent startup in seconds
+#define METADATA_MAINTENANCE_FIRST_CHECK (120)     // Maintenance first run after agent startup in seconds
 #define METADATA_MAINTENANCE_RETRY (60)             // Retry run if already running or last run did actual work
 #define METADATA_MAINTENANCE_REPEAT (60)            // Repeat time for main task
 #define METADATA_HEALTH_LOG_INTERVAL (3600)         // Repeat maintenance for health


### PR DESCRIPTION
##### Summary
- Improve the metadata cleanup jobs to cleanup stale dimensions, charts and chart labels
  - Cleanup jobs will incrementally cleanup the corresponding tables. To minimize resource usage jobs will run for max of 5 seconds or if 500 items are deleted and will be rescheduled after one minute. 
  - Storing new metadata always takes priority and skips running the cleanup jobs
- Issue a database incremental vacuum to shrink database size if free pages are over 5% of the database size

