### PR TITLE
Use UNUSED instead of __maybe_unused.

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -3607,7 +3607,7 @@ static void normalize_utilization(struct target *root) {
     // or entirely. Of course, either way, we disable it just a single iteration.
 
     kernel_uint_t max_time = get_system_cpus() * time_factor * RATES_DETAIL;
-    kernel_uint_t utime = 0, cutime = 0, stime = 0, cstime = 0, gtime = 0, cgtime = 0, minflt = 0, cminflt = 0, majflt = 0, cmajflt = 0;
+    kernel_uint_t utime = 0, cutime = 0, stime = 0, cstime = 0, gtime = 0, cgtime = 0;
 
     if(global_utime > max_time) global_utime = max_time;
     if(global_stime > max_time) global_stime = max_time;
@@ -3622,11 +3622,6 @@ static void normalize_utilization(struct target *root) {
         cutime  += w->cutime;
         cstime  += w->cstime;
         cgtime  += w->cgtime;
-
-        minflt  += w->minflt;
-        majflt  += w->majflt;
-        cminflt += w->cminflt;
-        cmajflt += w->cmajflt;
     }
 
     if(global_utime || global_stime || global_gtime) {

--- a/libnetdata/aral/aral.c
+++ b/libnetdata/aral/aral.c
@@ -220,7 +220,7 @@ static inline void aral_free_validate_internal_check(ARAL *ar, ARAL_FREE *fr) {
 // ----------------------------------------------------------------------------
 // find the page a pointer belongs to
 
-#ifdef NETDATA_INTERNAL_CHECKS
+#ifdef NETDATA_ARAL_INTERNAL_CHECKS
 static inline ARAL_PAGE *find_page_with_allocation_internal_check(ARAL *ar, void *ptr) {
     aral_lock(ar);
 

--- a/libnetdata/avl/avl.c
+++ b/libnetdata/avl/avl.c
@@ -362,10 +362,12 @@ void avl_init_lock(avl_tree_lock *tree, int (*compar)(void * /*a*/, void * /*b*/
 #endif
 }
 
-void avl_destroy_lock(avl_tree_lock *tree __maybe_unused) {
+void avl_destroy_lock(avl_tree_lock *tree) {
 #if defined(AVL_LOCK_WITH_RWLOCK)
     if(netdata_rwlock_destroy(&tree->rwlock) != 0)
         fatal("Failed to destroy AVL rwlock");
+#else
+    UNUSED(tree);
 #endif
 }
 

--- a/libnetdata/buffer/buffer.h
+++ b/libnetdata/buffer/buffer.h
@@ -72,7 +72,10 @@ typedef struct web_buffer {
 #define buffer_overflow_check(b)
 #endif
 
-static inline void _buffer_overflow_check(BUFFER *b __maybe_unused) {
+static inline void _buffer_overflow_check(BUFFER *b)
+{
+    UNUSED(b);
+
     assert(b->len <= b->size &&
                    "BUFFER: length is above buffer size.");
 

--- a/libnetdata/clocks/clocks.c
+++ b/libnetdata/clocks/clocks.c
@@ -17,7 +17,9 @@ usec_t clock_monotonic_resolution = DEFAULT_CLOCK_RESOLUTION_UT;
 usec_t clock_realtime_resolution = DEFAULT_CLOCK_RESOLUTION_UT;
 
 #ifndef HAVE_CLOCK_GETTIME
-inline int clock_gettime(clockid_t clk_id __maybe_unused, struct timespec *ts) {
+inline int clock_gettime(clockid_t clk_id, struct timespec *ts) {
+    UNUSED(clk_id);
+
     struct timeval tv;
     if(unlikely(gettimeofday(&tv, NULL) == -1)) {
         netdata_log_error("gettimeofday() failed.");

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -570,8 +570,10 @@ void ebpf_update_pid_table(ebpf_local_maps_t *pid, ebpf_module_t *em)
  * @param em        the structure with information about how the module/thread is working.
  * @param map_name  the name of the file used to log.
  */
-void ebpf_update_map_size(struct bpf_map *map, ebpf_local_maps_t *lmap, ebpf_module_t *em, const char *map_name __maybe_unused)
+void ebpf_update_map_size(struct bpf_map *map, ebpf_local_maps_t *lmap, ebpf_module_t *em, const char *map_name)
 {
+    UNUSED(map_name);
+
     uint32_t define_size = 0;
     uint32_t apps_type = NETDATA_EBPF_MAP_PID | NETDATA_EBPF_MAP_RESIZABLE;
     if (lmap->user_input && lmap->user_input != lmap->internal_input) {

--- a/libnetdata/facets/facets.c
+++ b/libnetdata/facets/facets.c
@@ -355,7 +355,7 @@ uint32_t facets_rows(FACETS *facets) {
 
 // ----------------------------------------------------------------------------
 
-static void facets_row_free(FACETS *facets __maybe_unused, FACET_ROW *row);
+static void facets_row_free(FACETS *facets, FACET_ROW *row);
 static inline void facet_value_is_used(FACET_KEY *k, FACET_VALUE *v);
 static inline bool facets_key_is_facet(FACETS *facets, FACET_KEY *k);
 
@@ -903,6 +903,7 @@ void facets_update_estimations(FACETS *facets, usec_t from_ut, usec_t to_ut, siz
     size_t total_ut = to_ut - from_ut;
     ssize_t remaining_entries = (ssize_t)entries;
     size_t slot = facets_histogram_slot_at_time_ut(facets, from_ut, v);
+
     for(; slot < facets->histogram.slots ;slot++) {
         usec_t slot_start_ut = facets->histogram.after_ut + slot * facets->histogram.slot_width_ut;
         usec_t slot_end_ut = slot_start_ut + facets->histogram.slot_width_ut;
@@ -920,6 +921,7 @@ void facets_update_estimations(FACETS *facets, usec_t from_ut, usec_t to_ut, siz
 
     // Check if all entries are assigned
     // This should always be true if the distribution is correct
+    UNUSED(remaining_entries);
     internal_fatal(remaining_entries < 0 || remaining_entries >= (ssize_t)(slots),
                    "distribution of estimations is not accurate - there are %zd remaining entries",
                    remaining_entries);
@@ -1010,7 +1012,7 @@ static inline void facets_key_value_transformed(FACETS *facets, FACET_KEY *k, FA
         buffer_strcat(dst, facets_key_value_cached(k, v, facets->report.used_hashes_registry));
 }
 
-static inline void facets_histogram_value_names(BUFFER *wb, FACETS *facets __maybe_unused, FACET_KEY *k, const char *key, const char *first_key) {
+static inline void facets_histogram_value_names(BUFFER *wb, FACETS *facets, FACET_KEY *k, const char *key, const char *first_key) {
     CLEAN_BUFFER *tb = buffer_create(0, NULL);
 
     buffer_json_member_add_array(wb, key);
@@ -1033,7 +1035,9 @@ static inline void facets_histogram_value_names(BUFFER *wb, FACETS *facets __may
     buffer_json_array_close(wb); // key
 }
 
-static inline void facets_histogram_value_colors(BUFFER *wb, FACETS *facets __maybe_unused, FACET_KEY *k, const char *key) {
+static inline void facets_histogram_value_colors(BUFFER *wb, FACETS *facets, FACET_KEY *k, const char *key) {
+    UNUSED(facets);
+
     buffer_json_member_add_array(wb, key);
     {
         if(k && k->values.enabled) {
@@ -1050,7 +1054,9 @@ static inline void facets_histogram_value_colors(BUFFER *wb, FACETS *facets __ma
     buffer_json_array_close(wb); // key
 }
 
-static inline void facets_histogram_value_units(BUFFER *wb, FACETS *facets __maybe_unused, FACET_KEY *k, const char *key) {
+static inline void facets_histogram_value_units(BUFFER *wb, FACETS *facets, FACET_KEY *k, const char *key) {
+    UNUSED(facets);
+
     buffer_json_member_add_array(wb, key);
     {
         if(k && k->values.enabled) {
@@ -1067,7 +1073,9 @@ static inline void facets_histogram_value_units(BUFFER *wb, FACETS *facets __may
     buffer_json_array_close(wb); // key
 }
 
-static inline void facets_histogram_value_min(BUFFER *wb, FACETS *facets __maybe_unused, FACET_KEY *k, const char *key) {
+static inline void facets_histogram_value_min(BUFFER *wb, FACETS *facets, FACET_KEY *k, const char *key) {
+    UNUSED(facets);
+
     buffer_json_member_add_array(wb, key);
     {
         if(k && k->values.enabled) {
@@ -1084,7 +1092,9 @@ static inline void facets_histogram_value_min(BUFFER *wb, FACETS *facets __maybe
     buffer_json_array_close(wb); // key
 }
 
-static inline void facets_histogram_value_max(BUFFER *wb, FACETS *facets __maybe_unused, FACET_KEY *k, const char *key) {
+static inline void facets_histogram_value_max(BUFFER *wb, FACETS *facets, FACET_KEY *k, const char *key) {
+    UNUSED(facets);
+
     buffer_json_member_add_array(wb, key);
     {
         if(k && k->values.enabled) {
@@ -1101,7 +1111,7 @@ static inline void facets_histogram_value_max(BUFFER *wb, FACETS *facets __maybe
     buffer_json_array_close(wb); // key
 }
 
-static inline void facets_histogram_value_avg(BUFFER *wb, FACETS *facets __maybe_unused, FACET_KEY *k, const char *key) {
+static inline void facets_histogram_value_avg(BUFFER *wb, FACETS *facets, FACET_KEY *k, const char *key) {
     buffer_json_member_add_array(wb, key);
     {
         if(k && k->values.enabled) {
@@ -1118,7 +1128,9 @@ static inline void facets_histogram_value_avg(BUFFER *wb, FACETS *facets __maybe
     buffer_json_array_close(wb); // key
 }
 
-static inline void facets_histogram_value_arp(BUFFER *wb, FACETS *facets __maybe_unused, FACET_KEY *k, const char *key) {
+static inline void facets_histogram_value_arp(BUFFER *wb, FACETS *facets, FACET_KEY *k, const char *key) {
+    UNUSED(facets);
+
     buffer_json_member_add_array(wb, key);
     {
         if(k && k->values.enabled) {
@@ -1135,7 +1147,9 @@ static inline void facets_histogram_value_arp(BUFFER *wb, FACETS *facets __maybe
     buffer_json_array_close(wb); // key
 }
 
-static inline void facets_histogram_value_con(BUFFER *wb, FACETS *facets __maybe_unused, FACET_KEY *k, const char *key, uint32_t sum) {
+static inline void facets_histogram_value_con(BUFFER *wb, FACETS *facets, FACET_KEY *k, const char *key, uint32_t sum) {
+    UNUSED(facets);
+
     buffer_json_member_add_array(wb, key);
     {
         if(k && k->values.enabled) {
@@ -1733,30 +1747,6 @@ void facets_set_additional_options(FACETS *facets, FACETS_OPTIONS options) {
 
 // ----------------------------------------------------------------------------
 
-static inline void facets_key_set_unsampled_value(FACETS *facets, FACET_KEY *k) {
-    if(likely(!facet_key_value_updated(k) && facets->keys_in_row.used < FACETS_KEYS_IN_ROW_MAX))
-        facets->keys_in_row.array[facets->keys_in_row.used++] = k;
-
-    k->current_value.flags |= FACET_KEY_VALUE_UPDATED | FACET_KEY_VALUE_UNSAMPLED;
-
-    facets->operations.values.registered++;
-    facets->operations.values.unsampled++;
-
-    // no need to copy the UNSET value
-    // empty values are exported as empty
-    k->current_value.raw = NULL;
-    k->current_value.raw_len = 0;
-    k->current_value.b->len = 0;
-    k->current_value.flags &= ~FACET_KEY_VALUE_COPIED;
-
-    if(unlikely(k->values.enabled))
-        FACET_VALUE_ADD_UNSAMPLED_VALUE_TO_INDEX(k);
-    else {
-        k->key_found_in_row++;
-        k->key_values_selected_in_row++;
-    }
-}
-
 static inline void facets_key_set_empty_value(FACETS *facets, FACET_KEY *k) {
     if(likely(!facet_key_value_updated(k) && facets->keys_in_row.used < FACETS_KEYS_IN_ROW_MAX))
         facets->keys_in_row.array[facets->keys_in_row.used++] = k;
@@ -1844,7 +1834,9 @@ void facets_add_key_value_length(FACETS *facets, const char *key, size_t key_len
 // ----------------------------------------------------------------------------
 // FACET_ROW dictionary hooks
 
-static void facet_row_key_value_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data) {
+static void facet_row_key_value_insert_callback(const DICTIONARY_ITEM *item, void *value, void *data) {
+    UNUSED(item);
+
     FACET_ROW_KEY_VALUE *rkv = value;
     FACET_ROW *row = data; (void)row;
 
@@ -1853,7 +1845,9 @@ static void facet_row_key_value_insert_callback(const DICTIONARY_ITEM *item __ma
         buffer_contents_replace(rkv->wb, rkv->tmp, rkv->tmp_len);
 }
 
-static bool facet_row_key_value_conflict_callback(const DICTIONARY_ITEM *item __maybe_unused, void *old_value, void *new_value, void *data) {
+static bool facet_row_key_value_conflict_callback(const DICTIONARY_ITEM *item, void *old_value, void *new_value, void *data) {
+    UNUSED(item);
+
     FACET_ROW_KEY_VALUE *rkv = old_value;
     FACET_ROW_KEY_VALUE *n_rkv = new_value;
     FACET_ROW *row = data; (void)row;
@@ -1868,7 +1862,9 @@ static bool facet_row_key_value_conflict_callback(const DICTIONARY_ITEM *item __
     return false;
 }
 
-static void facet_row_key_value_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data) {
+static void facet_row_key_value_delete_callback(const DICTIONARY_ITEM *item, void *value, void *data) {
+    UNUSED(item);
+
     FACET_ROW_KEY_VALUE *rkv = value;
     FACET_ROW *row = data; (void)row;
 
@@ -1878,7 +1874,9 @@ static void facet_row_key_value_delete_callback(const DICTIONARY_ITEM *item __ma
 // ----------------------------------------------------------------------------
 // FACET_ROW management
 
-static void facets_row_free(FACETS *facets __maybe_unused, FACET_ROW *row) {
+static void facets_row_free(FACETS *facets, FACET_ROW *row) {
+    UNUSED(facets);
+
     dictionary_destroy(row->dict);
     freez(row);
 }

--- a/libnetdata/facets/facets.h
+++ b/libnetdata/facets/facets.h
@@ -61,7 +61,7 @@ typedef struct facet_row {
 typedef struct facets FACETS;
 typedef struct facet_key FACET_KEY;
 
-typedef void (*facets_key_transformer_t)(FACETS *facets __maybe_unused, BUFFER *wb, FACETS_TRANSFORMATION_SCOPE scope, void *data);
+typedef void (*facets_key_transformer_t)(FACETS *facets, BUFFER *wb, FACETS_TRANSFORMATION_SCOPE scope, void *data);
 typedef void (*facet_dynamic_row_t)(FACETS *facets, BUFFER *json_array, FACET_ROW_KEY_VALUE *rkv, FACET_ROW *row, void *data);
 typedef FACET_ROW_SEVERITY (*facet_row_severity_t)(FACETS *facets, FACET_ROW *row, void *data);
 FACET_KEY *facets_register_dynamic_key_name(FACETS *facets, const char *key, FACET_KEY_OPTIONS options, facet_dynamic_row_t cb, void *data);

--- a/libnetdata/functions_evloop/functions_evloop.c
+++ b/libnetdata/functions_evloop/functions_evloop.c
@@ -280,7 +280,10 @@ static void *rrd_functions_worker_globals_reader_main(void *arg) {
     exit(1);
 }
 
-void worker_queue_delete_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused) {
+void worker_queue_delete_cb(const DICTIONARY_ITEM *item, void *value, void *data) {
+    UNUSED(item);
+    UNUSED(data);
+
     struct functions_evloop_worker_job *j = value;
     worker_job_cleanup(j);
 }

--- a/libnetdata/july/july.c
+++ b/libnetdata/july/july.c
@@ -157,7 +157,9 @@ size_t JulyLGet_binary_search_position_of_index(const struct JulyL *July, Word_t
     return left;
 }
 
-PPvoid_t JulyLGet(Pcvoid_t PArray, Word_t Index, PJError_t PJError __maybe_unused) {
+PPvoid_t JulyLGet(Pcvoid_t PArray, Word_t Index, PJError_t PJError) {
+    UNUSED(PJError);
+
     const struct JulyL *July = PArray;
     if(!July)
         return NULL;
@@ -170,7 +172,9 @@ PPvoid_t JulyLGet(Pcvoid_t PArray, Word_t Index, PJError_t PJError __maybe_unuse
     return (PPvoid_t)&July->array[pos].value;
 }
 
-PPvoid_t JulyLIns(PPvoid_t PPArray, Word_t Index, PJError_t PJError __maybe_unused) {
+PPvoid_t JulyLIns(PPvoid_t PPArray, Word_t Index, PJError_t PJError) {
+    UNUSED(PJError);
+
     struct JulyL *July = *PPArray;
     if(unlikely(!July)) {
         July = julyl_get();
@@ -209,7 +213,9 @@ PPvoid_t JulyLIns(PPvoid_t PPArray, Word_t Index, PJError_t PJError __maybe_unus
     return &July->array[pos].value;
 }
 
-PPvoid_t JulyLFirst(Pcvoid_t PArray, Word_t *Index, PJError_t PJError __maybe_unused) {
+PPvoid_t JulyLFirst(Pcvoid_t PArray, Word_t *Index, PJError_t PJError) {
+    UNUSED(PJError);
+
     const struct JulyL *July = PArray;
     if(!July)
         return NULL;
@@ -224,7 +230,9 @@ PPvoid_t JulyLFirst(Pcvoid_t PArray, Word_t *Index, PJError_t PJError __maybe_un
     return (PPvoid_t)&July->array[pos].value;
 }
 
-PPvoid_t JulyLNext(Pcvoid_t PArray, Word_t *Index, PJError_t PJError __maybe_unused) {
+PPvoid_t JulyLNext(Pcvoid_t PArray, Word_t *Index, PJError_t PJError) {
+    UNUSED(PJError);
+
     const struct JulyL *July = PArray;
     if(!July)
         return NULL;
@@ -246,7 +254,9 @@ PPvoid_t JulyLNext(Pcvoid_t PArray, Word_t *Index, PJError_t PJError __maybe_unu
     return (PPvoid_t)&July->array[pos].value;
 }
 
-PPvoid_t JulyLLast(Pcvoid_t PArray, Word_t *Index, PJError_t PJError __maybe_unused) {
+PPvoid_t JulyLLast(Pcvoid_t PArray, Word_t *Index, PJError_t PJError) {
+    UNUSED(PJError);
+
     const struct JulyL *July = PArray;
     if(!July)
         return NULL;
@@ -264,7 +274,9 @@ PPvoid_t JulyLLast(Pcvoid_t PArray, Word_t *Index, PJError_t PJError __maybe_unu
     return (PPvoid_t)&July->array[pos].value;
 }
 
-PPvoid_t JulyLPrev(Pcvoid_t PArray, Word_t *Index, PJError_t PJError __maybe_unused) {
+PPvoid_t JulyLPrev(Pcvoid_t PArray, Word_t *Index, PJError_t PJError) {
+    UNUSED(PJError);
+
     const struct JulyL *July = PArray;
     if(!July)
         return NULL;
@@ -282,7 +294,9 @@ PPvoid_t JulyLPrev(Pcvoid_t PArray, Word_t *Index, PJError_t PJError __maybe_unu
     return (PPvoid_t)&July->array[pos].value;
 }
 
-Word_t JulyLFreeArray(PPvoid_t PPArray, PJError_t PJError __maybe_unused) {
+Word_t JulyLFreeArray(PPvoid_t PPArray, PJError_t PJError) {
+    UNUSED(PJError);
+
     struct JulyL *July = *PPArray;
     if(unlikely(!July))
         return 0;

--- a/libnetdata/libnetdata.c
+++ b/libnetdata/libnetdata.c
@@ -1151,7 +1151,7 @@ inline int madvise_dontneed(void *mem, size_t len) {
     return ret;
 }
 
-inline int madvise_dontdump(void *mem __maybe_unused, size_t len __maybe_unused) {
+inline int madvise_dontdump(void *mem, size_t len) {
 #if __linux__
     static int logger = 1;
     int ret = madvise(mem, len, MADV_DONTDUMP);
@@ -1160,11 +1160,13 @@ inline int madvise_dontdump(void *mem __maybe_unused, size_t len __maybe_unused)
         netdata_log_error("madvise(MADV_DONTDUMP) failed.");
     return ret;
 #else
+    UNUSED(mem);
+    UNUSED(len);
     return 0;
 #endif
 }
 
-inline int madvise_mergeable(void *mem __maybe_unused, size_t len __maybe_unused) {
+inline int madvise_mergeable(void *mem, size_t len) {
 #ifdef MADV_MERGEABLE
     static int logger = 1;
     int ret = madvise(mem, len, MADV_MERGEABLE);
@@ -1173,6 +1175,8 @@ inline int madvise_mergeable(void *mem __maybe_unused, size_t len __maybe_unused
         netdata_log_error("madvise(MADV_MERGEABLE) failed.");
     return ret;
 #else
+    UNUSED(mem);
+    UNUSED(len);
     return 0;
 #endif
 }

--- a/libnetdata/locks/locks.c
+++ b/libnetdata/locks/locks.c
@@ -133,8 +133,14 @@ int __netdata_mutex_unlock(netdata_mutex_t *mutex) {
 
 #ifdef NETDATA_TRACE_RWLOCKS
 
-int netdata_mutex_init_debug(const char *file __maybe_unused, const char *function __maybe_unused,
-                             const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
+int netdata_mutex_init_debug(const char *file, const char *function,
+                             const unsigned long line, netdata_mutex_t *mutex) {
+#ifndef NETDATA_INTERNAL_CHECKS
+    UNUSED(file);
+    UNUSED(function);
+    UNUSED(line);
+#endif
+
     netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_init(%p) from %lu@%s, %s()", mutex, line, file, function);
 
     int ret = __netdata_mutex_init(mutex);
@@ -144,8 +150,14 @@ int netdata_mutex_init_debug(const char *file __maybe_unused, const char *functi
     return ret;
 }
 
-int netdata_mutex_destroy_debug(const char *file __maybe_unused, const char *function __maybe_unused,
-                             const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
+int netdata_mutex_destroy_debug(const char *file, const char *function,
+                             const unsigned long line, netdata_mutex_t *mutex) {
+#ifndef NETDATA_INTERNAL_CHECKS
+    UNUSED(file);
+    UNUSED(function);
+    UNUSED(line);
+#endif
+
     netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_destroy(%p) from %lu@%s, %s()", mutex, line, file, function);
 
     int ret = __netdata_mutex_destroy(mutex);
@@ -155,8 +167,14 @@ int netdata_mutex_destroy_debug(const char *file __maybe_unused, const char *fun
     return ret;
 }
 
-int netdata_mutex_lock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
-                             const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
+int netdata_mutex_lock_debug(const char *file, const char *function,
+                             const unsigned long line, netdata_mutex_t *mutex) {
+#ifndef NETDATA_INTERNAL_CHECKS
+    UNUSED(file);
+    UNUSED(function);
+    UNUSED(line);
+#endif
+
     netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(%p) from %lu@%s, %s()", mutex, line, file, function);
 
     usec_t start_s = now_monotonic_high_precision_usec();
@@ -172,8 +190,14 @@ int netdata_mutex_lock_debug(const char *file __maybe_unused, const char *functi
     return ret;
 }
 
-int netdata_mutex_trylock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
-                                const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
+int netdata_mutex_trylock_debug(const char *file, const char *function,
+                                const unsigned long line, netdata_mutex_t *mutex) {
+#ifndef NETDATA_INTERNAL_CHECKS
+    UNUSED(file);
+    UNUSED(function);
+    UNUSED(line);
+#endif
+
     netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_trylock(%p) from %lu@%s, %s()", mutex, line, file, function);
 
     usec_t start_s = now_monotonic_high_precision_usec();
@@ -189,8 +213,14 @@ int netdata_mutex_trylock_debug(const char *file __maybe_unused, const char *fun
     return ret;
 }
 
-int netdata_mutex_unlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
-                               const unsigned long line __maybe_unused, netdata_mutex_t *mutex) {
+int netdata_mutex_unlock_debug(const char *file, const char *function,
+                               const unsigned long line, netdata_mutex_t *mutex) {
+#ifndef NETDATA_INTERNAL_CHECKS
+    UNUSED(file);
+    UNUSED(function);
+    UNUSED(line);
+#endif
+
     netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(%p) from %lu@%s, %s()", mutex, line, file, function);
 
     usec_t start_s = now_monotonic_high_precision_usec();
@@ -433,7 +463,13 @@ bool rw_spinlock_trywrite_lock(RW_SPINLOCK *rw_spinlock) {
 // ----------------------------------------------------------------------------
 // lockers list
 
-static netdata_rwlock_locker *find_rwlock_locker(const char *file __maybe_unused, const char *function __maybe_unused, const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
+static netdata_rwlock_locker *find_rwlock_locker(const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock) {
+#ifndef NETDATA_INTERNAL_CHECK
+    UNUSED(file);
+    UNUSED(function);
+    UNUSED(line);
+#endif
+
     pid_t pid = gettid();
     netdata_rwlock_locker *locker = NULL;
 
@@ -466,7 +502,7 @@ static netdata_rwlock_locker *add_rwlock_locker(const char *file, const char *fu
         locker->line = line;
 
         __netdata_mutex_lock(&rwlock->lockers_mutex);
-        DOUBLE_LINKED_LIST_APPEND_UNSAFE(rwlock->lockers, locker, prev, next);
+        DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(rwlock->lockers, locker, prev, next);
         Pvoid_t *PValue = JudyLIns(&rwlock->lockers_pid_JudyL, locker->pid, PJE0);
         *PValue = locker;
         if (lock_type == RWLOCK_REQUEST_READ || lock_type == RWLOCK_REQUEST_TRYREAD) rwlock->readers++;
@@ -477,11 +513,17 @@ static netdata_rwlock_locker *add_rwlock_locker(const char *file, const char *fu
     return locker;
 }
 
-static void remove_rwlock_locker(const char *file __maybe_unused, const char *function __maybe_unused, const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock, netdata_rwlock_locker *locker) {
+static void remove_rwlock_locker(const char *file, const char *function, const unsigned long line, netdata_rwlock_t *rwlock, netdata_rwlock_locker *locker) {
+#ifndef NETDATA_INTERNAL_CHECK
+    UNUSED(file);
+    UNUSED(function);
+    UNUSED(line);
+#endif
+
     __netdata_mutex_lock(&rwlock->lockers_mutex);
     locker->refcount--;
     if(!locker->refcount) {
-        DOUBLE_LINKED_LIST_REMOVE_UNSAFE(rwlock->lockers, locker, prev, next);
+        DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(rwlock->lockers, locker, prev, next);
         JudyLDel(&rwlock->lockers_pid_JudyL, locker->pid, PJE0);
         if (locker->lock == RWLOCK_REQUEST_READ || locker->lock == RWLOCK_REQUEST_TRYREAD) rwlock->readers--;
         else if (locker->lock == RWLOCK_REQUEST_WRITE || locker->lock == RWLOCK_REQUEST_TRYWRITE) rwlock->writers--;
@@ -493,9 +535,8 @@ static void remove_rwlock_locker(const char *file __maybe_unused, const char *fu
 // ----------------------------------------------------------------------------
 // debug versions of rwlock
 
-int netdata_rwlock_destroy_debug(const char *file __maybe_unused, const char *function __maybe_unused,
-                                 const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
-
+int netdata_rwlock_destroy_debug(const char *file, const char *function,
+                                 const unsigned long line, netdata_rwlock_t *rwlock) {
     int ret = __netdata_rwlock_destroy(rwlock);
     if(!ret) {
         while (rwlock->lockers)
@@ -505,8 +546,13 @@ int netdata_rwlock_destroy_debug(const char *file __maybe_unused, const char *fu
     return ret;
 }
 
-int netdata_rwlock_init_debug(const char *file __maybe_unused, const char *function __maybe_unused,
-                              const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
+int netdata_rwlock_init_debug(const char *file, const char *function,
+                              const unsigned long line, netdata_rwlock_t *rwlock) {
+#ifndef NETDATA_INTERNAL_CHECK
+    UNUSED(file);
+    UNUSED(function);
+    UNUSED(line);
+#endif
 
     int ret = __netdata_rwlock_init(rwlock);
     if(!ret) {
@@ -520,9 +566,8 @@ int netdata_rwlock_init_debug(const char *file __maybe_unused, const char *funct
     return ret;
 }
 
-int netdata_rwlock_rdlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
-                                const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
-
+int netdata_rwlock_rdlock_debug(const char *file, const char *function,
+                                const unsigned long line, netdata_rwlock_t *rwlock) {
     netdata_rwlock_locker *locker = add_rwlock_locker(file, function, line, rwlock, RWLOCK_REQUEST_READ);
 
     int ret = __netdata_rwlock_rdlock(rwlock);
@@ -534,9 +579,8 @@ int netdata_rwlock_rdlock_debug(const char *file __maybe_unused, const char *fun
     return ret;
 }
 
-int netdata_rwlock_wrlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
-                                const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
-
+int netdata_rwlock_wrlock_debug(const char *file, const char *function,
+                                const unsigned long line, netdata_rwlock_t *rwlock) {
     netdata_rwlock_locker *locker = add_rwlock_locker(file, function, line, rwlock, RWLOCK_REQUEST_WRITE);
 
     int ret = __netdata_rwlock_wrlock(rwlock);
@@ -548,9 +592,8 @@ int netdata_rwlock_wrlock_debug(const char *file __maybe_unused, const char *fun
     return ret;
 }
 
-int netdata_rwlock_unlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
-                                const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
-
+int netdata_rwlock_unlock_debug(const char *file, const char *function,
+                                const unsigned long line, netdata_rwlock_t *rwlock) {
     netdata_rwlock_locker *locker = find_rwlock_locker(file, function, line, rwlock);
 
     if(unlikely(!locker))
@@ -563,9 +606,8 @@ int netdata_rwlock_unlock_debug(const char *file __maybe_unused, const char *fun
     return ret;
 }
 
-int netdata_rwlock_tryrdlock_debug(const char *file __maybe_unused, const char *function __maybe_unused,
-                                   const unsigned long line __maybe_unused, netdata_rwlock_t *rwlock) {
-
+int netdata_rwlock_tryrdlock_debug(const char *file, const char *function,
+                                   const unsigned long line, netdata_rwlock_t *rwlock) {
     netdata_rwlock_locker *locker = add_rwlock_locker(file, function, line, rwlock, RWLOCK_REQUEST_TRYREAD);
 
     int ret = __netdata_rwlock_tryrdlock(rwlock);

--- a/libnetdata/locks/locks.c
+++ b/libnetdata/locks/locks.c
@@ -185,7 +185,7 @@ int netdata_mutex_lock_debug(const char *file, const char *function,
     (void)start_s;
     (void)end_s;
 
-    netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, end_s - start_s, line, file, function);
+    netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_lock(%p) = %d in %" PRIu64 " usec, from %lu@%s, %s()", mutex, ret, end_s - start_s, line, file, function);
 
     return ret;
 }
@@ -208,7 +208,7 @@ int netdata_mutex_trylock_debug(const char *file, const char *function,
     (void)start_s;
     (void)end_s;
 
-    netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_trylock(%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, end_s - start_s, line, file, function);
+    netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_trylock(%p) = %d in %" PRIu64 " usec, from %lu@%s, %s()", mutex, ret, end_s - start_s, line, file, function);
 
     return ret;
 }
@@ -231,7 +231,7 @@ int netdata_mutex_unlock_debug(const char *file, const char *function,
     (void)start_s;
     (void)end_s;
 
-    netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(%p) = %d in %llu usec, from %lu@%s, %s()", mutex, ret, end_s - start_s, line, file, function);
+    netdata_log_debug(D_LOCKS, "MUTEX_LOCK: netdata_mutex_unlock(%p) = %d in %" PRIu64 " usec, from %lu@%s, %s()", mutex, ret, end_s - start_s, line, file, function);
 
     return ret;
 }

--- a/libnetdata/log/log.c
+++ b/libnetdata/log/log.c
@@ -1934,7 +1934,7 @@ static bool nd_logger_journal_direct(struct log_field *fields, size_t fields_max
 // ----------------------------------------------------------------------------
 // syslog logger - uses logfmt
 
-static bool nd_logger_syslog(int priority, ND_LOG_FORMAT format __maybe_unused, struct log_field *fields, size_t fields_max) {
+static bool nd_logger_syslog(int priority, struct log_field *fields, size_t fields_max) {
     CLEAN_BUFFER *wb = buffer_create(1024, NULL);
 
     nd_logger_logfmt(wb, fields, fields_max);
@@ -2058,7 +2058,7 @@ static void nd_logger_log_fields(SPINLOCK *spinlock, FILE *fp, bool limit, ND_LO
     }
 
     if(output == NDLM_SYSLOG)
-        nd_logger_syslog(priority, source->format, fields, fields_max);
+        nd_logger_syslog(priority, fields, fields_max);
 
     if(output == NDLM_FILE)
         nd_logger_file(fp, source->format, fields, fields_max);
@@ -2261,7 +2261,7 @@ void netdata_logger(ND_LOG_SOURCES source, ND_LOG_FIELD_PRIORITY priority, const
     va_end(args);
 }
 
-void netdata_logger_with_limit(ERROR_LIMIT *erl, ND_LOG_SOURCES source, ND_LOG_FIELD_PRIORITY priority, const char *file __maybe_unused, const char *function __maybe_unused, const unsigned long line __maybe_unused, const char *fmt, ... ) {
+void netdata_logger_with_limit(ERROR_LIMIT *erl, ND_LOG_SOURCES source, ND_LOG_FIELD_PRIORITY priority, const char *file, const char *function, const unsigned long line, const char *fmt, ... ) {
     int saved_errno = errno;
     source = nd_log_validate_source(source);
 

--- a/libnetdata/log/systemd-cat-native.c
+++ b/libnetdata/log/systemd-cat-native.c
@@ -11,22 +11,6 @@
 #include <machine/endian.h>
 #endif
 
-static inline void log_message_to_stderr(BUFFER *msg) {
-    CLEAN_BUFFER *tmp = buffer_create(0, NULL);
-
-    for(size_t i = 0; i < msg->len ;i++) {
-        if(isprint(msg->buffer[i]))
-            buffer_putc(tmp, msg->buffer[i]);
-        else {
-            buffer_putc(tmp, '[');
-            buffer_print_uint64_hex(tmp, msg->buffer[i]);
-            buffer_putc(tmp, ']');
-        }
-    }
-
-    fprintf(stderr, "SENDING: %s\n", buffer_tostring(tmp));
-}
-
 static inline buffered_reader_ret_t get_next_line(struct buffered_reader *reader, BUFFER *line, int timeout_ms) {
     while(true) {
         if(unlikely(!buffered_reader_next_line(reader, line))) {
@@ -225,9 +209,6 @@ static void journal_remote_complete_event(BUFFER *msg, usec_t *monotonic_ut) {
 }
 
 static CURLcode journal_remote_send_buffer(CURL* curl, BUFFER *msg) {
-
-    // log_message_to_stderr(msg);
-
     struct upload_data upload = {0};
 
     if (!curl || !buffer_strlen(msg))
@@ -659,8 +640,6 @@ static int log_input_as_netdata(const char *newline, int timeout_ms) {
 // log to a local systemd-journald
 
 static bool journal_local_send_buffer(int fd, BUFFER *msg) {
-    // log_message_to_stderr(msg);
-
     bool ret = journal_direct_send(fd, msg->buffer, msg->len);
     if (!ret)
         fprintf(stderr, "Cannot send message to systemd journal.\n");

--- a/libnetdata/onewayalloc/onewayalloc.c
+++ b/libnetdata/onewayalloc/onewayalloc.c
@@ -145,7 +145,10 @@ void *onewayalloc_memdupz(ONEWAYALLOC *owa, const void *src, size_t size) {
     return mem;
 }
 
-void onewayalloc_freez(ONEWAYALLOC *owa __maybe_unused, const void *ptr __maybe_unused) {
+void onewayalloc_freez(ONEWAYALLOC *owa, const void *ptr) {
+    UNUSED(owa);
+    UNUSED(ptr);
+
 #ifdef FSANITIZE_ADDRESS
     freez((void *)ptr);
     return;

--- a/libnetdata/simple_hashtable.h
+++ b/libnetdata/simple_hashtable.h
@@ -239,11 +239,25 @@ static inline SIMPLE_HASHTABLE_VALUE_TYPE **simple_hashtable_sorted_array_next_r
 
 #define SIMPLE_HASHTABLE_SORTED_FOREACH_READ_ONLY_VALUE(var) (*(var))
 
-#else
-static inline void simple_hashtable_add_value_sorted_named(SIMPLE_HASHTABLE_NAMED *ht __maybe_unused, SIMPLE_HASHTABLE_VALUE_TYPE *value __maybe_unused) { ; }
-static inline void simple_hashtable_del_value_sorted_named(SIMPLE_HASHTABLE_NAMED *ht __maybe_unused, SIMPLE_HASHTABLE_VALUE_TYPE *value __maybe_unused) { ; }
-static inline void simple_hashtable_replace_value_sorted_named(SIMPLE_HASHTABLE_NAMED *ht __maybe_unused, SIMPLE_HASHTABLE_VALUE_TYPE *old_value __maybe_unused, SIMPLE_HASHTABLE_VALUE_TYPE *new_value __maybe_unused) { ; }
-#endif
+#else /* SIMPLE_HASHTABLE_SORT_FUNCTION */
+
+static inline void simple_hashtable_add_value_sorted_named(SIMPLE_HASHTABLE_NAMED *ht, SIMPLE_HASHTABLE_VALUE_TYPE *value) {
+    (void) ht;
+    (void) value;
+}
+
+static inline void simple_hashtable_del_value_sorted_named(SIMPLE_HASHTABLE_NAMED *ht, SIMPLE_HASHTABLE_VALUE_TYPE *value) {
+    (void) ht;
+    (void) value;
+}
+
+static inline void simple_hashtable_replace_value_sorted_named(SIMPLE_HASHTABLE_NAMED *ht, SIMPLE_HASHTABLE_VALUE_TYPE *old_value, SIMPLE_HASHTABLE_VALUE_TYPE *new_value) {
+    (void) ht;
+    (void) old_value;
+    (void) new_value;
+}
+
+#endif /* SIMPLE_HASHTABLE_SORT_FUNCTION */
 
 static inline void simple_hashtable_init_named(SIMPLE_HASHTABLE_NAMED *ht, size_t size) {
     memset(ht, 0, sizeof(*ht));
@@ -272,7 +286,7 @@ static inline void simple_hashtable_resize_named(SIMPLE_HASHTABLE_NAMED *ht);
 
 static inline bool simple_hashtable_can_use_slot_named(
         SIMPLE_HASHTABLE_SLOT_NAMED *sl, SIMPLE_HASHTABLE_HASH hash,
-        SIMPLE_HASHTABLE_KEY_TYPE *key __maybe_unused) {
+        SIMPLE_HASHTABLE_KEY_TYPE *key) {
 
     if(simple_hashtable_is_slot_unset(sl))
         return true;
@@ -284,6 +298,7 @@ static inline bool simple_hashtable_can_use_slot_named(
 #if defined(SIMPLE_HASHTABLE_COMPARE_KEYS_FUNCTION) && defined(SIMPLE_HASHTABLE_VALUE2KEY_FUNCTION)
         return SIMPLE_HASHTABLE_COMPARE_KEYS_FUNCTION(SIMPLE_HASHTABLE_VALUE2KEY_FUNCTION(SIMPLE_HASHTABLE_SLOT_DATA(sl)), key);
 #else
+        (void) key;
         return true;
 #endif
     }

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -421,11 +421,17 @@ bool netdata_ssl_accept(NETDATA_SSL *ssl) {
  * @param where the variable with the flags set.
  * @param ret the return of the caller
  */
-static void netdata_ssl_info_callback(const SSL *ssl, int where, int ret __maybe_unused) {
-    (void)ssl;
+static void netdata_ssl_info_callback(const SSL *ssl, int where, int ret)
+{
+#ifdef NETDATA_INTERNAL_CHECKS
     if (where & SSL_CB_ALERT) {
         netdata_log_debug(D_WEB_CLIENT,"SSL INFO CALLBACK %s %s", SSL_alert_type_string(ret), SSL_alert_desc_string_long(ret));
     }
+#else
+    UNUSED(ssl);
+    UNUSED(where);
+    UNUSED(ret);
+#endif
 }
 
 /**

--- a/libnetdata/socket/security.c
+++ b/libnetdata/socket/security.c
@@ -423,12 +423,13 @@ bool netdata_ssl_accept(NETDATA_SSL *ssl) {
  */
 static void netdata_ssl_info_callback(const SSL *ssl, int where, int ret)
 {
+    UNUSED(ssl);
+
 #ifdef NETDATA_INTERNAL_CHECKS
     if (where & SSL_CB_ALERT) {
         netdata_log_debug(D_WEB_CLIENT,"SSL INFO CALLBACK %s %s", SSL_alert_type_string(ret), SSL_alert_desc_string_long(ret));
     }
 #else
-    UNUSED(ssl);
     UNUSED(where);
     UNUSED(ret);
 #endif

--- a/libnetdata/socket/socket.c
+++ b/libnetdata/socket/socket.c
@@ -1756,7 +1756,7 @@ static inline int poll_process_tcp_read(POLLJOB *p, POLLINFO *pi, struct pollfd 
     return 1;
 }
 
-static inline int poll_process_udp_read(POLLINFO *pi, struct pollfd *pf, time_t now __maybe_unused) {
+static inline int poll_process_udp_read(POLLINFO *pi, struct pollfd *pf, time_t now) {
     pi->last_received_t = now;
     pi->recv_count++;
 


### PR DESCRIPTION
##### Summary

`__may_unused`:
  - is actually the attribute unused, so the name is misleading.
  - should be used only in function declarations.
  - clutters the function header
  - it was overused in cases we'd want to know if the variable is actually used.

Use the good-old `UNUSED` macro for such things.

##### Test Plan

- CI jobs
- Built with/without internal checks and some other macros that are
  used for conditional building of code under `libnetdata/`. 
