### PR TITLE
fix crash on setting thread name

### DIFF
--- a/libnetdata/threads/threads.c
+++ b/libnetdata/threads/threads.c
@@ -234,12 +234,12 @@ void uv_thread_set_name_np(uv_thread_t ut, const char* name) {
     strncpyz(threadname, name, NETDATA_THREAD_NAME_MAX);
 
 #if defined(__FreeBSD__)
-    pthread_set_name_np(ut, threadname);
+    pthread_set_name_np(ut ? ut : pthread_self(), threadname);
 #elif defined(__APPLE__)
     // Apple can only set its own name
     UNUSED(ut);
 #else
-    ret = pthread_setname_np(ut, threadname);
+    ret = pthread_setname_np(ut ? ut : pthread_self(), threadname);
 #endif
 
     thread_name_get(true);


### PR DESCRIPTION
##### Summary

We noticed that some Netdatas are crashing on start on a host with 80 ND instances (docker containers). This PR fixes the following coredumps:

<details>
<summary>coredump1</summary>

```c
#0  pthread_setname_np (thread=0x0, name=name@entry=0x7fca6f1cf6d0 "ACLKSYNC") at src/thread/pthread_setname_np.c:20
#1  0x00005646b9672862 in uv_thread_set_name_np (ut=<optimized out>, name=<optimized out>) at libnetdata/threads/threads.c:242
#2  0x00005646b9703b69 in aclk_synchronization (arg=0x5646b99f1ba0 <aclk_sync_config>) at database/sqlite/sqlite_aclk.c:365
#3  0x00007fca71cacbd2 in start (p=0x7fca6f1cf7a0) at src/thread/pthread_create.c:207
#4  0x00007fca71caef40 in __clone () at src/thread/x86_64/clone.s:22
```

</details>

<details>
<summary>coredump2</summary>

```c
#0  pthread_setname_np (thread=0x0, name=name@entry=0x7f4401940690 "METASYNC") at src/thread/pthread_setname_np.c:20
#1  0x00005631c255b862 in uv_thread_set_name_np (ut=<optimized out>, name=<optimized out>) at libnetdata/threads/threads.c:242
#2  0x00005631c25e95c7 in metadata_event_loop (arg=0x5631c28d2960 <metasync_worker>) at database/sqlite/sqlite_metadata.c:1516
#3  0x00007f4402dddbd2 in start (p=0x7f44019407a0) at src/thread/pthread_create.c:207
#4  0x00007f4402ddff40 in __clone () at src/thread/x86_64/clone.s:22
```

</details>

##### Test Plan

Restart ND instances, and make sure they don't crash.


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
