### PR TITLE
Split cgroup charts

### DIFF
--- a/collectors/cgroups.plugin/metadata.yaml
+++ b/collectors/cgroups.plugin/metadata.yaml
@@ -821,154 +821,104 @@ modules:
       description: ""
       availability: []
       scopes:
-        - name: global
+        - name: systemd service
           description: ""
-          labels: []
+          labels:
+            - name: cgroup_name
+              description: Service name
           metrics:
-            - name: services.cpu
+            - name: systemd.service.cpu.utilization
               description: Systemd Services CPU utilization (100% = 1 core)
-              unit: "percentage"
+              unit: percentage
               chart_type: stacked
               dimensions:
-                - name: a dimension per systemd service
-            - name: services.mem_usage
+                - name: user
+                - name: system
+            - name: systemd.service.memory.usage
               description: Systemd Services Used Memory
-              unit: "MiB"
+              unit: MiB
               chart_type: stacked
               dimensions:
-                - name: a dimension per systemd service
-            - name: services.mem_rss
-              description: Systemd Services RSS Memory
-              unit: "MiB"
-              chart_type: stacked
-              dimensions:
-                - name: a dimension per systemd service
-            - name: services.mem_mapped
-              description: Systemd Services Mapped Memory
-              unit: "MiB"
-              chart_type: stacked
-              dimensions:
-                - name: a dimension per systemd service
-            - name: services.mem_cache
-              description: Systemd Services Cache Memory
-              unit: "MiB"
-              chart_type: stacked
-              dimensions:
-                - name: a dimension per systemd service
-            - name: services.mem_writeback
-              description: Systemd Services Writeback Memory
-              unit: "MiB"
-              chart_type: stacked
-              dimensions:
-                - name: a dimension per systemd service
-            - name: services.mem_pgfault
-              description: Systemd Services Memory Minor Page Faults
-              unit: "MiB/s"
-              chart_type: stacked
-              dimensions:
-                - name: a dimension per systemd service
-            - name: services.mem_pgmajfault
-              description: Systemd Services Memory Major Page Faults
-              unit: "MiB/s"
-              chart_type: stacked
-              dimensions:
-                - name: a dimension per systemd service
-            - name: services.mem_pgpgin
-              description: Systemd Services Memory Charging Activity
-              unit: "MiB/s"
-              chart_type: stacked
-              dimensions:
-                - name: a dimension per systemd service
-            - name: services.mem_pgpgout
-              description: Systemd Services Memory Uncharging Activity
-              unit: "MiB/s"
-              chart_type: stacked
-              dimensions:
-                - name: a dimension per systemd service
-            - name: services.mem_failcnt
+                - name: ram
+                - name: swap
+            - name: systemd.service.memory.failcnt
               description: Systemd Services Memory Limit Failures
-              unit: "failures"
+              unit: failures/s
+              chart_type: line
+              dimensions:
+                - name: fail
+            - name: systemd.service.memory.ram.usage
+              description: Systemd Services Memory
+              unit: MiB
               chart_type: stacked
               dimensions:
-                - name: a dimension per systemd service
-            - name: services.swap_usage
-              description: Systemd Services Swap Memory Used
-              unit: "MiB"
+                - name: rss
+                - name: cache
+                - name: mapped_file
+                - name: rss_huge
+            - name: systemd.service.memory.writeback
+              description: Systemd Services Writeback Memory
+              unit: MiB
               chart_type: stacked
               dimensions:
-                - name: a dimension per systemd service
-            - name: services.io_read
-              description: Systemd Services Disk Read Bandwidth
-              unit: "KiB/s"
-              chart_type: stacked
+                - name: writeback
+                - name: dirty
+            - name: systemd.service.memory.paging.faults
+              description: Systemd Services Memory Minor and Major Page Faults
+              unit: MiB/s
+              chart_type: area
               dimensions:
-                - name: a dimension per systemd service
-            - name: services.io_write
-              description: Systemd Services Disk Write Bandwidth
-              unit: "KiB/s"
-              chart_type: stacked
+                - name: minor
+                - name: major
+            - name: systemd.service.memory.paging.io
+              description: Systemd Services Memory Paging IO
+              unit: MiB/s
+              chart_type: area
               dimensions:
-                - name: a dimension per systemd service
-            - name: services.io_ops_read
-              description: Systemd Services Disk Read Operations
-              unit: "operations/s"
-              chart_type: stacked
+                - name: in
+                - name: out
+            - name: systemd.service.disk.io
+              description: Systemd Services Disk Read/Write Bandwidth
+              unit: KiB/s
+              chart_type: area
               dimensions:
-                - name: a dimension per systemd service
-            - name: services.io_ops_write
-              description: Systemd Services Disk Write Operations
-              unit: "operations/s"
-              chart_type: stacked
+                - name: read
+                - name: write
+            - name: systemd.service.disk.iops
+              description: Systemd Services Disk Read/Write Operations
+              unit: operations/s
+              chart_type: line
               dimensions:
-                - name: a dimension per systemd service
-            - name: services.throttle_io_read
-              description: Systemd Services Throttle Disk Read Bandwidth
-              unit: "KiB/s"
-              chart_type: stacked
+                - name: read
+                - name: write
+            - name: systemd.service.disk.throttle.io
+              description: Systemd Services Throttle Disk Read/Write Bandwidth
+              unit: KiB/s
+              chart_type: area
               dimensions:
-                - name: a dimension per systemd service
-            - name: services.services.throttle_io_write
-              description: Systemd Services Throttle Disk Write Bandwidth
-              unit: "KiB/s"
-              chart_type: stacked
+                - name: read
+                - name: write
+            - name: systemd.service.disk.throttle.iops
+              description: Systemd Services Throttle Disk Read/Write Operations
+              unit: operations/s
+              chart_type: line
               dimensions:
-                - name: a dimension per systemd service
-            - name: services.throttle_io_ops_read
-              description: Systemd Services Throttle Disk Read Operations
-              unit: "operations/s"
-              chart_type: stacked
+                - name: read
+                - name: write
+            - name: systemd.service.disk.queued_iops
+              description: Systemd Services Queued Disk Read/Write Operations
+              unit: operations/s
+              chart_type: line
               dimensions:
-                - name: a dimension per systemd service
-            - name: throttle_io_ops_write
-              description: Systemd Services Throttle Disk Write Operations
-              unit: "operations/s"
-              chart_type: stacked
+                - name: read
+                - name: write
+            - name: systemd.service.disk.merged_iops
+              description: Systemd Services Merged Disk Read/Write Operations
+              unit: operations/s
+              chart_type: line
               dimensions:
-                - name: a dimension per systemd service
-            - name: services.queued_io_ops_read
-              description: Systemd Services Queued Disk Read Operations
-              unit: "operations/s"
-              chart_type: stacked
-              dimensions:
-                - name: a dimension per systemd service
-            - name: services.queued_io_ops_write
-              description: Systemd Services Queued Disk Write Operations
-              unit: "operations/s"
-              chart_type: stacked
-              dimensions:
-                - name: a dimension per systemd service
-            - name: services.merged_io_ops_read
-              description: Systemd Services Merged Disk Read Operations
-              unit: "operations/s"
-              chart_type: stacked
-              dimensions:
-                - name: a dimension per systemd service
-            - name: services.merged_io_ops_write
-              description: Systemd Services Merged Disk Write Operations
-              unit: "operations/s"
-              chart_type: stacked
-              dimensions:
-                - name: a dimension per systemd service
+                - name: read
+                - name: write
   - <<: *module
     meta:
       <<: *meta

--- a/collectors/cgroups.plugin/metadata.yaml
+++ b/collectors/cgroups.plugin/metadata.yaml
@@ -824,7 +824,7 @@ modules:
         - name: systemd service
           description: ""
           labels:
-            - name: cgroup_name
+            - name: service_name
               description: Service name
           metrics:
             - name: systemd.service.cpu.utilization

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -880,12 +880,10 @@ struct cgroup {
     const RRDSETVAR_ACQUIRED *chart_var_memoryswap_limit;
 
     // services
-    RRDDIM *rd_throttle_io_read;
     RRDDIM *rd_throttle_io_serviced_read;
     RRDDIM *rd_io_queued_read;
     RRDDIM *rd_io_merged_read;
 
-    RRDDIM *rd_throttle_io_write;
     RRDDIM *rd_throttle_io_serviced_write;
     RRDDIM *rd_io_queued_write;
     RRDDIM *rd_io_merged_write;
@@ -2858,60 +2856,20 @@ void update_systemd_services_charts(
         , int do_merged_ops
 ) {
     static RRDSET
-        *st_throttle_io_read = NULL,
         *st_throttle_ops_read = NULL,
         *st_queued_ops_read = NULL,
         *st_merged_ops_read = NULL,
 
-        *st_throttle_io_write = NULL,
         *st_throttle_ops_write = NULL,
         *st_queued_ops_write = NULL,
         *st_merged_ops_write = NULL;
 
     // create the charts
 
-    if(likely(do_throttle_io)) {
-        if(unlikely(!st_throttle_io_read)) {
-
-            st_throttle_io_read = rrdset_create_localhost(
-                    "services"
-                    , "throttle_io_read"
-                    , NULL
-                    , "disk"
-                    , "services.throttle_io_read"
-                    , "Systemd Services Throttle Disk Read Bandwidth"
-                    , "KiB/s"
-                    , PLUGIN_CGROUPS_NAME
-                    , PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME
-                    , NETDATA_CHART_PRIO_CGROUPS_SYSTEMD + 160
-                    , update_every
-                    , RRDSET_TYPE_STACKED
-            );
-
-        }
-
-        if(unlikely(!st_throttle_io_write)) {
-            st_throttle_io_write = rrdset_create_localhost(
-                    "services"
-                    , "throttle_io_write"
-                    , NULL
-                    , "disk"
-                    , "services.throttle_io_write"
-                    , "Systemd Services Throttle Disk Write Bandwidth"
-                    , "KiB/s"
-                    , PLUGIN_CGROUPS_NAME
-                    , PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME
-                    , NETDATA_CHART_PRIO_CGROUPS_SYSTEMD + 170
-                    , update_every
-                    , RRDSET_TYPE_STACKED
-            );
-        }
-    }
-
     if(likely(do_throttle_ops)) {
         if(unlikely(!st_throttle_ops_read)) {
             st_throttle_ops_read = rrdset_create_localhost(
-                    "services"
+                "services"
                     , "throttle_io_ops_read"
                     , NULL
                     , "disk"
@@ -3231,7 +3189,7 @@ void update_systemd_services_charts(
         if(likely(do_io && cg->io_service_bytes.updated)) {
             if (unlikely(!cg->st_io)) {
                 cg->st_io = rrdset_create_localhost(
-                    "services"
+                    cgroup_chart_type(type, services_chart_id_prefix, cg->chart_title, RRD_ID_LENGTH_MAX)
                     , "io"
                     , NULL
                     , "disk"
@@ -3258,12 +3216,12 @@ void update_systemd_services_charts(
         if(likely(do_io_ops && cg->io_serviced.updated)) {
             if(unlikely(!cg->st_serviced_ops)) {
                 cg->st_serviced_ops = rrdset_create_localhost(
-                    "services"
-                        , "io_ops_read"
+                    cgroup_chart_type(type, services_chart_id_prefix, cg->chart_title, RRD_ID_LENGTH_MAX)
+                        , "io_ops"
                         , NULL
                         , "disk"
-                        , "services.io_ops_read"
-                        , "Systemd Services Disk Read Write Operations"
+                        , "systemd.services.io_ops"
+                        , "Systemd Services Disk Read/Write Operations"
                         , "operations/s"
                         , PLUGIN_CGROUPS_NAME
                         , PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME
@@ -3282,15 +3240,28 @@ void update_systemd_services_charts(
         }
 
         if(likely(do_throttle_io && cg->throttle_io_service_bytes.updated)) {
-            if(unlikely(!cg->rd_throttle_io_read))
-                cg->rd_throttle_io_read = rrddim_add(st_throttle_io_read, cg->chart_id, cg->chart_title, 1, 1024, RRD_ALGORITHM_INCREMENTAL);
+            if(unlikely(!cg->st_throttle_io)) {
+                cg->st_throttle_io = rrdset_create_localhost(
+                    cgroup_chart_type(type, services_chart_id_prefix, cg->chart_title, RRD_ID_LENGTH_MAX),
+                    "throttle_io",
+                    NULL,
+                    "disk",
+                    "systemd.services.throttle_io",
+                    "Systemd Services Throttle Disk Read/Write Bandwidth",
+                    "KiB/s",
+                    PLUGIN_CGROUPS_NAME,
+                    PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
+                    prio++,
+                    update_every,
+                    RRDSET_TYPE_STACKED);
 
-            rrddim_set_by_pointer(st_throttle_io_read, cg->rd_throttle_io_read, cg->throttle_io_service_bytes.Read);
-
-            if(unlikely(!cg->rd_throttle_io_write))
-                cg->rd_throttle_io_write = rrddim_add(st_throttle_io_write, cg->chart_id, cg->chart_title, 1, 1024, RRD_ALGORITHM_INCREMENTAL);
-
-            rrddim_set_by_pointer(st_throttle_io_write, cg->rd_throttle_io_write, cg->throttle_io_service_bytes.Write);
+                rrdset_update_rrdlabels(cg->st_throttle_io, cg->chart_labels);
+                rrddim_add(cg->st_throttle_io, "read", NULL, 1, 1024, RRD_ALGORITHM_INCREMENTAL);
+                rrddim_add(cg->st_throttle_io, "write", NULL, 1, 1024, RRD_ALGORITHM_INCREMENTAL);
+            }
+            rrddim_set(cg->st_throttle_io, "write", cg->throttle_io_service_bytes.Write);
+            rrddim_set(cg->st_throttle_io, "read", cg->throttle_io_service_bytes.Read);
+            rrdset_done(cg->st_throttle_io);
         }
 
         if(likely(do_throttle_ops && cg->throttle_io_serviced.updated)) {
@@ -3328,11 +3299,6 @@ void update_systemd_services_charts(
 
             rrddim_set_by_pointer(st_merged_ops_write, cg->rd_io_merged_write, cg->io_merged.Write);
         }
-    }
-
-    if(likely(do_throttle_io)) {
-        rrdset_done(st_throttle_io_read);
-        rrdset_done(st_throttle_io_write);
     }
 
     if(likely(do_throttle_ops)) {

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2784,6 +2784,14 @@ static inline char *cgroup_chart_type(char *buffer, const char *prefix, const ch
     return buffer;
 }
 
+static inline void cgroup_add_service_label(RRDLABELS *labels)
+{
+    if (rrdlabels_exist(labels, "services"))
+        return;
+
+    rrdlabels_add(labels, "service", "yes", RRDLABEL_SRC_AUTO);
+}
+
 void cgroup_discovery_worker(void *ptr)
 {
     UNUSED(ptr);
@@ -2855,6 +2863,7 @@ void update_systemd_services_charts(
         if(unlikely(!cg->enabled || cg->pending_renames || !is_cgroup_systemd_service(cg)))
             continue;
 
+        cgroup_add_service_label(cg->chart_labels);
         type[0] = '\0';
         if(likely(do_cpu && cg->cpuacct_stat.updated)) {
             if (unlikely(!cg->st_cpu)) {
@@ -2872,6 +2881,7 @@ void update_systemd_services_charts(
                                                      update_every,
                                                      RRDSET_TYPE_STACKED
                     );
+
                 rrdset_update_rrdlabels(cg->st_cpu, cg->chart_labels);
                 if (!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) {
                     rrddim_add(cg->st_cpu, "user", NULL, 100, system_hz, RRD_ALGORITHM_INCREMENTAL);

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2529,7 +2529,7 @@ static inline void discovery_share_cgroups_with_ebpf() {
 
     for (cg = cgroup_root, count = 0; cg; cg = cg->next, count++) {
         netdata_ebpf_cgroup_shm_body_t *ptr = &shm_cgroup_ebpf.body[count];
-        char *prefix = (is_cgroup_systemd_service(cg)) ? "" : "cgroup_";
+        char *prefix = (is_cgroup_systemd_service(cg)) ? services_chart_id_prefix : cgroup_chart_id_prefix;
         snprintfz(ptr->name, CGROUP_EBPF_NAME_SHARED_LENGTH - 1, "%s%s", prefix, cg->chart_id);
         ptr->hash = simple_hash(ptr->name);
         ptr->options = cg->options;

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -3123,7 +3123,6 @@ void update_systemd_services_charts(
                                                      RRDSET_TYPE_STACKED
                     );
                 rrdset_update_rrdlabels(cg->st_cpu, cg->chart_labels);
-
                 if (!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) {
                     rrddim_add(cg->st_cpu, "user", NULL, 100, system_hz, RRD_ALGORITHM_INCREMENTAL);
                     rrddim_add(cg->st_cpu, "system", NULL, 100, system_hz, RRD_ALGORITHM_INCREMENTAL);
@@ -3158,12 +3157,12 @@ void update_systemd_services_charts(
 
                 rrdset_update_rrdlabels(cg->st_mem_usage, cg->chart_labels);
                 rrddim_add(cg->st_mem_usage, "ram", NULL, 1, 1024*1024, RRD_ALGORITHM_ABSOLUTE);
-                if (likely(do_swap_usage && cg->memory.updated_msw_usage_in_bytes))
+                if (likely(do_swap_usage))
                     rrddim_add(cg->st_mem_usage, "swap", NULL, 1, 1024*1024, RRD_ALGORITHM_ABSOLUTE);
             }
 
             rrddim_set(cg->st_mem_usage, "ram", cg->memory.usage_in_bytes);
-            if (likely(do_swap_usage && cg->memory.updated_msw_usage_in_bytes)) {
+            if (likely(do_swap_usage) {
                 if(!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) {
                     rrddim_set(cg->st_mem_usage,
                                "swap",
@@ -3249,11 +3248,11 @@ void update_systemd_services_charts(
                     );
 
                 rrdset_update_rrdlabels(cg->st_mem, cg->chart_labels);
-                rrddim_add(cg->st_writeback, "write_back", NULL, 1, 1024*1024, RRD_ALGORITHM_ABSOLUTE);
+                rrddim_add(cg->st_writeback, "writeback", NULL, 1, 1024*1024, RRD_ALGORITHM_ABSOLUTE);
                 rrddim_add(cg->st_writeback, "dirty", NULL, 1, 1024*1024, RRD_ALGORITHM_ABSOLUTE);
             }
 
-            rrddim_set(cg->st_writeback, "write_back", cg->memory.total_writeback);
+            rrddim_set(cg->st_writeback, "writeback", cg->memory.total_writeback);
             rrddim_set(cg->st_writeback, "dirty", cg->memory.total_dirty);
             rrdset_done(cg->st_writeback);
 
@@ -3285,7 +3284,7 @@ void update_systemd_services_charts(
             if(unlikely(!cg->st_mem_activity)) {
                 cg->st_mem_activity = rrdset_create_localhost(
                     cgroup_chart_type(type, services_chart_id_prefix, cg->chart_title, RRD_ID_LENGTH_MAX)
-                    , "mem_pgpgin"
+                    , "mem_activity"
                     , NULL
                     , "mem"
                     , "systemd.services.memory.activity"

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2874,7 +2874,6 @@ void update_systemd_services_charts(
         , int do_merged_ops
 ) {
     static RRDSET
-        *st_mem_usage = NULL,
         *st_mem_failcnt = NULL,
         *st_swap_usage = NULL,
 
@@ -3359,7 +3358,7 @@ void update_systemd_services_charts(
             }
 
             rrddim_set(cg->st_mem_usage, "ram", cg->memory.usage_in_bytes);
-            rrdset_done(st_mem_usage);
+            rrdset_done(cg->st_mem_usage);
         }
 
         if(likely(do_mem_detailed && cg->memory.updated_detailed)) {

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -880,8 +880,6 @@ struct cgroup {
     const RRDSETVAR_ACQUIRED *chart_var_memoryswap_limit;
 
     // services
-    RRDDIM *rd_mem_detailed_cache;
-    RRDDIM *rd_mem_detailed_rss;
     RRDDIM *rd_mem_detailed_mapped;
     RRDDIM *rd_mem_detailed_writeback;
     RRDDIM *rd_mem_detailed_pgpgin;
@@ -2871,7 +2869,6 @@ void update_systemd_services_charts(
         , int do_merged_ops
 ) {
     static RRDSET
-        *st_mem_detailed_cache = NULL,
         *st_mem_detailed_mapped = NULL,
         *st_mem_detailed_writeback = NULL,
         *st_mem_detailed_pgfault = NULL,
@@ -3246,14 +3243,15 @@ void update_systemd_services_charts(
                                                      update_every,
                                                      RRDSET_TYPE_STACKED
                     );
-            }
+                rrdset_update_rrdlabels(cg->st_cpu, cg->chart_labels);
 
-            if (!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) {
-                rrddim_add(cg->st_cpu, "user", NULL, 100, system_hz, RRD_ALGORITHM_INCREMENTAL);
-                rrddim_add(cg->st_cpu, "system", NULL, 100, system_hz, RRD_ALGORITHM_INCREMENTAL);
-            } else {
-                rrddim_add(cg->st_cpu, "user", NULL, 100, 1000000, RRD_ALGORITHM_INCREMENTAL);
-                rrddim_add(cg->st_cpu, "system", NULL, 100, 1000000, RRD_ALGORITHM_INCREMENTAL);
+                if (!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) {
+                    rrddim_add(cg->st_cpu, "user", NULL, 100, system_hz, RRD_ALGORITHM_INCREMENTAL);
+                    rrddim_add(cg->st_cpu, "system", NULL, 100, system_hz, RRD_ALGORITHM_INCREMENTAL);
+                } else {
+                    rrddim_add(cg->st_cpu, "user", NULL, 100, 1000000, RRD_ALGORITHM_INCREMENTAL);
+                    rrddim_add(cg->st_cpu, "system", NULL, 100, 1000000, RRD_ALGORITHM_INCREMENTAL);
+                }
             }
 
             // complete the iteration
@@ -3279,6 +3277,7 @@ void update_systemd_services_charts(
                     , RRDSET_TYPE_STACKED
                     );
 
+                rrdset_update_rrdlabels(cg->st_mem_usage, cg->chart_labels);
                 rrddim_add(cg->st_mem_usage, "ram", NULL, 1, 1024*1024, RRD_ALGORITHM_ABSOLUTE);
                 if (likely(do_swap_usage && cg->memory.updated_msw_usage_in_bytes))
                     rrddim_add(cg->st_mem_usage, "swap", NULL, 1, 1024*1024, RRD_ALGORITHM_ABSOLUTE);
@@ -3315,6 +3314,7 @@ void update_systemd_services_charts(
                     , RRDSET_TYPE_STACKED
                     );
 
+                rrdset_update_rrdlabels(cg->st_mem_failcnt, cg->chart_labels);
                 rrddim_add(cg->st_mem_failcnt, "fail", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
             }
 
@@ -3340,6 +3340,7 @@ void update_systemd_services_charts(
                     , RRDSET_TYPE_STACKED
                     );
 
+                rrdset_update_rrdlabels(cg->st_mem, cg->chart_labels);
                 rrddim_add(cg->st_mem, "rss", NULL, 1, 1024*1024, RRD_ALGORITHM_ABSOLUTE);
                 rrddim_add(cg->st_mem, "cache", NULL, 1, 1024*1024, RRD_ALGORITHM_ABSOLUTE);
             }

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -3535,13 +3535,13 @@ void update_systemd_services_charts(
     }
 }
 
-static inline char *cgroup_chart_type(char *buffer, const char *id, size_t len) {
+static inline char *cgroup_chart_type(char *buffer, const char *prefix, const char *id, size_t len) {
     if(buffer[0]) return buffer;
 
     if(id[0] == '\0' || (id[0] == '/' && id[1] == '\0'))
         strncpy(buffer, "cgroup_root", len);
     else
-        snprintfz(buffer, len, "%s%s", cgroup_chart_id_prefix, id);
+        snprintfz(buffer, len, "%s%s", prefix, id);
 
     netdata_fix_chart_id(buffer);
     return buffer;
@@ -3711,7 +3711,7 @@ void update_cgroup_charts(int update_every) {
                     k8s_is_kubepod(cg) ? "CPU Usage (100%% = 1000 mCPU)" : "CPU Usage (100%% = 1 core)");
 
                 cg->st_cpu = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "cpu"
                         , NULL
                         , "cpu"
@@ -3780,7 +3780,7 @@ void update_cgroup_charts(int update_every) {
                             snprintfz(title, CHART_TITLE_MAX, "CPU Usage within the limits");
 
                             cg->st_cpu_limit = rrdset_create_localhost(
-                                    cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                                    cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                                     , "cpu_limit"
                                     , NULL
                                     , "cpu"
@@ -3832,7 +3832,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "CPU Throttled Runnable Periods");
 
                 cg->st_cpu_nr_throttled = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "throttled"
                         , NULL
                         , "cpu"
@@ -3857,7 +3857,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "CPU Throttled Time Duration");
 
                 cg->st_cpu_throttled_time = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "throttled_duration"
                         , NULL
                         , "cpu"
@@ -3884,7 +3884,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "CPU Time Relative Share");
 
                 cg->st_cpu_shares = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "cpu_shares"
                         , NULL
                         , "cpu"
@@ -3918,7 +3918,7 @@ void update_cgroup_charts(int update_every) {
                                          "CPU Usage (100%% = 1 core) Per Core");
 
                 cg->st_cpu_per_core = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "cpu_per_core"
                         , NULL
                         , "cpu"
@@ -3952,7 +3952,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Memory Usage");
 
                 cg->st_mem = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "mem"
                         , NULL
                         , "mem"
@@ -4010,7 +4010,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Writeback Memory");
 
                 cg->st_writeback = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "writeback"
                         , NULL
                         , "mem"
@@ -4043,7 +4043,7 @@ void update_cgroup_charts(int update_every) {
                     snprintfz(title, CHART_TITLE_MAX, "Memory Activity");
 
                     cg->st_mem_activity = rrdset_create_localhost(
-                            cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                            cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                             , "mem_activity"
                             , NULL
                             , "mem"
@@ -4072,7 +4072,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Memory Page Faults");
 
                 cg->st_pgfaults = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "pgfaults"
                         , NULL
                         , "mem"
@@ -4102,7 +4102,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Used Memory");
 
                 cg->st_mem_usage = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "mem_usage"
                         , NULL
                         , "mem"
@@ -4167,7 +4167,7 @@ void update_cgroup_charts(int update_every) {
                         snprintfz(title, CHART_TITLE_MAX, "Used RAM within the limits");
 
                         cg->st_mem_usage_limit = rrdset_create_localhost(
-                                cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                                cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                                 , "mem_usage_limit"
                                 , NULL
                                 , "mem"
@@ -4197,7 +4197,7 @@ void update_cgroup_charts(int update_every) {
                         snprintfz(title, CHART_TITLE_MAX, "Memory Utilization");
 
                         cg->st_mem_utilization = rrdset_create_localhost(
-                                cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                                cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                                 , "mem_utilization"
                                 , NULL
                                 , "mem"
@@ -4245,7 +4245,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Memory Limit Failures");
 
                 cg->st_mem_failcnt = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "mem_failcnt"
                         , NULL
                         , "mem"
@@ -4273,7 +4273,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "I/O Bandwidth (all disks)");
 
                 cg->st_io = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "io"
                         , NULL
                         , "disk"
@@ -4303,7 +4303,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Serviced I/O Operations (all disks)");
 
                 cg->st_serviced_ops = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "serviced_ops"
                         , NULL
                         , "disk"
@@ -4333,7 +4333,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Throttle I/O Bandwidth (all disks)");
 
                 cg->st_throttle_io = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "throttle_io"
                         , NULL
                         , "disk"
@@ -4363,7 +4363,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Throttle Serviced I/O Operations (all disks)");
 
                 cg->st_throttle_serviced_ops = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "throttle_serviced_ops"
                         , NULL
                         , "disk"
@@ -4393,7 +4393,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Queued I/O Operations (all disks)");
 
                 cg->st_queued_ops = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "queued_ops"
                         , NULL
                         , "disk"
@@ -4423,7 +4423,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Merged I/O Operations (all disks)");
 
                 cg->st_merged_ops = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "merged_ops"
                         , NULL
                         , "disk"
@@ -4459,7 +4459,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "CPU some pressure");
                     chart = pcs->share_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "cpu_some_pressure"
                         , NULL
                         , "cpu"
@@ -4482,7 +4482,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "CPU some pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "cpu_some_pressure_stall_time"
                         , NULL
                         , "cpu"
@@ -4509,7 +4509,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "CPU full pressure");
                     chart = pcs->share_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                       cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "cpu_full_pressure"
                         , NULL
                         , "cpu"
@@ -4532,7 +4532,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "CPU full pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "cpu_full_pressure_stall_time"
                         , NULL
                         , "cpu"
@@ -4562,7 +4562,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "Memory some pressure");
                     chart = pcs->share_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "mem_some_pressure"
                         , NULL
                         , "mem"
@@ -4585,7 +4585,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "Memory some pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "memory_some_pressure_stall_time"
                         , NULL
                         , "mem"
@@ -4614,7 +4614,7 @@ void update_cgroup_charts(int update_every) {
                     snprintfz(title, CHART_TITLE_MAX, "Memory full pressure");
 
                     chart = pcs->share_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "mem_full_pressure"
                         , NULL
                         , "mem"
@@ -4638,7 +4638,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "Memory full pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "memory_full_pressure_stall_time"
                         , NULL
                         , "mem"
@@ -4668,7 +4668,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "IRQ some pressure");
                     chart = pcs->share_time.st = rrdset_create_localhost(
-                            cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                     cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                     , "irq_some_pressure"
                     , NULL
                     , "interrupts"
@@ -4691,7 +4691,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "IRQ some pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
-                            cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                            cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                     , "irq_some_pressure_stall_time"
                     , NULL
                     , "interrupts"
@@ -4720,7 +4720,7 @@ void update_cgroup_charts(int update_every) {
                     snprintfz(title, CHART_TITLE_MAX, "IRQ full pressure");
 
                     chart = pcs->share_time.st = rrdset_create_localhost(
-                            cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                            cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                     , "irq_full_pressure"
                     , NULL
                     , "interrupts"
@@ -4744,7 +4744,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "IRQ full pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
-                            cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                            cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                     , "irq_full_pressure_stall_time"
                     , NULL
                     , "interrupts"
@@ -4774,7 +4774,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "I/O some pressure");
                     chart = pcs->share_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "io_some_pressure"
                         , NULL
                         , "disk"
@@ -4797,7 +4797,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "I/O some pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "io_some_pressure_stall_time"
                         , NULL
                         , "disk"
@@ -4825,7 +4825,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "I/O full pressure");
                     chart = pcs->share_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "io_full_pressure"
                         , NULL
                         , "disk"
@@ -4848,7 +4848,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "I/O full pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cg->chart_id, RRD_ID_LENGTH_MAX)
+                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "io_full_pressure_stall_time"
                         , NULL
                         , "disk"

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2959,7 +2959,7 @@ void update_systemd_services_charts(
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
                     prio++,
                     update_every,
-                    RRDSET_TYPE_STACKED);
+                    RRDSET_TYPE_LINE);
 
                 rrdset_update_rrdlabels(cg->st_mem_failcnt, cg->chart_labels);
                 rrddim_add(cg->st_mem_failcnt, "fail", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
@@ -3035,7 +3035,7 @@ void update_systemd_services_charts(
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
                     prio++,
                     update_every,
-                    RRDSET_TYPE_STACKED);
+                    RRDSET_TYPE_AREA);
 
                 rrdset_update_rrdlabels(cg->st_pgfaults, cg->chart_labels);
                 rrddim_add(cg->st_pgfaults, "minor", NULL, system_page_size, 1024 * 1024, RRD_ALGORITHM_INCREMENTAL);
@@ -3059,7 +3059,7 @@ void update_systemd_services_charts(
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
                     prio++,
                     update_every,
-                    RRDSET_TYPE_STACKED);
+                    RRDSET_TYPE_AREA);
 
                 rrdset_update_rrdlabels(cg->st_mem_activity, cg->chart_labels);
                 rrddim_add(cg->st_mem_activity, "in", NULL, system_page_size, 1024 * 1024, RRD_ALGORITHM_INCREMENTAL);
@@ -3085,7 +3085,7 @@ void update_systemd_services_charts(
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
                     prio++,
                     update_every,
-                    RRDSET_TYPE_STACKED);
+                    RRDSET_TYPE_AREA);
 
                 rrdset_update_rrdlabels(cg->st_io, cg->chart_labels);
                 rrddim_add(cg->st_io, "write", NULL, 1, 1024, RRD_ALGORITHM_INCREMENTAL);
@@ -3111,7 +3111,7 @@ void update_systemd_services_charts(
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
                     prio++,
                     update_every,
-                    RRDSET_TYPE_STACKED);
+                    RRDSET_TYPE_LINE);
 
                 rrdset_update_rrdlabels(cg->st_serviced_ops, cg->chart_labels);
                 rrddim_add(cg->st_serviced_ops, "read", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
@@ -3136,7 +3136,7 @@ void update_systemd_services_charts(
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
                     prio++,
                     update_every,
-                    RRDSET_TYPE_STACKED);
+                    RRDSET_TYPE_AREA);
 
                 rrdset_update_rrdlabels(cg->st_throttle_io, cg->chart_labels);
                 rrddim_add(cg->st_throttle_io, "read", NULL, 1, 1024, RRD_ALGORITHM_INCREMENTAL);
@@ -3162,7 +3162,7 @@ void update_systemd_services_charts(
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
                     prio++,
                     update_every,
-                    RRDSET_TYPE_STACKED);
+                    RRDSET_TYPE_LINE);
 
                 rrdset_update_rrdlabels(cg->st_throttle_serviced_ops, cg->chart_labels);
                 rrddim_add(cg->st_throttle_serviced_ops, "read", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
@@ -3188,7 +3188,7 @@ void update_systemd_services_charts(
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
                     prio++,
                     update_every,
-                    RRDSET_TYPE_STACKED);
+                    RRDSET_TYPE_LINE);
 
                 rrdset_update_rrdlabels(cg->st_queued_ops, cg->chart_labels);
                 rrddim_add(cg->st_queued_ops, "read", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
@@ -3213,7 +3213,7 @@ void update_systemd_services_charts(
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
                     prio++,
                     update_every,
-                    RRDSET_TYPE_STACKED);
+                    RRDSET_TYPE_LINE);
 
                 rrdset_update_rrdlabels(cg->st_merged_ops, cg->chart_labels);
                 rrddim_add(cg->st_merged_ops, "read", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2786,10 +2786,10 @@ static inline char *cgroup_chart_type(char *buffer, const char *prefix, const ch
 
 static inline void cgroup_add_service_label(RRDLABELS *labels)
 {
-    if (rrdlabels_exist(labels, "services"))
+    if (rrdlabels_exist(labels, "systemd_services"))
         return;
 
-    rrdlabels_add(labels, "service", "yes", RRDLABEL_SRC_AUTO);
+    rrdlabels_add(labels, "systemd_services", "yes", RRDLABEL_SRC_AUTO);
 }
 
 void cgroup_discovery_worker(void *ptr)

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2891,7 +2891,7 @@ void update_systemd_services_charts(
         if (unlikely(do_mem_usage && cg->memory.updated_usage_in_bytes)) {
             if (unlikely(!cg->st_mem_usage)) {
                 cg->st_mem_usage = rrdset_create_localhost(
-                    cgroup_chart_type(type, services_chart_id_prefix, cg->chart_title, RRD_ID_LENGTH_MAX)
+                      cgroup_chart_type(type, services_chart_id_prefix, cg->chart_title, RRD_ID_LENGTH_MAX)
                     , "mem_usage"
                     , NULL
                     , "mem"
@@ -2954,7 +2954,7 @@ void update_systemd_services_charts(
         if(likely(do_mem_detailed && cg->memory.updated_detailed)) {
             if(unlikely(!cg->st_mem)) {
                 cg->st_mem = rrdset_create_localhost(
-                    cgroup_chart_type(type, services_chart_id_prefix, cg->chart_title, RRD_ID_LENGTH_MAX)
+                      cgroup_chart_type(type, services_chart_id_prefix, cg->chart_title, RRD_ID_LENGTH_MAX)
                     , "mem_ram"
                     , NULL
                     , "mem"
@@ -2983,7 +2983,7 @@ void update_systemd_services_charts(
 
             if(unlikely(!cg->st_writeback)) {
                 cg->st_writeback = rrdset_create_localhost(
-                    cgroup_chart_type(type, services_chart_id_prefix, cg->chart_title, RRD_ID_LENGTH_MAX)
+                      cgroup_chart_type(type, services_chart_id_prefix, cg->chart_title, RRD_ID_LENGTH_MAX)
                     , "mem_writeback"
                     , NULL
                     , "mem"
@@ -3379,7 +3379,7 @@ void update_cgroup_charts(int update_every) {
                     k8s_is_kubepod(cg) ? "CPU Usage (100%% = 1000 mCPU)" : "CPU Usage (100%% = 1 core)");
 
                 cg->st_cpu = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "cpu"
                         , NULL
                         , "cpu"
@@ -3448,7 +3448,7 @@ void update_cgroup_charts(int update_every) {
                             snprintfz(title, CHART_TITLE_MAX, "CPU Usage within the limits");
 
                             cg->st_cpu_limit = rrdset_create_localhost(
-                                    cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                                      cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                                     , "cpu_limit"
                                     , NULL
                                     , "cpu"
@@ -3500,7 +3500,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "CPU Throttled Runnable Periods");
 
                 cg->st_cpu_nr_throttled = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "throttled"
                         , NULL
                         , "cpu"
@@ -3525,7 +3525,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "CPU Throttled Time Duration");
 
                 cg->st_cpu_throttled_time = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "throttled_duration"
                         , NULL
                         , "cpu"
@@ -3552,7 +3552,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "CPU Time Relative Share");
 
                 cg->st_cpu_shares = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "cpu_shares"
                         , NULL
                         , "cpu"
@@ -3586,7 +3586,7 @@ void update_cgroup_charts(int update_every) {
                                          "CPU Usage (100%% = 1 core) Per Core");
 
                 cg->st_cpu_per_core = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "cpu_per_core"
                         , NULL
                         , "cpu"
@@ -3620,7 +3620,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Memory Usage");
 
                 cg->st_mem = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "mem"
                         , NULL
                         , "mem"
@@ -3678,7 +3678,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Writeback Memory");
 
                 cg->st_writeback = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "writeback"
                         , NULL
                         , "mem"
@@ -3711,7 +3711,7 @@ void update_cgroup_charts(int update_every) {
                     snprintfz(title, CHART_TITLE_MAX, "Memory Activity");
 
                     cg->st_mem_activity = rrdset_create_localhost(
-                            cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                              cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                             , "mem_activity"
                             , NULL
                             , "mem"
@@ -3740,7 +3740,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Memory Page Faults");
 
                 cg->st_pgfaults = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "pgfaults"
                         , NULL
                         , "mem"
@@ -3770,7 +3770,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Used Memory");
 
                 cg->st_mem_usage = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "mem_usage"
                         , NULL
                         , "mem"
@@ -3865,7 +3865,7 @@ void update_cgroup_charts(int update_every) {
                         snprintfz(title, CHART_TITLE_MAX, "Memory Utilization");
 
                         cg->st_mem_utilization = rrdset_create_localhost(
-                                cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                                  cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                                 , "mem_utilization"
                                 , NULL
                                 , "mem"
@@ -3913,7 +3913,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Memory Limit Failures");
 
                 cg->st_mem_failcnt = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "mem_failcnt"
                         , NULL
                         , "mem"
@@ -3941,7 +3941,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "I/O Bandwidth (all disks)");
 
                 cg->st_io = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "io"
                         , NULL
                         , "disk"
@@ -3971,7 +3971,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Serviced I/O Operations (all disks)");
 
                 cg->st_serviced_ops = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "serviced_ops"
                         , NULL
                         , "disk"
@@ -4001,7 +4001,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Throttle I/O Bandwidth (all disks)");
 
                 cg->st_throttle_io = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "throttle_io"
                         , NULL
                         , "disk"
@@ -4031,7 +4031,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Throttle Serviced I/O Operations (all disks)");
 
                 cg->st_throttle_serviced_ops = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "throttle_serviced_ops"
                         , NULL
                         , "disk"
@@ -4061,7 +4061,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Queued I/O Operations (all disks)");
 
                 cg->st_queued_ops = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "queued_ops"
                         , NULL
                         , "disk"
@@ -4091,7 +4091,7 @@ void update_cgroup_charts(int update_every) {
                 snprintfz(title, CHART_TITLE_MAX, "Merged I/O Operations (all disks)");
 
                 cg->st_merged_ops = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "merged_ops"
                         , NULL
                         , "disk"
@@ -4127,7 +4127,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "CPU some pressure");
                     chart = pcs->share_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "cpu_some_pressure"
                         , NULL
                         , "cpu"
@@ -4150,7 +4150,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "CPU some pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "cpu_some_pressure_stall_time"
                         , NULL
                         , "cpu"
@@ -4177,7 +4177,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "CPU full pressure");
                     chart = pcs->share_time.st = rrdset_create_localhost(
-                       cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "cpu_full_pressure"
                         , NULL
                         , "cpu"
@@ -4200,7 +4200,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "CPU full pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "cpu_full_pressure_stall_time"
                         , NULL
                         , "cpu"
@@ -4230,7 +4230,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "Memory some pressure");
                     chart = pcs->share_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "mem_some_pressure"
                         , NULL
                         , "mem"
@@ -4253,7 +4253,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "Memory some pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "memory_some_pressure_stall_time"
                         , NULL
                         , "mem"
@@ -4282,7 +4282,7 @@ void update_cgroup_charts(int update_every) {
                     snprintfz(title, CHART_TITLE_MAX, "Memory full pressure");
 
                     chart = pcs->share_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "mem_full_pressure"
                         , NULL
                         , "mem"
@@ -4306,7 +4306,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "Memory full pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "memory_full_pressure_stall_time"
                         , NULL
                         , "mem"
@@ -4336,7 +4336,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "IRQ some pressure");
                     chart = pcs->share_time.st = rrdset_create_localhost(
-                     cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                       cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                     , "irq_some_pressure"
                     , NULL
                     , "interrupts"
@@ -4359,7 +4359,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "IRQ some pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
-                            cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                      cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                     , "irq_some_pressure_stall_time"
                     , NULL
                     , "interrupts"
@@ -4388,7 +4388,7 @@ void update_cgroup_charts(int update_every) {
                     snprintfz(title, CHART_TITLE_MAX, "IRQ full pressure");
 
                     chart = pcs->share_time.st = rrdset_create_localhost(
-                            cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                      cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                     , "irq_full_pressure"
                     , NULL
                     , "interrupts"
@@ -4412,7 +4412,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "IRQ full pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
-                            cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                      cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                     , "irq_full_pressure_stall_time"
                     , NULL
                     , "interrupts"
@@ -4442,7 +4442,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "I/O some pressure");
                     chart = pcs->share_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "io_some_pressure"
                         , NULL
                         , "disk"
@@ -4465,7 +4465,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "I/O some pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "io_some_pressure_stall_time"
                         , NULL
                         , "disk"
@@ -4493,7 +4493,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "I/O full pressure");
                     chart = pcs->share_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "io_full_pressure"
                         , NULL
                         , "disk"
@@ -4516,7 +4516,7 @@ void update_cgroup_charts(int update_every) {
                     RRDSET *chart;
                     snprintfz(title, CHART_TITLE_MAX, "I/O full pressure stall time");
                     chart = pcs->total_time.st = rrdset_create_localhost(
-                        cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
+                          cgroup_chart_type(type, cgroup_chart_id_prefix, cg->chart_id, RRD_ID_LENGTH_MAX)
                         , "io_full_pressure_stall_time"
                         , NULL
                         , "disk"

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -3203,7 +3203,7 @@ void update_systemd_services_charts(
                     update_every,
                     RRDSET_TYPE_STACKED);
 
-                rrdset_update_rrdlabels(cg->st_queued_ops, cg->chart_labels);
+                rrdset_update_rrdlabels(cg->st_merged_ops, cg->chart_labels);
                 rrddim_add(cg->st_merged_ops, "read", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
                 rrddim_add(cg->st_merged_ops, "write", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
             }

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2913,23 +2913,6 @@ void update_systemd_services_charts(
             );
         }
 
-        if(unlikely(!st_mem_detailed_cache)) {
-            st_mem_detailed_cache = rrdset_create_localhost(
-                    "services"
-                    , "mem_cache"
-                    , NULL
-                    , "mem"
-                    , "services.mem_cache"
-                    , "Systemd Services Cache Memory"
-                    , "MiB"
-                    , PLUGIN_CGROUPS_NAME
-                    , PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME
-                    , NETDATA_CHART_PRIO_CGROUPS_SYSTEMD + 40
-                    , update_every
-                    , RRDSET_TYPE_STACKED
-            );
-        }
-
         if(unlikely(!st_mem_detailed_writeback)) {
             st_mem_detailed_writeback = rrdset_create_localhost(
                     "services"
@@ -3358,20 +3341,17 @@ void update_systemd_services_charts(
                     );
 
                 rrddim_add(cg->st_mem, "rss", NULL, 1, 1024*1024, RRD_ALGORITHM_ABSOLUTE);
+                rrddim_add(cg->st_mem, "cache", NULL, 1, 1024*1024, RRD_ALGORITHM_ABSOLUTE);
             }
 
             rrddim_set(cg->st_mem, "rss", cg->memory.total_rss);
+            rrddim_set(cg->st_mem, "cache", cg->memory.total_cache);
             rrdset_done(cg->st_mem);
 
             if(unlikely(!cg->rd_mem_detailed_mapped))
                 cg->rd_mem_detailed_mapped = rrddim_add(st_mem_detailed_mapped, cg->chart_id, cg->chart_title, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
 
             rrddim_set_by_pointer(st_mem_detailed_mapped, cg->rd_mem_detailed_mapped, cg->memory.total_mapped_file);
-
-            if(unlikely(!cg->rd_mem_detailed_cache))
-                cg->rd_mem_detailed_cache = rrddim_add(st_mem_detailed_cache, cg->chart_id, cg->chart_title, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
-
-            rrddim_set_by_pointer(st_mem_detailed_cache, cg->rd_mem_detailed_cache, cg->memory.total_cache);
 
             if(unlikely(!cg->rd_mem_detailed_writeback))
                 cg->rd_mem_detailed_writeback = rrddim_add(st_mem_detailed_writeback, cg->chart_id, cg->chart_title, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
@@ -3473,7 +3453,6 @@ void update_systemd_services_charts(
     }
 
     if(unlikely(do_mem_detailed)) {
-        rrdset_done(st_mem_detailed_cache);
         rrdset_done(st_mem_detailed_mapped);
         rrdset_done(st_mem_detailed_writeback);
         rrdset_done(st_mem_detailed_pgfault);

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -3013,7 +3013,7 @@ void update_systemd_services_charts(
                     update_every,
                     RRDSET_TYPE_STACKED);
 
-                rrdset_update_rrdlabels(cg->st_mem, cg->chart_labels);
+                rrdset_update_rrdlabels(cg->st_writeback, cg->chart_labels);
                 rrddim_add(cg->st_writeback, "writeback", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
                 rrddim_add(cg->st_writeback, "dirty", NULL, 1, 1024 * 1024, RRD_ALGORITHM_ABSOLUTE);
             }

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2708,7 +2708,7 @@ static inline void discovery_process_cgroup(struct cgroup *cg) {
         }
         if (!cg->chart_labels)
             cg->chart_labels = rrdlabels_create();
-        rrdlabels_add(cg->chart_labels, "cgroup_name", cg->name, RRDLABEL_SRC_AUTO);
+        rrdlabels_add(cg->chart_labels, "service_name", cg->name, RRDLABEL_SRC_AUTO);
         cg->enabled = 1;
         return;
     }

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -2866,9 +2866,9 @@ void update_systemd_services_charts(
 {
     // update the values
     struct cgroup *cg;
-    // TODO: Remove constant (1000) when all charts are moved.
-    static int prio = NETDATA_CHART_PRIO_CGROUPS_SYSTEMD;
+    int systemd_cgroup_chart_priority = NETDATA_CHART_PRIO_CGROUPS_SYSTEMD;
     char type[RRD_ID_LENGTH_MAX + 1];
+
     for (cg = cgroup_root; cg; cg = cg->next) {
         if (unlikely(!cg->enabled || cg->pending_renames || !is_cgroup_systemd_service(cg)))
             continue;
@@ -2886,7 +2886,7 @@ void update_systemd_services_charts(
                     "percentage",
                     PLUGIN_CGROUPS_NAME,
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
-                    prio++,
+                    systemd_cgroup_chart_priority,
                     update_every,
                     RRDSET_TYPE_STACKED);
 
@@ -2918,7 +2918,7 @@ void update_systemd_services_charts(
                     "MiB",
                     PLUGIN_CGROUPS_NAME,
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
-                    prio++,
+                    systemd_cgroup_chart_priority + 5,
                     update_every,
                     RRDSET_TYPE_STACKED);
 
@@ -2957,7 +2957,7 @@ void update_systemd_services_charts(
                     "failures/s",
                     PLUGIN_CGROUPS_NAME,
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
-                    prio++,
+                    systemd_cgroup_chart_priority + 10,
                     update_every,
                     RRDSET_TYPE_LINE);
 
@@ -2981,7 +2981,7 @@ void update_systemd_services_charts(
                     "MiB",
                     PLUGIN_CGROUPS_NAME,
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
-                    prio++,
+                    systemd_cgroup_chart_priority + 15,
                     update_every,
                     RRDSET_TYPE_STACKED);
 
@@ -3009,7 +3009,7 @@ void update_systemd_services_charts(
                     "MiB",
                     PLUGIN_CGROUPS_NAME,
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
-                    prio++,
+                    systemd_cgroup_chart_priority + 20,
                     update_every,
                     RRDSET_TYPE_STACKED);
 
@@ -3033,7 +3033,7 @@ void update_systemd_services_charts(
                     "MiB/s",
                     PLUGIN_CGROUPS_NAME,
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
-                    prio++,
+                    systemd_cgroup_chart_priority + 25,
                     update_every,
                     RRDSET_TYPE_AREA);
 
@@ -3057,7 +3057,7 @@ void update_systemd_services_charts(
                     "MiB/s",
                     PLUGIN_CGROUPS_NAME,
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
-                    prio++,
+                    systemd_cgroup_chart_priority + 30,
                     update_every,
                     RRDSET_TYPE_AREA);
 
@@ -3083,7 +3083,7 @@ void update_systemd_services_charts(
                     "KiB/s",
                     PLUGIN_CGROUPS_NAME,
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
-                    prio++,
+                    systemd_cgroup_chart_priority + 35,
                     update_every,
                     RRDSET_TYPE_AREA);
 
@@ -3109,7 +3109,7 @@ void update_systemd_services_charts(
                     "operations/s",
                     PLUGIN_CGROUPS_NAME,
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
-                    prio++,
+                    systemd_cgroup_chart_priority + 40,
                     update_every,
                     RRDSET_TYPE_LINE);
 
@@ -3134,7 +3134,7 @@ void update_systemd_services_charts(
                     "KiB/s",
                     PLUGIN_CGROUPS_NAME,
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
-                    prio++,
+                    systemd_cgroup_chart_priority + 45,
                     update_every,
                     RRDSET_TYPE_AREA);
 
@@ -3160,7 +3160,7 @@ void update_systemd_services_charts(
                     "operations/s",
                     PLUGIN_CGROUPS_NAME,
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
-                    prio++,
+                    systemd_cgroup_chart_priority + 50,
                     update_every,
                     RRDSET_TYPE_LINE);
 
@@ -3186,7 +3186,7 @@ void update_systemd_services_charts(
                     "operations/s",
                     PLUGIN_CGROUPS_NAME,
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
-                    prio++,
+                    systemd_cgroup_chart_priority + 55,
                     update_every,
                     RRDSET_TYPE_LINE);
 
@@ -3211,7 +3211,7 @@ void update_systemd_services_charts(
                     "operations/s",
                     PLUGIN_CGROUPS_NAME,
                     PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME,
-                    prio++,
+                    systemd_cgroup_chart_priority + 60,
                     update_every,
                     RRDSET_TYPE_LINE);
 


### PR DESCRIPTION
##### Summary
Fixes #14943

This PR is reorganizing the way we are showing our services charts.

##### Test Plan

1. Compile this branch on environment that has systemd.
2. Run and take a look how charts are now shown on dashboard. 

##### Additional Information
This PR was tested on:

| Linux Distribution | Bare metal / VM | Kernel version | 
|----------------------------|-------------------------|-----------------------|
|Arch Linux | Libvirt | 6.5.2-arch1-1 | 
|Ubuntu 22.04 | Libvirt | 5.15.0-76-generic|
|Debian 11 | Libvirt| 5.10.191-1|

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? cgroup plugin
- Can they see the change or is it an under the hood? If they can see it, where? Yes, when user access dashboard they will have charts inside `systemd` submenu
- How is the user impacted by the change?  Services are not independent, instead to have they organized in one unique chart
- What are there any benefits of the change? Charts better organized.
</details>