### PR TITLE
eBPF apps order

### DIFF
--- a/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -492,7 +492,7 @@ void ebpf_oomkill_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_EBPF_MEMORY_GROUP,
                              NETDATA_EBPF_CHART_TYPE_STACKED,
                              "app.ebpf_oomkill",
-                             20020,
+                             20072,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_OOMKILL);
         ebpf_create_chart_labels("app_group", w->name, 0);

--- a/collectors/ebpf.plugin/ebpf_socket.c
+++ b/collectors/ebpf.plugin/ebpf_socket.c
@@ -647,7 +647,7 @@ static inline void ebpf_obsolete_socket_cgroup_charts(ebpf_module_t *em) {
  */
 void ebpf_socket_obsolete_apps_charts(struct ebpf_module *em)
 {
-    int order = 20080;
+    int order = 20130;
     struct ebpf_target *w;
     int update_every = em->update_every;
     for (w = apps_groups_root_target; w; w = w->next) {
@@ -1250,7 +1250,7 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
 {
     struct ebpf_target *root = ptr;
     struct ebpf_target *w;
-    int order = 20080;
+    int order = 20130;
     int update_every = em->update_every;
     for (w = root; w; w = w->next) {
         if (unlikely(!w->exposed))


### PR DESCRIPTION
##### Summary
@ilyam8  suggested three changes for eBPF plugin in this https://github.com/netdata/netdata/pull/16139#pullrequestreview-1718079096 PR. Two changes are addressed in this PR:

- Move OOMkill to bottom in memory family
- Move Net after disk on dashboard.

The third request will be addressed with PR https://github.com/netdata/netdata/pull/16030 .

##### Test Plan

1. Enable socket thread:
```sh
[global]
    ebpf load mode = return
[ebpf programs]
    socket = yes
```
2. Compile branch and verify dashboard position

##### Additional Information
It is not necessary to test on different kernels.

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? ebpf.plugin
- Can they see the change or is it an under the hood? If they can see it, where? Yes, when socket thread is enabled. When they access dashboard.
- How is the user impacted by the change? On top of apps submenu, they will have the most common hardware.
- What are there any benefits of the change?  We are keeping old pattern.
</details>
