### PR TITLE
python.d(smartd_log): collect Total LBAs written/read

### DIFF
--- a/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
+++ b/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
@@ -50,6 +50,8 @@ ATTR199 = '199'
 ATTR202 = '202'
 ATTR206 = '206'
 ATTR233 = '233'
+ATTR241 = '241'
+ATTR242 = '242'
 ATTR249 = '249'
 ATTR_READ_ERR_COR = 'read-total-err-corrected'
 ATTR_READ_ERR_UNC = 'read-total-unc-errors'
@@ -114,6 +116,8 @@ ORDER = [
     'offline_uncorrectable_sector_count',
     'percent_lifetime_used',
     'media_wearout_indicator',
+    'total_lbas_written',
+    'total_lbas_read',
 ]
 
 CHARTS = {
@@ -336,6 +340,18 @@ CHARTS = {
         'options': [None, 'NAND Writes', 'GiB', 'wear', 'smartd_log.nand_writes_1gib', 'line'],
         'lines': [],
         'attrs': [ATTR249],
+        'algo': ABSOLUTE,
+    },
+    'total_lbas_written': {
+        'options': [None, 'Total LBAs Written', 'sectors', 'wear', 'smartd_log.total_lbas_written', 'line'],
+        'lines': [],
+        'attrs': [ATTR241],
+        'algo': ABSOLUTE,
+    },
+    'total_lbas_read': {
+        'options': [None, 'Total LBAs Read', 'sectors', 'wear', 'smartd_log.total_lbas_read', 'line'],
+        'lines': [],
+        'attrs': [ATTR242],
         'algo': ABSOLUTE,
     },
 }

--- a/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
+++ b/collectors/python.d.plugin/smartd_log/smartd_log.chart.py
@@ -39,6 +39,7 @@ ATTR171 = '171'
 ATTR172 = '172'
 ATTR173 = '173'
 ATTR174 = '174'
+ATTR177 = '177'
 ATTR180 = '180'
 ATTR183 = '183'
 ATTR190 = '190'
@@ -333,7 +334,7 @@ CHARTS = {
     'media_wearout_indicator': {
         'options': [None, 'Media Wearout Indicator', 'percentage', 'wear', 'smartd_log.media_wearout_indicator', 'line'],
         'lines': [],
-        'attrs': [ATTR233],
+        'attrs': [ATTR233, ATTR177],
         'algo': ABSOLUTE,
     },
     'nand_writes_1gib': {
@@ -535,6 +536,7 @@ def ata_attribute_factory(value):
     elif name in [
         ATTR1,
         ATTR7,
+        ATTR177,
         ATTR202,
         ATTR206,
         ATTR233,


### PR DESCRIPTION
##### Summary

As [discussed](https://github.com/netdata/netdata/pull/10872#issuecomment-819652811) in https://github.com/netdata/netdata/pull/10872, it would be nice to have Total LBAs written/read metrics available.

Additionally, [Samsung drives use attribute 177 Wear Levelling Count](https://download.semiconductor.samsung.com/resources/others/SSD_Application_Note_SMART_final.pdf) for erase cycles currently only supported as [attribute 233 for Intel drives](https://www.thomas-krenn.com/en/wiki/SMART_attributes_of_Intel_SSDs), so I added that too.

Component: `python.d/smartd_log` collector

##### Test Plan

I've tested this manually with two Samsung drives:

![Screenshot 2023-10-18 at 22 11 29](https://github.com/netdata/netdata/assets/17737/74427ce3-afe0-4805-bf9e-91d107dd23b6)

##### Additional Information

SSDs are typically guaranteed for a maximum amount of drive writes within their warranty period, so this is an extremely useful metric to track.