### PR TITLE
Add agent version on startup

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1897,6 +1897,7 @@ int main(int argc, char **argv) {
 
         // initialize the log files
         open_all_log_files();
+        netdata_log_info("Netdata agent version \""VERSION"\" is starting");
 
         ieee754_doubles = is_system_ieee754_double();
 


### PR DESCRIPTION
##### Summary
Just log the agent version on startup 

```
2023-10-13 22:46:50: netdata INFO  : MAIN : Netdata agent version "v1.42.0-345-gb7ef34c3d" is starting
```
