### PR TITLE
Assorted build-related changes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1528,7 +1528,7 @@ include(packaging/cmake/systemd.cmake)
 
 add_library(libnetdata STATIC ${LIBNETDATA_FILES})
 
-target_include_directories(libnetdata BEFORE PUBLIC ${CONFIG_H_DIR} ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(libnetdata BEFORE PUBLIC ${CONFIG_H_DIR} ${CMAKE_SOURCE_DIR}/src)
 
 # pthread (FIXME: use find_package for this)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1656,9 +1656,6 @@ target_include_directories(libnetdata BEFORE PUBLIC ${OPENSSL_INCLUDE_DIRS})
 target_compile_options(libnetdata PUBLIC ${OPENSSL_CFLAGS_OTHER})
 target_link_libraries(libnetdata PUBLIC ${OPENSSL_LDFLAGS})
 
-# h2o
-target_link_libraries(libnetdata PUBLIC "$<$<BOOL:${ENABLE_H2O}>:h2o>")
-
 # mnl
 pkg_check_modules(MNL libmnl)
 if(MNL_FOUND)
@@ -2120,6 +2117,7 @@ target_link_libraries(netdata PRIVATE
         "$<$<BOOL:${MACOS}>:${IOKIT};${FOUNDATION}>"
         "$<$<BOOL:${ENABLE_SENTRY}>:sentry>"
         "$<$<BOOL:${ENABLE_WEBRTC}>:LibDataChannel::LibDataChannelStatic>"
+        "$<$<BOOL:${ENABLE_H2O}>:h2o>"
 )
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -663,7 +663,7 @@ set(LIBNETDATA_FILES
         src/libnetdata/os.c
         src/libnetdata/os.h
         src/libnetdata/simple_hashtable.h
-        src/libnetdata/endian.h
+        src/libnetdata/byteorder.h
         src/libnetdata/onewayalloc/onewayalloc.c
         src/libnetdata/onewayalloc/onewayalloc.h
         src/libnetdata/popen/popen.c

--- a/src/libnetdata/byteorder.h
+++ b/src/libnetdata/byteorder.h
@@ -29,4 +29,4 @@
 #define be64toh(x) OSSwapBigToHostInt64(x)
 #define le64toh(x) OSSwapLittleToHostInt64(x)
 
-#endif  /* LIBNETDATA_ENDIAN_H */
+#endif  /* LIBNETDATA_BYTE_ORDER_H */

--- a/src/libnetdata/byteorder.h
+++ b/src/libnetdata/byteorder.h
@@ -1,5 +1,5 @@
-#ifndef LIBNETDATA_ENDIAN_H
-#define LIBNETDATA_ENDIAN_H
+#ifndef LIBNETDATA_BYTE_ORDER_H
+#define LIBNETDATA_BYTE_ORDER_H
 
 /** compatibility header for endian.h
  * This is a simple compatibility shim to convert

--- a/src/libnetdata/os.h
+++ b/src/libnetdata/os.h
@@ -37,7 +37,7 @@ int getsysctl(const char *name, int *mib, size_t miblen, void *ptr, size_t *len)
 #if __APPLE__
 
 #include <sys/sysctl.h>
-#include "endian.h"
+#include "byteorder.h"
 
 #define GETSYSCTL_BY_NAME(name, var) getsysctl_by_name(name, &(var), sizeof(var))
 int getsysctl_by_name(const char *name, void *ptr, size_t len);


### PR DESCRIPTION
##### Summary

- Rename file to avoid header search path conflicts.
- Do not include top-level directory in the headers search path.
- Link h2o library with the main agent binary instead of libnetdata.

##### Test Plan

- CI jobs.