### PR TITLE
Update categories.yaml

### DIFF
--- a/integrations/categories.yaml
+++ b/integrations/categories.yaml
@@ -235,7 +235,7 @@
       priority: -1
       children: []
     - id: data-collection.ci-cd-systems
-      name: CI/CD Platforms
+      name: CICD Platforms
       description: ""
       most_popular: false
       priority: -1


### PR DESCRIPTION
##### Summary


`CI/CD` gets treated as a folder in Learn, easiest fix is to remove the slash in the category name.

>In software engineering, CI/CD or CICD is the combined practices of continuous integration and continuous delivery or, less often, continuous deployment. They are sometimes referred to collectively as continuous development or continuous software development. [Wikipedia](https://en.wikipedia.org/wiki/CI/CD)