### PR TITLE
uninstaller: improve removing `netdata` from groups

### DIFF
--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -520,6 +520,15 @@ portable_del_user_from_group() {
   groupname="${1}"
   username="${2}"
 
+  if command -v getent > /dev/null 2>&1; then
+    getent group "${1:-""}" | grep -q "${2}"
+  else
+    grep "^${1}:" /etc/group | grep -q "${2}"
+  fi
+
+  ret=$?
+  [ "${ret}" != "0" ] && return 0
+
   # username is not in group
   info "Deleting ${username} user from ${groupname} group ..."
 
@@ -758,18 +767,15 @@ fi
 
 FILE_REMOVAL_STATUS=1
 
-#### REMOVE NETDATA USER FROM ADDED GROUPS
-if [ -n "$NETDATA_ADDED_TO_GROUPS" ]; then
+#### REMOVE USER
+if user_input "Do you want to delete 'netdata' system user ? "; then
+  portable_del_user "netdata" || :
+elif [ -n "$NETDATA_ADDED_TO_GROUPS" ]; then
   if user_input "Do you want to delete 'netdata' from following groups: '$NETDATA_ADDED_TO_GROUPS' ? "; then
     for group in $NETDATA_ADDED_TO_GROUPS; do
       portable_del_user_from_group "${group}" "netdata"
     done
   fi
-fi
-
-#### REMOVE USER
-if user_input "Do you want to delete 'netdata' system user ? "; then
-  portable_del_user "netdata" || :
 fi
 
 ### REMOVE GROUP


### PR DESCRIPTION
##### Summary

Remove from groups only if:
- the user has not been removed.
- the user is in the group.

<details>
<summary><b>This PR</b></summary>

```bash
Do you want to delete 'netdata' system user ?  [y/n]
n
Do you want to delete 'netdata' from following groups: ' docker nginx varnish haproxy adm nsd proxy squid ceph nobody' ?  [y/n]
y
Tue 09 Jan 2024 01:20:59 PM EET : INFO: netdata-uninstaller.sh:  Deleting netdata user from docker group ...
[/home/ilyam]# gpasswd -d netdata docker
Removing user netdata from group docker
 OK

Tue 09 Jan 2024 01:20:59 PM EET : INFO: netdata-uninstaller.sh:  Deleting netdata user from adm group ...
[/home/ilyam]# gpasswd -d netdata adm
Removing user netdata from group adm
 OK

Tue 09 Jan 2024 01:20:59 PM EET : INFO: netdata-uninstaller.sh:  Deleting netdata user from proxy group ...
[/home/ilyam]# gpasswd -d netdata proxy
Removing user netdata from group proxy
 OK

Do you want to delete 'netdata' system group ?  [y/n]
```

</details>

<details>
<summary><b>Master</b></summary>

```bash
Do you want to delete 'netdata' from following groups: ' docker nginx varnish haproxy adm nsd proxy squid ceph nobody' ?  [y/n]
y
Tue 09 Jan 2024 12:32:40 PM EET : INFO: netdata-uninstaller.sh:  Deleting netdata user from docker group ...
[/home/ilyam]# gpasswd -d netdata docker
Removing user netdata from group docker
 OK

Tue 09 Jan 2024 12:32:40 PM EET : INFO: netdata-uninstaller.sh:  Deleting netdata user from nginx group ...
[/home/ilyam]# gpasswd -d netdata nginx
gpasswd: group 'nginx' does not exist in /etc/group
 FAILED

[/home/ilyam]# delgroup netdata nginx
/usr/sbin/delgroup: The group `nginx' does not exist.
 FAILED

Tue 09 Jan 2024 12:32:40 PM EET : ERROR: netdata-uninstaller.sh:  Failed to delete user netdata from group nginx !
Tue 09 Jan 2024 12:32:40 PM EET : INFO: netdata-uninstaller.sh:  Deleting netdata user from varnish group ...
[/home/ilyam]# gpasswd -d netdata varnish
gpasswd: group 'varnish' does not exist in /etc/group
 FAILED

[/home/ilyam]# delgroup netdata varnish
/usr/sbin/delgroup: The group `varnish' does not exist.
 FAILED

Tue 09 Jan 2024 12:32:40 PM EET : ERROR: netdata-uninstaller.sh:  Failed to delete user netdata from group varnish !
Tue 09 Jan 2024 12:32:40 PM EET : INFO: netdata-uninstaller.sh:  Deleting netdata user from haproxy group ...
[/home/ilyam]# gpasswd -d netdata haproxy
gpasswd: group 'haproxy' does not exist in /etc/group
 FAILED

[/home/ilyam]# delgroup netdata haproxy
/usr/sbin/delgroup: The group `haproxy' does not exist.
 FAILED

Tue 09 Jan 2024 12:32:40 PM EET : ERROR: netdata-uninstaller.sh:  Failed to delete user netdata from group haproxy !
Tue 09 Jan 2024 12:32:40 PM EET : INFO: netdata-uninstaller.sh:  Deleting netdata user from adm group ...
[/home/ilyam]# gpasswd -d netdata adm
Removing user netdata from group adm
 OK

Tue 09 Jan 2024 12:32:40 PM EET : INFO: netdata-uninstaller.sh:  Deleting netdata user from nsd group ...
[/home/ilyam]# gpasswd -d netdata nsd
gpasswd: group 'nsd' does not exist in /etc/group
 FAILED

[/home/ilyam]# delgroup netdata nsd
/usr/sbin/delgroup: The group `nsd' does not exist.
 FAILED

Tue 09 Jan 2024 12:32:40 PM EET : ERROR: netdata-uninstaller.sh:  Failed to delete user netdata from group nsd !
Tue 09 Jan 2024 12:32:40 PM EET : INFO: netdata-uninstaller.sh:  Deleting netdata user from proxy group ...
[/home/ilyam]# gpasswd -d netdata proxy
Removing user netdata from group proxy
 OK

Tue 09 Jan 2024 12:32:40 PM EET : INFO: netdata-uninstaller.sh:  Deleting netdata user from squid group ...
[/home/ilyam]# gpasswd -d netdata squid
gpasswd: group 'squid' does not exist in /etc/group
 FAILED

[/home/ilyam]# delgroup netdata squid
/usr/sbin/delgroup: The group `squid' does not exist.
 FAILED

Tue 09 Jan 2024 12:32:40 PM EET : ERROR: netdata-uninstaller.sh:  Failed to delete user netdata from group squid !
Tue 09 Jan 2024 12:32:40 PM EET : INFO: netdata-uninstaller.sh:  Deleting netdata user from ceph group ...
[/home/ilyam]# gpasswd -d netdata ceph
gpasswd: group 'ceph' does not exist in /etc/group
 FAILED

[/home/ilyam]# delgroup netdata ceph
/usr/sbin/delgroup: The group `ceph' does not exist.
 FAILED

Tue 09 Jan 2024 12:32:40 PM EET : ERROR: netdata-uninstaller.sh:  Failed to delete user netdata from group ceph !
Tue 09 Jan 2024 12:32:40 PM EET : INFO: netdata-uninstaller.sh:  Deleting netdata user from nobody group ...
[/home/ilyam]# gpasswd -d netdata nobody
gpasswd: group 'nobody' does not exist in /etc/group
 FAILED

[/home/ilyam]# delgroup netdata nobody
/usr/sbin/delgroup: The group `nobody' does not exist.
 FAILED

Tue 09 Jan 2024 12:32:40 PM EET : ERROR: netdata-uninstaller.sh:  Failed to delete user netdata from group nobody !
Do you want to delete 'netdata' system user ?  [y/n]
y
Tue 09 Jan 2024 12:33:00 PM EET : INFO: netdata-uninstaller.sh:  Deleting netdata user account ...
[/home/ilyam]# userdel -f netdata
 OK

Do you want to delete 'netdata' system group ?  [y/n]
y
Tue 09 Jan 2024 12:33:04 PM EET : INFO: netdata-uninstaller.sh:  Removing netdata user group ...
Tue 09 Jan 2024 12:33:04 PM EET : INFO: netdata-uninstaller.sh:  Group netdata already removed in a previous step.

Tue 09 Jan 2024 12:33:04 PM EET : INFO: netdata-uninstaller.sh:  Netdata files were successfully removed from your system
```

</details>

##### Test Plan

Use uninstaller script

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
