### PR TITLE
Prepare FD to be used wth functions.

### DIFF
--- a/collectors/ebpf.plugin/ebpf.d.conf
+++ b/collectors/ebpf.plugin/ebpf.d.conf
@@ -61,7 +61,7 @@
     cachestat = yes
     dcstat = no
     disk = no
-    fd = yes
+    fd = no
     filesystem = no
     hardirq = no
     mdflush = no


### PR DESCRIPTION
##### Summary
After we detect that FD can consume a lot of resources in specific kernel versions, we are disabling it by default to start working with its function.

##### Test Plan


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
