### PR TITLE
Delay datafile open and superblock check

### DIFF
--- a/src/database/engine/datafile.h
+++ b/src/database/engine/datafile.h
@@ -33,6 +33,10 @@ typedef enum __attribute__ ((__packed__)) {
     DATAFILE_ACQUIRE_MAX,
 } DATAFILE_ACQUIRE_REASONS;
 
+typedef enum __attribute__ ((__packed__)) {
+    DATAFILE_FLAG_IS_AVAILABLE          = (1 << 0),
+} DATAFILE_FLAGS;
+
 /* only one event loop is supported for now */
 struct rrdengine_datafile {
     unsigned tier;
@@ -44,6 +48,7 @@ struct rrdengine_datafile {
     struct rrdengine_journalfile *journalfile;
     struct rrdengine_datafile *prev;
     struct rrdengine_datafile *next;
+    DATAFILE_FLAGS flags;
 
     struct {
         SPINLOCK spinlock;


### PR DESCRIPTION
##### Summary
At startup, the agent keeps datafiles open for improved performance, but this might waste resources if some files are never used. 

The update now waits to open a file (and check its header) until it's actually needed. You will see a message similar to

`2023-11-11 14:49:48: netdata INFO  : DBENGINIT[2] : Accessing datafile 80 (tier 2) for superblock check in 0.03 ms`

