### PR TITLE
Fix statistics calculation in 32bit systems

### DIFF
--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -1427,8 +1427,8 @@ static void *query_prep_tp_worker(struct rrdengine_instance *ctx __maybe_unused,
     return data;
 }
 
-unsigned rrdeng_target_data_file_size(struct rrdengine_instance *ctx) {
-    unsigned target_size = ctx->config.max_disk_space / TARGET_DATAFILES;
+uint64_t rrdeng_target_data_file_size(struct rrdengine_instance *ctx) {
+    uint64_t target_size = ctx->config.max_disk_space / TARGET_DATAFILES;
     target_size = MIN(target_size, MAX_DATAFILE_SIZE);
     target_size = MAX(target_size, MIN_DATAFILE_SIZE);
     return target_size;

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -476,7 +476,7 @@ void pdc_route_synchronously(struct rrdengine_instance *ctx, struct page_details
 void pdc_acquire(PDC *pdc);
 bool pdc_release_and_destroy_if_unreferenced(PDC *pdc, bool worker, bool router);
 
-unsigned rrdeng_target_data_file_size(struct rrdengine_instance *ctx);
+uint64_t rrdeng_target_data_file_size(struct rrdengine_instance *ctx);
 
 struct page_descr_with_data *page_descriptor_get(void);
 

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -465,7 +465,7 @@ static inline uint64_t storage_engine_disk_space_max(STORAGE_ENGINE_BACKEND back
 }
 
 uint64_t rrdeng_disk_space_used(STORAGE_INSTANCE *db_instance);
-static inline size_t storage_engine_disk_space_used(STORAGE_ENGINE_BACKEND backend __maybe_unused, STORAGE_INSTANCE *db_instance __maybe_unused) {
+static inline uint64_t storage_engine_disk_space_used(STORAGE_ENGINE_BACKEND backend __maybe_unused, STORAGE_INSTANCE *db_instance __maybe_unused) {
 #ifdef ENABLE_DBENGINE
     if(likely(backend == STORAGE_ENGINE_BACKEND_DBENGINE))
         return rrdeng_disk_space_used(db_instance);


### PR DESCRIPTION
##### Summary
- Use uint64_t to prevent overflow on reported `disk_used` in 32bit systems
- Changed also when calculating target data file size

before
```
   "tier":0,
    "disk_used":3951299944,
    "disk_max":8589934592,
    "disk_percent":45.9991855,
    "from":1696413590,
    "to":1697532300,
    "retention":1118710,
    "expected_retention":2432021,
```

after
```
    "tier":0,
    "disk_used":8299235868,
    "disk_max":8589934592,
    "disk_percent":96.6158214,
    "from":1696413590,
    "to":1697535541,
    "retention":1121951,
    "expected_retention":1161249,
```


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
