### PR TITLE
kickstart: Add detection of multiple concurrent installs.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -892,8 +892,10 @@ detect_existing_install() {
       fatal "Multiple installs of Netdata agent detected (located at '${ndpath}' and '${_ndpath}'). Such a setup is not generally supported. If you are certain you want to operate on one of them despite this, use the '--install-prefix' option to specifiy the install you want to operate on." F0517
     fi
 
-    if [ -n "${INSTALL_PREFIX}" ]; then
+    if [ -n "${INSTALL_PREFIX}" ] && [ -n "${ndpath}" ]; then
       break
+    elif echo "${searchpath}" | grep -v ':'; then
+      searchpath=""
     else
       searchpath="$(echo "${searchpath}" | cut -f 2- -d ':')"
     fi

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
-# Next unused error code: F0517
+# Next unused error code: F0518
 
 # ======================================================================
 # Constants
@@ -874,31 +874,39 @@ detect_existing_install() {
   set_tmpdir
 
   progress "Checking for existing installations of Netdata..."
+  EXISTING_INSTALL_IS_NATIVE="0"
+
+  if [ -n "${INSTALL_PREFIX}" ]; then
+    searchpath="/opt/netdata/bin:${INSTALL_PREFIX}/bin:${INSTALL_PREFIX}/sbin:${INSTALL_PREFIX}/usr/bin:${INSTALL_PREFIX}/usr/sbin:${PATH}"
+    searchpath="${INSTALL_PREFIX}/netdata/bin:${INSTALL_PREFIX}/netdata/sbin:${INSTALL_PREFIX}/netdata/usr/bin:${INSTALL_PREFIX}/netdata/usr/sbin:${searchpath}"
+  else
+    searchpath="/opt/netdata/bin:${PATH}"
+  fi
+
+  while [ -n "${searchpath}" ]; do
+    _ndpath="$(PATH="${searchpath}" command -v netdata 2>/dev/null)"
+
+    if [ -z "${ndpath}" ]; then
+      ndpath="${_ndpath}"
+    elif [ -n "${_ndpath}" ]; then
+      fatal "Multiple installs of Netdata agent detected (located at '${ndpath}' and '${_ndpath}'). Such a setup is not generally supported. If you are certain you want to operate on one of them despite this, use the '--install-prefix' option to specifiy the install you want to operate on." F0517
+    fi
+
+    if [ -n "${INSTALL_PREFIX}" ]; then
+      break
+    else
+      searchpath="$(echo "${searchpath}" | cut -f 2- -d ':')"
+    fi
+  done
 
   if pkg_installed netdata; then
     ndprefix="/"
     EXISTING_INSTALL_IS_NATIVE="1"
-  else
-    EXISTING_INSTALL_IS_NATIVE="0"
-    if [ -n "${INSTALL_PREFIX}" ]; then
-      searchpath="${INSTALL_PREFIX}/bin:${INSTALL_PREFIX}/sbin:${INSTALL_PREFIX}/usr/bin:${INSTALL_PREFIX}/usr/sbin:${PATH}"
-      searchpath="${INSTALL_PREFIX}/netdata/bin:${INSTALL_PREFIX}/netdata/sbin:${INSTALL_PREFIX}/netdata/usr/bin:${INSTALL_PREFIX}/netdata/usr/sbin:${searchpath}"
-    else
-      searchpath="${PATH}"
-    fi
-
-    ndpath="$(PATH="${searchpath}" command -v netdata 2>/dev/null)"
-
-    if [ -z "$ndpath" ] && [ -x /opt/netdata/bin/netdata ]; then
-      ndpath="/opt/netdata/bin/netdata"
-    fi
-
-    if [ -n "${ndpath}" ]; then
-      case "${ndpath}" in
-        */usr/bin/netdata|*/usr/sbin/netdata) ndprefix="$(dirname "$(dirname "$(dirname "${ndpath}")")")" ;;
-        *) ndprefix="$(dirname "$(dirname "${ndpath}")")" ;;
-      esac
-    fi
+  elif [ -n "${ndpath}" ]; then
+    case "${ndpath}" in
+      */usr/bin/netdata|*/usr/sbin/netdata) ndprefix="$(dirname "$(dirname "$(dirname "${ndpath}")")")" ;;
+      *) ndprefix="$(dirname "$(dirname "${ndpath}")")" ;;
+    esac
 
     if echo "${ndprefix}" | grep -Eq '^/usr$'; then
       ndprefix="$(dirname "${ndprefix}")"


### PR DESCRIPTION
##### Summary

Such setups cause all kinds of problems, so properly detect and report them when possible (and refuse to continue until the situation is remidied) to help with debugging and avoid making things worse.

This is done by iteratively checking every directory in the search path, plus checking for the usual static install path without needing it explicitly specified. On regular runs without the issue at hand, this just makes the initial startup of the script a tiny bit slower (less than 0.01% in a Docker container on my laptop, likely similar on most other systems). On systems with multiple conflicting installs of the agent in the system search paths, it will instead bail at the second one it finds and report the issue.

##### Test Plan

The easiest way to test this is to install on a system that uses native packages, and then manually run a static install archive on the same system (not with the kickstart script, but by executing the `.run` file directly).

Without this PR, strange things happen when you try to use the kickstart script for anything on such a system (most notably, the static install will be completely untouched).

With this PR, such a setup should result in the kickstart script bailing out very early on with a fatal error mentioning that there are two installs of Netdata on the system.