### PR TITLE
Add static thread that serves gRPC requests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ project(netdata
 find_package(PkgConfig REQUIRED)
 
 set(CMAKE_C_STANDARD 11)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 set(CMAKE_C_STANDARD_REQUIRED On)
 set(CMAKE_CXX_STANDARD_REQUIRED On)
@@ -115,13 +115,62 @@ option(ENABLE_BUNDLED_PROTOBUF "enable bundled protobuf" False)
 
 option(ENABLE_LOGS_MANAGEMENT_TESTS "enable logs management tests" True)
 
+option(ENABLE_GRPC "enable grpc" True)
 option(ENABLE_SENTRY "enable sentry" False)
 option(ENABLE_WEBRTC "enable webrtc" False)
+
+if(ENABLE_GRPC)
+        include(FetchContent)
+
+        set(FETCHCONTENT_QUIET OFF)
+        set(FETCHCONTENT_FULLY_DISCONNECTED Off)
+
+        set(ABSL_ENABLE_INSTALL ON)
+
+        FetchContent_Declare(
+                gRPC
+                GIT_REPOSITORY https://github.com/grpc/grpc
+                GIT_TAG        v1.55.4
+        )
+        FetchContent_MakeAvailable(gRPC)
+        include(FindProtobuf)
+
+        set(_PROTOBUF_LIBPROTOBUF libprotobuf)
+        set(_PROTOBUF_PROTOC $<TARGET_FILE:protoc>)
+
+        set(_GRPC_GRPCPP grpc++)
+        set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:grpc_cpp_plugin>)
+
+        add_library(proto-objects OBJECT "src/foo/proto/hello.proto")
+
+        target_link_libraries(proto-objects PUBLIC protobuf::libprotobuf grpc++ grpc++_reflection)
+
+        set(PROTO_BINARY_DIR "${CMAKE_BINARY_DIR}/generated")
+        set(PROTO_IMPORT_DIRS "${CMAKE_SOURCE_DIR}/src/foo/proto")
+
+        target_include_directories(proto-objects PUBLIC "${PROTO_BINARY_DIR}")
+
+        protobuf_generate(
+            TARGET proto-objects
+            IMPORT_DIRS ${PROTO_IMPORT_DIRS}
+            PROTOC_OUT_DIR "${PROTO_BINARY_DIR}")
+
+        protobuf_generate(
+            TARGET proto-objects
+            LANGUAGE grpc
+            GENERATE_EXTENSIONS .grpc.pb.h .grpc.pb.cc
+            PLUGIN "protoc-gen-grpc=${_GRPC_CPP_PLUGIN_EXECUTABLE}"
+            IMPORT_DIRS ${PROTO_IMPORT_DIRS}
+            PROTOC_OUT_DIR "${PROTO_BINARY_DIR}")
+
+        add_library(foo STATIC "${CMAKE_SOURCE_DIR}/src/foo/foo_plugin.cc")
+        target_link_libraries(foo PUBLIC proto-objects)
+endif()
 
 if(ENABLE_SENTRY)
         include(FetchContent)
 
-        # ignore debhelper
+        set(FETCHCONTENT_QUIET OFF)
         set(FETCHCONTENT_FULLY_DISCONNECTED Off)
 
         set(SENTRY_VERSION 0.6.6)
@@ -2112,6 +2161,7 @@ target_link_libraries(netdata PRIVATE
         "$<$<BOOL:${MACOS}>:${IOKIT};${FOUNDATION}>"
         "$<$<BOOL:${ENABLE_SENTRY}>:sentry>"
         "$<$<BOOL:${ENABLE_WEBRTC}>:LibDataChannel::LibDataChannelStatic>"
+        "$<$<BOOL:${ENABLE_GRPC}>:foo>"
 )
 
 #

--- a/src/daemon/static_threads.c
+++ b/src/daemon/static_threads.c
@@ -15,6 +15,7 @@ void *statsd_main(void *ptr);
 void *timex_main(void *ptr);
 void *profile_main(void *ptr);
 void *replication_thread_main(void *ptr __maybe_unused);
+void *grpc_main(void *ptr);
 
 extern bool global_statistics_enabled;
 
@@ -194,6 +195,15 @@ const struct netdata_static_thread static_threads_common[] = {
         .thread = NULL,
         .init_routine = NULL,
         .start_routine = profile_main
+    },
+    {
+        .name = "P[GRPC]",
+        .config_section = CONFIG_SECTION_PLUGINS,
+        .config_name = "grpc",
+        .enabled = 1,
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = grpc_main
     },
 
     // terminator

--- a/src/foo/foo_plugin.cc
+++ b/src/foo/foo_plugin.cc
@@ -1,0 +1,54 @@
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <grpc++/grpc++.h>
+#include <grpc++/ext/proto_server_reflection_plugin.h>
+#include <grpcpp/grpcpp.h>
+#include "src/foo/proto/hello.grpc.pb.h"
+
+using grpc::Server;
+using grpc::ServerBuilder;
+using grpc::ServerContext;
+using grpc::Status;
+using helloworld::Greeter;
+using helloworld::HelloReply;
+using helloworld::HelloRequest;
+
+// Logic and data behind the server's behavior.
+class GreeterServiceImpl final : public Greeter::Service {
+    Status SayHello(ServerContext *context, const HelloRequest *request, HelloReply *reply) override
+    {
+        (void) context;
+        
+        std::string prefix("Hello ");
+        reply->set_message(prefix + request->name());
+        return Status::OK;
+    }
+};
+
+static void RunServer()
+{
+    std::string server_address("0.0.0.0:50051");
+    GreeterServiceImpl service;
+
+    grpc::EnableDefaultHealthCheckService(true);
+    grpc::reflection::InitProtoReflectionServerBuilderPlugin();
+
+    ServerBuilder builder;
+
+    builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+    builder.RegisterService(&service);
+
+    std::unique_ptr<Server> server(builder.BuildAndStart());
+    std::cout << "Server listening on " << server_address << std::endl;
+    server->Wait();
+}
+
+extern "C" void *grpc_main(void *arg)
+{
+    (void) arg;
+        
+    RunServer();
+    return nullptr;
+}

--- a/src/foo/proto/hello.proto
+++ b/src/foo/proto/hello.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package helloworld;
+
+service Greeter {
+    rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+message HelloRequest {
+    string name = 1;
+}
+
+message HelloReply {
+    string message = 1;
+}


### PR DESCRIPTION
##### Summary

This is proof-of-concept stage. grpc is will be fetched and built at configuration time from source.


##### Test Plan

- N/A.

You can test this by building -> installing -> running the agent and using

```
grpcurl -plaintext -d '{"name": "world"}' localhost:50051 helloworld.Greeter/SayHello
```

to hit the gRPC server and get back a hello world kind of message. You can install `grpcurl` with:

```
go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
```