### PR TITLE
Remove Netdata packages from APT cache when attempting to install.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1356,6 +1356,14 @@ check_special_native_deps() {
   fi
 }
 
+cleanup_apt_cache() {
+    cache_dir="/var/cache/apt/archives"
+
+    if [ -d "${cache_dir}" ]; then
+        find "${cache_dir}" -t file -name 'netdata*.deb' -delete
+    fi
+}
+
 common_rpm_opts() {
   pkg_type="rpm"
   pkg_suffix=".noarch"
@@ -1422,6 +1430,7 @@ try_package_install() {
         install_subcmd="install"
       fi
       needs_early_refresh=1
+      needs_apt_cache_cleanup=1
       pm_cmd="apt-get"
       repo_subcmd="update"
       pkg_type="deb"
@@ -1519,6 +1528,10 @@ try_package_install() {
       if ! run_as_root env ${env} ${pm_cmd} ${repo_subcmd} ${repo_update_opts}; then
         warning "${failed_refresh_msg}"
         return 2
+      fi
+
+      if [ -n "${needs_apt_cache_cleanup}" ]; then
+        cleanup_apt_cache
       fi
     fi
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1360,7 +1360,7 @@ cleanup_apt_cache() {
     cache_dir="/var/cache/apt/archives"
 
     if [ -d "${cache_dir}" ]; then
-        run_as_root find "${cache_dir}" -t file -name 'netdata*.deb' -delete
+        run_as_root find "${cache_dir}" -type f -name 'netdata*.deb' -delete
     fi
 }
 

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1360,7 +1360,7 @@ cleanup_apt_cache() {
     cache_dir="/var/cache/apt/archives"
 
     if [ -d "${cache_dir}" ]; then
-        find "${cache_dir}" -t file -name 'netdata*.deb' -delete
+        run_as_root find "${cache_dir}" -t file -name 'netdata*.deb' -delete
     fi
 }
 


### PR DESCRIPTION
##### Summary

This should help resolve some issues we have with installing when dealing with unclean caches after dist-upgrades.

##### Test Plan

Actually testing this properly requires manually populating the APT cache of a Debian or Ubuntu system with an incorrect repository config package prior to attempting to install Netdata on the system.

Without this fix, the incorrect package will be what gets installed, and installing with native packages will fail.

With this fix, the correct package should be installed, and installing with native packages should succeed.
