### PR TITLE
fix ebpf.plugin system swapcalls

### DIFF
--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -507,7 +507,7 @@ static void read_swap_apps_table(int maps_per_core)
 */
 static void swap_send_global()
 {
-    write_io_chart(NETDATA_MEM_SWAP_CHART, NETDATA_EBPF_SYSTEM_GROUP,
+    write_io_chart(NETDATA_MEM_SWAP_CHART, NETDATA_EBPF_MEMORY_GROUP,
                    swap_publish_aggregated[NETDATA_KEY_SWAP_WRITEPAGE_CALL].dimension,
                    (long long) swap_hash_values[NETDATA_KEY_SWAP_WRITEPAGE_CALL],
                    swap_publish_aggregated[NETDATA_KEY_SWAP_READPAGE_CALL].dimension,


### PR DESCRIPTION
##### Summary

Fixes

```
PLUGINSD: parser_action('BEGIN') failed on line 46: { "BEGIN" "system.swapcalls" } (quotes added to show parsing)
```

after moving system.swap charts to mem. in #15494



##### Test Plan

Install this branch and check if ebpf.plugin is running.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
