### PR TITLE
Update debug metadata

### DIFF
--- a/integrations/templates/troubleshooting.md
+++ b/integrations/templates/troubleshooting.md
@@ -41,6 +41,20 @@ should give you clues as to why the collector isn't working.
   ./charts.d.plugin debug 1 [[ entry.meta.module_name ]]
   ```
 
+[% elif entry.meta.plugin_name == 'xenstat.plugin' %]
+- Run the `xenstat.plugin` to debug the collector:
+
+  ```bash
+  ./xenstat.plugin debug 1 [[ entry.meta.module_name ]]
+  ```
+
+[% elif entry.meta.plugin_name == 'nfacct.plugin' %]
+- Run the `nfacct.plugin` to debug the collector:
+
+  ```bash
+  ./nfacct.plugin debug 1 [[ entry.meta.module_name ]]
+  ```
+
 [% endif %]
 [% else %]
 [% if entry.troubleshooting.problems.list %]


### PR DESCRIPTION
##### Summary
This PR is adding missing debug information for `xenstat` and `nfaact`.

##### Test Plan

1. Review grammar.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? Integration
- Can they see the change or is it an under the hood? If they can see it, where? When they access integration.
- How is the user impacted by the change? Detailed information about how to debug two plugins.
- What are there any benefits of the change?  A complete description about how to debug system.
</details>
