### PR TITLE
Fix error limit to respect the log every

### DIFF
--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -2226,6 +2226,8 @@ void netdata_logger_with_limit(ERROR_LIMIT *erl, ND_LOG_SOURCES source, ND_LOG_F
             source == NDLS_DAEMON || source == NDLS_COLLECTORS,
             saved_errno, fmt, args);
     va_end(args);
+    erl->last_logged = now;
+    erl->count = 0;
 }
 
 void netdata_logger_fatal( const char *file, const char *function, const unsigned long line, const char *fmt, ... ) {


### PR DESCRIPTION
##### Summary
Set the log every to prevent a flood of messages when error limit is specified
