### PR TITLE
Remove includes outside of libnetdata.

### DIFF
--- a/collectors/freebsd.plugin/plugin_freebsd.c
+++ b/collectors/freebsd.plugin/plugin_freebsd.c
@@ -91,7 +91,7 @@ void *freebsd_main(void *ptr)
 
     // initialize FreeBSD plugin
     if (freebsd_plugin_init())
-        netdata_cleanup_and_exit(1);
+        netdata_cleanup_and_exit(1, NULL, NULL, NULL);
 
     // check the enabled status for each module
     int i;

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -985,7 +985,7 @@ void analytics_statistic_send(const analytics_statistic_t *statistic) {
         return;
 
     const char *action_result = statistic->result;
-    const char *action_data = statistic->result;
+    const char *action_data = statistic->action_data;
 
     if (!statistic->result)
         action_result = "";

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -594,7 +594,9 @@ void *analytics_main(void *ptr)
 
     analytics_gather_immutable_meta_data();
     analytics_gather_mutable_meta_data();
-    send_statistics("META_START", "-", "-");
+
+    analytics_statistic_t statistic = { "META_START", "-", "-"  };
+    analytics_statistic_send(&statistic);
     analytics_log_data();
 
     sec = 0;
@@ -609,8 +611,11 @@ void *analytics_main(void *ptr)
             continue;
 
         analytics_gather_mutable_meta_data();
-        send_statistics("META", "-", "-");
+
+        analytics_statistic_t statistic = { "META", "-", "-"  };
+        analytics_statistic_send(&statistic);
         analytics_log_data();
+
         sec = 0;
     }
 
@@ -936,7 +941,10 @@ void set_global_environment() {
     setenv("LC_ALL", "C", 1);
 }
 
-void send_statistics(const char *action, const char *action_result, const char *action_data) {
+void analytics_statistic_send(const analytics_statistic_t *statistic) {
+    if (!statistic)
+        return;
+
     static char *as_script;
 
     if (netdata_anonymous_statistics_enabled == -1) {
@@ -973,16 +981,19 @@ void send_statistics(const char *action, const char *action_result, const char *
         freez(optout_file);
     }
 
-    if (!netdata_anonymous_statistics_enabled || !action)
+    if (!netdata_anonymous_statistics_enabled || !statistic->action)
         return;
 
-    if (!action_result)
+    const char *action_result = statistic->result;
+    const char *action_data = statistic->result;
+
+    if (!statistic->result)
         action_result = "";
-    if (!action_data)
+    if (!statistic->data)
         action_data = "";
 
     char *command_to_run = mallocz(
-        sizeof(char) * (strlen(action) + strlen(action_result) + strlen(action_data) + strlen(as_script) +
+        sizeof(char) * (strlen(statistic->action) + strlen(action_result) + strlen(action_data) + strlen(as_script) +
                         analytics_data.data_length + (ANALYTICS_NO_OF_ITEMS * 3) + 15));
     pid_t command_pid;
 
@@ -990,7 +1001,7 @@ void send_statistics(const char *action, const char *action_result, const char *
         command_to_run,
         "%s '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' '%s' ",
         as_script,
-        action,
+        statistic->action,
         action_result,
         action_data,
         analytics_data.netdata_config_stream_enabled,
@@ -1036,7 +1047,7 @@ void send_statistics(const char *action, const char *action_result, const char *
 
     nd_log(NDLS_DAEMON, NDLP_DEBUG,
            "%s '%s' '%s' '%s'",
-           as_script, action, action_result, action_data);
+           as_script, statistic->action, action_result, action_data);
 
     FILE *fp_child_input;
     FILE *fp_child_output = netdata_popen(command_to_run, &command_pid, &fp_child_input);

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -985,7 +985,7 @@ void analytics_statistic_send(const analytics_statistic_t *statistic) {
         return;
 
     const char *action_result = statistic->result;
-    const char *action_data = statistic->action_data;
+    const char *action_data = statistic->data;
 
     if (!statistic->result)
         action_result = "";

--- a/daemon/analytics.h
+++ b/daemon/analytics.h
@@ -78,7 +78,6 @@ struct analytics_data {
 void set_late_global_environment(struct rrdhost_system_info *system_info);
 void analytics_free_data(void);
 void set_global_environment(void);
-void send_statistics(const char *action, const char *action_result, const char *action_data);
 void analytics_log_shell(void);
 void analytics_log_json(void);
 void analytics_log_prometheus(void);
@@ -86,6 +85,14 @@ void analytics_log_dashboard(void);
 void analytics_gather_mutable_meta_data(void);
 void analytics_report_oom_score(long long int score);
 void get_system_timezone(void);
+
+typedef struct {
+    const char *action;
+    const char *result;
+    const char *data;
+} analytics_statistic_t;
+
+void analytics_statistic_send(const analytics_statistic_t *statistic);
 
 extern struct analytics_data analytics_data;
 

--- a/daemon/commands.c
+++ b/daemon/commands.c
@@ -183,7 +183,7 @@ static cmd_status_t cmd_exit_execute(char *args, char **message)
 
     nd_log_limits_unlimited();
     netdata_log_info("COMMAND: Cleaning up to exit.");
-    netdata_cleanup_and_exit(0);
+    netdata_cleanup_and_exit(0, NULL, NULL, NULL);
     exit(0);
 
     return CMD_STATUS_SUCCESS;

--- a/daemon/daemon.h
+++ b/daemon/daemon.h
@@ -7,7 +7,7 @@ int become_user(const char *username, int pid_fd);
 
 int become_daemon(int dont_fork, const char *user);
 
-void netdata_cleanup_and_exit(int i);
+void netdata_cleanup_and_exit(int ret, const char *action, const char *action_result, const char *action_data);
 
 void get_netdata_execution_path(void);
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -309,7 +309,7 @@ static bool service_wait_exit(SERVICE_TYPE service, usec_t timeout_ut) {
 
 void web_client_cache_destroy(void);
 
-void netdata_cleanup_and_exit(int ret) {
+void netdata_cleanup_and_exit(int ret, const char *action, const char *action_result, const char *action_data) {
     usec_t started_ut = now_monotonic_usec();
     usec_t last_ut = started_ut;
     const char *prev_msg = NULL;
@@ -318,7 +318,13 @@ void netdata_cleanup_and_exit(int ret) {
     nd_log_limits_unlimited();
     netdata_log_info("NETDATA SHUTDOWN: initializing shutdown with code %d...", ret);
 
-    send_statistics("EXIT", ret?"ERROR":"OK","-");
+    // send the stat from our caller
+    analytics_statistic_t statistic = { action, action_result, action_data };
+    analytics_statistic_send(&statistic);
+
+    // notify we are exiting
+    statistic = (analytics_statistic_t) {"EXIT", ret?"ERROR":"OK","-"};
+    analytics_statistic_send(&statistic);
 
     delta_shutdown_time("create shutdown file");
 
@@ -2200,11 +2206,15 @@ int main(int argc, char **argv) {
     netdata_log_info("NETDATA STARTUP: completed in %llu ms. Enjoy real-time performance monitoring!", (ready_ut - started_ut) / USEC_PER_MS);
     netdata_ready = true;
 
-    send_statistics("START", "-",  "-");
-    if (crash_detected)
-        send_statistics("CRASH", "-", "-");
-    if (incomplete_shutdown_detected)
-        send_statistics("INCOMPLETE_SHUTDOWN", "-", "-");
+
+    if (crash_detected) {
+        analytics_statistic_t statistic = { "START", "-",  "-" };
+        analytics_statistic_send(&statistic);
+    }
+    if (incomplete_shutdown_detected) {
+        analytics_statistic_t statistic = { "INCOMPLETE_SHUTDOWN", "-", "-" };
+        analytics_statistic_send(&statistic);
+    }
 
     //check if ANALYTICS needs to start
     if (netdata_anonymous_statistics_enabled == 1) {
@@ -2226,7 +2236,9 @@ int main(int argc, char **argv) {
     char filename[FILENAME_MAX + 1];
     snprintfz(filename, FILENAME_MAX, "%s/.aclk_report_sent", netdata_configured_varlib_dir);
     if (netdata_anonymous_statistics_enabled > 0 && access(filename, F_OK)) { // -1 -> not initialized
-        send_statistics("ACLK_DISABLED", "-", "-");
+        analytics_statistic_t statistic = { "ACLK_DISABLED", "-", "-" };
+        analytics_statistic_send(&statistic);
+
         int fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 444);
         if (fd == -1)
             netdata_log_error("Cannot create file '%s'. Please fix this.", filename);

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -2206,14 +2206,15 @@ int main(int argc, char **argv) {
     netdata_log_info("NETDATA STARTUP: completed in %llu ms. Enjoy real-time performance monitoring!", (ready_ut - started_ut) / USEC_PER_MS);
     netdata_ready = true;
 
-
+    analytics_statistic_t start_statistic = { "START", "-",  "-" };
+    analytics_statistic_send(&start_statistic);
     if (crash_detected) {
-        analytics_statistic_t statistic = { "START", "-",  "-" };
-        analytics_statistic_send(&statistic);
+        analytics_statistic_t crash_statistic = { "CRASH", "-",  "-" };
+        analytics_statistic_send(&crash_statistic);
     }
     if (incomplete_shutdown_detected) {
-        analytics_statistic_t statistic = { "INCOMPLETE_SHUTDOWN", "-", "-" };
-        analytics_statistic_send(&statistic);
+        analytics_statistic_t incomplete_shutdown_statistic = { "INCOMPLETE_SHUTDOWN", "-", "-" };
+        analytics_statistic_send(&incomplete_shutdown_statistic);
     }
 
     //check if ANALYTICS needs to start

--- a/daemon/main.h
+++ b/daemon/main.h
@@ -24,7 +24,6 @@ struct option_def {
 
 void cancel_main_threads(void);
 int killpid(pid_t pid);
-void netdata_cleanup_and_exit(int ret) NORETURN;
 
 typedef enum {
     ABILITY_DATA_QUERIES          = (1 << 0),

--- a/daemon/signals.c
+++ b/daemon/signals.c
@@ -227,7 +227,7 @@ void signals_handle(void) {
                                 nd_log_limits_unlimited();
                                 netdata_log_info("SIGNAL: Received %s. Cleaning up to exit...", name);
                                 commands_exit();
-                                netdata_cleanup_and_exit(0);
+                                netdata_cleanup_and_exit(0, NULL, NULL, NULL);
                                 exit(0);
                                 break;
 

--- a/exporting/exporting_engine.c
+++ b/exporting/exporting_engine.c
@@ -184,7 +184,9 @@ void *exporting_main(void *ptr)
 
     if (init_connectors(engine) != 0) {
         netdata_log_error("EXPORTING: cannot initialize exporting connectors");
-        send_statistics("EXPORTING_START", "FAIL", "-");
+
+        analytics_statistic_t statistic = { "EXPORTING_START", "FAIL", "-" };
+        analytics_statistic_send(&statistic);
         goto cleanup;
     }
 

--- a/exporting/init_connectors.c
+++ b/exporting/init_connectors.c
@@ -99,7 +99,8 @@ int init_connectors(struct engine *engine)
         snprintfz(threadname, NETDATA_THREAD_NAME_MAX, "EXPORTING-%zu", instance->index);
         uv_thread_set_name_np(instance->thread, threadname);
 
-        send_statistics("EXPORTING_START", "OK", instance->config.type_name);
+        analytics_statistic_t statistic = { "EXPORTING_START", "OK", instance->config.type_name };
+        analytics_statistic_send(&statistic);
     }
 
     return 0;

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -690,7 +690,7 @@ typedef enum {
 } OPEN_FD_EXCLUDE;
 void for_each_open_fd(OPEN_FD_ACTION action, OPEN_FD_EXCLUDE excluded_fds);
 
-void netdata_cleanup_and_exit(int ret) NORETURN;
+void netdata_cleanup_and_exit(int ret, const char *action, const char *action_result, const char *action_data) NORETURN;
 extern char *netdata_configured_host_prefix;
 
 #define XXH_INLINE_ALL

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -5,7 +5,6 @@
 #define SD_JOURNAL_SUPPRESS_LOCATION
 
 #include "../libnetdata.h"
-#include <daemon/main.h>
 
 #ifdef __FreeBSD__
 #include <sys/endian.h>
@@ -2282,7 +2281,6 @@ void netdata_logger_fatal( const char *file, const char *function, const unsigne
 
     char action_data[70+1];
     snprintfz(action_data, 70, "%04lu@%-10.10s:%-15.15s/%d", line, file, function, saved_errno);
-    char action_result[60+1];
 
     const char *thread_tag = thread_log_fields[NDF_THREAD_TAG].entry.txt;
     if(!thread_tag)
@@ -2296,8 +2294,8 @@ void netdata_logger_fatal( const char *file, const char *function, const unsigne
     if(strncmp(thread_tag, THREAD_TAG_STREAM_SENDER, strlen(THREAD_TAG_STREAM_SENDER)) == 0)
         tag_to_send = THREAD_TAG_STREAM_SENDER;
 
+    char action_result[60+1];
     snprintfz(action_result, 60, "%s:%s", program_name, tag_to_send);
-    send_statistics("FATAL", action_result, action_data);
 
 #ifdef HAVE_BACKTRACE
     int fd = nd_log.sources[NDLS_DAEMON].fd;
@@ -2316,7 +2314,7 @@ void netdata_logger_fatal( const char *file, const char *function, const unsigne
     abort();
 #endif
 
-    netdata_cleanup_and_exit(1);
+    netdata_cleanup_and_exit(1, "FATAL", action_result, action_data);
 }
 
 // ----------------------------------------------------------------------------

--- a/libnetdata/required_dummies.h
+++ b/libnetdata/required_dummies.h
@@ -4,16 +4,13 @@
 #define NETDATA_LIB_DUMMIES_H 1
 
 // callback required by fatal()
-void netdata_cleanup_and_exit(int ret)
-{
-    exit(ret);
-}
-
-void send_statistics(const char *action, const char *action_result, const char *action_data)
+void netdata_cleanup_and_exit(int ret, const char *action, const char *action_result, const char *action_data)
 {
     (void)action;
     (void)action_result;
     (void)action_data;
+
+    exit(ret);
 }
 
 // callbacks required by popen()

--- a/libnetdata/threads/threads.h
+++ b/libnetdata/threads/threads.h
@@ -59,6 +59,10 @@ struct netdata_static_thread {
 const char *netdata_thread_tag(void);
 int netdata_thread_tag_exists(void);
 
+#define THREAD_TAG_STREAM_RECEIVER "RCVR"
+#define THREAD_TAG_STREAM_SENDER "SNDR"
+
+
 size_t netdata_threads_init(void);
 void netdata_threads_init_after_fork(size_t stacksize);
 void netdata_threads_init_for_external_plugins(size_t stacksize);

--- a/streaming/rrdpush.h
+++ b/streaming/rrdpush.h
@@ -458,9 +458,6 @@ void rrdpush_send_claimed_id(RRDHOST *host);
 void rrdpush_send_global_functions(RRDHOST *host);
 void rrdpush_send_dyncfg(RRDHOST *host);
 
-#define THREAD_TAG_STREAM_RECEIVER "RCVR" // "[host]" is appended
-#define THREAD_TAG_STREAM_SENDER "SNDR" // "[host]" is appended
-
 int rrdpush_receiver_thread_spawn(struct web_client *w, char *decoded_query_string, void *h2o_ctx);
 void rrdpush_sender_thread_stop(RRDHOST *host, STREAM_HANDSHAKE reason, bool wait);
 

--- a/web/server/web_client.c
+++ b/web/server/web_client.c
@@ -1715,7 +1715,7 @@ static inline int web_client_process_url(RRDHOST *host, struct web_client *w, ch
                 buffer_strcat(w->response.data, "I am doing it already");
 
             netdata_log_error("web request to exit received.");
-            netdata_cleanup_and_exit(0);
+            netdata_cleanup_and_exit(0, NULL, NULL, NULL);
             return HTTP_RESP_OK;
         }
         else if(unlikely(hash == hash_debug && strcmp(tok, "debug") == 0)) {


### PR DESCRIPTION
##### Summary

libnetdata ended up using the header daemon/main.h.

This commit tries to resolve this issue by:

  - Moving the thread tags under libnetdata/threads/threads.h
  - Dropping the definition of `send_analytics` from libnetdata/ and, thus, the requirement for an extra dummy function.
  - Adding a new analytics_statistic_send() function.
  - Changing netdata_cleanup_and_exit() to accept the raw parts of an analytics statistic.

After this whole ordeal, only the declaration of netdata_cleanup_and_exit() is required from libnetdata/

##### Test Plan

- CI jobs
- Start/stop the agent.