### PR TITLE
packaging: deb remove setuid bit from systemd-journal

### DIFF
--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -219,7 +219,7 @@ override_dh_fixperms:
 	chmod 4750 $(TOP)/usr/libexec/netdata/plugins.d/local-listeners
 
 	# systemd-journal
-	chmod 4750 $(TOP)-plugin-systemd-journal/usr/libexec/netdata/plugins.d/systemd-journal.plugin
+	chmod 0750 $(TOP)-plugin-systemd-journal/usr/libexec/netdata/plugins.d/systemd-journal.plugin
 
 override_dh_installlogrotate:
 	cp system/logrotate/netdata debian/netdata.logrotate


### PR DESCRIPTION
##### Summary

Not needed because we set `cap_dac_read_search` [in postinst](https://github.com/netdata/netdata/blob/master/contrib/debian/netdata-plugin-systemd-journal.postinst).

##### Test Plan

Not needed

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
