### PR TITLE
diskspace missing mutex use

### DIFF
--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -637,6 +637,8 @@ static void diskspace_main_cleanup(void *ptr) {
 #endif
 
 int diskspace_function_mount_points(BUFFER *wb, const char *function __maybe_unused) {
+    netdata_mutex_lock(&slow_mountinfo_mutex);
+
     buffer_flush(wb);
     wb->content_type = CT_APPLICATION_JSON;
     buffer_json_initialize(wb, "\"", "\"", 0, true, BUFFER_JSON_OPTIONS_DEFAULT);
@@ -840,6 +842,7 @@ int diskspace_function_mount_points(BUFFER *wb, const char *function __maybe_unu
     buffer_json_member_add_time_t(wb, "expires", now_realtime_sec() + 1);
     buffer_json_finalize(wb);
 
+    netdata_mutex_unlock(&slow_mountinfo_mutex);
     return HTTP_RESP_OK;
 }
 


### PR DESCRIPTION
Fix this:

```
==18202==ERROR: AddressSanitizer: heap-use-after-free on address 0x60200000c838 at pc 0x563059bb6549 bp 0x7f8472ed56e0 sp 0x7f8472ed56d0
READ of size 1 at 0x60200000c838 thread T50 (WEB[2])
    #0 0x563059bb6548 in buffer_json_strcat /data/src/netdata-ktsaou.git/libnetdata/config/../buffer/buffer.h:284
    #1 0x563059bb6548 in buffer_json_add_string_value /data/src/netdata-ktsaou.git/libnetdata/config/../buffer/buffer.h:710
    #2 0x563059bb6548 in buffer_json_add_array_item_string /data/src/netdata-ktsaou.git/libnetdata/config/../buffer/buffer.h:841
    #3 0x563059bb6548 in diskspace_function_mount_points /data/src/netdata-ktsaou.git/collectors/diskspace.plugin/plugin_diskspace.c:669
    #4 0x56305962e018 in rrd_function_run_inline /data/src/netdata-ktsaou.git/database/rrdfunctions-inline.c:20
    #5 0x563059a10b15 in rrd_function_run /data/src/netdata-ktsaou.git/database/rrdfunctions-inflight.c:541
    #6 0x563059163913 in web_client_api_request_v1_function /data/src/netdata-ktsaou.git/web/api/web_api_v1.c:1426
    #7 0x563059b0c885 in web_client_api_request /data/src/netdata-ktsaou.git/web/server/web_client.c:655
    #8 0x563059b0d75a in check_host_and_call /data/src/netdata-ktsaou.git/web/server/web_client.c:606
    #9 0x563059b0d75a in web_client_process_url /data/src/netdata-ktsaou.git/web/server/web_client.c:1255
    #10 0x563059b101be in web_client_switch_host /data/src/netdata-ktsaou.git/web/server/web_client.c:1149
    #11 0x563059b101be in web_client_process_url /data/src/netdata-ktsaou.git/web/server/web_client.c:1259
    #12 0x563059b1b594 in web_client_process_request_from_web_server /data/src/netdata-ktsaou.git/web/server/web_client.c:1488
    #13 0x563059b20736 in web_server_rcv_callback /data/src/netdata-ktsaou.git/web/server/static/static-threaded.c:298
    #14 0x563059e55ac0 in poll_process_tcp_read /data/src/netdata-ktsaou.git/libnetdata/socket/socket.c:1750
    #15 0x563059e55ac0 in poll_events /data/src/netdata-ktsaou.git/libnetdata/socket/socket.c:2077
    #16 0x563059b20270 in socket_listen_main_static_threaded_worker /data/src/netdata-ktsaou.git/web/server/static/static-threaded.c:432
    #17 0x563059e63943 in netdata_thread_init /data/src/netdata-ktsaou.git/libnetdata/threads/threads.c:285
    #18 0x7f848e9b3fee in start_thread /var/tmp/portage/sys-libs/glibc-2.32-r8/work/glibc-2.32/nptl/pthread_create.c:463
    #19 0x7f848dfe100e in __clone (/lib64/libc.so.6+0xfa00e)

0x60200000c838 is located 8 bytes inside of 13-byte region [0x60200000c830,0x60200000c83d)
freed by thread T64 (P[diskspace]) here:
    #0 0x7f848ea8b85f in free (/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/libasan.so.6+0xb585f)
    #1 0x563059e5e0df in string_index_delete /data/src/netdata-ktsaou.git/libnetdata/string/string.c:280
    #2 0x563059e5e0df in string_freez /data/src/netdata-ktsaou.git/libnetdata/string/string.c:343

previously allocated by thread T0 here:
    #0 0x7f848ea8bb9f in __interceptor_malloc (/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/libasan.so.6+0xb5b9f)
    #1 0x563059df1b48 in mallocz /data/src/netdata-ktsaou.git/libnetdata/libnetdata.c:501

Thread T50 (WEB[2]) created by T47 (WEB[1]) here:
    #0 0x7f848ea2e922 in pthread_create (/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/libasan.so.6+0x58922)
    #1 0x563059e649fd in netdata_thread_create /data/src/netdata-ktsaou.git/libnetdata/threads/threads.c:299
    #2 0x563059e63446 in netdata_thread_set_tag /data/src/netdata-ktsaou.git/libnetdata/threads/threads.c:223

Thread T47 (WEB[1]) created by T0 here:
    #0 0x7f848ea2e922 in pthread_create (/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/libasan.so.6+0x58922)
    #1 0x563059e649fd in netdata_thread_create /data/src/netdata-ktsaou.git/libnetdata/threads/threads.c:299

Thread T64 (P[diskspace]) created by T0 here:
    #0 0x7f848ea2e922 in pthread_create (/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/libasan.so.6+0x58922)
    #1 0x563059e649fd in netdata_thread_create /data/src/netdata-ktsaou.git/libnetdata/threads/threads.c:299

SUMMARY: AddressSanitizer: heap-use-after-free /data/src/netdata-ktsaou.git/libnetdata/config/../buffer/buffer.h:284 in buffer_json_strcat
Shadow bytes around the buggy address:
  0x0c047fff98b0: fa fa 00 07 fa fa 00 05 fa fa 00 04 fa fa 00 05
  0x0c047fff98c0: fa fa 00 00 fa fa 00 06 fa fa 00 05 fa fa 00 07
  0x0c047fff98d0: fa fa 00 00 fa fa 00 03 fa fa 00 06 fa fa 00 00
  0x0c047fff98e0: fa fa fd fd fa fa 00 05 fa fa 00 06 fa fa 00 02
  0x0c047fff98f0: fa fa 00 06 fa fa fd fd fa fa 00 05 fa fa fd fd
=>0x0c047fff9900: fa fa 00 06 fa fa fd[fd]fa fa fd fd fa fa 00 06
  0x0c047fff9910: fa fa fd fd fa fa 00 05 fa fa 00 05 fa fa 00 04
  0x0c047fff9920: fa fa 00 00 fa fa 00 07 fa fa 00 00 fa fa 00 07
  0x0c047fff9930: fa fa 00 06 fa fa 00 07 fa fa 00 07 fa fa 00 07
  0x0c047fff9940: fa fa 00 02 fa fa 00 03 fa fa 00 04 fa fa 00 03
  0x0c047fff9950: fa fa 00 04 fa fa 00 05 fa fa 00 04 fa fa 00 06
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==18202==ABORTING
```
