### PR TITLE
Fix determining repo root in Coverity scan script.

### DIFF
--- a/packaging/utils/coverity-scan.sh
+++ b/packaging/utils/coverity-scan.sh
@@ -52,7 +52,7 @@ SCRIPT_SOURCE="$(
     cd "${self%/*}" || exit 1
     echo "$(pwd -P)/${self##*/}"
 )"
-REPO_ROOT="${SCRIPT_SOURCE}/../.."
+REPO_ROOT="$(dirname "${SCRIPT_SOURCE}")/../.."
 
 . "${REPO_ROOT}/packaging/installer/functions.sh"
 


### PR DESCRIPTION
##### Summary

Fixes a bug introduced by https://github.com/netdata/netdata/pull/16938

##### Test Plan

Manual testing of the updated script is required.