### PR TITLE
kickstart: use extended-regexp in `get_redirect()`

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -639,9 +639,9 @@ get_redirect() {
   url="${1}"
 
   if [ -n "${CURL}" ]; then
-    run sh -c "${CURL} ${url} -s -L -I -o /dev/null -w '%{url_effective}' | grep -o '[^/]*$'" || return 1
+    run sh -c "${CURL} ${url} -s -L -I -o /dev/null -w '%{url_effective}' | grep -Eo '[^/]+$'" || return 1
   elif command -v wget > /dev/null 2>&1; then
-    run sh -c "wget -S -O /dev/null ${url} 2>&1 | grep -m 1 Location | grep -o '[^/]*$'" || return 1
+    run sh -c "wget -S -O /dev/null ${url} 2>&1 | grep -m 1 Location | grep -Eo '[^/]+$'" || return 1
   else
     fatal "${ERROR_F0003}" F0003
   fi


### PR DESCRIPTION
##### Summary

Fixes: #16842.

`grep` + `--only-matching` (`-o`) + `*` in pattern match is [broken on macOS Sonoma](https://forums.developer.apple.com/forums/thread/738862). 

The workaround is using `+` instead of `*`.

##### Test Plan

- master branch

```bash
$ curl https://github.com/netdata/netdata/releases/latest -s -L -I -o /dev/null -w '%{url_effective}' | grep -o "[^/]*$"
Assertion failed: (advance > 0), function procline, file util.c, line 732.
Abort trap: 6
```

- this PR

```bash
$ curl https://github.com/netdata/netdata/releases/latest -s -L -I -o /dev/null -w '%{url_effective}' | grep -Eo "[^/]+$"
v1.44.1
```

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
