### PR TITLE
Add Erlang to Apps configuration

### DIFF
--- a/collectors/apps.plugin/apps_groups.conf
+++ b/collectors/apps.plugin/apps_groups.conf
@@ -381,6 +381,7 @@ rabbitmq: *rabbitmq*
 sidekiq: *sidekiq*
 java: java
 ipfs: ipfs
+erlang: beam.smp
 
 node: node
 factorio: factorio


### PR DESCRIPTION
##### Summary

We run a couple of Elixir apps in production and would like Netdata to report their compute usage. A command starts usually like this:

```
/app/erts-12.3.2.13/bin/beam.smp -- -root /app -progname erl -- -home /app -- -noshell -s elixir start_cli ...
```

ERTS is the Erlang Runtime System, BEAM is the virtual machine where the code is executed. Therefore, I suggest to search for `erts` in `apps_groups.conf`, as its the "lowest" component of the Erlang stack.

Note that RabbitMQ also uses Erlang, but I placed the line lower than RabbitMQ, so that those rules apply first.

##### Test Plan

- Run a Erlang-based application, like an [Elixir console](https://hub.docker.com/_/elixir), on a monitored Netdata node.
- The apps plugin should now report separate data for this Erlang process.

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
- Which area of Netdata is affected by the change: Netdata Apps Plugin.
- Can they see the change or is it an under the hood? If they can see it, where?: Change is visible in the dashboard.
- How is the user impacted by the change?: Users with Erlang applications see separate reports of the Erlang resource consumption, otherwise no impact.
</details>
