### PR TITLE
python.d/sensors: Increase voltage limits 127 -> 400

### DIFF
--- a/collectors/python.d.plugin/sensors/sensors.chart.py
+++ b/collectors/python.d.plugin/sensors/sensors.chart.py
@@ -66,7 +66,7 @@ CHARTS = {
 
 LIMITS = {
     'temperature': [-127, 1000],
-    'voltage': [-127, 127],
+    'voltage': [-400, 400],
     'current': [-127, 127],
     'fan': [0, 65535]
 }


### PR DESCRIPTION
##### Summary
* Fix a limit that caused my properly functioning PMBus power supply sensor to be skipped as it reported 208VAC.
* The 400V limit was pulled from the [Open Compute Project M-CRPS specification v1.0 Section 5.1.3.2](https://www.opencompute.org/documents/m-crps-r1-v1p0-rc4-pdf)  which defines a power supply input voltage as 380VDC and specifies a Vmax of 400VDC.
* Also decrease the lower limit to -400VDC as some telecom power supplies may report negative voltage, most notable is -48VDC and expect more could as well.

##### Test Plan
Patch system with PMBus enabled power supply and verify correct operation.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
- Increases voltage range to properly handle high voltage PMBus power supplies.
</details>
