### PR TITLE
fix api v1 mgmt/health

### DIFF
--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1524,12 +1524,19 @@ int web_client_api_request_v1_dbengine_stats(RRDHOST *host __maybe_unused, struc
 }
 #endif
 
+#define HLT_MGM "manage/health"
 int web_client_api_request_v1_mgmt(RRDHOST *host, struct web_client *w, char *url) {
     const char *haystack = buffer_tostring(w->url_path_decoded);
+    char *needle;
 
     buffer_flush(w->response.data);
 
-    if (strstr(haystack, "manage/health") == NULL) {
+    if ((needle = strstr(haystack, HLT_MGM)) == NULL) {
+        buffer_strcat(w->response.data, "Invalid management request. Curently only 'health' is supported.");
+        return HTTP_RESP_NOT_FOUND;
+    }
+    needle += strlen(HLT_MGM);
+    if (*needle != '\0') {
         buffer_strcat(w->response.data, "Invalid management request. Curently only 'health' is supported.");
         return HTTP_RESP_NOT_FOUND;
     }


### PR DESCRIPTION
##### Summary
For dynamic configuration we now have dynamic URLs (/api/v2/config/XXX/YYY/ZZZ) which are created and removed during runtime depending on the situation. During implementation of that we split URL on `/` to separate command name from sub path. However it escaped attention we actually had one command called `manage/health`. This points to issues of internal webserver and its URL parser which are rampant. Luckily we do gradually move to h2o.

Fixes https://github.com/netdata/netdata/issues/15800

##### Test Plan
`curl -X 'GET' -H "X-Auth-Token: `cat ./token`"  http://localhost:19999/api/v1/manage/health\?cmd\=LIST` should no longer result in `Unsupported API command: manage&#x2F;health`
<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
