### PR TITLE
fix "differ in signedness" warn in cgroup

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1166,7 +1166,7 @@ static void cgroup_read_pids_current(struct pids *pids) {
     if (unlikely(!pids->pids_current_filename))
         return;
 
-    pids->pids_current_updated = !read_single_signed_number_file(pids->pids_current_filename, &pids->pids_current);
+    pids->pids_current_updated = !read_single_number_file(pids->pids_current_filename, &pids->pids_current);
 }
 
 static inline void read_cgroup(struct cgroup *cg) {


### PR DESCRIPTION
##### Summary

ssia

##### Test Plan

not needed

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
