### PR TITLE
Set correct path for ansible-playbook in deployment tutorial

### DIFF
--- a/packaging/installer/methods/ansible.md
+++ b/packaging/installer/methods/ansible.md
@@ -55,7 +55,7 @@ current directory, and remove the rest of the cloned repository, as it's not req
 
 ```bash
 git clone https://github.com/netdata/community.git
-mv community/netdata-agent-deployment/ansible-quickstart .
+mv community/configuration-management/ansible-quickstart .
 rm -rf community
 ```
 


### PR DESCRIPTION
The Ansible tutorial points in a wrong directory for the ansible-quickstart role. Fixed so it points in a correct position.
