### PR TITLE
fix edit-config for containerized Netdata when running from host

### DIFF
--- a/system/edit-config
+++ b/system/edit-config
@@ -57,6 +57,12 @@ is_prefix() {
 }
 
 check_directories() {
+  if [ -f "${script_dir}/.container-hostname" ]; then
+    NETDATA_USER_CONFIG_DIR="${script_dir}"
+    NETDATA_STOCK_CONFIG_DIR="/usr/lib/netdata/conf.d"
+    return
+  fi
+
   if [ -e "${script_dir}/.environment" ]; then
     OLDPATH="${PATH}"
     # shellcheck disable=SC1091


### PR DESCRIPTION
##### Summary

Fixes "Unable to find stock config directory" reported in https://github.com/netdata/netdata/discussions/15636

>  edit-config for containerized Netdata when running from host

I guess it never worked, or we changed something 🤷‍♂️ 

##### Test Plan

- Install [ND with host-editable configuration](https://learn.netdata.cloud/docs/installing/docker#with-host-editable-configuration)
- Execute `edit-config` from the host system

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
