### PR TITLE
external plugins: respect env NETDATA_LOG_SEVERITY_LEVEL

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -5549,6 +5549,8 @@ int main(int argc, char **argv) {
     error_log_errors_per_period = 100;
     error_log_throttle_period = 3600;
 
+    log_set_global_severity_for_external_plugins();
+
     bool send_resource_usage = true;
     {
         const char *s = getenv("NETDATA_INTERNALS_MONITORING");

--- a/collectors/cgroups.plugin/cgroup-name.sh
+++ b/collectors/cgroups.plugin/cgroup-name.sh
@@ -16,6 +16,21 @@ export LC_ALL=C
 
 PROGRAM_NAME="$(basename "${0}")"
 
+LOG_LEVEL_ERR=1
+LOG_LEVEL_WARN=2
+LOG_LEVEL_INFO=3
+LOG_LEVEL="$LOG_LEVEL_INFO"
+
+set_log_severity_level() {
+  case ${NETDATA_LOG_SEVERITY_LEVEL,,} in
+    "info") LOG_LEVEL="$LOG_LEVEL_INFO";;
+    "warn" | "warning") LOG_LEVEL="$LOG_LEVEL_WARN";;
+    "err" | "error") LOG_LEVEL="$LOG_LEVEL_ERR";;
+  esac
+}
+
+set_log_severity_level
+
 logdate() {
   date "+%Y-%m-%d %H:%M:%S"
 }
@@ -28,16 +43,19 @@ log() {
 
 }
 
+info() {
+  [[ -n "$LOG_LEVEL" && "$LOG_LEVEL_INFO" -gt "$LOG_LEVEL" ]] && return
+  log INFO "${@}"
+}
+
 warning() {
+  [[ -n "$LOG_LEVEL" && "$LOG_LEVEL_WARN" -gt "$LOG_LEVEL" ]] && return
   log WARNING "${@}"
 }
 
 error() {
+  [[ -n "$LOG_LEVEL" && "$LOG_LEVEL_ERR" -gt "$LOG_LEVEL" ]] && return
   log ERROR "${@}"
-}
-
-info() {
-  log INFO "${@}"
 }
 
 fatal() {

--- a/collectors/cgroups.plugin/cgroup-network-helper.sh
+++ b/collectors/cgroups.plugin/cgroup-network-helper.sh
@@ -31,6 +31,21 @@ export LC_ALL=C
 
 PROGRAM_NAME="$(basename "${0}")"
 
+LOG_LEVEL_ERR=1
+LOG_LEVEL_WARN=2
+LOG_LEVEL_INFO=3
+LOG_LEVEL="$LOG_LEVEL_INFO"
+
+set_log_severity_level() {
+  case ${NETDATA_LOG_SEVERITY_LEVEL,,} in
+    "info") LOG_LEVEL="$LOG_LEVEL_INFO";;
+    "warn" | "warning") LOG_LEVEL="$LOG_LEVEL_WARN";;
+    "err" | "error") LOG_LEVEL="$LOG_LEVEL_ERR";;
+  esac
+}
+
+set_log_severity_level
+
 logdate() {
     date "+%Y-%m-%d %H:%M:%S"
 }
@@ -43,16 +58,19 @@ log() {
 
 }
 
+info() {
+    [[ -n "$LOG_LEVEL" && "$LOG_LEVEL_INFO" -gt "$LOG_LEVEL" ]] && return
+    log INFO "${@}"
+}
+
 warning() {
+    [[ -n "$LOG_LEVEL" && "$LOG_LEVEL_WARN" -gt "$LOG_LEVEL" ]] && return
     log WARNING "${@}"
 }
 
 error() {
+    [[ -n "$LOG_LEVEL" && "$LOG_LEVEL_ERR" -gt "$LOG_LEVEL" ]] && return
     log ERROR "${@}"
-}
-
-info() {
-    log INFO "${@}"
 }
 
 fatal() {

--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -680,6 +680,8 @@ int main(int argc, char **argv) {
 
     if(argc != 3)
         usage();
+    
+    log_set_global_severity_for_external_plugins();
 
     int arg = 1;
     int helper = 1;

--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -11,9 +11,11 @@
 #endif
 
 char environment_variable2[FILENAME_MAX + 50] = "";
+char environment_variable3[FILENAME_MAX + 50] = "";
 char *environment[] = {
         "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin",
         environment_variable2,
+        environment_variable3,
         NULL
 };
 
@@ -670,6 +672,10 @@ int main(int argc, char **argv) {
 
     // the first environment variable is a fixed PATH=
     snprintfz(environment_variable2, sizeof(environment_variable2) - 1, "NETDATA_HOST_PREFIX=%s", netdata_configured_host_prefix);
+
+    char *s = getenv("NETDATA_LOG_SEVERITY_LEVEL");
+    if (s)
+        snprintfz(environment_variable3, sizeof(environment_variable3) - 1, "NETDATA_LOG_SEVERITY_LEVEL=%s", s);
 
     // ------------------------------------------------------------------------
 

--- a/collectors/cups.plugin/cups_plugin.c
+++ b/collectors/cups.plugin/cups_plugin.c
@@ -241,6 +241,8 @@ int main(int argc, char **argv) {
     error_log_errors_per_period = 100;
     error_log_throttle_period = 3600;
 
+    log_set_global_severity_for_external_plugins();
+
     parse_command_line(argc, argv);
 
     errno = 0;

--- a/collectors/debugfs.plugin/debugfs_plugin.c
+++ b/collectors/debugfs.plugin/debugfs_plugin.c
@@ -168,6 +168,8 @@ int main(int argc, char **argv)
     // disable syslog for debugfs.plugin
     error_log_syslog = 0;
 
+    log_set_global_severity_for_external_plugins();
+
     netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
     if (verify_netdata_host_prefix() == -1)
         exit(1);

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -4062,6 +4062,9 @@ static void ebpf_manage_pid(pid_t pid)
 int main(int argc, char **argv)
 {
     stderror = stderr;
+
+    log_set_global_severity_for_external_plugins();
+
     clocks_init();
     main_thread_id = gettid();
 

--- a/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -1450,6 +1450,8 @@ int main (int argc, char **argv) {
     error_log_errors_per_period = 100;
     error_log_throttle_period = 3600;
 
+    log_set_global_severity_for_external_plugins();
+
     // initialize the threads
     netdata_threads_init_for_external_plugins(0); // set the default threads stack size here
 

--- a/collectors/ioping.plugin/ioping.plugin.in
+++ b/collectors/ioping.plugin/ioping.plugin.in
@@ -96,6 +96,21 @@ fi
 
 PROGRAM_NAME="$(basename "${0}")"
 
+LOG_LEVEL_ERR=1
+LOG_LEVEL_WARN=2
+LOG_LEVEL_INFO=3
+LOG_LEVEL="$LOG_LEVEL_INFO"
+
+set_log_severity_level() {
+  case ${NETDATA_LOG_SEVERITY_LEVEL,,} in
+    "info") LOG_LEVEL="$LOG_LEVEL_INFO";;
+    "warn" | "warning") LOG_LEVEL="$LOG_LEVEL_WARN";;
+    "err" | "error") LOG_LEVEL="$LOG_LEVEL_ERR";;
+  esac
+}
+
+set_log_severity_level
+
 logdate() {
     date "+%Y-%m-%d %H:%M:%S"
 }
@@ -108,16 +123,19 @@ log() {
 
 }
 
+info() {
+    [[ -n "$LOG_LEVEL" && "$LOG_LEVEL_INFO" -gt "$LOG_LEVEL" ]] && return
+    log INFO "${@}"
+}
+
 warning() {
+    [[ -n "$LOG_LEVEL" && "$LOG_LEVEL_WARN" -gt "$LOG_LEVEL" ]] && return
     log WARNING "${@}"
 }
 
 error() {
+    [[ -n "$LOG_LEVEL" && "$LOG_LEVEL_ERR" -gt "$LOG_LEVEL" ]] && return
     log ERROR "${@}"
-}
-
-info() {
-    log INFO "${@}"
 }
 
 fatal() {

--- a/collectors/nfacct.plugin/plugin_nfacct.c
+++ b/collectors/nfacct.plugin/plugin_nfacct.c
@@ -762,6 +762,8 @@ int main(int argc, char **argv) {
     error_log_errors_per_period = 100;
     error_log_throttle_period = 3600;
 
+    log_set_global_severity_for_external_plugins();
+
     // ------------------------------------------------------------------------
     // parse command line parameters
 

--- a/collectors/perf.plugin/perf_plugin.c
+++ b/collectors/perf.plugin/perf_plugin.c
@@ -1298,6 +1298,8 @@ int main(int argc, char **argv) {
     error_log_errors_per_period = 100;
     error_log_throttle_period = 3600;
 
+    log_set_global_severity_for_external_plugins();
+
     parse_command_line(argc, argv);
 
     errno = 0;

--- a/collectors/slabinfo.plugin/slabinfo.c
+++ b/collectors/slabinfo.plugin/slabinfo.c
@@ -343,6 +343,8 @@ int main(int argc, char **argv) {
     program_version = "0.1";
     error_log_syslog = 0;
 
+    log_set_global_severity_for_external_plugins();
+
     int update_every = 1, i, n, freq = 0;
 
     for (i = 1; i < argc; i++) {

--- a/collectors/systemd-journal.plugin/systemd-journal.c
+++ b/collectors/systemd-journal.plugin/systemd-journal.c
@@ -2514,6 +2514,8 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
     error_log_errors_per_period = 100;
     error_log_throttle_period = 3600;
 
+    log_set_global_severity_for_external_plugins();
+
     netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
     if(verify_netdata_host_prefix() == -1) exit(1);
 

--- a/collectors/xenstat.plugin/xenstat_plugin.c
+++ b/collectors/xenstat.plugin/xenstat_plugin.c
@@ -935,6 +935,8 @@ int main(int argc, char **argv) {
     error_log_errors_per_period = 100;
     error_log_throttle_period = 3600;
 
+    log_set_global_severity_for_external_plugins();
+
     // ------------------------------------------------------------------------
     // parse command line parameters
 

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -81,6 +81,21 @@ export LC_ALL=C
 
 PROGRAM_NAME="$(basename "${0}")"
 
+LOG_LEVEL_ERR=1
+LOG_LEVEL_WARN=2
+LOG_LEVEL_INFO=3
+LOG_LEVEL="$LOG_LEVEL_INFO"
+
+set_log_severity_level() {
+  case ${NETDATA_LOG_SEVERITY_LEVEL,,} in
+    "info") LOG_LEVEL="$LOG_LEVEL_INFO";;
+    "warn" | "warning") LOG_LEVEL="$LOG_LEVEL_WARN";;
+    "err" | "error") LOG_LEVEL="$LOG_LEVEL_ERR";;
+  esac
+}
+
+set_log_severity_level
+
 logdate() {
   date "+%Y-%m-%d %H:%M:%S"
 }
@@ -93,16 +108,19 @@ log() {
 
 }
 
+info() {
+  [[ -n "$LOG_LEVEL" && "$LOG_LEVEL_INFO" -gt "$LOG_LEVEL" ]] && return
+  log INFO "${@}"
+}
+
 warning() {
+  [[ -n "$LOG_LEVEL" && "$LOG_LEVEL_WARN" -gt "$LOG_LEVEL" ]] && return
   log WARNING "${@}"
 }
 
 error() {
+  [[ -n "$LOG_LEVEL" && "$LOG_LEVEL_ERR" -gt "$LOG_LEVEL" ]] && return
   log ERROR "${@}"
-}
-
-info() {
-  log INFO "${@}"
 }
 
 fatal() {

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -1163,3 +1163,11 @@ char *log_severity_level_to_severity_string(netdata_log_level_t level)
             return NETDATA_LOG_LEVEL_INFO_STR;
     }
 }
+
+void log_set_global_severity_for_external_plugins() {
+    char *s = getenv("NETDATA_LOG_SEVERITY_LEVEL");
+    if (!s)
+        return;
+    netdata_log_level_t level = log_severity_string_to_severity_level(s);
+    log_set_global_severity_level(level);
+}

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -120,6 +120,7 @@ extern netdata_log_level_t global_log_severity_level;
 netdata_log_level_t log_severity_string_to_severity_level(char *level);
 char *log_severity_level_to_severity_string(netdata_log_level_t level);
 void log_set_global_severity_level(netdata_log_level_t value);
+void log_set_global_severity_for_external_plugins();
 
 #define error_limit_static_global_var(var, log_every_secs, sleep_usecs) static ERROR_LIMIT var = { .last_logged = 0, .count = 0, .log_every = (log_every_secs), .sleep_ut = (sleep_usecs) }
 #define error_limit_static_thread_var(var, log_every_secs, sleep_usecs) static __thread ERROR_LIMIT var = { .last_logged = 0, .count = 0, .log_every = (log_every_secs), .sleep_ut = (sleep_usecs) }


### PR DESCRIPTION
##### Summary

Adds support for the env variable added in #14727 to:

- [x] apps
- [x] cgroup-network
- [x] cgroup-network-helper.sh (called by cgroup-network)
- [x] cgroup-name.sh (called by cgroups)
- [x] cups
- [x] debugfs
- [x] ioping 
- [x] ebpf
- [x] freeipmi
- [x] nfacct
- [x] perf
- [x] slabinfo
- [x] systemd-journal
- [x] xenstat
- [x] alarm-notify.sh script


python.d addressed in #16084, charts.d in #16085, go.d in netdata/go.d.plugin#1351

##### Test Plan

Tested by running from the terminal with different values:

```
NETDATA_LOG_SEVERITY_LEVEL=<Level> ./<Plugin>
```

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
