### PR TITLE
Access logs through the API for dev builds

### DIFF
--- a/libnetdata/libnetdata.c
+++ b/libnetdata/libnetdata.c
@@ -1628,7 +1628,7 @@ void recursive_config_double_dir_load(const char *user_path, const char *stock_p
 
 // Returns the number of bytes read from the file if file_size is not NULL.
 // The actual buffer has an extra byte set to zero (not included in the count).
-char *read_by_filename(char *filename, long *file_size)
+char *read_by_filename(const char *filename, long *file_size)
 {
     FILE *f = fopen(filename, "r");
     if (!f)

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -579,7 +579,7 @@ void recursive_config_double_dir_load(
         , void *data
         , size_t depth
 );
-char *read_by_filename(char *filename, long *file_size);
+char *read_by_filename(const char *filename, long *file_size);
 char *find_and_replace(const char *src, const char *find, const char *replace, const char *where);
 
 /* fix for alpine linux */

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -626,8 +626,14 @@ void open_all_log_files() {
 // ----------------------------------------------------------------------------
 // error log throttling
 
+#ifdef NETDATA_DEV_MODE
+time_t error_log_throttle_period = 60;
+unsigned long error_log_errors_per_period = 10000;
+#else
 time_t error_log_throttle_period = 1200;
 unsigned long error_log_errors_per_period = 200;
+#endif
+
 unsigned long error_log_errors_per_period_backup = 0;
 
 int error_log_limit(int reset) {


### PR DESCRIPTION
##### Summary

Enabled only when `NETDATA_DEV_MODE` is defined.
We also decrease throttling period and increase
default log lines, to increase chance of capturing
relevant logs.

##### Test Plan

- Build with `NETDATA_DEV_MODE`
- Access `api/v1/logs?kind=error`