### PR TITLE
disable cpu per core metrics by default

### DIFF
--- a/collectors/proc.plugin/proc_interrupts.c
+++ b/collectors/proc.plugin/proc_interrupts.c
@@ -60,7 +60,7 @@ int do_proc_interrupts(int update_every, usec_t dt) {
     struct interrupt *irrs = NULL;
 
     if(unlikely(do_per_core == CONFIG_BOOLEAN_INVALID))
-        do_per_core = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_PROC_INTERRUPTS, "interrupts per core", CONFIG_BOOLEAN_AUTO);
+        do_per_core = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_PROC_INTERRUPTS, "interrupts per core", CONFIG_BOOLEAN_NO);
 
     if(unlikely(!ff)) {
         char filename[FILENAME_MAX + 1];

--- a/collectors/proc.plugin/proc_net_softnet_stat.c
+++ b/collectors/proc.plugin/proc_net_softnet_stat.c
@@ -24,7 +24,10 @@ int do_proc_net_softnet_stat(int update_every, usec_t dt) {
     static size_t allocated_lines = 0, allocated_columns = 0;
     static uint32_t *data = NULL;
 
-    if(unlikely(do_per_core == -1)) do_per_core = config_get_boolean("plugin:proc:/proc/net/softnet_stat", "softnet_stat per core", 1);
+    if (unlikely(do_per_core == -1)) {
+        do_per_core =
+            config_get_boolean("plugin:proc:/proc/net/softnet_stat", "softnet_stat per core", CONFIG_BOOLEAN_NO);
+    }
 
     if(unlikely(!ff)) {
         char filename[FILENAME_MAX + 1];

--- a/collectors/proc.plugin/proc_softirqs.c
+++ b/collectors/proc.plugin/proc_softirqs.c
@@ -59,7 +59,7 @@ int do_proc_softirqs(int update_every, usec_t dt) {
     struct interrupt *irrs = NULL;
 
     if(unlikely(do_per_core == CONFIG_BOOLEAN_INVALID))
-        do_per_core = config_get_boolean_ondemand("plugin:proc:/proc/softirqs", "interrupts per core", CONFIG_BOOLEAN_AUTO);
+        do_per_core = config_get_boolean_ondemand("plugin:proc:/proc/softirqs", "interrupts per core", CONFIG_BOOLEAN_NO);
 
     if(unlikely(!ff)) {
         char filename[FILENAME_MAX + 1];

--- a/collectors/proc.plugin/proc_stat.c
+++ b/collectors/proc.plugin/proc_stat.c
@@ -487,7 +487,7 @@ int do_proc_stat(int update_every, usec_t dt) {
 
     if(unlikely(do_cpu == -1)) {
         do_cpu                    = config_get_boolean("plugin:proc:/proc/stat", "cpu utilization", CONFIG_BOOLEAN_YES);
-        do_cpu_cores              = config_get_boolean("plugin:proc:/proc/stat", "per cpu core utilization", CONFIG_BOOLEAN_YES);
+        do_cpu_cores              = config_get_boolean("plugin:proc:/proc/stat", "per cpu core utilization", CONFIG_BOOLEAN_NO);
         do_interrupts             = config_get_boolean("plugin:proc:/proc/stat", "cpu interrupts", CONFIG_BOOLEAN_YES);
         do_context                = config_get_boolean("plugin:proc:/proc/stat", "context switches", CONFIG_BOOLEAN_YES);
         do_forks                  = config_get_boolean("plugin:proc:/proc/stat", "processes started", CONFIG_BOOLEAN_YES);
@@ -508,7 +508,7 @@ int do_proc_stat(int update_every, usec_t dt) {
             do_core_throttle_count = CONFIG_BOOLEAN_AUTO;
             do_package_throttle_count = CONFIG_BOOLEAN_NO;
             do_cpu_freq = CONFIG_BOOLEAN_YES;
-            do_cpuidle = CONFIG_BOOLEAN_YES;
+            do_cpuidle = CONFIG_BOOLEAN_NO;
         }
         if(unlikely(get_system_cpus() > 24)) {
             // the system has too many processors


### PR DESCRIPTION
##### Summary

As announced in the [v1.44.0 release notes](https://github.com/netdata/netdata/releases/tag/v1.44.0#v1440-deprecation-notice), this PR disables per core CPU metrics by default. This change enhances performance and resource utilization.  Summary (per-system) metrics are still collected. 

##### Test Plan

Check per core metrics, should be disabled by default.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
