### PR TITLE
Improve handling around EPEL requirement for RPM packages.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1321,24 +1321,20 @@ netdata_avail_check() {
 
 # Check for any distro-specific dependencies we know we need.
 check_special_native_deps() {
-  if [ "${DISTRO_COMPAT_NAME}" = "centos" ] && [ "${SYSVERSION}" = "7" ]; then
-    progress "Checking for libuv availability."
-    if ${pm_cmd} search --nogpgcheck -v libuv | grep -q "No matches found"; then
-      progress "libuv not found, checking for EPEL availability."
-      if ${pm_cmd} search --nogpgcheck -v epel-release | grep -q "No matches found"; then
-        warning "Unable to find a suitable source for libuv, cannot install using native packages on this system."
-        return 1
-      else
-        progress "EPEL is available, attempting to install so that required dependencies are available."
+  if [ "${DISTRO_COMPAT_NAME}" = "centos" ] && [ "${SYSVERSION}" -gt 6 ]; then
+    progress "EPEL is required on this system, checking if it’s available."
 
-        # shellcheck disable=SC2086
-        if ! run_as_root env ${env} ${pm_cmd} ${install_subcmd} ${pkg_install_opts} epel-release; then
-          warning "Failed to install EPEL, even though it is required to install native packages on this system."
-          return 1
-        fi
-      fi
+    if ${pm_cmd} search --nogpgcheck -v epel-release | grep -q "No matches found"; then
+      warning "Unable to find a suitable source for libuv, cannot install using native packages on this system."
+      return 1
     else
-      return 0
+      progress "EPEL is available, attempting to install so that required dependencies are available."
+
+      # shellcheck disable=SC2086
+      if ! run_as_root env ${env} ${pm_cmd} ${install_subcmd} ${pkg_install_opts} epel-release; then
+        warning "Failed to install EPEL, even though it is required to install native packages on this system."
+        return 1
+      fi
     fi
   fi
 }

--- a/packaging/installer/methods/packages.md
+++ b/packaging/installer/methods/packages.md
@@ -44,7 +44,9 @@ repositories at that top level:
 
 Within each top level group of repositories, there are directories for each supported group of distributions:
 
-- `el`: Is for Red Hat Enterprise Linux and binary compatible distros, such as CentOS, Alma Linux, and Rocky Linux.
+- `amazonlinux`: Is for Amazon Linux and binary compatible distros.
+- `el`: Is for Red Hat Enterprise Linux and binary compatible distros that are not covered by other repos, such
+  as CentOS, Alma Linux, and Rocky Linux.
 - `fedora`: Is for Fedora and binary compatible distros.
 - `ol`: Is for Oracle Linux and binary compatible distros.
 - `opensuse`: Is for openSUSE and binary compatible distros.
@@ -63,6 +65,13 @@ If you are explicitly configuring a system to use our repositories, the recommen
 appropriate repository configuration package from https://repo.netdata.cloud/repos/repoconfig and install it
 directly on the target system using the system package manager. This will ensure any packages needed to use the
 repository are also installed, and will help enable a seamless transition if we ever need to change our infrastructure.
+
+> ### Note
+>
+> On RHEL and other systems that use the `el` repostiroies, some of the dependencies for Netdata can only be found
+> in the EPEL repository, which is not enabled or installed by default on most of these systems. This additional
+> repository _should_ be pulled in automatically by our repository config packages, but if it is not you may need
+> to manually install `epel-release` to be able to successfully install the Netdata packages.
 
 ## Manual setup of DEB packages.
 

--- a/packaging/repoconfig/debian/changelog
+++ b/packaging/repoconfig/debian/changelog
@@ -1,3 +1,9 @@
+netdata-repo (2-2) unstable; urgency=medium
+
+  * Version bump to keep in sync with RPM repo packages
+
+ -- Netdata Builder <bot@netdata.cloud>  Mon, 13 Nov 2023 11:15:00 -0500
+
 netdata-repo (2-1) unstable; urgency=medium
 
   * Switched to new package hosting infrastructure

--- a/packaging/repoconfig/netdata-repo.spec
+++ b/packaging/repoconfig/netdata-repo.spec
@@ -2,7 +2,7 @@
 
 Name:           netdata-repo
 Version:        2
-Release:        1
+Release:        2
 Summary:        Netdata stable repositories configuration.
 
 Group:          System Environment/Base
@@ -23,6 +23,10 @@ BuildArch:      noarch
 
 %if 0%{?centos_ver} && 0%{?centos_ver} < 8
 Requires:       yum-plugin-priorities
+%endif
+
+%if 0%{?centos_ver} && 0%{!?amazon_linux:1} && 0%{!?oraclelinux:1}
+Requires:       epel-release
 %endif
 
 # Overlapping file installs
@@ -104,6 +108,8 @@ This package contains the official Netdata package repository configuration for 
 %endif
 
 %changelog
+* Mon Nov 13 2023 Austin Hemmelgarn <austin@netdata.cloud> 2-2
+- Add EPEL requirement for RHEL packages.
 * Wed Dec 7 2022 Austin Hemmelgarn <austin@netdata.cloud> 2-1
 - Switch to new hosting at repo.netdata.cloud.
 * Mon Jun 6 2022 Austin Hemmelgarn <austin@netdata.cloud> 1-2


### PR DESCRIPTION
##### Summary

- Explicitly pull in EPEL on all systems where it’s required in kickstart.sh
- Explicitly depend on EPEL in our repository config packages for systems where it’s required.
- Document the requirement to use EPEL on these systems.

##### Test Plan

CI passes on this PR

##### Additional Information

Resolves #16404