### PR TITLE
add support for the info parameter to all external plugin functions

### DIFF
--- a/collectors/cgroups.plugin/cgroup-top.c
+++ b/collectors/cgroups.plugin/cgroup-top.c
@@ -107,6 +107,7 @@ int cgroup_function_cgroup_top(BUFFER *wb, const char *function __maybe_unused) 
     buffer_json_member_add_uint64(wb, "status", HTTP_RESP_OK);
     buffer_json_member_add_string(wb, "type", "table");
     buffer_json_member_add_time_t(wb, "update_every", 1);
+    buffer_json_member_add_boolean(wb, "has_history", false);
     buffer_json_member_add_string(wb, "help", RRDFUNCTIONS_CGTOP_HELP);
     buffer_json_member_add_array(wb, "data");
 
@@ -349,6 +350,7 @@ int cgroup_function_systemd_top(BUFFER *wb, const char *function __maybe_unused)
     buffer_json_member_add_uint64(wb, "status", HTTP_RESP_OK);
     buffer_json_member_add_string(wb, "type", "table");
     buffer_json_member_add_time_t(wb, "update_every", 1);
+    buffer_json_member_add_boolean(wb, "has_history", false);
     buffer_json_member_add_string(wb, "help", RRDFUNCTIONS_CGTOP_HELP);
     buffer_json_member_add_array(wb, "data");
 

--- a/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/collectors/diskspace.plugin/plugin_diskspace.c
@@ -645,6 +645,7 @@ int diskspace_function_mount_points(BUFFER *wb, const char *function __maybe_unu
     buffer_json_member_add_uint64(wb, "status", HTTP_RESP_OK);
     buffer_json_member_add_string(wb, "type", "table");
     buffer_json_member_add_time_t(wb, "update_every", 1);
+    buffer_json_member_add_boolean(wb, "has_history", false);
     buffer_json_member_add_string(wb, "help", RRDFUNCTIONS_DISKSPACE_HELP);
     buffer_json_member_add_array(wb, "data");
 

--- a/collectors/network-viewer.plugin/network-connections-chart.html
+++ b/collectors/network-viewer.plugin/network-connections-chart.html
@@ -557,15 +557,39 @@
 
         const app = updateApps(svg, data, w, h, borderPadding, theme);
 
+        app.transition().duration(5000)
+
         simulation = d3.forceSimulation(data)
             //.force('center', d3.forceCenter(cw, ch).strength(1))
-            .force("x", d3.forceX(d => d.d3.x).strength(0.05))
-            .force("y", d3.forceY(d => d.d3.y).strength(0.05))
+            .force("x", d3.forceX(d => d.d3.x).strength(d => {
+                if(d.counts.listen === d.counts.total)
+                    return 0.5
+                else
+                    return 0.05
+            }))
+            .force("y", d3.forceY(d => d.d3.y).strength(d => {
+                if(d.counts.listen === d.counts.total)
+                    return 0.5
+                else
+                    return 0.05
+            }))
             //.force("charge", d3.forceManyBody().strength(-0.05))
             .force("collide", d3.forceCollide(d => d.d3.size * 1.1 + 15).strength(1))
             .on('tick', ticked);
 
         function ticked() {
+            data.forEach(d => {
+                if(d.x > w - d.d3.size)
+                    d.x = w - d.d3.size;
+                else if(d.x < 0)
+                    d.x = 0;
+
+                if(d.y > h - d.d3.size)
+                    d.y = h - d.d3.size;
+                else if(d.y < 0)
+                    d.y = 0;
+            });
+
             app.attr('transform', d => `translate(${d.x}, ${d.y})`);
         }
 

--- a/collectors/network-viewer.plugin/network-viewer.c
+++ b/collectors/network-viewer.plugin/network-viewer.c
@@ -139,6 +139,7 @@ void network_viewer_function(const char *transaction, char *function __maybe_unu
                              bool *cancelled __maybe_unused, BUFFER *payload __maybe_unused, HTTP_ACCESS access __maybe_unused,
                              const char *source __maybe_unused, void *data __maybe_unused) {
 
+    time_t now_s = now_realtime_sec();
     CLEAN_BUFFER *wb = buffer_create(0, NULL);
     buffer_flush(wb);
     wb->content_type = CT_APPLICATION_JSON;
@@ -147,360 +148,379 @@ void network_viewer_function(const char *transaction, char *function __maybe_unu
     buffer_json_member_add_uint64(wb, "status", HTTP_RESP_OK);
     buffer_json_member_add_string(wb, "type", "table");
     buffer_json_member_add_time_t(wb, "update_every", 5);
+    buffer_json_member_add_boolean(wb, "has_history", false);
     buffer_json_member_add_string(wb, "help", NETWORK_CONNECTIONS_VIEWER_HELP);
-    buffer_json_member_add_array(wb, "data");
 
-    LS_STATE ls = {
-        .config = {
-            .listening = true,
-            .inbound = true,
-            .outbound = true,
-            .local = true,
-            .tcp4 = true,
-            .tcp6 = true,
-            .udp4 = true,
-            .udp6 = true,
-            .pid = true,
-            .uid = true,
-            .cmdline = true,
-            .comm = true,
-            .namespaces = true,
-
-            .max_errors = 10,
-
-            .cb = local_socket_to_array,
-            .data = wb,
-        },
-        .stats = { 0 },
-        .sockets_hashtable = { 0 },
-        .local_ips_hashtable = { 0 },
-        .listening_ports_hashtable = { 0 },
-    };
-
-    local_sockets_process(&ls);
-
-    buffer_json_array_close(wb);
-    buffer_json_member_add_object(wb, "columns");
-    {
-        size_t field_id = 0;
-
-        // Direction
-        buffer_rrdf_table_add_field(wb, field_id++, "Direction", "Socket Direction",
-                                    RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                                    RRDF_FIELD_OPTS_VISIBLE,
-                                    NULL);
-
-        // Protocol
-        buffer_rrdf_table_add_field(wb, field_id++, "Protocol", "Socket Protocol",
-                                    RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                                    RRDF_FIELD_OPTS_VISIBLE,
-                                    NULL);
-
-        // Type
-        buffer_rrdf_table_add_field(wb, field_id++, "Namespace", "Namespace",
-                                    RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                                    RRDF_FIELD_OPTS_VISIBLE,
-                                    NULL);
-
-        // State
-        buffer_rrdf_table_add_field(wb, field_id++, "State", "Socket State",
-                                    RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                                    RRDF_FIELD_OPTS_VISIBLE,
-                                    NULL);
-
-        // Pid
-        buffer_rrdf_table_add_field(wb, field_id++, "PID", "Process ID",
-                                    RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
-                                    RRDF_FIELD_OPTS_VISIBLE,
-                                    NULL);
-
-        // Comm
-        buffer_rrdf_table_add_field(wb, field_id++, "Process", "Process Name",
-                                    RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                                    RRDF_FIELD_OPTS_VISIBLE|RRDF_FIELD_OPTS_FULL_WIDTH,
-                                    NULL);
-
-        // Cmdline
-        buffer_rrdf_table_add_field(wb, field_id++, "CommandLine", "Command Line",
-                                    RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
-                                    RRDF_FIELD_OPTS_NONE|RRDF_FIELD_OPTS_FULL_WIDTH,
-                                    NULL);
-
-        // Uid
-        buffer_rrdf_table_add_field(wb, field_id++, "UID", "User ID",
-                                    RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
-                                    RRDF_FIELD_OPTS_NONE,
-                                    NULL);
-
-        // Username
-        buffer_rrdf_table_add_field(wb, field_id++, "User", "Username",
-                                    RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                                    RRDF_FIELD_OPTS_VISIBLE,
-                                    NULL);
-
-        // Local Address
-        buffer_rrdf_table_add_field(wb, field_id++, "LocalIP", "Local IP Address",
-                                    RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
-                                    RRDF_FIELD_OPTS_VISIBLE|RRDF_FIELD_OPTS_FULL_WIDTH,
-                                    NULL);
-
-        // Local Port
-        buffer_rrdf_table_add_field(wb, field_id++, "LocalPort", "Local Port",
-                                    RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
-                                    RRDF_FIELD_OPTS_VISIBLE,
-                                    NULL);
-
-        // Local Address Space
-        buffer_rrdf_table_add_field(wb, field_id++, "LocalAddressSpace", "Local IP Address Space",
-                                    RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                                    RRDF_FIELD_OPTS_NONE,
-                                    NULL);
-
-        // Remote Address
-        buffer_rrdf_table_add_field(wb, field_id++, "RemoteIP", "Remote IP Address",
-                                    RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
-                                    RRDF_FIELD_OPTS_VISIBLE|RRDF_FIELD_OPTS_FULL_WIDTH,
-                                    NULL);
-
-        // Remote Port
-        buffer_rrdf_table_add_field(wb, field_id++, "RemotePort", "Remote Port",
-                                    RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
-                                    RRDF_FIELD_OPTS_VISIBLE,
-                                    NULL);
-
-        // Remote Address Space
-        buffer_rrdf_table_add_field(wb, field_id++, "RemoteAddressSpace", "Remote IP Address Space",
-                                    RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                                    RRDF_FIELD_OPTS_NONE,
-                                    NULL);
-
-        // Server Port
-        buffer_rrdf_table_add_field(wb, field_id++, "ServerPort", "Server Port",
-                                    RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
-                                    RRDF_FIELD_OPTS_NONE,
-                                    NULL);
-
-        // inode
-        buffer_rrdf_table_add_field(wb, field_id++, "Inode", "Socket Inode",
-                                    RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
-                                    RRDF_FIELD_OPTS_NONE,
-                                    NULL);
-
-        // Namespace inode
-        buffer_rrdf_table_add_field(wb, field_id++, "Namespace Inode", "Namespace Inode",
-                                    RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
-                                    RRDF_FIELD_OPTS_NONE,
-                                    NULL);
-
-        // Count
-        buffer_rrdf_table_add_field(wb, field_id++, "Count", "Count",
-                                    RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
-                                    0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
-                                    RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
-                                    RRDF_FIELD_OPTS_NONE,
-                                    NULL);
-    }
-    buffer_json_object_close(wb); // columns
-    buffer_json_member_add_string(wb, "default_sort_column", "Direction");
-
-    buffer_json_member_add_object(wb, "custom_charts");
-    {
-        buffer_json_member_add_object(wb, "Network Map");
-        {
-            buffer_json_member_add_string(wb, "type", "network-viewer");
+    char function_copy[strlen(function) + 1];
+    memcpy(function_copy, function, sizeof(function_copy));
+    char *words[1024];
+    size_t num_words = quoted_strings_splitter_pluginsd(function_copy, words, 1024);
+    for(size_t i = 1; i < num_words ;i++) {
+        char *param = get_word(words, num_words, i);
+        if(strcmp(param, "info") == 0) {
+            buffer_json_member_add_array(wb, "accepted_params");
+            buffer_json_array_close(wb); // accepted_params
+            buffer_json_member_add_array(wb, "required_params");
+            buffer_json_array_close(wb); // required_params
+            goto close_and_send;
         }
-        buffer_json_object_close(wb);
     }
-    buffer_json_object_close(wb); // custom_charts
 
-    buffer_json_member_add_object(wb, "charts");
     {
-        // Data Collection Age chart
-        buffer_json_member_add_object(wb, "Count");
+        buffer_json_member_add_array(wb, "data");
+
+        LS_STATE ls = {
+            .config = {
+                .listening = true,
+                .inbound = true,
+                .outbound = true,
+                .local = true,
+                .tcp4 = true,
+                .tcp6 = true,
+                .udp4 = true,
+                .udp6 = true,
+                .pid = true,
+                .uid = true,
+                .cmdline = true,
+                .comm = true,
+                .namespaces = true,
+
+                .max_errors = 10,
+
+                .cb = local_socket_to_array,
+                .data = wb,
+            },
+            .stats = { 0 },
+            .sockets_hashtable = { 0 },
+            .local_ips_hashtable = { 0 },
+            .listening_ports_hashtable = { 0 },
+        };
+
+        local_sockets_process(&ls);
+
+        buffer_json_array_close(wb);
+        buffer_json_member_add_object(wb, "columns");
         {
-            buffer_json_member_add_string(wb, "type", "stacked-bar");
-            buffer_json_member_add_array(wb, "columns");
+            size_t field_id = 0;
+
+            // Direction
+            buffer_rrdf_table_add_field(wb, field_id++, "Direction", "Socket Direction",
+                                        RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                                        RRDF_FIELD_OPTS_VISIBLE,
+                                        NULL);
+
+            // Protocol
+            buffer_rrdf_table_add_field(wb, field_id++, "Protocol", "Socket Protocol",
+                                        RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                                        RRDF_FIELD_OPTS_VISIBLE,
+                                        NULL);
+
+            // Type
+            buffer_rrdf_table_add_field(wb, field_id++, "Namespace", "Namespace",
+                                        RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                                        RRDF_FIELD_OPTS_VISIBLE,
+                                        NULL);
+
+            // State
+            buffer_rrdf_table_add_field(wb, field_id++, "State", "Socket State",
+                                        RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                                        RRDF_FIELD_OPTS_VISIBLE,
+                                        NULL);
+
+            // Pid
+            buffer_rrdf_table_add_field(wb, field_id++, "PID", "Process ID",
+                                        RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
+                                        RRDF_FIELD_OPTS_VISIBLE,
+                                        NULL);
+
+            // Comm
+            buffer_rrdf_table_add_field(wb, field_id++, "Process", "Process Name",
+                                        RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                                        RRDF_FIELD_OPTS_VISIBLE|RRDF_FIELD_OPTS_FULL_WIDTH,
+                                        NULL);
+
+            // Cmdline
+            buffer_rrdf_table_add_field(wb, field_id++, "CommandLine", "Command Line",
+                                        RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
+                                        RRDF_FIELD_OPTS_NONE|RRDF_FIELD_OPTS_FULL_WIDTH,
+                                        NULL);
+
+            // Uid
+            buffer_rrdf_table_add_field(wb, field_id++, "UID", "User ID",
+                                        RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
+                                        RRDF_FIELD_OPTS_NONE,
+                                        NULL);
+
+            // Username
+            buffer_rrdf_table_add_field(wb, field_id++, "User", "Username",
+                                        RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                                        RRDF_FIELD_OPTS_VISIBLE,
+                                        NULL);
+
+            // Local Address
+            buffer_rrdf_table_add_field(wb, field_id++, "LocalIP", "Local IP Address",
+                                        RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
+                                        RRDF_FIELD_OPTS_VISIBLE|RRDF_FIELD_OPTS_FULL_WIDTH,
+                                        NULL);
+
+            // Local Port
+            buffer_rrdf_table_add_field(wb, field_id++, "LocalPort", "Local Port",
+                                        RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
+                                        RRDF_FIELD_OPTS_VISIBLE,
+                                        NULL);
+
+            // Local Address Space
+            buffer_rrdf_table_add_field(wb, field_id++, "LocalAddressSpace", "Local IP Address Space",
+                                        RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                                        RRDF_FIELD_OPTS_NONE,
+                                        NULL);
+
+            // Remote Address
+            buffer_rrdf_table_add_field(wb, field_id++, "RemoteIP", "Remote IP Address",
+                                        RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
+                                        RRDF_FIELD_OPTS_VISIBLE|RRDF_FIELD_OPTS_FULL_WIDTH,
+                                        NULL);
+
+            // Remote Port
+            buffer_rrdf_table_add_field(wb, field_id++, "RemotePort", "Remote Port",
+                                        RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
+                                        RRDF_FIELD_OPTS_VISIBLE,
+                                        NULL);
+
+            // Remote Address Space
+            buffer_rrdf_table_add_field(wb, field_id++, "RemoteAddressSpace", "Remote IP Address Space",
+                                        RRDF_FIELD_TYPE_STRING, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                                        RRDF_FIELD_OPTS_NONE,
+                                        NULL);
+
+            // Server Port
+            buffer_rrdf_table_add_field(wb, field_id++, "ServerPort", "Server Port",
+                                        RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_MULTISELECT,
+                                        RRDF_FIELD_OPTS_NONE,
+                                        NULL);
+
+            // inode
+            buffer_rrdf_table_add_field(wb, field_id++, "Inode", "Socket Inode",
+                                        RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
+                                        RRDF_FIELD_OPTS_NONE,
+                                        NULL);
+
+            // Namespace inode
+            buffer_rrdf_table_add_field(wb, field_id++, "Namespace Inode", "Namespace Inode",
+                                        RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
+                                        RRDF_FIELD_OPTS_NONE,
+                                        NULL);
+
+            // Count
+            buffer_rrdf_table_add_field(wb, field_id++, "Count", "Count",
+                                        RRDF_FIELD_TYPE_INTEGER, RRDF_FIELD_VISUAL_VALUE, RRDF_FIELD_TRANSFORM_NONE,
+                                        0, NULL, NAN, RRDF_FIELD_SORT_ASCENDING, NULL,
+                                        RRDF_FIELD_SUMMARY_COUNT, RRDF_FIELD_FILTER_NONE,
+                                        RRDF_FIELD_OPTS_NONE,
+                                        NULL);
+        }
+        buffer_json_object_close(wb); // columns
+        buffer_json_member_add_string(wb, "default_sort_column", "Direction");
+
+        buffer_json_member_add_object(wb, "custom_charts");
+        {
+            buffer_json_member_add_object(wb, "Network Map");
             {
-                buffer_json_add_array_item_string(wb, "Direction");
+                buffer_json_member_add_string(wb, "type", "network-viewer");
             }
+            buffer_json_object_close(wb);
+        }
+        buffer_json_object_close(wb); // custom_charts
+
+        buffer_json_member_add_object(wb, "charts");
+        {
+            // Data Collection Age chart
+            buffer_json_member_add_object(wb, "Count");
+            {
+                buffer_json_member_add_string(wb, "type", "stacked-bar");
+                buffer_json_member_add_array(wb, "columns");
+                {
+                    buffer_json_add_array_item_string(wb, "Direction");
+                }
+                buffer_json_array_close(wb);
+            }
+            buffer_json_object_close(wb);
+
+            // Streaming Age chart
+            buffer_json_member_add_object(wb, "Count");
+            {
+                buffer_json_member_add_string(wb, "type", "stacked-bar");
+                buffer_json_member_add_array(wb, "columns");
+                {
+                    buffer_json_add_array_item_string(wb, "Process");
+                }
+                buffer_json_array_close(wb);
+            }
+            buffer_json_object_close(wb);
+
+            // DB Duration
+            buffer_json_member_add_object(wb, "Count");
+            {
+                buffer_json_member_add_string(wb, "type", "stacked-bar");
+                buffer_json_member_add_array(wb, "columns");
+                {
+                    buffer_json_add_array_item_string(wb, "Protocol");
+                }
+                buffer_json_array_close(wb);
+            }
+            buffer_json_object_close(wb);
+        }
+        buffer_json_object_close(wb); // charts
+
+        buffer_json_member_add_array(wb, "default_charts");
+        {
+            buffer_json_add_array_item_array(wb);
+            buffer_json_add_array_item_string(wb, "Count");
+            buffer_json_add_array_item_string(wb, "Direction");
+            buffer_json_array_close(wb);
+
+            buffer_json_add_array_item_array(wb);
+            buffer_json_add_array_item_string(wb, "Count");
+            buffer_json_add_array_item_string(wb, "Process");
             buffer_json_array_close(wb);
         }
-        buffer_json_object_close(wb);
-
-        // Streaming Age chart
-        buffer_json_member_add_object(wb, "Count");
-        {
-            buffer_json_member_add_string(wb, "type", "stacked-bar");
-            buffer_json_member_add_array(wb, "columns");
-            {
-                buffer_json_add_array_item_string(wb, "Process");
-            }
-            buffer_json_array_close(wb);
-        }
-        buffer_json_object_close(wb);
-
-        // DB Duration
-        buffer_json_member_add_object(wb, "Count");
-        {
-            buffer_json_member_add_string(wb, "type", "stacked-bar");
-            buffer_json_member_add_array(wb, "columns");
-            {
-                buffer_json_add_array_item_string(wb, "Protocol");
-            }
-            buffer_json_array_close(wb);
-        }
-        buffer_json_object_close(wb);
-    }
-    buffer_json_object_close(wb); // charts
-
-    buffer_json_member_add_array(wb, "default_charts");
-    {
-        buffer_json_add_array_item_array(wb);
-        buffer_json_add_array_item_string(wb, "Count");
-        buffer_json_add_array_item_string(wb, "Direction");
         buffer_json_array_close(wb);
 
-        buffer_json_add_array_item_array(wb);
-        buffer_json_add_array_item_string(wb, "Count");
-        buffer_json_add_array_item_string(wb, "Process");
-        buffer_json_array_close(wb);
+        buffer_json_member_add_object(wb, "group_by");
+        {
+            buffer_json_member_add_object(wb, "Direction");
+            {
+                buffer_json_member_add_string(wb, "name", "Direction");
+                buffer_json_member_add_array(wb, "columns");
+                {
+                    buffer_json_add_array_item_string(wb, "Direction");
+                }
+                buffer_json_array_close(wb);
+            }
+            buffer_json_object_close(wb);
+
+            buffer_json_member_add_object(wb, "Protocol");
+            {
+                buffer_json_member_add_string(wb, "name", "Protocol");
+                buffer_json_member_add_array(wb, "columns");
+                {
+                    buffer_json_add_array_item_string(wb, "Protocol");
+                }
+                buffer_json_array_close(wb);
+            }
+            buffer_json_object_close(wb);
+
+            buffer_json_member_add_object(wb, "Namespace");
+            {
+                buffer_json_member_add_string(wb, "name", "Namespace");
+                buffer_json_member_add_array(wb, "columns");
+                {
+                    buffer_json_add_array_item_string(wb, "Namespace");
+                }
+                buffer_json_array_close(wb);
+            }
+            buffer_json_object_close(wb);
+
+            buffer_json_member_add_object(wb, "Process");
+            {
+                buffer_json_member_add_string(wb, "name", "Process");
+                buffer_json_member_add_array(wb, "columns");
+                {
+                    buffer_json_add_array_item_string(wb, "Process");
+                }
+                buffer_json_array_close(wb);
+            }
+            buffer_json_object_close(wb);
+
+            buffer_json_member_add_object(wb, "LocalIP");
+            {
+                buffer_json_member_add_string(wb, "name", "Local IP");
+                buffer_json_member_add_array(wb, "columns");
+                {
+                    buffer_json_add_array_item_string(wb, "LocalIP");
+                }
+                buffer_json_array_close(wb);
+            }
+            buffer_json_object_close(wb);
+
+            buffer_json_member_add_object(wb, "LocalPort");
+            {
+                buffer_json_member_add_string(wb, "name", "Local Port");
+                buffer_json_member_add_array(wb, "columns");
+                {
+                    buffer_json_add_array_item_string(wb, "LocalPort");
+                }
+                buffer_json_array_close(wb);
+            }
+            buffer_json_object_close(wb);
+
+            buffer_json_member_add_object(wb, "RemoteIP");
+            {
+                buffer_json_member_add_string(wb, "name", "Remote IP");
+                buffer_json_member_add_array(wb, "columns");
+                {
+                    buffer_json_add_array_item_string(wb, "RemoteIP");
+                }
+                buffer_json_array_close(wb);
+            }
+            buffer_json_object_close(wb);
+
+            buffer_json_member_add_object(wb, "RemotePort");
+            {
+                buffer_json_member_add_string(wb, "name", "Remote Port");
+                buffer_json_member_add_array(wb, "columns");
+                {
+                    buffer_json_add_array_item_string(wb, "RemotePort");
+                }
+                buffer_json_array_close(wb);
+            }
+            buffer_json_object_close(wb);
+        }
+        buffer_json_object_close(wb); // group_by
     }
-    buffer_json_array_close(wb);
 
-    buffer_json_member_add_object(wb, "group_by");
-    {
-        buffer_json_member_add_object(wb, "Direction");
-        {
-            buffer_json_member_add_string(wb, "name", "Direction");
-            buffer_json_member_add_array(wb, "columns");
-            {
-                buffer_json_add_array_item_string(wb, "Direction");
-            }
-            buffer_json_array_close(wb);
-        }
-        buffer_json_object_close(wb);
-
-        buffer_json_member_add_object(wb, "Protocol");
-        {
-            buffer_json_member_add_string(wb, "name", "Protocol");
-            buffer_json_member_add_array(wb, "columns");
-            {
-                buffer_json_add_array_item_string(wb, "Protocol");
-            }
-            buffer_json_array_close(wb);
-        }
-        buffer_json_object_close(wb);
-
-        buffer_json_member_add_object(wb, "Namespace");
-        {
-            buffer_json_member_add_string(wb, "name", "Namespace");
-            buffer_json_member_add_array(wb, "columns");
-            {
-                buffer_json_add_array_item_string(wb, "Namespace");
-            }
-            buffer_json_array_close(wb);
-        }
-        buffer_json_object_close(wb);
-
-        buffer_json_member_add_object(wb, "Process");
-        {
-            buffer_json_member_add_string(wb, "name", "Process");
-            buffer_json_member_add_array(wb, "columns");
-            {
-                buffer_json_add_array_item_string(wb, "Process");
-            }
-            buffer_json_array_close(wb);
-        }
-        buffer_json_object_close(wb);
-
-        buffer_json_member_add_object(wb, "LocalIP");
-        {
-            buffer_json_member_add_string(wb, "name", "Local IP");
-            buffer_json_member_add_array(wb, "columns");
-            {
-                buffer_json_add_array_item_string(wb, "LocalIP");
-            }
-            buffer_json_array_close(wb);
-        }
-        buffer_json_object_close(wb);
-
-        buffer_json_member_add_object(wb, "LocalPort");
-        {
-            buffer_json_member_add_string(wb, "name", "Local Port");
-            buffer_json_member_add_array(wb, "columns");
-            {
-                buffer_json_add_array_item_string(wb, "LocalPort");
-            }
-            buffer_json_array_close(wb);
-        }
-        buffer_json_object_close(wb);
-
-        buffer_json_member_add_object(wb, "RemoteIP");
-        {
-            buffer_json_member_add_string(wb, "name", "Remote IP");
-            buffer_json_member_add_array(wb, "columns");
-            {
-                buffer_json_add_array_item_string(wb, "RemoteIP");
-            }
-            buffer_json_array_close(wb);
-        }
-        buffer_json_object_close(wb);
-
-        buffer_json_member_add_object(wb, "RemotePort");
-        {
-            buffer_json_member_add_string(wb, "name", "Remote Port");
-            buffer_json_member_add_array(wb, "columns");
-            {
-                buffer_json_add_array_item_string(wb, "RemotePort");
-            }
-            buffer_json_array_close(wb);
-        }
-        buffer_json_object_close(wb);
-    }
-    buffer_json_object_close(wb); // group_by
-
-
-    buffer_json_member_add_time_t(wb, "expires", now_realtime_sec() + 1);
+close_and_send:
+    buffer_json_member_add_time_t(wb, "expires", now_s + 1);
     buffer_json_finalize(wb);
 
     netdata_mutex_lock(&stdout_mutex);
-    pluginsd_function_result_to_stdout(transaction, HTTP_RESP_OK, "application/json", now_realtime_sec(), wb);
+    pluginsd_function_result_to_stdout(transaction, HTTP_RESP_OK, "application/json", now_s + 1, wb);
     netdata_mutex_unlock(&stdout_mutex);
 }
 

--- a/collectors/plugins.d/local_listeners.c
+++ b/collectors/plugins.d/local_listeners.c
@@ -40,7 +40,7 @@ static void print_local_listeners(LS_STATE *ls __maybe_unused, LOCAL_SOCKET *n, 
         ipv6_address_to_txt(&n->remote.ip.ipv6, remote_address);
     }
 
-    printf("%s|%s|%u|%s\n", protocol_name(n), local_address, n->local.port, n->cmdline ? n->cmdline : "");
+    printf("%s|%s|%u|%s\n", protocol_name(n), local_address, n->local.port, string2str(n->cmdline));
 }
 
 static void print_local_listeners_debug(LS_STATE *ls __maybe_unused, LOCAL_SOCKET *n, void *data __maybe_unused) {

--- a/collectors/plugins.d/pluginsd_functions.c
+++ b/collectors/plugins.d/pluginsd_functions.c
@@ -13,7 +13,7 @@ static void inflight_functions_insert_callback(const DICTIONARY_ITEM *item, void
     PARSER  *parser = parser_ptr;
 
     // leave this code as default, so that when the dictionary is destroyed this will be sent back to the caller
-    pf->code = HTTP_RESP_GATEWAY_TIMEOUT;
+    pf->code = HTTP_RESP_SERVICE_UNAVAILABLE;
 
     const char *transaction = dictionary_acquired_item_name(item);
 
@@ -92,6 +92,9 @@ static void inflight_functions_delete_callback(const DICTIONARY_ITEM *item __may
                    string2str(pf->function), dictionary_acquired_item_name(item),
                    buffer_strlen(pf->result_body_wb),
                    pf->sent_monotonic_ut - pf->started_monotonic_ut, now_realtime_usec() - pf->sent_monotonic_ut);
+
+    if(pf->code == HTTP_RESP_SERVICE_UNAVAILABLE && !buffer_strlen(pf->result_body_wb))
+        rrd_call_function_error(pf->result_body_wb, "The plugin exited while servicing this call.", pf->code);
 
     pf->result.cb(pf->result_body_wb, pf->code, pf->result.data);
 

--- a/collectors/proc.plugin/proc_diskstats.c
+++ b/collectors/proc.plugin/proc_diskstats.c
@@ -1042,6 +1042,7 @@ static int diskstats_function_block_devices(BUFFER *wb, const char *function __m
     buffer_json_member_add_uint64(wb, "status", HTTP_RESP_OK);
     buffer_json_member_add_string(wb, "type", "table");
     buffer_json_member_add_time_t(wb, "update_every", 1);
+    buffer_json_member_add_boolean(wb, "has_history", false);
     buffer_json_member_add_string(wb, "help", RRDFUNCTIONS_DISKSTATS_HELP);
     buffer_json_member_add_array(wb, "data");
 

--- a/collectors/proc.plugin/proc_net_dev.c
+++ b/collectors/proc.plugin/proc_net_dev.c
@@ -482,6 +482,7 @@ int netdev_function_net_interfaces(BUFFER *wb, const char *function __maybe_unus
     buffer_json_member_add_uint64(wb, "status", HTTP_RESP_OK);
     buffer_json_member_add_string(wb, "type", "table");
     buffer_json_member_add_time_t(wb, "update_every", 1);
+    buffer_json_member_add_boolean(wb, "has_history", false);
     buffer_json_member_add_string(wb, "help", RRDFUNCTIONS_NETDEV_HELP);
     buffer_json_member_add_array(wb, "data");
 

--- a/src/database/rrdfunctions-inflight.c
+++ b/src/database/rrdfunctions-inflight.c
@@ -427,7 +427,6 @@ int rrd_function_run(RRDHOST *host, BUFFER *result_wb, int timeout_s,
 
     code = rrd_functions_find_by_name(host, result_wb, sanitized_cmd, sanitized_cmd_length, &host_function_acquired);
     if(code != HTTP_RESP_OK) {
-        rrd_call_function_error(result_wb, "not found", code);
 
         if(result_cb)
             result_cb(result_wb, code, result_cb_data);

--- a/src/database/rrdfunctions-streaming.c
+++ b/src/database/rrdfunctions-streaming.c
@@ -14,6 +14,7 @@ int rrdhost_function_streaming(BUFFER *wb, const char *function __maybe_unused) 
     buffer_json_member_add_uint64(wb, "status", HTTP_RESP_OK);
     buffer_json_member_add_string(wb, "type", "table");
     buffer_json_member_add_time_t(wb, "update_every", 1);
+    buffer_json_member_add_boolean(wb, "has_history", false);
     buffer_json_member_add_string(wb, "help", RRDFUNCTIONS_STREAMING_HELP);
     buffer_json_member_add_array(wb, "data");
 

--- a/src/libnetdata/aral/aral.c
+++ b/src/libnetdata/aral/aral.c
@@ -464,6 +464,12 @@ static inline ARAL_PAGE *aral_acquire_a_free_slot(ARAL *ar TRACE_ALLOCATIONS_FUN
     return page;
 }
 
+void *aral_callocz_internal(ARAL *ar TRACE_ALLOCATIONS_FUNCTION_DEFINITION_PARAMS) {
+    void *r = aral_mallocz_internal(ar TRACE_ALLOCATIONS_FUNCTION_CALL_PARAMS);
+    memset(r, 0, ar->config.requested_element_size);
+    return r;
+}
+
 void *aral_mallocz_internal(ARAL *ar TRACE_ALLOCATIONS_FUNCTION_DEFINITION_PARAMS) {
 #ifdef FSANITIZE_ADDRESS
     return mallocz(ar->config.requested_element_size);

--- a/src/libnetdata/aral/aral.h
+++ b/src/libnetdata/aral/aral.h
@@ -46,10 +46,12 @@ int aral_unittest(size_t elements);
 
 #ifdef NETDATA_TRACE_ALLOCATIONS
 
+#define aral_callocz(ar) aral_callocz_internal(ar, __FILE__, __FUNCTION__, __LINE__)
 #define aral_mallocz(ar) aral_mallocz_internal(ar, __FILE__, __FUNCTION__, __LINE__)
 #define aral_freez(ar, ptr) aral_freez_internal(ar, ptr, __FILE__, __FUNCTION__, __LINE__)
 #define aral_destroy(ar) aral_destroy_internal(ar, __FILE__, __FUNCTION__, __LINE__)
 
+void *aral_callocz_internal(ARAL *ar, const char *file, const char *function, size_t line);
 void *aral_mallocz_internal(ARAL *ar, const char *file, const char *function, size_t line);
 void aral_freez_internal(ARAL *ar, void *ptr, const char *file, const char *function, size_t line);
 void aral_destroy_internal(ARAL *ar, const char *file, const char *function, size_t line);
@@ -57,9 +59,11 @@ void aral_destroy_internal(ARAL *ar, const char *file, const char *function, siz
 #else // NETDATA_TRACE_ALLOCATIONS
 
 #define aral_mallocz(ar) aral_mallocz_internal(ar)
+#define aral_callocz(ar) aral_callocz_internal(ar)
 #define aral_freez(ar, ptr) aral_freez_internal(ar, ptr)
 #define aral_destroy(ar) aral_destroy_internal(ar)
 
+void *aral_callocz_internal(ARAL *ar);
 void *aral_mallocz_internal(ARAL *ar);
 void aral_freez_internal(ARAL *ar, void *ptr);
 void aral_destroy_internal(ARAL *ar);

--- a/src/libnetdata/buffer/buffer.c
+++ b/src/libnetdata/buffer/buffer.c
@@ -341,8 +341,10 @@ __attribute__((constructor)) void initialize_ascii_maps(void) {
         base64_value_from_ascii[i] = 255;
     }
 
-    for(size_t i = 0; i < 16 ; i++)
-        hex_value_from_ascii[(int)hex_digits[i]] = i;
+    for(size_t i = 0; i < 16 ; i++) {
+        hex_value_from_ascii[(int)toupper(hex_digits[i])] = i;
+        hex_value_from_ascii[(int)tolower(hex_digits[i])] = i;
+    }
 
     for(size_t i = 0; i < 64 ; i++)
         base64_value_from_ascii[(int)base64_digits[i]] = i;

--- a/src/libnetdata/inlined.h
+++ b/src/libnetdata/inlined.h
@@ -204,12 +204,28 @@ static inline long long str2ll(const char *s, char **endptr) {
     }
 }
 
+static inline uint32_t str2uint32_hex(const char *src, char **endptr) {
+    uint32_t num = 0;
+    const unsigned char *s = (const unsigned char *)src;
+    unsigned char c;
+
+    while ((c = hex_value_from_ascii[(uint8_t)*s]) != 255) {
+        num = (num << 4) | c;
+        s++;
+    }
+
+    if(endptr)
+        *endptr = (char *)s;
+
+    return num;
+}
+
 static inline uint64_t str2uint64_hex(const char *src, char **endptr) {
     uint64_t num = 0;
     const unsigned char *s = (const unsigned char *)src;
     unsigned char c;
 
-    while ((c = hex_value_from_ascii[toupper(*s)]) != 255) {
+    while ((c = hex_value_from_ascii[(uint8_t)*s]) != 255) {
         num = (num << 4) | c;
         s++;
     }

--- a/src/libnetdata/query_progress/progress.c
+++ b/src/libnetdata/query_progress/progress.c
@@ -408,6 +408,7 @@ int progress_function_result(BUFFER *wb, const char *hostname) {
     buffer_json_member_add_uint64(wb, "status", HTTP_RESP_OK);
     buffer_json_member_add_string(wb, "type", "table");
     buffer_json_member_add_time_t(wb, "update_every", 1);
+    buffer_json_member_add_boolean(wb, "has_history", false);
     buffer_json_member_add_string(wb, "help", RRDFUNCTIONS_PROGRESS_HELP);
     buffer_json_member_add_array(wb, "data");
 

--- a/src/libnetdata/socket/socket.c
+++ b/src/libnetdata/socket/socket.c
@@ -1387,7 +1387,7 @@ int accept_socket(int fd, int flags, char *client_ip, size_t ipsize, char *clien
     struct sockaddr_storage sadr;
     socklen_t addrlen = sizeof(sadr);
 
-    int nfd = accept4(fd, (struct sockaddr *)&sadr, &addrlen, flags);
+    int nfd = accept4(fd, (struct sockaddr *)&sadr, &addrlen, flags | SOCK_CLOEXEC);
     if (likely(nfd >= 0)) {
         if (getnameinfo((struct sockaddr *)&sadr, addrlen, client_ip, (socklen_t)ipsize,
                         client_port, (socklen_t)portsize, NI_NUMERICHOST | NI_NUMERICSERV) != 0) {


### PR DESCRIPTION
- [x] added support for the `info` function parameter to all external plugin functions
- [x] added the missing `SO_CLOEXEC` to `accept4()` when accepting incoming connections
- [x] network-viewer can now supports 2 modes of operation:
   - `aggregated` where it returns aggregated data of the sockets. Local and Remote IPs and Ports are not there anymore. The aggregation happens on "Server IP" (which is either Local or Remote depending on the direction). `aggregated` is currently disabled, until the UI can handle it.
   - `detailed`, where it returns all data like it did before this PR.
  
  The `aggregated` view should relax the pressure on web browser resources on very busy servers with thousands of inbound or outbound connections, allowing the visualization and the table to work efficiently.
- [x] local-sockets is now using ARAL for its memory allocations.
- [x] minimized the payload returned by network-connections to allow working in bigger setups