### PR TITLE
Do not force OOMKill

### DIFF
--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -2170,12 +2170,6 @@ static inline void ebpf_enable_specific_chart(struct ebpf_module *em, int disabl
 {
     em->enabled = NETDATA_THREAD_EBPF_RUNNING;
 
-    // oomkill stores data inside apps submenu, so it always need to have apps_enabled for plugin to create
-    // its chart, without this comparison eBPF.plugin will try to store invalid data when apps is disabled.
-    if (!strcmp(em->info.thread_name, "oomkill")) {
-        em->apps_charts = NETDATA_EBPF_APPS_FLAG_YES;
-    }
-
     if (!disable_cgroup) {
         em->cgroup_charts = CONFIG_BOOLEAN_YES;
     }


### PR DESCRIPTION
##### Summary
To collect `oomkill` events, it is necessary to have integration with apps enabled, this PR removes the initialization of `oomkill` when apps is not set.

##### Test Plan

1. Compile branch
2. start ebpf with apps integration disabled and check that we do not have the chars.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
