### PR TITLE
allow any field to be a facet

### DIFF
--- a/libnetdata/facets/facets.h
+++ b/libnetdata/facets/facets.h
@@ -34,8 +34,8 @@ void facets_string_hash(const char *src, size_t len, char *out);
 
 typedef void (*facets_key_transformer_t)(FACETS *facets __maybe_unused, BUFFER *wb, void *data);
 typedef void (*facet_dynamic_row_t)(FACETS *facets, BUFFER *json_array, FACET_ROW_KEY_VALUE *rkv, FACET_ROW *row, void *data);
-FACET_KEY *facets_register_dynamic_key(FACETS *facets, const char *key, FACET_KEY_OPTIONS options, facet_dynamic_row_t cb, void *data);
-FACET_KEY *facets_register_key_transformation(FACETS *facets, const char *key, FACET_KEY_OPTIONS options, facets_key_transformer_t cb, void *data);
+FACET_KEY *facets_register_dynamic_key_name(FACETS *facets, const char *key, FACET_KEY_OPTIONS options, facet_dynamic_row_t cb, void *data);
+FACET_KEY *facets_register_key_name_transformation(FACETS *facets, const char *key, FACET_KEY_OPTIONS options, facets_key_transformer_t cb, void *data);
 
 typedef enum __attribute__((packed)) {
     FACETS_OPTION_ALL_FACETS_VISIBLE    = (1 << 0), // all facets, should be visible by default in the table
@@ -50,11 +50,12 @@ void facets_accepted_param(FACETS *facets, const char *param);
 void facets_rows_begin(FACETS *facets);
 void facets_row_finished(FACETS *facets, usec_t usec);
 
-FACET_KEY *facets_register_key(FACETS *facets, const char *param, FACET_KEY_OPTIONS options);
+FACET_KEY *facets_register_key_name(FACETS *facets, const char *key, FACET_KEY_OPTIONS options);
 void facets_set_query(FACETS *facets, const char *query);
 void facets_set_items(FACETS *facets, uint32_t items);
 void facets_set_anchor(FACETS *facets, usec_t anchor);
-void facets_register_facet_filter(FACETS *facets, const char *key_id, char *value_ids, FACET_KEY_OPTIONS options);
+FACET_KEY *facets_register_facet_id(FACETS *facets, const char *key_id, FACET_KEY_OPTIONS options);
+void facets_register_facet_id_filter(FACETS *facets, const char *key_id, char *value_ids, FACET_KEY_OPTIONS options);
 void facets_set_histogram(FACETS *facets, const char *chart, usec_t after_ut, usec_t before_ut);
 
 void facets_add_key_value(FACETS *facets, const char *key, const char *value);


### PR DESCRIPTION
In systemd-journal we have the following problem:

1. Many fields are useless for facets, almost all their values are unique, like timestamps, or IDs of some kind.
2. Because of this, there is a hard-coded list of keys that is "interesting" for facets.
3. But since this list is hard-coded, how can a user turn a field he/she is interested to a facet?

To solve the problem, a new function parameter called `facets` is accepted, which gets a comma separated list of the key IDs, which should be treated as facets.