### PR TITLE
Fix configure checks for libsystemd.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1117,31 +1117,25 @@ AM_CONDITIONAL([ENABLE_PLUGIN_FREEIPMI], [test "${enable_plugin_freeipmi}" = "ye
 
 LIBS_BAK="${LIBS}"
 
-AC_CHECK_LIB([systemd], [sd_journal_open], [have_systemd_libs=yes], [have_systemd_libs=no])
-AC_CHECK_HEADERS([systemd/sd-journal.h], [have_systemd_journal_header=yes], [have_systemd_journal_header=no])
-
-if test "${have_systemd_libs}" = "yes" -a "${have_systemd_journal_header}" = "yes"; then
-    have_systemd="yes"
-else
-    have_systemd="no"
-fi
-
-test "${enable_plugin_systemd_journal}" = "yes" -a "${have_systemd}" != "yes" && \
-    AC_MSG_ERROR([systemd is required but not found. Try installing 'libsystemd-dev' or 'libsystemd-devel'])
-
-AC_MSG_CHECKING([if systemd-journal.plugin should be enabled])
-if test "${enable_plugin_systemd_journal}" != "no" -a "${have_systemd}" = "yes"; then
-    enable_plugin_systemd_journal="yes"
-    AC_DEFINE([HAVE_SYSTEMD], [1], [systemd usability])
-    OPTIONAL_SYSTEMD_CFLAGS="-I/usr/include"
-    OPTIONAL_SYSTEMD_LIBS="-lsystemd"
-else
+AS_IF([test "x${enable_plugin_systemd_journal}" != "xno"], [
+    PKG_CHECK_MODULES([OPTIONAL_SYSTEMD], [libsystemd], [
+        enable_plugin_systemd_journal="yes"
+    ], [
+        PKG_CHECK_MODULES([OPTIONAL_SYSTEMD], [libelogind], [
+            enable_plugin_systemd_journal="yes"
+        ], [
+            if test "x${enable_plugin_systemd_journal}" = "xyes"; then
+                AC_MSG_ERROR([systemd is required but not found. Try installing 'libsystemd-dev' or 'systemd-devel'])
+            fi
+            enable_plugin_systemd_journal="no"
+        ])
+    ])
+], [
     enable_plugin_systemd_journal="no"
-fi
+])
+AC_MSG_CHECKING([if systemd-journal.plugin should be enabled])
 AC_MSG_RESULT([${enable_plugin_systemd_journal}])
 AM_CONDITIONAL([ENABLE_PLUGIN_SYSTEMD_JOURNAL], [test "${enable_plugin_systemd_journal}" = "yes"])
-
-AC_MSG_NOTICE([OPTIONAL_SYSTEMD_LIBS is set to: ${OPTIONAL_SYSTEMD_LIBS}])
 
 LIBS="${LIBS_BAK}"
 

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -113,6 +113,9 @@ RUN chown -R root:root \
     if [ -f /usr/libexec/netdata/plugins.d/go.d.plugin ]; then \
         chmod 4755 /usr/libexec/netdata/plugins.d/go.d.plugin; \
     fi && \
+    if [ -f /usr/libexec/netdata/plugins.d/systemd-journal.plugin ]; then \
+        chmod 4755 /usr/libexec/netdata/plugins.d/systemd-journal.plugin; \
+    fi && \
     # Group write permissions due to: https://github.com/netdata/netdata/pull/6543
     find /var/lib/netdata /var/cache/netdata -type d -exec chmod 0770 {} \; && \
     find /var/lib/netdata /var/cache/netdata -type f -exec chmod 0660 {} \; && \


### PR DESCRIPTION
##### Summary

- Skip checking for libsystemd if the systemd-journal plugin is disabled. This saves a bit of time when configuring and makes it even more clear why we’re looking for libsystemd.
- Switch to using pkg-config to check the availability of libsystemd instead of blindly trying to link it directly and assuming specific header paths. This allows easier usage of a libsystemd from a non-root prefix, as well as allowing usage of alternative implementations that use different include or library paths. Notably, this enables using libelogind in place of libsystemd on Alpine Linux to build the systemd-journal plugin.
- If libsystemd cannot be found, try libelogind instead. Alpine Linux provides some compatibility bits to allow pkg-config to correctly identify libelogind as a libsystemd implementation, but some other Linux systems do not. Checking for libelogind allows us to correctly build the systemd-journal plugin on these systems.

##### Test Plan

CI passes correctly on this PR.

Docker images built from this PR include the systemd-journal plugin.