### PR TITLE
fix excessive "maximum number of cgroups reached" log messages

### DIFF
--- a/collectors/cgroups.plugin/cgroup-discovery.c
+++ b/collectors/cgroups.plugin/cgroup-discovery.c
@@ -351,6 +351,7 @@ static inline void discovery_find_cgroup_in_dir_callback(const char *dir) {
     if (!dir || !*dir) {
         dir = "/";
     }
+
     netdata_log_debug(D_CGROUP, "examining cgroup dir '%s'", dir);
 
     struct cgroup *cg = discovery_cgroup_find(dir);
@@ -360,14 +361,15 @@ static inline void discovery_find_cgroup_in_dir_callback(const char *dir) {
     }
 
     if (cgroup_root_count >= cgroup_root_max) {
-        collector_info("CGROUP: maximum number of cgroups reached (%d). Not adding cgroup '%s'", cgroup_root_count, dir);
+        nd_log_limit_static_global_var(erl, 3600, 0);
+        nd_log_limit(&erl, NDLS_COLLECTORS, NDLP_WARNING, "CGROUP: maximum number of cgroups reached (%d). No more cgroups will be added.", cgroup_root_count);
         return;
     }
 
     if (cgroup_max_depth > 0) {
         int depth = calc_cgroup_depth(dir);
         if (depth > cgroup_max_depth) {
-            collector_info("CGROUP: '%s' is too deep (%d, while max is %d)", dir, depth, cgroup_max_depth);
+            nd_log_collector(NDLP_DEBUG, "CGROUP: '%s' is too deep (%d, while max is %d)", dir, depth, cgroup_max_depth);
             return;
         }
     }


### PR DESCRIPTION
##### Summary

The issue is [reported on Discord](https://discord.com/channels/847502280503590932/1191216299477585981/1192775743642542101).

After this PR the message will be logged only once per hour.

##### Test Plan

ci

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
