### PR TITLE
Terminate cgroups discovery thread faster during shutdown

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -895,7 +895,6 @@ struct discovery_thread {
     uv_thread_t thread;
     uv_mutex_t mutex;
     uv_cond_t cond_var;
-    int start_discovery;
     int exited;
 } discovery_thread;
 
@@ -2781,14 +2780,6 @@ static inline void discovery_find_all_cgroups() {
     netdata_log_debug(D_CGROUP, "done searching for cgroups");
 }
 
-static void cgroup_discovery_cleanup(void *ptr) {
-    UNUSED(ptr);
-
-    discovery_thread.exited = 1;
-    worker_unregister();
-    service_exits();
-}
-
 static inline char *cgroup_chart_type(char *buffer, struct cgroup *cg) {
     if(buffer[0]) return buffer;
 
@@ -2805,8 +2796,6 @@ static inline char *cgroup_chart_type(char *buffer, struct cgroup *cg) {
 void cgroup_discovery_worker(void *ptr)
 {
     UNUSED(ptr);
-
-    netdata_thread_cleanup_push(cgroup_discovery_cleanup, ptr);
 
     worker_register("CGROUPSDISC");
     worker_register_job_name(WORKER_DISCOVERY_INIT,               "init");
@@ -2827,13 +2816,13 @@ void cgroup_discovery_worker(void *ptr)
             NULL,
             SIMPLE_PATTERN_EXACT, true);
 
+    service_register(SERVICE_THREAD_TYPE_LIBUV, NULL, NULL, NULL, false);
+
     while (service_running(SERVICE_COLLECTORS)) {
         worker_is_idle();
 
         uv_mutex_lock(&discovery_thread.mutex);
-        while (!discovery_thread.start_discovery && service_running(SERVICE_COLLECTORS))
-            uv_cond_wait(&discovery_thread.cond_var, &discovery_thread.mutex);
-        discovery_thread.start_discovery = 0;
+        uv_cond_wait(&discovery_thread.cond_var, &discovery_thread.mutex);
         uv_mutex_unlock(&discovery_thread.mutex);
 
         if (unlikely(!service_running(SERVICE_COLLECTORS)))
@@ -2841,8 +2830,9 @@ void cgroup_discovery_worker(void *ptr)
 
         discovery_find_all_cgroups();
     }
-
-    netdata_thread_cleanup_pop(1);
+    discovery_thread.exited = 1;
+    worker_unregister();
+    service_exits();
 }
 
 // ----------------------------------------------------------------------------
@@ -4572,7 +4562,6 @@ static void cgroup_main_cleanup(void *ptr) {
     if (!discovery_thread.exited) {
         collector_info("stopping discovery thread worker");
         uv_mutex_lock(&discovery_thread.mutex);
-        discovery_thread.start_discovery = 1;
         uv_cond_signal(&discovery_thread.cond_var);
         uv_mutex_unlock(&discovery_thread.mutex);
     }
@@ -4621,8 +4610,6 @@ void *cgroups_main(void *ptr) {
         goto exit;
     }
 
-    // dispatch a discovery worker thread
-    discovery_thread.start_discovery = 0;
     discovery_thread.exited = 0;
 
     if (uv_mutex_init(&discovery_thread.mutex)) {
@@ -4646,6 +4633,7 @@ void *cgroups_main(void *ptr) {
     usec_t step = cgroup_update_every * USEC_PER_SEC;
     usec_t find_every = cgroup_check_for_new_every * USEC_PER_SEC, find_dt = 0;
 
+    netdata_thread_disable_cancelability();
     while(service_running(SERVICE_COLLECTORS)) {
         worker_is_idle();
 
@@ -4654,8 +4642,9 @@ void *cgroups_main(void *ptr) {
 
         find_dt += hb_dt;
         if (unlikely(find_dt >= find_every || (!is_inside_k8s && cgroups_check))) {
+            uv_mutex_lock(&discovery_thread.mutex);
             uv_cond_signal(&discovery_thread.cond_var);
-            discovery_thread.start_discovery = 1;
+            uv_mutex_unlock(&discovery_thread.mutex);
             find_dt = 0;
             cgroups_check = 0;
         }
@@ -4665,18 +4654,22 @@ void *cgroups_main(void *ptr) {
 
         worker_is_busy(WORKER_CGROUPS_READ);
         read_all_discovered_cgroups(cgroup_root);
-        if(unlikely(!service_running(SERVICE_COLLECTORS))) break;
-
+        if (unlikely(!service_running(SERVICE_COLLECTORS))) {
+            uv_mutex_unlock(&cgroup_root_mutex);
+            break;
+        }
         worker_is_busy(WORKER_CGROUPS_CHART);
         update_cgroup_charts(cgroup_update_every);
-        if(unlikely(!service_running(SERVICE_COLLECTORS))) break;
+        if (unlikely(!service_running(SERVICE_COLLECTORS))) {
+           uv_mutex_unlock(&cgroup_root_mutex);
+           break;
+        }
 
         worker_is_idle();
         uv_mutex_unlock(&cgroup_root_mutex);
     }
 
 exit:
-    worker_unregister();
     netdata_thread_cleanup_pop(1);
     return NULL;
 }


### PR DESCRIPTION
##### Summary
During agent shutdown sometimes there is a deadlock when stopping the cgroups `discovery thread worker`. The result is the agent may need more that 15 seconds (the grace period for the discovery thread to properly shutdown). The error.log will have several messages similar to: 

```
netdata INFO  : MAIN : SERVICE CONTROL: waiting for the following 1 services [ COLLECTORS ] to exit: 'P[cgroups]' (226967)
netdata INFO  : MAIN : SERVICE CONTROL: waiting for the following 1 services [ COLLECTORS ] to exit: 'P[cgroups]' (226967)
netdata INFO  : MAIN : SERVICE CONTROL: waiting for the following 1 services [ COLLECTORS ] to exit: 'P[cgroups]' (226967)
```

The problem is identified in 
```
#4  0x00007ff445b569ad in uv_mutex_lock () from /lib/x86_64-linux-gnu/libuv.so.1
#5  0x0000559e7e6307f2 in cgroup_main_cleanup (ptr=0x559e80bb7138) at collectors/cgroups.plugin/sys_fs_cgroup.c:4577
#6  0x0000559e7e6309bc in cgroups_main (ptr=0x559e80bb7138) at collectors/cgroups.plugin/sys_fs_cgroup.c:4611
#7  0x0000559e7df5d3af in netdata_thread_init (ptr=0x559e83376860) at libnetdata/threads/threads.c:279
#8  0x00007ff444e8f6ba in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:444
```

