### PR TITLE
cmake: fix syntax error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ if(NOT ${DISABLE_HARDENING})
         endif()
 
         if(NOT ${CMAKE_C_FLAGS} MATCHES "stack-clash-protection")
-                check_c_compiler_flag("-fstack-clash-protection", HAVE_STACK_CLASH_FLAG)
+                check_c_compiler_flag("-fstack-clash-protection" HAVE_STACK_CLASH_FLAG)
                 if(HAVE_STACK_CLASH_FLAG)
                         set(EXTRA_HARDENING_FLAGS "${EXTRA_HARDENING_FLAGS} -fstack-clash-protection")
                 endif()


### PR DESCRIPTION
##### Summary
Fixes cmake warning:
```
CMake Warning (dev) at CMakeLists.txt:135:
  Syntax Warning in cmake code at column 65

  Argument not separated from preceding token by whitespace.
```

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
