### PR TITLE
disable socket port reuse

### DIFF
--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -303,7 +303,7 @@ int create_listen_socket4(int socktype, const char *ip, uint16_t port, int liste
     }
 
     sock_setreuse(sock, 1);
-    sock_setreuse_port(sock, 1);
+    sock_setreuse_port(sock, 0);
     sock_setnonblock(sock);
     sock_enlarge_in(sock);
 
@@ -348,7 +348,7 @@ int create_listen_socket6(int socktype, uint32_t scope_id, const char *ip, int p
     }
 
     sock_setreuse(sock, 1);
-    sock_setreuse_port(sock, 1);
+    sock_setreuse_port(sock, 0);
     sock_setnonblock(sock);
     sock_enlarge_in(sock);
 


### PR DESCRIPTION
##### Summary

It is possible to run multiple instances of ND and listen on the same port. This PR disables reusing TCP port.

##### Test Plan

Start 1+ Netdata instances and make sure only the one is running, the rest should fatal " Cannot listen on any API socket. Exiting...".

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
