### PR TITLE
cgroups: fix throttle_duration chart context

### DIFF
--- a/collectors/cgroups.plugin/cgroup-charts.c
+++ b/collectors/cgroups.plugin/cgroup-charts.c
@@ -142,7 +142,7 @@ void update_cpu_throttled_duration_chart(struct cgroup *cg) {
 
     if (unlikely(!cg->st_cpu_throttled_time)) {
         char *title = "CPU Throttled Time Duration";
-        char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.throttled" : "cgroup.throttled";
+        char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.throttled_duration" : "cgroup.throttled_duration";
         int prio = cgroup_containers_chart_priority + 15;
 
         char buff[RRD_ID_LENGTH_MAX + 1];


### PR DESCRIPTION
##### Summary

Bug introduced in #16314. `cgroup.throttled` and `cgroup.throttled_duration` charts have the same context. This PR fixes it.

##### Test Plan

Not needed

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
