### PR TITLE
docker install: support for Proxmox vms/containers name resolution

### DIFF
--- a/collectors/cgroups.plugin/cgroup-name.sh
+++ b/collectors/cgroups.plugin/cgroup-name.sh
@@ -620,21 +620,19 @@ if [ -z "${NAME}" ]; then
     # libvirtd / qemu virtual machines
     NAME="qemu_$(echo "${CGROUP}" | sed 's/^machine_//; s/\.libvirt-qemu$//; s/-/_/;')"
 
-  elif [[ ${CGROUP} =~ qemu.slice_([0-9]+).scope && -d /etc/pve ]]; then
+  elif [[ ${CGROUP} =~ qemu.slice_([0-9]+).scope && -d "${NETDATA_HOST_PREFIX}/etc/pve" ]]; then
     # Proxmox VMs
-
-    FILENAME="/etc/pve/qemu-server/${BASH_REMATCH[1]}.conf"
+    FILENAME="${NETDATA_HOST_PREFIX}/etc/pve/qemu-server/${BASH_REMATCH[1]}.conf"
     if [[ -f $FILENAME && -r $FILENAME ]]; then
-      NAME="qemu_$(grep -e '^name: ' "/etc/pve/qemu-server/${BASH_REMATCH[1]}.conf" | head -1 | sed -rn 's|\s*name\s*:\s*(.*)?$|\1|p')"
+      NAME="qemu_$(grep -e '^name: ' "${FILENAME}" | head -1 | sed -rn 's|\s*name\s*:\s*(.*)?$|\1|p')"
     else
       error "proxmox config file missing ${FILENAME} or netdata does not have read access.  Please ensure netdata is a member of www-data group."
     fi
-  elif [[ ${CGROUP} =~ lxc_([0-9]+) && -d /etc/pve ]]; then
+  elif [[ ${CGROUP} =~ lxc_([0-9]+) && -d "${NETDATA_HOST_PREFIX}/etc/pve" ]]; then
     # Proxmox Containers (LXC)
-
-    FILENAME="/etc/pve/lxc/${BASH_REMATCH[1]}.conf"
+    FILENAME="${NETDATA_HOST_PREFIX}/etc/pve/lxc/${BASH_REMATCH[1]}.conf"
     if [[ -f ${FILENAME} && -r ${FILENAME} ]]; then
-      NAME=$(grep -e '^hostname: ' "/etc/pve/lxc/${BASH_REMATCH[1]}.conf" | head -1 | sed -rn 's|\s*hostname\s*:\s*(.*)?$|\1|p')
+      NAME=$(grep -e '^hostname: ' "${FILENAME}" | head -1 | sed -rn 's|\s*hostname\s*:\s*(.*)?$|\1|p')
     else
       error "proxmox config file missing ${FILENAME} or netdata does not have read access.  Please ensure netdata is a member of www-data group."
     fi

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -46,6 +46,16 @@ if [ -n "${PGID}" ]; then
   usermod -a -G "${PGID}" "${DOCKER_USR}" || echo >&2 "Could not add netdata user to group docker with ID ${PGID}"
 fi
 
+# Needed to read Proxmox VMs and (LXC) containers configuration files (name resolution + CPU and memory limits)
+HOST_WWW_DATA_GID=$(stat -c %g /host/etc/pve 2>/dev/null || true)
+
+if [ -n "${HOST_WWW_DATA_GID}" ]; then
+  echo "Creating host-www-data group ${HOST_WWW_DATA_GID}"
+  addgroup -g "${HOST_WWW_DATA_GID}" "host-www-data" || echo >&2 "Could not add group with ID ${HOST_WWW_DATA_GID}, its already there probably"
+  echo "Assign netdata user to host-www-data group ${HOST_WWW_DATA_GID}"
+  usermod -a -G "${HOST_WWW_DATA_GID}" "${DOCKER_USR}" || echo >&2 "Could not add netdata user to group with ID ${HOST_WWW_DATA_GID}"
+fi
+
 if mountpoint -q /etc/netdata; then
   echo "Copying stock configuration to /etc/netdata"
   cp -an /etc/netdata.stock/* /etc/netdata

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -68,7 +68,9 @@ function add_netdata_to_proxmox_conf_files_group() {
   fi
 }
 
-[ -d "/host/etc/pve" ] && add_netdata_to_proxmox_conf_files_group
+if [ -d "/host/etc/pve" ]; then
+  add_netdata_to_proxmox_conf_files_group || true
+fi
 
 
 if mountpoint -q /etc/netdata; then


### PR DESCRIPTION
##### Summary

Proxmox virtual machine/container names, CPU and memory limits are found in the configuration files:

|  Type   | Dir |
| :-------- | :-------: |
| VMs  | `/etc/pve/qemu-server/`    |
| Containers | `/etc/pve/lxc/`     |

This PR:

- Adds `netdata` user to the host's `www-data` group (only if the host is a Proxmox host, needed to read the configuration file).
- Adds support for `NETDATA_HOST_PREFIX` in `cgroup-name.sh` for Proxmox name resolution.

##### Test Plan

Test that name resolution works by installing this PR on Proxmox:
 - docker ND (`-v /etc/pve:/host/etc/pve:ro` mount is needed).
 - regular ND.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
