### PR TITLE
Add a fail reason to pinpoint exactly what went wrong

### DIFF
--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -974,14 +974,17 @@ void send_statistics(const char *action, const char *action_result, const char *
         action_result = "";
     if (!action_data)
         action_data = "";
+
+    const char *fail_reason = getenv("NETDATA_FAIL_REASON") ? getenv("NETDATA_FAIL_REASON") : "";
+
     char *command_to_run = mallocz(
         sizeof(char) * (strlen(action) + strlen(action_result) + strlen(action_data) + strlen(as_script) +
-                        analytics_data.data_length + (ANALYTICS_NO_OF_ITEMS * 3) + 15));
+                        analytics_data.data_length + (ANALYTICS_NO_OF_ITEMS * 3) + 15 + strlen(fail_reason) + 5));
     pid_t command_pid;
 
     sprintf(
         command_to_run,
-        "%s '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' ",
+        "%s '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' ",
         as_script,
         action,
         action_result,
@@ -1024,7 +1027,8 @@ void send_statistics(const char *action, const char *action_result, const char *
         analytics_data.netdata_config_is_private_registry,
         analytics_data.netdata_config_use_private_registry,
         analytics_data.netdata_config_oom_score,
-        analytics_data.netdata_prebuilt_distro);
+        analytics_data.netdata_prebuilt_distro,
+        fail_reason);
 
     netdata_log_info("%s '%s' '%s' '%s'", as_script, action, action_result, action_data);
 

--- a/daemon/anonymous-statistics.sh.in
+++ b/daemon/anonymous-statistics.sh.in
@@ -69,6 +69,7 @@ NETDATA_USE_PRIVATE_REGISTRY="${40}"
 NETDATA_CONFIG_OOM_SCORE="${41}"
 NETDATA_PREBUILT_DISTRO="${42}"
 
+[ ! -z "${43}" ] && NETDATA_FAIL_REASON=", \"netdata_fail_reason\": \"${43}\""
 [ -z "$NETDATA_REGISTRY_UNIQUE_ID" ] && NETDATA_REGISTRY_UNIQUE_ID="00000000-0000-0000-0000-000000000000"
 
 KERNEL_NAME="$(uname -s)"
@@ -176,6 +177,7 @@ REQ_BODY="$(cat << EOF
         "mirrored_hosts_reachable": ${NETDATA_MIRRORED_HOSTS_REACHABLE},
         "mirrored_hosts_unreachable": ${NETDATA_MIRRORED_HOSTS_UNREACHABLE},
         "exporting_connectors": ${NETDATA_EXPORTING_CONNECTORS}
+        ${NETDATA_FAIL_REASON}
   }
 }
 EOF

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -323,6 +323,7 @@ int init_database_batch(sqlite3 *database, int rebuild, int init_type, const cha
         if (rc != SQLITE_OK) {
             error_report("SQLite error during database %s, rc = %d (%s)", init_type ? "cleanup" : "setup", rc, err_msg);
             error_report("SQLite failed statement %s", batch[i]);
+            setenv("NETDATA_FAIL_REASON", err_msg, 1);
             sqlite3_free(err_msg);
             if (SQLITE_CORRUPT == rc) {
                 if (!rebuild)
@@ -397,6 +398,7 @@ int sql_init_database(db_check_action_type_t rebuild, int memory)
     rc = sqlite3_open(sqlite_database, &db_meta);
     if (rc != SQLITE_OK) {
         error_report("Failed to initialize database at %s, due to \"%s\"", sqlite_database, sqlite3_errstr(rc));
+        setenv("NETDATA_FAIL_REASON", sqlite3_errstr(rc), 1);
         sqlite3_close(db_meta);
         db_meta = NULL;
         return 1;


### PR DESCRIPTION
##### Summary
When sending statistics, get if NETDATA_FAIL_REASON environment variable has been set. It should have a more detail fail reason (if possible) to help debugging. 

For now this will be set if the metadata database fails to initialize properly. 
