### PR TITLE
Metric release does not need to fetch retention

### DIFF
--- a/src/database/engine/metric.h
+++ b/src/database/engine/metric.h
@@ -52,7 +52,7 @@ MRG *mrg_create(ssize_t partitions);
 void mrg_destroy(MRG *mrg);
 
 METRIC *mrg_metric_dup(MRG *mrg, METRIC *metric);
-bool mrg_metric_release(MRG *mrg, METRIC *metric);
+void mrg_metric_release(MRG *mrg, METRIC *metric);
 
 METRIC *mrg_metric_add_and_acquire(MRG *mrg, MRG_ENTRY entry, bool *ret);
 METRIC *mrg_metric_get_and_acquire(MRG *mrg, uuid_t *uuid, Word_t section);


### PR DESCRIPTION
##### Summary
Currently the metric release function will also fetch retention and report if the metric can be deleted. This is not used as the eligibility of the metric deletion is determined with a different function call.

This PR removes the extra function call during metric release

