### PR TITLE
ci: add systemd-journal and metdata to labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -134,6 +134,10 @@ collectors/statsd:
   - collectors/statsd.plugin/*
   - collectors/statsd.plugin/**/*
 
+collectors/systemd-journal:
+  - collectors/systemd-journal.plugin/*
+  - collectors/systemd-journal.plugin/**/*
+
 collectors/tc:
   - collectors/tc.plugin/*
   - collectors/tc.plugin/**/*
@@ -151,6 +155,11 @@ collectors/xenstat:
 area/health:
   - health/*
   - health/**/*
+
+area/metadata:
+  - "**/*metadata.yaml"
+  - integrations/*
+  - integrations/**/*
 
 area/ml:
   - ml/*


### PR DESCRIPTION
##### Summary

This PR adds to the labeler config:

- collectors/systemd-journal
- area/metadata

##### Test Plan

n/a

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
