### PR TITLE
detect sockets direction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1946,7 +1946,8 @@ if(ENABLE_PLUGIN_EBPF)
 endif()
 
 if(ENABLE_PLUGIN_LOCAL_LISTENERS)
-        set(LOCAL_LISTENERS_FILES collectors/plugins.d/local_listeners.c)
+        set(LOCAL_LISTENERS_FILES collectors/plugins.d/local_listeners.c
+                collectors/plugins.d/local-sockets.h)
 
         add_executable(local-listeners ${LOCAL_LISTENERS_FILES})
         target_link_libraries(local-listeners libnetdata)

--- a/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1308,8 +1308,8 @@ static inline int update_memory_limits(struct cgroup *cg) {
                     return 1;
                 }
             } else {
-                char buffer[30 + 1];
-                int ret = read_file(*filename, buffer, 30);
+                char buffer[32];
+                int ret = read_txt_file(*filename, buffer, sizeof(buffer));
                 if(ret) {
                     collector_error("Cannot refresh cgroup %s memory limit by reading '%s'. Will not update its limit anymore.", cg->id, *filename);
                     freez(*filename);

--- a/collectors/debugfs.plugin/debugfs_zswap.c
+++ b/collectors/debugfs.plugin/debugfs_zswap.c
@@ -370,7 +370,7 @@ static int debugfs_is_zswap_enabled()
     snprintfz(filename, FILENAME_MAX, "/sys/module/zswap/parameters/enabled"); // host prefix is not needed here
     char state[ZSWAP_STATE_SIZE + 1];
 
-    int ret = read_file(filename, state, ZSWAP_STATE_SIZE);
+    int ret = read_txt_file(filename, state, sizeof(state));
 
     if (unlikely(!ret && !strcmp(state, "Y"))) {
         return 0;

--- a/collectors/debugfs.plugin/sys_devices_virtual_powercap.c
+++ b/collectors/debugfs.plugin/sys_devices_virtual_powercap.c
@@ -27,7 +27,7 @@ static struct zone_t *get_rapl_zone(const char *control_type __maybe_unused, str
     snprintfz(temp, FILENAME_MAX, "%s/%s", dirname, "name");
 
     char name[FILENAME_MAX + 1] = "";
-    if (read_file(temp, name, sizeof(name) - 1) != 0)
+    if (read_txt_file(temp, name, sizeof(name)) != 0)
         return NULL;
 
     char *trimmed = trim(name);

--- a/collectors/plugins.d/local-sockets.h
+++ b/collectors/plugins.d/local-sockets.h
@@ -1,0 +1,569 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_LOCAL_SOCKETS_H
+#define NETDATA_LOCAL_SOCKETS_H
+
+#include "libnetdata/libnetdata.h"
+
+struct local_socket;
+#define SIMPLE_HASHTABLE_VALUE_TYPE struct local_socket
+#define SIMPLE_HASHTABLE_NAME _LOCAL_SOCKET
+#include "libnetdata/simple_hashtable.h"
+
+union ipv46;
+#define SIMPLE_HASHTABLE_VALUE_TYPE union ipv46
+#define SIMPLE_HASHTABLE_NAME _LOCAL_IP
+#include "libnetdata/simple_hashtable.h"
+
+struct local_port;
+#define SIMPLE_HASHTABLE_VALUE_TYPE struct local_port
+#define SIMPLE_HASHTABLE_NAME _LOCAL_PORT
+#include "libnetdata/simple_hashtable.h"
+
+struct local_socket_state;
+typedef void (*local_sockets_cb_t)(struct local_socket_state *state, struct local_socket *n, void *data);
+
+typedef struct local_socket_state {
+    struct {
+        bool listening;
+        bool inbound;
+        bool outbound;
+        bool local;
+        bool tcp4;
+        bool tcp6;
+        bool udp4;
+        bool udp6;
+        bool pid;
+        bool cmdline;
+        bool comm;
+        size_t max_errors;
+
+        local_sockets_cb_t cb;
+        void *data;
+    } config;
+
+    struct {
+        size_t pid_fds_processed;
+        size_t pid_fds_failed;
+        size_t errors_encountered;
+    } stats;
+
+    SIMPLE_HASHTABLE_LOCAL_SOCKET sockets_hashtable;
+    SIMPLE_HASHTABLE_LOCAL_IP local_ips_hashtable;
+    SIMPLE_HASHTABLE_LOCAL_PORT listening_ports_hashtable;
+} LS_STATE;
+
+// --------------------------------------------------------------------------------------------------------------------
+
+typedef enum __attribute__((packed)) {
+    SOCKET_DIRECTION_LISTEN = (1 << 0),     // a listening socket
+    SOCKET_DIRECTION_INBOUND = (1 << 1),    // an inbound socket connecting a remote system to a local listening socket
+    SOCKET_DIRECTION_OUTBOUND = (1 << 2),   // a socket initiated by this system, connecting to another system
+    SOCKET_DIRECTION_LOCAL = (1 << 3),      // the socket connecting 2 localhost applications
+} SOCKET_DIRECTION;
+
+#ifndef TASK_COMM_LEN
+#define TASK_COMM_LEN 16
+#endif
+
+union ipv46 {
+    uint32_t ipv4;
+    struct in6_addr ipv6;
+};
+
+struct local_port {
+    uint16_t protocol;
+    uint16_t family;
+    uint16_t port;
+};
+
+struct socket_endpoint {
+    uint16_t port;
+    union ipv46 ip;
+};
+
+static inline void ipv6_to_in6_addr(const char *ipv6_str, struct in6_addr *d) {
+    char buf[9];
+
+    for (size_t k = 0; k < 4; ++k) {
+        memcpy(buf, ipv6_str + (k * 8), 8);
+        buf[sizeof(buf) - 1] = '\0';
+        d->s6_addr32[k] = strtoul(buf, NULL, 16);
+    }
+}
+
+typedef struct local_socket {
+    unsigned int inode;
+
+    uint16_t protocol;
+    uint16_t family;
+    int state;
+    struct socket_endpoint local;
+    struct socket_endpoint remote;
+    pid_t pid;
+
+    SOCKET_DIRECTION direction;
+
+    char comm[TASK_COMM_LEN];
+    char *cmdline;
+
+    struct local_port local_port_key;
+
+    XXH64_hash_t local_ip_hash;
+    XXH64_hash_t remote_ip_hash;
+    XXH64_hash_t local_port_hash;
+} LOCAL_SOCKET;
+
+// --------------------------------------------------------------------------------------------------------------------
+
+static inline void ll_log(LS_STATE *ls, const char *format, ...) __attribute__ ((format(__printf__, 2, 3)));
+static inline void ll_log(LS_STATE *ls, const char *format, ...) {
+    if(++ls->stats.errors_encountered >= ls->config.max_errors)
+        return;
+
+    char buf[16384];
+    va_list args;
+    va_start(args, format);
+    vsnprintf(buf, sizeof(buf), format, args);
+    va_end(args);
+
+    nd_log(NDLS_COLLECTORS, NDLP_ERR, "LOCAL-LISTENERS: %s", buf);
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+static void foreach_local_socket_call_cb_and_cleanup(LS_STATE *ls) {
+    for (unsigned int i = 0; i < ls->sockets_hashtable.size; i++) {
+        SIMPLE_HASHTABLE_SLOT_LOCAL_SOCKET *sl = &ls->sockets_hashtable.hashtable[i];
+        LOCAL_SOCKET *n = SIMPLE_HASHTABLE_SLOT_DATA(sl);
+        if(!n) continue;
+
+        if((ls->config.listening && n->direction & SOCKET_DIRECTION_LISTEN) ||
+            (ls->config.local && n->direction & SOCKET_DIRECTION_LOCAL) ||
+            (ls->config.inbound && n->direction & SOCKET_DIRECTION_INBOUND) ||
+            (ls->config.outbound && n->direction & SOCKET_DIRECTION_OUTBOUND)
+        ) {
+            // we have to call the callback for this socket
+            if (ls->config.cb)
+                ls->config.cb(ls, n, ls->config.data);
+        }
+
+        freez(n->cmdline);
+        freez(n);
+    }
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+static inline void fix_cmdline(char* str) {
+    char *s = str;
+
+    // map invalid characters to underscores
+    while(*s) {
+        if(*s == '|' || iscntrl(*s)) *s = '_';
+        s++;
+    }
+}
+
+static inline bool associate_inode_with_pid(LS_STATE *ls, unsigned int inode, pid_t pid) {
+    SIMPLE_HASHTABLE_SLOT_LOCAL_SOCKET *sl = simple_hashtable_get_slot_LOCAL_SOCKET(&ls->sockets_hashtable, inode, &inode, false);
+    LOCAL_SOCKET *n = SIMPLE_HASHTABLE_SLOT_DATA(sl);
+    if(!n) return false;
+
+    n->pid = pid;
+
+    if(ls->config.cmdline || ls->config.comm) {
+        char cmdline[8192] = "";
+        char filename[FILENAME_MAX + 1];
+        snprintfz(filename, FILENAME_MAX, "%s/proc/%d/cmdline", netdata_configured_host_prefix, pid);
+
+        if(ls->config.cmdline) {
+            if (read_proc_cmdline(filename, cmdline, sizeof(cmdline)))
+                ll_log(ls, "cannot open file: %s\n", filename);
+            else {
+                fix_cmdline(cmdline);
+
+                char *s = trim(cmdline);
+
+                if(s) {
+                    // replace it
+                    freez(n->cmdline);
+                    n->cmdline = strdupz(s);
+                }
+            }
+        }
+
+        if(ls->config.comm) {
+            n->comm[0] = '\0';
+            snprintfz(filename, FILENAME_MAX, "%s/proc/%d/comm", netdata_configured_host_prefix, pid);
+            if (read_txt_file(filename, n->comm, sizeof(n->comm)))
+                ll_log(ls, "cannot open file: %s\n", filename);
+            else {
+                size_t len = strlen(n->comm);
+                if(n->comm[len - 1] == '\n')
+                    n->comm[len - 1] = '\0';
+            }
+        }
+    }
+
+    return true;
+}
+
+// ----------------------------------------------------------------------------
+
+static inline bool find_all_sockets_in_proc(LS_STATE *ls, const char *proc_filename) {
+    DIR *proc_dir, *fd_dir;
+    struct dirent *proc_entry, *fd_entry;
+    char path_buffer[FILENAME_MAX + 1];
+
+    proc_dir = opendir(proc_filename);
+    if (proc_dir == NULL) {
+        ll_log(ls, "cannot opendir() '%s'", proc_filename);
+        ls->stats.pid_fds_failed++;
+        return false;
+    }
+
+    while ((proc_entry = readdir(proc_dir)) != NULL) {
+        // Check if directory entry is a PID by seeing if the name is made up of digits only
+        int is_pid = 1;
+        for (char *c = proc_entry->d_name; *c != '\0'; c++) {
+            if (*c < '0' || *c > '9') {
+                is_pid = 0;
+                break;
+            }
+        }
+
+        if (!is_pid)
+            continue;
+
+        // Build the path to the fd directory of the process
+        snprintfz(path_buffer, FILENAME_MAX, "%s/%s/fd/", proc_filename, proc_entry->d_name);
+
+        fd_dir = opendir(path_buffer);
+        if (fd_dir == NULL) {
+            ll_log(ls, "cannot opendir() '%s'", path_buffer);
+
+            ls->stats.pid_fds_failed++;
+            continue;
+        }
+
+        while ((fd_entry = readdir(fd_dir)) != NULL) {
+            if(!strcmp(fd_entry->d_name, ".") || !strcmp(fd_entry->d_name, ".."))
+                continue;
+
+            char link_path[FILENAME_MAX + 1];
+            char link_target[FILENAME_MAX + 1];
+            unsigned inode;
+
+            // Build the path to the file descriptor link
+            snprintfz(link_path, FILENAME_MAX, "%s/%s", path_buffer, fd_entry->d_name);
+
+            ssize_t len = readlink(link_path, link_target, sizeof(link_target) - 1);
+            if (len == -1) {
+                ll_log(ls, "cannot read link '%s'", link_path);
+
+                ls->stats.pid_fds_failed++;
+                continue;
+            }
+            link_target[len] = '\0';
+
+            ls->stats.pid_fds_processed++;
+
+            // If the link target indicates a socket, print its inode number
+            if (sscanf(link_target, "socket:[%u]", &inode) == 1)
+                associate_inode_with_pid(ls, inode, (pid_t)strtoul(proc_entry->d_name, NULL, 10));
+        }
+
+        closedir(fd_dir);
+    }
+
+    closedir(proc_dir);
+    return true;
+}
+
+// ----------------------------------------------------------------------------
+
+static bool is_ipv4_mapped_ipv6_address(const struct in6_addr *addr) {
+    // An IPv4-mapped IPv6 address starts with 80 bits of zeros followed by 16 bits of ones
+    static const unsigned char ipv4_mapped_prefix[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF };
+    return memcmp(addr->s6_addr, ipv4_mapped_prefix, 12) == 0;
+}
+
+static bool is_loopback_address(const void *ip, uint16_t family) {
+    if (family == AF_INET) {
+        // For IPv4, loopback addresses are in the 127.0.0.0/8 range
+        const uint32_t addr = ntohl(*((const uint32_t *)ip)); // Convert to host byte order for comparison
+        return (addr >> 24) == 127; // Check if the first byte is 127
+    } else if (family == AF_INET6) {
+        // Check if the address is an IPv4-mapped IPv6 address
+        const struct in6_addr *ipv6_addr = (const struct in6_addr *)ip;
+        if (is_ipv4_mapped_ipv6_address(ipv6_addr)) {
+            // Extract the last 32 bits (IPv4 address) and check if it's in the 127.0.0.0/8 range
+            const uint32_t ipv4_addr = ntohl(*((const uint32_t *)(ipv6_addr->s6_addr + 12)));
+            return (ipv4_addr >> 24) == 127;
+        }
+
+        // For IPv6, loopback address is ::1
+        const struct in6_addr loopback_ipv6 = IN6ADDR_LOOPBACK_INIT;
+        return memcmp(ipv6_addr, &loopback_ipv6, sizeof(struct in6_addr)) == 0;
+    }
+
+    return false;
+}
+
+static bool is_zero_address(const void *ip, uint16_t family) {
+    if (family == AF_INET) {
+        // For IPv4, check if the address is not 0.0.0.0
+        const uint32_t zero_ipv4 = 0; // Zero address in network byte order
+        return memcmp(ip, &zero_ipv4, sizeof(uint32_t)) == 0;
+    } else if (family == AF_INET6) {
+        // For IPv6, check if the address is not ::
+        const struct in6_addr zero_ipv6 = IN6ADDR_ANY_INIT;
+        return memcmp(ip, &zero_ipv6, sizeof(struct in6_addr)) == 0;
+    }
+
+    return false;
+}
+
+static inline bool read_proc_net_x(LS_STATE *ls, const char *filename, uint16_t family, uint16_t protocol) {
+    if(family != AF_INET && family != AF_INET6)
+        return false;
+
+    FILE *fp;
+    char *line = NULL;
+    size_t len = 0;
+    ssize_t read;
+
+    fp = fopen(filename, "r");
+    if (fp == NULL)
+        return false;
+
+    ssize_t min_line_length = (family == AF_INET) ? 105 : 155;
+    size_t counter = 0;
+
+    // Read line by line
+    while ((read = getline(&line, &len, fp)) != -1) {
+        if(counter++ == 0) continue; // skip the first line
+
+        if(read < min_line_length) {
+            ll_log(ls, "too small line No %zu of filename '%s': %s", counter, filename, line);
+            continue;
+        }
+
+        unsigned int local_address, local_port, state, remote_address, remote_port, inode = 0;
+        char local_address6[33], remote_address6[33];
+
+        if(family == AF_INET) {
+            if (sscanf(line, "%*d: %X:%X %X:%X %X %*X:%*X %*X:%*X %*X %*d %*d %u",
+                       &local_address, &local_port, &remote_address, &remote_port, &state, &inode) != 6) {
+                ll_log(ls, "cannot parse ipv4 line No %zu of filename '%s': %s", counter, filename, line);
+                continue;
+            }
+        }
+        else if(family == AF_INET6) {
+            if(sscanf(line, "%*d: %32[0-9A-Fa-f]:%X %32[0-9A-Fa-f]:%X %X %*X:%*X %*X:%*X %*X %*d %*d %u",
+                       local_address6, &local_port, remote_address6, &remote_port, &state, &inode) != 6) {
+                ll_log(ls, "cannot parse ipv6 line No %zu of filename '%s': %s", counter, filename, line);
+                continue;
+            }
+        }
+        if(!inode) continue;
+
+        SIMPLE_HASHTABLE_SLOT_LOCAL_SOCKET *sl = simple_hashtable_get_slot_LOCAL_SOCKET(&ls->sockets_hashtable, inode, &inode, true);
+        LOCAL_SOCKET *n = SIMPLE_HASHTABLE_SLOT_DATA(sl);
+        if(n) {
+            ll_log(ls, "inode %u given on line %zu of filename '%s', already exists in hashtable - ignoring duplicate", inode, counter, filename);
+            continue;
+        }
+
+        // allocate a new socket and index it
+
+        n = (LOCAL_SOCKET *)callocz(1, sizeof(LOCAL_SOCKET));
+
+        if(family == AF_INET) {
+            n->local.ip.ipv4 = local_address;
+            n->remote.ip.ipv4 = remote_address;
+        }
+        else if(family == AF_INET6) {
+            ipv6_to_in6_addr(local_address6, &n->local.ip.ipv6);
+            ipv6_to_in6_addr(remote_address6, &n->remote.ip.ipv6);
+        }
+
+        n->direction = 0;
+        n->protocol = protocol;
+        n->family = family;
+        n->state = (int)state;
+        n->inode = inode;
+        n->local.port = local_port;
+        n->remote.port = remote_port;
+        n->protocol = protocol;
+
+        n->local_port_key.port = n->local.port;
+        n->local_port_key.family = n->family;
+        n->local_port_key.protocol = n->protocol;
+
+        n->local_ip_hash = XXH3_64bits(&n->local.ip, sizeof(n->local.ip));
+        n->remote_ip_hash = XXH3_64bits(&n->remote.ip, sizeof(n->remote.ip));
+        n->local_port_hash = XXH3_64bits(&n->local_port_key, sizeof(n->local_port_key));
+
+        simple_hashtable_set_slot_LOCAL_SOCKET(&ls->sockets_hashtable, sl, inode, n);
+
+        if(!is_zero_address(&n->local.ip, n->family)) {
+            // put all the local IPs into the local_ips hashtable
+            // so, we learn all local IPs the system has
+
+            SIMPLE_HASHTABLE_SLOT_LOCAL_IP *sl_ip =
+                simple_hashtable_get_slot_LOCAL_IP(&ls->local_ips_hashtable, n->local_ip_hash, &n->local.ip, true);
+
+            union ipv46 *ip = SIMPLE_HASHTABLE_SLOT_DATA(sl_ip);
+            if(!ip)
+                simple_hashtable_set_slot_LOCAL_IP(&ls->local_ips_hashtable, sl_ip, n->local_ip_hash, &n->local.ip);
+        }
+
+        if((n->protocol == IPPROTO_TCP && n->state == TCP_LISTEN) || is_zero_address(&n->local.ip, n->family) || is_zero_address(&n->remote.ip, n->family)) {
+            // the socket is either in a TCP LISTEN, or
+            // the remote address is zero
+            n->direction |= SOCKET_DIRECTION_LISTEN;
+        }
+        else if(is_loopback_address(&n->local.ip, n->family) || is_loopback_address(&n->remote.ip, n->family)) {
+            // the local IP address is loopback
+            n->direction |= SOCKET_DIRECTION_LOCAL;
+        }
+        else {
+            // we can't say yet if it is inbound or outboud
+            // so, mark it as both inbound and outbound
+            n->direction |= SOCKET_DIRECTION_INBOUND | SOCKET_DIRECTION_OUTBOUND;
+        }
+
+        if(n->direction & SOCKET_DIRECTION_LISTEN) {
+            // for the listening sockets, keep a hashtable with all the local ports
+            // so that we will be able to detect INBOUND sockets
+
+            SIMPLE_HASHTABLE_SLOT_LOCAL_PORT *sl_port =
+                simple_hashtable_get_slot_LOCAL_PORT(&ls->listening_ports_hashtable, n->local_port_hash, &n->local_port_key, true);
+
+            struct local_port *port = SIMPLE_HASHTABLE_SLOT_DATA(sl_port);
+            if(!port)
+                simple_hashtable_set_slot_LOCAL_PORT(&ls->listening_ports_hashtable, sl_port, n->local_port_hash, &n->local_port_key);
+        }
+    }
+
+    fclose(fp);
+
+    if (line)
+        freez(line);
+
+    return true;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+static inline void local_sockets_detect_directions(LS_STATE *ls) {
+    for (unsigned int i = 0; i < ls->sockets_hashtable.size; i++) {
+        SIMPLE_HASHTABLE_SLOT_LOCAL_SOCKET *sl = &ls->sockets_hashtable.hashtable[i];
+        LOCAL_SOCKET *n = SIMPLE_HASHTABLE_SLOT_DATA(sl);
+        if (!n) continue;
+
+        if ((n->direction & (SOCKET_DIRECTION_INBOUND|SOCKET_DIRECTION_OUTBOUND)) !=
+            (SOCKET_DIRECTION_INBOUND|SOCKET_DIRECTION_OUTBOUND))
+            continue;
+
+        // check if the remote IP is one of our local IPs
+        {
+            SIMPLE_HASHTABLE_SLOT_LOCAL_IP *sl_ip =
+                simple_hashtable_get_slot_LOCAL_IP(&ls->local_ips_hashtable, n->remote_ip_hash, &n->remote.ip, false);
+
+            union ipv46 *d = SIMPLE_HASHTABLE_SLOT_DATA(sl_ip);
+            if (d) {
+                // the remote IP of this socket is one of our local IPs
+                n->direction &= ~(SOCKET_DIRECTION_INBOUND|SOCKET_DIRECTION_OUTBOUND);
+                n->direction |= SOCKET_DIRECTION_LOCAL;
+                continue;
+            }
+        }
+
+        // check if the local port is one of our listening ports
+        {
+            SIMPLE_HASHTABLE_SLOT_LOCAL_PORT *sl_port =
+                simple_hashtable_get_slot_LOCAL_PORT(&ls->listening_ports_hashtable, n->local_port_hash, &n->local_port_key, false);
+
+            struct local_port *port = SIMPLE_HASHTABLE_SLOT_DATA(sl_port); // do not reference this pointer - is invalid
+            if(port) {
+                // the local port of this socket is a port we listen to
+                n->direction &= ~SOCKET_DIRECTION_OUTBOUND;
+            }
+            else
+                n->direction &= ~SOCKET_DIRECTION_INBOUND;
+        }
+    }
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+static inline void local_sockets_process(LS_STATE *ls) {
+    char path[FILENAME_MAX + 1];
+
+    simple_hashtable_init_LOCAL_SOCKET(&ls->sockets_hashtable, 65535);
+    simple_hashtable_init_LOCAL_IP(&ls->local_ips_hashtable, 1024);
+    simple_hashtable_init_LOCAL_PORT(&ls->listening_ports_hashtable, 1024);
+
+    if(ls->config.tcp4) {
+        snprintfz(path, FILENAME_MAX, "%s/proc/net/tcp", netdata_configured_host_prefix);
+        read_proc_net_x(ls, path, AF_INET, IPPROTO_TCP);
+    }
+
+    if(ls->config.udp4) {
+        snprintfz(path, FILENAME_MAX, "%s/proc/net/udp", netdata_configured_host_prefix);
+        read_proc_net_x(ls, path, AF_INET, IPPROTO_UDP);
+    }
+
+    if(ls->config.tcp6) {
+        snprintfz(path, FILENAME_MAX, "%s/proc/net/tcp6", netdata_configured_host_prefix);
+        read_proc_net_x(ls, path, AF_INET6, IPPROTO_TCP);
+    }
+
+    if(ls->config.udp6) {
+        snprintfz(path, FILENAME_MAX, "%s/proc/net/udp6", netdata_configured_host_prefix);
+        read_proc_net_x(ls, path, AF_INET6, IPPROTO_UDP);
+    }
+
+    if(ls->config.cmdline || ls->config.comm || ls->config.pid) {
+        snprintfz(path, FILENAME_MAX, "%s/proc", netdata_configured_host_prefix);
+        find_all_sockets_in_proc(ls, path);
+    }
+
+    // detect the directions of the sockets
+    if(ls->config.inbound || ls->config.outbound || ls->config.local)
+        local_sockets_detect_directions(ls);
+
+    // this will call the callback for each socket and free the memory we use
+    foreach_local_socket_call_cb_and_cleanup(ls);
+
+    // free the hashtable
+    simple_hashtable_destroy_LOCAL_PORT(&ls->listening_ports_hashtable);
+    simple_hashtable_destroy_LOCAL_IP(&ls->local_ips_hashtable);
+    simple_hashtable_destroy_LOCAL_SOCKET(&ls->sockets_hashtable);
+}
+
+static inline void ipv6_address_to_txt(struct in6_addr *in6_addr, char *dst) {
+    struct sockaddr_in6 sa = { 0 };
+
+    sa.sin6_family = AF_INET6;
+    sa.sin6_port = htons(0);
+    sa.sin6_addr = *in6_addr;
+
+    // Convert to human-readable format
+    if (inet_ntop(AF_INET6, &(sa.sin6_addr), dst, INET6_ADDRSTRLEN) == NULL)
+        *dst = '\0';
+}
+
+static inline void ipv4_address_to_txt(uint32_t ip, char *dst) {
+    uint8_t octets[4];
+    octets[0] = ip & 0xFF;
+    octets[1] = (ip >> 8) & 0xFF;
+    octets[2] = (ip >> 16) & 0xFF;
+    octets[3] = (ip >> 24) & 0xFF;
+    sprintf(dst, "%u.%u.%u.%u", octets[0], octets[1], octets[2], octets[3]);
+}
+
+#endif //NETDATA_LOCAL_SOCKETS_H

--- a/collectors/plugins.d/local_listeners.c
+++ b/collectors/plugins.d/local_listeners.c
@@ -1,400 +1,264 @@
-#include "libnetdata/libnetdata.h"
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "local-sockets.h"
 #include "libnetdata/required_dummies.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <dirent.h>
-#include <string.h>
-#include <unistd.h>
-#include <ctype.h>
-#include <arpa/inet.h>
+// --------------------------------------------------------------------------------------------------------------------
 
-typedef enum {
-    PROC_NET_PROTOCOL_TCP,
-    PROC_NET_PROTOCOL_TCP6,
-    PROC_NET_PROTOCOL_UDP,
-    PROC_NET_PROTOCOL_UDP6,
-} PROC_NET_PROTOCOLS;
-
-#define MAX_ERROR_LOGS 10
-
-static size_t pid_fds_processed = 0;
-static size_t pid_fds_failed = 0;
-static size_t errors_encountered = 0;
-
-static inline const char *protocol_name(PROC_NET_PROTOCOLS protocol) {
-    switch(protocol) {
-        default:
-        case PROC_NET_PROTOCOL_TCP:
+static const char *protocol_name(LOCAL_SOCKET *n) {
+    if(n->family == AF_INET) {
+        if(n->protocol == IPPROTO_TCP)
             return "TCP";
-
-        case PROC_NET_PROTOCOL_UDP:
+        else if(n->protocol == IPPROTO_UDP)
             return "UDP";
-
-        case PROC_NET_PROTOCOL_TCP6:
+        else
+            return "UNKNOWN_IPV4";
+    }
+    else if(n->family == AF_INET6) {
+        if (n->protocol == IPPROTO_TCP)
             return "TCP6";
-
-        case PROC_NET_PROTOCOL_UDP6:
+        else if(n->protocol == IPPROTO_UDP)
             return "UDP6";
+        else
+            return "UNKNOWN_IPV6";
     }
+    else
+        return "UNKNOWN";
 }
 
-static inline int read_cmdline(pid_t pid, char* buffer, size_t bufferSize) {
-    char path[FILENAME_MAX + 1];
-    snprintfz(path, FILENAME_MAX, "%s/proc/%d/cmdline", netdata_configured_host_prefix, pid);
-
-    FILE* file = fopen(path, "r");
-    if (!file) {
-        if(++errors_encountered < MAX_ERROR_LOGS)
-            collector_error("LOCAL-LISTENERS: error opening file: %s\n", path);
-
-        return -1;
-    }
-
-    size_t bytesRead = fread(buffer, 1, bufferSize - 1, file);
-    buffer[bytesRead] = '\0';  // Ensure null-terminated
-
-    // Replace null characters in cmdline with spaces
-    for (size_t i = 0; i < bytesRead; i++) {
-        if (buffer[i] == '\0') {
-            buffer[i] = ' ';
-        }
-    }
-
-    fclose(file);
-    return 0;
-}
-
-static inline void fix_cmdline(char* str) {
-    if (str == NULL)
-        return;
-
-    char *s = str;
-
-    do {
-        if(*s == '|' || iscntrl(*s))
-            *s = '_';
-
-    } while(*++s);
-
-
-    while(s > str && *(s-1) == ' ')
-        *--s = '\0';
-}
-
-// ----------------------------------------------------------------------------
-
-#define HASH_TABLE_SIZE 100000
-
-typedef struct Node {
-    unsigned int inode; // key
-
-    // values
-    unsigned int port;
+static void print_local_listeners(LS_STATE *ls __maybe_unused, LOCAL_SOCKET *n, void *data __maybe_unused) {
     char local_address[INET6_ADDRSTRLEN];
-    PROC_NET_PROTOCOLS protocol;
-    bool processed;
+    char remote_address[INET6_ADDRSTRLEN];
 
-    // linking
-    struct Node *prev, *next;
-} Node;
-
-typedef struct HashTable {
-    Node *table[HASH_TABLE_SIZE];
-} HashTable;
-
-static HashTable *hashTable_key_inode_port_value = NULL;
-
-static inline void generate_output(const char *protocol, const char *address, unsigned int port, const char *cmdline) {
-    printf("%s|%s|%u|%s\n", protocol, address, port, cmdline);
-}
-
-HashTable* createHashTable() {
-    HashTable *hashTable = (HashTable*)mallocz(sizeof(HashTable));
-    memset(hashTable, 0, sizeof(HashTable));
-    return hashTable;
-}
-
-static inline unsigned int hashFunction(unsigned int inode) {
-    return inode % HASH_TABLE_SIZE;
-}
-
-static inline void insertHashTable(HashTable *hashTable, unsigned int inode, unsigned int port, PROC_NET_PROTOCOLS protocol, char *local_address) {
-    unsigned int index = hashFunction(inode);
-    Node *newNode = (Node*)mallocz(sizeof(Node));
-    newNode->inode = inode;
-    newNode->port = port;
-    newNode->protocol = protocol;
-    strncpyz(newNode->local_address, local_address, INET6_ADDRSTRLEN - 1);
-    DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(hashTable->table[index], newNode, prev, next);
-}
-
-static inline bool lookupHashTable_and_execute(HashTable *hashTable, unsigned int inode, pid_t pid) {
-    unsigned int index = hashFunction(inode);
-    for(Node *node = hashTable->table[index], *next = NULL ; node ; node = next) {
-        next = node->next;
-
-        if(node->inode == inode && node->port) {
-            DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(hashTable->table[index], node, prev, next);
-            char cmdline[8192] = "";
-            read_cmdline(pid, cmdline, sizeof(cmdline));
-            fix_cmdline(cmdline);
-            generate_output(protocol_name(node->protocol), node->local_address, node->port, cmdline);
-            freez(node);
-            return true;
-        }
+    if(n->family == AF_INET) {
+        ipv4_address_to_txt(n->local.ip.ipv4, local_address);
+        ipv4_address_to_txt(n->remote.ip.ipv4, remote_address);
+    }
+    else if(n->family == AF_INET6) {
+        ipv6_address_to_txt(&n->local.ip.ipv6, local_address);
+        ipv6_address_to_txt(&n->remote.ip.ipv6, remote_address);
     }
 
-    return false;
+    printf("%s|%s|%u|%s\n", protocol_name(n), local_address, n->local.port, n->cmdline ? n->cmdline : "");
 }
 
-void freeHashTable(HashTable *hashTable) {
-    for (unsigned int i = 0; i < HASH_TABLE_SIZE; i++) {
-        while(hashTable->table[i]) {
-            Node *tmp = hashTable->table[i];
-            DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(hashTable->table[i], tmp, prev, next);
-            generate_output(protocol_name(tmp->protocol), tmp->local_address, tmp->port, "");
-            freez(tmp);
-        }
+static void print_local_listeners_debug(LS_STATE *ls __maybe_unused, LOCAL_SOCKET *n, void *data __maybe_unused) {
+    char local_address[INET6_ADDRSTRLEN];
+    char remote_address[INET6_ADDRSTRLEN];
+
+    if(n->family == AF_INET) {
+        ipv4_address_to_txt(n->local.ip.ipv4, local_address);
+        ipv4_address_to_txt(n->remote.ip.ipv4, remote_address);
     }
-    freez(hashTable);
-}
-
-// ----------------------------------------------------------------------------
-
-static inline void found_this_socket_inode(pid_t pid, unsigned int inode) {
-    lookupHashTable_and_execute(hashTable_key_inode_port_value, inode, pid);
-}
-
-bool find_all_sockets_in_proc(const char *proc_filename) {
-    DIR *proc_dir, *fd_dir;
-    struct dirent *proc_entry, *fd_entry;
-    char path_buffer[FILENAME_MAX + 1];
-
-    proc_dir = opendir(proc_filename);
-    if (proc_dir == NULL) {
-        if(++errors_encountered < MAX_ERROR_LOGS)
-            collector_error("LOCAL-LISTENERS: cannot opendir() '%s'", proc_filename);
-
-        pid_fds_failed++;
-        return false;
+    else if(n->family == AF_INET6) {
+        ipv6_address_to_txt(&n->local.ip.ipv6, local_address);
+        ipv6_address_to_txt(&n->remote.ip.ipv6, remote_address);
     }
 
-    while ((proc_entry = readdir(proc_dir)) != NULL) {
-        // Check if directory entry is a PID by seeing if the name is made up of digits only
-        int is_pid = 1;
-        for (char *c = proc_entry->d_name; *c != '\0'; c++) {
-            if (*c < '0' || *c > '9') {
-                is_pid = 0;
-                break;
-            }
-        }
-
-        if (!is_pid)
-            continue;
-
-        // Build the path to the fd directory of the process
-        snprintfz(path_buffer, FILENAME_MAX, "%s/%s/fd/", proc_filename, proc_entry->d_name);
-
-        fd_dir = opendir(path_buffer);
-        if (fd_dir == NULL) {
-            if(++errors_encountered < MAX_ERROR_LOGS)
-                collector_error("LOCAL-LISTENERS: cannot opendir() '%s'", path_buffer);
-
-            pid_fds_failed++;
-            continue;
-        }
-
-        while ((fd_entry = readdir(fd_dir)) != NULL) {
-            if(!strcmp(fd_entry->d_name, ".") || !strcmp(fd_entry->d_name, ".."))
-                continue;
-
-            char link_path[FILENAME_MAX + 1];
-            char link_target[FILENAME_MAX + 1];
-            int inode;
-
-            // Build the path to the file descriptor link
-            snprintfz(link_path, FILENAME_MAX, "%s/%s", path_buffer, fd_entry->d_name);
-
-            ssize_t len = readlink(link_path, link_target, sizeof(link_target) - 1);
-            if (len == -1) {
-                if(++errors_encountered < MAX_ERROR_LOGS)
-                    collector_error("LOCAL-LISTENERS: cannot read link '%s'", link_path);
-
-                pid_fds_failed++;
-                continue;
-            }
-            link_target[len] = '\0';
-
-            pid_fds_processed++;
-
-            // If the link target indicates a socket, print its inode number
-            if (sscanf(link_target, "socket:[%d]", &inode) == 1)
-                found_this_socket_inode((pid_t)strtoul(proc_entry->d_name, NULL, 10), inode);
-        }
-
-        closedir(fd_dir);
-    }
-
-    closedir(proc_dir);
-    return true;
+    printf("%s, direction=%s%s%s%s%s pid=%d, state=0x%0x, local=%s[:%u], remote=%s[:%u], comm=%s\n",
+           protocol_name(n),
+           (n->direction & SOCKET_DIRECTION_LISTEN) ? "LISTEN," : "",
+           (n->direction & SOCKET_DIRECTION_INBOUND) ? "INBOUND," : "",
+           (n->direction & SOCKET_DIRECTION_OUTBOUND) ? "OUTBOUND," : "",
+           (n->direction & SOCKET_DIRECTION_LOCAL) ? "LOCAL," : "",
+           (n->direction == 0) ? "NONE," : "",
+           n->pid,
+           n->state,
+           local_address, n->local.port,
+           remote_address, n->remote.port,
+           n->comm);
 }
 
-// ----------------------------------------------------------------------------
-
-static inline void add_port_and_inode(PROC_NET_PROTOCOLS protocol, unsigned int port, unsigned int inode, char *local_address) {
-    insertHashTable(hashTable_key_inode_port_value, inode, port, protocol, local_address);
-}
-
-static inline void print_ipv6_address(const char *ipv6_str, char *dst) {
-    unsigned k;
-    char buf[9];
-    struct sockaddr_in6 sa;
-
-    // Initialize sockaddr_in6
-    memset(&sa, 0, sizeof(struct sockaddr_in6));
-    sa.sin6_family = AF_INET6;
-    sa.sin6_port = htons(0); // replace 0 with your port number
-
-    // Convert hex string to byte array
-    for (k = 0; k < 4; ++k)
-    {
-        memset(buf, 0, 9);
-        memcpy(buf, ipv6_str + (k * 8), 8);
-        sa.sin6_addr.s6_addr32[k] = strtoul(buf, NULL, 16);
-    }
-
-    // Convert to human-readable format
-    if (inet_ntop(AF_INET6, &(sa.sin6_addr), dst, INET6_ADDRSTRLEN) == NULL)
-        *dst = '\0';
-}
-
-static inline void print_ipv4_address(uint32_t address, char *dst) {
-    uint8_t octets[4];
-    octets[0] = address & 0xFF;
-    octets[1] = (address >> 8) & 0xFF;
-    octets[2] = (address >> 16) & 0xFF;
-    octets[3] = (address >> 24) & 0xFF;
-    sprintf(dst, "%u.%u.%u.%u", octets[0], octets[1], octets[2], octets[3]);
-}
-
-bool read_proc_net_x(const char *filename, PROC_NET_PROTOCOLS protocol) {
-    FILE *fp;
-    char *line = NULL;
-    size_t len = 0;
-    ssize_t read;
-    char address[INET6_ADDRSTRLEN];
-
-    ssize_t min_line_length = (protocol == PROC_NET_PROTOCOL_TCP || protocol == PROC_NET_PROTOCOL_UDP) ? 105 : 155;
-
-    fp = fopen(filename, "r");
-    if (fp == NULL)
-        return false;
-
-    // Read line by line
-    while ((read = getline(&line, &len, fp)) != -1) {
-        if(read < min_line_length) continue;
-
-        char local_address6[33], rem_address6[33];
-        unsigned int local_address, local_port, state, rem_address, rem_port, inode;
-
-        switch(protocol) {
-            case PROC_NET_PROTOCOL_TCP:
-                if(line[34] != '0' || line[35] != 'A')
-                    continue;
-                // fall-through
-
-            case PROC_NET_PROTOCOL_UDP:
-                if (sscanf(line, "%*d: %X:%X %X:%X %X %*X:%*X %*X:%*X %*X %*d %*d %u",
-                    &local_address, &local_port, &rem_address, &rem_port, &state, &inode) != 6)
-                    continue;
-
-                print_ipv4_address(local_address, address);
-                break;
-
-            case PROC_NET_PROTOCOL_TCP6:
-                if(line[82] != '0' || line[83] != 'A')
-                    continue;
-                    // fall-through
-
-            case PROC_NET_PROTOCOL_UDP6:
-                if(sscanf(line, "%*d: %32[0-9A-Fa-f]:%X %32[0-9A-Fa-f]:%X %X %*X:%*X %*X:%*X %*X %*d %*d %u",
-                    local_address6, &local_port, rem_address6, &rem_port, &state, &inode) != 6)
-                    continue;
-
-                print_ipv6_address(local_address6, address);
-                break;
-        }
-
-        add_port_and_inode(protocol, local_port, inode, address);
-    }
-
-    fclose(fp);
-    if (line)
-        free(line);
-
-    return true;
-}
-
-// ----------------------------------------------------------------------------
-typedef struct {
-  bool read_tcp;
-  bool read_tcp6;
-  bool read_udp;
-  bool read_udp6;
-} CommandLineArguments;
+// --------------------------------------------------------------------------------------------------------------------
 
 int main(int argc, char **argv) {
-    char path[FILENAME_MAX + 1];
-    hashTable_key_inode_port_value = createHashTable();
+    LS_STATE ls = {
+        .config = {
+            .listening = true,
+            .inbound = false,
+            .outbound = false,
+            .local = false,
+            .tcp4 = true,
+            .tcp6 = true,
+            .udp4 = true,
+            .udp6 = true,
+            .pid = false,
+            .cmdline = true,
+            .comm = false,
+
+            .max_errors = 10,
+
+            .cb = print_local_listeners,
+            .data = NULL,
+        },
+        .stats = { 0 },
+        .sockets_hashtable = { 0 },
+        .local_ips_hashtable = { 0 },
+        .listening_ports_hashtable = { 0 },
+    };
 
     netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");
     if(!netdata_configured_host_prefix) netdata_configured_host_prefix = "";
 
-    CommandLineArguments args = {.read_tcp = false, .read_tcp6 = false, .read_udp = false, .read_udp6 = false};
-
     for (int i = 1; i < argc; i++) {
-        if (strcmp("tcp", argv[i]) == 0) {
-            args.read_tcp = true;
-            continue;
-        } else if (strcmp("tcp6", argv[i]) == 0) {
-            args.read_tcp6 = true;
-            continue;
-        } else if (strcmp("udp", argv[i]) == 0) {
-            args.read_udp = true;
-            continue;
-        } else if (strcmp("udp6", argv[i]) == 0) {
-            args.read_udp6 = true;
-            continue;
+        char *s = argv[i];
+        bool positive = true;
+
+        if(strcmp(s, "-h") == 0 || strcmp(s, "--help") == 0) {
+            fprintf(stderr,
+                    "\n"
+                    " Netdata local-listeners\n"
+                    " (C) 2024 Netdata Inc.\n"
+                    "\n"
+                    " This program prints a list of all the processes that have a listening socket.\n"
+                    " It is used by Netdata to auto-detect the services running.\n"
+                    "\n"
+                    " Options:\n"
+                    "\n"
+                    " The options:\n"
+                    "\n"
+                    "    udp, udp4, udp6, tcp, tcp4, tcp6, ipv4, ipv6\n"
+                    "\n"
+                    " select the sources to read currently available sockets.\n"
+                    "\n"
+                    " while:\n"
+                    "\n"
+                    "    listening, local, inbound, outbound\n"
+                    "\n"
+                    " filter the output based on the direction of the sockets.\n"
+                    "\n"
+                    " Prepending any option with 'no-', 'not-' or 'non-' will disable them.\n"
+                    "\n"
+                    " Current options:\n"
+                    "\n"
+                    "    %s %s %s %s %s %s %s %s\n"
+                    "\n"
+                    " Option 'debug' enables all sources and all directions and provides\n"
+                    " a full dump of current sockets.\n"
+                    "\n"
+                    " DIRECTION DETECTION\n"
+                    " The program detects the direction of the sockets using these rules:\n"
+                    "\n"
+                    "   - listening   are all the TCP sockets that are in listen state\n"
+                    "                 and all sockets that their remote IP is zero.\n"
+                    "\n"
+                    "   - local       are all the non-listening sockets that either their source IP\n"
+                    "                 or their remote IP are loopback addresses. Loopback addresses are\n"
+                    "                 those in 127.0.0.0/8 and ::1. When IPv4 addresses are mapped\n"
+                    "                 into IPv6, the program extracts the IPv4 addresses to check them.\n"
+                    "\n"
+                    "                 Also, local are considered all the sockets that their remote\n"
+                    "                 IP is one of the IPs that appear as local on another socket.\n"
+                    "\n"
+                    "   - inbound     are all the non-listening and non-local sockets that their local\n"
+                    "                 port is a port of another socket that is marked as listening.\n"
+                    "\n"
+                    "   - outbound    are all the other sockets.\n"
+                    "\n"
+                    " Keep in mind that this kind of socket direction detection is not 100%% accurate,\n"
+                    " and there may be cases (e.g. reusable sockets) that this code may incorrectly\n"
+                    " mark sockets as inbound or outbound.\n"
+                    "\n"
+                    " WARNING:\n"
+                    " This program reads the entire /proc/net/{tcp,udp,tcp6,upd6} files, builds\n"
+                    " multiple hash maps in memory and traverses the entire /proc filesystem to\n"
+                    " associate sockets with processes. We have made the most to make it as\n"
+                    " lightweight and fast as possible, but still this program has a lot of work\n"
+                    " to do and it may have some impact on very busy servers with millions of.\n"
+                    " established connections."
+                    "\n"
+                    " Therefore, we suggest to avoid running it repeatedly for data collection.\n"
+                    "\n"
+                    " Netdata executes it only when it starts to auto-detect data collection sources\n"
+                    " and initialize the network dependencies explorer."
+                    "\n"
+                    , ls.config.udp4 ? "udp4" :"no-udp4"
+                    , ls.config.udp6 ? "udp6" :"no-udp6"
+                    , ls.config.tcp4 ? "tcp4" :"no-tcp4"
+                    , ls.config.tcp6 ? "tcp6" :"no-tcp6"
+                    , ls.config.listening ? "listening" : "no-listening"
+                    , ls.config.local ? "local" : "no-local"
+                    , ls.config.inbound ? "inbound" : "no-inbound"
+                    , ls.config.outbound ? "outbound" : "no-outbound"
+                    );
+            exit(1);
+        }
+
+        if(strncmp(s, "no-", 3) == 0) {
+            positive = false;
+            s += 3;
+        }
+        else if(strncmp(s, "not-", 4) == 0 || strncmp(s, "non-", 4) == 0) {
+            positive = false;
+            s += 4;
+        }
+
+        if(strcmp(s, "debug") == 0 || strcmp(s, "--debug") == 0) {
+            fprintf(stderr, "%s debugging\n", positive ? "enabling" : "disabling");
+            ls.config.listening = true;
+            ls.config.local = true;
+            ls.config.inbound = true;
+            ls.config.outbound = true;
+            ls.config.pid = true;
+            ls.config.comm = true;
+            ls.config.cmdline = false;
+            ls.config.cb = print_local_listeners_debug;
+        }
+        else if (strcmp("tcp", s) == 0) {
+            ls.config.tcp4 = ls.config.tcp6 = positive;
+            // fprintf(stderr, "%s tcp4 and tcp6\n", positive ? "enabling" : "disabling");
+        }
+        else if (strcmp("tcp4", s) == 0) {
+            ls.config.tcp4 = positive;
+            // fprintf(stderr, "%s tcp4\n", positive ? "enabling" : "disabling");
+        }
+        else if (strcmp("tcp6", s) == 0) {
+            ls.config.tcp6 = positive;
+            // fprintf(stderr, "%s tcp6\n", positive ? "enabling" : "disabling");
+        }
+        else if (strcmp("udp", s) == 0) {
+            ls.config.udp4 = ls.config.udp6 = positive;
+            // fprintf(stderr, "%s udp4 and udp6\n", positive ? "enabling" : "disabling");
+        }
+        else if (strcmp("udp4", s) == 0) {
+            ls.config.udp4 = positive;
+            // fprintf(stderr, "%s udp4\n", positive ? "enabling" : "disabling");
+        }
+        else if (strcmp("udp6", s) == 0) {
+            ls.config.udp6 = positive;
+            // fprintf(stderr, "%s udp6\n", positive ? "enabling" : "disabling");
+        }
+        else if (strcmp("ipv4", s) == 0) {
+            ls.config.tcp4 = ls.config.udp4 = positive;
+            // fprintf(stderr, "%s udp4 and tcp4\n", positive ? "enabling" : "disabling");
+        }
+        else if (strcmp("ipv6", s) == 0) {
+            ls.config.tcp6 = ls.config.udp6 = positive;
+            // fprintf(stderr, "%s udp6 and tcp6\n", positive ? "enabling" : "disabling");
+        }
+        else if (strcmp("listening", s) == 0) {
+            ls.config.listening = positive;
+            // fprintf(stderr, "%s listening\n", positive ? "enabling" : "disabling");
+        }
+        else if (strcmp("local", s) == 0) {
+            ls.config.local = positive;
+            // fprintf(stderr, "%s local\n", positive ? "enabling" : "disabling");
+        }
+        else if (strcmp("inbound", s) == 0) {
+            ls.config.inbound = positive;
+            // fprintf(stderr, "%s inbound\n", positive ? "enabling" : "disabling");
+        }
+        else if (strcmp("outbound", s) == 0) {
+            ls.config.outbound = positive;
+            // fprintf(stderr, "%s outbound\n", positive ? "enabling" : "disabling");
+        }
+        else {
+            fprintf(stderr, "Unknown parameter %s\n", s);
+            exit(1);
         }
     }
 
-    bool read_all_files = (!args.read_tcp && !args.read_tcp6 && !args.read_udp && !args.read_udp6);
+    local_sockets_process(&ls);
 
-    if (read_all_files || args.read_tcp) {
-        snprintfz(path, FILENAME_MAX, "%s/proc/net/tcp", netdata_configured_host_prefix);
-        read_proc_net_x(path, PROC_NET_PROTOCOL_TCP);
-    }
-
-    if (read_all_files || args.read_udp) {
-        snprintfz(path, FILENAME_MAX, "%s/proc/net/udp", netdata_configured_host_prefix);
-        read_proc_net_x(path, PROC_NET_PROTOCOL_UDP);
-    }
-
-    if (read_all_files || args.read_tcp6) {
-        snprintfz(path, FILENAME_MAX, "%s/proc/net/tcp6", netdata_configured_host_prefix);
-        read_proc_net_x(path, PROC_NET_PROTOCOL_TCP6);
-    }
-
-    if (read_all_files || args.read_udp6) {
-        snprintfz(path, FILENAME_MAX, "%s/proc/net/udp6", netdata_configured_host_prefix);
-        read_proc_net_x(path, PROC_NET_PROTOCOL_UDP6);
-    }
-
-    snprintfz(path, FILENAME_MAX, "%s/proc", netdata_configured_host_prefix);
-    find_all_sockets_in_proc(path);
-
-    freeHashTable(hashTable_key_inode_port_value);
     return 0;
 }

--- a/collectors/proc.plugin/proc_diskstats.c
+++ b/collectors/proc.plugin/proc_diskstats.c
@@ -213,7 +213,7 @@ static SIMPLE_PATTERN *excluded_disks = NULL;
 
 static unsigned long long int bcache_read_number_with_units(const char *filename) {
     char buffer[50 + 1];
-    if(read_file(filename, buffer, 50) == 0) {
+    if(read_txt_file(filename, buffer, sizeof(buffer)) == 0) {
         static int unknown_units_error = 10;
 
         char *end = NULL;
@@ -547,9 +547,9 @@ static inline char *get_disk_model(char *device) {
     char buffer[256 + 1];
 
     snprintfz(path, sizeof(path) - 1, "%s/%s/device/model", path_to_sys_block, device);
-    if(read_file(path, buffer, 256) != 0) {
+    if(read_txt_file(path, buffer, sizeof(buffer)) != 0) {
         snprintfz(path, sizeof(path) - 1, "%s/%s/device/name", path_to_sys_block, device);
-        if(read_file(path, buffer, 256) != 0)
+        if(read_txt_file(path, buffer, sizeof(buffer)) != 0)
             return NULL;
     }
 
@@ -565,7 +565,7 @@ static inline char *get_disk_serial(char *device) {
     char buffer[256 + 1];
 
     snprintfz(path, sizeof(path) - 1, "%s/%s/device/serial", path_to_sys_block, device);
-    if(read_file(path, buffer, 256) != 0)
+    if(read_txt_file(path, buffer, sizeof(buffer)) != 0)
         return NULL;
 
     return strdupz(buffer);
@@ -778,7 +778,7 @@ static struct disk *get_disk(unsigned long major, unsigned long minor, char *dis
         strncat(uuid_filename, "/dm/uuid", FILENAME_MAX - size);
 
         char device_uuid[RRD_ID_LENGTH_MAX + 1];
-        if (!read_file(uuid_filename, device_uuid, RRD_ID_LENGTH_MAX) && !strncmp(device_uuid, "LVM-", 4)) {
+        if (!read_txt_file(uuid_filename, device_uuid, sizeof(device_uuid)) && !strncmp(device_uuid, "LVM-", 4)) {
             trim(device_uuid);
 
             char chart_id[RRD_ID_LENGTH_MAX + 1];

--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -1140,7 +1140,7 @@ int do_proc_net_dev(int update_every, usec_t dt) {
              now_monotonic_sec() - d->duplex_file_lost_time > READ_RETRY_PERIOD)) {
             char buffer[STATE_LENGTH_MAX + 1];
 
-            if (read_file(d->filename_duplex, buffer, STATE_LENGTH_MAX)) {
+            if (read_txt_file(d->filename_duplex, buffer, sizeof(buffer))) {
                 if (d->duplex_file_exists)
                     collector_error("Cannot refresh interface %s duplex state by reading '%s'.", d->name, d->filename_duplex);
                 d->duplex_file_exists = 0;
@@ -1164,7 +1164,7 @@ int do_proc_net_dev(int update_every, usec_t dt) {
         if(d->do_operstate != CONFIG_BOOLEAN_NO && d->filename_operstate) {
             char buffer[STATE_LENGTH_MAX + 1], *trimmed_buffer;
 
-            if (read_file(d->filename_operstate, buffer, STATE_LENGTH_MAX)) {
+            if (read_txt_file(d->filename_operstate, buffer, sizeof(buffer))) {
                 collector_error(
                     "Cannot refresh %s operstate by reading '%s'. Will not update its status anymore.",
                     d->name, d->filename_operstate);

--- a/collectors/proc.plugin/proc_net_sockstat.c
+++ b/collectors/proc.plugin/proc_net_sockstat.c
@@ -44,7 +44,7 @@ static int read_tcp_mem(void) {
     }
 
     char buffer[200 + 1], *start, *end;
-    if(read_file(filename, buffer, 200) != 0) return 1;
+    if(read_txt_file(filename, buffer, sizeof(buffer)) != 0) return 1;
     buffer[200] = '\0';
 
     unsigned long long low = 0, pressure = 0, high = 0;

--- a/collectors/proc.plugin/proc_spl_kstat_zfs.c
+++ b/collectors/proc.plugin/proc_spl_kstat_zfs.c
@@ -378,7 +378,7 @@ int do_proc_spl_kstat_zfs_pool_state(int update_every, usec_t dt)
                 snprintfz(filename, FILENAME_MAX, "%s/%s/state", dirname, de->d_name);
 
                 char state[STATE_SIZE + 1];
-                int ret = read_file(filename, state, STATE_SIZE);
+                int ret = read_txt_file(filename, state, sizeof(state));
 
                 if (!ret) {
                     state_file_found = 1;

--- a/collectors/proc.plugin/sys_class_infiniband.c
+++ b/collectors/proc.plugin/sys_class_infiniband.c
@@ -470,7 +470,7 @@ int do_sys_class_infiniband(int update_every, usec_t dt)
                 snprintfz(buffer, FILENAME_MAX, "%s/%s/%s", ports_dirname, port_dent->d_name, "rate");
                 char buffer_rate[65];
                 p->width = 4;
-                if (read_file(buffer, buffer_rate, 64)) {
+                if (read_txt_file(buffer, buffer_rate, sizeof(buffer_rate))) {
                     collector_error("Unable to read '%s'", buffer);
                 } else {
                     char *buffer_width = strstr(buffer_rate, "(");

--- a/collectors/proc.plugin/sys_devices_system_edac_mc.c
+++ b/collectors/proc.plugin/sys_devices_system_edac_mc.c
@@ -150,7 +150,7 @@ static kernel_uint_t read_edac_count(struct edac_count *t) {
 static bool read_edac_mc_file(const char *mc, const char *filename, char *out, size_t out_size) {
     char f[FILENAME_MAX + 1];
     snprintfz(f, FILENAME_MAX, "%s/%s/%s", mc_dirname, mc, filename);
-    if(read_file(f, out, out_size) != 0) {
+    if(read_txt_file(f, out, out_size) != 0) {
         collector_error("EDAC: cannot read file '%s'", f);
         return false;
     }
@@ -160,7 +160,7 @@ static bool read_edac_mc_file(const char *mc, const char *filename, char *out, s
 static bool read_edac_mc_rank_file(const char *mc, const char *rank, const char *filename, char *out, size_t out_size) {
     char f[FILENAME_MAX + 1];
     snprintfz(f, FILENAME_MAX, "%s/%s/%s/%s", mc_dirname, mc, rank, filename);
-    if(read_file(f, out, out_size) != 0) {
+    if(read_txt_file(f, out, out_size) != 0) {
         collector_error("EDAC: cannot read file '%s'", f);
         return false;
     }

--- a/collectors/proc.plugin/sys_fs_btrfs.c
+++ b/collectors/proc.plugin/sys_fs_btrfs.c
@@ -122,7 +122,7 @@ static BTRFS_NODE *nodes = NULL;
 static inline int collect_btrfs_error_stats(BTRFS_DEVICE *device){
     char buffer[120 + 1];
     
-    int ret = read_file(device->error_stats_filename, buffer, 120);
+    int ret = read_txt_file(device->error_stats_filename, buffer, sizeof(buffer));
     if(unlikely(ret)) {
         collector_error("BTRFS: failed to read '%s'", device->error_stats_filename);
         device->write_errs = 0;
@@ -151,7 +151,7 @@ static inline int collect_btrfs_error_stats(BTRFS_DEVICE *device){
 static inline int collect_btrfs_commits_stats(BTRFS_NODE *node, int update_every){
     char buffer[120 + 1];
     
-    int ret = read_file(node->commit_stats_filename, buffer, 120);
+    int ret = read_txt_file(node->commit_stats_filename, buffer, sizeof(buffer));
     if(unlikely(ret)) {
         collector_error("BTRFS: failed to read '%s'", node->commit_stats_filename);
         node->commits_total = 0;
@@ -530,7 +530,7 @@ static inline int find_all_btrfs_pools(const char *path, int update_every) {
             char label[FILENAME_MAX + 1] = "";
 
             snprintfz(filename, FILENAME_MAX, "%s/%s/label", path, de->d_name);
-            if(read_file(filename, label, FILENAME_MAX) != 0) {
+            if(read_txt_file(filename, label, sizeof(label)) != 0) {
                 collector_error("BTRFS: failed to read '%s'", filename);
                 btrfs_free_node(node);
                 continue;

--- a/collectors/systemd-journal.plugin/systemd-internals.h
+++ b/collectors/systemd-journal.plugin/systemd-internals.h
@@ -132,13 +132,6 @@ void journal_watcher_restart(void);
 void function_systemd_units(const char *transaction, char *function, usec_t *stop_monotonic_ut, bool *cancelled, BUFFER *payload, HTTP_ACCESS access __maybe_unused, const char *source, void *data);
 #endif
 
-static inline void send_newline_and_flush(void) {
-    netdata_mutex_lock(&stdout_mutex);
-    fprintf(stdout, "\n");
-    fflush(stdout);
-    netdata_mutex_unlock(&stdout_mutex);
-}
-
 static inline bool parse_journal_field(const char *data, size_t data_length, const char **key, size_t *key_length, const char **value, size_t *value_length) {
     const char *k = data;
     const char *equal = strchr(k, '=');

--- a/collectors/systemd-journal.plugin/systemd-journal-files.c
+++ b/collectors/systemd-journal.plugin/systemd-journal-files.c
@@ -639,7 +639,7 @@ void journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, con
             if(files)
                 dictionary_set(files, full_path, NULL, 0);
 
-            send_newline_and_flush();
+            send_newline_and_flush(&stdout_mutex);
         }
         else if (entry->d_type == DT_LNK) {
             struct stat info;
@@ -657,7 +657,7 @@ void journal_directory_scan_recursively(DICTIONARY *files, DICTIONARY *dirs, con
                 if(files)
                     dictionary_set(files, full_path, NULL, 0);
 
-                send_newline_and_flush();
+                send_newline_and_flush(&stdout_mutex);
             }
         }
     }

--- a/collectors/systemd-journal.plugin/systemd-main.c
+++ b/collectors/systemd-journal.plugin/systemd-main.c
@@ -134,7 +134,7 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
         send_newline_ut += dt_ut;
 
         if(!tty && send_newline_ut > USEC_PER_SEC) {
-            send_newline_and_flush();
+            send_newline_and_flush(&stdout_mutex);
             send_newline_ut = 0;
         }
     }

--- a/daemon/analytics.c
+++ b/daemon/analytics.c
@@ -718,7 +718,7 @@ void get_system_timezone(void)
     }
 
     // use the contents of /etc/timezone
-    if (!timezone && !read_file("/etc/timezone", buffer, FILENAME_MAX)) {
+    if (!timezone && !read_txt_file("/etc/timezone", buffer, sizeof(buffer))) {
         timezone = buffer;
         netdata_log_info("TIMEZONE: using the contents of /etc/timezone");
     }

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1100,7 +1100,7 @@ static int get_hostname(char *buf, size_t buf_size) {
         char filename[FILENAME_MAX + 1];
         snprintfz(filename, FILENAME_MAX, "%s/etc/hostname", netdata_configured_host_prefix);
 
-        if (!read_file(filename, buf, buf_size)) {
+        if (!read_txt_file(filename, buf, buf_size)) {
             trim(buf);
             return 0;
         }

--- a/libnetdata/ebpf/ebpf.c
+++ b/libnetdata/ebpf/ebpf.c
@@ -179,8 +179,8 @@ static int kernel_is_rejected()
     char version_string[VERSION_STRING_LEN + 1];
     int version_string_len = 0;
 
-    if (read_file("/proc/version_signature", version_string, VERSION_STRING_LEN)) {
-        if (read_file("/proc/version", version_string, VERSION_STRING_LEN)) {
+    if (read_txt_file("/proc/version_signature", version_string, sizeof(version_string))) {
+        if (read_txt_file("/proc/version", version_string, sizeof(version_string))) {
             struct utsname uname_buf;
             if (!uname(&uname_buf)) {
                 netdata_log_info("Cannot check kernel version");

--- a/libnetdata/functions_evloop/functions_evloop.h
+++ b/libnetdata/functions_evloop/functions_evloop.h
@@ -138,6 +138,13 @@ static inline void pluginsd_function_progress_to_stdout(const char *transaction,
     fflush(stdout);
 }
 
+static inline void send_newline_and_flush(pthread_mutex_t *mutex) {
+    netdata_mutex_lock(mutex);
+    fprintf(stdout, "\n");
+    fflush(stdout);
+    netdata_mutex_unlock(mutex);
+}
+
 void functions_evloop_dyncfg_add(struct functions_evloop_globals *wg, const char *id, const char *path,
                                  DYNCFG_STATUS status, DYNCFG_TYPE type, DYNCFG_SOURCE_TYPE source_type, const char *source, DYNCFG_CMDS cmds,
                                  HTTP_ACCESS view_access, HTTP_ACCESS edit_access,

--- a/libnetdata/os.c
+++ b/libnetdata/os.c
@@ -151,11 +151,11 @@ unsigned long read_cpuset_cpus(const char *filename, long system_cpus) {
     static size_t buf_size = 0;
 
     if(!buf) {
-        buf_size = 100U + 6 * system_cpus; // taken from kernel/cgroup/cpuset.c
-        buf = mallocz(buf_size + 1);
+        buf_size = 100U + 6 * system_cpus + 1; // taken from kernel/cgroup/cpuset.c
+        buf = mallocz(buf_size);
     }
 
-    int ret = read_file(filename, buf, buf_size);
+    int ret = read_txt_file(filename, buf, buf_size);
 
     if(!ret) {
         char *s = buf;


### PR DESCRIPTION
```
 Netdata local-listeners
 (C) 2024 Netdata Inc.

 This program prints a list of all the processes that have a listening socket.
 It is used by Netdata to auto-detect the services running.

 Options:

 The options:

    udp, udp4, udp6, tcp, tcp4, tcp6, ipv4, ipv6

 select the sources to read currently available sockets.

 while:

    listening, local, inbound, outbound

 filter the output based on the direction of the sockets.

 Prepending any option with 'no-', 'not-' or 'non-' will disable them.

 Current options:

    udp4 udp6 tcp4 tcp6 listening no-local no-inbound no-outbound

 Option 'debug' enables all sources and all directions and provides
 a full dump of current sockets.

 DIRECTION DETECTION
 The program detects the direction of the sockets using these rules:

   - listening   are all the TCP sockets that are in listen state
                 and all sockets that their remote IP is zero.

   - local       are all the non-listening sockets that either their source IP
                 or their remote IP are loopback addresses. Loopback addresses are
                 those in 127.0.0.0/8 and ::1. When IPv4 addresses are mapped
                 into IPv6, the program extracts the IPv4 addresses to check them.

                 Also, local are considered all the sockets that their remote
                 IP is one of the IPs that appear as local on another socket.

   - inbound     are all the non-listening and non-local sockets that their local
                 port is a port of another socket that is marked as listening.

   - outbound    are all the other sockets.

 Keep in mind that this kind of socket direction detection is not 100% accurate,
 and there may be cases (e.g. reusable sockets) that this code may incorrectly
 mark sockets as inbound or outbound.

 WARNING:
 This program reads the entire /proc/net/{tcp,udp,tcp6,upd6} files, builds
 multiple hash maps in memory and traverses the entire /proc filesystem to
 associate sockets with processes. We have made the most to make it as
 lightweight and fast as possible, but still this program has a lot of work
 to do and it may have some impact on very busy servers with millions of.
 established connections.
 Therefore, we suggest to avoid running it repeatedly for data collection.

 Netdata executes it only when it starts to auto-detect data collection sources
 and initialize the network dependencies explorer.
```
