### PR TITLE
fix charts.d plugin loading configuration

### DIFF
--- a/collectors/charts.d.plugin/charts.d.plugin.in
+++ b/collectors/charts.d.plugin/charts.d.plugin.in
@@ -22,6 +22,7 @@ MODULE_NAME="main"
 # logging
 
 PROGRAM_NAME="$(basename "${0}")"
+SHORT_PROGRAM_NAME="${PROGRAM_NAME/.plugin/}"
 
 # these should be the same with syslog() priorities
 NDLP_EMERG=0   # system is unusable
@@ -304,7 +305,7 @@ source "$pluginsd/loopsleepms.sh.inc"
 # -----------------------------------------------------------------------------
 # load my configuration
 
-for myconfig in "${NETDATA_STOCK_CONFIG_DIR}/${PROGRAM_NAME}.conf" "${NETDATA_USER_CONFIG_DIR}/${PROGRAM_NAME}.conf"; do
+for myconfig in "${NETDATA_STOCK_CONFIG_DIR}/${SHORT_PROGRAM_NAME}.conf" "${NETDATA_USER_CONFIG_DIR}/${SHORT_PROGRAM_NAME}.conf"; do
 	if [ -f "$myconfig" ]; then
 		source "$myconfig"
 		if [ $? -ne 0 ]; then


### PR DESCRIPTION
##### Summary

Fixes: #16470

charts.d plugin tries to load wrong configuration files. Bug was introduced in #16357.

```log
Nov 24 12:19:55 pve-deb-work charts.d.plugin[1805163]: main: Configuration file '/opt/netdata/usr/lib/netdata/conf.d/charts.d.plugin.conf' not found.
Nov 24 12:19:55 pve-deb-work charts.d.plugin[1805168]: main: Configuration file '/opt/netdata/etc/netdata/charts.d.plugin.conf' not found.
```

##### Test Plan

Check charts.d plugin logs, make sure it load correct configuration files.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
