### PR TITLE
Switch to uint64_t to avoid overflow in 32bit systems

### DIFF
--- a/database/contexts/api_v2.c
+++ b/database/contexts/api_v2.c
@@ -1009,8 +1009,8 @@ void buffer_json_agents_v2(BUFFER *wb, struct query_timings *timings, time_t now
             STORAGE_ENGINE *eng = localhost->db[tier].eng;
             if (!eng) continue;
 
-            size_t max = storage_engine_disk_space_max(eng->backend, localhost->db[tier].instance);
-            size_t used = storage_engine_disk_space_used(eng->backend, localhost->db[tier].instance);
+            uint64_t max = storage_engine_disk_space_max(eng->backend, localhost->db[tier].instance);
+            uint64_t used = storage_engine_disk_space_used(eng->backend, localhost->db[tier].instance);
             time_t first_time_s = storage_engine_global_first_time_s(eng->backend, localhost->db[tier].instance);
             size_t currently_collected_metrics = storage_engine_collected_metrics(eng->backend, localhost->db[tier].instance);
 

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -1008,12 +1008,12 @@ bool rrdeng_metric_retention_by_uuid(STORAGE_INSTANCE *db_instance, uuid_t *dim_
     return true;
 }
 
-size_t rrdeng_disk_space_max(STORAGE_INSTANCE *db_instance) {
+uint64_t rrdeng_disk_space_max(STORAGE_INSTANCE *db_instance) {
     struct rrdengine_instance *ctx = (struct rrdengine_instance *)db_instance;
     return ctx->config.max_disk_space;
 }
 
-size_t rrdeng_disk_space_used(STORAGE_INSTANCE *db_instance) {
+uint64_t rrdeng_disk_space_used(STORAGE_INSTANCE *db_instance) {
     struct rrdengine_instance *ctx = (struct rrdengine_instance *)db_instance;
     return __atomic_load_n(&ctx->atomic.current_disk_space, __ATOMIC_RELAXED);
 }

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -222,7 +222,7 @@ RRDENG_SIZE_STATS rrdeng_size_statistics(struct rrdengine_instance *ctx);
 size_t rrdeng_collectors_running(struct rrdengine_instance *ctx);
 bool rrdeng_is_legacy(STORAGE_INSTANCE *db_instance);
 
-size_t rrdeng_disk_space_max(STORAGE_INSTANCE *db_instance);
-size_t rrdeng_disk_space_used(STORAGE_INSTANCE *db_instance);
+uint64_t rrdeng_disk_space_max(STORAGE_INSTANCE *db_instance);
+uint64_t rrdeng_disk_space_used(STORAGE_INSTANCE *db_instance);
 
 #endif /* NETDATA_RRDENGINEAPI_H */

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -454,8 +454,8 @@ static inline void storage_engine_store_metric(
                                        count, anomaly_count, flags);
 }
 
-size_t rrdeng_disk_space_max(STORAGE_INSTANCE *db_instance);
-static inline size_t storage_engine_disk_space_max(STORAGE_ENGINE_BACKEND backend __maybe_unused, STORAGE_INSTANCE *db_instance __maybe_unused) {
+uint64_t rrdeng_disk_space_max(STORAGE_INSTANCE *db_instance);
+static inline uint64_t storage_engine_disk_space_max(STORAGE_ENGINE_BACKEND backend __maybe_unused, STORAGE_INSTANCE *db_instance __maybe_unused) {
 #ifdef ENABLE_DBENGINE
     if(likely(backend == STORAGE_ENGINE_BACKEND_DBENGINE))
         return rrdeng_disk_space_max(db_instance);
@@ -464,7 +464,7 @@ static inline size_t storage_engine_disk_space_max(STORAGE_ENGINE_BACKEND backen
     return 0;
 }
 
-size_t rrdeng_disk_space_used(STORAGE_INSTANCE *db_instance);
+uint64_t rrdeng_disk_space_used(STORAGE_INSTANCE *db_instance);
 static inline size_t storage_engine_disk_space_used(STORAGE_ENGINE_BACKEND backend __maybe_unused, STORAGE_INSTANCE *db_instance __maybe_unused) {
 #ifdef ENABLE_DBENGINE
     if(likely(backend == STORAGE_ENGINE_BACKEND_DBENGINE))


### PR DESCRIPTION
##### Summary
Avoid an overflow in some statistics in 32 bit systems

e.g when configured
```
[db]
	dbengine multihost disk space MB = 8192
```

The corresponding section in the `api/v2/node_instances` api reads

```
         "tier":0,
         "disk_used":4031600652,
         "disk_max":0,
         "disk_percent":0,
         "from":1694503290,
         "to":1695656602,
         "retention":1153312,
         "expected_retention":2147483647,
         "currently_collected_metrics":13313
```

With this PR it reads

```
         "tier":0,
         "disk_used":4020221964,
         "disk_max":8589934592,
         "disk_percent":46.8015434,
         "from":1694503290,
         "to":1695655672,
         "retention":1152382,
         "expected_retention":2462273,
         "currently_collected_metrics":13313
```