### PR TITLE
Don't queue removed when there is a newer alert

### DIFF
--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -690,7 +690,7 @@ void aclk_start_alert_streaming(char *node_id, bool resets)
     "WHERE hl.host_id = @host_id AND hl.health_log_id = hld.health_log_id AND hld.new_status = -2 AND hld.updated_by_id = 0 " \
     "AND hld.unique_id NOT IN (SELECT alert_unique_id FROM aclk_alert_%s) " \
     "AND hl.config_hash_id NOT IN (select hash_id from alert_hash where warn is null and crit is null) " \
-    "AND hl.name || hl.chart NOT IN (select name || chart from health_log where name = hl.name and chart = hl.chart and alarm_id > hl.alarm_id) " \
+    "AND hl.name || hl.chart NOT IN (select name || chart from health_log where name = hl.name and chart = hl.chart and alarm_id > hl.alarm_id and host_id = hl.host_id) " \
     "ORDER BY hld.unique_id ASC ON CONFLICT (alert_unique_id) DO NOTHING;"
 void sql_process_queue_removed_alerts_to_aclk(char *node_id)
 {

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -690,6 +690,7 @@ void aclk_start_alert_streaming(char *node_id, bool resets)
     "WHERE hl.host_id = @host_id AND hl.health_log_id = hld.health_log_id AND hld.new_status = -2 AND hld.updated_by_id = 0 " \
     "AND hld.unique_id NOT IN (SELECT alert_unique_id FROM aclk_alert_%s) " \
     "AND hl.config_hash_id NOT IN (select hash_id from alert_hash where warn is null and crit is null) " \
+    "AND hl.name + hl.chart NOT IN (select name + chart from health_log where name = hl.name and chart = hl.chart and alarm_id > hl.alarm_id) " \
     "ORDER BY hld.unique_id ASC ON CONFLICT (alert_unique_id) DO NOTHING;"
 void sql_process_queue_removed_alerts_to_aclk(char *node_id)
 {

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -690,7 +690,7 @@ void aclk_start_alert_streaming(char *node_id, bool resets)
     "WHERE hl.host_id = @host_id AND hl.health_log_id = hld.health_log_id AND hld.new_status = -2 AND hld.updated_by_id = 0 " \
     "AND hld.unique_id NOT IN (SELECT alert_unique_id FROM aclk_alert_%s) " \
     "AND hl.config_hash_id NOT IN (select hash_id from alert_hash where warn is null and crit is null) " \
-    "AND hl.name + hl.chart NOT IN (select name + chart from health_log where name = hl.name and chart = hl.chart and alarm_id > hl.alarm_id) " \
+    "AND hl.name || hl.chart NOT IN (select name || chart from health_log where name = hl.name and chart = hl.chart and alarm_id > hl.alarm_id) " \
     "ORDER BY hld.unique_id ASC ON CONFLICT (alert_unique_id) DO NOTHING;"
 void sql_process_queue_removed_alerts_to_aclk(char *node_id)
 {


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

When there is a configuration change in an alert that does not involve it's name and chart, the agent starts a new alert chain (with a different alarm_id). It will then transmit a REMOVED for the previous chain, and a new status for the new one.

However, for the cloud, if the name and chart remain the same it's still considered the same alert. With the way it works, the cloud will receive the new alert and then the REMOVED.

This PR adds an additional check when it queues REMOVED events. If there is a newer (based on the alarm_id) alert with the same name and chart, it will not send that REMOVED event.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Test requires some digging on the sqlite database, or using the `converstation log` to check the messages to the cloud.

When running this PR on a claimed running agent, pick a random alert and slightly alter it's configuration (i.e. a new `info`). Then restart the agent and observe that the new alert is transmitted but not a REMOVED for it's previous config.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
