### PR TITLE
ci: fix labeler area/docs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -42,8 +42,6 @@ area/docs:
   - "*.md"
   - "**/*.md"
   - "**/*.mdx"
-  - "!integrations/*.md"
-  - "!integrations/**/*.md"
   - diagrams/**
 
 # -----------------collectors----------------------


### PR DESCRIPTION
##### Summary

I see some PRs getting the label `area/docs` when they shouldn't - e.g. #15775.

I guess it is because of negations. That is the only explanation I have despite it shouldn't work like that according to [action/labeler docs](https://github.com/actions/labeler#common-examples).

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
