### PR TITLE
Make image available to Learn + add a category overview page for new …

### DIFF
--- a/docs/netdata-cloud-onprem/getting-started.md
+++ b/docs/netdata-cloud-onprem/getting-started.md
@@ -195,6 +195,6 @@ Exposes API endpoints to authenticate agents connecting to the cloud.
 
 ## Infrastructure Diagram
 
-![infrastructure.jpeg](infrastructure.jpeg)
+![infrastructure.jpeg](https://github.com/netdata/netdata/blob/master/docs/netdata-cloud-onprem/infrastructure.jpeg)
 
 ### If you have any questions or suggestions please contact the Netdata team.


### PR DESCRIPTION
…category

Related to https://github.com/netdata/learn/pull/1895

##### Summary

If the image is a relative path then Learn can't work, we gotta make it a link for it to work nicely with Learn.

~~Also with the current structure we need a category overview page which I will add on a separate commit on this PR.~~

Actually @M4itee could we use https://github.com/netdata/netdata/edit/master/docs/netdata-cloud-onprem/getting-started.md and instead of calling it `Helm chart deployment` have it show up when we click the category, is that fine?