### PR TITLE
Name storage engine variables consistently.

### DIFF
--- a/daemon/global_statistics.c
+++ b/daemon/global_statistics.c
@@ -2560,9 +2560,9 @@ static void dbengine2_statistics_charts(void) {
                 /* get localhost's DB engine's statistics for each tier */
                 for(size_t tier = 0; tier < storage_tiers ;tier++) {
                     if(host->db[tier].mode != RRD_MEMORY_MODE_DBENGINE) continue;
-                    if(!host->db[tier].instance) continue;
+                    if(!host->db[tier].si) continue;
 
-                    if(is_storage_engine_shared(host->db[tier].instance)) {
+                    if(is_storage_engine_shared(host->db[tier].si)) {
                         if(counted_multihost_db[tier])
                             continue;
                         else
@@ -2570,7 +2570,7 @@ static void dbengine2_statistics_charts(void) {
                     }
 
                     ++dbengine_contexts;
-                    rrdeng_get_37_statistics((struct rrdengine_instance *)host->db[tier].instance, local_stats_array);
+                    rrdeng_get_37_statistics((struct rrdengine_instance *)host->db[tier].si, local_stats_array);
                     for (i = 0; i < RRDENG_NR_STATS; ++i) {
                         /* aggregate statistics across hosts */
                         stats_array[i] += local_stats_array[i];

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -275,7 +275,7 @@ restart_after_removal:
 
             if (rrdhost_option_check(host, RRDHOST_OPTION_DELETE_ORPHAN_HOST)
                 /* don't delete multi-host DB host files */
-                && !(host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && is_storage_engine_shared(host->db[0].instance))
+                && !(host->rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE && is_storage_engine_shared(host->db[0].si))
             ) {
                 worker_is_busy(WORKER_JOB_DELETE_HOST_CHARTS);
                 rrdhost_delete_charts(host);

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -52,13 +52,13 @@ static void svc_rrddim_obsolete_to_archive(RRDDIM *rd) {
 
         size_t tiers_available = 0, tiers_said_no_retention = 0;
         for(size_t tier = 0; tier < storage_tiers ;tier++) {
-            if(rd->tiers[tier].db_collection_handle) {
+            if(rd->tiers[tier].sch) {
                 tiers_available++;
 
-                if(storage_engine_store_finalize(rd->tiers[tier].db_collection_handle))
+                if(storage_engine_store_finalize(rd->tiers[tier].sch))
                     tiers_said_no_retention++;
 
-                rd->tiers[tier].db_collection_handle = NULL;
+                rd->tiers[tier].sch = NULL;
             }
         }
 

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -2237,9 +2237,9 @@ int test_dbengine(void)
     }
 
     rrd_wrlock();
-    rrdeng_prepare_exit((struct rrdengine_instance *)host->db[0].instance);
+    rrdeng_prepare_exit((struct rrdengine_instance *)host->db[0].si);
     rrdhost_delete_charts(host);
-    rrdeng_exit((struct rrdengine_instance *)host->db[0].instance);
+    rrdeng_exit((struct rrdengine_instance *)host->db[0].si);
     rrdeng_enq_cmd(NULL, RRDENG_OPCODE_SHUTDOWN_EVLOOP, NULL, NULL, STORAGE_PRIORITY_BEST_EFFORT, NULL, NULL);
     rrd_unlock();
 
@@ -2647,9 +2647,9 @@ void dbengine_stress_test(unsigned TEST_DURATION_SEC, unsigned DSET_CHARTS, unsi
     }
     freez(query_threads);
     rrd_wrlock();
-    rrdeng_prepare_exit((struct rrdengine_instance *)host->db[0].instance);
+    rrdeng_prepare_exit((struct rrdengine_instance *)host->db[0].si);
     rrdhost_delete_charts(host);
-    rrdeng_exit((struct rrdengine_instance *)host->db[0].instance);
+    rrdeng_exit((struct rrdengine_instance *)host->db[0].si);
     rrdeng_enq_cmd(NULL, RRDENG_OPCODE_SHUTDOWN_EVLOOP, NULL, NULL, STORAGE_PRIORITY_BEST_EFFORT, NULL, NULL);
     rrd_unlock();
 }

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1966,7 +1966,7 @@ static int test_dbengine_check_metrics(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS][DI
     int i, j, k, c, errors, update_every;
     collected_number last;
     NETDATA_DOUBLE value, expected;
-    struct storage_engine_query_handle handle;
+    struct storage_engine_query_handle seqh;
     size_t value_errors = 0, time_errors = 0;
 
     update_every = REGION_UPDATE_EVERY[current_region];
@@ -1977,13 +1977,13 @@ static int test_dbengine_check_metrics(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS][DI
         time_now = time_start + (c + 1) * update_every;
         for (i = 0 ; i < CHARTS ; ++i) {
             for (j = 0; j < DIMS; ++j) {
-                storage_engine_query_init(rd[i][j]->tiers[0].backend, rd[i][j]->tiers[0].smh, &handle, time_now, time_now + QUERY_BATCH * update_every, STORAGE_PRIORITY_NORMAL);
+                storage_engine_query_init(rd[i][j]->tiers[0].backend, rd[i][j]->tiers[0].smh, &seqh, time_now, time_now + QUERY_BATCH * update_every, STORAGE_PRIORITY_NORMAL);
                 for (k = 0; k < QUERY_BATCH; ++k) {
                     last = ((collected_number)i * DIMS) * REGION_POINTS[current_region] +
                            j * REGION_POINTS[current_region] + c + k;
                     expected = unpack_storage_number(pack_storage_number((NETDATA_DOUBLE)last, SN_DEFAULT_FLAGS));
 
-                    STORAGE_POINT sp = storage_engine_query_next_metric(&handle);
+                    STORAGE_POINT sp = storage_engine_query_next_metric(&seqh);
                     value = sp.sum;
                     time_retrieved = sp.start_time_s;
                     end_time = sp.end_time_s;
@@ -2005,7 +2005,7 @@ static int test_dbengine_check_metrics(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS][DI
                         errors++;
                     }
                 }
-                storage_engine_query_finalize(&handle);
+                storage_engine_query_finalize(&seqh);
             }
         }
     }
@@ -2418,7 +2418,7 @@ static void query_dbengine_chart(void *arg)
     time_t time_now, time_retrieved, end_time;
     collected_number generatedv;
     NETDATA_DOUBLE value, expected;
-    struct storage_engine_query_handle handle;
+    struct storage_engine_query_handle seqh;
     size_t value_errors = 0, time_errors = 0;
 
     do {
@@ -2445,13 +2445,13 @@ static void query_dbengine_chart(void *arg)
             time_before = MIN(time_after + duration, time_max); /* up to 1 hour queries */
         }
 
-        storage_engine_query_init(rd->tiers[0].backend, rd->tiers[0].smh, &handle, time_after, time_before, STORAGE_PRIORITY_NORMAL);
+        storage_engine_query_init(rd->tiers[0].backend, rd->tiers[0].smh, &seqh, time_after, time_before, STORAGE_PRIORITY_NORMAL);
         ++thread_info->queries_nr;
         for (time_now = time_after ; time_now <= time_before ; time_now += update_every) {
             generatedv = generate_dbengine_chart_value(i, j, time_now);
             expected = unpack_storage_number(pack_storage_number((NETDATA_DOUBLE) generatedv, SN_DEFAULT_FLAGS));
 
-            if (unlikely(storage_engine_query_is_finished(&handle))) {
+            if (unlikely(storage_engine_query_is_finished(&seqh))) {
                 if (!thread_info->delete_old_data) { /* data validation only when we don't delete */
                     fprintf(stderr, "    DB-engine stresstest %s/%s: at %lu secs, expecting value " NETDATA_DOUBLE_FORMAT
                         ", found data gap, ### E R R O R ###\n",
@@ -2461,7 +2461,7 @@ static void query_dbengine_chart(void *arg)
                 break;
             }
 
-            STORAGE_POINT sp = storage_engine_query_next_metric(&handle);
+            STORAGE_POINT sp = storage_engine_query_next_metric(&seqh);
             value = sp.sum;
             time_retrieved = sp.start_time_s;
             end_time = sp.end_time_s;
@@ -2499,7 +2499,7 @@ static void query_dbengine_chart(void *arg)
                 }
             }
         }
-        storage_engine_query_finalize(&handle);
+        storage_engine_query_finalize(&seqh);
     } while(!thread_info->done);
 
     if(value_errors)

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1977,7 +1977,7 @@ static int test_dbengine_check_metrics(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS][DI
         time_now = time_start + (c + 1) * update_every;
         for (i = 0 ; i < CHARTS ; ++i) {
             for (j = 0; j < DIMS; ++j) {
-                storage_engine_query_init(rd[i][j]->tiers[0].backend, rd[i][j]->tiers[0].db_metric_handle, &handle, time_now, time_now + QUERY_BATCH * update_every, STORAGE_PRIORITY_NORMAL);
+                storage_engine_query_init(rd[i][j]->tiers[0].backend, rd[i][j]->tiers[0].smh, &handle, time_now, time_now + QUERY_BATCH * update_every, STORAGE_PRIORITY_NORMAL);
                 for (k = 0; k < QUERY_BATCH; ++k) {
                     last = ((collected_number)i * DIMS) * REGION_POINTS[current_region] +
                            j * REGION_POINTS[current_region] + c + k;
@@ -2445,7 +2445,7 @@ static void query_dbengine_chart(void *arg)
             time_before = MIN(time_after + duration, time_max); /* up to 1 hour queries */
         }
 
-        storage_engine_query_init(rd->tiers[0].backend, rd->tiers[0].db_metric_handle, &handle, time_after, time_before, STORAGE_PRIORITY_NORMAL);
+        storage_engine_query_init(rd->tiers[0].backend, rd->tiers[0].smh, &handle, time_after, time_before, STORAGE_PRIORITY_NORMAL);
         ++thread_info->queries_nr;
         for (time_now = time_after ; time_now <= time_before ; time_now += update_every) {
             generatedv = generate_dbengine_chart_value(i, j, time_now);

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1977,7 +1977,7 @@ static int test_dbengine_check_metrics(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS][DI
         time_now = time_start + (c + 1) * update_every;
         for (i = 0 ; i < CHARTS ; ++i) {
             for (j = 0; j < DIMS; ++j) {
-                storage_engine_query_init(rd[i][j]->tiers[0].backend, rd[i][j]->tiers[0].smh, &seqh, time_now, time_now + QUERY_BATCH * update_every, STORAGE_PRIORITY_NORMAL);
+                storage_engine_query_init(rd[i][j]->tiers[0].seb, rd[i][j]->tiers[0].smh, &seqh, time_now, time_now + QUERY_BATCH * update_every, STORAGE_PRIORITY_NORMAL);
                 for (k = 0; k < QUERY_BATCH; ++k) {
                     last = ((collected_number)i * DIMS) * REGION_POINTS[current_region] +
                            j * REGION_POINTS[current_region] + c + k;
@@ -2445,7 +2445,7 @@ static void query_dbengine_chart(void *arg)
             time_before = MIN(time_after + duration, time_max); /* up to 1 hour queries */
         }
 
-        storage_engine_query_init(rd->tiers[0].backend, rd->tiers[0].smh, &seqh, time_after, time_before, STORAGE_PRIORITY_NORMAL);
+        storage_engine_query_init(rd->tiers[0].seb, rd->tiers[0].smh, &seqh, time_after, time_before, STORAGE_PRIORITY_NORMAL);
         ++thread_info->queries_nr;
         for (time_now = time_after ; time_now <= time_before ; time_now += update_every) {
             generatedv = generate_dbengine_chart_value(i, j, time_now);

--- a/daemon/unit_test.c
+++ b/daemon/unit_test.c
@@ -1907,7 +1907,7 @@ static void test_dbengine_create_charts(RRDHOST *host, RRDSET *st[CHARTS], RRDDI
     // Flush pages for subsequent real values
     for (i = 0 ; i < CHARTS ; ++i) {
         for (j = 0; j < DIMS; ++j) {
-            rrdeng_store_metric_flush_current_page((rd[i][j])->tiers[0].db_collection_handle);
+            rrdeng_store_metric_flush_current_page((rd[i][j])->tiers[0].sch);
         }
     }
 }
@@ -1926,7 +1926,7 @@ static time_t test_dbengine_create_metrics(RRDSET *st[CHARTS], RRDDIM *rd[CHARTS
     // feed it with the test data
     for (i = 0 ; i < CHARTS ; ++i) {
         for (j = 0 ; j < DIMS ; ++j) {
-            storage_engine_store_change_collection_frequency(rd[i][j]->tiers[0].db_collection_handle, update_every);
+            storage_engine_store_change_collection_frequency(rd[i][j]->tiers[0].sch, update_every);
 
             rd[i][j]->collector.last_collected_time.tv_sec =
             st[i]->last_collected_time.tv_sec = st[i]->last_updated.tv_sec = time_now;
@@ -2143,7 +2143,7 @@ int test_dbengine(void)
     for (i = 0 ; i < CHARTS ; ++i) {
         st[i]->update_every = update_every;
         for (j = 0; j < DIMS; ++j) {
-            rrdeng_store_metric_flush_current_page((rd[i][j])->tiers[0].db_collection_handle);
+            rrdeng_store_metric_flush_current_page((rd[i][j])->tiers[0].sch);
         }
     }
 
@@ -2161,7 +2161,7 @@ int test_dbengine(void)
     for (i = 0 ; i < CHARTS ; ++i) {
         st[i]->update_every = update_every;
         for (j = 0; j < DIMS; ++j) {
-            rrdeng_store_metric_flush_current_page((rd[i][j])->tiers[0].db_collection_handle);
+            rrdeng_store_metric_flush_current_page((rd[i][j])->tiers[0].sch);
         }
     }
 
@@ -2325,7 +2325,7 @@ static void generate_dbengine_chart(void *arg)
         thread_info->time_max = time_current;
     }
     for (j = 0; j < DSET_DIMS; ++j) {
-        rrdeng_store_metric_finalize((rd[j])->tiers[0].db_collection_handle);
+        rrdeng_store_metric_finalize((rd[j])->tiers[0].sch);
     }
 }
 

--- a/database/contexts/api_v2.c
+++ b/database/contexts/api_v2.c
@@ -1019,10 +1019,10 @@ void buffer_json_agents_v2(BUFFER *wb, struct query_timings *timings, time_t now
             STORAGE_ENGINE *eng = localhost->db[tier].eng;
             if (!eng) continue;
 
-            uint64_t max = storage_engine_disk_space_max(eng->backend, localhost->db[tier].si);
-            uint64_t used = storage_engine_disk_space_used(eng->backend, localhost->db[tier].si);
-            time_t first_time_s = storage_engine_global_first_time_s(eng->backend, localhost->db[tier].si);
-            size_t currently_collected_metrics = storage_engine_collected_metrics(eng->backend, localhost->db[tier].si);
+            uint64_t max = storage_engine_disk_space_max(eng->seb, localhost->db[tier].si);
+            uint64_t used = storage_engine_disk_space_used(eng->seb, localhost->db[tier].si);
+            time_t first_time_s = storage_engine_global_first_time_s(eng->seb, localhost->db[tier].si);
+            size_t currently_collected_metrics = storage_engine_collected_metrics(eng->seb, localhost->db[tier].si);
 
             NETDATA_DOUBLE percent;
             if (used && max)

--- a/database/contexts/api_v2.c
+++ b/database/contexts/api_v2.c
@@ -1019,10 +1019,10 @@ void buffer_json_agents_v2(BUFFER *wb, struct query_timings *timings, time_t now
             STORAGE_ENGINE *eng = localhost->db[tier].eng;
             if (!eng) continue;
 
-            uint64_t max = storage_engine_disk_space_max(eng->backend, localhost->db[tier].instance);
-            uint64_t used = storage_engine_disk_space_used(eng->backend, localhost->db[tier].instance);
-            time_t first_time_s = storage_engine_global_first_time_s(eng->backend, localhost->db[tier].instance);
-            size_t currently_collected_metrics = storage_engine_collected_metrics(eng->backend, localhost->db[tier].instance);
+            uint64_t max = storage_engine_disk_space_max(eng->backend, localhost->db[tier].si);
+            uint64_t used = storage_engine_disk_space_used(eng->backend, localhost->db[tier].si);
+            time_t first_time_s = storage_engine_global_first_time_s(eng->backend, localhost->db[tier].si);
+            size_t currently_collected_metrics = storage_engine_collected_metrics(eng->backend, localhost->db[tier].si);
 
             NETDATA_DOUBLE percent;
             if (used && max)

--- a/database/contexts/query_target.c
+++ b/database/contexts/query_target.c
@@ -255,7 +255,7 @@ static bool query_metric_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_CON
         if(rm->rrddim && rm->rrddim->tiers[tier].db_metric_handle)
             tier_retention[tier].db_metric_handle = eng->api.metric_dup(rm->rrddim->tiers[tier].db_metric_handle);
         else
-            tier_retention[tier].db_metric_handle = eng->api.metric_get(qn->rrdhost->db[tier].instance, &rm->uuid);
+            tier_retention[tier].db_metric_handle = eng->api.metric_get(qn->rrdhost->db[tier].si, &rm->uuid);
 
         if(tier_retention[tier].db_metric_handle) {
             tier_retention[tier].db_first_time_s = storage_engine_oldest_time_s(tier_retention[tier].eng->backend, tier_retention[tier].db_metric_handle);

--- a/database/contexts/query_target.c
+++ b/database/contexts/query_target.c
@@ -221,10 +221,10 @@ static inline void query_metric_release(QUERY_TARGET *qt, QUERY_METRIC *qm) {
 
     // reset the tiers
     for(size_t tier = 0; tier < storage_tiers ;tier++) {
-        if(qm->tiers[tier].db_metric_handle) {
+        if(qm->tiers[tier].smh) {
             STORAGE_ENGINE *eng = query_metric_storage_engine(qt, qm, tier);
-            eng->api.metric_release(qm->tiers[tier].db_metric_handle);
-            qm->tiers[tier].db_metric_handle = NULL;
+            eng->api.metric_release(qm->tiers[tier].smh);
+            qm->tiers[tier].smh = NULL;
         }
     }
 }
@@ -241,7 +241,7 @@ static bool query_metric_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_CON
 
     struct {
         STORAGE_ENGINE *eng;
-        STORAGE_METRIC_HANDLE *db_metric_handle;
+        STORAGE_METRIC_HANDLE *smh;
         time_t db_first_time_s;
         time_t db_last_time_s;
         time_t db_update_every_s;
@@ -252,14 +252,14 @@ static bool query_metric_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_CON
         tier_retention[tier].eng = eng;
         tier_retention[tier].db_update_every_s = (time_t) (qn->rrdhost->db[tier].tier_grouping * ri->update_every_s);
 
-        if(rm->rrddim && rm->rrddim->tiers[tier].db_metric_handle)
-            tier_retention[tier].db_metric_handle = eng->api.metric_dup(rm->rrddim->tiers[tier].db_metric_handle);
+        if(rm->rrddim && rm->rrddim->tiers[tier].smh)
+            tier_retention[tier].smh = eng->api.metric_dup(rm->rrddim->tiers[tier].smh);
         else
-            tier_retention[tier].db_metric_handle = eng->api.metric_get(qn->rrdhost->db[tier].si, &rm->uuid);
+            tier_retention[tier].smh = eng->api.metric_get(qn->rrdhost->db[tier].si, &rm->uuid);
 
-        if(tier_retention[tier].db_metric_handle) {
-            tier_retention[tier].db_first_time_s = storage_engine_oldest_time_s(tier_retention[tier].eng->backend, tier_retention[tier].db_metric_handle);
-            tier_retention[tier].db_last_time_s = storage_engine_latest_time_s(tier_retention[tier].eng->backend, tier_retention[tier].db_metric_handle);
+        if(tier_retention[tier].smh) {
+            tier_retention[tier].db_first_time_s = storage_engine_oldest_time_s(tier_retention[tier].eng->backend, tier_retention[tier].smh);
+            tier_retention[tier].db_last_time_s = storage_engine_latest_time_s(tier_retention[tier].eng->backend, tier_retention[tier].smh);
 
             if(!common_first_time_s)
                 common_first_time_s = tier_retention[tier].db_first_time_s;
@@ -331,7 +331,7 @@ static bool query_metric_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_CON
 
         for (size_t tier = 0; tier < storage_tiers; tier++) {
             internal_fatal(tier_retention[tier].eng != query_metric_storage_engine(qt, qm, tier), "QUERY TARGET: storage engine mismatch");
-            qm->tiers[tier].db_metric_handle = tier_retention[tier].db_metric_handle;
+            qm->tiers[tier].smh = tier_retention[tier].smh;
             qm->tiers[tier].db_first_time_s = tier_retention[tier].db_first_time_s;
             qm->tiers[tier].db_last_time_s = tier_retention[tier].db_last_time_s;
             qm->tiers[tier].db_update_every_s = tier_retention[tier].db_update_every_s;
@@ -342,8 +342,8 @@ static bool query_metric_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_CON
 
     // cleanup anything we allocated to the retention we will not use
     for(size_t tier = 0; tier < storage_tiers ;tier++) {
-        if (tier_retention[tier].db_metric_handle)
-            tier_retention[tier].eng->api.metric_release(tier_retention[tier].db_metric_handle);
+        if (tier_retention[tier].smh)
+            tier_retention[tier].eng->api.metric_release(tier_retention[tier].smh);
     }
 
     return false;

--- a/database/contexts/query_target.c
+++ b/database/contexts/query_target.c
@@ -258,8 +258,8 @@ static bool query_metric_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_CON
             tier_retention[tier].smh = eng->api.metric_get(qn->rrdhost->db[tier].si, &rm->uuid);
 
         if(tier_retention[tier].smh) {
-            tier_retention[tier].db_first_time_s = storage_engine_oldest_time_s(tier_retention[tier].eng->backend, tier_retention[tier].smh);
-            tier_retention[tier].db_last_time_s = storage_engine_latest_time_s(tier_retention[tier].eng->backend, tier_retention[tier].smh);
+            tier_retention[tier].db_first_time_s = storage_engine_oldest_time_s(tier_retention[tier].eng->seb, tier_retention[tier].smh);
+            tier_retention[tier].db_last_time_s = storage_engine_latest_time_s(tier_retention[tier].eng->seb, tier_retention[tier].smh);
 
             if(!common_first_time_s)
                 common_first_time_s = tier_retention[tier].db_first_time_s;

--- a/database/contexts/rrdcontext.h
+++ b/database/contexts/rrdcontext.h
@@ -210,7 +210,7 @@ typedef struct query_metric {
     RRDR_DIMENSION_FLAGS status;
 
     struct query_metric_tier {
-        STORAGE_METRIC_HANDLE *db_metric_handle;
+        STORAGE_METRIC_HANDLE *smh;
         time_t db_first_time_s;         // the oldest timestamp available for this tier
         time_t db_last_time_s;          // the latest timestamp available for this tier
         time_t db_update_every_s;       // latest update every for this tier

--- a/database/contexts/worker.c
+++ b/database/contexts/worker.c
@@ -239,7 +239,7 @@ bool rrdmetric_update_retention(RRDMETRIC *rm) {
             STORAGE_ENGINE *eng = rrdhost->db[tier].eng;
 
             time_t first_time_t, last_time_t;
-            if (eng->api.metric_retention_by_uuid(rrdhost->db[tier].instance, &rm->uuid, &first_time_t, &last_time_t)) {
+            if (eng->api.metric_retention_by_uuid(rrdhost->db[tier].si, &rm->uuid, &first_time_t, &last_time_t)) {
                 if (first_time_t < min_first_time_t)
                     min_first_time_t = first_time_t;
 

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -262,7 +262,7 @@ STORAGE_COLLECT_HANDLE *rrdeng_store_metric_init(STORAGE_METRIC_HANDLE *smh, uin
     struct rrdeng_collect_handle *handle;
 
     handle = callocz(1, sizeof(struct rrdeng_collect_handle));
-    handle->common.backend = STORAGE_ENGINE_BACKEND_DBENGINE;
+    handle->common.seb = STORAGE_ENGINE_BACKEND_DBENGINE;
     handle->metric = metric;
     
     handle->pgc_page = NULL;
@@ -755,7 +755,7 @@ void rrdeng_load_metric_init(STORAGE_METRIC_HANDLE *smh,
         seqh->start_time_s = handle->start_time_s;
         seqh->end_time_s = handle->end_time_s;
         seqh->priority = priority;
-        seqh->backend = STORAGE_ENGINE_BACKEND_DBENGINE;
+        seqh->seb = STORAGE_ENGINE_BACKEND_DBENGINE;
 
         pg_cache_preload(handle);
 
@@ -771,7 +771,7 @@ void rrdeng_load_metric_init(STORAGE_METRIC_HANDLE *smh,
         seqh->start_time_s = handle->start_time_s;
         seqh->end_time_s = 0;
         seqh->priority = priority;
-        seqh->backend = STORAGE_ENGINE_BACKEND_DBENGINE;
+        seqh->seb = STORAGE_ENGINE_BACKEND_DBENGINE;
     }
 }
 

--- a/database/engine/rrdengineapi.c
+++ b/database/engine/rrdengineapi.c
@@ -118,13 +118,13 @@ static METRIC *rrdeng_metric_get_legacy(STORAGE_INSTANCE *si, const char *rd_id,
 // ----------------------------------------------------------------------------
 // metric handle
 
-void rrdeng_metric_release(STORAGE_METRIC_HANDLE *db_metric_handle) {
-    METRIC *metric = (METRIC *)db_metric_handle;
+void rrdeng_metric_release(STORAGE_METRIC_HANDLE *smh) {
+    METRIC *metric = (METRIC *)smh;
     mrg_metric_release(main_mrg, metric);
 }
 
-STORAGE_METRIC_HANDLE *rrdeng_metric_dup(STORAGE_METRIC_HANDLE *db_metric_handle) {
-    METRIC *metric = (METRIC *)db_metric_handle;
+STORAGE_METRIC_HANDLE *rrdeng_metric_dup(STORAGE_METRIC_HANDLE *smh) {
+    METRIC *metric = (METRIC *)smh;
     return (STORAGE_METRIC_HANDLE *) mrg_metric_dup(main_mrg, metric);
 }
 
@@ -245,8 +245,8 @@ static inline bool check_completed_page_consistency(struct rrdeng_collect_handle
  * Gets a handle for storing metrics to the database.
  * The handle must be released with rrdeng_store_metric_final().
  */
-STORAGE_COLLECT_HANDLE *rrdeng_store_metric_init(STORAGE_METRIC_HANDLE *db_metric_handle, uint32_t update_every, STORAGE_METRICS_GROUP *smg) {
-    METRIC *metric = (METRIC *)db_metric_handle;
+STORAGE_COLLECT_HANDLE *rrdeng_store_metric_init(STORAGE_METRIC_HANDLE *smh, uint32_t update_every, STORAGE_METRICS_GROUP *smg) {
+    METRIC *metric = (METRIC *)smh;
     struct rrdengine_instance *ctx = mrg_metric_ctx(metric);
 
     bool is_1st_metric_writer = true;
@@ -704,7 +704,7 @@ static void unregister_query_handle(struct rrdeng_query_handle *handle __maybe_u
  * Gets a handle for loading metrics from the database.
  * The handle must be released with rrdeng_load_metric_final().
  */
-void rrdeng_load_metric_init(STORAGE_METRIC_HANDLE *db_metric_handle,
+void rrdeng_load_metric_init(STORAGE_METRIC_HANDLE *smh,
                              struct storage_engine_query_handle *rrddim_handle,
                              time_t start_time_s,
                              time_t end_time_s,
@@ -714,7 +714,7 @@ void rrdeng_load_metric_init(STORAGE_METRIC_HANDLE *db_metric_handle,
 
     netdata_thread_disable_cancelability();
 
-    METRIC *metric = (METRIC *)db_metric_handle;
+    METRIC *metric = (METRIC *)smh;
     struct rrdengine_instance *ctx = mrg_metric_ctx(metric);
     struct rrdeng_query_handle *handle;
 
@@ -918,8 +918,8 @@ time_t rrdeng_load_align_to_optimal_before(struct storage_engine_query_handle *r
     return rrddim_handle->end_time_s;
 }
 
-time_t rrdeng_metric_latest_time(STORAGE_METRIC_HANDLE *db_metric_handle) {
-    METRIC *metric = (METRIC *)db_metric_handle;
+time_t rrdeng_metric_latest_time(STORAGE_METRIC_HANDLE *smh) {
+    METRIC *metric = (METRIC *)smh;
     time_t latest_time_s = 0;
 
     if (metric)
@@ -928,8 +928,8 @@ time_t rrdeng_metric_latest_time(STORAGE_METRIC_HANDLE *db_metric_handle) {
     return latest_time_s;
 }
 
-time_t rrdeng_metric_oldest_time(STORAGE_METRIC_HANDLE *db_metric_handle) {
-    METRIC *metric = (METRIC *)db_metric_handle;
+time_t rrdeng_metric_oldest_time(STORAGE_METRIC_HANDLE *smh) {
+    METRIC *metric = (METRIC *)smh;
 
     time_t oldest_time_s = 0;
     if (metric)

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -28,10 +28,10 @@ void rrdeng_generate_legacy_uuid(const char *dim_id, const char *chart_id, uuid_
 
 STORAGE_METRIC_HANDLE *rrdeng_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE *si);
 STORAGE_METRIC_HANDLE *rrdeng_metric_get(STORAGE_INSTANCE *si, uuid_t *uuid);
-void rrdeng_metric_release(STORAGE_METRIC_HANDLE *db_metric_handle);
-STORAGE_METRIC_HANDLE *rrdeng_metric_dup(STORAGE_METRIC_HANDLE *db_metric_handle);
+void rrdeng_metric_release(STORAGE_METRIC_HANDLE *smh);
+STORAGE_METRIC_HANDLE *rrdeng_metric_dup(STORAGE_METRIC_HANDLE *smh);
 
-STORAGE_COLLECT_HANDLE *rrdeng_store_metric_init(STORAGE_METRIC_HANDLE *db_metric_handle, uint32_t update_every, STORAGE_METRICS_GROUP *smg);
+STORAGE_COLLECT_HANDLE *rrdeng_store_metric_init(STORAGE_METRIC_HANDLE *smh, uint32_t update_every, STORAGE_METRICS_GROUP *smg);
 void rrdeng_store_metric_flush_current_page(STORAGE_COLLECT_HANDLE *collection_handle);
 void rrdeng_store_metric_change_collection_frequency(STORAGE_COLLECT_HANDLE *collection_handle, int update_every);
 void rrdeng_store_metric_next(STORAGE_COLLECT_HANDLE *collection_handle, usec_t point_in_time_ut, NETDATA_DOUBLE n,
@@ -42,15 +42,15 @@ void rrdeng_store_metric_next(STORAGE_COLLECT_HANDLE *collection_handle, usec_t 
                                      SN_FLAGS flags);
 int rrdeng_store_metric_finalize(STORAGE_COLLECT_HANDLE *collection_handle);
 
-void rrdeng_load_metric_init(STORAGE_METRIC_HANDLE *db_metric_handle, struct storage_engine_query_handle *rrddim_handle,
+void rrdeng_load_metric_init(STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_handle *rrddim_handle,
                                     time_t start_time_s, time_t end_time_s, STORAGE_PRIORITY priority);
 STORAGE_POINT rrdeng_load_metric_next(struct storage_engine_query_handle *rrddim_handle);
 
 
 int rrdeng_load_metric_is_finished(struct storage_engine_query_handle *rrddim_handle);
 void rrdeng_load_metric_finalize(struct storage_engine_query_handle *rrddim_handle);
-time_t rrdeng_metric_latest_time(STORAGE_METRIC_HANDLE *db_metric_handle);
-time_t rrdeng_metric_oldest_time(STORAGE_METRIC_HANDLE *db_metric_handle);
+time_t rrdeng_metric_latest_time(STORAGE_METRIC_HANDLE *smh);
+time_t rrdeng_metric_oldest_time(STORAGE_METRIC_HANDLE *smh);
 time_t rrdeng_load_align_to_optimal_before(struct storage_engine_query_handle *rrddim_handle);
 
 void rrdeng_get_37_statistics(struct rrdengine_instance *ctx, unsigned long long *array);

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -42,16 +42,16 @@ void rrdeng_store_metric_next(STORAGE_COLLECT_HANDLE *collection_handle, usec_t 
                                      SN_FLAGS flags);
 int rrdeng_store_metric_finalize(STORAGE_COLLECT_HANDLE *collection_handle);
 
-void rrdeng_load_metric_init(STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_handle *rrddim_handle,
+void rrdeng_load_metric_init(STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_handle *seqh,
                                     time_t start_time_s, time_t end_time_s, STORAGE_PRIORITY priority);
-STORAGE_POINT rrdeng_load_metric_next(struct storage_engine_query_handle *rrddim_handle);
+STORAGE_POINT rrdeng_load_metric_next(struct storage_engine_query_handle *seqh);
 
 
-int rrdeng_load_metric_is_finished(struct storage_engine_query_handle *rrddim_handle);
-void rrdeng_load_metric_finalize(struct storage_engine_query_handle *rrddim_handle);
+int rrdeng_load_metric_is_finished(struct storage_engine_query_handle *seqh);
+void rrdeng_load_metric_finalize(struct storage_engine_query_handle *seqh);
 time_t rrdeng_metric_latest_time(STORAGE_METRIC_HANDLE *smh);
 time_t rrdeng_metric_oldest_time(STORAGE_METRIC_HANDLE *smh);
-time_t rrdeng_load_align_to_optimal_before(struct storage_engine_query_handle *rrddim_handle);
+time_t rrdeng_load_align_to_optimal_before(struct storage_engine_query_handle *seqh);
 
 void rrdeng_get_37_statistics(struct rrdengine_instance *ctx, unsigned long long *array);
 

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -26,8 +26,8 @@ extern uint8_t tier_page_type[];
 
 void rrdeng_generate_legacy_uuid(const char *dim_id, const char *chart_id, uuid_t *ret_uuid);
 
-STORAGE_METRIC_HANDLE *rrdeng_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE *db_instance);
-STORAGE_METRIC_HANDLE *rrdeng_metric_get(STORAGE_INSTANCE *db_instance, uuid_t *uuid);
+STORAGE_METRIC_HANDLE *rrdeng_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE *si);
+STORAGE_METRIC_HANDLE *rrdeng_metric_get(STORAGE_INSTANCE *si, uuid_t *uuid);
 void rrdeng_metric_release(STORAGE_METRIC_HANDLE *db_metric_handle);
 STORAGE_METRIC_HANDLE *rrdeng_metric_dup(STORAGE_METRIC_HANDLE *db_metric_handle);
 
@@ -64,10 +64,10 @@ void rrdeng_exit_mode(struct rrdengine_instance *ctx);
 
 int rrdeng_exit(struct rrdengine_instance *ctx);
 void rrdeng_prepare_exit(struct rrdengine_instance *ctx);
-bool rrdeng_metric_retention_by_uuid(STORAGE_INSTANCE *db_instance, uuid_t *dim_uuid, time_t *first_entry_s, time_t *last_entry_s);
+bool rrdeng_metric_retention_by_uuid(STORAGE_INSTANCE *si, uuid_t *dim_uuid, time_t *first_entry_s, time_t *last_entry_s);
 
-extern STORAGE_METRICS_GROUP *rrdeng_metrics_group_get(STORAGE_INSTANCE *db_instance, uuid_t *uuid);
-extern void rrdeng_metrics_group_release(STORAGE_INSTANCE *db_instance, STORAGE_METRICS_GROUP *smg);
+extern STORAGE_METRICS_GROUP *rrdeng_metrics_group_get(STORAGE_INSTANCE *si, uuid_t *uuid);
+extern void rrdeng_metrics_group_release(STORAGE_INSTANCE *si, STORAGE_METRICS_GROUP *smg);
 
 typedef struct rrdengine_size_statistics {
     size_t default_granularity_secs;
@@ -221,9 +221,9 @@ struct rrdeng_cache_efficiency_stats rrdeng_get_cache_efficiency_stats(void);
 
 RRDENG_SIZE_STATS rrdeng_size_statistics(struct rrdengine_instance *ctx);
 size_t rrdeng_collectors_running(struct rrdengine_instance *ctx);
-bool rrdeng_is_legacy(STORAGE_INSTANCE *db_instance);
+bool rrdeng_is_legacy(STORAGE_INSTANCE *si);
 
-uint64_t rrdeng_disk_space_max(STORAGE_INSTANCE *db_instance);
-uint64_t rrdeng_disk_space_used(STORAGE_INSTANCE *db_instance);
+uint64_t rrdeng_disk_space_max(STORAGE_INSTANCE *si);
+uint64_t rrdeng_disk_space_used(STORAGE_INSTANCE *si);
 
 #endif /* NETDATA_RRDENGINEAPI_H */

--- a/database/engine/rrdengineapi.h
+++ b/database/engine/rrdengineapi.h
@@ -32,15 +32,15 @@ void rrdeng_metric_release(STORAGE_METRIC_HANDLE *smh);
 STORAGE_METRIC_HANDLE *rrdeng_metric_dup(STORAGE_METRIC_HANDLE *smh);
 
 STORAGE_COLLECT_HANDLE *rrdeng_store_metric_init(STORAGE_METRIC_HANDLE *smh, uint32_t update_every, STORAGE_METRICS_GROUP *smg);
-void rrdeng_store_metric_flush_current_page(STORAGE_COLLECT_HANDLE *collection_handle);
-void rrdeng_store_metric_change_collection_frequency(STORAGE_COLLECT_HANDLE *collection_handle, int update_every);
-void rrdeng_store_metric_next(STORAGE_COLLECT_HANDLE *collection_handle, usec_t point_in_time_ut, NETDATA_DOUBLE n,
+void rrdeng_store_metric_flush_current_page(STORAGE_COLLECT_HANDLE *sch);
+void rrdeng_store_metric_change_collection_frequency(STORAGE_COLLECT_HANDLE *sch, int update_every);
+void rrdeng_store_metric_next(STORAGE_COLLECT_HANDLE *sch, usec_t point_in_time_ut, NETDATA_DOUBLE n,
                                      NETDATA_DOUBLE min_value,
                                      NETDATA_DOUBLE max_value,
                                      uint16_t count,
                                      uint16_t anomaly_count,
                                      SN_FLAGS flags);
-int rrdeng_store_metric_finalize(STORAGE_COLLECT_HANDLE *collection_handle);
+int rrdeng_store_metric_finalize(STORAGE_COLLECT_HANDLE *sch);
 
 void rrdeng_load_metric_init(STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_handle *seqh,
                                     time_t start_time_s, time_t end_time_s, STORAGE_PRIORITY priority);

--- a/database/ram/rrddim_mem.c
+++ b/database/ram/rrddim_mem.c
@@ -89,14 +89,14 @@ rrddim_metric_get(STORAGE_INSTANCE *si __maybe_unused, uuid_t *uuid) {
     return (STORAGE_METRIC_HANDLE *)mh;
 }
 
-STORAGE_METRIC_HANDLE *rrddim_metric_dup(STORAGE_METRIC_HANDLE *db_metric_handle) {
-    struct mem_metric_handle *mh = (struct mem_metric_handle *)db_metric_handle;
+STORAGE_METRIC_HANDLE *rrddim_metric_dup(STORAGE_METRIC_HANDLE *smh) {
+    struct mem_metric_handle *mh = (struct mem_metric_handle *)smh;
     __atomic_add_fetch(&mh->refcount, 1, __ATOMIC_RELAXED);
-    return db_metric_handle;
+    return smh;
 }
 
-void rrddim_metric_release(STORAGE_METRIC_HANDLE *db_metric_handle __maybe_unused) {
-    struct mem_metric_handle *mh = (struct mem_metric_handle *)db_metric_handle;
+void rrddim_metric_release(STORAGE_METRIC_HANDLE *smh __maybe_unused) {
+    struct mem_metric_handle *mh = (struct mem_metric_handle *)smh;
 
     if(__atomic_sub_fetch(&mh->refcount, 1, __ATOMIC_RELAXED) == 0) {
         // we are the last one holding this
@@ -117,26 +117,26 @@ void rrddim_metric_release(STORAGE_METRIC_HANDLE *db_metric_handle __maybe_unuse
 }
 
 bool rrddim_metric_retention_by_uuid(STORAGE_INSTANCE *si __maybe_unused, uuid_t *uuid, time_t *first_entry_s, time_t *last_entry_s) {
-    STORAGE_METRIC_HANDLE *db_metric_handle = rrddim_metric_get(si, uuid);
-    if(!db_metric_handle)
+    STORAGE_METRIC_HANDLE *smh = rrddim_metric_get(si, uuid);
+    if(!smh)
         return false;
 
-    *first_entry_s = rrddim_query_oldest_time_s(db_metric_handle);
-    *last_entry_s = rrddim_query_latest_time_s(db_metric_handle);
+    *first_entry_s = rrddim_query_oldest_time_s(smh);
+    *last_entry_s = rrddim_query_latest_time_s(smh);
 
     return true;
 }
 
 void rrddim_store_metric_change_collection_frequency(STORAGE_COLLECT_HANDLE *collection_handle, int update_every) {
     struct mem_collect_handle *ch = (struct mem_collect_handle *)collection_handle;
-    struct mem_metric_handle *mh = (struct mem_metric_handle *)ch->db_metric_handle;
+    struct mem_metric_handle *mh = (struct mem_metric_handle *)ch->smh;
 
     rrddim_store_metric_flush(collection_handle);
     mh->update_every_s = update_every;
 }
 
-STORAGE_COLLECT_HANDLE *rrddim_collect_init(STORAGE_METRIC_HANDLE *db_metric_handle, uint32_t update_every __maybe_unused, STORAGE_METRICS_GROUP *smg __maybe_unused) {
-    struct mem_metric_handle *mh = (struct mem_metric_handle *)db_metric_handle;
+STORAGE_COLLECT_HANDLE *rrddim_collect_init(STORAGE_METRIC_HANDLE *smh, uint32_t update_every __maybe_unused, STORAGE_METRICS_GROUP *smg __maybe_unused) {
+    struct mem_metric_handle *mh = (struct mem_metric_handle *)smh;
     RRDDIM *rd = mh->rd;
 
     update_metric_handle_from_rrddim(mh, rd);
@@ -145,7 +145,7 @@ STORAGE_COLLECT_HANDLE *rrddim_collect_init(STORAGE_METRIC_HANDLE *db_metric_han
     struct mem_collect_handle *ch = callocz(1, sizeof(struct mem_collect_handle));
     ch->common.backend = STORAGE_ENGINE_BACKEND_RRDDIM;
     ch->rd = rd;
-    ch->db_metric_handle = db_metric_handle;
+    ch->smh = smh;
 
     __atomic_add_fetch(&rrddim_db_memory_size, sizeof(struct mem_collect_handle), __ATOMIC_RELAXED);
 
@@ -154,7 +154,7 @@ STORAGE_COLLECT_HANDLE *rrddim_collect_init(STORAGE_METRIC_HANDLE *db_metric_han
 
 void rrddim_store_metric_flush(STORAGE_COLLECT_HANDLE *collection_handle) {
     struct mem_collect_handle *ch = (struct mem_collect_handle *)collection_handle;
-    struct mem_metric_handle *mh = (struct mem_metric_handle *)ch->db_metric_handle;
+    struct mem_metric_handle *mh = (struct mem_metric_handle *)ch->smh;
 
     RRDDIM *rd = mh->rd;
     size_t entries = mh->entries;
@@ -170,7 +170,7 @@ void rrddim_store_metric_flush(STORAGE_COLLECT_HANDLE *collection_handle) {
 
 static inline void rrddim_fill_the_gap(STORAGE_COLLECT_HANDLE *collection_handle, time_t now_collect_s) {
     struct mem_collect_handle *ch = (struct mem_collect_handle *)collection_handle;
-    struct mem_metric_handle *mh = (struct mem_metric_handle *)ch->db_metric_handle;
+    struct mem_metric_handle *mh = (struct mem_metric_handle *)ch->smh;
 
     RRDDIM *rd = mh->rd;
 
@@ -213,7 +213,7 @@ void rrddim_collect_store_metric(STORAGE_COLLECT_HANDLE *collection_handle,
                                  SN_FLAGS flags)
 {
     struct mem_collect_handle *ch = (struct mem_collect_handle *)collection_handle;
-    struct mem_metric_handle *mh = (struct mem_metric_handle *)ch->db_metric_handle;
+    struct mem_metric_handle *mh = (struct mem_metric_handle *)ch->smh;
 
     RRDDIM *rd = ch->rd;
     time_t point_in_time_s = (time_t)(point_in_time_ut / USEC_PER_SEC);
@@ -253,13 +253,13 @@ int rrddim_collect_finalize(STORAGE_COLLECT_HANDLE *collection_handle) {
 // get the slot of the round-robin database, for the given timestamp (t)
 // it always returns a valid slot, although it may not be for the time requested if the time is outside the round-robin database
 // only valid when not using dbengine
-static inline size_t rrddim_time2slot(STORAGE_METRIC_HANDLE *db_metric_handle, time_t t) {
-    struct mem_metric_handle *mh = (struct mem_metric_handle *)db_metric_handle;
+static inline size_t rrddim_time2slot(STORAGE_METRIC_HANDLE *smh, time_t t) {
+    struct mem_metric_handle *mh = (struct mem_metric_handle *)smh;
     RRDDIM *rd = mh->rd;
 
     size_t ret = 0;
-    time_t last_entry_s  = rrddim_query_latest_time_s(db_metric_handle);
-    time_t first_entry_s = rrddim_query_oldest_time_s(db_metric_handle);
+    time_t last_entry_s  = rrddim_query_latest_time_s(smh);
+    time_t first_entry_s = rrddim_query_oldest_time_s(smh);
     size_t entries       = mh->entries;
     size_t first_slot    = rrddim_first_slot(mh);
     size_t last_slot     = rrddim_last_slot(mh);
@@ -292,13 +292,13 @@ static inline size_t rrddim_time2slot(STORAGE_METRIC_HANDLE *db_metric_handle, t
 
 // get the timestamp of a specific slot in the round-robin database
 // only valid when not using dbengine
-static inline time_t rrddim_slot2time(STORAGE_METRIC_HANDLE *db_metric_handle, size_t slot) {
-    struct mem_metric_handle *mh = (struct mem_metric_handle *)db_metric_handle;
+static inline time_t rrddim_slot2time(STORAGE_METRIC_HANDLE *smh, size_t slot) {
+    struct mem_metric_handle *mh = (struct mem_metric_handle *)smh;
     RRDDIM *rd = mh->rd;
 
     time_t ret;
-    time_t last_entry_s  = rrddim_query_latest_time_s(db_metric_handle);
-    time_t first_entry_s = rrddim_query_oldest_time_s(db_metric_handle);
+    time_t last_entry_s  = rrddim_query_latest_time_s(smh);
+    time_t first_entry_s = rrddim_query_oldest_time_s(smh);
     size_t entries       = mh->entries;
     size_t last_slot     = rrddim_last_slot(mh);
     size_t update_every  = mh->update_every_s;
@@ -333,8 +333,8 @@ static inline time_t rrddim_slot2time(STORAGE_METRIC_HANDLE *db_metric_handle, s
 // ----------------------------------------------------------------------------
 // RRDDIM legacy database query functions
 
-void rrddim_query_init(STORAGE_METRIC_HANDLE *db_metric_handle, struct storage_engine_query_handle *handle, time_t start_time_s, time_t end_time_s, STORAGE_PRIORITY priority __maybe_unused) {
-    struct mem_metric_handle *mh = (struct mem_metric_handle *)db_metric_handle;
+void rrddim_query_init(STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_handle *handle, time_t start_time_s, time_t end_time_s, STORAGE_PRIORITY priority __maybe_unused) {
+    struct mem_metric_handle *mh = (struct mem_metric_handle *)smh;
 
     check_metric_handle_from_rrddim(mh);
 
@@ -343,15 +343,15 @@ void rrddim_query_init(STORAGE_METRIC_HANDLE *db_metric_handle, struct storage_e
     handle->priority = priority;
     handle->backend = STORAGE_ENGINE_BACKEND_RRDDIM;
     struct mem_query_handle* h = mallocz(sizeof(struct mem_query_handle));
-    h->db_metric_handle = db_metric_handle;
+    h->smh = smh;
 
-    h->slot           = rrddim_time2slot(db_metric_handle, start_time_s);
-    h->last_slot      = rrddim_time2slot(db_metric_handle, end_time_s);
+    h->slot           = rrddim_time2slot(smh, start_time_s);
+    h->last_slot      = rrddim_time2slot(smh, end_time_s);
     h->dt             = mh->update_every_s;
 
     h->next_timestamp = start_time_s;
-    h->slot_timestamp = rrddim_slot2time(db_metric_handle, h->slot);
-    h->last_timestamp = rrddim_slot2time(db_metric_handle, h->last_slot);
+    h->slot_timestamp = rrddim_slot2time(smh, h->slot);
+    h->last_timestamp = rrddim_slot2time(smh, h->last_slot);
 
     // netdata_log_info("RRDDIM QUERY INIT: start %ld, end %ld, next %ld, first %ld, last %ld, dt %ld", start_time, end_time, h->next_timestamp, h->slot_timestamp, h->last_timestamp, h->dt);
 
@@ -364,7 +364,7 @@ void rrddim_query_init(STORAGE_METRIC_HANDLE *db_metric_handle, struct storage_e
 // IT IS REQUIRED TO **ALWAYS** KEEP TRACK OF TIME, EVEN OUTSIDE THE DATABASE BOUNDARIES
 STORAGE_POINT rrddim_query_next_metric(struct storage_engine_query_handle *handle) {
     struct mem_query_handle* h = (struct mem_query_handle*)handle->handle;
-    struct mem_metric_handle *mh = (struct mem_metric_handle *)h->db_metric_handle;
+    struct mem_metric_handle *mh = (struct mem_metric_handle *)h->smh;
     RRDDIM *rd = mh->rd;
 
     size_t entries = mh->entries;
@@ -411,7 +411,7 @@ int rrddim_query_is_finished(struct storage_engine_query_handle *handle) {
 void rrddim_query_finalize(struct storage_engine_query_handle *handle) {
 #ifdef NETDATA_INTERNAL_CHECKS
     struct mem_query_handle *h = (struct mem_query_handle*)handle->handle;
-    struct mem_metric_handle *mh = (struct mem_metric_handle *)h->db_metric_handle;
+    struct mem_metric_handle *mh = (struct mem_metric_handle *)h->smh;
 
     internal_error(!rrddim_query_is_finished(handle),
                    "QUERY: query for chart '%s' dimension '%s' has been stopped unfinished",
@@ -426,12 +426,12 @@ time_t rrddim_query_align_to_optimal_before(struct storage_engine_query_handle *
     return rrddim_handle->end_time_s;
 }
 
-time_t rrddim_query_latest_time_s(STORAGE_METRIC_HANDLE *db_metric_handle) {
-    struct mem_metric_handle *mh = (struct mem_metric_handle *)db_metric_handle;
+time_t rrddim_query_latest_time_s(STORAGE_METRIC_HANDLE *smh) {
+    struct mem_metric_handle *mh = (struct mem_metric_handle *)smh;
     return mh->last_updated_s;
 }
 
-time_t rrddim_query_oldest_time_s(STORAGE_METRIC_HANDLE *db_metric_handle) {
-    struct mem_metric_handle *mh = (struct mem_metric_handle *)db_metric_handle;
+time_t rrddim_query_oldest_time_s(STORAGE_METRIC_HANDLE *smh) {
+    struct mem_metric_handle *mh = (struct mem_metric_handle *)smh;
     return (time_t)(mh->last_updated_s - metric_duration(mh));
 }

--- a/database/ram/rrddim_mem.c
+++ b/database/ram/rrddim_mem.c
@@ -9,11 +9,11 @@ static netdata_rwlock_t rrddim_JudyHS_rwlock = NETDATA_RWLOCK_INITIALIZER;
 // ----------------------------------------------------------------------------
 // metrics groups
 
-STORAGE_METRICS_GROUP *rrddim_metrics_group_get(STORAGE_INSTANCE *db_instance __maybe_unused, uuid_t *uuid __maybe_unused) {
+STORAGE_METRICS_GROUP *rrddim_metrics_group_get(STORAGE_INSTANCE *si __maybe_unused, uuid_t *uuid __maybe_unused) {
     return NULL;
 }
 
-void rrddim_metrics_group_release(STORAGE_INSTANCE *db_instance __maybe_unused, STORAGE_METRICS_GROUP *smg __maybe_unused) {
+void rrddim_metrics_group_release(STORAGE_INSTANCE *si __maybe_unused, STORAGE_METRICS_GROUP *smg __maybe_unused) {
     // if(!smg) return; // smg may be NULL
     ;
 }
@@ -48,8 +48,8 @@ static void check_metric_handle_from_rrddim(struct mem_metric_handle *mh) {
 }
 
 STORAGE_METRIC_HANDLE *
-rrddim_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE *db_instance __maybe_unused) {
-    struct mem_metric_handle *mh = (struct mem_metric_handle *)rrddim_metric_get(db_instance, &rd->metric_uuid);
+rrddim_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE *si __maybe_unused) {
+    struct mem_metric_handle *mh = (struct mem_metric_handle *)rrddim_metric_get(si, &rd->metric_uuid);
     while(!mh) {
         netdata_rwlock_wrlock(&rrddim_JudyHS_rwlock);
         Pvoid_t *PValue = JudyHSIns(&rrddim_JudyHS_array, &rd->metric_uuid, sizeof(uuid_t), PJE0);
@@ -75,7 +75,7 @@ rrddim_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE *db_instance __maybe_un
 }
 
 STORAGE_METRIC_HANDLE *
-rrddim_metric_get(STORAGE_INSTANCE *db_instance __maybe_unused, uuid_t *uuid) {
+rrddim_metric_get(STORAGE_INSTANCE *si __maybe_unused, uuid_t *uuid) {
     struct mem_metric_handle *mh = NULL;
     netdata_rwlock_rdlock(&rrddim_JudyHS_rwlock);
     Pvoid_t *PValue = JudyHSGet(rrddim_JudyHS_array, uuid, sizeof(uuid_t));
@@ -116,8 +116,8 @@ void rrddim_metric_release(STORAGE_METRIC_HANDLE *db_metric_handle __maybe_unuse
     }
 }
 
-bool rrddim_metric_retention_by_uuid(STORAGE_INSTANCE *db_instance __maybe_unused, uuid_t *uuid, time_t *first_entry_s, time_t *last_entry_s) {
-    STORAGE_METRIC_HANDLE *db_metric_handle = rrddim_metric_get(db_instance, uuid);
+bool rrddim_metric_retention_by_uuid(STORAGE_INSTANCE *si __maybe_unused, uuid_t *uuid, time_t *first_entry_s, time_t *last_entry_s) {
+    STORAGE_METRIC_HANDLE *db_metric_handle = rrddim_metric_get(si, uuid);
     if(!db_metric_handle)
         return false;
 

--- a/database/ram/rrddim_mem.c
+++ b/database/ram/rrddim_mem.c
@@ -143,7 +143,7 @@ STORAGE_COLLECT_HANDLE *rrddim_collect_init(STORAGE_METRIC_HANDLE *smh, uint32_t
     internal_fatal((uint32_t)mh->update_every_s != update_every, "RRDDIM: update requested does not match the dimension");
 
     struct mem_collect_handle *ch = callocz(1, sizeof(struct mem_collect_handle));
-    ch->common.backend = STORAGE_ENGINE_BACKEND_RRDDIM;
+    ch->common.seb = STORAGE_ENGINE_BACKEND_RRDDIM;
     ch->rd = rd;
     ch->smh = smh;
 
@@ -341,7 +341,7 @@ void rrddim_query_init(STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_h
     seqh->start_time_s = start_time_s;
     seqh->end_time_s = end_time_s;
     seqh->priority = priority;
-    seqh->backend = STORAGE_ENGINE_BACKEND_RRDDIM;
+    seqh->seb = STORAGE_ENGINE_BACKEND_RRDDIM;
     struct mem_query_handle* h = mallocz(sizeof(struct mem_query_handle));
     h->smh = smh;
 

--- a/database/ram/rrddim_mem.h
+++ b/database/ram/rrddim_mem.h
@@ -8,12 +8,12 @@
 struct mem_collect_handle {
     struct storage_collect_handle common; // has to be first item
 
-    STORAGE_METRIC_HANDLE *db_metric_handle;
+    STORAGE_METRIC_HANDLE *smh;
     RRDDIM *rd;
 };
 
 struct mem_query_handle {
-    STORAGE_METRIC_HANDLE *db_metric_handle;
+    STORAGE_METRIC_HANDLE *smh;
     time_t dt;
     time_t next_timestamp;
     time_t last_timestamp;
@@ -24,15 +24,15 @@ struct mem_query_handle {
 
 STORAGE_METRIC_HANDLE *rrddim_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE *si);
 STORAGE_METRIC_HANDLE *rrddim_metric_get(STORAGE_INSTANCE *si, uuid_t *uuid);
-STORAGE_METRIC_HANDLE *rrddim_metric_dup(STORAGE_METRIC_HANDLE *db_metric_handle);
-void rrddim_metric_release(STORAGE_METRIC_HANDLE *db_metric_handle);
+STORAGE_METRIC_HANDLE *rrddim_metric_dup(STORAGE_METRIC_HANDLE *smh);
+void rrddim_metric_release(STORAGE_METRIC_HANDLE *smh);
 
 bool rrddim_metric_retention_by_uuid(STORAGE_INSTANCE *si, uuid_t *uuid, time_t *first_entry_s, time_t *last_entry_s);
 
 STORAGE_METRICS_GROUP *rrddim_metrics_group_get(STORAGE_INSTANCE *si, uuid_t *uuid);
 void rrddim_metrics_group_release(STORAGE_INSTANCE *si, STORAGE_METRICS_GROUP *smg);
 
-STORAGE_COLLECT_HANDLE *rrddim_collect_init(STORAGE_METRIC_HANDLE *db_metric_handle, uint32_t update_every, STORAGE_METRICS_GROUP *smg);
+STORAGE_COLLECT_HANDLE *rrddim_collect_init(STORAGE_METRIC_HANDLE *smh, uint32_t update_every, STORAGE_METRICS_GROUP *smg);
 void rrddim_store_metric_change_collection_frequency(STORAGE_COLLECT_HANDLE *collection_handle, int update_every);
 void rrddim_collect_store_metric(STORAGE_COLLECT_HANDLE *collection_handle, usec_t point_in_time_ut, NETDATA_DOUBLE n,
                                  NETDATA_DOUBLE min_value,
@@ -43,12 +43,12 @@ void rrddim_collect_store_metric(STORAGE_COLLECT_HANDLE *collection_handle, usec
 void rrddim_store_metric_flush(STORAGE_COLLECT_HANDLE *collection_handle);
 int rrddim_collect_finalize(STORAGE_COLLECT_HANDLE *collection_handle);
 
-void rrddim_query_init(STORAGE_METRIC_HANDLE *db_metric_handle, struct storage_engine_query_handle *handle, time_t start_time_s, time_t end_time_s, STORAGE_PRIORITY priority);
+void rrddim_query_init(STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_handle *handle, time_t start_time_s, time_t end_time_s, STORAGE_PRIORITY priority);
 STORAGE_POINT rrddim_query_next_metric(struct storage_engine_query_handle *handle);
 int rrddim_query_is_finished(struct storage_engine_query_handle *handle);
 void rrddim_query_finalize(struct storage_engine_query_handle *handle);
-time_t rrddim_query_latest_time_s(STORAGE_METRIC_HANDLE *db_metric_handle);
-time_t rrddim_query_oldest_time_s(STORAGE_METRIC_HANDLE *db_metric_handle);
+time_t rrddim_query_latest_time_s(STORAGE_METRIC_HANDLE *smh);
+time_t rrddim_query_oldest_time_s(STORAGE_METRIC_HANDLE *smh);
 time_t rrddim_query_align_to_optimal_before(struct storage_engine_query_handle *rrddim_handle);
 
 #endif

--- a/database/ram/rrddim_mem.h
+++ b/database/ram/rrddim_mem.h
@@ -43,12 +43,12 @@ void rrddim_collect_store_metric(STORAGE_COLLECT_HANDLE *collection_handle, usec
 void rrddim_store_metric_flush(STORAGE_COLLECT_HANDLE *collection_handle);
 int rrddim_collect_finalize(STORAGE_COLLECT_HANDLE *collection_handle);
 
-void rrddim_query_init(STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_handle *handle, time_t start_time_s, time_t end_time_s, STORAGE_PRIORITY priority);
-STORAGE_POINT rrddim_query_next_metric(struct storage_engine_query_handle *handle);
-int rrddim_query_is_finished(struct storage_engine_query_handle *handle);
-void rrddim_query_finalize(struct storage_engine_query_handle *handle);
+void rrddim_query_init(STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_handle *seqh, time_t start_time_s, time_t end_time_s, STORAGE_PRIORITY priority);
+STORAGE_POINT rrddim_query_next_metric(struct storage_engine_query_handle *seqh);
+int rrddim_query_is_finished(struct storage_engine_query_handle *seqh);
+void rrddim_query_finalize(struct storage_engine_query_handle *seqh);
 time_t rrddim_query_latest_time_s(STORAGE_METRIC_HANDLE *smh);
 time_t rrddim_query_oldest_time_s(STORAGE_METRIC_HANDLE *smh);
-time_t rrddim_query_align_to_optimal_before(struct storage_engine_query_handle *rrddim_handle);
+time_t rrddim_query_align_to_optimal_before(struct storage_engine_query_handle *seqh);
 
 #endif

--- a/database/ram/rrddim_mem.h
+++ b/database/ram/rrddim_mem.h
@@ -33,15 +33,15 @@ STORAGE_METRICS_GROUP *rrddim_metrics_group_get(STORAGE_INSTANCE *si, uuid_t *uu
 void rrddim_metrics_group_release(STORAGE_INSTANCE *si, STORAGE_METRICS_GROUP *smg);
 
 STORAGE_COLLECT_HANDLE *rrddim_collect_init(STORAGE_METRIC_HANDLE *smh, uint32_t update_every, STORAGE_METRICS_GROUP *smg);
-void rrddim_store_metric_change_collection_frequency(STORAGE_COLLECT_HANDLE *collection_handle, int update_every);
-void rrddim_collect_store_metric(STORAGE_COLLECT_HANDLE *collection_handle, usec_t point_in_time_ut, NETDATA_DOUBLE n,
+void rrddim_store_metric_change_collection_frequency(STORAGE_COLLECT_HANDLE *sch, int update_every);
+void rrddim_collect_store_metric(STORAGE_COLLECT_HANDLE *sch, usec_t point_in_time_ut, NETDATA_DOUBLE n,
                                  NETDATA_DOUBLE min_value,
                                  NETDATA_DOUBLE max_value,
                                  uint16_t count,
                                  uint16_t anomaly_count,
                                  SN_FLAGS flags);
-void rrddim_store_metric_flush(STORAGE_COLLECT_HANDLE *collection_handle);
-int rrddim_collect_finalize(STORAGE_COLLECT_HANDLE *collection_handle);
+void rrddim_store_metric_flush(STORAGE_COLLECT_HANDLE *sch);
+int rrddim_collect_finalize(STORAGE_COLLECT_HANDLE *sch);
 
 void rrddim_query_init(STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_handle *seqh, time_t start_time_s, time_t end_time_s, STORAGE_PRIORITY priority);
 STORAGE_POINT rrddim_query_next_metric(struct storage_engine_query_handle *seqh);

--- a/database/ram/rrddim_mem.h
+++ b/database/ram/rrddim_mem.h
@@ -22,15 +22,15 @@ struct mem_query_handle {
     size_t last_slot;
 };
 
-STORAGE_METRIC_HANDLE *rrddim_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE *db_instance);
-STORAGE_METRIC_HANDLE *rrddim_metric_get(STORAGE_INSTANCE *db_instance, uuid_t *uuid);
+STORAGE_METRIC_HANDLE *rrddim_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE *si);
+STORAGE_METRIC_HANDLE *rrddim_metric_get(STORAGE_INSTANCE *si, uuid_t *uuid);
 STORAGE_METRIC_HANDLE *rrddim_metric_dup(STORAGE_METRIC_HANDLE *db_metric_handle);
 void rrddim_metric_release(STORAGE_METRIC_HANDLE *db_metric_handle);
 
-bool rrddim_metric_retention_by_uuid(STORAGE_INSTANCE *db_instance, uuid_t *uuid, time_t *first_entry_s, time_t *last_entry_s);
+bool rrddim_metric_retention_by_uuid(STORAGE_INSTANCE *si, uuid_t *uuid, time_t *first_entry_s, time_t *last_entry_s);
 
-STORAGE_METRICS_GROUP *rrddim_metrics_group_get(STORAGE_INSTANCE *db_instance, uuid_t *uuid);
-void rrddim_metrics_group_release(STORAGE_INSTANCE *db_instance, STORAGE_METRICS_GROUP *smg);
+STORAGE_METRICS_GROUP *rrddim_metrics_group_get(STORAGE_INSTANCE *si, uuid_t *uuid);
+void rrddim_metrics_group_release(STORAGE_INSTANCE *si, STORAGE_METRICS_GROUP *smg);
 
 STORAGE_COLLECT_HANDLE *rrddim_collect_init(STORAGE_METRIC_HANDLE *db_metric_handle, uint32_t update_every, STORAGE_METRICS_GROUP *smg);
 void rrddim_store_metric_change_collection_frequency(STORAGE_COLLECT_HANDLE *collection_handle, int update_every);

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -579,74 +579,74 @@ static inline time_t storage_engine_latest_time_s(STORAGE_ENGINE_BACKEND backend
 }
 
 void rrdeng_load_metric_init(
-        STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_handle *rrddim_handle,
+        STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_handle *seqh,
                 time_t start_time_s, time_t end_time_s, STORAGE_PRIORITY priority);
 
 void rrddim_query_init(
-        STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_handle *handle,
+        STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_handle *seqh,
                 time_t start_time_s, time_t end_time_s, STORAGE_PRIORITY priority);
 
 static inline void storage_engine_query_init(
         STORAGE_ENGINE_BACKEND backend __maybe_unused,
-        STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_handle *handle,
+        STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_handle *seqh,
                 time_t start_time_s, time_t end_time_s, STORAGE_PRIORITY priority) {
     internal_fatal(!is_valid_backend(backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
     if(likely(backend == STORAGE_ENGINE_BACKEND_DBENGINE))
-        rrdeng_load_metric_init(smh, handle, start_time_s, end_time_s, priority);
+        rrdeng_load_metric_init(smh, seqh, start_time_s, end_time_s, priority);
     else
 #endif
-        rrddim_query_init(smh, handle, start_time_s, end_time_s, priority);
+        rrddim_query_init(smh, seqh, start_time_s, end_time_s, priority);
 }
 
-STORAGE_POINT rrdeng_load_metric_next(struct storage_engine_query_handle *rrddim_handle);
-STORAGE_POINT rrddim_query_next_metric(struct storage_engine_query_handle *handle);
-static inline STORAGE_POINT storage_engine_query_next_metric(struct storage_engine_query_handle *handle) {
-    internal_fatal(!is_valid_backend(handle->backend), "STORAGE: invalid backend");
+STORAGE_POINT rrdeng_load_metric_next(struct storage_engine_query_handle *seqh);
+STORAGE_POINT rrddim_query_next_metric(struct storage_engine_query_handle *seqh);
+static inline STORAGE_POINT storage_engine_query_next_metric(struct storage_engine_query_handle *seqh) {
+    internal_fatal(!is_valid_backend(seqh->backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
-    if(likely(handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE))
-        return rrdeng_load_metric_next(handle);
+    if(likely(seqh->backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+        return rrdeng_load_metric_next(seqh);
 #endif
-    return rrddim_query_next_metric(handle);
+    return rrddim_query_next_metric(seqh);
 }
 
-int rrdeng_load_metric_is_finished(struct storage_engine_query_handle *rrddim_handle);
-int rrddim_query_is_finished(struct storage_engine_query_handle *handle);
-static inline int storage_engine_query_is_finished(struct storage_engine_query_handle *handle) {
-    internal_fatal(!is_valid_backend(handle->backend), "STORAGE: invalid backend");
+int rrdeng_load_metric_is_finished(struct storage_engine_query_handle *seqh);
+int rrddim_query_is_finished(struct storage_engine_query_handle *seqh);
+static inline int storage_engine_query_is_finished(struct storage_engine_query_handle *seqh) {
+    internal_fatal(!is_valid_backend(seqh->backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
-    if(likely(handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE))
-        return rrdeng_load_metric_is_finished(handle);
+    if(likely(seqh->backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+        return rrdeng_load_metric_is_finished(seqh);
 #endif
-    return rrddim_query_is_finished(handle);
+    return rrddim_query_is_finished(seqh);
 }
 
-void rrdeng_load_metric_finalize(struct storage_engine_query_handle *rrddim_handle);
-void rrddim_query_finalize(struct storage_engine_query_handle *handle);
-static inline void storage_engine_query_finalize(struct storage_engine_query_handle *handle) {
-    internal_fatal(!is_valid_backend(handle->backend), "STORAGE: invalid backend");
+void rrdeng_load_metric_finalize(struct storage_engine_query_handle *seqh);
+void rrddim_query_finalize(struct storage_engine_query_handle *seqh);
+static inline void storage_engine_query_finalize(struct storage_engine_query_handle *seqh) {
+    internal_fatal(!is_valid_backend(seqh->backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
-    if(likely(handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE))
-        rrdeng_load_metric_finalize(handle);
+    if(likely(seqh->backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+        rrdeng_load_metric_finalize(seqh);
     else
 #endif
-        rrddim_query_finalize(handle);
+        rrddim_query_finalize(seqh);
 }
 
-time_t rrdeng_load_align_to_optimal_before(struct storage_engine_query_handle *rrddim_handle);
-time_t rrddim_query_align_to_optimal_before(struct storage_engine_query_handle *rrddim_handle);
-static inline time_t storage_engine_align_to_optimal_before(struct storage_engine_query_handle *handle) {
-    internal_fatal(!is_valid_backend(handle->backend), "STORAGE: invalid backend");
+time_t rrdeng_load_align_to_optimal_before(struct storage_engine_query_handle *seqh);
+time_t rrddim_query_align_to_optimal_before(struct storage_engine_query_handle *seqh);
+static inline time_t storage_engine_align_to_optimal_before(struct storage_engine_query_handle *seqh) {
+    internal_fatal(!is_valid_backend(seqh->backend), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
-    if(likely(handle->backend == STORAGE_ENGINE_BACKEND_DBENGINE))
-        return rrdeng_load_align_to_optimal_before(handle);
+    if(likely(seqh->backend == STORAGE_ENGINE_BACKEND_DBENGINE))
+        return rrdeng_load_align_to_optimal_before(seqh);
 #endif
-    return rrddim_query_align_to_optimal_before(handle);
+    return rrddim_query_align_to_optimal_before(seqh);
 }
 
 // ------------------------------------------------------------------------

--- a/database/rrd.h
+++ b/database/rrd.h
@@ -779,7 +779,7 @@ struct rrdset {
 
     rrd_ml_chart_t *ml_chart;
 
-    STORAGE_METRICS_GROUP *storage_metrics_groups[RRD_STORAGE_TIERS];
+    STORAGE_METRICS_GROUP *smg[RRD_STORAGE_TIERS];
 
     // ------------------------------------------------------------------------
     // linking to siblings and parents

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -101,7 +101,7 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
             STORAGE_ENGINE *eng = host->db[tier].eng;
             rd->tiers[tier].backend = eng->backend;
             rd->tiers[tier].tier_grouping = host->db[tier].tier_grouping;
-            rd->tiers[tier].db_metric_handle = eng->api.metric_get_or_create(rd, host->db[tier].si);
+            rd->tiers[tier].smh = eng->api.metric_get_or_create(rd, host->db[tier].si);
             storage_point_unset(rd->tiers[tier].virtual_point);
             initialized++;
 
@@ -111,7 +111,7 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
         if(!initialized)
             netdata_log_error("Failed to initialize all db tiers for chart '%s', dimension '%s", rrdset_name(st), rrddim_name(rd));
 
-        if(!rd->tiers[0].db_metric_handle)
+        if(!rd->tiers[0].smh)
             netdata_log_error("Failed to initialize the first db tier for chart '%s', dimension '%s", rrdset_name(st), rrddim_name(rd));
     }
 
@@ -119,9 +119,9 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
     {
         size_t initialized = 0;
         for (size_t tier = 0; tier < storage_tiers; tier++) {
-            if (rd->tiers[tier].db_metric_handle) {
+            if (rd->tiers[tier].smh) {
                 rd->tiers[tier].db_collection_handle =
-                        storage_metric_store_init(rd->tiers[tier].backend, rd->tiers[tier].db_metric_handle, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->smg[tier]);
+                        storage_metric_store_init(rd->tiers[tier].backend, rd->tiers[tier].smh, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->smg[tier]);
                 initialized++;
             }
         }
@@ -222,11 +222,11 @@ static void rrddim_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, v
     rrddim_memory_file_free(rd);
 
     for(size_t tier = 0; tier < storage_tiers ;tier++) {
-        if(!rd->tiers[tier].db_metric_handle) continue;
+        if(!rd->tiers[tier].smh) continue;
 
         STORAGE_ENGINE* eng = host->db[tier].eng;
-        eng->api.metric_release(rd->tiers[tier].db_metric_handle);
-        rd->tiers[tier].db_metric_handle = NULL;
+        eng->api.metric_release(rd->tiers[tier].smh);
+        rd->tiers[tier].smh = NULL;
     }
 
     if(rd->db.data) {
@@ -259,7 +259,7 @@ static bool rrddim_conflict_callback(const DICTIONARY_ITEM *item __maybe_unused,
     for(size_t tier = 0; tier < storage_tiers ;tier++) {
         if (!rd->tiers[tier].db_collection_handle)
             rd->tiers[tier].db_collection_handle =
-                    storage_metric_store_init(rd->tiers[tier].backend, rd->tiers[tier].db_metric_handle, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->smg[tier]);
+                    storage_metric_store_init(rd->tiers[tier].backend, rd->tiers[tier].smh, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->smg[tier]);
     }
 
     if(rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED)) {
@@ -420,10 +420,10 @@ inline int rrddim_set_divisor(RRDSET *st, RRDDIM *rd, int32_t divisor) {
 // ----------------------------------------------------------------------------
 
 time_t rrddim_last_entry_s_of_tier(RRDDIM *rd, size_t tier) {
-    if(unlikely(tier > storage_tiers || !rd->tiers[tier].db_metric_handle))
+    if(unlikely(tier > storage_tiers || !rd->tiers[tier].smh))
         return 0;
 
-    return storage_engine_latest_time_s(rd->tiers[tier].backend, rd->tiers[tier].db_metric_handle);
+    return storage_engine_latest_time_s(rd->tiers[tier].backend, rd->tiers[tier].smh);
 }
 
 // get the timestamp of the last entry in the round-robin database
@@ -431,7 +431,7 @@ time_t rrddim_last_entry_s(RRDDIM *rd) {
     time_t latest_time_s = rrddim_last_entry_s_of_tier(rd, 0);
 
     for(size_t tier = 1; tier < storage_tiers ;tier++) {
-        if(unlikely(!rd->tiers[tier].db_metric_handle)) continue;
+        if(unlikely(!rd->tiers[tier].smh)) continue;
 
         time_t t = rrddim_last_entry_s_of_tier(rd, tier);
         if(t > latest_time_s)
@@ -442,10 +442,10 @@ time_t rrddim_last_entry_s(RRDDIM *rd) {
 }
 
 time_t rrddim_first_entry_s_of_tier(RRDDIM *rd, size_t tier) {
-    if(unlikely(tier > storage_tiers || !rd->tiers[tier].db_metric_handle))
+    if(unlikely(tier > storage_tiers || !rd->tiers[tier].smh))
         return 0;
 
-    return storage_engine_oldest_time_s(rd->tiers[tier].backend, rd->tiers[tier].db_metric_handle);
+    return storage_engine_oldest_time_s(rd->tiers[tier].backend, rd->tiers[tier].smh);
 }
 
 time_t rrddim_first_entry_s(RRDDIM *rd) {

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -121,7 +121,7 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
         for (size_t tier = 0; tier < storage_tiers; tier++) {
             if (rd->tiers[tier].db_metric_handle) {
                 rd->tiers[tier].db_collection_handle =
-                        storage_metric_store_init(rd->tiers[tier].backend, rd->tiers[tier].db_metric_handle, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->storage_metrics_groups[tier]);
+                        storage_metric_store_init(rd->tiers[tier].backend, rd->tiers[tier].db_metric_handle, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->smg[tier]);
                 initialized++;
             }
         }
@@ -259,7 +259,7 @@ static bool rrddim_conflict_callback(const DICTIONARY_ITEM *item __maybe_unused,
     for(size_t tier = 0; tier < storage_tiers ;tier++) {
         if (!rd->tiers[tier].db_collection_handle)
             rd->tiers[tier].db_collection_handle =
-                    storage_metric_store_init(rd->tiers[tier].backend, rd->tiers[tier].db_metric_handle, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->storage_metrics_groups[tier]);
+                    storage_metric_store_init(rd->tiers[tier].backend, rd->tiers[tier].db_metric_handle, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->smg[tier]);
     }
 
     if(rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED)) {

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -99,7 +99,7 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
         size_t initialized = 0;
         for(size_t tier = 0; tier < storage_tiers ; tier++) {
             STORAGE_ENGINE *eng = host->db[tier].eng;
-            rd->tiers[tier].backend = eng->backend;
+            rd->tiers[tier].seb = eng->seb;
             rd->tiers[tier].tier_grouping = host->db[tier].tier_grouping;
             rd->tiers[tier].smh = eng->api.metric_get_or_create(rd, host->db[tier].si);
             storage_point_unset(rd->tiers[tier].virtual_point);
@@ -121,7 +121,7 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
         for (size_t tier = 0; tier < storage_tiers; tier++) {
             if (rd->tiers[tier].smh) {
                 rd->tiers[tier].db_collection_handle =
-                        storage_metric_store_init(rd->tiers[tier].backend, rd->tiers[tier].smh, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->smg[tier]);
+                        storage_metric_store_init(rd->tiers[tier].seb, rd->tiers[tier].smh, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->smg[tier]);
                 initialized++;
             }
         }
@@ -259,7 +259,7 @@ static bool rrddim_conflict_callback(const DICTIONARY_ITEM *item __maybe_unused,
     for(size_t tier = 0; tier < storage_tiers ;tier++) {
         if (!rd->tiers[tier].db_collection_handle)
             rd->tiers[tier].db_collection_handle =
-                    storage_metric_store_init(rd->tiers[tier].backend, rd->tiers[tier].smh, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->smg[tier]);
+                    storage_metric_store_init(rd->tiers[tier].seb, rd->tiers[tier].smh, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->smg[tier]);
     }
 
     if(rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED)) {
@@ -423,7 +423,7 @@ time_t rrddim_last_entry_s_of_tier(RRDDIM *rd, size_t tier) {
     if(unlikely(tier > storage_tiers || !rd->tiers[tier].smh))
         return 0;
 
-    return storage_engine_latest_time_s(rd->tiers[tier].backend, rd->tiers[tier].smh);
+    return storage_engine_latest_time_s(rd->tiers[tier].seb, rd->tiers[tier].smh);
 }
 
 // get the timestamp of the last entry in the round-robin database
@@ -445,7 +445,7 @@ time_t rrddim_first_entry_s_of_tier(RRDDIM *rd, size_t tier) {
     if(unlikely(tier > storage_tiers || !rd->tiers[tier].smh))
         return 0;
 
-    return storage_engine_oldest_time_s(rd->tiers[tier].backend, rd->tiers[tier].smh);
+    return storage_engine_oldest_time_s(rd->tiers[tier].seb, rd->tiers[tier].smh);
 }
 
 time_t rrddim_first_entry_s(RRDDIM *rd) {

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -120,7 +120,7 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
         size_t initialized = 0;
         for (size_t tier = 0; tier < storage_tiers; tier++) {
             if (rd->tiers[tier].smh) {
-                rd->tiers[tier].db_collection_handle =
+                rd->tiers[tier].sch =
                         storage_metric_store_init(rd->tiers[tier].seb, rd->tiers[tier].smh, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->smg[tier]);
                 initialized++;
             }
@@ -176,15 +176,15 @@ bool rrddim_finalize_collection_and_check_retention(RRDDIM *rd) {
     size_t tiers_available = 0, tiers_said_no_retention = 0;
 
     for(size_t tier = 0; tier < storage_tiers ;tier++) {
-        if(!rd->tiers[tier].db_collection_handle)
+        if(!rd->tiers[tier].sch)
             continue;
 
         tiers_available++;
 
-        if(storage_engine_store_finalize(rd->tiers[tier].db_collection_handle))
+        if(storage_engine_store_finalize(rd->tiers[tier].sch))
             tiers_said_no_retention++;
 
-        rd->tiers[tier].db_collection_handle = NULL;
+        rd->tiers[tier].sch = NULL;
     }
 
     // return true if the dimension has retention in the db
@@ -257,8 +257,8 @@ static bool rrddim_conflict_callback(const DICTIONARY_ITEM *item __maybe_unused,
     rc += rrddim_set_divisor(st, rd, ctr->divisor);
 
     for(size_t tier = 0; tier < storage_tiers ;tier++) {
-        if (!rd->tiers[tier].db_collection_handle)
-            rd->tiers[tier].db_collection_handle =
+        if (!rd->tiers[tier].sch)
+            rd->tiers[tier].sch =
                     storage_metric_store_init(rd->tiers[tier].seb, rd->tiers[tier].smh, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->smg[tier]);
     }
 

--- a/database/rrddim.c
+++ b/database/rrddim.c
@@ -101,7 +101,7 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
             STORAGE_ENGINE *eng = host->db[tier].eng;
             rd->tiers[tier].backend = eng->backend;
             rd->tiers[tier].tier_grouping = host->db[tier].tier_grouping;
-            rd->tiers[tier].db_metric_handle = eng->api.metric_get_or_create(rd, host->db[tier].instance);
+            rd->tiers[tier].db_metric_handle = eng->api.metric_get_or_create(rd, host->db[tier].si);
             storage_point_unset(rd->tiers[tier].virtual_point);
             initialized++;
 

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -1377,7 +1377,7 @@ void rrddim_store_metric(RRDDIM *rd, usec_t point_end_time_ut, NETDATA_DOUBLE n,
     };
 
     for(size_t tier = 1; tier < storage_tiers ;tier++) {
-        if(unlikely(!rd->tiers[tier].db_metric_handle)) continue;
+        if(unlikely(!rd->tiers[tier].smh)) continue;
 
         struct rrddim_tier *t = &rd->tiers[tier];
 

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -888,7 +888,7 @@ void rrdset_reset(RRDSET *st) {
 
         if(!rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED)) {
             for(size_t tier = 0; tier < storage_tiers ;tier++)
-                storage_engine_store_flush(rd->tiers[tier].db_collection_handle);
+                storage_engine_store_flush(rd->tiers[tier].sch);
         }
     }
     rrddim_foreach_done(rd);
@@ -1267,7 +1267,7 @@ void store_metric_at_tier(RRDDIM *rd, size_t tier, struct rrddim_tier *t, STORAG
         if (likely(!storage_point_is_unset(t->virtual_point))) {
 
             storage_engine_store_metric(
-                t->db_collection_handle,
+                t->sch,
                 t->next_point_end_time_s * USEC_PER_SEC,
                 t->virtual_point.sum,
                 t->virtual_point.min,
@@ -1278,7 +1278,7 @@ void store_metric_at_tier(RRDDIM *rd, size_t tier, struct rrddim_tier *t, STORAG
         }
         else {
             storage_engine_store_metric(
-                t->db_collection_handle,
+                t->sch,
                 t->next_point_end_time_s * USEC_PER_SEC,
                 NAN,
                 NAN,
@@ -1357,7 +1357,7 @@ void rrddim_store_metric(RRDDIM *rd, usec_t point_end_time_ut, NETDATA_DOUBLE n,
 #endif // NETDATA_LOG_COLLECTION_ERRORS
 
     // store the metric on tier 0
-    storage_engine_store_metric(rd->tiers[0].db_collection_handle, point_end_time_ut,
+    storage_engine_store_metric(rd->tiers[0].sch, point_end_time_ut,
                                 n, 0, 0,
                                 1, 0, flags);
 
@@ -2140,9 +2140,9 @@ time_t rrdset_set_update_every_s(RRDSET *st, time_t update_every_s) {
     RRDDIM *rd;
     rrddim_foreach_read(rd, st) {
         for (size_t tier = 0; tier < storage_tiers; tier++) {
-            if (rd->tiers[tier].db_collection_handle)
+            if (rd->tiers[tier].sch)
                 storage_engine_store_change_collection_frequency(
-                        rd->tiers[tier].db_collection_handle,
+                        rd->tiers[tier].sch,
                         (int)(st->rrdhost->db[tier].tier_grouping * st->update_every));
         }
     }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -283,7 +283,7 @@ static void rrdset_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
             STORAGE_ENGINE *eng = st->rrdhost->db[tier].eng;
             if(!eng) continue;
 
-            st->storage_metrics_groups[tier] = storage_engine_metrics_group_get(eng->backend, host->db[tier].instance, &st->chart_uuid);
+            st->storage_metrics_groups[tier] = storage_engine_metrics_group_get(eng->backend, host->db[tier].si, &st->chart_uuid);
         }
     }
 
@@ -328,7 +328,7 @@ void rrdset_finalize_collection(RRDSET *st, bool dimensions_too) {
         if(!eng) continue;
 
         if(st->storage_metrics_groups[tier]) {
-            storage_engine_metrics_group_release(eng->backend, host->db[tier].instance, st->storage_metrics_groups[tier]);
+            storage_engine_metrics_group_release(eng->backend, host->db[tier].si, st->storage_metrics_groups[tier]);
             st->storage_metrics_groups[tier] = NULL;
         }
     }

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -283,7 +283,7 @@ static void rrdset_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
             STORAGE_ENGINE *eng = st->rrdhost->db[tier].eng;
             if(!eng) continue;
 
-            st->storage_metrics_groups[tier] = storage_engine_metrics_group_get(eng->backend, host->db[tier].si, &st->chart_uuid);
+            st->smg[tier] = storage_engine_metrics_group_get(eng->backend, host->db[tier].si, &st->chart_uuid);
         }
     }
 
@@ -327,9 +327,9 @@ void rrdset_finalize_collection(RRDSET *st, bool dimensions_too) {
         STORAGE_ENGINE *eng = st->rrdhost->db[tier].eng;
         if(!eng) continue;
 
-        if(st->storage_metrics_groups[tier]) {
-            storage_engine_metrics_group_release(eng->backend, host->db[tier].si, st->storage_metrics_groups[tier]);
-            st->storage_metrics_groups[tier] = NULL;
+        if(st->smg[tier]) {
+            storage_engine_metrics_group_release(eng->backend, host->db[tier].si, st->smg[tier]);
+            st->smg[tier] = NULL;
         }
     }
 

--- a/database/rrdset.c
+++ b/database/rrdset.c
@@ -283,7 +283,7 @@ static void rrdset_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
             STORAGE_ENGINE *eng = st->rrdhost->db[tier].eng;
             if(!eng) continue;
 
-            st->smg[tier] = storage_engine_metrics_group_get(eng->backend, host->db[tier].si, &st->chart_uuid);
+            st->smg[tier] = storage_engine_metrics_group_get(eng->seb, host->db[tier].si, &st->chart_uuid);
         }
     }
 
@@ -328,7 +328,7 @@ void rrdset_finalize_collection(RRDSET *st, bool dimensions_too) {
         if(!eng) continue;
 
         if(st->smg[tier]) {
-            storage_engine_metrics_group_release(eng->backend, host->db[tier].si, st->smg[tier]);
+            storage_engine_metrics_group_release(eng->seb, host->db[tier].si, st->smg[tier]);
             st->smg[tier] = NULL;
         }
     }

--- a/database/storage_engine.c
+++ b/database/storage_engine.c
@@ -10,7 +10,7 @@ static STORAGE_ENGINE engines[] = {
     {
         .id = RRD_MEMORY_MODE_NONE,
         .name = RRD_MEMORY_MODE_NONE_NAME,
-        .backend = STORAGE_ENGINE_BACKEND_RRDDIM,
+        .seb = STORAGE_ENGINE_BACKEND_RRDDIM,
         .api = {
             .metric_get = rrddim_metric_get,
             .metric_get_or_create = rrddim_metric_get_or_create,
@@ -22,7 +22,7 @@ static STORAGE_ENGINE engines[] = {
     {
         .id = RRD_MEMORY_MODE_RAM,
         .name = RRD_MEMORY_MODE_RAM_NAME,
-        .backend = STORAGE_ENGINE_BACKEND_RRDDIM,
+        .seb = STORAGE_ENGINE_BACKEND_RRDDIM,
         .api = {
             .metric_get = rrddim_metric_get,
             .metric_get_or_create = rrddim_metric_get_or_create,
@@ -34,7 +34,7 @@ static STORAGE_ENGINE engines[] = {
     {
         .id = RRD_MEMORY_MODE_MAP,
         .name = RRD_MEMORY_MODE_MAP_NAME,
-        .backend = STORAGE_ENGINE_BACKEND_RRDDIM,
+        .seb = STORAGE_ENGINE_BACKEND_RRDDIM,
         .api = {
             .metric_get = rrddim_metric_get,
             .metric_get_or_create = rrddim_metric_get_or_create,
@@ -46,7 +46,7 @@ static STORAGE_ENGINE engines[] = {
     {
         .id = RRD_MEMORY_MODE_SAVE,
         .name = RRD_MEMORY_MODE_SAVE_NAME,
-        .backend = STORAGE_ENGINE_BACKEND_RRDDIM,
+        .seb = STORAGE_ENGINE_BACKEND_RRDDIM,
         .api = {
             .metric_get = rrddim_metric_get,
             .metric_get_or_create = rrddim_metric_get_or_create,
@@ -58,7 +58,7 @@ static STORAGE_ENGINE engines[] = {
     {
         .id = RRD_MEMORY_MODE_ALLOC,
         .name = RRD_MEMORY_MODE_ALLOC_NAME,
-        .backend = STORAGE_ENGINE_BACKEND_RRDDIM,
+        .seb = STORAGE_ENGINE_BACKEND_RRDDIM,
         .api = {
             .metric_get = rrddim_metric_get,
             .metric_get_or_create = rrddim_metric_get_or_create,
@@ -71,7 +71,7 @@ static STORAGE_ENGINE engines[] = {
     {
         .id = RRD_MEMORY_MODE_DBENGINE,
         .name = RRD_MEMORY_MODE_DBENGINE_NAME,
-        .backend = STORAGE_ENGINE_BACKEND_DBENGINE,
+        .seb = STORAGE_ENGINE_BACKEND_DBENGINE,
         .api = {
             .metric_get = rrdeng_metric_get,
             .metric_get_or_create = rrdeng_metric_get_or_create,

--- a/exporting/process_data.c
+++ b/exporting/process_data.c
@@ -77,8 +77,8 @@ NETDATA_DOUBLE exporting_calculate_value_from_stored_data(
     time_t before = instance->before;
 
     // find the edges of the rrd database for this chart
-    time_t first_t = storage_engine_oldest_time_s(rd->tiers[0].backend, rd->tiers[0].smh);
-    time_t last_t = storage_engine_latest_time_s(rd->tiers[0].backend, rd->tiers[0].smh);
+    time_t first_t = storage_engine_oldest_time_s(rd->tiers[0].seb, rd->tiers[0].smh);
+    time_t last_t = storage_engine_latest_time_s(rd->tiers[0].seb, rd->tiers[0].smh);
     time_t update_every = st->update_every;
     struct storage_engine_query_handle handle;
 
@@ -126,7 +126,7 @@ NETDATA_DOUBLE exporting_calculate_value_from_stored_data(
     size_t counter = 0;
     NETDATA_DOUBLE sum = 0;
 
-    for (storage_engine_query_init(rd->tiers[0].backend, rd->tiers[0].smh, &handle, after, before, STORAGE_PRIORITY_SYNCHRONOUS); !storage_engine_query_is_finished(&handle);) {
+    for (storage_engine_query_init(rd->tiers[0].seb, rd->tiers[0].smh, &handle, after, before, STORAGE_PRIORITY_SYNCHRONOUS); !storage_engine_query_is_finished(&handle);) {
         STORAGE_POINT sp = storage_engine_query_next_metric(&handle);
         points_read++;
 

--- a/exporting/process_data.c
+++ b/exporting/process_data.c
@@ -77,8 +77,8 @@ NETDATA_DOUBLE exporting_calculate_value_from_stored_data(
     time_t before = instance->before;
 
     // find the edges of the rrd database for this chart
-    time_t first_t = storage_engine_oldest_time_s(rd->tiers[0].backend, rd->tiers[0].db_metric_handle);
-    time_t last_t = storage_engine_latest_time_s(rd->tiers[0].backend, rd->tiers[0].db_metric_handle);
+    time_t first_t = storage_engine_oldest_time_s(rd->tiers[0].backend, rd->tiers[0].smh);
+    time_t last_t = storage_engine_latest_time_s(rd->tiers[0].backend, rd->tiers[0].smh);
     time_t update_every = st->update_every;
     struct storage_engine_query_handle handle;
 
@@ -126,7 +126,7 @@ NETDATA_DOUBLE exporting_calculate_value_from_stored_data(
     size_t counter = 0;
     NETDATA_DOUBLE sum = 0;
 
-    for (storage_engine_query_init(rd->tiers[0].backend, rd->tiers[0].db_metric_handle, &handle, after, before, STORAGE_PRIORITY_SYNCHRONOUS); !storage_engine_query_is_finished(&handle);) {
+    for (storage_engine_query_init(rd->tiers[0].backend, rd->tiers[0].smh, &handle, after, before, STORAGE_PRIORITY_SYNCHRONOUS); !storage_engine_query_is_finished(&handle);) {
         STORAGE_POINT sp = storage_engine_query_next_metric(&handle);
         points_read++;
 

--- a/exporting/tests/netdata_doubles.c
+++ b/exporting/tests/netdata_doubles.c
@@ -182,25 +182,25 @@ void rrdset_update_heterogeneous_flag(RRDSET *st)
     (void)st;
 }
 
-time_t __mock_rrddim_query_oldest_time(STORAGE_METRIC_HANDLE *db_metric_handle)
+time_t __mock_rrddim_query_oldest_time(STORAGE_METRIC_HANDLE *smh)
 {
-    (void)db_metric_handle;
+    (void)smh;
 
     function_called();
     return mock_type(time_t);
 }
 
-time_t __mock_rrddim_query_latest_time(STORAGE_METRIC_HANDLE *db_metric_handle)
+time_t __mock_rrddim_query_latest_time(STORAGE_METRIC_HANDLE *smh)
 {
-    (void)db_metric_handle;
+    (void)smh;
 
     function_called();
     return mock_type(time_t);
 }
 
-void __mock_rrddim_query_init(STORAGE_METRIC_HANDLE *db_metric_handle, struct rrddim_query_handle *handle, time_t start_time, time_t end_time)
+void __mock_rrddim_query_init(STORAGE_METRIC_HANDLE *smh, struct rrddim_query_handle *handle, time_t start_time, time_t end_time)
 {
-    (void)db_metric_handle;
+    (void)smh;
     (void)handle;
 
     function_called();

--- a/exporting/tests/test_exporting_engine.h
+++ b/exporting/tests/test_exporting_engine.h
@@ -55,9 +55,9 @@ int __wrap_connect_to_one_of(
     size_t *reconnects_counter,
     char *connected_to,
     size_t connected_to_size);
-time_t __mock_rrddim_query_oldest_time(STORAGE_METRIC_HANDLE *db_metric_handle);
-time_t __mock_rrddim_query_latest_time(STORAGE_METRIC_HANDLE *db_metric_handle);
-void __mock_rrddim_query_init(STORAGE_METRIC_HANDLE *db_metric_handle, struct rrddim_query_handle *handle, time_t start_time, time_t end_time);
+time_t __mock_rrddim_query_oldest_time(STORAGE_METRIC_HANDLE *smh);
+time_t __mock_rrddim_query_latest_time(STORAGE_METRIC_HANDLE *smh);
+void __mock_rrddim_query_init(STORAGE_METRIC_HANDLE *smh, struct rrddim_query_handle *handle, time_t start_time, time_t end_time);
 int __mock_rrddim_query_is_finished(struct rrddim_query_handle *handle);
 STORAGE_POINT __mock_rrddim_query_next_metric(struct rrddim_query_handle *handle);
 void __mock_rrddim_query_finalize(struct rrddim_query_handle *handle);

--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -358,7 +358,7 @@ ml_dimension_calculated_numbers(ml_training_thread_t *training_thread, ml_dimens
     */
     struct storage_engine_query_handle handle;
 
-    storage_engine_query_init(dim->rd->tiers[0].backend, dim->rd->tiers[0].db_metric_handle, &handle,
+    storage_engine_query_init(dim->rd->tiers[0].backend, dim->rd->tiers[0].smh, &handle,
               training_response.query_after_t, training_response.query_before_t,
               STORAGE_PRIORITY_BEST_EFFORT);
 

--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -358,7 +358,7 @@ ml_dimension_calculated_numbers(ml_training_thread_t *training_thread, ml_dimens
     */
     struct storage_engine_query_handle handle;
 
-    storage_engine_query_init(dim->rd->tiers[0].backend, dim->rd->tiers[0].smh, &handle,
+    storage_engine_query_init(dim->rd->tiers[0].seb, dim->rd->tiers[0].smh, &handle,
               training_response.query_after_t, training_response.query_before_t,
               STORAGE_PRIORITY_BEST_EFFORT);
 

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -162,7 +162,7 @@ static struct replication_query *replication_query_prepare(
         }
     }
 
-    q->backend = st->rrdhost->db[0].eng->backend;
+    q->backend = st->rrdhost->db[0].eng->seb;
 
     // prepare our array of dimensions
     size_t count = 0;

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -184,7 +184,7 @@ static struct replication_query *replication_query_prepare(
         d->rda = dictionary_acquired_item_dup(rd_dfe.dict, rd_dfe.item);
         d->rd = rd;
 
-        storage_engine_query_init(q->backend, rd->tiers[0].db_metric_handle, &d->handle, q->query.after, q->query.before,
+        storage_engine_query_init(q->backend, rd->tiers[0].smh, &d->handle, q->query.after, q->query.before,
                      q->query.locked_data_collection ? STORAGE_PRIORITY_HIGH : STORAGE_PRIORITY_LOW);
         d->enabled = true;
         d->skip = false;

--- a/web/api/queries/query.c
+++ b/web/api/queries/query.c
@@ -939,7 +939,7 @@ static inline long rrdr_line_init(RRDR *r __maybe_unused, time_t t __maybe_unuse
 // tier management
 
 static bool query_metric_is_valid_tier(QUERY_METRIC *qm, size_t tier) {
-    if(!qm->tiers[tier].db_metric_handle || !qm->tiers[tier].db_first_time_s || !qm->tiers[tier].db_last_time_s || !qm->tiers[tier].db_update_every_s)
+    if(!qm->tiers[tier].smh || !qm->tiers[tier].db_first_time_s || !qm->tiers[tier].db_last_time_s || !qm->tiers[tier].db_update_every_s)
         return false;
 
     return true;
@@ -949,12 +949,12 @@ static size_t query_metric_first_working_tier(QUERY_METRIC *qm) {
     for(size_t tier = 0; tier < storage_tiers ; tier++) {
 
         // find the db time-range for this tier for all metrics
-        STORAGE_METRIC_HANDLE *db_metric_handle = qm->tiers[tier].db_metric_handle;
+        STORAGE_METRIC_HANDLE *smh = qm->tiers[tier].smh;
         time_t first_time_s = qm->tiers[tier].db_first_time_s;
         time_t last_time_s  = qm->tiers[tier].db_last_time_s;
         time_t update_every_s = qm->tiers[tier].db_update_every_s;
 
-        if(!db_metric_handle || !first_time_s || !last_time_s || !update_every_s)
+        if(!smh || !first_time_s || !last_time_s || !update_every_s)
             continue;
 
         return tier;
@@ -1018,12 +1018,12 @@ static size_t query_metric_best_tier_for_timeframe(QUERY_METRIC *qm, time_t afte
     for(size_t tier = 0; tier < storage_tiers ; tier++) {
 
         // find the db time-range for this tier for all metrics
-        STORAGE_METRIC_HANDLE *db_metric_handle = qm->tiers[tier].db_metric_handle;
+        STORAGE_METRIC_HANDLE *smh = qm->tiers[tier].smh;
         time_t first_time_s = qm->tiers[tier].db_first_time_s;
         time_t last_time_s  = qm->tiers[tier].db_last_time_s;
         time_t update_every_s = qm->tiers[tier].db_update_every_s;
 
-        if( !db_metric_handle ||
+        if( !smh ||
             !first_time_s ||
             !last_time_s ||
             !update_every_s ||
@@ -1261,7 +1261,7 @@ static void query_planer_initialize_plans(QUERY_ENGINE_OPS *ops) {
 
         struct query_metric_tier *tier_ptr = &qm->tiers[tier];
         STORAGE_ENGINE *eng = query_metric_storage_engine(ops->r->internal.qt, qm, tier);
-        storage_engine_query_init(eng->backend, tier_ptr->db_metric_handle, &ops->plans[p].handle,
+        storage_engine_query_init(eng->backend, tier_ptr->smh, &ops->plans[p].handle,
                 after, before, ops->r->internal.qt->request.priority);
 
         ops->plans[p].initialized = true;
@@ -1960,7 +1960,7 @@ void rrdr_fill_tier_gap_from_smaller_tiers(RRDDIM *rd, size_t tier, time_t now_s
     struct rrddim_tier *t = &rd->tiers[tier];
     if(unlikely(!t)) return;
 
-    time_t latest_time_s = storage_engine_latest_time_s(t->backend, t->db_metric_handle);
+    time_t latest_time_s = storage_engine_latest_time_s(t->backend, t->smh);
     time_t granularity = (time_t)t->tier_grouping * (time_t)rd->rrdset->update_every;
     time_t time_diff   = now_s - latest_time_s;
 
@@ -1974,15 +1974,15 @@ void rrdr_fill_tier_gap_from_smaller_tiers(RRDDIM *rd, size_t tier, time_t now_s
 
     // for each lower tier
     for(int read_tier = (int)tier - 1; read_tier >= 0 ; read_tier--){
-        time_t smaller_tier_first_time = storage_engine_oldest_time_s(rd->tiers[read_tier].backend, rd->tiers[read_tier].db_metric_handle);
-        time_t smaller_tier_last_time = storage_engine_latest_time_s(rd->tiers[read_tier].backend, rd->tiers[read_tier].db_metric_handle);
+        time_t smaller_tier_first_time = storage_engine_oldest_time_s(rd->tiers[read_tier].backend, rd->tiers[read_tier].smh);
+        time_t smaller_tier_last_time = storage_engine_latest_time_s(rd->tiers[read_tier].backend, rd->tiers[read_tier].smh);
         if(smaller_tier_last_time <= latest_time_s) continue;  // it is as bad as we are
 
         long after_wanted = (latest_time_s < smaller_tier_first_time) ? smaller_tier_first_time : latest_time_s;
         long before_wanted = smaller_tier_last_time;
 
         struct rrddim_tier *tmp = &rd->tiers[read_tier];
-        storage_engine_query_init(tmp->backend, tmp->db_metric_handle, &handle, after_wanted, before_wanted, STORAGE_PRIORITY_HIGH);
+        storage_engine_query_init(tmp->backend, tmp->smh, &handle, after_wanted, before_wanted, STORAGE_PRIORITY_HIGH);
 
         size_t points_read = 0;
 


### PR DESCRIPTION
##### Summary

- `STORAGE_INSTANCE` -> `si`
- `STORAGE_METRIC_GROUP` -> `smg`
- `STORAGE_METRIC_HANDLE` -> `smh`
- `STORAGE_COLLECT_HANDLE` -> `sch`
- `STORAGE_ENGINE_BACKEND` -> `seb`
- `STORAGE_ENGINE_QUERY_HANDLE` -> `seqh`

Various different variable and struct field names were used for the same entity. With this PR we have a consistent naming pattern for variables and fields across the entire code base for storage engines.

##### Test Plan

- CI jobs.