### PR TITLE
proc_net_dev: remove device config section

### DIFF
--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -366,6 +366,10 @@ static void netdev_free_chart_strings(struct netdev *d) {
 }
 
 static void netdev_free(struct netdev *d) {
+    char buf[FILENAME_MAX + 1];
+    snprintfz(buf, FILENAME_MAX, "plugin:proc:/proc/net/dev:%s", d->name);
+    config_section_destroy(buf);
+
     netdev_charts_release(d);
     netdev_free_chart_strings(d);
     rrdlabels_destroy(d->chart_labels);

--- a/daemon/common.h
+++ b/daemon/common.h
@@ -28,6 +28,7 @@
 
 #define config_generate(buffer, only_changed) appconfig_generate(&netdata_config, buffer, only_changed)
 
+#define config_section_destroy(section) appconfig_section_destroy_non_loaded(&netdata_config, section)
 #define config_section_option_destroy(section, name) appconfig_section_option_destroy_non_loaded(&netdata_config, section, name)
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary

We never remove sections for each network device in the config. This PR fixes it. Reported in https://github.com/netdata/netdata/issues/16412#issuecomment-1829590822.

##### Test Plan

- Start multiple docker containers.
- Stop/remove them.
- Check `[plugin:proc:/proc/net/dev:*`] sections in `/netdata.conf`. Shouldn't see any sections for veth* interfaces.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
