### PR TITLE
fix: use black version icon for Splunk in order to make it visible

### DIFF
--- a/integrations/cloud-notifications/metadata.yaml
+++ b/integrations/cloud-notifications/metadata.yaml
@@ -378,7 +378,7 @@
     link: 'https://splunk.com/'
     categories:
       - notify.cloud
-    icon_filename: 'splunk.svg'
+    icon_filename: 'splunk-black.svg'
   keywords:
     - Splunk
   overview:


### PR DESCRIPTION
use black version icon for Splunk in order to make it visible on learn website