### PR TITLE
charts.d: respect env NETDATA_LOG_SEVERITY_LEVEL

### DIFF
--- a/collectors/charts.d.plugin/charts.d.plugin.in
+++ b/collectors/charts.d.plugin/charts.d.plugin.in
@@ -20,6 +20,21 @@ PROGRAM_NAME="$(basename $0)"
 PROGRAM_NAME="${PROGRAM_NAME/.plugin/}"
 MODULE_NAME="main"
 
+LOG_LEVEL_ERR=1
+LOG_LEVEL_WARN=2
+LOG_LEVEL_INFO=3
+LOG_LEVEL="$LOG_LEVEL_INFO"
+
+set_log_severity_level() {
+  case ${NETDATA_LOG_SEVERITY_LEVEL,,} in
+    "info") LOG_LEVEL="$LOG_LEVEL_INFO";;
+    "warn" | "warning") LOG_LEVEL="$LOG_LEVEL_WARN";;
+    "err" | "error") LOG_LEVEL="$LOG_LEVEL_ERR";;
+  esac
+}
+
+set_log_severity_level
+
 # -----------------------------------------------------------------------------
 # create temp dir
 
@@ -55,16 +70,19 @@ log() {
 
 }
 
+info() {
+  [[ -n "$LOG_LEVEL" && "$LOG_LEVEL_INFO" -gt "$LOG_LEVEL" ]] && return
+  log INFO "${@}"
+}
+
 warning() {
-	log WARNING "${@}"
+  [[ -n "$LOG_LEVEL" && "$LOG_LEVEL_WARN" -gt "$LOG_LEVEL" ]] && return
+  log WARNING "${@}"
 }
 
 error() {
-	log ERROR "${@}"
-}
-
-info() {
-	log INFO "${@}"
+  [[ -n "$LOG_LEVEL" && "$LOG_LEVEL_ERR" -gt "$LOG_LEVEL" ]] && return
+  log ERROR "${@}"
 }
 
 fatal() {


### PR DESCRIPTION
##### Summary

Adds support for env variable added in #14727.

##### Test Plan

Tested by running from terminal with different values.

```
NETDATA_LOG_SEVERITY_LEVEL=err ./charts.d.plugin
```

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
