### PR TITLE
fix installing service file and start/stop ND using `launchctl` on macOS

### DIFF
--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -625,7 +625,7 @@ freebsd_cmds() {
 
 install_darwin_service() {
   info "Installing macOS plist file for launchd."
-  if ! install -C -S -p -m 0644 -o 0 -g 0 system/launchd/netdata.plist /Library/LaunchDaemons/com.github.netdata.plist; then
+  if ! install -C -S -p -m 0644 -o 0 -g 0 "${SVC_SOURCE}/launchd/netdata.plist" /Library/LaunchDaemons/com.github.netdata.plist; then
     error "Failed to copy plist file."
     exit 4
   fi

--- a/system/launchd/netdata.plist.in
+++ b/system/launchd/netdata.plist.in
@@ -8,6 +8,7 @@
     <key>ProgramArguments</key>
     <array>
         <string>@sbindir_POST@/netdata</string>
+        <string>-D</string>
     </array>
     <key>RunAtLoad</key>
     <true/>


### PR DESCRIPTION
##### Summary

Fixes: #13829
Fixes: #12578


This PR fixes 2 issues on macOS:

- installing the `netdata.plist` file. 

```bash
Installing macOS plist file for launchd.
install: system/launchd/netdata.plist: No such file or directory
ERROR: Failed to copy plist file.
```

- Stop Netdata service using `launchctl`.

##### Test Plan

- Install Netdata on macOS using `netdata-installer.sh`.
- Start/stop Netdata using `launchctl`.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
