### PR TITLE
Improve the update of the alert chart name in the database

### DIFF
--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -85,7 +85,8 @@ failed:
 #define SQL_INSERT_HEALTH_LOG "INSERT INTO health_log (host_id, alarm_id, " \
     "config_hash_id, name, chart, family, exec, recipient, units, chart_context, last_transition_id, chart_name) " \
     "VALUES (?,?,?,?,?,?,?,?,?,?,?,?) " \
-    "ON CONFLICT (host_id, alarm_id) DO UPDATE SET last_transition_id = excluded.last_transition_id RETURNING health_log_id; "
+    "ON CONFLICT (host_id, alarm_id) DO UPDATE SET last_transition_id = excluded.last_transition_id, " \
+    "chart_name = excluded.chart_name RETURNING health_log_id; "
 
 #define SQL_INSERT_HEALTH_LOG_DETAIL "INSERT INTO health_log_detail (health_log_id, unique_id, alarm_id, alarm_event_id, " \
     "updated_by_id, updates_id, when_key, duration, non_clear_duration, flags, exec_run_timestamp, delay_up_to_timestamp, " \

--- a/health/health.c
+++ b/health/health.c
@@ -844,8 +844,8 @@ static void initialize_health(RRDHOST *host)
     host->health.health_default_exec = string_strdupz(config_get(CONFIG_SECTION_HEALTH, "script to execute on alarm", filename));
     host->health.health_default_recipient = string_strdupz("root");
 
-    if (!is_chart_name_populated(&host->host_uuid))
-        chart_name_populate(&host->host_uuid);
+    //if (!is_chart_name_populated(&host->host_uuid))
+    //    chart_name_populate(&host->host_uuid);
 
     sql_health_alarm_log_load(host);
 


### PR DESCRIPTION
##### Summary
The current approach that tries to update the alert chart name during health init may cause a deadlock (on parents with a lot of children). 

This PR skips the update during health initialization and will do on demand when new alert transition is stored.

