### PR TITLE
adaptec_raid: fix parsing PD without NCQ status

### DIFF
--- a/collectors/python.d.plugin/adaptec_raid/adaptec_raid.chart.py
+++ b/collectors/python.d.plugin/adaptec_raid/adaptec_raid.chart.py
@@ -87,7 +87,7 @@ def find_pds(d):
         elif row.startswith('Temperature'):
             v = row.split(':')[-1].split()[0]
             pd.temperature = v
-        elif row.startswith('NCQ status'):
+        elif row.startswith(('NCQ status', 'Device Phy')) or not row:
             if pd.id and pd.state and pd.smart_warnings:
                 pds.append(pd)
             pd = PD()


### PR DESCRIPTION
##### Summary

Fixes: #16394

##### Test Plan

Test using `arcconf GETCONFIG 1 PD` output from #16394.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
