### PR TITLE
fix claiming on macOS

### DIFF
--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -27,8 +27,10 @@ void get_netdata_execution_path(void) {
 
     netdata_exe_file[exepath_size] = '\0';
 
-    strcpy(netdata_exe_path, netdata_exe_file);
-    dirname(netdata_exe_path);
+    // macOS's dirname(3) does not modify passed string
+    char *tmpdir = strdupz(netdata_exe_file);
+    strcpy(netdata_exe_path, dirname(tmpdir));
+    freez(tmpdir);
 }
 
 static void fix_directory_file_permissions(const char *dirname, uid_t uid, gid_t gid, bool recursive)


### PR DESCRIPTION
##### Summary

macOS's `dirname(3)` does not modify passed string.

This PR fixes a bug in Netdata's handling of `dirname()` on macOS.  Netdata can now correctly find the `netdata-claim.sh` script (which is located in the same directory as the main executable). 

##### Test Plan

Claim Netdata via UI on macOS.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
