### PR TITLE
Apcupsd selftest metric

### DIFF
--- a/collectors/charts.d.plugin/apcupsd/apcupsd.chart.sh
+++ b/collectors/charts.d.plugin/apcupsd/apcupsd.chart.sh
@@ -112,6 +112,9 @@ DIMENSION time time absolute 1 100
 CHART apcupsd_${host}.online '' "UPS ONLINE flag" "boolean" ups apcupsd.online line $((apcupsd_priority + 9)) $apcupsd_update_every '' '' 'apcupsd'
 DIMENSION online online absolute 0 1
 
+CHART apcupsd_${host}.selftest '' "UPS SELFTEST status" "Status_Code" ups apcupsd.selftest line $((apcupsd_priority + 10)) $apcupsd_update_every '' '' 'apcupsd'
+DIMENSION selftest_num selftest_num absolute 1 0
+
 EOF
   done
   return 0
@@ -138,12 +141,13 @@ BEGIN {
 	input_voltage_max = 0;
 	input_frequency = 0;
 	output_voltage = 0;
- 	output_voltage_nominal = 0;
+	output_voltage_nominal = 0;
 	load = 0;
 	temp = 0;
 	time = 0;
 	nompower = 0;
 	load_usage = 0;
+	selftest_num = 0;
 }
 /^BCHARGE.*/   { battery_charge = \$3 * 100 };
 /^BATTV.*/     { battery_voltage = \$3 * 100 };
@@ -158,7 +162,8 @@ BEGIN {
 /^ITEMP.*/     { temp = \$3 * 100 };
 /^NOMPOWER.*/  { nompower = \$3 };
 /^TIMELEFT.*/  { time = \$3 * 100 };
-/^STATUS.*/    { online=(\$3 != \"COMMLOST\" && !(\$3 == \"SHUTTING\" && \$4 == \"DOWN\"))?1:0 };
+/^STATUS.*/    { online=(\$3 != \"COMMLOST\" && !(\$3 == \"SHUTTING\" && \$4 == \"DOWN\"))?1:0; };
+/^SELFTEST.*/  { selftest_code = (\$3 == \"OK\") ? 0 : (\$3 == \"NO\") ? 1 : (\$3 == \"BT\") ? 2 : (\$3 == \"NG\") ? 3 : -1; };
 END {
 	{ load_usage = nompower * load / 100 };
 
@@ -206,6 +211,10 @@ END {
 		print \"BEGIN apcupsd_${host}.time $1\";
 		print \"SET time = \" time;
 		print \"END\"
+
+		print \"BEGIN apcupsd_${host}.selftest $1\";
+		print \"SET selftest_num = \" selftest_num;
+		print \"END\";
 	}
 }"
     # shellcheck disable=SC2181

--- a/collectors/charts.d.plugin/apcupsd/apcupsd.chart.sh
+++ b/collectors/charts.d.plugin/apcupsd/apcupsd.chart.sh
@@ -169,10 +169,10 @@ BEGIN {
 /^NOMPOWER.*/  { nompower = \$3 };
 /^TIMELEFT.*/  { time = \$3 * 100 };
 /^STATUS.*/    { online=(\$3 != \"COMMLOST\" && !(\$3 == \"SHUTTING\" && \$4 == \"DOWN\"))?1:0; };
-/^SELFTEST.*/  { selftest_OK = (\$3 == "OK") ? 1 : 0;
-                 selftest_NO = (\$3 == "NO") ? 1 : 0;
-                 selftest_BT = (\$3 == "BT") ? 1 : 0;
-                 selftest_NG = (\$3 == "NG") ? 1 : 0;
+/^SELFTEST.*/  { selftest_OK = (\$3 == \"OK\") ? 1 : 0;
+                 selftest_NO = (\$3 == \"NO\") ? 1 : 0;
+                 selftest_BT = (\$3 == \"BT\") ? 1 : 0;
+                 selftest_NG = (\$3 == \"NG\") ? 1 : 0;
                };
 END {
 	{ load_usage = nompower * load / 100 };

--- a/collectors/charts.d.plugin/apcupsd/apcupsd.chart.sh
+++ b/collectors/charts.d.plugin/apcupsd/apcupsd.chart.sh
@@ -112,7 +112,7 @@ DIMENSION time time absolute 1 100
 CHART apcupsd_${host}.online '' "UPS ONLINE flag" "boolean" ups apcupsd.online line $((apcupsd_priority + 9)) $apcupsd_update_every '' '' 'apcupsd'
 DIMENSION online online absolute 0 1
 
-CHART apcupsd_${host}.selftest '' "UPS SELFTEST status" "Status_Code" ups apcupsd.selftest line $((apcupsd_priority + 10)) $apcupsd_update_every '' '' 'apcupsd'
+CHART apcupsd_${host}.selftest '' "UPS Self-Test status" "status" ups apcupsd.selftest line $((apcupsd_priority + 10)) $apcupsd_update_every '' '' 'apcupsd'
 DIMENSION selftest_OK 'OK' absolute 0 1
 DIMENSION selftest_NO 'NO' absolute 0 1
 DIMENSION selftest_BT 'BT' absolute 0 1

--- a/health/health.d/apcupsd.conf
+++ b/health/health.d/apcupsd.conf
@@ -48,3 +48,13 @@ component: UPS device
   summary: APC UPS last collection
      info: APC UPS number of seconds since the last successful data collection
        to: sitemgr
+
+   alarm: apcupsd_failed_selftest
+   on: apcupsd_local.selftest
+   lookup: max -1s at 0 every 10s unaligned
+   units: status code
+   every: 10s
+   crit: $this > 1
+   delay: up 0 down 15m multiplier 1.5 max 1h
+   info: APC UPS self test failed due to insufficient battery capacity or due to overload. (0=OK,1=NO,2=BT,3=NG) 
+   to: sitemgr

--- a/health/health.d/apcupsd.conf
+++ b/health/health.d/apcupsd.conf
@@ -49,6 +49,8 @@ component: UPS device
      info: APC UPS number of seconds since the last successful data collection
        to: sitemgr
 
+#Send out a warning when SELFTEST code is BT or NG. Code descriptions can be found at:
+#http://www.apcupsd.org/manual/#:~:text=or%20N/A.-,SELFTEST,-The%20results%20of
  template: apcupsd_selftest_warning
        on: apcupsd_local.selftest
    lookup: max -1s unaligned match-names of BT,NG

--- a/health/health.d/apcupsd.conf
+++ b/health/health.d/apcupsd.conf
@@ -52,7 +52,7 @@ component: UPS device
 #Send out a warning when SELFTEST code is BT or NG. Code descriptions can be found at:
 #http://www.apcupsd.org/manual/#:~:text=or%20N/A.-,SELFTEST,-The%20results%20of
  template: apcupsd_selftest_warning
-       on: apcupsd_local.selftest
+       on: apcupsd.selftest
    lookup: max -1s unaligned match-names of BT,NG
     units: status
     every: 10s

--- a/health/health.d/apcupsd.conf
+++ b/health/health.d/apcupsd.conf
@@ -49,12 +49,13 @@ component: UPS device
      info: APC UPS number of seconds since the last successful data collection
        to: sitemgr
 
-   alarm: apcupsd_failed_selftest
-   on: apcupsd_local.selftest
-   lookup: max -1s at 0 every 10s unaligned
-   units: status code
-   every: 10s
-   crit: $this > 1
-   delay: up 0 down 15m multiplier 1.5 max 1h
-   info: APC UPS self test failed due to insufficient battery capacity or due to overload. (0=OK,1=NO,2=BT,3=NG) 
-   to: sitemgr
+    alarm: apcupsd_selftest_warning
+       on: apcupsd_local.selftest
+ families: selftest_BT selftest_NG
+   lookup: max -1s unaligned of selftest_BT,selftest_NG
+    units: status code
+    every: 10s
+     crit: $this == 1
+    delay: up 0 down 15m multiplier 1.5 max 1h
+     info: APC UPS self test failed due to insufficient battery capacity or due to overload. (0=OK,1=NO,2=BT,3=NG)
+       to: sitemgr

--- a/health/health.d/apcupsd.conf
+++ b/health/health.d/apcupsd.conf
@@ -49,13 +49,12 @@ component: UPS device
      info: APC UPS number of seconds since the last successful data collection
        to: sitemgr
 
-    alarm: apcupsd_selftest_warning
+ template: apcupsd_selftest_warning
        on: apcupsd_local.selftest
- families: selftest_BT selftest_NG
-   lookup: max -1s unaligned of selftest_BT,selftest_NG
-    units: status code
+   lookup: max -1s unaligned match-names of BT,NG
+    units: status
     every: 10s
-     crit: $this == 1
+     warn: $this == 1
     delay: up 0 down 15m multiplier 1.5 max 1h
-     info: APC UPS self test failed due to insufficient battery capacity or due to overload. (0=OK,1=NO,2=BT,3=NG)
+     info: APC UPS self-test failed due to insufficient battery capacity or due to overload.
        to: sitemgr


### PR DESCRIPTION
##### Summary
I propose to add a new chart for the SELFTEST status of the APCUPSD.  When it fails, i.e. that status code is NG or BT, it fires off an alarm to the sitemgr.  The SELFTEST failing is the first sign of APC battery problems, before the apcupsd status changes.

##### Test Plan
I'm not sure of a way to generate a bad SELFTEST code from apcaccess status, but you can inverse the logic to make sure that a good status code sends out a warning to know that it's working properly.  So  If you change this line in the acupsd.conf file:
    crit: $this > 1
to:  
   crit: $this < 0

It will fire off an alarm with a "good status", to test that it is working properly.

##### Additional Information

Describe the PR affects users: 
- This affects people that have enabled the apcupsd metric, and it allows people to optionally add the chart apcupds.selftest

