### PR TITLE
Function systemd-journal: always have a nd_journal_process

### DIFF
--- a/libnetdata/facets/facets.c
+++ b/libnetdata/facets/facets.c
@@ -1,6 +1,5 @@
 #include "facets.h"
 
-#define FACET_VALUE_UNSET "-"
 #define HISTOGRAM_COLUMNS 60
 
 static void facets_row_free(FACETS *facets __maybe_unused, FACET_ROW *row);

--- a/libnetdata/facets/facets.h
+++ b/libnetdata/facets/facets.h
@@ -3,6 +3,8 @@
 
 #include "../libnetdata.h"
 
+#define FACET_VALUE_UNSET "-"
+
 typedef enum __attribute__((packed)) {
     FACET_KEY_OPTION_FACET      = (1 << 0), // filterable values
     FACET_KEY_OPTION_NO_FACET   = (1 << 1), // non-filterable value


### PR DESCRIPTION
Depending on the journal transport, the column was sometimes not populated. Fixed it.