### PR TITLE
fix: the cleanup was not performed during the kickstart.sh dry run

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -414,6 +414,7 @@ success_banner() {
 cleanup() {
   if [ -z "${NO_CLEANUP}" ] && [ -n "${tmpdir}" ]; then
     cd || true
+    DRY_RUN=0
     run_as_root rm -rf "${tmpdir}"
   fi
 }


### PR DESCRIPTION
##### Summary

Fixes: #15770

##### Test Plan

Run `./kickstart.sh --dry-run` and check `/tmp/` after.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
