### PR TITLE
Split chars (eBPF <-> Apps integration)

### DIFF
--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -1215,6 +1215,7 @@ void ebpf_write_chart_cmd(char *type, char *id, char *suffix, char *title, char 
  *
  * @param type      chart type
  * @param id        chart id
+ * @param suffix    add suffix to obsolete charts.
  * @param title     chart title
  * @param units     units label
  * @param family    group name used to attach the chart on dashboard
@@ -1223,12 +1224,13 @@ void ebpf_write_chart_cmd(char *type, char *id, char *suffix, char *title, char 
  * @param order     chart order
  * @param update_every value to overwrite the update frequency set by the server.
  */
-void ebpf_write_chart_obsolete(char *type, char *id, char *title, char *units, char *family,
+void ebpf_write_chart_obsolete(char *type, char *id, char *suffix, char *title, char *units, char *family,
                                char *charttype, char *context, int order, int update_every)
 {
-    printf("CHART %s.%s '' '%s' '%s' '%s' '%s' '%s' %d %d 'obsolete'\n",
+    printf("CHART %s.%s%s '' '%s' '%s' '%s' '%s' '%s' %d %d 'obsolete'\n",
            type,
            id,
+           suffix,
            title,
            units,
            (family)?family:"",
@@ -1425,6 +1427,7 @@ void ebpf_statistic_obsolete_aral_chart(ebpf_module_t *em, int prio)
 {
     ebpf_write_chart_obsolete(NETDATA_MONITORING_FAMILY,
                               em->memory_allocations,
+                              "",
                               "Calls to allocate memory.",
                               "calls",
                               NETDATA_EBPF_FAMILY,
@@ -1435,6 +1438,7 @@ void ebpf_statistic_obsolete_aral_chart(ebpf_module_t *em, int prio)
 
     ebpf_write_chart_obsolete(NETDATA_MONITORING_FAMILY,
                               em->memory_allocations,
+                              "",
                               "Calls to allocate memory.",
                               "calls",
                               NETDATA_EBPF_FAMILY,

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -1082,7 +1082,7 @@ void write_chart_dimension(char *dim, long long value)
  */
 void write_count_chart(char *name, char *family, netdata_publish_syscall_t *move, uint32_t end)
 {
-    write_begin_chart(family, name, "");
+    ebpf_write_begin_chart(family, name, "");
 
     uint32_t i = 0;
     while (move && i < end) {
@@ -1092,7 +1092,7 @@ void write_count_chart(char *name, char *family, netdata_publish_syscall_t *move
         i++;
     }
 
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**
@@ -1105,7 +1105,7 @@ void write_count_chart(char *name, char *family, netdata_publish_syscall_t *move
  */
 void write_err_chart(char *name, char *family, netdata_publish_syscall_t *move, int end)
 {
-    write_begin_chart(family, name, "");
+    ebpf_write_begin_chart(family, name, "");
 
     int i = 0;
     while (move && i < end) {
@@ -1115,7 +1115,7 @@ void write_err_chart(char *name, char *family, netdata_publish_syscall_t *move, 
         i++;
     }
 
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**
@@ -1130,11 +1130,11 @@ void write_err_chart(char *name, char *family, netdata_publish_syscall_t *move, 
  */
 void ebpf_one_dimension_write_charts(char *family, char *chart, char *dim, long long v1)
 {
-    write_begin_chart(family, chart, "");
+    ebpf_write_begin_chart(family, chart, "");
 
     write_chart_dimension(dim, v1);
 
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**
@@ -1151,12 +1151,12 @@ void ebpf_one_dimension_write_charts(char *family, char *chart, char *dim, long 
  */
 void write_io_chart(char *chart, char *family, char *dwrite, long long vwrite, char *dread, long long vread)
 {
-    write_begin_chart(family, chart, "");
+    ebpf_write_begin_chart(family, chart, "");
 
     write_chart_dimension(dwrite, vwrite);
     write_chart_dimension(dread, vread);
 
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**
@@ -1303,14 +1303,14 @@ void ebpf_create_chart(char *type,
  */
 void write_histogram_chart(char *family, char *name, const netdata_idx_t *hist, char **dimensions, uint32_t end)
 {
-    write_begin_chart(family, name, "");
+    ebpf_write_begin_chart(family, name, "");
 
     uint32_t i;
     for (i = 0; i < end; i++) {
         write_chart_dimension(dimensions[i], (long long) hist[i]);
     }
 
-    write_end_chart();
+    ebpf_write_end_chart();
 
     fflush(stdout);
 }
@@ -1417,13 +1417,13 @@ void ebpf_send_data_aral_chart(ARAL *memory, ebpf_module_t *em)
 
     struct aral_statistics *stats = aral_statistics(memory);
 
-    write_begin_chart(NETDATA_MONITORING_FAMILY, em->memory_usage, "");
+    ebpf_write_begin_chart(NETDATA_MONITORING_FAMILY, em->memory_usage, "");
     write_chart_dimension(mem, (long long)stats->structures.allocated_bytes);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_MONITORING_FAMILY, em->memory_allocations, "");
+    ebpf_write_begin_chart(NETDATA_MONITORING_FAMILY, em->memory_allocations, "");
     write_chart_dimension(aral, (long long)stats->structures.allocations);
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /*****************************************************************
@@ -3404,7 +3404,7 @@ static char *hash_table_core[NETDATA_EBPF_LOAD_STAT_END] = {"per_core", "unique"
 static inline void ebpf_send_hash_table_pid_data(char *chart, uint32_t idx)
 {
     int i;
-    write_begin_chart(NETDATA_MONITORING_FAMILY, chart, "");
+    ebpf_write_begin_chart(NETDATA_MONITORING_FAMILY, chart, "");
     for (i = 0; i < EBPF_MODULE_FUNCTION_IDX; i++) {
         ebpf_module_t *wem = &ebpf_modules[i];
         if (wem->functions.apps_routine)
@@ -3413,7 +3413,7 @@ static inline void ebpf_send_hash_table_pid_data(char *chart, uint32_t idx)
                                   wem->hash_table_stats[idx]:
                                   0);
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**
@@ -3425,13 +3425,13 @@ static inline void ebpf_send_hash_table_pid_data(char *chart, uint32_t idx)
 static inline void ebpf_send_global_hash_table_data()
 {
     int i;
-    write_begin_chart(NETDATA_MONITORING_FAMILY, NETDATA_EBPF_HASH_TABLES_GLOBAL_ELEMENTS, "");
+    ebpf_write_begin_chart(NETDATA_MONITORING_FAMILY, NETDATA_EBPF_HASH_TABLES_GLOBAL_ELEMENTS, "");
     for (i = 0; i < EBPF_MODULE_FUNCTION_IDX; i++) {
         ebpf_module_t *wem = &ebpf_modules[i];
         write_chart_dimension((char *)wem->info.thread_name,
                               (wem->enabled < NETDATA_THREAD_EBPF_STOPPING) ? NETDATA_CONTROLLER_END: 0);
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**
@@ -3444,7 +3444,7 @@ void ebpf_send_statistic_data()
     if (!publish_internal_metrics)
         return;
 
-    write_begin_chart(NETDATA_MONITORING_FAMILY, NETDATA_EBPF_THREADS, "");
+    ebpf_write_begin_chart(NETDATA_MONITORING_FAMILY, NETDATA_EBPF_THREADS, "");
     int i;
     for (i = 0; i < EBPF_MODULE_FUNCTION_IDX; i++) {
         ebpf_module_t *wem = &ebpf_modules[i];
@@ -3453,9 +3453,9 @@ void ebpf_send_statistic_data()
 
         write_chart_dimension((char *)wem->info.thread_name, (wem->enabled < NETDATA_THREAD_EBPF_STOPPING) ? 1 : 0);
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_MONITORING_FAMILY, NETDATA_EBPF_LIFE_TIME, "");
+    ebpf_write_begin_chart(NETDATA_MONITORING_FAMILY, NETDATA_EBPF_LIFE_TIME, "");
     for (i = 0; i < EBPF_MODULE_FUNCTION_IDX ; i++) {
         ebpf_module_t *wem = &ebpf_modules[i];
         // Threads like VFS is slow to load and this can create an invalid number, this is the motive
@@ -3468,25 +3468,25 @@ void ebpf_send_statistic_data()
                               (long long) (wem->lifetime - wem->running_time):
                               0) ;
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_MONITORING_FAMILY, NETDATA_EBPF_LOAD_METHOD, "");
+    ebpf_write_begin_chart(NETDATA_MONITORING_FAMILY, NETDATA_EBPF_LOAD_METHOD, "");
     write_chart_dimension(load_event_stat[NETDATA_EBPF_LOAD_STAT_LEGACY], (long long)plugin_statistics.legacy);
     write_chart_dimension(load_event_stat[NETDATA_EBPF_LOAD_STAT_CORE], (long long)plugin_statistics.core);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_MONITORING_FAMILY, NETDATA_EBPF_KERNEL_MEMORY, "");
+    ebpf_write_begin_chart(NETDATA_MONITORING_FAMILY, NETDATA_EBPF_KERNEL_MEMORY, "");
     write_chart_dimension(memlock_stat, (long long)plugin_statistics.memlock_kern);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_MONITORING_FAMILY, NETDATA_EBPF_HASH_TABLES_LOADED, "");
+    ebpf_write_begin_chart(NETDATA_MONITORING_FAMILY, NETDATA_EBPF_HASH_TABLES_LOADED, "");
     write_chart_dimension(hash_table_stat, (long long)plugin_statistics.hash_tables);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_MONITORING_FAMILY, NETDATA_EBPF_HASH_TABLES_PER_CORE, "");
+    ebpf_write_begin_chart(NETDATA_MONITORING_FAMILY, NETDATA_EBPF_HASH_TABLES_PER_CORE, "");
     write_chart_dimension(hash_table_core[NETDATA_EBPF_THREAD_PER_CORE], (long long)plugin_statistics.hash_percpu);
     write_chart_dimension(hash_table_core[NETDATA_EBPF_THREAD_UNIQUE], (long long)plugin_statistics.hash_unique);
-    write_end_chart();
+    ebpf_write_end_chart();
 
     ebpf_send_global_hash_table_data();
 
@@ -3498,16 +3498,16 @@ void ebpf_send_statistic_data()
         if (!wem->functions.fnct_routine)
             continue;
 
-        write_begin_chart(NETDATA_MONITORING_FAMILY, (char *)wem->functions.fcnt_thread_chart_name, "");
+        ebpf_write_begin_chart(NETDATA_MONITORING_FAMILY, (char *)wem->functions.fcnt_thread_chart_name, "");
         write_chart_dimension((char *)wem->info.thread_name, (wem->enabled < NETDATA_THREAD_EBPF_STOPPING) ? 1 : 0);
-        write_end_chart();
+        ebpf_write_end_chart();
 
-        write_begin_chart(NETDATA_MONITORING_FAMILY, (char *)wem->functions.fcnt_thread_lifetime_name, "");
+        ebpf_write_begin_chart(NETDATA_MONITORING_FAMILY, (char *)wem->functions.fcnt_thread_lifetime_name, "");
         write_chart_dimension((char *)wem->info.thread_name,
                               (wem->lifetime && wem->enabled < NETDATA_THREAD_EBPF_STOPPING) ?
                               (long long) (wem->lifetime - wem->running_time):
                               0) ;
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -1291,33 +1291,6 @@ void ebpf_create_chart(char *type,
 }
 
 /**
- * Create charts on apps submenu
- *
- * @param id   the chart id
- * @param title  the value displayed on vertical axis.
- * @param units  the value displayed on vertical axis.
- * @param family Submenu that the chart will be attached on dashboard.
- * @param charttype chart type
- * @param order  the chart order
- * @param algorithm the algorithm used by dimension
- * @param root   structure used to create the dimensions.
- * @param update_every  update interval used by plugin
- * @param module    chart module name, this is the eBPF thread.
- */
-void ebpf_create_charts_on_apps(char *id, char *title, char *units, char *family, char *charttype, int order,
-                                char *algorithm, struct ebpf_target *root, int update_every, char *module)
-{
-    struct ebpf_target *w;
-    ebpf_write_chart_cmd(NETDATA_APPS_FAMILY, id, "", title, units, family, charttype, NULL, order,
-                         update_every, module);
-
-    for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed))
-            fprintf(stdout, "DIMENSION %s '' %s 1 1\n", w->name, algorithm);
-    }
-}
-
-/**
  * Call the necessary functions to create a name.
  *
  *  @param family     family name

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -1182,7 +1182,8 @@ void write_io_chart(char *chart, char *family, char *dwrite, long long vwrite, c
  * Write chart cmd on standard output
  *
  * @param type          chart type
- * @param id            chart id
+ * @param id            chart id (the apps group name).
+ * @param suffix        suffix to differentiate charts
  * @param title         chart title
  * @param units         units label
  * @param family        group name used to attach the chart on dashboard
@@ -1192,12 +1193,13 @@ void write_io_chart(char *chart, char *family, char *dwrite, long long vwrite, c
  * @param update_every  update interval used by plugin
  * @param module        chart module name, this is the eBPF thread.
  */
-void ebpf_write_chart_cmd(char *type, char *id, char *title, char *units, char *family,
+void ebpf_write_chart_cmd(char *type, char *id, char *suffix, char *title, char *units, char *family,
                           char *charttype, char *context, int order, int update_every, char *module)
 {
-    printf("CHART %s.%s '' '%s' '%s' '%s' '%s' '%s' %d %d '' 'ebpf.plugin' '%s'\n",
+    printf("CHART %s.%s%s '' '%s' '%s' '%s' '%s' '%s' %d %d '' 'ebpf.plugin' '%s'\n",
            type,
            id,
+           suffix,
            title,
            units,
            (family)?family:"",
@@ -1298,7 +1300,7 @@ void ebpf_create_chart(char *type,
                        int update_every,
                        char *module)
 {
-    ebpf_write_chart_cmd(type, id, title, units, family, charttype, context, order, update_every, module);
+    ebpf_write_chart_cmd(type, id, "", title, units, family, charttype, context, order, update_every, module);
 
     if (ncd) {
         ncd(move, end);
@@ -1323,7 +1325,7 @@ void ebpf_create_charts_on_apps(char *id, char *title, char *units, char *family
                                 char *algorithm, struct ebpf_target *root, int update_every, char *module)
 {
     struct ebpf_target *w;
-    ebpf_write_chart_cmd(NETDATA_APPS_FAMILY, id, title, units, family, charttype, NULL, order,
+    ebpf_write_chart_cmd(NETDATA_APPS_FAMILY, id, "", title, units, family, charttype, NULL, order,
                          update_every, module);
 
     for (w = root; w; w = w->next) {
@@ -1377,6 +1379,7 @@ int ebpf_statistic_create_aral_chart(char *name, ebpf_module_t *em)
 
     ebpf_write_chart_cmd(NETDATA_MONITORING_FAMILY,
                          em->memory_usage,
+                         "",
                          "Bytes allocated for ARAL.",
                          "bytes",
                          NETDATA_EBPF_FAMILY,
@@ -1392,6 +1395,7 @@ int ebpf_statistic_create_aral_chart(char *name, ebpf_module_t *em)
 
     ebpf_write_chart_cmd(NETDATA_MONITORING_FAMILY,
                          em->memory_allocations,
+                         "",
                          "Calls to allocate memory.",
                          "calls",
                          NETDATA_EBPF_FAMILY,
@@ -3586,6 +3590,7 @@ static void ebpf_create_thread_chart(char *name,
     // common call for specific and all charts.
     ebpf_write_chart_cmd(NETDATA_MONITORING_FAMILY,
                          name,
+                         "",
                          title,
                          units,
                          NETDATA_EBPF_FAMILY,
@@ -3625,6 +3630,7 @@ static inline void ebpf_create_statistic_load_chart(int update_every)
 {
     ebpf_write_chart_cmd(NETDATA_MONITORING_FAMILY,
                          NETDATA_EBPF_LOAD_METHOD,
+                         "",
                          "Load info.",
                          "methods",
                          NETDATA_EBPF_FAMILY,
@@ -3654,6 +3660,7 @@ static inline void ebpf_create_statistic_kernel_memory(int update_every)
 {
     ebpf_write_chart_cmd(NETDATA_MONITORING_FAMILY,
                          NETDATA_EBPF_KERNEL_MEMORY,
+                         "",
                          "Memory allocated for hash tables.",
                          "bytes",
                          NETDATA_EBPF_FAMILY,
@@ -3679,6 +3686,7 @@ static inline void ebpf_create_statistic_hash_tables(int update_every)
 {
     ebpf_write_chart_cmd(NETDATA_MONITORING_FAMILY,
                          NETDATA_EBPF_HASH_TABLES_LOADED,
+                         "",
                          "Number of hash tables loaded.",
                          "hash tables",
                          NETDATA_EBPF_FAMILY,
@@ -3704,6 +3712,7 @@ static inline void ebpf_create_statistic_hash_per_core(int update_every)
 {
     ebpf_write_chart_cmd(NETDATA_MONITORING_FAMILY,
                          NETDATA_EBPF_HASH_TABLES_PER_CORE,
+                         "",
                          "How threads are loading hash/array tables.",
                          "threads",
                          NETDATA_EBPF_FAMILY,
@@ -3733,6 +3742,7 @@ static void ebpf_create_statistic_hash_global_elements(int update_every)
 {
     ebpf_write_chart_cmd(NETDATA_MONITORING_FAMILY,
                          NETDATA_EBPF_HASH_TABLES_GLOBAL_ELEMENTS,
+                         "",
                          "Controllers inside global table",
                          "rows",
                          NETDATA_EBPF_FAMILY,
@@ -3764,6 +3774,7 @@ static void ebpf_create_statistic_hash_pid_table(int update_every, char *id, cha
 {
     ebpf_write_chart_cmd(NETDATA_MONITORING_FAMILY,
                          id,
+                         "",
                          title,
                          "rows",
                          NETDATA_EBPF_FAMILY,

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -275,17 +275,6 @@ void write_err_chart(char *name, char *family, netdata_publish_syscall_t *move, 
 void write_io_chart(char *chart, char *family, char *dwrite, long long vwrite,
                            char *dread, long long vread);
 
-void ebpf_create_charts_on_apps(char *name,
-                                       char *title,
-                                       char *units,
-                                       char *family,
-                                       char *charttype,
-                                       int order,
-                                       char *algorithm,
-                                       struct ebpf_target *root,
-                                       int update_every,
-                                       char *module);
-
 /**
  * Create Chart labels
  *

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -335,7 +335,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *root);
 void ebpf_one_dimension_write_charts(char *family, char *chart, char *dim, long long v1);
 collected_number get_value_from_structure(char *basis, size_t offset);
 void ebpf_update_pid_table(ebpf_local_maps_t *pid, ebpf_module_t *em);
-void ebpf_write_chart_obsolete(char *type, char *id, char *title, char *units, char *family,
+void ebpf_write_chart_obsolete(char *type, char *id, char *suffix, char *title, char *units, char *family,
                                       char *charttype, char *context, int order, int update_every);
 void write_histogram_chart(char *family, char *name, const netdata_idx_t *hist, char **dimensions, uint32_t end);
 void ebpf_update_disabled_plugin_stats(ebpf_module_t *em);

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -288,6 +288,28 @@ void ebpf_create_charts_on_apps(char *name,
                                        int update_every,
                                        char *module);
 
+/**
+ * Create Chart labels
+ *
+ * @param name    the label name.
+ * @param value   the label value.
+ * @param origin  the labeel source.
+ */
+static inline void ebpf_create_chart_labels(char *name, char *value, int source)
+{
+    fprintf(stdout, "CLABEL '%s' '%s' %d\n", name, value, source);
+}
+
+/**
+ * Commit label
+ *
+ * Write commit label to stdout
+ */
+static inline void ebpf_commit_label()
+{
+    fprintf(stdout, "CLABEL_COMMIT\n");
+}
+
 void write_end_chart();
 
 int ebpf_enable_tracepoint(ebpf_tracepoint_t *tp);

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -304,28 +304,15 @@ static inline void ebpf_commit_label()
  * @param name   the chart name
  * @param metric the chart suffix (used with apps and cgroups)
  */
-static inline void write_begin_chart(char *family, char *name, char *metric)
+static inline void ebpf_write_begin_chart(char *family, char *name, char *metric)
 {
     printf("BEGIN %s.%s%s\n", family, name, metric);
 }
 
 /**
- * Write begin command on standard output
- *
- * @param family the chart family name
- * @param name   the chart name
- * @param metric the chart suffix (used with apps and cgroups)
- * @param dt     the last heartbit
- */
-static inline void write_begin_chart_with_time(char *family, char *name, char *metric, usec_t dt)
-{
-    printf("BEGIN %s.%s_%s %"PRIu64"\n", family, name, metric, dt);
-}
-
-/**
  * Write END command on stdout.
  */
-static inline void write_end_chart()
+static inline void ebpf_write_end_chart()
 {
     printf("END\n");
 }

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -266,8 +266,6 @@ void ebpf_create_chart(char *type,
                               int update_every,
                               char *module);
 
-void write_begin_chart(char *family, char *name);
-
 void write_chart_dimension(char *dim, long long value);
 
 void write_count_chart(char *name, char *family, netdata_publish_syscall_t *move, uint32_t end);
@@ -308,6 +306,26 @@ static inline void ebpf_create_chart_labels(char *name, char *value, int source)
 static inline void ebpf_commit_label()
 {
     fprintf(stdout, "CLABEL_COMMIT\n");
+}
+
+/**
+ * Write begin command on standard output
+ *
+ * @param family the chart family name
+ * @param name   the chart name
+ * @param suffix the chart suffix (used with apps and cgroups)
+ */
+static inline void write_begin_chart(char *family, char *name, char *suffix)
+{
+    printf("BEGIN %s.%s%s\n", family, name, suffix);
+}
+
+/**
+ * Write END command on stdout.
+ */
+static inline void write_end_chart()
+{
+    printf("END\n");
 }
 
 void write_end_chart();

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -238,6 +238,7 @@ void ebpf_global_labels(netdata_syscall_stat_t *is,
 
 void ebpf_write_chart_cmd(char *type,
                                  char *id,
+                                 char *suffix,
                                  char *title,
                                  char *units,
                                  char *family,

--- a/collectors/ebpf.plugin/ebpf.h
+++ b/collectors/ebpf.plugin/ebpf.h
@@ -302,11 +302,24 @@ static inline void ebpf_commit_label()
  *
  * @param family the chart family name
  * @param name   the chart name
- * @param suffix the chart suffix (used with apps and cgroups)
+ * @param metric the chart suffix (used with apps and cgroups)
  */
-static inline void write_begin_chart(char *family, char *name, char *suffix)
+static inline void write_begin_chart(char *family, char *name, char *metric)
 {
-    printf("BEGIN %s.%s%s\n", family, name, suffix);
+    printf("BEGIN %s.%s%s\n", family, name, metric);
+}
+
+/**
+ * Write begin command on standard output
+ *
+ * @param family the chart family name
+ * @param name   the chart name
+ * @param metric the chart suffix (used with apps and cgroups)
+ * @param dt     the last heartbit
+ */
+static inline void write_begin_chart_with_time(char *family, char *name, char *metric, usec_t dt)
+{
+    printf("BEGIN %s.%s_%s %"PRIu64"\n", family, name, metric, dt);
 }
 
 /**
@@ -317,14 +330,15 @@ static inline void write_end_chart()
     printf("END\n");
 }
 
-void write_end_chart();
-
 int ebpf_enable_tracepoint(ebpf_tracepoint_t *tp);
 int ebpf_disable_tracepoint(ebpf_tracepoint_t *tp);
 uint32_t ebpf_enable_tracepoints(ebpf_tracepoint_t *tps);
 
 void ebpf_pid_file(char *filename, size_t length);
 
+#define EBPF_PROGRAMS_SECTION "ebpf programs"
+
+#define EBPF_COMMON_DIMENSION_PERCENTAGE "%"
 #define EBPF_PROGRAMS_SECTION "ebpf programs"
 
 #define EBPF_COMMON_DIMENSION_PERCENTAGE "%"

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -504,6 +504,10 @@ struct ebpf_target *get_apps_groups_target(struct ebpf_target **agrt, const char
 
     strncpyz(w->clean_name, w->name, EBPF_MAX_NAME);
     netdata_fix_chart_name(w->clean_name);
+    for (char *d = w->clean_name; *d; d++) {
+        if (*d == '.')
+            *d = '_';
+    }
 
     strncpyz(w->compare, nid, EBPF_MAX_COMPARE_NAME);
     size_t len = strlen(w->compare);

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -132,16 +132,6 @@ ebpf_socket_publish_apps_t *ebpf_socket_stat_get(void)
     return target;
 }
 
-/**
- * eBPF socket release
- *
- * @param stat Release a target after usage.
- */
-void ebpf_socket_release(ebpf_socket_publish_apps_t *stat)
-{
-    aral_freez(ebpf_aral_socket_pid, stat);
-}
-
 /*****************************************************************
  *
  *  CACHESTAT ARAL FUNCTIONS

--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -512,6 +512,9 @@ struct ebpf_target *get_apps_groups_target(struct ebpf_target **agrt, const char
         // copy the id
         strncpyz(w->name, nid, EBPF_MAX_NAME);
 
+    strncpyz(w->clean_name, w->name, EBPF_MAX_NAME);
+    netdata_fix_chart_name(w->clean_name);
+
     strncpyz(w->compare, nid, EBPF_MAX_COMPARE_NAME);
     size_t len = strlen(w->compare);
     if (w->compare[len - 1] == '*') {

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -221,7 +221,6 @@ extern ebpf_process_stat_t *process_stat_vector;
 extern ARAL *ebpf_aral_socket_pid;
 void ebpf_socket_aral_init();
 ebpf_socket_publish_apps_t *ebpf_socket_stat_get(void);
-void ebpf_socket_release(ebpf_socket_publish_apps_t *stat);
 
 extern ARAL *ebpf_aral_cachestat_pid;
 void ebpf_cachestat_aral_init();

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -10,6 +10,7 @@
 #include "libnetdata/ebpf/ebpf.h"
 
 #define NETDATA_APPS_FAMILY "apps"
+#define NETDATA_APP_FAMILY "app"
 #define NETDATA_APPS_FILE_GROUP "file_access"
 #define NETDATA_APPS_FILE_CGROUP_GROUP "file_access (eBPF)"
 #define NETDATA_APPS_PROCESS_GROUP "process (eBPF)"

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -48,6 +48,7 @@ struct ebpf_target {
 
     char id[EBPF_MAX_NAME + 1];
     uint32_t idhash;
+    uint32_t charts_created;
 
     char name[EBPF_MAX_NAME + 1];
     char clean_name[EBPF_MAX_NAME + 1]; // sanitized name used in chart id (need to replace at least dots)

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -50,6 +50,7 @@ struct ebpf_target {
     uint32_t idhash;
 
     char name[EBPF_MAX_NAME + 1];
+    char clean_name[EBPF_MAX_NAME + 1]; // sanitized name used in chart id (need to replace at least dots)
 
     // Changes made to simplify integration between apps and eBPF.
     netdata_publish_cachestat_t cachestat;

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -12,6 +12,7 @@
 #define NETDATA_APPS_FAMILY "apps"
 #define NETDATA_APP_FAMILY "app"
 #define NETDATA_APPS_FILE_GROUP "file_access"
+#define NETDATA_APPS_FILE_FDS "fds"
 #define NETDATA_APPS_FILE_CGROUP_GROUP "file_access (eBPF)"
 #define NETDATA_APPS_PROCESS_GROUP "process (eBPF)"
 #define NETDATA_APPS_NET_GROUP "net"

--- a/collectors/ebpf.plugin/ebpf_apps.h
+++ b/collectors/ebpf.plugin/ebpf_apps.h
@@ -15,7 +15,7 @@
 #define NETDATA_APPS_FILE_CGROUP_GROUP "file_access (eBPF)"
 #define NETDATA_APPS_PROCESS_GROUP "process (eBPF)"
 #define NETDATA_APPS_NET_GROUP "net"
-#define NETDATA_APPS_IPC_SHM_GROUP "ipc shm (eBPF)"
+#define NETDATA_APPS_IPC_SHM_GROUP "ipc shm"
 
 #include "ebpf_process.h"
 #include "ebpf_dcstat.h"

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -876,7 +876,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
         ebpf_create_chart_labels("app_group", w->name, 0);
         ebpf_commit_label();
-        fprintf(stdout, "DIMENSION access '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
+        fprintf(stdout, "DIMENSION hits '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
@@ -1023,7 +1023,7 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
 
         value = (collected_number) w->cachestat.hit;
         write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_cachestat_access");
-        write_chart_dimension("access", value);
+        write_chart_dimension("hits", value);
         write_end_chart();
 
         value = (collected_number) w->cachestat.miss;

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -530,6 +530,7 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
                                   "apps_cachestat_missees",
                                   20093,
                                   update_every);
+        w->charts_created &= ~(1<<EBPF_MODULE_CACHESTAT_IDX);
     }
 }
 
@@ -890,6 +891,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
         ebpf_create_chart_labels("app_group", w->name, 0);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION misses '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
+        w->charts_created |= 1<<EBPF_MODULE_CACHESTAT_IDX;
     }
 
     em->apps_charts |= NETDATA_EBPF_APPS_FLAG_CHART_CREATED;
@@ -992,7 +994,8 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
     collected_number value;
 
     for (w = root; w; w = w->next) {
-        if (likely(w->exposed && w->processes))
+        uint32_t cache_flag = w->charts_created & 1<<EBPF_MODULE_CACHESTAT_IDX;
+        if (likely(w->exposed && w->processes && !cache_flag))
             continue;
 
         ebpf_cachestat_sum_pids(&w->cachestat, w->root_pid);

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -1010,24 +1010,24 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
         cachestat_update_publish(&w->cachestat, mpa, mbd, apcl, apd);
 
         value = (collected_number) w->cachestat.ratio;
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_cachestat_hit_ratio");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_cachestat_hit_ratio");
         write_chart_dimension("ratio", value);
-        write_end_chart();
+        ebpf_write_end_chart();
 
         value = (collected_number) w->cachestat.dirty;
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_cachestat_dirty_pages");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_cachestat_dirty_pages");
         write_chart_dimension("pages", value);
-        write_end_chart();
+        ebpf_write_end_chart();
 
         value = (collected_number) w->cachestat.hit;
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_cachestat_access");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_cachestat_access");
         write_chart_dimension("hits", value);
-        write_end_chart();
+        ebpf_write_end_chart();
 
         value = (collected_number) w->cachestat.miss;
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_cachestat_misses");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_cachestat_misses");
         write_chart_dimension("misses", value);
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 }
 
@@ -1130,37 +1130,37 @@ static void ebpf_send_systemd_cachestat_charts()
 {
     ebpf_cgroup_target_t *ect;
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_HIT_RATIO_CHART, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_HIT_RATIO_CHART, "");
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_cachestat.ratio);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_DIRTY_CHART, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_DIRTY_CHART, "");
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_cachestat.dirty);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_HIT_CHART, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_HIT_CHART, "");
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_cachestat.hit);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_MISSES_CHART, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_MISSES_CHART, "");
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_cachestat.miss);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**
@@ -1170,21 +1170,21 @@ static void ebpf_send_systemd_cachestat_charts()
  */
 static void ebpf_send_specific_cachestat_data(char *type, netdata_publish_cachestat_t *npc)
 {
-    write_begin_chart(type, NETDATA_CACHESTAT_HIT_RATIO_CHART, "");
+    ebpf_write_begin_chart(type, NETDATA_CACHESTAT_HIT_RATIO_CHART, "");
     write_chart_dimension(cachestat_counter_publish_aggregated[NETDATA_CACHESTAT_IDX_RATIO].name, (long long)npc->ratio);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_CACHESTAT_DIRTY_CHART, "");
+    ebpf_write_begin_chart(type, NETDATA_CACHESTAT_DIRTY_CHART, "");
     write_chart_dimension(cachestat_counter_publish_aggregated[NETDATA_CACHESTAT_IDX_DIRTY].name, (long long)npc->dirty);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_CACHESTAT_HIT_CHART, "");
+    ebpf_write_begin_chart(type, NETDATA_CACHESTAT_HIT_CHART, "");
     write_chart_dimension(cachestat_counter_publish_aggregated[NETDATA_CACHESTAT_IDX_HIT].name, (long long)npc->hit);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_CACHESTAT_MISSES_CHART, "");
+    ebpf_write_begin_chart(type, NETDATA_CACHESTAT_MISSES_CHART, "");
     write_chart_dimension(cachestat_counter_publish_aggregated[NETDATA_CACHESTAT_IDX_MISS].name, (long long)npc->miss);
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -353,6 +353,7 @@ static void ebpf_obsolete_services(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_CACHESTAT_HIT_RATIO_CHART,
+                              "",
                               "Hit ratio",
                               EBPF_COMMON_DIMENSION_PERCENTAGE,
                               NETDATA_CACHESTAT_SUBMENU,
@@ -363,6 +364,7 @@ static void ebpf_obsolete_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_CACHESTAT_DIRTY_CHART,
+                              "",
                               "Number of dirty pages",
                               EBPF_CACHESTAT_DIMENSION_PAGE,
                               NETDATA_CACHESTAT_SUBMENU,
@@ -373,6 +375,7 @@ static void ebpf_obsolete_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_CACHESTAT_HIT_CHART,
+                              "",
                               "Number of accessed files",
                               EBPF_CACHESTAT_DIMENSION_HITS,
                               NETDATA_CACHESTAT_SUBMENU,
@@ -383,6 +386,7 @@ static void ebpf_obsolete_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_CACHESTAT_MISSES_CHART,
+                              "",
                               "Files out of page cache",
                               EBPF_CACHESTAT_DIMENSION_MISSES,
                               NETDATA_CACHESTAT_SUBMENU,
@@ -425,6 +429,7 @@ static void ebpf_obsolete_cachestat_global(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_EBPF_MEMORY_GROUP,
                               NETDATA_CACHESTAT_HIT_RATIO_CHART,
+                              "",
                               "Hit ratio",
                               EBPF_COMMON_DIMENSION_PERCENTAGE,
                               NETDATA_CACHESTAT_SUBMENU,
@@ -435,6 +440,7 @@ static void ebpf_obsolete_cachestat_global(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_EBPF_MEMORY_GROUP,
                               NETDATA_CACHESTAT_DIRTY_CHART,
+                              "",
                               "Number of dirty pages",
                               EBPF_CACHESTAT_DIMENSION_PAGE,
                               NETDATA_CACHESTAT_SUBMENU,
@@ -445,6 +451,7 @@ static void ebpf_obsolete_cachestat_global(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_EBPF_MEMORY_GROUP,
                               NETDATA_CACHESTAT_HIT_CHART,
+                              "",
                               "Number of accessed files",
                               EBPF_CACHESTAT_DIMENSION_HITS,
                               NETDATA_CACHESTAT_SUBMENU,
@@ -455,6 +462,7 @@ static void ebpf_obsolete_cachestat_global(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_EBPF_MEMORY_GROUP,
                               NETDATA_CACHESTAT_MISSES_CHART,
+                              "",
                               "Files out of page cache",
                               EBPF_CACHESTAT_DIMENSION_MISSES,
                               NETDATA_CACHESTAT_SUBMENU,
@@ -475,6 +483,7 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
 {
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_CACHESTAT_HIT_RATIO_CHART,
+                              "",
                               "Hit ratio",
                               EBPF_COMMON_DIMENSION_PERCENTAGE,
                               NETDATA_CACHESTAT_SUBMENU,
@@ -485,6 +494,7 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_CACHESTAT_DIRTY_CHART,
+                              "",
                               "Number of dirty pages",
                               EBPF_CACHESTAT_DIMENSION_PAGE,
                               NETDATA_CACHESTAT_SUBMENU,
@@ -493,7 +503,9 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
                               20091,
                               em->update_every);
 
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY, NETDATA_CACHESTAT_HIT_CHART,
+    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
+                              NETDATA_CACHESTAT_HIT_CHART,
+                              "",
                               "Number of accessed files",
                               EBPF_CACHESTAT_DIMENSION_HITS,
                               NETDATA_CACHESTAT_SUBMENU,
@@ -504,6 +516,7 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_CACHESTAT_MISSES_CHART,
+                              "",
                               "Files out of page cache",
                               EBPF_CACHESTAT_DIMENSION_MISSES,
                               NETDATA_CACHESTAT_SUBMENU,
@@ -1225,24 +1238,28 @@ static void ebpf_create_specific_cachestat_charts(char *type, int update_every)
 static void ebpf_obsolete_specific_cachestat_charts(char *type, int update_every)
 {
     ebpf_write_chart_obsolete(type, NETDATA_CACHESTAT_HIT_RATIO_CHART,
+                              "",
                       "Hit ratio",
                       EBPF_COMMON_DIMENSION_PERCENTAGE, NETDATA_CACHESTAT_SUBMENU,
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_CACHESTAT_HIT_RATIO_CONTEXT,
                       NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5200, update_every);
 
     ebpf_write_chart_obsolete(type, NETDATA_CACHESTAT_DIRTY_CHART,
+                              "",
                       "Number of dirty pages",
                       EBPF_CACHESTAT_DIMENSION_PAGE, NETDATA_CACHESTAT_SUBMENU,
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_CACHESTAT_MODIFIED_CACHE_CONTEXT,
                       NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5201, update_every);
 
     ebpf_write_chart_obsolete(type, NETDATA_CACHESTAT_HIT_CHART,
+                              "",
                       "Number of accessed files",
                       EBPF_CACHESTAT_DIMENSION_HITS, NETDATA_CACHESTAT_SUBMENU,
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_CACHESTAT_HIT_FILES_CONTEXT,
                       NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5202, update_every);
 
     ebpf_write_chart_obsolete(type, NETDATA_CACHESTAT_MISSES_CHART,
+                              "",
                       "Files out of page cache",
                       EBPF_CACHESTAT_DIMENSION_MISSES, NETDATA_CACHESTAT_SUBMENU,
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_CACHESTAT_MISS_FILES_CONTEXT,

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -494,7 +494,7 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
                                   EBPF_COMMON_DIMENSION_PERCENTAGE,
                                   NETDATA_CACHESTAT_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_LINE,
-                                  "apps_cachestat_ratio",
+                                  "ebpf.app_cachestat_ratio",
                                   20090,
                                   update_every);
 
@@ -505,7 +505,7 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
                                   EBPF_CACHESTAT_DIMENSION_PAGE,
                                   NETDATA_CACHESTAT_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "apps_cachestat_dirty",
+                                  "ebpf.app_cachestat_dirty",
                                   20091,
                                   update_every);
 
@@ -516,7 +516,7 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
                                   EBPF_CACHESTAT_DIMENSION_HITS,
                                   NETDATA_CACHESTAT_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "apps_cachestat_access",
+                                  "ebpf.app_cachestat_access",
                                   20092,
                                   update_every);
 
@@ -527,7 +527,7 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
                                   EBPF_CACHESTAT_DIMENSION_MISSES,
                                   NETDATA_CACHESTAT_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "apps_cachestat_missees",
+                                  "ebpf.app_cachestat_missees",
                                   20093,
                                   update_every);
         w->charts_created &= ~(1<<EBPF_MODULE_CACHESTAT_IDX);
@@ -838,7 +838,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              EBPF_COMMON_DIMENSION_PERCENTAGE,
                              NETDATA_CACHESTAT_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_LINE,
-                             "apps_cachestat_ratio",
+                             "ebpf.app_cachestat_ratio",
                              20090,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
@@ -854,7 +854,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              EBPF_CACHESTAT_DIMENSION_PAGE,
                              NETDATA_CACHESTAT_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_LINE,
-                             "apps_cachestat_dirty",
+                             "ebpf.app_cachestat_dirty",
                              20091,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
@@ -869,7 +869,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              EBPF_CACHESTAT_DIMENSION_HITS,
                              NETDATA_CACHESTAT_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "apps_cachestat_access",
+                             "ebpf.app_cachestat_access",
                              20092,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
@@ -884,7 +884,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              EBPF_CACHESTAT_DIMENSION_MISSES,
                              NETDATA_CACHESTAT_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "apps_cachestat_missees",
+                             "ebpf.app_cachestat_missees",
                              20093,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
@@ -994,8 +994,8 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
     collected_number value;
 
     for (w = root; w; w = w->next) {
-        uint32_t cache_flag = w->charts_created & 1<<EBPF_MODULE_CACHESTAT_IDX;
-        if (likely(w->exposed && w->processes && !cache_flag))
+        uint32_t flag = w->charts_created & 1<<EBPF_MODULE_CACHESTAT_IDX;
+        if (likely(w->exposed && w->processes && !flag))
             continue;
 
         ebpf_cachestat_sum_pids(&w->cachestat, w->root_pid);

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -484,8 +484,7 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = apps_groups_root_target; w; w = w->next) {
-        uint32_t flag = w->charts_created & (1 << EBPF_MODULE_CACHESTAT_IDX);
-        if (likely(w->exposed && w->processes && !flag))
+        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_CACHESTAT_IDX))))
             continue;
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -829,7 +828,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = root; w; w = w->next) {
-        if (likely(w->exposed && w->processes))
+        if (unlikely(!w->exposed))
             continue;
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
@@ -995,8 +994,7 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
     collected_number value;
 
     for (w = root; w; w = w->next) {
-        uint32_t flag = w->charts_created & 1<<EBPF_MODULE_CACHESTAT_IDX;
-        if (likely(w->exposed && w->processes && !flag))
+        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_CACHESTAT_IDX))))
             continue;
 
         ebpf_cachestat_sum_pids(&w->cachestat, w->root_pid);
@@ -1030,7 +1028,6 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
         write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_cachestat_misses");
         write_chart_dimension("misses", value);
         write_end_chart();
-        fflush(stdout);
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -495,7 +495,7 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
                                   NETDATA_CACHESTAT_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_LINE,
                                   "app.ebpf_cachestat_hit_ratio",
-                                  20090,
+                                  20260,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -506,7 +506,7 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
                                   NETDATA_CACHESTAT_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
                                   "app.ebpf_cachestat_dirty_pages",
-                                  20091,
+                                  20261,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -517,7 +517,7 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
                                   NETDATA_CACHESTAT_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
                                   "app.ebpf_cachestat_access",
-                                  20092,
+                                  20262,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -528,7 +528,7 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
                                   NETDATA_CACHESTAT_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
                                   "app.ebpf_cachestat_misses",
-                                  20093,
+                                  20263,
                                   update_every);
         w->charts_created &= ~(1<<EBPF_MODULE_CACHESTAT_IDX);
     }
@@ -839,7 +839,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_CACHESTAT_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_LINE,
                              "app.ebpf_cachestat_hit_ratio",
-                             20090,
+                             20260,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
         ebpf_create_chart_labels("app_group", w->name, 0);
@@ -855,7 +855,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_CACHESTAT_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_LINE,
                              "app.ebpf_cachestat_dirty_pages",
-                             20091,
+                             20261,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
         ebpf_create_chart_labels("app_group", w->name, 0);
@@ -870,7 +870,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_CACHESTAT_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
                              "app.ebpf_cachestat_access",
-                             20092,
+                             20262,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
         ebpf_create_chart_labels("app_group", w->name, 0);
@@ -885,7 +885,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_CACHESTAT_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
                              "app.ebpf_cachestat_misses",
-                             20093,
+                             20263,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
         ebpf_create_chart_labels("app_group", w->name, 0);

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -834,6 +834,8 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20090,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
+        ebpf_create_chart_labels("app_group", w->name, 0);
+        ebpf_commit_label();
         fprintf(stdout, "DIMENSION ratio '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 
 
@@ -848,6 +850,8 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20091,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
+        ebpf_create_chart_labels("app_group", w->name, 0);
+        ebpf_commit_label();
         fprintf(stdout, "DIMENSION dirties '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
@@ -861,6 +865,8 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20092,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
+        ebpf_create_chart_labels("app_group", w->name, 0);
+        ebpf_commit_label();
         fprintf(stdout, "DIMENSION access '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
@@ -874,6 +880,8 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20093,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
+        ebpf_create_chart_labels("app_group", w->name, 0);
+        ebpf_commit_label();
         fprintf(stdout, "DIMENSION misses '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
     }
 

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -490,45 +490,45 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_hit_ratio",
+                                  "_ebpf_cachestat_hit_ratio",
                                   "Hit ratio",
                                   EBPF_COMMON_DIMENSION_PERCENTAGE,
                                   NETDATA_CACHESTAT_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_LINE,
-                                  "ebpf.app_cachestat_ratio",
+                                  "app.ebpf_cachestat_hit_ratio",
                                   20090,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_dirty_pages",
+                                  "_ebpf_cachestat_dirty_pages",
                                   "Number of dirty pages",
                                   EBPF_CACHESTAT_DIMENSION_PAGE,
                                   NETDATA_CACHESTAT_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_cachestat_dirty",
+                                  "app.ebpf_cachestat_dirty_pages",
                                   20091,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_cachestat_access",
+                                  "_ebpf_cachestat_access",
                                   "Number of accessed files",
                                   EBPF_CACHESTAT_DIMENSION_HITS,
                                   NETDATA_CACHESTAT_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_cachestat_access",
+                                  "app.ebpf_cachestat_access",
                                   20092,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_cachestat_misses",
+                                  "_ebpf_cachestat_misses",
                                   "Files out of page cache",
                                   EBPF_CACHESTAT_DIMENSION_MISSES,
                                   NETDATA_CACHESTAT_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_cachestat_missees",
+                                  "app.ebpf_cachestat_misses",
                                   20093,
                                   update_every);
         w->charts_created &= ~(1<<EBPF_MODULE_CACHESTAT_IDX);
@@ -834,12 +834,12 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_hit_ratio",
+                             "_ebpf_cachestat_hit_ratio",
                              "Hit ratio",
                              EBPF_COMMON_DIMENSION_PERCENTAGE,
                              NETDATA_CACHESTAT_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_LINE,
-                             "ebpf.app_cachestat_ratio",
+                             "app.ebpf_cachestat_hit_ratio",
                              20090,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
@@ -850,27 +850,27 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_dirty_pages",
+                             "_ebpf_cachestat_dirty_pages",
                              "Number of dirty pages",
                              EBPF_CACHESTAT_DIMENSION_PAGE,
                              NETDATA_CACHESTAT_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_LINE,
-                             "ebpf.app_cachestat_dirty",
+                             "app.ebpf_cachestat_dirty_pages",
                              20091,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
         ebpf_create_chart_labels("app_group", w->name, 0);
         ebpf_commit_label();
-        fprintf(stdout, "DIMENSION dirties '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
+        fprintf(stdout, "DIMENSION pages '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_cachestat_access",
+                             "_ebpf_cachestat_access",
                              "Number of accessed files",
                              EBPF_CACHESTAT_DIMENSION_HITS,
                              NETDATA_CACHESTAT_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_cachestat_access",
+                             "app.ebpf_cachestat_access",
                              20092,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
@@ -880,12 +880,12 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_cachestat_misses",
+                             "_ebpf_cachestat_misses",
                              "Files out of page cache",
                              EBPF_CACHESTAT_DIMENSION_MISSES,
                              NETDATA_CACHESTAT_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_cachestat_missees",
+                             "app.ebpf_cachestat_misses",
                              20093,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
@@ -1012,24 +1012,25 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
         cachestat_update_publish(&w->cachestat, mpa, mbd, apcl, apd);
 
         value = (collected_number) w->cachestat.ratio;
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_hit_ratio");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_cachestat_hit_ratio");
         write_chart_dimension("ratio", value);
         write_end_chart();
 
         value = (collected_number) w->cachestat.dirty;
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_dirty_pages");
-        write_chart_dimension("dirties", value);
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_cachestat_dirty_pages");
+        write_chart_dimension("pages", value);
         write_end_chart();
 
         value = (collected_number) w->cachestat.hit;
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_cachestat_access");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_cachestat_access");
         write_chart_dimension("access", value);
         write_end_chart();
 
         value = (collected_number) w->cachestat.miss;
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_cachestat_misses");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_cachestat_misses");
         write_chart_dimension("misses", value);
         write_end_chart();
+        fflush(stdout);
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -828,7 +828,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = root; w; w = w->next) {
-        if (likely(w->exposed))
+        if (likely(w->exposed && w->processes))
             continue;
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -481,49 +481,56 @@ static void ebpf_obsolete_cachestat_global(ebpf_module_t *em)
  */
 void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
 {
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_CACHESTAT_HIT_RATIO_CHART,
-                              "",
-                              "Hit ratio",
-                              EBPF_COMMON_DIMENSION_PERCENTAGE,
-                              NETDATA_CACHESTAT_SUBMENU,
-                              NETDATA_EBPF_CHART_TYPE_LINE,
-                              NULL,
-                              20090,
-                              em->update_every);
+    struct ebpf_target *w;
+    int update_every = em->update_every;
+    for (w = apps_groups_root_target; w; w = w->next) {
+        if (likely(w->exposed || !w->processes))
+            continue;
 
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_CACHESTAT_DIRTY_CHART,
-                              "",
-                              "Number of dirty pages",
-                              EBPF_CACHESTAT_DIMENSION_PAGE,
-                              NETDATA_CACHESTAT_SUBMENU,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              20091,
-                              em->update_every);
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_hit_ratio",
+                                  "Hit ratio",
+                                  EBPF_COMMON_DIMENSION_PERCENTAGE,
+                                  NETDATA_CACHESTAT_SUBMENU,
+                                  NETDATA_EBPF_CHART_TYPE_LINE,
+                                  "apps_cachestat_ratio",
+                                  20090,
+                                  em->update_every);
 
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_CACHESTAT_HIT_CHART,
-                              "",
-                              "Number of accessed files",
-                              EBPF_CACHESTAT_DIMENSION_HITS,
-                              NETDATA_CACHESTAT_SUBMENU,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                               NULL,
-                              20092,
-                              em->update_every);
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_dirty_pages",
+                                  "Number of dirty pages",
+                                  EBPF_CACHESTAT_DIMENSION_PAGE,
+                                  NETDATA_CACHESTAT_SUBMENU,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  "apps_cachestat_dirty",
+                                  20091,
+                                  em->update_every);
 
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_CACHESTAT_MISSES_CHART,
-                              "",
-                              "Files out of page cache",
-                              EBPF_CACHESTAT_DIMENSION_MISSES,
-                              NETDATA_CACHESTAT_SUBMENU,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                               NULL,
-                              20093,
-                              em->update_every);
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_cachestat_access",
+                                  "Number of accessed files",
+                                  EBPF_CACHESTAT_DIMENSION_HITS,
+                                  NETDATA_CACHESTAT_SUBMENU,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  "apps_cachestat_access",
+                                  20092,
+                                  em->update_every);
+
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_cachestat_misses",
+                                  "Files out of page cache",
+                                  EBPF_CACHESTAT_DIMENSION_MISSES,
+                                  NETDATA_CACHESTAT_SUBMENU,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  "apps_cachestat_missees",
+                                  20093,
+                                  em->update_every);
+    }
 }
 
 /**

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -984,7 +984,7 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
     struct ebpf_target *w;
     collected_number value;
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_CACHESTAT_HIT_RATIO_CHART);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_CACHESTAT_HIT_RATIO_CHART, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             ebpf_cachestat_sum_pids(&w->cachestat, w->root_pid);
@@ -1005,7 +1005,7 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_CACHESTAT_DIRTY_CHART);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_CACHESTAT_DIRTY_CHART, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = (collected_number) w->cachestat.dirty;
@@ -1014,7 +1014,7 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_CACHESTAT_HIT_CHART);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_CACHESTAT_HIT_CHART, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = (collected_number) w->cachestat.hit;
@@ -1023,7 +1023,7 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_CACHESTAT_MISSES_CHART);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_CACHESTAT_MISSES_CHART, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = (collected_number) w->cachestat.miss;
@@ -1132,7 +1132,7 @@ static void ebpf_send_systemd_cachestat_charts()
 {
     ebpf_cgroup_target_t *ect;
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_HIT_RATIO_CHART);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_HIT_RATIO_CHART, "");
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_cachestat.ratio);
@@ -1140,7 +1140,7 @@ static void ebpf_send_systemd_cachestat_charts()
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_DIRTY_CHART);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_DIRTY_CHART, "");
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_cachestat.dirty);
@@ -1148,7 +1148,7 @@ static void ebpf_send_systemd_cachestat_charts()
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_HIT_CHART);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_HIT_CHART, "");
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_cachestat.hit);
@@ -1156,7 +1156,7 @@ static void ebpf_send_systemd_cachestat_charts()
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_MISSES_CHART);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_CACHESTAT_MISSES_CHART, "");
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_cachestat.miss);
@@ -1172,19 +1172,19 @@ static void ebpf_send_systemd_cachestat_charts()
  */
 static void ebpf_send_specific_cachestat_data(char *type, netdata_publish_cachestat_t *npc)
 {
-    write_begin_chart(type, NETDATA_CACHESTAT_HIT_RATIO_CHART);
+    write_begin_chart(type, NETDATA_CACHESTAT_HIT_RATIO_CHART, "");
     write_chart_dimension(cachestat_counter_publish_aggregated[NETDATA_CACHESTAT_IDX_RATIO].name, (long long)npc->ratio);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_CACHESTAT_DIRTY_CHART);
+    write_begin_chart(type, NETDATA_CACHESTAT_DIRTY_CHART, "");
     write_chart_dimension(cachestat_counter_publish_aggregated[NETDATA_CACHESTAT_IDX_DIRTY].name, (long long)npc->dirty);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_CACHESTAT_HIT_CHART);
+    write_begin_chart(type, NETDATA_CACHESTAT_HIT_CHART, "");
     write_chart_dimension(cachestat_counter_publish_aggregated[NETDATA_CACHESTAT_IDX_HIT].name, (long long)npc->hit);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_CACHESTAT_MISSES_CHART);
+    write_begin_chart(type, NETDATA_CACHESTAT_MISSES_CHART, "");
     write_chart_dimension(cachestat_counter_publish_aggregated[NETDATA_CACHESTAT_IDX_MISS].name, (long long)npc->miss);
     write_end_chart();
 }

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -824,7 +824,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
             continue;
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
-                             w->name,
+                             w->clean_name,
                              "_hit_ratio",
                              "Hit ratio",
                              EBPF_COMMON_DIMENSION_PERCENTAGE,
@@ -838,7 +838,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
 
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
-                             w->name,
+                             w->clean_name,
                              "_dirty_pages",
                              "Number of dirty pages",
                              EBPF_CACHESTAT_DIMENSION_PAGE,
@@ -851,7 +851,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
         fprintf(stdout, "DIMENSION dirties '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
-                             w->name,
+                             w->clean_name,
                              "_cachestat_access",
                              "Number of accessed files",
                              EBPF_CACHESTAT_DIMENSION_HITS,
@@ -864,7 +864,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
         fprintf(stdout, "DIMENSION access '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
-                             w->name,
+                             w->clean_name,
                              "_cachestat_misses",
                              "Files out of page cache",
                              EBPF_CACHESTAT_DIMENSION_MISSES,
@@ -992,7 +992,7 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
             cachestat_update_publish(&w->cachestat, mpa, mbd, apcl, apd);
             value = (collected_number) w->cachestat.ratio;
             // Here we are using different approach to have a chart more smooth
-            write_chart_dimension(w->name, value);
+            write_chart_dimension(w->clean_name, value);
         }
     }
     write_end_chart();
@@ -1001,7 +1001,7 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = (collected_number) w->cachestat.dirty;
-            write_chart_dimension(w->name, value);
+            write_chart_dimension(w->clean_name, value);
         }
     }
     write_end_chart();
@@ -1010,7 +1010,7 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = (collected_number) w->cachestat.hit;
-            write_chart_dimension(w->name, value);
+            write_chart_dimension(w->clean_name, value);
         }
     }
     write_end_chart();
@@ -1019,7 +1019,7 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = (collected_number) w->cachestat.miss;
-            write_chart_dimension(w->name, value);
+            write_chart_dimension(w->clean_name, value);
         }
     }
     write_end_chart();

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -804,41 +804,65 @@ static void ebpf_update_cachestat_cgroup(int maps_per_core)
 void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
 {
     struct ebpf_target *root = ptr;
-    ebpf_create_charts_on_apps(NETDATA_CACHESTAT_HIT_RATIO_CHART,
-                               "Hit ratio",
-                               EBPF_COMMON_DIMENSION_PERCENTAGE,
-                               NETDATA_CACHESTAT_SUBMENU,
-                               NETDATA_EBPF_CHART_TYPE_LINE,
-                               20090,
-                               ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX],
-                               root, em->update_every, NETDATA_EBPF_MODULE_NAME_CACHESTAT);
+    struct ebpf_target *w;
+    int update_every = em->update_every;
+    for (w = root; w; w = w->next) {
+        if (likely(w->exposed || !w->processes))
+            continue;
 
-    ebpf_create_charts_on_apps(NETDATA_CACHESTAT_DIRTY_CHART,
-                               "Number of dirty pages",
-                               EBPF_CACHESTAT_DIMENSION_PAGE,
-                               NETDATA_CACHESTAT_SUBMENU,
-                               NETDATA_EBPF_CHART_TYPE_STACKED,
-                               20091,
-                               ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                               root, em->update_every, NETDATA_EBPF_MODULE_NAME_CACHESTAT);
+        ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                             w->name,
+                             "_hit_ratio",
+                             "Hit ratio",
+                             EBPF_COMMON_DIMENSION_PERCENTAGE,
+                             NETDATA_CACHESTAT_SUBMENU,
+                             NETDATA_EBPF_CHART_TYPE_LINE,
+                             "apps_cachestat_ratio",
+                             20090,
+                             update_every,
+                             NETDATA_EBPF_MODULE_NAME_CACHESTAT);
+        fprintf(stdout, "DIMENSION ratio '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 
-    ebpf_create_charts_on_apps(NETDATA_CACHESTAT_HIT_CHART,
-                               "Number of accessed files",
-                               EBPF_CACHESTAT_DIMENSION_HITS,
-                               NETDATA_CACHESTAT_SUBMENU,
-                               NETDATA_EBPF_CHART_TYPE_STACKED,
-                               20092,
-                               ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX],
-                               root, em->update_every, NETDATA_EBPF_MODULE_NAME_CACHESTAT);
 
-    ebpf_create_charts_on_apps(NETDATA_CACHESTAT_MISSES_CHART,
-                               "Files out of page cache",
-                               EBPF_CACHESTAT_DIMENSION_MISSES,
-                               NETDATA_CACHESTAT_SUBMENU,
-                               NETDATA_EBPF_CHART_TYPE_STACKED,
-                               20093,
-                               ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX],
-                               root, em->update_every, NETDATA_EBPF_MODULE_NAME_CACHESTAT);
+        ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                             w->name,
+                             "_dirty_pages",
+                             "Number of dirty pages",
+                             EBPF_CACHESTAT_DIMENSION_PAGE,
+                             NETDATA_CACHESTAT_SUBMENU,
+                             NETDATA_EBPF_CHART_TYPE_LINE,
+                             "apps_cachestat_dirty",
+                             20091,
+                             update_every,
+                             NETDATA_EBPF_MODULE_NAME_CACHESTAT);
+        fprintf(stdout, "DIMENSION dirties '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
+
+        ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                             w->name,
+                             "_cachestat_access",
+                             "Number of accessed files",
+                             EBPF_CACHESTAT_DIMENSION_HITS,
+                             NETDATA_CACHESTAT_SUBMENU,
+                             NETDATA_EBPF_CHART_TYPE_STACKED,
+                             "apps_cachestat_access",
+                             20092,
+                             update_every,
+                             NETDATA_EBPF_MODULE_NAME_CACHESTAT);
+        fprintf(stdout, "DIMENSION access '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
+
+        ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                             w->name,
+                             "_cachestat_misses",
+                             "Files out of page cache",
+                             EBPF_CACHESTAT_DIMENSION_MISSES,
+                             NETDATA_CACHESTAT_SUBMENU,
+                             NETDATA_EBPF_CHART_TYPE_STACKED,
+                             "apps_cachestat_missees",
+                             20093,
+                             update_every,
+                             NETDATA_EBPF_MODULE_NAME_CACHESTAT);
+        fprintf(stdout, "DIMENSION misses '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
+    }
 
     em->apps_charts |= NETDATA_EBPF_APPS_FLAG_CHART_CREATED;
 }

--- a/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -484,7 +484,8 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = apps_groups_root_target; w; w = w->next) {
-        if (likely(w->exposed && w->processes))
+        uint32_t flag = w->charts_created & (1 << EBPF_MODULE_CACHESTAT_IDX);
+        if (likely(w->exposed && w->processes && !flag))
             continue;
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,

--- a/collectors/ebpf.plugin/ebpf_cgroup.c
+++ b/collectors/ebpf.plugin/ebpf_cgroup.c
@@ -331,7 +331,7 @@ void ebpf_create_charts_on_systemd(char *id, char *title, char *units, char *fam
                                    char *algorithm, char *context, char *module, int update_every)
 {
     ebpf_cgroup_target_t *w;
-    ebpf_write_chart_cmd(NETDATA_SERVICE_FAMILY, id, title, units, family, charttype, context,
+    ebpf_write_chart_cmd(NETDATA_SERVICE_FAMILY, id, "", title, units, family, charttype, context,
                          order, update_every, module);
 
     for (w = ebpf_cgroup_pids; w; w = w->next) {

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -766,7 +766,7 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
 
             dcstat_update_publish(&w->dcstat, cache, not_found);
             value = (collected_number) w->dcstat.ratio;
-            write_chart_dimension(w->name, value);
+            write_chart_dimension(w->clean_name, value);
         }
     }
     write_end_chart();
@@ -780,7 +780,7 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
 
             w->dcstat.cache_access = (long long)w->dcstat.curr.cache_access - (long long)w->dcstat.prev.cache_access;
             value = (collected_number) w->dcstat.cache_access;
-            write_chart_dimension(w->name, value);
+            write_chart_dimension(w->clean_name, value);
             w->dcstat.prev.cache_access = w->dcstat.curr.cache_access;
         }
     }
@@ -795,7 +795,7 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
 
             value = (collected_number) (!w->dcstat.cache_access) ? 0 :
                     (long long )w->dcstat.curr.file_system - (long long)w->dcstat.prev.file_system;
-            write_chart_dimension(w->name, value);
+            write_chart_dimension(w->clean_name, value);
             w->dcstat.prev.file_system = w->dcstat.curr.file_system;
         }
     }
@@ -809,7 +809,7 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
             }
             value = (collected_number) (!w->dcstat.cache_access) ? 0 :
                     (long long)w->dcstat.curr.not_found - (long long)w->dcstat.prev.not_found;
-            write_chart_dimension(w->name, value);
+            write_chart_dimension(w->clean_name, value);
             w->dcstat.prev.not_found = w->dcstat.curr.not_found;
         }
     }

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -385,45 +385,45 @@ void ebpf_obsolete_dc_apps_charts(struct ebpf_module *em)
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_dc_hit",
+                                  "_ebpf_dc_hit",
                                   "Percentage of files inside directory cache.",
                                   EBPF_COMMON_DIMENSION_PERCENTAGE,
                                   NETDATA_DIRECTORY_CACHE_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_LINE,
-                                  "ebpf.app_cachestat_ratio",
+                                  "app.ebpf_dc_hit",
                                   20100,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_dc_reference",
+                                  "_ebpf_dc_reference",
                                   "Count file access.",
                                   EBPF_COMMON_DIMENSION_FILES,
                                   NETDATA_DIRECTORY_CACHE_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_cachestat_ratio",
+                                  "app.ebpf_dc_reference",
                                   20101,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_not_cache",
+                                  "_ebpf_not_cache",
                                   "Files not present inside directory cache.",
                                   EBPF_COMMON_DIMENSION_FILES,
                                   NETDATA_DIRECTORY_CACHE_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_dc_not_cache",
+                                  "app.ebpf_dc_not_cache",
                                   20102,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_not_found",
+                                  "_ebpf_not_found",
                                   "Files not found.",
                                   EBPF_COMMON_DIMENSION_FILES,
                                   NETDATA_DIRECTORY_CACHE_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_dc_not_cache",
+                                  "app.ebpf_dc_not_found",
                                   20103,
                                   update_every);
 
@@ -541,12 +541,12 @@ void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_dc_hit",
+                             "_ebpf_dc_hit",
                              "Percentage of files inside directory cache.",
                              EBPF_COMMON_DIMENSION_PERCENTAGE,
                              NETDATA_DIRECTORY_CACHE_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_LINE,
-                             "ebpf.app_dc_hit",
+                             "app.ebpf_dc_hit",
                              20100,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_DCSTAT);
@@ -556,48 +556,48 @@ void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_dc_reference",
+                             "_ebpf_dc_reference",
                              "Count file access.",
                              EBPF_COMMON_DIMENSION_FILES,
                              NETDATA_DIRECTORY_CACHE_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_dc_hit",
+                             "app.ebpf_dc_reference",
                              20101,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_DCSTAT);
         ebpf_create_chart_labels("app_group", w->name, 0);
         ebpf_commit_label();
-        fprintf(stdout, "DIMENSION access '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
+        fprintf(stdout, "DIMENSION files '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_not_cache",
+                             "_ebpf_not_cache",
                              "Files not present inside directory cache.",
                              EBPF_COMMON_DIMENSION_FILES,
                              NETDATA_DIRECTORY_CACHE_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_dc_not_cache",
+                             "app.ebpf_dc_not_cache",
                              20102,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_DCSTAT);
         ebpf_create_chart_labels("app_group", w->name, 0);
         ebpf_commit_label();
-        fprintf(stdout, "DIMENSION access '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
+        fprintf(stdout, "DIMENSION files '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_not_found",
+                             "_ebpf_not_found",
                              "Files not found.",
                              EBPF_COMMON_DIMENSION_FILES,
                              NETDATA_DIRECTORY_CACHE_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_dc_not_cache",
+                             "app.ebpf_dc_not_found",
                              20103,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_DCSTAT);
         ebpf_create_chart_labels("app_group", w->name, 0);
         ebpf_commit_label();
-        fprintf(stdout, "DIMENSION access '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
+        fprintf(stdout, "DIMENSION files '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 
         w->charts_created |= 1<<EBPF_MODULE_DCSTAT_IDX;
     }
@@ -812,7 +812,7 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
         dcstat_update_publish(&w->dcstat, cache, not_found);
 
         value = (collected_number) w->dcstat.ratio;
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_dc_hit");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_dc_hit");
         write_chart_dimension("ratio", value);
         write_end_chart();
 
@@ -821,9 +821,9 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
         }
         w->dcstat.cache_access = (long long)w->dcstat.curr.cache_access - (long long)w->dcstat.prev.cache_access;
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_dc_reference");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_dc_reference");
         value = (collected_number) w->dcstat.cache_access;
-        write_chart_dimension("access", value);
+        write_chart_dimension("files", value);
         write_end_chart();
         w->dcstat.prev.cache_access = w->dcstat.curr.cache_access;
 
@@ -832,8 +832,8 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
         }
         value = (collected_number) (!w->dcstat.cache_access) ? 0 :
                 (long long )w->dcstat.curr.file_system - (long long)w->dcstat.prev.file_system;
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_not_cache");
-        write_chart_dimension("access", value);
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_not_cache");
+        write_chart_dimension("files", value);
         write_end_chart();
         w->dcstat.prev.file_system = w->dcstat.curr.file_system;
 
@@ -842,8 +842,8 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
         }
         value = (collected_number) (!w->dcstat.cache_access) ? 0 :
                 (long long)w->dcstat.curr.not_found - (long long)w->dcstat.prev.not_found;
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_not_found");
-        write_chart_dimension("access", value);
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_not_found");
+        write_chart_dimension("files", value);
         write_end_chart();
         w->dcstat.prev.not_found = w->dcstat.curr.not_found;
     }

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -390,7 +390,7 @@ void ebpf_obsolete_dc_apps_charts(struct ebpf_module *em)
                                   NETDATA_DIRECTORY_CACHE_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_LINE,
                                   "app.ebpf_dc_hit",
-                                  20100,
+                                  20265,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -401,7 +401,7 @@ void ebpf_obsolete_dc_apps_charts(struct ebpf_module *em)
                                   NETDATA_DIRECTORY_CACHE_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
                                   "app.ebpf_dc_reference",
-                                  20101,
+                                  20266,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -412,7 +412,7 @@ void ebpf_obsolete_dc_apps_charts(struct ebpf_module *em)
                                   NETDATA_DIRECTORY_CACHE_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
                                   "app.ebpf_dc_not_cache",
-                                  20102,
+                                  20267,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -423,7 +423,7 @@ void ebpf_obsolete_dc_apps_charts(struct ebpf_module *em)
                                   NETDATA_DIRECTORY_CACHE_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
                                   "app.ebpf_dc_not_found",
-                                  20103,
+                                  20268,
                                   update_every);
 
         w->charts_created &= ~(1<<EBPF_MODULE_DCSTAT_IDX);
@@ -546,7 +546,7 @@ void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_DIRECTORY_CACHE_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_LINE,
                              "app.ebpf_dc_hit",
-                             20100,
+                             20265,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_DCSTAT);
         ebpf_create_chart_labels("app_group", w->name, 0);
@@ -561,7 +561,7 @@ void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_DIRECTORY_CACHE_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
                              "app.ebpf_dc_reference",
-                             20101,
+                             20266,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_DCSTAT);
         ebpf_create_chart_labels("app_group", w->name, 0);
@@ -576,7 +576,7 @@ void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_DIRECTORY_CACHE_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
                              "app.ebpf_dc_not_cache",
-                             20102,
+                             20267,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_DCSTAT);
         ebpf_create_chart_labels("app_group", w->name, 0);
@@ -591,7 +591,7 @@ void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_DIRECTORY_CACHE_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
                              "app.ebpf_dc_not_found",
-                             20103,
+                             20268,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_DCSTAT);
         ebpf_create_chart_labels("app_group", w->name, 0);

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -810,19 +810,19 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
         dcstat_update_publish(&w->dcstat, cache, not_found);
 
         value = (collected_number) w->dcstat.ratio;
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_dc_hit");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_dc_hit");
         write_chart_dimension("ratio", value);
-        write_end_chart();
+        ebpf_write_end_chart();
 
         if (w->dcstat.curr.cache_access < w->dcstat.prev.cache_access) {
             w->dcstat.prev.cache_access = 0;
         }
         w->dcstat.cache_access = (long long)w->dcstat.curr.cache_access - (long long)w->dcstat.prev.cache_access;
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_dc_reference");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_dc_reference");
         value = (collected_number) w->dcstat.cache_access;
         write_chart_dimension("files", value);
-        write_end_chart();
+        ebpf_write_end_chart();
         w->dcstat.prev.cache_access = w->dcstat.curr.cache_access;
 
         if (w->dcstat.curr.file_system < w->dcstat.prev.file_system) {
@@ -830,9 +830,9 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
         }
         value = (collected_number) (!w->dcstat.cache_access) ? 0 :
                 (long long )w->dcstat.curr.file_system - (long long)w->dcstat.prev.file_system;
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_not_cache");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_not_cache");
         write_chart_dimension("files", value);
-        write_end_chart();
+        ebpf_write_end_chart();
         w->dcstat.prev.file_system = w->dcstat.curr.file_system;
 
         if (w->dcstat.curr.not_found < w->dcstat.prev.not_found) {
@@ -840,9 +840,9 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
         }
         value = (collected_number) (!w->dcstat.cache_access) ? 0 :
                 (long long)w->dcstat.curr.not_found - (long long)w->dcstat.prev.not_found;
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_not_found");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_not_found");
         write_chart_dimension("files", value);
-        write_end_chart();
+        ebpf_write_end_chart();
         w->dcstat.prev.not_found = w->dcstat.curr.not_found;
     }
 }
@@ -1074,23 +1074,23 @@ static void ebpf_send_systemd_dc_charts()
 {
     collected_number value;
     ebpf_cgroup_target_t *ect;
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_HIT_CHART, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_HIT_CHART, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long) ect->publish_dc.ratio);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_REFERENCE_CHART, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_REFERENCE_CHART, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long) ect->publish_dc.cache_access);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_REQUEST_NOT_CACHE_CHART, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_REQUEST_NOT_CACHE_CHART, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             value = (collected_number) (!ect->publish_dc.cache_access) ? 0 :
@@ -1100,9 +1100,9 @@ static void ebpf_send_systemd_dc_charts()
             write_chart_dimension(ect->name, (long long) value);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_REQUEST_NOT_FOUND_CHART, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_REQUEST_NOT_FOUND_CHART, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             value = (collected_number) (!ect->publish_dc.cache_access) ? 0 :
@@ -1113,7 +1113,7 @@ static void ebpf_send_systemd_dc_charts()
             write_chart_dimension(ect->name, (long long) value);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**
@@ -1125,31 +1125,31 @@ static void ebpf_send_systemd_dc_charts()
 static void ebpf_send_specific_dc_data(char *type, netdata_publish_dcstat_t *pdc)
 {
     collected_number value;
-    write_begin_chart(type, NETDATA_DC_HIT_CHART, "");
+    ebpf_write_begin_chart(type, NETDATA_DC_HIT_CHART, "");
     write_chart_dimension(dcstat_counter_publish_aggregated[NETDATA_DCSTAT_IDX_RATIO].name,
                           (long long) pdc->ratio);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_DC_REFERENCE_CHART, "");
+    ebpf_write_begin_chart(type, NETDATA_DC_REFERENCE_CHART, "");
     write_chart_dimension(dcstat_counter_publish_aggregated[NETDATA_DCSTAT_IDX_REFERENCE].name,
                           (long long) pdc->cache_access);
-    write_end_chart();
+    ebpf_write_end_chart();
 
     value = (collected_number) (!pdc->cache_access) ? 0 :
         (long long )pdc->curr.file_system - (long long)pdc->prev.file_system;
     pdc->prev.file_system = pdc->curr.file_system;
 
-    write_begin_chart(type, NETDATA_DC_REQUEST_NOT_CACHE_CHART, "");
+    ebpf_write_begin_chart(type, NETDATA_DC_REQUEST_NOT_CACHE_CHART, "");
     write_chart_dimension(dcstat_counter_publish_aggregated[NETDATA_DCSTAT_IDX_SLOW].name, (long long) value);
-    write_end_chart();
+    ebpf_write_end_chart();
 
     value = (collected_number) (!pdc->cache_access) ? 0 :
         (long long)pdc->curr.not_found - (long long)pdc->prev.not_found;
     pdc->prev.not_found = pdc->curr.not_found;
 
-    write_begin_chart(type, NETDATA_DC_REQUEST_NOT_FOUND_CHART, "");
+    ebpf_write_begin_chart(type, NETDATA_DC_REQUEST_NOT_FOUND_CHART, "");
     write_chart_dimension(dcstat_counter_publish_aggregated[NETDATA_DCSTAT_IDX_MISS].name, (long long) value);
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -756,7 +756,7 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
     struct ebpf_target *w;
     collected_number value;
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_DC_HIT_CHART);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_DC_HIT_CHART, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             ebpf_dcstat_sum_pids(&w->dcstat, w->root_pid);
@@ -771,7 +771,7 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_DC_REFERENCE_CHART);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_DC_REFERENCE_CHART, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             if (w->dcstat.curr.cache_access < w->dcstat.prev.cache_access) {
@@ -786,7 +786,7 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_DC_REQUEST_NOT_CACHE_CHART);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_DC_REQUEST_NOT_CACHE_CHART, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             if (w->dcstat.curr.file_system < w->dcstat.prev.file_system) {
@@ -801,7 +801,7 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_DC_REQUEST_NOT_FOUND_CHART);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_DC_REQUEST_NOT_FOUND_CHART, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             if (w->dcstat.curr.not_found < w->dcstat.prev.not_found) {
@@ -1043,7 +1043,7 @@ static void ebpf_send_systemd_dc_charts()
 {
     collected_number value;
     ebpf_cgroup_target_t *ect;
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_HIT_CHART);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_HIT_CHART, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long) ect->publish_dc.ratio);
@@ -1051,7 +1051,7 @@ static void ebpf_send_systemd_dc_charts()
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_REFERENCE_CHART);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_REFERENCE_CHART, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long) ect->publish_dc.cache_access);
@@ -1059,7 +1059,7 @@ static void ebpf_send_systemd_dc_charts()
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_REQUEST_NOT_CACHE_CHART);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_REQUEST_NOT_CACHE_CHART, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             value = (collected_number) (!ect->publish_dc.cache_access) ? 0 :
@@ -1071,7 +1071,7 @@ static void ebpf_send_systemd_dc_charts()
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_REQUEST_NOT_FOUND_CHART);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_DC_REQUEST_NOT_FOUND_CHART, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             value = (collected_number) (!ect->publish_dc.cache_access) ? 0 :
@@ -1094,12 +1094,12 @@ static void ebpf_send_systemd_dc_charts()
 static void ebpf_send_specific_dc_data(char *type, netdata_publish_dcstat_t *pdc)
 {
     collected_number value;
-    write_begin_chart(type, NETDATA_DC_HIT_CHART);
+    write_begin_chart(type, NETDATA_DC_HIT_CHART, "");
     write_chart_dimension(dcstat_counter_publish_aggregated[NETDATA_DCSTAT_IDX_RATIO].name,
                           (long long) pdc->ratio);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_DC_REFERENCE_CHART);
+    write_begin_chart(type, NETDATA_DC_REFERENCE_CHART, "");
     write_chart_dimension(dcstat_counter_publish_aggregated[NETDATA_DCSTAT_IDX_REFERENCE].name,
                           (long long) pdc->cache_access);
     write_end_chart();
@@ -1108,7 +1108,7 @@ static void ebpf_send_specific_dc_data(char *type, netdata_publish_dcstat_t *pdc
         (long long )pdc->curr.file_system - (long long)pdc->prev.file_system;
     pdc->prev.file_system = pdc->curr.file_system;
 
-    write_begin_chart(type, NETDATA_DC_REQUEST_NOT_CACHE_CHART);
+    write_begin_chart(type, NETDATA_DC_REQUEST_NOT_CACHE_CHART, "");
     write_chart_dimension(dcstat_counter_publish_aggregated[NETDATA_DCSTAT_IDX_SLOW].name, (long long) value);
     write_end_chart();
 
@@ -1116,7 +1116,7 @@ static void ebpf_send_specific_dc_data(char *type, netdata_publish_dcstat_t *pdc
         (long long)pdc->curr.not_found - (long long)pdc->prev.not_found;
     pdc->prev.not_found = pdc->curr.not_found;
 
-    write_begin_chart(type, NETDATA_DC_REQUEST_NOT_FOUND_CHART);
+    write_begin_chart(type, NETDATA_DC_REQUEST_NOT_FOUND_CHART, "");
     write_chart_dimension(dcstat_counter_publish_aggregated[NETDATA_DCSTAT_IDX_MISS].name, (long long) value);
     write_end_chart();
 }

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -379,8 +379,7 @@ void ebpf_obsolete_dc_apps_charts(struct ebpf_module *em)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = apps_groups_root_target; w; w = w->next) {
-        uint32_t flag = w->charts_created & 1<<EBPF_MODULE_DCSTAT_IDX;
-        if (likely(w->exposed && w->processes && !flag))
+        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_DCSTAT_IDX))))
             continue;
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -536,7 +535,7 @@ void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = root; w; w = w->next) {
-        if (likely(w->exposed && w->processes))
+        if (unlikely(!w->exposed))
             continue;
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
@@ -800,8 +799,7 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
     collected_number value;
 
     for (w = root; w; w = w->next) {
-        uint32_t flag = w->charts_created & 1<<EBPF_MODULE_DCSTAT_IDX;
-        if (unlikely(w->exposed && w->processes && !flag))
+        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_DCSTAT_IDX))))
             continue;
 
         ebpf_dcstat_sum_pids(&w->dcstat, w->root_pid);

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -379,8 +379,8 @@ void ebpf_obsolete_dc_apps_charts(struct ebpf_module *em)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = apps_groups_root_target; w; w = w->next) {
-        uint32_t cache_flag = w->charts_created & 1<<EBPF_MODULE_DCSTAT_IDX;
-        if (likely(w->exposed && w->processes && !cache_flag))
+        uint32_t flag = w->charts_created & 1<<EBPF_MODULE_DCSTAT_IDX;
+        if (likely(w->exposed && w->processes && !flag))
             continue;
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -390,7 +390,7 @@ void ebpf_obsolete_dc_apps_charts(struct ebpf_module *em)
                                   EBPF_COMMON_DIMENSION_PERCENTAGE,
                                   NETDATA_DIRECTORY_CACHE_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_LINE,
-                                  "app_cachestat_ratio",
+                                  "ebpf.app_cachestat_ratio",
                                   20100,
                                   update_every);
 
@@ -401,7 +401,7 @@ void ebpf_obsolete_dc_apps_charts(struct ebpf_module *em)
                                   EBPF_COMMON_DIMENSION_FILES,
                                   NETDATA_DIRECTORY_CACHE_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "app_cachestat_ratio",
+                                  "ebpf.app_cachestat_ratio",
                                   20101,
                                   update_every);
 
@@ -412,7 +412,7 @@ void ebpf_obsolete_dc_apps_charts(struct ebpf_module *em)
                                   EBPF_COMMON_DIMENSION_FILES,
                                   NETDATA_DIRECTORY_CACHE_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "app_dc_not_cache",
+                                  "ebpf.app_dc_not_cache",
                                   20102,
                                   update_every);
 
@@ -423,7 +423,7 @@ void ebpf_obsolete_dc_apps_charts(struct ebpf_module *em)
                                   EBPF_COMMON_DIMENSION_FILES,
                                   NETDATA_DIRECTORY_CACHE_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "app_dc_not_cache",
+                                  "ebpf.app_dc_not_cache",
                                   20103,
                                   update_every);
 
@@ -546,7 +546,7 @@ void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              EBPF_COMMON_DIMENSION_PERCENTAGE,
                              NETDATA_DIRECTORY_CACHE_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_LINE,
-                             "app_dc_hit",
+                             "ebpf.app_dc_hit",
                              20100,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_DCSTAT);
@@ -561,7 +561,7 @@ void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              EBPF_COMMON_DIMENSION_FILES,
                              NETDATA_DIRECTORY_CACHE_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "app_dc_hit",
+                             "ebpf.app_dc_hit",
                              20101,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_DCSTAT);
@@ -576,7 +576,7 @@ void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              EBPF_COMMON_DIMENSION_FILES,
                              NETDATA_DIRECTORY_CACHE_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "app_dc_not_cache",
+                             "ebpf.app_dc_not_cache",
                              20102,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_DCSTAT);
@@ -591,7 +591,7 @@ void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              EBPF_COMMON_DIMENSION_FILES,
                              NETDATA_DIRECTORY_CACHE_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "app_dc_not_cache",
+                             "ebpf.app_dc_not_cache",
                              20103,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_DCSTAT);
@@ -800,8 +800,8 @@ void ebpf_dcache_send_apps_data(struct ebpf_target *root)
     collected_number value;
 
     for (w = root; w; w = w->next) {
-        uint32_t cache_flag = w->charts_created & 1<<EBPF_MODULE_DCSTAT_IDX;
-        if (unlikely(w->exposed && w->processes && !cache_flag))
+        uint32_t flag = w->charts_created & 1<<EBPF_MODULE_DCSTAT_IDX;
+        if (unlikely(w->exposed && w->processes && !flag))
             continue;
 
         ebpf_dcstat_sum_pids(&w->dcstat, w->root_pid);

--- a/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -302,6 +302,7 @@ static void ebpf_obsolete_dc_services(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_DC_HIT_CHART,
+                              "",
                               "Percentage of files inside directory cache",
                               EBPF_COMMON_DIMENSION_PERCENTAGE,
                               NETDATA_DIRECTORY_CACHE_SUBMENU,
@@ -312,6 +313,7 @@ static void ebpf_obsolete_dc_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_DC_REFERENCE_CHART,
+                              "",
                               "Count file access",
                               EBPF_COMMON_DIMENSION_FILES,
                               NETDATA_DIRECTORY_CACHE_SUBMENU,
@@ -322,6 +324,7 @@ static void ebpf_obsolete_dc_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_DC_REQUEST_NOT_CACHE_CHART,
+                              "",
                               "Files not present inside directory cache",
                               EBPF_COMMON_DIMENSION_FILES,
                               NETDATA_DIRECTORY_CACHE_SUBMENU,
@@ -332,6 +335,7 @@ static void ebpf_obsolete_dc_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_DC_REQUEST_NOT_FOUND_CHART,
+                              "",
                               "Files not found",
                               EBPF_COMMON_DIMENSION_FILES,
                               NETDATA_DIRECTORY_CACHE_SUBMENU,
@@ -374,6 +378,7 @@ void ebpf_obsolete_dc_apps_charts(struct ebpf_module *em)
 {
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_DC_HIT_CHART,
+                              "",
                               "Percentage of files inside directory cache",
                               EBPF_COMMON_DIMENSION_PERCENTAGE,
                               NETDATA_DIRECTORY_CACHE_SUBMENU,
@@ -384,6 +389,7 @@ void ebpf_obsolete_dc_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_DC_REFERENCE_CHART,
+                              "",
                               "Count file access",
                               EBPF_COMMON_DIMENSION_FILES,
                               NETDATA_DIRECTORY_CACHE_SUBMENU,
@@ -394,6 +400,7 @@ void ebpf_obsolete_dc_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_DC_REQUEST_NOT_CACHE_CHART,
+                              "",
                               "Files not present inside directory cache",
                               EBPF_COMMON_DIMENSION_FILES,
                               NETDATA_DIRECTORY_CACHE_SUBMENU,
@@ -404,6 +411,7 @@ void ebpf_obsolete_dc_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_DC_REQUEST_NOT_FOUND_CHART,
+                              "",
                               "Files not found",
                               EBPF_COMMON_DIMENSION_FILES,
                               NETDATA_DIRECTORY_CACHE_SUBMENU,
@@ -424,6 +432,7 @@ static void ebpf_obsolete_dc_global(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                               NETDATA_DC_HIT_CHART,
+                              "",
                               "Percentage of files inside directory cache",
                               EBPF_COMMON_DIMENSION_PERCENTAGE,
                               NETDATA_DIRECTORY_CACHE_SUBMENU,
@@ -434,6 +443,7 @@ static void ebpf_obsolete_dc_global(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                               NETDATA_DC_REFERENCE_CHART,
+                              "",
                               "Variables used to calculate hit ratio.",
                               EBPF_COMMON_DIMENSION_FILES,
                               NETDATA_DIRECTORY_CACHE_SUBMENU,
@@ -898,24 +908,28 @@ static void ebpf_create_specific_dc_charts(char *type, int update_every)
 static void ebpf_obsolete_specific_dc_charts(char *type, int update_every)
 {
     ebpf_write_chart_obsolete(type, NETDATA_DC_HIT_CHART,
+                              "",
                               "Percentage of files inside directory cache",
                               EBPF_COMMON_DIMENSION_PERCENTAGE, NETDATA_DIRECTORY_CACHE_SUBMENU,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_DC_HIT_RATIO_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5700, update_every);
 
     ebpf_write_chart_obsolete(type, NETDATA_DC_REFERENCE_CHART,
+                              "",
                               "Count file access",
                               EBPF_COMMON_DIMENSION_FILES, NETDATA_DIRECTORY_CACHE_SUBMENU,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_DC_REFERENCE_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5701, update_every);
 
     ebpf_write_chart_obsolete(type, NETDATA_DC_REQUEST_NOT_CACHE_CHART,
+                              "",
                               "Files not present inside directory cache",
                               EBPF_COMMON_DIMENSION_FILES, NETDATA_DIRECTORY_CACHE_SUBMENU,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_DC_NOT_CACHE_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5702, update_every);
 
     ebpf_write_chart_obsolete(type, NETDATA_DC_REQUEST_NOT_FOUND_CHART,
+                              "",
                               "Files not found",
                               EBPF_COMMON_DIMENSION_FILES, NETDATA_DIRECTORY_CACHE_SUBMENU,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_DC_NOT_FOUND_CONTEXT,

--- a/collectors/ebpf.plugin/ebpf_dcstat.h
+++ b/collectors/ebpf.plugin/ebpf_dcstat.h
@@ -13,7 +13,7 @@
 #define NETDATA_DC_REQUEST_NOT_CACHE_CHART "dc_not_cache"
 #define NETDATA_DC_REQUEST_NOT_FOUND_CHART "dc_not_found"
 
-#define NETDATA_DIRECTORY_CACHE_SUBMENU "directory cache (eBPF)"
+#define NETDATA_DIRECTORY_CACHE_SUBMENU "directory cache"
 
 // configuration file
 #define NETDATA_DIRECTORY_DCSTAT_CONFIG_FILE "dcstat.conf"

--- a/collectors/ebpf.plugin/ebpf_disk.c
+++ b/collectors/ebpf.plugin/ebpf_disk.c
@@ -485,6 +485,7 @@ static void ebpf_obsolete_disk_global(ebpf_module_t *em)
         if (flags & NETDATA_DISK_CHART_CREATED) {
             ebpf_write_chart_obsolete(ned->histogram.name,
                                       ned->family,
+                                      "",
                                       "Disk latency",
                                       EBPF_COMMON_DIMENSION_CALL,
                                       ned->family,
@@ -655,7 +656,7 @@ static void read_hard_disk_tables(int table, int maps_per_core)
  */
 static void ebpf_obsolete_hd_charts(netdata_ebpf_disks_t *w, int update_every)
 {
-    ebpf_write_chart_obsolete(w->histogram.name, w->family, w->histogram.title, EBPF_COMMON_DIMENSION_CALL,
+    ebpf_write_chart_obsolete(w->histogram.name, w->family, "", w->histogram.title, EBPF_COMMON_DIMENSION_CALL,
                               w->family, NETDATA_EBPF_CHART_TYPE_STACKED, "disk.latency_io",
                               w->histogram.order, update_every);
 

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -473,48 +473,48 @@ void ebpf_obsolete_fd_apps_charts(struct ebpf_module *em)
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_fd_open",
+                                  "_ebpf_file_open",
                                   "Number of open files",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_FILE_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_fd_open",
+                                  "app.ebpf_file_open",
                                   20061,
                                   update_every);
 
         if (em->mode < MODE_ENTRY) {
             ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                       w->clean_name,
-                                      "_fd_open_error",
+                                      "_ebpf_file_open_error",
                                       "Fails to open files.",
                                       EBPF_COMMON_DIMENSION_CALL,
                                       NETDATA_APPS_FILE_GROUP,
                                       NETDATA_EBPF_CHART_TYPE_STACKED,
-                                      "ebpf.app_fd_open_error",
+                                      "app.ebpf_file_open_error",
                                       20062,
                                       update_every);
         }
 
         ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                                   w->clean_name,
-                                  "_fd_close",
+                                  "_ebpf_file_closed",
                                   "Files closed.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_FILE_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  NULL,
+                                  "app.ebpf_file_closed",
                                   20063,
                                   update_every);
 
         if (em->mode < MODE_ENTRY) {
             ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                                       w->clean_name,
-                                      "_fd_close_error",
+                                      "_ebpf_file_close_error",
                                       "Fails to close files.",
                                       EBPF_COMMON_DIMENSION_CALL,
                                       NETDATA_APPS_FILE_GROUP,
                                       NETDATA_EBPF_CHART_TYPE_STACKED,
-                                      "ebpf.app_fd_close_error",
+                                      "app.ebpf_fd_close_error",
                                       20064,
                                       update_every);
         }
@@ -827,23 +827,23 @@ void ebpf_fd_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
         ebpf_fd_sum_pids(&w->fd, w->root_pid);
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_fd_open");
-        write_chart_dimension("files", w->fd.open_call);
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_file_open");
+        write_chart_dimension("calls", w->fd.open_call);
         write_end_chart();
 
         if (em->mode < MODE_ENTRY) {
-            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_fd_open_error");
-            write_chart_dimension("files", w->fd.open_err);
+            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_file_open_error");
+            write_chart_dimension("calls", w->fd.open_err);
             write_end_chart();
         }
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_fd_close");
-        write_chart_dimension("files", w->fd.close_call);
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_file_closed");
+        write_chart_dimension("calls", w->fd.close_call);
         write_end_chart();
 
         if (em->mode < MODE_ENTRY) {
-            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_fd_close_error");
-            write_chart_dimension("files", w->fd.close_err);
+            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_file_close_error");
+            write_chart_dimension("calls", w->fd.close_err);
             write_end_chart();
         }
     }
@@ -1210,66 +1210,66 @@ void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_fd_open",
+                             "_ebpf_file_open",
                              "Number of open files",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_APPS_FILE_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_fd_open",
+                             "app.ebpf_file_open",
                              20061,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_FD);
         ebpf_create_chart_labels("app_group", w->name, 0);
         ebpf_commit_label();
-        fprintf(stdout, "DIMENSION files '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
         if (em->mode < MODE_ENTRY) {
             ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                                  w->clean_name,
-                                 "_fd_open_error",
+                                 "_ebpf_file_open_error",
                                  "Fails to open files.",
                                  EBPF_COMMON_DIMENSION_CALL,
                                  NETDATA_APPS_FILE_GROUP,
                                  NETDATA_EBPF_CHART_TYPE_STACKED,
-                                 "ebpf.app_fd_open_error",
+                                 "app.ebpf_file_open_error",
                                  20062,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_FD);
             ebpf_create_chart_labels("app_group", w->name, 0);
             ebpf_commit_label();
-            fprintf(stdout, "DIMENSION files '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
+            fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
         }
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_fd_close",
+                             "_ebpf_file_closed",
                              "Files closed.",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_APPS_FILE_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_fd_close",
+                             "app.ebpf_file_closed",
                              20063,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_FD);
         ebpf_create_chart_labels("app_group", w->name, 0);
         ebpf_commit_label();
-        fprintf(stdout, "DIMENSION files '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
         if (em->mode < MODE_ENTRY) {
             ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                                  w->clean_name,
-                                 "_fd_close_error",
+                                 "_ebpf_file_close_error",
                                  "Fails to close files.",
                                  EBPF_COMMON_DIMENSION_CALL,
                                  NETDATA_APPS_FILE_GROUP,
                                  NETDATA_EBPF_CHART_TYPE_STACKED,
-                                 "ebpf.app_fd_close_error",
+                                 "app.ebpf_file_close_error",
                                  20064,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_FD);
             ebpf_create_chart_labels("app_group", w->name, 0);
             ebpf_commit_label();
-            fprintf(stdout, "DIMENSION files '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
+            fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
         }
 
         w->charts_created |= 1<<EBPF_MODULE_FD_IDX;

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -817,7 +817,7 @@ void ebpf_fd_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         }
     }
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_OPEN);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_OPEN, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             write_chart_dimension(w->clean_name, w->fd.open_call);
@@ -826,7 +826,7 @@ void ebpf_fd_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_OPEN_ERROR);
+        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_OPEN_ERROR, "");
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed && w->processes)) {
                 write_chart_dimension(w->clean_name, w->fd.open_err);
@@ -835,7 +835,7 @@ void ebpf_fd_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         write_end_chart();
     }
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_CLOSED);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_CLOSED, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             write_chart_dimension(w->clean_name, w->fd.close_call);
@@ -844,7 +844,7 @@ void ebpf_fd_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_CLOSE_ERROR);
+        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_CLOSE_ERROR, "");
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed && w->processes)) {
                 write_chart_dimension(w->clean_name, w->fd.close_err);
@@ -978,22 +978,22 @@ static void ebpf_obsolete_specific_fd_charts(char *type, ebpf_module_t *em)
  */
 static void ebpf_send_specific_fd_data(char *type, netdata_fd_stat_t *values, ebpf_module_t *em)
 {
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_OPEN);
+    write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_OPEN, "");
     write_chart_dimension(fd_publish_aggregated[NETDATA_FD_SYSCALL_OPEN].name, (long long)values->open_call);
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_OPEN_ERROR);
+        write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_OPEN_ERROR, "");
         write_chart_dimension(fd_publish_aggregated[NETDATA_FD_SYSCALL_OPEN].name, (long long)values->open_err);
         write_end_chart();
     }
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_CLOSED);
+    write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_CLOSED, "");
     write_chart_dimension(fd_publish_aggregated[NETDATA_FD_SYSCALL_CLOSE].name, (long long)values->close_call);
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_CLOSE_ERROR);
+        write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_CLOSE_ERROR, "");
         write_chart_dimension(fd_publish_aggregated[NETDATA_FD_SYSCALL_CLOSE].name, (long long)values->close_err);
         write_end_chart();
     }
@@ -1047,7 +1047,7 @@ static void ebpf_create_systemd_fd_charts(ebpf_module_t *em)
 static void ebpf_send_systemd_fd_charts(ebpf_module_t *em)
 {
     ebpf_cgroup_target_t *ect;
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_OPEN);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_OPEN, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_fd.open_call);
@@ -1056,7 +1056,7 @@ static void ebpf_send_systemd_fd_charts(ebpf_module_t *em)
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_OPEN_ERROR);
+        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_OPEN_ERROR, "");
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {
                 write_chart_dimension(ect->name, ect->publish_systemd_fd.open_err);
@@ -1065,7 +1065,7 @@ static void ebpf_send_systemd_fd_charts(ebpf_module_t *em)
         write_end_chart();
     }
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_CLOSED);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_CLOSED, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_fd.close_call);
@@ -1074,7 +1074,7 @@ static void ebpf_send_systemd_fd_charts(ebpf_module_t *em)
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_CLOSE_ERROR);
+        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_CLOSE_ERROR, "");
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {
                 write_chart_dimension(ect->name, ect->publish_systemd_fd.close_err);

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -386,6 +386,7 @@ static void ebpf_obsolete_fd_services(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SYSCALL_APPS_FILE_OPEN,
+                              "",
                               "Number of open files",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_FILE_CGROUP_GROUP,
@@ -397,6 +398,7 @@ static void ebpf_obsolete_fd_services(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                                   NETDATA_SYSCALL_APPS_FILE_OPEN_ERROR,
+                                  "",
                                   "Fails to open files",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_FILE_CGROUP_GROUP,
@@ -408,6 +410,7 @@ static void ebpf_obsolete_fd_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SYSCALL_APPS_FILE_CLOSED,
+                              "",
                               "Files closed",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_FILE_CGROUP_GROUP,
@@ -419,6 +422,7 @@ static void ebpf_obsolete_fd_services(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                                   NETDATA_SYSCALL_APPS_FILE_CLOSE_ERROR,
+                                  "",
                                   "Fails to close files",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_FILE_CGROUP_GROUP,
@@ -462,6 +466,7 @@ void ebpf_obsolete_fd_apps_charts(struct ebpf_module *em)
 {
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_SYSCALL_APPS_FILE_OPEN,
+                              "",
                               "Number of open files",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_FILE_GROUP,
@@ -473,6 +478,7 @@ void ebpf_obsolete_fd_apps_charts(struct ebpf_module *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                                   NETDATA_SYSCALL_APPS_FILE_OPEN_ERROR,
+                                  "",
                                   "Fails to open files",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_FILE_GROUP,
@@ -484,6 +490,7 @@ void ebpf_obsolete_fd_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_SYSCALL_APPS_FILE_CLOSED,
+                              "",
                               "Files closed",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_FILE_GROUP,
@@ -495,6 +502,7 @@ void ebpf_obsolete_fd_apps_charts(struct ebpf_module *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                                   NETDATA_SYSCALL_APPS_FILE_CLOSE_ERROR,
+                                  "",
                                   "Fails to close files",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_FILE_GROUP,
@@ -516,6 +524,7 @@ static void ebpf_obsolete_fd_global(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                               NETDATA_FILE_OPEN_CLOSE_COUNT,
+                              "",
                               "Open and close calls",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_FILE_GROUP,
@@ -527,6 +536,7 @@ static void ebpf_obsolete_fd_global(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                                   NETDATA_FILE_OPEN_ERR_COUNT,
+                                  "",
                                   "Open fails",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_FILE_GROUP,
@@ -933,25 +943,25 @@ static void ebpf_create_specific_fd_charts(char *type, ebpf_module_t *em)
  */
 static void ebpf_obsolete_specific_fd_charts(char *type, ebpf_module_t *em)
 {
-    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_FILE_OPEN, "Number of open files",
+    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_FILE_OPEN, "", "Number of open files",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_APPS_FILE_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_FD_OPEN_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5400, em->update_every);
 
     if (em->mode < MODE_ENTRY) {
-        ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_FILE_OPEN_ERROR, "Fails to open files",
+        ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_FILE_OPEN_ERROR, "", "Fails to open files",
                                   EBPF_COMMON_DIMENSION_CALL, NETDATA_APPS_FILE_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_FD_OPEN_ERR_CONTEXT,
                                   NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5401, em->update_every);
     }
 
-    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_FILE_CLOSED, "Files closed",
+    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_FILE_CLOSED, "", "Files closed",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_APPS_FILE_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_FD_CLOSE_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5402, em->update_every);
 
     if (em->mode < MODE_ENTRY) {
-        ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_FILE_CLOSE_ERROR, "Fails to close files",
+        ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_FILE_CLOSE_ERROR, "", "Fails to close files",
                                   EBPF_COMMON_DIMENSION_CALL, NETDATA_APPS_FILE_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_FD_CLOSE_ERR_CONTEXT,
                                   NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5403, em->update_every);

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -820,7 +820,7 @@ void ebpf_fd_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_OPEN);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->name, w->fd.open_call);
+            write_chart_dimension(w->clean_name, w->fd.open_call);
         }
     }
     write_end_chart();
@@ -829,7 +829,7 @@ void ebpf_fd_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_OPEN_ERROR);
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed && w->processes)) {
-                write_chart_dimension(w->name, w->fd.open_err);
+                write_chart_dimension(w->clean_name, w->fd.open_err);
             }
         }
         write_end_chart();
@@ -838,7 +838,7 @@ void ebpf_fd_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_CLOSED);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->name, w->fd.close_call);
+            write_chart_dimension(w->clean_name, w->fd.close_call);
         }
     }
     write_end_chart();
@@ -847,7 +847,7 @@ void ebpf_fd_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_CLOSE_ERROR);
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed && w->processes)) {
-                write_chart_dimension(w->name, w->fd.close_err);
+                write_chart_dimension(w->clean_name, w->fd.close_err);
             }
         }
         write_end_chart();

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -825,24 +825,24 @@ void ebpf_fd_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
         ebpf_fd_sum_pids(&w->fd, w->root_pid);
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_file_open");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_file_open");
         write_chart_dimension("calls", w->fd.open_call);
-        write_end_chart();
+        ebpf_write_end_chart();
 
         if (em->mode < MODE_ENTRY) {
-            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_file_open_error");
+            ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_file_open_error");
             write_chart_dimension("calls", w->fd.open_err);
-            write_end_chart();
+            ebpf_write_end_chart();
         }
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_file_closed");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_file_closed");
         write_chart_dimension("calls", w->fd.close_call);
-        write_end_chart();
+        ebpf_write_end_chart();
 
         if (em->mode < MODE_ENTRY) {
-            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_file_close_error");
+            ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_file_close_error");
             write_chart_dimension("calls", w->fd.close_err);
-            write_end_chart();
+            ebpf_write_end_chart();
         }
     }
 }
@@ -971,24 +971,24 @@ static void ebpf_obsolete_specific_fd_charts(char *type, ebpf_module_t *em)
  */
 static void ebpf_send_specific_fd_data(char *type, netdata_fd_stat_t *values, ebpf_module_t *em)
 {
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_OPEN, "");
+    ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_OPEN, "");
     write_chart_dimension(fd_publish_aggregated[NETDATA_FD_SYSCALL_OPEN].name, (long long)values->open_call);
-    write_end_chart();
+    ebpf_write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_OPEN_ERROR, "");
+        ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_OPEN_ERROR, "");
         write_chart_dimension(fd_publish_aggregated[NETDATA_FD_SYSCALL_OPEN].name, (long long)values->open_err);
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_CLOSED, "");
+    ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_CLOSED, "");
     write_chart_dimension(fd_publish_aggregated[NETDATA_FD_SYSCALL_CLOSE].name, (long long)values->close_call);
-    write_end_chart();
+    ebpf_write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_CLOSE_ERROR, "");
+        ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_CLOSE_ERROR, "");
         write_chart_dimension(fd_publish_aggregated[NETDATA_FD_SYSCALL_CLOSE].name, (long long)values->close_err);
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 }
 
@@ -1040,40 +1040,40 @@ static void ebpf_create_systemd_fd_charts(ebpf_module_t *em)
 static void ebpf_send_systemd_fd_charts(ebpf_module_t *em)
 {
     ebpf_cgroup_target_t *ect;
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_OPEN, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_OPEN, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_fd.open_call);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_OPEN_ERROR, "");
+        ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_OPEN_ERROR, "");
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {
                 write_chart_dimension(ect->name, ect->publish_systemd_fd.open_err);
             }
         }
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_CLOSED, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_CLOSED, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_fd.close_call);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_CLOSE_ERROR, "");
+        ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_CLOSE_ERROR, "");
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {
                 write_chart_dimension(ect->name, ect->publish_systemd_fd.close_err);
             }
         }
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -475,10 +475,10 @@ void ebpf_obsolete_fd_apps_charts(struct ebpf_module *em)
                                   "_ebpf_file_open",
                                   "Number of open files",
                                   EBPF_COMMON_DIMENSION_CALL,
-                                  NETDATA_APPS_FILE_GROUP,
+                                  NETDATA_APPS_FILE_FDS,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
                                   "app.ebpf_file_open",
-                                  20061,
+                                  20220,
                                   update_every);
 
         if (em->mode < MODE_ENTRY) {
@@ -487,10 +487,10 @@ void ebpf_obsolete_fd_apps_charts(struct ebpf_module *em)
                                       "_ebpf_file_open_error",
                                       "Fails to open files.",
                                       EBPF_COMMON_DIMENSION_CALL,
-                                      NETDATA_APPS_FILE_GROUP,
+                                      NETDATA_APPS_FILE_FDS,
                                       NETDATA_EBPF_CHART_TYPE_STACKED,
                                       "app.ebpf_file_open_error",
-                                      20062,
+                                      20221,
                                       update_every);
         }
 
@@ -499,10 +499,10 @@ void ebpf_obsolete_fd_apps_charts(struct ebpf_module *em)
                                   "_ebpf_file_closed",
                                   "Files closed.",
                                   EBPF_COMMON_DIMENSION_CALL,
-                                  NETDATA_APPS_FILE_GROUP,
+                                  NETDATA_APPS_FILE_FDS,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
                                   "app.ebpf_file_closed",
-                                  20063,
+                                  20222,
                                   update_every);
 
         if (em->mode < MODE_ENTRY) {
@@ -511,10 +511,10 @@ void ebpf_obsolete_fd_apps_charts(struct ebpf_module *em)
                                       "_ebpf_file_close_error",
                                       "Fails to close files.",
                                       EBPF_COMMON_DIMENSION_CALL,
-                                      NETDATA_APPS_FILE_GROUP,
+                                      NETDATA_APPS_FILE_FDS,
                                       NETDATA_EBPF_CHART_TYPE_STACKED,
                                       "app.ebpf_fd_close_error",
-                                      20064,
+                                      20223,
                                       update_every);
         }
         w->charts_created &= ~(1<<EBPF_MODULE_FD_IDX);
@@ -1211,10 +1211,10 @@ void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr)
                              "_ebpf_file_open",
                              "Number of open files",
                              EBPF_COMMON_DIMENSION_CALL,
-                             NETDATA_APPS_FILE_GROUP,
+                             NETDATA_APPS_FILE_FDS,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
                              "app.ebpf_file_open",
-                             20270,
+                             20220,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_FD);
         ebpf_create_chart_labels("app_group", w->name, 0);
@@ -1227,10 +1227,10 @@ void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr)
                                  "_ebpf_file_open_error",
                                  "Fails to open files.",
                                  EBPF_COMMON_DIMENSION_CALL,
-                                 NETDATA_APPS_FILE_GROUP,
+                                 NETDATA_APPS_FILE_FDS,
                                  NETDATA_EBPF_CHART_TYPE_STACKED,
                                  "app.ebpf_file_open_error",
-                                 20271,
+                                 20221,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_FD);
             ebpf_create_chart_labels("app_group", w->name, 0);
@@ -1243,10 +1243,10 @@ void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr)
                              "_ebpf_file_closed",
                              "Files closed.",
                              EBPF_COMMON_DIMENSION_CALL,
-                             NETDATA_APPS_FILE_GROUP,
+                             NETDATA_APPS_FILE_FDS,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
                              "app.ebpf_file_closed",
-                             20272,
+                             20222,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_FD);
         ebpf_create_chart_labels("app_group", w->name, 0);
@@ -1259,10 +1259,10 @@ void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr)
                                  "_ebpf_file_close_error",
                                  "Fails to close files.",
                                  EBPF_COMMON_DIMENSION_CALL,
-                                 NETDATA_APPS_FILE_GROUP,
+                                 NETDATA_APPS_FILE_FDS,
                                  NETDATA_EBPF_CHART_TYPE_STACKED,
                                  "app.ebpf_file_close_error",
-                                 20273,
+                                 20223,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_FD);
             ebpf_create_chart_labels("app_group", w->name, 0);

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -392,7 +392,7 @@ static void ebpf_obsolete_fd_services(ebpf_module_t *em)
                               NETDATA_APPS_FILE_CGROUP_GROUP,
                               NETDATA_EBPF_CHART_TYPE_STACKED,
                               NETDATA_CGROUP_FD_OPEN_CONTEXT,
-                              20061,
+                              20270,
                               em->update_every);
 
     if (em->mode < MODE_ENTRY) {
@@ -404,7 +404,7 @@ static void ebpf_obsolete_fd_services(ebpf_module_t *em)
                                   NETDATA_APPS_FILE_CGROUP_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
                                   NETDATA_CGROUP_FD_OPEN_ERR_CONTEXT,
-                                  20062,
+                                  20271,
                                   em->update_every);
     }
 
@@ -416,7 +416,7 @@ static void ebpf_obsolete_fd_services(ebpf_module_t *em)
                               NETDATA_APPS_FILE_CGROUP_GROUP,
                               NETDATA_EBPF_CHART_TYPE_STACKED,
                               NETDATA_CGROUP_FD_CLOSE_CONTEXT,
-                              20063,
+                              20272,
                               em->update_every);
 
     if (em->mode < MODE_ENTRY) {
@@ -428,7 +428,7 @@ static void ebpf_obsolete_fd_services(ebpf_module_t *em)
                                   NETDATA_APPS_FILE_CGROUP_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
                                   NETDATA_CGROUP_FD_CLOSE_ERR_CONTEXT,
-                                  20064,
+                                  20273,
                                   em->update_every);
     }
 }
@@ -1214,7 +1214,7 @@ void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_APPS_FILE_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
                              "app.ebpf_file_open",
-                             20061,
+                             20270,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_FD);
         ebpf_create_chart_labels("app_group", w->name, 0);
@@ -1230,7 +1230,7 @@ void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr)
                                  NETDATA_APPS_FILE_GROUP,
                                  NETDATA_EBPF_CHART_TYPE_STACKED,
                                  "app.ebpf_file_open_error",
-                                 20062,
+                                 20271,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_FD);
             ebpf_create_chart_labels("app_group", w->name, 0);
@@ -1246,7 +1246,7 @@ void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_APPS_FILE_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
                              "app.ebpf_file_closed",
-                             20063,
+                             20272,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_FD);
         ebpf_create_chart_labels("app_group", w->name, 0);
@@ -1262,7 +1262,7 @@ void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr)
                                  NETDATA_APPS_FILE_GROUP,
                                  NETDATA_EBPF_CHART_TYPE_STACKED,
                                  "app.ebpf_file_close_error",
-                                 20064,
+                                 20273,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_FD);
             ebpf_create_chart_labels("app_group", w->name, 0);

--- a/collectors/ebpf.plugin/ebpf_fd.c
+++ b/collectors/ebpf.plugin/ebpf_fd.c
@@ -467,8 +467,7 @@ void ebpf_obsolete_fd_apps_charts(struct ebpf_module *em)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = apps_groups_root_target; w; w = w->next) {
-        uint32_t flag = w->charts_created & (1 << EBPF_MODULE_FD_IDX);
-        if (likely(w->exposed && w->processes && !flag))
+        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_FD_IDX))))
             continue;
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -821,8 +820,7 @@ void ebpf_fd_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 {
     struct ebpf_target *w;
     for (w = root; w; w = w->next) {
-        uint32_t flag = w->charts_created & 1<<EBPF_MODULE_FD_IDX;
-        if (likely(w->exposed && w->processes && !flag))
+        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_FD_IDX))))
             continue;
 
         ebpf_fd_sum_pids(&w->fd, w->root_pid);
@@ -1205,7 +1203,7 @@ void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = root; w; w = w->next) {
-        if (likely(w->exposed && w->processes))
+        if (unlikely(!w->exposed))
             continue;
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,

--- a/collectors/ebpf.plugin/ebpf_filesystem.c
+++ b/collectors/ebpf.plugin/ebpf_filesystem.c
@@ -351,20 +351,22 @@ static void ebpf_obsolete_fs_charts(int update_every)
             flags &= ~NETDATA_FILESYSTEM_FLAG_CHART_CREATED;
 
             ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY, efp->hread.name,
+                                      "",
                                       efp->hread.title,
                                       EBPF_COMMON_DIMENSION_CALL, efp->family_name,
                                       NULL, NETDATA_EBPF_CHART_TYPE_STACKED, efp->hread.order, update_every);
 
             ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY, efp->hwrite.name,
+                                      "",
                                       efp->hwrite.title,
                                       EBPF_COMMON_DIMENSION_CALL, efp->family_name,
                                       NULL, NETDATA_EBPF_CHART_TYPE_STACKED, efp->hwrite.order, update_every);
 
-            ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY, efp->hopen.name, efp->hopen.title,
+            ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY, efp->hopen.name, "", efp->hopen.title,
                                       EBPF_COMMON_DIMENSION_CALL, efp->family_name,
                                       NULL, NETDATA_EBPF_CHART_TYPE_STACKED, efp->hopen.order, update_every);
 
-            ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY, efp->hadditional.name, efp->hadditional.title,
+            ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY, efp->hadditional.name,"",  efp->hadditional.title,
                                       EBPF_COMMON_DIMENSION_CALL, efp->family_name,
                                       NULL, NETDATA_EBPF_CHART_TYPE_STACKED, efp->hadditional.order,
                                       update_every);
@@ -671,6 +673,7 @@ static void ebpf_obsolete_filesystem_global(ebpf_module_t *em)
 
         ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                                   efp->hread.name,
+                                  "",
                                   efp->hread.title,
                                   EBPF_COMMON_DIMENSION_CALL,
                                   efp->family_name,
@@ -681,6 +684,7 @@ static void ebpf_obsolete_filesystem_global(ebpf_module_t *em)
 
         ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                                   efp->hwrite.name,
+                                  "",
                                   efp->hwrite.title,
                                   EBPF_COMMON_DIMENSION_CALL,
                                   efp->family_name,
@@ -691,6 +695,7 @@ static void ebpf_obsolete_filesystem_global(ebpf_module_t *em)
 
         ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                                   efp->hopen.name,
+                                  "",
                                   efp->hopen.title,
                                   EBPF_COMMON_DIMENSION_CALL,
                                   efp->family_name,
@@ -701,6 +706,7 @@ static void ebpf_obsolete_filesystem_global(ebpf_module_t *em)
 
         ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                                   efp->hadditional.name,
+                                  "",
                                   efp->hadditional.title,
                                   EBPF_COMMON_DIMENSION_CALL,
                                   efp->family_name,

--- a/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -594,10 +594,10 @@ static void hardirq_collector(ebpf_module_t *em)
         pthread_mutex_lock(&lock);
 
         // write dims now for all hitherto discovered IRQs.
-        write_begin_chart(NETDATA_EBPF_SYSTEM_GROUP, "hardirq_latency", "");
+        ebpf_write_begin_chart(NETDATA_EBPF_SYSTEM_GROUP, "hardirq_latency", "");
         avl_traverse_lock(&hardirq_pub, hardirq_write_dims, NULL);
         hardirq_write_static_dims();
-        write_end_chart();
+        ebpf_write_end_chart();
 
         pthread_mutex_unlock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -594,7 +594,7 @@ static void hardirq_collector(ebpf_module_t *em)
         pthread_mutex_lock(&lock);
 
         // write dims now for all hitherto discovered IRQs.
-        write_begin_chart(NETDATA_EBPF_SYSTEM_GROUP, "hardirq_latency");
+        write_begin_chart(NETDATA_EBPF_SYSTEM_GROUP, "hardirq_latency", "");
         avl_traverse_lock(&hardirq_pub, hardirq_write_dims, NULL);
         hardirq_write_static_dims();
         write_end_chart();

--- a/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -226,6 +226,7 @@ static void ebpf_obsolete_hardirq_global(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_EBPF_SYSTEM_GROUP,
                               "hardirq_latency",
+                              "",
                               "Hardware IRQ latency",
                               EBPF_COMMON_DIMENSION_MILLISECONDS,
                               "interrupts",

--- a/collectors/ebpf.plugin/ebpf_mdflush.c
+++ b/collectors/ebpf.plugin/ebpf_mdflush.c
@@ -140,6 +140,7 @@ static void ebpf_obsolete_mdflush_global(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete("mdstat",
                               "mdstat_flush",
+                              "",
                               "MD flushes",
                               "flushes",
                               "flush (eBPF)",

--- a/collectors/ebpf.plugin/ebpf_mdflush.c
+++ b/collectors/ebpf.plugin/ebpf_mdflush.c
@@ -356,9 +356,9 @@ static void mdflush_collector(ebpf_module_t *em)
         mdflush_read_count_map(maps_per_core);
         pthread_mutex_lock(&lock);
         // write dims now for all hitherto discovered devices.
-        write_begin_chart("mdstat", "mdstat_flush", "");
+        ebpf_write_begin_chart("mdstat", "mdstat_flush", "");
         avl_traverse_lock(&mdflush_pub, mdflush_write_dims, NULL);
-        write_end_chart();
+        ebpf_write_end_chart();
 
         pthread_mutex_unlock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_mdflush.c
+++ b/collectors/ebpf.plugin/ebpf_mdflush.c
@@ -356,7 +356,7 @@ static void mdflush_collector(ebpf_module_t *em)
         mdflush_read_count_map(maps_per_core);
         pthread_mutex_lock(&lock);
         // write dims now for all hitherto discovered devices.
-        write_begin_chart("mdstat", "mdstat_flush");
+        write_begin_chart("mdstat", "mdstat_flush", "");
         avl_traverse_lock(&mdflush_pub, mdflush_write_dims, NULL);
         write_end_chart();
 

--- a/collectors/ebpf.plugin/ebpf_mount.c
+++ b/collectors/ebpf.plugin/ebpf_mount.c
@@ -233,6 +233,7 @@ static void ebpf_obsolete_mount_global(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_EBPF_MOUNT_GLOBAL_FAMILY,
                               NETDATA_EBPF_MOUNT_CALLS,
+                              "",
                               "Calls to mount and umount syscalls",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_EBPF_MOUNT_FAMILY,
@@ -243,6 +244,7 @@ static void ebpf_obsolete_mount_global(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_EBPF_MOUNT_GLOBAL_FAMILY,
                               NETDATA_EBPF_MOUNT_ERRORS,
+                              "",
                               "Errors to mount and umount file systems",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_EBPF_MOUNT_FAMILY,

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -57,6 +57,7 @@ static void ebpf_obsolete_oomkill_services(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_OOMKILL_CHART,
+                              "",
                               "OOM kills. This chart is provided by eBPF plugin.",
                               EBPF_COMMON_DIMENSION_KILLS,
                               NETDATA_EBPF_MEMORY_GROUP,
@@ -100,7 +101,8 @@ static void ebpf_obsolete_oomkill_apps(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_OOMKILL_CHART,
-                             "OOM kills",
+                              "",
+                              "OOM kills",
                               EBPF_COMMON_DIMENSION_KILLS,
                               "mem",
                               NETDATA_EBPF_CHART_TYPE_STACKED,
@@ -266,7 +268,7 @@ static void ebpf_send_specific_oomkill_data(char *type, int value)
  */
 static void ebpf_obsolete_specific_oomkill_charts(char *type, int update_every)
 {
-    ebpf_write_chart_obsolete(type, NETDATA_OOMKILL_CHART, "OOM kills. This chart is provided by eBPF plugin.",
+    ebpf_write_chart_obsolete(type, NETDATA_OOMKILL_CHART, "", "OOM kills. This chart is provided by eBPF plugin.",
                               EBPF_COMMON_DIMENSION_KILLS, NETDATA_EBPF_MEMORY_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_OOMKILLS_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5600, update_every);

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -233,7 +233,7 @@ static void ebpf_create_systemd_oomkill_charts(int update_every)
 static void ebpf_send_systemd_oomkill_charts()
 {
     ebpf_cgroup_target_t *ect;
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_OOMKILL_CHART);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_OOMKILL_CHART, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long) ect->oomkill);
@@ -253,7 +253,7 @@ static void ebpf_send_systemd_oomkill_charts()
  */
 static void ebpf_send_specific_oomkill_data(char *type, int value)
 {
-    write_begin_chart(type, NETDATA_OOMKILL_CHART);
+    write_begin_chart(type, NETDATA_OOMKILL_CHART, "");
     write_chart_dimension(oomkill_publish_aggregated.name, (long long)value);
     write_end_chart();
 }
@@ -447,7 +447,7 @@ static void oomkill_collector(ebpf_module_t *em)
         }
 
         if (em->apps_charts & NETDATA_EBPF_APPS_FLAG_CHART_CREATED) {
-            write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_OOMKILL_CHART);
+            write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_OOMKILL_CHART, "");
             oomkill_write_data(keys, count);
             write_end_chart();
         }

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -102,8 +102,7 @@ static void ebpf_obsolete_oomkill_apps(ebpf_module_t *em)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = apps_groups_root_target; w; w = w->next) {
-        uint32_t flag = w->charts_created & (1 << EBPF_MODULE_OOMKILL_IDX);
-        if (likely(w->exposed && w->processes && !flag))
+        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_OOMKILL_IDX))))
             continue;
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -483,7 +482,7 @@ void ebpf_oomkill_create_apps_charts(struct ebpf_module *em, void *ptr)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = root; w; w = w->next) {
-        if (likely(w->exposed && w->processes))
+        if (unlikely(!w->exposed))
             continue;
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -182,9 +182,9 @@ static void oomkill_write_data(int32_t *keys, uint32_t total)
             }
         }
 write_dim:
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_oomkill");
+    ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_oomkill");
         write_chart_dimension(EBPF_COMMON_DIMENSION_KILLS, was_oomkilled);
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 
     // for any remaining keys for which we couldn't find a group, this could be
@@ -247,14 +247,14 @@ static void ebpf_create_systemd_oomkill_charts(int update_every)
 static void ebpf_send_systemd_oomkill_charts()
 {
     ebpf_cgroup_target_t *ect;
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_OOMKILL_CHART, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_OOMKILL_CHART, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long) ect->oomkill);
             ect->oomkill = 0;
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /*
@@ -267,9 +267,9 @@ static void ebpf_send_systemd_oomkill_charts()
  */
 static void ebpf_send_specific_oomkill_data(char *type, int value)
 {
-    write_begin_chart(type, NETDATA_OOMKILL_CHART, "");
+    ebpf_write_begin_chart(type, NETDATA_OOMKILL_CHART, "");
     write_chart_dimension(oomkill_publish_aggregated.name, (long long)value);
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -183,7 +183,7 @@ static void oomkill_write_data(int32_t *keys, uint32_t total)
             }
         }
 write_dim:
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_app_oomkill");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_oomkill");
         write_chart_dimension(EBPF_COMMON_DIMENSION_KILLS, was_oomkilled);
         write_end_chart();
     }
@@ -488,12 +488,12 @@ void ebpf_oomkill_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_app_oomkill",
+                             "_ebpf_oomkill",
                              "OOM kills.",
                              EBPF_COMMON_DIMENSION_KILLS,
                              NETDATA_EBPF_MEMORY_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_oomkill",
+                             "app.ebpf_oomkill",
                              20020,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_OOMKILL);

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -169,7 +169,7 @@ static void oomkill_write_data(int32_t *keys, uint32_t total)
             }
 
         write_dim:;
-            write_chart_dimension(w->name, was_oomkilled);
+            write_chart_dimension(w->clean_name, was_oomkilled);
         }
     }
 

--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -161,8 +161,7 @@ static void oomkill_write_data(int32_t *keys, uint32_t total)
     // for each app, see if it was OOM killed. record as 1 if so otherwise 0.
     struct ebpf_target *w;
     for (w = apps_groups_root_target; w != NULL; w = w->next) {
-        uint32_t flag = w->charts_created & 1 << EBPF_MODULE_OOMKILL_IDX;
-        if (likely(w->exposed && w->processes && !flag))
+        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_OOMKILL_IDX))))
             continue;
 
         bool was_oomkilled = false;
@@ -182,7 +181,7 @@ static void oomkill_write_data(int32_t *keys, uint32_t total)
             }
         }
 write_dim:
-    ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_oomkill");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_oomkill");
         write_chart_dimension(EBPF_COMMON_DIMENSION_KILLS, was_oomkilled);
         ebpf_write_end_chart();
     }

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -116,7 +116,7 @@ static void ebpf_update_global_publish(netdata_publish_syscall_t *publish, netda
  */
 static void write_status_chart(char *family, netdata_publish_vfs_common_t *pvc)
 {
-    write_begin_chart(family, NETDATA_PROCESS_STATUS_NAME);
+    write_begin_chart(family, NETDATA_PROCESS_STATUS_NAME, "");
 
     write_chart_dimension(status[0], (long long)pvc->running);
     write_chart_dimension(status[1], (long long)pvc->zombie);
@@ -203,7 +203,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
     struct ebpf_target *w;
     collected_number value;
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_PROCESS);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_PROCESS, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t, create_process));
@@ -212,7 +212,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_THREAD);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_THREAD, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t, create_thread));
@@ -221,7 +221,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_EXIT);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_EXIT, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t,
@@ -231,7 +231,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_CLOSE);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_CLOSE, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t,
@@ -242,7 +242,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_ERROR);
+        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_TASK_ERROR, "");
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed && w->processes)) {
                 value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t,
@@ -833,28 +833,28 @@ static void ebpf_process_sum_cgroup_pids(ebpf_process_stat_t *ps, struct pid_on_
  */
 static void ebpf_send_specific_process_data(char *type, ebpf_process_stat_t *values, ebpf_module_t *em)
 {
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_PROCESS);
+    write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_PROCESS, "");
     write_chart_dimension(process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_FORK].name,
                           (long long) values->create_process);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_THREAD);
+    write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_THREAD, "");
     write_chart_dimension(process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_CLONE].name,
                           (long long) values->create_thread);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_EXIT);
+    write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_EXIT, "");
     write_chart_dimension(process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_EXIT].name,
                           (long long) values->release_call);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_CLOSE);
+    write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_CLOSE, "");
     write_chart_dimension(process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_RELEASE_TASK].name,
                           (long long) values->release_call);
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_ERROR);
+        write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_ERROR, "");
         write_chart_dimension(process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_EXIT].name,
                               (long long) values->task_err);
         write_end_chart();
@@ -1003,7 +1003,7 @@ static void ebpf_create_systemd_process_charts(ebpf_module_t *em)
 static void ebpf_send_systemd_process_charts(ebpf_module_t *em)
 {
     ebpf_cgroup_target_t *ect;
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_PROCESS);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_PROCESS, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_ps.create_process);
@@ -1011,7 +1011,7 @@ static void ebpf_send_systemd_process_charts(ebpf_module_t *em)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_THREAD);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_THREAD, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_ps.create_thread);
@@ -1019,7 +1019,7 @@ static void ebpf_send_systemd_process_charts(ebpf_module_t *em)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_EXIT);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_EXIT, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_ps.exit_call);
@@ -1027,7 +1027,7 @@ static void ebpf_send_systemd_process_charts(ebpf_module_t *em)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_CLOSE);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_CLOSE, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_ps.release_call);
@@ -1036,7 +1036,7 @@ static void ebpf_send_systemd_process_charts(ebpf_module_t *em)
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_ERROR);
+        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_ERROR, "");
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {
                 write_chart_dimension(ect->name, ect->publish_systemd_ps.task_err);

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -205,8 +205,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
     collected_number values[5];
 
     for (w = root; w; w = w->next) {
-        uint32_t flag = w->charts_created & 1 << EBPF_MODULE_PROCESS_IDX;
-        if (likely(w->exposed && w->processes && !flag))
+        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_PROCESS_IDX))))
             continue;
 
         values[0] = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t, create_process));
@@ -424,7 +423,7 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = root; w; w = w->next) {
-        if (likely(w->exposed && w->processes))
+        if (unlikely(!w->exposed))
             continue;
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
@@ -618,8 +617,7 @@ void ebpf_obsolete_process_apps_charts(struct ebpf_module *em)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = apps_groups_root_target; w; w = w->next) {
-        uint32_t flag = w->charts_created & (1 << EBPF_MODULE_PROCESS_IDX);
-        if (likely(w->exposed && w->processes && !flag))
+        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_PROCESS_IDX))))
             continue;
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -116,12 +116,12 @@ static void ebpf_update_global_publish(netdata_publish_syscall_t *publish, netda
  */
 static void write_status_chart(char *family, netdata_publish_vfs_common_t *pvc)
 {
-    write_begin_chart(family, NETDATA_PROCESS_STATUS_NAME, "");
+    ebpf_write_begin_chart(family, NETDATA_PROCESS_STATUS_NAME, "");
 
     write_chart_dimension(status[0], (long long)pvc->running);
     write_chart_dimension(status[1], (long long)pvc->zombie);
 
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**
@@ -217,26 +217,26 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
         values[4] = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t,
                                                                            task_err));
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_process_start");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_process_start");
         write_chart_dimension("calls", values[0]);
-        write_end_chart();
+        ebpf_write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_thread_start");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_thread_start");
         write_chart_dimension("calls", values[1]);
-        write_end_chart();
+        ebpf_write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_task_exit");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_task_exit");
         write_chart_dimension("calls", values[2]);
-        write_end_chart();
+        ebpf_write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_task_released");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_task_released");
         write_chart_dimension("calls", values[3]);
-        write_end_chart();
+        ebpf_write_end_chart();
 
         if (em->mode < MODE_ENTRY) {
-            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_task_error");
+            ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_task_error");
             write_chart_dimension("calls", values[4]);
-            write_end_chart();
+            ebpf_write_end_chart();
         }
     }
 
@@ -866,31 +866,31 @@ static void ebpf_process_sum_cgroup_pids(ebpf_process_stat_t *ps, struct pid_on_
  */
 static void ebpf_send_specific_process_data(char *type, ebpf_process_stat_t *values, ebpf_module_t *em)
 {
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_PROCESS, "");
+    ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_PROCESS, "");
     write_chart_dimension(process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_FORK].name,
                           (long long) values->create_process);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_THREAD, "");
+    ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_THREAD, "");
     write_chart_dimension(process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_CLONE].name,
                           (long long) values->create_thread);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_EXIT, "");
+    ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_EXIT, "");
     write_chart_dimension(process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_EXIT].name,
                           (long long) values->release_call);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_CLOSE, "");
+    ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_CLOSE, "");
     write_chart_dimension(process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_RELEASE_TASK].name,
                           (long long) values->release_call);
-    write_end_chart();
+    ebpf_write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_ERROR, "");
+        ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_TASK_ERROR, "");
         write_chart_dimension(process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_EXIT].name,
                               (long long) values->task_err);
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 }
 
@@ -1036,46 +1036,46 @@ static void ebpf_create_systemd_process_charts(ebpf_module_t *em)
 static void ebpf_send_systemd_process_charts(ebpf_module_t *em)
 {
     ebpf_cgroup_target_t *ect;
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_PROCESS, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_PROCESS, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_ps.create_process);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_THREAD, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_THREAD, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_ps.create_thread);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_EXIT, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_EXIT, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_ps.exit_call);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_CLOSE, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_CLOSE, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_ps.release_call);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_ERROR, "");
+        ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_TASK_ERROR, "");
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {
                 write_chart_dimension(ect->name, ect->publish_systemd_ps.task_err);
             }
         }
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -503,6 +503,7 @@ static void ebpf_obsolete_process_services(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SYSCALL_APPS_TASK_PROCESS,
+                              "",
                               "Process started",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_PROCESS_GROUP,
@@ -513,6 +514,7 @@ static void ebpf_obsolete_process_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SYSCALL_APPS_TASK_THREAD,
+                              "",
                               "Threads started",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_PROCESS_GROUP,
@@ -523,6 +525,7 @@ static void ebpf_obsolete_process_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SYSCALL_APPS_TASK_CLOSE,
+                              "",
                               "Tasks starts exit process.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_PROCESS_GROUP,
@@ -533,6 +536,7 @@ static void ebpf_obsolete_process_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SYSCALL_APPS_TASK_EXIT,
+                              "",
                               "Tasks closed",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_PROCESS_GROUP,
@@ -544,6 +548,7 @@ static void ebpf_obsolete_process_services(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                                   NETDATA_SYSCALL_APPS_TASK_ERROR,
+                                  "",
                                   "Errors to create process or threads.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_PROCESS_GROUP,
@@ -587,6 +592,7 @@ void ebpf_obsolete_process_apps_charts(struct ebpf_module *em)
 {
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_SYSCALL_APPS_TASK_PROCESS,
+                              "",
                               "Process started",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_PROCESS_GROUP,
@@ -597,6 +603,7 @@ void ebpf_obsolete_process_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_SYSCALL_APPS_TASK_THREAD,
+                              "",
                               "Threads started",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_PROCESS_GROUP,
@@ -607,6 +614,7 @@ void ebpf_obsolete_process_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_SYSCALL_APPS_TASK_EXIT,
+                              "",
                               "Tasks starts exit process.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_PROCESS_GROUP,
@@ -617,6 +625,7 @@ void ebpf_obsolete_process_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_SYSCALL_APPS_TASK_CLOSE,
+                              "",
                               "Tasks closed",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_PROCESS_GROUP,
@@ -628,6 +637,7 @@ void ebpf_obsolete_process_apps_charts(struct ebpf_module *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                                   NETDATA_SYSCALL_APPS_TASK_ERROR,
+                                  "",
                                   "Errors to create process or threads.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_PROCESS_GROUP,
@@ -649,6 +659,7 @@ static void ebpf_obsolete_process_global(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_EBPF_SYSTEM_GROUP,
                               NETDATA_PROCESS_SYSCALL,
+                              "",
                               "Start process",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_PROCESS_GROUP,
@@ -659,6 +670,7 @@ static void ebpf_obsolete_process_global(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_EBPF_SYSTEM_GROUP,
                               NETDATA_EXIT_SYSCALL,
+                              "",
                               "Exit process",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_PROCESS_GROUP,
@@ -669,6 +681,7 @@ static void ebpf_obsolete_process_global(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_EBPF_SYSTEM_GROUP,
                               NETDATA_PROCESS_STATUS_NAME,
+                              "",
                               "Process not closed",
                               EBPF_COMMON_DIMENSION_DIFFERENCE,
                               NETDATA_PROCESS_GROUP,
@@ -680,6 +693,7 @@ static void ebpf_obsolete_process_global(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_EBPF_SYSTEM_GROUP,
                                   NETDATA_PROCESS_ERROR_NAME,
+                                  "",
                                   "Fails to create process",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_PROCESS_GROUP,
@@ -909,28 +923,28 @@ static void ebpf_create_specific_process_charts(char *type, ebpf_module_t *em)
  */
 static void ebpf_obsolete_specific_process_charts(char *type, ebpf_module_t *em)
 {
-    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_TASK_PROCESS, "Process started",
+    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_TASK_PROCESS, "", "Process started",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_PROCESS_GROUP, NETDATA_EBPF_CHART_TYPE_LINE,
                               NETDATA_CGROUP_PROCESS_CREATE_CONTEXT, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5000,
                               em->update_every);
 
-    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_TASK_THREAD, "Threads started",
+    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_TASK_THREAD, "", "Threads started",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_PROCESS_GROUP, NETDATA_EBPF_CHART_TYPE_LINE,
                               NETDATA_CGROUP_THREAD_CREATE_CONTEXT, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5001,
                               em->update_every);
 
-    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_TASK_EXIT,"Tasks starts exit process.",
+    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_TASK_EXIT, "","Tasks starts exit process.",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_PROCESS_GROUP, NETDATA_EBPF_CHART_TYPE_LINE,
                               NETDATA_CGROUP_PROCESS_EXIT_CONTEXT, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5002,
                               em->update_every);
 
-    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_TASK_CLOSE,"Tasks closed",
+    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_TASK_CLOSE, "","Tasks closed",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_PROCESS_GROUP, NETDATA_EBPF_CHART_TYPE_LINE,
                               NETDATA_CGROUP_PROCESS_CLOSE_CONTEXT, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5003,
                               em->update_every);
 
     if (em->mode < MODE_ENTRY) {
-        ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_TASK_ERROR,"Errors to create process or threads.",
+        ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_TASK_ERROR, "","Errors to create process or threads.",
                                   EBPF_COMMON_DIMENSION_CALL, NETDATA_PROCESS_GROUP, NETDATA_EBPF_CHART_TYPE_LINE,
                                   NETDATA_CGROUP_PROCESS_ERROR_CONTEXT, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5004,
                                   em->update_every);

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -434,7 +434,7 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_PROCESS_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
                              "app.ebpf_process_start",
-                             20065,
+                             20161,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_PROCESS);
         ebpf_create_chart_labels("app_group", w->name, 0);
@@ -449,7 +449,7 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_PROCESS_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
                              "app.ebpf_thread_start",
-                             20066,
+                             20162,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_PROCESS);
         ebpf_create_chart_labels("app_group", w->name, 0);
@@ -464,7 +464,7 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_PROCESS_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
                              "app.ebpf_task_exit",
-                             20067,
+                             20163,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_PROCESS);
         ebpf_create_chart_labels("app_group", w->name, 0);
@@ -479,7 +479,7 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_PROCESS_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
                              "app.ebpf_task_released",
-                             20068,
+                             20164,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_PROCESS);
         ebpf_create_chart_labels("app_group", w->name, 0);
@@ -495,7 +495,7 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
                                  NETDATA_PROCESS_GROUP,
                                  NETDATA_EBPF_CHART_TYPE_STACKED,
                                  "app.ebpf_task_error",
-                                 20069,
+                                 20165,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_PROCESS);
             ebpf_create_chart_labels("app_group", w->name, 0);
@@ -628,7 +628,7 @@ void ebpf_obsolete_process_apps_charts(struct ebpf_module *em)
                                   NETDATA_PROCESS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
                                   "app.ebpf_process_start",
-                                  20065,
+                                  20161,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -639,7 +639,7 @@ void ebpf_obsolete_process_apps_charts(struct ebpf_module *em)
                                   NETDATA_PROCESS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
                                   "app.ebpf_thread_start",
-                                  20066,
+                                  20162,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -650,7 +650,7 @@ void ebpf_obsolete_process_apps_charts(struct ebpf_module *em)
                                   NETDATA_PROCESS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
                                   "app.ebpf_task_exit",
-                                  20067,
+                                  20163,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -661,7 +661,7 @@ void ebpf_obsolete_process_apps_charts(struct ebpf_module *em)
                                   NETDATA_PROCESS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
                                   "app.ebpf_task_released",
-                                  20068,
+                                  20164,
                                   update_every);
 
         if (em->mode < MODE_ENTRY) {
@@ -673,7 +673,7 @@ void ebpf_obsolete_process_apps_charts(struct ebpf_module *em)
                                       NETDATA_PROCESS_GROUP,
                                       NETDATA_EBPF_CHART_TYPE_STACKED,
                                       "app.ebpf_task_error",
-                                      20069,
+                                      20165,
                                       update_every);
         }
 

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -218,25 +218,25 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
         values[4] = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t,
                                                                            task_err));
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_process_start");
-        write_chart_dimension("processes", values[0]);
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_process_start");
+        write_chart_dimension("calls", values[0]);
         write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_thread_start");
-        write_chart_dimension("threads", values[1]);
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_thread_start");
+        write_chart_dimension("calls", values[1]);
         write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_task_exit");
-        write_chart_dimension("tasks", values[2]);
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_task_exit");
+        write_chart_dimension("calls", values[2]);
         write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_task_released");
-        write_chart_dimension("tasks", values[3]);
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_task_released");
+        write_chart_dimension("calls", values[3]);
         write_end_chart();
 
         if (em->mode < MODE_ENTRY) {
-            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_task_error");
-            write_chart_dimension("tasks", values[4]);
+            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_task_error");
+            write_chart_dimension("calls", values[4]);
             write_end_chart();
         }
     }
@@ -429,79 +429,79 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_process_start",
+                             "_ebpf_process_start",
                              "Process started.",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_PROCESS_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_process_start",
+                             "app.ebpf_process_start",
                              20065,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_PROCESS);
         ebpf_create_chart_labels("app_group", w->name, 0);
         ebpf_commit_label();
-        fprintf(stdout, "DIMENSION processes '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_thread_start",
+                             "_ebpf_thread_start",
                              "Threads started.",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_PROCESS_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_thread_start",
+                             "app.ebpf_thread_start",
                              20066,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_PROCESS);
         ebpf_create_chart_labels("app_group", w->name, 0);
         ebpf_commit_label();
-        fprintf(stdout, "DIMENSION threads '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_task_exit",
+                             "_ebpf_task_exit",
                              "Tasks starts exit process.",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_PROCESS_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_task_exit",
+                             "app.ebpf_task_exit",
                              20067,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_PROCESS);
         ebpf_create_chart_labels("app_group", w->name, 0);
         ebpf_commit_label();
-        fprintf(stdout, "DIMENSION tasks '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_task_released",
+                             "_ebpf_task_released",
                              "Tasks released.",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_PROCESS_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_task_released",
+                             "app.ebpf_task_released",
                              20068,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_PROCESS);
         ebpf_create_chart_labels("app_group", w->name, 0);
         ebpf_commit_label();
-        fprintf(stdout, "DIMENSION tasks '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 
         if (em->mode < MODE_ENTRY) {
             ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                                  w->clean_name,
-                                 "_task_error",
+                                 "_ebpf_task_error",
                                  "Errors to create process or threads.",
                                  EBPF_COMMON_DIMENSION_CALL,
                                  NETDATA_PROCESS_GROUP,
                                  NETDATA_EBPF_CHART_TYPE_STACKED,
-                                 "ebpf.app_task_error",
+                                 "app.ebpf_task_error",
                                  20069,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_PROCESS);
             ebpf_create_chart_labels("app_group", w->name, 0);
             ebpf_commit_label();
-            fprintf(stdout, "DIMENSION tasks '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
+            fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
         }
         w->charts_created |= 1<<EBPF_MODULE_PROCESS_IDX;
     }
@@ -624,76 +624,62 @@ void ebpf_obsolete_process_apps_charts(struct ebpf_module *em)
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_process_start",
+                                  "_ebpf_process_start",
                                   "Process started.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_PROCESS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_process_start",
+                                  "app.ebpf_process_start",
                                   20065,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_thread_start",
+                                  "_ebpf_thread_start",
                                   "Threads started.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_PROCESS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_thread_start",
+                                  "app.ebpf_thread_start",
                                   20066,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_task_exit",
+                                  "_ebpf_task_exit",
                                   "Tasks starts exit process.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_PROCESS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_task_exit",
+                                  "app.ebpf_task_exit",
                                   20067,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_task_released",
+                                  "_ebpf_task_released",
                                   "Tasks released.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_PROCESS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_task_released",
+                                  "app.ebpf_task_released",
                                   20068,
                                   update_every);
 
         if (em->mode < MODE_ENTRY) {
             ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                       w->clean_name,
-                                      "_task_error",
+                                      "_ebpf_task_error",
                                       "Errors to create process or threads.",
                                       EBPF_COMMON_DIMENSION_CALL,
                                       NETDATA_PROCESS_GROUP,
                                       NETDATA_EBPF_CHART_TYPE_STACKED,
-                                      "ebpf.app_task_error",
+                                      "app.ebpf_task_error",
                                       20069,
                                       update_every);
         }
 
         w->charts_created &= ~(1<<EBPF_MODULE_PROCESS_IDX);
-    }
-
-
-    if (em->mode < MODE_ENTRY) {
-        ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                                  NETDATA_SYSCALL_APPS_TASK_ERROR,
-                                  "",
-                                  "Errors to create process or threads.",
-                                  EBPF_COMMON_DIMENSION_CALL,
-                                  NETDATA_PROCESS_GROUP,
-                                  NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  NULL,
-                                  20069,
-                                  em->update_every);
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf_process.c
+++ b/collectors/ebpf.plugin/ebpf_process.c
@@ -207,7 +207,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t, create_process));
-            write_chart_dimension(w->name, value);
+            write_chart_dimension(w->clean_name, value);
         }
     }
     write_end_chart();
@@ -216,7 +216,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t, create_thread));
-            write_chart_dimension(w->name, value);
+            write_chart_dimension(w->clean_name, value);
         }
     }
     write_end_chart();
@@ -226,7 +226,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t,
                                                                            exit_call));
-            write_chart_dimension(w->name, value);
+            write_chart_dimension(w->clean_name, value);
         }
     }
     write_end_chart();
@@ -236,7 +236,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t,
                                                                            release_call));
-            write_chart_dimension(w->name, value);
+            write_chart_dimension(w->clean_name, value);
         }
     }
     write_end_chart();
@@ -247,7 +247,7 @@ void ebpf_process_send_apps_data(struct ebpf_target *root, ebpf_module_t *em)
             if (unlikely(w->exposed && w->processes)) {
                 value = ebpf_process_sum_values_for_pids(w->root_pid, offsetof(ebpf_process_stat_t,
                                                                                task_err));
-                write_chart_dimension(w->name, value);
+                write_chart_dimension(w->clean_name, value);
             }
         }
         write_end_chart();

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -379,49 +379,59 @@ static inline void ebpf_obsolete_shm_cgroup_charts(ebpf_module_t *em) {
  */
 void ebpf_obsolete_shm_apps_charts(struct ebpf_module *em)
 {
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_SHMGET_CHART,
-                              "",
-                              "Calls to syscall <code>shmget(2)</code>.",
-                               EBPF_COMMON_DIMENSION_CALL,
-                               NETDATA_APPS_IPC_SHM_GROUP,
-                               NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                               20191,
-                              em->update_every);
+    struct ebpf_target *w;
+    int update_every = em->update_every;
+    for (w = apps_groups_root_target; w; w = w->next) {
+        uint32_t flag = w->charts_created & (1 << EBPF_MODULE_SHM_IDX);
+        if (likely(w->exposed && w->processes && !flag))
+            continue;
 
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_SHMAT_CHART,
-                              "",
-                              "Calls to syscall <code>shmat(2)</code>.",
-                              EBPF_COMMON_DIMENSION_CALL,
-                              NETDATA_APPS_IPC_SHM_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              20192,
-                              em->update_every);
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_shmget_call",
+                                  "Calls to syscall shmget(2).",
+                                  EBPF_COMMON_DIMENSION_CALL,
+                                  NETDATA_APPS_IPC_SHM_GROUP,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  "ebpf.app_shmget_call",
+                                  20191,
+                                  update_every);
 
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_SHMDT_CHART,
-                              "",
-                              "Calls to syscall <code>shmdt(2)</code>.",
-                              EBPF_COMMON_DIMENSION_CALL,
-                              NETDATA_APPS_IPC_SHM_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              20193,
-                              em->update_every);
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_shmat_call",
+                                  "Calls to syscall shmat(2).",
+                                  EBPF_COMMON_DIMENSION_CALL,
+                                  NETDATA_APPS_IPC_SHM_GROUP,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  "ebpf.app_shmat_call",
+                                  20192,
+                                  update_every);
 
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_SHMCTL_CHART,
-                              "",
-                              "Calls to syscall <code>shmctl(2)</code>.",
-                              EBPF_COMMON_DIMENSION_CALL,
-                              NETDATA_APPS_IPC_SHM_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              20194,
-                              em->update_every);
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_shmdt_call",
+                                  "Calls to syscall shmdt(2).",
+                                  EBPF_COMMON_DIMENSION_CALL,
+                                  NETDATA_APPS_IPC_SHM_GROUP,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  "ebpf.app_shmdt_call",
+                                  20193,
+                                  update_every);
+
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_shmctl_call",
+                                  "Calls to syscall shmctl(2).",
+                                  EBPF_COMMON_DIMENSION_CALL,
+                                  NETDATA_APPS_IPC_SHM_GROUP,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  "ebpf.app_shmctl_call",
+                                  20194,
+                                  update_every);
+
+        w->charts_created &= ~(1<<EBPF_MODULE_SHM_IDX);
+    }
 }
 
 /**
@@ -708,42 +718,28 @@ void ebpf_shm_send_apps_data(struct ebpf_target *root)
 {
     struct ebpf_target *w;
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
-            ebpf_shm_sum_pids(&w->shm, w->root_pid);
-        }
-    }
+        uint32_t flag = w->charts_created & 1<<EBPF_MODULE_SHM_IDX;
+        if (likely(w->exposed && w->processes && !flag))
+            continue;
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMGET_CHART, "");
-    for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->clean_name, (long long) w->shm.get);
-        }
-    }
-    write_end_chart();
+        ebpf_shm_sum_pids(&w->shm, w->root_pid);
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMAT_CHART, "");
-    for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->clean_name, (long long) w->shm.at);
-        }
-    }
-    write_end_chart();
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_shmget_call");
+        write_chart_dimension("calls", (long long) w->shm.get);
+        write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMDT_CHART, "");
-    for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->clean_name, (long long) w->shm.dt);
-        }
-    }
-    write_end_chart();
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_shmat_call");
+        write_chart_dimension("calls", (long long) w->shm.at);
+        write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMCTL_CHART, "");
-    for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->clean_name, (long long) w->shm.ctl);
-        }
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_shmdt_call");
+        write_chart_dimension("calls", (long long) w->shm.dt);
+        write_end_chart();
+
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_shmctl_call");
+        write_chart_dimension("calls", (long long) w->shm.ctl);
+        write_end_chart();
     }
-    write_end_chart();
 }
 
 /**
@@ -1110,41 +1106,74 @@ static void shm_collector(ebpf_module_t *em)
 void ebpf_shm_create_apps_charts(struct ebpf_module *em, void *ptr)
 {
     struct ebpf_target *root = ptr;
-    ebpf_create_charts_on_apps(NETDATA_SHMGET_CHART,
-                               "Calls to syscall <code>shmget(2)</code>.",
-                               EBPF_COMMON_DIMENSION_CALL,
-                               NETDATA_APPS_IPC_SHM_GROUP,
-                               NETDATA_EBPF_CHART_TYPE_STACKED,
-                               20191,
-                               ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                               root, em->update_every, NETDATA_EBPF_MODULE_NAME_SHM);
+    struct ebpf_target *w;
+    int update_every = em->update_every;
+    for (w = root; w; w = w->next) {
+        if (likely(w->exposed && w->processes))
+            continue;
 
-    ebpf_create_charts_on_apps(NETDATA_SHMAT_CHART,
-                               "Calls to syscall <code>shmat(2)</code>.",
-                               EBPF_COMMON_DIMENSION_CALL,
-                               NETDATA_APPS_IPC_SHM_GROUP,
-                               NETDATA_EBPF_CHART_TYPE_STACKED,
-                               20192,
-                               ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                               root, em->update_every, NETDATA_EBPF_MODULE_NAME_SHM);
+        ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                             w->clean_name,
+                             "_shmget_call",
+                             "Calls to syscall shmget(2).",
+                             EBPF_COMMON_DIMENSION_CALL,
+                             NETDATA_APPS_IPC_SHM_GROUP,
+                             NETDATA_EBPF_CHART_TYPE_STACKED,
+                             "ebpf.app_shmget_call",
+                             20191,
+                             update_every,
+                             NETDATA_EBPF_MODULE_NAME_SHM);
+        ebpf_create_chart_labels("app_group", w->name, 0);
+        ebpf_commit_label();
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
-    ebpf_create_charts_on_apps(NETDATA_SHMDT_CHART,
-                               "Calls to syscall <code>shmdt(2)</code>.",
-                               EBPF_COMMON_DIMENSION_CALL,
-                               NETDATA_APPS_IPC_SHM_GROUP,
-                               NETDATA_EBPF_CHART_TYPE_STACKED,
-                               20193,
-                               ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                               root, em->update_every, NETDATA_EBPF_MODULE_NAME_SHM);
+        ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                             w->clean_name,
+                             "_shmat_call",
+                             "Calls to syscall shmat(2).",
+                             EBPF_COMMON_DIMENSION_CALL,
+                             NETDATA_APPS_IPC_SHM_GROUP,
+                             NETDATA_EBPF_CHART_TYPE_STACKED,
+                             "ebpf.app_shmat_call",
+                             20192,
+                             update_every,
+                             NETDATA_EBPF_MODULE_NAME_SHM);
+        ebpf_create_chart_labels("app_group", w->name, 0);
+        ebpf_commit_label();
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
-    ebpf_create_charts_on_apps(NETDATA_SHMCTL_CHART,
-                               "Calls to syscall <code>shmctl(2)</code>.",
-                               EBPF_COMMON_DIMENSION_CALL,
-                               NETDATA_APPS_IPC_SHM_GROUP,
-                               NETDATA_EBPF_CHART_TYPE_STACKED,
-                               20194,
-                               ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                               root, em->update_every, NETDATA_EBPF_MODULE_NAME_SHM);
+        ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                             w->clean_name,
+                             "_shmdt_call",
+                             "Calls to syscall shmdt(2).",
+                             EBPF_COMMON_DIMENSION_CALL,
+                             NETDATA_APPS_IPC_SHM_GROUP,
+                             NETDATA_EBPF_CHART_TYPE_STACKED,
+                             "ebpf.app_shmdt_call",
+                             20193,
+                             update_every,
+                             NETDATA_EBPF_MODULE_NAME_SHM);
+        ebpf_create_chart_labels("app_group", w->name, 0);
+        ebpf_commit_label();
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
+
+        ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                             w->clean_name,
+                             "_shmctl_call",
+                             "Calls to syscall shmctl(2).",
+                             EBPF_COMMON_DIMENSION_CALL,
+                             NETDATA_APPS_IPC_SHM_GROUP,
+                             NETDATA_EBPF_CHART_TYPE_STACKED,
+                             "ebpf.app_shmctl_call",
+                             20194,
+                             update_every,
+                             NETDATA_EBPF_MODULE_NAME_SHM);
+        ebpf_create_chart_labels("app_group", w->name, 0);
+        ebpf_commit_label();
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
+
+        w->charts_created |= 1<<EBPF_MODULE_SHM_IDX;
+    }
 
     em->apps_charts |= NETDATA_EBPF_APPS_FLAG_CHART_CREATED;
 }

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -716,7 +716,7 @@ void ebpf_shm_send_apps_data(struct ebpf_target *root)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMGET_CHART);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->name, (long long) w->shm.get);
+            write_chart_dimension(w->clean_name, (long long) w->shm.get);
         }
     }
     write_end_chart();
@@ -724,7 +724,7 @@ void ebpf_shm_send_apps_data(struct ebpf_target *root)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMAT_CHART);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->name, (long long) w->shm.at);
+            write_chart_dimension(w->clean_name, (long long) w->shm.at);
         }
     }
     write_end_chart();
@@ -732,7 +732,7 @@ void ebpf_shm_send_apps_data(struct ebpf_target *root)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMDT_CHART);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->name, (long long) w->shm.dt);
+            write_chart_dimension(w->clean_name, (long long) w->shm.dt);
         }
     }
     write_end_chart();
@@ -740,7 +740,7 @@ void ebpf_shm_send_apps_data(struct ebpf_target *root)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMCTL_CHART);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->name, (long long) w->shm.ctl);
+            write_chart_dimension(w->clean_name, (long long) w->shm.ctl);
         }
     }
     write_end_chart();

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -306,7 +306,7 @@ static void ebpf_obsolete_shm_services(ebpf_module_t *em)
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SHMGET_CHART,
                               "",
-                              "Calls to syscall <code>shmget(2)</code>.",
+                              "Calls to syscall shmget(2).",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,
                               NETDATA_EBPF_CHART_TYPE_STACKED,
@@ -317,7 +317,7 @@ static void ebpf_obsolete_shm_services(ebpf_module_t *em)
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SHMAT_CHART,
                               "",
-                              "Calls to syscall <code>shmat(2)</code>.",
+                              "Calls to syscall shmat(2).",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,
                               NETDATA_EBPF_CHART_TYPE_STACKED,
@@ -328,7 +328,7 @@ static void ebpf_obsolete_shm_services(ebpf_module_t *em)
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SHMDT_CHART,
                               "",
-                              "Calls to syscall <code>shmdt(2)</code>.",
+                              "Calls to syscall shmdt(2).",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,
                               NETDATA_EBPF_CHART_TYPE_STACKED,
@@ -339,7 +339,7 @@ static void ebpf_obsolete_shm_services(ebpf_module_t *em)
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SHMCTL_CHART,
                               "",
-                              "Calls to syscall <code>shmctl(2)</code>.",
+                              "Calls to syscall shmctl(2).",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,
                               NETDATA_EBPF_CHART_TYPE_STACKED,
@@ -771,7 +771,7 @@ static void ebpf_shm_sum_cgroup_pids(netdata_publish_shm_t *shm, struct pid_on_t
 static void ebpf_create_specific_shm_charts(char *type, int update_every)
 {
     ebpf_create_chart(type, NETDATA_SHMGET_CHART,
-                      "Calls to syscall <code>shmget(2)</code>.",
+                      "Calls to syscall shmget(2).",
                       EBPF_COMMON_DIMENSION_CALL,
                       NETDATA_APPS_IPC_SHM_GROUP,
                       NETDATA_CGROUP_SHM_GET_CONTEXT,
@@ -784,7 +784,7 @@ static void ebpf_create_specific_shm_charts(char *type, int update_every)
                       NETDATA_EBPF_MODULE_NAME_SHM);
 
     ebpf_create_chart(type, NETDATA_SHMAT_CHART,
-                      "Calls to syscall <code>shmat(2)</code>.",
+                      "Calls to syscall shmat(2).",
                       EBPF_COMMON_DIMENSION_CALL,
                       NETDATA_APPS_IPC_SHM_GROUP,
                       NETDATA_CGROUP_SHM_AT_CONTEXT,
@@ -797,7 +797,7 @@ static void ebpf_create_specific_shm_charts(char *type, int update_every)
                       NETDATA_EBPF_MODULE_NAME_SHM);
 
     ebpf_create_chart(type, NETDATA_SHMDT_CHART,
-                      "Calls to syscall <code>shmdt(2)</code>.",
+                      "Calls to syscall shmdt(2).",
                       EBPF_COMMON_DIMENSION_CALL,
                       NETDATA_APPS_IPC_SHM_GROUP,
                       NETDATA_CGROUP_SHM_DT_CONTEXT,
@@ -810,7 +810,7 @@ static void ebpf_create_specific_shm_charts(char *type, int update_every)
                       NETDATA_EBPF_MODULE_NAME_SHM);
 
     ebpf_create_chart(type, NETDATA_SHMCTL_CHART,
-                      "Calls to syscall <code>shmctl(2)</code>.",
+                      "Calls to syscall shmctl(2).",
                       EBPF_COMMON_DIMENSION_CALL,
                       NETDATA_APPS_IPC_SHM_GROUP,
                       NETDATA_CGROUP_SHM_CTL_CONTEXT,
@@ -835,7 +835,7 @@ static void ebpf_obsolete_specific_shm_charts(char *type, int update_every)
 {
     ebpf_write_chart_obsolete(type, NETDATA_SHMGET_CHART,
                               "",
-                              "Calls to syscall <code>shmget(2)</code>.",
+                              "Calls to syscall shmget(2).",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_SHM_GET_CONTEXT,
@@ -843,7 +843,7 @@ static void ebpf_obsolete_specific_shm_charts(char *type, int update_every)
 
     ebpf_write_chart_obsolete(type, NETDATA_SHMAT_CHART,
                               "",
-                              "Calls to syscall <code>shmat(2)</code>.",
+                              "Calls to syscall shmat(2).",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_SHM_AT_CONTEXT,
@@ -851,7 +851,7 @@ static void ebpf_obsolete_specific_shm_charts(char *type, int update_every)
 
     ebpf_write_chart_obsolete(type, NETDATA_SHMDT_CHART,
                               "",
-                              "Calls to syscall <code>shmdt(2)</code>.",
+                              "Calls to syscall shmdt(2).",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_SHM_DT_CONTEXT,
@@ -859,7 +859,7 @@ static void ebpf_obsolete_specific_shm_charts(char *type, int update_every)
 
     ebpf_write_chart_obsolete(type, NETDATA_SHMCTL_CHART,
                               "",
-                              "Calls to syscall <code>shmctl(2)</code>.",
+                              "Calls to syscall shmctl(2).",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_SHM_CTL_CONTEXT,
@@ -876,7 +876,7 @@ static void ebpf_obsolete_specific_shm_charts(char *type, int update_every)
 static void ebpf_create_systemd_shm_charts(int update_every)
 {
     ebpf_create_charts_on_systemd(NETDATA_SHMGET_CHART,
-                                  "Calls to syscall <code>shmget(2)</code>.",
+                                  "Calls to syscall shmget(2).",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_IPC_SHM_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
@@ -885,7 +885,7 @@ static void ebpf_create_systemd_shm_charts(int update_every)
                                   NETDATA_SYSTEMD_SHM_GET_CONTEXT, NETDATA_EBPF_MODULE_NAME_SHM, update_every);
 
     ebpf_create_charts_on_systemd(NETDATA_SHMAT_CHART,
-                                  "Calls to syscall <code>shmat(2)</code>.",
+                                  "Calls to syscall shmat(2).",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_IPC_SHM_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
@@ -894,7 +894,7 @@ static void ebpf_create_systemd_shm_charts(int update_every)
                                   NETDATA_SYSTEMD_SHM_AT_CONTEXT, NETDATA_EBPF_MODULE_NAME_SHM, update_every);
 
     ebpf_create_charts_on_systemd(NETDATA_SHMDT_CHART,
-                                  "Calls to syscall <code>shmdt(2)</code>.",
+                                  "Calls to syscall shmdt(2).",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_IPC_SHM_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
@@ -903,7 +903,7 @@ static void ebpf_create_systemd_shm_charts(int update_every)
                                   NETDATA_SYSTEMD_SHM_DT_CONTEXT, NETDATA_EBPF_MODULE_NAME_SHM, update_every);
 
     ebpf_create_charts_on_systemd(NETDATA_SHMCTL_CHART,
-                                  "Calls to syscall <code>shmctl(2)</code>.",
+                                  "Calls to syscall shmctl(2).",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_IPC_SHM_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -639,7 +639,7 @@ static void read_shm_apps_table(int maps_per_core)
 */
 static void shm_send_global()
 {
-    write_begin_chart(NETDATA_EBPF_SYSTEM_GROUP, NETDATA_SHM_GLOBAL_CHART, "");
+    ebpf_write_begin_chart(NETDATA_EBPF_SYSTEM_GROUP, NETDATA_SHM_GLOBAL_CHART, "");
     write_chart_dimension(
         shm_publish_aggregated[NETDATA_KEY_SHMGET_CALL].dimension,
         (long long) shm_hash_values[NETDATA_KEY_SHMGET_CALL]
@@ -656,7 +656,7 @@ static void shm_send_global()
         shm_publish_aggregated[NETDATA_KEY_SHMCTL_CALL].dimension,
         (long long) shm_hash_values[NETDATA_KEY_SHMCTL_CALL]
     );
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**
@@ -722,21 +722,21 @@ void ebpf_shm_send_apps_data(struct ebpf_target *root)
 
         ebpf_shm_sum_pids(&w->shm, w->root_pid);
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_shmget_call");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_shmget_call");
         write_chart_dimension("calls", (long long) w->shm.get);
-        write_end_chart();
+        ebpf_write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_shmat_call");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_shmat_call");
         write_chart_dimension("calls", (long long) w->shm.at);
-        write_end_chart();
+        ebpf_write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_shmdt_call");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_shmdt_call");
         write_chart_dimension("calls", (long long) w->shm.dt);
-        write_end_chart();
+        ebpf_write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_shmctl_call");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_shmctl_call");
         write_chart_dimension("calls", (long long) w->shm.ctl);
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 }
 
@@ -920,37 +920,37 @@ static void ebpf_create_systemd_shm_charts(int update_every)
 static void ebpf_send_systemd_shm_charts()
 {
     ebpf_cgroup_target_t *ect;
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMGET_CHART, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMGET_CHART, "");
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_shm.get);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMAT_CHART, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMAT_CHART, "");
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_shm.at);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMDT_CHART, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMDT_CHART, "");
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_shm.dt);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMCTL_CHART, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMCTL_CHART, "");
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_shm.ctl);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /*
@@ -963,21 +963,21 @@ static void ebpf_send_systemd_shm_charts()
  */
 static void ebpf_send_specific_shm_data(char *type, netdata_publish_shm_t *values)
 {
-    write_begin_chart(type, NETDATA_SHMGET_CHART, "");
+    ebpf_write_begin_chart(type, NETDATA_SHMGET_CHART, "");
     write_chart_dimension(shm_publish_aggregated[NETDATA_KEY_SHMGET_CALL].name, (long long)values->get);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_SHMAT_CHART, "");
+    ebpf_write_begin_chart(type, NETDATA_SHMAT_CHART, "");
     write_chart_dimension(shm_publish_aggregated[NETDATA_KEY_SHMAT_CALL].name, (long long)values->at);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_SHMDT_CHART, "");
+    ebpf_write_begin_chart(type, NETDATA_SHMDT_CHART, "");
     write_chart_dimension(shm_publish_aggregated[NETDATA_KEY_SHMDT_CALL].name, (long long)values->dt);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_SHMCTL_CHART, "");
+    ebpf_write_begin_chart(type, NETDATA_SHMCTL_CHART, "");
     write_chart_dimension(shm_publish_aggregated[NETDATA_KEY_SHMCTL_CALL].name, (long long)values->ctl);
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -388,45 +388,45 @@ void ebpf_obsolete_shm_apps_charts(struct ebpf_module *em)
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_shmget_call",
+                                  "_ebpf_shmget_call",
                                   "Calls to syscall shmget(2).",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_IPC_SHM_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_shmget_call",
+                                  "app.ebpf_shmget_call",
                                   20191,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_shmat_call",
+                                  "_ebpf_shmat_call",
                                   "Calls to syscall shmat(2).",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_IPC_SHM_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_shmat_call",
+                                  "app.ebpf_shmat_call",
                                   20192,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_shmdt_call",
+                                  "_ebpf_shmdt_call",
                                   "Calls to syscall shmdt(2).",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_IPC_SHM_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_shmdt_call",
+                                  "app.ebpf_shmdt_call",
                                   20193,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_shmctl_call",
+                                  "_ebpf_shmctl_call",
                                   "Calls to syscall shmctl(2).",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_IPC_SHM_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_shmctl_call",
+                                  "app.ebpf_shmctl_call",
                                   20194,
                                   update_every);
 
@@ -724,19 +724,19 @@ void ebpf_shm_send_apps_data(struct ebpf_target *root)
 
         ebpf_shm_sum_pids(&w->shm, w->root_pid);
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_shmget_call");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_shmget_call");
         write_chart_dimension("calls", (long long) w->shm.get);
         write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_shmat_call");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_shmat_call");
         write_chart_dimension("calls", (long long) w->shm.at);
         write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_shmdt_call");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_shmdt_call");
         write_chart_dimension("calls", (long long) w->shm.dt);
         write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_shmctl_call");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_shmctl_call");
         write_chart_dimension("calls", (long long) w->shm.ctl);
         write_end_chart();
     }
@@ -1114,12 +1114,12 @@ void ebpf_shm_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_shmget_call",
+                             "_ebpf_shmget_call",
                              "Calls to syscall shmget(2).",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_APPS_IPC_SHM_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_shmget_call",
+                             "app.ebpf_shmget_call",
                              20191,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SHM);
@@ -1129,12 +1129,12 @@ void ebpf_shm_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_shmat_call",
+                             "_ebpf_shmat_call",
                              "Calls to syscall shmat(2).",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_APPS_IPC_SHM_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_shmat_call",
+                             "app.ebpf_shmat_call",
                              20192,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SHM);
@@ -1144,12 +1144,12 @@ void ebpf_shm_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_shmdt_call",
+                             "_ebpf_shmdt_call",
                              "Calls to syscall shmdt(2).",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_APPS_IPC_SHM_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_shmdt_call",
+                             "app.ebpf_shmdt_call",
                              20193,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SHM);
@@ -1159,12 +1159,12 @@ void ebpf_shm_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_shmctl_call",
+                             "_ebpf_shmctl_call",
                              "Calls to syscall shmctl(2).",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_APPS_IPC_SHM_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_shmctl_call",
+                             "app.ebpf_shmctl_call",
                              20194,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SHM);

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -630,7 +630,7 @@ static void read_shm_apps_table(int maps_per_core)
 */
 static void shm_send_global()
 {
-    write_begin_chart(NETDATA_EBPF_SYSTEM_GROUP, NETDATA_SHM_GLOBAL_CHART);
+    write_begin_chart(NETDATA_EBPF_SYSTEM_GROUP, NETDATA_SHM_GLOBAL_CHART, "");
     write_chart_dimension(
         shm_publish_aggregated[NETDATA_KEY_SHMGET_CALL].dimension,
         (long long) shm_hash_values[NETDATA_KEY_SHMGET_CALL]
@@ -713,7 +713,7 @@ void ebpf_shm_send_apps_data(struct ebpf_target *root)
         }
     }
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMGET_CHART);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMGET_CHART, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             write_chart_dimension(w->clean_name, (long long) w->shm.get);
@@ -721,7 +721,7 @@ void ebpf_shm_send_apps_data(struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMAT_CHART);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMAT_CHART, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             write_chart_dimension(w->clean_name, (long long) w->shm.at);
@@ -729,7 +729,7 @@ void ebpf_shm_send_apps_data(struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMDT_CHART);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMDT_CHART, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             write_chart_dimension(w->clean_name, (long long) w->shm.dt);
@@ -737,7 +737,7 @@ void ebpf_shm_send_apps_data(struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMCTL_CHART);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SHMCTL_CHART, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             write_chart_dimension(w->clean_name, (long long) w->shm.ctl);
@@ -926,7 +926,7 @@ static void ebpf_create_systemd_shm_charts(int update_every)
 static void ebpf_send_systemd_shm_charts()
 {
     ebpf_cgroup_target_t *ect;
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMGET_CHART);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMGET_CHART, "");
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_shm.get);
@@ -934,7 +934,7 @@ static void ebpf_send_systemd_shm_charts()
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMAT_CHART);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMAT_CHART, "");
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_shm.at);
@@ -942,7 +942,7 @@ static void ebpf_send_systemd_shm_charts()
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMDT_CHART);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMDT_CHART, "");
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_shm.dt);
@@ -950,7 +950,7 @@ static void ebpf_send_systemd_shm_charts()
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMCTL_CHART);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SHMCTL_CHART, "");
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_shm.ctl);
@@ -969,19 +969,19 @@ static void ebpf_send_systemd_shm_charts()
  */
 static void ebpf_send_specific_shm_data(char *type, netdata_publish_shm_t *values)
 {
-    write_begin_chart(type, NETDATA_SHMGET_CHART);
+    write_begin_chart(type, NETDATA_SHMGET_CHART, "");
     write_chart_dimension(shm_publish_aggregated[NETDATA_KEY_SHMGET_CALL].name, (long long)values->get);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_SHMAT_CHART);
+    write_begin_chart(type, NETDATA_SHMAT_CHART, "");
     write_chart_dimension(shm_publish_aggregated[NETDATA_KEY_SHMAT_CALL].name, (long long)values->at);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_SHMDT_CHART);
+    write_begin_chart(type, NETDATA_SHMDT_CHART, "");
     write_chart_dimension(shm_publish_aggregated[NETDATA_KEY_SHMDT_CALL].name, (long long)values->dt);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_SHMCTL_CHART);
+    write_begin_chart(type, NETDATA_SHMCTL_CHART, "");
     write_chart_dimension(shm_publish_aggregated[NETDATA_KEY_SHMCTL_CALL].name, (long long)values->ctl);
     write_end_chart();
 }

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -382,8 +382,7 @@ void ebpf_obsolete_shm_apps_charts(struct ebpf_module *em)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = apps_groups_root_target; w; w = w->next) {
-        uint32_t flag = w->charts_created & (1 << EBPF_MODULE_SHM_IDX);
-        if (likely(w->exposed && w->processes && !flag))
+        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_SHM_IDX))))
             continue;
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -718,8 +717,7 @@ void ebpf_shm_send_apps_data(struct ebpf_target *root)
 {
     struct ebpf_target *w;
     for (w = root; w; w = w->next) {
-        uint32_t flag = w->charts_created & 1<<EBPF_MODULE_SHM_IDX;
-        if (likely(w->exposed && w->processes && !flag))
+        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_SHM_IDX))))
             continue;
 
         ebpf_shm_sum_pids(&w->shm, w->root_pid);
@@ -1109,7 +1107,7 @@ void ebpf_shm_create_apps_charts(struct ebpf_module *em, void *ptr)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = root; w; w = w->next) {
-        if (likely(w->exposed && w->processes))
+        if (unlikely(!w->exposed))
             continue;
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,

--- a/collectors/ebpf.plugin/ebpf_shm.c
+++ b/collectors/ebpf.plugin/ebpf_shm.c
@@ -305,6 +305,7 @@ static void ebpf_obsolete_shm_services(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SHMGET_CHART,
+                              "",
                               "Calls to syscall <code>shmget(2)</code>.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,
@@ -315,6 +316,7 @@ static void ebpf_obsolete_shm_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SHMAT_CHART,
+                              "",
                               "Calls to syscall <code>shmat(2)</code>.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,
@@ -325,6 +327,7 @@ static void ebpf_obsolete_shm_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SHMDT_CHART,
+                              "",
                               "Calls to syscall <code>shmdt(2)</code>.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,
@@ -335,6 +338,7 @@ static void ebpf_obsolete_shm_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SHMCTL_CHART,
+                              "",
                               "Calls to syscall <code>shmctl(2)</code>.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,
@@ -377,6 +381,7 @@ void ebpf_obsolete_shm_apps_charts(struct ebpf_module *em)
 {
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_SHMGET_CHART,
+                              "",
                               "Calls to syscall <code>shmget(2)</code>.",
                                EBPF_COMMON_DIMENSION_CALL,
                                NETDATA_APPS_IPC_SHM_GROUP,
@@ -387,6 +392,7 @@ void ebpf_obsolete_shm_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_SHMAT_CHART,
+                              "",
                               "Calls to syscall <code>shmat(2)</code>.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,
@@ -397,6 +403,7 @@ void ebpf_obsolete_shm_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_SHMDT_CHART,
+                              "",
                               "Calls to syscall <code>shmdt(2)</code>.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,
@@ -407,6 +414,7 @@ void ebpf_obsolete_shm_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_SHMCTL_CHART,
+                              "",
                               "Calls to syscall <code>shmctl(2)</code>.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,
@@ -427,6 +435,7 @@ static void ebpf_obsolete_shm_global(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_EBPF_SYSTEM_GROUP,
                               NETDATA_SHM_GLOBAL_CHART,
+                              "",
                               "Calls to shared memory system calls",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_SYSTEM_IPC_SHM_SUBMENU,
@@ -831,6 +840,7 @@ static void ebpf_create_specific_shm_charts(char *type, int update_every)
 static void ebpf_obsolete_specific_shm_charts(char *type, int update_every)
 {
     ebpf_write_chart_obsolete(type, NETDATA_SHMGET_CHART,
+                              "",
                               "Calls to syscall <code>shmget(2)</code>.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,
@@ -838,6 +848,7 @@ static void ebpf_obsolete_specific_shm_charts(char *type, int update_every)
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5800, update_every);
 
     ebpf_write_chart_obsolete(type, NETDATA_SHMAT_CHART,
+                              "",
                               "Calls to syscall <code>shmat(2)</code>.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,
@@ -845,6 +856,7 @@ static void ebpf_obsolete_specific_shm_charts(char *type, int update_every)
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5801, update_every);
 
     ebpf_write_chart_obsolete(type, NETDATA_SHMDT_CHART,
+                              "",
                               "Calls to syscall <code>shmdt(2)</code>.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,
@@ -852,6 +864,7 @@ static void ebpf_obsolete_specific_shm_charts(char *type, int update_every)
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5802, update_every);
 
     ebpf_write_chart_obsolete(type, NETDATA_SHMCTL_CHART,
+                              "",
                               "Calls to syscall <code>shmctl(2)</code>.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_IPC_SHM_GROUP,

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -1073,9 +1073,9 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         ebpf_write_end_chart();
 
         if (tcp_v6_connect_address.type == 'T') {
-            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_tcp_v6_connection");
+            ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_tcp_v6_connection");
             write_chart_dimension("calls", values[1]);
-            write_end_chart();
+            ebpf_write_end_chart();
         }
 
         ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_sock_bytes_sent");
@@ -2278,10 +2278,10 @@ static void ebpf_send_specific_socket_data(char *type, ebpf_socket_publish_apps_
     ebpf_write_end_chart();
 
     if (tcp_v6_connect_address.type == 'T') {
-        write_begin_chart(type, NETDATA_NET_APPS_CONNECTION_TCP_V6, "");
+        ebpf_write_begin_chart(type, NETDATA_NET_APPS_CONNECTION_TCP_V6, "");
         write_chart_dimension(
             socket_publish_aggregated[NETDATA_IDX_TCP_CONNECTION_V6].name, (long long)values->call_tcp_v6_connection);
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 
     ebpf_write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_SENT, "");
@@ -2438,13 +2438,13 @@ static void ebpf_send_systemd_socket_charts()
     ebpf_write_end_chart();
 
     if (tcp_v6_connect_address.type == 'T') {
-        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V6, "");
+        ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V6, "");
         for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {
                 write_chart_dimension(ect->name, (long long)ect->publish_socket.call_tcp_v6_connection);
             }
         }
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 
     ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_SENT, "");

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -651,8 +651,7 @@ void ebpf_socket_obsolete_apps_charts(struct ebpf_module *em)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = apps_groups_root_target; w; w = w->next) {
-        uint32_t flag = w->charts_created & (1 << EBPF_MODULE_SOCKET_IDX);
-        if (likely(w->exposed && w->processes && !flag))
+        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_SOCKET_IDX))))
             continue;
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -1070,8 +1069,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     collected_number values[9];
 
     for (w = root; w; w = w->next) {
-        uint32_t flag = w->charts_created & 1 << EBPF_MODULE_PROCESS_IDX;
-        if (likely(w->exposed && w->processes && !flag))
+        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_SOCKET_IDX))))
             continue;
 
         values[0] = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
@@ -1279,7 +1277,7 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
     int order = 20080;
     int update_every = em->update_every;
     for (w = root; w; w = w->next) {
-        if (likely(w->exposed && w->processes))
+        if (unlikely(!w->exposed))
             continue;
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -527,6 +527,7 @@ static void ebpf_obsolete_systemd_socket_charts(int update_every)
     if (tcp_v6_connect_address.type == 'T') {
         ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                                   NETDATA_NET_APPS_CONNECTION_TCP_V6,
+                                  "",
                                   "Calls to tcp_v6_connection",
                                   EBPF_COMMON_DIMENSION_CONNECTIONS,
                                   NETDATA_APPS_NET_GROUP,
@@ -654,103 +655,104 @@ void ebpf_socket_obsolete_apps_charts(struct ebpf_module *em)
         if (likely(w->exposed && w->processes && !flag))
             continue;
 
-        if (tcp_v6_connect_address.type == 'T') {
-            ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                                  NETDATA_NET_APPS_CONNECTION_TCP_V6,
-                                  "Calls to tcp_v6_connection",
-                                  EBPF_COMMON_DIMENSION_CONNECTIONS,
-                                  NETDATA_APPS_NET_GROUP,
-                                  NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  NULL,
-                                  order++,
-                                  em->update_every);
-        }
-
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_call_tcp_v4_connection",
+                                  "_ebpf_call_tcp_v4_connection",
                                   "Calls to tcp_v4_connection.",
                                   EBPF_COMMON_DIMENSION_CONNECTIONS,
                                   NETDATA_APPS_NET_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_call_tcp_v4_connection",
+                                  "app.ebpf_call_tcp_v4_connection",
                                   order++,
                                   update_every);
 
+        if (tcp_v6_connect_address.type == 'T') {
+            ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                      w->clean_name,
+                                      "_ebpf_call_tcp_v6_connection",
+                                      "Calls to tcp_v6_connection.",
+                                      EBPF_COMMON_DIMENSION_CONNECTIONS,
+                                      NETDATA_APPS_NET_GROUP,
+                                      NETDATA_EBPF_CHART_TYPE_STACKED,
+                                      "app.ebpf_call_tcp_v6_connection",
+                                      order++,
+                                      update_every);
+        }
+
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_sock_bytes_sent",
+                                  "_ebpf_sock_bytes_sent",
                                   "Bytes sent.",
                                   EBPF_COMMON_DIMENSION_BITS,
                                   NETDATA_APPS_NET_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_sock_bytes_sent",
+                                  "app.ebpf_sock_bytes_sent",
                                   order++,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_sock_bytes_received",
+                                  "_ebpf_sock_bytes_received",
                                   "Bytes received.",
                                   EBPF_COMMON_DIMENSION_BITS,
                                   NETDATA_APPS_NET_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_sock_bytes_received",
+                                  "app.ebpf_sock_bytes_received",
                                   order++,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_call_tcp_sendmsg",
+                                  "_ebpf_call_tcp_sendmsg",
                                   "Calls to tcp_sendmsg.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_NET_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_call_tcp_sendmsg",
+                                  "app.ebpf_call_tcp_sendmsg",
                                   order++,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_call_tcp_cleanup_rbuf",
+                                  "_ebpf_call_tcp_cleanup_rbuf",
                                   "Calls to tcp_cleanup_rbuf.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_NET_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_call_tcp_cleanup_rbuf",
+                                  "app.ebpf_call_tcp_cleanup_rbuf",
                                   order++,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_call_tcp_retransmit",
+                                  "_ebpf_call_tcp_retransmit",
                                   "Calls to tcp_retransmit.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_NET_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_call_tcp_retransmit",
+                                  "app.ebpf_call_tcp_retransmit",
                                   order++,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_call_udp_sendmsg",
+                                  "_ebpf_call_udp_sendmsg",
                                   "Calls to udp_sendmsg.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_NET_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_call_udp_sendmsg",
+                                  "app.ebpf_call_udp_sendmsg",
                                   order++,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_call_udp_recvmsg",
+                                  "_ebpf_call_udp_recvmsg",
                                   "Calls to udp_recvmsg.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_APPS_NET_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_call_udp_recvmsg",
+                                  "app.ebpf_call_udp_recvmsg",
                                   order++,
                                   update_every);
 
@@ -1092,8 +1094,8 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         values[8] = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           call_udp_received));
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_tcp_v4_connection");
-        write_chart_dimension("calls", values[0]);
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_tcp_v4_connection");
+        write_chart_dimension("connections", values[0]);
         write_end_chart();
 
         if (tcp_v6_connect_address.type == 'T') {
@@ -1102,33 +1104,33 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
             write_end_chart();
         }
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_sock_bytes_sent");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_sock_bytes_sent");
         // We multiply by 0.008, because we read bytes, but we display bits
         write_chart_dimension("bandwidth", ((values[2])*8)/1000);
         write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_sock_bytes_received");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_sock_bytes_received");
         // We multiply by 0.008, because we read bytes, but we display bits
         write_chart_dimension("bandwidth", ((values[3])*8)/1000);
         write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_tcp_sendmsg");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_tcp_sendmsg");
         write_chart_dimension("calls", values[4]);
         write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_tcp_cleanup_rbuf");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_tcp_cleanup_rbuf");
         write_chart_dimension("calls", values[5]);
         write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_tcp_retransmit");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_tcp_retransmit");
         write_chart_dimension("calls", values[6]);
         write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_udp_sendmsg");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_udp_sendmsg");
         write_chart_dimension("calls", values[7]);
         write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_udp_recvmsg");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_udp_recvmsg");
         write_chart_dimension("calls", values[8]);
         write_end_chart();
     }
@@ -1280,42 +1282,46 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
         if (likely(w->exposed && w->processes))
             continue;
 
-        if (tcp_v6_connect_address.type == 'T') {
-            ebpf_create_charts_on_apps(NETDATA_NET_APPS_CONNECTION_TCP_V6,
-                                      "Calls to tcp_v6_connection",
-                                       EBPF_COMMON_DIMENSION_CONNECTIONS,
-                                       NETDATA_APPS_NET_GROUP,
-                                       NETDATA_EBPF_CHART_TYPE_STACKED,
-                                       order++,
-                                       ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                                       root,
-                                       em->update_every,
-                                       NETDATA_EBPF_MODULE_NAME_SOCKET);
-       }
-
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_call_tcp_v6_connection",
-                             "Calls to tcp_v6_connection.",
+                             "_ebpf_call_tcp_v4_connection",
+                             "Calls to tcp_v4_connection.",
                              EBPF_COMMON_DIMENSION_CONNECTIONS,
                              NETDATA_APPS_NET_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_call_tcp_v6_connection",
+                             "app.ebpf_call_tcp_v4_connection",
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SOCKET);
         ebpf_create_chart_labels("app_group", w->name, 0);
         ebpf_commit_label();
-        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
+        fprintf(stdout, "DIMENSION connections '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
+
+        if (tcp_v6_connect_address.type == 'T') {
+            ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                                 w->clean_name,
+                                 "_ebpf_call_tcp_v6_connection",
+                                 "Calls to tcp_v6_connection.",
+                                 EBPF_COMMON_DIMENSION_CONNECTIONS,
+                                 NETDATA_APPS_NET_GROUP,
+                                 NETDATA_EBPF_CHART_TYPE_STACKED,
+                                 "app.ebpf_call_tcp_v6_connection",
+                                 order++,
+                                 update_every,
+                                 NETDATA_EBPF_MODULE_NAME_SOCKET);
+            ebpf_create_chart_labels("app_group", w->name, 0);
+            ebpf_commit_label();
+            fprintf(stdout, "DIMENSION connections '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
+        }
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_sock_bytes_sent",
+                             "_ebpf_sock_bytes_sent",
                              "Bytes sent.",
                              EBPF_COMMON_DIMENSION_BITS,
                              NETDATA_APPS_NET_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_sock_bytes_sent",
+                             "app.ebpf_sock_bytes_sent",
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SOCKET);
@@ -1325,12 +1331,12 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_sock_bytes_received",
+                             "_ebpf_sock_bytes_received",
                              "Bytes received.",
                              EBPF_COMMON_DIMENSION_BITS,
                              NETDATA_APPS_NET_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_sock_bytes_received",
+                             "app.ebpf_sock_bytes_received",
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SOCKET);
@@ -1340,12 +1346,12 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_call_tcp_sendmsg",
+                             "_ebpf_call_tcp_sendmsg",
                              "Calls to tcp_sendmsg.",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_APPS_NET_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_call_tcp_sendmsg",
+                             "app.ebpf_call_tcp_sendmsg",
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SOCKET);
@@ -1355,12 +1361,12 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_call_tcp_cleanup_rbuf",
+                             "_ebpf_call_tcp_cleanup_rbuf",
                              "Calls to tcp_cleanup_rbuf.",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_APPS_NET_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_call_tcp_cleanup_rbuf",
+                             "app.ebpf_call_tcp_cleanup_rbuf",
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SOCKET);
@@ -1370,12 +1376,12 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_call_tcp_retransmit",
+                             "_ebpf_call_tcp_retransmit",
                              "Calls to tcp_retransmit.",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_APPS_NET_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_call_tcp_retransmit",
+                             "app.ebpf_call_tcp_retransmit",
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SOCKET);
@@ -1385,12 +1391,12 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_call_udp_sendmsg",
+                             "_ebpf_call_udp_sendmsg",
                              "Calls to udp_sendmsg.",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_APPS_NET_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_call_udp_sendmsg",
+                             "app.ebpf_call_udp_sendmsg",
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SOCKET);
@@ -1400,12 +1406,12 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_call_udp_recvmsg",
+                             "_ebpf_call_udp_recvmsg",
                              "Calls to udp_recvmsg.",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_APPS_NET_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_call_udp_recvmsg",
+                             "app.ebpf_call_udp_recvmsg",
                              order,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SOCKET);
@@ -2236,6 +2242,7 @@ static void ebpf_obsolete_specific_socket_charts(char *type, int update_every)
     if (tcp_v6_connect_address.type == 'T') {
         ebpf_write_chart_obsolete(type,
                                   NETDATA_NET_APPS_CONNECTION_TCP_V6,
+                                  "",
                                   "Calls to tcp_v6_connection",
                                   EBPF_COMMON_DIMENSION_CONNECTIONS,
                                   NETDATA_APPS_NET_GROUP,
@@ -2297,7 +2304,7 @@ static void ebpf_send_specific_socket_data(char *type, ebpf_socket_publish_apps_
     write_end_chart();
 
     if (tcp_v6_connect_address.type == 'T') {
-        write_begin_chart(type, NETDATA_NET_APPS_CONNECTION_TCP_V6);
+        write_begin_chart(type, NETDATA_NET_APPS_CONNECTION_TCP_V6, "");
         write_chart_dimension(
             socket_publish_aggregated[NETDATA_IDX_TCP_CONNECTION_V6].name, (long long)values->call_tcp_v6_connection);
         write_end_chart();
@@ -2457,7 +2464,7 @@ static void ebpf_send_systemd_socket_charts()
     write_end_chart();
 
     if (tcp_v6_connect_address.type == 'T') {
-        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V6);
+        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V6, "");
         for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {
                 write_chart_dimension(ect->name, (long long)ect->publish_socket.call_tcp_v6_connection);

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -515,6 +515,7 @@ static void ebpf_obsolete_systemd_socket_charts(int update_every)
     int order = 20080;
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_NET_APPS_CONNECTION_TCP_V4,
+                              "",
                               "Calls to tcp_v4_connection",
                               EBPF_COMMON_DIMENSION_CONNECTIONS,
                               NETDATA_APPS_NET_GROUP,
@@ -537,6 +538,7 @@ static void ebpf_obsolete_systemd_socket_charts(int update_every)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_NET_APPS_BANDWIDTH_RECV,
+                              "",
                               "Bytes received",
                               EBPF_COMMON_DIMENSION_BITS,
                               NETDATA_APPS_NET_GROUP,
@@ -547,6 +549,7 @@ static void ebpf_obsolete_systemd_socket_charts(int update_every)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_NET_APPS_BANDWIDTH_SENT,
+                              "",
                               "Bytes sent",
                               EBPF_COMMON_DIMENSION_BITS,
                               NETDATA_APPS_NET_GROUP,
@@ -557,6 +560,7 @@ static void ebpf_obsolete_systemd_socket_charts(int update_every)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS,
+                              "",
                               "Calls to tcp_cleanup_rbuf.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_NET_GROUP,
@@ -567,6 +571,7 @@ static void ebpf_obsolete_systemd_socket_charts(int update_every)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS,
+                              "",
                               "Calls to tcp_sendmsg.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_NET_GROUP,
@@ -577,6 +582,7 @@ static void ebpf_obsolete_systemd_socket_charts(int update_every)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT,
+                              "",
                               "Calls to tcp_retransmit",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_NET_GROUP,
@@ -587,6 +593,7 @@ static void ebpf_obsolete_systemd_socket_charts(int update_every)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS,
+                              "",
                               "Calls to udp_sendmsg",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_NET_GROUP,
@@ -597,6 +604,7 @@ static void ebpf_obsolete_systemd_socket_charts(int update_every)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS,
+                              "",
                               "Calls to udp_recvmsg",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_NET_GROUP,
@@ -641,6 +649,7 @@ void ebpf_socket_obsolete_apps_charts(struct ebpf_module *em)
     int order = 20080;
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_NET_APPS_CONNECTION_TCP_V4,
+                              "",
                               "Calls to tcp_v4_connection",
                               EBPF_COMMON_DIMENSION_CONNECTIONS,
                               NETDATA_APPS_NET_GROUP,
@@ -663,6 +672,7 @@ void ebpf_socket_obsolete_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_NET_APPS_BANDWIDTH_SENT,
+                              "",
                               "Bytes sent",
                               EBPF_COMMON_DIMENSION_BITS,
                               NETDATA_APPS_NET_GROUP,
@@ -673,6 +683,7 @@ void ebpf_socket_obsolete_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_NET_APPS_BANDWIDTH_RECV,
+                              "",
                                "bytes received",
                               EBPF_COMMON_DIMENSION_BITS,
                               NETDATA_APPS_NET_GROUP,
@@ -683,6 +694,7 @@ void ebpf_socket_obsolete_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS,
+                              "",
                               "Calls for tcp_sendmsg",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_NET_GROUP,
@@ -693,6 +705,7 @@ void ebpf_socket_obsolete_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS,
+                              "",
                               "Calls for tcp_cleanup_rbuf",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_NET_GROUP,
@@ -703,6 +716,7 @@ void ebpf_socket_obsolete_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT,
+                              "",
                               "Calls for tcp_retransmit",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_NET_GROUP,
@@ -713,6 +727,7 @@ void ebpf_socket_obsolete_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS,
+                              "",
                               "Calls for udp_sendmsg",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_NET_GROUP,
@@ -723,6 +738,7 @@ void ebpf_socket_obsolete_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS,
+                              "",
                               "Calls for udp_recvmsg",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_APPS_NET_GROUP,
@@ -744,6 +760,7 @@ static void ebpf_socket_obsolete_global_charts(ebpf_module_t *em)
     int order = 21070;
     ebpf_write_chart_obsolete(NETDATA_EBPF_IP_FAMILY,
                               NETDATA_INBOUND_CONNECTIONS,
+                              "",
                               "Inbound connections.",
                               EBPF_COMMON_DIMENSION_CONNECTIONS,
                               NETDATA_SOCKET_KERNEL_FUNCTIONS,
@@ -754,6 +771,7 @@ static void ebpf_socket_obsolete_global_charts(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_EBPF_IP_FAMILY,
                               NETDATA_TCP_OUTBOUND_CONNECTIONS,
+                              "",
                               "TCP outbound connections.",
                               EBPF_COMMON_DIMENSION_CONNECTIONS,
                               NETDATA_SOCKET_KERNEL_FUNCTIONS,
@@ -765,6 +783,7 @@ static void ebpf_socket_obsolete_global_charts(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_EBPF_IP_FAMILY,
                               NETDATA_TCP_FUNCTION_COUNT,
+                              "",
                               "Calls to internal functions",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_SOCKET_KERNEL_FUNCTIONS,
@@ -775,6 +794,7 @@ static void ebpf_socket_obsolete_global_charts(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_EBPF_IP_FAMILY,
                               NETDATA_TCP_FUNCTION_BITS,
+                              "",
                               "TCP bandwidth",
                               EBPF_COMMON_DIMENSION_BITS,
                               NETDATA_SOCKET_KERNEL_FUNCTIONS,
@@ -786,6 +806,7 @@ static void ebpf_socket_obsolete_global_charts(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_EBPF_IP_FAMILY,
                                   NETDATA_TCP_FUNCTION_ERROR,
+                                  "",
                                   "TCP errors",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_SOCKET_KERNEL_FUNCTIONS,
@@ -797,6 +818,7 @@ static void ebpf_socket_obsolete_global_charts(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_EBPF_IP_FAMILY,
                               NETDATA_TCP_RETRANSMIT,
+                              "",
                               "Packages retransmitted",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_SOCKET_KERNEL_FUNCTIONS,
@@ -807,6 +829,7 @@ static void ebpf_socket_obsolete_global_charts(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_EBPF_IP_FAMILY,
                               NETDATA_UDP_FUNCTION_COUNT,
+                              "",
                               "UDP calls",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_SOCKET_KERNEL_FUNCTIONS,
@@ -817,6 +840,7 @@ static void ebpf_socket_obsolete_global_charts(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_EBPF_IP_FAMILY,
                               NETDATA_UDP_FUNCTION_BITS,
+                              "",
                               "UDP bandwidth",
                               EBPF_COMMON_DIMENSION_BITS,
                               NETDATA_SOCKET_KERNEL_FUNCTIONS,
@@ -828,6 +852,7 @@ static void ebpf_socket_obsolete_global_charts(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_EBPF_IP_FAMILY,
                                   NETDATA_UDP_FUNCTION_ERROR,
+                                  "",
                                   "UDP errors",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_SOCKET_KERNEL_FUNCTIONS,
@@ -2162,7 +2187,7 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
 static void ebpf_obsolete_specific_socket_charts(char *type, int update_every)
 {
     int order_basis = 5300;
-    ebpf_write_chart_obsolete(type, NETDATA_NET_APPS_CONNECTION_TCP_V4, "Calls to tcp_v4_connection",
+    ebpf_write_chart_obsolete(type, NETDATA_NET_APPS_CONNECTION_TCP_V4, "", "Calls to tcp_v4_connection",
                               EBPF_COMMON_DIMENSION_CONNECTIONS, NETDATA_APPS_NET_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_SERVICES_SOCKET_TCP_V4_CONN_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + order_basis++, update_every);
@@ -2179,37 +2204,37 @@ static void ebpf_obsolete_specific_socket_charts(char *type, int update_every)
                                   update_every);
     }
 
-    ebpf_write_chart_obsolete(type, NETDATA_NET_APPS_BANDWIDTH_RECV, "Bytes received",
+    ebpf_write_chart_obsolete(type, NETDATA_NET_APPS_BANDWIDTH_RECV, "", "Bytes received",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_APPS_NET_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_SERVICES_SOCKET_BYTES_RECV_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + order_basis++, update_every);
 
-    ebpf_write_chart_obsolete(type, NETDATA_NET_APPS_BANDWIDTH_SENT,"Bytes sent",
+    ebpf_write_chart_obsolete(type, NETDATA_NET_APPS_BANDWIDTH_SENT, "","Bytes sent",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_APPS_NET_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_SERVICES_SOCKET_BYTES_SEND_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + order_basis++, update_every);
 
-    ebpf_write_chart_obsolete(type, NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS, "Calls to tcp_cleanup_rbuf.",
+    ebpf_write_chart_obsolete(type, NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS, "", "Calls to tcp_cleanup_rbuf.",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_APPS_NET_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_SERVICES_SOCKET_TCP_RECV_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + order_basis++, update_every);
 
-    ebpf_write_chart_obsolete(type, NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS, "Calls to tcp_sendmsg.",
+    ebpf_write_chart_obsolete(type, NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS, "", "Calls to tcp_sendmsg.",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_APPS_NET_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_SERVICES_SOCKET_TCP_SEND_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + order_basis++, update_every);
 
-    ebpf_write_chart_obsolete(type, NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT, "Calls to tcp_retransmit.",
+    ebpf_write_chart_obsolete(type, NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT, "", "Calls to tcp_retransmit.",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_APPS_NET_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_SERVICES_SOCKET_TCP_RETRANSMIT_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + order_basis++, update_every);
 
-    ebpf_write_chart_obsolete(type, NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS, "Calls to udp_sendmsg",
+    ebpf_write_chart_obsolete(type, NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS, "", "Calls to udp_sendmsg",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_APPS_NET_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_SERVICES_SOCKET_UDP_SEND_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + order_basis++, update_every);
 
-    ebpf_write_chart_obsolete(type, NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS, "Calls to udp_recvmsg",
+    ebpf_write_chart_obsolete(type, NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS, "", "Calls to udp_recvmsg",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_APPS_NET_GROUP, NETDATA_EBPF_CHART_TYPE_LINE,
                               NETDATA_SERVICES_SOCKET_UDP_RECV_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + order_basis++, update_every);

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -647,19 +647,15 @@ static inline void ebpf_obsolete_socket_cgroup_charts(ebpf_module_t *em) {
 void ebpf_socket_obsolete_apps_charts(struct ebpf_module *em)
 {
     int order = 20080;
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_NET_APPS_CONNECTION_TCP_V4,
-                              "",
-                              "Calls to tcp_v4_connection",
-                              EBPF_COMMON_DIMENSION_CONNECTIONS,
-                              NETDATA_APPS_NET_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              order++,
-                              em->update_every);
+    struct ebpf_target *w;
+    int update_every = em->update_every;
+    for (w = apps_groups_root_target; w; w = w->next) {
+        uint32_t flag = w->charts_created & (1 << EBPF_MODULE_SOCKET_IDX);
+        if (likely(w->exposed && w->processes && !flag))
+            continue;
 
-    if (tcp_v6_connect_address.type == 'T') {
-        ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
+        if (tcp_v6_connect_address.type == 'T') {
+            ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                                   NETDATA_NET_APPS_CONNECTION_TCP_V6,
                                   "Calls to tcp_v6_connection",
                                   EBPF_COMMON_DIMENSION_CONNECTIONS,
@@ -668,84 +664,98 @@ void ebpf_socket_obsolete_apps_charts(struct ebpf_module *em)
                                   NULL,
                                   order++,
                                   em->update_every);
+        }
+
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_call_tcp_v4_connection",
+                                  "Calls to tcp_v4_connection.",
+                                  EBPF_COMMON_DIMENSION_CONNECTIONS,
+                                  NETDATA_APPS_NET_GROUP,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  "ebpf.app_call_tcp_v4_connection",
+                                  order++,
+                                  update_every);
+
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_sock_bytes_sent",
+                                  "Bytes sent.",
+                                  EBPF_COMMON_DIMENSION_BITS,
+                                  NETDATA_APPS_NET_GROUP,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  "ebpf.app_sock_bytes_sent",
+                                  order++,
+                                  update_every);
+
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_sock_bytes_received",
+                                  "Bytes received.",
+                                  EBPF_COMMON_DIMENSION_BITS,
+                                  NETDATA_APPS_NET_GROUP,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  "ebpf.app_sock_bytes_received",
+                                  order++,
+                                  update_every);
+
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_call_tcp_sendmsg",
+                                  "Calls to tcp_sendmsg.",
+                                  EBPF_COMMON_DIMENSION_CALL,
+                                  NETDATA_APPS_NET_GROUP,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  "ebpf.app_call_tcp_sendmsg",
+                                  order++,
+                                  update_every);
+
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_call_tcp_cleanup_rbuf",
+                                  "Calls to tcp_cleanup_rbuf.",
+                                  EBPF_COMMON_DIMENSION_CALL,
+                                  NETDATA_APPS_NET_GROUP,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  "ebpf.app_call_tcp_cleanup_rbuf",
+                                  order++,
+                                  update_every);
+
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_call_tcp_retransmit",
+                                  "Calls to tcp_retransmit.",
+                                  EBPF_COMMON_DIMENSION_CALL,
+                                  NETDATA_APPS_NET_GROUP,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  "ebpf.app_call_tcp_retransmit",
+                                  order++,
+                                  update_every);
+
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_call_udp_sendmsg",
+                                  "Calls to udp_sendmsg.",
+                                  EBPF_COMMON_DIMENSION_CALL,
+                                  NETDATA_APPS_NET_GROUP,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  "ebpf.app_call_udp_sendmsg",
+                                  order++,
+                                  update_every);
+
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_call_udp_recvmsg",
+                                  "Calls to udp_recvmsg.",
+                                  EBPF_COMMON_DIMENSION_CALL,
+                                  NETDATA_APPS_NET_GROUP,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  "ebpf.app_call_udp_recvmsg",
+                                  order++,
+                                  update_every);
+
+        w->charts_created &= ~(1<<EBPF_MODULE_SOCKET_IDX);
     }
-
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_NET_APPS_BANDWIDTH_SENT,
-                              "",
-                              "Bytes sent",
-                              EBPF_COMMON_DIMENSION_BITS,
-                              NETDATA_APPS_NET_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              order++,
-                              em->update_every);
-
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_NET_APPS_BANDWIDTH_RECV,
-                              "",
-                               "bytes received",
-                              EBPF_COMMON_DIMENSION_BITS,
-                              NETDATA_APPS_NET_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              order++,
-                              em->update_every);
-
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS,
-                              "",
-                              "Calls for tcp_sendmsg",
-                              EBPF_COMMON_DIMENSION_CALL,
-                              NETDATA_APPS_NET_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              order++,
-                              em->update_every);
-
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS,
-                              "",
-                              "Calls for tcp_cleanup_rbuf",
-                              EBPF_COMMON_DIMENSION_CALL,
-                              NETDATA_APPS_NET_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              order++,
-                              em->update_every);
-
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT,
-                              "",
-                              "Calls for tcp_retransmit",
-                              EBPF_COMMON_DIMENSION_CALL,
-                              NETDATA_APPS_NET_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              order++,
-                              em->update_every);
-
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS,
-                              "",
-                              "Calls for udp_sendmsg",
-                              EBPF_COMMON_DIMENSION_CALL,
-                              NETDATA_APPS_NET_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              order++,
-                              em->update_every);
-
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS,
-                              "",
-                              "Calls for udp_recvmsg",
-                              EBPF_COMMON_DIMENSION_CALL,
-                              NETDATA_APPS_NET_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              order++,
-                              em->update_every);
 }
 
 /**

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -1061,7 +1061,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           call_tcp_v4_connection));
-            write_chart_dimension(w->name, value);
+            write_chart_dimension(w->clean_name, value);
         }
     }
     write_end_chart();
@@ -1084,7 +1084,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           bytes_sent));
             // We multiply by 0.008, because we read bytes, but we display bits
-            write_chart_dimension(w->name, ((value)*8)/1000);
+            write_chart_dimension(w->clean_name, ((value)*8)/1000);
         }
     }
     write_end_chart();
@@ -1095,7 +1095,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           bytes_received));
             // We multiply by 0.008, because we read bytes, but we display bits
-            write_chart_dimension(w->name, ((value)*8)/1000);
+            write_chart_dimension(w->clean_name, ((value)*8)/1000);
         }
     }
     write_end_chart();
@@ -1105,7 +1105,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           call_tcp_sent));
-            write_chart_dimension(w->name, value);
+            write_chart_dimension(w->clean_name, value);
         }
     }
     write_end_chart();
@@ -1115,7 +1115,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           call_tcp_received));
-            write_chart_dimension(w->name, value);
+            write_chart_dimension(w->clean_name, value);
         }
     }
     write_end_chart();
@@ -1125,7 +1125,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           retransmit));
-            write_chart_dimension(w->name, value);
+            write_chart_dimension(w->clean_name, value);
         }
     }
     write_end_chart();
@@ -1135,7 +1135,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           call_udp_sent));
-            write_chart_dimension(w->name, value);
+            write_chart_dimension(w->clean_name, value);
         }
     }
     write_end_chart();
@@ -1145,7 +1145,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           call_udp_received));
-            write_chart_dimension(w->name, value);
+            write_chart_dimension(w->clean_name, value);
         }
     }
     write_end_chart();

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -974,7 +974,7 @@ static void ebpf_socket_send_global_inbound_conn()
         move = move->next;
     }
 
-    write_begin_chart(NETDATA_EBPF_IP_FAMILY, NETDATA_INBOUND_CONNECTIONS);
+    write_begin_chart(NETDATA_EBPF_IP_FAMILY, NETDATA_INBOUND_CONNECTIONS, "");
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_INCOMING_CONNECTION_TCP].name, (long long) tcp_conn);
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_INCOMING_CONNECTION_UDP].name, (long long) udp_conn);
     write_end_chart();
@@ -1056,7 +1056,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     struct ebpf_target *w;
     collected_number value;
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V4);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V4, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
@@ -1078,7 +1078,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         write_end_chart();
     }
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_SENT);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_SENT, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
@@ -1089,7 +1089,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_RECV);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_RECV, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
@@ -1100,7 +1100,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
@@ -1110,7 +1110,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
@@ -1120,7 +1120,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
@@ -1130,7 +1130,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
@@ -1140,7 +1140,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
@@ -2250,7 +2250,7 @@ static void ebpf_obsolete_specific_socket_charts(char *type, int update_every)
  */
 static void ebpf_send_specific_socket_data(char *type, ebpf_socket_publish_apps_t *values)
 {
-    write_begin_chart(type, NETDATA_NET_APPS_CONNECTION_TCP_V4);
+    write_begin_chart(type, NETDATA_NET_APPS_CONNECTION_TCP_V4, "");
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_TCP_CONNECTION_V4].name,
                           (long long) values->call_tcp_v4_connection);
     write_end_chart();
@@ -2262,37 +2262,37 @@ static void ebpf_send_specific_socket_data(char *type, ebpf_socket_publish_apps_
         write_end_chart();
     }
 
-    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_SENT);
+    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_SENT, "");
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_TCP_SENDMSG].name,
                           (long long) values->bytes_sent);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_RECV);
+    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_RECV, "");
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_TCP_CLEANUP_RBUF].name,
                           (long long) values->bytes_received);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS);
+    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS, "");
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_TCP_SENDMSG].name,
                           (long long) values->call_tcp_sent);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS);
+    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS, "");
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_TCP_CLEANUP_RBUF].name,
                           (long long) values->call_tcp_received);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT);
+    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT, "");
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_TCP_RETRANSMIT].name,
                           (long long) values->retransmit);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS);
+    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS, "");
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_UDP_SENDMSG].name,
                           (long long) values->call_udp_sent);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS);
+    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS, "");
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_UDP_RECVBUF].name,
                           (long long) values->call_udp_received);
     write_end_chart();
@@ -2407,7 +2407,7 @@ static void ebpf_create_systemd_socket_charts(int update_every)
 static void ebpf_send_systemd_socket_charts()
 {
     ebpf_cgroup_target_t *ect;
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V4);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V4, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.call_tcp_v4_connection);
@@ -2425,7 +2425,7 @@ static void ebpf_send_systemd_socket_charts()
         write_end_chart();
     }
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_SENT);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_SENT, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.bytes_sent);
@@ -2433,7 +2433,7 @@ static void ebpf_send_systemd_socket_charts()
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_RECV);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_RECV, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.bytes_received);
@@ -2441,7 +2441,7 @@ static void ebpf_send_systemd_socket_charts()
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.call_tcp_sent);
@@ -2449,7 +2449,7 @@ static void ebpf_send_systemd_socket_charts()
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.call_tcp_received);
@@ -2457,7 +2457,7 @@ static void ebpf_send_systemd_socket_charts()
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.retransmit);
@@ -2465,7 +2465,7 @@ static void ebpf_send_systemd_socket_charts()
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.call_udp_sent);
@@ -2473,7 +2473,7 @@ static void ebpf_send_systemd_socket_charts()
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.call_udp_received);

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -985,10 +985,10 @@ static void ebpf_socket_send_global_inbound_conn()
         move = move->next;
     }
 
-    write_begin_chart(NETDATA_EBPF_IP_FAMILY, NETDATA_INBOUND_CONNECTIONS, "");
+    ebpf_write_begin_chart(NETDATA_EBPF_IP_FAMILY, NETDATA_INBOUND_CONNECTIONS, "");
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_INCOMING_CONNECTION_TCP].name, (long long) tcp_conn);
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_INCOMING_CONNECTION_UDP].name, (long long) udp_conn);
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**
@@ -1092,9 +1092,9 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         values[8] = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
                                                                           call_udp_received));
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_tcp_v4_connection");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_tcp_v4_connection");
         write_chart_dimension("connections", values[0]);
-        write_end_chart();
+        ebpf_write_end_chart();
 
         if (tcp_v6_connect_address.type == 'T') {
             write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_tcp_v6_connection");
@@ -1102,35 +1102,35 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
             write_end_chart();
         }
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_sock_bytes_sent");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_sock_bytes_sent");
         // We multiply by 0.008, because we read bytes, but we display bits
         write_chart_dimension("bandwidth", ((values[2])*8)/1000);
-        write_end_chart();
+        ebpf_write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_sock_bytes_received");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_sock_bytes_received");
         // We multiply by 0.008, because we read bytes, but we display bits
         write_chart_dimension("bandwidth", ((values[3])*8)/1000);
-        write_end_chart();
+        ebpf_write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_tcp_sendmsg");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_tcp_sendmsg");
         write_chart_dimension("calls", values[4]);
-        write_end_chart();
+        ebpf_write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_tcp_cleanup_rbuf");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_tcp_cleanup_rbuf");
         write_chart_dimension("calls", values[5]);
-        write_end_chart();
+        ebpf_write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_tcp_retransmit");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_tcp_retransmit");
         write_chart_dimension("calls", values[6]);
-        write_end_chart();
+        ebpf_write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_udp_sendmsg");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_udp_sendmsg");
         write_chart_dimension("calls", values[7]);
-        write_end_chart();
+        ebpf_write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_udp_recvmsg");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_udp_recvmsg");
         write_chart_dimension("calls", values[8]);
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 }
 
@@ -2296,10 +2296,10 @@ static void ebpf_obsolete_specific_socket_charts(char *type, int update_every)
  */
 static void ebpf_send_specific_socket_data(char *type, ebpf_socket_publish_apps_t *values)
 {
-    write_begin_chart(type, NETDATA_NET_APPS_CONNECTION_TCP_V4, "");
+    ebpf_write_begin_chart(type, NETDATA_NET_APPS_CONNECTION_TCP_V4, "");
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_TCP_CONNECTION_V4].name,
                           (long long) values->call_tcp_v4_connection);
-    write_end_chart();
+    ebpf_write_end_chart();
 
     if (tcp_v6_connect_address.type == 'T') {
         write_begin_chart(type, NETDATA_NET_APPS_CONNECTION_TCP_V6, "");
@@ -2308,40 +2308,40 @@ static void ebpf_send_specific_socket_data(char *type, ebpf_socket_publish_apps_
         write_end_chart();
     }
 
-    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_SENT, "");
+    ebpf_write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_SENT, "");
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_TCP_SENDMSG].name,
                           (long long) values->bytes_sent);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_RECV, "");
+    ebpf_write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_RECV, "");
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_TCP_CLEANUP_RBUF].name,
                           (long long) values->bytes_received);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS, "");
+    ebpf_write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS, "");
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_TCP_SENDMSG].name,
                           (long long) values->call_tcp_sent);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS, "");
+    ebpf_write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS, "");
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_TCP_CLEANUP_RBUF].name,
                           (long long) values->call_tcp_received);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT, "");
+    ebpf_write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT, "");
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_TCP_RETRANSMIT].name,
                           (long long) values->retransmit);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS, "");
+    ebpf_write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS, "");
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_UDP_SENDMSG].name,
                           (long long) values->call_udp_sent);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS, "");
+    ebpf_write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS, "");
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_UDP_RECVBUF].name,
                           (long long) values->call_udp_received);
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**
@@ -2453,13 +2453,13 @@ static void ebpf_create_systemd_socket_charts(int update_every)
 static void ebpf_send_systemd_socket_charts()
 {
     ebpf_cgroup_target_t *ect;
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V4, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V4, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.call_tcp_v4_connection);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
     if (tcp_v6_connect_address.type == 'T') {
         write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V6, "");
@@ -2471,61 +2471,61 @@ static void ebpf_send_systemd_socket_charts()
         write_end_chart();
     }
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_SENT, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_SENT, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.bytes_sent);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_RECV, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_RECV, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.bytes_received);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.call_tcp_sent);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.call_tcp_received);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.retransmit);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.call_udp_sent);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long)ect->publish_socket.call_udp_received);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**

--- a/collectors/ebpf.plugin/ebpf_socket.h
+++ b/collectors/ebpf.plugin/ebpf_socket.h
@@ -318,10 +318,6 @@ typedef struct netata_socket_plus {
     } socket_string;
 } netdata_socket_plus_t;
 
-enum netdata_udp_ports {
-    NETDATA_EBPF_UDP_PORT = 53
-};
-
 extern ARAL *aral_socket_table;
 
 /**

--- a/collectors/ebpf.plugin/ebpf_softirq.c
+++ b/collectors/ebpf.plugin/ebpf_softirq.c
@@ -71,6 +71,7 @@ static void ebpf_obsolete_softirq_global(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_EBPF_SYSTEM_GROUP,
                               "softirq_latency",
+                              "",
                               "Software IRQ latency",
                               EBPF_COMMON_DIMENSION_MILLISECONDS,
                               "softirqs",

--- a/collectors/ebpf.plugin/ebpf_softirq.c
+++ b/collectors/ebpf.plugin/ebpf_softirq.c
@@ -229,7 +229,7 @@ static void softirq_collector(ebpf_module_t *em)
         pthread_mutex_lock(&lock);
 
         // write dims now for all hitherto discovered IRQs.
-        write_begin_chart(NETDATA_EBPF_SYSTEM_GROUP, "softirq_latency");
+        write_begin_chart(NETDATA_EBPF_SYSTEM_GROUP, "softirq_latency", "");
         softirq_write_dims();
         write_end_chart();
 

--- a/collectors/ebpf.plugin/ebpf_softirq.c
+++ b/collectors/ebpf.plugin/ebpf_softirq.c
@@ -229,9 +229,9 @@ static void softirq_collector(ebpf_module_t *em)
         pthread_mutex_lock(&lock);
 
         // write dims now for all hitherto discovered IRQs.
-        write_begin_chart(NETDATA_EBPF_SYSTEM_GROUP, "softirq_latency", "");
+        ebpf_write_begin_chart(NETDATA_EBPF_SYSTEM_GROUP, "softirq_latency", "");
         softirq_write_dims();
-        write_end_chart();
+        ebpf_write_end_chart();
 
         pthread_mutex_unlock(&lock);
 

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -297,10 +297,10 @@ void ebpf_obsolete_swap_apps_charts(struct ebpf_module *em)
                                   "_ebpf_call_swap_readpage",
                                   "Calls to function swap_readpage.",
                                   EBPF_COMMON_DIMENSION_CALL,
-                                  NETDATA_SWAP_SUBMENU,
+                                  NETDATA_EBPF_MEMORY_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
                                   "app.ebpf_call_swap_readpage",
-                                  20191,
+                                  20070,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -308,10 +308,10 @@ void ebpf_obsolete_swap_apps_charts(struct ebpf_module *em)
                                   "_ebpf_call_swap_writepage",
                                   "Calls to function swap_writepage.",
                                   EBPF_COMMON_DIMENSION_CALL,
-                                  NETDATA_SWAP_SUBMENU,
+                                  NETDATA_EBPF_MEMORY_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
                                   "app.ebpf_call_swap_writepage",
-                                  20192,
+                                  20071,
                                   update_every);
         w->charts_created &= ~(1<<EBPF_MODULE_SWAP_IDX);
     }
@@ -868,10 +868,10 @@ void ebpf_swap_create_apps_charts(struct ebpf_module *em, void *ptr)
                              "_ebpf_call_swap_readpage",
                              "Calls to function swap_readpage.",
                              EBPF_COMMON_DIMENSION_CALL,
-                             NETDATA_SWAP_SUBMENU,
+                             NETDATA_EBPF_MEMORY_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
                              "app.ebpf_call_swap_readpage",
-                             20191,
+                             20070,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SWAP);
         ebpf_create_chart_labels("app_group", w->name, 0);
@@ -883,10 +883,10 @@ void ebpf_swap_create_apps_charts(struct ebpf_module *em, void *ptr)
                              "_ebpf_call_swap_writepage",
                              "Calls to function swap_writepage.",
                              EBPF_COMMON_DIMENSION_CALL,
-                             NETDATA_SWAP_SUBMENU,
+                             NETDATA_EBPF_MEMORY_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
                              "app.ebpf_call_swap_writepage",
-                             20192,
+                             20071,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SWAP);
         ebpf_create_chart_labels("app_group", w->name, 0);

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -289,8 +289,7 @@ void ebpf_obsolete_swap_apps_charts(struct ebpf_module *em)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = apps_groups_root_target; w; w = w->next) {
-        uint32_t flag = w->charts_created & (1 << EBPF_MODULE_SWAP_IDX);
-        if (likely(w->exposed && w->processes && !flag))
+        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_SWAP_IDX))))
             continue;
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -582,8 +581,7 @@ void ebpf_swap_send_apps_data(struct ebpf_target *root)
 {
     struct ebpf_target *w;
     for (w = root; w; w = w->next) {
-        uint32_t flag = w->charts_created & 1<<EBPF_MODULE_SWAP_IDX;
-        if (likely(w->exposed && w->processes && !flag))
+        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_SWAP_IDX))))
             continue;
 
         ebpf_swap_sum_pids(&w->swap, w->root_pid);
@@ -862,7 +860,7 @@ void ebpf_swap_create_apps_charts(struct ebpf_module *em, void *ptr)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = root; w; w = w->next) {
-        if (likely(w->exposed && w->processes))
+        if (unlikely(!w->exposed))
             continue;
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -295,23 +295,23 @@ void ebpf_obsolete_swap_apps_charts(struct ebpf_module *em)
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_call_swap_readpage",
+                                  "_ebpf_call_swap_readpage",
                                   "Calls to function swap_readpage.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_SWAP_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_call_swap_readpage",
+                                  "app.ebpf_call_swap_readpage",
                                   20191,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_call_swap_writepage",
+                                  "_ebpf_call_swap_writepage",
                                   "Calls to function swap_writepage.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_SWAP_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_call_swap_writepage",
+                                  "app.ebpf_call_swap_writepage",
                                   20192,
                                   update_every);
         w->charts_created &= ~(1<<EBPF_MODULE_SWAP_IDX);
@@ -588,11 +588,11 @@ void ebpf_swap_send_apps_data(struct ebpf_target *root)
 
         ebpf_swap_sum_pids(&w->swap, w->root_pid);
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_swap_readpage");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_swap_readpage");
         write_chart_dimension("calls", (long long) w->swap.read);
         write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_swap_writepage");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_swap_writepage");
         write_chart_dimension("calls", (long long) w->swap.write);
         write_end_chart();
     }
@@ -867,12 +867,12 @@ void ebpf_swap_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_call_swap_readpage",
+                             "_ebpf_call_swap_readpage",
                              "Calls to function swap_readpage.",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_SWAP_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_call_swap_readpage",
+                             "app.ebpf_call_swap_readpage",
                              20191,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SWAP);
@@ -882,12 +882,12 @@ void ebpf_swap_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_call_swap_writepage",
+                             "_ebpf_call_swap_writepage",
                              "Calls to function swap_writepage.",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_SWAP_SUBMENU,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_call_swap_writepage",
+                             "app.ebpf_call_swap_writepage",
                              20192,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SWAP);

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -581,7 +581,7 @@ void ebpf_swap_send_apps_data(struct ebpf_target *root)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_MEM_SWAP_READ_CHART);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->name, (long long) w->swap.read);
+            write_chart_dimension(w->clean_name, (long long) w->swap.read);
         }
     }
     write_end_chart();
@@ -589,7 +589,7 @@ void ebpf_swap_send_apps_data(struct ebpf_target *root)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_MEM_SWAP_WRITE_CHART);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->name, (long long) w->swap.write);
+            write_chart_dimension(w->clean_name, (long long) w->swap.write);
         }
     }
     write_end_chart();

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -578,7 +578,7 @@ void ebpf_swap_send_apps_data(struct ebpf_target *root)
         }
     }
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_MEM_SWAP_READ_CHART);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_MEM_SWAP_READ_CHART, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             write_chart_dimension(w->clean_name, (long long) w->swap.read);
@@ -586,7 +586,7 @@ void ebpf_swap_send_apps_data(struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_MEM_SWAP_WRITE_CHART);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_MEM_SWAP_WRITE_CHART, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             write_chart_dimension(w->clean_name, (long long) w->swap.write);
@@ -629,7 +629,7 @@ static void ebpf_swap_sum_cgroup_pids(netdata_publish_swap_t *swap, struct pid_o
 static void ebpf_send_systemd_swap_charts()
 {
     ebpf_cgroup_target_t *ect;
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_MEM_SWAP_READ_CHART);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_MEM_SWAP_READ_CHART, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long) ect->publish_systemd_swap.read);
@@ -637,7 +637,7 @@ static void ebpf_send_systemd_swap_charts()
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_MEM_SWAP_WRITE_CHART);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_MEM_SWAP_WRITE_CHART, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long) ect->publish_systemd_swap.write);
@@ -705,11 +705,11 @@ static void ebpf_obsolete_specific_swap_charts(char *type, int update_every)
  */
 static void ebpf_send_specific_swap_data(char *type, netdata_publish_swap_t *values)
 {
-    write_begin_chart(type, NETDATA_MEM_SWAP_READ_CHART);
+    write_begin_chart(type, NETDATA_MEM_SWAP_READ_CHART, "");
     write_chart_dimension(swap_publish_aggregated[NETDATA_KEY_SWAP_READPAGE_CALL].name, (long long) values->read);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_MEM_SWAP_WRITE_CHART);
+    write_begin_chart(type, NETDATA_MEM_SWAP_WRITE_CHART, "");
     write_chart_dimension(swap_publish_aggregated[NETDATA_KEY_SWAP_WRITEPAGE_CALL].name, (long long) values->write);
     write_end_chart();
 }

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -586,13 +586,13 @@ void ebpf_swap_send_apps_data(struct ebpf_target *root)
 
         ebpf_swap_sum_pids(&w->swap, w->root_pid);
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_swap_readpage");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_swap_readpage");
         write_chart_dimension("calls", (long long) w->swap.read);
-        write_end_chart();
+        ebpf_write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_swap_writepage");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_swap_writepage");
         write_chart_dimension("calls", (long long) w->swap.write);
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 }
 
@@ -630,21 +630,21 @@ static void ebpf_swap_sum_cgroup_pids(netdata_publish_swap_t *swap, struct pid_o
 static void ebpf_send_systemd_swap_charts()
 {
     ebpf_cgroup_target_t *ect;
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_MEM_SWAP_READ_CHART, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_MEM_SWAP_READ_CHART, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long) ect->publish_systemd_swap.read);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_MEM_SWAP_WRITE_CHART, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_MEM_SWAP_WRITE_CHART, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, (long long) ect->publish_systemd_swap.write);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**
@@ -706,13 +706,13 @@ static void ebpf_obsolete_specific_swap_charts(char *type, int update_every)
  */
 static void ebpf_send_specific_swap_data(char *type, netdata_publish_swap_t *values)
 {
-    write_begin_chart(type, NETDATA_MEM_SWAP_READ_CHART, "");
+    ebpf_write_begin_chart(type, NETDATA_MEM_SWAP_READ_CHART, "");
     write_chart_dimension(swap_publish_aggregated[NETDATA_KEY_SWAP_READPAGE_CALL].name, (long long) values->read);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_MEM_SWAP_WRITE_CHART, "");
+    ebpf_write_begin_chart(type, NETDATA_MEM_SWAP_WRITE_CHART, "");
     write_chart_dimension(swap_publish_aggregated[NETDATA_KEY_SWAP_WRITEPAGE_CALL].name, (long long) values->write);
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -235,7 +235,7 @@ static void ebpf_obsolete_swap_services(ebpf_module_t *em)
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_MEM_SWAP_READ_CHART,
                               "",
-                              "Calls to function <code>swap_readpage</code>.",
+                              "Calls to function swap_readpage.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_SYSTEM_CGROUP_SWAP_SUBMENU,
                               NETDATA_EBPF_CHART_TYPE_LINE,
@@ -246,7 +246,7 @@ static void ebpf_obsolete_swap_services(ebpf_module_t *em)
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_MEM_SWAP_WRITE_CHART,
                               "",
-                              "Calls to function <code>swap_writepage</code>.",
+                              "Calls to function swap_writepage.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_SYSTEM_CGROUP_SWAP_SUBMENU,
                               NETDATA_EBPF_CHART_TYPE_LINE,
@@ -658,7 +658,7 @@ static void ebpf_send_systemd_swap_charts()
 static void ebpf_create_specific_swap_charts(char *type, int update_every)
 {
     ebpf_create_chart(type, NETDATA_MEM_SWAP_READ_CHART,
-                      "Calls to function <code>swap_readpage</code>.",
+                      "Calls to function swap_readpage.",
                       EBPF_COMMON_DIMENSION_CALL, NETDATA_SYSTEM_CGROUP_SWAP_SUBMENU,
                       NETDATA_CGROUP_SWAP_READ_CONTEXT, NETDATA_EBPF_CHART_TYPE_LINE,
                       NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5100,
@@ -666,7 +666,7 @@ static void ebpf_create_specific_swap_charts(char *type, int update_every)
                       swap_publish_aggregated, 1, update_every, NETDATA_EBPF_MODULE_NAME_SWAP);
 
     ebpf_create_chart(type, NETDATA_MEM_SWAP_WRITE_CHART,
-                      "Calls to function <code>swap_writepage</code>.",
+                      "Calls to function swap_writepage.",
                       EBPF_COMMON_DIMENSION_CALL, NETDATA_SYSTEM_CGROUP_SWAP_SUBMENU,
                       NETDATA_CGROUP_SWAP_WRITE_CONTEXT, NETDATA_EBPF_CHART_TYPE_LINE,
                       NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5101,
@@ -685,12 +685,12 @@ static void ebpf_create_specific_swap_charts(char *type, int update_every)
  */
 static void ebpf_obsolete_specific_swap_charts(char *type, int update_every)
 {
-    ebpf_write_chart_obsolete(type, NETDATA_MEM_SWAP_READ_CHART, "", "Calls to function <code>swap_readpage</code>.",
+    ebpf_write_chart_obsolete(type, NETDATA_MEM_SWAP_READ_CHART, "", "Calls to function swap_readpage.",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_SYSTEM_CGROUP_SWAP_SUBMENU,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_SWAP_READ_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5100, update_every);
 
-    ebpf_write_chart_obsolete(type, NETDATA_MEM_SWAP_WRITE_CHART, "",  "Calls to function <code>swap_writepage</code>.",
+    ebpf_write_chart_obsolete(type, NETDATA_MEM_SWAP_WRITE_CHART, "",  "Calls to function swap_writepage.",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_SYSTEM_CGROUP_SWAP_SUBMENU,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_SWAP_WRITE_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5101, update_every);
@@ -725,14 +725,14 @@ static void ebpf_send_specific_swap_data(char *type, netdata_publish_swap_t *val
 static void ebpf_create_systemd_swap_charts(int update_every)
 {
     ebpf_create_charts_on_systemd(NETDATA_MEM_SWAP_READ_CHART,
-                                  "Calls to <code>swap_readpage</code>.",
+                                  "Calls to swap_readpage.",
                                   EBPF_COMMON_DIMENSION_CALL, NETDATA_SYSTEM_CGROUP_SWAP_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED, 20191,
                                   ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX], NETDATA_SYSTEMD_SWAP_READ_CONTEXT,
                                   NETDATA_EBPF_MODULE_NAME_SWAP, update_every);
 
     ebpf_create_charts_on_systemd(NETDATA_MEM_SWAP_WRITE_CHART,
-                                  "Calls to function <code>swap_writepage</code>.",
+                                  "Calls to function swap_writepage.",
                                   EBPF_COMMON_DIMENSION_CALL, NETDATA_SYSTEM_CGROUP_SWAP_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_STACKED, 20192,
                                   ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX], NETDATA_SYSTEMD_SWAP_WRITE_CONTEXT,

--- a/collectors/ebpf.plugin/ebpf_swap.c
+++ b/collectors/ebpf.plugin/ebpf_swap.c
@@ -234,6 +234,7 @@ static void ebpf_obsolete_swap_services(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_MEM_SWAP_READ_CHART,
+                              "",
                               "Calls to function <code>swap_readpage</code>.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_SYSTEM_CGROUP_SWAP_SUBMENU,
@@ -244,6 +245,7 @@ static void ebpf_obsolete_swap_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_MEM_SWAP_WRITE_CHART,
+                              "",
                               "Calls to function <code>swap_writepage</code>.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_SYSTEM_CGROUP_SWAP_SUBMENU,
@@ -286,6 +288,7 @@ void ebpf_obsolete_swap_apps_charts(struct ebpf_module *em)
 {
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_MEM_SWAP_READ_CHART,
+                              "",
                               "Calls to function <code>swap_readpage</code>.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_SWAP_SUBMENU,
@@ -296,6 +299,7 @@ void ebpf_obsolete_swap_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_MEM_SWAP_WRITE_CHART,
+                              "",
                               "Calls to function <code>swap_writepage</code>.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_SWAP_SUBMENU,
@@ -316,6 +320,7 @@ static void ebpf_obsolete_swap_global(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_EBPF_MEMORY_GROUP,
                               NETDATA_MEM_SWAP_CHART,
+                              "",
                               "Calls to access swap memory",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_SYSTEM_SWAP_SUBMENU,
                               NETDATA_EBPF_CHART_TYPE_LINE,
@@ -679,12 +684,12 @@ static void ebpf_create_specific_swap_charts(char *type, int update_every)
  */
 static void ebpf_obsolete_specific_swap_charts(char *type, int update_every)
 {
-    ebpf_write_chart_obsolete(type, NETDATA_MEM_SWAP_READ_CHART,"Calls to function <code>swap_readpage</code>.",
+    ebpf_write_chart_obsolete(type, NETDATA_MEM_SWAP_READ_CHART, "", "Calls to function <code>swap_readpage</code>.",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_SYSTEM_CGROUP_SWAP_SUBMENU,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_SWAP_READ_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5100, update_every);
 
-    ebpf_write_chart_obsolete(type, NETDATA_MEM_SWAP_WRITE_CHART, "Calls to function <code>swap_writepage</code>.",
+    ebpf_write_chart_obsolete(type, NETDATA_MEM_SWAP_WRITE_CHART, "",  "Calls to function <code>swap_writepage</code>.",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_SYSTEM_CGROUP_SWAP_SUBMENU,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_SWAP_WRITE_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5101, update_every);

--- a/collectors/ebpf.plugin/ebpf_sync.c
+++ b/collectors/ebpf.plugin/ebpf_sync.c
@@ -610,7 +610,7 @@ static void ebpf_create_sync_chart(char *id,
                                    int end,
                                    int update_every)
 {
-    ebpf_write_chart_cmd(NETDATA_EBPF_MEMORY_GROUP, id, title, EBPF_COMMON_DIMENSION_CALL,
+    ebpf_write_chart_cmd(NETDATA_EBPF_MEMORY_GROUP, id, "", title, EBPF_COMMON_DIMENSION_CALL,
                          NETDATA_EBPF_SYNC_SUBMENU, NETDATA_EBPF_CHART_TYPE_LINE, NULL, order,
                          update_every,
                          NETDATA_EBPF_MODULE_NAME_SYNC);

--- a/collectors/ebpf.plugin/ebpf_sync.c
+++ b/collectors/ebpf.plugin/ebpf_sync.c
@@ -299,7 +299,7 @@ static void ebpf_obsolete_sync_global(ebpf_module_t *em)
         ebpf_write_chart_obsolete(NETDATA_EBPF_MEMORY_GROUP,
                                   NETDATA_EBPF_FILE_SYNC_CHART,
                                   "",
-                                  "Monitor calls for <code>fsync(2)</code> and <code>fdatasync(2)</code>.",
+                                  "Monitor calls to fsync(2) and fdatasync(2).",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_EBPF_SYNC_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_LINE,
@@ -311,7 +311,7 @@ static void ebpf_obsolete_sync_global(ebpf_module_t *em)
         ebpf_write_chart_obsolete(NETDATA_EBPF_MEMORY_GROUP,
                                   NETDATA_EBPF_MSYNC_CHART,
                                   "",
-                               "Monitor calls for <code>msync(2)</code>.",
+                                  "Monitor calls to msync(2).",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_EBPF_SYNC_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_LINE,
@@ -323,7 +323,7 @@ static void ebpf_obsolete_sync_global(ebpf_module_t *em)
         ebpf_write_chart_obsolete(NETDATA_EBPF_MEMORY_GROUP,
                                   NETDATA_EBPF_SYNC_CHART,
                                   "",
-                               "Monitor calls for <code>sync(2)</code> and <code>syncfs(2)</code>.",
+                                  "Monitor calls to sync(2) and syncfs(2).",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_EBPF_SYNC_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_LINE,
@@ -335,7 +335,7 @@ static void ebpf_obsolete_sync_global(ebpf_module_t *em)
         ebpf_write_chart_obsolete(NETDATA_EBPF_MEMORY_GROUP,
                                   NETDATA_EBPF_FILE_SEGMENT_CHART,
                                   "",
-                               "Monitor calls for <code>sync_file_range(2)</code>.",
+                                  "Monitor calls to sync_file_range(2).",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_EBPF_SYNC_SUBMENU,
                                   NETDATA_EBPF_CHART_TYPE_LINE,
@@ -641,22 +641,22 @@ static void ebpf_create_sync_charts(int update_every)
 {
     if (local_syscalls[NETDATA_SYNC_FSYNC_IDX].enabled && local_syscalls[NETDATA_SYNC_FDATASYNC_IDX].enabled)
         ebpf_create_sync_chart(NETDATA_EBPF_FILE_SYNC_CHART,
-                               "Monitor calls for <code>fsync(2)</code> and <code>fdatasync(2)</code>.", 21300,
+                               "Monitor calls to fsync(2) and fdatasync(2).", 21300,
                                NETDATA_SYNC_FSYNC_IDX, NETDATA_SYNC_FDATASYNC_IDX, update_every);
 
     if (local_syscalls[NETDATA_SYNC_MSYNC_IDX].enabled)
         ebpf_create_sync_chart(NETDATA_EBPF_MSYNC_CHART,
-                               "Monitor calls for <code>msync(2)</code>.", 21301,
+                               "Monitor calls to msync(2).", 21301,
                                NETDATA_SYNC_MSYNC_IDX, NETDATA_SYNC_MSYNC_IDX, update_every);
 
     if (local_syscalls[NETDATA_SYNC_SYNC_IDX].enabled && local_syscalls[NETDATA_SYNC_SYNCFS_IDX].enabled)
         ebpf_create_sync_chart(NETDATA_EBPF_SYNC_CHART,
-                               "Monitor calls for <code>sync(2)</code> and <code>syncfs(2)</code>.", 21302,
+                               "Monitor calls to sync(2) and syncfs(2).", 21302,
                                NETDATA_SYNC_SYNC_IDX, NETDATA_SYNC_SYNCFS_IDX, update_every);
 
     if (local_syscalls[NETDATA_SYNC_SYNC_FILE_RANGE_IDX].enabled)
         ebpf_create_sync_chart(NETDATA_EBPF_FILE_SEGMENT_CHART,
-                               "Monitor calls for <code>sync_file_range(2)</code>.", 21303,
+                               "Monitor calls to sync_file_range(2).", 21303,
                                NETDATA_SYNC_SYNC_FILE_RANGE_IDX, NETDATA_SYNC_SYNC_FILE_RANGE_IDX, update_every);
 
     fflush(stdout);

--- a/collectors/ebpf.plugin/ebpf_sync.c
+++ b/collectors/ebpf.plugin/ebpf_sync.c
@@ -298,6 +298,7 @@ static void ebpf_obsolete_sync_global(ebpf_module_t *em)
     if (local_syscalls[NETDATA_SYNC_FSYNC_IDX].enabled && local_syscalls[NETDATA_SYNC_FDATASYNC_IDX].enabled)
         ebpf_write_chart_obsolete(NETDATA_EBPF_MEMORY_GROUP,
                                   NETDATA_EBPF_FILE_SYNC_CHART,
+                                  "",
                                   "Monitor calls for <code>fsync(2)</code> and <code>fdatasync(2)</code>.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_EBPF_SYNC_SUBMENU,
@@ -309,6 +310,7 @@ static void ebpf_obsolete_sync_global(ebpf_module_t *em)
     if (local_syscalls[NETDATA_SYNC_MSYNC_IDX].enabled)
         ebpf_write_chart_obsolete(NETDATA_EBPF_MEMORY_GROUP,
                                   NETDATA_EBPF_MSYNC_CHART,
+                                  "",
                                "Monitor calls for <code>msync(2)</code>.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_EBPF_SYNC_SUBMENU,
@@ -320,6 +322,7 @@ static void ebpf_obsolete_sync_global(ebpf_module_t *em)
     if (local_syscalls[NETDATA_SYNC_SYNC_IDX].enabled && local_syscalls[NETDATA_SYNC_SYNCFS_IDX].enabled)
         ebpf_write_chart_obsolete(NETDATA_EBPF_MEMORY_GROUP,
                                   NETDATA_EBPF_SYNC_CHART,
+                                  "",
                                "Monitor calls for <code>sync(2)</code> and <code>syncfs(2)</code>.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_EBPF_SYNC_SUBMENU,
@@ -331,6 +334,7 @@ static void ebpf_obsolete_sync_global(ebpf_module_t *em)
     if (local_syscalls[NETDATA_SYNC_SYNC_FILE_RANGE_IDX].enabled)
         ebpf_write_chart_obsolete(NETDATA_EBPF_MEMORY_GROUP,
                                   NETDATA_EBPF_FILE_SEGMENT_CHART,
+                                  "",
                                "Monitor calls for <code>sync_file_range(2)</code>.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_EBPF_SYNC_SUBMENU,

--- a/collectors/ebpf.plugin/ebpf_sync.c
+++ b/collectors/ebpf.plugin/ebpf_sync.c
@@ -511,7 +511,7 @@ static void ebpf_send_sync_chart(char *id,
                                    int idx,
                                    int end)
 {
-    write_begin_chart(NETDATA_EBPF_MEMORY_GROUP, id, "");
+    ebpf_write_begin_chart(NETDATA_EBPF_MEMORY_GROUP, id, "");
 
     netdata_publish_syscall_t *move = &sync_counter_publish_aggregated[idx];
 
@@ -523,7 +523,7 @@ static void ebpf_send_sync_chart(char *id,
         idx++;
     }
 
-    write_end_chart();
+    ebpf_write_end_chart();
 }
 
 /**

--- a/collectors/ebpf.plugin/ebpf_sync.c
+++ b/collectors/ebpf.plugin/ebpf_sync.c
@@ -511,7 +511,7 @@ static void ebpf_send_sync_chart(char *id,
                                    int idx,
                                    int end)
 {
-    write_begin_chart(NETDATA_EBPF_MEMORY_GROUP, id);
+    write_begin_chart(NETDATA_EBPF_MEMORY_GROUP, id, "");
 
     netdata_publish_syscall_t *move = &sync_counter_publish_aggregated[idx];
 

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -1127,7 +1127,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         }
     }
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_DELETED);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_DELETED, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             write_chart_dimension(w->clean_name, w->vfs.unlink_call);
@@ -1135,7 +1135,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             write_chart_dimension(w->clean_name, w->vfs.write_call + w->vfs.writev_call);
@@ -1144,7 +1144,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR);
+        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR, "");
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed && w->processes)) {
                 write_chart_dimension(w->clean_name, w->vfs.write_err + w->vfs.writev_err);
@@ -1153,7 +1153,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         write_end_chart();
     }
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             write_chart_dimension(w->clean_name, w->vfs.read_call + w->vfs.readv_call);
@@ -1162,7 +1162,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR);
+        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR, "");
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed && w->processes)) {
                 write_chart_dimension(w->clean_name, w->vfs.read_err + w->vfs.readv_err);
@@ -1171,7 +1171,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         write_end_chart();
     }
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             write_chart_dimension(w->clean_name, w->vfs.write_bytes + w->vfs.writev_bytes);
@@ -1179,7 +1179,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_BYTES);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_BYTES, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             write_chart_dimension(w->clean_name, w->vfs.read_bytes + w->vfs.readv_bytes);
@@ -1187,7 +1187,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             write_chart_dimension(w->clean_name, w->vfs.fsync_call);
@@ -1196,7 +1196,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR);
+        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR, "");
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed && w->processes)) {
                 write_chart_dimension(w->clean_name, w->vfs.fsync_err);
@@ -1205,7 +1205,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         write_end_chart();
     }
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             write_chart_dimension(w->clean_name, w->vfs.open_call);
@@ -1214,7 +1214,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR);
+        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR, "");
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed && w->processes)) {
                 write_chart_dimension(w->clean_name, w->vfs.open_err);
@@ -1223,7 +1223,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         write_end_chart();
     }
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE);
+    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE, "");
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
             write_chart_dimension(w->clean_name, w->vfs.create_call);
@@ -1232,7 +1232,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR);
+        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR, "");
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed && w->processes)) {
                 write_chart_dimension(w->clean_name, w->vfs.create_err);
@@ -1626,75 +1626,75 @@ static void ebpf_obsolete_specific_vfs_charts(char *type, ebpf_module_t *em)
  */
 static void ebpf_send_specific_vfs_data(char *type, netdata_publish_vfs_t *values, ebpf_module_t *em)
 {
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_DELETED);
+    write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_DELETED, "");
     write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_UNLINK].name, (long long)values->unlink_call);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS);
+    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS, "");
     write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_WRITE].name,
                           (long long)values->write_call + (long long)values->writev_call);
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR);
+        write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR, "");
         write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_WRITE].name,
                               (long long)values->write_err + (long long)values->writev_err);
         write_end_chart();
     }
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_READ_CALLS);
+    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_READ_CALLS, "");
     write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_READ].name,
                           (long long)values->read_call + (long long)values->readv_call);
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR);
+        write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR, "");
         write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_READ].name,
                               (long long)values->read_err + (long long)values->readv_err);
         write_end_chart();
     }
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES);
+    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES, "");
     write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_WRITE].name,
                           (long long)values->write_bytes + (long long)values->writev_bytes);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_READ_BYTES);
+    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_READ_BYTES, "");
     write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_READ].name,
                           (long long)values->read_bytes + (long long)values->readv_bytes);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_FSYNC);
+    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_FSYNC, "");
     write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_FSYNC].name,
                           (long long)values->fsync_call);
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR);
+        write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR, "");
         write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_FSYNC].name,
                               (long long)values->fsync_err);
         write_end_chart();
     }
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_OPEN);
+    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_OPEN, "");
     write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_OPEN].name,
                           (long long)values->open_call);
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR);
+        write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR, "");
         write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_OPEN].name,
                               (long long)values->open_err);
         write_end_chart();
     }
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_CREATE);
+    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_CREATE, "");
     write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_CREATE].name,
                           (long long)values->create_call);
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR);
+        write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR, "");
         write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_CREATE].name,
                               (long long)values->create_err);
         write_end_chart();
@@ -1810,7 +1810,7 @@ static void ebpf_create_systemd_vfs_charts(ebpf_module_t *em)
 static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
 {
     ebpf_cgroup_target_t *ect;
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_DELETED);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_DELETED, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.unlink_call);
@@ -1818,7 +1818,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.write_call +
@@ -1828,7 +1828,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR);
+        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR, "");
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {
                 write_chart_dimension(ect->name, ect->publish_systemd_vfs.write_err +
@@ -1838,7 +1838,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
         write_end_chart();
     }
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.read_call +
@@ -1848,7 +1848,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR);
+        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR, "");
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {
                 write_chart_dimension(ect->name, ect->publish_systemd_vfs.read_err +
@@ -1858,7 +1858,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
         write_end_chart();
     }
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.write_bytes +
@@ -1868,7 +1868,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
     write_end_chart();
 
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_BYTES);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_BYTES, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.read_bytes +
@@ -1877,7 +1877,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.fsync_call);
@@ -1886,7 +1886,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR);
+        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR, "");
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {
                 write_chart_dimension(ect->name, ect->publish_systemd_vfs.fsync_err);
@@ -1895,7 +1895,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
         write_end_chart();
     }
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.open_call);
@@ -1904,7 +1904,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR);
+        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR, "");
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {
                 write_chart_dimension(ect->name, ect->publish_systemd_vfs.open_err);
@@ -1913,7 +1913,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
         write_end_chart();
     }
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE);
+    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.create_call);
@@ -1922,7 +1922,7 @@ static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
     write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR);
+        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR, "");
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {
                 write_chart_dimension(ect->name, ect->publish_systemd_vfs.create_err);

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -420,6 +420,7 @@ static void ebpf_obsolete_vfs_services(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SYSCALL_APPS_FILE_DELETED,
+                              "",
                               "Files deleted",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_CGROUP_GROUP,
@@ -430,6 +431,7 @@ static void ebpf_obsolete_vfs_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS,
+                              "",
                               "Write to disk",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_CGROUP_GROUP,
@@ -441,6 +443,7 @@ static void ebpf_obsolete_vfs_services(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                                   NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR,
+                                  "",
                                   "Fails to write",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_CGROUP_GROUP,
@@ -452,6 +455,7 @@ static void ebpf_obsolete_vfs_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SYSCALL_APPS_VFS_READ_CALLS,
+                              "",
                               "Read from disk",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_CGROUP_GROUP,
@@ -463,6 +467,7 @@ static void ebpf_obsolete_vfs_services(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                                   NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR,
+                                  "",
                                   "Fails to read",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_CGROUP_GROUP,
@@ -474,6 +479,7 @@ static void ebpf_obsolete_vfs_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES,
+                              "",
                               "Bytes written on disk",
                               EBPF_COMMON_DIMENSION_BYTES,
                               NETDATA_VFS_CGROUP_GROUP,
@@ -484,6 +490,7 @@ static void ebpf_obsolete_vfs_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SYSCALL_APPS_VFS_READ_BYTES,
+                              "",
                               "Bytes read from disk",
                               EBPF_COMMON_DIMENSION_BYTES,
                               NETDATA_VFS_CGROUP_GROUP,
@@ -494,6 +501,7 @@ static void ebpf_obsolete_vfs_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SYSCALL_APPS_VFS_FSYNC,
+                              "",
                               "Calls to <code>vfs_fsync</code>",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_CGROUP_GROUP,
@@ -505,6 +513,7 @@ static void ebpf_obsolete_vfs_services(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                                   NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR,
+                                  "",
                                   "Sync error",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_CGROUP_GROUP,
@@ -515,6 +524,7 @@ static void ebpf_obsolete_vfs_services(ebpf_module_t *em)
     }
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SYSCALL_APPS_VFS_OPEN,
+                              "",
                               "Calls to <code>vfs_open</code>",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_CGROUP_GROUP,
@@ -526,6 +536,7 @@ static void ebpf_obsolete_vfs_services(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                                   NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR,
+                                  "",
                                   "Open error",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_CGROUP_GROUP,
@@ -537,6 +548,7 @@ static void ebpf_obsolete_vfs_services(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SYSCALL_APPS_VFS_CREATE,
+                              "",
                               "Calls to <code>vfs_create</code>",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_CGROUP_GROUP,
@@ -548,6 +560,7 @@ static void ebpf_obsolete_vfs_services(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                                   NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR,
+                                  "",
                                   "Create error",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_CGROUP_GROUP,
@@ -591,6 +604,7 @@ void ebpf_obsolete_vfs_apps_charts(struct ebpf_module *em)
 {
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_SYSCALL_APPS_FILE_DELETED,
+                              "",
                               "Files deleted",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_GROUP,
@@ -601,6 +615,7 @@ void ebpf_obsolete_vfs_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS,
+                              "",
                               "Write to disk",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_GROUP,
@@ -612,6 +627,7 @@ void ebpf_obsolete_vfs_apps_charts(struct ebpf_module *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                                   NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR,
+                                  "",
                                   "Fails to write",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
@@ -623,6 +639,7 @@ void ebpf_obsolete_vfs_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_SYSCALL_APPS_VFS_READ_CALLS,
+                              "",
                               "Read from disk",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_GROUP,
@@ -634,6 +651,7 @@ void ebpf_obsolete_vfs_apps_charts(struct ebpf_module *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                                   NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR,
+                                  "",
                                   "Fails to read",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
@@ -645,6 +663,7 @@ void ebpf_obsolete_vfs_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES,
+                              "",
                               "Bytes written on disk",
                               EBPF_COMMON_DIMENSION_BYTES,
                               NETDATA_VFS_GROUP,
@@ -655,6 +674,7 @@ void ebpf_obsolete_vfs_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_SYSCALL_APPS_VFS_READ_BYTES,
+                              "",
                               "Bytes read from disk",
                               EBPF_COMMON_DIMENSION_BYTES,
                               NETDATA_VFS_GROUP,
@@ -665,6 +685,7 @@ void ebpf_obsolete_vfs_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_SYSCALL_APPS_VFS_FSYNC,
+                              "",
                               "Calls for <code>vfs_fsync</code>",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_GROUP,
@@ -676,6 +697,7 @@ void ebpf_obsolete_vfs_apps_charts(struct ebpf_module *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                                   NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR,
+                                  "",
                                   "Sync error",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
@@ -687,6 +709,7 @@ void ebpf_obsolete_vfs_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_SYSCALL_APPS_VFS_OPEN,
+                              "",
                               "Calls for <code>vfs_open</code>",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_GROUP,
@@ -698,6 +721,7 @@ void ebpf_obsolete_vfs_apps_charts(struct ebpf_module *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                                   NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR,
+                                  "",
                                   "Open error",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
@@ -709,6 +733,7 @@ void ebpf_obsolete_vfs_apps_charts(struct ebpf_module *em)
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_SYSCALL_APPS_VFS_CREATE,
+                              "",
                               "Calls for <code>vfs_create</code>",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_GROUP,
@@ -720,6 +745,7 @@ void ebpf_obsolete_vfs_apps_charts(struct ebpf_module *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                                   NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR,
+                                  "",
                                   "Create error",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
@@ -741,6 +767,7 @@ static void ebpf_obsolete_vfs_global(ebpf_module_t *em)
 {
     ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                               NETDATA_VFS_FILE_CLEAN_COUNT,
+                              "",
                               "Remove files",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_GROUP,
@@ -751,6 +778,7 @@ static void ebpf_obsolete_vfs_global(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                               NETDATA_VFS_FILE_IO_COUNT,
+                              "",
                               "Calls to IO",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_GROUP,
@@ -761,6 +789,7 @@ static void ebpf_obsolete_vfs_global(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                               NETDATA_VFS_IO_FILE_BYTES,
+                              "",
                               "Bytes written and read",
                               EBPF_COMMON_DIMENSION_BYTES,
                               NETDATA_VFS_GROUP,
@@ -772,6 +801,7 @@ static void ebpf_obsolete_vfs_global(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                                   NETDATA_VFS_FILE_ERR_COUNT,
+                                  "",
                                   "Fails to write or read",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
@@ -783,6 +813,7 @@ static void ebpf_obsolete_vfs_global(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                               NETDATA_VFS_FSYNC,
+                              "",
                               "Calls for <code>vfs_fsync</code>",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_GROUP,
@@ -794,6 +825,7 @@ static void ebpf_obsolete_vfs_global(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                                   NETDATA_VFS_FSYNC_ERR,
+                                  "",
                                   "Fails to synchronize",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
@@ -805,6 +837,7 @@ static void ebpf_obsolete_vfs_global(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                               NETDATA_VFS_OPEN,
+                              "",
                               "Calls for <code>vfs_open</code>",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_GROUP,
@@ -816,6 +849,7 @@ static void ebpf_obsolete_vfs_global(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                                   NETDATA_VFS_OPEN_ERR,
+                                  "",
                                   "Fails to open a file",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
@@ -827,6 +861,7 @@ static void ebpf_obsolete_vfs_global(ebpf_module_t *em)
 
     ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                               NETDATA_VFS_CREATE,
+                              "",
                               "Calls for <code>vfs_create</code>",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_GROUP,
@@ -838,6 +873,7 @@ static void ebpf_obsolete_vfs_global(ebpf_module_t *em)
     if (em->mode < MODE_ENTRY) {
         ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                                   NETDATA_VFS_CREATE_ERR,
+                                  "",
                                   "Fails to create a file.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
@@ -1504,76 +1540,76 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
  */
 static void ebpf_obsolete_specific_vfs_charts(char *type, ebpf_module_t *em)
 {
-    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_FILE_DELETED, "Files deleted",
+    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_FILE_DELETED, "", "Files deleted",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_VFS_UNLINK_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5500, em->update_every);
 
-    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS, "Write to disk",
+    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS, "", "Write to disk",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_VFS_WRITE_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5501, em->update_every);
 
     if (em->mode < MODE_ENTRY) {
-        ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR, "Fails to write",
+        ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR, "", "Fails to write",
                                   EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_VFS_WRITE_ERROR_CONTEXT,
                                   NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5502, em->update_every);
     }
 
-    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_READ_CALLS, "Read from disk",
+    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_READ_CALLS, "", "Read from disk",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_VFS_READ_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5503, em->update_every);
 
     if (em->mode < MODE_ENTRY) {
-        ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR, "Fails to read",
+        ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR, "", "Fails to read",
                                   EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_VFS_READ_ERROR_CONTEXT,
                                   NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5504, em->update_every);
     }
 
-    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES, "Bytes written on disk",
+    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES, "", "Bytes written on disk",
                               EBPF_COMMON_DIMENSION_BYTES, NETDATA_VFS_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_VFS_WRITE_BYTES_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5505, em->update_every);
 
-    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_READ_BYTES, "Bytes read from disk",
+    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_READ_BYTES, "", "Bytes read from disk",
                               EBPF_COMMON_DIMENSION_BYTES, NETDATA_VFS_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_VFS_READ_BYTES_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5506, em->update_every);
 
-    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_FSYNC, "Calls for <code>vfs_fsync</code>",
+    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_FSYNC, "", "Calls for <code>vfs_fsync</code>",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_VFS_FSYNC_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5507, em->update_every);
 
     if (em->mode < MODE_ENTRY) {
-        ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR, "Sync error",
+        ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR, "", "Sync error",
                                   EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_VFS_FSYNC_ERROR_CONTEXT,
                                   NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5508, em->update_every);
     }
 
-    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_OPEN, "Calls for <code>vfs_open</code>",
+    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_OPEN, "", "Calls for <code>vfs_open</code>",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_VFS_OPEN_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5509, em->update_every);
 
     if (em->mode < MODE_ENTRY) {
-        ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR, "Open error",
+        ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR, "", "Open error",
                                   EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_VFS_OPEN_ERROR_CONTEXT,
                                   NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5510, em->update_every);
     }
 
-    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_CREATE, "Calls for <code>vfs_create</code>",
+    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_CREATE, "", "Calls for <code>vfs_create</code>",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_VFS_CREATE_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5511, em->update_every);
 
     if (em->mode < MODE_ENTRY) {
-        ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR, "Create error",
+        ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR, "", "Create error",
                                   EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_VFS_CREATE_ERROR_CONTEXT,
                                   NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5512, em->update_every);

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -1136,66 +1136,66 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
         ebpf_vfs_sum_pids(&w->vfs, w->root_pid);
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_unlink");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_unlink");
         write_chart_dimension("calls", w->vfs.unlink_call);
-        write_end_chart();
+        ebpf_write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_write");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_write");
         write_chart_dimension("calls", w->vfs.write_call + w->vfs.writev_call);
-        write_end_chart();
+        ebpf_write_end_chart();
 
         if (em->mode < MODE_ENTRY) {
-            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_write_error");
+            ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_write_error");
             write_chart_dimension("calls", w->vfs.write_err + w->vfs.writev_err);
-            write_end_chart();
+            ebpf_write_end_chart();
         }
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_read");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_read");
         write_chart_dimension("calls", w->vfs.read_call + w->vfs.readv_call);
-        write_end_chart();
+        ebpf_write_end_chart();
 
         if (em->mode < MODE_ENTRY) {
-            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_read_error");
+            ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_read_error");
             write_chart_dimension("calls", w->vfs.read_err + w->vfs.readv_err);
-            write_end_chart();
+            ebpf_write_end_chart();
         }
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_write_bytes");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_write_bytes");
         write_chart_dimension("writes", w->vfs.write_bytes + w->vfs.writev_bytes);
-        write_end_chart();
+        ebpf_write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_read_bytes");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_read_bytes");
         write_chart_dimension("reads", w->vfs.read_bytes + w->vfs.readv_bytes);
-        write_end_chart();
+        ebpf_write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_fsync");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_fsync");
         write_chart_dimension("calls", w->vfs.fsync_call);
-        write_end_chart();
+        ebpf_write_end_chart();
 
         if (em->mode < MODE_ENTRY) {
-            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_fsync_error");
+            ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_fsync_error");
             write_chart_dimension("calls", w->vfs.fsync_err);
-            write_end_chart();
+            ebpf_write_end_chart();
         }
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_open");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_open");
         write_chart_dimension("calls", w->vfs.open_call);
-        write_end_chart();
+        ebpf_write_end_chart();
 
         if (em->mode < MODE_ENTRY) {
-            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_open_error");
+            ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_open_error");
             write_chart_dimension("calls", w->vfs.open_err);
-            write_end_chart();
+            ebpf_write_end_chart();
         }
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_create");
+        ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_create");
         write_chart_dimension("calls", w->vfs.create_call);
-        write_end_chart();
+        ebpf_write_end_chart();
 
         if (em->mode < MODE_ENTRY) {
-            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_create_error");
+            ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_create_error");
             write_chart_dimension("calls", w->vfs.create_err);
-            write_end_chart();
+            ebpf_write_end_chart();
         }
     }
 }
@@ -1584,78 +1584,78 @@ static void ebpf_obsolete_specific_vfs_charts(char *type, ebpf_module_t *em)
  */
 static void ebpf_send_specific_vfs_data(char *type, netdata_publish_vfs_t *values, ebpf_module_t *em)
 {
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_DELETED, "");
+    ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_FILE_DELETED, "");
     write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_UNLINK].name, (long long)values->unlink_call);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS, "");
+    ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS, "");
     write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_WRITE].name,
                           (long long)values->write_call + (long long)values->writev_call);
-    write_end_chart();
+    ebpf_write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR, "");
+        ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR, "");
         write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_WRITE].name,
                               (long long)values->write_err + (long long)values->writev_err);
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_READ_CALLS, "");
+    ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_READ_CALLS, "");
     write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_READ].name,
                           (long long)values->read_call + (long long)values->readv_call);
-    write_end_chart();
+    ebpf_write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR, "");
+        ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR, "");
         write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_READ].name,
                               (long long)values->read_err + (long long)values->readv_err);
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES, "");
+    ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES, "");
     write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_WRITE].name,
                           (long long)values->write_bytes + (long long)values->writev_bytes);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_READ_BYTES, "");
+    ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_READ_BYTES, "");
     write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_READ].name,
                           (long long)values->read_bytes + (long long)values->readv_bytes);
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_FSYNC, "");
+    ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_FSYNC, "");
     write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_FSYNC].name,
                           (long long)values->fsync_call);
-    write_end_chart();
+    ebpf_write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR, "");
+        ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR, "");
         write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_FSYNC].name,
                               (long long)values->fsync_err);
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_OPEN, "");
+    ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_OPEN, "");
     write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_OPEN].name,
                           (long long)values->open_call);
-    write_end_chart();
+    ebpf_write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR, "");
+        ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR, "");
         write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_OPEN].name,
                               (long long)values->open_err);
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 
-    write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_CREATE, "");
+    ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_CREATE, "");
     write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_CREATE].name,
                           (long long)values->create_call);
-    write_end_chart();
+    ebpf_write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR, "");
+        ebpf_write_begin_chart(type, NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR, "");
         write_chart_dimension(vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_CREATE].name,
                               (long long)values->create_err);
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 }
 
@@ -1768,125 +1768,124 @@ static void ebpf_create_systemd_vfs_charts(ebpf_module_t *em)
 static void ebpf_send_systemd_vfs_charts(ebpf_module_t *em)
 {
     ebpf_cgroup_target_t *ect;
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_DELETED, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_FILE_DELETED, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.unlink_call);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.write_call +
             ect->publish_systemd_vfs.writev_call);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR, "");
+        ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR, "");
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {
                 write_chart_dimension(ect->name, ect->publish_systemd_vfs.write_err +
                 ect->publish_systemd_vfs.writev_err);
             }
         }
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.read_call +
             ect->publish_systemd_vfs.readv_call);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR, "");
+        ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR, "");
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {
                 write_chart_dimension(ect->name, ect->publish_systemd_vfs.read_err +
                 ect->publish_systemd_vfs.readv_err);
             }
         }
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.write_bytes +
             ect->publish_systemd_vfs.writev_bytes);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_BYTES, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_BYTES, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.read_bytes +
             ect->publish_systemd_vfs.readv_bytes);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.fsync_call);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR, "");
+        ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR, "");
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {
                 write_chart_dimension(ect->name, ect->publish_systemd_vfs.fsync_err);
             }
         }
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.open_call);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR, "");
+        ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR, "");
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {
                 write_chart_dimension(ect->name, ect->publish_systemd_vfs.open_err);
             }
         }
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE, "");
+    ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE, "");
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
         if (unlikely(ect->systemd) && unlikely(ect->updated)) {
             write_chart_dimension(ect->name, ect->publish_systemd_vfs.create_call);
         }
     }
-    write_end_chart();
+    ebpf_write_end_chart();
 
     if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR, "");
+        ebpf_write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR, "");
         for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {
                 write_chart_dimension(ect->name, ect->publish_systemd_vfs.create_err);
             }
         }
-        write_end_chart();
+        ebpf_write_end_chart();
     }
 }
 

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -606,8 +606,7 @@ void ebpf_obsolete_vfs_apps_charts(struct ebpf_module *em)
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = apps_groups_root_target; w; w = w->next) {
-        uint32_t flag = w->charts_created & (1 << EBPF_MODULE_SOCKET_IDX);
-        if (likely(w->exposed && w->processes && !flag))
+        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_VFS_IDX))))
             continue;
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
@@ -1132,8 +1131,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 {
     struct ebpf_target *w;
     for (w = root; w; w = w->next) {
-        uint32_t flag = w->charts_created & 1 << EBPF_MODULE_VFS_IDX;
-        if (likely(w->exposed && w->processes && !flag))
+        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_VFS_IDX))))
             continue;
 
         ebpf_vfs_sum_pids(&w->vfs, w->root_pid);
@@ -2188,7 +2186,7 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
     int order = 20065;
     int update_every = em->update_every;
     for (w = root; w; w = w->next) {
-        if (likely(w->exposed && w->processes))
+        if (unlikely(!w->exposed))
             continue;
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -1130,7 +1130,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_DELETED);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->name, w->vfs.unlink_call);
+            write_chart_dimension(w->clean_name, w->vfs.unlink_call);
         }
     }
     write_end_chart();
@@ -1138,7 +1138,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->name, w->vfs.write_call + w->vfs.writev_call);
+            write_chart_dimension(w->clean_name, w->vfs.write_call + w->vfs.writev_call);
         }
     }
     write_end_chart();
@@ -1147,7 +1147,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR);
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed && w->processes)) {
-                write_chart_dimension(w->name, w->vfs.write_err + w->vfs.writev_err);
+                write_chart_dimension(w->clean_name, w->vfs.write_err + w->vfs.writev_err);
             }
         }
         write_end_chart();
@@ -1156,7 +1156,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->name, w->vfs.read_call + w->vfs.readv_call);
+            write_chart_dimension(w->clean_name, w->vfs.read_call + w->vfs.readv_call);
         }
     }
     write_end_chart();
@@ -1165,7 +1165,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR);
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed && w->processes)) {
-                write_chart_dimension(w->name, w->vfs.read_err + w->vfs.readv_err);
+                write_chart_dimension(w->clean_name, w->vfs.read_err + w->vfs.readv_err);
             }
         }
         write_end_chart();
@@ -1174,7 +1174,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->name, w->vfs.write_bytes + w->vfs.writev_bytes);
+            write_chart_dimension(w->clean_name, w->vfs.write_bytes + w->vfs.writev_bytes);
         }
     }
     write_end_chart();
@@ -1182,7 +1182,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_BYTES);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->name, w->vfs.read_bytes + w->vfs.readv_bytes);
+            write_chart_dimension(w->clean_name, w->vfs.read_bytes + w->vfs.readv_bytes);
         }
     }
     write_end_chart();
@@ -1190,7 +1190,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->name, w->vfs.fsync_call);
+            write_chart_dimension(w->clean_name, w->vfs.fsync_call);
         }
     }
     write_end_chart();
@@ -1199,7 +1199,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR);
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed && w->processes)) {
-                write_chart_dimension(w->name, w->vfs.fsync_err);
+                write_chart_dimension(w->clean_name, w->vfs.fsync_err);
             }
         }
         write_end_chart();
@@ -1208,7 +1208,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->name, w->vfs.open_call);
+            write_chart_dimension(w->clean_name, w->vfs.open_call);
         }
     }
     write_end_chart();
@@ -1217,7 +1217,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR);
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed && w->processes)) {
-                write_chart_dimension(w->name, w->vfs.open_err);
+                write_chart_dimension(w->clean_name, w->vfs.open_err);
             }
         }
         write_end_chart();
@@ -1226,7 +1226,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE);
     for (w = root; w; w = w->next) {
         if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->name, w->vfs.create_call);
+            write_chart_dimension(w->clean_name, w->vfs.create_call);
         }
     }
     write_end_chart();
@@ -1235,7 +1235,7 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
         write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR);
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed && w->processes)) {
-                write_chart_dimension(w->name, w->vfs.create_err);
+                write_chart_dimension(w->clean_name, w->vfs.create_err);
             }
         }
         write_end_chart();

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -612,153 +612,153 @@ void ebpf_obsolete_vfs_apps_charts(struct ebpf_module *em)
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_call_vfs_unlink",
+                                  "_ebpf_call_vfs_unlink",
                                   "Files deleted.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_call_vfs_unlink",
+                                  "app.ebpf_call_vfs_unlink",
                                   order++,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_call_vfs_write",
+                                  "_ebpf_call_vfs_write",
                                   "Write to disk.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_call_vfs_write",
+                                  "app.ebpf_call_vfs_write",
                                   order++,
                                   update_every);
 
         if (em->mode < MODE_ENTRY) {
             ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                       w->clean_name,
-                                      "_call_vfs_write_error",
+                                      "_ebpf_call_vfs_write_error",
                                       "Fails to write.",
                                       EBPF_COMMON_DIMENSION_CALL,
                                       NETDATA_VFS_GROUP,
                                       NETDATA_EBPF_CHART_TYPE_STACKED,
-                                      "ebpf.app_call_vfs_write_error",
+                                      "app.ebpf_call_vfs_write_error",
                                       order++,
                                       update_every);
         }
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_call_vfs_read",
+                                  "_ebpf_call_vfs_read",
                                   "Read from disk.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_call_vfs_read",
+                                  "app.ebpf_call_vfs_read",
                                   order++,
                                   update_every);
 
         if (em->mode < MODE_ENTRY) {
             ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                       w->clean_name,
-                                      "_call_vfs_read_error",
+                                      "_ebpf_call_vfs_read_error",
                                       "Fails to read.",
                                       EBPF_COMMON_DIMENSION_CALL,
                                       NETDATA_VFS_GROUP,
                                       NETDATA_EBPF_CHART_TYPE_STACKED,
-                                      "ebpf.app_call_vfs_read_error",
+                                      "app.ebpf_call_vfs_read_error",
                                       order++,
                                       update_every);
         }
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_call_vfs_write_bytes",
+                                  "_ebpf_call_vfs_write_bytes",
                                   "Bytes written on disk.",
                                   EBPF_COMMON_DIMENSION_BYTES,
                                   NETDATA_VFS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_call_vfs_write_bytes",
+                                  "app.ebpf_call_vfs_write_bytes",
                                   order++,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_call_vfs_read_bytes",
+                                  "_ebpf_call_vfs_read_bytes",
                                   "Bytes read from disk.",
                                   EBPF_COMMON_DIMENSION_BYTES,
                                   NETDATA_VFS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_call_vfs_read_bytes",
+                                  "app.ebpf_call_vfs_read_bytes",
                                   order++,
                                   update_every);
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_call_vfs_fsync",
+                                  "_ebpf_call_vfs_fsync",
                                   "Calls to vfs_fsync.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_call_vfs_fsync",
+                                  "app.ebpf_call_vfs_fsync",
                                   order++,
                                   update_every);
 
         if (em->mode < MODE_ENTRY) {
             ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                       w->clean_name,
-                                      "_call_vfs_fsync_error",
+                                      "_ebpf_call_vfs_fsync_error",
                                       "Fails to sync.",
                                       EBPF_COMMON_DIMENSION_CALL,
                                       NETDATA_VFS_GROUP,
                                       NETDATA_EBPF_CHART_TYPE_STACKED,
-                                      "ebpf.app_call_vfs_fsync_error",
+                                      "app.ebpf_call_vfs_fsync_error",
                                       order++,
                                       update_every);
         }
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_call_vfs_open",
+                                  "_ebpf_call_vfs_open",
                                   "Calls to vfs_open.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_call_vfs_open",
+                                  "app.ebpf_call_vfs_open",
                                   order++,
                                   update_every);
 
         if (em->mode < MODE_ENTRY) {
             ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                       w->clean_name,
-                                      "_call_vfs_open_error",
+                                      "_ebpf_call_vfs_open_error",
                                       "Fails to open.",
                                       EBPF_COMMON_DIMENSION_CALL,
                                       NETDATA_VFS_GROUP,
                                       NETDATA_EBPF_CHART_TYPE_STACKED,
-                                      "ebpf.app_call_vfs_open_error",
+                                      "app.ebpf_call_vfs_open_error",
                                       order++,
                                       update_every);
         }
 
         ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                   w->clean_name,
-                                  "_call_vfs_create",
+                                  "_ebpf_call_vfs_create",
                                   "Calls to vfs_create.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  "ebpf.app_call_vfs_create",
+                                  "app.ebpf_call_vfs_create",
                                   order++,
                                   update_every);
 
         if (em->mode < MODE_ENTRY) {
             ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
                                       w->clean_name,
-                                      "_call_vfs_create_error",
+                                      "_ebpf_call_vfs_create_error",
                                       "Fails to create.",
                                       EBPF_COMMON_DIMENSION_CALL,
                                       NETDATA_VFS_GROUP,
                                       NETDATA_EBPF_CHART_TYPE_STACKED,
-                                      "ebpf.app_call_vfs_create_error",
+                                      "app.ebpf_call_vfs_create_error",
                                       order++,
                                       update_every);
         }
@@ -1138,64 +1138,64 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 
         ebpf_vfs_sum_pids(&w->vfs, w->root_pid);
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_unlink");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_unlink");
         write_chart_dimension("calls", w->vfs.unlink_call);
         write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_write");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_write");
         write_chart_dimension("calls", w->vfs.write_call + w->vfs.writev_call);
         write_end_chart();
 
         if (em->mode < MODE_ENTRY) {
-            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_write_error");
+            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_write_error");
             write_chart_dimension("calls", w->vfs.write_err + w->vfs.writev_err);
             write_end_chart();
         }
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_read");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_read");
         write_chart_dimension("calls", w->vfs.read_call + w->vfs.readv_call);
         write_end_chart();
 
         if (em->mode < MODE_ENTRY) {
-            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_read_error");
+            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_read_error");
             write_chart_dimension("calls", w->vfs.read_err + w->vfs.readv_err);
             write_end_chart();
         }
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_write_bytes");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_write_bytes");
         write_chart_dimension("writes", w->vfs.write_bytes + w->vfs.writev_bytes);
         write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_read_bytes");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_read_bytes");
         write_chart_dimension("reads", w->vfs.read_bytes + w->vfs.readv_bytes);
         write_end_chart();
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_fsync");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_fsync");
         write_chart_dimension("calls", w->vfs.fsync_call);
         write_end_chart();
 
         if (em->mode < MODE_ENTRY) {
-            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_fsync_error");
+            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_fsync_error");
             write_chart_dimension("calls", w->vfs.fsync_err);
             write_end_chart();
         }
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_open");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_open");
         write_chart_dimension("calls", w->vfs.open_call);
         write_end_chart();
 
         if (em->mode < MODE_ENTRY) {
-            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_open_error");
+            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_open_error");
             write_chart_dimension("calls", w->vfs.open_err);
             write_end_chart();
         }
 
-        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_create");
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_create");
         write_chart_dimension("calls", w->vfs.create_call);
         write_end_chart();
 
         if (em->mode < MODE_ENTRY) {
-            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_create_error");
+            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_vfs_create_error");
             write_chart_dimension("calls", w->vfs.create_err);
             write_end_chart();
         }
@@ -2193,12 +2193,12 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_call_vfs_unlink",
+                             "_ebpf_call_vfs_unlink",
                              "Files deleted.",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_VFS_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_call_vfs_unlink",
+                             "app.ebpf_call_vfs_unlink",
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_VFS);
@@ -2208,12 +2208,12 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_call_vfs_write",
+                             "_ebpf_call_vfs_write",
                              "Write to disk.",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_VFS_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_call_vfs_write",
+                             "app.ebpf_call_vfs_write",
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_VFS);
@@ -2224,12 +2224,12 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
         if (em->mode < MODE_ENTRY) {
             ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                                  w->clean_name,
-                                 "_call_vfs_write_error",
+                                 "_ebpf_call_vfs_write_error",
                                  "Fails to write.",
                                  EBPF_COMMON_DIMENSION_CALL,
                                  NETDATA_VFS_GROUP,
                                  NETDATA_EBPF_CHART_TYPE_STACKED,
-                                 "ebpf.app_call_vfs_write_error",
+                                 "app.ebpf_call_vfs_write_error",
                                  order++,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_VFS);
@@ -2240,12 +2240,12 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_call_vfs_read",
+                             "_ebpf_call_vfs_read",
                              "Read from disk.",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_VFS_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_call_vfs_read",
+                             "app.ebpf_call_vfs_read",
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_VFS);
@@ -2256,12 +2256,12 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
         if (em->mode < MODE_ENTRY) {
             ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                                  w->clean_name,
-                                 "_call_vfs_read_error",
+                                 "_ebpf_call_vfs_read_error",
                                  "Fails to read.",
                                  EBPF_COMMON_DIMENSION_CALL,
                                  NETDATA_VFS_GROUP,
                                  NETDATA_EBPF_CHART_TYPE_STACKED,
-                                 "ebpf.app_call_vfs_read_error",
+                                 "app.ebpf_call_vfs_read_error",
                                  order++,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_VFS);
@@ -2272,12 +2272,12 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_call_vfs_write_bytes",
+                             "_ebpf_call_vfs_write_bytes",
                              "Bytes written on disk.",
                              EBPF_COMMON_DIMENSION_BYTES,
                              NETDATA_VFS_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_call_vfs_write_bytes",
+                             "app.ebpf_call_vfs_write_bytes",
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_VFS);
@@ -2287,12 +2287,12 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_call_vfs_read_bytes",
+                             "_ebpf_call_vfs_read_bytes",
                              "Bytes read from disk.",
                              EBPF_COMMON_DIMENSION_BYTES,
                              NETDATA_VFS_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_call_vfs_read_bytes",
+                             "app.ebpf_call_vfs_read_bytes",
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_VFS);
@@ -2302,12 +2302,12 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_call_vfs_fsync",
+                             "_ebpf_call_vfs_fsync",
                              "Calls to vfs_fsync.",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_VFS_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_call_vfs_fsync",
+                             "app.ebpf_call_vfs_fsync",
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_VFS);
@@ -2318,12 +2318,12 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
         if (em->mode < MODE_ENTRY) {
             ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                                  w->clean_name,
-                                 "_call_vfs_fsync_error",
+                                 "_ebpf_call_vfs_fsync_error",
                                  "Fails to sync.",
                                  EBPF_COMMON_DIMENSION_CALL,
                                  NETDATA_VFS_GROUP,
                                  NETDATA_EBPF_CHART_TYPE_STACKED,
-                                 "ebpf.app_call_vfs_fsync_error",
+                                 "app.ebpf_call_vfs_fsync_error",
                                  order++,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_VFS);
@@ -2334,12 +2334,12 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_call_vfs_open",
+                             "_ebpf_call_vfs_open",
                              "Calls to vfs_open.",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_VFS_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_call_vfs_open",
+                             "app.ebpf_call_vfs_open",
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_VFS);
@@ -2350,12 +2350,12 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
         if (em->mode < MODE_ENTRY) {
             ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                                  w->clean_name,
-                                 "_call_vfs_open_error",
+                                 "_ebpf_call_vfs_open_error",
                                  "Fails to open.",
                                  EBPF_COMMON_DIMENSION_CALL,
                                  NETDATA_VFS_GROUP,
                                  NETDATA_EBPF_CHART_TYPE_STACKED,
-                                 "ebpf.app_call_vfs_open_error",
+                                 "app.ebpf_call_vfs_open_error",
                                  order++,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_VFS);
@@ -2366,12 +2366,12 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
-                             "_call_vfs_create",
+                             "_ebpf_call_vfs_create",
                              "Calls to vfs_create.",
                              EBPF_COMMON_DIMENSION_CALL,
                              NETDATA_VFS_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                             "ebpf.app_call_vfs_create",
+                             "app.ebpf_call_vfs_create",
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_VFS);
@@ -2382,12 +2382,12 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
         if (em->mode < MODE_ENTRY) {
             ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                                  w->clean_name,
-                                 "_call_vfs_create_error",
+                                 "_ebpf_call_vfs_create_error",
                                  "Fails to create a file.",
                                  EBPF_COMMON_DIMENSION_CALL,
                                  NETDATA_VFS_GROUP,
                                  NETDATA_EBPF_CHART_TYPE_STACKED,
-                                 "ebpf.app_call_vfs_create_error",
+                                 "app.ebpf_call_vfs_create_error",
                                  order++,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_VFS);

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -602,157 +602,167 @@ static inline void ebpf_obsolete_vfs_cgroup_charts(ebpf_module_t *em) {
  */
 void ebpf_obsolete_vfs_apps_charts(struct ebpf_module *em)
 {
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_SYSCALL_APPS_FILE_DELETED,
-                              "",
-                              "Files deleted",
-                              EBPF_COMMON_DIMENSION_CALL,
-                              NETDATA_VFS_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              20065,
-                              em->update_every);
+    int order = 20065;
+    struct ebpf_target *w;
+    int update_every = em->update_every;
+    for (w = apps_groups_root_target; w; w = w->next) {
+        uint32_t flag = w->charts_created & (1 << EBPF_MODULE_SOCKET_IDX);
+        if (likely(w->exposed && w->processes && !flag))
+            continue;
 
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS,
-                              "",
-                              "Write to disk",
-                              EBPF_COMMON_DIMENSION_CALL,
-                              NETDATA_VFS_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              20066,
-                              em->update_every);
-
-    if (em->mode < MODE_ENTRY) {
-        ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                                  NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR,
-                                  "",
-                                  "Fails to write",
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_call_vfs_unlink",
+                                  "Files deleted.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  NULL,
-                                  20067,
-                                  em->update_every);
-    }
+                                  "ebpf.app_call_vfs_unlink",
+                                  order++,
+                                  update_every);
 
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_SYSCALL_APPS_VFS_READ_CALLS,
-                              "",
-                              "Read from disk",
-                              EBPF_COMMON_DIMENSION_CALL,
-                              NETDATA_VFS_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              20068,
-                              em->update_every);
-
-    if (em->mode < MODE_ENTRY) {
-        ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                                  NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR,
-                                  "",
-                                  "Fails to read",
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_call_vfs_write",
+                                  "Write to disk.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  NULL,
-                                  20069,
-                                  em->update_every);
-    }
+                                  "ebpf.app_call_vfs_write",
+                                  order++,
+                                  update_every);
 
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES,
-                              "",
-                              "Bytes written on disk",
-                              EBPF_COMMON_DIMENSION_BYTES,
-                              NETDATA_VFS_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              20070,
-                              em->update_every);
+        if (em->mode < MODE_ENTRY) {
+            ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                      w->clean_name,
+                                      "_call_vfs_write_error",
+                                      "Fails to write.",
+                                      EBPF_COMMON_DIMENSION_CALL,
+                                      NETDATA_VFS_GROUP,
+                                      NETDATA_EBPF_CHART_TYPE_STACKED,
+                                      "ebpf.app_call_vfs_write_error",
+                                      order++,
+                                      update_every);
+        }
 
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_SYSCALL_APPS_VFS_READ_BYTES,
-                              "",
-                              "Bytes read from disk",
-                              EBPF_COMMON_DIMENSION_BYTES,
-                              NETDATA_VFS_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              20071,
-                              em->update_every);
-
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_SYSCALL_APPS_VFS_FSYNC,
-                              "",
-                              "Calls for <code>vfs_fsync</code>",
-                              EBPF_COMMON_DIMENSION_CALL,
-                              NETDATA_VFS_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              20072,
-                              em->update_every);
-
-    if (em->mode < MODE_ENTRY) {
-        ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                                  NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR,
-                                  "",
-                                  "Sync error",
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_call_vfs_read",
+                                  "Read from disk.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  NULL,
-                                  20073,
-                                  em->update_every);
-    }
+                                  "ebpf.app_call_vfs_read",
+                                  order++,
+                                  update_every);
 
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_SYSCALL_APPS_VFS_OPEN,
-                              "",
-                              "Calls for <code>vfs_open</code>",
-                              EBPF_COMMON_DIMENSION_CALL,
-                              NETDATA_VFS_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              20074,
-                              em->update_every);
+        if (em->mode < MODE_ENTRY) {
+            ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                      w->clean_name,
+                                      "_call_vfs_read_error",
+                                      "Fails to read.",
+                                      EBPF_COMMON_DIMENSION_CALL,
+                                      NETDATA_VFS_GROUP,
+                                      NETDATA_EBPF_CHART_TYPE_STACKED,
+                                      "ebpf.app_call_vfs_read_error",
+                                      order++,
+                                      update_every);
+        }
 
-    if (em->mode < MODE_ENTRY) {
-        ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                                  NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR,
-                                  "",
-                                  "Open error",
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_call_vfs_write_bytes",
+                                  "Bytes written on disk.",
+                                  EBPF_COMMON_DIMENSION_BYTES,
+                                  NETDATA_VFS_GROUP,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  "ebpf.app_call_vfs_write_bytes",
+                                  order++,
+                                  update_every);
+
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_call_vfs_read_bytes",
+                                  "Bytes read from disk.",
+                                  EBPF_COMMON_DIMENSION_BYTES,
+                                  NETDATA_VFS_GROUP,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  "ebpf.app_call_vfs_read_bytes",
+                                  order++,
+                                  update_every);
+
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_call_vfs_fsync",
+                                  "Calls to vfs_fsync.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  NULL,
-                                  20075,
-                                  em->update_every);
-    }
+                                  "ebpf.app_call_vfs_fsync",
+                                  order++,
+                                  update_every);
 
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_SYSCALL_APPS_VFS_CREATE,
-                              "",
-                              "Calls for <code>vfs_create</code>",
-                              EBPF_COMMON_DIMENSION_CALL,
-                              NETDATA_VFS_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              20076,
-                              em->update_every);
+        if (em->mode < MODE_ENTRY) {
+            ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                      w->clean_name,
+                                      "_call_vfs_fsync_error",
+                                      "Fails to sync.",
+                                      EBPF_COMMON_DIMENSION_CALL,
+                                      NETDATA_VFS_GROUP,
+                                      NETDATA_EBPF_CHART_TYPE_STACKED,
+                                      "ebpf.app_call_vfs_fsync_error",
+                                      order++,
+                                      update_every);
+        }
 
-    if (em->mode < MODE_ENTRY) {
-        ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                                  NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR,
-                                  "",
-                                  "Create error",
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_call_vfs_open",
+                                  "Calls to vfs_open.",
                                   EBPF_COMMON_DIMENSION_CALL,
                                   NETDATA_VFS_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  NULL,
-                                  20077,
-                                  em->update_every);
+                                  "ebpf.app_call_vfs_open",
+                                  order++,
+                                  update_every);
+
+        if (em->mode < MODE_ENTRY) {
+            ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                      w->clean_name,
+                                      "_call_vfs_open_error",
+                                      "Fails to open.",
+                                      EBPF_COMMON_DIMENSION_CALL,
+                                      NETDATA_VFS_GROUP,
+                                      NETDATA_EBPF_CHART_TYPE_STACKED,
+                                      "ebpf.app_call_vfs_open_error",
+                                      order++,
+                                      update_every);
+        }
+
+        ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                  w->clean_name,
+                                  "_call_vfs_create",
+                                  "Calls to vfs_create.",
+                                  EBPF_COMMON_DIMENSION_CALL,
+                                  NETDATA_VFS_GROUP,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  "ebpf.app_call_vfs_create",
+                                  order++,
+                                  update_every);
+
+        if (em->mode < MODE_ENTRY) {
+            ebpf_write_chart_obsolete(NETDATA_APP_FAMILY,
+                                      w->clean_name,
+                                      "_call_vfs_create_error",
+                                      "Fails to create.",
+                                      EBPF_COMMON_DIMENSION_CALL,
+                                      NETDATA_VFS_GROUP,
+                                      NETDATA_EBPF_CHART_TYPE_STACKED,
+                                      "ebpf.app_call_vfs_create_error",
+                                      order++,
+                                      update_every);
+        }
+        w->charts_created &= ~(1<<EBPF_MODULE_VFS_IDX);
     }
 }
 
@@ -1122,123 +1132,73 @@ void ebpf_vfs_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
 {
     struct ebpf_target *w;
     for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
-            ebpf_vfs_sum_pids(&w->vfs, w->root_pid);
-        }
-    }
+        uint32_t flag = w->charts_created & 1 << EBPF_MODULE_VFS_IDX;
+        if (likely(w->exposed && w->processes && !flag))
+            continue;
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_FILE_DELETED, "");
-    for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->clean_name, w->vfs.unlink_call);
-        }
-    }
-    write_end_chart();
+        ebpf_vfs_sum_pids(&w->vfs, w->root_pid);
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS, "");
-    for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->clean_name, w->vfs.write_call + w->vfs.writev_call);
-        }
-    }
-    write_end_chart();
-
-    if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR, "");
-        for (w = root; w; w = w->next) {
-            if (unlikely(w->exposed && w->processes)) {
-                write_chart_dimension(w->clean_name, w->vfs.write_err + w->vfs.writev_err);
-            }
-        }
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_unlink");
+        write_chart_dimension("calls", w->vfs.unlink_call);
         write_end_chart();
-    }
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS, "");
-    for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->clean_name, w->vfs.read_call + w->vfs.readv_call);
-        }
-    }
-    write_end_chart();
-
-    if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR, "");
-        for (w = root; w; w = w->next) {
-            if (unlikely(w->exposed && w->processes)) {
-                write_chart_dimension(w->clean_name, w->vfs.read_err + w->vfs.readv_err);
-            }
-        }
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_write");
+        write_chart_dimension("calls", w->vfs.write_call + w->vfs.writev_call);
         write_end_chart();
-    }
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES, "");
-    for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->clean_name, w->vfs.write_bytes + w->vfs.writev_bytes);
+        if (em->mode < MODE_ENTRY) {
+            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_write_error");
+            write_chart_dimension("calls", w->vfs.write_err + w->vfs.writev_err);
+            write_end_chart();
         }
-    }
-    write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_READ_BYTES, "");
-    for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->clean_name, w->vfs.read_bytes + w->vfs.readv_bytes);
-        }
-    }
-    write_end_chart();
-
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC, "");
-    for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->clean_name, w->vfs.fsync_call);
-        }
-    }
-    write_end_chart();
-
-    if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR, "");
-        for (w = root; w; w = w->next) {
-            if (unlikely(w->exposed && w->processes)) {
-                write_chart_dimension(w->clean_name, w->vfs.fsync_err);
-            }
-        }
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_read");
+        write_chart_dimension("calls", w->vfs.read_call + w->vfs.readv_call);
         write_end_chart();
-    }
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN, "");
-    for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->clean_name, w->vfs.open_call);
+        if (em->mode < MODE_ENTRY) {
+            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_read_error");
+            write_chart_dimension("calls", w->vfs.read_err + w->vfs.readv_err);
+            write_end_chart();
         }
-    }
-    write_end_chart();
 
-    if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR, "");
-        for (w = root; w; w = w->next) {
-            if (unlikely(w->exposed && w->processes)) {
-                write_chart_dimension(w->clean_name, w->vfs.open_err);
-            }
-        }
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_write_bytes");
+        write_chart_dimension("writes", w->vfs.write_bytes + w->vfs.writev_bytes);
         write_end_chart();
-    }
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE, "");
-    for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
-            write_chart_dimension(w->clean_name, w->vfs.create_call);
-        }
-    }
-    write_end_chart();
-
-    if (em->mode < MODE_ENTRY) {
-        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR, "");
-        for (w = root; w; w = w->next) {
-            if (unlikely(w->exposed && w->processes)) {
-                write_chart_dimension(w->clean_name, w->vfs.create_err);
-            }
-        }
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_read_bytes");
+        write_chart_dimension("reads", w->vfs.read_bytes + w->vfs.readv_bytes);
         write_end_chart();
+
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_fsync");
+        write_chart_dimension("calls", w->vfs.fsync_call);
+        write_end_chart();
+
+        if (em->mode < MODE_ENTRY) {
+            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_fsync_error");
+            write_chart_dimension("calls", w->vfs.fsync_err);
+            write_end_chart();
+        }
+
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_open");
+        write_chart_dimension("calls", w->vfs.open_call);
+        write_end_chart();
+
+        if (em->mode < MODE_ENTRY) {
+            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_open_error");
+            write_chart_dimension("calls", w->vfs.open_err);
+            write_end_chart();
+        }
+
+        write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_create");
+        write_chart_dimension("calls", w->vfs.create_call);
+        write_end_chart();
+
+        if (em->mode < MODE_ENTRY) {
+            write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_call_vfs_create_error");
+            write_chart_dimension("calls", w->vfs.create_err);
+            write_end_chart();
+        }
     }
 }
 
@@ -2224,127 +2184,219 @@ static void ebpf_create_global_charts(ebpf_module_t *em)
 void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
 {
     struct ebpf_target *root = ptr;
+    struct ebpf_target *w;
+    int order = 20065;
+    int update_every = em->update_every;
+    for (w = root; w; w = w->next) {
+        if (likely(w->exposed && w->processes))
+            continue;
 
-    ebpf_create_charts_on_apps(NETDATA_SYSCALL_APPS_FILE_DELETED,
-                               "Files deleted",
-                               EBPF_COMMON_DIMENSION_CALL,
-                               NETDATA_VFS_GROUP,
-                               NETDATA_EBPF_CHART_TYPE_STACKED,
-                               20065,
-                               ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                               root, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                             w->clean_name,
+                             "_call_vfs_unlink",
+                             "Files deleted.",
+                             EBPF_COMMON_DIMENSION_CALL,
+                             NETDATA_VFS_GROUP,
+                             NETDATA_EBPF_CHART_TYPE_STACKED,
+                             "ebpf.app_call_vfs_unlink",
+                             order++,
+                             update_every,
+                             NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_create_chart_labels("app_group", w->name, 0);
+        ebpf_commit_label();
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
-    ebpf_create_charts_on_apps(NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS,
-                               "Write to disk",
-                               EBPF_COMMON_DIMENSION_CALL,
-                               NETDATA_VFS_GROUP,
-                               NETDATA_EBPF_CHART_TYPE_STACKED,
-                               20066,
-                               ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                               root, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                             w->clean_name,
+                             "_call_vfs_write",
+                             "Write to disk.",
+                             EBPF_COMMON_DIMENSION_CALL,
+                             NETDATA_VFS_GROUP,
+                             NETDATA_EBPF_CHART_TYPE_STACKED,
+                             "ebpf.app_call_vfs_write",
+                             order++,
+                             update_every,
+                             NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_create_chart_labels("app_group", w->name, 0);
+        ebpf_commit_label();
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
-    if (em->mode < MODE_ENTRY) {
-        ebpf_create_charts_on_apps(NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR,
-                                   "Fails to write",
-                                   EBPF_COMMON_DIMENSION_CALL,
-                                   NETDATA_VFS_GROUP,
-                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                   20067,
-                                   ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                                   root, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
-    }
+        if (em->mode < MODE_ENTRY) {
+            ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                                 w->clean_name,
+                                 "_call_vfs_write_error",
+                                 "Fails to write.",
+                                 EBPF_COMMON_DIMENSION_CALL,
+                                 NETDATA_VFS_GROUP,
+                                 NETDATA_EBPF_CHART_TYPE_STACKED,
+                                 "ebpf.app_call_vfs_write_error",
+                                 order++,
+                                 update_every,
+                                 NETDATA_EBPF_MODULE_NAME_VFS);
+            ebpf_create_chart_labels("app_group", w->name, 0);
+            ebpf_commit_label();
+            fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
+        }
 
-    ebpf_create_charts_on_apps(NETDATA_SYSCALL_APPS_VFS_READ_CALLS,
-                               "Read from disk",
-                               EBPF_COMMON_DIMENSION_CALL,
-                               NETDATA_VFS_GROUP,
-                               NETDATA_EBPF_CHART_TYPE_STACKED,
-                               20068,
-                               ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                               root, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                             w->clean_name,
+                             "_call_vfs_read",
+                             "Read from disk.",
+                             EBPF_COMMON_DIMENSION_CALL,
+                             NETDATA_VFS_GROUP,
+                             NETDATA_EBPF_CHART_TYPE_STACKED,
+                             "ebpf.app_call_vfs_read",
+                             order++,
+                             update_every,
+                             NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_create_chart_labels("app_group", w->name, 0);
+        ebpf_commit_label();
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
-    if (em->mode < MODE_ENTRY) {
-        ebpf_create_charts_on_apps(NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR,
-                                   "Fails to read",
-                                   EBPF_COMMON_DIMENSION_CALL,
-                                   NETDATA_VFS_GROUP,
-                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                   20069,
-                                   ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                                   root, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
-    }
+        if (em->mode < MODE_ENTRY) {
+            ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                                 w->clean_name,
+                                 "_call_vfs_read_error",
+                                 "Fails to read.",
+                                 EBPF_COMMON_DIMENSION_CALL,
+                                 NETDATA_VFS_GROUP,
+                                 NETDATA_EBPF_CHART_TYPE_STACKED,
+                                 "ebpf.app_call_vfs_read_error",
+                                 order++,
+                                 update_every,
+                                 NETDATA_EBPF_MODULE_NAME_VFS);
+            ebpf_create_chart_labels("app_group", w->name, 0);
+            ebpf_commit_label();
+            fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
+        }
 
-    ebpf_create_charts_on_apps(NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES,
-                               "Bytes written on disk", EBPF_COMMON_DIMENSION_BYTES,
-                               NETDATA_VFS_GROUP,
-                               NETDATA_EBPF_CHART_TYPE_STACKED,
-                               20070,
-                               ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                               root, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                             w->clean_name,
+                             "_call_vfs_write_bytes",
+                             "Bytes written on disk.",
+                             EBPF_COMMON_DIMENSION_BYTES,
+                             NETDATA_VFS_GROUP,
+                             NETDATA_EBPF_CHART_TYPE_STACKED,
+                             "ebpf.app_call_vfs_write_bytes",
+                             order++,
+                             update_every,
+                             NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_create_chart_labels("app_group", w->name, 0);
+        ebpf_commit_label();
+        fprintf(stdout, "DIMENSION writes '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
-    ebpf_create_charts_on_apps(NETDATA_SYSCALL_APPS_VFS_READ_BYTES,
-                               "Bytes read from disk", EBPF_COMMON_DIMENSION_BYTES,
-                               NETDATA_VFS_GROUP,
-                               NETDATA_EBPF_CHART_TYPE_STACKED,
-                               20071,
-                               ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                               root, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                             w->clean_name,
+                             "_call_vfs_read_bytes",
+                             "Bytes read from disk.",
+                             EBPF_COMMON_DIMENSION_BYTES,
+                             NETDATA_VFS_GROUP,
+                             NETDATA_EBPF_CHART_TYPE_STACKED,
+                             "ebpf.app_call_vfs_read_bytes",
+                             order++,
+                             update_every,
+                             NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_create_chart_labels("app_group", w->name, 0);
+        ebpf_commit_label();
+        fprintf(stdout, "DIMENSION reads '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
-    ebpf_create_charts_on_apps(NETDATA_SYSCALL_APPS_VFS_FSYNC,
-                               "Calls for <code>vfs_fsync</code>", EBPF_COMMON_DIMENSION_CALL,
-                               NETDATA_VFS_GROUP,
-                               NETDATA_EBPF_CHART_TYPE_STACKED,
-                               20072,
-                               ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                               root, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                             w->clean_name,
+                             "_call_vfs_fsync",
+                             "Calls to vfs_fsync.",
+                             EBPF_COMMON_DIMENSION_CALL,
+                             NETDATA_VFS_GROUP,
+                             NETDATA_EBPF_CHART_TYPE_STACKED,
+                             "ebpf.app_call_vfs_fsync",
+                             order++,
+                             update_every,
+                             NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_create_chart_labels("app_group", w->name, 0);
+        ebpf_commit_label();
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
-    if (em->mode < MODE_ENTRY) {
-        ebpf_create_charts_on_apps(NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR,
-                                   "Sync error",
-                                   EBPF_COMMON_DIMENSION_CALL,
-                                   NETDATA_VFS_GROUP,
-                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                   20073,
-                                   ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                                   root, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
-    }
+        if (em->mode < MODE_ENTRY) {
+            ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                                 w->clean_name,
+                                 "_call_vfs_fsync_error",
+                                 "Fails to sync.",
+                                 EBPF_COMMON_DIMENSION_CALL,
+                                 NETDATA_VFS_GROUP,
+                                 NETDATA_EBPF_CHART_TYPE_STACKED,
+                                 "ebpf.app_call_vfs_fsync_error",
+                                 order++,
+                                 update_every,
+                                 NETDATA_EBPF_MODULE_NAME_VFS);
+            ebpf_create_chart_labels("app_group", w->name, 0);
+            ebpf_commit_label();
+            fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
+        }
 
-    ebpf_create_charts_on_apps(NETDATA_SYSCALL_APPS_VFS_OPEN,
-                               "Calls for <code>vfs_open</code>", EBPF_COMMON_DIMENSION_CALL,
-                               NETDATA_VFS_GROUP,
-                               NETDATA_EBPF_CHART_TYPE_STACKED,
-                               20074,
-                               ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                               root, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                             w->clean_name,
+                             "_call_vfs_open",
+                             "Calls to vfs_open.",
+                             EBPF_COMMON_DIMENSION_CALL,
+                             NETDATA_VFS_GROUP,
+                             NETDATA_EBPF_CHART_TYPE_STACKED,
+                             "ebpf.app_call_vfs_open",
+                             order++,
+                             update_every,
+                             NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_create_chart_labels("app_group", w->name, 0);
+        ebpf_commit_label();
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
-    if (em->mode < MODE_ENTRY) {
-        ebpf_create_charts_on_apps(NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR,
-                                   "Open error",
-                                   EBPF_COMMON_DIMENSION_CALL,
-                                   NETDATA_VFS_GROUP,
-                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                   20075,
-                                   ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                                   root, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
-    }
+        if (em->mode < MODE_ENTRY) {
+            ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                                 w->clean_name,
+                                 "_call_vfs_open_error",
+                                 "Fails to open.",
+                                 EBPF_COMMON_DIMENSION_CALL,
+                                 NETDATA_VFS_GROUP,
+                                 NETDATA_EBPF_CHART_TYPE_STACKED,
+                                 "ebpf.app_call_vfs_open_error",
+                                 order++,
+                                 update_every,
+                                 NETDATA_EBPF_MODULE_NAME_VFS);
+            ebpf_create_chart_labels("app_group", w->name, 0);
+            ebpf_commit_label();
+            fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
+        }
 
-    ebpf_create_charts_on_apps(NETDATA_SYSCALL_APPS_VFS_CREATE,
-                               "Calls for <code>vfs_create</code>", EBPF_COMMON_DIMENSION_CALL,
-                               NETDATA_VFS_GROUP,
-                               NETDATA_EBPF_CHART_TYPE_STACKED,
-                               20076,
-                               ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                               root, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                             w->clean_name,
+                             "_call_vfs_create",
+                             "Calls to vfs_create.",
+                             EBPF_COMMON_DIMENSION_CALL,
+                             NETDATA_VFS_GROUP,
+                             NETDATA_EBPF_CHART_TYPE_STACKED,
+                             "ebpf.app_call_vfs_create",
+                             order++,
+                             update_every,
+                             NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_create_chart_labels("app_group", w->name, 0);
+        ebpf_commit_label();
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
-    if (em->mode < MODE_ENTRY) {
-        ebpf_create_charts_on_apps(NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR,
-                                   "Create error",
-                                   EBPF_COMMON_DIMENSION_CALL,
-                                   NETDATA_VFS_GROUP,
-                                   NETDATA_EBPF_CHART_TYPE_STACKED,
-                                   20077,
-                                   ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                                   root, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+        if (em->mode < MODE_ENTRY) {
+            ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
+                                 w->clean_name,
+                                 "_call_vfs_create_error",
+                                 "Fails to create a file.",
+                                 EBPF_COMMON_DIMENSION_CALL,
+                                 NETDATA_VFS_GROUP,
+                                 NETDATA_EBPF_CHART_TYPE_STACKED,
+                                 "ebpf.app_call_vfs_create_error",
+                                 order++,
+                                 update_every,
+                                 NETDATA_EBPF_MODULE_NAME_VFS);
+            ebpf_create_chart_labels("app_group", w->name, 0);
+            ebpf_commit_label();
+            fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
+        }
+
+        w->charts_created |= 1<<EBPF_MODULE_VFS_IDX;
     }
 
     em->apps_charts |= NETDATA_EBPF_APPS_FLAG_CHART_CREATED;

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -602,7 +602,7 @@ static inline void ebpf_obsolete_vfs_cgroup_charts(ebpf_module_t *em) {
  */
 void ebpf_obsolete_vfs_apps_charts(struct ebpf_module *em)
 {
-    int order = 20065;
+    int order = 20275;
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = apps_groups_root_target; w; w = w->next) {
@@ -2182,7 +2182,7 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
 {
     struct ebpf_target *root = ptr;
     struct ebpf_target *w;
-    int order = 20065;
+    int order = 20275;
     int update_every = em->update_every;
     for (w = root; w; w = w->next) {
         if (unlikely(!w->exposed))

--- a/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/collectors/ebpf.plugin/ebpf_vfs.c
@@ -502,7 +502,7 @@ static void ebpf_obsolete_vfs_services(ebpf_module_t *em)
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SYSCALL_APPS_VFS_FSYNC,
                               "",
-                              "Calls to <code>vfs_fsync</code>",
+                              "Calls to vfs_fsync.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_CGROUP_GROUP,
                               NETDATA_EBPF_CHART_TYPE_STACKED,
@@ -525,7 +525,7 @@ static void ebpf_obsolete_vfs_services(ebpf_module_t *em)
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SYSCALL_APPS_VFS_OPEN,
                               "",
-                              "Calls to <code>vfs_open</code>",
+                              "Calls to vfs_open.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_CGROUP_GROUP,
                               NETDATA_EBPF_CHART_TYPE_STACKED,
@@ -549,7 +549,7 @@ static void ebpf_obsolete_vfs_services(ebpf_module_t *em)
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_SYSCALL_APPS_VFS_CREATE,
                               "",
-                              "Calls to <code>vfs_create</code>",
+                              "Calls to vfs_create.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_CGROUP_GROUP,
                               NETDATA_EBPF_CHART_TYPE_STACKED,
@@ -823,7 +823,7 @@ static void ebpf_obsolete_vfs_global(ebpf_module_t *em)
     ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                               NETDATA_VFS_FSYNC,
                               "",
-                              "Calls for <code>vfs_fsync</code>",
+                              "Calls to vfs_fsync.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE,
@@ -847,7 +847,7 @@ static void ebpf_obsolete_vfs_global(ebpf_module_t *em)
     ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                               NETDATA_VFS_OPEN,
                               "",
-                              "Calls for <code>vfs_open</code>",
+                              "Calls to vfs_open.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE,
@@ -871,7 +871,7 @@ static void ebpf_obsolete_vfs_global(ebpf_module_t *em)
     ebpf_write_chart_obsolete(NETDATA_FILESYSTEM_FAMILY,
                               NETDATA_VFS_CREATE,
                               "",
-                              "Calls for <code>vfs_create</code>",
+                              "Calls to vfs_create.",
                               EBPF_COMMON_DIMENSION_CALL,
                               NETDATA_VFS_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE,
@@ -1445,7 +1445,7 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_READ],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
 
-    ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_FSYNC, "Calls for <code>vfs_fsync</code>",
+    ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_FSYNC, "Calls to vfs_fsync.",
                       EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_CGROUP_GROUP, NETDATA_CGROUP_VFS_FSYNC_CONTEXT,
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5507,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_FSYNC],
@@ -1459,7 +1459,7 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                           1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
     }
 
-    ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_OPEN, "Calls for <code>vfs_open</code>",
+    ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_OPEN, "Calls to vfs_open.",
                       EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_CGROUP_GROUP, NETDATA_CGROUP_VFS_OPEN_CONTEXT,
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5509,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_OPEN],
@@ -1473,7 +1473,7 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                           1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
     }
 
-    ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_CREATE, "Calls for <code>vfs_create</code>",
+    ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_CREATE, "Calls to vfs_create.",
                       EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_CGROUP_GROUP, NETDATA_CGROUP_VFS_CREATE_CONTEXT,
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5511,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_CREATE],
@@ -1537,7 +1537,7 @@ static void ebpf_obsolete_specific_vfs_charts(char *type, ebpf_module_t *em)
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_VFS_READ_BYTES_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5506, em->update_every);
 
-    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_FSYNC, "", "Calls for <code>vfs_fsync</code>",
+    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_FSYNC, "", "Calls to vfs_fsync.",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_VFS_FSYNC_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5507, em->update_every);
@@ -1549,7 +1549,7 @@ static void ebpf_obsolete_specific_vfs_charts(char *type, ebpf_module_t *em)
                                   NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5508, em->update_every);
     }
 
-    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_OPEN, "", "Calls for <code>vfs_open</code>",
+    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_OPEN, "", "Calls to vfs_open.",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_VFS_OPEN_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5509, em->update_every);
@@ -1561,7 +1561,7 @@ static void ebpf_obsolete_specific_vfs_charts(char *type, ebpf_module_t *em)
                                   NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5510, em->update_every);
     }
 
-    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_CREATE, "", "Calls for <code>vfs_create</code>",
+    ebpf_write_chart_obsolete(type, NETDATA_SYSCALL_APPS_VFS_CREATE, "", "Calls to vfs_create.",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_GROUP,
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CGROUP_VFS_CREATE_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5511, em->update_every);
@@ -1716,7 +1716,7 @@ static void ebpf_create_systemd_vfs_charts(ebpf_module_t *em)
                                   ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX], NETDATA_SYSTEMD_VFS_READ_BYTES_CONTEXT,
                                   NETDATA_EBPF_MODULE_NAME_VFS, em->update_every);
 
-    ebpf_create_charts_on_systemd(NETDATA_SYSCALL_APPS_VFS_FSYNC, "Calls to <code>vfs_fsync</code>",
+    ebpf_create_charts_on_systemd(NETDATA_SYSCALL_APPS_VFS_FSYNC, "Calls to vfs_fsync.",
                                   EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_CGROUP_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED, 20072,
                                   ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX], NETDATA_SYSTEMD_VFS_FSYNC_CONTEXT,
@@ -1729,7 +1729,7 @@ static void ebpf_create_systemd_vfs_charts(ebpf_module_t *em)
                                       ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX], NETDATA_SYSTEMD_VFS_FSYNC_ERROR_CONTEXT,
                                       NETDATA_EBPF_MODULE_NAME_VFS, em->update_every);
     }
-    ebpf_create_charts_on_systemd(NETDATA_SYSCALL_APPS_VFS_OPEN, "Calls to <code>vfs_open</code>",
+    ebpf_create_charts_on_systemd(NETDATA_SYSCALL_APPS_VFS_OPEN, "Calls to vfs_open.",
                                   EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_CGROUP_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED, 20074,
                                   ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX], NETDATA_SYSTEMD_VFS_OPEN_CONTEXT,
@@ -1743,7 +1743,7 @@ static void ebpf_create_systemd_vfs_charts(ebpf_module_t *em)
                                       NETDATA_EBPF_MODULE_NAME_VFS, em->update_every);
     }
 
-    ebpf_create_charts_on_systemd(NETDATA_SYSCALL_APPS_VFS_CREATE, "Calls to <code>vfs_create</code>",
+    ebpf_create_charts_on_systemd(NETDATA_SYSCALL_APPS_VFS_CREATE, "Calls to vfs_create.",
                                   EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_CGROUP_GROUP,
                                   NETDATA_EBPF_CHART_TYPE_STACKED, 20076,
                                   ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX], NETDATA_SYSTEMD_VFS_CREATE_CONTEXT,
@@ -2091,7 +2091,7 @@ static void ebpf_create_global_charts(ebpf_module_t *em)
 
     ebpf_create_chart(NETDATA_FILESYSTEM_FAMILY,
                       NETDATA_VFS_FSYNC,
-                      "Calls for <code>vfs_fsync</code>",
+                      "Calls to vfs_fsync.",
                       EBPF_COMMON_DIMENSION_CALL,
                       NETDATA_VFS_GROUP,
                       NULL,
@@ -2117,7 +2117,7 @@ static void ebpf_create_global_charts(ebpf_module_t *em)
 
     ebpf_create_chart(NETDATA_FILESYSTEM_FAMILY,
                       NETDATA_VFS_OPEN,
-                      "Calls for <code>vfs_open</code>",
+                      "Calls to vfs_open.",
                       EBPF_COMMON_DIMENSION_CALL,
                       NETDATA_VFS_GROUP,
                       NULL,
@@ -2143,7 +2143,7 @@ static void ebpf_create_global_charts(ebpf_module_t *em)
 
     ebpf_create_chart(NETDATA_FILESYSTEM_FAMILY,
                       NETDATA_VFS_CREATE,
-                      "Calls for <code>vfs_create</code>",
+                      "Calls to vfs_create.",
                       EBPF_COMMON_DIMENSION_CALL,
                       NETDATA_VFS_GROUP,
                       NULL,

--- a/collectors/ebpf.plugin/metadata.yaml
+++ b/collectors/ebpf.plugin/metadata.yaml
@@ -1503,12 +1503,12 @@ modules:
           description: "These metrics show cgroup/service that reached OOM."
           labels: []
           metrics:
-            - name: apps.oomkills
+            - name: app_group.oomkill
               description: OOM kills
               unit: "kills"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
+                - name: kills
   - meta:
       plugin_name: ebpf.plugin
       module_name: socket

--- a/collectors/ebpf.plugin/metadata.yaml
+++ b/collectors/ebpf.plugin/metadata.yaml
@@ -848,25 +848,25 @@ modules:
               unit: "%"
               chart_type: line
               dimensions:
-                - name: a dimension per app group
+                - name: ratio
             - name: app_group.ebpf_cachestat_dirty_pages
               description: Number of dirty pages
               unit: "page/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
+                - name: pages
             - name: app_group.ebpf_cachestat_access
               description: Number of accessed files
               unit: "hits/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
+                - name: hits
             - name: app_group.ebpf_cachestat_misses
               description: Files out of page cache
               unit: "misses/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
+                - name: misses
         - name: cgroup
           description: ""
           labels: []
@@ -2007,30 +2007,30 @@ modules:
           description: "These Metrics show grouped information per apps group."
           labels: []
           metrics:
-            - name: apps.dc_ratio
+            - name: app_group.ebpf_dc_ratio
               description: Percentage of files inside directory cache
               unit: "%"
               chart_type: line
               dimensions:
-                - name: a dimension per app group
-            - name: apps.dc_reference
+                - name: ratio
+            - name: app_group.ebpf_dc_reference
               description: Count file access
               unit: "files"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.dc_not_cache
+                - name: files
+            - name: app_group.ebpf_dc_not_cache
               description: Files not present inside directory cache
               unit: "files"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.dc_not_found
+                - name: files
+            - name: app_group.ebpf_dc_not_found
               description: Files not found
               unit: "files"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
+                - name: files
         - name: filesystem
           description: "These metrics show total number of calls to functions inside kernel."
           labels: []

--- a/collectors/ebpf.plugin/metadata.yaml
+++ b/collectors/ebpf.plugin/metadata.yaml
@@ -381,36 +381,36 @@ modules:
           description: "These Metrics show grouped information per apps group."
           labels: []
           metrics:
-            - name: apps.process_create
+            - name: app_group.process_create
               description: Process started
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.thread_create
+                - name: calls
+            - name: app_group.thread_create
               description: Threads started
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.task_exit
+                - name: call
+            - name: app_group.task_exit
               description: Tasks starts exit process
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.task_close
+                - name: callp
+            - name: app_group.task_close
               description: Tasks closed
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.task_error
+                - name: call
+            - name: app_group.task_error
               description: Errors to create process or threads
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
+                - name: app
         - name: cgroup
           description: "These Metrics show grouped information per cgroup/service."
           labels: []

--- a/collectors/ebpf.plugin/metadata.yaml
+++ b/collectors/ebpf.plugin/metadata.yaml
@@ -3076,84 +3076,84 @@ modules:
           description: "These Metrics show grouped information per apps group."
           labels: []
           metrics:
-            - name: apps.file_deleted
+            - name: app_group.ebpf_call_vfs_unlink
               description: Files deleted
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.vfs_write_call
+                - name: calls
+            - name: app_group.ebpf_call_vfs_write
               description: Write to disk
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.vfs_write_error
+                - name: calls
+            - name: app_group.ebpf_call_vfs_write_error
               description: Fails to write
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.vfs_read_call
+                - name: calls
+            - name: app_group.ebpf_call_vfs_read
               description: Read from disk
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.vfs_read_error
+                - name: calls
+            - name: app_group.ebpf_call_vfs_read_error
               description: Fails to read
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.vfs_write_bytes
+                - name: calls
+            - name: app_group.ebpf_call_vfs_write_bytes
               description: Bytes written on disk
               unit: "bytes/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.vfs_read_bytes
+                - name: writes
+            - name: app_group.ebpf_call_vfs_read_bytes
               description: Bytes read on disk
               unit: "bytes/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.vfs_fsync
+                - name: reads
+            - name: app_group.ebpf_call_vfs_fsync
               description: Calls for <code>vfs_fsync</code>
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.vfs_fsync_error
+                - name: calls
+            - name: app_group.ebpf_call_vfs_fsync_error
               description: Sync error
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.vfs_open
+                - name: calls
+            - name: app_group.ebpf_call_vfs_open
               description: Calls for <code>vfs_open</code>
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.vfs_open_error
+                - name: calls
+            - name: app_group.ebpf_call_vfs_open_error
               description: Open error
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.vfs_create
+                - name: calls
+            - name: app_group.ebpf_call_vfs_create
               description: Calls for <code>vfs_create</code>
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.vfs_create_error
+                - name: calls
+            - name: app_group.ebpf_call_vfs_create_error
               description: Create error
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
+                - name: calls
   - meta:
       plugin_name: ebpf.plugin
       module_name: process

--- a/collectors/ebpf.plugin/metadata.yaml
+++ b/collectors/ebpf.plugin/metadata.yaml
@@ -200,25 +200,25 @@ modules:
             - name: app_group
               description: The name of the group defined in the configuration.
           metrics:
-            - name: app_group.ebpf_file_open
+            - name: app.ebpf_file_open
               description: Number of open files
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_file_open_error
+            - name: app.ebpf_file_open_error
               description: Fails to open files
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_file_closed
+            - name: app.ebpf_file_closed
               description: Files closed
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_file_close_error
+            - name: app.ebpf_file_close_error
               description: Fails to close files
               unit: "calls/s"
               chart_type: stacked
@@ -385,31 +385,31 @@ modules:
             - name: app_group
               description: The name of the group defined in the configuration.
           metrics:
-            - name: app_group.process_create
+            - name: app.process_create
               description: Process started
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.thread_create
+            - name: app.thread_create
               description: Threads started
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: call
-            - name: app_group.task_exit
+            - name: app.task_exit
               description: Tasks starts exit process
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: callp
-            - name: app_group.task_close
+            - name: app.task_close
               description: Tasks closed
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: call
-            - name: app_group.task_error
+            - name: app.task_error
               description: Errors to create process or threads
               unit: "calls/s"
               chart_type: stacked
@@ -849,25 +849,25 @@ modules:
             - name: app_group
               description: The name of the group defined in the configuration.
           metrics:
-            - name: app_group.ebpf_cachestat_hit_ratio
+            - name: app.ebpf_cachestat_hit_ratio
               description: Hit ratio
               unit: "%"
               chart_type: line
               dimensions:
                 - name: ratio
-            - name: app_group.ebpf_cachestat_dirty_pages
+            - name: app.ebpf_cachestat_dirty_pages
               description: Number of dirty pages
               unit: "page/s"
               chart_type: stacked
               dimensions:
                 - name: pages
-            - name: app_group.ebpf_cachestat_access
+            - name: app.ebpf_cachestat_access
               description: Number of accessed files
               unit: "hits/s"
               chart_type: stacked
               dimensions:
                 - name: hits
-            - name: app_group.ebpf_cachestat_misses
+            - name: app.ebpf_cachestat_misses
               description: Files out of page cache
               unit: "misses/s"
               chart_type: stacked
@@ -1368,13 +1368,13 @@ modules:
             - name: app_group
               description: The name of the group defined in the configuration.
           metrics:
-            - name: app_group.ebpf_call_swap_readpage
+            - name: app.ebpf_call_swap_readpage
               description: Calls to function swap_readpage.
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: a dimension per app group
-            - name: app_group.ebpf_call_swap_writepage
+            - name: app.ebpf_call_swap_writepage
               description: Calls to function swap_writepage.
               unit: "calls/s"
               chart_type: stacked
@@ -1513,7 +1513,7 @@ modules:
             - name: app_group
               description: The name of the group defined in the configuration.
           metrics:
-            - name: app_group.oomkill
+            - name: app.oomkill
               description: OOM kills
               unit: "kills"
               chart_type: stacked
@@ -1727,55 +1727,55 @@ modules:
             - name: app_group
               description: The name of the group defined in the configuration.
           metrics:
-            - name: app_group.ebpf_call_tcp_v4_connection
+            - name: app.ebpf_call_tcp_v4_connection
               description: Calls to tcp_v4_connection
               unit: "connections/s"
               chart_type: stacked
               dimensions:
                 - name: connections
-            - name: app_group.app.ebpf_call_tcp_v6_connection
+            - name: app.app.ebpf_call_tcp_v6_connection
               description: Calls to tcp_v6_connection
               unit: "connections/s"
               chart_type: stacked
               dimensions:
                 - name: connections
-            - name: app_group.ebpf_sock_bytes_sent
+            - name: app.ebpf_sock_bytes_sent
               description: Bytes sent
               unit: "kilobits/s"
               chart_type: stacked
               dimensions:
                 - name: bandwidth
-            - name: app_group.ebpf_sock_bytes_received
+            - name: app.ebpf_sock_bytes_received
               description: bytes received
               unit: "kilobits/s"
               chart_type: stacked
               dimensions:
                 - name: bandwidth
-            - name: app_group.ebpf_call_tcp_sendmsg
+            - name: app.ebpf_call_tcp_sendmsg
               description: Calls for tcp_sendmsg
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_call_tcp_cleanup_rbuf
+            - name: app.ebpf_call_tcp_cleanup_rbuf
               description: Calls for tcp_cleanup_rbuf
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_call_tcp_retransmit
+            - name: app.ebpf_call_tcp_retransmit
               description: Calls for tcp_retransmit
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_call_udp_sendmsg
+            - name: app.ebpf_call_udp_sendmsg
               description: Calls for udp_sendmsg
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_call_udp_recvmsg
+            - name: app.ebpf_call_udp_recvmsg
               description: Calls for udp_recvmsg
               unit: "calls/s"
               chart_type: stacked
@@ -2015,25 +2015,25 @@ modules:
             - name: app_group
               description: The name of the group defined in the configuration.
           metrics:
-            - name: app_group.ebpf_dc_ratio
+            - name: app.ebpf_dc_ratio
               description: Percentage of files inside directory cache
               unit: "%"
               chart_type: line
               dimensions:
                 - name: ratio
-            - name: app_group.ebpf_dc_reference
+            - name: app.ebpf_dc_reference
               description: Count file access
               unit: "files"
               chart_type: stacked
               dimensions:
                 - name: files
-            - name: app_group.ebpf_dc_not_cache
+            - name: app.ebpf_dc_not_cache
               description: Files not present inside directory cache
               unit: "files"
               chart_type: stacked
               dimensions:
                 - name: files
-            - name: app_group.ebpf_dc_not_found
+            - name: app.ebpf_dc_not_found
               description: Files not found
               unit: "files"
               chart_type: stacked
@@ -2470,25 +2470,25 @@ modules:
             - name: app_group
               description: The name of the group defined in the configuration.
           metrics:
-            - name: app_group.ebpf_shmget_call
+            - name: app.ebpf_shmget_call
               description: Calls to syscall shmget(2).
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_shmat_call
+            - name: app.ebpf_shmat_call
               description: Calls to syscall shmat(2).
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_shmdt_call
+            - name: app.ebpf_shmdt_call
               description: Calls to syscall shmdt(2).
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_shmctl_call
+            - name: app.ebpf_shmctl_call
               description: Calls to syscall shmctl(2).
               unit: "calls/s"
               chart_type: stacked
@@ -3094,79 +3094,79 @@ modules:
             - name: app_group
               description: The name of the group defined in the configuration.
           metrics:
-            - name: app_group.ebpf_call_vfs_unlink
+            - name: app.ebpf_call_vfs_unlink
               description: Files deleted
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_call_vfs_write
+            - name: app.ebpf_call_vfs_write
               description: Write to disk
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_call_vfs_write_error
+            - name: app.ebpf_call_vfs_write_error
               description: Fails to write
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_call_vfs_read
+            - name: app.ebpf_call_vfs_read
               description: Read from disk
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_call_vfs_read_error
+            - name: app.ebpf_call_vfs_read_error
               description: Fails to read
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_call_vfs_write_bytes
+            - name: app.ebpf_call_vfs_write_bytes
               description: Bytes written on disk
               unit: "bytes/s"
               chart_type: stacked
               dimensions:
                 - name: writes
-            - name: app_group.ebpf_call_vfs_read_bytes
+            - name: app.ebpf_call_vfs_read_bytes
               description: Bytes read on disk
               unit: "bytes/s"
               chart_type: stacked
               dimensions:
                 - name: reads
-            - name: app_group.ebpf_call_vfs_fsync
+            - name: app.ebpf_call_vfs_fsync
               description: Calls to vfs_fsync.
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_call_vfs_fsync_error
+            - name: app.ebpf_call_vfs_fsync_error
               description: Sync error
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_call_vfs_open
+            - name: app.ebpf_call_vfs_open
               description: Calls to vfs_open.
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_call_vfs_open_error
+            - name: app.ebpf_call_vfs_open_error
               description: Open error
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_call_vfs_create
+            - name: app.ebpf_call_vfs_create
               description: Calls to vfs_create.
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
-            - name: app_group.ebpf_call_vfs_create_error
+            - name: app.ebpf_call_vfs_create_error
               description: Create error
               unit: "calls/s"
               chart_type: stacked

--- a/collectors/ebpf.plugin/metadata.yaml
+++ b/collectors/ebpf.plugin/metadata.yaml
@@ -1076,27 +1076,27 @@ modules:
           labels: []
           metrics:
             - name: mem.file_sync
-              description: Monitor calls for <code>fsync(2)</code> and <code>fdatasync(2)</code>.
+              description: Monitor calls to fsync(2) and fdatasync(2).
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: fsync
                 - name: fdatasync
             - name: mem.meory_map
-              description: Monitor calls for <code>msync(2)</code>.
+              description: Monitor calls to msync(2).
               unit: "calls/s"
               chart_type: line
               dimensions:
                 - name: msync
             - name: mem.sync
-              description: Monitor calls for <code>sync(2)</code> and <code>syncfs(2)</code>.
+              description: Monitor calls to sync(2) and syncfs(2).
               unit: "calls/s"
               chart_type: line
               dimensions:
                 - name: sync
                 - name: syncfs
             - name: mem.file_segment
-              description: Monitor calls for <code>sync_file_range(2)</code>.
+              description: Monitor calls to sync_file_range(2).
               unit: "calls/s"
               chart_type: line
               dimensions:
@@ -1333,25 +1333,25 @@ modules:
           labels: []
           metrics:
             - name: cgroup.swap_read
-              description: Calls to function <code>swap_readpage</code>.
+              description: Calls to function swap_readpage.
               unit: "calls/s"
               chart_type: line
               dimensions:
                 - name: read
             - name: cgroup.swap_write
-              description: Calls to function <code>swap_writepage</code>.
+              description: Calls to function swap_writepage.
               unit: "calls/s"
               chart_type: line
               dimensions:
                 - name: write
             - name: services.swap_read
-              description: Calls to <code>swap_readpage</code>.
+              description: Calls to swap_readpage.
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: a dimension per systemd service
             - name: services.swap_write
-              description: Calls to function <code>swap_writepage</code>.
+              description: Calls to function swap_writepage.
               unit: "calls/s"
               chart_type: stacked
               dimensions:
@@ -1361,13 +1361,13 @@ modules:
           labels: []
           metrics:
             - name: app_group.ebpf_call_swap_readpage
-              description: Calls to function <code>swap_readpage</code>.
+              description: Calls to function swap_readpage.
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: a dimension per app group
             - name: app_group.ebpf_call_swap_writepage
-              description: Calls to function <code>swap_writepage</code>.
+              description: Calls to function swap_writepage.
               unit: "calls/s"
               chart_type: stacked
               dimensions:
@@ -2403,49 +2403,49 @@ modules:
           labels: []
           metrics:
             - name: cgroup.shmget
-              description: Calls to syscall <code>shmget(2)</code>.
+              description: Calls to syscall shmget(2).
               unit: "calls/s"
               chart_type: line
               dimensions:
                 - name: get
             - name: cgroup.shmat
-              description: Calls to syscall <code>shmat(2)</code>.
+              description: Calls to syscall shmat(2).
               unit: "calls/s"
               chart_type: line
               dimensions:
                 - name: at
             - name: cgroup.shmdt
-              description: Calls to syscall <code>shmdt(2)</code>.
+              description: Calls to syscall shmdt(2).
               unit: "calls/s"
               chart_type: line
               dimensions:
                 - name: dt
             - name: cgroup.shmctl
-              description: Calls to syscall <code>shmctl(2)</code>.
+              description: Calls to syscall shmctl(2).
               unit: "calls/s"
               chart_type: line
               dimensions:
                 - name: ctl
             - name: services.shmget
-              description: Calls to syscall <code>shmget(2)</code>.
+              description: Calls to syscall shmget(2).
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: a dimension per systemd service
             - name: services.shmat
-              description: Calls to syscall <code>shmat(2)</code>.
+              description: Calls to syscall shmat(2).
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: a dimension per systemd service
             - name: services.shmdt
-              description: Calls to syscall <code>shmdt(2)</code>.
+              description: Calls to syscall shmdt(2).
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: a dimension per systemd service
             - name: services.shmctl
-              description: Calls to syscall <code>shmctl(2)</code>.
+              description: Calls to syscall shmctl(2).
               unit: "calls/s"
               chart_type: stacked
               dimensions:
@@ -2455,25 +2455,25 @@ modules:
           labels: []
           metrics:
             - name: app_group.ebpf_shmget_call
-              description: Calls to syscall <code>shmget(2)</code>.
+              description: Calls to syscall shmget(2).
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
             - name: app_group.ebpf_shmat_call
-              description: Calls to syscall <code>shmat(2)</code>.
+              description: Calls to syscall shmat(2).
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
             - name: app_group.ebpf_shmdt_call
-              description: Calls to syscall <code>shmdt(2)</code>.
+              description: Calls to syscall shmdt(2).
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: calls
             - name: app_group.ebpf_shmctl_call
-              description: Calls to syscall <code>shmctl(2)</code>.
+              description: Calls to syscall shmctl(2).
               unit: "calls/s"
               chart_type: stacked
               dimensions:
@@ -2892,7 +2892,7 @@ modules:
               dimensions:
                 - name: read
             - name: cgroup.vfs_fsync
-              description: Calls for <code>vfs_fsync</code>
+              description: Calls to vfs_fsync.
               unit: "calls/s"
               chart_type: line
               dimensions:
@@ -2904,7 +2904,7 @@ modules:
               dimensions:
                 - name: fsync
             - name: cgroup.vfs_open
-              description: Calls for <code>vfs_open</code>
+              description: Calls to vfs_open.
               unit: "calls/s"
               chart_type: line
               dimensions:
@@ -2916,7 +2916,7 @@ modules:
               dimensions:
                 - name: open
             - name: cgroup.vfs_create
-              description: Calls for <code>vfs_create</code>
+              description: Calls to vfs_create.
               unit: "calls/s"
               chart_type: line
               dimensions:
@@ -2970,7 +2970,7 @@ modules:
               dimensions:
                 - name: a dimension per systemd service
             - name: services.vfs_fsync
-              description: Calls to <code>vfs_fsync</code>
+              description: Calls to vfs_fsync.
               unit: "calls/s"
               chart_type: stacked
               dimensions:
@@ -2982,7 +2982,7 @@ modules:
               dimensions:
                 - name: a dimension per systemd service
             - name: services.vfs_open
-              description: Calls to <code>vfs_open</code>
+              description: Calls to vfs_open.
               unit: "calls/s"
               chart_type: stacked
               dimensions:
@@ -2994,7 +2994,7 @@ modules:
               dimensions:
                 - name: a dimension per systemd service
             - name: services.vfs_create
-              description: Calls to <code>vfs_create</code>
+              description: Calls to vfs_create.
               unit: "calls/s"
               chart_type: stacked
               dimensions:
@@ -3037,7 +3037,7 @@ modules:
                 - name: read
                 - name: write
             - name: filesystem.vfs_fsync
-              description: Calls for <code>vfs_fsync</code>
+              description: Calls to vfs_fsync.
               unit: "calls/s"
               chart_type: line
               dimensions:
@@ -3049,7 +3049,7 @@ modules:
               dimensions:
                 - name: fsync
             - name: filesystem.vfs_open
-              description: Calls for <code>vfs_open</code>
+              description: Calls to vfs_open.
               unit: "calls/s"
               chart_type: line
               dimensions:
@@ -3061,7 +3061,7 @@ modules:
               dimensions:
                 - name: open
             - name: filesystem.vfs_create
-              description: Calls for <code>vfs_create</code>
+              description: Calls to vfs_create.
               unit: "calls/s"
               chart_type: line
               dimensions:
@@ -3119,7 +3119,7 @@ modules:
               dimensions:
                 - name: reads
             - name: app_group.ebpf_call_vfs_fsync
-              description: Calls for <code>vfs_fsync</code>
+              description: Calls to vfs_fsync.
               unit: "calls/s"
               chart_type: stacked
               dimensions:
@@ -3131,7 +3131,7 @@ modules:
               dimensions:
                 - name: calls
             - name: app_group.ebpf_call_vfs_open
-              description: Calls for <code>vfs_open</code>
+              description: Calls to vfs_open.
               unit: "calls/s"
               chart_type: stacked
               dimensions:
@@ -3143,7 +3143,7 @@ modules:
               dimensions:
                 - name: calls
             - name: app_group.ebpf_call_vfs_create
-              description: Calls for <code>vfs_create</code>
+              description: Calls to vfs_create.
               unit: "calls/s"
               chart_type: stacked
               dimensions:

--- a/collectors/ebpf.plugin/metadata.yaml
+++ b/collectors/ebpf.plugin/metadata.yaml
@@ -843,25 +843,25 @@ modules:
           description: "These Metrics show grouped information per apps group."
           labels: []
           metrics:
-            - name: apps.cachestat_ratio
+            - name: app_group.ebpf_cachestat_hit_ratio
               description: Hit ratio
               unit: "%"
               chart_type: line
               dimensions:
                 - name: a dimension per app group
-            - name: apps.cachestat_dirties
+            - name: app_group.ebpf_cachestat_dirty_pages
               description: Number of dirty pages
               unit: "page/s"
               chart_type: stacked
               dimensions:
                 - name: a dimension per app group
-            - name: apps.cachestat_hits
+            - name: app_group.ebpf_cachestat_access
               description: Number of accessed files
               unit: "hits/s"
               chart_type: stacked
               dimensions:
                 - name: a dimension per app group
-            - name: apps.cachestat_misses
+            - name: app_group.ebpf_cachestat_misses
               description: Files out of page cache
               unit: "misses/s"
               chart_type: stacked

--- a/collectors/ebpf.plugin/metadata.yaml
+++ b/collectors/ebpf.plugin/metadata.yaml
@@ -198,30 +198,30 @@ modules:
           description: "These Metrics show grouped information per apps group."
           labels: []
           metrics:
-            - name: apps.file_open
+            - name: app_group.ebpf_file_open
               description: Number of open files
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.file_open_error
+                - name: calls
+            - name: app_group.ebpf_file_open_error
               description: Fails to open files
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.file_closed
+                - name: calls
+            - name: app_group.ebpf_file_closed
               description: Files closed
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.file_close_error
+                - name: calls
+            - name: app_group.ebpf_file_close_error
               description: Fails to close files
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
+                - name: calls
   - meta:
       plugin_name: ebpf.plugin
       module_name: processes

--- a/collectors/ebpf.plugin/metadata.yaml
+++ b/collectors/ebpf.plugin/metadata.yaml
@@ -2460,30 +2460,30 @@ modules:
           description: "These Metrics show grouped information per apps group."
           labels: []
           metrics:
-            - name: apps.shmget_call
+            - name: app_group.ebpf_shmget_call
               description: Calls to syscall <code>shmget(2)</code>.
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.shmat_call
+                - name: calls
+            - name: app_group.ebpf_shmat_call
               description: Calls to syscall <code>shmat(2)</code>.
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.shmdt_call
+                - name: calls
+            - name: app_group.ebpf_shmdt_call
               description: Calls to syscall <code>shmdt(2)</code>.
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.shmctl_call
+                - name: calls
+            - name: app_group.ebpf_shmctl_call
               description: Calls to syscall <code>shmctl(2)</code>.
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
+                - name: calls
         - name: global
           description: "These Metrics show number of calls for specified syscall."
           labels: []

--- a/collectors/ebpf.plugin/metadata.yaml
+++ b/collectors/ebpf.plugin/metadata.yaml
@@ -1715,66 +1715,60 @@ modules:
           description: "These metrics show grouped information per apps group."
           labels: []
           metrics:
-            - name: apps.outbound_conn_v4
+            - name: app_group.ebpf_call_tcp_v4_connection
               description: Calls to tcp_v4_connection
               unit: "connections/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.outbound_conn_v6
+                - name: connections
+            - name: app_group.app.ebpf_call_tcp_v6_connection
               description: Calls to tcp_v6_connection
               unit: "connections/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.total_bandwidth_sent
+                - name: connections
+            - name: app_group.ebpf_sock_bytes_sent
               description: Bytes sent
               unit: "kilobits/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.total_bandwidth_recv
+                - name: bandwidth
+            - name: app_group.ebpf_sock_bytes_received
               description: bytes received
               unit: "kilobits/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.bandwidth_tcp_send
+                - name: bandwidth
+            - name: app_group.ebpf_call_tcp_sendmsg
               description: Calls for tcp_sendmsg
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.bandwidth_tcp_recv
+                - name: calls
+            - name: app_group.ebpf_call_tcp_cleanup_rbuf
               description: Calls for tcp_cleanup_rbuf
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.bandwidth_tcp_retransmit
+                - name: calls
+            - name: app_group.ebpf_call_tcp_retransmit
               description: Calls for tcp_retransmit
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.bandwidth_udp_send
+                - name: calls
+            - name: app_group.ebpf_call_udp_sendmsg
               description: Calls for udp_sendmsg
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: apps.bandwidth_udp_recv
+                - name: calls
+            - name: app_group.ebpf_call_udp_recvmsg
               description: Calls for udp_recvmsg
               unit: "calls/s"
               chart_type: stacked
               dimensions:
-                - name: a dimension per app group
-            - name: services.net_conn_ipv4
-              description: Calls to tcp_v4_connection
-              unit: "connections/s"
-              chart_type: stacked
-              dimensions:
-                - name: a dimension per systemd service
+                - name: calls
         - name: cgroup
           description: ""
           labels: []

--- a/collectors/ebpf.plugin/metadata.yaml
+++ b/collectors/ebpf.plugin/metadata.yaml
@@ -196,7 +196,9 @@ modules:
                 - name: close
         - name: apps
           description: "These Metrics show grouped information per apps group."
-          labels: []
+          labels:
+            - name: app_group
+              description: The name of the group defined in the configuration.
           metrics:
             - name: app_group.ebpf_file_open
               description: Number of open files
@@ -379,7 +381,9 @@ modules:
                 - name: task
         - name: apps
           description: "These Metrics show grouped information per apps group."
-          labels: []
+          labels:
+            - name: app_group
+              description: The name of the group defined in the configuration.
           metrics:
             - name: app_group.process_create
               description: Process started
@@ -841,7 +845,9 @@ modules:
                 - name: miss
         - name: apps
           description: "These Metrics show grouped information per apps group."
-          labels: []
+          labels:
+            - name: app_group
+              description: The name of the group defined in the configuration.
           metrics:
             - name: app_group.ebpf_cachestat_hit_ratio
               description: Hit ratio
@@ -1358,7 +1364,9 @@ modules:
                 - name: a dimension per systemd service
         - name: apps
           description: "These Metrics show grouped information per apps group."
-          labels: []
+          labels:
+            - name: app_group
+              description: The name of the group defined in the configuration.
           metrics:
             - name: app_group.ebpf_call_swap_readpage
               description: Calls to function swap_readpage.
@@ -1501,7 +1509,9 @@ modules:
                 - name: a dimension per systemd service
         - name: apps
           description: "These metrics show cgroup/service that reached OOM."
-          labels: []
+          labels:
+            - name: app_group
+              description: The name of the group defined in the configuration.
           metrics:
             - name: app_group.oomkill
               description: OOM kills
@@ -1713,7 +1723,9 @@ modules:
                 - name: send
         - name: apps
           description: "These metrics show grouped information per apps group."
-          labels: []
+          labels:
+            - name: app_group
+              description: The name of the group defined in the configuration.
           metrics:
             - name: app_group.ebpf_call_tcp_v4_connection
               description: Calls to tcp_v4_connection
@@ -1999,7 +2011,9 @@ modules:
       scopes:
         - name: apps
           description: "These Metrics show grouped information per apps group."
-          labels: []
+          labels:
+            - name: app_group
+              description: The name of the group defined in the configuration.
           metrics:
             - name: app_group.ebpf_dc_ratio
               description: Percentage of files inside directory cache
@@ -2452,7 +2466,9 @@ modules:
                 - name: a dimension per systemd service
         - name: apps
           description: "These Metrics show grouped information per apps group."
-          labels: []
+          labels:
+            - name: app_group
+              description: The name of the group defined in the configuration.
           metrics:
             - name: app_group.ebpf_shmget_call
               description: Calls to syscall shmget(2).
@@ -3074,7 +3090,9 @@ modules:
                 - name: create
         - name: apps
           description: "These Metrics show grouped information per apps group."
-          labels: []
+          labels:
+            - name: app_group
+              description: The name of the group defined in the configuration.
           metrics:
             - name: app_group.ebpf_call_vfs_unlink
               description: Files deleted

--- a/collectors/ebpf.plugin/metadata.yaml
+++ b/collectors/ebpf.plugin/metadata.yaml
@@ -1360,13 +1360,13 @@ modules:
           description: "These Metrics show grouped information per apps group."
           labels: []
           metrics:
-            - name: apps.swap_read_call
+            - name: app_group.ebpf_call_swap_readpage
               description: Calls to function <code>swap_readpage</code>.
               unit: "calls/s"
               chart_type: stacked
               dimensions:
                 - name: a dimension per app group
-            - name: apps.swap_write_call
+            - name: app_group.ebpf_call_swap_writepage
               description: Calls to function <code>swap_writepage</code>.
               unit: "calls/s"
               chart_type: stacked


### PR DESCRIPTION
##### Summary
Update eBPF charts to have same pattern used with apps.plugin.

##### Test Plan
1. Change your configuration file `/etc/netdata/ebpf.d.conf` to:
```sh
[global]
    ebpf load mode = return
[ebpf programs]
    cachestat = yes
    dcstat = yes
    fd = yes
    process = yes
    shm = yes
    socket = yes
    swap = yes
    vfs = yes
```
2. Compile this branch
3. Start netdata confirming we have charts per app. You can also confirm this through our API accessing http://localhost:19999/api/v1/charts?all

##### Additional Information
<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? ebpf.plugin
- Can they see the change or is it an under the hood? If they can see it, where? Yes, now we won't have more one chart grouping apps data.
- How is the user impacted by the change? Explicit metrics.
- What are there any benefits of the change? We have now the same pattern used with apps and other software.
</details>
