### PR TITLE
Update input skip patterns

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,10 +67,10 @@ jobs:
             **/*.md
       - name: List all changed files in pattern
         env:
-          ALL_CHANGED_FILES: ${{ steps.check-files.outputs.all_changed_files }}
+          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.all_modified_files }}
         run: |
-          for file in ${ALL_CHANGED_FILES}; do
-            echo "$file was changed"
+          for file in ${ALL_MODIFIED_FILES}; do
+            echo "$file was modified"
           done
       - name: Check Run
         id: check-run

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,13 +38,13 @@ jobs:
         with:
           since_last_remote_commit: ${{ github.event_name != 'pull_request' }}
           files: |
-            **.c
-            **.cc
-            **.h
-            **.hh
-            **.in
-            **.patch
-            **.cmake
+            **/*.c
+            **/*.cc
+            **/*.h
+            **/*.hh
+            **/*.in
+            **/*.patch
+            **/*.cmake
             CMakeLists.txt
             netdata-installer.sh
             .github/data/distros.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
             **/*.md
       - name: List all modified files in pattern
         env:
-          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.all_modified_files }}
+          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.any_modified }}
         run: |
           for file in ${ALL_MODIFIED_FILES}; do
             echo "$file was modified"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,13 @@ jobs:
           files_ignore: |
             netdata.spec.in
             **/*.md
+      - name: List all changed files in pattern
+        env:
+          ALL_CHANGED_FILES: ${{ steps.check-files.outputs.all_changed_files }}
+        run: |
+          for file in ${ALL_CHANGED_FILES}; do
+            echo "$file was changed"
+          done
       - name: Check Run
         id: check-run
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,8 +64,7 @@ jobs:
             web/server/h2o/libh2o/
           files_ignore: |
             netdata.spec.in
-            **.md
-          negation_patterns_first: true
+            **/*.md
       - name: Check Run
         id: check-run
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
             **/*.md
       - name: List all modified files in pattern
         env:
-          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.any_modified }}
+          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.all_modified_files }}
         run: |
           for file in ${ALL_MODIFIED_FILES}; do
             echo "$file was modified"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
           files_ignore: |
             netdata.spec.in
             **/*.md
-      - name: List all changed files in pattern
+      - name: List all modified files in pattern
         env:
           ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.all_modified_files }}
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,13 +29,13 @@ jobs:
         with:
           since_last_remote_commit: ${{ github.event_name != 'pull_request' }}
           files: |
-            **.c
-            **.cc
-            **.h
-            **.hh
-            **.in
-            **.patch
-            **.cmake
+            **/*.c
+            **/*.cc
+            **/*.h
+            **/*.hh
+            **/*.in
+            **/*.patch
+            **/*.cmake
             CMakeLists.txt
             .gitignore
             .github/data/distros.yml

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,7 +55,7 @@ jobs:
             **/*.md
       - name: List all modified files in pattern
         env:
-          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.any_modified }}
+          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.all_modified_files }}
         run: |
           for file in ${ALL_MODIFIED_FILES}; do
             echo "$file was modified"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,7 +55,7 @@ jobs:
             **/*.md
       - name: List all modified files in pattern
         env:
-          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.all_modified_files }}
+          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.any_modified }}
         run: |
           for file in ${ALL_MODIFIED_FILES}; do
             echo "$file was modified"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -53,7 +53,7 @@ jobs:
           files_ignore: |
             netdata.spec.in
             **/*.md
-      - name: List all changed files in pattern
+      - name: List all modified files in pattern
         env:
           ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.all_modified_files }}
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,10 +55,10 @@ jobs:
             **/*.md
       - name: List all changed files in pattern
         env:
-          ALL_CHANGED_FILES: ${{ steps.check-files.outputs.all_changed_files }}
+          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.all_modified_files }}
         run: |
-          for file in ${ALL_CHANGED_FILES}; do
-            echo "$file was changed"
+          for file in ${ALL_MODIFIED_FILES}; do
+            echo "$file was modified"
           done
       - name: Check Run
         id: check-run

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -53,6 +53,13 @@ jobs:
           files_ignore: |
             netdata.spec.in
             **/*.md
+      - name: List all changed files in pattern
+        env:
+          ALL_CHANGED_FILES: ${{ steps.check-files.outputs.all_changed_files }}
+        run: |
+          for file in ${ALL_CHANGED_FILES}; do
+            echo "$file was changed"
+          done
       - name: Check Run
         id: check-run
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -52,8 +52,7 @@ jobs:
             web/server/h2o/libh2o/
           files_ignore: |
             netdata.spec.in
-            **.md
-          negation_patterns_first: true
+            **/*.md
       - name: Check Run
         id: check-run
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
             **/*.md
       - name: List all modified files in pattern
         env:
-          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.any_modified }}
+          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.all_modified_files }}
         run: |
           for file in ${ALL_MODIFIED_FILES}; do
             echo "$file was modified"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
             **/*.md
       - name: List all modified files in pattern
         env:
-          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.all_modified_files }}
+          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.any_modified }}
         run: |
           for file in ${ALL_MODIFIED_FILES}; do
             echo "$file was modified"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
           files_ignore: |
             netdata.spec.in
             **/*.md
-      - name: List all changed files in pattern
+      - name: List all modified files in pattern
         env:
           ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.all_modified_files }}
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,8 +58,7 @@ jobs:
             web/server/h2o/libh2o/
           files_ignore: |
             netdata.spec.in
-            **.md
-          negation_patterns_first: true
+            **/*.md
       - name: Check Run
         id: check-run
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - name: Check files
-        id: file-check
+        id: check-files
         uses: tj-actions/changed-files@v42
         with:
           since_last_remote_commit: ${{ github.event_name != 'pull_request' }}
@@ -61,15 +61,15 @@ jobs:
             **/*.md
       - name: List all changed files in pattern
         env:
-          ALL_CHANGED_FILES: ${{ steps.check-files.outputs.all_changed_files }}
+          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.all_modified_files }}
         run: |
-          for file in ${ALL_CHANGED_FILES}; do
-            echo "$file was changed"
+          for file in ${ALL_MODIFIED_FILES}; do
+            echo "$file was modified"
           done
       - name: Check Run
         id: check-run
         run: |
-          if [ "${{ steps.file-check.outputs.any_modified }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+          if [ "${{ steps.check-files.outputs.any_modified }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo 'run=true' >> "${GITHUB_OUTPUT}"
           else
             echo 'run=false' >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,6 +59,13 @@ jobs:
           files_ignore: |
             netdata.spec.in
             **/*.md
+      - name: List all changed files in pattern
+        env:
+          ALL_CHANGED_FILES: ${{ steps.check-files.outputs.all_changed_files }}
+        run: |
+          for file in ${ALL_CHANGED_FILES}; do
+            echo "$file was changed"
+          done
       - name: Check Run
         id: check-run
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,13 +35,13 @@ jobs:
         with:
           since_last_remote_commit: ${{ github.event_name != 'pull_request' }}
           files: |
-            **.c
-            **.cc
-            **.h
-            **.hh
-            **.in
-            **.patch
-            **.cmake
+            **/*.c
+            **/*.cc
+            **/*.h
+            **/*.hh
+            **/*.in
+            **/*.patch
+            **/*.cmake
             .dockerignore
             CMakeLists.txt
             netdata-installer.sh

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -68,6 +68,13 @@ jobs:
             web/server/h2o/libh2o/
           files_ignore: |
             **/*.md
+      - name: List all changed files in pattern
+        env:
+          ALL_CHANGED_FILES: ${{ steps.check-files.outputs.all_changed_files }}
+        run: |
+          for file in ${ALL_CHANGED_FILES}; do
+            echo "$file was changed"
+          done
       - name: Check Run
         id: check-run
         run: |

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -45,13 +45,13 @@ jobs:
         with:
           since_last_remote_commit: ${{ github.event_name != 'pull_request' }}
           files: |
-            **.c
-            **.cc
-            **.h
-            **.hh
-            **.in
-            **.patch
-            **.cmake
+            **/*.c
+            **/*.cc
+            **/*.h
+            **/*.hh
+            **/*.in
+            **/*.patch
+            **/*.cmake
             netdata.spec.in
             contrib/debian/
             CMakeLists.txt

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -68,7 +68,7 @@ jobs:
             web/server/h2o/libh2o/
           files_ignore: |
             **/*.md
-      - name: List all changed files in pattern
+      - name: List all modified files in pattern
         env:
           ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.all_modified_files }}
         run: |

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -40,7 +40,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - name: Check files
-        id: file-check
+        id: check-files
         uses: tj-actions/changed-files@v42
         with:
           since_last_remote_commit: ${{ github.event_name != 'pull_request' }}
@@ -70,15 +70,15 @@ jobs:
             **/*.md
       - name: List all changed files in pattern
         env:
-          ALL_CHANGED_FILES: ${{ steps.check-files.outputs.all_changed_files }}
+          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.all_modified_files }}
         run: |
-          for file in ${ALL_CHANGED_FILES}; do
-            echo "$file was changed"
+          for file in ${ALL_MODIFIED_FILES}; do
+            echo "$file was modified"
           done
       - name: Check Run
         id: check-run
         run: |
-          if [ "${{ steps.file-check.outputs.any_modified }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+          if [ "${{ steps.check-files.outputs.any_modified }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo 'run=true' >> "${GITHUB_OUTPUT}"
           else
             echo 'run=false' >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -70,7 +70,7 @@ jobs:
             **/*.md
       - name: List all modified files in pattern
         env:
-          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.all_modified_files }}
+          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.any_modified }}
         run: |
           for file in ${ALL_MODIFIED_FILES}; do
             echo "$file was modified"

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -67,8 +67,7 @@ jobs:
             src/fluent-bit/
             web/server/h2o/libh2o/
           files_ignore: |
-            **.md
-          negation_patterns_first: true
+            **/*.md
       - name: Check Run
         id: check-run
         run: |

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -70,7 +70,7 @@ jobs:
             **/*.md
       - name: List all modified files in pattern
         env:
-          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.any_modified }}
+          ALL_MODIFIED_FILES: ${{ steps.check-files.outputs.all_modified_files }}
         run: |
           for file in ${ALL_MODIFIED_FILES}; do
             echo "$file was modified"


### PR DESCRIPTION
##### Summary

- negation must be after the match.
- `**.xyz` matches only the root folder
- `**/*.xyz` matches everything.

Changes: 

1. Fix minor typo:
    - job name will be file-check in any workflow
    - file-check job has a step which is check-file

2. Print any modified files (previous approach was not printing deleted)

3. Change glob patterns for all source files (*.c, *.h etc). With the previous approach they only matched the root folder

Co-authored-by: ilyam8 <22274335+ilyam8@users.noreply.github.com>

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
