### PR TITLE
log flood protection to 1000 log lines / 1 minute

### DIFF
--- a/libnetdata/log/README.md
+++ b/libnetdata/log/README.md
@@ -45,24 +45,26 @@ All other sources default to a file.
 
 ## Log formats
 
-Netdata supports the follow formats for its logs:
-
-- **journal**, this is automatically selected when logging to systemd-journal.
-- **logfmt**, this is the default when logging to any output other than `journal`. In this format, Netdata annotates the fields to make them human readable. 
-- **json**, to write logs lines in json format. The output is machine readable, similar to `journal`.
+| Format  | Description                                                                                            |
+|---------|--------------------------------------------------------------------------------------------------------|
+| journal | journald-specific log format. Automatically selected when logging to systemd-journal.                  |
+| logfmt  | logs data as a series of key/value pairs. The default when logging to any output other than `journal`. |
+| json    | logs data in JSON format.                                                                              |
 
 ## Log levels
 
 Each time Netdata logs, it assigns a priority to the log. It can be one of this (in order of importance):
 
-- **emergency**, a fatal condition; most likely Netdata will exit immediately after,
-- **alert**, a very important issue that may affect how Netdata operates,
-- **critical**, a very important issue the user should know which, Netdata thinks it can survive,
-- **error**, an error condition indicating that Netdata is trying to do something but it fails,
-- **warning**, something that may or may not affect the operation of Netdata, but the outcome cannot be determined at the time Netdata logs,
-- **notice**, something that does not affect the operation of Netdata, but the user should notice,
-- **info**, the default log level about information the user should know,
-- **debug**, these are more verbose logs that can be ignored,
+| Level     | Description                                                                            |
+|-----------|----------------------------------------------------------------------------------------|
+| emergency | a fatal condition; most likely Netdata will exit immediately after.                    |
+| alert     | a very important issue that may affect how Netdata operates.                           |
+| critical  | a very important issue the user should know which, Netdata thinks it can survive.      |
+| error     | an error condition indicating that Netdata is trying to do something, but it fails.    |
+| warning   | Something unexpected has happened that may or may not affect the operation of Netdata. |
+| notice    | something that does not affect the operation of Netdata, but the user should notice.   |
+| info      | the default log level about information the user should know.                          |
+| debug     | these are more verbose logs that can be ignored.                                       |
 
 ## Logs Configuration
 
@@ -70,8 +72,8 @@ In `netdata.conf`, there are the following settings:
 
 ```
 [logs]
-	# logs to trigger flood protection = 600
-	# logs flood protection period = 3600
+	# logs to trigger flood protection = 1200
+	# logs flood protection period = 60
 	# facility = daemon
 	# level = info
 	# daemon = journal

--- a/libnetdata/log/README.md
+++ b/libnetdata/log/README.md
@@ -57,11 +57,11 @@ Each time Netdata logs, it assigns a priority to the log. It can be one of this 
 
 | Level     | Description                                                                            |
 |-----------|----------------------------------------------------------------------------------------|
-| emergency | a fatal condition; most likely Netdata will exit immediately after.                    |
+| emergency | a fatal condition, Netdata will most likely exit immediately after.                    |
 | alert     | a very important issue that may affect how Netdata operates.                           |
 | critical  | a very important issue the user should know which, Netdata thinks it can survive.      |
 | error     | an error condition indicating that Netdata is trying to do something, but it fails.    |
-| warning   | Something unexpected has happened that may or may not affect the operation of Netdata. |
+| warning   | something unexpected has happened that may or may not affect the operation of Netdata. |
 | notice    | something that does not affect the operation of Netdata, but the user should notice.   |
 | info      | the default log level about information the user should know.                          |
 | debug     | these are more verbose logs that can be ignored.                                       |

--- a/libnetdata/log/README.md
+++ b/libnetdata/log/README.md
@@ -72,7 +72,7 @@ In `netdata.conf`, there are the following settings:
 
 ```
 [logs]
-	# logs to trigger flood protection = 1200
+	# logs to trigger flood protection = 1000
 	# logs flood protection period = 60
 	# facility = daemon
 	# level = info

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "../libnetdata.h"
 
 #define ND_LOG_DEFAULT_THROTTLE_LOGS 1200
-#define ND_LOG_DEFAULT_THROTTLE_PERIOD 3600
+#define ND_LOG_DEFAULT_THROTTLE_PERIOD 60
 
 typedef enum  __attribute__((__packed__)) {
     NDLS_UNSET = 0,   // internal use only

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -9,7 +9,7 @@ extern "C" {
 
 #include "../libnetdata.h"
 
-#define ND_LOG_DEFAULT_THROTTLE_LOGS 1200
+#define ND_LOG_DEFAULT_THROTTLE_LOGS 1000
 #define ND_LOG_DEFAULT_THROTTLE_PERIOD 60
 
 typedef enum  __attribute__((__packed__)) {


### PR DESCRIPTION
##### Summary

This PR relaxes flood protection: period 3600 => 60. 3600 is huge.

Additionally, this PR improves logs readme by changing some lists into tables (better readability).


##### Test Plan

I think not needed because the only change is changing the ND_LOG_DEFAULT_THROTTLE_PERIOD define value.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
