### PR TITLE
Clean up python deps for RPM packages.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -124,18 +124,6 @@ BuildRequires: systemd-rpm-macros
 BuildRequires: systemd
 %endif
 
-# Runtime dependencies
-#
-%if 0%{?centos_ver} == 7 || 0%{?centos_ver} == 6
-Requires: python
-%else
-%if 0%{?centos_ver} == 8
-Requires: python38
-%else
-Requires: python3
-%endif
-%endif
-
 # Core requirements for the install to succeed
 Requires(pre): /usr/sbin/groupadd
 Requires(pre): /usr/sbin/useradd
@@ -767,11 +755,7 @@ Conflicts: netdata < %{version}
 %if 0%{?centos_ver} == 7 || 0%{?centos_ver} == 6
 Requires: python
 %else
-%if 0%{?centos_ver} == 8
-Requires: python38
-%else
 Requires: python3
-%endif
 %endif
 %if 0%{?centos_ver} != 7
 Suggests: sudo


### PR DESCRIPTION
##### Summary

- Don't depend on Python for the core agent, since it's only needed for the python plugin.
- Don't explicitly version Python dependency on RHEL 8 and clones.

##### Test Plan

CI passes on this PR.