### PR TITLE
Update input paths for tj-actions/changed-files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,8 @@ jobs:
             .github/scripts/get-static-cache-key.sh
             .github/scripts/gen-matrix-build.py
             .github/scripts/run-updater-check.sh
-            packaging/makeself/**
-            packaging/installer/**
+            packaging/makeself/
+            packaging/installer/
             packaging/*.sh
             packaging/*.version
             packaging/*.checksums

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,7 @@ jobs:
           files_ignore: |
             netdata.spec.in
             **.md
+          negation_patterns_first: true
       - name: Check Run
         id: check-run
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -53,6 +53,7 @@ jobs:
           files_ignore: |
             netdata.spec.in
             **.md
+          negation_patterns_first: true
       - name: Check Run
         id: check-run
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,6 +59,7 @@ jobs:
           files_ignore: |
             netdata.spec.in
             **.md
+          negation_patterns_first: true
       - name: Check Run
         id: check-run
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,8 +47,8 @@ jobs:
             netdata-installer.sh
             .github/workflows/docker.yml
             .github/scripts/docker-test.sh
-            packaging/docker/**
-            packaging/installer/**
+            packaging/docker/
+            packaging/installer/
             packaging/runtime-check.sh
             packaging/*.version
             packaging/*.checksums

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -53,7 +53,7 @@ jobs:
             **.patch
             **.cmake
             netdata.spec.in
-            contrib/debian/**
+            contrib/debian/
             CMakeLists.txt
             .github/data/distros.yml
             .github/workflows/packaging.yml

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -68,6 +68,7 @@ jobs:
             web/server/h2o/libh2o/
           files_ignore: |
             **.md
+          negation_patterns_first: true
       - name: Check Run
         id: check-run
         run: |


### PR DESCRIPTION
##### Summary
Breaking  change in v42 https://github.com/tj-actions/changed-files/releases/tag/v42
Dir input pattern doesn't require globstar

This may fix the issue that we see, _workflows are running when we touch only  files_ignored_
##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
