### PR TITLE
update default netdata.conf used for native packages

### DIFF
--- a/system/netdata.conf
+++ b/system/netdata.conf
@@ -10,14 +10,3 @@
 # or
 #  curl -o /etc/netdata/netdata.conf http://localhost:19999/netdata.conf
 #
-# You can uncomment and change any of the options below.
-# The value shown in the commented settings, is the default value.
-#
-
-[global]
-    run as user = netdata
-
-    # default storage size - increase for longer data retention
-    page cache size = 32
-    dbengine multihost disk space = 256
-


### PR DESCRIPTION
##### Summary

This PR removes all (outdated) configuration options from the `netdata.conf` file used for native packages (deb, rpm), the only data left is comments that explain how to get the latest version of the file. We have such `netdata.conf` in Docker images.

This file:

- contains outdated configuration (db settings in `[global]`) which of course [confuses for users](https://community.netdata.cloud/t/reduce-memory-footprint-of-netdata-agent/5026#what-i-expected-to-happen-4).
- contains just a few settings which is a [known problem](https://github.com/netdata/netdata/issues/12404) but it doesn't look like it will get fixed.
- contains uncommented settings which is a problem because we won't be able to change them for existing installs (e.g. we plan to change dbengine tiers disk space).

The lack of settings will make people pay attention to the comments and they will get the actual configuration using the `/netdata.conf` endpoint.

##### Test Plan

n/a

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
