### PR TITLE
Fix sanitizer errors

### DIFF
--- a/database/rrdlabels.c
+++ b/database/rrdlabels.c
@@ -698,7 +698,6 @@ static RRDLABEL *rrdlabels_find_label_with_key_unsafe(RRDLABELS *labels, RRDLABE
  * FIXME: Attribute added because address sanitizer reports an issue when
  * running the agent with `-W unittest`.
 */
-__attribute__((no_sanitize("address")))
 static void labels_add_already_sanitized(RRDLABELS *labels, const char *key, const char *value, RRDLABEL_SRC ls)
 {
     RRDLABEL *new_label = add_label_name_value(key, value);
@@ -715,10 +714,13 @@ static void labels_add_already_sanitized(RRDLABELS *labels, const char *key, con
 
     if(*PValue) {
         new_ls |= RRDLABEL_FLAG_OLD;
+        *((RRDLABEL_SRC *)PValue) = new_ls;
+
         delete_label(new_label);
     }
     else {
         new_ls |= RRDLABEL_FLAG_NEW;
+        *((RRDLABEL_SRC *)PValue) = new_ls;
 
         RRDLABEL *old_label_with_same_key = rrdlabels_find_label_with_key_unsafe(labels, new_label);
         if (old_label_with_same_key) {
@@ -728,7 +730,6 @@ static void labels_add_already_sanitized(RRDLABELS *labels, const char *key, con
     }
 
     labels->version++;
-    *((RRDLABEL_SRC *)PValue) = new_ls;
 
     size_t mem_after_judyl = JudyLMemUsed(labels->JudyL);
     STATS_PLUS_MEMORY(&dictionary_stats_category_rrdlabels, 0, mem_after_judyl - mem_before_judyl, 0);
@@ -1470,8 +1471,11 @@ static int rrdlabels_unittest_double_check()
     rrdlabels_add(labels, "key1", "value1", RRDLABEL_SRC_CONFIG);
     ret += rrdlabels_unittest_expect_value(labels, "key1", "value1", RRDLABEL_FLAG_NEW);
 
-    rrdlabels_add(labels, "key1", "value2", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(labels, "key1", "value2", RRDLABEL_SRC_K8S);
     ret += !rrdlabels_unittest_expect_value(labels, "key1", "value2", RRDLABEL_FLAG_OLD);
+
+    rrdlabels_add(labels, "key1", "value3", RRDLABEL_SRC_ACLK);
+    ret += !rrdlabels_unittest_expect_value(labels, "key1", "value3", RRDLABEL_FLAG_OLD);
 
     ret += (rrdlabels_entries(labels) != 1);
 

--- a/database/rrdlabels.c
+++ b/database/rrdlabels.c
@@ -694,10 +694,6 @@ static RRDLABEL *rrdlabels_find_label_with_key_unsafe(RRDLABELS *labels, RRDLABE
 // ----------------------------------------------------------------------------
 // rrdlabels_add()
 
-/*
- * FIXME: Attribute added because address sanitizer reports an issue when
- * running the agent with `-W unittest`.
-*/
 static void labels_add_already_sanitized(RRDLABELS *labels, const char *key, const char *value, RRDLABEL_SRC ls)
 {
     RRDLABEL *new_label = add_label_name_value(key, value);

--- a/libnetdata/buffer/buffer.h
+++ b/libnetdata/buffer/buffer.h
@@ -279,11 +279,6 @@ static inline void buffer_memcat(BUFFER *wb, const void *mem, size_t bytes) {
     buffer_overflow_check(wb);
 }
 
-/*
- * FIXME: Attribute added because address sanitizer reports a log-related
- * issue when running the agent with `-W unittest`.
-*/
-__attribute__((no_sanitize("address")))
 static inline void buffer_json_strcat(BUFFER *wb, const char *txt)
 {
     if(unlikely(!txt || !*txt)) return;

--- a/libnetdata/dictionary/dictionary.c
+++ b/libnetdata/dictionary/dictionary.c
@@ -3803,6 +3803,8 @@ int dictionary_unittest(size_t entries) {
     errors += dictionary_unittest_threads();
     errors += dictionary_unittest_view_threads();
 
+    cleanup_destroyed_dictionaries();
+
     fprintf(stderr, "\n%zu errors found\n", errors);
     return  errors ? 1 : 0;
 }

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -1576,10 +1576,6 @@ static void priority_annotator(BUFFER *wb, const char *key, struct log_field *lf
     buffer_strcat(wb, nd_log_id2priority(pri));
 }
 
-/*
- * FIXME: Attribute added because address sanitizer reports a log-related
- * issue when running the agent with `-W unittest`.
-*/
 static bool needs_quotes_for_logfmt(const char *s)
 {
     static bool safe_for_logfmt[256] = {
@@ -1612,10 +1608,6 @@ static bool needs_quotes_for_logfmt(const char *s)
     return false;
 }
 
-/*
- * FIXME: Attribute added because address sanitizer reports a log-related
- * issue when running the agent with `-W unittest`.
-*/
 static void string_to_logfmt(BUFFER *wb, const char *s)
 {
     bool spaces = needs_quotes_for_logfmt(s);
@@ -1629,10 +1621,6 @@ static void string_to_logfmt(BUFFER *wb, const char *s)
         buffer_fast_strcat(wb, "\"", 1);
 }
 
-/*
- * FIXME: Attribute added because address sanitizer reports a log-related
- * issue when running the agent with `-W unittest`.
-*/
 static void nd_logger_logfmt(BUFFER *wb, struct log_field *fields, size_t fields_max)
 {
 
@@ -2257,10 +2245,6 @@ static ND_LOG_SOURCES nd_log_validate_source(ND_LOG_SOURCES source) {
 // ----------------------------------------------------------------------------
 // public API for loggers
 
-/*
- * FIXME: Attribute added because address sanitizer reports a log-related
- * issue when running the agent with `-W unittest`.
-*/
 void netdata_logger(ND_LOG_SOURCES source, ND_LOG_FIELD_PRIORITY priority, const char *file, const char *function, unsigned long line, const char *fmt, ... )
 {
     int saved_errno = errno;

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -1580,7 +1580,6 @@ static void priority_annotator(BUFFER *wb, const char *key, struct log_field *lf
  * FIXME: Attribute added because address sanitizer reports a log-related
  * issue when running the agent with `-W unittest`.
 */
-__attribute__((no_sanitize("address")))
 static bool needs_quotes_for_logfmt(const char *s)
 {
     static bool safe_for_logfmt[256] = {
@@ -1617,7 +1616,6 @@ static bool needs_quotes_for_logfmt(const char *s)
  * FIXME: Attribute added because address sanitizer reports a log-related
  * issue when running the agent with `-W unittest`.
 */
-__attribute__((no_sanitize("address")))
 static void string_to_logfmt(BUFFER *wb, const char *s)
 {
     bool spaces = needs_quotes_for_logfmt(s);
@@ -1635,7 +1633,6 @@ static void string_to_logfmt(BUFFER *wb, const char *s)
  * FIXME: Attribute added because address sanitizer reports a log-related
  * issue when running the agent with `-W unittest`.
 */
-__attribute__((no_sanitize("address")))
 static void nd_logger_logfmt(BUFFER *wb, struct log_field *fields, size_t fields_max)
 {
 
@@ -2170,8 +2167,8 @@ static void nd_logger(const char *file, const char *function, const unsigned lon
     if(likely(!thread_log_fields[NDF_TID].entry.set))
         thread_log_fields[NDF_TID].entry = ND_LOG_FIELD_U64(NDF_TID, gettid());
 
+    char os_threadname[NETDATA_THREAD_NAME_MAX + 1];
     if(likely(!thread_log_fields[NDF_THREAD_TAG].entry.set)) {
-        char os_threadname[NETDATA_THREAD_NAME_MAX + 1];
         const char *thread_tag = netdata_thread_tag();
         if(!netdata_thread_tag_exists()) {
             if (!netdata_thread_tag_exists()) {
@@ -2264,7 +2261,6 @@ static ND_LOG_SOURCES nd_log_validate_source(ND_LOG_SOURCES source) {
  * FIXME: Attribute added because address sanitizer reports a log-related
  * issue when running the agent with `-W unittest`.
 */
-__attribute__((no_sanitize("address")))
 void netdata_logger(ND_LOG_SOURCES source, ND_LOG_FIELD_PRIORITY priority, const char *file, const char *function, unsigned long line, const char *fmt, ... )
 {
     int saved_errno = errno;


### PR DESCRIPTION
- [x] fixed bug in log.c where a stack char * was accessed during logging
- [x] fixed bug in rrdlabels.c where a PValue was written after Judy re-arranged the tree
- [x] removed sanitizer exceptions that were introduced because of the above