### PR TITLE
add --disable-logsmanagement when building static

### DIFF
--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -36,6 +36,7 @@ run ./netdata-installer.sh \
   --use-system-protobuf \
   --dont-scrub-cflags-even-though-it-may-break-things \
   --one-time-build \
+  --disable-logsmanagement \
   --enable-lto
 
 # shellcheck disable=SC2015


### PR DESCRIPTION
##### Summary

Building logs-management always fails. This PR disables it for static build to avoid wasting time on ci and when building locally.

<details>
<summary>build error</summary>

```c
[100%] Linking C shared library ../lib/libfluent-bit.so
/usr/lib/gcc/x86_64-alpine-linux-musl/12.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: /openssl-static/lib64/libcrypto.a(libcrypto-lib-v3_genn.o): warning: relocation against `d2i_GENERAL_NAME' in read-only section `.text'
/usr/lib/gcc/x86_64-alpine-linux-musl/12.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: /openssl-static/lib64/libssl.a(libssl-lib-s3_lib.o): relocation R_X86_64_PC32 against symbol `tls12downgrade' can not be used when making a shared object; recompile with -fPIC
/usr/lib/gcc/x86_64-alpine-linux-musl/12.2.1/../../../../x86_64-alpine-linux-musl/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
make[2]: *** [src/CMakeFiles/fluent-bit-shared.dir/build.make:1937: lib/libfluent-bit.so] Error 1
make[1]: *** [CMakeFiles/Makefile2:4411: src/CMakeFiles/fluent-bit-shared.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
 FAILED  ''

 WARNING  Failed to build Fluent-Bit, Netdata Logs Management support will be disabled in this build.
```

</details>

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
