### PR TITLE
update docker swarm deploy info

### DIFF
--- a/integrations/deploy.yaml
+++ b/integrations/deploy.yaml
@@ -370,11 +370,12 @@
               netdata:
                 image: netdata/netdata:edge
                 container_name: netdata
-                ports:
-                  - 19999:19999
+                pid: host
+                network_mode: host
                 restart: unless-stopped
                 cap_add:
                   - SYS_PTRACE
+                  - SYS_ADMIN
                 security_opt:
                   - apparmor:unconfined
                 volumes:
@@ -387,6 +388,7 @@
                   - /sys:/host/sys:ro
                   - /etc/os-release:/host/etc/os-release:ro
                   - /etc/hostname:/etc/hostname:ro
+                  - /var/run/docker.sock:/var/run/docker.sock:ro
             {% if $showClaimingOptions %}
                 environment:
                   - NETDATA_CLAIM_TOKEN={% claim_token %}
@@ -406,11 +408,12 @@
               netdata:
                 image: netdata/netdata:stable
                 container_name: netdata
-                ports:
-                  - 19999:19999
+                pid: host
+                network_mode: host
                 restart: unless-stopped
                 cap_add:
                   - SYS_PTRACE
+                  - SYS_ADMIN
                 security_opt:
                   - apparmor:unconfined
                 volumes:
@@ -423,6 +426,7 @@
                   - /sys:/host/sys:ro
                   - /etc/os-release:/host/etc/os-release:ro
                   - /etc/hostname:/etc/hostname:ro
+                  - /var/run/docker.sock:/var/run/docker.sock:ro
             {% if $showClaimingOptions %}
                 environment:
                   - NETDATA_CLAIM_TOKEN={% claim_token %}

--- a/integrations/deploy.yaml
+++ b/integrations/deploy.yaml
@@ -369,7 +369,6 @@
             services:
               netdata:
                 image: netdata/netdata:edge
-                container_name: netdata
                 pid: host
                 network_mode: host
                 cap_add:
@@ -408,7 +407,6 @@
             services:
               netdata:
                 image: netdata/netdata:stable
-                container_name: netdata
                 pid: host
                 network_mode: host
                 cap_add:

--- a/integrations/deploy.yaml
+++ b/integrations/deploy.yaml
@@ -372,7 +372,6 @@
                 container_name: netdata
                 pid: host
                 network_mode: host
-                restart: unless-stopped
                 cap_add:
                   - SYS_PTRACE
                   - SYS_ADMIN
@@ -397,6 +396,8 @@
             {% /if %}
                 deploy:
                   mode: global
+                  restart_policy:
+                    condition: on-failure
             volumes:
               netdataconfig:
               netdatalib:
@@ -410,7 +411,6 @@
                 container_name: netdata
                 pid: host
                 network_mode: host
-                restart: unless-stopped
                 cap_add:
                   - SYS_PTRACE
                   - SYS_ADMIN
@@ -435,6 +435,8 @@
             {% /if %}
                 deploy:
                   mode: global
+                  restart_policy:
+                    condition: on-failure
             volumes:
               netdataconfig:
               netdatalib:


### PR DESCRIPTION
##### Summary

I think the Docker Swarm config should be the same as Docker Compose. The current version is missing some privileges and mounts from [Recommended Way](https://learn.netdata.cloud/docs/installing/docker#create-a-new-netdata-agent-container) => Docker Swarm install fails to resolve container names and monitor container network interfaces.

Fixes: #16307

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
