### PR TITLE
cleanup systemd unit files After

### DIFF
--- a/system/systemd/netdata.service.in
+++ b/system/systemd/netdata.service.in
@@ -3,7 +3,7 @@
 Description=Real time performance monitoring
 
 # append here other services you want netdata to wait for them to start
-After=network.target httpd.service squid.service nfs-server.service mysqld.service mysql.service named.service postfix.service chronyd.service
+After=network.target
 
 [Service]
 Type=simple

--- a/system/systemd/netdata.service.v235.in
+++ b/system/systemd/netdata.service.v235.in
@@ -3,7 +3,7 @@
 Description=Real time performance monitoring
 
 # append here other services you want netdata to wait for them to start
-After=network.target httpd.service squid.service nfs-server.service mysqld.service mysql.service named.service postfix.service chronyd.service
+After=network.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
##### Summary

Services in After were added long before we implemented "autodetection_retry" in python.d/go.d. Not needed anymore.

Removing because for each of them systemd creates a non-found/inactive/dead service on every system.



##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
