### PR TITLE
Split network viewer plugin to it’s own package.

### DIFF
--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -230,6 +230,7 @@ Architecture: any
 Depends: ${shlibs:Depends},
          netdata (= ${source:Version})
 Pre-Depends: libcap2-bin, adduser
+Recommends: netdata-plugin-ebpf (= ${source:Version} )
 Conflicts: netdata (<< ${source:Version})
 Description: The network viewer plugin for the Netdata Agent
  This plugin allows the Netdata Agent to provide network connection

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -58,7 +58,8 @@ Conflicts: netdata-core,
 Suggests: netdata-plugin-cups (= ${source:Version}),
           netdata-plugin-freeipmi (= ${source:Version})
 Recommends: netdata-plugin-systemd-journal (= ${source:Version}),
-            netdata-plugin-logs-management (= ${source:Version})
+            netdata-plugin-logs-management (= ${source:Version}),
+            netdata-plugin-network-viewer (= ${source:Version})
 Description: real-time charts for system monitoring
  Netdata is a daemon that collects data in realtime (per second)
  and presents a web site to view and analyze them. The presentation
@@ -223,3 +224,13 @@ Conflicts: netdata (<< ${source:Version})
 Description: The logs-management plugin for the Netdata Agent
  This plugin allows the Netdata Agent to collect logs from the system
  and parse them to extract metrics.
+
+Package: netdata-plugin-network-viewer
+Architecture: any
+Depends: ${shlibs:Depends},
+         netdata (= ${source:Version})
+Pre-Depends: libcap2-bin, adduser
+Conflicts: netdata (<< ${source:Version})
+Description: The network viewer plugin for the Netdata Agent
+ This plugin allows the Netdata Agent to provide network connection
+ mapping functionality for use in netdata Cloud.

--- a/contrib/debian/netdata-plugin-network-viewer-plugin.postinst
+++ b/contrib/debian/netdata-plugin-network-viewer-plugin.postinst
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+  configure|reconfigure)
+    chown root:netdata /usr/libexec/netdata/plugins.d/network-viewer.plugin
+    chmod 0750 /usr/libexec/netdata/plugins.d/network-viewer.plugin
+    if ! setcap "cap_dac_read_search,cap_sys_admin,cap_sys_ptrace=eip" /usr/libexec/netdata/plugins.d/network-viewer.plugin; then
+        chmod -f 4750 /usr/libexec/netdata/plugins.d/network-viewer.plugin
+    fi
+    ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/contrib/debian/netdata-plugin-network-viewer-plugin.preinst
+++ b/contrib/debian/netdata-plugin-network-viewer-plugin.preinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+  install)
+    if ! getent group netdata > /dev/null; then
+      addgroup --quiet --system netdata
+    fi
+    ;;
+esac
+
+#DEBHELPER#

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -124,7 +124,7 @@ override_dh_install:
 	mv -f $(TEMPTOP)/usr/libexec/netdata/plugins.d/freeipmi.plugin \
 	$(TOP)-plugin-freeipmi/usr/libexec/netdata/plugins.d/freeipmi.plugin
 
-	# Add free IPMI plugin install rules
+	# Add NFACCT plugin install rules
 	#
 	mkdir -p $(TOP)-plugin-nfacct/usr/libexec/netdata/plugins.d
 	mv -f $(TEMPTOP)/usr/libexec/netdata/plugins.d/nfacct.plugin \
@@ -222,6 +222,11 @@ override_dh_install:
 	mv -f $(TEMPTOP)/usr/lib/netdata/conf.d/go.d \
 	$(TOP)-plugin-go/usr/lib/netdata/conf.d/go.d
 
+	# Add network-viewer plugin install rules
+	mkdir -p $(TOP)-plugin-network-viewer/usr/libexec/netdata/plugins.d/
+	mv -f $(TEMPTOP)/usr/libexec/netdata/plugins.d/network-viewer.plugin \
+	$(TOP)-plugin-network-viewer/usr/libexec/netdata/plugins.d/network-viewer.plugin
+
 	# Set the rest of the software in the main package
 	#
 	cp -rp $(TEMPTOP)/usr $(TOP)
@@ -294,7 +299,7 @@ override_dh_fixperms:
 	chmod 4750 $(TOP)/usr/libexec/netdata/plugins.d/local-listeners
 
 	# network-viewer
-	chmod 4750 $(TOP)/usr/libexec/netdata/plugins.d/network-viewer.plugin
+	chmod 4750 $(TOP)-plugin-network-viewer/usr/libexec/netdata/plugins.d/network-viewer.plugin
 
 	# systemd-journal
 	chmod 4750 $(TOP)-plugin-systemd-journal/usr/libexec/netdata/plugins.d/systemd-journal.plugin

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -1000,6 +1000,11 @@ Summary: The network viewer plugin for the Netdata Agent
 Group: Applications/System
 Requires: %{name} = %{version}
 Conflicts: %{name} < %{version}
+%if 0%{?centos_ver} != 7
+Recommends: %{name}-plugin-ebpf = %{version}
+%else
+Requires: %{name}-plugin-ebpf = %{version}
+%endif
 
 %description plugin-network-viewer
  This plugin allows the Netdata Agent to provide network connection

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -211,9 +211,11 @@ Suggests: %{name}-plugin-freeipmi = %{version}
 Suggests: %{name}-plugin-cups = %{version}
 %endif
 Recommends: %{name}-plugin-systemd-journal = %{version}
+Recommends: %{name}-plugin-network-viewer = %{version}
 Recommends: %{name}-plugin-logs-management = %{version}
 %else
 Requires: %{name}-plugin-systemd-journal = %{version}
+Requires: %{name}-plugin-network-viewer = %{version}
 %endif
 
 
@@ -629,6 +631,9 @@ rm -rf "${RPM_BUILD_ROOT}"
 %exclude %{_libdir}/%{name}/conf.d/logsmanagement.d.conf
 %exclude %{_libdir}/%{name}/conf.d/logsmanagement.d
 
+# Network viewer belongs to a different sub-package
+%exclude %{_libexecdir}/%{name}/plugins.d/network-viewer.plugin
+
 # CUPS belongs to a different sub package
 %if %{_have_cups}
 %exclude %{_libexecdir}/%{name}/plugins.d/cups.plugin
@@ -990,7 +995,29 @@ fi
 # CAP_DAC_READ_SEARCH and CAP_SYSLOG needed for data collection.
 %caps(cap_dac_read_search,cap_syslog=ep) %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/logs-management.plugin
 
+%package plugin-network-viewer
+Summary: The network viewer plugin for the Netdata Agent
+Group: Applications/System
+Requires: %{name} = %{version}
+Conflicts: %{name} < %{version}
+
+%description plugin-network-viewer
+ This plugin allows the Netdata Agent to provide network connection
+ mapping functionality for use in netdata Cloud.
+
+%pre plugin-network-viewer
+if ! getent group %{name} > /dev/null; then
+  groupadd --system %{name}
+fi
+
+%files plugin-network-viewer
+%defattr(0750,root,netdata,0750)
+# CAP_SYS_ADMIN, CAP_SYS_PTRACE and CAP_DAC_READ_SEARCH needed for data collection.
+%caps(cap_sys_admin,cap_sys_ptrace,cap_dac_read_search=ep) %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/network-viewer.plugin
+
 %changelog
+* Tue Feb 06 2024 Austin hemmelgarn <austin@netdata.cloud>
+- Add package for network-viewer plugin
 * Thu Oct 26 2023 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-24
 - Add package for logs-management plugin
 * Tue Sep 19 2023 Austin hemmelgarn <austin@netdata.cloud> 0.0.0-24

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -1016,7 +1016,7 @@ fi
 %caps(cap_sys_admin,cap_sys_ptrace,cap_dac_read_search=ep) %attr(0750,root,netdata) %{_libexecdir}/%{name}/plugins.d/network-viewer.plugin
 
 %changelog
-* Tue Feb 06 2024 Austin hemmelgarn <austin@netdata.cloud>
+* Tue Feb 06 2024 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-25
 - Add package for network-viewer plugin
 * Thu Oct 26 2023 Austin Hemmelgarn <austin@netdata.cloud> 0.0.0-24
 - Add package for logs-management plugin


### PR DESCRIPTION
##### Summary

It should have been in it’s own package to begin with, especially with how potentially sensitive the information it can expose is.

Recommended by default for now, possibly shifted to suggested at some point in the future.

##### Test Plan

CI passes on this PR.