### PR TITLE
fix: don't count reused connections as new

### DIFF
--- a/web/server/web_client_cache.c
+++ b/web/server/web_client_cache.c
@@ -91,20 +91,19 @@ struct web_client *web_client_get_from_cache(void) {
         // get it from avail
         DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(web_clients_cache.avail.head, w, cache.prev, cache.next);
         web_clients_cache.avail.count--;
+
         spinlock_unlock(&web_clients_cache.avail.spinlock);
-
         web_client_reuse_from_cache(w);
-
         spinlock_lock(&web_clients_cache.used.spinlock);
+
         web_clients_cache.used.reused++;
     }
     else {
         spinlock_unlock(&web_clients_cache.avail.spinlock);
-
-        // allocate it
         w = web_client_create(&netdata_buffers_statistics.buffers_web);
-
         spinlock_lock(&web_clients_cache.used.spinlock);
+
+        w->id = global_statistics_web_client_connected();
         web_clients_cache.used.allocated++;
     }
 
@@ -115,7 +114,6 @@ struct web_client *web_client_get_from_cache(void) {
 
     // initialize it
     w->use_count++;
-    w->id = global_statistics_web_client_connected();
     w->mode = WEB_CLIENT_MODE_GET;
 
     return w;


### PR DESCRIPTION
##### Summary

Fixes: #16410

##### Test Plan

The number of connected clients ("Netdata Web Clients") should be ~= (CONNECTED - DISCONNECTED) from `access.log`.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
