### PR TITLE
proc.plugin: dont log if pressure/irq does not exist

### DIFF
--- a/collectors/proc.plugin/proc_pressure.c
+++ b/collectors/proc.plugin/proc_pressure.c
@@ -178,6 +178,9 @@ int do_proc_pressure(int update_every, usec_t dt) {
         procfile *ff = resource_info[i].pf;
         int do_some = resources[i].some.enabled, do_full = resources[i].full.enabled;
 
+        if (!resources[i].some.available && !resources[i].full.available)
+            continue;
+
         if (unlikely(!ff)) {
             char filename[FILENAME_MAX + 1];
             char config_key[CONFIG_MAX_NAME + 1];
@@ -200,14 +203,19 @@ int do_proc_pressure(int update_every, usec_t dt) {
             do_full = config_get_boolean(CONFIG_SECTION_PLUGIN_PROC_PRESSURE, config_key, do_full);
             resources[i].full.enabled = do_full;
 
-            if(!do_full && !do_some)
+            if (!do_full && !do_some) {
+                resources[i].some.available = false;
+                resources[i].full.available = false;
                 continue;
+            }
 
             ff = procfile_open(filename, " =", PROCFILE_FLAG_NO_ERROR_ON_FILE_IO);
             if (unlikely(!ff)) {
                 // PSI IRQ was added recently (https://github.com/torvalds/linux/commit/52b1364ba0b105122d6de0e719b36db705011ac1) 
                 if (strcmp(resource_info[i].name, "irq") != 0)
                     collector_error("Cannot read pressure information from %s.", filename);
+                resources[i].some.available = false;
+                resources[i].full.available = false;
                 continue;
             }
         }

--- a/collectors/proc.plugin/proc_pressure.c
+++ b/collectors/proc.plugin/proc_pressure.c
@@ -203,9 +203,11 @@ int do_proc_pressure(int update_every, usec_t dt) {
             if(!do_full && !do_some)
                 continue;
 
-            ff = procfile_open(filename, " =", PROCFILE_FLAG_DEFAULT);
+            ff = procfile_open(filename, " =", PROCFILE_FLAG_NO_ERROR_ON_FILE_IO);
             if (unlikely(!ff)) {
-                collector_error("Cannot read pressure information from %s.", filename);
+                // PSI IRQ was added recently (https://github.com/torvalds/linux/commit/52b1364ba0b105122d6de0e719b36db705011ac1) 
+                if (strcmp(resource_info[i].name, "irq") != 0)
+                    collector_error("Cannot read pressure information from %s.", filename);
                 continue;
             }
         }


### PR DESCRIPTION
##### Summary

Fixes: #15729

##### Test Plan

No 

> PROCFILE: Cannot open file '/host/proc/pressure/irq' (errno 2, No such file or directory)

in collector.log.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
