### PR TITLE
extend the trimming window to avoid empty points at the end of queries

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -4746,7 +4746,7 @@ static void function_processes(const char *transaction, char *function __maybe_u
     unsigned int io_divisor = 1024 * RATES_DETAIL;
 
     BUFFER *wb = buffer_create(PLUGINSD_LINE_MAX, NULL);
-    buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_NEWLINE_ON_ARRAYS);
+    buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_NEWLINE_ON_ARRAY_ITEMS);
     buffer_json_member_add_uint64(wb, "status", HTTP_RESP_OK);
     buffer_json_member_add_string(wb, "type", "table");
     buffer_json_member_add_time_t(wb, "update_every", update_every);

--- a/collectors/ebpf.plugin/ebpf_functions.c
+++ b/collectors/ebpf.plugin/ebpf_functions.c
@@ -206,7 +206,7 @@ static void ebpf_function_thread_manipulation(const char *transaction,
     time_t expires = now_realtime_sec() + em->update_every;
 
     BUFFER *wb = buffer_create(PLUGINSD_LINE_MAX, NULL);
-    buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_NEWLINE_ON_ARRAYS);
+    buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_NEWLINE_ON_ARRAY_ITEMS);
     buffer_json_member_add_uint64(wb, "status", HTTP_RESP_OK);
     buffer_json_member_add_string(wb, "type", "table");
     buffer_json_member_add_time_t(wb, "update_every", em->update_every);

--- a/collectors/systemd-journal.plugin/systemd-journal.c
+++ b/collectors/systemd-journal.plugin/systemd-journal.c
@@ -323,7 +323,7 @@ static void function_systemd_journal(const char *transaction, char *function, ch
 
     BUFFER *wb = buffer_create(0, NULL);
     buffer_flush(wb);
-    buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_NEWLINE_ON_ARRAYS);
+    buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_NEWLINE_ON_ARRAY_ITEMS);
 
     FACETS *facets = facets_create(50, 0, FACETS_OPTION_ALL_KEYS_FTS,
                                    SYSTEMD_ALWAYS_VISIBLE_KEYS,

--- a/libnetdata/facets/facets.c
+++ b/libnetdata/facets/facets.c
@@ -622,7 +622,6 @@ void facets_row_finished(FACETS *facets, usec_t usec) {
     // dfe_start_read(facets->keys, k) {
     for(k = facets->keys_ll ; k ; k = k->next) {
         if(!k->key_found_in_row) {
-            internal_fatal(buffer_strlen(k->current_value.b), "key is not found in row but it has a current value");
             // put the FACET_VALUE_UNSET value into it
             facets_check_value(facets, k);
         }


### PR DESCRIPTION
Solved 3 problems:

- [x] when update every is big, the trimming was applied up to 1x update every, but some times it is longer than that. Now trimming is applied 2x update every so that there is no case of empty points at the end of the query.
- [x] when json is not minified, insert newlines before arrays that are added in other arrays.
- [x] removed an obsolete internal fatal from systemd-journal