### PR TITLE
Patch release 1.44.1

### DIFF
--- a/.github/workflows/monitor-releases.yml
+++ b/.github/workflows/monitor-releases.yml
@@ -19,7 +19,6 @@ concurrency: # This keeps multiple instances of the job from running concurrentl
 jobs:
   update-stable-agents-metadata:
     name: update-stable-agents-metadata
-    if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/collectors/debugfs.plugin/debugfs_plugin.c
+++ b/collectors/debugfs.plugin/debugfs_plugin.c
@@ -235,6 +235,13 @@ int main(int argc, char **argv)
             netdata_log_info("all modules are disabled, exiting...");
             return 1;
         }
+
+        fprintf(stdout, "\n");
+        fflush(stdout);
+        if (ferror(stdout) && errno == EPIPE) {
+            netdata_log_error("error writing to stdout: EPIPE. Exiting...");
+            return 1;
+        }
     }
 
     fprintf(stdout, "EXIT\n");

--- a/collectors/proc.plugin/sys_class_drm.c
+++ b/collectors/proc.plugin/sys_class_drm.c
@@ -648,13 +648,17 @@ static int read_clk_freq_file(procfile **p_ff, const char *const pathname, colle
         *p_ff = procfile_open(pathname, NULL, PROCFILE_FLAG_NO_ERROR_ON_FILE_IO);
         if(unlikely(!*p_ff)) return -2;
     }
-    
+
     if(unlikely(NULL == (*p_ff = procfile_readall(*p_ff)))) return -3;
 
     for(size_t l = 0; l < procfile_lines(*p_ff) ; l++) {
+        char *str_with_units = NULL;
+        if((*p_ff)->lines->lines[l].words >= 3 && !strcmp(procfile_lineword((*p_ff), l, 2), "*")) //format: X: collected_number *
+            str_with_units = procfile_lineword((*p_ff), l, 1);
+        else if ((*p_ff)->lines->lines[l].words == 2 && !strcmp(procfile_lineword((*p_ff), l, 1), "*")) //format:   collected_number *
+            str_with_units = procfile_lineword((*p_ff), l, 0);
 
-        if((*p_ff)->lines->lines[l].words >= 3 && !strcmp(procfile_lineword((*p_ff), l, 2), "*")){
-            char *str_with_units = procfile_lineword((*p_ff), l, 1);
+        if (str_with_units) {
             char *delim = strchr(str_with_units, 'M');
             char str_without_units[10];
             memcpy(str_without_units, str_with_units, delim - str_with_units);

--- a/contrib/debian/netdata-plugin-perf.postinst
+++ b/contrib/debian/netdata-plugin-perf.postinst
@@ -7,16 +7,10 @@ case "$1" in
     chown root:netdata /usr/libexec/netdata/plugins.d/perf.plugin
     chmod 0750 /usr/libexec/netdata/plugins.d/perf.plugin
 
-    if capsh --supports=cap_perfmon 2>/dev/null; then
-        setcap cap_perfmon+ep /usr/libexec/netdata/plugins.d/perf.plugin
-        ret="$?"
-    else
-        setcap cap_sys_admin+ep /usr/libexec/netdata/plugins.d/perf.plugin
-        ret="$?"
-    fi
-
-    if [ "${ret}" -ne 0 ]; then
-        chmod -f 4750 /usr/libexec/netdata/plugins.d/perf.plugin
+    if ! setcap cap_perfmon+ep /usr/libexec/netdata/plugins.d/perf.plugin 2>/dev/null; then
+        if ! setcap cap_sys_admin+ep /usr/libexec/netdata/plugins.d/perf.plugin 2>/dev/null; then
+            chmod -f 4750 /usr/libexec/netdata/plugins.d/perf.plugin
+        fi
     fi
     ;;
 esac

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -842,7 +842,6 @@ void set_global_environment() {
     setenv("NETDATA_LIB_DIR", verify_or_create_required_directory(netdata_configured_varlib_dir), 1);
     setenv("NETDATA_LOCK_DIR", verify_or_create_required_directory(netdata_configured_lock_dir), 1);
     setenv("NETDATA_LOG_DIR", verify_or_create_required_directory(netdata_configured_log_dir), 1);
-    setenv("HOME", verify_or_create_required_directory(netdata_configured_home_dir), 1);
     setenv("NETDATA_HOST_PREFIX", netdata_configured_host_prefix, 1);
 
     {

--- a/daemon/buildinfo.c
+++ b/daemon/buildinfo.c
@@ -343,7 +343,7 @@ static struct {
                 .json = "cpu_frequency",
                 .value = "unknown",
         },
-        [BIB_HW_RAM_SIZE] = {
+        [BIB_HW_ARCHITECTURE] = {
                 .category = BIC_HARDWARE,
                 .type = BIT_STRING,
                 .analytics = NULL,
@@ -351,7 +351,7 @@ static struct {
                 .json = "cpu_architecture",
                 .value = "unknown",
         },
-        [BIB_HW_DISK_SPACE] = {
+        [BIB_HW_RAM_SIZE] = {
                 .category = BIC_HARDWARE,
                 .type = BIT_STRING,
                 .analytics = NULL,
@@ -359,7 +359,7 @@ static struct {
                 .json = "ram",
                 .value = "unknown",
         },
-        [BIB_HW_ARCHITECTURE] = {
+        [BIB_HW_DISK_SPACE] = {
                 .category = BIC_HARDWARE,
                 .type = BIT_STRING,
                 .analytics = NULL,

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -80,7 +80,12 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
     UNUSED(argc);
     UNUSED(column);
 
-    time_t last_connected =  (time_t) (argv[IDX_LAST_CONNECTED] ? str2uint64_t(argv[IDX_LAST_CONNECTED], NULL) : 0);
+    time_t last_connected =
+        (time_t)(argv[IDX_LAST_CONNECTED] ? str2uint64_t(argv[IDX_LAST_CONNECTED], NULL) : 0);
+
+    if (!last_connected)
+        last_connected = now_realtime_sec();
+
     time_t age = now_realtime_sec() - last_connected;
     int is_ephemeral = 0;
 

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -1288,6 +1288,8 @@ static void start_all_host_load_context(uv_work_t *req __maybe_unused)
     RRDHOST *host;
 
     size_t max_threads = MIN(get_netdata_cpus() / 2, 6);
+    if (max_threads < 1)
+        max_threads = 1;
     nd_log(NDLS_DAEMON, NDLP_DEBUG, "METADATA: Using %zu threads for context loading", max_threads);
     struct host_context_load_thread *hclt = callocz(max_threads, sizeof(*hclt));
 

--- a/database/sqlite/sqlite_metadata.c
+++ b/database/sqlite/sqlite_metadata.c
@@ -1474,12 +1474,11 @@ static void start_metadata_hosts(uv_work_t *req __maybe_unused)
             char *machine_guid = *PValue;
 
             host = rrdhost_find_by_guid(machine_guid);
-            if (unlikely(host))
-                continue;
-
-            uuid_t host_uuid;
-            if (!uuid_parse(machine_guid, host_uuid))
-                delete_host_chart_labels(&host_uuid);
+            if (likely(!host)) {
+                uuid_t host_uuid;
+                if (!uuid_parse(machine_guid, host_uuid))
+                    delete_host_chart_labels(&host_uuid);
+            }
 
             freez(machine_guid);
         }

--- a/libnetdata/Makefile.am
+++ b/libnetdata/Makefile.am
@@ -41,4 +41,5 @@ SUBDIRS = \
 
 dist_noinst_DATA = \
     README.md \
+    gorilla/README.md \
     $(NULL)

--- a/libnetdata/gorilla/README.md
+++ b/libnetdata/gorilla/README.md
@@ -1,0 +1,39 @@
+# Gorilla compression and decompression
+
+This provides an alternative way of representing values stored in database
+pages. Instead of allocating and using a page of fixed size, ie. 4096 bytes,
+the Gorilla implementation adds support for dynamically sized pages that
+contain a variable number of Gorilla buffers.
+
+Each buffer takes 512 bytes and compresses incoming data using the Gorilla
+compression:
+
+- The very first value is stored as it is.
+- For each new value, Gorilla compression doesn't store the value itself. Instead,
+it computes the difference (XOR) between the new value and the previous value.
+- If the XOR result is zero (meaning the new value is identical to the previous
+value), we store just a single bit set to `1`.
+- If the XOR result is not zero (meaning the new value differs from the previous):
+  - We store a `0` bit to indicate the change.
+  - We compute the leading-zero count (LZC) of the XOR result, and compare it
+    with the previous LZC. If the two LZCs are equal we store a `1` bit.
+  - If the LZCs are different we use 5 bits to store the new LZC, and we store
+    the rest of the value (ie. without its LZC) in the buffer.
+
+A Gorilla page can have multiple Gorilla buffers. If the values of a metric
+are highly compressible, just one Gorilla buffer is able to store all the values
+that otherwise would require a regular 4096 byte page, ie. we can use just 512
+bytes instead. In the worst case scenario (for metrics whose values are not
+compressible at all), a Gorilla page might end up having `9` Gorilla buffers,
+consuming 4608 bytes. In practice, this is pretty rare and does not negate
+the effect of compression for the metrics.
+
+When a gorilla page is full, ie. it contains 1024 slots/values, we serialize
+the linked-list of gorilla buffers directly to disk. During deserialization,
+eg. when performing a DBEngine query, the Gorilla page is loaded from the disk and
+its linked-list entries are patched to point to the new memory allocated for
+serving the query results.
+
+Overall, on a real-agent the Gorilla compression scheme reduces memory
+consumption approximately by ~30%, which can be several GiB of RAM for parents
+having hundreds, or even thousands of children streaming to them.

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -168,10 +168,12 @@ Requires: %{name}-plugin-nfacct = %{version}
 %if 0%{?_have_freeipmi} && 0%{?centos_ver} != 6 && 0%{?centos_ver} != 7 && 0%{?amazon_linux} != 2
 Suggests: %{name}-plugin-freeipmi = %{version}
 %endif
-%if 0%{?centos_ver} != 6 && 0%{?centos_ver} != 7 && 0%{?amazon_linux} != 2
+%if 0%{?centos_ver} != 7 && 0%{?amazon_linux} != 2
 Suggests: %{name}-plugin-cups = %{version}
 Recommends: %{name}-plugin-systemd-journal = %{version}
 Recommends: %{name}-plugin-logs-management = %{version}
+%else
+Requires: %{name}-plugin-systemd-journal = %{version}
 %endif
 
 

--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -739,9 +739,11 @@ if [ -n "${NETDATA_PREFIX}" ] && [ -d "${NETDATA_PREFIX}" ] && [ "netdata" = "$(
 else
   rm_file "${NETDATA_PREFIX}/usr/sbin/netdata"
   rm_file "${NETDATA_PREFIX}/usr/sbin/netdatacli"
+  rm_file "${NETDATA_PREFIX}/usr/sbin/netdata-claim.sh"
+  rm_file "${NETDATA_PREFIX}/usr/sbin/log2journal"
+  rm_file "${NETDATA_PREFIX}/usr/sbin/systemd-cat-native"
   rm_file "/tmp/netdata-ipc"
   rm_file "/tmp/netdata-service-cmds"
-  rm_file "${NETDATA_PREFIX}/usr/sbin/netdata-claim.sh"
   rm_dir "${NETDATA_PREFIX}/usr/share/netdata"
   rm_dir "${NETDATA_PREFIX}/usr/libexec/netdata"
   rm_dir "${NETDATA_PREFIX}/var/lib/netdata"

--- a/system/Makefile.am
+++ b/system/Makefile.am
@@ -3,6 +3,7 @@
 
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 CLEANFILES = \
+    install-service.sh \
     cron/netdata-updater-daily \
     freebsd/rc.d/netdata \
     initd/init.d/netdata \


### PR DESCRIPTION
##### Summary
- uninstaller remove log2journal and systemd-cat-native (#16585)
- Change the workflow on how we set the right permissions for perf-plugin (#16558)
- make debugfs exit on sigpipe (#16569)
- Fix memory leak during host chart label cleanup (#16568)
- fix cpu arch/ram/disk values in buildinfo (#16567)
- Resolve issue on startup in servers with 1 core (#16565)
- Fix for AMD GPU drm different format proc file (#16561)
- set "HOME" after switching to netdata user (#16548)
- Fix release metadata workflow (#16563)
- Make  the systemd-journal mandatory package on Centos 7 and Amazon linux 2 (#16562)
- Update README.md
- Add README for gorilla (#16553)

