### PR TITLE
set "HOME" after switching to netdata user

### DIFF
--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -842,7 +842,6 @@ void set_global_environment() {
     setenv("NETDATA_LIB_DIR", verify_or_create_required_directory(netdata_configured_varlib_dir), 1);
     setenv("NETDATA_LOCK_DIR", verify_or_create_required_directory(netdata_configured_lock_dir), 1);
     setenv("NETDATA_LOG_DIR", verify_or_create_required_directory(netdata_configured_log_dir), 1);
-    setenv("HOME", verify_or_create_required_directory(netdata_configured_home_dir), 1);
     setenv("NETDATA_HOST_PREFIX", netdata_configured_host_prefix, 1);
 
     {

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -2069,8 +2069,8 @@ int main(int argc, char **argv) {
         fatal("Cannot daemonize myself.");
 
     // The "HOME" env var points to the root's home dir because Netdata starts as root. Can't use "HOME".
-    struct passwd *pw = getpwnam(user);
-    if (config_exists(CONFIG_SECTION_DIRECTORIES, "home") || !pw) {
+    struct passwd *pw = getpwuid(getuid());
+    if (config_exists(CONFIG_SECTION_DIRECTORIES, "home") || !pw || !pw->pw_dir) {
         netdata_configured_home_dir = config_get(CONFIG_SECTION_DIRECTORIES, "home", netdata_configured_home_dir);
     } else {
         netdata_configured_home_dir = config_get(CONFIG_SECTION_DIRECTORIES, "home", pw->pw_dir);

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1167,8 +1167,6 @@ static void get_netdata_configured_variables() {
     netdata_configured_web_dir          = config_get(CONFIG_SECTION_DIRECTORIES, "web",          netdata_configured_web_dir);
     netdata_configured_cache_dir        = config_get(CONFIG_SECTION_DIRECTORIES, "cache",        netdata_configured_cache_dir);
     netdata_configured_varlib_dir       = config_get(CONFIG_SECTION_DIRECTORIES, "lib",          netdata_configured_varlib_dir);
-    char *env_home=getenv("HOME");
-    netdata_configured_home_dir         = config_get(CONFIG_SECTION_DIRECTORIES, "home",         env_home?env_home:netdata_configured_home_dir);
 
     netdata_configured_lock_dir = initialize_lock_directory_path(netdata_configured_varlib_dir);
 
@@ -2069,6 +2067,16 @@ int main(int argc, char **argv) {
     // fork, switch user, create pid file, set process priority
     if(become_daemon(dont_fork, user) == -1)
         fatal("Cannot daemonize myself.");
+
+    // The "HOME" env var points to the root's home dir because Netdata starts as root. Can't use "HOME".
+    struct passwd *pw = getpwnam(user);
+    if (config_exists(CONFIG_SECTION_DIRECTORIES, "home") || !pw) {
+        netdata_configured_home_dir = config_get(CONFIG_SECTION_DIRECTORIES, "home", netdata_configured_home_dir);
+    } else {
+        netdata_configured_home_dir = config_get(CONFIG_SECTION_DIRECTORIES, "home", pw->pw_dir);
+    }
+
+    setenv("HOME", netdata_configured_home_dir, 1);
 
     dyn_conf_init();
 

--- a/system/Makefile.am
+++ b/system/Makefile.am
@@ -3,6 +3,7 @@
 
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 CLEANFILES = \
+    install-service.sh \
     cron/netdata-updater-daily \
     freebsd/rc.d/netdata \
     initd/init.d/netdata \


### PR DESCRIPTION
##### Summary

Fixes: #16511

I installed Netdata on FreeBSD using `netdata-installer.sh` and it failed to start `service netdata start`:

```cmd
time=2023-12-05T15:15:26.079+02:00 comm=netdata source=daemon level=alert errno="21, Is a directory" tid=100760  msg="Cannot create required directory '/'"
0x4684bc <netdata_logger_fatal+0x1ec> at /opt/netdata/usr/sbin/netdata
0x41ece3 <set_global_environment+0x1423> at /opt/netdata/usr/sbin/netdata
```

The problem is:
- main.c: on [this line](https://github.com/netdata/netdata/blob/6e049a523c3760c9f263a8469fdf3fb595b464cc/daemon/main.c#L1170-L1171) we set the home directory to the value of the “HOME” env var.
- analytics.c: on [this line](https://github.com/netdata/netdata/blob/6e049a523c3760c9f263a8469fdf3fb595b464cc/daemon/analytics.c#L845) we “verify” the value by creating/opening the dir and fatal on fail.

This happens before switching to the `netdata` user, so we are the `root` user. This means the value is incorrect, it is not "HOME" netdata. If you check `[directory] home =` in `netdata.conf` on your instances, you will see that it is `/root`. The "HOME" environment value is `/root` on Linux and `/` on FreeBSD. And the check function fails in FreeBSD => fatal.

---

The fix is:

- do not use "HOME" env variable because it points to root's home (Netdata starts as root).
- get the home directory of the user that Netdata is configured to run as and set "HOME" to it after switching to the new user.

##### Test Plan

Install on FreeBSD using `netdata-installer.sh` and make sure:

- `service netdata status/stop/start/restart` works.
- `[directories] home` in `netdata.conf` is set to the home directory of the user that Netdata is configured to run as (default: `netdata`).

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
