### PR TITLE
Improve dimension ML model load

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -371,6 +371,10 @@ void netdata_cleanup_and_exit(int ret) {
             SERVICE_REPLICATION // replication has to be stopped after STREAMING, because it cleans up ARAL
             , 3 * USEC_PER_SEC);
 
+    delta_shutdown_time("prepare metasync shutdown");
+
+    metadata_sync_shutdown_prepare();
+
     delta_shutdown_time("disable ML detection and training threads");
 
     ml_stop_threads();
@@ -395,10 +399,6 @@ void netdata_cleanup_and_exit(int ret) {
     delta_shutdown_time("clean rrdhost database");
 
     rrdhost_cleanup_all();
-
-    delta_shutdown_time("prepare metasync shutdown");
-
-    metadata_sync_shutdown_prepare();
 
     delta_shutdown_time("stop aclk threads");
 

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -258,8 +258,8 @@ typedef enum __attribute__ ((__packed__)) rrddim_flags {
     RRDDIM_FLAG_ARCHIVED                        = (1 << 2),
     RRDDIM_FLAG_METADATA_UPDATE                 = (1 << 3),  // Metadata needs to go to the database
 
-    RRDDIM_FLAG_META_HIDDEN                     = (1 << 4), // Status of hidden option in the metadata database
-    RRDDIM_FLAG_ML_MODEL_LOAD                   = (1 << 5),  // Metadata needs to go to the database
+    RRDDIM_FLAG_META_HIDDEN                     = (1 << 4),  // Status of hidden option in the metadata database
+    RRDDIM_FLAG_ML_MODEL_LOAD                   = (1 << 5),  // Do ML LOAD for this dimension
 
     // this is 8 bit
 } RRDDIM_FLAGS;

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -259,7 +259,7 @@ typedef enum __attribute__ ((__packed__)) rrddim_flags {
     RRDDIM_FLAG_METADATA_UPDATE                 = (1 << 3),  // Metadata needs to go to the database
 
     RRDDIM_FLAG_META_HIDDEN                     = (1 << 4), // Status of hidden option in the metadata database
-
+    RRDDIM_FLAG_ML_MODEL_LOAD                   = (1 << 5),  // Metadata needs to go to the database
 
     // this is 8 bit
 } RRDDIM_FLAGS;

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -85,7 +85,6 @@ sqlite3 *db_meta = NULL;
 
 #define MAX_PREPARED_STATEMENTS (32)
 pthread_key_t key_pool[MAX_PREPARED_STATEMENTS];
-pthread_key_t plugin_key;
 
 SQLITE_API int sqlite3_exec_monitored(
     sqlite3 *db,                               /* An open database */

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -1899,9 +1899,7 @@ void metaqueue_host_update_info(RRDHOST *host)
 
 void metaqueue_ml_load_models(RRDDIM *rd)
 {
-    if (unlikely(!metasync_worker.loop))
-        return;
-    queue_metadata_cmd(METADATA_ML_LOAD_MODELS, rd, NULL);
+    rrddim_flag_set(rd, RRDDIM_FLAG_ML_MODEL_LOAD);
 }
 
 void metadata_queue_load_host_context(RRDHOST *host)

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -321,9 +321,6 @@ static inline bool receiver_should_stop(struct receiver_state *rpt) {
     return false;
 }
 
-extern pthread_key_t plugin_key;
-struct plugin_data;
-
 static size_t streaming_parser(struct receiver_state *rpt, struct plugind *cd, int fd, void *ssl) {
     size_t result = 0;
 


### PR DESCRIPTION
##### Summary
Currently we queue dimension ML load commands as dimensions are created. We can take advantage of the metadata
event loop that already processes all dimensions to perform the model load. 

This PR sets `RRDDIM_FLAG_ML_MODEL_LOAD` to the dimension that need ml model load. 

Additional code cleanup and switch to using a spinlock instead of mutex to queue / dequeue commands

