### PR TITLE
Fix troubleshooting section in data-collection integrations

### DIFF
--- a/integrations/templates/troubleshooting.md
+++ b/integrations/templates/troubleshooting.md
@@ -1,11 +1,9 @@
 [% if entry.troubleshooting.list or entry.integration_type == 'collector' or entry.integration_type == 'notification' %]
-## Troubleshooting
-
 [% if entry.integration_type == 'collector' %]
-[% if entry.plugin_name == 'go.d.plugin' %]
+[% if entry.meta.plugin_name == 'go.d.plugin' %]
 ### Debug Mode
 
-To troubleshoot issues with the `[[ entry.module_name ]]` collector, run the `go.d.plugin` with the debug option enabled. The output
+To troubleshoot issues with the `[[ entry.meta.module_name ]]` collector, run the `go.d.plugin` with the debug option enabled. The output
 should give you clues as to why the collector isn't working.
 
 - Navigate to the `plugins.d` directory, usually at `/usr/libexec/netdata/plugins.d/`. If that's not the case on
@@ -24,12 +22,12 @@ should give you clues as to why the collector isn't working.
 - Run the `go.d.plugin` to debug the collector:
 
   ```bash
-  ./go.d.plugin -d -m [[ entry.module_name ]]
+  ./go.d.plugin -d -m [[ entry.meta.module_name ]]
   ```
-[% elif entry.plugin_name == 'python.d.plugin' %]
+[% elif entry.meta.plugin_name == 'python.d.plugin' %]
 ### Debug Mode
 
-To troubleshoot issues with the `[[ entry.module_name ]]` collector, run the `python.d.plugin` with the debug option enabled. The output
+To troubleshoot issues with the `[[ entry.meta.module_name ]]` collector, run the `python.d.plugin` with the debug option enabled. The output
 should give you clues as to why the collector isn't working.
 
 - Navigate to the `plugins.d` directory, usually at `/usr/libexec/netdata/plugins.d/`. If that's not the case on
@@ -48,12 +46,12 @@ should give you clues as to why the collector isn't working.
 - Run the `python.d.plugin` to debug the collector:
 
   ```bash
-  ./python.d.plugin [[ entry.module_name ]] debug trace
+  ./python.d.plugin [[ entry.meta.module_name ]] debug trace
   ```
-[% elif entry.plugin_name == 'charts.d.plugin' %]
+[% elif entry.meta.plugin_name == 'charts.d.plugin' %]
 ### Debug Mode
 
-To troubleshoot issues with the `[[ entry.module_name ]]` collector, run the `charts.d.plugin` with the debug option enabled. The output
+To troubleshoot issues with the `[[ entry.meta.module_name ]]` collector, run the `charts.d.plugin` with the debug option enabled. The output
 should give you clues as to why the collector isn't working.
 
 - Navigate to the `plugins.d` directory, usually at `/usr/libexec/netdata/plugins.d/`. If that's not the case on
@@ -72,7 +70,7 @@ should give you clues as to why the collector isn't working.
 - Run the `charts.d.plugin` to debug the collector:
 
   ```bash
-  ./charts.d.plugin debug 1 [[ entry.module_name ]]
+  ./charts.d.plugin debug 1 [[ entry.meta.module_name ]]
   ```
 [% endif %]
 [% elif entry.integration_type == 'notification' %]


### PR DESCRIPTION
##### Summary

This was simple, we needed to take a look inside `meta` for plugin and module name.

This fixes data collection integrations (has been tested locally) but not the agent alert notifications. Those don't seem to have a key for troubleshooting in the output, so I think the script doesn't support it. Most sane way would be for @Ferroin to take a look at the script instead of me trying to identify the issue if any.

I also removed the `## Troubleshooting` as it seems we don't do this for other categories, we don't need to state the top heading.