### PR TITLE
facets: data-only queries

### DIFF
--- a/collectors/systemd-journal.plugin/systemd-journal.c
+++ b/collectors/systemd-journal.plugin/systemd-journal.c
@@ -22,6 +22,7 @@
 #define SYSTEMD_JOURNAL_MAX_PARAMS              100
 #define SYSTEMD_JOURNAL_DEFAULT_QUERY_DURATION  (3 * 3600)
 #define SYSTEMD_JOURNAL_DEFAULT_ITEMS_PER_QUERY 200
+#define SYSTEMD_JOURNAL_EXCESS_ROWS_ALLOWED     50
 
 #define JOURNAL_PARAMETER_HELP                  "help"
 #define JOURNAL_PARAMETER_AFTER                 "after"
@@ -33,6 +34,7 @@
 #define JOURNAL_PARAMETER_HISTOGRAM             "histogram"
 #define JOURNAL_PARAMETER_DIRECTION             "direction"
 #define JOURNAL_PARAMETER_IF_MODIFIED_SINCE     "if_modified_since"
+#define JOURNAL_PARAMETER_DATA_ONLY_IF_NOT_MODIFIED_SINCE "data_only_if_not_modified_since"
 #define JOURNAL_PARAMETER_SOURCE                "source"
 #define JOURNAL_PARAMETER_INFO                  "info"
 
@@ -61,7 +63,7 @@ DICTIONARY *gids = NULL;
 
 // ----------------------------------------------------------------------------
 
-int systemd_journal_query(BUFFER *wb, FACETS *facets, usec_t after_ut, usec_t before_ut, usec_t if_modified_since, usec_t stop_monotonic_ut) {
+static inline sd_journal *netdata_open_systemd_journal(void) {
     sd_journal *j = NULL;
     int r;
 
@@ -82,36 +84,78 @@ int systemd_journal_query(BUFFER *wb, FACETS *facets, usec_t after_ut, usec_t be
 
     if (r < 0) {
         netdata_log_error("SYSTEMD-JOURNAL: Failed to open SystemD Journal, with error %d", r);
-        return HTTP_RESP_INTERNAL_SERVER_ERROR;
+        return NULL;
     }
 
-    facets_rows_begin(facets);
+    return j;
+}
 
-    uint64_t first_msg_ut = 0;
+typedef enum {
+    ND_SD_JOURNAL_FAILED_TO_SEEK,
+    ND_SD_JOURNAL_TIMED_OUT,
+    ND_SD_JOURNAL_OK,
+    ND_SD_JOURNAL_NOT_MODIFIED,
+} ND_SD_JOURNAL_STATUS;
+
+static inline bool netdata_systemd_journal_seek_to(sd_journal *j, usec_t timestamp) {
+    if(sd_journal_seek_realtime_usec(j, timestamp) < 0) {
+        netdata_log_error("SYSTEMD-JOURNAL: Failed to seek to %" PRIu64, timestamp);
+        if(sd_journal_seek_tail(j) < 0) {
+            netdata_log_error("SYSTEMD-JOURNAL: Failed to seek to journal's tail");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static inline void netdata_systemd_journal_process_row(sd_journal *j, FACETS *facets) {
+    const void *data;
+    size_t length;
+    SD_JOURNAL_FOREACH_DATA(j, data, length) {
+        const char *key = data;
+        const char *equal = strchr(key, '=');
+        if(unlikely(!equal))
+            continue;
+
+        const char *value = ++equal;
+        size_t key_length = value - key; // including '\0'
+
+        char key_copy[key_length];
+        memcpy(key_copy, key, key_length - 1);
+        key_copy[key_length - 1] = '\0';
+
+        size_t value_length = length - key_length; // without '\0'
+        facets_add_key_value_length(facets, key_copy, key_length - 1, value, value_length <= FACET_MAX_VALUE_LENGTH ? value_length : FACET_MAX_VALUE_LENGTH);
+    }
+}
+
+ND_SD_JOURNAL_STATUS netdata_systemd_journal_query_full(sd_journal *j, BUFFER *wb, FACETS *facets, usec_t after_ut, usec_t before_ut, usec_t if_modified_since, usec_t stop_monotonic_ut, usec_t *last_modified) {
+    if(!netdata_systemd_journal_seek_to(j, before_ut))
+        return ND_SD_JOURNAL_FAILED_TO_SEEK;
+
+    size_t errors_no_timestamp = 0;
+    usec_t first_msg_ut = 0;
     bool timed_out = false;
     size_t row_counter = 0;
 
     // the entries are not guaranteed to be sorted, so we process up to 100 entries beyond
     // the end of the query to find possibly useful logs for our time-frame
-    size_t excess_rows_allowed = 100;
+    size_t excess_rows_allowed = SYSTEMD_JOURNAL_EXCESS_ROWS_ALLOWED;
 
-    if(sd_journal_seek_realtime_usec(j, before_ut) < 0) {
-        netdata_log_error("SYSTEMD-JOURNAL: Failed to seek to %" PRIu64, before_ut);
-        if(sd_journal_seek_tail(j) < 0) {
-            netdata_log_error("SYSTEMD-JOURNAL: Failed to seek to journal's tail");
-            goto finalize;
-        }
-    }
+    facets_rows_begin(facets);
     while (sd_journal_previous(j) > 0) {
         row_counter++;
 
-        uint64_t msg_ut;
-        sd_journal_get_realtime_usec(j, &msg_ut);
+        usec_t msg_ut;
+        if(sd_journal_get_realtime_usec(j, &msg_ut) < 0) {
+            errors_no_timestamp++;
+            continue;
+        }
 
         if(unlikely(!first_msg_ut)) {
             if(msg_ut == if_modified_since) {
-                sd_journal_close(j);
-                return HTTP_RESP_NOT_MODIFIED;
+                return ND_SD_JOURNAL_NOT_MODIFIED;
             }
 
             first_msg_ut = msg_ut;
@@ -127,25 +171,7 @@ int systemd_journal_query(BUFFER *wb, FACETS *facets, usec_t after_ut, usec_t be
             continue;
         }
 
-        const void *data;
-        size_t length;
-        SD_JOURNAL_FOREACH_DATA(j, data, length) {
-            const char *key = data;
-            const char *equal = strchr(key, '=');
-            if(unlikely(!equal))
-                continue;
-
-            const char *value = ++equal;
-            size_t key_length = value - key; // including '\0'
-
-            char key_copy[key_length];
-            memcpy(key_copy, key, key_length - 1);
-            key_copy[key_length - 1] = '\0';
-
-            size_t value_length = length - key_length; // without '\0'
-            facets_add_key_value_length(facets, key_copy, key_length - 1, value, value_length <= FACET_MAX_VALUE_LENGTH ? value_length : FACET_MAX_VALUE_LENGTH);
-        }
-
+        netdata_systemd_journal_process_row(j, facets);
         facets_row_finished(facets, msg_ut);
 
         if((row_counter % 100) == 0 && now_monotonic_usec() > stop_monotonic_ut) {
@@ -154,25 +180,198 @@ int systemd_journal_query(BUFFER *wb, FACETS *facets, usec_t after_ut, usec_t be
         }
     }
 
-finalize:
+    if(errors_no_timestamp)
+        netdata_log_error("SYSTEMD-JOURNAL: %zu lines did not have timestamps", errors_no_timestamp);
+
+    *last_modified = first_msg_ut;
+
+    if(timed_out)
+        return ND_SD_JOURNAL_TIMED_OUT;
+
+    return ND_SD_JOURNAL_OK;
+}
+
+ND_SD_JOURNAL_STATUS netdata_systemd_journal_query_data_forward(sd_journal *j, BUFFER *wb, FACETS *facets, usec_t after_ut, usec_t before_ut, usec_t anchor, size_t entries, usec_t stop_monotonic_ut) {
+    if(!netdata_systemd_journal_seek_to(j, anchor))
+        return ND_SD_JOURNAL_FAILED_TO_SEEK;
+
+    size_t errors_no_timestamp = 0;
+    bool timed_out = false;
+    size_t row_counter = 0;
+    size_t rows_added = 0;
+
+    // the entries are not guaranteed to be sorted, so we process up to 100 entries beyond
+    // the end of the query to find possibly useful logs for our time-frame
+    size_t excess_rows_allowed = SYSTEMD_JOURNAL_EXCESS_ROWS_ALLOWED;
+
+    facets_rows_begin(facets);
+    while (sd_journal_next(j) > 0) {
+        row_counter++;
+
+        usec_t msg_ut;
+        if(sd_journal_get_realtime_usec(j, &msg_ut) < 0) {
+            errors_no_timestamp++;
+            continue;
+        }
+
+        if (msg_ut > before_ut || msg_ut <= anchor)
+            continue;
+
+        if (msg_ut < after_ut) {
+            if(--excess_rows_allowed == 0)
+                break;
+
+            continue;
+        }
+
+        if(rows_added > entries && --excess_rows_allowed == 0)
+            break;
+
+        netdata_systemd_journal_process_row(j, facets);
+        facets_row_finished(facets, msg_ut);
+        rows_added++;
+
+        if((row_counter % 100) == 0 && now_monotonic_usec() > stop_monotonic_ut) {
+            timed_out = true;
+            break;
+        }
+    }
+
+    if(errors_no_timestamp)
+        netdata_log_error("SYSTEMD-JOURNAL: %zu lines did not have timestamps", errors_no_timestamp);
+
+    if(timed_out)
+        return ND_SD_JOURNAL_TIMED_OUT;
+
+    return ND_SD_JOURNAL_OK;
+}
+
+ND_SD_JOURNAL_STATUS netdata_systemd_journal_query_data_backward(sd_journal *j, BUFFER *wb, FACETS *facets, usec_t after_ut, usec_t before_ut, usec_t anchor, size_t entries, usec_t stop_monotonic_ut) {
+    if(!netdata_systemd_journal_seek_to(j, anchor))
+        return ND_SD_JOURNAL_FAILED_TO_SEEK;
+
+    size_t errors_no_timestamp = 0;
+    bool timed_out = false;
+    size_t row_counter = 0;
+    size_t rows_added = 0;
+
+    // the entries are not guaranteed to be sorted, so we process up to 100 entries beyond
+    // the end of the query to find possibly useful logs for our time-frame
+    size_t excess_rows_allowed = SYSTEMD_JOURNAL_EXCESS_ROWS_ALLOWED;
+
+    facets_rows_begin(facets);
+    while (sd_journal_previous(j) > 0) {
+        row_counter++;
+
+        usec_t msg_ut;
+        if(sd_journal_get_realtime_usec(j, &msg_ut) < 0) {
+            errors_no_timestamp++;
+            continue;
+        }
+
+        if (msg_ut > before_ut || msg_ut >= anchor)
+            continue;
+
+        if (msg_ut < after_ut) {
+            if(--excess_rows_allowed == 0)
+                break;
+
+            continue;
+        }
+
+        if(rows_added > entries && --excess_rows_allowed == 0)
+            break;
+
+        netdata_systemd_journal_process_row(j, facets);
+        facets_row_finished(facets, msg_ut);
+        rows_added++;
+
+        if((row_counter % 100) == 0 && now_monotonic_usec() > stop_monotonic_ut) {
+            timed_out = true;
+            break;
+        }
+    }
+
+    if(errors_no_timestamp)
+        netdata_log_error("SYSTEMD-JOURNAL: %zu lines did not have timestamps", errors_no_timestamp);
+
+    if(timed_out)
+        return ND_SD_JOURNAL_TIMED_OUT;
+
+    return ND_SD_JOURNAL_OK;
+}
+
+bool systemd_journal_check_if_modified_since(sd_journal *j, usec_t seek_to, usec_t last_modified) {
+    // return true, if data have been modified since the timestamp
+
+    if(!netdata_systemd_journal_seek_to(j, seek_to))
+        return false;
+
+    usec_t first_msg_ut;
+    while (sd_journal_previous(j) > 0) {
+        usec_t msg_ut;
+        if(sd_journal_get_realtime_usec(j, &msg_ut) < 0)
+            continue;
+
+        if(!first_msg_ut) {
+            first_msg_ut = msg_ut;
+            break;
+        }
+    }
+
+    return first_msg_ut != last_modified;
+}
+
+static int netdata_systemd_journal_query(BUFFER *wb, FACETS *facets,
+                                         usec_t after_ut, usec_t before_ut,
+                                         usec_t anchor, FACETS_ANCHOR_DIRECTION direction, size_t entries,
+                                         usec_t if_modified_since, usec_t data_only_if_not_modified_since,
+                                         usec_t stop_monotonic_ut) {
+    sd_journal *j = netdata_open_systemd_journal();
+    if(!j)
+        return HTTP_RESP_INTERNAL_SERVER_ERROR;
+
+    usec_t last_modified = 0;
+
+    ND_SD_JOURNAL_STATUS status;
+
+    if(data_only_if_not_modified_since && !systemd_journal_check_if_modified_since(j, before_ut, data_only_if_not_modified_since)) {
+        facets_data_only_mode(facets);
+
+        // we can do a data-only query
+        if(direction == FACETS_ANCHOR_DIRECTION_FORWARD)
+            status = netdata_systemd_journal_query_data_forward(j, wb, facets, after_ut, before_ut, anchor, entries, stop_monotonic_ut);
+        else
+            status = netdata_systemd_journal_query_data_backward(j, wb, facets, after_ut, before_ut, anchor, entries, stop_monotonic_ut);
+    }
+    else {
+        // we have to do a full query
+        status = netdata_systemd_journal_query_full(j, wb, facets,
+                                                    after_ut, before_ut, if_modified_since,
+                                                    stop_monotonic_ut, &last_modified);
+    }
+
     sd_journal_close(j);
 
-    buffer_json_member_add_uint64(wb, "status", HTTP_RESP_OK);
-    buffer_json_member_add_boolean(wb, "partial", timed_out);
+    if(status == ND_SD_JOURNAL_NOT_MODIFIED)
+        return HTTP_RESP_NOT_MODIFIED;
+
+    buffer_json_member_add_uint64(wb, "status", status == ND_SD_JOURNAL_FAILED_TO_SEEK ? HTTP_RESP_INTERNAL_SERVER_ERROR : HTTP_RESP_OK);
+    buffer_json_member_add_boolean(wb, "partial", status != ND_SD_JOURNAL_OK);
     buffer_json_member_add_string(wb, "type", "table");
     buffer_json_member_add_time_t(wb, "update_every", 1);
     buffer_json_member_add_string(wb, "help", SYSTEMD_JOURNAL_FUNCTION_DESCRIPTION);
-    buffer_json_member_add_uint64(wb, "last_modified", first_msg_ut);
+    buffer_json_member_add_uint64(wb, "last_modified", last_modified);
 
     facets_report(facets, wb);
 
     buffer_json_member_add_time_t(wb, "expires", now_realtime_sec());
     buffer_json_finalize(wb);
 
-    return HTTP_RESP_OK;
+    return status == ND_SD_JOURNAL_FAILED_TO_SEEK ? HTTP_RESP_INTERNAL_SERVER_ERROR : HTTP_RESP_OK;
 }
 
-static void systemd_journal_function_help(const char *transaction) {
+static void netdata_systemd_journal_function_help(const char *transaction) {
     pluginsd_function_result_begin_to_stdout(transaction, HTTP_RESP_OK, "text/plain", now_realtime_sec() + 3600);
     fprintf(stdout,
             "%s / %s\n"
@@ -255,6 +454,26 @@ static const char *syslog_priority_to_name(int priority) {
     }
 }
 
+static FACET_ROW_SEVERITY syslog_priority_to_facet_severity(int priority) {
+    // same to
+    // https://github.com/systemd/systemd/blob/aab9e4b2b86905a15944a1ac81e471b5b7075932/src/basic/terminal-util.c#L1501
+    // function get_log_colors()
+
+    if(priority <= LOG_ERR)
+        return FACET_ROW_SEVERITY_CRITICAL;
+
+    else if (priority <= LOG_WARNING)
+        return FACET_ROW_SEVERITY_WARNING;
+
+    else if(priority <= LOG_NOTICE)
+        return FACET_ROW_SEVERITY_NOTICE;
+
+    else if(priority >= LOG_DEBUG)
+        return FACET_ROW_SEVERITY_DEBUG;
+
+    return FACET_ROW_SEVERITY_NORMAL;
+}
+
 static char *uid_to_username(uid_t uid, char *buffer, size_t buffer_size) {
     struct passwd pw, *result;
     char tmp[1024 + 1];
@@ -277,7 +496,7 @@ static char *gid_to_groupname(gid_t gid, char* buffer, size_t buffer_size) {
     return buffer;
 }
 
-static void systemd_journal_transform_syslog_facility(FACETS *facets __maybe_unused, BUFFER *wb, void *data __maybe_unused) {
+static void netdata_systemd_journal_transform_syslog_facility(FACETS *facets __maybe_unused, BUFFER *wb, void *data __maybe_unused) {
     const char *v = buffer_tostring(wb);
     if(*v && isdigit(*v)) {
         int facility = str2i(buffer_tostring(wb));
@@ -289,7 +508,7 @@ static void systemd_journal_transform_syslog_facility(FACETS *facets __maybe_unu
     }
 }
 
-static void systemd_journal_transform_priority(FACETS *facets __maybe_unused, BUFFER *wb, void *data __maybe_unused) {
+static void netdata_systemd_journal_transform_priority(FACETS *facets __maybe_unused, BUFFER *wb, void *data __maybe_unused) {
     const char *v = buffer_tostring(wb);
     if(*v && isdigit(*v)) {
         int priority = str2i(buffer_tostring(wb));
@@ -298,10 +517,12 @@ static void systemd_journal_transform_priority(FACETS *facets __maybe_unused, BU
             buffer_flush(wb);
             buffer_strcat(wb, name);
         }
+
+        facets_set_current_row_severity(facets, syslog_priority_to_facet_severity(priority));
     }
 }
 
-static void systemd_journal_transform_uid(FACETS *facets __maybe_unused, BUFFER *wb, void *data) {
+static void netdata_systemd_journal_transform_uid(FACETS *facets __maybe_unused, BUFFER *wb, void *data) {
     DICTIONARY *cache = data;
     const char *v = buffer_tostring(wb);
     if(*v && isdigit(*v)) {
@@ -321,7 +542,7 @@ static void systemd_journal_transform_uid(FACETS *facets __maybe_unused, BUFFER 
     }
 }
 
-static void systemd_journal_transform_gid(FACETS *facets __maybe_unused, BUFFER *wb, void *data) {
+static void netdata_systemd_journal_transform_gid(FACETS *facets __maybe_unused, BUFFER *wb, void *data) {
     DICTIONARY *cache = data;
     const char *v = buffer_tostring(wb);
     if(*v && isdigit(*v)) {
@@ -341,7 +562,7 @@ static void systemd_journal_transform_gid(FACETS *facets __maybe_unused, BUFFER 
     }
 }
 
-static void systemd_journal_dynamic_row_id(FACETS *facets __maybe_unused, BUFFER *json_array, FACET_ROW_KEY_VALUE *rkv, FACET_ROW *row, void *data __maybe_unused) {
+static void netdata_systemd_journal_dynamic_row_id(FACETS *facets __maybe_unused, BUFFER *json_array, FACET_ROW_KEY_VALUE *rkv, FACET_ROW *row, void *data __maybe_unused) {
     FACET_ROW_KEY_VALUE *pid_rkv = dictionary_get(row->dict, "_PID");
     const char *pid = pid_rkv ? buffer_tostring(pid_rkv->wb) : FACET_VALUE_UNSET;
 
@@ -384,37 +605,39 @@ static void function_systemd_journal(const char *transaction, char *function, ch
     facets_accepted_param(facets, JOURNAL_PARAMETER_FACETS);
     facets_accepted_param(facets, JOURNAL_PARAMETER_HISTOGRAM);
     facets_accepted_param(facets, JOURNAL_PARAMETER_IF_MODIFIED_SINCE);
+    facets_accepted_param(facets, JOURNAL_PARAMETER_DATA_ONLY_IF_NOT_MODIFIED_SINCE);
 
     // register the fields in the order you want them on the dashboard
 
     facets_register_dynamic_key_name(facets, "ND_JOURNAL_PROCESS",
                                      FACET_KEY_OPTION_NEVER_FACET | FACET_KEY_OPTION_VISIBLE | FACET_KEY_OPTION_FTS,
-                                     systemd_journal_dynamic_row_id, NULL);
+                                     netdata_systemd_journal_dynamic_row_id, NULL);
 
     facets_register_key_name(facets, "MESSAGE",
                              FACET_KEY_OPTION_NEVER_FACET | FACET_KEY_OPTION_MAIN_TEXT | FACET_KEY_OPTION_VISIBLE |
                              FACET_KEY_OPTION_FTS);
 
     facets_register_key_name_transformation(facets, "PRIORITY", FACET_KEY_OPTION_FACET | FACET_KEY_OPTION_FTS,
-                                            systemd_journal_transform_priority, NULL);
+                                            netdata_systemd_journal_transform_priority, NULL);
 
     facets_register_key_name_transformation(facets, "SYSLOG_FACILITY", FACET_KEY_OPTION_FACET | FACET_KEY_OPTION_FTS,
-                                            systemd_journal_transform_syslog_facility, NULL);
+                                            netdata_systemd_journal_transform_syslog_facility, NULL);
 
     facets_register_key_name(facets, "SYSLOG_IDENTIFIER", FACET_KEY_OPTION_FACET | FACET_KEY_OPTION_FTS);
     facets_register_key_name(facets, "UNIT", FACET_KEY_OPTION_FACET | FACET_KEY_OPTION_FTS);
     facets_register_key_name(facets, "USER_UNIT", FACET_KEY_OPTION_FACET | FACET_KEY_OPTION_FTS);
 
     facets_register_key_name_transformation(facets, "_UID", FACET_KEY_OPTION_FACET | FACET_KEY_OPTION_FTS,
-                                            systemd_journal_transform_uid, uids);
+                                            netdata_systemd_journal_transform_uid, uids);
 
     facets_register_key_name_transformation(facets, "_GID", FACET_KEY_OPTION_FACET | FACET_KEY_OPTION_FTS,
-                                            systemd_journal_transform_gid, gids);
+                                            netdata_systemd_journal_transform_gid, gids);
 
     bool info = false;
     time_t after_s = 0, before_s = 0;
     usec_t anchor = 0;
     usec_t if_modified_since = 0;
+    usec_t data_only_if_not_modified_since = 0;
     size_t last = 0;
     FACETS_ANCHOR_DIRECTION direction = FACETS_ANCHOR_DIRECTION_BACKWARD;
     const char *query = NULL;
@@ -430,7 +653,7 @@ static void function_systemd_journal(const char *transaction, char *function, ch
         if(!keyword) break;
 
         if(strcmp(keyword, JOURNAL_PARAMETER_HELP) == 0) {
-            systemd_journal_function_help(transaction);
+            netdata_systemd_journal_function_help(transaction);
             goto cleanup;
         }
         else if(strcmp(keyword, JOURNAL_PARAMETER_INFO) == 0) {
@@ -447,6 +670,9 @@ static void function_systemd_journal(const char *transaction, char *function, ch
         }
         else if(strncmp(keyword, JOURNAL_PARAMETER_IF_MODIFIED_SINCE ":", sizeof(JOURNAL_PARAMETER_IF_MODIFIED_SINCE ":") - 1) == 0) {
             if_modified_since = str2ull(&keyword[sizeof(JOURNAL_PARAMETER_IF_MODIFIED_SINCE ":") - 1], NULL);
+        }
+        else if(strncmp(keyword, JOURNAL_PARAMETER_DATA_ONLY_IF_NOT_MODIFIED_SINCE ":", sizeof(JOURNAL_PARAMETER_DATA_ONLY_IF_NOT_MODIFIED_SINCE ":") - 1) == 0) {
+            data_only_if_not_modified_since = str2ull(&keyword[sizeof(JOURNAL_PARAMETER_DATA_ONLY_IF_NOT_MODIFIED_SINCE ":") - 1], NULL);
         }
         else if(strncmp(keyword, JOURNAL_PARAMETER_ANCHOR ":", sizeof(JOURNAL_PARAMETER_ANCHOR ":") - 1) == 0) {
             anchor = str2ull(&keyword[sizeof(JOURNAL_PARAMETER_ANCHOR ":") - 1], NULL);
@@ -580,8 +806,10 @@ static void function_systemd_journal(const char *transaction, char *function, ch
     facets_set_query(facets, query);
     facets_set_histogram(facets, chart ? chart : "PRIORITY", after_s * USEC_PER_SEC, before_s * USEC_PER_SEC);
 
-    response = systemd_journal_query(wb, facets, after_s * USEC_PER_SEC, before_s * USEC_PER_SEC,
-                                     if_modified_since, now_monotonic_usec() + (timeout - 1) * USEC_PER_SEC);
+    response = netdata_systemd_journal_query(wb, facets, after_s * USEC_PER_SEC, before_s * USEC_PER_SEC,
+                                             anchor, direction, last,
+                                             if_modified_since, data_only_if_not_modified_since,
+                                             now_monotonic_usec() + (timeout - 1) * USEC_PER_SEC);
 
     if(response != HTTP_RESP_OK) {
         pluginsd_function_json_error_to_stdout(transaction, response, "failed");

--- a/libnetdata/buffer/buffer.h
+++ b/libnetdata/buffer/buffer.h
@@ -938,10 +938,12 @@ typedef enum __attribute__((packed)) {
     RRDF_FIELD_OPTS_VISIBLE      = (1 << 1), // the field should be visible by default
     RRDF_FIELD_OPTS_STICKY       = (1 << 2), // the field should be sticky
     RRDF_FIELD_OPTS_FULL_WIDTH   = (1 << 3), // the field should get full width
-    RRDF_FIELD_OPTS_WRAP         = (1 << 4), // the field should get full width
+    RRDF_FIELD_OPTS_WRAP         = (1 << 4), // the field should wrap
+    RRDR_FIELD_OPTS_DUMMY        = (1 << 5), // not a presentable field
 } RRDF_FIELD_OPTIONS;
 
 typedef enum __attribute__((packed)) {
+    RRDF_FIELD_TYPE_NONE,
     RRDF_FIELD_TYPE_INTEGER,
     RRDF_FIELD_TYPE_STRING,
     RRDF_FIELD_TYPE_DETAIL_STRING,
@@ -954,6 +956,9 @@ typedef enum __attribute__((packed)) {
 static inline const char *rrdf_field_type_to_string(RRDF_FIELD_TYPE type) {
     switch(type) {
         default:
+        case RRDF_FIELD_TYPE_NONE:
+            return "none";
+
         case RRDF_FIELD_TYPE_INTEGER:
             return "integer";
 
@@ -978,10 +983,11 @@ static inline const char *rrdf_field_type_to_string(RRDF_FIELD_TYPE type) {
 }
 
 typedef enum __attribute__((packed)) {
-    RRDF_FIELD_VISUAL_VALUE,    // show the value, possibly applying a transformation
-    RRDF_FIELD_VISUAL_BAR,      // show the value and a bar, respecting the max field to fill the bar at 100%
-    RRDF_FIELD_VISUAL_PILL,     //
-    RRDF_FIELD_VISUAL_MARKDOC,  //
+    RRDF_FIELD_VISUAL_VALUE,        // show the value, possibly applying a transformation
+    RRDF_FIELD_VISUAL_BAR,          // show the value and a bar, respecting the max field to fill the bar at 100%
+    RRDF_FIELD_VISUAL_PILL,         //
+    RRDF_FIELD_VISUAL_RICH,         //
+    RRDR_FIELD_VISUAL_ROW_OPTIONS,  // this is a dummy column that is used for row options
 } RRDF_FIELD_VISUAL;
 
 static inline const char *rrdf_field_visual_to_string(RRDF_FIELD_VISUAL visual) {
@@ -996,8 +1002,11 @@ static inline const char *rrdf_field_visual_to_string(RRDF_FIELD_VISUAL visual) 
         case RRDF_FIELD_VISUAL_PILL:
             return "pill";
 
-        case RRDF_FIELD_VISUAL_MARKDOC:
-            return "markdoc";
+        case RRDF_FIELD_VISUAL_RICH:
+            return "richValue";
+
+        case RRDR_FIELD_VISUAL_ROW_OPTIONS:
+            return "rowOptions";
     }
 }
 
@@ -1144,6 +1153,9 @@ buffer_rrdf_table_add_field(BUFFER *wb, size_t field_id, const char *key, const 
 
         buffer_json_member_add_boolean(wb, "full_width", options & RRDF_FIELD_OPTS_FULL_WIDTH);
         buffer_json_member_add_boolean(wb, "wrap", options & RRDF_FIELD_OPTS_WRAP);
+
+        if(options & RRDR_FIELD_OPTS_DUMMY)
+            buffer_json_member_add_boolean(wb, "dummy", true);
     }
     buffer_json_object_close(wb);
 }

--- a/libnetdata/facets/facets.h
+++ b/libnetdata/facets/facets.h
@@ -21,6 +21,14 @@ typedef enum __attribute__((packed)) {
     FACET_KEY_OPTION_REORDER        = (1 << 7), // give the key a new order id on first encounter
 } FACET_KEY_OPTIONS;
 
+typedef enum __attribute__((packed)) {
+    FACET_ROW_SEVERITY_DEBUG,       // lowest - not important
+    FACET_ROW_SEVERITY_NORMAL,      // the default
+    FACET_ROW_SEVERITY_NOTICE,      // bold
+    FACET_ROW_SEVERITY_WARNING,     // yellow + bold
+    FACET_ROW_SEVERITY_CRITICAL,    // red + bold
+} FACET_ROW_SEVERITY;
+
 typedef struct facet_row_key_value {
     const char *tmp;
     BUFFER *wb;
@@ -30,6 +38,7 @@ typedef struct facet_row_key_value {
 typedef struct facet_row {
     usec_t usec;
     DICTIONARY *dict;
+    FACET_ROW_SEVERITY severity;
     struct facet_row *prev, *next;
 } FACET_ROW;
 
@@ -47,6 +56,8 @@ FACET_KEY *facets_register_key_name_transformation(FACETS *facets, const char *k
 typedef enum __attribute__((packed)) {
     FACETS_OPTION_ALL_FACETS_VISIBLE    = (1 << 0), // all facets, should be visible by default in the table
     FACETS_OPTION_ALL_KEYS_FTS          = (1 << 1), // all keys are searchable by full text search
+    FACETS_OPTION_DISABLE_ALL_FACETS    = (1 << 2),
+    FACETS_OPTION_DISABLE_HISTOGRAM     = (1 << 3),
 } FACETS_OPTIONS;
 
 FACETS *facets_create(uint32_t items_to_return, FACETS_OPTIONS options, const char *visible_keys, const char *facet_keys, const char *non_facet_keys);
@@ -70,5 +81,7 @@ void facets_add_key_value_length(FACETS *facets, const char *key, size_t key_len
 
 void facets_report(FACETS *facets, BUFFER *wb);
 void facets_accepted_parameters_to_json_array(FACETS *facets, BUFFER *wb, bool with_keys);
+void facets_set_current_row_severity(FACETS *facets, FACET_ROW_SEVERITY severity);
+void facets_data_only_mode(FACETS *facets);
 
 #endif


### PR DESCRIPTION
This PR adds the parameter `data_only_if_not_modified_since:{timestamp}` which executes a fast data query to retrieve entries from the log, without recalculating all the facets for the entire timeframe.

So, the first time the facets come up, the entire timeframe is calculated by passing all the log lines through the facets library, but then retrieval of individual log lines inside that timeframe just seek the db to the proper location and retrieve the wanted number of log entries.

The `timestamp` parameter should be the `last_modified` of a previous response.

If the data have been modified in the database, the query will recalculate the entire time-frame.

---

Additionally, there is now a hidden column at which the severity of the log lines is exposed to the UI, for coloring the rows accordingly.