### PR TITLE
fix crash on query_progress initializer

### DIFF
--- a/libnetdata/query_progress/progress.c
+++ b/libnetdata/query_progress/progress.c
@@ -71,7 +71,8 @@ static struct progress {
     SIMPLE_HASHTABLE_QUERY hashtable;
 
 } progress = {
-        .initialized = false,
+    .initialized = false,
+    .spinlock = NETDATA_SPINLOCK_INITIALIZER,
 };
 
 SIMPLE_HASHTABLE_HASH query_hash(uuid_t *transaction) {
@@ -85,7 +86,6 @@ SIMPLE_HASHTABLE_HASH query_hash(uuid_t *transaction) {
 
 static void query_progress_init_unsafe(void) {
     if(!progress.initialized) {
-        memset(&progress, 0, sizeof(progress));
         simple_hashtable_init_QUERY(&progress.hashtable, PROGRESS_CACHE_SIZE * 4);
         progress.initialized = true;
     }


### PR DESCRIPTION
1. Gets the lock
2. zeros the structure that has the lock inside