### PR TITLE
Fix use after free

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -509,7 +509,8 @@ int is_legacy = 1;
     if(t != host) {
         netdata_log_error("Host '%s': cannot add host with machine guid '%s' to index. It already exists as host '%s' with machine guid '%s'.",
                           rrdhost_hostname(host), host->machine_guid, rrdhost_hostname(t), t->machine_guid);
-        rrdhost_free___while_having_rrd_wrlock(host, true);
+        if (!is_localhost)
+            rrdhost_free___while_having_rrd_wrlock(host, true);
         rrd_unlock();
         return NULL;
     }

--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -1726,6 +1726,9 @@ void ml_stop_threads()
     Cfg.detection_stop = true;
     Cfg.training_stop = true;
 
+    if (!Cfg.detection_thread)
+        return;
+
     netdata_thread_cancel(Cfg.detection_thread);
     netdata_thread_join(Cfg.detection_thread, NULL);
 


### PR DESCRIPTION
##### Summary
Fix an issue when rrd_init fails. This will try to create  localhost and if it fails it will try to set the environment
so that `fatal` may be able to submit a report (if allowed). The problem is that system_info in this case will
be invalid as it may have been released. 

This PR will preserve system info if we are creating the localhost -- it will not release the memory but we will fail anyway. 


```
    if(rrd_init(netdata_configured_hostname, system_info, false)) {
        set_late_global_environment(system_info);
        fatal("Cannot initialize localhost instance with name '%s'.", netdata_configured_hostname);
    }
```
An additional check has been added when shutting down the ml threads. A quick agent shutdown (as in the case above) needs to check if the ml detection_thread is valid.
