### PR TITLE
Handle coverity issues related to Y2K38_SAFETY

### DIFF
--- a/database/engine/cache.c
+++ b/database/engine/cache.c
@@ -1949,13 +1949,13 @@ time_t pgc_page_end_time_s(PGC_PAGE *page) {
     return page->end_time_s;
 }
 
-time_t pgc_page_update_every_s(PGC_PAGE *page) {
+uint32_t pgc_page_update_every_s(PGC_PAGE *page) {
     return page->update_every_s;
 }
 
-time_t pgc_page_fix_update_every(PGC_PAGE *page, time_t update_every_s) {
+uint32_t pgc_page_fix_update_every(PGC_PAGE *page, uint32_t update_every_s) {
     if(page->update_every_s == 0)
-        page->update_every_s = (uint32_t) update_every_s;
+        page->update_every_s = update_every_s;
 
     return page->update_every_s;
 }

--- a/database/engine/cache.h
+++ b/database/engine/cache.h
@@ -27,7 +27,7 @@ typedef struct pgc_entry {
     time_t end_time_s;          // the end time of the page
     size_t size;                // the size in bytes of the allocation, outside the cache
     void *data;                 // a pointer to data outside the cache
-    uint32_t update_every_s;      // the update every of the page
+    uint32_t update_every_s;    // the update every of the page
     bool hot;                   // true if this entry is currently being collected
     uint8_t *custom_data;
 } PGC_ENTRY;
@@ -210,8 +210,8 @@ Word_t pgc_page_section(PGC_PAGE *page);
 Word_t pgc_page_metric(PGC_PAGE *page);
 time_t pgc_page_start_time_s(PGC_PAGE *page);
 time_t pgc_page_end_time_s(PGC_PAGE *page);
-time_t pgc_page_update_every_s(PGC_PAGE *page);
-time_t pgc_page_fix_update_every(PGC_PAGE *page, time_t update_every_s);
+uint32_t pgc_page_update_every_s(PGC_PAGE *page);
+uint32_t pgc_page_fix_update_every(PGC_PAGE *page, uint32_t update_every_s);
 time_t pgc_page_fix_end_time_s(PGC_PAGE *page, time_t end_time_s);
 void *pgc_page_data(PGC_PAGE *page);
 void *pgc_page_custom_data(PGC *cache, PGC_PAGE *page);

--- a/database/engine/journalfile.c
+++ b/database/engine/journalfile.c
@@ -934,6 +934,8 @@ static int journalfile_v2_validate(void *data_start, size_t journal_v2_file_size
     netdata_log_info("DBENGINE: checking %u metrics that exist in the journal", j2_header->metric_count);
     for (entries = 0; entries < j2_header->metric_count; entries++) {
 
+        char uuid_str[UUID_STR_LEN];
+        uuid_unparse_lower(metric->uuid, uuid_str);
         struct journal_page_header *metric_list_header = (void *) (data_start + metric->page_offset);
         struct journal_page_header local_metric_list_header = *metric_list_header;
 

--- a/database/engine/journalfile.c
+++ b/database/engine/journalfile.c
@@ -700,7 +700,7 @@ static void journalfile_restore_extent_metadata(struct rrdengine_instance *ctx, 
                     .section = (Word_t)ctx,
                     .first_time_s = vd.start_time_s,
                     .last_time_s = vd.end_time_s,
-                    .latest_update_every_s = (uint32_t) vd.update_every_s,
+                    .latest_update_every_s = vd.update_every_s,
             };
 
             bool added;
@@ -934,8 +934,6 @@ static int journalfile_v2_validate(void *data_start, size_t journal_v2_file_size
     netdata_log_info("DBENGINE: checking %u metrics that exist in the journal", j2_header->metric_count);
     for (entries = 0; entries < j2_header->metric_count; entries++) {
 
-        char uuid_str[UUID_STR_LEN];
-        uuid_unparse_lower(metric->uuid, uuid_str);
         struct journal_page_header *metric_list_header = (void *) (data_start + metric->page_offset);
         struct journal_page_header local_metric_list_header = *metric_list_header;
 
@@ -1226,7 +1224,7 @@ void *journalfile_v2_write_data_page(struct journal_v2_header *j2_header, void *
     data_page->delta_end_s = (uint32_t) (page_info->end_time_s - (time_t) (j2_header->start_time_ut) / USEC_PER_SEC);
     data_page->extent_index = page_info->extent_index;
 
-    data_page->update_every_s = (uint32_t) page_info->update_every_s;
+    data_page->update_every_s = page_info->update_every_s;
     data_page->page_length = (uint16_t) (ei ? ei->page_length : page_info->page_length);
     data_page->type = 0;
 
@@ -1252,7 +1250,7 @@ static void *journalfile_v2_write_descriptors(struct journal_v2_header *j2_heade
         page_info = *PValue;
         // Write one descriptor and return the next data page location
         data_page = journalfile_v2_write_data_page(j2_header, (void *) data_page, page_info);
-        update_every_s = (uint32_t) page_info->update_every_s;
+        update_every_s = page_info->update_every_s;
         if (NULL == data_page)
             break;
     }

--- a/database/engine/metric.h
+++ b/database/engine/metric.h
@@ -70,12 +70,12 @@ bool mrg_metric_set_clean_latest_time_s(MRG *mrg, METRIC *metric, time_t latest_
 bool mrg_metric_set_hot_latest_time_s(MRG *mrg, METRIC *metric, time_t latest_time_s);
 time_t mrg_metric_get_latest_time_s(MRG *mrg, METRIC *metric);
 
-bool mrg_metric_set_update_every(MRG *mrg, METRIC *metric, time_t update_every_s);
-bool mrg_metric_set_update_every_s_if_zero(MRG *mrg, METRIC *metric, time_t update_every_s);
-time_t mrg_metric_get_update_every_s(MRG *mrg, METRIC *metric);
+bool mrg_metric_set_update_every(MRG *mrg, METRIC *metric, uint32_t update_every_s);
+bool mrg_metric_set_update_every_s_if_zero(MRG *mrg, METRIC *metric, uint32_t update_every_s);
+uint32_t mrg_metric_get_update_every_s(MRG *mrg, METRIC *metric);
 
-void mrg_metric_expand_retention(MRG *mrg, METRIC *metric, time_t first_time_s, time_t last_time_s, time_t update_every_s);
-void mrg_metric_get_retention(MRG *mrg, METRIC *metric, time_t *first_time_s, time_t *last_time_s, time_t *update_every_s);
+void mrg_metric_expand_retention(MRG *mrg, METRIC *metric, time_t first_time_s, time_t last_time_s, uint32_t update_every_s);
+void mrg_metric_get_retention(MRG *mrg, METRIC *metric, time_t *first_time_s, time_t *last_time_s, uint32_t *update_every_s);
 bool mrg_metric_zero_disk_retention(MRG *mrg __maybe_unused, METRIC *metric);
 
 bool mrg_metric_set_writer(MRG *mrg, METRIC *metric);

--- a/database/engine/pagecache.h
+++ b/database/engine/pagecache.h
@@ -54,9 +54,9 @@ struct page_details_control;
 void rrdeng_prep_wait(struct page_details_control *pdc);
 void rrdeng_prep_query(struct page_details_control *pdc, bool worker);
 void pg_cache_preload(struct rrdeng_query_handle *handle);
-struct pgc_page *pg_cache_lookup_next(struct rrdengine_instance *ctx, struct page_details_control *pdc, time_t now_s, time_t last_update_every_s, size_t *entries);
+struct pgc_page *pg_cache_lookup_next(struct rrdengine_instance *ctx, struct page_details_control *pdc, time_t now_s, uint32_t last_update_every_s, size_t *entries);
 void pgc_and_mrg_initialize(void);
 
-void pgc_open_add_hot_page(Word_t section, Word_t metric_id, time_t start_time_s, time_t end_time_s, time_t update_every_s, struct rrdengine_datafile *datafile, uint64_t extent_offset, unsigned extent_size, uint32_t page_length);
+void pgc_open_add_hot_page(Word_t section, Word_t metric_id, time_t start_time_s, time_t end_time_s, uint32_t update_every_s, struct rrdengine_datafile *datafile, uint64_t extent_offset, unsigned extent_size, uint32_t page_length);
 
 #endif /* NETDATA_PAGECACHE_H */

--- a/database/engine/pdc.c
+++ b/database/engine/pdc.c
@@ -628,7 +628,7 @@ void collect_page_flags_to_buffer(BUFFER *wb, RRDENG_COLLECT_PAGE_FLAGS flags) {
         buffer_strcat(wb, "STEP_UNALIGNED");
 }
 
-inline VALIDATED_PAGE_DESCRIPTOR validate_extent_page_descr(const struct rrdeng_extent_page_descr *descr, time_t now_s, time_t overwrite_zero_update_every_s, bool have_read_error) {
+inline VALIDATED_PAGE_DESCRIPTOR validate_extent_page_descr(const struct rrdeng_extent_page_descr *descr, time_t now_s, uint32_t overwrite_zero_update_every_s, bool have_read_error) {
     time_t start_time_s = (time_t) (descr->start_time_ut / USEC_PER_SEC);
 
     time_t end_time_s;
@@ -666,12 +666,12 @@ VALIDATED_PAGE_DESCRIPTOR validate_page(
         uuid_t *uuid,
         time_t start_time_s,
         time_t end_time_s,
-        time_t update_every_s,                  // can be zero, if unknown
+        uint32_t update_every_s,                // can be zero, if unknown
         size_t page_length,
         uint8_t page_type,
         size_t entries,                         // can be zero, if unknown
         time_t now_s,                           // can be zero, to disable future timestamp check
-        time_t overwrite_zero_update_every_s,   // can be zero, if unknown
+        uint32_t overwrite_zero_update_every_s,   // can be zero, if unknown
         bool have_read_error,
         const char *msg,
         RRDENG_COLLECT_PAGE_FLAGS flags) {
@@ -732,7 +732,6 @@ VALIDATED_PAGE_DESCRIPTOR validate_page(
         (now_s && vd.end_time_s > now_s)                        ||
         vd.start_time_s <= 0                                    ||
         vd.end_time_s <= 0                                      ||
-        vd.update_every_s < 0                                   ||
         (vd.start_time_s == vd.end_time_s && vd.entries > 1)    ||
         (vd.update_every_s == 0 && vd.entries > 1))
     {
@@ -797,7 +796,7 @@ VALIDATED_PAGE_DESCRIPTOR validate_page(
             );
         }
         else {
-            const char *err_valid = (vd.is_valid) ? "" : "found invalid, ";
+            const char *err_valid = "";
             const char *err_start = (vd.start_time_s == start_time_s) ? "" : "start time updated, ";
             const char *err_end = (vd.end_time_s == end_time_s) ? "" : "end time updated, ";
             const char *err_update = (vd.update_every_s == update_every_s) ? "" : "update every updated, ";

--- a/database/engine/rrdengine.h
+++ b/database/engine/rrdengine.h
@@ -153,9 +153,9 @@ struct jv2_metrics_info {
 struct jv2_page_info {
     time_t start_time_s;
     time_t end_time_s;
-    time_t update_every_s;
-    size_t page_length;
+    uint32_t update_every_s;
     uint32_t extent_index;
+    size_t page_length;
     void *custom_data;
 
     // private
@@ -217,7 +217,7 @@ struct rrdeng_query_handle {
 
     // internal data
     time_t now_s;
-    time_t dt_s;
+    uint32_t dt_s;
 
     unsigned position;
     unsigned entries;
@@ -481,7 +481,7 @@ struct page_descr_with_data *page_descriptor_get(void);
 typedef struct validated_page_descriptor {
     time_t start_time_s;
     time_t end_time_s;
-    time_t update_every_s;
+    uint32_t update_every_s;
     size_t page_length;
     size_t point_size;
     size_t entries;
@@ -498,16 +498,16 @@ typedef struct validated_page_descriptor {
 VALIDATED_PAGE_DESCRIPTOR validate_page(uuid_t *uuid,
                                         time_t start_time_s,
                                         time_t end_time_s,
-                                        time_t update_every_s,
+                                        uint32_t update_every_s,
                                         size_t page_length,
                                         uint8_t page_type,
                                         size_t entries,
                                         time_t now_s,
-                                        time_t overwrite_zero_update_every_s,
+                                        uint32_t overwrite_zero_update_every_s,
                                         bool have_read_error,
                                         const char *msg,
                                         RRDENG_COLLECT_PAGE_FLAGS flags);
-VALIDATED_PAGE_DESCRIPTOR validate_extent_page_descr(const struct rrdeng_extent_page_descr *descr, time_t now_s, time_t overwrite_zero_update_every_s, bool have_read_error);
+VALIDATED_PAGE_DESCRIPTOR validate_extent_page_descr(const struct rrdeng_extent_page_descr *descr, time_t now_s, uint32_t overwrite_zero_update_every_s, bool have_read_error);
 void collect_page_flags_to_buffer(BUFFER *wb, RRDENG_COLLECT_PAGE_FLAGS flags);
 
 typedef enum {


### PR DESCRIPTION
##### Summary
Update every is stored as uint32_t. This PR touches places where it is treated as time_t and converted back and forth to uint32_t causing coverity warnings. Some fields in structures have been changed to reduce memory usage as well. 
