### PR TITLE
cgroups: don't multiply cgroup_check_for_new_every by update_every

### DIFF
--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -255,7 +255,7 @@ void read_cgroup_plugin_configuration() {
     if(cgroup_update_every < localhost->rrd_update_every)
         cgroup_update_every = localhost->rrd_update_every;
 
-    cgroup_check_for_new_every = (int)config_get_number("plugin:cgroups", "check for new cgroups every", (long long)cgroup_check_for_new_every * (long long)cgroup_update_every);
+    cgroup_check_for_new_every = (int)config_get_number("plugin:cgroups", "check for new cgroups every", cgroup_check_for_new_every);
     if(cgroup_check_for_new_every < cgroup_update_every)
         cgroup_check_for_new_every = cgroup_update_every;
 


### PR DESCRIPTION
##### Summary

I changed the global `update_every` to 10 and noticed that it takes a while to discover cgroups: 100 seconds. 

This PR changes the default `check for new cgroups every` value: it is 10 seconds if `update_every` < 10 or equal to `update_every`.

##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
