### PR TITLE
QUERIES: use tiers only when they have useful data

### DIFF
--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -1391,9 +1391,10 @@ static bool query_plan(QUERY_ENGINE_OPS *ops, time_t after_wanted, time_t before
 
                 // find the first time of this tier
                 time_t tier_first_time_s = qm->tiers[tr].db_first_time_s;
+                time_t tier_last_time_s = qm->tiers[tr].db_last_time_s;
 
                 // can it help?
-                if (tier_first_time_s < selected_tier_first_time_s) {
+                if (tier_first_time_s < selected_tier_first_time_s && tier_first_time_s <= before_wanted && tier_last_time_s >= after_wanted) {
                     // it can help us add detail at the beginning of the query
                     QUERY_PLAN_ENTRY t = {
                         .tier = tr,
@@ -1423,12 +1424,13 @@ static bool query_plan(QUERY_ENGINE_OPS *ops, time_t after_wanted, time_t before
                     continue;
 
                 // find the last time of this tier
+                time_t tier_first_time_s = qm->tiers[tr].db_first_time_s;
                 time_t tier_last_time_s = qm->tiers[tr].db_last_time_s;
 
                 //buffer_sprintf(wb, ": EVAL BEFORE tier %d, %ld", tier, last_time_s);
 
                 // can it help?
-                if (tier_last_time_s > selected_tier_last_time_s) {
+                if (tier_last_time_s > selected_tier_last_time_s && tier_first_time_s <= before_wanted && tier_last_time_s >= after_wanted) {
                     // it can help us add detail at the end of the query
                     QUERY_PLAN_ENTRY t = {
                         .tier = tr,


### PR DESCRIPTION
Use the additional tiers to query, only when they provide data to the requested time-frame.