### PR TITLE
Fix handling of troubleshooting section in integrations.

### DIFF
--- a/integrations/gen_integrations.py
+++ b/integrations/gen_integrations.py
@@ -56,11 +56,13 @@ COLLECTOR_RENDER_KEYS = [
 EXPORTER_RENDER_KEYS = [
     'overview',
     'setup',
+    'troubleshooting',
 ]
 
 NOTIFICATION_RENDER_KEYS = [
     'overview',
     'setup',
+    'troubleshooting',
 ]
 
 GITHUB_ACTIONS = os.environ.get('GITHUB_ACTIONS', False)
@@ -473,12 +475,15 @@ def render_collectors(categories, collectors, ids):
                 }
 
         for key in COLLECTOR_RENDER_KEYS:
-            template = get_jinja_env().get_template(f'{ key }.md')
-            data = template.render(entry=item, related=related)
+            if key in item.keys():
+                template = get_jinja_env().get_template(f'{ key }.md')
+                data = template.render(entry=item, related=related)
 
-            if 'variables' in item['meta']['monitored_instance']:
-                template = get_jinja_env().from_string(data)
-                data = template.render(variables=item['meta']['monitored_instance']['variables'])
+                if 'variables' in item['meta']['monitored_instance']:
+                    template = get_jinja_env().from_string(data)
+                    data = template.render(variables=item['meta']['monitored_instance']['variables'])
+            else:
+                data = ''
 
             item[key] = data
 
@@ -540,12 +545,15 @@ def render_exporters(categories, exporters, ids):
 
     for item in exporters:
         for key in EXPORTER_RENDER_KEYS:
-            template = get_jinja_env().get_template(f'{ key }.md')
-            data = template.render(entry=item)
+            if key in item.keys():
+                template = get_jinja_env().get_template(f'{ key }.md')
+                data = template.render(entry=item)
 
-            if 'variables' in item['meta']:
-                template = get_jinja_env().from_string(data)
-                data = template.render(variables=item['meta']['variables'])
+                if 'variables' in item['meta']:
+                    template = get_jinja_env().from_string(data)
+                    data = template.render(variables=item['meta']['variables'])
+            else:
+                data = ''
 
             item[key] = data
 
@@ -569,12 +577,15 @@ def render_notifications(categories, notifications, ids):
 
     for item in notifications:
         for key in NOTIFICATION_RENDER_KEYS:
-            template = get_jinja_env().get_template(f'{ key }.md')
-            data = template.render(entry=item)
+            if key in item.keys():
+                template = get_jinja_env().get_template(f'{ key }.md')
+                data = template.render(entry=item)
 
-            if 'variables' in item['meta']:
-                template = get_jinja_env().from_string(data)
-                data = template.render(variables=item['meta']['variables'])
+                if 'variables' in item['meta']:
+                    template = get_jinja_env().from_string(data)
+                    data = template.render(variables=item['meta']['variables'])
+            else:
+                data = ''
 
             item[key] = data
 

--- a/integrations/schemas/collector.json
+++ b/integrations/schemas/collector.json
@@ -222,43 +222,7 @@
             "$ref": "./shared.json#/$defs/full_setup"
           },
           "troubleshooting": {
-            "type": "object",
-            "description": "Information needed to troubleshoot issues with this collector.",
-            "properties": {
-              "problems": {
-                "type": "object",
-                "description": "Common problems that users face again and again... and their solutions.",
-                "properties": {
-                  "list": {
-                    "type": "array",
-                    "description": "List of common problems.",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "description": "Problem name."
-                        },
-                        "description": {
-                          "type": "string",
-                          "description": "Explanation of the problem and its solution."
-                        }
-                      }
-                    },
-                    "required": [
-                      "name",
-                      "description"
-                    ]
-                  }
-                },
-                "required": [
-                  "list"
-                ]
-              }
-            },
-            "required": [
-              "problems"
-            ]
+            "$ref": "./shared.json#/$defs/troubleshooting"
           },
           "alerts": {
             "type": "array",

--- a/integrations/schemas/exporter.json
+++ b/integrations/schemas/exporter.json
@@ -46,6 +46,9 @@
         },
         "setup": {
           "$ref": "./shared.json#/$defs/full_setup"
+        },
+        "troubleshooting": {
+          "$ref": "./shared.json#/$defs/troubleshooting"
         }
       },
       "required": [

--- a/integrations/schemas/notification.json
+++ b/integrations/schemas/notification.json
@@ -70,6 +70,9 @@
               "$ref": "./shared.json#/$defs/full_setup"
             }
           ]
+        },
+        "troubleshooting": {
+          "$ref": "./shared.json#/$defs/troubleshooting"
         }
       },
       "required": [

--- a/integrations/schemas/shared.json
+++ b/integrations/schemas/shared.json
@@ -249,6 +249,45 @@
         "configuration"
       ]
     },
+    "troubleshooting": {
+      "type": "object",
+      "description": "Information needed to troubleshoot issues with this collector.",
+      "properties": {
+        "problems": {
+          "type": "object",
+          "description": "Common problems that users face again and again... and their solutions.",
+          "properties": {
+            "list": {
+              "type": "array",
+              "description": "List of common problems.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Problem name."
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "Explanation of the problem and its solution."
+                  }
+                }
+              },
+              "required": [
+                "name",
+                "description"
+              ]
+            }
+          },
+          "required": [
+            "list"
+          ]
+        }
+      },
+      "required": [
+        "problems"
+      ]
+    },
     "_folding": {
       "type": "object",
       "description": "Content folding settings.",

--- a/integrations/templates/troubleshooting.md
+++ b/integrations/templates/troubleshooting.md
@@ -1,5 +1,5 @@
 [% if entry.integration_type == 'collector' %]
-[% if entry.plugin_name == 'go.d.plugin' %]
+[% if entry.meta.plugin_name == 'go.d.plugin' %]
 ## Troubleshooting
 
 ### Debug Mode
@@ -26,7 +26,7 @@ should give you clues as to why the collector isn't working.
   ./go.d.plugin -d -m [[ entry.module_name ]]
   ```
 
-[% elif entry.plugin_name == 'python.d.plugin' %]
+[% elif entry.meta.plugin_name == 'python.d.plugin' %]
 ## Troubleshooting
 
 ### Debug Mode
@@ -53,7 +53,7 @@ should give you clues as to why the collector isn't working.
   ./python.d.plugin [[ entry.module_name ]] debug trace
   ```
 
-[% elif entry.plugin_name == 'charts.d.plugin' %]
+[% elif entry.meta.plugin_name == 'charts.d.plugin' %]
 ## Troubleshooting
 
 ### Debug Mode

--- a/integrations/templates/troubleshooting.md
+++ b/integrations/templates/troubleshooting.md
@@ -1,8 +1,7 @@
-[% if entry.troubleshooting.list or entry.integration_type == 'collector' or entry.integration_type == 'notification' %]
-## Troubleshooting
-
 [% if entry.integration_type == 'collector' %]
 [% if entry.plugin_name == 'go.d.plugin' %]
+## Troubleshooting
+
 ### Debug Mode
 
 To troubleshoot issues with the `[[ entry.module_name ]]` collector, run the `go.d.plugin` with the debug option enabled. The output
@@ -26,7 +25,10 @@ should give you clues as to why the collector isn't working.
   ```bash
   ./go.d.plugin -d -m [[ entry.module_name ]]
   ```
+
 [% elif entry.plugin_name == 'python.d.plugin' %]
+## Troubleshooting
+
 ### Debug Mode
 
 To troubleshoot issues with the `[[ entry.module_name ]]` collector, run the `python.d.plugin` with the debug option enabled. The output
@@ -50,7 +52,10 @@ should give you clues as to why the collector isn't working.
   ```bash
   ./python.d.plugin [[ entry.module_name ]] debug trace
   ```
+
 [% elif entry.plugin_name == 'charts.d.plugin' %]
+## Troubleshooting
+
 ### Debug Mode
 
 To troubleshoot issues with the `[[ entry.module_name ]]` collector, run the `charts.d.plugin` with the debug option enabled. The output
@@ -74,9 +79,22 @@ should give you clues as to why the collector isn't working.
   ```bash
   ./charts.d.plugin debug 1 [[ entry.module_name ]]
   ```
+
+[% else %]
+[% if entry.troubleshooting.problems.list %]
+## Troubleshooting
+
+[% endif %]
 [% endif %]
 [% elif entry.integration_type == 'notification' %]
-[% if not 'cloud-notifications' in entry._src_path %]
+[% if 'cloud-notifications' in entry._src_path %]
+[% if entry.troubleshooting.problems.list %]
+## Troubleshooting
+
+[% endif %]
+[% else %]
+## Troubleshooting
+
 ### Test Notification
 
 You can run the following command by hand, to test alerts configuration:
@@ -96,9 +114,14 @@ export NETDATA_ALARM_NOTIFY_DEBUG=1
 ```
 
 Note that this will test _all_ alert mechanisms for the selected role.
+
+[% elif entry.integration_type == 'exporter' %]
+[% if entry.troubleshooting.problems.list %]
+## Troubleshooting
+
 [% endif %]
 [% endif %]
-[% for item in entry.troubleshooting.list %]
+[% for item in entry.troubleshooting.problems.list %]
 ### [[ item.name ]]
 
 [[ description ]]


### PR DESCRIPTION
##### Summary

- Add optional `troubleshooting` section to notification and exporter schemas.
- Update script to support rendering of optional keys.
- Update script to render troubleshooting key for notification and exporter schemas.
- Fix the troubleshooting template so that it renders things correctly for all integration types where it is rendered.

##### Test Plan

n/a