### PR TITLE
Skip database migration steps in new installation

### DIFF
--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -138,28 +138,22 @@ const char *database_migrate_v13_v14[] = {
     NULL
 };
 
-static int do_migration_v1_v2(sqlite3 *database, const char *name)
+static int do_migration_v1_v2(sqlite3 *database)
 {
-    netdata_log_info("Running \"%s\" database migration", name);
-
     if (table_exists_in_database(database, "host") && !column_exists_in_table(database, "host", "hops"))
         return init_database_batch(database, &database_migrate_v1_v2[0]);
     return 0;
 }
 
-static int do_migration_v2_v3(sqlite3 *database, const char *name)
+static int do_migration_v2_v3(sqlite3 *database)
 {
-    netdata_log_info("Running \"%s\" database migration", name);
-
     if (table_exists_in_database(database, "host") && !column_exists_in_table(database, "host", "memory_mode"))
         return init_database_batch(database, &database_migrate_v2_v3[0]);
     return 0;
 }
 
-static int do_migration_v3_v4(sqlite3 *database, const char *name)
+static int do_migration_v3_v4(sqlite3 *database)
 {
-    netdata_log_info("Running database migration %s", name);
-
     char sql[256];
 
     int rc;
@@ -187,24 +181,18 @@ static int do_migration_v3_v4(sqlite3 *database, const char *name)
     return 0;
 }
 
-static int do_migration_v4_v5(sqlite3 *database, const char *name)
+static int do_migration_v4_v5(sqlite3 *database)
 {
-    netdata_log_info("Running \"%s\" database migration", name);
-
     return init_database_batch(database, &database_migrate_v4_v5[0]);
 }
 
-static int do_migration_v5_v6(sqlite3 *database, const char *name)
+static int do_migration_v5_v6(sqlite3 *database)
 {
-    netdata_log_info("Running \"%s\" database migration", name);
-
     return init_database_batch(database, &database_migrate_v5_v6[0]);
 }
 
-static int do_migration_v6_v7(sqlite3 *database, const char *name)
+static int do_migration_v6_v7(sqlite3 *database)
 {
-    netdata_log_info("Running \"%s\" database migration", name);
-
     char sql[256];
 
     int rc;
@@ -234,10 +222,8 @@ static int do_migration_v6_v7(sqlite3 *database, const char *name)
     return 0;
 }
 
-static int do_migration_v7_v8(sqlite3 *database, const char *name)
+static int do_migration_v7_v8(sqlite3 *database)
 {
-    netdata_log_info("Running database migration %s", name);
-
     char sql[256];
 
     int rc;
@@ -265,10 +251,8 @@ static int do_migration_v7_v8(sqlite3 *database, const char *name)
     return 0;
 }
 
-static int do_migration_v8_v9(sqlite3 *database, const char *name)
+static int do_migration_v8_v9(sqlite3 *database)
 {
-    netdata_log_info("Running database migration %s", name);
-
     char sql[2048];
     int rc;
     sqlite3_stmt *res = NULL;
@@ -339,19 +323,15 @@ static int do_migration_v8_v9(sqlite3 *database, const char *name)
     return 0;
 }
 
-static int do_migration_v9_v10(sqlite3 *database, const char *name)
+static int do_migration_v9_v10(sqlite3 *database)
 {
-    netdata_log_info("Running \"%s\" database migration", name);
-
     if (table_exists_in_database(database, "alert_hash") && !column_exists_in_table(database, "alert_hash", "chart_labels"))
         return init_database_batch(database, &database_migrate_v9_v10[0]);
     return 0;
 }
 
-static int do_migration_v10_v11(sqlite3 *database, const char *name)
+static int do_migration_v10_v11(sqlite3 *database)
 {
-    netdata_log_info("Running \"%s\" database migration", name);
-
     if (table_exists_in_database(database, "health_log") && !column_exists_in_table(database, "health_log", "chart_name"))
         return init_database_batch(database, &database_migrate_v10_v11[0]);
 
@@ -359,11 +339,9 @@ static int do_migration_v10_v11(sqlite3 *database, const char *name)
 }
 
 #define MIGR_11_12_UPD_HEALTH_LOG_DETAIL "UPDATE health_log_detail SET summary = (select name from health_log where health_log_id = health_log_detail.health_log_id);"
-static int do_migration_v11_v12(sqlite3 *database, const char *name)
+static int do_migration_v11_v12(sqlite3 *database)
 {
     int rc = 0;
-
-    netdata_log_info("Running \"%s\" database migration", name);
 
     if (table_exists_in_database(database, "health_log_detail") && !column_exists_in_table(database, "health_log_detail", "summary") &&
         table_exists_in_database(database, "alert_hash") && !column_exists_in_table(database, "alert_hash", "summary"))
@@ -375,11 +353,9 @@ static int do_migration_v11_v12(sqlite3 *database, const char *name)
     return rc;
 }
 
-static int do_migration_v12_v13(sqlite3 *database, const char *name)
+static int do_migration_v12_v13(sqlite3 *database)
 {
     int rc = 0;
-
-    netdata_log_info("Running \"%s\" database migration", name);
 
     if (table_exists_in_database(database, "health_log_detail") && !column_exists_in_table(database, "health_log_detail", "summary")) {
         rc = init_database_batch(database, &database_migrate_v12_v13_detail[0]);
@@ -392,10 +368,8 @@ static int do_migration_v12_v13(sqlite3 *database, const char *name)
     return rc;
 }
 
-static int do_migration_v13_v14(sqlite3 *database, const char *name)
+static int do_migration_v13_v14(sqlite3 *database)
 {
-    netdata_log_info("Running \"%s\" database migration", name);
-
     if (table_exists_in_database(database, "host") && !column_exists_in_table(database, "host", "last_connected"))
         return init_database_batch(database, &database_migrate_v13_v14[0]);
 
@@ -412,25 +386,22 @@ const char *database_ml_migrate_v1_v2[] = {
     NULL
 };
 
-static int do_ml_migration_v1_v2(sqlite3 *database, const char *name)
+static int do_ml_migration_v1_v2(sqlite3 *database)
 {
-    netdata_log_info("Running \"%s\" database migration", name);
-
     if (get_auto_vaccum(database) != 2)
         return init_database_batch(database, &database_ml_migrate_v1_v2[0]);
     return 0;
 }
 
-static int do_migration_noop(sqlite3 *database, const char *name)
+static int do_migration_noop(sqlite3 *database)
 {
     UNUSED(database);
-    netdata_log_info("Running database migration %s", name);
     return 0;
 }
 
 typedef struct database_func_migration_list {
     char *name;
-    int (*func)(sqlite3 *database, const char *name);
+    int (*func)(sqlite3 *database);
 } DATABASE_FUNC_MIGRATION_LIST;
 
 
@@ -452,7 +423,8 @@ static int migrate_database(sqlite3 *database, int target_version, char *db_name
 
     netdata_log_info("Database version is %d, current version is %d. Running migration for %s ...", user_version, target_version, db_name);
     for (int i = user_version; i < target_version && migration_list[i].func; i++) {
-        rc = (migration_list[i].func)(database, migration_list[i].name);
+        netdata_log_info("Running database \"%s\" migration %s", db_name, migration_list[i].name);
+        rc = (migration_list[i].func)(database);
         if (unlikely(rc)) {
             error_report("Database %s migration from version %d to version %d failed", db_name, i, i + 1);
             return i;

--- a/database/sqlite/sqlite_db_migration.h
+++ b/database/sqlite/sqlite_db_migration.h
@@ -8,7 +8,7 @@
 
 int perform_database_migration(sqlite3 *database, int target_version);
 int perform_context_database_migration(sqlite3 *database, int target_version);
-int table_exists_in_database(const char *table);
+int table_exists_in_database(sqlite3 *database, const char *table);
 int perform_ml_database_migration(sqlite3 *database, int target_version);
 
 #endif //NETDATA_SQLITE_DB_MIGRATION_H

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -325,7 +325,7 @@ int init_database_batch(sqlite3 *database, const char *batch[])
         if (rc != SQLITE_OK) {
             error_report("SQLite error during database initialization, rc = %d (%s)", rc, err_msg);
             error_report("SQLite failed statement %s", batch[i]);
-            analytics_set_data_str(&analytics_data.netdata_fail_reason, err_msg);
+            analytics_set_data_str(&analytics_data.netdata_fail_reason, sqlite3_errstr(sqlite3_extended_errcode(database)));
             sqlite3_free(err_msg);
             if (SQLITE_CORRUPT == rc) {
                 if (mark_database_to_recover(NULL, database))
@@ -409,7 +409,7 @@ int sql_init_database(db_check_action_type_t rebuild, int memory)
     rc = sqlite3_open(sqlite_database, &db_meta);
     if (rc != SQLITE_OK) {
         error_report("Failed to initialize database at %s, due to \"%s\"", sqlite_database, sqlite3_errstr(rc));
-        analytics_set_data_str(&analytics_data.netdata_fail_reason, sqlite3_errstr(rc));
+        analytics_set_data_str(&analytics_data.netdata_fail_reason, sqlite3_errstr(sqlite3_extended_errcode(db_meta)));
         sqlite3_close(db_meta);
         db_meta = NULL;
         return 1;

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -458,7 +458,7 @@ void sql_health_alarm_log_cleanup(RRDHOST *host, bool claimed) {
     uuid_unparse_lower_fix(&host->host_uuid, uuid_str);
     snprintfz(command, MAX_HEALTH_SQL_SIZE, "aclk_alert_%s", uuid_str);
 
-    bool aclk_table_exists = table_exists_in_database(command);
+    bool aclk_table_exists = table_exists_in_database(db_meta, command);
 
     char *sql = SQL_CLEANUP_HEALTH_LOG_DETAIL_NOT_CLAIMED;
 


### PR DESCRIPTION
##### Summary
Currently on a new agent installation the database migration steps are followed. Initially this was needed when the migration process was set in place and the database version for older agents was not known (set to 0).

With this PR if the database user version is 0 and no tables are found the migration steps are skipped (no needed)
