### PR TITLE
fix proc meminfo cached calculation

### DIFF
--- a/collectors/proc.plugin/proc_meminfo.c
+++ b/collectors/proc.plugin/proc_meminfo.c
@@ -230,7 +230,9 @@ int do_proc_meminfo(int update_every, usec_t dt) {
     }
 
     // http://calimeroteknik.free.fr/blag/?article20/really-used-memory-on-gnu-linux
-    unsigned long long MemCached = Cached + SReclaimable + KReclaimable - Shmem;
+    // KReclaimable includes SReclaimable, it was added in kernel v4.20
+    unsigned long long reclaimable = KReclaimable > 0 ? KReclaimable : SReclaimable;
+    unsigned long long MemCached = Cached + reclaimable - Shmem;
     unsigned long long MemUsed = MemTotal - MemFree - MemCached - Buffers;
     // The Linux kernel doesn't report ZFS ARC usage as cache memory (the ARC is included in the total used system memory)
     if (!inside_lxc_container) {


### PR DESCRIPTION
##### Summary

The bug was introduced in https://github.com/netdata/netdata/pull/15494/files#diff-13ee0998f68cd432ef08fa560ede0b845e8b3100947a8c9e9d70bdc234ffb577

[Reported on Discord](https://discord.com/channels/847502280503590932/1143104256753274983/1143104256753274983): negative ram `used` and huge `cached`.

[KReclaimable includes SReclaimable](https://github.com/torvalds/linux/blob/f7757129e3dea336c407551c98f50057c22bb266/fs/proc/meminfo.c#L106), we shouldn't sum them but use KReclaimable (available since kernel v4.20) or SReclaimable.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
