### PR TITLE
add config to ignore item which has been disabled

### DIFF
--- a/collectors/proc.plugin/proc_diskstats.c
+++ b/collectors/proc.plugin/proc_diskstats.c
@@ -193,6 +193,7 @@ static int name_disks_by_id = CONFIG_BOOLEAN_NO;
 static int global_bcache_priority_stats_update_every = 0; // disabled by default
 
 static int  global_enable_new_disks_detected_at_runtime = CONFIG_BOOLEAN_YES,
+        global_enable_record_excluded_disks = CONFIG_BOOLEAN_YES,
         global_enable_performance_for_physical_disks = CONFIG_BOOLEAN_AUTO,
         global_enable_performance_for_virtual_disks = CONFIG_BOOLEAN_AUTO,
         global_enable_performance_for_partitions = CONFIG_BOOLEAN_NO,
@@ -599,6 +600,11 @@ static void get_disk_config(struct disk *d) {
     if(def_enable != CONFIG_BOOLEAN_NO && (simple_pattern_matches(excluded_disks, d->device) || simple_pattern_matches(excluded_disks, d->disk))) {
         d->excluded = true;
         def_enable = CONFIG_BOOLEAN_NO;
+    }
+
+    if (unlikely(!def_enable && global_enable_record_excluded_disks == CONFIG_BOOLEAN_NO)) {
+        netdata_log_debug(D_COLLECTOR, "DISKSTAT: Skipping device: %s, disk: %s because it is excluded by configuration.", d->device, d->disk);
+        return;
     }
 
     char var_name[4096 + 1];
@@ -1414,6 +1420,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
         globals_initialized = 1;
 
         global_enable_new_disks_detected_at_runtime = config_get_boolean(CONFIG_SECTION_PLUGIN_PROC_DISKSTATS, "enable new disks detected at runtime", global_enable_new_disks_detected_at_runtime);
+        global_enable_record_excluded_disks = config_get_boolean(CONFIG_SECTION_PLUGIN_PROC_DISKSTATS, "enable record exlueded disks", global_enable_record_excluded_disks);
         global_enable_performance_for_physical_disks = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_PROC_DISKSTATS, "performance metrics for physical disks", global_enable_performance_for_physical_disks);
         global_enable_performance_for_virtual_disks = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_PROC_DISKSTATS, "performance metrics for virtual disks", global_enable_performance_for_virtual_disks);
         global_enable_performance_for_partitions = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_PROC_DISKSTATS, "performance metrics for partitions", global_enable_performance_for_partitions);

--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -1109,7 +1109,7 @@ int do_proc_net_dev(int update_every, usec_t dt) {
 
 
         enable_new_interfaces = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_PROC_NETDEV, "enable new interfaces detected at runtime", CONFIG_BOOLEAN_AUTO);
-        enable_record_disabled_interfaces = config_get_boolean(CONFIG_SECTION_PLUGIN_PROC_NETDEV, "record disabled interfaces", CONFIG_BOOLEAN_YES);
+        enable_record_disabled_interfaces = config_get_boolean(CONFIG_SECTION_PLUGIN_PROC_NETDEV, "enable record disabled interfaces", CONFIG_BOOLEAN_YES);
 
         do_bandwidth    = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_PROC_NETDEV, "bandwidth for all interfaces", CONFIG_BOOLEAN_AUTO);
         do_packets      = config_get_boolean_ondemand(CONFIG_SECTION_PLUGIN_PROC_NETDEV, "packets for all interfaces", CONFIG_BOOLEAN_AUTO);

--- a/libnetdata/log/log.h
+++ b/libnetdata/log/log.h
@@ -224,6 +224,7 @@ void log_stack_push(struct log_stack_entry *lgs);
 #define D_RRDENGINE         0x0000000100000000
 #define D_ACLK              0x0000000200000000
 #define D_REPLICATION       0x0000002000000000
+#define D_COLLECTOR         0x0000004000000000
 #define D_SYSTEM            0x8000000000000000
 
 extern uint64_t debug_flags;


### PR DESCRIPTION
##### Summary
We notice netdata will usage so much memroy in machine which will start and stop many container, (it will create thousands of net devices and mount points, and will destory after container stop); netdata will record all netdev and mount point, it will usage so much memory after run long time. 

I add the switch for proc_net_dev, proc_diskstats, disk_space, when the switch set no, if a net dev is ignore in proc:/proc/net/dev -> disable by default interfaces matching , it will not show in online netdata.conf.
Disk stat and disk stat will have same action after the config set off.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
will add options `enable record excluded mountpoints or filesystems` for plugin diskspace, 
add option `enable record exlueded disks` for plugin proc(disk stat),
add option `enable record disabled interfaces` for plugin proc(netdev),
the options set YES as default value.

</details>
