### PR TITLE
Add an obsoletion time for statsd private charts

### DIFF
--- a/collectors/statsd.plugin/README.md
+++ b/collectors/statsd.plugin/README.md
@@ -173,8 +173,8 @@ You can find the configuration at `/etc/netdata/netdata.conf`:
 	# update every (flushInterval) = 1
 	# udp messages to process at once = 10
 	# create private charts for metrics matching = *
-	# max private charts allowed = 200
 	# max private charts hard limit = 1000
+	# cleanup obsolete charts after secs = 0
 	# private charts memory mode = save
 	# private charts history = 3996
 	# histograms and timers percentile (percentThreshold) = 95.00000
@@ -234,13 +234,11 @@ The default behavior is to use the same settings as the rest of the Netdata Agen
 - `private charts memory mode`
 - `private charts history`
 
-### Optimize private metric charts visualization and storage
+### Optimize private metric charts storage
 
-If you have thousands of metrics, each with its own private chart, you may notice that your web browser becomes slow when you view the Netdata dashboard (this is a web browser issue we need to address at the Netdata UI). So, Netdata has a protection to stop creating charts when `max private charts allowed = 200` (soft limit) is reached.
+For optimization reasons, Netdata imposes a hard limit on private metric charts. The limit is set via the `max private charts hard limit` setting (which defaults to 1000 charts). Metrics above this hard limit are still collected, but they can only be used in synthetic charts (once a metric is added to chart, it will be sent to backend servers too).
 
-The metrics above this soft limit are still processed by Netdata, can be used in synthetic charts and will be available to be sent to backend time-series databases, up to `max private charts hard limit = 1000`. So, between 200 and 1000 charts, Netdata will still generate charts, but they will automatically be created with `memory mode = none` (Netdata will not maintain a database for them). These metrics will be sent to backend time series databases, if the backend configuration is set to `as collected`.
-
-Metrics above the hard limit are still collected, but they can only be used in synthetic charts (once a metric is added to chart, it will be sent to backend servers too).
+If you have many ephemeral metrics collected (i.e. that you collect values for a certain amount of time), you can set the configuration option `set charts as obsolete after secs`. Setting a value in seconds here, means that Netdata will mark those metrics (and their private charts) as obsolete after the specified time has passed since the last sent metric value. Those charts will later be deleted according to the setting in `cleanup obsolete charts after secs`. Setting `set charts as obsolete after secs` to 0 (which is also the default value) will disable this functionality.
 
 Example private charts (automatically generated without any configuration):
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR adds an obsoletion functionality to statsd private charts. It attempts to address #16149 

A new configuration option is added called `set charts as obsolete after secs`. The default value is 0, which in this case statsd should operate as before. Setting the option to a number of seconds, statsd will set the private chart of the metric to obsolete after those seconds have passed since the last received metric and will stop updating the metric. The chart will be freed by the service thread, and the metrics from statsd.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Set the option `set charts as obsolete after secs` to a value, e.g. 60.
Start Netdata and start sending random metrics and values (e.g. using `echo "deploys.test.myservice_1:40|g" | nc -w 1 -u localhost 8125`).
Stop sending metrics and wait 60 seconds
Observe the `statsd` charts under Netdata monitoring.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
