### PR TITLE
DYNCFG: support test on new jobs

### DIFF
--- a/src/daemon/config/dyncfg.c
+++ b/src/daemon/config/dyncfg.c
@@ -331,7 +331,7 @@ bool dyncfg_add_low_level(RRDHOST *host, const char *id, const char *path,
     // data
     if(type == DYNCFG_TYPE_TEMPLATE) {
         // templates do not have data
-        cmds &= ~(DYNCFG_CMD_GET | DYNCFG_CMD_UPDATE | DYNCFG_CMD_TEST);
+        cmds &= ~(DYNCFG_CMD_GET | DYNCFG_CMD_UPDATE);
     }
 
     if(cmds != old_cmds) {

--- a/src/health/health_dyncfg.c
+++ b/src/health/health_dyncfg.c
@@ -382,12 +382,15 @@ static int dyncfg_health_prototype_template_action(BUFFER *result, DYNCFG_CMDS c
             code = dyncfg_default_response(result, HTTP_RESP_NOT_IMPLEMENTED, "schema not implemented yet for prototype templates");
             break;
 
+        case DYNCFG_CMD_TEST:
+            code = dyncfg_default_response(result, HTTP_RESP_NOT_IMPLEMENTED, "test not implemented yet for prototype templates");
+            break;
+
         case DYNCFG_CMD_REMOVE:
         case DYNCFG_CMD_RESTART:
         case DYNCFG_CMD_DISABLE:
         case DYNCFG_CMD_ENABLE:
         case DYNCFG_CMD_UPDATE:
-        case DYNCFG_CMD_TEST:
         case DYNCFG_CMD_GET:
             code = dyncfg_default_response(result, HTTP_RESP_BAD_REQUEST, "action given is not supported for prototype templates");
             break;
@@ -599,7 +602,7 @@ void health_dyncfg_register_all_prototypes(void) {
                DYNCFG_HEALTH_ALERT_PROTOTYPE_PREFIX, "/health/alerts/prototypes",
                DYNCFG_STATUS_ACCEPTED, DYNCFG_TYPE_TEMPLATE,
                DYNCFG_SOURCE_TYPE_INTERNAL, "internal",
-               DYNCFG_CMD_SCHEMA | DYNCFG_CMD_ADD | DYNCFG_CMD_ENABLE | DYNCFG_CMD_DISABLE,
+               DYNCFG_CMD_SCHEMA | DYNCFG_CMD_ADD | DYNCFG_CMD_ENABLE | DYNCFG_CMD_DISABLE | DYNCFG_CMD_TEST,
                HTTP_ACCESS_SIGNED_ID | HTTP_ACCESS_SAME_SPACE | HTTP_ACCESS_VIEW_AGENT_CONFIG,
                HTTP_ACCESS_SIGNED_ID | HTTP_ACCESS_SAME_SPACE | HTTP_ACCESS_EDIT_AGENT_CONFIG,
                dyncfg_health_cb, NULL);


### PR DESCRIPTION
To support TEST action on new jobs:

1. Set the TEST command to templates
2. The callback of the template will be called with the ID of the new job (so the plugin will receive on the callback of the template a test action with ID the new job name)
