### PR TITLE
Functions: allow collectors to be restarted

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -931,6 +931,8 @@ typedef enum __attribute__ ((__packed__)) rrdhost_flags {
 
     RRDHOST_FLAG_METADATA_CLAIMID               = (1 << 28), // metadata needs to be stored in the database
     RRDHOST_FLAG_RRDPUSH_RECEIVER_DISCONNECTED  = (1 << 29), // set when the receiver part is disconnected
+
+    RRDHOST_FLAG_GLOBAL_FUNCTIONS_UPDATED       = (1 << 30), // set when the host has updated global functions
 } RRDHOST_FLAGS;
 
 #define rrdhost_flag_check(host, flag) (__atomic_load_n(&((host)->flags), __ATOMIC_SEQ_CST) & (flag))

--- a/database/rrdfunctions.c
+++ b/database/rrdfunctions.c
@@ -323,7 +323,11 @@ static void rrd_collector_free(struct rrd_collector *rdc) {
 
 // called once per collector
 void rrd_collector_started(void) {
-    if(likely(thread_rrd_collector)) return;
+    if(likely(thread_rrd_collector)) {
+        thread_rrd_collector->tid = gettid();
+        thread_rrd_collector->running = true;
+        return;
+    }
 
     thread_rrd_collector = callocz(1, sizeof(struct rrd_collector));
     thread_rrd_collector->tid = gettid();

--- a/database/rrdfunctions.c
+++ b/database/rrdfunctions.c
@@ -323,13 +323,9 @@ static void rrd_collector_free(struct rrd_collector *rdc) {
 
 // called once per collector
 void rrd_collector_started(void) {
-    if(likely(thread_rrd_collector)) {
-        thread_rrd_collector->tid = gettid();
-        thread_rrd_collector->running = true;
-        return;
-    }
+    if(!thread_rrd_collector)
+        thread_rrd_collector = callocz(1, sizeof(struct rrd_collector));
 
-    thread_rrd_collector = callocz(1, sizeof(struct rrd_collector));
     thread_rrd_collector->tid = gettid();
     thread_rrd_collector->running = true;
 }

--- a/database/rrdfunctions.c
+++ b/database/rrdfunctions.c
@@ -390,9 +390,9 @@ static void rrd_functions_insert_callback(const DICTIONARY_ITEM *item __maybe_un
     rrd_collector_started();
     rdcf->collector = rrd_collector_acquire();
 
-    internal_error(true, "FUNCTIONS: adding function '%s' on host '%s', collection tid %d, %s",
-                   dictionary_acquired_item_name(item), rrdhost_hostname(host),
-                   rdcf->collector->tid, rdcf->collector->running ? "running" : "NOT running");
+//    internal_error(true, "FUNCTIONS: adding function '%s' on host '%s', collection tid %d, %s",
+//                   dictionary_acquired_item_name(item), rrdhost_hostname(host),
+//                   rdcf->collector->tid, rdcf->collector->running ? "running" : "NOT running");
 }
 
 static void rrd_functions_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, void *func,
@@ -447,9 +447,9 @@ static bool rrd_functions_conflict_callback(const DICTIONARY_ITEM *item __maybe_
         changed = true;
     }
 
-    internal_error(true, "FUNCTIONS: adding function '%s' on host '%s', collection tid %d, %s",
-                   dictionary_acquired_item_name(item), rrdhost_hostname(host),
-                   rdcf->collector->tid, rdcf->collector->running ? "running" : "NOT running");
+//    internal_error(true, "FUNCTIONS: adding function '%s' on host '%s', collection tid %d, %s",
+//                   dictionary_acquired_item_name(item), rrdhost_hostname(host),
+//                   rdcf->collector->tid, rdcf->collector->running ? "running" : "NOT running");
 
     return changed;
 }

--- a/libnetdata/required_dummies.h
+++ b/libnetdata/required_dummies.h
@@ -37,6 +37,7 @@ void rrdset_thread_rda_free(void){};
 void sender_thread_buffer_free(void){};
 void query_target_free(void){};
 void service_exits(void){};
+void rrd_collector_finished(void){};
 
 // required by get_system_cpus()
 char *netdata_configured_host_prefix = "";

--- a/libnetdata/threads/threads.c
+++ b/libnetdata/threads/threads.c
@@ -178,6 +178,7 @@ void rrdset_thread_rda_free(void);
 void sender_thread_buffer_free(void);
 void query_target_free(void);
 void service_exits(void);
+void rrd_collector_finished(void);
 
 static void thread_cleanup(void *ptr) {
     if(netdata_thread != ptr) {
@@ -188,6 +189,7 @@ static void thread_cleanup(void *ptr) {
     if(!(netdata_thread->options & NETDATA_THREAD_OPTION_DONT_LOG_CLEANUP))
         netdata_log_info("thread with task id %d finished", gettid());
 
+    rrd_collector_finished();
     sender_thread_buffer_free();
     rrdset_thread_rda_free();
     query_target_free();

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -489,6 +489,12 @@ RRDSET_STREAM_BUFFER rrdset_push_metric_initialize(RRDSET *st, time_t wall_clock
         rrdhost_flag_clear(host, RRDHOST_FLAG_RRDPUSH_SENDER_LOGGED_STATUS);
     }
 
+    if(unlikely(host_flags & RRDHOST_FLAG_GLOBAL_FUNCTIONS_UPDATED)) {
+        BUFFER *wb = sender_start(host->sender);
+        rrd_functions_expose_global_rrdpush(host, wb);
+        sender_commit(host->sender, wb, STREAM_TRAFFIC_TYPE_METADATA);
+    }
+
     RRDSET_FLAGS rrdset_flags = __atomic_load_n(&st->flags, __ATOMIC_SEQ_CST);
     bool exposed_upstream = (rrdset_flags & RRDSET_FLAG_UPSTREAM_EXPOSED);
     bool replication_in_progress = !(rrdset_flags & RRDSET_FLAG_SENDER_REPLICATION_FINISHED);


### PR DESCRIPTION
Sometimes functions of children become unavailable. It seems that somehow the collector is not marked as running, although there is a collector running...

This PR makes sure a collector is always in running state when it runs.

The problem was the GLOBAL functions. If they were added after netdata connected to a parent, they were not propagated to that parent. Now, a host flag has been added to enable sending them again to the parent, once they have been updated.