### PR TITLE
fix potential crash bug. 

### DIFF
--- a/web/server/h2o/http_server.c
+++ b/web/server/h2o/http_server.c
@@ -77,6 +77,7 @@ static int ssl_init()
     if(!accept_ctx.ssl_ctx)
     {
         // output error log
+        netdata_log_error("Could not allocate a new SSL_CTX");
         return -1;
     }
 

--- a/web/server/h2o/http_server.c
+++ b/web/server/h2o/http_server.c
@@ -73,10 +73,7 @@ static int ssl_init()
 #else
     accept_ctx.ssl_ctx = SSL_CTX_new(TLS_server_method());
 #endif
-    // Check if accept_ctx.ssl_ctx is NULL, otherwise SSL_CTX_set_options will crash
-    if(!accept_ctx.ssl_ctx)
-    {
-        // output error log
+    if (!accept_ctx.ssl_ctx) {
         netdata_log_error("Could not allocate a new SSL_CTX");
         return -1;
     }

--- a/web/server/h2o/http_server.c
+++ b/web/server/h2o/http_server.c
@@ -73,6 +73,12 @@ static int ssl_init()
 #else
     accept_ctx.ssl_ctx = SSL_CTX_new(TLS_server_method());
 #endif
+    // Check if accept_ctx.ssl_ctx is NULL, otherwise SSL_CTX_set_options will crash
+    if(!accept_ctx.ssl_ctx)
+    {
+        // output error log
+        return -1;
+    }
 
     SSL_CTX_set_options(accept_ctx.ssl_ctx, SSL_OP_NO_SSLv2);
 


### PR DESCRIPTION
Check that its argument is not NULL before using SSL_CTX_set_options.

If the parameter 1 of SSL_CTX_set_options is NULL, there is a null-dereference which will cause crash. So there should be a check against NULL in the code to avoid the problem.

