### PR TITLE
Fix the current disk space calculation

### DIFF
--- a/database/storage_engine.h
+++ b/database/storage_engine.h
@@ -118,7 +118,7 @@ static inline size_t storage_engine_disk_space_used(STORAGE_ENGINE_ID id, STORAG
             return rrddim_disk_space_used(db_instance);
 #ifdef ENABLE_DBENGINE
         case STORAGE_ENGINE_DBENGINE:
-            return rrdeng_disk_space_max(db_instance);
+            return rrdeng_disk_space_used(db_instance);
 #endif
         default:
             __builtin_unreachable();


### PR DESCRIPTION
##### Summary
This PR will fix the disk_percent calculation. Now is it reported always 100% in /api/v2/node_instances

eg
```
  "disk_used":2147483648,
  "disk_max":2147483648,
  "disk_percent":100,
```
