### PR TITLE
Fix integrations regen workflow

### DIFF
--- a/.github/workflows/generate-integrations.yml
+++ b/.github/workflows/generate-integrations.yml
@@ -8,9 +8,12 @@ on:
       - master
     paths: # If any of these files change, we need to regenerate integrations.js.
       - 'collectors/**/metadata.yaml'
-      - 'collectors/**/multi_metadata.yaml'
+      - 'exporting/**/metadata.yaml'
+      - 'health/notifications/**/metadata.yaml'
       - 'integrations/templates/**'
       - 'integrations/categories.yaml'
+      - 'integrations/deploy.yaml'
+      - 'integrations/cloud-notifications/metadata.yaml'
       - 'integrations/gen_integrations.py'
       - 'packaging/go.d.version'
   workflow_dispatch: null

--- a/.github/workflows/generate-integrations.yml
+++ b/.github/workflows/generate-integrations.yml
@@ -44,7 +44,9 @@ jobs:
           ref: ${{ env.go_ref }}
       - name: Prepare Dependencies
         id: prep-deps
-        run: sudo apt-get install python3-jsonschema python3-referencing python3-jinja2 python3-ruamel.yaml
+        run: |
+          sudo apt-get install python3-jsonschema python3-pip python3-jinja2 python3-ruamel.yaml
+          sudo pip install referencing
       - name: Generate Integrations
         id: generate
         run: integrations/gen_integrations.py


### PR DESCRIPTION
##### Summary

- Use correct list of trigger files.
- Properly handle the fact that Ubuntu for some reason completely lacks an extremely popular Python module that’s essentially mandatory to use the jsonschema module.

##### Test Plan

n/a