### PR TITLE
Add missing call for aral_freez (eBPF)

### DIFF
--- a/collectors/ebpf.plugin/ebpf_apps.c
+++ b/collectors/ebpf.plugin/ebpf_apps.c
@@ -1201,6 +1201,7 @@ static inline void del_pid_entry(pid_t pid)
             }
             JudyLFreeArray(&pid_ptr->socket_stats.JudyLArray, PJE0);
         }
+        aral_freez(ebpf_judy_pid.pid_table, pid_ptr);
         JudyLDel(&ebpf_judy_pid.index.JudyLArray, p->pid, PJE0);
     }
     rw_spinlock_write_unlock(&ebpf_judy_pid.index.rw_spinlock);


### PR DESCRIPTION
##### Summary
This PR address the reported issuee:

```sh
#3 0x555942444f62 in ebpf_get_pid_from_judy_unsafe /home/costa/src/netdata-ktsaou.git/collectors/ebpf.plugin/ebpf.c:708
    #4 0x5559425273be in read_proc_pid_cmdline /home/costa/src/netdata-ktsaou.git/collectors/ebpf.plugin/ebpf_apps.c:869
    #5 0x555942527fe9 in read_proc_pid_stat /home/costa/src/netdata-ktsaou.git/collectors/ebpf.plugin/ebpf_apps.c:932
    #6 0x555942528518 in collect_data_for_pid /home/costa/src/netdata-ktsaou.git/collectors/ebpf.plugin/ebpf_apps.c:966
    #7 0x55594252b2f9 in read_proc_filesystem /home/costa/src/netdata-ktsaou.git/collectors/ebpf.plugin/ebpf_apps.c:1347
    #8 0x55594252bcbb in collect_data_for_all_processes /home/costa/src/netdata-ktsaou.git/collectors/ebpf.plugin/ebpf_apps.c:1432
    #9 0x5559424524d5 in main /home/costa/src/netdata-ktsaou.git/collectors/ebpf.plugin/ebpf.c:4097
```

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
