### PR TITLE
Journal sampling

### DIFF
--- a/collectors/systemd-journal.plugin/systemd-journal.c
+++ b/collectors/systemd-journal.plugin/systemd-journal.c
@@ -352,7 +352,7 @@ static void sampling_decide_file_sampling_every(FUNCTION_QUERY_STATUS *fqs, stru
         fqs->samples_per_file.every = 1;
 }
 
-static inline bool is_row_in_sample(FUNCTION_QUERY_STATUS *fqs, struct journal_file *jf, usec_t msg_ut) {
+static inline bool is_row_in_sample(FUNCTION_QUERY_STATUS *fqs, struct journal_file *jf, usec_t msg_ut, bool candidate_to_keep) {
     if(!fqs->sampling)
         return true;
 
@@ -365,7 +365,7 @@ static inline bool is_row_in_sample(FUNCTION_QUERY_STATUS *fqs, struct journal_f
     if(slot >= SYSTEMD_JOURNAL_SAMPLING_SLOTS)
         slot = SYSTEMD_JOURNAL_SAMPLING_SLOTS - 1;
 
-    bool should_sample = false;
+    bool should_sample = candidate_to_keep;
 
     if(fqs->samples_per_file.sampled < fqs->samples_per_file.init ||
         fqs->samples_per_time_slot.sampled[slot] < fqs->samples_per_time_slot.init)
@@ -530,7 +530,7 @@ ND_SD_JOURNAL_STATUS netdata_systemd_journal_query_backward(
         if (unlikely(msg_ut < stop_ut))
             break;
 
-        if(is_row_in_sample(fqs, jf, msg_ut))
+        if(is_row_in_sample(fqs, jf, msg_ut, facets_row_candidate_to_keep(facets, msg_ut)))
             bytes += netdata_systemd_journal_process_row(j, facets, jf, &msg_ut);
 
         // make sure each line gets a unique timestamp
@@ -617,7 +617,7 @@ ND_SD_JOURNAL_STATUS netdata_systemd_journal_query_forward(
         if (unlikely(msg_ut > stop_ut))
             break;
 
-        if(is_row_in_sample(fqs, jf, msg_ut))
+        if(is_row_in_sample(fqs, jf, msg_ut, facets_row_candidate_to_keep(facets, msg_ut)))
             bytes += netdata_systemd_journal_process_row(j, facets, jf, &msg_ut);
 
         // make sure each line gets a unique timestamp

--- a/collectors/systemd-journal.plugin/systemd-main.c
+++ b/collectors/systemd-journal.plugin/systemd-main.c
@@ -38,7 +38,7 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
 
     if(argc == 2 && strcmp(argv[1], "debug") == 0) {
         bool cancelled = false;
-        char buf[] = "systemd-journal after:-16000000 before:0 last:1";
+        char buf[] = "systemd-journal after:1700412109 before:1700433709 last:200 slice:true source:namespace-test";
         // char buf[] = "systemd-journal after:1695332964 before:1695937764 direction:backward last:100 slice:true source:all DHKucpqUoe1:PtVoyIuX.MU";
         // char buf[] = "systemd-journal after:1694511062 before:1694514662 anchor:1694514122024403";
         function_systemd_journal("123", buf, 600, &cancelled);

--- a/collectors/systemd-journal.plugin/systemd-main.c
+++ b/collectors/systemd-journal.plugin/systemd-main.c
@@ -38,7 +38,7 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
 
     if(argc == 2 && strcmp(argv[1], "debug") == 0) {
         bool cancelled = false;
-        char buf[] = "ystemd-journal after:1700465563 before:1700469163 last:200 slice:true source:all query:journald";
+        char buf[] = "systemd-journal after:-8640000 before:0 direction:backward last:200 data_only:false slice:true source:all";
         // char buf[] = "systemd-journal after:1695332964 before:1695937764 direction:backward last:100 slice:true source:all DHKucpqUoe1:PtVoyIuX.MU";
         // char buf[] = "systemd-journal after:1694511062 before:1694514662 anchor:1694514122024403";
         function_systemd_journal("123", buf, 600, &cancelled);

--- a/collectors/systemd-journal.plugin/systemd-main.c
+++ b/collectors/systemd-journal.plugin/systemd-main.c
@@ -38,7 +38,7 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
 
     if(argc == 2 && strcmp(argv[1], "debug") == 0) {
         bool cancelled = false;
-        char buf[] = "systemd-journal after:1700412109 before:1700433709 last:200 slice:true source:namespace-test";
+        char buf[] = "ystemd-journal after:1700465563 before:1700469163 last:200 slice:true source:all query:journald";
         // char buf[] = "systemd-journal after:1695332964 before:1695937764 direction:backward last:100 slice:true source:all DHKucpqUoe1:PtVoyIuX.MU";
         // char buf[] = "systemd-journal after:1694511062 before:1694514662 anchor:1694514122024403";
         function_systemd_journal("123", buf, 600, &cancelled);

--- a/libnetdata/facets/facets.c
+++ b/libnetdata/facets/facets.c
@@ -2611,6 +2611,7 @@ void facets_report(FACETS *facets, BUFFER *wb, DICTIONARY *used_hashes_registry)
     if(show_items) {
         buffer_json_member_add_uint64(wb, "evaluated", facets->operations.rows.evaluated);
         buffer_json_member_add_uint64(wb, "matched", facets->operations.rows.matched);
+        buffer_json_member_add_uint64(wb, "unsampled", facets->operations.rows.unsampled);
         buffer_json_member_add_uint64(wb, "returned", facets->items_to_return);
         buffer_json_member_add_uint64(wb, "max_to_return", facets->max_items_to_return);
         buffer_json_member_add_uint64(wb, "before", facets->operations.skips_before);

--- a/libnetdata/facets/facets.c
+++ b/libnetdata/facets/facets.c
@@ -1771,6 +1771,10 @@ static inline bool facets_is_entry_within_anchor(FACETS *facets, usec_t usec) {
     return true;
 }
 
+bool facets_row_candidate_to_keep(FACETS *facets, usec_t usec) {
+    return !facets->base || usec > facets->base->prev->usec || facets->items_to_return < facets->max_items_to_return;
+}
+
 static void facets_row_keep(FACETS *facets, usec_t usec) {
     facets->operations.rows.matched++;
 

--- a/libnetdata/facets/facets.h
+++ b/libnetdata/facets/facets.h
@@ -84,7 +84,10 @@ void facets_destroy(FACETS *facets);
 void facets_accepted_param(FACETS *facets, const char *param);
 
 void facets_rows_begin(FACETS *facets);
-bool facets_row_finished(FACETS *facets, usec_t usec, bool sampled);
+bool facets_row_finished(FACETS *facets, usec_t usec);
+
+void facets_row_finished_unsampled(FACETS *facets, usec_t usec);
+size_t facets_histogram_slots(FACETS *facets);
 
 FACET_KEY *facets_register_key_name(FACETS *facets, const char *key, FACET_KEY_OPTIONS options);
 void facets_set_query(FACETS *facets, const char *query);

--- a/libnetdata/facets/facets.h
+++ b/libnetdata/facets/facets.h
@@ -6,6 +6,7 @@
 #include "../libnetdata.h"
 
 #define FACET_VALUE_UNSET "-"
+#define FACET_VALUE_UNSAMPLED "[unsampled]"
 
 typedef enum __attribute__((packed)) {
     FACETS_ANCHOR_DIRECTION_FORWARD,
@@ -83,7 +84,7 @@ void facets_destroy(FACETS *facets);
 void facets_accepted_param(FACETS *facets, const char *param);
 
 void facets_rows_begin(FACETS *facets);
-bool facets_row_finished(FACETS *facets, usec_t usec);
+bool facets_row_finished(FACETS *facets, usec_t usec, bool sampled);
 
 FACET_KEY *facets_register_key_name(FACETS *facets, const char *key, FACET_KEY_OPTIONS options);
 void facets_set_query(FACETS *facets, const char *query);

--- a/libnetdata/facets/facets.h
+++ b/libnetdata/facets/facets.h
@@ -90,6 +90,7 @@ void facets_set_query(FACETS *facets, const char *query);
 void facets_set_items(FACETS *facets, uint32_t items);
 void facets_set_anchor(FACETS *facets, usec_t start_ut, usec_t stop_ut, FACETS_ANCHOR_DIRECTION direction);
 void facets_enable_slice_mode(FACETS *facets);
+bool facets_row_candidate_to_keep(FACETS *facets, usec_t usec);
 
 FACET_KEY *facets_register_facet_id(FACETS *facets, const char *key_id, FACET_KEY_OPTIONS options);
 void facets_register_facet_id_filter(FACETS *facets, const char *key_id, char *value_id, FACET_KEY_OPTIONS options);


### PR DESCRIPTION
When dealing with very large journals, the dashboard can get quite slow.
This PR adds the ability the sample parts of the data to render the dashboard.

By default sampling has a target of about 1M log entries. The parameter `sampling:ENTRIES` is exposed for the UI to change this default.

- Sampling is activated at 50% of the target. So, as long as the number of lines are below 500k, 100% sampling is performed.

- The target is distributed like this:
   - 50% of the target is used to trigger sampling. So, as long as the total number of events processed so far is below 50% of the target, sampling is disabled.
   - 25% of the target is allocated to each journal file evenly, with a minimum of `last x 2` items (usually 200 x 2 = 400). So, as long the total number of events processed so far for each file is below its share, sampling is disabled.
   - 25% of the target is allocated to a time-slot (as many slots as the bars on the histogram), with a minimum of `last` items (usually 200). So, as long as the total number of events processed for each time slot is below its share, sampling is disabled.
- Once sampling is enabled, a calculation predicts the expected total lines on the file currently being read. This estimation is recalibrated every 10k events read from the file. Based on this estimation, the system decides to sample 1 ever X events read from this file.
- The histogram shows `[unsampled]` entries when there are unsampled data in the query.

![image](https://github.com/netdata/netdata/assets/2662304/6ed42fe4-c9fc-4ef8-8e83-371f8ca5dbcf)
