### PR TITLE
Fix coverity 402975

### DIFF
--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -365,7 +365,7 @@ static int store_host_metadata(RRDHOST *host)
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = sqlite3_bind_int(res, ++param, (int ) host->last_connected);
+    rc = sqlite3_bind_int64(res, ++param, (sqlite3_int64) host->last_connected);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 


### PR DESCRIPTION
##### Summary
- CID 402975:  High impact quality  (Y2K38_SAFETY)
   /database/sqlite/sqlite_metadata.c: 368 in store_host_metadata()

Use sqlite3_bind_int64 to resolve issue