### PR TITLE
proc_net_dev: keep nic_speed_max in kilobits

### DIFF
--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -1446,7 +1446,7 @@ int do_proc_net_dev(int update_every, usec_t dt) {
                         }
 
                         rrdsetvar_custom_chart_variable_set(
-                            d->st_bandwidth, d->chart_var_speed, (NETDATA_DOUBLE)d->speed);
+                            d->st_bandwidth, d->chart_var_speed, (NETDATA_DOUBLE)d->speed * KILOBITS_IN_A_MEGABIT);
 
                         if (d->speed) {
                             d->speed_file_exists = 1;

--- a/health/health.d/net.conf
+++ b/health/health.d/net.conf
@@ -11,7 +11,7 @@
 component: Network
        os: *
     hosts: *
-     calc: ( $nic_speed_max > 0 ) ? ( $nic_speed_max) : ( nan )
+     calc: ( $nic_speed_max > 0 ) ? ( $nic_speed_max / 1000) : ( nan )
     units: Mbit
     every: 10s
      info: Network interface ${label:device} current speed


### PR DESCRIPTION
##### Summary

Fixes https://github.com/netdata/netdata/pull/16418#issuecomment-1815985358

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
