### PR TITLE
Limit what we upload to GCS for nightlies.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -808,7 +808,7 @@ jobs:
         with:
           destination: ${{ secrets.GCP_NIGHTLY_STORAGE_BUCKET }}
           gzip: false
-          path: ./final-artifacts
+          path: ./final-artifacts/latest-version.txt
           parent: false
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
##### Summary

We have not actually used GCS for much of anything WRT our nightly builds for quite some time now, but have continued uploading to it. This wastes a significant amount of money on bandwidth and storage for something we’re not actually using, so this PR just updates things to only upload the `latest-version.txt` file, which is still used by version checks for nightlies in the older dashboard code.

##### Test Plan

n/a