### PR TITLE
Fix typo in notification schema.

### DIFF
--- a/integrations/schemas/notification.json
+++ b/integrations/schemas/notification.json
@@ -7,12 +7,13 @@
     },
     {
       "type": "array",
+      "minLength": 1,
       "items": {
         "$ref": "#/$defs/entry"
       }
     }
   ],
-  "$def": {
+  "$defs": {
     "entry": {
       "type": "object",
       "description": "Data for a single notification method.",


### PR DESCRIPTION
##### Summary

Single character typo that causes the schema to not work.

##### Test Plan

n/a