### PR TITLE
Disable local Go builds in our RPM packages.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -45,12 +45,14 @@ AutoReqProv: yes
 %endif
 
 # Disable go.d.plugin build on outdated golang distros
+%if 0
 %if 0%{?centos_ver:1}
 %if 0%{?centos_ver} >= 10 && 0%{?almalinux_ver:1} && 0%{?rocky_ver:1}
 %global _golang_build 1
 %else
 %global _golang_build 0
 %global _missing_build_ids_terminate_build 0
+%endif
 %endif
 %endif
 
@@ -263,10 +265,12 @@ BuildRequires: cups-devel
 # end - cups plugin dependencies
 
 # go.d.plugin dependencies
+%if 0%{?_golang_build}
 %if 0%{?suse_version}
 BuildRequires: go
 %else
 BuildRequires: golang
+%endif
 %endif
 # end - go.d.plugin plugin dependencies
 


### PR DESCRIPTION
##### Summary

We’re in the process of migrating the Go collectors to be part of the main repo (see #16808 for more details on that), and some of the intermediate steps don’t pay nice with the current code in the spec file for handling of the Go plugin, so stub it out for now.

Long-term this code is going to be removed completely (and some special stuff will be done to handle the dependencies correctly since we need a very recent version of Go that is not included on _most_ platforms), as the Go code will be handled automatically as part of the CMake build process, but for now it’s in the way and it’s simpler to just stub it out.

##### Test Plan

CI passes on this PR.