### PR TITLE
Reuse ML load prepared statement

### DIFF
--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -1539,12 +1539,19 @@ static void start_ml_model_load(uv_work_t *req __maybe_unused)
     RRDDIM *rd;
     RRDDIM_ACQUIRED *rda;
     internal_error(true, "Batch ML load loader, %zu items", ml_data->count);
+
+    sqlite3_stmt *ml_load_stmt = NULL;
     while((PValue = JudyLFirstThenNext(ml_data->JudyL, &Index, &first))) {
         UNUSED(PValue);
         rda = (RRDDIM_ACQUIRED *) Index;
         rd = rrddim_acquired_to_rrddim(rda);
-        ml_dimension_load_models(rd);
+        ml_dimension_load_models(rd, &ml_load_stmt);
         rrddim_acquired_release(rda);
+    }
+
+    if (ml_load_stmt) {
+        sqlite3_finalize(ml_load_stmt);
+        ml_load_stmt = NULL;
     }
     worker_is_idle();
 }

--- a/ml/ml-dummy.c
+++ b/ml/ml-dummy.c
@@ -100,7 +100,7 @@ bool ml_dimension_is_anomalous(RRDDIM *rd, time_t curr_time, double value, bool 
     return false;
 }
 
-int ml_dimension_load_models(RRDDIM *rd) {
+int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **stmp) {
     UNUSED(rd);
     return 0;
 }

--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -621,7 +621,7 @@ bind_fail:
     return rc;
 }
 
-int ml_dimension_load_models(RRDDIM *rd) {
+int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **active_stmt) {
     ml_dimension_t *dim = (ml_dimension_t *) rd->ml_dimension;
     if (!dim)
         return 0;
@@ -635,7 +635,7 @@ int ml_dimension_load_models(RRDDIM *rd) {
 
     std::vector<ml_kmeans_t> V;
 
-    static __thread sqlite3_stmt *res = NULL;
+    sqlite3_stmt *res = active_stmt ? *active_stmt : NULL;
     int rc = 0;
     int param = 0;
 
@@ -645,18 +645,20 @@ int ml_dimension_load_models(RRDDIM *rd) {
     }
 
     if (unlikely(!res)) {
-        rc = prepare_statement(db, db_models_load, &res);
+        rc = sqlite3_prepare_v2(db, db_models_load, -1, &res, NULL);
         if (unlikely(rc != SQLITE_OK)) {
             error_report("Failed to prepare statement to load models, rc = %d", rc);
             return 1;
         }
+        if (active_stmt)
+            *active_stmt = res;
     }
 
     rc = sqlite3_bind_blob(res, ++param, &dim->rd->metric_uuid, sizeof(dim->rd->metric_uuid), SQLITE_STATIC);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = sqlite3_bind_int(res, ++param, now_realtime_usec() - (Cfg.num_models_to_use * Cfg.max_train_samples));
+    rc = sqlite3_bind_int64(res, ++param, now_realtime_sec() - (Cfg.num_models_to_use * Cfg.max_train_samples));
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
@@ -702,9 +704,12 @@ int ml_dimension_load_models(RRDDIM *rd) {
     if (unlikely(rc != SQLITE_DONE))
         error_report("Failed to load models, rc = %d", rc);
 
-    rc = sqlite3_reset(res);
+    if (active_stmt)
+        rc = sqlite3_reset(res);
+    else
+        rc = sqlite3_finalize(res);
     if (unlikely(rc != SQLITE_OK))
-        error_report("Failed to reset statement when loading models, rc = %d", rc);
+        error_report("Failed to %s statement when loading models, rc = %d", active_stmt ? "reset" : "finalize", rc);
 
     return 0;
 

--- a/ml/ml.h
+++ b/ml/ml.h
@@ -40,7 +40,7 @@ void ml_dimension_new(RRDDIM *rd);
 void ml_dimension_delete(RRDDIM *rd);
 bool ml_dimension_is_anomalous(RRDDIM *rd, time_t curr_time, double value, bool exists);
 
-int ml_dimension_load_models(RRDDIM *rd);
+int ml_dimension_load_models(RRDDIM *rd, sqlite3_stmt **stmt);
 
 void ml_update_global_statistics_charts(uint64_t models_consulted);
 


### PR DESCRIPTION
##### Summary
- ML models to be loaded are grouped together and handed of to a separate worker thread for batch load. Right now the worker thread will not release the prepared statement resources when done (kept to be reused when that same worker thread
is selected to do a batch ML load in the future). Since this may not be the case this PR changes this behavior and releases the resources on each batch load. 

- Fix parameter to ML model load to be in seconds not usec and also bind as int64. This would result in more models to be loaded than needed due to an overflow during the param binding. 
