### PR TITLE
Fix Discord webhook payload

### DIFF
--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -1786,7 +1786,7 @@ send_discord() {
                     "text": "${info}",
                     "fields": [
                         {
-                            "title": "${chart}",
+                            "title": "${chart}"
                         }
                     ],
                     "thumb_url": "${image}",


### PR DESCRIPTION
##### Summary

Removes a trailing comma to make the Discord/Slack payload valid JSON.
Otherwise the Discord notification is not sent.

##### Test Plan

https://learn.netdata.cloud/docs/alerting/notifications/agent-dispatched-notifications/discord#test-notification

##### Additional Information

Fixes #16256

<details> <summary>For users: How does this change affect me?</summary>
Discord notifications should be sent again.
</details>
