### PR TITLE
Adjust storage tiers if we fail to create the requested number of tiers

### DIFF
--- a/src/database/engine/datafile.c
+++ b/src/database/engine/datafile.c
@@ -557,7 +557,9 @@ void finalize_data_files(struct rrdengine_instance *ctx)
 {
     bool logged = false;
 
-    logged = false;
+    if (!ctx->datafiles.first)
+        return;
+
     while(__atomic_load_n(&ctx->atomic.extents_currently_being_flushed, __ATOMIC_RELAXED)) {
         if(!logged) {
             netdata_log_info("Waiting for inflight flush to finish on tier %d...", ctx->config.tier);


### PR DESCRIPTION
##### Summary
- Adjust storage tiers if we fail to create the requested number of tiers.
  Although no datafiles were produced for this tier, there was an attempt to finalize files during shutdown
- Report correct number of tiers activated  
- Do not create a dbengine-tierX directory if the tier cannot be activated
  Right now an empty directory is created
- Check for datafiles existence during finalize of ctx (sanity check)
 
Fixes #16888
