### PR TITLE
fix cpu per core charts priority

### DIFF
--- a/collectors/all.h
+++ b/collectors/all.h
@@ -59,16 +59,14 @@
 // CPU per core
 
 #define NETDATA_CHART_PRIO_CPU_PER_CORE               1000 // +1 per core
+#define NETDATA_CHART_PRIO_CPUFREQ_SCALING_CUR_FREQ   1002
+#define NETDATA_CHART_PRIO_CORE_THROTTLING            1003
+#define NETDATA_CHART_PRIO_PACKAGE_THROTTLING         1004
+#define NETDATA_CHART_PRIO_CPUIDLE                    1005
+#define NETDATA_CHART_PRIO_INTERRUPTS_PER_CORE        1006 // +1 per core
+#define NETDATA_CHART_PRIO_POWERCAP                   1007 // Linux powercap
 #define NETDATA_CHART_PRIO_CPU_TEMPERATURE            1050 // freebsd only
-#define NETDATA_CHART_PRIO_CPUFREQ_SCALING_CUR_FREQ   5003 // freebsd only
-#define NETDATA_CHART_PRIO_CPUIDLE                    6000
 
-#define NETDATA_CHART_PRIO_CORE_THROTTLING            5001
-#define NETDATA_CHART_PRIO_PACKAGE_THROTTLING         5002
-
-// Interrupts per core
-
-#define NETDATA_CHART_PRIO_INTERRUPTS_PER_CORE        1100 // +1 per core
 
 // Memory Section - 1xxx
 
@@ -383,10 +381,6 @@
 #define NETDATA_CHART_PRIO_POWER_SUPPLY_CHARGE        9501
 #define NETDATA_CHART_PRIO_POWER_SUPPLY_ENERGY        9502
 #define NETDATA_CHART_PRIO_POWER_SUPPLY_VOLTAGE       9503
-
-// Linux powercap
-
-#define NETDATA_CHART_PRIO_POWERCAP                   9600
 
 // Wireless
 


### PR DESCRIPTION
##### Summary

[Reported on Discord](https://discord.com/channels/847502280503590932/1192515472151826534/1194678175024824482).

This is necessary to ensure that the CPU section is second on the dashboard regardless of the enabled/disabled collector.

##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
