### PR TITLE
Keep a count of metrics and samples collected

### DIFF
--- a/src/database/contexts/api_v2.c
+++ b/src/database/contexts/api_v2.c
@@ -1131,6 +1131,8 @@ void buffer_json_agents_v2(BUFFER *wb, struct query_timings *timings, time_t now
 
             buffer_json_add_array_item_object(wb);
             buffer_json_member_add_uint64(wb, "tier", tier);
+            buffer_json_member_add_uint64(wb, "metrics", storage_engine_metrics(eng->seb, localhost->db[tier].si));
+            buffer_json_member_add_uint64(wb, "samples", storage_engine_samples(eng->seb, localhost->db[tier].si));
 
             if(used || max) {
                 buffer_json_member_add_uint64(wb, "disk_used", used);

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -708,8 +708,14 @@ static void journalfile_restore_extent_metadata(struct rrdengine_instance *ctx, 
 
             bool added;
             metric = mrg_metric_add_and_acquire(main_mrg, entry, &added);
-            if(added)
+            if(added) {
+                __atomic_add_fetch(&ctx->atomic.metrics, 1, __ATOMIC_RELAXED);
                 update_metric_time = false;
+            }
+            if (vd.update_every_s) {
+                uint64_t samples = (vd.end_time_s - vd.start_time_s) / vd.update_every_s;
+                __atomic_add_fetch(&ctx->atomic.samples, samples, __ATOMIC_RELAXED);
+            }
         }
         Word_t metric_id = mrg_metric_id(main_mrg, metric);
 

--- a/src/database/engine/metric.h
+++ b/src/database/engine/metric.h
@@ -69,6 +69,7 @@ time_t mrg_metric_get_first_time_s(MRG *mrg, METRIC *metric);
 bool mrg_metric_set_clean_latest_time_s(MRG *mrg, METRIC *metric, time_t latest_time_s);
 bool mrg_metric_set_hot_latest_time_s(MRG *mrg, METRIC *metric, time_t latest_time_s);
 time_t mrg_metric_get_latest_time_s(MRG *mrg, METRIC *metric);
+time_t mrg_metric_get_latest_clean_time_s(MRG *mrg, METRIC *metric);
 
 bool mrg_metric_set_update_every(MRG *mrg, METRIC *metric, uint32_t update_every_s);
 bool mrg_metric_set_update_every_s_if_zero(MRG *mrg, METRIC *metric, uint32_t update_every_s);

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1171,7 +1171,15 @@ static void update_metrics_first_time_s(struct rrdengine_instance *ctx, struct r
     for (size_t index = 0; index < added; ++index) {
         uuid_first_t_entry = &uuid_first_entry_list[index];
         if (likely(uuid_first_t_entry->first_time_s != LONG_MAX)) {
-            mrg_metric_set_first_time_s_if_bigger(main_mrg, uuid_first_t_entry->metric, uuid_first_t_entry->first_time_s);
+
+            time_t old_first_time_s = mrg_metric_get_first_time_s(main_mrg, uuid_first_t_entry->metric);
+
+            bool changed = mrg_metric_set_first_time_s_if_bigger(main_mrg, uuid_first_t_entry->metric, uuid_first_t_entry->first_time_s);
+            if (changed) {
+                uint64_t remove_samples = (uuid_first_t_entry->first_time_s - old_first_time_s) /
+                                          mrg_metric_get_update_every_s(main_mrg, uuid_first_t_entry->metric);
+                __atomic_sub_fetch(&ctx->atomic.samples, remove_samples, __ATOMIC_RELAXED);
+            }
             mrg_metric_release(main_mrg, uuid_first_t_entry->metric);
         }
         else {
@@ -1180,6 +1188,14 @@ static void update_metrics_first_time_s(struct rrdengine_instance *ctx, struct r
             // there is no retention for this metric
             bool has_retention = mrg_metric_zero_disk_retention(main_mrg, uuid_first_t_entry->metric);
             if (!has_retention) {
+                time_t first_time_s = mrg_metric_get_first_time_s(main_mrg, uuid_first_t_entry->metric);
+                time_t last_time_s = mrg_metric_get_latest_time_s(main_mrg, uuid_first_t_entry->metric);
+                time_t update_every_s = mrg_metric_get_update_every_s(main_mrg, uuid_first_t_entry->metric);
+                if (update_every_s && first_time_s && last_time_s) {
+                    uint64_t remove_samples = (first_time_s - last_time_s) / update_every_s;
+                    __atomic_sub_fetch(&ctx->atomic.samples, remove_samples, __ATOMIC_RELAXED);
+                }
+
                 bool deleted = mrg_metric_release_and_delete(main_mrg, uuid_first_t_entry->metric);
                 if(deleted)
                     deleted_metrics++;

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1176,9 +1176,11 @@ static void update_metrics_first_time_s(struct rrdengine_instance *ctx, struct r
 
             bool changed = mrg_metric_set_first_time_s_if_bigger(main_mrg, uuid_first_t_entry->metric, uuid_first_t_entry->first_time_s);
             if (changed) {
-                uint64_t remove_samples = (uuid_first_t_entry->first_time_s - old_first_time_s) /
-                                          mrg_metric_get_update_every_s(main_mrg, uuid_first_t_entry->metric);
-                __atomic_sub_fetch(&ctx->atomic.samples, remove_samples, __ATOMIC_RELAXED);
+                uint32_t update_every_s = mrg_metric_get_update_every_s(main_mrg, uuid_first_t_entry->metric);
+                if (update_every_s && old_first_time_s && uuid_first_t_entry->first_time_s > old_first_time_s) {
+                    uint64_t remove_samples = (uuid_first_t_entry->first_time_s - old_first_time_s) / update_every_s;
+                    __atomic_sub_fetch(&ctx->atomic.samples, remove_samples, __ATOMIC_RELAXED);
+                }
             }
             mrg_metric_release(main_mrg, uuid_first_t_entry->metric);
         }

--- a/src/database/engine/rrdengine.h
+++ b/src/database/engine/rrdengine.h
@@ -387,6 +387,8 @@ struct rrdengine_instance {
         unsigned extents_currently_being_flushed;   // non-zero until we commit data to disk (both datafile and journal file)
 
         time_t first_time_s;
+        uint64_t metrics;
+        uint64_t samples;
     } atomic;
 
     struct {

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -145,7 +145,10 @@ static METRIC *rrdeng_metric_create(STORAGE_INSTANCE *si, uuid_t *uuid) {
             .latest_update_every_s = 0,
     };
 
-    METRIC *metric = mrg_metric_add_and_acquire(main_mrg, entry, NULL);
+    bool added;
+    METRIC *metric = mrg_metric_add_and_acquire(main_mrg, entry, &added);
+    if (added)
+        __atomic_add_fetch(&ctx->atomic.metrics, 1, __ATOMIC_RELAXED);
     return metric;
 }
 
@@ -306,7 +309,19 @@ void rrdeng_store_metric_flush_current_page(STORAGE_COLLECT_HANDLE *sch) {
 
     else {
         check_completed_page_consistency(handle);
-        mrg_metric_set_clean_latest_time_s(main_mrg, handle->metric, pgc_page_end_time_s(handle->pgc_page));
+
+        struct rrdengine_instance *ctx = (struct rrdengine_instance *) mrg_metric_section(main_mrg, handle->metric);
+        if (ctx) {
+            time_t old_clean_last_time_s = mrg_metric_get_latest_clean_time_s(main_mrg, handle->metric);
+            time_t last_time_s = pgc_page_end_time_s(handle->pgc_page);
+            bool changed = mrg_metric_set_clean_latest_time_s(main_mrg, handle->metric, last_time_s);
+            uint32_t update_every_s = mrg_metric_get_update_every_s(main_mrg, handle->metric);
+            if (changed && last_time_s > old_clean_last_time_s && update_every_s) {
+                uint64_t add_samples = (last_time_s - old_clean_last_time_s) / update_every_s;
+                __atomic_add_fetch(&ctx->atomic.samples, add_samples, __ATOMIC_RELAXED);
+            }
+        }
+
         pgc_page_hot_to_dirty_and_release(main_cache, handle->pgc_page);
     }
 
@@ -965,6 +980,16 @@ uint64_t rrdeng_disk_space_max(STORAGE_INSTANCE *si) {
 uint64_t rrdeng_disk_space_used(STORAGE_INSTANCE *si) {
     struct rrdengine_instance *ctx = (struct rrdengine_instance *)si;
     return __atomic_load_n(&ctx->atomic.current_disk_space, __ATOMIC_RELAXED);
+}
+
+uint64_t rrdeng_metrics(STORAGE_INSTANCE *si) {
+    struct rrdengine_instance *ctx = (struct rrdengine_instance *)si;
+    return __atomic_load_n(&ctx->atomic.metrics, __ATOMIC_RELAXED);
+}
+
+uint64_t rrdeng_samples(STORAGE_INSTANCE *si) {
+    struct rrdengine_instance *ctx = (struct rrdengine_instance *)si;
+    return __atomic_load_n(&ctx->atomic.samples, __ATOMIC_RELAXED);
 }
 
 time_t rrdeng_global_first_time_s(STORAGE_INSTANCE *si) {

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -309,7 +309,7 @@ void rrdeng_store_metric_flush_current_page(STORAGE_COLLECT_HANDLE *sch) {
 
     else {
         check_completed_page_consistency(handle);
-
+        mrg_metric_set_clean_latest_time_s(main_mrg, handle->metric, pgc_page_end_time_s(handle->pgc_page));
         struct rrdengine_instance *ctx = (struct rrdengine_instance *) mrg_metric_section(main_mrg, handle->metric);
         if (ctx) {
             time_t start_time_s = pgc_page_start_time_s(handle->pgc_page);

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -310,15 +310,14 @@ void rrdeng_store_metric_flush_current_page(STORAGE_COLLECT_HANDLE *sch) {
     else {
         check_completed_page_consistency(handle);
         mrg_metric_set_clean_latest_time_s(main_mrg, handle->metric, pgc_page_end_time_s(handle->pgc_page));
-        struct rrdengine_instance *ctx = (struct rrdengine_instance *) mrg_metric_section(main_mrg, handle->metric);
-        if (ctx) {
-            time_t start_time_s = pgc_page_start_time_s(handle->pgc_page);
-            time_t end_time_s = pgc_page_end_time_s(handle->pgc_page);
-            uint32_t update_every_s = mrg_metric_get_update_every_s(main_mrg, handle->metric);
-            if (end_time_s && start_time_s && end_time_s > start_time_s && update_every_s) {
-                uint64_t add_samples = (end_time_s - start_time_s) / update_every_s;
-                __atomic_add_fetch(&ctx->atomic.samples, add_samples, __ATOMIC_RELAXED);
-            }
+
+        struct rrdengine_instance *ctx = mrg_metric_ctx(handle->metric);
+        time_t start_time_s = pgc_page_start_time_s(handle->pgc_page);
+        time_t end_time_s = pgc_page_end_time_s(handle->pgc_page);
+        uint32_t update_every_s = mrg_metric_get_update_every_s(main_mrg, handle->metric);
+        if (end_time_s && start_time_s && end_time_s > start_time_s && update_every_s) {
+            uint64_t add_samples = (end_time_s - start_time_s) / update_every_s;
+            __atomic_add_fetch(&ctx->atomic.samples, add_samples, __ATOMIC_RELAXED);
         }
 
         pgc_page_hot_to_dirty_and_release(main_cache, handle->pgc_page);

--- a/src/database/engine/rrdengineapi.h
+++ b/src/database/engine/rrdengineapi.h
@@ -223,7 +223,4 @@ RRDENG_SIZE_STATS rrdeng_size_statistics(struct rrdengine_instance *ctx);
 size_t rrdeng_collectors_running(struct rrdengine_instance *ctx);
 bool rrdeng_is_legacy(STORAGE_INSTANCE *si);
 
-uint64_t rrdeng_disk_space_max(STORAGE_INSTANCE *si);
-uint64_t rrdeng_disk_space_used(STORAGE_INSTANCE *si);
-
 #endif /* NETDATA_RRDENGINEAPI_H */

--- a/src/database/rrd.h
+++ b/src/database/rrd.h
@@ -446,6 +446,27 @@ static inline uint64_t storage_engine_disk_space_used(STORAGE_ENGINE_BACKEND seb
     return 0;
 }
 
+uint64_t rrdeng_metrics(STORAGE_INSTANCE *si);
+static inline uint64_t storage_engine_metrics(STORAGE_ENGINE_BACKEND seb __maybe_unused, STORAGE_INSTANCE *si __maybe_unused) {
+#ifdef ENABLE_DBENGINE
+    if(likely(seb == STORAGE_ENGINE_BACKEND_DBENGINE))
+        return rrdeng_metrics(si);
+#endif
+
+    // TODO - calculate the total host disk space for memory mode save and map
+    return 0;
+}
+
+uint64_t rrdeng_samples(STORAGE_INSTANCE *si);
+static inline uint64_t storage_engine_samples(STORAGE_ENGINE_BACKEND seb __maybe_unused, STORAGE_INSTANCE *si __maybe_unused) {
+#ifdef ENABLE_DBENGINE
+    if(likely(seb == STORAGE_ENGINE_BACKEND_DBENGINE))
+        return rrdeng_samples(si);
+#endif
+    return 0;
+}
+
+
 time_t rrdeng_global_first_time_s(STORAGE_INSTANCE *si);
 static inline time_t storage_engine_global_first_time_s(STORAGE_ENGINE_BACKEND seb __maybe_unused, STORAGE_INSTANCE *si __maybe_unused) {
 #ifdef ENABLE_DBENGINE


### PR DESCRIPTION
##### Summary
- Keep a count of metrics during agent startup
- Calculate number of samples during information from metric page data (start time, end time) and the update frequency
- Expose metric and sample count in api/v2/info 