### PR TITLE
Change the workflow on how we set the right permissions for perf-plugin

### DIFF
--- a/contrib/debian/netdata-plugin-perf.postinst
+++ b/contrib/debian/netdata-plugin-perf.postinst
@@ -9,14 +9,10 @@ case "$1" in
 
     if capsh --supports=cap_perfmon 2>/dev/null; then
         setcap cap_perfmon+ep /usr/libexec/netdata/plugins.d/perf.plugin
-        ret="$?"
     else
-        setcap cap_sys_admin+ep /usr/libexec/netdata/plugins.d/perf.plugin
-        ret="$?"
-    fi
-
-    if [ "${ret}" -ne 0 ]; then
-        chmod -f 4750 /usr/libexec/netdata/plugins.d/perf.plugin
+        if ! setcap cap_sys_admin+ep /usr/libexec/netdata/plugins.d/perf.plugin; then
+            chmod -f 4750 /usr/libexec/netdata/plugins.d/perf.plugin
+        fi
     fi
     ;;
 esac


### PR DESCRIPTION
##### Summary
The current workflow has a flaw, the post installation script tries to set capabilities without making sure that the system supports them, so the script fails. 

The new workflow follows the least privileged approach. Uses the `CAP_PERFMON` in systems that support it and if it fails to set `CAP_SYS_ADMIN` then sets the setuid bit.

 
##### Test Plan

On a deb based environment without support for CAPS

1. Build native packages locally for your arch https://github.com/netdata/netdata/blob/master/packaging/building-native-packages-locally.md 
2. Install them.
installation must finish without errors
3 . dpkg --configure -a, must not return any errors.


<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
