### PR TITLE
Optimize database before agent shutdown

### DIFF
--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -471,6 +471,9 @@ void sql_close_database(void)
 
     add_stmt_to_list(NULL);
 
+    (void) db_execute(db_meta, "PRAGMA analysis_limit=1000");
+    (void) db_execute(db_meta, "PRAGMA optimize");
+
     rc = sqlite3_close_v2(db_meta);
     if (unlikely(rc != SQLITE_OK))
         error_report("Error %d while closing the SQLite database, %s", rc, sqlite3_errstr(rc));


### PR DESCRIPTION
##### Summary
Perform recommended optimization before closing the metadata database. Refer to [sqlite analyze command](https://www.sqlite.org/lang_analyze.html) for details
