### PR TITLE
Add community key in schema

### DIFF
--- a/collectors/metadata/schemas/single-module.json
+++ b/collectors/metadata/schemas/single-module.json
@@ -108,6 +108,10 @@
         "most_popular": {
           "type": "boolean",
           "description": "Whether or not the integration is to be flagged as most-popular, meaning it will show up at the top of the menu."
+        },
+        "community": {
+          "type": "boolean",
+          "description": "Whether or not the integration should be flagged as community."
         }
       },
       "required": [


### PR DESCRIPTION
##### Summary


As discussed, this is a prop to set to true, if the integration should be flagged as "community", [OP](https://netdata-cloud.slack.com/archives/C05F9KAM3HR/p1689860734272019?thread_ts=1689853988.463609&cid=C05F9KAM3HR)