### PR TITLE
Allows excluding v2 dashboard from installation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -240,6 +240,19 @@ if test "${enable_cloud}" = "no"; then
 fi
 
 # -----------------------------------------------------------------------------
+# Allows disabling v2 dashboard
+
+AC_ARG_ENABLE(
+    [cloud-ui],
+    [AS_HELP_STRING([--disable-cloud-ui],
+                    [Excludes cloud dashboard from installation])],
+    [ enable_cloud_ui="$enableval" ],
+    [ enable_cloud_ui="yes" ]
+)
+
+AM_CONDITIONAL([ENABLE_CLOUD_UI], [test "${enable_cloud_ui}" = "yes"])
+
+# -----------------------------------------------------------------------------
 # C++ version check
 
 # Check for C++17 support (optional)

--- a/web/gui/Makefile.am
+++ b/web/gui/Makefile.am
@@ -10,8 +10,13 @@ CLEANFILES = \
 
 SUBDIRS = \
     v1 \
-    v2 \
     $(NULL)
+
+if ENABLE_CLOUD_UI
+    SUBDIRS += \
+        v2 \
+        $(NULL)
+endif
 
 DASHBOARD_JS_FILES = \
     $(srcdir)/src/dashboard.js/prologue.js.inc \
@@ -55,7 +60,6 @@ dist_web_DATA = \
     dashboard.js \
     $(srcdir)/dashboard_info_custom_example.js \
     $(srcdir)/dashboard_info.js \
-    $(srcdir)/index.html \
     $(srcdir)/main.css \
     $(srcdir)/main.js \
     $(srcdir)/registry-access.html \
@@ -65,6 +69,14 @@ dist_web_DATA = \
     $(srcdir)/ilove.html \
     version.txt \
     $(NULL)
+
+# Note: when this is false, v1's index.html get installed instead, which
+# works outside of v1/ path too.
+if ENABLE_CLOUD_UI
+    dist_web_DATA += \
+        $(srcdir)/index.html \
+        $(NULL)
+endif
 
 webolddir=$(webdir)/old
 dist_webold_DATA = \


### PR DESCRIPTION
##### Summary
For certain Linux distributions, it's important that they ship only software with free license. To help with that, add a flag which disable installing the v2 dashboard.

The flag excludes the web/gui/v2/ directory from building, as well as the index.html which downloads the latest v2 dashboard from server. index.html of v1 will get installed instead, which means users will seamlessly use the v1 dashboard in this case.

Bug: https://github.com/netdata/netdata/issues/16035

##### Test Plan

Build Netdata with `--disable-cloud-ui`. Observes that `${prefix}/share/netdata/web/v2` doesn't exists. `http://localhost:1999` shows the v1 UI.

Build Netdata without `--disable-cloud-ui`. Observes that `${prefix}/share/netdata/web/v2` exists. `http://localhost:1999` shows the v2 UI.

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
If you install Netdata from the official distribution package, nothing will change for you. However, if you install Netdata using packages from Linux distributions, the distribution may choose not to install the latest Cloud UI which is included since version 1.41.0. In such case, you'll be served with v1 UI instead.
</details>
