### PR TITLE
Add plugin and module information to collector integrations.

### DIFF
--- a/integrations/templates/overview/collector.md
+++ b/integrations/templates/overview/collector.md
@@ -1,5 +1,8 @@
 # [[ entry.meta.monitored_instance.name ]]
 
+Plugin: [[ entry.meta.plugin_name ]]
+Module: [[ entry.meta.module_name ]]
+
 ## Overview
 
 [[ entry.overview.data_collection.metrics_description ]]


### PR DESCRIPTION
##### Summary

This adds info about the plugin and module for a collector to the top of the integration overview.

##### Test Plan

n/a

##### Additional Information

Relevant to: https://github.com/netdata/netdata/issues/15707