### PR TITLE
fix cpu MHz from /proc/cpuinfo

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -313,7 +313,7 @@ elif [ -r /proc/cpuinfo ]; then
   if (echo "${CPU_INFO_SOURCE}" | grep -qv procfs); then
     CPU_INFO_SOURCE="${CPU_INFO_SOURCE} procfs"
   fi
-  value=$(grep "cpu MHz" /proc/cpuinfo 2>/dev/null | grep -o "[0-9]*" | head -n 1 | awk '{print int($0*1000000)}')
+  value=$(grep "cpu MHz" /proc/cpuinfo 2>/dev/null | grep -o "[0-9]*" | head -n 1 | awk '{printf "%0.f",int($0*1000000)}')
   [ -n "$value" ] && CPU_FREQ="$value"
 fi
 


### PR DESCRIPTION
##### Summary


##### Test Plan

Before

```
# /usr/libexec/netdata/plugins.d/system-info.sh | grep FREQ
NETDATA_SYSTEM_CPU_FREQ=2.494e+09
```

After

```
# /usr/libexec/netdata/plugins.d/system-info.sh | grep FREQ
NETDATA_SYSTEM_CPU_FREQ=2494000000
```



##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
