### PR TITLE
Use C++14 by default when building on systems that support it.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,13 @@ project(netdata
 find_package(PkgConfig REQUIRED)
 
 set(CMAKE_C_STANDARD 11)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
+
+option(USE_CXX_11 "use C++11 instead of C++14" False)
+
+if(USE_CXX_11)
+    set(CMAKE_CXX_STANDARD 11)
+endif()
 
 set(CMAKE_C_STANDARD_REQUIRED On)
 set(CMAKE_CXX_STANDARD_REQUIRED On)

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -209,6 +209,7 @@ USAGE: ${PROGRAM} [options]
   --disable-ebpf             Disable eBPF Kernel plugin. Default: enabled.
   --disable-cloud            Disable all Netdata Cloud functionality.
   --require-cloud            Fail the install if it can't build Netdata Cloud support.
+  --force-legacy-cxx         Force usage of an older C++ standard to allow building on older systems. This will usually be autodetected.
   --enable-plugin-freeipmi   Enable the FreeIPMI plugin. Default: enable it when libipmimonitoring is available.
   --disable-plugin-freeipmi  Explicitly disable the FreeIPMI plugin.
   --disable-https            Explicitly disable TLS support.
@@ -257,6 +258,7 @@ ENABLE_H2O=1
 ENABLE_CLOUD=1
 ENABLE_LOGS_MANAGEMENT=1
 ENABLE_LOGS_MANAGEMENT_TESTS=0
+FORCE_LEGACY_CXX=0
 NETDATA_CMAKE_OPTIONS="${NETDATA_CMAKE_OPTIONS-}"
 
 RELEASE_CHANNEL="nightly" # valid values are 'nightly' and 'stable'
@@ -273,6 +275,7 @@ while [ -n "${1}" ]; do
     "--auto-update-type") ;;
     "--stable-channel") RELEASE_CHANNEL="stable" ;;
     "--nightly-channel") RELEASE_CHANNEL="nightly" ;;
+    "--force-legacy-cxx") FORCE_LEGACY_CXX=1 ;;
     "--enable-plugin-freeipmi") ENABLE_FREEIPMI=1 ;;
     "--disable-plugin-freeipmi") ENABLE_FREEIPMI=0 ;;
     "--disable-https")

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -352,6 +352,11 @@ make download
 # Conf step
 %cmake -G Ninja \
 	-DCMAKE_INSTALL_PREFIX=/ \
+	%if 0%{?centos_ver:1}
+	%if %{centos_ver} < 8
+	-DUSE_CXX_11=On \
+	%endif
+	%endif
 	%if %{_have_cups}
 	-DENABLE_PLUGIN_CUPS=On \
 	%else


### PR DESCRIPTION
##### Summary

This is needed to properly support the latest versions of Protobuf.

Support for older systems is handled via:

- A new CMake option, `USE_CXX_11`, defaulting to disabled, which when set will switch to using C++11 instead of C++14 during the build.
- An explicit exception in the RPM spec file to set that option on the few platforms we build native RPM packages for that are known to need it.
- Additional checks in the installer code that constructs the CMake command line to verify compiler versions and enable the aforementioned CMake option if needed.
- A new option for the `netdata-installer.sh` script, `--force-legacy-cxx`, which overrides the above-mentioned compiler version checks to force-enable the aforementioned CMake option.

##### Test Plan

CI passes on this PR.

Supplementary testing should include manual verification of the new installer option, all other code paths are covered by CI.