### PR TITLE
apps: fix uptime for groups with 0 processes

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -3806,16 +3806,30 @@ static void send_collected_data_to_netdata(struct target *root, const char *type
 #endif
 
 #ifndef __FreeBSD__
-        send_BEGIN(type, w->clean_name, "uptime", dt);
-        send_SET("uptime", (global_uptime > w->starttime) ? (global_uptime - w->starttime) : 0);
-        send_END();
-
-        if (enable_detailed_uptime_charts) {
-            send_BEGIN(type, w->clean_name, "uptime_summary", dt);
-            send_SET("min", w->uptime_min);
-            send_SET("avg", w->processes > 0 ? w->uptime_sum / w->processes : 0);
-            send_SET("max", w->uptime_max);
+        if (w->processes == 0) {
+            send_BEGIN(type, w->clean_name, "uptime", dt);
+            send_SET("uptime", 0);
             send_END();
+
+            if (enable_detailed_uptime_charts) {
+                send_BEGIN(type, w->clean_name, "uptime_summary", dt);
+                send_SET("min", 0);
+                send_SET("avg", 0);
+                send_SET("max", 0);
+                send_END();
+            }
+        } else {
+            send_BEGIN(type, w->clean_name, "uptime", dt);
+            send_SET("uptime", (global_uptime > w->starttime) ? (global_uptime - w->starttime) : 0);
+            send_END();
+
+            if (enable_detailed_uptime_charts) {
+                send_BEGIN(type, w->clean_name, "uptime_summary", dt);
+                send_SET("min", w->uptime_min);
+                send_SET("avg", w->processes > 0 ? w->uptime_sum / w->processes : 0);
+                send_SET("max", w->uptime_max);
+                send_END();
+            }
         }
 #endif
 

--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -3750,7 +3750,7 @@ static void send_collected_data_to_netdata(struct target *root, const char *type
     struct target *w;
 
     for (w = root; w ; w = w->next) {
-        if (unlikely(!w->exposed && !w->is_other))
+        if (unlikely(!w->exposed))
             continue;
 
         send_BEGIN(type, w->clean_name, "processes", dt);


### PR DESCRIPTION
##### Summary

Fixes the uptime metric for groups with 0 processes (`other` group).

##### Test Plan

Uptime of the `other` group with 0 processes should be 0, not == the host uptime.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
