### PR TITLE
Add proper SUID fallback for DEB plugin packages.

### DIFF
--- a/contrib/debian/netdata-plugin-apps.postinst
+++ b/contrib/debian/netdata-plugin-apps.postinst
@@ -5,7 +5,10 @@ set -e
 case "$1" in
   configure|reconfigure)
     chown root:netdata /usr/libexec/netdata/plugins.d/apps.plugin
-    setcap "cap_dac_read_search=eip cap_sys_ptrace=eip" /usr/libexec/netdata/plugins.d/apps.plugin
+    chmod 0750 /usr/libexec/netdata/plugins.d/apps.plugin
+    if ! setcap "cap_dac_read_search=eip cap_sys_ptrace=eip" /usr/libexec/netdata/plugins.d/apps.plugin; then
+        chmod -f 4750 /usr/libexec/netdata/plugins.d/apps.plugin
+    fi
     ;;
 esac
 

--- a/contrib/debian/netdata-plugin-debugfs.postinst
+++ b/contrib/debian/netdata-plugin-debugfs.postinst
@@ -5,7 +5,10 @@ set -e
 case "$1" in
   configure|reconfigure)
     chown root:netdata /usr/libexec/netdata/plugins.d/debugfs.plugin
-    setcap "cap_dac_read_search=eip" /usr/libexec/netdata/plugins.d/debugfs.plugin
+    chmod 0750 /usr/libexec/netdata/plugins.d/debugfs.plugin
+    if ! setcap "cap_dac_read_search=eip" /usr/libexec/netdata/plugins.d/debugfs.plugin; then
+        chmod -f 4750 /usr/libexec/netdata/plugins.d/debugfs.plugin
+    fi
     ;;
 esac
 

--- a/contrib/debian/netdata-plugin-go.postinst
+++ b/contrib/debian/netdata-plugin-go.postinst
@@ -5,7 +5,10 @@ set -e
 case "$1" in
   configure|reconfigure)
     chown root:netdata /usr/libexec/netdata/plugins.d/go.d.plugin
-    setcap "cap_net_admin=eip cap_net_raw=eip" /usr/libexec/netdata/plugins.d/go.d.plugin
+    chmod 0750 /usr/libexec/netdata/plugins.d/go.d.plugin
+    if ! setcap "cap_net_admin=eip cap_net_raw=eip" /usr/libexec/netdata/plugins.d/go.d.plugin; then
+        chmod -f 4750 /usr/libexec/netdata/plugins.d/go.d.plugin
+    fi
     ;;
 esac
 

--- a/contrib/debian/netdata-plugin-perf.postinst
+++ b/contrib/debian/netdata-plugin-perf.postinst
@@ -5,10 +5,18 @@ set -e
 case "$1" in
   configure|reconfigure)
     chown root:netdata /usr/libexec/netdata/plugins.d/perf.plugin
+    chown 0750 /usr/libexec/netdata/plugins.d/perf.plugin
+
     if capsh --supports=cap_perfmon 2>/dev/null; then
         setcap cap_perfmon+ep /usr/libexec/netdata/plugins.d/perf.plugin
+        ret="$?"
     else
         setcap cap_sys_admin+ep /usr/libexec/netdata/plugins.d/perf.plugin
+        ret="$?"
+    fi
+
+    if [ "${ret}" -ne 0 ]; then
+        chmod -f 4750 /usr/libexec/netdata/plugins.d/perf.plugin
     fi
     ;;
 esac

--- a/contrib/debian/netdata-plugin-slabinfo.postinst
+++ b/contrib/debian/netdata-plugin-slabinfo.postinst
@@ -5,7 +5,10 @@ set -e
 case "$1" in
   configure|reconfigure)
     chown root:netdata /usr/libexec/netdata/plugins.d/slabinfo.plugin
-    setcap "cap_dac_read_search=eip" /usr/libexec/netdata/plugins.d/slabinfo.plugin
+    chmod 0750 /usr/libexec/netdata/plugins.d/slabinfo.plugin
+    if ! setcap "cap_dac_read_search=eip" /usr/libexec/netdata/plugins.d/slabinfo.plugin; then
+        chmod -f 4750 /usr/libexec/netdata/plugins.d/slabinfo.plugin
+    fi
     ;;
 esac
 

--- a/contrib/debian/netdata-plugin-systemd-journal.postinst
+++ b/contrib/debian/netdata-plugin-systemd-journal.postinst
@@ -5,7 +5,10 @@ set -e
 case "$1" in
   configure|reconfigure)
     chown root:netdata /usr/libexec/netdata/plugins.d/systemd-journal.plugin
-    setcap "cap_dac_read_search=eip" /usr/libexec/netdata/plugins.d/systemd-journal.plugin
+    chmod 0750 /usr/libexec/netdata/plugins.d/systemd-journal.plugin
+    if ! setcap "cap_dac_read_search=eip" /usr/libexec/netdata/plugins.d/systemd-journal.plugin; then
+        chmod -f 4750 /usr/libexec/netdata/plugins.d/systemd-journal.plugin
+    fi
     ;;
 esac
 


### PR DESCRIPTION
##### Summary

On systems where file capabilities are not usable, we need to properly mark plugins that use them as SUID 0 so that they still are able to work.

This code is not expected to run on a vast majority of systems (possibly not even _any_ systems) as it is vanishingly rare that file capabilities are not usable.

##### Test Plan

CI passes on this PR.

Proper validation of these changes is extremely difficult, because it’s actually pretty hard to make file capabilities not work, but it’s probably fine to only verify that this breaks nothing since that case is so unlikely to occur in the wild.