### PR TITLE
respect NETDATA_LOG_LEVEL if set

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -880,7 +880,10 @@ static void log_init(void) {
     logs = (unsigned long)config_get_number(CONFIG_SECTION_LOGS, "logs to trigger flood protection", (long long int)logs);
     nd_log_set_flood_protection(logs, period);
 
-    nd_log_set_priority_level(config_get(CONFIG_SECTION_LOGS, "level", NDLP_INFO_STR));
+    const char *netdata_log_level = getenv("NETDATA_LOG_LEVEL");
+    netdata_log_level = netdata_log_level ? nd_log_id2priority(nd_log_priority2id(netdata_log_level)) : NDLP_INFO_STR;
+
+    nd_log_set_priority_level(config_get(CONFIG_SECTION_LOGS, "level", netdata_log_level));
 
     char filename[FILENAME_MAX + 1];
     snprintfz(filename, FILENAME_MAX, "%s/debug.log", netdata_configured_log_dir);


### PR DESCRIPTION
##### Summary

Needed to change the log level of an ND docker container without using netdata.conf.

##### Test Plan

Start docker container, NETDATA_LOG_LEVEL set to:

- [correct level](https://github.com/netdata/netdata/tree/master/src/libnetdata/log#log-levels): log messages <= level.
- incorrect level: log messages <= info.
- not set: log messages <= info.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
