### PR TITLE
Add info to distros.yml for handling of legacy platforms.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -291,6 +291,17 @@ include:
     packages:
       <<: *ubuntu_packages
       repo_distro: ubuntu/focal
+legacy: # Info for platforms we used to support and still need to handle packages for
+  - <<: *fedora
+    version: "37"
+    packages:
+      <<: *fedora_packages
+      repo_distro: fedora/37
+  - <<: *opensuse
+    version: "15.4"
+    packages:
+      <<: *opensuse_packages
+      repo_distro: opensuse/15.4
 no_include: # Info for platforms not covered in CI
   - distro: docker
     version: "19.03 or newer"


### PR DESCRIPTION
##### Summary

Specifically, record the information required for them to be handled correctly by our native package repositories.

This will require a separate update to the tooling managing the repos before it actually takes effect.

##### Test Plan

n/a

##### Additional Information

First half of a fix for #16707.