### PR TITLE
Bump openssl version of static builds to 1.1.1v

### DIFF
--- a/packaging/makeself/openssl.version
+++ b/packaging/makeself/openssl.version
@@ -1,1 +1,1 @@
-OpenSSL_1_1_1t
+OpenSSL_1_1_1v


### PR DESCRIPTION
##### Summary

New version of openSSL is published a while back. Major changes introduced in a meanwhile


Introduced in the transition between OpenSSL 1.1.1u and OpenSSL 1.1.1v [1 Aug 2023]
- Fix excessive time spent checking DH q parameter value ([CVE-2023-3817](https://www.openssl.org/news/vulnerabilities.html#CVE-2023-3817))
- Fix DH_check() excessive time with over sized modulus ([CVE-2023-3446](https://www.openssl.org/news/vulnerabilities.html#CVE-2023-3446))

Introduced in the transition between OpenSSL 1.1.1t and OpenSSL 1.1.1u [30 May 2023]
- Mitigate for very slow `OBJ_obj2txt()` performance with gigantic OBJECT IDENTIFIER sub-identities. ([CVE-2023-2650](https://www.openssl.org/news/vulnerabilities.html#CVE-2023-2650))
- Fixed documentation of X509_VERIFY_PARAM_add0_policy() ([CVE-2023-0466](https://www.openssl.org/news/vulnerabilities.html#CVE-2023-0466))
- Fixed handling of invalid certificate policies in leaf certificates ([CVE-2023-0465](https://www.openssl.org/news/vulnerabilities.html#CVE-2023-0465))
- Limited the number of nodes created in a policy tree ([[CVE-2023-0464](https://www.openssl.org/news/vulnerabilities.html#CVE-2023-0464)])


##### Test Plan

- [ ]  [Configure (TLS)](https://learn.netdata.cloud/docs/agent/web/server#enabling-tls-support) and access local dashboard via https
 - [ ] Setup [Parent (TLS)](https://learn.netdata.cloud/docs/agent/streaming#securing-streaming-communications) and verify its working (during streaming)

##### Additional Information


- [ ]  Include this in the patch release for 1.42.1
