### PR TITLE
disable freeipmi in docker by default

### DIFF
--- a/collectors/plugins.d/plugins_d.c
+++ b/collectors/plugins.d/plugins_d.c
@@ -217,6 +217,11 @@ void *pluginsd_main(void *ptr)
 
     // disable some plugins by default
     config_get_boolean(CONFIG_SECTION_PLUGINS, "slabinfo", CONFIG_BOOLEAN_NO);
+    // it crashes (both threads) on Alpine after we made it multi-threaded
+    // works with "--device /dev/ipmi0", but this is not default
+    // see https://github.com/netdata/netdata/pull/15564 for details
+    if (getenv("NETDATA_LISTENER_PORT"))
+        config_get_boolean(CONFIG_SECTION_PLUGINS, "freeipmi", CONFIG_BOOLEAN_NO);
 
     // store the errno for each plugins directory
     // so that we don't log broken directories on each loop


### PR DESCRIPTION
##### Summary

Because it crashes (freeipmi lib functions) after we made it multi-threaded if there is no access to ipmi (`/dev/ipmi0`) device.

See [coredumps](https://github.com/netdata/netdata/pull/15564#issue-1823064137).

##### Test Plan

Check that freeipmi is disabled by default only in Docker.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
