### PR TITLE
eBPF - Network Viewer (Move code)

### DIFF
--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -3064,7 +3064,7 @@ int ebpf_check_conditions()
         return -1;
     }
 
-    if (!am_i_running_as_root()) {
+    if (!is_ebpf_plugin_running_as_root()) {
         netdata_log_error(
             "ebpf.plugin should either run as root (now running with uid %u, euid %u) or have special capabilities..",
             (unsigned int)getuid(), (unsigned int)geteuid());

--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -3059,7 +3059,7 @@ static inline void ebpf_load_thread_config()
  */
 int ebpf_check_conditions()
 {
-    if (!has_condition_to_run(running_on_kernel)) {
+    if (!has_ebpf_kernel_version(running_on_kernel)) {
         netdata_log_error("The current collector cannot run on this kernel.");
         return -1;
     }

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -378,7 +378,7 @@ int ebpf_read_hash_table(void *ep, int fd, uint32_t pid)
  *
  * @return It returns 1 for root and 0 otherwise.
  */
-int am_i_running_as_root()
+int is_ebpf_plugin_running_as_root()
 {
     uid_t uid = getuid(), euid = geteuid();
 

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -372,24 +372,6 @@ int ebpf_read_hash_table(void *ep, int fd, uint32_t pid)
  *****************************************************************/
 
 /**
- * Am I running as Root
- *
- * Verify the user that is running the collector.
- *
- * @return It returns 1 for root and 0 otherwise.
- */
-int is_ebpf_plugin_running_as_root()
-{
-    uid_t uid = getuid(), euid = geteuid();
-
-    if (uid == 0 || euid == 0) {
-        return 1;
-    }
-
-    return 0;
-}
-
-/**
  * Reset the target values
  *
  * @param root the pointer to the chain that will be reset.

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -195,8 +195,6 @@ void clean_apps_groups_target(struct ebpf_target *apps_groups_root_target);
 
 size_t zero_all_targets(struct ebpf_target *root);
 
-int is_ebpf_plugin_running_as_root();
-
 void cleanup_exited_pids();
 
 int ebpf_read_hash_table(void *ep, int fd, uint32_t pid);

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -195,7 +195,7 @@ void clean_apps_groups_target(struct ebpf_target *apps_groups_root_target);
 
 size_t zero_all_targets(struct ebpf_target *root);
 
-int am_i_running_as_root();
+int is_ebpf_plugin_running_as_root();
 
 void cleanup_exited_pids();
 

--- a/src/collectors/ebpf.plugin/ebpf_functions.c
+++ b/src/collectors/ebpf.plugin/ebpf_functions.c
@@ -116,7 +116,10 @@ static void ebpf_fill_function_buffer(BUFFER *wb, netdata_socket_plus_t *values,
     buffer_json_add_array_item_uint64(wb, (uint64_t)values->pid);
 
     // NAME
-    buffer_json_add_array_item_string(wb, (name) ? name : "unknown");
+    if (!values->data.name[0])
+        buffer_json_add_array_item_string(wb, (name) ? name : "unknown");
+    else
+        buffer_json_add_array_item_string(wb, values->data.name);
 
     // Origin
     buffer_json_add_array_item_string(wb, (values->data.external_origin) ? "in" : "out");

--- a/src/libnetdata/ebpf/ebpf.c
+++ b/src/libnetdata/ebpf/ebpf.c
@@ -244,21 +244,13 @@ static int kernel_is_rejected()
     return 0;
 }
 
-static int has_ebpf_kernel_version(int version)
+int has_ebpf_kernel_version(int version)
 {
     if (kernel_is_rejected())
         return 0;
 
     // Kernel 4.11.0 or RH > 7.5
     return (version >= NETDATA_MINIMUM_EBPF_KERNEL || get_redhat_release() >= NETDATA_MINIMUM_RH_VERSION);
-}
-
-int has_condition_to_run(int version)
-{
-    if (!has_ebpf_kernel_version(version))
-        return 0;
-
-    return 1;
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/libnetdata/ebpf/ebpf.c
+++ b/src/libnetdata/ebpf/ebpf.c
@@ -244,13 +244,85 @@ static int kernel_is_rejected()
     return 0;
 }
 
-int has_ebpf_kernel_version(int version)
+/**
+ * Check Kernel Version
+ *
+ * Test kernel version
+ *
+ * @param version current kernel version
+ *
+ * @return It returns 1 when kernel is supported and 0 otherwise
+ */
+int ebpf_check_kernel_version(int version)
 {
     if (kernel_is_rejected())
         return 0;
 
     // Kernel 4.11.0 or RH > 7.5
     return (version >= NETDATA_MINIMUM_EBPF_KERNEL || get_redhat_release() >= NETDATA_MINIMUM_RH_VERSION);
+}
+
+/**
+ * Am I running as Root
+ *
+ * Verify the user that is running the collector.
+ *
+ * @return It returns 1 for root and 0 otherwise.
+ */
+int is_ebpf_plugin_running_as_root()
+{
+    uid_t uid = getuid(), euid = geteuid();
+
+    if (uid == 0 || euid == 0) {
+        return 1;
+    }
+
+    return 0;
+}
+
+/**
+ * Can the plugin run eBPF code
+ *
+ * This function checks kernel version and permissions.
+ *
+ * @param kver  the kernel version
+ * @param name  the plugin name.
+ *
+ * @return It returns 0 on success and -1 otherwise
+ */
+int ebpf_can_plugin_load_code(int kver, char *plugin_name)
+{
+    if (!ebpf_check_kernel_version(kver)) {
+        netdata_log_error("The current collector cannot run on this kernel.");
+        return -1;
+    }
+
+    if (!is_ebpf_plugin_running_as_root()) {
+        netdata_log_error(
+            "%s should either run as root (now running with uid %u, euid %u) or have special capabilities.",
+            plugin_name, (unsigned int)getuid(), (unsigned int)geteuid());
+        return -1;
+    }
+
+    return 0;
+}
+
+/**
+ * Adjust memory
+ *
+ * Adjust memory values to load eBPF programs.
+ *
+ * @return It returns 0 on success and -1 otherwise
+ */
+int ebpf_adjust_memory_limit()
+{
+    struct rlimit r = { RLIM_INFINITY, RLIM_INFINITY };
+    if (setrlimit(RLIMIT_MEMLOCK, &r)) {
+        netdata_log_error("Setrlimit(RLIMIT_MEMLOCK)");
+        return -1;
+    }
+
+    return 0;
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/libnetdata/ebpf/ebpf.h
+++ b/src/libnetdata/ebpf/ebpf.h
@@ -361,7 +361,7 @@ typedef struct ebpf_module {
 
 int ebpf_get_kernel_version();
 int get_redhat_release();
-int has_condition_to_run(int version);
+int has_ebpf_kernel_version(int version);
 char *ebpf_kernel_suffix(int version, int isrh);
 struct bpf_link **ebpf_load_program(char *plugins_dir, ebpf_module_t *em, int kver, int is_rhf,
                                            struct bpf_object **obj);

--- a/src/libnetdata/ebpf/ebpf.h
+++ b/src/libnetdata/ebpf/ebpf.h
@@ -486,4 +486,7 @@ int ebpf_statistic_create_aral_chart(char *name, ebpf_module_t *em);
 void ebpf_statistic_obsolete_aral_chart(ebpf_module_t *em, int prio);
 void ebpf_send_data_aral_chart(ARAL *memory, ebpf_module_t *em);
 
+int ebpf_can_plugin_load_code(int kver, char *plugin_name);
+int ebpf_adjust_memory_limit();
+
 #endif /* NETDATA_EBPF_H */

--- a/src/libnetdata/ebpf/ebpf.h
+++ b/src/libnetdata/ebpf/ebpf.h
@@ -363,7 +363,6 @@ typedef struct ebpf_module {
 
 int ebpf_get_kernel_version();
 int get_redhat_release();
-int has_ebpf_kernel_version(int version);
 char *ebpf_kernel_suffix(int version, int isrh);
 struct bpf_link **ebpf_load_program(char *plugins_dir, ebpf_module_t *em, int kver, int is_rhf,
                                            struct bpf_object **obj);

--- a/src/libnetdata/ebpf/ebpf.h
+++ b/src/libnetdata/ebpf/ebpf.h
@@ -3,6 +3,8 @@
 #ifndef NETDATA_EBPF_H
 #define NETDATA_EBPF_H 1
 
+#define NETDATA_EBPF_PLUGIN_NAME "ebpf.plugin"
+
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
 #ifdef LIBBPF_DEPRECATED


### PR DESCRIPTION
##### Summary
This PR is moving some code inside eBPF.plugin to `libnetdata/ebpf` allowing network viewer plugin to test environment before to select the way it will collect data.

##### Test Plan
1. Compile PR.
2. Verify whether eBPF.plugin is running

##### Additional Information
It is not necessary to test on different kernels, because this is only changing user ring code.

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
