### PR TITLE
remove system info logging

### DIFF
--- a/collectors/plugins.d/pluginsd_parser.c
+++ b/collectors/plugins.d/pluginsd_parser.c
@@ -1117,7 +1117,7 @@ void pluginsd_function_cancel(void *data) {
     dfe_done(t);
 
     if(sent <= 0)
-        nd_log(NDLS_DAEMON, NDLP_NOTICE,
+        nd_log(NDLS_DAEMON, NDLP_DEBUG,
                "PLUGINSD: FUNCTION_CANCEL request didn't match any pending function requests in pluginsd.d.");
 }
 

--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -1291,7 +1291,7 @@ __attribute__((constructor)) void initialize_build_info(void) {
 // ----------------------------------------------------------------------------
 // system info
 
-int get_system_info(struct rrdhost_system_info *system_info, bool log);
+int get_system_info(struct rrdhost_system_info *system_info);
 static void populate_system_info(void) {
     static bool populated = false;
     static SPINLOCK spinlock = NETDATA_SPINLOCK_INITIALIZER;
@@ -1314,7 +1314,7 @@ static void populate_system_info(void) {
     }
     else {
         system_info = callocz(1, sizeof(struct rrdhost_system_info));
-        get_system_info(system_info, false);
+        get_system_info(system_info);
         free_system_info = true;
     }
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1346,6 +1346,8 @@ int get_system_info(struct rrdhost_system_info *system_info) {
 
                 if(unlikely(rrdhost_set_system_info_variable(system_info, line, value))) {
                     netdata_log_error("Unexpected environment variable %s=%s", line, value);
+                } else {
+                    setenv(line, value, 1);
                 }
             }
         }

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1349,7 +1349,7 @@ int get_system_info(struct rrdhost_system_info *system_info, bool log) {
                 }
                 else {
                     if(log)
-                        netdata_log_info("%s=%s", line, value);
+                        netdata_log_debug("%s=%s", line, value);
 
                     setenv(line, value, 1);
                 }

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1314,7 +1314,7 @@ static inline void coverity_remove_taint(char *s)
     (void)s;
 }
 
-int get_system_info(struct rrdhost_system_info *system_info, bool log) {
+int get_system_info(struct rrdhost_system_info *system_info) {
     char *script;
     script = mallocz(sizeof(char) * (strlen(netdata_configured_primary_plugins_dir) + strlen("system-info.sh") + 2));
     sprintf(script, "%s/%s", netdata_configured_primary_plugins_dir, "system-info.sh");
@@ -1346,12 +1346,6 @@ int get_system_info(struct rrdhost_system_info *system_info, bool log) {
 
                 if(unlikely(rrdhost_set_system_info_variable(system_info, line, value))) {
                     netdata_log_error("Unexpected environment variable %s=%s", line, value);
-                }
-                else {
-                    if(log)
-                        netdata_log_debug("%s=%s", line, value);
-
-                    setenv(line, value, 1);
                 }
             }
         }
@@ -2107,7 +2101,7 @@ int main(int argc, char **argv) {
     netdata_anonymous_statistics_enabled=-1;
     struct rrdhost_system_info *system_info = callocz(1, sizeof(struct rrdhost_system_info));
     __atomic_sub_fetch(&netdata_buffers_statistics.rrdhost_allocations_size, sizeof(struct rrdhost_system_info), __ATOMIC_RELAXED);
-    get_system_info(system_info, true);
+    get_system_info(system_info);
     (void) registry_get_this_machine_guid();
     system_info->hops = 0;
     get_install_type(&system_info->install_type, &system_info->prebuilt_arch, &system_info->prebuilt_dist);


### PR DESCRIPTION
##### Summary

There is no need to log system info variables on every start/restart (33 lines!). 

Additionally, this PR changes the "Function cancel" log message level to debug (discussed with ktsaou).

##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
