### PR TITLE
docker: mount /etc/localtime

### DIFF
--- a/integrations/deploy.yaml
+++ b/integrations/deploy.yaml
@@ -251,6 +251,7 @@
             -v netdatacache:/var/cache/netdata \
             -v /etc/passwd:/host/etc/passwd:ro \
             -v /etc/group:/host/etc/group:ro \
+            -v /etc/localtime:/etc/localtime:ro \
             -v /proc:/host/proc:ro \
             -v /sys:/host/sys:ro \
             -v /etc/os-release:/host/etc/os-release:ro \
@@ -275,6 +276,7 @@
             -v netdatacache:/var/cache/netdata \
             -v /etc/passwd:/host/etc/passwd:ro \
             -v /etc/group:/host/etc/group:ro \
+            -v /etc/localtime:/etc/localtime:ro \
             -v /proc:/host/proc:ro \
             -v /sys:/host/sys:ro \
             -v /etc/os-release:/host/etc/os-release:ro \
@@ -312,6 +314,7 @@
                   - netdatacache:/var/cache/netdata
                   - /etc/passwd:/host/etc/passwd:ro
                   - /etc/group:/host/etc/group:ro
+                  - /etc/localtime:/etc/localtime:ro
                   - /proc:/host/proc:ro
                   - /sys:/host/sys:ro
                   - /etc/os-release:/host/etc/os-release:ro
@@ -347,6 +350,7 @@
                   - netdatacache:/var/cache/netdata
                   - /etc/passwd:/host/etc/passwd:ro
                   - /etc/group:/host/etc/group:ro
+                  - /etc/localtime:/etc/localtime:ro
                   - /proc:/host/proc:ro
                   - /sys:/host/sys:ro
                   - /etc/os-release:/host/etc/os-release:ro
@@ -382,6 +386,7 @@
                   - netdatacache:/var/cache/netdata
                   - /etc/passwd:/host/etc/passwd:ro
                   - /etc/group:/host/etc/group:ro
+                  - /etc/localtime:/etc/localtime:ro
                   - /proc:/host/proc:ro
                   - /sys:/host/sys:ro
                   - /etc/os-release:/host/etc/os-release:ro
@@ -420,6 +425,7 @@
                   - netdatacache:/var/cache/netdata
                   - /etc/passwd:/host/etc/passwd:ro
                   - /etc/group:/host/etc/group:ro
+                  - /etc/localtime:/etc/localtime:ro
                   - /proc:/host/proc:ro
                   - /sys:/host/sys:ro
                   - /etc/os-release:/host/etc/os-release:ro

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -69,6 +69,7 @@ docker run -d --name=netdata \
   -v netdatacache:/var/cache/netdata \
   -v /etc/passwd:/host/etc/passwd:ro \
   -v /etc/group:/host/etc/group:ro \
+  -v /etc/localtime:/etc/localtime:ro \
   -v /proc:/host/proc:ro \
   -v /sys:/host/sys:ro \
   -v /etc/os-release:/host/etc/os-release:ro \
@@ -108,6 +109,7 @@ services:
       - netdatacache:/var/cache/netdata
       - /etc/passwd:/host/etc/passwd:ro
       - /etc/group:/host/etc/group:ro
+      - /etc/localtime:/etc/localtime:ro
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /etc/os-release:/host/etc/os-release:ro
@@ -153,6 +155,7 @@ docker run -d --name=netdata \
   -v netdatacache:/var/cache/netdata \
   -v /etc/passwd:/host/etc/passwd:ro \
   -v /etc/group:/host/etc/group:ro \
+  -v /etc/localtime:/etc/localtime:ro \
   -v /proc:/host/proc:ro \
   -v /sys:/host/sys:ro \
   -v /etc/os-release:/host/etc/os-release:ro \
@@ -192,6 +195,7 @@ services:
       - netdatacache:/var/cache/netdata
       - /etc/passwd:/host/etc/passwd:ro
       - /etc/group:/host/etc/group:ro
+      - /etc/localtime:/etc/localtime:ro
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /etc/os-release:/host/etc/os-release:ro
@@ -261,6 +265,7 @@ services:
       - netdatacache:/var/cache/netdata
       - /etc/passwd:/host/etc/passwd:ro
       - /etc/group:/host/etc/group:ro
+      - /etc/localtime:/etc/localtime:ro
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /etc/os-release:/host/etc/os-release:ro
@@ -310,6 +315,7 @@ services:
       - netdatacache:/var/cache/netdata
       - /etc/passwd:/host/etc/passwd:ro
       - /etc/group:/host/etc/group:ro
+      - /etc/localtime:/etc/localtime:ro
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /etc/os-release:/host/etc/os-release:ro
@@ -355,6 +361,7 @@ services:
       - netdatacache:/var/cache/netdata
       - /etc/passwd:/host/etc/passwd:ro
       - /etc/group:/host/etc/group:ro
+      - /etc/localtime:/etc/localtime:ro
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /etc/os-release:/host/etc/os-release:ro


### PR DESCRIPTION
##### Summary

To sync the time with the host. This way the timestamp of the logs will reflect the host time.

##### Test Plan

Mount `/etc/loca/time`, and check the timestamp of the logs.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
