### PR TITLE
add description for Homebrew on Apple Silicon Mac(netdata/learn/#1789)

### DIFF
--- a/packaging/installer/methods/macos.md
+++ b/packaging/installer/methods/macos.md
@@ -56,6 +56,8 @@ The Netdata Agent is installed under `/usr/local/netdata` on your machine. Your 
 If you experience issues while claiming your node, follow the steps in our [Troubleshooting](https://github.com/netdata/netdata/blob/master/claim/README.md#troubleshooting) documentation.
 ## Install Netdata via Homebrew
 
+### For macOS Intel
+
 To install Netdata and all its dependencies, run Homebrew using the following command: 
 
 ```sh
@@ -64,6 +66,20 @@ brew install netdata
 Homebrew will place your Netdata configuration directory at `/usr/local/etc/netdata/`. 
 
 Use the `edit-config` script and the files in this directory to configure Netdata. For reference, you can find stock configuration files at `/usr/local/Cellar/netdata/{NETDATA_VERSION}/lib/netdata/conf.d/`.
+
+### For Apple Silicon
+
+To install Netdata and all its dependencies, run Homebrew using the following command: 
+
+```sh
+brew install netdata
+```
+
+Homebrew will place your Netdata configuration directory at `/opt/homebrew/etc/netdata/`. 
+
+Use the `edit-config` script and the files in this directory to configure Netdata. For reference, you can find stock configuration files at `/opt/homebrew/Cellar/netdata/{NETDATA_VERSION}/lib/netdata/conf.d/`.
+
+
 
 Skip on ahead to the [What's next?](#whats-next) section to find links to helpful post-installation guides.
 


### PR DESCRIPTION
##### Summary
Docs for fixing https://github.com/netdata/learn/issues/1789
Instaling via Homebrew on Apple Silicon Macs uses different path prefix with Intel Macs.
Describe separately for them.

##### Test Plan

It's just markdown document updates.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
This change would update netdata document. For users using Apple Silicon Macs, it will help them installing netdata via Homebrew.
</details>
