### PR TITLE
Add support for installing a specific major version of the agent on install.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
-# Next unused error code: F0515
+# Next unused error code: F0516
 
 # ======================================================================
 # Constants
@@ -38,6 +38,7 @@ FORUM_URL="https://community.netdata.cloud/"
 INSTALL_DOC_URL="https://learn.netdata.cloud/docs/install-the-netdata-agent/one-line-installer-for-all-linux-systems"
 PACKAGES_SCRIPT="https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh"
 PUBLIC_CLOUD_URL="https://app.netdata.cloud"
+RELEASE_INFO_URL="https://repo.netdata.cloud/releases"
 REPOCONFIG_DEB_URL_PREFIX="https://repo.netdata.cloud/repos/repoconfig"
 REPOCONFIG_RPM_URL_PREFIX="https://repo.netdata.cloud/repos/repoconfig"
 TELEMETRY_URL="https://us-east1-netdata-analytics-bi.cloudfunctions.net/ingest_agent_events"
@@ -612,6 +613,22 @@ download() {
   else
     fatal "${ERROR_F0003}" F0003
   fi
+}
+
+get_actual_version() {
+    major="${1}"
+    channel="${2}"
+    url="${RELEASE_INFO_URL}/${channel}/v${major}"
+
+    if check_for_remote_file "${RELEASE_INFO_URL}"; then
+        if check_for_remote_file "${url}"; then
+            download "${url}" -
+        else
+            echo "NONE"
+        fi
+    else
+        echo ""
+    fi
 }
 
 get_redirect() {
@@ -2025,6 +2042,40 @@ install_on_freebsd() {
 # ======================================================================
 # Argument parsing code
 
+handle_major_version() {
+  CONTINUE_INSTALL_PROMPT="Attempting to install will use the latest version available overall. Do you wish to continue the install?"
+
+  if [ -z "${INSTALL_MAJOR_VERSION}" ]; then
+    return
+  fi
+
+  actual_version="$(get_actual_version "${INSTALL_MAJOR_VERSION}" "${RELEASE_CHANNEL}")"
+
+  if [ -z "${actual_version}" ]; then
+    if [ "${INTERACTIVE}" -eq 0 ]; then
+      fatal "Could not determine the lastest releaase in channel '${RELEASE_CHANNEL}' with major version '${INSTALL_MAJOR_VERSION}'" F0517
+    else
+      if confirm "Unable to determine the correct version to install for major version '${INSTALL_MAJOR_VERSION}'. ${CONTINUE_INSTALL_PROMPT}"; then
+        progress "User requested continuing the install with the latest version."
+      else
+        fatal "Cancelling installation at user request." F0518
+      fi
+    fi
+  elif [ "${actual_version}" = 'NONE' ]; then
+    if [ "${INTERACTIVE}" -eq 0 ]; then
+      warning "No releases with major version '${INSTALL_MAJOR_VERSION}' have been published. Continuing the install with the latest version instead."
+    else
+      if confirm "No releases with major version '${INSTALL_MAJOR_VERSION}' have been published. ${CONTINUE_INSTALL_PROMPT}"; then
+        progress "User requested continuing the install with the latest version."
+      else
+        fatal "Cancelling installation at user request." F0519
+      fi
+    fi
+  else
+    INSTALL_VERSION="${actual_version}"
+  fi
+}
+
 validate_args() {
   check_claim_opts
 
@@ -2056,22 +2107,6 @@ validate_args() {
     esac
   fi
 
-  if [ -n "${NETDATA_OFFLINE_INSTALL_SOURCE}" ] && [ -n "${INSTALL_VERSION}" ]; then
-      fatal "Specifying an install version alongside an offline install source is not supported." F050A
-  fi
-
-  if [ "${NETDATA_AUTO_UPDATES}" = "default" ]; then
-    if [ -n "${NETDATA_OFFLINE_INSTALL_SOURCE}" ] || [ -n "${INSTALL_VERSION}" ]; then
-      AUTO_UPDATE=0
-    else
-      AUTO_UPDATE=1
-    fi
-  elif [ "${NETDATA_AUTO_UPDATES}" = 1 ]; then
-    AUTO_UPDATE=1
-  else
-    AUTO_UPDATE=0
-  fi
-
   if [ "${RELEASE_CHANNEL}" = "default" ]; then
     if [ -n "${NETDATA_OFFLINE_INSTALL_SOURCE}" ]; then
       SELECTED_RELEASE_CHANNEL="$(cat "${NETDATA_OFFLINE_INSTALL_SOURCE}/channel")"
@@ -2088,6 +2123,31 @@ validate_args() {
     fi
 
     SELECTED_RELEASE_CHANNEL="${RELEASE_CHANNEL}"
+  fi
+
+  if [ -n "${INSTALL_MAJOR_VERSION}" ] && [ -n "${INSTALL_VERSION}" ]; then
+    fatal "Only one of --install-version or --install-major-version may be specified." F0515
+  fi
+
+  handle_major_version # Appropriately updates INSTALL_VERSION if INSTALL_MAJOR_VERSION is set.
+
+  if [ -n "${NETDATA_OFFLINE_INSTALL_SOURCE}" ] && [ -n "${INSTALL_VERSION}" ]; then
+      fatal "Specifying an install version alongside an offline install source is not supported." F050A
+  fi
+
+  if [ "${NETDATA_AUTO_UPDATES}" = "default" ]; then
+    if [ -n "${NETDATA_OFFLINE_INSTALL_SOURCE}" ] || [ -n "${INSTALL_VERSION}" ]; then
+      AUTO_UPDATE=0
+    else
+      AUTO_UPDATE=1
+    fi
+  elif [ "${NETDATA_INSTALL_MAJOR_VERSION}" ]; then
+    warning "Forcibly disabling auto updates as a specific major version was requested."
+    AUTO_UPDATE=0
+  elif [ "${NETDATA_AUTO_UPDATES}" = 1 ]; then
+    AUTO_UPDATE=1
+  else
+    AUTO_UPDATE=0
   fi
 }
 
@@ -2166,6 +2226,10 @@ parse_args() {
         ;;
       "--old-install-prefix")
         OLD_INSTALL_PREFIX="${2}"
+        shift 1
+        ;;
+      "--install-major-version")
+        INSTALL_MAJOR_VERSION="${2}"
         shift 1
         ;;
       "--install-version")

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -618,7 +618,7 @@ download() {
 get_actual_version() {
     major="${1}"
     channel="${2}"
-    url="${RELEASE_INFO_URL}/${channel}/v${major}"
+    url="${RELEASE_INFO_URL}/${channel}/${major}"
 
     if check_for_remote_file "${RELEASE_INFO_URL}"; then
         if check_for_remote_file "${url}"; then
@@ -2049,7 +2049,7 @@ handle_major_version() {
     return
   fi
 
-  actual_version="$(get_actual_version "${INSTALL_MAJOR_VERSION}" "${RELEASE_CHANNEL}")"
+  actual_version="$(get_actual_version "v${INSTALL_MAJOR_VERSION}" "${RELEASE_CHANNEL}")"
 
   if [ -z "${actual_version}" ]; then
     if [ "${INTERACTIVE}" -eq 0 ]; then


### PR DESCRIPTION
##### Summary

This adds a new option to the kickstart script called `--install-major-version` which allows the user to specify a particular major version of Netdata to attempt to install.

When this is used, it calls out to `https://repo.netdata.cloud/releases` to check what the latest published release for the requested major version is, and then proceeds as if the user had specified that version for the existing `--install-version` option and asked for auto-updates to be disabled.

If an issue is encountered when calling out to the release info URL, behavior is as follows:
- If running interactively, prompt the user with info about the error, and ask whether they want to abort the install or install the latest version overall instead.
- If running non-interactively and the failure was a result of the file not being found (which indicates that no release has been published of that version yet), issue a warning and install the latest version available.
- If running non-interactively and the failure was a result of some other issue (such as an inability to connect to the server), fail the install with an error message explaining that we couldn’t figure out the latest version.

Auto updates are disabled when this option is used because:
- A vast majority of users who are likely to use it are also likely to not want auto-updates.
- The updater currently doesn’t really support this, and implementing it there is non-trivial.

##### Test Plan

Testing consists of running the kickstart script from this PR with the specified new option. A value greater than 2 should be used for testing the fallback cases for non-published versions.

##### Additional Information

Support in the updater script for sticking to specific major version will be added in a separate PR, though that may not change the behavior of this option with respect to auto-updates.