### PR TITLE
fix packaging: link health.log to stdout

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -79,6 +79,7 @@ RUN mkdir -p /opt/src /var/log/netdata && \
     ln -sf /dev/stdout /var/log/netdata/debug.log && \
     ln -sf /dev/stderr /var/log/netdata/error.log && \
     ln -sf /dev/stdout /var/log/netdata/collector.log && \
+    ln -sf /dev/stdout /var/log/netdata/health.log && \
     # Add netdata user
     addgroup -g ${NETDATA_GID} -S "${DOCKER_GRP}" && \
     adduser -S -H -s /usr/sbin/nologin -u ${NETDATA_GID} -h /etc/netdata -G "${DOCKER_GRP}" "${DOCKER_USR}"


### PR DESCRIPTION
##### Summary

Noticed the problem:

```bash
# ls -l /var/log/netdata/
total 12
lrwxrwxrwx    1 netdata  root            11 Aug 15 15:27 access.log -> /dev/stdout
lrwxrwxrwx    1 netdata  root            11 Aug 15 15:27 collector.log -> /dev/stdout
lrwxrwxrwx    1 netdata  root            11 Aug 15 15:27 debug.log -> /dev/stdout
lrwxrwxrwx    1 netdata  root            11 Aug 15 15:27 error.log -> /dev/stderr
-rw-r--r--    1 netdata  netdata      11686 Aug 15 16:12 health.log
```

##### Test Plan

After this PR

```bash
$ docker exec netdata ls -l /var/log/netdata
total 0
lrwxrwxrwx    1 netdata  root            11 Aug 15 16:21 access.log -> /dev/stdout
lrwxrwxrwx    1 netdata  root            11 Aug 15 16:21 collector.log -> /dev/stdout
lrwxrwxrwx    1 netdata  root            11 Aug 15 16:21 debug.log -> /dev/stdout
lrwxrwxrwx    1 netdata  root            11 Aug 15 16:21 error.log -> /dev/stderr
lrwxrwxrwx    1 netdata  root            11 Aug 15 16:21 health.log -> /dev/stdout
```

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
