### PR TITLE
Correctly mark protobuf as required in find_package.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -555,7 +555,7 @@ if(ENABLE_ACLK OR ENABLE_EXPORTER_PROMETHEUS_REMOTE_WRITE)
                         set(Protobuf_USE_STATIC_LIBS On)
                 endif()
 
-                find_package(Protobuf)
+                find_package(Protobuf REQUIRED)
         endif()
 
         set(ENABLE_PROTOBUF True)


### PR DESCRIPTION
##### Summary

At the point at which we call `find_package()` to locate protobuf, we know that we do, in fact, need it for this build. Given this, we should be marking it as required in the `find_package()` call so that if it’s not found the configuration phase fails instead of things breaking in potentially strange ways later on during the build itself.

##### Test Plan

CI passes on this PR.

Confirmation of the behavior of this change requires testing a build on a system without protobuf _and_ without requesting usage of a bundled copy (which means building directly instead of using the installer).