### PR TITLE
remove " Metrics" from linux categories

### DIFF
--- a/integrations/categories.yaml
+++ b/integrations/categories.yaml
@@ -138,61 +138,61 @@
       priority: 5
       children:
         - id: data-collection.linux-systems.system-metrics
-          name: System Metrics
+          name: System
           description: ""
           most_popular: true
           priority: 1
           children: []
         - id: data-collection.linux-systems.memory-metrics
-          name: Memory Metrics
+          name: Memory
           description: ""
           most_popular: true
           priority: 3
           children: []
         - id: data-collection.linux-systems.cpu-metrics
-          name: CPU Metrics
+          name: CPU
           description: ""
           most_popular: true
           priority: 2
           children: []
         - id: data-collection.linux-systems.pressure-metrics
-          name: Pressure Metrics
+          name: Pressure
           description: ""
           most_popular: false
           priority: -1
           children: []
         - id: data-collection.linux-systems.network-metrics
-          name: Network Metrics
+          name: Network
           description: ""
           most_popular: true
           priority: 5
           children: []
         - id: data-collection.linux-systems.ipc-metrics
-          name: IPC Metrics
+          name: IPC
           description: ""
           most_popular: false
           priority: -1
           children: []
         - id: data-collection.linux-systems.disk-metrics
-          name: Disk Metrics
+          name: Disk
           description: ""
           most_popular: true
           priority: 4
           children: []
         - id: data-collection.linux-systems.firewall-metrics
-          name: Firewall Metrics
+          name: Firewall
           description: ""
           most_popular: false
           priority: -1
           children: []
         - id: data-collection.linux-systems.power-supply-metrics
-          name: Power Supply Metrics
+          name: Power Supply
           description: ""
           most_popular: false
           priority: -1
           children: []
         - id: data-collection.linux-systems.filesystem-metrics
-          name: Filesystem Metrics
+          name: Filesystem
           description: ""
           most_popular: false
           priority: -1
@@ -216,7 +216,7 @@
               priority: -1
               children: []
         - id: data-collection.linux-systems.kernel-metrics
-          name: Kernel Metrics
+          name: Kernel
           description: ""
           most_popular: false
           priority: -1


### PR DESCRIPTION
##### Summary

I think it's redundant to have "Metric", it looks better without it.

<img width="310" alt="Screenshot 2023-08-01 at 14 36 35" src="https://github.com/netdata/netdata/assets/22274335/93493beb-1ee4-4d33-b59e-87aa08c17dfe">

##### Test Plan



<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
