### PR TITLE
uninstaller: remove /etc/cron.d/netdata-updater-daily

### DIFF
--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -731,6 +731,7 @@ rm_file /etc/init.d/netdata
 rm_file /etc/periodic/daily/netdata-updater
 rm_file /etc/cron.daily/netdata-updater
 rm_file /etc/cron.d/netdata-updater
+rm_file /etc/cron.d/netdata-updater-daily
 
 
 if [ -n "${NETDATA_PREFIX}" ] && [ -d "${NETDATA_PREFIX}" ] && [ "netdata" = "$(basename "$NETDATA_PREFIX")" ] ; then


### PR DESCRIPTION
##### Summary

Remove the updater file added for `crontab` updater type

https://github.com/netdata/netdata/blob/3af70c8f9ea269d7324a5be7ebc4dd69eb0495b3/packaging/installer/netdata-updater.sh#L238-L241

##### Test Plan

Not needed

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
