### PR TITLE
systemd-journal fixes

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -16,6 +16,9 @@
         fprintf(stdout, PLUGINSD_KEYWORD_FUNCTION " \"processes\" %d \"%s\"\n", PLUGINS_FUNCTIONS_TIMEOUT_DEFAULT, APPS_PLUGIN_PROCESSES_FUNCTION_DESCRIPTION); \
     } while(0)
 
+#define APPS_PLUGIN_GLOBAL_FUNCTIONS() do { \
+        fprintf(stdout, PLUGINSD_KEYWORD_FUNCTION " GLOBAL \"processes\" %d \"%s\"\n", PLUGINS_FUNCTIONS_TIMEOUT_DEFAULT, APPS_PLUGIN_PROCESSES_FUNCTION_DESCRIPTION); \
+    } while(0)
 
 // ----------------------------------------------------------------------------
 // debugging
@@ -5687,7 +5690,7 @@ int main(int argc, char **argv) {
     netdata_thread_create(&reader_thread, "APPS_READER", NETDATA_THREAD_OPTION_DONT_LOG, reader_main, NULL);
     netdata_mutex_lock(&mutex);
 
-    APPS_PLUGIN_FUNCTIONS();
+    APPS_PLUGIN_GLOBAL_FUNCTIONS();
 
     usec_t step = update_every * USEC_PER_SEC;
     global_iterations_counter = 1;

--- a/collectors/systemd-journal.plugin/systemd-journal.c
+++ b/collectors/systemd-journal.plugin/systemd-journal.c
@@ -566,7 +566,7 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
     bool tty = isatty(fileno(stderr)) == 1;
 
     netdata_mutex_lock(&mutex);
-    fprintf(stdout, PLUGINSD_KEYWORD_FUNCTION " \"%s\" %d \"%s\"\n",
+    fprintf(stdout, PLUGINSD_KEYWORD_FUNCTION " GLOBAL \"%s\" %d \"%s\"\n",
             SYSTEMD_JOURNAL_FUNCTION_NAME, SYSTEMD_JOURNAL_DEFAULT_TIMEOUT, SYSTEMD_JOURNAL_FUNCTION_DESCRIPTION);
 
     heartbeat_t hb;

--- a/libnetdata/facets/facets.c
+++ b/libnetdata/facets/facets.c
@@ -196,14 +196,14 @@ static void facet_value_insert_callback(const DICTIONARY_ITEM *item __maybe_unus
     FACET_VALUE *v = value;
     FACET_KEY *k = data;
 
+    if(!v->selected)
+        v->selected = k->default_selected_for_values;
+
     if(v->name) {
         // an actual value, not a filter
         v->name = strdupz(v->name);
         facet_value_is_used(k, v);
     }
-
-    if(!v->selected)
-        v->selected = k->default_selected_for_values;
 }
 
 static bool facet_value_conflict_callback(const DICTIONARY_ITEM *item __maybe_unused, void *old_value, void *new_value, void *data) {
@@ -217,6 +217,9 @@ static bool facet_value_conflict_callback(const DICTIONARY_ITEM *item __maybe_un
 
     if(v->name)
         facet_value_is_used(k, v);
+
+    internal_fatal(v->name && strcmp(v->name, nv->name) != 0, "hash conflict: '%s' and '%s' have the same hash '%s'", v->name, nv->name,
+                   dictionary_acquired_item_name(item));
 
     return false;
 }


### PR DESCRIPTION
- [x] journal was incorrectly filtering out some entries (0 counted facets, without any filters applied) - fixed it
- [x] global functions require the GLOBAL keyword, but it was not set (fixed it for both systemd-journal and processes)
