### PR TITLE
Fix incorrect major version check in updater.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -600,7 +600,7 @@ update_available() {
         update_safe=0
 
         for v in ${NETDATA_ACCEPT_MAJOR_VERSIONS}; do
-          if [ "${current_major}" -eq "${v}" ]; then
+          if [ "${latest_major}" -eq "${v}" ]; then
             update_safe=1
             break
           fi

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -910,7 +910,7 @@ update_binpkg() {
     update_safe=0
 
     for v in ${NETDATA_ACCEPT_MAJOR_VERSIONS}; do
-      if [ "${current_major}" -eq "${v}" ]; then
+      if [ "${latest_major}" -eq "${v}" ]; then
         update_safe=1
         break
       fi


### PR DESCRIPTION
##### Summary

We should be checking the target version for the update, not the current version.

##### Test Plan

Testing is as outlined in https://github.com/netdata/netdata/pull/15898, except that explicitly setting `NETDATA_ACCEPT_MAJOR_VERSIONS="1"` in the updater config should exhibit different behavior with and without this change. Without this change, the update should continue without warning or prompting, while with this change it should result in a failure for non-interactive updates or a prompt for interactive ones.

##### Additional Information

Pointed out by @ilyam8 in https://github.com/netdata/netdata/pull/15898#discussion_r1455532491