### PR TITLE
Add additional variable section to instance data in schema.

### DIFF
--- a/integrations/schemas/shared.json
+++ b/integrations/schemas/shared.json
@@ -30,6 +30,29 @@
         "icon_filename": {
           "type": "string",
           "description": "The filename of the integration's icon, as sourced from https://github.com/netdata/website/tree/master/themes/tailwind/static/img."
+        },
+        "variables": {
+          "type": "object",
+          "description": "A mapping of variables to be used when templating other keys.",
+          "patternProperties": {
+            "^[a-zA-Z_][a-zA-Z0-9_]*$": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
         }
       },
       "required": [


### PR DESCRIPTION
##### Summary

This is a new optional key in the `instance` sub-schema. The value should be a mapping of strings that are valid Python identifiers to strings, integers, floats, or booleans.

If this key is present, the script using the metadata files will make a second rendering pass over the keys it’s rendering, passing in the mapping as an object named `variables`.

The keys this second rendering pass is run on can reference this object and it’s properties by using double square brackets. For example, to template in the value of a key in this mapping called `port`, the syntax would be `[[ variables.port ]]`.

This sub-schema is used for the `meta.monitored_instance` section in collector integrations, and the `meta` section in the deploy, exporter, and notification integrations.

##### Test Plan

n/a
