### PR TITLE
fix clock resolution detection

### DIFF
--- a/libnetdata/clocks/clocks.c
+++ b/libnetdata/clocks/clocks.c
@@ -58,7 +58,7 @@ static usec_t get_clock_resolution(clockid_t clock) {
     if(clock_getres(clock, &ts) == 0) {
         usec_t ret = ts.tv_sec * USEC_PER_SEC + ts.tv_nsec * NSEC_PER_USEC;
         if(ret > 100 * USEC_PER_MS) {
-            nd_log(NDLS_DAEMON, NDLP_ERR, "clock_getres(%d) returned more than 100ms, using defaults for clock resolution.", (int)clock);
+            nd_log(NDLS_DAEMON, NDLP_ERR, "clock_getres(%d) returned %"PRIu64" usec (more than 100ms), using defaults for clock resolution.", (int)clock, ret);
             return 0 * USEC_PER_SEC + 1 * NSEC_PER_USEC;
         }
         return ret;


### PR DESCRIPTION
Closes: #16710

netdata reads the system's clock resolution to understand the steps it should pause to synchronize data collection.

On some systems `clock_getres()` is broken. It either returns an error, or it returns invalid values.

Now netdata checks that `clock_getres()` returns success and also that the the value in usec is bigger than zero and less than 10ms.

If successful, it rounds the clock precision in usec and returns it back. Resolutions smaller than 1 usec are rounded to 1 usec.

If unsuccessful, it returns the default clock resolution of 1ms.
