### PR TITLE
More concretely utilize local modules in our CMake code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ project(netdata
         DESCRIPTION "Netdata real-time monitoring"
         HOMEPAGE_URL "https://www.netdata.cloud"
         LANGUAGES C CXX)
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/packaging/cmake/Modules")
 
 find_package(PkgConfig REQUIRED)
 
@@ -1522,7 +1523,7 @@ set_source_files_properties(JudyLTables.c PROPERTIES COMPILE_OPTIONS "-I${CMAKE_
 # build libnetdata
 #
 
-include(packaging/cmake/systemd.cmake)
+include(DetectSystemd)
 
 add_library(libnetdata STATIC ${LIBNETDATA_FILES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,8 +166,7 @@ endif()
 # handling of extra compiler flags
 #
 
-include(CheckCCompilerFlag)
-include(CheckCXXCompilerFlag)
+include(CompilerFlags)
 
 # Disable hardening for debug builds by default.
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -175,71 +174,6 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 else()
         option(DISABLE_HARDENING "disable adding extra compiler flags for hardening" FALSE)
 endif()
-
-# Construct a pre-processor safe name
-function(make_cpp_safe_name value target)
-        string(REPLACE "-" "_" tmp "${value}")
-        string(REPLACE "=" "_" tmp "${tmp}")
-        set(${target} "${tmp}" PARENT_SCOPE)
-endfunction()
-
-# Conditionally add an extra compiler flag to C and C++ flags.
-#
-# If the language flags already match the `match` argument, skip this flag.
-# Otherwise, check for support for `flag` and if support is found, add it to
-# the language-specific `target` flag group.
-function(add_simple_extra_compiler_flag match flag target)
-        set(CMAKE_REQUIRED_FLAGS "-Werror")
-
-        make_cpp_safe_name("${flag}" flag_name)
-
-        if(NOT ${CMAKE_C_FLAGS} MATCHES ${match})
-                check_c_compiler_flag("${flag}" HAVE_C_${flag_name})
-                if(HAVE_C_${flag_name})
-                        set(${target}_C_FLAGS "${${target}_C_FLAGS} ${flag}" PARENT_SCOPE)
-                endif()
-        endif()
-
-        if(NOT ${CMAKE_CXX_FLAGS} MATCHES ${match})
-                check_cxx_compiler_flag("${flag}" HAVE_CXX_${flag_name})
-                if(HAVE_CXX_${flag_name})
-                        set(${target}_CXX_FLAGS "${${target}_CXX_FLAGS} ${flag}" PARENT_SCOPE)
-                endif()
-        endif()
-endfunction()
-
-# Same as add_simple_extra_compiler_flag, but check for a second flag if the
-# first one is unsupported.
-function(add_double_extra_compiler_flag match flag1 flag2 target)
-        set(CMAKE_REQUIRED_FLAGS "-Werror")
-
-        make_cpp_safe_name("${flag1}" flag1_name)
-        make_cpp_safe_name("${flag2}" flag2_name)
-
-        if(NOT ${CMAKE_C_FLAGS} MATCHES ${match})
-                check_c_compiler_flag("${flag1}" HAVE_C_${flag1_name})
-                if(HAVE_C_${flag1_name})
-                        set(${target}_C_FLAGS "${${target}_C_FLAGS} ${flag1}" PARENT_SCOPE)
-                else()
-                        check_c_compiler_flag("${flag2}" HAVE_C_${flag2_name})
-                        if(HAVE_C_${flag2_name})
-                                set(${target}_C_FLAGS "${${target}_C_FLAGS} ${flag2}" PARENT_SCOPE)
-                        endif()
-                endif()
-        endif()
-
-        if(NOT ${CMAKE_CXX_FLAGS} MATCHES ${match})
-                check_cxx_compiler_flag("${flag1}" HAVE_CXX_${flag1_name})
-                if(HAVE_CXX_${flag1_name})
-                        set(${target}_CXX_FLAGS "${${target}_CXX_FLAGS} ${flag1}" PARENT_SCOPE)
-                else()
-                        check_cxx_compiler_flag("${flag2}" HAVE_CXX_${flag2_name})
-                        if(HAVE_CXX_${flag2_name})
-                                set(${target}_CXX_FLAGS "${${target}_CXX_FLAGS} ${flag2}" PARENT_SCOPE)
-                        endif()
-                endif()
-        endif()
-endfunction()
 
 set(EXTRA_HARDENING_C_FLAGS "")
 set(EXTRA_HARDENING_CXX_FLAGS "")

--- a/packaging/cmake/Modules/CompilerFlags.cmake
+++ b/packaging/cmake/Modules/CompilerFlags.cmake
@@ -1,0 +1,75 @@
+# Functions to simplify handling of extra compiler flags.
+#
+# Copyright (c) 2024 Netdata Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
+
+# Construct a pre-processor safe name
+#
+# This takes a specified value, and assigns the generated name to the
+# specified target.
+function(make_cpp_safe_name value target)
+        string(REPLACE "-" "_" tmp "${value}")
+        string(REPLACE "=" "_" tmp "${tmp}")
+        set(${target} "${tmp}" PARENT_SCOPE)
+endfunction()
+
+# Conditionally add an extra compiler flag to C and C++ flags.
+#
+# If the language flags already match the `match` argument, skip this flag.
+# Otherwise, check for support for `flag` and if support is found, add it to
+# the language-specific `target` flag group.
+function(add_simple_extra_compiler_flag match flag target)
+        set(CMAKE_REQUIRED_FLAGS "-Werror")
+
+        make_cpp_safe_name("${flag}" flag_name)
+
+        if(NOT ${CMAKE_C_FLAGS} MATCHES ${match})
+                check_c_compiler_flag("${flag}" HAVE_C_${flag_name})
+                if(HAVE_C_${flag_name})
+                        set(${target}_C_FLAGS "${${target}_C_FLAGS} ${flag}" PARENT_SCOPE)
+                endif()
+        endif()
+
+        if(NOT ${CMAKE_CXX_FLAGS} MATCHES ${match})
+                check_cxx_compiler_flag("${flag}" HAVE_CXX_${flag_name})
+                if(HAVE_CXX_${flag_name})
+                        set(${target}_CXX_FLAGS "${${target}_CXX_FLAGS} ${flag}" PARENT_SCOPE)
+                endif()
+        endif()
+endfunction()
+
+# Same as add_simple_extra_compiler_flag, but check for a second flag if the
+# first one is unsupported.
+function(add_double_extra_compiler_flag match flag1 flag2 target)
+        set(CMAKE_REQUIRED_FLAGS "-Werror")
+
+        make_cpp_safe_name("${flag1}" flag1_name)
+        make_cpp_safe_name("${flag2}" flag2_name)
+
+        if(NOT ${CMAKE_C_FLAGS} MATCHES ${match})
+                check_c_compiler_flag("${flag1}" HAVE_C_${flag1_name})
+                if(HAVE_C_${flag1_name})
+                        set(${target}_C_FLAGS "${${target}_C_FLAGS} ${flag1}" PARENT_SCOPE)
+                else()
+                        check_c_compiler_flag("${flag2}" HAVE_C_${flag2_name})
+                        if(HAVE_C_${flag2_name})
+                                set(${target}_C_FLAGS "${${target}_C_FLAGS} ${flag2}" PARENT_SCOPE)
+                        endif()
+                endif()
+        endif()
+
+        if(NOT ${CMAKE_CXX_FLAGS} MATCHES ${match})
+                check_cxx_compiler_flag("${flag1}" HAVE_CXX_${flag1_name})
+                if(HAVE_CXX_${flag1_name})
+                        set(${target}_CXX_FLAGS "${${target}_CXX_FLAGS} ${flag1}" PARENT_SCOPE)
+                else()
+                        check_cxx_compiler_flag("${flag2}" HAVE_CXX_${flag2_name})
+                        if(HAVE_CXX_${flag2_name})
+                                set(${target}_CXX_FLAGS "${${target}_CXX_FLAGS} ${flag2}" PARENT_SCOPE)
+                        endif()
+                endif()
+        endif()
+endfunction()

--- a/packaging/cmake/Modules/CompilerFlags.cmake
+++ b/packaging/cmake/Modules/CompilerFlags.cmake
@@ -3,6 +3,8 @@
 # Copyright (c) 2024 Netdata Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+include_guard()
+
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 

--- a/packaging/cmake/Modules/DetectSystemd.cmake
+++ b/packaging/cmake/Modules/DetectSystemd.cmake
@@ -3,6 +3,8 @@
 # Copyright (c) 2024 Netdata Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+include_guard()
+
 find_library(SYSTEMD_LIBRARY NAMES systemd)
 
 include(CheckFunctionExists)

--- a/packaging/cmake/Modules/DetectSystemd.cmake
+++ b/packaging/cmake/Modules/DetectSystemd.cmake
@@ -1,3 +1,8 @@
+# CMake Module to handle all the systemd-related checks for Netdata.
+#
+# Copyright (c) 2024 Netdata Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 find_library(SYSTEMD_LIBRARY NAMES systemd)
 
 include(CheckFunctionExists)


### PR DESCRIPTION
##### Summary

- Set up a proper local module directory and append it to the module search path.
- Move the existing `systemd.cmake` module that we’re using for detecting systemd configuration into the local module directory, and rename it to properly reflect what it's doing.
- Split the functions for handling of compiler flags to their own module.
- Add include guards on both of the above-mentioned modules.

Overall, CMake modules are somewhat cleaner than just including arbitrary files, and certain usage actually _requires_ them. We will need to use modules anyway for the Go integration, so this PR is independently doing some cleanup regarding them.

##### Test Plan

CI passes on this PR.