### PR TITLE
Improve page validity check during database extent load

### DIFF
--- a/database/engine/pdc.c
+++ b/database/engine/pdc.c
@@ -998,7 +998,9 @@ static bool epdl_populate_pages_from_extent_data(
         uncompressed_payload_length = 0;
         for (i = 0; i < count; ++i) {
             size_t page_length = header->descr[i].page_length;
-            if(page_length > RRDENG_BLOCK_SIZE) {
+            if (page_length > RRDENG_BLOCK_SIZE && (header->descr[i].type != PAGE_GORILLA_METRICS ||
+                                                    (header->descr[i].type == PAGE_GORILLA_METRICS &&
+                                                     (page_length - RRDENG_BLOCK_SIZE) % GORILLA_BUFFER_SIZE))) {
                 have_read_error = true;
                 break;
             }


### PR DESCRIPTION
##### Summary
Suppress error such as
```
DBENGINE: metric 'b4789e58-f98c-4466-9652-fd8c16e57d72' loaded invalid page of type 2 from 1701843352 to 1701844375 (now 1701853367), update every 1, page length 3072, entries 1024 (flags: )
```

Pages with type 2 (gorilla compression) can be > 4096 bytes in multiples of GORILLA PAGE SIZE
