### PR TITLE
Exporting moved, so changes needed for integrations, + CODEOWNERS change

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,7 +16,7 @@ collectors/freebsd.plugin/ @thiagoftsm
 collectors/macos.plugin/ @thiagoftsm
 collectors/python.d.plugin/ @ilyam8
 collectors/cups.plugin/ @thiagoftsm
-exporting/ @thiagoftsm
+src/exporting/ @thiagoftsm
 daemon/ @thiagoftsm @vkalintiris
 database/ @thiagoftsm @vkalintiris
 docs/ @tkatsoulas @Ancairon

--- a/.github/workflows/generate-integrations.yml
+++ b/.github/workflows/generate-integrations.yml
@@ -7,7 +7,7 @@ on:
       - master
     paths: # If any of these files change, we need to regenerate integrations.js.
       - 'collectors/**/metadata.yaml'
-      - 'exporting/**/metadata.yaml'
+      - 'src/exporting/**/metadata.yaml'
       - 'health/notifications/**/metadata.yaml'
       - 'integrations/templates/**'
       - 'integrations/categories.yaml'

--- a/integrations/gen_docs_integrations.py
+++ b/integrations/gen_docs_integrations.py
@@ -21,7 +21,7 @@ def cleanup():
             if "integrations" in str(element):
                 shutil.rmtree(element)
 
-        for element in Path("exporting").glob('**/*/'):
+        for element in Path("src/exporting").glob('**/*/'):
             if "integrations" in str(element):
                 shutil.rmtree(element)
         for element in Path("integrations/cloud-notifications").glob('**/*/'):

--- a/integrations/gen_integrations.py
+++ b/integrations/gen_integrations.py
@@ -39,7 +39,7 @@ DEPLOY_SOURCES = [
 ]
 
 EXPORTER_SOURCES = [
-    (AGENT_REPO, REPO_PATH / 'exporting', True),
+    (AGENT_REPO, REPO_PATH / 'src' / 'exporting', True),
 ]
 
 NOTIFICATION_SOURCES = [


### PR DESCRIPTION
##### Summary

@Ferroin mainly, I ran the workflow locally without this fix and it nuked the .md files under the new src/exporting, so I changed all references to that path, the change inside integrations.js and .json is huge and won't load on my machine, but I guess it is correct because the .md files were generated, which use the yamls.