### PR TITLE
Remove Ubuntu 23.04 from CI and platform support.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -282,11 +282,6 @@ include:
       <<: *ubuntu_packages
       repo_distro: ubuntu/mantic
   - <<: *ubuntu
-    version: "23.04"
-    packages:
-      <<: *ubuntu_packages
-      repo_distro: ubuntu/lunar
-  - <<: *ubuntu
     version: "20.04"
     packages:
       <<: *ubuntu_packages

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -70,16 +70,13 @@ to work on these platforms with minimal user effort.
 | Debian                   | 10.x           | x86\_64, i386, ARMv7, AArch64          |                                                                                                                                                    |
 | Fedora                   | 39             | x86\_64, AArch64                       |                                                                                                                                                    |
 | Fedora                   | 38             | x86\_64, AArch64                       |                                                                                                                                                    |
-| Fedora                   | 37             | x86\_64, AArch64                       |                                                                                                                                                    |
 | openSUSE                 | Leap 15.5      | x86\_64, AArch64                       |                                                                                                                                                    |
-| openSUSE                 | Leap 15.4      | x86\_64, AArch64                       |                                                                                                                                                    |
 | Oracle Linux             | 9.x            | x86\_64, AArch64                       |                                                                                                                                                    |
 | Oracle Linux             | 8.x            | x86\_64, AArch64                       |                                                                                                                                                    |
 | Red Hat Enterprise Linux | 9.x            | x86\_64, AArch64                       |                                                                                                                                                    |
 | Red Hat Enterprise Linux | 8.x            | x86\_64, AArch64                       |                                                                                                                                                    |
 | Red Hat Enterprise Linux | 7.x            | x86\_64                                |                                                                                                                                                    |
 | Ubuntu                   | 23.10          | x86\_64, AArch64, ARMv7                |                                                                                                                                                    |
-| Ubuntu                   | 23.04          | x86\_64, AArch64, ARMv7                |                                                                                                                                                    |
 | Ubuntu                   | 22.04          | x86\_64, ARMv7, AArch64                |                                                                                                                                                    |
 | Ubuntu                   | 20.04          | x86\_64, ARMv7, AArch64                |                                                                                                                                                    |
 
@@ -157,15 +154,11 @@ This is a list of platforms that we have supported in the recent past but no lon
 | Platform     | Version   | Notes                |
 |--------------|-----------|----------------------|
 | Alpine Linux | 3.14      | EOL as of 2023-05-01 |
-| Alpine Linux | 3.13      | EOL as of 2022-11-01 |
-| Debian       | 9.x       | EOL as of 2022-06-30 |
 | Fedora       | 37        | EOL as of 2023-12-05 |
 | Fedora       | 36        | EOL as of 2023-05-18 |
-| Fedora       | 35        | EOL as of 2022-12-13 |
 | openSUSE     | Leap 15.4 | EOL as of 2023-12-07 |
-| openSUSE     | Leap 15.3 | EOL as of 2022-12-01 |
+| Ubuntu       | 23.04     | EOL as of 2024-01-20 |
 | Ubuntu       | 22.10     | EOL as of 2023-07-20 |
-| Ubuntu       | 21.10     | EOL as of 2022-07-31 |
 | Ubuntu       | 18.04     | EOL as of 2023-04-02 |
 
 ## Static builds


### PR DESCRIPTION
##### Summary

To be merged on 2024-01-20 when it goes EOL upstream.

##### Test Plan

n/a

##### Additional Info

Closes: #16666 