### PR TITLE
logs-management: Add backfilling for FLB_SYSTEMD logs

### DIFF
--- a/logsmanagement/README.md
+++ b/logsmanagement/README.md
@@ -169,6 +169,7 @@ This collector will collect logs from the journald daemon. See also documentatio
 |  Configuration Option | Description  |
 |      :------------:  	| ------------ |
 | `log path` | Path to the systemd journal directory. If set to `auto`, the default path will be used to read local-only logs. |
+| `read from tail` | (**Experimental**) The first time this option is set to `no`, the collector will attempt to read all system journal logs from the beginning and maintain a cursor to the last collected log, so that it can continue from that point after an agent restart. This ensures no logs are missed when the agent is offline. This feature is disabled by default (defaults to `yes`), as it can cause high CPU usage. |
 | `priority value chart` | Enable chart showing Syslog Priority values (PRIVAL) of collected logs. The Priority value ranges from 0 to 191 and represents both the Facility and Severity. It is calculated by first multiplying the Facility number by 8 and then adding the numerical value of the Severity. Please see the [rfc5424: Syslog Protocol](https://www.rfc-editor.org/rfc/rfc5424#section-6.2.1) document for more information.|
 | `severity chart` | Enable chart showing Syslog Severity values of collected logs. Severity values are in the range of 0 to 7 inclusive.|
 | `facility chart` | Enable chart showing Syslog Facility values of collected logs. Facility values show which subsystem generated the log and are in the range of 0 to 23 inclusive.|

--- a/logsmanagement/circular_buffer.c
+++ b/logsmanagement/circular_buffer.c
@@ -257,7 +257,6 @@ int circ_buff_insert(Circ_buff_t *const buff){
         debug_log( "buff out of space! will be expanded.");
         uv_rwlock_wrlock(&buff->buff_realloc_rwlock);
 
-        
         Circ_buff_item_t *items_new = callocz(buff->num_of_items + 1, sizeof(Circ_buff_item_t));
 
         for(int i = 0; i < buff->num_of_items; i++){

--- a/logsmanagement/circular_buffer.h
+++ b/logsmanagement/circular_buffer.h
@@ -57,7 +57,7 @@ typedef struct Circ_buff {
 } Circ_buff_t;
 
 void circ_buff_search(logs_query_params_t *const p_query_params, struct File_info *const p_file_infos[]);
-void circ_buff_reclaim_empty_items_space(Circ_buff_t *const buff);
+void circ_buff_reclaim_empty_items_space_unsafe(Circ_buff_t *const buff);
 size_t circ_buff_prepare_write(Circ_buff_t *const buff, size_t const requested_text_space);
 int circ_buff_insert(Circ_buff_t *const buff);
 Circ_buff_item_t *circ_buff_read_item(Circ_buff_t *const buff);

--- a/logsmanagement/circular_buffer.h
+++ b/logsmanagement/circular_buffer.h
@@ -43,11 +43,11 @@ typedef struct Circ_buff {
     int head;							        /**< Position of next item insertion **/
     int read;							        /**< Index between tail and head, used to read items out of Circ_buff **/
     int tail;							        /**< Last valid item in Circ_buff **/
-    int parse;									/**< Points to next item in buffer to be parsed **/
     int full;							        /**< When head == tail, this indicates if buffer is full or empty **/
     uv_rwlock_t buff_realloc_rwlock;            /**< RW lock to lock buffer operations when reallocating or expanding buffer **/
     unsigned int buff_realloc_cnt;              /**< Counter of how any buffer reallocations have occurred **/
-    size_t total_cached_mem;				    /**< Total memory allocated for Circ_buff (excluding *in) **/
+    time_t buff_realloc_last;                   /**< Timestamp of last realloc **/
+    size_t total_cached_mem;				    /**< Total memory allocated for Circ_buff **/
     size_t total_cached_mem_max;				/**< Maximum allowable size for total_cached_mem **/
     int allow_dropped_logs;                     /**< Boolean to indicate whether logs are allowed to be dropped if buffer is full */
     size_t text_size_total;				        /**< Total size of items[]->text_size **/
@@ -56,6 +56,7 @@ typedef struct Circ_buff {
 } Circ_buff_t;
 
 void circ_buff_search(logs_query_params_t *const p_query_params, struct File_info *const p_file_infos[]);
+void circ_buff_reclaim_empty_items_space(Circ_buff_t *const buff);
 size_t circ_buff_prepare_write(Circ_buff_t *const buff, size_t const requested_text_space);
 int circ_buff_insert(Circ_buff_t *const buff);
 Circ_buff_item_t *circ_buff_read_item(Circ_buff_t *const buff);

--- a/logsmanagement/circular_buffer.h
+++ b/logsmanagement/circular_buffer.h
@@ -21,7 +21,7 @@ struct File_info;
 typedef enum {
     CIRC_BUFF_ITEM_STATUS_UNPROCESSED = 0,
     CIRC_BUFF_ITEM_STATUS_PARSED = 1,
-    CIRC_BUFF_ITEM_STATUS_STREAMED = 2,
+    CIRC_BUFF_ITEM_STATUS_STREAMED = 2,         // To be used in the future.
     CIRC_BUFF_ITEM_STATUS_DONE = 3              // == CIRC_BUFF_ITEM_STATUS_PARSED | CIRC_BUFF_ITEM_STATUS_STREAMED
 } circ_buff_item_status_t;
 

--- a/logsmanagement/circular_buffer.h
+++ b/logsmanagement/circular_buffer.h
@@ -37,6 +37,7 @@ typedef struct Circ_buff_item {
 } Circ_buff_item_t;
 
 typedef struct Circ_buff {
+    int num_of_items_initial;                   /**< Initial number of preallocated items in the buffer - useful when reclaiming space **/
     int num_of_items;                           /**< Number of preallocated items in the buffer **/
     Circ_buff_item_t *items;                    /**< Array of all circular buffer items **/
     Circ_buff_item_t *in;                       /**< Circular buffer item to write new data into **/

--- a/logsmanagement/db_api.c
+++ b/logsmanagement/db_api.c
@@ -137,7 +137,7 @@ static void db_writer_db_mode_none(void *arg){
         uv_rwlock_rdlock(&p_file_info->circ_buff->buff_realloc_rwlock);
         do{ item = circ_buff_read_item(p_file_info->circ_buff);} while(item);
         circ_buff_read_done(p_file_info->circ_buff);
-        circ_buff_reclaim_empty_items_space(p_file_info->circ_buff);
+        circ_buff_reclaim_empty_items_space_unsafe(p_file_info->circ_buff);
         uv_rwlock_rdunlock(&p_file_info->circ_buff->buff_realloc_rwlock);
         for(int i = 0; i < p_file_info->buff_flush_to_db_interval * 4; i++){
             if(__atomic_load_n(&p_file_info->state, __ATOMIC_RELAXED) != LOG_SRC_READY)
@@ -455,7 +455,7 @@ static void db_writer_db_mode_full(void *arg){
             return_db_writer_db_mode_none(p_file_info, 1);
         }
 
-        circ_buff_reclaim_empty_items_space(p_file_info->circ_buff);
+        circ_buff_reclaim_empty_items_space_unsafe(p_file_info->circ_buff);
 
         // TODO: Can uv_mutex_unlock(p_file_info->db_mut) be moved before if(blob_filesize > p_file_info-> blob_max_size) ?
         uv_mutex_unlock(p_file_info->db_mut);

--- a/logsmanagement/db_api.c
+++ b/logsmanagement/db_api.c
@@ -137,6 +137,7 @@ static void db_writer_db_mode_none(void *arg){
         uv_rwlock_rdlock(&p_file_info->circ_buff->buff_realloc_rwlock);
         do{ item = circ_buff_read_item(p_file_info->circ_buff);} while(item);
         circ_buff_read_done(p_file_info->circ_buff);
+        circ_buff_reclaim_empty_items_space(p_file_info->circ_buff);
         uv_rwlock_rdunlock(&p_file_info->circ_buff->buff_realloc_rwlock);
         for(int i = 0; i < p_file_info->buff_flush_to_db_interval * 4; i++){
             if(__atomic_load_n(&p_file_info->state, __ATOMIC_RELAXED) != LOG_SRC_READY)
@@ -453,6 +454,8 @@ static void db_writer_db_mode_full(void *arg){
             throw_error(p_file_info->chartname, ERR_TYPE_SQLITE, rc, __LINE__, __FILE__, __FUNCTION__);
             return_db_writer_db_mode_none(p_file_info, 1);
         }
+
+        circ_buff_reclaim_empty_items_space(p_file_info->circ_buff);
 
         // TODO: Can uv_mutex_unlock(p_file_info->db_mut) be moved before if(blob_filesize > p_file_info-> blob_max_size) ?
         uv_mutex_unlock(p_file_info->db_mut);

--- a/logsmanagement/db_api.h
+++ b/logsmanagement/db_api.h
@@ -12,8 +12,6 @@
 #include "query.h"
 #include "file_info.h"	
 
-#define LOGS_MANAG_DB_SUBPATH "/logs_management_db"
-
 int db_user_version(sqlite3 *const db, const int set_user_version);
 void db_set_main_dir(char *const dir);
 int db_init(void);

--- a/logsmanagement/defaults.h
+++ b/logsmanagement/defaults.h
@@ -41,6 +41,8 @@
 /*                                  Database                                  */
 /* -------------------------------------------------------------------------- */
 
+#define LOGS_MANAG_DB_SUBPATH "/logs_management_db"     /**< Logs management database directory subpath **/
+
 typedef enum {
     LOGS_MANAG_DB_MODE_FULL = 0,
     LOGS_MANAG_DB_MODE_NONE
@@ -111,6 +113,7 @@ typedef enum {
 #define FLB_LOG_FILENAME_DEFAULT "fluentbit.log"         /**< Default Fluent Bit log filename **/
 #define FLB_LOG_LEVEL_DEFAULT "info"                     /**< Default Fluent Bit log level **/
 #define FLB_CORO_STACK_SIZE_DEFAULT "24576"              /**< Default Fluent Bit coro stack size - do not change this value unless there is a good reason **/
+#define FLB_CURSOR_DB_FILENAME_DEFAULT "flb-cursor.db"   /**< Default Fluent Bit cursor DB filename **/
 
 #define FLB_FORWARD_UNIX_PATH_DEFAULT ""                 /**< Default path for Forward unix socket configuration, see also https://docs.fluentbit.io/manual/pipeline/inputs/forward#configuration-parameters **/
 #define FLB_FORWARD_UNIX_PERM_DEFAULT "0644"             /**< Default permissions for Forward unix socket configuration, see also https://docs.fluentbit.io/manual/pipeline/inputs/forward#configuration-parameters **/

--- a/logsmanagement/defaults.h
+++ b/logsmanagement/defaults.h
@@ -81,8 +81,8 @@ typedef enum {
 
 #define CIRC_BUFF_PREP_WR_RETRY_AFTER_MS 1000           /**< If circ_buff_prepare_write() fails due to not enough space, how many millisecs to wait before retrying **/
 
-#define CIRC_BUFF_SCALE_FACTOR 1.5                      /**< **/
-#define CIRC_BUFF_DO_NOT_RECLAIM_SPACE_FOR_SEC 60       /**< Minimum time that must have passed after a buffer realloc operation to attempt to reclaim empty items space **/
+#define CIRC_BUFF_SCALE_FACTOR 1.5                      /**< Multiplier to use when scaling circular buffers in terms of items or data allocated memory for each item **/
+#define CIRC_BUFF_DO_NOT_RECLAIM_SPACE_FOR_SEC 300      /**< Minimum time that must have passed after a buffer realloc operation to attempt to reclaim empty items space **/
 
 /* -------------------------------------------------------------------------- */
 

--- a/logsmanagement/defaults.h
+++ b/logsmanagement/defaults.h
@@ -81,6 +81,9 @@ typedef enum {
 
 #define CIRC_BUFF_PREP_WR_RETRY_AFTER_MS 1000           /**< If circ_buff_prepare_write() fails due to not enough space, how many millisecs to wait before retrying **/
 
+#define CIRC_BUFF_SCALE_FACTOR 1.5                      /**< **/
+#define CIRC_BUFF_DO_NOT_RECLAIM_SPACE_FOR_SEC 60       /**< Minimum time that must have passed after a buffer realloc operation to attempt to reclaim empty items space **/
+
 /* -------------------------------------------------------------------------- */
 
 

--- a/logsmanagement/file_info.h
+++ b/logsmanagement/file_info.h
@@ -49,6 +49,10 @@ typedef struct flb_kmsg_config {
     char *prio_level;
 } Flb_kmsg_config_t;
 
+typedef struct flb_systemd_config {
+    char *read_from_tail;
+} Flb_systemd_config_t;
+
 typedef struct flb_serial_config {
     char *bitrate;
     char *min_bytes;

--- a/logsmanagement/flb_plugin.c
+++ b/logsmanagement/flb_plugin.c
@@ -1289,20 +1289,12 @@ int flb_add_input(struct File_info *const p_file_info){
             /* Set up systemd input */
             p_file_info->flb_input = flb_input(ctx, "systemd", NULL);
             if(p_file_info->flb_input < 0 ) return FLB_INPUT_ERROR;
-            if(!strcmp(p_file_info->filename, SYSTEMD_DEFAULT_PATH)){
-                if(flb_input_set(ctx, p_file_info->flb_input, 
-                    "Tag", tag_s,
-                    "Read_From_Tail", "On",
-                    "Strip_Underscores", "On",
-                    NULL) != 0) return FLB_INPUT_SET_ERROR;
-            } else {
-                if(flb_input_set(ctx, p_file_info->flb_input, 
-                    "Tag", tag_s,
-                    "Read_From_Tail", "On",
-                    "Strip_Underscores", "On",
-                    "Path", p_file_info->filename,
-                    NULL) != 0) return FLB_INPUT_SET_ERROR;
-            }
+            if(flb_input_set(ctx, p_file_info->flb_input, 
+                "Tag", tag_s,
+                "Read_From_Tail", "On",
+                "Strip_Underscores", "On",
+                "Path", !strcmp(p_file_info->filename, SYSTEMD_DEFAULT_PATH) ? "" : p_file_info->filename,
+                NULL) != 0) return FLB_INPUT_SET_ERROR;
 
             break;
         }

--- a/logsmanagement/logsmanag_config.c
+++ b/logsmanagement/logsmanag_config.c
@@ -724,7 +724,7 @@ static void config_section_init(uv_loop_t *main_loop,
                     return p_file_info_destroy(p_file_info);
                 } else p_file_info->filename = strdupz(KMSG_DEFAULT_PATH);
                 break;
-            case FLB_SYSTEMD:
+            case FLB_SYSTEMD:{
                 const char *const systemd_path_default[] = {
                     "/run/log/journal",
                     "/var/log/journal",
@@ -749,6 +749,7 @@ static void config_section_init(uv_loop_t *main_loop,
                 }
                 if(!p_file_info->filename)
                     p_file_info->filename = strdupz(SYSTEMD_DEFAULT_PATH); // last resort, try to open local only
+            }
                 break;
             case FLB_DOCKER_EV:
                 if(access(DOCKER_EV_DEFAULT_PATH, R_OK)){

--- a/logsmanagement/logsmanag_config.c
+++ b/logsmanagement/logsmanag_config.c
@@ -1060,6 +1060,25 @@ static void config_section_init(uv_loop_t *main_loop,
 
             p_file_info->parser_config->gen_config = syslog_config;
         }
+        else {
+            Flb_systemd_config_t *systemd_config = callocz(1, sizeof(Flb_systemd_config_t));
+
+            systemd_config->read_from_tail = appconfig_get(&log_management_config, config_section->name, "read from tail", NULL);
+            
+            /* not possible to backfill correctly if _SOURCE_REALTIME_TIMESTAMP is not used */
+            if( p_file_info->use_log_timestamp && 
+                systemd_config->read_from_tail && (
+                !strcasecmp(systemd_config->read_from_tail, "off") ||
+                !strcasecmp(systemd_config->read_from_tail, "no"))
+                ){
+                systemd_config->read_from_tail = "Off";
+            }
+            else
+                systemd_config->read_from_tail = "On";
+
+            p_file_info->flb_config = systemd_config;
+
+        }
         if(appconfig_get_boolean(&log_management_config, config_section->name, "priority value chart", CONFIG_BOOLEAN_NO)) {
             p_file_info->parser_config->chart_config |= CHART_SYSLOG_PRIOR;
         }

--- a/logsmanagement/logsmanagement.c
+++ b/logsmanagement/logsmanagement.c
@@ -160,7 +160,7 @@ int main(int argc, char **argv) {
     p_file_infos_arr = callocz(1, sizeof(struct File_infos_arr));
 
     if(logs_manag_config_load(&flb_srvc_config, &p_forward_in_config, g_update_every)) 
-        exit(1);    
+        exit(1);
 
     if(flb_init(flb_srvc_config, get_stock_config_dir(), g_logs_manag_config.sd_journal_field_prefix)){
         collector_error("flb_init() failed - logs management will be disabled");
@@ -178,18 +178,13 @@ int main(int argc, char **argv) {
         exit(1);
     }
 
-    /* Run Fluent Bit engine
-     * NOTE: flb_run() ideally would be executed after db_init(), but in case of
-     * a db_init() failure, it is easier to call flb_stop_and_cleanup() rather 
-     * than the other way round (i.e. cleaning up after db_init(), if flb_run() 
-     * fails). */
-    if(flb_run()){
-        collector_error("flb_run() failed - logs management will be disabled");
+    if(db_init()){
+        collector_error("db_init() failed - logs management will be disabled");
         exit(1);
     }
 
-    if(db_init()){
-        collector_error("db_init() failed - logs management will be disabled");
+    if(flb_run()){
+        collector_error("flb_run() failed - logs management will be disabled");
         exit(1);
     }
 

--- a/logsmanagement/stock_conf/logsmanagement.d/default.conf
+++ b/logsmanagement/stock_conf/logsmanagement.d/default.conf
@@ -74,6 +74,11 @@
 	## Use default path to Systemd Journal
 	log path = auto
 
+	## (Experiemental) Change to 'no' to check for missed system journal logs at startup (backfilling).
+	## It may generate high CPU usage the first time it is enabled.
+	## It requires to set 'log timestamp = auto'.
+	# read from tail = yes
+
 	## Charts to enable
 	# collected logs total chart enable = no
 	# collected logs rate chart enable = yes

--- a/logsmanagement/stress_test/run_stress_test.sh
+++ b/logsmanagement/stress_test/run_stress_test.sh
@@ -54,9 +54,9 @@ sudo killall -s KILL stress_test
 sudo killall -s KILL -u netdata
 
 # Remove potentially persistent directories and files
-sudo rm -f $INSTALL_PATH/netdata/var/log/netdata/error.log
-sudo rm -rf $INSTALL_PATH/netdata/var/cache/netdata/logs_management_db 
-sudo rm -rf $INSTALL_PATH/netdata_log_management_stress_test_data
+# sudo rm -f $INSTALL_PATH/netdata/var/log/netdata/error.log
+# sudo rm -rf $INSTALL_PATH/netdata/var/cache/netdata/logs_management_db 
+# sudo rm -rf $INSTALL_PATH/netdata_log_management_stress_test_data
 
 CPU_CORES=$(grep ^cpu\\scores /proc/cpuinfo | uniq |  awk '{print $4}')
 
@@ -65,7 +65,7 @@ if [ "$build_clean_netdata" -eq 1 ]
 then
 	cd ../..
 	sudo $INSTALL_PATH/netdata/usr/libexec/netdata/netdata-uninstaller.sh -y -f -e $INSTALL_PATH/netdata/etc/netdata/.environment
-	sudo rm -rf $INSTALL_PATH/netdata/etc/netdata # Remove /etc/netdata if it persists for some reason
+	# sudo rm -rf $INSTALL_PATH/netdata/etc/netdata # Remove /etc/netdata if it persists for some reason
 	sudo git clean -dxff && git submodule update --init --recursive --force 
 
 	if [ "$build_for_release" -eq 0 ]

--- a/logsmanagement/stress_test/run_stress_test.sh
+++ b/logsmanagement/stress_test/run_stress_test.sh
@@ -54,9 +54,9 @@ sudo killall -s KILL stress_test
 sudo killall -s KILL -u netdata
 
 # Remove potentially persistent directories and files
-# sudo rm -f $INSTALL_PATH/netdata/var/log/netdata/error.log
-# sudo rm -rf $INSTALL_PATH/netdata/var/cache/netdata/logs_management_db 
-# sudo rm -rf $INSTALL_PATH/netdata_log_management_stress_test_data
+sudo rm -f $INSTALL_PATH/netdata/var/log/netdata/error.log
+sudo rm -rf $INSTALL_PATH/netdata/var/cache/netdata/logs_management_db 
+sudo rm -rf $INSTALL_PATH/netdata_log_management_stress_test_data
 
 CPU_CORES=$(grep ^cpu\\scores /proc/cpuinfo | uniq |  awk '{print $4}')
 
@@ -65,7 +65,7 @@ if [ "$build_clean_netdata" -eq 1 ]
 then
 	cd ../..
 	sudo $INSTALL_PATH/netdata/usr/libexec/netdata/netdata-uninstaller.sh -y -f -e $INSTALL_PATH/netdata/etc/netdata/.environment
-	# sudo rm -rf $INSTALL_PATH/netdata/etc/netdata # Remove /etc/netdata if it persists for some reason
+	sudo rm -rf $INSTALL_PATH/netdata/etc/netdata # Remove /etc/netdata if it persists for some reason
 	sudo git clean -dxff && git submodule update --init --recursive --force 
 
 	if [ "$build_for_release" -eq 0 ]


### PR DESCRIPTION
##### Summary
This PR adds metrics and logs backfilling to `FLB_SYSTEMD` log type sources.

To enable it, set `read from tail = no` in a log source of `FLB_SYSTEMD` type.

The metrics backfilling will only work if no metrics have been collected for this log source previously at all.

> [!CAUTION]
> This change requires extensive testing because the agent may experience significant CPU usage the first time the setting is set to `no`, especially if the system journals have several hundreds of thousands of logs stored.

In addition to that:

1. The PR changes the default behaviour of `FLB_SYSTEMD` log sources, to search `/run/log/journal` and `/var/log/journal` before falling back to `SD_JOURNAL_LOCAL_ONLY`.
2. Most importantly, it adds the ability to periodically reclaim circular buffer unused space by both reducing the number of unused (empty) items in circular buffers and also reclaiming some of the allocated memory for used items.

~~This PR will remain a draft until https://github.com/netdata/netdata/pull/16485 gets merged first.~~

##### Test Plan

On a system with at least several hundreds of thousands of system journal logs:

1. Start from a clean state (fresh install with no previous dbengine metrics) and set `read from tail = no`. Watch if the behaviour of the agent is normal until the `FLB_SYSTEMD` log source settles to a steady state (i.e. it finishes catching up with system logs). Check the Netdata monitoring section and confirm that the number of circular buffer items gets reduced after a few minutes and so is the total cached memory.
2. Repeat the above test but on a setup where there are already metrics stored in dbengine from a previous execution of the agent, but where it's the first time `read from tail = no` is set (i.e. emulate the scenario of a user enabling this after the PR gets merged).
3. Test the circular buffer items and memory reclamation works well with other sources too, especially under stress testing scenarios with tens of thousands of logs collected per second. 

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
