### PR TITLE
fix missing systemd-cat-native in docker

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -49,6 +49,7 @@ RUN mkdir -p /app/usr/sbin/ \
     mv /usr/sbin/netdata    /app/usr/sbin/ && \
     mv /usr/sbin/netdata-claim.sh    /app/usr/sbin/ && \
     mv /usr/sbin/netdatacli    /app/usr/sbin/ && \
+    mv /usr/sbin/systemd-cat-native    /app/usr/sbin/ && \
     mv packaging/docker/run.sh        /app/usr/sbin/ && \
     mv packaging/docker/health.sh     /app/usr/sbin/ && \
     mkdir -p /deps/etc && \


### PR DESCRIPTION
##### Summary

ssia

##### Test Plan

Check logs, no `systemd-cat-native: command not found` in logs.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
