### PR TITLE
Drop an unused index from aclk_alert table

### DIFF
--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1681,13 +1681,6 @@ int test_sqlite(void) {
     rc = sqlite3_exec_monitored(db_meta, buffer_tostring(sql), 0, 0, NULL);
     if (rc != SQLITE_OK)
         goto error;
-    buffer_flush(sql);
-
-    buffer_sprintf(sql, INDEX_ACLK_ALERT, uuid_str, uuid_str);
-    rc = sqlite3_exec_monitored(db_meta, buffer_tostring(sql), 0, 0, NULL);
-    if (rc != SQLITE_OK)
-        goto error;
-    buffer_flush(sql);
 
     buffer_free(sql);
     fprintf(stderr,"SQLite is OK\n");

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -483,11 +483,6 @@ void sql_create_aclk_table(RRDHOST *host __maybe_unused, uuid_t *host_uuid __may
     if (unlikely(rc))
         error_report("Failed to create ACLK alert table for host %s", host ? rrdhost_hostname(host) : host_guid);
     else {
-        snprintfz(sql, ACLK_SYNC_QUERY_SIZE -1, INDEX_ACLK_ALERT, uuid_str, uuid_str);
-        rc = db_execute(db_meta, sql);
-        if (unlikely(rc))
-            error_report("Failed to create ACLK alert table index for host %s", host ? string2str(host->hostname) : host_guid);
-
         snprintfz(sql, ACLK_SYNC_QUERY_SIZE -1, INDEX_ACLK_ALERT1, uuid_str, uuid_str);
         rc = db_execute(db_meta, sql);
         if (unlikely(rc))

--- a/database/sqlite/sqlite_aclk_alert.c
+++ b/database/sqlite/sqlite_aclk_alert.c
@@ -292,13 +292,6 @@ void aclk_push_alert_event(struct aclk_sync_host_config *wc)
         rc = db_execute(db_meta, buffer_tostring(sql_fix));
         if (unlikely(rc))
             error_report("Failed to create ACLK alert table for host %s", rrdhost_hostname(wc->host));
-
-        else {
-            buffer_flush(sql_fix);
-            buffer_sprintf(sql_fix, INDEX_ACLK_ALERT, wc->uuid_str, wc->uuid_str);
-            if (unlikely(db_execute(db_meta, buffer_tostring(sql_fix))))
-                error_report("Failed to create ACLK alert table for host %s", rrdhost_hostname(wc->host));
-        }
         buffer_free(sql_fix);
 
         // Try again

--- a/database/sqlite/sqlite_db_migration.c
+++ b/database/sqlite/sqlite_db_migration.c
@@ -368,6 +368,33 @@ static int do_migration_v11_v12(sqlite3 *database)
     return rc;
 }
 
+static int do_migration_v14_v15(sqlite3 *database)
+{
+    char sql[256];
+
+    int rc;
+    sqlite3_stmt *res = NULL;
+    snprintfz(sql, 255, "SELECT name FROM sqlite_schema WHERE type = \"index\" AND name LIKE \"aclk_alert_index@_%%\" ESCAPE \"@\"");
+    rc = sqlite3_prepare_v2(database, sql, -1, &res, 0);
+    if (rc != SQLITE_OK) {
+        error_report("Failed to prepare statement to drop unused indices");
+        return 1;
+    }
+
+    BUFFER *wb = buffer_create(128, NULL);
+    while (sqlite3_step_monitored(res) == SQLITE_ROW)
+        buffer_sprintf(wb, "DROP INDEX IF EXISTS %s;", (char *) sqlite3_column_text(res, 0));
+
+    rc = sqlite3_finalize(res);
+    if (unlikely(rc != SQLITE_OK))
+        error_report("Failed to finalize statement when dropping unused indices, rc = %d", rc);
+
+    (void) db_execute(database, buffer_tostring(wb));
+
+    buffer_free(wb);
+    return 0;
+}
+
 static int do_migration_v12_v13(sqlite3 *database)
 {
     int rc = 0;
@@ -446,7 +473,6 @@ static int migrate_database(sqlite3 *database, int target_version, char *db_name
         }
     }
     return target_version;
-
 }
 
 DATABASE_FUNC_MIGRATION_LIST migration_action[] = {
@@ -464,6 +490,7 @@ DATABASE_FUNC_MIGRATION_LIST migration_action[] = {
     {.name = "v11 to v12",  .func = do_migration_v11_v12},
     {.name = "v12 to v13",  .func = do_migration_v12_v13},
     {.name = "v13 to v14",  .func = do_migration_v13_v14},
+    {.name = "v14 to v15",  .func = do_migration_v14_v15},
     // the terminator of this array
     {.name = NULL, .func = NULL}
 };

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -4,7 +4,7 @@
 #include "sqlite3recover.h"
 #include "sqlite_db_migration.h"
 
-#define DB_METADATA_VERSION 14
+#define DB_METADATA_VERSION 15
 
 const char *database_config[] = {
     "CREATE TABLE IF NOT EXISTS host(host_id BLOB PRIMARY KEY, hostname TEXT NOT NULL, "

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -872,7 +872,7 @@ static void check_dimension_metadata(struct metadata_wc *wc)
         next_execution_t = now + METADATA_DIM_CHECK_INTERVAL;
     }
 
-    netdata_log_info(
+    internal_error(true,
         "METADATA: Dimensions checked %u, deleted %u. Checks will %s in %lld seconds",
         total_checked,
         total_deleted,
@@ -939,7 +939,7 @@ static void check_chart_metadata(struct metadata_wc *wc)
         next_execution_t = now + METADATA_CHART_CHECK_INTERVAL;
     }
 
-    netdata_log_info(
+    internal_error(true,
         "METADATA: Charts checked %u, deleted %u. Checks will %s in %lld seconds",
         total_checked,
         total_deleted,
@@ -1008,7 +1008,7 @@ static void check_label_metadata(struct metadata_wc *wc)
         next_execution_t = now + METADATA_LABEL_CHECK_INTERVAL;
     }
 
-    netdata_log_info(
+    internal_error(true,
         "METADATA: Chart labels checked %u, deleted %u. Checks will %s in %lld seconds",
         total_checked,
         total_deleted,


### PR DESCRIPTION
##### Summary
- The index `aclk_alert_index_xxx`  where x is a nodes machine guid, is not used.  The corresponding table column (alert_unique_id) is defined as `unique` and has an automatic index created anyway. This PR will drop it to save some space.
- Switch 3 log messages that refer to internal cleanup to appear only when compiled with NETDATA_INTERNAL_CHECKS
