### PR TITLE
cgroups: collect pids/pids.current

### DIFF
--- a/collectors/cgroups.plugin/cgroup-charts.c
+++ b/collectors/cgroups.plugin/cgroup-charts.c
@@ -1518,7 +1518,7 @@ void update_pids_current_chart(struct cgroup *cg) {
             RRDSET_TYPE_LINE);
 
         rrdset_update_rrdlabels(chart, cg->chart_labels);
-        cg->st_pids_rd_pids_current = rrddim_add(chart, "pids_current", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        cg->st_pids_rd_pids_current = rrddim_add(chart, "pids", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
     }
 
     rrddim_set_by_pointer(chart, cg->st_pids_rd_pids_current, (collected_number)cg->pids.pids_current);

--- a/collectors/cgroups.plugin/cgroup-charts.c
+++ b/collectors/cgroups.plugin/cgroup-charts.c
@@ -1484,3 +1484,43 @@ void update_io_full_pressure_stall_time_chart(struct cgroup *cg) {
     rrddim_set_by_pointer(chart, pcs->total_time.rdtotal, (collected_number)(pcs->total_time.value_total));
     rrdset_done(chart);
 }
+
+void update_pids_current_chart(struct cgroup *cg) {
+    RRDSET *chart = cg->st_pids;
+
+    if (unlikely(!cg->st_pids)) {
+        char *title;
+        char *context;
+        int prio;
+        if (is_cgroup_systemd_service(cg)) {
+            title = "Systemd Services Number of Processes";
+            context = "systemd.service.pids.current";
+            prio = NETDATA_CHART_PRIO_CGROUPS_SYSTEMD + 70;
+        } else {
+            title = "Number of processes";
+            context = k8s_is_kubepod(cg) ? "k8s.cgroup.pids_current" : "cgroup.pids_current";
+            prio = cgroup_containers_chart_priority + 2150;
+        }
+
+        char buff[RRD_ID_LENGTH_MAX + 1];
+        chart = cg->st_pids = rrdset_create_localhost(
+            cgroup_chart_type(buff, cg),
+            "pids_current",
+            NULL,
+            "pids",
+            context,
+            title,
+            "pids",
+            PLUGIN_CGROUPS_NAME,
+            is_cgroup_systemd_service(cg) ? PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME : PLUGIN_CGROUPS_MODULE_CGROUPS_NAME,
+            prio,
+            cgroup_update_every,
+            RRDSET_TYPE_LINE);
+
+        rrdset_update_rrdlabels(chart, cg->chart_labels);
+        cg->st_pids_rd_pids_current = rrddim_add(chart, "pids_current", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+    }
+
+    rrddim_set_by_pointer(chart, cg->st_pids_rd_pids_current, (collected_number)cg->pids.pids_current);
+    rrdset_done(chart);
+}

--- a/collectors/cgroups.plugin/cgroup-discovery.c
+++ b/collectors/cgroups.plugin/cgroup-discovery.c
@@ -75,6 +75,7 @@ static inline void cgroup_free(struct cgroup *cg) {
     if(cg->st_throttle_serviced_ops) rrdset_is_obsolete___safe_from_collector_thread(cg->st_throttle_serviced_ops);
     if(cg->st_queued_ops) rrdset_is_obsolete___safe_from_collector_thread(cg->st_queued_ops);
     if(cg->st_merged_ops) rrdset_is_obsolete___safe_from_collector_thread(cg->st_merged_ops);
+    if(cg->st_pids) rrdset_is_obsolete___safe_from_collector_thread(cg->st_pids);
 
     freez(cg->filename_cpuset_cpus);
     freez(cg->filename_cpu_cfs_period);
@@ -105,6 +106,7 @@ static inline void cgroup_free(struct cgroup *cg) {
 
     freez(cg->io_merged.filename);
     freez(cg->io_queued.filename);
+    freez(cg->pids.pids_current_filename);
 
     free_pressure(&cg->cpu_pressure);
     free_pressure(&cg->io_pressure);
@@ -598,6 +600,14 @@ static inline void discovery_update_filenames_cgroup_v1(struct cgroup *cg) {
             }
         }
     }
+
+    // Pids
+    if (unlikely(!cg->pids.pids_current_filename)) {
+        snprintfz(filename, FILENAME_MAX, "%s%s/pids.current", cgroup_pids_base, cg->id);
+        if (likely(stat(filename, &buf) != -1)) {
+            cg->pids.pids_current_filename = strdupz(filename);
+        }
+    }
 }
 
 static inline void discovery_update_filenames_cgroup_v2(struct cgroup *cg) {
@@ -711,6 +721,14 @@ static inline void discovery_update_filenames_cgroup_v2(struct cgroup *cg) {
             cg->irq_pressure.filename = strdupz(filename);
             cg->irq_pressure.some.enabled = cgroup_enable_pressure_irq_some;
             cg->irq_pressure.full.enabled = cgroup_enable_pressure_irq_full;
+        }
+    }
+
+    // Pids
+    if (unlikely(!cg->pids.pids_current_filename)) {
+        snprintfz(filename, FILENAME_MAX, "%s%s/pids.current", cgroup_unified_base, cg->id);
+        if (likely(stat(filename, &buf) != -1)) {
+            cg->pids.pids_current_filename = strdupz(filename);
         }
     }
 }

--- a/collectors/cgroups.plugin/cgroup-internals.h
+++ b/collectors/cgroups.plugin/cgroup-internals.h
@@ -25,6 +25,12 @@ struct blkio {
 */
 };
 
+struct pids {
+    char *pids_current_filename;
+    int pids_current_updated;
+    unsigned long long pids_current;
+};
+
 // https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt
 struct memory {
     ARL_BASE *arl_base;
@@ -218,6 +224,8 @@ struct cgroup {
     struct blkio io_merged;                     // operations
     struct blkio io_queued;                     // operations
 
+    struct pids pids;
+
     struct cgroup_network_interface *interfaces;
 
     struct pressure cpu_pressure;
@@ -225,7 +233,7 @@ struct cgroup {
     struct pressure memory_pressure;
     struct pressure irq_pressure;
 
-    // per cgroup charts
+    // Cpu
     RRDSET *st_cpu;
     RRDDIM *st_cpu_rd_user;
     RRDDIM *st_cpu_rd_system;
@@ -236,6 +244,7 @@ struct cgroup {
     RRDSET *st_cpu_throttled_time;
     RRDSET *st_cpu_shares;
 
+    // Memory
     RRDSET *st_mem;
     RRDDIM *st_mem_rd_ram;
     RRDDIM *st_mem_rd_swap;
@@ -248,6 +257,7 @@ struct cgroup {
     RRDSET *st_mem_usage_limit;
     RRDSET *st_mem_failcnt;
 
+    // Blkio
     RRDSET *st_io;
     RRDDIM *st_io_rd_read;
     RRDDIM *st_io_rd_written;
@@ -262,6 +272,10 @@ struct cgroup {
 
     RRDSET *st_queued_ops;
     RRDSET *st_merged_ops;
+
+    // Pids
+    RRDSET *st_pids;
+    RRDDIM *st_pids_rd_pids_current;
 
     // per cgroup chart variables
     char *filename_cpuset_cpus;
@@ -307,10 +321,6 @@ extern uv_mutex_t cgroup_root_mutex;
 
 void cgroup_discovery_worker(void *ptr);
 
-
-
-
-
 extern int is_inside_k8s;
 extern long system_page_size;
 extern int cgroup_enable_cpuacct_stat;
@@ -350,6 +360,7 @@ extern char *cgroup_cpuacct_base;
 extern char *cgroup_cpuset_base;
 extern char *cgroup_blkio_base;
 extern char *cgroup_memory_base;
+extern char *cgroup_pids_base;
 extern char *cgroup_devices_base;
 extern char *cgroup_unified_base;
 extern int cgroup_root_count;
@@ -478,18 +489,23 @@ void update_throttle_io_serviced_ops_chart(struct cgroup *cg);
 void update_io_queued_ops_chart(struct cgroup *cg);
 void update_io_merged_ops_chart(struct cgroup *cg);
 
+void update_pids_current_chart(struct cgroup *cg);
+
 void update_cpu_some_pressure_chart(struct cgroup *cg);
 void update_cpu_some_pressure_stall_time_chart(struct cgroup *cg);
 void update_cpu_full_pressure_chart(struct cgroup *cg);
 void update_cpu_full_pressure_stall_time_chart(struct cgroup *cg);
+
 void update_mem_some_pressure_chart(struct cgroup *cg);
 void update_mem_some_pressure_stall_time_chart(struct cgroup *cg);
 void update_mem_full_pressure_chart(struct cgroup *cg);
 void update_mem_full_pressure_stall_time_chart(struct cgroup *cg);
+
 void update_irq_some_pressure_chart(struct cgroup *cg);
 void update_irq_some_pressure_stall_time_chart(struct cgroup *cg);
 void update_irq_full_pressure_chart(struct cgroup *cg);
 void update_irq_full_pressure_stall_time_chart(struct cgroup *cg);
+
 void update_io_some_pressure_chart(struct cgroup *cg);
 void update_io_some_pressure_stall_time_chart(struct cgroup *cg);
 void update_io_full_pressure_chart(struct cgroup *cg);


### PR DESCRIPTION
##### Summary

This PR adds [pids/pids.current](https://www.kernel.org/doc/Documentation/cgroup-v1/pids.txt) metric to cgroups and systemd services.

It is `PIDS` value from `docker stats`.

```bash
CONTAINER ID   NAME      CPU %     MEM USAGE / LIMIT     MEM %     NET I/O         BLOCK I/O     PIDS
57baa46ca32c   nd        5.14%     278.7MiB / 503.7GiB   0.05%     1.1MB / 570kB   3.81MB / 0B   117
```

##### Test Plan

Check that the new metric value ==  pids/pids.current (charts, functions). Check cgroup v1 and v2.


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
