### PR TITLE
fix: link daemon.log to stderr in docker

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -89,6 +89,7 @@ RUN mkdir -p /opt/src /var/log/netdata && \
     ln -sf /dev/stdout /var/log/netdata/access.log && \
     ln -sf /dev/stdout /var/log/netdata/debug.log && \
     ln -sf /dev/stderr /var/log/netdata/error.log && \
+    ln -sf /dev/stderr /var/log/netdata/daemon.log && \
     ln -sf /dev/stdout /var/log/netdata/collector.log && \
     ln -sf /dev/stdout /var/log/netdata/health.log && \
     addgroup -g ${NETDATA_GID} -S "${DOCKER_GRP}" && \


### PR DESCRIPTION
##### Summary

daemon.log was introduced in #16357

why this PR - see #15813

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
