### PR TITLE
convert some error messages to info

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -235,22 +235,22 @@ void aclk_mqtt_wss_log_cb(mqtt_wss_log_type_t log_type, const char* str)
     switch(log_type) {
         case MQTT_WSS_LOG_ERROR:
         case MQTT_WSS_LOG_FATAL:
+            nd_log(NDLS_DAEMON, NDLP_ERR, "%s", str);
+            return;
+
         case MQTT_WSS_LOG_WARN:
-            error_report("%s", str);
+            nd_log(NDLS_DAEMON, NDLP_WARNING, "%s", str);
             return;
 
         case MQTT_WSS_LOG_INFO:
-            nd_log(NDLS_DAEMON, NDLP_INFO,
-                   "%s",
-                   str);
+            nd_log(NDLS_DAEMON, NDLP_INFO, "%s", str);
             return;
 
         case MQTT_WSS_LOG_DEBUG:
             return;
 
         default:
-            nd_log(NDLS_DAEMON, NDLP_ERR,
-                   "Unknown log type from mqtt_wss");
+            nd_log(NDLS_DAEMON, NDLP_ERR, "Unknown log type from mqtt_wss");
     }
 }
 

--- a/collectors/proc.plugin/proc_diskstats.c
+++ b/collectors/proc.plugin/proc_diskstats.c
@@ -366,7 +366,10 @@ static inline int get_disk_name_from_path(const char *path, char *result, size_t
 
     DIR *dir = opendir(path);
     if (!dir) {
-        collector_error("DEVICE-MAPPER ('%s', %lu:%lu): Cannot open directory '%s'.", disk, major, minor, path);
+        if (errno == ENOENT)
+            collector_info("DEVICE-MAPPER ('%s', %lu:%lu): Cannot open directory '%s'.", disk, major, minor, path);
+        else
+            collector_error("DEVICE-MAPPER ('%s', %lu:%lu): Cannot open directory '%s'.", disk, major, minor, path);
         goto failed;
     }
 

--- a/collectors/proc.plugin/proc_spl_kstat_zfs.c
+++ b/collectors/proc.plugin/proc_spl_kstat_zfs.c
@@ -335,7 +335,10 @@ int do_proc_spl_kstat_zfs_pool_state(int update_every, usec_t dt)
     if (likely(do_zfs_pool_state)) {
         DIR *dir = opendir(dirname);
         if (unlikely(!dir)) {
-            collector_error("Cannot read directory '%s'", dirname);
+            if (errno == ENOENT)
+                collector_info("Cannot read directory '%s'", dirname);
+            else
+                collector_error("Cannot read directory '%s'", dirname);
             return 1;
         }
 

--- a/libnetdata/procfile/procfile.c
+++ b/libnetdata/procfile/procfile.c
@@ -407,9 +407,14 @@ procfile *procfile_open(const char *filename, const char *separators, uint32_t f
 
     int fd = open(filename, procfile_open_flags, 0666);
     if(unlikely(fd == -1)) {
-        if(unlikely(!(flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) collector_error(PF_PREFIX ": Cannot open file '%s'", filename);
-        else if(unlikely(flags & PROCFILE_FLAG_ERROR_ON_ERROR_LOG))
+        if (unlikely(flags & PROCFILE_FLAG_ERROR_ON_ERROR_LOG))
             netdata_log_error(PF_PREFIX ": Cannot open file '%s'", filename);
+        else if (unlikely(!(flags & PROCFILE_FLAG_NO_ERROR_ON_FILE_IO))) {
+            if (errno == ENOENT)
+                collector_info(PF_PREFIX ": Cannot open file '%s'", filename);
+            else
+                collector_error(PF_PREFIX ": Cannot open file '%s'", filename);
+        }
         return NULL;
     }
 


### PR DESCRIPTION
##### Summary

This PR:

- `procfile_open()` uses info if the file doesn't exist instead of error. The caller should log an error if needed.
- ~ fix to zfs and diskstats collectors.

##### Test Plan

Restart netdata, check error level log/journal entries.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
