### PR TITLE
Add a summary field to alerts

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1062,6 +1062,7 @@ typedef struct health {
     uint32_t health_default_warn_repeat_every;     // the default value for the interval between repeating warning notifications
     uint32_t health_default_crit_repeat_every;     // the default value for the interval between repeating critical notifications
     unsigned int health_enabled;                   // 1 when this host has health enabled
+    bool use_summary_for_notifications;            // whether or not to use the summary field as a subject for notifications
 } HEALTH;
 
 // ----------------------------------------------------------------------------

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1002,6 +1002,7 @@ struct alarm_entry {
 
     STRING *source;
     STRING *units;
+    STRING *summary;
     STRING *info;
 
     NETDATA_DOUBLE old_value;
@@ -1038,6 +1039,7 @@ struct alarm_entry {
 #define ae_recipient(ae) string2str((ae)->recipient)
 #define ae_source(ae) string2str((ae)->source)
 #define ae_units(ae) string2str((ae)->units)
+#define ae_summary(ae) string2str((ae)->summary)
 #define ae_info(ae) string2str((ae)->info)
 #define ae_old_value_string(ae) string2str((ae)->old_value_string)
 #define ae_new_value_string(ae) string2str((ae)->new_value_string)

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -98,7 +98,7 @@ uint32_t rrdcalc_get_unique_id(RRDHOST *host, STRING *chart, STRING *name, uint3
 }
 
 // ----------------------------------------------------------------------------
-// RRDCALC replacing info text variables with RRDSET labels
+// RRDCALC replacing info/summary text variables with RRDSET labels
 
 static STRING *rrdcalc_replace_variables_with_rrdset_labels(const char *line, RRDCALC *rc) {
     if (!line || !*line)
@@ -158,9 +158,17 @@ void rrdcalc_update_info_using_rrdset_labels(RRDCALC *rc) {
     size_t labels_version = rrdlabels_version(rc->rrdset->rrdlabels);
     if(rc->labels_version != labels_version) {
 
-        STRING *old = rc->info;
-        rc->info = rrdcalc_replace_variables_with_rrdset_labels(rrdcalc_original_info(rc), rc);
-        string_freez(old);
+        if (rc->original_info) {
+            STRING *old = rc->info;
+            rc->info = rrdcalc_replace_variables_with_rrdset_labels(rrdcalc_original_info(rc), rc);
+            string_freez(old);
+        }
+
+         if (rc->original_summary) {
+            STRING *old = rc->summary;
+            rc->summary = rrdcalc_replace_variables_with_rrdset_labels(rrdcalc_original_summary(rc), rc);
+            string_freez(old);
+        }
 
         rc->labels_version = labels_version;
     }
@@ -285,6 +293,11 @@ static void rrdcalc_link_to_rrdset(RRDSET *st, RRDCALC *rc) {
 
     rrdcalc_update_info_using_rrdset_labels(rc);
 
+    if(!rc->summary) {
+        rc->summary = string_dup(rc->name);
+        rc->original_summary = string_dup(rc->name);
+    }
+
     time_t now = now_realtime_sec();
 
     ALARM_ENTRY *ae = health_create_alarm_entry(
@@ -310,6 +323,7 @@ static void rrdcalc_link_to_rrdset(RRDSET *st, RRDCALC *rc) {
         rc->status,
         rc->source,
         rc->units,
+        rc->summary,
         rc->info,
         0,
         rrdcalc_isrepeating(rc)?HEALTH_ENTRY_FLAG_IS_REPEATING:0);
@@ -355,6 +369,7 @@ static void rrdcalc_unlink_from_rrdset(RRDCALC *rc, bool having_ll_wrlock) {
             RRDCALC_STATUS_REMOVED,
             rc->source,
             rc->units,
+            rc->summary,
             rc->info,
             0,
             0);
@@ -510,6 +525,11 @@ static void rrdcalc_rrdhost_insert_callback(const DICTIONARY_ITEM *item __maybe_
         rc->units = string_dup(rt->units);
         rc->info = string_dup(rt->info);
         rc->original_info = string_dup(rt->info);
+
+        if (!rt->summary)
+            rt->summary = string_dup(rc->name);
+        rc->summary = string_dup(rt->summary);
+        rc->original_summary = string_dup(rt->summary);
 
         rc->classification = string_dup(rt->classification);
         rc->component = string_dup(rt->component);

--- a/database/rrdcalc.h
+++ b/database/rrdcalc.h
@@ -64,8 +64,10 @@ struct rrdcalc {
 
     STRING *source;                 // the source of this alarm
     STRING *units;                  // the units of the alarm
+    STRING *summary;                // a short alert summary
+    STRING *original_summary;       // the original summary field before any variable replacement
     STRING *original_info;          // the original info field before any variable replacement
-    STRING *info;                   // a short description of the alarm
+    STRING *info;                   // a description of the alarm
 
     int update_every;               // update frequency for the alarm
 
@@ -170,6 +172,8 @@ struct rrdcalc {
 #define rrdcalc_module_match(rc) string2str((rc)->module_match)
 #define rrdcalc_source(rc) string2str((rc)->source)
 #define rrdcalc_units(rc) string2str((rc)->units)
+#define rrdcalc_original_summary(rc) string2str((rc)->original_summary)
+#define rrdcalc_summary(rc) string2str((rc)->summary)
 #define rrdcalc_original_info(rc) string2str((rc)->original_info)
 #define rrdcalc_info(rc) string2str((rc)->info)
 #define rrdcalc_dimensions(rc) string2str((rc)->dimensions)
@@ -206,6 +210,7 @@ struct alert_config {
     STRING *exec;
     STRING *to;
     STRING *units;
+    STRING *summary;
     STRING *info;
     STRING *classification;
     STRING *component;

--- a/database/rrdcalctemplate.h
+++ b/database/rrdcalctemplate.h
@@ -36,7 +36,8 @@ struct rrdcalctemplate {
 
     STRING *source;                 // the source of this alarm
     STRING *units;                  // the units of the alarm
-    STRING *info;                   // a short description of the alarm
+    STRING *summary;                // a short summary of the alarm
+    STRING *info;                   // a description of the alarm
 
     int update_every;               // update frequency for the alarm
 
@@ -105,6 +106,7 @@ struct rrdcalctemplate {
 #define rrdcalctemplate_module_match(rt) string2str((rt)->module_match)
 #define rrdcalctemplate_charts_match(rt) string2str((rt)->charts_match)
 #define rrdcalctemplate_units(rt) string2str((rt)->units)
+#define rrdcalctemplate_summary(rt) string2str((rt)->summary)
 #define rrdcalctemplate_info(rt) string2str((rt)->info)
 #define rrdcalctemplate_source(rt) string2str((rt)->source)
 #define rrdcalctemplate_dimensions(rt) string2str((rt)->dimensions)

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -330,7 +330,7 @@ static int do_migration_v11_v12(sqlite3 *database, const char *name)
 
     if (table_exists_in_database("health_log_detail") && !column_exists_in_table("health_log_detail", "summary") &&
         table_exists_in_database("alert_hash") && !column_exists_in_table("alert_hash", "summary"))
-        rc = init_database_batch(database, DB_CHECK_NONE, 0, &database_migrate_v11_v12[0]);
+        rc = init_database_batch(database, &database_migrate_v11_v12[0]);
 
     if (!rc) {
         snprintfz(sql, 2047, "UPDATE health_log_detail SET summary = (select name from health_log where health_log_id = health_log_detail.health_log_id);");

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -321,9 +321,9 @@ static int do_migration_v10_v11(sqlite3 *database, const char *name)
     return 0;
 }
 
+#define MIGR_11_12_UPD_HEALTH_LOG_DETAIL "UPDATE health_log_detail SET summary = (select name from health_log where health_log_id = health_log_detail.health_log_id);"
 static int do_migration_v11_v12(sqlite3 *database, const char *name)
 {
-    char sql[2048];
     int rc = 0;
 
     netdata_log_info("Running \"%s\" database migration", name);
@@ -332,10 +332,8 @@ static int do_migration_v11_v12(sqlite3 *database, const char *name)
         table_exists_in_database("alert_hash") && !column_exists_in_table("alert_hash", "summary"))
         rc = init_database_batch(database, &database_migrate_v11_v12[0]);
 
-    if (!rc) {
-        snprintfz(sql, 2047, "UPDATE health_log_detail SET summary = (select name from health_log where health_log_id = health_log_detail.health_log_id);");
-        sqlite3_exec_monitored(database, sql, 0, 0, NULL);
-    }
+    if (!rc)
+        sqlite3_exec_monitored(database, MIGR_11_12_UPD_HEALTH_LOG_DETAIL, 0, 0, NULL);
 
     return rc;
 }

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -88,6 +88,12 @@ const char *database_migrate_v10_v11[] = {
     NULL
 };
 
+const char *database_migrate_v11_v12[] = {
+    "ALTER TABLE health_log_detail ADD summary TEXT;",
+    "ALTER TABLE alert_hash ADD summary TEXT;",
+    NULL
+};
+
 static int do_migration_v1_v2(sqlite3 *database, const char *name)
 {
     UNUSED(name);
@@ -315,6 +321,17 @@ static int do_migration_v10_v11(sqlite3 *database, const char *name)
     return 0;
 }
 
+static int do_migration_v11_v12(sqlite3 *database, const char *name)
+{
+    netdata_log_info("Running \"%s\" database migration", name);
+
+    if (table_exists_in_database("health_log") && !column_exists_in_table("health_log", "summary") &&
+        table_exists_in_database("alert_hash") && !column_exists_in_table("alert_hash", "summary"))
+        return init_database_batch(database, DB_CHECK_NONE, 0, &database_migrate_v11_v12[0]);
+
+    return 0;
+}
+
 static int do_migration_noop(sqlite3 *database, const char *name)
 {
     UNUSED(database);
@@ -369,6 +386,7 @@ DATABASE_FUNC_MIGRATION_LIST migration_action[] = {
     {.name = "v8 to v9",  .func = do_migration_v8_v9},
     {.name = "v9 to v10",  .func = do_migration_v9_v10},
     {.name = "v10 to v11",  .func = do_migration_v10_v11},
+    {.name = "v11 to v12",  .func = do_migration_v11_v12},
     // the terminator of this array
     {.name = NULL, .func = NULL}
 };

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -4,7 +4,7 @@
 #include "sqlite3recover.h"
 #include "sqlite_db_migration.h"
 
-#define DB_METADATA_VERSION 11
+#define DB_METADATA_VERSION 12
 
 const char *database_config[] = {
     "CREATE TABLE IF NOT EXISTS host(host_id BLOB PRIMARY KEY, hostname TEXT NOT NULL, "
@@ -33,7 +33,7 @@ const char *database_config[] = {
     "every text, units text, calc text, families text, plugin text, module text, charts text, green text, "
     "red text, warn text, crit text, exec text, to_key text, info text, delay text, options text, "
     "repeat text, host_labels text, p_db_lookup_dimensions text, p_db_lookup_method text, p_db_lookup_options int, "
-    "p_db_lookup_after int, p_db_lookup_before int, p_update_every int, source text, chart_labels text);",
+    "p_db_lookup_after int, p_db_lookup_before int, p_update_every int, source text, chart_labels text, summary text);",
 
     "CREATE TABLE IF NOT EXISTS host_info(host_id blob, system_key text NOT NULL, system_value text NOT NULL, "
     "date_created INT, PRIMARY KEY(host_id, system_key));",
@@ -54,7 +54,7 @@ const char *database_config[] = {
     "updated_by_id int, updates_id int, when_key int, duration int, non_clear_duration int, "
     "flags int, exec_run_timestamp int, delay_up_to_timestamp int, "
     "info text, exec_code int, new_status real, old_status real, delay int, "
-    "new_value double, old_value double, last_repeat int, transition_id blob, global_id int);",
+    "new_value double, old_value double, last_repeat int, transition_id blob, global_id int, summary text);",
 
     "CREATE INDEX IF NOT EXISTS health_log_d_ind_2 ON health_log_detail (global_id);",
     "CREATE INDEX IF NOT EXISTS health_log_d_ind_3 ON health_log_detail (transition_id);",

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -346,7 +346,7 @@ static void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae) {
         goto failed;
     }
 
-    rc = sqlite3_bind_string_or_null(res, ae->summary, 23);
+    rc = SQLITE3_BIND_STRING_OR_NULL(res, ae->summary, 23);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to bind summary parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
         goto failed;
@@ -1139,7 +1139,7 @@ int sql_store_alert_config_hash(uuid_t *hash_id, struct alert_config *cfg)
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = sqlite3_bind_string_or_null(res, cfg->summary, ++param);
+    rc = SQLITE3_BIND_STRING_OR_NULL(res, cfg->summary, ++param);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -895,11 +895,7 @@ void sql_health_alarm_log_load(RRDHOST *host)
             ae->global_id = sqlite3_column_int64(res, 32);
 
         ae->chart_name = SQLITE3_COLUMN_STRINGDUP_OR_NULL(res, 33);
-
-        if (sqlite3_column_type(res, 34) != SQLITE_NULL)
-            ae->summary = string_strdupz((char *) sqlite3_column_text(res, 34));
-        else
-            ae->summary = NULL;
+        ae->summary = SQLITE3_COLUMN_STRINGDUP_OR_NULL(res, 34);
 
         char value_string[100 + 1];
         string_freez(ae->old_value_string);

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -105,9 +105,8 @@ failed:
 #define SQL_INSERT_HEALTH_LOG_DETAIL                                                                                        \
     "INSERT INTO health_log_detail (health_log_id, unique_id, alarm_id, alarm_event_id, "                                   \
     "updated_by_id, updates_id, when_key, duration, non_clear_duration, flags, exec_run_timestamp, delay_up_to_timestamp, " \
-    "info, exec_code, new_status, old_status, delay, new_value, old_value, last_repeat, transition_id, global_id) "         \
-    "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,@global_id); "
-
+    "info, exec_code, new_status, old_status, delay, new_value, old_value, last_repeat, transition_id, global_id, summary) " \
+    "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,@global_id,?); "
 static void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae) {
     sqlite3_stmt *res = NULL;
     int rc;
@@ -347,6 +346,12 @@ static void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae) {
         goto failed;
     }
 
+    rc = sqlite3_bind_string_or_null(res, ae->summary, 23);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind summary parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
     rc = execute_insert(res);
     if (unlikely(rc != SQLITE_DONE)) {
         error_report("HEALTH [%s]: Failed to execute SQL_INSERT_HEALTH_LOG_DETAIL, rc = %d", rrdhost_hostname(host), rc);
@@ -500,9 +505,9 @@ done:
 #define SQL_INJECT_REMOVED                                                                                                      \
     "insert into health_log_detail (health_log_id, unique_id, alarm_id, alarm_event_id, updated_by_id, updates_id, when_key, "  \
     "duration, non_clear_duration, flags, exec_run_timestamp, delay_up_to_timestamp, info, exec_code, new_status, old_status, " \
-    "delay, new_value, old_value, last_repeat, transition_id, global_id) "                                                      \
+    "delay, new_value, old_value, last_repeat, transition_id, global_id, summary) "                                             \
     "select health_log_id, ?1, ?2, ?3, 0, ?4, unixepoch(), 0, 0, flags, exec_run_timestamp, unixepoch(), info, exec_code, -2, " \
-    "new_status, delay, NULL, new_value, 0, ?5, now_usec(0) from health_log_detail where unique_id = ?6 and transition_id = ?7;"
+    "new_status, delay, NULL, new_value, 0, ?5, now_usec(0), summary from health_log_detail where unique_id = ?6 and transition_id = ?7;"
 
 #define SQL_INJECT_REMOVED_UPDATE_DETAIL "update health_log_detail set flags = flags | ?1, updated_by_id = ?2 where unique_id = ?3 and transition_id = ?4;"
 
@@ -742,7 +747,7 @@ void sql_check_removed_alerts_state(RRDHOST *host)
             "hld.updates_id, hld.when_key, hld.duration, hld.non_clear_duration, hld.flags, hld.exec_run_timestamp, " \
             "hld.delay_up_to_timestamp, hl.name, hl.chart, hl.family, hl.exec, hl.recipient, ah.source, hl.units, " \
             "hld.info, hld.exec_code, hld.new_status, hld.old_status, hld.delay, hld.new_value, hld.old_value, " \
-            "hld.last_repeat, ah.class, ah.component, ah.type, hl.chart_context, hld.transition_id, hld.global_id, hl.chart_name " \
+            "hld.last_repeat, ah.class, ah.component, ah.type, hl.chart_context, hld.transition_id, hld.global_id, hl.chart_name, hld.summary " \
             "FROM health_log hl, alert_hash ah, health_log_detail hld " \
             "WHERE hl.config_hash_id = ah.hash_id and hl.host_id = @host_id and hl.last_transition_id = hld.transition_id;"
 
@@ -891,6 +896,11 @@ void sql_health_alarm_log_load(RRDHOST *host)
 
         ae->chart_name = SQLITE3_COLUMN_STRINGDUP_OR_NULL(res, 33);
 
+        if (sqlite3_column_type(res, 34) != SQLITE_NULL)
+            ae->summary = string_strdupz((char *) sqlite3_column_text(res, 34));
+        else
+            ae->summary = NULL;
+
         char value_string[100 + 1];
         string_freez(ae->old_value_string);
         string_freez(ae->new_value_string);
@@ -940,8 +950,8 @@ void sql_health_alarm_log_load(RRDHOST *host)
     "on_key, class, component, type, os, hosts, lookup, every, units, calc, families, plugin, module, " \
     "charts, green, red, warn, crit, exec, to_key, info, delay, options, repeat, host_labels, " \
     "p_db_lookup_dimensions, p_db_lookup_method, p_db_lookup_options, p_db_lookup_after, " \
-    "p_db_lookup_before, p_update_every, source, chart_labels) values (?1,unixepoch(),?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12," \
-    "?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26,?27,?28,?29,?30,?31,?32,?33,?34,?35,?36);"
+    "p_db_lookup_before, p_update_every, source, chart_labels, summary) values (?1,unixepoch(),?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12," \
+    "?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26,?27,?28,?29,?30,?31,?32,?33,?34,?35,?36,?37);"
 
 int sql_store_alert_config_hash(uuid_t *hash_id, struct alert_config *cfg)
 {
@@ -1129,6 +1139,10 @@ int sql_store_alert_config_hash(uuid_t *hash_id, struct alert_config *cfg)
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
+    rc = sqlite3_bind_string_or_null(res, cfg->summary, ++param);
+    if (unlikely(rc != SQLITE_OK))
+        goto bind_fail;
+
     rc = execute_insert(res);
     if (unlikely(rc != SQLITE_DONE))
         error_report("Failed to store alert config, rc = %d", rc);
@@ -1195,6 +1209,7 @@ int alert_hash_and_store_config(
     DIGEST_ALERT_CONFIG_VAL(cfg->repeat);
     DIGEST_ALERT_CONFIG_VAL(cfg->host_labels);
     DIGEST_ALERT_CONFIG_VAL(cfg->chart_labels);
+    DIGEST_ALERT_CONFIG_VAL(cfg->summary);
 
     EVP_DigestFinal_ex(evpctx, hash_value, &hash_len);
     EVP_MD_CTX_destroy(evpctx);
@@ -1275,8 +1290,8 @@ done:
      "hld.when_key, hld.duration, hld.non_clear_duration, hld.flags, hld.exec_run_timestamp, "                         \
      "hld.delay_up_to_timestamp, hl.name, hl.chart, hl.family, hl.exec, hl.recipient, ah.source, "                     \
      "hl.units, hld.info, hld.exec_code, hld.new_status, hld.old_status, hld.delay, hld.new_value, hld.old_value, "    \
-     "hld.last_repeat, ah.class, ah.component, ah.type, hl.chart_context, hld.transition_id FROM health_log hl, "      \
-     "alert_hash ah, health_log_detail hld WHERE hl.config_hash_id = ah.hash_id and "                                  \
+     "hld.last_repeat, ah.class, ah.component, ah.type, hl.chart_context, hld.transition_id, hld.summary "             \
+     "FROM health_log hl, alert_hash ah, health_log_detail hld WHERE hl.config_hash_id = ah.hash_id and "              \
      "hl.health_log_id = hld.health_log_id and hl.host_id = @host_id "
 
 void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *chart) {
@@ -1424,6 +1439,7 @@ void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *
             (long unsigned int)sqlite3_column_int64(res, 26),
             (sqlite3_column_int64(res, 9) & HEALTH_ENTRY_FLAG_SILENCED)?"true":"false");
 
+        health_string2json(wb, "\t\t", "summary", (char *) sqlite3_column_text(res, 32), ",\n");
         health_string2json(wb, "\t\t", "info", (char *) sqlite3_column_text(res, 19), ",\n");
 
         if(unlikely(sqlite3_column_int64(res, 9) & HEALTH_ENTRY_FLAG_NO_CLEAR_NOTIFICATION)) {

--- a/health/health.c
+++ b/health/health.c
@@ -1157,6 +1157,7 @@ void *health_main(void *ptr) {
                                                                     RRDCALC_STATUS_REMOVED,
                                                                     rc->source,
                                                                     rc->units,
+                                                                    rc->summary,
                                                                     rc->info,
                                                                     0,
                                                                     rrdcalc_isrepeating(rc)?HEALTH_ENTRY_FLAG_IS_REPEATING:0);
@@ -1424,6 +1425,7 @@ void *health_main(void *ptr) {
                                                                     status,
                                                                     rc->source,
                                                                     rc->units,
+                                                                    rc->summary,
                                                                     rc->info,
                                                                     rc->delay_last,
                                                                     (
@@ -1511,6 +1513,7 @@ void *health_main(void *ptr) {
                                                                     rc->status,
                                                                     rc->source,
                                                                     rc->units,
+                                                                    rc->summary,
                                                                     rc->info,
                                                                     rc->delay_last,
                                                                     (

--- a/health/health.c
+++ b/health/health.c
@@ -82,7 +82,8 @@ static bool prepare_command(BUFFER *wb,
                             const char *classification,
                             const char *edit_command,
                             const char *machine_guid,
-                            uuid_t *transition_id
+                            uuid_t *transition_id,
+                            const char *summary
 ) {
     char buf[8192];
     size_t n = 8192 - 1;
@@ -192,6 +193,10 @@ static bool prepare_command(BUFFER *wb,
     char tr_id[UUID_STR_LEN];
     uuid_unparse_lower(*transition_id, tr_id);
     if (!sanitize_command_argument_string(buf, tr_id, n))
+        return false;
+    buffer_sprintf(wb, " '%s'", buf);
+
+    if (!sanitize_command_argument_string(buf, summary, n))
         return false;
     buffer_sprintf(wb, " '%s'", buf);
 
@@ -581,7 +586,8 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
                               ae->classification?ae_classification(ae):"Unknown",
                               edit_command,
                               host->machine_guid,
-                              &ae->transition_id);
+                              &ae->transition_id,
+                              host->health.use_summary_for_notifications && ae->summary?ae_summary(ae):ae_name(ae));
 
     const char *command_to_run = buffer_tostring(wb);
     if (ok) {
@@ -835,6 +841,7 @@ static void initialize_health(RRDHOST *host)
     snprintfz(filename, FILENAME_MAX, "%s/alarm-notify.sh", netdata_configured_primary_plugins_dir);
     host->health.health_default_exec = string_strdupz(config_get(CONFIG_SECTION_HEALTH, "script to execute on alarm", filename));
     host->health.health_default_recipient = string_strdupz("root");
+    host->health.use_summary_for_notifications = config_get_boolean(CONFIG_SECTION_HEALTH, "use summary for notifications", CONFIG_BOOLEAN_YES);
 
     sql_health_alarm_log_load(host);
 

--- a/health/health.d/btrfs.conf
+++ b/health/health.d/btrfs.conf
@@ -11,7 +11,8 @@ component: File system
     every: 10s
      warn: $this > (($status == $CRITICAL) ? (95) : (98))
     delay: up 1m down 15m multiplier 1.5 max 1h
-     info: percentage of allocated BTRFS physical disk space
+  summary: BTRFS space allocated
+     info: Percentage of allocated BTRFS physical disk space
        to: silent
 
  template: btrfs_data
@@ -27,7 +28,8 @@ component: File system
      warn: $this > (($status >= $WARNING)  ? (90) : (95)) && $btrfs_allocated > 98
      crit: $this > (($status == $CRITICAL) ? (95) : (98)) && $btrfs_allocated > 98
     delay: up 1m down 15m multiplier 1.5 max 1h
-     info: utilization of BTRFS data space
+  summary: BTRFS space utilization
+     info: Utilization of BTRFS data space
        to: sysadmin
 
  template: btrfs_metadata
@@ -43,7 +45,8 @@ component: File system
      warn: $this > (($status >= $WARNING)  ? (90) : (95)) && $btrfs_allocated > 98
      crit: $this > (($status == $CRITICAL) ? (95) : (98)) && $btrfs_allocated > 98
     delay: up 1m down 15m multiplier 1.5 max 1h
-     info: utilization of BTRFS metadata space
+  summary: BTRFS metadata space utilization
+     info: Utilization of BTRFS metadata space
        to: sysadmin
 
  template: btrfs_system
@@ -59,7 +62,8 @@ component: File system
      warn: $this > (($status >= $WARNING)  ? (90) : (95)) && $btrfs_allocated > 98
      crit: $this > (($status == $CRITICAL) ? (95) : (98)) && $btrfs_allocated > 98
     delay: up 1m down 15m multiplier 1.5 max 1h
-     info: utilization of BTRFS system space
+  summary: BTRFS system space utilization
+     info: Utilization of BTRFS system space
        to: sysadmin
 
  template: btrfs_device_read_errors
@@ -73,7 +77,8 @@ component: File system
    lookup: max -10m every 1m of read_errs
      warn: $this > 0
     delay: up 1m down 15m multiplier 1.5 max 1h
-     info: number of encountered BTRFS read errors
+  summary: BTRFS device read errors
+     info: Number of encountered BTRFS read errors
        to: sysadmin
 
  template: btrfs_device_write_errors
@@ -87,7 +92,8 @@ component: File system
    lookup: max -10m every 1m of write_errs
      crit: $this > 0
     delay: up 1m down 15m multiplier 1.5 max 1h
-     info: number of encountered BTRFS write errors
+  summary: BTRFS device write errors
+     info: Number of encountered BTRFS write errors
        to: sysadmin
 
  template: btrfs_device_flush_errors
@@ -101,7 +107,8 @@ component: File system
    lookup: max -10m every 1m of flush_errs
      crit: $this > 0
     delay: up 1m down 15m multiplier 1.5 max 1h
-     info: number of encountered BTRFS flush errors
+  summary: BTRFS device flush errors
+     info: Number of encountered BTRFS flush errors
        to: sysadmin
 
  template: btrfs_device_corruption_errors
@@ -115,7 +122,8 @@ component: File system
    lookup: max -10m every 1m of corruption_errs
      warn: $this > 0
     delay: up 1m down 15m multiplier 1.5 max 1h
-     info: number of encountered BTRFS corruption errors
+  summary: BTRFS device corruption errors
+     info: Number of encountered BTRFS corruption errors
        to: sysadmin
 
  template: btrfs_device_generation_errors
@@ -129,5 +137,6 @@ component: File system
    lookup: max -10m every 1m of generation_errs
      warn: $this > 0
     delay: up 1m down 15m multiplier 1.5 max 1h
-     info: number of encountered BTRFS generation errors
+  summary: BTRFS device generation errors
+     info: Number of encountered BTRFS generation errors
        to: sysadmin

--- a/health/health.d/cgroups.conf
+++ b/health/health.d/cgroups.conf
@@ -13,7 +13,8 @@ component: CPU
     every: 1m
      warn: $this > (($status == $CRITICAL) ? (85) : (95))
     delay: down 15m multiplier 1.5 max 1h
-     info: average cgroup CPU utilization over the last 10 minutes
+  summary: Cgroup CPU utilization
+     info: Average cgroup CPU utilization over the last 10 minutes
        to: silent
 
  template: cgroup_ram_in_use
@@ -29,7 +30,8 @@ component: Memory
      warn: $this > (($status >= $WARNING)  ? (80) : (90))
      crit: $this > (($status == $CRITICAL) ? (90) : (98))
     delay: down 15m multiplier 1.5 max 1h
-     info: cgroup memory utilization
+  summary: Cgroup ram utilization
+     info: Cgroup memory utilization
        to: silent
 
 # FIXME COMMENTED DUE TO A BUG IN NETDATA
@@ -83,7 +85,8 @@ component: CPU
     every: 1m
      warn: $this > (($status >= $WARNING)  ? (75) : (85))
     delay: down 15m multiplier 1.5 max 1h
-     info: container ${label:k8s_container_name} of pod ${label:k8s_pod_name} of namespace ${label:k8s_namespace}, \
+  summary: Container ${label:k8s_container_name} CPU utilization
+     info: Container ${label:k8s_container_name} of pod ${label:k8s_pod_name} of namespace ${label:k8s_namespace}, \
            average CPU utilization over the last 10 minutes
        to: silent
 
@@ -100,6 +103,7 @@ component: Memory
      warn: $this > (($status >= $WARNING)  ? (80) : (90))
      crit: $this > (($status == $CRITICAL) ? (90) : (98))
     delay: down 15m multiplier 1.5 max 1h
+  summary: Container ${label:k8s_container_name} ram utilization
      info: container ${label:k8s_container_name} of pod ${label:k8s_pod_name} of namespace ${label:k8s_namespace}, \
            memory utilization
        to: silent

--- a/health/health.d/cpu.conf
+++ b/health/health.d/cpu.conf
@@ -14,7 +14,8 @@ component: CPU
      warn: $this > (($status >= $WARNING)  ? (75) : (85))
      crit: $this > (($status == $CRITICAL) ? (85) : (95))
     delay: down 15m multiplier 1.5 max 1h
-     info: average CPU utilization over the last 10 minutes (excluding iowait, nice and steal)
+  summary: CPU utilization
+     info: Average CPU utilization over the last 10 minutes (excluding iowait, nice and steal)
        to: silent
 
  template: 10min_cpu_iowait
@@ -29,7 +30,8 @@ component: CPU
     every: 1m
      warn: $this > (($status >= $WARNING)  ? (20) : (40))
     delay: up 30m down 30m multiplier 1.5 max 2h
-     info: average CPU iowait time over the last 10 minutes
+  summary: CPU iowait time
+     info: Average CPU iowait time over the last 10 minutes
        to: silent
 
  template: 20min_steal_cpu
@@ -44,7 +46,8 @@ component: CPU
     every: 5m
      warn: $this > (($status >= $WARNING)  ? (5)  : (10))
     delay: down 1h multiplier 1.5 max 2h
-     info: average CPU steal time over the last 20 minutes
+  summary: CPU steal time
+     info: Average CPU steal time over the last 20 minutes
        to: silent
 
 ## FreeBSD
@@ -61,5 +64,6 @@ component: CPU
      warn: $this > (($status >= $WARNING)  ? (75) : (85))
      crit: $this > (($status == $CRITICAL) ? (85) : (95))
     delay: down 15m multiplier 1.5 max 1h
-     info: average CPU utilization over the last 10 minutes (excluding nice)
+  summary: CPU utilization
+     info: Average CPU utilization over the last 10 minutes (excluding nice)
        to: silent

--- a/health/health.d/disks.conf
+++ b/health/health.d/disks.conf
@@ -23,7 +23,8 @@ chart labels: mount_point=!/dev !/dev/* !/run !/run/* *
      warn: $this > (($status >= $WARNING ) ? (80) : (90))
      crit: ($this > (($status == $CRITICAL) ? (90) : (98))) && $avail < 5
     delay: up 1m down 15m multiplier 1.5 max 1h
-     info: disk ${label:mount_point} space utilization
+  summary: Disk ${label:mount_point} space usage
+     info: Total space utilization of disk ${label:mount_point}
        to: sysadmin
 
  template: disk_inode_usage
@@ -40,7 +41,8 @@ chart labels: mount_point=!/dev !/dev/* !/run !/run/* *
      warn: $this > (($status >= $WARNING)  ? (80) : (90))
      crit: $this > (($status == $CRITICAL) ? (90) : (98))
     delay: up 1m down 15m multiplier 1.5 max 1h
-     info: disk ${label:mount_point} inode utilization
+  summary: Disk ${label:mount_point} inode usage
+     info: Total inode utilization of disk ${label:mount_point}
        to: sysadmin
 
 
@@ -79,7 +81,8 @@ template: out_of_disk_space_time
     warn: $this > 0 and $this < (($status >= $WARNING)  ? (48) : (8))
     crit: $this > 0 and $this < (($status == $CRITICAL) ? (24) : (2))
    delay: down 15m multiplier 1.2 max 1h
-    info: estimated time the disk will run out of space, if the system continues to add data with the rate of the last hour
+ summary: Out of disk space time for ${label:mount_point}
+    info: estimated time the disk ${label:mount_point} will run out of space, if the system continues to add data with the rate of the last hour
       to: silent
 
 

--- a/health/health.d/disks.conf
+++ b/health/health.d/disks.conf
@@ -145,7 +145,7 @@ component: Disk
     every: 1m
      warn: $this > 98 * (($status >= $WARNING)  ? (0.7) : (1))
     delay: down 15m multiplier 1.2 max 1h
-  summary: 10 minute disk utilization for ${label:device}
+  summary: Disk ${label:device} utilization
      info: Average percentage of time ${label:device} disk was busy over the last 10 minutes
        to: silent
 
@@ -167,6 +167,6 @@ component: Disk
     every: 1m
      warn: $this > 5000 * (($status >= $WARNING)  ? (0.7) : (1))
     delay: down 15m multiplier 1.2 max 1h
-  summary: 10 minute disk backlog for ${label:device}
+  summary: Disk ${label:device} backlog
      info: Average backlog size of the ${label:device} disk over the last 10 minutes
        to: silent

--- a/health/health.d/disks.conf
+++ b/health/health.d/disks.conf
@@ -82,7 +82,7 @@ template: out_of_disk_space_time
     crit: $this > 0 and $this < (($status == $CRITICAL) ? (24) : (2))
    delay: down 15m multiplier 1.2 max 1h
  summary: Out of disk space time for ${label:mount_point}
-    info: estimated time the disk ${label:mount_point} will run out of space, if the system continues to add data with the rate of the last hour
+    info: Estimated time the disk ${label:mount_point} will run out of space, if the system continues to add data with the rate of the last hour
       to: silent
 
 
@@ -121,7 +121,8 @@ template: out_of_disk_inodes_time
     warn: $this > 0 and $this < (($status >= $WARNING)  ? (48) : (8))
     crit: $this > 0 and $this < (($status == $CRITICAL) ? (24) : (2))
    delay: down 15m multiplier 1.2 max 1h
-    info: estimated time the disk will run out of inodes, if the system continues to allocate inodes with the rate of the last hour
+ summary: Out of disk inodes time for ${label:mount_point}
+    info: Estimated time the disk ${label:mount_point} will run out of inodes, if the system continues to allocate inodes with the rate of the last hour
       to: silent
 
 
@@ -144,7 +145,8 @@ component: Disk
     every: 1m
      warn: $this > 98 * (($status >= $WARNING)  ? (0.7) : (1))
     delay: down 15m multiplier 1.2 max 1h
-     info: average percentage of time ${label:device} disk was busy over the last 10 minutes
+  summary: 10 minute disk utilization for ${label:device}
+     info: Average percentage of time ${label:device} disk was busy over the last 10 minutes
        to: silent
 
 
@@ -165,5 +167,6 @@ component: Disk
     every: 1m
      warn: $this > 5000 * (($status >= $WARNING)  ? (0.7) : (1))
     delay: down 15m multiplier 1.2 max 1h
-     info: average backlog size of the ${label:device} disk over the last 10 minutes
+  summary: 10 minute disk backlog for ${label:device}
+     info: Average backlog size of the ${label:device} disk over the last 10 minutes
        to: silent

--- a/health/health.d/docker.conf
+++ b/health/health.d/docker.conf
@@ -7,5 +7,6 @@ component: Docker
     every: 10s
    lookup: average -10s of unhealthy
      warn: $this > 0
+  summary: Docker container ${label:container_name} health
      info: ${label:container_name} docker container health status is unhealthy
        to: sysadmin

--- a/health/health.d/file_descriptors.conf
+++ b/health/health.d/file_descriptors.conf
@@ -11,7 +11,8 @@
      every: 1m
       crit: $this > 90
      delay: down 15m multiplier 1.5 max 1h
-      info: system-wide utilization of open files
+   summary: System open files utilization
+      info: System-wide utilization of open files
         to: sysadmin
 
  template: apps_group_file_descriptors_utilization
@@ -27,5 +28,6 @@ component: Process
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (85) : (95))
     delay: down 15m multiplier 1.5 max 1h
-     info: open files percentage against the processes limits, among all PIDs in application group
+  summary: Group open files utilization
+     info: Open files percentage against the processes limits, among all PIDs in application group
        to: sysadmin

--- a/health/health.d/httpcheck.conf
+++ b/health/health.d/httpcheck.conf
@@ -23,7 +23,8 @@ component: HTTP endpoint
      warn: $this >= 10 AND $this < 40
      crit: $this >= 40
     delay: down 5m multiplier 1.5 max 1h
-     info: percentage of HTTP responses from ${label:url} with unexpected content in the last 5 minutes
+  summary: HTTP check for ${label:url} unexpected content
+     info: Percentage of HTTP responses from ${label:url} with unexpected content in the last 5 minutes
        to: webmaster
 
  template: httpcheck_web_service_bad_status
@@ -37,7 +38,8 @@ component: HTTP endpoint
      warn: $this >= 10 AND $this < 40
      crit: $this >= 40
     delay: down 5m multiplier 1.5 max 1h
-     info: percentage of HTTP responses from ${label:url} with unexpected status in the last 5 minutes
+  summary: HTTP check for ${label:url} unexpected status
+     info: Percentage of HTTP responses from ${label:url} with unexpected status in the last 5 minutes
        to: webmaster
 
  template: httpcheck_web_service_timeouts
@@ -51,7 +53,8 @@ component: HTTP endpoint
      warn: $this >= 10 AND $this < 40
      crit: $this >= 40
     delay: down 5m multiplier 1.5 max 1h
-     info: percentage of timed-out HTTP requests to ${label:url} in the last 5 minutes
+  summary: HTTP check for ${label:url} timeouts
+     info: Percentage of timed-out HTTP requests to ${label:url} in the last 5 minutes
        to: webmaster
 
  template: httpcheck_web_service_no_connection
@@ -65,5 +68,6 @@ component: HTTP endpoint
      warn: $this >= 10 AND $this < 40
      crit: $this >= 40
     delay: down 5m multiplier 1.5 max 1h
-     info: percentage of failed HTTP requests to ${label:url} in the last 5 minutes
+  summary: HTTP check for ${label:url} failed requests
+     info: Percentage of failed HTTP requests to ${label:url} in the last 5 minutes
        to: webmaster

--- a/health/health.d/ipc.conf
+++ b/health/health.d/ipc.conf
@@ -13,6 +13,7 @@ component: IPC
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (70) : (80))
     delay: down 5m multiplier 1.5 max 1h
+  summary: IPC semaphores used
      info: IPC semaphore utilization
        to: sysadmin
 
@@ -28,5 +29,6 @@ component: IPC
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (70) : (80))
     delay: down 5m multiplier 1.5 max 1h
+  summary: IPC semaphore arrays used
      info: IPC semaphore arrays utilization
        to: sysadmin

--- a/health/health.d/ipmi.conf
+++ b/health/health.d/ipmi.conf
@@ -9,6 +9,7 @@ component: IPMI
      warn: $warning > 0
      crit: $critical > 0
     delay: up 5m down 15m multiplier 1.5 max 1h
+  summary: IPMI sensor ${label:sensor} state
      info: IPMI sensor ${label:sensor} (${label:component}) state
        to: sysadmin
 
@@ -22,5 +23,6 @@ component: IPMI
     every: 10s
      warn: $this > 0
     delay: up 5m down 15m multiplier 1.5 max 1h
+  summary: IPMI events
      info: number of events in the IPMI System Event Log (SEL)
        to: silent

--- a/health/health.d/linux_power_supply.conf
+++ b/health/health.d/linux_power_supply.conf
@@ -10,5 +10,6 @@ component: Battery
     every: 10s
      warn: $this < 10
     delay: up 30s down 5m multiplier 1.2 max 1h
-     info: percentage of remaining power supply capacity
+  summary: Power supply capacity
+     info: Percentage of remaining power supply capacity
        to: silent

--- a/health/health.d/load.conf
+++ b/health/health.d/load.conf
@@ -33,7 +33,8 @@ component: Load
     every: 1m
      warn: ($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 175 : 200)
     delay: down 15m multiplier 1.5 max 1h
-     info: system fifteen-minute load average
+  summary: 15 minutes load average
+     info: System load average for the past 15 minutes
        to: silent
 
     alarm: load_average_5
@@ -49,7 +50,8 @@ component: Load
     every: 1m
      warn: ($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 350 : 400)
     delay: down 15m multiplier 1.5 max 1h
-     info: system five-minute load average
+  summary: 5 minutes load average
+     info: System load average for the past 5 minutes
        to: silent
 
     alarm: load_average_1
@@ -65,5 +67,6 @@ component: Load
     every: 1m
      warn: ($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 700 : 800)
     delay: down 15m multiplier 1.5 max 1h
-     info: system one-minute load average
+  summary: 1 minute load average
+     info: System load average for the past 1 minute
        to: silent

--- a/health/health.d/load.conf
+++ b/health/health.d/load.conf
@@ -14,7 +14,7 @@ component: Load
      calc: ($active_processors == nan or $active_processors == 0) ? (nan) : ( ($active_processors < 2) ? ( 2 ) : ( $active_processors ) )
     units: cpus
     every: 1m
-     info: number of active CPU cores in the system
+     info: Number of active CPU cores in the system
 
 # Send alarms if the load average is unusually high.
 # These intentionally _do not_ calculate the average over the sampled
@@ -33,7 +33,7 @@ component: Load
     every: 1m
      warn: ($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 175 : 200)
     delay: down 15m multiplier 1.5 max 1h
-  summary: 15 minutes load average
+  summary: Load average (15 minutes)
      info: System load average for the past 15 minutes
        to: silent
 
@@ -50,7 +50,7 @@ component: Load
     every: 1m
      warn: ($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 350 : 400)
     delay: down 15m multiplier 1.5 max 1h
-  summary: 5 minutes load average
+  summary: Load average (5 minutes)
      info: System load average for the past 5 minutes
        to: silent
 
@@ -67,6 +67,6 @@ component: Load
     every: 1m
      warn: ($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 700 : 800)
     delay: down 15m multiplier 1.5 max 1h
-  summary: 1 minute load average
+  summary: Load average (1 minute)
      info: System load average for the past 1 minute
        to: silent

--- a/health/health.d/mdstat.conf
+++ b/health/health.d/mdstat.conf
@@ -8,7 +8,8 @@ component: RAID
     every: 10s
      calc: $down
      warn: $this > 0
-     info: number of devices in the down state for the ${label:device} ${label:raid_level} array. \
+  summary: Mdtat device ${label:device} down
+     info: Number of devices in the down state for the ${label:device} ${label:raid_level} array. \
            Any number > 0 indicates that the array is degraded.
        to: sysadmin
 
@@ -23,7 +24,8 @@ chart labels: raid_level=!raid1 !raid10 *
     every: 60s
      warn: $this > 1024
     delay: up 30m
-     info: number of unsynchronized blocks for the ${label:device} ${label:raid_level} array
+  summary: Mdstat device ${label:device} unsynchronized blocks
+     info: Number of unsynchronized blocks for the ${label:device} ${label:raid_level} array
        to: silent
 
  template: mdstat_nonredundant_last_collected
@@ -36,5 +38,6 @@ component: RAID
     every: 10s
      warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
      crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
-     info: number of seconds since the last successful data collection
+  summary: Mdstat last collected
+     info: Number of seconds since the last successful data collection
        to: sysadmin

--- a/health/health.d/net.conf
+++ b/health/health.d/net.conf
@@ -29,6 +29,7 @@ component: Network
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (85) : (90))
     delay: up 1m down 1m multiplier 1.5 max 1h
+  summary: 1 minute received traffic overflow for ${label:device}
      info: average inbound utilization for the network interface ${label:device} over the last minute
        to: silent
 
@@ -45,6 +46,7 @@ component: Network
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (85) : (90))
     delay: up 1m down 1m multiplier 1.5 max 1h
+  summary: 1 minute sent traffic overflow for ${label:device}
      info: average outbound utilization for the network interface ${label:device} over the last minute
        to: silent
 
@@ -96,7 +98,8 @@ chart labels: device=!wl* *
     every: 1m
      warn: $this >= 2
     delay: up 1m down 1h multiplier 1.5 max 2h
-     info: ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
+  summary: Inbound packets dropped ratio for ${label:device}
+     info: Ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
        to: silent
 
  template: outbound_packets_dropped_ratio
@@ -113,7 +116,8 @@ chart labels: device=!wl* *
     every: 1m
      warn: $this >= 2
     delay: up 1m down 1h multiplier 1.5 max 2h
-     info: ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
+  summary: Outbound packets dropped ratio for ${label:device}
+     info: Ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
        to: silent
 
  template: wifi_inbound_packets_dropped_ratio
@@ -130,7 +134,8 @@ chart labels: device=wl*
     every: 1m
      warn: $this >= 10
     delay: up 1m down 1h multiplier 1.5 max 2h
-     info: ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
+  summary: Inbound packets dropped ratio for ${label:device}
+     info: Ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
        to: silent
 
  template: wifi_outbound_packets_dropped_ratio
@@ -147,7 +152,8 @@ chart labels: device=wl*
     every: 1m
      warn: $this >= 10
     delay: up 1m down 1h multiplier 1.5 max 2h
-     info: ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
+  summary: Outbound packets dropped ratio for ${label:device}
+     info: Ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
        to: silent
 
 # -----------------------------------------------------------------------------
@@ -165,7 +171,8 @@ component: Network
     every: 1m
      warn: $this >= 5
     delay: down 1h multiplier 1.5 max 2h
-     info: number of inbound errors for the network interface ${label:device} in the last 10 minutes
+  summary: Inbound interface errors for ${label:device}
+     info: Number of inbound errors for the network interface ${label:device} in the last 10 minutes
        to: silent
 
  template: interface_outbound_errors
@@ -180,6 +187,7 @@ component: Network
     every: 1m
      warn: $this >= 5
     delay: down 1h multiplier 1.5 max 2h
+  summary: Outbound interface errors for ${label:device}
      info: number of outbound errors for the network interface ${label:device} in the last 10 minutes
        to: silent
 
@@ -241,6 +249,7 @@ component: Network
      warn: $this > (($status >= $WARNING)?(200):(5000))
      crit: $this > (($status == $CRITICAL)?(5000):(6000))
   options: no-clear-notification
+  summary: 10 sec received packets storm for ${label:device}
      info: ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, \
            compared to the rate over the last minute
        to: silent

--- a/health/health.d/net.conf
+++ b/health/health.d/net.conf
@@ -14,7 +14,7 @@ component: Network
      calc: ( $nic_speed_max > 0 ) ? ( $nic_speed_max) : ( nan )
     units: Mbit
     every: 10s
-     info: network interface ${label:device} current speed
+     info: Network interface ${label:device} current speed
 
  template: 1m_received_traffic_overflow
        on: net.net
@@ -30,7 +30,7 @@ component: Network
      warn: $this > (($status >= $WARNING)  ? (85) : (90))
     delay: up 1m down 1m multiplier 1.5 max 1h
   summary: 1 minute received traffic overflow for ${label:device}
-     info: average inbound utilization for the network interface ${label:device} over the last minute
+     info: Average inbound utilization for the network interface ${label:device} over the last minute
        to: silent
 
  template: 1m_sent_traffic_overflow
@@ -47,7 +47,7 @@ component: Network
      warn: $this > (($status >= $WARNING)  ? (85) : (90))
     delay: up 1m down 1m multiplier 1.5 max 1h
   summary: 1 minute sent traffic overflow for ${label:device}
-     info: average outbound utilization for the network interface ${label:device} over the last minute
+     info: Average outbound utilization for the network interface ${label:device} over the last minute
        to: silent
 
 # -----------------------------------------------------------------------------
@@ -70,7 +70,7 @@ component: Network
    lookup: sum -10m unaligned absolute of inbound
     units: packets
     every: 1m
-     info: number of inbound dropped packets for the network interface ${label:device} in the last 10 minutes
+     info: Number of inbound dropped packets for the network interface ${label:device} in the last 10 minutes
 
  template: outbound_packets_dropped
        on: net.drops
@@ -82,7 +82,7 @@ component: Network
    lookup: sum -10m unaligned absolute of outbound
     units: packets
     every: 1m
-     info: number of outbound dropped packets for the network interface ${label:device} in the last 10 minutes
+     info: Number of outbound dropped packets for the network interface ${label:device} in the last 10 minutes
 
  template: inbound_packets_dropped_ratio
        on: net.packets
@@ -188,7 +188,7 @@ component: Network
      warn: $this >= 5
     delay: down 1h multiplier 1.5 max 2h
   summary: Outbound interface errors for ${label:device}
-     info: number of outbound errors for the network interface ${label:device} in the last 10 minutes
+     info: Number of outbound errors for the network interface ${label:device} in the last 10 minutes
        to: silent
 
 # -----------------------------------------------------------------------------
@@ -211,7 +211,8 @@ component: Network
     every: 1m
      warn: $this > 0
     delay: down 1h multiplier 1.5 max 2h
-     info: number of FIFO errors for the network interface ${label:device} in the last 10 minutes
+  summary: Net FIFO errors for ${label:device}
+     info: Number of FIFO errors for the network interface ${label:device} in the last 10 minutes
        to: silent
 
 # -----------------------------------------------------------------------------
@@ -233,7 +234,7 @@ component: Network
    lookup: average -1m unaligned of received
     units: packets
     every: 10s
-     info: average number of packets received by the network interface ${label:device} over the last minute
+     info: Average number of packets received by the network interface ${label:device} over the last minute
 
  template: 10s_received_packets_storm
        on: net.packets
@@ -249,7 +250,7 @@ component: Network
      warn: $this > (($status >= $WARNING)?(200):(5000))
      crit: $this > (($status == $CRITICAL)?(5000):(6000))
   options: no-clear-notification
-  summary: 10 sec received packets storm for ${label:device}
-     info: ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, \
+  summary: Received packets storm for ${label:device}
+     info: Ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, \
            compared to the rate over the last minute
        to: silent

--- a/health/health.d/nut.conf
+++ b/health/health.d/nut.conf
@@ -13,7 +13,8 @@ component: UPS
      warn: $this > (($status >= $WARNING)  ? (70) : (80))
      crit: $this > (($status == $CRITICAL) ? (85) : (95))
     delay: down 10m multiplier 1.5 max 1h
-     info: average UPS load over the last 10 minutes
+  summary: UPS load
+     info: Average UPS load over the last 10 minutes
        to: sitemgr
 
  template: nut_ups_charge
@@ -29,7 +30,8 @@ component: UPS
      warn: $this < 75
      crit: $this < 40
     delay: down 10m multiplier 1.5 max 1h
-     info: average UPS charge over the last minute
+  summary: UPS charge
+     info: Average UPS charge over the last minute
        to: sitemgr
 
  template: nut_last_collected_secs
@@ -43,5 +45,6 @@ component: UPS device
      warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
      crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
     delay: down 5m multiplier 1.5 max 1h
+  summary: NUT last collected
      info: number of seconds since the last successful data collection
        to: sitemgr

--- a/health/health.d/nvme.conf
+++ b/health/health.d/nvme.conf
@@ -10,5 +10,6 @@ component: Disk
     every: 10s
      crit: $this != nan AND $this != 0
     delay: down 5m multiplier 1.5 max 2h
+  summary: NVMe device ${label:device} state
      info: NVMe device ${label:device} has critical warnings
        to: sysadmin

--- a/health/health.d/ping.conf
+++ b/health/health.d/ping.conf
@@ -11,7 +11,8 @@ component: Network
     every: 10s
      crit: $this == 0
     delay: down 30m multiplier 1.5 max 2h
-     info: network host ${label:host} reachability status
+  summary: Host ${label:host} ping status
+     info: Network host ${label:host} reachability status
        to: sysadmin
 
  template: ping_packet_loss
@@ -27,7 +28,8 @@ component: Network
      warn: $this > $green
      crit: $this > $red
     delay: down 30m multiplier 1.5 max 2h
-     info: packet loss percentage to the network host ${label:host} over the last 10 minutes
+  summary: Host ${label:host} ping packet loss
+     info: Packet loss percentage to the network host ${label:host} over the last 10 minutes
        to: sysadmin
 
  template: ping_host_latency
@@ -43,5 +45,6 @@ component: Network
      warn: $this > $green OR $max > $red
      crit: $this > $red
     delay: down 30m multiplier 1.5 max 2h
-     info: average latency to the network host ${label:host} over the last 10 seconds
+  summary: Host ${label:host} ping latency
+     info: Average latency to the network host ${label:host} over the last 10 seconds
        to: sysadmin

--- a/health/health.d/postgres.conf
+++ b/health/health.d/postgres.conf
@@ -12,7 +12,8 @@ component: PostgreSQL
      warn: $this > (($status >= $WARNING)  ? (70) : (80))
      crit: $this > (($status == $CRITICAL) ? (80) : (90))
     delay: down 15m multiplier 1.5 max 1h
-     info: average total connection utilization over the last minute
+  summary: PostgreSQL connection utilization
+     info: Average total connection utilization over the last minute
        to: dba
 
  template: postgres_acquired_locks_utilization
@@ -26,7 +27,8 @@ component: PostgreSQL
     every: 1m
      warn: $this > (($status >= $WARNING)  ? (15) : (20))
     delay: down 15m multiplier 1.5 max 1h
-     info: average acquired locks utilization over the last minute
+  summary: PostgreSQL acquired locks utilization
+     info: Average acquired locks utilization over the last minute
        to: dba
 
  template: postgres_txid_exhaustion_perc
@@ -40,7 +42,8 @@ component: PostgreSQL
     every: 1m
      warn: $this > 90
     delay: down 15m multiplier 1.5 max 1h
-     info: percent towards TXID wraparound
+  summary: PostgreSQL TXID exhaustion
+     info: Percent towards TXID wraparound
        to: dba
 
 # Database alarms

--- a/health/health.d/postgres.conf
+++ b/health/health.d/postgres.conf
@@ -61,7 +61,8 @@ component: PostgreSQL
      warn: $this < (($status >= $WARNING)  ? (70) : (60))
      crit: $this < (($status == $CRITICAL) ? (60) : (50))
     delay: down 15m multiplier 1.5 max 1h
-     info: average cache hit ratio in db ${label:database} over the last minute
+  summary: PostgreSQL DB ${label:database} cache hit ratio
+     info: Average cache hit ratio in db ${label:database} over the last minute
        to: dba
 
  template: postgres_db_transactions_rollback_ratio	
@@ -75,7 +76,8 @@ component: PostgreSQL
     every: 1m
      warn: $this > (($status >= $WARNING)  ? (0) : (2))
     delay: down 15m multiplier 1.5 max 1h
-     info: average aborted transactions percentage in db ${label:database} over the last five minutes
+  summary: PostgreSQL DB ${label:database} aborted transactions
+     info: Average aborted transactions percentage in db ${label:database} over the last five minutes
        to: dba
 
  template: postgres_db_deadlocks_rate
@@ -89,7 +91,8 @@ component: PostgreSQL
     every: 1m
      warn: $this > (($status >= $WARNING)  ? (0) : (10))
     delay: down 15m multiplier 1.5 max 1h
-     info: number of deadlocks detected in db ${label:database} in the last minute
+  summary: PostgreSQL DB ${label:database} deadlocks rate
+     info: Number of deadlocks detected in db ${label:database} in the last minute
        to: dba
 
 # Table alarms
@@ -107,7 +110,8 @@ component: PostgreSQL
      warn: $this < (($status >= $WARNING)  ? (70) : (60))
      crit: $this < (($status == $CRITICAL) ? (60) : (50))
     delay: down 15m multiplier 1.5 max 1h
-     info: average cache hit ratio in db ${label:database} table ${label:table} over the last minute
+  summary: PostgreSQL table ${label:table} cache hit ratio
+     info: Average cache hit ratio in db ${label:database} table ${label:table} over the last minute
        to: dba
 
  template: postgres_table_index_cache_io_ratio
@@ -123,7 +127,8 @@ component: PostgreSQL
      warn: $this < (($status >= $WARNING)  ? (70) : (60))
      crit: $this < (($status == $CRITICAL) ? (60) : (50))
     delay: down 15m multiplier 1.5 max 1h
-     info: average index cache hit ratio in db ${label:database} table ${label:table} over the last minute
+  summary: PostgreSQL table ${label:table} index cache hit ratio
+     info: Average index cache hit ratio in db ${label:database} table ${label:table} over the last minute
        to: dba
 
  template: postgres_table_toast_cache_io_ratio
@@ -139,7 +144,8 @@ component: PostgreSQL
      warn: $this < (($status >= $WARNING)  ? (70) : (60))
      crit: $this < (($status == $CRITICAL) ? (60) : (50))
     delay: down 15m multiplier 1.5 max 1h
-     info: average TOAST hit ratio in db ${label:database} table ${label:table} over the last minute
+  summary: PostgreSQL table ${label:table} toast cache hit ratio
+     info: Average TOAST hit ratio in db ${label:database} table ${label:table} over the last minute
        to: dba
 
  template: postgres_table_toast_index_cache_io_ratio
@@ -155,6 +161,7 @@ component: PostgreSQL
      warn: $this < (($status >= $WARNING)  ? (70) : (60))
      crit: $this < (($status == $CRITICAL) ? (60) : (50))
     delay: down 15m multiplier 1.5 max 1h
+  summary: PostgreSQL table ${label:table} index toast hit ratio
      info: average index TOAST hit ratio in db ${label:database} table ${label:table} over the last minute
        to: dba
 
@@ -170,7 +177,8 @@ component: PostgreSQL
      warn: $this > (($status >= $WARNING)  ? (60) : (70))
      crit: $this > (($status == $CRITICAL) ? (70) : (80))
     delay: down 15m multiplier 1.5 max 1h
-     info: bloat size percentage in db ${label:database} table ${label:table}
+  summary: PostgreSQL table ${label:table} bloat size
+     info: Bloat size percentage in db ${label:database} table ${label:table}
        to: dba
 
  template: postgres_table_last_autovacuum_time
@@ -183,7 +191,8 @@ component: PostgreSQL
     units: seconds
     every: 1m
      warn: $this != nan AND $this > (60 * 60 * 24 * 7)
-     info: time elapsed since db ${label:database} table ${label:table} was vacuumed by the autovacuum daemon
+  summary: PostgreSQL table ${label:table} last autovacuum
+     info: Time elapsed since db ${label:database} table ${label:table} was vacuumed by the autovacuum daemon
        to: dba
 
  template: postgres_table_last_autoanalyze_time
@@ -196,7 +205,8 @@ component: PostgreSQL
     units: seconds
     every: 1m
      warn: $this != nan AND $this > (60 * 60 * 24 * 7)
-     info: time elapsed since db ${label:database} table ${label:table} was analyzed by the autovacuum daemon
+  summary: PostgreSQL table ${label:table} last autoanalyze
+     info: Time elapsed since db ${label:database} table ${label:table} was analyzed by the autovacuum daemon
        to: dba
 
 # Index alarms
@@ -213,5 +223,6 @@ component: PostgreSQL
      warn: $this > (($status >= $WARNING)  ? (60) : (70))
      crit: $this > (($status == $CRITICAL) ? (70) : (80))
     delay: down 15m multiplier 1.5 max 1h
-     info: bloat size percentage in db ${label:database} table ${label:table} index ${label:index}
+  summary: PostgreSQL table ${label:table} index bloat size
+     info: Bloat size percentage in db ${label:database} table ${label:table} index ${label:index}
        to: dba

--- a/health/health.d/qos.conf
+++ b/health/health.d/qos.conf
@@ -13,5 +13,6 @@ template: 10min_qos_packet_drops
    every: 30s
     warn: $this > 0
    units: packets
-    info: dropped packets in the last 5 minutes
+ summary: QOS packet drops
+    info: Dropped packets in the last 5 minutes
       to: silent

--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -32,7 +32,7 @@ component: Memory
     delay: down 15m multiplier 1.5 max 1h
   summary: available ram
      info: percentage of estimated amount of RAM available for userspace processes, without causing swapping
-       to: sysadmin
+       to: silent
 
       alarm: oom_kill
          on: mem.oom_kill

--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -14,6 +14,7 @@ component: Memory
      warn: $this > (($status >= $WARNING)  ? (80) : (90))
      crit: $this > (($status == $CRITICAL) ? (90) : (98))
     delay: down 15m multiplier 1.5 max 1h
+  summary: RAM in use
      info: system memory utilization
        to: sysadmin
 
@@ -29,6 +30,7 @@ component: Memory
     every: 10s
      warn: $this < (($status >= $WARNING)  ? (15) : (10))
     delay: down 15m multiplier 1.5 max 1h
+  summary: Available RAM
      info: percentage of estimated amount of RAM available for userspace processes, without causing swapping
        to: silent
 

--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -14,8 +14,8 @@ component: Memory
      warn: $this > (($status >= $WARNING)  ? (80) : (90))
      crit: $this > (($status == $CRITICAL) ? (90) : (98))
     delay: down 15m multiplier 1.5 max 1h
-  summary: ram usage
-     info: system memory utilization
+  summary: Ram utilization
+     info: System memory utilization
        to: sysadmin
 
     alarm: ram_available
@@ -30,21 +30,22 @@ component: Memory
     every: 10s
      warn: $this < (($status >= $WARNING)  ? (15) : (10))
     delay: down 15m multiplier 1.5 max 1h
-  summary: available ram
-     info: percentage of estimated amount of RAM available for userspace processes, without causing swapping
+  summary: Available Ram
+     info: Percentage of estimated amount of RAM available for userspace processes, without causing swapping
        to: silent
 
-      alarm: oom_kill
-         on: mem.oom_kill
-         os: linux
-      hosts: *
-     lookup: sum -30m unaligned
-      units: kills
-      every: 5m
-       warn: $this > 0
-      delay: down 10m
-       info: number of out of memory kills in the last 30 minutes
-         to: silent
+    alarm: oom_kill
+       on: mem.oom_kill
+       os: linux
+    hosts: *
+   lookup: sum -30m unaligned
+    units: kills
+    every: 5m
+     warn: $this > 0
+    delay: down 10m
+  summary: OOM kills
+     info: Number of out of memory kills in the last 30 minutes
+       to: silent
 
 ## FreeBSD
     alarm: ram_in_use
@@ -60,7 +61,8 @@ component: Memory
      warn: $this > (($status >= $WARNING)  ? (80) : (90))
      crit: $this > (($status == $CRITICAL) ? (90) : (98))
     delay: down 15m multiplier 1.5 max 1h
-     info: system memory utilization
+  summary: Ram utilization
+     info: System memory utilization
        to: sysadmin
 
     alarm: ram_available
@@ -75,5 +77,6 @@ component: Memory
     every: 10s
      warn: $this < (($status >= $WARNING)  ? (15) : (10))
     delay: down 15m multiplier 1.5 max 1h
-     info: percentage of estimated amount of RAM available for userspace processes, without causing swapping
+  summary: Available Ram
+     info: Percentage of estimated amount of RAM available for userspace processes, without causing swapping
        to: silent

--- a/health/health.d/ram.conf
+++ b/health/health.d/ram.conf
@@ -14,7 +14,7 @@ component: Memory
      warn: $this > (($status >= $WARNING)  ? (80) : (90))
      crit: $this > (($status == $CRITICAL) ? (90) : (98))
     delay: down 15m multiplier 1.5 max 1h
-  summary: RAM in use
+  summary: ram usage
      info: system memory utilization
        to: sysadmin
 
@@ -30,9 +30,9 @@ component: Memory
     every: 10s
      warn: $this < (($status >= $WARNING)  ? (15) : (10))
     delay: down 15m multiplier 1.5 max 1h
-  summary: Available RAM
+  summary: available ram
      info: percentage of estimated amount of RAM available for userspace processes, without causing swapping
-       to: silent
+       to: sysadmin
 
       alarm: oom_kill
          on: mem.oom_kill

--- a/health/health.d/redis.conf
+++ b/health/health.d/redis.conf
@@ -9,7 +9,8 @@ component: Redis
     every: 10s
     units: connections
      warn: $this > 0
-     info: connections rejected because of maxclients limit in the last minute
+  summary: Redis rejected connections
+     info: Connections rejected because of maxclients limit in the last minute
     delay: down 5m multiplier 1.5 max 1h
        to: dba
 
@@ -21,7 +22,8 @@ component: Redis
     every: 10s
      crit: $last_bgsave != nan AND $last_bgsave != 0
     units: ok/failed
-     info: status of the last RDB save operation (0: ok, 1: error)
+  summary: Redis background save
+     info: Status of the last RDB save operation (0: ok, 1: error)
     delay: down 5m multiplier 1.5 max 1h
        to: dba
 
@@ -35,7 +37,8 @@ component: Redis
      warn: $this > 600
      crit: $this > 1200
     units: seconds
-     info: duration of the on-going RDB save operation
+  summary: Redis slow background save
+     info: Duration of the on-going RDB save operation
     delay: down 5m multiplier 1.5 max 1h
        to: dba
 
@@ -48,6 +51,7 @@ component: Redis
      calc: $time
     units: seconds
      crit: $this != nan AND $this > 0
-     info: time elapsed since the link between master and slave is down
+  summary: Redis master link down
+     info: Time elapsed since the link between master and slave is down
     delay: down 5m multiplier 1.5 max 1h
        to: dba

--- a/health/health.d/swap.conf
+++ b/health/health.d/swap.conf
@@ -15,7 +15,8 @@ component: Memory
     every: 1m
      warn: $this > (($status >= $WARNING)  ? (20) : (30))
     delay: down 15m multiplier 1.5 max 1h
-     info: percentage of the system RAM swapped in the last 30 minutes
+  summary: Ram swapped out
+     info: Percentage of the system RAM swapped in the last 30 minutes
        to: silent
 
     alarm: used_swap
@@ -31,5 +32,6 @@ component: Memory
      warn: $this > (($status >= $WARNING)  ? (80) : (90))
      crit: $this > (($status == $CRITICAL) ? (90) : (98))
     delay: up 30s down 15m multiplier 1.5 max 1h
-     info: swap memory utilization
+  summary: Swap utilization
+     info: Swap memory utilization
        to: sysadmin

--- a/health/health.d/tcp_mem.conf
+++ b/health/health.d/tcp_mem.conf
@@ -19,5 +19,6 @@ component: Network
      warn: ${mem} > (($status >= $WARNING  ) ? ( ${tcp_mem_pressure} * 0.8 ) : ( ${tcp_mem_pressure}   ))
      crit: ${mem} > (($status == $CRITICAL ) ? ( ${tcp_mem_pressure}       ) : ( ${tcp_mem_high} * 0.9 ))
     delay: up 0 down 5m multiplier 1.5 max 1h
+  summary: TCP memory utilization
      info: TCP memory utilization
        to: silent

--- a/health/health.d/timex.conf
+++ b/health/health.d/timex.conf
@@ -13,5 +13,6 @@ component: Clock
     every: 10s
      warn: $system.uptime.uptime > 17 * 60 AND $this == 0
     delay: down 5m
-     info: when set to 0, the system kernel believes the system clock is not properly synchronized to a reliable server
+  summary: System clock sync state
+     info: When set to 0, the system kernel believes the system clock is not properly synchronized to a reliable server
        to: silent

--- a/health/health.d/vernemq.conf
+++ b/health/health.d/vernemq.conf
@@ -11,7 +11,8 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
-     info: number of socket errors in the last minute
+  summary: VerneMQ socket errors
+     info: Number of socket errors in the last minute
        to: sysadmin
 
 # Queues dropped/expired/unhandled PUBLISH messages
@@ -26,7 +27,8 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
-     info: number of dropped messaged due to full queues in the last minute
+  summary: VerneMQ dropped messages
+     info: Number of dropped messages due to full queues in the last minute
        to: sysadmin
 
  template: vernemq_queue_message_expired
@@ -39,6 +41,7 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
+  summary: VerneMQ expired messages
      info: number of messages which expired before delivery in the last minute
        to: sysadmin
 
@@ -52,7 +55,8 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
-     info: number of unhandled messages (connections with clean session=true) in the last minute
+  summary: VerneMQ unhandled messages
+     info: Number of unhandled messages (connections with clean session=true) in the last minute
        to: sysadmin
 
 # Erlang VM
@@ -68,7 +72,8 @@ component: VerneMQ
      warn: $this > (($status >= $WARNING)  ? (75) : (85))
      crit: $this > (($status == $CRITICAL) ? (85) : (95))
     delay: down 15m multiplier 1.5 max 1h
-     info: average scheduler utilization over the last 10 minutes
+  summary: VerneMQ scheduler utilization
+     info: Average scheduler utilization over the last 10 minutes
        to: sysadmin
 
 # Cluster communication and netsplits
@@ -83,7 +88,8 @@ component: VerneMQ
     every: 1m
      warn: $this > 0
     delay: up 5m down 5m multiplier 1.5 max 1h
-     info: amount of traffic dropped during communication with the cluster nodes in the last minute
+  summary: VerneMQ dropped traffic
+     info: Amount of traffic dropped during communication with the cluster nodes in the last minute
        to: sysadmin
 
  template: vernemq_netsplits
@@ -96,7 +102,8 @@ component: VerneMQ
     every: 10s
      warn: $this > 0
     delay: down 5m multiplier 1.5 max 2h
-     info: number of detected netsplits (split brain situation) in the last minute
+  summary: VerneMQ netsplits
+     info: Number of detected netsplits (split brain situation) in the last minute
        to: sysadmin
 
 # Unsuccessful CONNACK
@@ -111,7 +118,8 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
-     info: number of sent unsuccessful v3/v5 CONNACK packets in the last minute
+  summary: VerneMQ unsuccessful CONNACK
+     info: Number of sent unsuccessful v3/v5 CONNACK packets in the last minute
        to: sysadmin
 
 # Not normal DISCONNECT
@@ -126,7 +134,8 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
-     info: number of received not normal v5 DISCONNECT packets in the last minute
+  summary: VerneMQ received not normal DISCONNECT
+     info: Number of received not normal v5 DISCONNECT packets in the last minute
        to: sysadmin
 
  template: vernemq_mqtt_disconnect_sent_reason_not_normal
@@ -139,7 +148,8 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
-     info: number of sent not normal v5 DISCONNECT packets in the last minute
+  summary: VerneMQ sent not normal DISCONNECT
+     info: Number of sent not normal v5 DISCONNECT packets in the last minute
        to: sysadmin
 
 # SUBSCRIBE errors and unauthorized attempts
@@ -154,7 +164,8 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
-     info: number of failed v3/v5 SUBSCRIBE operations in the last minute
+  summary: VerneMQ failed SUBSCRIBE
+     info: Number of failed v3/v5 SUBSCRIBE operations in the last minute
        to: sysadmin
 
  template: vernemq_mqtt_subscribe_auth_error
@@ -167,6 +178,7 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
+  summary: VerneMQ unauthorized SUBSCRIBE
      info: number of unauthorized v3/v5 SUBSCRIBE attempts in the last minute
        to: sysadmin
 
@@ -182,7 +194,8 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
-     info: number of failed v3/v5 UNSUBSCRIBE operations in the last minute
+  summary: VerneMQ failed UNSUBSCRIBE
+     info: Number of failed v3/v5 UNSUBSCRIBE operations in the last minute
        to: sysadmin
 
 # PUBLISH errors and unauthorized attempts
@@ -197,7 +210,8 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
-     info: number of failed v3/v5 PUBLISH operations in the last minute
+  summary: VerneMQ failed PUBLISH
+     info: Number of failed v3/v5 PUBLISH operations in the last minute
        to: sysadmin
 
  template: vernemq_mqtt_publish_auth_errors
@@ -210,7 +224,8 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
-     info: number of unauthorized v3/v5 PUBLISH attempts in the last minute
+  summary: VerneMQ unauthorized PUBLISH
+     info: Number of unauthorized v3/v5 PUBLISH attempts in the last minute
        to: sysadmin
 
 # Unsuccessful and unexpected PUBACK
@@ -225,7 +240,8 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
-     info: number of received unsuccessful v5 PUBACK packets in the last minute
+  summary: VerneMQ unsuccessful received PUBACK
+     info: Number of received unsuccessful v5 PUBACK packets in the last minute
        to: sysadmin
 
  template: vernemq_mqtt_puback_sent_reason_unsuccessful
@@ -238,7 +254,8 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
-     info: number of sent unsuccessful v5 PUBACK packets in the last minute
+  summary: VerneMQ unsuccessful sent PUBACK
+     info: Number of sent unsuccessful v5 PUBACK packets in the last minute
        to: sysadmin
 
  template: vernemq_mqtt_puback_unexpected
@@ -251,7 +268,8 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
-     info: number of received unexpected v3/v5 PUBACK packets in the last minute
+  summary: VerneMQ unnexpected recieved PUBACK
+     info: Number of received unexpected v3/v5 PUBACK packets in the last minute
        to: sysadmin
 
 # Unsuccessful and unexpected PUBREC
@@ -266,7 +284,8 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
-     info: number of received unsuccessful v5 PUBREC packets in the last minute
+  summary: VerneMQ unsuccessful received PUBREC
+     info: Number of received unsuccessful v5 PUBREC packets in the last minute
        to: sysadmin
 
  template: vernemq_mqtt_pubrec_sent_reason_unsuccessful
@@ -279,7 +298,8 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
-     info: number of sent unsuccessful v5 PUBREC packets in the last minute
+  summary: VerneMQ unsuccessful sent PUBREC
+     info: Number of sent unsuccessful v5 PUBREC packets in the last minute
        to: sysadmin
 
  template: vernemq_mqtt_pubrec_invalid_error
@@ -292,7 +312,8 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
-     info: number of received unexpected v3 PUBREC packets in the last minute
+  summary: VerneMQ invalid received PUBREC
+     info: Number of received invalid v3 PUBREC packets in the last minute
        to: sysadmin
 
 # Unsuccessful PUBREL
@@ -307,7 +328,8 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
-     info: number of received unsuccessful v5 PUBREL packets in the last minute
+  summary: VerneMQ unsuccessful received PUBREL
+     info: Number of received unsuccessful v5 PUBREL packets in the last minute
        to: sysadmin
 
  template: vernemq_mqtt_pubrel_sent_reason_unsuccessful
@@ -320,6 +342,7 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
+  summary: VerneMQ unsuccessful sent PUBREL
      info: number of sent unsuccessful v5 PUBREL packets in the last minute
        to: sysadmin
 
@@ -335,7 +358,8 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
-     info: number of received unsuccessful v5 PUBCOMP packets in the last minute
+  summary: VerneMQ unsuccessful received PUBCOMP
+     info: Number of received unsuccessful v5 PUBCOMP packets in the last minute
        to: sysadmin
 
  template: vernemq_mqtt_pubcomp_sent_reason_unsuccessful
@@ -348,6 +372,7 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
+  summary: VerneMQ unsuccessful sent PUBCOMP
      info: number of sent unsuccessful v5 PUBCOMP packets in the last minute
        to: sysadmin
 
@@ -361,5 +386,6 @@ component: VerneMQ
     every: 1m
      warn: $this > (($status >= $WARNING) ? (0) : (5))
     delay: up 2m down 5m multiplier 1.5 max 2h
+  summary: VerneMQ unexpected received PUBCOMP
      info: number of received unexpected v3/v5 PUBCOMP packets in the last minute
        to: sysadmin

--- a/health/health.d/zfs.conf
+++ b/health/health.d/zfs.conf
@@ -9,6 +9,7 @@ component: File system
     every: 1m
      warn: $this > 0
     delay: down 1h multiplier 1.5 max 2h
+  summary: ZFS memory throttle
      info: number of times ZFS had to limit the ARC growth in the last 10 minutes
        to: silent
 
@@ -24,6 +25,7 @@ component: File system
     every: 10s
      warn: $this > 0
     delay: down 1m multiplier 1.5 max 1h
+  summary: ZFS pool ${label:pool} state
      info: ZFS pool ${label:pool} state is degraded
        to: sysadmin
 
@@ -37,5 +39,6 @@ component: File system
     every: 10s
      crit: $this > 0
     delay: down 1m multiplier 1.5 max 1h
+  summary: Critical ZFS pool ${label:pool} state
      info: ZFS pool ${label:pool} state is faulted or unavail
        to: sysadmin

--- a/health/health.h
+++ b/health/health.h
@@ -84,6 +84,7 @@ ALARM_ENTRY* health_create_alarm_entry(
     RRDCALC_STATUS new_status,
     STRING *source,
     STRING *units,
+    STRING *summary,
     STRING *info,
     int delay,
     HEALTH_ENTRY_FLAGS flags);

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -60,6 +60,7 @@ static inline void health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC
                     "\t\t\t\"recipient\": \"%s\",\n"
                     "\t\t\t\"source\": \"%s\",\n"
                     "\t\t\t\"units\": \"%s\",\n"
+                    "\t\t\t\"summary\": \"%s\",\n"
                     "\t\t\t\"info\": \"%s\",\n"
                     "\t\t\t\"status\": \"%s\",\n"
                     "\t\t\t\"last_status_change\": %lu,\n"
@@ -93,6 +94,7 @@ static inline void health_rrdcalc2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC
                    , rc->recipient?rrdcalc_recipient(rc):string2str(host->health.health_default_recipient)
                    , rrdcalc_source(rc)
                    , rrdcalc_units(rc)
+                   , rrdcalc_summary(rc)
                    , rrdcalc_info(rc)
                    , rrdcalc_status2string(rc->status)
                    , (unsigned long)rc->last_status_change

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -72,6 +72,7 @@ inline ALARM_ENTRY* health_create_alarm_entry(
     ae->old_value_string = string_strdupz(format_value_and_unit(value_string, 100, ae->old_value, ae_units(ae), -1));
     ae->new_value_string = string_strdupz(format_value_and_unit(value_string, 100, ae->new_value, ae_units(ae), -1));
 
+    ae->summary = string_dup(summary);
     ae->info = string_dup(info);
     ae->old_status = old_status;
     ae->new_status = new_status;

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -34,6 +34,7 @@ inline ALARM_ENTRY* health_create_alarm_entry(
     RRDCALC_STATUS new_status,
     STRING *source,
     STRING *units,
+    STRING *summary,
     STRING *info,
     int delay,
     HEALTH_ENTRY_FLAGS flags

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -3185,7 +3185,7 @@ Content-Transfer-Encoding: 8bit
                       <tbody>
                       <tr>
                         <td align="left" style="font-size:0px;padding:10px 25px;padding-top:15px;word-break:break-word;">
-                          <div style="font-family:Open Sans, sans-serif;font-size:20px;font-weight:700;line-height:1;text-align:left;color:#35414A;">${name}</div>
+                          <div style="font-family:Open Sans, sans-serif;font-size:20px;font-weight:700;line-height:1;text-align:left;color:#35414A;">${summary}</div>
                         </td>
                       </tr>
                       </tbody>
@@ -3343,14 +3343,14 @@ Content-Transfer-Encoding: 8bit
               <tbody>
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-bottom:6px;word-break:break-word;">
-                  <div style="font-family:Open Sans, sans-serif;font-size:18px;line-height:1;text-align:left;color:#35414A;">Chart:
-                    <span style="font-weight:700; font-size:20px">${chart}</span></div>
+                  <div style="font-family:Open Sans, sans-serif;font-size:18px;line-height:1;text-align:left;color:#35414A;">Alert:
+                    <span style="font-weight:700; font-size:20px">${name}</span></div>
                 </td>
               </tr>
               <tr>
                 <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
-                  <div style="font-family:Open Sans, sans-serif;font-size:18px;line-height:1;text-align:left;color:#35414A;">Family:
-                    <span style="font-weight:700; font-size:20px">${family}</span></div>
+                  <div style="font-family:Open Sans, sans-serif;font-size:18px;line-height:1;text-align:left;color:#35414A;">Chart:
+                    <span style="font-weight:700; font-size:20px">${chart}</span></div>
                 </td>
               </tr>
               <tr>

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -248,6 +248,7 @@ else
   edit_command_line="${28}"  # The command to edit the alarm, with the line number
   child_machine_guid="${29}" # the machine_guid of the child
   transition_id="${30}"      # the transition_id of the alert
+  summary="${31}"            # the summary text field of the alert
 fi
 
 # -----------------------------------------------------------------------------
@@ -2531,7 +2532,7 @@ status_message="status unknown"
 color="grey"
 
 # the alarm value
-alarm="${name//_/ } = ${value_string}"
+alarm="${summary//_/ } = ${value_string}"
 
 # the image of the alarm
 image="${images_base_url}/images/banner-icon-144x144.png"
@@ -2582,7 +2583,7 @@ CLEAR)
 esac
 
 # the html email subject
-html_email_subject="${status_email_subject}, ${name} = ${value_string}, on ${host}"
+html_email_subject="${status_email_subject}, ${summary} = ${value_string}, on ${host}"
 
 if [ "${status}" = "CLEAR" ]; then
   severity="Recovered from ${old_status}"
@@ -2593,8 +2594,8 @@ if [ "${status}" = "CLEAR" ]; then
 
   # don't show the value when the status is CLEAR
   # for certain alarms, this value might not have any meaning
-  alarm="${name//_/ } ${raised_for}"
-  html_email_subject="${status_email_subject}, ${name} ${raised_for}, on ${host}"
+  alarm="${summary//_/ } ${raised_for}"
+  html_email_subject="${status_email_subject}, ${summary} ${raised_for}, on ${host}"
 
 elif { [ "${old_status}" = "WARNING" ] && [ "${status}" = "CRITICAL" ]; }; then
   severity="Escalated to ${status}"
@@ -3610,7 +3611,7 @@ Content-Transfer-Encoding: 8bit
                     <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;padding-bottom:0;word-break:break-word;">
-                        <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#35414A;">© Netdata 2021 - The real-time performance and health monitoring</div>
+                        <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#35414A;">© Netdata $(date +'%Y') - The real-time performance and health monitoring</div>
                       </td>
                     </tr>
                     </tbody>


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Adds a `summary` field to alerts. This is a short text field that can be used in some places where we currently use the alert name.

The field can be enriched as with the info field, with chart labels. This brings some more information in a glance in e.g. notifications subjects and our alert list in dashboard.

As an example, the same notification will change from:

![image](https://github.com/netdata/netdata/assets/1905463/d223b352-b271-45c1-86da-8aa9141b3e60)

to

![image](https://github.com/netdata/netdata/assets/1905463/ed10dbf8-461c-4601-b7cc-8be2dd119468)

Because we plan to remove the family entry from alerts, we need a way to present alert specific instance information to notifications.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
