### PR TITLE
Add Alpine Linux 3.19 to CI.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -30,6 +30,11 @@ include:
     test:
       ebpf-core: true
   - <<: *alpine
+    version: "3.19"
+    support_type: Core
+    notes: ''
+    eol_check: true
+  - <<: *alpine
     version: "3.18"
     support_type: Core
     notes: ''


### PR DESCRIPTION
##### Summary

Released on 2023-12-07.

##### Test Plan

n/a