### PR TITLE
logs-management: Add function cancellability

### DIFF
--- a/logsmanagement/circular_buffer.c
+++ b/logsmanagement/circular_buffer.c
@@ -91,7 +91,7 @@ void circ_buff_search(logs_query_params_t *const p_query_params, struct File_inf
 
         /* If exceeding quota or timeout is reached and new timestamp is different than previous, 
          * terminate query but inform caller about act_to_ts to continue from (its next value) in next call. */
-        if((res_buff->len >= p_query_params->quota || now_monotonic_usec() > p_query_params->stop_monotonic_ut) && 
+        if( (res_buff->len >= p_query_params->quota || terminate_logs_manag_query(p_query_params)) && 
                 items[i].cbi->timestamp != res_hdr.timestamp){
             p_query_params->act_to_ts = res_hdr.timestamp;
             break;

--- a/logsmanagement/db_api.c
+++ b/logsmanagement/db_api.c
@@ -1288,7 +1288,7 @@ void db_search(logs_query_params_t *const p_query_params, struct File_info *cons
 
         /* If exceeding quota or timeout is reached and new timestamp 
          * is different than previous, terminate query. */
-        if((res_buff->len >= p_query_params->quota || now_monotonic_usec() > p_query_params->stop_monotonic_ut) && 
+        if((res_buff->len >= p_query_params->quota || terminate_logs_manag_query(p_query_params)) && 
                 tmp_itm.timestamp != res_hdr.timestamp){
             p_query_params->act_to_ts = res_hdr.timestamp;
             break;

--- a/logsmanagement/stress_test/run_stress_test.sh
+++ b/logsmanagement/stress_test/run_stress_test.sh
@@ -54,9 +54,9 @@ sudo killall -s KILL stress_test
 sudo killall -s KILL -u netdata
 
 # Remove potentially persistent directories and files
-# sudo rm -f $INSTALL_PATH/netdata/var/log/netdata/error.log
-# sudo rm -rf $INSTALL_PATH/netdata/var/cache/netdata/logs_management_db 
-# sudo rm -rf $INSTALL_PATH/netdata_log_management_stress_test_data
+sudo rm -f $INSTALL_PATH/netdata/var/log/netdata/error.log
+sudo rm -rf $INSTALL_PATH/netdata/var/cache/netdata/logs_management_db 
+sudo rm -rf $INSTALL_PATH/netdata_log_management_stress_test_data
 
 CPU_CORES=$(grep ^cpu\\scores /proc/cpuinfo | uniq |  awk '{print $4}')
 

--- a/logsmanagement/stress_test/run_stress_test.sh
+++ b/logsmanagement/stress_test/run_stress_test.sh
@@ -54,9 +54,9 @@ sudo killall -s KILL stress_test
 sudo killall -s KILL -u netdata
 
 # Remove potentially persistent directories and files
-sudo rm -f $INSTALL_PATH/netdata/var/log/netdata/error.log
-sudo rm -rf $INSTALL_PATH/netdata/var/cache/netdata/logs_management_db 
-sudo rm -rf $INSTALL_PATH/netdata_log_management_stress_test_data
+# sudo rm -f $INSTALL_PATH/netdata/var/log/netdata/error.log
+# sudo rm -rf $INSTALL_PATH/netdata/var/cache/netdata/logs_management_db 
+# sudo rm -rf $INSTALL_PATH/netdata_log_management_stress_test_data
 
 CPU_CORES=$(grep ^cpu\\scores /proc/cpuinfo | uniq |  awk '{print $4}')
 


### PR DESCRIPTION
##### Summary
This PR adds the ability to cancel logs management function calls.

##### Test Plan

Test that cancelling a logs-management function call can be performed either by timeout or by submitting a cancel request from the UI. 

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
