### PR TITLE
add curl example to create_netdata_conf()

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -905,8 +905,13 @@ create_netdata_conf() {
   fi
 
   if [ -z "$url" ]; then
-    echo "# netdata can generate its own config which is available at 'http://<netdata_ip>/netdata.conf'" > "${path}"
-    echo "# You can download it with command like: 'wget -O ${path} http://localhost:19999/netdata.conf'" >> "${path}"
+    cat << EOF > "${path}"
+# netdata can generate its own config which is available at 'http://<IP>:19999/netdata.conf'
+# You can download it using:
+#    curl -o ${path} http://localhost:19999/netdata.conf
+# or
+#    wget -O ${path} http://localhost:19999/netdata.conf
+EOF
   fi
 
 }


### PR DESCRIPTION
##### Summary

Because the Docker image doesn't have `wget`

##### Test Plan

Build docker image, and check netdata.conf.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
