### PR TITLE
Add schema and examples for notification method metadata.

### DIFF
--- a/health/notifications/sample-metadata.yaml
+++ b/health/notifications/sample-metadata.yaml
@@ -1,0 +1,39 @@
+id: ''
+meta:
+  name: ''
+  link: ''
+  categories: []
+  icon_filename: ''
+keywords: []
+overview:
+  exporter_description: ''
+  exporter_limitations: ''
+setup:
+  prerequisites:
+    list:
+      - title: ''
+        description: ''
+  configuration:
+    file:
+      name: ''
+      description: ''
+    options:
+      description: ''
+      folding:
+        title: ''
+        enabled: true
+      list:
+        - name: ''
+          default_value: ''
+          description: ''
+          required: false
+    examples:
+      folding:
+        enabled: true
+        title: ''
+      list:
+        - name: ''
+          folding:
+            enabled: false
+          description: ''
+          config: ''

--- a/integrations/notifications.yaml
+++ b/integrations/notifications.yaml
@@ -1,0 +1,39 @@
+- id: ''
+  meta:
+    name: ''
+    link: ''
+    categories: []
+    icon_filename: ''
+  keywords: []
+  overview:
+    notification_description: ''
+    notification_limitations: ''
+  setup:
+    prerequisites:
+      list:
+        - title: ''
+          description: ''
+    configuration:
+      file:
+        name: ''
+        description: ''
+      options:
+        description: ''
+        folding:
+          title: ''
+          enabled: true
+        list:
+          - name: ''
+            default_value: ''
+            description: ''
+            required: false
+      examples:
+        folding:
+          enabled: true
+          title: ''
+        list:
+          - name: ''
+            folding:
+              enabled: false
+            description: ''
+            config: ''

--- a/integrations/schemas/notification.json
+++ b/integrations/schemas/notification.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Netdata notification mechanism metadata.",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/entry"
+    },
+    {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/entry"
+      }
+    }
+  ],
+  "$def": {
+    "entry": {
+      "type": "object",
+      "description": "Data for a single notification method.",
+      "properties": {
+        "id": {
+          "$ref": "./shared.json#/$defs/id"
+        },
+        "meta": {
+          "$ref": "./shared.json#/$defs/instance"
+        },
+        "keywords": {
+          "$ref": "./shared.json#/$defs/keywords"
+        },
+        "overview": {
+          "type": "object",
+          "description": "General information about the notification method.",
+          "properties": {
+            "notification_description": {
+              "type": "string",
+              "description": "General description of what the notification method does."
+            },
+            "notification_limitations": {
+              "type": "string",
+              "description": "Explanation of any limitations of the notification method."
+            }
+          },
+          "required": [
+            "notification_description",
+            "notification_limitations"
+          ]
+        },
+        "setup": {
+          "$ref": "./shared.json#/$defs/setup"
+        }
+      },
+      "required": [
+        "id",
+        "meta",
+        "keywords",
+        "overview",
+        "setup"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
##### Summary

Files can be either a single entry, or a list of entries.

`integrations/notifications.yaml` is intended for metadata for Cloud notification methods. Agent methods should have appropriate metadata files added alongside their README files in `health/notifications` subdirectories.

##### Test Plan

n/a