### PR TITLE
Include timer units failed state alert as default

### DIFF
--- a/health/health.d/systemdunits.conf
+++ b/health/health.d/systemdunits.conf
@@ -159,3 +159,19 @@ component: Systemd units
   summary: systemd unit ${label:unit_name} state
      info: systemd slice units in the failed state
        to: sysadmin
+
+## Timer units
+ template: systemd_timer_unit_failed_state
+       on: systemd.timer_unit_state
+    class: Errors
+     type: Linux
+component: Systemd units
+   module: !* *
+     calc: $failed
+    units: state
+    every: 10s
+     warn: $this != nan AND $this == 1
+    delay: down 5m multiplier 1.5 max 1h
+  summary: systemd unit ${label:unit_name} state
+     info: systemd timer unit in the failed state
+       to: sysadmin


### PR DESCRIPTION
##### Summary

I am sure I am not the only one that needs it. 

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
