### PR TITLE
journal: updates

### DIFF
--- a/collectors/systemd-journal.plugin/README.md
+++ b/collectors/systemd-journal.plugin/README.md
@@ -98,6 +98,13 @@ For information about configuring a journals' centralization server, check [this
 
 ## Journal Fields
 
+`systemd` journals are designed to support multiple fields per log entry. The power of `systemd` journals is that
+unlike other log management systems, it supports different, dynamic and variable fields for each log message
+while all fields are indexed for fast queries.
+
+This means that each application can log using its own unique fields.
+For a description of the most frequent fields found in `systemd` journals, check `man systemd.journal-fields`. 
+
 Fields found in the journal files are automatically added to the UI in multiple places to help you explore
 and filter the data.
 
@@ -107,17 +114,17 @@ The plugin automatically enriches certain fields to make them more user-friendly
 - `PRIORITY`: the numeric value is replaced with the human-readable name of each priority.
 - `SYSLOG_FACILITY`: the encoded value is replaced with the human-readable name of each facility.
 - `ERRNO`: the numeric value is annotated with the short name of each value.
-- `_UID` `_AUDIT_LOGINUID` and `_SYSTEMD_OWNER_UID`: the local user database is consulted to annotate them with usernames.
-- `_GID`: the local group database is consulted to annotate them with group names.
+- `_UID` `_AUDIT_LOGINUID`, `_SYSTEMD_OWNER_UID`, `OBJECT_UID`, `OBJECT_SYSTEMD_OWNER_UID`, `OBJECT_AUDIT_LOGINUID`: the local user database is consulted to annotate them with usernames.
+- `_GID`, `OBJECT_GID`: the local group database is consulted to annotate them with group names.
 - `_CAP_EFFECTIVE`: the encoded value is annotated with a human-readable list of the linux capabilities.
 - `_SOURCE_REALTIME_TIMESTAMP`: the numeric value is annotated with human-readable datetime in UTC.
 
 The values of all other fields are presented as found in the journals.
 
 > IMPORTANT:
-> `_UID` `_AUDIT_LOGINUID`, `_SYSTEMD_OWNER_UID` and `_GID` annotations are added during presentation and are taken
-> from the server running the plugin. For `remote` sources, the names presented may not reflect the actual user and
-> group names on the origin server. The numeric value will still be visible though, as-is on the origin server.
+> The UID and GID annotations are added during presentation and are taken from the server running the plugin.
+> For `remote` sources, the names presented may not reflect the actual user and group names on the origin server.
+> The numeric value will still be visible though, as-is on the origin server.
 
 The annotations are not searchable with full text search. They are only added for the presentation of the fields. 
 


### PR DESCRIPTION
- [x] dynamic facets hashtables, for faster operation when the keys have really a lot of values, or when there is a huge number of keys
- [x] more default facets fields for journal
- [x] enforce the facets blacklist
- [x] mark the fields as non-sortable
- [x] require at least 2 items to be returned
- [x] enable `fstat` caching at a thread level to help `libsystemd` go faster
