### PR TITLE
When unregistering an ephemeral host, delete its chart labels

### DIFF
--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -1422,7 +1422,8 @@ static inline PARSER_RC pluginsd_label(char **words, size_t num_words, PARSER *p
         int is_ephemeral = appconfig_test_boolean_value((char *) value);
         if (is_ephemeral) {
             RRDHOST *host = pluginsd_require_scope_host(parser, PLUGINSD_KEYWORD_LABEL);
-            rrdhost_option_set(host, RRDHOST_OPTION_EPHEMERAL_HOST);
+            if (likely(host))
+                rrdhost_option_set(host, RRDHOST_OPTION_EPHEMERAL_HOST);
         }
     }
 

--- a/database/sqlite/sqlite_metadata.h
+++ b/database/sqlite/sqlite_metadata.h
@@ -17,6 +17,7 @@ void metaqueue_host_update_info(RRDHOST *host);
 void metaqueue_ml_load_models(RRDDIM *rd);
 void migrate_localhost(uuid_t *host_uuid);
 void metadata_queue_load_host_context(RRDHOST *host);
+void metadata_delete_host_chart_labels(char *machine_guid);
 void vacuum_database(sqlite3 *database, const char *db_alias, int threshold, int vacuum_pc);
 
 // UNIT TEST


### PR DESCRIPTION
##### Summary
This PR adds support to clean chart labels when unregistering an ephemeral host.

