### PR TITLE
Do not cancel detection thread.

### DIFF
--- a/ml/ml.cc
+++ b/ml/ml.cc
@@ -1844,7 +1844,6 @@ void ml_stop_threads()
     if (!Cfg.detection_thread)
         return;
 
-    netdata_thread_cancel(Cfg.detection_thread);
     netdata_thread_join(Cfg.detection_thread, NULL);
 
     // signal the training queue of each thread


### PR DESCRIPTION
An atomic flag is used before every iteration
of the detection thread. The flag is set right
before the cancellation request. It is possible
for the detection thread to have already exited
prior to sending the cancellation request.

The training thread most probably suffers from
the same issue, a separate PR will be opened
to fix it.
