### PR TITLE
eBPF socket: function with event loop

### DIFF
--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -3815,9 +3815,11 @@ static void ebpf_create_statistic_charts(int update_every)
                              NETDATA_EBPF_ORDER_STAT_THREADS,
                              update_every,
                              NULL);
+    /*
 #ifdef NETDATA_DEV_MODE
     EBPF_PLUGIN_FUNCTIONS(EBPF_FUNCTION_THREAD, EBPF_PLUGIN_THREAD_FUNCTION_DESCRIPTION);
 #endif
+     */
 
     ebpf_create_thread_chart(NETDATA_EBPF_LIFE_TIME,
                              "Time remaining for thread.",
@@ -3825,9 +3827,11 @@ static void ebpf_create_statistic_charts(int update_every)
                              NETDATA_EBPF_ORDER_STAT_LIFE_TIME,
                              update_every,
                              NULL);
+    /*
 #ifdef NETDATA_DEV_MODE
     EBPF_PLUGIN_FUNCTIONS(EBPF_FUNCTION_THREAD, EBPF_PLUGIN_THREAD_FUNCTION_DESCRIPTION);
 #endif
+     */
 
     int i,j;
     char name[256];

--- a/collectors/ebpf.plugin/ebpf_functions.c
+++ b/collectors/ebpf.plugin/ebpf_functions.c
@@ -7,8 +7,6 @@
  *  EBPF FUNCTION COMMON
  *****************************************************************/
 
-RW_SPINLOCK rw_spinlock;        // protect the buffer
-
 /**
  * Function Start thread
  *
@@ -1076,7 +1074,6 @@ void *ebpf_function_thread(void *ptr)
     ebpf_module_t *em = (ebpf_module_t *)ptr;
     char buffer[PLUGINSD_LINE_MAX + 1];
 
-    rw_spinlock_init(&rw_spinlock);
     char *s = NULL;
     while(!ebpf_exit_plugin && (s = fgets(buffer, PLUGINSD_LINE_MAX, stdin))) {
         char *words[PLUGINSD_MAX_WORDS] = { NULL };
@@ -1098,7 +1095,6 @@ void *ebpf_function_thread(void *ptr)
             }
             else {
                 int timeout = str2i(timeout_s);
-                rw_spinlock_write_lock(&rw_spinlock);
                 pthread_mutex_lock(&lock);
                 if (!strncmp(function, EBPF_FUNCTION_THREAD, sizeof(EBPF_FUNCTION_THREAD) - 1))
                     ebpf_function_thread_manipulation(transaction,
@@ -1120,7 +1116,6 @@ void *ebpf_function_thread(void *ptr)
                                         "No function with this name found in ebpf.plugin.");
 
                 pthread_mutex_unlock(&lock);
-                rw_spinlock_write_unlock(&rw_spinlock);
             }
         }
         else

--- a/collectors/ebpf.plugin/ebpf_functions.c
+++ b/collectors/ebpf.plugin/ebpf_functions.c
@@ -47,7 +47,6 @@ static int ebpf_function_start_thread(ebpf_module_t *em, int period)
  * @param thread_name name of the thread we are looking for.
  *
  * @return it returns a pointer for the module that has thread_name on success or NULL otherwise.
- */
 ebpf_module_t *ebpf_functions_select_module(const char *thread_name) {
     int i;
     for (i = 0; i < EBPF_MODULE_FUNCTION_IDX; i++) {
@@ -58,6 +57,7 @@ ebpf_module_t *ebpf_functions_select_module(const char *thread_name) {
 
     return NULL;
 }
+ */
 
 /*****************************************************************
  *  EBPF HELP FUNCTIONS
@@ -69,7 +69,6 @@ ebpf_module_t *ebpf_functions_select_module(const char *thread_name) {
  * Shows help with all options accepted by thread function.
  *
  * @param transaction  the transaction id that Netdata sent for this function execution
-*/
 static void ebpf_function_thread_manipulation_help(const char *transaction) {
     BUFFER *wb = buffer_create(0, NULL);
     buffer_sprintf(wb, "%s",
@@ -96,6 +95,7 @@ static void ebpf_function_thread_manipulation_help(const char *transaction) {
 
     buffer_free(wb);
 }
+*/
 
 /*****************************************************************
  *  EBPF ERROR FUNCTIONS
@@ -129,7 +129,6 @@ static void ebpf_function_error(const char *transaction, int code, const char *m
  * @param line_max     Number of arguments given
  * @param timeout      The function timeout
  * @param em           The structure with thread information
- */
 static void ebpf_function_thread_manipulation(const char *transaction,
                                               char *function __maybe_unused,
                                               char *line_buffer __maybe_unused,
@@ -368,6 +367,7 @@ static void ebpf_function_thread_manipulation(const char *transaction,
 
     buffer_free(wb);
 }
+ */
 
 /*****************************************************************
  *  EBPF SOCKET FUNCTION
@@ -1071,7 +1071,7 @@ static void ebpf_function_socket_manipulation(const char *transaction,
  */
 void *ebpf_function_thread(void *ptr)
 {
-    ebpf_module_t *em = (ebpf_module_t *)ptr;
+    (void)ptr;
     char buffer[PLUGINSD_LINE_MAX + 1];
 
     char *s = NULL;
@@ -1096,14 +1096,7 @@ void *ebpf_function_thread(void *ptr)
             else {
                 int timeout = str2i(timeout_s);
                 pthread_mutex_lock(&lock);
-                if (!strncmp(function, EBPF_FUNCTION_THREAD, sizeof(EBPF_FUNCTION_THREAD) - 1))
-                    ebpf_function_thread_manipulation(transaction,
-                                                      function,
-                                                      buffer,
-                                                      PLUGINSD_LINE_MAX + 1,
-                                                      timeout,
-                                                      em);
-                else if (!strncmp(function, EBPF_FUNCTION_SOCKET, sizeof(EBPF_FUNCTION_SOCKET) - 1))
+                if (!strncmp(function, EBPF_FUNCTION_SOCKET, sizeof(EBPF_FUNCTION_SOCKET) - 1))
                     ebpf_function_socket_manipulation(transaction,
                                                       function,
                                                       buffer,

--- a/collectors/ebpf.plugin/ebpf_functions.c
+++ b/collectors/ebpf.plugin/ebpf_functions.c
@@ -634,20 +634,16 @@ void ebpf_socket_read_open_connections(BUFFER *buf, struct ebpf_module *em)
  *
  * @param transaction  the transaction id that Netdata sent for this function execution
  * @param function     function name and arguments given to thread.
- * @param line_buffer  buffer used to parse args
- * @param line_max     Number of arguments given
  * @param timeout      The function timeout
- * @param em           The structure with thread information
+ * @param cancelled    Variable used to store function status.
  */
 static void ebpf_function_socket_manipulation(const char *transaction,
                                               char *function __maybe_unused,
-                                              char *line_buffer __maybe_unused,
-                                              int line_max __maybe_unused,
                                               int timeout __maybe_unused,
-                                              ebpf_module_t *em)
+                                              bool *cancelled __maybe_unused)
 {
-    UNUSED(line_buffer);
     UNUSED(timeout);
+    ebpf_module_t *em = &ebpf_modules[EBPF_MODULE_SOCKET_IDX];
 
     char *words[PLUGINSD_MAX_WORDS] = {NULL};
     size_t num_words = quoted_strings_splitter_pluginsd(function, words, PLUGINSD_MAX_WORDS);
@@ -1099,10 +1095,8 @@ void *ebpf_function_thread(void *ptr)
                 if (!strncmp(function, EBPF_FUNCTION_SOCKET, sizeof(EBPF_FUNCTION_SOCKET) - 1))
                     ebpf_function_socket_manipulation(transaction,
                                                       function,
-                                                      buffer,
-                                                      PLUGINSD_LINE_MAX + 1,
                                                       timeout,
-                                                      &ebpf_modules[EBPF_MODULE_SOCKET_IDX]);
+                                                      NULL);
                 else
                     ebpf_function_error(transaction,
                                         HTTP_RESP_NOT_FOUND,


### PR DESCRIPTION
##### Summary
After PR https://github.com/netdata/netdata/pull/15977 to be merged, it was neccessary to modify eBPF plugin to also follow new pattern for our internal functions.

After meeting with @hugovalente-pm we decided to hide the eBPF threads function for while . Next eBPF PR will add more functions to control threads separated.

##### Test Plan
1. Compile this branch
2. Run netdata and take a look that functions are working as expected.

##### Additional Information
This PR is changing only `user ring` code, so it is not necessary to test on different kernels.

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? eBPF.plugin
- Can they see the change or is it an under the hood? If they can see it, where? no
- How is the user impacted by the change? A better control for socket function.
- What are there any benefits of the change?  Users can control better the functions, and it also give conditions for netdata to close a plugin using functions.
</details>