### PR TITLE
fix missing labels from parents

### DIFF
--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -1466,6 +1466,7 @@ static inline PARSER_RC pluginsd_clabel_commit(char **words __maybe_unused, size
 
     rrdset_flag_set(st, RRDSET_FLAG_METADATA_UPDATE);
     rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_METADATA_UPDATE);
+    rrdset_metadata_updated(st);
 
     parser->user.chart_rrdlabels_linked_temporarily = NULL;
     return PARSER_RC_OK;

--- a/database/rrdlabels.c
+++ b/database/rrdlabels.c
@@ -1307,6 +1307,7 @@ void rrdset_update_rrdlabels(RRDSET *st, RRDLABELS *new_rrdlabels) {
 
     rrdset_flag_set(st, RRDSET_FLAG_METADATA_UPDATE);
     rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_METADATA_UPDATE);
+    rrdset_metadata_updated(st);
 }
 
 

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -510,6 +510,7 @@ static void rrdset_react_callback(const DICTIONARY_ITEM *item __maybe_unused, vo
         }
         rrdset_flag_set(st, RRDSET_FLAG_METADATA_UPDATE);
         rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_METADATA_UPDATE);
+        rrdset_metadata_updated(st);
     }
 
     rrdcontext_updated_rrdset(st);


### PR DESCRIPTION
increase metadata version to resend chart upstream when labels and other metadata are updated
