### PR TITLE
disable freeipmi.plugin in Docker

### DIFF
--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -1429,6 +1429,14 @@ static size_t send_ipmi_sel_metrics_to_netdata(struct netdata_ipmi_state *state)
 // main, command line arguments parsing
 
 int main (int argc, char **argv) {
+    // both threads (sensors and sel) crash
+    if (getenv("NETDATA_LISTENER_PORT")) {
+        collector_info("%s(): freeipmi not working in Docker on Alpine. Exiting...", __FUNCTION__);
+        fprintf(stdout, "DISABLE\n");
+        fflush(stdout);
+        exit(0);
+    }
+
     bool netdata_do_sel = IPMI_ENABLE_SEL_BY_DEFAULT;
 
     stderror = stderr;


### PR DESCRIPTION
##### Summary

because both threads crash. I guess something is wrong with freeipmi lib on Alpine 🤷‍♂️. 

Noticed the problem when I checked the coredumpctl list and saw many entries with freeipmi.plugin.

<details>
<summary>sensors coredump</summary>

```c
Thread 2 "IPMI[sensors]" received signal SIGSEGV, Segmentation fault.
[Switching to LWP 607]
0x00007f23f14bf62f in ?? () from /usr/lib/libfreeipmi.so.17
(gdb) bt
#0  0x00007f23f14bf62f in ?? () from /usr/lib/libfreeipmi.so.17
#1  0x00007f23f149a8f2 in ?? () from /usr/lib/libfreeipmi.so.17
#2  0x00007f23f1494405 in ipmi_interpret_load_sensor_config () from /usr/lib/libfreeipmi.so.17
#3  0x00007f23f1809694 in ipmi_monitoring_ctx_sensor_config_file () from /usr/lib/libipmimonitoring.so.6
#4  0x000055cd3fce720c in netdata_read_ipmi_sensors (ipmi_config=ipmi_config@entry=0x7ffc3646a270, state=state@entry=0x7ffc3646a2d0)
    at collectors/freeipmi.plugin/freeipmi_plugin.c:388
#5  0x000055cd3fce7833 in netdata_ipmi_collect_data (ipmi_config=ipmi_config@entry=0x7ffc3646a270, type=type@entry=IPMI_COLLECT_TYPE_SENSORS,
    state=state@entry=0x7ffc3646a2d0) at collectors/freeipmi.plugin/freeipmi_plugin.c:1117
#6  0x000055cd3fce7916 in netdata_ipmi_detect_speed_secs (ipmi_config=ipmi_config@entry=0x7ffc3646a270, type=IPMI_COLLECT_TYPE_SENSORS,
    state=state@entry=0x7ffc3646a2d0) at collectors/freeipmi.plugin/freeipmi_plugin.c:1141
#7  0x000055cd3fce7a04 in netdata_ipmi_collection_thread (ptr=0x7ffc3646a270) at collectors/freeipmi.plugin/freeipmi_plugin.c:1193
#8  0x000055cd3fce9bf8 in netdata_thread_init (ptr=0x7f23f18e5fb0) at libnetdata/threads/threads.c:262
#9  0x00007f23f18a0c0b in ?? () from /lib/ld-musl-x86_64.so.1
#10 0x0000000000000000 in ?? ()
```

</details>

<details>
<summary>sel coredump</summary>

```c
Thread 3 "IPMI[sel]" received signal SIGSEGV, Segmentation fault.
[Switching to LWP 903]
0x00007f28bc70aa70 in ?? () from /lib/ld-musl-x86_64.so.1
(gdb) bt
#0  0x00007f28bc70aa70 in ?? () from /lib/ld-musl-x86_64.so.1
#1  0x000000001fff5529 in ?? ()
#2  0x00007f28bc122cc0 in ?? ()
#3  0x0000000000000004 in ?? ()
#4  0x00007ffffeb2d950 in ?? ()
#5  0x0000000000000001 in ?? ()
#6  0x00007f28bc33060e in ?? () from /usr/lib/libfreeipmi.so.17
#7  0x00007f28bc33197f in ?? () from /usr/lib/libfreeipmi.so.17
#8  0x00007f28bc32e121 in ipmi_interpret_ctx_destroy () from /usr/lib/libfreeipmi.so.17
#9  0x00007f28bc6a2968 in ?? () from /usr/lib/libipmimonitoring.so.6
#10 0x000055f1a30c2d16 in netdata_get_ipmi_sel_events_count (ipmi_config=ipmi_config@entry=0x7ffffeb2d950, state=state@entry=0x7ffffeb2d9b0)
    at collectors/freeipmi.plugin/freeipmi_plugin.c:544
#11 0x000055f1a30c985a in netdata_ipmi_collect_data (ipmi_config=ipmi_config@entry=0x7ffffeb2d950, type=type@entry=IPMI_COLLECT_TYPE_SEL,
    state=state@entry=0x7ffffeb2d9b0) at collectors/freeipmi.plugin/freeipmi_plugin.c:1123
#12 0x000055f1a30c9916 in netdata_ipmi_detect_speed_secs (ipmi_config=ipmi_config@entry=0x7ffffeb2d950, type=IPMI_COLLECT_TYPE_SEL,
    state=state@entry=0x7ffffeb2d9b0) at collectors/freeipmi.plugin/freeipmi_plugin.c:1141
#13 0x000055f1a30c9a04 in netdata_ipmi_collection_thread (ptr=0x7ffffeb2d950) at collectors/freeipmi.plugin/freeipmi_plugin.c:1193
#14 0x000055f1a30cbbf8 in netdata_thread_init (ptr=0x7f28bc6b9fa0) at libnetdata/threads/threads.c:262
#15 0x00007f28bc73ac0b in ?? () from /lib/ld-musl-x86_64.so.1
#16 0x0000000000000000 in ?? ()
```



</details>

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
