### PR TITLE
make debugfs exit on sigpipe

### DIFF
--- a/collectors/debugfs.plugin/debugfs_plugin.c
+++ b/collectors/debugfs.plugin/debugfs_plugin.c
@@ -235,6 +235,13 @@ int main(int argc, char **argv)
             netdata_log_info("all modules are disabled, exiting...");
             return 1;
         }
+
+        fprintf(stdout, "\n");
+        fflush(stdout);
+        if (ferror(stdout) && errno == EPIPE) {
+            netdata_log_info("error writing to stdout: EPIPE. Exiting...");
+            break;
+        }
     }
 
     fprintf(stdout, "EXIT\n");

--- a/collectors/debugfs.plugin/debugfs_plugin.c
+++ b/collectors/debugfs.plugin/debugfs_plugin.c
@@ -239,8 +239,8 @@ int main(int argc, char **argv)
         fprintf(stdout, "\n");
         fflush(stdout);
         if (ferror(stdout) && errno == EPIPE) {
-            netdata_log_info("error writing to stdout: EPIPE. Exiting...");
-            break;
+            netdata_log_error("error writing to stdout: EPIPE. Exiting...");
+            return 1;
         }
     }
 


### PR DESCRIPTION
##### Summary

debugfs.plugin doesn't exit if you:

 - Start Netdata manually.
 - kill -9 $(pidof netdata)

This PR fixes it. 

##### Test Plan

Start Netdata manually, kill the main Netdata process, and make sure debugfs exits. I tested both from source and static installs.


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
