### PR TITLE
link aclk.log to stdout in docker

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -88,6 +88,7 @@ ENV NETDATA_EXTRA_DEB_PACKAGES=""
 
 RUN mkdir -p /opt/src /var/log/netdata && \
     ln -sf /dev/stdout /var/log/netdata/access.log && \
+    ln -sf /dev/stdout /var/log/netdata/aclk.log && \
     ln -sf /dev/stdout /var/log/netdata/debug.log && \
     ln -sf /dev/stderr /var/log/netdata/error.log && \
     ln -sf /dev/stderr /var/log/netdata/daemon.log && \


### PR DESCRIPTION
##### Summary



```cmd
$ docker exec nd-child-host6-1 ls -l /var/log/netdata
total 0
lrwxrwxrwx 1 netdata root    11 Dec  4 00:28 access.log -> /dev/stdout
-rw-r--r-- 1 netdata netdata  0 Dec  4 09:38 aclk.log
lrwxrwxrwx 1 netdata root    11 Dec  4 00:28 collector.log -> /dev/stdout
lrwxrwxrwx 1 netdata root    11 Dec  4 00:28 daemon.log -> /dev/stderr
lrwxrwxrwx 1 netdata root    11 Dec  4 00:28 debug.log -> /dev/stdout
lrwxrwxrwx 1 netdata root    11 Dec  4 00:28 error.log -> /dev/stderr
lrwxrwxrwx 1 netdata root    11 Dec  4 00:28 fluentbit.log -> /dev/stdout
lrwxrwxrwx 1 netdata root    11 Dec  4 00:28 health.log -> /dev/stdout
```

##### Test Plan

Not needed, the changes are straightforward.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
