### PR TITLE
Skip copying environment/install-type files when checking existing installs.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -881,9 +881,8 @@ detect_existing_install() {
   if [ -n "${ndprefix}" ]; then
     typefile="${ndprefix}/etc/netdata/.install-type"
     if [ -r "${typefile}" ]; then
-      run_as_root sh -c "cat \"${typefile}\" > \"${tmpdir}/install-type\""
       # shellcheck disable=SC1090,SC1091
-      . "${tmpdir}/install-type"
+      . "${typefile}"
     else
       INSTALL_TYPE="unknown"
     fi
@@ -891,9 +890,8 @@ detect_existing_install() {
     envfile="${ndprefix}/etc/netdata/.environment"
     if [ "${INSTALL_TYPE}" = "unknown" ] || [ "${INSTALL_TYPE}" = "custom" ]; then
       if [ -r "${envfile}" ]; then
-        run_as_root sh -c "cat \"${envfile}\" > \"${tmpdir}/environment\""
-        # shellcheck disable=SC1091
-        . "${tmpdir}/environment"
+        # shellcheck disable=SC1090,SC1091
+        . "${envfile}"
         if [ -n "${NETDATA_IS_STATIC_INSTALL}" ]; then
           if [ "${NETDATA_IS_STATIC_INSTALL}" = "yes" ]; then
             INSTALL_TYPE="legacy-static"


### PR DESCRIPTION
##### Summary

The existing code fails in dry run mode because it blindly expects the files to be copied. However, we don’t actually need to copy them at all since we just want to read them.

##### Test Plan

The failure cases here are only seen when running in dry-run mode against an existing install. Without this PR, such a run of the kickstart script should fail in a manner like what is reported in #15875. With this PR, the run should complete successfully.

##### Additional Information

Fixes: #15875