### PR TITLE
Fix compilation warning

### DIFF
--- a/aclk/aclk_rx_msgs.c
+++ b/aclk/aclk_rx_msgs.c
@@ -449,7 +449,7 @@ int stop_streaming_contexts(const char *msg, size_t msg_len)
 
 int cancel_pending_req(const char *msg, size_t msg_len)
 {
-    struct aclk_cancel_pending_req cmd;
+    struct aclk_cancel_pending_req cmd = {.request_id = NULL, .trace_id = NULL};
     if(parse_cancel_pending_req(msg, msg_len, &cmd)) {
         error_report("Error parsing CancelPendingReq");
         return 1;


### PR DESCRIPTION
##### Summary
Initialize trace id to avoid warning

```
aclk/aclk_rx_msgs.c:458:5: warning: 'MEM[(struct aclk_cancel_pending_req *)&cmd].trace_id' may be used uninitialized [-Wmaybe-uninitialized]
  458 |     netdata_log_access("ACLK CancelPendingRequest REQ: %s, cloud trace-id: %s", cmd.request_id, cmd.trace_id);
      |     ^
aclk/aclk_rx_msgs.c:452:36: note: 'MEM[(struct aclk_cancel_pending_req *)&cmd].trace_id' was declared here
  452 |     struct aclk_cancel_pending_req cmd;
```
