### PR TITLE
Add a schema for the categories.yaml file.

### DIFF
--- a/integrations/categories.yaml
+++ b/integrations/categories.yaml
@@ -1,344 +1,415 @@
-- name: deploy
+- id: deploy
+  name: deploy
   description: ""
   most_popular: false
+  priority: -1
   children:
     - id: deploy.operating-systems
       name: Operating Systems
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: deploy.docker-kubernetes
       name: Docker & Kubernetes
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: deploy.provisioning-systems
       parent: deploy
       name: Provisioning Systems
       description: ""
       most_popular: false
+      priority: -1
       children: []
-- name: data-collection
+- id: data-collection
+  name: data-collection
   description: ""
   most_popular: false
+  priority: -1
   children:
     - id: data-collection.other
       name: Other
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.ebpf
       name: eBPF
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.freebsd
       name: FreeBSD
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.containers-and-vms
       name: Containers and VMs
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.database-servers
       name: Database Servers
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.kubernetes
       name: Kubernetes
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.service-discovery-registry
       name: Service Discovery / Registry
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.web-servers-and-web-proxies
       name: Web Servers and Web Proxies
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.cloud-provider-managed
       name: Cloud Provider Managed
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.windows-systems
       name: Windows Systems
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.apm
       name: APM
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.hardware-devices-and-sensors
       name: Hardware Devices and Sensors
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.macos-systems
       name: macOS Systems
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.message-brokers
       name: Message Brokers
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.provisioning-systems
       name: Provisioning Systems
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.search-engines
       name: Search Engines
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.linux-systems
       name: Linux Systems
       description: ""
       most_popular: false
+      priority: -1
       children:
         - id: data-collection.linux-systems.system-metrics
           name: System Metrics
           description: ""
           most_popular: false
+          priority: -1
           children: []
         - id: data-collection.linux-systems.memory-metrics
           name: Memory Metrics
           description: ""
           most_popular: false
+          priority: -1
           children: []
         - id: data-collection.linux-systems.cpu-metrics
           name: CPU Metrics
           description: ""
           most_popular: false
+          priority: -1
           children: []
         - id: data-collection.linux-systems.pressure-metrics
           name: Pressure Metrics
           description: ""
           most_popular: false
+          priority: -1
           children: []
         - id: data-collection.linux-systems.network-metrics
           name: Network Metrics
           description: ""
           most_popular: false
+          priority: -1
           children: []
         - id: data-collection.linux-systems.ipc-metrics
           name: IPC Metrics
           description: ""
           most_popular: false
+          priority: -1
           children: []
         - id: data-collection.linux-systems.disk-metrics
           name: Disk Metrics
           description: ""
           most_popular: false
+          priority: -1
           children: []
         - id: data-collection.linux-systems.firewall-metrics
           name: Firewall Metrics
           description: ""
           most_popular: false
+          priority: -1
           children: []
         - id: data-collection.linux-systems.power-supply-metrics
           name: Power Supply Metrics
           description: ""
           most_popular: false
+          priority: -1
           children: []
         - id: data-collection.linux-systems.filesystem-metrics
           name: Filesystem Metrics
           description: ""
           most_popular: false
+          priority: -1
           children:
             - id: data-collection.linux-systems.filesystem-metrics.zfs
               name: ZFS
               description: ""
               most_popular: false
+              priority: -1
               children: []
             - id: data-collection.linux-systems.filesystem-metrics.btrfs
               name: BTRFS
               description: ""
               most_popular: false
+              priority: -1
               children: []
             - id: data-collection.linux-systems.filesystem-metrics.nfs
               name: NFS
               description: ""
               most_popular: false
+              priority: -1
               children: []
         - id: data-collection.linux-systems.kernel-metrics
           name: Kernel Metrics
           description: ""
           most_popular: false
+          priority: -1
           children: []
     - id: data-collection.notifications
       name: Notifications
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.networking-stack-and-network-interfaces
       name: Networking Stack and Network Interfaces
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.synthetic-checks
       name: Synthetic Checks
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.ci-cd-systems
       name: CI/CD Systems
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.ups
       name: UPS
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.freebsd-systems
       name: FreeBSD Systems
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.logs-servers
       name: Logs Servers
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.security-systems
       name: Security Systems
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.observability
       name: Observability
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.gaming
       name: Gaming
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.iot-devices
       name: IoT Devices
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.media-streaming-servers
       name: Media Streaming Servers
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.authentication-and-authorization
       name: Authentication and Authorization
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.project-management
       name: Project Management
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.application-servers
       name: Application Servers
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.export
       name: Export
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.dns-and-dhcp-servers
       name: DNS and DHCP Servers
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.mail-servers
       name: Mail Servers
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.processes-and-system-services
       name: Processes and System Services
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.storage-mount-points-and-filesystems
       name: Storage, Mount Points and Filesystems
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.systemd
       name: Systemd
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.telephony-servers
       name: Telephony Servers
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.vpns
       name: VPNs
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.blockchain-servers
       name: Blockchain Servers
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.distributed-computing-systems
       name: Distributed Computing Systems
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.generic-data-collection
       name: Generic Data Collection
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.p2p
       name: P2P
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.snmp-and-networked-devices
       name: SNMP and Networked Devices
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.system-clock-and-ntp
       name: System Clock and NTP
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.nas
       name: NAS
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.api-gateways
       name: API Gateways
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.task-queues
       name: Task Queues
       description: ""
       most_popular: false
+      priority: -1
       children: []
     - id: data-collection.ftp-servers
       name: FTP Servers
       description: ""
       most_popular: false
+      priority: -1
       children: []

--- a/integrations/schemas/categories.json
+++ b/integrations/schemas/categories.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "title": "Category information for integrations.",
+  "items": {
+    "$ref": "#/$defs/category"
+  },
+  "$defs": {
+    "category": {
+      "type": "object",
+      "description": "An entry for a single category.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "A unique ID for the category. Recommended format is a dot-separated list of categories that are parents of this category, followed by a unique value for this category. Must be URL safe."
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The display name for the category."
+        },
+        "description": {
+          "type": "string",
+          "description": "A description of the category."
+        },
+        "most_popular": {
+          "type": "boolean",
+          "description": "Indicates if the category should show up in the initial list of categories, or only in the full expanded list."
+        },
+        "priority": {
+          "type": "integer",
+          "description": "Indicates sort order for categories that are marked as most popular."
+        },
+        "children": {
+          "type": "array",
+          "description": "A list of categories that are children of this category.",
+          "items": {
+            "$ref": "#/$defs/category"
+          }
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "description",
+        "most_popular",
+        "priority",
+        "children"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
##### Summary

This adds a schema for the `integrations/categories.yaml` file so that the structure and meaning is properly documented.

This also adds a `priority` field that will control sort order for categories that are listed as most popular.

##### Test Plan

n/a

##### Additional Information

I’ve set priorities on all the categories to `-1` in this PR just so the schema validates. These will need to be updated appropriately.