### PR TITLE
docker: use /host/etc/hostname if mounted

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1179,7 +1179,6 @@ static void get_netdata_configured_variables() {
        default_rrd_memory_mode = RRD_MEMORY_MODE_SAVE;
     }
 #endif
-    // ------------------------------------------------------------------------
 
     // --------------------------------------------------------------------
     // get KSM settings

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1060,7 +1060,7 @@ static int get_hostname(char *buf) {
         snprintfz(filename, FILENAME_MAX, "%s/etc/hostname", netdata_configured_host_prefix);
 
         if (!read_file(filename, buf, HOSTNAME_MAX)) {
-            buf = trim(buf);
+            trim(buf);
             return 0;
         }
     }

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1054,6 +1054,20 @@ static void backwards_compatible_config() {
 
 }
 
+static int get_hostname(char *buf) {
+    if (netdata_configured_host_prefix && *netdata_configured_host_prefix) {
+        char filename[FILENAME_MAX + 1];
+        snprintfz(filename, FILENAME_MAX, "%s/etc/hostname", netdata_configured_host_prefix);
+
+        if (!read_file(filename, buf, HOSTNAME_MAX)) {
+            buf = trim(buf);
+            return 0;
+        }
+    }
+
+    return gethostname(buf, HOSTNAME_MAX);
+}
+
 static void get_netdata_configured_variables() {
     backwards_compatible_config();
 
@@ -1061,9 +1075,9 @@ static void get_netdata_configured_variables() {
     // get the hostname
 
     char buf[HOSTNAME_MAX + 1];
-    if(gethostname(buf, HOSTNAME_MAX) == -1){
+
+    if (get_hostname(buf))
         netdata_log_error("Cannot get machine hostname.");
-    }
 
     netdata_configured_hostname = config_get(CONFIG_SECTION_GLOBAL, "hostname", buf);
     netdata_log_debug(D_OPTIONS, "hostname set to '%s'", netdata_configured_hostname);

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1054,18 +1054,18 @@ static void backwards_compatible_config() {
 
 }
 
-static int get_hostname(char *buf) {
+static int get_hostname(char *buf, size_t buf_size) {
     if (netdata_configured_host_prefix && *netdata_configured_host_prefix) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s/etc/hostname", netdata_configured_host_prefix);
 
-        if (!read_file(filename, buf, HOSTNAME_MAX)) {
+        if (!read_file(filename, buf, buf_size)) {
             trim(buf);
             return 0;
         }
     }
 
-    return gethostname(buf, HOSTNAME_MAX);
+    return gethostname(buf, buf_size);
 }
 
 static void get_netdata_configured_variables() {
@@ -1078,8 +1078,7 @@ static void get_netdata_configured_variables() {
     verify_netdata_host_prefix();
 
     char buf[HOSTNAME_MAX + 1];
-
-    if (get_hostname(buf))
+    if (get_hostname(buf, HOSTNAME_MAX))
         netdata_log_error("Cannot get machine hostname.");
 
     netdata_configured_hostname = config_get(CONFIG_SECTION_GLOBAL, "hostname", buf);

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1074,6 +1074,9 @@ static void get_netdata_configured_variables() {
     // ------------------------------------------------------------------------
     // get the hostname
 
+    netdata_configured_host_prefix = config_get(CONFIG_SECTION_GLOBAL, "host access prefix", "");
+    verify_netdata_host_prefix();
+
     char buf[HOSTNAME_MAX + 1];
 
     if (get_hostname(buf))
@@ -1178,9 +1181,6 @@ static void get_netdata_configured_variables() {
     }
 #endif
     // ------------------------------------------------------------------------
-
-    netdata_configured_host_prefix = config_get(CONFIG_SECTION_GLOBAL, "host access prefix", "");
-    verify_netdata_host_prefix();
 
     // --------------------------------------------------------------------
     // get KSM settings

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -446,9 +446,9 @@ above section on [configuring Agent containers](#configure-agent-containers) to 
 how you created the container.
 
 Alternatively, you can directly use the hostname from the node running the container by mounting `/etc/hostname` from
-the host in the container. With `docker run`, this can be done by adding `--volume /etc/hostname:/etc/hostname:ro` to
+the host in the container. With `docker run`, this can be done by adding `--volume /etc/hostname:/host/etc/hostname:ro` to
 the options. If you are using Docker Compose, you can add an entry to the container's `volumes` section
-reading `- /etc/hostname:/etc/hostname:ro`.
+reading `- /etc/hostname:/host/etc/hostname:ro`.
 
 ## Adding extra packages at runtime
 


### PR DESCRIPTION
##### Summary

Fixes: #16396

##### Test Plan

Start docker container with/without mounted /host/etc/hostname and check the hostname in `/netdata.conf`.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
