### PR TITLE
Fix occasional shutdown deadlock

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -424,6 +424,13 @@ void netdata_cleanup_and_exit(int ret) {
             delta_shutdown_time("flush dbengine tiers");
             for (size_t tier = 0; tier < storage_tiers; tier++)
                 rrdeng_prepare_exit(multidb_ctx[tier]);
+
+            for (size_t tier = 0; tier < storage_tiers; tier++) {
+                if (!multidb_ctx[tier])
+                    continue;
+                completion_wait_for(&multidb_ctx[tier]->quiesce.completion);
+                completion_destroy(&multidb_ctx[tier]->quiesce.completion);
+            }
         }
 #endif
 

--- a/database/engine/rrdengine.c
+++ b/database/engine/rrdengine.c
@@ -1345,9 +1345,6 @@ static void after_ctx_shutdown(struct rrdengine_instance *ctx __maybe_unused, vo
 static void *ctx_shutdown_tp_worker(struct rrdengine_instance *ctx __maybe_unused, void *data __maybe_unused, struct completion *completion __maybe_unused, uv_work_t *uv_work_req __maybe_unused) {
     worker_is_busy(UV_EVENT_DBENGINE_SHUTDOWN);
 
-    completion_wait_for(&ctx->quiesce.completion);
-    completion_destroy(&ctx->quiesce.completion);
-
     bool logged = false;
     while(__atomic_load_n(&ctx->atomic.extents_currently_being_flushed, __ATOMIC_RELAXED) ||
             __atomic_load_n(&ctx->atomic.inflight_queries, __ATOMIC_RELAXED)) {

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -1227,6 +1227,8 @@ void rrdeng_prepare_exit(struct rrdengine_instance *ctx) {
 
     completion_init(&ctx->quiesce.completion);
     rrdeng_enq_cmd(ctx, RRDENG_OPCODE_CTX_QUIESCE, NULL, NULL, STORAGE_PRIORITY_INTERNAL_DBENGINE, NULL, NULL);
+    completion_wait_for(&ctx->quiesce.completion);
+    completion_destroy(&ctx->quiesce.completion);
 }
 
 static void populate_v2_statistics(struct rrdengine_datafile *datafile, RRDENG_SIZE_STATS *stats)

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -1227,8 +1227,6 @@ void rrdeng_prepare_exit(struct rrdengine_instance *ctx) {
 
     completion_init(&ctx->quiesce.completion);
     rrdeng_enq_cmd(ctx, RRDENG_OPCODE_CTX_QUIESCE, NULL, NULL, STORAGE_PRIORITY_INTERNAL_DBENGINE, NULL, NULL);
-    completion_wait_for(&ctx->quiesce.completion);
-    completion_destroy(&ctx->quiesce.completion);
 }
 
 static void populate_v2_statistics(struct rrdengine_datafile *datafile, RRDENG_SIZE_STATS *stats)


### PR DESCRIPTION
##### Summary
Wait for CTX_QUIESCE command to complete before attempting to finalize collection for all hosts

This may cause a report of collectors still running during shutdown, or a deadlock between the 

- flush_all_hot_and_dirty_pages_of_section_tp_worker
- rrdhost_finalize_collection



