### PR TITLE
ML improve init

### DIFF
--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -1217,6 +1217,7 @@ void ml_host_new(RRDHOST *rh)
     host->rh = rh;
     host->mls = ml_machine_learning_stats_t();
     host->host_anomaly_rate = 0.0;
+    host->anomaly_rate_rs = NULL;
 
     static std::atomic<size_t> times_called(0);
     host->training_queue = Cfg.training_threads[times_called++ % Cfg.num_training_threads].training_queue;


### PR DESCRIPTION
##### Summary
Init anomaly_rate_rs chart to avoid warning from valgrind

```
==505866== Conditional jump or move depends on uninitialised value(s)
==505866==    at 0x467A87: store_metric_at_tier (rrdset.c:1185)
==505866==    by 0x467D50: rrddim_store_metric (rrdset.c:1258)
==505866==    by 0x4684DD: rrdset_done_interpolate (rrdset.c:1453)
==505866==    by 0x4696E0: rrdset_timed_done (rrdset.c:1893)
==505866==    by 0x468702: rrdset_done (rrdset.c:1502)
==505866==    by 0x244400: ml_update_host_and_detection_rate_charts(ml_host_t*, long long) (ad_charts.cc:333)
==505866==    by 0x400C51: ml_host_detect_once(ml_host_t*) (ml.cc:1048)
==505866==    by 0x401039: ml_detect_main(void*) (ml.cc:1142)
==505866==    by 0x1D5ED0: netdata_thread_init (threads.c:262)
==505866==    by 0x51D5043: start_thread (pthread_create.c:442)
==505866==    by 0x525485F: clone (clone.S:100)
```
