### PR TITLE
Don't print errors from reading filtered alerts

### DIFF
--- a/health/health_config.c
+++ b/health/health_config.c
@@ -583,6 +583,7 @@ static int health_readfile(const char *filename, void *data) {
     struct alert_config *alert_cfg = NULL;
 
     int ignore_this = 0;
+    bool filtered_config = false;
     size_t line = 0, append = 0;
     char *s;
     while((s = fgets(&buffer[append], (int)(HEALTH_CONF_MAX_LINE - append), fp)) || append) {
@@ -680,8 +681,10 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->alarm = string_dup(rc->name);
                 alert_cfg->source = health_source_file(line, filename);
                 ignore_this = 0;
+                filtered_config = false;
             } else {
                 rc = NULL;
+                filtered_config = true;
             }
         }
         else if(hash == hash_template && !strcasecmp(key, HEALTH_TEMPLATE_KEY)) {
@@ -727,8 +730,10 @@ static int health_readfile(const char *filename, void *data) {
                 alert_cfg->template_key = string_dup(rt->name);
                 alert_cfg->source = health_source_file(line, filename);
                 ignore_this = 0;
+                filtered_config = false;
             } else {
                 rt = NULL;
+                filtered_config = true;
             }
         }
         else if(hash == hash_os && !strcasecmp(key, HEALTH_OS_KEY)) {
@@ -1320,8 +1325,8 @@ static int health_readfile(const char *filename, void *data) {
             }
         }
         else {
-            netdata_log_error("Health configuration at line %zu of file '%s' has unknown key '%s'. Expected either '" HEALTH_ALARM_KEY "' or '" HEALTH_TEMPLATE_KEY "'.",
-                              line, filename, key);
+            if (!filtered_config)
+                netdata_log_error("Health configuration at line %zu of file '%s' has unknown key '%s'. Expected either '" HEALTH_ALARM_KEY "' or '" HEALTH_TEMPLATE_KEY "'.", line, filename, key);
         }
     }
 


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

This PR suppresses errors from when loading alert config files that their alerts have been filtered with `enabled alarms` config option.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Filter an alarm with `enabled alarms` config option in health, e.g. `enabled alarms = !*ram* *`. Notice in error.log there are errors in the form `Health configuration at line 26 of file '/usr/lib/netdata/conf.d/health.d/windows.conf' has unknown key 'class'. Expected either 'alarm' or 'template'.

With this PR there should not be any errors.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
