### PR TITLE
journals management improvements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -156,6 +156,8 @@ LIBNETDATA_FILES = \
     libnetdata/completion/completion.h \
     libnetdata/datetime/iso8601.c \
     libnetdata/datetime/iso8601.h \
+    libnetdata/datetime/rfc3339.c \
+    libnetdata/datetime/rfc3339.h \
     libnetdata/datetime/rfc7231.c \
     libnetdata/datetime/rfc7231.h \
     libnetdata/dictionary/dictionary.c \

--- a/collectors/systemd-journal.plugin/systemd-internals.h
+++ b/collectors/systemd-journal.plugin/systemd-internals.h
@@ -13,13 +13,13 @@
 #define SYSTEMD_JOURNAL_FUNCTION_DESCRIPTION    "View, search and analyze systemd journal entries."
 #define SYSTEMD_JOURNAL_FUNCTION_NAME           "systemd-journal"
 #define SYSTEMD_JOURNAL_DEFAULT_TIMEOUT         60
+#define SYSTEMD_JOURNAL_ENABLE_ESTIMATIONS_FILE_PERCENTAGE 0.01
+#define SYSTEMD_JOURNAL_EXECUTE_WATCHER_PENDING_EVERY_MS 250
+#define SYSTEMD_JOURNAL_ALL_FILES_SCAN_EVERY_USEC (5 * 60 * USEC_PER_SEC)
 
 #define SYSTEMD_UNITS_FUNCTION_DESCRIPTION      "View the status of systemd units"
 #define SYSTEMD_UNITS_FUNCTION_NAME              "systemd-list-units"
 #define SYSTEMD_UNITS_DEFAULT_TIMEOUT            30
-
-#define EXECUTE_WATCHER_PENDING_EVERY_MS 500
-#define FULL_JOURNAL_SCAN_EVERY_USEC (5 * 60 * USEC_PER_SEC)
 
 extern __thread size_t fstat_thread_calls;
 extern __thread size_t fstat_thread_cached_responses;
@@ -27,7 +27,6 @@ void fstat_cache_enable_on_thread(void);
 void fstat_cache_disable_on_thread(void);
 
 extern netdata_mutex_t stdout_mutex;
-
 
 typedef enum {
     ND_SD_JOURNAL_NO_FILE_MATCHED,
@@ -97,7 +96,8 @@ int journal_file_dict_items_forward_compar(const void *a, const void *b);
 void buffer_json_journal_versions(BUFFER *wb);
 void available_journal_file_sources_to_json_array(BUFFER *wb);
 bool journal_files_completed_once(void);
-void journal_files_updater_all_headers_sorted(void);
+void journal_files_registry_update(void);
+void journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, const char *dirname, int depth);
 
 FACET_ROW_SEVERITY syslog_priority_to_facet_severity(FACETS *facets, FACET_ROW *row, void *data);
 
@@ -116,14 +116,12 @@ usec_t journal_file_update_annotation_boot_id(sd_journal *j, struct journal_file
 #define MAX_JOURNAL_DIRECTORIES 100
 struct journal_directory {
     char *path;
-    bool logged_failure;
 };
 extern struct journal_directory journal_directories[MAX_JOURNAL_DIRECTORIES];
 
 void journal_init_files_and_directories(void);
 void journal_init_query_status(void);
 void function_systemd_journal(const char *transaction, char *function, int timeout, bool *cancelled);
-void journal_files_registry_update(void);
 void journal_file_update_header(const char *filename, struct journal_file *jf);
 
 void netdata_systemd_journal_message_ids_init(void);

--- a/collectors/systemd-journal.plugin/systemd-journal-annotations.c
+++ b/collectors/systemd-journal.plugin/systemd-journal-annotations.c
@@ -427,8 +427,8 @@ void netdata_systemd_journal_transform_boot_id(FACETS *facets __maybe_unused, BU
             ut = *p_ut;
 
         if(ut && ut != UINT64_MAX) {
-            char buffer[ISO8601_MAX_LENGTH];
-            iso8601_datetime_ut(buffer, sizeof(buffer), ut, ISO8601_UTC);
+            char buffer[RFC3339_MAX_LENGTH];
+            rfc3339_datetime_ut(buffer, sizeof(buffer), ut, 0, true);
 
             switch(scope) {
                 default:
@@ -506,8 +506,8 @@ void netdata_systemd_journal_transform_timestamp_usec(FACETS *facets __maybe_unu
     if(*v && isdigit(*v)) {
         uint64_t ut = str2ull(buffer_tostring(wb), NULL);
         if(ut) {
-            char buffer[ISO8601_MAX_LENGTH];
-            iso8601_datetime_ut(buffer, sizeof(buffer), ut, ISO8601_UTC | ISO8601_MICROSECONDS);
+            char buffer[RFC3339_MAX_LENGTH];
+            rfc3339_datetime_ut(buffer, sizeof(buffer), ut, 6, true);
             buffer_sprintf(wb, " (%s)", buffer);
         }
     }

--- a/collectors/systemd-journal.plugin/systemd-journal-files.c
+++ b/collectors/systemd-journal.plugin/systemd-journal-files.c
@@ -621,7 +621,7 @@ void journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, con
     }
 
     bool existing = false;
-    bool *found = dictionary_set(dirs, full_path, &existing, sizeof(existing));
+    bool *found = dictionary_set(dirs, dirname, &existing, sizeof(existing));
     if(*found) return;
     *found = true;
 

--- a/collectors/systemd-journal.plugin/systemd-journal-files.c
+++ b/collectors/systemd-journal.plugin/systemd-journal-files.c
@@ -628,7 +628,7 @@ void journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, con
     // Read each entry in the directory.
     while ((entry = readdir(dir)) != NULL) {
         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
-            return;
+            continue;
 
         ssize_t len = snprintfz(full_path, sizeof(full_path), "%s/%s", dirname, entry->d_name);
 

--- a/collectors/systemd-journal.plugin/systemd-journal-files.c
+++ b/collectors/systemd-journal.plugin/systemd-journal-files.c
@@ -602,17 +602,16 @@ static void files_registry_delete_cb(const DICTIONARY_ITEM *item, void *value, v
     string_freez(jf->source);
 }
 
-void journal_directory_scan(const char *dirname, int depth, usec_t last_scan_monotonic_ut) {
+void journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, const char *dirname, int depth) {
     static const char *ext = ".journal";
-    static const size_t ext_len = sizeof(".journal") - 1;
+    static const ssize_t ext_len = sizeof(".journal") - 1;
 
     if (depth > VAR_LOG_JOURNAL_MAX_DEPTH)
         return;
 
     DIR *dir;
     struct dirent *entry;
-    struct stat info;
-    char absolute_path[FILENAME_MAX];
+    char full_path[FILENAME_MAX];
 
     // Open the directory.
     if ((dir = opendir(dirname)) == NULL) {
@@ -621,33 +620,43 @@ void journal_directory_scan(const char *dirname, int depth, usec_t last_scan_mon
         return;
     }
 
+    bool existing = false;
+    bool *found = dictionary_set(dirs, full_path, &existing, sizeof(existing));
+    if(*found) return;
+    *found = true;
+
     // Read each entry in the directory.
     while ((entry = readdir(dir)) != NULL) {
-        snprintfz(absolute_path, sizeof(absolute_path), "%s/%s", dirname, entry->d_name);
-        if (stat(absolute_path, &info) != 0) {
-            netdata_log_error("Failed to stat() '%s", absolute_path);
-            continue;
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+            return;
+
+        ssize_t len = snprintfz(full_path, sizeof(full_path), "%s/%s", dirname, entry->d_name);
+
+        if (entry->d_type == DT_DIR) {
+            journal_directory_scan_recursively(files, dirs, full_path, depth++);
         }
+        else if (entry->d_type == DT_REG && len > ext_len && strcmp(full_path + len - ext_len, ext) == 0) {
+            if(files)
+                dictionary_set(files, full_path, NULL, 0);
 
-        if (S_ISDIR(info.st_mode)) {
-            // If entry is a directory, call traverse recursively.
-            if (strcmp(entry->d_name, ".") != 0 && strcmp(entry->d_name, "..") != 0)
-                journal_directory_scan(absolute_path, depth + 1, last_scan_monotonic_ut);
-
+            send_newline_and_flush();
         }
-        else if (S_ISREG(info.st_mode)) {
-            // If entry is a regular file, check if it ends with .journal.
-            char *filename = entry->d_name;
-            size_t len = strlen(filename);
+        else if (entry->d_type == DT_LNK) {
+            struct stat info;
+            if (stat(full_path, &info) == -1)
+                continue;
 
-            if (len > ext_len && strcmp(filename + len - ext_len, ext) == 0) {
-                struct journal_file t = {
-                        .file_last_modified_ut = info.st_mtim.tv_sec * USEC_PER_SEC + info.st_mtim.tv_nsec / NSEC_PER_USEC,
-                        .last_scan_monotonic_ut = last_scan_monotonic_ut,
-                        .size = info.st_size,
-                        .max_journal_vs_realtime_delta_ut = JOURNAL_VS_REALTIME_DELTA_DEFAULT_UT,
-                };
-                dictionary_set(journal_files_registry, absolute_path, &t, sizeof(t));
+            if (S_ISDIR(info.st_mode)) {
+                // The symbolic link points to a directory
+                char resolved_path[FILENAME_MAX + 1];
+                if (realpath(full_path, resolved_path) != NULL) {
+                    journal_directory_scan_recursively(files, dirs, resolved_path, depth++);
+                }
+            }
+            else if(S_ISREG(info.st_mode) && len > ext_len && strcmp(full_path + len - ext_len, ext) == 0) {
+                if(files)
+                    dictionary_set(files, full_path, NULL, 0);
+
                 send_newline_and_flush();
             }
         }
@@ -661,41 +670,38 @@ bool journal_files_completed_once(void) {
     return journal_files_scans > 0;
 }
 
-static int journal_file_dict_items_last_modified_compar(const void *a, const void *b) {
-    const DICTIONARY_ITEM **ad = (const DICTIONARY_ITEM **)a, **bd = (const DICTIONARY_ITEM **)b;
-    struct journal_file *jfa = dictionary_acquired_item_value(*ad);
-    struct journal_file *jfb = dictionary_acquired_item_value(*bd);
+int filenames_compar(const void *a, const void *b) {
+    const char *p1 = *(const char **)a;
+    const char *p2 = *(const char **)b;
 
-    if(jfa->file_last_modified_ut > jfb->file_last_modified_ut)
+    const char *at1 = strchr(p1, '@');
+    const char *at2 = strchr(p2, '@');
+
+    if(!at1 && at2)
         return -1;
-    else if(jfa->file_last_modified_ut < jfb->file_last_modified_ut)
+
+    if(at1 && !at2)
         return 1;
 
-    return 0;
-}
+    if(!at1 && !at2)
+        return strcmp(p1, p2);
 
-void journal_files_updater_all_headers_sorted(void) {
-    const DICTIONARY_ITEM *file_items[dictionary_entries(journal_files_registry)];
-    size_t files_used = 0;
+    const char *dash1 = strrchr(at1, '-');
+    const char *dash2 = strrchr(at2, '-');
 
-    struct journal_file *jf;
-    dfe_start_write(journal_files_registry, jf){
-        if(jf->last_scan_header_vs_last_modified_ut < jf->file_last_modified_ut)
-            file_items[files_used++] = dictionary_acquired_item_dup(journal_files_registry, jf_dfe.item);
-    }
-    dfe_done(jf);
+    if(!dash1 || !dash2)
+        return strcmp(p1, p2);
 
-    // sort them in reverse order (newer first)
-    qsort(file_items, files_used, sizeof(const DICTIONARY_ITEM *),
-          journal_file_dict_items_last_modified_compar);
+    uint64_t ts1 = strtoul(dash1 + 1, NULL, 16);
+    uint64_t ts2 = strtoul(dash2 + 1, NULL, 16);
 
-    // update the header (first and last message ut, sequence numbers, etc)
-    for(size_t i = 0; i < files_used ; i++) {
-        jf = dictionary_acquired_item_value(file_items[i]);
-        journal_file_update_header(jf->filename, jf);
-        dictionary_acquired_item_release(journal_files_registry, file_items[i]);
-        send_newline_and_flush();
-    }
+    if(ts1 > ts2)
+        return -1;
+
+    if(ts1 < ts2)
+        return 1;
+
+    return -strcmp(p1, p2);
 }
 
 void journal_files_registry_update(void) {
@@ -704,12 +710,45 @@ void journal_files_registry_update(void) {
     if(spinlock_trylock(&spinlock)) {
         usec_t scan_monotonic_ut = now_monotonic_usec();
 
-        for(unsigned i = 0; i < MAX_JOURNAL_DIRECTORIES; i++) {
-            if(!journal_directories[i].path)
-                break;
+        DICTIONARY *files = dictionary_create(DICT_OPTION_SINGLE_THREADED | DICT_OPTION_DONT_OVERWRITE_VALUE);
+        DICTIONARY *dirs = dictionary_create(DICT_OPTION_SINGLE_THREADED|DICT_OPTION_DONT_OVERWRITE_VALUE);
 
-            journal_directory_scan(journal_directories[i].path, 0, scan_monotonic_ut);
+        for(unsigned i = 0; i < MAX_JOURNAL_DIRECTORIES; i++) {
+            if(!journal_directories[i].path) break;
+            journal_directory_scan_recursively(files, dirs, journal_directories[i].path, 0);
         }
+
+        const char **array = mallocz(sizeof(const char *) * dictionary_entries(files));
+        size_t used = 0;
+
+        void *x;
+        dfe_start_read(files, x) {
+            if(used >= dictionary_entries(files)) continue;
+            array[used++] = x_dfe.name;
+        }
+        dfe_done(x);
+
+        qsort(array, used, sizeof(const char *), filenames_compar);
+
+        for(size_t i = 0; i < used ;i++) {
+            const char *full_path = array[i];
+
+            struct stat info;
+            if (stat(full_path, &info) == -1)
+                continue;
+
+            struct journal_file t = {
+                    .file_last_modified_ut = info.st_mtim.tv_sec * USEC_PER_SEC + info.st_mtim.tv_nsec / NSEC_PER_USEC,
+                    .last_scan_monotonic_ut = scan_monotonic_ut,
+                    .size = info.st_size,
+                    .max_journal_vs_realtime_delta_ut = JOURNAL_VS_REALTIME_DELTA_DEFAULT_UT,
+            };
+            struct journal_file *jf = dictionary_set(journal_files_registry, full_path, &t, sizeof(t));
+            journal_file_update_header(jf->filename, jf);
+        }
+        freez(array);
+        dictionary_destroy(files);
+        dictionary_destroy(dirs);
 
         struct journal_file *jf;
         dfe_start_write(journal_files_registry, jf){
@@ -717,8 +756,6 @@ void journal_files_registry_update(void) {
                 dictionary_del(journal_files_registry, jf_dfe.name);
         }
         dfe_done(jf);
-
-        journal_files_updater_all_headers_sorted();
 
         journal_files_scans++;
         spinlock_unlock(&spinlock);

--- a/collectors/systemd-journal.plugin/systemd-journal.c
+++ b/collectors/systemd-journal.plugin/systemd-journal.c
@@ -496,7 +496,7 @@ static size_t sampling_running_file_query_estimate_remaining_lines_by_time(FUNCT
 
     nd_log(NDLS_COLLECTORS, NDLP_INFO,
            "JOURNAL ESTIMATION: "
-           "scanned_lines=%zu [sampled=%zu, unsampled=%zu], "
+           "scanned_lines=%zu [sampled=%zu, unsampled=%zu, estimated=%zu], "
            "file [%"PRIu64" - %"PRIu64", duration %"PRId64", known lines in file %zu], "
            "query [%"PRIu64" - %"PRIu64", duration %"PRId64"], "
            "first message read from the file at "PRIu64", current message at %"PRIu64", "
@@ -504,7 +504,7 @@ static size_t sampling_running_file_query_estimate_remaining_lines_by_time(FUNCT
            "expected total lines in file %zu, "
            "remaining lines %zu, "
            "remaining time %"PRIu64" [%"PRIu64" - %"PRIu64", duration %"PRId64"]"
-           , scanned_lines, fqs->samples_per_file.sampled, fqs->samples_per_file.unsampled
+           , scanned_lines, fqs->samples_per_file.sampled, fqs->samples_per_file.unsampled, fqs->samples_per_file.estimated
            , jf->msg_first_ut, jf->msg_last_ut, jf->msg_last_ut - jf->msg_first_ut, jf->messages_in_file
            , fqs->query_file.start_ut, fqs->query_file.stop_ut, fqs->query_file.stop_ut - fqs->query_file.start_ut
            , fqs->query_file.first_msg_ut, msg_ut
@@ -1187,7 +1187,7 @@ static int netdata_systemd_journal_query(BUFFER *wb, FACETS *facets, FUNCTION_QU
 
         nd_log(NDLS_COLLECTORS, NDLP_INFO,
                "JOURNAL ESTIMATION FINAL: "
-               "total lines %zu [sampled=%zu, unsampled=%zu, estimated], "
+               "total lines %zu [sampled=%zu, unsampled=%zu, estimated=%zu], "
                "file [%"PRIu64" - %"PRIu64", duration %"PRId64", known lines in file %zu], "
                "query [%"PRIu64" - %"PRIu64", duration %"PRId64"], "
                , fqs->samples_per_file.sampled + fqs->samples_per_file.unsampled + fqs->samples_per_file.estimated

--- a/collectors/systemd-journal.plugin/systemd-journal.c
+++ b/collectors/systemd-journal.plugin/systemd-journal.c
@@ -633,7 +633,7 @@ static inline sampling_t is_row_in_sample(sd_journal *j, FUNCTION_QUERY_STATUS *
     if(fqs->samples_per_file.unsampled > fqs->samples_per_file.sampled) {
         double progress_by_time = sampling_running_file_query_progress_by_time(fqs, jf, direction, msg_ut);
 
-        if(progress_by_time > 0.05)
+        if(progress_by_time > SYSTEMD_JOURNAL_ENABLE_ESTIMATIONS_FILE_PERCENTAGE)
             return SAMPLING_STOP_AND_ESTIMATE;
     }
 

--- a/collectors/systemd-journal.plugin/systemd-journal.c
+++ b/collectors/systemd-journal.plugin/systemd-journal.c
@@ -495,7 +495,7 @@ static size_t sampling_running_file_query_estimate_remaining_lines_by_time(FUNCT
     if (remaining_logs_by_time < 1) remaining_logs_by_time = 1;
 
     nd_log(NDLS_COLLECTORS, NDLP_INFO,
-           "JOURNAL ESTIMATION: "
+           "JOURNAL ESTIMATION: '%s' "
            "scanned_lines=%zu [sampled=%zu, unsampled=%zu, estimated=%zu], "
            "file [%"PRIu64" - %"PRIu64", duration %"PRId64", known lines in file %zu], "
            "query [%"PRIu64" - %"PRIu64", duration %"PRId64"], "
@@ -504,6 +504,7 @@ static size_t sampling_running_file_query_estimate_remaining_lines_by_time(FUNCT
            "expected total lines in file %zu, "
            "remaining lines %zu, "
            "remaining time %"PRIu64" [%"PRIu64" - %"PRIu64", duration %"PRId64"]"
+           , jf->filename
            , scanned_lines, fqs->samples_per_file.sampled, fqs->samples_per_file.unsampled, fqs->samples_per_file.estimated
            , jf->msg_first_ut, jf->msg_last_ut, jf->msg_last_ut - jf->msg_first_ut, jf->messages_in_file
            , fqs->query_file.start_ut, fqs->query_file.stop_ut, fqs->query_file.stop_ut - fqs->query_file.start_ut
@@ -1186,10 +1187,11 @@ static int netdata_systemd_journal_query(BUFFER *wb, FACETS *facets, FUNCTION_QU
         ND_SD_JOURNAL_STATUS tmp_status = netdata_systemd_journal_query_one_file(filename, wb, facets, jf, fqs);
 
         nd_log(NDLS_COLLECTORS, NDLP_INFO,
-               "JOURNAL ESTIMATION FINAL: "
+               "JOURNAL ESTIMATION FINAL: '%s' "
                "total lines %zu [sampled=%zu, unsampled=%zu, estimated=%zu], "
                "file [%"PRIu64" - %"PRIu64", duration %"PRId64", known lines in file %zu], "
                "query [%"PRIu64" - %"PRIu64", duration %"PRId64"], "
+               , jf->filename
                , fqs->samples_per_file.sampled + fqs->samples_per_file.unsampled + fqs->samples_per_file.estimated
                , fqs->samples_per_file.sampled, fqs->samples_per_file.unsampled, fqs->samples_per_file.estimated
                , jf->msg_first_ut, jf->msg_last_ut, jf->msg_last_ut - jf->msg_first_ut, jf->messages_in_file

--- a/collectors/systemd-journal.plugin/systemd-journal.c
+++ b/collectors/systemd-journal.plugin/systemd-journal.c
@@ -494,26 +494,26 @@ static size_t sampling_running_file_query_estimate_remaining_lines_by_time(FUNCT
     size_t remaining_logs_by_time = expected_matching_logs_by_time - scanned_lines;
     if (remaining_logs_by_time < 1) remaining_logs_by_time = 1;
 
-    nd_log(NDLS_COLLECTORS, NDLP_INFO,
-           "JOURNAL ESTIMATION: '%s' "
-           "scanned_lines=%zu [sampled=%zu, unsampled=%zu, estimated=%zu], "
-           "file [%"PRIu64" - %"PRIu64", duration %"PRId64", known lines in file %zu], "
-           "query [%"PRIu64" - %"PRIu64", duration %"PRId64"], "
-           "first message read from the file at %"PRIu64", current message at %"PRIu64", "
-           "proportion of time %.2f %%, "
-           "expected total lines in file %zu, "
-           "remaining lines %zu, "
-           "remaining time %"PRIu64" [%"PRIu64" - %"PRIu64", duration %"PRId64"]"
-           , jf->filename
-           , scanned_lines, fqs->samples_per_file.sampled, fqs->samples_per_file.unsampled, fqs->samples_per_file.estimated
-           , jf->msg_first_ut, jf->msg_last_ut, jf->msg_last_ut - jf->msg_first_ut, jf->messages_in_file
-           , fqs->query_file.start_ut, fqs->query_file.stop_ut, fqs->query_file.stop_ut - fqs->query_file.start_ut
-           , fqs->query_file.first_msg_ut, msg_ut
-           , proportion_by_time * 100.0
-           , expected_matching_logs_by_time
-           , remaining_logs_by_time
-           , remaining_time_ut, remaining_start_ut, remaining_end_ut, remaining_end_ut - remaining_start_ut
-           );
+//    nd_log(NDLS_COLLECTORS, NDLP_INFO,
+//           "JOURNAL ESTIMATION: '%s' "
+//           "scanned_lines=%zu [sampled=%zu, unsampled=%zu, estimated=%zu], "
+//           "file [%"PRIu64" - %"PRIu64", duration %"PRId64", known lines in file %zu], "
+//           "query [%"PRIu64" - %"PRIu64", duration %"PRId64"], "
+//           "first message read from the file at %"PRIu64", current message at %"PRIu64", "
+//           "proportion of time %.2f %%, "
+//           "expected total lines in file %zu, "
+//           "remaining lines %zu, "
+//           "remaining time %"PRIu64" [%"PRIu64" - %"PRIu64", duration %"PRId64"]"
+//           , jf->filename
+//           , scanned_lines, fqs->samples_per_file.sampled, fqs->samples_per_file.unsampled, fqs->samples_per_file.estimated
+//           , jf->msg_first_ut, jf->msg_last_ut, jf->msg_last_ut - jf->msg_first_ut, jf->messages_in_file
+//           , fqs->query_file.start_ut, fqs->query_file.stop_ut, fqs->query_file.stop_ut - fqs->query_file.start_ut
+//           , fqs->query_file.first_msg_ut, msg_ut
+//           , proportion_by_time * 100.0
+//           , expected_matching_logs_by_time
+//           , remaining_logs_by_time
+//           , remaining_time_ut, remaining_start_ut, remaining_end_ut, remaining_end_ut - remaining_start_ut
+//           );
 
     return remaining_logs_by_time;
 }
@@ -1186,17 +1186,17 @@ static int netdata_systemd_journal_query(BUFFER *wb, FACETS *facets, FUNCTION_QU
 
         ND_SD_JOURNAL_STATUS tmp_status = netdata_systemd_journal_query_one_file(filename, wb, facets, jf, fqs);
 
-        nd_log(NDLS_COLLECTORS, NDLP_INFO,
-               "JOURNAL ESTIMATION FINAL: '%s' "
-               "total lines %zu [sampled=%zu, unsampled=%zu, estimated=%zu], "
-               "file [%"PRIu64" - %"PRIu64", duration %"PRId64", known lines in file %zu], "
-               "query [%"PRIu64" - %"PRIu64", duration %"PRId64"], "
-               , jf->filename
-               , fqs->samples_per_file.sampled + fqs->samples_per_file.unsampled + fqs->samples_per_file.estimated
-               , fqs->samples_per_file.sampled, fqs->samples_per_file.unsampled, fqs->samples_per_file.estimated
-               , jf->msg_first_ut, jf->msg_last_ut, jf->msg_last_ut - jf->msg_first_ut, jf->messages_in_file
-               , fqs->query_file.start_ut, fqs->query_file.stop_ut, fqs->query_file.stop_ut - fqs->query_file.start_ut
-        );
+//        nd_log(NDLS_COLLECTORS, NDLP_INFO,
+//               "JOURNAL ESTIMATION FINAL: '%s' "
+//               "total lines %zu [sampled=%zu, unsampled=%zu, estimated=%zu], "
+//               "file [%"PRIu64" - %"PRIu64", duration %"PRId64", known lines in file %zu], "
+//               "query [%"PRIu64" - %"PRIu64", duration %"PRId64"], "
+//               , jf->filename
+//               , fqs->samples_per_file.sampled + fqs->samples_per_file.unsampled + fqs->samples_per_file.estimated
+//               , fqs->samples_per_file.sampled, fqs->samples_per_file.unsampled, fqs->samples_per_file.estimated
+//               , jf->msg_first_ut, jf->msg_last_ut, jf->msg_last_ut - jf->msg_first_ut, jf->messages_in_file
+//               , fqs->query_file.start_ut, fqs->query_file.stop_ut, fqs->query_file.stop_ut - fqs->query_file.start_ut
+//        );
 
         rows_useful = fqs->rows_useful - rows_useful;
         rows_read = fqs->rows_read - rows_read;

--- a/collectors/systemd-journal.plugin/systemd-journal.c
+++ b/collectors/systemd-journal.plugin/systemd-journal.c
@@ -517,7 +517,6 @@ static size_t sampling_running_file_query_estimate_remaining_lines_by_time(FUNCT
     return remaining_logs_by_time;
 }
 
-
 static size_t sampling_running_file_query_estimate_remaining_lines(sd_journal *j, FUNCTION_QUERY_STATUS *fqs, struct journal_file *jf, FACETS_ANCHOR_DIRECTION direction, usec_t msg_ut) {
     size_t expected_matching_logs_by_seqnum = 0;
     double proportion_by_seqnum = 0.0;
@@ -1185,6 +1184,17 @@ static int netdata_systemd_journal_query(BUFFER *wb, FACETS *facets, FUNCTION_QU
         sampling_file_init(fqs, jf);
 
         ND_SD_JOURNAL_STATUS tmp_status = netdata_systemd_journal_query_one_file(filename, wb, facets, jf, fqs);
+
+        nd_log(NDLS_COLLECTORS, NDLP_INFO,
+               "JOURNAL ESTIMATION FINAL: "
+               "total lines %zu [sampled=%zu, unsampled=%zu, estimated], "
+               "file [%"PRIu64" - %"PRIu64", duration %"PRId64", known lines in file %zu], "
+               "query [%"PRIu64" - %"PRIu64", duration %"PRId64"], "
+               , fqs->samples_per_file.sampled + fqs->samples_per_file.unsampled + fqs->samples_per_file.estimated
+               , fqs->samples_per_file.sampled, fqs->samples_per_file.unsampled, fqs->samples_per_file.estimated
+               , jf->msg_first_ut, jf->msg_last_ut, jf->msg_last_ut - jf->msg_first_ut, jf->messages_in_file
+               , fqs->query_file.start_ut, fqs->query_file.stop_ut, fqs->query_file.stop_ut - fqs->query_file.start_ut
+        );
 
         rows_useful = fqs->rows_useful - rows_useful;
         rows_read = fqs->rows_read - rows_read;

--- a/collectors/systemd-journal.plugin/systemd-journal.c
+++ b/collectors/systemd-journal.plugin/systemd-journal.c
@@ -499,7 +499,7 @@ static size_t sampling_running_file_query_estimate_remaining_lines_by_time(FUNCT
            "scanned_lines=%zu [sampled=%zu, unsampled=%zu, estimated=%zu], "
            "file [%"PRIu64" - %"PRIu64", duration %"PRId64", known lines in file %zu], "
            "query [%"PRIu64" - %"PRIu64", duration %"PRId64"], "
-           "first message read from the file at "PRIu64", current message at %"PRIu64", "
+           "first message read from the file at %"PRIu64", current message at %"PRIu64", "
            "proportion of time %.2f %%, "
            "expected total lines in file %zu, "
            "remaining lines %zu, "

--- a/collectors/systemd-journal.plugin/systemd-journal.c
+++ b/collectors/systemd-journal.plugin/systemd-journal.c
@@ -497,21 +497,21 @@ static size_t sampling_running_file_query_estimate_remaining_lines_by_time(FUNCT
     nd_log(NDLS_COLLECTORS, NDLP_INFO,
            "JOURNAL ESTIMATION: "
            "scanned_lines=%zu [sampled=%zu, unsampled=%zu], "
-           "file [%zd - %zd, duration %zd, known lines in file %zu], "
-           "query [%zd - %zd, duration %zd], "
-           "message at %zd, "
-           "proportion of time %03.f, "
+           "file [%"PRIu64" - %"PRIu64", duration %"PRId64", known lines in file %zu], "
+           "query [%"PRIu64" - %"PRIu64", duration %"PRId64"], "
+           "first message read from the file at "PRIu64", current message at %"PRIu64", "
+           "proportion of time %.2f %%, "
            "expected total lines in file %zu, "
            "remaining lines %zu, "
-           "remaining time %zu [%zd - %zd, duration %zd]"
-           , scanned_lines, fqs->samples.sampled, fqs->samples.unsampled
-           , (ssize_t)(jf->msg_first_ut / USEC_PER_SEC), (ssize_t)(jf->msg_last_ut / USEC_PER_SEC), (ssize_t)((jf->msg_last_ut - jf->msg_first_ut) / USEC_PER_SEC), jf->messages_in_file
-           , (ssize_t)(fqs->query_file.start_ut / USEC_PER_SEC), (ssize_t)(fqs->query_file.stop_ut / USEC_PER_SEC), (ssize_t)((fqs->query_file.stop_ut - fqs->query_file.start_ut) / USEC_PER_SEC)
-           , (ssize_t)(msg_ut / USEC_PER_SEC)
-           , proportion_by_time
+           "remaining time %"PRIu64" [%"PRIu64" - %"PRIu64", duration %"PRId64"]"
+           , scanned_lines, fqs->samples_per_file.sampled, fqs->samples_per_file.unsampled
+           , jf->msg_first_ut, jf->msg_last_ut, jf->msg_last_ut - jf->msg_first_ut, jf->messages_in_file
+           , fqs->query_file.start_ut, fqs->query_file.stop_ut, fqs->query_file.stop_ut - fqs->query_file.start_ut
+           , fqs->query_file.first_msg_ut, msg_ut
+           , proportion_by_time * 100.0
            , expected_matching_logs_by_time
            , remaining_logs_by_time
-           , remaining_time_ut, (ssize_t)(remaining_start_ut / USEC_PER_SEC), (ssize_t)(remaining_end_ut / USEC_PER_SEC), (ssize_t)((remaining_end_ut - remaining_start_ut) / USEC_PER_SEC)
+           , remaining_time_ut, remaining_start_ut, remaining_end_ut, remaining_end_ut - remaining_start_ut
            );
 
     return remaining_logs_by_time;

--- a/collectors/systemd-journal.plugin/systemd-main.c
+++ b/collectors/systemd-journal.plugin/systemd-main.c
@@ -86,14 +86,14 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
 
     usec_t step_ut = 100 * USEC_PER_MS;
     usec_t send_newline_ut = 0;
-    usec_t since_last_scan_ut = FULL_JOURNAL_SCAN_EVERY_USEC * 2; // something big to trigger scanning at start
+    usec_t since_last_scan_ut = SYSTEMD_JOURNAL_ALL_FILES_SCAN_EVERY_USEC * 2; // something big to trigger scanning at start
     bool tty = isatty(fileno(stderr)) == 1;
 
     heartbeat_t hb;
     heartbeat_init(&hb);
     while(!plugin_should_exit) {
 
-        if(since_last_scan_ut > FULL_JOURNAL_SCAN_EVERY_USEC) {
+        if(since_last_scan_ut > SYSTEMD_JOURNAL_ALL_FILES_SCAN_EVERY_USEC) {
             journal_files_registry_update();
             since_last_scan_ut = 0;
         }

--- a/libnetdata/datetime/rfc3339.c
+++ b/libnetdata/datetime/rfc3339.c
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "../libnetdata.h"
+
+#include "rfc3339.h"
+
+size_t rfc3339_datetime_ut(char *buffer, size_t len, usec_t now_ut, size_t fractional_digits, bool utc) {
+    if (!buffer || len == 0)
+        return 0;
+
+    time_t t = (time_t)(now_ut / USEC_PER_SEC);
+    struct tm *tmp, tmbuf;
+
+    if (utc)
+        tmp = gmtime_r(&t, &tmbuf);
+    else
+        tmp = localtime_r(&t, &tmbuf);
+
+    if (!tmp) {
+        buffer[0] = '\0';
+        return 0;
+    }
+
+    size_t used_length = strftime(buffer, len, "%Y-%m-%dT%H:%M:%S", tmp);
+    if (used_length == 0) {
+        buffer[0] = '\0';
+        return 0;
+    }
+
+    if (fractional_digits >= 0 && fractional_digits <= 9) {
+        int fractional_part = (int)(now_ut % USEC_PER_SEC);
+        if (fractional_part && len - used_length > fractional_digits + 1) {
+            char format[] = ".%01d";
+            format[3] = (char)('0' + fractional_digits);
+
+            // Adjust fractional part
+            fractional_part /= (int)pow(10, 6 - fractional_digits);
+
+            used_length += snprintf(buffer + used_length, len - used_length,
+                                    format, fractional_part);
+        }
+    }
+
+    if (utc) {
+        if (used_length + 1 < len) {
+            buffer[used_length++] = 'Z';
+            buffer[used_length] = '\0';
+        }
+    }
+    else {
+        long offset = tmbuf.tm_gmtoff;
+        int hours = (int)(offset / 3600);
+        int minutes = abs((int)((offset % 3600) / 60));
+
+        if (used_length + 7 < len) { // Space for "+HH:MM\0"
+            used_length += snprintf(buffer + used_length, len - used_length, "%+03d:%02d", hours, minutes);
+        }
+    }
+
+    return used_length;
+}
+
+usec_t rfc3339_parse_ut(const char *rfc3339, char **endptr) {
+    struct tm tm = { 0 };
+    int tz_hours = 0, tz_mins = 0;
+    char *s;
+    usec_t timestamp, usec = 0;
+
+    // Use strptime to parse up to seconds
+    s = strptime(rfc3339, "%Y-%m-%dT%H:%M:%S", &tm);
+    if (!s)
+        return 0; // Parsing error
+
+    // Parse fractional seconds if present
+    if (*s == '.') {
+        char *next;
+        usec = strtoul(s + 1, &next, 10);
+        int digits_parsed = (int)(next - (s + 1));
+
+        if (digits_parsed < 1 || digits_parsed > 9)
+            return 0; // parsing error
+
+        static const usec_t fix_usec[] = {
+                1000000,  // 0 digits (not used)
+                100000,   // 1 digit
+                10000,    // 2 digits
+                1000,     // 3 digits
+                100,      // 4 digits
+                10,       // 5 digits
+                1,        // 6 digits
+                10,       // 7 digits
+                100,      // 8 digits
+                1000,     // 9 digits
+        };
+        usec = digits_parsed <= 6 ? usec * fix_usec[digits_parsed] : usec / fix_usec[digits_parsed];
+
+        s = next;
+    }
+
+    // Check and parse timezone if present
+    int tz_offset = 0;
+    if (*s == '+' || *s == '-') {
+        // Parse the hours:mins part of the timezone
+
+        if (!isdigit(s[1]) || !isdigit(s[2]) || s[3] != ':' ||
+            !isdigit(s[4]) || !isdigit(s[5]))
+            return 0; // Parsing error
+
+        char tz_sign = *s;
+        tz_hours = (s[1] - '0') * 10 + (s[2] - '0');
+        tz_mins = (s[4] - '0') * 10 + (s[5] - '0');
+
+        tz_offset = tz_hours * 3600 + tz_mins * 60;
+        tz_offset *= (tz_sign == '+' ? 1 : -1);
+
+        s += 6; // Move past the timezone part
+    }
+    else if (*s == 'Z')
+        s++;
+    else
+        return 0; // Invalid RFC 3339 format
+
+    // Convert to time_t (assuming local time, then adjusting for timezone later)
+    time_t epoch_s = mktime(&tm);
+    if (epoch_s == -1)
+        return 0; // Error in time conversion
+
+    timestamp = (usec_t)epoch_s * USEC_PER_SEC + usec;
+    timestamp -= tz_offset * USEC_PER_SEC;
+
+    if(endptr)
+        *endptr = s;
+
+    return timestamp;
+}

--- a/libnetdata/datetime/rfc3339.h
+++ b/libnetdata/datetime/rfc3339.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "../libnetdata.h"
+
+#ifndef NETDATA_RFC3339_H
+#define NETDATA_RFC3339_H
+
+#define RFC3339_MAX_LENGTH 36
+size_t rfc3339_datetime_ut(char *buffer, size_t len, usec_t now_ut, size_t fractional_digits, bool utc);
+usec_t rfc3339_parse_ut(const char *rfc3339, char **endptr);
+
+#endif //NETDATA_RFC3339_H

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -723,6 +723,7 @@ extern char *netdata_configured_host_prefix;
 #include "line_splitter/line_splitter.h"
 #include "clocks/clocks.h"
 #include "datetime/iso8601.h"
+#include "datetime/rfc3339.h"
 #include "datetime/rfc7231.h"
 #include "completion/completion.h"
 #include "popen/popen.h"

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -1498,8 +1498,8 @@ static void timestamp_usec_annotator(BUFFER *wb, const char *key, struct log_fie
     if(!ut)
         return;
 
-    char datetime[ISO8601_MAX_LENGTH];
-    iso8601_datetime_ut(datetime, sizeof(datetime), ut, ISO8601_LOCAL_TIMEZONE | ISO8601_MILLISECONDS);
+    char datetime[RFC3339_MAX_LENGTH];
+    rfc3339_datetime_ut(datetime, sizeof(datetime), ut, 3, false);
 
     if(buffer_strlen(wb))
         buffer_fast_strcat(wb, " ", 1);

--- a/streaming/sender.c
+++ b/streaming/sender.c
@@ -557,8 +557,8 @@ static inline bool rrdpush_sender_validate_response(RRDHOST *host, struct sender
     };
     ND_LOG_STACK_PUSH(lgs);
 
-    char buf[ISO8601_MAX_LENGTH];
-    iso8601_datetime_ut(buf, sizeof(buf), host->destination->postpone_reconnection_until * USEC_PER_SEC, 0);
+    char buf[RFC3339_MAX_LENGTH];
+    rfc3339_datetime_ut(buf, sizeof(buf), host->destination->postpone_reconnection_until * USEC_PER_SEC, 0, false);
 
     nd_log(NDLS_DAEMON, priority,
            "STREAM %s [send to %s]: %s - will retry in %d secs, at %s",


### PR DESCRIPTION
- [x] re-write of the journal estimations distributions. Cleaner code and easier to maintain.
- [x] unify the watcher and the scan logic, so that there is only 1 logic about the files and directories interesting. It also detects infinite recursions (via links), and prevents adding or watching the same file or dir multiple times.
- [x] when starting on a huge journals directory, populate first files that are currently been written and files that are are newer and progress towards the past as fast as the filesystem allows. The entire process runs at the background, the systemd-journal function should now be available immediately after start.
- [x] `systemd-cat-journal` now populates key missing fields when it sends messages to systemd-journal-remote
- [x] the standard datetime format of Netdata is now rfc3339 (the iso8601 variation that has become internet standard)