### PR TITLE
count functions as collections, to restart plugins

### DIFF
--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -887,6 +887,8 @@ static inline PARSER_RC pluginsd_function(char **words, size_t num_words, PARSER
 
     rrd_collector_add_function(host, st, name, timeout, help, false, pluginsd_execute_function_callback, parser);
 
+    parser->user.data_collections_count++;
+
     return PARSER_RC_OK;
 }
 
@@ -895,6 +897,8 @@ static void pluginsd_function_result_end(struct parser *parser, void *action_dat
     if(key)
         dictionary_del(parser->inflight.functions, string2str(key));
     string_freez(key);
+
+    parser->user.data_collections_count++;
 }
 
 static inline PARSER_RC pluginsd_function_result_begin(char **words, size_t num_words, PARSER *parser) {


### PR DESCRIPTION
`systemd-journal` does not expose any metrics, but it restarts from time to time.
After 10 restarts without any metrics collected, plugins.d does not restart the plugin any more.

This PR counts function definitions and results as collections.