### PR TITLE
Properly check for the minimum required version of systemd.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1117,24 +1117,29 @@ AM_CONDITIONAL([ENABLE_PLUGIN_FREEIPMI], [test "${enable_plugin_freeipmi}" = "ye
 
 LIBS_BAK="${LIBS}"
 
-AC_CHECK_LIB([systemd], [sd_journal_open], [have_systemd_libs=yes], [have_systemd_libs=no])
-AC_CHECK_HEADERS([systemd/sd-journal.h], [have_systemd_journal_header=yes], [have_systemd_journal_header=no])
-
-if test "${have_systemd_libs}" = "yes" -a "${have_systemd_journal_header}" = "yes"; then
-    have_systemd="yes"
-else
-    have_systemd="no"
-fi
+PKG_CHECK_MODULES(
+    [OPTIONAL_SYSTEMD],
+    [libsystemd>=245],
+    [AC_CHECK_LIB(
+        [systemd],
+        [sd_journal_open],
+        [AC_CHECK_HEADERS(
+            [systemd/sd-journal.h],
+            [have_systemd='yes'],
+            [have_systemd='no']
+        )],
+        [have_systemd='no'],
+    )],
+    [have_systemd='no']
+)
 
 test "${enable_plugin_systemd_journal}" = "yes" -a "${have_systemd}" != "yes" && \
-    AC_MSG_ERROR([systemd is required but not found. Try installing 'libsystemd-dev' or 'libsystemd-devel'])
+    AC_MSG_ERROR([systemd 245 or newer is required but not found. Try installing 'libsystemd-dev' or 'systemd-devel'])
 
 AC_MSG_CHECKING([if systemd-journal.plugin should be enabled])
 if test "${enable_plugin_systemd_journal}" != "no" -a "${have_systemd}" = "yes"; then
     enable_plugin_systemd_journal="yes"
     AC_DEFINE([HAVE_SYSTEMD], [1], [systemd usability])
-    OPTIONAL_SYSTEMD_CFLAGS="-I/usr/include"
-    OPTIONAL_SYSTEMD_LIBS="-lsystemd"
 else
     enable_plugin_systemd_journal="no"
 fi


### PR DESCRIPTION
##### Summary

This fixes the checks for systemd libraries to properly use `pkg-config` to verify that libsystemd v245 or newer is available before attempting any other checks related to libsystemd. This helps ensure that we actually meet our minimum version requirement.

##### Test Plan

Testing needs to be done manually on platforms that provide systemd, because we do not currently pull in the optional dependencies required to check this case in our CI.

On Debian/Ubuntu: Debian 10 with `libsystemd-dev` installed should fail to build Netdata without this PR, but should build correctly with it. Other Debian/Ubuntu systems with `libsystemd-dev` should build both with or without it.

On RHEL/OEL/CentOS/Rocky/Amla/Fedora: RHEL 8 or earlier and clones thereof with `systemd-devel` installed should fail to build Netdata without this PR, but should build correctly with it. Other systems in this group with `systemd-devel` installed should build both with or without it.

All other supported platforms with systemd development files installed (`systemd-devel` on SUSE-like systems, `libelogind-devel` on Alpine, `systemd-libs` on Arch-like systems) should behave identically with or without this PR.