### PR TITLE
Add ARMv6 static builds.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,6 +152,7 @@ jobs:
       matrix:
         arch:
           - x86_64
+          - armv6l
           - armv7l
           - aarch64
           - ppc64le

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -177,9 +177,9 @@ means that they generally do not support non-local username mappings or exotic n
 
 We currently provide static builds for the following CPU architectures:
 
-- 32-bit x86
 - 64-bit x86
 - ARMv7
+- ARMv6
 - AArch64
 - POWER8+
 
@@ -189,3 +189,8 @@ We currently provide static builds for the following CPU architectures:
 
 Our IPMI collector is based on FreeIPMI. Due to upstream limitations in FreeIPMI, we are unable to support our
 IPMI collector on POWER-based hardware.
+
+### Systemd
+
+Many of our systemd integrations are not supported in our static builds. This is due to a general refusal by the
+systemd developers to support static linking (or any C runtime other than glibc), and is not something we can resolve.

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -24,7 +24,7 @@ PATH="${PATH}:/usr/local/bin:/usr/local/sbin"
 REPOCONFIG_DEB_VERSION="2-2"
 REPOCONFIG_RPM_VERSION="2-2"
 START_TIME="$(date +%s)"
-STATIC_INSTALL_ARCHES="x86_64 armv7l aarch64 ppc64le"
+STATIC_INSTALL_ARCHES="x86_64 armv7l armv6l aarch64 ppc64le"
 
 # ======================================================================
 # URLs used throughout the script
@@ -1902,9 +1902,13 @@ prepare_offline_install_source() {
         for arch in ${STATIC_INSTALL_ARCHES}; do
           set_static_archive_urls "${SELECTED_RELEASE_CHANNEL}" "${arch}"
 
-          progress "Fetching ${NETDATA_STATIC_ARCHIVE_URL}"
-          if ! download "${NETDATA_STATIC_ARCHIVE_URL}" "netdata-${arch}-latest.gz.run"; then
-            warning "Failed to download static installer archive for ${arch}. ${BADNET_MSG}."
+          if check_for_remote_file "${NETDATA_STATIC_ARCH_URL}"; then
+            progress "Fetching ${NETDATA_STATIC_ARCHIVE_URL}"
+            if ! download "${NETDATA_STATIC_ARCHIVE_URL}" "netdata-${arch}-latest.gz.run"; then
+                warning "Failed to download static installer archive for ${arch}. ${BADNET_MSG}."
+            fi
+          else
+            progress "Skipping ${NETDATA_STATIC_ARCHIVE_URL} as it does not exist on the server."
           fi
         done
         legacy=0

--- a/packaging/makeself/uname2platform.sh
+++ b/packaging/makeself/uname2platform.sh
@@ -8,6 +8,7 @@ BUILDARCH="${1}"
 
 case "${BUILDARCH}" in
   x86_64) echo "linux/amd64" ;;
+  armv6l) echo "linux/arm/v6" ;;
   armv7l) echo "linux/arm/v7" ;;
   aarch64) echo "linux/arm64/v8" ;;
   ppc64le) echo "linux/ppc64le" ;;


### PR DESCRIPTION
##### Summary

This adds ARMv6 support to our static build infrastructure, including starting publishing ARMv6 static builds.

These are thus far minimally tested, but should work on any ARMv6zk hardware with hardware floating point support, including most 32-bit Raspberry Pi systems (other than the Pico) and a majority of equivalent-spec competitors of a similar vintage.

##### Test Plan

CI passes on this PR.

##### Additional Information

Relevant to #16846