### PR TITLE
Remove multiple categories due to bug

### DIFF
--- a/collectors/cgroups.plugin/metadata.yaml
+++ b/collectors/cgroups.plugin/metadata.yaml
@@ -406,7 +406,7 @@ modules:
         link: https://kubernetes.io/
         icon_filename: kubernetes.svg
         categories:
-          - data-collection.containers-and-vms
+          #- data-collection.containers-and-vms
           - data-collection.kubernetes
       keywords:
         - k8s

--- a/collectors/python.d.plugin/beanstalk/metadata.yaml
+++ b/collectors/python.d.plugin/beanstalk/metadata.yaml
@@ -8,7 +8,7 @@ modules:
         link: "https://beanstalkd.github.io/"
         categories:
           - data-collection.message-brokers
-          - data-collection.task-queues
+          #- data-collection.task-queues
         icon_filename: "beanstalk.svg"
       related_resources:
         integrations:


### PR DESCRIPTION
##### Summary

Due to a bug/misbehavior in integrations/gen_integrations.py when there are multiple categories on an integration, they get randomly written in the .js file, and the documentation generation script uses the first one, resulting in constant rotation of the categories.

We comment the category we don't want until we find a fix for this.
