### PR TITLE
python.d: logger: remove timestamp when logging to journald.

### DIFF
--- a/collectors/python.d.plugin/python.d.plugin.in
+++ b/collectors/python.d.plugin/python.d.plugin.in
@@ -225,7 +225,8 @@ class ModuleConfig:
         self.is_stock = False
 
     def load(self, abs_path):
-        self.is_stock = abs_path.startswith(DIRS.modules_stock_config)
+        if not IS_ATTY:
+            self.is_stock = abs_path.startswith(DIRS.modules_stock_config)
         self.config.update(load_config(abs_path) or dict())
 
     def defaults(self):

--- a/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SimpleService.py
+++ b/collectors/python.d.plugin/python_modules/bases/FrameworkServices/SimpleService.py
@@ -8,7 +8,7 @@ import os
 
 from bases.charts import Charts, ChartError, create_runtime_chart
 from bases.collection import safe_print
-from bases.loggers import PythonDLimitedLogger
+from bases.loggers import PythonDLogger
 from third_party.monotonic import monotonic
 from time import sleep, time
 
@@ -62,7 +62,7 @@ def clean_module_name(name):
     return name
 
 
-class SimpleService(PythonDLimitedLogger, object):
+class SimpleService(PythonDLogger, object):
     """
     Prototype of Service class.
     Implemented basic functionality to run jobs by `python.d.plugin`
@@ -73,7 +73,7 @@ class SimpleService(PythonDLimitedLogger, object):
         :param configuration: <dict>
         :param name: <str>
         """
-        PythonDLimitedLogger.__init__(self)
+        PythonDLogger.__init__(self)
         self.configuration = configuration
         self.order = list()
         self.definitions = dict()

--- a/collectors/python.d.plugin/python_modules/bases/loggers.py
+++ b/collectors/python.d.plugin/python_modules/bases/loggers.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
+import os
+import stat
 import traceback
 
 from sys import exc_info
@@ -15,39 +17,46 @@ except ImportError:
 
 from bases.collection import on_try_except_finally, unicode_str
 
-LOGGING_LEVELS = {'CRITICAL': 50,
-                  'ERROR': 40,
-                  'WARNING': 30,
-                  'INFO': 20,
-                  'DEBUG': 10,
-                  'NOTSET': 0}
+LOGGING_LEVELS = {
+    'CRITICAL': 50,
+    'ERROR': 40,
+    'WARNING': 30,
+    'INFO': 20,
+    'DEBUG': 10,
+    'NOTSET': 0,
+}
+
+
+def is_stderr_connected_to_journal():
+    journal_stream = os.environ.get("JOURNAL_STREAM")
+    if not journal_stream:
+        return False
+
+    colon_index = journal_stream.find(":")
+    if colon_index <= 0:
+        return False
+
+    device, inode = journal_stream[:colon_index], journal_stream[colon_index + 1:]
+
+    try:
+        device_number, inode_number = os.fstat(2)[stat.ST_DEV], os.fstat(2)[stat.ST_INO]
+    except OSError:
+        return False
+
+    return str(device_number) == device and str(inode_number) == inode
+
+
+is_journal = is_stderr_connected_to_journal()
 
 DEFAULT_LOG_LINE_FORMAT = '%(asctime)s: %(name)s %(levelname)s : %(message)s'
-DEFAULT_LOG_TIME_FORMAT = '%Y-%m-%d %H:%M:%S'
-
 PYTHON_D_LOG_LINE_FORMAT = '%(asctime)s: %(name)s %(levelname)s: %(module_name)s[%(job_name)s] : %(message)s'
+
+if is_journal:
+    DEFAULT_LOG_LINE_FORMAT = '%(name)s %(levelname)s : %(message)s'
+    PYTHON_D_LOG_LINE_FORMAT = '%(name)s %(levelname)s: %(module_name)s[%(job_name)s] : %(message)s '
+
+DEFAULT_LOG_TIME_FORMAT = '%Y-%m-%d %H:%M:%S'
 PYTHON_D_LOG_NAME = 'python.d'
-
-
-def limiter(log_max_count=30, allowed_in_seconds=60):
-    def on_decorator(func):
-
-        def on_call(*args):
-            current_time = args[0]._runtime_counters.start_mono
-            lc = args[0]._logger_counters
-
-            if lc.logged and lc.logged % log_max_count == 0:
-                if current_time - lc.time_to_compare <= allowed_in_seconds:
-                    lc.dropped += 1
-                    return
-                lc.time_to_compare = current_time
-
-            lc.logged += 1
-            func(*args)
-
-        return on_call
-
-    return on_decorator
 
 
 def add_traceback(func):
@@ -66,26 +75,14 @@ def add_traceback(func):
     return on_call
 
 
-class LoggerCounters:
-    def __init__(self):
-        self.logged = 0
-        self.dropped = 0
-        self.time_to_compare = time()
-
-    def __repr__(self):
-        return 'LoggerCounter(logged: {logged}, dropped: {dropped})'.format(logged=self.logged,
-                                                                            dropped=self.dropped)
-
-
 class BaseLogger(object):
-    def __init__(self, logger_name, log_fmt=DEFAULT_LOG_LINE_FORMAT, date_fmt=DEFAULT_LOG_TIME_FORMAT,
-                 handler=logging.StreamHandler):
-        """
-        :param logger_name: <str>
-        :param log_fmt: <str>
-        :param date_fmt: <str>
-        :param handler: <logging handler>
-        """
+    def __init__(
+            self,
+            logger_name,
+            log_fmt=DEFAULT_LOG_LINE_FORMAT,
+            date_fmt=DEFAULT_LOG_TIME_FORMAT,
+            handler=logging.StreamHandler,
+    ):
         self.logger = logging.getLogger(logger_name)
         self._muted = False
         if not self.has_handlers():
@@ -97,11 +94,6 @@ class BaseLogger(object):
         return '<Logger: {name})>'.format(name=self.logger.name)
 
     def set_formatter(self, fmt, date_fmt=DEFAULT_LOG_TIME_FORMAT):
-        """
-        :param fmt: <str>
-        :param date_fmt: <str>
-        :return:
-        """
         if self.has_handlers():
             self.logger.handlers[0].setFormatter(logging.Formatter(fmt=fmt, datefmt=date_fmt))
 
@@ -114,36 +106,31 @@ class BaseLogger(object):
 
     @severity.setter
     def severity(self, level):
-        """
-        :param level: <str> or <int>
-        :return:
-        """
         if level in LOGGING_LEVELS:
             self.logger.setLevel(LOGGING_LEVELS[level])
 
-    def debug(self, *msg, **kwargs):
+    def _log(self, level, *msg, **kwargs):
         if not self._muted:
-            self.logger.debug(' '.join(map(unicode_str, msg)), **kwargs)
+            self.logger.log(level, ' '.join(map(unicode_str, msg)), **kwargs)
+
+    def debug(self, *msg, **kwargs):
+        self._log(logging.DEBUG, *msg, **kwargs)
 
     def info(self, *msg, **kwargs):
-        if not self._muted:
-            self.logger.info(' '.join(map(unicode_str, msg)), **kwargs)
+        self._log(logging.INFO, *msg, **kwargs)
 
     def warning(self, *msg, **kwargs):
-        if not self._muted:
-            self.logger.warning(' '.join(map(unicode_str, msg)), **kwargs)
+        self._log(logging.WARN, *msg, **kwargs)
 
     def error(self, *msg, **kwargs):
-        if not self._muted:
-            self.logger.error(' '.join(map(unicode_str, msg)), **kwargs)
+        self._log(logging.ERROR, *msg, **kwargs)
 
     def alert(self, *msg, **kwargs):
-        if not self._muted:
-            self.logger.critical(' '.join(map(unicode_str, msg)), **kwargs)
+        self._log(logging.CRITICAL, *msg, **kwargs)
 
     @on_try_except_finally(on_finally=(exit, 1))
     def fatal(self, *msg, **kwargs):
-        self.logger.critical(' '.join(map(unicode_str, msg)), **kwargs)
+        self._log(logging.CRITICAL, *msg, **kwargs)
 
     def mute(self):
         self._muted = True
@@ -153,15 +140,14 @@ class BaseLogger(object):
 
 
 class PythonDLogger(object):
-    def __init__(self, logger_name=PYTHON_D_LOG_NAME, log_fmt=PYTHON_D_LOG_LINE_FORMAT):
-        """
-        :param logger_name: <str>
-        :param log_fmt: <str>
-        """
+    def __init__(
+            self,
+            logger_name=PYTHON_D_LOG_NAME,
+            log_fmt=PYTHON_D_LOG_LINE_FORMAT,
+    ):
         self.logger = BaseLogger(logger_name, log_fmt=log_fmt)
         self.module_name = 'plugin'
         self.job_name = 'main'
-        self._logger_counters = LoggerCounters()
 
     _LOG_TRACEBACK = False
 
@@ -174,45 +160,39 @@ class PythonDLogger(object):
         PythonDLogger._LOG_TRACEBACK = value
 
     def debug(self, *msg):
-        self.logger.debug(*msg, extra={'module_name': self.module_name,
-                                       'job_name': self.job_name or self.module_name})
+        self.logger.debug(*msg, extra={
+            'module_name': self.module_name,
+            'job_name': self.job_name or self.module_name,
+        })
 
     def info(self, *msg):
-        self.logger.info(*msg, extra={'module_name': self.module_name,
-                                      'job_name': self.job_name or self.module_name})
+        self.logger.info(*msg, extra={
+            'module_name': self.module_name,
+            'job_name': self.job_name or self.module_name,
+        })
 
     def warning(self, *msg):
-        self.logger.warning(*msg, extra={'module_name': self.module_name,
-                                         'job_name': self.job_name or self.module_name})
+        self.logger.warning(*msg, extra={
+            'module_name': self.module_name,
+            'job_name': self.job_name or self.module_name,
+        })
 
     @add_traceback
     def error(self, *msg):
-        self.logger.error(*msg, extra={'module_name': self.module_name,
-                                       'job_name': self.job_name or self.module_name})
+        self.logger.error(*msg, extra={
+            'module_name': self.module_name,
+            'job_name': self.job_name or self.module_name,
+        })
 
     @add_traceback
     def alert(self, *msg):
-        self.logger.alert(*msg, extra={'module_name': self.module_name,
-                                       'job_name': self.job_name or self.module_name})
+        self.logger.alert(*msg, extra={
+            'module_name': self.module_name,
+            'job_name': self.job_name or self.module_name,
+        })
 
     def fatal(self, *msg):
-        self.logger.fatal(*msg, extra={'module_name': self.module_name,
-                                       'job_name': self.job_name or self.module_name})
-
-
-class PythonDLimitedLogger(PythonDLogger):
-    @limiter()
-    def info(self, *msg):
-        PythonDLogger.info(self, *msg)
-
-    @limiter()
-    def warning(self, *msg):
-        PythonDLogger.warning(self, *msg)
-
-    @limiter()
-    def error(self, *msg):
-        PythonDLogger.error(self, *msg)
-
-    @limiter()
-    def alert(self, *msg):
-        PythonDLogger.alert(self, *msg)
+        self.logger.fatal(*msg, extra={
+            'module_name': self.module_name,
+            'job_name': self.job_name or self.module_name,
+        })


### PR DESCRIPTION
##### Summary

Because journald adds the timestamp. The timestamp is only removed when stderr is connected to journald.

Before:

```bash
$ ndlogs --grep python.d
Nov 30 21:08:26 pve-deb-work netdata[1145877]: 2023-11-30 21:08:26: python.d INFO: plugin[main] : using python v3
Nov 30 21:08:28 pve-deb-work netdata[1145877]: 2023-11-30 21:08:28: python.d INFO: plugin[main] : '/opt/netdata/etc/netdata/python.d.conf' was not found
Nov 30 21:08:28 pve-deb-work netdata[1145877]: 2023-11-30 21:08:28: python.d INFO: plugin[main] : [adaptec_raid] is disabled by default, skipping it
```

After:

```bash
$ ndlogs --grep python.d
Nov 30 21:05:39 pve-deb-work netdata[1129911]: python.d INFO: plugin[main] : using python v3
Nov 30 21:05:41 pve-deb-work netdata[1129911]: python.d INFO: plugin[main] : '/opt/netdata/etc/netdata/python.d.conf' was not found
Nov 30 21:05:41 pve-deb-work netdata[1129911]: python.d INFO: plugin[main] : [adaptec_raid] is disabled by default, skipping it
```


---

And cleanup: remove limited logger, Netdata's log flood protection is enough.

##### Test Plan

Check netdata logs in journald.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
