### PR TITLE
log method = none is not respected

### DIFF
--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -891,7 +891,9 @@ static void nd_log_open(struct nd_log_source *e, ND_LOG_SOURCES source) {
             e->fd = STDOUT_FILENO;
             break;
 
-        default:
+        case NDLM_DISABLED:
+            break;
+
         case NDLM_DEFAULT:
         case NDLM_STDERR:
             e->method = NDLM_STDERR;


### PR DESCRIPTION
When the log method is set to none, do not log anything.