### PR TITLE
Change FreeBSD / macOS system.swap(io) to mem.swap(io)

### DIFF
--- a/build_external/scenarios/gaps_lo/mostly_off.conf
+++ b/build_external/scenarios/gaps_lo/mostly_off.conf
@@ -545,7 +545,7 @@ enabled = no
 [cpu.cpu7_softirqs]
 enabled = no
 
-[system.swapio]
+[mem.swapio]
 enabled = no
 
 [system.pgpgio]
@@ -560,7 +560,7 @@ enabled = no
 [mem.available]
 enabled = no
 
-[system.swap]
+[mem.swap]
 enabled = no
 
 [mem.committed]

--- a/collectors/ebpf.plugin/metadata.yaml
+++ b/collectors/ebpf.plugin/metadata.yaml
@@ -1376,7 +1376,7 @@ modules:
           description: "These metrics show total number of calls to functions inside kernel."
           labels: []
           metrics:
-            - name: system.swapcalls
+            - name: mem.swapcalls
               description: Calls to access swap memory
               unit: "calls/s"
               chart_type: line

--- a/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -834,7 +834,7 @@ int do_vm_swap_info(int update_every, usec_t dt) {
     static int mib[3] = {0, 0, 0};
 
     if (unlikely(getsysctl_mib("vm.swap_info", mib, 2))) {
-        collector_error("DISABLED: system.swap chart");
+        collector_error("DISABLED: mem.swap chart");
         collector_error("DISABLED: vm.swap_info module");
         return 1;
     } else {
@@ -853,13 +853,13 @@ int do_vm_swap_info(int update_every, usec_t dt) {
             if (unlikely(sysctl(mib, 3, &xsw, &size, NULL, 0) == -1 )) {
                 if (unlikely(errno != ENOENT)) {
                     collector_error("FREEBSD: sysctl(%s...) failed: %s", "vm.swap_info", strerror(errno));
-                    collector_error("DISABLED: system.swap chart");
+                    collector_error("DISABLED: mem.swap chart");
                     collector_error("DISABLED: vm.swap_info module");
                     return 1;
                 } else {
                     if (unlikely(size != sizeof(xsw))) {
                         collector_error("FREEBSD: sysctl(%s...) expected %lu, got %lu", "vm.swap_info", (unsigned long)sizeof(xsw), (unsigned long)size);
-                        collector_error("DISABLED: system.swap chart");
+                        collector_error("DISABLED: mem.swap chart");
                         collector_error("DISABLED: vm.swap_info module");
                         return 1;
                     } else break;
@@ -1026,7 +1026,7 @@ int do_vm_stats_sys_v_swappgs(int update_every, usec_t dt) {
 
     if (unlikely(GETSYSCTL_SIMPLE("vm.stats.vm.v_swappgsin", mib_swappgsin, vmmeter_data.v_swappgsin) ||
                  GETSYSCTL_SIMPLE("vm.stats.vm.v_swappgsout", mib_swappgsout, vmmeter_data.v_swappgsout))) {
-        collector_error("DISABLED: system.swapio chart");
+        collector_error("DISABLED: mem.swapio chart");
         collector_error("DISABLED: vm.stats.vm.v_swappgs module");
         return 1;
     } else {

--- a/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -874,7 +874,7 @@ int do_vm_swap_info(int update_every, usec_t dt) {
 
         if (unlikely(!st)) {
             st = rrdset_create_localhost(
-                    "system",
+                    "mem",
                     "swap",
                     NULL,
                     "swap",
@@ -883,7 +883,7 @@ int do_vm_swap_info(int update_every, usec_t dt) {
                     "MiB",
                     "freebsd.plugin",
                     "vm.swap_info",
-                    NETDATA_CHART_PRIO_SYSTEM_SWAP,
+                    NETDATA_CHART_PRIO_MEM_SWAP,
                     update_every,
                     RRDSET_TYPE_STACKED
             );

--- a/collectors/freebsd.plugin/metadata.yaml
+++ b/collectors/freebsd.plugin/metadata.yaml
@@ -851,7 +851,7 @@ modules:
     alerts:
       - name: used_swap
         link: https://github.com/netdata/netdata/blob/master/health/health.d/swap.conf
-        metric: system.swap
+        metric: mem.swap
         info: swap memory utilization
         os: "linux freebsd"
     metrics:
@@ -865,7 +865,7 @@ modules:
           description: "This metric shows the SWAP usage."
           labels: []
           metrics:
-            - name: system.swap
+            - name: mem.swap
               description: System Swap
               unit: "MiB"
               chart_type: stacked
@@ -1043,7 +1043,7 @@ modules:
     alerts:
       - name: 30min_ram_swapped_out
         link: https://github.com/netdata/netdata/blob/master/health/health.d/swap.conf
-        metric: system.swapio
+        metric: mem.swapio
         info: percentage of the system RAM swapped in the last 30 minutes
         os: "linux freebsd"
     metrics:
@@ -1057,7 +1057,7 @@ modules:
           description: "This metric shows events happening on SWAP."
           labels: []
           metrics:
-            - name: system.swapio
+            - name: mem.swapio
               description: Swap I/O
               unit: "KiB/s"
               chart_type: area

--- a/collectors/macos.plugin/macos_mach_smi.c
+++ b/collectors/macos.plugin/macos_mach_smi.c
@@ -151,7 +151,7 @@ int do_macos_mach_smi(int update_every, usec_t dt) {
                 st = rrdset_find_active_localhost("system.swapio");
                 if (unlikely(!st)) {
                     st = rrdset_create_localhost(
-                            "system"
+                            "mem"
                             , "swapio"
                             , NULL
                             , "swap"

--- a/collectors/macos.plugin/macos_mach_smi.c
+++ b/collectors/macos.plugin/macos_mach_smi.c
@@ -99,7 +99,7 @@ int do_macos_mach_smi(int update_every, usec_t dt) {
             do_ram = 0;
             collector_error("DISABLED: system.ram");
             do_swapio = 0;
-            collector_error("DISABLED: system.swapio");
+            collector_error("DISABLED: mem.swapio");
             do_pgfaults = 0;
             collector_error("DISABLED: mem.pgfaults");
         } else {
@@ -148,7 +148,7 @@ int do_macos_mach_smi(int update_every, usec_t dt) {
 
 #if (defined __MAC_OS_X_VERSION_MIN_REQUIRED && __MAC_OS_X_VERSION_MIN_REQUIRED >= 1090)
             if (likely(do_swapio)) {
-                st = rrdset_find_active_localhost("system.swapio");
+                st = rrdset_find_active_localhost("mem.swapio");
                 if (unlikely(!st)) {
                     st = rrdset_create_localhost(
                             "mem"

--- a/collectors/macos.plugin/macos_sysctl.c
+++ b/collectors/macos.plugin/macos_sysctl.c
@@ -260,9 +260,9 @@ int do_macos_sysctl(int update_every, usec_t dt) {
     if (likely(do_swap)) {
         if (unlikely(GETSYSCTL_BY_NAME("vm.swapusage", swap_usage))) {
             do_swap = 0;
-            collector_error("DISABLED: system.swap");
+            collector_error("DISABLED: mem.swap");
         } else {
-            st = rrdset_find_active_localhost("system.swap");
+            st = rrdset_find_active_localhost("mem.swap");
             if (unlikely(!st)) {
                 st = rrdset_create_localhost(
                         "mem"

--- a/collectors/macos.plugin/macos_sysctl.c
+++ b/collectors/macos.plugin/macos_sysctl.c
@@ -265,7 +265,7 @@ int do_macos_sysctl(int update_every, usec_t dt) {
             st = rrdset_find_active_localhost("system.swap");
             if (unlikely(!st)) {
                 st = rrdset_create_localhost(
-                        "system"
+                        "mem"
                         , "swap"
                         , NULL
                         , "swap"

--- a/collectors/macos.plugin/metadata.yaml
+++ b/collectors/macos.plugin/metadata.yaml
@@ -317,7 +317,7 @@ modules:
                 - name: purgeable
                 - name: speculative
                 - name: free
-            - name: system.swapio
+            - name: mem.swapio
               description: Swap I/O
               unit: "KiB/s"
               chart_type: area
@@ -346,7 +346,7 @@ modules:
                 - name: load1
                 - name: load5
                 - name: load15
-            - name: system.swap
+            - name: mem.swap
               description: System Swap
               unit: "MiB"
               chart_type: stacked

--- a/collectors/proc.plugin/metadata.yaml
+++ b/collectors/proc.plugin/metadata.yaml
@@ -465,7 +465,7 @@ modules:
     alerts:
       - name: 30min_ram_swapped_out
         link: https://github.com/netdata/netdata/blob/master/health/health.d/swap.conf
-        metric: system.swapio
+        metric: mem.swapio
         info: percentage of the system RAM swapped in the last 30 minutes
         os: "linux freebsd"
       - name: oom_kill
@@ -484,7 +484,7 @@ modules:
           description: ""
           labels: []
           metrics:
-            - name: system.swapio
+            - name: mem.swapio
               description: Swap I/O
               unit: "KiB/s"
               chart_type: area
@@ -1340,7 +1340,7 @@ modules:
         os: "linux"
       - name: used_swap
         link: https://github.com/netdata/netdata/blob/master/health/health.d/swap.conf
-        metric: system.swap
+        metric: mem.swap
         info: swap memory utilization
         os: "linux freebsd"
       - name: 1hour_memory_hw_corrupted

--- a/web/gui/dashboard_info.js
+++ b/web/gui/dashboard_info.js
@@ -1530,7 +1530,7 @@ netdataDashboard.context = {
         info: 'Memory paged from/to disk. This is usually the total disk I/O of the system.'
     },
 
-    'system.swapio': {
+    'mem.swapio': {
         info: '<p>System swap I/O.</p>'+
         '<b>In</b> - pages the system has swapped in from disk to RAM. '+
         '<b>Out</b> - pages the system has swapped out from RAM to disk.'
@@ -1675,7 +1675,7 @@ netdataDashboard.context = {
         info: 'System Random Access Memory (i.e. physical memory) usage.'
     },
 
-    'system.swap': {
+    'mem.swap': {
         info: 'System swap memory usage. Swap space is used when the amount of physical memory (RAM) is full. When the system needs more memory resources and the RAM is full, inactive pages in memory are moved to the swap space (usually a disk, a disk partition or a file).'
     },
 


### PR DESCRIPTION
##### Summary

`master` is broken on FreeBSD due to https://github.com/netdata/netdata/pull/15494 . This PR fixes it.

It also updates several other references from `system.swap` to `mem.swap` and `system.swapio` to `mem.swapio`.

##### Test Plan

Check this PR builds successfully on FreeBSD.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
