### PR TITLE
Re-store rrdvars on late dimensions

### DIFF
--- a/database/rrd.h
+++ b/database/rrd.h
@@ -709,6 +709,8 @@ typedef enum __attribute__ ((__packed__)) rrdset_flags {
     RRDSET_FLAG_UPSTREAM_SEND_VARIABLES          = (1 << 26), // a custom variable has been updated and needs to be exposed to parent
 
     RRDSET_FLAG_COLLECTION_FINISHED              = (1 << 27), // when set, data collection is not available for this chart
+
+    RRDSET_FLAG_HAS_RRDCALC_LINKED               = (1 << 28), // this chart has at least one rrdcal linked
 } RRDSET_FLAGS;
 
 #define rrdset_flag_check(st, flag) (__atomic_load_n(&((st)->flags), __ATOMIC_SEQ_CST) & (flag))

--- a/database/rrdcalc.c
+++ b/database/rrdcalc.c
@@ -316,6 +316,7 @@ static void rrdcalc_link_to_rrdset(RRDSET *st, RRDCALC *rc) {
 
     rc->ae = ae;
     health_alarm_log_add_entry(host, ae);
+    rrdset_flag_set(st, RRDSET_FLAG_HAS_RRDCALC_LINKED);
 }
 
 static void rrdcalc_unlink_from_rrdset(RRDCALC *rc, bool having_ll_wrlock) {

--- a/health/health.c
+++ b/health/health.c
@@ -990,7 +990,7 @@ static void health_execute_delayed_initializations(RRDHOST *host) {
             }
             foreach_rrdcalctemplate_done(rt);
 
-            if (health_variable_check(health_rrdvars, st, rd))
+            if (health_variable_check(health_rrdvars, st, rd) || rrdset_flag_check(st, RRDSET_FLAG_HAS_RRDCALC_LINKED))
                 rrdvar_store_for_chart(host, st);
         }
         rrddim_foreach_done(rd);


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR addresses the following issue:

When a chart with X dimensions is created and is linked to an rrdcalc, then only those present X dimensions are added to the charts's rrdvars.

When a new dimension of this chart arrives after this, it is not stored in rrdvars. This PR adds a check that if the chart is already linked to at least one rrdcalc, then it re-stores the data we need in rrdvars.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

To check the bug exists, a modified charts.d example is used, that sends the random3 dimension 60 seconds after it sends the initial 2. e.g.:

```
@@ -92,11 +92,14 @@ example_create() {
 CHART example.random '' "Random Numbers Stacked Chart" "% of random numbers" random random stacked $((example_priority)) $example_update_every '' '' 'example'
 DIMENSION random1 '' percentage-of-absolute-row 1 1
 DIMENSION random2 '' percentage-of-absolute-row 1 1
-DIMENSION random3 '' percentage-of-absolute-row 1 1
-CHART example.random2 '' "A random number" "random number" random random area $((example_priority + 1)) $example_update_every '' '' 'example'
-DIMENSION random '' absolute 1 1
 EOF
 
+  sleep 60
+  
+  cat << EOF2
+DIMENSION random3 '' percentage-of-absolute-row 1 1
+EOF2
+
   return 0
 }
```

A test alert is used:

```
    alarm: example_alarm
       on: example.random
    class: Utilization
     type: System
component: Example
    units: %
    every: 1m
     calc: $random1 + $random2 + $random3
     warn: $this > 100
     info: how much the example stuff work
       to: silent
```

Running master and visiting `http://localhost:19999/api/v1/alarm_variables?chart=example.random` you will notice that only `random1` and `random2` appear in the list. Running this PR the `random3` variable should appear after 60 seconds.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
