### PR TITLE
Update an oversight on the openSUSE 15.5 packages

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -198,7 +198,7 @@ include:
       zypper rm -y libjson-c-devel
     packages: &opensuse_packages
       type: rpm
-      repo_distro: opensuse/leap:15.4
+      repo_distro: opensuse/leap:15.5
       arches:
         - x86_64
         - aarch64


### PR DESCRIPTION
##### Summary

I introduced a bug during https://github.com/netdata/netdata/pull/15554. This bug prevent packages of openSUSE 15.5 to be published into our package server. We need to investigate also in what extend this bug affects openSUSE 15.4 packages.

##### Test Plan

CI/CD

