### PR TITLE
update journal sources once per minute

### DIFF
--- a/collectors/systemd-journal.plugin/systemd-journal.c
+++ b/collectors/systemd-journal.plugin/systemd-journal.c
@@ -2822,6 +2822,9 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
         if(!tty)
             fprintf(stdout, "\n");
 
+        if(iteration % 60 == 0)
+            journal_files_registry_update();
+
         fflush(stdout);
 
         time_t now = now_monotonic_sec();


### PR DESCRIPTION
On busy centralization servers, accessing the journal for the first time can be slow because the plugin has to go through a lot of files to query and extract the time-frame available in each journal file.

Now the plugin scans the journal files every minute, so that when a user accesses the journal function, it will only have to scan journal files that have been updated during the last minute.