### PR TITLE
Maintain node's last connected timestamp in the db

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1178,6 +1178,7 @@ struct rrdhost {
     // ------------------------------------------------------------------------
     // streaming of data from remote hosts - rrdpush receiver
 
+    time_t last_connected;                          // last time child connected (stored in db)
     time_t child_connect_time;                      // the time the last sender was connected
     time_t child_last_chart_command;                // the time of the last CHART streaming command
     time_t child_disconnected_time;                 // the time the last sender was disconnected

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -336,6 +336,7 @@ int is_legacy = 1;
 
     if (likely(!archived)) {
         rrdfunctions_host_init(host);
+        host->last_connected = now_realtime_sec();
         host->rrdlabels = rrdlabels_create();
         rrdhost_initialize_rrdpush_sender(
             host, rrdpush_enabled, rrdpush_destination, rrdpush_api_key, rrdpush_send_charts_matching);
@@ -661,6 +662,8 @@ static void rrdhost_update(RRDHOST *host
 
     if(!host->rrdvars)
         host->rrdvars = rrdvariables_create();
+
+    host->last_connected = now_realtime_sec();
 
     if (rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED)) {
         rrdhost_flag_clear(host, RRDHOST_FLAG_ARCHIVED);

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -104,7 +104,7 @@ const char *database_migrate_v12_v13_hash[] = {
     NULL
 };
 
-const char *database_migrate_v12_v13[] = {
+const char *database_migrate_v13_v14[] = {
     "ALTER TABLE host ADD last_connected INT NOT NULL DEFAULT 0;",
     NULL
 };
@@ -370,12 +370,12 @@ static int do_migration_v12_v13(sqlite3 *database, const char *name)
     return rc;
 }
 
-static int do_migration_v12_v13(sqlite3 *database, const char *name)
+static int do_migration_v13_v14(sqlite3 *database, const char *name)
 {
     netdata_log_info("Running \"%s\" database migration", name);
 
     if (!column_exists_in_table("host", "last_connected"))
-        return init_database_batch(database, &database_migrate_v11_v12[0]);
+        return init_database_batch(database, &database_migrate_v13_v14[0]);
 
     return 0;
 }
@@ -437,6 +437,7 @@ DATABASE_FUNC_MIGRATION_LIST migration_action[] = {
     {.name = "v10 to v11",  .func = do_migration_v10_v11},
     {.name = "v11 to v12",  .func = do_migration_v11_v12},
     {.name = "v12 to v13",  .func = do_migration_v12_v13},
+    {.name = "v13 to v14",  .func = do_migration_v13_v14},
     // the terminator of this array
     {.name = NULL, .func = NULL}
 };

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -104,6 +104,11 @@ const char *database_migrate_v12_v13_hash[] = {
     NULL
 };
 
+const char *database_migrate_v12_v13[] = {
+    "ALTER TABLE host ADD last_connected INT NOT NULL DEFAULT 0;",
+    NULL
+};
+
 static int do_migration_v1_v2(sqlite3 *database, const char *name)
 {
     UNUSED(name);
@@ -364,6 +369,17 @@ static int do_migration_v12_v13(sqlite3 *database, const char *name)
 
     return rc;
 }
+
+static int do_migration_v12_v13(sqlite3 *database, const char *name)
+{
+    netdata_log_info("Running \"%s\" database migration", name);
+
+    if (!column_exists_in_table("host", "last_connected"))
+        return init_database_batch(database, &database_migrate_v11_v12[0]);
+
+    return 0;
+}
+
 
 static int do_migration_noop(sqlite3 *database, const char *name)
 {

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -4,7 +4,7 @@
 #include "sqlite3recover.h"
 #include "sqlite_db_migration.h"
 
-#define DB_METADATA_VERSION 13
+#define DB_METADATA_VERSION 14
 
 const char *database_config[] = {
     "CREATE TABLE IF NOT EXISTS host(host_id BLOB PRIMARY KEY, hostname TEXT NOT NULL, "

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -14,7 +14,7 @@ const char *database_config[] = {
     "memory_mode INT DEFAULT 0, abbrev_timezone TEXT DEFAULT '', utc_offset INT NOT NULL DEFAULT 0,"
     "program_name TEXT NOT NULL DEFAULT 'unknown', program_version TEXT NOT NULL DEFAULT 'unknown', "
     "entries INT NOT NULL DEFAULT 0,"
-    "health_enabled INT NOT NULL DEFAULT 0);",
+    "health_enabled INT NOT NULL DEFAULT 0, last_connected INT NOT NULL DEFAULT 0);",
 
     "CREATE TABLE IF NOT EXISTS chart(chart_id blob PRIMARY KEY, host_id blob, type text, id text, name text, "
     "family text, context text, title text, unit text, plugin text, module text, priority int, update_every int, "

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -20,13 +20,14 @@
 
 #define DELETE_DIMENSION_UUID   "DELETE FROM dimension WHERE dim_id = @uuid;"
 
-#define SQL_STORE_HOST_INFO "INSERT OR REPLACE INTO host " \
-        "(host_id, hostname, registry_hostname, update_every, os, timezone," \
-        "tags, hops, memory_mode, abbrev_timezone, utc_offset, program_name, program_version," \
-        "entries, health_enabled) " \
-        "values (@host_id, @hostname, @registry_hostname, @update_every, @os, @timezone, @tags, @hops, @memory_mode, " \
-        "@abbrev_timezone, @utc_offset, @program_name, @program_version, " \
-        "@entries, @health_enabled);"
+#define SQL_STORE_HOST_INFO                                                                                            \
+    "INSERT OR REPLACE INTO host "                                                                                     \
+    "(host_id, hostname, registry_hostname, update_every, os, timezone, tags, hops, memory_mode, "                     \
+    "abbrev_timezone, utc_offset, program_name, program_version,"                                                      \
+    "entries, health_enabled, last_connected) "                                                                        \
+    "VALUES (@host_id, @hostname, @registry_hostname, @update_every, @os, @timezone, @tags, @hops, @memory_mode, "     \
+    "@abbrev_timezone, @utc_offset, @program_name, @program_version, "                                                 \
+    "@entries, @health_enabled, @last_connected);"
 
 #define SQL_STORE_CHART "insert or replace into chart (chart_id, host_id, type, id, " \
     "name, family, context, title, unit, plugin, module, priority, update_every , chart_type , memory_mode , " \
@@ -361,6 +362,10 @@ static int store_host_metadata(RRDHOST *host)
         goto bind_fail;
 
     rc = sqlite3_bind_int(res, ++param, (int ) host->health.health_enabled);
+    if (unlikely(rc != SQLITE_OK))
+        goto bind_fail;
+
+    rc = sqlite3_bind_int(res, ++param, (int ) host->last_connected);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 


### PR DESCRIPTION
##### Summary
Store the last connected time per node. This will be useful to handle ephemeral nodes
and other optimizations
