### PR TITLE
python.d: respect env NETDATA_LOG_SEVERITY_LEVEL

### DIFF
--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -876,6 +876,17 @@ def main():
     cmd = parse_command_line()
     log = PythonDLogger()
 
+    level = os.getenv('NETDATA_LOG_SEVERITY_LEVEL') or str()
+    level = level.upper()
+    if level == 'DEBUG':
+        log.logger.severity = 'DEBUG'
+    elif level == 'INFO':
+        log.logger.severity = 'INFO'
+    elif level == 'WARN' or level == 'WARNING':
+        log.logger.severity = 'WARNING'
+    elif level == 'ERR' or level == 'ERROR':
+        log.logger.severity = 'ERROR'
+
     if cmd.debug:
         log.logger.severity = 'DEBUG'
     if cmd.trace:

--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -877,14 +877,14 @@ def main():
     log = PythonDLogger()
 
     level = os.getenv('NETDATA_LOG_SEVERITY_LEVEL') or str()
-    level = level.upper()
-    if level == 'DEBUG':
+    level = level.lower()
+    if level == 'debug':
         log.logger.severity = 'DEBUG'
-    elif level == 'INFO':
+    elif level == 'info':
         log.logger.severity = 'INFO'
-    elif level == 'WARN' or level == 'WARNING':
+    elif level == 'warn' or level == 'warning':
         log.logger.severity = 'WARNING'
-    elif level == 'ERR' or level == 'ERROR':
+    elif level == 'err' or level == 'error':
         log.logger.severity = 'ERROR'
 
     if cmd.debug:


### PR DESCRIPTION
##### Summary

Adds support for env variable added in #14727.

##### Test Plan

Tested by running from terminal with different values.

```
NETDATA_LOG_SEVERITY_LEVEL=err ./python.d.plugin example
```

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
