### PR TITLE
ci: run "Generate Integrations" only in netdata/netdata

### DIFF
--- a/.github/workflows/generate-integrations.yml
+++ b/.github/workflows/generate-integrations.yml
@@ -24,6 +24,7 @@ jobs:
   generate-integrations:
     name: Generate Integrations
     runs-on: ubuntu-latest
+    if: github.repository == 'netdata/netdata'
     steps:
       - name: Checkout Agent
         id: checkout-agent


### PR DESCRIPTION
##### Summary

Found it failing on "Create PR" step in my fork.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
