### PR TITLE
Split configuration/business logic when initializing dbengine.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -776,6 +776,7 @@ set(RRD_PLUGIN_FILES
         database/engine/rrdenginelib.h
         database/engine/rrdengineapi.c
         database/engine/rrdengineapi.h
+        database/engine/rrddim_eng.c
         database/engine/rrddim_eng.h
         database/engine/pagecache.c
         database/engine/pagecache.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -549,6 +549,7 @@ libjudy_a-JudyLTables.$(OBJEXT) : CFLAGS += -I$(abs_top_srcdir)/libnetdata/libju
 
 if ENABLE_DBENGINE
     RRD_PLUGIN_FILES += \
+        database/engine/rrddim_eng.c \
         database/engine/rrddim_eng.h \
         database/engine/rrdengine.c \
         database/engine/rrdengine.h \

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -666,7 +666,7 @@ void set_late_global_environment(struct rrdhost_system_info *system_info)
         snprintfz(b, 15, "%d", rrdb.default_rrdeng_page_cache_mb);
         analytics_set_data(&analytics_data.netdata_config_page_cache_size, b);
 
-        snprintfz(b, 15, "%d", rrdb.default_multidb_disk_quota_mb);
+        snprintfz(b, 15, "%d", rrdb.multidb_disk_quota_mb[0]);
         analytics_set_data(&analytics_data.netdata_config_multidb_disk_quota, b);
     }
 #endif

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -663,10 +663,10 @@ void set_late_global_environment(struct rrdhost_system_info *system_info)
 #ifdef ENABLE_DBENGINE
     {
         char b[16];
-        snprintfz(b, 15, "%d", rrdb.default_rrdeng_page_cache_mb);
+        snprintfz(b, 15, "%d", rrdb.dbengine_cfg.page_cache_mb);
         analytics_set_data(&analytics_data.netdata_config_page_cache_size, b);
 
-        snprintfz(b, 15, "%d", rrdb.multidb_disk_quota_mb[0]);
+        snprintfz(b, 15, "%d", rrdb.dbengine_cfg.multidb_disk_quota_mb[0]);
         analytics_set_data(&analytics_data.netdata_config_multidb_disk_quota, b);
     }
 #endif

--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -514,7 +514,7 @@ static struct {
                 .analytics = NULL,
                 .print = "Tiering (multiple dbs with different metrics resolution)",
                 .json = "tiering",
-                .value = TOSTRING(RRD_STORAGE_TIERS),
+                .value = TOSTRING(STORAGE_ENGINE_TIERS),
         },
         [BIB_FEATURE_ML] = {
                 .category = BIC_FEATURE,

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -65,7 +65,7 @@ static struct global_statistics {
     uint64_t backfill_queries_made;
     uint64_t backfill_db_points_read;
 
-    uint64_t db_points_stored_per_tier[RRD_STORAGE_TIERS];
+    uint64_t db_points_stored_per_tier[STORAGE_ENGINE_TIERS];
 
 } global_statistics = {
         .connected_clients = 0,
@@ -796,7 +796,7 @@ static void global_statistics_charts(void) {
 
     {
         static RRDSET *st_points_stored = NULL;
-        static RRDDIM *rds[RRD_STORAGE_TIERS] = {};
+        static RRDDIM *rds[STORAGE_ENGINE_TIERS] = {};
 
         if (unlikely(!st_points_stored)) {
             st_points_stored = rrdset_create_localhost(
@@ -2466,7 +2466,7 @@ static void dbengine2_statistics_charts(void) {
         RRDHOST *host;
         unsigned long long stats_array[RRDENG_NR_STATS] = {0};
         unsigned long long local_stats_array[RRDENG_NR_STATS];
-        unsigned dbengine_contexts = 0, counted_multihost_db[RRD_STORAGE_TIERS] = { 0 }, i;
+        unsigned dbengine_contexts = 0, counted_multihost_db[STORAGE_ENGINE_TIERS] = { 0 }, i;
 
         rrdhost_foreach_read(host) {
             if (!rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED)) {

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -4159,7 +4159,7 @@ void *global_statistics_main(void *ptr)
         registry_statistics();
 
 #ifdef ENABLE_DBENGINE
-        if(rrdb.dbengine_cfg.enabled) {
+        if(rrdb.dbengine_enabled) {
             worker_is_busy(WORKER_JOB_DBENGINE);
             dbengine2_statistics_charts();
         }

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -83,7 +83,7 @@ static struct global_statistics {
 };
 
 void global_statistics_rrdset_done_chart_collection_completed(size_t *points_read_per_tier_array) {
-    for(size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers ;tier++) {
+    for(size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
         __atomic_fetch_add(&global_statistics.db_points_stored_per_tier[tier], points_read_per_tier_array[tier], __ATOMIC_RELAXED);
         points_read_per_tier_array[tier] = 0;
     }
@@ -210,7 +210,7 @@ static inline void global_statistics_copy(struct global_statistics *gs, uint8_t 
     gs->backfill_queries_made       = __atomic_load_n(&global_statistics.backfill_queries_made, __ATOMIC_RELAXED);
     gs->backfill_db_points_read     = __atomic_load_n(&global_statistics.backfill_db_points_read, __ATOMIC_RELAXED);
 
-    for(size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers ;tier++)
+    for (size_t tier = 0; tier < rrd_storage_tiers(); tier++)
         gs->db_points_stored_per_tier[tier] = __atomic_load_n(&global_statistics.db_points_stored_per_tier[tier], __ATOMIC_RELAXED);
 
     if(options & GLOBAL_STATS_RESET_WEB_USEC_MAX) {
@@ -814,14 +814,14 @@ static void global_statistics_charts(void) {
                     , RRDSET_TYPE_STACKED
             );
 
-            for(size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers ;tier++) {
+            for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
                 char buf[30 + 1];
                 snprintfz(buf, 30, "tier%zu", tier);
                 rds[tier] = rrddim_add(st_points_stored, buf, NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
             }
         }
 
-        for(size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers ;tier++)
+        for (size_t tier = 0; tier < rrd_storage_tiers(); tier++)
             rrddim_set_by_pointer(st_points_stored, rds[tier], (collected_number)gs.db_points_stored_per_tier[tier]);
 
         rrdset_done(st_points_stored);
@@ -2472,7 +2472,7 @@ static void dbengine2_statistics_charts(void) {
             if (!rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED)) {
 
                 /* get localhost's DB engine's statistics for each tier */
-                for(size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers ;tier++) {
+                for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
                     if(host->db[tier].id != STORAGE_ENGINE_DBENGINE) continue;
                     if(!host->db[tier].instance) continue;
 

--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -83,7 +83,7 @@ static struct global_statistics {
 };
 
 void global_statistics_rrdset_done_chart_collection_completed(size_t *points_read_per_tier_array) {
-    for(size_t tier = 0; tier < rrdb.storage_tiers ;tier++) {
+    for(size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers ;tier++) {
         __atomic_fetch_add(&global_statistics.db_points_stored_per_tier[tier], points_read_per_tier_array[tier], __ATOMIC_RELAXED);
         points_read_per_tier_array[tier] = 0;
     }
@@ -210,7 +210,7 @@ static inline void global_statistics_copy(struct global_statistics *gs, uint8_t 
     gs->backfill_queries_made       = __atomic_load_n(&global_statistics.backfill_queries_made, __ATOMIC_RELAXED);
     gs->backfill_db_points_read     = __atomic_load_n(&global_statistics.backfill_db_points_read, __ATOMIC_RELAXED);
 
-    for(size_t tier = 0; tier < rrdb.storage_tiers ;tier++)
+    for(size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers ;tier++)
         gs->db_points_stored_per_tier[tier] = __atomic_load_n(&global_statistics.db_points_stored_per_tier[tier], __ATOMIC_RELAXED);
 
     if(options & GLOBAL_STATS_RESET_WEB_USEC_MAX) {
@@ -814,14 +814,14 @@ static void global_statistics_charts(void) {
                     , RRDSET_TYPE_STACKED
             );
 
-            for(size_t tier = 0; tier < rrdb.storage_tiers ;tier++) {
+            for(size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers ;tier++) {
                 char buf[30 + 1];
                 snprintfz(buf, 30, "tier%zu", tier);
                 rds[tier] = rrddim_add(st_points_stored, buf, NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
             }
         }
 
-        for(size_t tier = 0; tier < rrdb.storage_tiers ;tier++)
+        for(size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers ;tier++)
             rrddim_set_by_pointer(st_points_stored, rds[tier], (collected_number)gs.db_points_stored_per_tier[tier]);
 
         rrdset_done(st_points_stored);
@@ -2472,7 +2472,7 @@ static void dbengine2_statistics_charts(void) {
             if (!rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED)) {
 
                 /* get localhost's DB engine's statistics for each tier */
-                for(size_t tier = 0; tier < rrdb.storage_tiers ;tier++) {
+                for(size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers ;tier++) {
                     if(host->db[tier].id != STORAGE_ENGINE_DBENGINE) continue;
                     if(!host->db[tier].instance) continue;
 
@@ -4159,7 +4159,7 @@ void *global_statistics_main(void *ptr)
         registry_statistics();
 
 #ifdef ENABLE_DBENGINE
-        if(rrdb.dbengine_enabled) {
+        if(rrdb.dbengine_cfg.enabled) {
             worker_is_busy(WORKER_JOB_DBENGINE);
             dbengine2_statistics_charts();
         }

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1101,6 +1101,13 @@ static void get_netdata_configured_variables() {
         }
     }
 
+#if !defined(ENABLE_DBENGINE)
+    if (default_storage_engine_id  == STORAGE_ENGINE_DBENGINE) {
+       error_report("RRD_MEMORY_MODE_DBENGINE is not supported in this platform. The agent will use db mode 'save' instead.");
+       default_storage_engine_id = STORAGE_ENGINE_SAVE;
+    }
+#endif
+
     // ------------------------------------------------------------------------
     // get default database size
 
@@ -1135,38 +1142,6 @@ static void get_netdata_configured_variables() {
         netdata_configured_primary_plugins_dir = plugin_directories[PLUGINSD_STOCK_PLUGINS_DIRECTORY_PATH];
     }
 
-#ifdef ENABLE_DBENGINE
-    // ------------------------------------------------------------------------
-    // get default Database Engine page cache size in MiB
-
-    rrdb.default_rrdeng_page_cache_mb = (int) config_get_number(CONFIG_SECTION_DB, "dbengine page cache size MB", rrdb.default_rrdeng_page_cache_mb);
-    rrdb.default_rrdeng_extent_cache_mb = (int) config_get_number(CONFIG_SECTION_DB, "dbengine extent cache size MB", rrdb.default_rrdeng_extent_cache_mb);
-    rrdb.db_engine_journal_check = config_get_boolean(CONFIG_SECTION_DB, "dbengine enable journal integrity check", CONFIG_BOOLEAN_NO);
-
-    if(rrdb.default_rrdeng_extent_cache_mb < 0)
-        rrdb.default_rrdeng_extent_cache_mb = 0;
-
-    if(rrdb.default_rrdeng_page_cache_mb < RRDENG_MIN_PAGE_CACHE_SIZE_MB) {
-        netdata_log_error("Invalid page cache size %d given. Defaulting to %d.", rrdb.default_rrdeng_page_cache_mb, RRDENG_MIN_PAGE_CACHE_SIZE_MB);
-        rrdb.default_rrdeng_page_cache_mb = RRDENG_MIN_PAGE_CACHE_SIZE_MB;
-        config_set_number(CONFIG_SECTION_DB, "dbengine page cache size MB", rrdb.default_rrdeng_page_cache_mb);
-    }
-
-    // ------------------------------------------------------------------------
-    // get default Database Engine disk space quota in MiB
-
-    rrdb.default_rrdeng_disk_quota_mb = (int) config_get_number(CONFIG_SECTION_DB, "dbengine disk space MB", rrdb.default_rrdeng_disk_quota_mb);
-    if (rrdb.default_rrdeng_disk_quota_mb < RRDENG_MIN_DISK_SPACE_MB) {
-        netdata_log_error("Invalid dbengine disk space %d given. Defaulting to %d.", rrdb.default_rrdeng_disk_quota_mb, RRDENG_MIN_DISK_SPACE_MB);
-        rrdb.default_rrdeng_disk_quota_mb = RRDENG_MIN_DISK_SPACE_MB;
-        config_set_number(CONFIG_SECTION_DB, "dbengine disk space MB", rrdb.default_rrdeng_disk_quota_mb);
-    }
-#else
-    if (default_storage_engine_id  == STORAGE_ENGINE_DBENGINE) {
-       error_report("RRD_MEMORY_MODE_DBENGINE is not supported in this platform. The agent will use db mode 'save' instead.");
-       default_storage_engine_id = STORAGE_ENGINE_SAVE;
-    }
-#endif
     // ------------------------------------------------------------------------
 
     netdata_configured_host_prefix = config_get(CONFIG_SECTION_GLOBAL, "host access prefix", "");

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -326,7 +326,7 @@ void netdata_cleanup_and_exit(int ret) {
 #ifdef ENABLE_DBENGINE
     if (rrdb.dbengine_cfg.enabled) {
         delta_shutdown_time("dbengine exit mode");
-        for (size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers; tier++)
+        for (size_t tier = 0; tier < rrd_storage_tiers(); tier++)
             rrdeng_exit_mode(rrdb.dbengine_cfg.multidb_ctx[tier]);
     }
 #endif
@@ -417,7 +417,7 @@ void netdata_cleanup_and_exit(int ret) {
 #ifdef ENABLE_DBENGINE
         if (rrdb.dbengine_cfg.enabled) {
             delta_shutdown_time("flush dbengine tiers");
-            for (size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers; tier++)
+            for (size_t tier = 0; tier < rrd_storage_tiers(); tier++)
                 rrdeng_prepare_exit(rrdb.dbengine_cfg.multidb_ctx[tier]);
         }
 #endif
@@ -439,7 +439,7 @@ void netdata_cleanup_and_exit(int ret) {
             size_t running = 1;
             while(running) {
                 running = 0;
-                for (size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers; tier++)
+                for (size_t tier = 0; tier < rrd_storage_tiers(); tier++)
                     running += rrdeng_collectors_running(rrdb.dbengine_cfg.multidb_ctx[tier]);
 
                 if(running) {
@@ -457,7 +457,7 @@ void netdata_cleanup_and_exit(int ret) {
             }
 
             delta_shutdown_time("stop dbengine tiers");
-            for (size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers; tier++)
+            for (size_t tier = 0; tier < rrd_storage_tiers(); tier++)
                 rrdeng_exit(rrdb.dbengine_cfg.multidb_ctx[tier]);
         }
 #endif

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1590,7 +1590,10 @@ int main(int argc, char **argv) {
                             default_storage_engine_id = STORAGE_ENGINE_RAM;
                             default_health_enabled = 0;
 #ifdef ENABLE_DBENGINE
-                            rrdb.dbengine_cfg.storage_tiers = 1;
+                            dbengine_config_t cfg = dbengine_default_config();
+                            cfg.storage_tiers = 1;
+                            rrdb.dbengine_cfg = cfg;
+                            dbengine_init("foo", rrdb.dbengine_cfg);
 #endif
                             registry_init();
                             if(rrd_init("unittest", NULL, true)) {

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1672,6 +1672,13 @@ int main(int argc, char **argv) {
                             return pluginsd_parser_unittest();
                         }
                         else if(strncmp(optarg, createdataset_string, strlen(createdataset_string)) == 0) {
+#ifdef ENABLE_DBENGINE
+                            dbengine_config_t cfg = dbengine_default_config();
+                            cfg.storage_tiers = 1;
+                            rrdb.dbengine_cfg = cfg;
+                            dbengine_init("foo", rrdb.dbengine_cfg);
+#endif
+
                             optarg += strlen(createdataset_string);
                             unsigned history_seconds = strtoul(optarg, NULL, 0);
                             post_conf_load(&user);

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1161,13 +1161,6 @@ static void get_netdata_configured_variables() {
         rrdb.default_rrdeng_disk_quota_mb = RRDENG_MIN_DISK_SPACE_MB;
         config_set_number(CONFIG_SECTION_DB, "dbengine disk space MB", rrdb.default_rrdeng_disk_quota_mb);
     }
-
-    rrdb.default_multidb_disk_quota_mb = (int) config_get_number(CONFIG_SECTION_DB, "dbengine multihost disk space MB", compute_multidb_diskspace());
-    if(rrdb.default_multidb_disk_quota_mb < RRDENG_MIN_DISK_SPACE_MB) {
-        netdata_log_error("Invalid multidb disk space %d given. Defaulting to %d.", rrdb.default_multidb_disk_quota_mb, rrdb.default_rrdeng_disk_quota_mb);
-        rrdb.default_multidb_disk_quota_mb = rrdb.default_rrdeng_disk_quota_mb;
-        config_set_number(CONFIG_SECTION_DB, "dbengine multihost disk space MB", rrdb.default_multidb_disk_quota_mb);
-    }
 #else
     if (default_storage_engine_id  == STORAGE_ENGINE_DBENGINE) {
        error_report("RRD_MEMORY_MODE_DBENGINE is not supported in this platform. The agent will use db mode 'save' instead.");

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -324,7 +324,7 @@ void netdata_cleanup_and_exit(int ret) {
     (void) rename(agent_crash_file, agent_incomplete_shutdown_file);
 
 #ifdef ENABLE_DBENGINE
-    if (rrdb.dbengine_cfg.enabled) {
+    if (rrdb.dbengine_enabled) {
         delta_shutdown_time("dbengine exit mode");
         for (size_t tier = 0; tier < rrd_storage_tiers(); tier++)
             rrdeng_exit_mode(rrdb.dbengine_cfg.multidb_ctx[tier]);
@@ -415,7 +415,7 @@ void netdata_cleanup_and_exit(int ret) {
         // exit cleanly
 
 #ifdef ENABLE_DBENGINE
-        if (rrdb.dbengine_cfg.enabled) {
+        if (rrdb.dbengine_enabled) {
             delta_shutdown_time("flush dbengine tiers");
             for (size_t tier = 0; tier < rrd_storage_tiers(); tier++)
                 rrdeng_prepare_exit(rrdb.dbengine_cfg.multidb_ctx[tier]);
@@ -433,7 +433,7 @@ void netdata_cleanup_and_exit(int ret) {
         metadata_sync_shutdown();
 
 #ifdef ENABLE_DBENGINE
-        if (rrdb.dbengine_cfg.enabled) {
+        if (rrdb.dbengine_enabled) {
             delta_shutdown_time("wait for dbengine collectors to finish");
 
             size_t running = 1;
@@ -1589,7 +1589,9 @@ int main(int argc, char **argv) {
                             rrdb.default_update_every = 1;
                             default_storage_engine_id = STORAGE_ENGINE_RAM;
                             default_health_enabled = 0;
+#ifdef ENABLE_DBENGINE
                             rrdb.dbengine_cfg.storage_tiers = 1;
+#endif
                             registry_init();
                             if(rrd_init("unittest", NULL, true)) {
                                 fprintf(stderr, "rrd_init failed for unittest\n");

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -51,7 +51,7 @@ static void svc_rrddim_obsolete_to_archive(RRDDIM *rd) {
         /* only a collector can mark a chart as obsolete, so we must remove the reference */
 
         size_t tiers_available = 0, tiers_said_no_retention = 0;
-        for(size_t tier = 0; tier < rrdb.storage_tiers ;tier++) {
+        for(size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers ;tier++) {
             if(rd->tiers[tier].db_collection_handle) {
                 tiers_available++;
 

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -51,7 +51,7 @@ static void svc_rrddim_obsolete_to_archive(RRDDIM *rd) {
         /* only a collector can mark a chart as obsolete, so we must remove the reference */
 
         size_t tiers_available = 0, tiers_said_no_retention = 0;
-        for(size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers ;tier++) {
+        for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
             if(rd->tiers[tier].db_collection_handle) {
                 tiers_available++;
 

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -2337,11 +2337,11 @@ void generate_dbengine_dataset(unsigned history_seconds)
     time_t time_present;
 
     default_storage_engine_id = STORAGE_ENGINE_DBENGINE;
-    rrdb.default_rrdeng_page_cache_mb = 128;
+    rrdb.dbengine_cfg.page_cache_mb = 128;
     // Worst case for uncompressible data
-    rrdb.default_rrdeng_disk_quota_mb = (((uint64_t)DSET_DIMS * DSET_CHARTS) * sizeof(storage_number) * history_seconds) /
+    rrdb.dbengine_cfg.disk_quota_mb = (((uint64_t)DSET_DIMS * DSET_CHARTS) * sizeof(storage_number) * history_seconds) /
                                    (1024 * 1024);
-    rrdb.default_rrdeng_disk_quota_mb -= rrdb.default_rrdeng_disk_quota_mb * EXPECTED_COMPRESSION_RATIO / 100;
+    rrdb.dbengine_cfg.disk_quota_mb -= rrdb.dbengine_cfg.disk_quota_mb * EXPECTED_COMPRESSION_RATIO / 100;
 
     error_log_limit_unlimited();
     fprintf(stderr, "Initializing localhost with hostname 'dbengine-dataset'");
@@ -2429,7 +2429,7 @@ static void query_dbengine_chart(void *arg)
 
         if (thread_info->delete_old_data) {
             /* A time window of twice the disk space is sufficient for compression space savings of up to 50% */
-            time_approx_min = time_max - (rrdb.default_rrdeng_disk_quota_mb * 2 * 1024 * 1024) /
+            time_approx_min = time_max - (rrdb.dbengine_cfg.disk_quota_mb * 2 * 1024 * 1024) /
                                          (((uint64_t) DSET_DIMS * DSET_CHARTS) * sizeof(storage_number));
             time_min = MAX(time_min, time_approx_min);
         }
@@ -2530,16 +2530,16 @@ void dbengine_stress_test(unsigned TEST_DURATION_SEC, unsigned DSET_CHARTS, unsi
         PAGE_CACHE_MB = RRDENG_MIN_PAGE_CACHE_SIZE_MB;
 
     default_storage_engine_id = STORAGE_ENGINE_DBENGINE;
-    rrdb.default_rrdeng_page_cache_mb = PAGE_CACHE_MB;
+    rrdb.dbengine_cfg.page_cache_mb = PAGE_CACHE_MB;
     if (DISK_SPACE_MB) {
         fprintf(stderr, "By setting disk space limit data are allowed to be deleted. "
                         "Data validation is turned off for this run.\n");
-        rrdb.default_rrdeng_disk_quota_mb = DISK_SPACE_MB;
+        rrdb.dbengine_cfg.disk_quota_mb = DISK_SPACE_MB;
     } else {
         // Worst case for uncompressible data
-        rrdb.default_rrdeng_disk_quota_mb =
+        rrdb.dbengine_cfg.disk_quota_mb =
                 (((uint64_t) DSET_DIMS * DSET_CHARTS) * sizeof(storage_number) * HISTORY_SECONDS) / (1024 * 1024);
-        rrdb.default_rrdeng_disk_quota_mb -= rrdb.default_rrdeng_disk_quota_mb * EXPECTED_COMPRESSION_RATIO / 100;
+        rrdb.dbengine_cfg.disk_quota_mb -= rrdb.dbengine_cfg.disk_quota_mb * EXPECTED_COMPRESSION_RATIO / 100;
     }
 
     fprintf(stderr, "Initializing localhost with hostname 'dbengine-stress-test'\n");

--- a/database/contexts/api_v2.c
+++ b/database/contexts/api_v2.c
@@ -1005,7 +1005,7 @@ void buffer_json_agents_v2(BUFFER *wb, struct query_timings *timings, time_t now
         buffer_json_cloud_status(wb, now_s);
 
         buffer_json_member_add_array(wb, "db_size");
-        for (size_t tier = 0; tier < rrdb.storage_tiers; tier++) {
+        for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
             STORAGE_ENGINE_ID storage_engine_id = rrdb.localhost->db[tier].id;
 
             size_t max = storage_engine_disk_space_max(storage_engine_id, rrdb.localhost->db[tier].instance);

--- a/database/contexts/query_target.c
+++ b/database/contexts/query_target.c
@@ -220,7 +220,7 @@ static inline void query_metric_release(QUERY_TARGET *qt, QUERY_METRIC *qm) {
     qm->plan.used = 0;
 
     // reset the tiers
-    for(size_t tier = 0; tier < rrdb.storage_tiers ;tier++) {
+    for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
         if(qm->tiers[tier].db_metric_handle) {
             STORAGE_ENGINE_ID storage_engine_id = query_metric_storage_engine(qt, qm, tier);
             storage_engine_metric_release(storage_engine_id, qm->tiers[tier].db_metric_handle);
@@ -245,9 +245,9 @@ static bool query_metric_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_CON
         time_t db_first_time_s;
         time_t db_last_time_s;
         time_t db_update_every_s;
-    } tier_retention[rrdb.storage_tiers];
+    } tier_retention[rrd_storage_tiers()];
 
-    for (size_t tier = 0; tier < rrdb.storage_tiers; tier++) {
+    for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
         STORAGE_ENGINE_ID storage_engine_id = qn->rrdhost->db[tier].id;
         tier_retention[tier].storage_engine_id = storage_engine_id;
         tier_retention[tier].db_update_every_s = (time_t) (qn->rrdhost->db[tier].tier_grouping * ri->update_every_s);
@@ -285,7 +285,7 @@ static bool query_metric_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_CON
         }
     }
 
-    for (size_t tier = 0; tier < rrdb.storage_tiers; tier++) {
+    for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
         if(!qt->db.tiers[tier].update_every || (tier_retention[tier].db_update_every_s && tier_retention[tier].db_update_every_s < qt->db.tiers[tier].update_every))
             qt->db.tiers[tier].update_every = tier_retention[tier].db_update_every_s;
 
@@ -329,7 +329,7 @@ static bool query_metric_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_CON
         if (!qt->db.last_time_s || common_last_time_s > qt->db.last_time_s)
             qt->db.last_time_s = common_last_time_s;
 
-        for (size_t tier = 0; tier < rrdb.storage_tiers; tier++) {
+        for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
             internal_fatal(tier_retention[tier].storage_engine_id != query_metric_storage_engine(qt, qm, tier), "QUERY TARGET: storage engine mismatch");
             qm->tiers[tier].db_metric_handle = tier_retention[tier].db_metric_handle;
             qm->tiers[tier].db_first_time_s = tier_retention[tier].db_first_time_s;
@@ -341,7 +341,7 @@ static bool query_metric_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_CON
     }
 
     // cleanup anything we allocated to the retention we will not use
-    for(size_t tier = 0; tier < rrdb.storage_tiers ;tier++) {
+    for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
         if (tier_retention[tier].db_metric_handle)
             storage_engine_metric_release(tier_retention[tier].storage_engine_id, tier_retention[tier].db_metric_handle);
     }

--- a/database/contexts/rrdcontext.h
+++ b/database/contexts/rrdcontext.h
@@ -142,7 +142,7 @@ typedef struct query_plan_entry {
     time_t before;
 } QUERY_PLAN_ENTRY;
 
-#define QUERY_PLANS_MAX (RRD_STORAGE_TIERS)
+#define QUERY_PLANS_MAX (STORAGE_ENGINE_TIERS)
 
 typedef struct query_metrics_counts {   // counts the number of metrics related to an object
     size_t selected;                    // selected to be queried
@@ -215,7 +215,7 @@ typedef struct query_metric {
         time_t db_last_time_s;          // the latest timestamp available for this tier
         time_t db_update_every_s;       // latest update every for this tier
         long weight;
-    } tiers[RRD_STORAGE_TIERS];
+    } tiers[STORAGE_ENGINE_TIERS];
 
     struct {
         size_t used;
@@ -351,11 +351,11 @@ typedef struct query_target {
     } window;
 
     struct {
-        size_t queries[RRD_STORAGE_TIERS];
+        size_t queries[STORAGE_ENGINE_TIERS];
         time_t first_time_s;                  // the combined first_time_t of all metrics in the query, across all tiers
         time_t last_time_s;                   // the combined last_time_T of all metrics in the query, across all tiers
         time_t minimum_latest_update_every_s; // the min update every of the metrics in the query
-        struct query_tier_statistics tiers[RRD_STORAGE_TIERS];
+        struct query_tier_statistics tiers[STORAGE_ENGINE_TIERS];
     } db;
 
     struct {

--- a/database/contexts/worker.c
+++ b/database/contexts/worker.c
@@ -235,7 +235,7 @@ bool rrdmetric_update_retention(RRDMETRIC *rm) {
     }
     else {
         RRDHOST *rrdhost = rm->ri->rc->rrdhost;
-        for (size_t tier = 0; tier < rrdb.storage_tiers; tier++) {
+        for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
             time_t first_time_t, last_time_t;
             if (storage_engine_metric_retention(rrdhost->db[tier].id, rrdhost->db[tier].instance, &rm->uuid, &first_time_t, &last_time_t)) {
                 if (first_time_t < min_first_time_t)

--- a/database/engine/datafile.c
+++ b/database/engine/datafile.c
@@ -250,7 +250,7 @@ int create_data_file(struct rrdengine_datafile *datafile)
     char path[RRDENG_PATH_MAX];
 
     generate_datafilepath(datafile, path, sizeof(path));
-    fd = open_file_for_io(path, O_CREAT | O_RDWR | O_TRUNC, &file, rrdb.dbengine_cfg.use_direct_io);
+    fd = open_file_for_io(path, O_CREAT | O_RDWR | O_TRUNC, &file, dbengine_cfg.use_direct_io);
     if (fd < 0) {
         ctx_fs_error(ctx);
         return fd;
@@ -333,7 +333,7 @@ static int load_data_file(struct rrdengine_datafile *datafile)
     char path[RRDENG_PATH_MAX];
 
     generate_datafilepath(datafile, path, sizeof(path));
-    fd = open_file_for_io(path, O_RDWR, &file, rrdb.dbengine_cfg.use_direct_io);
+    fd = open_file_for_io(path, O_RDWR, &file, dbengine_cfg.use_direct_io);
     if (fd < 0) {
         ctx_fs_error(ctx);
         return fd;

--- a/database/engine/datafile.c
+++ b/database/engine/datafile.c
@@ -250,7 +250,7 @@ int create_data_file(struct rrdengine_datafile *datafile)
     char path[RRDENG_PATH_MAX];
 
     generate_datafilepath(datafile, path, sizeof(path));
-    fd = open_file_for_io(path, O_CREAT | O_RDWR | O_TRUNC, &file, rrdb.use_direct_io);
+    fd = open_file_for_io(path, O_CREAT | O_RDWR | O_TRUNC, &file, rrdb.dbengine_cfg.use_direct_io);
     if (fd < 0) {
         ctx_fs_error(ctx);
         return fd;
@@ -333,7 +333,7 @@ static int load_data_file(struct rrdengine_datafile *datafile)
     char path[RRDENG_PATH_MAX];
 
     generate_datafilepath(datafile, path, sizeof(path));
-    fd = open_file_for_io(path, O_RDWR, &file, rrdb.use_direct_io);
+    fd = open_file_for_io(path, O_RDWR, &file, rrdb.dbengine_cfg.use_direct_io);
     if (fd < 0) {
         ctx_fs_error(ctx);
         return fd;

--- a/database/engine/journalfile.c
+++ b/database/engine/journalfile.c
@@ -296,8 +296,8 @@ static bool journalfile_v2_mounted_data_unmount(struct rrdengine_journalfile *jo
 void journalfile_v2_data_unmount_cleanup(time_t now_s) {
     // DO NOT WAIT ON ANY LOCK!!!
 
-    for (size_t tier = 0; tier < rrdb.storage_tiers; tier++) {
-        struct rrdengine_instance *ctx = (struct rrdengine_instance *) rrdb.multidb_ctx[tier];
+    for (size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers; tier++) {
+        struct rrdengine_instance *ctx = (struct rrdengine_instance *) rrdb.dbengine_cfg.multidb_ctx[tier];
         if(!ctx) continue;
 
         struct rrdengine_datafile *datafile;
@@ -577,7 +577,7 @@ int journalfile_create(struct rrdengine_journalfile *journalfile, struct rrdengi
     char path[RRDENG_PATH_MAX];
 
     journalfile_v1_generate_path(datafile, path, sizeof(path));
-    fd = open_file_for_io(path, O_CREAT | O_RDWR | O_TRUNC, &file, rrdb.use_direct_io);
+    fd = open_file_for_io(path, O_CREAT | O_RDWR | O_TRUNC, &file, rrdb.dbengine_cfg.use_direct_io);
     if (fd < 0) {
         ctx_fs_error(ctx);
         return fd;
@@ -917,7 +917,7 @@ static int journalfile_v2_validate(void *data_start, size_t journal_v2_file_size
     rc = journalfile_check_v2_extent_list(data_start, journal_v2_file_size);
     if (rc) return 1;
 
-    if (!rrdb.db_engine_journal_check)
+    if (!rrdb.dbengine_cfg.check_journal)
         return 0;
 
     rc = journalfile_check_v2_metric_list(data_start, journal_v2_file_size);
@@ -1115,7 +1115,7 @@ int journalfile_v2_load(struct rrdengine_instance *ctx, struct rrdengine_journal
 
     // Initialize the journal file to be able to access the data
 
-    if (!rrdb.db_engine_journal_check)
+    if (!rrdb.dbengine_cfg.check_journal)
         journalfile->v2.flags |= JOURNALFILE_FLAG_METRIC_CRC_CHECK;
     journalfile_v2_data_set(journalfile, fd, data_start, journal_v2_file_size);
 
@@ -1501,7 +1501,7 @@ int journalfile_load(struct rrdengine_instance *ctx, struct rrdengine_journalfil
 
     journalfile_v1_generate_path(datafile, path, sizeof(path));
 
-    fd = open_file_for_io(path, O_RDWR, &file, rrdb.use_direct_io);
+    fd = open_file_for_io(path, O_RDWR, &file, rrdb.dbengine_cfg.use_direct_io);
     if (fd < 0) {
         ctx_fs_error(ctx);
 

--- a/database/engine/journalfile.c
+++ b/database/engine/journalfile.c
@@ -296,8 +296,8 @@ static bool journalfile_v2_mounted_data_unmount(struct rrdengine_journalfile *jo
 void journalfile_v2_data_unmount_cleanup(time_t now_s) {
     // DO NOT WAIT ON ANY LOCK!!!
 
-    for (size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers; tier++) {
-        struct rrdengine_instance *ctx = (struct rrdengine_instance *) rrdb.dbengine_cfg.multidb_ctx[tier];
+    for (size_t tier = 0; tier < dbengine_cfg.storage_tiers; tier++) {
+        struct rrdengine_instance *ctx = (struct rrdengine_instance *) dbengine_cfg.multidb_ctx[tier];
         if(!ctx) continue;
 
         struct rrdengine_datafile *datafile;
@@ -577,7 +577,7 @@ int journalfile_create(struct rrdengine_journalfile *journalfile, struct rrdengi
     char path[RRDENG_PATH_MAX];
 
     journalfile_v1_generate_path(datafile, path, sizeof(path));
-    fd = open_file_for_io(path, O_CREAT | O_RDWR | O_TRUNC, &file, rrdb.dbengine_cfg.use_direct_io);
+    fd = open_file_for_io(path, O_CREAT | O_RDWR | O_TRUNC, &file, dbengine_cfg.use_direct_io);
     if (fd < 0) {
         ctx_fs_error(ctx);
         return fd;
@@ -917,7 +917,7 @@ static int journalfile_v2_validate(void *data_start, size_t journal_v2_file_size
     rc = journalfile_check_v2_extent_list(data_start, journal_v2_file_size);
     if (rc) return 1;
 
-    if (!rrdb.dbengine_cfg.check_journal)
+    if (!dbengine_cfg.check_journal)
         return 0;
 
     rc = journalfile_check_v2_metric_list(data_start, journal_v2_file_size);
@@ -1115,7 +1115,7 @@ int journalfile_v2_load(struct rrdengine_instance *ctx, struct rrdengine_journal
 
     // Initialize the journal file to be able to access the data
 
-    if (!rrdb.dbengine_cfg.check_journal)
+    if (!dbengine_cfg.check_journal)
         journalfile->v2.flags |= JOURNALFILE_FLAG_METRIC_CRC_CHECK;
     journalfile_v2_data_set(journalfile, fd, data_start, journal_v2_file_size);
 
@@ -1501,7 +1501,7 @@ int journalfile_load(struct rrdengine_instance *ctx, struct rrdengine_journalfil
 
     journalfile_v1_generate_path(datafile, path, sizeof(path));
 
-    fd = open_file_for_io(path, O_RDWR, &file, rrdb.dbengine_cfg.use_direct_io);
+    fd = open_file_for_io(path, O_RDWR, &file, dbengine_cfg.use_direct_io);
     if (fd < 0) {
         ctx_fs_error(ctx);
 

--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -1084,7 +1084,7 @@ void pgc_and_mrg_initialize(void)
 {
     main_mrg = mrg_create(0);
 
-    size_t target_cache_size = (size_t) rrdb.dbengine_cfg.page_cache_mb * 1024ULL * 1024ULL;
+    size_t target_cache_size = (size_t) dbengine_cfg.page_cache_mb * 1024ULL * 1024ULL;
     size_t main_cache_size = (target_cache_size / 100) * 95;
     size_t open_cache_size = 0;
     size_t extent_cache_size = (target_cache_size / 100) * 5;
@@ -1094,13 +1094,13 @@ void pgc_and_mrg_initialize(void)
         main_cache_size = target_cache_size - extent_cache_size;
     }
 
-    extent_cache_size += (size_t) (rrdb.dbengine_cfg.extent_cache_mb * 1024ULL * 1024ULL);
+    extent_cache_size += (size_t) (dbengine_cfg.extent_cache_mb * 1024ULL * 1024ULL);
 
     main_cache = pgc_create(
             "main_cache",
             main_cache_size,
             main_cache_free_clean_page_callback,
-            (size_t) rrdb.dbengine_cfg.pages_per_extent,
+            (size_t) dbengine_cfg.pages_per_extent,
             main_cache_flush_dirty_page_init_callback,
             main_cache_flush_dirty_page_callback,
             10,

--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -1100,7 +1100,7 @@ void pgc_and_mrg_initialize(void)
             "main_cache",
             main_cache_size,
             main_cache_free_clean_page_callback,
-            (size_t) rrdeng_pages_per_extent,
+            (size_t) rrdb.rrdeng_pages_per_extent,
             main_cache_flush_dirty_page_init_callback,
             main_cache_flush_dirty_page_callback,
             10,

--- a/database/engine/pagecache.c
+++ b/database/engine/pagecache.c
@@ -1084,7 +1084,7 @@ void pgc_and_mrg_initialize(void)
 {
     main_mrg = mrg_create(0);
 
-    size_t target_cache_size = (size_t) rrdb.default_rrdeng_page_cache_mb * 1024ULL * 1024ULL;
+    size_t target_cache_size = (size_t) rrdb.dbengine_cfg.page_cache_mb * 1024ULL * 1024ULL;
     size_t main_cache_size = (target_cache_size / 100) * 95;
     size_t open_cache_size = 0;
     size_t extent_cache_size = (target_cache_size / 100) * 5;
@@ -1094,13 +1094,13 @@ void pgc_and_mrg_initialize(void)
         main_cache_size = target_cache_size - extent_cache_size;
     }
 
-    extent_cache_size += (size_t) (rrdb.default_rrdeng_extent_cache_mb * 1024ULL * 1024ULL);
+    extent_cache_size += (size_t) (rrdb.dbengine_cfg.extent_cache_mb * 1024ULL * 1024ULL);
 
     main_cache = pgc_create(
             "main_cache",
             main_cache_size,
             main_cache_free_clean_page_callback,
-            (size_t) rrdb.rrdeng_pages_per_extent,
+            (size_t) rrdb.dbengine_cfg.pages_per_extent,
             main_cache_flush_dirty_page_init_callback,
             main_cache_flush_dirty_page_callback,
             10,

--- a/database/engine/pdc.c
+++ b/database/engine/pdc.c
@@ -667,7 +667,7 @@ VALIDATED_PAGE_DESCRIPTOR validate_page(
     };
 
     // always calculate entries by size
-    vd.point_size = rrdb.page_type_size[vd.type];
+    vd.point_size = rrdb.dbengine_cfg.page_type_size[vd.type];
     vd.entries = page_entries_by_size(vd.page_length, vd.point_size);
 
     // allow to be called without entries (when loading pages from disk)

--- a/database/engine/pdc.c
+++ b/database/engine/pdc.c
@@ -667,7 +667,7 @@ VALIDATED_PAGE_DESCRIPTOR validate_page(
     };
 
     // always calculate entries by size
-    vd.point_size = rrdb.dbengine_cfg.page_type_size[vd.type];
+    vd.point_size = dbengine_cfg.page_type_size[vd.type];
     vd.entries = page_entries_by_size(vd.page_length, vd.point_size);
 
     // allow to be called without entries (when loading pages from disk)

--- a/database/engine/rrddim_eng.c
+++ b/database/engine/rrddim_eng.c
@@ -2,6 +2,87 @@
 
 #include "rrddim_eng.h"
 
+struct dbengine_initialization {
+    netdata_thread_t thread;
+    char path[FILENAME_MAX + 1];
+    int disk_space_mb;
+    size_t tier;
+    int ret;
+};
+
+static void *dbengine_tier_init(void *ptr) {
+    struct dbengine_initialization *dbi = ptr;
+    dbi->ret = rrdeng_tier_init(NULL, dbi->path, dbi->disk_space_mb, dbi->tier);
+    return ptr;
+}
+
+bool dbengine_init(const char *hostname, dbengine_config_t *cfg) {
+    struct dbengine_initialization tiers_init[STORAGE_ENGINE_TIERS] = {};
+
+    for (size_t tier = 0; tier < cfg->storage_tiers ;tier++) {
+        char dbenginepath[FILENAME_MAX + 1];
+
+        if (tier == 0)
+            snprintfz(dbenginepath, FILENAME_MAX, "%s/dbengine", cfg->base_path);
+        else
+            snprintfz(dbenginepath, FILENAME_MAX, "%s/dbengine-tier%zu", cfg->base_path, tier);
+
+        int ret = mkdir(dbenginepath, 0775);
+        if (ret != 0 && errno != EEXIST) {
+            netdata_log_error("DBENGINE on '%s': cannot create directory '%s'", hostname, dbenginepath);
+            break;
+        }
+
+        tiers_init[tier].disk_space_mb = cfg->multidb_disk_quota_mb[tier];
+        tiers_init[tier].tier = tier;
+        strncpyz(tiers_init[tier].path, dbenginepath, FILENAME_MAX);
+        tiers_init[tier].ret = 0;
+
+        if (cfg->parallel_initialization) {
+            char tag[NETDATA_THREAD_TAG_MAX + 1];
+            snprintfz(tag, NETDATA_THREAD_TAG_MAX, "DBENGINIT[%zu]", tier);
+            netdata_thread_create(&tiers_init[tier].thread, tag, NETDATA_THREAD_OPTION_JOINABLE,
+                                  dbengine_tier_init, &tiers_init[tier]);
+        }
+        else
+            dbengine_tier_init(&tiers_init[tier]);
+    }
+
+    size_t created_tiers = 0;
+
+    for (size_t tier = 0; tier < cfg->storage_tiers ;tier++) {
+        void *ptr;
+
+        if (cfg->parallel_initialization)
+            netdata_thread_join(tiers_init[tier].thread, &ptr);
+
+        if (tiers_init[tier].ret != 0) {
+            netdata_log_error("DBENGINE on '%s': Failed to initialize multi-host database tier %zu on path '%s'",
+                              hostname,
+                              tiers_init[tier].tier,
+                              tiers_init[tier].path);
+        }
+        else if (created_tiers == tier)
+            created_tiers++;
+    }
+
+    if (created_tiers && created_tiers < cfg->storage_tiers) {
+        netdata_log_error("DBENGINE on '%s': Managed to create %zu tiers instead of %zu. Continuing with %zu available.",
+                          hostname,
+                          created_tiers,
+                          cfg->storage_tiers,
+                          created_tiers);
+        cfg->storage_tiers = created_tiers;
+    }
+    else if (!created_tiers)
+        fatal("DBENGINE on '%s', failed to initialize databases at '%s'.", hostname, cfg->base_path);
+
+    for (size_t tier = 0; tier < cfg->storage_tiers ;tier++)
+        rrdeng_readiness_wait(cfg->multidb_ctx[tier]);
+
+    return true;
+}
+
 dbengine_config_t dbengine_cfg = {
     .base_path = CACHE_DIR,
 

--- a/database/engine/rrddim_eng.c
+++ b/database/engine/rrddim_eng.c
@@ -1,6 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "rrddim_eng.h"
+#include "rrdengineapi.h"
+
+/* Default global database instance */
+struct rrdengine_instance multidb_ctx_storage_tier0;
+struct rrdengine_instance multidb_ctx_storage_tier1;
+struct rrdengine_instance multidb_ctx_storage_tier2;
+struct rrdengine_instance multidb_ctx_storage_tier3;
+struct rrdengine_instance multidb_ctx_storage_tier4;
 
 struct dbengine_initialization {
     netdata_thread_t thread;
@@ -112,11 +120,11 @@ static const dbengine_config_t default_dbengine_cfg = {
     .storage_tiers = 3,
 
     .multidb_ctx = {
-        NULL,
-        NULL,
-        NULL,
-        NULL,
-        NULL,
+        (STORAGE_INSTANCE *) &multidb_ctx_storage_tier0,
+        (STORAGE_INSTANCE *) &multidb_ctx_storage_tier1,
+        (STORAGE_INSTANCE *) &multidb_ctx_storage_tier2,
+        (STORAGE_INSTANCE *) &multidb_ctx_storage_tier3,
+        (STORAGE_INSTANCE *) &multidb_ctx_storage_tier4,
     },
 
     .multidb_disk_quota_mb = {

--- a/database/engine/rrddim_eng.c
+++ b/database/engine/rrddim_eng.c
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "rrddim_eng.h"
+
+dbengine_config_t dbengine_cfg = {
+    .base_path = CACHE_DIR,
+
+    .check_journal  = CONFIG_BOOLEAN_NO,
+    .use_direct_io = true,
+    .parallel_initialization = false,
+
+    .disk_quota_mb = 256,
+
+    #if defined(ENV32BIT)
+        .page_cache_mb = 16,
+        .extent_cache_mb = 0,
+    #else
+        .page_cache_mb = 32,
+        .extent_cache_mb = 0,
+    #endif
+
+    .pages_per_extent = 64,
+
+    .page_type_size = {
+        sizeof(storage_number),
+        sizeof(storage_number_tier1_t)
+    },
+
+    .storage_tiers = 3,
+
+    .multidb_ctx = {
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+    },
+
+    .multidb_disk_quota_mb = {
+        256,
+        128,
+        64,
+        32,
+        16,
+    },
+
+    .storage_tiers_grouping_iterations = {
+        1,
+        60,
+        60,
+        60,
+        60
+    },
+
+    .storage_tiers_backfill = {
+        STORAGE_TIER_BACKFILL_NEW,
+        STORAGE_TIER_BACKFILL_NEW,
+        STORAGE_TIER_BACKFILL_NEW,
+        STORAGE_TIER_BACKFILL_NEW,
+        STORAGE_TIER_BACKFILL_NEW,
+    },
+
+#if defined(ENV32BIT)
+    .tier_page_size = {
+        2048,
+        1024,
+        192,
+        192,
+        192
+    },
+#else
+    .tier_page_size = {
+        4096,
+        2048,
+        384,
+        384,
+        384
+    },
+#endif
+};

--- a/database/engine/rrddim_eng.h
+++ b/database/engine/rrddim_eng.h
@@ -93,8 +93,14 @@ typedef struct {
     size_t tier_page_size[STORAGE_ENGINE_TIERS];
 } dbengine_config_t;
 
+// returns a copy of sane default options for dbengine
+dbengine_config_t dbengine_default_config();
+
+// global to keep runtime configuration options as modified the user by
+// calling `dbengine_init()``
 extern dbengine_config_t dbengine_cfg;
 
-bool dbengine_init(const char *hostname, dbengine_config_t *cfg);
+// initialize dbengine with the provided configuration settings
+bool dbengine_init(const char *hostname, dbengine_config_t cfg);
 
 #endif /* NETDATA_RRDDIM_ENG_H */

--- a/database/engine/rrddim_eng.h
+++ b/database/engine/rrddim_eng.h
@@ -93,4 +93,6 @@ typedef struct {
     size_t tier_page_size[STORAGE_ENGINE_TIERS];
 } dbengine_config_t;
 
+extern dbengine_config_t dbengine_cfg;
+
 #endif /* NETDATA_RRDDIM_ENG_H */

--- a/database/engine/rrddim_eng.h
+++ b/database/engine/rrddim_eng.h
@@ -95,4 +95,6 @@ typedef struct {
 
 extern dbengine_config_t dbengine_cfg;
 
+bool dbengine_init(const char *hostname, dbengine_config_t *cfg);
+
 #endif /* NETDATA_RRDDIM_ENG_H */

--- a/database/engine/rrddim_eng.h
+++ b/database/engine/rrddim_eng.h
@@ -70,4 +70,28 @@ size_t rrdeng_collectors_running(STORAGE_INSTANCE *db_instance);
 
 void rrdeng_size_statistics(STORAGE_INSTANCE *db_instance, BUFFER *wb);
 
+typedef struct {
+    bool enabled;
+    const char *base_path;
+
+    int check_journal;
+    bool use_direct_io;
+    bool parallel_initialization;
+
+    int disk_quota_mb;
+    int page_cache_mb;
+    int extent_cache_mb;
+
+    unsigned pages_per_extent;
+    size_t page_type_size[256];
+
+    size_t storage_tiers;
+
+    STORAGE_INSTANCE *multidb_ctx[RRD_STORAGE_TIERS];
+    int multidb_disk_quota_mb[RRD_STORAGE_TIERS];
+    size_t storage_tiers_grouping_iterations[RRD_STORAGE_TIERS];
+    RRD_BACKFILL storage_tiers_backfill[RRD_STORAGE_TIERS];
+    size_t tier_page_size[RRD_STORAGE_TIERS];
+} dbengine_config_t;
+
 #endif /* NETDATA_RRDDIM_ENG_H */

--- a/database/engine/rrddim_eng.h
+++ b/database/engine/rrddim_eng.h
@@ -87,11 +87,11 @@ typedef struct {
 
     size_t storage_tiers;
 
-    STORAGE_INSTANCE *multidb_ctx[RRD_STORAGE_TIERS];
-    int multidb_disk_quota_mb[RRD_STORAGE_TIERS];
-    size_t storage_tiers_grouping_iterations[RRD_STORAGE_TIERS];
-    STORAGE_TIER_BACKFILL storage_tiers_backfill[RRD_STORAGE_TIERS];
-    size_t tier_page_size[RRD_STORAGE_TIERS];
+    STORAGE_INSTANCE *multidb_ctx[STORAGE_ENGINE_TIERS];
+    int multidb_disk_quota_mb[STORAGE_ENGINE_TIERS];
+    size_t storage_tiers_grouping_iterations[STORAGE_ENGINE_TIERS];
+    STORAGE_TIER_BACKFILL storage_tiers_backfill[STORAGE_ENGINE_TIERS];
+    size_t tier_page_size[STORAGE_ENGINE_TIERS];
 } dbengine_config_t;
 
 #endif /* NETDATA_RRDDIM_ENG_H */

--- a/database/engine/rrddim_eng.h
+++ b/database/engine/rrddim_eng.h
@@ -57,8 +57,8 @@ bool rrdeng_is_legacy(STORAGE_INSTANCE *db_instance);
 
 void rrdeng_get_37_statistics(STORAGE_INSTANCE *db_instance, unsigned long long *array);
 
-int rrdeng_init(STORAGE_INSTANCE **db_instance, const char *dbfiles_path,
-                       unsigned disk_space_mb, size_t tier);
+int rrdeng_tier_init(STORAGE_INSTANCE **db_instance, const char *dbfiles_path,
+                     unsigned disk_space_mb, size_t tier);
 
 void rrdeng_readiness_wait(STORAGE_INSTANCE *db_instance);
 void rrdeng_exit_mode(STORAGE_INSTANCE *db_instance);

--- a/database/engine/rrddim_eng.h
+++ b/database/engine/rrddim_eng.h
@@ -71,7 +71,6 @@ size_t rrdeng_collectors_running(STORAGE_INSTANCE *db_instance);
 void rrdeng_size_statistics(STORAGE_INSTANCE *db_instance, BUFFER *wb);
 
 typedef struct {
-    bool enabled;
     const char *base_path;
 
     int check_journal;

--- a/database/engine/rrddim_eng.h
+++ b/database/engine/rrddim_eng.h
@@ -90,7 +90,7 @@ typedef struct {
     STORAGE_INSTANCE *multidb_ctx[RRD_STORAGE_TIERS];
     int multidb_disk_quota_mb[RRD_STORAGE_TIERS];
     size_t storage_tiers_grouping_iterations[RRD_STORAGE_TIERS];
-    RRD_BACKFILL storage_tiers_backfill[RRD_STORAGE_TIERS];
+    STORAGE_TIER_BACKFILL storage_tiers_backfill[RRD_STORAGE_TIERS];
     size_t tier_page_size[RRD_STORAGE_TIERS];
 } dbengine_config_t;
 

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -355,7 +355,7 @@ static void wal_cleanup1(void) {
     if(!spinlock_trylock(&wal_globals.protected.spinlock))
         return;
 
-    if (wal_globals.protected.available_items && wal_globals.protected.available > rrdb.dbengine_cfg.storage_tiers) {
+    if (wal_globals.protected.available_items && wal_globals.protected.available > dbengine_cfg.storage_tiers) {
         wal = wal_globals.protected.available_items;
         DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(wal_globals.protected.available_items, wal, cache.prev, cache.next);
         wal_globals.protected.available--;
@@ -583,25 +583,25 @@ struct {
 } dbengine_page_alloc_globals = {};
 
 static inline ARAL *page_size_lookup(size_t size) {
-    for (size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers ;tier++)
-        if(size == rrdb.dbengine_cfg.tier_page_size[tier])
+    for (size_t tier = 0; tier < dbengine_cfg.storage_tiers ;tier++)
+        if(size == dbengine_cfg.tier_page_size[tier])
             return dbengine_page_alloc_globals.aral[tier];
 
     return NULL;
 }
 
 static void dbengine_page_alloc_init(void) {
-    for (size_t i = rrdb.dbengine_cfg.storage_tiers; i > 0 ;i--) {
-        size_t tier = rrdb.dbengine_cfg.storage_tiers - i;
+    for (size_t i = dbengine_cfg.storage_tiers; i > 0 ;i--) {
+        size_t tier = dbengine_cfg.storage_tiers - i;
 
         char buf[20 + 1];
         snprintfz(buf, 20, "tier%zu-pages", tier);
 
         dbengine_page_alloc_globals.aral[tier] = aral_create(
                 buf,
-                rrdb.dbengine_cfg.tier_page_size[tier],
+                dbengine_cfg.tier_page_size[tier],
                 64,
-                512 * rrdb.dbengine_cfg.tier_page_size[tier],
+                512 * dbengine_cfg.tier_page_size[tier],
                 pgc_aral_statistics(),
                 NULL, NULL, false, false);
     }
@@ -837,7 +837,7 @@ static struct extent_io_descriptor *datafile_extent_build(struct rrdengine_insta
     uLong crc;
 
     for(descr = base, Index = 0, count = 0, uncompressed_payload_length = 0;
-        descr && count != rrdb.dbengine_cfg.pages_per_extent;
+        descr && count != dbengine_cfg.pages_per_extent;
         descr = descr->link.next, Index++) {
 
         uncompressed_payload_length += descr->page_length;

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -579,7 +579,7 @@ static inline struct rrdeng_cmd rrdeng_deq_cmd(bool from_worker) {
 // ----------------------------------------------------------------------------
 
 struct {
-    ARAL *aral[RRD_STORAGE_TIERS];
+    ARAL *aral[STORAGE_ENGINE_TIERS];
 } dbengine_page_alloc_globals = {};
 
 static inline ARAL *page_size_lookup(size_t size) {

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -9,8 +9,6 @@ rrdeng_stats_t rrdeng_reserved_file_descriptors = 0;
 rrdeng_stats_t global_pg_cache_over_half_dirty_events = 0;
 rrdeng_stats_t global_flushing_pressure_page_deletions = 0;
 
-unsigned rrdeng_pages_per_extent = MAX_PAGES_PER_EXTENT;
-
 #if WORKER_UTILIZATION_MAX_JOB_TYPES < (RRDENG_OPCODE_MAX + 2)
 #error Please increase WORKER_UTILIZATION_MAX_JOB_TYPES to at least (RRDENG_MAX_OPCODE + 2)
 #endif
@@ -839,7 +837,7 @@ static struct extent_io_descriptor *datafile_extent_build(struct rrdengine_insta
     uLong crc;
 
     for(descr = base, Index = 0, count = 0, uncompressed_payload_length = 0;
-        descr && count != rrdeng_pages_per_extent;
+        descr && count != rrdb.rrdeng_pages_per_extent;
         descr = descr->link.next, Index++) {
 
         uncompressed_payload_length += descr->page_length;

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -355,7 +355,7 @@ static void wal_cleanup1(void) {
     if(!spinlock_trylock(&wal_globals.protected.spinlock))
         return;
 
-    if (wal_globals.protected.available_items && wal_globals.protected.available > rrdb.storage_tiers) {
+    if (wal_globals.protected.available_items && wal_globals.protected.available > rrdb.dbengine_cfg.storage_tiers) {
         wal = wal_globals.protected.available_items;
         DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(wal_globals.protected.available_items, wal, cache.prev, cache.next);
         wal_globals.protected.available--;
@@ -583,25 +583,25 @@ struct {
 } dbengine_page_alloc_globals = {};
 
 static inline ARAL *page_size_lookup(size_t size) {
-    for (size_t tier = 0; tier < rrdb.storage_tiers ;tier++)
-        if(size == rrdb.tier_page_size[tier])
+    for (size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers ;tier++)
+        if(size == rrdb.dbengine_cfg.tier_page_size[tier])
             return dbengine_page_alloc_globals.aral[tier];
 
     return NULL;
 }
 
 static void dbengine_page_alloc_init(void) {
-    for (size_t i = rrdb.storage_tiers; i > 0 ;i--) {
-        size_t tier = rrdb.storage_tiers - i;
+    for (size_t i = rrdb.dbengine_cfg.storage_tiers; i > 0 ;i--) {
+        size_t tier = rrdb.dbengine_cfg.storage_tiers - i;
 
         char buf[20 + 1];
         snprintfz(buf, 20, "tier%zu-pages", tier);
 
         dbengine_page_alloc_globals.aral[tier] = aral_create(
                 buf,
-                rrdb.tier_page_size[tier],
+                rrdb.dbengine_cfg.tier_page_size[tier],
                 64,
-                512 * rrdb.tier_page_size[tier],
+                512 * rrdb.dbengine_cfg.tier_page_size[tier],
                 pgc_aral_statistics(),
                 NULL, NULL, false, false);
     }
@@ -837,7 +837,7 @@ static struct extent_io_descriptor *datafile_extent_build(struct rrdengine_insta
     uLong crc;
 
     for(descr = base, Index = 0, count = 0, uncompressed_payload_length = 0;
-        descr && count != rrdb.rrdeng_pages_per_extent;
+        descr && count != rrdb.dbengine_cfg.pages_per_extent;
         descr = descr->link.next, Index++) {
 
         uncompressed_payload_length += descr->page_length;

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -1132,7 +1132,7 @@ void rrdeng_exit_mode(STORAGE_INSTANCE *db_instance) {
 /*
  * Returns 0 on success, negative on error
  */
-int rrdeng_init(STORAGE_INSTANCE **db_instance_ptr, const char *dbfiles_path,
+int rrdeng_tier_init(STORAGE_INSTANCE **db_instance_ptr, const char *dbfiles_path,
                 unsigned disk_space_mb, size_t tier) {
     struct rrdengine_instance **ctxp = (struct rrdengine_instance **) db_instance_ptr;
 

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -1372,7 +1372,7 @@ static RRDENG_SIZE_STATS rrdeng_size_statistics_internal(struct rrdengine_instan
     stats.sizeof_page_in_cache = 0; // struct_natural_alignment(sizeof(struct page_cache_descr));
     stats.sizeof_point_data = rrdb.page_type_size[ctx->config.page_type];
     stats.sizeof_page_data = rrdb.tier_page_size[ctx->config.tier];
-    stats.pages_per_extent = rrdeng_pages_per_extent;
+    stats.pages_per_extent = rrdb.rrdeng_pages_per_extent;
 
 //    stats.sizeof_metric_in_index = 40;
 //    stats.sizeof_page_in_index = 24;

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -10,10 +10,10 @@ struct rrdengine_instance multidb_ctx_storage_tier4;
 
 #define mrg_metric_ctx(metric) (struct rrdengine_instance *)mrg_metric_section(main_mrg, metric)
 
-#if RRD_STORAGE_TIERS != 5
-#error RRD_STORAGE_TIERS is not 5 - you need to add allocations here
+#if STORAGE_ENGINE_TIERS != 5
+#error STORAGE_ENGINE_TIERS is not 5 - you need to add allocations here
 #endif
-uint8_t tier_page_type[RRD_STORAGE_TIERS] = {PAGE_METRICS, PAGE_TIER, PAGE_TIER, PAGE_TIER, PAGE_TIER};
+uint8_t tier_page_type[STORAGE_ENGINE_TIERS] = {PAGE_METRICS, PAGE_TIER, PAGE_TIER, PAGE_TIER, PAGE_TIER};
 
 #if PAGE_TYPE_MAX != 1
 #error PAGE_TYPE_MAX is not 1 - you need to add allocations here

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -20,11 +20,11 @@ uint8_t tier_page_type[STORAGE_ENGINE_TIERS] = {PAGE_METRICS, PAGE_TIER, PAGE_TI
 #endif
 
 __attribute__((constructor)) void initialize_multidb_ctx(void) {
-    rrdb.dbengine_cfg.multidb_ctx[0] = (STORAGE_INSTANCE *) &multidb_ctx_storage_tier0;
-    rrdb.dbengine_cfg.multidb_ctx[1] = (STORAGE_INSTANCE *) &multidb_ctx_storage_tier1;
-    rrdb.dbengine_cfg.multidb_ctx[2] = (STORAGE_INSTANCE *) &multidb_ctx_storage_tier2;
-    rrdb.dbengine_cfg.multidb_ctx[3] = (STORAGE_INSTANCE *) &multidb_ctx_storage_tier3;
-    rrdb.dbengine_cfg.multidb_ctx[4] = (STORAGE_INSTANCE *) &multidb_ctx_storage_tier4;
+    dbengine_cfg.multidb_ctx[0] = (STORAGE_INSTANCE *) &multidb_ctx_storage_tier0;
+    dbengine_cfg.multidb_ctx[1] = (STORAGE_INSTANCE *) &multidb_ctx_storage_tier1;
+    dbengine_cfg.multidb_ctx[2] = (STORAGE_INSTANCE *) &multidb_ctx_storage_tier2;
+    dbengine_cfg.multidb_ctx[3] = (STORAGE_INSTANCE *) &multidb_ctx_storage_tier3;
+    dbengine_cfg.multidb_ctx[4] = (STORAGE_INSTANCE *) &multidb_ctx_storage_tier4;
 }
 
 // ----------------------------------------------------------------------------
@@ -423,7 +423,7 @@ static size_t aligned_allocation_entries(size_t max_slots, size_t target_slot, t
 static void *rrdeng_alloc_new_metric_data(struct rrdeng_collect_handle *handle, size_t *data_size, usec_t point_in_time_ut) {
     struct rrdengine_instance *ctx = mrg_metric_ctx(handle->metric);
 
-    size_t max_size = rrdb.dbengine_cfg.tier_page_size[ctx->config.tier];
+    size_t max_size = dbengine_cfg.tier_page_size[ctx->config.tier];
     size_t max_slots = max_size / CTX_POINT_SIZE_BYTES(ctx);
 
     size_t slots = aligned_allocation_entries(
@@ -443,7 +443,7 @@ static void *rrdeng_alloc_new_metric_data(struct rrdeng_collect_handle *handle, 
     // internal_error(true, "PAGE ALLOC %zu bytes (%zu max)", size, max_size);
 
     internal_fatal(slots < 3 || slots > max_slots, "ooops! wrong distribution of metrics across time");
-    internal_fatal(size > rrdb.dbengine_cfg.tier_page_size[ctx->config.tier] || size < CTX_POINT_SIZE_BYTES(ctx) * 2, "ooops! wrong page size");
+    internal_fatal(size > dbengine_cfg.tier_page_size[ctx->config.tier] || size < CTX_POINT_SIZE_BYTES(ctx) * 2, "ooops! wrong page size");
 
     *data_size = size;
     void *d = dbengine_page_alloc(size);
@@ -1061,7 +1061,7 @@ static void rrdeng_populate_mrg(struct rrdengine_instance *ctx) {
         datafiles++;
     uv_rwlock_rdunlock(&ctx->datafiles.rwlock);
 
-    ssize_t cpus = (ssize_t) get_netdata_cpus() / rrdb.dbengine_cfg.storage_tiers;
+    ssize_t cpus = (ssize_t) get_netdata_cpus() / dbengine_cfg.storage_tiers;
     if(cpus > (ssize_t)datafiles)
         cpus = (ssize_t)datafiles;
 
@@ -1155,7 +1155,7 @@ int rrdeng_tier_init(STORAGE_INSTANCE **db_instance_ptr, const char *dbfiles_pat
     }
 
     if(NULL == ctxp) {
-        ctx = (struct rrdengine_instance *) rrdb.dbengine_cfg.multidb_ctx[tier];
+        ctx = (struct rrdengine_instance *) dbengine_cfg.multidb_ctx[tier];
         memset(ctx, 0, sizeof(*ctx));
         ctx->config.legacy = false;
     }
@@ -1370,9 +1370,9 @@ static RRDENG_SIZE_STATS rrdeng_size_statistics_internal(struct rrdengine_instan
 //    stats.sizeof_metric = 0;
     stats.sizeof_datafile = struct_natural_alignment(sizeof(struct rrdengine_datafile)) + struct_natural_alignment(sizeof(struct rrdengine_journalfile));
     stats.sizeof_page_in_cache = 0; // struct_natural_alignment(sizeof(struct page_cache_descr));
-    stats.sizeof_point_data = rrdb.dbengine_cfg.page_type_size[ctx->config.page_type];
-    stats.sizeof_page_data = rrdb.dbengine_cfg.tier_page_size[ctx->config.tier];
-    stats.pages_per_extent = rrdb.dbengine_cfg.pages_per_extent;
+    stats.sizeof_point_data = dbengine_cfg.page_type_size[ctx->config.page_type];
+    stats.sizeof_page_data = dbengine_cfg.tier_page_size[ctx->config.tier];
+    stats.pages_per_extent = dbengine_cfg.pages_per_extent;
 
 //    stats.sizeof_metric_in_index = 40;
 //    stats.sizeof_page_in_index = 24;

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -1,13 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "rrdengine.h"
 
-/* Default global database instance */
-struct rrdengine_instance multidb_ctx_storage_tier0;
-struct rrdengine_instance multidb_ctx_storage_tier1;
-struct rrdengine_instance multidb_ctx_storage_tier2;
-struct rrdengine_instance multidb_ctx_storage_tier3;
-struct rrdengine_instance multidb_ctx_storage_tier4;
-
 #define mrg_metric_ctx(metric) (struct rrdengine_instance *)mrg_metric_section(main_mrg, metric)
 
 #if STORAGE_ENGINE_TIERS != 5
@@ -18,14 +11,6 @@ uint8_t tier_page_type[STORAGE_ENGINE_TIERS] = {PAGE_METRICS, PAGE_TIER, PAGE_TI
 #if PAGE_TYPE_MAX != 1
 #error PAGE_TYPE_MAX is not 1 - you need to add allocations here
 #endif
-
-__attribute__((constructor)) void initialize_multidb_ctx(void) {
-    dbengine_cfg.multidb_ctx[0] = (STORAGE_INSTANCE *) &multidb_ctx_storage_tier0;
-    dbengine_cfg.multidb_ctx[1] = (STORAGE_INSTANCE *) &multidb_ctx_storage_tier1;
-    dbengine_cfg.multidb_ctx[2] = (STORAGE_INSTANCE *) &multidb_ctx_storage_tier2;
-    dbengine_cfg.multidb_ctx[3] = (STORAGE_INSTANCE *) &multidb_ctx_storage_tier3;
-    dbengine_cfg.multidb_ctx[4] = (STORAGE_INSTANCE *) &multidb_ctx_storage_tier4;
-}
 
 // ----------------------------------------------------------------------------
 // metrics groups

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -12,7 +12,7 @@
 
 #define RRDENG_FD_BUDGET_PER_INSTANCE (50)
 
-#define CTX_POINT_SIZE_BYTES(ctx) rrdb.page_type_size[(ctx)->config.page_type]
+#define CTX_POINT_SIZE_BYTES(ctx) rrdb.dbengine_cfg.page_type_size[(ctx)->config.page_type]
 
 typedef struct rrdengine_size_statistics {
     size_t default_granularity_secs;

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -12,7 +12,7 @@
 
 #define RRDENG_FD_BUDGET_PER_INSTANCE (50)
 
-#define CTX_POINT_SIZE_BYTES(ctx) rrdb.dbengine_cfg.page_type_size[(ctx)->config.page_type]
+#define CTX_POINT_SIZE_BYTES(ctx) dbengine_cfg.page_type_size[(ctx)->config.page_type]
 
 typedef struct rrdengine_size_statistics {
     size_t default_granularity_secs;

--- a/database/engine/rrdenginelib.c
+++ b/database/engine/rrdenginelib.c
@@ -142,7 +142,7 @@ int compute_multidb_diskspace()
     if (computed_multidb_disk_quota_mb == -1) {
         int rc = count_legacy_children(netdata_configured_cache_dir);
         if (likely(rc >= 0)) {
-            computed_multidb_disk_quota_mb = (rc + 1) * rrdb.dbengine_cfg.disk_quota_mb;
+            computed_multidb_disk_quota_mb = (rc + 1) * dbengine_cfg.disk_quota_mb;
             netdata_log_info("Found %d legacy dbengines, setting multidb diskspace to %dMB", rc, computed_multidb_disk_quota_mb);
 
             fp = fopen(multidb_disk_space_file, "w");
@@ -154,7 +154,7 @@ int compute_multidb_diskspace()
                 netdata_log_error("Failed to store the default multidb disk quota size on '%s'", multidb_disk_space_file);
         }
         else
-            computed_multidb_disk_quota_mb = rrdb.dbengine_cfg.disk_quota_mb;
+            computed_multidb_disk_quota_mb = dbengine_cfg.disk_quota_mb;
     }
 
     return computed_multidb_disk_quota_mb;

--- a/database/engine/rrdenginelib.c
+++ b/database/engine/rrdenginelib.c
@@ -142,7 +142,7 @@ int compute_multidb_diskspace()
     if (computed_multidb_disk_quota_mb == -1) {
         int rc = count_legacy_children(netdata_configured_cache_dir);
         if (likely(rc >= 0)) {
-            computed_multidb_disk_quota_mb = (rc + 1) * rrdb.default_rrdeng_disk_quota_mb;
+            computed_multidb_disk_quota_mb = (rc + 1) * rrdb.dbengine_cfg.disk_quota_mb;
             netdata_log_info("Found %d legacy dbengines, setting multidb diskspace to %dMB", rc, computed_multidb_disk_quota_mb);
 
             fp = fopen(multidb_disk_space_file, "w");
@@ -154,7 +154,7 @@ int compute_multidb_diskspace()
                 netdata_log_error("Failed to store the default multidb disk quota size on '%s'", multidb_disk_space_file);
         }
         else
-            computed_multidb_disk_quota_mb = rrdb.default_rrdeng_disk_quota_mb;
+            computed_multidb_disk_quota_mb = rrdb.dbengine_cfg.disk_quota_mb;
     }
 
     return computed_multidb_disk_quota_mb;

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -111,10 +111,10 @@ static void dbengine_init(const char *hostname, const dbengine_config_t *cfg) {
 
     unsigned read_num = (unsigned)config_get_number(CONFIG_SECTION_DB, "dbengine pages per extent", MAX_PAGES_PER_EXTENT);
     if (read_num > 0 && read_num <= MAX_PAGES_PER_EXTENT)
-        rrdeng_pages_per_extent = read_num;
+        rrdb.rrdeng_pages_per_extent = read_num;
     else {
-        netdata_log_error("Invalid dbengine pages per extent %u given. Using %u.", read_num, rrdeng_pages_per_extent);
-        config_set_number(CONFIG_SECTION_DB, "dbengine pages per extent", rrdeng_pages_per_extent);
+        netdata_log_error("Invalid dbengine pages per extent %u given. Using %u.", read_num, rrdb.rrdeng_pages_per_extent);
+        config_set_number(CONFIG_SECTION_DB, "dbengine pages per extent", rrdb.rrdeng_pages_per_extent);
     }
 
     struct dbengine_initialization tiers_init[RRD_STORAGE_TIERS] = {};
@@ -381,6 +381,7 @@ struct rrdb rrdb = {
     .storage_tiers = 3,
     .use_direct_io = true,
     .parallel_initialization = false,
+    .rrdeng_pages_per_extent = MAX_PAGES_PER_EXTENT,
     .storage_tiers_grouping_iterations = {
         1,
         60,

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -84,6 +84,7 @@ STRING *rrd_string_strdupz(const char *s) {
 // ----------------------------------------------------------------------------
 // rrd global / startup initialization
 
+#ifdef ENABLE_DBENGINE
 static dbengine_config_t get_dbengine_config(const char *hostname) {
     // use the global `dbengine_cfg` instance to retrieve default values;
     dbengine_config_t cfg = dbengine_cfg;
@@ -224,6 +225,7 @@ static dbengine_config_t get_dbengine_config(const char *hostname) {
 
     return cfg;
 }
+#endif // ENABLE_DBENGINE
 
 static void init_host_indexes() {
     internal_fatal(rrdb.rrdhost_root_index || rrdb.rrdhost_root_index_hostname,

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -106,6 +106,8 @@ typedef struct {
     bool parallel_initialization;
     unsigned rrdeng_pages_per_extent;
     const char *dbengine_base_path;
+    int default_rrdeng_disk_quota_mb;
+    size_t storage_tiers_grouping_iterations[RRD_STORAGE_TIERS];
 } dbengine_config_t;
 
 static void dbengine_init(const char *hostname, const dbengine_config_t *cfg) {
@@ -290,12 +292,16 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
             cfg.parallel_initialization = config_get_boolean(CONFIG_SECTION_DB, "dbengine parallel initialization", cfg.parallel_initialization);
 
             cfg.dbengine_base_path = rrdb.dbengine_base_path;
+            cfg.default_rrdeng_disk_quota_mb = rrdb.default_rrdeng_disk_quota_mb;
+            memcpy(cfg.storage_tiers_grouping_iterations, rrdb.storage_tiers_grouping_iterations, RRD_STORAGE_TIERS);
 
             rrdb.use_direct_io = cfg.use_direct_io;
             rrdb.storage_tiers = cfg.storage_tiers;
             rrdb.parallel_initialization = cfg.parallel_initialization;
             rrdb.rrdeng_pages_per_extent = cfg.rrdeng_pages_per_extent;
             rrdb.dbengine_base_path = cfg.dbengine_base_path;
+            rrdb.default_rrdeng_disk_quota_mb = cfg.default_rrdeng_disk_quota_mb;
+            memcpy(rrdb.storage_tiers_grouping_iterations, cfg.storage_tiers_grouping_iterations, RRD_STORAGE_TIERS);
 
             dbengine_init(hostname, &cfg);
 #else

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -95,7 +95,7 @@ struct dbengine_initialization {
 
 static void *dbengine_tier_init(void *ptr) {
     struct dbengine_initialization *dbi = ptr;
-    dbi->ret = rrdeng_init(NULL, dbi->path, dbi->disk_space_mb, dbi->tier);
+    dbi->ret = rrdeng_tier_init(NULL, dbi->path, dbi->disk_space_mb, dbi->tier);
     return ptr;
 }
 

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -101,7 +101,7 @@ static void *dbengine_tier_init(void *ptr) {
 #endif
 
 static void dbengine_init(const char *hostname, dbengine_config_t *cfg) {
-    struct dbengine_initialization tiers_init[RRD_STORAGE_TIERS] = {};
+    struct dbengine_initialization tiers_init[STORAGE_ENGINE_TIERS] = {};
 
     for (size_t tier = 0; tier < cfg->storage_tiers ;tier++) {
         char dbenginepath[FILENAME_MAX + 1];
@@ -255,9 +255,9 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
                 cfg.storage_tiers = 1;
                 config_set_number(CONFIG_SECTION_DB, "storage tiers", cfg.storage_tiers);
             }
-            if (cfg.storage_tiers > RRD_STORAGE_TIERS) {
-                netdata_log_error("Up to %d storage tier are supported. Assuming %d.", RRD_STORAGE_TIERS, RRD_STORAGE_TIERS);
-                cfg.storage_tiers = RRD_STORAGE_TIERS;
+            if (cfg.storage_tiers > STORAGE_ENGINE_TIERS) {
+                netdata_log_error("Up to %d storage tier are supported. Assuming %d.", STORAGE_ENGINE_TIERS, RRD_STORAGE_TIERS);
+                cfg.storage_tiers = STORAGE_ENGINE_TIERS;
                 config_set_number(CONFIG_SECTION_DB, "storage tiers", cfg.storage_tiers);
             }
 

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -316,24 +316,24 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
             // tier backfilling
             {
                 for (size_t tier = 0; tier != cfg.storage_tiers; tier++) {
-                    RRD_BACKFILL backfill = cfg.storage_tiers_backfill[tier];
+                    STORAGE_TIER_BACKFILL backfill = cfg.storage_tiers_backfill[tier];
 
                     if (tier > 0) {
                         char buf[200 + 1];
                         snprintfz(buf, 200, "dbengine tier %zu backfill", tier);
 
-                        const char *bf = config_get(CONFIG_SECTION_DB, buf, backfill == RRD_BACKFILL_NEW ? "new" : backfill == RRD_BACKFILL_FULL ? "full" : "none");
+                        const char *bf = config_get(CONFIG_SECTION_DB, buf, backfill == STORAGE_TIER_BACKFILL_NEW ? "new" : backfill == STORAGE_TIER_BACKFILL_FULL ? "full" : "none");
 
                         if(strcmp(bf, "new") == 0)
-                            backfill = RRD_BACKFILL_NEW;
+                            backfill = STORAGE_TIER_BACKFILL_NEW;
                         else if(strcmp(bf, "full") == 0)
-                            backfill = RRD_BACKFILL_FULL;
+                            backfill = STORAGE_TIER_BACKFILL_FULL;
                         else if(strcmp(bf, "none") == 0)
-                            backfill = RRD_BACKFILL_NONE;
+                            backfill = STORAGE_TIER_BACKFILL_NONE;
                         else {
                             netdata_log_error("DBENGINE: unknown backfill value '%s', assuming 'new'", bf);
                             config_set(CONFIG_SECTION_DB, buf, "new");
-                            backfill = RRD_BACKFILL_NEW;
+                            backfill = STORAGE_TIER_BACKFILL_NEW;
                         }
                     }
 
@@ -491,11 +491,11 @@ struct rrdb rrdb = {
         },
 
         .storage_tiers_backfill = {
-            RRD_BACKFILL_NEW,
-            RRD_BACKFILL_NEW,
-            RRD_BACKFILL_NEW,
-            RRD_BACKFILL_NEW,
-            RRD_BACKFILL_NEW,
+            STORAGE_TIER_BACKFILL_NEW,
+            STORAGE_TIER_BACKFILL_NEW,
+            STORAGE_TIER_BACKFILL_NEW,
+            STORAGE_TIER_BACKFILL_NEW,
+            STORAGE_TIER_BACKFILL_NEW,
         },
 
     #if defined(ENV32BIT)

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -100,12 +100,12 @@ static void *dbengine_tier_init(void *ptr) {
 }
 #endif
 
-typedef struct {} dbengine_config_t;
+typedef struct {
+    bool use_direct_io;
+} dbengine_config_t;
 
 static void dbengine_init(const char *hostname, const dbengine_config_t *cfg) {
     UNUSED(cfg);
-
-    rrdb.use_direct_io = config_get_boolean(CONFIG_SECTION_DB, "dbengine use direct io", rrdb.use_direct_io);
 
     unsigned read_num = (unsigned)config_get_number(CONFIG_SECTION_DB, "dbengine pages per extent", MAX_PAGES_PER_EXTENT);
     if (read_num > 0 && read_num <= MAX_PAGES_PER_EXTENT)
@@ -282,6 +282,11 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
 
 #ifdef ENABLE_DBENGINE
             dbengine_config_t cfg;
+
+            cfg.use_direct_io = config_get_boolean(CONFIG_SECTION_DB, "dbengine use direct io", rrdb.use_direct_io);
+
+            rrdb.use_direct_io = cfg.use_direct_io;
+
             dbengine_init(hostname, &cfg);
 #else
             rrdb.storage_tiers = config_get_number(CONFIG_SECTION_DB, "storage tiers", 1);

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -219,6 +219,29 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
             netdata_log_info("DBENGINE: Initializing ...");
 
 #ifdef ENABLE_DBENGINE
+            rrdb.default_rrdeng_page_cache_mb = (int) config_get_number(CONFIG_SECTION_DB, "dbengine page cache size MB", rrdb.default_rrdeng_page_cache_mb);
+            rrdb.default_rrdeng_extent_cache_mb = (int) config_get_number(CONFIG_SECTION_DB, "dbengine extent cache size MB", rrdb.default_rrdeng_extent_cache_mb);
+            rrdb.db_engine_journal_check = config_get_boolean(CONFIG_SECTION_DB, "dbengine enable journal integrity check", CONFIG_BOOLEAN_NO);
+
+            if(rrdb.default_rrdeng_extent_cache_mb < 0)
+                rrdb.default_rrdeng_extent_cache_mb = 0;
+
+            if(rrdb.default_rrdeng_page_cache_mb < RRDENG_MIN_PAGE_CACHE_SIZE_MB) {
+                netdata_log_error("Invalid page cache size %d given. Defaulting to %d.", rrdb.default_rrdeng_page_cache_mb, RRDENG_MIN_PAGE_CACHE_SIZE_MB);
+                rrdb.default_rrdeng_page_cache_mb = RRDENG_MIN_PAGE_CACHE_SIZE_MB;
+                config_set_number(CONFIG_SECTION_DB, "dbengine page cache size MB", rrdb.default_rrdeng_page_cache_mb);
+            }
+
+            // ------------------------------------------------------------------------
+            // get default Database Engine disk space quota in MiB
+
+            rrdb.default_rrdeng_disk_quota_mb = (int) config_get_number(CONFIG_SECTION_DB, "dbengine disk space MB", rrdb.default_rrdeng_disk_quota_mb);
+            if (rrdb.default_rrdeng_disk_quota_mb < RRDENG_MIN_DISK_SPACE_MB) {
+                netdata_log_error("Invalid dbengine disk space %d given. Defaulting to %d.", rrdb.default_rrdeng_disk_quota_mb, RRDENG_MIN_DISK_SPACE_MB);
+                rrdb.default_rrdeng_disk_quota_mb = RRDENG_MIN_DISK_SPACE_MB;
+                config_set_number(CONFIG_SECTION_DB, "dbengine disk space MB", rrdb.default_rrdeng_disk_quota_mb);
+            }
+
             dbengine_config_t cfg;
 
             cfg.use_direct_io = config_get_boolean(CONFIG_SECTION_DB, "dbengine use direct io", rrdb.use_direct_io);

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -86,8 +86,7 @@ STRING *rrd_string_strdupz(const char *s) {
 
 #ifdef ENABLE_DBENGINE
 static dbengine_config_t get_dbengine_config(const char *hostname) {
-    // use the global `dbengine_cfg` instance to retrieve default values;
-    dbengine_config_t cfg = dbengine_cfg;
+    dbengine_config_t cfg = dbengine_default_config();
 
     // check journal
     cfg.check_journal = config_get_boolean(CONFIG_SECTION_DB, "dbengine enable journal integrity check", cfg.check_journal);
@@ -267,7 +266,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
 
 #ifdef ENABLE_DBENGINE
         rrdb.dbengine_cfg = get_dbengine_config(hostname);
-        rrdb.dbengine_enabled = dbengine_init(hostname, &rrdb.dbengine_cfg);
+        rrdb.dbengine_enabled = dbengine_init(hostname, rrdb.dbengine_cfg);
 #endif
         } else {
             netdata_log_info("DBENGINE: Not initializing ...");

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -100,7 +100,11 @@ static void *dbengine_tier_init(void *ptr) {
 }
 #endif
 
-static void dbengine_init(const char *hostname) {
+typedef struct {} dbengine_config_t;
+
+static void dbengine_init(const char *hostname, const dbengine_config_t *cfg) {
+    UNUSED(cfg);
+
 #ifdef ENABLE_DBENGINE
     rrdb.use_direct_io = config_get_boolean(CONFIG_SECTION_DB, "dbengine use direct io", rrdb.use_direct_io);
 
@@ -285,7 +289,9 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
 
         if (default_storage_engine_id == STORAGE_ENGINE_DBENGINE || rrdpush_receiver_needs_dbengine()) {
             netdata_log_info("DBENGINE: Initializing ...");
-            dbengine_init(hostname);
+
+            dbengine_config_t cfg;
+            dbengine_init(hostname, &cfg);
         }
         else {
             netdata_log_info("DBENGINE: Not initializing ...");

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -256,7 +256,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
                 config_set_number(CONFIG_SECTION_DB, "storage tiers", cfg.storage_tiers);
             }
             if (cfg.storage_tiers > STORAGE_ENGINE_TIERS) {
-                netdata_log_error("Up to %d storage tier are supported. Assuming %d.", STORAGE_ENGINE_TIERS, RRD_STORAGE_TIERS);
+                netdata_log_error("Up to %d storage tier are supported. Assuming %d.", STORAGE_ENGINE_TIERS, STORAGE_ENGINE_TIERS);
                 cfg.storage_tiers = STORAGE_ENGINE_TIERS;
                 config_set_number(CONFIG_SECTION_DB, "storage tiers", cfg.storage_tiers);
             }

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -161,7 +161,7 @@ static bool dbengine_init(const char *hostname, dbengine_config_t *cfg) {
         fatal("DBENGINE on '%s', failed to initialize databases at '%s'.", hostname, netdata_configured_cache_dir);
 
     for (size_t tier = 0; tier < cfg->storage_tiers ;tier++)
-        rrdeng_readiness_wait(rrdb.dbengine_cfg.multidb_ctx[tier]);
+        rrdeng_readiness_wait(cfg->multidb_ctx[tier]);
 
     return true;
 }
@@ -205,7 +205,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
             netdata_log_info("DBENGINE: Initializing ...");
 
 #ifdef ENABLE_DBENGINE
-            dbengine_config_t cfg = rrdb.dbengine_cfg;
+            dbengine_config_t cfg = dbengine_cfg;
 
             // check journal
             cfg.check_journal = config_get_boolean(CONFIG_SECTION_DB, "dbengine enable journal integrity check", cfg.check_journal);
@@ -435,81 +435,6 @@ struct rrdb rrdb = {
     .dbengine_enabled = false,
 
 #ifdef ENABLE_DBENGINE
-    .dbengine_cfg = {
-        .base_path = CACHE_DIR,
-
-        .check_journal  = CONFIG_BOOLEAN_NO,
-        .use_direct_io = true,
-        .parallel_initialization = false,
-
-        .disk_quota_mb = 256,
-
-        #if defined(ENV32BIT)
-            .page_cache_mb = 16,
-            .extent_cache_mb = 0,
-        #else
-            .page_cache_mb = 32,
-            .extent_cache_mb = 0,
-        #endif
-
-        .pages_per_extent = MAX_PAGES_PER_EXTENT,
-
-        .page_type_size = {
-            sizeof(storage_number),
-            sizeof(storage_number_tier1_t)
-        },
-
-        .storage_tiers = 3,
-
-        .multidb_ctx = {
-            NULL,
-            NULL,
-            NULL,
-            NULL,
-            NULL,
-        },
-
-        .multidb_disk_quota_mb = {
-            256,
-            128,
-            64,
-            32,
-            16,
-        },
-
-        .storage_tiers_grouping_iterations = {
-            1,
-            60,
-            60,
-            60,
-            60
-        },
-
-        .storage_tiers_backfill = {
-            STORAGE_TIER_BACKFILL_NEW,
-            STORAGE_TIER_BACKFILL_NEW,
-            STORAGE_TIER_BACKFILL_NEW,
-            STORAGE_TIER_BACKFILL_NEW,
-            STORAGE_TIER_BACKFILL_NEW,
-        },
-
-    #if defined(ENV32BIT)
-        .tier_page_size = {
-            2048,
-            1024,
-            192,
-            192,
-            192
-        },
-    #else
-        .tier_page_size = {
-            4096,
-            2048,
-            384,
-            384,
-            384
-        },
-    #endif
-    },
+    .dbengine_cfg = {},
 #endif // ENABLE_DBENGINE
 };

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -108,6 +108,7 @@ typedef struct {
     const char *dbengine_base_path;
     int default_rrdeng_disk_quota_mb;
     size_t storage_tiers_grouping_iterations[RRD_STORAGE_TIERS];
+    RRD_BACKFILL storage_tiers_backfill[RRD_STORAGE_TIERS];
 } dbengine_config_t;
 
 static void dbengine_init(const char *hostname, const dbengine_config_t *cfg) {
@@ -292,8 +293,12 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
             cfg.parallel_initialization = config_get_boolean(CONFIG_SECTION_DB, "dbengine parallel initialization", cfg.parallel_initialization);
 
             cfg.dbengine_base_path = rrdb.dbengine_base_path;
+
             cfg.default_rrdeng_disk_quota_mb = rrdb.default_rrdeng_disk_quota_mb;
+
             memcpy(cfg.storage_tiers_grouping_iterations, rrdb.storage_tiers_grouping_iterations, RRD_STORAGE_TIERS);
+
+            memcpy(cfg.storage_tiers_backfill, rrdb.storage_tiers_backfill, RRD_STORAGE_TIERS);
 
             rrdb.use_direct_io = cfg.use_direct_io;
             rrdb.storage_tiers = cfg.storage_tiers;
@@ -302,6 +307,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
             rrdb.dbengine_base_path = cfg.dbengine_base_path;
             rrdb.default_rrdeng_disk_quota_mb = cfg.default_rrdeng_disk_quota_mb;
             memcpy(rrdb.storage_tiers_grouping_iterations, cfg.storage_tiers_grouping_iterations, RRD_STORAGE_TIERS);
+            memcpy(rrdb.storage_tiers_backfill, cfg.storage_tiers_backfill, RRD_STORAGE_TIERS);
 
             dbengine_init(hostname, &cfg);
 #else

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -117,10 +117,11 @@ static void dbengine_init(const char *hostname, const dbengine_config_t *cfg) {
     struct dbengine_initialization tiers_init[RRD_STORAGE_TIERS] = {};
 
     size_t created_tiers = 0;
-    char dbenginepath[FILENAME_MAX + 1];
-    char dbengineconfig[200 + 1];
     int divisor = 1;
+
     for(size_t tier = 0; tier < rrdb.storage_tiers ;tier++) {
+        char dbenginepath[FILENAME_MAX + 1];
+
         if(tier == 0)
             snprintfz(dbenginepath, FILENAME_MAX, "%s/dbengine", rrdb.dbengine_base_path);
         else
@@ -140,6 +141,7 @@ static void dbengine_init(const char *hostname, const dbengine_config_t *cfg) {
         RRD_BACKFILL backfill = rrdb.storage_tiers_backfill[tier];
 
         if(tier > 0) {
+            char dbengineconfig[200 + 1];
             snprintfz(dbengineconfig, 200, "dbengine tier %zu multihost disk space MB", tier);
             disk_space_mb = config_get_number(CONFIG_SECTION_DB, dbengineconfig, disk_space_mb);
 

--- a/database/rrd.c
+++ b/database/rrd.c
@@ -157,9 +157,12 @@ static void dbengine_init(const char *hostname, const dbengine_config_t *cfg) {
 
             snprintfz(dbengineconfig, 200, "dbengine tier %zu backfill", tier);
             const char *bf = config_get(CONFIG_SECTION_DB, dbengineconfig, backfill == RRD_BACKFILL_NEW ? "new" : backfill == RRD_BACKFILL_FULL ? "full" : "none");
-            if(strcmp(bf, "new") == 0) backfill = RRD_BACKFILL_NEW;
-            else if(strcmp(bf, "full") == 0) backfill = RRD_BACKFILL_FULL;
-            else if(strcmp(bf, "none") == 0) backfill = RRD_BACKFILL_NONE;
+            if(strcmp(bf, "new") == 0)
+                backfill = RRD_BACKFILL_NEW;
+            else if(strcmp(bf, "full") == 0)
+                backfill = RRD_BACKFILL_FULL;
+            else if(strcmp(bf, "none") == 0)
+                backfill = RRD_BACKFILL_NONE;
             else {
                 netdata_log_error("DBENGINE: unknown backfill value '%s', assuming 'new'", bf);
                 config_set(CONFIG_SECTION_DB, dbengineconfig, "new");

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -921,8 +921,10 @@ extern struct rrdb rrdb;
 
 #ifdef DBENGINE
 #define rrd_storage_tiers() (rrdb.dbengine_cfg.storage_tiers)
+#define rrd_storage_tier_backfill(tier) (rrdb.dbengine_cfg.storage_tiers[(tier)])
 #else
 #define rrd_storage_tiers() 1
+#define rrd_storage_tier_backfill(tier) RRD_BACKFILL_NEW
 #endif
 
 #define rrdhost_hostname(host) string2str((host)->hostname)

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -879,6 +879,8 @@ struct rrdb {
 
     unsigned rrdeng_pages_per_extent;
 
+    const char *dbengine_base_path;
+
     size_t storage_tiers_grouping_iterations[RRD_STORAGE_TIERS];
     RRD_BACKFILL storage_tiers_backfill[RRD_STORAGE_TIERS];
 

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -41,8 +41,6 @@ typedef enum __attribute__ ((__packed__)) {
     QUERY_SOURCE_UNITTEST,
 } QUERY_SOURCE;
 
-#define RRD_STORAGE_TIERS 5
-
 // forward declarations
 struct rrddim_tier;
 
@@ -85,12 +83,6 @@ RRDSET_TYPE rrdset_type_id(const char *name);
 const char *rrdset_type_name(RRDSET_TYPE chart_type);
 
 #include "contexts/rrdcontext.h"
-
-typedef enum __attribute__ ((__packed__)) {
-    RRD_BACKFILL_NONE = 0,
-    RRD_BACKFILL_FULL,
-    RRD_BACKFILL_NEW
-} RRD_BACKFILL;
 
 #define UPDATE_EVERY_MIN 1
 #define UPDATE_EVERY_MAX 600
@@ -866,31 +858,6 @@ struct rrdhost {
 // ----------------------------------------------------------------------------
 // RRDB 
 
-typedef struct {
-    bool enabled;
-    const char *base_path;
-
-    int check_journal;
-    bool use_direct_io;
-    bool parallel_initialization;
-
-    int disk_quota_mb;
-    int page_cache_mb;
-    int extent_cache_mb;
-
-    unsigned pages_per_extent;
-    size_t page_type_size[256];
-
-    size_t storage_tiers;
-
-    STORAGE_INSTANCE *multidb_ctx[RRD_STORAGE_TIERS];
-    int multidb_disk_quota_mb[RRD_STORAGE_TIERS];
-    size_t storage_tiers_grouping_iterations[RRD_STORAGE_TIERS];
-    RRD_BACKFILL storage_tiers_backfill[RRD_STORAGE_TIERS];
-    size_t tier_page_size[RRD_STORAGE_TIERS];
-} dbengine_config_t;
-
-
 struct rrdb {
     DICTIONARY *rrdhost_root_index;
     DICTIONARY *rrdhost_root_index_hostname;
@@ -914,7 +881,9 @@ struct rrdb {
 
     RRDHOST *localhost;
 
+#ifdef ENABLE_DBENGINE
     dbengine_config_t dbengine_cfg;
+#endif
 };
 
 extern struct rrdb rrdb;

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -866,23 +866,36 @@ struct rrdhost {
 // ----------------------------------------------------------------------------
 // RRDB 
 
+typedef struct {
+    bool enabled;
+    const char *base_path;
+
+    int check_journal;
+    bool use_direct_io;
+    bool parallel_initialization;
+
+    int disk_quota_mb;
+    int page_cache_mb;
+    int extent_cache_mb;
+
+    unsigned pages_per_extent;
+    size_t page_type_size[256];
+
+    size_t storage_tiers;
+
+    STORAGE_INSTANCE *multidb_ctx[RRD_STORAGE_TIERS];
+    int multidb_disk_quota_mb[RRD_STORAGE_TIERS];
+    size_t storage_tiers_grouping_iterations[RRD_STORAGE_TIERS];
+    RRD_BACKFILL storage_tiers_backfill[RRD_STORAGE_TIERS];
+    size_t tier_page_size[RRD_STORAGE_TIERS];
+} dbengine_config_t;
+
+
 struct rrdb {
     DICTIONARY *rrdhost_root_index;
     DICTIONARY *rrdhost_root_index_hostname;
 
     bool unittest_running;
-    bool dbengine_enabled;
-    size_t storage_tiers;
-    bool use_direct_io;
-
-    bool parallel_initialization;
-
-    unsigned rrdeng_pages_per_extent;
-
-    const char *dbengine_base_path;
-
-    size_t storage_tiers_grouping_iterations[RRD_STORAGE_TIERS];
-    RRD_BACKFILL storage_tiers_backfill[RRD_STORAGE_TIERS];
 
     int default_update_every;
     int default_rrd_history_entries;
@@ -901,24 +914,16 @@ struct rrdb {
 
     RRDHOST *localhost;
 
-    int default_rrdeng_page_cache_mb;
-
-    int default_rrdeng_extent_cache_mb;
-
-    int db_engine_journal_check;
-
-    int default_rrdeng_disk_quota_mb;
-
-    int multidb_disk_quota_mb[RRD_STORAGE_TIERS];
-
-    STORAGE_INSTANCE *multidb_ctx[RRD_STORAGE_TIERS];
-
-    size_t page_type_size[256];
-
-    size_t tier_page_size[RRD_STORAGE_TIERS];
+    dbengine_config_t dbengine_cfg;
 };
 
 extern struct rrdb rrdb;
+
+#ifdef DBENGINE
+#define rrd_storage_tiers() (rrdb.dbengine_cfg.storage_tiers)
+#else
+#define rrd_storage_tiers() 1
+#endif
 
 #define rrdhost_hostname(host) string2str((host)->hostname)
 #define rrdhost_registry_hostname(host) string2str((host)->registry_hostname)

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -877,6 +877,8 @@ struct rrdb {
 
     bool parallel_initialization;
 
+    unsigned rrdeng_pages_per_extent;
+
     size_t storage_tiers_grouping_iterations[RRD_STORAGE_TIERS];
     RRD_BACKFILL storage_tiers_backfill[RRD_STORAGE_TIERS];
 

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -881,6 +881,8 @@ struct rrdb {
 
     RRDHOST *localhost;
 
+    bool dbengine_enabled;
+
 #ifdef ENABLE_DBENGINE
     dbengine_config_t dbengine_cfg;
 #endif

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -909,7 +909,7 @@ struct rrdb {
 
     int default_rrdeng_disk_quota_mb;
 
-    int default_multidb_disk_quota_mb;
+    int multidb_disk_quota_mb[RRD_STORAGE_TIERS];
 
     STORAGE_INSTANCE *multidb_ctx[RRD_STORAGE_TIERS];
 

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -875,6 +875,8 @@ struct rrdb {
     size_t storage_tiers;
     bool use_direct_io;
 
+    bool parallel_initialization;
+
     size_t storage_tiers_grouping_iterations[RRD_STORAGE_TIERS];
     RRD_BACKFILL storage_tiers_backfill[RRD_STORAGE_TIERS];
 

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -893,7 +893,7 @@ extern struct rrdb rrdb;
 #define rrd_storage_tier_backfill(tier) (rrdb.dbengine_cfg.storage_tiers[(tier)])
 #else
 #define rrd_storage_tiers() 1
-#define rrd_storage_tier_backfill(tier) RRD_BACKFILL_NEW
+#define rrd_storage_tier_backfill(tier) STORAGE_TIER_BACKFILL_NEW
 #endif
 
 #define rrdhost_hostname(host) string2str((host)->hostname)

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -377,7 +377,7 @@ struct rrdset {
 
     rrd_ml_chart_t *ml_chart;
 
-    STORAGE_METRICS_GROUP *storage_metrics_groups[RRD_STORAGE_TIERS];
+    STORAGE_METRICS_GROUP *storage_metrics_groups[STORAGE_ENGINE_TIERS];
 
     // ------------------------------------------------------------------------
     // linking to siblings and parents
@@ -744,7 +744,7 @@ struct rrdhost {
         STORAGE_ENGINE_ID id;                       // the storage engine id for this tier
         STORAGE_INSTANCE *instance;                 // the db instance for this tier
         uint32_t tier_grouping;                     // tier 0 iterations aggregated on this tier
-    } db[RRD_STORAGE_TIERS];
+    } db[STORAGE_ENGINE_TIERS];
 
     struct rrdhost_system_info *system_info;        // information collected from the host environment
 

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -261,7 +261,7 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
     // initialize the db tiers
     {
         size_t initialized = 0;
-        for (size_t tier = 0; tier < rrdb.storage_tiers; tier++) {
+        for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
             rd->tiers[tier].db_metric_handle = storage_engine_metric_get_or_create(rd, host->db[tier].id, host->db[tier].instance);
             storage_point_unset(rd->tiers[tier].virtual_point);
             initialized++;
@@ -279,7 +279,7 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
     // initialize data collection for all tiers
     {
         size_t initialized = 0;
-        for (size_t tier = 0; tier < rrdb.storage_tiers; tier++) {
+        for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
             if (rd->tiers[tier].db_metric_handle) {
                 rd->tiers[tier].db_collection_handle =
                         storage_metric_store_init(st->storage_engine_id, rd->tiers[tier].db_metric_handle, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->storage_metrics_groups[tier]);
@@ -337,7 +337,7 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
 bool rrddim_finalize_collection_and_check_retention(RRDDIM *rd) {
     size_t tiers_available = 0, tiers_said_no_retention = 0;
 
-    for (size_t tier = 0; tier < rrdb.storage_tiers ;tier++) {
+    for (size_t tier = 0; tier < rrd_storage_tiers() ;tier++) {
         if(!rd->tiers[tier].db_collection_handle)
             continue;
 
@@ -383,7 +383,7 @@ static void rrddim_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, v
     // this will free MEMORY_MODE_SAVE and MEMORY_MODE_MAP structures
     rrddim_memory_file_free(rd);
 
-    for (size_t tier = 0; tier < rrdb.storage_tiers ;tier++) {
+    for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
         if(!rd->tiers[tier].db_metric_handle) continue;
 
         storage_engine_metric_release(host->db[tier].id, rd->tiers[tier].db_metric_handle);
@@ -417,7 +417,7 @@ static bool rrddim_conflict_callback(const DICTIONARY_ITEM *item __maybe_unused,
     rc += rrddim_set_multiplier(st, rd, ctr->multiplier);
     rc += rrddim_set_divisor(st, rd, ctr->divisor);
 
-    for (size_t tier = 0; tier < rrdb.storage_tiers ;tier++) {
+    for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
         if (!rd->tiers[tier].db_collection_handle)
             rd->tiers[tier].db_collection_handle =
                     storage_metric_store_init(st->storage_engine_id, rd->tiers[tier].db_metric_handle, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->storage_metrics_groups[tier]);
@@ -457,7 +457,7 @@ static void rrddim_react_callback(const DICTIONARY_ITEM *item __maybe_unused, vo
 }
 
 size_t rrddim_size(void) {
-    return sizeof(RRDDIM) + rrdb.storage_tiers * sizeof(struct rrddim_tier);
+    return sizeof(RRDDIM) + rrd_storage_tiers() * sizeof(struct rrddim_tier);
 }
 
 void rrddim_index_init(RRDSET *st) {
@@ -577,7 +577,7 @@ inline int rrddim_set_divisor(RRDSET *st, RRDDIM *rd, int32_t divisor) {
 // ----------------------------------------------------------------------------
 
 time_t rrddim_last_entry_s_of_tier(RRDDIM *rd, size_t tier) {
-    if (unlikely(tier > rrdb.storage_tiers || !rd->tiers[tier].db_metric_handle))
+    if (unlikely(tier > rrd_storage_tiers() || !rd->tiers[tier].db_metric_handle))
         return 0;
 
     return storage_engine_latest_time_s(rd->rrdset->storage_engine_id, rd->tiers[tier].db_metric_handle);
@@ -587,7 +587,7 @@ time_t rrddim_last_entry_s_of_tier(RRDDIM *rd, size_t tier) {
 time_t rrddim_last_entry_s(RRDDIM *rd) {
     time_t latest_time_s = rrddim_last_entry_s_of_tier(rd, 0);
 
-    for (size_t tier = 1; tier < rrdb.storage_tiers ;tier++) {
+    for (size_t tier = 1; tier < rrd_storage_tiers(); tier++) {
         if(unlikely(!rd->tiers[tier].db_metric_handle)) continue;
 
         time_t t = rrddim_last_entry_s_of_tier(rd, tier);
@@ -599,7 +599,7 @@ time_t rrddim_last_entry_s(RRDDIM *rd) {
 }
 
 time_t rrddim_first_entry_s_of_tier(RRDDIM *rd, size_t tier) {
-    if (unlikely(tier > rrdb.storage_tiers || !rd->tiers[tier].db_metric_handle))
+    if (unlikely(tier > rrd_storage_tiers() || !rd->tiers[tier].db_metric_handle))
         return 0;
 
     return storage_engine_oldest_time_s(rd->rrdset->storage_engine_id, rd->tiers[tier].db_metric_handle);
@@ -608,7 +608,7 @@ time_t rrddim_first_entry_s_of_tier(RRDDIM *rd, size_t tier) {
 time_t rrddim_first_entry_s(RRDDIM *rd) {
     time_t oldest_time_s = 0;
 
-    for (size_t tier = 0; tier < rrdb.storage_tiers ;tier++) {
+    for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
         time_t t = rrddim_first_entry_s_of_tier(rd, tier);
         if(t != 0 && (oldest_time_s == 0 || t < oldest_time_s))
             oldest_time_s = t;

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -8,6 +8,7 @@ static void rrdhost_streaming_sender_structures_init(RRDHOST *host);
 #error STORAGE_ENGINE_TIERS is not 5 - you need to update the grouping iterations per tier
 #endif
 
+#ifdef ENABLE_DBENGINE
 size_t get_tier_grouping(size_t tier) {
     if (unlikely(tier >= rrd_storage_tiers()))
         tier = rrd_storage_tiers() - 1;
@@ -19,6 +20,12 @@ size_t get_tier_grouping(size_t tier) {
 
     return grouping;
 }
+#else
+size_t get_tier_grouping(size_t tier) {
+    UNUSED(tier);
+    return 1;
+}
+#endif
 
 bool is_storage_engine_shared(STORAGE_INSTANCE *engine __maybe_unused) {
 #ifdef ENABLE_DBENGINE
@@ -275,7 +282,7 @@ RRDHOST *rrdhost_create(
 ) {
     netdata_log_debug(D_RRDHOST, "Host '%s': adding with guid '%s'", hostname, guid);
 
-    if(storage_engine_id == STORAGE_ENGINE_DBENGINE && !rrdb.dbengine_cfg.enabled) {
+    if(storage_engine_id == STORAGE_ENGINE_DBENGINE && !rrdb.dbengine_enabled) {
         netdata_log_error("memory mode 'dbengine' is not enabled, but host '%s' is configured for it. Falling back to 'alloc'", hostname);
         storage_engine_id = STORAGE_ENGINE_ALLOC;
     }

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -4,8 +4,8 @@
 
 static void rrdhost_streaming_sender_structures_init(RRDHOST *host);
 
-#if RRD_STORAGE_TIERS != 5
-#error RRD_STORAGE_TIERS is not 5 - you need to update the grouping iterations per tier
+#if STORAGE_ENGINE_TIERS != 5
+#error STORAGE_ENGINE_TIERS is not 5 - you need to update the grouping iterations per tier
 #endif
 
 size_t get_tier_grouping(size_t tier) {

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -403,7 +403,7 @@ int is_legacy = 1;
             host->db[0].tier_grouping = get_tier_grouping(0);
 
              // may fail here for legacy dbengine initialization
-            ret = rrdeng_init(&host->db[0].instance, dbenginepath, rrdb.dbengine_cfg.disk_quota_mb, 0);
+            ret = rrdeng_tier_init(&host->db[0].instance, dbenginepath, rrdb.dbengine_cfg.disk_quota_mb, 0);
 
             if(ret == 0) {
                 rrdeng_readiness_wait(host->db[0].instance);

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -435,7 +435,7 @@ static void rrdset_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
 
     // initialize the db tiers
     {
-        for (size_t tier = 0; tier < rrdb.storage_tiers ; tier++) {
+        for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
             STORAGE_ENGINE_ID storage_engine_id = st->rrdhost->db[tier].id;
             st->storage_metrics_groups[tier] = storage_engine_metrics_group_get(storage_engine_id, host->db[tier].instance, &st->chart_uuid);
         }
@@ -477,7 +477,7 @@ void rrdset_finalize_collection(RRDSET *st, bool dimensions_too) {
         rrddim_foreach_done(rd);
     }
 
-    for(size_t tier = 0; tier < rrdb.storage_tiers ; tier++) {
+    for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
         STORAGE_ENGINE_ID storage_engine_id = st->rrdhost->db[tier].id;
 
         if(st->storage_metrics_groups[tier]) {
@@ -875,7 +875,7 @@ time_t rrdset_first_entry_s(RRDSET *st) {
 }
 
 time_t rrdset_first_entry_s_of_tier(RRDSET *st, size_t tier) {
-    if(unlikely(tier > rrdb.storage_tiers))
+    if (unlikely(tier > rrd_storage_tiers()))
         return 0;
 
     RRDDIM *rd;
@@ -1037,7 +1037,7 @@ static void rrdset_reset(RRDSET *st) {
         rd->collector.counter = 0;
 
         if(!rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED)) {
-            for(size_t tier = 0; tier < rrdb.storage_tiers ;tier++) {
+            for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
                 if (rd->tiers[tier].db_collection_handle)
                     storage_engine_store_flush(st->storage_engine_id, rd->tiers[tier].db_collection_handle);
             }
@@ -1461,7 +1461,7 @@ void rrddim_store_metric(RRDDIM *rd, usec_t point_end_time_ut, NETDATA_DOUBLE n,
         .flags = flags
     };
 
-    for(size_t tier = 1; tier < rrdb.storage_tiers ;tier++) {
+    for (size_t tier = 1; tier < rrd_storage_tiers(); tier++) {
         if(unlikely(!rd->tiers[tier].db_metric_handle)) continue;
 
         struct rrddim_tier *t = &rd->tiers[tier];
@@ -2213,7 +2213,7 @@ time_t rrdset_set_update_every_s(RRDSET *st, time_t update_every_s) {
     // switch update every to the storage engine
     RRDDIM *rd;
     rrddim_foreach_read(rd, st) {
-        for (size_t tier = 0; tier < rrdb.storage_tiers; tier++) {
+        for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
             if (rd->tiers[tier].db_collection_handle)
                 storage_engine_store_change_collection_frequency(
                         st->storage_engine_id,

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1341,7 +1341,7 @@ static inline void rrdset_init_last_updated_time(RRDSET *st) {
     last_updated_time_align(st);
 }
 
-static __thread size_t rrdset_done_statistics_points_stored_per_tier[RRD_STORAGE_TIERS];
+static __thread size_t rrdset_done_statistics_points_stored_per_tier[STORAGE_ENGINE_TIERS];
 
 static inline time_t tier_next_point_time_s(RRDDIM *rd, size_t tier, time_t now_s) {
     uint32_t tier_grouping = rd->rrdset->rrdhost->db[tier].tier_grouping;

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -653,13 +653,13 @@ bind_fail:
 static bool dimension_can_be_deleted(uuid_t *dim_uuid __maybe_unused)
 {
 #ifdef ENABLE_DBENGINE
-    if (rrdb.dbengine_enabled) {
+    if (rrdb.dbengine_cfg.enabled) {
         bool no_retention = true;
-        for (size_t tier = 0; tier < rrdb.storage_tiers; tier++) {
-            if (!rrdb.multidb_ctx[tier])
+        for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
+            if (!rrdb.dbengine_cfg.multidb_ctx[tier])
                 continue;
             time_t first_time_t = 0, last_time_t = 0;
-            if (rrdeng_metric_retention_by_uuid((void *) rrdb.multidb_ctx[tier], dim_uuid, &first_time_t, &last_time_t)) {
+            if (rrdeng_metric_retention_by_uuid((void *) rrdb.dbengine_cfg.multidb_ctx[tier], dim_uuid, &first_time_t, &last_time_t)) {
                 if (first_time_t > 0) {
                     no_retention = false;
                     break;

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -653,7 +653,7 @@ bind_fail:
 static bool dimension_can_be_deleted(uuid_t *dim_uuid __maybe_unused)
 {
 #ifdef ENABLE_DBENGINE
-    if (rrdb.dbengine_cfg.enabled) {
+    if (rrdb.dbengine_enabled) {
         bool no_retention = true;
         for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
             if (!rrdb.dbengine_cfg.multidb_ctx[tier])

--- a/database/storage_engine_types.h
+++ b/database/storage_engine_types.h
@@ -5,14 +5,6 @@
 
 #include "libnetdata/libnetdata.h"
 
-#define STORAGE_ENGINE_TIERS 5
-
-typedef enum __attribute__ ((__packed__)) {
-    STORAGE_TIER_BACKFILL_NONE = 0,
-    STORAGE_TIER_BACKFILL_FULL,
-    STORAGE_TIER_BACKFILL_NEW
-} STORAGE_TIER_BACKFILL;
-
 typedef struct rrddim RRDDIM;
 typedef struct storage_instance STORAGE_INSTANCE;
 typedef struct storage_metric_handle STORAGE_METRIC_HANDLE;
@@ -60,5 +52,13 @@ struct storage_engine_query_handle {
     STORAGE_ENGINE_ID id;
     STORAGE_QUERY_HANDLE *handle;
 };
+
+typedef enum __attribute__ ((__packed__)) {
+    STORAGE_TIER_BACKFILL_NONE = 0,
+    STORAGE_TIER_BACKFILL_FULL,
+    STORAGE_TIER_BACKFILL_NEW
+} STORAGE_TIER_BACKFILL;
+
+#define STORAGE_ENGINE_TIERS 5
 
 #endif /* NETDATA_STORAGE_ENGINE_TYPES_H */

--- a/database/storage_engine_types.h
+++ b/database/storage_engine_types.h
@@ -8,10 +8,10 @@
 #define RRD_STORAGE_TIERS 5
 
 typedef enum __attribute__ ((__packed__)) {
-    RRD_BACKFILL_NONE = 0,
-    RRD_BACKFILL_FULL,
-    RRD_BACKFILL_NEW
-} RRD_BACKFILL;
+    STORAGE_TIER_BACKFILL_NONE = 0,
+    STORAGE_TIER_BACKFILL_FULL,
+    STORAGE_TIER_BACKFILL_NEW
+} STORAGE_TIER_BACKFILL;
 
 typedef struct rrddim RRDDIM;
 typedef struct storage_instance STORAGE_INSTANCE;

--- a/database/storage_engine_types.h
+++ b/database/storage_engine_types.h
@@ -5,7 +5,7 @@
 
 #include "libnetdata/libnetdata.h"
 
-#define RRD_STORAGE_TIERS 5
+#define STORAGE_ENGINE_TIERS 5
 
 typedef enum __attribute__ ((__packed__)) {
     STORAGE_TIER_BACKFILL_NONE = 0,

--- a/database/storage_engine_types.h
+++ b/database/storage_engine_types.h
@@ -5,6 +5,14 @@
 
 #include "libnetdata/libnetdata.h"
 
+#define RRD_STORAGE_TIERS 5
+
+typedef enum __attribute__ ((__packed__)) {
+    RRD_BACKFILL_NONE = 0,
+    RRD_BACKFILL_FULL,
+    RRD_BACKFILL_NEW
+} RRD_BACKFILL;
+
 typedef struct rrddim RRDDIM;
 typedef struct storage_instance STORAGE_INSTANCE;
 typedef struct storage_metric_handle STORAGE_METRIC_HANDLE;

--- a/libnetdata/libnetdata.c
+++ b/libnetdata/libnetdata.c
@@ -1628,7 +1628,7 @@ void recursive_config_double_dir_load(const char *user_path, const char *stock_p
 
 // Returns the number of bytes read from the file if file_size is not NULL.
 // The actual buffer has an extra byte set to zero (not included in the count).
-char *read_by_filename(const char *filename, long *file_size)
+char *read_by_filename(char *filename, long *file_size)
 {
     FILE *f = fopen(filename, "r");
     if (!f)

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -579,7 +579,7 @@ void recursive_config_double_dir_load(
         , void *data
         , size_t depth
 );
-char *read_by_filename(const char *filename, long *file_size);
+char *read_by_filename(char *filename, long *file_size);
 char *find_and_replace(const char *src, const char *find, const char *replace, const char *where);
 
 /* fix for alpine linux */

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -626,14 +626,8 @@ void open_all_log_files() {
 // ----------------------------------------------------------------------------
 // error log throttling
 
-#ifdef NETDATA_DEV_MODE
-time_t error_log_throttle_period = 60;
-unsigned long error_log_errors_per_period = 10000;
-#else
 time_t error_log_throttle_period = 1200;
 unsigned long error_log_errors_per_period = 200;
-#endif
-
 unsigned long error_log_errors_per_period_backup = 0;
 
 int error_log_limit(int reset) {

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -626,8 +626,14 @@ void open_all_log_files() {
 // ----------------------------------------------------------------------------
 // error log throttling
 
+#ifdef NETDATA_DEV_MODE
+time_t error_log_throttle_period = 60;
+unsigned long error_log_errors_per_period = 10000;
+#else
 time_t error_log_throttle_period = 1200;
 unsigned long error_log_errors_per_period = 200;
+#endif
+
 unsigned long error_log_errors_per_period_backup = 0;
 
 int error_log_limit(int reset) {

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -594,7 +594,7 @@ static void rrdpush_receive(struct receiver_state *rpt)
         }
     }
 
-    if (unlikely(rpt->config.storage_engine_id == STORAGE_ENGINE_DBENGINE && !rrdb.dbengine_cfg.enabled))
+    if (unlikely(rpt->config.storage_engine_id == STORAGE_ENGINE_DBENGINE && !rrdb.dbengine_enabled))
     {
         netdata_log_error("STREAM '%s' [receive from %s:%s]: dbengine is not enabled, falling back to default.",
                           rpt->hostname, rpt->client_ip, rpt->client_port);

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -594,7 +594,7 @@ static void rrdpush_receive(struct receiver_state *rpt)
         }
     }
 
-    if (unlikely(rpt->config.storage_engine_id == STORAGE_ENGINE_DBENGINE && !rrdb.dbengine_enabled))
+    if (unlikely(rpt->config.storage_engine_id == STORAGE_ENGINE_DBENGINE && !rrdb.dbengine_cfg.enabled))
     {
         netdata_log_error("STREAM '%s' [receive from %s:%s]: dbengine is not enabled, falling back to default.",
                           rpt->hostname, rpt->client_ip, rpt->client_port);

--- a/web/api/formatters/json_wrapper.c
+++ b/web/api/formatters/json_wrapper.c
@@ -16,7 +16,7 @@ static void jsonwrap_query_metric_plan(BUFFER *wb, QUERY_METRIC *qm) {
     buffer_json_array_close(wb);
 
     buffer_json_member_add_array(wb, "tiers");
-    for (size_t tier = 0; tier < rrdb.storage_tiers; tier++) {
+    for (size_t tier = 0; tier < rrd_storage_tiers(); tier++) {
         buffer_json_add_array_item_object(wb);
         buffer_json_member_add_uint64(wb, "tr", tier);
         buffer_json_member_add_time_t(wb, "fe", qm->tiers[tier].db_first_time_s);
@@ -920,7 +920,7 @@ void rrdr_json_wrapper_begin(RRDR *r, BUFFER *wb) {
     buffer_json_member_add_string(wb, "format", rrdr_format_to_string(format));
 
     buffer_json_member_add_array(wb, "db_points_per_tier");
-    for(size_t tier = 0; tier < rrdb.storage_tiers ; tier++)
+    for(size_t tier = 0; tier < rrd_storage_tiers(); tier++)
         buffer_json_add_array_item_uint64(wb, qt->db.tiers[tier].points);
     buffer_json_array_close(wb);
 
@@ -1498,7 +1498,7 @@ void rrdr_json_wrapper_end2(RRDR *r, BUFFER *wb) {
 
     buffer_json_member_add_object(wb, "db");
     {
-        buffer_json_member_add_uint64(wb, "tiers", rrdb.storage_tiers);
+        buffer_json_member_add_uint64(wb, "tiers", rrd_storage_tiers());
         buffer_json_member_add_time_t(wb, "update_every", qt->db.minimum_latest_update_every_s);
         buffer_json_member_add_time_t(wb, "first_entry", qt->db.first_time_s);
         buffer_json_member_add_time_t(wb, "last_entry", qt->db.last_time_s);
@@ -1513,7 +1513,7 @@ void rrdr_json_wrapper_end2(RRDR *r, BUFFER *wb) {
         buffer_json_object_close(wb); // dimensions
 
         buffer_json_member_add_array(wb, "per_tier");
-        for(size_t tier = 0; tier < rrdb.storage_tiers ; tier++) {
+        for(size_t tier = 0; tier < rrd_storage_tiers() ; tier++) {
             buffer_json_add_array_item_object(wb);
             buffer_json_member_add_uint64(wb, "tier", tier);
             buffer_json_member_add_uint64(wb, "queries", qt->db.tiers[tier].queries);

--- a/web/api/formatters/rrd2json.c
+++ b/web/api/formatters/rrd2json.c
@@ -99,7 +99,7 @@ int rrdset2value_api_v1(
         *db_points_read += r->stats.db_points_read;
 
     if(db_points_per_tier) {
-        for(size_t t = 0; t < rrdb.storage_tiers ;t++)
+        for (size_t t = 0; t < rrd_storage_tiers(); t++)
             db_points_per_tier[t] += r->internal.qt->db.tiers[t].points;
     }
 

--- a/web/api/formatters/value/value.c
+++ b/web/api/formatters/value/value.c
@@ -131,7 +131,7 @@ QUERY_VALUE rrdmetric2value(RRDHOST *host,
             storage_point_merge_to(qv.sp, r->internal.qt->query.array[d].query_points);
         }
 
-        for(size_t t = 0; t < rrdb.storage_tiers ;t++)
+        for (size_t t = 0; t < rrd_storage_tiers(); t++)
             qv.storage_points_per_tier[t] = r->internal.qt->db.tiers[t].points;
 
         long i = (!(options & RRDR_OPTION_REVERSED))?(long)rrdr_rows(r) - 1:0;

--- a/web/api/formatters/value/value.h
+++ b/web/api/formatters/value/value.h
@@ -11,7 +11,7 @@ typedef struct storage_value {
     time_t after;
     time_t before;
     size_t points_read;
-    size_t storage_points_per_tier[RRD_STORAGE_TIERS];
+    size_t storage_points_per_tier[STORAGE_ENGINE_TIERS];
     size_t result_points;
     STORAGE_POINT sp;
     usec_t duration_ut;

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -1187,7 +1187,7 @@ typedef struct query_engine_ops {
 
     // statistics
     size_t db_total_points_read;
-    size_t db_points_read_per_tier[RRD_STORAGE_TIERS];
+    size_t db_points_read_per_tier[STORAGE_ENGINE_TIERS];
 
     struct {
         time_t expanded_after;

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -1954,7 +1954,7 @@ void rrdr_fill_tier_gap_from_smaller_tiers(RRDDIM *rd, size_t tier, time_t now_s
     if (unlikely(tier >= rrd_storage_tiers()))
         return;
 
-    if (rrd_storage_tier_backfill(tier) == RRD_BACKFILL_NONE)
+    if (rrd_storage_tier_backfill(tier) == STORAGE_TIER_BACKFILL_NONE)
         return;
 
     struct rrddim_tier *t = &rd->tiers[tier];
@@ -1967,7 +1967,7 @@ void rrdr_fill_tier_gap_from_smaller_tiers(RRDDIM *rd, size_t tier, time_t now_s
     time_t time_diff   = now_s - latest_time_s;
 
     // if the user wants only NEW backfilling, and we don't have any data
-    if (rrd_storage_tier_backfill(tier) == RRD_BACKFILL_NEW && latest_time_s <= 0)
+    if (rrd_storage_tier_backfill(tier) == STORAGE_TIER_BACKFILL_NEW && latest_time_s <= 0)
         return;
 
     // there is really nothing we can do

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -1953,7 +1953,8 @@ void store_metric_at_tier(RRDDIM *rd, size_t tier, struct rrddim_tier *t, STORAG
 void rrdr_fill_tier_gap_from_smaller_tiers(RRDDIM *rd, size_t tier, time_t now_s) {
     if (unlikely(tier >= rrd_storage_tiers()))
         return;
-    if (rrdb.dbengine_cfg.storage_tiers_backfill[tier] == RRD_BACKFILL_NONE)
+
+    if (rrd_storage_tier_backfill(tier) == RRD_BACKFILL_NONE)
         return;
 
     struct rrddim_tier *t = &rd->tiers[tier];
@@ -1966,7 +1967,7 @@ void rrdr_fill_tier_gap_from_smaller_tiers(RRDDIM *rd, size_t tier, time_t now_s
     time_t time_diff   = now_s - latest_time_s;
 
     // if the user wants only NEW backfilling, and we don't have any data
-    if (rrdb.dbengine_cfg.storage_tiers_backfill[tier] == RRD_BACKFILL_NEW && latest_time_s <= 0)
+    if (rrd_storage_tier_backfill(tier) == RRD_BACKFILL_NEW && latest_time_s <= 0)
         return;
 
     // there is really nothing we can do

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -1042,7 +1042,7 @@ static size_t query_metric_best_tier_for_timeframe(QUERY_METRIC *qm, time_t afte
     }
 
     size_t best_tier = 0;
-    for(size_t tier = 1; tier < rrdb.dbengine_cfg.storage_tiers ; tier++) {
+    for (size_t tier = 1; tier < rrd_storage_tiers(); tier++) {
         if(qm->tiers[tier].weight >= qm->tiers[best_tier].weight)
             best_tier = tier;
     }
@@ -1051,7 +1051,7 @@ static size_t query_metric_best_tier_for_timeframe(QUERY_METRIC *qm, time_t afte
 }
 
 static size_t rrddim_find_best_tier_for_timeframe(QUERY_TARGET *qt, time_t after_wanted, time_t before_wanted, size_t points_wanted) {
-    if(unlikely(rrdb.dbengine_cfg.storage_tiers < 2))
+    if(unlikely(rrd_storage_tiers() < 2))
         return 0;
 
     if(unlikely(after_wanted == before_wanted || points_wanted <= 0)) {
@@ -1059,10 +1059,10 @@ static size_t rrddim_find_best_tier_for_timeframe(QUERY_TARGET *qt, time_t after
         return 0;
     }
 
-    long weight[rrdb.dbengine_cfg.storage_tiers];
+    long weight[rrd_storage_tiers()];
 
-    for(size_t tier = 0; tier < rrdb.dbengine_cfg.storage_tiers ; tier++) {
-
+    for (size_t tier = 0; tier < rrd_storage_tiers(); tier++)
+    {
         time_t common_first_time_s = 0;
         time_t common_last_time_s = 0;
         time_t common_update_every_s = 0;
@@ -1098,7 +1098,7 @@ static size_t rrddim_find_best_tier_for_timeframe(QUERY_TARGET *qt, time_t after
     }
 
     size_t best_tier = 0;
-    for(size_t tier = 1; tier < rrdb.dbengine_cfg.storage_tiers ; tier++) {
+    for (size_t tier = 1; tier < rrd_storage_tiers(); tier++) {
         if(weight[tier] >= weight[best_tier])
             best_tier = tier;
     }
@@ -1111,7 +1111,7 @@ static size_t rrddim_find_best_tier_for_timeframe(QUERY_TARGET *qt, time_t after
 
 static time_t rrdset_find_natural_update_every_for_timeframe(QUERY_TARGET *qt, time_t after_wanted, time_t before_wanted, size_t points_wanted, RRDR_OPTIONS options, size_t tier) {
     size_t best_tier;
-    if((options & RRDR_OPTION_SELECTED_TIER) && tier < rrdb.dbengine_cfg.storage_tiers)
+    if ((options & RRDR_OPTION_SELECTED_TIER) && tier < rrd_storage_tiers())
         best_tier = tier;
     else
         best_tier = rrddim_find_best_tier_for_timeframe(qt, after_wanted, before_wanted, points_wanted);

--- a/web/api/queries/weights.c
+++ b/web/api/queries/weights.c
@@ -149,7 +149,7 @@ static void results_header_to_json(DICTIONARY *results __maybe_unused, BUFFER *w
 
         buffer_json_member_add_array(wb, "db_points_per_tier");
         {
-            for (size_t tier = 0; tier < rrdb.storage_tiers; tier++)
+            for (size_t tier = 0; tier < rrd_storage_tiers(); tier++)
                 buffer_json_add_array_item_uint64(wb, stats->db_points_per_tier[tier]);
         }
         buffer_json_array_close(wb);
@@ -461,7 +461,7 @@ static void results_header_to_json_v2(DICTIONARY *results __maybe_unused, BUFFER
 
         buffer_json_member_add_array(wb, "db_points_per_tier");
         {
-            for (size_t tier = 0; tier < rrdb.storage_tiers; tier++)
+            for (size_t tier = 0; tier < rrd_storage_tiers(); tier++)
                 buffer_json_add_array_item_uint64(wb, stats->db_points_per_tier[tier]);
         }
         buffer_json_array_close(wb);
@@ -1288,7 +1288,7 @@ NETDATA_DOUBLE *rrd2rrdr_ks2(
     stats->db_queries++;
     stats->result_points += r->stats.result_points_generated;
     stats->db_points += r->stats.db_points_read;
-    for(size_t tr = 0; tr < rrdb.storage_tiers ; tr++)
+    for (size_t tr = 0; tr < rrd_storage_tiers(); tr++)
         stats->db_points_per_tier[tr] += r->internal.qt->db.tiers[tr].points;
 
     if(r->d != 1 || r->internal.qt->query.used != 1) {
@@ -1395,7 +1395,7 @@ static void merge_query_value_to_stats(QUERY_VALUE *qv, WEIGHTS_STATS *stats, si
     stats->db_queries += queries;
     stats->result_points += qv->result_points;
     stats->db_points += qv->points_read;
-    for(size_t tier = 0; tier < rrdb.storage_tiers ; tier++)
+    for (size_t tier = 0; tier < rrd_storage_tiers(); tier++)
         stats->db_points_per_tier[tier] += qv->storage_points_per_tier[tier];
 }
 

--- a/web/api/queries/weights.c
+++ b/web/api/queries/weights.c
@@ -13,7 +13,7 @@ typedef struct weights_stats {
     size_t db_points;
     size_t result_points;
     size_t db_queries;
-    size_t db_points_per_tier[RRD_STORAGE_TIERS];
+    size_t db_points_per_tier[STORAGE_ENGINE_TIERS];
     size_t binary_searches;
 } WEIGHTS_STATS;
 

--- a/web/api/web_api.c
+++ b/web/api/web_api.c
@@ -196,7 +196,7 @@ int web_client_api_request_weights(RRDHOST *host, struct web_client *w, char *ur
 
         else if(!strcmp(name, "tier")) {
             tier = str2ul(value);
-            if(tier < rrdb.storage_tiers)
+            if (tier < rrd_storage_tiers())
                 options |= RRDR_OPTION_SELECTED_TIER;
             else
                 tier = 0;

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1264,7 +1264,7 @@ inline int web_client_api_request_v1_info_fill_buffer(RRDHOST *host, BUFFER *wb)
 
     buffer_json_member_add_string(wb, "memory-mode", storage_engine_name(host->storage_engine_id));
 #ifdef ENABLE_DBENGINE
-    buffer_json_member_add_uint64(wb, "multidb-disk-quota", rrdb.default_multidb_disk_quota_mb);
+    buffer_json_member_add_uint64(wb, "multidb-disk-quota", rrdb.multidb_disk_quota_mb[0]);
     buffer_json_member_add_uint64(wb, "page-cache-size", rrdb.default_rrdeng_page_cache_mb);
 #endif // ENABLE_DBENGINE
     buffer_json_member_add_boolean(wb, "web-enabled", web_server_mode != WEB_SERVER_MODE_NONE);

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1462,64 +1462,6 @@ int web_client_api_request_v1_dbengine_stats(RRDHOST *host __maybe_unused, struc
 }
 #endif
 
-#ifdef NETDATA_DEV_MODE
-int web_client_api_request_v1_logs(RRDHOST *host __maybe_unused, struct web_client *w, char *url __maybe_unused) {
-    if (!netdata_ready)
-        return HTTP_RESP_BACKEND_FETCH_FAILED;
-
-    const char *kind = NULL;
-
-    while (url) {
-        char *value = strsep_skip_consecutive_separators(&url, "&");
-        if (!value || !*value)
-            continue;
-
-        char *name = strsep_skip_consecutive_separators(&value, "=");
-        if(!name || !*name)
-            continue;
-
-        if (!name || !*name || !value || !*value)
-            return HTTP_RESP_NOT_FOUND;
-
-
-        if (!strncmp(name, "kind", strlen("kind"))) {
-            kind = value;
-        }
-    }
-
-    if (!kind)
-        return HTTP_RESP_NOT_FOUND;
-
-    const char *filename = NULL;
-
-    if (!strcmp(kind, "error"))
-        filename = stderr_filename;
-    else if (!strcmp(kind, "access"))
-        filename = stdaccess_filename;
-    else if (!strcmp(kind, "collector"))
-        filename = stdcollector_filename;
-    else if (!strcmp(kind, "health"))
-        filename = stdhealth_filename;
-    else {
-        return HTTP_RESP_NOT_FOUND;
-    }
-
-    BUFFER *wb = w->response.data;
-    buffer_flush(wb);
-
-    long file_size = 0;
-    char *contents = read_by_filename(filename, &file_size);
-    if (!contents)
-        return HTTP_RESP_BACKEND_FETCH_FAILED;
-
-    buffer_fast_strcat(wb, contents, file_size);
-    freez(contents);
-
-    buffer_no_cacheable(wb);
-    return HTTP_RESP_OK;
-}
-#endif
-
 static struct web_api_command api_commands_v1[] = {
         { "info",            0, WEB_CLIENT_ACL_DASHBOARD_ACLK_WEBRTC, web_client_api_request_v1_info,     0                     },
         { "data",            0, WEB_CLIENT_ACL_DASHBOARD_ACLK_WEBRTC, web_client_api_request_v1_data,     0                     },
@@ -1555,10 +1497,6 @@ static struct web_api_command api_commands_v1[] = {
         {"functions",            0, WEB_CLIENT_ACL_ACLK_WEBRTC_DASHBOARD_WITH_BEARER | ACL_DEV_OPEN_ACCESS, web_client_api_request_v1_functions, 0 },
 
         { "dbengine_stats",      0, WEB_CLIENT_ACL_DASHBOARD_ACLK_WEBRTC, web_client_api_request_v1_dbengine_stats, 0 },
-
-#ifdef NETDATA_DEV_MODE
-        { "logs",                0, WEB_CLIENT_ACL_DASHBOARD_ACLK_WEBRTC, web_client_api_request_v1_logs },
-#endif
 
         // terminator
         { NULL,                  0, WEB_CLIENT_ACL_NONE,      NULL, 0 },

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1462,6 +1462,64 @@ int web_client_api_request_v1_dbengine_stats(RRDHOST *host __maybe_unused, struc
 }
 #endif
 
+#ifdef NETDATA_DEV_MODE
+int web_client_api_request_v1_logs(RRDHOST *host __maybe_unused, struct web_client *w, char *url __maybe_unused) {
+    if (!netdata_ready)
+        return HTTP_RESP_BACKEND_FETCH_FAILED;
+
+    const char *kind = NULL;
+
+    while (url) {
+        char *value = strsep_skip_consecutive_separators(&url, "&");
+        if (!value || !*value)
+            continue;
+
+        char *name = strsep_skip_consecutive_separators(&value, "=");
+        if(!name || !*name)
+            continue;
+
+        if (!name || !*name || !value || !*value)
+            return HTTP_RESP_NOT_FOUND;
+
+
+        if (!strncmp(name, "kind", strlen("kind"))) {
+            kind = value;
+        }
+    }
+
+    if (!kind)
+        return HTTP_RESP_NOT_FOUND;
+
+    const char *filename = NULL;
+
+    if (!strcmp(kind, "error"))
+        filename = stderr_filename;
+    else if (!strcmp(kind, "access"))
+        filename = stdaccess_filename;
+    else if (!strcmp(kind, "collector"))
+        filename = stdcollector_filename;
+    else if (!strcmp(kind, "health"))
+        filename = stdhealth_filename;
+    else {
+        return HTTP_RESP_NOT_FOUND;
+    }
+
+    BUFFER *wb = w->response.data;
+    buffer_flush(wb);
+
+    long file_size = 0;
+    char *contents = read_by_filename(filename, &file_size);
+    if (!contents)
+        return HTTP_RESP_BACKEND_FETCH_FAILED;
+
+    buffer_fast_strcat(wb, contents, file_size);
+    freez(contents);
+
+    buffer_no_cacheable(wb);
+    return HTTP_RESP_OK;
+}
+#endif
+
 static struct web_api_command api_commands_v1[] = {
         { "info",            0, WEB_CLIENT_ACL_DASHBOARD_ACLK_WEBRTC, web_client_api_request_v1_info,     0                     },
         { "data",            0, WEB_CLIENT_ACL_DASHBOARD_ACLK_WEBRTC, web_client_api_request_v1_data,     0                     },
@@ -1497,6 +1555,10 @@ static struct web_api_command api_commands_v1[] = {
         {"functions",            0, WEB_CLIENT_ACL_ACLK_WEBRTC_DASHBOARD_WITH_BEARER | ACL_DEV_OPEN_ACCESS, web_client_api_request_v1_functions, 0 },
 
         { "dbengine_stats",      0, WEB_CLIENT_ACL_DASHBOARD_ACLK_WEBRTC, web_client_api_request_v1_dbengine_stats, 0 },
+
+#ifdef NETDATA_DEV_MODE
+        { "logs",                0, WEB_CLIENT_ACL_DASHBOARD_ACLK_WEBRTC, web_client_api_request_v1_logs },
+#endif
 
         // terminator
         { NULL,                  0, WEB_CLIENT_ACL_NONE,      NULL, 0 },

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1443,7 +1443,7 @@ int web_client_api_request_v1_dbengine_stats(RRDHOST *host __maybe_unused, struc
     BUFFER *wb = w->response.data;
     buffer_flush(wb);
 
-    if(!rrdb.dbengine_cfg.enabled) {
+    if(!rrdb.dbengine_enabled) {
         buffer_strcat(wb, "dbengine is not enabled");
         return HTTP_RESP_NOT_FOUND;
     }

--- a/web/api/web_api_v2.c
+++ b/web/api/web_api_v2.c
@@ -521,7 +521,7 @@ static int web_client_api_request_v2_data(RRDHOST *host __maybe_unused, struct w
 
     if(tier_str && *tier_str) {
         tier = str2ul(tier_str);
-        if(tier < rrdb.storage_tiers)
+        if (tier < rrd_storage_tiers())
             options |= RRDR_OPTION_SELECTED_TIER;
         else
             tier = 0;


### PR DESCRIPTION
##### Summary

Use a global `dbengine_config_t` value with sane defaults for dbengine. `RRD` overrides these defaults based on the configuration options provided by the user's `netdata.conf` and maintains the modified copy in `rrdb`.

`RRD_STORAGE_TIERS` and `RRD_BACKFILL` have been renamed to `STORAGE_ENGINE_TIERS` and `STORAGE_TIER_BACKFILL`, and moved to `storage_engine_types.h`, in order to better reflect that this is functionality provided by each storage engine.

The configuration logic vs the business logic of instantiating a `dbengine` instance have been split, which will take us another step towards making `dbengine` behave like a true library.

##### Test Plan

- CI jobs
- Build and test with various configuration options, ie. storage_tiers, page/extent cache size, etc.
