### PR TITLE
Add missing file in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -670,6 +670,7 @@ set(PROC_PLUGIN_FILES
         collectors/proc.plugin/sys_class_infiniband.c
         collectors/proc.plugin/sys_fs_btrfs.c
         collectors/proc.plugin/sys_class_power_supply.c
+        collectors/proc.plugin/sys_devices_pci_aer.c
         )
 
 set(TC_PLUGIN_FILES


### PR DESCRIPTION
##### Summary
Add missing file `collectors/proc.plugin/sys_devices_pci_aer.c` in `CMakeLists.txt`

