### PR TITLE
Fix release metadata workflow

### DIFF
--- a/.github/workflows/monitor-releases.yml
+++ b/.github/workflows/monitor-releases.yml
@@ -19,7 +19,6 @@ concurrency: # This keeps multiple instances of the job from running concurrentl
 jobs:
   update-stable-agents-metadata:
     name: update-stable-agents-metadata
-    if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
##### Summary

Yesterday on the release, this workflow was skipped, probably due to the fact the the event trigger don't specify a branch, that's why I strongly believe that this PR will fix the issue 

CC @Ferroin 

