### PR TITLE
Replace rrdset_is_obsolete & rrdset_isnot_obsolete

### DIFF
--- a/collectors/statsd.plugin/statsd.c
+++ b/collectors/statsd.plugin/statsd.c
@@ -484,7 +484,7 @@ static inline void metric_update_counters_and_obsoletion(STATSD_METRIC *m) {
     m->count++;
     m->last_collected = now_realtime_sec();
     if (m->st && unlikely(rrdset_flag_check(m->st, RRDSET_FLAG_OBSOLETE))) {
-        rrdset_isnot_obsolete(m->st);
+        rrdset_isnot_obsolete___safe_from_collector_thread(m->st);
         m->options &= ~STATSD_METRIC_OPTION_OBSOLETE;
     }
 }
@@ -1870,7 +1870,7 @@ static inline void metric_check_obsoletion(STATSD_METRIC *m) {
        !rrdset_flag_check(m->st, RRDSET_FLAG_OBSOLETE) &&
        m->options & STATSD_METRIC_OPTION_PRIVATE_CHART_ENABLED &&
        m->last_collected + statsd.set_obsolete_after < now_realtime_sec()) {
-        rrdset_is_obsolete(m->st);
+        rrdset_is_obsolete___safe_from_collector_thread(m->st);
         m->options |= STATSD_METRIC_OPTION_OBSOLETE;
     }
 }


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

After https://github.com/netdata/netdata/pull/16269 `rrdset_isnot_obsolete` and `rrdset_is_obsolete` need to be replaced by new versions.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

CI

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
