### PR TITLE
`tcp_v6_connect` monitoring

### DIFF
--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -75,6 +75,7 @@ static netdata_publish_syscall_t socket_publish_aggregated[NETDATA_MAX_SOCKET_VE
 netdata_socket_t *socket_values;
 
 ebpf_network_viewer_port_list_t *listen_ports = NULL;
+ebpf_addresses_t tcp_v6_connect_address = {.function = "tcp_v6_connect", .hash = 0, .addr = 0};
 
 struct config socket_config = { .first_section = NULL,
     .last_section = NULL,
@@ -177,11 +178,13 @@ static void ebpf_set_trampoline_target(struct socket_bpf *obj)
     bpf_program__set_attach_target(obj->progs.netdata_tcp_v4_connect_fexit, 0,
                                    socket_targets[NETDATA_FCNT_TCP_V4_CONNECT].name);
 
-    bpf_program__set_attach_target(obj->progs.netdata_tcp_v6_connect_fentry, 0,
-                                   socket_targets[NETDATA_FCNT_TCP_V6_CONNECT].name);
+    if (!tcp_v6_connect_address.addr) {
+        bpf_program__set_attach_target(
+            obj->progs.netdata_tcp_v6_connect_fentry, 0, socket_targets[NETDATA_FCNT_TCP_V6_CONNECT].name);
 
-    bpf_program__set_attach_target(obj->progs.netdata_tcp_v6_connect_fexit, 0,
+        bpf_program__set_attach_target(obj->progs.netdata_tcp_v6_connect_fexit, 0,
                                    socket_targets[NETDATA_FCNT_TCP_V6_CONNECT].name);
+    }
 
     bpf_program__set_attach_target(obj->progs.netdata_tcp_retransmit_skb_fentry, 0,
                                    socket_targets[NETDATA_FCNT_TCP_RETRANSMIT].name);
@@ -332,12 +335,13 @@ static long ebpf_socket_attach_probes(struct socket_bpf *obj, netdata_run_mode_t
         if (ret)
             return -1;
 
-        obj->links.netdata_tcp_v6_connect_kretprobe = bpf_program__attach_kprobe(obj->progs.netdata_tcp_v6_connect_kretprobe,
-                                                                                 true,
-                                                                                 socket_targets[NETDATA_FCNT_TCP_V6_CONNECT].name);
-        ret = libbpf_get_error(obj->links.netdata_tcp_v6_connect_kretprobe);
-        if (ret)
-            return -1;
+        if (!tcp_v6_connect_address.addr) {
+            obj->links.netdata_tcp_v6_connect_kretprobe = bpf_program__attach_kprobe(
+                obj->progs.netdata_tcp_v6_connect_kretprobe, true, socket_targets[NETDATA_FCNT_TCP_V6_CONNECT].name);
+            ret = libbpf_get_error(obj->links.netdata_tcp_v6_connect_kretprobe);
+            if (ret)
+                return -1;
+        }
     } else {
         obj->links.netdata_tcp_sendmsg_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_tcp_sendmsg_kprobe,
                                                                            false,
@@ -360,12 +364,14 @@ static long ebpf_socket_attach_probes(struct socket_bpf *obj, netdata_run_mode_t
         if (ret)
             return -1;
 
-        obj->links.netdata_tcp_v6_connect_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_tcp_v6_connect_kprobe,
-                                                                              false,
-                                                                              socket_targets[NETDATA_FCNT_TCP_V6_CONNECT].name);
-        ret = libbpf_get_error(obj->links.netdata_tcp_v6_connect_kprobe);
-        if (ret)
-            return -1;
+        if (!tcp_v6_connect_address.addr) {
+            obj->links.netdata_tcp_v6_connect_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_tcp_v6_connect_kprobe,
+                                                                                  false,
+                                                                                  socket_targets[NETDATA_FCNT_TCP_V6_CONNECT].name);
+            ret = libbpf_get_error(obj->links.netdata_tcp_v6_connect_kprobe);
+            if (ret)
+                return -1;
+        }
     }
 
     return 0;
@@ -411,6 +417,17 @@ static void ebpf_socket_adjust_map(struct socket_bpf *obj, ebpf_module_t *em)
 }
 
 /**
+ * Disable TCP V6 connect
+ */
+static void ebpf_disable_tcp_v6_connect(struct socket_bpf *obj)
+{
+    bpf_program__set_autoload(obj->progs.netdata_tcp_v6_connect_kretprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_tcp_v6_connect_kprobe, false);
+    bpf_program__set_autoload(obj->progs.netdata_tcp_v6_connect_fexit, false);
+    bpf_program__set_autoload(obj->progs.netdata_tcp_v6_connect_fentry, false);
+}
+
+/**
  * Load and attach
  *
  * Load and attach the eBPF code in kernel.
@@ -437,6 +454,10 @@ static inline int ebpf_socket_load_and_attach(struct socket_bpf *obj, ebpf_modul
     }
 
     ebpf_socket_adjust_map(obj, em);
+
+    if (!tcp_v6_connect_address.addr) {
+        ebpf_disable_tcp_v6_connect(obj);
+    }
 
     int ret = socket_bpf__load(obj);
     if (ret) {
@@ -502,15 +523,17 @@ static void ebpf_obsolete_systemd_socket_charts(int update_every)
                               order++,
                               update_every);
 
-    ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
-                              NETDATA_NET_APPS_CONNECTION_TCP_V6,
-                              "Calls to tcp_v6_connection",
-                              EBPF_COMMON_DIMENSION_CONNECTIONS,
-                              NETDATA_APPS_NET_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NETDATA_SERVICES_SOCKET_TCP_V6_CONN_CONTEXT,
-                              order++,
-                              update_every);
+    if (tcp_v6_connect_address.addr) {
+        ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
+                                  NETDATA_NET_APPS_CONNECTION_TCP_V6,
+                                  "Calls to tcp_v6_connection",
+                                  EBPF_COMMON_DIMENSION_CONNECTIONS,
+                                  NETDATA_APPS_NET_GROUP,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  NETDATA_SERVICES_SOCKET_TCP_V6_CONN_CONTEXT,
+                                  order++,
+                                  update_every);
+    }
 
     ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                               NETDATA_NET_APPS_BANDWIDTH_RECV,
@@ -626,15 +649,17 @@ void ebpf_socket_obsolete_apps_charts(struct ebpf_module *em)
                               order++,
                               em->update_every);
 
-    ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
-                              NETDATA_NET_APPS_CONNECTION_TCP_V6,
-                              "Calls to tcp_v6_connection",
-                              EBPF_COMMON_DIMENSION_CONNECTIONS,
-                              NETDATA_APPS_NET_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_STACKED,
-                              NULL,
-                              order++,
-                              em->update_every);
+    if (tcp_v6_connect_address.addr) {
+        ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
+                                  NETDATA_NET_APPS_CONNECTION_TCP_V6,
+                                  "Calls to tcp_v6_connection",
+                                  EBPF_COMMON_DIMENSION_CONNECTIONS,
+                                  NETDATA_APPS_NET_GROUP,
+                                  NETDATA_EBPF_CHART_TYPE_STACKED,
+                                  NULL,
+                                  order++,
+                                  em->update_every);
+    }
 
     ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                               NETDATA_NET_APPS_BANDWIDTH_SENT,
@@ -1016,15 +1041,17 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V6);
-    for (w = root; w; w = w->next) {
-        if (unlikely(w->exposed && w->processes)) {
-            value = ebpf_socket_sum_values_for_pids(w->root_pid, offsetof(ebpf_socket_publish_apps_t,
-                                                                          call_tcp_v6_connection));
-            write_chart_dimension(w->name, value);
+    if (tcp_v6_connect_address.addr) {
+        write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V6);
+        for (w = root; w; w = w->next) {
+            if (unlikely(w->exposed && w->processes)) {
+                value = ebpf_socket_sum_values_for_pids(
+                    w->root_pid, offsetof(ebpf_socket_publish_apps_t, call_tcp_v6_connection));
+                write_chart_dimension(w->name, value);
+            }
         }
+        write_end_chart();
     }
-    write_end_chart();
 
     write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_BANDWIDTH_SENT);
     for (w = root; w; w = w->next) {
@@ -1248,13 +1275,18 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
                                ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
                                root, em->update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
 
-    ebpf_create_charts_on_apps(NETDATA_NET_APPS_CONNECTION_TCP_V6,
-                               "Calls to tcp_v6_connection", EBPF_COMMON_DIMENSION_CONNECTIONS,
-                               NETDATA_APPS_NET_GROUP,
-                               NETDATA_EBPF_CHART_TYPE_STACKED,
-                               order++,
-                               ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                               root, em->update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
+    if (tcp_v6_connect_address.addr) {
+        ebpf_create_charts_on_apps(NETDATA_NET_APPS_CONNECTION_TCP_V6,
+                              "Calls to tcp_v6_connection",
+                                   EBPF_COMMON_DIMENSION_CONNECTIONS,
+                                   NETDATA_APPS_NET_GROUP,
+                                   NETDATA_EBPF_CHART_TYPE_STACKED,
+                                   order++,
+                                   ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
+                                   root,
+                                   em->update_every,
+                                   NETDATA_EBPF_MODULE_NAME_SOCKET);
+    }
 
     ebpf_create_charts_on_apps(NETDATA_NET_APPS_BANDWIDTH_SENT,
                                "Bytes sent", EBPF_COMMON_DIMENSION_BITS,
@@ -2032,15 +2064,21 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                       &socket_publish_aggregated[NETDATA_IDX_TCP_CONNECTION_V4], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
 
-    ebpf_create_chart(type, NETDATA_NET_APPS_CONNECTION_TCP_V6,
-                      "Calls to tcp_v6_connection",
-                      EBPF_COMMON_DIMENSION_CONNECTIONS, NETDATA_CGROUP_NET_GROUP,
-                      NETDATA_CGROUP_TCP_V6_CONN_CONTEXT,
-                      NETDATA_EBPF_CHART_TYPE_LINE,
-                      NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + order_basis++,
-                      ebpf_create_global_dimension,
-                      &socket_publish_aggregated[NETDATA_IDX_TCP_CONNECTION_V6], 1,
-                      update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
+    if (tcp_v6_connect_address.addr) {
+        ebpf_create_chart(type,
+                          NETDATA_NET_APPS_CONNECTION_TCP_V6,
+                          "Calls to tcp_v6_connection",
+                          EBPF_COMMON_DIMENSION_CONNECTIONS,
+                          NETDATA_CGROUP_NET_GROUP,
+                          NETDATA_CGROUP_TCP_V6_CONN_CONTEXT,
+                          NETDATA_EBPF_CHART_TYPE_LINE,
+                          NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + order_basis++,
+                          ebpf_create_global_dimension,
+                          &socket_publish_aggregated[NETDATA_IDX_TCP_CONNECTION_V6],
+                          1,
+                          update_every,
+                          NETDATA_EBPF_MODULE_NAME_SOCKET);
+    }
 
     ebpf_create_chart(type, NETDATA_NET_APPS_BANDWIDTH_RECV,
                       "Bytes received",
@@ -2129,10 +2167,17 @@ static void ebpf_obsolete_specific_socket_charts(char *type, int update_every)
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_SERVICES_SOCKET_TCP_V4_CONN_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + order_basis++, update_every);
 
-    ebpf_write_chart_obsolete(type, NETDATA_NET_APPS_CONNECTION_TCP_V6,"Calls to tcp_v6_connection",
-                              EBPF_COMMON_DIMENSION_CONNECTIONS, NETDATA_APPS_NET_GROUP,
-                              NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_SERVICES_SOCKET_TCP_V6_CONN_CONTEXT,
-                              NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + order_basis++, update_every);
+    if (tcp_v6_connect_address.addr) {
+        ebpf_write_chart_obsolete(type,
+                                  NETDATA_NET_APPS_CONNECTION_TCP_V6,
+                                  "Calls to tcp_v6_connection",
+                                  EBPF_COMMON_DIMENSION_CONNECTIONS,
+                                  NETDATA_APPS_NET_GROUP,
+                                  NETDATA_EBPF_CHART_TYPE_LINE,
+                                  NETDATA_SERVICES_SOCKET_TCP_V6_CONN_CONTEXT,
+                                  NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + order_basis++,
+                                  update_every);
+    }
 
     ebpf_write_chart_obsolete(type, NETDATA_NET_APPS_BANDWIDTH_RECV, "Bytes received",
                               EBPF_COMMON_DIMENSION_CALL, NETDATA_APPS_NET_GROUP,
@@ -2185,10 +2230,12 @@ static void ebpf_send_specific_socket_data(char *type, ebpf_socket_publish_apps_
                           (long long) values->call_tcp_v4_connection);
     write_end_chart();
 
-    write_begin_chart(type, NETDATA_NET_APPS_CONNECTION_TCP_V6);
-    write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_TCP_CONNECTION_V6].name,
-                          (long long) values->call_tcp_v6_connection);
-    write_end_chart();
+    if (tcp_v6_connect_address.addr) {
+        write_begin_chart(type, NETDATA_NET_APPS_CONNECTION_TCP_V6);
+        write_chart_dimension(
+            socket_publish_aggregated[NETDATA_IDX_TCP_CONNECTION_V6].name, (long long)values->call_tcp_v6_connection);
+        write_end_chart();
+    }
 
     write_begin_chart(type, NETDATA_NET_APPS_BANDWIDTH_SENT);
     write_chart_dimension(socket_publish_aggregated[NETDATA_IDX_TCP_SENDMSG].name,
@@ -2245,14 +2292,18 @@ static void ebpf_create_systemd_socket_charts(int update_every)
                                   NETDATA_SERVICES_SOCKET_TCP_V4_CONN_CONTEXT, NETDATA_EBPF_MODULE_NAME_SOCKET,
                                   update_every);
 
-    ebpf_create_charts_on_systemd(NETDATA_NET_APPS_CONNECTION_TCP_V6,
-                                  "Calls to tcp_v6_connection", EBPF_COMMON_DIMENSION_CONNECTIONS,
-                                  NETDATA_APPS_NET_GROUP,
-                                  NETDATA_EBPF_CHART_TYPE_STACKED,
-                                  order++,
-                                  ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
-                                  NETDATA_SERVICES_SOCKET_TCP_V6_CONN_CONTEXT, NETDATA_EBPF_MODULE_NAME_SOCKET,
-                                  update_every);
+    if (tcp_v6_connect_address.addr) {
+        ebpf_create_charts_on_systemd(NETDATA_NET_APPS_CONNECTION_TCP_V6,
+                                      "Calls to tcp_v6_connection",
+                                      EBPF_COMMON_DIMENSION_CONNECTIONS,
+                                      NETDATA_APPS_NET_GROUP,
+                                      NETDATA_EBPF_CHART_TYPE_STACKED,
+                                      order++,
+                                      ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
+                                      NETDATA_SERVICES_SOCKET_TCP_V6_CONN_CONTEXT,
+                                      NETDATA_EBPF_MODULE_NAME_SOCKET,
+                                      update_every);
+    }
 
     ebpf_create_charts_on_systemd(NETDATA_NET_APPS_BANDWIDTH_RECV,
                                   "Bytes received", EBPF_COMMON_DIMENSION_BITS,
@@ -2339,13 +2390,15 @@ static void ebpf_send_systemd_socket_charts()
     }
     write_end_chart();
 
-    write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V6);
-    for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
-        if (unlikely(ect->systemd) && unlikely(ect->updated)) {
-            write_chart_dimension(ect->name, (long long)ect->publish_socket.call_tcp_v6_connection);
+    if (tcp_v6_connect_address.addr) {
+        write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V6);
+        for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
+            if (unlikely(ect->systemd) && unlikely(ect->updated)) {
+                write_chart_dimension(ect->name, (long long)ect->publish_socket.call_tcp_v6_connection);
+            }
         }
+        write_end_chart();
     }
-    write_end_chart();
 
     write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_BANDWIDTH_SENT);
     for (ect = ebpf_cgroup_pids; ect ; ect = ect->next) {
@@ -2562,6 +2615,8 @@ static void ebpf_socket_initialize_global_vectors()
                                                sizeof(netdata_socket_plus_t));
 
     socket_values = callocz((size_t)ebpf_nprocs, sizeof(netdata_socket_t));
+
+    ebpf_load_addresses(&tcp_v6_connect_address, -1);
 }
 
 /*****************************************************************

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -75,7 +75,7 @@ static netdata_publish_syscall_t socket_publish_aggregated[NETDATA_MAX_SOCKET_VE
 netdata_socket_t *socket_values;
 
 ebpf_network_viewer_port_list_t *listen_ports = NULL;
-ebpf_addresses_t tcp_v6_connect_address = {.function = "tcp_v6_connect", .hash = 0, .addr = 0};
+ebpf_addresses_t tcp_v6_connect_address = {.function = "tcp_v6_connect", .hash = 0, .addr = 0, .type = 0};
 
 struct config socket_config = { .first_section = NULL,
     .last_section = NULL,

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -178,7 +178,7 @@ static void ebpf_set_trampoline_target(struct socket_bpf *obj)
     bpf_program__set_attach_target(obj->progs.netdata_tcp_v4_connect_fexit, 0,
                                    socket_targets[NETDATA_FCNT_TCP_V4_CONNECT].name);
 
-    if (!tcp_v6_connect_address.addr) {
+    if (tcp_v6_connect_address.type == 'T') {
         bpf_program__set_attach_target(
             obj->progs.netdata_tcp_v6_connect_fentry, 0, socket_targets[NETDATA_FCNT_TCP_V6_CONNECT].name);
 
@@ -335,7 +335,7 @@ static long ebpf_socket_attach_probes(struct socket_bpf *obj, netdata_run_mode_t
         if (ret)
             return -1;
 
-        if (!tcp_v6_connect_address.addr) {
+        if (tcp_v6_connect_address.type == 'T') {
             obj->links.netdata_tcp_v6_connect_kretprobe = bpf_program__attach_kprobe(
                 obj->progs.netdata_tcp_v6_connect_kretprobe, true, socket_targets[NETDATA_FCNT_TCP_V6_CONNECT].name);
             ret = libbpf_get_error(obj->links.netdata_tcp_v6_connect_kretprobe);
@@ -364,7 +364,7 @@ static long ebpf_socket_attach_probes(struct socket_bpf *obj, netdata_run_mode_t
         if (ret)
             return -1;
 
-        if (!tcp_v6_connect_address.addr) {
+        if (tcp_v6_connect_address.type == 'T') {
             obj->links.netdata_tcp_v6_connect_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_tcp_v6_connect_kprobe,
                                                                                   false,
                                                                                   socket_targets[NETDATA_FCNT_TCP_V6_CONNECT].name);
@@ -455,7 +455,7 @@ static inline int ebpf_socket_load_and_attach(struct socket_bpf *obj, ebpf_modul
 
     ebpf_socket_adjust_map(obj, em);
 
-    if (!tcp_v6_connect_address.addr) {
+    if (tcp_v6_connect_address.type != 'T') {
         ebpf_disable_tcp_v6_connect(obj);
     }
 
@@ -523,7 +523,7 @@ static void ebpf_obsolete_systemd_socket_charts(int update_every)
                               order++,
                               update_every);
 
-    if (tcp_v6_connect_address.addr) {
+    if (tcp_v6_connect_address.type == 'T') {
         ebpf_write_chart_obsolete(NETDATA_SERVICE_FAMILY,
                                   NETDATA_NET_APPS_CONNECTION_TCP_V6,
                                   "Calls to tcp_v6_connection",
@@ -649,7 +649,7 @@ void ebpf_socket_obsolete_apps_charts(struct ebpf_module *em)
                               order++,
                               em->update_every);
 
-    if (tcp_v6_connect_address.addr) {
+    if (tcp_v6_connect_address.type == 'T') {
         ebpf_write_chart_obsolete(NETDATA_APPS_FAMILY,
                                   NETDATA_NET_APPS_CONNECTION_TCP_V6,
                                   "Calls to tcp_v6_connection",
@@ -1041,7 +1041,7 @@ void ebpf_socket_send_apps_data(ebpf_module_t *em, struct ebpf_target *root)
     }
     write_end_chart();
 
-    if (tcp_v6_connect_address.addr) {
+    if (tcp_v6_connect_address.type == 'T') {
         write_begin_chart(NETDATA_APPS_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V6);
         for (w = root; w; w = w->next) {
             if (unlikely(w->exposed && w->processes)) {
@@ -1275,7 +1275,7 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
                                ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX],
                                root, em->update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
 
-    if (tcp_v6_connect_address.addr) {
+    if (tcp_v6_connect_address.type == 'T') {
         ebpf_create_charts_on_apps(NETDATA_NET_APPS_CONNECTION_TCP_V6,
                               "Calls to tcp_v6_connection",
                                    EBPF_COMMON_DIMENSION_CONNECTIONS,
@@ -2064,7 +2064,7 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                       &socket_publish_aggregated[NETDATA_IDX_TCP_CONNECTION_V4], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
 
-    if (tcp_v6_connect_address.addr) {
+    if (tcp_v6_connect_address.type == 'T') {
         ebpf_create_chart(type,
                           NETDATA_NET_APPS_CONNECTION_TCP_V6,
                           "Calls to tcp_v6_connection",
@@ -2167,7 +2167,7 @@ static void ebpf_obsolete_specific_socket_charts(char *type, int update_every)
                               NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_SERVICES_SOCKET_TCP_V4_CONN_CONTEXT,
                               NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + order_basis++, update_every);
 
-    if (tcp_v6_connect_address.addr) {
+    if (tcp_v6_connect_address.type == 'T') {
         ebpf_write_chart_obsolete(type,
                                   NETDATA_NET_APPS_CONNECTION_TCP_V6,
                                   "Calls to tcp_v6_connection",
@@ -2230,7 +2230,7 @@ static void ebpf_send_specific_socket_data(char *type, ebpf_socket_publish_apps_
                           (long long) values->call_tcp_v4_connection);
     write_end_chart();
 
-    if (tcp_v6_connect_address.addr) {
+    if (tcp_v6_connect_address.type == 'T') {
         write_begin_chart(type, NETDATA_NET_APPS_CONNECTION_TCP_V6);
         write_chart_dimension(
             socket_publish_aggregated[NETDATA_IDX_TCP_CONNECTION_V6].name, (long long)values->call_tcp_v6_connection);
@@ -2292,7 +2292,7 @@ static void ebpf_create_systemd_socket_charts(int update_every)
                                   NETDATA_SERVICES_SOCKET_TCP_V4_CONN_CONTEXT, NETDATA_EBPF_MODULE_NAME_SOCKET,
                                   update_every);
 
-    if (tcp_v6_connect_address.addr) {
+    if (tcp_v6_connect_address.type == 'T') {
         ebpf_create_charts_on_systemd(NETDATA_NET_APPS_CONNECTION_TCP_V6,
                                       "Calls to tcp_v6_connection",
                                       EBPF_COMMON_DIMENSION_CONNECTIONS,
@@ -2390,7 +2390,7 @@ static void ebpf_send_systemd_socket_charts()
     }
     write_end_chart();
 
-    if (tcp_v6_connect_address.addr) {
+    if (tcp_v6_connect_address.type == 'T') {
         write_begin_chart(NETDATA_SERVICE_FAMILY, NETDATA_NET_APPS_CONNECTION_TCP_V6);
         for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
             if (unlikely(ect->systemd) && unlikely(ect->updated)) {

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -1367,6 +1367,8 @@ void ebpf_load_addresses(ebpf_addresses_t *fa, int fd)
         char *fcnt = procfile_lineword(ff, l, 2);
         uint32_t hash = simple_hash(fcnt);
         if (fa->hash == hash && !strcmp(fcnt, fa->function)) {
+            char *type = procfile_lineword(ff, l, 2);
+            fa->type = type[0];
             if (fd > 0) {
                 char addr[128];
                 snprintf(addr, 127, "0x%s", procfile_lineword(ff, l, 0));

--- a/libnetdata/ebpf/ebpf.h
+++ b/libnetdata/ebpf/ebpf.h
@@ -148,6 +148,7 @@ typedef struct ebpf_addresses {
     uint32_t hash;
     // We use long as address, because it matches system length
     unsigned long addr;
+    uint32_t type;
 } ebpf_addresses_t;
 
 extern char *ebpf_user_config_dir;


### PR DESCRIPTION
##### Summary
On kernels where `tcp_v6_connect` is `static` it is not possible to monitor calls for this function and `socket` thread would not work. To avoid this issue, present with the last kernels, this PR adds a variable to store symbol type and load the trampoline/probe only when it is possible.

##### Test Plan

1. Compile this branch
2. Access `Ebpf_socket` function and verify whether you have data.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? eBPF.plugin
- Can they see the change or is it an under the hood? If they can see it, where? When they access socket plugin.
- How is the user impacted by the change? Avoid wrong initialization and chart without data.
- What are there any benefits of the change? Socket functions running on all kernel versions that we support.
</details>