### PR TITLE
Handle ephemeral hosts

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -917,7 +917,7 @@ exit:
     return NULL;
 }
 
-void aclk_host_state_update(RRDHOST *host, int cmd)
+void aclk_host_state_update(RRDHOST *host, int cmd, int queryable)
 {
     uuid_t node_id;
     int ret = 0;
@@ -962,7 +962,7 @@ void aclk_host_state_update(RRDHOST *host, int cmd)
     node_instance_connection_t node_state_update = {
         .hops = host->system_info->hops,
         .live = cmd,
-        .queryable = 1,
+        .queryable = queryable,
         .session_id = aclk_session_newarch
     };
     node_state_update.node_id = mallocz(UUID_STR_LEN);

--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -976,9 +976,8 @@ void aclk_host_state_update(RRDHOST *host, int cmd, int queryable)
     rrdhost_aclk_state_unlock(localhost);
 
     nd_log(NDLS_DAEMON, NDLP_DEBUG,
-           "Queuing status update for node=%s, live=%d, hops=%u",
-           (char*)node_state_update.node_id, cmd, host->system_info->hops);
-
+           "Queuing status update for node=%s, live=%d, hops=%u, queryable=%d",
+           (char*)node_state_update.node_id, cmd, host->system_info->hops, queryable);
     freez((void*)node_state_update.node_id);
     query->data.bin_payload.msg_name = "UpdateNodeInstanceConnection";
     query->data.bin_payload.topic = ACLK_TOPICID_NODE_CONN;
@@ -1022,7 +1021,7 @@ void aclk_send_node_instances()
             rrdhost_aclk_state_unlock(localhost);
 
             nd_log(NDLS_DAEMON, NDLP_DEBUG,
-                   "Queuing status update for node=%s, live=%d, hops=%d",
+                   "Queuing status update for node=%s, live=%d, hops=%d, queryable=1",
                    (char*)node_state_update.node_id, list->live, list->hops);
 
             freez((void*)node_state_update.capabilities);

--- a/aclk/aclk.h
+++ b/aclk/aclk.h
@@ -75,7 +75,7 @@ extern struct aclk_shared_state {
     int mqtt_shutdown_msg_rcvd;
 } aclk_shared_state;
 
-void aclk_host_state_update(RRDHOST *host, int cmd);
+void aclk_host_state_update(RRDHOST *host, int cmd, int queryable);
 void aclk_send_node_instances(void);
 
 void aclk_send_bin_msg(char *msg, size_t msg_len, enum aclk_topics subtopic, const char *msgname);

--- a/collectors/plugins.d/pluginsd_parser.h
+++ b/collectors/plugins.d/pluginsd_parser.h
@@ -15,6 +15,7 @@
 
 #define PLUGINSD_MIN_RRDSET_POINTERS_CACHE 1024
 
+#define HOST_LABEL_IS_EPHEMERAL "_is_ephemeral"
 // PARSER return codes
 typedef enum __attribute__ ((__packed__)) parser_rc {
     PARSER_RC_OK,       // Callback was successful, go on

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1078,7 +1078,7 @@ static void backwards_compatible_config() {
     config_move(CONFIG_SECTION_LOGS,   "errors flood protection period",
                 CONFIG_SECTION_LOGS,   "logs flood protection period");
     config_move(CONFIG_SECTION_HEALTH, "is ephemeral",
-                CONFIG_SECTION_GLOBAL, "is ephemeral");
+                CONFIG_SECTION_GLOBAL, "is ephemeral node");
 
     config_move(CONFIG_SECTION_HEALTH, "has unstable connection",
                 CONFIG_SECTION_GLOBAL, "has unstable connection");

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1223,6 +1223,7 @@ static void get_netdata_configured_variables() {
     // --------------------------------------------------------------------
 
     rrdset_free_obsolete_time_s = config_get_number(CONFIG_SECTION_DB, "cleanup obsolete charts after secs", rrdset_free_obsolete_time_s);
+    rrdhost_free_ephemeral_time_s = config_get_number(CONFIG_SECTION_DB, "cleanup ephemeral hosts after secs", rrdhost_free_ephemeral_time_s);
     // Current chart locking and invalidation scheme doesn't prevent Netdata from segmentation faults if a short
     // cleanup delay is set. Extensive stress tests showed that 10 seconds is quite a safe delay. Look at
     // https://github.com/netdata/netdata/pull/11222#issuecomment-868367920 for more information.

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1077,6 +1077,11 @@ static void backwards_compatible_config() {
 
     config_move(CONFIG_SECTION_LOGS,   "errors flood protection period",
                 CONFIG_SECTION_LOGS,   "logs flood protection period");
+    config_move(CONFIG_SECTION_HEALTH, "is ephemeral",
+                CONFIG_SECTION_GLOBAL, "is ephemeral");
+
+    config_move(CONFIG_SECTION_HEALTH, "has unstable connection",
+                CONFIG_SECTION_GLOBAL, "has unstable connection");
 }
 
 static int get_hostname(char *buf, size_t buf_size) {

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -272,22 +272,37 @@ restart_after_removal:
         if(!rrdhost_should_be_removed(host, protected_host, now))
             continue;
 
-        netdata_log_info("Host '%s' with machine guid '%s' is obsolete - cleaning up.", rrdhost_hostname(host), host->machine_guid);
+        bool is_archived = rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED);
+        if (!is_archived) {
+            netdata_log_info("Host '%s' with machine guid '%s' is obsolete - cleaning up.", rrdhost_hostname(host), host->machine_guid);
 
-        if (rrdhost_option_check(host, RRDHOST_OPTION_DELETE_ORPHAN_HOST)
-            /* don't delete multi-host DB host files */
-            && !(host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && is_storage_engine_shared(host->db[0].instance))
-        ) {
-            worker_is_busy(WORKER_JOB_DELETE_HOST_CHARTS);
-            rrdhost_delete_charts(host);
+            if (rrdhost_option_check(host, RRDHOST_OPTION_DELETE_ORPHAN_HOST)
+                /* don't delete multi-host DB host files */
+                && !(host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && is_storage_engine_shared(host->db[0].instance))
+            ) {
+                worker_is_busy(WORKER_JOB_DELETE_HOST_CHARTS);
+                rrdhost_delete_charts(host);
+            }
+            else {
+                worker_is_busy(WORKER_JOB_SAVE_HOST_CHARTS);
+                rrdhost_save_charts(host);
+            }
         }
-        else {
-            worker_is_busy(WORKER_JOB_SAVE_HOST_CHARTS);
-            rrdhost_save_charts(host);
+
+        bool force = false;
+
+        if (rrdhost_option_check(host, RRDHOST_OPTION_EPHEMERAL_HOST) && now - host->last_connected > rrdhost_free_ephemeral_time_s)
+            force = true;
+
+        if (!force && is_archived)
+            continue;
+
+       if (force) {
+            netdata_log_info("Host '%s' with machine guid '%s' is archived, ephemeral clean up.", rrdhost_hostname(host), host->machine_guid);
         }
 
         worker_is_busy(WORKER_JOB_FREE_HOST);
-        rrdhost_free___while_having_rrd_wrlock(host, false);
+        rrdhost_free___while_having_rrd_wrlock(host, force);
         goto restart_after_removal;
     }
 

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -305,8 +305,10 @@ restart_after_removal:
 #ifdef ENABLE_ACLK
         // in case we have cloud connection we inform cloud
         // a child disconnected
-        if (netdata_cloud_enabled && force)
+        if (netdata_cloud_enabled && force) {
             aclk_host_state_update(host, 0, 0);
+            unregister_node(host->machine_guid);
+        }
 #endif
         rrdhost_free___while_having_rrd_wrlock(host, force);
         goto restart_after_removal;

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -302,6 +302,12 @@ restart_after_removal:
         }
 
         worker_is_busy(WORKER_JOB_FREE_HOST);
+#ifdef ENABLE_ACLK
+        // in case we have cloud connection we inform cloud
+        // a child disconnected
+        if (netdata_cloud_enabled)
+            aclk_host_state_update(host, 0, 0);
+#endif
         rrdhost_free___while_having_rrd_wrlock(host, force);
         goto restart_after_removal;
     }

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -305,7 +305,7 @@ restart_after_removal:
 #ifdef ENABLE_ACLK
         // in case we have cloud connection we inform cloud
         // a child disconnected
-        if (netdata_cloud_enabled)
+        if (netdata_cloud_enabled && force)
             aclk_host_state_update(host, 0, 0);
 #endif
         rrdhost_free___while_having_rrd_wrlock(host, force);

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1824,30 +1824,29 @@ static RRDHOST *dbengine_rrdhost_find_or_create(char *name)
     /* We don't want to drop metrics when generating load, we prefer to block data generation itself */
 
     return rrdhost_find_or_create(
-            name
-            , name
-            , name
-            , os_type
-            , netdata_configured_timezone
-            , netdata_configured_abbrev_timezone
-            , netdata_configured_utc_offset
-            , ""
-            , program_name
-            , program_version
-            , default_rrd_update_every
-            , default_rrd_history_entries
-            , RRD_MEMORY_MODE_DBENGINE
-            , default_health_enabled
-            , default_rrdpush_enabled
-            , default_rrdpush_destination
-            , default_rrdpush_api_key
-            , default_rrdpush_send_charts_matching
-            , default_rrdpush_enable_replication
-            , default_rrdpush_seconds_to_replicate
-            , default_rrdpush_replication_step
-            , NULL
-            , 0
-    );
+        name,
+        name,
+        name,
+        os_type,
+        netdata_configured_timezone,
+        netdata_configured_abbrev_timezone,
+        netdata_configured_utc_offset,
+        "",
+        program_name,
+        program_version,
+        default_rrd_update_every,
+        default_rrd_history_entries,
+        RRD_MEMORY_MODE_DBENGINE,
+        default_health_enabled,
+        default_rrdpush_enabled,
+        default_rrdpush_destination,
+        default_rrdpush_api_key,
+        default_rrdpush_send_charts_matching,
+        default_rrdpush_enable_replication,
+        default_rrdpush_seconds_to_replicate,
+        default_rrdpush_replication_step,
+        NULL,
+        0);
 }
 
 // constants for test_dbengine

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -1043,6 +1043,7 @@ typedef enum __attribute__ ((__packed__)) {
     RRDHOST_OPTION_REPLICATION              = (1 << 5), // when set, we support replication for this host
 
     RRDHOST_OPTION_VIRTUAL_HOST             = (1 << 6), // when set, this host is a virtual one
+    RRDHOST_OPTION_EPHEMERAL_HOST           = (1 << 7), // when set, this host is an ephemeral one
 } RRDHOST_OPTIONS;
 
 #define rrdhost_option_check(host, flag) ((host)->options & (flag))
@@ -1426,6 +1427,7 @@ void rrddim_index_destroy(RRDSET *st);
 // ----------------------------------------------------------------------------
 
 extern time_t rrdhost_free_orphan_time_s;
+extern time_t rrdhost_free_ephemeral_time_s;
 
 int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unittest);
 
@@ -1434,30 +1436,29 @@ RRDHOST *rrdhost_find_by_guid(const char *guid);
 RRDHOST *find_host_by_node_id(char *node_id);
 
 RRDHOST *rrdhost_find_or_create(
-        const char *hostname
-        , const char *registry_hostname
-        , const char *guid
-        , const char *os
-        , const char *timezone
-        , const char *abbrev_timezone
-        , int32_t utc_offset
-        , const char *tags
-        , const char *program_name
-        , const char *program_version
-        , int update_every
-        , long history
-        , RRD_MEMORY_MODE mode
-        , unsigned int health_enabled
-        , unsigned int rrdpush_enabled
-        , char *rrdpush_destination
-        , char *rrdpush_api_key
-        , char *rrdpush_send_charts_matching
-        , bool rrdpush_enable_replication
-        , time_t rrdpush_seconds_to_replicate
-        , time_t rrdpush_replication_step
-        , struct rrdhost_system_info *system_info
-        , bool is_archived
-);
+    const char *hostname,
+    const char *registry_hostname,
+    const char *guid,
+    const char *os,
+    const char *timezone,
+    const char *abbrev_timezone,
+    int32_t utc_offset,
+    const char *tags,
+    const char *program_name,
+    const char *program_version,
+    int update_every,
+    long history,
+    RRD_MEMORY_MODE mode,
+    unsigned int health_enabled,
+    unsigned int rrdpush_enabled,
+    char *rrdpush_destination,
+    char *rrdpush_api_key,
+    char *rrdpush_send_charts_matching,
+    bool rrdpush_enable_replication,
+    time_t rrdpush_seconds_to_replicate,
+    time_t rrdpush_replication_step,
+    struct rrdhost_system_info *system_info,
+    bool is_archived);
 
 int rrdhost_set_system_info_variable(struct rrdhost_system_info *system_info, char *name, char *value);
 

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1465,7 +1465,14 @@ static void rrdhost_load_auto_labels(void) {
 
     add_aclk_host_labels();
 
-    health_add_host_labels();
+    // The source should be CONF, but when it is set, these labels are exported by default ('send configured labels' in exporting.conf).
+    // Their export seems to break exporting to Graphite, see https://github.com/netdata/netdata/issues/14084.
+
+    int is_ephemeral = appconfig_get_boolean(&netdata_config, CONFIG_SECTION_GLOBAL, "is ephemeral", CONFIG_BOOLEAN_NO);
+    rrdlabels_add(labels, "_is_ephemeral", is_ephemeral ? "true" : "false", RRDLABEL_SRC_AUTO);
+
+    int has_unstable_connection = appconfig_get_boolean(&netdata_config, CONFIG_SECTION_GLOBAL, "has unstable connection", CONFIG_BOOLEAN_NO);
+    rrdlabels_add(labels, "_has_unstable_connection", has_unstable_connection ? "true" : "false", RRDLABEL_SRC_AUTO);
 
     rrdlabels_add(labels, "_is_parent", (localhost->connected_children_count > 0) ? "true" : "false", RRDLABEL_SRC_AUTO);
 

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -31,7 +31,7 @@ netdata_rwlock_t rrd_rwlock = NETDATA_RWLOCK_INITIALIZER;
 
 time_t rrdset_free_obsolete_time_s = 3600;
 time_t rrdhost_free_orphan_time_s = 3600;
-time_t rrdhost_free_ephemeral_time_s = 3600;
+time_t rrdhost_free_ephemeral_time_s = 86400;
 
 bool is_storage_engine_shared(STORAGE_INSTANCE *engine __maybe_unused) {
 #ifdef ENABLE_DBENGINE

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -31,6 +31,7 @@ netdata_rwlock_t rrd_rwlock = NETDATA_RWLOCK_INITIALIZER;
 
 time_t rrdset_free_obsolete_time_s = 3600;
 time_t rrdhost_free_orphan_time_s = 3600;
+time_t rrdhost_free_ephemeral_time_s = 3600;
 
 bool is_storage_engine_shared(STORAGE_INSTANCE *engine __maybe_unused) {
 #ifdef ENABLE_DBENGINE
@@ -838,7 +839,7 @@ inline int rrdhost_should_be_removed(RRDHOST *host, RRDHOST *protected_host, tim
        && rrdhost_receiver_replicating_charts(host) == 0
        && rrdhost_sender_replicating_charts(host) == 0
        && rrdhost_flag_check(host, RRDHOST_FLAG_ORPHAN)
-       && !rrdhost_flag_check(host, RRDHOST_FLAG_ARCHIVED)
+       && !rrdhost_flag_check(host, RRDHOST_FLAG_PENDING_CONTEXT_LOAD)
        && !host->receiver
        && host->child_disconnected_time
        && host->child_disconnected_time + rrdhost_free_orphan_time_s < now_s)

--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -1468,7 +1468,7 @@ static void rrdhost_load_auto_labels(void) {
     // The source should be CONF, but when it is set, these labels are exported by default ('send configured labels' in exporting.conf).
     // Their export seems to break exporting to Graphite, see https://github.com/netdata/netdata/issues/14084.
 
-    int is_ephemeral = appconfig_get_boolean(&netdata_config, CONFIG_SECTION_GLOBAL, "is ephemeral", CONFIG_BOOLEAN_NO);
+    int is_ephemeral = appconfig_get_boolean(&netdata_config, CONFIG_SECTION_GLOBAL, "is ephemeral node", CONFIG_BOOLEAN_NO);
     rrdlabels_add(labels, "_is_ephemeral", is_ephemeral ? "true" : "false", RRDLABEL_SRC_AUTO);
 
     int has_unstable_connection = appconfig_get_boolean(&netdata_config, CONFIG_SECTION_GLOBAL, "has unstable connection", CONFIG_BOOLEAN_NO);

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -407,7 +407,7 @@ static void aclk_synchronization(void *arg __maybe_unused)
                     struct aclk_sync_cfg_t *ahc = host->aclk_config;
                     if (unlikely(!ahc))
                         sql_create_aclk_table(host, &host->host_uuid, host->node_id);
-                    aclk_host_state_update(host, live);
+                    aclk_host_state_update(host, live, 1);
                     break;
 // ALERTS
                 case ACLK_DATABASE_PUSH_ALERT_CONFIG:

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -71,6 +71,7 @@ enum {
     IDX_ENTRIES,
     IDX_HEALTH_ENABLED,
     IDX_LAST_CONNECTED,
+    IDX_IS_EPHEMERAL,
 };
 
 static int create_host_callback(void *data, int argc, char **argv, char **column)
@@ -79,8 +80,25 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
     UNUSED(argc);
     UNUSED(column);
 
+    time_t last_connected =  (time_t) (argv[IDX_LAST_CONNECTED] ? str2uint64_t(argv[IDX_LAST_CONNECTED], NULL) : 0);
+    time_t age = now_realtime_sec() - last_connected;
+    int is_ephemeral = 0;
+
+    if (argv[IDX_IS_EPHEMERAL])
+        is_ephemeral = str2i(argv[IDX_IS_EPHEMERAL]);
+
     char guid[UUID_STR_LEN];
     uuid_unparse_lower(*(uuid_t *)argv[IDX_HOST_ID], guid);
+
+    if (is_ephemeral && age > rrdhost_free_ephemeral_time_s) {
+        netdata_log_info(
+            "Skipping ephemeral hostname \"%s\" with GUID \"%s\", age = %ld seconds (limit %ld seconds)",
+            (const char *)argv[IDX_HOSTNAME],
+            guid,
+            age,
+            rrdhost_free_ephemeral_time_s);
+        return 0;
+    }
 
     struct rrdhost_system_info *system_info = callocz(1, sizeof(struct rrdhost_system_info));
     __atomic_sub_fetch(&netdata_buffers_statistics.rrdhost_allocations_size, sizeof(struct rrdhost_system_info), __ATOMIC_RELAXED);
@@ -90,33 +108,47 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
     sql_build_host_system_info((uuid_t *)argv[IDX_HOST_ID], system_info);
 
     RRDHOST *host = rrdhost_find_or_create(
-          (const char *) argv[IDX_HOSTNAME]
-        , (const char *) argv[IDX_REGISTRY]
-        , guid
-        , (const char *) argv[IDX_OS]
-        , (const char *) argv[IDX_TIMEZONE]
-        , (const char *) argv[IDX_ABBREV_TIMEZONE]
-        , (int32_t) (argv[IDX_UTC_OFFSET] ? str2uint32_t(argv[IDX_UTC_OFFSET], NULL) : 0)
-        , (const char *) argv[IDX_TAGS]
-        , (const char *) (argv[IDX_PROGRAM_NAME] ? argv[IDX_PROGRAM_NAME] : "unknown")
-        , (const char *) (argv[IDX_PROGRAM_VERSION] ? argv[IDX_PROGRAM_VERSION] : "unknown")
-        , argv[IDX_UPDATE_EVERY] ? str2i(argv[IDX_UPDATE_EVERY]) : 1
-        , argv[IDX_ENTRIES] ? str2i(argv[IDX_ENTRIES]) : 0
-        , default_rrd_memory_mode
-        , 0 // health
-        , 0 // rrdpush enabled
-        , NULL  //destination
-        , NULL  // api key
-        , NULL  // send charts matching
-        , false // rrdpush_enable_replication
-        , 0     // rrdpush_seconds_to_replicate
-        , 0     // rrdpush_replication_step
-        , system_info
-        , 1
-    );
+        (const char *)argv[IDX_HOSTNAME],
+        (const char *)argv[IDX_REGISTRY],
+        guid,
+        (const char *)argv[IDX_OS],
+        (const char *)argv[IDX_TIMEZONE],
+        (const char *)argv[IDX_ABBREV_TIMEZONE],
+        (int32_t)(argv[IDX_UTC_OFFSET] ? str2uint32_t(argv[IDX_UTC_OFFSET], NULL) : 0),
+        (const char *)argv[IDX_TAGS],
+        (const char *)(argv[IDX_PROGRAM_NAME] ? argv[IDX_PROGRAM_NAME] : "unknown"),
+        (const char *)(argv[IDX_PROGRAM_VERSION] ? argv[IDX_PROGRAM_VERSION] : "unknown"),
+        argv[IDX_UPDATE_EVERY] ? str2i(argv[IDX_UPDATE_EVERY]) : 1,
+        argv[IDX_ENTRIES] ? str2i(argv[IDX_ENTRIES]) : 0,
+        default_rrd_memory_mode,
+        0 // health
+        ,
+        0 // rrdpush enabled
+        ,
+        NULL //destination
+        ,
+        NULL // api key
+        ,
+        NULL // send charts matching
+        ,
+        false // rrdpush_enable_replication
+        ,
+        0 // rrdpush_seconds_to_replicate
+        ,
+        0 // rrdpush_replication_step
+        ,
+        system_info,
+        1);
+
     if (likely(host)) {
+        if (is_ephemeral)
+            rrdhost_option_set(host, RRDHOST_OPTION_EPHEMERAL_HOST);
+
+        if (is_ephemeral)
+            host->child_disconnected_time = now_realtime_sec();
+
         host->rrdlabels = sql_load_host_labels((uuid_t *)argv[IDX_HOST_ID]);
-        host->last_connected = (time_t) (argv[IDX_LAST_CONNECTED] ? str2uint64_t(argv[IDX_LAST_CONNECTED], NULL) : 0);
+        host->last_connected = last_connected;
     }
 
     (*number_of_chidren)++;
@@ -125,7 +157,7 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
     char node_str[UUID_STR_LEN] = "<none>";
     if (likely(host->node_id))
         uuid_unparse_lower(*host->node_id, node_str);
-    internal_error(true, "Adding archived host \"%s\" with GUID \"%s\" node id = \"%s\"", rrdhost_hostname(host), host->machine_guid, node_str);
+    internal_error(true, "Adding archived host \"%s\" with GUID \"%s\" node id = \"%s\"  ephemeral=%d", rrdhost_hostname(host), host->machine_guid, node_str, is_ephemeral);
 #endif
     return 0;
 }
@@ -472,7 +504,10 @@ void sql_create_aclk_table(RRDHOST *host __maybe_unused, uuid_t *host_uuid __may
 #define SQL_FETCH_ALL_HOSTS                                                                                            \
     "SELECT host_id, hostname, registry_hostname, update_every, os, "                                                  \
     "timezone, tags, hops, memory_mode, abbrev_timezone, utc_offset, program_name, "                                   \
-    "program_version, entries, health_enabled, last_connected FROM host WHERE hops >0;"
+    "program_version, entries, health_enabled, last_connected, "                                                       \
+    "(SELECT CASE WHEN hl.label_value = 'true' THEN 1 ELSE 0 END FROM "                                                \
+    "host_label hl WHERE hl.host_id = h.host_id AND hl.label_key = '_is_ephemeral')  "                                 \
+    "FROM host h WHERE hops > 0"
 
 #define SQL_FETCH_ALL_INSTANCES                                                                                        \
     "SELECT ni.host_id, ni.node_id FROM host h, node_instance ni "                                                     \

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -59,6 +59,7 @@ enum aclk_database_opcode {
     ACLK_DATABASE_PUSH_ALERT_SNAPSHOT,
     ACLK_DATABASE_PUSH_ALERT_CHECKPOINT,
     ACLK_DATABASE_QUEUE_REMOVED_ALERTS,
+    ACLK_DATABASE_NODE_UNREGISTER,
     ACLK_DATABASE_TIMER,
 
     // leave this last
@@ -93,5 +94,8 @@ void aclk_push_alert_config(const char *node_id, const char *config_hash);
 void aclk_push_node_alert_snapshot(const char *node_id);
 void aclk_push_node_removed_alerts(const char *node_id);
 void schedule_node_info_update(RRDHOST *host);
+#ifdef ENABLE_ACLK
+void unregister_node(const char *machine_guid);
+#endif
 
 #endif //NETDATA_SQLITE_ACLK_H

--- a/health/health.c
+++ b/health/health.c
@@ -1651,17 +1651,3 @@ void *health_main(void *ptr) {
     netdata_thread_cleanup_pop(1);
     return NULL;
 }
-
-void health_add_host_labels(void) {
-    RRDLABELS *labels = localhost->rrdlabels;
-
-    // The source should be CONF, but when it is set, these labels are exported by default ('send configured labels' in exporting.conf).
-    // Their export seems to break exporting to Graphite, see https://github.com/netdata/netdata/issues/14084.
-
-    int is_ephemeral = appconfig_get_boolean(&netdata_config, CONFIG_SECTION_HEALTH, "is ephemeral", CONFIG_BOOLEAN_NO);
-    rrdlabels_add(labels, "_is_ephemeral", is_ephemeral ? "true" : "false", RRDLABEL_SRC_AUTO);
-
-    int has_unstable_connection = appconfig_get_boolean(&netdata_config, CONFIG_SECTION_HEALTH, "has unstable connection", CONFIG_BOOLEAN_NO);
-    rrdlabels_add(labels, "_has_unstable_connection", has_unstable_connection ? "true" : "false", RRDLABEL_SRC_AUTO);
-}
-

--- a/health/health.h
+++ b/health/health.h
@@ -102,7 +102,6 @@ void *health_cmdapi_thread(void *ptr);
 char *health_edit_command_from_source(const char *source);
 void sql_refresh_hashes(void);
 
-void health_add_host_labels(void);
 void health_string2json(BUFFER *wb, const char *prefix, const char *label, const char *value, const char *suffix);
 
 void health_log_alert_transition_with_trace(RRDHOST *host, ALARM_ENTRY *ae, int line, const char *file, const char *function);

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -812,7 +812,7 @@ static void rrdpush_receive(struct receiver_state *rpt)
     // in case we have cloud connection we inform cloud
     // new child connected
     if (netdata_cloud_enabled)
-        aclk_host_state_update(rpt->host, 1);
+        aclk_host_state_update(rpt->host, 1, 1);
 #endif
 
     rrdhost_set_is_parent_label();
@@ -845,7 +845,7 @@ static void rrdpush_receive(struct receiver_state *rpt)
     // in case we have cloud connection we inform cloud
     // a child disconnected
     if (netdata_cloud_enabled)
-        aclk_host_state_update(rpt->host, 0);
+        aclk_host_state_update(rpt->host, 0, 1);
 #endif
 
 cleanup:

--- a/streaming/receiver.c
+++ b/streaming/receiver.c
@@ -623,6 +623,10 @@ static void rrdpush_receive(struct receiver_state *rpt)
     rpt->config.rrdpush_compression = appconfig_get_boolean(&stream_config, rpt->key, "enable compression", rpt->config.rrdpush_compression);
     rpt->config.rrdpush_compression = appconfig_get_boolean(&stream_config, rpt->machine_guid, "enable compression", rpt->config.rrdpush_compression);
 
+    bool is_ephemeral = false;
+    is_ephemeral = appconfig_get_boolean(&stream_config, rpt->key, "is ephemeral node", CONFIG_BOOLEAN_NO);
+    is_ephemeral = appconfig_get_boolean(&stream_config, rpt->machine_guid, "is ephemeral node", is_ephemeral);
+
     if(rpt->config.rrdpush_compression) {
         char *order = appconfig_get(&stream_config, rpt->key, "compression algorithms order", RRDPUSH_COMPRESSION_ALGORITHMS_ORDER);
         order = appconfig_get(&stream_config, rpt->machine_guid, "compression algorithms order", order);
@@ -635,30 +639,31 @@ static void rrdpush_receive(struct receiver_state *rpt)
     {
         // this will also update the host with our system_info
         RRDHOST *host = rrdhost_find_or_create(
-                rpt->hostname
-                , rpt->registry_hostname
-                , rpt->machine_guid
-                , rpt->os
-                , rpt->timezone
-                , rpt->abbrev_timezone
-                , rpt->utc_offset
-                , rpt->tags
-                , rpt->program_name
-                , rpt->program_version
-                , rpt->config.update_every
-                , rpt->config.history
-                , rpt->config.mode
-                , (unsigned int)(rpt->config.health_enabled != CONFIG_BOOLEAN_NO)
-                , (unsigned int)(rpt->config.rrdpush_enabled && rpt->config.rrdpush_destination && *rpt->config.rrdpush_destination && rpt->config.rrdpush_api_key && *rpt->config.rrdpush_api_key)
-                , rpt->config.rrdpush_destination
-                , rpt->config.rrdpush_api_key
-                , rpt->config.rrdpush_send_charts_matching
-                , rpt->config.rrdpush_enable_replication
-                , rpt->config.rrdpush_seconds_to_replicate
-                , rpt->config.rrdpush_replication_step
-                , rpt->system_info
-                , 0
-        );
+            rpt->hostname,
+            rpt->registry_hostname,
+            rpt->machine_guid,
+            rpt->os,
+            rpt->timezone,
+            rpt->abbrev_timezone,
+            rpt->utc_offset,
+            rpt->tags,
+            rpt->program_name,
+            rpt->program_version,
+            rpt->config.update_every,
+            rpt->config.history,
+            rpt->config.mode,
+            (unsigned int)(rpt->config.health_enabled != CONFIG_BOOLEAN_NO),
+            (unsigned int)(rpt->config.rrdpush_enabled && rpt->config.rrdpush_destination &&
+                           *rpt->config.rrdpush_destination && rpt->config.rrdpush_api_key &&
+                           *rpt->config.rrdpush_api_key),
+            rpt->config.rrdpush_destination,
+            rpt->config.rrdpush_api_key,
+            rpt->config.rrdpush_send_charts_matching,
+            rpt->config.rrdpush_enable_replication,
+            rpt->config.rrdpush_seconds_to_replicate,
+            rpt->config.rrdpush_replication_step,
+            rpt->system_info,
+            0);
 
         if(!host) {
             rrdpush_receive_log_status(
@@ -811,6 +816,9 @@ static void rrdpush_receive(struct receiver_state *rpt)
 #endif
 
     rrdhost_set_is_parent_label();
+
+    if (is_ephemeral)
+        rrdhost_option_set(rpt->host, RRDHOST_OPTION_EPHEMERAL_HOST);
 
     // let it reconnect to parent immediately
     rrdpush_reset_destinations_postpone_time(rpt->host);

--- a/streaming/stream.conf
+++ b/streaming/stream.conf
@@ -183,6 +183,11 @@
     # The duration we want to replicate per each step.
     #replication_step = 600
 
+    # Indicate whether this child is an ephemeral node. An ephemeral node will become unavailable
+    # after the specified duration of "cleanup ephemeral hosts after secs" (as defined in the db section of netdata.conf)
+    # from the time of the node's last connection.
+    #is ephemeral node = false
+
 # -----------------------------------------------------------------------------
 # 3. PER SENDING HOST SETTINGS, ON PARENT NETDATA
 #    THIS IS OPTIONAL - YOU DON'T HAVE TO CONFIGURE IT
@@ -253,3 +258,8 @@
 
     # The duration we want to replicate per each step.
     #replication_step = 600
+
+    # Indicate whether this child is an ephemeral node. An ephemeral node will become unavailable
+    # after the specified duration of "cleanup ephemeral hosts after secs" (as defined in the db section of netdata.conf)
+    # from the time of the node's last connection.
+    #is ephemeral node = false


### PR DESCRIPTION
##### Summary

Related #15868

---

- Add a new `cleanup ephemeral hosts after secs` config option under the `[db]` section
- Handle the `_is_ephemeral` host label on agent start
- Use the child's last connected time + ephemeral indication to decide if a node should be loaded on startup
   - Node is loaded if `(current_time - last connected time)` < `ephemeral hosts after secs`
- New option in the stream.conf on the parent side, to indicate a node is ephemeral `is ephemeral node = yes | no` or `true | false`
   - The ephemeral indication can be set on the child side under the `[global]` section (previously under `[health]`)  

The child will be eligible to go away after the specified number of seconds passes provided it is not connected. 
