### PR TITLE
filter out systemd-udevd.service/udevd

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -476,6 +476,7 @@ void read_cgroup_plugin_configuration() {
                        " !*.mount "
                        " !*.partition "
                        " !*.service "
+                       " !*.service/udev "
                        " !*.socket "
                        " !*.slice "
                        " !*.swap "


### PR DESCRIPTION
##### Summary

Noticed that all my deb12 VMs have 1 container - `/system.slice/systemd-udevd.service/udev`. This PR filters it.

```
/sys/fs/cgroup/
├── system.slice
│   ├── systemd-udevd.service
        └── udev
```

##### Test Plan

Tested the updated filter locally.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
