### PR TITLE
h2o add api/v2 support

### DIFF
--- a/web/server/h2o/http_server.c
+++ b/web/server/h2o/http_server.c
@@ -207,10 +207,12 @@ static inline int _netdata_uberhandler(h2o_req_t *req, RRDHOST **host)
     w.response.data = buffer_create(NBUF_INITIAL_SIZE_RESP, NULL);
     w.response.header = buffer_create(NBUF_INITIAL_SIZE_RESP, NULL);
     w.url_query_string_decoded = buffer_create(NBUF_INITIAL_SIZE_RESP, NULL);
+    w.url_as_received = buffer_create(NBUF_INITIAL_SIZE_RESP, NULL);
     w.acl = WEB_CLIENT_ACL_DASHBOARD;
 
     char *path_c_str = iovec_to_cstr(&api_command);
     char *path_unescaped = url_unescape(path_c_str);
+    buffer_strcat(w.url_as_received, iovec_to_cstr(&norm_path));
     freez(path_c_str);
 
     IF_HAS_URL_PARAMS(req) {
@@ -250,6 +252,7 @@ static inline int _netdata_uberhandler(h2o_req_t *req, RRDHOST **host)
     buffer_free(w.response.data);
     buffer_free(w.response.header);
     buffer_free(w.url_query_string_decoded);
+    buffer_free(w.url_as_received);
 
     return 0;
 }

--- a/web/server/h2o/http_server.c
+++ b/web/server/h2o/http_server.c
@@ -137,6 +137,8 @@ static inline int _netdata_uberhandler(h2o_req_t *req, RRDHOST **host)
         *host = rrdhost_find_by_hostname(c_host_id);
         if (!*host)
             *host = rrdhost_find_by_guid(c_host_id);
+        if (!*host)
+            *host = find_host_by_node_id(c_host_id);
         if (!*host) {
             req->res.status = HTTP_RESP_BAD_REQUEST;
             req->res.reason = "Wrong host id";


### PR DESCRIPTION
##### Summary
This adds `api/v2` support for h2o and as a result enables the new dashboard to work trough h2o.

##### Test Plan
Enable h2o, connect your browser to h2o port. Before this PR you cannot see new dashboard, after this PR it looks better.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
