### PR TITLE
Fix coverity issues

### DIFF
--- a/daemon/config/dyncfg-unittest.c
+++ b/daemon/config/dyncfg-unittest.c
@@ -516,8 +516,8 @@ static int dyncfg_unittest_run(const char *cmd, BUFFER *wb, const char *payload,
 }
 
 static void dyncfg_unittest_cleanup_files(void) {
-    char path[PATH_MAX];
-    snprintfz(path, sizeof(path), "%s/%s", netdata_configured_varlib_dir, "config");
+    char path[FILENAME_MAX];
+    snprintfz(path, sizeof(path) - 1, "%s/%s", netdata_configured_varlib_dir, "config");
 
     DIR *dir = opendir(path);
     if (!dir) {
@@ -526,7 +526,7 @@ static void dyncfg_unittest_cleanup_files(void) {
     }
 
     struct dirent *entry;
-    char filename[FILENAME_MAX];
+    char filename[FILENAME_MAX + sizeof(entry->d_name)];
     while ((entry = readdir(dir)) != NULL) {
         if ((entry->d_type == DT_REG || entry->d_type == DT_LNK) && strstartswith(entry->d_name, "unittest:") && strendswith(entry->d_name, ".dyncfg")) {
             snprintf(filename, sizeof(filename), "%s/%s", path, entry->d_name);
@@ -788,5 +788,6 @@ int dyncfg_unittest(void) {
     netdata_thread_join(thread, &ptr);
     dyncfg_unittest_cleanup_files();
     dictionary_destroy(dyncfg_unittest_data.nodes);
+    buffer_free(wb);
     return __atomic_load_n(&dyncfg_unittest_data.errors, __ATOMIC_RELAXED) > 0 ? 1 : 0;
 }

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -1509,11 +1509,7 @@ static int web_client_api_request_v1_config(RRDHOST *host, struct web_client *w,
     char transaction[UUID_COMPACT_STR_LEN];
     uuid_unparse_lower_compact(w->transaction, transaction);
 
-    size_t len = (action ? strlen(action) : 0)
-                 + (id ? strlen(id) : 0)
-                 + (path ? strlen(path) : 0)
-                 + (add_name ? strlen(add_name) : 0)
-                 + 100;
+    size_t len = strlen(action) + (id ? strlen(id) : 0) + strlen(path) + (add_name ? strlen(add_name) : 0) + 100;
 
     char cmd[len];
     if(strcmp(action, "tree") == 0)


### PR DESCRIPTION

##### Summary
- Fix warning note: ‘snprintf’ output between 2 and 4352 bytes into a buffer of size 4096
- CID 413881:  Control flow issues  (DEADCODE)
  - /web/api/web_api_v1.c: 1512 in web_client_api_request_v1_config()
- CID 413882:  Control flow issues  (DEADCODE)
  - /web/api/web_api_v1.c: 1512 in web_client_api_request_v1_config()
- CID 413883:  Resource leaks  (RESOURCE_LEAK)
   /daemon/config/dyncfg-unittest.c: 791 in dyncfg_unittest()


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
