### PR TITLE
include more cases for megacli degraded state

### DIFF
--- a/collectors/python.d.plugin/megacli/megacli.chart.py
+++ b/collectors/python.d.plugin/megacli/megacli.chart.py
@@ -91,7 +91,7 @@ def battery_charts(bats):
 
 
 RE_ADAPTER = re.compile(
-    r'Adapter #([0-9]+) State(?:\s+)?: ([a-zA-Z]+)'
+    r'Adapter #([0-9]+) State(?:\s+)?: ([a-zA-Z ]+)'
 )
 
 RE_VD = re.compile(
@@ -124,13 +124,13 @@ def find_batteries(d):
 class Adapter:
     def __init__(self, n, state):
         self.id = n
-        self.state = int(state == 'Degraded')
+        # TODO: Rewrite all of this
+        self.state = int(state in ("Partially Degraded", "Degraded", "Failed"))
 
     def data(self):
         return {
             'adapter_{0}_degraded'.format(self.id): self.state,
         }
-
 
 class PD:
     def __init__(self, n, media_err, predict_fail):


### PR DESCRIPTION
##### Summary
As discussed with @ilyam8 on discord, this *temporarily* fixes the Issue of not being alerted about a `Partially Degraded` or `Failed` megacli raid array.

A correct fix would require rewriting bigger parts of this system, and is not an easy task, so this will be the best solution for the time being.

##### Test Plan
- Requires megacli and hardware raid
- Set raid state to failed or partially degraded (you can use `-PDOffline -PhysDrv [Enclosure:ID] -aN` to mark a disk as offline, which will cause either of the two, depending on your raid level, `-PDOnline` to bring it back up)

##### Additional Information
See Summary

<details> <summary>For users: How does this change affect me?</summary>

- Megacli raid arrays are now also considered degraded if it is only partial, or fully failed
- Change will affect you only if you use that collector. If you do, see the "adapter" chart with an unhealthy array
- Non-breaking
</details>
