### PR TITLE
atomically load the metric reference count

### DIFF
--- a/database/engine/metric.c
+++ b/database/engine/metric.c
@@ -132,7 +132,7 @@ static inline time_t mrg_metric_get_first_time_s_smart(MRG *mrg __maybe_unused, 
 
 static inline REFCOUNT metric_acquire(MRG *mrg __maybe_unused, METRIC *metric) {
     size_t partition = metric->partition;
-    REFCOUNT expected = metric->refcount;
+    REFCOUNT expected = __atomic_load_n(&metric->refcount, __ATOMIC_RELAXED);
     REFCOUNT refcount;
 
     do {
@@ -152,7 +152,7 @@ static inline REFCOUNT metric_acquire(MRG *mrg __maybe_unused, METRIC *metric) {
 
 static inline bool metric_release_and_can_be_deleted(MRG *mrg __maybe_unused, METRIC *metric) {
     size_t partition = metric->partition;
-    REFCOUNT expected = metric->refcount;
+    REFCOUNT expected = __atomic_load_n(&metric->refcount, __ATOMIC_RELAXED);
     REFCOUNT refcount;
 
     do {


### PR DESCRIPTION
Prevent fatal conditions with message: `METRIC: refcount is 0 (zero or negative) during release`