### PR TITLE
fix cpu arch/ram/disk values in buildinfo

### DIFF
--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -343,7 +343,7 @@ static struct {
                 .json = "cpu_frequency",
                 .value = "unknown",
         },
-        [BIB_HW_RAM_SIZE] = {
+        [BIB_HW_ARCHITECTURE] = {
                 .category = BIC_HARDWARE,
                 .type = BIT_STRING,
                 .analytics = NULL,
@@ -351,7 +351,7 @@ static struct {
                 .json = "cpu_architecture",
                 .value = "unknown",
         },
-        [BIB_HW_DISK_SPACE] = {
+        [BIB_HW_RAM_SIZE] = {
                 .category = BIC_HARDWARE,
                 .type = BIT_STRING,
                 .analytics = NULL,
@@ -359,7 +359,7 @@ static struct {
                 .json = "ram",
                 .value = "unknown",
         },
-        [BIB_HW_ARCHITECTURE] = {
+        [BIB_HW_DISK_SPACE] = {
                 .category = BIC_HARDWARE,
                 .type = BIT_STRING,
                 .analytics = NULL,


### PR DESCRIPTION
##### Summary

Fixes this issue in buildinfo

```
    CPU Architecture ___________________________________________ : 33652752384
    RAM Bytes __________________________________________________ : 214748364800
    Disk Capacity ______________________________________________ : x86_64
```

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
