### PR TITLE
Improve container detection logic for edit-config.

### DIFF
--- a/system/edit-config
+++ b/system/edit-config
@@ -112,8 +112,10 @@ check_editor() {
 running_in_container() {
   [ -e /.dockerenv ] && return 0
   [ -e /.dockerinit ] && return 0
-  [ -r /proc/1/environ ] && tr '\000' '\n' </proc/1/environ | grep -Eiq '^container=podman' && return 0
+  [ -e /run/.containerenv ] && return 0
+  [ -r /proc/1/environ ] && tr '\000' '\n' </proc/1/environ | grep -Eiq 'container=' && return 0
   grep -qF -e /docker/ -e /libpod- /proc/self/cgroup 2>/dev/null && return 0
+  return 1
 }
 
 get_docker_command() {


### PR DESCRIPTION
##### Summary

- Check for `/run/.containerenv`, which is used by modern versions of Podman and some other OCI stacks to signal that the environment is a container.
- Relax the PID 1 environment checking to not require `container` to be set to `podman` (some images override it), and not require it to be the first item in the list of environment variables (it will often not be).
- Explicitly return a non-zero exit status if no signs of being in a container are detected.

##### Test Plan

This needs to be manually tested in affected environments to confirm it works.

Testing should be as simple as copying the version of the edit-config script from the PR branch to the expected location in the test environment and running it there.

##### Additional Information

Fixes: #16819 