### PR TITLE
Detect machine GUID change

### DIFF
--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -1107,7 +1107,7 @@ int rrd_init(char *hostname, struct rrdhost_system_info *system_info, bool unitt
                             rrdhost_function_progress);
 
     if (likely(system_info)) {
-        migrate_localhost(&localhost->host_uuid);
+        detect_machine_guid_change(&localhost->host_uuid);
         sql_aclk_sync_init();
         web_client_api_v1_management_init();
     }

--- a/src/database/sqlite/sqlite_metadata.h
+++ b/src/database/sqlite/sqlite_metadata.h
@@ -15,7 +15,7 @@ void metaqueue_delete_dimension_uuid(uuid_t *uuid);
 void metaqueue_store_claim_id(uuid_t *host_uuid, uuid_t *claim_uuid);
 void metaqueue_host_update_info(RRDHOST *host);
 void metaqueue_ml_load_models(RRDDIM *rd);
-void migrate_localhost(uuid_t *host_uuid);
+void detect_machine_guid_change(uuid_t *host_uuid);
 void metadata_queue_load_host_context(RRDHOST *host);
 void metadata_delete_host_chart_labels(char *machine_guid);
 void vacuum_database(sqlite3 *database, const char *db_alias, int threshold, int vacuum_pc);


### PR DESCRIPTION
##### Summary
Currently, if you copy the entire /var/cache/netdata folder to a newly installed agent and then start the agent, the new system will use the existing history by switching the parent agent found in the metadata to the newly installed agent. In essence, the historical data from the old system is inherited by the new system.

With this change, the parent found in the copied data will be switched to an archived child node. 

##### Test Plan
- Install a new agent (A) but don't start it
- Stop an `existing` agent (B) and copied it's /var/cache/netdata to agent (A)
- Start agent (A)
  - You should see data being collected for A
  - You should have an archived child with data from B
 