### PR TITLE
fix proc net dev: keep iface speed chart var in Mbits

### DIFF
--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -1446,7 +1446,7 @@ int do_proc_net_dev(int update_every, usec_t dt) {
                         }
 
                         rrdsetvar_custom_chart_variable_set(
-                            d->st_bandwidth, d->chart_var_speed, (NETDATA_DOUBLE)d->speed * KILOBITS_IN_A_MEGABIT);
+                            d->st_bandwidth, d->chart_var_speed, (NETDATA_DOUBLE)d->speed);
 
                         if (d->speed) {
                             d->speed_file_exists = 1;

--- a/health/health.d/net.conf
+++ b/health/health.d/net.conf
@@ -24,7 +24,7 @@ component: Network
        os: linux
     hosts: *
    lookup: average -1m unaligned absolute of received
-     calc: ($interface_speed > 0) ? ($this * 100 / ($interface_speed)) : ( nan )
+     calc: ($interface_speed > 0) ? ($this * 100 / ($interface_speed * 1000)) : ( nan )
     units: %
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (85) : (90))
@@ -41,7 +41,7 @@ component: Network
        os: linux
     hosts: *
    lookup: average -1m unaligned absolute of sent
-     calc: ($interface_speed > 0) ? ($this * 100 / ($interface_speed)) : ( nan )
+     calc: ($interface_speed > 0) ? ($this * 100 / ($interface_speed * 1000)) : ( nan )
     units: %
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (85) : (90))


### PR DESCRIPTION
##### Summary

This PR removes the variable network interface speed chart conversion to kilobits.

This fixes an issue where we are showing the wrong value on [interface_speed](https://github.com/netdata/netdata/blob/183a7fb84f85885a3d91f8e28d4e9780f964f659/health/health.d/net.conf#L7). That is 10G interface, should be 10000Mbit.

<details open>
<summary>screenshot</summary>

<img width="735" alt="Screenshot 2023-11-15 at 12 02 06" src="https://github.com/netdata/netdata/assets/22274335/61a1120a-a459-499f-aa8a-084770f6684b">

</details>


I've adjusted the alarms using interface_speed, we need to convert interface_speed to kilobits.

##### Test Plan

Check interface_speed value.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
