### PR TITLE
Add check to avoid auto-installing new major versions of Netdata.

### DIFF
--- a/.github/scripts/run-updater-check.sh
+++ b/.github/scripts/run-updater-check.sh
@@ -12,7 +12,7 @@ echo "::group::>>> Pre-Update Netdata Build Info"
 netdata -W buildinfo
 echo "::endgroup::"
 echo ">>> Updating Netdata..."
-export NETDATA_BASE_URL="http://localhost:8080/artifacts/" # Pull the tarball from the local web server.
+export NETDATA_BASE_URL="http://localhost:8080/artifacts" # Pull the tarball from the local web server.
 echo NETDATA_MAJOR_VERSION_UPDATES=1 > /etc/netdata/netdata-updater.conf
 timeout 3600 /netdata/packaging/installer/netdata-updater.sh --not-running-from-cron --no-updater-self-update
 

--- a/.github/scripts/run-updater-check.sh
+++ b/.github/scripts/run-updater-check.sh
@@ -13,6 +13,7 @@ netdata -W buildinfo
 echo "::endgroup::"
 echo ">>> Updating Netdata..."
 export NETDATA_BASE_URL="http://localhost:8080/artifacts/" # Pull the tarball from the local web server.
+echo NETDATA_MAJOR_VERSION_UPDATES=1 > /etc/netdata/netdata-updater.conf
 timeout 3600 /netdata/packaging/installer/netdata-updater.sh --not-running-from-cron --no-updater-self-update
 
 case "$?" in

--- a/.github/scripts/run-updater-check.sh
+++ b/.github/scripts/run-updater-check.sh
@@ -13,7 +13,7 @@ netdata -W buildinfo
 echo "::endgroup::"
 echo ">>> Updating Netdata..."
 export NETDATA_BASE_URL="http://localhost:8080/artifacts" # Pull the tarball from the local web server.
-echo NETDATA_MAJOR_VERSION_UPDATES=1 > /etc/netdata/netdata-updater.conf
+echo 'NETDATA_ACCEPT_MAJOR_VERSIONS="1 9999"' > /etc/netdata/netdata-updater.conf
 timeout 3600 /netdata/packaging/installer/netdata-updater.sh --not-running-from-cron --no-updater-self-update
 
 case "$?" in

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -508,13 +508,16 @@ jobs:
         id: prepare
         if: needs.file-check.outputs.run == 'true'
         run: |
-          mkdir -p artifacts/download/latest || exit 1
-          echo "9999.0.0-0" > artifacts/download/latest/latest-version.txt || exit 1
-          cp dist-tarball/* artifacts/download/latest || exit 1
-          cd artifacts/download/latest || exit 1
+          mkdir -p artifacts/download/v9999.0.0 || exit 1
+          mkdir -p artifacts/latest || exit 1
+          echo "v9999.0.0" > artifacts/latest/latest-version.txt || exit 1
+          cp dist-tarball/* artifacts/download/v9999.0.0 || exit 1
+          cd artifacts/download/v9999.0.0 || exit 1
           ln -s ${{ needs.build-dist.outputs.distfile }} netdata-latest.tar.gz || exit 1
           sha256sum -b ./* > "sha256sums.txt" || exit 1
           cat sha256sums.txt
+          cd ../.. || exit 1
+          ls -lR
       - name: Fetch test environment
         id: fetch-test-environment
         if: needs.file-check.outputs.run == 'true'

--- a/packaging/installer/UPDATE.md
+++ b/packaging/installer/UPDATE.md
@@ -204,6 +204,8 @@ The following configuration options are currently supported:
   as a scheduled task. This random delay helps avoid issues resulting from too many nodes trying to reconnect to
   the Cloud at the same time. The default value is 3600, which corresponds to one hour. Most users should not ever
   need to change this.
+- `NETDATA_MAJOR_VERSION_UPDATES`: If set to a value other than 0, then new major versions will be installed
+  without user confirmation. Must be set to a  non-zero value for automated updates to install new major versions.
 - `NETDATA_NO_SYSTEMD_JOURNAL`: If set to a value other than 0, skip attempting to install the
   `netdata-plugin-systemd-journal` package on supported systems on update. This optional package will be installed
   by default on supported systems by the updater if this option is not set. Only affects systems using native packages.

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -433,7 +433,6 @@ download() {
 
 get_netdata_latest_tag() {
   url="${1}/latest"
-  dest="${2}"
 
   check_for_curl
 
@@ -457,7 +456,7 @@ get_netdata_latest_tag() {
     fi
   fi
 
-  echo "${tag}" > "${dest}"
+  echo "${tag}"
 }
 
 newer_commit_date() {
@@ -545,9 +544,9 @@ parse_version() {
 
 get_latest_version() {
   if [ "${RELEASE_CHANNEL}" = "stable" ]; then
-    get_netdata_latest_tag "${NETDATA_STABLE_BASE_URL}" /dev/stdout
+    get_netdata_latest_tag "${NETDATA_STABLE_BASE_URL}"
   else
-    get_netdata_latest_tag "${NETDATA_NIGHTLY_BASE_URL}" /dev/stdout
+    get_netdata_latest_tag "${NETDATA_NIGHTLY_BASE_URL}"
   fi
 }
 
@@ -622,11 +621,11 @@ set_tarball_urls() {
   fi
 
   if [ "$1" = "stable" ]; then
-    latest="$(get_netdata_latest_tag "${NETDATA_STABLE_BASE_URL}" /dev/stdout)"
+    latest="$(get_netdata_latest_tag "${NETDATA_STABLE_BASE_URL}")"
     export NETDATA_TARBALL_URL="${NETDATA_STABLE_BASE_URL}/download/$latest/${filename}"
     export NETDATA_TARBALL_CHECKSUM_URL="${NETDATA_STABLE_BASE_URL}/download/$latest/sha256sums.txt"
   else
-    tag="$(get_netdata_latest_tag "${NETDATA_NIGHTLY_BASE_URL}" /dev/stdout)"
+    tag="$(get_netdata_latest_tag "${NETDATA_NIGHTLY_BASE_URL}")"
     export NETDATA_TARBALL_URL="${NETDATA_NIGHTLY_BASE_URL}/download/${tag}/${filename}"
     export NETDATA_TARBALL_CHECKSUM_URL="${NETDATA_NIGHTLY_BASE_URL}/download/${tag}/sha256sums.txt"
   fi

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -597,7 +597,16 @@ update_available() {
       latest_major="$(echo "${latest_tag}" | cut -f 1 -d '.' | tr -d 'v')"
 
       if [ "${current_major}" -ne "${latest_major}" ]; then
-        if echo "${NETDATA_ACCEPT_MAJOR_VERSIONS}" | grep -F -q -w "${current_major}" ; then
+        update_safe=0
+
+        for v in ${NETDATA_ACCEPT_MAJOR_VERSIONS}; do
+          if [ "${current_major}" -eq "${v}" ]; then
+            update_safe=1
+            break
+          fi
+        done
+
+        if [ "${update_safe}" -eq 0 ]; then
           warn_major_update
         fi
       fi
@@ -897,7 +906,16 @@ update_binpkg() {
   latest_major="$(get_new_binpkg_major)"
 
   if [ -n "${latest_major}" ] && [ "${latest_major}" -ne "${current_major}" ]; then
-    if echo "${NETDATA_ACCEPT_MAJOR_VERSIONS}" | grep -F -q -w "${current_major}" ; then
+    update_safe=0
+
+    for v in ${NETDATA_ACCEPT_MAJOR_VERSIONS}; do
+      if [ "${current_major}" -eq "${v}" ]; then
+        update_safe=1
+        break
+      fi
+    done
+
+    if [ "${update_safe}" -eq 0 ]; then
       warn_major_update
     fi
   fi

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -445,7 +445,16 @@ get_netdata_latest_tag() {
     fatal "I need curl or wget to proceed, but neither of them are available on this system." U0006
   fi
 
-  echo "${tag}" >"${dest}"
+  # Fallback case for simpler local testing.
+  if echo "${tag}" | grep -q '[^/]latest$'; then
+    if _safe_download "${url}/latest-version.txt" ./ndupdate-version.txt; then
+      tag="$(cat ./ndupdate-version.txt)"
+    fi
+
+    rm -f ./ndupdate-version.txt
+  fi
+
+  echo "${tag}" > "${dest}"
 }
 
 newer_commit_date() {

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -446,9 +446,7 @@ get_netdata_latest_tag() {
 
   # Fallback case for simpler local testing.
   if echo "${tag}" | grep -Eq 'latest/?$'; then
-    _safe_download "${url}/latest-version.txt" ./ndupdate-version.txt || true
-
-    if [ -r ./ndupdate-version.txt ]; then
+    if _safe_download "${url}/latest-version.txt" ./ndupdate-version.txt; then
       tag="$(cat ./ndupdate-version.txt)"
       rm -f ./ndupdate-version.txt
     else

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -448,6 +448,11 @@ get_netdata_latest_tag() {
   if echo "${tag}" | grep -Eq 'latest/?$'; then
     if _safe_download "${url}/latest-version.txt" ./ndupdate-version.txt; then
       tag="$(cat ./ndupdate-version.txt)"
+
+      if grep -q 'Not Found' ./ndupdate-version.txt; then
+        tag="latest"
+      fi
+
       rm -f ./ndupdate-version.txt
     else
       tag="latest"

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -28,7 +28,7 @@
 # Author: Pavlos Emm. Katsoulakis <paul@netdata.cloud>
 # Author: Austin S. Hemmelgarn <austin@netdata.cloud>
 
-# Next unused error code: U001B
+# Next unused error code: U001D
 
 set -e
 
@@ -40,6 +40,7 @@ NETDATA_NIGHTLY_BASE_URL="${NETDATA_BASE_URL:-https://github.com/netdata/netdata
 # Following variables are intended to be overridden by the updater config file.
 NETDATA_UPDATER_JITTER=3600
 NETDATA_NO_SYSTEMD_JOURNAL=0
+NETDATA_MAJOR_VERSION_UPDATES=0
 
 script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)"
 
@@ -168,6 +169,44 @@ _get_scheduler_type() {
     echo 'crontab'
   else
     echo 'none'
+  fi
+}
+
+confirm() {
+  prompt="${1} [y/n]"
+
+  while true; do
+    echo "${prompt}"
+    read -r yn
+
+    case "$yn" in
+      [Yy]*) return 0;;
+      [Nn]*) return 1;;
+      *) echo "Please answer yes or no.";;
+    esac
+  done
+}
+
+warn_major_update() {
+  if ! is_integer "${NETDATA_MAJOR_VERSION_UPDATES}"; then
+    NETDATA_MAJOR_VERSION_UPDATES=1
+  fi
+
+  nmv_suffix="New major versions generally involve breaking changes, and may not work in the same way as older versions."
+
+  if [ "${INTERACTIVE}" -eq 0 ] && [ "${NETDATA_MAJOR_VERSION_UPDATES}" -eq 0 ]; then
+    warning "Would update to a new major version of Netdata. ${nmv_suffix}"
+    warning "To install the new major version anyway, either run the updater interactively, or set NETDATA_MAJOR_VERSION_UPDATES to a non-zero value in ${UPDATER_CONFIG_PATH}."
+    fatal "Aborting update to new major version to avoid breaking things." U001B
+  elif [ "${NETDATA_MAJOR_VERSION_UPDATES}" -ne 0 ]; then
+    warning "Updating to a new major version of Netdata at user request. This may break some functionality."
+  else
+    warning "This update will install a new major version of Netdata. ${nmv_suffix}"
+    if confirm "Are you sure you want to update to a new major version of Netdata?"; then
+      notice "User accepted update to new major version of Netdata."
+    else
+      fatal "Aborting update to new major version at user request." U001C
+    fi
   fi
 }
 
@@ -513,6 +552,7 @@ update_available() {
      info "Force update requested"
      return 0
   fi
+
   basepath="$(dirname "$(dirname "$(dirname "${NETDATA_LIB_DIR}")")")"
   searchpath="${basepath}/bin:${basepath}/sbin:${basepath}/usr/bin:${basepath}/usr/sbin:${PATH}"
   searchpath="${basepath}/netdata/bin:${basepath}/netdata/sbin:${basepath}/netdata/usr/bin:${basepath}/netdata/usr/sbin:${searchpath}"
@@ -542,6 +582,16 @@ update_available() {
     return 1
   else
     info "Update available"
+
+    if [ "${current_version}" -ne 0 ] && [ "${latest_version}" -ne 0 ]; then
+      current_major="$(${ndbinary} -v | cut -f 2 -d ' ' | cut -f 1 -d '.' | tr -d 'v')"
+      latest_major="$(echo "${latest_tag}" | cut -f 1 -d '.' | tr -d 'v')"
+
+      if [ "${current_major}" -ne "${latest_major}" ]; then
+        warn_major_update
+      fi
+    fi
+
     return 0
   fi
 }
@@ -713,6 +763,15 @@ update_static() {
   exit 0
 }
 
+get_new_binpkg_major() {
+  case "${pm_cmd}" in
+    apt-get) apt-get --just-print upgrade 2>&1 | grep Inst | grep ' netdata ' | cut -f 3 -d ' ' | tr -d '[]' | cut -f 1 -d '.' ;;
+    yum) yum check-update netdata | grep -E '^netdata ' | awk '{print $2}' | cut -f 1 -d '.' ;;
+    dnf) dnf check-update netdata | grep -E '^netdata ' | awk '{print $2}' | cut -f 1 -d '.' ;;
+    zypper) zypper list-updates | grep '| netdata |' | cut -f 5 -d '|' | tr -d ' ' | cut -f 1 -d '.' ;;
+  esac
+}
+
 update_binpkg() {
   os_release_file=
   if [ -s "/etc/os-release" ] && [ -r "/etc/os-release" ]; then
@@ -823,6 +882,13 @@ update_binpkg() {
     fi
   done
 
+  current_major="$(netdata -v | cut -f 2 -d ' ' | cut -f 1 -d '.' | tr -d 'v')"
+  latest_major="$(get_new_binpkg_major)"
+
+  if [ -n "${latest_major}" ] && [ "${latest_major}" -ne "${current_major}" ]; then
+    warn_major_version_update
+  fi
+
   # shellcheck disable=SC2086
   env ${env} ${pm_cmd} ${upgrade_subcmd} ${pkg_install_opts} netdata >&3 2>&3 || fatal "Failed to update Netdata package." U000F
 
@@ -901,9 +967,10 @@ if [ -r "$(dirname "${ENVIRONMENT_FILE}")/.install-type" ]; then
   . "$(dirname "${ENVIRONMENT_FILE}")/.install-type" || fatal "Failed to source $(dirname "${ENVIRONMENT_FILE}")/.install-type" U0015
 fi
 
-if [ -r "$(dirname "${ENVIRONMENT_FILE}")/netdata-updater.conf" ]; then
+UPDATER_CONFIG_PATH="$(dirname "${ENVIRONMENT_FILE}")/netdata-updater.conf"
+if [ -r "${UPDATER_CONFIG_PATH}" ]; then
   # shellcheck source=/dev/null
-  . "$(dirname "${ENVIRONMENT_FILE}")/netdata-updater.conf"
+  . "${UPDATER_CONFIG_PATH}"
 fi
 
 while [ -n "${1}" ]; do

--- a/system/netdata-updater.conf
+++ b/system/netdata-updater.conf
@@ -2,9 +2,18 @@
 #
 # When run non-interactively, the updater script will delay some
 # random number of seconds up to NETDATA_UPDATER_JITTER before
-# actually running the update. The default is 3600 (one
-# hour). Most users should not need to change this.
+# actually running the update. The default is 3600 (one hour). Most
+# users should not need to change this.
 #NETDATA_UPDATER_JITTER="3600"
+
+# By default, the updater requires user confirmation before it will
+# attempt to install a new major version of Netdata to avoid unexpectedly
+# breaking things.
+#
+# If NETDATA_MAJOR_VERSION_UPDATES is set to a value other than 0, then
+# this check will be skipped and new major versions will be installed
+# without user confirmation.
+#NETDATA_MAJOR_VERSION_UPDATES="0"
 
 # On systems using our native packages, the updater will by default
 # attempt to install optional plugin packages that would be installed by
@@ -13,7 +22,7 @@
 # This behavior can be disabled on a per-package basis using the below
 # variables. Setting the variable to a value other than 0 will disable
 # the corresponding package (note that you still need to remove the package
-# yourself if you don0t want it, this just controls whether the updater
+# yourself if you don't want it, this just controls whether the updater
 # will try to ensure it’s installed or not).
 #
 # NETDATA_NO_SYSTEMD_JOURNAL controls the `netdata-plugin-systemd-journal`

--- a/system/netdata-updater.conf
+++ b/system/netdata-updater.conf
@@ -6,14 +6,25 @@
 # users should not need to change this.
 #NETDATA_UPDATER_JITTER="3600"
 
-# By default, the updater requires user confirmation before it will
-# attempt to install a new major version of Netdata to avoid unexpectedly
-# breaking things.
+# By default, the updater will update to new major versions without asking
+# for user confirmation once we consider them ready for general usage.
 #
-# If NETDATA_MAJOR_VERSION_UPDATES is set to a value other than 0, then
-# this check will be skipped and new major versions will be installed
-# without user confirmation.
-#NETDATA_MAJOR_VERSION_UPDATES="0"
+# You can override this behavior by setting NETDATA_ACCEPT_MAJOR_VERSIONS
+# to a space separated list of major versions you are willing to update
+# to. Attempts to update to newer major versions not listed in this variable
+# will be treated as a fatal error.
+#
+# An empty value is equivalent to the default behavior.
+#
+# This only applies to static builds and local builds. If you are using
+# our native packages, use your package manager’s existing functionality
+# to prevent updates (for example, pinning versions on APT-based systems,
+# or the DNF versionlock plugin on RHEL/Fedora).
+#
+# To lock yourself to a specific major version, set this value to exactly
+# that major version number. For example, to stay on version 1.x even
+# if 2.x has been released, set this to a value of `1`.
+#NETDATA_ACCEPT_MAJOR_VERSIONS=''
 
 # On systems using our native packages, the updater will by default
 # attempt to install optional plugin packages that would be installed by


### PR DESCRIPTION
##### Summary

This adds new logic to the updater so that users can opt-out of updating to specific new major versions of Netdata. A new updater configuration variable called `NETDATA_ACCEPT_MAJOR_VERSIONS` has been added, which should contain a list of major version numbers that we’re allowed to update to. This will by default be populated by us in the updater itself, allowing us to easily block specific major versions if we discover serious issues, and also allowing us to have updates run by default 

Not specifying anything in the updater config file should get behavior exactly equivalent to the current behavior.

Setting `NETDATA_ACCEPT_MAJOR_VERSIONS` in the updater config file so that it doesn’t include the target major version should cause a non-interactive update to fail, or an interactive update to prompt the user about whether they really want to update.

##### Test Plan

There are functionally two code paths to test:

1. Local builds
2. Static builds

Local builds  and static builds can be tested as follows:

1. Install a current version of Netdata using the kickstart script with the appropriate option (`--build-only` for local builds, `--static-only` for static builds) on the test system.
2. Prepare a test directory in a location of your choice, either on the test system or a separate system the test system can communicate with over the network.
3.  Set up a web server (any web server works) to serve the test directory from step 2 to the test system. The test directory should be at the root of the web server for these tests.
4. Prepare the update file that will be used for testing:
    - For local builds, check out the agent repository and then run `autoreconf -ivf && ./configure && make dist` in the agent repository. This will produce a file with a name like `netdata-v1.42.0-100-gb67882aee.tar.gz`, which is the update file that will be used in the next step.
    - For static builds, check out the agent repository and then run `packaging/makeself/build-static.sh $(uname -m)` (if not building on the test system, replace `$(uname -m)` with the output of `uname -m` run on the test system). This will produce a file with a name like `netdata-x86_64-v1.42.0-100-gb67882aee.gz.run` in a directory called `artifacts`, which is the update file that will be used in the next step.
5. Create a directory called `download/v9999.0.0` in the test directory from step 2. It should contain:
    - The update file produced in step 4.
    - A symbolic link pointing to the update file from step 4 with the same name as the update file from step for with the version in the filename replaced by `latest`. For example, if the update file is named `netdata-x86_64-v1.42.0-100-gb67882aee.gz.run`, then the symbolic link should be `netdata-x86_64-latest.gz.run`.
    - A file called `sha256sums.txt`, generated by running `sha256sum -b ./* > ./sha256sums.txt` from in the `download/lv9999.0.0` directory.
6. Create a second directory called `latest` in the test directory from step 2. It should contain a single file called `latest-version.txt` containing the exact text `v9999.0.0`.
7. Run the updater script from this PR on the test system like so: `NETDATA_BASE_URL="<server-url>" ./netdata-updater.sh --no-updater-self-update`. Replace `<server-url>` with the full URL for the web server set up in step 3.

Behavior of the updater script should match what is described in the summary section above.

##### Additional Information

This _MUST_ be merged before any version 2.0 functionality is merged.

Further PRs will be made later to provide the ability to update to a specific version of the agent and to allow updating to the latest release of a given major version.