### PR TITLE
Improve service thread shutdown

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -357,6 +357,12 @@ void netdata_cleanup_and_exit(int ret, const char *action, const char *action_re
             | SERVICE_ACLKSYNC
             );
 
+    delta_shutdown_time("stop maintenance thread");
+
+    timeout = !service_wait_exit(
+        SERVICE_MAINTENANCE
+        , 3 * USEC_PER_SEC);
+
     delta_shutdown_time("stop replication, exporters, health and web servers threads");
 
     timeout = !service_wait_exit(
@@ -392,12 +398,6 @@ void netdata_cleanup_and_exit(int ret, const char *action, const char *action_re
 
     timeout = !service_wait_exit(
             SERVICE_CONTEXT
-            , 3 * USEC_PER_SEC);
-
-    delta_shutdown_time("stop maintenance thread");
-
-    timeout = !service_wait_exit(
-            SERVICE_MAINTENANCE
             , 3 * USEC_PER_SEC);
 
     delta_shutdown_time("clear web client cache");

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -307,12 +307,18 @@ void *service_main(void *ptr)
     heartbeat_t hb;
     heartbeat_init(&hb);
     usec_t step = USEC_PER_SEC * SERVICE_HEARTBEAT;
+    usec_t real_step = USEC_PER_SEC;
 
     netdata_log_debug(D_SYSTEM, "Service thread starts");
 
     while (service_running(SERVICE_MAINTENANCE)) {
         worker_is_idle();
-        heartbeat_next(&hb, step);
+        heartbeat_next(&hb, USEC_PER_SEC);
+        if (real_step < step) {
+            real_step += USEC_PER_SEC;
+            continue;
+        }
+        real_step = USEC_PER_SEC;
 
         svc_rrd_cleanup_obsolete_charts_from_all_hosts();
         svc_rrdhost_cleanup_orphan_hosts(localhost);


### PR DESCRIPTION
##### Summary
- Ensure the service thread concludes first during shutdown.
- The service thread now pauses in one-second intervals.
