### PR TITLE
Avoid an extra uuid_copy when creating new MRG entries

### DIFF
--- a/database/engine/journalfile.c
+++ b/database/engine/journalfile.c
@@ -696,12 +696,12 @@ static void journalfile_restore_extent_metadata(struct rrdengine_instance *ctx, 
         bool update_metric_time = true;
         if (!metric) {
             MRG_ENTRY entry = {
+                    .uuid = temp_id,
                     .section = (Word_t)ctx,
                     .first_time_s = vd.start_time_s,
                     .last_time_s = vd.end_time_s,
                     .latest_update_every_s = (uint32_t) vd.update_every_s,
             };
-            uuid_copy(entry.uuid, *temp_id);
 
             bool added;
             metric = mrg_metric_add_and_acquire(main_mrg, entry, &added);

--- a/database/engine/metric.c
+++ b/database/engine/metric.c
@@ -166,7 +166,7 @@ static inline bool metric_release_and_can_be_deleted(MRG *mrg __maybe_unused, ME
 }
 
 static inline METRIC *metric_add_and_acquire(MRG *mrg, MRG_ENTRY *entry, bool *ret) {
-    size_t partition = uuid_partition(mrg, &entry->uuid);
+    size_t partition = uuid_partition(mrg, entry->uuid);
 
     METRIC *allocation = aral_mallocz(mrg->index[partition].aral);
 
@@ -174,7 +174,7 @@ static inline METRIC *metric_add_and_acquire(MRG *mrg, MRG_ENTRY *entry, bool *r
 
     size_t mem_before_judyl, mem_after_judyl;
 
-    Pvoid_t *sections_judy_pptr = JudyHSIns(&mrg->index[partition].uuid_judy, &entry->uuid, sizeof(uuid_t), PJE0);
+    Pvoid_t *sections_judy_pptr = JudyHSIns(&mrg->index[partition].uuid_judy, entry->uuid, sizeof(uuid_t), PJE0);
     if(unlikely(!sections_judy_pptr || sections_judy_pptr == PJERR))
         fatal("DBENGINE METRIC: corrupted UUIDs JudyHS array");
 
@@ -207,8 +207,7 @@ static inline METRIC *metric_add_and_acquire(MRG *mrg, MRG_ENTRY *entry, bool *r
     }
 
     METRIC *metric = allocation;
-    // memcpy(metric->uuid, entry->uuid, sizeof(uuid_t));
-    uuid_copy(metric->uuid, entry->uuid);
+    uuid_copy(metric->uuid, *entry->uuid);
     metric->section = entry->section;
     metric->first_time_s = MAX(0, entry->first_time_s);
     metric->latest_time_s_clean = MAX(0, entry->last_time_s);
@@ -690,13 +689,12 @@ inline void mrg_update_metric_retention_and_granularity_by_uuid(
     METRIC *metric = mrg_metric_get_and_acquire(mrg, uuid, section);
     if (!metric) {
         MRG_ENTRY entry = {
+                .uuid = uuid,
                 .section = section,
                 .first_time_s = first_time_s,
                 .last_time_s = last_time_s,
                 .latest_update_every_s = (uint32_t) update_every_s
         };
-        // memcpy(entry.uuid, *uuid, sizeof(uuid_t));
-        uuid_copy(entry.uuid, *uuid);
         metric = mrg_metric_add_and_acquire(mrg, entry, &added);
     }
 
@@ -788,13 +786,15 @@ int mrg_unittest(void) {
     METRIC *m1_t1, *m2_t1, *m3_t1, *m4_t1;
     bool ret;
 
+    uuid_t test_uuid;
+    uuid_generate(test_uuid);
     MRG_ENTRY entry = {
+            .uuid = &test_uuid,
             .section = 0,
             .first_time_s = 2,
             .last_time_s = 3,
             .latest_update_every_s = 4,
     };
-    uuid_generate(entry.uuid);
     m1_t0 = mrg_metric_add_and_acquire(mrg, entry, &ret);
     if(!ret)
         fatal("DBENGINE METRIC: failed to add metric");
@@ -806,7 +806,7 @@ int mrg_unittest(void) {
     if(ret)
         fatal("DBENGINE METRIC: managed to add the same metric twice");
 
-    m3_t0 = mrg_metric_get_and_acquire(mrg, &entry.uuid, entry.section);
+    m3_t0 = mrg_metric_get_and_acquire(mrg, entry.uuid, entry.section);
     if(m3_t0 != m1_t0)
         fatal("DBENGINE METRIC: cannot find the metric added");
 
@@ -830,7 +830,7 @@ int mrg_unittest(void) {
     if(ret)
         fatal("DBENGINE METRIC: managed to add the same metric twice in (section 0)");
 
-    m3_t1 = mrg_metric_get_and_acquire(mrg, &entry.uuid, entry.section);
+    m3_t1 = mrg_metric_get_and_acquire(mrg, entry.uuid, entry.section);
     if(m3_t1 != m1_t1)
         fatal("DBENGINE METRIC: cannot find the metric added (section %zu)", (size_t)entry.section);
 
@@ -844,7 +844,7 @@ int mrg_unittest(void) {
     if(!mrg_metric_release_and_delete(mrg, m1_t0))
         fatal("DBENGINE METRIC: cannot delete the first metric");
 
-    m4_t1 = mrg_metric_get_and_acquire(mrg, &entry.uuid, entry.section);
+    m4_t1 = mrg_metric_get_and_acquire(mrg, entry.uuid, entry.section);
     if(m4_t1 != m1_t1)
         fatal("DBENGINE METRIC: cannot find the metric added (section %zu), after deleting the first one", (size_t)entry.section);
 

--- a/database/engine/metric.h
+++ b/database/engine/metric.h
@@ -9,7 +9,7 @@ typedef struct metric METRIC;
 typedef struct mrg MRG;
 
 typedef struct mrg_entry {
-    uuid_t uuid;
+    uuid_t *uuid;
     Word_t section;
     time_t first_time_s;
     time_t last_time_s;

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -131,12 +131,12 @@ static METRIC *rrdeng_metric_create(STORAGE_INSTANCE *db_instance, uuid_t *uuid)
 
     struct rrdengine_instance *ctx = (struct rrdengine_instance *)db_instance;
     MRG_ENTRY entry = {
+            .uuid = uuid,
             .section = (Word_t)ctx,
             .first_time_s = 0,
             .last_time_s = 0,
             .latest_update_every_s = 0,
     };
-    uuid_copy(entry.uuid, *uuid);
 
     METRIC *metric = mrg_metric_add_and_acquire(main_mrg, entry, NULL);
     return metric;


### PR DESCRIPTION
##### Summary

Currently we copy the UUIDs twice. Passing the pointer and doing the copy once seems to improve performance
when creating a lot of entries

