### PR TITLE
fix verify_netdata_host_prefix log spam

### DIFF
--- a/collectors/apps.plugin/apps_plugin.c
+++ b/collectors/apps.plugin/apps_plugin.c
@@ -5270,7 +5270,7 @@ int main(int argc, char **argv) {
     procfile_open_flags = O_RDONLY|O_NOFOLLOW;
 
     netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
-    if(verify_netdata_host_prefix() == -1) exit(1);
+    if(verify_netdata_host_prefix(true) == -1) exit(1);
 
     user_config_dir = getenv("NETDATA_USER_CONFIG_DIR");
     if(user_config_dir == NULL) {

--- a/collectors/cgroups.plugin/cgroup-network.c
+++ b/collectors/cgroups.plugin/cgroup-network.c
@@ -666,7 +666,7 @@ int main(int argc, char **argv) {
     // make sure NETDATA_HOST_PREFIX is safe
 
     netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
-    if(verify_netdata_host_prefix() == -1) exit(1);
+    if(verify_netdata_host_prefix(false) == -1) exit(1);
 
     if(netdata_configured_host_prefix[0] != '\0' && verify_path(netdata_configured_host_prefix) == -1)
         fatal("invalid NETDATA_HOST_PREFIX '%s'", netdata_configured_host_prefix);

--- a/collectors/debugfs.plugin/debugfs_plugin.c
+++ b/collectors/debugfs.plugin/debugfs_plugin.c
@@ -163,7 +163,7 @@ int main(int argc, char **argv)
     nd_log_initialize_for_external_plugins("debugfs.plugin");
 
     netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
-    if (verify_netdata_host_prefix() == -1)
+    if (verify_netdata_host_prefix(true) == -1)
         exit(1);
 
     user_config_dir = getenv("NETDATA_USER_CONFIG_DIR");

--- a/collectors/ebpf.plugin/ebpf.c
+++ b/collectors/ebpf.plugin/ebpf.c
@@ -4031,7 +4031,7 @@ int main(int argc, char **argv)
     ebpf_start_pthread_variables();
 
     netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
-    if(verify_netdata_host_prefix() == -1) ebpf_exit(6);
+    if(verify_netdata_host_prefix(true) == -1) ebpf_exit(6);
 
     ebpf_allocate_common_vectors();
 

--- a/collectors/systemd-journal.plugin/systemd-main.c
+++ b/collectors/systemd-journal.plugin/systemd-main.c
@@ -23,7 +23,7 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
     nd_log_initialize_for_external_plugins("systemd-journal.plugin");
 
     netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
-    if(verify_netdata_host_prefix() == -1) exit(1);
+    if(verify_netdata_host_prefix(true) == -1) exit(1);
 
     // ------------------------------------------------------------------------
     // initialization

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1116,7 +1116,7 @@ static void get_netdata_configured_variables() {
     // get the hostname
 
     netdata_configured_host_prefix = config_get(CONFIG_SECTION_GLOBAL, "host access prefix", "");
-    verify_netdata_host_prefix();
+    verify_netdata_host_prefix(true);
 
     char buf[HOSTNAME_MAX + 1];
     if (get_hostname(buf, HOSTNAME_MAX))

--- a/libnetdata/libnetdata.c
+++ b/libnetdata/libnetdata.c
@@ -1329,7 +1329,7 @@ static int is_virtual_filesystem(const char *path, char **reason) {
     return 0;
 }
 
-int verify_netdata_host_prefix() {
+int verify_netdata_host_prefix(bool log_msg) {
     if(!netdata_configured_host_prefix)
         netdata_configured_host_prefix = "";
 
@@ -1362,13 +1362,16 @@ int verify_netdata_host_prefix() {
     if(is_virtual_filesystem(path, &reason) == -1)
         goto failed;
 
-    if(netdata_configured_host_prefix && *netdata_configured_host_prefix)
-        netdata_log_info("Using host prefix directory '%s'", netdata_configured_host_prefix);
+    if (netdata_configured_host_prefix && *netdata_configured_host_prefix) {
+        if (log_msg)
+            netdata_log_info("Using host prefix directory '%s'", netdata_configured_host_prefix);
+    }
 
     return 0;
 
 failed:
-    netdata_log_error("Ignoring host prefix '%s': path '%s' %s", netdata_configured_host_prefix, path, reason);
+    if (log_msg)
+        netdata_log_error("Ignoring host prefix '%s': path '%s' %s", netdata_configured_host_prefix, path, reason);
     netdata_configured_host_prefix = "";
     return -1;
 }

--- a/libnetdata/libnetdata.h
+++ b/libnetdata/libnetdata.h
@@ -559,7 +559,7 @@ extern int enable_ksm;
 
 char *fgets_trim_len(char *buf, size_t buf_size, FILE *fp, size_t *len);
 
-int verify_netdata_host_prefix();
+int verify_netdata_host_prefix(bool log_msg);
 
 extern volatile sig_atomic_t netdata_exit;
 

--- a/logsmanagement/logsmanagement.c
+++ b/logsmanagement/logsmanagement.c
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
     nd_log_initialize_for_external_plugins(program_name);
 
     // netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
-    // if(verify_netdata_host_prefix() == -1) exit(1);
+    // if(verify_netdata_host_prefix(true) == -1) exit(1);
 
     int g_update_every = 0;
     for(int i = 1; i < argc ; i++) {


### PR DESCRIPTION
##### Summary

The goal is to not log "Using host prefix..." from [cgroups.plugin/cgroup-network](https://github.com/netdata/netdata/blob/8bf8d095b8fbbe5aba4099816ce52c3939ff7415/collectors/cgroups.plugin/cgroup-network.c#L655-L669) (executed for every discovered container).

<details>
<summary>logs</summary>

```
kubectl logs netdata-child-9j5lb -c netdata 2>&1 | grep "host prefix"
time=2024-01-19T14:26:09.252+00:00 comm=netdata source=daemon level=info tid=2990974 thread=netdata msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:10.426+00:00 comm=systemd-journal.plugin source=collector level=info tid=2991243 thread=SDMAIN msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:10.428+00:00 comm=debugfs.plugin source=collector level=info tid=2991250 thread=debugfs.plugin msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:10.433+00:00 comm=apps.plugin source=collector level=info tid=2991260 thread=apps.plugin msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:22.633+00:00 comm=cgroup-network source=collector level=info tid=2991884 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:22.670+00:00 comm=cgroup-network source=collector level=info tid=2991915 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:22.688+00:00 comm=cgroup-network source=collector level=info tid=2991934 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:22.718+00:00 comm=cgroup-network source=collector level=info tid=2991958 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:22.751+00:00 comm=cgroup-network source=collector level=info tid=2991982 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:22.783+00:00 comm=cgroup-network source=collector level=info tid=2992006 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:22.813+00:00 comm=cgroup-network source=collector level=info tid=2992030 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:22.852+00:00 comm=cgroup-network source=collector level=info tid=2992061 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:22.872+00:00 comm=cgroup-network source=collector level=info tid=2992078 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:22.901+00:00 comm=cgroup-network source=collector level=info tid=2992102 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:22.928+00:00 comm=cgroup-network source=collector level=info tid=2992126 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:22.959+00:00 comm=cgroup-network source=collector level=info tid=2992150 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:22.988+00:00 comm=cgroup-network source=collector level=info tid=2992174 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.036+00:00 comm=cgroup-network source=collector level=info tid=2992207 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.071+00:00 comm=cgroup-network source=collector level=info tid=2992231 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.106+00:00 comm=cgroup-network source=collector level=info tid=2992255 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.134+00:00 comm=cgroup-network source=collector level=info tid=2992272 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.175+00:00 comm=cgroup-network source=collector level=info tid=2992303 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.204+00:00 comm=cgroup-network source=collector level=info tid=2992327 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.233+00:00 comm=cgroup-network source=collector level=info tid=2992351 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.253+00:00 comm=cgroup-network source=collector level=info tid=2992368 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.281+00:00 comm=cgroup-network source=collector level=info tid=2992392 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.312+00:00 comm=cgroup-network source=collector level=info tid=2992416 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.353+00:00 comm=cgroup-network source=collector level=info tid=2992440 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.396+00:00 comm=cgroup-network source=collector level=info tid=2992471 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.417+00:00 comm=cgroup-network source=collector level=info tid=2992488 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.458+00:00 comm=cgroup-network source=collector level=info tid=2992519 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.487+00:00 comm=cgroup-network source=collector level=info tid=2992543 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.519+00:00 comm=cgroup-network source=collector level=info tid=2992567 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.549+00:00 comm=cgroup-network source=collector level=info tid=2992591 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.568+00:00 comm=cgroup-network source=collector level=info tid=2992608 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.608+00:00 comm=cgroup-network source=collector level=info tid=2992639 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.638+00:00 comm=cgroup-network source=collector level=info tid=2992663 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.658+00:00 comm=cgroup-network source=collector level=info tid=2992680 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.699+00:00 comm=cgroup-network source=collector level=info tid=2992711 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.729+00:00 comm=cgroup-network source=collector level=info tid=2992735 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.760+00:00 comm=cgroup-network source=collector level=info tid=2992759 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.791+00:00 comm=cgroup-network source=collector level=info tid=2992783 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.823+00:00 comm=cgroup-network source=collector level=info tid=2992807 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.854+00:00 comm=cgroup-network source=collector level=info tid=2992831 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.884+00:00 comm=cgroup-network source=collector level=info tid=2992855 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.916+00:00 comm=cgroup-network source=collector level=info tid=2992879 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.945+00:00 comm=cgroup-network source=collector level=info tid=2992903 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.966+00:00 comm=cgroup-network source=collector level=info tid=2992920 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:23.995+00:00 comm=cgroup-network source=collector level=info tid=2992944 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.046+00:00 comm=cgroup-network source=collector level=info tid=2992968 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.090+00:00 comm=cgroup-network source=collector level=info tid=2992999 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.122+00:00 comm=cgroup-network source=collector level=info tid=2993023 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.146+00:00 comm=cgroup-network source=collector level=info tid=2993040 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.191+00:00 comm=cgroup-network source=collector level=info tid=2993071 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.211+00:00 comm=cgroup-network source=collector level=info tid=2993088 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.250+00:00 comm=cgroup-network source=collector level=info tid=2993119 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.293+00:00 comm=cgroup-network source=collector level=info tid=2993143 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.323+00:00 comm=cgroup-network source=collector level=info tid=2993160 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.372+00:00 comm=cgroup-network source=collector level=info tid=2993184 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.418+00:00 comm=cgroup-network source=collector level=info tid=2993208 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.472+00:00 comm=cgroup-network source=collector level=info tid=2993232 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.540+00:00 comm=cgroup-network source=collector level=info tid=2993263 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.567+00:00 comm=cgroup-network source=collector level=info tid=2993280 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.615+00:00 comm=cgroup-network source=collector level=info tid=2993311 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.636+00:00 comm=cgroup-network source=collector level=info tid=2993328 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.664+00:00 comm=cgroup-network source=collector level=info tid=2993352 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.685+00:00 comm=cgroup-network source=collector level=info tid=2993369 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.731+00:00 comm=cgroup-network source=collector level=info tid=2993400 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.749+00:00 comm=cgroup-network source=collector level=info tid=2993417 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.776+00:00 comm=cgroup-network source=collector level=info tid=2993441 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.815+00:00 comm=cgroup-network source=collector level=info tid=2993472 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.848+00:00 comm=cgroup-network source=collector level=info tid=2993496 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.870+00:00 comm=cgroup-network source=collector level=info tid=2993513 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.912+00:00 comm=cgroup-network source=collector level=info tid=2993544 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.932+00:00 comm=cgroup-network source=collector level=info tid=2993561 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:24.972+00:00 comm=cgroup-network source=collector level=info tid=2993592 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:25.000+00:00 comm=cgroup-network source=collector level=info tid=2993616 thread=cgroup-network msg="Using host prefix directory '/host'"
time=2024-01-19T14:26:25.036+00:00 comm=cgroup-network source=collector level=info tid=2993634 thread=cgroup-network msg="Using host prefix directory '/host'"
```


</details>

 

##### Test Plan

Check logs and make sure `cgroup-network` doesn't log the message.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
