### PR TITLE
dont strip newlines when forwarding FUNCTION_PAYLOAD

### DIFF
--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -956,6 +956,8 @@ void execute_commands(struct sender_state *s) {
         *newline = '\0';
 
         if (s->receiving_function_payload && unlikely(strcmp(start, PLUGINSD_KEYWORD_FUNCTION_PAYLOAD_END) != 0)) {
+            if (buffer_strlen(s->function_payload.payload) != 0)
+                buffer_strcat(s->function_payload.payload, "\n");
             buffer_strcat(s->function_payload.payload, start);
             start = newline + 1;
             continue;


### PR DESCRIPTION
##### Summary

Fixes #16074

This bug is in developer only code at this time (only compiled when DYNCFG CFLAG is used).

When FUNCTION_PAYLOAD was sent over streaming the parser stripped newlines accidentally.

##### Test Plan

Use some HTTP client of your choice (you can use https://github.com/netdata/netdata/pull/16113, or insomnia, curl, wget) to set plugin config trough parent.

New lines should not be stripped anymore.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
