### PR TITLE
apps: fix "has aggregated" debug output

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -3860,7 +3860,7 @@ static void send_charts_updates_to_netdata(struct target *root, const char *type
 
     if (debug_enabled) {
         for (w = root; w; w = w->next) {
-            if (unlikely(w->debug_enabled && !w->target && w->processes)) {
+            if (unlikely(!w->target && w->processes)) {
                 struct pid_on_target *pid_on_target;
                 fprintf(stderr, "apps.plugin: target '%s' has aggregated %u process(es):", w->name, w->processes);
                 for (pid_on_target = w->root_pid; pid_on_target; pid_on_target = pid_on_target->next) {


### PR DESCRIPTION
##### Summary

ssia

##### Test Plan

See output using

```bash
./apps.plugin debug without-users without-groups 2>&1 | grep "has aggregated"
```


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
