### PR TITLE
In help doc, added mkdir to the OpenSSL script to prevent errors

### DIFF
--- a/docs/metrics-storage-management/enable-streaming.md
+++ b/docs/metrics-storage-management/enable-streaming.md
@@ -173,6 +173,7 @@ On the **parent** node, use OpenSSL to create the key and certificate, then use 
 by the `netdata` user.
 
 ```bash
+mkdir -p /etc/netdata/ssl
 sudo openssl req -newkey rsa:2048 -nodes -sha512 -x509 -days 365 -keyout /etc/netdata/ssl/key.pem -out /etc/netdata/ssl/cert.pem
 sudo chown netdata:netdata /etc/netdata/ssl/cert.pem /etc/netdata/ssl/key.pem
 ```


### PR DESCRIPTION
For default install on Ubuntu, the ssl subdirectory is not created, so the openssl command fails.  This adds the mkdir command, with -p so that it will not cause an error if the directory already exists.  This should solve the problem for Ubuntu and be harmless in any other case.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
