### PR TITLE
add sbindir_POST to PATH of bash scripts that use `systemd-cat-native`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,7 @@ daemon/get-kubernetes-labels.sh
 
 health/notifications/alarm-notify.sh
 claim/netdata-claim.sh
+collectors/cgroups.plugin/cgroup-name.sh
 collectors/tc.plugin/tc-qos-helper.sh
 collectors/charts.d.plugin/charts.d.plugin
 collectors/python.d.plugin/python.d.plugin

--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ daemon/get-kubernetes-labels.sh
 health/notifications/alarm-notify.sh
 claim/netdata-claim.sh
 collectors/cgroups.plugin/cgroup-name.sh
+collectors/cgroups.plugin/cgroup-network-helper.sh
 collectors/tc.plugin/tc-qos-helper.sh
 collectors/charts.d.plugin/charts.d.plugin
 collectors/python.d.plugin/python.d.plugin

--- a/collectors/cgroups.plugin/Makefile.am
+++ b/collectors/cgroups.plugin/Makefile.am
@@ -3,11 +3,19 @@
 AUTOMAKE_OPTIONS = subdir-objects
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 
+CLEANFILES = \
+    cgroup-name.sh \
+    $(NULL)
+
+include $(top_srcdir)/build/subst.inc
+SUFFIXES = .in
+
 dist_plugins_SCRIPTS = \
     cgroup-name.sh \
     cgroup-network-helper.sh \
     $(NULL)
 
 dist_noinst_DATA = \
+    cgroup-name.sh.in \
     README.md \
     $(NULL)

--- a/collectors/cgroups.plugin/Makefile.am
+++ b/collectors/cgroups.plugin/Makefile.am
@@ -5,6 +5,7 @@ MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 
 CLEANFILES = \
     cgroup-name.sh \
+    cgroup-network-helper.sh \
     $(NULL)
 
 include $(top_srcdir)/build/subst.inc
@@ -17,5 +18,6 @@ dist_plugins_SCRIPTS = \
 
 dist_noinst_DATA = \
     cgroup-name.sh.in \
+    cgroup-network-helper.sh.in \
     README.md \
     $(NULL)

--- a/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -9,7 +9,7 @@
 # Script to find a better name for cgroups
 #
 
-export PATH="${PATH}:/sbin:/usr/sbin:/usr/local/sbin"
+export PATH="${PATH}:/sbin:/usr/sbin:/usr/local/sbin:@sbindir_POST@"
 export LC_ALL=C
 
 cmd_line="'${0}' $(printf "'%s' " "${@}")"

--- a/collectors/cgroups.plugin/cgroup-network-helper.sh.in
+++ b/collectors/cgroups.plugin/cgroup-network-helper.sh.in
@@ -34,6 +34,8 @@ cmd_line="'${0}' $(printf "'%s' " "${@}")"
 # -----------------------------------------------------------------------------
 # logging
 
+NETDATA_EXE_PATH=@sbindir_POST@
+
 PROGRAM_NAME="$(basename "${0}")"
 
 # these should be the same with syslog() priorities
@@ -93,7 +95,7 @@ log() {
 
   [[ -n "$level" && -n "$LOG_LEVEL" && "$level" -gt "$LOG_LEVEL" ]] && return
 
-  systemd-cat-native --log-as-netdata --newline="{NEWLINE}" <<EOFLOG
+  PATH=${NETDATA_EXE_PATH} systemd-cat-native --log-as-netdata --newline="{NEWLINE}" <<EOFLOG
 INVOCATION_ID=${NETDATA_INVOCATION_ID}
 SYSLOG_IDENTIFIER=${PROGRAM_NAME}
 PRIORITY=${level}

--- a/collectors/cgroups.plugin/cgroup-network-helper.sh.in
+++ b/collectors/cgroups.plugin/cgroup-network-helper.sh.in
@@ -26,6 +26,7 @@
 # the system path is cleared by cgroup-network
 # shellcheck source=/dev/null
 [ -f /etc/profile ] && source /etc/profile
+export PATH="${PATH}:@sbindir_POST@"
 
 export LC_ALL=C
 
@@ -33,8 +34,6 @@ cmd_line="'${0}' $(printf "'%s' " "${@}")"
 
 # -----------------------------------------------------------------------------
 # logging
-
-NETDATA_EXE_PATH=@sbindir_POST@
 
 PROGRAM_NAME="$(basename "${0}")"
 
@@ -95,7 +94,7 @@ log() {
 
   [[ -n "$level" && -n "$LOG_LEVEL" && "$level" -gt "$LOG_LEVEL" ]] && return
 
-  PATH=${NETDATA_EXE_PATH} systemd-cat-native --log-as-netdata --newline="{NEWLINE}" <<EOFLOG
+  systemd-cat-native --log-as-netdata --newline="{NEWLINE}" <<EOFLOG
 INVOCATION_ID=${NETDATA_INVOCATION_ID}
 SYSLOG_IDENTIFIER=${PROGRAM_NAME}
 PRIORITY=${level}

--- a/collectors/charts.d.plugin/charts.d.plugin.in
+++ b/collectors/charts.d.plugin/charts.d.plugin.in
@@ -13,7 +13,7 @@
 # each will have a different config file and modules configuration directory.
 #
 
-export PATH="${PATH}:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
+export PATH="${PATH}:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin:@sbindir_POST@"
 
 PROGRAM_FILE="$0"
 MODULE_NAME="main"

--- a/health/notifications/alarm-notify.sh.in
+++ b/health/notifications/alarm-notify.sh.in
@@ -76,7 +76,7 @@ if { [ "${1}" = "test" ] || [ "${2}" = "test" ]; } && [ "${#}" -le 2 ]; then
   exit $test_res
 fi
 
-export PATH="${PATH}:/sbin:/usr/sbin:/usr/local/sbin"
+export PATH="${PATH}:/sbin:/usr/sbin:/usr/local/sbin:@sbindir_POST@"
 export LC_ALL=C
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary

An alternative to #16453

This is needed for `systemd-cat-native` users:

 - cgroup-name.sh
 - cgroup-network-helper.sh
 - charts.d.plugin
 - alarm-notify.sh

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
