### PR TITLE
Facets: fixes 5

### DIFF
--- a/collectors/systemd-journal.plugin/systemd-journal.c
+++ b/collectors/systemd-journal.plugin/systemd-journal.c
@@ -600,6 +600,40 @@ static void netdata_systemd_journal_rich_message(FACETS *facets __maybe_unused, 
 }
 
 static void function_systemd_journal(const char *transaction, char *function, char *line_buffer __maybe_unused, int line_max __maybe_unused, int timeout __maybe_unused) {
+    static struct {
+        BUFFER *tmp;
+        BUFFER *wb;
+        BUFFER *function;
+        int response;
+        time_t expires;
+    } cache = {
+            .tmp = NULL,
+            .wb = NULL,
+            .function = NULL,
+            .response = 0,
+            .expires = 0,
+    };
+
+    if(unlikely(!cache.wb)) {
+        cache.tmp = buffer_create(0, NULL);
+        cache.wb = buffer_create(0, NULL);
+        cache.function = buffer_create(0, NULL);
+    }
+
+    if(buffer_strlen(cache.function) && buffer_strlen(cache.wb) && strcmp(buffer_tostring(cache.function), function) == 0) {
+        // repeated the same request
+        netdata_mutex_lock(&stdout_mutex);
+        if(cache.response == HTTP_RESP_OK)
+            pluginsd_function_result_to_stdout(transaction, cache.response, "application/json", cache.expires, cache.wb);
+        else
+            pluginsd_function_json_error_to_stdout(transaction, cache.response, "failed");
+        netdata_mutex_unlock(&stdout_mutex);
+        return;
+    }
+
+    buffer_flush(cache.tmp);
+    buffer_strcat(cache.tmp, function);
+
     BUFFER *wb = buffer_create(0, NULL);
     buffer_flush(wb);
     buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_NEWLINE_ON_ARRAY_ITEMS);
@@ -837,6 +871,14 @@ static void function_systemd_journal(const char *transaction, char *function, ch
         netdata_mutex_unlock(&stdout_mutex);
         goto cleanup;
     }
+
+    // keep this response in the cache
+    cache.response = response;
+    cache.expires = expires;
+    buffer_flush(cache.wb);
+    buffer_fast_strcat(cache.wb, buffer_tostring(wb), buffer_strlen(wb));
+    buffer_flush(cache.function);
+    buffer_fast_strcat(cache.function, buffer_tostring(cache.tmp), buffer_strlen(cache.tmp));
 
 output:
     netdata_mutex_lock(&stdout_mutex);

--- a/libnetdata/facets/facets.c
+++ b/libnetdata/facets/facets.c
@@ -187,7 +187,7 @@ static usec_t calculate_histogram_bar_width(usec_t after_ut, usec_t before_ut) {
     static int array_size = sizeof(valid_durations_s) / sizeof(valid_durations_s[0]);
 
     usec_t duration_ut = before_ut - after_ut;
-    usec_t bar_width_ut = 1 * 60 * USEC_PER_SEC;
+    usec_t bar_width_ut = 1 * USEC_PER_SEC;
 
     for (int i = array_size - 1; i >= 0; --i) {
         if (duration_ut / (valid_durations_s[i] * USEC_PER_SEC) >= HISTOGRAM_COLUMNS) {

--- a/libnetdata/facets/facets.c
+++ b/libnetdata/facets/facets.c
@@ -1456,6 +1456,7 @@ void facets_report(FACETS *facets, BUFFER *wb) {
             buffer_json_member_add_boolean(wb, "enabled", true);
             buffer_json_member_add_string(wb, "key", "anchor");
             buffer_json_member_add_string(wb, "column", "timestamp");
+            buffer_json_member_add_string(wb, "units", "timestamp_usec");
         }
         buffer_json_object_close(wb); // pagination
 


### PR DESCRIPTION
- [x] caching of the last successful response, so that repeated queries as served immediately
- [x] allow the histogram to have resolution of up to 1 second
- [x] specify the units of the pagination, so that the UI can calculate them