### PR TITLE
Resolve issue on startup in servers with 1 core

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -80,7 +80,12 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
     UNUSED(argc);
     UNUSED(column);
 
-    time_t last_connected =  (time_t) (argv[IDX_LAST_CONNECTED] ? str2uint64_t(argv[IDX_LAST_CONNECTED], NULL) : 0);
+    time_t last_connected =
+        (time_t)(argv[IDX_LAST_CONNECTED] ? str2uint64_t(argv[IDX_LAST_CONNECTED], NULL) : now_realtime_sec());
+
+    if (!last_connected)
+        last_connected = now_realtime_sec();
+
     time_t age = now_realtime_sec() - last_connected;
     int is_ephemeral = 0;
 

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -81,7 +81,7 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
     UNUSED(column);
 
     time_t last_connected =
-        (time_t)(argv[IDX_LAST_CONNECTED] ? str2uint64_t(argv[IDX_LAST_CONNECTED], NULL) : now_realtime_sec());
+        (time_t)(argv[IDX_LAST_CONNECTED] ? str2uint64_t(argv[IDX_LAST_CONNECTED], NULL) : 0);
 
     if (!last_connected)
         last_connected = now_realtime_sec();

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -1288,6 +1288,8 @@ static void start_all_host_load_context(uv_work_t *req __maybe_unused)
     RRDHOST *host;
 
     size_t max_threads = MIN(get_netdata_cpus() / 2, 6);
+    if (max_threads < 1)
+        max_threads = 1;
     nd_log(NDLS_DAEMON, NDLP_DEBUG, "METADATA: Using %zu threads for context loading", max_threads);
     struct host_context_load_thread *hclt = callocz(max_threads, sizeof(*hclt));
 


### PR DESCRIPTION
##### Summary
- Use at least one thread to do context load
- Check for uninitialized last connected timestamp on startup when creating archived hosts to prevent accidental removal when the host is also marked as ephemeral.

Fixes #16559