### PR TITLE
packaging: add cap_dac_read_search to go.d.plugin

### DIFF
--- a/contrib/debian/netdata-plugin-go.postinst
+++ b/contrib/debian/netdata-plugin-go.postinst
@@ -6,7 +6,7 @@ case "$1" in
   configure|reconfigure)
     chown root:netdata /usr/libexec/netdata/plugins.d/go.d.plugin
     chmod 0750 /usr/libexec/netdata/plugins.d/go.d.plugin
-    if ! setcap "cap_net_admin=eip cap_net_raw=eip" /usr/libexec/netdata/plugins.d/go.d.plugin; then
+    if ! setcap "cap_dac_read_search+epi cap_net_admin=eip cap_net_raw=eip" /usr/libexec/netdata/plugins.d/go.d.plugin; then
         chmod -f 4750 /usr/libexec/netdata/plugins.d/go.d.plugin
     fi
     ;;

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1620,7 +1620,7 @@ install_go
 
 if [ -f "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin" ]; then
   if command -v setcap 1>/dev/null 2>&1; then
-    run setcap "cap_net_admin+epi cap_net_raw=eip" "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin"
+    run setcap "cap_dac_read_search+epi cap_net_admin+epi cap_net_raw=eip" "${NETDATA_PREFIX}/usr/libexec/netdata/plugins.d/go.d.plugin"
   fi
 fi
 

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -993,7 +993,7 @@ fi
 %defattr(0750,root,netdata,0750)
 # CAP_NET_ADMIN needed for WireGuard collector
 # CAP_NET_RAW needed for ping collector
-%caps(cap_net_admin,cap_net_raw=eip) %{_libexecdir}/%{name}/plugins.d/%{go_name}
+%caps(cap_dac_read_search+epi,cap_net_admin,cap_net_raw=eip) %{_libexecdir}/%{name}/plugins.d/%{go_name}
 %defattr(0644,root,netdata,0755)
 %{_libdir}/%{name}/conf.d/go.d.conf
 %{_libdir}/%{name}/conf.d/go.d

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -993,7 +993,7 @@ fi
 %defattr(0750,root,netdata,0750)
 # CAP_NET_ADMIN needed for WireGuard collector
 # CAP_NET_RAW needed for ping collector
-%caps(cap_dac_read_search+epi,cap_net_admin,cap_net_raw=eip) %{_libexecdir}/%{name}/plugins.d/%{go_name}
+%caps(cap_dac_read_search,cap_net_admin,cap_net_raw=eip) %{_libexecdir}/%{name}/plugins.d/%{go_name}
 %defattr(0644,root,netdata,0755)
 %{_libdir}/%{name}/conf.d/go.d.conf
 %{_libdir}/%{name}/conf.d/go.d

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -190,7 +190,7 @@ if command -v setcap >/dev/null 2>&1; then
         run setcap "cap_sys_admin=ep" "usr/libexec/netdata/plugins.d/perf.plugin"
     fi
 
-    run setcap "cap_net_admin,cap_net_raw=eip" "usr/libexec/netdata/plugins.d/go.d.plugin"
+    run setcap "cap_dac_read_search+epi cap_net_admin+epi cap_net_raw=eip" "usr/libexec/netdata/plugins.d/go.d.plugin"
 else
   for x in ndsudo apps.plugin perf.plugin slabinfo.plugin debugfs.plugin; do
     f="usr/libexec/netdata/plugins.d/${x}"


### PR DESCRIPTION
##### Summary

Needed for [go.d/filecheck](https://github.com/netdata/go.d.plugin/tree/master/modules/filecheck#readme).

##### Test Plan

Install and check go.d.plugin capabilities:

- deb package
- rpm package
- static build
- from source

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
