### PR TITLE
Make sentry bundle dont fail on PRs

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -216,6 +216,7 @@ jobs:
           else
               echo "RELEASE_PIPELINE=Unknown" >> "${GITHUB_ENV}"
               echo "UPLOAD_SENTRY=false" >> "${GITHUB_ENV}"
+              echo "SENTRY_DSN=https://1ea0662a@o01e.ingest.sentry.io/dummy"
           fi
       - name: Setup QEMU
         id: qemu


### PR DESCRIPTION
##### Summary

We pass netdata's sentry DSN as a secret (which is a little bit overkill but let's hide as much information we can, because this endpoint can be used to polute our data) so PRs from forks can't access our secrets. 

This PR adds a dummy env var for netdata agent to build properly 

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->
CI Passes on this PR but verify that the dummy env var is placed

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
