### PR TITLE
health: add upsd alerts

### DIFF
--- a/health/Makefile.am
+++ b/health/Makefile.am
@@ -94,6 +94,7 @@ dist_healthconfig_DATA = \
     health.d/tcp_resets.conf \
     health.d/udp_errors.conf \
     health.d/unbound.conf \
+    health.d/upsd.conf \
     health.d/vcsa.conf \
     health.d/vernemq.conf \
     health.d/vsphere.conf \

--- a/health/health.d/upsd.conf
+++ b/health/health.d/upsd.conf
@@ -1,0 +1,50 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+ template: upsd_10min_ups_load
+       on: upsd.ups_load
+    class: Utilization
+     type: Power Supply
+component: UPS
+       os: *
+    hosts: *
+   lookup: average -10m unaligned of load
+    units: %
+    every: 1m
+     warn: $this > (($status >= $WARNING)  ? (70) : (80))
+     crit: $this > (($status == $CRITICAL) ? (85) : (95))
+    delay: down 10m multiplier 1.5 max 1h
+  summary: UPS ${label:ups_name} load
+     info: UPS ${label:ups_name} average load over the last 10 minutes
+       to: sitemgr
+
+ template: upsd_ups_battery_charge
+       on: upsd.ups_battery_charge	
+    class: Errors
+     type: Power Supply
+component: UPS
+       os: *
+    hosts: *
+   lookup: average -60s unaligned of charge
+    units: %
+    every: 60s
+     warn: $this < 75
+     crit: $this < 40
+    delay: down 10m multiplier 1.5 max 1h
+  summary: UPS ${label:ups_name} battery charge
+     info: UPS ${label:ups_name} average battery charge over the last minute
+       to: sitemgr
+
+ template: upsd_ups_last_collected_secs
+       on: upsd.ups_load
+    class: Latency
+     type: Power Supply
+component: UPS device
+     calc: $now - $last_collected_t
+    every: 10s
+    units: seconds ago
+     warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
+     crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
+    delay: down 5m multiplier 1.5 max 1h
+  summary: UPS ${label:ups_name} last collected
+     info: UPS ${label:ups_name} number of seconds since the last successful data collection
+       to: sitemgr


### PR DESCRIPTION
##### Summary

This PR adds alerts for [go.d/upsd](https://github.com/netdata/go.d.plugin/tree/master/modules/upsd#ups-nut-collector) (replacement for [charts.d/nut](https://github.com/netdata/netdata/tree/master/collectors/charts.d.plugin/nut#upspdu-collector)). That collector is not yet in the master branch, will be added next week.

##### Test Plan

Install this branch and check if upsd alerts are installed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
