### PR TITLE
Fix configure: WARNING: unrecognized options: --with-zlib

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1015,7 +1015,6 @@ if ! run ./configure \
          --localstatedir="${NETDATA_PREFIX}/var" \
          --libexecdir="${NETDATA_PREFIX}/usr/libexec" \
          --libdir="${NETDATA_PREFIX}/usr/lib" \
-         --with-zlib \
          --with-math \
          --with-user="${NETDATA_USER}" \
          ${NETDATA_CONFIGURE_OPTIONS} \


### PR DESCRIPTION
##### Summary
Clears the warning during compilation

```
configure: WARNING: unrecognized options: --with-zlib
```

##### Test Plan
