### PR TITLE
add freebsd jail detection to system-info.sh

### DIFF
--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -101,6 +101,10 @@ if [ "${CONTAINER}" = "unknown" ]; then
     CONT_DETECTION="kubernetes"
   fi
 
+  if [ "${KERNEL_NAME}" = FreeBSD ] && command -v sysctl && sysctl security.jail.jailed 2>/dev/null | grep -q "1$"; then
+    CONTAINER="jail"
+    CONT_DETECTION="sysctl"
+  fi
 fi
 
 # -------------------------------------------------------------------------------------------------

--- a/daemon/system-info.sh
+++ b/daemon/system-info.sh
@@ -57,7 +57,7 @@ if [ -z "${VIRTUALIZATION}" ]; then
     VIRTUALIZATION="unknown"
     VIRT_DETECTION="none"
   elif [ "$VIRTUALIZATION" != "none" ] && [ "$VIRTUALIZATION" != "unknown" ]; then
-    VIRTUALIZATION=$(virtualization_normalize_name $VIRTUALIZATION)
+    VIRTUALIZATION=$(virtualization_normalize_name "$VIRTUALIZATION")
   fi
 else
   # Passed from outside - probably in docker run


### PR DESCRIPTION
##### Summary

Fixes: #16852

https://man.freebsd.org/cgi/man.cgi?jail(8)

> The read-only entry security.jail.jailed	can be used to determine if  a process is running inside a jail	(value is one) or not (value is	zero).


```bash
$ sysctl security.jail.jailed
security.jail.jailed: 0
```


##### Test Plan

Tested on FreeBSD.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
