### PR TITLE
bundle_dashboard_v1: make it possible to use as a library

### DIFF
--- a/web/gui/bundle_dashboard_v1.py
+++ b/web/gui/bundle_dashboard_v1.py
@@ -13,8 +13,6 @@ import sys
 
 from pathlib import Path
 
-os.chdir(Path(__file__).parent.absolute())
-
 BASEPATH = Path('v1')
 
 URLTEMPLATE = 'https://github.com/netdata/dashboard/releases/download/{0}/dashboard.tar.gz'
@@ -126,6 +124,9 @@ def list_changed_files():
         subprocess.check_call('echo "EOF" >> $GITHUB_ENV', shell=True)
 
 
-copy_dashboard(sys.argv[1])
-write_makefile()
-list_changed_files()
+if __name__ == "__main__":
+    os.chdir(Path(__file__).parent.absolute())
+
+    copy_dashboard(sys.argv[1])
+    write_makefile()
+    list_changed_files()


### PR DESCRIPTION
##### Summary
Wrap the actual code execution inside standard `if __name__ == "__main__"` boilerplate. This makes it possible to call only a specific function, like this:

```py
import bundle_dashboard_v1

bundle_dashboard_v1.write_makefile()
```

This makes life easier for certain distributors which requires the dashboard to be built from source to comply to GPLv3. Such distributor can build the dashboard separately, copy the files in, and then run the above snippet to integrate the build into the tree.

##### Test Plan

Run `./bundle_dashboard_v1.py v3.0.1`. Observe using `git status` (or equivalent) that it doesn't produce any changed files.

##### Additional Information

Minified code is widely considered to be a form of compiled code. As the dashboard is also licensed under GPLv3 [1], Linux distributions will have to also distribute the corresponding source code. Some more strict distributions (such as Debian) also requires that the code shipped is built from the said source. This change is 1 of the steps that will make Linux distributions' life easier.

[1] Actually, I'm not sure what license the dashboard is. See https://github.com/netdata/dashboard/issues/466