### PR TITLE
remove v1 dashboard version check from installer

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1988,25 +1988,6 @@ KSM2
   fi
 fi
 
-# -----------------------------------------------------------------------------
-progress "Check version.txt"
-
-if [ ! -s web/gui/version.txt ]; then
-  cat << VERMSG
-
-${TPUT_BOLD}Version update check warning${TPUT_RESET}
-
-The way you downloaded netdata, we cannot find its version. This means the
-Update check on the dashboard, will not work.
-
-If you want to have version update check, please re-install it
-following the procedure in:
-
-https://docs.netdata.cloud/packaging/installer/
-
-VERMSG
-fi
-
 if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/apps.plugin" ]; then
   # -----------------------------------------------------------------------------
   progress "Check apps.plugin"


### PR DESCRIPTION
##### Summary

Generating web/gui/version.txt wasn't implemented in the cmake PR [because wontfix](https://github.com/netdata/netdata/issues/16573).


##### Test Plan

Not needed

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
