### PR TITLE
fix charts.d.plugin configuration directory names

### DIFF
--- a/collectors/charts.d.plugin/charts.d.plugin.in
+++ b/collectors/charts.d.plugin/charts.d.plugin.in
@@ -192,8 +192,8 @@ info "started from '$PROGRAM_FILE' with options: $*"
 [ -z "${NETDATA_STOCK_CONFIG_DIR}" ] && NETDATA_STOCK_CONFIG_DIR="@libconfigdir_POST@"
 
 pluginsd="${NETDATA_PLUGINS_DIR}"
-stockconfd="${NETDATA_STOCK_CONFIG_DIR}/${PROGRAM_NAME}"
-userconfd="${NETDATA_USER_CONFIG_DIR}/${PROGRAM_NAME}"
+stockconfd="${NETDATA_STOCK_CONFIG_DIR}/${SHORT_PROGRAM_NAME}"
+userconfd="${NETDATA_USER_CONFIG_DIR}/${SHORT_PROGRAM_NAME}"
 olduserconfd="${NETDATA_USER_CONFIG_DIR}"
 chartsd="$pluginsd/../charts.d"
 


### PR DESCRIPTION
##### Summary

`PROGRAM_NAME` is `charts.d.plugin`, we need [SHORT_PROGRAM_NAME](https://github.com/netdata/netdata/blob/85b274833bb01e5bdef3e230f4f2e7ec6c8f26e5/collectors/charts.d.plugin/charts.d.plugin.in#L25).

##### Test Plan

Before

```
thread=charts.d.plugin msg="apcupsd: not found module configuration: '/opt/netdata/usr/lib/netdata/conf.d/charts.d.plugin/apcupsd.conf'"
thread=charts.d.plugin msg="apcupsd: not found module configuration: '/opt/netdata/etc/netdata/charts.d.plugin/apcupsd.conf'"
```

After

```
thread=charts.d.plugin msg="apcupsd: loading module configuration: '/opt/netdata/usr/lib/netdata/conf.d/charts.d/apcupsd.conf'"
thread=charts.d.plugin msg="apcupsd: loading module configuration: '/opt/netdata/etc/netdata/charts.d/apcupsd.conf'"
```

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
