### PR TITLE
disable logging to syslog by default

### DIFF
--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -13,7 +13,7 @@ const char *program_name = "";
 uint64_t debug_flags = 0;
 
 int access_log_syslog = 1;
-int error_log_syslog = 1;
+int error_log_syslog = 0;
 int collector_log_syslog = 1;
 int output_log_syslog = 1;  // debug log
 int health_log_syslog = 1;

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -12,11 +12,11 @@ int web_server_is_multithreaded = 1;
 const char *program_name = "";
 uint64_t debug_flags = 0;
 
-int access_log_syslog = 1;
+int access_log_syslog = 0;
 int error_log_syslog = 0;
-int collector_log_syslog = 1;
-int output_log_syslog = 1;  // debug log
-int health_log_syslog = 1;
+int collector_log_syslog = 0;
+int output_log_syslog = 0;  // debug log
+int health_log_syslog = 0;
 
 int stdaccess_fd = -1;
 FILE *stdaccess = NULL;


### PR DESCRIPTION
##### Summary

It can be configured by changing the destination value to `syslog` (the default is a path to the file).

##### Test Plan

Install Netdata, check /var/log/syslog (and journalctl -u netdata).

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
