### PR TITLE
Retain a list structure instead of a set for data collection integrations categories

### DIFF
--- a/integrations/gen_integrations.py
+++ b/integrations/gen_integrations.py
@@ -462,7 +462,7 @@ def render_collectors(categories, collectors, ids):
             item['meta']['monitored_instance']['categories'] = list(default_cats)
             warn(f'{ item["id"] } does not list any caregories, adding it to: { default_cats }', item["_src_path"])
         else:
-            item['meta']['monitored_instance']['categories'] = list(actual_cats)
+            item['meta']['monitored_instance']['categories'] =  [x for x in item['meta']['monitored_instance']['categories'] if x in list(actual_cats)]
 
         for scope in item['metrics']['scopes']:
             if scope['name'] == 'global':


### PR DESCRIPTION
##### Summary

It was found that using sets was writing the categories in random order to the final js file, thus making Learn (which uses always the first one in the list) to keep moving documents around.

This fix uses a list comprehension to get the list of the elements and then remove those that are not present in the `actual_cats` set, which is shuffled sometimes.

The list always retains its order, thus solving the above-mentioned issue.