### PR TITLE
Fix for AMD GPU drm different format proc file

### DIFF
--- a/collectors/proc.plugin/sys_class_drm.c
+++ b/collectors/proc.plugin/sys_class_drm.c
@@ -648,13 +648,17 @@ static int read_clk_freq_file(procfile **p_ff, const char *const pathname, colle
         *p_ff = procfile_open(pathname, NULL, PROCFILE_FLAG_NO_ERROR_ON_FILE_IO);
         if(unlikely(!*p_ff)) return -2;
     }
-    
+
     if(unlikely(NULL == (*p_ff = procfile_readall(*p_ff)))) return -3;
 
     for(size_t l = 0; l < procfile_lines(*p_ff) ; l++) {
+        char *str_with_units = NULL;
+        if((*p_ff)->lines->lines[l].words >= 3 && !strcmp(procfile_lineword((*p_ff), l, 2), "*")) //format: X: collected_number *
+            str_with_units = procfile_lineword((*p_ff), l, 1);
+        else if ((*p_ff)->lines->lines[l].words == 2 && !strcmp(procfile_lineword((*p_ff), l, 1), "*")) //format:   collected_number *
+            str_with_units = procfile_lineword((*p_ff), l, 0);
 
-        if((*p_ff)->lines->lines[l].words >= 3 && !strcmp(procfile_lineword((*p_ff), l, 2), "*")){
-            char *str_with_units = procfile_lineword((*p_ff), l, 1);
+        if (str_with_units) {
             char *delim = strchr(str_with_units, 'M');
             char str_without_units[10];
             memcpy(str_without_units, str_with_units, delim - str_with_units);


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes #16530 

Our code for AMD gpu's is trying to read a proc file in format:

```
0: 1333Mhz *
1: 1333Mhz *
2: 933Mhz 
3: 400Mhz 
```

Sometimes, as in the case of #16530 the format can be:

```
3: 1667Mhz
   1666Mhz *
```

This PR adds a small check to also read the file if present in the second format.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

If you have an AMD gpu, check either `/sys/class/drm/card0/device/pp_dpm_mclk` or `/sys/class/drm/card0/device/pp_dpm_sclk`.

If one of those is in the second format above, it will likely crash. With this PR it should not.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
