### PR TITLE
cmake: make WEB_DIR configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1746,6 +1746,7 @@ set(LOG_DIR "${CMAKE_INSTALL_PREFIX}/var/log/netdata")
 set(PLUGINS_DIR "${CMAKE_INSTALL_PREFIX}/usr/libexec/netdata/plugins.d")
 set(VARLIB_DIR "${CMAKE_INSTALL_PREFIX}/var/lib/netdata")
 
+# A non-default value is only used when building Debian packages (/var/lib/netdata/www)
 if(NOT DEFINED WEB_DIR)
   set(WEB_DIR "usr/share/netdata/web")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1744,8 +1744,16 @@ set(CONFIG_DIR "${CMAKE_INSTALL_PREFIX}/etc/netdata")
 set(LIBCONFIG_DIR "${CMAKE_INSTALL_PREFIX}/usr/lib/netdata/conf.d")
 set(LOG_DIR "${CMAKE_INSTALL_PREFIX}/var/log/netdata")
 set(PLUGINS_DIR "${CMAKE_INSTALL_PREFIX}/usr/libexec/netdata/plugins.d")
-set(WEB_DIR "${CMAKE_INSTALL_PREFIX}/usr/share/netdata/web")
 set(VARLIB_DIR "${CMAKE_INSTALL_PREFIX}/var/lib/netdata")
+
+if(NOT DEFINED WEB_DIR)
+  set(WEB_DIR "usr/share/netdata/web")
+else()
+  string(REGEX REPLACE "^/" "" WEB_DIR "${WEB_DIR}")
+endif()
+set(WEB_DEST "${WEB_DIR}")
+set(WEB_DIR "${CMAKE_INSTALL_PREFIX}/${WEB_DEST}")
+
 
 set(CONFIGURE_COMMAND "dummy-configure-command")
 if (NOT NETDATA_USER)
@@ -1777,7 +1785,7 @@ install(DIRECTORY DESTINATION etc/netdata/ssl)
 install(DIRECTORY DESTINATION etc/netdata/statsd.d)
 install(DIRECTORY DESTINATION usr/lib/netdata/conf.d)
 install(DIRECTORY DESTINATION usr/libexec/netdata/plugins.d)
-install(DIRECTORY DESTINATION usr/share/netdata/web)
+install(DIRECTORY DESTINATION ${WEB_DEST})
 
 set(libsysdir_POST "${CMAKE_INSTALL_PREFIX}/usr/lib/netdata/system")
 set(pkglibexecdir_POST "${CMAKE_INSTALL_PREFIX}/usr/libexec/netdata")
@@ -1852,7 +1860,7 @@ install(FILES streaming/stream.conf
 #
 install(FILES web/api/netdata-swagger.json
               web/api/netdata-swagger.yaml
-        DESTINATION usr/share/netdata/web)
+        DESTINATION ${WEB_DEST})
 
 #
 # service files
@@ -2175,7 +2183,7 @@ endforeach()
 configure_file(${CMAKE_BINARY_DIR}/dashboard.js.in
                ${CMAKE_BINARY_DIR}/dashboard.js COPYONLY)
 
-install(FILES ${CMAKE_BINARY_DIR}/dashboard.js DESTINATION usr/share/netdata/web)
+install(FILES ${CMAKE_BINARY_DIR}/dashboard.js DESTINATION ${WEB_DEST})
 
 install(FILES web/gui/dashboard_info_custom_example.js
               web/gui/dashboard_info.js
@@ -2187,19 +2195,19 @@ install(FILES web/gui/dashboard_info_custom_example.js
               web/gui/registry-hello.html
               web/gui/switch.html
               web/gui/ilove.html
-        DESTINATION usr/share/netdata/web)
+        DESTINATION ${WEB_DEST})
 
-install(FILES web/gui/old/index.html DESTINATION usr/share/netdata/web/old)
+install(FILES web/gui/old/index.html DESTINATION ${WEB_DEST}/old)
 
-install(FILES web/gui/static/img/netdata-logomark.svg DESTINATION usr/share/netdata/web/static/img)
+install(FILES web/gui/static/img/netdata-logomark.svg DESTINATION ${WEB_DEST}/static/img)
 
 install(FILES web/gui/css/morris-0.5.1.css
               web/gui/css/c3-0.4.18.min.css
-        DESTINATION usr/share/netdata/web/css)
+        DESTINATION ${WEB_DEST}/css)
 
 install(FILES web/gui/.well-known/dnt/cookies
-        DESTINATION usr/share/netdata/web/.well-known/dnt)
+        DESTINATION ${WEB_DEST}/.well-known/dnt)
 
 # v0 dashboard
 install(FILES web/gui/v0/index.html
-        DESTINATION usr/share/netdata/web/v0)
+        DESTINATION ${WEB_DEST}/v0)

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -55,6 +55,7 @@ override_dh_auto_configure:
 	fi
 	dh_auto_configure -- -G Ninja \
 		-DCMAKE_INSTALL_PREFIX=/ \
+		-DWEB_DIR=/var/lib/netdata/www \
 		-DENABLE_ACLK=On \
 		-DENABLE_CLOUD=On \
 		-DENABLE_DBENGINE=On \

--- a/web/gui/cmake_dashboard_v1.py
+++ b/web/gui/cmake_dashboard_v1.py
@@ -17,15 +17,15 @@ BASEPATH = Path('v1')
 URLTEMPLATE = 'https://github.com/netdata/dashboard/releases/download/{0}/dashboard.tar.gz'
 
 CMAKETEMPLATE = '''
-    install(FILES {0} DESTINATION usr/share/netdata/web)
-    install(FILES {1} DESTINATION usr/share/netdata/web/css)
-    install(FILES {2} DESTINATION usr/share/netdata/web/fonts)
-    install(FILES {3} DESTINATION usr/share/netdata/web/images)
-    install(FILES {4} DESTINATION usr/share/netdata/web/lib)
-    install(FILES {5} DESTINATION usr/share/netdata/web/static/css)
-    install(FILES {6} DESTINATION usr/share/netdata/web/static/js)
-    install(FILES {7} DESTINATION usr/share/netdata/web/static/media)
-    install(FILES web/gui/v1/index.html DESTINATION usr/share/netdata/web/v1)
+    install(FILES {0} DESTINATION ${WEB_DEST})
+    install(FILES {1} DESTINATION ${WEB_DEST}/css)
+    install(FILES {2} DESTINATION ${WEB_DEST}/fonts)
+    install(FILES {3} DESTINATION ${WEB_DEST}/images)
+    install(FILES {4} DESTINATION ${WEB_DEST}/lib)
+    install(FILES {5} DESTINATION ${WEB_DEST}/static/css)
+    install(FILES {6} DESTINATION ${WEB_DEST}/static/js)
+    install(FILES {7} DESTINATION ${WEB_DEST}/static/media)
+    install(FILES web/gui/v1/index.html DESTINATION ${WEB_DEST}/v1)
 '''
 
 def copy_dashboard(tag):

--- a/web/gui/cmake_dashboard_v2.py
+++ b/web/gui/cmake_dashboard_v2.py
@@ -23,14 +23,14 @@ TMPPATH = Path('tmp')
 URLSRC = 'https://app.netdata.cloud/agent.tar.gz'
 
 CMAKETEMPLATE = '''
-    install(FILES {0} DESTINATION usr/share/netdata/web/v2)
-    install(FILES {1} DESTINATION usr/share/netdata/web/v2/static)
-    install(FILES {2} DESTINATION usr/share/netdata/web/v2/static/email/img)
-    install(FILES {3} DESTINATION usr/share/netdata/web/v2/static/img)
-    install(FILES {4} DESTINATION usr/share/netdata/web/v2/static/img/logos/os)
-    install(FILES {5} DESTINATION usr/share/netdata/web/v2/static/img/logos/services)
-    install(FILES {6} DESTINATION usr/share/netdata/web/v2/static/img/mail)
-    install(FILES {7} DESTINATION usr/share/netdata/web/v2/static/site/pages/holding-page-503)
+    install(FILES {0} DESTINATION ${WEB_DEST}/v2)
+    install(FILES {1} DESTINATION ${WEB_DEST}/v2/static)
+    install(FILES {2} DESTINATION ${WEB_DEST}/v2/static/email/img)
+    install(FILES {3} DESTINATION ${WEB_DEST}/v2/static/img)
+    install(FILES {4} DESTINATION ${WEB_DEST}/v2/static/img/logos/os)
+    install(FILES {5} DESTINATION ${WEB_DEST}/v2/static/img/logos/services)
+    install(FILES {6} DESTINATION ${WEB_DEST}/v2/static/img/mail)
+    install(FILES {7} DESTINATION ${WEB_DEST}/v2/static/site/pages/holding-page-503)
 '''
 
 MAKEFILETEMPLATE = '''

--- a/web/gui/v1/dashboard_v1.cmake
+++ b/web/gui/v1/dashboard_v1.cmake
@@ -22,19 +22,19 @@ web/gui/v1/robots.txt
 web/gui/v1/service-worker.js
 web/gui/v1/sitemap.xml
 web/gui/v1/tv-react.html
-web/gui/v1/tv.html DESTINATION usr/share/netdata/web)
+web/gui/v1/tv.html DESTINATION ${WEB_DEST})
     install(FILES web/gui/v1/css/bootstrap-3.3.7.css
 web/gui/v1/css/bootstrap-slate-flat-3.3.7.css
 web/gui/v1/css/bootstrap-slider-10.0.0.min.css
 web/gui/v1/css/bootstrap-theme-3.3.7.min.css
 web/gui/v1/css/bootstrap-toggle-2.2.2.min.css
 web/gui/v1/css/dashboard.css
-web/gui/v1/css/dashboard.slate.css DESTINATION usr/share/netdata/web/css)
+web/gui/v1/css/dashboard.slate.css DESTINATION ${WEB_DEST}/css)
     install(FILES web/gui/v1/fonts/glyphicons-halflings-regular.eot
 web/gui/v1/fonts/glyphicons-halflings-regular.svg
 web/gui/v1/fonts/glyphicons-halflings-regular.ttf
 web/gui/v1/fonts/glyphicons-halflings-regular.woff
-web/gui/v1/fonts/glyphicons-halflings-regular.woff2 DESTINATION usr/share/netdata/web/fonts)
+web/gui/v1/fonts/glyphicons-halflings-regular.woff2 DESTINATION ${WEB_DEST}/fonts)
     install(FILES web/gui/v1/images/alert-128-orange.png
 web/gui/v1/images/alert-128-red.png
 web/gui/v1/images/alert-multi-size-orange.ico
@@ -84,7 +84,7 @@ web/gui/v1/images/overview.png
 web/gui/v1/images/packaging-beta-tag.svg
 web/gui/v1/images/post.png
 web/gui/v1/images/pricing.png
-web/gui/v1/images/seo-performance-128.png DESTINATION usr/share/netdata/web/images)
+web/gui/v1/images/seo-performance-128.png DESTINATION ${WEB_DEST}/images)
     install(FILES web/gui/v1/lib/bootstrap-3.3.7.min.js
 web/gui/v1/lib/bootstrap-slider-10.0.0.min.js
 web/gui/v1/lib/bootstrap-table-1.11.0.min.js
@@ -104,13 +104,13 @@ web/gui/v1/lib/jquery.sparkline-2.1.2.min.js
 web/gui/v1/lib/lz-string-1.4.4.min.js
 web/gui/v1/lib/pako-1.0.6.min.js
 web/gui/v1/lib/perfect-scrollbar-0.6.15.min.js
-web/gui/v1/lib/tableExport-1.6.0.min.js DESTINATION usr/share/netdata/web/lib)
+web/gui/v1/lib/tableExport-1.6.0.min.js DESTINATION ${WEB_DEST}/lib)
     install(FILES web/gui/v1/static/css/2.c454aab8.chunk.css
 web/gui/v1/static/css/2.c454aab8.chunk.css.map
 web/gui/v1/static/css/4.a36e3b73.chunk.css
 web/gui/v1/static/css/4.a36e3b73.chunk.css.map
 web/gui/v1/static/css/main.53ba10f1.chunk.css
-web/gui/v1/static/css/main.53ba10f1.chunk.css.map DESTINATION usr/share/netdata/web/static/css)
+web/gui/v1/static/css/main.53ba10f1.chunk.css.map DESTINATION ${WEB_DEST}/static/css)
     install(FILES web/gui/v1/static/js/10.a5cd7d0e.chunk.js
 web/gui/v1/static/js/10.a5cd7d0e.chunk.js.map
 web/gui/v1/static/js/2.62d105c5.chunk.js
@@ -135,7 +135,7 @@ web/gui/v1/static/js/main.e248095a.chunk.js
 web/gui/v1/static/js/main.e248095a.chunk.js.LICENSE
 web/gui/v1/static/js/main.e248095a.chunk.js.map
 web/gui/v1/static/js/runtime-main.08abed8f.js
-web/gui/v1/static/js/runtime-main.08abed8f.js.map DESTINATION usr/share/netdata/web/static/js)
+web/gui/v1/static/js/runtime-main.08abed8f.js.map DESTINATION ${WEB_DEST}/static/js)
     install(FILES web/gui/v1/static/media/ibm-plex-sans-latin-100.245539db.woff2
 web/gui/v1/static/media/ibm-plex-sans-latin-100.9a582f3a.woff
 web/gui/v1/static/media/ibm-plex-sans-latin-100italic.1ea7c5d2.woff
@@ -164,5 +164,5 @@ web/gui/v1/static/media/ibm-plex-sans-latin-700.b8809d61.woff
 web/gui/v1/static/media/ibm-plex-sans-latin-700.c9983d3d.woff2
 web/gui/v1/static/media/ibm-plex-sans-latin-700italic.02954bee.woff2
 web/gui/v1/static/media/ibm-plex-sans-latin-700italic.72e9af40.woff
-web/gui/v1/static/media/material-icons.0509ab09.woff2 DESTINATION usr/share/netdata/web/static/media)
-    install(FILES web/gui/v1/index.html DESTINATION usr/share/netdata/web/v1)
+web/gui/v1/static/media/material-icons.0509ab09.woff2 DESTINATION ${WEB_DEST}/static/media)
+    install(FILES web/gui/v1/index.html DESTINATION ${WEB_DEST}/v1)

--- a/web/gui/v2/dashboard_v2.cmake
+++ b/web/gui/v2/dashboard_v2.cmake
@@ -106,9 +106,9 @@ web/gui/v2/registry-access.html
 web/gui/v2/registry-alert-redirect.html
 web/gui/v2/registry-hello.html
 web/gui/v2/runtime.74551d83062ac1b566cc.js
-web/gui/v2/sw.js DESTINATION usr/share/netdata/web/v2)
+web/gui/v2/sw.js DESTINATION ${WEB_DEST}/v2)
     install(FILES web/gui/v2/static/apple-app-site-association
-web/gui/v2/static/splash.css DESTINATION usr/share/netdata/web/v2/static)
+web/gui/v2/static/splash.css DESTINATION ${WEB_DEST}/v2/static)
     install(FILES web/gui/v2/static/email/img/clea_badge.png
 web/gui/v2/static/email/img/clea_siren.png
 web/gui/v2/static/email/img/community_icon.png
@@ -124,12 +124,12 @@ web/gui/v2/static/email/img/label_recovered.png
 web/gui/v2/static/email/img/label_warning.png
 web/gui/v2/static/email/img/reachability_siren.png
 web/gui/v2/static/email/img/warn_badge.png
-web/gui/v2/static/email/img/warn_siren.png DESTINATION usr/share/netdata/web/v2/static/email/img)
+web/gui/v2/static/email/img/warn_siren.png DESTINATION ${WEB_DEST}/v2/static/email/img)
     install(FILES web/gui/v2/static/img/list-style-image.svg
 web/gui/v2/static/img/new-dashboard.svg
 web/gui/v2/static/img/no-filter-results.png
 web/gui/v2/static/img/no-nodes-room.svg
-web/gui/v2/static/img/rack.png DESTINATION usr/share/netdata/web/v2/static/img)
+web/gui/v2/static/img/rack.png DESTINATION ${WEB_DEST}/v2/static/img)
     install(FILES web/gui/v2/static/img/logos/os/alpine.svg
 web/gui/v2/static/img/logos/os/arch.svg
 web/gui/v2/static/img/logos/os/centos.svg
@@ -155,7 +155,7 @@ web/gui/v2/static/img/logos/os/raspberry-pi.svg
 web/gui/v2/static/img/logos/os/redhat.svg
 web/gui/v2/static/img/logos/os/rocky.svg
 web/gui/v2/static/img/logos/os/suse.svg
-web/gui/v2/static/img/logos/os/ubuntu.svg DESTINATION usr/share/netdata/web/v2/static/img/logos/os)
+web/gui/v2/static/img/logos/os/ubuntu.svg DESTINATION ${WEB_DEST}/v2/static/img/logos/os)
     install(FILES web/gui/v2/static/img/logos/services/access-point.svg
 web/gui/v2/static/img/logos/services/activemq.svg
 web/gui/v2/static/img/logos/services/adaptec.svg
@@ -282,14 +282,14 @@ web/gui/v2/static/img/logos/services/unbound.svg
 web/gui/v2/static/img/logos/services/uwsgi.svg
 web/gui/v2/static/img/logos/services/varnish.svg
 web/gui/v2/static/img/logos/services/veritas.svg
-web/gui/v2/static/img/logos/services/xen.svg DESTINATION usr/share/netdata/web/v2/static/img/logos/services)
+web/gui/v2/static/img/logos/services/xen.svg DESTINATION ${WEB_DEST}/v2/static/img/logos/services)
     install(FILES web/gui/v2/static/img/mail/isotype.png
 web/gui/v2/static/img/mail/isotype.svg
 web/gui/v2/static/img/mail/logotype.png
-web/gui/v2/static/img/mail/logotype.svg DESTINATION usr/share/netdata/web/v2/static/img/mail)
+web/gui/v2/static/img/mail/logotype.svg DESTINATION ${WEB_DEST}/v2/static/img/mail)
     install(FILES web/gui/v2/static/site/pages/holding-page-503/holding-page-503.css
 web/gui/v2/static/site/pages/holding-page-503/holding-page-503.svg
 web/gui/v2/static/site/pages/holding-page-503/index.html
 web/gui/v2/static/site/pages/holding-page-503/multiple-logos-group.svg
 web/gui/v2/static/site/pages/holding-page-503/netdata-logo-white.svg
-web/gui/v2/static/site/pages/holding-page-503/reset.svg DESTINATION usr/share/netdata/web/v2/static/site/pages/holding-page-503)
+web/gui/v2/static/site/pages/holding-page-503/reset.svg DESTINATION ${WEB_DEST}/v2/static/site/pages/holding-page-503)


### PR DESCRIPTION
##### Summary

Fixes: #16626
Closes: #16633

##### Test Plan

- Build/install debian package and check web dir: must be `/var/lib/netdata/www`
- Install from source and check web dir: 
  - with a prefix, must be `/opt/netdata/usr/share/netdata/web`
  - without prefix, must be `/usr/share/netdata/web`

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
