### PR TITLE
Prepare to functions (eBPF)

### DIFF
--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -4032,6 +4032,7 @@ int main(int argc, char **argv)
     heartbeat_t hb;
     heartbeat_init(&hb);
     int update_apps_every = (int) EBPF_CFG_UPDATE_APPS_EVERY_DEFAULT;
+    int max_period = update_apps_every * EBPF_CLEANUP_FACTOR;
     int update_apps_list = update_apps_every - 1;
     int process_maps_per_core = ebpf_modules[EBPF_MODULE_PROCESS_IDX].maps_per_core;
     //Plugin will be killed when it receives a signal
@@ -4051,7 +4052,7 @@ int main(int argc, char **argv)
             update_apps_list = 0;
             pthread_mutex_lock(&lock);
             pthread_mutex_lock(&collect_data_mutex);
-            cleanup_exited_pids();
+            ebpf_cleanup_exited_pids(max_period);
             collect_data_for_all_processes(process_pid_fd, process_maps_per_core);
 
             ebpf_create_apps_charts(apps_groups_root_target);

--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -4047,19 +4047,17 @@ int main(int argc, char **argv)
             fflush(stdout);
         }
 
-        pthread_mutex_lock(&ebpf_exit_cleanup);
-        pthread_mutex_lock(&collect_data_mutex);
         if (++update_apps_list == update_apps_every) {
             update_apps_list = 0;
+            pthread_mutex_lock(&lock);
+            pthread_mutex_lock(&collect_data_mutex);
             cleanup_exited_pids();
             collect_data_for_all_processes(process_pid_fd, process_maps_per_core);
 
-            pthread_mutex_lock(&lock);
             ebpf_create_apps_charts(apps_groups_root_target);
+            pthread_mutex_unlock(&collect_data_mutex);
             pthread_mutex_unlock(&lock);
         }
-        pthread_mutex_unlock(&collect_data_mutex);
-        pthread_mutex_unlock(&ebpf_exit_cleanup);
     }
 
     ebpf_stop_threads(0);

--- a/src/collectors/ebpf.plugin/ebpf.d.conf
+++ b/src/collectors/ebpf.plugin/ebpf.d.conf
@@ -61,7 +61,7 @@
     cachestat = no
     dcstat = no
     disk = no
-    fd = yes
+    fd = no
     filesystem = no
     hardirq = no
     mdflush = no
@@ -72,6 +72,6 @@
     socket = no
     softirq = yes
     sync = no
-    swap = yes
+    swap = no
     vfs = no
     network connections = no

--- a/src/collectors/ebpf.plugin/ebpf.d.conf
+++ b/src/collectors/ebpf.plugin/ebpf.d.conf
@@ -68,7 +68,7 @@
     mount = yes
     oomkill = yes
     process = no
-    shm = yes
+    shm = no
     socket = no
     softirq = yes
     sync = no

--- a/src/collectors/ebpf.plugin/ebpf.d.conf
+++ b/src/collectors/ebpf.plugin/ebpf.d.conf
@@ -58,7 +58,7 @@
 # When plugin detects that system has support to BTF, it enables integration with apps.plugin.
 #
 [ebpf programs]
-    cachestat = yes
+    cachestat = no
     dcstat = no
     disk = no
     fd = yes
@@ -67,7 +67,7 @@
     mdflush = no
     mount = yes
     oomkill = yes
-    process = yes
+    process = no
     shm = yes
     socket = no
     softirq = yes

--- a/src/collectors/ebpf.plugin/ebpf.d/cachestat.conf
+++ b/src/collectors/ebpf.plugin/ebpf.d/cachestat.conf
@@ -37,6 +37,6 @@
 #    pid table size = 32768
     ebpf type format = auto
     ebpf co-re tracing = trampoline
-    collect pid = real parent
+    collect pid = all
 #    maps per core = yes
     lifetime = 300

--- a/src/collectors/ebpf.plugin/ebpf.d/dcstat.conf
+++ b/src/collectors/ebpf.plugin/ebpf.d/dcstat.conf
@@ -35,6 +35,6 @@
 #    pid table size = 32768
     ebpf type format = auto
     ebpf co-re tracing = trampoline
-    collect pid = real parent
+    collect pid = all
 #    maps per core = yes
     lifetime = 300

--- a/src/collectors/ebpf.plugin/ebpf.d/process.conf
+++ b/src/collectors/ebpf.plugin/ebpf.d/process.conf
@@ -26,6 +26,6 @@
 #    cgroups = no
 #    update every = 10
 #    pid table size = 32768
-    collect pid = real parent
+    collect pid = all
 #    maps per core = yes
     lifetime = 300

--- a/src/collectors/ebpf.plugin/ebpf.d/shm.conf
+++ b/src/collectors/ebpf.plugin/ebpf.d/shm.conf
@@ -31,6 +31,7 @@
 #    pid table size = 32768
     ebpf type format = auto
     ebpf co-re tracing = trampoline
+    collect pid = all
 #    maps per core = yes
     lifetime = 300
 

--- a/src/collectors/ebpf.plugin/ebpf.d/swap.conf
+++ b/src/collectors/ebpf.plugin/ebpf.d/swap.conf
@@ -30,5 +30,6 @@
 #    pid table size = 32768
     ebpf type format = auto
     ebpf co-re tracing = trampoline
+    collect pid = all
 #    maps per core = yes
     lifetime = 300

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -1066,11 +1066,11 @@ void ebpf_process_sum_values_for_pids(ebpf_process_stat_t *process, struct ebpf_
         ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid, 0);
         if (local_pid) {
             ebpf_process_stat_t *in = &local_pid->process;
-            process->task_err = in->task_err;
-            process->release_call = in->release_call;
-            process->exit_call = in->exit_call;
-            process->create_thread = in->create_thread;
-            process->create_process = in->create_process;
+            process->task_err += in->task_err;
+            process->release_call += in->release_call;
+            process->exit_call += in->exit_call;
+            process->create_thread += in->create_thread;
+            process->create_process += in->create_process;
         }
 
         root = root->next;

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -739,7 +739,7 @@ static inline int managed_log(struct ebpf_pid_stat *p, uint32_t log, int status)
  *
  * @return It returns the pid entry structure
  */
-static inline struct ebpf_pid_stat *ebpf_get_pid_entry(pid_t pid)
+struct ebpf_pid_stat *ebpf_get_pid_entry(pid_t pid)
 {
     if (unlikely(ebpf_all_pids[pid]))
         return ebpf_all_pids[pid];

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -739,7 +739,7 @@ static inline int managed_log(struct ebpf_pid_stat *p, uint32_t log, int status)
  *
  * @return It returns the pid entry structure
  */
-static inline struct ebpf_pid_stat *get_pid_entry(pid_t pid)
+static inline struct ebpf_pid_stat *ebpf_get_pid_entry(pid_t pid)
 {
     if (unlikely(ebpf_all_pids[pid]))
         return ebpf_all_pids[pid];
@@ -933,14 +933,14 @@ static inline int read_proc_pid_stat(struct ebpf_pid_stat *p, void *ptr)
  *
  * @return It returns 1 on success and 0 otherwise
  */
-static inline int collect_data_for_pid(pid_t pid, void *ptr)
+static inline int ebpf_collect_data_for_pid(pid_t pid, void *ptr)
 {
     if (unlikely(pid < 0 || pid > pid_max)) {
         netdata_log_error("Invalid pid %d read (expected %d to %d). Ignoring process.", pid, 0, pid_max);
         return 0;
     }
 
-    struct ebpf_pid_stat *p = get_pid_entry(pid);
+    struct ebpf_pid_stat *p = ebpf_get_pid_entry(pid);
     if (unlikely(!p || p->read))
         return 0;
     p->read = 1;
@@ -1327,7 +1327,7 @@ static inline void read_proc_filesystem()
         if (unlikely(endptr == de->d_name || *endptr != '\0'))
             continue;
 
-        collect_data_for_pid(pid, NULL);
+        ebpf_collect_data_for_pid(pid, NULL);
     }
     closedir(dir);
 }

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -14,7 +14,6 @@ ARAL *ebpf_aral_shm_pid = NULL;
 // ----------------------------------------------------------------------------
 // Global vectors used with apps
 ebpf_socket_publish_apps_t **socket_bandwidth_curr = NULL;
-netdata_publish_swap_t **swap_pid = NULL;
 netdata_publish_vfs_t **vfs_pid = NULL;
 
 /**
@@ -1028,12 +1027,6 @@ int get_pid_comm(pid_t pid, size_t n, char *dest)
  */
 void cleanup_variables_from_other_threads(uint32_t pid)
 {
-    // Clean swap structure
-    if (swap_pid) {
-        freez(swap_pid[pid]);
-        swap_pid[pid] = NULL;
-    }
-
     // Clean vfs structure
     if (vfs_pid) {
         ebpf_vfs_release(vfs_pid[pid]);

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -866,7 +866,7 @@ static inline void post_aggregate_targets(struct ebpf_target *root)
  *
  * @param pid the PID that will be removed.
  */
-static inline void del_pid_entry(pid_t pid)
+static inline void ebpf_del_pid_entry(pid_t pid)
 {
     struct ebpf_pid_stat *p = ebpf_all_pids[pid];
 
@@ -945,25 +945,26 @@ int get_pid_comm(pid_t pid, size_t n, char *dest)
 /**
  * Remove PIDs when they are not running more.
  */
-void cleanup_exited_pids()
+void ebpf_cleanup_exited_pids(int max)
 {
     struct ebpf_pid_stat *p = NULL;
 
     for (p = ebpf_root_of_pids; p;) {
-        if (!p->updated && (!p->keep || p->keeploops > 0)) {
+        if (p->not_updated > max) {
             if (unlikely(debug_enabled && (p->keep || p->keeploops)))
                 debug_log(" > CLEANUP cannot keep exited process %d (%s) anymore - removing it.", p->pid, p->comm);
 
             pid_t r = p->pid;
             p = p->next;
 
-            del_pid_entry(r);
-        } else {
+            ebpf_del_pid_entry(r);
+        }/* else {
             if (unlikely(p->keep))
                 p->keeploops++;
             p->keep = 0;
             p = p->next;
-        }
+        } */
+        p = p->next;
     }
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -7,12 +7,10 @@
 // ----------------------------------------------------------------------------
 // ARAL vectors used to speed up processing
 ARAL *ebpf_aral_apps_pid_stat = NULL;
-ARAL *ebpf_aral_socket_pid = NULL;
 ARAL *ebpf_aral_vfs_pid = NULL;
 
 // ----------------------------------------------------------------------------
 // Global vectors used with apps
-ebpf_socket_publish_apps_t **socket_bandwidth_curr = NULL;
 netdata_publish_vfs_t **vfs_pid = NULL;
 
 /**
@@ -57,36 +55,6 @@ struct ebpf_pid_stat *ebpf_pid_stat_get(void)
 void ebpf_pid_stat_release(struct ebpf_pid_stat *stat)
 {
     aral_freez(ebpf_aral_apps_pid_stat, stat);
-}
-
-/*****************************************************************
- *
- *  SOCKET ARAL FUNCTIONS
- *
- *****************************************************************/
-
-/**
- * eBPF socket Aral init
- *
- * Initiallize array allocator that will be used when integration with apps is enabled.
- */
-void ebpf_socket_aral_init()
-{
-    ebpf_aral_socket_pid = ebpf_allocate_pid_aral(NETDATA_EBPF_SOCKET_ARAL_NAME, sizeof(ebpf_socket_publish_apps_t));
-}
-
-/**
- * eBPF socket get
- *
- * Get a ebpf_socket_publish_apps_t entry to be used with a specific PID.
- *
- * @return it returns the address on success.
- */
-ebpf_socket_publish_apps_t *ebpf_socket_stat_get(void)
-{
-    ebpf_socket_publish_apps_t *target = aral_mallocz(ebpf_aral_socket_pid);
-    memset(target, 0, sizeof(ebpf_socket_publish_apps_t));
-    return target;
 }
 
 /*****************************************************************

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -1296,13 +1296,11 @@ end_process_loop:
 
     post_aggregate_targets(apps_groups_root_target);
 
-
     struct ebpf_target *w;
     for (w = apps_groups_root_target; w; w = w->next) {
-        if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_PROCESS_IDX))))
+        if (unlikely(!(w->processes)))
             continue;
 
         ebpf_process_sum_values_for_pids(&w->process, w->root_pid);
-        pids = pids->next;
     }
 }

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -964,12 +964,7 @@ void ebpf_cleanup_exited_pids(int max)
             p = p->next;
 
             ebpf_del_pid_entry(r);
-        }/* else {
-            if (unlikely(p->keep))
-                p->keeploops++;
-            p->keep = 0;
-            p = p->next;
-        } */
+        }
         p = p->next;
     }
 }

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -9,7 +9,6 @@
 ARAL *ebpf_aral_apps_pid_stat = NULL;
 ARAL *ebpf_aral_process_stat = NULL;
 ARAL *ebpf_aral_socket_pid = NULL;
-ARAL *ebpf_aral_cachestat_pid = NULL;
 ARAL *ebpf_aral_dcstat_pid = NULL;
 ARAL *ebpf_aral_vfs_pid = NULL;
 ARAL *ebpf_aral_fd_pid = NULL;
@@ -18,7 +17,6 @@ ARAL *ebpf_aral_shm_pid = NULL;
 // ----------------------------------------------------------------------------
 // Global vectors used with apps
 ebpf_socket_publish_apps_t **socket_bandwidth_curr = NULL;
-netdata_publish_cachestat_t **cachestat_pid = NULL;
 netdata_publish_dcstat_t **dcstat_pid = NULL;
 netdata_publish_swap_t **swap_pid = NULL;
 netdata_publish_vfs_t **vfs_pid = NULL;
@@ -130,46 +128,6 @@ ebpf_socket_publish_apps_t *ebpf_socket_stat_get(void)
     ebpf_socket_publish_apps_t *target = aral_mallocz(ebpf_aral_socket_pid);
     memset(target, 0, sizeof(ebpf_socket_publish_apps_t));
     return target;
-}
-
-/*****************************************************************
- *
- *  CACHESTAT ARAL FUNCTIONS
- *
- *****************************************************************/
-
-/**
- * eBPF Cachestat Aral init
- *
- * Initiallize array allocator that will be used when integration with apps is enabled.
- */
-void ebpf_cachestat_aral_init()
-{
-    ebpf_aral_cachestat_pid = ebpf_allocate_pid_aral(NETDATA_EBPF_CACHESTAT_ARAL_NAME, sizeof(netdata_publish_cachestat_t));
-}
-
-/**
- * eBPF publish cachestat get
- *
- * Get a netdata_publish_cachestat_t entry to be used with a specific PID.
- *
- * @return it returns the address on success.
- */
-netdata_publish_cachestat_t *ebpf_publish_cachestat_get(void)
-{
-    netdata_publish_cachestat_t *target = aral_mallocz(ebpf_aral_cachestat_pid);
-    memset(target, 0, sizeof(netdata_publish_cachestat_t));
-    return target;
-}
-
-/**
- * eBPF cachestat release
- *
- * @param stat Release a target after usage.
- */
-void ebpf_cachestat_release(netdata_publish_cachestat_t *stat)
-{
-    aral_freez(ebpf_aral_cachestat_pid, stat);
 }
 
 /*****************************************************************
@@ -1229,12 +1187,6 @@ int get_pid_comm(pid_t pid, size_t n, char *dest)
  */
 void cleanup_variables_from_other_threads(uint32_t pid)
 {
-    // Clean cachestat structure
-    if (cachestat_pid) {
-        ebpf_cachestat_release(cachestat_pid[pid]);
-        cachestat_pid[pid] = NULL;
-    }
-
     // Clean directory cache structure
     if (dcstat_pid) {
         ebpf_dcstat_release(dcstat_pid[pid]);

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -16,7 +16,6 @@ ARAL *ebpf_aral_shm_pid = NULL;
 ebpf_socket_publish_apps_t **socket_bandwidth_curr = NULL;
 netdata_publish_swap_t **swap_pid = NULL;
 netdata_publish_vfs_t **vfs_pid = NULL;
-netdata_publish_shm_t **shm_pid = NULL;
 
 /**
  * eBPF ARAL Init
@@ -130,46 +129,6 @@ netdata_publish_vfs_t *ebpf_vfs_get(void)
 void ebpf_vfs_release(netdata_publish_vfs_t *stat)
 {
     aral_freez(ebpf_aral_vfs_pid, stat);
-}
-
-/*****************************************************************
- *
- *  SHM ARAL FUNCTIONS
- *
- *****************************************************************/
-
-/**
- * eBPF shared memory Aral init
- *
- * Initiallize array allocator that will be used when integration with apps is enabled.
- */
-void ebpf_shm_aral_init()
-{
-    ebpf_aral_shm_pid = ebpf_allocate_pid_aral(NETDATA_EBPF_SHM_ARAL_NAME, sizeof(netdata_publish_shm_t));
-}
-
-/**
- * eBPF shared memory get
- *
- * Get a netdata_publish_shm_t entry to be used with a specific PID.
- *
- * @return it returns the address on success.
- */
-netdata_publish_shm_t *ebpf_shm_stat_get(void)
-{
-    netdata_publish_shm_t *target = aral_mallocz(ebpf_aral_shm_pid);
-    memset(target, 0, sizeof(netdata_publish_shm_t));
-    return target;
-}
-
-/**
- * eBPF shared memory release
- *
- * @param stat Release a target after usage.
- */
-void ebpf_shm_release(netdata_publish_shm_t *stat)
-{
-    aral_freez(ebpf_aral_shm_pid, stat);
 }
 
 // ----------------------------------------------------------------------------
@@ -1079,12 +1038,6 @@ void cleanup_variables_from_other_threads(uint32_t pid)
     if (vfs_pid) {
         ebpf_vfs_release(vfs_pid[pid]);
         vfs_pid[pid] = NULL;
-    }
-
-    // Clean shm structure
-    if (shm_pid) {
-        ebpf_shm_release(shm_pid[pid]);
-        shm_pid[pid] = NULL;
     }
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -10,7 +10,6 @@ ARAL *ebpf_aral_apps_pid_stat = NULL;
 ARAL *ebpf_aral_process_stat = NULL;
 ARAL *ebpf_aral_socket_pid = NULL;
 ARAL *ebpf_aral_vfs_pid = NULL;
-ARAL *ebpf_aral_fd_pid = NULL;
 ARAL *ebpf_aral_shm_pid = NULL;
 
 // ----------------------------------------------------------------------------
@@ -18,7 +17,6 @@ ARAL *ebpf_aral_shm_pid = NULL;
 ebpf_socket_publish_apps_t **socket_bandwidth_curr = NULL;
 netdata_publish_swap_t **swap_pid = NULL;
 netdata_publish_vfs_t **vfs_pid = NULL;
-netdata_fd_stat_t **fd_pid = NULL;
 netdata_publish_shm_t **shm_pid = NULL;
 ebpf_process_stat_t **global_process_stats = NULL;
 
@@ -166,46 +164,6 @@ netdata_publish_vfs_t *ebpf_vfs_get(void)
 void ebpf_vfs_release(netdata_publish_vfs_t *stat)
 {
     aral_freez(ebpf_aral_vfs_pid, stat);
-}
-
-/*****************************************************************
- *
- *  FD ARAL FUNCTIONS
- *
- *****************************************************************/
-
-/**
- * eBPF file descriptor Aral init
- *
- * Initiallize array allocator that will be used when integration with apps is enabled.
- */
-void ebpf_fd_aral_init()
-{
-    ebpf_aral_fd_pid = ebpf_allocate_pid_aral(NETDATA_EBPF_FD_ARAL_NAME, sizeof(netdata_fd_stat_t));
-}
-
-/**
- * eBPF publish file descriptor get
- *
- * Get a netdata_fd_stat_t entry to be used with a specific PID.
- *
- * @return it returns the address on success.
- */
-netdata_fd_stat_t *ebpf_fd_stat_get(void)
-{
-    netdata_fd_stat_t *target = aral_mallocz(ebpf_aral_fd_pid);
-    memset(target, 0, sizeof(netdata_fd_stat_t));
-    return target;
-}
-
-/**
- * eBPF file descriptor release
- *
- * @param stat Release a target after usage.
- */
-void ebpf_fd_release(netdata_fd_stat_t *stat)
-{
-    aral_freez(ebpf_aral_fd_pid, stat);
 }
 
 /*****************************************************************
@@ -1155,12 +1113,6 @@ void cleanup_variables_from_other_threads(uint32_t pid)
     if (vfs_pid) {
         ebpf_vfs_release(vfs_pid[pid]);
         vfs_pid[pid] = NULL;
-    }
-
-    // Clean fd structure
-    if (fd_pid) {
-        ebpf_fd_release(fd_pid[pid]);
-        fd_pid[pid] = NULL;
     }
 
     // Clean shm structure

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -9,7 +9,6 @@
 ARAL *ebpf_aral_apps_pid_stat = NULL;
 ARAL *ebpf_aral_socket_pid = NULL;
 ARAL *ebpf_aral_vfs_pid = NULL;
-ARAL *ebpf_aral_shm_pid = NULL;
 
 // ----------------------------------------------------------------------------
 // Global vectors used with apps

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -739,7 +739,7 @@ static inline int managed_log(struct ebpf_pid_stat *p, uint32_t log, int status)
  *
  * @return It returns the pid entry structure
  */
-struct ebpf_pid_stat *ebpf_get_pid_entry(pid_t pid)
+ebpf_pid_stat_t *ebpf_get_pid_entry(pid_t pid)
 {
     if (unlikely(ebpf_all_pids[pid]))
         return ebpf_all_pids[pid];
@@ -940,7 +940,7 @@ static inline int ebpf_collect_data_for_pid(pid_t pid, void *ptr)
         return 0;
     }
 
-    struct ebpf_pid_stat *p = ebpf_get_pid_entry(pid);
+    ebpf_pid_stat_t *p = ebpf_get_pid_entry(pid);
     if (unlikely(!p || p->read))
         return 0;
     p->read = 1;

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -112,6 +112,7 @@ typedef struct ebpf_pid_stat {
 
     // each process gets a unique number
     netdata_publish_cachestat_t cachestat;
+    netdata_publish_dcstat_t dc;
 
     struct ebpf_target *target;       // app_groups.conf targets
     struct ebpf_target *user_target;  // uid based targets
@@ -210,7 +211,6 @@ void collect_data_for_all_processes(int tbl_pid_stats_fd, int maps_per_core);
 void ebpf_process_apps_accumulator(ebpf_process_stat_t *out, int maps_per_core);
 
 extern ebpf_process_stat_t **global_process_stats;
-extern netdata_publish_dcstat_t **dcstat_pid;
 extern netdata_publish_swap_t **swap_pid;
 extern netdata_publish_vfs_t **vfs_pid;
 extern netdata_fd_stat_t **fd_pid;
@@ -234,16 +234,6 @@ extern ebpf_process_stat_t *process_stat_vector;
 extern ARAL *ebpf_aral_socket_pid;
 void ebpf_socket_aral_init();
 ebpf_socket_publish_apps_t *ebpf_socket_stat_get(void);
-
-extern ARAL *ebpf_aral_cachestat_pid;
-void ebpf_cachestat_aral_init();
-netdata_publish_cachestat_t *ebpf_publish_cachestat_get(void);
-void ebpf_cachestat_release(netdata_publish_cachestat_t *stat);
-
-extern ARAL *ebpf_aral_dcstat_pid;
-void ebpf_dcstat_aral_init();
-netdata_publish_dcstat_t *ebpf_publish_dcstat_get(void);
-void ebpf_dcstat_release(netdata_publish_dcstat_t *stat);
 
 extern ARAL *ebpf_aral_vfs_pid;
 void ebpf_vfs_aral_init();

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -142,6 +142,9 @@ typedef struct ebpf_pid_stat {
         int not_updated;
     } publish_fd;
     ebpf_process_stat_t process;
+    netdata_publish_shm_t shm;
+
+    int not_updated;
 
     struct ebpf_target *target;       // app_groups.conf targets
     struct ebpf_target *user_target;  // uid based targets
@@ -218,7 +221,6 @@ void ebpf_process_apps_accumulator(ebpf_process_stat_t *out, int maps_per_core);
 
 extern netdata_publish_swap_t **swap_pid;
 extern netdata_publish_vfs_t **vfs_pid;
-extern netdata_publish_shm_t **shm_pid;
 
 // The default value is at least 32 times smaller than maximum number of PIDs allowed on system,
 // this is only possible because we are using ARAL (https://github.com/netdata/netdata/tree/master/src/libnetdata/aral).

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -137,10 +137,7 @@ typedef struct ebpf_pid_stat {
     // each process gets a unique number
     netdata_publish_cachestat_t cachestat;
     netdata_publish_dcstat_t dc;
-    struct {
-        netdata_fd_stat_t fd;
-        int not_updated;
-    } publish_fd;
+    netdata_fd_stat_t fd;
     ebpf_process_stat_t process;
     netdata_publish_shm_t shm;
 

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -143,6 +143,7 @@ typedef struct ebpf_pid_stat {
     netdata_publish_shm_t shm;
     netdata_publish_swap_t swap;
     ebpf_socket_publish_apps_t socket;
+    netdata_publish_vfs_t vfs;
 
     int not_updated;
 
@@ -218,8 +219,6 @@ int get_pid_comm(pid_t pid, size_t n, char *dest);
 
 void collect_data_for_all_processes(int tbl_pid_stats_fd, int maps_per_core);
 void ebpf_process_apps_accumulator(ebpf_process_stat_t *out, int maps_per_core);
-
-extern netdata_publish_vfs_t **vfs_pid;
 
 // The default value is at least 32 times smaller than maximum number of PIDs allowed on system,
 // this is only possible because we are using ARAL (https://github.com/netdata/netdata/tree/master/src/libnetdata/aral).

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -91,6 +91,7 @@ struct ebpf_target {
     netdata_fd_stat_t fd;
     netdata_publish_shm_t shm;
     ebpf_process_stat_t process;
+    ebpf_socket_publish_apps_t socket;
 
     kernel_uint_t starttime;
     kernel_uint_t collected_starttime;

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -229,7 +229,7 @@ void ebpf_process_apps_accumulator(ebpf_process_stat_t *out, int maps_per_core);
 
 // ARAL Sectiion
 extern void ebpf_aral_init(void);
-extern ebpf_pid_stat_t *ebpf_get_pid_entry(pid_t pid);
+extern ebpf_pid_stat_t *ebpf_get_pid_entry(pid_t pid, pid_t tgid);
 extern ebpf_process_stat_t *process_stat_vector;
 
 extern ARAL *ebpf_aral_vfs_pid;

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -140,6 +140,7 @@ typedef struct ebpf_pid_stat {
     netdata_fd_stat_t fd;
     ebpf_process_stat_t process;
     netdata_publish_shm_t shm;
+    netdata_publish_swap_t swap;
 
     int not_updated;
 
@@ -216,7 +217,6 @@ int get_pid_comm(pid_t pid, size_t n, char *dest);
 void collect_data_for_all_processes(int tbl_pid_stats_fd, int maps_per_core);
 void ebpf_process_apps_accumulator(ebpf_process_stat_t *out, int maps_per_core);
 
-extern netdata_publish_swap_t **swap_pid;
 extern netdata_publish_vfs_t **vfs_pid;
 
 // The default value is at least 32 times smaller than maximum number of PIDs allowed on system,

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -90,7 +90,7 @@ extern struct ebpf_target *apps_groups_root_target;
 extern struct ebpf_target *users_root_target;
 extern struct ebpf_target *groups_root_target;
 
-struct ebpf_pid_stat {
+typedef struct ebpf_pid_stat {
     int32_t pid;
     char comm[EBPF_MAX_COMPARE_NAME + 1];
     char *cmdline;
@@ -119,6 +119,8 @@ struct ebpf_pid_stat {
     usec_t stat_collected_usec;
     usec_t last_stat_collected_usec;
 
+    netdata_publish_cachestat_t cache;
+
     char *stat_filename;
     char *status_filename;
     char *io_filename;
@@ -127,7 +129,7 @@ struct ebpf_pid_stat {
     struct ebpf_pid_stat *parent;
     struct ebpf_pid_stat *prev;
     struct ebpf_pid_stat *next;
-};
+} ebpf_pid_stat_t;
 
 // ----------------------------------------------------------------------------
 // target
@@ -223,7 +225,7 @@ extern netdata_publish_shm_t **shm_pid;
 
 // ARAL Sectiion
 extern void ebpf_aral_init(void);
-extern struct ebpf_pid_stat *ebpf_get_pid_entry(pid_t pid);
+extern ebpf_pid_stat_t *ebpf_get_pid_entry(pid_t pid);
 
 extern ebpf_process_stat_t *ebpf_process_stat_get(void);
 extern void ebpf_process_stat_release(ebpf_process_stat_t *stat);

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -223,6 +223,7 @@ extern netdata_publish_shm_t **shm_pid;
 
 // ARAL Sectiion
 extern void ebpf_aral_init(void);
+extern struct ebpf_pid_stat *ebpf_get_pid_entry(pid_t pid);
 
 extern ebpf_process_stat_t *ebpf_process_stat_get(void);
 extern void ebpf_process_stat_release(ebpf_process_stat_t *stat);

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -46,6 +46,29 @@
 #define EBPF_CLEANUP_FACTOR 10
 
 // ----------------------------------------------------------------------------
+// Structures used to read information from kernel ring
+typedef struct ebpf_process_stat {
+    uint64_t ct;
+    uint32_t uid;
+    uint32_t gid;
+    char name[TASK_COMM_LEN];
+
+    uint32_t tgid;
+    uint32_t pid;
+
+    //Counter
+    uint32_t exit_call;
+    uint32_t release_call;
+    uint32_t create_process;
+    uint32_t create_thread;
+
+    //Counter
+    uint32_t task_err;
+
+    uint8_t removeme;
+} ebpf_process_stat_t;
+
+// ----------------------------------------------------------------------------
 // pid_stat
 //
 struct ebpf_target {
@@ -67,6 +90,7 @@ struct ebpf_target {
     netdata_publish_vfs_t vfs;
     netdata_fd_stat_t fd;
     netdata_publish_shm_t shm;
+    ebpf_process_stat_t process;
 
     kernel_uint_t starttime;
     kernel_uint_t collected_starttime;
@@ -117,6 +141,7 @@ typedef struct ebpf_pid_stat {
         netdata_fd_stat_t fd;
         int not_updated;
     } publish_fd;
+    ebpf_process_stat_t process;
 
     struct ebpf_target *target;       // app_groups.conf targets
     struct ebpf_target *user_target;  // uid based targets
@@ -149,29 +174,6 @@ struct ebpf_pid_on_target {
     int32_t pid;
     struct ebpf_pid_on_target *next;
 };
-
-// ----------------------------------------------------------------------------
-// Structures used to read information from kernel ring
-typedef struct ebpf_process_stat {
-    uint64_t ct;
-    uint32_t uid;
-    uint32_t gid;
-    char name[TASK_COMM_LEN];
-
-    uint32_t tgid;
-    uint32_t pid;
-
-    //Counter
-    uint32_t exit_call;
-    uint32_t release_call;
-    uint32_t create_process;
-    uint32_t create_thread;
-
-    //Counter
-    uint32_t task_err;
-
-    uint8_t removeme;
-} ebpf_process_stat_t;
 
 /**
  * Internal function used to write debug messages.
@@ -214,7 +216,6 @@ int get_pid_comm(pid_t pid, size_t n, char *dest);
 void collect_data_for_all_processes(int tbl_pid_stats_fd, int maps_per_core);
 void ebpf_process_apps_accumulator(ebpf_process_stat_t *out, int maps_per_core);
 
-extern ebpf_process_stat_t **global_process_stats;
 extern netdata_publish_swap_t **swap_pid;
 extern netdata_publish_vfs_t **vfs_pid;
 extern netdata_publish_shm_t **shm_pid;
@@ -260,10 +261,5 @@ extern ebpf_socket_publish_apps_t **socket_bandwidth_curr;
 // Threads integrated with apps
 
 #include "libnetdata/threads/threads.h"
-
-// ARAL variables
-extern ARAL *ebpf_aral_apps_pid_stat;
-extern ARAL *ebpf_aral_process_stat;
-#define NETDATA_EBPF_PROC_ARAL_NAME "ebpf_proc_stat"
 
 #endif /* NETDATA_EBPF_APPS_H */

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -111,6 +111,7 @@ typedef struct ebpf_pid_stat {
     int sortlist; // higher numbers = top on the process tree
 
     // each process gets a unique number
+    netdata_publish_cachestat_t cachestat;
 
     struct ebpf_target *target;       // app_groups.conf targets
     struct ebpf_target *user_target;  // uid based targets
@@ -209,7 +210,6 @@ void collect_data_for_all_processes(int tbl_pid_stats_fd, int maps_per_core);
 void ebpf_process_apps_accumulator(ebpf_process_stat_t *out, int maps_per_core);
 
 extern ebpf_process_stat_t **global_process_stats;
-extern netdata_publish_cachestat_t **cachestat_pid;
 extern netdata_publish_dcstat_t **dcstat_pid;
 extern netdata_publish_swap_t **swap_pid;
 extern netdata_publish_vfs_t **vfs_pid;

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -113,6 +113,10 @@ typedef struct ebpf_pid_stat {
     // each process gets a unique number
     netdata_publish_cachestat_t cachestat;
     netdata_publish_dcstat_t dc;
+    struct {
+        netdata_fd_stat_t fd;
+        int not_updated;
+    } publish_fd;
 
     struct ebpf_target *target;       // app_groups.conf targets
     struct ebpf_target *user_target;  // uid based targets
@@ -213,7 +217,6 @@ void ebpf_process_apps_accumulator(ebpf_process_stat_t *out, int maps_per_core);
 extern ebpf_process_stat_t **global_process_stats;
 extern netdata_publish_swap_t **swap_pid;
 extern netdata_publish_vfs_t **vfs_pid;
-extern netdata_fd_stat_t **fd_pid;
 extern netdata_publish_shm_t **shm_pid;
 
 // The default value is at least 32 times smaller than maximum number of PIDs allowed on system,

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -141,6 +141,7 @@ typedef struct ebpf_pid_stat {
     ebpf_process_stat_t process;
     netdata_publish_shm_t shm;
     netdata_publish_swap_t swap;
+    ebpf_socket_publish_apps_t socket;
 
     int not_updated;
 
@@ -231,10 +232,6 @@ extern void ebpf_aral_init(void);
 extern ebpf_pid_stat_t *ebpf_get_pid_entry(pid_t pid);
 extern ebpf_process_stat_t *process_stat_vector;
 
-extern ARAL *ebpf_aral_socket_pid;
-void ebpf_socket_aral_init();
-ebpf_socket_publish_apps_t *ebpf_socket_stat_get(void);
-
 extern ARAL *ebpf_aral_vfs_pid;
 void ebpf_vfs_aral_init();
 netdata_publish_vfs_t *ebpf_vfs_get(void);
@@ -248,7 +245,6 @@ void ebpf_shm_release(netdata_publish_shm_t *stat);
 // ARAL Section end
 
 // Threads integrated with apps
-extern ebpf_socket_publish_apps_t **socket_bandwidth_curr;
 // Threads integrated with apps
 
 #include "libnetdata/threads/threads.h"

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -230,9 +230,6 @@ extern netdata_publish_shm_t **shm_pid;
 // ARAL Sectiion
 extern void ebpf_aral_init(void);
 extern ebpf_pid_stat_t *ebpf_get_pid_entry(pid_t pid);
-
-extern ebpf_process_stat_t *ebpf_process_stat_get(void);
-extern void ebpf_process_stat_release(ebpf_process_stat_t *stat);
 extern ebpf_process_stat_t *process_stat_vector;
 
 extern ARAL *ebpf_aral_socket_pid;
@@ -243,11 +240,6 @@ extern ARAL *ebpf_aral_vfs_pid;
 void ebpf_vfs_aral_init();
 netdata_publish_vfs_t *ebpf_vfs_get(void);
 void ebpf_vfs_release(netdata_publish_vfs_t *stat);
-
-extern ARAL *ebpf_aral_fd_pid;
-void ebpf_fd_aral_init();
-netdata_fd_stat_t *ebpf_fd_stat_get(void);
-void ebpf_fd_release(netdata_fd_stat_t *stat);
 
 extern ARAL *ebpf_aral_shm_pid;
 void ebpf_shm_aral_init();

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -43,6 +43,8 @@
 #define EBPF_MAX_COMPARE_NAME 100
 #define EBPF_MAX_NAME 100
 
+#define EBPF_CLEANUP_FACTOR 10
+
 // ----------------------------------------------------------------------------
 // pid_stat
 //

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -722,7 +722,7 @@ static void ebpf_read_cachestat_apps_table(int maps_per_core, int max_period)
 
         cachestat_apps_accumulator(cv, maps_per_core);
 
-        ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(key);
+        ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(key, cv->tgid);
         if (!local_pid)
             goto end_cachestat_loop;
 
@@ -758,7 +758,7 @@ static void ebpf_update_cachestat_cgroup()
         for (pids = ect->pids; pids; pids = pids->next) {
             int pid = pids->pid;
             netdata_cachestat_pid_t *out = &pids->cachestat;
-            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid);
+            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid, 0);
             if (local_pid) {
                 netdata_publish_cachestat_t *in = &local_pid->cachestat;
 
@@ -785,7 +785,7 @@ void ebpf_cachestat_sum_pids(netdata_publish_cachestat_t *publish, struct ebpf_p
     netdata_cachestat_pid_t *dst = &publish->current;
     while (root) {
         int32_t pid = root->pid;
-        ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid);
+        ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid, 0);
         if (local_pid) {
             netdata_publish_cachestat_t *w = &local_pid->cachestat;
             netdata_cachestat_pid_t *src = &w->current;

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -200,7 +200,7 @@ static int ebpf_cachestat_attach_probe(struct cachestat_bpf *obj)
     obj->links.netdata_add_to_page_cache_lru_kprobe = bpf_program__attach_kprobe(obj->progs.netdata_add_to_page_cache_lru_kprobe,
                                                                                  false,
                                                                                  cachestat_targets[NETDATA_KEY_CALLS_ADD_TO_PAGE_CACHE_LRU].name);
-    int ret = libbpf_get_error(obj->links.netdata_add_to_page_cache_lru_kprobe);
+    long ret = libbpf_get_error(obj->links.netdata_add_to_page_cache_lru_kprobe);
     if (ret)
         return -1;
 
@@ -1015,7 +1015,7 @@ static void cachestat_send_global(netdata_publish_cachestat_t *publish)
 
     ebpf_one_dimension_write_charts(
         NETDATA_EBPF_MEMORY_GROUP, NETDATA_CACHESTAT_DIRTY_CHART, ptr[NETDATA_CACHESTAT_IDX_DIRTY].dimension,
-        cachestat_hash_values[NETDATA_KEY_CALLS_MARK_BUFFER_DIRTY]);
+        (long long)cachestat_hash_values[NETDATA_KEY_CALLS_MARK_BUFFER_DIRTY]);
 
     ebpf_one_dimension_write_charts(
         NETDATA_EBPF_MEMORY_GROUP, NETDATA_CACHESTAT_HIT_CHART, ptr[NETDATA_CACHESTAT_IDX_HIT].dimension, publish->hit);
@@ -1045,7 +1045,7 @@ void ebpf_cache_send_apps_data(struct ebpf_target *root)
 
         uint64_t mpa = current->mark_page_accessed - prev->mark_page_accessed;
         uint64_t mbd = current->mark_buffer_dirty - prev->mark_buffer_dirty;
-        w->cachestat.dirty = mbd;
+        w->cachestat.dirty = (long long)mbd;
         uint64_t apcl = current->add_to_page_cache_lru - prev->add_to_page_cache_lru;
         uint64_t apd = current->account_page_dirtied - prev->account_page_dirtied;
 
@@ -1116,7 +1116,7 @@ void ebpf_cachestat_calc_chart_values()
 
         uint64_t mpa = current->mark_page_accessed - prev->mark_page_accessed;
         uint64_t mbd = current->mark_buffer_dirty - prev->mark_buffer_dirty;
-        ect->publish_cachestat.dirty = mbd;
+        ect->publish_cachestat.dirty = (long long)mbd;
         uint64_t apcl = current->add_to_page_cache_lru - prev->add_to_page_cache_lru;
         uint64_t apd = current->account_page_dirtied - prev->account_page_dirtied;
 

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -466,6 +466,7 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
 {
     struct ebpf_target *w;
     int update_every = em->update_every;
+    pthread_mutex_lock(&collect_data_mutex);
     for (w = apps_groups_root_target; w; w = w->next) {
         if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_CACHESTAT_IDX))))
             continue;
@@ -515,6 +516,7 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
                                   update_every);
         w->charts_created &= ~(1<<EBPF_MODULE_CACHESTAT_IDX);
     }
+    pthread_mutex_unlock(&collect_data_mutex);
 }
 
 /**

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -835,7 +835,7 @@ void ebpf_cachestat_sum_pids(netdata_publish_cachestat_t *publish, struct ebpf_p
 
         root = root->next;
     }
-    }
+}
 
 /**
  * Resume apps data

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -58,10 +58,6 @@ netdata_ebpf_targets_t cachestat_targets[] = { {.name = "add_to_page_cache_lru",
 static char *account_page[NETDATA_CACHESTAT_ACCOUNT_DIRTY_END] ={ "account_page_dirtied",
                                                                   "__set_page_dirty", "__folio_mark_dirty"  };
 
-#ifdef NETDATA_DEV_MODE
-int cachestat_disable_priority;
-#endif
-
 struct netdata_static_thread ebpf_read_cachestat = {
     .name = "EBPF_READ_CACHESTAT",
     .config_section = NULL,

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.h
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.h
@@ -82,6 +82,9 @@ typedef struct netdata_publish_cachestat_pid {
 } netdata_cachestat_pid_t;
 
 typedef struct netdata_publish_cachestat {
+    uint64_t ct;
+    int not_updated;
+
     long long ratio;
     long long dirty;
     long long hit;

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.h
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.h
@@ -34,9 +34,6 @@
 #define NETDATA_SYSTEMD_CACHESTAT_HIT_FILE_CONTEXT "services.cachestat_hits"
 #define NETDATA_SYSTEMD_CACHESTAT_MISS_FILES_CONTEXT "services.cachestat_misses"
 
-// ARAL Name
-#define NETDATA_EBPF_CACHESTAT_ARAL_NAME "ebpf_cachestat"
-
 // variables
 enum cachestat_counters {
     NETDATA_KEY_CALLS_ADD_TO_PAGE_CACHE_LRU,

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.h
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.h
@@ -80,7 +80,6 @@ typedef struct netdata_publish_cachestat_pid {
 
 typedef struct netdata_publish_cachestat {
     uint64_t ct;
-    int not_updated;
 
     long long ratio;
     long long dirty;

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -59,10 +59,6 @@ netdata_ebpf_targets_t dc_targets[] = { {.name = "lookup_fast", .mode = EBPF_LOA
                                         {.name = "d_lookup", .mode = EBPF_LOAD_TRAMPOLINE},
                                         {.name = NULL, .mode = EBPF_LOAD_TRAMPOLINE}};
 
-#ifdef NETDATA_DEV_MODE
-int dcstat_disable_priority;
-#endif
-
 struct netdata_static_thread ebpf_read_dcstat = {
     .name = "EBPF_READ_DCSTAT",
     .config_section = NULL,

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -585,12 +585,10 @@ void ebpf_dcstat_sum_pids(netdata_publish_dcstat_t *publish, struct ebpf_pid_on_
         ebpf_pid_stat_t *pid_stat = ebpf_get_pid_entry(pid, 0);
         if (pid_stat) {
             netdata_publish_dcstat_t *w = &pid_stat->dc;
-            if (w) {
-                netdata_dcstat_pid_t *src = &w->curr;
-                dst->cache_access += src->cache_access;
-                dst->file_system += src->file_system;
-                dst->not_found += src->not_found;
-            }
+            netdata_dcstat_pid_t *src = &w->curr;
+            dst->cache_access += src->cache_access;
+            dst->file_system += src->file_system;
+            dst->not_found += src->not_found;
         }
 
         root = root->next;

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -549,7 +549,7 @@ static void ebpf_read_dc_apps_table(int maps_per_core, int max_period)
 
         ebpf_dcstat_apps_accumulator(cv, maps_per_core);
 
-        ebpf_pid_stat_t *pid_stat = ebpf_get_pid_entry(key);
+        ebpf_pid_stat_t *pid_stat = ebpf_get_pid_entry(key, cv->tgid);
         if (pid_stat) {
             netdata_publish_dcstat_t *publish = &pid_stat->dc;
             if (!publish->ct || publish->ct != cv->ct) {
@@ -582,7 +582,7 @@ void ebpf_dcstat_sum_pids(netdata_publish_dcstat_t *publish, struct ebpf_pid_on_
     netdata_dcstat_pid_t *dst = &publish->curr;
     while (root) {
         int32_t pid = root->pid;
-        ebpf_pid_stat_t *pid_stat = ebpf_get_pid_entry(pid);
+        ebpf_pid_stat_t *pid_stat = ebpf_get_pid_entry(pid, 0);
         if (pid_stat) {
             netdata_publish_dcstat_t *w = &pid_stat->dc;
             if (w) {
@@ -774,7 +774,7 @@ static void ebpf_update_dc_cgroup()
         for (pids = ect->pids; pids; pids = pids->next) {
             int pid = pids->pid;
             netdata_dcstat_pid_t *out = &pids->dc;
-            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid);
+            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid, 0);
             if (local_pid) {
                 netdata_publish_dcstat_t *in = &local_pid->dc;
 

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -652,9 +652,9 @@ void *ebpf_read_dcstat_thread(void *ptr)
             continue;
 
         netdata_thread_disable_cancelability();
-        ebpf_read_dc_apps_table(maps_per_core, max_period);
 
         pthread_mutex_lock(&collect_data_mutex);
+        ebpf_read_dc_apps_table(maps_per_core, max_period);
         ebpf_dc_resume_apps_data();
         pthread_mutex_unlock(&collect_data_mutex);
 

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -131,7 +131,7 @@ static int ebpf_dc_attach_probes(struct dc_bpf *obj)
     obj->links.netdata_d_lookup_kretprobe = bpf_program__attach_kprobe(obj->progs.netdata_d_lookup_kretprobe,
                                                                        true,
                                                                        dc_targets[NETDATA_DC_TARGET_D_LOOKUP].name);
-    int ret = libbpf_get_error(obj->links.netdata_d_lookup_kretprobe);
+    long ret = libbpf_get_error(obj->links.netdata_d_lookup_kretprobe);
     if (ret)
         return -1;
 

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -554,10 +554,10 @@ static void ebpf_read_dc_apps_table(int maps_per_core, int max_period)
             netdata_publish_dcstat_t *publish = &pid_stat->dc;
             if (!publish->ct || publish->ct != cv->ct) {
                 memcpy(&publish->curr, &cv[0], sizeof(netdata_dcstat_pid_t));
-                publish->not_updated = 0;
-            } else if (++publish->not_updated >= max_period) {
+                pid_stat->not_updated = 0;
+            } else if (++pid_stat->not_updated >= max_period) {
                 bpf_map_delete_elem(fd, &key);
-                publish->not_updated = 0;
+                pid_stat->not_updated = 0;
             }
         }
 

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.h
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.h
@@ -77,7 +77,6 @@ typedef struct netdata_publish_dcstat_pid {
 
 typedef struct netdata_publish_dcstat {
     uint64_t ct;
-    int not_updated;
 
     long long ratio;
     long long cache_access;

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.h
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.h
@@ -76,6 +76,9 @@ typedef struct netdata_publish_dcstat_pid {
 } netdata_dcstat_pid_t;
 
 typedef struct netdata_publish_dcstat {
+    uint64_t ct;
+    int not_updated;
+
     long long ratio;
     long long cache_access;
 

--- a/src/collectors/ebpf.plugin/ebpf_fd.c
+++ b/src/collectors/ebpf.plugin/ebpf_fd.c
@@ -684,7 +684,7 @@ static void ebpf_read_fd_apps_table(int maps_per_core, int max_period)
 
         fd_apps_accumulator(fv, maps_per_core);
 
-        ebpf_pid_stat_t *pid_stat = ebpf_get_pid_entry(key);
+        ebpf_pid_stat_t *pid_stat = ebpf_get_pid_entry(key, fv->tgid);
         if (pid_stat) {
             netdata_fd_stat_t *publish_fd = &pid_stat->fd;
             if (!publish_fd->ct || publish_fd->ct != fv->ct) {
@@ -717,7 +717,7 @@ static void ebpf_fd_sum_pids(netdata_fd_stat_t *fd, struct ebpf_pid_on_target *r
 
     while (root) {
         int32_t pid = root->pid;
-        ebpf_pid_stat_t *pid_stat = ebpf_get_pid_entry(pid);
+        ebpf_pid_stat_t *pid_stat = ebpf_get_pid_entry(pid, 0);
         if (pid_stat) {
             netdata_fd_stat_t *w = &pid_stat->fd;
             fd->open_call += w->open_call;
@@ -815,7 +815,7 @@ static void ebpf_update_fd_cgroup()
         for (pids = ect->pids; pids; pids = pids->next) {
             int pid = pids->pid;
             netdata_fd_stat_t *out = &pids->fd;
-            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid);
+            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid, 0);
             if (local_pid) {
                 netdata_fd_stat_t *in = &local_pid->fd;
 

--- a/src/collectors/ebpf.plugin/ebpf_fd.c
+++ b/src/collectors/ebpf.plugin/ebpf_fd.c
@@ -57,12 +57,8 @@ netdata_ebpf_targets_t fd_targets[] = { {.name = "open", .mode = EBPF_LOAD_TRAMP
                                         {.name = "close", .mode = EBPF_LOAD_TRAMPOLINE},
                                         {.name = NULL, .mode = EBPF_LOAD_TRAMPOLINE}};
 
-#ifdef NETDATA_DEV_MODE
-int fd_disable_priority;
-#endif
-
 struct netdata_static_thread ebpf_read_fd = {
-    .name = "EBPF_READ_F",
+    .name = "EBPF_READ_FD",
     .config_section = NULL,
     .config_name = NULL,
     .env_name = NULL,

--- a/src/collectors/ebpf.plugin/ebpf_fd.c
+++ b/src/collectors/ebpf.plugin/ebpf_fd.c
@@ -686,13 +686,13 @@ static void ebpf_read_fd_apps_table(int maps_per_core, int max_period)
 
         ebpf_pid_stat_t *pid_stat = ebpf_get_pid_entry(key);
         if (pid_stat) {
-            netdata_fd_stat_t *publish_fd = &pid_stat->publish_fd.fd;
+            netdata_fd_stat_t *publish_fd = &pid_stat->fd;
             if (!publish_fd->ct || publish_fd->ct != fv->ct) {
                 memcpy(publish_fd, &fv[0], sizeof(netdata_fd_stat_t));
-                pid_stat->publish_fd.not_updated = 0;
-            } else if (++pid_stat->publish_fd.not_updated >= max_period) {
+                pid_stat->not_updated = 0;
+            } else if (++pid_stat->not_updated >= max_period) {
                 bpf_map_delete_elem(fd, &key);
-                pid_stat->publish_fd.not_updated = 0;
+                pid_stat->not_updated = 0;
             }
         }
 
@@ -719,7 +719,7 @@ static void ebpf_fd_sum_pids(netdata_fd_stat_t *fd, struct ebpf_pid_on_target *r
         int32_t pid = root->pid;
         ebpf_pid_stat_t *pid_stat = ebpf_get_pid_entry(pid);
         if (pid_stat) {
-            netdata_fd_stat_t *w = &pid_stat->publish_fd.fd;
+            netdata_fd_stat_t *w = &pid_stat->fd;
             fd->open_call += w->open_call;
             fd->close_call += w->close_call;
             fd->open_err += w->open_err;
@@ -817,7 +817,7 @@ static void ebpf_update_fd_cgroup()
             netdata_fd_stat_t *out = &pids->fd;
             ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid);
             if (local_pid) {
-                netdata_fd_stat_t *in = &local_pid->publish_fd.fd;
+                netdata_fd_stat_t *in = &local_pid->fd;
 
                 memcpy(out, in, sizeof(netdata_fd_stat_t));
             }

--- a/src/collectors/ebpf.plugin/ebpf_process.c
+++ b/src/collectors/ebpf.plugin/ebpf_process.c
@@ -232,7 +232,7 @@ static void ebpf_update_process_cgroup()
         for (pids = ect->pids; pids; pids = pids->next) {
             int pid = pids->pid;
             ebpf_process_stat_t *out = &pids->ps;
-            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid);
+            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid, 0);
             if (local_pid) {
                 ebpf_process_stat_t *in = &local_pid->process;
 

--- a/src/collectors/ebpf.plugin/ebpf_process.c
+++ b/src/collectors/ebpf.plugin/ebpf_process.c
@@ -361,7 +361,7 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_EBPF_MODULE_NAME_PROCESS);
         ebpf_create_chart_labels("app_group", w->name, 1);
         ebpf_commit_label();
-        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
@@ -376,7 +376,7 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_EBPF_MODULE_NAME_PROCESS);
         ebpf_create_chart_labels("app_group", w->name, 1);
         ebpf_commit_label();
-        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
@@ -391,7 +391,7 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_EBPF_MODULE_NAME_PROCESS);
         ebpf_create_chart_labels("app_group", w->name, 1);
         ebpf_commit_label();
-        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
         ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
                              w->clean_name,
@@ -406,7 +406,7 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
                              NETDATA_EBPF_MODULE_NAME_PROCESS);
         ebpf_create_chart_labels("app_group", w->name, 1);
         ebpf_commit_label();
-        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
+        fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
         if (em->mode < MODE_ENTRY) {
             ebpf_write_chart_cmd(NETDATA_APP_FAMILY,
@@ -422,7 +422,7 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
                                  NETDATA_EBPF_MODULE_NAME_PROCESS);
             ebpf_create_chart_labels("app_group", w->name, 1);
             ebpf_commit_label();
-            fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
+            fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
         }
         w->charts_created |= 1<<EBPF_MODULE_PROCESS_IDX;
     }

--- a/src/collectors/ebpf.plugin/ebpf_process.c
+++ b/src/collectors/ebpf.plugin/ebpf_process.c
@@ -65,10 +65,6 @@ struct config process_config = { .first_section = NULL,
     .index = { .avl_tree = { .root = NULL, .compar = appconfig_section_compare },
         .rwlock = AVL_LOCK_INITIALIZER } };
 
-#ifdef NETDATA_DEV_MODE
-int process_disable_priority;
-#endif
-
 /*****************************************************************
  *
  *  PROCESS DATA AND SEND TO NETDATA

--- a/src/collectors/ebpf.plugin/ebpf_shm.c
+++ b/src/collectors/ebpf.plugin/ebpf_shm.c
@@ -685,8 +685,6 @@ void ebpf_shm_send_apps_data(struct ebpf_target *root)
         if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_SHM_IDX))))
             continue;
 
-        ebpf_shm_sum_pids(&w->shm, w->root_pid);
-
         ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_shmget_call");
         write_chart_dimension("calls", (long long) w->shm.get);
         ebpf_write_end_chart();

--- a/src/collectors/ebpf.plugin/ebpf_shm.c
+++ b/src/collectors/ebpf.plugin/ebpf_shm.c
@@ -1023,6 +1023,8 @@ static void shm_collector(ebpf_module_t *em)
         counter = 0;
         netdata_apps_integration_flags_t apps = em->apps_charts;
         ebpf_shm_read_global_table(stats, maps_per_core);
+        pthread_mutex_lock(&lock);
+
         pthread_mutex_lock(&collect_data_mutex);
         if (apps) {
             read_shm_apps_table(maps_per_core);
@@ -1031,8 +1033,6 @@ static void shm_collector(ebpf_module_t *em)
         if (cgroups) {
             ebpf_update_shm_cgroup(maps_per_core);
         }
-
-        pthread_mutex_lock(&lock);
 
         shm_send_global();
 
@@ -1049,8 +1049,8 @@ static void shm_collector(ebpf_module_t *em)
             ebpf_shm_send_cgroup_data(update_every);
         }
 
-        pthread_mutex_unlock(&lock);
         pthread_mutex_unlock(&collect_data_mutex);
+        pthread_mutex_unlock(&lock);
 
         pthread_mutex_lock(&ebpf_exit_cleanup);
         if (running_time && !em->running_time)

--- a/src/collectors/ebpf.plugin/ebpf_shm.c
+++ b/src/collectors/ebpf.plugin/ebpf_shm.c
@@ -539,7 +539,7 @@ static void ebpf_update_shm_cgroup()
         for (pids = ect->pids; pids; pids = pids->next) {
             int pid = pids->pid;
             netdata_publish_shm_t *out = &pids->shm;
-            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid);
+            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid, 0);
             if (local_pid) {
                 netdata_publish_shm_t *in = &local_pid->shm;
 
@@ -573,7 +573,7 @@ static void ebpf_read_shm_apps_table(int maps_per_core, int max_period)
 
         shm_apps_accumulator(cv, maps_per_core);
 
-        ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(key);
+        ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(key, 0);
         if (!local_pid)
             goto end_shm_loop;
 
@@ -654,7 +654,7 @@ static void ebpf_shm_sum_pids(netdata_publish_shm_t *shm, struct ebpf_pid_on_tar
     memset(shm, 0, sizeof(netdata_publish_shm_t));
     while (root) {
         int32_t pid = root->pid;
-        ebpf_pid_stat_t *pid_stat = ebpf_get_pid_entry(pid);
+        ebpf_pid_stat_t *pid_stat = ebpf_get_pid_entry(pid, 0);
         if (pid_stat) {
             netdata_publish_shm_t *w = &pid_stat->shm;
             shm->get += w->get;

--- a/src/collectors/ebpf.plugin/ebpf_shm.h
+++ b/src/collectors/ebpf.plugin/ebpf_shm.h
@@ -28,9 +28,6 @@
 #define NETDATA_SYSTEMD_SHM_DT_CONTEXT "services.shmdt"
 #define NETDATA_SYSTEMD_SHM_CTL_CONTEXT "services.shmctl"
 
-// ARAL name
-#define NETDATA_EBPF_SHM_ARAL_NAME "ebpf_shm"
-
 typedef struct netdata_publish_shm {
     uint64_t ct;
     char name[TASK_COMM_LEN];

--- a/src/collectors/ebpf.plugin/ebpf_socket.c
+++ b/src/collectors/ebpf.plugin/ebpf_socket.c
@@ -1794,7 +1794,7 @@ void ebpf_socket_resume_apps_data()
         memset(&w->socket, 0, sizeof(ebpf_socket_publish_apps_t));
         while (move) {
             int32_t pid = move->pid;
-            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid);
+            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid, 0);
             if (local_pid) {
                 ebpf_socket_publish_apps_t *ws = &local_pid->socket;
                 values->call_tcp_v4_connection = ws->call_tcp_v4_connection;
@@ -1998,7 +1998,7 @@ static void ebpf_socket_read_hash_global_tables(netdata_idx_t *stats, int maps_p
  */
 void ebpf_socket_fill_publish_apps(uint32_t current_pid, netdata_socket_t *ns)
 {
-    ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(current_pid);
+    ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(current_pid, 0);
     if (!local_pid)
         return;
 
@@ -2032,7 +2032,7 @@ static void ebpf_update_socket_cgroup()
         for (pids = ect->pids; pids; pids = pids->next) {
             int pid = pids->pid;
             ebpf_socket_publish_apps_t *publish = &ect->publish_socket;
-            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid);
+            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid, 0);
             if (local_pid) {
                 ebpf_socket_publish_apps_t *in = &local_pid->socket;
 

--- a/src/collectors/ebpf.plugin/ebpf_swap.c
+++ b/src/collectors/ebpf.plugin/ebpf_swap.c
@@ -421,7 +421,7 @@ static void ebpf_update_swap_cgroup()
         for (pids = ect->pids; pids; pids = pids->next) {
             int pid = pids->pid;
             netdata_publish_swap_t *out = &pids->swap;
-            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid);
+            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid, 0);
             if (local_pid) {
                 netdata_publish_swap_t *in = &local_pid->swap;
 
@@ -447,7 +447,7 @@ static void ebpf_swap_sum_pids(netdata_publish_swap_t *swap, struct ebpf_pid_on_
 
     while (root) {
         int32_t pid = root->pid;
-        ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid);
+        ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid, 0);
         if (local_pid) {
             netdata_publish_swap_t *w = &local_pid->swap;
             local_write += w->write;
@@ -498,7 +498,7 @@ static void ebpf_read_swap_apps_table(int maps_per_core, int max_period)
 
         swap_apps_accumulator(cv, maps_per_core);
 
-        ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(key);
+        ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(key, cv->tgid);
         if (!local_pid)
             goto end_swap_loop;
 

--- a/src/collectors/ebpf.plugin/ebpf_swap.c
+++ b/src/collectors/ebpf.plugin/ebpf_swap.c
@@ -52,6 +52,17 @@ netdata_ebpf_targets_t swap_targets[] = { {.name = "swap_readpage", .mode = EBPF
                                            {.name = "swap_writepage", .mode = EBPF_LOAD_TRAMPOLINE},
                                            {.name = NULL, .mode = EBPF_LOAD_TRAMPOLINE}};
 
+struct netdata_static_thread ebpf_read_swap = {
+    .name = "EBPF_READ_SWAP",
+    .config_section = NULL,
+    .config_name = NULL,
+    .env_name = NULL,
+    .enabled = 1,
+    .thread = NULL,
+    .init_routine = NULL,
+    .start_routine = NULL
+};
+
 #ifdef LIBBPF_MAJOR_VERSION
 /**
  * Disable probe
@@ -269,6 +280,7 @@ void ebpf_obsolete_swap_apps_charts(struct ebpf_module *em)
 {
     struct ebpf_target *w;
     int update_every = em->update_every;
+    pthread_mutex_lock(&collect_data_mutex);
     for (w = apps_groups_root_target; w; w = w->next) {
         if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_SWAP_IDX))))
             continue;
@@ -296,6 +308,7 @@ void ebpf_obsolete_swap_apps_charts(struct ebpf_module *em)
                                   update_every);
         w->charts_created &= ~(1<<EBPF_MODULE_SWAP_IDX);
     }
+    pthread_mutex_unlock(&collect_data_mutex);
 }
 
 /**
@@ -328,6 +341,9 @@ static void ebpf_obsolete_swap_global(ebpf_module_t *em)
 static void ebpf_swap_exit(void *ptr)
 {
     ebpf_module_t *em = (ebpf_module_t *)ptr;
+
+    if (ebpf_read_swap.thread)
+        netdata_thread_cancel(*ebpf_read_swap.thread);
 
     if (em->enabled == NETDATA_THREAD_EBPF_FUNCTION_RUNNING) {
         pthread_mutex_lock(&lock);
@@ -392,63 +408,71 @@ static void swap_apps_accumulator(netdata_publish_swap_t *out, int maps_per_core
 }
 
 /**
- * Fill PID
- *
- * Fill PID structures
- *
- * @param current_pid pid that we are collecting data
- * @param out         values read from hash tables;
- */
-static void swap_fill_pid(uint32_t current_pid, netdata_publish_swap_t *publish)
-{
-    netdata_publish_swap_t *curr = swap_pid[current_pid];
-    if (!curr) {
-        curr = callocz(1, sizeof(netdata_publish_swap_t));
-        swap_pid[current_pid] = curr;
-    }
-
-    memcpy(curr, publish, sizeof(netdata_publish_swap_t));
-}
-
-/**
  * Update cgroup
  *
  * Update cgroup data based in
- *
- * @param maps_per_core do I need to read all cores?
  */
-static void ebpf_update_swap_cgroup(int maps_per_core)
+static void ebpf_update_swap_cgroup()
 {
     ebpf_cgroup_target_t *ect ;
-    netdata_publish_swap_t *cv = swap_vector;
-    int fd = swap_maps[NETDATA_PID_SWAP_TABLE].map_fd;
-    size_t length = sizeof(netdata_publish_swap_t);
-    if (maps_per_core)
-        length *= ebpf_nprocs;
     pthread_mutex_lock(&mutex_cgroup_shm);
     for (ect = ebpf_cgroup_pids; ect; ect = ect->next) {
         struct pid_on_target2 *pids;
         for (pids = ect->pids; pids; pids = pids->next) {
             int pid = pids->pid;
             netdata_publish_swap_t *out = &pids->swap;
-            if (likely(swap_pid) && swap_pid[pid]) {
-                netdata_publish_swap_t *in = swap_pid[pid];
+            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid);
+            if (local_pid) {
+                netdata_publish_swap_t *in = &local_pid->swap;
 
                 memcpy(out, in, sizeof(netdata_publish_swap_t));
-            } else {
-                memset(cv, 0, length);
-                if (!bpf_map_lookup_elem(fd, &pid, cv)) {
-                    swap_apps_accumulator(cv, maps_per_core);
-
-                    memcpy(out, cv, sizeof(netdata_publish_swap_t));
-
-                    // We are cleaning to avoid passing data read from one process to other.
-                    memset(cv, 0, length);
-                }
             }
         }
     }
     pthread_mutex_unlock(&mutex_cgroup_shm);
+}
+
+/**
+ * Sum PIDs
+ *
+ * Sum values for all targets.
+ *
+ * @param swap
+ * @param root
+ */
+static void ebpf_swap_sum_pids(netdata_publish_swap_t *swap, struct ebpf_pid_on_target *root)
+{
+    uint64_t local_read = 0;
+    uint64_t local_write = 0;
+
+    while (root) {
+        int32_t pid = root->pid;
+        ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid);
+        if (local_pid) {
+            netdata_publish_swap_t *w = &local_pid->swap;
+            local_write += w->write;
+            local_read += w->read;
+        }
+        root = root->next;
+    }
+
+    // These conditions were added, because we are using incremental algorithm
+    swap->write = (local_write >= swap->write) ? local_write : swap->write;
+    swap->read = (local_read >= swap->read) ? local_read : swap->read;
+    }
+
+
+/**
+ * Resume apps data
+ */
+void ebpf_swap_resume_apps_data() {
+    struct ebpf_target *w;
+    for (w = apps_groups_root_target; w; w = w->next) {
+        if (unlikely(!(w->charts_created & (1 << EBPF_MODULE_SWAP_IDX))))
+            continue;
+
+        ebpf_swap_sum_pids(&w->swap, w->root_pid);
+    }
 }
 
 /**
@@ -458,7 +482,7 @@ static void ebpf_update_swap_cgroup(int maps_per_core)
  *
  * @param maps_per_core do I need to read all cores?
  */
-static void read_swap_apps_table(int maps_per_core)
+static void ebpf_read_swap_apps_table(int maps_per_core, int max_period)
 {
     netdata_publish_swap_t *cv = swap_vector;
     int fd = swap_maps[NETDATA_PID_SWAP_TABLE].map_fd;
@@ -474,13 +498,78 @@ static void read_swap_apps_table(int maps_per_core)
 
         swap_apps_accumulator(cv, maps_per_core);
 
-        swap_fill_pid(key, cv);
+        ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(key);
+        if (!local_pid)
+            goto end_swap_loop;
+
+        netdata_publish_swap_t *publish = &local_pid->swap;
+        if (!publish->ct || publish->ct != cv->ct) {
+            memcpy(publish, cv, sizeof(netdata_publish_swap_t));
+            local_pid->not_updated = 0;
+        } else if (++local_pid->not_updated >= max_period) {
+            bpf_map_delete_elem(fd, &key);
+            local_pid->not_updated = 0;
+        }
 
         // We are cleaning to avoid passing data read from one process to other.
 end_swap_loop:
         memset(cv, 0, length);
         key = next_key;
     }
+}
+
+/**
+ * SWAP thread
+ *
+ * Thread used to generate swap charts.
+ *
+ * @param ptr a pointer to `struct ebpf_module`
+ *
+ * @return It always return NULL
+ */
+void *ebpf_read_swap_thread(void *ptr)
+{
+    heartbeat_t hb;
+    heartbeat_init(&hb);
+
+    ebpf_module_t *em = (ebpf_module_t *)ptr;
+
+    int maps_per_core = em->maps_per_core;
+    int update_every = em->update_every;
+
+    int counter = update_every - 1;
+
+    uint32_t lifetime = em->lifetime;
+    uint32_t running_time = 0;
+    usec_t period = update_every * USEC_PER_SEC;
+    int max_period = update_every * EBPF_CLEANUP_FACTOR;
+
+    while (!ebpf_plugin_exit && running_time < lifetime) {
+        (void)heartbeat_next(&hb, period);
+        if (ebpf_plugin_exit || ++counter != update_every)
+            continue;
+
+        netdata_thread_disable_cancelability();
+
+        pthread_mutex_lock(&collect_data_mutex);
+        ebpf_read_swap_apps_table(maps_per_core, max_period);
+        ebpf_swap_resume_apps_data();
+        pthread_mutex_unlock(&collect_data_mutex);
+
+        counter = 0;
+
+        pthread_mutex_lock(&ebpf_exit_cleanup);
+        if (running_time && !em->running_time)
+            running_time = update_every;
+        else
+            running_time += update_every;
+
+        em->running_time = running_time;
+        pthread_mutex_unlock(&ebpf_exit_cleanup);
+        netdata_thread_enable_cancelability();
+    }
+
+    return NULL;
 }
 
 /**
@@ -523,34 +612,6 @@ static void ebpf_swap_read_global_table(netdata_idx_t *stats, int maps_per_core)
 }
 
 /**
- * Sum PIDs
- *
- * Sum values for all targets.
- *
- * @param swap
- * @param root
- */
-static void ebpf_swap_sum_pids(netdata_publish_swap_t *swap, struct ebpf_pid_on_target *root)
-{
-    uint64_t local_read = 0;
-    uint64_t local_write = 0;
-
-    while (root) {
-        int32_t pid = root->pid;
-        netdata_publish_swap_t *w = swap_pid[pid];
-        if (w) {
-            local_write += w->write;
-            local_read += w->read;
-        }
-        root = root->next;
-    }
-
-    // These conditions were added, because we are using incremental algorithm
-    swap->write = (local_write >= swap->write) ? local_write : swap->write;
-    swap->read = (local_read >= swap->read) ? local_read : swap->read;
-}
-
-/**
  * Send data to Netdata calling auxiliary functions.
  *
  * @param root the target list.
@@ -558,11 +619,10 @@ static void ebpf_swap_sum_pids(netdata_publish_swap_t *swap, struct ebpf_pid_on_
 void ebpf_swap_send_apps_data(struct ebpf_target *root)
 {
     struct ebpf_target *w;
+    pthread_mutex_lock(&collect_data_mutex);
     for (w = root; w; w = w->next) {
         if (unlikely(!(w->charts_created & (1<<EBPF_MODULE_SWAP_IDX))))
             continue;
-
-        ebpf_swap_sum_pids(&w->swap, w->root_pid);
 
         ebpf_write_begin_chart(NETDATA_APP_FAMILY, w->clean_name, "_ebpf_call_swap_readpage");
         write_chart_dimension("calls", (long long) w->swap.read);
@@ -572,6 +632,7 @@ void ebpf_swap_send_apps_data(struct ebpf_target *root)
         write_chart_dimension("calls", (long long) w->swap.write);
         ebpf_write_end_chart();
     }
+    pthread_mutex_unlock(&collect_data_mutex);
 }
 
 /**
@@ -788,12 +849,9 @@ static void swap_collector(ebpf_module_t *em)
         counter = 0;
         netdata_apps_integration_flags_t apps = em->apps_charts;
         ebpf_swap_read_global_table(stats, maps_per_core);
-        pthread_mutex_lock(&collect_data_mutex);
-        if (apps)
-            read_swap_apps_table(maps_per_core);
 
         if (cgroup)
-            ebpf_update_swap_cgroup(maps_per_core);
+            ebpf_update_swap_cgroup();
 
         pthread_mutex_lock(&lock);
 
@@ -806,7 +864,6 @@ static void swap_collector(ebpf_module_t *em)
             ebpf_swap_send_cgroup_data(update_every);
 
         pthread_mutex_unlock(&lock);
-        pthread_mutex_unlock(&collect_data_mutex);
 
         pthread_mutex_lock(&ebpf_exit_cleanup);
         if (running_time && !em->running_time)
@@ -881,14 +938,9 @@ void ebpf_swap_create_apps_charts(struct ebpf_module *em, void *ptr)
  *
  * We are not testing the return, because callocz does this and shutdown the software
  * case it was not possible to allocate.
- *
- * @param apps is apps enabled?
  */
-static void ebpf_swap_allocate_global_vectors(int apps)
+static void ebpf_swap_allocate_global_vectors()
 {
-    if (apps)
-        swap_pid = callocz((size_t)pid_max, sizeof(netdata_publish_swap_t *));
-
     swap_vector = callocz((size_t)ebpf_nprocs, sizeof(netdata_publish_swap_t));
 
     swap_values = callocz((size_t)ebpf_nprocs, sizeof(netdata_idx_t));
@@ -986,7 +1038,7 @@ void *ebpf_swap_thread(void *ptr)
         goto endswap;
     }
 
-    ebpf_swap_allocate_global_vectors(em->apps_charts);
+    ebpf_swap_allocate_global_vectors();
 
     int algorithms[NETDATA_SWAP_END] = { NETDATA_EBPF_INCREMENTAL_IDX, NETDATA_EBPF_INCREMENTAL_IDX };
     ebpf_global_labels(swap_aggregated_data, swap_publish_aggregated, swap_dimension_name, swap_dimension_name,
@@ -997,6 +1049,13 @@ void *ebpf_swap_thread(void *ptr)
     ebpf_update_stats(&plugin_statistics, em);
     ebpf_update_kernel_memory_with_vector(&plugin_statistics, em->maps, EBPF_ACTION_STAT_ADD);
     pthread_mutex_unlock(&lock);
+
+    ebpf_read_swap.thread = mallocz(sizeof(netdata_thread_t));
+    netdata_thread_create(ebpf_read_swap.thread,
+                          ebpf_read_swap.name,
+                          NETDATA_THREAD_OPTION_DEFAULT,
+                          ebpf_read_swap_thread,
+                          em);
 
     swap_collector(em);
 

--- a/src/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/src/collectors/ebpf.plugin/ebpf_vfs.c
@@ -1046,7 +1046,7 @@ static void ebpf_vfs_sum_pids(netdata_publish_vfs_t *vfs, struct ebpf_pid_on_tar
 
     while (root) {
         int32_t pid = root->pid;
-        ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid);
+        ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid, 0);
         if (local_pid) {
             netdata_publish_vfs_t *w = &local_pid->vfs;
             accumulator.write_call += w->write_call;
@@ -1231,7 +1231,7 @@ static void ebpf_vfs_read_apps(int maps_per_core, int max_period)
 
         vfs_apps_accumulator(vv, maps_per_core);
 
-        ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(key);
+        ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(key, vv->tgid);
         if (!local_pid)
             goto end_vfs_loop;
 
@@ -1267,7 +1267,7 @@ static void read_update_vfs_cgroup()
         for (pids = ect->pids; pids; pids = pids->next) {
             int pid = pids->pid;
             netdata_publish_vfs_t *out = &pids->vfs;
-            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid);
+            ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(pid, 0);
             if (local_pid) {
                 netdata_publish_vfs_t *in = &local_pid->vfs;
 


### PR DESCRIPTION
##### Summary
This is the last PR before introduction of more eBPF functions.
Blocked by https://github.com/netdata/netdata/pull/16671

##### Test Plan

1. Configure your `ebpf.d.conf` with the following options:
```sh
[global]
    ebpf load mode = return
    apps = yes
[ebpf programs]
    cachestat = yes
    dcstat = yes
    fd = yes
    oomkill = yes
    process = yes
    shm = yes
    socket = yes
    swap = yes
    vfs = yes
```
2. Compile branch
3. Look for `libbpf` errors in our logs or using `journalctl`

##### Additional Information
This PR was tested on:

| Linux Distribution | kernel version  | 
|----------------------------|-----------------------|
|Slackware Current | 6.6.11 | 
|Arch Linux | 6.7.0-arch3-1 |
|Ubuntu 22.04 | 5.15.0-76-generic |
|Alma 9 | 5.14.0-362.13.1.el9_3.x86_64|
|Alma 8.9 | 4.18.0-513.11.1.el8_9.x86_64 |

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
