### PR TITLE
Change default build directory in installer to `build`.

### DIFF
--- a/coverity-scan.sh
+++ b/coverity-scan.sh
@@ -54,7 +54,7 @@ fi
 CMAKE_OPTS="${ninja:+-G Ninja}"
 BUILD_OPTS="VERBOSE=1"
 [ -n "${ninja}" ] && BUILD_OPTS="-v"
-NETDATA_BUILD_DIR="${NETDATA_BUILD_DIR:-./cmake-build-release/}"
+NETDATA_BUILD_DIR="${NETDATA_BUILD_DIR:-./build/}"
 
 if [ -f ".coverity-scan.conf" ]; then
   source ".coverity-scan.conf"

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1092,7 +1092,7 @@ fi
 echo >&2
 
 [ -n "${GITHUB_ACTIONS}" ] && echo "::group::Configuring Netdata."
-NETDATA_BUILD_DIR="${NETDATA_BUILD_DIR:-./cmake-build-release/}"
+NETDATA_BUILD_DIR="${NETDATA_BUILD_DIR:-./build/}"
 rm -rf "${NETDATA_BUILD_DIR}"
 
 # function to extract values from the config file


### PR DESCRIPTION
##### Summary

Allows better integration with external tooling like IDEs.

##### Test Plan

CI still passes on this PR

##### Additional Information

Resolves: #16751 