### PR TITLE
fix claiming via UI for static build

### DIFF
--- a/packaging/makeself/jobs/99-makeself.install.sh
+++ b/packaging/makeself/jobs/99-makeself.install.sh
@@ -47,6 +47,12 @@ EOF
 run chmod 755 "${NETDATA_INSTALL_PATH}/bin/netdata"
 
 # -----------------------------------------------------------------------------
+# the claiming script must be in the same directory as the netdata binary for web-based claiming to work
+
+run ln -s "${NETDATA_INSTALL_PATH}/bin/netdata-claim.sh" \
+  "${NETDATA_INSTALL_PATH}/bin/srv/netdata-claim.sh" || exit 1
+
+# -----------------------------------------------------------------------------
 # copy the SSL/TLS configuration and certificates from the build system
 
 run cp -a /etc/ssl "${NETDATA_INSTALL_PATH}/share/ssl"


### PR DESCRIPTION
##### Summary

Netdata expects claiming script to be in the same directory as the netdata binary.


This PR creates a symlink to `netdata-claim.sh` in `/opt/netdata/bin/srv/`

```
/opt/netdata/bin/
├── bash
├── bashbug
├── curl
├── curl-config
├── netdata
├── netdata-claim.sh
├── netdatacli
└── srv
    ├── netdata
    └── netdata-claim.sh -> /opt/netdata/bin/netdata-claim.sh
```

##### Test Plan

- Install static image and do claiming via web .

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
