### PR TITLE
Fix memory leak during host chart label cleanup

### DIFF
--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -1474,12 +1474,11 @@ static void start_metadata_hosts(uv_work_t *req __maybe_unused)
             char *machine_guid = *PValue;
 
             host = rrdhost_find_by_guid(machine_guid);
-            if (unlikely(host))
-                continue;
-
-            uuid_t host_uuid;
-            if (!uuid_parse(machine_guid, host_uuid))
-                delete_host_chart_labels(&host_uuid);
+            if (likely(!host)) {
+                uuid_t host_uuid;
+                if (!uuid_parse(machine_guid, host_uuid))
+                    delete_host_chart_labels(&host_uuid);
+            }
 
             freez(machine_guid);
         }


### PR DESCRIPTION
##### Summary
There is a memory leak that can occur if during an ephemeral host (child) chart label cleanup the host happens to reconnect.


