### PR TITLE
Fix script halt issue by ignoring non-zero exit code from `cp`

### DIFF
--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -48,8 +48,8 @@ fi
 
 if mountpoint -q /etc/netdata; then
   echo "Copying stock configuration to /etc/netdata"
-  cp -an /etc/netdata.stock/* /etc/netdata
-  cp -an /etc/netdata.stock/.[^.]* /etc/netdata
+  cp -an /etc/netdata.stock/* /etc/netdata || true
+  cp -an /etc/netdata.stock/.[^.]* /etc/netdata || true
 fi
 
 if [ -w "/etc/netdata" ]; then


### PR DESCRIPTION
This pull request addresses a file copying issue observed in the `run.sh` script. In particular, the `cp` command with the `-n` flag halts the script execution if any file already exists in the destination directory due to the `set -e` directive.

The proposed modification ensures the script continues to execute even when some files are already present in the destination directory, by ignoring the non-zero exit code that `cp` might return.

Here are the changes in detail:

- Modify the `cp` command to ignore errors arising from the `-n` flag when files already exist in the destination directory.

Fixed:

```
Copying stock configuration to /etc/netdata
cp: not replacing '/etc/netdata/edit-config'
cp: not replacing '/etc/netdata/netdata-updater.conf'
cp: not replacing '/etc/netdata/netdata.conf'
cp: not replacing '/etc/netdata/orig'
```

This modification has been tested and confirmed to resolve the issue without introducing any side effects.

Result:

```
root@vitaliy-dle-test-hetzner:~# docker logs netdata 2>&1 | grep -A20 "Copying stock configuration"
Copying stock configuration to /etc/netdata
cp: not replacing '/etc/netdata/edit-config'
cp: not replacing '/etc/netdata/netdata-updater.conf'
cp: not replacing '/etc/netdata/netdata.conf'
cp: not replacing '/etc/netdata/orig'
cp: not replacing '/etc/netdata/.environment'
cp: not replacing '/etc/netdata/.install-type'
2023-09-27 19:30:48: netdata INFO  : MAIN : CONFIG: cannot load cloud config '/var/lib/netdata/cloud.d/cloud.conf'. Running with internal defaults.
2023-09-27 19:30:48: netdata INFO  : MAIN : Using host prefix directory '/host'
2023-09-27 19:30:48: netdata INFO  : MAIN : IEEE754: system is using IEEE754 DOUBLE PRECISION values
2023-09-27 19:30:48: netdata INFO  : MAIN : TIMEZONE: using strftime(): 'UTC'
2023-09-27 19:30:48: netdata INFO  : MAIN : TIMEZONE: fixed as 'UTC'
2023-09-27 19:30:48: netdata INFO  : MAIN : NETDATA STARTUP: next: initialize ML
2023-09-27 19:30:48: netdata INFO  : MAIN : NETDATA STARTUP: in       2 ms, initialize ML - next: initialize signals
2023-09-27 19:30:48: netdata INFO  : MAIN : NETDATA STARTUP: in       0 ms, initialize signals - next: initialize static threads
2023-09-27 19:30:48: netdata INFO  : MAIN : NETDATA STARTUP: in       0 ms, initialize static threads - next: initialize web server
2023-09-27 19:30:48: netdata INFO  : MAIN : NETDATA STARTUP: in       0 ms, initialize web server - next: initialize h2o server
2023-09-27 19:30:48: netdata INFO  : MAIN : NETDATA STARTUP: in       0 ms, initialize h2o server - next: set resource limits
2023-09-27 19:30:48: netdata INFO  : MAIN : resources control: allowed file descriptors: soft = 1048576, max = 1048576
2023-09-27 19:30:48: netdata INFO  : MAIN : NETDATA STARTUP: in       0 ms, set resource limits - next: become daemon
2023-09-27 19:30:48: netdata INFO  : MAIN : Out-Of-Memory (OOM) score is already set to the wanted value 0
root@vitaliy-dle-test-hetzner:~# 
```

- we ignore the error of not being able to overwrite the file and started netdata process.

![image](https://github.com/netdata/netdata/assets/37010174/36d30f90-3620-4738-adc2-8dd4a3353c37)
