### PR TITLE
Replace distutils with packaging for version

### DIFF
--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
@@ -6,7 +6,7 @@
 
 import urllib3
 
-from distutils.version import StrictVersion as version
+from packaging.version import parse as version
 
 from bases.FrameworkServices.SimpleService import SimpleService
 

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/UrlService.py
@@ -6,8 +6,6 @@
 
 import urllib3
 
-from packaging.version import parse as version
-
 from bases.FrameworkServices.SimpleService import SimpleService
 
 try:
@@ -15,28 +13,11 @@ try:
 except AttributeError:
     pass
 
-# https://github.com/urllib3/urllib3/blob/master/CHANGES.rst#19-2014-07-04
-# New retry logic and urllib3.util.retry.Retry configuration object. (Issue https://github.com/urllib3/urllib3/pull/326)
-URLLIB3_MIN_REQUIRED_VERSION = '1.9'
 URLLIB3_VERSION = urllib3.__version__
 URLLIB3 = 'urllib3'
 
-
-def version_check():
-    if version(URLLIB3_VERSION) >= version(URLLIB3_MIN_REQUIRED_VERSION):
-        return
-
-    err = '{0} version: {1}, minimum required version: {2}, please upgrade'.format(
-        URLLIB3,
-        URLLIB3_VERSION,
-        URLLIB3_MIN_REQUIRED_VERSION,
-    )
-    raise Exception(err)
-
-
 class UrlService(SimpleService):
     def __init__(self, configuration=None, name=None):
-        version_check()
         SimpleService.__init__(self, configuration=configuration, name=name)
         self.debug("{0} version: {1}".format(URLLIB3, URLLIB3_VERSION))
         self.url = self.configuration.get('url')


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #16254 

Replaces `distutils.version` with `packaging.version` as suggested in https://peps.python.org/pep-0632/

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Make sure python.d.plugin continues to work when it uses the `UrlService`.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
