### PR TITLE
DYNCFG fix REPORT_JOB_STATUS streaming

### DIFF
--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -2512,7 +2512,7 @@ static inline PARSER_RC pluginsd_job_status_common(char **words, size_t num_word
         return PLUGINSD_DISABLE_PLUGIN(parser, PLUGINSD_KEYWORD_REPORT_JOB_STATUS, "unknown job status");
 
     char *message = NULL;
-    if (num_words == 5)
+    if (num_words == 5 && strlen(words[4]) > 0)
         message = words[4];
 
     const DICTIONARY_ITEM *plugin_item;

--- a/libnetdata/dyn_conf/README.md
+++ b/libnetdata/dyn_conf/README.md
@@ -119,8 +119,10 @@ Where:
 #### REPORT_JOB_STATUS
 
 ```
-REPORT_JOB_STATUS {MODULE_NAME} {JOB_NAME} {STATUS} {STATE} "{REASON}"
+REPORT_JOB_STATUS {MODULE_NAME} {JOB_NAME} {STATUS} {STATE} ["REASON"]
 ```
+
+Nore REASON is optional and can be entirelly ommited for example when job is OK there is no need to send any reason.
 
 Where:
 
@@ -128,7 +130,7 @@ Where:
 - `JOB_NAME` is the name of the job.
 - `STATUS` is one of `stopped`, `running`, or `error`.
 - `STATE`, just send zero.
-- `REASON` is a message describing the status.
+- `REASON` is a message describing the status. If OK you might prefer no reason in which case it is preferable to omit this parameter altogether (as opposed to sending empty string `""`).
 
 
 ### Commands plugins must serve

--- a/libnetdata/dyn_conf/README.md
+++ b/libnetdata/dyn_conf/README.md
@@ -122,7 +122,7 @@ Where:
 REPORT_JOB_STATUS {MODULE_NAME} {JOB_NAME} {STATUS} {STATE} ["REASON"]
 ```
 
-Nore REASON is optional and can be entirelly ommited for example when job is OK there is no need to send any reason.
+Note the REASON parameter is optional and can be entirelly ommited (for example when state is OK there is no need to send any reason).
 
 Where:
 
@@ -130,7 +130,7 @@ Where:
 - `JOB_NAME` is the name of the job.
 - `STATUS` is one of `stopped`, `running`, or `error`.
 - `STATE`, just send zero.
-- `REASON` is a message describing the status. If OK you might prefer no reason in which case it is preferable to omit this parameter altogether (as opposed to sending empty string `""`).
+- `REASON` is a message describing the status. In case you don't want to send any reason string it is preferable to omit this parameter altogether (as opposed to sending empty string `""`).
 
 
 ### Commands plugins must serve

--- a/streaming/rrdpush.c
+++ b/streaming/rrdpush.c
@@ -485,9 +485,12 @@ void rrdpush_send_job_status_update(RRDHOST *host, const char *plugin_name, cons
 
     BUFFER *wb = sender_start(host->sender);
 
-    buffer_sprintf(wb, PLUGINSD_KEYWORD_REPORT_JOB_STATUS " %s %s %s %s %d\n", plugin_name, module_name, job->name, job_status2str(job->status), job->state);
-    if (job->reason)
+    buffer_sprintf(wb, PLUGINSD_KEYWORD_REPORT_JOB_STATUS " %s %s %s %s %d", plugin_name, module_name, job->name, job_status2str(job->status), job->state);
+
+    if (job->reason && strlen(job->reason))
         buffer_sprintf(wb, " \"%s\"", job->reason);
+
+    buffer_strcat(wb, "\n");
 
     sender_commit(host->sender, wb, STREAM_TRAFFIC_TYPE_METADATA);
 


### PR DESCRIPTION
##### Summary
Fixes https://github.com/netdata/netdata/issues/16075
additionally adds clarification to documentation.

If reason string is to be omitted (it makes no sense for example if status is OK) originally the intention was that plugin will not send this parameter at all. However this was not documented and as consequence `go.d` sent `""` empty string as reason in such case.

This PR makes it work both ways `""` empty string is considered equal to no reason string at all. Also fixes the streaming of the command to parent.

##### Test Plan
2 agents with streaming
create `go.d/httpcheck` job using `POST api/v2/go.d/httpcheck` 
streaming will not disconnect anymore after job starts running (and reports running status)

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
