### PR TITLE
Disable mongodb exporter builds where broken.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -286,6 +286,9 @@ autoreconf -ivf
 	--with-bundled-protobuf \
 	%endif
 	%endif
+	%if 0%{?oraclelinux}
+	--disable-exporting-mongodb \
+	%endif
 	--prefix="%{_prefix}" \
 	--sysconfdir="%{_sysconfdir}" \
 	--localstatedir="%{_localstatedir}" \

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -31,6 +31,7 @@ run ./netdata-installer.sh \
   --install-prefix "${NETDATA_INSTALL_PARENT}" \
   --dont-wait \
   --dont-start-it \
+  --disable-exporting-mongodb \
   --require-cloud \
   --use-system-protobuf \
   --dont-scrub-cflags-even-though-it-may-break-things \


### PR DESCRIPTION
##### Summary

Some quirks on specific platforms mean it doesn’t build cleanly right now in a couple of our pre-built platforms, so just disable it for them.

##### Test Plan

Static builds and Oracle Linux package builds pass on this PR.