### PR TITLE
Protect type anomaly rate map

### DIFF
--- a/src/libnetdata/locks/locks.h
+++ b/src/libnetdata/locks/locks.h
@@ -25,6 +25,10 @@ void spinlock_lock(SPINLOCK *spinlock);
 void spinlock_unlock(SPINLOCK *spinlock);
 bool spinlock_trylock(SPINLOCK *spinlock);
 
+void spinlock_lock_cancelable(SPINLOCK *spinlock);
+void spinlock_unlock_cancelable(SPINLOCK *spinlock);
+bool spinlock_trylock_cancelable(SPINLOCK *spinlock);
+
 typedef struct netdata_rw_spinlock {
     int32_t readers;
     SPINLOCK spinlock;

--- a/src/ml/ad_charts.cc
+++ b/src/ml/ad_charts.cc
@@ -288,6 +288,7 @@ void ml_update_host_and_detection_rate_charts(ml_host_t *host, collected_number 
             rrdset_flag_set(host->type_anomaly_rate_rs, RRDSET_FLAG_ANOMALY_DETECTION);
         }
 
+        spinlock_lock_cancelable(&host->type_anomaly_rate_spinlock);
         for (auto &entry : host->type_anomaly_rate) {
             ml_type_anomaly_rate_t &type_anomaly_rate = entry.second;
 
@@ -304,6 +305,7 @@ void ml_update_host_and_detection_rate_charts(ml_host_t *host, collected_number 
             type_anomaly_rate.anomalous_dimensions = 0;
             type_anomaly_rate.normal_dimensions = 0;
         }
+        spinlock_unlock_cancelable(&host->type_anomaly_rate_spinlock);
 
         rrdset_done(host->type_anomaly_rate_rs);
     }

--- a/src/ml/ml-private.h
+++ b/src/ml/ml-private.h
@@ -264,6 +264,7 @@ typedef struct {
     RRDDIM *detector_events_new_anomaly_event_rd;
 
     RRDSET *type_anomaly_rate_rs;
+    SPINLOCK type_anomaly_rate_spinlock;
     std::unordered_map<STRING *, ml_type_anomaly_rate_t> type_anomaly_rate;
 } ml_host_t;
 


### PR DESCRIPTION
##### Summary

Otherwise it's not possible to compute the correct anomaly rate in every case.

For optimization reasons, this PR extends the spinlock API to allow spinlocks ops without changing the cancellation state of the thread.

##### Test Plan

- CI jobs.
- Manually by adding the appropriate checks in the code and running a parent with many children.