### PR TITLE
Add basic support for dinit in our system service handling code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2290,6 +2290,11 @@ install(PROGRAMS
         ${CMAKE_BINARY_DIR}/system/runit/run
         DESTINATION usr/lib/netdata/system/runit)
 
+configure_file(system/dinit/netdata.in system/dinit/netdata @ONLY)
+install(FILES
+        ${CMAKE_BINARY_DIR}/system/dinit/netdata
+        DESTINATION usr/lib/netdata/system/dinit)
+
 configure_file(system/systemd/netdata.service.in system/systemd/netdata.service @ONLY)
 install(FILES
         ${CMAKE_BINARY_DIR}/system/systemd/netdata.service

--- a/system/dinit/netdata.in
+++ b/system/dinit/netdata.in
@@ -1,0 +1,11 @@
+# dinit service description for Netdata
+#
+# Currently only properly tested on Chimera Linux.
+
+type = bgprocess
+command = @sbindir_POST@/netdata -P @localstatedir_POST@/run/netdata.pid -D
+pid-file = @localstatedir_POST@/run/netdata.pid
+options = signal-process-only
+load-options = export-passwd-vars
+depends-on = early-fs-local.target
+after = network.target

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -29,7 +29,7 @@ DUMP_CMDS=0
 ENABLE="auto"
 EXPORT_CMDS=0
 INSTALL=1
-LINUX_INIT_TYPES="systemd openrc lsb initd runit"
+LINUX_INIT_TYPES="systemd openrc lsb initd runit dinit"
 PLATFORM="$(uname -s)"
 SHOW_SVC_TYPE=0
 SVC_SOURCE="@libsysdir_POST@"
@@ -560,6 +560,43 @@ install_runit_service() {
 runit_cmds() {
   NETDATA_START_CMD="sv start netdata"
   NETDATA_STOP_CMD="sv stop netdata"
+}
+
+# =====================================================================
+# dinit support functions
+
+_check_dinit() {
+  # if /etc/dinit.d does not exist, it’s not dinit
+  [ ! -d /etc/dinit.d ] && echo "NO" && return 0
+
+  # if PID 1 is dinit, it’s dinit
+  [ "$(basename "$(readlink /proc/1/exe)" 2> /dev/null)" = "dinit" ] && echo "YES" && return 0
+
+  # if /run/dinitctl exists and is a socket, it’s dinit
+  [ -S /run/dinitctl ] && echo "YES" && return 0
+
+  # if the dinitctl command exists despite getting to this point, it’s dinit, but not booted as such
+  [ -n "$(command -v dinitctl 2>/dev/null || true)" ] && echo "OFFLINE" && return 0
+
+  echo "NO" && return 0
+}
+
+check_dinit() {
+  if [ -z "${IS_DINIT}" ]; then
+    IS_DINIT="$(_check_dinit)"
+  fi
+
+  echo "${IS_DINIT}"
+}
+
+install_dinit_service() {
+  echo "${DINIT_ERROR_MSG}"
+  exit 3
+}
+
+dinit_cmds() {
+  echo "${DINIT_ERROR_MSG}"
+  exit 3
 }
 
 # =====================================================================

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -589,14 +589,36 @@ check_dinit() {
   echo "${IS_DINIT}"
 }
 
+_run_dinitctl() {
+  opts=''
+
+  if [ "$(check_dinit)" = "OFFLINE" ]; then
+    opts="-o"
+  fi
+
+  # shellcheck disable=SC2086
+  dinitctl ${opts} "${@}"
+}
+
+enable_dinit() {
+  _run_dinitctl enable netdata
+}
+
+enable_dinit() {
+  _run_dinitctl disable netdata
+}
+
 install_dinit_service() {
-  echo "${DINIT_ERROR_MSG}"
-  exit 3
+  install_generic_service dinit/netdata "dinit" /etc/dinit.d enable_dinit disable_dinit
 }
 
 dinit_cmds() {
-  echo "${DINIT_ERROR_MSG}"
-  exit 3
+  if [ "$(check_dinit)" = "YES" ]; then
+    NETDATA_START_CMD='dinitctl start netdata'
+    NETDATA_STOP_CMD='dinitct stop netdata'
+  else # Not booted using dinit, use external defaults by not providing commands.
+    warning "Detected dinit, but the system is not booted using dinit. Unable to provide commands to start or stop Netdata using the service manager."
+  fi
 }
 
 # =====================================================================


### PR DESCRIPTION
##### Summary

This adds basic support for installing Netdata as a system service on systems using [dinit](https://davmac.org/projects/dinit/) as a service manager. Such systems are not particularly common, but support for them is also extremely simple to provide, so there’s not much downside to providing such support.

So far this is minimally tested, just enough to ensure that the detection logic works correctly and that the dinit service file passes `dinitcheck` once put in the right place. Testing has only been done thus far on [Chimera Liinux](https://chimera-linux.org/), as that is the only pre-built Linux distribution that uses dinit by default (some other distros, such as Artix, Devuan, and Gentoo, can theoretically use it, but they require a nontrivial amount of manual setup and are thus less than ideal for testing).

##### Test Plan

Testing requires building and installing the agent on a system that uses dinit as it’s init system. The easiest platform for this is the aforementioned Chimera Linux, though this is as of right now not supported by our dependency handling script, and as such requires some manual set up of our dependencies (everything needed for a basic build appears to be available between the main and contrib repos, it’s just a matter of installing the packages).