### PR TITLE
Misc improvements

### DIFF
--- a/src/daemon/analytics.c
+++ b/src/daemon/analytics.c
@@ -470,7 +470,7 @@ void analytics_alarms(void)
  */
 void analytics_misc(void)
 {
-    analytics_data.spinlock.locked = false;
+    spinlock_init(&analytics_data.spinlock);
 
 #ifdef ENABLE_ACLK
     analytics_set_data(&analytics_data.netdata_host_cloud_available, "true");

--- a/src/database/rrddim.c
+++ b/src/database/rrddim.c
@@ -95,7 +95,7 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
             rd->tiers[tier].seb = eng->seb;
             rd->tiers[tier].tier_grouping = host->db[tier].tier_grouping;
             rd->tiers[tier].smh = eng->api.metric_get_or_create(rd, host->db[tier].si);
-            rd->tiers[tier].spinlock.locked = false;
+            spinlock_init(&rd->tiers[tier].spinlock);
             storage_point_unset(rd->tiers[tier].virtual_point);
             initialized++;
 

--- a/src/database/sqlite/sqlite_functions.c
+++ b/src/database/sqlite/sqlite_functions.c
@@ -450,6 +450,7 @@ int sql_init_database(db_check_action_type_t rebuild, int memory)
     }
 
     if (rebuild & DB_CHECK_ANALYZE) {
+        errno = 0;
         netdata_log_info("Running ANALYZE on %s", sqlite_database);
         rc = sqlite3_exec_monitored(db_meta, "ANALYZE", 0, 0, &err_msg);
         if (rc != SQLITE_OK) {


### PR DESCRIPTION
##### Summary
- Use `spinlock init` for proper initialization so that it will work properly when compiling with NETDATA_INTERNAL_CHECKS
- Clear errno so that it will not report an error when logging output of the `sqlite-analyze` command
