### PR TITLE
Fix plugin running on Xeon i686

### DIFF
--- a/libnetdata/clocks/clocks.c
+++ b/libnetdata/clocks/clocks.c
@@ -360,11 +360,16 @@ void sleep_usec_with_now(usec_t usec, usec_t started_ut) {
     time_t req_tv_sec = (time_t)usec;
     req_tv_sec /= USEC_PER_SEC;
 
+    // it was not identified the same issue fixed by previous variable, this variable was added
+    // to have an unique logic.
+    suseconds_t req_tv_nsec = (suseconds_t)usec;
+    req_tv_nsec = ((req_tv_nsec % USEC_PER_SEC) * NSEC_PER_USEC);
+
     // we expect microseconds (1.000.000 per second)
     // but timespec is nanoseconds (1.000.000.000 per second)
     struct timespec rem = { 0, 0 }, req = {
             .tv_sec = req_tv_sec,
-            .tv_nsec = (suseconds_t) ((usec % USEC_PER_SEC) * NSEC_PER_USEC)
+            .tv_nsec = req_tv_nsec
     };
 
     // make sure errno is not EINTR

--- a/libnetdata/clocks/clocks.c
+++ b/libnetdata/clocks/clocks.c
@@ -356,10 +356,14 @@ usec_t heartbeat_next(heartbeat_t *hb, usec_t tick) {
 }
 
 void sleep_usec_with_now(usec_t usec, usec_t started_ut) {
+    // this is necessary on Xeon i686 running Yggdrasil to avoid wrong cast.
+    time_t req_tv_sec = (time_t)usec;
+    req_tv_sec /= USEC_PER_SEC;
+
     // we expect microseconds (1.000.000 per second)
     // but timespec is nanoseconds (1.000.000.000 per second)
     struct timespec rem = { 0, 0 }, req = {
-            .tv_sec = (time_t) (usec / USEC_PER_SEC),
+            .tv_sec = req_tv_sec,
             .tv_nsec = (suseconds_t) ((usec % USEC_PER_SEC) * NSEC_PER_USEC)
     };
 

--- a/libnetdata/clocks/clocks.c
+++ b/libnetdata/clocks/clocks.c
@@ -357,8 +357,12 @@ usec_t heartbeat_next(heartbeat_t *hb, usec_t tick) {
 
 void sleep_usec_with_now(usec_t usec, usec_t started_ut) {
     // this is necessary on Xeon i686 running Yggdrasil to avoid wrong cast.
+    time_t divisor = (usec > NSEC_PER_SEC) ? NSEC_PER_SEC : USEC_PER_SEC;
     time_t req_tv_sec = (time_t)usec;
-    req_tv_sec /= USEC_PER_SEC;
+    req_tv_sec /= divisor;
+    // Our algorithm does not expect values higher than NSEC_PER_SEC
+    if (divisor == NSEC_PER_SEC)
+        usec /= 1000;
 
     // it was not identified the same issue fixed by previous variable, this variable was added
     // to have an unique logic.


### PR DESCRIPTION
##### Summary
Our user reported that when `apps` and `debugfs`  plugin ran on his environment, the plugins never show data. After he gave us access, I could observe that `nanosleep` was receiving wrong values:

```sh
statx(1, "", AT_STATX_SYNC_AS_STAT|AT_NO_AUTOMOUNT|AT_EMPTY_PATH, STATX_BASIC_STATS, {stx_mask=STATX_BASIC_STATS|STATX_MNT_ID, stx_attributes=0, stx_mode=S_IFREG|0644, stx_size=0, ...}) = 0
clock_nanosleep(CLOCK_REALTIME, 0, {tv_sec=469, tv_nsec=791422000}, {tv_sec=389, tv_nsec=198875161}) = ? ERESTART_RESTARTBLOCK (Interrupted by signal)
```

and plugins were killed by netdata.
Instead, to store result direct on variable, we are now casting it and after this we start the math.
This issue was not observed when we run on other Intel processors.

##### Test Plan
1. Compile this branch
2. Confirm that you have on your environment `apps.plugin` running as expected.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
