### PR TITLE
Fix query to properly check for transition ids

### DIFF
--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -435,8 +435,8 @@ done:
     "hl.host_id = @host_id AND hl.health_log_id = hld.health_log_id) " \
     "AND health_log_id IN (SELECT health_log_id FROM health_log WHERE host_id = @host_id) " \
     "AND when_key < unixepoch() - @history " \
-    "AND updated_by_id <> 0 AND transition_id NOT IN " \
-    "(SELECT last_transition_id FROM health_log hl WHERE hl.host_id = @host_id);", guid
+    "AND updated_by_id <> 0 AND HEX(transition_id) NOT IN " \
+    "(SELECT HEX(last_transition_id) FROM health_log hl WHERE hl.host_id = @host_id);", guid
 
 void sql_health_alarm_log_cleanup(RRDHOST *host, bool claimed) {
     sqlite3_stmt *res = NULL;


### PR DESCRIPTION
##### Summary
It looks like the check for the transition ids (as blobs) is not working properly -- the `NOT IN` condition

This PR converts to hex to bypass the issue

Example
```
sqlite> select count(*) from health_log_detail where transition_id IN (SELECT last_transition_id FROM health_log WHERE host_id = x'fb5fc0224e3411ed82730b54b351e955');
count(*)
--------
419     
sqlite> select count(*) from health_log_detail where transition_id NOT IN (SELECT last_transition_id FROM health_log WHERE host_id = x'fb5fc0224e3411ed82730b54b351e955');
count(*)
--------
0       
sqlite> select count(*) from health_log_detail where HEX(transition_id) NOT IN (SELECT HEX(last_transition_id) FROM health_log WHERE host_id = x'fb5fc0224e3411ed82730b54b351e955');
count(*)
--------
86126   
sqlite> select count(*) from health_log_detail where HEX(transition_id) IN (SELECT HEX(last_transition_id) FROM health_log WHERE host_id = x'fb5fc0224e3411ed82730b54b351e955');
count(*)
--------
419     
```
