### PR TITLE
fix: check for null rrdim in cgroup functions

### DIFF
--- a/collectors/cgroups.plugin/cgroup-top.c
+++ b/collectors/cgroups.plugin/cgroup-top.c
@@ -138,7 +138,7 @@ int cgroup_function_cgroup_top(BUFFER *wb, int timeout __maybe_unused, const cha
             buffer_json_add_array_item_string(wb, "cgroup"); // Kind
 
         double cpu = NAN;
-        if (cg->st_cpu_rd_user &&  cg->st_cpu_rd_system) {
+        if (cg->st_cpu_rd_user && cg->st_cpu_rd_system) {
             cpu = cg->st_cpu_rd_user->collector.last_stored_value + cg->st_cpu_rd_system->collector.last_stored_value;
             max_cpu = MAX(max_cpu, cpu);
         }
@@ -378,7 +378,7 @@ int cgroup_function_systemd_top(BUFFER *wb, int timeout __maybe_unused, const ch
         buffer_json_add_array_item_string(wb, cg->name);
 
         double cpu = NAN;
-        if (cg->st_cpu_rd_user &&  cg->st_cpu_rd_system) {
+        if (cg->st_cpu_rd_user && cg->st_cpu_rd_system) {
             cpu = cg->st_cpu_rd_user->collector.last_stored_value + cg->st_cpu_rd_system->collector.last_stored_value;
             max_cpu = MAX(max_cpu, cpu);
         }

--- a/collectors/cgroups.plugin/cgroup-top.c
+++ b/collectors/cgroups.plugin/cgroup-top.c
@@ -137,12 +137,18 @@ int cgroup_function_cgroup_top(BUFFER *wb, int timeout __maybe_unused, const cha
         else
             buffer_json_add_array_item_string(wb, "cgroup"); // Kind
 
-        double cpu = cg->st_cpu_rd_user->collector.last_stored_value + cg->st_cpu_rd_system->collector.last_stored_value;
-        max_cpu = MAX(max_cpu, cpu);
+        double cpu = NAN;
+        if (cg->st_cpu_rd_user &&  cg->st_cpu_rd_system) {
+            cpu = cg->st_cpu_rd_user->collector.last_stored_value + cg->st_cpu_rd_system->collector.last_stored_value;
+            max_cpu = MAX(max_cpu, cpu);
+        }
         buffer_json_add_array_item_double(wb, cpu);
 
-        double ram = cg->st_mem_rd_ram->collector.last_stored_value;
-        max_ram = MAX(max_ram, ram);
+        double ram = NAN;
+        if (cg->st_mem_rd_ram) {
+            ram = cg->st_mem_rd_ram->collector.last_stored_value;
+            max_ram = MAX(max_ram, ram);
+        }
         buffer_json_add_array_item_double(wb, ram);
 
         double disk_io_read = NAN;
@@ -371,12 +377,18 @@ int cgroup_function_systemd_top(BUFFER *wb, int timeout __maybe_unused, const ch
 
         buffer_json_add_array_item_string(wb, cg->name);
 
-        double cpu = cg->st_cpu_rd_user->collector.last_stored_value + cg->st_cpu_rd_system->collector.last_stored_value;
-        max_cpu = MAX(max_cpu, cpu);
+        double cpu = NAN;
+        if (cg->st_cpu_rd_user &&  cg->st_cpu_rd_system) {
+            cpu = cg->st_cpu_rd_user->collector.last_stored_value + cg->st_cpu_rd_system->collector.last_stored_value;
+            max_cpu = MAX(max_cpu, cpu);
+        }
         buffer_json_add_array_item_double(wb, cpu);
 
-        double ram = cg->st_mem_rd_ram->collector.last_stored_value;
-        max_ram = MAX(max_ram, ram);
+        double ram = NAN;
+        if (cg->st_mem_rd_ram) {
+            ram = cg->st_mem_rd_ram->collector.last_stored_value;
+            max_ram = MAX(max_ram, ram);
+        }
         buffer_json_add_array_item_double(wb, ram);
 
         double disk_io_read = NAN;


### PR DESCRIPTION
##### Summary

Due to configuration settings, some metrics may not be generated. This is true even for basic things like CPU and RAM, we can't assume they always exist.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
