### PR TITLE
fix compilation warnings

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -2460,7 +2460,7 @@ static inline int debug_print_process_and_parents(struct pid_stat *p, usec_t tim
     for(i = 0; i < indent ;i++) buffer[i] = ' ';
     buffer[i] = '\0';
 
-    fprintf(stderr, "  %s %s%s (%d %s %llu"
+    fprintf(stderr, "  %s %s%s (%d %s %"PRIu64""
         , buffer
         , prefix
         , p->comm
@@ -3432,7 +3432,7 @@ static void calculate_netdata_statistics(void) {
 // update chart dimensions
 
 static inline void send_BEGIN(const char *type, const char *id, usec_t usec) {
-    fprintf(stdout, "BEGIN %s.%s %llu\n", type, id, usec);
+    fprintf(stdout, "BEGIN %s.%s %"PRIu64"\n", type, id, usec);
 }
 
 static inline void send_SET(const char *name, kernel_uint_t value) {
@@ -3518,11 +3518,11 @@ void send_resource_usage_to_netdata(usec_t dt) {
     }
 
     fprintf(stdout,
-        "BEGIN netdata.apps_cpu %llu\n"
-        "SET user = %llu\n"
-        "SET system = %llu\n"
+        "BEGIN netdata.apps_cpu %"PRIu64"\n"
+        "SET user = %"PRIu64"\n"
+        "SET system = %"PRIu64"\n"
         "END\n"
-        "BEGIN netdata.apps_sizes %llu\n"
+        "BEGIN netdata.apps_sizes %"PRIu64"\n"
         "SET calls = %zu\n"
         "SET files = %zu\n"
         "SET filenames = %zu\n"
@@ -3549,7 +3549,7 @@ void send_resource_usage_to_netdata(usec_t dt) {
         );
 
     fprintf(stdout,
-            "BEGIN netdata.apps_fix %llu\n"
+            "BEGIN netdata.apps_fix %"PRIu64"\n"
             "SET utime = %u\n"
             "SET stime = %u\n"
             "SET gtime = %u\n"
@@ -3566,7 +3566,7 @@ void send_resource_usage_to_netdata(usec_t dt) {
 
     if(include_exited_childs)
         fprintf(stdout,
-            "BEGIN netdata.apps_children_fix %llu\n"
+            "BEGIN netdata.apps_children_fix %"PRIu64"\n"
             "SET cutime = %u\n"
             "SET cstime = %u\n"
             "SET cgtime = %u\n"

--- a/collectors/perf.plugin/perf_plugin.c
+++ b/collectors/perf.plugin/perf_plugin.c
@@ -1328,7 +1328,7 @@ int main(int argc, char **argv) {
         if(unlikely(netdata_exit)) break;
 
         if(unlikely(debug && iteration))
-            fprintf(stderr, "perf.plugin: iteration %zu, dt %llu usec\n"
+            fprintf(stderr, "perf.plugin: iteration %zu, dt %"PRIu64" usec\n"
                     , iteration
                     , dt
             );

--- a/database/engine/metric.c
+++ b/database/engine/metric.c
@@ -923,7 +923,7 @@ int mrg_unittest(void) {
     netdata_log_info("DBENGINE METRIC: did %zu additions, %zu duplicate additions, "
          "%zu deletions, %zu wrong deletions, "
          "%zu successful searches, %zu wrong searches, "
-         "in %llu usecs",
+         "in %"PRIu64" usecs",
         stats.additions, stats.additions_duplicate,
         stats.deletions, stats.delete_misses,
         stats.search_hits, stats.search_misses,

--- a/database/rrdfunctions.c
+++ b/database/rrdfunctions.c
@@ -757,7 +757,9 @@ struct rrd_function_call_wait {
     int code;
 };
 
-static void rrd_inflight_function_cleanup(RRDHOST *host, const DICTIONARY_ITEM *host_function_acquired, const char *transaction) {
+static void rrd_inflight_function_cleanup(RRDHOST *host __maybe_unused,
+                                          const DICTIONARY_ITEM *host_function_acquired __maybe_unused,
+                                          const char *transaction) {
     dictionary_del(rrd_functions_inflight_requests, transaction);
     dictionary_garbage_collect(rrd_functions_inflight_requests);
 }
@@ -1176,7 +1178,8 @@ int rrdhost_function_streaming(BUFFER *wb, int timeout __maybe_unused, const cha
                                void *collector_data __maybe_unused,
                                rrd_function_result_callback_t result_cb, void *result_cb_data,
                                rrd_function_is_cancelled_cb_t is_cancelled_cb, void *is_cancelled_cb_data,
-                               rrd_function_register_canceller_cb_t register_cancel_cb, void *register_cancel_db_data) {
+                               rrd_function_register_canceller_cb_t register_canceller_cb __maybe_unused,
+                               void *register_canceller_cb_data __maybe_unused) {
 
     time_t now = now_realtime_sec();
 

--- a/database/rrdfunctions.h
+++ b/database/rrdfunctions.h
@@ -50,7 +50,7 @@ int rrd_call_function_error(BUFFER *wb, const char *msg, int code);
 int rrdhost_function_streaming(BUFFER *wb, int timeout, const char *function, void *collector_data,
                                rrd_function_result_callback_t result_cb, void *result_cb_data,
                                rrd_function_is_cancelled_cb_t is_cancelled_cb, void *is_cancelled_cb_data,
-                               rrd_function_register_canceller_cb_t register_cancel_cb, void *register_cancel_db_data);
+                               rrd_function_register_canceller_cb_t register_canceller_cb, void *register_canceller_cb_data);
 
 #define RRDFUNCTIONS_STREAMING_HELP "Streaming status for parents and children."
 

--- a/exporting/prometheus/prometheus.c
+++ b/exporting/prometheus/prometheus.c
@@ -522,7 +522,7 @@ static void generate_as_collected_prom_metric(BUFFER *wb,
         buffer_sprintf(wb, COLLECTED_NUMBER_FORMAT, p->rd->collector.last_collected_value);
 
     if (p->output_options & PROMETHEUS_OUTPUT_TIMESTAMPS)
-        buffer_sprintf(wb, " %llu\n", timeval_msec(&p->rd->collector.last_collected_time));
+        buffer_sprintf(wb, " %"PRIu64"\n", timeval_msec(&p->rd->collector.last_collected_time));
     else
         buffer_sprintf(wb, "\n");
 }

--- a/libnetdata/aral/aral.c
+++ b/libnetdata/aral/aral.c
@@ -1057,7 +1057,7 @@ int aral_stress_test(size_t threads, size_t elements, size_t seconds) {
     }
 
     netdata_log_info("ARAL: did %zu malloc, %zu free, "
-         "using %zu threads, in %llu usecs",
+         "using %zu threads, in %"PRIu64" usecs",
          auc.ar->aral_lock.user_malloc_operations,
          auc.ar->aral_lock.user_free_operations,
          threads,

--- a/libnetdata/clocks/clocks.c
+++ b/libnetdata/clocks/clocks.c
@@ -299,7 +299,7 @@ usec_t heartbeat_next(heartbeat_t *hb, usec_t tick) {
         usec_t tmp = (now_realtime_usec() * clock_realtime_resolution) % (tick / 2);
 
         error_limit_static_global_var(erl, 10, 0);
-        error_limit(&erl, "heartbeat randomness of %llu is too big for a tick of %llu - setting it to %llu", hb->randomness, tick, tmp);
+        error_limit(&erl, "heartbeat randomness of %"PRIu64" is too big for a tick of %"PRIu64" - setting it to %"PRIu64"", hb->randomness, tick, tmp);
         hb->randomness = tmp;
     }
 
@@ -326,12 +326,12 @@ usec_t heartbeat_next(heartbeat_t *hb, usec_t tick) {
     if(unlikely(now < next)) {
         errno = 0;
         error_limit_static_global_var(erl, 10, 0);
-        error_limit(&erl, "heartbeat clock: woke up %llu microseconds earlier than expected (can be due to the CLOCK_REALTIME set to the past).", next - now);
+        error_limit(&erl, "heartbeat clock: woke up %"PRIu64" microseconds earlier than expected (can be due to the CLOCK_REALTIME set to the past).", next - now);
     }
     else if(unlikely(now - next >  tick / 2)) {
         errno = 0;
         error_limit_static_global_var(erl, 10, 0);
-        error_limit(&erl, "heartbeat clock: woke up %llu microseconds later than expected (can be due to system load or the CLOCK_REALTIME set to the future).", now - next);
+        error_limit(&erl, "heartbeat clock: woke up %"PRIu64" microseconds later than expected (can be due to system load or the CLOCK_REALTIME set to the future).", now - next);
     }
 
     if(unlikely(!hb->realtime)) {
@@ -381,7 +381,7 @@ void sleep_usec_with_now(usec_t usec, usec_t started_ut) {
             }
         }
         else {
-            netdata_log_error("Cannot nanosleep() for %llu microseconds.", usec);
+            netdata_log_error("Cannot nanosleep() for %"PRIu64" microseconds.", usec);
             break;
         }
     }

--- a/libnetdata/dictionary/dictionary.c
+++ b/libnetdata/dictionary/dictionary.c
@@ -2877,7 +2877,7 @@ static usec_t dictionary_unittest_run_and_measure_time(DICTIONARY *dict, char *m
         }
     }
 
-    fprintf(stderr, " %zu errors, %d (found %ld) items in dictionary, %d (found %ld) referenced, %d (found %ld) deleted, %llu usec \n",
+    fprintf(stderr, " %zu errors, %d (found %ld) items in dictionary, %d (found %ld) referenced, %d (found %ld) deleted, %"PRIu64" usec \n",
             errs, dict?dict->entries:0, found_ok, dict?dict->referenced_items:0, found_referenced, dict?dict->pending_deletion_items:0, found_deleted, dt);
     *errors += errs;
     return dt;

--- a/libnetdata/facets/facets.c
+++ b/libnetdata/facets/facets.c
@@ -1762,7 +1762,7 @@ void facets_report(FACETS *facets, BUFFER *wb) {
 
     buffer_json_member_add_array(wb, "data");
     {
-        usec_t last_usec = 0;
+        usec_t last_usec = 0; (void)last_usec;
 
         for(FACET_ROW *row = facets->base ; row ;row = row->next) {
 

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -890,7 +890,7 @@ void error_limit_int(ERROR_LIMIT *erl, const char *prefix, const char *file __ma
                 erl->count, (unsigned long long)(erl->last_logged ? now - erl->last_logged : 0));
 
     if(erl->sleep_ut)
-        fprintf(fp, " (sleeping for %llu microseconds every time this happens)", erl->sleep_ut);
+        fprintf(fp, " (sleeping for %"PRIu64" microseconds every time this happens)", erl->sleep_ut);
 
     if(__errno) {
         char buf[1024];

--- a/libnetdata/string/string.c
+++ b/libnetdata/string/string.c
@@ -533,42 +533,42 @@ int string_unittest(size_t entries) {
             strings[i] = string_strdupz(names[i]);
         }
         end_ut = now_realtime_usec();
-        fprintf(stderr, "Created %zu strings in %llu usecs\n", entries, end_ut - start_ut);
+        fprintf(stderr, "Created %zu strings in %"PRIu64" usecs\n", entries, end_ut - start_ut);
 
         start_ut = now_realtime_usec();
         for(size_t i = 0; i < entries ;i++) {
             strings[i] = string_dup(strings[i]);
         }
         end_ut = now_realtime_usec();
-        fprintf(stderr, "Cloned %zu strings in %llu usecs\n", entries, end_ut - start_ut);
+        fprintf(stderr, "Cloned %zu strings in %"PRIu64" usecs\n", entries, end_ut - start_ut);
 
         start_ut = now_realtime_usec();
         for(size_t i = 0; i < entries ;i++) {
             strings[i] = string_strdupz(string2str(strings[i]));
         }
         end_ut = now_realtime_usec();
-        fprintf(stderr, "Found %zu existing strings in %llu usecs\n", entries, end_ut - start_ut);
+        fprintf(stderr, "Found %zu existing strings in %"PRIu64" usecs\n", entries, end_ut - start_ut);
 
         start_ut = now_realtime_usec();
         for(size_t i = 0; i < entries ;i++) {
             string_freez(strings[i]);
         }
         end_ut = now_realtime_usec();
-        fprintf(stderr, "Released %zu referenced strings in %llu usecs\n", entries, end_ut - start_ut);
+        fprintf(stderr, "Released %zu referenced strings in %"PRIu64" usecs\n", entries, end_ut - start_ut);
 
         start_ut = now_realtime_usec();
         for(size_t i = 0; i < entries ;i++) {
             string_freez(strings[i]);
         }
         end_ut = now_realtime_usec();
-        fprintf(stderr, "Released (again) %zu referenced strings in %llu usecs\n", entries, end_ut - start_ut);
+        fprintf(stderr, "Released (again) %zu referenced strings in %"PRIu64" usecs\n", entries, end_ut - start_ut);
 
         start_ut = now_realtime_usec();
         for(size_t i = 0; i < entries ;i++) {
             string_freez(strings[i]);
         }
         end_ut = now_realtime_usec();
-        fprintf(stderr, "Freed %zu strings in %llu usecs\n", entries, end_ut - start_ut);
+        fprintf(stderr, "Freed %zu strings in %"PRIu64" usecs\n", entries, end_ut - start_ut);
 
         freez(strings);
 


### PR DESCRIPTION
Fix warnings due to `usec_t` being defined at `uint64_t`.
`%llu` warnings for USEC should now be `PRIu64`.