### PR TITLE
bump openssl for static in 3.1.4

### DIFF
--- a/packaging/makeself/bundled-packages
+++ b/packaging/makeself/bundled-packages
@@ -1,7 +1,7 @@
 # Source of truth for all the packages we bundle in static builds
 PACKAGES=("OPENSSL" "CURL" "BASH" "IOPING" "LIBNETFILTER_ACT")
 SOURCE_TYPES=("GH_REPO_CLONE" "GH_REPO_CLONE" "DW_TARBALL" "GH_REPO_SOURCE" "DW_TARBALL")
-OPENSSL_VERSION="openssl-3.1.3"
+OPENSSL_VERSION="openssl-3.1.4"
 OPENSSL_SOURCE="https://github.com/openssl/openssl"
 CURL_VERSION="curl-8_4_0"
 CURL_SOURCE="https://github.com/curl/curl"


### PR DESCRIPTION
##### Summary

[Sec Adv 20231024](https://www.openssl.org/news/secadv/20231024.txt)

Not a blocker for the patch release 

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
