### PR TITLE
health: attach drops ratio alarms to net.drops

### DIFF
--- a/collectors/freebsd.plugin/metadata.yaml
+++ b/collectors/freebsd.plugin/metadata.yaml
@@ -2893,36 +2893,16 @@ modules:
         metric: net.net
         info: network interface ${label:device} current speed
         os: "*"
-      - name: 1m_received_traffic_overflow
-        link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
-        metric: net.net
-        info: average inbound utilization for the network interface ${label:device} over the last minute
-        os: "linux"
-      - name: 1m_sent_traffic_overflow
-        link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
-        metric: net.net
-        info: average outbound utilization for the network interface ${label:device} over the last minute
-        os: "linux"
       - name: inbound_packets_dropped_ratio
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
-        metric: net.packets
+        metric: net.drops
         info: ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
-        os: "linux"
+        os: "*"
       - name: outbound_packets_dropped_ratio
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
-        metric: net.packets
+        metric: net.drops
         info: ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
-        os: "linux"
-      - name: wifi_inbound_packets_dropped_ratio
-        link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
-        metric: net.packets
-        info: ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
-        os: "linux"
-      - name: wifi_outbound_packets_dropped_ratio
-        link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
-        metric: net.packets
-        info: ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
-        os: "linux"
+        os: "*"
       - name: 1m_received_packets_rate
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
@@ -2931,9 +2911,7 @@ modules:
       - name: 10s_received_packets_storm
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info:
-          ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, compared to the rate over
-          the last minute
+        info: ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, compared to the rate over the last minute
         os: "linux freebsd"
       - name: interface_inbound_errors
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
@@ -2945,16 +2923,6 @@ modules:
         metric: net.errors
         info: number of outbound errors for the network interface ${label:device} in the last 10 minutes
         os: "freebsd"
-      - name: inbound_packets_dropped
-        link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
-        metric: net.drops
-        info: number of inbound dropped packets for the network interface ${label:device} in the last 10 minutes
-        os: "linux"
-      - name: outbound_packets_dropped
-        link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
-        metric: net.drops
-        info: number of outbound dropped packets for the network interface ${label:device} in the last 10 minutes
-        os: "linux"
     metrics:
       folding:
         title: Metrics

--- a/collectors/proc.plugin/metadata.yaml
+++ b/collectors/proc.plugin/metadata.yaml
@@ -2643,22 +2643,22 @@ modules:
         os: "linux"
       - name: inbound_packets_dropped_ratio
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
-        metric: net.packets
+        metric: net.drops
         info: ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
         os: "linux"
       - name: outbound_packets_dropped_ratio
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
-        metric: net.packets
+        metric: net.drops
         info: ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
         os: "linux"
       - name: wifi_inbound_packets_dropped_ratio
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
-        metric: net.packets
+        metric: net.drops
         info: ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
         os: "linux"
       - name: wifi_outbound_packets_dropped_ratio
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
-        metric: net.packets
+        metric: net.drops
         info: ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
         os: "linux"
       - name: 1m_received_packets_rate
@@ -2669,20 +2669,8 @@ modules:
       - name: 10s_received_packets_storm
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.packets
-        info:
-          ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, compared to the rate over
-          the last minute
+        info: ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, compared to the rate over the last minute
         os: "linux freebsd"
-      - name: inbound_packets_dropped
-        link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
-        metric: net.drops
-        info: number of inbound dropped packets for the network interface ${label:device} in the last 10 minutes
-        os: "linux"
-      - name: outbound_packets_dropped
-        link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
-        metric: net.drops
-        info: number of outbound dropped packets for the network interface ${label:device} in the last 10 minutes
-        os: "linux"
       - name: 10min_fifo_errors
         link: https://github.com/netdata/netdata/blob/master/health/health.d/net.conf
         metric: net.fifo

--- a/health/health.d/net.conf
+++ b/health/health.d/net.conf
@@ -65,7 +65,7 @@ component: Network
     class: Workload
      type: System
 component: Network
-       os: linux
+       os: *
     hosts: *
    lookup: sum -10m unaligned absolute of received
     units: packets
@@ -78,7 +78,7 @@ component: Network
     class: Workload
      type: System
 component: Network
-       os: linux
+       os: *
     hosts: *
    lookup: sum -10m unaligned absolute of sent
     units: packets
@@ -91,7 +91,7 @@ component: Network
     class: Errors
      type: System
 component: Network
-       os: linux
+       os: *
     hosts: *
 chart labels: device=!wl* *
    lookup: sum -10m unaligned absolute of inbound
@@ -109,7 +109,7 @@ chart labels: device=!wl* *
     class: Errors
      type: System
 component: Network
-       os: linux
+       os: *
     hosts: *
 chart labels: device=!wl* *
    lookup: sum -10m unaligned absolute of outbound

--- a/health/health.d/net.conf
+++ b/health/health.d/net.conf
@@ -60,40 +60,42 @@ component: Network
 # it is possible to have expected packet drops on an interface for some network configurations
 # look at the Monitoring Network Interfaces section in the proc.plugin documentation for more information
 
- template: inbound_packets_dropped
-       on: net.drops
-    class: Errors
+ template: net_interface_inbound_packets
+       on: net.packets
+    class: Workload
      type: System
 component: Network
        os: linux
     hosts: *
-   lookup: sum -10m unaligned absolute of inbound
+   lookup: sum -10m unaligned absolute of received
     units: packets
     every: 1m
-     info: Number of inbound dropped packets for the network interface ${label:device} in the last 10 minutes
+  summary: Network interface ${label:device} received packets
+     info: Received packets for the network interface ${label:device} in the last 10 minutes
 
- template: outbound_packets_dropped
-       on: net.drops
-    class: Errors
+ template: net_interface_outbound_packets
+       on: net.packets
+    class: Workload
      type: System
 component: Network
        os: linux
     hosts: *
-   lookup: sum -10m unaligned absolute of outbound
+   lookup: sum -10m unaligned absolute of sent
     units: packets
     every: 1m
-     info: Number of outbound dropped packets for the network interface ${label:device} in the last 10 minutes
+  summary: Network interface ${label:device} sent packets
+     info: Sent packets for the network interface ${label:device} in the last 10 minutes
 
  template: inbound_packets_dropped_ratio
-       on: net.packets
+       on: net.drops
     class: Errors
      type: System
 component: Network
        os: linux
     hosts: *
 chart labels: device=!wl* *
-   lookup: sum -10m unaligned absolute of received
-     calc: (($inbound_packets_dropped != nan AND $this > 10000) ? ($inbound_packets_dropped * 100 / $this) : (0))
+   lookup: sum -10m unaligned absolute of inbound
+     calc: (($net_interface_inbound_packets > 10000) ? ($this * 100 / $net_interface_inbound_packets) : (0))
     units: %
     every: 1m
      warn: $this >= 2
@@ -103,15 +105,15 @@ chart labels: device=!wl* *
        to: silent
 
  template: outbound_packets_dropped_ratio
-       on: net.packets
+       on: net.drops
     class: Errors
      type: System
 component: Network
        os: linux
     hosts: *
 chart labels: device=!wl* *
-   lookup: sum -10m unaligned absolute of sent
-     calc: (($outbound_packets_dropped != nan AND $this > 1000) ? ($outbound_packets_dropped * 100 / $this) : (0))
+   lookup: sum -10m unaligned absolute of outbound
+     calc: (($net_interface_outbound_packets > 1000) ? ($this * 100 / $net_interface_outbound_packets) : (0))
     units: %
     every: 1m
      warn: $this >= 2
@@ -121,7 +123,7 @@ chart labels: device=!wl* *
        to: silent
 
  template: wifi_inbound_packets_dropped_ratio
-       on: net.packets
+       on: net.drops
     class: Errors
      type: System
 component: Network
@@ -129,7 +131,7 @@ component: Network
     hosts: *
 chart labels: device=wl*
    lookup: sum -10m unaligned absolute of received
-     calc: (($inbound_packets_dropped != nan AND $this > 10000) ? ($inbound_packets_dropped * 100 / $this) : (0))
+     calc: (($net_interface_inbound_packets > 10000) ? ($this * 100 / $net_interface_inbound_packets) : (0))
     units: %
     every: 1m
      warn: $this >= 10
@@ -139,7 +141,7 @@ chart labels: device=wl*
        to: silent
 
  template: wifi_outbound_packets_dropped_ratio
-       on: net.packets
+       on: net.drops
     class: Errors
      type: System
 component: Network
@@ -147,7 +149,7 @@ component: Network
     hosts: *
 chart labels: device=wl*
    lookup: sum -10m unaligned absolute of sent
-     calc: (($outbound_packets_dropped != nan AND $this > 1000) ? ($outbound_packets_dropped * 100 / $this) : (0))
+     calc: (($net_interface_outbound_packets > 1000) ? ($this * 100 / $net_interface_outbound_packets) : (0))
     units: %
     every: 1m
      warn: $this >= 10


### PR DESCRIPTION
##### Summary

Instead of `net.packets` which is very confusing when you "go to chart".

##### Test Plan

Check net interface drops ratio alarms.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
