### PR TITLE
Apply a label prefix for netdata labels

### DIFF
--- a/exporting/exporting.conf
+++ b/exporting/exporting.conf
@@ -12,6 +12,7 @@
     # send charts matching = *
     # send hosts matching = localhost *
     # prefix = netdata
+    # netdata label prefix = 
 
 # An example configuration for graphite, json, opentsdb exporting connectors
 # [graphite:my_graphite_instance]

--- a/exporting/exporting_engine.h
+++ b/exporting/exporting_engine.h
@@ -74,6 +74,7 @@ struct instance_config {
     const char *username;
     const char *password;
     const char *prefix;
+    const char *label_prefix;
     const char *hostname;
 
     int update_every;

--- a/exporting/prometheus/prometheus.c
+++ b/exporting/prometheus/prometheus.c
@@ -455,6 +455,7 @@ static int print_host_variables_callback(const DICTIONARY_ITEM *item __maybe_unu
 
 struct gen_parameters {
     const char *prefix;
+    const char *labels_prefix;
     char *context;
     char *suffix;
 
@@ -526,12 +527,12 @@ static void generate_as_collected_prom_metric(BUFFER *wb,
     if (!homogeneous)
         buffer_sprintf(wb, "_%s", p->dimension);
 
-    buffer_sprintf(wb, "%s{chart=\"%s\"", p->suffix, p->chart);
+    buffer_sprintf(wb, "%s{%schart=\"%s\"", p->suffix, p->labels_prefix, p->chart);
 
     if (homogeneous)
-        buffer_sprintf(wb, ",dimension=\"%s\"", p->dimension);
+        buffer_sprintf(wb, ",%sdimension=\"%s\"", p->labels_prefix, p->dimension);
 
-    buffer_sprintf(wb, ",family=\"%s\"", p->family);
+    buffer_sprintf(wb, ",%sfamily=\"%s\"", p->labels_prefix, p->family);
 
     rrdlabels_walkthrough_read(chart_labels, format_prometheus_chart_label_callback, &local_label);
 
@@ -686,6 +687,7 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
 
                         struct gen_parameters p;
                         p.prefix = prefix;
+                        p.labels_prefix = instance->config.label_prefix;
                         p.context = context;
                         p.suffix = suffix;
                         p.chart = chart;

--- a/exporting/read_config.c
+++ b/exporting/read_config.c
@@ -272,6 +272,8 @@ struct engine *read_exporting_config()
 
         prometheus_exporter_instance->config.prefix = prometheus_config_get("prefix", global_exporting_prefix);
 
+        prometheus_exporter_instance->config.label_prefix = prometheus_config_get("netdata label prefix", "");
+
         prometheus_exporter_instance->config.initialized = 1;
     }
 


### PR DESCRIPTION
##### Summary

#15099 introduced a bug for metrics utilizing label names that conflict with existing 'special' names: chart, dimension, family, instance.

This bug results in duplicate labels, which Prometheus will reject on intake.

My original fix in #15387 was to replace either the netdata labels or the chart labels when there are duplicates.

@ilyam8 suggested to apply a prefix to netdata labels instead of eliminating one or the other. This PR implements this.

##### Test Plan

1. Compile Branch and start netdata.
2. Update netdata prometheus exporting conf to apply a label prefix.
3. Query the prometheus exporter. The netdata labels have a prefix.

Example exporting configuration:
```
[prometheus:exporter]
    netdata label prefix = nd_
```

Results in labels like:
```
netdata_system_exit_calls_persec_average{nd_chart="system.exit",nd_dimension="system.exit",nd_family="process",nd_instance="kevinlargeubuntu"}

netdata_prometheus_coredns_local_coredns_dns_requests_total_requests_persec_average{nd_chart="prometheus_coredns_local.coredns_dns_requests_total-family_1-proto_udp-server_dns____1053-type_A-zone_.",nd_dimension="prometheus_coredns_local.coredns_dns_requests_total-family_1-proto_udp-server_dns____1053-type_A-zone_.",nd_family="coredns_dns_requests_total",family="1",proto="udp",server="dns://:1053",type="A",view="[none]",zone=".",nd_instance="kevinlargeubuntu"}
```

##### Additional Information


