### PR TITLE
journal startup

### DIFF
--- a/collectors/systemd-journal.plugin/systemd-internals.h
+++ b/collectors/systemd-journal.plugin/systemd-internals.h
@@ -108,4 +108,11 @@ void netdata_systemd_journal_transform_message_id(FACETS *facets __maybe_unused,
 void function_systemd_units(const char *transaction, char *function, int timeout, bool *cancelled);
 #endif
 
+static inline void send_newline_and_flush(void) {
+    netdata_mutex_lock(&stdout_mutex);
+    fprintf(stdout, "\n");
+    fflush(stdout);
+    netdata_mutex_unlock(&stdout_mutex);
+}
+
 #endif //NETDATA_COLLECTORS_SYSTEMD_INTERNALS_H

--- a/collectors/systemd-journal.plugin/systemd-main.c
+++ b/collectors/systemd-journal.plugin/systemd-main.c
@@ -74,8 +74,6 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
     usec_t since_last_scan_ut = 1000 * USEC_PER_SEC; // something big to trigger scanning at start
     bool tty = isatty(fileno(stderr)) == 1;
 
-    netdata_mutex_lock(&stdout_mutex);
-
     fprintf(stdout, PLUGINSD_KEYWORD_FUNCTION " GLOBAL \"%s\" %d \"%s\"\n",
             SYSTEMD_JOURNAL_FUNCTION_NAME, SYSTEMD_JOURNAL_DEFAULT_TIMEOUT, SYSTEMD_JOURNAL_FUNCTION_DESCRIPTION);
 
@@ -83,6 +81,8 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
     fprintf(stdout, PLUGINSD_KEYWORD_FUNCTION " GLOBAL \"%s\" %d \"%s\"\n",
             SYSTEMD_UNITS_FUNCTION_NAME, SYSTEMD_UNITS_DEFAULT_TIMEOUT, SYSTEMD_UNITS_FUNCTION_DESCRIPTION);
 #endif
+
+    send_newline_and_flush();
 
     heartbeat_t hb;
     heartbeat_init(&hb);

--- a/collectors/systemd-journal.plugin/systemd-main.c
+++ b/collectors/systemd-journal.plugin/systemd-main.c
@@ -68,11 +68,9 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
 #endif
 
     // ------------------------------------------------------------------------
+    // register functions to netdata
 
-    usec_t step_ut = 100 * USEC_PER_MS;
-    usec_t send_newline_ut = 0;
-    usec_t since_last_scan_ut = 1000 * USEC_PER_SEC; // something big to trigger scanning at start
-    bool tty = isatty(fileno(stderr)) == 1;
+    netdata_mutex_lock(&stdout_mutex);
 
     fprintf(stdout, PLUGINSD_KEYWORD_FUNCTION " GLOBAL \"%s\" %d \"%s\"\n",
             SYSTEMD_JOURNAL_FUNCTION_NAME, SYSTEMD_JOURNAL_DEFAULT_TIMEOUT, SYSTEMD_JOURNAL_FUNCTION_DESCRIPTION);
@@ -82,7 +80,15 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
             SYSTEMD_UNITS_FUNCTION_NAME, SYSTEMD_UNITS_DEFAULT_TIMEOUT, SYSTEMD_UNITS_FUNCTION_DESCRIPTION);
 #endif
 
-    send_newline_and_flush();
+    fflush(stdout);
+    netdata_mutex_unlock(&stdout_mutex);
+
+    // ------------------------------------------------------------------------
+
+    usec_t step_ut = 100 * USEC_PER_MS;
+    usec_t send_newline_ut = 0;
+    usec_t since_last_scan_ut = 1000 * USEC_PER_SEC; // something big to trigger scanning at start
+    bool tty = isatty(fileno(stderr)) == 1;
 
     heartbeat_t hb;
     heartbeat_init(&hb);


### PR DESCRIPTION
On very busy journal servers, the plugin times out while Netdata is waiting for it to start.

1. change the main loop of systemd-journal.plugin so that it registers functions before scanning files,
2. pings netdata while scanning files
3. allows only 1 scan at a time, so that functions execution will not stuck at updating the files registry.
