### PR TITLE
Fix compilation error when using --disable-dbengine

### DIFF
--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -857,6 +857,7 @@ static void global_statistics_charts(void) {
 
     // ----------------------------------------------------------------
 
+#ifdef ENABLE_DBENGINE
     if (tier_page_type[0] == PAGE_GORILLA_METRICS)
     {
         static RRDSET *st_tier0_gorilla_pages = NULL;
@@ -918,6 +919,7 @@ static void global_statistics_charts(void) {
 
         rrdset_done(st_tier0_compression_info);
     }
+#endif
 }
 
 // ----------------------------------------------------------------------------

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1502,11 +1502,11 @@ int main(int argc, char **argv) {
 #ifdef ENABLE_DBENGINE
                         char* createdataset_string = "createdataset=";
                         char* stresstest_string = "stresstest=";
-#endif
 
                         if(strcmp(optarg, "pgd-tests") == 0) {
                             return pgd_test(argc, argv);
                         }
+#endif
 
                         if(strcmp(optarg, "sqlite-meta-recover") == 0) {
                             sql_init_database(DB_CHECK_RECOVER, 0);


### PR DESCRIPTION
##### Summary
Fix a compilation error when trying to compile without dbengine (`--disable-dbengine`) . 
This PR disables the failing statistics and internal page generation tests

Fixes #16643
