### PR TITLE
Fix resource leak - CID 396310

### DIFF
--- a/collectors/proc.plugin/sys_devices_system_edac_mc.c
+++ b/collectors/proc.plugin/sys_devices_system_edac_mc.c
@@ -121,6 +121,7 @@ static void find_all_mc() {
                     DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(m->dimms, d, prev, next);
             }
         }
+        closedir(dir);
     }
 }
 


### PR DESCRIPTION
##### Summary
- Fix CID 396310:    (RESOURCE_LEAK)
  - /collectors/proc.plugin/sys_devices_system_edac_mc.c: 89 in find_all_mc()
