### PR TITLE
don't return `-1` if the socket was closed

### DIFF
--- a/exporting/send_data.c
+++ b/exporting/send_data.c
@@ -103,6 +103,8 @@ void simple_connector_receive_response(int *sock, struct instance *instance)
             // failed to receive data
             if (errno != EAGAIN && errno != EWOULDBLOCK) {
                 netdata_log_error("EXPORTING: cannot receive data from '%s'.", instance->config.destination);
+                close(*sock);
+                *sock = -1;
             }
         }
 

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -236,7 +236,7 @@ ssize_t netdata_ssl_read(NETDATA_SSL *ssl, void *buf, size_t num) {
         int err = SSL_get_error(ssl->conn, bytes);
         if (err == SSL_ERROR_ZERO_RETURN) {
             ssl->ssl_errno = err;
-            return bytes;
+            return 0;
         }
 
         if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -232,8 +232,13 @@ ssize_t netdata_ssl_read(NETDATA_SSL *ssl, void *buf, size_t num) {
 
     int bytes = SSL_read(ssl->conn, buf, (int)num);
 
-    if(unlikely(bytes < 0)) {
+    if(unlikely(bytes <= 0)) {
         int err = SSL_get_error(ssl->conn, bytes);
+        if (err == SSL_ERROR_ZERO_RETURN) {
+            ssl->ssl_errno = err;
+            return bytes;
+        }
+
         if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
             ssl->ssl_errno = err;
             errno = EWOULDBLOCK;

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -232,7 +232,7 @@ ssize_t netdata_ssl_read(NETDATA_SSL *ssl, void *buf, size_t num) {
 
     int bytes = SSL_read(ssl->conn, buf, (int)num);
 
-    if(unlikely(bytes <= 0)) {
+    if(unlikely(bytes < 0)) {
         int err = SSL_get_error(ssl->conn, bytes);
         if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
             ssl->ssl_errno = err;


### PR DESCRIPTION
##### Summary
`SSL_read()` in `netdata_ssl_read()` returning 0 bytes is currently being treated as an error, and returning `-1` instead. If the connection is closed on the other end, 0 bytes should be returned to the calling method, so the connection is properly closed on both sides.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Check that connector response methods now correctly handle a closed socket and don't treat 0 returns bytes as an error case.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
