### PR TITLE
cgroup-network: don't log an error opening pid file if doesn't exist

### DIFF
--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -288,7 +288,8 @@ int switch_namespace(const char *prefix, pid_t pid) {
 pid_t read_pid_from_cgroup_file(const char *filename) {
     int fd = open(filename, procfile_open_flags);
     if(fd == -1) {
-        collector_error("Cannot open pid_from_cgroup() file '%s'.", filename);
+        if (errno != ENOENT)
+            collector_error("Cannot open pid_from_cgroup() file '%s'.", filename);
         return 0;
     }
 


### PR DESCRIPTION
##### Summary

`cgroup-network` tries to [read **cgroup.procs** and **tasks**](https://github.com/netdata/netdata/blob/b1121d4e02bd62a150e5cab849778624c67db2ea/collectors/cgroups.plugin/cgroup-network.c#L319-L328). The latter doesn't always exist, so it is not an error to fail to open it.


##### Test Plan

Check logs.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
