### PR TITLE
Update platform support info and add a schema.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -20,6 +20,8 @@ include:
   - &alpine
     distro: alpine
     version: edge
+    support_type: Community
+    notes: ''
     eol_check: false
     env_prep: |
       apk add -U bash
@@ -28,17 +30,30 @@ include:
     test:
       ebpf-core: true
   - <<: *alpine
+    version: "3.18"
+    support_type: Core
+    notes: ''
+    eol_check: true
+  - <<: *alpine
     version: "3.17"
+    support_type: Intermediate
+    notes: ''
     eol_check: true
   - <<: *alpine
     version: "3.16"
+    support_type: Intermediate
+    notes: ''
     eol_check: true
   - <<: *alpine
     version: "3.15"
+    support_type: Intermediate
+    notes: ''
     eol_check: true
 
   - distro: archlinux
     version: latest
+    support_type: Intermediate
+    notes: ''
     eol_check: false
     env_prep: |
       pacman --noconfirm -Syu && pacman --noconfirm -Sy grep libffi
@@ -48,6 +63,8 @@ include:
   - &alma
     distro: almalinux
     version: "9"
+    support_type: Core
+    notes: ''
     jsonc_removal: |
       dnf remove -y json-c-devel
     eol_check: true
@@ -74,6 +91,8 @@ include:
   - &amzn
     distro: amazonlinux
     version: "2"
+    support_type: Core
+    notes: ''
     eol_check: 'amazon-linux'
     packages: &amzn_packages
       type: rpm
@@ -92,6 +111,8 @@ include:
 
   - distro: centos
     version: "7"
+    support_type: Core
+    notes: ''
     eol_check: false
     packages:
       type: rpm
@@ -107,6 +128,8 @@ include:
   - &debian
     distro: debian
     version: "12"
+    support_type: Core
+    notes: ''
     base_image: debian:bookworm
     eol_check: true
     env_prep: |
@@ -143,6 +166,8 @@ include:
   - &fedora
     distro: fedora
     version: "38"
+    support_type: Core
+    notes: ''
     eol_check: true
     jsonc_removal: |
       dnf remove -y json-c-devel
@@ -165,6 +190,8 @@ include:
   - &opensuse
     distro: opensuse
     version: "tumbleweed"
+    support_type: Intermediate
+    notes: ''
     eol_check: true
     base_image: opensuse/tumbleweed
     jsonc_removal: |
@@ -179,12 +206,16 @@ include:
       ebpf-core: true
   - <<: *opensuse
     version: "15.5"
+    support_type: Core
+    notes: ''
     base_image: opensuse/leap:15.5
     packages:
       <<: *opensuse_packages
       repo_distro: opensuse/15.5
   - <<: *opensuse
     version: "15.4"
+    support_type: Core
+    notes: ''
     base_image: opensuse/leap:15.4
     packages:
       <<: *opensuse_packages
@@ -193,6 +224,8 @@ include:
   - &oracle
     distro: oraclelinux
     version: "8"
+    support_type: Core
+    notes: ''
     eol_check: true
     jsonc_removal: |
       dnf remove -y json-c-devel
@@ -213,6 +246,8 @@ include:
   - &ubuntu
     distro: ubuntu
     version: "22.04"
+    support_type: Core
+    notes: ''
     eol_check: true
     env_prep: |
       rm -f /etc/apt/apt.conf.d/docker && apt-get update
@@ -239,7 +274,9 @@ include:
       repo_distro: ubuntu/focal
 no_include: # Info for platforms not covered in CI
   - distro: docker
-    version: latest
+    version: "19.03 or newer"
+    support_type: Core
+    notes: ''
     packages:
       arches:
         - linux/i386
@@ -247,3 +284,46 @@ no_include: # Info for platforms not covered in CI
         - linux/arm/v7
         - linux/arm64
         - linux/ppc64le
+
+  - distro: clearlinux
+    version: latest
+    support_type: Community
+    notes: ''
+
+  - &rhel
+    distro: rhel
+    version: "9.x"
+    support_type: Core
+    notes: ''
+    packages:
+      arches:
+        - x86_64
+        - aarch64
+  - <<: *rhel
+    version: "8.x"
+  - <<: *rhel
+    version: "7.x"
+    packages:
+      arches:
+        - x86_64
+
+  - &freebsd
+    distro: freebsd
+    version: 13-STABLE
+    support_type: Community
+    notes: ''
+
+  - &macos
+    distro: macos
+    version: '13'
+    support_type: Community
+    notes: ''
+  - <<: *macos
+    version: '12'
+  - <<: *macos
+    version: '11'
+
+  - distro: gentoo
+    version: latest
+    support_type: Community
+    notes: ''

--- a/integrations/schemas/distros.json
+++ b/integrations/schemas/distros.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Platform support information for the Netdata agent.",
+  "properties": {
+    "platform_map": {
+      "type": "object",
+      "description": "Maps CPU architectures to Docker platform strings. Used by CI when generating build matrices.",
+      "patternProperties": {
+        "^.+$": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "arch_order": {
+      "type": "array",
+      "description": "Defines the CPU architecture sort order used when generating build matrices in CI.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "include": {
+      "type": "array",
+      "description": "Defines data for platforms that are included in CI.",
+      "items": {
+        "$ref": "#/$defs/platform"
+      }
+    }
+  },
+  "required": [
+    "platform_map",
+    "arch_order",
+    "include"
+  ],
+  "$defs": {
+    "platform": {
+      "type": "object",
+      "description": "Describes a platform.",
+      "properties": {
+        "distro": {
+          "type": "string",
+          "description": "The name of the platform.",
+          "pattern": "^[a-z][a-z0-9]*$"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version identifier for the platform.",
+          "pattern": "^[a-z0-9][a-z.0-9]*$"
+        },
+        "support_type": {
+          "type": "string",
+          "description": "Defines the support tier that the platform is in.",
+          "enum": [
+            "Core",
+            "Intermediate",
+            "Community",
+            "Third-Party",
+            "Unsupported"
+          ]
+        },
+        "notes": {
+          "type": "string",
+          "description": "Any additional notes about the platform."
+        },
+        "eol_check": {
+          "description": "Indicates if EOL checks should be done for this platform. Only relevant if the platform is included in CI. If the value is a string, that value is used for the EOL check lookup, otherwise the value of the distro key is used.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9._-]*$"
+            }
+          ]
+        },
+        "base_image": {
+          "type": "string",
+          "description": "A string specifying the Docker image to be used for testing this platform.",
+          "pattern": "^[a-z][a-z0-9._/:-]*$"
+        },
+        "env_prep": {
+          "type": "string",
+          "description": "A string containing any shell commands that need to be run to prep the platform for testing in CI."
+        },
+        "jsonc_removal": {
+          "type": "string",
+          "description": "A string containing a shell command to uninstall JSON-C development files during CI checks."
+        },
+        "test": {
+          "type": "object",
+          "description": "Contains additional data for usage by CI.",
+          "properties": {
+            "ebpf-core": {
+              "type": "boolean",
+              "description": "If true, then eBPF CO-RE CI jobs should be run for this platform."
+            }
+          }
+        },
+        "packages": {
+          "type": "object",
+          "description": "Additional information about native packages for this platform.",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Indicates the type of native packages to build for the platform.",
+              "enum": [
+                "deb",
+                "rpm",
+                ""
+              ]
+            },
+            "arches": {
+              "type": "array",
+              "description": "A list of CPU architectures (specified in the usual manner for the platform) that native packages are built for for this platform.",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "repo_distro": {
+              "type": "string",
+              "description": "Identifies the repository name to be used when publishing packages for this platform.",
+              "minLength": 1
+            },
+            "alt_links": {
+              "type": "array",
+              "description": "A list of alternative repository names to be used when publishing packages for this platform.",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "required": [
+            "type",
+            "arches"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "distro",
+        "version",
+        "support_type",
+        "notes"
+      ]
+    }
+  }
+}

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -58,9 +58,11 @@ to work on these platforms with minimal user effort.
 
 | Platform                 | Version        | Official Native Packages               | Notes                                                                                                                                              |
 |--------------------------|----------------|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| Alpine Linux             | 3.17           | No                                     | The latest release of Alpine Linux is guaranteed to remain at **Core** tier due to usage for our Docker images                                     |
+| Alpine Linux             | 3.18           | No                                     | The latest release of Alpine Linux is guaranteed to remain at **Core** tier due to usage for our Docker images                                     |
 | Alma Linux               | 9.x            | x86\_64, AArch64                       | Also includes support for Rocky Linux and other ABI compatible RHEL derivatives                                                                    |
 | Alma Linux               | 8.x            | x86\_64, AArch64                       | Also includes support for Rocky Linux and other ABI compatible RHEL derivatives                                                                    |
+| Amazon Linux             | 2023           | x86\_64, AArch64         |                                                                                                      |
+| Amazon Linux             | 2              | x86\_64, AArch64         |                                                                                                      |
 | CentOS                   | 7.x            | x86\_64                                |                                                                                                                                                    |
 | Docker                   | 19.03 or newer | x86\_64, i386, ARMv7, AArch64, POWER8+ | See our [Docker documentation](https://github.com/netdata/netdata/blob/master/packaging/docker/README.md) for more info on using Netdata on Docker |
 | Debian                   | 12.x           | x86\_64, i386, ARMv7, AArch64          |                                                                                                                                                    |
@@ -91,10 +93,10 @@ with minimal user effort.
 
 | Platform      | Version    | Official Native Packages | Notes                                                                                                |
 |---------------|------------|--------------------------|------------------------------------------------------------------------------------------------------|
+| Alpine Linux  | Edge       | No                       |                                                                                                      |
+| Alpine Linux  | 3.17       | No                       |                                                                                                      |
 | Alpine Linux  | 3.16       | No                       |                                                                                                      |
 | Alpine Linux  | 3.15       | No                       |                                                                                                      |
-| Amazon Linux  | 2023       | x86\_64, AArch64         | Scheduled for promotion to Core tier at some point after the release of v1.39.0 of the Netdata Agent |
-| Amazon Linux  | 2          | x86\_64, AArch64         | Scheduled for promotion to Core tier at some point after the release of v1.39.0 of the Netdata Agent |
 | Arch Linux    | Latest     | No                       | We officially recommend the community packages available for Arch Linux                              |
 | Manjaro Linux | Latest     | No                       | We officially recommend the community packages available for Arch Linux                              |
 | openSUSE      | Tumbleweed | x86\_64, AArch64         | Scheduled for promotion to Core tier at some point after the release of v1.41.0 of the Netdata Agent |
@@ -109,16 +111,14 @@ platforms, but may require some extra effort from users.
 
 | Platform     | Version    | Official Native Packages | Notes                                                                                                     |
 |--------------|------------|--------------------------|-----------------------------------------------------------------------------------------------------------|
-| Alpine Linux | Edge       | No                       |                                                                                                           |
 | Clear Linux  | Latest     | No                       |                                                                                                           |
 | Debian       | Sid        | No                       |                                                                                                           |
 | Fedora       | Rawhide    | No                       |                                                                                                           |
 | FreeBSD      | 13-STABLE  | No                       | Netdata is included in the FreeBSD Ports Tree, and this is the recommended installation method on FreeBSD |
-| FreeBSD      | 12-STABLE  | No                       | Netdata is included in the FreeBSD Ports Tree, and this is the recommended installation method on FreeBSD |
 | Gentoo       | Latest     | No                       |                                                                                                           |
+| macOS        | 13         | No                       | Currently only works for Intel-based hardware. Requires Homebrew for dependencies                         |
 | macOS        | 12         | No                       | Currently only works for Intel-based hardware. Requires Homebrew for dependencies                         |
 | macOS        | 11         | No                       | Currently only works for Intel-based hardware. Requires Homebrew for dependencies.                        |
-| macOS        | 10.15      | No                       | Requires Homebrew for dependencies.                                                                       |
 | openSUSE     | Tumbleweed | No                       |                                                                                                           |
 
 ## Third-party supported platforms


### PR DESCRIPTION
##### Summary

- Add a proper schema for the distros.yml file.
- Add extra keys to support using this information for integrations (and eventually for generating the platform support document).
- Add Alpine 3.18, which should have been added back when it was released.
- Add info for distros we have support for but do not run CI for.
- Sync up info in the platform support document.

##### Test Plan

n/a