### PR TITLE
uninstaller: remove ND systemd preset and tmp dir

### DIFF
--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -158,7 +158,7 @@ create_tmp_directory() {
     fi
   fi
 
-  mktemp -d -t netdata-kickstart-XXXXXXXXXX
+  mktemp -d -t netdata-uninstaller-XXXXXXXXXX
 }
 
 tmpdir="$(create_tmp_directory)"
@@ -725,6 +725,8 @@ rm_file /usr/lib/systemd/system/netdata-updater.service
 rm_file /etc/systemd/system/netdata-updater.timer
 rm_file /lib/systemd/system/netdata-updater.timer
 rm_file /usr/lib/systemd/system/netdata-updater.timer
+rm_file /usr/lib/systemd/system-preset/50-netdata.preset
+rm_file /lib/systemd/system-preset/50-netdata.preset
 rm_file /etc/init.d/netdata
 rm_file /etc/periodic/daily/netdata-updater
 rm_file /etc/cron.daily/netdata-updater
@@ -737,6 +739,7 @@ else
   rm_file "/usr/sbin/netdata"
   rm_file "/usr/sbin/netdatacli"
   rm_file "/tmp/netdata-ipc"
+  rm_file "/tmp/netdata-service-cmds"
   rm_file "/usr/sbin/netdata-claim.sh"
   rm_dir "/usr/share/netdata"
   rm_dir "/usr/libexec/netdata"
@@ -744,6 +747,10 @@ else
   rm_dir "/var/cache/netdata"
   rm_dir "/var/log/netdata"
   rm_dir "/etc/netdata"
+fi
+
+if [ -n "${tmpdir}" ]; then
+  run rm -rf "${tmpdir}" || true
 fi
 
 FILE_REMOVAL_STATUS=1


### PR DESCRIPTION
##### Summary

Fixes: #16147

I think the only missing part is `systemctl daemon-reload` after stopping ND/deleting ND systemd files, but that is a different issue and subject to a separate PR.

##### Test Plan

```bash
sudo ./kickstart.sh --static-only
./kickstart.sh --uninstall


find /usr/lib/systemd -iname "*netdata*"
find /tmp -iname "*netdata*"
```

Check `/tmp`


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
