### PR TITLE
Minor: Remove backtick from doc

### DIFF
--- a/health/REFERENCE.md
+++ b/health/REFERENCE.md
@@ -701,14 +701,14 @@ If you have an e.g. external disk mounted on `/mnt/disk1` and you don't wish any
 it (but you do for all other mount points), you can add the following to the alert's configuration:
 
 ```yaml
-chart labels: mount_point=!/mnt/disk1 *`
+chart labels: mount_point=!/mnt/disk1 *
 ```
 
 The `chart labels` is a space-separated list that accepts simple patterns. If you use multiple different chart labels,
 then the result is an OR between them. i.e. the following:
 
 ```yaml
-chart labels: mount_point=/mnt/disk1 device=sda`
+chart labels: mount_point=/mnt/disk1 device=sda
 ```
 
 Will create the alert if the `mount_point` is `/mnt/disk1` or the `device` is `sda`. Furthermore, if a chart label name


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

As mentioned in #15973, the docs in https://learn.netdata.cloud/docs/alerting/health-configuration-reference#alert-line-chart-labels have a lone backtick at the end.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
