### PR TITLE
fix exporting internal charts context and family

### DIFF
--- a/exporting/send_internal_metrics.c
+++ b/exporting/send_internal_metrics.c
@@ -18,8 +18,18 @@ void create_main_rusage_chart(RRDSET **st_rusage, RRDDIM **rd_user, RRDDIM **rd_
         return;
 
     *st_rusage = rrdset_create_localhost(
-        "netdata", "exporting_main_thread_cpu", NULL, "exporting", "exporting_cpu_usage", "Netdata Main Exporting Thread CPU Usage",
-        "milliseconds/s", "exporting", NULL, 130600, localhost->rrd_update_every, RRDSET_TYPE_STACKED);
+        "netdata",
+        "exporting_main_thread_cpu",
+        NULL,
+        "exporting",
+        "netdata.exporting_cpu_usage",
+        "Netdata Main Exporting Thread CPU Usage",
+        "milliseconds/s",
+        "exporting",
+        NULL,
+        130600,
+        localhost->rrd_update_every,
+        RRDSET_TYPE_STACKED);
 
     *rd_user = rrddim_add(*st_rusage, "user", NULL, 1, 1000, RRD_ALGORITHM_INCREMENTAL);
     *rd_system = rrddim_add(*st_rusage, "system", NULL, 1, 1000, RRD_ALGORITHM_INCREMENTAL);
@@ -73,8 +83,18 @@ void send_internal_metrics(struct instance *instance)
         netdata_fix_chart_id(id);
 
         stats->st_metrics = rrdset_create_localhost(
-            "netdata", id, NULL, buffer_tostring(family), "exporting_buffer", "Netdata Buffered Metrics", "metrics", "exporting", NULL,
-            130610, instance->config.update_every, RRDSET_TYPE_LINE);
+            "netdata",
+            id,
+            NULL,
+            buffer_tostring(family),
+            "netdata.exporting_buffer",
+            "Netdata Buffered Metrics",
+            "metrics",
+            "exporting",
+            NULL,
+            130610,
+            instance->config.update_every,
+            RRDSET_TYPE_LINE);
 
         stats->rd_buffered_metrics = rrddim_add(stats->st_metrics, "buffered", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
         stats->rd_lost_metrics     = rrddim_add(stats->st_metrics, "lost", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
@@ -86,8 +106,18 @@ void send_internal_metrics(struct instance *instance)
         netdata_fix_chart_id(id);
 
         stats->st_bytes = rrdset_create_localhost(
-            "netdata", id, NULL, buffer_tostring(family), "exporting_data_size", "Netdata Exporting Data Size", "KiB", "exporting", NULL,
-            130620, instance->config.update_every, RRDSET_TYPE_AREA);
+            "netdata",
+            id,
+            NULL,
+            buffer_tostring(family),
+            "netdata.exporting_data_size",
+            "Netdata Exporting Data Size",
+            "KiB",
+            "exporting",
+            NULL,
+            130620,
+            instance->config.update_every,
+            RRDSET_TYPE_AREA);
 
         stats->rd_buffered_bytes = rrddim_add(stats->st_bytes, "buffered", NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
         stats->rd_lost_bytes     = rrddim_add(stats->st_bytes, "lost", NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
@@ -100,8 +130,18 @@ void send_internal_metrics(struct instance *instance)
         netdata_fix_chart_id(id);
 
         stats->st_ops = rrdset_create_localhost(
-            "netdata", id, NULL, buffer_tostring(family), "exporting_operations", "Netdata Exporting Operations", "operations", "exporting",
-            NULL, 130630, instance->config.update_every, RRDSET_TYPE_LINE);
+            "netdata",
+            id,
+            NULL,
+            buffer_tostring(family),
+            "netdata.exporting_operations",
+            "Netdata Exporting Operations",
+            "operations",
+            "exporting",
+            NULL,
+            130630,
+            instance->config.update_every,
+            RRDSET_TYPE_LINE);
 
         stats->rd_transmission_successes = rrddim_add(stats->st_ops, "write", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
         stats->rd_data_lost_events       = rrddim_add(stats->st_ops, "discard", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
@@ -115,8 +155,18 @@ void send_internal_metrics(struct instance *instance)
         netdata_fix_chart_id(id);
 
         stats->st_rusage = rrdset_create_localhost(
-            "netdata", id, NULL, buffer_tostring(family), "exporting_instance", "Netdata Exporting Instance Thread CPU Usage",
-            "milliseconds/s", "exporting", NULL, 130640, instance->config.update_every, RRDSET_TYPE_STACKED);
+            "netdata",
+            id,
+            NULL,
+            buffer_tostring(family),
+            "netdata.exporting_instance",
+            "Netdata Exporting Instance Thread CPU Usage",
+            "milliseconds/s",
+            "exporting",
+            NULL,
+            130640,
+            instance->config.update_every,
+            RRDSET_TYPE_STACKED);
 
         stats->rd_user   = rrddim_add(stats->st_rusage, "user", NULL, 1, 1000, RRD_ALGORITHM_INCREMENTAL);
         stats->rd_system = rrddim_add(stats->st_rusage, "system", NULL, 1, 1000, RRD_ALGORITHM_INCREMENTAL);

--- a/exporting/send_internal_metrics.c
+++ b/exporting/send_internal_metrics.c
@@ -75,10 +75,6 @@ void send_internal_metrics(struct instance *instance)
 
     if (!stats->initialized) {
         char id[RRD_ID_LENGTH_MAX + 1];
-        BUFFER *family = buffer_create(0, &netdata_buffers_statistics.buffers_exporters);
-
-        buffer_sprintf(family, "exporting_%s", instance->config.name);
-
         snprintf(id, RRD_ID_LENGTH_MAX, "exporting_%s_metrics", instance->config.name);
         netdata_fix_chart_id(id);
 
@@ -86,7 +82,7 @@ void send_internal_metrics(struct instance *instance)
             "netdata",
             id,
             NULL,
-            buffer_tostring(family),
+            "exporting",
             "netdata.exporting_buffer",
             "Netdata Buffered Metrics",
             "metrics",
@@ -109,7 +105,7 @@ void send_internal_metrics(struct instance *instance)
             "netdata",
             id,
             NULL,
-            buffer_tostring(family),
+            "exporting",
             "netdata.exporting_data_size",
             "Netdata Exporting Data Size",
             "KiB",
@@ -133,7 +129,7 @@ void send_internal_metrics(struct instance *instance)
             "netdata",
             id,
             NULL,
-            buffer_tostring(family),
+            "exporting",
             "netdata.exporting_operations",
             "Netdata Exporting Operations",
             "operations",
@@ -158,7 +154,7 @@ void send_internal_metrics(struct instance *instance)
             "netdata",
             id,
             NULL,
-            buffer_tostring(family),
+            "exporting",
             "netdata.exporting_instance",
             "Netdata Exporting Instance Thread CPU Usage",
             "milliseconds/s",
@@ -170,8 +166,6 @@ void send_internal_metrics(struct instance *instance)
 
         stats->rd_user   = rrddim_add(stats->st_rusage, "user", NULL, 1, 1000, RRD_ALGORITHM_INCREMENTAL);
         stats->rd_system = rrddim_add(stats->st_rusage, "system", NULL, 1, 1000, RRD_ALGORITHM_INCREMENTAL);
-
-        buffer_free(family);
 
         stats->initialized = 1;
     }

--- a/exporting/tests/test_exporting_engine.c
+++ b/exporting/tests/test_exporting_engine.c
@@ -844,7 +844,7 @@ static void test_create_main_rusage_chart(void **state)
     expect_string(rrdset_create_custom, id, "exporting_main_thread_cpu");
     expect_value(rrdset_create_custom, name, NULL);
     expect_string(rrdset_create_custom, family, "exporting");
-    expect_string(rrdset_create_custom, context, "exporting_cpu_usage");
+    expect_string(rrdset_create_custom, context, "netdata.exporting_cpu_usage");
     expect_string(rrdset_create_custom, units, "milliseconds/s");
     expect_string(rrdset_create_custom, plugin, "exporting");
     expect_value(rrdset_create_custom, module, NULL);

--- a/exporting/tests/test_exporting_engine.c
+++ b/exporting/tests/test_exporting_engine.c
@@ -912,7 +912,7 @@ static void test_send_internal_metrics(void **state)
     expect_string(rrdset_create_custom, type, "netdata");
     expect_string(rrdset_create_custom, id, "exporting_test_instance_metrics");
     expect_value(rrdset_create_custom, name, NULL);
-    expect_string(rrdset_create_custom, family, "exporting_test_instance");
+    expect_string(rrdset_create_custom, family, "exporting");
     expect_string(rrdset_create_custom, context, "exporting_buffer");
     expect_string(rrdset_create_custom, units, "metrics");
     expect_string(rrdset_create_custom, plugin, "exporting");
@@ -936,7 +936,7 @@ static void test_send_internal_metrics(void **state)
     expect_string(rrdset_create_custom, type, "netdata");
     expect_string(rrdset_create_custom, id, "exporting_test_instance_bytes");
     expect_value(rrdset_create_custom, name, NULL);
-    expect_string(rrdset_create_custom, family, "exporting_test_instance");
+    expect_string(rrdset_create_custom, family, "exporting");
     expect_string(rrdset_create_custom, context, "exporting_data_size");
     expect_string(rrdset_create_custom, units, "KiB");
     expect_string(rrdset_create_custom, plugin, "exporting");
@@ -960,7 +960,7 @@ static void test_send_internal_metrics(void **state)
     expect_string(rrdset_create_custom, type, "netdata");
     expect_string(rrdset_create_custom, id, "exporting_test_instance_ops");
     expect_value(rrdset_create_custom, name, NULL);
-    expect_string(rrdset_create_custom, family, "exporting_test_instance");
+    expect_string(rrdset_create_custom, family, "exporting");
     expect_string(rrdset_create_custom, context, "exporting_operations");
     expect_string(rrdset_create_custom, units, "operations");
     expect_string(rrdset_create_custom, plugin, "exporting");
@@ -984,7 +984,7 @@ static void test_send_internal_metrics(void **state)
     expect_string(rrdset_create_custom, type, "netdata");
     expect_string(rrdset_create_custom, id, "exporting_test_instance_thread_cpu");
     expect_value(rrdset_create_custom, name, NULL);
-    expect_string(rrdset_create_custom, family, "exporting_test_instance");
+    expect_string(rrdset_create_custom, family, "exporting");
     expect_string(rrdset_create_custom, context, "exporting_instance");
     expect_string(rrdset_create_custom, units, "milliseconds/s");
     expect_string(rrdset_create_custom, plugin, "exporting");

--- a/health/health.d/exporting.conf
+++ b/health/health.d/exporting.conf
@@ -1,6 +1,6 @@
 
  template: exporting_last_buffering
-       on: exporting_data_size
+       on: netdata.exporting_data_size
     class: Latency
      type: Netdata
 component: Exporting engine
@@ -15,7 +15,7 @@ component: Exporting engine
        to: dba
 
  template: exporting_metrics_sent
-       on: exporting_data_size
+       on: netdata.exporting_data_size
     class: Workload
      type: Netdata
 component: Exporting engine


### PR DESCRIPTION
##### Summary

Fixes this issue:

<img width="357" alt="Screenshot 2023-12-28 at 19 13 08" src="https://github.com/netdata/netdata/assets/22274335/a66dbf48-7c4f-475c-a6c7-fa1c19762672">

##### Test Plan



<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
