### PR TITLE
Add necessary libraries for curl and libcurl

### DIFF
--- a/packaging/makeself/jobs/50-curl.install.sh
+++ b/packaging/makeself/jobs/50-curl.install.sh
@@ -27,8 +27,8 @@ fi
 
 cd "${NETDATA_MAKESELF_PATH}/tmp/curl" || exit 1
 
-export CFLAGS="-I/openssl-static/include -pipe"
-export LDFLAGS="-static -L/openssl-static/lib64"
+export CFLAGS="-pipe"
+export LDFLAGS="-static -L/openssl-static/lib64 -L/usr/lib -lidn2 -L/usr/lib -lpsl -L/usr/lib -lunistring"
 export PKG_CONFIG="pkg-config --static"
 export PKG_CONFIG_PATH="/openssl-static/lib64/pkgconfig"
 
@@ -55,6 +55,7 @@ if [ "${CACHE_HIT:-0}" -eq 0 ]; then
         --enable-ipv6 \
         --enable-cookies \
         --with-ca-fallback \
+        --with-libidn2 \
         --with-openssl \
         --disable-dependency-tracking
 


### PR DESCRIPTION
##### Summary

We build curl and libcurl from source in our static builds. At some point they used one library that we didn't provide `libpsl` and `libpsl` needs `idn2` and `unistrings`

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
