### PR TITLE
Skip trying to preserve file owners when bundling external code.

### DIFF
--- a/packaging/bundle-ebpf-co-re.sh
+++ b/packaging/bundle-ebpf-co-re.sh
@@ -6,4 +6,4 @@ CORE_VERSION="$(cat "${SRCDIR}/packaging/ebpf-co-re.version")"
 CORE_TARBALL="netdata-ebpf-co-re-glibc-${CORE_VERSION}.tar.xz"
 curl -sSL --connect-timeout 10 --retry 3 "https://github.com/netdata/ebpf-co-re/releases/download/${CORE_VERSION}/${CORE_TARBALL}" > "${CORE_TARBALL}" || exit 1
 grep "${CORE_TARBALL}" "${SRCDIR}/packaging/ebpf-co-re.checksums" | sha256sum -c - || exit 1
-tar -xaf "${CORE_TARBALL}" -C "${SRCDIR}/collectors/ebpf.plugin" || exit 1
+tar -xa --no-same-owner -f "${CORE_TARBALL}" -C "${SRCDIR}/collectors/ebpf.plugin" || exit 1

--- a/packaging/bundle-ebpf.sh
+++ b/packaging/bundle-ebpf.sh
@@ -11,7 +11,7 @@ if [ -x "${PLUGINDIR}/ebpf.plugin" ] || [ "${FORCE}" = "force" ]; then
     mkdir -p "${SRCDIR}/tmp/ebpf"
     curl -sSL --connect-timeout 10 --retry 3 "https://github.com/netdata/kernel-collector/releases/download/${EBPF_VERSION}/${EBPF_TARBALL}" > "${EBPF_TARBALL}" || exit 1
     grep "${EBPF_TARBALL}" "${SRCDIR}/packaging/ebpf.checksums" | sha256sum -c - || exit 1
-    tar -xvaf "${EBPF_TARBALL}" -C "${SRCDIR}/tmp/ebpf" || exit 1
+    tar -xva --no-same-owner -f "${EBPF_TARBALL}" -C "${SRCDIR}/tmp/ebpf" || exit 1
     if [ ! -d "${PLUGINDIR}/ebpf.d" ];then
         mkdir "${PLUGINDIR}/ebpf.d"
     fi

--- a/packaging/bundle-libbpf.sh
+++ b/packaging/bundle-libbpf.sh
@@ -20,7 +20,7 @@ LIBBPF_BUILD_PATH="${1}/externaldeps/libbpf/libbpf-$(cat "${1}/packaging/libbpf.
 mkdir -p "${1}/externaldeps/libbpf" || exit 1
 curl -sSL --connect-timeout 10 --retry 3 "https://github.com/netdata/libbpf/archive/${LIBBPF_TARBALL}" > "${LIBBPF_TARBALL}" || exit 1
 sha256sum -c "${1}/packaging/libbpf.checksums" || exit 1
-tar -xzf "${LIBBPF_TARBALL}" -C "${1}/externaldeps/libbpf" || exit 1
+tar -xz --no-same-owner -f "${LIBBPF_TARBALL}" -C "${1}/externaldeps/libbpf" || exit 1
 make -C "${LIBBPF_BUILD_PATH}/src" BUILD_STATIC_ONLY=1 OBJDIR=build/ DESTDIR=../ install || exit 1
 cp -r "${LIBBPF_BUILD_PATH}/usr/${lib_subdir}/libbpf.a" "${1}/externaldeps/libbpf" || exit 1
 cp -r "${LIBBPF_BUILD_PATH}/usr/include" "${1}/externaldeps/libbpf" || exit 1

--- a/packaging/bundle-protobuf.sh
+++ b/packaging/bundle-protobuf.sh
@@ -6,7 +6,7 @@ PROTOBUF_BUILD_PATH="${1}/externaldeps/protobuf/protobuf-$(cat "${1}/packaging/p
 mkdir -p "${1}/externaldeps/protobuf" || exit 1
 curl -sSL --connect-timeout 10 --retry 3 "https://github.com/protocolbuffers/protobuf/releases/download/v$(cat "${1}/packaging/protobuf.version")/${PROTOBUF_TARBALL}" > "${PROTOBUF_TARBALL}" || exit 1
 sha256sum -c "${1}/packaging/protobuf.checksums" || exit 1
-tar -xzf "${PROTOBUF_TARBALL}" -C "${1}/externaldeps/protobuf" || exit 1
+tar -xz --no-same-owner -f "${PROTOBUF_TARBALL}" -C "${1}/externaldeps/protobuf" || exit 1
 OLDPWD="${PWD}"
 cd "${PROTOBUF_BUILD_PATH}" || exit 1
 ./configure --disable-shared --without-zlib --disable-dependency-tracking --with-pic || exit 1


### PR DESCRIPTION
##### Summary

This fixes an issue that shows up when building packages for some distros (most notably CentOS 7) with a rootless container runtime (such as using Podman for the build as a regular user).

##### Test Plan

This one is a bit tricky to test. It requires using a rootless container runtime (either Podman or rootless Docker, run as a regular user other than root) to attempt to build one of our native packages, but the failure is only observed with some target distributions (CentOS 7 is the only one I’ve currently confirmed to be affected, but I suspect it affects most of the other target distributions as well), and it may be dependent specific aspects of configuration of the build host as well.

On affected setups without this PR, error messages should be seen complaining about failing to change file ownership when extracting tarballs.

On affected setups with this PR, the above-mentioned errors should not be seen.