### PR TITLE
Fix coverity issues

### DIFF
--- a/collectors/log2journal/log2journal-replace.c
+++ b/collectors/log2journal/log2journal-replace.c
@@ -74,6 +74,7 @@ bool replace_pattern_set(REPLACE_PATTERN *rp, const char *pattern) {
                 log2stderr("Error: Failed to add replacement node for variable.");
                 return false;
             }
+            freez(variable_name);
 
             current = end + 1; // Move past the variable
         }
@@ -97,6 +98,7 @@ bool replace_pattern_set(REPLACE_PATTERN *rp, const char *pattern) {
                 log2stderr("Error: Failed to add replacement node for text.");
                 return false;
             }
+            freez(text);
         }
     }
 

--- a/collectors/log2journal/log2journal-yaml.c
+++ b/collectors/log2journal/log2journal-yaml.c
@@ -561,6 +561,8 @@ static size_t yaml_parse_rewrites(yaml_parser_t *parser, LOG_JOB *jb) {
 
                     yaml_event_delete(&sub_event);
                 }
+                freez(replace_pattern);
+                replace_pattern = NULL;
             }
                 break;
 

--- a/logsmanagement/parser.c
+++ b/logsmanagement/parser.c
@@ -226,7 +226,6 @@ int search_keyword( char *src, size_t src_sz __maybe_unused,
             size_t regcomp_err_str_size = regerror(rc, &regex_compiled, 0, 0);
             char *regcomp_err_str = mallocz(regcomp_err_str_size);
             regerror(rc, &regex_compiled, regcomp_err_str, regcomp_err_str_size);
-            freez(regcomp_err_str);
             fatal("Could not compile regular expression:%.*s, error: %s", (int) MAX_REGEX_SIZE, regexString, regcomp_err_str);
         }
     }

--- a/logsmanagement/query.c
+++ b/logsmanagement/query.c
@@ -95,8 +95,8 @@ const logs_qry_res_err_t *fetch_log_sources(BUFFER *wb){
         buffer_json_member_add_string(wb, "filename", p_file_infos_arr->data[i]->filename);
         buffer_json_member_add_string(wb, "log_type", log_src_type_t_str[p_file_infos_arr->data[i]->log_type]);
         buffer_json_member_add_string(wb, "db_dir", p_file_infos_arr->data[i]->db_dir);
-        buffer_json_member_add_uint64(wb, "db_version", db_user_version(p_file_infos_arr->data[i]->db, -1));
-        buffer_json_member_add_uint64(wb, "db_flush_freq", db_user_version(p_file_infos_arr->data[i]->db, -1));
+        buffer_json_member_add_int64(wb, "db_version", db_user_version(p_file_infos_arr->data[i]->db, -1));
+        buffer_json_member_add_int64(wb, "db_flush_freq", db_user_version(p_file_infos_arr->data[i]->db, -1));
         buffer_json_member_add_int64( wb, "db_disk_space_limit", p_file_infos_arr->data[i]->blob_max_size * BLOB_MAX_FILES);
         buffer_json_object_close(wb); // options object
     }

--- a/logsmanagement/unit_test/unit_test.c
+++ b/logsmanagement/unit_test/unit_test.c
@@ -169,6 +169,7 @@ static int test_compression_decompression() {
         fprintf(stderr, "- Error, original and decompressed data not the same\n");
         ++errors;
     }
+    freez(decompressed_text);
 
     fprintf(stderr, "%s\n", errors ? "FAIL" : "OK");
     return errors;
@@ -183,6 +184,7 @@ static int test_read_last_line() {
     #else
     char tmpname[] = "/tmp/tmp.XXXXXX";
     #endif
+    (void) umask(0022);
 
     int fd = mkstemp(tmpname);
     if (fd == -1){
@@ -219,6 +221,7 @@ static int test_read_last_line() {
 
     unlink(tmpname);
     close(fd);
+    fclose(tmpfp);
 
     fprintf(stderr, "%s\n", errors ? "FAIL" : "OK");
     return errors;


### PR DESCRIPTION
##### Summary
* CID 410249:    (RESOURCE_LEAK)
   /collectors/log2journal/log2journal-yaml.c: 501 in yaml_parse_rewrites()
* CID 410233:  Resource leaks  (RESOURCE_LEAK)
  /collectors/log2journal/log2journal-replace.c: 100 in replace_pattern_set()
* CID 410209:  Resource leaks  (RESOURCE_LEAK)
  /collectors/log2journal/log2journal-replace.c: 77 in replace_pattern_set()
* CID 410247:  Resource leaks  (RESOURCE_LEAK)
   /collectors/log2journal/log2journal-yaml.c: 564 in yaml_parse_rewrites()

A few issues in logsmanagement
