### PR TITLE
Make  the systemd-journal mandatory package on Centos 7  and Amazon linux 2

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -173,9 +173,7 @@ Suggests: %{name}-plugin-cups = %{version}
 Recommends: %{name}-plugin-systemd-journal = %{version}
 Recommends: %{name}-plugin-logs-management = %{version}
 %else
-Suggests: %{name}-plugin-cups = %{version}
 Requires: %{name}-plugin-systemd-journal = %{version}
-Recommends: %{name}-plugin-logs-management = %{version}
 %endif
 
 


### PR DESCRIPTION
##### Summary

Switch the package dependencies on centos 7 and Amazon linux 2;  make the systemd-journal plugin hard dependency

In 1f19d17da7b75e699e18a6c7b6ca3d4e5a40b7df  I removed the check (about centos ver 6) is this a garbage or am I missing something? 

##### Test Plan

Build native packages for CentOS 7 and try to install them without specifying the systemd-journal plugin, it should complain.


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
