### PR TITLE
Fix warning when compiling with -flto

### DIFF
--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -826,6 +826,8 @@ struct node_instance_list *get_node_list(void)
             uuid_t *host_id = (uuid_t *)sqlite3_column_blob(res, 1);
             uuid_unparse_lower(*host_id, host_guid);
             RRDHOST *host = rrdhost_find_by_guid(host_guid);
+            if (!host)
+                continue;
             if (rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD)) {
                 netdata_log_info("ACLK: 'host:%s' skipping get node list because context is initializing", rrdhost_hostname(host));
                 continue;


### PR DESCRIPTION
##### Summary
Fixes warning

```
database/sqlite/sqlite_functions.c:829:17: warning: '__atomic_load_4' writing 4 bytes into a region of size 0 overflows the destination [-Wstringop-overflow=]
  829 |             if (rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD)) {

```

