### PR TITLE
fix v0 dashboard

### DIFF
--- a/web/api/formatters/rrdset2json.c
+++ b/web/api/formatters/rrdset2json.c
@@ -34,7 +34,7 @@ void rrdset2json(RRDSET *st, BUFFER *wb, size_t *dimensions_count, size_t *memor
     buffer_json_member_add_string(wb, "units", rrdset_units(st));
 
     char data_url[RRD_ID_LENGTH_MAX + 16];
-    snprintfz(data_url, RRD_ID_LENGTH_MAX + 15, "/api/v1/chart=%s", rrdset_name(st));
+    snprintfz(data_url, RRD_ID_LENGTH_MAX + 15, "/api/v1/data?chart=%s", rrdset_name(st));
     buffer_json_member_add_string(wb, "data_url", data_url);
 
     buffer_json_member_add_string(wb, "chart_type", rrdset_type_name(st->chart_type));


### PR DESCRIPTION
##### Summary

The old (v0) dashboard and custom dashboard use `charts.data_url` from `/api/v1/charts`.


<img width="1453" alt="Screenshot 2023-11-12 at 16 27 40" src="https://github.com/netdata/netdata/assets/22274335/b4cabfef-8a83-4ba0-b1d6-943235cf63f1">

##### Test Plan

Install, check the `/v0` endpoint.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
