### PR TITLE
Fix memory corruption

### DIFF
--- a/database/contexts/api_v2.c
+++ b/database/contexts/api_v2.c
@@ -1113,8 +1113,9 @@ static bool contexts_conflict_callback(const DICTIONARY_ITEM *item __maybe_unuse
         }
         else {
             // merge
-            string_freez(o->family);
+            STRING *old_family = o->family;
             o->family = string_2way_merge(o->family, n->family);
+            string_freez(old_family);
         }
     }
 


### PR DESCRIPTION
##### Summary
Fix issue in case there is only one reference and the o->family is then invalid when used

