### PR TITLE
Fix journal file index when collision is detected

### DIFF
--- a/database/engine/journalfile.c
+++ b/database/engine/journalfile.c
@@ -169,7 +169,7 @@ static void njfv2idx_add(struct rrdengine_datafile *datafile) {
             *PValue = datafile;
             break;
         }
-    } while(0);
+    } while(1);
 
     rw_spinlock_write_unlock(&datafile->ctx->njfv2idx.spinlock);
 }


### PR DESCRIPTION
##### Summary
The internal journal file index would fail to add entries properly. This can lead to a crash during shutdown when the agent is compiled with NETDATA_INTERNAL_CHECKS

This could also affect queries
