### PR TITLE
skip spaces when reading cpuset

### DIFF
--- a/libnetdata/os.c
+++ b/libnetdata/os.c
@@ -162,7 +162,11 @@ unsigned long read_cpuset_cpus(const char *filename, long system_cpus) {
         unsigned long ncpus = 0;
 
         // parse the cpuset string and calculate the number of cpus the cgroup is allowed to use
-        while(*s) {
+        while (*s) {
+            if (isspace(*s)) {
+                s++;
+                continue;
+            }
             unsigned long n = cpuset_str2ul(&s);
             ncpus++;
             if(*s == ',') {


### PR DESCRIPTION
##### Summary

Noticed that ND incorrectly determines the number of cores when running in a container. In `netdata.conf` I see

```ini
[global]
	# cpu cores = 1
```

[get_netdata_cpus()](https://github.com/netdata/netdata/blob/487e2b99676293b3e9d879d76bcefcd25bfc3ff7/daemon/common.c#L28):

```bash
2023-11-11 13:50:09: netdata INFO  : MAIN : System CPUs: 1, (system: 16, cgroups cpuset v1: 0, cgroups cpuset v2: 1, netdata.conf: 1)
```

Because `cpuset.cpus` is not really empty:

```bash
# wc /sys/fs/cgroup/cpuset.cpus
1 0 1 /sys/fs/cgroup/cpuset.cpus
```

##### Test Plan

Check `cpu cores` in netdata.conf.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
