### PR TITLE
fix installation of `libfluent-bit.so`

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -1736,7 +1736,7 @@ should_install_fluentbit() {
   elif [ "${FLUENT_BIT_BUILD_SUCCESS:=0}" -eq 0 ]; then
     run_failed "Fluent-Bit was not built successfully, Netdata Logs Management support will be disabled in this build."
     return 1
-  elif [ ! -f fluent-bit/build/lib/libfluent-bit.so ]; then
+  elif [ ! -f src/fluent-bit/build/lib/libfluent-bit.so ]; then
     run_failed "libfluent-bit.so is missing, Netdata Logs Management support will be disabled in this build."
     return 1
   fi
@@ -1752,10 +1752,10 @@ install_fluentbit() {
 
   [ -n "${GITHUB_ACTIONS}" ] && echo "::group::Installing Fluent-Bit."
 
-  run chown "root:${NETDATA_GROUP}" fluent-bit/build/lib
-  run chmod 0644 fluent-bit/build/lib/libfluent-bit.so
+  run chown "root:${NETDATA_GROUP}" src/fluent-bit/build/lib
+  run chmod 0644 src/fluent-bit/build/lib/libfluent-bit.so
 
-  run cp -a -v fluent-bit/build/lib/libfluent-bit.so "${NETDATA_PREFIX}"/usr/lib/netdata
+  run cp -a -v src/fluent-bit/build/lib/libfluent-bit.so "${NETDATA_PREFIX}"/usr/lib/netdata
 
   [ -n "${GITHUB_ACTIONS}" ] && echo "::endgroup::"
 }


### PR DESCRIPTION
##### Summary

Fixes this problem:

```
 The following warnings and non-fatal errors were encountered during the installation process:

  - libfluent-bit.so is missing, Netdata Logs Management support will be disabled in this build.
```



##### Test Plan

`libfluent-bit.so` is in `"${NETDATA_PREFIX}"/usr/lib/netdata`.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
