### PR TITLE
respect log level for all sources

### DIFF
--- a/src/libnetdata/log/log.c
+++ b/src/libnetdata/log/log.c
@@ -661,8 +661,10 @@ void nd_log_set_priority_level(const char *setting) {
     priority = NDLP_DEBUG;
 #endif
 
-    nd_log.sources[NDLS_DAEMON].min_priority = priority;
-    nd_log.sources[NDLS_COLLECTORS].min_priority = priority;
+    for (size_t i = 0; i < _NDLS_MAX; i++) {
+        if (i != NDLS_DEBUG)
+            nd_log.sources[i].min_priority = priority;
+    }
 
     // the right one
     setenv("NETDATA_LOG_LEVEL", nd_log_id2priority(priority), 1);

--- a/src/libnetdata/log/log.c
+++ b/src/libnetdata/log/log.c
@@ -2254,7 +2254,7 @@ void netdata_logger(ND_LOG_SOURCES source, ND_LOG_FIELD_PRIORITY priority, const
     int saved_errno = errno;
     source = nd_log_validate_source(source);
 
-    if((source == NDLS_DAEMON || source == NDLS_COLLECTORS) && priority > nd_log.sources[source].min_priority)
+    if (source != NDLS_DEBUG && priority > nd_log.sources[source].min_priority)
         return;
 
     va_list args;
@@ -2268,6 +2268,9 @@ void netdata_logger(ND_LOG_SOURCES source, ND_LOG_FIELD_PRIORITY priority, const
 void netdata_logger_with_limit(ERROR_LIMIT *erl, ND_LOG_SOURCES source, ND_LOG_FIELD_PRIORITY priority, const char *file __maybe_unused, const char *function __maybe_unused, const unsigned long line __maybe_unused, const char *fmt, ... ) {
     int saved_errno = errno;
     source = nd_log_validate_source(source);
+
+    if (source != NDLS_DEBUG && priority > nd_log.sources[source].min_priority)
+        return;
 
     if(erl->sleep_ut)
         sleep_usec(erl->sleep_ut);


### PR DESCRIPTION
##### Summary

There are two things in the logging library that are not documented and I believe are not bugs, but are implemented for a reason:

1. The default log level affects only the daemon and collector logs ([nd_log_set_priority_level()](https://github.com/netdata/netdata/blob/master/src/libnetdata/log/log.c#L654-L669)).
2. There is a way to [set the log level per source](https://github.com/netdata/netdata/tree/master/src/libnetdata/log#configuring-log-sources), but again, the filtering affects only the daemon and collector logs ([netdata_logger()](https://github.com/netdata/netdata/blob/e34730ea322aef32be77608d34bb96fad6e6b471/src/libnetdata/log/log.c#L2257-L2258)).

I think I understand 1. - we don't want to filter health (alerts transitions) and access sources (web server access logs) if the global log level is < info. But I think we should respect the log levels of each source when explicitly set (2.).

The issue is [reported on Discord](https://discord.com/channels/847502280503590932/1200550025504235600).


**This PR changes both 1 and 2**: both global and individual log levels apply to all sources.

##### Test Plan

[Set access log level](https://github.com/netdata/netdata/tree/master/src/libnetdata/log#configuring-log-sources), check logs.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
