### PR TITLE
apps: remove mem_private on FreeBSD

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -3777,13 +3777,14 @@ static void send_collected_data_to_netdata(struct target *root, const char *type
         send_SET("voluntary", w->status_voluntary_ctxt_switches);
         send_SET("involuntary", w->status_nonvoluntary_ctxt_switches);
         send_END();
-#endif
-        send_BEGIN(type, w->clean_name, "mem_usage", dt);
-        send_SET("rss", w->status_vmrss);
-        send_END();
 
         send_BEGIN(type, w->clean_name, "mem_private_usage", dt);
         send_SET("mem", (w->status_vmrss > w->status_vmshared)?(w->status_vmrss - w->status_vmshared) : 0ULL);
+        send_END();
+#endif
+
+        send_BEGIN(type, w->clean_name, "mem_usage", dt);
+        send_SET("rss", w->status_vmrss);
         send_END();
 
         send_BEGIN(type, w->clean_name, "vmem_usage", dt);
@@ -3892,17 +3893,17 @@ static void send_charts_updates_to_netdata(struct target *root, const char *type
         fprintf(stdout, "CLABEL_COMMIT\n");
         fprintf(stdout, "DIMENSION voluntary '' absolute 1 %llu\n", RATES_DETAIL);
         fprintf(stdout, "DIMENSION involuntary '' absolute 1 %llu\n", RATES_DETAIL);
-#endif
 
-        fprintf(stdout, "CHART %s.%s_mem_usage '' '%s memory RSS usage' 'MiB' mem %s.mem_usage area 20050 %d\n", type, w->clean_name, title, type, update_every);
-        fprintf(stdout, "CLABEL '%s' '%s' 0\n", lbl_name, w->name);
-        fprintf(stdout, "CLABEL_COMMIT\n");
-        fprintf(stdout, "DIMENSION rss '' absolute %ld %ld\n", 1L, 1024L);
-
-        fprintf(stdout, "CHART %s.%s_mem_private_usage '' '%s memory usage without shared' 'MiB' mem %s.mem_private_usage area 20055 %d\n", type, w->clean_name, title, type, update_every);
+        fprintf(stdout, "CHART %s.%s_mem_private_usage '' '%s memory usage without shared' 'MiB' mem %s.mem_private_usage area 20050 %d\n", type, w->clean_name, title, type, update_every);
         fprintf(stdout, "CLABEL '%s' '%s' 0\n", lbl_name, w->name);
         fprintf(stdout, "CLABEL_COMMIT\n");
         fprintf(stdout, "DIMENSION mem '' absolute %ld %ld\n", 1L, 1024L);
+#endif
+
+        fprintf(stdout, "CHART %s.%s_mem_usage '' '%s memory RSS usage' 'MiB' mem %s.mem_usage area 20055 %d\n", type, w->clean_name, title, type, update_every);
+        fprintf(stdout, "CLABEL '%s' '%s' 0\n", lbl_name, w->name);
+        fprintf(stdout, "CLABEL_COMMIT\n");
+        fprintf(stdout, "DIMENSION rss '' absolute %ld %ld\n", 1L, 1024L);
 
         fprintf(stdout, "CHART %s.%s_mem_page_faults '' '%s memory page faults' 'pgfaults/s' mem %s.mem_page_faults stacked 20060 %d\n", type, w->clean_name, title, type, update_every);
         fprintf(stdout, "CLABEL '%s' '%s' 0\n", lbl_name, w->name);


### PR DESCRIPTION
##### Summary

This PR removes `mem_private_usage` (rss - shared) apps.plugin chart on FreeBSD because we don't collect shared.

https://github.com/netdata/netdata/blob/f7789e1a83fa819cb072b7d818aef1ceb79c1bcb/collectors/apps.plugin/apps_plugin.c#L1518-L1525

##### Test Plan

- install on Linux, check `mem_private_usage` - exists.
- install on FreeBSD, check `mem_private_usage` - doesn't exist.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
