### PR TITLE
Update to use versioned base images for CI.

### DIFF
--- a/.github/scripts/get-static-cache-key.sh
+++ b/.github/scripts/get-static-cache-key.sh
@@ -2,13 +2,14 @@
 
 arch="${1}"
 platform="$(packaging/makeself/uname2platform.sh "${arch}")"
+builder_rev="v1"
 
-docker pull --platform "${platform}" netdata/static-builder
+docker pull --platform "${platform}" netdata/static-builder:${builder_rev}
 
 # shellcheck disable=SC2046
 cat $(find packaging/makeself/jobs -type f ! -regex '.*\(netdata\|-makeself\).*') > /tmp/static-cache-key-data
 
-docker run -it --rm --platform "${platform}" netdata/static-builder sh -c 'apk list -I 2>/dev/null' >> /tmp/static-cache-key-data
+docker run -it --rm --platform "${platform}" netdata/static-builder:${builder_rev} sh -c 'apk list -I 2>/dev/null' >> /tmp/static-cache-key-data
 
 h="$(sha256sum /tmp/static-cache-key-data | cut -f 1 -d ' ')"
 

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -228,14 +228,14 @@ jobs:
           timeout_seconds: 900
           command: |
             docker pull --platform ${{ matrix.platform }} ${{ matrix.base_image }}
-            docker pull --platform ${{ matrix.platform }} netdata/package-builders:${{ matrix.distro }}${{ matrix.version }}.v1
+            docker pull --platform ${{ matrix.platform }} netdata/package-builders:${{ matrix.distro }}${{ matrix.version }}-v1
       - name: Build Packages
         id: build
         if: needs.file-check.outputs.run == 'true'
         shell: bash
         run: |
           docker run --security-opt seccomp=unconfined -e DISABLE_TELEMETRY=1 -e VERSION=${{ needs.version-check.outputs.version }} \
-                     --platform=${{ matrix.platform }} -v "$PWD":/netdata netdata/package-builders:${{ matrix.distro }}${{ matrix.version }}.v1
+                     --platform=${{ matrix.platform }} -v "$PWD":/netdata netdata/package-builders:${{ matrix.distro }}${{ matrix.version }}-v1
       - name: Save Packages
         id: artifacts
         if: needs.file-check.outputs.run == 'true'

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -228,14 +228,14 @@ jobs:
           timeout_seconds: 900
           command: |
             docker pull --platform ${{ matrix.platform }} ${{ matrix.base_image }}
-            docker pull --platform ${{ matrix.platform }} netdata/package-builders:${{ matrix.distro }}${{ matrix.version }}
+            docker pull --platform ${{ matrix.platform }} netdata/package-builders:${{ matrix.distro }}${{ matrix.version }}.v1
       - name: Build Packages
         id: build
         if: needs.file-check.outputs.run == 'true'
         shell: bash
         run: |
           docker run --security-opt seccomp=unconfined -e DISABLE_TELEMETRY=1 -e VERSION=${{ needs.version-check.outputs.version }} \
-                     --platform=${{ matrix.platform }} -v "$PWD":/netdata netdata/package-builders:${{ matrix.distro }}${{ matrix.version }}
+                     --platform=${{ matrix.platform }} -v "$PWD":/netdata netdata/package-builders:${{ matrix.distro }}${{ matrix.version }}.v1
       - name: Save Packages
         id: artifacts
         if: needs.file-check.outputs.run == 'true'

--- a/packaging/building-native-packages-locally.md
+++ b/packaging/building-native-packages-locally.md
@@ -26,7 +26,7 @@ podman run -it --rm -e VERSION=0.1 -v $PWD:/netdata netdata/package-builders:<ta
 
 The `<tag>` should be the lowercase distribution name with no spaces, followed by the
 release of that distribution. For example, `centos7` to build on CentOS 7, or `ubuntu20.04`
-to build on Ubuntu 20.04. Note that we use Alma Linux for builds on CentOS/RHEL 8 or newer. See
+to build on Ubuntu 20.04. Note that we use Rocky Linux for builds on CentOS/RHEL 8 or newer. See
 [netdata/package-builders](https://hub.docker.com/r/netdata/package-builders/tags) for all available tags.
 
 The value passed in the `VERSION` environment variable can be any version number accepted by the type of package

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -3,7 +3,7 @@
 
 # This image contains preinstalled dependencies
 # hadolint ignore=DL3007
-FROM netdata/builder:latest as builder
+FROM netdata/builder:v1 as builder
 
 # One of 'nightly' or 'stable'
 ARG RELEASE_CHANNEL=nightly
@@ -59,7 +59,7 @@ RUN mkdir -p /app/usr/sbin/ \
 #####################################################################
 # This image contains preinstalled dependencies
 # hadolint ignore=DL3007
-FROM netdata/base:latest as base
+FROM netdata/base:v1 as base
 
 LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
 LABEL org.opencontainers.image.url="https://netdata.cloud"

--- a/packaging/makeself/build-static.sh
+++ b/packaging/makeself/build-static.sh
@@ -24,7 +24,7 @@ else
     exit 1
 fi
 
-DOCKER_IMAGE_NAME="netdata/static-builder"
+DOCKER_IMAGE_NAME="netdata/static-builder:v1"
 
 if [ "${BUILDARCH}" != "$(uname -m)" ] && [ "$(uname -m)" = 'x86_64' ] && [ -z "${SKIP_EMULATION}" ]; then
     ${docker} run --rm --privileged multiarch/qemu-user-static --reset -p yes || exit 1


### PR DESCRIPTION
##### Summary

Second part of https://github.com/netdata/helper-images/pull/242. This updates our CI to actually used the new version tags for the various Docker images it’s using.

##### Test Plan

CI passes on this PR

##### Additional Information

This needs to be merged before https://github.com/netdata/helper-images/pull/223 gets merged.