### PR TITLE
Improve shutdown when collectors are active

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -440,7 +440,8 @@ void netdata_cleanup_and_exit(int ret) {
             delta_shutdown_time("wait for dbengine collectors to finish");
 
             size_t running = 1;
-            while(running) {
+            size_t count = 10;
+            while(running && count) {
                 running = 0;
                 for (size_t tier = 0; tier < storage_tiers; tier++)
                     running += rrdeng_collectors_running(multidb_ctx[tier]);
@@ -451,6 +452,7 @@ void netdata_cleanup_and_exit(int ret) {
                     // sleep_usec(100 * USEC_PER_MS);
                     cleanup_destroyed_dictionaries();
                 }
+                count--;
             }
 
             delta_shutdown_time("wait for dbengine main cache to finish flushing");


### PR DESCRIPTION
##### Summary

This is a work around until the root cause is identified (not easily reproduced). All collectors should be finalized during shutdown. 
When that is not the case a message appears in the `error.log` , similar to:

```
2023-10-30 12:27:07:  netdata ERROR : MAIN : waiting for 42 collectors to finish (similar messages repeated 10 times in the last 1 secs) (sleeping for 100000 microseconds every time this happens)
```
This PR adds a counter to give up trying and proceed with the shutdown.

