### PR TITLE
Check for agent already running

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -2016,11 +2016,11 @@ int main(int argc, char **argv) {
         health_set_silencers_filename();
         health_initialize_global_silencers();
 
-        // --------------------------------------------------------------------
-        // Initialize ML configuration
-
-        delta_startup_time("initialize ML");
-        ml_init();
+//        // --------------------------------------------------------------------
+//        // Initialize ML configuration
+//
+//        delta_startup_time("initialize ML");
+//        ml_init();
 
         // --------------------------------------------------------------------
         // setup process signals
@@ -2073,8 +2073,18 @@ int main(int argc, char **argv) {
         web_client_api_v1_init();
         web_server_threading_selection();
 
-        if(web_server_mode != WEB_SERVER_MODE_NONE)
-            api_listen_sockets_setup();
+        if(web_server_mode != WEB_SERVER_MODE_NONE) {
+            if (!api_listen_sockets_setup()) {
+                netdata_log_info("Cannot setup listen port(s). Is Netdata already running?");
+                exit(1);
+            }
+        }
+
+        // --------------------------------------------------------------------
+        // Initialize ML configuration
+
+        delta_startup_time("initialize ML");
+        ml_init();
 
 #ifdef ENABLE_H2O
         delta_startup_time("initialize h2o server");

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -2075,7 +2075,7 @@ int main(int argc, char **argv) {
 
         if(web_server_mode != WEB_SERVER_MODE_NONE) {
             if (!api_listen_sockets_setup()) {
-                netdata_log_info("Cannot setup listen port(s). Is Netdata already running?");
+                netdata_log_error("Cannot setup listen port(s). Is Netdata already running?");
                 exit(1);
             }
         }

--- a/web/server/web_server.c
+++ b/web/server/web_server.c
@@ -57,16 +57,16 @@ void debug_sockets() {
 	buffer_free(wb);
 }
 
-void api_listen_sockets_setup(void) {
+bool api_listen_sockets_setup(void) {
 	int socks = listen_sockets_setup(&api_sockets);
 
 	if(!socks)
-		fatal("LISTENER: Cannot listen on any API socket. Exiting...");
+        return false;
 
 	if(unlikely(debug_flags & D_WEB_CLIENT))
 		debug_sockets();
 
-	return;
+	return true;
 }
 
 

--- a/web/server/web_server.h
+++ b/web/server/web_server.h
@@ -39,7 +39,7 @@ extern WEB_SERVER_MODE web_server_mode;
 WEB_SERVER_MODE web_server_mode_id(const char *mode);
 const char *web_server_mode_name(WEB_SERVER_MODE id);
 
-void api_listen_sockets_setup(void);
+bool api_listen_sockets_setup(void);
 
 #define DEFAULT_TIMEOUT_TO_RECEIVE_FIRST_WEB_REQUEST 60
 #define DEFAULT_DISCONNECT_IDLE_WEB_CLIENTS_AFTER_SECONDS 60


### PR DESCRIPTION
##### Summary
Currently if we fail to bind to the agents listen ports we assume the agent is running and exit (with fatal)

With this change the agent will exit normally and log `Cannot setup listen port(s). Is Netdata already running?`

The ML initialization code has been moved until after socket listen is successful

