### PR TITLE
add LogNamespace to systemd units

### DIFF
--- a/system/systemd/netdata.service.in
+++ b/system/systemd/netdata.service.in
@@ -6,6 +6,7 @@ Description=Real time performance monitoring
 After=network.target
 
 [Service]
+LogNamespace=netdata
 Type=simple
 User=root
 RuntimeDirectory=netdata

--- a/system/systemd/netdata.service.v235.in
+++ b/system/systemd/netdata.service.v235.in
@@ -6,6 +6,7 @@ Description=Real time performance monitoring
 After=network.target
 
 [Service]
+LogNamespace=netdata
 Type=simple
 User=root
 EnvironmentFile=-/etc/default/netdata


### PR DESCRIPTION
##### Summary

This PR adds the [LogNamespace](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#LogNamespace=) setting to the ND systemd unit file. Netdata logs will go in the `netdata` journal namespace.

##### Test Plan

`journalctl --namespace=netdata`

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
