### PR TITLE
Remove __builtin_expect from our codebase.

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -174,7 +174,7 @@ static int wait_till_agent_claimed(void)
 {
     //TODO prevent malloc and freez
     char *agent_id = get_agent_claimid();
-    while (likely(!agent_id)) {
+    while (!agent_id) {
         sleep_usec(USEC_PER_SEC * 1);
         if (!service_running(SERVICE_ACLK))
             return 1;
@@ -260,12 +260,12 @@ static void msg_callback(const char *topic, const void *msg, size_t msglen, int 
     }
 
     const char *msgtype = strrchr(topic, '/');
-    if (unlikely(!msgtype)) {
+    if (!msgtype) {
         error_report("Cannot get message type from topic. Ignoring message from topic \"%s\"", topic);
         return;
     }
     msgtype++;
-    if (unlikely(!*msgtype)) {
+    if (!*msgtype) {
         error_report("Message type empty. Ignoring message from topic \"%s\"", topic);
         return;
     }
@@ -850,7 +850,7 @@ void *aclk_main(void *ptr)
         if (aclk_attempt_to_connect(mqttwss_client))
             goto exit_full;
 
-        if (unlikely(!query_threads.thread_list))
+        if (!query_threads.thread_list)
             aclk_query_threads_start(&query_threads, mqttwss_client);
 
         if (handle_connection(mqttwss_client)) {
@@ -959,7 +959,7 @@ void aclk_send_node_instances()
 {
     struct node_instance_list *list_head = get_node_list();
     struct node_instance_list *list = list_head;
-    if (unlikely(!list)) {
+    if (!list) {
         error_report("Failure to get_node_list from DB!");
         return;
     }
@@ -979,7 +979,7 @@ void aclk_send_node_instances()
             uuid_unparse_lower(list->host_id, host_id);
 
             RRDHOST *host = rrdhost_find_by_guid(host_id);
-            if (unlikely(!host)) {
+            if (!host) {
                 freez((void*)node_state_update.node_id);
                 freez(query);
                 continue;
@@ -1323,6 +1323,6 @@ void add_aclk_host_labels(void) {
 void aclk_queue_node_info(RRDHOST *host, bool immediate)
 {
     struct aclk_sync_host_config *wc = (struct aclk_sync_host_config *) host->aclk_sync_host_config;
-    if (likely(wc))
+    if (wc)
         wc->node_info_send_time = (host == localhost || immediate) ? 1 : now_realtime_sec();
 }

--- a/aclk/aclk_query.c
+++ b/aclk/aclk_query.c
@@ -344,7 +344,7 @@ void *aclk_query_main_thread(void *ptr)
 
         worker_is_idle();
         QUERY_THREAD_LOCK;
-        if (unlikely(pthread_cond_wait(&query_cond_wait, &query_lock_wait)))
+        if (pthread_cond_wait(&query_cond_wait, &query_lock_wait))
             sleep_usec(USEC_PER_SEC * 1);
         QUERY_THREAD_UNLOCK;
     }
@@ -364,7 +364,7 @@ void aclk_query_threads_start(struct aclk_query_threads *query_threads, mqtt_wss
         query_threads->thread_list[i].idx = i; //thread needs to know its index for statistics
         query_threads->thread_list[i].client = client;
 
-        if(unlikely(snprintfz(thread_name, TASK_LEN_MAX, "ACLK_QRY[%d]", i) < 0))
+        if(snprintfz(thread_name, TASK_LEN_MAX, "ACLK_QRY[%d]", i) < 0)
             netdata_log_error("snprintf encoding error");
         netdata_thread_create(
             &query_threads->thread_list[i].thread, thread_name, NETDATA_THREAD_OPTION_JOINABLE, aclk_query_main_thread,

--- a/aclk/aclk_query_queue.c
+++ b/aclk/aclk_query_queue.c
@@ -78,7 +78,7 @@ aclk_query_t aclk_queue_pop(void)
     }
 
     aclk_query_queue.head = ret->next;
-    if (unlikely(!aclk_query_queue.head))
+    if (!aclk_query_queue.head)
         aclk_query_queue.tail = aclk_query_queue.head;
     ACLK_QUEUE_UNLOCK;
 

--- a/aclk/aclk_query_queue.h
+++ b/aclk/aclk_query_queue.h
@@ -76,7 +76,7 @@ void aclk_queue_lock(void);
 void aclk_queue_unlock(void);
 
 #define QUEUE_IF_PAYLOAD_PRESENT(query)                                                                                \
-    if (likely(query->data.bin_payload.payload)) {                                                                     \
+    if (query->data.bin_payload.payload) {                                                                     \
         aclk_queue_query(query);                                                                                       \
     } else {                                                                                                           \
         netdata_log_error("Failed to generate payload (%s)", __FUNCTION__);                                            \

--- a/aclk/aclk_stats.c
+++ b/aclk/aclk_stats.c
@@ -35,7 +35,7 @@ static void aclk_stats_collect(struct aclk_metrics_per_sample *per_sample, struc
     static RRDSET *st_aclkstats = NULL;
     static RRDDIM *rd_online_status = NULL;
 
-    if (unlikely(!st_aclkstats)) {
+    if (!st_aclkstats) {
         st_aclkstats = rrdset_create_localhost(
             "netdata", "aclk_status", NULL, "aclk", NULL, "ACLK/Cloud connection status",
             "connected", "netdata", "stats", 200000, localhost->rrd_update_every, RRDSET_TYPE_LINE);
@@ -54,7 +54,7 @@ static void aclk_stats_query_queue(struct aclk_metrics_per_sample *per_sample)
     static RRDDIM *rd_queued = NULL;
     static RRDDIM *rd_dispatched = NULL;
 
-    if (unlikely(!st_query_thread)) {
+    if (!st_query_thread) {
         st_query_thread = rrdset_create_localhost(
             "netdata", "aclk_query_per_second", NULL, "aclk", NULL, "ACLK Queries per second", "queries/s",
             "netdata", "stats", 200001, localhost->rrd_update_every, RRDSET_TYPE_AREA);
@@ -76,7 +76,7 @@ static void aclk_stats_latency(struct aclk_metrics_per_sample *per_sample)
     static RRDDIM *rd_avg = NULL;
     static RRDDIM *rd_max = NULL;
 
-    if (unlikely(!st)) {
+    if (!st) {
         st = rrdset_create_localhost(
             "netdata", "aclk_latency_mqtt", NULL, "aclk", NULL, "ACLK Message Publish Latency", "ms",
             "netdata", "stats", 200002, localhost->rrd_update_every, RRDSET_TYPE_LINE);
@@ -102,7 +102,7 @@ static void aclk_stats_cloud_req(struct aclk_metrics_per_sample *per_sample)
     static RRDDIM *rd_rq_rcvd = NULL;
     static RRDDIM *rd_rq_err = NULL;
 
-    if (unlikely(!st)) {
+    if (!st) {
         st = rrdset_create_localhost(
             "netdata", "aclk_cloud_req", NULL, "aclk", NULL, "Requests received from cloud", "req/s",
             "netdata", "stats", 200005, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
@@ -122,7 +122,7 @@ static void aclk_stats_cloud_req_type(struct aclk_metrics_per_sample *per_sample
     static RRDSET *st = NULL;
     static RRDDIM *dims[ACLK_QUERY_TYPE_COUNT];
 
-    if (unlikely(!st)) {
+    if (!st) {
         st = rrdset_create_localhost(
             "netdata", "aclk_processed_query_type", NULL, "aclk", NULL, "Query thread commands processed by their type", "cmd/s",
             "netdata", "stats", 200006, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
@@ -164,7 +164,7 @@ static void aclk_stats_cloud_req_http_type(struct aclk_metrics_per_sample *per_s
     static RRDSET *st = NULL;
     static RRDDIM *rd_rq_types[ACLK_STATS_CLOUD_HTTP_REQ_TYPE_CNT];
 
-    if (unlikely(!st)) {
+    if (!st) {
         st = rrdset_create_localhost(
             "netdata", "aclk_cloud_req_http_type", NULL, "aclk", NULL, "Requests received from cloud via HTTP by their type", "req/s",
             "netdata", "stats", 200007, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
@@ -186,7 +186,7 @@ static void aclk_stats_query_threads(uint32_t *queries_per_thread)
 
     char dim_name[MAX_DIM_NAME];
 
-    if (unlikely(!st)) {
+    if (!st) {
         st = rrdset_create_localhost(
             "netdata", "aclk_query_threads", NULL, "aclk", NULL, "Queries Processed Per Thread", "req/s",
             "netdata", "stats", 200009, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
@@ -212,7 +212,7 @@ static void aclk_stats_query_time(struct aclk_metrics_per_sample *per_sample)
     static RRDDIM *rd_rq_max = NULL;
     static RRDDIM *rd_rq_total = NULL;
 
-    if (unlikely(!st)) {
+    if (!st) {
         st = rrdset_create_localhost(
             "netdata", "aclk_query_time", NULL, "aclk", NULL, "Time it took to process cloud requested DB queries", "us",
             "netdata", "stats", 200008, localhost->rrd_update_every, RRDSET_TYPE_LINE);
@@ -237,7 +237,7 @@ static void aclk_stats_newproto_rx(uint32_t *rx_msgs_sample)
 {
     static RRDSET *st = NULL;
 
-    if (unlikely(!st)) {
+    if (!st) {
         st = rrdset_create_localhost(
             "netdata", "aclk_protobuf_rx_types", NULL, "aclk", NULL, "Received new cloud architecture messages by their type.", "msg/s",
             "netdata", "stats", 200010, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
@@ -281,7 +281,7 @@ static void aclk_stats_mqtt_wss(struct mqtt_wss_stats *stats)
     sent += stats->bytes_tx;
     recvd += stats->bytes_rx;
 
-    if (unlikely(!st)) {
+    if (!st) {
         st = rrdset_create_localhost(
             "netdata", "aclk_openssl_bytes", NULL, "aclk", NULL, "Received and Sent bytes.", "B/s",
             "netdata", "stats", 200011, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
@@ -290,7 +290,7 @@ static void aclk_stats_mqtt_wss(struct mqtt_wss_stats *stats)
         rd_recvd = rrddim_add(st, "received", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
     }
 
-    if (unlikely(!st_txbuf_perc)) {
+    if (!st_txbuf_perc) {
         st_txbuf_perc = rrdset_create_localhost(
             "netdata", "aclk_mqtt_tx_perc", NULL, "aclk", NULL, "Actively used percentage of MQTT Tx Buffer,", "%",
             "netdata", "stats", 200012, localhost->rrd_update_every, RRDSET_TYPE_LINE);
@@ -298,7 +298,7 @@ static void aclk_stats_mqtt_wss(struct mqtt_wss_stats *stats)
         rd_txbuf_perc = rrddim_add(st_txbuf_perc, "used", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
     }
 
-    if (unlikely(!st_txbuf)) {
+    if (!st_txbuf) {
         st_txbuf = rrdset_create_localhost(
             "netdata", "aclk_mqtt_tx_queue", NULL, "aclk", NULL, "State of transmit MQTT queue.", "B",
             "netdata", "stats", 200013, localhost->rrd_update_every, RRDSET_TYPE_LINE);
@@ -310,7 +310,7 @@ static void aclk_stats_mqtt_wss(struct mqtt_wss_stats *stats)
         rd_tx_buffer_size = rrddim_add(st_txbuf, "size", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
     }
 
-    if (unlikely(!st_timing)) {
+    if (!st_timing) {
         st_timing = rrdset_create_localhost(
             "netdata", "aclk_mqtt_wss_time", NULL, "aclk", NULL, "Time spent handling MQTT, WSS, SSL and network communication.", "us",
             "netdata", "stats", 200014, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
@@ -461,7 +461,7 @@ void aclk_stats_msg_puback(uint16_t id)
         return;
     }
 
-    if (unlikely(!pub_time[id])) {
+    if (!pub_time[id]) {
         ACLK_STATS_UNLOCK;
         netdata_log_error("Received PUBACK for unknown message?!");
         return;

--- a/aclk/aclk_tx_msgs.c
+++ b/aclk/aclk_tx_msgs.c
@@ -31,7 +31,7 @@ uint16_t aclk_send_bin_message_subtopic_pid(mqtt_wss_client client, char *msg, s
     uint16_t packet_id;
     const char *topic = aclk_get_topic(subtopic);
 
-    if (unlikely(!topic)) {
+    if (!topic) {
         netdata_log_error("Couldn't get topic. Aborting message send.");
         return 0;
     }
@@ -60,7 +60,7 @@ static int aclk_send_message_with_bin_payload(mqtt_wss_client client, json_objec
     char *full_msg = NULL;
     int len;
 
-    if (unlikely(!topic || topic[0] != '/')) {
+    if (!topic || topic[0] != '/') {
         netdata_log_error("Full topic required!");
         json_object_put(msg);
         return HTTP_RESP_INTERNAL_SERVER_ERROR;
@@ -109,7 +109,7 @@ static struct json_object *create_hdr(const char *type, const char *msg_id, time
     tmp = json_object_new_string(type);
     json_object_object_add(obj, "type", tmp);
 
-    if (unlikely(!msg_id)) {
+    if (!msg_id) {
         uuid_generate(uuid);
         uuid_unparse(uuid, uuid_str);
         msg_id = uuid_str;
@@ -219,7 +219,7 @@ uint16_t aclk_send_agent_connection_update(mqtt_wss_client client, int reachable
     };
 
     rrdhost_aclk_state_lock(localhost);
-    if (unlikely(!localhost->aclk_state.claimed_id)) {
+    if (!localhost->aclk_state.claimed_id) {
         netdata_log_error("Internal error. Should not come here if not claimed");
         rrdhost_aclk_state_unlock(localhost);
         return 0;
@@ -254,7 +254,7 @@ char *aclk_generate_lwt(size_t *size) {
     };
 
     rrdhost_aclk_state_lock(localhost);
-    if (unlikely(!localhost->aclk_state.claimed_id)) {
+    if (!localhost->aclk_state.claimed_id) {
         netdata_log_error("Internal error. Should not come here if not claimed");
         rrdhost_aclk_state_unlock(localhost);
         return NULL;

--- a/aclk/aclk_util.c
+++ b/aclk/aclk_util.c
@@ -184,7 +184,7 @@ static void topic_generate_final(struct aclk_topic *t) {
         return;
 
     rrdhost_aclk_state_lock(localhost);
-    if (unlikely(!localhost->aclk_state.claimed_id)) {
+    if (!localhost->aclk_state.claimed_id) {
         netdata_log_error("This should never be called if agent not claimed");
         rrdhost_aclk_state_unlock(localhost);
         return;

--- a/cli/cli.c
+++ b/cli/cli.c
@@ -31,7 +31,7 @@ void fatal_int( const char *file __maybe_unused, const char *function __maybe_un
 void *callocz_int(size_t nmemb, size_t size, const char *file __maybe_unused, const char *function __maybe_unused, size_t line __maybe_unused)
 {
     void *p = calloc(nmemb, size);
-    if (unlikely(!p)) {
+    if (!p) {
         netdata_log_error("Cannot allocate %zu bytes of memory.", nmemb * size);
         exit(1);
     }
@@ -41,7 +41,7 @@ void *callocz_int(size_t nmemb, size_t size, const char *file __maybe_unused, co
 void *mallocz_int(size_t size, const char *file __maybe_unused, const char *function __maybe_unused, size_t line __maybe_unused)
 {
     void *p = malloc(size);
-    if (unlikely(!p)) {
+    if (!p) {
         netdata_log_error("Cannot allocate %zu bytes of memory.", size);
         exit(1);
     }
@@ -51,7 +51,7 @@ void *mallocz_int(size_t size, const char *file __maybe_unused, const char *func
 void *reallocz_int(void *ptr, size_t size, const char *file __maybe_unused, const char *function __maybe_unused, size_t line __maybe_unused)
 {
     void *p = realloc(ptr, size);
-    if (unlikely(!p)) {
+    if (!p) {
         netdata_log_error("Cannot allocate %zu bytes of memory.", size);
         exit(1);
     }
@@ -69,7 +69,7 @@ void freez(void *ptr) {
 
 void *mallocz(size_t size) {
     void *p = malloc(size);
-    if (unlikely(!p)) {
+    if (!p) {
         netdata_log_error("Cannot allocate %zu bytes of memory.", size);
         exit(1);
     }
@@ -78,7 +78,7 @@ void *mallocz(size_t size) {
 
 void *callocz(size_t nmemb, size_t size) {
     void *p = calloc(nmemb, size);
-    if (unlikely(!p)) {
+    if (!p) {
         netdata_log_error("Cannot allocate %zu bytes of memory.", nmemb * size);
         exit(1);
     }
@@ -87,7 +87,7 @@ void *callocz(size_t nmemb, size_t size) {
 
 void *reallocz(void *ptr, size_t size) {
     void *p = realloc(ptr, size);
-    if (unlikely(!p)) {
+    if (!p) {
         netdata_log_error("Cannot allocate %zu bytes of memory.", size);
         exit(1);
     }
@@ -96,12 +96,12 @@ void *reallocz(void *ptr, size_t size) {
 #endif
 
 int vsnprintfz(char *dst, size_t n, const char *fmt, va_list args) {
-    if(unlikely(!n)) return 0;
+    if(!n) return 0;
 
     int size = vsnprintf(dst, n, fmt, args);
     dst[n - 1] = '\0';
 
-    if (unlikely((size_t) size > n)) size = (int)n;
+    if ((size_t) size > n) size = (int)n;
 
     return size;
 }

--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -74,13 +74,13 @@ struct iface *read_proc_net_dev(const char *scope __maybe_unused, const char *pr
 #endif
 
     ff = procfile_open(filename, " \t,:|", PROCFILE_FLAG_DEFAULT);
-    if(unlikely(!ff)) {
+    if(!ff) {
         collector_error("Cannot open file '%s'", filename);
         return NULL;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff)) {
+    if(!ff) {
         collector_error("Cannot read file '%s'", filename);
         return NULL;
     }
@@ -88,7 +88,7 @@ struct iface *read_proc_net_dev(const char *scope __maybe_unused, const char *pr
     size_t lines = procfile_lines(ff), l;
     struct iface *root = NULL;
     for(l = 2; l < lines ;l++) {
-        if (unlikely(procfile_linewords(ff, l) < 1)) continue;
+        if (procfile_linewords(ff, l) < 1) continue;
 
         struct iface *t = callocz(1, sizeof(struct iface));
         t->device = strdupz(procfile_lineword(ff, l, 0));

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -591,7 +591,7 @@ void netdata_cgroup_ebpf_initialize_shm()
                                                                        PROT_READ | PROT_WRITE, MAP_SHARED,
                                                                        shm_fd_cgroup_ebpf, 0);
 
-    if (unlikely(MAP_FAILED == shm_cgroup_ebpf.header)) {
+    if (MAP_FAILED == shm_cgroup_ebpf.header) {
         shm_cgroup_ebpf.header = NULL;
         collector_error("Cannot map shared memory used between cgroup and eBPF, integration won't happen");
         goto end_init_shm;
@@ -983,19 +983,19 @@ static int k8s_get_container_first_proc_comm(const char *id, char *comm) {
     snprintfz(filename, FILENAME_MAX, "%s/%s/cgroup.procs", cgroup_cpuacct_base, id);
 
     ff = procfile_reopen(ff, filename, NULL, CGROUP_PROCFILE_FLAG);
-    if (unlikely(!ff)) {
+    if (!ff) {
         netdata_log_debug(D_CGROUP, "CGROUP: k8s_is_pause_container(): cannot open file '%s'.", filename);
         return 1;
     }
 
     ff = procfile_readall(ff);
-    if (unlikely(!ff)) {
+    if (!ff) {
         netdata_log_debug(D_CGROUP, "CGROUP: k8s_is_pause_container(): cannot read file '%s'.", filename);
         return 1;
     }
 
     unsigned long lines = procfile_lines(ff);
-    if (likely(lines < 2)) {
+    if (lines < 2) {
         return 1;
     }
 
@@ -1007,19 +1007,19 @@ static int k8s_get_container_first_proc_comm(const char *id, char *comm) {
     snprintfz(filename, FILENAME_MAX, "%s/proc/%s/comm", netdata_configured_host_prefix, pid);
 
     ff = procfile_reopen(ff, filename, NULL, PROCFILE_FLAG_DEFAULT);
-    if (unlikely(!ff)) {
+    if (!ff) {
         netdata_log_debug(D_CGROUP, "CGROUP: k8s_is_pause_container(): cannot open file '%s'.", filename);
         return 1;
     }
 
     ff = procfile_readall(ff);
-    if (unlikely(!ff)) {
+    if (!ff) {
         netdata_log_debug(D_CGROUP, "CGROUP: k8s_is_pause_container(): cannot read file '%s'.", filename);
         return 1;
     }
 
     lines = procfile_lines(ff);
-    if (unlikely(lines != 2)) {
+    if (lines != 2) {
         return 1;
     }
 
@@ -1052,7 +1052,7 @@ static int calc_cgroup_depth(const char *id) {
     int depth = 0;
     const char *s;
     for (s = id; *s; s++) {
-        depth += unlikely(*s == '/');
+        depth += *s == '/';
     }
     return depth;
 }
@@ -1063,16 +1063,16 @@ static int calc_cgroup_depth(const char *id) {
 static inline void cgroup_read_cpuacct_stat(struct cpuacct_stat *cp) {
     static procfile *ff = NULL;
 
-    if(likely(cp->filename)) {
+    if(cp->filename) {
         ff = procfile_reopen(ff, cp->filename, NULL, CGROUP_PROCFILE_FLAG);
-        if(unlikely(!ff)) {
+        if(!ff) {
             cp->updated = 0;
             cgroups_check = 1;
             return;
         }
 
         ff = procfile_readall(ff);
-        if(unlikely(!ff)) {
+        if(!ff) {
             cp->updated = 0;
             cgroups_check = 1;
             return;
@@ -1080,7 +1080,7 @@ static inline void cgroup_read_cpuacct_stat(struct cpuacct_stat *cp) {
 
         unsigned long i, lines = procfile_lines(ff);
 
-        if(unlikely(lines < 1)) {
+        if(lines < 1) {
             collector_error("CGROUP: file '%s' should have 1+ lines.", cp->filename);
             cp->updated = 0;
             return;
@@ -1090,43 +1090,43 @@ static inline void cgroup_read_cpuacct_stat(struct cpuacct_stat *cp) {
             char *s = procfile_lineword(ff, i, 0);
             uint32_t hash = simple_hash(s);
 
-            if(unlikely(hash == user_hash && !strcmp(s, "user")))
+            if(hash == user_hash && !strcmp(s, "user"))
                 cp->user = str2ull(procfile_lineword(ff, i, 1), NULL);
 
-            else if(unlikely(hash == system_hash && !strcmp(s, "system")))
+            else if(hash == system_hash && !strcmp(s, "system"))
                 cp->system = str2ull(procfile_lineword(ff, i, 1), NULL);
         }
 
         cp->updated = 1;
 
-        if(unlikely(cp->enabled == CONFIG_BOOLEAN_AUTO &&
-                    (cp->user || cp->system || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
+        if(cp->enabled == CONFIG_BOOLEAN_AUTO &&
+                    (cp->user || cp->system || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))
             cp->enabled = CONFIG_BOOLEAN_YES;
     }
 }
 
 static inline void cgroup_read_cpuacct_cpu_stat(struct cpuacct_cpu_throttling *cp) {
-    if (unlikely(!cp->filename)) {
+    if (!cp->filename) {
         return;
     }
 
     static procfile *ff = NULL;
     ff = procfile_reopen(ff, cp->filename, NULL, CGROUP_PROCFILE_FLAG);
-    if (unlikely(!ff)) {
+    if (!ff) {
         cp->updated = 0;
         cgroups_check = 1;
         return;
     }
 
     ff = procfile_readall(ff);
-    if (unlikely(!ff)) {
+    if (!ff) {
         cp->updated = 0;
         cgroups_check = 1;
         return;
     }
 
     unsigned long lines = procfile_lines(ff);
-    if (unlikely(lines < 3)) {
+    if (lines < 3) {
         collector_error("CGROUP: file '%s' should have 3 lines.", cp->filename);
         cp->updated = 0;
         return;
@@ -1139,11 +1139,11 @@ static inline void cgroup_read_cpuacct_cpu_stat(struct cpuacct_cpu_throttling *c
         char *s = procfile_lineword(ff, i, 0);
         uint32_t hash = simple_hash(s);
 
-        if (unlikely(hash == nr_periods_hash && !strcmp(s, "nr_periods"))) {
+        if (hash == nr_periods_hash && !strcmp(s, "nr_periods")) {
             cp->nr_periods = str2ull(procfile_lineword(ff, i, 1), NULL);
-        } else if (unlikely(hash == nr_throttled_hash && !strcmp(s, "nr_throttled"))) {
+        } else if (hash == nr_throttled_hash && !strcmp(s, "nr_throttled")) {
             cp->nr_throttled = str2ull(procfile_lineword(ff, i, 1), NULL);
-        } else if (unlikely(hash == throttled_time_hash && !strcmp(s, "throttled_time"))) {
+        } else if (hash == throttled_time_hash && !strcmp(s, "throttled_time")) {
             cp->throttled_time = str2ull(procfile_lineword(ff, i, 1), NULL);
         }
     }
@@ -1152,10 +1152,10 @@ static inline void cgroup_read_cpuacct_cpu_stat(struct cpuacct_cpu_throttling *c
 
     cp->updated = 1;
 
-    if (unlikely(cp->enabled == CONFIG_BOOLEAN_AUTO)) {
-        if (likely(
+    if (cp->enabled == CONFIG_BOOLEAN_AUTO) {
+        if (
                 cp->nr_periods || cp->nr_throttled || cp->throttled_time ||
-                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)) {
+                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES) {
             cp->enabled = CONFIG_BOOLEAN_YES;
         }
     }
@@ -1163,19 +1163,19 @@ static inline void cgroup_read_cpuacct_cpu_stat(struct cpuacct_cpu_throttling *c
 
 static inline void cgroup2_read_cpuacct_cpu_stat(struct cpuacct_stat *cp, struct cpuacct_cpu_throttling *cpt) {
     static procfile *ff = NULL;
-    if (unlikely(!cp->filename)) {
+    if (!cp->filename) {
         return;
     }
 
     ff = procfile_reopen(ff, cp->filename, NULL, CGROUP_PROCFILE_FLAG);
-    if (unlikely(!ff)) {
+    if (!ff) {
         cp->updated = 0;
         cgroups_check = 1;
         return;
     }
 
     ff = procfile_readall(ff);
-    if (unlikely(!ff)) {
+    if (!ff) {
         cp->updated = 0;
         cgroups_check = 1;
         return;
@@ -1183,7 +1183,7 @@ static inline void cgroup2_read_cpuacct_cpu_stat(struct cpuacct_stat *cp, struct
 
     unsigned long lines = procfile_lines(ff);
 
-    if (unlikely(lines < 3)) {
+    if (lines < 3) {
         collector_error("CGROUP: file '%s' should have at least 3 lines.", cp->filename);
         cp->updated = 0;
         return;
@@ -1196,15 +1196,15 @@ static inline void cgroup2_read_cpuacct_cpu_stat(struct cpuacct_stat *cp, struct
         char *s = procfile_lineword(ff, i, 0);
         uint32_t hash = simple_hash(s);
 
-        if (unlikely(hash == user_usec_hash && !strcmp(s, "user_usec"))) {
+        if (hash == user_usec_hash && !strcmp(s, "user_usec")) {
             cp->user = str2ull(procfile_lineword(ff, i, 1), NULL);
-        } else if (unlikely(hash == system_usec_hash && !strcmp(s, "system_usec"))) {
+        } else if (hash == system_usec_hash && !strcmp(s, "system_usec")) {
             cp->system = str2ull(procfile_lineword(ff, i, 1), NULL);
-        } else if (unlikely(hash == nr_periods_hash && !strcmp(s, "nr_periods"))) {
+        } else if (hash == nr_periods_hash && !strcmp(s, "nr_periods")) {
             cpt->nr_periods = str2ull(procfile_lineword(ff, i, 1), NULL);
-        } else if (unlikely(hash == nr_throttled_hash && !strcmp(s, "nr_throttled"))) {
+        } else if (hash == nr_throttled_hash && !strcmp(s, "nr_throttled")) {
             cpt->nr_throttled = str2ull(procfile_lineword(ff, i, 1), NULL);
-        } else if (unlikely(hash == throttled_usec_hash && !strcmp(s, "throttled_usec"))) {
+        } else if (hash == throttled_usec_hash && !strcmp(s, "throttled_usec")) {
             cpt->throttled_time = str2ull(procfile_lineword(ff, i, 1), NULL) * 1000; // usec -> ns
         }
     }
@@ -1214,33 +1214,33 @@ static inline void cgroup2_read_cpuacct_cpu_stat(struct cpuacct_stat *cp, struct
     cp->updated = 1;
     cpt->updated = 1;
 
-    if (unlikely(cp->enabled == CONFIG_BOOLEAN_AUTO)) {
-        if (likely(cp->user || cp->system || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)) {
+    if (cp->enabled == CONFIG_BOOLEAN_AUTO) {
+        if (cp->user || cp->system || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES) {
             cp->enabled = CONFIG_BOOLEAN_YES;
         }
     }
-    if (unlikely(cpt->enabled == CONFIG_BOOLEAN_AUTO)) {
-        if (likely(
+    if (cpt->enabled == CONFIG_BOOLEAN_AUTO) {
+        if (
                 cpt->nr_periods || cpt->nr_throttled || cpt->throttled_time ||
-                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)) {
+                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES) {
             cpt->enabled = CONFIG_BOOLEAN_YES;
         }
     }
 }
 
 static inline void cgroup_read_cpuacct_cpu_shares(struct cpuacct_cpu_shares *cp) {
-    if (unlikely(!cp->filename)) {
+    if (!cp->filename) {
         return;
     }
 
-    if (unlikely(read_single_number_file(cp->filename, &cp->shares))) {
+    if (read_single_number_file(cp->filename, &cp->shares)) {
         cp->updated = 0;
         cgroups_check = 1;
         return;
     }
 
     cp->updated = 1;
-    if (unlikely((cp->enabled == CONFIG_BOOLEAN_AUTO)) &&
+    if ((cp->enabled == CONFIG_BOOLEAN_AUTO) &&
         (cp->shares || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)) {
         cp->enabled = CONFIG_BOOLEAN_YES;
     }
@@ -1249,29 +1249,29 @@ static inline void cgroup_read_cpuacct_cpu_shares(struct cpuacct_cpu_shares *cp)
 static inline void cgroup_read_cpuacct_usage(struct cpuacct_usage *ca) {
     static procfile *ff = NULL;
 
-    if(likely(ca->filename)) {
+    if(ca->filename) {
         ff = procfile_reopen(ff, ca->filename, NULL, CGROUP_PROCFILE_FLAG);
-        if(unlikely(!ff)) {
+        if(!ff) {
             ca->updated = 0;
             cgroups_check = 1;
             return;
         }
 
         ff = procfile_readall(ff);
-        if(unlikely(!ff)) {
+        if(!ff) {
             ca->updated = 0;
             cgroups_check = 1;
             return;
         }
 
-        if(unlikely(procfile_lines(ff) < 1)) {
+        if(procfile_lines(ff) < 1) {
             collector_error("CGROUP: file '%s' should have 1+ lines but has %zu.", ca->filename, procfile_lines(ff));
             ca->updated = 0;
             return;
         }
 
         unsigned long i = procfile_linewords(ff, 0);
-        if(unlikely(i == 0)) {
+        if(i == 0) {
             ca->updated = 0;
             return;
         }
@@ -1283,7 +1283,7 @@ static inline void cgroup_read_cpuacct_usage(struct cpuacct_usage *ca) {
             else break;
         }
 
-        if(unlikely(i != ca->cpus)) {
+        if(i != ca->cpus) {
             freez(ca->cpu_percpu);
             ca->cpu_percpu = mallocz(sizeof(unsigned long long) * i);
             ca->cpus = (unsigned int)i;
@@ -1298,30 +1298,30 @@ static inline void cgroup_read_cpuacct_usage(struct cpuacct_usage *ca) {
 
         ca->updated = 1;
 
-        if(unlikely(ca->enabled == CONFIG_BOOLEAN_AUTO &&
-                    (total || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
+        if(ca->enabled == CONFIG_BOOLEAN_AUTO &&
+                    (total || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))
             ca->enabled = CONFIG_BOOLEAN_YES;
     }
 }
 
 static inline void cgroup_read_blkio(struct blkio *io) {
-    if(unlikely(io->enabled == CONFIG_BOOLEAN_AUTO && io->delay_counter > 0)) {
+    if(io->enabled == CONFIG_BOOLEAN_AUTO && io->delay_counter > 0) {
         io->delay_counter--;
         return;
     }
 
-    if(likely(io->filename)) {
+    if(io->filename) {
         static procfile *ff = NULL;
 
         ff = procfile_reopen(ff, io->filename, NULL, CGROUP_PROCFILE_FLAG);
-        if(unlikely(!ff)) {
+        if(!ff) {
             io->updated = 0;
             cgroups_check = 1;
             return;
         }
 
         ff = procfile_readall(ff);
-        if(unlikely(!ff)) {
+        if(!ff) {
             io->updated = 0;
             cgroups_check = 1;
             return;
@@ -1329,7 +1329,7 @@ static inline void cgroup_read_blkio(struct blkio *io) {
 
         unsigned long i, lines = procfile_lines(ff);
 
-        if(unlikely(lines < 1)) {
+        if(lines < 1) {
             collector_error("CGROUP: file '%s' should have 1+ lines.", io->filename);
             io->updated = 0;
             return;
@@ -1347,28 +1347,28 @@ static inline void cgroup_read_blkio(struct blkio *io) {
             char *s = procfile_lineword(ff, i, 1);
             uint32_t hash = simple_hash(s);
 
-            if(unlikely(hash == Read_hash && !strcmp(s, "Read")))
+            if(hash == Read_hash && !strcmp(s, "Read"))
                 io->Read += str2ull(procfile_lineword(ff, i, 2), NULL);
 
-            else if(unlikely(hash == Write_hash && !strcmp(s, "Write")))
+            else if(hash == Write_hash && !strcmp(s, "Write"))
                 io->Write += str2ull(procfile_lineword(ff, i, 2), NULL);
 
 /*
-            else if(unlikely(hash == Sync_hash && !strcmp(s, "Sync")))
+            else if(hash == Sync_hash && !strcmp(s, "Sync"))
                 io->Sync += str2ull(procfile_lineword(ff, i, 2));
 
-            else if(unlikely(hash == Async_hash && !strcmp(s, "Async")))
+            else if(hash == Async_hash && !strcmp(s, "Async"))
                 io->Async += str2ull(procfile_lineword(ff, i, 2));
 
-            else if(unlikely(hash == Total_hash && !strcmp(s, "Total")))
+            else if(hash == Total_hash && !strcmp(s, "Total"))
                 io->Total += str2ull(procfile_lineword(ff, i, 2));
 */
         }
 
         io->updated = 1;
 
-        if(unlikely(io->enabled == CONFIG_BOOLEAN_AUTO)) {
-            if(unlikely(io->Read || io->Write || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))
+        if(io->enabled == CONFIG_BOOLEAN_AUTO) {
+            if(io->Read || io->Write || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)
                 io->enabled = CONFIG_BOOLEAN_YES;
             else
                 io->delay_counter = cgroup_recheck_zero_blkio_every_iterations;
@@ -1377,23 +1377,23 @@ static inline void cgroup_read_blkio(struct blkio *io) {
 }
 
 static inline void cgroup2_read_blkio(struct blkio *io, unsigned int word_offset) {
-    if(unlikely(io->enabled == CONFIG_BOOLEAN_AUTO && io->delay_counter > 0)) {
+    if(io->enabled == CONFIG_BOOLEAN_AUTO && io->delay_counter > 0) {
             io->delay_counter--;
             return;
         }
 
-        if(likely(io->filename)) {
+        if(io->filename) {
             static procfile *ff = NULL;
 
             ff = procfile_reopen(ff, io->filename, NULL, CGROUP_PROCFILE_FLAG);
-            if(unlikely(!ff)) {
+            if(!ff) {
                 io->updated = 0;
                 cgroups_check = 1;
                 return;
             }
 
             ff = procfile_readall(ff);
-            if(unlikely(!ff)) {
+            if(!ff) {
                 io->updated = 0;
                 cgroups_check = 1;
                 return;
@@ -1401,7 +1401,7 @@ static inline void cgroup2_read_blkio(struct blkio *io, unsigned int word_offset
 
             unsigned long i, lines = procfile_lines(ff);
 
-            if (unlikely(lines < 1)) {
+            if (lines < 1) {
                 collector_error("CGROUP: file '%s' should have 1+ lines.", io->filename);
                 io->updated = 0;
                 return;
@@ -1417,8 +1417,8 @@ static inline void cgroup2_read_blkio(struct blkio *io, unsigned int word_offset
 
             io->updated = 1;
 
-            if(unlikely(io->enabled == CONFIG_BOOLEAN_AUTO)) {
-                if(unlikely(io->Read || io->Write || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))
+            if(io->enabled == CONFIG_BOOLEAN_AUTO) {
+                if(io->Read || io->Write || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)
                     io->enabled = CONFIG_BOOLEAN_YES;
                 else
                     io->delay_counter = cgroup_recheck_zero_blkio_every_iterations;
@@ -1429,16 +1429,16 @@ static inline void cgroup2_read_blkio(struct blkio *io, unsigned int word_offset
 static inline void cgroup2_read_pressure(struct pressure *res) {
     static procfile *ff = NULL;
 
-    if (likely(res->filename)) {
+    if (res->filename) {
         ff = procfile_reopen(ff, res->filename, " =", CGROUP_PROCFILE_FLAG);
-        if (unlikely(!ff)) {
+        if (!ff) {
             res->updated = 0;
             cgroups_check = 1;
             return;
         }
 
         ff = procfile_readall(ff);
-        if (unlikely(!ff)) {
+        if (!ff) {
             res->updated = 0;
             cgroups_check = 1;
             return;
@@ -1465,7 +1465,7 @@ static inline void cgroup2_read_pressure(struct pressure *res) {
 
         res->updated = 1;
 
-        if (unlikely(res->some.enabled == CONFIG_BOOLEAN_AUTO)) {
+        if (res->some.enabled == CONFIG_BOOLEAN_AUTO) {
             res->some.enabled = CONFIG_BOOLEAN_YES;
             if (lines > 2) {
                 res->full.enabled = CONFIG_BOOLEAN_YES;
@@ -1480,21 +1480,21 @@ static inline void cgroup_read_memory(struct memory *mem, char parent_cg_is_unif
     static procfile *ff = NULL;
 
     // read detailed ram usage
-    if(likely(mem->filename_detailed)) {
-        if(unlikely(mem->enabled_detailed == CONFIG_BOOLEAN_AUTO && mem->delay_counter_detailed > 0)) {
+    if(mem->filename_detailed) {
+        if(mem->enabled_detailed == CONFIG_BOOLEAN_AUTO && mem->delay_counter_detailed > 0) {
             mem->delay_counter_detailed--;
             goto memory_next;
         }
 
         ff = procfile_reopen(ff, mem->filename_detailed, NULL, CGROUP_PROCFILE_FLAG);
-        if(unlikely(!ff)) {
+        if(!ff) {
             mem->updated_detailed = 0;
             cgroups_check = 1;
             goto memory_next;
         }
 
         ff = procfile_readall(ff);
-        if(unlikely(!ff)) {
+        if(!ff) {
             mem->updated_detailed = 0;
             cgroups_check = 1;
             goto memory_next;
@@ -1502,14 +1502,14 @@ static inline void cgroup_read_memory(struct memory *mem, char parent_cg_is_unif
 
         unsigned long i, lines = procfile_lines(ff);
 
-        if(unlikely(lines < 1)) {
+        if(lines < 1) {
             collector_error("CGROUP: file '%s' should have 1+ lines.", mem->filename_detailed);
             mem->updated_detailed = 0;
             goto memory_next;
         }
 
 
-        if(unlikely(!mem->arl_base)) {
+        if(!mem->arl_base) {
             if(parent_cg_is_unified == 0){
                 mem->arl_base = arl_create("cgroup/memory", NULL, 60);
 
@@ -1550,17 +1550,17 @@ static inline void cgroup_read_memory(struct memory *mem, char parent_cg_is_unif
                     procfile_lineword(ff, i, 1))) break;
         }
 
-        if(unlikely(mem->arl_dirty->flags & ARL_ENTRY_FLAG_FOUND))
+        if(mem->arl_dirty->flags & ARL_ENTRY_FLAG_FOUND)
             mem->detailed_has_dirty = 1;
 
-        if(unlikely(parent_cg_is_unified == 0 && mem->arl_swap->flags & ARL_ENTRY_FLAG_FOUND))
+        if(parent_cg_is_unified == 0 && mem->arl_swap->flags & ARL_ENTRY_FLAG_FOUND)
             mem->detailed_has_swap = 1;
 
         // fprintf(stderr, "READ: '%s', cache: %llu, rss: %llu, rss_huge: %llu, mapped_file: %llu, writeback: %llu, dirty: %llu, swap: %llu, pgpgin: %llu, pgpgout: %llu, pgfault: %llu, pgmajfault: %llu, inactive_anon: %llu, active_anon: %llu, inactive_file: %llu, active_file: %llu, unevictable: %llu, hierarchical_memory_limit: %llu, total_cache: %llu, total_rss: %llu, total_rss_huge: %llu, total_mapped_file: %llu, total_writeback: %llu, total_dirty: %llu, total_swap: %llu, total_pgpgin: %llu, total_pgpgout: %llu, total_pgfault: %llu, total_pgmajfault: %llu, total_inactive_anon: %llu, total_active_anon: %llu, total_inactive_file: %llu, total_active_file: %llu, total_unevictable: %llu\n", mem->filename, mem->cache, mem->rss, mem->rss_huge, mem->mapped_file, mem->writeback, mem->dirty, mem->swap, mem->pgpgin, mem->pgpgout, mem->pgfault, mem->pgmajfault, mem->inactive_anon, mem->active_anon, mem->inactive_file, mem->active_file, mem->unevictable, mem->hierarchical_memory_limit, mem->total_cache, mem->total_rss, mem->total_rss_huge, mem->total_mapped_file, mem->total_writeback, mem->total_dirty, mem->total_swap, mem->total_pgpgin, mem->total_pgpgout, mem->total_pgfault, mem->total_pgmajfault, mem->total_inactive_anon, mem->total_active_anon, mem->total_inactive_file, mem->total_active_file, mem->total_unevictable);
 
         mem->updated_detailed = 1;
 
-        if(unlikely(mem->enabled_detailed == CONFIG_BOOLEAN_AUTO)) {
+        if(mem->enabled_detailed == CONFIG_BOOLEAN_AUTO) {
             if(( (!parent_cg_is_unified) && ( mem->total_cache || mem->total_dirty || mem->total_rss || mem->total_rss_huge || mem->total_mapped_file || mem->total_writeback
                     || mem->total_swap || mem->total_pgpgin || mem->total_pgpgout || mem->total_pgfault || mem->total_pgmajfault || mem->total_inactive_file))
                || (parent_cg_is_unified && ( mem->anon || mem->total_dirty || mem->kernel_stack || mem->slab || mem->sock || mem->total_writeback
@@ -1575,36 +1575,36 @@ static inline void cgroup_read_memory(struct memory *mem, char parent_cg_is_unif
 memory_next:
 
     // read usage_in_bytes
-    if(likely(mem->filename_usage_in_bytes)) {
+    if(mem->filename_usage_in_bytes) {
         mem->updated_usage_in_bytes = !read_single_number_file(mem->filename_usage_in_bytes, &mem->usage_in_bytes);
-        if(unlikely(mem->updated_usage_in_bytes && mem->enabled_usage_in_bytes == CONFIG_BOOLEAN_AUTO &&
-                    (mem->usage_in_bytes || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
+        if(mem->updated_usage_in_bytes && mem->enabled_usage_in_bytes == CONFIG_BOOLEAN_AUTO &&
+                    (mem->usage_in_bytes || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))
             mem->enabled_usage_in_bytes = CONFIG_BOOLEAN_YES;
     }
 
-    if (likely(mem->updated_usage_in_bytes && mem->updated_detailed)) {
+    if (mem->updated_usage_in_bytes && mem->updated_detailed) {
         mem->usage_in_bytes =
             (mem->usage_in_bytes > mem->total_inactive_file) ? (mem->usage_in_bytes - mem->total_inactive_file) : 0;
     }
 
     // read msw_usage_in_bytes
-    if(likely(mem->filename_msw_usage_in_bytes)) {
+    if(mem->filename_msw_usage_in_bytes) {
         mem->updated_msw_usage_in_bytes = !read_single_number_file(mem->filename_msw_usage_in_bytes, &mem->msw_usage_in_bytes);
-        if(unlikely(mem->updated_msw_usage_in_bytes && mem->enabled_msw_usage_in_bytes == CONFIG_BOOLEAN_AUTO &&
-                    (mem->msw_usage_in_bytes || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
+        if(mem->updated_msw_usage_in_bytes && mem->enabled_msw_usage_in_bytes == CONFIG_BOOLEAN_AUTO &&
+                    (mem->msw_usage_in_bytes || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))
             mem->enabled_msw_usage_in_bytes = CONFIG_BOOLEAN_YES;
     }
 
     // read failcnt
-    if(likely(mem->filename_failcnt)) {
-        if(unlikely(mem->enabled_failcnt == CONFIG_BOOLEAN_AUTO && mem->delay_counter_failcnt > 0)) {
+    if(mem->filename_failcnt) {
+        if(mem->enabled_failcnt == CONFIG_BOOLEAN_AUTO && mem->delay_counter_failcnt > 0) {
             mem->updated_failcnt = 0;
             mem->delay_counter_failcnt--;
         }
         else {
             mem->updated_failcnt = !read_single_number_file(mem->filename_failcnt, &mem->failcnt);
-            if(unlikely(mem->updated_failcnt && mem->enabled_failcnt == CONFIG_BOOLEAN_AUTO)) {
-                if(unlikely(mem->failcnt || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))
+            if(mem->updated_failcnt && mem->enabled_failcnt == CONFIG_BOOLEAN_AUTO) {
+                if(mem->failcnt || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)
                     mem->enabled_failcnt = CONFIG_BOOLEAN_YES;
                 else
                     mem->delay_counter_failcnt = cgroup_recheck_zero_mem_failcnt_every_iterations;
@@ -1930,22 +1930,22 @@ static void is_cgroup_procs_exist(netdata_ebpf_cgroup_shm_body_t *out, char *id)
     struct stat buf;
 
     snprintfz(out->path, FILENAME_MAX, "%s%s/cgroup.procs", cgroup_cpuset_base, id);
-    if (likely(stat(out->path, &buf) == 0)) {
+    if (stat(out->path, &buf) == 0) {
         return;
     }
 
     snprintfz(out->path, FILENAME_MAX, "%s%s/cgroup.procs", cgroup_blkio_base, id);
-    if (likely(stat(out->path, &buf) == 0)) {
+    if (stat(out->path, &buf) == 0) {
         return;
     }
 
     snprintfz(out->path, FILENAME_MAX, "%s%s/cgroup.procs", cgroup_memory_base, id);
-    if (likely(stat(out->path, &buf) == 0)) {
+    if (stat(out->path, &buf) == 0) {
         return;
     }
 
     snprintfz(out->path, FILENAME_MAX, "%s%s/cgroup.procs", cgroup_devices_base, id);
-    if (likely(stat(out->path, &buf) == 0)) {
+    if (stat(out->path, &buf) == 0) {
         return;
     }
 
@@ -1962,7 +1962,7 @@ static inline void convert_cgroup_to_systemd_service(struct cgroup *cg) {
     // skip to the last slash
     size_t len = strlen(s);
     while (len--) {
-        if (unlikely(s[len] == '/')) {
+        if (s[len] == '/') {
             break;
         }
     }
@@ -1973,7 +1973,7 @@ static inline void convert_cgroup_to_systemd_service(struct cgroup *cg) {
     // remove extension
     len = strlen(s);
     while (len--) {
-        if (unlikely(s[len] == '.')) {
+        if (s[len] == '.') {
             break;
         }
     }
@@ -2125,7 +2125,7 @@ static inline void discovery_update_filenames() {
     struct cgroup *cg;
     struct stat buf;
     for(cg = discovered_cgroup_root; cg ; cg = cg->discovered_next) {
-        if(unlikely(!cg->available || !cg->enabled || cg->pending_renames))
+        if(!cg->available || !cg->enabled || cg->pending_renames)
             continue;
 
         netdata_log_debug(D_CGROUP, "checking paths for cgroup '%s'", cg->id);
@@ -2134,9 +2134,9 @@ static inline void discovery_update_filenames() {
         // and update the filenames they read
         char filename[FILENAME_MAX + 1];
         if(!cgroup_use_unified_cgroups) {
-            if(unlikely(cgroup_enable_cpuacct_stat && !cg->cpuacct_stat.filename)) {
+            if(cgroup_enable_cpuacct_stat && !cg->cpuacct_stat.filename) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/cpuacct.stat", cgroup_cpuacct_base, cg->id);
-                if(likely(stat(filename, &buf) != -1)) {
+                if(stat(filename, &buf) != -1) {
                     cg->cpuacct_stat.filename = strdupz(filename);
                     cg->cpuacct_stat.enabled = cgroup_enable_cpuacct_stat;
                     snprintfz(filename, FILENAME_MAX, "%s%s/cpuset.cpus", cgroup_cpuset_base, cg->id);
@@ -2151,9 +2151,9 @@ static inline void discovery_update_filenames() {
                     netdata_log_debug(D_CGROUP, "cpuacct.stat file for cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
 
-            if(unlikely(cgroup_enable_cpuacct_usage && !cg->cpuacct_usage.filename && !is_cgroup_systemd_service(cg))) {
+            if(cgroup_enable_cpuacct_usage && !cg->cpuacct_usage.filename && !is_cgroup_systemd_service(cg)) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/cpuacct.usage_percpu", cgroup_cpuacct_base, cg->id);
-                if(likely(stat(filename, &buf) != -1)) {
+                if(stat(filename, &buf) != -1) {
                     cg->cpuacct_usage.filename = strdupz(filename);
                     cg->cpuacct_usage.enabled = cgroup_enable_cpuacct_usage;
                     netdata_log_debug(D_CGROUP, "cpuacct.usage_percpu filename for cgroup '%s': '%s'", cg->id, cg->cpuacct_usage.filename);
@@ -2161,9 +2161,9 @@ static inline void discovery_update_filenames() {
                 else
                     netdata_log_debug(D_CGROUP, "cpuacct.usage_percpu file for cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
-            if(unlikely(cgroup_enable_cpuacct_cpu_throttling && !cg->cpuacct_cpu_throttling.filename && !is_cgroup_systemd_service(cg))) {
+            if(cgroup_enable_cpuacct_cpu_throttling && !cg->cpuacct_cpu_throttling.filename && !is_cgroup_systemd_service(cg)) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/cpu.stat", cgroup_cpuacct_base, cg->id);
-                if(likely(stat(filename, &buf) != -1)) {
+                if(stat(filename, &buf) != -1) {
                     cg->cpuacct_cpu_throttling.filename = strdupz(filename);
                     cg->cpuacct_cpu_throttling.enabled = cgroup_enable_cpuacct_cpu_throttling;
                     netdata_log_debug(D_CGROUP, "cpu.stat filename for cgroup '%s': '%s'", cg->id, cg->cpuacct_cpu_throttling.filename);
@@ -2171,11 +2171,11 @@ static inline void discovery_update_filenames() {
                 else
                     netdata_log_debug(D_CGROUP, "cpu.stat file for cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
-            if (unlikely(
+            if (
                     cgroup_enable_cpuacct_cpu_shares && !cg->cpuacct_cpu_shares.filename &&
-                    !is_cgroup_systemd_service(cg))) {
+                    !is_cgroup_systemd_service(cg)) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/cpu.shares", cgroup_cpuacct_base, cg->id);
-                if (likely(stat(filename, &buf) != -1)) {
+                if (stat(filename, &buf) != -1) {
                     cg->cpuacct_cpu_shares.filename = strdupz(filename);
                     cg->cpuacct_cpu_shares.enabled = cgroup_enable_cpuacct_cpu_shares;
                     netdata_log_debug(
@@ -2184,9 +2184,9 @@ static inline void discovery_update_filenames() {
                     netdata_log_debug(D_CGROUP, "cpu.shares file for cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
 
-            if(unlikely((cgroup_enable_detailed_memory || cgroup_used_memory) && !cg->memory.filename_detailed && (cgroup_used_memory || cgroup_enable_systemd_services_detailed_memory || !is_cgroup_systemd_service(cg)))) {
+            if((cgroup_enable_detailed_memory || cgroup_used_memory) && !cg->memory.filename_detailed && (cgroup_used_memory || cgroup_enable_systemd_services_detailed_memory || !is_cgroup_systemd_service(cg))) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/memory.stat", cgroup_memory_base, cg->id);
-                if(likely(stat(filename, &buf) != -1)) {
+                if(stat(filename, &buf) != -1) {
                     cg->memory.filename_detailed = strdupz(filename);
                     cg->memory.enabled_detailed = (cgroup_enable_detailed_memory == CONFIG_BOOLEAN_YES)?CONFIG_BOOLEAN_YES:CONFIG_BOOLEAN_AUTO;
                     netdata_log_debug(D_CGROUP, "memory.stat filename for cgroup '%s': '%s'", cg->id, cg->memory.filename_detailed);
@@ -2195,9 +2195,9 @@ static inline void discovery_update_filenames() {
                     netdata_log_debug(D_CGROUP, "memory.stat file for cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
 
-            if(unlikely(cgroup_enable_memory && !cg->memory.filename_usage_in_bytes)) {
+            if(cgroup_enable_memory && !cg->memory.filename_usage_in_bytes) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/memory.usage_in_bytes", cgroup_memory_base, cg->id);
-                if(likely(stat(filename, &buf) != -1)) {
+                if(stat(filename, &buf) != -1) {
                     cg->memory.filename_usage_in_bytes = strdupz(filename);
                     cg->memory.enabled_usage_in_bytes = cgroup_enable_memory;
                     netdata_log_debug(D_CGROUP, "memory.usage_in_bytes filename for cgroup '%s': '%s'", cg->id, cg->memory.filename_usage_in_bytes);
@@ -2208,9 +2208,9 @@ static inline void discovery_update_filenames() {
                     netdata_log_debug(D_CGROUP, "memory.usage_in_bytes file for cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
 
-            if(unlikely(cgroup_enable_swap && !cg->memory.filename_msw_usage_in_bytes)) {
+            if(cgroup_enable_swap && !cg->memory.filename_msw_usage_in_bytes) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/memory.memsw.usage_in_bytes", cgroup_memory_base, cg->id);
-                if(likely(stat(filename, &buf) != -1)) {
+                if(stat(filename, &buf) != -1) {
                     cg->memory.filename_msw_usage_in_bytes = strdupz(filename);
                     cg->memory.enabled_msw_usage_in_bytes = cgroup_enable_swap;
                     snprintfz(filename, FILENAME_MAX, "%s%s/memory.memsw.limit_in_bytes", cgroup_memory_base, cg->id);
@@ -2221,9 +2221,9 @@ static inline void discovery_update_filenames() {
                     netdata_log_debug(D_CGROUP, "memory.msw_usage_in_bytes file for cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
 
-            if(unlikely(cgroup_enable_memory_failcnt && !cg->memory.filename_failcnt)) {
+            if(cgroup_enable_memory_failcnt && !cg->memory.filename_failcnt) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/memory.failcnt", cgroup_memory_base, cg->id);
-                if(likely(stat(filename, &buf) != -1)) {
+                if(stat(filename, &buf) != -1) {
                     cg->memory.filename_failcnt = strdupz(filename);
                     cg->memory.enabled_failcnt = cgroup_enable_memory_failcnt;
                     netdata_log_debug(D_CGROUP, "memory.failcnt filename for cgroup '%s': '%s'", cg->id, cg->memory.filename_failcnt);
@@ -2232,16 +2232,16 @@ static inline void discovery_update_filenames() {
                     netdata_log_debug(D_CGROUP, "memory.failcnt file for cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
 
-            if(unlikely(cgroup_enable_blkio_io && !cg->io_service_bytes.filename)) {
+            if(cgroup_enable_blkio_io && !cg->io_service_bytes.filename) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_service_bytes_recursive", cgroup_blkio_base, cg->id);
-                if (unlikely(stat(filename, &buf) != -1)) {
+                if (stat(filename, &buf) != -1) {
                     cg->io_service_bytes.filename = strdupz(filename);
                     cg->io_service_bytes.enabled = cgroup_enable_blkio_io;
                     netdata_log_debug(D_CGROUP, "blkio.io_service_bytes_recursive filename for cgroup '%s': '%s'", cg->id, cg->io_service_bytes.filename);
                 } else {
                     netdata_log_debug(D_CGROUP, "blkio.io_service_bytes_recursive file for cgroup '%s': '%s' does not exist.", cg->id, filename);
                     snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_service_bytes", cgroup_blkio_base, cg->id);
-                    if (likely(stat(filename, &buf) != -1)) {
+                    if (stat(filename, &buf) != -1) {
                         cg->io_service_bytes.filename = strdupz(filename);
                         cg->io_service_bytes.enabled = cgroup_enable_blkio_io;
                         netdata_log_debug(D_CGROUP, "blkio.io_service_bytes filename for cgroup '%s': '%s'", cg->id, cg->io_service_bytes.filename);
@@ -2251,16 +2251,16 @@ static inline void discovery_update_filenames() {
                 }
             }
 
-            if (unlikely(cgroup_enable_blkio_ops && !cg->io_serviced.filename)) {
+            if (cgroup_enable_blkio_ops && !cg->io_serviced.filename) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_serviced_recursive", cgroup_blkio_base, cg->id);
-                if (unlikely(stat(filename, &buf) != -1)) {
+                if (stat(filename, &buf) != -1) {
                     cg->io_serviced.filename = strdupz(filename);
                     cg->io_serviced.enabled = cgroup_enable_blkio_ops;
                     netdata_log_debug(D_CGROUP, "blkio.io_serviced_recursive filename for cgroup '%s': '%s'", cg->id, cg->io_serviced.filename);
                 } else {
                     netdata_log_debug(D_CGROUP, "blkio.io_serviced_recursive file for cgroup '%s': '%s' does not exist.", cg->id, filename);
                     snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_serviced", cgroup_blkio_base, cg->id);
-                    if (likely(stat(filename, &buf) != -1)) {
+                    if (stat(filename, &buf) != -1) {
                         cg->io_serviced.filename = strdupz(filename);
                         cg->io_serviced.enabled = cgroup_enable_blkio_ops;
                         netdata_log_debug(D_CGROUP, "blkio.io_serviced filename for cgroup '%s': '%s'", cg->id, cg->io_serviced.filename);
@@ -2270,9 +2270,9 @@ static inline void discovery_update_filenames() {
                 }
             }
 
-            if (unlikely(cgroup_enable_blkio_throttle_io && !cg->throttle_io_service_bytes.filename)) {
+            if (cgroup_enable_blkio_throttle_io && !cg->throttle_io_service_bytes.filename) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/blkio.throttle.io_service_bytes_recursive", cgroup_blkio_base, cg->id);
-                if (unlikely(stat(filename, &buf) != -1)) {
+                if (stat(filename, &buf) != -1) {
                     cg->throttle_io_service_bytes.filename = strdupz(filename);
                     cg->throttle_io_service_bytes.enabled = cgroup_enable_blkio_throttle_io;
                     netdata_log_debug(D_CGROUP,"blkio.throttle.io_service_bytes_recursive filename for cgroup '%s': '%s'", cg->id, cg->throttle_io_service_bytes.filename);
@@ -2280,7 +2280,7 @@ static inline void discovery_update_filenames() {
                     netdata_log_debug(D_CGROUP, "blkio.throttle.io_service_bytes_recursive file for cgroup '%s': '%s' does not exist.", cg->id, filename);
                     snprintfz(
                         filename, FILENAME_MAX, "%s%s/blkio.throttle.io_service_bytes", cgroup_blkio_base, cg->id);
-                    if (likely(stat(filename, &buf) != -1)) {
+                    if (stat(filename, &buf) != -1) {
                         cg->throttle_io_service_bytes.filename = strdupz(filename);
                         cg->throttle_io_service_bytes.enabled = cgroup_enable_blkio_throttle_io;
                         netdata_log_debug(D_CGROUP, "blkio.throttle.io_service_bytes filename for cgroup '%s': '%s'", cg->id, cg->throttle_io_service_bytes.filename);
@@ -2290,16 +2290,16 @@ static inline void discovery_update_filenames() {
                 }
             }
 
-            if (unlikely(cgroup_enable_blkio_throttle_ops && !cg->throttle_io_serviced.filename)) {
+            if (cgroup_enable_blkio_throttle_ops && !cg->throttle_io_serviced.filename) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/blkio.throttle.io_serviced_recursive", cgroup_blkio_base, cg->id);
-                if (unlikely(stat(filename, &buf) != -1)) {
+                if (stat(filename, &buf) != -1) {
                     cg->throttle_io_serviced.filename = strdupz(filename);
                     cg->throttle_io_serviced.enabled = cgroup_enable_blkio_throttle_ops;
                     netdata_log_debug(D_CGROUP, "blkio.throttle.io_serviced_recursive filename for cgroup '%s': '%s'", cg->id, cg->throttle_io_serviced.filename);
                 } else {
                     netdata_log_debug(D_CGROUP, "blkio.throttle.io_serviced_recursive file for cgroup '%s': '%s' does not exist.", cg->id, filename);
                     snprintfz(filename, FILENAME_MAX, "%s%s/blkio.throttle.io_serviced", cgroup_blkio_base, cg->id);
-                    if (likely(stat(filename, &buf) != -1)) {
+                    if (stat(filename, &buf) != -1) {
                         cg->throttle_io_serviced.filename = strdupz(filename);
                         cg->throttle_io_serviced.enabled = cgroup_enable_blkio_throttle_ops;
                         netdata_log_debug(D_CGROUP, "blkio.throttle.io_serviced filename for cgroup '%s': '%s'", cg->id, cg->throttle_io_serviced.filename);
@@ -2309,16 +2309,16 @@ static inline void discovery_update_filenames() {
                 }
             }
 
-            if (unlikely(cgroup_enable_blkio_merged_ops && !cg->io_merged.filename)) {
+            if (cgroup_enable_blkio_merged_ops && !cg->io_merged.filename) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_merged_recursive", cgroup_blkio_base, cg->id);
-                if (unlikely(stat(filename, &buf) != -1)) {
+                if (stat(filename, &buf) != -1) {
                     cg->io_merged.filename = strdupz(filename);
                     cg->io_merged.enabled = cgroup_enable_blkio_merged_ops;
                     netdata_log_debug(D_CGROUP, "blkio.io_merged_recursive filename for cgroup '%s': '%s'", cg->id, cg->io_merged.filename);
                 } else {
                     netdata_log_debug(D_CGROUP, "blkio.io_merged_recursive file for cgroup '%s': '%s' does not exist.", cg->id, filename);
                     snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_merged", cgroup_blkio_base, cg->id);
-                    if (likely(stat(filename, &buf) != -1)) {
+                    if (stat(filename, &buf) != -1) {
                         cg->io_merged.filename = strdupz(filename);
                         cg->io_merged.enabled = cgroup_enable_blkio_merged_ops;
                         netdata_log_debug(D_CGROUP, "blkio.io_merged filename for cgroup '%s': '%s'", cg->id, cg->io_merged.filename);
@@ -2328,16 +2328,16 @@ static inline void discovery_update_filenames() {
                 }
             }
 
-            if (unlikely(cgroup_enable_blkio_queued_ops && !cg->io_queued.filename)) {
+            if (cgroup_enable_blkio_queued_ops && !cg->io_queued.filename) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_queued_recursive", cgroup_blkio_base, cg->id);
-                if (unlikely(stat(filename, &buf) != -1)) {
+                if (stat(filename, &buf) != -1) {
                     cg->io_queued.filename = strdupz(filename);
                     cg->io_queued.enabled = cgroup_enable_blkio_queued_ops;
                     netdata_log_debug(D_CGROUP, "blkio.io_queued_recursive filename for cgroup '%s': '%s'", cg->id, cg->io_queued.filename);
                 } else {
                     netdata_log_debug(D_CGROUP, "blkio.io_queued_recursive file for cgroup '%s': '%s' does not exist.", cg->id, filename);
                     snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_queued", cgroup_blkio_base, cg->id);
-                    if (likely(stat(filename, &buf) != -1)) {
+                    if (stat(filename, &buf) != -1) {
                         cg->io_queued.filename = strdupz(filename);
                         cg->io_queued.enabled = cgroup_enable_blkio_queued_ops;
                         netdata_log_debug(D_CGROUP, "blkio.io_queued filename for cgroup '%s': '%s'", cg->id, cg->io_queued.filename);
@@ -2347,30 +2347,30 @@ static inline void discovery_update_filenames() {
                 }
             }
         }
-        else if(likely(cgroup_unified_exist)) {
-            if(unlikely(cgroup_enable_blkio_io && !cg->io_service_bytes.filename)) {
+        else if(cgroup_unified_exist) {
+            if(cgroup_enable_blkio_io && !cg->io_service_bytes.filename) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/io.stat", cgroup_unified_base, cg->id);
-                if(likely(stat(filename, &buf) != -1)) {
+                if(stat(filename, &buf) != -1) {
                     cg->io_service_bytes.filename = strdupz(filename);
                     cg->io_service_bytes.enabled = cgroup_enable_blkio_io;
                     netdata_log_debug(D_CGROUP, "io.stat filename for unified cgroup '%s': '%s'", cg->id, cg->io_service_bytes.filename);
                 } else
                     netdata_log_debug(D_CGROUP, "io.stat file for unified cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
-            if (unlikely(cgroup_enable_blkio_ops && !cg->io_serviced.filename)) {
+            if (cgroup_enable_blkio_ops && !cg->io_serviced.filename) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/io.stat", cgroup_unified_base, cg->id);
-                if (likely(stat(filename, &buf) != -1)) {
+                if (stat(filename, &buf) != -1) {
                     cg->io_serviced.filename = strdupz(filename);
                     cg->io_serviced.enabled = cgroup_enable_blkio_ops;
                     netdata_log_debug(D_CGROUP, "io.stat filename for unified cgroup '%s': '%s'", cg->id, cg->io_service_bytes.filename);
                 } else
                     netdata_log_debug(D_CGROUP, "io.stat file for unified cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
-            if (unlikely(
+            if (
                     (cgroup_enable_cpuacct_stat || cgroup_enable_cpuacct_cpu_throttling) &&
-                    !cg->cpuacct_stat.filename)) {
+                    !cg->cpuacct_stat.filename) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/cpu.stat", cgroup_unified_base, cg->id);
-                if(likely(stat(filename, &buf) != -1)) {
+                if(stat(filename, &buf) != -1) {
                     cg->cpuacct_stat.filename = strdupz(filename);
                     cg->cpuacct_stat.enabled = cgroup_enable_cpuacct_stat;
                     cg->cpuacct_cpu_throttling.enabled = cgroup_enable_cpuacct_cpu_throttling;
@@ -2383,9 +2383,9 @@ static inline void discovery_update_filenames() {
                 else
                     netdata_log_debug(D_CGROUP, "cpu.stat file for unified cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
-            if (unlikely(cgroup_enable_cpuacct_cpu_shares && !cg->cpuacct_cpu_shares.filename)) {
+            if (cgroup_enable_cpuacct_cpu_shares && !cg->cpuacct_cpu_shares.filename) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/cpu.weight", cgroup_unified_base, cg->id);
-                if (likely(stat(filename, &buf) != -1)) {
+                if (stat(filename, &buf) != -1) {
                     cg->cpuacct_cpu_shares.filename = strdupz(filename);
                     cg->cpuacct_cpu_shares.enabled = cgroup_enable_cpuacct_cpu_shares;
                     netdata_log_debug(D_CGROUP, "cpu.weight filename for cgroup '%s': '%s'", cg->id, cg->cpuacct_cpu_shares.filename);
@@ -2393,9 +2393,9 @@ static inline void discovery_update_filenames() {
                     netdata_log_debug(D_CGROUP, "cpu.weight file for cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
 
-            if(unlikely((cgroup_enable_detailed_memory || cgroup_used_memory) && !cg->memory.filename_detailed && (cgroup_used_memory || cgroup_enable_systemd_services_detailed_memory || !is_cgroup_systemd_service(cg)))) {
+            if((cgroup_enable_detailed_memory || cgroup_used_memory) && !cg->memory.filename_detailed && (cgroup_used_memory || cgroup_enable_systemd_services_detailed_memory || !is_cgroup_systemd_service(cg))) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/memory.stat", cgroup_unified_base, cg->id);
-                if(likely(stat(filename, &buf) != -1)) {
+                if(stat(filename, &buf) != -1) {
                     cg->memory.filename_detailed = strdupz(filename);
                     cg->memory.enabled_detailed = (cgroup_enable_detailed_memory == CONFIG_BOOLEAN_YES)?CONFIG_BOOLEAN_YES:CONFIG_BOOLEAN_AUTO;
                     netdata_log_debug(D_CGROUP, "memory.stat filename for cgroup '%s': '%s'", cg->id, cg->memory.filename_detailed);
@@ -2404,9 +2404,9 @@ static inline void discovery_update_filenames() {
                     netdata_log_debug(D_CGROUP, "memory.stat file for cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
 
-            if(unlikely(cgroup_enable_memory && !cg->memory.filename_usage_in_bytes)) {
+            if(cgroup_enable_memory && !cg->memory.filename_usage_in_bytes) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/memory.current", cgroup_unified_base, cg->id);
-                if(likely(stat(filename, &buf) != -1)) {
+                if(stat(filename, &buf) != -1) {
                     cg->memory.filename_usage_in_bytes = strdupz(filename);
                     cg->memory.enabled_usage_in_bytes = cgroup_enable_memory;
                     netdata_log_debug(D_CGROUP, "memory.current filename for cgroup '%s': '%s'", cg->id, cg->memory.filename_usage_in_bytes);
@@ -2417,9 +2417,9 @@ static inline void discovery_update_filenames() {
                     netdata_log_debug(D_CGROUP, "memory.current file for cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
 
-            if(unlikely(cgroup_enable_swap && !cg->memory.filename_msw_usage_in_bytes)) {
+            if(cgroup_enable_swap && !cg->memory.filename_msw_usage_in_bytes) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/memory.swap.current", cgroup_unified_base, cg->id);
-                if(likely(stat(filename, &buf) != -1)) {
+                if(stat(filename, &buf) != -1) {
                     cg->memory.filename_msw_usage_in_bytes = strdupz(filename);
                     cg->memory.enabled_msw_usage_in_bytes = cgroup_enable_swap;
                     snprintfz(filename, FILENAME_MAX, "%s%s/memory.swap.max", cgroup_unified_base, cg->id);
@@ -2430,9 +2430,9 @@ static inline void discovery_update_filenames() {
                     netdata_log_debug(D_CGROUP, "memory.swap file for cgroup '%s': '%s' does not exist.", cg->id, filename);
             }
 
-            if (unlikely(cgroup_enable_pressure_cpu && !cg->cpu_pressure.filename)) {
+            if (cgroup_enable_pressure_cpu && !cg->cpu_pressure.filename) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/cpu.pressure", cgroup_unified_base, cg->id);
-                if (likely(stat(filename, &buf) != -1)) {
+                if (stat(filename, &buf) != -1) {
                     cg->cpu_pressure.filename = strdupz(filename);
                     cg->cpu_pressure.some.enabled = cgroup_enable_pressure_cpu;
                     cg->cpu_pressure.full.enabled = CONFIG_BOOLEAN_NO;
@@ -2442,9 +2442,9 @@ static inline void discovery_update_filenames() {
                 }
             }
 
-            if (unlikely((cgroup_enable_pressure_io_some || cgroup_enable_pressure_io_full) && !cg->io_pressure.filename)) {
+            if ((cgroup_enable_pressure_io_some || cgroup_enable_pressure_io_full) && !cg->io_pressure.filename) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/io.pressure", cgroup_unified_base, cg->id);
-                if (likely(stat(filename, &buf) != -1)) {
+                if (stat(filename, &buf) != -1) {
                     cg->io_pressure.filename = strdupz(filename);
                     cg->io_pressure.some.enabled = cgroup_enable_pressure_io_some;
                     cg->io_pressure.full.enabled = cgroup_enable_pressure_io_full;
@@ -2454,9 +2454,9 @@ static inline void discovery_update_filenames() {
                 }
             }
 
-            if (unlikely((cgroup_enable_pressure_memory_some || cgroup_enable_pressure_memory_full) && !cg->memory_pressure.filename)) {
+            if ((cgroup_enable_pressure_memory_some || cgroup_enable_pressure_memory_full) && !cg->memory_pressure.filename) {
                 snprintfz(filename, FILENAME_MAX, "%s%s/memory.pressure", cgroup_unified_base, cg->id);
-                if (likely(stat(filename, &buf) != -1)) {
+                if (stat(filename, &buf) != -1) {
                     cg->memory_pressure.filename = strdupz(filename);
                     cg->memory_pressure.some.enabled = cgroup_enable_pressure_memory_some;
                     cg->memory_pressure.full.enabled = cgroup_enable_pressure_memory_full;
@@ -2537,7 +2537,7 @@ static inline void discovery_share_cgroups_with_ebpf() {
         ptr->enabled = cg->enabled;
         if (cgroup_use_unified_cgroups) {
             snprintfz(ptr->path, FILENAME_MAX, "%s%s/cgroup.procs", cgroup_unified_base, cg->id);
-            if (likely(stat(ptr->path, &buf) == -1)) {
+            if (stat(ptr->path, &buf) == -1) {
                 ptr->path[0] = '\0';
                 ptr->enabled = 0;
             }
@@ -2676,7 +2676,7 @@ static inline void discovery_process_cgroup(struct cgroup *cg) {
     if (cg->first_time_seen) {
         worker_is_busy(WORKER_DISCOVERY_PROCESS_FIRST_TIME);
         discovery_process_first_time_seen_cgroup(cg);
-        if (unlikely(cg->first_time_seen || cg->processed)) {
+        if (cg->first_time_seen || cg->processed) {
             return;
         }
     }
@@ -2684,7 +2684,7 @@ static inline void discovery_process_cgroup(struct cgroup *cg) {
     if (cg->pending_renames) {
         worker_is_busy(WORKER_DISCOVERY_PROCESS_RENAME);
         discovery_rename_cgroup(cg);
-        if (unlikely(cg->pending_renames || cg->processed)) {
+        if (cg->pending_renames || cg->processed) {
             return;
         }
     }
@@ -2812,7 +2812,7 @@ void cgroup_discovery_worker(void *ptr)
         discovery_thread.start_discovery = 0;
         uv_mutex_unlock(&discovery_thread.mutex);
 
-        if (unlikely(!service_running(SERVICE_COLLECTORS)))
+        if (!service_running(SERVICE_COLLECTORS))
             break;
 
         discovery_find_all_cgroups();
@@ -2871,7 +2871,7 @@ void update_systemd_services_charts(
 
     // create the charts
 
-    if (unlikely(do_cpu && !st_cpu)) {
+    if (do_cpu && !st_cpu) {
         char title[CHART_TITLE_MAX + 1];
         snprintfz(title, CHART_TITLE_MAX, "Systemd Services CPU utilization (100%% = 1 core)");
 
@@ -2891,7 +2891,7 @@ void update_systemd_services_charts(
         );
     }
 
-    if (unlikely(do_mem_usage && !st_mem_usage)) {
+    if (do_mem_usage && !st_mem_usage) {
         st_mem_usage = rrdset_create_localhost(
                 "services"
                 , "mem_usage"
@@ -2908,8 +2908,8 @@ void update_systemd_services_charts(
         );
     }
 
-    if(likely(do_mem_detailed)) {
-        if(unlikely(!st_mem_detailed_rss)) {
+    if(do_mem_detailed) {
+        if(!st_mem_detailed_rss) {
             st_mem_detailed_rss = rrdset_create_localhost(
                     "services"
                     , "mem_rss"
@@ -2926,7 +2926,7 @@ void update_systemd_services_charts(
             );
         }
 
-        if(unlikely(!st_mem_detailed_mapped)) {
+        if(!st_mem_detailed_mapped) {
             st_mem_detailed_mapped = rrdset_create_localhost(
                     "services"
                     , "mem_mapped"
@@ -2943,7 +2943,7 @@ void update_systemd_services_charts(
             );
         }
 
-        if(unlikely(!st_mem_detailed_cache)) {
+        if(!st_mem_detailed_cache) {
             st_mem_detailed_cache = rrdset_create_localhost(
                     "services"
                     , "mem_cache"
@@ -2960,7 +2960,7 @@ void update_systemd_services_charts(
             );
         }
 
-        if(unlikely(!st_mem_detailed_writeback)) {
+        if(!st_mem_detailed_writeback) {
             st_mem_detailed_writeback = rrdset_create_localhost(
                     "services"
                     , "mem_writeback"
@@ -2978,7 +2978,7 @@ void update_systemd_services_charts(
 
         }
 
-        if(unlikely(!st_mem_detailed_pgfault)) {
+        if(!st_mem_detailed_pgfault) {
             st_mem_detailed_pgfault = rrdset_create_localhost(
                     "services"
                     , "mem_pgfault"
@@ -2995,7 +2995,7 @@ void update_systemd_services_charts(
             );
         }
 
-        if(unlikely(!st_mem_detailed_pgmajfault)) {
+        if(!st_mem_detailed_pgmajfault) {
             st_mem_detailed_pgmajfault = rrdset_create_localhost(
                     "services"
                     , "mem_pgmajfault"
@@ -3012,7 +3012,7 @@ void update_systemd_services_charts(
             );
         }
 
-        if(unlikely(!st_mem_detailed_pgpgin)) {
+        if(!st_mem_detailed_pgpgin) {
             st_mem_detailed_pgpgin = rrdset_create_localhost(
                     "services"
                     , "mem_pgpgin"
@@ -3030,7 +3030,7 @@ void update_systemd_services_charts(
 
         }
 
-        if(unlikely(!st_mem_detailed_pgpgout)) {
+        if(!st_mem_detailed_pgpgout) {
             st_mem_detailed_pgpgout = rrdset_create_localhost(
                     "services"
                     , "mem_pgpgout"
@@ -3048,7 +3048,7 @@ void update_systemd_services_charts(
         }
     }
 
-    if(unlikely(do_mem_failcnt && !st_mem_failcnt)) {
+    if(do_mem_failcnt && !st_mem_failcnt) {
         st_mem_failcnt = rrdset_create_localhost(
                 "services"
                 , "mem_failcnt"
@@ -3082,8 +3082,8 @@ void update_systemd_services_charts(
         );
     }
 
-    if(likely(do_io)) {
-        if(unlikely(!st_io_read)) {
+    if(do_io) {
+        if(!st_io_read) {
             st_io_read = rrdset_create_localhost(
                     "services"
                     , "io_read"
@@ -3100,7 +3100,7 @@ void update_systemd_services_charts(
             );
         }
 
-        if(unlikely(!st_io_write)) {
+        if(!st_io_write) {
             st_io_write = rrdset_create_localhost(
                     "services"
                     , "io_write"
@@ -3118,8 +3118,8 @@ void update_systemd_services_charts(
         }
     }
 
-    if(likely(do_io_ops)) {
-        if(unlikely(!st_io_serviced_read)) {
+    if(do_io_ops) {
+        if(!st_io_serviced_read) {
             st_io_serviced_read = rrdset_create_localhost(
                     "services"
                     , "io_ops_read"
@@ -3136,7 +3136,7 @@ void update_systemd_services_charts(
             );
         }
 
-        if(unlikely(!st_io_serviced_write)) {
+        if(!st_io_serviced_write) {
             st_io_serviced_write = rrdset_create_localhost(
                     "services"
                     , "io_ops_write"
@@ -3154,8 +3154,8 @@ void update_systemd_services_charts(
         }
     }
 
-    if(likely(do_throttle_io)) {
-        if(unlikely(!st_throttle_io_read)) {
+    if(do_throttle_io) {
+        if(!st_throttle_io_read) {
 
             st_throttle_io_read = rrdset_create_localhost(
                     "services"
@@ -3174,7 +3174,7 @@ void update_systemd_services_charts(
 
         }
 
-        if(unlikely(!st_throttle_io_write)) {
+        if(!st_throttle_io_write) {
             st_throttle_io_write = rrdset_create_localhost(
                     "services"
                     , "throttle_io_write"
@@ -3192,8 +3192,8 @@ void update_systemd_services_charts(
         }
     }
 
-    if(likely(do_throttle_ops)) {
-        if(unlikely(!st_throttle_ops_read)) {
+    if(do_throttle_ops) {
+        if(!st_throttle_ops_read) {
             st_throttle_ops_read = rrdset_create_localhost(
                     "services"
                     , "throttle_io_ops_read"
@@ -3210,7 +3210,7 @@ void update_systemd_services_charts(
             );
         }
 
-        if(unlikely(!st_throttle_ops_write)) {
+        if(!st_throttle_ops_write) {
             st_throttle_ops_write = rrdset_create_localhost(
                     "services"
                     , "throttle_io_ops_write"
@@ -3228,8 +3228,8 @@ void update_systemd_services_charts(
         }
     }
 
-    if(likely(do_queued_ops)) {
-        if(unlikely(!st_queued_ops_read)) {
+    if(do_queued_ops) {
+        if(!st_queued_ops_read) {
             st_queued_ops_read = rrdset_create_localhost(
                     "services"
                     , "queued_io_ops_read"
@@ -3246,7 +3246,7 @@ void update_systemd_services_charts(
             );
         }
 
-        if(unlikely(!st_queued_ops_write)) {
+        if(!st_queued_ops_write) {
 
             st_queued_ops_write = rrdset_create_localhost(
                     "services"
@@ -3265,8 +3265,8 @@ void update_systemd_services_charts(
         }
     }
 
-    if(likely(do_merged_ops)) {
-        if(unlikely(!st_merged_ops_read)) {
+    if(do_merged_ops) {
+        if(!st_merged_ops_read) {
             st_merged_ops_read = rrdset_create_localhost(
                     "services"
                     , "merged_io_ops_read"
@@ -3283,7 +3283,7 @@ void update_systemd_services_charts(
             );
         }
 
-        if(unlikely(!st_merged_ops_write)) {
+        if(!st_merged_ops_write) {
             st_merged_ops_write = rrdset_create_localhost(
                     "services"
                     , "merged_io_ops_write"
@@ -3304,11 +3304,11 @@ void update_systemd_services_charts(
     // update the values
     struct cgroup *cg;
     for(cg = cgroup_root; cg ; cg = cg->next) {
-        if(unlikely(!cg->enabled || cg->pending_renames || !is_cgroup_systemd_service(cg)))
+        if(!cg->enabled || cg->pending_renames || !is_cgroup_systemd_service(cg))
             continue;
 
-        if(likely(do_cpu && cg->cpuacct_stat.updated)) {
-            if(unlikely(!cg->rd_cpu)){
+        if(do_cpu && cg->cpuacct_stat.updated) {
+            if(!cg->rd_cpu){
 
 
                 if (!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) {
@@ -3321,64 +3321,64 @@ void update_systemd_services_charts(
             rrddim_set_by_pointer(st_cpu, cg->rd_cpu, cg->cpuacct_stat.user + cg->cpuacct_stat.system);
         }
 
-        if(likely(do_mem_usage && cg->memory.updated_usage_in_bytes)) {
-            if(unlikely(!cg->rd_mem_usage))
+        if(do_mem_usage && cg->memory.updated_usage_in_bytes) {
+            if(!cg->rd_mem_usage)
                 cg->rd_mem_usage = rrddim_add(st_mem_usage, cg->chart_id, cg->chart_title, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
 
             rrddim_set_by_pointer(st_mem_usage, cg->rd_mem_usage, cg->memory.usage_in_bytes);
         }
 
-        if(likely(do_mem_detailed && cg->memory.updated_detailed)) {
-            if(unlikely(!cg->rd_mem_detailed_rss))
+        if(do_mem_detailed && cg->memory.updated_detailed) {
+            if(!cg->rd_mem_detailed_rss)
                 cg->rd_mem_detailed_rss = rrddim_add(st_mem_detailed_rss, cg->chart_id, cg->chart_title, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
 
             rrddim_set_by_pointer(st_mem_detailed_rss, cg->rd_mem_detailed_rss, cg->memory.total_rss);
 
-            if(unlikely(!cg->rd_mem_detailed_mapped))
+            if(!cg->rd_mem_detailed_mapped)
                 cg->rd_mem_detailed_mapped = rrddim_add(st_mem_detailed_mapped, cg->chart_id, cg->chart_title, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
 
             rrddim_set_by_pointer(st_mem_detailed_mapped, cg->rd_mem_detailed_mapped, cg->memory.total_mapped_file);
 
-            if(unlikely(!cg->rd_mem_detailed_cache))
+            if(!cg->rd_mem_detailed_cache)
                 cg->rd_mem_detailed_cache = rrddim_add(st_mem_detailed_cache, cg->chart_id, cg->chart_title, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
 
             rrddim_set_by_pointer(st_mem_detailed_cache, cg->rd_mem_detailed_cache, cg->memory.total_cache);
 
-            if(unlikely(!cg->rd_mem_detailed_writeback))
+            if(!cg->rd_mem_detailed_writeback)
                 cg->rd_mem_detailed_writeback = rrddim_add(st_mem_detailed_writeback, cg->chart_id, cg->chart_title, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
 
             rrddim_set_by_pointer(st_mem_detailed_writeback, cg->rd_mem_detailed_writeback, cg->memory.total_writeback);
 
-            if(unlikely(!cg->rd_mem_detailed_pgfault))
+            if(!cg->rd_mem_detailed_pgfault)
                 cg->rd_mem_detailed_pgfault = rrddim_add(st_mem_detailed_pgfault, cg->chart_id, cg->chart_title, system_page_size, 1024 * 1024, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st_mem_detailed_pgfault, cg->rd_mem_detailed_pgfault, cg->memory.total_pgfault);
 
-            if(unlikely(!cg->rd_mem_detailed_pgmajfault))
+            if(!cg->rd_mem_detailed_pgmajfault)
                 cg->rd_mem_detailed_pgmajfault = rrddim_add(st_mem_detailed_pgmajfault, cg->chart_id, cg->chart_title, system_page_size, 1024 * 1024, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st_mem_detailed_pgmajfault, cg->rd_mem_detailed_pgmajfault, cg->memory.total_pgmajfault);
 
-            if(unlikely(!cg->rd_mem_detailed_pgpgin))
+            if(!cg->rd_mem_detailed_pgpgin)
                 cg->rd_mem_detailed_pgpgin = rrddim_add(st_mem_detailed_pgpgin, cg->chart_id, cg->chart_title, system_page_size, 1024 * 1024, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st_mem_detailed_pgpgin, cg->rd_mem_detailed_pgpgin, cg->memory.total_pgpgin);
 
-            if(unlikely(!cg->rd_mem_detailed_pgpgout))
+            if(!cg->rd_mem_detailed_pgpgout)
                 cg->rd_mem_detailed_pgpgout = rrddim_add(st_mem_detailed_pgpgout, cg->chart_id, cg->chart_title, system_page_size, 1024 * 1024, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st_mem_detailed_pgpgout, cg->rd_mem_detailed_pgpgout, cg->memory.total_pgpgout);
         }
 
-        if(likely(do_mem_failcnt && cg->memory.updated_failcnt)) {
-            if(unlikely(!cg->rd_mem_failcnt))
+        if(do_mem_failcnt && cg->memory.updated_failcnt) {
+            if(!cg->rd_mem_failcnt)
                 cg->rd_mem_failcnt = rrddim_add(st_mem_failcnt, cg->chart_id, cg->chart_title, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st_mem_failcnt, cg->rd_mem_failcnt, cg->memory.failcnt);
         }
 
-        if(likely(do_swap_usage && cg->memory.updated_msw_usage_in_bytes)) {
-            if(unlikely(!cg->rd_swap_usage))
+        if(do_swap_usage && cg->memory.updated_msw_usage_in_bytes) {
+            if(!cg->rd_swap_usage)
                 cg->rd_swap_usage = rrddim_add(st_swap_usage, cg->chart_id, cg->chart_title, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
 
             if(!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) {
@@ -3392,73 +3392,73 @@ void update_systemd_services_charts(
             }
         }
 
-        if(likely(do_io && cg->io_service_bytes.updated)) {
-            if(unlikely(!cg->rd_io_service_bytes_read))
+        if(do_io && cg->io_service_bytes.updated) {
+            if(!cg->rd_io_service_bytes_read)
                 cg->rd_io_service_bytes_read = rrddim_add(st_io_read, cg->chart_id, cg->chart_title, 1, 1024, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st_io_read, cg->rd_io_service_bytes_read, cg->io_service_bytes.Read);
 
-            if(unlikely(!cg->rd_io_service_bytes_write))
+            if(!cg->rd_io_service_bytes_write)
                 cg->rd_io_service_bytes_write = rrddim_add(st_io_write, cg->chart_id, cg->chart_title, 1, 1024, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st_io_write, cg->rd_io_service_bytes_write, cg->io_service_bytes.Write);
         }
 
-        if(likely(do_io_ops && cg->io_serviced.updated)) {
-            if(unlikely(!cg->rd_io_serviced_read))
+        if(do_io_ops && cg->io_serviced.updated) {
+            if(!cg->rd_io_serviced_read)
                 cg->rd_io_serviced_read = rrddim_add(st_io_serviced_read, cg->chart_id, cg->chart_title, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st_io_serviced_read, cg->rd_io_serviced_read, cg->io_serviced.Read);
 
-            if(unlikely(!cg->rd_io_serviced_write))
+            if(!cg->rd_io_serviced_write)
                 cg->rd_io_serviced_write = rrddim_add(st_io_serviced_write, cg->chart_id, cg->chart_title, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st_io_serviced_write, cg->rd_io_serviced_write, cg->io_serviced.Write);
         }
 
-        if(likely(do_throttle_io && cg->throttle_io_service_bytes.updated)) {
-            if(unlikely(!cg->rd_throttle_io_read))
+        if(do_throttle_io && cg->throttle_io_service_bytes.updated) {
+            if(!cg->rd_throttle_io_read)
                 cg->rd_throttle_io_read = rrddim_add(st_throttle_io_read, cg->chart_id, cg->chart_title, 1, 1024, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st_throttle_io_read, cg->rd_throttle_io_read, cg->throttle_io_service_bytes.Read);
 
-            if(unlikely(!cg->rd_throttle_io_write))
+            if(!cg->rd_throttle_io_write)
                 cg->rd_throttle_io_write = rrddim_add(st_throttle_io_write, cg->chart_id, cg->chart_title, 1, 1024, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st_throttle_io_write, cg->rd_throttle_io_write, cg->throttle_io_service_bytes.Write);
         }
 
-        if(likely(do_throttle_ops && cg->throttle_io_serviced.updated)) {
-            if(unlikely(!cg->rd_throttle_io_serviced_read))
+        if(do_throttle_ops && cg->throttle_io_serviced.updated) {
+            if(!cg->rd_throttle_io_serviced_read)
                 cg->rd_throttle_io_serviced_read = rrddim_add(st_throttle_ops_read, cg->chart_id, cg->chart_title, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st_throttle_ops_read, cg->rd_throttle_io_serviced_read, cg->throttle_io_serviced.Read);
 
-            if(unlikely(!cg->rd_throttle_io_serviced_write))
+            if(!cg->rd_throttle_io_serviced_write)
                 cg->rd_throttle_io_serviced_write = rrddim_add(st_throttle_ops_write, cg->chart_id, cg->chart_title, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st_throttle_ops_write, cg->rd_throttle_io_serviced_write, cg->throttle_io_serviced.Write);
         }
 
-        if(likely(do_queued_ops && cg->io_queued.updated)) {
-            if(unlikely(!cg->rd_io_queued_read))
+        if(do_queued_ops && cg->io_queued.updated) {
+            if(!cg->rd_io_queued_read)
                 cg->rd_io_queued_read = rrddim_add(st_queued_ops_read, cg->chart_id, cg->chart_title, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st_queued_ops_read, cg->rd_io_queued_read, cg->io_queued.Read);
 
-            if(unlikely(!cg->rd_io_queued_write))
+            if(!cg->rd_io_queued_write)
                 cg->rd_io_queued_write = rrddim_add(st_queued_ops_write, cg->chart_id, cg->chart_title, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st_queued_ops_write, cg->rd_io_queued_write, cg->io_queued.Write);
         }
 
-        if(likely(do_merged_ops && cg->io_merged.updated)) {
-            if(unlikely(!cg->rd_io_merged_read))
+        if(do_merged_ops && cg->io_merged.updated) {
+            if(!cg->rd_io_merged_read)
                 cg->rd_io_merged_read = rrddim_add(st_merged_ops_read, cg->chart_id, cg->chart_title, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st_merged_ops_read, cg->rd_io_merged_read, cg->io_merged.Read);
 
-            if(unlikely(!cg->rd_io_merged_write))
+            if(!cg->rd_io_merged_write)
                 cg->rd_io_merged_write = rrddim_add(st_merged_ops_write, cg->chart_id, cg->chart_title, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st_merged_ops_write, cg->rd_io_merged_write, cg->io_merged.Write);
@@ -3466,13 +3466,13 @@ void update_systemd_services_charts(
     }
 
     // complete the iteration
-    if(likely(do_cpu))
+    if(do_cpu)
         rrdset_done(st_cpu);
 
-    if(likely(do_mem_usage))
+    if(do_mem_usage)
         rrdset_done(st_mem_usage);
 
-    if(unlikely(do_mem_detailed)) {
+    if(do_mem_detailed) {
         rrdset_done(st_mem_detailed_cache);
         rrdset_done(st_mem_detailed_rss);
         rrdset_done(st_mem_detailed_mapped);
@@ -3483,38 +3483,38 @@ void update_systemd_services_charts(
         rrdset_done(st_mem_detailed_pgpgout);
     }
 
-    if(likely(do_mem_failcnt))
+    if(do_mem_failcnt)
         rrdset_done(st_mem_failcnt);
 
-    if(likely(do_swap_usage))
+    if(do_swap_usage)
         rrdset_done(st_swap_usage);
 
-    if(likely(do_io)) {
+    if(do_io) {
         rrdset_done(st_io_read);
         rrdset_done(st_io_write);
     }
 
-    if(likely(do_io_ops)) {
+    if(do_io_ops) {
         rrdset_done(st_io_serviced_read);
         rrdset_done(st_io_serviced_write);
     }
 
-    if(likely(do_throttle_io)) {
+    if(do_throttle_io) {
         rrdset_done(st_throttle_io_read);
         rrdset_done(st_throttle_io_write);
     }
 
-    if(likely(do_throttle_ops)) {
+    if(do_throttle_ops) {
         rrdset_done(st_throttle_ops_read);
         rrdset_done(st_throttle_ops_write);
     }
 
-    if(likely(do_queued_ops)) {
+    if(do_queued_ops) {
         rrdset_done(st_queued_ops_read);
         rrdset_done(st_queued_ops_write);
     }
 
-    if(likely(do_merged_ops)) {
+    if(do_merged_ops) {
         rrdset_done(st_merged_ops_read);
         rrdset_done(st_merged_ops_write);
     }
@@ -3564,18 +3564,18 @@ static inline void update_cpu_limits2(struct cgroup *cg) {
         static procfile *ff = NULL;
 
         ff = procfile_reopen(ff, cg->filename_cpu_cfs_quota, NULL, CGROUP_PROCFILE_FLAG);
-        if(unlikely(!ff)) {
+        if(!ff) {
             goto cpu_limits2_err;
         }
 
         ff = procfile_readall(ff);
-        if(unlikely(!ff)) {
+        if(!ff) {
             goto cpu_limits2_err;
         }
 
         unsigned long lines = procfile_lines(ff);
 
-        if (unlikely(lines < 1)) {
+        if (lines < 1) {
             collector_error("CGROUP: file '%s' should have 1 lines.", cg->filename_cpu_cfs_quota);
             return;
         }
@@ -3602,7 +3602,7 @@ cpu_limits2_err:
 
 static inline int update_memory_limits(char **filename, const RRDSETVAR_ACQUIRED **chart_var, unsigned long long *value, const char *chart_var_name, struct cgroup *cg) {
     if(*filename) {
-        if(unlikely(!*chart_var)) {
+        if(!*chart_var) {
             *chart_var = rrdsetvar_custom_chart_variable_add_and_acquire(cg->st_mem_usage, chart_var_name);
             if(!*chart_var) {
                 collector_error("Cannot create cgroup %s chart variable '%s'. Will not update its limit anymore.", cg->id, chart_var_name);
@@ -3666,10 +3666,10 @@ void update_cgroup_charts(int update_every) {
 
     struct cgroup *cg;
     for(cg = cgroup_root; cg ; cg = cg->next) {
-        if(unlikely(!cg->enabled || cg->pending_renames))
+        if(!cg->enabled || cg->pending_renames)
             continue;
 
-        if(likely(cgroup_enable_systemd_services && is_cgroup_systemd_service(cg))) {
+        if(cgroup_enable_systemd_services && is_cgroup_systemd_service(cg)) {
             if(cg->cpuacct_stat.updated && cg->cpuacct_stat.enabled == CONFIG_BOOLEAN_YES) services_do_cpu++;
 
             if(cgroup_enable_systemd_services_detailed_memory && cg->memory.updated_detailed && cg->memory.enabled_detailed) services_do_mem_detailed++;
@@ -3688,8 +3688,8 @@ void update_cgroup_charts(int update_every) {
 
         type[0] = '\0';
 
-        if(likely(cg->cpuacct_stat.updated && cg->cpuacct_stat.enabled == CONFIG_BOOLEAN_YES)) {
-            if(unlikely(!cg->st_cpu)) {
+        if(cg->cpuacct_stat.updated && cg->cpuacct_stat.enabled == CONFIG_BOOLEAN_YES) {
+            if(!cg->st_cpu) {
                 snprintfz(
                     title,
                     CHART_TITLE_MAX,
@@ -3726,7 +3726,7 @@ void update_cgroup_charts(int update_every) {
             rrddim_set(cg->st_cpu, "system", cg->cpuacct_stat.system);
             rrdset_done(cg->st_cpu);
 
-            if(likely(cg->filename_cpuset_cpus || cg->filename_cpu_cfs_period || cg->filename_cpu_cfs_quota)) {
+            if(cg->filename_cpuset_cpus || cg->filename_cpu_cfs_period || cg->filename_cpu_cfs_quota) {
                 if(!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) {
                     update_cpu_limits(&cg->filename_cpuset_cpus, &cg->cpuset_cpus, cg);
                     update_cpu_limits(&cg->filename_cpu_cfs_period, &cg->cpu_cfs_period, cg);
@@ -3735,7 +3735,7 @@ void update_cgroup_charts(int update_every) {
                     update_cpu_limits2(cg);
                 }
 
-                if(unlikely(!cg->chart_var_cpu_limit)) {
+                if(!cg->chart_var_cpu_limit) {
                     cg->chart_var_cpu_limit = rrdsetvar_custom_chart_variable_add_and_acquire(cg->st_cpu, "cpu_limit");
                     if(!cg->chart_var_cpu_limit) {
                         collector_error("Cannot create cgroup %s chart variable 'cpu_limit'. Will not update its limit anymore.", cg->id);
@@ -3750,18 +3750,18 @@ void update_cgroup_charts(int update_every) {
                 else {
                     NETDATA_DOUBLE value = 0, quota = 0;
 
-                    if(likely( ((!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) && (cg->filename_cpuset_cpus || (cg->filename_cpu_cfs_period && cg->filename_cpu_cfs_quota)))
-                            || ((cg->options & CGROUP_OPTIONS_IS_UNIFIED) && cg->filename_cpu_cfs_quota))) {
-                        if(unlikely(cg->cpu_cfs_quota > 0))
+                    if( ((!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) && (cg->filename_cpuset_cpus || (cg->filename_cpu_cfs_period && cg->filename_cpu_cfs_quota)))
+                            || ((cg->options & CGROUP_OPTIONS_IS_UNIFIED) && cg->filename_cpu_cfs_quota)) {
+                        if(cg->cpu_cfs_quota > 0)
                             quota = (NETDATA_DOUBLE)cg->cpu_cfs_quota / (NETDATA_DOUBLE)cg->cpu_cfs_period;
 
-                        if(unlikely(quota > 0 && quota < cg->cpuset_cpus))
+                        if(quota > 0 && quota < cg->cpuset_cpus)
                             value = quota * 100;
                         else
                             value = (NETDATA_DOUBLE)cg->cpuset_cpus * 100;
                     }
-                    if(likely(value)) {
-                        if(unlikely(!cg->st_cpu_limit)) {
+                    if(value) {
+                        if(!cg->st_cpu_limit) {
                             snprintfz(title, CHART_TITLE_MAX, "CPU Usage within the limits");
 
                             cg->st_cpu_limit = rrdset_create_localhost(
@@ -3802,7 +3802,7 @@ void update_cgroup_charts(int update_every) {
                         rrdset_done(cg->st_cpu_limit);
                     }
                     else {
-                        if(unlikely(cg->st_cpu_limit)) {
+                        if(cg->st_cpu_limit) {
                             rrdset_is_obsolete(cg->st_cpu_limit);
                             cg->st_cpu_limit = NULL;
                         }
@@ -3812,8 +3812,8 @@ void update_cgroup_charts(int update_every) {
             }
         }
 
-        if (likely(cg->cpuacct_cpu_throttling.updated && cg->cpuacct_cpu_throttling.enabled == CONFIG_BOOLEAN_YES)) {
-            if (unlikely(!cg->st_cpu_nr_throttled)) {
+        if (cg->cpuacct_cpu_throttling.updated && cg->cpuacct_cpu_throttling.enabled == CONFIG_BOOLEAN_YES) {
+            if (!cg->st_cpu_nr_throttled) {
                 snprintfz(title, CHART_TITLE_MAX, "CPU Throttled Runnable Periods");
 
                 cg->st_cpu_nr_throttled = rrdset_create_localhost(
@@ -3838,7 +3838,7 @@ void update_cgroup_charts(int update_every) {
                 rrdset_done(cg->st_cpu_nr_throttled);
             }
 
-            if (unlikely(!cg->st_cpu_throttled_time)) {
+            if (!cg->st_cpu_throttled_time) {
                 snprintfz(title, CHART_TITLE_MAX, "CPU Throttled Time Duration");
 
                 cg->st_cpu_throttled_time = rrdset_create_localhost(
@@ -3864,8 +3864,8 @@ void update_cgroup_charts(int update_every) {
             }
         }
 
-        if (likely(cg->cpuacct_cpu_shares.updated && cg->cpuacct_cpu_shares.enabled == CONFIG_BOOLEAN_YES)) {
-            if (unlikely(!cg->st_cpu_shares)) {
+        if (cg->cpuacct_cpu_shares.updated && cg->cpuacct_cpu_shares.enabled == CONFIG_BOOLEAN_YES) {
+            if (!cg->st_cpu_shares) {
                 snprintfz(title, CHART_TITLE_MAX, "CPU Time Relative Share");
 
                 cg->st_cpu_shares = rrdset_create_localhost(
@@ -3891,11 +3891,11 @@ void update_cgroup_charts(int update_every) {
             }
         }
 
-        if(likely(cg->cpuacct_usage.updated && cg->cpuacct_usage.enabled == CONFIG_BOOLEAN_YES)) {
+        if(cg->cpuacct_usage.updated && cg->cpuacct_usage.enabled == CONFIG_BOOLEAN_YES) {
             char id[RRD_ID_LENGTH_MAX + 1];
             unsigned int i;
 
-            if(unlikely(!cg->st_cpu_per_core)) {
+            if(!cg->st_cpu_per_core) {
                 snprintfz(
                     title,
                     CHART_TITLE_MAX,
@@ -3932,8 +3932,8 @@ void update_cgroup_charts(int update_every) {
             rrdset_done(cg->st_cpu_per_core);
         }
 
-        if(likely(cg->memory.updated_detailed && cg->memory.enabled_detailed == CONFIG_BOOLEAN_YES)) {
-            if(unlikely(!cg->st_mem)) {
+        if(cg->memory.updated_detailed && cg->memory.enabled_detailed == CONFIG_BOOLEAN_YES) {
+            if(!cg->st_mem) {
                 snprintfz(title, CHART_TITLE_MAX, "Memory Usage");
 
                 cg->st_mem = rrdset_create_localhost(
@@ -3991,7 +3991,7 @@ void update_cgroup_charts(int update_every) {
             }
             rrdset_done(cg->st_mem);
 
-            if(unlikely(!cg->st_writeback)) {
+            if(!cg->st_writeback) {
                 snprintfz(title, CHART_TITLE_MAX, "Writeback Memory");
 
                 cg->st_writeback = rrdset_create_localhost(
@@ -4024,7 +4024,7 @@ void update_cgroup_charts(int update_every) {
             rrdset_done(cg->st_writeback);
 
             if(!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) {
-                if(unlikely(!cg->st_mem_activity)) {
+                if(!cg->st_mem_activity) {
                     snprintfz(title, CHART_TITLE_MAX, "Memory Activity");
 
                     cg->st_mem_activity = rrdset_create_localhost(
@@ -4053,7 +4053,7 @@ void update_cgroup_charts(int update_every) {
                 rrdset_done(cg->st_mem_activity);
             }
 
-            if(unlikely(!cg->st_pgfaults)) {
+            if(!cg->st_pgfaults) {
                 snprintfz(title, CHART_TITLE_MAX, "Memory Page Faults");
 
                 cg->st_pgfaults = rrdset_create_localhost(
@@ -4082,8 +4082,8 @@ void update_cgroup_charts(int update_every) {
             rrdset_done(cg->st_pgfaults);
         }
 
-        if(likely(cg->memory.updated_usage_in_bytes && cg->memory.enabled_usage_in_bytes == CONFIG_BOOLEAN_YES)) {
-            if(unlikely(!cg->st_mem_usage)) {
+        if(cg->memory.updated_usage_in_bytes && cg->memory.enabled_usage_in_bytes == CONFIG_BOOLEAN_YES) {
+            if(!cg->st_mem_usage) {
                 snprintfz(title, CHART_TITLE_MAX, "Used Memory");
 
                 cg->st_mem_usage = rrdset_create_localhost(
@@ -4119,19 +4119,19 @@ void update_cgroup_charts(int update_every) {
             }
             rrdset_done(cg->st_mem_usage);
 
-            if (likely(update_memory_limits(&cg->filename_memory_limit, &cg->chart_var_memory_limit, &cg->memory_limit, "memory_limit", cg))) {
+            if (update_memory_limits(&cg->filename_memory_limit, &cg->chart_var_memory_limit, &cg->memory_limit, "memory_limit", cg)) {
                 static unsigned long long ram_total = 0;
 
-                if(unlikely(!ram_total)) {
+                if(!ram_total) {
                     procfile *ff = NULL;
 
                     char filename[FILENAME_MAX + 1];
                     snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/meminfo");
                     ff = procfile_open(config_get("plugin:cgroups", "meminfo filename to monitor", filename), " \t:", PROCFILE_FLAG_DEFAULT);
 
-                    if(likely(ff))
+                    if(ff)
                         ff = procfile_readall(ff);
-                    if(likely(ff && procfile_lines(ff) && !strncmp(procfile_word(ff, 0), "MemTotal", 8)))
+                    if(ff && procfile_lines(ff) && !strncmp(procfile_word(ff, 0), "MemTotal", 8))
                         ram_total = str2ull(procfile_word(ff, 1), NULL) * 1024;
                     else {
                         collector_error("Cannot read file %s. Will not update cgroup %s RAM limit anymore.", filename, cg->id);
@@ -4142,13 +4142,13 @@ void update_cgroup_charts(int update_every) {
                     procfile_close(ff);
                 }
 
-                if(likely(ram_total)) {
+                if(ram_total) {
                     unsigned long long memory_limit = ram_total;
 
-                    if(unlikely(cg->memory_limit < ram_total))
+                    if(cg->memory_limit < ram_total)
                         memory_limit = cg->memory_limit;
 
-                    if(unlikely(!cg->st_mem_usage_limit)) {
+                    if(!cg->st_mem_usage_limit) {
                         snprintfz(title, CHART_TITLE_MAX, "Used RAM within the limits");
 
                         cg->st_mem_usage_limit = rrdset_create_localhost(
@@ -4178,7 +4178,7 @@ void update_cgroup_charts(int update_every) {
                     rrddim_set(cg->st_mem_usage_limit, "used", cg->memory.usage_in_bytes);
                     rrdset_done(cg->st_mem_usage_limit);
 
-                    if (unlikely(!cg->st_mem_utilization)) {
+                    if (!cg->st_mem_utilization) {
                         snprintfz(title, CHART_TITLE_MAX, "Memory Utilization");
 
                         cg->st_mem_utilization = rrdset_create_localhost(
@@ -4211,12 +4211,12 @@ void update_cgroup_charts(int update_every) {
                 }
             }
             else {
-                if(unlikely(cg->st_mem_usage_limit)) {
+                if(cg->st_mem_usage_limit) {
                     rrdset_is_obsolete(cg->st_mem_usage_limit);
                     cg->st_mem_usage_limit = NULL;
                 }
 
-                if(unlikely(cg->st_mem_utilization)) {
+                if(cg->st_mem_utilization) {
                     rrdset_is_obsolete(cg->st_mem_utilization);
                     cg->st_mem_utilization = NULL;
                 }
@@ -4225,8 +4225,8 @@ void update_cgroup_charts(int update_every) {
             update_memory_limits(&cg->filename_memoryswap_limit, &cg->chart_var_memoryswap_limit, &cg->memoryswap_limit, "memory_and_swap_limit", cg);
         }
 
-        if(likely(cg->memory.updated_failcnt && cg->memory.enabled_failcnt == CONFIG_BOOLEAN_YES)) {
-            if(unlikely(!cg->st_mem_failcnt)) {
+        if(cg->memory.updated_failcnt && cg->memory.enabled_failcnt == CONFIG_BOOLEAN_YES) {
+            if(!cg->st_mem_failcnt) {
                 snprintfz(title, CHART_TITLE_MAX, "Memory Limit Failures");
 
                 cg->st_mem_failcnt = rrdset_create_localhost(
@@ -4253,8 +4253,8 @@ void update_cgroup_charts(int update_every) {
             rrdset_done(cg->st_mem_failcnt);
         }
 
-        if(likely(cg->io_service_bytes.updated && cg->io_service_bytes.enabled == CONFIG_BOOLEAN_YES)) {
-            if(unlikely(!cg->st_io)) {
+        if(cg->io_service_bytes.updated && cg->io_service_bytes.enabled == CONFIG_BOOLEAN_YES) {
+            if(!cg->st_io) {
                 snprintfz(title, CHART_TITLE_MAX, "I/O Bandwidth (all disks)");
 
                 cg->st_io = rrdset_create_localhost(
@@ -4283,8 +4283,8 @@ void update_cgroup_charts(int update_every) {
             rrdset_done(cg->st_io);
         }
 
-        if(likely(cg->io_serviced.updated && cg->io_serviced.enabled == CONFIG_BOOLEAN_YES)) {
-            if(unlikely(!cg->st_serviced_ops)) {
+        if(cg->io_serviced.updated && cg->io_serviced.enabled == CONFIG_BOOLEAN_YES) {
+            if(!cg->st_serviced_ops) {
                 snprintfz(title, CHART_TITLE_MAX, "Serviced I/O Operations (all disks)");
 
                 cg->st_serviced_ops = rrdset_create_localhost(
@@ -4313,8 +4313,8 @@ void update_cgroup_charts(int update_every) {
             rrdset_done(cg->st_serviced_ops);
         }
 
-        if(likely(cg->throttle_io_service_bytes.updated && cg->throttle_io_service_bytes.enabled == CONFIG_BOOLEAN_YES)) {
-            if(unlikely(!cg->st_throttle_io)) {
+        if(cg->throttle_io_service_bytes.updated && cg->throttle_io_service_bytes.enabled == CONFIG_BOOLEAN_YES) {
+            if(!cg->st_throttle_io) {
                 snprintfz(title, CHART_TITLE_MAX, "Throttle I/O Bandwidth (all disks)");
 
                 cg->st_throttle_io = rrdset_create_localhost(
@@ -4343,8 +4343,8 @@ void update_cgroup_charts(int update_every) {
             rrdset_done(cg->st_throttle_io);
         }
 
-        if(likely(cg->throttle_io_serviced.updated && cg->throttle_io_serviced.enabled == CONFIG_BOOLEAN_YES)) {
-            if(unlikely(!cg->st_throttle_serviced_ops)) {
+        if(cg->throttle_io_serviced.updated && cg->throttle_io_serviced.enabled == CONFIG_BOOLEAN_YES) {
+            if(!cg->st_throttle_serviced_ops) {
                 snprintfz(title, CHART_TITLE_MAX, "Throttle Serviced I/O Operations (all disks)");
 
                 cg->st_throttle_serviced_ops = rrdset_create_localhost(
@@ -4373,8 +4373,8 @@ void update_cgroup_charts(int update_every) {
             rrdset_done(cg->st_throttle_serviced_ops);
         }
 
-        if(likely(cg->io_queued.updated && cg->io_queued.enabled == CONFIG_BOOLEAN_YES)) {
-            if(unlikely(!cg->st_queued_ops)) {
+        if(cg->io_queued.updated && cg->io_queued.enabled == CONFIG_BOOLEAN_YES) {
+            if(!cg->st_queued_ops) {
                 snprintfz(title, CHART_TITLE_MAX, "Queued I/O Operations (all disks)");
 
                 cg->st_queued_ops = rrdset_create_localhost(
@@ -4403,8 +4403,8 @@ void update_cgroup_charts(int update_every) {
             rrdset_done(cg->st_queued_ops);
         }
 
-        if(likely(cg->io_merged.updated && cg->io_merged.enabled == CONFIG_BOOLEAN_YES)) {
-            if(unlikely(!cg->st_merged_ops)) {
+        if(cg->io_merged.updated && cg->io_merged.enabled == CONFIG_BOOLEAN_YES) {
+            if(!cg->st_merged_ops) {
                 snprintfz(title, CHART_TITLE_MAX, "Merged I/O Operations (all disks)");
 
                 cg->st_merged_ops = rrdset_create_localhost(
@@ -4436,11 +4436,11 @@ void update_cgroup_charts(int update_every) {
         if (cg->options & CGROUP_OPTIONS_IS_UNIFIED) {
             struct pressure *res = &cg->cpu_pressure;
 
-            if (likely(res->updated && res->some.enabled)) {
+            if (res->updated && res->some.enabled) {
                 struct pressure_charts *pcs;
                 pcs = &res->some;
 
-                if (unlikely(!pcs->share_time.st)) {
+                if (!pcs->share_time.st) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "CPU some pressure");
                     chart = pcs->share_time.st = rrdset_create_localhost(
@@ -4463,7 +4463,7 @@ void update_cgroup_charts(int update_every) {
                     pcs->share_time.rd300 = rrddim_add(chart, "some 300", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
                 }
 
-                if (unlikely(!pcs->total_time.st)) {
+                if (!pcs->total_time.st) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "CPU some pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
@@ -4486,11 +4486,11 @@ void update_cgroup_charts(int update_every) {
 
                 update_pressure_charts(pcs);
             }
-            if (likely(res->updated && res->full.enabled)) {
+            if (res->updated && res->full.enabled) {
                 struct pressure_charts *pcs;
                 pcs = &res->full;
 
-                if (unlikely(!pcs->share_time.st)) {
+                if (!pcs->share_time.st) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "CPU full pressure");
                     chart = pcs->share_time.st = rrdset_create_localhost(
@@ -4513,7 +4513,7 @@ void update_cgroup_charts(int update_every) {
                     pcs->share_time.rd300 = rrddim_add(chart, "full 300", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
                 }
 
-                if (unlikely(!pcs->total_time.st)) {
+                if (!pcs->total_time.st) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "CPU full pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
@@ -4539,11 +4539,11 @@ void update_cgroup_charts(int update_every) {
 
             res = &cg->memory_pressure;
 
-            if (likely(res->updated && res->some.enabled)) {
+            if (res->updated && res->some.enabled) {
                 struct pressure_charts *pcs;
                 pcs = &res->some;
 
-                if (unlikely(!pcs->share_time.st)) {
+                if (!pcs->share_time.st) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "Memory some pressure");
                     chart = pcs->share_time.st = rrdset_create_localhost(
@@ -4566,7 +4566,7 @@ void update_cgroup_charts(int update_every) {
                     pcs->share_time.rd300 = rrddim_add(chart, "some 300", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
                 }
 
-                if (unlikely(!pcs->total_time.st)) {
+                if (!pcs->total_time.st) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "Memory some pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
@@ -4590,11 +4590,11 @@ void update_cgroup_charts(int update_every) {
                 update_pressure_charts(pcs);
             }
 
-            if (likely(res->updated && res->full.enabled)) {
+            if (res->updated && res->full.enabled) {
                 struct pressure_charts *pcs;
                 pcs = &res->full;
 
-                if (unlikely(!pcs->share_time.st)) {
+                if (!pcs->share_time.st) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "Memory full pressure");
 
@@ -4619,7 +4619,7 @@ void update_cgroup_charts(int update_every) {
                     pcs->share_time.rd300 = rrddim_add(chart, "full 300", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
                 }
 
-                if (unlikely(!pcs->total_time.st)) {
+                if (!pcs->total_time.st) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "Memory full pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
@@ -4645,11 +4645,11 @@ void update_cgroup_charts(int update_every) {
 
             res = &cg->io_pressure;
 
-            if (likely(res->updated && res->some.enabled)) {
+            if (res->updated && res->some.enabled) {
                 struct pressure_charts *pcs;
                 pcs = &res->some;
 
-                if (unlikely(!pcs->share_time.st)) {
+                if (!pcs->share_time.st) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "I/O some pressure");
                     chart = pcs->share_time.st = rrdset_create_localhost(
@@ -4672,7 +4672,7 @@ void update_cgroup_charts(int update_every) {
                     pcs->share_time.rd300 = rrddim_add(chart, "some 300", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
                 }
 
-                if (unlikely(!pcs->total_time.st)) {
+                if (!pcs->total_time.st) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "I/O some pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
@@ -4696,11 +4696,11 @@ void update_cgroup_charts(int update_every) {
                 update_pressure_charts(pcs);
             }
 
-            if (likely(res->updated && res->full.enabled)) {
+            if (res->updated && res->full.enabled) {
                 struct pressure_charts *pcs;
                 pcs = &res->full;
 
-                if (unlikely(!pcs->share_time.st)) {
+                if (!pcs->share_time.st) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "I/O full pressure");
                     chart = pcs->share_time.st = rrdset_create_localhost(
@@ -4723,7 +4723,7 @@ void update_cgroup_charts(int update_every) {
                     pcs->share_time.rd300 = rrddim_add(chart, "full 300", NULL, 1, 100, RRD_ALGORITHM_ABSOLUTE);
                 }
 
-                if (unlikely(!pcs->total_time.st)) {
+                if (!pcs->total_time.st) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "I/O full pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
@@ -4749,7 +4749,7 @@ void update_cgroup_charts(int update_every) {
         }
     }
 
-    if(likely(cgroup_enable_systemd_services))
+    if(cgroup_enable_systemd_services)
         update_systemd_services_charts(update_every, services_do_cpu, services_do_mem_usage, services_do_mem_detailed
                                        , services_do_mem_failcnt, services_do_swap_usage, services_do_io
                                        , services_do_io_ops, services_do_throttle_io, services_do_throttle_ops
@@ -4853,10 +4853,10 @@ void *cgroups_main(void *ptr) {
         worker_is_idle();
 
         usec_t hb_dt = heartbeat_next(&hb, step);
-        if(unlikely(!service_running(SERVICE_COLLECTORS))) break;
+        if(!service_running(SERVICE_COLLECTORS)) break;
 
         find_dt += hb_dt;
-        if (unlikely(find_dt >= find_every || (!is_inside_k8s && cgroups_check))) {
+        if (find_dt >= find_every || (!is_inside_k8s && cgroups_check)) {
             uv_cond_signal(&discovery_thread.cond_var);
             discovery_thread.start_discovery = 1;
             find_dt = 0;
@@ -4868,11 +4868,11 @@ void *cgroups_main(void *ptr) {
 
         worker_is_busy(WORKER_CGROUPS_READ);
         read_all_discovered_cgroups(cgroup_root);
-        if(unlikely(!service_running(SERVICE_COLLECTORS))) break;
+        if(!service_running(SERVICE_COLLECTORS)) break;
 
         worker_is_busy(WORKER_CGROUPS_CHART);
         update_cgroup_charts(cgroup_update_every);
-        if(unlikely(!service_running(SERVICE_COLLECTORS))) break;
+        if(!service_running(SERVICE_COLLECTORS)) break;
 
         worker_is_idle();
         uv_mutex_unlock(&cgroup_root_mutex);

--- a/collectors/cups.plugin/cups_plugin.c
+++ b/collectors/cups.plugin/cups_plugin.c
@@ -170,7 +170,7 @@ void send_job_charts_definitions_to_netdata(const char *name, uint32_t job_id, b
 struct job_metrics *get_job_metrics(char *dest) {
     struct job_metrics *jm = dictionary_get(dict_dest_job_metrics, dest);
 
-    if (unlikely(!jm)) {
+    if (!jm) {
         static uint32_t job_id = 0;
         struct job_metrics new_job_metrics = { .id = ++job_id };
         jm = dictionary_set(dict_dest_job_metrics, dest, &new_job_metrics, sizeof(struct job_metrics));
@@ -262,7 +262,7 @@ int main(int argc, char **argv) {
     for (iteration = 0; 1; iteration++) {
         heartbeat_next(&hb, step);
 
-        if (unlikely(netdata_exit))
+        if (netdata_exit)
             break;
 
         reset_metrics();
@@ -270,7 +270,7 @@ int main(int argc, char **argv) {
         cups_dest_t *dests;
         num_dest_total = cupsGetDests2(http, &dests);
 
-        if(unlikely(num_dest_total == 0)) {
+        if(num_dest_total == 0) {
             // reconnect to cups to check if the server is down.
             httpClose(http);
             http = httpConnect2(cupsServer(), ippPort(), NULL, AF_UNSPEC, cupsEncryption(), 0, netdata_update_every * 1000, NULL);
@@ -334,7 +334,7 @@ int main(int argc, char **argv) {
         }
         cupsFreeDests(num_dest_total, dests);
 
-        if (unlikely(netdata_exit))
+        if (netdata_exit)
             break;
 
         cups_job_t *jobs, *curr_job;
@@ -374,7 +374,7 @@ int main(int argc, char **argv) {
         dictionary_garbage_collect(dict_dest_job_metrics);
 
         static int cups_printer_by_option_created = 0;
-        if (unlikely(!cups_printer_by_option_created))
+        if (!cups_printer_by_option_created)
         {
             cups_printer_by_option_created = 1;
             printf("CHART cups.dest_state '' 'Destinations by state' dests overview cups.dests_state stacked 100000 %i\n", netdata_update_every);
@@ -429,7 +429,7 @@ int main(int argc, char **argv) {
 
         fflush(stdout);
 
-        if (unlikely(netdata_exit))
+        if (netdata_exit)
             break;
 
         // restart check (14400 seconds)

--- a/collectors/debugfs.plugin/debugfs_extfrag.c
+++ b/collectors/debugfs.plugin/debugfs_extfrag.c
@@ -27,7 +27,7 @@ static struct netdata_extrafrag *find_or_create_extrafrag(const char *name)
 
     // search it, from beginning to the end
     for (extrafrag = netdata_extrafrags_root ; extrafrag ; extrafrag = extrafrag->next) {
-        if (unlikely(hash == extrafrag->hash && !strcmp(name, extrafrag->node_zone))) {
+        if (hash == extrafrag->hash && !strcmp(name, extrafrag->node_zone)) {
             return extrafrag;
         }
     }
@@ -63,7 +63,7 @@ int do_debugfs_extfrag(int update_every, const char *name) {
     static procfile *ff = NULL;
     static int chart_order = NETDATA_CHART_PRIO_MEM_FRAGMENTATION;
 
-    if (unlikely(!ff)) {
+    if (!ff) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename,
                   FILENAME_MAX,
@@ -72,17 +72,17 @@ int do_debugfs_extfrag(int update_every, const char *name) {
                   "/sys/kernel/debug/extfrag/extfrag_index");
 
         ff = procfile_open(filename, " \t,", PROCFILE_FLAG_DEFAULT);
-        if (unlikely(!ff)) return 1;
+        if (!ff) return 1;
     }
 
     ff = procfile_readall(ff);
-    if (unlikely(!ff)) return 1;
+    if (!ff) return 1;
 
     size_t l, i, j, lines = procfile_lines(ff);
     for (l = 0; l < lines; l++) {
         char chart_id[64];
         char zone_lowercase[32];
-        if (unlikely(procfile_linewords(ff, l) < 15)) continue;
+        if (procfile_linewords(ff, l) < 15) continue;
         char *zone = procfile_lineword(ff, l, 3);
         strncpyz(zone_lowercase, zone, 31);
         debugfs2lower(zone_lowercase);
@@ -98,7 +98,7 @@ int do_debugfs_extfrag(int update_every, const char *name) {
             line_orders[j] = (collected_number) (value * 1000.0);
         }
 
-        if (unlikely(!extrafrag->id)) {
+        if (!extrafrag->id) {
             extrafrag->id = extrafrag->node_zone;
             fprintf(
                 stdout,

--- a/collectors/debugfs.plugin/debugfs_plugin.c
+++ b/collectors/debugfs.plugin/debugfs_plugin.c
@@ -230,11 +230,11 @@ int main(int argc, char **argv)
 
         for (int i = 0; debugfs_modules[i].name; i++) {
             struct debugfs_module *pm = &debugfs_modules[i];
-            if (unlikely(!pm->enabled))
+            if (!pm->enabled)
                 continue;
 
             pm->enabled = !pm->func(update_every, pm->name);
-            if (likely(pm->enabled))
+            if (pm->enabled)
                 enabled++;
         }
         if (!enabled) {

--- a/collectors/debugfs.plugin/sys_devices_virtual_powercap.c
+++ b/collectors/debugfs.plugin/sys_devices_virtual_powercap.c
@@ -22,7 +22,7 @@ static struct zone_t *g_zones = NULL;
 static int get_measurement(const char *path, struct measurement_t *measurement)
 {
     int result;
-    if (likely((result = read_single_number_file(path, &measurement->energy_uj)) == 0)) {
+    if ((result = read_single_number_file(path, &measurement->energy_uj)) == 0) {
         measurement->time_us = now_monotonic_high_precision_usec();
     }
     return result;
@@ -33,11 +33,11 @@ calculate_watts(unsigned long long max_energy_range_uj, struct measurement_t *be
 {
     unsigned long long energy_uj = 0;
     usec_t delta_us = after->time_us - before->time_us;
-    if (unlikely(delta_us == 0)) {
+    if (delta_us == 0) {
         return 0;
     }
 
-    if (likely(after->energy_uj >= before->energy_uj)) {
+    if (after->energy_uj >= before->energy_uj) {
         energy_uj = after->energy_uj - before->energy_uj;
     } else {
         energy_uj = after->energy_uj + (max_energy_range_uj - before->energy_uj);
@@ -57,20 +57,20 @@ get_zone(const char *control_type, struct zone_t *parent, const char *dirname, s
     }
 
     char *trimmed = trim(name);
-    if (unlikely(trimmed == NULL || trimmed[0] == 0)) {
+    if (trimmed == NULL || trimmed[0] == 0) {
         return NULL;
     }
 
     snprintfz(temp, FILENAME_MAX, "%s/%s", dirname, "max_energy_range_uj");
     unsigned long long max_energy_range_uj = 0;
-    if (unlikely(read_single_number_file(temp, &max_energy_range_uj) != 0)) {
+    if (read_single_number_file(temp, &max_energy_range_uj) != 0) {
         collector_error("Cannot read %s", temp);
         return NULL;
     }
 
     snprintfz(temp, FILENAME_MAX, "%s/%s", dirname, "energy_uj");
     struct measurement_t measurement;
-    if (unlikely(get_measurement(temp, &measurement) != 0)) {
+    if (get_measurement(temp, &measurement) != 0) {
         collector_error("%s: Cannot read %s", trimmed, temp);
         return NULL;
     }
@@ -103,7 +103,7 @@ static void
 look_for_zones(const char *control_type, struct zone_t *parent, const char *path, struct zone_t **zones, size_t *count)
 {
     DIR *dir = opendir(path);
-    if (unlikely(dir == NULL)) {
+    if (dir == NULL) {
         return;
     }
 
@@ -135,7 +135,7 @@ static int get_rapl_zones(struct zone_t **zones)
     snprintfz(dirname, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/devices/virtual/powercap");
 
     DIR *dir = opendir(dirname);
-    if (unlikely(dir == NULL)) {
+    if (dir == NULL) {
         return 0;
     }
 
@@ -199,12 +199,12 @@ static void send_end_and_flush()
 
 int do_sys_devices_virtual_powercap(int update_every, const char *name)
 {
-    if (unlikely(g_zones_count <= 0)) {
+    if (g_zones_count <= 0) {
         g_zones_count = get_rapl_zones(&g_zones);
-        if (unlikely(g_zones_count < 0)) {
+        if (g_zones_count < 0) {
             collector_error("Failed to find powercap zones.");
             return 1;
-        } else if (unlikely(g_zones_count == 0)) {
+        } else if (g_zones_count == 0) {
             collector_info("No powercap zones found.");
             return 1;
         }
@@ -225,7 +225,7 @@ int do_sys_devices_virtual_powercap(int update_every, const char *name)
         struct measurement_t measurement;
         struct zone_t *zone = &g_zones[ii];
 
-        if (unlikely(get_measurement(zone->path, &measurement) != 0)) {
+        if (get_measurement(zone->path, &measurement) != 0) {
             collector_error("%s: Cannot read %s", zone->name, zone->path);
             continue;
         }

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -852,7 +852,7 @@ static inline void ebpf_create_apps_for_module(ebpf_module_t *em, struct ebpf_ta
  */
 static void ebpf_create_apps_charts(struct ebpf_target *root)
 {
-    if (unlikely(!ebpf_all_pids))
+    if (!ebpf_all_pids)
         return;
 
     struct ebpf_target *w;
@@ -862,7 +862,7 @@ static void ebpf_create_apps_charts(struct ebpf_target *root)
         if (w->target)
             continue;
 
-        if (unlikely(w->processes && (debug_enabled || w->debug_enabled))) {
+        if (w->processes && (debug_enabled || w->debug_enabled)) {
             struct ebpf_pid_on_target *pid_on_target;
 
             fprintf(
@@ -1188,7 +1188,7 @@ void ebpf_create_charts_on_apps(char *id, char *title, char *units, char *family
                          update_every, module);
 
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed))
+        if (w->exposed)
             fprintf(stdout, "DIMENSION %s '' %s 1 1\n", w->name, algorithm);
     }
 }
@@ -1684,7 +1684,7 @@ static void read_local_ports(char *filename, uint8_t proto)
     for(l = 0; l < lines ;l++) {
         size_t words = procfile_linewords(ff, l);
         // This is header or end of file
-        if (unlikely(words < 14))
+        if (words < 14)
             continue;
 
         // https://elixir.bootlin.com/linux/v5.7.8/source/include/net/tcp_states.h
@@ -2921,13 +2921,13 @@ static char *ebpf_get_process_name(pid_t pid)
     snprintfz(filename, FILENAME_MAX, "/proc/%d/status", pid);
 
     procfile *ff = procfile_open(filename, " \t", PROCFILE_FLAG_DEFAULT);
-    if(unlikely(!ff)) {
+    if(!ff) {
         netdata_log_error("Cannot open %s", filename);
         return name;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff))
+    if(!ff)
         return name;
 
     unsigned long i, lines = procfile_lines(ff);

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -775,7 +775,7 @@ static void ebpf_update_cachestat_cgroup(int maps_per_core)
         for (pids = ect->pids; pids; pids = pids->next) {
             int pid = pids->pid;
             netdata_cachestat_pid_t *out = &pids->cachestat;
-            if (likely(cachestat_pid) && cachestat_pid[pid]) {
+            if (cachestat_pid && cachestat_pid[pid]) {
                 netdata_publish_cachestat_t *in = cachestat_pid[pid];
 
                 memcpy(out, &in->current, sizeof(netdata_cachestat_pid_t));
@@ -941,7 +941,7 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_CACHESTAT_HIT_RATIO_CHART);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             ebpf_cachestat_sum_pids(&w->cachestat, w->root_pid);
             netdata_cachestat_pid_t *current = &w->cachestat.current;
             netdata_cachestat_pid_t *prev = &w->cachestat.prev;
@@ -962,7 +962,7 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_CACHESTAT_DIRTY_CHART);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             value = (collected_number) w->cachestat.dirty;
             write_chart_dimension(w->name, value);
         }
@@ -971,7 +971,7 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_CACHESTAT_HIT_CHART);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             value = (collected_number) w->cachestat.hit;
             write_chart_dimension(w->name, value);
         }
@@ -980,7 +980,7 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_CACHESTAT_MISSES_CHART);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             value = (collected_number) w->cachestat.miss;
             write_chart_dimension(w->name, value);
         }
@@ -1089,7 +1089,7 @@ static void ebpf_send_systemd_cachestat_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_HIT_RATIO_CHART);
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long)ect->publish_cachestat.ratio);
         }
     }
@@ -1097,7 +1097,7 @@ static void ebpf_send_systemd_cachestat_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_DIRTY_CHART);
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long)ect->publish_cachestat.dirty);
         }
     }
@@ -1105,7 +1105,7 @@ static void ebpf_send_systemd_cachestat_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_HIT_CHART);
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long)ect->publish_cachestat.hit);
         }
     }
@@ -1113,7 +1113,7 @@ static void ebpf_send_systemd_cachestat_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_MISSES_CHART);
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long)ect->publish_cachestat.miss);
         }
     }

--- a/collectors/ebpf.plugin/ebpf_cgroup.c
+++ b/collectors/ebpf.plugin/ebpf_cgroup.c
@@ -80,7 +80,7 @@ void ebpf_map_cgroup_shared_memory()
     // Map only header
     void *mapped = (netdata_ebpf_cgroup_shm_header_t *) ebpf_cgroup_map_shm_locally(shm_fd_ebpf_cgroup,
                                                                                    sizeof(netdata_ebpf_cgroup_shm_header_t));
-    if (unlikely(mapped == SEM_FAILED)) {
+    if (mapped == SEM_FAILED) {
         return;
     }
     netdata_ebpf_cgroup_shm_header_t *header = mapped;
@@ -94,7 +94,7 @@ void ebpf_map_cgroup_shared_memory()
     }
 
     ebpf_mapped_memory = (void *)ebpf_cgroup_map_shm_locally(shm_fd_ebpf_cgroup, length);
-    if (unlikely(ebpf_mapped_memory == MAP_FAILED)) {
+    if (ebpf_mapped_memory == MAP_FAILED) {
         return;
     }
     shm_ebpf_cgroup.header = ebpf_mapped_memory;
@@ -335,7 +335,7 @@ void ebpf_create_charts_on_systemd(char *id, char *title, char *units, char *fam
                          order, update_every, module);
 
     for (w = ebpf_cgroup_pids; w; w = w->next) {
-        if (unlikely(w->systemd) && unlikely(w->updated))
+        if (w->systemd && w->updated)
             fprintf(stdout, "DIMENSION %s '' %s 1 1\n", w->name, algorithm);
     }
 }

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -666,7 +666,7 @@ static void ebpf_update_dc_cgroup(int maps_per_core)
         for (pids = ect->pids; pids; pids = pids->next) {
             int pid = pids->pid;
             netdata_dcstat_pid_t *out = &pids->dc;
-            if (likely(dcstat_pid) && dcstat_pid[pid]) {
+            if (dcstat_pid && dcstat_pid[pid]) {
                 netdata_publish_dcstat_t *in = dcstat_pid[pid];
 
                 memcpy(out, &in->curr, sizeof(netdata_dcstat_pid_t));
@@ -748,7 +748,7 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_DC_HIT_CHART);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             ebpf_dcstat_sum_pids(&w->dcstat, w->root_pid);
 
             uint64_t cache = w->dcstat.curr.cache_access;
@@ -763,7 +763,7 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_DC_REFERENCE_CHART);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             if (w->dcstat.curr.cache_access < w->dcstat.prev.cache_access) {
                 w->dcstat.prev.cache_access = 0;
             }
@@ -778,7 +778,7 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_DC_REQUEST_NOT_CACHE_CHART);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             if (w->dcstat.curr.file_system < w->dcstat.prev.file_system) {
                 w->dcstat.prev.file_system = 0;
             }
@@ -793,7 +793,7 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_DC_REQUEST_NOT_FOUND_CHART);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             if (w->dcstat.curr.not_found < w->dcstat.prev.not_found) {
                 w->dcstat.prev.not_found = 0;
             }
@@ -1031,7 +1031,7 @@ static void ebpf_send_systemd_dc_charts()
     ebpf_cgroup_target_t *ect;
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_HIT_CHART);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long) ect->publish_dc.ratio);
         }
     }
@@ -1039,7 +1039,7 @@ static void ebpf_send_systemd_dc_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_REFERENCE_CHART);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long) ect->publish_dc.cache_access);
         }
     }
@@ -1047,7 +1047,7 @@ static void ebpf_send_systemd_dc_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_REQUEST_NOT_CACHE_CHART);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             value = (collected_number) (!ect->publish_dc.cache_access) ? 0 :
                 (long long )ect->publish_dc.curr.file_system - (long long)ect->publish_dc.prev.file_system;
             ect->publish_dc.prev.file_system = ect->publish_dc.curr.file_system;
@@ -1059,7 +1059,7 @@ static void ebpf_send_systemd_dc_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_REQUEST_NOT_FOUND_CHART);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             value = (collected_number) (!ect->publish_dc.cache_access) ? 0 :
                 (long long)ect->publish_dc.curr.not_found - (long long)ect->publish_dc.prev.not_found;
 

--- a/collectors/ebpf.plugin/ebpf_disk.c
+++ b/collectors/ebpf.plugin/ebpf_disk.c
@@ -300,7 +300,7 @@ static void update_disk_table(char *name, int major, int minor, time_t current_t
     }
 
     netdata_ebpf_disks_t *update_next = disk_list;
-    if (likely(disk_list)) {
+    if (disk_list) {
         netdata_ebpf_disks_t *move = disk_list;
         while (move) {
             if (dev == move->dev)
@@ -374,7 +374,7 @@ static int read_local_disks()
     for(l = 2; l < lines ;l++) {
         size_t words = procfile_linewords(ff, l);
         // This is header or end of file
-        if (unlikely(words < 4))
+        if (words < 4)
             continue;
 
         int major = (int)strtol(procfile_lineword(ff, l, 0), NULL, 10);
@@ -558,7 +558,7 @@ static void ebpf_fill_plot_disks(netdata_ebpf_disks_t *ptr)
 {
     pthread_mutex_lock(&plot_mutex);
     ebpf_publish_disk_t *w;
-    if (likely(plot_disks)) {
+    if (plot_disks) {
         ebpf_publish_disk_t *move = plot_disks, *store = plot_disks;
         while (move) {
             if (move->plot == ptr) {
@@ -608,7 +608,7 @@ static void read_hard_disk_tables(int table, int maps_per_core)
         netdata_ebpf_disks_t find;
         find.dev = key.dev;
 
-        if (likely(ret)) {
+        if (ret) {
             if (find.dev != ret->dev)
                 ret = (netdata_ebpf_disks_t *)avl_search_lock(&disk_tree, (avl_t *)&find);
         } else

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -740,7 +740,7 @@ static void ebpf_update_fd_cgroup(int maps_per_core)
         for (pids = ect->pids; pids; pids = pids->next) {
             int pid = pids->pid;
             netdata_fd_stat_t *out = &pids->fd;
-            if (likely(fd_pid) && fd_pid[pid]) {
+            if (fd_pid && fd_pid[pid]) {
                 netdata_fd_stat_t *in = fd_pid[pid];
 
                 memcpy(out, in, sizeof(netdata_fd_stat_t));
@@ -802,14 +802,14 @@ void ebpf_fd_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 {
     struct ebpf_target *w;
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             ebpf_fd_sum_pids(&w->fd, w->root_pid);
         }
     }
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_OPEN);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             write_chart_dimension(w->name, w->fd.open_call);
         }
     }
@@ -818,7 +818,7 @@ void ebpf_fd_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     if (em->mode < MODE_ENTRY) {
         write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_OPEN_ERROR);
         for (w = root; w; w = w->next) {
-            if (unlikely(w->exposed && w->processes)) {
+            if (w->exposed && w->processes) {
                 write_chart_dimension(w->name, w->fd.open_err);
             }
         }
@@ -827,7 +827,7 @@ void ebpf_fd_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_CLOSED);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             write_chart_dimension(w->name, w->fd.close_call);
         }
     }
@@ -836,7 +836,7 @@ void ebpf_fd_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     if (em->mode < MODE_ENTRY) {
         write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_CLOSE_ERROR);
         for (w = root; w; w = w->next) {
-            if (unlikely(w->exposed && w->processes)) {
+            if (w->exposed && w->processes) {
                 write_chart_dimension(w->name, w->fd.close_err);
             }
         }
@@ -1039,7 +1039,7 @@ static void ebpf_send_systemd_fd_charts(ebpf_module_t *em)
     ebpf_cgroup_target_t *ect;
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_OPEN);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, ect->publish_systemd_fd.open_call);
         }
     }
@@ -1048,7 +1048,7 @@ static void ebpf_send_systemd_fd_charts(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_OPEN_ERROR);
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-            if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+            if (ect->systemd && ect->updated) {
                 write_chart_dimension(ect->name, ect->publish_systemd_fd.open_err);
             }
         }
@@ -1057,7 +1057,7 @@ static void ebpf_send_systemd_fd_charts(ebpf_module_t *em)
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_CLOSED);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, ect->publish_systemd_fd.close_call);
         }
     }
@@ -1066,7 +1066,7 @@ static void ebpf_send_systemd_fd_charts(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_CLOSE_ERROR);
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-            if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+            if (ect->systemd && ect->updated) {
                 write_chart_dimension(ect->name, ect->publish_systemd_fd.close_err);
             }
         }

--- a/collectors/ebpf.plugin/ebpf_filesystem.c
+++ b/collectors/ebpf.plugin/ebpf_filesystem.c
@@ -542,14 +542,14 @@ static int ebpf_read_local_partitions()
     char filename[FILENAME_MAX + 1];
     snprintfz(filename, FILENAME_MAX, "%s/proc/self/mountinfo", netdata_configured_host_prefix);
     procfile *ff = procfile_open(filename, " \t", PROCFILE_FLAG_DEFAULT);
-    if(unlikely(!ff)) {
+    if(!ff) {
         snprintfz(filename, FILENAME_MAX, "%s/proc/1/mountinfo", netdata_configured_host_prefix);
         ff = procfile_open(filename, " \t", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff)) return 0;
+        if(!ff) return 0;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff))
+    if(!ff)
         return 0;
 
     int count = 0;

--- a/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -316,37 +316,37 @@ static int hardirq_parse_interrupts(char *irq_name, int irq)
 {
     static procfile *ff = NULL;
     static int cpus = -1;
-    if(unlikely(!ff)) {
+    if(!ff) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/interrupts");
         ff = procfile_open(filename, " \t:", PROCFILE_FLAG_DEFAULT);
     }
-    if(unlikely(!ff))
+    if(!ff)
         return -1;
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff))
+    if(!ff)
         return -1; // we return 0, so that we will retry to open it next time
 
     size_t words = procfile_linewords(ff, 0);
-    if(unlikely(cpus == -1)) {
+    if(cpus == -1) {
         uint32_t w;
         cpus = 0;
         for(w = 0; w < words ; w++) {
-            if(likely(strncmp(procfile_lineword(ff, 0, w), "CPU", 3) == 0))
+            if(strncmp(procfile_lineword(ff, 0, w), "CPU", 3) == 0)
                 cpus++;
         }
    }
 
     size_t lines = procfile_lines(ff), l;
-    if(unlikely(!lines)) {
+    if(!lines) {
         collector_error("Cannot read /proc/interrupts, zero lines reported.");
         return -1;
     }
 
     for(l = 1; l < lines ;l++) {
         words = procfile_linewords(ff, l);
-        if(unlikely(!words)) continue;
+        if(!words) continue;
         const char *id = procfile_lineword(ff, l, 0);
         if (!isdigit(id[0]))
             continue;
@@ -355,7 +355,7 @@ static int hardirq_parse_interrupts(char *irq_name, int irq)
         if (cmp != irq)
             continue;
 
-        if(unlikely((uint32_t)(cpus + 2) < words)) {
+        if((uint32_t)(cpus + 2) < words) {
             const char *name = procfile_lineword(ff, l, words - 1);
             // On some motherboards IRQ can have the same name, so we append IRQ id to differentiate.
             snprintfz(irq_name, NETDATA_HARDIRQ_NAME_LEN - 1, "%d_%s", irq, name);
@@ -388,7 +388,7 @@ static int hardirq_read_latency_map(int mapfd)
     while (bpf_map_get_next_key(mapfd, &key, &next_key) == 0) {
         // get val for this key.
         int test = bpf_map_lookup_elem(mapfd, &key, hardirq_ebpf_vals);
-        if (unlikely(test < 0)) {
+        if (test < 0) {
             key = next_key;
             continue;
         }
@@ -409,7 +409,7 @@ static int hardirq_read_latency_map(int mapfd)
         bool v_is_new = false;
         search_v.irq = key.irq;
         v = (hardirq_val_t *)avl_search_lock(&hardirq_pub, (avl_t *)&search_v);
-        if (unlikely(v == NULL)) {
+        if (v == NULL) {
             // latency/name can only be added reliably at a later time.
             // when they're added, only then will we AVL insert.
             v = ebpf_hardirq_get();
@@ -462,7 +462,7 @@ static void hardirq_read_latency_static_map(int mapfd)
     for (i = 0; i < HARDIRQ_EBPF_STATIC_END; i++) {
         uint32_t map_i = hardirq_static_vals[i].idx;
         int test = bpf_map_lookup_elem(mapfd, &map_i, hardirq_ebpf_static_vals);
-        if (unlikely(test < 0)) {
+        if (test < 0) {
             continue;
         }
 

--- a/collectors/ebpf.plugin/ebpf_mdflush.c
+++ b/collectors/ebpf.plugin/ebpf_mdflush.c
@@ -227,7 +227,7 @@ static void mdflush_read_count_map(int maps_per_core)
 
         // get val for this key.
         int test = bpf_map_lookup_elem(mapfd, &key, mdflush_ebpf_vals);
-        if (unlikely(test < 0)) {
+        if (test < 0) {
             continue;
         }
 
@@ -250,7 +250,7 @@ static void mdflush_read_count_map(int maps_per_core)
             &mdflush_pub,
             (avl_t *)&search_v
         );
-        if (unlikely(v == NULL)) {
+        if (v == NULL) {
             // flush count can only be added reliably at a later time.
             // when they're added, only then will we AVL insert.
             v = callocz(1, sizeof(netdata_mdflush_t));

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -205,7 +205,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_PROCESS);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t, create_process));
             write_chart_dimension(w->name, value);
         }
@@ -214,7 +214,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_THREAD);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t, create_thread));
             write_chart_dimension(w->name, value);
         }
@@ -223,7 +223,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_EXIT);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t,
                                                                            exit_call));
             write_chart_dimension(w->name, value);
@@ -233,7 +233,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_CLOSE);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t,
                                                                            release_call));
             write_chart_dimension(w->name, value);
@@ -244,7 +244,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_ERROR);
         for (w = root; w; w = w->next) {
-            if (unlikely(w->exposed && w->processes)) {
+            if (w->exposed && w->processes) {
                 value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t,
                                                                                task_err));
                 write_chart_dimension(w->name, value);
@@ -991,7 +991,7 @@ static void ebpf_send_systemd_process_charts(ebpf_module_t *em)
     ebpf_cgroup_target_t *ect;
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_PROCESS);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, ect->publish_systemd_ps.create_process);
         }
     }
@@ -999,7 +999,7 @@ static void ebpf_send_systemd_process_charts(ebpf_module_t *em)
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_THREAD);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, ect->publish_systemd_ps.create_thread);
         }
     }
@@ -1007,7 +1007,7 @@ static void ebpf_send_systemd_process_charts(ebpf_module_t *em)
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_EXIT);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, ect->publish_systemd_ps.exit_call);
         }
     }
@@ -1015,7 +1015,7 @@ static void ebpf_send_systemd_process_charts(ebpf_module_t *em)
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_CLOSE);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, ect->publish_systemd_ps.release_call);
         }
     }
@@ -1024,7 +1024,7 @@ static void ebpf_send_systemd_process_charts(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_ERROR);
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-            if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+            if (ect->systemd && ect->updated) {
                 write_chart_dimension(ect->name, ect->publish_systemd_ps.task_err);
             }
         }

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -559,7 +559,7 @@ static void ebpf_update_shm_cgroup(int maps_per_core)
         for (pids = ect->pids; pids; pids = pids->next) {
             int pid = pids->pid;
             netdata_publish_shm_t *out = &pids->shm;
-            if (likely(shm_pid) && shm_pid[pid]) {
+            if (shm_pid && shm_pid[pid]) {
                 netdata_publish_shm_t *in = shm_pid[pid];
 
                 memcpy(out, in, sizeof(netdata_publish_shm_t));
@@ -699,14 +699,14 @@ void ebpf_shm_send_apps_data(struct ebpf_target *root)
 {
     struct ebpf_target *w;
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             ebpf_shm_sum_pids(&w->shm, w->root_pid);
         }
     }
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMGET_CHART);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             write_chart_dimension(w->name, (long long) w->shm.get);
         }
     }
@@ -714,7 +714,7 @@ void ebpf_shm_send_apps_data(struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMAT_CHART);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             write_chart_dimension(w->name, (long long) w->shm.at);
         }
     }
@@ -722,7 +722,7 @@ void ebpf_shm_send_apps_data(struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMDT_CHART);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             write_chart_dimension(w->name, (long long) w->shm.dt);
         }
     }
@@ -730,7 +730,7 @@ void ebpf_shm_send_apps_data(struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMCTL_CHART);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             write_chart_dimension(w->name, (long long) w->shm.ctl);
         }
     }
@@ -915,7 +915,7 @@ static void ebpf_send_systemd_shm_charts()
     ebpf_cgroup_target_t *ect;
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMGET_CHART);
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long)ect->publish_shm.get);
         }
     }
@@ -923,7 +923,7 @@ static void ebpf_send_systemd_shm_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMAT_CHART);
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long)ect->publish_shm.at);
         }
     }
@@ -931,7 +931,7 @@ static void ebpf_send_systemd_shm_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMDT_CHART);
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long)ect->publish_shm.dt);
         }
     }
@@ -939,7 +939,7 @@ static void ebpf_send_systemd_shm_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMCTL_CHART);
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long)ect->publish_shm.ctl);
         }
     }

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -526,7 +526,7 @@ static void clean_allocated_socket_plot()
  * @param ptr a pointer to the link list.
 static void clean_network_ports(ebpf_network_viewer_port_list_t *ptr)
 {
-    if (unlikely(!ptr))
+    if (!ptr)
         return;
 
     while (ptr) {
@@ -546,7 +546,7 @@ static void clean_network_ports(ebpf_network_viewer_port_list_t *ptr)
  * @param names the link list.
 static void clean_service_names(ebpf_network_viewer_dim_name_t *names)
 {
-    if (unlikely(!names))
+    if (!names)
         return;
 
     while (names) {
@@ -564,7 +564,7 @@ static void clean_service_names(ebpf_network_viewer_dim_name_t *names)
  * @param hostnames the hostnames to clean
 static void clean_hostnames(ebpf_network_viewer_hostname_list_t *hostnames)
 {
-    if (unlikely(!hostnames))
+    if (!hostnames)
         return;
 
     while (hostnames) {
@@ -1007,7 +1007,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V4);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           call_tcp_v4_connection));
             write_chart_dimension(w->name, value);
@@ -1017,7 +1017,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V6);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           call_tcp_v6_connection));
             write_chart_dimension(w->name, value);
@@ -1027,7 +1027,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_SENT);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           bytes_sent));
             // We multiply by 0.008, because we read bytes, but we display bits
@@ -1038,7 +1038,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_RECV);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           bytes_received));
             // We multiply by 0.008, because we read bytes, but we display bits
@@ -1049,7 +1049,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           call_tcp_sent));
             write_chart_dimension(w->name, value);
@@ -1059,7 +1059,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           call_tcp_received));
             write_chart_dimension(w->name, value);
@@ -1069,7 +1069,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           retransmit));
             write_chart_dimension(w->name, value);
@@ -1079,7 +1079,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           call_udp_sent));
             write_chart_dimension(w->name, value);
@@ -1089,7 +1089,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           call_udp_received));
             write_chart_dimension(w->name, value);
@@ -2104,7 +2104,7 @@ static inline void fill_nv_port_list(ebpf_network_viewer_port_list_t *out, uint1
 void update_listen_table(uint16_t value, uint16_t proto, netdata_passive_connection_t *in)
 {
     ebpf_network_viewer_port_list_t *w;
-    if (likely(listen_ports)) {
+    if (listen_ports) {
         ebpf_network_viewer_port_list_t *move = listen_ports, *store = listen_ports;
         while (move) {
             if (move->protocol == proto && move->first == value) {
@@ -2354,7 +2354,7 @@ static void ebpf_update_socket_cgroup(int maps_per_core)
             int pid = pids->pid;
             ebpf_bandwidth_t *out = &pids->socket;
             ebpf_socket_publish_apps_t *publish = &ect->publish_socket;
-            if (likely(socket_bandwidth_curr) && socket_bandwidth_curr[pid]) {
+            if (socket_bandwidth_curr && socket_bandwidth_curr[pid]) {
                 ebpf_socket_publish_apps_t *in = socket_bandwidth_curr[pid];
 
                 publish->bytes_sent = in->bytes_sent;
@@ -2758,7 +2758,7 @@ static void ebpf_send_systemd_socket_charts()
     ebpf_cgroup_target_t *ect;
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V4);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.call_tcp_v4_connection);
         }
     }
@@ -2766,7 +2766,7 @@ static void ebpf_send_systemd_socket_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V6);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.call_tcp_v6_connection);
         }
     }
@@ -2774,7 +2774,7 @@ static void ebpf_send_systemd_socket_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_SENT);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.bytes_sent);
         }
     }
@@ -2782,7 +2782,7 @@ static void ebpf_send_systemd_socket_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_RECV);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.bytes_received);
         }
     }
@@ -2790,7 +2790,7 @@ static void ebpf_send_systemd_socket_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.call_tcp_sent);
         }
     }
@@ -2798,7 +2798,7 @@ static void ebpf_send_systemd_socket_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.call_tcp_received);
         }
     }
@@ -2806,7 +2806,7 @@ static void ebpf_send_systemd_socket_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.retransmit);
         }
     }
@@ -2814,7 +2814,7 @@ static void ebpf_send_systemd_socket_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.call_udp_sent);
         }
     }
@@ -2822,7 +2822,7 @@ static void ebpf_send_systemd_socket_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.call_udp_received);
         }
     }
@@ -3050,7 +3050,7 @@ static void initialize_inbound_outbound()
  */
 static inline void fill_port_list(ebpf_network_viewer_port_list_t **out, ebpf_network_viewer_port_list_t *in)
 {
-    if (likely(*out)) {
+    if (*out) {
         ebpf_network_viewer_port_list_t *move = *out, *store = *out;
         uint16_t first = ntohs(in->first);
         uint16_t last = ntohs(in->last);
@@ -3311,7 +3311,7 @@ void ebpf_fill_ip_list(ebpf_network_viewer_ip_list_t **out, ebpf_network_viewer_
         in->first.addr32[0] = ntohl(in->first.addr32[0]);
         in->last.addr32[0] = ntohl(in->last.addr32[0]);
     }
-    if (likely(*out)) {
+    if (*out) {
         ebpf_network_viewer_ip_list_t *move = *out, *store = *out;
         while (move) {
             if (in->ver == move->ver &&
@@ -3530,15 +3530,15 @@ cleanipdup:
 static void ebpf_parse_ips(char *ptr)
 {
     // No value
-    if (unlikely(!ptr))
+    if (!ptr)
         return;
 
-    while (likely(ptr)) {
+    while (ptr) {
         // Move forward until next valid character
         while (isspace(*ptr)) ptr++;
 
         // No valid value found
-        if (unlikely(!*ptr))
+        if (!*ptr)
             return;
 
         // Find space that ends the list
@@ -3592,7 +3592,7 @@ static void parse_port_list(void **out, char *range)
     while (*end && *end != ':' && *end != '-') end++;
 
     //It has a range
-    if (likely(*end)) {
+    if (*end) {
         *end++ = '\0';
         if (*end == '!') {
             netdata_log_info("The exclusion cannot be in the second part of the range, the range %s will be ignored.", copied);
@@ -3679,15 +3679,15 @@ static void read_max_dimension(struct config *cfg)
 static void parse_ports(char *ptr)
 {
     // No value
-    if (unlikely(!ptr))
+    if (!ptr)
         return;
 
-    while (likely(ptr)) {
+    while (ptr) {
         // Move forward until next valid character
         while (isspace(*ptr)) ptr++;
 
         // No valid value found
-        if (unlikely(!*ptr))
+        if (!*ptr)
             return;
 
         // Find space that ends the list
@@ -3725,7 +3725,7 @@ static void parse_ports(char *ptr)
  */
 static void link_hostname(ebpf_network_viewer_hostname_list_t **out, ebpf_network_viewer_hostname_list_t *in)
 {
-    if (likely(*out)) {
+    if (*out) {
         ebpf_network_viewer_hostname_list_t *move = *out;
         for (; move->next ; move = move->next ) {
             if (move->hash == in->hash && !strcmp(move->value, in->value)) {
@@ -3760,15 +3760,15 @@ static void link_hostname(ebpf_network_viewer_hostname_list_t **out, ebpf_networ
 static void link_hostnames(char *parse)
 {
     // No value
-    if (unlikely(!parse))
+    if (!parse)
         return;
 
-    while (likely(parse)) {
+    while (parse) {
         // Find the first valid value
         while (isspace(*parse)) parse++;
 
         // No valid value found
-        if (unlikely(!*parse))
+        if (!*parse)
             return;
 
         // Find space that ends the list
@@ -3855,7 +3855,7 @@ static void link_dimension_name(char *port, uint32_t hash, char *value)
     w->port = (uint16_t) htons(test);
 
     ebpf_network_viewer_dim_name_t *names = network_viewer_opt.names;
-    if (unlikely(!names)) {
+    if (!names) {
         network_viewer_opt.names = w;
     } else {
         for (; names->next; names = names->next) {

--- a/collectors/ebpf.plugin/ebpf_softirq.c
+++ b/collectors/ebpf.plugin/ebpf_softirq.c
@@ -141,7 +141,7 @@ static void softirq_read_latency_map(int maps_per_core)
 
     for (i = 0; i < NETDATA_SOFTIRQ_MAX_IRQS; i++) {
         int test = bpf_map_lookup_elem(fd, &i, softirq_ebpf_vals);
-        if (unlikely(test < 0)) {
+        if (test < 0) {
             continue;
         }
 

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -445,7 +445,7 @@ static void ebpf_update_swap_cgroup(int maps_per_core)
         for (pids = ect->pids; pids; pids = pids->next) {
             int pid = pids->pid;
             netdata_publish_swap_t *out = &pids->swap;
-            if (likely(swap_pid) && swap_pid[pid]) {
+            if (swap_pid && swap_pid[pid]) {
                 netdata_publish_swap_t *in = swap_pid[pid];
 
                 memcpy(out, in, sizeof(netdata_publish_swap_t));
@@ -576,14 +576,14 @@ void ebpf_swap_send_apps_data(struct ebpf_target *root)
 {
     struct ebpf_target *w;
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             ebpf_swap_sum_pids(&w->swap, w->root_pid);
         }
     }
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_MEM_SWAP_READ_CHART);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             write_chart_dimension(w->name, (long long) w->swap.read);
         }
     }
@@ -591,7 +591,7 @@ void ebpf_swap_send_apps_data(struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_MEM_SWAP_WRITE_CHART);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             write_chart_dimension(w->name, (long long) w->swap.write);
         }
     }
@@ -634,7 +634,7 @@ static void ebpf_send_systemd_swap_charts()
     ebpf_cgroup_target_t *ect;
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_MEM_SWAP_READ_CHART);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long) ect->publish_systemd_swap.read);
         }
     }
@@ -642,7 +642,7 @@ static void ebpf_send_systemd_swap_charts()
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_MEM_SWAP_WRITE_CHART);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, (long long) ect->publish_systemd_swap.write);
         }
     }

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -1086,14 +1086,14 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 {
     struct ebpf_target *w;
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             ebpf_vfs_sum_pids(&w->vfs, w->root_pid);
         }
     }
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_DELETED);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             write_chart_dimension(w->name, w->vfs.unlink_call);
         }
     }
@@ -1101,7 +1101,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             write_chart_dimension(w->name, w->vfs.write_call + w->vfs.writev_call);
         }
     }
@@ -1110,7 +1110,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     if (em->mode < MODE_ENTRY) {
         write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR);
         for (w = root; w; w = w->next) {
-            if (unlikely(w->exposed && w->processes)) {
+            if (w->exposed && w->processes) {
                 write_chart_dimension(w->name, w->vfs.write_err + w->vfs.writev_err);
             }
         }
@@ -1119,7 +1119,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             write_chart_dimension(w->name, w->vfs.read_call + w->vfs.readv_call);
         }
     }
@@ -1128,7 +1128,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     if (em->mode < MODE_ENTRY) {
         write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR);
         for (w = root; w; w = w->next) {
-            if (unlikely(w->exposed && w->processes)) {
+            if (w->exposed && w->processes) {
                 write_chart_dimension(w->name, w->vfs.read_err + w->vfs.readv_err);
             }
         }
@@ -1137,7 +1137,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             write_chart_dimension(w->name, w->vfs.write_bytes + w->vfs.writev_bytes);
         }
     }
@@ -1145,7 +1145,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_BYTES);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             write_chart_dimension(w->name, w->vfs.read_bytes + w->vfs.readv_bytes);
         }
     }
@@ -1153,7 +1153,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             write_chart_dimension(w->name, w->vfs.fsync_call);
         }
     }
@@ -1162,7 +1162,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     if (em->mode < MODE_ENTRY) {
         write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR);
         for (w = root; w; w = w->next) {
-            if (unlikely(w->exposed && w->processes)) {
+            if (w->exposed && w->processes) {
                 write_chart_dimension(w->name, w->vfs.fsync_err);
             }
         }
@@ -1171,7 +1171,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             write_chart_dimension(w->name, w->vfs.open_call);
         }
     }
@@ -1180,7 +1180,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     if (em->mode < MODE_ENTRY) {
         write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR);
         for (w = root; w; w = w->next) {
-            if (unlikely(w->exposed && w->processes)) {
+            if (w->exposed && w->processes) {
                 write_chart_dimension(w->name, w->vfs.open_err);
             }
         }
@@ -1189,7 +1189,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE);
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
+        if (w->exposed && w->processes) {
             write_chart_dimension(w->name, w->vfs.create_call);
         }
     }
@@ -1198,7 +1198,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     if (em->mode < MODE_ENTRY) {
         write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR);
         for (w = root; w; w = w->next) {
-            if (unlikely(w->exposed && w->processes)) {
+            if (w->exposed && w->processes) {
                 write_chart_dimension(w->name, w->vfs.create_err);
             }
         }
@@ -1311,7 +1311,7 @@ static void read_update_vfs_cgroup(int maps_per_core)
         for (pids = ect->pids; pids; pids = pids->next) {
             int pid = pids->pid;
             netdata_publish_vfs_t *out = &pids->vfs;
-            if (likely(vfs_pid) && vfs_pid[pid]) {
+            if (vfs_pid && vfs_pid[pid]) {
                 netdata_publish_vfs_t *in = vfs_pid[pid];
 
                 memcpy(out, in, sizeof(netdata_publish_vfs_t));
@@ -1776,7 +1776,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
     ebpf_cgroup_target_t *ect;
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_DELETED);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.unlink_call);
         }
     }
@@ -1784,7 +1784,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.write_call +
             ect->publish_systemd_vfs.writev_call);
         }
@@ -1794,7 +1794,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR);
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-            if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+            if (ect->systemd && ect->updated) {
                 write_chart_dimension(ect->name, ect->publish_systemd_vfs.write_err +
                 ect->publish_systemd_vfs.writev_err);
             }
@@ -1804,7 +1804,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.read_call +
             ect->publish_systemd_vfs.readv_call);
         }
@@ -1814,7 +1814,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR);
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-            if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+            if (ect->systemd && ect->updated) {
                 write_chart_dimension(ect->name, ect->publish_systemd_vfs.read_err +
                 ect->publish_systemd_vfs.readv_err);
             }
@@ -1824,7 +1824,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.write_bytes +
             ect->publish_systemd_vfs.writev_bytes);
         }
@@ -1834,7 +1834,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_BYTES);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.read_bytes +
             ect->publish_systemd_vfs.readv_bytes);
         }
@@ -1843,7 +1843,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.fsync_call);
         }
     }
@@ -1852,7 +1852,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR);
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-            if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+            if (ect->systemd && ect->updated) {
                 write_chart_dimension(ect->name, ect->publish_systemd_vfs.fsync_err);
             }
         }
@@ -1861,7 +1861,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.open_call);
         }
     }
@@ -1870,7 +1870,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR);
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-            if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+            if (ect->systemd && ect->updated) {
                 write_chart_dimension(ect->name, ect->publish_systemd_vfs.open_err);
             }
         }
@@ -1879,7 +1879,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+        if (ect->systemd && ect->updated) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.create_call);
         }
     }
@@ -1888,7 +1888,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR);
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-            if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+            if (ect->systemd && ect->updated) {
                 write_chart_dimension(ect->name, ect->publish_systemd_vfs.create_err);
             }
         }

--- a/collectors/freebsd.plugin/freebsd_getifaddrs.c
+++ b/collectors/freebsd.plugin/freebsd_getifaddrs.c
@@ -51,15 +51,15 @@ static struct cgroup_network_interface *network_interfaces_root = NULL, *network
 static size_t network_interfaces_added = 0, network_interfaces_found = 0;
 
 static void network_interface_free(struct cgroup_network_interface *ifm) {
-    if (likely(ifm->st_bandwidth))
+    if (ifm->st_bandwidth)
         rrdset_is_obsolete(ifm->st_bandwidth);
-    if (likely(ifm->st_packets))
+    if (ifm->st_packets)
         rrdset_is_obsolete(ifm->st_packets);
-    if (likely(ifm->st_errors))
+    if (ifm->st_errors)
         rrdset_is_obsolete(ifm->st_errors);
-    if (likely(ifm->st_drops))
+    if (ifm->st_drops)
         rrdset_is_obsolete(ifm->st_drops);
-    if (likely(ifm->st_events))
+    if (ifm->st_events)
         rrdset_is_obsolete(ifm->st_events);
 
     network_interfaces_added--;
@@ -68,11 +68,11 @@ static void network_interface_free(struct cgroup_network_interface *ifm) {
 }
 
 static void network_interfaces_cleanup() {
-    if (likely(network_interfaces_found == network_interfaces_added)) return;
+    if (network_interfaces_found == network_interfaces_added) return;
 
     struct cgroup_network_interface *ifm = network_interfaces_root, *last = NULL;
     while(ifm) {
-        if (unlikely(!ifm->updated)) {
+        if (!ifm->updated) {
             // collector_info("Removing network interface '%s', linked after '%s'", ifm->name, last?last->name:"ROOT");
 
             if (network_interfaces_last_used == ifm)
@@ -104,7 +104,7 @@ static struct cgroup_network_interface *get_network_interface(const char *name) 
 
     // search it, from the last position to the end
     for(ifm = network_interfaces_last_used ; ifm ; ifm = ifm->next) {
-        if (unlikely(hash == ifm->hash && !strcmp(name, ifm->name))) {
+        if (hash == ifm->hash && !strcmp(name, ifm->name)) {
             network_interfaces_last_used = ifm->next;
             return ifm;
         }
@@ -112,7 +112,7 @@ static struct cgroup_network_interface *get_network_interface(const char *name) 
 
     // search it from the beginning to the last position we used
     for(ifm = network_interfaces_root ; ifm != network_interfaces_last_used ; ifm = ifm->next) {
-        if (unlikely(hash == ifm->hash && !strcmp(name, ifm->name))) {
+        if (hash == ifm->hash && !strcmp(name, ifm->name)) {
             network_interfaces_last_used = ifm->next;
             return ifm;
         }
@@ -152,7 +152,7 @@ int do_getifaddrs(int update_every, usec_t dt) {
             do_errors = -1, do_drops = -1, do_events = -1;
     static SIMPLE_PATTERN *excluded_interfaces = NULL, *physical_interfaces = NULL;
 
-    if (unlikely(enable_new_interfaces == -1)) {
+    if (enable_new_interfaces == -1) {
         enable_new_interfaces = config_get_boolean_ondemand(CONFIG_SECTION_GETIFADDRS,
                                                               "enable new interfaces detected at runtime",
                                                               CONFIG_BOOLEAN_AUTO);
@@ -188,11 +188,11 @@ int do_getifaddrs(int update_every, usec_t dt) {
             true);
     }
 
-    if (likely(do_bandwidth_ipv4 || do_bandwidth_ipv6 || do_bandwidth || do_packets || do_errors || do_bandwidth_net || do_packets_net ||
-               do_drops || do_events)) {
+    if (do_bandwidth_ipv4 || do_bandwidth_ipv6 || do_bandwidth || do_packets || do_errors || do_bandwidth_net || do_packets_net ||
+               do_drops || do_events) {
         struct ifaddrs *ifap;
 
-        if (unlikely(getifaddrs(&ifap))) {
+        if (getifaddrs(&ifap)) {
             collector_error("FREEBSD: getifaddrs() failed");
             do_bandwidth_net = 0;
             collector_error("DISABLED: system.net chart");
@@ -226,7 +226,7 @@ int do_getifaddrs(int update_every, usec_t dt) {
                 u_long  ift_omcasts;
             } iftot = {0, 0, 0, 0, 0, 0};
 
-            if (likely(do_bandwidth_net)) {
+            if (do_bandwidth_net) {
 
                 iftot.ift_ibytes = iftot.ift_obytes = 0;
                 for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
@@ -241,7 +241,7 @@ int do_getifaddrs(int update_every, usec_t dt) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_in = NULL, *rd_out = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost("system",
                                                  "net",
                                                  NULL,
@@ -265,7 +265,7 @@ int do_getifaddrs(int update_every, usec_t dt) {
                 rrdset_done(st);
             }
 
-            if (likely(do_packets_net)) {
+            if (do_packets_net) {
                 iftot.ift_ipackets = iftot.ift_opackets = iftot.ift_imcasts = iftot.ift_omcasts = 0;
 
                 for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
@@ -282,7 +282,7 @@ int do_getifaddrs(int update_every, usec_t dt) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_packets_in = NULL, *rd_packets_out = NULL, *rd_packets_m_in = NULL, *rd_packets_m_out = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost("system",
                                                  "packets",
                                                  NULL,
@@ -312,7 +312,7 @@ int do_getifaddrs(int update_every, usec_t dt) {
                 rrdset_done(st);
             }
 
-            if (likely(do_bandwidth_ipv4)) {
+            if (do_bandwidth_ipv4) {
                 iftot.ift_ibytes = iftot.ift_obytes = 0;
                 for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
                     if (ifa->ifa_addr->sa_family != AF_INET)
@@ -324,7 +324,7 @@ int do_getifaddrs(int update_every, usec_t dt) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_in = NULL, *rd_out = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost("system",
                                                  "ipv4",
                                                  NULL,
@@ -348,7 +348,7 @@ int do_getifaddrs(int update_every, usec_t dt) {
                 rrdset_done(st);
             }
 
-            if (likely(do_bandwidth_ipv6)) {
+            if (do_bandwidth_ipv6) {
                 iftot.ift_ibytes = iftot.ift_obytes = 0;
                 for (ifa = ifap; ifa; ifa = ifa->ifa_next) {
                     if (ifa->ifa_addr->sa_family != AF_INET6)
@@ -360,7 +360,7 @@ int do_getifaddrs(int update_every, usec_t dt) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_in = NULL, *rd_out = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost("system",
                                                  "ipv6",
                                                  NULL,
@@ -394,7 +394,7 @@ int do_getifaddrs(int update_every, usec_t dt) {
                 ifm->updated = 1;
                 network_interfaces_found++;
 
-                if (unlikely(!ifm->configured)) {
+                if (!ifm->configured) {
                     char var_name[4096 + 1];
 
                     // this is the first time we see this network interface
@@ -404,13 +404,13 @@ int do_getifaddrs(int update_every, usec_t dt) {
 
                     ifm->enabled = enable_new_interfaces;
 
-                    if (likely(ifm->enabled))
+                    if (ifm->enabled)
                         ifm->enabled = !simple_pattern_matches(excluded_interfaces, ifa->ifa_name);
 
                     snprintfz(var_name, 4096, "%s:%s", CONFIG_SECTION_GETIFADDRS, ifa->ifa_name);
                     ifm->enabled = config_get_boolean_ondemand(var_name, "enabled", ifm->enabled);
 
-                    if (unlikely(ifm->enabled == CONFIG_BOOLEAN_NO))
+                    if (ifm->enabled == CONFIG_BOOLEAN_NO)
                         continue;
 
                     ifm->do_bandwidth = config_get_boolean_ondemand(var_name, "bandwidth", do_bandwidth);
@@ -420,14 +420,14 @@ int do_getifaddrs(int update_every, usec_t dt) {
                     ifm->do_events    = config_get_boolean_ondemand(var_name, "events",    do_events);
                 }
 
-                if (unlikely(!ifm->enabled))
+                if (!ifm->enabled)
                     continue;
 
                 if (ifm->do_bandwidth == CONFIG_BOOLEAN_YES || (ifm->do_bandwidth == CONFIG_BOOLEAN_AUTO &&
                                                                 (IFA_DATA(ibytes) ||
                                                                  IFA_DATA(obytes) ||
                                                                  netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
-                    if (unlikely(!ifm->st_bandwidth)) {
+                    if (!ifm->st_bandwidth) {
                         ifm->st_bandwidth = rrdset_create_localhost("net",
                                                                     ifa->ifa_name,
                                                                     NULL,
@@ -457,7 +457,7 @@ int do_getifaddrs(int update_every, usec_t dt) {
                                                                IFA_DATA(imcasts) ||
                                                                IFA_DATA(omcasts) ||
                                                                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
-                    if (unlikely(!ifm->st_packets)) {
+                    if (!ifm->st_packets) {
                         ifm->st_packets = rrdset_create_localhost("net_packets",
                                                                   ifa->ifa_name,
                                                                   NULL,
@@ -495,7 +495,7 @@ int do_getifaddrs(int update_every, usec_t dt) {
                                                              (IFA_DATA(ierrors) ||
                                                               IFA_DATA(oerrors) ||
                                                               netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
-                    if (unlikely(!ifm->st_errors)) {
+                    if (!ifm->st_errors) {
                         ifm->st_errors = rrdset_create_localhost("net_errors",
                                                                  ifa->ifa_name,
                                                                  NULL,
@@ -527,7 +527,7 @@ int do_getifaddrs(int update_every, usec_t dt) {
                                                              IFA_DATA(oqdrops) ||
                                                              #endif
                                                              netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
-                    if (unlikely(!ifm->st_drops)) {
+                    if (!ifm->st_drops) {
                         ifm->st_drops = rrdset_create_localhost("net_drops",
                                                                 ifa->ifa_name,
                                                                 NULL,
@@ -560,7 +560,7 @@ int do_getifaddrs(int update_every, usec_t dt) {
                 if (ifm->do_events == CONFIG_BOOLEAN_YES || (ifm->do_events == CONFIG_BOOLEAN_AUTO &&
                                                              (IFA_DATA(collisions) ||
                                                               netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
-                    if (unlikely(!ifm->st_events)) {
+                    if (!ifm->st_events) {
                         ifm->st_events = rrdset_create_localhost("net_events",
                                                                  ifa->ifa_name,
                                                                  NULL,

--- a/collectors/freebsd.plugin/freebsd_kstat_zfs.c
+++ b/collectors/freebsd.plugin/freebsd_kstat_zfs.c
@@ -13,7 +13,7 @@ int do_kstat_zfs_misc_arcstats(int update_every, usec_t dt) {
     (void)dt;
 
     static int show_zero_charts = -1;
-    if(unlikely(show_zero_charts == -1))
+    if(show_zero_charts == -1)
         show_zero_charts = config_get_boolean_ondemand("plugin:freebsd:zfs_arcstats", "show zero charts", CONFIG_BOOLEAN_NO);
 
     unsigned long long l2_size;
@@ -114,10 +114,10 @@ int do_kstat_zfs_misc_arcstats(int update_every, usec_t dt) {
 
     arcstats.l2exist = -1;
 
-    if(unlikely(sysctlbyname("kstat.zfs.misc.arcstats.l2_size", &l2_size, &uint64_t_size, NULL, 0)))
+    if(sysctlbyname("kstat.zfs.misc.arcstats.l2_size", &l2_size, &uint64_t_size, NULL, 0))
         return 0;
 
-    if(likely(l2_size))
+    if(l2_size)
         arcstats.l2exist = 1;
     else
         arcstats.l2exist = 0;
@@ -234,10 +234,10 @@ int do_kstat_zfs_misc_zio_trim(int update_every, usec_t dt) {
                mib_failed[5] = {0, 0, 0, 0, 0}, mib_unsupported[5] = {0, 0, 0, 0, 0};
     uint64_t bytes, success, failed, unsupported;
 
-    if (unlikely(GETSYSCTL_SIMPLE("kstat.zfs.misc.zio_trim.bytes", mib_bytes, bytes) ||
+    if (GETSYSCTL_SIMPLE("kstat.zfs.misc.zio_trim.bytes", mib_bytes, bytes) ||
                  GETSYSCTL_SIMPLE("kstat.zfs.misc.zio_trim.success", mib_success, success) ||
                  GETSYSCTL_SIMPLE("kstat.zfs.misc.zio_trim.failed", mib_failed, failed) ||
-                 GETSYSCTL_SIMPLE("kstat.zfs.misc.zio_trim.unsupported", mib_unsupported, unsupported))) {
+                 GETSYSCTL_SIMPLE("kstat.zfs.misc.zio_trim.unsupported", mib_unsupported, unsupported)) {
         collector_error("DISABLED: zfs.trim_bytes chart");
         collector_error("DISABLED: zfs.trim_success chart");
         collector_error("DISABLED: kstat.zfs.misc.zio_trim module");
@@ -247,7 +247,7 @@ int do_kstat_zfs_misc_zio_trim(int update_every, usec_t dt) {
         static RRDSET *st_bytes = NULL;
         static RRDDIM *rd_bytes = NULL;
 
-        if (unlikely(!st_bytes)) {
+        if (!st_bytes) {
             st_bytes = rrdset_create_localhost(
                     "zfs",
                     "trim_bytes",
@@ -272,7 +272,7 @@ int do_kstat_zfs_misc_zio_trim(int update_every, usec_t dt) {
         static RRDSET *st_requests = NULL;
         static RRDDIM *rd_successful = NULL, *rd_failed = NULL, *rd_unsupported = NULL;
 
-        if (unlikely(!st_requests)) {
+        if (!st_requests) {
             st_requests = rrdset_create_localhost(
                     "zfs",
                     "trim_requests",

--- a/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -100,12 +100,12 @@ int freebsd_plugin_init()
         return 1;
     }
 
-    if (unlikely(GETSYSCTL_BY_NAME("kern.smp.cpus", number_of_cpus))) {
+    if (GETSYSCTL_BY_NAME("kern.smp.cpus", number_of_cpus)) {
         collector_error("FREEBSD: can't get number of cpus");
         return 1;
     }
 
-    if (unlikely(!number_of_cpus)) {
+    if (!number_of_cpus) {
         collector_error("FREEBSD: wrong number of cpus");
         return 1;
     }
@@ -125,7 +125,7 @@ int do_vm_loadavg(int update_every, usec_t dt){
         static int mib[2] = {0, 0};
         struct loadavg sysload;
 
-        if (unlikely(GETSYSCTL_SIMPLE("vm.loadavg", mib, sysload))) {
+        if (GETSYSCTL_SIMPLE("vm.loadavg", mib, sysload)) {
             collector_error("DISABLED: system.load chart");
             collector_error("DISABLED: vm.loadavg module");
             return 1;
@@ -133,7 +133,7 @@ int do_vm_loadavg(int update_every, usec_t dt){
             static RRDSET *st = NULL;
             static RRDDIM *rd_load1 = NULL, *rd_load2 = NULL, *rd_load3 = NULL;
 
-            if (unlikely(!st)) {
+            if (!st) {
                 st = rrdset_create_localhost(
                         "system",
                         "load",
@@ -173,17 +173,17 @@ int do_vm_vmtotal(int update_every, usec_t dt) {
     (void)dt;
     static int do_all_processes = -1, do_processes = -1, do_mem_real = -1;
 
-    if (unlikely(do_all_processes == -1)) {
+    if (do_all_processes == -1) {
         do_all_processes    = config_get_boolean("plugin:freebsd:vm.vmtotal", "enable total processes", 1);
         do_processes        = config_get_boolean("plugin:freebsd:vm.vmtotal", "processes running", 1);
         do_mem_real         = config_get_boolean("plugin:freebsd:vm.vmtotal", "real memory", 1);
     }
 
-    if (likely(do_all_processes | do_processes | do_mem_real)) {
+    if (do_all_processes | do_processes | do_mem_real) {
         static int mib[2] = {0, 0};
         struct vmtotal vmtotal_data;
 
-        if (unlikely(GETSYSCTL_SIMPLE("vm.vmtotal", mib, vmtotal_data))) {
+        if (GETSYSCTL_SIMPLE("vm.vmtotal", mib, vmtotal_data)) {
             do_all_processes = 0;
             collector_error("DISABLED: system.active_processes chart");
             do_processes = 0;
@@ -193,11 +193,11 @@ int do_vm_vmtotal(int update_every, usec_t dt) {
             collector_error("DISABLED: vm.vmtotal module");
             return 1;
         } else {
-            if (likely(do_all_processes)) {
+            if (do_all_processes) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "system",
                             "active_processes",
@@ -219,11 +219,11 @@ int do_vm_vmtotal(int update_every, usec_t dt) {
                 rrdset_done(st);
             }
 
-            if (likely(do_processes)) {
+            if (do_processes) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_running = NULL, *rd_blocked = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "system",
                             "processes",
@@ -248,11 +248,11 @@ int do_vm_vmtotal(int update_every, usec_t dt) {
                 rrdset_done(st);
             }
 
-            if (likely(do_mem_real)) {
+            if (do_mem_real) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "mem",
                             "real",
@@ -289,7 +289,7 @@ int do_vm_vmtotal(int update_every, usec_t dt) {
 int do_kern_cp_time(int update_every, usec_t dt) {
     (void)dt;
 
-    if (unlikely(CPUSTATES != 5)) {
+    if (CPUSTATES != 5) {
         collector_error("FREEBSD: There are %d CPU states (5 was expected)", CPUSTATES);
         collector_error("DISABLED: system.cpu chart");
         collector_error("DISABLED: kern.cp_time module");
@@ -298,7 +298,7 @@ int do_kern_cp_time(int update_every, usec_t dt) {
         static int mib[2] = {0, 0};
         long cp_time[CPUSTATES];
 
-        if (unlikely(GETSYSCTL_SIMPLE("kern.cp_time", mib, cp_time))) {
+        if (GETSYSCTL_SIMPLE("kern.cp_time", mib, cp_time)) {
             collector_error("DISABLED: system.cpu chart");
             collector_error("DISABLED: kern.cp_time module");
             return 1;
@@ -306,7 +306,7 @@ int do_kern_cp_time(int update_every, usec_t dt) {
             static RRDSET *st = NULL;
             static RRDDIM *rd_nice = NULL, *rd_system = NULL, *rd_user = NULL, *rd_interrupt = NULL, *rd_idle = NULL;
 
-            if (unlikely(!st)) {
+            if (!st) {
                 st = rrdset_create_localhost(
                         "system",
                         "cpu",
@@ -347,7 +347,7 @@ int do_kern_cp_time(int update_every, usec_t dt) {
 int do_kern_cp_times(int update_every, usec_t dt) {
     (void)dt;
 
-    if (unlikely(CPUSTATES != 5)) {
+    if (CPUSTATES != 5) {
         collector_error("FREEBSD: There are %d CPU states (5 was expected)", CPUSTATES);
         collector_error("DISABLED: cpu.cpuXX charts");
         collector_error("DISABLED: kern.cp_times module");
@@ -358,9 +358,9 @@ int do_kern_cp_times(int update_every, usec_t dt) {
         static long *pcpu_cp_time = NULL;
         static int old_number_of_cpus = 0;
 
-        if(unlikely(number_of_cpus != old_number_of_cpus))
+        if(number_of_cpus != old_number_of_cpus)
             pcpu_cp_time = reallocz(pcpu_cp_time, sizeof(cp_time) * number_of_cpus);
-        if (unlikely(GETSYSCTL_WSIZE("kern.cp_times", mib, pcpu_cp_time, sizeof(cp_time) * number_of_cpus))) {
+        if (GETSYSCTL_WSIZE("kern.cp_times", mib, pcpu_cp_time, sizeof(cp_time) * number_of_cpus)) {
             collector_error("DISABLED: cpu.cpuXX charts");
             collector_error("DISABLED: kern.cp_times module");
             return 1;
@@ -376,13 +376,13 @@ int do_kern_cp_times(int update_every, usec_t dt) {
                 RRDDIM *rd_idle;
             } *all_cpu_charts = NULL;
 
-            if(unlikely(number_of_cpus > old_number_of_cpus)) {
+            if(number_of_cpus > old_number_of_cpus) {
                 all_cpu_charts = reallocz(all_cpu_charts, sizeof(struct cpu_chart) * number_of_cpus);
                 memset(&all_cpu_charts[old_number_of_cpus], 0, sizeof(struct cpu_chart) * (number_of_cpus - old_number_of_cpus));
             }
 
             for (i = 0; i < number_of_cpus; i++) {
-                if (unlikely(!all_cpu_charts[i].st)) {
+                if (!all_cpu_charts[i].st) {
                     snprintfz(all_cpu_charts[i].cpuid, MAX_INT_DIGITS, "cpu%d", i);
                     all_cpu_charts[i].st = rrdset_create_localhost(
                             "cpu",
@@ -439,16 +439,16 @@ int do_dev_cpu_temperature(int update_every, usec_t dt) {
     char char_mib[MAX_INT_DIGITS + 21];
     char char_rd[MAX_INT_DIGITS + 9];
 
-    if (unlikely(number_of_cpus != old_number_of_cpus)) {
+    if (number_of_cpus != old_number_of_cpus) {
         pcpu_temperature = reallocz(pcpu_temperature, sizeof(int) * number_of_cpus);
         mib = reallocz(mib, sizeof(int) * number_of_cpus * 4);
-        if (unlikely(number_of_cpus > old_number_of_cpus))
+        if (number_of_cpus > old_number_of_cpus)
             memset(&mib[old_number_of_cpus * 4], 0, sizeof(int) * (number_of_cpus - old_number_of_cpus) * 4);
     }
     for (i = 0; i < number_of_cpus; i++) {
-        if (unlikely(!(mib[i * 4])))
+        if (!(mib[i * 4]))
             sprintf(char_mib, "dev.cpu.%d.temperature", i);
-        if (unlikely(getsysctl_simple(char_mib, &mib[i * 4], 4, &pcpu_temperature[i], sizeof(int)))) {
+        if (getsysctl_simple(char_mib, &mib[i * 4], 4, &pcpu_temperature[i], sizeof(int))) {
             collector_error("DISABLED: cpu.temperature chart");
             collector_error("DISABLED: dev.cpu.temperature module");
             return 1;
@@ -458,13 +458,13 @@ int do_dev_cpu_temperature(int update_every, usec_t dt) {
     static RRDSET *st;
     static RRDDIM **rd_pcpu_temperature;
 
-    if (unlikely(number_of_cpus != old_number_of_cpus)) {
+    if (number_of_cpus != old_number_of_cpus) {
         rd_pcpu_temperature = reallocz(rd_pcpu_temperature, sizeof(RRDDIM *) * number_of_cpus);
-        if (unlikely(number_of_cpus > old_number_of_cpus))
+        if (number_of_cpus > old_number_of_cpus)
             memset(&rd_pcpu_temperature[old_number_of_cpus], 0, sizeof(RRDDIM *) * (number_of_cpus - old_number_of_cpus));
     }
 
-    if (unlikely(!st)) {
+    if (!st) {
         st = rrdset_create_localhost(
                 "cpu",
                 "temperature",
@@ -482,7 +482,7 @@ int do_dev_cpu_temperature(int update_every, usec_t dt) {
     }
 
     for (i = 0; i < number_of_cpus; i++) {
-        if (unlikely(!rd_pcpu_temperature[i])) {
+        if (!rd_pcpu_temperature[i]) {
             sprintf(char_rd, "cpu%d.temp", i);
             rd_pcpu_temperature[i] = rrddim_add(st, char_rd, NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
         }
@@ -504,7 +504,7 @@ int do_dev_cpu_0_freq(int update_every, usec_t dt) {
     static int mib[4] = {0, 0, 0, 0};
     int cpufreq;
 
-    if (unlikely(GETSYSCTL_SIMPLE("dev.cpu.0.freq", mib, cpufreq))) {
+    if (GETSYSCTL_SIMPLE("dev.cpu.0.freq", mib, cpufreq)) {
         collector_error("DISABLED: cpu.scaling_cur_freq chart");
         collector_error("DISABLED: dev.cpu.0.freq module");
         return 1;
@@ -512,7 +512,7 @@ int do_dev_cpu_0_freq(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd = NULL;
 
-        if (unlikely(!st)) {
+        if (!st) {
             st = rrdset_create_localhost(
                     "cpu",
                     "scaling_cur_freq",
@@ -546,7 +546,7 @@ int do_hw_intcnt(int update_every, usec_t dt) {
     static int mib_hw_intrcnt[2] = {0, 0};
     size_t intrcnt_size = 0;
 
-    if (unlikely(GETSYSCTL_SIZE("hw.intrcnt", mib_hw_intrcnt, intrcnt_size))) {
+    if (GETSYSCTL_SIZE("hw.intrcnt", mib_hw_intrcnt, intrcnt_size)) {
         collector_error("DISABLED: system.intr chart");
         collector_error("DISABLED: system.interrupts chart");
         collector_error("DISABLED: hw.intrcnt module");
@@ -557,9 +557,9 @@ int do_hw_intcnt(int update_every, usec_t dt) {
         static unsigned long *intrcnt = NULL;
 
         nintr = intrcnt_size / sizeof(u_long);
-        if (unlikely(nintr != old_nintr))
+        if (nintr != old_nintr)
             intrcnt = reallocz(intrcnt, nintr * sizeof(u_long));
-        if (unlikely(GETSYSCTL_WSIZE("hw.intrcnt", mib_hw_intrcnt, intrcnt, nintr * sizeof(u_long)))) {
+        if (GETSYSCTL_WSIZE("hw.intrcnt", mib_hw_intrcnt, intrcnt, nintr * sizeof(u_long))) {
             collector_error("DISABLED: system.intr chart");
             collector_error("DISABLED: system.interrupts chart");
             collector_error("DISABLED: hw.intrcnt module");
@@ -574,7 +574,7 @@ int do_hw_intcnt(int update_every, usec_t dt) {
             static RRDSET *st_intr = NULL;
             static RRDDIM *rd_intr = NULL;
 
-            if (unlikely(!st_intr)) {
+            if (!st_intr) {
                 st_intr = rrdset_create_localhost(
                         "system",
                         "intr",
@@ -601,15 +601,15 @@ int do_hw_intcnt(int update_every, usec_t dt) {
             static int mib_hw_intrnames[2] = {0, 0};
             static char *intrnames = NULL;
 
-            if (unlikely(GETSYSCTL_SIZE("hw.intrnames", mib_hw_intrnames, size))) {
+            if (GETSYSCTL_SIZE("hw.intrnames", mib_hw_intrnames, size)) {
                 collector_error("DISABLED: system.intr chart");
                 collector_error("DISABLED: system.interrupts chart");
                 collector_error("DISABLED: hw.intrcnt module");
                 return 1;
             } else {
-                if (unlikely(nintr != old_nintr))
+                if (nintr != old_nintr)
                     intrnames = reallocz(intrnames, size);
-                if (unlikely(GETSYSCTL_WSIZE("hw.intrnames", mib_hw_intrnames, intrnames, size))) {
+                if (GETSYSCTL_WSIZE("hw.intrnames", mib_hw_intrnames, intrnames, size)) {
                     collector_error("DISABLED: system.intr chart");
                     collector_error("DISABLED: system.interrupts chart");
                     collector_error("DISABLED: hw.intrcnt module");
@@ -617,7 +617,7 @@ int do_hw_intcnt(int update_every, usec_t dt) {
                 } else {
                     static RRDSET *st_interrupts = NULL;
 
-                    if (unlikely(!st_interrupts)) {
+                    if (!st_interrupts) {
                         st_interrupts = rrdset_create_localhost(
                                 "system",
                                 "interrupts",
@@ -638,10 +638,10 @@ int do_hw_intcnt(int update_every, usec_t dt) {
                         void *p;
 
                         p = intrnames + i * (strlen(intrnames) + 1);
-                        if (unlikely((intrcnt[i] != 0) && (*(char *) p != 0))) {
+                        if ((intrcnt[i] != 0) && (*(char *) p != 0)) {
                             RRDDIM *rd_interrupts = rrddim_find_active(st_interrupts, p);
 
-                            if (unlikely(!rd_interrupts))
+                            if (!rd_interrupts)
                                 rd_interrupts = rrddim_add(st_interrupts, p, NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
                             rrddim_set_by_pointer(st_interrupts, rd_interrupts, intrcnt[i]);
@@ -665,7 +665,7 @@ int do_vm_stats_sys_v_intr(int update_every, usec_t dt) {
     static int mib[4] = {0, 0, 0, 0};
     u_int int_number;
 
-    if (unlikely(GETSYSCTL_SIMPLE("vm.stats.sys.v_intr", mib, int_number))) {
+    if (GETSYSCTL_SIMPLE("vm.stats.sys.v_intr", mib, int_number)) {
         collector_error("DISABLED: system.dev_intr chart");
         collector_error("DISABLED: vm.stats.sys.v_intr module");
         return 1;
@@ -673,7 +673,7 @@ int do_vm_stats_sys_v_intr(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd = NULL;
 
-        if (unlikely(!st)) {
+        if (!st) {
             st = rrdset_create_localhost(
                     "system",
                     "dev_intr",
@@ -706,7 +706,7 @@ int do_vm_stats_sys_v_soft(int update_every, usec_t dt) {
     static int mib[4] = {0, 0, 0, 0};
     u_int soft_intr_number;
 
-    if (unlikely(GETSYSCTL_SIMPLE("vm.stats.sys.v_soft", mib, soft_intr_number))) {
+    if (GETSYSCTL_SIMPLE("vm.stats.sys.v_soft", mib, soft_intr_number)) {
         collector_error("DISABLED: system.dev_intr chart");
         collector_error("DISABLED: vm.stats.sys.v_soft module");
         return 1;
@@ -714,7 +714,7 @@ int do_vm_stats_sys_v_soft(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd = NULL;
 
-        if (unlikely(!st)) {
+        if (!st) {
             st = rrdset_create_localhost(
                     "system",
                     "soft_intr",
@@ -747,7 +747,7 @@ int do_vm_stats_sys_v_swtch(int update_every, usec_t dt) {
     static int mib[4] = {0, 0, 0, 0};
     u_int ctxt_number;
 
-    if (unlikely(GETSYSCTL_SIMPLE("vm.stats.sys.v_swtch", mib, ctxt_number))) {
+    if (GETSYSCTL_SIMPLE("vm.stats.sys.v_swtch", mib, ctxt_number)) {
         collector_error("DISABLED: system.ctxt chart");
         collector_error("DISABLED: vm.stats.sys.v_swtch module");
         return 1;
@@ -755,7 +755,7 @@ int do_vm_stats_sys_v_swtch(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd = NULL;
 
-        if (unlikely(!st)) {
+        if (!st) {
             st = rrdset_create_localhost(
                     "system",
                     "ctxt",
@@ -788,7 +788,7 @@ int do_vm_stats_sys_v_forks(int update_every, usec_t dt) {
     static int mib[4] = {0, 0, 0, 0};
     u_int forks_number;
 
-    if (unlikely(GETSYSCTL_SIMPLE("vm.stats.vm.v_forks", mib, forks_number))) {
+    if (GETSYSCTL_SIMPLE("vm.stats.vm.v_forks", mib, forks_number)) {
         collector_error("DISABLED: system.forks chart");
         collector_error("DISABLED: vm.stats.sys.v_swtch module");
         return 1;
@@ -799,7 +799,7 @@ int do_vm_stats_sys_v_forks(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd = NULL;
 
-        if (unlikely(!st)) {
+        if (!st) {
             st = rrdset_create_localhost(
                     "system",
                     "forks",
@@ -833,7 +833,7 @@ int do_vm_swap_info(int update_every, usec_t dt) {
     (void)dt;
     static int mib[3] = {0, 0, 0};
 
-    if (unlikely(getsysctl_mib("vm.swap_info", mib, 2))) {
+    if (getsysctl_mib("vm.swap_info", mib, 2)) {
         collector_error("DISABLED: system.swap chart");
         collector_error("DISABLED: vm.swap_info module");
         return 1;
@@ -850,14 +850,14 @@ int do_vm_swap_info(int update_every, usec_t dt) {
 
             mib[2] = i;
             size = sizeof(xsw);
-            if (unlikely(sysctl(mib, 3, &xsw, &size, NULL, 0) == -1 )) {
-                if (unlikely(errno != ENOENT)) {
+            if (sysctl(mib, 3, &xsw, &size, NULL, 0) == -1 ) {
+                if (errno != ENOENT) {
                     collector_error("FREEBSD: sysctl(%s...) failed: %s", "vm.swap_info", strerror(errno));
                     collector_error("DISABLED: system.swap chart");
                     collector_error("DISABLED: vm.swap_info module");
                     return 1;
                 } else {
-                    if (unlikely(size != sizeof(xsw))) {
+                    if (size != sizeof(xsw)) {
                         collector_error("FREEBSD: sysctl(%s...) expected %lu, got %lu", "vm.swap_info", (unsigned long)sizeof(xsw), (unsigned long)size);
                         collector_error("DISABLED: system.swap chart");
                         collector_error("DISABLED: vm.swap_info module");
@@ -872,7 +872,7 @@ int do_vm_swap_info(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_free = NULL, *rd_used = NULL;
 
-        if (unlikely(!st)) {
+        if (!st) {
             st = rrdset_create_localhost(
                     "system",
                     "swap",
@@ -921,7 +921,7 @@ int do_system_ram(int update_every, usec_t dt) {
     static int mib_laundry_count[4] = {0, 0, 0, 0};
 #endif
 
-    if (unlikely(GETSYSCTL_SIMPLE("vm.stats.vm.v_active_count",   mib_active_count,   vmmeter_data.v_active_count) ||
+    if (GETSYSCTL_SIMPLE("vm.stats.vm.v_active_count",   mib_active_count,   vmmeter_data.v_active_count) ||
                  GETSYSCTL_SIMPLE("vm.stats.vm.v_inactive_count", mib_inactive_count, vmmeter_data.v_inactive_count) ||
                  GETSYSCTL_SIMPLE("vm.stats.vm.v_wire_count",     mib_wire_count,     vmmeter_data.v_wire_count) ||
 #if __FreeBSD_version < 1200016
@@ -931,7 +931,7 @@ int do_system_ram(int update_every, usec_t dt) {
                  GETSYSCTL_SIMPLE("vm.stats.vm.v_laundry_count",  mib_laundry_count,  vmmeter_data.v_laundry_count) ||
 #endif
                  GETSYSCTL_SIMPLE("vfs.bufspace",                 mib_vfs_bufspace,     vfs_bufspace_count) ||
-                 GETSYSCTL_SIMPLE("vm.stats.vm.v_free_count",     mib_free_count,     vmmeter_data.v_free_count))) {
+                 GETSYSCTL_SIMPLE("vm.stats.vm.v_free_count",     mib_free_count,     vmmeter_data.v_free_count)) {
         collector_error("DISABLED: system.ram chart");
         collector_error("DISABLED: system.ram module");
         return 1;
@@ -944,7 +944,7 @@ int do_system_ram(int update_every, usec_t dt) {
         static RRDDIM *rd_laundry = NULL;
 #endif
 
-        if (unlikely(!st)) {
+        if (!st) {
             st = rrdset_create_localhost(
                     "system",
                     "ram",
@@ -986,7 +986,7 @@ int do_system_ram(int update_every, usec_t dt) {
         rrddim_set_by_pointer(st, rd_buffers,  vfs_bufspace_count);
         rrdset_done(st);
 
-        if (unlikely(!st_mem_available)) {
+        if (!st_mem_available) {
             st_mem_available = rrdset_create_localhost(
                     "mem",
                     "available",
@@ -1024,8 +1024,8 @@ int do_vm_stats_sys_v_swappgs(int update_every, usec_t dt) {
     static int mib_swappgsin[4] = {0, 0, 0, 0}, mib_swappgsout[4] = {0, 0, 0, 0};
     vmmeter_t vmmeter_data;
 
-    if (unlikely(GETSYSCTL_SIMPLE("vm.stats.vm.v_swappgsin", mib_swappgsin, vmmeter_data.v_swappgsin) ||
-                 GETSYSCTL_SIMPLE("vm.stats.vm.v_swappgsout", mib_swappgsout, vmmeter_data.v_swappgsout))) {
+    if (GETSYSCTL_SIMPLE("vm.stats.vm.v_swappgsin", mib_swappgsin, vmmeter_data.v_swappgsin) ||
+                 GETSYSCTL_SIMPLE("vm.stats.vm.v_swappgsout", mib_swappgsout, vmmeter_data.v_swappgsout)) {
         collector_error("DISABLED: system.swapio chart");
         collector_error("DISABLED: vm.stats.vm.v_swappgs module");
         return 1;
@@ -1033,7 +1033,7 @@ int do_vm_stats_sys_v_swappgs(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_in = NULL, *rd_out = NULL;
 
-        if (unlikely(!st)) {
+        if (!st) {
             st = rrdset_create_localhost(
                     "system",
                     "swapio",
@@ -1069,11 +1069,11 @@ int do_vm_stats_sys_v_pgfaults(int update_every, usec_t dt) {
                mib_cow_optim[4] = {0, 0, 0, 0}, mib_intrans[4] = {0, 0, 0, 0};
     vmmeter_t vmmeter_data;
 
-    if (unlikely(GETSYSCTL_SIMPLE("vm.stats.vm.v_vm_faults",  mib_vm_faults,  vmmeter_data.v_vm_faults) ||
+    if (GETSYSCTL_SIMPLE("vm.stats.vm.v_vm_faults",  mib_vm_faults,  vmmeter_data.v_vm_faults) ||
                  GETSYSCTL_SIMPLE("vm.stats.vm.v_io_faults",  mib_io_faults,  vmmeter_data.v_io_faults) ||
                  GETSYSCTL_SIMPLE("vm.stats.vm.v_cow_faults", mib_cow_faults, vmmeter_data.v_cow_faults) ||
                  GETSYSCTL_SIMPLE("vm.stats.vm.v_cow_optim",  mib_cow_optim,  vmmeter_data.v_cow_optim) ||
-                 GETSYSCTL_SIMPLE("vm.stats.vm.v_intrans",    mib_intrans,    vmmeter_data.v_intrans))) {
+                 GETSYSCTL_SIMPLE("vm.stats.vm.v_intrans",    mib_intrans,    vmmeter_data.v_intrans)) {
         collector_error("DISABLED: mem.pgfaults chart");
         collector_error("DISABLED: vm.stats.vm.v_pgfaults module");
         return 1;
@@ -1082,7 +1082,7 @@ int do_vm_stats_sys_v_pgfaults(int update_every, usec_t dt) {
         static RRDDIM *rd_memory = NULL, *rd_io_requiring = NULL, *rd_cow = NULL,
                       *rd_cow_optimized = NULL, *rd_in_transit = NULL;
 
-        if (unlikely(!st)) {
+        if (!st) {
             st = rrdset_create_localhost(
                     "mem",
                     "pgfaults",
@@ -1130,7 +1130,7 @@ int do_kern_ipc_sem(int update_every, usec_t dt) {
         collected_number semaphores;
     } ipc_sem = {0, 0, 0};
 
-    if (unlikely(GETSYSCTL_SIMPLE("kern.ipc.semmni", mib_semmni, ipc_sem.semmni))) {
+    if (GETSYSCTL_SIMPLE("kern.ipc.semmni", mib_semmni, ipc_sem.semmni)) {
         collector_error("DISABLED: system.ipc_semaphores chart");
         collector_error("DISABLED: system.ipc_semaphore_arrays chart");
         collector_error("DISABLED: kern.ipc.sem module");
@@ -1140,11 +1140,11 @@ int do_kern_ipc_sem(int update_every, usec_t dt) {
         static int old_semmni = 0;
         static int mib_sema[3] = {0, 0, 0};
 
-        if (unlikely(ipc_sem.semmni != old_semmni)) {
+        if (ipc_sem.semmni != old_semmni) {
             ipc_sem_data = reallocz(ipc_sem_data, sizeof(struct semid_kernel) * ipc_sem.semmni);
             old_semmni = ipc_sem.semmni;
         }
-        if (unlikely(GETSYSCTL_WSIZE("kern.ipc.sema", mib_sema, ipc_sem_data, sizeof(struct semid_kernel) * ipc_sem.semmni))) {
+        if (GETSYSCTL_WSIZE("kern.ipc.sema", mib_sema, ipc_sem_data, sizeof(struct semid_kernel) * ipc_sem.semmni)) {
             collector_error("DISABLED: system.ipc_semaphores chart");
             collector_error("DISABLED: system.ipc_semaphore_arrays chart");
             collector_error("DISABLED: kern.ipc.sem module");
@@ -1153,7 +1153,7 @@ int do_kern_ipc_sem(int update_every, usec_t dt) {
             int i;
 
             for (i = 0; i < ipc_sem.semmni; i++) {
-                if (unlikely(ipc_sem_data[i].u.sem_perm.mode & SEM_ALLOC)) {
+                if (ipc_sem_data[i].u.sem_perm.mode & SEM_ALLOC) {
                     ipc_sem.sets += 1;
                     ipc_sem.semaphores += ipc_sem_data[i].u.sem_nsems;
                 }
@@ -1162,7 +1162,7 @@ int do_kern_ipc_sem(int update_every, usec_t dt) {
             static RRDSET *st_semaphores = NULL, *st_semaphore_arrays = NULL;
             static RRDDIM *rd_semaphores = NULL, *rd_semaphore_arrays = NULL;
 
-            if (unlikely(!st_semaphores)) {
+            if (!st_semaphores) {
                 st_semaphores = rrdset_create_localhost(
                         "system",
                         "ipc_semaphores",
@@ -1184,7 +1184,7 @@ int do_kern_ipc_sem(int update_every, usec_t dt) {
             rrddim_set_by_pointer(st_semaphores, rd_semaphores, ipc_sem.semaphores);
             rrdset_done(st_semaphores);
 
-            if (unlikely(!st_semaphore_arrays)) {
+            if (!st_semaphore_arrays) {
                 st_semaphore_arrays = rrdset_create_localhost(
                         "system",
                         "ipc_semaphore_arrays",
@@ -1222,7 +1222,7 @@ int do_kern_ipc_shm(int update_every, usec_t dt) {
         collected_number segsize;
     } ipc_shm = {0, 0, 0};
 
-    if (unlikely(GETSYSCTL_SIMPLE("kern.ipc.shmmni", mib_shmmni, ipc_shm.shmmni))) {
+    if (GETSYSCTL_SIMPLE("kern.ipc.shmmni", mib_shmmni, ipc_shm.shmmni)) {
         collector_error("DISABLED: system.ipc_shared_mem_segs chart");
         collector_error("DISABLED: system.ipc_shared_mem_size chart");
         collector_error("DISABLED: kern.ipc.shmmodule");
@@ -1232,12 +1232,12 @@ int do_kern_ipc_shm(int update_every, usec_t dt) {
         static u_long old_shmmni = 0;
         static int mib_shmsegs[3] = {0, 0, 0};
 
-        if (unlikely(ipc_shm.shmmni != old_shmmni)) {
+        if (ipc_shm.shmmni != old_shmmni) {
             ipc_shm_data = reallocz(ipc_shm_data, sizeof(struct shmid_kernel) * ipc_shm.shmmni);
             old_shmmni = ipc_shm.shmmni;
         }
-        if (unlikely(
-                GETSYSCTL_WSIZE("kern.ipc.shmsegs", mib_shmsegs, ipc_shm_data, sizeof(struct shmid_kernel) * ipc_shm.shmmni))) {
+        if (
+                GETSYSCTL_WSIZE("kern.ipc.shmsegs", mib_shmsegs, ipc_shm_data, sizeof(struct shmid_kernel) * ipc_shm.shmmni)) {
             collector_error("DISABLED: system.ipc_shared_mem_segs chart");
             collector_error("DISABLED: system.ipc_shared_mem_size chart");
             collector_error("DISABLED: kern.ipc.shmmodule");
@@ -1246,7 +1246,7 @@ int do_kern_ipc_shm(int update_every, usec_t dt) {
             unsigned long i;
 
             for (i = 0; i < ipc_shm.shmmni; i++) {
-                if (unlikely(ipc_shm_data[i].u.shm_perm.mode & 0x0800)) {
+                if (ipc_shm_data[i].u.shm_perm.mode & 0x0800) {
                     ipc_shm.segs += 1;
                     ipc_shm.segsize += ipc_shm_data[i].u.shm_segsz;
                 }
@@ -1255,7 +1255,7 @@ int do_kern_ipc_shm(int update_every, usec_t dt) {
             static RRDSET *st_segs = NULL, *st_size = NULL;
             static RRDDIM *rd_segments = NULL, *rd_allocated = NULL;
 
-            if (unlikely(!st_segs)) {
+            if (!st_segs) {
                 st_segs = rrdset_create_localhost(
                         "system",
                         "ipc_shared_mem_segs",
@@ -1277,7 +1277,7 @@ int do_kern_ipc_shm(int update_every, usec_t dt) {
             rrddim_set_by_pointer(st_segs, rd_segments, ipc_shm.segs);
             rrdset_done(st_segs);
 
-            if (unlikely(!st_size)) {
+            if (!st_size) {
                 st_size = rrdset_create_localhost(
                         "system",
                         "ipc_shared_mem_size",
@@ -1317,7 +1317,7 @@ int do_kern_ipc_msq(int update_every, usec_t dt) {
         collected_number allocsize;
     } ipc_msq = {0, 0, 0, 0, 0};
 
-    if (unlikely(GETSYSCTL_SIMPLE("kern.ipc.msgmni", mib_msgmni, ipc_msq.msgmni))) {
+    if (GETSYSCTL_SIMPLE("kern.ipc.msgmni", mib_msgmni, ipc_msq.msgmni)) {
         collector_error("DISABLED: system.ipc_msq_queues chart");
         collector_error("DISABLED: system.ipc_msq_messages chart");
         collector_error("DISABLED: system.ipc_msq_size chart");
@@ -1328,12 +1328,12 @@ int do_kern_ipc_msq(int update_every, usec_t dt) {
         static int old_msgmni = 0;
         static int mib_msqids[3] = {0, 0, 0};
 
-        if (unlikely(ipc_msq.msgmni != old_msgmni)) {
+        if (ipc_msq.msgmni != old_msgmni) {
             ipc_msq_data = reallocz(ipc_msq_data, sizeof(struct msqid_kernel) * ipc_msq.msgmni);
             old_msgmni = ipc_msq.msgmni;
         }
-        if (unlikely(
-                GETSYSCTL_WSIZE("kern.ipc.msqids", mib_msqids, ipc_msq_data, sizeof(struct msqid_kernel) * ipc_msq.msgmni))) {
+        if (
+                GETSYSCTL_WSIZE("kern.ipc.msqids", mib_msqids, ipc_msq_data, sizeof(struct msqid_kernel) * ipc_msq.msgmni)) {
             collector_error("DISABLED: system.ipc_msq_queues chart");
             collector_error("DISABLED: system.ipc_msq_messages chart");
             collector_error("DISABLED: system.ipc_msq_size chart");
@@ -1343,7 +1343,7 @@ int do_kern_ipc_msq(int update_every, usec_t dt) {
             int i;
 
             for (i = 0; i < ipc_msq.msgmni; i++) {
-                if (unlikely(ipc_msq_data[i].u.msg_qbytes != 0)) {
+                if (ipc_msq_data[i].u.msg_qbytes != 0) {
                     ipc_msq.queues += 1;
                     ipc_msq.messages += ipc_msq_data[i].u.msg_qnum;
                     ipc_msq.usedsize += ipc_msq_data[i].u.msg_cbytes;
@@ -1354,7 +1354,7 @@ int do_kern_ipc_msq(int update_every, usec_t dt) {
             static RRDSET *st_queues = NULL, *st_messages = NULL, *st_size = NULL;
             static RRDDIM *rd_queues = NULL, *rd_messages = NULL, *rd_allocated = NULL, *rd_used = NULL;
 
-            if (unlikely(!st_queues)) {
+            if (!st_queues) {
                 st_queues = rrdset_create_localhost(
                         "system",
                         "ipc_msq_queues",
@@ -1376,7 +1376,7 @@ int do_kern_ipc_msq(int update_every, usec_t dt) {
             rrddim_set_by_pointer(st_queues, rd_queues, ipc_msq.queues);
             rrdset_done(st_queues);
 
-            if (unlikely(!st_messages)) {
+            if (!st_messages) {
                 st_messages = rrdset_create_localhost(
                         "system",
                         "ipc_msq_messages",
@@ -1398,7 +1398,7 @@ int do_kern_ipc_msq(int update_every, usec_t dt) {
             rrddim_set_by_pointer(st_messages, rd_messages, ipc_msq.messages);
             rrdset_done(st_messages);
 
-            if (unlikely(!st_size)) {
+            if (!st_size) {
                 st_size = rrdset_create_localhost(
                         "system",
                         "ipc_msq_size",
@@ -1438,7 +1438,7 @@ int do_uptime(int update_every, usec_t dt) {
     static RRDSET *st = NULL;
     static RRDDIM *rd = NULL;
 
-    if(unlikely(!st)) {
+    if(!st) {
         st = rrdset_create_localhost(
                 "system",
                 "uptime",
@@ -1468,7 +1468,7 @@ int do_net_isr(int update_every, usec_t dt) {
     (void)dt;
     static int do_netisr = -1, do_netisr_per_core = -1;
 
-    if (unlikely(do_netisr == -1)) {
+    if (do_netisr == -1) {
         do_netisr =          config_get_boolean("plugin:freebsd:net.isr", "netisr",          1);
         do_netisr_per_core = config_get_boolean("plugin:freebsd:net.isr", "netisr per core", 1);
     }
@@ -1480,7 +1480,7 @@ int do_net_isr(int update_every, usec_t dt) {
         collected_number queued;
     } *netisr_stats = NULL;
 
-    if (likely(do_netisr || do_netisr_per_core)) {
+    if (do_netisr || do_netisr_per_core) {
         static int mib_workstream[3] = {0, 0, 0}, mib_work[3] = {0, 0, 0};
         size_t netisr_workstream_size = 0, netisr_work_size = 0;
         static struct sysctl_netisr_workstream *netisr_workstream = NULL;
@@ -1488,37 +1488,37 @@ int do_net_isr(int update_every, usec_t dt) {
         unsigned long num_netisr_workstreams = 0, num_netisr_works = 0;
         int common_error = 0;
 
-        if (unlikely(GETSYSCTL_SIZE("net.isr.workstream", mib_workstream, netisr_workstream_size))) {
+        if (GETSYSCTL_SIZE("net.isr.workstream", mib_workstream, netisr_workstream_size)) {
             common_error = 1;
-        } else if (unlikely(GETSYSCTL_SIZE("net.isr.work", mib_work, netisr_work_size))) {
+        } else if (GETSYSCTL_SIZE("net.isr.work", mib_work, netisr_work_size)) {
             common_error = 1;
         } else {
             static size_t old_netisr_workstream_size = 0;
 
             num_netisr_workstreams = netisr_workstream_size / sizeof(struct sysctl_netisr_workstream);
-            if (unlikely(netisr_workstream_size != old_netisr_workstream_size)) {
+            if (netisr_workstream_size != old_netisr_workstream_size) {
                 netisr_workstream = reallocz(netisr_workstream,
                                              num_netisr_workstreams * sizeof(struct sysctl_netisr_workstream));
                 old_netisr_workstream_size = netisr_workstream_size;
             }
-            if (unlikely(GETSYSCTL_WSIZE("net.isr.workstream", mib_workstream, netisr_workstream,
-                                           num_netisr_workstreams * sizeof(struct sysctl_netisr_workstream)))){
+            if (GETSYSCTL_WSIZE("net.isr.workstream", mib_workstream, netisr_workstream,
+                                           num_netisr_workstreams * sizeof(struct sysctl_netisr_workstream))){
                 common_error = 1;
             } else {
                 static size_t old_netisr_work_size = 0;
 
                 num_netisr_works = netisr_work_size / sizeof(struct sysctl_netisr_work);
-                if (unlikely(netisr_work_size != old_netisr_work_size)) {
+                if (netisr_work_size != old_netisr_work_size) {
                     netisr_work = reallocz(netisr_work, num_netisr_works * sizeof(struct sysctl_netisr_work));
                     old_netisr_work_size = netisr_work_size;
                 }
-                if (unlikely(GETSYSCTL_WSIZE("net.isr.work", mib_work, netisr_work,
-                                               num_netisr_works * sizeof(struct sysctl_netisr_work)))){
+                if (GETSYSCTL_WSIZE("net.isr.work", mib_work, netisr_work,
+                                               num_netisr_works * sizeof(struct sysctl_netisr_work))){
                     common_error = 1;
                 }
             }
         }
-        if (unlikely(common_error)) {
+        if (common_error) {
             do_netisr = 0;
             collector_error("DISABLED: system.softnet_stat chart");
             do_netisr_per_core = 0;
@@ -1531,7 +1531,7 @@ int do_net_isr(int update_every, usec_t dt) {
             int j;
             static int old_number_of_cpus = 0;
 
-            if (unlikely(number_of_cpus != old_number_of_cpus)) {
+            if (number_of_cpus != old_number_of_cpus) {
                 netisr_stats = reallocz(netisr_stats, (number_of_cpus + 1) * sizeof(struct netisr_stats));
                 old_number_of_cpus = number_of_cpus;
             }
@@ -1558,11 +1558,11 @@ int do_net_isr(int update_every, usec_t dt) {
         return 1;
     }
 
-    if (likely(do_netisr)) {
+    if (do_netisr) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_dispatched = NULL, *rd_hybrid_dispatched = NULL, *rd_qdrops = NULL, *rd_queued = NULL;
 
-        if (unlikely(!st)) {
+        if (!st) {
             st = rrdset_create_localhost(
                     "system",
                     "softnet_stat",
@@ -1591,7 +1591,7 @@ int do_net_isr(int update_every, usec_t dt) {
         rrdset_done(st);
     }
 
-    if (likely(do_netisr_per_core)) {
+    if (do_netisr_per_core) {
         static struct softnet_chart {
             char netisr_cpuid[MAX_INT_DIGITS + 17];
             RRDSET *st;
@@ -1603,7 +1603,7 @@ int do_net_isr(int update_every, usec_t dt) {
         static int old_number_of_cpus = 0;
         int i;
 
-        if(unlikely(number_of_cpus > old_number_of_cpus)) {
+        if(number_of_cpus > old_number_of_cpus) {
             all_softnet_charts = reallocz(all_softnet_charts, sizeof(struct softnet_chart) * number_of_cpus);
             memset(&all_softnet_charts[old_number_of_cpus], 0, sizeof(struct softnet_chart) * (number_of_cpus - old_number_of_cpus));
             old_number_of_cpus = number_of_cpus;
@@ -1612,7 +1612,7 @@ int do_net_isr(int update_every, usec_t dt) {
         for (i = 0; i < number_of_cpus ;i++) {
             snprintfz(all_softnet_charts[i].netisr_cpuid, MAX_INT_DIGITS + 17, "cpu%d_softnet_stat", i);
 
-            if (unlikely(!all_softnet_charts[i].st)) {
+            if (!all_softnet_charts[i].st) {
                 all_softnet_charts[i].st = rrdset_create_localhost(
                         "cpu",
                         all_softnet_charts[i].netisr_cpuid,
@@ -1661,7 +1661,7 @@ int do_net_inet_tcp_states(int update_every, usec_t dt) {
     uint64_t tcps_states[TCP_NSTATES];
 
     // see http://net-snmp.sourceforge.net/docs/mibs/tcp.html
-    if (unlikely(GETSYSCTL_SIMPLE("net.inet.tcp.states", mib, tcps_states))) {
+    if (GETSYSCTL_SIMPLE("net.inet.tcp.states", mib, tcps_states)) {
         collector_error("DISABLED: ipv4.tcpsock chart");
         collector_error("DISABLED: net.inet.tcp.states module");
         return 1;
@@ -1669,7 +1669,7 @@ int do_net_inet_tcp_states(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd = NULL;
 
-        if (unlikely(!st)) {
+        if (!st) {
             st = rrdset_create_localhost(
                     "ipv4",
                     "tcpsock",
@@ -1702,7 +1702,7 @@ int do_net_inet_tcp_stats(int update_every, usec_t dt) {
     static int do_tcp_packets = -1, do_tcp_errors = -1, do_tcp_handshake = -1, do_tcpext_connaborts = -1, do_tcpext_ofo = -1,
                do_tcpext_syncookies = -1, do_tcpext_listen = -1, do_ecn = -1;
 
-    if (unlikely(do_tcp_packets == -1)) {
+    if (do_tcp_packets == -1) {
         do_tcp_packets       = config_get_boolean("plugin:freebsd:net.inet.tcp.stats", "ipv4 TCP packets",          1);
         do_tcp_errors        = config_get_boolean("plugin:freebsd:net.inet.tcp.stats", "ipv4 TCP errors",           1);
         do_tcp_handshake     = config_get_boolean("plugin:freebsd:net.inet.tcp.stats", "ipv4 TCP handshake issues", 1);
@@ -1719,12 +1719,12 @@ int do_net_inet_tcp_stats(int update_every, usec_t dt) {
     }
 
     // see http://net-snmp.sourceforge.net/docs/mibs/tcp.html
-    if (likely(do_tcp_packets || do_tcp_errors || do_tcp_handshake || do_tcpext_connaborts || do_tcpext_ofo ||
-               do_tcpext_syncookies || do_tcpext_listen || do_ecn)) {
+    if (do_tcp_packets || do_tcp_errors || do_tcp_handshake || do_tcpext_connaborts || do_tcpext_ofo ||
+               do_tcpext_syncookies || do_tcpext_listen || do_ecn) {
         static int mib[4] = {0, 0, 0, 0};
         struct tcpstat tcpstat;
 
-        if (unlikely(GETSYSCTL_SIMPLE("net.inet.tcp.stats", mib, tcpstat))) {
+        if (GETSYSCTL_SIMPLE("net.inet.tcp.stats", mib, tcpstat)) {
             do_tcp_packets = 0;
             collector_error("DISABLED: ipv4.tcppackets chart");
             do_tcp_errors = 0;
@@ -1744,11 +1744,11 @@ int do_net_inet_tcp_stats(int update_every, usec_t dt) {
             collector_error("DISABLED: net.inet.tcp.stats module");
             return 1;
         } else {
-            if (likely(do_tcp_packets)) {
+            if (do_tcp_packets) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_in_segs = NULL, *rd_out_segs = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv4",
                             "tcppackets",
@@ -1773,11 +1773,11 @@ int do_net_inet_tcp_stats(int update_every, usec_t dt) {
                 rrdset_done(st);
             }
 
-            if (likely(do_tcp_errors)) {
+            if (do_tcp_errors) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_in_errs = NULL, *rd_in_csum_errs = NULL, *rd_retrans_segs = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv4",
                             "tcperrors",
@@ -1811,12 +1811,12 @@ int do_net_inet_tcp_stats(int update_every, usec_t dt) {
                 rrdset_done(st);
             }
 
-            if (likely(do_tcp_handshake)) {
+            if (do_tcp_handshake) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_estab_resets = NULL, *rd_active_opens = NULL, *rd_passive_opens = NULL,
                               *rd_attempt_fails = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv4",
                             "tcphandshake",
@@ -1860,7 +1860,7 @@ int do_net_inet_tcp_stats(int update_every, usec_t dt) {
                 static RRDDIM *rd_on_data = NULL, *rd_on_close = NULL, *rd_on_memory = NULL,
                               *rd_on_timeout = NULL, *rd_on_linger = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv4",
                             "tcpconnaborts",
@@ -1899,7 +1899,7 @@ int do_net_inet_tcp_stats(int update_every, usec_t dt) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_ofo_queue = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv4",
                             "tcpofo",
@@ -1932,7 +1932,7 @@ int do_net_inet_tcp_stats(int update_every, usec_t dt) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_recv = NULL, *rd_send = NULL, *rd_failed = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv4",
                             "tcpsyncookies",
@@ -1967,7 +1967,7 @@ int do_net_inet_tcp_stats(int update_every, usec_t dt) {
                 static RRDSET *st_listen = NULL;
                 static RRDDIM *rd_overflows = NULL;
 
-                if(unlikely(!st_listen)) {
+                if(!st_listen) {
 
                     st_listen = rrdset_create_localhost(
                             "ipv4",
@@ -2020,7 +2020,7 @@ int do_net_inet_tcp_stats(int update_every, usec_t dt) {
                               *rd_sndect1 = NULL;
 #endif                                                              
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv4",
                             "ecnpkts",
@@ -2079,17 +2079,17 @@ int do_net_inet_udp_stats(int update_every, usec_t dt) {
     (void)dt;
     static int do_udp_packets = -1, do_udp_errors = -1;
 
-    if (unlikely(do_udp_packets == -1)) {
+    if (do_udp_packets == -1) {
         do_udp_packets = config_get_boolean("plugin:freebsd:net.inet.udp.stats", "ipv4 UDP packets", 1);
         do_udp_errors  = config_get_boolean("plugin:freebsd:net.inet.udp.stats", "ipv4 UDP errors", 1);
     }
 
     // see http://net-snmp.sourceforge.net/docs/mibs/udp.html
-    if (likely(do_udp_packets || do_udp_errors)) {
+    if (do_udp_packets || do_udp_errors) {
         static int mib[4] = {0, 0, 0, 0};
         struct udpstat udpstat;
 
-        if (unlikely(GETSYSCTL_SIMPLE("net.inet.udp.stats", mib, udpstat))) {
+        if (GETSYSCTL_SIMPLE("net.inet.udp.stats", mib, udpstat)) {
             do_udp_packets = 0;
             collector_error("DISABLED: ipv4.udppackets chart");
             do_udp_errors = 0;
@@ -2097,11 +2097,11 @@ int do_net_inet_udp_stats(int update_every, usec_t dt) {
             collector_error("DISABLED: net.inet.udp.stats module");
             return 1;
         } else {
-            if (likely(do_udp_packets)) {
+            if (do_udp_packets) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_in = NULL, *rd_out = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv4",
                             "udppackets",
@@ -2126,12 +2126,12 @@ int do_net_inet_udp_stats(int update_every, usec_t dt) {
                 rrdset_done(st);
             }
 
-            if (likely(do_udp_errors)) {
+            if (do_udp_errors) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_in_errors = NULL, *rd_no_ports = NULL, *rd_recv_buf_errors = NULL,
                               *rd_in_csum_errors = NULL, *rd_ignored_multi = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv4",
                             "udperrors",
@@ -2178,13 +2178,13 @@ int do_net_inet_icmp_stats(int update_every, usec_t dt) {
     (void)dt;
     static int do_icmp_packets = -1, do_icmp_errors = -1, do_icmpmsg = -1;
 
-    if (unlikely(do_icmp_packets == -1)) {
+    if (do_icmp_packets == -1) {
         do_icmp_packets = config_get_boolean("plugin:freebsd:net.inet.icmp.stats", "ipv4 ICMP packets",  1);
         do_icmp_errors  = config_get_boolean("plugin:freebsd:net.inet.icmp.stats", "ipv4 ICMP errors",   1);
         do_icmpmsg      = config_get_boolean("plugin:freebsd:net.inet.icmp.stats", "ipv4 ICMP messages", 1);
     }
 
-    if (likely(do_icmp_packets || do_icmp_errors || do_icmpmsg)) {
+    if (do_icmp_packets || do_icmp_errors || do_icmpmsg) {
         static int mib[4] = {0, 0, 0, 0};
         struct icmpstat icmpstat;
         struct icmp_total {
@@ -2192,7 +2192,7 @@ int do_net_inet_icmp_stats(int update_every, usec_t dt) {
             u_long  msgs_out;
         } icmp_total = {0, 0};
 
-        if (unlikely(GETSYSCTL_SIMPLE("net.inet.icmp.stats", mib, icmpstat))) {
+        if (GETSYSCTL_SIMPLE("net.inet.icmp.stats", mib, icmpstat)) {
             do_icmp_packets = 0;
             collector_error("DISABLED: ipv4.icmp chart");
             do_icmp_errors = 0;
@@ -2210,11 +2210,11 @@ int do_net_inet_icmp_stats(int update_every, usec_t dt) {
             }
             icmp_total.msgs_in += icmpstat.icps_badcode + icmpstat.icps_badlen + icmpstat.icps_checksum + icmpstat.icps_tooshort;
 
-            if (likely(do_icmp_packets)) {
+            if (do_icmp_packets) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_in = NULL, *rd_out = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv4"
                             , "icmp"
@@ -2239,11 +2239,11 @@ int do_net_inet_icmp_stats(int update_every, usec_t dt) {
                 rrdset_done(st);
             }
 
-            if (likely(do_icmp_errors)) {
+            if (do_icmp_errors) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_in = NULL, *rd_out = NULL, *rd_in_csum = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv4"
                             , "icmp_errors"
@@ -2272,11 +2272,11 @@ int do_net_inet_icmp_stats(int update_every, usec_t dt) {
                 rrdset_done(st);
             }
 
-            if (likely(do_icmpmsg)) {
+            if (do_icmpmsg) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_in_reps = NULL, *rd_out_reps = NULL, *rd_in = NULL, *rd_out = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv4"
                             , "icmpmsg"
@@ -2319,7 +2319,7 @@ int do_net_inet_ip_stats(int update_every, usec_t dt) {
     (void)dt;
     static int do_ip_packets = -1, do_ip_fragsout = -1, do_ip_fragsin = -1, do_ip_errors = -1;
 
-    if (unlikely(do_ip_packets == -1)) {
+    if (do_ip_packets == -1) {
         do_ip_packets  = config_get_boolean("plugin:freebsd:net.inet.ip.stats", "ipv4 packets", 1);
         do_ip_fragsout = config_get_boolean("plugin:freebsd:net.inet.ip.stats", "ipv4 fragments sent", 1);
         do_ip_fragsin  = config_get_boolean("plugin:freebsd:net.inet.ip.stats", "ipv4 fragments assembly", 1);
@@ -2327,11 +2327,11 @@ int do_net_inet_ip_stats(int update_every, usec_t dt) {
     }
 
     // see also http://net-snmp.sourceforge.net/docs/mibs/ip.html
-    if (likely(do_ip_packets || do_ip_fragsout || do_ip_fragsin || do_ip_errors)) {
+    if (do_ip_packets || do_ip_fragsout || do_ip_fragsin || do_ip_errors) {
         static int mib[4] = {0, 0, 0, 0};
         struct ipstat ipstat;
 
-        if (unlikely(GETSYSCTL_SIMPLE("net.inet.ip.stats", mib, ipstat))) {
+        if (GETSYSCTL_SIMPLE("net.inet.ip.stats", mib, ipstat)) {
             do_ip_packets = 0;
             collector_error("DISABLED: ipv4.packets chart");
             do_ip_fragsout = 0;
@@ -2343,12 +2343,12 @@ int do_net_inet_ip_stats(int update_every, usec_t dt) {
             collector_error("DISABLED: net.inet.ip.stats module");
             return 1;
         } else {
-            if (likely(do_ip_packets)) {
+            if (do_ip_packets) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_in_receives = NULL, *rd_out_requests = NULL, *rd_forward_datagrams = NULL,
                               *rd_in_delivers = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv4",
                             "packets",
@@ -2377,11 +2377,11 @@ int do_net_inet_ip_stats(int update_every, usec_t dt) {
                 rrdset_done(st);
             }
 
-            if (likely(do_ip_fragsout)) {
+            if (do_ip_fragsout) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_ok = NULL, *rd_fails = NULL, *rd_created = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv4",
                             "fragsout",
@@ -2410,11 +2410,11 @@ int do_net_inet_ip_stats(int update_every, usec_t dt) {
                 rrdset_done(st);
             }
 
-            if (likely(do_ip_fragsin)) {
+            if (do_ip_fragsin) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_ok = NULL, *rd_failed = NULL, *rd_all = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv4",
                             "fragsin",
@@ -2443,13 +2443,13 @@ int do_net_inet_ip_stats(int update_every, usec_t dt) {
                 rrdset_done(st);
             }
 
-            if (likely(do_ip_errors)) {
+            if (do_ip_errors) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_in_discards = NULL, *rd_out_discards = NULL,
                               *rd_in_hdr_errors = NULL, *rd_out_no_routes = NULL,
                               *rd_in_addr_errors = NULL, *rd_in_unknown_protos = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv4",
                             "errors",
@@ -2500,7 +2500,7 @@ int do_net_inet6_ip6_stats(int update_every, usec_t dt) {
     (void)dt;
     static int do_ip6_packets = -1, do_ip6_fragsout = -1, do_ip6_fragsin = -1, do_ip6_errors = -1;
 
-    if (unlikely(do_ip6_packets == -1)) {
+    if (do_ip6_packets == -1) {
         do_ip6_packets  = config_get_boolean_ondemand("plugin:freebsd:net.inet6.ip6.stats", "ipv6 packets",
                                                       CONFIG_BOOLEAN_AUTO);
         do_ip6_fragsout = config_get_boolean_ondemand("plugin:freebsd:net.inet6.ip6.stats", "ipv6 fragments sent",
@@ -2511,11 +2511,11 @@ int do_net_inet6_ip6_stats(int update_every, usec_t dt) {
                                                       CONFIG_BOOLEAN_AUTO);
     }
 
-    if (likely(do_ip6_packets || do_ip6_fragsout || do_ip6_fragsin || do_ip6_errors)) {
+    if (do_ip6_packets || do_ip6_fragsout || do_ip6_fragsin || do_ip6_errors) {
         static int mib[4] = {0, 0, 0, 0};
         struct ip6stat ip6stat;
 
-        if (unlikely(GETSYSCTL_SIMPLE("net.inet6.ip6.stats", mib, ip6stat))) {
+        if (GETSYSCTL_SIMPLE("net.inet6.ip6.stats", mib, ip6stat)) {
             do_ip6_packets = 0;
             collector_error("DISABLED: ipv6.packets chart");
             do_ip6_fragsout = 0;
@@ -2538,7 +2538,7 @@ int do_net_inet6_ip6_stats(int update_every, usec_t dt) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_received = NULL, *rd_sent = NULL, *rd_forwarded = NULL, *rd_delivers = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv6",
                             "packets",
@@ -2577,7 +2577,7 @@ int do_net_inet6_ip6_stats(int update_every, usec_t dt) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_ok = NULL, *rd_failed = NULL, *rd_all = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv6",
                              "fragsout",
@@ -2617,7 +2617,7 @@ int do_net_inet6_ip6_stats(int update_every, usec_t dt) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_ok = NULL, *rd_failed = NULL, *rd_timeout = NULL, *rd_all = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv6",
                             "fragsin",
@@ -2666,7 +2666,7 @@ int do_net_inet6_ip6_stats(int update_every, usec_t dt) {
                               *rd_in_hdr_errors = NULL, *rd_in_addr_errors = NULL, *rd_in_truncated_pkts = NULL,
                               *rd_in_no_routes = NULL, *rd_out_no_routes = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv6",
                             "errors",
@@ -2719,7 +2719,7 @@ int do_net_inet6_icmp6_stats(int update_every, usec_t dt) {
     static int do_icmp6 = -1, do_icmp6_redir = -1, do_icmp6_errors = -1, do_icmp6_echos = -1, do_icmp6_router = -1,
             do_icmp6_neighbor = -1, do_icmp6_types = -1;
 
-    if (unlikely(do_icmp6 == -1)) {
+    if (do_icmp6 == -1) {
         do_icmp6          = config_get_boolean_ondemand("plugin:freebsd:net.inet6.icmp6.stats", "icmp",
                                                         CONFIG_BOOLEAN_AUTO);
         do_icmp6_redir    = config_get_boolean_ondemand("plugin:freebsd:net.inet6.icmp6.stats", "icmp redirects",
@@ -2736,11 +2736,11 @@ int do_net_inet6_icmp6_stats(int update_every, usec_t dt) {
                                                         CONFIG_BOOLEAN_AUTO);
     }
 
-    if (likely(do_icmp6 || do_icmp6_redir || do_icmp6_errors || do_icmp6_echos || do_icmp6_router || do_icmp6_neighbor || do_icmp6_types)) {
+    if (do_icmp6 || do_icmp6_redir || do_icmp6_errors || do_icmp6_echos || do_icmp6_router || do_icmp6_neighbor || do_icmp6_types) {
         static int mib[4] = {0, 0, 0, 0};
         struct icmp6stat icmp6stat;
 
-        if (unlikely(GETSYSCTL_SIMPLE("net.inet6.icmp6.stats", mib, icmp6stat))) {
+        if (GETSYSCTL_SIMPLE("net.inet6.icmp6.stats", mib, icmp6stat)) {
             do_icmp6 = 0;
             collector_error("DISABLED: ipv6.icmp chart");
             do_icmp6_redir = 0;
@@ -2781,7 +2781,7 @@ int do_net_inet6_icmp6_stats(int update_every, usec_t dt) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_received = NULL, *rd_sent = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv6",
                             "icmp",
@@ -2815,7 +2815,7 @@ int do_net_inet6_icmp6_stats(int update_every, usec_t dt) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_received = NULL, *rd_sent = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv6",
                             "icmpredir",
@@ -2861,7 +2861,7 @@ int do_net_inet6_icmp6_stats(int update_every, usec_t dt) {
                               *rd_in_parm_problems = NULL, *rd_out_dest_unreachs = NULL, *rd_out_time_excds = NULL,
                               *rd_out_parm_problems = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv6",
                             "icmperrors",
@@ -2913,7 +2913,7 @@ int do_net_inet6_icmp6_stats(int update_every, usec_t dt) {
                 static RRDSET *st = NULL;
                 static RRDDIM *rd_in = NULL, *rd_out = NULL, *rd_in_replies = NULL, *rd_out_replies = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv6",
                             "icmpechos",
@@ -2954,7 +2954,7 @@ int do_net_inet6_icmp6_stats(int update_every, usec_t dt) {
                 static RRDDIM *rd_in_solicits = NULL, *rd_out_solicits = NULL,
                               *rd_in_advertisements = NULL, *rd_out_advertisements = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv6",
                             "icmprouter",
@@ -2995,7 +2995,7 @@ int do_net_inet6_icmp6_stats(int update_every, usec_t dt) {
                 static RRDDIM *rd_in_solicits = NULL, *rd_out_solicits = NULL,
                               *rd_in_advertisements = NULL, *rd_out_advertisements = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv6",
                             "icmpneighbor",
@@ -3043,7 +3043,7 @@ int do_net_inet6_icmp6_stats(int update_every, usec_t dt) {
                               *rd_out_1 = NULL, *rd_out_128 = NULL, *rd_out_129 = NULL, *rd_out_133 = NULL,
                               *rd_out_135 = NULL, *rd_out_143 = NULL;
 
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "ipv6",
                             "icmptypes",

--- a/collectors/freebsd.plugin/plugin_freebsd.c
+++ b/collectors/freebsd.plugin/plugin_freebsd.c
@@ -113,12 +113,12 @@ void *freebsd_main(void *ptr)
 
         usec_t hb_dt = heartbeat_next(&hb, step);
 
-        if (unlikely(netdata_exit))
+        if (netdata_exit)
             break;
 
         for (i = 0; freebsd_modules[i].name; i++) {
             struct freebsd_module *pm = &freebsd_modules[i];
-            if (unlikely(!pm->enabled))
+            if (!pm->enabled)
                 continue;
 
             netdata_log_debug(D_PROCNETDEV_LOOP, "FREEBSD calling %s.", pm->name);
@@ -126,7 +126,7 @@ void *freebsd_main(void *ptr)
             worker_is_busy(i);
             pm->enabled = !pm->func(localhost->rrd_update_every, hb_dt);
 
-            if (unlikely(netdata_exit))
+            if (netdata_exit)
                 break;
         }
     }

--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -929,15 +929,15 @@ static void netdata_update_ipmi_sensor_reading(
         , char **sensor_bitmask_strings __maybe_unused
         , struct netdata_ipmi_state *state
 ) {
-    if(unlikely(sensor_state == IPMI_MONITORING_STATE_UNKNOWN &&
+    if(sensor_state == IPMI_MONITORING_STATE_UNKNOWN &&
         sensor_type == IPMI_MONITORING_SENSOR_TYPE_UNKNOWN &&
         sensor_units == IPMI_MONITORING_SENSOR_UNITS_UNKNOWN &&
         sensor_reading_type == IPMI_MONITORING_SENSOR_READING_TYPE_UNKNOWN &&
-        (!sensor_name || !*sensor_name)))
+        (!sensor_name || !*sensor_name))
         // we can't do anything about this sensor - everything is unknown
         return;
 
-    if(unlikely(!sensor_name || !*sensor_name))
+    if(!sensor_name || !*sensor_name)
         sensor_name = "UNNAMED";
 
     state->sensors.collected++;
@@ -948,7 +948,7 @@ static void netdata_update_ipmi_sensor_reading(
 
     // find the sensor record
     const DICTIONARY_ITEM *item = dictionary_get_and_acquire_item(state->sensors.dict, key);
-    if(likely(item)) {
+    if(item) {
         // recurring collection
 
         if(state->debug)
@@ -1131,7 +1131,7 @@ int netdata_ipmi_detect_speed_secs(struct ipmi_monitoring_ipmi_config *ipmi_conf
     usec_t total = 0;
 
     for(i = 0 ; i < checks ; i++) {
-        if(unlikely(state->debug))
+        if(state->debug)
             fprintf(stderr, "%s: checking %s data collection speed iteration %d of %d\n",
                     program_name, netdata_collect_type_to_string(type), i + 1, checks);
 
@@ -1145,7 +1145,7 @@ int netdata_ipmi_detect_speed_secs(struct ipmi_monitoring_ipmi_config *ipmi_conf
 
         successful++;
 
-        if(unlikely(state->debug))
+        if(state->debug)
             fprintf(stderr, "%s: %s data collection speed was %llu usec\n",
                     program_name, netdata_collect_type_to_string(type), end - start);
 
@@ -1287,7 +1287,7 @@ static inline bool is_sensor_updated(usec_t last_collected_ut, usec_t now_ut, us
 
 static size_t send_ipmi_sensor_metrics_to_netdata(struct netdata_ipmi_state *state) {
     if(state->sensors.status != ICS_RUNNING) {
-        if(unlikely(state->debug))
+        if(state->debug)
             fprintf(stderr, "%s: %s() sensors state is not RUNNING\n",
                     program_name, __FUNCTION__ );
         return 0;
@@ -1299,19 +1299,19 @@ static size_t send_ipmi_sensor_metrics_to_netdata(struct netdata_ipmi_state *sta
 
     // generate the CHART/DIMENSION lines, if we have to
     dfe_start_reentrant(state->sensors.dict, sn) {
-                if(unlikely(!sn->do_metric && !sn->do_state))
+                if(!sn->do_metric && !sn->do_state)
                     continue;
 
                 bool did_metric = false, did_state = false;
 
-                if(likely(sn->do_metric)) {
-                    if(unlikely(!is_sensor_updated(sn->last_collected_metric_ut, state->updates.now_ut, state->sensors.freq_ut))) {
-                        if(unlikely(state->debug))
+                if(sn->do_metric) {
+                    if(!is_sensor_updated(sn->last_collected_metric_ut, state->updates.now_ut, state->sensors.freq_ut)) {
+                        if(state->debug)
                             fprintf(stderr, "%s: %s() sensor '%s' metric is not UPDATED (last updated %llu, now %llu, freq %llu\n",
                                     program_name, __FUNCTION__, sn->sensor_name, sn->last_collected_metric_ut, state->updates.now_ut, state->sensors.freq_ut);
                     }
                     else {
-                        if (unlikely(!sn->metric_chart_sent)) {
+                        if (!sn->metric_chart_sent) {
                             sn->metric_chart_sent = true;
 
                             printf("CHART '%s_%s' '' '%s' '%s' '%s' '%s' '%s' %d %d '' '%s' '%s'\n",
@@ -1357,14 +1357,14 @@ static size_t send_ipmi_sensor_metrics_to_netdata(struct netdata_ipmi_state *sta
                     }
                 }
 
-                if(likely(sn->do_state)) {
-                    if(unlikely(!is_sensor_updated(sn->last_collected_state_ut, state->updates.now_ut, state->sensors.freq_ut))) {
-                        if (unlikely(state->debug))
+                if(sn->do_state) {
+                    if(!is_sensor_updated(sn->last_collected_state_ut, state->updates.now_ut, state->sensors.freq_ut)) {
+                        if (state->debug)
                             fprintf(stderr, "%s: %s() sensor '%s' state is not UPDATED (last updated %llu, now %llu, freq %llu\n",
                                     program_name, __FUNCTION__, sn->sensor_name, sn->last_collected_state_ut, state->updates.now_ut, state->sensors.freq_ut);
                     }
                     else {
-                        if (unlikely(!sn->state_chart_sent)) {
+                        if (!sn->state_chart_sent) {
                             sn->state_chart_sent = true;
 
                             printf("CHART 'ipmi.sensor_state_%s' '' 'IPMI Sensor State' 'state' 'states' 'ipmi.sensor_state' 'line' %d %d '' '%s' '%s'\n",
@@ -1391,7 +1391,7 @@ static size_t send_ipmi_sensor_metrics_to_netdata(struct netdata_ipmi_state *sta
                     }
                 }
 
-                if(likely(did_metric || did_state))
+                if(did_metric || did_state)
                     total_sensors_sent++;
             }
     dfe_done(sn);
@@ -1402,8 +1402,8 @@ static size_t send_ipmi_sensor_metrics_to_netdata(struct netdata_ipmi_state *sta
 static size_t send_ipmi_sel_metrics_to_netdata(struct netdata_ipmi_state *state) {
     static bool sel_chart_generated = false;
 
-    if(likely(state->sel.status == ICS_RUNNING)) {
-        if(unlikely(!sel_chart_generated)) {
+    if(state->sel.status == ICS_RUNNING) {
+        if(!sel_chart_generated) {
             sel_chart_generated = true;
             printf("CHART ipmi.events '' 'IPMI Events' 'events' 'events' ipmi.sel area %d %d '' '%s' '%s'\n"
                     , state->sel.priority + 2
@@ -1855,7 +1855,7 @@ int main (int argc, char **argv) {
             }
         }
 
-        if(unlikely(debug))
+        if(debug)
             fprintf(stderr, "%s: calling send_ipmi_sensor_metrics_to_netdata()\n", program_name);
 
         state.updates.now_ut = now_monotonic_usec();
@@ -1864,7 +1864,7 @@ int main (int argc, char **argv) {
         if(netdata_do_sel)
             send_ipmi_sel_metrics_to_netdata(&state);
 
-        if(unlikely(debug))
+        if(debug)
             fprintf(stderr, "%s: iteration %zu, dt %llu usec, sensors ever collected %zu, sensors last collected %zu \n"
                     , program_name
                     , iteration

--- a/collectors/idlejitter.plugin/plugin_idlejitter.c
+++ b/collectors/idlejitter.plugin/plugin_idlejitter.c
@@ -68,7 +68,7 @@ void *cpuidlejitter_main(void *ptr) {
             usec_t error = dt - sleep_ut;
             error_total += error;
 
-            if(unlikely(!iterations))
+            if(!iterations)
                 error_min = error;
             else if(error < error_min)
                 error_min = error;

--- a/collectors/macos.plugin/macos_mach_smi.c
+++ b/collectors/macos.plugin/macos_mach_smi.c
@@ -9,7 +9,7 @@ int do_macos_mach_smi(int update_every, usec_t dt) {
 
     static int do_cpu = -1, do_ram = - 1, do_swapio = -1, do_pgfaults = -1;
 
-    if (unlikely(do_cpu == -1)) {
+    if (do_cpu == -1) {
         do_cpu                  = config_get_boolean("plugin:macos:mach_smi", "cpu utilization", 1);
         do_ram                  = config_get_boolean("plugin:macos:mach_smi", "system ram", 1);
         do_swapio               = config_get_boolean("plugin:macos:mach_smi", "swap i/o", 1);
@@ -36,25 +36,25 @@ int do_macos_mach_smi(int update_every, usec_t dt) {
 
     host = mach_host_self();
     kr = host_page_size(host, &system_pagesize);
-    if (unlikely(kr != KERN_SUCCESS))
+    if (kr != KERN_SUCCESS)
         return -1;
 
-    if (likely(do_cpu)) {
-        if (unlikely(HOST_CPU_LOAD_INFO_COUNT != 4)) {
+    if (do_cpu) {
+        if (HOST_CPU_LOAD_INFO_COUNT != 4) {
             collector_error("MACOS: There are %d CPU states (4 was expected)", HOST_CPU_LOAD_INFO_COUNT);
             do_cpu = 0;
             collector_error("DISABLED: system.cpu");
         } else {
             count = HOST_CPU_LOAD_INFO_COUNT;
             kr = host_statistics(host, HOST_CPU_LOAD_INFO, (host_info_t)cp_time, &count);
-            if (unlikely(kr != KERN_SUCCESS)) {
+            if (kr != KERN_SUCCESS) {
                 collector_error("MACOS: host_statistics() failed: %s", mach_error_string(kr));
                 do_cpu = 0;
                 collector_error("DISABLED: system.cpu");
             } else {
 
                 st = rrdset_find_active_bytype_localhost("system", "cpu");
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "system"
                             , "cpu"
@@ -86,7 +86,7 @@ int do_macos_mach_smi(int update_every, usec_t dt) {
         }
     }
 
-    if (likely(do_ram || do_swapio || do_pgfaults)) {
+    if (do_ram || do_swapio || do_pgfaults) {
 #if (defined __MAC_OS_X_VERSION_MIN_REQUIRED && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1060)
         count = sizeof(vm_statistics64_data_t);
         kr = host_statistics64(host, HOST_VM_INFO64, (host_info64_t)&vm_statistics, &count);
@@ -94,7 +94,7 @@ int do_macos_mach_smi(int update_every, usec_t dt) {
         count = sizeof(vm_statistics_data_t);
         kr = host_statistics(host, HOST_VM_INFO, (host_info_t)&vm_statistics, &count);
 #endif
-        if (unlikely(kr != KERN_SUCCESS)) {
+        if (kr != KERN_SUCCESS) {
             collector_error("MACOS: host_statistics64() failed: %s", mach_error_string(kr));
             do_ram = 0;
             collector_error("DISABLED: system.ram");
@@ -103,9 +103,9 @@ int do_macos_mach_smi(int update_every, usec_t dt) {
             do_pgfaults = 0;
             collector_error("DISABLED: mem.pgfaults");
         } else {
-            if (likely(do_ram)) {
+            if (do_ram) {
                 st = rrdset_find_active_localhost("system.ram");
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "system"
                             , "ram"
@@ -147,9 +147,9 @@ int do_macos_mach_smi(int update_every, usec_t dt) {
             }
 
 #if (defined __MAC_OS_X_VERSION_MIN_REQUIRED && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1090)
-            if (likely(do_swapio)) {
+            if (do_swapio) {
                 st = rrdset_find_active_localhost("system.swapio");
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "system"
                             , "swapio"
@@ -175,9 +175,9 @@ int do_macos_mach_smi(int update_every, usec_t dt) {
             }
 #endif
 
-            if (likely(do_pgfaults)) {
+            if (do_pgfaults) {
                 st = rrdset_find_active_localhost("mem.pgfaults");
-                if (unlikely(!st)) {
+                if (!st) {
                     st = rrdset_create_localhost(
                             "mem"
                             , "pgfaults"

--- a/collectors/macos.plugin/plugin_macos.c
+++ b/collectors/macos.plugin/plugin_macos.c
@@ -63,7 +63,7 @@ void *macos_main(void *ptr)
 
         for (int i = 0; macos_modules[i].name; i++) {
             struct macos_module *pm = &macos_modules[i];
-            if (unlikely(!pm->enabled))
+            if (!pm->enabled)
                 continue;
 
             netdata_log_debug(D_PROCNETDEV_LOOP, "macos calling %s.", pm->name);
@@ -71,7 +71,7 @@ void *macos_main(void *ptr)
             worker_is_busy(i);
             pm->enabled = !pm->func(localhost->rrd_update_every, hb_dt);
 
-            if (unlikely(netdata_exit))
+            if (netdata_exit)
                 break;
         }
     }

--- a/collectors/nfacct.plugin/plugin_nfacct.c
+++ b/collectors/nfacct.plugin/plugin_nfacct.c
@@ -533,7 +533,7 @@ static struct {
 static inline struct nfacct_data *nfacct_data_get(const char *name, uint32_t hash) {
     struct nfacct_data *d = NULL, *last = NULL;
     for(d = nfacct_root.nfacct_metrics; d ; last = d, d = d->next) {
-        if(unlikely(d->hash == hash && !strcmp(d->name, name)))
+        if(d->hash == hash && !strcmp(d->name, name))
             return d;
     }
 
@@ -661,8 +661,8 @@ static void nfacct_send_metrics() {
     }
 
     for(d = nfacct_root.nfacct_metrics; d ; d = d->next) {
-        if(likely(d->updated)) {
-            if(unlikely(!d->packets_dimension_added)) {
+        if(d->updated) {
+            if(!d->packets_dimension_added) {
                 d->packets_dimension_added = 1;
                 printf(
                     "CHART netfilter.nfacct_packets '' 'Netfilter Accounting Packets' 'packets/s' 'nfacct' '' stacked %d %d %s\n",
@@ -675,7 +675,7 @@ static void nfacct_send_metrics() {
     }
     printf("BEGIN netfilter.nfacct_packets\n");
     for(d = nfacct_root.nfacct_metrics; d ; d = d->next) {
-        if(likely(d->updated)) {
+        if(d->updated) {
             printf("SET %s = %lld\n"
                     , d->name
                     , (collected_number)d->pkts
@@ -696,8 +696,8 @@ static void nfacct_send_metrics() {
     }
 
     for(d = nfacct_root.nfacct_metrics; d ; d = d->next) {
-        if(likely(d->updated)) {
-            if(unlikely(!d->bytes_dimension_added)) {
+        if(d->updated) {
+            if(!d->bytes_dimension_added) {
                 d->bytes_dimension_added = 1;
                 printf(
                     "CHART netfilter.nfacct_bytes '' 'Netfilter Accounting Bandwidth' 'kilobytes/s' 'nfacct' '' stacked %d %d %s\n",
@@ -710,7 +710,7 @@ static void nfacct_send_metrics() {
     }
     printf("BEGIN netfilter.nfacct_bytes\n");
     for(d = nfacct_root.nfacct_metrics; d ; d = d->next) {
-        if(likely(d->updated)) {
+        if(d->updated) {
             printf("SET %s = %lld\n"
                    , d->name
                    , (collected_number)d->bytes
@@ -849,7 +849,7 @@ int main(int argc, char **argv) {
     for(iteration = 0; 1; iteration++) {
         usec_t dt = heartbeat_next(&hb, step);
 
-        if(unlikely(netdata_exit)) break;
+        if(netdata_exit) break;
 
         if(debug && iteration)
             fprintf(stderr, "nfacct.plugin: iteration %zu, dt %llu usec\n"
@@ -857,21 +857,21 @@ int main(int argc, char **argv) {
                     , dt
             );
 
-        if(likely(nfacct)) {
+        if(nfacct) {
             if(debug) fprintf(stderr, "nfacct.plugin: calling nfacct_collect()\n");
             nfacct = !nfacct_collect();
 
-            if(likely(nfacct)) {
+            if(nfacct) {
                 if(debug) fprintf(stderr, "nfacct.plugin: calling nfacct_send_metrics()\n");
                 nfacct_send_metrics();
             }
         }
 
-        if(likely(nfstat)) {
+        if(nfstat) {
             if(debug) fprintf(stderr, "nfacct.plugin: calling nfstat_collect()\n");
             nfstat = !nfstat_collect();
 
-            if(likely(nfstat)) {
+            if(nfstat) {
                 if(debug) fprintf(stderr, "nfacct.plugin: calling nfstat_send_metrics()\n");
                 nfstat_send_metrics();
             }

--- a/collectors/plugins.d/pluginsd_parser.h
+++ b/collectors/plugins.d/pluginsd_parser.h
@@ -126,10 +126,10 @@ PARSER_RC parser_execute(PARSER *parser, PARSER_KEYWORD *keyword, char **words, 
 static inline int find_first_keyword(const char *src, char *dst, int dst_size, bool *isspace_map) {
     const char *s = src, *keyword_start;
 
-    while (unlikely(isspace_map[(uint8_t)*s])) s++;
+    while (isspace_map[(uint8_t)*s]) s++;
     keyword_start = s;
 
-    while (likely(*s && !isspace_map[(uint8_t)*s]) && dst_size > 1) {
+    while (*s && !isspace_map[(uint8_t)*s] && dst_size > 1) {
         *dst++ = *s++;
         dst_size--;
     }
@@ -150,7 +150,7 @@ static inline PARSER_KEYWORD *parser_find_keyword(PARSER *parser, const char *co
 static inline int parser_action(PARSER *parser, char *input) {
     parser->line++;
 
-    if(unlikely(parser->flags & PARSER_DEFER_UNTIL_KEYWORD)) {
+    if(parser->flags & PARSER_DEFER_UNTIL_KEYWORD) {
         char command[PLUGINSD_LINE_MAX + 1];
         bool has_keyword = find_first_keyword(input, command, PLUGINSD_LINE_MAX, isspace_map_pluginsd);
 
@@ -184,12 +184,12 @@ static inline int parser_action(PARSER *parser, char *input) {
     size_t num_words = quoted_strings_splitter_pluginsd(input, words, PLUGINSD_MAX_WORDS);
     const char *command = get_word(words, num_words, 0);
 
-    if(unlikely(!command))
+    if(!command)
         return 0;
 
     PARSER_RC rc;
     PARSER_KEYWORD *t = parser_find_keyword(parser, command);
-    if(likely(t)) {
+    if(t) {
         worker_is_busy(t->worker_job_id);
         rc = parser_execute(parser, t, words, num_words);
         // rc = (*t->func)(words, num_words, parser);

--- a/collectors/proc.plugin/ipc.c
+++ b/collectors/proc.plugin/ipc.c
@@ -75,13 +75,13 @@ static inline int ipc_sem_get_limits(struct ipc_limits *lim) {
     static int error_shown = 0;
     static char filename[FILENAME_MAX + 1] = "";
 
-    if(unlikely(!filename[0]))
+    if(!filename[0])
         snprintfz(filename, FILENAME_MAX, "%s/proc/sys/kernel/sem", netdata_configured_host_prefix);
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         ff = procfile_open(filename, NULL, PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff)) {
-            if(unlikely(!error_shown)) {
+        if(!ff) {
+            if(!error_shown) {
                 collector_error("IPC: Cannot open file '%s'.", filename);
                 error_shown = 1;
             }
@@ -90,8 +90,8 @@ static inline int ipc_sem_get_limits(struct ipc_limits *lim) {
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff)) {
-        if(unlikely(!error_shown)) {
+    if(!ff) {
+        if(!error_shown) {
             collector_error("IPC: Cannot read file '%s'.", filename);
             error_shown = 1;
         }
@@ -107,7 +107,7 @@ static inline int ipc_sem_get_limits(struct ipc_limits *lim) {
         return 0;
     }
     else {
-        if(unlikely(!error_shown)) {
+        if(!error_shown) {
             collector_error("IPC: Invalid content in file '%s'.", filename);
             error_shown = 1;
         }
@@ -121,7 +121,7 @@ ipc:
         struct seminfo seminfo = {.semmni = 0};
         union semun arg = {.array = (ushort *) &seminfo};
 
-        if(unlikely(semctl(0, 0, IPC_INFO, arg) < 0)) {
+        if(semctl(0, 0, IPC_INFO, arg) < 0) {
             collector_error("IPC: Failed to read '%s' and request IPC_INFO with semctl().", filename);
             goto error;
         }
@@ -162,10 +162,10 @@ static inline int ipc_sem_get_status(struct ipc_status *st) {
 
     arg.array = (ushort *)  (void *) &seminfo;
 
-    if(unlikely(semctl (0, 0, SEM_INFO, arg) < 0)) {
+    if(semctl (0, 0, SEM_INFO, arg) < 0) {
         /* kernel not configured for semaphores */
         static int error_shown = 0;
-        if(unlikely(!error_shown)) {
+        if(!error_shown) {
             collector_error("IPC: kernel is not configured for semaphores");
             error_shown = 1;
         }
@@ -183,18 +183,18 @@ int ipc_msq_get_info(char *msg_filename, struct message_queue **message_queue_ro
     static procfile *ff;
     struct message_queue *msq;
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         ff = procfile_open(msg_filename, " \t:", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff)) return 1;
+        if(!ff) return 1;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff)) return 1;
+    if(!ff) return 1;
 
     size_t lines = procfile_lines(ff);
     size_t words = 0;
 
-    if(unlikely(lines < 2)) {
+    if(lines < 2) {
         collector_error("Cannot read %s. Expected 2 or more lines, read %zu.", procfile_filename(ff), lines);
         return 1;
     }
@@ -203,8 +203,8 @@ int ipc_msq_get_info(char *msg_filename, struct message_queue **message_queue_ro
     size_t l;
     for(l = 1; l < lines - 1; l++) {
         words = procfile_linewords(ff, l);
-        if(unlikely(words < 2)) continue;
-        if(unlikely(words < 14)) {
+        if(words < 2) continue;
+        if(words < 14) {
             collector_error("Cannot read %s line. Expected 14 params, read %zu.", procfile_filename(ff), words);
             continue;
         }
@@ -214,13 +214,13 @@ int ipc_msq_get_info(char *msg_filename, struct message_queue **message_queue_ro
 
         unsigned long long id = str2ull(procfile_lineword(ff, l, 1), NULL);
         for(msq = *message_queue_root; msq ; msq = msq->next) {
-            if(unlikely(id == msq->id)) {
+            if(id == msq->id) {
                 found = 1;
                 break;
             }
         }
 
-        if(unlikely(!found)) {
+        if(!found) {
             msq = callocz(1, sizeof(struct message_queue));
             msq->next = *message_queue_root;
             *message_queue_root = msq;
@@ -238,18 +238,18 @@ int ipc_msq_get_info(char *msg_filename, struct message_queue **message_queue_ro
 int ipc_shm_get_info(char *shm_filename, struct shm_stats *shm) {
     static procfile *ff;
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         ff = procfile_open(shm_filename, " \t:", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff)) return 1;
+        if(!ff) return 1;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff)) return 1;
+    if(!ff) return 1;
 
     size_t lines = procfile_lines(ff);
     size_t words = 0;
 
-    if(unlikely(lines < 2)) {
+    if(lines < 2) {
         collector_error("Cannot read %s. Expected 2 or more lines, read %zu.", procfile_filename(ff), lines);
         return 1;
     }
@@ -261,8 +261,8 @@ int ipc_shm_get_info(char *shm_filename, struct shm_stats *shm) {
     size_t l;
     for(l = 1; l < lines - 1; l++) {
         words = procfile_linewords(ff, l);
-        if(unlikely(words < 2)) continue;
-        if(unlikely(words < 16)) {
+        if(words < 2) continue;
+        if(words < 16) {
             collector_error("Cannot read %s line. Expected 16 params, read %zu.", procfile_filename(ff), words);
             continue;
         }
@@ -289,7 +289,7 @@ int do_ipc(int update_every, usec_t dt) {
     static long long dimensions_limit;
     static char *shm_filename = NULL;
 
-    if(unlikely(do_sem == -1)) {
+    if(do_sem == -1) {
         do_msg = config_get_boolean("plugin:proc:ipc", "message queues", CONFIG_BOOLEAN_YES);
         do_sem = config_get_boolean("plugin:proc:ipc", "semaphore totals", CONFIG_BOOLEAN_YES);
         do_shm = config_get_boolean("plugin:proc:ipc", "shared memory totals", CONFIG_BOOLEAN_YES);
@@ -315,7 +315,7 @@ int do_ipc(int update_every, usec_t dt) {
         }
         else {
             // create the charts
-            if(unlikely(!st_semaphores)) {
+            if(!st_semaphores) {
                 st_semaphores = rrdset_create_localhost(
                         "system"
                         , "ipc_semaphores"
@@ -333,7 +333,7 @@ int do_ipc(int update_every, usec_t dt) {
                 rd_semaphores = rrddim_add(st_semaphores, "semaphores", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             }
 
-            if(unlikely(!st_arrays)) {
+            if(!st_arrays) {
                 st_arrays = rrdset_create_localhost(
                         "system"
                         , "ipc_semaphore_arrays"
@@ -361,15 +361,15 @@ int do_ipc(int update_every, usec_t dt) {
             do_msg = CONFIG_BOOLEAN_NO;
         }
 
-        if(unlikely(do_sem == CONFIG_BOOLEAN_NO && do_msg == CONFIG_BOOLEAN_NO)) {
+        if(do_sem == CONFIG_BOOLEAN_NO && do_msg == CONFIG_BOOLEAN_NO) {
             collector_error("ipc module disabled");
             return 1;
         }
     }
 
-    if(likely(do_sem != CONFIG_BOOLEAN_NO)) {
-        if(unlikely(read_limits_next < 0)) {
-            if(unlikely(ipc_sem_get_limits(&limits) == -1)) {
+    if(do_sem != CONFIG_BOOLEAN_NO) {
+        if(read_limits_next < 0) {
+            if(ipc_sem_get_limits(&limits) == -1) {
                 collector_error("Unable to fetch semaphore limits.");
             }
             else {
@@ -385,7 +385,7 @@ int do_ipc(int update_every, usec_t dt) {
         else
             read_limits_next--;
 
-        if(unlikely(ipc_sem_get_status(&status) == -1)) {
+        if(ipc_sem_get_status(&status) == -1) {
             collector_error("Unable to get semaphore statistics");
             return 0;
         }
@@ -397,13 +397,13 @@ int do_ipc(int update_every, usec_t dt) {
         rrdset_done(st_arrays);
     }
 
-    if(likely(do_msg != CONFIG_BOOLEAN_NO)) {
+    if(do_msg != CONFIG_BOOLEAN_NO) {
         static RRDSET *st_msq_messages = NULL, *st_msq_bytes = NULL;
 
         int ret = ipc_msq_get_info(msg_filename, &message_queue_root);
 
         if(!ret && message_queue_root) {
-            if(unlikely(!st_msq_messages))
+            if(!st_msq_messages)
                 st_msq_messages = rrdset_create_localhost(
                         "system"
                         , "message_queue_messages"
@@ -419,7 +419,7 @@ int do_ipc(int update_every, usec_t dt) {
                         , RRDSET_TYPE_STACKED
                 );
 
-            if(unlikely(!st_msq_bytes))
+            if(!st_msq_bytes)
                 st_msq_bytes = rrdset_create_localhost(
                         "system"
                         , "message_queue_bytes"
@@ -436,13 +436,13 @@ int do_ipc(int update_every, usec_t dt) {
                 );
 
             struct message_queue *msq = message_queue_root, *msq_prev = NULL;
-            while(likely(msq)){
-                if(likely(msq->found)) {
-                    if(unlikely(!msq->rd_messages || !msq->rd_bytes)) {
+            while(msq){
+                if(msq->found) {
+                    if(!msq->rd_messages || !msq->rd_bytes) {
                         char id[RRD_ID_LENGTH_MAX + 1];
                         snprintfz(id, RRD_ID_LENGTH_MAX, "%llu", msq->id);
-                        if(likely(!msq->rd_messages)) msq->rd_messages = rrddim_add(st_msq_messages, id, NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-                        if(likely(!msq->rd_bytes)) msq->rd_bytes = rrddim_add(st_msq_bytes, id, NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+                        if(!msq->rd_messages) msq->rd_messages = rrddim_add(st_msq_messages, id, NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+                        if(!msq->rd_bytes) msq->rd_bytes = rrddim_add(st_msq_bytes, id, NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
                     }
 
                     rrddim_set_by_pointer(st_msq_messages, msq->rd_messages, msq->messages);
@@ -462,7 +462,7 @@ int do_ipc(int update_every, usec_t dt) {
                     freez(msq);
                     msq = NULL;
                 }
-                if(likely(msq)) {
+                if(msq) {
                     msq_prev = msq;
                     msq = msq->next;
                 }
@@ -477,7 +477,7 @@ int do_ipc(int update_every, usec_t dt) {
 
             long long dimensions_num = rrdset_number_of_dimensions(st_msq_messages);
 
-            if(unlikely(dimensions_num > dimensions_limit)) {
+            if(dimensions_num > dimensions_limit) {
                 collector_info("Message queue statistics has been disabled");
                 collector_info("There are %lld dimensions in memory but limit was set to %lld", dimensions_num, dimensions_limit);
                 rrdset_is_obsolete(st_msq_messages);
@@ -486,7 +486,7 @@ int do_ipc(int update_every, usec_t dt) {
                 st_msq_bytes = NULL;
                 do_msg = CONFIG_BOOLEAN_NO;
             }
-            else if(unlikely(!message_queue_root)) {
+            else if(!message_queue_root) {
                 collector_info("Making chart %s (%s) obsolete since it does not have any dimensions", rrdset_name(st_msq_messages), rrdset_id(st_msq_messages));
                 rrdset_is_obsolete(st_msq_messages);
                 st_msq_messages = NULL;
@@ -498,13 +498,13 @@ int do_ipc(int update_every, usec_t dt) {
         }
     }
 
-    if(likely(do_shm != CONFIG_BOOLEAN_NO)) {
+    if(do_shm != CONFIG_BOOLEAN_NO) {
         static RRDSET *st_shm_segments = NULL, *st_shm_bytes = NULL;
         static RRDDIM *rd_shm_segments = NULL, *rd_shm_bytes = NULL;
         struct shm_stats shm;
 
         if(!ipc_shm_get_info(shm_filename, &shm)) {
-            if(unlikely(!st_shm_segments)) {
+            if(!st_shm_segments) {
                 st_shm_segments = rrdset_create_localhost(
                         "system"
                         , "shared_memory_segments"
@@ -526,7 +526,7 @@ int do_ipc(int update_every, usec_t dt) {
             rrddim_set_by_pointer(st_shm_segments, rd_shm_segments, shm.segments);
             rrdset_done(st_shm_segments);
 
-            if(unlikely(!st_shm_bytes)) {
+            if(!st_shm_bytes) {
                 st_shm_bytes = rrdset_create_localhost(
                         "system"
                         , "shared_memory_bytes"

--- a/collectors/proc.plugin/plugin_proc.c
+++ b/collectors/proc.plugin/plugin_proc.c
@@ -104,16 +104,16 @@ bool inside_lxc_container = false;
 static bool is_lxcfs_proc_mounted() {
     procfile *ff = NULL;
 
-    if (unlikely(!ff)) {
+    if (!ff) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "/proc/self/mounts");
         ff = procfile_open(filename, " \t", PROCFILE_FLAG_DEFAULT);
-        if (unlikely(!ff))
+        if (!ff)
             return false;
     }
 
     ff = procfile_readall(ff);
-    if (unlikely(!ff))
+    if (!ff)
         return false;
 
     unsigned long l, lines = procfile_lines(ff);
@@ -170,15 +170,15 @@ void *proc_main(void *ptr)
         worker_is_idle();
         usec_t hb_dt = heartbeat_next(&hb, step);
 
-        if (unlikely(!service_running(SERVICE_COLLECTORS)))
+        if (!service_running(SERVICE_COLLECTORS))
             break;
 
         for (i = 0; proc_modules[i].name; i++) {
-            if (unlikely(!service_running(SERVICE_COLLECTORS)))
+            if (!service_running(SERVICE_COLLECTORS))
                 break;
 
             struct proc_module *pm = &proc_modules[i];
-            if (unlikely(!pm->enabled))
+            if (!pm->enabled)
                 continue;
 
             netdata_log_debug(D_PROCNETDEV_LOOP, "PROC calling %s.", pm->name);

--- a/collectors/proc.plugin/proc_interrupts.c
+++ b/collectors/proc.plugin/proc_interrupts.c
@@ -32,7 +32,7 @@ static inline struct interrupt *get_interrupts_array(size_t lines, int cpus) {
     static struct interrupt *irrs = NULL;
     static size_t allocated = 0;
 
-    if(unlikely(lines != allocated)) {
+    if(lines != allocated) {
         size_t l;
         int c;
 
@@ -59,40 +59,40 @@ int do_proc_interrupts(int update_every, usec_t dt) {
     static int cpus = -1, do_per_core = CONFIG_BOOLEAN_INVALID;
     struct interrupt *irrs = NULL;
 
-    if(unlikely(do_per_core == CONFIG_BOOLEAN_INVALID))
+    if(do_per_core == CONFIG_BOOLEAN_INVALID)
         do_per_core = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_PROC_INTERRUPTS, "interrupts per core", CONFIG_BOOLEAN_AUTO);
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/interrupts");
         ff = procfile_open(config_get(CONFIG_SECTION_PLUGIN_PROC_INTERRUPTS, "filename to monitor", filename), " \t:", PROCFILE_FLAG_DEFAULT);
     }
-    if(unlikely(!ff))
+    if(!ff)
         return 1;
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff))
+    if(!ff)
         return 0; // we return 0, so that we will retry to open it next time
 
     size_t lines = procfile_lines(ff), l;
     size_t words = procfile_linewords(ff, 0);
 
-    if(unlikely(!lines)) {
+    if(!lines) {
         collector_error("Cannot read /proc/interrupts, zero lines reported.");
         return 1;
     }
 
     // find how many CPUs are there
-    if(unlikely(cpus == -1)) {
+    if(cpus == -1) {
         uint32_t w;
         cpus = 0;
         for(w = 0; w < words ; w++) {
-            if(likely(strncmp(procfile_lineword(ff, 0, w), "CPU", 3) == 0))
+            if(strncmp(procfile_lineword(ff, 0, w), "CPU", 3) == 0)
                 cpus++;
         }
     }
 
-    if(unlikely(!cpus)) {
+    if(!cpus) {
         collector_error("PLUGIN: PROC_INTERRUPTS: Cannot find the number of CPUs in /proc/interrupts");
         return 1;
     }
@@ -108,10 +108,10 @@ int do_proc_interrupts(int update_every, usec_t dt) {
         irr->total = 0;
 
         words = procfile_linewords(ff, l);
-        if(unlikely(!words)) continue;
+        if(!words) continue;
 
         irr->id = procfile_lineword(ff, l, 0);
-        if(unlikely(!irr->id || !irr->id[0])) continue;
+        if(!irr->id || !irr->id[0]) continue;
 
         size_t idlen = strlen(irr->id);
         if(irr->id[idlen - 1] == ':')
@@ -119,7 +119,7 @@ int do_proc_interrupts(int update_every, usec_t dt) {
 
         int c;
         for(c = 0; c < cpus ;c++) {
-            if(likely((c + 1) < (int)words))
+            if((c + 1) < (int)words)
                 irr->cpu[c].value = str2ull(procfile_lineword(ff, l, (uint32_t) (c + 1)), NULL);
             else
                 irr->cpu[c].value = 0;
@@ -127,10 +127,10 @@ int do_proc_interrupts(int update_every, usec_t dt) {
             irr->total += irr->cpu[c].value;
         }
 
-        if(unlikely(isdigit(irr->id[0]) && (uint32_t)(cpus + 2) < words)) {
+        if(isdigit(irr->id[0]) && (uint32_t)(cpus + 2) < words) {
             strncpyz(irr->name, procfile_lineword(ff, l, words - 1), MAX_INTERRUPT_NAME);
             size_t nlen = strlen(irr->name);
-            if(likely(nlen + 1 + idlen <= MAX_INTERRUPT_NAME)) {
+            if(nlen + 1 + idlen <= MAX_INTERRUPT_NAME) {
                 irr->name[nlen] = '_';
                 strncpyz(&irr->name[nlen + 1], irr->id, MAX_INTERRUPT_NAME - nlen - 1);
             }
@@ -147,7 +147,7 @@ int do_proc_interrupts(int update_every, usec_t dt) {
     }
 
     static RRDSET *st_system_interrupts = NULL;
-    if(unlikely(!st_system_interrupts))
+    if(!st_system_interrupts)
         st_system_interrupts = rrdset_create_localhost(
                 "system"
                 , "interrupts"
@@ -169,12 +169,12 @@ int do_proc_interrupts(int update_every, usec_t dt) {
             // some interrupt may have changed without changing the total number of lines
             // if the same number of interrupts have been added and removed between two
             // calls of this function.
-            if(unlikely(!irr->rd || strncmp(rrddim_name(irr->rd), irr->name, MAX_INTERRUPT_NAME) != 0)) {
+            if(!irr->rd || strncmp(rrddim_name(irr->rd), irr->name, MAX_INTERRUPT_NAME) != 0) {
                 irr->rd = rrddim_add(st_system_interrupts, irr->id, irr->name, 1, 1, RRD_ALGORITHM_INCREMENTAL);
                 rrddim_reset_name(st_system_interrupts, irr->rd, irr->name);
 
                 // also reset per cpu RRDDIMs to avoid repeating strncmp() in the per core loop
-                if(likely(do_per_core != CONFIG_BOOLEAN_NO)) {
+                if(do_per_core != CONFIG_BOOLEAN_NO) {
                     int c;
                     for(c = 0; c < cpus; c++) irr->cpu[c].rd = NULL;
                 }
@@ -186,7 +186,7 @@ int do_proc_interrupts(int update_every, usec_t dt) {
 
     rrdset_done(st_system_interrupts);
 
-    if(likely(do_per_core != CONFIG_BOOLEAN_NO)) {
+    if(do_per_core != CONFIG_BOOLEAN_NO) {
         static RRDSET **core_st = NULL;
         static int old_cpus = 0;
 
@@ -199,7 +199,7 @@ int do_proc_interrupts(int update_every, usec_t dt) {
         int c;
 
         for(c = 0; c < cpus ;c++) {
-            if(unlikely(!core_st[c])) {
+            if(!core_st[c]) {
                 char id[50+1];
                 snprintfz(id, 50, "cpu%d_interrupts", c);
 
@@ -228,7 +228,7 @@ int do_proc_interrupts(int update_every, usec_t dt) {
             for(l = 0; l < lines ;l++) {
                 struct interrupt *irr = irrindex(irrs, l, cpus);
                 if(irr->used && (do_per_core == CONFIG_BOOLEAN_YES || irr->cpu[c].value)) {
-                    if(unlikely(!irr->cpu[c].rd)) {
+                    if(!irr->cpu[c].rd) {
                         irr->cpu[c].rd = rrddim_add(core_st[c], irr->id, irr->name, 1, 1, RRD_ALGORITHM_INCREMENTAL);
                         rrddim_reset_name(core_st[c], irr->cpu[c].rd, irr->name);
                     }

--- a/collectors/proc.plugin/proc_loadavg.c
+++ b/collectors/proc.plugin/proc_loadavg.c
@@ -13,29 +13,29 @@ int do_proc_loadavg(int update_every, usec_t dt) {
     static int do_loadavg = -1, do_all_processes = -1;
     static usec_t next_loadavg_dt = 0;
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/loadavg");
 
         ff = procfile_open(config_get(CONFIG_SECTION_PLUGIN_PROC_LOADAVG, "filename to monitor", filename), " \t,:|/", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff))
+        if(!ff)
             return 1;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff))
+    if(!ff)
         return 0; // we return 0, so that we will retry to open it next time
 
-    if(unlikely(do_loadavg == -1)) {
+    if(do_loadavg == -1) {
         do_loadavg          = config_get_boolean(CONFIG_SECTION_PLUGIN_PROC_LOADAVG, "enable load average", 1);
         do_all_processes    = config_get_boolean(CONFIG_SECTION_PLUGIN_PROC_LOADAVG, "enable total processes", 1);
     }
 
-    if(unlikely(procfile_lines(ff) < 1)) {
+    if(procfile_lines(ff) < 1) {
         collector_error("/proc/loadavg has no lines.");
         return 1;
     }
-    if(unlikely(procfile_linewords(ff, 0) < 6)) {
+    if(procfile_linewords(ff, 0) < 6) {
         collector_error("/proc/loadavg has less than 6 words in it.");
         return 1;
     }
@@ -53,11 +53,11 @@ int do_proc_loadavg(int update_every, usec_t dt) {
     //unsigned long long next_pid           = str2ull(procfile_lineword(ff, 0, 5));
 
     if(next_loadavg_dt <= dt) {
-        if(likely(do_loadavg)) {
+        if(do_loadavg) {
             static RRDSET *load_chart = NULL;
             static RRDDIM *rd_load1 = NULL, *rd_load5 = NULL, *rd_load15 = NULL;
 
-            if(unlikely(!load_chart)) {
+            if(!load_chart) {
                 load_chart = rrdset_create_localhost(
                         "system"
                         , "load"
@@ -92,12 +92,12 @@ int do_proc_loadavg(int update_every, usec_t dt) {
         next_loadavg_dt -= dt;
 
 
-    if(likely(do_all_processes)) {
+    if(do_all_processes) {
         static RRDSET *processes_chart = NULL;
         static RRDDIM *rd_active = NULL;
         static const RRDSETVAR_ACQUIRED *rd_pidmax;
 
-        if(unlikely(!processes_chart)) {
+        if(!processes_chart) {
             processes_chart = rrdset_create_localhost(
                     "system"
                     , "active_processes"

--- a/collectors/proc.plugin/proc_meminfo.c
+++ b/collectors/proc.plugin/proc_meminfo.c
@@ -62,7 +62,7 @@ int do_proc_meminfo(int update_every, usec_t dt) {
             //DirectMap2M = 0,
             HardwareCorrupted = 0;
 
-    if(unlikely(!arl_base)) {
+    if(!arl_base) {
         do_ram          = config_get_boolean(CONFIG_SECTION_PLUGIN_PROC_MEMINFO, "system ram", 1);
         do_swap         = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_PROC_MEMINFO, "system swap", CONFIG_BOOLEAN_AUTO);
         do_hwcorrupt    = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_PROC_MEMINFO, "hardware corrupted ECC", CONFIG_BOOLEAN_AUTO);
@@ -121,16 +121,16 @@ int do_proc_meminfo(int update_every, usec_t dt) {
         //arl_expect(arl_base, "DirectMap2M", &DirectMap2M);
     }
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/meminfo");
         ff = procfile_open(config_get(CONFIG_SECTION_PLUGIN_PROC_MEMINFO, "filename to monitor", filename), " \t:", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff))
+        if(!ff)
             return 1;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff))
+    if(!ff)
         return 0; // we return 0, so that we will retry to open it next time
 
     size_t lines = procfile_lines(ff), l;
@@ -141,14 +141,14 @@ int do_proc_meminfo(int update_every, usec_t dt) {
 
     for(l = 0; l < lines ;l++) {
         size_t words = procfile_linewords(ff, l);
-        if(unlikely(words < 2)) continue;
+        if(words < 2) continue;
 
         if (first_ff_read && !strcmp(procfile_lineword(ff, l, 0), "Percpu"))
             do_percpu = 1;
 
-        if(unlikely(arl_check(arl_base,
+        if(arl_check(arl_base,
                 procfile_lineword(ff, l, 0),
-                procfile_lineword(ff, l, 1)))) break;
+                procfile_lineword(ff, l, 1))) break;
     }
 
     if (first_ff_read)
@@ -169,7 +169,7 @@ int do_proc_meminfo(int update_every, usec_t dt) {
             static RRDSET *st_system_ram = NULL;
             static RRDDIM *rd_free = NULL, *rd_used = NULL, *rd_cached = NULL, *rd_buffers = NULL;
 
-            if(unlikely(!st_system_ram)) {
+            if(!st_system_ram) {
                 st_system_ram = rrdset_create_localhost(
                         "system"
                         , "ram"
@@ -202,7 +202,7 @@ int do_proc_meminfo(int update_every, usec_t dt) {
             static RRDSET *st_mem_available = NULL;
             static RRDDIM *rd_avail = NULL;
 
-            if(unlikely(!st_mem_available)) {
+            if(!st_mem_available) {
                 st_mem_available = rrdset_create_localhost(
                         "mem"
                         , "available"
@@ -236,7 +236,7 @@ int do_proc_meminfo(int update_every, usec_t dt) {
         static RRDSET *st_system_swap = NULL;
         static RRDDIM *rd_free = NULL, *rd_used = NULL;
 
-        if(unlikely(!st_system_swap)) {
+        if(!st_system_swap) {
             st_system_swap = rrdset_create_localhost(
                     "system"
                     , "swap"
@@ -272,7 +272,7 @@ int do_proc_meminfo(int update_every, usec_t dt) {
         static RRDSET *st_mem_hwcorrupt = NULL;
         static RRDDIM *rd_corrupted = NULL;
 
-        if(unlikely(!st_mem_hwcorrupt)) {
+        if(!st_mem_hwcorrupt) {
             st_mem_hwcorrupt = rrdset_create_localhost(
                     "mem"
                     , "hwcorrupt"
@@ -301,7 +301,7 @@ int do_proc_meminfo(int update_every, usec_t dt) {
         static RRDSET *st_mem_committed = NULL;
         static RRDDIM *rd_committed = NULL;
 
-        if(unlikely(!st_mem_committed)) {
+        if(!st_mem_committed) {
             st_mem_committed = rrdset_create_localhost(
                     "mem"
                     , "committed"
@@ -330,7 +330,7 @@ int do_proc_meminfo(int update_every, usec_t dt) {
         static RRDSET *st_mem_writeback = NULL;
         static RRDDIM *rd_dirty = NULL, *rd_writeback = NULL, *rd_fusewriteback = NULL, *rd_nfs_writeback = NULL, *rd_bounce = NULL;
 
-        if(unlikely(!st_mem_writeback)) {
+        if(!st_mem_writeback) {
             st_mem_writeback = rrdset_create_localhost(
                     "mem"
                     , "writeback"
@@ -369,7 +369,7 @@ int do_proc_meminfo(int update_every, usec_t dt) {
         static RRDDIM *rd_slab = NULL, *rd_kernelstack = NULL, *rd_pagetables = NULL, *rd_vmallocused = NULL,
                       *rd_percpu = NULL;
 
-        if(unlikely(!st_mem_kernel)) {
+        if(!st_mem_kernel) {
             st_mem_kernel = rrdset_create_localhost(
                     "mem"
                     , "kernel"
@@ -409,7 +409,7 @@ int do_proc_meminfo(int update_every, usec_t dt) {
         static RRDSET *st_mem_slab = NULL;
         static RRDDIM *rd_reclaimable = NULL, *rd_unreclaimable = NULL;
 
-        if(unlikely(!st_mem_slab)) {
+        if(!st_mem_slab) {
             st_mem_slab = rrdset_create_localhost(
                     "mem"
                     , "slab"
@@ -444,7 +444,7 @@ int do_proc_meminfo(int update_every, usec_t dt) {
         static RRDSET *st_mem_hugepages = NULL;
         static RRDDIM *rd_used = NULL, *rd_free = NULL, *rd_rsvd = NULL, *rd_surp = NULL;
 
-        if(unlikely(!st_mem_hugepages)) {
+        if(!st_mem_hugepages) {
             st_mem_hugepages = rrdset_create_localhost(
                     "mem"
                     , "hugepages"
@@ -484,7 +484,7 @@ int do_proc_meminfo(int update_every, usec_t dt) {
         static RRDSET *st_mem_transparent_hugepages = NULL;
         static RRDDIM *rd_anonymous = NULL, *rd_shared = NULL;
 
-        if(unlikely(!st_mem_transparent_hugepages)) {
+        if(!st_mem_transparent_hugepages) {
             st_mem_transparent_hugepages = rrdset_create_localhost(
                     "mem"
                     , "transparent_hugepages"

--- a/collectors/proc.plugin/proc_net_ip_vs_stats.c
+++ b/collectors/proc.plugin/proc_net_ip_vs_stats.c
@@ -42,7 +42,7 @@ int do_proc_net_ip_vs_stats(int update_every, usec_t dt) {
     if(do_sockets) {
         static RRDSET *st = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_IPVS
                     , "sockets"
@@ -67,7 +67,7 @@ int do_proc_net_ip_vs_stats(int update_every, usec_t dt) {
 
     if(do_packets) {
         static RRDSET *st = NULL;
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_IPVS
                     , "packets"
@@ -94,7 +94,7 @@ int do_proc_net_ip_vs_stats(int update_every, usec_t dt) {
 
     if(do_bandwidth) {
         static RRDSET *st = NULL;
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_IPVS
                     , "net"

--- a/collectors/proc.plugin/proc_net_netstat.c
+++ b/collectors/proc.plugin/proc_net_netstat.c
@@ -96,13 +96,13 @@ static void parse_line_pair(procfile *ff_netstat, ARL_BASE *base, size_t header_
     size_t vwords = procfile_linewords(ff_netstat, values_line);
     size_t w;
 
-    if(unlikely(vwords > hwords)) {
+    if(vwords > hwords) {
         collector_error("File /proc/net/netstat on header line %zu has %zu words, but on value line %zu has %zu words.", header_line, hwords, values_line, vwords);
         vwords = hwords;
     }
 
     for(w = 1; w < vwords ;w++) {
-        if(unlikely(arl_check(base, procfile_lineword(ff_netstat, header_line, w), procfile_lineword(ff_netstat, values_line, w))))
+        if(arl_check(base, procfile_lineword(ff_netstat, header_line, w), procfile_lineword(ff_netstat, values_line, w)))
             break;
     }
 }
@@ -220,7 +220,7 @@ static void do_proc_net_snmp6(int update_every) {
 
     // prepare for /proc/net/snmp6 parsing
 
-    if(unlikely(!arl_ipv6)) {
+    if(!arl_ipv6) {
         do_ip6_packets          = config_get_boolean_ondemand("plugin:proc:/proc/net/snmp6", "ipv6 packets", CONFIG_BOOLEAN_AUTO);
         do_ip6_fragsout         = config_get_boolean_ondemand("plugin:proc:/proc/net/snmp6", "ipv6 fragments sent", CONFIG_BOOLEAN_AUTO);
         do_ip6_fragsin          = config_get_boolean_ondemand("plugin:proc:/proc/net/snmp6", "ipv6 fragments assembly", CONFIG_BOOLEAN_AUTO);
@@ -341,19 +341,19 @@ static void do_proc_net_snmp6(int update_every) {
 
     // parse /proc/net/snmp
 
-    if (unlikely(!ff_snmp6)) {
+    if (!ff_snmp6) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/net/snmp6");
         ff_snmp6 = procfile_open(
             config_get("plugin:proc:/proc/net/snmp6", "filename to monitor", filename), " \t:", PROCFILE_FLAG_DEFAULT);
-        if (unlikely(!ff_snmp6)) {
+        if (!ff_snmp6) {
             do_snmp6 = false;
             return;
         }
     }
 
     ff_snmp6 = procfile_readall(ff_snmp6);
-    if (unlikely(!ff_snmp6))
+    if (!ff_snmp6)
         return;
 
     size_t lines, l;
@@ -364,14 +364,14 @@ static void do_proc_net_snmp6(int update_every) {
 
     for (l = 0; l < lines; l++) {
         size_t words = procfile_linewords(ff_snmp6, l);
-        if (unlikely(words < 2)) {
-            if (unlikely(words)) {
+        if (words < 2) {
+            if (words) {
                 collector_error("Cannot read /proc/net/snmp6 line %zu. Expected 2 params, read %zu.", l, words);
                 continue;
             }
         }
 
-        if (unlikely(arl_check(arl_ipv6, procfile_lineword(ff_snmp6, l, 0), procfile_lineword(ff_snmp6, l, 1))))
+        if (arl_check(arl_ipv6, procfile_lineword(ff_snmp6, l, 0), procfile_lineword(ff_snmp6, l, 1)))
             break;
     }
 
@@ -384,7 +384,7 @@ static void do_proc_net_snmp6(int update_every) {
         static RRDDIM *rd_received = NULL,
                       *rd_sent = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "system"
                     , "ipv6"
@@ -422,7 +422,7 @@ static void do_proc_net_snmp6(int update_every) {
                       *rd_forwarded = NULL,
                       *rd_delivers = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "packets"
@@ -462,7 +462,7 @@ static void do_proc_net_snmp6(int update_every) {
                       *rd_failed = NULL,
                       *rd_all = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "fragsout"
@@ -504,7 +504,7 @@ static void do_proc_net_snmp6(int update_every) {
                       *rd_timeout = NULL,
                       *rd_all = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "fragsin"
@@ -555,7 +555,7 @@ static void do_proc_net_snmp6(int update_every) {
                       *rd_InNoRoutes      = NULL,
                       *rd_OutNoRoutes     = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "errors"
@@ -603,7 +603,7 @@ static void do_proc_net_snmp6(int update_every) {
         static RRDDIM *rd_received = NULL,
                       *rd_sent     = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "udppackets"
@@ -645,7 +645,7 @@ static void do_proc_net_snmp6(int update_every) {
                       *rd_InCsumErrors = NULL,
                       *rd_IgnoredMulti = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "udperrors"
@@ -687,7 +687,7 @@ static void do_proc_net_snmp6(int update_every) {
         static RRDDIM *rd_received = NULL,
                       *rd_sent     = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "udplitepackets"
@@ -728,7 +728,7 @@ static void do_proc_net_snmp6(int update_every) {
                       *rd_NoPorts      = NULL,
                       *rd_InCsumErrors = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "udpliteerrors"
@@ -769,7 +769,7 @@ static void do_proc_net_snmp6(int update_every) {
         static RRDDIM *rd_Ip6InMcastOctets  = NULL,
                       *rd_Ip6OutMcastOctets = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "mcast"
@@ -804,7 +804,7 @@ static void do_proc_net_snmp6(int update_every) {
         static RRDDIM *rd_Ip6InBcastOctets  = NULL,
                       *rd_Ip6OutBcastOctets = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "bcast"
@@ -839,7 +839,7 @@ static void do_proc_net_snmp6(int update_every) {
         static RRDDIM *rd_Ip6InMcastPkts  = NULL,
                       *rd_Ip6OutMcastPkts = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "mcastpkts"
@@ -874,7 +874,7 @@ static void do_proc_net_snmp6(int update_every) {
         static RRDDIM *rd_Icmp6InMsgs  = NULL,
                       *rd_Icmp6OutMsgs = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "icmp"
@@ -908,7 +908,7 @@ static void do_proc_net_snmp6(int update_every) {
         static RRDDIM *rd_Icmp6InRedirects  = NULL,
                       *rd_Icmp6OutRedirects = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "icmpredir"
@@ -960,7 +960,7 @@ static void do_proc_net_snmp6(int update_every) {
                       *rd_OutTimeExcds    = NULL,
                       *rd_OutParmProblems = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "icmperrors"
@@ -1016,7 +1016,7 @@ static void do_proc_net_snmp6(int update_every) {
                       *rd_InEchoReplies  = NULL,
                       *rd_OutEchoReplies = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "icmpechos"
@@ -1062,7 +1062,7 @@ static void do_proc_net_snmp6(int update_every) {
                       *rd_InReductions  = NULL,
                       *rd_OutReductions = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "groupmemb"
@@ -1107,7 +1107,7 @@ static void do_proc_net_snmp6(int update_every) {
                       *rd_InAdvertisements  = NULL,
                       *rd_OutAdvertisements = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "icmprouter"
@@ -1149,7 +1149,7 @@ static void do_proc_net_snmp6(int update_every) {
                       *rd_InAdvertisements  = NULL,
                       *rd_OutAdvertisements = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "icmpneighbor"
@@ -1187,7 +1187,7 @@ static void do_proc_net_snmp6(int update_every) {
         static RRDDIM *rd_InMLDv2Reports  = NULL,
                       *rd_OutMLDv2Reports = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "icmpmldv2"
@@ -1237,7 +1237,7 @@ static void do_proc_net_snmp6(int update_every) {
                       *rd_OutType135 = NULL,
                       *rd_OutType143 = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP6
                     , "icmptypes"
@@ -1285,7 +1285,7 @@ static void do_proc_net_snmp6(int update_every) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_InNoECTPkts = NULL, *rd_InECT1Pkts = NULL, *rd_InECT0Pkts = NULL, *rd_InCEPkts = NULL;
 
-        if (unlikely(!st)) {
+        if (!st) {
             st = rrdset_create_localhost(
                 RRD_TYPE_NET_SNMP6,
                 "ect",
@@ -1421,7 +1421,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
     // prepare for /proc/net/netstat parsing
 
-    if(unlikely(!arl_ipext)) {
+    if(!arl_ipext) {
         hash_ipext = simple_hash("IpExt");
         hash_tcpext = simple_hash("TcpExt");
 
@@ -1537,7 +1537,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
     // prepare for /proc/net/snmp parsing
 
-    if(unlikely(!arl_ip)) {
+    if(!arl_ip) {
         do_ip_packets       = config_get_boolean_ondemand("plugin:proc:/proc/net/snmp", "ipv4 packets", CONFIG_BOOLEAN_AUTO);
         do_ip_fragsout      = config_get_boolean_ondemand("plugin:proc:/proc/net/snmp", "ipv4 fragments sent", CONFIG_BOOLEAN_AUTO);
         do_ip_fragsin       = config_get_boolean_ondemand("plugin:proc:/proc/net/snmp", "ipv4 fragments assembly", CONFIG_BOOLEAN_AUTO);
@@ -1654,15 +1654,15 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
     // parse /proc/net/netstat
 
-    if(unlikely(!ff_netstat)) {
+    if(!ff_netstat) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/net/netstat");
         ff_netstat = procfile_open(config_get(CONFIG_SECTION_PLUGIN_PROC_NETSTAT, "filename to monitor", filename), " \t:", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff_netstat)) return 1;
+        if(!ff_netstat) return 1;
     }
 
     ff_netstat = procfile_readall(ff_netstat);
-    if(unlikely(!ff_netstat)) return 0; // we return 0, so that we will retry to open it next time
+    if(!ff_netstat) return 0; // we return 0, so that we will retry to open it next time
 
     lines = procfile_lines(ff_netstat);
 
@@ -1673,11 +1673,11 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         char *key = procfile_lineword(ff_netstat, l, 0);
         uint32_t hash = simple_hash(key);
 
-        if(unlikely(hash == hash_ipext && strcmp(key, "IpExt") == 0)) {
+        if(hash == hash_ipext && strcmp(key, "IpExt") == 0) {
             size_t h = l++;
 
             words = procfile_linewords(ff_netstat, l);
-            if(unlikely(words < 2)) {
+            if(words < 2) {
                 collector_error("Cannot read /proc/net/netstat IpExt line. Expected 2+ params, read %zu.", words);
                 continue;
             }
@@ -1685,11 +1685,11 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
             parse_line_pair(ff_netstat, arl_ipext, h, l);
 
         }
-        else if(unlikely(hash == hash_tcpext && strcmp(key, "TcpExt") == 0)) {
+        else if(hash == hash_tcpext && strcmp(key, "TcpExt") == 0) {
             size_t h = l++;
 
             words = procfile_linewords(ff_netstat, l);
-            if(unlikely(words < 2)) {
+            if(words < 2) {
                 collector_error("Cannot read /proc/net/netstat TcpExt line. Expected 2+ params, read %zu.", words);
                 continue;
             }
@@ -1700,15 +1700,15 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
     // parse /proc/net/snmp
 
-    if(unlikely(!ff_snmp)) {
+    if(!ff_snmp) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/net/snmp");
         ff_snmp = procfile_open(config_get("plugin:proc:/proc/net/snmp", "filename to monitor", filename), " \t:", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff_snmp)) return 1;
+        if(!ff_snmp) return 1;
     }
 
     ff_snmp = procfile_readall(ff_snmp);
-    if(unlikely(!ff_snmp)) return 0; // we return 0, so that we will retry to open it next time
+    if(!ff_snmp) return 0; // we return 0, so that we will retry to open it next time
 
     lines = procfile_lines(ff_snmp);
     size_t w;
@@ -1717,7 +1717,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         char *key = procfile_lineword(ff_snmp, l, 0);
         uint32_t hash = simple_hash(key);
 
-        if(unlikely(hash == hash_ip && strcmp(key, "Ip") == 0)) {
+        if(hash == hash_ip && strcmp(key, "Ip") == 0) {
             size_t h = l++;
 
             if(strcmp(procfile_lineword(ff_snmp, l, 0), "Ip") != 0) {
@@ -1733,11 +1733,11 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             arl_begin(arl_ip);
             for(w = 1; w < words ; w++) {
-                if (unlikely(arl_check(arl_ip, procfile_lineword(ff_snmp, h, w), procfile_lineword(ff_snmp, l, w)) != 0))
+                if (arl_check(arl_ip, procfile_lineword(ff_snmp, h, w), procfile_lineword(ff_snmp, l, w)) != 0)
                     break;
             }
         }
-        else if(unlikely(hash == hash_icmp && strcmp(key, "Icmp") == 0)) {
+        else if(hash == hash_icmp && strcmp(key, "Icmp") == 0) {
             size_t h = l++;
 
             if(strcmp(procfile_lineword(ff_snmp, l, 0), "Icmp") != 0) {
@@ -1753,11 +1753,11 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             arl_begin(arl_icmp);
             for(w = 1; w < words ; w++) {
-                if (unlikely(arl_check(arl_icmp, procfile_lineword(ff_snmp, h, w), procfile_lineword(ff_snmp, l, w)) != 0))
+                if (arl_check(arl_icmp, procfile_lineword(ff_snmp, h, w), procfile_lineword(ff_snmp, l, w)) != 0)
                     break;
             }
         }
-        else if(unlikely(hash == hash_icmpmsg && strcmp(key, "IcmpMsg") == 0)) {
+        else if(hash == hash_icmpmsg && strcmp(key, "IcmpMsg") == 0) {
             size_t h = l++;
 
             if(strcmp(procfile_lineword(ff_snmp, l, 0), "IcmpMsg") != 0) {
@@ -1773,11 +1773,11 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             arl_begin(arl_icmpmsg);
             for(w = 1; w < words ; w++) {
-                if (unlikely(arl_check(arl_icmpmsg, procfile_lineword(ff_snmp, h, w), procfile_lineword(ff_snmp, l, w)) != 0))
+                if (arl_check(arl_icmpmsg, procfile_lineword(ff_snmp, h, w), procfile_lineword(ff_snmp, l, w)) != 0)
                     break;
             }
         }
-        else if(unlikely(hash == hash_tcp && strcmp(key, "Tcp") == 0)) {
+        else if(hash == hash_tcp && strcmp(key, "Tcp") == 0) {
             size_t h = l++;
 
             if(strcmp(procfile_lineword(ff_snmp, l, 0), "Tcp") != 0) {
@@ -1793,11 +1793,11 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             arl_begin(arl_tcp);
             for(w = 1; w < words ; w++) {
-                if (unlikely(arl_check(arl_tcp, procfile_lineword(ff_snmp, h, w), procfile_lineword(ff_snmp, l, w)) != 0))
+                if (arl_check(arl_tcp, procfile_lineword(ff_snmp, h, w), procfile_lineword(ff_snmp, l, w)) != 0)
                     break;
             }
         }
-        else if(unlikely(hash == hash_udp && strcmp(key, "Udp") == 0)) {
+        else if(hash == hash_udp && strcmp(key, "Udp") == 0) {
             size_t h = l++;
 
             if(strcmp(procfile_lineword(ff_snmp, l, 0), "Udp") != 0) {
@@ -1813,11 +1813,11 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             arl_begin(arl_udp);
             for(w = 1; w < words ; w++) {
-                if (unlikely(arl_check(arl_udp, procfile_lineword(ff_snmp, h, w), procfile_lineword(ff_snmp, l, w)) != 0))
+                if (arl_check(arl_udp, procfile_lineword(ff_snmp, h, w), procfile_lineword(ff_snmp, l, w)) != 0)
                     break;
             }
         }
-        else if(unlikely(hash == hash_udplite && strcmp(key, "UdpLite") == 0)) {
+        else if(hash == hash_udplite && strcmp(key, "UdpLite") == 0) {
             size_t h = l++;
 
             if(strcmp(procfile_lineword(ff_snmp, l, 0), "UdpLite") != 0) {
@@ -1833,7 +1833,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
 
             arl_begin(arl_udplite);
             for(w = 1; w < words ; w++) {
-                if (unlikely(arl_check(arl_udplite, procfile_lineword(ff_snmp, h, w), procfile_lineword(ff_snmp, l, w)) != 0))
+                if (arl_check(arl_udplite, procfile_lineword(ff_snmp, h, w), procfile_lineword(ff_snmp, l, w)) != 0)
                     break;
             }
         }
@@ -1849,7 +1849,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         static RRDSET *st_system_ip = NULL;
         static RRDDIM *rd_in = NULL, *rd_out = NULL;
 
-        if(unlikely(!st_system_ip)) {
+        if(!st_system_ip) {
             st_system_ip = rrdset_create_localhost(
                     "system"
                     , RRD_TYPE_NET_NETSTAT
@@ -1882,7 +1882,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         static RRDSET *st_ip_inerrors = NULL;
         static RRDDIM *rd_noroutes = NULL, *rd_truncated = NULL, *rd_checksum = NULL;
 
-        if(unlikely(!st_ip_inerrors)) {
+        if(!st_ip_inerrors) {
             st_ip_inerrors = rrdset_create_localhost(
                     RRD_TYPE_NET_NETSTAT
                     , "inerrors"
@@ -1919,7 +1919,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         static RRDSET *st_ip_mcast = NULL;
         static RRDDIM *rd_in = NULL, *rd_out = NULL;
 
-        if(unlikely(!st_ip_mcast)) {
+        if(!st_ip_mcast) {
             st_ip_mcast = rrdset_create_localhost(
                     RRD_TYPE_NET_NETSTAT
                     , "mcast"
@@ -1958,7 +1958,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         static RRDSET *st_ip_bcast = NULL;
         static RRDDIM *rd_in = NULL, *rd_out = NULL;
 
-        if(unlikely(!st_ip_bcast)) {
+        if(!st_ip_bcast) {
             st_ip_bcast = rrdset_create_localhost(
                     RRD_TYPE_NET_NETSTAT
                     , "bcast"
@@ -1997,7 +1997,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         static RRDSET *st_ip_mcastpkts = NULL;
         static RRDDIM *rd_in = NULL, *rd_out = NULL;
 
-        if(unlikely(!st_ip_mcastpkts)) {
+        if(!st_ip_mcastpkts) {
             st_ip_mcastpkts = rrdset_create_localhost(
                     RRD_TYPE_NET_NETSTAT
                     , "mcastpkts"
@@ -2033,7 +2033,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         static RRDSET *st_ip_bcastpkts = NULL;
         static RRDDIM *rd_in = NULL, *rd_out = NULL;
 
-        if(unlikely(!st_ip_bcastpkts)) {
+        if(!st_ip_bcastpkts) {
             st_ip_bcastpkts = rrdset_create_localhost(
                     RRD_TYPE_NET_NETSTAT
                     , "bcastpkts"
@@ -2071,7 +2071,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         static RRDSET *st_ecnpkts = NULL;
         static RRDDIM *rd_cep = NULL, *rd_noectp = NULL, *rd_ectp0 = NULL, *rd_ectp1 = NULL;
 
-        if(unlikely(!st_ecnpkts)) {
+        if(!st_ecnpkts) {
             st_ecnpkts = rrdset_create_localhost(
                     RRD_TYPE_NET_NETSTAT
                     , "ecnpkts"
@@ -2112,7 +2112,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         static RRDSET *st_tcpmemorypressures = NULL;
         static RRDDIM *rd_pressures = NULL;
 
-        if(unlikely(!st_tcpmemorypressures)) {
+        if(!st_tcpmemorypressures) {
             st_tcpmemorypressures = rrdset_create_localhost(
                     RRD_TYPE_NET_NETSTAT
                     , "tcpmemorypressures"
@@ -2148,7 +2148,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         static RRDSET *st_tcpconnaborts = NULL;
         static RRDDIM *rd_baddata = NULL, *rd_userclosed = NULL, *rd_nomemory = NULL, *rd_timeout = NULL, *rd_linger = NULL, *rd_failed = NULL;
 
-        if(unlikely(!st_tcpconnaborts)) {
+        if(!st_tcpconnaborts) {
             st_tcpconnaborts = rrdset_create_localhost(
                     RRD_TYPE_NET_NETSTAT
                     , "tcpconnaborts"
@@ -2192,7 +2192,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         static RRDSET *st_tcpreorders = NULL;
         static RRDDIM *rd_timestamp = NULL, *rd_sack = NULL, *rd_fack = NULL, *rd_reno = NULL;
 
-        if(unlikely(!st_tcpreorders)) {
+        if(!st_tcpreorders) {
             st_tcpreorders = rrdset_create_localhost(
                     RRD_TYPE_NET_NETSTAT
                     , "tcpreorders"
@@ -2233,7 +2233,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         static RRDSET *st_ip_tcpofo = NULL;
         static RRDDIM *rd_inqueue = NULL, *rd_dropped = NULL, *rd_merged = NULL, *rd_pruned = NULL;
 
-        if(unlikely(!st_ip_tcpofo)) {
+        if(!st_ip_tcpofo) {
 
             st_ip_tcpofo = rrdset_create_localhost(
                     RRD_TYPE_NET_NETSTAT
@@ -2273,7 +2273,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         static RRDSET *st_syncookies = NULL;
         static RRDDIM *rd_received = NULL, *rd_sent = NULL, *rd_failed = NULL;
 
-        if(unlikely(!st_syncookies)) {
+        if(!st_syncookies) {
 
             st_syncookies = rrdset_create_localhost(
                     RRD_TYPE_NET_NETSTAT
@@ -2312,7 +2312,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
                 *rd_TCPReqQFullDrop = NULL,
                 *rd_TCPReqQFullDoCookies = NULL;
 
-        if(unlikely(!st_syn_queue)) {
+        if(!st_syn_queue) {
 
             st_syn_queue = rrdset_create_localhost(
                     RRD_TYPE_NET_NETSTAT
@@ -2348,7 +2348,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         static RRDDIM *rd_overflows = NULL,
             *rd_drops = NULL;
 
-        if(unlikely(!st_accept_queue)) {
+        if(!st_accept_queue) {
 
             st_accept_queue = rrdset_create_localhost(
                     RRD_TYPE_NET_NETSTAT
@@ -2390,7 +2390,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
                         *rd_ForwDatagrams = NULL,
                         *rd_InDelivers = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP
                     , "packets"
@@ -2431,7 +2431,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
                         *rd_FragFails = NULL,
                         *rd_FragCreates = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP
                     , "fragsout"
@@ -2471,7 +2471,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
                         *rd_ReasmFails = NULL,
                         *rd_ReasmReqds = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP
                     , "fragsin"
@@ -2517,7 +2517,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
                         *rd_InAddrErrors = NULL,
                         *rd_InUnknownProtos = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP
                     , "errors"
@@ -2569,7 +2569,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
             static RRDDIM *rd_InMsgs = NULL,
                             *rd_OutMsgs = NULL;
 
-            if(unlikely(!st_packets)) {
+            if(!st_packets) {
                 st_packets = rrdset_create_localhost(
                         RRD_TYPE_NET_SNMP
                         , "icmp"
@@ -2600,7 +2600,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
                             *rd_OutErrors = NULL,
                             *rd_InCsumErrors = NULL;
 
-            if(unlikely(!st_errors)) {
+            if(!st_errors) {
                 st_errors = rrdset_create_localhost(
                         RRD_TYPE_NET_SNMP
                         , "icmp_errors"
@@ -2676,7 +2676,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
                         *rd_InTimestampReps  = NULL,
                         *rd_OutTimestampReps = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP
                     , "icmpmsg"
@@ -2752,7 +2752,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_CurrEstab = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP
                     , "tcpsock"
@@ -2785,7 +2785,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         static RRDDIM *rd_InSegs = NULL,
                         *rd_OutSegs = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP
                     , "tcppackets"
@@ -2824,7 +2824,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
                         *rd_InCsumErrors = NULL,
                         *rd_RetransSegs = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP
                     , "tcperrors"
@@ -2862,7 +2862,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         static RRDDIM *rd_ActiveOpens = NULL,
                         *rd_PassiveOpens = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP
                     , "tcpopens"
@@ -2901,7 +2901,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
                         *rd_AttemptFails = NULL,
                         *rd_TCPSynRetrans = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP
                     , "tcphandshake"
@@ -2944,7 +2944,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
         static RRDDIM *rd_InDatagrams = NULL,
                         *rd_OutDatagrams = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP
                     , "udppackets"
@@ -2989,7 +2989,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
                         *rd_InCsumErrors = NULL,
                         *rd_IgnoredMulti = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_SNMP
                     , "udperrors"
@@ -3042,7 +3042,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
             static RRDDIM *rd_InDatagrams = NULL,
                             *rd_OutDatagrams = NULL;
 
-            if(unlikely(!st)) {
+            if(!st) {
                 st = rrdset_create_localhost(
                         RRD_TYPE_NET_SNMP
                         , "udplite"
@@ -3076,7 +3076,7 @@ int do_proc_net_netstat(int update_every, usec_t dt) {
                             *rd_InCsumErrors = NULL,
                             *rd_IgnoredMulti = NULL;
 
-            if(unlikely(!st)) {
+            if(!st) {
                 st = rrdset_create_localhost(
                         RRD_TYPE_NET_SNMP
                         , "udplite_errors"

--- a/collectors/proc.plugin/proc_net_rpc_nfs.c
+++ b/collectors/proc.plugin/proc_net_rpc_nfs.c
@@ -280,7 +280,7 @@ int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
         static RRDDIM *rd_udp = NULL,
                       *rd_tcp = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "nfs"
                     , "net"
@@ -317,7 +317,7 @@ int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
                       *rd_retransmits  = NULL,
                       *rd_auth_refresh = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "nfs"
                     , "rpc"
@@ -347,7 +347,7 @@ int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
 
     if(do_proc2 == 2) {
         static RRDSET *st = NULL;
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "nfs"
                     , "proc2"
@@ -366,7 +366,7 @@ int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
 
         size_t i;
         for(i = 0; nfs_proc2_values[i].present ; i++) {
-            if(unlikely(!nfs_proc2_values[i].rd))
+            if(!nfs_proc2_values[i].rd)
                 nfs_proc2_values[i].rd = rrddim_add(st, nfs_proc2_values[i].name, NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st, nfs_proc2_values[i].rd, nfs_proc2_values[i].value);
@@ -377,7 +377,7 @@ int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
 
     if(do_proc3 == 2) {
         static RRDSET *st = NULL;
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "nfs"
                     , "proc3"
@@ -396,7 +396,7 @@ int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
 
         size_t i;
         for(i = 0; nfs_proc3_values[i].present ; i++) {
-            if(unlikely(!nfs_proc3_values[i].rd))
+            if(!nfs_proc3_values[i].rd)
                 nfs_proc3_values[i].rd = rrddim_add(st, nfs_proc3_values[i].name, NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st, nfs_proc3_values[i].rd, nfs_proc3_values[i].value);
@@ -407,7 +407,7 @@ int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
 
     if(do_proc4 == 2) {
         static RRDSET *st = NULL;
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "nfs"
                     , "proc4"
@@ -426,7 +426,7 @@ int do_proc_net_rpc_nfs(int update_every, usec_t dt) {
 
         size_t i;
         for(i = 0; nfs_proc4_values[i].present ; i++) {
-            if(unlikely(!nfs_proc4_values[i].rd))
+            if(!nfs_proc4_values[i].rd)
                 nfs_proc4_values[i].rd = rrddim_add(st, nfs_proc4_values[i].name, NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st, nfs_proc4_values[i].rd, nfs_proc4_values[i].value);

--- a/collectors/proc.plugin/proc_net_rpc_nfsd.c
+++ b/collectors/proc.plugin/proc_net_rpc_nfsd.c
@@ -228,17 +228,17 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
     static int do_rc = -1, do_fh = -1, do_io = -1, do_th = -1, do_net = -1, do_rpc = -1, do_proc2 = -1, do_proc3 = -1, do_proc4 = -1, do_proc4ops = -1;
     static int proc2_warning = 0, proc3_warning = 0, proc4_warning = 0, proc4ops_warning = 0;
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/net/rpc/nfsd");
         ff = procfile_open(config_get("plugin:proc:/proc/net/rpc/nfsd", "filename to monitor", filename), " \t", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff)) return 1;
+        if(!ff) return 1;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff)) return 0; // we return 0, so that we will retry to open it next time
+    if(!ff) return 0; // we return 0, so that we will retry to open it next time
 
-    if(unlikely(do_rc == -1)) {
+    if(do_rc == -1) {
         do_rc = config_get_boolean("plugin:proc:/proc/net/rpc/nfsd", "read cache", 1);
         do_fh = config_get_boolean("plugin:proc:/proc/net/rpc/nfsd", "file handles", 1);
         do_io = config_get_boolean("plugin:proc:/proc/net/rpc/nfsd", "I/O", 1);
@@ -276,12 +276,12 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
 
     for(l = 0; l < lines ;l++) {
         size_t words = procfile_linewords(ff, l);
-        if(unlikely(!words)) continue;
+        if(!words) continue;
 
         type = procfile_lineword(ff, l, 0);
 
         if(do_rc == 1 && strcmp(type, "rc") == 0) {
-            if(unlikely(words < 4)) {
+            if(words < 4) {
                 collector_error("%s line of /proc/net/rpc/nfsd has %zu words, expected %d", type, words, 4);
                 continue;
             }
@@ -295,7 +295,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
             else do_rc = 2;
         }
         else if(do_fh == 1 && strcmp(type, "fh") == 0) {
-            if(unlikely(words < 6)) {
+            if(words < 6) {
                 collector_error("%s line of /proc/net/rpc/nfsd has %zu words, expected %d", type, words, 6);
                 continue;
             }
@@ -308,7 +308,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
             else do_fh = 2;
         }
         else if(do_io == 1 && strcmp(type, "io") == 0) {
-            if(unlikely(words < 3)) {
+            if(words < 3) {
                 collector_error("%s line of /proc/net/rpc/nfsd has %zu words, expected %d", type, words, 3);
                 continue;
             }
@@ -321,7 +321,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
             else do_io = 2;
         }
         else if(do_th == 1 && strcmp(type, "th") == 0) {
-            if(unlikely(words < 13)) {
+            if(words < 13) {
                 collector_error("%s line of /proc/net/rpc/nfsd has %zu words, expected %d", type, words, 13);
                 continue;
             }
@@ -334,7 +334,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
             do_th = 2;
         }
         else if(do_net == 1 && strcmp(type, "net") == 0) {
-            if(unlikely(words < 5)) {
+            if(words < 5) {
                 collector_error("%s line of /proc/net/rpc/nfsd has %zu words, expected %d", type, words, 5);
                 continue;
             }
@@ -349,7 +349,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
             else do_net = 2;
         }
         else if(do_rpc == 1 && strcmp(type, "rpc") == 0) {
-            if(unlikely(words < 6)) {
+            if(words < 6) {
                 collector_error("%s line of /proc/net/rpc/nfsd has %zu words, expected %d", type, words, 6);
                 continue;
             }
@@ -455,7 +455,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
                       *rd_misses  = NULL,
                       *rd_nocache = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "nfsd"
                     , "readcache"
@@ -486,7 +486,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_stale                 = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "nfsd"
                     , "filehandles"
@@ -515,7 +515,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
         static RRDDIM *rd_read  = NULL,
                       *rd_write = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "nfsd"
                     , "io"
@@ -544,7 +544,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_threads = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "nfsd"
                     , "threads"
@@ -572,7 +572,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
         static RRDDIM *rd_udp = NULL,
                       *rd_tcp = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "nfsd"
                     , "net"
@@ -608,7 +608,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
                       *rd_bad_format = NULL,
                       *rd_bad_auth   = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "nfsd"
                     , "rpc"
@@ -641,7 +641,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
 
     if(do_proc2 == 2) {
         static RRDSET *st = NULL;
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "nfsd"
                     , "proc2"
@@ -660,7 +660,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
 
         size_t i;
         for(i = 0; nfsd_proc2_values[i].present ; i++) {
-            if(unlikely(!nfsd_proc2_values[i].rd))
+            if(!nfsd_proc2_values[i].rd)
                 nfsd_proc2_values[i].rd = rrddim_add(st, nfsd_proc2_values[i].name, NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st, nfsd_proc2_values[i].rd, nfsd_proc2_values[i].value);
@@ -671,7 +671,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
 
     if(do_proc3 == 2) {
         static RRDSET *st = NULL;
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "nfsd"
                     , "proc3"
@@ -690,7 +690,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
 
         size_t i;
         for(i = 0; nfsd_proc3_values[i].present ; i++) {
-            if(unlikely(!nfsd_proc3_values[i].rd))
+            if(!nfsd_proc3_values[i].rd)
                 nfsd_proc3_values[i].rd = rrddim_add(st, nfsd_proc3_values[i].name, NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st, nfsd_proc3_values[i].rd, nfsd_proc3_values[i].value);
@@ -701,7 +701,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
 
     if(do_proc4 == 2) {
         static RRDSET *st = NULL;
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "nfsd"
                     , "proc4"
@@ -720,7 +720,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
 
         size_t i;
         for(i = 0; nfsd_proc4_values[i].present ; i++) {
-            if(unlikely(!nfsd_proc4_values[i].rd))
+            if(!nfsd_proc4_values[i].rd)
                 nfsd_proc4_values[i].rd = rrddim_add(st, nfsd_proc4_values[i].name, NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st, nfsd_proc4_values[i].rd, nfsd_proc4_values[i].value);
@@ -731,7 +731,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
 
     if(do_proc4ops == 2) {
         static RRDSET *st = NULL;
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "nfsd"
                     , "proc4ops"
@@ -750,7 +750,7 @@ int do_proc_net_rpc_nfsd(int update_every, usec_t dt) {
 
         size_t i;
         for(i = 0; nfsd4_ops_values[i].present ; i++) {
-            if(unlikely(!nfsd4_ops_values[i].rd))
+            if(!nfsd4_ops_values[i].rd)
                 nfsd4_ops_values[i].rd = rrddim_add(st, nfsd4_ops_values[i].name, NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
             rrddim_set_by_pointer(st, nfsd4_ops_values[i].rd, nfsd4_ops_values[i].value);

--- a/collectors/proc.plugin/proc_net_sctp_snmp.c
+++ b/collectors/proc.plugin/proc_net_sctp_snmp.c
@@ -51,7 +51,7 @@ int do_proc_net_sctp_snmp(int update_every, usec_t dt) {
     static unsigned long long SctpInPktDiscards           = 0ULL;
     static unsigned long long SctpInDataChunkDiscards     = 0ULL;
 
-    if(unlikely(!arl_base)) {
+    if(!arl_base) {
         do_associations = config_get_boolean_ondemand("plugin:proc:/proc/net/sctp/snmp", "established associations", CONFIG_BOOLEAN_AUTO);
         do_transitions = config_get_boolean_ondemand("plugin:proc:/proc/net/sctp/snmp", "association transitions", CONFIG_BOOLEAN_AUTO);
         do_fragmentation = config_get_boolean_ondemand("plugin:proc:/proc/net/sctp/snmp", "fragmentation", CONFIG_BOOLEAN_AUTO);
@@ -94,16 +94,16 @@ int do_proc_net_sctp_snmp(int update_every, usec_t dt) {
         arl_expect(arl_base, "SctpInDataChunkDiscards", &SctpInDataChunkDiscards);
     }
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/net/sctp/snmp");
         ff = procfile_open(config_get("plugin:proc:/proc/net/sctp/snmp", "filename to monitor", filename), " \t:", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff))
+        if(!ff)
             return 1;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff))
+    if(!ff)
         return 0; // we return 0, so that we will retry to open it next time
 
     size_t lines = procfile_lines(ff), l;
@@ -112,14 +112,14 @@ int do_proc_net_sctp_snmp(int update_every, usec_t dt) {
 
     for(l = 0; l < lines ;l++) {
         size_t words = procfile_linewords(ff, l);
-        if(unlikely(words < 2)) {
-            if(unlikely(words)) collector_error("Cannot read /proc/net/sctp/snmp line %zu. Expected 2 params, read %zu.", l, words);
+        if(words < 2) {
+            if(words) collector_error("Cannot read /proc/net/sctp/snmp line %zu. Expected 2 params, read %zu.", l, words);
             continue;
         }
 
-        if(unlikely(arl_check(arl_base,
+        if(arl_check(arl_base,
                 procfile_lineword(ff, l, 0),
-                procfile_lineword(ff, l, 1)))) break;
+                procfile_lineword(ff, l, 1))) break;
     }
 
     // --------------------------------------------------------------------
@@ -130,7 +130,7 @@ int do_proc_net_sctp_snmp(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_established = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "sctp"
                     , "established"
@@ -168,7 +168,7 @@ int do_proc_net_sctp_snmp(int update_every, usec_t dt) {
                       *rd_aborted = NULL,
                       *rd_shutdown = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "sctp"
                     , "transitions"
@@ -208,7 +208,7 @@ int do_proc_net_sctp_snmp(int update_every, usec_t dt) {
         static RRDDIM *rd_received = NULL,
                       *rd_sent = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "sctp"
                     , "packets"
@@ -245,7 +245,7 @@ int do_proc_net_sctp_snmp(int update_every, usec_t dt) {
         static RRDDIM *rd_invalid = NULL,
                       *rd_csum = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "sctp"
                     , "packet_errors"
@@ -283,7 +283,7 @@ int do_proc_net_sctp_snmp(int update_every, usec_t dt) {
         static RRDDIM *rd_fragmented = NULL,
                       *rd_reassembled = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "sctp"
                     , "fragmentation"
@@ -328,7 +328,7 @@ int do_proc_net_sctp_snmp(int update_every, usec_t dt) {
                 *rd_OutOrder   = NULL,
                 *rd_OutUnorder = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "sctp"
                     , "chunks"

--- a/collectors/proc.plugin/proc_net_sockstat.c
+++ b/collectors/proc.plugin/proc_net_sockstat.c
@@ -31,13 +31,13 @@ static int read_tcp_mem(void) {
                   *tcp_mem_pressure_threshold = NULL,
                   *tcp_mem_high_threshold = NULL;
 
-    if(unlikely(!tcp_mem_low_threshold)) {
+    if(!tcp_mem_low_threshold) {
         tcp_mem_low_threshold      = rrdvar_custom_host_variable_add_and_acquire(localhost, "tcp_mem_low");
         tcp_mem_pressure_threshold = rrdvar_custom_host_variable_add_and_acquire(localhost, "tcp_mem_pressure");
         tcp_mem_high_threshold     = rrdvar_custom_host_variable_add_and_acquire(localhost, "tcp_mem_high");
     }
 
-    if(unlikely(!filename)) {
+    if(!filename) {
         char buffer[FILENAME_MAX + 1];
         snprintfz(buffer, FILENAME_MAX, "%s/proc/sys/net/ipv4/tcp_mem", netdata_configured_host_prefix);
         filename = strdupz(buffer);
@@ -71,7 +71,7 @@ static kernel_uint_t read_tcp_max_orphans(void) {
     static char *filename = NULL;
     static const RRDVAR_ACQUIRED *tcp_max_orphans_var = NULL;
 
-    if(unlikely(!filename)) {
+    if(!filename) {
         char buffer[FILENAME_MAX + 1];
         snprintfz(buffer, FILENAME_MAX, "%s/proc/sys/net/ipv4/tcp_max_orphans", netdata_configured_host_prefix);
         filename = strdupz(buffer);
@@ -80,7 +80,7 @@ static kernel_uint_t read_tcp_max_orphans(void) {
     unsigned long long tcp_max_orphans = 0;
     if(read_single_number_file(filename, &tcp_max_orphans) == 0) {
 
-        if(unlikely(!tcp_max_orphans_var))
+        if(!tcp_max_orphans_var)
             tcp_max_orphans_var = rrdvar_custom_host_variable_add_and_acquire(localhost, "tcp_max_orphans");
 
         rrdvar_custom_host_variable_set(localhost, tcp_max_orphans_var, tcp_max_orphans);
@@ -117,7 +117,7 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
     static uint32_t hashes[7] = { 0 };
     static ARL_BASE *bases[7] = { NULL };
 
-    if(unlikely(!arl_sockets)) {
+    if(!arl_sockets) {
         do_sockets         = config_get_boolean_ondemand("plugin:proc:/proc/net/sockstat", "ipv4 sockets", CONFIG_BOOLEAN_AUTO);
         do_tcp_sockets     = config_get_boolean_ondemand("plugin:proc:/proc/net/sockstat", "ipv4 TCP sockets", CONFIG_BOOLEAN_AUTO);
         do_tcp_mem         = config_get_boolean_ondemand("plugin:proc:/proc/net/sockstat", "ipv4 TCP memory", CONFIG_BOOLEAN_AUTO);
@@ -172,21 +172,21 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
     }
 
     update_constants_count += update_every;
-    if(unlikely(update_constants_count > update_constants_every)) {
+    if(update_constants_count > update_constants_every) {
         read_tcp_max_orphans();
         read_tcp_mem();
         update_constants_count = 0;
     }
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/net/sockstat");
         ff = procfile_open(config_get("plugin:proc:/proc/net/sockstat", "filename to monitor", filename), " \t:", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff)) return 1;
+        if(!ff) return 1;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff)) return 0; // we return 0, so that we will retry to open it next time
+    if(!ff) return 0; // we return 0, so that we will retry to open it next time
 
     size_t lines = procfile_lines(ff), l;
 
@@ -197,7 +197,7 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
 
         int k;
         for(k = 0; keys[k] ; k++) {
-            if(unlikely(hash == hashes[k] && strcmp(key, keys[k]) == 0)) {
+            if(hash == hashes[k] && strcmp(key, keys[k]) == 0) {
                 // fprintf(stderr, "KEY: '%s', l=%zu, w=1, words=%zu\n", key, l, words);
                 ARL_BASE *arl = bases[k];
                 arl_begin(arl);
@@ -207,7 +207,7 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
                     char *name  = procfile_lineword(ff, l, w); w++;
                     char *value = procfile_lineword(ff, l, w); w++;
                     // fprintf(stderr, " > NAME '%s', VALUE '%s', l=%zu, w=%zu, words=%zu\n", name, value, l, w, words);
-                    if(unlikely(arl_check(arl, name, value) != 0))
+                    if(arl_check(arl, name, value) != 0)
                         break;
                 }
 
@@ -226,7 +226,7 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_used = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "ipv4"
                     , "sockstat_sockets"
@@ -265,7 +265,7 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
                       *rd_timewait = NULL,
                       *rd_alloc = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "ipv4"
                     , "sockstat_tcp_sockets"
@@ -303,7 +303,7 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_mem = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "ipv4"
                     , "sockstat_tcp_mem"
@@ -336,7 +336,7 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_inuse = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "ipv4"
                     , "sockstat_udp_sockets"
@@ -369,7 +369,7 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_mem = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "ipv4"
                     , "sockstat_udp_mem"
@@ -402,7 +402,7 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_inuse = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "ipv4"
                     , "sockstat_udplite_sockets"
@@ -435,7 +435,7 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_inuse = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "ipv4"
                     , "sockstat_raw_sockets"
@@ -468,7 +468,7 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_inuse = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "ipv4"
                     , "sockstat_frag_sockets"
@@ -501,7 +501,7 @@ int do_proc_net_sockstat(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_mem = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "ipv4"
                     , "sockstat_frag_mem"

--- a/collectors/proc.plugin/proc_net_sockstat6.c
+++ b/collectors/proc.plugin/proc_net_sockstat6.c
@@ -35,7 +35,7 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
     static uint32_t hashes[6] = { 0 };
     static ARL_BASE *bases[6] = { NULL };
 
-    if(unlikely(!arl_tcp)) {
+    if(!arl_tcp) {
         do_tcp_sockets     = config_get_boolean_ondemand("plugin:proc:/proc/net/sockstat6", "ipv6 TCP sockets", CONFIG_BOOLEAN_AUTO);
         do_udp_sockets     = config_get_boolean_ondemand("plugin:proc:/proc/net/sockstat6", "ipv6 UDP sockets", CONFIG_BOOLEAN_AUTO);
         do_udplite_sockets = config_get_boolean_ondemand("plugin:proc:/proc/net/sockstat6", "ipv6 UDPLITE sockets", CONFIG_BOOLEAN_AUTO);
@@ -71,15 +71,15 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
         keys[5] = NULL; // terminator
     }
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/net/sockstat6");
         ff = procfile_open(config_get("plugin:proc:/proc/net/sockstat6", "filename to monitor", filename), " \t:", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff)) return 1;
+        if(!ff) return 1;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff)) return 0; // we return 0, so that we will retry to open it next time
+    if(!ff) return 0; // we return 0, so that we will retry to open it next time
 
     size_t lines = procfile_lines(ff), l;
 
@@ -90,7 +90,7 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
 
         int k;
         for(k = 0; keys[k] ; k++) {
-            if(unlikely(hash == hashes[k] && strcmp(key, keys[k]) == 0)) {
+            if(hash == hashes[k] && strcmp(key, keys[k]) == 0) {
                 // fprintf(stderr, "KEY: '%s', l=%zu, w=1, words=%zu\n", key, l, words);
                 ARL_BASE *arl = bases[k];
                 arl_begin(arl);
@@ -100,7 +100,7 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
                     char *name  = procfile_lineword(ff, l, w); w++;
                     char *value = procfile_lineword(ff, l, w); w++;
                     // fprintf(stderr, " > NAME '%s', VALUE '%s', l=%zu, w=%zu, words=%zu\n", name, value, l, w, words);
-                    if(unlikely(arl_check(arl, name, value) != 0))
+                    if(arl_check(arl, name, value) != 0)
                         break;
                 }
 
@@ -119,7 +119,7 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_inuse = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "ipv6"
                     , "sockstat6_tcp_sockets"
@@ -152,7 +152,7 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_inuse = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "ipv6"
                     , "sockstat6_udp_sockets"
@@ -185,7 +185,7 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_inuse = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "ipv6"
                     , "sockstat6_udplite_sockets"
@@ -218,7 +218,7 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_inuse = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "ipv6"
                     , "sockstat6_raw_sockets"
@@ -251,7 +251,7 @@ int do_proc_net_sockstat6(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_inuse = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     "ipv6"
                     , "sockstat6_frag_sockets"

--- a/collectors/proc.plugin/proc_net_softnet_stat.c
+++ b/collectors/proc.plugin/proc_net_softnet_stat.c
@@ -24,30 +24,30 @@ int do_proc_net_softnet_stat(int update_every, usec_t dt) {
     static size_t allocated_lines = 0, allocated_columns = 0;
     static uint32_t *data = NULL;
 
-    if(unlikely(do_per_core == -1)) do_per_core = config_get_boolean("plugin:proc:/proc/net/softnet_stat", "softnet_stat per core", 1);
+    if(do_per_core == -1) do_per_core = config_get_boolean("plugin:proc:/proc/net/softnet_stat", "softnet_stat per core", 1);
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/net/softnet_stat");
         ff = procfile_open(config_get("plugin:proc:/proc/net/softnet_stat", "filename to monitor", filename), " \t", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff)) return 1;
+        if(!ff) return 1;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff)) return 0; // we return 0, so that we will retry to open it next time
+    if(!ff) return 0; // we return 0, so that we will retry to open it next time
 
     size_t lines = procfile_lines(ff), l;
     size_t words = procfile_linewords(ff, 0), w;
 
-    if(unlikely(!lines || !words)) {
+    if(!lines || !words) {
         collector_error("Cannot read /proc/net/softnet_stat, %zu lines and %zu columns reported.", lines, words);
         return 1;
     }
 
-    if(unlikely(lines > 200)) lines = 200;
-    if(unlikely(words > 50)) words = 50;
+    if(lines > 200) lines = 200;
+    if(words > 50) words = 50;
 
-    if(unlikely(!data || lines > allocated_lines || words > allocated_columns)) {
+    if(!data || lines > allocated_lines || words > allocated_columns) {
         freez(data);
         allocated_lines = lines;
         allocated_columns = words;
@@ -60,13 +60,13 @@ int do_proc_net_softnet_stat(int update_every, usec_t dt) {
     // parse the values
     for(l = 0; l < lines ;l++) {
         words = procfile_linewords(ff, l);
-        if(unlikely(!words)) continue;
+        if(!words) continue;
 
-        if(unlikely(words > allocated_columns))
+        if(words > allocated_columns)
             words = allocated_columns;
 
         for(w = 0; w < words ; w++) {
-            if(unlikely(softnet_column_name(w))) {
+            if(softnet_column_name(w)) {
                 uint32_t t = (uint32_t)strtoul(procfile_lineword(ff, l, w), NULL, 16);
                 data[w] += t;
                 data[((l + 1) * allocated_columns) + w] = t;
@@ -74,7 +74,7 @@ int do_proc_net_softnet_stat(int update_every, usec_t dt) {
         }
     }
 
-    if(unlikely(data[(lines * allocated_columns)] == 0))
+    if(data[(lines * allocated_columns)] == 0)
         lines--;
 
     RRDSET *st;
@@ -82,7 +82,7 @@ int do_proc_net_softnet_stat(int update_every, usec_t dt) {
     // --------------------------------------------------------------------
 
     st = rrdset_find_active_bytype_localhost("system", "softnet_stat");
-    if(unlikely(!st)) {
+    if(!st) {
         st = rrdset_create_localhost(
                 "system"
                 , "softnet_stat"
@@ -98,12 +98,12 @@ int do_proc_net_softnet_stat(int update_every, usec_t dt) {
                 , RRDSET_TYPE_LINE
         );
         for(w = 0; w < allocated_columns ;w++)
-            if(unlikely(softnet_column_name(w)))
+            if(softnet_column_name(w))
                 rrddim_add(st, softnet_column_name(w), NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
     }
 
     for(w = 0; w < allocated_columns ;w++)
-        if(unlikely(softnet_column_name(w)))
+        if(softnet_column_name(w))
             rrddim_set(st, softnet_column_name(w), data[w]);
 
     rrdset_done(st);
@@ -114,7 +114,7 @@ int do_proc_net_softnet_stat(int update_every, usec_t dt) {
             snprintfz(id, 50, "cpu%zu_softnet_stat", l);
 
             st = rrdset_find_active_bytype_localhost("cpu", id);
-            if(unlikely(!st)) {
+            if(!st) {
                 char title[100+1];
                 snprintfz(title, 100, "CPU softnet_stat");
 
@@ -133,12 +133,12 @@ int do_proc_net_softnet_stat(int update_every, usec_t dt) {
                         , RRDSET_TYPE_LINE
                 );
                 for(w = 0; w < allocated_columns ;w++)
-                    if(unlikely(softnet_column_name(w)))
+                    if(softnet_column_name(w))
                         rrddim_add(st, softnet_column_name(w), NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
             }
 
             for(w = 0; w < allocated_columns ;w++)
-                if(unlikely(softnet_column_name(w)))
+                if(softnet_column_name(w))
                     rrddim_set(st, softnet_column_name(w), data[((l + 1) * allocated_columns) + w]);
 
             rrdset_done(st);

--- a/collectors/proc.plugin/proc_net_stat_conntrack.c
+++ b/collectors/proc.plugin/proc_net_stat_conntrack.c
@@ -17,7 +17,7 @@ int do_proc_net_stat_conntrack(int update_every, usec_t dt) {
     unsigned long long aentries = 0, asearched = 0, afound = 0, anew = 0, ainvalid = 0, aignore = 0, adelete = 0, adelete_list = 0,
             ainsert = 0, ainsert_failed = 0, adrop = 0, aearly_drop = 0, aicmp_error = 0, aexpect_new = 0, aexpect_create = 0, aexpect_delete = 0, asearch_restart = 0;
 
-    if(unlikely(do_sockets == -1)) {
+    if(do_sockets == -1) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/net/stat/nf_conntrack");
         nf_conntrack_filename = config_get("plugin:proc:/proc/net/stat/nf_conntrack", "filename to monitor", filename);
@@ -53,23 +53,23 @@ int do_proc_net_stat_conntrack(int update_every, usec_t dt) {
         rrdvar_max = rrdvar_custom_host_variable_add_and_acquire(localhost, "netfilter_conntrack_max");
     }
 
-    if(likely(read_full)) {
-        if(unlikely(!ff)) {
+    if(read_full) {
+        if(!ff) {
             ff = procfile_open(nf_conntrack_filename, " \t:", PROCFILE_FLAG_DEFAULT);
-            if(unlikely(!ff))
+            if(!ff)
                 return 0; // we return 0, so that we will retry to open it next time
         }
 
         ff = procfile_readall(ff);
-        if(unlikely(!ff))
+        if(!ff)
             return 0; // we return 0, so that we will retry to open it next time
 
         size_t lines = procfile_lines(ff), l;
 
         for(l = 1; l < lines ;l++) {
             size_t words = procfile_linewords(ff, l);
-            if(unlikely(words < 17)) {
-                if(unlikely(words)) collector_error("Cannot read /proc/net/stat/nf_conntrack line. Expected 17 params, read %zu.", words);
+            if(words < 17) {
+                if(words) collector_error("Cannot read /proc/net/stat/nf_conntrack line. Expected 17 params, read %zu.", words);
                 continue;
             }
 
@@ -93,7 +93,7 @@ int do_proc_net_stat_conntrack(int update_every, usec_t dt) {
             texpect_delete  = strtoull(procfile_lineword(ff, l, 15), NULL, 16);
             tsearch_restart = strtoull(procfile_lineword(ff, l, 16), NULL, 16);
 
-            if(unlikely(!aentries)) aentries =  tentries;
+            if(!aentries) aentries =  tentries;
 
             // sum all the cpus together
             asearched           += tsearched;       // conntrack.search
@@ -115,16 +115,16 @@ int do_proc_net_stat_conntrack(int update_every, usec_t dt) {
         }
     }
     else {
-        if(unlikely(read_single_number_file(nf_conntrack_count_filename, &aentries)))
+        if(read_single_number_file(nf_conntrack_count_filename, &aentries))
             return 0; // we return 0, so that we will retry to open it next time
     }
 
     usec_since_last_max += dt;
-    if(unlikely(rrdvar_max && usec_since_last_max >= get_max_every)) {
+    if(rrdvar_max && usec_since_last_max >= get_max_every) {
         usec_since_last_max = 0;
 
         unsigned long long max;
-        if(likely(!read_single_number_file(nf_conntrack_max_filename, &max)))
+        if(!read_single_number_file(nf_conntrack_max_filename, &max))
             rrdvar_custom_host_variable_set(localhost, rrdvar_max, max);
     }
 
@@ -134,7 +134,7 @@ int do_proc_net_stat_conntrack(int update_every, usec_t dt) {
         static RRDSET *st = NULL;
         static RRDDIM *rd_connections = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_STAT_NETFILTER
                     , RRD_TYPE_NET_STAT_CONNTRACK "_sockets"
@@ -166,7 +166,7 @@ int do_proc_net_stat_conntrack(int update_every, usec_t dt) {
                 *rd_ignore  = NULL,
                 *rd_invalid = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_STAT_NETFILTER
                     , RRD_TYPE_NET_STAT_CONNTRACK "_new"
@@ -202,7 +202,7 @@ int do_proc_net_stat_conntrack(int update_every, usec_t dt) {
                 *rd_deleted     = NULL,
                 *rd_delete_list = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_STAT_NETFILTER
                     , RRD_TYPE_NET_STAT_CONNTRACK "_changes"
@@ -238,7 +238,7 @@ int do_proc_net_stat_conntrack(int update_every, usec_t dt) {
                       *rd_deleted = NULL,
                       *rd_new     = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_STAT_NETFILTER
                     , RRD_TYPE_NET_STAT_CONNTRACK "_expect"
@@ -274,7 +274,7 @@ int do_proc_net_stat_conntrack(int update_every, usec_t dt) {
                       *rd_restarted = NULL,
                       *rd_found     = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_STAT_NETFILTER
                     , RRD_TYPE_NET_STAT_CONNTRACK "_search"
@@ -311,7 +311,7 @@ int do_proc_net_stat_conntrack(int update_every, usec_t dt) {
                       *rd_drop          = NULL,
                       *rd_early_drop    = NULL;
 
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_STAT_NETFILTER
                     , RRD_TYPE_NET_STAT_CONNTRACK "_errors"

--- a/collectors/proc.plugin/proc_net_stat_synproxy.c
+++ b/collectors/proc.plugin/proc_net_stat_synproxy.c
@@ -13,27 +13,27 @@ int do_proc_net_stat_synproxy(int update_every, usec_t dt) {
     static int do_cookies = -1, do_syns = -1, do_reopened = -1;
     static procfile *ff = NULL;
 
-    if(unlikely(do_cookies == -1)) {
+    if(do_cookies == -1) {
         do_cookies  = config_get_boolean_ondemand("plugin:proc:/proc/net/stat/synproxy", "SYNPROXY cookies", CONFIG_BOOLEAN_AUTO);
         do_syns     = config_get_boolean_ondemand("plugin:proc:/proc/net/stat/synproxy", "SYNPROXY SYN received", CONFIG_BOOLEAN_AUTO);
         do_reopened = config_get_boolean_ondemand("plugin:proc:/proc/net/stat/synproxy", "SYNPROXY connections reopened", CONFIG_BOOLEAN_AUTO);
     }
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/net/stat/synproxy");
         ff = procfile_open(config_get("plugin:proc:/proc/net/stat/synproxy", "filename to monitor", filename), " \t,:|", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff))
+        if(!ff)
             return 1;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff))
+    if(!ff)
         return 0; // we return 0, so that we will retry to open it next time
 
     // make sure we have 3 lines
     size_t lines = procfile_lines(ff), l;
-    if(unlikely(lines < 2)) {
+    if(lines < 2) {
         collector_error("/proc/net/stat/synproxy has %zu lines, expected no less than 2. Disabling it.", lines);
         return 1;
     }
@@ -43,7 +43,7 @@ int do_proc_net_stat_synproxy(int update_every, usec_t dt) {
     // synproxy gives its values per CPU
     for(l = 1; l < lines ;l++) {
         size_t words = procfile_linewords(ff, l);
-        if(unlikely(words < 6))
+        if(words < 6)
             continue;
 
         syn_received    += strtoull(procfile_lineword(ff, l, 1), NULL, 16);
@@ -62,7 +62,7 @@ int do_proc_net_stat_synproxy(int update_every, usec_t dt) {
         do_syns = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_STAT_NETFILTER
                     , RRD_TYPE_NET_STAT_SYNPROXY "_syn_received"
@@ -92,7 +92,7 @@ int do_proc_net_stat_synproxy(int update_every, usec_t dt) {
         do_reopened = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_STAT_NETFILTER
                     , RRD_TYPE_NET_STAT_SYNPROXY "_conn_reopened"
@@ -122,7 +122,7 @@ int do_proc_net_stat_synproxy(int update_every, usec_t dt) {
         do_cookies = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st = NULL;
-        if(unlikely(!st)) {
+        if(!st) {
             st = rrdset_create_localhost(
                     RRD_TYPE_NET_STAT_NETFILTER
                     , RRD_TYPE_NET_STAT_SYNPROXY "_cookies"

--- a/collectors/proc.plugin/proc_net_wireless.c
+++ b/collectors/proc.plugin/proc_net_wireless.c
@@ -147,7 +147,7 @@ static struct netwireless *find_or_create_wireless(const char *name)
 
     // search it, from beginning to the end
     for (wireless = netwireless_root ; wireless ; wireless = wireless->next) {
-        if (unlikely(hash == wireless->hash && !strcmp(name, wireless->name))) {
+        if (hash == wireless->hash && !strcmp(name, wireless->name)) {
             return wireless;
         }
     }
@@ -209,7 +209,7 @@ int do_proc_net_wireless(int update_every, usec_t dt)
     static int do_status, do_quality = -1, do_discarded_packets, do_beacon;
     static char *proc_net_wireless_filename = NULL;
 
-    if (unlikely(do_quality == -1)) {
+    if (do_quality == -1) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/net/wireless");
 
@@ -220,20 +220,20 @@ int do_proc_net_wireless(int update_every, usec_t dt)
         do_beacon = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_PROC_NETWIRELESS, "missed beacon for all interface", CONFIG_BOOLEAN_AUTO);
 	}
 
-    if (unlikely(!ff)) {
+    if (!ff) {
         ff = procfile_open(proc_net_wireless_filename, " \t,|", PROCFILE_FLAG_DEFAULT);
-        if (unlikely(!ff)) return 1;
+        if (!ff) return 1;
     }
 
     ff = procfile_readall(ff);
-    if (unlikely(!ff)) return 1;
+    if (!ff) return 1;
 
     size_t lines = procfile_lines(ff);
     struct timeval timestamp;
     size_t l;
     gettimeofday(&timestamp, NULL);
     for (l = 2; l < lines; l++) {
-        if (unlikely(procfile_linewords(ff, l) < 11)) continue;
+        if (procfile_linewords(ff, l) < 11) continue;
 
         char *name = procfile_lineword(ff, l, 0);
         size_t len = strlen(name);
@@ -241,14 +241,14 @@ int do_proc_net_wireless(int update_every, usec_t dt)
 
         struct netwireless *wireless_dev = find_or_create_wireless(name);
 
-        if (unlikely(!wireless_dev->configured)) {
+        if (!wireless_dev->configured) {
             configure_device(do_status, do_quality, do_discarded_packets, do_beacon, wireless_dev);
 		}
 
-        if (likely(do_status != CONFIG_BOOLEAN_NO)) {
+        if (do_status != CONFIG_BOOLEAN_NO) {
             wireless_dev->status = str2kernel_uint_t(procfile_lineword(ff, l, 1));
 
-            if (unlikely(!wireless_dev->st_status)) {
+            if (!wireless_dev->st_status) {
                 wireless_dev->st_status = rrdset_create_localhost(
                     "wireless",
                     wireless_dev->chart_id_net_status,
@@ -275,12 +275,12 @@ int do_proc_net_wireless(int update_every, usec_t dt)
             rrdset_done(wireless_dev->st_status);
         }
 
-        if (likely(do_quality != CONFIG_BOOLEAN_NO)) {
+        if (do_quality != CONFIG_BOOLEAN_NO) {
             wireless_dev->link = str2ndd(procfile_lineword(ff, l, 2), NULL);
             wireless_dev->level = str2ndd(procfile_lineword(ff, l, 3), NULL);
             wireless_dev->noise = str2ndd(procfile_lineword(ff, l, 4), NULL);
 
-            if (unlikely(!wireless_dev->st_link)) {
+            if (!wireless_dev->st_link) {
                 wireless_dev->st_link = rrdset_create_localhost(
                     "wireless",
                     wireless_dev->chart_id_net_link,
@@ -301,7 +301,7 @@ int do_proc_net_wireless(int update_every, usec_t dt)
                 add_labels_to_wireless(wireless_dev, wireless_dev->st_link);
             }
 
-            if (unlikely(!wireless_dev->st_level)) {
+            if (!wireless_dev->st_level) {
                 wireless_dev->st_level = rrdset_create_localhost(
                     "wireless",
                     wireless_dev->chart_id_net_level,
@@ -322,7 +322,7 @@ int do_proc_net_wireless(int update_every, usec_t dt)
                 add_labels_to_wireless(wireless_dev, wireless_dev->st_level);
             }
 
-            if (unlikely(!wireless_dev->st_noise)) {
+            if (!wireless_dev->st_noise) {
                 wireless_dev->st_noise = rrdset_create_localhost(
                     "wireless",
                     wireless_dev->chart_id_net_noise,
@@ -353,14 +353,14 @@ int do_proc_net_wireless(int update_every, usec_t dt)
             rrdset_done(wireless_dev->st_noise);
         }
 
-        if (likely(do_discarded_packets)) {
+        if (do_discarded_packets) {
             wireless_dev->nwid = str2kernel_uint_t(procfile_lineword(ff, l, 5));
             wireless_dev->crypt = str2kernel_uint_t(procfile_lineword(ff, l, 6));
             wireless_dev->frag = str2kernel_uint_t(procfile_lineword(ff, l, 7));
             wireless_dev->retry = str2kernel_uint_t(procfile_lineword(ff, l, 8));
             wireless_dev->misc = str2kernel_uint_t(procfile_lineword(ff, l, 9));
 
-            if (unlikely(!wireless_dev->st_discarded_packets)) {
+            if (!wireless_dev->st_discarded_packets) {
                 wireless_dev->st_discarded_packets = rrdset_create_localhost(
                     "wireless",
                     wireless_dev->chart_id_net_discarded_packets,
@@ -395,10 +395,10 @@ int do_proc_net_wireless(int update_every, usec_t dt)
             rrdset_done(wireless_dev->st_discarded_packets);
         }
 
-        if (likely(do_beacon)) {
+        if (do_beacon) {
             wireless_dev->missed_beacon = str2kernel_uint_t(procfile_lineword(ff, l, 10));
 
-            if (unlikely(!wireless_dev->st_missed_beacon)) {
+            if (!wireless_dev->st_missed_beacon) {
                 wireless_dev->st_missed_beacon = rrdset_create_localhost(
                     "wireless",
                     wireless_dev->chart_id_net_missed_beacon,

--- a/collectors/proc.plugin/proc_pagetypeinfo.c
+++ b/collectors/proc.plugin/proc_pagetypeinfo.c
@@ -84,34 +84,34 @@ int do_proc_pagetypeinfo(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
     // Startup: Init arch and open /proc/pagetypeinfo
-    if (unlikely(!pagesize)) {
+    if (!pagesize) {
         pagesize = sysconf(_SC_PAGESIZE);
     }
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         snprintfz(ff_path, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, PLUGIN_PROC_MODULE_PAGETYPEINFO_NAME);
         ff = procfile_open(config_get(CONFIG_SECTION_PLUGIN_PROC_PAGETYPEINFO, "filename to monitor", ff_path), " \t:", PROCFILE_FLAG_DEFAULT);
 
-        if(unlikely(!ff)) {
+        if(!ff) {
             strncpyz(ff_path, PLUGIN_PROC_MODULE_PAGETYPEINFO_NAME, FILENAME_MAX);
             ff = procfile_open(PLUGIN_PROC_MODULE_PAGETYPEINFO_NAME, " \t,", PROCFILE_FLAG_DEFAULT);
         }
     }
-    if(unlikely(!ff))
+    if(!ff)
         return 1;
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff))
+    if(!ff)
         return 0; // we return 0, so that we will retry to open it next time
 
     // --------------------------------------------------------------------
     // Init: find how many Nodes, Zones and Types
-    if(unlikely(pagelines_cnt == 0)) {
+    if(pagelines_cnt == 0) {
         size_t nodenumlast = -1;
         char *zonenamelast = NULL;
 
         ff_lines = procfile_lines(ff);
-        if(unlikely(!ff_lines)) {
+        if(!ff_lines) {
             collector_error("PLUGIN: PROC_PAGETYPEINFO: Cannot read %s, zero lines reported.", ff_path);
             return 1;
         }

--- a/collectors/proc.plugin/proc_pressure.c
+++ b/collectors/proc.plugin/proc_pressure.c
@@ -71,7 +71,7 @@ static void proc_pressure_do_resource(procfile *ff, int res_idx, int some) {
     pcs = some ? &resources[res_idx].some : &resources[res_idx].full;
     ri = resource_info[res_idx];
 
-    if (unlikely(!pcs->share_time.st)) {
+    if (!pcs->share_time.st) {
         pcs->share_time.st = rrdset_create_localhost(
             "system",
             pcs->share_time.id,
@@ -97,7 +97,7 @@ static void proc_pressure_do_resource(procfile *ff, int res_idx, int some) {
     pcs->share_time.value60 = strtod(procfile_lineword(ff, some ? 0 : 1, 4), NULL);
     pcs->share_time.value300 = strtod(procfile_lineword(ff, some ? 0 : 1, 6), NULL);
 
-    if (unlikely(!pcs->total_time.st)) {
+    if (!pcs->total_time.st) {
         pcs->total_time.st = rrdset_create_localhost(
             "system",
             pcs->total_time.id,
@@ -142,7 +142,7 @@ int do_proc_pressure(int update_every, usec_t dt) {
         return 0;
     }
 
-    if (unlikely(!base_path)) {
+    if (!base_path) {
         base_path = config_get(CONFIG_SECTION_PLUGIN_PROC_PRESSURE, "base path of pressure metrics", "/proc/pressure");
     }
 
@@ -150,7 +150,7 @@ int do_proc_pressure(int update_every, usec_t dt) {
         procfile *ff = resource_info[i].pf;
         int do_some = resources[i].some.enabled, do_full = resources[i].full.enabled;
 
-        if (unlikely(!ff)) {
+        if (!ff) {
             char filename[FILENAME_MAX + 1];
             char config_key[CONFIG_MAX_NAME + 1];
 
@@ -177,7 +177,7 @@ int do_proc_pressure(int update_every, usec_t dt) {
             }
 
             ff = procfile_open(filename, " =", PROCFILE_FLAG_DEFAULT);
-            if (unlikely(!ff)) {
+            if (!ff) {
                 collector_error("Cannot read pressure information from %s.", filename);
                 fail_count++;
                 continue;
@@ -186,13 +186,13 @@ int do_proc_pressure(int update_every, usec_t dt) {
 
         ff = procfile_readall(ff);
         resource_info[i].pf = ff;
-        if (unlikely(!ff)) {
+        if (!ff) {
             fail_count++;
             continue;
         }
 
         size_t lines = procfile_lines(ff);
-        if (unlikely(lines < 1)) {
+        if (lines < 1) {
             collector_error("%s has no lines.", procfile_filename(ff));
             fail_count++;
             continue;

--- a/collectors/proc.plugin/proc_stat.c
+++ b/collectors/proc.plugin/proc_stat.c
@@ -63,19 +63,19 @@ static int read_per_core_files(struct cpu_chart *all_cpu_charts, size_t len, siz
 
         f->found = 0;
 
-        if(unlikely(!f->filename))
+        if(!f->filename)
             continue;
 
-        if(unlikely(f->fd == -1)) {
+        if(f->fd == -1) {
             f->fd = open(f->filename, O_RDONLY);
-            if (unlikely(f->fd == -1)) {
+            if (f->fd == -1) {
                 collector_error("Cannot open file '%s'", f->filename);
                 continue;
             }
         }
 
         ssize_t ret = read(f->fd, buf, 50);
-        if(unlikely(ret < 0)) {
+        if(ret < 0) {
             // cannot read that file
 
             collector_error("Cannot read file '%s'", f->filename);
@@ -89,7 +89,7 @@ static int read_per_core_files(struct cpu_chart *all_cpu_charts, size_t len, siz
             // terminate the buffer
             buf[ret] = '\0';
 
-            if(unlikely(keep_per_core_fds_open != CONFIG_BOOLEAN_YES)) {
+            if(keep_per_core_fds_open != CONFIG_BOOLEAN_YES) {
                 close(f->fd);
                 f->fd = -1;
             }
@@ -104,7 +104,7 @@ static int read_per_core_files(struct cpu_chart *all_cpu_charts, size_t len, siz
         f->found = 1;
 
         f->value = str2ll(buf, NULL);
-        if(likely(f->value != 0))
+        if(f->value != 0)
             files_nonzero++;
     }
 
@@ -126,12 +126,12 @@ static int read_per_core_time_in_state_files(struct cpu_chart *all_cpu_charts, s
 
         f->found = 0;
 
-        if(unlikely(!tsf->filename))
+        if(!tsf->filename)
             continue;
 
-        if(unlikely(!tsf->ff)) {
+        if(!tsf->ff) {
             tsf->ff = procfile_open(tsf->filename, " \t:", PROCFILE_FLAG_DEFAULT);
-            if(unlikely(!tsf->ff))
+            if(!tsf->ff)
             {
                 collector_error("Cannot open file '%s'", tsf->filename);
                 continue;
@@ -139,7 +139,7 @@ static int read_per_core_time_in_state_files(struct cpu_chart *all_cpu_charts, s
         }
 
         tsf->ff = procfile_readall(tsf->ff);
-        if(unlikely(!tsf->ff)) {
+        if(!tsf->ff) {
             collector_error("Cannot read file '%s'", tsf->filename);
             procfile_close(tsf->ff);
             tsf->ff = NULL;
@@ -154,7 +154,7 @@ static int read_per_core_time_in_state_files(struct cpu_chart *all_cpu_charts, s
 
             // Check if there is at least one frequency in time_in_state
             if (procfile_word(tsf->ff, 0)[0] == '\0') {
-                if(unlikely(keep_per_core_fds_open != CONFIG_BOOLEAN_YES)) {
+                if(keep_per_core_fds_open != CONFIG_BOOLEAN_YES) {
                     procfile_close(tsf->ff);
                     tsf->ff = NULL;
                 }
@@ -166,7 +166,7 @@ static int read_per_core_time_in_state_files(struct cpu_chart *all_cpu_charts, s
                 continue;
             }
 
-            if (unlikely(tsf->last_ticks_len < lines || tsf->last_ticks == NULL)) {
+            if (tsf->last_ticks_len < lines || tsf->last_ticks == NULL) {
                 tsf->last_ticks = reallocz(tsf->last_ticks, sizeof(struct last_ticks) * lines);
                 memset(tsf->last_ticks, 0, sizeof(struct last_ticks) * lines);
                 tsf->last_ticks_len = lines;
@@ -178,7 +178,7 @@ static int read_per_core_time_in_state_files(struct cpu_chart *all_cpu_charts, s
                 unsigned long long frequency = 0, ticks = 0, ticks_since_last = 0;
 
                 words = procfile_linewords(tsf->ff, l);
-                if(unlikely(words < 2)) {
+                if(words < 2) {
                     collector_error("Cannot read time_in_state line. Expected 2 params, read %zu.", words);
                     continue;
                 }
@@ -195,12 +195,12 @@ static int read_per_core_time_in_state_files(struct cpu_chart *all_cpu_charts, s
 
             }
 
-            if (likely(total_ticks_since_last)) {
+            if (total_ticks_since_last) {
                 avg_freq /= total_ticks_since_last;
                 f->value = avg_freq;
             }
 
-            if(unlikely(keep_per_core_fds_open != CONFIG_BOOLEAN_YES)) {
+            if(keep_per_core_fds_open != CONFIG_BOOLEAN_YES) {
                 procfile_close(tsf->ff);
                 tsf->ff = NULL;
             }
@@ -210,14 +210,14 @@ static int read_per_core_time_in_state_files(struct cpu_chart *all_cpu_charts, s
 
         f->found = 1;
 
-        if(likely(f->value != 0))
+        if(f->value != 0)
             files_nonzero++;
     }
 
-    if(unlikely(files_read == 0))
+    if(files_read == 0)
         return -1;
 
-    if(unlikely(files_nonzero == 0))
+    if(files_nonzero == 0)
         return 0;
 
     return (int)files_nonzero;
@@ -228,10 +228,10 @@ static void chart_per_core_files(struct cpu_chart *all_cpu_charts, size_t len, s
     for(x = 0; x < len ; x++) {
         struct per_core_single_number_file *f = &all_cpu_charts[x].files[index];
 
-        if(unlikely(!f->found))
+        if(!f->found)
             continue;
 
-        if(unlikely(!f->rd))
+        if(!f->rd)
             f->rd = rrddim_add(st, all_cpu_charts[x].id, NULL, multiplier, divisor, algorithm);
 
         rrddim_set_by_pointer(st, f->rd, f->value);
@@ -271,12 +271,12 @@ static void* wake_cpu_thread(void* core) {
     CPU_SET(*(int*)core, &cpu_set);
 
     thread = pthread_self();
-    if(unlikely(pthread_setaffinity_np(thread, sizeof(cpu_set_t), &cpu_set))) {
-        if(unlikely(errors < 8)) {
+    if(pthread_setaffinity_np(thread, sizeof(cpu_set_t), &cpu_set)) {
+        if(errors < 8) {
             collector_error("Cannot set CPU affinity for core %d", *(int*)core);
             errors++;
         }
-        else if(unlikely(errors < 9)) {
+        else if(errors < 9) {
             collector_error("CPU affinity errors are disabled");
             errors++;
         }
@@ -294,13 +294,13 @@ static int read_schedstat(char *schedstat_filename, struct per_core_cpuidle_char
     struct per_core_cpuidle_chart *cpuidle_charts = *cpuidle_charts_address;
     size_t cores_found = 0;
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         ff = procfile_open(schedstat_filename, " \t:", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff)) return 1;
+        if(!ff) return 1;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff)) return 1;
+    if(!ff) return 1;
 
     size_t lines = procfile_lines(ff), l;
     size_t words;
@@ -309,21 +309,21 @@ static int read_schedstat(char *schedstat_filename, struct per_core_cpuidle_char
         char *row_key = procfile_lineword(ff, l, 0);
 
         // faster strncmp(row_key, "cpu", 3) == 0
-        if(likely(row_key[0] == 'c' && row_key[1] == 'p' && row_key[2] == 'u')) {
+        if(row_key[0] == 'c' && row_key[1] == 'p' && row_key[2] == 'u') {
             words = procfile_linewords(ff, l);
-            if(unlikely(words < 10)) {
+            if(words < 10) {
                 collector_error("Cannot read /proc/schedstat cpu line. Expected 9 params, read %zu.", words);
                 return 1;
             }
             cores_found++;
 
             size_t core = str2ul(&row_key[3]);
-            if(unlikely(core >= cores_found)) {
+            if(core >= cores_found) {
                 collector_error("Core %zu found but no more than %zu cores were expected.", core, cores_found);
                 return 1;
             }
 
-            if(unlikely(cpuidle_charts_len < cores_found)) {
+            if(cpuidle_charts_len < cores_found) {
                 cpuidle_charts = reallocz(cpuidle_charts, sizeof(struct per_core_cpuidle_chart) * cores_found);
                 *cpuidle_charts_address = cpuidle_charts;
                 memset(cpuidle_charts + cpuidle_charts_len, 0, sizeof(struct per_core_cpuidle_chart) * (cores_found - cpuidle_charts_len));
@@ -341,7 +341,7 @@ static int read_schedstat(char *schedstat_filename, struct per_core_cpuidle_char
 static int read_one_state(char *buf, const char *filename, int *fd) {
     ssize_t ret = read(*fd, buf, 50);
 
-    if(unlikely(ret <= 0)) {
+    if(ret <= 0) {
         // cannot read that file
         collector_error("Cannot read file '%s'", filename);
         close(*fd);
@@ -354,7 +354,7 @@ static int read_one_state(char *buf, const char *filename, int *fd) {
         // terminate the buffer
         buf[ret - 1] = '\0';
 
-        if(unlikely(keep_cpuidle_fds_open != CONFIG_BOOLEAN_YES)) {
+        if(keep_cpuidle_fds_open != CONFIG_BOOLEAN_YES) {
             close(*fd);
             *fd = -1;
         }
@@ -375,7 +375,7 @@ static int read_cpuidle_states(char *cpuidle_name_filename , char *cpuidle_time_
     struct per_core_cpuidle_chart *cc = &cpuidle_charts[core];
     size_t state;
 
-    if(unlikely(!cc->cpuidle_state_len || cc->rescan_cpu_states)) {
+    if(!cc->cpuidle_state_len || cc->rescan_cpu_states) {
         int state_file_found = 1; // check at least one state
 
         if(cc->cpuidle_state_len) {
@@ -395,7 +395,7 @@ static int read_cpuidle_states(char *cpuidle_name_filename , char *cpuidle_time_
             cc->st = NULL;
         }
 
-        while(likely(state_file_found)) {
+        while(state_file_found) {
             snprintfz(filename, FILENAME_MAX, cpuidle_name_filename, core, cc->cpuidle_state_len);
             if (stat(filename, &stbuf) == 0)
                 cc->cpuidle_state_len++;
@@ -404,7 +404,7 @@ static int read_cpuidle_states(char *cpuidle_name_filename , char *cpuidle_time_
         }
         snprintfz(next_state_filename, FILENAME_MAX, cpuidle_name_filename, core, cc->cpuidle_state_len);
 
-        if(likely(cc->cpuidle_state_len))
+        if(cc->cpuidle_state_len)
             cc->cpuidle_state = callocz(cc->cpuidle_state_len, sizeof(struct cpuidle_state));
 
         for(state = 0; state < cc->cpuidle_state_len; state++) {
@@ -412,14 +412,14 @@ static int read_cpuidle_states(char *cpuidle_name_filename , char *cpuidle_time_
             snprintfz(filename, FILENAME_MAX, cpuidle_name_filename, core, state);
 
             int fd = open(filename, O_RDONLY, 0666);
-            if(unlikely(fd == -1)) {
+            if(fd == -1) {
                 collector_error("Cannot open file '%s'", filename);
                 cc->rescan_cpu_states = 1;
                 return 1;
             }
 
             ssize_t r = read(fd, name_buf, 50);
-            if(unlikely(r < 1)) {
+            if(r < 1) {
                 collector_error("Cannot read file '%s'", filename);
                 close(fd);
                 cc->rescan_cpu_states = 1;
@@ -442,9 +442,9 @@ static int read_cpuidle_states(char *cpuidle_name_filename , char *cpuidle_time_
 
         struct cpuidle_state *cs = &cc->cpuidle_state[state];
 
-        if(unlikely(cs->time_fd == -1)) {
+        if(cs->time_fd == -1) {
             cs->time_fd = open(cs->time_filename, O_RDONLY);
-            if (unlikely(cs->time_fd == -1)) {
+            if (cs->time_fd == -1) {
                 collector_error("Cannot open file '%s'", cs->time_filename);
                 cc->rescan_cpu_states = 1;
                 return 1;
@@ -452,7 +452,7 @@ static int read_cpuidle_states(char *cpuidle_name_filename , char *cpuidle_time_
         }
 
         char time_buf[50 + 1];
-        if(likely(read_one_state(time_buf, cs->time_filename, &cs->time_fd))) {
+        if(read_one_state(time_buf, cs->time_filename, &cs->time_fd)) {
             cs->value = str2ll(time_buf, NULL);
         }
         else {
@@ -462,7 +462,7 @@ static int read_cpuidle_states(char *cpuidle_name_filename , char *cpuidle_time_
     }
 
     // check if the number of states was increased
-    if(unlikely(stat(next_state_filename, &stbuf) == 0)) {
+    if(stat(next_state_filename, &stbuf) == 0) {
         cc->rescan_cpu_states = 1;
         return 1;
     }
@@ -485,7 +485,7 @@ int do_proc_stat(int update_every, usec_t dt) {
     static int accurate_freq_avail = 0, accurate_freq_is_used = 0;
     size_t cores_found = (size_t)get_system_cpus();
 
-    if(unlikely(do_cpu == -1)) {
+    if(do_cpu == -1) {
         do_cpu                    = config_get_boolean("plugin:proc:/proc/stat", "cpu utilization", CONFIG_BOOLEAN_YES);
         do_cpu_cores              = config_get_boolean("plugin:proc:/proc/stat", "per cpu core utilization", CONFIG_BOOLEAN_YES);
         do_interrupts             = config_get_boolean("plugin:proc:/proc/stat", "cpu interrupts", CONFIG_BOOLEAN_YES);
@@ -494,7 +494,7 @@ int do_proc_stat(int update_every, usec_t dt) {
         do_processes              = config_get_boolean("plugin:proc:/proc/stat", "processes running", CONFIG_BOOLEAN_YES);
 
         // give sane defaults based on the number of processors
-        if(unlikely(get_system_cpus() > 50)) {
+        if(get_system_cpus() > 50) {
             // the system has too many processors
             keep_per_core_fds_open = CONFIG_BOOLEAN_NO;
             do_core_throttle_count = CONFIG_BOOLEAN_NO;
@@ -510,7 +510,7 @@ int do_proc_stat(int update_every, usec_t dt) {
             do_cpu_freq = CONFIG_BOOLEAN_YES;
             do_cpuidle = CONFIG_BOOLEAN_YES;
         }
-        if(unlikely(get_system_cpus() > 24)) {
+        if(get_system_cpus() > 24) {
             // the system has too many processors
             keep_cpuidle_fds_open = CONFIG_BOOLEAN_NO;
         }
@@ -562,15 +562,15 @@ int do_proc_stat(int update_every, usec_t dt) {
         cpuidle_time_filename = config_get("plugin:proc:/proc/stat", "cpuidle time filename to monitor", filename);
     }
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/stat");
         ff = procfile_open(config_get("plugin:proc:/proc/stat", "filename to monitor", filename), " \t:", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff)) return 1;
+        if(!ff) return 1;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff)) return 0; // we return 0, so that we will retry to open it next time
+    if(!ff) return 0; // we return 0, so that we will retry to open it next time
 
     size_t lines = procfile_lines(ff), l;
     size_t words;
@@ -582,17 +582,17 @@ int do_proc_stat(int update_every, usec_t dt) {
         uint32_t hash = simple_hash(row_key);
 
         // faster strncmp(row_key, "cpu", 3) == 0
-        if(likely(row_key[0] == 'c' && row_key[1] == 'p' && row_key[2] == 'u')) {
+        if(row_key[0] == 'c' && row_key[1] == 'p' && row_key[2] == 'u') {
             words = procfile_linewords(ff, l);
-            if(unlikely(words < 9)) {
+            if(words < 9) {
                 collector_error("Cannot read /proc/stat cpu line. Expected 9 params, read %zu.", words);
                 continue;
             }
 
             size_t core    = (row_key[3] == '\0') ? 0 : str2ul(&row_key[3]) + 1;
-            if(likely(core > 0)) cores_found = core;
+            if(core > 0) cores_found = core;
 
-            if(likely((core == 0 && do_cpu) || (core > 0 && do_cpu_cores))) {
+            if((core == 0 && do_cpu) || (core > 0 && do_cpu_cores)) {
                 char *id;
                 unsigned long long user = 0, nice = 0, system = 0, idle = 0, iowait = 0, irq = 0, softirq = 0, steal = 0, guest = 0, guest_nice = 0;
 
@@ -615,7 +615,7 @@ int do_proc_stat(int update_every, usec_t dt) {
                 char *title, *type, *context, *family;
                 long priority;
 
-                if(unlikely(core >= all_cpu_charts_size)) {
+                if(core >= all_cpu_charts_size) {
                     size_t old_cpu_charts_size = all_cpu_charts_size;
                     all_cpu_charts_size = core + 1;
                     all_cpu_charts = reallocz(all_cpu_charts, sizeof(struct cpu_chart) * all_cpu_charts_size);
@@ -623,10 +623,10 @@ int do_proc_stat(int update_every, usec_t dt) {
                 }
                 struct cpu_chart *cpu_chart = &all_cpu_charts[core];
 
-                if(unlikely(!cpu_chart->st)) {
+                if(!cpu_chart->st) {
                     cpu_chart->id = strdupz(id);
 
-                    if(unlikely(core == 0)) {
+                    if(core == 0) {
                         title = "Total CPU utilization";
                         type = "system";
                         context = "system.cpu";
@@ -718,7 +718,7 @@ int do_proc_stat(int update_every, usec_t dt) {
                         rrdlabels_add(cpu_chart->st->rrdlabels, "cpu", cpu_core, RRDLABEL_SRC_AUTO);
                     }
 
-                    if(unlikely(core == 0 && cpus_var == NULL))
+                    if(core == 0 && cpus_var == NULL)
                         cpus_var = rrdvar_custom_host_variable_add_and_acquire(localhost, "active_processors");
                 }
 
@@ -735,13 +735,13 @@ int do_proc_stat(int update_every, usec_t dt) {
                 rrdset_done(cpu_chart->st);
             }
         }
-        else if(unlikely(hash == hash_intr && strcmp(row_key, "intr") == 0)) {
-            if(likely(do_interrupts)) {
+        else if(hash == hash_intr && strcmp(row_key, "intr") == 0) {
+            if(do_interrupts) {
                 static RRDSET *st_intr = NULL;
                 static RRDDIM *rd_interrupts = NULL;
                 unsigned long long value = str2ull(procfile_lineword(ff, l, 1), NULL);
 
-                if(unlikely(!st_intr)) {
+                if(!st_intr) {
                     st_intr = rrdset_create_localhost(
                             "system"
                             , "intr"
@@ -766,13 +766,13 @@ int do_proc_stat(int update_every, usec_t dt) {
                 rrdset_done(st_intr);
             }
         }
-        else if(unlikely(hash == hash_ctxt && strcmp(row_key, "ctxt") == 0)) {
-            if(likely(do_context)) {
+        else if(hash == hash_ctxt && strcmp(row_key, "ctxt") == 0) {
+            if(do_context) {
                 static RRDSET *st_ctxt = NULL;
                 static RRDDIM *rd_switches = NULL;
                 unsigned long long value = str2ull(procfile_lineword(ff, l, 1), NULL);
 
-                if(unlikely(!st_ctxt)) {
+                if(!st_ctxt) {
                     st_ctxt = rrdset_create_localhost(
                             "system"
                             , "ctxt"
@@ -795,24 +795,24 @@ int do_proc_stat(int update_every, usec_t dt) {
                 rrdset_done(st_ctxt);
             }
         }
-        else if(unlikely(hash == hash_processes && !processes && strcmp(row_key, "processes") == 0)) {
+        else if(hash == hash_processes && !processes && strcmp(row_key, "processes") == 0) {
             processes = str2ull(procfile_lineword(ff, l, 1), NULL);
         }
-        else if(unlikely(hash == hash_procs_running && !running && strcmp(row_key, "procs_running") == 0)) {
+        else if(hash == hash_procs_running && !running && strcmp(row_key, "procs_running") == 0) {
             running = str2ull(procfile_lineword(ff, l, 1), NULL);
         }
-        else if(unlikely(hash == hash_procs_blocked && !blocked && strcmp(row_key, "procs_blocked") == 0)) {
+        else if(hash == hash_procs_blocked && !blocked && strcmp(row_key, "procs_blocked") == 0) {
             blocked = str2ull(procfile_lineword(ff, l, 1), NULL);
         }
     }
 
     // --------------------------------------------------------------------
 
-    if(likely(do_forks)) {
+    if(do_forks) {
         static RRDSET *st_forks = NULL;
         static RRDDIM *rd_started = NULL;
 
-        if(unlikely(!st_forks)) {
+        if(!st_forks) {
             st_forks = rrdset_create_localhost(
                     "system"
                     , "forks"
@@ -838,12 +838,12 @@ int do_proc_stat(int update_every, usec_t dt) {
 
     // --------------------------------------------------------------------
 
-    if(likely(do_processes)) {
+    if(do_processes) {
         static RRDSET *st_processes = NULL;
         static RRDDIM *rd_running = NULL;
         static RRDDIM *rd_blocked = NULL;
 
-        if(unlikely(!st_processes)) {
+        if(!st_processes) {
             st_processes = rrdset_create_localhost(
                     "system"
                     , "processes"
@@ -868,15 +868,15 @@ int do_proc_stat(int update_every, usec_t dt) {
         rrdset_done(st_processes);
     }
 
-    if(likely(all_cpu_charts_size > 1)) {
-        if(likely(do_core_throttle_count != CONFIG_BOOLEAN_NO)) {
+    if(all_cpu_charts_size > 1) {
+        if(do_core_throttle_count != CONFIG_BOOLEAN_NO) {
             int r = read_per_core_files(&all_cpu_charts[1], all_cpu_charts_size - 1, CORE_THROTTLE_COUNT_INDEX);
-            if(likely(r != -1 && (do_core_throttle_count == CONFIG_BOOLEAN_YES || r > 0))) {
+            if(r != -1 && (do_core_throttle_count == CONFIG_BOOLEAN_YES || r > 0)) {
                 do_core_throttle_count = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st_core_throttle_count = NULL;
 
-                if (unlikely(!st_core_throttle_count)) {
+                if (!st_core_throttle_count) {
                     st_core_throttle_count = rrdset_create_localhost(
                             "cpu"
                             , "core_throttling"
@@ -898,14 +898,14 @@ int do_proc_stat(int update_every, usec_t dt) {
             }
         }
 
-        if(likely(do_package_throttle_count != CONFIG_BOOLEAN_NO)) {
+        if(do_package_throttle_count != CONFIG_BOOLEAN_NO) {
             int r = read_per_core_files(&all_cpu_charts[1], all_cpu_charts_size - 1, PACKAGE_THROTTLE_COUNT_INDEX);
-            if(likely(r != -1 && (do_package_throttle_count == CONFIG_BOOLEAN_YES || r > 0))) {
+            if(r != -1 && (do_package_throttle_count == CONFIG_BOOLEAN_YES || r > 0)) {
                 do_package_throttle_count = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st_package_throttle_count = NULL;
 
-                if(unlikely(!st_package_throttle_count)) {
+                if(!st_package_throttle_count) {
                     st_package_throttle_count = rrdset_create_localhost(
                             "cpu"
                             , "package_throttling"
@@ -927,7 +927,7 @@ int do_proc_stat(int update_every, usec_t dt) {
             }
         }
 
-        if(likely(do_cpu_freq != CONFIG_BOOLEAN_NO)) {
+        if(do_cpu_freq != CONFIG_BOOLEAN_NO) {
             char filename[FILENAME_MAX + 1];
             int r = 0;
 
@@ -948,12 +948,12 @@ int do_proc_stat(int update_every, usec_t dt) {
                 }
             }
 
-            if(likely(r != -1 && (do_cpu_freq == CONFIG_BOOLEAN_YES || r > 0))) {
+            if(r != -1 && (do_cpu_freq == CONFIG_BOOLEAN_YES || r > 0)) {
                 do_cpu_freq = CONFIG_BOOLEAN_YES;
 
                 static RRDSET *st_scaling_cur_freq = NULL;
 
-                if(unlikely(!st_scaling_cur_freq)) {
+                if(!st_scaling_cur_freq) {
                     st_scaling_cur_freq = rrdset_create_localhost(
                             "cpu"
                             , "cpufreq"
@@ -981,7 +981,7 @@ int do_proc_stat(int update_every, usec_t dt) {
     static struct per_core_cpuidle_chart *cpuidle_charts = NULL;
     size_t schedstat_cores_found = 0;
 
-    if(likely(do_cpuidle != CONFIG_BOOLEAN_NO && !read_schedstat(schedstat_filename, &cpuidle_charts, &schedstat_cores_found))) {
+    if(do_cpuidle != CONFIG_BOOLEAN_NO && !read_schedstat(schedstat_filename, &cpuidle_charts, &schedstat_cores_found)) {
         int cpu_states_updated = 0;
         size_t core, state;
 
@@ -989,12 +989,12 @@ int do_proc_stat(int update_every, usec_t dt) {
         // proc.plugin runs on Linux systems only. Multi-platform compatibility is not needed here,
         // so bare pthread functions are used to avoid unneeded overheads.
         for(core = 0; core < schedstat_cores_found; core++) {
-            if(unlikely(!(cpuidle_charts[core].active_time - cpuidle_charts[core].last_active_time))) {
+            if(!(cpuidle_charts[core].active_time - cpuidle_charts[core].last_active_time)) {
                 pthread_t thread;
                 cpu_set_t global_cpu_set;
 
-                if (likely(!pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &global_cpu_set))) {
-                    if (unlikely(!CPU_ISSET(core, &global_cpu_set))) {
+                if (!pthread_getaffinity_np(pthread_self(), sizeof(cpu_set_t), &global_cpu_set)) {
+                    if (!CPU_ISSET(core, &global_cpu_set)) {
                         continue;
                     }
                 }
@@ -1002,26 +1002,26 @@ int do_proc_stat(int update_every, usec_t dt) {
                     collector_error("Cannot read current process affinity");
 
                 // These threads are very ephemeral and don't need to have a specific name
-                if(unlikely(pthread_create(&thread, NULL, wake_cpu_thread, (void *)&core)))
+                if(pthread_create(&thread, NULL, wake_cpu_thread, (void *)&core))
                     collector_error("Cannot create wake_cpu_thread");
-                else if(unlikely(pthread_join(thread, NULL)))
+                else if(pthread_join(thread, NULL))
                     collector_error("Cannot join wake_cpu_thread");
                 cpu_states_updated = 1;
             }
         }
 
-        if(unlikely(!cpu_states_updated || !read_schedstat(schedstat_filename, &cpuidle_charts, &schedstat_cores_found))) {
+        if(!cpu_states_updated || !read_schedstat(schedstat_filename, &cpuidle_charts, &schedstat_cores_found)) {
             for(core = 0; core < schedstat_cores_found; core++) {
                 cpuidle_charts[core].last_active_time = cpuidle_charts[core].active_time;
 
                 int r = read_cpuidle_states(cpuidle_name_filename, cpuidle_time_filename, cpuidle_charts, core);
-                if(likely(r != -1 && (do_cpuidle == CONFIG_BOOLEAN_YES || r > 0))) {
+                if(r != -1 && (do_cpuidle == CONFIG_BOOLEAN_YES || r > 0)) {
                     do_cpuidle = CONFIG_BOOLEAN_YES;
 
                     char cpuidle_chart_id[RRD_ID_LENGTH_MAX + 1];
                     snprintfz(cpuidle_chart_id, RRD_ID_LENGTH_MAX, "cpu%zu_cpuidle", core);
 
-                    if(unlikely(!cpuidle_charts[core].st)) {
+                    if(!cpuidle_charts[core].st) {
                         cpuidle_charts[core].st = rrdset_create_localhost(
                                 "cpu"
                                 , cpuidle_chart_id

--- a/collectors/proc.plugin/proc_sys_fs_file_nr.c
+++ b/collectors/proc.plugin/proc_sys_fs_file_nr.c
@@ -7,15 +7,15 @@ int do_proc_sys_fs_file_nr(int update_every, usec_t dt) {
 
     static procfile *ff = NULL;
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/sys/fs/file-nr");
         ff = procfile_open(config_get("plugin:proc:/proc/sys/fs/file-nr", "filename to monitor", filename), "", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff)) return 1;
+        if(!ff) return 1;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff)) return 0; // we return 0, so that we will retry to open it next time
+    if(!ff) return 0; // we return 0, so that we will retry to open it next time
 
     uint64_t allocated = str2ull(procfile_lineword(ff, 0, 0), NULL);
     uint64_t unused = str2ull(procfile_lineword(ff, 0, 1), NULL);
@@ -26,7 +26,7 @@ int do_proc_sys_fs_file_nr(int update_every, usec_t dt) {
     static RRDSET *st_files = NULL;
     static RRDDIM *rd_used = NULL;
 
-    if(unlikely(!st_files)) {
+    if(!st_files) {
         st_files = rrdset_create_localhost(
                 "system"
                 , "file_nr_used"
@@ -51,7 +51,7 @@ int do_proc_sys_fs_file_nr(int update_every, usec_t dt) {
     static RRDSET *st_files_utilization = NULL;
     static RRDDIM *rd_utilization = NULL;
 
-    if(unlikely(!st_files_utilization)) {
+    if(!st_files_utilization) {
         st_files_utilization = rrdset_create_localhost(
                 "system"
                 , "file_nr_utilization"

--- a/collectors/proc.plugin/proc_sys_kernel_random_entropy_avail.c
+++ b/collectors/proc.plugin/proc_sys_kernel_random_entropy_avail.c
@@ -7,22 +7,22 @@ int do_proc_sys_kernel_random_entropy_avail(int update_every, usec_t dt) {
 
     static procfile *ff = NULL;
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/sys/kernel/random/entropy_avail");
         ff = procfile_open(config_get("plugin:proc:/proc/sys/kernel/random/entropy_avail", "filename to monitor", filename), "", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff)) return 1;
+        if(!ff) return 1;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff)) return 0; // we return 0, so that we will retry to open it next time
+    if(!ff) return 0; // we return 0, so that we will retry to open it next time
 
     unsigned long long entropy = str2ull(procfile_lineword(ff, 0, 0), NULL);
 
     static RRDSET *st = NULL;
     static RRDDIM *rd = NULL;
 
-    if(unlikely(!st)) {
+    if(!st) {
         st = rrdset_create_localhost(
                 "system"
                 , "entropy"

--- a/collectors/proc.plugin/proc_uptime.c
+++ b/collectors/proc.plugin/proc_uptime.c
@@ -16,7 +16,7 @@ int do_proc_uptime(int update_every, usec_t dt) {
     static RRDSET *st = NULL;
     static RRDDIM *rd = NULL;
 
-    if(unlikely(!st)) {
+    if(!st) {
 
         st = rrdset_create_localhost(
                 "system"

--- a/collectors/proc.plugin/proc_vmstat.c
+++ b/collectors/proc.plugin/proc_vmstat.c
@@ -128,19 +128,19 @@ int do_proc_vmstat(int update_every, usec_t dt) {
 //    static unsigned long long direct_map_level3_splits = 0ULL;
 //    static unsigned long long nr_unstable = 0ULL;
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/vmstat");
         ff = procfile_open(config_get("plugin:proc:/proc/vmstat", "filename to monitor", filename), " \t:", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff)) return 1;
+        if(!ff) return 1;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff)) return 0; // we return 0, so that we will retry to open it next time
+    if(!ff) return 0; // we return 0, so that we will retry to open it next time
 
     size_t lines = procfile_lines(ff), l;
 
-    if(unlikely(!arl_base)) {
+    if(!arl_base) {
         do_swapio = config_get_boolean_ondemand("plugin:proc:/proc/vmstat", "swap i/o", CONFIG_BOOLEAN_AUTO);
         do_io = config_get_boolean("plugin:proc:/proc/vmstat", "disk i/o", CONFIG_BOOLEAN_YES);
         do_pgfaults = config_get_boolean("plugin:proc:/proc/vmstat", "memory page faults", CONFIG_BOOLEAN_YES);
@@ -249,14 +249,14 @@ int do_proc_vmstat(int update_every, usec_t dt) {
     arl_begin(arl_base);
     for(l = 0; l < lines ;l++) {
         size_t words = procfile_linewords(ff, l);
-        if(unlikely(words < 2)) {
-            if(unlikely(words)) collector_error("Cannot read /proc/vmstat line %zu. Expected 2 params, read %zu.", l, words);
+        if(words < 2) {
+            if(words) collector_error("Cannot read /proc/vmstat line %zu. Expected 2 params, read %zu.", l, words);
             continue;
         }
 
-        if(unlikely(arl_check(arl_base,
+        if(arl_check(arl_base,
                 procfile_lineword(ff, l, 0),
-                procfile_lineword(ff, l, 1)))) break;
+                procfile_lineword(ff, l, 1))) break;
     }
 
     // --------------------------------------------------------------------
@@ -269,7 +269,7 @@ int do_proc_vmstat(int update_every, usec_t dt) {
         static RRDSET *st_swapio = NULL;
         static RRDDIM *rd_in = NULL, *rd_out = NULL;
 
-        if(unlikely(!st_swapio)) {
+        if(!st_swapio) {
             st_swapio = rrdset_create_localhost(
                     "system"
                     , "swapio"
@@ -300,7 +300,7 @@ int do_proc_vmstat(int update_every, usec_t dt) {
         static RRDSET *st_io = NULL;
         static RRDDIM *rd_in = NULL, *rd_out = NULL;
 
-        if(unlikely(!st_io)) {
+        if(!st_io) {
             st_io = rrdset_create_localhost(
                     "system"
                     , "pgpgio"
@@ -331,7 +331,7 @@ int do_proc_vmstat(int update_every, usec_t dt) {
         static RRDSET *st_pgfaults = NULL;
         static RRDDIM *rd_minor = NULL, *rd_major = NULL;
 
-        if(unlikely(!st_pgfaults)) {
+        if(!st_pgfaults) {
             st_pgfaults = rrdset_create_localhost(
                     "mem"
                     , "pgfaults"
@@ -367,7 +367,7 @@ int do_proc_vmstat(int update_every, usec_t dt) {
 
         do_oom_kill = CONFIG_BOOLEAN_YES;
 
-        if(unlikely(!st_oom_kill)) {
+        if(!st_oom_kill) {
             st_oom_kill = rrdset_create_localhost(
                     "mem"
                     , "oom_kill"
@@ -398,7 +398,7 @@ int do_proc_vmstat(int update_every, usec_t dt) {
     // check it only once. We check whether the node count is >= 2 because
     // single-node systems have uninteresting statistics (since all accesses
     // are local).
-    if(unlikely(has_numa == -1))
+    if(has_numa == -1)
 
         has_numa = (numa_local || numa_foreign || numa_interleave || numa_other || numa_pte_updates ||
                      numa_huge_pte_updates || numa_hint_faults || numa_hint_faults_local || numa_pages_migrated) ? 1 : 0;
@@ -409,7 +409,7 @@ int do_proc_vmstat(int update_every, usec_t dt) {
         static RRDSET *st_numa = NULL;
         static RRDDIM *rd_local = NULL, *rd_foreign = NULL, *rd_interleave = NULL, *rd_other = NULL, *rd_pte_updates = NULL, *rd_huge_pte_updates = NULL, *rd_hint_faults = NULL, *rd_hint_faults_local = NULL, *rd_pages_migrated = NULL;
 
-        if(unlikely(!st_numa)) {
+        if(!st_numa) {
             st_numa = rrdset_create_localhost(
                     "mem"
                     , "numa"
@@ -465,7 +465,7 @@ int do_proc_vmstat(int update_every, usec_t dt) {
         static RRDSET *st_balloon = NULL;
         static RRDDIM *rd_inflate = NULL, *rd_deflate = NULL, *rd_migrate = NULL;
 
-        if(unlikely(!st_balloon)) {
+        if(!st_balloon) {
             st_balloon = rrdset_create_localhost(
                     "mem"
                     , "balloon"
@@ -503,7 +503,7 @@ int do_proc_vmstat(int update_every, usec_t dt) {
         static RRDSET *st_zswapio = NULL;
         static RRDDIM *rd_in = NULL, *rd_out = NULL;
 
-        if(unlikely(!st_zswapio)) {
+        if(!st_zswapio) {
             st_zswapio = rrdset_create_localhost(
                     "system"
                     , "zswapio"
@@ -538,7 +538,7 @@ int do_proc_vmstat(int update_every, usec_t dt) {
         static RRDSET *st_ksm_cow = NULL;
         static RRDDIM *rd_swapin = NULL, *rd_write = NULL;
 
-        if(unlikely(!st_ksm_cow)) {
+        if(!st_ksm_cow) {
             st_ksm_cow = rrdset_create_localhost(
                     "mem"
             , "ksm_cow"
@@ -574,7 +574,7 @@ int do_proc_vmstat(int update_every, usec_t dt) {
             static RRDSET *st_thp_fault = NULL;
             static RRDDIM *rd_alloc = NULL, *rd_fallback = NULL, *rd_fallback_charge = NULL;
 
-            if(unlikely(!st_thp_fault)) {
+            if(!st_thp_fault) {
                 st_thp_fault = rrdset_create_localhost(
                         "mem"
                         , "thp_faults"
@@ -608,7 +608,7 @@ int do_proc_vmstat(int update_every, usec_t dt) {
             static RRDSET *st_thp_file = NULL;
             static RRDDIM *rd_alloc = NULL, *rd_fallback = NULL, *rd_fallback_charge = NULL, *rd_mapped = NULL;
 
-            if(unlikely(!st_thp_file)) {
+            if(!st_thp_file) {
                 st_thp_file = rrdset_create_localhost(
                         "mem"
                         , "thp_file"
@@ -644,7 +644,7 @@ int do_proc_vmstat(int update_every, usec_t dt) {
             static RRDSET *st_thp_zero = NULL;
             static RRDDIM *rd_alloc = NULL, *rd_failed = NULL;
 
-            if(unlikely(!st_thp_zero)) {
+            if(!st_thp_zero) {
                 st_thp_zero = rrdset_create_localhost(
                         "mem"
                         , "thp_zero"
@@ -676,7 +676,7 @@ int do_proc_vmstat(int update_every, usec_t dt) {
             static RRDSET *st_khugepaged = NULL;
             static RRDDIM *rd_alloc = NULL, *rd_failed = NULL;
 
-            if(unlikely(!st_khugepaged)) {
+            if(!st_khugepaged) {
                 st_khugepaged = rrdset_create_localhost(
                         "mem"
                         , "thp_collapse"
@@ -708,7 +708,7 @@ int do_proc_vmstat(int update_every, usec_t dt) {
             static RRDSET *st_thp_split = NULL;
             static RRDDIM *rd_split = NULL, *rd_failed = NULL, *rd_deferred_split = NULL, *rd_split_pmd = NULL;
 
-            if(unlikely(!st_thp_split)) {
+            if(!st_thp_split) {
                 st_thp_split = rrdset_create_localhost(
                         "mem"
                         , "thp_split"
@@ -744,7 +744,7 @@ int do_proc_vmstat(int update_every, usec_t dt) {
             static RRDSET *st_tmp_swapout = NULL;
             static RRDDIM *rd_swapout = NULL, *rd_fallback = NULL;
 
-            if(unlikely(!st_tmp_swapout)) {
+            if(!st_tmp_swapout) {
                 st_tmp_swapout = rrdset_create_localhost(
                         "mem"
                         , "thp_swapout"
@@ -776,7 +776,7 @@ int do_proc_vmstat(int update_every, usec_t dt) {
             static RRDSET *st_thp_compact = NULL;
             static RRDDIM *rd_success = NULL, *rd_fail = NULL, *rd_stall = NULL;
 
-            if(unlikely(!st_thp_compact)) {
+            if(!st_thp_compact) {
                 st_thp_compact = rrdset_create_localhost(
                         "mem"
                         , "thp_compact"

--- a/collectors/proc.plugin/sys_block_zram.c
+++ b/collectors/proc.plugin/sys_block_zram.c
@@ -139,12 +139,12 @@ static int init_devices(DICTIONARY *devices, unsigned int zram_id, int update_ev
     snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/dev");
     DIR *dir = opendir(filename);
 
-    if (unlikely(!dir))
+    if (!dir)
         return 0;
     while ((de = readdir(dir)))
     {
         snprintfz(filename, FILENAME_MAX, "%s/dev/%s", netdata_configured_host_prefix, de->d_name);
-        if (unlikely(stat(filename, &st) != 0))
+        if (stat(filename, &st) != 0)
         {
             collector_error("ZRAM : Unable to stat %s: %s", filename, strerror(errno));
             continue;
@@ -211,7 +211,7 @@ static int collect_zram_metrics(const DICTIONARY_ITEM *item, void *entry, void *
     MM_STAT mm;
     int value;
 
-    if (unlikely(read_mm_stat(dev->file, &mm) < 0)) {
+    if (read_mm_stat(dev->file, &mm) < 0) {
         free_device(dict, name);
         return -1;
     }
@@ -248,7 +248,7 @@ int do_sys_block_zram(int update_every, usec_t dt) {
 
     (void)dt;
 
-    if (unlikely(!initialized))
+    if (!initialized)
     {
         initialized = 1;
 
@@ -277,7 +277,7 @@ int do_sys_block_zram(int update_every, usec_t dt) {
         device_count = init_devices(devices, (unsigned int)zram_id, update_every);
     }
 
-    if (unlikely(device_count < 1))
+    if (device_count < 1)
         return 1;
 
     dictionary_walkthrough_write(devices, collect_zram_metrics, devices);

--- a/collectors/proc.plugin/sys_class_infiniband.c
+++ b/collectors/proc.plugin/sys_class_infiniband.c
@@ -239,7 +239,7 @@ static struct ibport *get_ibport(const char *dev, const char *port)
 
     // search it, resuming from the last position in sequence
     for (p = ibport_last_used; p; p = p->next) {
-        if (unlikely(!strcmp(name, p->name))) {
+        if (!strcmp(name, p->name)) {
             ibport_last_used = p->next;
             return p;
         }
@@ -247,7 +247,7 @@ static struct ibport *get_ibport(const char *dev, const char *port)
 
     // new round, from the beginning to the last position used this time
     for (p = ibport_root; p != ibport_last_used; p = p->next) {
-        if (unlikely(!strcmp(name, p->name))) {
+        if (!strcmp(name, p->name)) {
             ibport_last_used = p->next;
             return p;
         }
@@ -306,7 +306,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
 
     static long long int dt_to_refresh_ports = 0, last_refresh_ports_usec = 0;
 
-    if (unlikely(enable_new_ports == -1)) {
+    if (enable_new_ports == -1) {
         char dirname[FILENAME_MAX + 1];
 
         snprintfz(dirname, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/class/infiniband");
@@ -339,10 +339,10 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
     }
 
     // init listing of /sys/class/infiniband/ (or rediscovery)
-    if (unlikely(!initialized) || unlikely(last_refresh_ports_usec >= dt_to_refresh_ports)) {
+    if (!initialized || last_refresh_ports_usec >= dt_to_refresh_ports) {
         // If folder does not exists, return 1 to disable
         DIR *devices_dir = opendir(sys_class_infiniband_dirname);
-        if (unlikely(!devices_dir))
+        if (!devices_dir)
             return 1;
 
         // Work on all device available
@@ -357,7 +357,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
             snprintfz(ports_dirname, FILENAME_MAX, "%s/%s/%s", sys_class_infiniband_dirname, dev_dent->d_name, "ports");
 
             DIR *ports_dir = opendir(ports_dirname);
-            if (unlikely(!ports_dir))
+            if (!ports_dir)
                 continue;
 
             struct dirent *port_dent;
@@ -524,7 +524,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
             FOREACH_COUNTER_BYTES(GEN_DO_COUNTER_READ, port)
 
             // First creation of RRD Set (charts)
-            if (unlikely(!port->st_bytes)) {
+            if (!port->st_bytes) {
                 port->st_bytes = rrdset_create_localhost(
                     "Infiniband",
                     port->chart_id_bytes,
@@ -562,7 +562,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
             FOREACH_COUNTER_PACKETS(GEN_DO_COUNTER_READ, port)
 
             // First creation of RRD Set (charts)
-            if (unlikely(!port->st_packets)) {
+            if (!port->st_packets) {
                 port->st_packets = rrdset_create_localhost(
                     "Infiniband",
                     port->chart_id_packets,
@@ -591,7 +591,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
             FOREACH_COUNTER_ERRORS(GEN_DO_COUNTER_READ, port)
 
             // First creation of RRD Set (charts)
-            if (unlikely(!port->st_errors)) {
+            if (!port->st_errors) {
                 port->st_errors = rrdset_create_localhost(
                     "Infiniband",
                     port->chart_id_errors,
@@ -626,7 +626,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
 
             if (port->do_hwerrors != CONFIG_BOOLEAN_NO) {
                 // First creation of RRD Set (charts)
-                if (unlikely(!port->st_hwerrors)) {
+                if (!port->st_hwerrors) {
                     port->st_hwerrors = rrdset_create_localhost(
                         "Infiniband",
                         port->chart_id_hwerrors,
@@ -662,7 +662,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
 
             if (port->do_hwpackets != CONFIG_BOOLEAN_NO) {
                 // First creation of RRD Set (charts)
-                if (unlikely(!port->st_hwpackets)) {
+                if (!port->st_hwpackets) {
                     port->st_hwpackets = rrdset_create_localhost(
                         "Infiniband",
                         port->chart_id_hwpackets,

--- a/collectors/proc.plugin/sys_class_power_supply.c
+++ b/collectors/proc.plugin/sys_class_power_supply.c
@@ -61,27 +61,27 @@ static struct power_supply *power_supply_root = NULL;
 static int files_num = 0;
 
 void power_supply_free(struct power_supply *ps) {
-    if(likely(ps)) {
+    if(ps) {
 
         // free capacity structure
-        if(likely(ps->capacity)) {
-            if(likely(ps->capacity->st)) rrdset_is_obsolete(ps->capacity->st);
+        if(ps->capacity) {
+            if(ps->capacity->st) rrdset_is_obsolete(ps->capacity->st);
             freez(ps->capacity->filename);
-            if(likely(ps->capacity->fd != -1)) close(ps->capacity->fd);
+            if(ps->capacity->fd != -1) close(ps->capacity->fd);
             files_num--;
             freez(ps->capacity);
         }
         freez(ps->name);
 
         struct ps_property *pr = ps->property_root;
-        while(likely(pr)) {
+        while(pr) {
 
             // free dimensions
             struct ps_property_dim *pd = pr->property_dim_root;
-            while(likely(pd)) {
+            while(pd) {
                 freez(pd->name);
                 freez(pd->filename);
-                if(likely(pd->fd != -1)) close(pd->fd);
+                if(pd->fd != -1) close(pd->fd);
                 files_num--;
                 struct ps_property_dim *d = pd;
                 pd = pd->next;
@@ -89,7 +89,7 @@ void power_supply_free(struct power_supply *ps) {
             }
 
             // free properties
-            if(likely(pr->st)) rrdset_is_obsolete(pr->st);
+            if(pr->st) rrdset_is_obsolete(pr->st);
             freez(pr->name);
             freez(pr->title);
             freez(pr->units);
@@ -99,13 +99,13 @@ void power_supply_free(struct power_supply *ps) {
         }
 
         // remove power supply from linked list
-        if(likely(ps == power_supply_root)) {
+        if(ps == power_supply_root) {
             power_supply_root = ps->next;
         }
         else {
             struct power_supply *last;
             for(last = power_supply_root; last && last->next != ps; last = last->next);
-            if(likely(last)) last->next = ps->next;
+            if(last) last->next = ps->next;
         }
 
         freez(ps);
@@ -122,7 +122,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
     static int keep_fds_open = CONFIG_BOOLEAN_NO, keep_fds_open_config = -1;
     static char *dirname = NULL;
 
-    if(unlikely(do_capacity == -1)) {
+    if(do_capacity == -1) {
         do_capacity    = config_get_boolean("plugin:proc:/sys/class/power_supply", "battery capacity", CONFIG_BOOLEAN_YES);
         do_property[0] = config_get_boolean("plugin:proc:/sys/class/power_supply", "battery charge", CONFIG_BOOLEAN_NO);
         do_property[1] = config_get_boolean("plugin:proc:/sys/class/power_supply", "battery energy", CONFIG_BOOLEAN_NO);
@@ -136,33 +136,33 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
     }
 
     DIR *dir = opendir(dirname);
-    if(unlikely(!dir)) {
+    if(!dir) {
         collector_error("Cannot read directory '%s'", dirname);
         return 1;
     }
 
     struct dirent *de = NULL;
-    while(likely(de = readdir(dir))) {
-        if(likely(de->d_type == DT_DIR
+    while(de = readdir(dir)) {
+        if(de->d_type == DT_DIR
             && (
                 (de->d_name[0] == '.' && de->d_name[1] == '\0')
                 || (de->d_name[0] == '.' && de->d_name[1] == '.' && de->d_name[2] == '\0')
-                )))
+                ))
             continue;
 
-        if(likely(de->d_type == DT_LNK || de->d_type == DT_DIR)) {
+        if(de->d_type == DT_LNK || de->d_type == DT_DIR) {
             uint32_t hash = simple_hash(de->d_name);
 
             struct power_supply *ps;
             for(ps = power_supply_root; ps; ps = ps->next) {
-                if(unlikely(ps->hash == hash && !strcmp(ps->name, de->d_name))) {
+                if(ps->hash == hash && !strcmp(ps->name, de->d_name)) {
                     ps->found = 1;
                     break;
                 }
             }
 
             // allocate memory for power supply and initialize it
-            if(unlikely(!ps)) {
+            if(!ps) {
                 ps = callocz(sizeof(struct power_supply), 1);
                 ps->name = strdupz(de->d_name);
                 ps->hash = simple_hash(de->d_name);
@@ -171,7 +171,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                 power_supply_root = ps;
 
                 struct stat stbuf;
-                if(likely(do_capacity != CONFIG_BOOLEAN_NO)) {
+                if(do_capacity != CONFIG_BOOLEAN_NO) {
                     char filename[FILENAME_MAX + 1];
                     snprintfz(filename, FILENAME_MAX, "%s/%s/%s", dirname, de->d_name, "capacity");
                     if (stat(filename, &stbuf) == 0) {
@@ -187,7 +187,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                 size_t prev_idx = 3; // there is no property with this index
 
                 for(pr_idx = 0; pr_idx < 3; pr_idx++) {
-                    if(unlikely(do_property[pr_idx] != CONFIG_BOOLEAN_NO)) {
+                    if(do_property[pr_idx] != CONFIG_BOOLEAN_NO) {
                         struct ps_property *pr = NULL;
                         int min_value_found = 0, max_value_found = 0;
 
@@ -199,13 +199,13 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                                       ps_property_names[pr_idx], ps_property_dim_names[pd_idx]);
                             if (stat(filename, &stbuf) == 0) {
 
-                                if(unlikely(pd_idx == pr_idx * 5 + 1))
+                                if(pd_idx == pr_idx * 5 + 1)
                                     min_value_found = 1;
-                                if(unlikely(pd_idx == pr_idx * 5 + 3))
+                                if(pd_idx == pr_idx * 5 + 3)
                                     max_value_found = 1;
 
                                 // add chart
-                                if(unlikely(prev_idx != pr_idx)) {
+                                if(prev_idx != pr_idx) {
                                     pr = callocz(sizeof(struct ps_property), 1);
                                     pr->name = strdupz(ps_property_names[pr_idx]);
                                     pr->title = strdupz(ps_property_titles[pr_idx]);
@@ -228,7 +228,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                         }
 
                         // create a zero empty/min dimension
-                        if(unlikely(max_value_found && !min_value_found)) {
+                        if(max_value_found && !min_value_found) {
                             struct ps_property_dim *pd;
                             pd= callocz(sizeof(struct ps_property_dim), 1);
                             pd->name = strdupz(ps_property_dim_names[pr_idx * 5 + 1]);
@@ -241,12 +241,12 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
             }
 
             // read capacity file
-            if(likely(ps->capacity)) {
+            if(ps->capacity) {
                 char buffer[30 + 1];
 
-                if(unlikely(ps->capacity->fd == -1)) {
+                if(ps->capacity->fd == -1) {
                     ps->capacity->fd = open(ps->capacity->filename, O_RDONLY, 0666);
-                    if(unlikely(ps->capacity->fd == -1)) {
+                    if(ps->capacity->fd == -1) {
                         collector_error("Cannot open file '%s'", ps->capacity->filename);
                         power_supply_free(ps);
                         ps = NULL;
@@ -256,7 +256,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                 if (ps)
                 {
                     ssize_t r = read(ps->capacity->fd, buffer, 30);
-                    if(unlikely(r < 1)) {
+                    if(r < 1) {
                         collector_error("Cannot read file '%s'", ps->capacity->filename);
                         power_supply_free(ps);
                         ps = NULL;
@@ -265,11 +265,11 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                         buffer[r] = '\0';
                         ps->capacity->value = str2ull(buffer, NULL);
 
-                        if(unlikely(!keep_fds_open)) {
+                        if(!keep_fds_open) {
                             close(ps->capacity->fd);
                             ps->capacity->fd = -1;
                         }
-                        else if(unlikely(lseek(ps->capacity->fd, 0, SEEK_SET) == -1)) {
+                        else if(lseek(ps->capacity->fd, 0, SEEK_SET) == -1) {
                             collector_error("Cannot seek in file '%s'", ps->capacity->filename);
                             close(ps->capacity->fd);
                             ps->capacity->fd = -1;
@@ -286,12 +286,12 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                 for(pr = ps->property_root; pr && !read_error; pr = pr->next) {
                     struct ps_property_dim *pd;
                     for(pd = pr->property_dim_root; pd; pd = pd->next) {
-                        if(likely(!pd->always_zero)) {
+                        if(!pd->always_zero) {
                             char buffer[30 + 1];
 
-                            if(unlikely(pd->fd == -1)) {
+                            if(pd->fd == -1) {
                                 pd->fd = open(pd->filename, O_RDONLY, 0666);
-                                if(unlikely(pd->fd == -1)) {
+                                if(pd->fd == -1) {
                                     collector_error("Cannot open file '%s'", pd->filename);
                                     read_error = 1;
                                     power_supply_free(ps);
@@ -300,7 +300,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                             }
 
                             ssize_t r = read(pd->fd, buffer, 30);
-                            if(unlikely(r < 1)) {
+                            if(r < 1) {
                                 collector_error("Cannot read file '%s'", pd->filename);
                                 read_error = 1;
                                 power_supply_free(ps);
@@ -309,11 +309,11 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                             buffer[r] = '\0';
                             pd->value = str2ull(buffer, NULL);
 
-                            if(unlikely(!keep_fds_open)) {
+                            if(!keep_fds_open) {
                                 close(pd->fd);
                                 pd->fd = -1;
                             }
-                            else if(unlikely(lseek(pd->fd, 0, SEEK_SET) == -1)) {
+                            else if(lseek(pd->fd, 0, SEEK_SET) == -1) {
                                 collector_error("Cannot seek in file '%s'", pd->filename);
                                 close(pd->fd);
                                 pd->fd = -1;
@@ -328,8 +328,8 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
     closedir(dir);
 
     keep_fds_open = keep_fds_open_config;
-    if(likely(keep_fds_open_config == CONFIG_BOOLEAN_AUTO)) {
-        if(unlikely(files_num > 32))
+    if(keep_fds_open_config == CONFIG_BOOLEAN_AUTO) {
+        if(files_num > 32)
             keep_fds_open = CONFIG_BOOLEAN_NO;
         else
             keep_fds_open = CONFIG_BOOLEAN_YES;
@@ -338,16 +338,16 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
     // --------------------------------------------------------------------
 
     struct power_supply *ps = power_supply_root;
-    while(unlikely(ps)) {
-        if(unlikely(!ps->found)) {
+    while(ps) {
+        if(!ps->found) {
             struct power_supply *f = ps;
             ps = ps->next;
             power_supply_free(f);
             continue;
         }
 
-        if(likely(ps->capacity)) {
-            if(unlikely(!ps->capacity->st)) {
+        if(ps->capacity) {
+            if(!ps->capacity->st) {
                 ps->capacity->st = rrdset_create_localhost(
                         "powersupply_capacity"
                         , ps->name
@@ -366,7 +366,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                 add_labels_to_power_supply(ps, ps->capacity->st);
             }
 
-            if(unlikely(!ps->capacity->rd)) ps->capacity->rd = rrddim_add(ps->capacity->st, "capacity", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            if(!ps->capacity->rd) ps->capacity->rd = rrddim_add(ps->capacity->st, "capacity", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
             rrddim_set_by_pointer(ps->capacity->st, ps->capacity->rd, ps->capacity->value);
 
             rrdset_done(ps->capacity->st);
@@ -374,7 +374,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
 
         struct ps_property *pr;
         for(pr = ps->property_root; pr; pr = pr->next) {
-            if(unlikely(!pr->st)) {
+            if(!pr->st) {
                 char id[RRD_ID_LENGTH_MAX + 1], context[RRD_ID_LENGTH_MAX + 1];
                 snprintfz(id, RRD_ID_LENGTH_MAX, "powersupply_%s", pr->name);
                 snprintfz(context, RRD_ID_LENGTH_MAX, "powersupply.%s", pr->name);
@@ -399,7 +399,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
 
             struct ps_property_dim *pd;
             for(pd = pr->property_dim_root; pd; pd = pd->next) {
-                if(unlikely(!pd->rd)) pd->rd = rrddim_add(pr->st, pd->name, NULL, 1, 1000000, RRD_ALGORITHM_ABSOLUTE);
+                if(!pd->rd) pd->rd = rrddim_add(pr->st, pd->name, NULL, 1, 1000000, RRD_ALGORITHM_ABSOLUTE);
                 rrddim_set_by_pointer(pr->st, pd->rd, pd->value);
             }
 

--- a/collectors/proc.plugin/sys_devices_system_edac_mc.c
+++ b/collectors/proc.plugin/sys_devices_system_edac_mc.c
@@ -29,7 +29,7 @@ static void find_all_mc() {
     char *dirname = config_get("plugin:proc:/sys/devices/system/edac/mc", "directory to monitor", name);
 
     DIR *dir = opendir(dirname);
-    if(unlikely(!dir)) {
+    if(!dir) {
         collector_error("Cannot read ECC memory errors directory '%s'", dirname);
         return;
     }
@@ -67,9 +67,9 @@ static void find_all_mc() {
 int do_proc_sys_devices_system_edac_mc(int update_every, usec_t dt) {
     (void)dt;
 
-    if(unlikely(mc_root == NULL)) {
+    if(mc_root == NULL) {
         find_all_mc();
-        if(unlikely(mc_root == NULL))
+        if(mc_root == NULL)
             return 1;
     }
 
@@ -77,7 +77,7 @@ int do_proc_sys_devices_system_edac_mc(int update_every, usec_t dt) {
     NETDATA_DOUBLE ce_sum = 0, ue_sum = 0;
     struct mc *m;
 
-    if(unlikely(do_ce == -1)) {
+    if(do_ce == -1) {
         do_ce = config_get_boolean_ondemand("plugin:proc:/sys/devices/system/edac/mc", "enable ECC memory correctable errors", CONFIG_BOOLEAN_YES);
         do_ue = config_get_boolean_ondemand("plugin:proc:/sys/devices/system/edac/mc", "enable ECC memory uncorrectable errors", CONFIG_BOOLEAN_YES);
     }
@@ -87,14 +87,14 @@ int do_proc_sys_devices_system_edac_mc(int update_every, usec_t dt) {
             if(m->ce_count_filename) {
                 m->ce_updated = 0;
 
-                if(unlikely(!m->ce_ff)) {
+                if(!m->ce_ff) {
                     m->ce_ff = procfile_open(m->ce_count_filename, " \t", PROCFILE_FLAG_DEFAULT);
-                    if(unlikely(!m->ce_ff))
+                    if(!m->ce_ff)
                         continue;
                 }
 
                 m->ce_ff = procfile_readall(m->ce_ff);
-                if(unlikely(!m->ce_ff || procfile_lines(m->ce_ff) < 1 || procfile_linewords(m->ce_ff, 0) < 1))
+                if(!m->ce_ff || procfile_lines(m->ce_ff) < 1 || procfile_linewords(m->ce_ff, 0) < 1)
                     continue;
 
                 m->ce_count = str2ull(procfile_lineword(m->ce_ff, 0, 0), NULL);
@@ -109,14 +109,14 @@ int do_proc_sys_devices_system_edac_mc(int update_every, usec_t dt) {
             if(m->ue_count_filename) {
                 m->ue_updated = 0;
 
-                if(unlikely(!m->ue_ff)) {
+                if(!m->ue_ff) {
                     m->ue_ff = procfile_open(m->ue_count_filename, " \t", PROCFILE_FLAG_DEFAULT);
-                    if(unlikely(!m->ue_ff))
+                    if(!m->ue_ff)
                         continue;
                 }
 
                 m->ue_ff = procfile_readall(m->ue_ff);
-                if(unlikely(!m->ue_ff || procfile_lines(m->ue_ff) < 1 || procfile_linewords(m->ue_ff, 0) < 1))
+                if(!m->ue_ff || procfile_lines(m->ue_ff) < 1 || procfile_linewords(m->ue_ff, 0) < 1)
                     continue;
 
                 m->ue_count = str2ull(procfile_lineword(m->ue_ff, 0, 0), NULL);
@@ -134,7 +134,7 @@ int do_proc_sys_devices_system_edac_mc(int update_every, usec_t dt) {
 
         static RRDSET *ce_st = NULL;
 
-        if(unlikely(!ce_st)) {
+        if(!ce_st) {
             ce_st = rrdset_create_localhost(
                     "mem"
                     , "ecc_ce"
@@ -153,7 +153,7 @@ int do_proc_sys_devices_system_edac_mc(int update_every, usec_t dt) {
 
         for(m = mc_root; m; m = m->next) {
             if (m->ce_count_filename && m->ce_updated) {
-                if(unlikely(!m->ce_rd))
+                if(!m->ce_rd)
                     m->ce_rd = rrddim_add(ce_st, m->name, NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
                 rrddim_set_by_pointer(ce_st, m->ce_rd, m->ce_count);
@@ -171,7 +171,7 @@ int do_proc_sys_devices_system_edac_mc(int update_every, usec_t dt) {
 
         static RRDSET *ue_st = NULL;
 
-        if(unlikely(!ue_st)) {
+        if(!ue_st) {
             ue_st = rrdset_create_localhost(
                     "mem"
                     , "ecc_ue"
@@ -190,7 +190,7 @@ int do_proc_sys_devices_system_edac_mc(int update_every, usec_t dt) {
 
         for(m = mc_root; m; m = m->next) {
             if (m->ue_count_filename && m->ue_updated) {
-                if(unlikely(!m->ue_rd))
+                if(!m->ue_rd)
                     m->ue_rd = rrddim_add(ue_st, m->name, NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
                 rrddim_set_by_pointer(ue_st, m->ue_rd, m->ue_count);

--- a/collectors/proc.plugin/sys_devices_system_node.c
+++ b/collectors/proc.plugin/sys_devices_system_node.c
@@ -66,13 +66,13 @@ int do_proc_sys_devices_system_node(int update_every, usec_t dt) {
     static int do_numastat = -1, numa_node_count = 0;
     struct node *m;
 
-    if(unlikely(numa_root == NULL)) {
+    if(numa_root == NULL) {
         numa_node_count = find_all_nodes();
-        if(unlikely(numa_root == NULL))
+        if(numa_root == NULL)
             return 1;
     }
 
-    if(unlikely(do_numastat == -1)) {
+    if(do_numastat == -1) {
         do_numastat = config_get_boolean_ondemand("plugin:proc:/sys/devices/system/node", "enable per-node numa metrics", CONFIG_BOOLEAN_AUTO);
 
         hash_local_node     = simple_hash("local_node");
@@ -88,18 +88,18 @@ int do_proc_sys_devices_system_node(int update_every, usec_t dt) {
         for(m = numa_root; m; m = m->next) {
             if(m->numastat_filename) {
 
-                if(unlikely(!m->numastat_ff)) {
+                if(!m->numastat_ff) {
                     m->numastat_ff = procfile_open(m->numastat_filename, " ", PROCFILE_FLAG_DEFAULT);
 
-                    if(unlikely(!m->numastat_ff))
+                    if(!m->numastat_ff)
                         continue;
                 }
 
                 m->numastat_ff = procfile_readall(m->numastat_ff);
-                if(unlikely(!m->numastat_ff || procfile_lines(m->numastat_ff) < 1 || procfile_linewords(m->numastat_ff, 0) < 1))
+                if(!m->numastat_ff || procfile_lines(m->numastat_ff) < 1 || procfile_linewords(m->numastat_ff, 0) < 1)
                     continue;
 
-                if(unlikely(!m->numastat_st)) {
+                if(!m->numastat_st) {
                     m->numastat_st = rrdset_create_localhost(
                             "mem"
                             , m->name
@@ -132,8 +132,8 @@ int do_proc_sys_devices_system_node(int update_every, usec_t dt) {
                 for(l = 0; l < lines; l++) {
                     size_t words = procfile_linewords(m->numastat_ff, l);
 
-                    if(unlikely(words < 2)) {
-                        if(unlikely(words))
+                    if(words < 2) {
+                        if(words)
                             collector_error("Cannot read %s numastat line %zu. Expected 2 params, read %zu.", m->name, l, words);
                         continue;
                     }
@@ -141,18 +141,18 @@ int do_proc_sys_devices_system_node(int update_every, usec_t dt) {
                     char *name  = procfile_lineword(m->numastat_ff, l, 0);
                     char *value = procfile_lineword(m->numastat_ff, l, 1);
 
-                    if (unlikely(!name || !*name || !value || !*value))
+                    if (!name || !*name || !value || !*value)
                         continue;
 
                     uint32_t hash = simple_hash(name);
-                    if(likely(
+                    if(
                                (hash == hash_numa_hit       && !strcmp(name, "numa_hit"))
                             || (hash == hash_numa_miss      && !strcmp(name, "numa_miss"))
                             || (hash == hash_local_node     && !strcmp(name, "local_node"))
                             || (hash == hash_numa_foreign   && !strcmp(name, "numa_foreign"))
                             || (hash == hash_interleave_hit && !strcmp(name, "interleave_hit"))
                             || (hash == hash_other_node     && !strcmp(name, "other_node"))
-                    ))
+                    )
                         rrddim_set(m->numastat_st, name, (collected_number)str2kernel_uint_t(value));
                 }
 

--- a/collectors/proc.plugin/sys_kernel_mm_ksm.c
+++ b/collectors/proc.plugin/sys_kernel_mm_ksm.c
@@ -28,68 +28,68 @@ int do_sys_kernel_mm_ksm(int update_every, usec_t dt) {
     static procfile *ff_pages_shared = NULL, *ff_pages_sharing = NULL, *ff_pages_unshared = NULL, *ff_pages_volatile = NULL/*, *ff_pages_to_scan = NULL*/;
     static unsigned long page_size = 0;
 
-    if(unlikely(page_size == 0))
+    if(page_size == 0)
         page_size = (unsigned long)sysconf(_SC_PAGESIZE);
 
-    if(unlikely(!ff_pages_shared)) {
+    if(!ff_pages_shared) {
         snprintfz(values[PAGES_SHARED].filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/kernel/mm/ksm/pages_shared");
         snprintfz(values[PAGES_SHARED].filename, FILENAME_MAX, "%s", config_get("plugin:proc:/sys/kernel/mm/ksm", "/sys/kernel/mm/ksm/pages_shared", values[PAGES_SHARED].filename));
         ff_pages_shared = procfile_open(values[PAGES_SHARED].filename, " \t:", PROCFILE_FLAG_DEFAULT);
     }
 
-    if(unlikely(!ff_pages_sharing)) {
+    if(!ff_pages_sharing) {
         snprintfz(values[PAGES_SHARING].filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/kernel/mm/ksm/pages_sharing");
         snprintfz(values[PAGES_SHARING].filename, FILENAME_MAX, "%s", config_get("plugin:proc:/sys/kernel/mm/ksm", "/sys/kernel/mm/ksm/pages_sharing", values[PAGES_SHARING].filename));
         ff_pages_sharing = procfile_open(values[PAGES_SHARING].filename, " \t:", PROCFILE_FLAG_DEFAULT);
     }
 
-    if(unlikely(!ff_pages_unshared)) {
+    if(!ff_pages_unshared) {
         snprintfz(values[PAGES_UNSHARED].filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/kernel/mm/ksm/pages_unshared");
         snprintfz(values[PAGES_UNSHARED].filename, FILENAME_MAX, "%s", config_get("plugin:proc:/sys/kernel/mm/ksm", "/sys/kernel/mm/ksm/pages_unshared", values[PAGES_UNSHARED].filename));
         ff_pages_unshared = procfile_open(values[PAGES_UNSHARED].filename, " \t:", PROCFILE_FLAG_DEFAULT);
     }
 
-    if(unlikely(!ff_pages_volatile)) {
+    if(!ff_pages_volatile) {
         snprintfz(values[PAGES_VOLATILE].filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/kernel/mm/ksm/pages_volatile");
         snprintfz(values[PAGES_VOLATILE].filename, FILENAME_MAX, "%s", config_get("plugin:proc:/sys/kernel/mm/ksm", "/sys/kernel/mm/ksm/pages_volatile", values[PAGES_VOLATILE].filename));
         ff_pages_volatile = procfile_open(values[PAGES_VOLATILE].filename, " \t:", PROCFILE_FLAG_DEFAULT);
     }
 
-    //if(unlikely(!ff_pages_to_scan)) {
+    //if(!ff_pages_to_scan) {
     //    snprintfz(values[PAGES_TO_SCAN].filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/kernel/mm/ksm/pages_to_scan");
     //    snprintfz(values[PAGES_TO_SCAN].filename, FILENAME_MAX, "%s", config_get("plugin:proc:/sys/kernel/mm/ksm", "/sys/kernel/mm/ksm/pages_to_scan", values[PAGES_TO_SCAN].filename));
     //    ff_pages_to_scan = procfile_open(values[PAGES_TO_SCAN].filename, " \t:", PROCFILE_FLAG_DEFAULT);
     //}
 
-    if(unlikely(!ff_pages_shared || !ff_pages_sharing || !ff_pages_unshared || !ff_pages_volatile /*|| !ff_pages_to_scan */))
+    if(!ff_pages_shared || !ff_pages_sharing || !ff_pages_unshared || !ff_pages_volatile /*|| !ff_pages_to_scan */)
         return 1;
 
     unsigned long long pages_shared = 0, pages_sharing = 0, pages_unshared = 0, pages_volatile = 0, /*pages_to_scan = 0,*/ offered = 0, saved = 0;
 
     ff_pages_shared = procfile_readall(ff_pages_shared);
-    if(unlikely(!ff_pages_shared)) return 0; // we return 0, so that we will retry to open it next time
+    if(!ff_pages_shared) return 0; // we return 0, so that we will retry to open it next time
     pages_shared = str2ull(procfile_lineword(ff_pages_shared, 0, 0), NULL);
 
     ff_pages_sharing = procfile_readall(ff_pages_sharing);
-    if(unlikely(!ff_pages_sharing)) return 0; // we return 0, so that we will retry to open it next time
+    if(!ff_pages_sharing) return 0; // we return 0, so that we will retry to open it next time
     pages_sharing = str2ull(procfile_lineword(ff_pages_sharing, 0, 0), NULL);
 
     ff_pages_unshared = procfile_readall(ff_pages_unshared);
-    if(unlikely(!ff_pages_unshared)) return 0; // we return 0, so that we will retry to open it next time
+    if(!ff_pages_unshared) return 0; // we return 0, so that we will retry to open it next time
     pages_unshared = str2ull(procfile_lineword(ff_pages_unshared, 0, 0), NULL);
 
     ff_pages_volatile = procfile_readall(ff_pages_volatile);
-    if(unlikely(!ff_pages_volatile)) return 0; // we return 0, so that we will retry to open it next time
+    if(!ff_pages_volatile) return 0; // we return 0, so that we will retry to open it next time
     pages_volatile = str2ull(procfile_lineword(ff_pages_volatile, 0, 0), NULL);
 
     //ff_pages_to_scan = procfile_readall(ff_pages_to_scan);
-    //if(unlikely(!ff_pages_to_scan)) return 0; // we return 0, so that we will retry to open it next time
+    //if(!ff_pages_to_scan) return 0; // we return 0, so that we will retry to open it next time
     //pages_to_scan = str2ull(procfile_lineword(ff_pages_to_scan, 0, 0));
 
     offered = pages_sharing + pages_shared + pages_unshared + pages_volatile;
     saved = pages_sharing;
 
-    if(unlikely(!offered /*|| !pages_to_scan*/ && netdata_zero_metrics_enabled == CONFIG_BOOLEAN_NO)) return 0;
+    if(!offered /*|| !pages_to_scan*/ && netdata_zero_metrics_enabled == CONFIG_BOOLEAN_NO) return 0;
 
     // --------------------------------------------------------------------
 
@@ -97,7 +97,7 @@ int do_sys_kernel_mm_ksm(int update_every, usec_t dt) {
         static RRDSET *st_mem_ksm = NULL;
         static RRDDIM *rd_shared = NULL, *rd_unshared = NULL, *rd_sharing = NULL, *rd_volatile = NULL/*, *rd_to_scan = NULL*/;
 
-        if (unlikely(!st_mem_ksm)) {
+        if (!st_mem_ksm) {
             st_mem_ksm = rrdset_create_localhost(
                     "mem"
                     , "ksm"
@@ -135,7 +135,7 @@ int do_sys_kernel_mm_ksm(int update_every, usec_t dt) {
         static RRDSET *st_mem_ksm_savings = NULL;
         static RRDDIM *rd_savings = NULL, *rd_offered = NULL;
 
-        if (unlikely(!st_mem_ksm_savings)) {
+        if (!st_mem_ksm_savings) {
             st_mem_ksm_savings = rrdset_create_localhost(
                     "mem"
                     , "ksm_savings"
@@ -167,7 +167,7 @@ int do_sys_kernel_mm_ksm(int update_every, usec_t dt) {
         static RRDSET *st_mem_ksm_ratios = NULL;
         static RRDDIM *rd_savings = NULL;
 
-        if (unlikely(!st_mem_ksm_ratios)) {
+        if (!st_mem_ksm_ratios) {
             st_mem_ksm_ratios = rrdset_create_localhost(
                     "mem"
                     , "ksm_ratios"

--- a/collectors/proc.plugin/zfs_common.c
+++ b/collectors/proc.plugin/zfs_common.c
@@ -8,7 +8,7 @@ void generate_charts_arcstats(const char *plugin, const char *module, int show_z
     static int do_arc_size = -1, do_l2_size = -1, do_reads = -1, do_l2bytes = -1, do_ahits = -1, do_dhits = -1, \
                do_phits = -1, do_mhits = -1, do_l2hits = -1, do_list_hits = -1;
 
-    if(unlikely(do_arc_size == -1))
+    if(do_arc_size == -1)
         do_arc_size = do_l2_size = do_reads = do_l2bytes = do_ahits = do_dhits = do_phits = do_mhits \
         = do_l2hits = do_list_hits = show_zero_charts;
 
@@ -46,7 +46,7 @@ void generate_charts_arcstats(const char *plugin, const char *module, int show_z
         static RRDDIM *rd_arc_target_min_size = NULL;
         static RRDDIM *rd_arc_target_max_size = NULL;
 
-        if (unlikely(!st_arc_size)) {
+        if (!st_arc_size) {
             st_arc_size = rrdset_create_localhost(
                     "zfs"
                     , "arc_size"
@@ -77,14 +77,14 @@ void generate_charts_arcstats(const char *plugin, const char *module, int show_z
 
     // --------------------------------------------------------------------
 
-    if(likely(arcstats.l2exist) && (do_l2_size == CONFIG_BOOLEAN_YES || arcstats.l2_size || arcstats.l2_asize)) {
+    if(arcstats.l2exist && (do_l2_size == CONFIG_BOOLEAN_YES || arcstats.l2_size || arcstats.l2_asize)) {
         do_l2_size = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_l2_size = NULL;
         static RRDDIM *rd_l2_size = NULL;
         static RRDDIM *rd_l2_asize = NULL;
 
-        if (unlikely(!st_l2_size)) {
+        if (!st_l2_size) {
             st_l2_size = rrdset_create_localhost(
                     "zfs"
                     , "l2_size"
@@ -111,7 +111,7 @@ void generate_charts_arcstats(const char *plugin, const char *module, int show_z
 
     // --------------------------------------------------------------------
 
-    if(likely(do_reads == CONFIG_BOOLEAN_YES || aread || dread || pread || mread || l2read)) {
+    if(do_reads == CONFIG_BOOLEAN_YES || aread || dread || pread || mread || l2read) {
         do_reads = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_reads = NULL;
@@ -121,7 +121,7 @@ void generate_charts_arcstats(const char *plugin, const char *module, int show_z
         static RRDDIM *rd_mread = NULL;
         static RRDDIM *rd_l2read = NULL;
 
-        if (unlikely(!st_reads)) {
+        if (!st_reads) {
             st_reads = rrdset_create_localhost(
                     "zfs"
                     , "reads"
@@ -159,14 +159,14 @@ void generate_charts_arcstats(const char *plugin, const char *module, int show_z
 
     // --------------------------------------------------------------------
 
-    if(likely(arcstats.l2exist && (do_l2bytes == CONFIG_BOOLEAN_YES || arcstats.l2_read_bytes || arcstats.l2_write_bytes))) {
+    if(arcstats.l2exist && (do_l2bytes == CONFIG_BOOLEAN_YES || arcstats.l2_read_bytes || arcstats.l2_write_bytes)) {
         do_l2bytes = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_l2bytes = NULL;
         static RRDDIM *rd_l2_read_bytes = NULL;
         static RRDDIM *rd_l2_write_bytes = NULL;
 
-        if (unlikely(!st_l2bytes)) {
+        if (!st_l2bytes) {
             st_l2bytes = rrdset_create_localhost(
                     "zfs"
                     , "bytes"
@@ -193,14 +193,14 @@ void generate_charts_arcstats(const char *plugin, const char *module, int show_z
 
     // --------------------------------------------------------------------
 
-    if(likely(do_ahits == CONFIG_BOOLEAN_YES || arcstats.hits || arcstats.misses)) {
+    if(do_ahits == CONFIG_BOOLEAN_YES || arcstats.hits || arcstats.misses) {
         do_ahits = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_ahits = NULL;
         static RRDDIM *rd_ahits = NULL;
         static RRDDIM *rd_amisses = NULL;
 
-        if (unlikely(!st_ahits)) {
+        if (!st_ahits) {
             st_ahits = rrdset_create_localhost(
                     "zfs"
                     , "hits"
@@ -228,7 +228,7 @@ void generate_charts_arcstats(const char *plugin, const char *module, int show_z
         static RRDDIM *rd_ahits_rate = NULL;
         static RRDDIM *rd_amisses_rate = NULL;
 
-        if (unlikely(!st_ahits_rate)) {
+        if (!st_ahits_rate) {
             st_ahits_rate = rrdset_create_localhost(
                     "zfs"
                     , "hits_rate"
@@ -255,14 +255,14 @@ void generate_charts_arcstats(const char *plugin, const char *module, int show_z
 
     // --------------------------------------------------------------------
 
-    if(likely(do_dhits == CONFIG_BOOLEAN_YES || dhit || dmiss)) {
+    if(do_dhits == CONFIG_BOOLEAN_YES || dhit || dmiss) {
         do_dhits = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_dhits = NULL;
         static RRDDIM *rd_dhits = NULL;
         static RRDDIM *rd_dmisses = NULL;
 
-        if (unlikely(!st_dhits)) {
+        if (!st_dhits) {
             st_dhits = rrdset_create_localhost(
                     "zfs"
                     , "dhits"
@@ -290,7 +290,7 @@ void generate_charts_arcstats(const char *plugin, const char *module, int show_z
         static RRDDIM *rd_dhits_rate = NULL;
         static RRDDIM *rd_dmisses_rate = NULL;
 
-        if (unlikely(!st_dhits_rate)) {
+        if (!st_dhits_rate) {
             st_dhits_rate = rrdset_create_localhost(
                     "zfs"
                     , "dhits_rate"
@@ -317,14 +317,14 @@ void generate_charts_arcstats(const char *plugin, const char *module, int show_z
 
     // --------------------------------------------------------------------
 
-    if(likely(do_phits == CONFIG_BOOLEAN_YES || phit || pmiss)) {
+    if(do_phits == CONFIG_BOOLEAN_YES || phit || pmiss) {
         do_phits = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_phits = NULL;
         static RRDDIM *rd_phits = NULL;
         static RRDDIM *rd_pmisses = NULL;
 
-        if (unlikely(!st_phits)) {
+        if (!st_phits) {
             st_phits = rrdset_create_localhost(
                     "zfs"
                     , "phits"
@@ -352,7 +352,7 @@ void generate_charts_arcstats(const char *plugin, const char *module, int show_z
         static RRDDIM *rd_phits_rate = NULL;
         static RRDDIM *rd_pmisses_rate = NULL;
 
-        if (unlikely(!st_phits_rate)) {
+        if (!st_phits_rate) {
             st_phits_rate = rrdset_create_localhost(
                     "zfs"
                     , "phits_rate"
@@ -379,14 +379,14 @@ void generate_charts_arcstats(const char *plugin, const char *module, int show_z
 
     // --------------------------------------------------------------------
 
-    if(likely(do_mhits == CONFIG_BOOLEAN_YES || mhit || mmiss)) {
+    if(do_mhits == CONFIG_BOOLEAN_YES || mhit || mmiss) {
         do_mhits = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_mhits = NULL;
         static RRDDIM *rd_mhits = NULL;
         static RRDDIM *rd_mmisses = NULL;
 
-        if (unlikely(!st_mhits)) {
+        if (!st_mhits) {
             st_mhits = rrdset_create_localhost(
                     "zfs"
                     , "mhits"
@@ -414,7 +414,7 @@ void generate_charts_arcstats(const char *plugin, const char *module, int show_z
         static RRDDIM *rd_mhits_rate = NULL;
         static RRDDIM *rd_mmisses_rate = NULL;
 
-        if (unlikely(!st_mhits_rate)) {
+        if (!st_mhits_rate) {
             st_mhits_rate = rrdset_create_localhost(
                     "zfs"
                     , "mhits_rate"
@@ -441,14 +441,14 @@ void generate_charts_arcstats(const char *plugin, const char *module, int show_z
 
     // --------------------------------------------------------------------
 
-    if(likely(arcstats.l2exist && (do_l2hits == CONFIG_BOOLEAN_YES || l2hit || l2miss))) {
+    if(arcstats.l2exist && (do_l2hits == CONFIG_BOOLEAN_YES || l2hit || l2miss)) {
         do_l2hits = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_l2hits = NULL;
         static RRDDIM *rd_l2hits = NULL;
         static RRDDIM *rd_l2misses = NULL;
 
-        if (unlikely(!st_l2hits)) {
+        if (!st_l2hits) {
             st_l2hits = rrdset_create_localhost(
                     "zfs"
                     , "l2hits"
@@ -476,7 +476,7 @@ void generate_charts_arcstats(const char *plugin, const char *module, int show_z
         static RRDDIM *rd_l2hits_rate = NULL;
         static RRDDIM *rd_l2misses_rate = NULL;
 
-        if (unlikely(!st_l2hits_rate)) {
+        if (!st_l2hits_rate) {
             st_l2hits_rate = rrdset_create_localhost(
                     "zfs"
                     , "l2hits_rate"
@@ -503,10 +503,10 @@ void generate_charts_arcstats(const char *plugin, const char *module, int show_z
 
     // --------------------------------------------------------------------
 
-    if(likely(do_list_hits == CONFIG_BOOLEAN_YES || arcstats.mfu_hits \
+    if(do_list_hits == CONFIG_BOOLEAN_YES || arcstats.mfu_hits \
                                                  || arcstats.mru_hits \
                                                  || arcstats.mfu_ghost_hits \
-                                                 || arcstats.mru_ghost_hits)) {
+                                                 || arcstats.mru_ghost_hits) {
         do_list_hits = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_list_hits = NULL;
@@ -515,7 +515,7 @@ void generate_charts_arcstats(const char *plugin, const char *module, int show_z
         static RRDDIM *rd_mfug = NULL;
         static RRDDIM *rd_mrug = NULL;
 
-        if (unlikely(!st_list_hits)) {
+        if (!st_list_hits) {
             st_list_hits = rrdset_create_localhost(
                     "zfs"
                     , "list_hits"
@@ -549,7 +549,7 @@ void generate_charts_arc_summary(const char *plugin, const char *module, int sho
     static int do_arc_size_breakdown = -1, do_memory = -1, do_important_ops = -1, do_actual_hits = -1, \
                do_demand_data_hits = -1, do_prefetch_data_hits = -1, do_hash_elements = -1, do_hash_chains = -1;
 
-    if(unlikely(do_arc_size_breakdown == -1))
+    if(do_arc_size_breakdown == -1)
         do_arc_size_breakdown = do_memory = do_important_ops = do_actual_hits = do_demand_data_hits \
         = do_prefetch_data_hits = do_hash_elements = do_hash_chains = show_zero_charts;
 
@@ -574,14 +574,14 @@ void generate_charts_arc_summary(const char *plugin, const char *module, int sho
 
     // --------------------------------------------------------------------
 
-    if(likely(do_arc_size_breakdown == CONFIG_BOOLEAN_YES || mru_size || mfu_size)) {
+    if(do_arc_size_breakdown == CONFIG_BOOLEAN_YES || mru_size || mfu_size) {
         do_arc_size_breakdown = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_arc_size_breakdown = NULL;
         static RRDDIM *rd_most_recent = NULL;
         static RRDDIM *rd_most_frequent = NULL;
 
-        if (unlikely(!st_arc_size_breakdown)) {
+        if (!st_arc_size_breakdown) {
             st_arc_size_breakdown = rrdset_create_localhost(
                     "zfs"
                     , "arc_size_breakdown"
@@ -608,9 +608,9 @@ void generate_charts_arc_summary(const char *plugin, const char *module, int sho
 
     // --------------------------------------------------------------------
 
-    if(likely(do_memory == CONFIG_BOOLEAN_YES || arcstats.memory_direct_count \
+    if(do_memory == CONFIG_BOOLEAN_YES || arcstats.memory_direct_count \
                                               || arcstats.memory_throttle_count \
-                                              || arcstats.memory_indirect_count)) {
+                                              || arcstats.memory_indirect_count) {
         do_memory = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_memory = NULL;
@@ -622,7 +622,7 @@ void generate_charts_arc_summary(const char *plugin, const char *module, int sho
         static RRDDIM *rd_indirect = NULL;
 #endif
 
-        if (unlikely(!st_memory)) {
+        if (!st_memory) {
             st_memory = rrdset_create_localhost(
                     "zfs"
                     , "memory_ops"
@@ -659,10 +659,10 @@ void generate_charts_arc_summary(const char *plugin, const char *module, int sho
 
     // --------------------------------------------------------------------
 
-    if(likely(do_important_ops == CONFIG_BOOLEAN_YES || arcstats.deleted \
+    if(do_important_ops == CONFIG_BOOLEAN_YES || arcstats.deleted \
                                                      || arcstats.evict_skip \
                                                      || arcstats.mutex_miss \
-                                                     || arcstats.hash_collisions)) {
+                                                     || arcstats.hash_collisions) {
         do_important_ops = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_important_ops = NULL;
@@ -671,7 +671,7 @@ void generate_charts_arc_summary(const char *plugin, const char *module, int sho
         static RRDDIM *rd_evict_skips = NULL;
         static RRDDIM *rd_hash_collisions = NULL;
 
-        if (unlikely(!st_important_ops)) {
+        if (!st_important_ops) {
             st_important_ops = rrdset_create_localhost(
                     "zfs"
                     , "important_ops"
@@ -702,14 +702,14 @@ void generate_charts_arc_summary(const char *plugin, const char *module, int sho
 
     // --------------------------------------------------------------------
 
-    if(likely(do_actual_hits == CONFIG_BOOLEAN_YES || real_hits || real_misses)) {
+    if(do_actual_hits == CONFIG_BOOLEAN_YES || real_hits || real_misses) {
         do_actual_hits = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_actual_hits = NULL;
         static RRDDIM *rd_actual_hits = NULL;
         static RRDDIM *rd_actual_misses = NULL;
 
-        if (unlikely(!st_actual_hits)) {
+        if (!st_actual_hits) {
             st_actual_hits = rrdset_create_localhost(
                     "zfs"
                     , "actual_hits"
@@ -737,7 +737,7 @@ void generate_charts_arc_summary(const char *plugin, const char *module, int sho
         static RRDDIM *rd_actual_hits_rate = NULL;
         static RRDDIM *rd_actual_misses_rate = NULL;
 
-        if (unlikely(!st_actual_hits_rate)) {
+        if (!st_actual_hits_rate) {
             st_actual_hits_rate = rrdset_create_localhost(
                     "zfs"
                     , "actual_hits_rate"
@@ -764,14 +764,14 @@ void generate_charts_arc_summary(const char *plugin, const char *module, int sho
 
     // --------------------------------------------------------------------
 
-    if(likely(do_demand_data_hits == CONFIG_BOOLEAN_YES || arcstats.demand_data_hits || arcstats.demand_data_misses)) {
+    if(do_demand_data_hits == CONFIG_BOOLEAN_YES || arcstats.demand_data_hits || arcstats.demand_data_misses) {
         do_demand_data_hits = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_demand_data_hits = NULL;
         static RRDDIM *rd_demand_data_hits = NULL;
         static RRDDIM *rd_demand_data_misses = NULL;
 
-        if (unlikely(!st_demand_data_hits)) {
+        if (!st_demand_data_hits) {
             st_demand_data_hits = rrdset_create_localhost(
                     "zfs"
                     , "demand_data_hits"
@@ -799,7 +799,7 @@ void generate_charts_arc_summary(const char *plugin, const char *module, int sho
         static RRDDIM *rd_demand_data_hits_rate = NULL;
         static RRDDIM *rd_demand_data_misses_rate = NULL;
 
-        if (unlikely(!st_demand_data_hits_rate)) {
+        if (!st_demand_data_hits_rate) {
             st_demand_data_hits_rate = rrdset_create_localhost(
                     "zfs"
                     , "demand_data_hits_rate"
@@ -826,15 +826,15 @@ void generate_charts_arc_summary(const char *plugin, const char *module, int sho
 
     // --------------------------------------------------------------------
 
-    if(likely(do_prefetch_data_hits == CONFIG_BOOLEAN_YES || arcstats.prefetch_data_hits \
-                                                          || arcstats.prefetch_data_misses)) {
+    if(do_prefetch_data_hits == CONFIG_BOOLEAN_YES || arcstats.prefetch_data_hits \
+                                                          || arcstats.prefetch_data_misses) {
         do_prefetch_data_hits = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_prefetch_data_hits = NULL;
         static RRDDIM *rd_prefetch_data_hits = NULL;
         static RRDDIM *rd_prefetch_data_misses = NULL;
 
-        if (unlikely(!st_prefetch_data_hits)) {
+        if (!st_prefetch_data_hits) {
             st_prefetch_data_hits = rrdset_create_localhost(
                     "zfs"
                     , "prefetch_data_hits"
@@ -862,7 +862,7 @@ void generate_charts_arc_summary(const char *plugin, const char *module, int sho
         static RRDDIM *rd_prefetch_data_hits_rate = NULL;
         static RRDDIM *rd_prefetch_data_misses_rate = NULL;
 
-        if (unlikely(!st_prefetch_data_hits_rate)) {
+        if (!st_prefetch_data_hits_rate) {
             st_prefetch_data_hits_rate = rrdset_create_localhost(
                     "zfs"
                     , "prefetch_data_hits_rate"
@@ -889,14 +889,14 @@ void generate_charts_arc_summary(const char *plugin, const char *module, int sho
 
     // --------------------------------------------------------------------
 
-    if(likely(do_hash_elements == CONFIG_BOOLEAN_YES || arcstats.hash_elements || arcstats.hash_elements_max)) {
+    if(do_hash_elements == CONFIG_BOOLEAN_YES || arcstats.hash_elements || arcstats.hash_elements_max) {
         do_hash_elements = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_hash_elements = NULL;
         static RRDDIM *rd_hash_elements_current = NULL;
         static RRDDIM *rd_hash_elements_max = NULL;
 
-        if (unlikely(!st_hash_elements)) {
+        if (!st_hash_elements) {
             st_hash_elements = rrdset_create_localhost(
                     "zfs"
                     , "hash_elements"
@@ -923,14 +923,14 @@ void generate_charts_arc_summary(const char *plugin, const char *module, int sho
 
     // --------------------------------------------------------------------
 
-    if(likely(do_hash_chains == CONFIG_BOOLEAN_YES || arcstats.hash_chains || arcstats.hash_chain_max)) {
+    if(do_hash_chains == CONFIG_BOOLEAN_YES || arcstats.hash_chains || arcstats.hash_chain_max) {
         do_hash_chains = CONFIG_BOOLEAN_YES;
 
         static RRDSET *st_hash_chains = NULL;
         static RRDDIM *rd_hash_chains_current = NULL;
         static RRDDIM *rd_hash_chains_max = NULL;
 
-        if (unlikely(!st_hash_chains)) {
+        if (!st_hash_chains) {
             st_hash_chains = rrdset_create_localhost(
                     "zfs"
                     , "hash_chains"

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -134,21 +134,21 @@ struct slabinfo *read_file_slabinfo() {
     static procfile *ff = NULL;
     static long slab_pagesize = 0;
 
-    if (unlikely(!slab_pagesize)) {
+    if (!slab_pagesize) {
         slab_pagesize = sysconf(_SC_PAGESIZE);
         slabdebug("   Discovered pagesize: %ld", slab_pagesize);
     }
 
-    if(unlikely(!ff)) {
+    if(!ff) {
         ff = procfile_reopen(ff, PLUGIN_SLABINFO_PROCFILE, " ,:" , PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!ff)) {
+        if(!ff) {
             collector_error("<- Cannot open file '%s", PLUGIN_SLABINFO_PROCFILE);
             exit(1);
         }
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff)) {
+    if(!ff) {
         collector_error("<- Cannot read file '%s'", PLUGIN_SLABINFO_PROCFILE);
         exit(0);
     }
@@ -156,14 +156,14 @@ struct slabinfo *read_file_slabinfo() {
 
     // Iterate on all lines to populate / update the slabinfo struct
     size_t lines = procfile_lines(ff), l;
-    if (unlikely(lines != lines_discovered)) {
+    if (lines != lines_discovered) {
         lines_discovered = lines;
         redraw_chart = 1;
     }
 
     slabdebug("   Read %lu lines from procfile", (unsigned long)lines);
     for(l = 2; l < lines; l++) {
-        if (unlikely(procfile_linewords(ff, l) < 14)) {
+        if (procfile_linewords(ff, l) < 14) {
             slabdebug("    Line %zu has only %zu words, skipping", l, procfile_linewords(ff,l));
             continue;
         }
@@ -227,7 +227,7 @@ unsigned int do_slab_stats(int update_every) {
         sactive = read_file_slabinfo();
 
         // Init Charts
-        if (unlikely(redraw_chart)) {
+        if (redraw_chart) {
             redraw_chart = 0;
             // Memory Usage
             printf("CHART %s.%s '' 'Memory Usage' 'B' '%s' '' line %d %d %s\n"

--- a/collectors/timex.plugin/plugin_timex.c
+++ b/collectors/timex.plugin/plugin_timex.c
@@ -56,7 +56,7 @@ void *timex_main(void *ptr)
     int do_sync = config_get_boolean(CONFIG_SECTION_TIMEX, "clock synchronization state", CONFIG_BOOLEAN_YES);
     int do_offset = config_get_boolean(CONFIG_SECTION_TIMEX, "time offset", CONFIG_BOOLEAN_YES);
 
-    if (unlikely(do_sync == CONFIG_BOOLEAN_NO && do_offset == CONFIG_BOOLEAN_NO)) {
+    if (do_sync == CONFIG_BOOLEAN_NO && do_offset == CONFIG_BOOLEAN_NO) {
         netdata_log_info("No charts to show");
         goto exit;
     }
@@ -93,7 +93,7 @@ void *timex_main(void *ptr)
             static RRDSET *st_sync_state = NULL;
             static RRDDIM *rd_sync_state;
 
-            if (unlikely(!st_sync_state)) {
+            if (!st_sync_state) {
                 st_sync_state = rrdset_create_localhost(
                     "system",
                     "clock_sync_state",
@@ -116,7 +116,7 @@ void *timex_main(void *ptr)
 
             static RRDSET *st_clock_status = NULL;
 
-            if (unlikely(!st_clock_status)) {
+            if (!st_clock_status) {
                 st_clock_status = rrdset_create_localhost(
                     "system",
                     "clock_status",
@@ -147,7 +147,7 @@ void *timex_main(void *ptr)
             static RRDSET *st_offset = NULL;
             static RRDDIM *rd_offset;
 
-            if (unlikely(!st_offset)) {
+            if (!st_offset) {
                 st_offset = rrdset_create_localhost(
                     "system",
                     "clock_sync_offset",

--- a/collectors/xenstat.plugin/xenstat_plugin.c
+++ b/collectors/xenstat.plugin/xenstat_plugin.c
@@ -143,17 +143,17 @@ static struct node_metrics node_metrics = {
 static inline struct domain_metrics *domain_metrics_get(const char *uuid, uint32_t hash) {
     struct domain_metrics *d = NULL, *last = NULL;
     for(d = node_metrics.domain_root; d ; last = d, d = d->next) {
-        if(unlikely(d->hash == hash && !strcmp(d->uuid, uuid)))
+        if(d->hash == hash && !strcmp(d->uuid, uuid))
             return d;
     }
 
-    if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: allocating memory for domain with uuid %s\n", uuid);
+    if(debug) fprintf(stderr, "xenstat.plugin: allocating memory for domain with uuid %s\n", uuid);
 
     d = callocz(1, sizeof(struct domain_metrics));
     d->uuid = strdupz(uuid);
     d->hash = hash;
 
-    if(unlikely(!last)) {
+    if(!last) {
         d->next = node_metrics.domain_root;
         node_metrics.domain_root = d;
     }
@@ -171,18 +171,18 @@ static struct domain_metrics *domain_metrics_free(struct domain_metrics *d) {
     struct vbd_metrics *vbd, *vbd_f;
     struct network_metrics *network, *network_f;
 
-    if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: freeing memory for domain '%s' id %u, uuid %s\n", d->name, d->id, d->uuid);
+    if(debug) fprintf(stderr, "xenstat.plugin: freeing memory for domain '%s' id %u, uuid %s\n", d->name, d->id, d->uuid);
 
     for(cur = node_metrics.domain_root; cur ; last = cur, cur = cur->next) {
-        if(unlikely(cur->hash == d->hash && !strcmp(cur->uuid, d->uuid))) break;
+        if(cur->hash == d->hash && !strcmp(cur->uuid, d->uuid)) break;
     }
 
-    if(unlikely(!cur)) {
+    if(!cur) {
         netdata_log_error("XENSTAT: failed to free domain metrics.");
         return NULL;
     }
 
-    if(likely(last))
+    if(last)
         last->next = cur->next;
     else
         node_metrics.domain_root = NULL;
@@ -230,10 +230,10 @@ static int vcpu_metrics_collect(struct domain_metrics *d, xenstat_domain *domain
 
     unsigned int  i, num_online_vcpus=0;
     for(i = 0; i < num_vcpus; i++) {
-        if(unlikely(!vcpu_m)) {
+        if(!vcpu_m) {
             vcpu_m = callocz(1, sizeof(struct vcpu_metrics));
 
-            if(unlikely(i == 0)) d->vcpu_root = vcpu_m;
+            if(i == 0) d->vcpu_root = vcpu_m;
             else last_vcpu_m->next = vcpu_m;
         }
 
@@ -241,13 +241,13 @@ static int vcpu_metrics_collect(struct domain_metrics *d, xenstat_domain *domain
 
         vcpu = xenstat_domain_vcpu(domain, i);
 
-        if(unlikely(!vcpu)) {
+        if(!vcpu) {
             netdata_log_error("XENSTAT: cannot get VCPU statistics.");
             return 1;
         }
 
         vcpu_m->online = xenstat_vcpu_online(vcpu);
-        if(likely(vcpu_m->online)) { num_online_vcpus++; }
+        if(vcpu_m->online) { num_online_vcpus++; }
         vcpu_m->ns = xenstat_vcpu_ns(vcpu);
 
         vcpu_m->updated = 1;
@@ -256,7 +256,7 @@ static int vcpu_metrics_collect(struct domain_metrics *d, xenstat_domain *domain
         vcpu_m = vcpu_m->next;
     }
 
-    if(unlikely(num_online_vcpus != d->cur_vcpus)) {
+    if(num_online_vcpus != d->cur_vcpus) {
         d->num_vcpus_changed = 1;
         d->cur_vcpus = num_online_vcpus;
     }
@@ -276,10 +276,10 @@ static int vbd_metrics_collect(struct domain_metrics *d, xenstat_domain *domain)
 
     unsigned int  i;
     for(i = 0; i < num_vbds; i++) {
-        if(unlikely(!vbd_m)) {
+        if(!vbd_m) {
             vbd_m = callocz(1, sizeof(struct vbd_metrics));
 
-            if(unlikely(i == 0)) d->vbd_root = vbd_m;
+            if(i == 0) d->vbd_root = vbd_m;
             else last_vbd_m->next = vbd_m;
         }
 
@@ -287,7 +287,7 @@ static int vbd_metrics_collect(struct domain_metrics *d, xenstat_domain *domain)
 
         vbd = xenstat_domain_vbd(domain, i);
 
-        if(unlikely(!vbd)) {
+        if(!vbd) {
             netdata_log_error("XENSTAT: cannot get VBD statistics.");
             return 1;
         }
@@ -324,10 +324,10 @@ static int network_metrics_collect(struct domain_metrics *d, xenstat_domain *dom
 
     unsigned int  i;
     for(i = 0; i < num_networks; i++) {
-        if(unlikely(!network_m)) {
+        if(!network_m) {
             network_m = callocz(1, sizeof(struct network_metrics));
 
-            if(unlikely(i == 0)) d->network_root = network_m;
+            if(i == 0) d->network_root = network_m;
             else last_network_m->next = network_m;
         }
 
@@ -335,7 +335,7 @@ static int network_metrics_collect(struct domain_metrics *d, xenstat_domain *dom
 
         network = xenstat_domain_network(domain, i);
 
-        if(unlikely(!network)) {
+        if(!network) {
             netdata_log_error("XENSTAT: cannot get network statistics.");
             return 1;
         }
@@ -367,7 +367,7 @@ static int xenstat_collect(xenstat_handle *xhandle, libxl_ctx *ctx, libxl_dominf
         d->updated = 0;
 
     xenstat_node *node = xenstat_get_node(xhandle, XENSTAT_ALL);
-    if (unlikely(!node)) {
+    if (!node) {
         netdata_log_error("XENSTAT: failed to retrieve statistics from libxenstat.");
         return 1;
     }
@@ -387,7 +387,7 @@ static int xenstat_collect(xenstat_handle *xhandle, libxl_ctx *ctx, libxl_dominf
 
         // get domain UUID
         unsigned int id = xenstat_domain_id(domain);
-        if(unlikely(libxl_domain_info(ctx, info, id))) {
+        if(libxl_domain_info(ctx, info, id)) {
             netdata_log_error("XENSTAT: cannot get domain info.");
         }
         else {
@@ -398,10 +398,10 @@ static int xenstat_collect(xenstat_handle *xhandle, libxl_ctx *ctx, libxl_dominf
         d = domain_metrics_get(uuid, hash);
 
         d->id = id;
-        if(unlikely(!d->name)) {
+        if(!d->name) {
             d->name = strdupz(xenstat_domain_name(domain));
             netdata_fix_chart_id(d->name);
-            if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: domain id %u, uuid %s has name '%s'\n", d->id, d->uuid, d->name);
+            if(debug) fprintf(stderr, "xenstat.plugin: domain id %u, uuid %s has name '%s'\n", d->id, d->uuid, d->name);
         }
 
         d->running  = xenstat_domain_running(domain);
@@ -415,7 +415,7 @@ static int xenstat_collect(xenstat_handle *xhandle, libxl_ctx *ctx, libxl_dominf
         d->cur_mem = xenstat_domain_cur_mem(domain);
         d->max_mem = xenstat_domain_max_mem(domain);
 
-        if(unlikely(vcpu_metrics_collect(d, domain) || vbd_metrics_collect(d, domain) || network_metrics_collect(d, domain))) {
+        if(vcpu_metrics_collect(d, domain) || vbd_metrics_collect(d, domain) || network_metrics_collect(d, domain)) {
             xenstat_free_node(node);
             return 1;
         }
@@ -433,7 +433,7 @@ static void xenstat_send_node_metrics() {
 
     // ----------------------------------------------------------------
 
-    if(unlikely(!mem_chart_generated)) {
+    if(!mem_chart_generated) {
         printf("CHART xenstat.mem '' 'Memory Usage' 'MiB' 'memory' '' stacked %d %d '' %s\n"
                , NETDATA_CHART_PRIO_XENSTAT_NODE_MEM
                , netdata_update_every
@@ -455,7 +455,7 @@ static void xenstat_send_node_metrics() {
 
     // ----------------------------------------------------------------
 
-    if(unlikely(!domains_chart_generated)) {
+    if(!domains_chart_generated) {
         printf("CHART xenstat.domains '' 'Number of Domains' 'domains' 'domains' '' line %d %d '' %s\n"
                , NETDATA_CHART_PRIO_XENSTAT_NODE_DOMAINS
                , netdata_update_every
@@ -474,7 +474,7 @@ static void xenstat_send_node_metrics() {
 
     // ----------------------------------------------------------------
 
-    if(unlikely(!cpus_chart_generated)) {
+    if(!cpus_chart_generated) {
         printf("CHART xenstat.cpus '' 'Number of CPUs' 'cpus' 'cpu' '' line %d %d '' %s\n"
                , NETDATA_CHART_PRIO_XENSTAT_NODE_CPUS
                , netdata_update_every
@@ -493,7 +493,7 @@ static void xenstat_send_node_metrics() {
 
     // ----------------------------------------------------------------
 
-    if(unlikely(!cpu_freq_chart_generated)) {
+    if(!cpu_freq_chart_generated) {
         printf("CHART xenstat.cpu_freq '' 'CPU Frequency' 'MHz' 'cpu' '' line %d %d '' %s\n"
                , NETDATA_CHART_PRIO_XENSTAT_NODE_CPU_FREQ
                , netdata_update_every
@@ -562,7 +562,7 @@ static void print_domain_vcpu_chart_definition(char *type, struct domain_metrics
     );
 
     for(vcpu_m = d->vcpu_root; vcpu_m; vcpu_m = vcpu_m->next) {
-        if(likely(vcpu_m->updated && vcpu_m->online)) {
+        if(vcpu_m->updated && vcpu_m->online) {
             printf("DIMENSION vcpu%u '' incremental 100 %d\n", vcpu_m->id, netdata_update_every * 1000000000);
         }
     }
@@ -667,18 +667,18 @@ static void print_domain_network_drops_chart_definition(char *type, unsigned int
 
 static void xenstat_send_domain_metrics() {
 
-    if(unlikely(!node_metrics.domain_root)) return;
+    if(!node_metrics.domain_root) return;
     struct domain_metrics *d;
 
     for(d = node_metrics.domain_root; d; d = d->next) {
         char type[TYPE_LENGTH_MAX + 1];
         snprintfz(type, TYPE_LENGTH_MAX, "xendomain_%s_%s", d->name, d->uuid);
 
-        if(likely(d->updated)) {
+        if(d->updated) {
 
             // ----------------------------------------------------------------
 
-            if(unlikely(!d->states_chart_generated)) {
+            if(!d->states_chart_generated) {
                 print_domain_states_chart_definition(type, CHART_IS_NOT_OBSOLETE);
                 d->states_chart_generated = 1;
             }
@@ -702,7 +702,7 @@ static void xenstat_send_domain_metrics() {
 
             // ----------------------------------------------------------------
 
-            if(unlikely(!d->cpu_chart_generated)) {
+            if(!d->cpu_chart_generated) {
                 print_domain_cpu_chart_definition(type, CHART_IS_NOT_OBSOLETE);
                 d->cpu_chart_generated = 1;
             }
@@ -718,7 +718,7 @@ static void xenstat_send_domain_metrics() {
 
             struct vcpu_metrics *vcpu_m;
 
-            if(unlikely(!d->vcpu_chart_generated || d->num_vcpus_changed)) {
+            if(!d->vcpu_chart_generated || d->num_vcpus_changed) {
                 print_domain_vcpu_chart_definition(type, d, CHART_IS_NOT_OBSOLETE);
                 d->num_vcpus_changed = 0;
                 d->vcpu_chart_generated = 1;
@@ -726,7 +726,7 @@ static void xenstat_send_domain_metrics() {
 
             printf("BEGIN %s.vcpu\n", type);
             for(vcpu_m = d->vcpu_root; vcpu_m; vcpu_m = vcpu_m->next) {
-                if(likely(vcpu_m->updated && vcpu_m->online)) {
+                if(vcpu_m->updated && vcpu_m->online) {
                     printf(
                             "SET vcpu%u = %lld\n"
                             , vcpu_m->id
@@ -738,7 +738,7 @@ static void xenstat_send_domain_metrics() {
 
             // ----------------------------------------------------------------
 
-            if(unlikely(!d->mem_chart_generated)) {
+            if(!d->mem_chart_generated) {
                 print_domain_mem_chart_definition(type, CHART_IS_NOT_OBSOLETE);
                 d->mem_chart_generated = 1;
             }
@@ -756,8 +756,8 @@ static void xenstat_send_domain_metrics() {
 
             struct vbd_metrics *vbd_m;
             for(vbd_m = d->vbd_root; vbd_m; vbd_m = vbd_m->next) {
-                if(likely(vbd_m->updated && !vbd_m->error)) {
-                    if(unlikely(!vbd_m->oo_req_chart_generated)) {
+                if(vbd_m->updated && !vbd_m->error) {
+                    if(!vbd_m->oo_req_chart_generated) {
                         print_domain_vbd_oo_chart_definition(type, vbd_m->id, CHART_IS_NOT_OBSOLETE);
                         vbd_m->oo_req_chart_generated = 1;
                     }
@@ -772,7 +772,7 @@ static void xenstat_send_domain_metrics() {
 
                     // ----------------------------------------------------------------
 
-                    if(unlikely(!vbd_m->requests_chart_generated)) {
+                    if(!vbd_m->requests_chart_generated) {
                         print_domain_vbd_requests_chart_definition(type, vbd_m->id, CHART_IS_NOT_OBSOLETE);
                         vbd_m->requests_chart_generated = 1;
                     }
@@ -789,7 +789,7 @@ static void xenstat_send_domain_metrics() {
 
                     // ----------------------------------------------------------------
 
-                    if(unlikely(!vbd_m->sectors_chart_generated)) {
+                    if(!vbd_m->sectors_chart_generated) {
                         print_domain_vbd_sectors_chart_definition(type, vbd_m->id, CHART_IS_NOT_OBSOLETE);
                         vbd_m->sectors_chart_generated = 1;
                     }
@@ -805,10 +805,10 @@ static void xenstat_send_domain_metrics() {
                     );
                 }
                 else {
-                    if(unlikely(vbd_m->oo_req_chart_generated
+                    if(vbd_m->oo_req_chart_generated
                                 || vbd_m->requests_chart_generated
-                                || vbd_m->sectors_chart_generated)) {
-                        if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: mark charts as obsolete for vbd %u, domain '%s', id %u, uuid %s\n", vbd_m->id, d->name, d->id, d->uuid);
+                                || vbd_m->sectors_chart_generated) {
+                        if(debug) fprintf(stderr, "xenstat.plugin: mark charts as obsolete for vbd %u, domain '%s', id %u, uuid %s\n", vbd_m->id, d->name, d->id, d->uuid);
                         print_domain_vbd_oo_chart_definition(type, vbd_m->id, CHART_IS_OBSOLETE);
                         print_domain_vbd_requests_chart_definition(type, vbd_m->id, CHART_IS_OBSOLETE);
                         print_domain_vbd_sectors_chart_definition(type, vbd_m->id, CHART_IS_OBSOLETE);
@@ -823,8 +823,8 @@ static void xenstat_send_domain_metrics() {
 
             struct network_metrics *network_m;
             for(network_m = d->network_root; network_m; network_m = network_m->next) {
-                if(likely(network_m->updated)) {
-                    if(unlikely(!network_m->bytes_chart_generated)) {
+                if(network_m->updated) {
+                    if(!network_m->bytes_chart_generated) {
                         print_domain_network_bytes_chart_definition(type, network_m->id, CHART_IS_NOT_OBSOLETE);
                         network_m->bytes_chart_generated = 1;
                     }
@@ -841,7 +841,7 @@ static void xenstat_send_domain_metrics() {
 
                     // ----------------------------------------------------------------
 
-                    if(unlikely(!network_m->packets_chart_generated)) {
+                    if(!network_m->packets_chart_generated) {
                         print_domain_network_packets_chart_definition(type, network_m->id, CHART_IS_NOT_OBSOLETE);
                         network_m->packets_chart_generated = 1;
                     }
@@ -858,7 +858,7 @@ static void xenstat_send_domain_metrics() {
 
                     // ----------------------------------------------------------------
 
-                    if(unlikely(!network_m->errors_chart_generated)) {
+                    if(!network_m->errors_chart_generated) {
                         print_domain_network_errors_chart_definition(type, network_m->id, CHART_IS_NOT_OBSOLETE);
                         network_m->errors_chart_generated = 1;
                     }
@@ -875,7 +875,7 @@ static void xenstat_send_domain_metrics() {
 
                     // ----------------------------------------------------------------
 
-                    if(unlikely(!network_m->drops_chart_generated)) {
+                    if(!network_m->drops_chart_generated) {
                         print_domain_network_drops_chart_definition(type, network_m->id, CHART_IS_NOT_OBSOLETE);
                         network_m->drops_chart_generated = 1;
                     }
@@ -891,11 +891,11 @@ static void xenstat_send_domain_metrics() {
                     );
                 }
                 else {
-                    if(unlikely(network_m->bytes_chart_generated
+                    if(network_m->bytes_chart_generated
                                 || network_m->packets_chart_generated
                                 || network_m->errors_chart_generated
-                                || network_m->drops_chart_generated))
-                    if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: mark charts as obsolete for network %u, domain '%s', id %u, uuid %s\n", network_m->id, d->name, d->id, d->uuid);
+                                || network_m->drops_chart_generated)
+                    if(debug) fprintf(stderr, "xenstat.plugin: mark charts as obsolete for network %u, domain '%s', id %u, uuid %s\n", network_m->id, d->name, d->id, d->uuid);
                     print_domain_network_bytes_chart_definition(type, network_m->id, CHART_IS_OBSOLETE);
                     print_domain_network_packets_chart_definition(type, network_m->id, CHART_IS_OBSOLETE);
                     print_domain_network_errors_chart_definition(type, network_m->id, CHART_IS_OBSOLETE);
@@ -908,7 +908,7 @@ static void xenstat_send_domain_metrics() {
             }
         }
         else{
-            if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: mark charts as obsolete for domain '%s', id %u, uuid %s\n", d->name, d->id, d->uuid);
+            if(debug) fprintf(stderr, "xenstat.plugin: mark charts as obsolete for domain '%s', id %u, uuid %s\n", d->name, d->id, d->uuid);
             print_domain_states_chart_definition(type, CHART_IS_OBSOLETE);
             print_domain_cpu_chart_definition(type, CHART_IS_OBSOLETE);
             print_domain_vcpu_chart_definition(type, d, CHART_IS_OBSOLETE);
@@ -1005,14 +1005,14 @@ int main(int argc, char **argv) {
     libxl_ctx *ctx = NULL;
     libxl_dominfo info;
 
-    if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: calling xenstat_init()\n");
+    if(debug) fprintf(stderr, "xenstat.plugin: calling xenstat_init()\n");
     xhandle = xenstat_init();
     if (xhandle == NULL) {
         netdata_log_error("XENSTAT: failed to initialize xenstat library.");
         return 1;
     }
 
-    if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: calling libxl_ctx_alloc()\n");
+    if(debug) fprintf(stderr, "xenstat.plugin: calling libxl_ctx_alloc()\n");
     if (libxl_ctx_alloc(&ctx, LIBXL_VERSION, 0, NULL)) {
         netdata_log_error("XENSTAT: failed to initialize xl context.");
         xenstat_uninit(xhandle);
@@ -1023,7 +1023,7 @@ int main(int argc, char **argv) {
     // ------------------------------------------------------------------------
     // the main loop
 
-    if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: starting data collection\n");
+    if(debug) fprintf(stderr, "xenstat.plugin: starting data collection\n");
 
     time_t started_t = now_monotonic_sec();
 
@@ -1035,33 +1035,33 @@ int main(int argc, char **argv) {
     for(iteration = 0; 1; iteration++) {
         usec_t dt = heartbeat_next(&hb, step);
 
-        if(unlikely(netdata_exit)) break;
+        if(netdata_exit) break;
 
-        if(unlikely(debug && iteration))
+        if(debug && iteration)
             fprintf(stderr, "xenstat.plugin: iteration %zu, dt %llu usec\n"
                     , iteration
                     , dt
             );
 
-        if(likely(xhandle)) {
-            if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: calling xenstat_collect()\n");
+        if(xhandle) {
+            if(debug) fprintf(stderr, "xenstat.plugin: calling xenstat_collect()\n");
             int ret = xenstat_collect(xhandle, ctx, &info);
 
-            if(likely(!ret)) {
-                if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: calling xenstat_send_node_metrics()\n");
+            if(!ret) {
+                if(debug) fprintf(stderr, "xenstat.plugin: calling xenstat_send_node_metrics()\n");
                 xenstat_send_node_metrics();
-                if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: calling xenstat_send_domain_metrics()\n");
+                if(debug) fprintf(stderr, "xenstat.plugin: calling xenstat_send_domain_metrics()\n");
                 xenstat_send_domain_metrics();
             }
             else {
-                if(unlikely(debug)) fprintf(stderr, "xenstat.plugin: can't collect data\n");
+                if(debug) fprintf(stderr, "xenstat.plugin: can't collect data\n");
             }
         }
 
         fflush(stdout);
 
         // restart check (14400 seconds)
-        if(unlikely(now_monotonic_sec() - started_t > 14400)) break;
+        if(now_monotonic_sec() - started_t > 14400) break;
     }
 
     libxl_ctx_free(ctx);

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -145,7 +145,7 @@ void analytics_set_data_str(char **name, char *value)
  */
 void analytics_log_prometheus(void)
 {
-    if (netdata_anonymous_statistics_enabled == 1 && likely(analytics_data.prometheus_hits < ANALYTICS_MAX_PROMETHEUS_HITS)) {
+    if (netdata_anonymous_statistics_enabled == 1 && analytics_data.prometheus_hits < ANALYTICS_MAX_PROMETHEUS_HITS) {
         analytics_data.prometheus_hits++;
         char b[21];
         snprintfz(b, 20, "%zu", analytics_data.prometheus_hits);
@@ -158,7 +158,7 @@ void analytics_log_prometheus(void)
  */
 void analytics_log_shell(void)
 {
-    if (netdata_anonymous_statistics_enabled == 1 && likely(analytics_data.shell_hits < ANALYTICS_MAX_SHELL_HITS)) {
+    if (netdata_anonymous_statistics_enabled == 1 && analytics_data.shell_hits < ANALYTICS_MAX_SHELL_HITS) {
         analytics_data.shell_hits++;
         char b[21];
         snprintfz(b, 20, "%zu", analytics_data.shell_hits);
@@ -171,7 +171,7 @@ void analytics_log_shell(void)
  */
 void analytics_log_json(void)
 {
-    if (netdata_anonymous_statistics_enabled == 1 && likely(analytics_data.json_hits < ANALYTICS_MAX_JSON_HITS)) {
+    if (netdata_anonymous_statistics_enabled == 1 && analytics_data.json_hits < ANALYTICS_MAX_JSON_HITS) {
         analytics_data.json_hits++;
         char b[21];
         snprintfz(b, 20, "%zu", analytics_data.json_hits);
@@ -184,7 +184,7 @@ void analytics_log_json(void)
  */
 void analytics_log_dashboard(void)
 {
-    if (netdata_anonymous_statistics_enabled == 1 && likely(analytics_data.dashboard_hits < ANALYTICS_MAX_DASHBOARD_HITS)) {
+    if (netdata_anonymous_statistics_enabled == 1 && analytics_data.dashboard_hits < ANALYTICS_MAX_DASHBOARD_HITS) {
         analytics_data.dashboard_hits++;
         char b[21];
         snprintfz(b, 20, "%zu", analytics_data.dashboard_hits);
@@ -246,7 +246,7 @@ int collector_counter_callb(const DICTIONARY_ITEM *item __maybe_unused, void *en
 
     BUFFER *bt = ap->both;
 
-    if (likely(ap->c)) {
+    if (ap->c) {
         buffer_strcat(bt, ",");
     }
 
@@ -313,7 +313,7 @@ void analytics_alarms_notifications(void)
     script = mallocz(
         sizeof(char) * (strlen(netdata_configured_primary_plugins_dir) + strlen("alarm-notify.sh dump_methods") + 2));
     sprintf(script, "%s/%s", netdata_configured_primary_plugins_dir, "alarm-notify.sh");
-    if (unlikely(access(script, R_OK) != 0)) {
+    if (access(script, R_OK) != 0) {
         netdata_log_info("Alarm notify script %s not found.", script);
         freez(script);
         return;
@@ -338,7 +338,7 @@ void analytics_alarms_notifications(void)
                 end++;
             *end = '\0';
 
-            if (likely(cnt))
+            if (cnt)
                 buffer_strcat(b, "|");
 
             buffer_strcat(b, line);
@@ -437,7 +437,7 @@ void analytics_alarms(void)
     char b[21];
     RRDCALC *rc;
     foreach_rrdcalc_in_rrdhost_read(localhost, rc) {
-        if (unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
+        if (!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec)
             continue;
 
         switch (rc->status) {
@@ -584,12 +584,12 @@ void *analytics_main(void *ptr)
     netdata_log_debug(D_ANALYTICS, "Analytics thread starts");
 
     //first delay after agent start
-    while (service_running(SERVICE_ANALYTICS) && likely(sec <= ANALYTICS_INIT_SLEEP_SEC)) {
+    while (service_running(SERVICE_ANALYTICS) && sec <= ANALYTICS_INIT_SLEEP_SEC) {
         heartbeat_next(&hb, step_ut);
         sec++;
     }
 
-    if (unlikely(!service_running(SERVICE_ANALYTICS)))
+    if (!service_running(SERVICE_ANALYTICS))
         goto cleanup;
 
     analytics_gather_immutable_meta_data();
@@ -602,10 +602,10 @@ void *analytics_main(void *ptr)
         heartbeat_next(&hb, step_ut * 2);
         sec += 2;
 
-        if (unlikely(!service_running(SERVICE_ANALYTICS)))
+        if (!service_running(SERVICE_ANALYTICS))
             break;
 
-        if (likely(sec < ANALYTICS_HEARTBEAT))
+        if (sec < ANALYTICS_HEARTBEAT)
             continue;
 
         analytics_gather_mutable_meta_data();
@@ -948,12 +948,12 @@ void send_statistics(const char *action, const char *action_result, const char *
             sizeof(char) *
             (strlen(netdata_configured_user_config_dir) + strlen(".opt-out-from-anonymous-statistics") + 2));
         sprintf(optout_file, "%s/%s", netdata_configured_user_config_dir, ".opt-out-from-anonymous-statistics");
-        if (likely(access(optout_file, R_OK) != 0)) {
+        if (access(optout_file, R_OK) != 0) {
             as_script = mallocz(
                 sizeof(char) *
                 (strlen(netdata_configured_primary_plugins_dir) + strlen("anonymous-statistics.sh") + 2));
             sprintf(as_script, "%s/%s", netdata_configured_primary_plugins_dir, "anonymous-statistics.sh");
-            if (unlikely(access(as_script, R_OK) != 0)) {
+            if (access(as_script, R_OK) != 0) {
                 netdata_anonymous_statistics_enabled = 0;
                 netdata_log_info("Anonymous statistics script %s not found.", as_script);
                 freez(as_script);

--- a/daemon/event_loop.c
+++ b/daemon/event_loop.c
@@ -7,7 +7,7 @@
 void register_libuv_worker_jobs() {
     static __thread bool registered = false;
 
-    if(likely(registered))
+    if(registered)
         return;
 
     registered = true;

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -250,7 +250,7 @@ static void global_statistics_charts(void) {
         static RRDDIM *rd_cpu_user   = NULL,
                       *rd_cpu_system = NULL;
 
-        if (unlikely(!st_cpu)) {
+        if (!st_cpu) {
             st_cpu = rrdset_create_localhost(
                     "netdata"
                     , "server_cpu"
@@ -296,7 +296,7 @@ static void global_statistics_charts(void) {
         static RRDDIM *rd_judy = NULL;
         static RRDDIM *rd_other = NULL;
 
-        if (unlikely(!st_memory)) {
+        if (!st_memory) {
             st_memory = rrdset_create_localhost(
                     "netdata",
                     "memory",
@@ -385,7 +385,7 @@ static void global_statistics_charts(void) {
         static RRDDIM *rd_buffers_aral = NULL;
         static RRDDIM *rd_buffers_judy = NULL;
 
-        if (unlikely(!st_memory_buffers)) {
+        if (!st_memory_buffers) {
             st_memory_buffers = rrdset_create_localhost(
                 "netdata",
                 "memory_buffers",
@@ -440,7 +440,7 @@ static void global_statistics_charts(void) {
         static RRDSET *st_uptime = NULL;
         static RRDDIM *rd_uptime = NULL;
 
-        if (unlikely(!st_uptime)) {
+        if (!st_uptime) {
             st_uptime = rrdset_create_localhost(
                     "netdata",
                     "uptime",
@@ -468,7 +468,7 @@ static void global_statistics_charts(void) {
         static RRDSET *st_clients = NULL;
         static RRDDIM *rd_clients = NULL;
 
-        if (unlikely(!st_clients)) {
+        if (!st_clients) {
             st_clients = rrdset_create_localhost(
                     "netdata"
                     , "clients"
@@ -497,7 +497,7 @@ static void global_statistics_charts(void) {
         static RRDSET *st_reqs = NULL;
         static RRDDIM *rd_requests = NULL;
 
-        if (unlikely(!st_reqs)) {
+        if (!st_reqs) {
             st_reqs = rrdset_create_localhost(
                     "netdata"
                     , "requests"
@@ -527,7 +527,7 @@ static void global_statistics_charts(void) {
         static RRDDIM *rd_in = NULL,
                       *rd_out = NULL;
 
-        if (unlikely(!st_bytes)) {
+        if (!st_bytes) {
             st_bytes = rrdset_create_localhost(
                     "netdata"
                     , "net"
@@ -559,7 +559,7 @@ static void global_statistics_charts(void) {
         static RRDDIM *rd_average = NULL,
                       *rd_max     = NULL;
 
-        if (unlikely(!st_duration)) {
+        if (!st_duration) {
             st_duration = rrdset_create_localhost(
                     "netdata"
                     , "response_time"
@@ -591,7 +591,7 @@ static void global_statistics_charts(void) {
         if (web_requests)
             average_response_time = (collected_number) (web_usec / web_requests);
 
-        if (unlikely(average_response_time != -1))
+        if (average_response_time != -1)
             rrddim_set_by_pointer(st_duration, rd_average, average_response_time);
         else
             rrddim_set_by_pointer(st_duration, rd_average, 0);
@@ -606,7 +606,7 @@ static void global_statistics_charts(void) {
         static RRDSET *st_compression = NULL;
         static RRDDIM *rd_savings = NULL;
 
-        if (unlikely(!st_compression)) {
+        if (!st_compression) {
             st_compression = rrdset_create_localhost(
                     "netdata"
                     , "compression_ratio"
@@ -658,7 +658,7 @@ static void global_statistics_charts(void) {
         static RRDDIM *rd_backfill_queries = NULL;
         static RRDDIM *rd_replication_queries = NULL;
 
-        if (unlikely(!st_queries)) {
+        if (!st_queries) {
             st_queries = rrdset_create_localhost(
                     "netdata"
                     , "queries"
@@ -709,7 +709,7 @@ static void global_statistics_charts(void) {
         static RRDDIM *rd_backfill_points_read = NULL;
         static RRDDIM *rd_replication_points_read = NULL;
 
-        if (unlikely(!st_points_read)) {
+        if (!st_points_read) {
             st_points_read = rrdset_create_localhost(
                     "netdata"
                     , "db_points_read"
@@ -758,7 +758,7 @@ static void global_statistics_charts(void) {
         static RRDDIM *rd_ml_points_generated = NULL;
         static RRDDIM *rd_replication_points_generated = NULL;
 
-        if (unlikely(!st_points_generated)) {
+        if (!st_points_generated) {
             st_points_generated = rrdset_create_localhost(
                     "netdata"
                     , "db_points_results"
@@ -798,7 +798,7 @@ static void global_statistics_charts(void) {
         static RRDSET *st_points_stored = NULL;
         static RRDDIM *rds[RRD_STORAGE_TIERS] = {};
 
-        if (unlikely(!st_points_stored)) {
+        if (!st_points_stored) {
             st_points_stored = rrdset_create_localhost(
                     "netdata"
                     , "db_points_stored"
@@ -956,7 +956,7 @@ static void sqlite3_statistics_charts(void) {
         static RRDSET *st_sqlite3_queries = NULL;
         static RRDDIM *rd_queries = NULL;
 
-        if (unlikely(!st_sqlite3_queries)) {
+        if (!st_sqlite3_queries) {
             st_sqlite3_queries = rrdset_create_localhost(
                 "netdata"
                 , "sqlite3_queries"
@@ -986,7 +986,7 @@ static void sqlite3_statistics_charts(void) {
         static RRDSET *st_sqlite3_queries_by_status = NULL;
         static RRDDIM *rd_ok = NULL, *rd_failed = NULL, *rd_busy = NULL, *rd_locked = NULL;
 
-        if (unlikely(!st_sqlite3_queries_by_status)) {
+        if (!st_sqlite3_queries_by_status) {
             st_sqlite3_queries_by_status = rrdset_create_localhost(
                 "netdata"
                 , "sqlite3_queries_by_status"
@@ -1022,7 +1022,7 @@ static void sqlite3_statistics_charts(void) {
         static RRDSET *st_sqlite3_rows = NULL;
         static RRDDIM *rd_rows = NULL;
 
-        if (unlikely(!st_sqlite3_rows)) {
+        if (!st_sqlite3_rows) {
             st_sqlite3_rows = rrdset_create_localhost(
                 "netdata"
                 , "sqlite3_rows"
@@ -1053,7 +1053,7 @@ static void sqlite3_statistics_charts(void) {
         static RRDDIM *rd_cache_spill= NULL;
         static RRDDIM *rd_cache_write= NULL;
 
-        if (unlikely(!st_sqlite3_cache)) {
+        if (!st_sqlite3_cache) {
             st_sqlite3_cache = rrdset_create_localhost(
                 "netdata"
                 , "sqlite3_metatada_cache"
@@ -1097,7 +1097,7 @@ static void sqlite3_statistics_charts(void) {
         static RRDDIM *rd_cache_spill= NULL;
         static RRDDIM *rd_cache_write= NULL;
 
-        if (unlikely(!st_sqlite3_cache)) {
+        if (!st_sqlite3_cache) {
             st_sqlite3_cache = rrdset_create_localhost(
                 "netdata"
                 , "sqlite3_context_cache"
@@ -1216,7 +1216,7 @@ struct dbengine2_cache_pointers {
 static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *ptrs, struct pgc_statistics *pgc_stats, struct pgc_statistics *pgc_stats_old __maybe_unused, const char *name, int priority) {
 
     {
-        if (unlikely(!ptrs->st_cache_hit_ratio)) {
+        if (!ptrs->st_cache_hit_ratio) {
             BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_cache_hit_ratio", name);
 
@@ -1264,7 +1264,7 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
     }
 
     {
-        if (unlikely(!ptrs->st_operations)) {
+        if (!ptrs->st_operations) {
             BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_cache_operations", name);
 
@@ -1318,7 +1318,7 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
     }
 
     {
-        if (unlikely(!ptrs->st_pgc_memory)) {
+        if (!ptrs->st_pgc_memory) {
             BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_cache_memory", name);
 
@@ -1372,7 +1372,7 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
     }
 
     {
-        if (unlikely(!ptrs->st_pgc_tm)) {
+        if (!ptrs->st_pgc_tm) {
             BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_target_memory", name);
 
@@ -1422,7 +1422,7 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
     }
 
     {
-        if (unlikely(!ptrs->st_pgc_pages)) {
+        if (!ptrs->st_pgc_pages) {
             BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_cache_pages", name);
 
@@ -1466,7 +1466,7 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
     }
 
     {
-        if (unlikely(!ptrs->st_pgc_memory_changes)) {
+        if (!ptrs->st_pgc_memory_changes) {
             BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_cache_memory_changes", name);
 
@@ -1508,7 +1508,7 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
     }
 
     {
-        if (unlikely(!ptrs->st_pgc_memory_migrations)) {
+        if (!ptrs->st_pgc_memory_migrations) {
             BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_cache_memory_migrations", name);
 
@@ -1548,7 +1548,7 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
     }
 
     {
-        if (unlikely(!ptrs->st_pgc_memory_events)) {
+        if (!ptrs->st_pgc_memory_events) {
             BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_cache_events", name);
 
@@ -1590,7 +1590,7 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
     }
 
     {
-        if (unlikely(!ptrs->st_pgc_waste)) {
+        if (!ptrs->st_pgc_waste) {
             BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_waste_events", name);
 
@@ -1642,7 +1642,7 @@ static void dbengine2_cache_statistics_charts(struct dbengine2_cache_pointers *p
     }
 
     {
-        if (unlikely(!ptrs->st_pgc_workers)) {
+        if (!ptrs->st_pgc_workers) {
             BUFFER *id = buffer_create(100, NULL);
             buffer_sprintf(id, "dbengine_%s_cache_workers", name);
 
@@ -1740,7 +1740,7 @@ static void dbengine2_statistics_charts(void) {
         static RRDDIM *rd_pgc_memory_metrics = NULL;  // metric registry memory
         static RRDDIM *rd_pgc_memory_buffers = NULL;
 
-        if (unlikely(!st_pgc_memory)) {
+        if (!st_pgc_memory) {
             st_pgc_memory = rrdset_create_localhost(
                     "netdata",
                     "dbengine_memory",
@@ -1792,7 +1792,7 @@ static void dbengine2_statistics_charts(void) {
         static RRDDIM *rd_pgc_buffers_julyl = NULL;
 #endif
 
-        if (unlikely(!st_pgc_buffers)) {
+        if (!st_pgc_buffers) {
             st_pgc_buffers = rrdset_create_localhost(
                     "netdata",
                     "dbengine_buffers",
@@ -1851,7 +1851,7 @@ static void dbengine2_statistics_charts(void) {
         static RRDSET *st_julyl_moved = NULL;
         static RRDDIM *rd_julyl_moved = NULL;
 
-        if (unlikely(!st_julyl_moved)) {
+        if (!st_julyl_moved) {
             st_julyl_moved = rrdset_create_localhost(
                     "netdata",
                     "dbengine_julyl_moved",
@@ -1885,7 +1885,7 @@ static void dbengine2_statistics_charts(void) {
         static RRDDIM *rd_mrg_without_retention = NULL;
         static RRDDIM *rd_mrg_multiple_writers = NULL;
 
-        if (unlikely(!st_mrg_metrics)) {
+        if (!st_mrg_metrics) {
             st_mrg_metrics = rrdset_create_localhost(
                     "netdata",
                     "dbengine_metrics",
@@ -1925,7 +1925,7 @@ static void dbengine2_statistics_charts(void) {
         static RRDDIM *rd_mrg_del = NULL;
         static RRDDIM *rd_mrg_search = NULL;
 
-        if (unlikely(!st_mrg_ops)) {
+        if (!st_mrg_ops) {
             st_mrg_ops = rrdset_create_localhost(
                     "netdata",
                     "dbengine_metrics_registry_operations",
@@ -1957,7 +1957,7 @@ static void dbengine2_statistics_charts(void) {
         static RRDSET *st_mrg_references = NULL;
         static RRDDIM *rd_mrg_references = NULL;
 
-        if (unlikely(!st_mrg_references)) {
+        if (!st_mrg_references) {
             st_mrg_references = rrdset_create_localhost(
                     "netdata",
                     "dbengine_metrics_registry_references",
@@ -1988,7 +1988,7 @@ static void dbengine2_statistics_charts(void) {
         static RRDDIM *rd_extent_cache_hit_ratio = NULL;
         static RRDDIM *rd_extent_merge_hit_ratio = NULL;
 
-        if (unlikely(!st_cache_hit_ratio)) {
+        if (!st_cache_hit_ratio) {
             st_cache_hit_ratio = rrdset_create_localhost(
                     "netdata",
                     "dbengine_cache_hit_ratio",
@@ -2065,7 +2065,7 @@ static void dbengine2_statistics_charts(void) {
         static RRDDIM *rd_planned_with_gaps = NULL;
         static RRDDIM *rd_executed_with_gaps = NULL;
 
-        if (unlikely(!st_queries)) {
+        if (!st_queries) {
             st_queries = rrdset_create_localhost(
                     "netdata",
                     "dbengine_queries",
@@ -2101,7 +2101,7 @@ static void dbengine2_statistics_charts(void) {
         static RRDSET *st_queries_running = NULL;
         static RRDDIM *rd_queries = NULL;
 
-        if (unlikely(!st_queries_running)) {
+        if (!st_queries_running) {
             st_queries_running = rrdset_create_localhost(
                     "netdata",
                     "dbengine_queries_running",
@@ -2131,7 +2131,7 @@ static void dbengine2_statistics_charts(void) {
         static RRDDIM *rd_open = NULL;
         static RRDDIM *rd_jv2 = NULL;
 
-        if (unlikely(!st_query_pages_metadata_source)) {
+        if (!st_query_pages_metadata_source) {
             st_query_pages_metadata_source = rrdset_create_localhost(
                     "netdata",
                     "dbengine_query_pages_metadata_source",
@@ -2165,7 +2165,7 @@ static void dbengine2_statistics_charts(void) {
         static RRDDIM *rd_pages_disk = NULL;
         static RRDDIM *rd_pages_extent_cache = NULL;
 
-        if (unlikely(!st_query_pages_data_source)) {
+        if (!st_query_pages_data_source) {
             st_query_pages_data_source = rrdset_create_localhost(
                     "netdata",
                     "dbengine_query_pages_data_source",
@@ -2201,7 +2201,7 @@ static void dbengine2_statistics_charts(void) {
         static RRDDIM *rd_wait_loaded = NULL;
         static RRDDIM *rd_nowait_loaded = NULL;
 
-        if (unlikely(!st_query_next_page)) {
+        if (!st_query_next_page) {
             st_query_next_page = rrdset_create_localhost(
                     "netdata",
                     "dbengine_query_next_page",
@@ -2242,7 +2242,7 @@ static void dbengine2_statistics_charts(void) {
         static RRDDIM *rd_pages_fixed_entries = NULL;
         static RRDDIM *rd_pages_overlapping = NULL;
 
-        if (unlikely(!st_query_page_issues)) {
+        if (!st_query_page_issues) {
             st_query_page_issues = rrdset_create_localhost(
                     "netdata",
                     "dbengine_query_next_page_issues",
@@ -2289,7 +2289,7 @@ static void dbengine2_statistics_charts(void) {
         static RRDDIM *rd_invalid_extent = NULL;
         static RRDDIM *rd_extent_merged = NULL;
 
-        if (unlikely(!st_query_pages_from_disk)) {
+        if (!st_query_pages_from_disk) {
             st_query_pages_from_disk = rrdset_create_localhost(
                     "netdata",
                     "dbengine_query_pages_disk_load",
@@ -2341,7 +2341,7 @@ static void dbengine2_statistics_charts(void) {
         static RRDDIM *rd_jv2_indexing = NULL;
         static RRDDIM *rd_retention = NULL;
 
-        if (unlikely(!st_events)) {
+        if (!st_events) {
             st_events = rrdset_create_localhost(
                     "netdata",
                     "dbengine_events",
@@ -2385,7 +2385,7 @@ static void dbengine2_statistics_charts(void) {
         static RRDDIM *rd_journal_v2 = NULL;
         static RRDDIM *rd_pass4 = NULL;
 
-        if (unlikely(!st_prep_timings)) {
+        if (!st_prep_timings) {
             st_prep_timings = rrdset_create_localhost(
                     "netdata",
                     "dbengine_prep_timings",
@@ -2426,7 +2426,7 @@ static void dbengine2_statistics_charts(void) {
         static RRDDIM *rd_next_page_preload_fast = NULL;
         static RRDDIM *rd_next_page_preload_slow = NULL;
 
-        if (unlikely(!st_query_timings)) {
+        if (!st_query_timings) {
             st_query_timings = rrdset_create_localhost(
                     "netdata",
                     "dbengine_query_timings",
@@ -2508,7 +2508,7 @@ static void dbengine2_statistics_charts(void) {
                 static RRDSET *st_compression = NULL;
                 static RRDDIM *rd_savings = NULL;
 
-                if (unlikely(!st_compression)) {
+                if (!st_compression) {
                     st_compression = rrdset_create_localhost(
                             "netdata",
                             "dbengine_compression_ratio",
@@ -2549,7 +2549,7 @@ static void dbengine2_statistics_charts(void) {
                 static RRDDIM *rd_reads = NULL;
                 static RRDDIM *rd_writes = NULL;
 
-                if (unlikely(!st_io_stats)) {
+                if (!st_io_stats) {
                     st_io_stats = rrdset_create_localhost(
                             "netdata",
                             "dbengine_io_throughput",
@@ -2581,7 +2581,7 @@ static void dbengine2_statistics_charts(void) {
                 static RRDDIM *rd_reads = NULL;
                 static RRDDIM *rd_writes = NULL;
 
-                if (unlikely(!st_io_stats)) {
+                if (!st_io_stats) {
                     st_io_stats = rrdset_create_localhost(
                             "netdata",
                             "dbengine_io_operations",
@@ -2614,7 +2614,7 @@ static void dbengine2_statistics_charts(void) {
                 static RRDDIM *rd_io_errors = NULL;
                 static RRDDIM *pg_cache_over_half_dirty_events = NULL;
 
-                if (unlikely(!st_errors)) {
+                if (!st_errors) {
                     st_errors = rrdset_create_localhost(
                             "netdata",
                             "dbengine_global_errors",
@@ -2649,7 +2649,7 @@ static void dbengine2_statistics_charts(void) {
                 static RRDDIM *rd_fd_current = NULL;
                 static RRDDIM *rd_fd_max = NULL;
 
-                if (unlikely(!st_fd)) {
+                if (!st_fd) {
                     st_fd = rrdset_create_localhost(
                             "netdata",
                             "dbengine_global_file_descriptors",
@@ -2689,7 +2689,7 @@ static void update_strings_charts() {
 
     string_statistics(&inserts, &deletes, &searches, &entries, &references, &memory, &duplications, &releases);
 
-    if (unlikely(!st_ops)) {
+    if (!st_ops) {
         st_ops = rrdset_create_localhost(
             "netdata"
             , "strings_ops"
@@ -2718,7 +2718,7 @@ static void update_strings_charts() {
     rrddim_set_by_pointer(st_ops, rd_ops_releases,     (collected_number)releases);
     rrdset_done(st_ops);
 
-    if (unlikely(!st_entries)) {
+    if (!st_entries) {
         st_entries = rrdset_create_localhost(
             "netdata"
             , "strings_entries"
@@ -2741,7 +2741,7 @@ static void update_strings_charts() {
     rrddim_set_by_pointer(st_entries, rd_entries_refs, (collected_number)references);
     rrdset_done(st_entries);
 
-    if (unlikely(!st_mem)) {
+    if (!st_mem) {
         st_mem = rrdset_create_localhost(
             "netdata"
             , "strings_memory"
@@ -2769,7 +2769,7 @@ static void update_heartbeat_charts() {
     static RRDDIM *rd_heartbeat_max = NULL;
     static RRDDIM *rd_heartbeat_avg = NULL;
 
-    if (unlikely(!st_heartbeat)) {
+    if (!st_heartbeat) {
         st_heartbeat = rrdset_create_localhost(
             "netdata"
             , "heartbeat"
@@ -2885,7 +2885,7 @@ static void update_dictionary_category_charts(struct dictionary_categories *c) {
     load_dictionary_stats_entry(dictionaries.deleted);
 
     if(c->st_dicts || total != 0) {
-        if (unlikely(!c->st_dicts)) {
+        if (!c->st_dicts) {
             char id[RRD_ID_LENGTH_MAX + 1];
             snprintfz(id, RRD_ID_LENGTH_MAX, "%s.%s.dictionaries", c->context_prefix, stats.name);
 
@@ -2926,7 +2926,7 @@ static void update_dictionary_category_charts(struct dictionary_categories *c) {
     load_dictionary_stats_entry(items.pending_deletion);
 
     if(c->st_items || total != 0) {
-        if (unlikely(!c->st_items)) {
+        if (!c->st_items) {
             char id[RRD_ID_LENGTH_MAX + 1];
             snprintfz(id, RRD_ID_LENGTH_MAX, "%s.%s.items", c->context_prefix, stats.name);
 
@@ -2976,7 +2976,7 @@ static void update_dictionary_category_charts(struct dictionary_categories *c) {
     load_dictionary_stats_entry(ops.deletes);
 
     if(c->st_ops || total != 0) {
-        if (unlikely(!c->st_ops)) {
+        if (!c->st_ops) {
             char id[RRD_ID_LENGTH_MAX + 1];
             snprintfz(id, RRD_ID_LENGTH_MAX, "%s.%s.ops", c->context_prefix, stats.name);
 
@@ -3035,7 +3035,7 @@ static void update_dictionary_category_charts(struct dictionary_categories *c) {
     load_dictionary_stats_entry(callbacks.deletes);
 
     if(c->st_callbacks || total != 0) {
-        if (unlikely(!c->st_callbacks)) {
+        if (!c->st_callbacks) {
             char id[RRD_ID_LENGTH_MAX + 1];
             snprintfz(id, RRD_ID_LENGTH_MAX, "%s.%s.callbacks", c->context_prefix, stats.name);
 
@@ -3081,7 +3081,7 @@ static void update_dictionary_category_charts(struct dictionary_categories *c) {
     load_dictionary_stats_entry(memory.dict);
 
     if(c->st_memory || total != 0) {
-        if (unlikely(!c->st_memory)) {
+        if (!c->st_memory) {
             char id[RRD_ID_LENGTH_MAX + 1];
             snprintfz(id, RRD_ID_LENGTH_MAX, "%s.%s.memory", c->context_prefix, stats.name);
 
@@ -3126,7 +3126,7 @@ static void update_dictionary_category_charts(struct dictionary_categories *c) {
     load_dictionary_stats_entry(spin_locks.delete_spins);
 
     if(c->st_spins || total != 0) {
-        if (unlikely(!c->st_spins)) {
+        if (!c->st_spins) {
             char id[RRD_ID_LENGTH_MAX + 1];
             snprintfz(id, RRD_ID_LENGTH_MAX, "%s.%s.spins", c->context_prefix, stats.name);
 
@@ -3492,7 +3492,7 @@ static void workers_utilization_update_chart(struct worker_utilization *wu) {
 
     // ----------------------------------------------------------------------
 
-    if(unlikely(!wu->st_workers_time)) {
+    if(!wu->st_workers_time) {
         char name[RRD_ID_LENGTH_MAX + 1];
         snprintfz(name, RRD_ID_LENGTH_MAX, "workers_time_%s", wu->name_lowercase);
 
@@ -3517,16 +3517,16 @@ static void workers_utilization_update_chart(struct worker_utilization *wu) {
 
     // we add the min and max dimensions only when we have multiple workers
 
-    if(unlikely(!wu->rd_workers_time_min && wu->workers_registered > 1))
+    if(!wu->rd_workers_time_min && wu->workers_registered > 1)
         wu->rd_workers_time_min = rrddim_add(wu->st_workers_time, "min", NULL, 1, WORKER_CHART_DECIMAL_PRECISION, RRD_ALGORITHM_ABSOLUTE);
 
-    if(unlikely(!wu->rd_workers_time_max && wu->workers_registered > 1))
+    if(!wu->rd_workers_time_max && wu->workers_registered > 1)
         wu->rd_workers_time_max = rrddim_add(wu->st_workers_time, "max", NULL, 1, WORKER_CHART_DECIMAL_PRECISION, RRD_ALGORITHM_ABSOLUTE);
 
-    if(unlikely(!wu->rd_workers_time_avg))
+    if(!wu->rd_workers_time_avg)
         wu->rd_workers_time_avg = rrddim_add(wu->st_workers_time, "average", NULL, 1, WORKER_CHART_DECIMAL_PRECISION, RRD_ALGORITHM_ABSOLUTE);
 
-    if(unlikely(wu->workers_min_busy_time == WORKERS_MIN_PERCENT_DEFAULT)) wu->workers_min_busy_time = 0.0;
+    if(wu->workers_min_busy_time == WORKERS_MIN_PERCENT_DEFAULT) wu->workers_min_busy_time = 0.0;
 
     if(wu->rd_workers_time_min)
         rrddim_set_by_pointer(wu->st_workers_time, wu->rd_workers_time_min, (collected_number)((double)wu->workers_min_busy_time * WORKER_CHART_DECIMAL_PRECISION));
@@ -3545,7 +3545,7 @@ static void workers_utilization_update_chart(struct worker_utilization *wu) {
 
 #ifdef __linux__
     if(wu->workers_cpu_registered || wu->st_workers_cpu) {
-        if(unlikely(!wu->st_workers_cpu)) {
+        if(!wu->st_workers_cpu) {
             char name[RRD_ID_LENGTH_MAX + 1];
             snprintfz(name, RRD_ID_LENGTH_MAX, "workers_cpu_%s", wu->name_lowercase);
 
@@ -3568,16 +3568,16 @@ static void workers_utilization_update_chart(struct worker_utilization *wu) {
             );
         }
 
-        if (unlikely(!wu->rd_workers_cpu_min && wu->workers_registered > 1))
+        if (!wu->rd_workers_cpu_min && wu->workers_registered > 1)
             wu->rd_workers_cpu_min = rrddim_add(wu->st_workers_cpu, "min", NULL, 1, WORKER_CHART_DECIMAL_PRECISION, RRD_ALGORITHM_ABSOLUTE);
 
-        if (unlikely(!wu->rd_workers_cpu_max && wu->workers_registered > 1))
+        if (!wu->rd_workers_cpu_max && wu->workers_registered > 1)
             wu->rd_workers_cpu_max = rrddim_add(wu->st_workers_cpu, "max", NULL, 1, WORKER_CHART_DECIMAL_PRECISION, RRD_ALGORITHM_ABSOLUTE);
 
-        if(unlikely(!wu->rd_workers_cpu_avg))
+        if(!wu->rd_workers_cpu_avg)
             wu->rd_workers_cpu_avg = rrddim_add(wu->st_workers_cpu, "average", NULL, 1, WORKER_CHART_DECIMAL_PRECISION, RRD_ALGORITHM_ABSOLUTE);
 
-        if(unlikely(wu->workers_cpu_min == WORKERS_MIN_PERCENT_DEFAULT)) wu->workers_cpu_min = 0.0;
+        if(wu->workers_cpu_min == WORKERS_MIN_PERCENT_DEFAULT) wu->workers_cpu_min = 0.0;
 
         if(wu->rd_workers_cpu_min)
             rrddim_set_by_pointer(wu->st_workers_cpu, wu->rd_workers_cpu_min, (collected_number)(wu->workers_cpu_min * WORKER_CHART_DECIMAL_PRECISION));
@@ -3596,7 +3596,7 @@ static void workers_utilization_update_chart(struct worker_utilization *wu) {
 
     // ----------------------------------------------------------------------
 
-    if(unlikely(!wu->st_workers_jobs_per_job_type)) {
+    if(!wu->st_workers_jobs_per_job_type) {
         char name[RRD_ID_LENGTH_MAX + 1];
         snprintfz(name, RRD_ID_LENGTH_MAX, "workers_jobs_by_type_%s", wu->name_lowercase);
 
@@ -3622,12 +3622,12 @@ static void workers_utilization_update_chart(struct worker_utilization *wu) {
     {
         size_t i;
         for(i = 0; i <= wu->workers_max_job_id ;i++) {
-            if(unlikely(wu->per_job_type[i].type != WORKER_METRIC_IDLE_BUSY))
+            if(wu->per_job_type[i].type != WORKER_METRIC_IDLE_BUSY)
                 continue;
 
             if (wu->per_job_type[i].name) {
 
-                if(unlikely(!wu->per_job_type[i].rd_jobs_started))
+                if(!wu->per_job_type[i].rd_jobs_started)
                     wu->per_job_type[i].rd_jobs_started = rrddim_add(wu->st_workers_jobs_per_job_type, string2str(wu->per_job_type[i].name), NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
 
                 rrddim_set_by_pointer(wu->st_workers_jobs_per_job_type, wu->per_job_type[i].rd_jobs_started, (collected_number)(wu->per_job_type[i].jobs_started));
@@ -3639,7 +3639,7 @@ static void workers_utilization_update_chart(struct worker_utilization *wu) {
 
     // ----------------------------------------------------------------------
 
-    if(unlikely(!wu->st_workers_busy_per_job_type)) {
+    if(!wu->st_workers_busy_per_job_type) {
         char name[RRD_ID_LENGTH_MAX + 1];
         snprintfz(name, RRD_ID_LENGTH_MAX, "workers_busy_time_by_type_%s", wu->name_lowercase);
 
@@ -3665,12 +3665,12 @@ static void workers_utilization_update_chart(struct worker_utilization *wu) {
     {
         size_t i;
         for(i = 0; i <= wu->workers_max_job_id ;i++) {
-            if(unlikely(wu->per_job_type[i].type != WORKER_METRIC_IDLE_BUSY))
+            if(wu->per_job_type[i].type != WORKER_METRIC_IDLE_BUSY)
                 continue;
 
             if (wu->per_job_type[i].name) {
 
-                if(unlikely(!wu->per_job_type[i].rd_busy_time))
+                if(!wu->per_job_type[i].rd_busy_time)
                     wu->per_job_type[i].rd_busy_time = rrddim_add(wu->st_workers_busy_per_job_type, string2str(wu->per_job_type[i].name), NULL, 1, USEC_PER_MS, RRD_ALGORITHM_ABSOLUTE);
 
                 rrddim_set_by_pointer(wu->st_workers_busy_per_job_type, wu->per_job_type[i].rd_busy_time, (collected_number)(wu->per_job_type[i].busy_time));
@@ -3683,7 +3683,7 @@ static void workers_utilization_update_chart(struct worker_utilization *wu) {
     // ----------------------------------------------------------------------
 
     if(wu->st_workers_threads || wu->workers_registered > 1) {
-        if(unlikely(!wu->st_workers_threads)) {
+        if(!wu->st_workers_threads) {
             char name[RRD_ID_LENGTH_MAX + 1];
             snprintfz(name, RRD_ID_LENGTH_MAX, "workers_threads_%s", wu->name_lowercase);
 
@@ -3843,7 +3843,7 @@ static void workers_utilization_reset_statistics(struct worker_utilization *wu) 
 
     size_t i;
     for(i = 0; i < WORKER_UTILIZATION_MAX_JOB_TYPES ;i++) {
-        if(unlikely(!wu->name_lowercase)) {
+        if(!wu->name_lowercase) {
             wu->name_lowercase = strdupz(wu->name);
             char *s = wu->name_lowercase;
             for( ; *s ; s++) *s = tolower(*s);
@@ -3881,14 +3881,14 @@ static int read_thread_cpu_time_from_proc_stat(pid_t pid __maybe_unused, kernel_
     // (re)open the procfile to the new filename
     bool set_quotes = (ff == NULL) ? true : false;
     ff = procfile_reopen(ff, filename, NULL, PROCFILE_FLAG_ERROR_ON_ERROR_LOG);
-    if(unlikely(!ff)) return -1;
+    if(!ff) return -1;
 
     if(set_quotes)
         procfile_set_open_close(ff, "(", ")");
 
     // read the entire file and split it to lines and words
     ff = procfile_readall(ff);
-    if(unlikely(!ff)) return -1;
+    if(!ff) return -1;
 
     // parse the numbers we are interested
     *utime = str2kernel_uint_t(procfile_lineword(ff, 0, 13));
@@ -4062,7 +4062,7 @@ static void worker_utilization_charts(void) {
         netdata_thread_enable_cancelability();
 
         // skip the first iteration, so that we don't accumulate startup utilization to our charts
-        if(likely(iterations > 1))
+        if(iterations > 1)
             workers_utilization_update_chart(&all_workers_utilization[i]);
 
         netdata_thread_disable_cancelability();

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -106,7 +106,7 @@ void service_exits(void) {
 bool service_running(SERVICE_TYPE service) {
     static __thread SERVICE_THREAD *sth = NULL;
 
-    if(unlikely(!sth))
+    if(!sth)
         sth = service_register(SERVICE_THREAD_TYPE_NETDATA, NULL, NULL, NULL, false);
 
     sth->services |= service;
@@ -1262,7 +1262,7 @@ int get_system_info(struct rrdhost_system_info *system_info, bool log) {
     char *script;
     script = mallocz(sizeof(char) * (strlen(netdata_configured_primary_plugins_dir) + strlen("system-info.sh") + 2));
     sprintf(script, "%s/%s", netdata_configured_primary_plugins_dir, "system-info.sh");
-    if (unlikely(access(script, R_OK) != 0)) {
+    if (access(script, R_OK) != 0) {
         netdata_log_error("System info script %s not found.",script);
         freez(script);
         return 1;
@@ -1288,7 +1288,7 @@ int get_system_info(struct rrdhost_system_info *system_info, bool log) {
                 coverity_remove_taint(line);    // I/O is controlled result of system_info.sh - not tainted
                 coverity_remove_taint(value);
 
-                if(unlikely(rrdhost_set_system_info_variable(system_info, line, value))) {
+                if(rrdhost_set_system_info_variable(system_info, line, value)) {
                     netdata_log_error("Unexpected environment variable %s=%s", line, value);
                 }
                 else {

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -41,7 +41,7 @@ static void svc_rrddim_obsolete_to_archive(RRDDIM *rd) {
     const char *cache_filename = rrddim_cache_filename(rd);
     if(cache_filename) {
         netdata_log_info("Deleting dimension file '%s'.", cache_filename);
-        if (unlikely(unlink(cache_filename) == -1))
+        if (unlink(cache_filename) == -1)
             netdata_log_error("Cannot delete dimension file '%s'", cache_filename);
     }
 
@@ -85,10 +85,10 @@ static bool svc_rrdset_archive_obsolete_dimensions(RRDSET *st, bool all_dimensio
     bool done_all_dimensions = true;
 
     dfe_start_write(st->rrddim_root_index, rd) {
-        if(unlikely(
+        if(
                 all_dimensions ||
                 (rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE) && (rd->collector.last_collected_time.tv_sec + rrdset_free_obsolete_time_s < now))
-                    )) {
+                    ) {
 
             if(dictionary_acquired_item_references(rd_dfe.item) == 1) {
                 netdata_log_info("Removing obsolete dimension '%s' (%s) of '%s' (%s).", rrddim_name(rd), rrddim_id(rd), rrdset_name(st), rrdset_id(st));
@@ -145,11 +145,11 @@ static void svc_rrdhost_cleanup_obsolete_charts(RRDHOST *host) {
         if(rrdset_is_replicating(st))
             continue;
 
-        if(unlikely(rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE)
+        if(rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE)
                      && st->last_accessed_time_s + rrdset_free_obsolete_time_s < now
                      && st->last_updated.tv_sec + rrdset_free_obsolete_time_s < now
                      && st->last_collected_time.tv_sec + rrdset_free_obsolete_time_s < now
-                     )) {
+                     ) {
             svc_rrdset_obsolete_to_archive(st);
         }
         else if(rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE_DIMENSIONS)) {

--- a/daemon/signals.c
+++ b/daemon/signals.c
@@ -37,7 +37,7 @@ static void signal_handler(int signo) {
     // find the entry in the list
     int i;
     for(i = 0; signals_waiting[i].action != NETDATA_SIGNAL_END_OF_LIST ; i++) {
-        if(unlikely(signals_waiting[i].signo == signo)) {
+        if(signals_waiting[i].signo == signo) {
             signals_waiting[i].count++;
 
             if(signals_waiting[i].action == NETDATA_SIGNAL_FATAL) {

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1663,7 +1663,7 @@ int test_sqlite(void) {
     }
 
     rc = sqlite3_create_function(db_meta, "now_usec", 1, SQLITE_ANY, 0, sqlite_now_usec, 0, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         fprintf(stderr, "Failed to register internal now_usec function");
         return 1;
     }
@@ -1823,7 +1823,7 @@ static inline void rrddim_set_by_pointer_fake_time(RRDDIM *rd, collected_number 
     rd->collector.counter++;
 
     collected_number v = (value >= 0) ? value : -value;
-    if(unlikely(v > rd->collector.collected_value_max)) rd->collector.collected_value_max = v;
+    if(v > rd->collector.collected_value_max) rd->collector.collected_value_max = v;
 }
 
 static RRDHOST *dbengine_rrdhost_find_or_create(char *name)
@@ -2061,7 +2061,7 @@ static int test_dbengine_check_rrdr(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS][DIMS]
 
                 // for each dimension
                 rrddim_foreach_read(d, r->internal.qt->request.st) {
-                    if(unlikely(d_dfe.counter >= r->d)) break; // d_counter is provided by the dictionary dfe
+                    if(d_dfe.counter >= r->d) break; // d_counter is provided by the dictionary dfe
 
                     j = (int)d_dfe.counter;
 
@@ -2200,7 +2200,7 @@ int test_dbengine(void)
 
                 // for each dimension
                 rrddim_foreach_read(d, r->internal.qt->request.st) {
-                    if(unlikely(d_dfe.counter >= r->d)) break; // d_counter is provided by the dictionary dfe
+                    if(d_dfe.counter >= r->d) break; // d_counter is provided by the dictionary dfe
 
                     j = (int)d_dfe.counter;
 
@@ -2447,7 +2447,7 @@ static void query_dbengine_chart(void *arg)
             generatedv = generate_dbengine_chart_value(i, j, time_now);
             expected = unpack_storage_number(pack_storage_number((NETDATA_DOUBLE) generatedv, SN_DEFAULT_FLAGS));
 
-            if (unlikely(storage_engine_query_is_finished(&handle))) {
+            if (storage_engine_query_is_finished(&handle)) {
                 if (!thread_info->delete_old_data) { /* data validation only when we don't delete */
                     fprintf(stderr, "    DB-engine stresstest %s/%s: at %lu secs, expecting value " NETDATA_DOUBLE_FORMAT
                         ", found data gap, ### E R R O R ###\n",

--- a/database/contexts/api_v1.c
+++ b/database/contexts/api_v1.c
@@ -58,7 +58,7 @@ static inline int rrdmetric_to_json_callback(const DICTIONARY_ITEM *item, void *
     time_t after = t->after;
     time_t before = t->before;
 
-    if(unlikely(rrd_flag_is_deleted(rm) && !(options & RRDCONTEXT_OPTION_SHOW_DELETED)))
+    if(rrd_flag_is_deleted(rm) && !(options & RRDCONTEXT_OPTION_SHOW_DELETED))
         return 0;
 
     if(after && (!rm->last_time_s || after > rm->last_time_s))
@@ -122,7 +122,7 @@ static inline int rrdinstance_to_json_callback(const DICTIONARY_ITEM *item, void
     time_t before = t_parent->before;
     bool has_filter = t_parent->chart_label_key || t_parent->chart_labels_filter || t_parent->chart_dimensions;
 
-    if(unlikely(rrd_flag_is_deleted(ri) && !(options & RRDCONTEXT_OPTION_SHOW_DELETED)))
+    if(rrd_flag_is_deleted(ri) && !(options & RRDCONTEXT_OPTION_SHOW_DELETED))
         return 0;
 
     if(after && (!ri->last_time_s || after > ri->last_time_s))
@@ -242,10 +242,10 @@ static inline int rrdcontext_to_json_callback(const DICTIONARY_ITEM *item, void 
     time_t before = t_parent->before;
     bool has_filter = t_parent->chart_label_key || t_parent->chart_labels_filter || t_parent->chart_dimensions;
 
-    if(unlikely(rrd_flag_check(rc, RRD_FLAG_HIDDEN) && !(options & RRDCONTEXT_OPTION_SHOW_HIDDEN)))
+    if(rrd_flag_check(rc, RRD_FLAG_HIDDEN) && !(options & RRDCONTEXT_OPTION_SHOW_HIDDEN))
         return 0;
 
-    if(unlikely(rrd_flag_is_deleted(rc) && !(options & RRDCONTEXT_OPTION_SHOW_DELETED)))
+    if(rrd_flag_is_deleted(rc) && !(options & RRDCONTEXT_OPTION_SHOW_DELETED))
         return 0;
 
     if(options & RRDCONTEXT_OPTION_DEEPSCAN)

--- a/database/contexts/context.c
+++ b/database/contexts/context.c
@@ -225,8 +225,8 @@ static bool rrdcontext_post_processing_queue_conflict_callback(const DICTIONARY_
 
 
 void rrdhost_create_rrdcontexts(RRDHOST *host) {
-    if(unlikely(!host)) return;
-    if(likely(host->rrdctx.contexts)) return;
+    if(!host) return;
+    if(host->rrdctx.contexts) return;
 
     host->rrdctx.contexts = dictionary_create_advanced(
             DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_FIXED_SIZE,
@@ -249,8 +249,8 @@ void rrdhost_create_rrdcontexts(RRDHOST *host) {
 }
 
 void rrdhost_destroy_rrdcontexts(RRDHOST *host) {
-    if(unlikely(!host)) return;
-    if(unlikely(!host->rrdctx.contexts)) return;
+    if(!host) return;
+    if(!host->rrdctx.contexts) return;
 
     DICTIONARY *old;
 

--- a/database/contexts/query_scope.c
+++ b/database/contexts/query_scope.c
@@ -74,7 +74,7 @@ ssize_t query_scope_foreach_host(SIMPLE_PATTERN *scope_hosts_sp, SIMPLE_PATTERN 
 
 ssize_t query_scope_foreach_context(RRDHOST *host, const char *scope_contexts, SIMPLE_PATTERN *scope_contexts_sp,
                                    SIMPLE_PATTERN *contexts_sp, foreach_context_cb_t cb, bool queryable_host, void *data) {
-    if(unlikely(!host->rrdctx.contexts))
+    if(!host->rrdctx.contexts)
         return 0;
 
     ssize_t added = 0;
@@ -84,7 +84,7 @@ ssize_t query_scope_foreach_context(RRDHOST *host, const char *scope_contexts, S
     if(scope_contexts)
         rca = (RRDCONTEXT_ACQUIRED *)dictionary_get_and_acquire_item(host->rrdctx.contexts, scope_contexts);
 
-    if(likely(rca)) {
+    if(rca) {
         // we found it!
 
         bool queryable_context = queryable_host;

--- a/database/contexts/query_target.c
+++ b/database/contexts/query_target.c
@@ -58,7 +58,7 @@ static void query_target_destroy(QUERY_TARGET *qt) {
 }
 
 void query_target_release(QUERY_TARGET *qt) {
-    if(unlikely(!qt)) return;
+    if(!qt) return;
 
     internal_fatal(!qt->internal.used, "QUERY TARGET: qt to be released is not used");
 
@@ -159,7 +159,7 @@ static QUERY_TARGET *query_target_get(void) {
     }
     spinlock_unlock(&query_target_base.available.spinlock);
 
-    if(unlikely(!qt))
+    if(!qt)
         qt = callocz(1, sizeof(*qt));
 
     spinlock_lock(&query_target_base.used.spinlock);
@@ -496,7 +496,7 @@ static bool query_dimension_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_
 }
 
 static inline STRING *rrdinstance_create_id_fqdn_v1(RRDINSTANCE_ACQUIRED *ria) {
-    if(unlikely(!ria))
+    if(!ria)
         return NULL;
 
     RRDINSTANCE *ri = rrdinstance_acquired_value(ria);
@@ -504,7 +504,7 @@ static inline STRING *rrdinstance_create_id_fqdn_v1(RRDINSTANCE_ACQUIRED *ria) {
 }
 
 static inline STRING *rrdinstance_create_name_fqdn_v1(RRDINSTANCE_ACQUIRED *ria) {
-    if(unlikely(!ria))
+    if(!ria)
         return NULL;
 
     RRDINSTANCE *ri = rrdinstance_acquired_value(ria);
@@ -512,7 +512,7 @@ static inline STRING *rrdinstance_create_name_fqdn_v1(RRDINSTANCE_ACQUIRED *ria)
 }
 
 static inline STRING *rrdinstance_create_id_fqdn_v2(RRDINSTANCE_ACQUIRED *ria) {
-    if(unlikely(!ria))
+    if(!ria)
         return NULL;
 
     char buffer[RRD_ID_LENGTH_MAX + 1];
@@ -523,7 +523,7 @@ static inline STRING *rrdinstance_create_id_fqdn_v2(RRDINSTANCE_ACQUIRED *ria) {
 }
 
 static inline STRING *rrdinstance_create_name_fqdn_v2(RRDINSTANCE_ACQUIRED *ria) {
-    if(unlikely(!ria))
+    if(!ria)
         return NULL;
 
     char buffer[RRD_ID_LENGTH_MAX + 1];
@@ -764,7 +764,7 @@ static bool query_instance_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_C
 
     size_t dimensions_added = 0, metrics_added = 0, priority = 0;
 
-    if(unlikely(qt->request.rma)) {
+    if(qt->request.rma) {
         if(query_dimension_add(qtl, qn, qc, qi, qt->request.rma, queryable_instance, &metrics_added, priority++))
             dimensions_added++;
     }
@@ -831,11 +831,11 @@ static ssize_t query_context_add(void *data, RRDCONTEXT_ACQUIRED *rca, bool quer
     QUERY_CONTEXT *qc = query_context_allocate(qt, rca);
 
     ssize_t added = 0;
-    if(unlikely(qt->request.ria)) {
+    if(qt->request.ria) {
         if(query_instance_add(qtl, qn, qc, qt->request.ria, queryable_context, false))
             added++;
     }
-    else if(unlikely(qtl->st && qtl->st->rrdcontext == rca && qtl->st->rrdinstance)) {
+    else if(qtl->st && qtl->st->rrdcontext == rca && qtl->st->rrdinstance) {
         if(query_instance_add(qtl, qn, qc, qtl->st->rrdinstance, queryable_context, false))
             added++;
     }
@@ -894,11 +894,11 @@ static ssize_t query_node_add(void *data, RRDHOST *host, bool queryable_host) {
         qn->node_id[0] = '\0';
 
     // is the chart given valid?
-    if(unlikely(qtl->st && (!qtl->st->rrdinstance || !qtl->st->rrdcontext))) {
+    if(qtl->st && (!qtl->st->rrdinstance || !qtl->st->rrdcontext)) {
         netdata_log_error("QUERY TARGET: RRDSET '%s' given, but it is not linked to rrdcontext structures. Linking it now.", rrdset_name(qtl->st));
         rrdinstance_from_rrdset(qtl->st);
 
-        if(unlikely(qtl->st && (!qtl->st->rrdinstance || !qtl->st->rrdcontext))) {
+        if(qtl->st && (!qtl->st->rrdinstance || !qtl->st->rrdcontext)) {
             netdata_log_error("QUERY TARGET: RRDSET '%s' given, but failed to be linked to rrdcontext structures. Switching to context query.",
                               rrdset_name(qtl->st));
 
@@ -912,11 +912,11 @@ static ssize_t query_node_add(void *data, RRDHOST *host, bool queryable_host) {
     qtl->qn = qn;
 
     ssize_t added = 0;
-    if(unlikely(qt->request.rca)) {
+    if(qt->request.rca) {
         if(query_context_add(qtl, qt->request.rca, true))
             added++;
     }
-    else if(unlikely(qtl->st)) {
+    else if(qtl->st) {
         // single chart data queries
         if(query_context_add(qtl, qtl->st->rrdcontext, true))
             added++;
@@ -1087,7 +1087,7 @@ QUERY_TARGET *query_target_create(QUERY_TARGET_REQUEST *qtr) {
 
     qtl.match_ids = qt->request.options & RRDR_OPTION_MATCH_IDS;
     qtl.match_names = qt->request.options & RRDR_OPTION_MATCH_NAMES;
-    if(likely(!qtl.match_ids && !qtl.match_names))
+    if(!qtl.match_ids && !qtl.match_names)
         qtl.match_ids = qtl.match_names = true;
 
     // verify that the chart belongs to the host we are interested
@@ -1096,7 +1096,7 @@ QUERY_TARGET *query_target_create(QUERY_TARGET_REQUEST *qtr) {
             // It is NULL, set it ourselves.
             host = qtl.st->rrdhost;
         }
-        else if (unlikely(host != qtl.st->rrdhost)) {
+        else if (host != qtl.st->rrdhost) {
             // Oops! A different host!
             netdata_log_error("QUERY TARGET: RRDSET '%s' given does not belong to host '%s'. Switching query host to '%s'",
                   rrdset_name(qtl.st), rrdhost_hostname(host), rrdhost_hostname(qtl.st->rrdhost));
@@ -1210,7 +1210,7 @@ ssize_t weights_foreach_rrdmetric_in_context(RRDCONTEXT_ACQUIRED *rca,
                         }
                 dfe_done(rm);
 
-                if(unlikely(!proceed))
+                if(!proceed)
                     break;
             }
     dfe_done(ri);

--- a/database/contexts/rrdcontext.c
+++ b/database/contexts/rrdcontext.c
@@ -167,14 +167,14 @@ void rrdcontext_host_child_disconnected(RRDHOST *host) {
 }
 
 int rrdcontext_foreach_instance_with_rrdset_in_context(RRDHOST *host, const char *context, int (*callback)(RRDSET *st, void *data), void *data) {
-    if(unlikely(!host || !context || !*context || !callback))
+    if(!host || !context || !*context || !callback)
         return -1;
 
     RRDCONTEXT_ACQUIRED *rca = (RRDCONTEXT_ACQUIRED *)dictionary_get_and_acquire_item(host->rrdctx.contexts, context);
-    if(unlikely(!rca)) return -1;
+    if(!rca) return -1;
 
     RRDCONTEXT *rc = rrdcontext_acquired_value(rca);
-    if(unlikely(!rc)) return -1;
+    if(!rc) return -1;
 
     int ret = 0;
     RRDINSTANCE *ri;
@@ -314,7 +314,7 @@ void rrdcontext_hub_stop_streaming_command(void *ptr) {
 }
 
 bool rrdcontext_retention_match(RRDCONTEXT_ACQUIRED *rca, time_t after, time_t before) {
-    if(unlikely(!rca)) return false;
+    if(!rca) return false;
 
     RRDCONTEXT *rc = rrdcontext_acquired_value(rca);
 

--- a/database/engine/datafile.c
+++ b/database/engine/datafile.c
@@ -259,7 +259,7 @@ int create_data_file(struct rrdengine_datafile *datafile)
     __atomic_add_fetch(&ctx->stats.datafile_creations, 1, __ATOMIC_RELAXED);
 
     ret = posix_memalign((void *)&superblock, RRDFILE_ALIGNMENT, sizeof(*superblock));
-    if (unlikely(ret)) {
+    if (ret) {
         fatal("DBENGINE: posix_memalign:%s", strerror(ret));
     }
     memset(superblock, 0, sizeof(*superblock));
@@ -296,7 +296,7 @@ static int check_data_file_superblock(uv_file file)
     uv_fs_t req;
 
     ret = posix_memalign((void *)&superblock, RRDFILE_ALIGNMENT, sizeof(*superblock));
-    if (unlikely(ret)) {
+    if (ret) {
         fatal("DBENGINE: posix_memalign:%s", strerror(ret));
     }
     iov = uv_buf_init((void *)superblock, sizeof(*superblock));

--- a/database/engine/rrdenginelib.c
+++ b/database/engine/rrdenginelib.c
@@ -81,15 +81,15 @@ int is_legacy_child(const char *machine_guid)
     uuid_t uuid;
     char  dbengine_file[FILENAME_MAX+1];
 
-    if (unlikely(!strcmp(machine_guid, "unittest-dbengine") || !strcmp(machine_guid, "dbengine-dataset") ||
-                 !strcmp(machine_guid, "dbengine-stress-test"))) {
+    if (!strcmp(machine_guid, "unittest-dbengine") || !strcmp(machine_guid, "dbengine-dataset") ||
+                 !strcmp(machine_guid, "dbengine-stress-test")) {
         return 1;
     }
     if (!uuid_parse(machine_guid, uuid)) {
         uv_fs_t stat_req;
         snprintfz(dbengine_file, FILENAME_MAX, "%s/%s/dbengine", netdata_configured_cache_dir, machine_guid);
         int rc = uv_fs_stat(NULL, &stat_req, dbengine_file, NULL);
-        if (likely(rc == 0 && ((stat_req.statbuf.st_mode & S_IFMT) == S_IFDIR))) {
+        if (rc == 0 && ((stat_req.statbuf.st_mode & S_IFMT) == S_IFDIR)) {
             //netdata_log_info("Found legacy engine folder \"%s\"", dbengine_file);
             return 1;
         }
@@ -129,10 +129,10 @@ int compute_multidb_diskspace()
 
     snprintfz(multidb_disk_space_file, FILENAME_MAX, "%s/dbengine_multihost_size", netdata_configured_varlib_dir);
     fp = fopen(multidb_disk_space_file, "r");
-    if (likely(fp)) {
+    if (fp) {
         int rc = fscanf(fp, "%d", &computed_multidb_disk_quota_mb);
         fclose(fp);
-        if (unlikely(rc != 1 || computed_multidb_disk_quota_mb < RRDENG_MIN_DISK_SPACE_MB)) {
+        if (rc != 1 || computed_multidb_disk_quota_mb < RRDENG_MIN_DISK_SPACE_MB) {
             errno = 0;
             netdata_log_error("File '%s' contains invalid input, it will be rebuild", multidb_disk_space_file);
             computed_multidb_disk_quota_mb = -1;
@@ -141,12 +141,12 @@ int compute_multidb_diskspace()
 
     if (computed_multidb_disk_quota_mb == -1) {
         int rc = count_legacy_children(netdata_configured_cache_dir);
-        if (likely(rc >= 0)) {
+        if (rc >= 0) {
             computed_multidb_disk_quota_mb = (rc + 1) * default_rrdeng_disk_quota_mb;
             netdata_log_info("Found %d legacy dbengines, setting multidb diskspace to %dMB", rc, computed_multidb_disk_quota_mb);
 
             fp = fopen(multidb_disk_space_file, "w");
-            if (likely(fp)) {
+            if (fp) {
                 fprintf(fp, "%d", computed_multidb_disk_quota_mb);
                 netdata_log_info("Created file '%s' to store the computed value", multidb_disk_space_file);
                 fclose(fp);

--- a/database/ram/rrddim_mem.c
+++ b/database/ram/rrddim_mem.c
@@ -79,7 +79,7 @@ rrddim_metric_get(STORAGE_INSTANCE *db_instance __maybe_unused, uuid_t *uuid) {
     struct mem_metric_handle *mh = NULL;
     netdata_rwlock_rdlock(&rrddim_JudyHS_rwlock);
     Pvoid_t *PValue = JudyHSGet(rrddim_JudyHS_array, uuid, sizeof(uuid_t));
-    if (likely(NULL != PValue)) {
+    if (NULL != PValue) {
         mh = *PValue;
         if(__atomic_add_fetch(&mh->refcount, 1, __ATOMIC_RELAXED) <= 0)
             mh = NULL;
@@ -194,7 +194,7 @@ static inline void rrddim_fill_the_gap(STORAGE_COLLECT_HANDLE *collection_handle
         for(c = 0; c < entries && now_store_s <= now_collect_s ; now_store_s += update_every_s, c++) {
             rd->db.data[current_entry++] = empty;
 
-            if(unlikely(current_entry >= entries))
+            if(current_entry >= entries)
                 current_entry = 0;
         }
         mh->counter += c;
@@ -221,10 +221,10 @@ void rrddim_collect_store_metric(STORAGE_COLLECT_HANDLE *collection_handle,
     internal_fatal(ch->rd != mh->rd, "RRDDIM: dimensions do not match");
     check_metric_handle_from_rrddim(mh);
 
-    if(unlikely(point_in_time_s <= mh->last_updated_s))
+    if(point_in_time_s <= mh->last_updated_s)
         return;
 
-    if(unlikely(mh->last_updated_s && point_in_time_s - mh->update_every_s > mh->last_updated_s))
+    if(mh->last_updated_s && point_in_time_s - mh->update_every_s > mh->last_updated_s)
         rrddim_fill_the_gap(collection_handle, point_in_time_s);
 
     rd->db.data[mh->current_entry] = pack_storage_number(n, flags);
@@ -282,7 +282,7 @@ static inline size_t rrddim_time2slot(STORAGE_METRIC_HANDLE *db_metric_handle, t
         }
     }
 
-    if(unlikely(ret >= entries)) {
+    if(ret >= entries) {
         netdata_log_error("INTERNAL ERROR: rrddim_time2slot() on %s returns values outside entries", rrddim_name(rd));
         ret = entries - 1;
     }
@@ -313,14 +313,14 @@ static inline time_t rrddim_slot2time(STORAGE_METRIC_HANDLE *db_metric_handle, s
     else
         ret = last_entry_s - (time_t)(update_every * (last_slot - slot));
 
-    if(unlikely(ret < first_entry_s)) {
+    if(ret < first_entry_s) {
         netdata_log_error("INTERNAL ERROR: rrddim_slot2time() on dimension '%s' of chart '%s' returned time (%ld) too far in the past (before first_entry_s %ld) for slot %zu",
               rrddim_name(rd), rrdset_id(rd->rrdset), ret, first_entry_s, slot);
 
         ret = first_entry_s;
     }
 
-    if(unlikely(ret > last_entry_s)) {
+    if(ret > last_entry_s) {
         netdata_log_error("INTERNAL ERROR: rrddim_slot2time() on dimension '%s' of chart '%s' returned time (%ld) too far into the future (after last_entry_s %ld) for slot %zu",
               rrddim_name(rd), rrdset_id(rd->rrdset), ret, last_entry_s, slot);
 
@@ -380,18 +380,18 @@ STORAGE_POINT rrddim_query_next_metric(struct storage_engine_query_handle *handl
     sp.start_time_s = this_timestamp - h->dt;
     sp.end_time_s = this_timestamp;
 
-    if(unlikely(this_timestamp < h->slot_timestamp)) {
+    if(this_timestamp < h->slot_timestamp) {
         storage_point_empty(sp, sp.start_time_s, sp.end_time_s);
         return sp;
     }
 
-    if(unlikely(this_timestamp > h->last_timestamp)) {
+    if(this_timestamp > h->last_timestamp) {
         storage_point_empty(sp, sp.start_time_s, sp.end_time_s);
         return sp;
     }
 
     storage_number n = rd->db.data[slot++];
-    if(unlikely(slot >= entries)) slot = 0;
+    if(slot >= entries) slot = 0;
 
     h->slot = slot;
     h->slot_timestamp += h->dt;

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -108,13 +108,13 @@ const char *rrd_algorithm_name(RRD_ALGORITHM algorithm) {
 // RRD - chart types
 
 inline RRDSET_TYPE rrdset_type_id(const char *name) {
-    if(unlikely(strcmp(name, RRDSET_TYPE_AREA_NAME) == 0))
+    if(strcmp(name, RRDSET_TYPE_AREA_NAME) == 0)
         return RRDSET_TYPE_AREA;
 
-    else if(unlikely(strcmp(name, RRDSET_TYPE_STACKED_NAME) == 0))
+    else if(strcmp(name, RRDSET_TYPE_STACKED_NAME) == 0)
         return RRDSET_TYPE_STACKED;
 
-    else // if(unlikely(strcmp(name, RRDSET_TYPE_LINE_NAME) == 0))
+    else // if(strcmp(name, RRDSET_TYPE_LINE_NAME) == 0)
         return RRDSET_TYPE_LINE;
 }
 
@@ -158,7 +158,7 @@ char *rrdhost_cache_dir_for_rrdset_alloc(RRDHOST *host, const char *id) {
 // RRD - string management
 
 STRING *rrd_string_strdupz(const char *s) {
-    if(unlikely(!s || !*s)) return string_strdupz(s);
+    if(!s || !*s) return string_strdupz(s);
 
     char *tmp = strdupz(s);
     json_fix_string(tmp);

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -447,7 +447,7 @@ static inline STORAGE_METRICS_GROUP *storage_engine_metrics_group_get(STORAGE_EN
     internal_fatal(!is_valid_backend(backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
-    if(likely(backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+    if(backend == STORAGE_ENGINE_BACKEND_DBENGINE)
         return rrdeng_metrics_group_get(db_instance, uuid);
 #endif
     return rrddim_metrics_group_get(db_instance, uuid);
@@ -459,7 +459,7 @@ static inline void storage_engine_metrics_group_release(STORAGE_ENGINE_BACKEND b
     internal_fatal(!is_valid_backend(backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
-    if(likely(backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+    if(backend == STORAGE_ENGINE_BACKEND_DBENGINE)
         rrdeng_metrics_group_release(db_instance, smg);
     else
 #endif
@@ -472,7 +472,7 @@ static inline STORAGE_COLLECT_HANDLE *storage_metric_store_init(STORAGE_ENGINE_B
     internal_fatal(!is_valid_backend(backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
-    if(likely(backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+    if(backend == STORAGE_ENGINE_BACKEND_DBENGINE)
         return rrdeng_store_metric_init(db_metric_handle, update_every, smg);
 #endif
     return rrddim_collect_init(db_metric_handle, update_every, smg);
@@ -495,7 +495,7 @@ static inline void storage_engine_store_metric(
     internal_fatal(!is_valid_backend(collection_handle->backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
-    if(likely(collection_handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+    if(collection_handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE)
         return rrdeng_store_metric_next(collection_handle, point_in_time_ut,
                                         n, min_value, max_value,
                                         count, anomaly_count, flags);
@@ -508,7 +508,7 @@ static inline void storage_engine_store_metric(
 size_t rrdeng_disk_space_max(STORAGE_INSTANCE *db_instance);
 static inline size_t storage_engine_disk_space_max(STORAGE_ENGINE_BACKEND backend __maybe_unused, STORAGE_INSTANCE *db_instance) {
 #ifdef ENABLE_DBENGINE
-    if(likely(backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+    if(backend == STORAGE_ENGINE_BACKEND_DBENGINE)
         return rrdeng_disk_space_max(db_instance);
 #endif
 
@@ -518,7 +518,7 @@ static inline size_t storage_engine_disk_space_max(STORAGE_ENGINE_BACKEND backen
 size_t rrdeng_disk_space_used(STORAGE_INSTANCE *db_instance);
 static inline size_t storage_engine_disk_space_used(STORAGE_ENGINE_BACKEND backend __maybe_unused, STORAGE_INSTANCE *db_instance) {
 #ifdef ENABLE_DBENGINE
-    if(likely(backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+    if(backend == STORAGE_ENGINE_BACKEND_DBENGINE)
         return rrdeng_disk_space_used(db_instance);
 #endif
 
@@ -529,7 +529,7 @@ static inline size_t storage_engine_disk_space_used(STORAGE_ENGINE_BACKEND backe
 time_t rrdeng_global_first_time_s(STORAGE_INSTANCE *db_instance);
 static inline time_t storage_engine_global_first_time_s(STORAGE_ENGINE_BACKEND backend __maybe_unused, STORAGE_INSTANCE *db_instance) {
 #ifdef ENABLE_DBENGINE
-    if(likely(backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+    if(backend == STORAGE_ENGINE_BACKEND_DBENGINE)
         return rrdeng_global_first_time_s(db_instance);
 #endif
 
@@ -539,7 +539,7 @@ static inline time_t storage_engine_global_first_time_s(STORAGE_ENGINE_BACKEND b
 size_t rrdeng_currently_collected_metrics(STORAGE_INSTANCE *db_instance);
 static inline size_t storage_engine_collected_metrics(STORAGE_ENGINE_BACKEND backend __maybe_unused, STORAGE_INSTANCE *db_instance) {
 #ifdef ENABLE_DBENGINE
-    if(likely(backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+    if(backend == STORAGE_ENGINE_BACKEND_DBENGINE)
         return rrdeng_currently_collected_metrics(db_instance);
 #endif
 
@@ -550,13 +550,13 @@ static inline size_t storage_engine_collected_metrics(STORAGE_ENGINE_BACKEND bac
 void rrdeng_store_metric_flush_current_page(STORAGE_COLLECT_HANDLE *collection_handle);
 void rrddim_store_metric_flush(STORAGE_COLLECT_HANDLE *collection_handle);
 static inline void storage_engine_store_flush(STORAGE_COLLECT_HANDLE *collection_handle) {
-    if(unlikely(!collection_handle))
+    if(!collection_handle)
         return;
 
     internal_fatal(!is_valid_backend(collection_handle->backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
-    if(likely(collection_handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+    if(collection_handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE)
         rrdeng_store_metric_flush_current_page(collection_handle);
     else
 #endif
@@ -571,7 +571,7 @@ static inline int storage_engine_store_finalize(STORAGE_COLLECT_HANDLE *collecti
     internal_fatal(!is_valid_backend(collection_handle->backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
-    if(likely(collection_handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+    if(collection_handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE)
         return rrdeng_store_metric_finalize(collection_handle);
 #endif
 
@@ -584,7 +584,7 @@ static inline void storage_engine_store_change_collection_frequency(STORAGE_COLL
     internal_fatal(!is_valid_backend(collection_handle->backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
-    if(likely(collection_handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+    if(collection_handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE)
         rrdeng_store_metric_change_collection_frequency(collection_handle, update_every);
     else
 #endif
@@ -601,7 +601,7 @@ static inline time_t storage_engine_oldest_time_s(STORAGE_ENGINE_BACKEND backend
     internal_fatal(!is_valid_backend(backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
-    if(likely(backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+    if(backend == STORAGE_ENGINE_BACKEND_DBENGINE)
         return rrdeng_metric_oldest_time(db_metric_handle);
 #endif
     return rrddim_query_oldest_time_s(db_metric_handle);
@@ -613,7 +613,7 @@ static inline time_t storage_engine_latest_time_s(STORAGE_ENGINE_BACKEND backend
     internal_fatal(!is_valid_backend(backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
-    if(likely(backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+    if(backend == STORAGE_ENGINE_BACKEND_DBENGINE)
         return rrdeng_metric_latest_time(db_metric_handle);
 #endif
     return rrddim_query_latest_time_s(db_metric_handle);
@@ -634,7 +634,7 @@ static inline void storage_engine_query_init(
     internal_fatal(!is_valid_backend(backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
-    if(likely(backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+    if(backend == STORAGE_ENGINE_BACKEND_DBENGINE)
         rrdeng_load_metric_init(db_metric_handle, handle, start_time_s, end_time_s, priority);
     else
 #endif
@@ -647,7 +647,7 @@ static inline STORAGE_POINT storage_engine_query_next_metric(struct storage_engi
     internal_fatal(!is_valid_backend(handle->backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
-    if(likely(handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+    if(handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE)
         return rrdeng_load_metric_next(handle);
 #endif
     return rrddim_query_next_metric(handle);
@@ -659,7 +659,7 @@ static inline int storage_engine_query_is_finished(struct storage_engine_query_h
     internal_fatal(!is_valid_backend(handle->backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
-    if(likely(handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+    if(handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE)
         return rrdeng_load_metric_is_finished(handle);
 #endif
     return rrddim_query_is_finished(handle);
@@ -671,7 +671,7 @@ static inline void storage_engine_query_finalize(struct storage_engine_query_han
     internal_fatal(!is_valid_backend(handle->backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
-    if(likely(handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+    if(handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE)
         rrdeng_load_metric_finalize(handle);
     else
 #endif
@@ -684,7 +684,7 @@ static inline time_t storage_engine_align_to_optimal_before(struct storage_engin
     internal_fatal(!is_valid_backend(handle->backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
-    if(likely(handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+    if(handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE)
         return rrdeng_load_align_to_optimal_before(handle);
 #endif
     return rrddim_query_align_to_optimal_before(handle);
@@ -996,7 +996,7 @@ typedef enum __attribute__ ((__packed__)) rrdhost_flags {
 #define rrdhost_flag_clear(host, flag) __atomic_and_fetch(&((host)->flags), ~(flag), __ATOMIC_SEQ_CST)
 
 #ifdef NETDATA_INTERNAL_CHECKS
-#define rrdset_debug(st, fmt, args...) do { if(unlikely(debug_flags & D_RRD_STATS && rrdset_flag_check(st, RRDSET_FLAG_DEBUG))) \
+#define rrdset_debug(st, fmt, args...) do { if(debug_flags & D_RRD_STATS && rrdset_flag_check(st, RRDSET_FLAG_DEBUG)) \
             debug_int(__FILE__, __FUNCTION__, __LINE__, "%s: " fmt, rrdset_name(st), ##args); } while(0)
 #else
 #define rrdset_debug(st, fmt, args...) debug_dummy()
@@ -1461,7 +1461,7 @@ void rrdset_acquired_release(RRDSET_ACQUIRED *rsa);
 static inline RRDSET *rrdset_find_active_localhost(const char *id)
 {
     RRDSET *st = rrdset_find_localhost(id);
-    if (unlikely(st && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED)))
+    if (st && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED))
         return NULL;
     return st;
 }
@@ -1472,7 +1472,7 @@ RRDSET *rrdset_find_bytype(RRDHOST *host, const char *type, const char *id);
 static inline RRDSET *rrdset_find_active_bytype_localhost(const char *type, const char *id)
 {
     RRDSET *st = rrdset_find_bytype_localhost(type, id);
-    if (unlikely(st && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED)))
+    if (st && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED))
         return NULL;
     return st;
 }
@@ -1483,7 +1483,7 @@ RRDSET *rrdset_find_byname(RRDHOST *host, const char *name);
 static inline RRDSET *rrdset_find_active_byname_localhost(const char *name)
 {
     RRDSET *st = rrdset_find_byname_localhost(name);
-    if (unlikely(st && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED)))
+    if (st && rrdset_flag_check(st, RRDSET_FLAG_ARCHIVED))
         return NULL;
     return st;
 }

--- a/database/rrdcalc.h
+++ b/database/rrdcalc.h
@@ -248,7 +248,7 @@ void rrdcalc_delete_alerts_not_matching_host_labels_from_all_hosts();
 void rrdcalc_delete_alerts_not_matching_host_labels_from_this_host(RRDHOST *host);
 
 static inline int rrdcalc_isrepeating(RRDCALC *rc) {
-    if (unlikely(rc->warn_repeat_every > 0 || rc->crit_repeat_every > 0)) {
+    if (rc->warn_repeat_every > 0 || rc->crit_repeat_every > 0) {
         return 1;
     }
     return 0;

--- a/database/rrdcalctemplate.c
+++ b/database/rrdcalctemplate.c
@@ -132,7 +132,7 @@ static void rrdcalctemplate_free_internals(RRDCALCTEMPLATE *rt) {
 }
 
 void rrdcalctemplate_free_unused_rrdcalctemplate_loaded_from_config(RRDCALCTEMPLATE *rt) {
-    if(unlikely(!rt)) return;
+    if(!rt) return;
 
     rrdcalctemplate_free_internals(rt);
     freez(rt);
@@ -222,17 +222,17 @@ static size_t rrdcalctemplate_key(char *dst, size_t dst_len, const char *name, c
 }
 
 void rrdcalctemplate_add_from_config(RRDHOST *host, RRDCALCTEMPLATE *rt) {
-    if(unlikely(!rt->context)) {
+    if(!rt->context) {
         netdata_log_error("Health configuration for template '%s' does not have a context", rrdcalctemplate_name(rt));
         return;
     }
 
-    if(unlikely(!rt->update_every)) {
+    if(!rt->update_every) {
         netdata_log_error("Health configuration for template '%s' has no frequency (parameter 'every'). Ignoring it.", rrdcalctemplate_name(rt));
         return;
     }
 
-    if(unlikely(!RRDCALCTEMPLATE_HAS_DB_LOOKUP(rt) && !rt->calculation && !rt->warning && !rt->critical)) {
+    if(!RRDCALCTEMPLATE_HAS_DB_LOOKUP(rt) && !rt->calculation && !rt->warning && !rt->critical) {
         netdata_log_error("Health configuration for template '%s' is useless (no calculation, no warning and no critical evaluation)", rrdcalctemplate_name(rt));
         return;
     }

--- a/database/rrddimvar.c
+++ b/database/rrddimvar.c
@@ -253,7 +253,7 @@ void rrddimvar_rename_all(RRDDIM *rd) {
 
     RRDDIMVAR *rs;
     dfe_start_write(st->rrddimvar_root_index, rs) {
-        if(unlikely(rs->rrddim == rd))
+        if(rs->rrddim == rd)
             rrddimvar_update_variables_unsafe(rs);
     }
     dfe_done(rs);
@@ -266,7 +266,7 @@ void rrddimvar_delete_all(RRDDIM *rd) {
 
     RRDDIMVAR *rs;
     dfe_start_write(st->rrddimvar_root_index, rs) {
-        if(unlikely(rs->rrddim == rd))
+        if(rs->rrddim == rd)
             dictionary_del(st->rrddimvar_root_index, rs_dfe.name);
     }
     dfe_done(rs);

--- a/database/rrdfamily.c
+++ b/database/rrdfamily.c
@@ -58,12 +58,12 @@ const RRDFAMILY_ACQUIRED *rrdfamily_add_and_acquire(RRDHOST *host, const char *i
 }
 
 void rrdfamily_release(RRDHOST *host, const RRDFAMILY_ACQUIRED *rfa) {
-    if(unlikely(!rfa)) return;
+    if(!rfa) return;
     dictionary_acquired_item_release(host->rrdfamily_root_index, (const DICTIONARY_ITEM *)rfa);
 }
 
 DICTIONARY *rrdfamily_rrdvars_dict(const RRDFAMILY_ACQUIRED *rfa) {
-    if(unlikely(!rfa)) return NULL;
+    if(!rfa) return NULL;
     RRDFAMILY *rf = dictionary_acquired_item_value((const DICTIONARY_ITEM *)rfa);
     return(rf->rrdvars);
 }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -16,7 +16,7 @@ RRD_BACKFILL storage_tiers_backfill[RRD_STORAGE_TIERS] = { RRD_BACKFILL_NEW, RRD
 #endif
 
 size_t get_tier_grouping(size_t tier) {
-    if(unlikely(tier >= storage_tiers)) tier = storage_tiers - 1;
+    if(tier >= storage_tiers) tier = storage_tiers - 1;
 
     size_t grouping = 1;
     // first tier is always 1 iteration of whatever update every the chart has
@@ -44,7 +44,7 @@ bool is_storage_engine_shared(STORAGE_INSTANCE *engine __maybe_unused) {
 RRDHOST *find_host_by_node_id(char *node_id) {
 
     uuid_t node_uuid;
-    if (unlikely(!node_id || uuid_parse(node_id, node_uuid)))
+    if (!node_id || uuid_parse(node_id, node_uuid))
         return NULL;
 
     RRDHOST *host, *ret = NULL;
@@ -66,13 +66,13 @@ DICTIONARY *rrdhost_root_index = NULL;
 static DICTIONARY *rrdhost_root_index_hostname = NULL;
 
 static inline void rrdhost_init() {
-    if(unlikely(!rrdhost_root_index)) {
+    if(!rrdhost_root_index) {
         rrdhost_root_index = dictionary_create_advanced(
             DICT_OPTION_NAME_LINK_DONT_CLONE | DICT_OPTION_VALUE_LINK_DONT_CLONE | DICT_OPTION_DONT_OVERWRITE_VALUE,
             &dictionary_stats_category_rrdhost, 0);
     }
 
-    if(unlikely(!rrdhost_root_index_hostname)) {
+    if(!rrdhost_root_index_hostname) {
         rrdhost_root_index_hostname = dictionary_create_advanced(
             DICT_OPTION_NAME_LINK_DONT_CLONE | DICT_OPTION_VALUE_LINK_DONT_CLONE | DICT_OPTION_DONT_OVERWRITE_VALUE,
             &dictionary_stats_category_rrdhost, 0);
@@ -86,14 +86,14 @@ RRDHOST_ACQUIRED *rrdhost_find_and_acquire(const char *machine_guid) {
 }
 
 RRDHOST *rrdhost_acquired_to_rrdhost(RRDHOST_ACQUIRED *rha) {
-    if(unlikely(!rha))
+    if(!rha)
         return NULL;
 
     return (RRDHOST *) dictionary_acquired_item_value((const DICTIONARY_ITEM *)rha);
 }
 
 void rrdhost_acquired_release(RRDHOST_ACQUIRED *rha) {
-    if(unlikely(!rha))
+    if(!rha)
         return;
 
     dictionary_acquired_item_release(rrdhost_root_index, (const DICTIONARY_ITEM *)rha);
@@ -137,14 +137,14 @@ static void rrdhost_index_del_by_guid(RRDHOST *host) {
 // RRDHOST index by hostname
 
 inline RRDHOST *rrdhost_find_by_hostname(const char *hostname) {
-    if(unlikely(!strcmp(hostname, "localhost")))
+    if(!strcmp(hostname, "localhost"))
         return localhost;
 
     return dictionary_get(rrdhost_root_index_hostname, hostname);
 }
 
 static inline void rrdhost_index_del_hostname(RRDHOST *host) {
-    if(unlikely(!host->hostname)) return;
+    if(!host->hostname) return;
 
     if(rrdhost_option_check(host, RRDHOST_OPTION_INDEXED_HOSTNAME)) {
         if(!dictionary_del(rrdhost_root_index_hostname, rrdhost_hostname(host)))
@@ -186,7 +186,7 @@ static inline void rrdhost_init_tags(RRDHOST *host, const char *tags) {
 }
 
 static inline void rrdhost_init_hostname(RRDHOST *host, const char *hostname, bool add_to_index) {
-    if(unlikely(hostname && !*hostname)) hostname = NULL;
+    if(hostname && !*hostname) hostname = NULL;
 
     if(host->hostname && hostname && !strcmp(rrdhost_hostname(host), hostname))
         return;
@@ -331,7 +331,7 @@ int is_legacy = 1;
     host->rrd_history_entries        = align_entries_to_pagesize(memory_mode, entries);
     host->health.health_enabled      = ((memory_mode == RRD_MEMORY_MODE_NONE)) ? 0 : health_enabled;
 
-    if (likely(!archived)) {
+    if (!archived) {
         rrdfunctions_init(host);
         host->rrdlabels = rrdlabels_create();
         rrdhost_initialize_rrdpush_sender(
@@ -399,7 +399,7 @@ int is_legacy = 1;
     if(!host->rrdvars)
         host->rrdvars = rrdvariables_create();
 
-    if (likely(!uuid_parse(host->machine_guid, host->host_uuid)))
+    if (!uuid_parse(host->machine_guid, host->host_uuid))
         sql_load_node_id(host);
     else
         error_report("Host machine GUID %s is not valid", host->machine_guid);
@@ -727,9 +727,9 @@ RRDHOST *rrdhost_find_or_create(
     netdata_log_debug(D_RRDHOST, "Searching for host '%s' with guid '%s'", hostname, guid);
 
     RRDHOST *host = rrdhost_find_by_guid(guid);
-    if (unlikely(host && host->rrd_memory_mode != mode && rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED))) {
+    if (host && host->rrd_memory_mode != mode && rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED)) {
 
-        if (likely(!archived && rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD)))
+        if (!archived && rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD))
             return host;
 
         /* If a legacy memory mode instantiates all dbengine state must be discarded to avoid inconsistencies */
@@ -773,7 +773,7 @@ RRDHOST *rrdhost_find_or_create(
         );
     }
     else {
-        if (likely(!rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD)))
+        if (!rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD))
             rrdhost_update(host
                , hostname
                , registry_hostname
@@ -988,7 +988,7 @@ void dbengine_init(char *hostname) {
 int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unittest) {
     rrdhost_init();
 
-    if (unlikely(sql_init_database(DB_CHECK_NONE, system_info ? 0 : 1))) {
+    if (sql_init_database(DB_CHECK_NONE, system_info ? 0 : 1)) {
         if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE) {
             set_late_global_environment(system_info);
             fatal("Failed to initialize SQLite");
@@ -996,11 +996,11 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
         netdata_log_info("Skipping SQLITE metadata initialization since memory mode is not dbengine");
     }
 
-    if (unlikely(sql_init_context_database(system_info ? 0 : 1))) {
+    if (sql_init_context_database(system_info ? 0 : 1)) {
         error_report("Failed to initialize context metadata database");
     }
 
-    if (unlikely(unittest)) {
+    if (unittest) {
         dbengine_enabled = true;
     }
     else {
@@ -1061,7 +1061,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
             , 0
     );
 
-    if (unlikely(!localhost)) {
+    if (!localhost) {
         return 1;
     }
 
@@ -1074,7 +1074,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
                                rrdhost_function_streaming, NULL);
 #endif
 
-    if (likely(system_info)) {
+    if (system_info) {
         migrate_localhost(&localhost->host_uuid);
         sql_aclk_sync_init();
         web_client_api_v1_management_init();
@@ -1086,7 +1086,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
 // RRDHOST - free
 
 void rrdhost_system_info_free(struct rrdhost_system_info *system_info) {
-    if(likely(system_info)) {
+    if(system_info) {
         __atomic_sub_fetch(&netdata_buffers_statistics.rrdhost_allocations_size, sizeof(struct rrdhost_system_info), __ATOMIC_RELAXED);
 
         freez(system_info->cloud_provider_type);
@@ -1154,7 +1154,7 @@ static void rrdhost_streaming_sender_structures_free(RRDHOST *host)
 {
     rrdhost_option_clear(host, RRDHOST_OPTION_SENDER_ENABLED);
 
-    if (unlikely(!host->sender))
+    if (!host->sender)
         return;
 
     rrdpush_sender_thread_stop(host, STREAM_HANDSHAKE_DISCONNECT_HOST_CLEANUP, true); // stop a possibly running thread
@@ -1452,7 +1452,7 @@ static void rrdhost_load_kubernetes_labels(void) {
     char label_script[sizeof(char) * (strlen(netdata_configured_primary_plugins_dir) + strlen("get-kubernetes-labels.sh") + 2)];
     sprintf(label_script, "%s/%s", netdata_configured_primary_plugins_dir, "get-kubernetes-labels.sh");
 
-    if (unlikely(access(label_script, R_OK) != 0)) {
+    if (access(label_script, R_OK) != 0) {
         netdata_log_error("Kubernetes pod label fetching script %s not found.",label_script);
         return;
     }
@@ -1922,7 +1922,7 @@ void rrdhost_status(RRDHOST *host, time_t now, RRDHOST_STATUS *s) {
 
             RRDCALC *rc;
             foreach_rrdcalc_in_rrdhost_read(host, rc) {
-                if (unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
+                if (!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec)
                     continue;
 
                 switch (rc->status) {

--- a/database/rrdlabels.c
+++ b/database/rrdlabels.c
@@ -370,9 +370,9 @@ __attribute__((constructor)) void initialize_labels_keys_char_map(void) {
 }
 
 size_t text_sanitize(unsigned char *dst, const unsigned char *src, size_t dst_size, unsigned char *char_map, bool utf, const char *empty, size_t *multibyte_length) {
-    if(unlikely(!dst_size)) return 0;
+    if(!dst_size) return 0;
 
-    if(unlikely(!src || !*src)) {
+    if(!src || !*src) {
         strncpyz((char *)dst, empty, dst_size);
         dst[dst_size - 1] = '\0';
         size_t len = strlen((char *)dst);
@@ -454,13 +454,13 @@ size_t text_sanitize(unsigned char *dst, const unsigned char *src, size_t dst_si
     if(*dst == '_') {
         unsigned char *t = dst;
         while (*t == '_') t++;
-        if (unlikely(*t == '\0')) {
+        if (*t == '\0') {
             *dst = '\0';
             mblen = 0;
         }
     }
 
-    if(unlikely(*dst == '\0')) {
+    if(*dst == '\0') {
         strncpyz((char *)dst, empty, dst_size);
         dst[dst_size - 1] = '\0';
         mblen = strlen((char *)dst);
@@ -591,24 +591,24 @@ static const char *get_quoted_string_up_to(char *dst, size_t dst_size, const cha
     size_t len = 0;
     char *d = dst, quote = 0;
     while(*string && len++ < dst_size) {
-        if(unlikely(!quote && (*string == '\'' || *string == '"'))) {
+        if(!quote && (*string == '\'' || *string == '"')) {
             quote = *string++;
             continue;
         }
 
-        if(unlikely(quote && *string == quote)) {
+        if(quote && *string == quote) {
             quote = 0;
             string++;
             continue;
         }
 
-        if(unlikely(quote && *string == '\\' && string[1])) {
+        if(quote && *string == '\\' && string[1]) {
             string++;
             *d++ = *string++;
             continue;
         }
 
-        if(unlikely(!quote && (*string == upto1 || *string == upto2))) break;
+        if(!quote && (*string == upto1 || *string == upto2)) break;
 
         *d++ = *string++;
     }

--- a/database/rrdsetvar.c
+++ b/database/rrdsetvar.c
@@ -285,7 +285,7 @@ void rrdsetvar_print_to_streaming_custom_chart_variables(RRDSET *st, BUFFER *wb)
     // send the chart local custom variables
     RRDSETVAR *rs;
     dfe_start_read(st->rrdsetvar_root_index, rs) {
-        if(unlikely(rs->type == RRDVAR_TYPE_CALCULATED && rs->flags & RRDVAR_FLAG_CUSTOM_CHART_VAR)) {
+        if(rs->type == RRDVAR_TYPE_CALCULATED && rs->flags & RRDVAR_FLAG_CUSTOM_CHART_VAR) {
             NETDATA_DOUBLE *value = (NETDATA_DOUBLE *) rs->value;
 
             buffer_sprintf(wb

--- a/database/rrdvar.c
+++ b/database/rrdvar.c
@@ -111,7 +111,7 @@ static inline const RRDVAR_ACQUIRED *rrdvar_get_and_acquire(DICTIONARY *dict, ST
 }
 
 inline void rrdvar_release_and_del(DICTIONARY *dict, const RRDVAR_ACQUIRED *rva) {
-    if(unlikely(!dict || !rva)) return;
+    if(!dict || !rva) return;
 
     RRDVAR *rv = dictionary_acquired_item_value((const DICTIONARY_ITEM *)rva);
 
@@ -121,7 +121,7 @@ inline void rrdvar_release_and_del(DICTIONARY *dict, const RRDVAR_ACQUIRED *rva)
 }
 
 inline const RRDVAR_ACQUIRED *rrdvar_add_and_acquire(const char *scope __maybe_unused, DICTIONARY *dict, STRING *name, RRDVAR_TYPE type, RRDVAR_FLAGS options, void *value) {
-    if(unlikely(!dict || !name)) return NULL;
+    if(!dict || !name) return NULL;
 
     struct rrdvar_constructor tmp = {
         .name = name,
@@ -134,7 +134,7 @@ inline const RRDVAR_ACQUIRED *rrdvar_add_and_acquire(const char *scope __maybe_u
 }
 
 inline void rrdvar_add(const char *scope __maybe_unused, DICTIONARY *dict, STRING *name, RRDVAR_TYPE type, RRDVAR_FLAGS options, void *value) {
-    if(unlikely(!dict || !name)) return;
+    if(!dict || !name) return;
 
     struct rrdvar_constructor tmp = {
         .name = name,
@@ -155,13 +155,13 @@ void rrdvar_delete_all(DICTIONARY *dict) {
 // CUSTOM HOST VARIABLES
 
 inline int rrdvar_walkthrough_read(DICTIONARY *dict, int (*callback)(const DICTIONARY_ITEM *item, void *rrdvar, void *data), void *data) {
-    if(unlikely(!dict)) return 0;  // when health is not enabled
+    if(!dict) return 0;  // when health is not enabled
     return dictionary_walkthrough_read(dict, callback, data);
 }
 
 const RRDVAR_ACQUIRED *rrdvar_custom_host_variable_add_and_acquire(RRDHOST *host, const char *name) {
     DICTIONARY *dict = host->rrdvars;
-    if(unlikely(!dict)) return NULL; // when health is not enabled
+    if(!dict) return NULL; // when health is not enabled
 
     STRING *name_string = rrdvar_name_to_string(name);
 
@@ -172,7 +172,7 @@ const RRDVAR_ACQUIRED *rrdvar_custom_host_variable_add_and_acquire(RRDHOST *host
 }
 
 void rrdvar_custom_host_variable_set(RRDHOST *host, const RRDVAR_ACQUIRED *rva, NETDATA_DOUBLE value) {
-    if(unlikely(!host->rrdvars || !rva)) return; // when health is not enabled
+    if(!host->rrdvars || !rva) return; // when health is not enabled
 
     if(rrdvar_type(rva) != RRDVAR_TYPE_CALCULATED || !(rrdvar_flags(rva) & (RRDVAR_FLAG_CUSTOM_HOST_VAR | RRDVAR_FLAG_ALLOCATED)))
         netdata_log_error("requested to set variable '%s' to value " NETDATA_DOUBLE_FORMAT " but the variable is not a custom one.", rrdvar_name(rva), value);
@@ -189,7 +189,7 @@ void rrdvar_custom_host_variable_set(RRDHOST *host, const RRDVAR_ACQUIRED *rva, 
 }
 
 void rrdvar_release(DICTIONARY *dict, const RRDVAR_ACQUIRED *rva) {
-    if(unlikely(!dict || !rva)) return;  // when health is not enabled
+    if(!dict || !rva) return;  // when health is not enabled
     dictionary_acquired_item_release(dict, (const DICTIONARY_ITEM *)rva);
 }
 
@@ -197,7 +197,7 @@ void rrdvar_release(DICTIONARY *dict, const RRDVAR_ACQUIRED *rva) {
 // RRDVAR lookup
 
 NETDATA_DOUBLE rrdvar2number(const RRDVAR_ACQUIRED *rva) {
-    if(unlikely(!rva)) return NAN;
+    if(!rva) return NAN;
 
     RRDVAR *rv = dictionary_acquired_item_value((const DICTIONARY_ITEM *)rva);
 
@@ -325,7 +325,7 @@ static int single_variable2json_callback(const DICTIONARY_ITEM *item __maybe_unu
     NETDATA_DOUBLE value = rrdvar2number(rva);
 
     if (helper->options == RRDVAR_FLAG_NONE || rrdvar_flags(rva) & helper->options) {
-        if(unlikely(isnan(value) || isinf(value)))
+        if(isnan(value) || isinf(value))
             buffer_sprintf(helper->buf, "%s\n\t\t\"%s\": null", helper->counter?",":"", rrdvar_name(rva));
         else
             buffer_sprintf(helper->buf, "%s\n\t\t\"%s\": %0.5" NETDATA_DOUBLE_MODIFIER, helper->counter?",":"", rrdvar_name(rva), (NETDATA_DOUBLE)value);

--- a/database/sqlite/sqlite_aclk_node.c
+++ b/database/sqlite/sqlite_aclk_node.c
@@ -31,11 +31,11 @@ static void build_node_collectors(char *node_id __maybe_unused)
 
     RRDHOST *host = find_host_by_node_id(node_id);
 
-    if (unlikely(!host))
+    if (!host)
         return;
 
     struct aclk_sync_host_config *wc = (struct aclk_sync_host_config *) host->aclk_sync_host_config;
-    if (unlikely(!wc))
+    if (!wc)
         return;
 
     struct update_node_collectors upd_node_collectors;
@@ -61,14 +61,14 @@ static void build_node_info(char *node_id __maybe_unused)
 
     RRDHOST *host = find_host_by_node_id(node_id);
 
-    if (unlikely((!host))) {
+    if ((!host)) {
         freez(node_id);
         return;
     }
 
     struct aclk_sync_host_config *wc = (struct aclk_sync_host_config *) host->aclk_sync_host_config;
 
-    if (unlikely(!wc)) {
+    if (!wc) {
         freez(node_id);
         return;
     }
@@ -141,17 +141,17 @@ void aclk_check_node_info_and_collectors(void)
 {
     RRDHOST *host;
 
-    if (unlikely(!aclk_connected))
+    if (!aclk_connected)
         return;
 
     size_t pending = 0;
     dfe_start_reentrant(rrdhost_root_index, host) {
 
         struct aclk_sync_host_config *wc = host->aclk_sync_host_config;
-        if (unlikely(!wc))
+        if (!wc)
             continue;
 
-        if (unlikely(rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD))) {
+        if (rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD)) {
             internal_error(true, "ACLK SYNC: Context still pending for %s", rrdhost_hostname(host));
             pending++;
             continue;

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -134,7 +134,7 @@ static int do_migration_v3_v4(sqlite3 *database, const char *name)
     }
 
     rc = sqlite3_finalize(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to finalize statement when altering health_log tables, rc = %d", rc);
 
     return 0;
@@ -184,7 +184,7 @@ static int do_migration_v6_v7(sqlite3 *database, const char *name)
     }
 
     rc = sqlite3_finalize(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to finalize statement when altering aclk_alert tables, rc = %d", rc);
 
     return 0;
@@ -216,7 +216,7 @@ static int do_migration_v7_v8(sqlite3 *database, const char *name)
     }
 
     rc = sqlite3_finalize(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to finalize statement when altering health_log tables, rc = %d", rc);
 
     return 0;
@@ -280,7 +280,7 @@ static int do_migration_v8_v9(sqlite3 *database, const char *name)
     }
 
     rc = sqlite3_finalize(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to finalize statement when copying health_log tables, rc = %d", rc);
 
     char *table = NULL;
@@ -340,7 +340,7 @@ static int migrate_database(sqlite3 *database, int target_version, char *db_name
         sqlite3_free(err_msg);
     }
 
-    if (likely(user_version == target_version)) {
+    if (user_version == target_version) {
         netdata_log_info("%s database version is %d (no migration needed)", db_name, target_version);
         return target_version;
     }
@@ -348,7 +348,7 @@ static int migrate_database(sqlite3 *database, int target_version, char *db_name
     netdata_log_info("Database version is %d, current version is %d. Running migration for %s ...", user_version, target_version, db_name);
     for (int i = user_version; i < target_version && migration_list[i].func; i++) {
         rc = (migration_list[i].func)(database, migration_list[i].name);
-        if (unlikely(rc)) {
+        if (rc) {
             error_report("Database %s migration from version %d to version %d failed", db_name, i, i + 1);
             return i;
         }

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -28,7 +28,7 @@ typedef enum db_check_action_type {
 #define SQLITE_INSERT_DELAY (10)        // Insert delay in case of lock
 
 #define CHECK_SQLITE_CONNECTION(db_meta)                                                                               \
-    if (unlikely(!db_meta)) {                                                                                          \
+    if (!db_meta) {                                                                                          \
         if (default_rrd_memory_mode != RRD_MEMORY_MODE_DBENGINE) {                                                     \
             return 1;                                                                                                  \
         }                                                                                                              \

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -15,67 +15,67 @@ void sql_health_alarm_log_update(RRDHOST *host, ALARM_ENTRY *ae) {
     sqlite3_stmt *res = NULL;
     int rc;
 
-    if (unlikely(!db_meta)) {
+    if (!db_meta) {
         if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
             error_report("HEALTH [%s]: Database has not been initialized", rrdhost_hostname(host));
         return;
     }
 
     rc = sqlite3_prepare_v2(db_meta, SQL_UPDATE_HEALTH_LOG, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("HEALTH [%s]: Failed to prepare statement for SQL_UPDATE_HEALTH_LOG", rrdhost_hostname(host));
         return;
     }
 
     rc = sqlite3_bind_int64(res, 1, (sqlite3_int64) ae->updated_by_id);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind updated_by_id parameter for SQL_UPDATE_HEALTH_LOG");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 2, (sqlite3_int64) ae->flags);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind flags parameter for SQL_UPDATE_HEALTH_LOG");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 3, (sqlite3_int64) ae->exec_run_timestamp);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind exec_run_timestamp parameter for SQL_UPDATE_HEALTH_LOG");
         goto failed;
     }
 
     rc = sqlite3_bind_int(res, 4, ae->exec_code);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind exec_code parameter for SQL_UPDATE_HEALTH_LOG");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 5, (sqlite3_int64) ae->unique_id);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind unique_id parameter for SQL_UPDATE_HEALTH_LOG");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 6, (sqlite3_int64) ae->alarm_id);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind unique_id parameter for SQL_UPDATE_HEALTH_LOG");
         goto failed;
     }
 
     rc = sqlite3_bind_blob(res, 7, &ae->transition_id, sizeof(ae->transition_id), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind host_id for SQL_UPDATE_HEALTH_LOG.");
         goto failed;
     }
 
     rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE)) {
+    if (rc != SQLITE_DONE) {
         error_report("HEALTH [%s]: Failed to update health log, rc = %d", rrdhost_hostname(host), rc);
     }
 
 failed:
-    if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
+    if (sqlite3_finalize(res) != SQLITE_OK)
         error_report("HEALTH [%s]: Failed to finalize the prepared statement for updating health log.", rrdhost_hostname(host));
 }
 
@@ -96,92 +96,92 @@ void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae) {
     int rc;
     uint64_t health_log_id = 0;
 
-    if (unlikely(!db_meta)) {
+    if (!db_meta) {
         if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
             error_report("HEALTH [%s]: Database has not been initialized", rrdhost_hostname(host));
         return;
     }
 
     rc = sqlite3_prepare_v2(db_meta, SQL_INSERT_HEALTH_LOG, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("HEALTH [%s]: Failed to prepare statement for SQL_INSERT_HEALTH_LOG", rrdhost_hostname(host));
         return;
     }
 
     rc = sqlite3_bind_blob(res, 1, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind host_id for SQL_INSERT_HEALTH_LOG.");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 2, (sqlite3_int64) ae->alarm_id);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind alarm_id parameter for SQL_INSERT_HEALTH_LOG");
         goto failed;
     }
 
     rc = sqlite3_bind_blob(res, 3, &ae->config_hash_id, sizeof(ae->config_hash_id), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind config_hash_id parameter for SQL_INSERT_HEALTH_LOG");
         goto failed;
     }
 
     rc = sqlite3_bind_string_or_null(res, ae->name, 4);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind name parameter for SQL_INSERT_HEALTH_LOG");
         goto failed;
     }
 
     rc = sqlite3_bind_string_or_null(res, ae->chart, 5);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind chart parameter for SQL_INSERT_HEALTH_LOG");
         goto failed;
     }
 
     rc = sqlite3_bind_string_or_null(res, ae->family, 6);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind family parameter for SQL_INSERT_HEALTH_LOG");
         goto failed;
     }
 
     rc = sqlite3_bind_string_or_null(res, ae->exec, 7);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind exec parameter for SQL_INSERT_HEALTH_LOG");
         goto failed;
     }
 
     rc = sqlite3_bind_string_or_null(res, ae->recipient, 8);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind recipient parameter for SQL_INSERT_HEALTH_LOG");
         goto failed;
     }
 
     rc = sqlite3_bind_string_or_null(res, ae->units, 9);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind host_id parameter to store node instance information");
         goto failed;
     }
 
     rc = sqlite3_bind_string_or_null(res, ae->chart_context, 10);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind chart_context parameter for SQL_INSERT_HEALTH_LOG");
         goto failed;
     }
 
     rc = sqlite3_bind_blob(res, 11, &ae->transition_id, sizeof(ae->transition_id), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind transition_id parameter for SQL_INSERT_HEALTH_LOG");
         goto failed;
     }
 
     rc = sqlite3_bind_string_or_null(res, ae->chart_name, 12);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind chart_name parameter for SQL_INSERT_HEALTH_LOG");
         goto failed;
     }
 
     rc = sqlite3_step_monitored(res);
-    if (likely(rc == SQLITE_ROW))
+    if (rc == SQLITE_ROW)
         health_log_id = (size_t) sqlite3_column_int64(res, 0);
     else {
         error_report("HEALTH [%s]: Failed to execute SQL_INSERT_HEALTH_LOG, rc = %d", rrdhost_hostname(host), rc);
@@ -189,149 +189,149 @@ void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae) {
     }
 
     rc = sqlite3_finalize(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("HEALTH [%s]: Failed to finalize the prepared statement for inserting to health log.", rrdhost_hostname(host));
 
     rc = sqlite3_prepare_v2(db_meta, SQL_INSERT_HEALTH_LOG_DETAIL, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("HEALTH [%s]: Failed to prepare statement for SQL_INSERT_HEALTH_LOG_DETAIL", rrdhost_hostname(host));
         return;
     }
 
     rc = sqlite3_bind_int64(res, 1, (sqlite3_int64) health_log_id);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind unique_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 2, (sqlite3_int64) ae->unique_id);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind unique_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 3, (sqlite3_int64) ae->alarm_id);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind unique_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 4, (sqlite3_int64) ae->alarm_event_id);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind alarm_event_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 5, (sqlite3_int64) ae->updated_by_id);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind updated_by_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 6, (sqlite3_int64) ae->updates_id);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind updates_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 7, (sqlite3_int64) ae->when);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind when parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 8, (sqlite3_int64) ae->duration);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind duration parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 9, (sqlite3_int64) ae->non_clear_duration);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind non_clear_duration parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 10, (sqlite3_int64) ae->flags);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind flags parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 11, (sqlite3_int64) ae->exec_run_timestamp);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind exec_run_timestamp parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 12, (sqlite3_int64) ae->delay_up_to_timestamp);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind delay_up_to_timestamp parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_string_or_null(res, ae->info, 13);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind info parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int(res, 14, ae->exec_code);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind exec_code parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int(res, 15, ae->new_status);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind new_status parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int(res, 16, ae->old_status);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind old_status parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int(res, 17, ae->delay);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind delay parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_double(res, 18, ae->new_value);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind new_value parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_double(res, 19, ae->old_value);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind old_value parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 20, (sqlite3_int64) ae->last_repeat);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind last_repeat parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_blob(res, 21, &ae->transition_id, sizeof(ae->transition_id), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind transition_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 22, (sqlite3_int64) ae->global_id);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind global_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
     }
 
     rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE)) {
+    if (rc != SQLITE_DONE) {
         error_report("HEALTH [%s]: Failed to execute SQL_INSERT_HEALTH_LOG_DETAIL, rc = %d", rrdhost_hostname(host), rc);
         goto failed;
     }
@@ -340,7 +340,7 @@ void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae) {
     host->health.health_log_entries_written++;
 
 failed:
-    if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
+    if (sqlite3_finalize(res) != SQLITE_OK)
         error_report("HEALTH [%s]: Failed to finalize the prepared statement for inserting to health log.", rrdhost_hostname(host));
 }
 
@@ -366,31 +366,31 @@ void sql_health_alarm_log_count(RRDHOST *host) {
     sqlite3_stmt *res = NULL;
     int rc;
 
-    if (unlikely(!db_meta)) {
+    if (!db_meta) {
         if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
             error_report("Database has not been initialized");
         return;
     }
 
     rc = sqlite3_prepare_v2(db_meta, SQL_COUNT_HEALTH_LOG_DETAIL, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to prepare statement to count health log entries from db");
         return;
     }
 
     rc = sqlite3_bind_blob(res, 1, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind host_id for SQL_COUNT_HEALTH_LOG.");
         sqlite3_finalize(res);
         return;
     }
 
     rc = sqlite3_step_monitored(res);
-    if (likely(rc == SQLITE_ROW))
+    if (rc == SQLITE_ROW)
         host->health.health_log_entries_written = (size_t) sqlite3_column_int64(res, 0);
 
     rc = sqlite3_finalize(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to finalize the prepared statement to count health log entries from db");
 
     netdata_log_info("HEALTH [%s]: Table health_log_detail contains %lu entries.", rrdhost_hostname(host), (unsigned long int) host->health.health_log_entries_written);
@@ -405,7 +405,7 @@ void sql_health_alarm_log_cleanup_not_claimed(RRDHOST *host) {
     int rc;
     char command[MAX_HEALTH_SQL_SIZE + 1];
 
-    if (unlikely(!db_meta)) {
+    if (!db_meta) {
         if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
             error_report("Database has not been initialized");
         return;
@@ -415,44 +415,44 @@ void sql_health_alarm_log_cleanup_not_claimed(RRDHOST *host) {
     uuid_unparse_lower_fix(&host->host_uuid, uuid_str);
 
     rc = sqlite3_prepare_v2(db_meta, SQL_CLEANUP_HEALTH_LOG_DETAIL_NOT_CLAIMED, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to prepare statement to cleanup health log detail table (un-claimed)");
         return;
     }
 
     rc = sqlite3_bind_blob(res, 1, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind host_id for SQL_CLEANUP_HEALTH_LOG_NOT_CLAIMED.");
         sqlite3_finalize(res);
         return;
     }
 
     rc = sqlite3_bind_int64(res, 2, (sqlite3_int64)host->health_log.health_log_history);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind health log history for SQL_CLEANUP_HEALTH_LOG_NOT_CLAIMED.");
         sqlite3_finalize(res);
         return;
     }
 
     rc = sqlite3_bind_blob(res, 3, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind host_id for SQL_CLEANUP_HEALTH_LOG_NOT_CLAIMED.");
         sqlite3_finalize(res);
         return;
     }
 
     rc = sqlite3_step_monitored(res);
-    if (unlikely(rc != SQLITE_DONE))
+    if (rc != SQLITE_DONE)
         error_report("Failed to cleanup health log detail table, rc = %d", rc);
 
     rc = sqlite3_finalize(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to finalize the prepared statement to cleanup health log detail table (un-claimed)");
 
     sql_health_alarm_log_count(host);
 
     snprintfz(command, MAX_HEALTH_SQL_SIZE, "aclk_alert_%s", uuid_str);
-    if (unlikely(table_exists_in_database(command))) {
+    if (table_exists_in_database(command)) {
         sql_aclk_alert_clean_dead_entries(host);
     }
 }
@@ -466,7 +466,7 @@ void sql_health_alarm_log_cleanup_claimed(RRDHOST *host) {
     int rc;
     char command[MAX_HEALTH_SQL_SIZE + 1];
 
-    if (unlikely(!db_meta)) {
+    if (!db_meta) {
         if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
             error_report("Database has not been initialized");
         return;
@@ -484,45 +484,45 @@ void sql_health_alarm_log_cleanup_claimed(RRDHOST *host) {
     snprintfz(command, MAX_HEALTH_SQL_SIZE, SQL_CLEANUP_HEALTH_LOG_DETAIL_CLAIMED(uuid_str));
 
     rc = sqlite3_prepare_v2(db_meta, command, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to prepare statement to cleanup health log detail table (claimed)");
         return;
     }
 
     rc = sqlite3_bind_blob(res, 1, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind first host_id for SQL_CLEANUP_HEALTH_LOG_CLAIMED.");
         sqlite3_finalize(res);
         return;
     }
 
     rc = sqlite3_bind_blob(res, 2, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind second host_id for SQL_CLEANUP_HEALTH_LOG_CLAIMED.");
         sqlite3_finalize(res);
         return;
     }
 
     rc = sqlite3_bind_int64(res, 3, (sqlite3_int64)host->health_log.health_log_history);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind health log history for SQL_CLEANUP_HEALTH_LOG_CLAIMED.");
         sqlite3_finalize(res);
         return;
     }
 
     rc = sqlite3_bind_blob(res, 4, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind second host_id for SQL_CLEANUP_HEALTH_LOG_CLAIMED.");
         sqlite3_finalize(res);
         return;
     }
 
     rc = sqlite3_step_monitored(res);
-    if (unlikely(rc != SQLITE_DONE))
+    if (rc != SQLITE_DONE)
         error_report("Failed to cleanup health log detail table, rc = %d", rc);
 
     rc = sqlite3_finalize(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to finalize the prepared statement to cleanup health log detail table (claimed)");
 
     sql_health_alarm_log_count(host);
@@ -560,25 +560,25 @@ void sql_inject_removed_status(RRDHOST *host, uint32_t alarm_id, uint32_t alarm_
     }
 
     rc = sqlite3_bind_int64(res, 1, (sqlite3_int64) max_unique_id);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind max_unique_id parameter for SQL_INJECT_REMOVED");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 2, (sqlite3_int64) alarm_id);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind alarm_id parameter for SQL_INJECT_REMOVED");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 3, (sqlite3_int64) alarm_event_id + 1);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind alarm_event_id parameter for SQL_INJECT_REMOVED");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 4, (sqlite3_int64) unique_id);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind unique_id parameter for SQL_INJECT_REMOVED");
         goto failed;
     }
@@ -586,30 +586,30 @@ void sql_inject_removed_status(RRDHOST *host, uint32_t alarm_id, uint32_t alarm_
     uuid_t transition_id;
     uuid_generate_random(transition_id);
     rc = sqlite3_bind_blob(res, 5, &transition_id, sizeof(transition_id), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind config_hash_id parameter for SQL_INJECT_REMOVED");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 6, (sqlite3_int64) unique_id);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind unique_id parameter for SQL_INJECT_REMOVED");
         goto failed;
     }
 
     rc = sqlite3_bind_blob(res, 7, prev_transition_id, sizeof(*prev_transition_id), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind host_id parameter for SQL_INJECT_REMOVED.");
         goto failed;
     }
 
     rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE)) {
+    if (rc != SQLITE_DONE) {
         error_report("HEALTH [N/A]: Failed to execute SQL_INJECT_REMOVED, rc = %d", rc);
         goto failed;
     }
 
-    if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
+    if (sqlite3_finalize(res) != SQLITE_OK)
         error_report("HEALTH [N/A]: Failed to finalize the prepared statement for injecting removed event.");
 
     //update the old entry in health_log_detail
@@ -620,31 +620,31 @@ void sql_inject_removed_status(RRDHOST *host, uint32_t alarm_id, uint32_t alarm_
     }
 
     rc = sqlite3_bind_int64(res, 1, (sqlite3_int64) HEALTH_ENTRY_FLAG_UPDATED);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind flags parameter for SQL_INJECT_REMOVED_UPDATE_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 2, (sqlite3_int64) max_unique_id);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind max_unique_id parameter for SQL_INJECT_REMOVED_UPDATE_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 3, (sqlite3_int64) unique_id);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind unique_id parameter for SQL_INJECT_REMOVED_UPDATE_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_blob(res, 4, prev_transition_id, sizeof(*prev_transition_id), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind host_id parameter for SQL_INJECT_REMOVED_UPDATE_DETAIL");
         goto failed;
     }
 
     rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE)) {
+    if (rc != SQLITE_DONE) {
         error_report("HEALTH [N/A]: Failed to execute SQL_INJECT_REMOVED_UPDATE_DETAIL, rc = %d", rc);
         goto failed;
     }
@@ -657,37 +657,37 @@ void sql_inject_removed_status(RRDHOST *host, uint32_t alarm_id, uint32_t alarm_
     }
 
     rc = sqlite3_bind_blob(res, 1, &transition_id, sizeof(transition_id), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind host_id parameter for SQL_INJECT_REMOVED_UPDATE_LOG");
         goto failed;
     }
 
     rc = sqlite3_bind_int64(res, 2, (sqlite3_int64) alarm_id);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind unique_id parameter for SQL_INJECT_REMOVED_UPDATE_DETAIL");
         goto failed;
     }
 
     rc = sqlite3_bind_blob(res, 3, prev_transition_id, sizeof(*prev_transition_id), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind host_id parameter for SQL_INJECT_REMOVED_UPDATE_LOG");
         goto failed;
     }
 
     rc = sqlite3_bind_blob(res, 4, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind host_id parameter for SQL_INJECT_REMOVED_UPDATE_DETAIL");
         goto failed;
     }
 
     rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE)) {
+    if (rc != SQLITE_DONE) {
         error_report("HEALTH [N/A]: Failed to execute SQL_INJECT_REMOVED_UPDATE_DETAIL, rc = %d", rc);
         goto failed;
     }
 
 failed:
-    if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
+    if (sqlite3_finalize(res) != SQLITE_OK)
         error_report("HEALTH [N/A]: Failed to finalize the prepared statement for injecting removed event.");
 }
 
@@ -706,7 +706,7 @@ uint32_t sql_get_max_unique_id (RRDHOST *host)
     }
 
     rc = sqlite3_bind_blob(res, 1, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind host_id parameter for SQL_SELECT_MAX_UNIQUE_ID.");
         sqlite3_finalize(res);
         return 0;
@@ -717,7 +717,7 @@ uint32_t sql_get_max_unique_id (RRDHOST *host)
      }
 
      rc = sqlite3_finalize(res);
-     if (unlikely(rc != SQLITE_OK))
+     if (rc != SQLITE_OK)
          error_report("Failed to finalize the statement");
 
      return max_unique_id;
@@ -738,7 +738,7 @@ void sql_check_removed_alerts_state(RRDHOST *host)
     }
 
     rc = sqlite3_bind_blob(res, 1, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind host_id parameter for SQL_SELECT_LAST_STATUSES.");
         sqlite3_finalize(res);
         return;
@@ -753,15 +753,15 @@ void sql_check_removed_alerts_state(RRDHOST *host)
         alarm_id = (uint32_t) sqlite3_column_int64(res, 2);
         alarm_event_id = (uint32_t) sqlite3_column_int64(res, 3);
         uuid_copy(transition_id, *((uuid_t *) sqlite3_column_blob(res, 4)));
-        if (unlikely(status != RRDCALC_STATUS_REMOVED)) {
-            if (unlikely(!max_unique_id))
+        if (status != RRDCALC_STATUS_REMOVED) {
+            if (!max_unique_id)
                 max_unique_id = sql_get_max_unique_id (host);
             sql_inject_removed_status (host, alarm_id, alarm_event_id, unique_id, ++max_unique_id, &transition_id);
         }
     }
 
      rc = sqlite3_finalize(res);
-     if (unlikely(rc != SQLITE_OK))
+     if (rc != SQLITE_OK)
          error_report("Failed to finalize the statement");
 }
 
@@ -782,7 +782,7 @@ void sql_health_alarm_log_load(RRDHOST *host) {
 
     host->health.health_log_entries_written = 0;
 
-    if (unlikely(!db_meta)) {
+    if (!db_meta) {
         if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
             error_report("HEALTH [%s]: Database has not been initialized", rrdhost_hostname(host));
         return;
@@ -791,13 +791,13 @@ void sql_health_alarm_log_load(RRDHOST *host) {
     sql_check_removed_alerts_state(host);
 
     ret = sqlite3_prepare_v2(db_meta, SQL_LOAD_HEALTH_LOG, -1, &res, 0);
-    if (unlikely(ret != SQLITE_OK)) {
+    if (ret != SQLITE_OK) {
         error_report("HEALTH [%s]: Failed to prepare sql statement to load health log.", rrdhost_hostname(host));
         return;
     }
 
     ret = sqlite3_bind_blob(res, 1, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
-    if (unlikely(ret != SQLITE_OK)) {
+    if (ret != SQLITE_OK) {
         error_report("Failed to bind host_id parameter for SQL_LOAD_HEALTH_LOG.");
         sqlite3_finalize(res);
         return;
@@ -854,7 +854,7 @@ void sql_health_alarm_log_load(RRDHOST *host) {
         time_t last_repeat = (time_t)sqlite3_column_int64(res, 26);
 
         rc = dictionary_get(all_rrdcalcs, (char *) sqlite3_column_text(res, 13));
-        if(unlikely(rc)) {
+        if(rc) {
             if (rrdcalc_isrepeating(rc)) {
                 rc->last_repeat = last_repeat;
                 // We iterate through repeating alarm entries only to
@@ -965,10 +965,10 @@ void sql_health_alarm_log_load(RRDHOST *host) {
         ae->next = host->health_log.alarms;
         host->health_log.alarms = ae;
 
-        if(unlikely(ae->unique_id > host->health_max_unique_id))
+        if(ae->unique_id > host->health_max_unique_id)
             host->health_max_unique_id = ae->unique_id;
 
-        if(unlikely(ae->alarm_id >= host->health_max_alarm_id))
+        if(ae->alarm_id >= host->health_max_alarm_id)
             host->health_max_alarm_id = ae->alarm_id;
 
         loaded++;
@@ -983,13 +983,13 @@ void sql_health_alarm_log_load(RRDHOST *host) {
     if(!host->health_max_alarm_id)  host->health_max_alarm_id  = (uint32_t)now_realtime_sec();
 
     host->health_log.next_log_id = host->health_max_unique_id + 1;
-    if (unlikely(!host->health_log.next_alarm_id || host->health_log.next_alarm_id <= host->health_max_alarm_id))
+    if (!host->health_log.next_alarm_id || host->health_log.next_alarm_id <= host->health_max_alarm_id)
         host->health_log.next_alarm_id = host->health_max_alarm_id + 1;
 
     netdata_log_health("[%s]: Table health_log, loaded %zd alarm entries, errors in %zd entries.", rrdhost_hostname(host), loaded, errored);
 
     ret = sqlite3_finalize(res);
-    if (unlikely(ret != SQLITE_OK))
+    if (ret != SQLITE_OK)
         error_report("Failed to finalize the health log read statement");
 
     sql_health_alarm_log_count(host);
@@ -1010,193 +1010,193 @@ int sql_store_alert_config_hash(uuid_t *hash_id, struct alert_config *cfg)
     static __thread sqlite3_stmt *res = NULL;
     int rc, param = 0;
 
-    if (unlikely(!db_meta)) {
+    if (!db_meta) {
         if (default_rrd_memory_mode != RRD_MEMORY_MODE_DBENGINE)
             return 0;
         error_report("Database has not been initialized");
         return 1;
     }
 
-    if (unlikely(!res)) {
+    if (!res) {
         rc = prepare_statement(db_meta, SQL_STORE_ALERT_CONFIG_HASH, &res);
-        if (unlikely(rc != SQLITE_OK)) {
+        if (rc != SQLITE_OK) {
             error_report("Failed to prepare statement to store alert configuration, rc = %d", rc);
             return 1;
         }
     }
 
     rc = sqlite3_bind_blob(res, ++param, hash_id, sizeof(*hash_id), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->alarm, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->template_key, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->on, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->classification, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->component, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->type, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->os, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->host, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->lookup, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->every, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->units, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->calc, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->families, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->plugin, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->module, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->charts, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->green, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->red, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->warn, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->crit, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->exec, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->to, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->info, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->delay, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->options, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->repeat, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->host_labels, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     if (cfg->p_db_lookup_after) {
         rc = sqlite3_bind_string_or_null(res, cfg->p_db_lookup_dimensions, ++param);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             goto bind_fail;
 
         rc = sqlite3_bind_string_or_null(res, cfg->p_db_lookup_method, ++param);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             goto bind_fail;
 
         rc = sqlite3_bind_int(res, ++param, (int) cfg->p_db_lookup_options);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             goto bind_fail;
 
         rc = sqlite3_bind_int(res, ++param, (int) cfg->p_db_lookup_after);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             goto bind_fail;
 
         rc = sqlite3_bind_int(res, ++param, (int) cfg->p_db_lookup_before);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             goto bind_fail;
     } else {
         rc = sqlite3_bind_null(res, ++param);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             goto bind_fail;
 
         rc = sqlite3_bind_null(res, ++param);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             goto bind_fail;
 
         rc = sqlite3_bind_null(res, ++param);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             goto bind_fail;
 
         rc = sqlite3_bind_null(res, ++param);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             goto bind_fail;
 
         rc = sqlite3_bind_null(res, ++param);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             goto bind_fail;
     }
 
     rc = sqlite3_bind_int(res, ++param, cfg->p_update_every);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->source, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_string_or_null(res, cfg->chart_labels, ++param);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE))
+    if (rc != SQLITE_DONE)
         error_report("Failed to store alert config, rc = %d", rc);
 
     rc = sqlite3_reset(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to reset statement in alert hash_id store function, rc = %d", rc);
 
     return 0;
@@ -1204,7 +1204,7 @@ int sql_store_alert_config_hash(uuid_t *hash_id, struct alert_config *cfg)
 bind_fail:
     error_report("Failed to bind parameter %d to store alert hash_id, rc = %d", param, rc);
     rc = sqlite3_reset(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to reset statement in alert hash_id store function, rc = %d", rc);
     return 1;
 }
@@ -1294,7 +1294,7 @@ int sql_health_get_last_executed_event(RRDHOST *host, ALARM_ENTRY *ae, RRDCALC_S
     }
 
     rc = sqlite3_bind_blob(res, 1, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind host_id parameter for SQL_SELECT_HEALTH_LAST_EXECUTED_EVENT.");
         sqlite3_finalize(res);
         return ret;
@@ -1307,7 +1307,7 @@ int sql_health_get_last_executed_event(RRDHOST *host, ALARM_ENTRY *ae, RRDCALC_S
     }
 
      rc = sqlite3_finalize(res);
-     if (unlikely(rc != SQLITE_OK))
+     if (rc != SQLITE_OK)
          error_report("Failed to finalize the statement.");
 
      return ret;
@@ -1346,14 +1346,14 @@ void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *
     }
 
     rc = sqlite3_prepare_v2(db_meta, buffer_tostring(command), -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to prepare statement SQL_SELECT_HEALTH_LOG");
         buffer_free(command);
         return;
     }
 
     rc = sqlite3_bind_blob(res, 1, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind host_id for SQL_SELECT_HEALTH_LOG.");
         sqlite3_finalize(res);
         buffer_free(command);
@@ -1461,7 +1461,7 @@ void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *
 
         health_string2json(wb, "\t\t", "info", (char *) sqlite3_column_text(res, 19), ",\n");
 
-        if(unlikely(sqlite3_column_int64(res, 9) & HEALTH_ENTRY_FLAG_NO_CLEAR_NOTIFICATION)) {
+        if(sqlite3_column_int64(res, 9) & HEALTH_ENTRY_FLAG_NO_CLEAR_NOTIFICATION) {
             buffer_strcat(wb, "\t\t\"no_clear_notification\": true,\n");
         }
 
@@ -1487,7 +1487,7 @@ void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *
     buffer_strcat(wb, "\n]");
 
     rc = sqlite3_finalize(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to finalize statement for SQL_SELECT_HEALTH_LOG");
 
     buffer_free(command);
@@ -1521,26 +1521,26 @@ int health_migrate_old_health_log_table(char *table) {
     sqlite3_stmt *res = NULL;
     snprintfz(command, MAX_HEALTH_SQL_SIZE, SQL_COPY_HEALTH_LOG(table));
     rc = sqlite3_prepare_v2(db_meta, command, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to prepare statement to copy health log, rc = %d", rc);
         freez(uuid_from_table);
         return 0;
     }
 
     rc = sqlite3_bind_blob(res, 1, &uuid, sizeof(uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         rc = sqlite3_finalize(res);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             error_report("Failed to reset statement to copy health log table, rc = %d", rc);
         freez(uuid_from_table);
         return 0;
     }
 
     rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE)) {
+    if (rc != SQLITE_DONE) {
         error_report("Failed to execute SQL_COPY_HEALTH_LOG, rc = %d", rc);
         rc = sqlite3_finalize(res);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             error_report("Failed to reset statement to copy health log table, rc = %d", rc);
         freez(uuid_from_table);
     }
@@ -1548,95 +1548,95 @@ int health_migrate_old_health_log_table(char *table) {
     //detail
     snprintfz(command, MAX_HEALTH_SQL_SIZE, SQL_COPY_HEALTH_LOG_DETAIL(table));
     rc = sqlite3_prepare_v2(db_meta, command, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to prepare statement to copy health log detail, rc = %d", rc);
         return 0;
     }
 
     rc = sqlite3_bind_blob(res, 1, &uuid, sizeof(uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         rc = sqlite3_finalize(res);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             error_report("Failed to reset statement to copy health log detail, rc = %d", rc);
         return 0;
     }
 
     rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE)) {
+    if (rc != SQLITE_DONE) {
         error_report("Failed to execute SQL_COPY_HEALTH_LOG_DETAIL, rc = %d", rc);
         rc = sqlite3_finalize(res);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             error_report("Failed to reset statement to copy health log detail table, rc = %d", rc);
         return 0;
     }
 
     //update transition ids
     rc = sqlite3_prepare_v2(db_meta, SQL_UPDATE_HEALTH_LOG_DETAIL_TRANSITION_ID, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to prepare statement to update health log detail with transition ids, rc = %d", rc);
         return 0;
     }
 
     rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE)) {
+    if (rc != SQLITE_DONE) {
         error_report("Failed to execute SQL_UPDATE_HEALTH_LOG_DETAIL_TRANSITION_ID, rc = %d", rc);
         rc = sqlite3_finalize(res);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             error_report("Failed to reset statement to update health log detail table with transition ids, rc = %d", rc);
         return 0;
     }
 
     //update health_log_id
     rc = sqlite3_prepare_v2(db_meta, SQL_UPDATE_HEALTH_LOG_DETAIL_HEALTH_LOG_ID, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to prepare statement to update health log detail with health log ids, rc = %d", rc);
         return 0;
     }
 
     rc = sqlite3_bind_blob(res, 1, &uuid, sizeof(uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         rc = sqlite3_finalize(res);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             error_report("Failed to reset statement to update health log detail with health log ids, rc = %d", rc);
         return 0;
     }
 
     rc = sqlite3_bind_blob(res, 2, &uuid, sizeof(uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         rc = sqlite3_finalize(res);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             error_report("Failed to reset statement to update health log detail with health log ids, rc = %d", rc);
         return 0;
     }
 
     rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE)) {
+    if (rc != SQLITE_DONE) {
         error_report("Failed to execute SQL_UPDATE_HEALTH_LOG_DETAIL_HEALTH_LOG_ID, rc = %d", rc);
         rc = sqlite3_finalize(res);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             error_report("Failed to reset statement to update health log detail table with health log ids, rc = %d", rc);
     }
 
     //update last transition id
     rc = sqlite3_prepare_v2(db_meta, SQL_UPDATE_HEALTH_LOG_LAST_TRANSITION_ID, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to prepare statement to update health log  with last transition id, rc = %d", rc);
         return 0;
     }
 
     rc = sqlite3_bind_blob(res, 1, &uuid, sizeof(uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         rc = sqlite3_finalize(res);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             error_report("Failed to reset statement to update health log with last transition id, rc = %d", rc);
         return 0;
     }
 
     rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE)) {
+    if (rc != SQLITE_DONE) {
         error_report("Failed to execute SQL_UPDATE_HEALTH_LOG_LAST_TRANSITION_ID, rc = %d", rc);
         rc = sqlite3_finalize(res);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             error_report("Failed to reset statement to update health log table with last transition id, rc = %d", rc);
     }
 
@@ -1659,28 +1659,28 @@ uint32_t sql_get_alarm_id(RRDHOST *host, STRING *chart, STRING *name, uint32_t *
     }
 
     rc = sqlite3_bind_blob(res, 1, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind host_id parameter for SQL_GET_ALARM_ID.");
         sqlite3_finalize(res);
         return alarm_id;
     }
 
     rc = sqlite3_bind_string_or_null(res, chart, 2);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind char parameter for SQL_GET_ALARM_ID.");
         sqlite3_finalize(res);
         return alarm_id;
     }
 
     rc = sqlite3_bind_string_or_null(res, name, 3);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind name parameter for SQL_GET_ALARM_ID.");
         sqlite3_finalize(res);
         return alarm_id;
     }
 
     rc = sqlite3_bind_blob(res, 4, config_hash_id, sizeof(*config_hash_id), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind config_hash_id parameter for SQL_GET_ALARM_ID.");
         sqlite3_finalize(res);
         return alarm_id;
@@ -1692,7 +1692,7 @@ uint32_t sql_get_alarm_id(RRDHOST *host, STRING *chart, STRING *name, uint32_t *
     }
 
      rc = sqlite3_finalize(res);
-     if (unlikely(rc != SQLITE_OK))
+     if (rc != SQLITE_OK)
          error_report("Failed to finalize the statement while getting an alarm id.");
 
      if (alarm_id) {
@@ -1703,14 +1703,14 @@ uint32_t sql_get_alarm_id(RRDHOST *host, STRING *chart, STRING *name, uint32_t *
          }
 
          rc = sqlite3_bind_int64(res, 1, (sqlite3_int64) health_log_id);
-         if (unlikely(rc != SQLITE_OK)) {
+         if (rc != SQLITE_OK) {
              error_report("Failed to bind host_id parameter for SQL_GET_EVENT_ID.");
              sqlite3_finalize(res);
              return alarm_id;
          }
 
          rc = sqlite3_bind_int64(res, 2, (sqlite3_int64) alarm_id);
-         if (unlikely(rc != SQLITE_OK)) {
+         if (rc != SQLITE_OK) {
              error_report("Failed to bind char parameter for SQL_GET_EVENT_ID.");
              sqlite3_finalize(res);
              return alarm_id;
@@ -1721,7 +1721,7 @@ uint32_t sql_get_alarm_id(RRDHOST *host, STRING *chart, STRING *name, uint32_t *
          }
 
          rc = sqlite3_finalize(res);
-         if (unlikely(rc != SQLITE_OK))
+         if (rc != SQLITE_OK)
              error_report("Failed to finalize the statement while getting an alarm id.");
      }
 
@@ -1743,9 +1743,9 @@ bool sql_find_alert_transition(const char *transition, void (*cb)(const char *ma
     if (uuid_parse(transition, transition_uuid))
         return false;
 
-    if (unlikely(!res)) {
+    if (!res) {
         rc = prepare_statement(db_meta, SQL_GET_ALARM_ID_FROM_TRANSITION_ID, &res);
-        if (unlikely(rc != SQLITE_OK)) {
+        if (rc != SQLITE_OK) {
              error_report("Failed to prepare statement when trying to get transition id");
              return false;
         }
@@ -1754,7 +1754,7 @@ bool sql_find_alert_transition(const char *transition, void (*cb)(const char *ma
     bool ok = false;
 
     rc = sqlite3_bind_blob(res, 1, &transition_uuid, sizeof(transition_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind transition");
         goto fail;
     }
@@ -1767,7 +1767,7 @@ bool sql_find_alert_transition(const char *transition, void (*cb)(const char *ma
 
 fail:
     rc = sqlite3_reset(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to reset the statement when trying to find transition");
 
     return ok;
@@ -1809,7 +1809,7 @@ void sql_alert_transitions(
     sqlite3_stmt *res = NULL;
     BUFFER *command = NULL;
 
-    if (unlikely(!nodes))
+    if (!nodes)
         return;
 
     if (transition) {
@@ -1821,7 +1821,7 @@ void sql_alert_transitions(
         rc = sqlite3_prepare_v2(db_meta, SQL_SEARCH_ALERT_TRANSITION_DIRECT, -1, &res, 0);
 
         rc = sqlite3_bind_blob(res, 1, &transition_uuid, sizeof(transition_uuid), SQLITE_STATIC);
-        if (unlikely(rc != SQLITE_OK)) {
+        if (rc != SQLITE_OK) {
             error_report("Failed to bind transition_id parameter");
             goto fail;
         }
@@ -1837,7 +1837,7 @@ void sql_alert_transitions(
 
     // Prepare statement to add things
     rc = sqlite3_prepare_v2(db_meta, sql, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to prepare statement to INSERT into v_%p", nodes);
         goto fail_only_drop;
     }
@@ -1848,7 +1848,7 @@ void sql_alert_transitions(
         uuid_parse( t_dfe.name, host_uuid);
 
         rc = sqlite3_bind_blob(res, 1, &host_uuid, sizeof(host_uuid), SQLITE_STATIC);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             error_report("Failed to bind host_id parameter.");
 
         rc = sqlite3_step_monitored(res);
@@ -1862,7 +1862,7 @@ void sql_alert_transitions(
     dfe_done(t);
 
     rc = sqlite3_finalize(res);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         // log error but continue
         error_report("Failed to finalize statement for sql_alert_transitions temp table population");
     }
@@ -1880,27 +1880,27 @@ void sql_alert_transitions(
     buffer_strcat(command, " ORDER BY d.global_id DESC");
 
     rc = sqlite3_prepare_v2(db_meta, buffer_tostring(command), -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to prepare statement sql_alert_transitions");
         goto fail_only_drop;
     }
 
     int param = 1;
     rc = sqlite3_bind_int64(res, param++, (sqlite3_int64)(after * USEC_PER_SEC));
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind after parameter");
         goto fail;
     }
 
     rc = sqlite3_bind_int64(res, param++, (sqlite3_int64)(before * USEC_PER_SEC));
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind before parameter");
         goto fail;
     }
 
     if (context) {
         rc = sqlite3_bind_text(res, param++, context, -1, SQLITE_STATIC);
-        if (unlikely(rc != SQLITE_OK)) {
+        if (rc != SQLITE_OK) {
             error_report("Failed to bind context parameter");
             goto fail;
         }
@@ -1908,7 +1908,7 @@ void sql_alert_transitions(
 
     if (alert_name) {
         rc = sqlite3_bind_text(res, param++, alert_name, -1, SQLITE_STATIC);
-        if (unlikely(rc != SQLITE_OK)) {
+        if (rc != SQLITE_OK) {
             error_report("Failed to bind alert_name parameter");
             goto fail;
         }
@@ -1955,11 +1955,11 @@ run_query:;
 
 fail:
     rc = sqlite3_finalize(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to finalize statement for sql_alert_transitions");
 
 fail_only_drop:
-    if (likely(!transition)) {
+    if (!transition) {
         (void)snprintfz(sql, 511, "DROP TABLE IF EXISTS v_%p", nodes);
         (void)db_execute(db_meta, sql);
         buffer_free(command);
@@ -1988,7 +1988,7 @@ int sql_get_alert_configuration(
     sqlite3_stmt *res = NULL;
     BUFFER *command = NULL;
 
-    if (unlikely(!configs))
+    if (!configs)
         return added;
 
     snprintfz(sql, 511, SQL_BUILD_CONFIG_TARGET_LIST, configs);
@@ -2000,7 +2000,7 @@ int sql_get_alert_configuration(
 
     // Prepare statement to add things
     rc = sqlite3_prepare_v2(db_meta, sql, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to prepare statement to INSERT into c_%p", configs);
         goto fail_only_drop;
     }
@@ -2011,7 +2011,7 @@ int sql_get_alert_configuration(
         uuid_parse( t_dfe.name, hash_id);
 
         rc = sqlite3_bind_blob(res, 1, &hash_id, sizeof(hash_id), SQLITE_STATIC);
-        if (unlikely(rc != SQLITE_OK))
+        if (rc != SQLITE_OK)
             error_report("Failed to bind host_id parameter.");
 
         rc = sqlite3_step_monitored(res);
@@ -2025,7 +2025,7 @@ int sql_get_alert_configuration(
     dfe_done(t);
 
     rc = sqlite3_finalize(res);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         // log error but continue
         error_report("Failed to finalize statement for sql_get_alert_configuration temp table population");
     }
@@ -2035,7 +2035,7 @@ int sql_get_alert_configuration(
     buffer_sprintf(command, SQL_SEARCH_CONFIG_LIST, configs);
 
     rc = sqlite3_prepare_v2(db_meta, buffer_tostring(command), -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to prepare statement sql_get_alert_configuration");
         goto fail_only_drop;
     }
@@ -2088,7 +2088,7 @@ int sql_get_alert_configuration(
     }
 
     rc = sqlite3_finalize(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to finalize statement for sql_get_alert_configuration");
 
 fail_only_drop:
@@ -2107,24 +2107,24 @@ bool is_chart_name_populated(uuid_t  *host_uuid)
     bool status = true;
 
     rc = sqlite3_prepare_v2(db_meta, SQL_FETCH_CHART_NAME, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to prepare statement to check health_log chart_name");
         return true;
     }
 
     rc = sqlite3_bind_blob(res, 1, host_uuid, sizeof(*host_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind host_id for health_log chart_name check");
         goto fail;
     }
 
     rc = sqlite3_step_monitored(res);
-    if (likely(rc == SQLITE_ROW))
+    if (rc == SQLITE_ROW)
         status = sqlite3_column_type(res, 0) != SQLITE_NULL;
 fail:
 
     rc = sqlite3_finalize(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to finalize the prepared statement for health_log chart_name check");
 
     return status;
@@ -2142,24 +2142,24 @@ void chart_name_populate(uuid_t *host_uuid)
     int rc;
 
     rc = sqlite3_prepare_v2(db_meta, SQL_POPULATE_CHART_NAME, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to prepare statement to update health_log chart_name");
         return;
     }
 
     rc = sqlite3_bind_blob(res, 1, host_uuid, sizeof(*host_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to bind host_id for health_log chart_name update");
         goto fail;
     }
 
     rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE))
+    if (rc != SQLITE_DONE)
         error_report("Failed to update chart name in health_log, rc = %d", rc);
 
 fail:
 
     rc = sqlite3_finalize(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to finalize the prepared statement for health_log chart_name update");
 }

--- a/exporting/aws_kinesis/aws_kinesis.c
+++ b/exporting/aws_kinesis/aws_kinesis.c
@@ -109,7 +109,7 @@ void aws_kinesis_connector_worker(void *instance_p)
             uv_cond_wait(&instance->cond_var, &instance->mutex);
         instance->data_is_ready = 0;
 
-        if (unlikely(instance->engine->exit)) {
+        if (instance->engine->exit) {
             uv_mutex_unlock(&instance->mutex);
             break;
         }
@@ -171,8 +171,8 @@ void aws_kinesis_connector_worker(void *instance_p)
 
             size_t sent_bytes = 0, lost_bytes = 0;
 
-            if (unlikely(kinesis_get_result(
-                    connector_specific_data->request_outcomes, error_message, &sent_bytes, &lost_bytes))) {
+            if (kinesis_get_result(
+                    connector_specific_data->request_outcomes, error_message, &sent_bytes, &lost_bytes)) {
                 // oops! we couldn't send (all or some of the) data
                 netdata_log_error("EXPORTING: %s", error_message);
                 netdata_log_error("EXPORTING: failed to write data to external database '%s'. Willing to write %zu bytes, wrote %zu bytes.",
@@ -194,12 +194,12 @@ void aws_kinesis_connector_worker(void *instance_p)
                 stats->receptions++;
             }
 
-            if (unlikely(instance->engine->exit))
+            if (instance->engine->exit)
                 break;
         }
 
         stats->sent_bytes += sent;
-        if (likely(sent == buffer_len))
+        if (sent == buffer_len)
             stats->sent_metrics = stats->buffered_metrics;
 
         buffer_flush(buffer);

--- a/exporting/check_filters.c
+++ b/exporting/check_filters.c
@@ -24,7 +24,7 @@ int rrdhost_is_exportable(struct instance *instance, RRDHOST *host)
 
     RRDHOST_FLAGS *flags = &host->exporting_flags[instance->index];
 
-    if (unlikely((*flags & (RRDHOST_FLAG_EXPORTING_SEND | RRDHOST_FLAG_EXPORTING_DONT_SEND)) == 0)) {
+    if ((*flags & (RRDHOST_FLAG_EXPORTING_SEND | RRDHOST_FLAG_EXPORTING_DONT_SEND)) == 0) {
         const char *host_name = (host == localhost) ? "localhost" : rrdhost_hostname(host);
 
         if (!instance->config.hosts_pattern || simple_pattern_matches(instance->config.hosts_pattern, host_name)) {
@@ -36,7 +36,7 @@ int rrdhost_is_exportable(struct instance *instance, RRDHOST *host)
         }
     }
 
-    if (likely(*flags & RRDHOST_FLAG_EXPORTING_SEND))
+    if (*flags & RRDHOST_FLAG_EXPORTING_SEND)
         return 1;
     else
         return 0;
@@ -60,10 +60,10 @@ int rrdset_is_exportable(struct instance *instance, RRDSET *st)
 
     RRDSET_FLAGS *flags = &st->exporting_flags[instance->index];
 
-    if(unlikely(*flags & RRDSET_FLAG_EXPORTING_IGNORE))
+    if(*flags & RRDSET_FLAG_EXPORTING_IGNORE)
         return 0;
 
-    if(unlikely(!(*flags & RRDSET_FLAG_EXPORTING_SEND))) {
+    if(!(*flags & RRDSET_FLAG_EXPORTING_SEND)) {
         // we have not checked this chart
         if(simple_pattern_matches_string(instance->config.charts_pattern, st->id) || simple_pattern_matches_string(instance->config.charts_pattern, st->name))
             *flags |= RRDSET_FLAG_EXPORTING_SEND;
@@ -74,12 +74,12 @@ int rrdset_is_exportable(struct instance *instance, RRDSET *st)
         }
     }
 
-    if(unlikely(!rrdset_is_available_for_exporting_and_alarms(st))) {
+    if(!rrdset_is_available_for_exporting_and_alarms(st)) {
         netdata_log_debug(D_EXPORTING, "EXPORTING: not sending chart '%s' of host '%s', because it is not available for exporting.", rrdset_id(st), rrdhost_hostname(host));
         return 0;
     }
 
-    if(unlikely(st->rrd_memory_mode == RRD_MEMORY_MODE_NONE && !(EXPORTING_OPTIONS_DATA_SOURCE(instance->config.options) == EXPORTING_SOURCE_DATA_AS_COLLECTED))) {
+    if(st->rrd_memory_mode == RRD_MEMORY_MODE_NONE && !(EXPORTING_OPTIONS_DATA_SOURCE(instance->config.options) == EXPORTING_SOURCE_DATA_AS_COLLECTED)) {
         netdata_log_debug(D_EXPORTING, "EXPORTING: not sending chart '%s' of host '%s' because its memory mode is '%s' and the exporting engine requires database access.", rrdset_id(st), rrdhost_hostname(host), rrd_memory_mode_name(host->rrd_memory_mode));
         return 0;
     }

--- a/exporting/graphite/graphite.c
+++ b/exporting/graphite/graphite.c
@@ -97,7 +97,7 @@ int format_host_labels_graphite_plaintext(struct instance *instance, RRDHOST *ho
     if (!instance->labels_buffer)
         instance->labels_buffer = buffer_create(1024, &netdata_buffers_statistics.buffers_exporters);
 
-    if (unlikely(!sending_labels_configured(instance)))
+    if (!sending_labels_configured(instance))
         return 0;
 
     rrdlabels_to_buffer(host->rrdlabels, instance->labels_buffer, ";", "=", "", "",

--- a/exporting/json/json.c
+++ b/exporting/json/json.c
@@ -120,7 +120,7 @@ int format_host_labels_json_plaintext(struct instance *instance, RRDHOST *host)
     if (!instance->labels_buffer)
         instance->labels_buffer = buffer_create(1024, &netdata_buffers_statistics.buffers_exporters);
 
-    if (unlikely(!sending_labels_configured(instance)))
+    if (!sending_labels_configured(instance))
         return 0;
 
     buffer_strcat(instance->labels_buffer, "\"labels\":{");

--- a/exporting/opentsdb/opentsdb.c
+++ b/exporting/opentsdb/opentsdb.c
@@ -150,7 +150,7 @@ int format_host_labels_opentsdb_telnet(struct instance *instance, RRDHOST *host)
     if(!instance->labels_buffer)
         instance->labels_buffer = buffer_create(1024, &netdata_buffers_statistics.buffers_exporters);
 
-    if (unlikely(!sending_labels_configured(instance)))
+    if (!sending_labels_configured(instance))
         return 0;
 
     buffer_strcat(instance->labels_buffer, " ");
@@ -283,7 +283,7 @@ int format_host_labels_opentsdb_http(struct instance *instance, RRDHOST *host) {
     if (!instance->labels_buffer)
         instance->labels_buffer = buffer_create(1024, &netdata_buffers_statistics.buffers_exporters);
 
-    if (unlikely(!sending_labels_configured(instance)))
+    if (!sending_labels_configured(instance))
         return 0;
 
     rrdlabels_to_buffer(host->rrdlabels, instance->labels_buffer, ",", ":", "\"", "",

--- a/exporting/process_data.c
+++ b/exporting/process_data.c
@@ -95,17 +95,17 @@ NETDATA_DOUBLE exporting_calculate_value_from_stored_data(
     // the latest point will be reported the next time
     before -= update_every;
 
-    if (unlikely(after > before))
+    if (after > before)
         // this can happen when update_every > before - after
         after = before;
 
-    if (unlikely(after < first_t))
+    if (after < first_t)
         after = first_t;
 
-    if (unlikely(before > last_t))
+    if (before > last_t)
         before = last_t;
 
-    if (unlikely(before < first_t || after > last_t)) {
+    if (before < first_t || after > last_t) {
         // the chart has not been updated in the wanted timeframe
         netdata_log_debug(
             D_EXPORTING,
@@ -130,7 +130,7 @@ NETDATA_DOUBLE exporting_calculate_value_from_stored_data(
         STORAGE_POINT sp = storage_engine_query_next_metric(&handle);
         points_read++;
 
-        if (unlikely(storage_point_is_gap(sp))) {
+        if (storage_point_is_gap(sp)) {
             // not collected
             continue;
         }
@@ -141,7 +141,7 @@ NETDATA_DOUBLE exporting_calculate_value_from_stored_data(
     storage_engine_query_finalize(&handle);
     global_statistics_exporters_query_completed(points_read);
 
-    if (unlikely(!counter)) {
+    if (!counter) {
         netdata_log_debug(
             D_EXPORTING,
             "EXPORTING: %s.%s.%s: no values stored in database for range %lu to %lu",
@@ -153,7 +153,7 @@ NETDATA_DOUBLE exporting_calculate_value_from_stored_data(
         return NAN;
     }
 
-    if (unlikely(EXPORTING_OPTIONS_DATA_SOURCE(instance->config.options) == EXPORTING_SOURCE_DATA_SUM))
+    if (EXPORTING_OPTIONS_DATA_SOURCE(instance->config.options) == EXPORTING_SOURCE_DATA_SUM)
         return sum;
 
     return sum / (NETDATA_DOUBLE)counter;

--- a/exporting/prometheus/remote_write/remote_write.c
+++ b/exporting/prometheus/remote_write/remote_write.c
@@ -46,7 +46,7 @@ void prometheus_remote_write_prepare_header(struct instance *instance)
  */
 int process_prometheus_remote_write_response(BUFFER *buffer, struct instance *instance)
 {
-    if (unlikely(!buffer))
+    if (!buffer)
         return 1;
 
     const char *s = buffer_tostring(buffer);
@@ -61,7 +61,7 @@ int process_prometheus_remote_write_response(BUFFER *buffer, struct instance *in
     s++;
     len--;
 
-    if (likely(len > 4 && (!strncmp(s, "200 ", 4) || !strncmp(s, "204 ", 4))))
+    if (len > 4 && (!strncmp(s, "200 ", 4) || !strncmp(s, "204 ", 4)))
         return 0;
     else
         return exporting_discard_response(buffer, instance);
@@ -177,7 +177,7 @@ int format_host_prometheus_remote_write(struct instance *instance, RRDHOST *host
         connector_specific_data->write_request,
         "netdata_info", hostname, rrdhost_program_name(host), rrdhost_program_version(host), now_realtime_usec() / USEC_PER_MS);
     
-    if (unlikely(sending_labels_configured(instance))) {
+    if (sending_labels_configured(instance)) {
         struct format_remote_write_label_callback tmp = {
             .write_request = connector_specific_data->write_request,
             .instance = instance
@@ -243,7 +243,7 @@ int format_dimension_prometheus_remote_write(struct instance *instance, RRDDIM *
         if (as_collected) {
             // we need as-collected / raw data
 
-            if (unlikely(rd->collector.last_collected_time.tv_sec < instance->after)) {
+            if (rd->collector.last_collected_time.tv_sec < instance->after) {
                 netdata_log_debug(
                     D_EXPORTING,
                     "EXPORTING: not sending dimension '%s' of chart '%s' from host '%s', "
@@ -385,7 +385,7 @@ int format_batch_prometheus_remote_write(struct instance *instance)
 
     size_t data_size = get_write_request_size(connector_specific_data->write_request);
 
-    if (unlikely(!data_size)) {
+    if (!data_size) {
         netdata_log_error("EXPORTING: write request size is out of range");
         return 1;
     }
@@ -393,7 +393,7 @@ int format_batch_prometheus_remote_write(struct instance *instance)
     BUFFER *buffer = instance->buffer;
 
     buffer_need_bytes(buffer, data_size);
-    if (unlikely(pack_and_clear_write_request(connector_specific_data->write_request, buffer->buffer, &data_size))) {
+    if (pack_and_clear_write_request(connector_specific_data->write_request, buffer->buffer, &data_size)) {
         netdata_log_error("EXPORTING: cannot pack write request");
         return 1;
     }

--- a/exporting/pubsub/pubsub.c
+++ b/exporting/pubsub/pubsub.c
@@ -109,7 +109,7 @@ void pubsub_connector_worker(void *instance_p)
         instance->data_is_ready = 0;
 
 
-        if (unlikely(instance->engine->exit)) {
+        if (instance->engine->exit) {
             uv_mutex_unlock(&instance->mutex);
             break;
         }
@@ -161,8 +161,8 @@ void pubsub_connector_worker(void *instance_p)
 
         size_t sent_metrics = 0, lost_metrics = 0, sent_bytes = 0, lost_bytes = 0;
 
-        if (unlikely(pubsub_get_result(
-                connector_specific_data, error_message, &sent_metrics, &sent_bytes, &lost_metrics, &lost_bytes))) {
+        if (pubsub_get_result(
+                connector_specific_data, error_message, &sent_metrics, &sent_bytes, &lost_metrics, &lost_bytes)) {
             // oops! we couldn't send (all or some of the) data
             netdata_log_error("EXPORTING: %s", error_message);
             netdata_log_error(

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -18,7 +18,7 @@ static _CONNECTOR_INSTANCE *find_instance(const char *section)
     _CONNECTOR_INSTANCE *local_ci;
 
     local_ci = add_connector_instance(NULL, NULL); // Get root section
-    if (unlikely(!local_ci))
+    if (!local_ci)
         return local_ci;
 
     if (!section)
@@ -104,7 +104,7 @@ int get_connector_instance(struct connector_instance *target_ci)
 
     global_connector_instance = find_instance(NULL); // Fetch head of instances
 
-    if (unlikely(!global_connector_instance))
+    if (!global_connector_instance)
         return 0;
 
     if (target_ci == NULL) {
@@ -204,7 +204,7 @@ struct engine *read_exporting_config()
     struct connector_instance local_ci;
     struct connector_instance_list *tmp_ci_list = NULL, *tmp_ci_list1 = NULL, *tmp_ci_list_prev = NULL;
 
-    if (unlikely(engine))
+    if (engine)
         return engine;
 
     char *filename = strdupz_path_subpath(netdata_configured_user_config_dir, EXPORTING_CONF);
@@ -293,7 +293,7 @@ struct engine *read_exporting_config()
             netdata_log_info("Instance (%s) on connector (%s) is not enabled", local_ci.instance_name, local_ci.connector_name);
     }
 
-    if (unlikely(!instances_to_activate)) {
+    if (!instances_to_activate) {
         netdata_log_info("No connector instances to activate");
         return NULL;
     }
@@ -497,7 +497,7 @@ struct engine *read_exporting_config()
             tmp_instance->config.options);
 #endif
 
-        if (unlikely(!exporting_config_exists) && !engine->config.hostname) {
+        if (!exporting_config_exists && !engine->config.hostname) {
             engine->config.hostname = strdupz(config_get(instance_name, "hostname", netdata_configured_hostname));
             engine->config.update_every =
                 config_get_number(instance_name, EXPORTING_UPDATE_EVERY_OPTION_NAME, EXPORTING_UPDATE_EVERY_DEFAULT);

--- a/exporting/send_data.c
+++ b/exporting/send_data.c
@@ -35,7 +35,7 @@ int exporting_discard_response(BUFFER *buffer, struct instance *instance) {
 
     for(; *s && d < e ;s++) {
         char c = *s;
-        if(unlikely(!isprint(c))) c = ' ';
+        if(!isprint(c)) c = ' ';
         *d++ = c;
     }
     *d = '\0';
@@ -88,7 +88,7 @@ void simple_connector_receive_response(int *sock, struct instance *instance)
 #else
         r = recv(*sock, &response->buffer[response->len], response->size - response->len, MSG_DONTWAIT);
 #endif
-        if (likely(r > 0)) {
+        if (r > 0) {
             // we received some data
             response->len += r;
             stats->received_bytes += r;
@@ -240,7 +240,7 @@ void simple_connector_worker(void *instance_p)
             send_stats = 1;
         }
 
-        if (unlikely(instance->engine->exit)) {
+        if (instance->engine->exit) {
             uv_mutex_unlock(&instance->mutex);
             break;
         }
@@ -278,13 +278,13 @@ void simple_connector_worker(void *instance_p)
         // ------------------------------------------------------------------------
         // if we are connected, receive a response, without blocking
 
-        if (likely(sock != -1))
+        if (sock != -1)
             simple_connector_receive_response(&sock, instance);
 
         // ------------------------------------------------------------------------
         // if we are not connected, connect to a data collecting server
 
-        if (unlikely(sock == -1)) {
+        if (sock == -1) {
             size_t reconnects = 0;
 
             sock = connect_to_one_of_urls(
@@ -322,7 +322,7 @@ void simple_connector_worker(void *instance_p)
             stats->reconnects += reconnects;
         }
 
-        if (unlikely(instance->engine->exit))
+        if (instance->engine->exit)
             break;
 
         // ------------------------------------------------------------------------
@@ -330,7 +330,7 @@ void simple_connector_worker(void *instance_p)
 
         failures = 0;
 
-        if (likely(sock != -1)) {
+        if (sock != -1) {
             simple_connector_send_buffer(
                 &sock,
                 &failures,
@@ -352,7 +352,7 @@ void simple_connector_worker(void *instance_p)
             connector_specific_data->first_buffer = connector_specific_data->first_buffer->next;
         }
 
-        if (unlikely(instance->engine->exit))
+        if (instance->engine->exit)
             break;
 
         if (send_stats) {

--- a/health/health_config.c
+++ b/health/health_config.c
@@ -443,7 +443,7 @@ char *health_edit_command_from_source(const char *source)
     char *line_num = strchr(temp, '@');
     char *file_no_path = strrchr(temp, '/');
 
-    if (likely(file_no_path && line_num)) {
+    if (file_no_path && line_num) {
         *line_num = '\0';
         snprintfz(
             buffer,
@@ -541,7 +541,7 @@ static int health_readfile(const char *filename, void *data) {
 
     char buffer[HEALTH_CONF_MAX_LINE + 1];
 
-    if(unlikely(!hash_alarm)) {
+    if(!hash_alarm) {
         hash_alarm = simple_uhash(HEALTH_ALARM_KEY);
         hash_template = simple_uhash(HEALTH_TEMPLATE_KEY);
         hash_on = simple_uhash(HEALTH_ON_KEY);
@@ -1326,7 +1326,7 @@ void sql_refresh_hashes(void)
 }
 
 void health_readdir(RRDHOST *host, const char *user_path, const char *stock_path, const char *subpath) {
-    if(unlikely((!host->health.health_enabled) && !rrdhost_flag_check(host, RRDHOST_FLAG_INITIALIZED_HEALTH)) ||
+    if((!host->health.health_enabled) && !rrdhost_flag_check(host, RRDHOST_FLAG_INITIALIZED_HEALTH) ||
         !service_running(SERVICE_HEALTH)) {
         netdata_log_debug(D_HEALTH, "CONFIG health is not enabled for host '%s'", rrdhost_hostname(host));
         return;

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -112,7 +112,7 @@ static inline void health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC
                    , (unsigned long)rc->times_repeat
     );
 
-    if(unlikely(rc->options & RRDCALC_OPTION_NO_CLEAR_NOTIFICATION)) {
+    if(rc->options & RRDCALC_OPTION_NO_CLEAR_NOTIFICATION) {
         buffer_strcat(wb, "\t\t\t\"no_clear_notification\": true,\n");
     }
 
@@ -181,13 +181,13 @@ void health_aggregate_alarms(RRDHOST *host, BUFFER *wb, BUFFER* contexts, RRDCAL
             STRING *tok_string = string_strdupz(tok);
 
             foreach_rrdcalc_in_rrdhost_read(host, rc) {
-                if(unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
+                if(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec)
                     continue;
-                if (unlikely(!rrdset_is_available_for_exporting_and_alarms(rc->rrdset)))
+                if (!rrdset_is_available_for_exporting_and_alarms(rc->rrdset))
                     continue;
-                if(unlikely(rc->rrdset
+                if(rc->rrdset
                              && rc->rrdset->context == tok_string
-                             && ((status==RRDCALC_STATUS_RAISED)?(rc->status >= RRDCALC_STATUS_WARNING):rc->status == status)))
+                             && ((status==RRDCALC_STATUS_RAISED)?(rc->status >= RRDCALC_STATUS_WARNING):rc->status == status))
                     numberOfAlarms++;
             }
             foreach_rrdcalc_in_rrdhost_done(rc);
@@ -197,11 +197,11 @@ void health_aggregate_alarms(RRDHOST *host, BUFFER *wb, BUFFER* contexts, RRDCAL
     }
     else {
         foreach_rrdcalc_in_rrdhost_read(host, rc) {
-            if(unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
+            if(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec)
                 continue;
-            if (unlikely(!rrdset_is_available_for_exporting_and_alarms(rc->rrdset)))
+            if (!rrdset_is_available_for_exporting_and_alarms(rc->rrdset))
                 continue;
-            if(unlikely((status==RRDCALC_STATUS_RAISED)?(rc->status >= RRDCALC_STATUS_WARNING):rc->status == status))
+            if((status==RRDCALC_STATUS_RAISED)?(rc->status >= RRDCALC_STATUS_WARNING):rc->status == status)
                 numberOfAlarms++;
         }
         foreach_rrdcalc_in_rrdhost_done(rc);
@@ -214,16 +214,16 @@ static void health_alarms2json_fill_alarms(RRDHOST *host, BUFFER *wb, int all, v
     RRDCALC *rc;
     int i = 0;
     foreach_rrdcalc_in_rrdhost_read(host, rc) {
-        if(unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
+        if(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec)
             continue;
 
-        if (unlikely(!rrdset_is_available_for_exporting_and_alarms(rc->rrdset)))
+        if (!rrdset_is_available_for_exporting_and_alarms(rc->rrdset))
             continue;
 
-        if(likely(!all && !(rc->status == RRDCALC_STATUS_WARNING || rc->status == RRDCALC_STATUS_CRITICAL)))
+        if(!all && !(rc->status == RRDCALC_STATUS_WARNING || rc->status == RRDCALC_STATUS_CRITICAL))
             continue;
 
-        if(likely(i)) buffer_strcat(wb, ",\n");
+        if(i) buffer_strcat(wb, ",\n");
         fp(host, wb, rc);
         i++;
     }

--- a/libnetdata/adaptive_resortable_list/adaptive_resortable_list.c
+++ b/libnetdata/adaptive_resortable_list/adaptive_resortable_list.c
@@ -48,7 +48,7 @@ ARL_BASE *arl_create(const char *name, void (*processor)(const char *, uint32_t,
 }
 
 void arl_free(ARL_BASE *arl_base) {
-    if(unlikely(!arl_base))
+    if(!arl_base)
         return;
 
     while(arl_base->head) {
@@ -74,19 +74,19 @@ void arl_free(ARL_BASE *arl_base) {
 void arl_begin(ARL_BASE *base) {
 
 #ifdef NETDATA_INTERNAL_CHECKS
-    if(likely(base->iteration > 10)) {
+    if(base->iteration > 10) {
         // do these checks after the ARL has been sorted
 
-        if(unlikely(base->relinkings > (base->expected + base->allocated)))
+        if(base->relinkings > (base->expected + base->allocated))
             netdata_log_info("ARL '%s' has %zu relinkings with %zu expected and %zu allocated entries. Is the source changing so fast?"
                  , base->name, base->relinkings, base->expected, base->allocated);
 
-        if(unlikely(base->slow > base->fast))
+        if(base->slow > base->fast)
             netdata_log_info("ARL '%s' has %zu fast searches and %zu slow searches. Is the source really changing so fast?"
                  , base->name, base->fast, base->slow);
 
         /*
-        if(unlikely(base->iteration % 60 == 0)) {
+        if(base->iteration % 60 == 0) {
             netdata_log_info("ARL '%s' statistics: iteration %zu, expected %zu, wanted %zu, allocated %zu, fred %zu, relinkings %zu, found %zu, added %zu, fast %zu, slow %zu"
                  , base->name
                  , base->iteration
@@ -107,7 +107,7 @@ void arl_begin(ARL_BASE *base) {
     }
 #endif
 
-    if(unlikely(base->iteration > 0 && (base->added || (base->iteration % base->rechecks) == 0))) {
+    if(base->iteration > 0 && (base->added || (base->iteration % base->rechecks) == 0)) {
         int wanted_equals_expected = ((base->iteration % base->rechecks) == 0);
 
         // fprintf(stderr, "\n\narl_begin() rechecking, added %zu, iteration %zu, rechecks %zu, wanted_equals_expected %d\n\n\n", base->added, base->iteration, base->rechecks, wanted_equals_expected);
@@ -156,7 +156,7 @@ void arl_begin(ARL_BASE *base) {
         }
     }
 
-    if(unlikely(!base->head)) {
+    if(!base->head) {
         // hm... no nodes at all in the list #1700
         // add a fake one to prevent a crash
         // this is better than checking for the existence of nodes all the time
@@ -204,7 +204,7 @@ int arl_find_or_create_and_relink(ARL_BASE *base, const char *s, const char *val
             break;
 
 #ifdef NETDATA_INTERNAL_CHECKS
-    if(unlikely(base->next_keyword && e == base->next_keyword))
+    if(base->next_keyword && e == base->next_keyword)
         fatal("Internal Error: e == base->last");
 #endif
 
@@ -214,7 +214,7 @@ int arl_find_or_create_and_relink(ARL_BASE *base, const char *s, const char *val
         base->relinkings++;
 
         // run the processor for it
-        if(unlikely(e->dst)) {
+        if(e->dst) {
             e->processor(e->name, hash, value, e->dst);
             base->found++;
         }
@@ -241,7 +241,7 @@ int arl_find_or_create_and_relink(ARL_BASE *base, const char *s, const char *val
     }
 
 #ifdef NETDATA_INTERNAL_CHECKS
-    if(unlikely(base->iteration % 60 == 0 && e->flags & ARL_ENTRY_FLAG_FOUND))
+    if(base->iteration % 60 == 0 && e->flags & ARL_ENTRY_FLAG_FOUND)
         netdata_log_info("ARL '%s': entry '%s' is already found. Did you forget to call arl_begin()?", base->name, s);
 #endif
 
@@ -268,10 +268,10 @@ int arl_find_or_create_and_relink(ARL_BASE *base, const char *s, const char *val
 
     // prepare the next iteration
     base->next_keyword = e->next;
-    if(unlikely(!base->next_keyword))
+    if(!base->next_keyword)
         base->next_keyword = base->head;
 
-    if(unlikely(base->found == base->wanted)) {
+    if(base->found == base->wanted) {
         // fprintf(stderr, "FOUND ALL WANTED 1: found = %zu, wanted = %zu, expected %zu\n", base->found, base->wanted, base->expected);
         return 1;
     }

--- a/libnetdata/adaptive_resortable_list/adaptive_resortable_list.h
+++ b/libnetdata/adaptive_resortable_list/adaptive_resortable_list.h
@@ -93,12 +93,12 @@ static inline int arl_check(ARL_BASE *base, const char *keyword, const char *val
     ARL_ENTRY *e = base->next_keyword;
 
 #ifdef NETDATA_INTERNAL_CHECKS
-    if(unlikely((base->fast + base->slow) % (base->expected + base->allocated) == 0 && (base->fast + base->slow) > (base->expected + base->allocated) * base->iteration))
+    if((base->fast + base->slow) % (base->expected + base->allocated) == 0 && (base->fast + base->slow) > (base->expected + base->allocated) * base->iteration)
         netdata_log_info("ARL '%s': Did you forget to call arl_begin()?", base->name);
 #endif
 
     // it should be the first entry (pointed by base->next_keyword)
-    if(likely(!strcmp(keyword, e->name))) {
+    if(!strcmp(keyword, e->name)) {
         // it is
 
 #ifdef NETDATA_INTERNAL_CHECKS
@@ -108,18 +108,18 @@ static inline int arl_check(ARL_BASE *base, const char *keyword, const char *val
         e->flags |= ARL_ENTRY_FLAG_FOUND;
 
         // execute the processor
-        if(unlikely(e->dst)) {
+        if(e->dst) {
             e->processor(e->name, e->hash, value, e->dst);
             base->found++;
         }
 
         // be prepared for the next iteration
         base->next_keyword = e->next;
-        if(unlikely(!base->next_keyword))
+        if(!base->next_keyword)
             base->next_keyword = base->head;
 
         // stop if we collected all the values for this iteration
-        if(unlikely(base->found == base->wanted)) {
+        if(base->found == base->wanted) {
             // fprintf(stderr, "FOUND ALL WANTED 2: found = %zu, wanted = %zu, expected %zu\n", base->found, base->wanted, base->expected);
             return 1;
         }

--- a/libnetdata/buffer/buffer.c
+++ b/libnetdata/buffer/buffer.c
@@ -41,18 +41,18 @@ void buffer_char_replace(BUFFER *wb, char from, char to) {
 }
 
 void buffer_print_sn_flags(BUFFER *wb, SN_FLAGS flags, bool send_anomaly_bit) {
-    if(unlikely(flags == SN_EMPTY_SLOT)) {
+    if(flags == SN_EMPTY_SLOT) {
         buffer_fast_strcat(wb, "E", 1);
         return;
     }
 
     size_t printed = 0;
-    if(likely(send_anomaly_bit && (flags & SN_FLAG_NOT_ANOMALOUS))) {
+    if(send_anomaly_bit && (flags & SN_FLAG_NOT_ANOMALOUS)) {
         buffer_fast_strcat(wb, "A", 1);
         printed++;
     }
 
-    if(unlikely(flags & SN_FLAG_RESET)) {
+    if(flags & SN_FLAG_RESET) {
         buffer_fast_strcat(wb, "R", 1);
         printed++;
     }
@@ -84,7 +84,7 @@ void buffer_strcat_htmlescape(BUFFER *wb, const char *txt)
 
 void buffer_snprintf(BUFFER *wb, size_t len, const char *fmt, ...)
 {
-    if(unlikely(!fmt || !*fmt)) return;
+    if(!fmt || !*fmt) return;
 
     buffer_need_bytes(wb, len + 1);
 
@@ -100,7 +100,7 @@ void buffer_snprintf(BUFFER *wb, size_t len, const char *fmt, ...)
 
 void buffer_vsprintf(BUFFER *wb, const char *fmt, va_list args)
 {
-    if(unlikely(!fmt || !*fmt)) return;
+    if(!fmt || !*fmt) return;
 
     size_t wrote = 0, need = 2, space_remaining = 0;
 
@@ -123,7 +123,7 @@ void buffer_vsprintf(BUFFER *wb, const char *fmt, va_list args)
 
 void buffer_sprintf(BUFFER *wb, const char *fmt, ...)
 {
-    if(unlikely(!fmt || !*fmt)) return;
+    if(!fmt || !*fmt) return;
 
     va_list args;
     size_t wrote = 0, need = 2, space_remaining = 0;
@@ -264,7 +264,7 @@ BUFFER *buffer_create(size_t size, size_t *statistics)
 }
 
 void buffer_free(BUFFER *b) {
-    if(unlikely(!b)) return;
+    if(!b) return;
 
     buffer_overflow_check(b);
 

--- a/libnetdata/buffer/buffer.h
+++ b/libnetdata/buffer/buffer.h
@@ -143,7 +143,7 @@ h2o_iovec_t buffer_to_h2o_iovec(BUFFER *wb);
 #endif
 
 static inline void buffer_need_bytes(BUFFER *buffer, size_t needed_free_size) {
-    if(unlikely(buffer->len + needed_free_size >= buffer->size))
+    if(buffer->len + needed_free_size >= buffer->size)
         buffer_increase(buffer, needed_free_size + 1);
 }
 
@@ -176,7 +176,7 @@ static inline void buffer_fast_charcat(BUFFER *wb, const char c) {
 }
 
 static inline void buffer_fast_rawcat(BUFFER *wb, const char *txt, size_t len) {
-    if(unlikely(!txt || !*txt || !len)) return;
+    if(!txt || !*txt || !len) return;
 
     buffer_need_bytes(wb, len + 1);
 
@@ -195,7 +195,7 @@ static inline void buffer_fast_rawcat(BUFFER *wb, const char *txt, size_t len) {
 }
 
 static inline void buffer_fast_strcat(BUFFER *wb, const char *txt, size_t len) {
-    if(unlikely(!txt || !*txt || !len)) return;
+    if(!txt || !*txt || !len) return;
 
     buffer_need_bytes(wb, len + 1);
 
@@ -222,7 +222,7 @@ static inline void buffer_fast_strcat(BUFFER *wb, const char *txt, size_t len) {
 }
 
 static inline void buffer_strcat(BUFFER *wb, const char *txt) {
-    if(unlikely(!txt || !*txt)) return;
+    if(!txt || !*txt) return;
 
     const char *t = txt;
     while(*t) {
@@ -244,7 +244,7 @@ static inline void buffer_strcat(BUFFER *wb, const char *txt) {
 }
 
 static inline void buffer_strncat(BUFFER *wb, const char *txt, size_t len) {
-    if(unlikely(!txt || !*txt)) return;
+    if(!txt || !*txt) return;
 
     const char *t = txt;
     buffer_need_bytes(wb, len + 1);
@@ -263,7 +263,7 @@ static inline void buffer_strncat(BUFFER *wb, const char *txt, size_t len) {
 }
 
 static inline void buffer_json_strcat(BUFFER *wb, const char *txt) {
-    if(unlikely(!txt || !*txt)) return;
+    if(!txt || !*txt) return;
 
     const unsigned char *t = (const unsigned char *)txt;
     while(*t) {
@@ -274,7 +274,7 @@ static inline void buffer_json_strcat(BUFFER *wb, const char *txt) {
 
         while(*t && d < e) {
 #ifdef BUFFER_JSON_ESCAPE_UTF
-            if(unlikely(IS_UTF8_STARTBYTE(*t) && IS_UTF8_BYTE(t[1]))) {
+            if(IS_UTF8_STARTBYTE(*t) && IS_UTF8_BYTE(t[1])) {
                 // UTF-8 multi-byte encoded character
 
                 // find how big this character is (2-4 bytes)
@@ -300,7 +300,7 @@ static inline void buffer_json_strcat(BUFFER *wb, const char *txt) {
             }
             else
 #endif
-            if(unlikely(*t < ' ')) {
+            if(*t < ' ') {
                 uint32_t v = *t++;
                 *d++ = '\\';
                 *d++ = 'u';
@@ -310,7 +310,7 @@ static inline void buffer_json_strcat(BUFFER *wb, const char *txt) {
                 *d++ = hex_digits[v & 0xf];
             }
             else {
-                if (unlikely(*t == '\\' || *t == '\"'))
+                if (*t == '\\' || *t == '\"')
                     *d++ = '\\';
 
                 *d++ = *t++;
@@ -327,7 +327,7 @@ static inline void buffer_json_strcat(BUFFER *wb, const char *txt) {
 }
 
 static inline void buffer_json_quoted_strcat(BUFFER *wb, const char *txt) {
-    if(unlikely(!txt || !*txt)) return;
+    if(!txt || !*txt) return;
 
     if(*txt == '"')
         txt++;
@@ -340,12 +340,12 @@ static inline void buffer_json_quoted_strcat(BUFFER *wb, const char *txt) {
         const char *e = &wb->buffer[wb->size - 1]; // remove 1 to make room for the escape character
 
         while(*t && d < e) {
-            if(unlikely(*t == '"' && !t[1])) {
+            if(*t == '"' && !t[1]) {
                 t++;
                 continue;
             }
 
-            if(unlikely(*t == '\\' || *t == '"'))
+            if(*t == '\\' || *t == '"')
                 *d++ = '\\';
 
             *d++ = *t++;
@@ -425,7 +425,7 @@ static inline void char_array_reverse(char *from, char *to) {
 static inline int print_netdata_double(char *dst, NETDATA_DOUBLE value) {
     char *s = dst;
 
-    if(unlikely(value < 0)) {
+    if(value < 0) {
         *s++ = '-';
         value = fabsndd(value);
     }
@@ -433,7 +433,7 @@ static inline int print_netdata_double(char *dst, NETDATA_DOUBLE value) {
     uint64_t fractional_precision = 10000000ULL; // fractional part 7 digits
     int fractional_wanted_digits = 7;
     int exponent = 0;
-    if(unlikely(value >= (NETDATA_DOUBLE)(UINT64_MAX / 10))) {
+    if(value >= (NETDATA_DOUBLE)(UINT64_MAX / 10)) {
         // the number is too big to print using 64bit numbers
         // so, let's convert it to exponential notation
         exponent = (int)(floorndd(log10ndd(value)));
@@ -452,7 +452,7 @@ static inline int print_netdata_double(char *dst, NETDATA_DOUBLE value) {
     // get the integral and the fractional parts as 64-bit integers
     uint64_t integral = (uint64_t)integral_d;
     uint64_t fractional = (uint64_t)llrintndd(fractional_d * (NETDATA_DOUBLE)fractional_precision);
-    if(unlikely(fractional >= fractional_precision)) {
+    if(fractional >= fractional_precision) {
         integral++;
         fractional -= fractional_precision;
     }
@@ -461,7 +461,7 @@ static inline int print_netdata_double(char *dst, NETDATA_DOUBLE value) {
     d = print_uint64_reversed(d, integral);
     char_array_reverse(s, d - 1);      // copy reversed the integral string
 
-    if(likely(fractional != 0)) {
+    if(fractional != 0) {
         *d++ = '.'; // add the dot
 
         // convert the fractional part to string (reversed)
@@ -474,7 +474,7 @@ static inline int print_netdata_double(char *dst, NETDATA_DOUBLE value) {
         while(*(d - 1) == '0') d--;
     }
 
-    if(unlikely(exponent != 0)) {
+    if(exponent != 0) {
         *d++ = 'e';
         *d++ = '+';
         d = print_uint32_reversed(s = d, exponent);

--- a/libnetdata/circular_buffer/circular_buffer.c
+++ b/libnetdata/circular_buffer/circular_buffer.c
@@ -16,7 +16,7 @@ struct circular_buffer *cbuffer_new(size_t initial, size_t max, size_t *statisti
 }
 
 void cbuffer_free(struct circular_buffer *buf) {
-    if (unlikely(!buf))
+    if (!buf)
         return;
 
     if(buf->statistics)

--- a/libnetdata/clocks/clocks.c
+++ b/libnetdata/clocks/clocks.c
@@ -13,7 +13,7 @@ usec_t clock_realtime_resolution = 1000;
 #ifndef HAVE_CLOCK_GETTIME
 inline int clock_gettime(clockid_t clk_id __maybe_unused, struct timespec *ts) {
     struct timeval tv;
-    if(unlikely(gettimeofday(&tv, NULL) == -1)) {
+    if(gettimeofday(&tv, NULL) == -1) {
         netdata_log_error("gettimeofday() failed.");
         return -1;
     }
@@ -78,7 +78,7 @@ void clocks_init(void) {
 
 inline time_t now_sec(clockid_t clk_id) {
     struct timespec ts;
-    if(unlikely(clock_gettime(clk_id, &ts) == -1)) {
+    if(clock_gettime(clk_id, &ts) == -1) {
         netdata_log_error("clock_gettime(%d, &timespec) failed.", clk_id);
         return 0;
     }
@@ -87,7 +87,7 @@ inline time_t now_sec(clockid_t clk_id) {
 
 inline usec_t now_usec(clockid_t clk_id) {
     struct timespec ts;
-    if(unlikely(clock_gettime(clk_id, &ts) == -1)) {
+    if(clock_gettime(clk_id, &ts) == -1) {
         netdata_log_error("clock_gettime(%d, &timespec) failed.", clk_id);
         return 0;
     }
@@ -97,7 +97,7 @@ inline usec_t now_usec(clockid_t clk_id) {
 inline int now_timeval(clockid_t clk_id, struct timeval *tv) {
     struct timespec ts;
 
-    if(unlikely(clock_gettime(clk_id, &ts) == -1)) {
+    if(clock_gettime(clk_id, &ts) == -1) {
         netdata_log_error("clock_gettime(%d, &timespec) failed.", clk_id);
         tv->tv_sec = 0;
         tv->tv_usec = 0;
@@ -169,7 +169,7 @@ inline susec_t dt_usec_signed(struct timeval *now, struct timeval *old) {
     usec_t ts1 = timeval_usec(now);
     usec_t ts2 = timeval_usec(old);
 
-    if(likely(ts1 >= ts2)) return (susec_t)(ts1 - ts2);
+    if(ts1 >= ts2) return (susec_t)(ts1 - ts2);
     return -((susec_t)(ts2 - ts1));
 }
 
@@ -294,7 +294,7 @@ inline void heartbeat_init(heartbeat_t *hb) {
 // it returns the dt using the realtime clock
 
 usec_t heartbeat_next(heartbeat_t *hb, usec_t tick) {
-    if(unlikely(hb->randomness > tick / 2)) {
+    if(hb->randomness > tick / 2) {
         // TODO: The heartbeat tick should be specified at the heartbeat_init() function
         usec_t tmp = (now_realtime_usec() * clock_realtime_resolution) % (tick / 2);
 
@@ -323,18 +323,18 @@ usec_t heartbeat_next(heartbeat_t *hb, usec_t tick) {
         heartbeat_alignment_values[hb->statistics_id].sequence++;
     }
 
-    if(unlikely(now < next)) {
+    if(now < next) {
         errno = 0;
         error_limit_static_global_var(erl, 10, 0);
         error_limit(&erl, "heartbeat clock: woke up %llu microseconds earlier than expected (can be due to the CLOCK_REALTIME set to the past).", next - now);
     }
-    else if(unlikely(now - next >  tick / 2)) {
+    else if(now - next >  tick / 2) {
         errno = 0;
         error_limit_static_global_var(erl, 10, 0);
         error_limit(&erl, "heartbeat clock: woke up %llu microseconds later than expected (can be due to system load or the CLOCK_REALTIME set to the future).", now - next);
     }
 
-    if(unlikely(!hb->realtime)) {
+    if(!hb->realtime) {
         // the first time return zero
         dt = 0;
     }
@@ -360,7 +360,7 @@ void sleep_usec_with_now(usec_t usec, usec_t started_ut) {
     usec_t end_ut = started_ut + usec;
 
     while (nanosleep(&req, &rem) != 0) {
-        if (likely(errno == EINTR && (rem.tv_sec || rem.tv_nsec))) {
+        if (errno == EINTR && (rem.tv_sec || rem.tv_nsec)) {
             req = rem;
             rem = (struct timespec){ 0, 0 };
 
@@ -398,19 +398,19 @@ static inline collected_number uptime_from_boottime(void) {
 
 static procfile *read_proc_uptime_ff = NULL;
 static inline collected_number read_proc_uptime(char *filename) {
-    if(unlikely(!read_proc_uptime_ff)) {
+    if(!read_proc_uptime_ff) {
         read_proc_uptime_ff = procfile_open(filename, " \t", PROCFILE_FLAG_DEFAULT);
-        if(unlikely(!read_proc_uptime_ff)) return 0;
+        if(!read_proc_uptime_ff) return 0;
     }
 
     read_proc_uptime_ff = procfile_readall(read_proc_uptime_ff);
-    if(unlikely(!read_proc_uptime_ff)) return 0;
+    if(!read_proc_uptime_ff) return 0;
 
-    if(unlikely(procfile_lines(read_proc_uptime_ff) < 1)) {
+    if(procfile_lines(read_proc_uptime_ff) < 1) {
         netdata_log_error("/proc/uptime has no lines.");
         return 0;
     }
-    if(unlikely(procfile_linewords(read_proc_uptime_ff, 0) < 1)) {
+    if(procfile_linewords(read_proc_uptime_ff, 0) < 1) {
         netdata_log_error("/proc/uptime has less than 1 word in it.");
         return 0;
     }
@@ -421,7 +421,7 @@ static inline collected_number read_proc_uptime(char *filename) {
 inline collected_number uptime_msec(char *filename){
     static int use_boottime = -1;
 
-    if(unlikely(use_boottime == -1)) {
+    if(use_boottime == -1) {
         collected_number uptime_boottime = uptime_from_boottime();
         collected_number uptime_proc     = read_proc_uptime(filename);
 

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -479,13 +479,13 @@ void ebpf_update_kernel_memory(ebpf_plugin_stats_t *report, ebpf_local_maps_t *m
     char filename[FILENAME_MAX+1];
     snprintfz(filename, FILENAME_MAX, "/proc/self/fdinfo/%d", map->map_fd);
     procfile *ff = procfile_open(filename, " \t", PROCFILE_FLAG_DEFAULT);
-    if(unlikely(!ff)) {
+    if(!ff) {
         netdata_log_error("Cannot open %s", filename);
         return;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff))
+    if(!ff)
         return;
 
     unsigned long j, lines = procfile_lines(ff);
@@ -896,13 +896,13 @@ char *ebpf_find_symbol(char *search)
     char *ret = NULL;
     snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, NETDATA_KALLSYMS);
     procfile *ff = procfile_open(filename, " \t", PROCFILE_FLAG_DEFAULT);
-    if(unlikely(!ff)) {
+    if(!ff) {
         netdata_log_error("Cannot open %s%s", netdata_configured_host_prefix, NETDATA_KALLSYMS);
         return ret;
     }
 
     ff = procfile_readall(ff);
-    if(unlikely(!ff))
+    if(!ff)
         return ret;
 
     unsigned long i, lines = procfile_lines(ff);

--- a/libnetdata/eval/eval.c
+++ b/libnetdata/eval/eval.c
@@ -77,7 +77,7 @@ static inline NETDATA_DOUBLE eval_variable(EVAL_EXPRESSION *exp, EVAL_VARIABLE *
 
     NETDATA_DOUBLE n;
 
-    if(unlikely(this_string == NULL)) {
+    if(this_string == NULL) {
         this_string = string_strdupz("this");
         now_string = string_strdupz("now");
         after_string = string_strdupz("after");
@@ -91,7 +91,7 @@ static inline NETDATA_DOUBLE eval_variable(EVAL_EXPRESSION *exp, EVAL_VARIABLE *
         critical_string = string_strdupz("CRITICAL");
     }
 
-    if(unlikely(v->name == this_string)) {
+    if(v->name == this_string) {
         n = (exp->myself)?*exp->myself:NAN;
         buffer_strcat(exp->error_msg, "[ $this = ");
         print_parsed_as_constant(exp->error_msg, n);
@@ -99,7 +99,7 @@ static inline NETDATA_DOUBLE eval_variable(EVAL_EXPRESSION *exp, EVAL_VARIABLE *
         return n;
     }
 
-    if(unlikely(v->name == after_string)) {
+    if(v->name == after_string) {
         n = (exp->after && *exp->after)?*exp->after:NAN;
         buffer_strcat(exp->error_msg, "[ $after = ");
         print_parsed_as_constant(exp->error_msg, n);
@@ -107,7 +107,7 @@ static inline NETDATA_DOUBLE eval_variable(EVAL_EXPRESSION *exp, EVAL_VARIABLE *
         return n;
     }
 
-    if(unlikely(v->name == before_string)) {
+    if(v->name == before_string) {
         n = (exp->before && *exp->before)?*exp->before:NAN;
         buffer_strcat(exp->error_msg, "[ $before = ");
         print_parsed_as_constant(exp->error_msg, n);
@@ -115,7 +115,7 @@ static inline NETDATA_DOUBLE eval_variable(EVAL_EXPRESSION *exp, EVAL_VARIABLE *
         return n;
     }
 
-    if(unlikely(v->name == now_string)) {
+    if(v->name == now_string) {
         n = (NETDATA_DOUBLE)now_realtime_sec();
         buffer_strcat(exp->error_msg, "[ $now = ");
         print_parsed_as_constant(exp->error_msg, n);
@@ -123,7 +123,7 @@ static inline NETDATA_DOUBLE eval_variable(EVAL_EXPRESSION *exp, EVAL_VARIABLE *
         return n;
     }
 
-    if(unlikely(v->name == status_string)) {
+    if(v->name == status_string) {
         n = (exp->status)?*exp->status:RRDCALC_STATUS_UNINITIALIZED;
         buffer_strcat(exp->error_msg, "[ $status = ");
         print_parsed_as_constant(exp->error_msg, n);
@@ -131,7 +131,7 @@ static inline NETDATA_DOUBLE eval_variable(EVAL_EXPRESSION *exp, EVAL_VARIABLE *
         return n;
     }
 
-    if(unlikely(v->name == removed_string)) {
+    if(v->name == removed_string) {
         n = RRDCALC_STATUS_REMOVED;
         buffer_strcat(exp->error_msg, "[ $REMOVED = ");
         print_parsed_as_constant(exp->error_msg, n);
@@ -139,7 +139,7 @@ static inline NETDATA_DOUBLE eval_variable(EVAL_EXPRESSION *exp, EVAL_VARIABLE *
         return n;
     }
 
-    if(unlikely(v->name == uninitialized_string)) {
+    if(v->name == uninitialized_string) {
         n = RRDCALC_STATUS_UNINITIALIZED;
         buffer_strcat(exp->error_msg, "[ $UNINITIALIZED = ");
         print_parsed_as_constant(exp->error_msg, n);
@@ -147,7 +147,7 @@ static inline NETDATA_DOUBLE eval_variable(EVAL_EXPRESSION *exp, EVAL_VARIABLE *
         return n;
     }
 
-    if(unlikely(v->name == undefined_string)) {
+    if(v->name == undefined_string) {
         n = RRDCALC_STATUS_UNDEFINED;
         buffer_strcat(exp->error_msg, "[ $UNDEFINED = ");
         print_parsed_as_constant(exp->error_msg, n);
@@ -155,7 +155,7 @@ static inline NETDATA_DOUBLE eval_variable(EVAL_EXPRESSION *exp, EVAL_VARIABLE *
         return n;
     }
 
-    if(unlikely(v->name == clear_string)) {
+    if(v->name == clear_string) {
         n = RRDCALC_STATUS_CLEAR;
         buffer_strcat(exp->error_msg, "[ $CLEAR = ");
         print_parsed_as_constant(exp->error_msg, n);
@@ -163,7 +163,7 @@ static inline NETDATA_DOUBLE eval_variable(EVAL_EXPRESSION *exp, EVAL_VARIABLE *
         return n;
     }
 
-    if(unlikely(v->name == warning_string)) {
+    if(v->name == warning_string) {
         n = RRDCALC_STATUS_WARNING;
         buffer_strcat(exp->error_msg, "[ $WARNING = ");
         print_parsed_as_constant(exp->error_msg, n);
@@ -171,7 +171,7 @@ static inline NETDATA_DOUBLE eval_variable(EVAL_EXPRESSION *exp, EVAL_VARIABLE *
         return n;
     }
 
-    if(unlikely(v->name == critical_string)) {
+    if(v->name == critical_string) {
         n = RRDCALC_STATUS_CRITICAL;
         buffer_strcat(exp->error_msg, "[ $CRITICAL = ");
         print_parsed_as_constant(exp->error_msg, n);
@@ -354,7 +354,7 @@ static struct operator {
 #define eval_precedence(operator) (operators[(unsigned char)(operator)].precedence)
 
 static inline NETDATA_DOUBLE eval_node(EVAL_EXPRESSION *exp, EVAL_NODE *op, int *error) {
-    if(unlikely(op->count != operators[op->operator].parameters)) {
+    if(op->count != operators[op->operator].parameters) {
         *error = EVAL_ERROR_INVALID_NUMBER_OF_OPERANDS;
         return 0;
     }
@@ -373,12 +373,12 @@ static inline void print_parsed_as_variable(BUFFER *out, EVAL_VARIABLE *v, int *
 }
 
 static inline void print_parsed_as_constant(BUFFER *out, NETDATA_DOUBLE n) {
-    if(unlikely(isnan(n))) {
+    if(isnan(n)) {
         buffer_strcat(out, "nan");
         return;
     }
 
-    if(unlikely(isinf(n))) {
+    if(isinf(n)) {
         buffer_strcat(out, "inf");
         return;
     }
@@ -419,7 +419,7 @@ static inline void print_parsed_as_value(BUFFER *out, EVAL_VALUE *v, int *error)
 }
 
 static inline void print_parsed_as_node(BUFFER *out, EVAL_NODE *op, int *error) {
-    if(unlikely(op->count != operators[op->operator].parameters)) {
+    if(op->count != operators[op->operator].parameters) {
         *error = EVAL_ERROR_INVALID_NUMBER_OF_OPERANDS;
         return;
     }
@@ -752,7 +752,7 @@ static inline int parse_variable(const char **string, char *buffer, size_t len) 
 static inline int parse_constant(const char **string, NETDATA_DOUBLE *number) {
     char *end = NULL;
     NETDATA_DOUBLE n = str2ndd(*string, &end);
-    if(unlikely(!end || *string == end)) {
+    if(!end || *string == end) {
         *number = 0;
         return 0;
     }
@@ -1076,15 +1076,15 @@ int expression_evaluate(EVAL_EXPRESSION *expression) {
     buffer_reset(expression->error_msg);
     expression->result = eval_node(expression, (EVAL_NODE *)expression->nodes, &expression->error);
 
-    if(unlikely(isnan(expression->result))) {
+    if(isnan(expression->result)) {
         if(expression->error == EVAL_ERROR_OK)
             expression->error = EVAL_ERROR_VALUE_IS_NAN;
     }
-    else if(unlikely(isinf(expression->result))) {
+    else if(isinf(expression->result)) {
         if(expression->error == EVAL_ERROR_OK)
             expression->error = EVAL_ERROR_VALUE_IS_INFINITE;
     }
-    else if(unlikely(expression->error == EVAL_ERROR_UNKNOWN_VARIABLE)) {
+    else if(expression->error == EVAL_ERROR_UNKNOWN_VARIABLE) {
         // although there is an unknown variable
         // the expression was evaluated successfully
         expression->error = EVAL_ERROR_OK;

--- a/libnetdata/health/health.c
+++ b/libnetdata/health/health.c
@@ -52,7 +52,7 @@ SILENCER *health_silencers_addparam(SILENCER *silencer, char *key, char *value) 
             hash_host = 0,
             hash_families = 0;
 
-    if (unlikely(!hash_alarm)) {
+    if (!hash_alarm) {
         hash_alarm = simple_uhash(HEALTH_ALARM_KEY);
         hash_template = simple_uhash(HEALTH_TEMPLATE_KEY);
         hash_chart = simple_uhash(HEALTH_CHART_KEY);
@@ -62,7 +62,7 @@ SILENCER *health_silencers_addparam(SILENCER *silencer, char *key, char *value) 
     }
 
     uint32_t hash = simple_uhash(key);
-    if (unlikely(silencer == NULL)) {
+    if (silencer == NULL) {
         if (
                 (hash == hash_alarm && !strcasecmp(key, HEALTH_ALARM_KEY)) ||
                 (hash == hash_template && !strcasecmp(key, HEALTH_TEMPLATE_KEY)) ||

--- a/libnetdata/inlined.h
+++ b/libnetdata/inlined.h
@@ -74,7 +74,7 @@ static inline uint32_t fnv1a_uhash32(const char *name) {
     unsigned char *s = (unsigned char *) name;
     uint32_t hash = 0x811c9dc5, c;
     while ((c = *s++)) {
-        if (unlikely(c >= 'A' && c <= 'Z')) c += 'a' - 'A';
+        if (c >= 'A' && c <= 'Z') c += 'a' - 'A';
         hash ^= c;
         hash *= 0x01000193; // 16777619
     }
@@ -127,12 +127,12 @@ static inline unsigned int str2u(const char *s) {
 }
 
 static inline int str2i(const char *s) {
-    if(unlikely(*s == '-')) {
+    if(*s == '-') {
         s++;
         return -(int) str2u(s);
     }
     else {
-        if(unlikely(*s == '+')) s++;
+        if(*s == '+') s++;
         return (int) str2u(s);
     }
 }
@@ -147,12 +147,12 @@ static inline unsigned long str2ul(const char *s) {
 }
 
 static inline long str2l(const char *s) {
-    if(unlikely(*s == '-')) {
+    if(*s == '-') {
         s++;
         return -(long) str2ul(s);
     }
     else {
-        if(unlikely(*s == '+')) s++;
+        if(*s == '+') s++;
         return (long) str2ul(s);
     }
 }
@@ -163,7 +163,7 @@ static inline uint32_t str2uint32_t(const char *s, char **endptr) {
     while(*s >= '0' && *s <= '9')
         n = n * 10 + (*s++ - '0');
 
-    if(unlikely(endptr))
+    if(endptr)
         *endptr = (char *)s;
 
     return n;
@@ -183,7 +183,7 @@ static inline uint64_t str2uint64_t(const char *s, char **endptr) {
     while(*s >= '0' && *s <= '9')
         n = n * 10 + (*s++ - '0');
 
-    if(unlikely(endptr))
+    if(endptr)
         *endptr = (char *)s;
 
     return n;
@@ -194,12 +194,12 @@ static inline unsigned long long int str2ull(const char *s, char **endptr) {
 }
 
 static inline long long str2ll(const char *s, char **endptr) {
-    if(unlikely(*s == '-')) {
+    if(*s == '-') {
         s++;
         return -(long long) str2uint64_t(s, endptr);
     }
     else {
-        if(unlikely(*s == '+')) s++;
+        if(*s == '+') s++;
         return (long long) str2uint64_t(s, endptr);
     }
 }
@@ -305,13 +305,13 @@ static inline NETDATA_DOUBLE str2ndd(const char *src, char **endptr) {
     result = str2ndd_parse_double_decimal_digits_internal(s, &integral_digits);
     s += integral_digits;
 
-    if(unlikely(*s == '.')) {
+    if(*s == '.') {
         s++;
         fractional = str2ndd_parse_double_decimal_digits_internal(s, &fractional_digits);
         s += fractional_digits;
     }
 
-    if (unlikely(*s == 'e' || *s == 'E')) {
+    if (*s == 'e' || *s == 'E') {
         const char *e_ptr = s;
         s++;
 
@@ -324,7 +324,7 @@ static inline NETDATA_DOUBLE str2ndd(const char *src, char **endptr) {
             s++;
 
         exponent = str2ndd_parse_double_decimal_digits_internal(s, &exponent_digits);
-        if(unlikely(!exponent_digits)) {
+        if(!exponent_digits) {
             exponent = 0;
             s = e_ptr;
         }
@@ -334,13 +334,13 @@ static inline NETDATA_DOUBLE str2ndd(const char *src, char **endptr) {
         }
     }
 
-    if(unlikely(endptr))
+    if(endptr)
         *endptr = (char *)s;
 
-    if (unlikely(exponent_digits))
+    if (exponent_digits)
         result *= powndd(10.0, exponent);
 
-    if (unlikely(fractional_digits))
+    if (fractional_digits)
         result += fractional / powndd(10.0, fractional_digits) * (exponent_digits ? powndd(10.0, exponent) : 1.0);
 
     return sign * result;
@@ -385,10 +385,10 @@ static inline NETDATA_DOUBLE str2ndd_encoded(const char *src, char **endptr) {
         src++;
     }
 
-    if(unlikely(*src == IEEE754_UINT64_B64_PREFIX[0]))
+    if(*src == IEEE754_UINT64_B64_PREFIX[0])
         return (NETDATA_DOUBLE) str2uint64_base64(src + sizeof(IEEE754_UINT64_B64_PREFIX) - 1, endptr) * sign;
 
-    if(unlikely(*src == HEX_PREFIX[0] && src[1] == HEX_PREFIX[1]))
+    if(*src == HEX_PREFIX[0] && src[1] == HEX_PREFIX[1])
         return (NETDATA_DOUBLE) str2uint64_hex(src + sizeof(HEX_PREFIX) - 1, endptr) * sign;
 
     return str2ndd(src, endptr) * sign;
@@ -462,16 +462,16 @@ static inline bool sanitize_command_argument_string(char *dst, const char *src, 
 }
 
 static inline int read_file(const char *filename, char *buffer, size_t size) {
-    if(unlikely(!size)) return 3;
+    if(!size) return 3;
 
     int fd = open(filename, O_RDONLY, 0666);
-    if(unlikely(fd == -1)) {
+    if(fd == -1) {
         buffer[0] = '\0';
         return 1;
     }
 
     ssize_t r = read(fd, buffer, size);
-    if(unlikely(r == -1)) {
+    if(r == -1) {
         buffer[0] = '\0';
         close(fd);
         return 2;
@@ -486,7 +486,7 @@ static inline int read_single_number_file(const char *filename, unsigned long lo
     char buffer[30 + 1];
 
     int ret = read_file(filename, buffer, 30);
-    if(unlikely(ret)) {
+    if(ret) {
         *result = 0;
         return ret;
     }
@@ -500,7 +500,7 @@ static inline int read_single_signed_number_file(const char *filename, long long
     char buffer[30 + 1];
 
     int ret = read_file(filename, buffer, 30);
-    if(unlikely(ret)) {
+    if(ret) {
         *result = 0;
         return ret;
     }

--- a/libnetdata/json/json.c
+++ b/libnetdata/json/json.c
@@ -406,13 +406,13 @@ size_t json_walk_object(char *js, jsmntok_t *t, size_t nest, size_t start, JSON_
             default:
                 if(key) {
                     int len = t[start].end - t[start].start;
-                    if (unlikely(len>JSON_NAME_LEN)) len=JSON_NAME_LEN;
+                    if (len>JSON_NAME_LEN) len=JSON_NAME_LEN;
                     strncpy(ne.name, &js[t[start].start], len);
                     ne.name[len] = '\0';
                     len=strlen(e->fullname) + strlen(e->fullname[0]?".":"") + strlen(ne.name);
                     char *c = mallocz((len+1)*sizeof(char));
                     sprintf(c,"%s%s%s", e->fullname, e->fullname[0]?".":"", ne.name);
-                    if (unlikely(len>JSON_FULLNAME_LEN)) len=JSON_FULLNAME_LEN;
+                    if (len>JSON_FULLNAME_LEN) len=JSON_FULLNAME_LEN;
                     strncpy(ne.fullname, c, len);
                     freez(c);
                     start++;

--- a/libnetdata/july/july.h
+++ b/libnetdata/july/july.h
@@ -16,7 +16,7 @@ PPvoid_t JulyLPrev(Pcvoid_t PArray, Word_t *Index, PJError_t PJError);
 Word_t JulyLFreeArray(PPvoid_t PPArray, PJError_t PJError);
 
 static inline PPvoid_t JulyLFirstThenNext(Pcvoid_t PArray, Word_t * PIndex, bool *first) {
-    if(unlikely(*first)) {
+    if(*first) {
         *first = false;
         return JulyLFirst(PArray, PIndex, PJE0);
     }
@@ -25,7 +25,7 @@ static inline PPvoid_t JulyLFirstThenNext(Pcvoid_t PArray, Word_t * PIndex, bool
 }
 
 static inline PPvoid_t JulyLLastThenPrev(Pcvoid_t PArray, Word_t * PIndex, bool *first) {
-    if(unlikely(*first)) {
+    if(*first) {
         *first = false;
         return JulyLLast(PArray, PIndex, PJE0);
     }

--- a/libnetdata/libnetdata.c
+++ b/libnetdata/libnetdata.c
@@ -307,7 +307,7 @@ void *mallocz_int(size_t size, const char *file, const char *function, size_t li
     size_t_atomic_bytes(add, p->bytes, size);
 
     struct malloc_header *t = (struct malloc_header *)libc_malloc(malloc_header_size + size);
-    if (unlikely(!t)) fatal("mallocz() cannot allocate %zu bytes of memory (%zu with header).", size, malloc_header_size + size);
+    if (!t) fatal("mallocz() cannot allocate %zu bytes of memory (%zu with header).", size, malloc_header_size + size);
     t->signature.magic = 0x0BADCAFE;
     t->signature.trace = p;
     t->signature.size = size;
@@ -329,7 +329,7 @@ void *callocz_int(size_t nmemb, size_t size, const char *file, const char *funct
     size_t_atomic_bytes(add, p->bytes, size);
 
     struct malloc_header *t = (struct malloc_header *)libc_calloc(1, malloc_header_size + size);
-    if (unlikely(!t)) fatal("mallocz() cannot allocate %zu bytes of memory (%zu with header).", size, malloc_header_size + size);
+    if (!t) fatal("mallocz() cannot allocate %zu bytes of memory (%zu with header).", size, malloc_header_size + size);
     t->signature.magic = 0x0BADCAFE;
     t->signature.trace = p;
     t->signature.size = size;
@@ -351,7 +351,7 @@ char *strdupz_int(const char *s, const char *file, const char *function, size_t 
     size_t_atomic_bytes(add, p->bytes, size);
 
     struct malloc_header *t = (struct malloc_header *)libc_malloc(malloc_header_size + size);
-    if (unlikely(!t)) fatal("strdupz() cannot allocate %zu bytes of memory (%zu with header).", size, malloc_header_size + size);
+    if (!t) fatal("strdupz() cannot allocate %zu bytes of memory (%zu with header).", size, malloc_header_size + size);
     t->signature.magic = 0x0BADCAFE;
     t->signature.trace = p;
     t->signature.size = size;
@@ -395,7 +395,7 @@ void *reallocz_int(void *ptr, size_t size, const char *file, const char *functio
     size_t_atomic_bytes(add, p->bytes, size);
 
     t = (struct malloc_header *)libc_realloc(t, malloc_header_size + size);
-    if (unlikely(!t)) fatal("reallocz() cannot allocate %zu bytes of memory (%zu with header).", size, malloc_header_size + size);
+    if (!t) fatal("reallocz() cannot allocate %zu bytes of memory (%zu with header).", size, malloc_header_size + size);
     t->signature.magic = 0x0BADCAFE;
     t->signature.trace = p;
     t->signature.size = size;
@@ -409,7 +409,7 @@ void *reallocz_int(void *ptr, size_t size, const char *file, const char *functio
 }
 
 size_t mallocz_usable_size_int(void *ptr, const char *file, const char *function, size_t line) {
-    if(unlikely(!ptr)) return 0;
+    if(!ptr) return 0;
 
     struct malloc_header *t = malloc_get_header(ptr, __FUNCTION__, file, function, line);
     if(!t) {
@@ -423,7 +423,7 @@ size_t mallocz_usable_size_int(void *ptr, const char *file, const char *function
 }
 
 void freez_int(void *ptr, const char *file, const char *function, size_t line) {
-    if(unlikely(!ptr)) return;
+    if(!ptr) return;
 
     struct malloc_header *t = malloc_get_header(ptr, __FUNCTION__, file, function, line);
     if(!t) {
@@ -446,7 +446,7 @@ void freez_int(void *ptr, const char *file, const char *function, size_t line) {
 
 char *strdupz(const char *s) {
     char *t = strdup(s);
-    if (unlikely(!t)) fatal("Cannot strdup() string '%s'", s);
+    if (!t) fatal("Cannot strdup() string '%s'", s);
     return t;
 }
 
@@ -457,19 +457,19 @@ void freez(void *ptr) {
 
 void *mallocz(size_t size) {
     void *p = malloc(size);
-    if (unlikely(!p)) fatal("Cannot allocate %zu bytes of memory.", size);
+    if (!p) fatal("Cannot allocate %zu bytes of memory.", size);
     return p;
 }
 
 void *callocz(size_t nmemb, size_t size) {
     void *p = calloc(nmemb, size);
-    if (unlikely(!p)) fatal("Cannot allocate %zu bytes of memory.", nmemb * size);
+    if (!p) fatal("Cannot allocate %zu bytes of memory.", nmemb * size);
     return p;
 }
 
 void *reallocz(void *ptr, size_t size) {
     void *p = realloc(ptr, size);
-    if (unlikely(!p)) fatal("Cannot re-allocate memory to %zu bytes.", size);
+    if (!p) fatal("Cannot re-allocate memory to %zu bytes.", size);
     return p;
 }
 
@@ -486,8 +486,8 @@ void json_escape_string(char *dst, const char *src, size_t size) {
     char *d = dst, *e = &dst[size - 1];
 
     for(t = src; *t && d < e ;t++) {
-        if(unlikely(*t == '\\' || *t == '"')) {
-            if(unlikely(d + 1 >= e)) break;
+        if(*t == '\\' || *t == '"') {
+            if(d + 1 >= e) break;
             *d++ = '\\';
         }
         *d++ = *t;
@@ -499,13 +499,13 @@ void json_escape_string(char *dst, const char *src, size_t size) {
 void json_fix_string(char *s) {
     unsigned char c;
     while((c = (unsigned char)*s)) {
-        if(unlikely(c == '\\'))
+        if(c == '\\')
             *s++ = '/';
-        else if(unlikely(c == '"'))
+        else if(c == '"')
             *s++ = '\'';
-        else if(unlikely(isspace(c) || iscntrl(c)))
+        else if(isspace(c) || iscntrl(c))
             *s++ = ' ';
-        else if(unlikely(!isprint(c) || c > 127))
+        else if(!isprint(c) || c > 127)
             *s++ = '_';
         else
             s++;
@@ -1142,17 +1142,17 @@ void *netdata_mmap(const char *filename, size_t size, int flags, int ksm, bool r
     // MAP_SHARED is used in memory mode map
     // MAP_PRIVATE is used in memory mode ram and save
 
-    if(unlikely(!(flags & MAP_SHARED) && !(flags & MAP_PRIVATE)))
+    if(!(flags & MAP_SHARED) && !(flags & MAP_PRIVATE))
         fatal("Neither MAP_SHARED or MAP_PRIVATE were given to netdata_mmap()");
 
-    if(unlikely((flags & MAP_SHARED) && (flags & MAP_PRIVATE)))
+    if((flags & MAP_SHARED) && (flags & MAP_PRIVATE))
         fatal("Both MAP_SHARED and MAP_PRIVATE were given to netdata_mmap()");
 
-    if(unlikely((flags & MAP_SHARED) && (!filename || !*filename)))
+    if((flags & MAP_SHARED) && (!filename || !*filename))
         fatal("MAP_SHARED requested, without a filename to netdata_mmap()");
 
     // don't enable ksm is the global setting is disabled
-    if(unlikely(!enable_ksm)) ksm = 0;
+    if(!enable_ksm) ksm = 0;
 
     // KSM only merges anonymous (private) pages, never pagecache (file) pages
     // but MAP_PRIVATE without MAP_ANONYMOUS it fails too, so we need it always
@@ -1270,12 +1270,12 @@ char *fgets_trim_len(char *buf, size_t buf_size, FILE *fp, size_t *len) {
 }
 
 int vsnprintfz(char *dst, size_t n, const char *fmt, va_list args) {
-    if(unlikely(!n)) return 0;
+    if(!n) return 0;
 
     int size = vsnprintf(dst, n, fmt, args);
     dst[n - 1] = '\0';
 
-    if (unlikely((size_t) size > n)) size = (int)n;
+    if ((size_t) size > n) size = (int)n;
 
     return size;
 }
@@ -1332,14 +1332,14 @@ int recursively_delete_dir(const char *path, const char *reason) {
         }
 
         netdata_log_info("Deleting %s file '%s'", reason?reason:"", fullpath);
-        if(unlikely(unlink(fullpath) == -1))
+        if(unlink(fullpath) == -1)
             netdata_log_error("Cannot delete %s file '%s'", reason?reason:"", fullpath);
         else
             ret++;
     }
 
     netdata_log_info("Deleting empty directory '%s'", path);
-    if(unlikely(rmdir(path) == -1))
+    if(rmdir(path) == -1)
         netdata_log_error("Cannot delete empty directory '%s'", path);
     else
         ret++;
@@ -1420,8 +1420,8 @@ failed:
 }
 
 char *strdupz_path_subpath(const char *path, const char *subpath) {
-    if(unlikely(!path || !*path)) path = ".";
-    if(unlikely(!subpath)) subpath = "";
+    if(!path || !*path) path = ".";
+    if(!subpath) subpath = "";
 
     // skip trailing slashes in path
     size_t len = strlen(path);
@@ -1671,13 +1671,13 @@ char *find_and_replace(const char *src, const char *find, const char *replace, c
     size_t repl_len = strlen(replace);
     char *value, *dst;
 
-    if (likely(where))
+    if (where)
         size += (repl_len - find_len);
 
     value = mallocz(size);
     dst = value;
 
-    if (likely(where)) {
+    if (where) {
         size_t count = where - src;
 
         memmove(dst, src, count);
@@ -1813,7 +1813,7 @@ void for_each_open_fd(OPEN_FD_ACTION action, OPEN_FD_EXCLUDE excluded_fds){
         struct dirent *entry;
         while ((entry = readdir(dir)) != NULL) {
             fd = str2i(entry->d_name);
-            if(unlikely((fd == STDIN_FILENO ) || (fd == STDOUT_FILENO) || (fd == STDERR_FILENO) )) continue;
+            if((fd == STDIN_FILENO ) || (fd == STDOUT_FILENO) || (fd == STDERR_FILENO) ) continue;
             switch(action){
                 case OPEN_FD_ACTION_CLOSE:
                     if(fd_is_valid(fd)) (void)close(fd);

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -259,7 +259,7 @@ size_t judy_aral_structures(void);
     do {                                                                                       \
         (item)->next = (head);                                                                 \
                                                                                                \
-        if(likely(head)) {                                                                     \
+        if(head) {                                                                     \
             (item)->prev = (head)->prev;                                                       \
             (head)->prev = (item);                                                             \
         }                                                                                      \
@@ -274,7 +274,7 @@ size_t judy_aral_structures(void);
                                                                                                \
         (item)->next = NULL;                                                                   \
                                                                                                \
-        if(likely(head)) {                                                                     \
+        if(head) {                                                                     \
             (item)->prev = (head)->prev;                                                       \
             (head)->prev->next = (item);                                                       \
             (head)->prev = (item);                                                             \
@@ -477,16 +477,16 @@ typedef struct storage_point {
         if(!storage_point_is_unset(sp) &&               \
            !storage_point_is_gap(sp)) {                 \
                                                         \
-            if(unlikely(signbit((sp).sum)))             \
+            if(signbit((sp).sum))             \
                 (sp).sum = -(sp).sum;                   \
                                                         \
-            if(unlikely(signbit((sp).min)))             \
+            if(signbit((sp).min))             \
                 (sp).min = -(sp).min;                   \
                                                         \
-            if(unlikely(signbit((sp).max)))             \
+            if(signbit((sp).max))             \
                 (sp).max = -(sp).max;                   \
                                                         \
-            if(unlikely((sp).min > (sp).max)) {         \
+            if((sp).min > (sp).max) {         \
                 NETDATA_DOUBLE t = (sp).min;            \
                 (sp).min = (sp).max;                    \
                 (sp).max = t;                           \
@@ -697,16 +697,16 @@ static inline size_t quoted_strings_splitter(char *str, char **words, size_t max
     size_t i = 0;
 
     // skip all white space
-    while (unlikely(isspace_map[(uint8_t)*s]))
+    while (isspace_map[(uint8_t)*s])
         s++;
 
-    if(unlikely(!*s)) {
+    if(!*s) {
         words[i] = NULL;
         return 0;
     }
 
     // check for quote
-    if (unlikely(*s == '\'' || *s == '"')) {
+    if (*s == '\'' || *s == '"') {
         quote = *s; // remember the quote
         s++;        // skip the quote
     }
@@ -715,41 +715,41 @@ static inline size_t quoted_strings_splitter(char *str, char **words, size_t max
     words[i++] = s;
 
     // while we have something
-    while (likely(*s)) {
+    while (*s) {
         // if it is an escape
-        if (unlikely(*s == '\\' && s[1])) {
+        if (*s == '\\' && s[1]) {
             s += 2;
             continue;
         }
 
         // if it is a quote
-        else if (unlikely(*s == quote)) {
+        else if (*s == quote) {
             quote = 0;
             *s = ' ';
             continue;
         }
 
         // if it is a space
-        else if (unlikely(quote == 0 && isspace_map[(uint8_t)*s])) {
+        else if (quote == 0 && isspace_map[(uint8_t)*s]) {
             // terminate the word
             *s++ = '\0';
 
             // skip all white space
-            while (likely(isspace_map[(uint8_t)*s]))
+            while (isspace_map[(uint8_t)*s])
                 s++;
 
             // check for a quote
-            if (unlikely(*s == '\'' || *s == '"')) {
+            if (*s == '\'' || *s == '"') {
                 quote = *s; // remember the quote
                 s++;        // skip the quote
             }
 
             // if we reached the end, stop
-            if (unlikely(!*s))
+            if (!*s)
                 break;
 
             // store the next word
-            if (likely(i < max_words))
+            if (i < max_words)
                 words[i++] = s;
             else
                 break;
@@ -760,7 +760,7 @@ static inline size_t quoted_strings_splitter(char *str, char **words, size_t max
             s++;
     }
 
-    if (likely(i < max_words))
+    if (i < max_words)
         words[i] = NULL;
 
     return i;
@@ -776,7 +776,7 @@ static inline size_t quoted_strings_splitter(char *str, char **words, size_t max
         quoted_strings_splitter(str, words, max_words, isspace_map_pluginsd)
 
 static inline char *get_word(char **words, size_t num_words, size_t index) {
-    if (unlikely(index >= num_words))
+    if (index >= num_words)
         return NULL;
 
     return words[index];
@@ -846,7 +846,7 @@ static inline size_t struct_natural_alignment(size_t size) __attribute__((const)
 
 #define STRUCT_NATURAL_ALIGNMENT (sizeof(uintptr_t) * 2)
 static inline size_t struct_natural_alignment(size_t size) {
-    if(unlikely(size % STRUCT_NATURAL_ALIGNMENT))
+    if(size % STRUCT_NATURAL_ALIGNMENT)
         size = size + STRUCT_NATURAL_ALIGNMENT - (size % STRUCT_NATURAL_ALIGNMENT);
 
     return size;
@@ -880,7 +880,7 @@ struct malloc_trace {
 #endif // NETDATA_TRACE_ALLOCATIONS
 
 static inline PPvoid_t JudyLFirstThenNext(Pcvoid_t PArray, Word_t * PIndex, bool *first) {
-    if(unlikely(*first)) {
+    if(*first) {
         *first = false;
         return JudyLFirst(PArray, PIndex, PJE0);
     }
@@ -889,7 +889,7 @@ static inline PPvoid_t JudyLFirstThenNext(Pcvoid_t PArray, Word_t * PIndex, bool
 }
 
 static inline PPvoid_t JudyLLastThenPrev(Pcvoid_t PArray, Word_t * PIndex, bool *first) {
-    if(unlikely(*first)) {
+    if(*first) {
         *first = false;
         return JudyLLast(PArray, PIndex, PJE0);
     }

--- a/libnetdata/locks/locks.c
+++ b/libnetdata/locks/locks.c
@@ -43,7 +43,7 @@ inline void netdata_thread_disable_cancelability(void) {
 }
 
 inline void netdata_thread_enable_cancelability(void) {
-    if(unlikely(netdata_thread_nested_disables < 1)) {
+    if(netdata_thread_nested_disables < 1) {
         internal_fatal(true, "THREAD_CANCELABILITY: trying to enable cancelability, but it was not not disabled");
 
         netdata_log_error("THREAD_CANCELABILITY: netdata_thread_enable_cancelability(): invalid thread cancelability count %d "
@@ -81,14 +81,14 @@ inline void netdata_thread_enable_cancelability(void) {
 
 int __netdata_mutex_init(netdata_mutex_t *mutex) {
     int ret = pthread_mutex_init(mutex, NULL);
-    if(unlikely(ret != 0))
+    if(ret != 0)
         netdata_log_error("MUTEX_LOCK: failed to initialize (code %d).", ret);
     return ret;
 }
 
 int __netdata_mutex_destroy(netdata_mutex_t *mutex) {
     int ret = pthread_mutex_destroy(mutex);
-    if(unlikely(ret != 0))
+    if(ret != 0)
         netdata_log_error("MUTEX_LOCK: failed to destroy (code %d).", ret);
     return ret;
 }
@@ -97,7 +97,7 @@ int __netdata_mutex_lock(netdata_mutex_t *mutex) {
     netdata_thread_disable_cancelability();
 
     int ret = pthread_mutex_lock(mutex);
-    if(unlikely(ret != 0)) {
+    if(ret != 0) {
         netdata_thread_enable_cancelability();
         netdata_log_error("MUTEX_LOCK: failed to get lock (code %d)", ret);
     }
@@ -121,7 +121,7 @@ int __netdata_mutex_trylock(netdata_mutex_t *mutex) {
 
 int __netdata_mutex_unlock(netdata_mutex_t *mutex) {
     int ret = pthread_mutex_unlock(mutex);
-    if(unlikely(ret != 0))
+    if(ret != 0)
         netdata_log_error("MUTEX_LOCK: failed to unlock (code %d).", ret);
     else {
         netdata_locks_acquired_mutexes--;
@@ -213,14 +213,14 @@ int netdata_mutex_unlock_debug(const char *file __maybe_unused, const char *func
 
 int __netdata_rwlock_destroy(netdata_rwlock_t *rwlock) {
     int ret = pthread_rwlock_destroy(&rwlock->rwlock_t);
-    if(unlikely(ret != 0))
+    if(ret != 0)
         netdata_log_error("RW_LOCK: failed to destroy lock (code %d)", ret);
     return ret;
 }
 
 int __netdata_rwlock_init(netdata_rwlock_t *rwlock) {
     int ret = pthread_rwlock_init(&rwlock->rwlock_t, NULL);
-    if(unlikely(ret != 0))
+    if(ret != 0)
         netdata_log_error("RW_LOCK: failed to initialize lock (code %d)", ret);
     return ret;
 }
@@ -229,7 +229,7 @@ int __netdata_rwlock_rdlock(netdata_rwlock_t *rwlock) {
     netdata_thread_disable_cancelability();
 
     int ret = pthread_rwlock_rdlock(&rwlock->rwlock_t);
-    if(unlikely(ret != 0)) {
+    if(ret != 0) {
         netdata_thread_enable_cancelability();
         netdata_log_error("RW_LOCK: failed to obtain read lock (code %d)", ret);
     }
@@ -243,7 +243,7 @@ int __netdata_rwlock_wrlock(netdata_rwlock_t *rwlock) {
     netdata_thread_disable_cancelability();
 
     int ret = pthread_rwlock_wrlock(&rwlock->rwlock_t);
-    if(unlikely(ret != 0)) {
+    if(ret != 0) {
         netdata_log_error("RW_LOCK: failed to obtain write lock (code %d)", ret);
         netdata_thread_enable_cancelability();
     }
@@ -255,7 +255,7 @@ int __netdata_rwlock_wrlock(netdata_rwlock_t *rwlock) {
 
 int __netdata_rwlock_unlock(netdata_rwlock_t *rwlock) {
     int ret = pthread_rwlock_unlock(&rwlock->rwlock_t);
-    if(unlikely(ret != 0))
+    if(ret != 0)
         netdata_log_error("RW_LOCK: failed to release lock (code %d)", ret);
     else {
         netdata_thread_enable_cancelability();
@@ -315,7 +315,7 @@ void spinlock_lock(SPINLOCK *spinlock) {
 #ifdef NETDATA_INTERNAL_CHECKS
         spins++;
 #endif
-        if(unlikely(i == 8)) {
+        if(i == 8) {
             i = 0;
             nanosleep(&ns, NULL);
         }
@@ -553,11 +553,11 @@ int netdata_rwlock_unlock_debug(const char *file __maybe_unused, const char *fun
 
     netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
 
-    if(unlikely(!locker))
+    if(!locker)
         fatal("UNLOCK WITHOUT LOCK");
 
     int ret = __netdata_rwlock_unlock(rwlock);
-    if(likely(!ret))
+    if(!ret)
         remove_rwlock_locker(file, function, line, rwlock, locker);
 
     return ret;

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -134,7 +134,7 @@ static int log_facility_id(const char *facility_name)
         hash_local6 = 0,
         hash_local7 = 0;
 
-    if(unlikely(!hash_auth))
+    if(!hash_auth)
     {
         hash_auth = simple_hash(LOG_AUTH_KEY);
         hash_authpriv = simple_hash(LOG_AUTHPRIV_KEY);
@@ -466,7 +466,7 @@ void syslog_init() {
 }
 
 void log_date(char *buffer, size_t len, time_t now) {
-    if(unlikely(!buffer || !len))
+    if(!buffer || !len)
         return;
 
     time_t t = now;
@@ -479,7 +479,7 @@ void log_date(char *buffer, size_t len, time_t now) {
         return;
     }
 
-    if (unlikely(strftime(buffer, len, "%Y-%m-%d %H:%M:%S", tmp) == 0))
+    if (strftime(buffer, len, "%Y-%m-%d %H:%M:%S", tmp) == 0)
         buffer[0] = '\0';
 
     buffer[len - 1] = '\0';

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -109,9 +109,9 @@ typedef struct error_with_limit {
 #define error_limit_static_thread_var(var, log_every_secs, sleep_usecs) static __thread ERROR_LIMIT var = { .last_logged = 0, .count = 0, .log_every = (log_every_secs), .sleep_ut = (sleep_usecs) }
 
 #ifdef NETDATA_INTERNAL_CHECKS
-#define netdata_log_debug(type, args...) do { if(unlikely(debug_flags & type)) debug_int(__FILE__, __FUNCTION__, __LINE__, ##args); } while(0)
-#define internal_error(condition, args...) do { if(unlikely(condition)) error_int(0, "IERR", __FILE__, __FUNCTION__, __LINE__, ##args); } while(0)
-#define internal_fatal(condition, args...) do { if(unlikely(condition)) fatal_int(__FILE__, __FUNCTION__, __LINE__, ##args); } while(0)
+#define netdata_log_debug(type, args...) do { if(debug_flags & type) debug_int(__FILE__, __FUNCTION__, __LINE__, ##args); } while(0)
+#define internal_error(condition, args...) do { if(condition) error_int(0, "IERR", __FILE__, __FUNCTION__, __LINE__, ##args); } while(0)
+#define internal_fatal(condition, args...) do { if(condition) fatal_int(__FILE__, __FUNCTION__, __LINE__, ##args); } while(0)
 #else
 #define netdata_log_debug(type, args...) debug_dummy()
 #define internal_error(args...) debug_dummy()

--- a/libnetdata/onewayalloc/onewayalloc.c
+++ b/libnetdata/onewayalloc/onewayalloc.c
@@ -23,7 +23,7 @@ size_t onewayalloc_allocated_memory(void) {
 // allocations need to be aligned to CPU register width
 // https://en.wikipedia.org/wiki/Data_structure_alignment
 static inline size_t natural_alignment(size_t size) {
-    if(unlikely(size % OWA_NATURAL_ALIGNMENT))
+    if(size % OWA_NATURAL_ALIGNMENT)
         size = size + OWA_NATURAL_ALIGNMENT - (size % OWA_NATURAL_ALIGNMENT);
 
     return size;
@@ -36,9 +36,9 @@ static inline size_t natural_alignment(size_t size) {
 static OWA_PAGE *onewayalloc_create_internal(OWA_PAGE *head, size_t size_hint) {
     static size_t OWA_NATURAL_PAGE_SIZE = 0;
 
-    if(unlikely(!OWA_NATURAL_PAGE_SIZE)) {
+    if(!OWA_NATURAL_PAGE_SIZE) {
         long int page_size = sysconf(_SC_PAGE_SIZE);
-        if (unlikely(page_size == -1))
+        if (page_size == -1)
             OWA_NATURAL_PAGE_SIZE = 4096;
         else
             OWA_NATURAL_PAGE_SIZE = page_size;
@@ -55,7 +55,7 @@ static OWA_PAGE *onewayalloc_create_internal(OWA_PAGE *head, size_t size_hint) {
     if(size_hint > size) size = size_hint;
 
     // try to allocate half of the total we have allocated already
-    if(likely(head)) {
+    if(head) {
         size_t optimal_size = head->stats_pages_size / 2;
         if(optimal_size > size) size = optimal_size;
     }
@@ -64,7 +64,7 @@ static OWA_PAGE *onewayalloc_create_internal(OWA_PAGE *head, size_t size_hint) {
     if(size % OWA_NATURAL_PAGE_SIZE) size = size + OWA_NATURAL_PAGE_SIZE - (size % OWA_NATURAL_PAGE_SIZE);
 
     // OWA_PAGE *page = (OWA_PAGE *)netdata_mmap(NULL, size, MAP_ANONYMOUS|MAP_PRIVATE, 0);
-    // if(unlikely(!page)) fatal("Cannot allocate onewayalloc buffer of size %zu", size);
+    // if(!page) fatal("Cannot allocate onewayalloc buffer of size %zu", size);
     OWA_PAGE *page = (OWA_PAGE *)mallocz(size);
     __atomic_add_fetch(&onewayalloc_total_memory, size, __ATOMIC_RELAXED);
 
@@ -72,7 +72,7 @@ static OWA_PAGE *onewayalloc_create_internal(OWA_PAGE *head, size_t size_hint) {
     page->offset = natural_alignment(sizeof(OWA_PAGE));
     page->next = page->last = NULL;
 
-    if(unlikely(!head)) {
+    if(!head) {
         // this is the first time we are called
         head = page;
         head->stats_pages = 0;
@@ -111,7 +111,7 @@ void *onewayalloc_mallocz(ONEWAYALLOC *owa, size_t size) {
     // make sure the size is aligned
     size = natural_alignment(size);
 
-    if(unlikely(page->size - page->offset < size)) {
+    if(page->size - page->offset < size) {
         // we don't have enough space to fit the data
         // let's get another page
         page = onewayalloc_create_internal(head, (size > page->size)?size:page->size);
@@ -156,7 +156,7 @@ void onewayalloc_freez(ONEWAYALLOC *owa __maybe_unused, const void *ptr __maybe_
     // so try to find it in our memory and if it is not there
     // log an error
 
-    if (unlikely(!ptr))
+    if (!ptr)
         return;
 
     OWA_PAGE *head = (OWA_PAGE *)owa;

--- a/libnetdata/os.c
+++ b/libnetdata/os.c
@@ -14,7 +14,7 @@ long get_system_cpus_with_cache(bool cache, bool for_netdata) {
 
     int index = for_netdata ? CPUS_FOR_NETDATA : CPUS_FOR_COLLECTORS;
 
-    if(likely(cache && processors[index] > 0))
+    if(cache && processors[index] > 0)
         return processors[index];
 
 #if defined(__APPLE__) || defined(__FreeBSD__)
@@ -27,7 +27,7 @@ long get_system_cpus_with_cache(bool cache, bool for_netdata) {
     int32_t tmp_processors;
     bool error = false;
 
-    if (unlikely(GETSYSCTL_BY_NAME(HW_CPU_NAME, tmp_processors)))
+    if (GETSYSCTL_BY_NAME(HW_CPU_NAME, tmp_processors))
         error = true;
     else
         processors[index] = tmp_processors;
@@ -91,7 +91,7 @@ pid_t get_system_pid_max(void) {
 #elif __FreeBSD__
     int32_t tmp_pid_max;
 
-        if (unlikely(GETSYSCTL_BY_NAME("kern.pid_max", tmp_pid_max))) {
+        if (GETSYSCTL_BY_NAME("kern.pid_max", tmp_pid_max)) {
             pid_max = 99999;
             netdata_log_error("Assuming system's maximum pid is %d.", pid_max);
         } else {
@@ -102,7 +102,7 @@ pid_t get_system_pid_max(void) {
 #else
 
     static char read = 0;
-    if(unlikely(read)) return pid_max;
+    if(read) return pid_max;
     read = 1;
 
     char filename[FILENAME_MAX + 1];
@@ -196,11 +196,11 @@ const char *os_type = "freebsd";
 int getsysctl_by_name(const char *name, void *ptr, size_t len) {
     size_t nlen = len;
 
-    if (unlikely(sysctlbyname(name, ptr, &nlen, NULL, 0) == -1)) {
+    if (sysctlbyname(name, ptr, &nlen, NULL, 0) == -1) {
         netdata_log_error("FREEBSD: sysctl(%s...) failed: %s", name, strerror(errno));
         return 1;
     }
-    if (unlikely(nlen != len)) {
+    if (nlen != len) {
         netdata_log_error("FREEBSD: sysctl(%s...) expected %lu, got %lu", name, (unsigned long)len, (unsigned long)nlen);
         return 1;
     }
@@ -210,15 +210,15 @@ int getsysctl_by_name(const char *name, void *ptr, size_t len) {
 int getsysctl_simple(const char *name, int *mib, size_t miblen, void *ptr, size_t len) {
     size_t nlen = len;
 
-    if (unlikely(!mib[0]))
-        if (unlikely(getsysctl_mib(name, mib, miblen)))
+    if (!mib[0])
+        if (getsysctl_mib(name, mib, miblen))
             return 1;
 
-    if (unlikely(sysctl(mib, miblen, ptr, &nlen, NULL, 0) == -1)) {
+    if (sysctl(mib, miblen, ptr, &nlen, NULL, 0) == -1) {
         netdata_log_error("FREEBSD: sysctl(%s...) failed: %s", name, strerror(errno));
         return 1;
     }
-    if (unlikely(nlen != len)) {
+    if (nlen != len) {
         netdata_log_error("FREEBSD: sysctl(%s...) expected %lu, got %lu", name, (unsigned long)len, (unsigned long)nlen);
         return 1;
     }
@@ -229,15 +229,15 @@ int getsysctl_simple(const char *name, int *mib, size_t miblen, void *ptr, size_
 int getsysctl(const char *name, int *mib, size_t miblen, void *ptr, size_t *len) {
     size_t nlen = *len;
 
-    if (unlikely(!mib[0]))
-        if (unlikely(getsysctl_mib(name, mib, miblen)))
+    if (!mib[0])
+        if (getsysctl_mib(name, mib, miblen))
             return 1;
 
-    if (unlikely(sysctl(mib, miblen, ptr, len, NULL, 0) == -1)) {
+    if (sysctl(mib, miblen, ptr, len, NULL, 0) == -1) {
         netdata_log_error("FREEBSD: sysctl(%s...) failed: %s", name, strerror(errno));
         return 1;
     }
-    if (unlikely(ptr != NULL && nlen != *len)) {
+    if (ptr != NULL && nlen != *len) {
         netdata_log_error("FREEBSD: sysctl(%s...) expected %lu, got %lu", name, (unsigned long)*len, (unsigned long)nlen);
         return 1;
     }
@@ -248,11 +248,11 @@ int getsysctl(const char *name, int *mib, size_t miblen, void *ptr, size_t *len)
 int getsysctl_mib(const char *name, int *mib, size_t len) {
     size_t nlen = len;
 
-    if (unlikely(sysctlnametomib(name, mib, &nlen) == -1)) {
+    if (sysctlnametomib(name, mib, &nlen) == -1) {
         netdata_log_error("FREEBSD: sysctl(%s...) failed: %s", name, strerror(errno));
         return 1;
     }
-    if (unlikely(nlen != len)) {
+    if (nlen != len) {
         netdata_log_error("FREEBSD: sysctl(%s...) expected %lu, got %lu", name, (unsigned long)len, (unsigned long)nlen);
         return 1;
     }
@@ -273,11 +273,11 @@ const char *os_type = "macos";
 int getsysctl_by_name(const char *name, void *ptr, size_t len) {
     size_t nlen = len;
 
-    if (unlikely(sysctlbyname(name, ptr, &nlen, NULL, 0) == -1)) {
+    if (sysctlbyname(name, ptr, &nlen, NULL, 0) == -1) {
         netdata_log_error("MACOS: sysctl(%s...) failed: %s", name, strerror(errno));
         return 1;
     }
-    if (unlikely(nlen != len)) {
+    if (nlen != len) {
         netdata_log_error("MACOS: sysctl(%s...) expected %lu, got %lu", name, (unsigned long)len, (unsigned long)nlen);
         return 1;
     }

--- a/libnetdata/popen/popen.c
+++ b/libnetdata/popen/popen.c
@@ -46,7 +46,7 @@ static void netdata_popen_tracking_del_pid(pid_t pid) {
     netdata_popen_tracking_lock();
 
     DOUBLE_LINKED_LIST_FOREACH_FORWARD(netdata_popen_root, mp, prev, next) {
-        if(unlikely(mp->pid == pid))
+        if(mp->pid == pid)
             break;
     }
 
@@ -82,7 +82,7 @@ int netdata_waitid(idtype_t idtype, id_t id, siginfo_t *infop, int options) {
 
         netdata_popen_tracking_lock();
         DOUBLE_LINKED_LIST_FOREACH_FORWARD(netdata_popen_root, mp, prev, next) {
-            if(unlikely(mp->pid == (pid_t)id))
+            if(mp->pid == (pid_t)id)
                 break;
         }
 

--- a/libnetdata/simple_pattern/simple_pattern.c
+++ b/libnetdata/simple_pattern/simple_pattern.c
@@ -15,7 +15,7 @@ struct simple_pattern {
 };
 
 static struct simple_pattern *parse_pattern(char *str, SIMPLE_PREFIX_MODE default_mode, size_t count) {
-    if(unlikely(count >= 1000))
+    if(count >= 1000)
         return NULL;
 
     // fprintf(stderr, "PARSING PATTERN: '%s'\n", str);
@@ -76,7 +76,7 @@ static struct simple_pattern *parse_pattern(char *str, SIMPLE_PREFIX_MODE defaul
 SIMPLE_PATTERN *simple_pattern_create(const char *list, const char *separators, SIMPLE_PREFIX_MODE default_mode, bool case_sensitive) {
     struct simple_pattern *root = NULL, *last = NULL;
 
-    if(unlikely(!list || !*list)) return root;
+    if(!list || !*list) return root;
 
     char isseparator[256] = {
             [' '] = 1       // space
@@ -87,7 +87,7 @@ SIMPLE_PATTERN *simple_pattern_create(const char *list, const char *separators, 
             , ['\v'] = 1    // vertical tab
     };
 
-    if (unlikely(separators && *separators)) {
+    if (separators && *separators) {
         memset(&isseparator[0], 0, sizeof(isseparator));
         while(*separators) isseparator[(unsigned char)*separators++] = 1;
     }
@@ -111,7 +111,7 @@ SIMPLE_PATTERN *simple_pattern_create(const char *list, const char *separators, 
         }
 
         // empty string
-        if(unlikely(!*s))
+        if(!*s)
             break;
 
         // find the next space
@@ -136,7 +136,7 @@ SIMPLE_PATTERN *simple_pattern_create(const char *list, const char *separators, 
         *c = '\0';
 
         // if we matched the empty string, skip it
-        if(unlikely(!*buf))
+        if(!*buf)
             continue;
 
         // fprintf(stderr, "FOUND PATTERN: '%s'\n", buf);
@@ -145,7 +145,7 @@ SIMPLE_PATTERN *simple_pattern_create(const char *list, const char *separators, 
         m->case_sensitive = case_sensitive;
 
         // link it at the end
-        if(unlikely(!root))
+        if(!root)
             root = last = m;
         else {
             last->next = m;
@@ -164,10 +164,10 @@ static inline char *add_wildcarded(const char *matched, size_t matched_size, cha
     //    fprintf(stderr, "ADD WILDCARDED '%s' of length %zu\n", buf, matched_size);
     //}
 
-    if(unlikely(wildcarded && *wildcarded_size && matched && *matched && matched_size)) {
+    if(wildcarded && *wildcarded_size && matched && *matched && matched_size) {
         size_t wss = *wildcarded_size - 1;
         size_t len = (matched_size < wss)?matched_size:wss;
-        if(likely(len)) {
+        if(len) {
             strncpyz(wildcarded, matched, len);
 
             *wildcarded_size -= len;
@@ -209,7 +209,7 @@ static inline bool match_pattern(struct simple_pattern *m, const char *str, size
         switch(m->mode) {
             default:
             case SIMPLE_PATTERN_EXACT:
-                if(unlikely(sp_strcmp(str, m->match, m->case_sensitive) == 0)) {
+                if(sp_strcmp(str, m->match, m->case_sensitive) == 0) {
                     if(!m->child) return true;
                     return false;
                 }
@@ -236,7 +236,7 @@ static inline bool match_pattern(struct simple_pattern *m, const char *str, size
                 break;
 
             case SIMPLE_PATTERN_PREFIX:
-                if(unlikely(sp_strncmp(str, m->match, m->len, m->case_sensitive) == 0)) {
+                if(sp_strncmp(str, m->match, m->len, m->case_sensitive) == 0) {
                     if(!m->child) {
                         add_wildcarded(&str[m->len], len - m->len, wildcarded, wildcarded_size);
                         return true;
@@ -253,7 +253,7 @@ static inline bool match_pattern(struct simple_pattern *m, const char *str, size
                 break;
 
             case SIMPLE_PATTERN_SUFFIX:
-                if(unlikely(sp_strcmp(&str[len - m->len], m->match, m->case_sensitive) == 0)) {
+                if(sp_strcmp(&str[len - m->len], m->match, m->case_sensitive) == 0) {
                     add_wildcarded(str, len - m->len, wildcarded, wildcarded_size);
                     if(!m->child) return true;
                     return false;
@@ -271,7 +271,7 @@ static inline SIMPLE_PATTERN_RESULT simple_pattern_matches_extract_with_length(S
     for(m = root; m ; m = m->next) {
         char *ws = wildcarded;
         size_t wss = wildcarded_size;
-        if(unlikely(ws)) *ws = '\0';
+        if(ws) *ws = '\0';
 
         if (match_pattern(m, str, len, ws, &wss)) {
             if (m->negative) return SP_MATCHED_NEGATIVE;

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -15,7 +15,7 @@ bool netdata_ssl_validate_certificate_sender =  true;
 static SOCKET_PEERS netdata_ssl_peers(NETDATA_SSL *ssl) {
     int sock_fd;
 
-    if(unlikely(!ssl->conn))
+    if(!ssl->conn)
         sock_fd = -1;
     else
         sock_fd = SSL_get_rfd(ssl->conn);
@@ -175,7 +175,7 @@ void netdata_ssl_close(NETDATA_SSL *ssl) {
 static inline bool is_handshake_complete(NETDATA_SSL *ssl, const char *op) {
     error_limit_static_thread_var(erl, 1, 0);
 
-    if(unlikely(!ssl->conn)) {
+    if(!ssl->conn) {
         internal_error(true, "SSL: trying to %s on a NULL connection", op);
         return false;
     }
@@ -227,12 +227,12 @@ ssize_t netdata_ssl_read(NETDATA_SSL *ssl, void *buf, size_t num) {
     errno = 0;
     ssl->ssl_errno = 0;
 
-    if(unlikely(!is_handshake_complete(ssl, "read")))
+    if(!is_handshake_complete(ssl, "read"))
         return -1;
 
     int bytes = SSL_read(ssl->conn, buf, (int)num);
 
-    if(unlikely(bytes <= 0)) {
+    if(bytes <= 0) {
         int err = SSL_get_error(ssl->conn, bytes);
         if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
             ssl->ssl_errno = err;
@@ -264,12 +264,12 @@ ssize_t netdata_ssl_write(NETDATA_SSL *ssl, const void *buf, size_t num) {
     errno = 0;
     ssl->ssl_errno = 0;
 
-    if(unlikely(!is_handshake_complete(ssl, "write")))
+    if(!is_handshake_complete(ssl, "write"))
         return -1;
 
     int bytes = SSL_write(ssl->conn, (uint8_t *)buf, (int)num);
 
-    if(unlikely(bytes <= 0)) {
+    if(bytes <= 0) {
         int err = SSL_get_error(ssl->conn, bytes);
         if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
             ssl->ssl_errno = err;
@@ -287,7 +287,7 @@ ssize_t netdata_ssl_write(NETDATA_SSL *ssl, const void *buf, size_t num) {
 static inline bool is_handshake_initialized(NETDATA_SSL *ssl, const char *op) {
     error_limit_static_thread_var(erl, 1, 0);
 
-    if(unlikely(!ssl->conn)) {
+    if(!ssl->conn) {
         internal_error(true, "SSL: trying to %s on a NULL connection", op);
         return false;
     }
@@ -346,7 +346,7 @@ bool netdata_ssl_connect(NETDATA_SSL *ssl) {
     errno = 0;
     ssl->ssl_errno = 0;
 
-    if(unlikely(!is_handshake_initialized(ssl, "connect")))
+    if(!is_handshake_initialized(ssl, "connect"))
         return false;
 
     SSL_set_connect_state(ssl->conn);
@@ -372,7 +372,7 @@ bool netdata_ssl_accept(NETDATA_SSL *ssl) {
     errno = 0;
     ssl->ssl_errno = 0;
 
-    if(unlikely(!is_handshake_initialized(ssl, "accept")))
+    if(!is_handshake_initialized(ssl, "accept"))
         return false;
 
     SSL_set_accept_state(ssl->conn);

--- a/libnetdata/storage_number/storage_number.c
+++ b/libnetdata/storage_number/storage_number.c
@@ -83,12 +83,12 @@ storage_number pack_storage_number(NETDATA_DOUBLE value, SN_FLAGS flags) {
     // bit 25 SN_ANOMALY_BIT = 0: anomalous, 1: not anomalous
     // bit 24 to bit 1 = the value
 
-    if(unlikely(fpclassify(value) == FP_NAN || fpclassify(value) == FP_INFINITE))
+    if(fpclassify(value) == FP_NAN || fpclassify(value) == FP_INFINITE)
         return SN_EMPTY_SLOT;
 
     storage_number r = flags & SN_USER_FLAGS;
 
-    if(unlikely(fpclassify(value) == FP_ZERO || fpclassify(value) == FP_SUBNORMAL))
+    if(fpclassify(value) == FP_ZERO || fpclassify(value) == FP_SUBNORMAL)
         return r;
 
     int m = 0;
@@ -138,7 +138,7 @@ storage_number pack_storage_number(NETDATA_DOUBLE value, SN_FLAGS flags) {
             m++;
         }
 
-        if (unlikely(n > (NETDATA_DOUBLE)0x00ffffff)) {
+        if (n > (NETDATA_DOUBLE)0x00ffffff) {
             n /= 10;
             m--;
         }

--- a/libnetdata/storage_number/storage_number.h
+++ b/libnetdata/storage_number/storage_number.h
@@ -133,22 +133,22 @@ static inline NETDATA_DOUBLE unpack_storage_number(storage_number value) __attri
 static inline NETDATA_DOUBLE unpack_storage_number(storage_number value) {
     extern NETDATA_DOUBLE unpack_storage_number_lut10x[4 * 8];
 
-    if(unlikely(value == SN_EMPTY_SLOT))
+    if(value == SN_EMPTY_SLOT)
         return NAN;
 
     int sign = 1, exp = 0;
     int factor = 0;
 
     // bit 32 = 0:positive, 1:negative
-    if(unlikely(value & SN_FLAG_NEGATIVE))
+    if(value & SN_FLAG_NEGATIVE)
         sign = -1;
 
     // bit 31 = 0:divide, 1:multiply
-    if(unlikely(value & SN_FLAG_MULTIPLY))
+    if(value & SN_FLAG_MULTIPLY)
         exp = 1;
 
     // bit 27 SN_FLAG_NOT_EXISTS_MUL100
-    if(unlikely(value & SN_FLAG_NOT_EXISTS_MUL100))
+    if(value & SN_FLAG_NOT_EXISTS_MUL100)
         factor = 1;
 
     // bit 26 SN_FLAG_RESET

--- a/libnetdata/threads/threads.c
+++ b/libnetdata/threads/threads.c
@@ -87,7 +87,7 @@ static __thread pid_t gettid_cached_tid = 0;
 pid_t gettid(void) {
     pid_t tid = 0;
 
-    if(likely(gettid_cached_tid > 0))
+    if(gettid_cached_tid > 0)
         return gettid_cached_tid;
 
 #ifdef __FreeBSD__

--- a/libnetdata/url/url.c
+++ b/libnetdata/url/url.c
@@ -56,7 +56,7 @@ char *url_encode(char *str) {
  *  @return The character decoded on success and 0 otherwise
  */
 char url_percent_escape_decode(const char *s) {
-    if(likely(s[1] && s[2]))
+    if(s[1] && s[2])
         return (char)(from_hex(s[1]) << 4 | from_hex(s[2]));
     return 0;
 }
@@ -75,7 +75,7 @@ char url_utf8_get_byte_length(char c) {
         return 1;
 
     char length = 0;
-    while(likely(c & 0x80)) {
+    while(c & 0x80) {
         length++;
         c <<= 1;
     }
@@ -101,19 +101,19 @@ char url_utf8_get_byte_length(char c) {
 char url_decode_multibyte_utf8(const char *s, char *d, const char *d_end) {
     char first_byte = url_percent_escape_decode(s);
 
-    if(unlikely(!first_byte || !IS_UTF8_STARTBYTE(first_byte)))
+    if(!first_byte || !IS_UTF8_STARTBYTE(first_byte))
         return 0;
 
     char byte_length = url_utf8_get_byte_length(first_byte);
 
-    if(unlikely(byte_length <= 0 || d+byte_length >= d_end))
+    if(byte_length <= 0 || d+byte_length >= d_end)
         return 0;
 
     char to_read = byte_length;
     while(to_read > 0) {
         char c = url_percent_escape_decode(s);
 
-        if(unlikely( !IS_UTF8_BYTE(c) ))
+        if( !IS_UTF8_BYTE(c) )
             return 0;
         if((to_read != byte_length) && IS_UTF8_STARTBYTE(c)) 
             return 0;
@@ -195,11 +195,11 @@ char *url_decode_r(char *to, const char *url, size_t size) {
          *e = &to[size - 1]; // destination end
 
     while(*s && d < e) {
-        if(unlikely(*s == '%')) {
+        if(*s == '%') {
             char t = url_percent_escape_decode(s);
             if(IS_UTF8_BYTE(t)) {
                 char bytes_written = url_decode_multibyte_utf8(s, d, e);
-                if(likely(bytes_written)){
+                if(bytes_written){
                     d += bytes_written;
                     s += (bytes_written * 3)-1;
                 }
@@ -207,7 +207,7 @@ char *url_decode_r(char *to, const char *url, size_t size) {
                     goto fail_cleanup;
                 }
             }
-            else if(likely(t) && isprint(t)) {
+            else if(t && isprint(t)) {
                 // avoid HTTP header injection
                 *d++ = t;
                 s += 2;
@@ -215,7 +215,7 @@ char *url_decode_r(char *to, const char *url, size_t size) {
             else
                 goto fail_cleanup;
         }
-        else if(unlikely(*s == '+'))
+        else if(*s == '+')
             *d++ = ' ';
 
         else
@@ -226,7 +226,7 @@ char *url_decode_r(char *to, const char *url, size_t size) {
 
     *d = '\0';
 
-    if(unlikely( utf8_check((unsigned  char *)to) )) //NULL means success here
+    if( utf8_check((unsigned  char *)to) ) //NULL means success here
         return NULL;
 
     return to;
@@ -240,10 +240,10 @@ inline bool url_is_request_complete(char *begin, char *end, size_t length, char 
     if (begin == end || length < 4)
         return false;
 
-    if(likely(strncmp(begin, "GET ", 4)) == 0) {
+    if(strncmp(begin, "GET ", 4) == 0) {
         return strstr(end - 4, "\r\n\r\n");
     }
-    else if(unlikely(strncmp(begin, "POST ", 5) == 0)) {
+    else if(strncmp(begin, "POST ", 5) == 0) {
         char *cl = strstr(begin, "Content-Length: ");
         if(!cl) return false;
         cl = &cl[16];

--- a/libnetdata/worker_utilization/worker_utilization.c
+++ b/libnetdata/worker_utilization/worker_utilization.c
@@ -78,7 +78,7 @@ size_t workers_allocated_memory(void) {
 }
 
 void worker_register(const char *name) {
-    if(unlikely(worker)) return;
+    if(worker) return;
 
     worker = callocz(1, sizeof(struct worker));
     worker->pid = gettid();
@@ -115,9 +115,9 @@ void worker_register(const char *name) {
 }
 
 void worker_register_job_custom_metric(size_t job_id, const char *name, const char *units, WORKER_METRIC_TYPE type) {
-    if(unlikely(!worker)) return;
+    if(!worker) return;
 
-    if(unlikely(job_id >= WORKER_UTILIZATION_MAX_JOB_TYPES)) {
+    if(job_id >= WORKER_UTILIZATION_MAX_JOB_TYPES) {
         netdata_log_error("WORKER_UTILIZATION: job_id %zu is too big. Max is %zu", job_id, (size_t)(WORKER_UTILIZATION_MAX_JOB_TYPES - 1));
         return;
     }
@@ -141,7 +141,7 @@ void worker_register_job_name(size_t job_id, const char *name) {
 }
 
 void worker_unregister(void) {
-    if(unlikely(!worker)) return;
+    if(!worker) return;
 
     size_t workname_size = strlen(worker->workname) + 1;
     spinlock_lock(&workers_globals.spinlock);
@@ -182,18 +182,18 @@ static inline void worker_is_idle_with_time(usec_t now) {
     // set it to idle before we set the timestamp
 
     worker->last_action = WORKER_IDLE;
-    if(likely(worker->last_action_timestamp < now))
+    if(worker->last_action_timestamp < now)
         worker->last_action_timestamp = now;
 }
 
 void worker_is_idle(void) {
-    if(unlikely(!worker || worker->last_action != WORKER_BUSY)) return;
+    if(!worker || worker->last_action != WORKER_BUSY) return;
 
     worker_is_idle_with_time(worker_now_monotonic_usec());
 }
 
 void worker_is_busy(size_t job_id) {
-    if(unlikely(!worker || job_id >= WORKER_UTILIZATION_MAX_JOB_TYPES))
+    if(!worker || job_id >= WORKER_UTILIZATION_MAX_JOB_TYPES)
         return;
 
     usec_t now = worker_now_monotonic_usec();
@@ -212,8 +212,8 @@ void worker_is_busy(size_t job_id) {
 }
 
 void worker_set_metric(size_t job_id, NETDATA_DOUBLE value) {
-    if(unlikely(!worker)) return;
-    if(unlikely(job_id >= WORKER_UTILIZATION_MAX_JOB_TYPES))
+    if(!worker) return;
+    if(job_id >= WORKER_UTILIZATION_MAX_JOB_TYPES)
         return;
 
     switch(worker->per_job_type[job_id].type) {

--- a/ml/ad_charts.cc
+++ b/ml/ad_charts.cc
@@ -496,7 +496,7 @@ void ml_update_global_statistics_charts(uint64_t models_consulted) {
         static RRDSET *st = NULL;
         static RRDDIM *rd = NULL;
 
-        if (unlikely(!st)) {
+        if (!st) {
             st = rrdset_create_localhost(
                     "netdata" // type
                     , "ml_models_consulted" // id

--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -443,37 +443,37 @@ ml_dimension_add_model(const uuid_t *metric_uuid, const ml_kmeans_t *km)
     int param = 0;
     int rc = 0;
 
-    if (unlikely(!db)) {
+    if (!db) {
         error_report("Database has not been initialized");
         return 1;
     }
 
-    if (unlikely(!res)) {
+    if (!res) {
         rc = prepare_statement(db, db_models_add_model, &res);
-        if (unlikely(rc != SQLITE_OK)) {
+        if (rc != SQLITE_OK) {
             error_report("Failed to prepare statement to store model, rc = %d", rc);
             return 1;
         }
     }
 
     rc = sqlite3_bind_blob(res, ++param, metric_uuid, sizeof(*metric_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_int(res, ++param, (int) km->after);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_int(res, ++param, (int) km->before);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_double(res, ++param, km->min_dist);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_double(res, ++param, km->max_dist);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     if (km->cluster_centers.size() != 2)
@@ -486,19 +486,19 @@ ml_dimension_add_model(const uuid_t *metric_uuid, const ml_kmeans_t *km)
         for (long idx = 0; idx != ds.size(); idx++) {
             calculated_number_t cn = ds(idx);
             int rc = sqlite3_bind_double(res, ++param, cn);
-            if (unlikely(rc != SQLITE_OK))
+            if (rc != SQLITE_OK)
                 goto bind_fail;
         }
     }
 
     rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE)) {
+    if (rc != SQLITE_DONE) {
         error_report("Failed to store model, rc = %d", rc);
         return rc;
     }
 
     rc = sqlite3_reset(res);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to reset statement when storing model, rc = %d", rc);
         return rc;
     }
@@ -508,7 +508,7 @@ ml_dimension_add_model(const uuid_t *metric_uuid, const ml_kmeans_t *km)
 bind_fail:
     error_report("Failed to bind parameter %d to store model, rc = %d", param, rc);
     rc = sqlite3_reset(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to reset statement to store model, rc = %d", rc);
     return rc;
 }
@@ -520,35 +520,35 @@ ml_dimension_delete_models(const uuid_t *metric_uuid, time_t before)
     int rc = 0;
     int param = 0;
 
-    if (unlikely(!db)) {
+    if (!db) {
         error_report("Database has not been initialized");
         return 1;
     }
 
-    if (unlikely(!res)) {
+    if (!res) {
         rc = prepare_statement(db, db_models_delete, &res);
-        if (unlikely(rc != SQLITE_OK)) {
+        if (rc != SQLITE_OK) {
             error_report("Failed to prepare statement to delete models, rc = %d", rc);
             return rc;
         }
     }
 
     rc = sqlite3_bind_blob(res, ++param, metric_uuid, sizeof(*metric_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_int(res, ++param, (int) before);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE)) {
+    if (rc != SQLITE_DONE) {
         error_report("Failed to delete models, rc = %d", rc);
         return rc;
     }
 
     rc = sqlite3_reset(res);
-    if (unlikely(rc != SQLITE_OK)) {
+    if (rc != SQLITE_OK) {
         error_report("Failed to reset statement when deleting models, rc = %d", rc);
         return rc;
     }
@@ -558,7 +558,7 @@ ml_dimension_delete_models(const uuid_t *metric_uuid, time_t before)
 bind_fail:
     error_report("Failed to bind parameter %d to delete models, rc = %d", param, rc);
     rc = sqlite3_reset(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to reset statement to delete models, rc = %d", rc);
     return rc;
 }
@@ -581,25 +581,25 @@ int ml_dimension_load_models(RRDDIM *rd) {
     int rc = 0;
     int param = 0;
 
-    if (unlikely(!db)) {
+    if (!db) {
         error_report("Database has not been initialized");
         return 1;
     }
 
-    if (unlikely(!res)) {
+    if (!res) {
         rc = prepare_statement(db, db_models_load, &res);
-        if (unlikely(rc != SQLITE_OK)) {
+        if (rc != SQLITE_OK) {
             error_report("Failed to prepare statement to load models, rc = %d", rc);
             return 1;
         }
     }
 
     rc = sqlite3_bind_blob(res, ++param, &dim->rd->metric_uuid, sizeof(dim->rd->metric_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     rc = sqlite3_bind_int(res, ++param, now_realtime_usec() - (Cfg.num_models_to_use * Cfg.max_train_samples));
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         goto bind_fail;
 
     spinlock_lock(&dim->slock);
@@ -641,11 +641,11 @@ int ml_dimension_load_models(RRDDIM *rd) {
 
     spinlock_unlock(&dim->slock);
 
-    if (unlikely(rc != SQLITE_DONE))
+    if (rc != SQLITE_DONE)
         error_report("Failed to load models, rc = %d", rc);
 
     rc = sqlite3_reset(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to reset statement when loading models, rc = %d", rc);
 
     return 0;
@@ -653,7 +653,7 @@ int ml_dimension_load_models(RRDDIM *rd) {
 bind_fail:
     error_report("Failed to bind parameter %d to load models, rc = %d", param, rc);
     rc = sqlite3_reset(res);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Failed to reset statement to load models, rc = %d", rc);
     return 1;
 }
@@ -1693,7 +1693,7 @@ void ml_fini() {
         return;
 
     int rc = sqlite3_close_v2(db);
-    if (unlikely(rc != SQLITE_OK))
+    if (rc != SQLITE_OK)
         error_report("Error %d while closing the SQLite database, %s", rc, sqlite3_errstr(rc));
 }
 

--- a/registry/registry.c
+++ b/registry/registry.c
@@ -94,7 +94,7 @@ static STRING *asterisks = NULL;
 
 // callback for rendering PERSON_URLs
 static int registry_json_person_url_callback(REGISTRY_PERSON_URL *pu, struct registry_json_walk_person_urls_callback *c) {
-    if(unlikely(!asterisks))
+    if(!asterisks)
         asterisks = string_strdupz("***");
 
     struct web_client *w = c->w;
@@ -114,7 +114,7 @@ static int registry_json_person_url_callback(REGISTRY_PERSON_URL *pu, struct reg
 
 // callback for rendering MACHINE_URLs
 static int registry_json_machine_url_callback(REGISTRY_MACHINE_URL *mu, struct registry_json_walk_person_urls_callback *c, STRING *hostname) {
-    if(unlikely(!asterisks))
+    if(!asterisks)
         asterisks = string_strdupz("***");
 
     struct web_client *w = c->w;
@@ -214,7 +214,7 @@ int registry_request_hello_json(RRDHOST *host, struct web_client *w) {
 
 // the main method for registering an access
 int registry_request_access_json(RRDHOST *host, struct web_client *w, char *person_guid, char *machine_guid, char *url, char *name, time_t when) {
-    if(unlikely(!registry.enabled))
+    if(!registry.enabled)
         return registry_json_disabled(host, w, "access");
 
     if(!registry_is_valid_url(url)) {
@@ -241,7 +241,7 @@ int registry_request_access_json(RRDHOST *host, struct web_client *w, char *pers
         return HTTP_RESP_OK;
     }
 
-    if(unlikely(person_guid[0] && is_dummy_person(person_guid)))
+    if(person_guid[0] && is_dummy_person(person_guid))
         // it passed the check - they gave us a different person_guid
         // empty the dummy one, so that we will generate a new person_guid
         person_guid[0] = '\0';
@@ -441,7 +441,7 @@ void registry_statistics(void) {
 
     static RRDSET *sts = NULL, *stc = NULL, *stm = NULL;
 
-    if(unlikely(!sts)) {
+    if(!sts) {
         sts = rrdset_create_localhost(
                 "netdata"
                 , "registry_sessions"
@@ -465,7 +465,7 @@ void registry_statistics(void) {
 
     // ------------------------------------------------------------------------
 
-    if(unlikely(!stc)) {
+    if(!stc) {
         stc = rrdset_create_localhost(
                 "netdata"
                 , "registry_entries"
@@ -495,7 +495,7 @@ void registry_statistics(void) {
 
     // ------------------------------------------------------------------------
 
-    if(unlikely(!stm)) {
+    if(!stm) {
         stm = rrdset_create_localhost(
                 "netdata"
                 , "registry_mem"

--- a/registry/registry_db.c
+++ b/registry/registry_db.c
@@ -106,10 +106,10 @@ static inline int registry_person_save(const DICTIONARY_ITEM *item __maybe_unuse
 // SAVE THE REGISTRY DATABASE
 
 int registry_db_save(void) {
-    if(unlikely(!registry.enabled))
+    if(!registry.enabled)
         return -1;
 
-    if(unlikely(!registry_db_should_be_saved()))
+    if(!registry_db_should_be_saved())
         return -2;
 
     error_log_limit_unlimited();
@@ -235,7 +235,7 @@ size_t registry_db_load(void) {
         netdata_log_debug(D_REGISTRY, "REGISTRY: read line %zu to length %zu: %s", line, len, s);
         switch(*s) {
             case 'U': // person URL
-                if(unlikely(!p)) {
+                if(!p) {
                     netdata_log_error("REGISTRY: ignoring line %zu, no person loaded: %s", line, s);
                     continue;
                 }
@@ -293,7 +293,7 @@ size_t registry_db_load(void) {
             case 'P': // person
                 m = NULL;
                 // verify it is valid
-                if(unlikely(len != 65 || s[1] != '\t' || s[10] != '\t' || s[19] != '\t' || s[28] != '\t' || s[65] != '\0')) {
+                if(len != 65 || s[1] != '\t' || s[10] != '\t' || s[19] != '\t' || s[28] != '\t' || s[65] != '\0') {
                     netdata_log_error("REGISTRY: person line %zu is wrong (len = %zu).", line, len);
                     continue;
                 }
@@ -306,7 +306,7 @@ size_t registry_db_load(void) {
                 break;
 
             case 'V': // machine URL
-                if(unlikely(!m)) {
+                if(!m) {
                     netdata_log_error("REGISTRY: ignoring line %zu, no machine loaded: %s", line, s);
                     continue;
                 }
@@ -345,7 +345,7 @@ size_t registry_db_load(void) {
             case 'M': // machine
                 p = NULL;
                 // verify it is valid
-                if(unlikely(len != 65 || s[1] != '\t' || s[10] != '\t' || s[19] != '\t' || s[28] != '\t' || s[65] != '\0')) {
+                if(len != 65 || s[1] != '\t' || s[10] != '\t' || s[19] != '\t' || s[28] != '\t' || s[65] != '\0') {
                     netdata_log_error("REGISTRY: person line %zu is wrong (len = %zu).", line, len);
                     continue;
                 }
@@ -358,7 +358,7 @@ size_t registry_db_load(void) {
                 break;
 
             case 'T': // totals
-                if(unlikely(len != 103 || s[1] != '\t' || s[18] != '\t' || s[35] != '\t' || s[52] != '\t' || s[69] != '\t' || s[86] != '\t' || s[103] != '\0')) {
+                if(len != 103 || s[1] != '\t' || s[18] != '\t' || s[35] != '\t' || s[52] != '\t' || s[69] != '\t' || s[86] != '\t' || s[103] != '\0') {
                     netdata_log_error("REGISTRY: totals line %zu is wrong (len = %zu).", line, len);
                     continue;
                 }

--- a/registry/registry_init.c
+++ b/registry/registry_init.c
@@ -48,7 +48,7 @@ void registry_db_stats(void) {
 
 void registry_generate_curl_urls(void) {
     FILE *fp = fopen("/tmp/registry.curl", "w+");
-    if (unlikely(!fp))
+    if (!fp)
         return;
 
     REGISTRY_PERSON *p;
@@ -179,7 +179,7 @@ int registry_init(void) {
         registry_db_load();
         registry_log_load();
 
-        if(unlikely(registry_db_should_be_saved()))
+        if(registry_db_should_be_saved())
             registry_db_save();
 
 //        registry_db_stats();

--- a/registry/registry_internals.c
+++ b/registry/registry_internals.c
@@ -12,7 +12,7 @@ struct registry registry;
 // this is used as a protection against the variations of GUIDs
 int regenerate_guid(const char *guid, char *result) {
     uuid_t uuid;
-    if(unlikely(uuid_parse(guid, uuid) == -1)) {
+    if(uuid_parse(guid, uuid) == -1) {
         netdata_log_info("Registry: GUID '%s' is not a valid GUID.", guid);
         return -1;
     }
@@ -40,7 +40,7 @@ static inline char *registry_fix_machine_name(char *name, size_t *len) {
     // make sure all spaces are a SPACE
     char *t = s;
     while(*t) {
-        if(unlikely(isspace(*t)))
+        if(isspace(*t))
             *t = ' ';
 
         t++;
@@ -55,7 +55,7 @@ static inline char *registry_fix_machine_name(char *name, size_t *len) {
     }
     t++;
 
-    if(likely(len))
+    if(len)
         *len = (t - s);
 
     return s;
@@ -273,7 +273,7 @@ char *registry_get_this_machine_hostname(void) {
 char *registry_get_this_machine_guid(void) {
     static char guid[GUID_LEN + 1] = "";
 
-    if(likely(guid[0]))
+    if(guid[0])
         return guid;
 
     // read it from disk

--- a/registry/registry_log.c
+++ b/registry/registry_log.c
@@ -4,14 +4,14 @@
 #include "registry_internals.h"
 
 void registry_log(char action, REGISTRY_PERSON *p, REGISTRY_MACHINE *m, STRING *u, const char *name) {
-    if(likely(registry.log_fp)) {
-        if(unlikely(fprintf(registry.log_fp, "%c\t%08x\t%s\t%s\t%s\t%s\n",
+    if(registry.log_fp) {
+        if(fprintf(registry.log_fp, "%c\t%08x\t%s\t%s\t%s\t%s\n",
                 action,
                 p->last_t,
                 p->guid,
                 m->guid,
                 name,
-                string2str(u)) < 0))
+                string2str(u)) < 0)
             netdata_log_error("Registry: failed to save log. Registry data may be lost in case of abnormal restart.");
 
         // we increase the counter even on failures
@@ -21,7 +21,7 @@ void registry_log(char action, REGISTRY_PERSON *p, REGISTRY_MACHINE *m, STRING *
         // this must be outside the log_lock(), or a deadlock will happen.
         // registry_db_save() checks the same inside the log_lock, so only
         // one thread will save the db
-        if(unlikely(registry_db_should_be_saved()))
+        if(registry_db_should_be_saved())
             registry_db_save();
     }
 }
@@ -87,7 +87,7 @@ ssize_t registry_log_load(void) {
                 case 'D': // deletes
 
                     // verify it is valid
-                    if (unlikely(len < 85 || s[1] != '\t' || s[10] != '\t' || s[47] != '\t' || s[84] != '\t')) {
+                    if (len < 85 || s[1] != '\t' || s[10] != '\t' || s[47] != '\t' || s[84] != '\t') {
                         netdata_log_error("Registry: log line %zd is wrong (len = %zu).", line, len);
                         continue;
                     }

--- a/registry/registry_machine.c
+++ b/registry/registry_machine.c
@@ -70,10 +70,10 @@ REGISTRY_MACHINE *registry_machine_allocate(const char *machine_guid, time_t whe
 REGISTRY_MACHINE *registry_machine_find_or_create(const char *machine_guid, time_t when, bool is_dummy __maybe_unused) {
     REGISTRY_MACHINE *m = NULL;
 
-    if(likely(machine_guid && *machine_guid)) {
+    if(machine_guid && *machine_guid) {
         // validate it is a GUID
         char buf[GUID_LEN + 1];
-        if(unlikely(regenerate_guid(machine_guid, buf) == -1))
+        if(regenerate_guid(machine_guid, buf) == -1)
             netdata_log_info("REGISTRY: machine guid '%s' is not a valid guid. Ignoring it.", machine_guid);
         else {
             machine_guid = buf;
@@ -101,11 +101,11 @@ REGISTRY_MACHINE_URL *registry_machine_link_to_url(REGISTRY_MACHINE *m, STRING *
     else {
         netdata_log_debug(D_REGISTRY, "REGISTRY: registry_machine_link_to_url('%s', '%s'): found", m->guid, string2str(url));
         mu->usages++;
-        if(likely(mu->last_t < (uint32_t)when)) mu->last_t = (uint32_t)when;
+        if(mu->last_t < (uint32_t)when) mu->last_t = (uint32_t)when;
     }
 
     m->usages++;
-    if(likely(m->last_t < (uint32_t)when)) m->last_t = (uint32_t)when;
+    if(m->last_t < (uint32_t)when) m->last_t = (uint32_t)when;
 
     if(mu->flags & REGISTRY_URL_FLAGS_EXPIRED) {
         netdata_log_debug(D_REGISTRY, "REGISTRY: registry_machine_link_to_url('%s', '%s'): accessing an expired URL.", m->guid, string2str(url));

--- a/registry/registry_person.c
+++ b/registry/registry_person.c
@@ -158,7 +158,7 @@ REGISTRY_PERSON *registry_person_find_or_create(const char *person_guid, time_t 
 
     if(person_guid && *person_guid) {
         // validate it is a GUID
-        if(unlikely(regenerate_guid(person_guid, buf) == -1)) {
+        if(regenerate_guid(person_guid, buf) == -1) {
             netdata_log_info("Registry: person guid '%s' is not a valid guid. Ignoring it.", person_guid);
             person_guid = NULL;
         }
@@ -192,7 +192,7 @@ REGISTRY_PERSON_URL *registry_person_link_to_url(REGISTRY_PERSON *p, REGISTRY_MA
     else {
         netdata_log_debug(D_REGISTRY, "registry_person_link_to_url('%s', '%s', '%s'): found", p->guid, m->guid, string2str(url));
         pu->usages++;
-        if(likely(pu->last_t < (uint32_t)when)) pu->last_t = (uint32_t)when;
+        if(pu->last_t < (uint32_t)when) pu->last_t = (uint32_t)when;
 
         if(pu->machine != m) {
             REGISTRY_MACHINE_URL *mu = registry_machine_url_find(pu->machine, url);
@@ -217,7 +217,7 @@ REGISTRY_PERSON_URL *registry_person_link_to_url(REGISTRY_PERSON *p, REGISTRY_MA
     }
 
     p->usages++;
-    if(likely(p->last_t < (uint32_t)when)) p->last_t = (uint32_t)when;
+    if(p->last_t < (uint32_t)when) p->last_t = (uint32_t)when;
 
     if(pu->flags & REGISTRY_URL_FLAGS_EXPIRED) {
         netdata_log_debug(D_REGISTRY, "registry_person_link_to_url('%s', '%s', '%s'): accessing an expired URL. Re-enabling URL.", p->guid, m->guid, string2str(url));

--- a/spawn/spawn_server.c
+++ b/spawn/spawn_server.c
@@ -235,7 +235,7 @@ static void server_parse_spawn_protocol(unsigned source_len, char *source)
         command_length = payload->command_length;
 
         required_len += command_length;
-        if (unlikely(required_len > MAX_COMMAND_LENGTH - 1)) {
+        if (required_len > MAX_COMMAND_LENGTH - 1) {
             fprintf(stderr, "SPAWN: Ran out of protocol buffer space.\n");
             command_length = (MAX_COMMAND_LENGTH - 1) - (sizeof(*header) + sizeof(*payload));
             required_len = MAX_COMMAND_LENGTH - 1;

--- a/streaming/compression.c
+++ b/streaming/compression.c
@@ -48,10 +48,10 @@ void rrdpush_compressor_destroy(struct compressor_state *state) {
  * or 0 in case of error
  */
 size_t rrdpush_compress(struct compressor_state *state, const char *data, size_t size, char **out) {
-    if(unlikely(!state || !size || !out))
+    if(!state || !size || !out)
         return 0;
 
-    if(unlikely(size > COMPRESSION_MAX_MSG_SIZE)) {
+    if(size > COMPRESSION_MAX_MSG_SIZE) {
         netdata_log_error("RRDPUSH COMPRESS: Compression Failed - Message size %lu above compression buffer limit: %d",
               (long unsigned int)size, COMPRESSION_MAX_MSG_SIZE);
         return 0;
@@ -64,7 +64,7 @@ size_t rrdpush_compress(struct compressor_state *state, const char *data, size_t
         state->compression_result_buffer = mallocz(data_size);
         state->compression_result_buffer_size = data_size;
     }
-    else if(unlikely(state->compression_result_buffer_size < data_size)) {
+    else if(state->compression_result_buffer_size < data_size) {
         state->compression_result_buffer = reallocz(state->compression_result_buffer, data_size);
         state->compression_result_buffer_size = data_size;
     }
@@ -89,7 +89,7 @@ size_t rrdpush_compress(struct compressor_state *state, const char *data, size_t
 
     // update the next writing position of the ring buffer
     state->stream.input_ring_buffer_pos += size;
-    if(unlikely(state->stream.input_ring_buffer_pos >= state->stream.input_ring_buffer_size - COMPRESSION_MAX_MSG_SIZE))
+    if(state->stream.input_ring_buffer_pos >= state->stream.input_ring_buffer_size - COMPRESSION_MAX_MSG_SIZE)
         state->stream.input_ring_buffer_pos = 0;
 
     // update the signature header
@@ -105,13 +105,13 @@ size_t rrdpush_compress(struct compressor_state *state, const char *data, size_t
  * Return the size of uncompressed data or 0 for error
  */
 size_t rrdpush_decompress(struct decompressor_state *state, const char *compressed_data, size_t compressed_size) {
-    if (unlikely(!state || !compressed_data || !compressed_size))
+    if (!state || !compressed_data || !compressed_size)
         return 0;
 
-    if(unlikely(state->stream.read_at != state->stream.write_at))
+    if(state->stream.read_at != state->stream.write_at)
         fatal("RRDPUSH_DECOMPRESS: asked to decompress new data, while there are unread data in the decompression buffer!");
 
-    if (unlikely(state->stream.write_at >= state->stream.size / 2)) {
+    if (state->stream.write_at >= state->stream.size / 2) {
         state->stream.write_at = 0;
         state->stream.read_at = 0;
     }
@@ -124,12 +124,12 @@ size_t rrdpush_decompress(struct decompressor_state *state, const char *compress
             , (int)(state->stream.size - state->stream.write_at)
             );
 
-    if (unlikely(decompressed_size < 0)) {
+    if (decompressed_size < 0) {
         netdata_log_error("RRDPUSH DECOMPRESS: decompressor returned negative decompressed bytes: %ld", decompressed_size);
         return 0;
     }
 
-    if(unlikely(decompressed_size + state->stream.write_at > state->stream.size))
+    if(decompressed_size + state->stream.write_at > state->stream.size)
         fatal("RRDPUSH DECOMPRESS: decompressor overflown the stream_buffer. size: %zu, pos: %zu, added: %ld, "
               "exceeding the buffer by %zu"
               , state->stream.size
@@ -164,7 +164,7 @@ void rrdpush_decompressor_reset(struct decompressor_state *state) {
 }
 
 void rrdpush_decompressor_destroy(struct decompressor_state *state) {
-    if(unlikely(!state->initialized))
+    if(!state->initialized)
         return;
 
     if (state->stream.lz4_stream) {

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -162,14 +162,14 @@ void rrdpush_decompressor_reset(struct decompressor_state *state);
 size_t rrdpush_decompress(struct decompressor_state *state, const char *compressed_data, size_t compressed_size);
 
 static inline size_t rrdpush_decompress_decode_header(const char *data, size_t data_size) {
-    if (unlikely(!data || !data_size))
+    if (!data || !data_size)
         return 0;
 
-    if (unlikely(data_size != RRDPUSH_COMPRESSION_SIGNATURE_SIZE))
+    if (data_size != RRDPUSH_COMPRESSION_SIGNATURE_SIZE)
         return 0;
 
     uint32_t sign = *(uint32_t *)data;
-    if (unlikely((sign & RRDPUSH_COMPRESSION_SIGNATURE_MASK) != RRDPUSH_COMPRESSION_SIGNATURE))
+    if ((sign & RRDPUSH_COMPRESSION_SIGNATURE_MASK) != RRDPUSH_COMPRESSION_SIGNATURE)
         return 0;
 
     size_t length = ((sign >> 8) & 0x7f) | ((sign >> 9) & (0x7f << 7));
@@ -177,26 +177,26 @@ static inline size_t rrdpush_decompress_decode_header(const char *data, size_t d
 }
 
 static inline size_t rrdpush_decompressor_start(struct decompressor_state *state, const char *header, size_t header_size) {
-    if(unlikely(state->stream.read_at != state->stream.write_at))
+    if(state->stream.read_at != state->stream.write_at)
         fatal("RRDPUSH DECOMPRESS: asked to decompress new data, while there are unread data in the decompression buffer!");
 
     return rrdpush_decompress_decode_header(header, header_size);
 }
 
 static inline size_t rrdpush_decompressed_bytes_in_buffer(struct decompressor_state *state) {
-    if(unlikely(state->stream.read_at > state->stream.write_at))
+    if(state->stream.read_at > state->stream.write_at)
         fatal("RRDPUSH DECOMPRESS: invalid read/write stream positions");
 
     return state->stream.write_at - state->stream.read_at;
 }
 
 static inline size_t rrdpush_decompressor_get(struct decompressor_state *state, char *dst, size_t size) {
-    if (unlikely(!state || !size || !dst))
+    if (!state || !size || !dst)
         return 0;
 
     size_t remaining = rrdpush_decompressed_bytes_in_buffer(state);
 
-    if(unlikely(!remaining))
+    if(!remaining)
         return 0;
 
     size_t bytes_to_return = size;
@@ -206,7 +206,7 @@ static inline size_t rrdpush_decompressor_get(struct decompressor_state *state, 
     memcpy(dst, state->stream.buffer + state->stream.read_at, bytes_to_return);
     state->stream.read_at += bytes_to_return;
 
-    if(unlikely(state->stream.read_at > state->stream.write_at))
+    if(state->stream.read_at > state->stream.write_at)
         fatal("RRDPUSH DECOMPRESS: invalid read/write stream positions");
 
     return bytes_to_return;

--- a/tests/profile/benchmark-line-parsing.c
+++ b/tests/profile/benchmark-line-parsing.c
@@ -6,8 +6,8 @@
 #include <ctype.h>
 #include <sys/time.h>
 
-#define likely(x) __builtin_expect(!!(x), 1)
-#define unlikely(x) __builtin_expect(!!(x), 0)
+#define x __builtin_expect(!!(x), 1)
+#define x __builtin_expect(!!(x), 0)
 
 #define simple_hash(name) ({                                         \
     register unsigned char *__hash_source = (unsigned char *)(name); \
@@ -136,37 +136,37 @@ void test1() {
   for(i = 0; strings[i] ; i++) {
     char *s = strings[i];
 
-    if(unlikely(!strcmp(s, "cache")))
+    if(!strcmp(s, "cache"))
       values1[i] = strtoull(NUMBER1, NULL, 10);
 
-    else if(unlikely(!strcmp(s, "rss")))
+    else if(!strcmp(s, "rss"))
       values1[i] = strtoull(NUMBER2, NULL, 10);
     
-    else if(unlikely(!strcmp(s, "rss_huge")))
+    else if(!strcmp(s, "rss_huge"))
       values1[i] = strtoull(NUMBER3, NULL, 10);
   
-    else if(unlikely(!strcmp(s, "mapped_file")))
+    else if(!strcmp(s, "mapped_file"))
       values1[i] = strtoull(NUMBER4, NULL, 10);
     
-    else if(unlikely(!strcmp(s, "writeback")))
+    else if(!strcmp(s, "writeback"))
       values1[i] = strtoull(NUMBER5, NULL, 10);
     
-    else if(unlikely(!strcmp(s, "dirty")))
+    else if(!strcmp(s, "dirty"))
       values1[i] = strtoull(NUMBER6, NULL, 10);
     
-    else if(unlikely(!strcmp(s, "swap")))
+    else if(!strcmp(s, "swap"))
       values1[i] = strtoull(NUMBER7, NULL, 10);
     
-    else if(unlikely(!strcmp(s, "pgpgin")))
+    else if(!strcmp(s, "pgpgin"))
       values1[i] = strtoull(NUMBER8, NULL, 10);
     
-    else if(unlikely(!strcmp(s, "pgpgout")))
+    else if(!strcmp(s, "pgpgout"))
       values1[i] = strtoull(NUMBER9, NULL, 10);
     
-    else if(unlikely(!strcmp(s, "pgfault")))
+    else if(!strcmp(s, "pgfault"))
       values1[i] = strtoull(NUMBER10, NULL, 10);
     
-    else if(unlikely(!strcmp(s, "pgmajfault")))
+    else if(!strcmp(s, "pgmajfault"))
       values1[i] = strtoull(NUMBER11, NULL, 10);
   }
 }
@@ -178,37 +178,37 @@ void test2() {
     char *s = strings[i];
     uint32_t hash = simple_hash2(s);
 
-    if(unlikely(hash == cache_hash && !strcmp(s, "cache")))
+    if(hash == cache_hash && !strcmp(s, "cache"))
       values2[i] = strtoull(NUMBER1, NULL, 10);
     
-    else if(unlikely(hash == rss_hash && !strcmp(s, "rss")))
+    else if(hash == rss_hash && !strcmp(s, "rss"))
       values2[i] = strtoull(NUMBER2, NULL, 10);
     
-    else if(unlikely(hash == rss_huge_hash && !strcmp(s, "rss_huge")))
+    else if(hash == rss_huge_hash && !strcmp(s, "rss_huge"))
       values2[i] = strtoull(NUMBER3, NULL, 10);
     
-    else if(unlikely(hash == mapped_file_hash && !strcmp(s, "mapped_file")))
+    else if(hash == mapped_file_hash && !strcmp(s, "mapped_file"))
       values2[i] = strtoull(NUMBER4, NULL, 10);
     
-    else if(unlikely(hash == writeback_hash && !strcmp(s, "writeback")))
+    else if(hash == writeback_hash && !strcmp(s, "writeback"))
       values2[i] = strtoull(NUMBER5, NULL, 10);
     
-    else if(unlikely(hash == dirty_hash && !strcmp(s, "dirty")))
+    else if(hash == dirty_hash && !strcmp(s, "dirty"))
       values2[i] = strtoull(NUMBER6, NULL, 10);
     
-    else if(unlikely(hash == swap_hash && !strcmp(s, "swap")))
+    else if(hash == swap_hash && !strcmp(s, "swap"))
       values2[i] = strtoull(NUMBER7, NULL, 10);
   
-    else if(unlikely(hash == pgpgin_hash && !strcmp(s, "pgpgin")))
+    else if(hash == pgpgin_hash && !strcmp(s, "pgpgin"))
       values2[i] = strtoull(NUMBER8, NULL, 10);
     
-    else if(unlikely(hash == pgpgout_hash && !strcmp(s, "pgpgout")))
+    else if(hash == pgpgout_hash && !strcmp(s, "pgpgout"))
       values2[i] = strtoull(NUMBER9, NULL, 10);
     
-    else if(unlikely(hash == pgfault_hash && !strcmp(s, "pgfault")))
+    else if(hash == pgfault_hash && !strcmp(s, "pgfault"))
       values2[i] = strtoull(NUMBER10, NULL, 10);
     
-    else if(unlikely(hash == pgmajfault_hash && !strcmp(s, "pgmajfault")))
+    else if(hash == pgmajfault_hash && !strcmp(s, "pgmajfault"))
       values2[i] = strtoull(NUMBER11, NULL, 10);
   }
 }
@@ -220,37 +220,37 @@ void test3() {
     char *s = strings[i];
     uint32_t hash = simple_hash(s);
 
-    if(unlikely(hash == cache_hash && !strcmp(s, "cache")))
+    if(hash == cache_hash && !strcmp(s, "cache"))
       values3[i] = strtoull(NUMBER1, NULL, 10);
     
-    else if(unlikely(hash == rss_hash && !strcmp(s, "rss")))
+    else if(hash == rss_hash && !strcmp(s, "rss"))
       values3[i] = strtoull(NUMBER2, NULL, 10);
     
-    else if(unlikely(hash == rss_huge_hash && !strcmp(s, "rss_huge")))
+    else if(hash == rss_huge_hash && !strcmp(s, "rss_huge"))
       values3[i] = strtoull(NUMBER3, NULL, 10);
     
-    else if(unlikely(hash == mapped_file_hash && !strcmp(s, "mapped_file")))
+    else if(hash == mapped_file_hash && !strcmp(s, "mapped_file"))
       values3[i] = strtoull(NUMBER4, NULL, 10);
     
-    else if(unlikely(hash == writeback_hash && !strcmp(s, "writeback")))
+    else if(hash == writeback_hash && !strcmp(s, "writeback"))
       values3[i] = strtoull(NUMBER5, NULL, 10);
     
-    else if(unlikely(hash == dirty_hash && !strcmp(s, "dirty")))
+    else if(hash == dirty_hash && !strcmp(s, "dirty"))
       values3[i] = strtoull(NUMBER6, NULL, 10);
     
-    else if(unlikely(hash == swap_hash && !strcmp(s, "swap")))
+    else if(hash == swap_hash && !strcmp(s, "swap"))
       values3[i] = strtoull(NUMBER7, NULL, 10);
     
-    else if(unlikely(hash == pgpgin_hash && !strcmp(s, "pgpgin")))
+    else if(hash == pgpgin_hash && !strcmp(s, "pgpgin"))
       values3[i] = strtoull(NUMBER8, NULL, 10);
     
-    else if(unlikely(hash == pgpgout_hash && !strcmp(s, "pgpgout")))
+    else if(hash == pgpgout_hash && !strcmp(s, "pgpgout"))
       values3[i] = strtoull(NUMBER9, NULL, 10);
     
-    else if(unlikely(hash == pgfault_hash && !strcmp(s, "pgfault")))
+    else if(hash == pgfault_hash && !strcmp(s, "pgfault"))
       values3[i] = strtoull(NUMBER10, NULL, 10);
     
-    else if(unlikely(hash == pgmajfault_hash && !strcmp(s, "pgmajfault")))
+    else if(hash == pgmajfault_hash && !strcmp(s, "pgmajfault"))
       values3[i] = strtoull(NUMBER11, NULL, 10);
   }
 }
@@ -263,57 +263,57 @@ void test4() {
     char *s = strings[i];
     uint32_t hash = simple_hash2(s);
 
-    if(unlikely(hash == cache_hash && !strcmp(s, "cache"))) {
+    if(hash == cache_hash && !strcmp(s, "cache")) {
       values4[i] = strtoull(NUMBER1, NULL, 0);
       continue;
     }
 
-    if(unlikely(hash == rss_hash && !strcmp(s, "rss"))) {
+    if(hash == rss_hash && !strcmp(s, "rss")) {
       values4[i] = strtoull(NUMBER2, NULL, 0);
       continue;
     }
     
-    if(unlikely(hash == rss_huge_hash && !strcmp(s, "rss_huge"))) {
+    if(hash == rss_huge_hash && !strcmp(s, "rss_huge")) {
       values4[i] = strtoull(NUMBER3, NULL, 0);
       continue;
     }
     
-    if(unlikely(hash == mapped_file_hash && !strcmp(s, "mapped_file"))) {
+    if(hash == mapped_file_hash && !strcmp(s, "mapped_file")) {
       values4[i] = strtoull(NUMBER4, NULL, 0);
       continue;
     }
     
-    if(unlikely(hash == writeback_hash && !strcmp(s, "writeback"))) {
+    if(hash == writeback_hash && !strcmp(s, "writeback")) {
       values4[i] = strtoull(NUMBER5, NULL, 0);
       continue;
     }
     
-    if(unlikely(hash == dirty_hash && !strcmp(s, "dirty"))) {
+    if(hash == dirty_hash && !strcmp(s, "dirty")) {
       values4[i] = strtoull(NUMBER6, NULL, 0);
       continue;
     }
     
-    if(unlikely(hash == swap_hash && !strcmp(s, "swap"))) {
+    if(hash == swap_hash && !strcmp(s, "swap")) {
       values4[i] = strtoull(NUMBER7, NULL, 0);
       continue;
     }
     
-    if(unlikely(hash == pgpgin_hash && !strcmp(s, "pgpgin"))) {
+    if(hash == pgpgin_hash && !strcmp(s, "pgpgin")) {
       values4[i] = strtoull(NUMBER8, NULL, 0);
       continue;
     }
     
-    if(unlikely(hash == pgpgout_hash && !strcmp(s, "pgpgout"))) {
+    if(hash == pgpgout_hash && !strcmp(s, "pgpgout")) {
       values4[i] = strtoull(NUMBER9, NULL, 0);
       continue;
     }
     
-    if(unlikely(hash == pgfault_hash && !strcmp(s, "pgfault"))) {
+    if(hash == pgfault_hash && !strcmp(s, "pgfault")) {
       values4[i] = strtoull(NUMBER10, NULL, 0);
       continue;
     }
     
-    if(unlikely(hash == pgmajfault_hash && !strcmp(s, "pgmajfault"))) {
+    if(hash == pgmajfault_hash && !strcmp(s, "pgmajfault")) {
       values4[i] = strtoull(NUMBER11, NULL, 0);
       continue;
     }
@@ -327,37 +327,37 @@ void test5() {
     char *s = strings[i];
     uint32_t hash = simple_hash2(s);
 
-    if(unlikely(hash == cache_hash && !strcmp(s, "cache")))
+    if(hash == cache_hash && !strcmp(s, "cache"))
       values5[i] = fast_strtoull(NUMBER1);
     
-    else if(unlikely(hash == rss_hash && !strcmp(s, "rss")))
+    else if(hash == rss_hash && !strcmp(s, "rss"))
       values5[i] = fast_strtoull(NUMBER2);
     
-    else if(unlikely(hash == rss_huge_hash && !strcmp(s, "rss_huge")))
+    else if(hash == rss_huge_hash && !strcmp(s, "rss_huge"))
       values5[i] = fast_strtoull(NUMBER3);
     
-    else if(unlikely(hash == mapped_file_hash && !strcmp(s, "mapped_file")))
+    else if(hash == mapped_file_hash && !strcmp(s, "mapped_file"))
       values5[i] = fast_strtoull(NUMBER4);
     
-    else if(unlikely(hash == writeback_hash && !strcmp(s, "writeback")))
+    else if(hash == writeback_hash && !strcmp(s, "writeback"))
       values5[i] = fast_strtoull(NUMBER5);
     
-    else if(unlikely(hash == dirty_hash && !strcmp(s, "dirty")))
+    else if(hash == dirty_hash && !strcmp(s, "dirty"))
       values5[i] = fast_strtoull(NUMBER6);
     
-    else if(unlikely(hash == swap_hash && !strcmp(s, "swap")))
+    else if(hash == swap_hash && !strcmp(s, "swap"))
       values5[i] = fast_strtoull(NUMBER7);
   
-    else if(unlikely(hash == pgpgin_hash && !strcmp(s, "pgpgin")))
+    else if(hash == pgpgin_hash && !strcmp(s, "pgpgin"))
       values5[i] = fast_strtoull(NUMBER8);
     
-    else if(unlikely(hash == pgpgout_hash && !strcmp(s, "pgpgout")))
+    else if(hash == pgpgout_hash && !strcmp(s, "pgpgout"))
       values5[i] = fast_strtoull(NUMBER9);
     
-    else if(unlikely(hash == pgfault_hash && !strcmp(s, "pgfault")))
+    else if(hash == pgfault_hash && !strcmp(s, "pgfault"))
       values5[i] = fast_strtoull(NUMBER10);
     
-    else if(unlikely(hash == pgmajfault_hash && !strcmp(s, "pgmajfault")))
+    else if(hash == pgmajfault_hash && !strcmp(s, "pgmajfault"))
       values5[i] = fast_strtoull(NUMBER11);
   }
 }
@@ -421,7 +421,7 @@ static inline struct base *entry(struct base *base, const char *name, void *data
 static inline int check(struct base *base, const char *s) {
   uint32_t hash = simple_hash2(s);
 
-  if(likely(!strcmp(s, base->last->name))) {
+  if(!strcmp(s, base->last->name)) {
     base->last->found = 1;
     base->found++;
     if(base->last->func) base->last->func(base->last->data1, base->last->data2);
@@ -503,7 +503,7 @@ static inline int check(struct base *base, const char *s) {
 
 static inline void begin(struct base *base) {
 
-  if(unlikely(base->iteration % 60) == 1) {
+  if(base->iteration % 60 == 1) {
     base->wanted = 0;
     struct entry *e;
     for(e = base->entries; e ; e = e->next)
@@ -519,7 +519,7 @@ void test6() {
 
   static struct base *base = NULL;
 
-  if(unlikely(!base)) {
+  if(!base) {
     base = entry(base, "cache", NUMBER1, &values6[0], callback_system_strtoull);
     base = entry(base, "rss", NUMBER2, &values6[1], callback_system_strtoull);
     base = entry(base, "rss_huge", NUMBER3, &values6[2], callback_system_strtoull);
@@ -546,7 +546,7 @@ void test7() {
 
     static struct base *base = NULL;
 
-    if(unlikely(!base)) {
+    if(!base) {
         base = entry(base, "cache", NUMBER1, &values6[0], callback);
         base = entry(base, "rss", NUMBER2, &values6[1], callback);
         base = entry(base, "rss_huge", NUMBER3, &values6[2], callback);
@@ -595,14 +595,14 @@ static unsigned long long clk;
 
 static void begin_clock() {
     struct timeval tv;
-    if(unlikely(gettimeofday(&tv, NULL) == -1))
+    if(gettimeofday(&tv, NULL) == -1)
         return;
     clk = tv.tv_sec  * 1000000 + tv.tv_usec;
 }
 
 static unsigned long long end_clock() {
     struct timeval tv;
-    if(unlikely(gettimeofday(&tv, NULL) == -1))
+    if(gettimeofday(&tv, NULL) == -1)
         return -1;
     return clk = tv.tv_sec  * 1000000 + tv.tv_usec - clk;
 }

--- a/tests/profile/benchmark-procfile-parser.c
+++ b/tests/profile/benchmark-procfile-parser.c
@@ -38,7 +38,7 @@ static inline void pfwords_add(procfile *ff, char *str) {
     // netdata_log_debug(D_PROCFILE, PF_PREFIX ":   adding word No %d: '%s'", fw->len, str);
 
     pfwords *fw = ff->words;
-    if(unlikely(fw->len == fw->size)) {
+    if(fw->len == fw->size) {
         // netdata_log_debug(D_PROCFILE, PF_PREFIX ":   expanding words");
 
         ff->words = fw = reallocz(fw, sizeof(pfwords) + (fw->size + PFWORDS_INCREASE_STEP) * sizeof(char *));
@@ -53,7 +53,7 @@ static inline size_t *pflines_add(procfile *ff) {
     // netdata_log_debug(D_PROCFILE, PF_PREFIX ":   adding line %d at word %d", fl->len, first_word);
 
     pflines *fl = ff->lines;
-    if(unlikely(fl->len == fl->size)) {
+    if(fl->len == fl->size) {
         // netdata_log_debug(D_PROCFILE, PF_PREFIX ":   expanding lines");
 
         ff->lines = fl = reallocz(fl, sizeof(pflines) + (fl->size + PFLINES_INCREASE_STEP) * sizeof(ffline));
@@ -121,12 +121,12 @@ static void procfile_parser(procfile *ff) {
 		    	break;
 
 		    case PF_CHAR_IS_QUOTE:
-		        if(unlikely(!quote && s == t)) {
+		        if(!quote && s == t) {
 		            // quote opened at the beginning
 		            quote = *s;
 		            t = ++s;
 		        }
-		        else if(unlikely(quote && quote == *s)) {
+		        else if(quote && quote == *s) {
 		            // quote closed
 		            quote = 0;
 
@@ -174,9 +174,9 @@ static void procfile_parser(procfile *ff) {
     	}
 	}
 
-    if(likely(s > t && t < e)) {
+    if(s > t && t < e) {
         // the last word
-        if(unlikely(ff->len >= ff->size)) {
+        if(ff->len >= ff->size) {
             // we are going to loose the last byte
             s = &ff->data[ff->size - 1];
         }
@@ -198,7 +198,7 @@ procfile *procfile_readall1(procfile *ff) {
         ssize_t s = ff->len;
         ssize_t x = ff->size - s;
 
-        if(unlikely(!x)) {
+        if(!x) {
             netdata_log_debug(D_PROCFILE, PF_PREFIX ": Expanding data buffer for file '%s'.", procfile_filename(ff));
             ff = reallocz(ff, sizeof(procfile) + ff->size + PROCFILE_INCREMENT_BUFFER);
             ff->size += PROCFILE_INCREMENT_BUFFER;
@@ -206,8 +206,8 @@ procfile *procfile_readall1(procfile *ff) {
 
         netdata_log_debug(D_PROCFILE, "Reading file '%s', from position %zd with length %zd", procfile_filename(ff), s, (ssize_t)(ff->size - s));
         r = read(ff->fd, &ff->data[s], ff->size - s);
-        if(unlikely(r == -1)) {
-            if(unlikely(!(ff->flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) netdata_log_error(PF_PREFIX ": Cannot read from file '%s' on fd %d", procfile_filename(ff), ff->fd);
+        if(r == -1) {
+            if(!(ff->flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO)) netdata_log_error(PF_PREFIX ": Cannot read from file '%s' on fd %d", procfile_filename(ff), ff->fd);
             procfile_close(ff);
             return NULL;
         }
@@ -216,8 +216,8 @@ procfile *procfile_readall1(procfile *ff) {
     }
 
     // netdata_log_debug(D_PROCFILE, "Rewinding file '%s'", ff->filename);
-    if(unlikely(lseek(ff->fd, 0, SEEK_SET) == -1)) {
-        if(unlikely(!(ff->flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) netdata_log_error(PF_PREFIX ": Cannot rewind on file '%s'.", procfile_filename(ff));
+    if(lseek(ff->fd, 0, SEEK_SET) == -1) {
+        if(!(ff->flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO)) netdata_log_error(PF_PREFIX ": Cannot rewind on file '%s'.", procfile_filename(ff));
         procfile_close(ff);
         return NULL;
     }
@@ -226,10 +226,10 @@ procfile *procfile_readall1(procfile *ff) {
     pfwords_reset(ff->words);
     procfile_parser(ff);
 
-    if(unlikely(procfile_adaptive_initial_allocation)) {
-        if(unlikely(ff->len > procfile_max_allocation)) procfile_max_allocation = ff->len;
-        if(unlikely(ff->lines->len > procfile_max_lines)) procfile_max_lines = ff->lines->len;
-        if(unlikely(ff->words->len > procfile_max_words)) procfile_max_words = ff->words->len;
+    if(procfile_adaptive_initial_allocation) {
+        if(ff->len > procfile_max_allocation) procfile_max_allocation = ff->len;
+        if(ff->lines->len > procfile_max_lines) procfile_max_lines = ff->lines->len;
+        if(ff->words->len > procfile_max_words) procfile_max_words = ff->words->len;
     }
 
     // netdata_log_debug(D_PROCFILE, "File '%s' updated.", ff->filename);

--- a/tests/profile/benchmark-value-pairs.c
+++ b/tests/profile/benchmark-value-pairs.c
@@ -136,37 +136,37 @@ void test1() {
     const char *s = pairs[i].name;
     const char *v = pairs[i].value;
 
-    if(unlikely(!strcmp(s, "cache")))
+    if(!strcmp(s, "cache"))
       values1[i] = strtoull(v, NULL, 10);
 
-    else if(unlikely(!strcmp(s, "rss")))
+    else if(!strcmp(s, "rss"))
       values1[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(!strcmp(s, "rss_huge")))
+    else if(!strcmp(s, "rss_huge"))
       values1[i] = strtoull(v, NULL, 10);
   
-    else if(unlikely(!strcmp(s, "mapped_file")))
+    else if(!strcmp(s, "mapped_file"))
       values1[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(!strcmp(s, "writeback")))
+    else if(!strcmp(s, "writeback"))
       values1[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(!strcmp(s, "dirty")))
+    else if(!strcmp(s, "dirty"))
       values1[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(!strcmp(s, "swap")))
+    else if(!strcmp(s, "swap"))
       values1[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(!strcmp(s, "pgpgin")))
+    else if(!strcmp(s, "pgpgin"))
       values1[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(!strcmp(s, "pgpgout")))
+    else if(!strcmp(s, "pgpgout"))
       values1[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(!strcmp(s, "pgfault")))
+    else if(!strcmp(s, "pgfault"))
       values1[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(!strcmp(s, "pgmajfault")))
+    else if(!strcmp(s, "pgmajfault"))
       values1[i] = strtoull(v, NULL, 10);
   }
 }
@@ -180,37 +180,37 @@ void test2() {
 
     uint32_t hash = simple_hash2(s);
 
-    if(unlikely(hash == cache_hash && !strcmp(s, "cache")))
+    if(hash == cache_hash && !strcmp(s, "cache"))
       values2[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == rss_hash && !strcmp(s, "rss")))
+    else if(hash == rss_hash && !strcmp(s, "rss"))
       values2[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == rss_huge_hash && !strcmp(s, "rss_huge")))
+    else if(hash == rss_huge_hash && !strcmp(s, "rss_huge"))
       values2[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == mapped_file_hash && !strcmp(s, "mapped_file")))
+    else if(hash == mapped_file_hash && !strcmp(s, "mapped_file"))
       values2[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == writeback_hash && !strcmp(s, "writeback")))
+    else if(hash == writeback_hash && !strcmp(s, "writeback"))
       values2[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == dirty_hash && !strcmp(s, "dirty")))
+    else if(hash == dirty_hash && !strcmp(s, "dirty"))
       values2[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == swap_hash && !strcmp(s, "swap")))
+    else if(hash == swap_hash && !strcmp(s, "swap"))
       values2[i] = strtoull(v, NULL, 10);
   
-    else if(unlikely(hash == pgpgin_hash && !strcmp(s, "pgpgin")))
+    else if(hash == pgpgin_hash && !strcmp(s, "pgpgin"))
       values2[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == pgpgout_hash && !strcmp(s, "pgpgout")))
+    else if(hash == pgpgout_hash && !strcmp(s, "pgpgout"))
       values2[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == pgfault_hash && !strcmp(s, "pgfault")))
+    else if(hash == pgfault_hash && !strcmp(s, "pgfault"))
       values2[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == pgmajfault_hash && !strcmp(s, "pgmajfault")))
+    else if(hash == pgmajfault_hash && !strcmp(s, "pgmajfault"))
       values2[i] = strtoull(v, NULL, 10);
   }
 }
@@ -224,37 +224,37 @@ void test3() {
 
     uint32_t hash = simple_hash(s);
 
-    if(unlikely(hash == cache_hash && !strcmp(s, "cache")))
+    if(hash == cache_hash && !strcmp(s, "cache"))
       values3[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == rss_hash && !strcmp(s, "rss")))
+    else if(hash == rss_hash && !strcmp(s, "rss"))
       values3[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == rss_huge_hash && !strcmp(s, "rss_huge")))
+    else if(hash == rss_huge_hash && !strcmp(s, "rss_huge"))
       values3[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == mapped_file_hash && !strcmp(s, "mapped_file")))
+    else if(hash == mapped_file_hash && !strcmp(s, "mapped_file"))
       values3[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == writeback_hash && !strcmp(s, "writeback")))
+    else if(hash == writeback_hash && !strcmp(s, "writeback"))
       values3[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == dirty_hash && !strcmp(s, "dirty")))
+    else if(hash == dirty_hash && !strcmp(s, "dirty"))
       values3[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == swap_hash && !strcmp(s, "swap")))
+    else if(hash == swap_hash && !strcmp(s, "swap"))
       values3[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == pgpgin_hash && !strcmp(s, "pgpgin")))
+    else if(hash == pgpgin_hash && !strcmp(s, "pgpgin"))
       values3[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == pgpgout_hash && !strcmp(s, "pgpgout")))
+    else if(hash == pgpgout_hash && !strcmp(s, "pgpgout"))
       values3[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == pgfault_hash && !strcmp(s, "pgfault")))
+    else if(hash == pgfault_hash && !strcmp(s, "pgfault"))
       values3[i] = strtoull(v, NULL, 10);
     
-    else if(unlikely(hash == pgmajfault_hash && !strcmp(s, "pgmajfault")))
+    else if(hash == pgmajfault_hash && !strcmp(s, "pgmajfault"))
       values3[i] = strtoull(v, NULL, 10);
   }
 }
@@ -269,57 +269,57 @@ void test4() {
 
     uint32_t hash = simple_hash2(s);
 
-    if(unlikely(hash == cache_hash && !strcmp(s, "cache"))) {
+    if(hash == cache_hash && !strcmp(s, "cache")) {
       values4[i] = strtoull(v, NULL, 0);
       continue;
     }
 
-    if(unlikely(hash == rss_hash && !strcmp(s, "rss"))) {
+    if(hash == rss_hash && !strcmp(s, "rss")) {
       values4[i] = strtoull(v, NULL, 0);
       continue;
     }
     
-    if(unlikely(hash == rss_huge_hash && !strcmp(s, "rss_huge"))) {
+    if(hash == rss_huge_hash && !strcmp(s, "rss_huge")) {
       values4[i] = strtoull(v, NULL, 0);
       continue;
     }
     
-    if(unlikely(hash == mapped_file_hash && !strcmp(s, "mapped_file"))) {
+    if(hash == mapped_file_hash && !strcmp(s, "mapped_file")) {
       values4[i] = strtoull(v, NULL, 0);
       continue;
     }
     
-    if(unlikely(hash == writeback_hash && !strcmp(s, "writeback"))) {
+    if(hash == writeback_hash && !strcmp(s, "writeback")) {
       values4[i] = strtoull(v, NULL, 0);
       continue;
     }
     
-    if(unlikely(hash == dirty_hash && !strcmp(s, "dirty"))) {
+    if(hash == dirty_hash && !strcmp(s, "dirty")) {
       values4[i] = strtoull(v, NULL, 0);
       continue;
     }
     
-    if(unlikely(hash == swap_hash && !strcmp(s, "swap"))) {
+    if(hash == swap_hash && !strcmp(s, "swap")) {
       values4[i] = strtoull(v, NULL, 0);
       continue;
     }
     
-    if(unlikely(hash == pgpgin_hash && !strcmp(s, "pgpgin"))) {
+    if(hash == pgpgin_hash && !strcmp(s, "pgpgin")) {
       values4[i] = strtoull(v, NULL, 0);
       continue;
     }
     
-    if(unlikely(hash == pgpgout_hash && !strcmp(s, "pgpgout"))) {
+    if(hash == pgpgout_hash && !strcmp(s, "pgpgout")) {
       values4[i] = strtoull(v, NULL, 0);
       continue;
     }
     
-    if(unlikely(hash == pgfault_hash && !strcmp(s, "pgfault"))) {
+    if(hash == pgfault_hash && !strcmp(s, "pgfault")) {
       values4[i] = strtoull(v, NULL, 0);
       continue;
     }
     
-    if(unlikely(hash == pgmajfault_hash && !strcmp(s, "pgmajfault"))) {
+    if(hash == pgmajfault_hash && !strcmp(s, "pgmajfault")) {
       values4[i] = strtoull(v, NULL, 0);
       continue;
     }
@@ -335,37 +335,37 @@ void test5() {
 
     uint32_t hash = simple_hash2(s);
 
-    if(unlikely(hash == cache_hash && !strcmp(s, "cache")))
+    if(hash == cache_hash && !strcmp(s, "cache"))
       values5[i] = fast_strtoull(v);
     
-    else if(unlikely(hash == rss_hash && !strcmp(s, "rss")))
+    else if(hash == rss_hash && !strcmp(s, "rss"))
       values5[i] = fast_strtoull(v);
     
-    else if(unlikely(hash == rss_huge_hash && !strcmp(s, "rss_huge")))
+    else if(hash == rss_huge_hash && !strcmp(s, "rss_huge"))
       values5[i] = fast_strtoull(v);
     
-    else if(unlikely(hash == mapped_file_hash && !strcmp(s, "mapped_file")))
+    else if(hash == mapped_file_hash && !strcmp(s, "mapped_file"))
       values5[i] = fast_strtoull(v);
     
-    else if(unlikely(hash == writeback_hash && !strcmp(s, "writeback")))
+    else if(hash == writeback_hash && !strcmp(s, "writeback"))
       values5[i] = fast_strtoull(v);
     
-    else if(unlikely(hash == dirty_hash && !strcmp(s, "dirty")))
+    else if(hash == dirty_hash && !strcmp(s, "dirty"))
       values5[i] = fast_strtoull(v);
     
-    else if(unlikely(hash == swap_hash && !strcmp(s, "swap")))
+    else if(hash == swap_hash && !strcmp(s, "swap"))
       values5[i] = fast_strtoull(v);
   
-    else if(unlikely(hash == pgpgin_hash && !strcmp(s, "pgpgin")))
+    else if(hash == pgpgin_hash && !strcmp(s, "pgpgin"))
       values5[i] = fast_strtoull(v);
     
-    else if(unlikely(hash == pgpgout_hash && !strcmp(s, "pgpgout")))
+    else if(hash == pgpgout_hash && !strcmp(s, "pgpgout"))
       values5[i] = fast_strtoull(v);
     
-    else if(unlikely(hash == pgfault_hash && !strcmp(s, "pgfault")))
+    else if(hash == pgfault_hash && !strcmp(s, "pgfault"))
       values5[i] = fast_strtoull(v);
     
-    else if(unlikely(hash == pgmajfault_hash && !strcmp(s, "pgmajfault")))
+    else if(hash == pgmajfault_hash && !strcmp(s, "pgmajfault"))
       values5[i] = fast_strtoull(v);
   }
 }
@@ -384,7 +384,7 @@ void arl_strtoull(const char *name, uint32_t hash, const char *value, void *dst)
 void test6() {
     static ARL_BASE *base = NULL;
 
-    if(unlikely(!base)) {
+    if(!base) {
         base = arl_create("test6", arl_strtoull, 60);
         arl_expect_custom(base, "cache",       NULL, &values6[0]);
         arl_expect_custom(base, "rss",         NULL, &values6[1]);
@@ -418,7 +418,7 @@ void arl_str2ull(const char *name, uint32_t hash, const char *value, void *dst) 
 void test7() {
     static ARL_BASE *base = NULL;
 
-    if(unlikely(!base)) {
+    if(!base) {
         base = arl_create("test7", arl_str2ull, 60);
         arl_expect_custom(base, "cache",       NULL, &values7[0]);
         arl_expect_custom(base, "rss",         NULL, &values7[1]);
@@ -497,14 +497,14 @@ static unsigned long long clk;
 
 static void begin_clock() {
     struct timeval tv;
-    if(unlikely(gettimeofday(&tv, NULL) == -1))
+    if(gettimeofday(&tv, NULL) == -1)
         return;
     clk = tv.tv_sec  * 1000000 + tv.tv_usec;
 }
 
 static unsigned long long end_clock() {
     struct timeval tv;
-    if(unlikely(gettimeofday(&tv, NULL) == -1))
+    if(gettimeofday(&tv, NULL) == -1)
         return -1;
     return clk = tv.tv_sec  * 1000000 + tv.tv_usec - clk;
 }

--- a/web/api/badges/web_buffer_svg.c
+++ b/web/api/badges/web_buffer_svg.c
@@ -160,7 +160,7 @@ static inline double verdana11_width(const char *s, float em_size) {
             w += em_size;
         }
         else {
-            if(likely(!(*s & 0x80))){ // Byte 1XXX XXXX is not valid in UTF8
+            if(!(*s & 0x80)){ // Byte 1XXX XXXX is not valid in UTF8
             double t = verdana11_widths[(unsigned char)*s];
                 if(t != 0.0)
                 w += t + VERDANA_KERNING;
@@ -251,11 +251,11 @@ cleanup:
 
 static inline char *format_value_with_precision_and_unit(char *value_string, size_t value_string_len,
     NETDATA_DOUBLE value, const char *units, int precision) {
-    if(unlikely(isnan(value) || isinf(value)))
+    if(isnan(value) || isinf(value))
         value = 0.0;
 
     char *separator = "";
-    if(unlikely(isalnum(*units)))
+    if(isalnum(*units))
         separator = " ";
 
     if(precision < 0) {
@@ -279,16 +279,16 @@ static inline char *format_value_with_precision_and_unit(char *value_string, siz
         else if(isgreaterequal(abs, 0.0001)) len = snprintfz(value_string, value_string_len, "%0.6" NETDATA_DOUBLE_MODIFIER, (NETDATA_DOUBLE) value);
         else                                 len = snprintfz(value_string, value_string_len, "%0.7" NETDATA_DOUBLE_MODIFIER, (NETDATA_DOUBLE) value);
 
-        if(unlikely(trim_zeros)) {
+        if(trim_zeros) {
             int l;
             // remove trailing zeros from the decimal part
             for(l = len - 1; l > lstop; l--) {
-                if(likely(value_string[l] == '0')) {
+                if(value_string[l] == '0') {
                     value_string[l] = '\0';
                     len--;
                 }
 
-                else if(unlikely(value_string[l] == '.')) {
+                else if(value_string[l] == '.') {
                     value_string[l] = '\0';
                     len--;
                     break;
@@ -299,7 +299,7 @@ static inline char *format_value_with_precision_and_unit(char *value_string, siz
             }
         }
 
-        if(unlikely(len <= 0)) len = 1;
+        if(len <= 0) len = 1;
         snprintfz(&value_string[len], value_string_len - len, "%s%s", separator, units);
     }
     else {
@@ -365,14 +365,14 @@ inline char *format_value_and_unit(char *value_string, size_t value_string_len,
     static int max = -1;
     int i;
 
-    if(unlikely(max == -1)) {
+    if(max == -1) {
         for(i = 0; badge_units_formatters[i].units; i++)
             badge_units_formatters[i].hash = simple_hash(badge_units_formatters[i].units);
 
         max = i;
     }
 
-    if(unlikely(!units)) units = "";
+    if(!units) units = "";
     uint32_t hash_units = simple_hash(units);
 
     UNITS_FORMAT format = UNITS_FORMAT_NONE;
@@ -385,7 +385,7 @@ inline char *format_value_and_unit(char *value_string, size_t value_string_len,
         }
     }
 
-    if(unlikely(format == UNITS_FORMAT_SECONDS || format == UNITS_FORMAT_SECONDS_AGO)) {
+    if(format == UNITS_FORMAT_SECONDS || format == UNITS_FORMAT_SECONDS_AGO) {
         if(value == 0.0) {
             snprintfz(value_string, value_string_len, "%s", "now");
             return value_string;
@@ -415,7 +415,7 @@ inline char *format_value_and_unit(char *value_string, size_t value_string_len,
         return value_string;
     }
 
-    else if(unlikely(format == UNITS_FORMAT_MINUTES || format == UNITS_FORMAT_MINUTES_AGO)) {
+    else if(format == UNITS_FORMAT_MINUTES || format == UNITS_FORMAT_MINUTES_AGO) {
         if(value == 0.0) {
             snprintfz(value_string, value_string_len, "%s", "now");
             return value_string;
@@ -442,7 +442,7 @@ inline char *format_value_and_unit(char *value_string, size_t value_string_len,
         return value_string;
     }
 
-    else if(unlikely(format == UNITS_FORMAT_HOURS || format == UNITS_FORMAT_HOURS_AGO)) {
+    else if(format == UNITS_FORMAT_HOURS || format == UNITS_FORMAT_HOURS_AGO) {
         if(value == 0.0) {
             snprintfz(value_string, value_string_len, "%s", "now");
             return value_string;
@@ -466,33 +466,33 @@ inline char *format_value_and_unit(char *value_string, size_t value_string_len,
         return value_string;
     }
 
-    else if(unlikely(format == UNITS_FORMAT_ONOFF)) {
+    else if(format == UNITS_FORMAT_ONOFF) {
         snprintfz(value_string, value_string_len, "%s", (value != 0.0)?"on":"off");
         return value_string;
     }
 
-    else if(unlikely(format == UNITS_FORMAT_UPDOWN)) {
+    else if(format == UNITS_FORMAT_UPDOWN) {
         snprintfz(value_string, value_string_len, "%s", (value != 0.0)?"up":"down");
         return value_string;
     }
 
-    else if(unlikely(format == UNITS_FORMAT_OKERROR)) {
+    else if(format == UNITS_FORMAT_OKERROR) {
         snprintfz(value_string, value_string_len, "%s", (value != 0.0)?"ok":"error");
         return value_string;
     }
 
-    else if(unlikely(format == UNITS_FORMAT_OKFAILED)) {
+    else if(format == UNITS_FORMAT_OKFAILED) {
         snprintfz(value_string, value_string_len, "%s", (value != 0.0)?"ok":"failed");
         return value_string;
     }
 
-    else if(unlikely(format == UNITS_FORMAT_EMPTY))
+    else if(format == UNITS_FORMAT_EMPTY)
         units = "";
 
-    else if(unlikely(format == UNITS_FORMAT_PERCENT))
+    else if(format == UNITS_FORMAT_PERCENT)
         units = "%";
 
-    if(unlikely(isnan(value) || isinf(value))) {
+    if(isnan(value) || isinf(value)) {
         strcpy(value_string, "-");
         return value_string;
     }
@@ -529,7 +529,7 @@ static inline const char *color_map(const char *color, const char *def) {
     static int max = -1;
     int i;
 
-    if(unlikely(max == -1)) {
+    if(max == -1) {
         for(i = 0; badge_colors[i].name ;i++)
             badge_colors[i].hash = simple_hash(badge_colors[i].name);
 
@@ -655,17 +655,17 @@ static inline void calc_colorz(const char *color, char *final, size_t len, NETDA
                     v = NAN;
             }
 
-            if(unlikely(isnan(value) || isnan(v))) {
+            if(isnan(value) || isnan(v)) {
                 if(isnan(value) && isnan(v))
                     break;
             }
             else {
-                     if (unlikely(comparison == COLOR_COMPARE_LESS && isless(value, v))) break;
-                else if (unlikely(comparison == COLOR_COMPARE_LESSEQUAL && islessequal(value, v))) break;
-                else if (unlikely(comparison == COLOR_COMPARE_GREATER && isgreater(value, v))) break;
-                else if (unlikely(comparison == COLOR_COMPARE_GREATEREQUAL && isgreaterequal(value, v))) break;
-                else if (unlikely(comparison == COLOR_COMPARE_EQUAL && !islessgreater(value, v))) break;
-                else if (unlikely(comparison == COLOR_COMPARE_NOTEQUAL && islessgreater(value, v))) break;
+                     if (comparison == COLOR_COMPARE_LESS && isless(value, v)) break;
+                else if (comparison == COLOR_COMPARE_LESSEQUAL && islessequal(value, v)) break;
+                else if (comparison == COLOR_COMPARE_GREATER && isgreater(value, v)) break;
+                else if (comparison == COLOR_COMPARE_GREATEREQUAL && isgreaterequal(value, v)) break;
+                else if (comparison == COLOR_COMPARE_EQUAL && !islessgreater(value, v)) break;
+                else if (comparison == COLOR_COMPARE_NOTEQUAL && islessgreater(value, v)) break;
             }
         }
         else
@@ -702,7 +702,7 @@ static int html_color_check(const char *str) {
     while(str[i]) {
         if(!allowed_hexa_char(str[i]))
             return 0;
-        if(unlikely(i >= 6))
+        if(i >= 6)
             return 0;
         i++;
     }
@@ -749,7 +749,7 @@ void buffer_svg(BUFFER *wb, const char *label,
 
     if(scale < 100) scale = 100;
 
-    if(unlikely(!value_color || !*value_color))
+    if(!value_color || !*value_color)
         value_color = (isnan(value) || isinf(value))?"999":"4c1";
 
     calc_colorz(value_color, value_color_buffer, COLOR_STRING_SIZE, value);

--- a/web/api/exporters/shell/allmetrics_shell.c
+++ b/web/api/exporters/shell/allmetrics_shell.c
@@ -12,7 +12,7 @@ static inline size_t shell_name_copy(char *d, const char *s, size_t usable) {
     for(n = 0; *s && n < usable ; d++, s++, n++) {
         register char c = *s;
 
-        if(unlikely(!isalnum(c))) *d = '_';
+        if(!isalnum(c)) *d = '_';
         else *d = (char)toupper(c);
     }
     *d = '\0';

--- a/web/api/formatters/charts2json.c
+++ b/web/api/formatters/charts2json.c
@@ -43,7 +43,7 @@ void charts2json(RRDHOST *host, BUFFER *wb, int skip_volatile, int show_archived
 
     time_t now = now_realtime_sec();
 
-    if(unlikely(!custom_dashboard_info_js_filename))
+    if(!custom_dashboard_info_js_filename)
         custom_dashboard_info_js_filename = config_get(CONFIG_SECTION_WEB, "custom dashboard_info.js", "");
 
     buffer_sprintf(wb, "{\n"
@@ -105,7 +105,7 @@ void charts2json(RRDHOST *host, BUFFER *wb, int skip_volatile, int show_archived
                    , rrdhost_hosts_available()
     );
 
-    if(unlikely(rrdhost_hosts_available() > 1)) {
+    if(rrdhost_hosts_available() > 1) {
         rrd_rdlock();
 
         size_t found = 0;

--- a/web/api/formatters/json/json.c
+++ b/web/api/formatters/json/json.c
@@ -162,49 +162,49 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
             if(!tm) {
                 netdata_log_error("localtime_r() failed."); continue; }
 
-            if(likely(i != start)) buffer_fast_strcat(wb, ",\n", 2);
+            if(i != start) buffer_fast_strcat(wb, ",\n", 2);
             buffer_fast_strcat(wb, pre_date, pre_date_len);
 
             if( options & RRDR_OPTION_OBJECTSROWS )
                 buffer_fast_strcat(wb, object_rows_time, object_rows_time_len);
 
-            if(unlikely(dates_with_new))
+            if(dates_with_new)
                 buffer_fast_strcat(wb, "new ", 4);
 
             buffer_jsdate(wb, tm->tm_year + 1900, tm->tm_mon, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec);
 
             buffer_fast_strcat(wb, post_date, post_date_len);
 
-            if(unlikely(row_annotations)) {
+            if(row_annotations) {
                 // google supports one annotation per row
                 int annotation_found = 0;
                 for(c = 0; c < used ; c++) {
-                    if(unlikely(!(r->od[c] & RRDR_DIMENSION_QUERIED))) continue;
+                    if(!(r->od[c] & RRDR_DIMENSION_QUERIED)) continue;
 
-                    if(unlikely(co[c] & RRDR_VALUE_RESET)) {
+                    if(co[c] & RRDR_VALUE_RESET) {
                         buffer_fast_strcat(wb, overflow_annotation, overflow_annotation_len);
                         annotation_found = 1;
                         break;
                     }
                 }
-                if(likely(!annotation_found))
+                if(!annotation_found)
                     buffer_fast_strcat(wb, normal_annotation, normal_annotation_len);
             }
         }
         else {
             // print the timestamp of the line
-            if(likely(i != start))
+            if(i != start)
                 buffer_fast_strcat(wb, ",\n", 2);
 
             buffer_fast_strcat(wb, pre_date, pre_date_len);
 
-            if(unlikely( options & RRDR_OPTION_OBJECTSROWS ))
+            if( options & RRDR_OPTION_OBJECTSROWS )
                 buffer_fast_strcat(wb, object_rows_time, object_rows_time_len);
 
             buffer_print_netdata_double(wb, (NETDATA_DOUBLE) r->t[i]);
 
             // in ms
-            if(unlikely(options & RRDR_OPTION_MILLISECONDS))
+            if(options & RRDR_OPTION_MILLISECONDS)
                 buffer_fast_strcat(wb, "000", 3);
 
             buffer_fast_strcat(wb, post_date, post_date_len);
@@ -216,18 +216,18 @@ void rrdr2json(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, int datatable) {
                 continue;
 
             NETDATA_DOUBLE n;
-            if(unlikely(options & RRDR_OPTION_INTERNAL_AR))
+            if(options & RRDR_OPTION_INTERNAL_AR)
                 n = ar[c];
             else
                 n = cn[c];
 
             buffer_fast_strcat(wb, pre_value, pre_value_len);
 
-            if(unlikely( options & RRDR_OPTION_OBJECTSROWS ))
+            if( options & RRDR_OPTION_OBJECTSROWS )
                 buffer_sprintf(wb, "%s%s%s: ", kq, string2str(r->dn[c]), kq);
 
             if(co[c] & RRDR_VALUE_EMPTY && !(options & (RRDR_OPTION_INTERNAL_AR))) {
-                if(unlikely(options & RRDR_OPTION_NULL2ZERO))
+                if(options & RRDR_OPTION_NULL2ZERO)
                     buffer_fast_strcat(wb, "0", 1);
                 else
                     buffer_fast_strcat(wb, "null", 4);
@@ -317,7 +317,7 @@ void rrdr2json_v2(RRDR *r, BUFFER *wb) {
                 NETDATA_DOUBLE n = cn[d];
 
                 if(o & RRDR_VALUE_EMPTY) {
-                    if (unlikely(options & RRDR_OPTION_NULL2ZERO))
+                    if (options & RRDR_OPTION_NULL2ZERO)
                         buffer_json_add_array_item_double(wb, 0);
                     else
                         buffer_json_add_array_item_double(wb, NAN);

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -102,7 +102,7 @@ struct summary_total_counts {
 };
 
 static inline void aggregate_into_summary_totals(struct summary_total_counts *totals, QUERY_METRICS_COUNTS *metrics) {
-    if(unlikely(!totals || !metrics))
+    if(!totals || !metrics)
         return;
 
     if(metrics->selected) {
@@ -761,7 +761,7 @@ static inline void rrdr_dimension_query_points_statistics(BUFFER *wb, const char
     STORAGE_POINT *sp = (dview) ? r->dview : r->dqp;
     NETDATA_DOUBLE anomaly_rate_multiplier = (dview) ? RRDR_DVIEW_ANOMALY_COUNT_MULTIPLIER : 1.0;
 
-    if(unlikely(!sp))
+    if(!sp)
         return;
 
     if(key)
@@ -1284,7 +1284,7 @@ void rrdr_json_wrapper_begin2(RRDR *r, BUFFER *wb) {
     char kq[2] = "\"",                    // key quote
          sq[2] = "\"";                    // string quote
 
-    if(unlikely(options & RRDR_OPTION_GOOGLE_JSON)) {
+    if(options & RRDR_OPTION_GOOGLE_JSON) {
         kq[0] = '\0';
         sq[0] = '\'';
     }

--- a/web/api/formatters/rrd2json.h
+++ b/web/api/formatters/rrd2json.h
@@ -87,12 +87,12 @@ int rrdset2value_api_v1(
 );
 
 static inline bool rrdr_dimension_should_be_exposed(RRDR_DIMENSION_FLAGS rrdr_dim_flags, RRDR_OPTIONS options) {
-    if(unlikely((options & RRDR_OPTION_RETURN_RAW) && (rrdr_dim_flags & RRDR_DIMENSION_QUERIED)))
+    if((options & RRDR_OPTION_RETURN_RAW) && (rrdr_dim_flags & RRDR_DIMENSION_QUERIED))
         return true;
 
-    if(unlikely(rrdr_dim_flags & RRDR_DIMENSION_HIDDEN)) return false;
-    if(unlikely(!(rrdr_dim_flags & RRDR_DIMENSION_QUERIED))) return false;
-    if(unlikely((options & RRDR_OPTION_NONZERO) && !(rrdr_dim_flags & RRDR_DIMENSION_NONZERO))) return false;
+    if(rrdr_dim_flags & RRDR_DIMENSION_HIDDEN) return false;
+    if(!(rrdr_dim_flags & RRDR_DIMENSION_QUERIED)) return false;
+    if((options & RRDR_OPTION_NONZERO) && !(rrdr_dim_flags & RRDR_DIMENSION_NONZERO)) return false;
 
     return true;
 }

--- a/web/api/formatters/rrdset2json.c
+++ b/web/api/formatters/rrdset2json.c
@@ -4,7 +4,7 @@
 
 void chart_labels2json(RRDSET *st, BUFFER *wb, size_t indentation)
 {
-    if(unlikely(!st->rrdlabels))
+    if(!st->rrdlabels)
         return;
 
     char tabs[11];
@@ -57,7 +57,7 @@ void rrdset2json(RRDSET *st, BUFFER *wb, size_t *dimensions_count, size_t *memor
         rrdset_name(st),
         rrdset_type_name(st->chart_type));
 
-    if (likely(!skip_volatile))
+    if (!skip_volatile)
         buffer_sprintf(
             wb,
             "\t\t\t\"duration\": %"PRId64",\n",
@@ -70,7 +70,7 @@ void rrdset2json(RRDSET *st, BUFFER *wb, size_t *dimensions_count, size_t *memor
         (int64_t)first_entry_t //rrdset_first_entry_t(st)
     );
 
-    if (likely(!skip_volatile))
+    if (!skip_volatile)
         buffer_sprintf(
             wb,
             "\t\t\t\"last_entry\": %"PRId64",\n",
@@ -116,7 +116,7 @@ void rrdset2json(RRDSET *st, BUFFER *wb, size_t *dimensions_count, size_t *memor
     buffer_strcat(wb, ",\n\t\t\t\"red\": ");
     buffer_print_netdata_double(wb, st->red);
 
-    if (likely(!skip_volatile)) {
+    if (!skip_volatile) {
         buffer_strcat(wb, ",\n\t\t\t\"alarms\": {\n");
         size_t alarms = 0;
         RRDCALC *rc;

--- a/web/api/formatters/ssv/ssv.c
+++ b/web/api/formatters/ssv/ssv.c
@@ -19,7 +19,7 @@ void rrdr2ssv(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, const char *prefix, con
         int all_values_are_null = 0;
         NETDATA_DOUBLE v = rrdr2value(r, i, options, &all_values_are_null, NULL);
 
-        if(likely(i != start)) {
+        if(i != start) {
             if(r->view.min > v) r->view.min = v;
             if(r->view.max < v) r->view.max = v;
         }
@@ -28,7 +28,7 @@ void rrdr2ssv(RRDR *r, BUFFER *wb, RRDR_OPTIONS options, const char *prefix, con
             r->view.max = v;
         }
 
-        if(likely(i != start))
+        if(i != start)
             buffer_strcat(wb, separator);
 
         if(all_values_are_null) {

--- a/web/api/formatters/value/value.c
+++ b/web/api/formatters/value/value.c
@@ -22,7 +22,7 @@ inline NETDATA_DOUBLE rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all
 
         NETDATA_DOUBLE n = cn[c];
 
-        if(unlikely(init)) {
+        if(init) {
             if(n > 0) {
                 min = 0;
                 max = n;
@@ -34,7 +34,7 @@ inline NETDATA_DOUBLE rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all
             init = 0;
         }
 
-        if(likely(!(co[c] & RRDR_VALUE_EMPTY))) {
+        if(!(co[c] & RRDR_VALUE_EMPTY)) {
             all_null = 0;
             sum += n;
         }
@@ -50,13 +50,13 @@ inline NETDATA_DOUBLE rrdr2value(RRDR *r, long i, RRDR_OPTIONS options, int *all
         else *anomaly_rate = total_anomaly_rate / (NETDATA_DOUBLE)r->d;
     }
 
-    if(unlikely(all_null)) {
-        if(likely(all_values_are_null))
+    if(all_null) {
+        if(all_values_are_null)
             *all_values_are_null = 1;
         return 0;
     }
     else {
-        if(likely(all_values_are_null))
+        if(all_values_are_null)
             *all_values_are_null = 0;
     }
 

--- a/web/api/health/health_cmdapi.c
+++ b/web/api/health/health_cmdapi.c
@@ -68,7 +68,7 @@ void health_silencers2json(BUFFER *wb) {
     SILENCER *silencer;
     int i = 0, j = 0;
     for(silencer = silencers->silencers; silencer ; silencer = silencer->next) {
-        if(likely(i)) buffer_strcat(wb, ",");
+        if(i) buffer_strcat(wb, ",");
         buffer_strcat(wb, "\n\t\t{");
         j=health_silencers2json_entry(wb, HEALTH_ALARM_KEY, silencer->alarms, j);
         j=health_silencers2json_entry(wb, HEALTH_CHART_KEY, silencer->charts, j);
@@ -79,7 +79,7 @@ void health_silencers2json(BUFFER *wb) {
         buffer_strcat(wb, "\n\t\t}");
         i++;
     }
-    if(likely(i)) buffer_strcat(wb, "\n\t");
+    if(i) buffer_strcat(wb, "\n\t");
     buffer_strcat(wb, "]\n}\n");
 }
 
@@ -180,14 +180,14 @@ int web_client_api_request_v1_mgmt_health(RRDHOST *host, struct web_client *w, c
                 }
             }
 
-            if (likely(silencer)) {
+            if (silencer) {
                 health_silencers_add(silencer);
                 buffer_strcat(wb, HEALTH_CMDAPI_MSG_ADDED);
                 if (silencers->stype == STYPE_NONE) {
                     buffer_strcat(wb, HEALTH_CMDAPI_MSG_STYPEWARNING);
                 }
             }
-            if (unlikely(silencers->stype != STYPE_NONE && !silencers->all_alarms && !silencers->silencers)) {
+            if (silencers->stype != STYPE_NONE && !silencers->all_alarms && !silencers->silencers) {
                 buffer_strcat(wb, HEALTH_CMDAPI_MSG_NOSELECTORWARNING);
             }
             ret = HTTP_RESP_OK;

--- a/web/api/queries/average/average.h
+++ b/web/api/queries/average/average.h
@@ -42,12 +42,12 @@ static inline NETDATA_DOUBLE tg_average_flush(RRDR *r, RRDR_VALUE_FLAGS *rrdr_va
 
     NETDATA_DOUBLE value;
 
-    if(unlikely(!g->count)) {
+    if(!g->count) {
         value = 0.0;
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
     }
     else {
-        if(unlikely(r->time_grouping.resampling_group != 1))
+        if(r->time_grouping.resampling_group != 1)
             value = g->sum / r->time_grouping.resampling_divisor;
         else
             value = g->sum / g->count;

--- a/web/api/queries/countif/countif.h
+++ b/web/api/queries/countif/countif.h
@@ -131,7 +131,7 @@ static inline NETDATA_DOUBLE tg_countif_flush(RRDR *r, RRDR_VALUE_FLAGS *rrdr_va
 
     NETDATA_DOUBLE value;
 
-    if(unlikely(!g->count)) {
+    if(!g->count) {
         value = 0.0;
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
     }

--- a/web/api/queries/des/des.h
+++ b/web/api/queries/des/des.h
@@ -98,10 +98,10 @@ static inline void tg_des_free(RRDR *r) {
 static inline void tg_des_add(RRDR *r, NETDATA_DOUBLE value) {
     struct tg_des *g = (struct tg_des *)r->time_grouping.data;
 
-    if(likely(g->count > 0)) {
+    if(g->count > 0) {
         // we have at least a number so far
 
-        if(unlikely(g->count == 1)) {
+        if(g->count == 1) {
             // the second value we got
             g->trend = value - g->trend;
             g->level = value;
@@ -125,7 +125,7 @@ static inline void tg_des_add(RRDR *r, NETDATA_DOUBLE value) {
 static inline NETDATA_DOUBLE tg_des_flush(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
     struct tg_des *g = (struct tg_des *)r->time_grouping.data;
 
-    if(unlikely(!g->count || !netdata_double_isnumber(g->level))) {
+    if(!g->count || !netdata_double_isnumber(g->level)) {
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
         return 0.0;
     }

--- a/web/api/queries/incremental_sum/incremental_sum.h
+++ b/web/api/queries/incremental_sum/incremental_sum.h
@@ -34,7 +34,7 @@ static inline void tg_incremental_sum_free(RRDR *r) {
 static inline void tg_incremental_sum_add(RRDR *r, NETDATA_DOUBLE value) {
     struct tg_incremental_sum *g = (struct tg_incremental_sum *)r->time_grouping.data;
 
-    if(unlikely(!g->count)) {
+    if(!g->count) {
         if(isnan(g->first))
             g->first = value;
         else
@@ -53,7 +53,7 @@ static inline NETDATA_DOUBLE tg_incremental_sum_flush(RRDR *r, RRDR_VALUE_FLAGS 
 
     NETDATA_DOUBLE value;
 
-    if(unlikely(!g->count || isnan(g->first) || isnan(g->last))) {
+    if(!g->count || isnan(g->first) || isnan(g->last)) {
         value = 0.0;
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
     }

--- a/web/api/queries/max/max.h
+++ b/web/api/queries/max/max.h
@@ -42,7 +42,7 @@ static inline NETDATA_DOUBLE tg_max_flush(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_
 
     NETDATA_DOUBLE value;
 
-    if(unlikely(!g->count)) {
+    if(!g->count) {
         value = 0.0;
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
     }

--- a/web/api/queries/median/median.h
+++ b/web/api/queries/median/median.h
@@ -80,7 +80,7 @@ static inline void tg_median_free(RRDR *r) {
 static inline void tg_median_add(RRDR *r, NETDATA_DOUBLE value) {
     struct tg_median *g = (struct tg_median *)r->time_grouping.data;
 
-    if(unlikely(g->next_pos >= g->series_size)) {
+    if(g->next_pos >= g->series_size) {
         g->series = onewayalloc_doublesize( r->internal.owa, g->series, g->series_size * sizeof(NETDATA_DOUBLE));
         g->series_size *= 2;
     }
@@ -94,7 +94,7 @@ static inline NETDATA_DOUBLE tg_median_flush(RRDR *r, RRDR_VALUE_FLAGS *rrdr_val
     size_t available_slots = g->next_pos;
     NETDATA_DOUBLE value;
 
-    if(unlikely(!available_slots)) {
+    if(!available_slots) {
         value = 0.0;
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
     }
@@ -128,7 +128,7 @@ static inline NETDATA_DOUBLE tg_median_flush(RRDR *r, RRDR_VALUE_FLAGS *rrdr_val
             value = median_on_sorted_series(&g->series[start_slot], end_slot - start_slot + 1);
     }
 
-    if(unlikely(!netdata_double_isnumber(value))) {
+    if(!netdata_double_isnumber(value)) {
         value = 0.0;
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
     }

--- a/web/api/queries/min/min.h
+++ b/web/api/queries/min/min.h
@@ -42,7 +42,7 @@ static inline NETDATA_DOUBLE tg_min_flush(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_
 
     NETDATA_DOUBLE value;
 
-    if(unlikely(!g->count)) {
+    if(!g->count) {
         value = 0.0;
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
     }

--- a/web/api/queries/percentile/percentile.h
+++ b/web/api/queries/percentile/percentile.h
@@ -80,7 +80,7 @@ static inline void tg_percentile_free(RRDR *r) {
 static inline void tg_percentile_add(RRDR *r, NETDATA_DOUBLE value) {
     struct tg_percentile *g = (struct tg_percentile *)r->time_grouping.data;
 
-    if(unlikely(g->next_pos >= g->series_size)) {
+    if(g->next_pos >= g->series_size) {
         g->series = onewayalloc_doublesize( r->internal.owa, g->series, g->series_size * sizeof(NETDATA_DOUBLE));
         g->series_size *= 2;
     }
@@ -94,7 +94,7 @@ static inline NETDATA_DOUBLE tg_percentile_flush(RRDR *r, RRDR_VALUE_FLAGS *rrdr
     NETDATA_DOUBLE value;
     size_t available_slots = g->next_pos;
 
-    if(unlikely(!available_slots)) {
+    if(!available_slots) {
         value = 0.0;
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
     }
@@ -157,7 +157,7 @@ static inline NETDATA_DOUBLE tg_percentile_flush(RRDR *r, RRDR_VALUE_FLAGS *rrdr
             value = min;
     }
 
-    if(unlikely(!netdata_double_isnumber(value))) {
+    if(!netdata_double_isnumber(value)) {
         value = 0.0;
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
     }

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -649,7 +649,7 @@ RRDR_TIME_GROUPING time_grouping_parse(const char *name, RRDR_TIME_GROUPING def)
 
     uint32_t hash = simple_hash(name);
     for(i = 0; api_v1_data_groups[i].name ; i++)
-        if(unlikely(hash == api_v1_data_groups[i].hash && !strcmp(name, api_v1_data_groups[i].name)))
+        if(hash == api_v1_data_groups[i].hash && !strcmp(name, api_v1_data_groups[i].name))
             return api_v1_data_groups[i].value;
 
     return def;
@@ -659,7 +659,7 @@ const char *time_grouping_tostring(RRDR_TIME_GROUPING group) {
     int i;
 
     for(i = 0; api_v1_data_groups[i].name ; i++)
-        if(unlikely(group == api_v1_data_groups[i].value))
+        if(group == api_v1_data_groups[i].value)
             return api_v1_data_groups[i].name;
 
     return "unknown";
@@ -991,10 +991,10 @@ static long query_plan_points_coverage_weight(time_t db_first_time_s, time_t db_
 }
 
 static size_t query_metric_best_tier_for_timeframe(QUERY_METRIC *qm, time_t after_wanted, time_t before_wanted, size_t points_wanted) {
-    if(unlikely(storage_tiers < 2))
+    if(storage_tiers < 2)
         return 0;
 
-    if(unlikely(after_wanted == before_wanted || points_wanted <= 0))
+    if(after_wanted == before_wanted || points_wanted <= 0)
         return query_metric_first_working_tier(qm);
 
     if(points_wanted < QUERY_PLAN_MIN_POINTS)
@@ -1051,10 +1051,10 @@ static size_t query_metric_best_tier_for_timeframe(QUERY_METRIC *qm, time_t afte
 }
 
 static size_t rrddim_find_best_tier_for_timeframe(QUERY_TARGET *qt, time_t after_wanted, time_t before_wanted, size_t points_wanted) {
-    if(unlikely(storage_tiers < 2))
+    if(storage_tiers < 2)
         return 0;
 
-    if(unlikely(after_wanted == before_wanted || points_wanted <= 0)) {
+    if(after_wanted == before_wanted || points_wanted <= 0) {
         internal_error(true, "QUERY: '%s' has invalid params to tier calculation", qt->id);
         return 0;
     }
@@ -1475,7 +1475,7 @@ static bool query_plan(QUERY_ENGINE_OPS *ops, time_t after_wanted, time_t before
 // dimension level query engine
 
 #define query_interpolate_point(this_point, last_point, now)      do {  \
-    if(likely(                                                          \
+    if(                                                          \
             /* the point to interpolate is more than 1s wide */         \
             (this_point).sp.end_time_s - (this_point).sp.start_time_s > 1 \
                                                                         \
@@ -1486,18 +1486,18 @@ static bool query_plan(QUERY_ENGINE_OPS *ops, time_t after_wanted, time_t before
          && netdata_double_isnumber((this_point).value)                 \
          && netdata_double_isnumber((last_point).value)                 \
                                                                         \
-        )) {                                                            \
+        ) {                                                            \
             (this_point).value = (last_point).value + ((this_point).value - (last_point).value) * (1.0 - (NETDATA_DOUBLE)((this_point).sp.end_time_s - (now)) / (NETDATA_DOUBLE)((this_point).sp.end_time_s - (this_point).sp.start_time_s)); \
             (this_point).sp.end_time_s = now;                           \
         }                                                               \
 } while(0)
 
 #define query_add_point_to_group(r, point, ops, add_flush)        do {  \
-    if(likely(netdata_double_isnumber((point).value))) {                \
-        if(likely(fpclassify((point).value) != FP_ZERO))                \
+    if(netdata_double_isnumber((point).value)) {                \
+        if(fpclassify((point).value) != FP_ZERO)                \
             (ops)->group_points_non_zero++;                             \
                                                                         \
-        if(unlikely((point).sp.flags & SN_FLAG_RESET))                  \
+        if((point).sp.flags & SN_FLAG_RESET)                  \
             (ops)->group_value_flags |= RRDR_VALUE_RESET;               \
                                                                         \
         time_grouping_add(r, (point).value, add_flush);                 \
@@ -1607,7 +1607,7 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
     for( ; points_added < points_wanted && query_is_finished_counter <= 10 ;
         now_start_time = now_end_time, now_end_time += ops->view_update_every) {
 
-        if(unlikely(query_plan_should_switch_plan(ops, now_end_time))) {
+        if(query_plan_should_switch_plan(ops, now_end_time)) {
             query_planer_next_plan(ops, now_end_time, new_point.sp.end_time_s);
             db_points_read_since_plan_switch = 0;
         }
@@ -1616,12 +1616,12 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
 
         size_t count_same_end_time = 0;
         while(count_same_end_time < 100) {
-            if(likely(count_same_end_time == 0)) {
+            if(count_same_end_time == 0) {
                 last2_point = last1_point;
                 last1_point = new_point;
             }
 
-            if(unlikely(storage_engine_query_is_finished(ops->handle))) {
+            if(storage_engine_query_is_finished(ops->handle)) {
                 query_is_finished_counter++;
 
                 if(count_same_end_time != 0) {
@@ -1642,13 +1642,13 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
             // fetch the new point
             {
                 STORAGE_POINT sp;
-                if(likely(storage_point_is_unset(next1_point))) {
+                if(storage_point_is_unset(next1_point)) {
                     db_points_read_since_plan_switch++;
                     sp = storage_engine_query_next_metric(ops->handle);
                     ops->db_points_read_per_tier[ops->tier]++;
                     ops->db_total_points_read++;
 
-                    if(unlikely(options & RRDR_OPTION_ABSOLUTE))
+                    if(options & RRDR_OPTION_ABSOLUTE)
                         storage_point_make_positive(sp);
                 }
                 else {
@@ -1659,8 +1659,8 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
                 }
 
                 // ONE POINT READ-AHEAD
-                if(unlikely(query_plan_should_switch_plan(ops, sp.end_time_s) &&
-                    query_planer_next_plan(ops, now_end_time, new_point.sp.end_time_s))) {
+                if(query_plan_should_switch_plan(ops, sp.end_time_s) &&
+                    query_planer_next_plan(ops, now_end_time, new_point.sp.end_time_s)) {
 
                     // The end time of the current point, crosses our plans (tiers)
                     // so, we switched plan (tier)
@@ -1674,7 +1674,7 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
                     ops->db_points_read_per_tier[ops->tier]++;
                     ops->db_total_points_read++;
 
-                    if(unlikely(options & RRDR_OPTION_ABSOLUTE))
+                    if(options & RRDR_OPTION_ABSOLUTE)
                         storage_point_make_positive(sp);
 
                     if(sp.start_time_s > sp2.start_time_s)
@@ -1696,9 +1696,9 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
 //                         new_point.id, new_point.start_time, new_point.end_time, now_start_time, now_end_time, after_wanted, before_wanted);
 //
                 // get the right value from the point we got
-                if(likely(!storage_point_is_unset(sp) && !storage_point_is_gap(sp))) {
+                if(!storage_point_is_unset(sp) && !storage_point_is_gap(sp)) {
 
-                    if(unlikely(use_anomaly_bit_as_value))
+                    if(use_anomaly_bit_as_value)
                         new_point.value = storage_point_anomaly_rate(new_point.sp);
 
                     else {
@@ -1727,8 +1727,8 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
             }
 
             // check if the db is giving us zero duration points
-            if(unlikely(db_points_read_since_plan_switch > 1 &&
-                        new_point.sp.start_time_s == new_point.sp.end_time_s)) {
+            if(db_points_read_since_plan_switch > 1 &&
+                        new_point.sp.start_time_s == new_point.sp.end_time_s) {
 
                 internal_error(true, "QUERY: '%s', dimension '%s' next_metric() returned "
                                      "point %zu from %ld to %ld, that are both equal",
@@ -1739,8 +1739,8 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
             }
 
             // check if the db is advancing the query
-            if(unlikely(db_points_read_since_plan_switch > 1 &&
-                        new_point.sp.end_time_s <= last1_point.sp.end_time_s)) {
+            if(db_points_read_since_plan_switch > 1 &&
+                        new_point.sp.end_time_s <= last1_point.sp.end_time_s) {
 
                 internal_error(true,
                                "QUERY: '%s', dimension '%s' next_metric() returned "
@@ -1758,10 +1758,10 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
             count_same_end_time = 0;
 
             // decide how to use this point
-            if(likely(new_point.sp.end_time_s < now_end_time)) { // likely to favor tier0
+            if(new_point.sp.end_time_s < now_end_time) { // likely to favor tier0
                 // this db point ends before our now_end_time
 
-                if(likely(new_point.sp.end_time_s >= now_start_time)) { // likely to favor tier0
+                if(new_point.sp.end_time_s >= now_start_time) { // likely to favor tier0
                     // this db point ends after our now_start time
 
                     query_add_point_to_group(r, new_point, ops, add_flush);
@@ -1796,7 +1796,7 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
             }
         }
 
-        if(unlikely(count_same_end_time)) {
+        if(count_same_end_time) {
             internal_error(true,
                            "QUERY: '%s', dimension '%s', the database does not advance the query,"
                            " it returned an end time less or equal to the end time of the last "
@@ -1804,12 +1804,12 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
                            qt->id, query_metric_id(qt, qm),
                            last1_point.sp.end_time_s, count_same_end_time);
 
-            if(unlikely(new_point.sp.end_time_s <= last1_point.sp.end_time_s))
+            if(new_point.sp.end_time_s <= last1_point.sp.end_time_s)
                 new_point.sp.end_time_s = now_end_time;
         }
 
         time_t stop_time = new_point.sp.end_time_s;
-        if(unlikely(!storage_point_is_unset(next1_point) && next1_point.start_time_s >= now_end_time)) {
+        if(!storage_point_is_unset(next1_point) && next1_point.start_time_s >= now_end_time) {
             // ONE POINT READ-AHEAD
             // the point crosses the start time of the
             // read ahead storage point we have read
@@ -1830,7 +1830,7 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
 
             QUERY_POINT current_point;
 
-            if(likely(now_end_time > new_point.sp.start_time_s)) {
+            if(now_end_time > new_point.sp.start_time_s) {
                 // it is time for our NEW point to be used
                 current_point = new_point;
                 new_point.added = true; // first copy, then set it, so that new_point will not be added again
@@ -1849,7 +1849,7 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
 //                               current_point.id, current_point.start_time, current_point.end_time,
 //                               now_end_time);
             }
-            else if(likely(now_end_time <= last1_point.sp.end_time_s)) {
+            else if(now_end_time <= last1_point.sp.end_time_s) {
                 // our LAST point is still valid
                 current_point = last1_point;
                 last1_point.added = true; // first copy, then set it, so that last1_point will not be added again
@@ -1881,7 +1881,7 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
             RRDR_VALUE_FLAGS *rrdr_value_options_ptr = &r->o[rrdr_o_v_index];
 
             // update the dimension options
-            if(likely(ops->group_points_non_zero))
+            if(ops->group_points_non_zero)
                 r->od[dim_id_in_rrdr] |= RRDR_DIMENSION_NONZERO;
 
             // store the specific point options
@@ -1893,11 +1893,11 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
 
             r->ar[rrdr_o_v_index] = storage_point_anomaly_rate(ops->group_point);
 
-            if(likely(points_added || r->internal.queries_count)) {
+            if(points_added || r->internal.queries_count) {
                 // find the min/max across all dimensions
 
-                if(unlikely(group_value < min)) min = group_value;
-                if(unlikely(group_value > max)) max = group_value;
+                if(group_value < min) min = group_value;
+                if(group_value > max) max = group_value;
 
             }
             else {
@@ -1950,11 +1950,11 @@ static void rrd2rrdr_query_execute(RRDR *r, size_t dim_id_in_rrdr, QUERY_ENGINE_
 void store_metric_at_tier(RRDDIM *rd, size_t tier, struct rrddim_tier *t, STORAGE_POINT sp, usec_t now_ut);
 
 void rrdr_fill_tier_gap_from_smaller_tiers(RRDDIM *rd, size_t tier, time_t now_s) {
-    if(unlikely(tier >= storage_tiers)) return;
+    if(tier >= storage_tiers) return;
     if(storage_tiers_backfill[tier] == RRD_BACKFILL_NONE) return;
 
     struct rrddim_tier *t = &rd->tiers[tier];
-    if(unlikely(!t)) return;
+    if(!t) return;
 
     time_t latest_time_s = storage_engine_latest_time_s(t->backend, t->db_metric_handle);
     time_t granularity = (time_t)t->tier_grouping * (time_t)rd->rrdset->update_every;
@@ -2176,7 +2176,7 @@ bool rrdr_relative_window_to_absolute(time_t *after, time_t *before, time_t *now
 #endif
 
 bool query_target_calculate_window(QUERY_TARGET *qt) {
-    if (unlikely(!qt)) return false;
+    if (!qt) return false;
 
     size_t points_requested = (long)qt->request.points;
     time_t after_requested = qt->request.after;
@@ -2314,14 +2314,14 @@ bool query_target_calculate_window(QUERY_TARGET *qt) {
     // automatic_natural_points is set when the user wants all the points available in the database
     if (automatic_natural_points) {
         points_wanted = (before_wanted - after_wanted + 1) / query_granularity;
-        if (unlikely(points_wanted <= 0)) points_wanted = 1;
+        if (points_wanted <= 0) points_wanted = 1;
         query_debug_log(":auto natural points_wanted %zu", points_wanted);
     }
 
     time_t duration = before_wanted - after_wanted;
 
     // if the resampling time is too big, extend the duration to the past
-    if (unlikely(resampling_time_requested > duration)) {
+    if (resampling_time_requested > duration) {
         after_wanted = before_wanted - resampling_time_requested;
         duration = before_wanted - after_wanted;
         query_debug_log(":resampling after_wanted %ld", after_wanted);
@@ -2341,7 +2341,7 @@ bool query_target_calculate_window(QUERY_TARGET *qt) {
 
     // the available points of the query
     size_t points_available = (duration + 1) / query_granularity;
-    if (unlikely(points_available <= 0)) points_available = 1;
+    if (points_available <= 0) points_available = 1;
     query_debug_log(":points_available %zu", points_available);
 
     if (points_wanted > points_available) {
@@ -2376,7 +2376,7 @@ bool query_target_calculate_window(QUERY_TARGET *qt) {
         if (points_wanted * group < points_available)
             points_wanted++;
 
-        if (unlikely(points_wanted == 0))
+        if (points_wanted == 0)
             points_wanted = 1;
 
         query_debug_log(":optimal points %zu", points_wanted);
@@ -2385,20 +2385,20 @@ bool query_target_calculate_window(QUERY_TARGET *qt) {
     // resampling_time_requested enforces a certain grouping multiple
     NETDATA_DOUBLE resampling_divisor = 1.0;
     size_t resampling_group = 1;
-    if (unlikely(resampling_time_requested > query_granularity)) {
+    if (resampling_time_requested > query_granularity) {
         // the points we should group to satisfy gtime
         resampling_group = resampling_time_requested / query_granularity;
-        if (unlikely(resampling_time_requested % query_granularity))
+        if (resampling_time_requested % query_granularity)
             resampling_group++;
 
         query_debug_log(":resampling group %zu", resampling_group);
 
         // adapt group according to resampling_group
-        if (unlikely(group < resampling_group)) {
+        if (group < resampling_group) {
             group = resampling_group; // do not allow grouping below the desired one
             query_debug_log(":group less res %zu", group);
         }
-        if (unlikely(group % resampling_group)) {
+        if (group % resampling_group) {
             group += resampling_group - (group % resampling_group); // make sure group is multiple of resampling_group
             query_debug_log(":group mod res %zu", group);
         }
@@ -2561,10 +2561,10 @@ static void rrd2rrdr_set_timestamps(RRDR *r) {
 
 static void query_group_by_make_dimension_key(BUFFER *key, RRDR_GROUP_BY group_by, size_t group_by_id, QUERY_TARGET *qt, QUERY_NODE *qn, QUERY_CONTEXT *qc, QUERY_INSTANCE *qi, QUERY_DIMENSION *qd __maybe_unused, QUERY_METRIC *qm, bool query_has_percentage_of_group) {
     buffer_flush(key);
-    if(unlikely(!query_has_percentage_of_group && qm->status & RRDR_DIMENSION_HIDDEN)) {
+    if(!query_has_percentage_of_group && qm->status & RRDR_DIMENSION_HIDDEN) {
         buffer_strcat(key, "__hidden_dimensions__");
     }
-    else if(unlikely(group_by & RRDR_GROUP_BY_SELECTED)) {
+    else if(group_by & RRDR_GROUP_BY_SELECTED) {
         buffer_strcat(key, "selected");
     }
     else {
@@ -2605,10 +2605,10 @@ static void query_group_by_make_dimension_key(BUFFER *key, RRDR_GROUP_BY group_b
 
 static void query_group_by_make_dimension_id(BUFFER *key, RRDR_GROUP_BY group_by, size_t group_by_id, QUERY_TARGET *qt, QUERY_NODE *qn, QUERY_CONTEXT *qc, QUERY_INSTANCE *qi, QUERY_DIMENSION *qd __maybe_unused, QUERY_METRIC *qm, bool query_has_percentage_of_group) {
     buffer_flush(key);
-    if(unlikely(!query_has_percentage_of_group && qm->status & RRDR_DIMENSION_HIDDEN)) {
+    if(!query_has_percentage_of_group && qm->status & RRDR_DIMENSION_HIDDEN) {
         buffer_strcat(key, "__hidden_dimensions__");
     }
-    else if(unlikely(group_by & RRDR_GROUP_BY_SELECTED)) {
+    else if(group_by & RRDR_GROUP_BY_SELECTED) {
         buffer_strcat(key, "selected");
     }
     else {
@@ -2660,10 +2660,10 @@ static void query_group_by_make_dimension_id(BUFFER *key, RRDR_GROUP_BY group_by
 
 static void query_group_by_make_dimension_name(BUFFER *key, RRDR_GROUP_BY group_by, size_t group_by_id, QUERY_TARGET *qt, QUERY_NODE *qn, QUERY_CONTEXT *qc, QUERY_INSTANCE *qi, QUERY_DIMENSION *qd __maybe_unused, QUERY_METRIC *qm, bool query_has_percentage_of_group) {
     buffer_flush(key);
-    if(unlikely(!query_has_percentage_of_group && qm->status & RRDR_DIMENSION_HIDDEN)) {
+    if(!query_has_percentage_of_group && qm->status & RRDR_DIMENSION_HIDDEN) {
         buffer_strcat(key, "__hidden_dimensions__");
     }
-    else if(unlikely(group_by & RRDR_GROUP_BY_SELECTED)) {
+    else if(group_by & RRDR_GROUP_BY_SELECTED) {
         buffer_strcat(key, "selected");
     }
     else {
@@ -2730,7 +2730,7 @@ static RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
     if(qt->request.version < 2) {
         // v1 query
         RRDR *r = rrdr_create(owa, qt, qt->query.used, qt->window.points);
-         if(unlikely(!r)) {
+         if(!r) {
              internal_error(true, "QUERY: cannot create RRDR for %s, after=%ld, before=%ld, dimensions=%u, points=%zu",
                             qt->id, qt->window.after, qt->window.before, qt->query.used, qt->window.points);
              return NULL;
@@ -2901,7 +2901,7 @@ static RRDR *rrd2rrdr_group_by_initialize(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
 
             entries[pos].count++;
 
-            if (unlikely(priority < entries[pos].priority))
+            if (priority < entries[pos].priority)
                 entries[pos].priority = priority;
 
             if(g > 0)
@@ -3141,20 +3141,20 @@ static void rrdr2rrdr_group_by_partial_trimming(RRDR *r) {
             break;
     }
 
-    if(unlikely(i < 0))
+    if(i < 0)
         return;
 
     size_t last_row_gbc = 0;
     for (; i < (ssize_t)r->n; i++) {
         size_t row_gbc = 0;
         for (size_t d = 0; d < r->d; d++) {
-            if (unlikely(!(r->od[d] & RRDR_DIMENSION_QUERIED)))
+            if (!(r->od[d] & RRDR_DIMENSION_QUERIED))
                 continue;
 
             row_gbc += r->gbc[ i * r->d + d ];
         }
 
-        if (unlikely(r->t[i] >= trimmable_after && row_gbc < last_row_gbc)) {
+        if (r->t[i] >= trimmable_after && row_gbc < last_row_gbc) {
             // discard the rest of the points
             r->partial_data_trimming.trimmed_after = r->t[i];
             r->rows = i;
@@ -3205,7 +3205,7 @@ static void rrd2rrdr_convert_values_to_percentage_of_total(RRDR *r) {
 
         NETDATA_DOUBLE total = 0;
         for (size_t d = 0; d < r->d; d++) {
-            if (unlikely(!(r->od[d] & RRDR_DIMENSION_QUERIED)))
+            if (!(r->od[d] & RRDR_DIMENSION_QUERIED))
                 continue;
 
             if(co[d] & RRDR_VALUE_EMPTY)
@@ -3218,7 +3218,7 @@ static void rrd2rrdr_convert_values_to_percentage_of_total(RRDR *r) {
             total = 1.0;
 
         for (size_t d = 0; d < r->d; d++) {
-            if (unlikely(!(r->od[d] & RRDR_DIMENSION_QUERIED)))
+            if (!(r->od[d] & RRDR_DIMENSION_QUERIED))
                 continue;
 
             if(co[d] & RRDR_VALUE_EMPTY)
@@ -3227,7 +3227,7 @@ static void rrd2rrdr_convert_values_to_percentage_of_total(RRDR *r) {
             NETDATA_DOUBLE n = cn[d];
             n = cn[d] = n * 100.0 / total;
 
-            if(unlikely(!global_min_max_values++))
+            if(!global_min_max_values++)
                 global_min = global_max = n;
             else {
                 if(n < global_min)
@@ -3248,7 +3248,7 @@ static void rrd2rrdr_convert_values_to_percentage_of_total(RRDR *r) {
     // v2 query
 
     for (size_t d = 0; d < r->d; d++) {
-        if (unlikely(!(r->od[d] & RRDR_DIMENSION_QUERIED)))
+        if (!(r->od[d] & RRDR_DIMENSION_QUERIED))
             continue;
 
         size_t count = 0;
@@ -3340,7 +3340,7 @@ static RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
     size_t dimensions_nonzero = 0;
     NETDATA_DOUBLE global_min = NAN, global_max = NAN;
     for (size_t d = 0; d < r->d; d++) {
-        if (unlikely(!(r->od[d] & RRDR_DIMENSION_QUERIED)))
+        if (!(r->od[d] & RRDR_DIMENSION_QUERIED))
             continue;
 
         size_t points_nonzero = 0;
@@ -3355,7 +3355,7 @@ static RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
             NETDATA_DOUBLE *ar = &r->ar[ idx ];
             uint32_t gbc = r->gbc[ idx ];
 
-            if(likely(gbc)) {
+            if(gbc) {
                 *co &= ~RRDR_VALUE_EMPTY;
 
                 if(gbc != r->dgbc[d])
@@ -3377,7 +3377,7 @@ static RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
                 if(islessgreater(n, 0.0))
                     points_nonzero++;
 
-                if(unlikely(!count))
+                if(!count)
                     min = max = n;
                 else {
                     if(n < min)
@@ -3387,7 +3387,7 @@ static RRDR *rrd2rrdr_group_by_finalize(RRDR *r_tmp) {
                         max = n;
                 }
 
-                if(unlikely(!global_min_max_values++))
+                if(!global_min_max_values++)
                     global_min = global_max = n;
                 else {
                     if(n < global_min)
@@ -3657,7 +3657,7 @@ RRDR *rrd2rrdr(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
             dimensions_nonzero++;
 
         // verify all dimensions are aligned
-        if(unlikely(!dimensions_used)) {
+        if(!dimensions_used) {
             min_before = r->view.before;
             max_after = r->view.after;
             max_rows = r->rows;
@@ -3776,7 +3776,7 @@ RRDR *rrd2rrdr(ONEWAYALLOC *owa, QUERY_TARGET *qt) {
 
     onewayalloc_freez(owa, ops);
 
-    if(likely(dimensions_used && (qt->window.options & RRDR_OPTION_NONZERO) && !dimensions_nonzero))
+    if(dimensions_used && (qt->window.options & RRDR_OPTION_NONZERO) && !dimensions_nonzero)
         // when all the dimensions are zero, we should return all of them
         qt->window.options &= ~RRDR_OPTION_NONZERO;
 

--- a/web/api/queries/rrdr.c
+++ b/web/api/queries/rrdr.c
@@ -38,8 +38,8 @@ static void rrdr_dump(RRDR *r)
 
         // for each dimension
         for(c = 0, d = r->st->dimensions; d ;c++, d = d->next) {
-            if(unlikely(r->od[c] & RRDR_DIMENSION_HIDDEN)) continue;
-            if(unlikely(!(r->od[c] & RRDR_DIMENSION_NONZERO))) continue;
+            if(r->od[c] & RRDR_DIMENSION_HIDDEN) continue;
+            if(!(r->od[c] & RRDR_DIMENSION_NONZERO)) continue;
 
             if(co[c] & RRDR_EMPTY)
                 fprintf(stderr, "null ");
@@ -59,7 +59,7 @@ static void rrdr_dump(RRDR *r)
 */
 
 inline void rrdr_free(ONEWAYALLOC *owa, RRDR *r) {
-    if(unlikely(!r)) return;
+    if(!r) return;
 
     for(size_t d = 0; d < r->d ;d++) {
         string_freez(r->di[d]);
@@ -108,7 +108,7 @@ inline void rrdr_free(ONEWAYALLOC *owa, RRDR *r) {
 }
 
 RRDR *rrdr_create(ONEWAYALLOC *owa, QUERY_TARGET *qt, size_t dimensions, size_t points) {
-    if(unlikely(!qt))
+    if(!qt)
         return NULL;
 
     // create the rrdr

--- a/web/api/queries/ses/ses.h
+++ b/web/api/queries/ses/ses.h
@@ -71,7 +71,7 @@ static inline void tg_ses_free(RRDR *r) {
 static inline void tg_ses_add(RRDR *r, NETDATA_DOUBLE value) {
     struct tg_ses *g = (struct tg_ses *)r->time_grouping.data;
 
-    if(unlikely(!g->count))
+    if(!g->count)
         g->level = value;
 
     g->level = g->alpha * value + g->alpha_other * g->level;
@@ -81,7 +81,7 @@ static inline void tg_ses_add(RRDR *r, NETDATA_DOUBLE value) {
 static inline NETDATA_DOUBLE tg_ses_flush(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr) {
     struct tg_ses *g = (struct tg_ses *)r->time_grouping.data;
 
-    if(unlikely(!g->count || !netdata_double_isnumber(g->level))) {
+    if(!g->count || !netdata_double_isnumber(g->level)) {
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
         return 0.0;
     }

--- a/web/api/queries/stddev/stddev.c
+++ b/web/api/queries/stddev/stddev.c
@@ -14,7 +14,7 @@ NETDATA_DOUBLE grouping_flush_mean(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options
 
     NETDATA_DOUBLE value;
 
-    if(unlikely(!g->count)) {
+    if(!g->count) {
         value = 0.0;
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
     }
@@ -41,7 +41,7 @@ NETDATA_DOUBLE grouping_flush_variance(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_opt
 
     NETDATA_DOUBLE value;
 
-    if(unlikely(!g->count)) {
+    if(!g->count) {
         value = 0.0;
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
     }

--- a/web/api/queries/stddev/stddev.h
+++ b/web/api/queries/stddev/stddev.h
@@ -66,7 +66,7 @@ static inline NETDATA_DOUBLE tg_stddev_flush(RRDR *r, RRDR_VALUE_FLAGS *rrdr_val
 
     NETDATA_DOUBLE value;
 
-    if(likely(g->count > 1)) {
+    if(g->count > 1) {
         value = tg_stddev_stddev(g);
 
         if(!netdata_double_isnumber(value)) {
@@ -93,11 +93,11 @@ static inline NETDATA_DOUBLE tg_stddev_coefficient_of_variation_flush(RRDR *r, R
 
     NETDATA_DOUBLE value;
 
-    if(likely(g->count > 1)) {
+    if(g->count > 1) {
         NETDATA_DOUBLE m = tg_stddev_mean(g);
         value = 100.0 * tg_stddev_stddev(g) / ((m < 0)? -m : m);
 
-        if(unlikely(!netdata_double_isnumber(value))) {
+        if(!netdata_double_isnumber(value)) {
             value = 0.0;
             *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
         }

--- a/web/api/queries/sum/sum.h
+++ b/web/api/queries/sum/sum.h
@@ -39,7 +39,7 @@ static inline NETDATA_DOUBLE tg_sum_flush(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_
 
     NETDATA_DOUBLE value;
 
-    if(unlikely(!g->count)) {
+    if(!g->count) {
         value = 0.0;
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
     }

--- a/web/api/queries/trimmed_mean/trimmed_mean.h
+++ b/web/api/queries/trimmed_mean/trimmed_mean.h
@@ -77,7 +77,7 @@ static inline void tg_trimmed_mean_free(RRDR *r) {
 static inline void tg_trimmed_mean_add(RRDR *r, NETDATA_DOUBLE value) {
     struct tg_trimmed_mean *g = (struct tg_trimmed_mean *)r->time_grouping.data;
 
-    if(unlikely(g->next_pos >= g->series_size)) {
+    if(g->next_pos >= g->series_size) {
         g->series = onewayalloc_doublesize( r->internal.owa, g->series, g->series_size * sizeof(NETDATA_DOUBLE));
         g->series_size *= 2;
     }
@@ -91,7 +91,7 @@ static inline NETDATA_DOUBLE tg_trimmed_mean_flush(RRDR *r, RRDR_VALUE_FLAGS *rr
     NETDATA_DOUBLE value;
     size_t available_slots = g->next_pos;
 
-    if(unlikely(!available_slots)) {
+    if(!available_slots) {
         value = 0.0;
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
     }
@@ -154,7 +154,7 @@ static inline NETDATA_DOUBLE tg_trimmed_mean_flush(RRDR *r, RRDR_VALUE_FLAGS *rr
             value = min;
     }
 
-    if(unlikely(!netdata_double_isnumber(value))) {
+    if(!netdata_double_isnumber(value)) {
         value = 0.0;
         *rrdr_value_options_ptr |= RRDR_VALUE_EMPTY;
     }

--- a/web/api/queries/weights.c
+++ b/web/api/queries/weights.c
@@ -87,7 +87,7 @@ static void register_result(DICTIONARY *results, RRDHOST *host, RRDCONTEXT_ACQUI
     NETDATA_DOUBLE v = fabsndd(value);
 
     // no need to store zero scored values
-    if(unlikely(fpclassify(v) == FP_ZERO && !register_zero))
+    if(fpclassify(v) == FP_ZERO && !register_zero)
         return;
 
     // keep track of the max of the baseline / highlight ratio
@@ -1222,7 +1222,7 @@ static double ks_2samp(
     double en = round(dbase_size * dhigh_size / (dbase_size + dhigh_size));
 
     // under these conditions, KSfbar() crashes
-    if(unlikely(isnan(en) || isinf(en) || en == 0.0 || isnan(d) || isinf(d)))
+    if(isnan(en) || isinf(en) || en == 0.0 || isnan(d) || isinf(d))
         return NAN;
 
     return KSfbar((int)en, d);
@@ -1240,10 +1240,10 @@ static double kstwo(
     int base_size = (int)calculate_pairs_diff(baseline_diffs, baseline, baseline_points);
     int high_size = (int)calculate_pairs_diff(highlight_diffs, highlight, highlight_points);
 
-    if(unlikely(!base_size || !high_size))
+    if(!base_size || !high_size)
         return NAN;
 
-    if(unlikely(base_size != baseline_points - 1 || high_size != highlight_points - 1)) {
+    if(base_size != baseline_points - 1 || high_size != highlight_points - 1) {
         netdata_log_error("Metric correlations: internal error - calculate_pairs_diff() returns the wrong number of entries");
         return NAN;
     }
@@ -1297,13 +1297,13 @@ NETDATA_DOUBLE *rrd2rrdr_ks2(
         goto cleanup;
     }
 
-    if(unlikely(r->od[0] & RRDR_DIMENSION_HIDDEN))
+    if(r->od[0] & RRDR_DIMENSION_HIDDEN)
         goto cleanup;
 
-    if(unlikely(!(r->od[0] & RRDR_DIMENSION_QUERIED)))
+    if(!(r->od[0] & RRDR_DIMENSION_QUERIED))
         goto cleanup;
 
-    if(unlikely(!(r->od[0] & RRDR_DIMENSION_NONZERO)))
+    if(!(r->od[0] & RRDR_DIMENSION_NONZERO))
         goto cleanup;
 
     if(rrdr_rows(r) < 2)
@@ -1367,11 +1367,11 @@ static void rrdset_metric_correlations_ks2(
     if(!isnan(prob) && !isinf(prob)) {
 
         // these conditions should never happen, but still let's check
-        if(unlikely(prob < 0.0)) {
+        if(prob < 0.0) {
             netdata_log_error("Metric correlations: kstwo() returned a negative number: %f", prob);
             prob = -prob;
         }
-        if(unlikely(prob > 1.0)) {
+        if(prob > 1.0) {
             netdata_log_error("Metric correlations: kstwo() returned a number above 1.0: %f", prob);
             prob = 1.0;
         }
@@ -1628,7 +1628,7 @@ static size_t spread_results_evenly(DICTIONARY *results, WEIGHTS_STATS *stats) {
     NETDATA_DOUBLE last_value = NAN;
     size_t unique_values = 0;
     for(size_t i = 0; i < dimensions ;i++) {
-        if(likely(slots[i] != last_value))
+        if(slots[i] != last_value)
             slots[unique_values++] = last_value = slots[i];
     }
 
@@ -1642,7 +1642,7 @@ static size_t spread_results_evenly(DICTIONARY *results, WEIGHTS_STATS *stats) {
     dfe_start_read(results, t) {
         int slot = binary_search_bigger_than_netdata_double(slots, 0, (int)unique_values, t->value);
         NETDATA_DOUBLE v = slot * slot_weight;
-        if(unlikely(v > 1.0)) v = 1.0;
+        if(v > 1.0) v = 1.0;
         v = 1.0 - v;
         t->value = v;
     }

--- a/web/api/web_api.c
+++ b/web/api/web_api.c
@@ -32,7 +32,7 @@ static bool web_client_check_acl_and_bearer(struct web_client *w, WEB_CLIENT_ACL
 }
 
 int web_client_api_request_vX(RRDHOST *host, struct web_client *w, char *url_path_endpoint, struct web_api_command *api_commands) {
-    if(unlikely(!url_path_endpoint || !*url_path_endpoint)) {
+    if(!url_path_endpoint || !*url_path_endpoint) {
         buffer_flush(w->response.data);
         buffer_sprintf(w->response.data, "Which API command?");
         return HTTP_RESP_BAD_REQUEST;
@@ -41,8 +41,8 @@ int web_client_api_request_vX(RRDHOST *host, struct web_client *w, char *url_pat
     uint32_t hash = simple_hash(url_path_endpoint);
 
     for(int i = 0; api_commands[i].command ; i++) {
-        if(unlikely(hash == api_commands[i].hash && !strcmp(url_path_endpoint, api_commands[i].command))) {
-            if(unlikely(!web_client_check_acl_and_bearer(w, api_commands[i].acl)))
+        if(hash == api_commands[i].hash && !strcmp(url_path_endpoint, api_commands[i].command)) {
+            if(!web_client_check_acl_and_bearer(w, api_commands[i].acl))
                 return web_client_bearer_required(w);
 
             char *query_string = (char *)buffer_tostring(w->url_query_string_decoded);

--- a/web/api/web_api.h
+++ b/web/api/web_api.h
@@ -27,7 +27,7 @@ struct web_client;
 int web_client_api_request_vX(RRDHOST *host, struct web_client *w, char *url_path_endpoint, struct web_api_command *api_commands);
 
 static inline void fix_google_param(char *s) {
-    if(unlikely(!s || !*s)) return;
+    if(!s || !*s) return;
 
     for( ; *s ;s++) {
         if(!isalnum(*s) && *s != '.' && *s != '_' && *s != '-')

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -153,7 +153,7 @@ char *get_mgmt_api_key(void) {
     char *api_key_filename=config_get(CONFIG_SECTION_REGISTRY, "netdata management api key file", filename);
     static char guid[GUID_LEN + 1] = "";
 
-    if(likely(guid[0]))
+    if(guid[0])
         return guid;
 
     // read it from disk
@@ -219,7 +219,7 @@ inline RRDR_OPTIONS web_client_api_request_v1_data_options(char *o) {
         uint32_t hash = simple_hash(tok);
         int i;
         for(i = 0; api_v1_data_options[i].name ; i++) {
-            if (unlikely(hash == api_v1_data_options[i].hash && !strcmp(tok, api_v1_data_options[i].name))) {
+            if (hash == api_v1_data_options[i].hash && !strcmp(tok, api_v1_data_options[i].name)) {
                 ret |= api_v1_data_options[i].value;
                 break;
             }
@@ -239,7 +239,7 @@ inline CONTEXTS_V2_OPTIONS web_client_api_request_v2_context_options(char *o) {
         uint32_t hash = simple_hash(tok);
         int i;
         for(i = 0; contexts_v2_options[i].name ; i++) {
-            if (unlikely(hash == contexts_v2_options[i].hash && !strcmp(tok, contexts_v2_options[i].name))) {
+            if (hash == contexts_v2_options[i].hash && !strcmp(tok, contexts_v2_options[i].name)) {
                 ret |= contexts_v2_options[i].value;
                 break;
             }
@@ -259,7 +259,7 @@ inline CONTEXTS_V2_ALERT_STATUS web_client_api_request_v2_alert_status(char *o) 
         uint32_t hash = simple_hash(tok);
         int i;
         for(i = 0; contexts_v2_alert_status[i].name ; i++) {
-            if (unlikely(hash == contexts_v2_alert_status[i].hash && !strcmp(tok, contexts_v2_alert_status[i].name))) {
+            if (hash == contexts_v2_alert_status[i].hash && !strcmp(tok, contexts_v2_alert_status[i].name)) {
                 ret |= contexts_v2_alert_status[i].value;
                 break;
             }
@@ -274,7 +274,7 @@ void web_client_api_request_v2_contexts_alerts_status_to_buffer_json_array(BUFFE
 
     RRDR_OPTIONS used = 0; // to prevent adding duplicates
     for(int i = 0; contexts_v2_alert_status[i].name ; i++) {
-        if (unlikely((contexts_v2_alert_status[i].value & options) && !(contexts_v2_alert_status[i].value & used))) {
+        if ((contexts_v2_alert_status[i].value & options) && !(contexts_v2_alert_status[i].value & used)) {
             const char *name = contexts_v2_alert_status[i].name;
             used |= contexts_v2_alert_status[i].value;
 
@@ -290,7 +290,7 @@ void web_client_api_request_v2_contexts_options_to_buffer_json_array(BUFFER *wb,
 
     RRDR_OPTIONS used = 0; // to prevent adding duplicates
     for(int i = 0; contexts_v2_options[i].name ; i++) {
-        if (unlikely((contexts_v2_options[i].value & options) && !(contexts_v2_options[i].value & used))) {
+        if ((contexts_v2_options[i].value & options) && !(contexts_v2_options[i].value & used)) {
             const char *name = contexts_v2_options[i].name;
             used |= contexts_v2_options[i].value;
 
@@ -306,7 +306,7 @@ void web_client_api_request_v1_data_options_to_buffer_json_array(BUFFER *wb, con
 
     RRDR_OPTIONS used = 0; // to prevent adding duplicates
     for(int i = 0; api_v1_data_options[i].name ; i++) {
-        if (unlikely((api_v1_data_options[i].value & options) && !(api_v1_data_options[i].value & used))) {
+        if ((api_v1_data_options[i].value & options) && !(api_v1_data_options[i].value & used)) {
             const char *name = api_v1_data_options[i].name;
             used |= api_v1_data_options[i].value;
 
@@ -324,7 +324,7 @@ void web_client_api_request_v1_data_options_to_string(char *buf, size_t size, RR
     RRDR_OPTIONS used = 0; // to prevent adding duplicates
     int added = 0;
     for(int i = 0; api_v1_data_options[i].name ; i++) {
-        if (unlikely((api_v1_data_options[i].value & options) && !(api_v1_data_options[i].value & used))) {
+        if ((api_v1_data_options[i].value & options) && !(api_v1_data_options[i].value & used)) {
             const char *name = api_v1_data_options[i].name;
             used |= api_v1_data_options[i].value;
 
@@ -345,7 +345,7 @@ inline uint32_t web_client_api_request_v1_data_format(char *name) {
     int i;
 
     for(i = 0; api_v1_data_formats[i].name ; i++) {
-        if (unlikely(hash == api_v1_data_formats[i].hash && !strcmp(name, api_v1_data_formats[i].name))) {
+        if (hash == api_v1_data_formats[i].hash && !strcmp(name, api_v1_data_formats[i].name)) {
             return api_v1_data_formats[i].value;
         }
     }
@@ -358,7 +358,7 @@ inline uint32_t web_client_api_request_v1_data_google_format(char *name) {
     int i;
 
     for(i = 0; api_v1_data_google_formats[i].name ; i++) {
-        if (unlikely(hash == api_v1_data_google_formats[i].hash && !strcmp(name, api_v1_data_google_formats[i].name))) {
+        if (hash == api_v1_data_google_formats[i].hash && !strcmp(name, api_v1_data_google_formats[i].name)) {
             return api_v1_data_google_formats[i].value;
         }
     }
@@ -909,7 +909,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
             hash_switch = 0, hash_machine = 0, hash_url = 0, hash_name = 0, hash_delete_url = 0, hash_for = 0,
             hash_to = 0 /*, hash_redirects = 0 */;
 
-    if(unlikely(!hash_action)) {
+    if(!hash_action) {
         hash_action = simple_hash("action");
         hash_access = simple_hash("access");
         hash_hello = simple_hash("hello");
@@ -1008,21 +1008,21 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
 #endif /* NETDATA_INTERNAL_CHECKS */
     }
 
-    if(unlikely(respect_web_browser_do_not_track_policy && web_client_has_donottrack(w))) {
+    if(respect_web_browser_do_not_track_policy && web_client_has_donottrack(w)) {
         buffer_flush(w->response.data);
         buffer_sprintf(w->response.data, "Your web browser is sending 'DNT: 1' (Do Not Track). The registry requires persistent cookies on your browser to work.");
         return HTTP_RESP_BAD_REQUEST;
     }
 
-    if(unlikely(action == 'H')) {
+    if(action == 'H') {
         // HELLO request, dashboard ACL
         analytics_log_dashboard();
-        if(unlikely(!web_client_can_access_dashboard(w)))
+        if(!web_client_can_access_dashboard(w))
             return web_client_permission_denied(w);
     }
     else {
         // everything else, registry ACL
-        if(unlikely(!web_client_can_access_registry(w)))
+        if(!web_client_can_access_registry(w))
             return web_client_permission_denied(w);
     }
 
@@ -1030,7 +1030,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
 
     switch(action) {
         case 'A':
-            if(unlikely(!machine_guid || !machine_url || !url_name)) {
+            if(!machine_guid || !machine_url || !url_name) {
                 netdata_log_error("Invalid registry request - access requires these parameters: machine ('%s'), url ('%s'), name ('%s')", machine_guid ? machine_guid : "UNSET", machine_url ? machine_url : "UNSET", url_name ? url_name : "UNSET");
                 buffer_flush(w->response.data);
                 buffer_strcat(w->response.data, "Invalid registry Access request.");
@@ -1041,7 +1041,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
             return registry_request_access_json(host, w, person_guid, machine_guid, machine_url, url_name, now_realtime_sec());
 
         case 'D':
-            if(unlikely(!machine_guid || !machine_url || !delete_url)) {
+            if(!machine_guid || !machine_url || !delete_url) {
                 netdata_log_error("Invalid registry request - delete requires these parameters: machine ('%s'), url ('%s'), delete_url ('%s')", machine_guid?machine_guid:"UNSET", machine_url?machine_url:"UNSET", delete_url?delete_url:"UNSET");
                 buffer_flush(w->response.data);
                 buffer_strcat(w->response.data, "Invalid registry Delete request.");
@@ -1052,7 +1052,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
             return registry_request_delete_json(host, w, person_guid, machine_guid, machine_url, delete_url, now_realtime_sec());
 
         case 'S':
-            if(unlikely(!search_machine_guid)) {
+            if(!search_machine_guid) {
                 netdata_log_error("Invalid registry request - search requires these parameters: for ('%s')", search_machine_guid?search_machine_guid:"UNSET");
                 buffer_flush(w->response.data);
                 buffer_strcat(w->response.data, "Invalid registry Search request.");
@@ -1063,7 +1063,7 @@ inline int web_client_api_request_v1_registry(RRDHOST *host, struct web_client *
             return registry_request_search_json(host, w, person_guid, search_machine_guid);
 
         case 'W':
-            if(unlikely(!machine_guid || !machine_url || !to_person_guid)) {
+            if(!machine_guid || !machine_url || !to_person_guid) {
                 netdata_log_error("Invalid registry request - switching identity requires these parameters: machine ('%s'), url ('%s'), to ('%s')", machine_guid?machine_guid:"UNSET", machine_url?machine_url:"UNSET", to_person_guid?to_person_guid:"UNSET");
                 buffer_flush(w->response.data);
                 buffer_strcat(w->response.data, "Invalid registry Switch request.");
@@ -1089,7 +1089,7 @@ void web_client_api_request_v1_info_summary_alarm_statuses(RRDHOST *host, BUFFER
     size_t normal = 0, warning = 0, critical = 0;
     RRDCALC *rc;
     foreach_rrdcalc_in_rrdhost_read(host, rc) {
-        if(unlikely(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec))
+        if(!rc->rrdset || !rc->rrdset->last_collected_time.tv_sec)
             continue;
 
         switch(rc->status) {
@@ -1562,7 +1562,7 @@ static struct web_api_command api_commands_v1[] = {
 inline int web_client_api_request_v1(RRDHOST *host, struct web_client *w, char *url_path_endpoint) {
     static int initialized = 0;
 
-    if(unlikely(initialized == 0)) {
+    if(initialized == 0) {
         initialized = 1;
 
         for(int i = 0; api_commands_v1[i].command ; i++)

--- a/web/api/web_api_v2.c
+++ b/web/api/web_api_v2.c
@@ -669,7 +669,7 @@ static struct web_api_command api_commands_v2[] = {
 inline int web_client_api_request_v2(RRDHOST *host, struct web_client *w, char *url_path_endpoint) {
     static int initialized = 0;
 
-    if(unlikely(initialized == 0)) {
+    if(initialized == 0) {
         initialized = 1;
 
         for(int i = 0; api_commands_v2[i].command ; i++)

--- a/web/rtc/webrtc.c
+++ b/web/rtc/webrtc.c
@@ -626,7 +626,7 @@ static void myGatheringStateCallback(int pc __maybe_unused, rtcGatheringState st
 }
 
 int webrtc_new_connection(const char *sdp, BUFFER *wb) {
-    if(unlikely(!webrtc_base.enabled)) {
+    if(!webrtc_base.enabled) {
         buffer_flush(wb);
         buffer_strcat(wb, "WebRTC is not enabled on this agent.");
         wb->content_type = CT_TEXT_PLAIN;
@@ -635,7 +635,7 @@ int webrtc_new_connection(const char *sdp, BUFFER *wb) {
 
     cleanupConnections();
 
-    if(unlikely(!sdp || !*sdp)) {
+    if(!sdp || !*sdp) {
         buffer_flush(wb);
         buffer_strcat(wb, "No SDP message posted with the request");
         wb->content_type = CT_TEXT_PLAIN;

--- a/web/server/web_server.c
+++ b/web/server/web_server.c
@@ -63,7 +63,7 @@ void api_listen_sockets_setup(void) {
 	if(!socks)
 		fatal("LISTENER: Cannot listen on any API socket. Exiting...");
 
-	if(unlikely(debug_flags & D_WEB_CLIENT))
+	if(debug_flags & D_WEB_CLIENT)
 		debug_sockets();
 
 	return;


### PR DESCRIPTION
##### Summary

Here's what GCC's manual has to say:

> In general, you should prefer to use actual
> profile feedback for this (-fprofile-arcs),
> as programmers are notoriously bad at
> predicting how their programs actually
> perform.

Indeed, using the profile plugin with:

- 16 threads
- 400 charts per thread
- 5 dimensions per chart,
- 1M points to backfill per dim,

leads to a consistent, small improvement of
2-3% in the rate of total points written
per second when **removing** the builtin.

There are definitely some places where we
could benefit from using `__builtin_expect`.
However:
  - Currently, we use it everywhere which negates any improvements.
  - We need to profile each location where we use the builtin.

In general, the agent is memory bound for most
of its heavy operations. I don't think:
  - we can easily outsmart compilers + post-2000s CPUs, and
  - there's any real-world scenario where using this builtin would show up any visible difference.

Removing the builtin makes the code much more
readable.

##### Test Plan

- CI jobs