### PR TITLE
add summary to /alerts

### DIFF
--- a/database/contexts/api_v2.c
+++ b/database/contexts/api_v2.c
@@ -184,6 +184,7 @@ struct alert_v2_entry {
     RRDCALC *tmp;
 
     STRING *name;
+    STRING *summary;
 
     size_t ati;
 
@@ -315,6 +316,7 @@ static void alerts_v2_insert_callback(const DICTIONARY_ITEM *item __maybe_unused
     struct alert_v2_entry *t = value;
     RRDCALC *rc = t->tmp;
     t->name = rc->name;
+    t->summary = rc->summary;
     t->ati = ctl->alerts.ati++;
 
     t->nodes = dictionary_create(DICT_OPTION_SINGLE_THREADED|DICT_OPTION_VALUE_LINK_DONT_CLONE|DICT_OPTION_NAME_LINK_DONT_CLONE);
@@ -1400,6 +1402,7 @@ static void contexts_v2_alerts_to_json(BUFFER *wb, struct rrdcontext_to_json_v2_
                         {
                             buffer_json_member_add_uint64(wb, "ati", t->ati);
                             buffer_json_member_add_string(wb, "nm", string2str(t->name));
+                            buffer_json_member_add_string(wb, "sum", string2str(t->summary));
 
                             buffer_json_member_add_uint64(wb, "cr", t->critical);
                             buffer_json_member_add_uint64(wb, "wr", t->warning);


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Adds the `summary` field to `/api/v2/alerts` under the `alerts` array (it was only added to `alert_instances`).

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Start an agent and visit e.g. `http://localhost:19999//api/v2/alerts?options=summary,instances,values`. Summary (as `sum`) should be under the `alerts` array.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
