### PR TITLE
Send alerts summary field to cloud

### DIFF
--- a/aclk/schema-wrappers/alarm_config.cc
+++ b/aclk/schema-wrappers/alarm_config.cc
@@ -50,6 +50,7 @@ void destroy_aclk_alarm_configuration(struct aclk_alarm_configuration *cfg)
     freez(cfg->p_db_lookup_options);
 
     freez(cfg->chart_labels);
+    freez(cfg->summary);
 }
 
 char *generate_provide_alarm_configuration(size_t *len, struct provide_alarm_configuration *data)
@@ -131,6 +132,9 @@ char *generate_provide_alarm_configuration(size_t *len, struct provide_alarm_con
 
     if (data->cfg.chart_labels)
         cfg->set_chart_labels(data->cfg.chart_labels);
+
+    if (data->cfg.summary)
+        cfg->set_summary(data->cfg.summary);
 
     *len = PROTO_COMPAT_MSG_SIZE(msg);
     char *bin = (char*)mallocz(*len);

--- a/aclk/schema-wrappers/alarm_config.h
+++ b/aclk/schema-wrappers/alarm_config.h
@@ -52,6 +52,7 @@ struct aclk_alarm_configuration {
     int32_t p_update_every;
 
     char *chart_labels;
+    char *summary;
 };
 
 void destroy_aclk_alarm_configuration(struct aclk_alarm_configuration *cfg);

--- a/aclk/schema-wrappers/alarm_stream.cc
+++ b/aclk/schema-wrappers/alarm_stream.cc
@@ -68,26 +68,21 @@ void destroy_alarm_log_entry(struct alarm_log_entry *entry)
 {
     //freez(entry->node_id);
     //freez(entry->claim_id);
-
     freez(entry->chart);
     freez(entry->name);
     freez(entry->family);
-
     freez(entry->config_hash);
-
     freez(entry->timezone);
-
     freez(entry->exec_path);
     freez(entry->conf_source);
     freez(entry->command);
-
     freez(entry->value_string);
     freez(entry->old_value_string);
-
     freez(entry->rendered_info);
     freez(entry->chart_context);
     freez(entry->transition_id);
     freez(entry->chart_name);
+    freez(entry->summary);
 }
 
 static void fill_alarm_log_entry(struct alarm_log_entry *data, AlarmLogEntry *proto)
@@ -136,6 +131,7 @@ static void fill_alarm_log_entry(struct alarm_log_entry *data, AlarmLogEntry *pr
     proto->set_event_id(data->event_id);
     proto->set_transition_id(data->transition_id);
     proto->set_chart_name(data->chart_name);
+    proto->set_summary(data->summary);
 }
 
 char *generate_alarm_log_entry(size_t *len, struct alarm_log_entry *data)

--- a/aclk/schema-wrappers/alarm_stream.h
+++ b/aclk/schema-wrappers/alarm_stream.h
@@ -76,7 +76,8 @@ struct alarm_log_entry {
     char *chart_name;
 
     uint64_t event_id;
-    char *transition_id;  
+    char *transition_id;
+    char *summary;
 };
 
 struct send_alarm_checkpoint {

--- a/database/contexts/api_v2.c
+++ b/database/contexts/api_v2.c
@@ -355,6 +355,7 @@ static void alert_instances_v2_insert_callback(const DICTIONARY_ITEM *item __may
     t->status = rc->status;
     t->flags = rc->run_flags;
     t->info = rc->info;
+    t->summary = rc->summary;
     t->value = rc->value;
     t->last_updated = rc->last_updated;
     t->last_status_change = rc->last_status_change;

--- a/database/contexts/api_v2.c
+++ b/database/contexts/api_v2.c
@@ -1280,6 +1280,7 @@ static void contexts_v2_alert_config_to_json_from_sql_alert_config_data(struct s
         buffer_json_member_add_string(wb, "component", t->component);
         buffer_json_member_add_string(wb, "type", t->type);
         buffer_json_member_add_string(wb, "info", t->info);
+        buffer_json_member_add_string(wb, "summary", t->summary);
         // buffer_json_member_add_string(wb, "source", t->source); // moved to alert instance
     }
     
@@ -1343,6 +1344,7 @@ static int contexts_v2_alert_instance_to_json_callback(const DICTIONARY_ITEM *it
             buffer_json_member_add_string(wb, "units", string2str(t->units));
             buffer_json_member_add_string(wb, "fami", string2str(t->family));
             buffer_json_member_add_string(wb, "info", string2str(t->info));
+            buffer_json_member_add_string(wb, "sum", string2str(t->summary));
             buffer_json_member_add_string(wb, "ctx", string2str(t->context));
             buffer_json_member_add_string(wb, "st", rrdcalc_status2string(t->status));
             buffer_json_member_add_uuid(wb, "tr_i", &t->last_transition_id);
@@ -1438,6 +1440,7 @@ struct sql_alert_transition_fixed_size {
     char units[SQL_TRANSITION_DATA_SMALL_STRING];
     char exec[SQL_TRANSITION_DATA_BIG_STRING];
     char info[SQL_TRANSITION_DATA_BIG_STRING];
+    char summary[SQL_TRANSITION_DATA_BIG_STRING];
     char classification[SQL_TRANSITION_DATA_SMALL_STRING];
     char type[SQL_TRANSITION_DATA_SMALL_STRING];
     char component[SQL_TRANSITION_DATA_SMALL_STRING];
@@ -1477,6 +1480,7 @@ static struct sql_alert_transition_fixed_size *contexts_v2_alert_transition_dup(
     strncpyz(n->units, t->units ? t->units : "", sizeof(n->units) - 1);
     strncpyz(n->exec, t->exec ? t->exec : "", sizeof(n->exec) - 1);
     strncpyz(n->info, t->info ? t->info : "", sizeof(n->info) - 1);
+    strncpyz(n->summary, t->summary ? t->summary : "", sizeof(n->summary) - 1);
     strncpyz(n->classification, t->classification ? t->classification : "", sizeof(n->classification) - 1);
     strncpyz(n->type, t->type ? t->type : "", sizeof(n->type) - 1);
     strncpyz(n->component, t->component ? t->component : "", sizeof(n->component) - 1);
@@ -1734,6 +1738,7 @@ static void contexts_v2_alert_transitions_to_json(BUFFER *wb, struct rrdcontext_
 
             buffer_json_member_add_time_t(wb, "when", t->when_key);
             buffer_json_member_add_string(wb, "info", *t->info ? t->info : "");
+            buffer_json_member_add_string(wb, "summary", *t->summary ? t->summary : "");
             buffer_json_member_add_string(wb, "units", *t->units ? t->units : NULL);
             buffer_json_member_add_object(wb, "new");
             {

--- a/database/contexts/rrdcontext.h
+++ b/database/contexts/rrdcontext.h
@@ -432,6 +432,7 @@ struct sql_alert_transition_data {
     const char *units;
     const char *exec;
     const char *info;
+    const char *summary;
     const char *classification;
     const char *type;
     const char *component;
@@ -472,6 +473,7 @@ struct sql_alert_config_data {
     const char *classification;
     const char *component;
     const char *type;
+    const char *summary;
 
     struct {
         struct {
@@ -531,6 +533,7 @@ struct sql_alert_instance_v2_entry {
     RRDCALC_STATUS status;
     RRDCALC_FLAGS flags;
     STRING *info;
+    STRING *summary;
     NETDATA_DOUBLE value;
     time_t last_updated;
     time_t last_status_change;

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -1882,7 +1882,7 @@ done:
     "SELECT h.host_id, h.alarm_id, h.config_hash_id, h.name, h.chart, h.chart_name, h.family, h.recipient, h.units, h.exec, " \
     "h.chart_context,  d.when_key, d.duration, d.non_clear_duration, d.flags, d.delay_up_to_timestamp, "                      \
     "d.info, d.exec_code, d.new_status, d.old_status, d.delay, d.new_value, d.old_value, d.last_repeat, "                     \
-    "d.transition_id, d.global_id, ah.class, ah.type, ah.component, d.exec_run_timestamp"
+    "d.transition_id, d.global_id, ah.class, ah.type, ah.component, d.exec_run_timestamp, d.summary"
 
 #define SQL_SEARCH_ALERT_TRANSITION_COMMON_WHERE "h.config_hash_id = ah.hash_id AND h.health_log_id = d.health_log_id"
 
@@ -2054,6 +2054,7 @@ run_query:;
         atd.type = (const char *) sqlite3_column_text(res, 27);
         atd.component = (const char *) sqlite3_column_text(res, 28);
         atd.exec_run_timestamp = sqlite3_column_int64(res, 29);
+        atd.summary = (const char *) sqlite3_column_text(res, 30);
 
         cb(&atd, data);
     }
@@ -2079,7 +2080,7 @@ done_only_drop:
     "SELECT ah.hash_id, alarm, template, on_key, class, component, type, os, hosts, lookup, every, "                   \
     " units, calc, families, plugin, module, charts, green, red, warn, crit, "                                         \
     " exec, to_key, info, delay, options, repeat, host_labels, p_db_lookup_dimensions, p_db_lookup_method, "           \
-    " p_db_lookup_options, p_db_lookup_after, p_db_lookup_before, p_update_every, source, chart_labels "               \
+    " p_db_lookup_options, p_db_lookup_after, p_db_lookup_before, p_update_every, source, chart_labels, summary "      \
     " FROM alert_hash ah, c_%p t where ah.hash_id = t.hash_id"
 
 int sql_get_alert_configuration(
@@ -2188,6 +2189,7 @@ int sql_get_alert_configuration(
         acd.value.update_every = (int32_t) sqlite3_column_int(res, param++);
         acd.source = (const char *) sqlite3_column_text(res, param++);
         acd.selectors.chart_labels = (const char *) sqlite3_column_text(res, param++);
+        acd.summary = (const char *) sqlite3_column_text(res, param++);
 
         cb(&acd, data);
         added++;


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR sends the `summary` field of the alerts (both from alarm log events and configs) to the cloud. It also exposes the field to `v2/alert_transitions` and `v2/alert_config`.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Will be tested with backend, points to test:

* Field is transmitted in normal alert stream
* Field is transmitted in alert snapshots
* Field is transmitted in alert configs

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
