### PR TITLE
Fix package builds on Rocky Linux.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -21,11 +21,15 @@ AutoReqProv: yes
 
 # Disable go.d.plugin build on outdated golang distros
 %if 0%{?centos_ver:1}
-%if 0%{?centos_ver} >= 8 && 0%{!?almalinux_ver:1}
+%if 0%{?centos_ver} >= 8 && 0%{!?almalinux_ver:1} && 0%{!?rocky_ver:1}
+%global _golang_build 1
+%else
+%if 0%{?centos_ver} >= 10
 %global _golang_build 1
 %else
 %global _golang_build 0
 %global _missing_build_ids_terminate_build 0
+%endif
 %endif
 %endif
 


### PR DESCRIPTION
##### Summary

When switching from Alma Linux to Rocky Linux for our RHEL package builds, we missed one place in our RPM spec file where a conditional was checking whether we were building on Alma or not.

This fixes that conditional so it also checks for Rocky, which otherwise fails the build in the same way that Alma would without the conditional.

It also future-proofs things so that we behave correctly on RHEL 10 when that finally comes out.

##### Test Plan

Rocky Linux CI jobs pass on this PR.
