### PR TITLE
Network-interfaces function small improvements

### DIFF
--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -738,7 +738,7 @@ int netdev_function_net_interfaces(BUFFER *wb, int timeout __maybe_unused, const
     {
         size_t field_id = 0;
 
-        buffer_rrdf_table_add_field(wb, field_id++, "Name", "Network Interface Name",
+        buffer_rrdf_table_add_field(wb, field_id++, "Interface", "Network Interface Name",
                 RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
                 0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
                 RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
@@ -894,7 +894,7 @@ int netdev_function_net_interfaces(BUFFER *wb, int timeout __maybe_unused, const
     {
         buffer_json_add_array_item_array(wb);
         buffer_json_add_array_item_string(wb, "Traffic");
-        buffer_json_add_array_item_string(wb, "Name");
+        buffer_json_add_array_item_string(wb, "Interface");
         buffer_json_array_close(wb);
 
         buffer_json_add_array_item_array(wb);

--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -722,6 +722,12 @@ int netdev_function_net_interfaces(BUFFER *wb, int timeout __maybe_unused, const
         }
         buffer_json_add_array_item_double(wb, drops_tx);
 
+        buffer_json_add_array_item_object(wb);
+        {
+            buffer_json_member_add_string(wb, "severity", drops_rx + drops_tx > 0 ? "warning" : "normal");
+        }
+        buffer_json_object_close(wb);
+
         buffer_json_array_close(wb);
     }
 
@@ -836,6 +842,19 @@ int netdev_function_net_interfaces(BUFFER *wb, int timeout __maybe_unused, const
                 RRDF_FIELD_SUMMARY_SUM, RRDF_FIELD_FILTER_NONE,
                 RRDF_FIELD_OPTS_VISIBLE,
                 NULL);
+
+        buffer_rrdf_table_add_field(
+                wb, field_id++,
+                "rowOptions", "rowOptions",
+                RRDF_FIELD_TYPE_NONE,
+                RRDR_FIELD_VISUAL_ROW_OPTIONS,
+                RRDF_FIELD_TRANSFORM_NONE, 0, NULL, NAN,
+                RRDF_FIELD_SORT_FIXED,
+                NULL,
+                RRDF_FIELD_SUMMARY_COUNT,
+                RRDF_FIELD_FILTER_NONE,
+                RRDF_FIELD_OPTS_DUMMY,
+                NULL);
     }
 
     buffer_json_object_close(wb); // columns
@@ -884,6 +903,21 @@ int netdev_function_net_interfaces(BUFFER *wb, int timeout __maybe_unused, const
         buffer_json_array_close(wb);
     }
     buffer_json_array_close(wb);
+
+    buffer_json_member_add_object(wb, "group_by");
+    {
+        buffer_json_member_add_object(wb, "Type");
+        {
+            buffer_json_member_add_string(wb, "name", "Type");
+            buffer_json_member_add_array(wb, "columns");
+            {
+                buffer_json_add_array_item_string(wb, "Type");
+            }
+            buffer_json_array_close(wb);
+        }
+        buffer_json_object_close(wb);
+    }
+    buffer_json_object_close(wb); // group_by
 
     buffer_json_member_add_time_t(wb, "expires", now_realtime_sec() + 1);
     buffer_json_finalize(wb);


### PR DESCRIPTION
##### Summary

- highlight (yellow) interfaces with drops.
- rename the Name field to Interface.
- add Group By Type option.

<img width="1271" alt="Screenshot 2023-11-04 at 20 46 56" src="https://github.com/netdata/netdata/assets/22274335/6963b31b-028a-48ba-b78f-096e4e18adf6">

##### Test Plan



##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
