### PR TITLE
Revert "fix proc net dev: keep iface speed chart var in Mbits"

### DIFF
--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -1446,7 +1446,7 @@ int do_proc_net_dev(int update_every, usec_t dt) {
                         }
 
                         rrdsetvar_custom_chart_variable_set(
-                            d->st_bandwidth, d->chart_var_speed, (NETDATA_DOUBLE)d->speed);
+                            d->st_bandwidth, d->chart_var_speed, (NETDATA_DOUBLE)d->speed * KILOBITS_IN_A_MEGABIT);
 
                         if (d->speed) {
                             d->speed_file_exists = 1;

--- a/health/health.d/net.conf
+++ b/health/health.d/net.conf
@@ -24,7 +24,7 @@ component: Network
        os: linux
     hosts: *
    lookup: average -1m unaligned absolute of received
-     calc: ($interface_speed > 0) ? ($this * 100 / ($interface_speed * 1000)) : ( nan )
+     calc: ($interface_speed > 0) ? ($this * 100 / ($interface_speed)) : ( nan )
     units: %
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (85) : (90))
@@ -41,7 +41,7 @@ component: Network
        os: linux
     hosts: *
    lookup: average -1m unaligned absolute of sent
-     calc: ($interface_speed > 0) ? ($this * 100 / ($interface_speed * 1000)) : ( nan )
+     calc: ($interface_speed > 0) ? ($this * 100 / ($interface_speed)) : ( nan )
     units: %
     every: 10s
      warn: $this > (($status >= $WARNING)  ? (85) : (90))


### PR DESCRIPTION
Reverts netdata/netdata#16418

Because of https://github.com/netdata/netdata/pull/16418#issuecomment-1815985358

I think we will just update the units of the `interface_speed` alarm to Kilobits. But we will need to make this change but announcing it first.