### PR TITLE
HEALTH: eliminate fields that should be labels

### DIFF
--- a/src/collectors/plugins.d/pluginsd_parser.c
+++ b/src/collectors/plugins.d/pluginsd_parser.c
@@ -673,6 +673,13 @@ static inline PARSER_RC pluginsd_overwrite(char **words __maybe_unused, size_t n
     rrdlabels_migrate_to_these(host->rrdlabels, parser->user.new_host_labels);
     if (rrdhost_option_check(host, RRDHOST_OPTION_EPHEMERAL_HOST))
         rrdlabels_add(host->rrdlabels, HOST_LABEL_IS_EPHEMERAL, "true", RRDLABEL_SRC_CONFIG);
+
+    if(!rrdlabels_exist(host->rrdlabels, "_os"))
+        rrdlabels_add(host->rrdlabels, "_os", string2str(host->os), RRDLABEL_SRC_AUTO);
+
+    if(!rrdlabels_exist(host->rrdlabels, "_hostname"))
+        rrdlabels_add(host->rrdlabels, "_hostname", string2str(host->hostname), RRDLABEL_SRC_AUTO);
+
     rrdhost_flag_set(host, RRDHOST_FLAG_METADATA_LABELS | RRDHOST_FLAG_METADATA_UPDATE);
 
     rrdlabels_destroy(parser->user.new_host_labels);

--- a/src/collectors/systemd-journal.plugin/schema.d/systemd-journal:monitored-directories.json
+++ b/src/collectors/systemd-journal.plugin/schema.d/systemd-journal:monitored-directories.json
@@ -4,13 +4,16 @@
     "type": "object",
     "properties": {
       "journalDirectories": {
+        "title": "systemd-journal directories",
+        "description": "The list of directories `systemd-journald` and `systemd-journal-remote` store journal files. Netdata monitors these directories to automatically detect changes.",
         "type": "array",
         "items": {
+          "title": "Absolute Path",
           "type": "string",
-          "pattern": "^/.*$"
+          "pattern": "^/.+$"
         },
         "maxItems": 100,
-	"uniqueItems": true
+	    "uniqueItems": true
       }
     },
     "required": [
@@ -19,6 +22,7 @@
   },
   "uiSchema": {
     "journalDirectories": {
+      "ui:listFlavour": "list",
       "ui:options": {
         "addable": true,
         "orderable": false,

--- a/src/collectors/systemd-journal.plugin/systemd-journal-dyncfg.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-dyncfg.c
@@ -4,6 +4,49 @@
 
 #define JOURNAL_DIRECTORIES_JSON_NODE "journalDirectories"
 
+static bool is_directory(const char *dir) {
+    struct stat statbuf;
+    if (stat(dir, &statbuf) != 0) {
+        // Error in stat() means the path probably doesn't exist or can't be accessed.
+        return false;
+    }
+    // S_ISDIR macro is true if the path is a directory.
+    return S_ISDIR(statbuf.st_mode) ? true : false;
+}
+
+static const char *is_valid_dir(const char *dir) {
+    if(strcmp(dir, "/") == 0)
+        return "/ is not acceptable";
+
+    if(!strstartswith(dir, "/"))
+        return "only directories starting with / are accepted";
+
+    if(strstr(dir, "/./"))
+        return "directory contains /./";
+
+    if(strstr(dir, "/../") || strendswith(dir, "/.."))
+        return "directory contains /../";
+
+    if(strstartswith(dir, "/dev/") || strcmp(dir, "/dev") == 0)
+        return "directory contains /dev";
+
+    if(strstartswith(dir, "/proc/") || strcmp(dir, "/proc") == 0)
+        return "directory contains /proc";
+
+    if(strstartswith(dir, "/sys/") || strcmp(dir, "/sys") == 0)
+        return "directory contains /sys";
+
+    if(strstartswith(dir, "/etc/") || strcmp(dir, "/etc") == 0)
+        return "directory contains /etc";
+
+    if(strstartswith(dir, "/lib/") || strcmp(dir, "/lib") == 0
+        || strstartswith(dir, "/lib32/") || strcmp(dir, "/lib32") == 0
+        || strstartswith(dir, "/lib64/") || strcmp(dir, "/lib64") == 0)
+        return "directory contains /lib";
+
+    return NULL;
+}
+
 static int systemd_journal_directories_dyncfg_update(BUFFER *result, BUFFER *payload) {
     if(!payload || !buffer_strlen(payload))
         return dyncfg_default_response(result, HTTP_RESP_BAD_REQUEST, "empty payload received");
@@ -16,14 +59,30 @@ static int systemd_journal_directories_dyncfg_update(BUFFER *result, BUFFER *pay
     json_object_object_get_ex(jobj, JOURNAL_DIRECTORIES_JSON_NODE, &journalDirectories);
 
     size_t n_directories = json_object_array_length(journalDirectories);
+    if(n_directories > MAX_JOURNAL_DIRECTORIES)
+        return dyncfg_default_response(result, HTTP_RESP_BAD_REQUEST, "too many directories configured");
 
-    size_t added = 0;
+    // validate the directories
+    for(size_t i = 0; i < n_directories; i++) {
+        struct json_object *dir = json_object_array_get_idx(journalDirectories, i);
+        const char *s = json_object_get_string(dir);
+        if(s && *s) {
+            const char *msg = is_valid_dir(s);
+            if(msg)
+                return dyncfg_default_response(result, HTTP_RESP_BAD_REQUEST, msg);
+        }
+    }
+
+    size_t added = 0, not_found = 0;
     for(size_t i = 0; i < n_directories; i++) {
         struct json_object *dir = json_object_array_get_idx(journalDirectories, i);
         const char *s = json_object_get_string(dir);
         if(s && *s) {
             string_freez(journal_directories[added].path);
             journal_directories[added++].path = string_strdupz(s);
+
+            if(!is_directory(s))
+                not_found++;
         }
     }
 
@@ -36,7 +95,9 @@ static int systemd_journal_directories_dyncfg_update(BUFFER *result, BUFFER *pay
         }
     }
 
-    return dyncfg_default_response(result, HTTP_RESP_OK, "applied");
+    journal_watcher_restart();
+
+    return dyncfg_default_response(result, HTTP_RESP_OK, not_found ? "added, but some directories are not found in the filesystem" : "");
 }
 
 static int systemd_journal_directories_dyncfg_get(BUFFER *wb) {

--- a/src/collectors/systemd-journal.plugin/systemd-journal-dyncfg.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-dyncfg.c
@@ -150,7 +150,7 @@ void systemd_journal_dyncfg_init(struct functions_evloop_globals *wg) {
     functions_evloop_dyncfg_add(
         wg,
         "systemd-journal:monitored-directories",
-        "/collectors/logs/systemd-journal",
+        "/logs/systemd-journal",
         DYNCFG_STATUS_RUNNING,
         DYNCFG_TYPE_SINGLE,
         DYNCFG_SOURCE_TYPE_INTERNAL,

--- a/src/collectors/systemd-journal.plugin/systemd-journal-watcher.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-watcher.c
@@ -300,7 +300,7 @@ void journal_watcher_restart(void) {
 
 void *journal_watcher_main(void *arg __maybe_unused) {
     while(1) {
-        size_t journal_watcher_session_id = journal_watcher_wanted_session_id;
+        size_t journal_watcher_session_id = __atomic_load_n(&journal_watcher_wanted_session_id, __ATOMIC_RELAXED);
 
         Watcher watcher = {
                 .watchList = mallocz(INITIAL_WATCHES * sizeof(WatchEntry)),

--- a/src/database/contexts/api_v2.c
+++ b/src/database/contexts/api_v2.c
@@ -1319,14 +1319,9 @@ static void contexts_v2_alert_config_to_json_from_sql_alert_config_data(struct s
             buffer_json_member_add_string(wb, "type", is_template ? "template" : "alarm");
             buffer_json_member_add_string(wb, "on", is_template ? t->selectors.on_template : t->selectors.on_key);
 
-            buffer_json_member_add_string(wb, "os", t->selectors.os);
-            buffer_json_member_add_string(wb, "hosts", t->selectors.hosts);
             buffer_json_member_add_string(wb, "families", t->selectors.families);
-            buffer_json_member_add_string(wb, "plugin", t->selectors.plugin);
-            buffer_json_member_add_string(wb, "module", t->selectors.module);
             buffer_json_member_add_string(wb, "host_labels", t->selectors.host_labels);
             buffer_json_member_add_string(wb, "chart_labels", t->selectors.chart_labels);
-            buffer_json_member_add_string(wb, "charts", t->selectors.charts);
         }
         buffer_json_object_close(wb); // selectors
 

--- a/src/database/contexts/query_target.c
+++ b/src/database/contexts/query_target.c
@@ -11,7 +11,6 @@ static void query_dimension_release(QUERY_DIMENSION *qd);
 static void query_instance_release(QUERY_INSTANCE *qi);
 static void query_context_release(QUERY_CONTEXT *qc);
 static void query_node_release(QUERY_NODE *qn);
-static void free_label_pattern_list(struct label_pattern_list *lpl);
 
 static __thread QUERY_TARGET *thread_qt = NULL;
 static struct {
@@ -83,10 +82,6 @@ void query_target_release(QUERY_TARGET *qt) {
 
     simple_pattern_free(qt->instances.labels_pattern);
     qt->instances.labels_pattern = NULL;
-
-    free_label_pattern_list(qt->instances.label_pattern_list);
-    qt->instances.label_pattern_list = NULL;
-
     simple_pattern_free(qt->query.pattern);
     qt->query.pattern = NULL;
 
@@ -734,23 +729,18 @@ static inline SIMPLE_PATTERN_RESULT query_instance_matches(QUERY_INSTANCE *qi,
 static inline bool query_instance_matches_labels(
     RRDINSTANCE *ri,
     SIMPLE_PATTERN *chart_label_key_sp,
-    SIMPLE_PATTERN *labels_sp,
-    struct label_pattern_list *lpl)
+    SIMPLE_PATTERN *labels_sp)
 {
 
     if (chart_label_key_sp && !rrdlabels_match_simple_pattern_parsed(ri->rrdlabels, chart_label_key_sp, '\0', NULL))
         return false;
 
-    if (lpl) {
-        for (size_t i = 0; i < lpl->size; i++) {
-            if (!rrdlabels_match_simple_pattern_parsed(ri->rrdlabels,  lpl->labels_pattern[i], ':', NULL))
-                return false;
-        }
-        return true;
+    if (labels_sp) {
+        struct pattern_array *pa = pattern_array_add_simple_pattern(NULL, labels_sp, ':');
+        bool found = pattern_array_label_match(pa, ri->rrdlabels, ':', NULL, rrdlabels_match_simple_pattern_parsed);
+        pattern_array_free(pa);
+        return found;
     }
-
-    if (labels_sp && !rrdlabels_match_simple_pattern_parsed(ri->rrdlabels, labels_sp, ':', NULL))
-        return false;
 
     return true;
 }
@@ -775,8 +765,7 @@ static bool query_instance_add(QUERY_TARGET_LOCALS *qtl, QUERY_NODE *qn, QUERY_C
         queryable_instance = query_instance_matches_labels(
             ri,
             qt->instances.chart_label_key_pattern,
-            qt->instances.labels_pattern,
-            qt->instances.label_pattern_list);
+            qt->instances.labels_pattern);
 
     if(queryable_instance) {
         if(qt->instances.alerts_pattern && !query_target_match_alert_pattern(ria, qt->instances.alerts_pattern))
@@ -1045,84 +1034,6 @@ void query_target_generate_name(QUERY_TARGET *qt) {
     json_fix_string(qt->id);
 }
 
-static void add_label_pattern(struct label_pattern_list *lpl, char *label_key_value)
-{
-    char *label_key;
-
-    if (unlikely(!label_key_value || !(label_key = strchr(label_key_value, ':'))))
-        return;
-
-    *label_key = '\0';
-    STRING *key_match = string_strdupz(label_key_value);
-    *label_key = ':';
-
-    size_t index;
-    bool need_to_add = true;
-
-    for (size_t i = 0; i < lpl->size; i++) {
-        if (lpl->key[i] == key_match) {
-            index = i;
-            need_to_add = false;
-            break;
-        }
-    }
-
-    if (need_to_add) {
-        index = lpl->size++;
-        lpl->buffer_list = reallocz(lpl->buffer_list, lpl->size * sizeof(BUFFER *));
-        lpl->key = reallocz(lpl->key, lpl->size * sizeof(STRING *));
-
-        lpl->buffer_list[index] = buffer_create(128, NULL);
-        lpl->key[index] = key_match;
-    } else {
-        string_freez(key_match);
-        buffer_strncat(lpl->buffer_list[index], ",", 1);
-    }
-
-    buffer_strcat(lpl->buffer_list[index], label_key_value);
-}
-
-static struct label_pattern_list *build_pattern_list(SIMPLE_PATTERN *pattern)
-{
-    if (unlikely(!pattern))
-        return NULL;
-
-    char *label_key = NULL;
-
-    struct label_pattern_list *lpl = callocz(1, sizeof(*lpl));
-
-    while (pattern && (label_key = simple_pattern_iterate(&pattern)))
-        add_label_pattern(lpl, label_key);
-
-    lpl->labels_pattern = callocz(lpl->size, sizeof(SIMPLE_PATTERN *));
-
-    for (size_t i = 0; i < lpl->size; i++) {
-        lpl->labels_pattern[i] = string_to_simple_pattern(buffer_tostring(lpl->buffer_list[i]));
-        buffer_free(lpl->buffer_list[i]);
-        string_freez(lpl->key[i]);
-    }
-
-    freez(lpl->buffer_list);
-    lpl->buffer_list = NULL;
-
-    freez(lpl->key);
-    lpl->key = NULL;
-    return lpl;
-}
-
-static void free_label_pattern_list(struct label_pattern_list *lpl)
-{
-    if (unlikely(!lpl))
-        return;
-
-    for(size_t i = 0; i < lpl->size; i++)
-        simple_pattern_free(lpl->labels_pattern[i]);
-
-    freez(lpl->labels_pattern);
-    freez(lpl);
-}
-
-
 QUERY_TARGET *query_target_create(QUERY_TARGET_REQUEST *qtr) {
     if(!service_running(ABILITY_DATA_QUERIES))
         return NULL;
@@ -1187,10 +1098,6 @@ QUERY_TARGET *query_target_create(QUERY_TARGET_REQUEST *qtr) {
     qt->query.pattern = string_to_simple_pattern(qtl.dimensions);
     qt->instances.chart_label_key_pattern = string_to_simple_pattern(qtl.chart_label_key);
     qt->instances.labels_pattern = string_to_simple_pattern(qtl.labels);
-
-    if (qt->instances.labels_pattern)
-        qt->instances.label_pattern_list = build_pattern_list(qt->instances.labels_pattern);
-
     qt->instances.alerts_pattern = string_to_simple_pattern(qtl.alerts);
 
     qtl.match_ids = qt->request.options & RRDR_OPTION_MATCH_IDS;
@@ -1262,11 +1169,6 @@ ssize_t weights_foreach_rrdmetric_in_context(RRDCONTEXT_ACQUIRED *rca,
 
     ssize_t count = 0;
     RRDINSTANCE *ri;
-
-    struct label_pattern_list *lpl = NULL;
-    if (labels_sp)
-        lpl = build_pattern_list(labels_sp);
-
     dfe_start_read(rc->rrdinstances, ri) {
                 if(rrd_flag_is_deleted(ri))
                     continue;
@@ -1283,7 +1185,7 @@ ssize_t weights_foreach_rrdmetric_in_context(RRDCONTEXT_ACQUIRED *rca,
                         continue;
                 }
 
-                if(!query_instance_matches_labels(ri, chart_label_key_sp, labels_sp, lpl))
+                if(!query_instance_matches_labels(ri, chart_label_key_sp, labels_sp))
                     continue;
 
                 if(alerts_sp && !query_target_match_alert_pattern(ria, alerts_sp))
@@ -1327,8 +1229,5 @@ ssize_t weights_foreach_rrdmetric_in_context(RRDCONTEXT_ACQUIRED *rca,
                     break;
             }
     dfe_done(ri);
-
-    free_label_pattern_list(lpl);
-
     return count;
 }

--- a/src/database/contexts/rrdcontext.h
+++ b/src/database/contexts/rrdcontext.h
@@ -461,14 +461,9 @@ struct sql_alert_config_data {
         const char *on_template;
         const char *on_key;
 
-        const char *os;
-        const char *hosts;
         const char *families;
-        const char *plugin;
-        const char *module;
         const char *host_labels;
         const char *chart_labels;
-        const char *charts;
     } selectors;
 
     const char *info;

--- a/src/database/contexts/rrdcontext.h
+++ b/src/database/contexts/rrdcontext.h
@@ -329,13 +329,6 @@ struct query_timings {
     usec_t finished_ut;
 };
 
-struct label_pattern_list {
-    BUFFER **buffer_list;
-    STRING **key;
-    SIMPLE_PATTERN **labels_pattern;
-    size_t size;
-};
-
 #define query_view_update_every(qt) ((qt)->window.group * (qt)->window.query_granularity)
 
 typedef struct query_target {
@@ -386,7 +379,6 @@ typedef struct query_target {
         uint32_t size;                      // the size of the array
         SIMPLE_PATTERN *pattern;
         SIMPLE_PATTERN *labels_pattern;
-        struct label_pattern_list *label_pattern_list;
         SIMPLE_PATTERN *alerts_pattern;
         SIMPLE_PATTERN *chart_label_key_pattern;
     } instances;

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -1438,6 +1438,9 @@ static void rrdhost_load_auto_labels(void) {
 
     rrdlabels_add(labels, "_is_parent", (localhost->connected_children_count > 0) ? "true" : "false", RRDLABEL_SRC_AUTO);
 
+    rrdlabels_add(labels, "_hostname", string2str(localhost->hostname), RRDLABEL_SRC_AUTO);
+    rrdlabels_add(labels, "_os", string2str(localhost->os), RRDLABEL_SRC_AUTO);
+
     if (localhost->rrdpush_send_destination)
         rrdlabels_add(labels, "_streams_to", localhost->rrdpush_send_destination, RRDLABEL_SRC_AUTO);
 }

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -1347,6 +1347,143 @@ void rrdset_update_rrdlabels(RRDSET *st, RRDLABELS *new_rrdlabels) {
     rrdset_metadata_updated(st);
 }
 
+struct pattern_array *pattern_array_allocate()
+{
+    struct pattern_array *pa = callocz(1, sizeof(*pa));
+    return pa;
+}
+
+static void pattern_array_add_lblkey_with_sp(struct pattern_array *pa, const char *key, SIMPLE_PATTERN *sp)
+{
+    if (!pa || !key || !sp)
+        return;
+
+    STRING *string_key = string_strdupz(key);
+    Pvoid_t *Pvalue = JudyLIns(&pa->JudyL, (Word_t) string_key, PJE0);
+    if (!Pvalue) {
+        string_freez(string_key);
+        simple_pattern_free(sp);
+        return;
+    }
+
+    struct pattern_array_item *pai;
+    if (*Pvalue) {
+        pai = *Pvalue;
+    } else {
+        *Pvalue = pai = callocz(1, sizeof(*pai));
+        pa->key_count++;
+    }
+
+    pai->size++;
+    Pvalue = JudyLIns(&pai->JudyL, (Word_t) pai->size, PJE0);
+    if (!Pvalue) {
+        simple_pattern_free(sp);
+        return;
+    }
+
+    *Pvalue = sp;
+}
+
+bool pattern_array_label_match(
+    struct pattern_array *pa,
+    RRDLABELS *labels,
+    char eq,
+    size_t *searches,
+    bool (*callback_function)(RRDLABELS *, void *, char, size_t *))
+{
+    if (!pa || !labels)
+        return true;
+
+    Pvoid_t *Pvalue;
+    Word_t Index = 0;
+    bool first_then_next = true;
+    while ((Pvalue = JudyLFirstThenNext(pa->JudyL, &Index, &first_then_next))) {
+        struct pattern_array_item *pai = *Pvalue;
+        bool match = false;
+        for (Word_t i = 1; !match && i <= pai->size; i++) {
+            if (!(Pvalue = JudyLGet(pai->JudyL, i, PJE0)) || !*Pvalue)
+                continue;
+            match = callback_function(labels, (SIMPLE_PATTERN *)(*Pvalue), eq, searches);
+        }
+        if (!match)
+            return false;
+    }
+    return true;
+}
+
+struct pattern_array *pattern_array_add_key_simple_pattern(struct pattern_array *pa, const char *key, SIMPLE_PATTERN *pattern)
+{
+    if (unlikely(!pattern || !key))
+        return pa;
+
+    if (!pa)
+        pa = pattern_array_allocate();
+
+    pattern_array_add_lblkey_with_sp(pa, key, pattern);
+    return pa;
+}
+
+struct pattern_array *pattern_array_add_simple_pattern(struct pattern_array *pa, SIMPLE_PATTERN *pattern, char sep)
+{
+    if (unlikely(!pattern))
+        return pa;
+
+    if (!pa)
+        pa = pattern_array_allocate();
+
+    char *label_key;
+    while (pattern && (label_key = simple_pattern_iterate(&pattern))) {
+        char key[RRDLABELS_MAX_NAME_LENGTH + 1], *key_sep;
+
+        if (unlikely(!label_key || !(key_sep = strchr(label_key, sep))))
+            return pa;
+
+        *key_sep = '\0';
+        strncpyz(key, label_key, RRDLABELS_MAX_NAME_LENGTH);
+        *key_sep = sep;
+
+        pattern_array_add_lblkey_with_sp(pa, key, string_to_simple_pattern(label_key));
+    }
+    return pa;
+}
+
+struct pattern_array *pattern_array_add_key_value(struct pattern_array *pa, const char *key, const char *value, char sep)
+{
+    if (unlikely(!key || !value))
+        return pa;
+
+    if (!pa)
+        pa = pattern_array_allocate();
+
+    char label_key[RRDLABELS_MAX_NAME_LENGTH + RRDLABELS_MAX_VALUE_LENGTH + 2];
+    snprintfz(label_key, sizeof(label_key) - 1, "%s%c%s", key, sep, value);
+    pattern_array_add_lblkey_with_sp(
+        pa, key, simple_pattern_create(label_key, SIMPLE_PATTERN_DEFAULT_WEB_SEPARATORS, SIMPLE_PATTERN_EXACT, true));
+    return pa;
+}
+
+void pattern_array_free(struct pattern_array *pa)
+{
+    if (!pa)
+        return;
+
+    Pvoid_t *Pvalue;
+    Word_t Index = 0;
+    while ((Pvalue = JudyLFirst(pa->JudyL, &Index, PJE0))) {
+        struct pattern_array_item *pai = *Pvalue;
+
+        for (Word_t i = 1; i <= pai->size; i++) {
+            if (!(Pvalue = JudyLGet(pai->JudyL, i, PJE0)))
+                continue;
+            simple_pattern_free((SIMPLE_PATTERN *) (*Pvalue));
+        }
+        JudyLFreeArray(&(pai->JudyL), PJE0);
+
+        string_freez((STRING *)Index);
+        (void) JudyLDel(&(pa->JudyL), Index, PJE0);
+        Index = 0;
+    }
+}
 
 // ----------------------------------------------------------------------------
 // rrdlabels unit test
@@ -1549,6 +1686,70 @@ static int unittest_dump_labels(const char *name, const char *value, RRDLABEL_SR
     return 1;
 }
 
+static int rrdlabels_unittest_pattern_check()
+{
+    fprintf(stderr, "\n%s() tests\n", __FUNCTION__);
+    int rc = 0;
+
+    RRDLABELS *labels = NULL;
+
+    labels = rrdlabels_create();
+
+    rrdlabels_add(labels, "_module", "disk_detection", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(labels, "_plugin", "super_plugin", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(labels, "key1", "value1", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(labels, "key2", "caterpillar", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(labels, "key3", "elephant", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(labels, "key4", "value4", RRDLABEL_SRC_CONFIG);
+
+    bool match;
+    struct pattern_array *pa = pattern_array_add_key_value(NULL, "_module", "wrong_module", '=');
+    match = pattern_array_label_match(pa, labels, '=', NULL, rrdlabels_match_simple_pattern_parsed);
+    // This should not match:  _module in ("wrong_module")
+    if (match)
+        rc++;
+
+    pattern_array_add_key_value(pa, "_module", "disk_detection", '=');
+    match = pattern_array_label_match(pa, labels, '=', NULL, rrdlabels_match_simple_pattern_parsed);
+    // This should match: _module in ("wrong_module","disk_detection")
+    if (!match)
+        rc++;
+
+    pattern_array_add_key_value(pa, "key1", "wrong_key1_value", '=');
+    match = pattern_array_label_match(pa, labels, '=', NULL, rrdlabels_match_simple_pattern_parsed);
+    // This should not match: _module in ("wrong_module","disk_detection") AND key1 in ("wrong_key1_value")
+    if (match)
+        rc++;
+
+    pattern_array_add_key_value(pa, "key1", "value1", '=');
+    match = pattern_array_label_match(pa, labels, '=', NULL, rrdlabels_match_simple_pattern_parsed);
+    // This should match: _module in ("wrong_module","disk_detection") AND key1 in ("wrong_key1_value", "value1")
+    if (!match)
+        rc++;
+
+    SIMPLE_PATTERN *sp = simple_pattern_create("key2=cat*,!d*", SIMPLE_PATTERN_DEFAULT_WEB_SEPARATORS, SIMPLE_PATTERN_EXACT, true);
+    pattern_array_add_lblkey_with_sp(pa, "key2", sp);
+
+    sp = simple_pattern_create("key3=*phant", SIMPLE_PATTERN_DEFAULT_WEB_SEPARATORS, SIMPLE_PATTERN_EXACT, true);
+    pattern_array_add_lblkey_with_sp(pa, "key3", sp);
+
+    match = pattern_array_label_match(pa, labels, '=', NULL, rrdlabels_match_simple_pattern_parsed);
+    // This should match: _module in ("wrong_module","disk_detection") AND key1 in ("wrong_key1_value", "value1") AND key2 in ("cat* !d*") AND key3 in ("*phant")
+    if (!match)
+        rc++;
+
+    rrdlabels_add(labels, "key3", "now_fail", RRDLABEL_SRC_CONFIG);
+    match = pattern_array_label_match(pa, labels, '=', NULL, rrdlabels_match_simple_pattern_parsed);
+    // This should not match: _module in ("wrong_module","disk_detection") AND key1 in ("wrong_key1_value", "value1") AND key2 in ("cat* !d*") AND key3 in ("*phant")
+    if (match)
+        rc++;
+
+    pattern_array_free(pa);
+    rrdlabels_destroy(labels);
+
+    return rc;
+}
+
 static int rrdlabels_unittest_migrate_check()
 {
     fprintf(stderr, "\n%s() tests\n", __FUNCTION__);
@@ -1724,7 +1925,9 @@ int rrdlabels_unittest(void) {
     errors += rrdlabels_unittest_simple_pattern();
     errors += rrdlabels_unittest_double_check();
     errors += rrdlabels_unittest_migrate_check();
+    errors += rrdlabels_unittest_pattern_check();
 
     fprintf(stderr, "%d errors found\n", errors);
     return errors;
 }
+

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -1389,7 +1389,7 @@ bool pattern_array_label_match(
     RRDLABELS *labels,
     char eq,
     size_t *searches,
-    bool (*callback_function)(RRDLABELS *, void *, char, size_t *))
+    bool (*callback_function)(RRDLABELS *, SIMPLE_PATTERN *, char, size_t *))
 {
     if (!pa || !labels)
         return true;

--- a/src/database/rrdlabels.h
+++ b/src/database/rrdlabels.h
@@ -70,7 +70,7 @@ bool pattern_array_label_match(
     RRDLABELS *labels,
     char eq,
     size_t *searches,
-    bool (*callback_function)(RRDLABELS *, void *, char, size_t *));
+    bool (*callback_function)(RRDLABELS *, SIMPLE_PATTERN *, char, size_t *));
 struct pattern_array *pattern_array_add_simple_pattern(struct pattern_array *pa, SIMPLE_PATTERN *pattern, char sep);
 struct pattern_array *
 pattern_array_add_key_simple_pattern(struct pattern_array *pa, const char *key, SIMPLE_PATTERN *pattern);

--- a/src/database/rrdlabels.h
+++ b/src/database/rrdlabels.h
@@ -5,6 +5,16 @@
 
 #include "rrd.h"
 
+struct pattern_array_item {
+    Word_t size;
+    Pvoid_t JudyL;
+};
+
+struct pattern_array {
+    Word_t key_count;
+    Pvoid_t JudyL;
+};
+
 typedef enum __attribute__ ((__packed__)) rrdlabel_source {
     RRDLABEL_SRC_AUTO       = (1 << 0), // set when Netdata found the label by some automation
     RRDLABEL_SRC_CONFIG     = (1 << 1), // set when the user configured the label
@@ -51,6 +61,20 @@ void rrdlabels_to_buffer_json_members(RRDLABELS *labels, BUFFER *wb);
 void rrdlabels_migrate_to_these(RRDLABELS *dst, RRDLABELS *src);
 void rrdlabels_copy(RRDLABELS *dst, RRDLABELS *src);
 size_t rrdlabels_common_count(RRDLABELS *labels1, RRDLABELS *labels2);
+
+struct pattern_array *pattern_array_allocate();
+struct pattern_array *
+pattern_array_add_key_value(struct pattern_array *pa, const char *key, const char *value, char sep);
+bool pattern_array_label_match(
+    struct pattern_array *pa,
+    RRDLABELS *labels,
+    char eq,
+    size_t *searches,
+    bool (*callback_function)(RRDLABELS *, void *, char, size_t *));
+struct pattern_array *pattern_array_add_simple_pattern(struct pattern_array *pa, SIMPLE_PATTERN *pattern, char sep);
+struct pattern_array *
+pattern_array_add_key_simple_pattern(struct pattern_array *pa, const char *key, SIMPLE_PATTERN *pattern);
+void pattern_array_free(struct pattern_array *pa);
 
 int rrdlabels_unittest(void);
 

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -897,12 +897,12 @@ void sql_health_alarm_log_load(RRDHOST *host)
  */
 #define SQL_STORE_ALERT_CONFIG_HASH                                                                                     \
     "insert or replace into alert_hash (hash_id, date_updated, alarm, template, "                                       \
-    "on_key, class, component, type, os, hosts, lookup, every, units, calc, plugin, module, "                           \
-    "charts, green, red, warn, crit, exec, to_key, info, delay, options, repeat, host_labels, "                         \
+    "on_key, class, component, type, lookup, every, units, calc, "                                                      \
+    "green, red, warn, crit, exec, to_key, info, delay, options, repeat, host_labels, "                                 \
     "p_db_lookup_dimensions, p_db_lookup_method, p_db_lookup_options, p_db_lookup_after, "                              \
     "p_db_lookup_before, p_update_every, source, chart_labels, summary) values (@hash_id,UNIXEPOCH(),@alarm,@template," \
-    "@on_key,@class,@component,@type,@os,@hosts,@lookup,@every,@units,@calc,@plugin,@module,"                           \
-    "@charts,@green,@red,@warn,@crit,@exec,@to_key,@info,@delay,@options,@repeat,@host_labels,"                         \
+    "@on_key,@class,@component,@type,@lookup,@every,@units,@calc,"                                                      \
+    "@green,@red,@warn,@crit,@exec,@to_key,@info,@delay,@options,@repeat,@host_labels,"                                 \
     "@p_db_lookup_dimensions,@p_db_lookup_method,@p_db_lookup_options,@p_db_lookup_after,"                              \
     "@p_db_lookup_before,@p_update_every,@source,@chart_labels,@summary)"
 

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -1835,8 +1835,8 @@ done_only_drop:
 #define SQL_POPULATE_TEMP_CONFIG_TARGET_TABLE "INSERT INTO c_%p (hash_id) VALUES (@hash_id)"
 
 #define SQL_SEARCH_CONFIG_LIST                                                                                         \
-    "SELECT ah.hash_id, alarm, template, on_key, class, component, type, os, hosts, lookup, every, "                   \
-    " units, calc, families, plugin, module, charts, green, red, warn, crit, "                                         \
+    "SELECT ah.hash_id, alarm, template, on_key, class, component, type, lookup, every, "                              \
+    " units, calc, families, green, red, warn, crit, "                                                                 \
     " exec, to_key, info, delay, options, repeat, host_labels, p_db_lookup_dimensions, p_db_lookup_method, "           \
     " p_db_lookup_options, p_db_lookup_after, p_db_lookup_before, p_update_every, source, chart_labels, summary "      \
     " FROM alert_hash ah, c_%p t where ah.hash_id = t.hash_id"
@@ -1918,16 +1918,11 @@ int sql_get_alert_configuration(
         acd.classification = (const char *) sqlite3_column_text(res, param++);
         acd.component = (const char *) sqlite3_column_text(res, param++);
         acd.type = (const char *) sqlite3_column_text(res, param++);
-        acd.selectors.os = (const char *) sqlite3_column_text(res, param++);
-        acd.selectors.hosts = (const char *) sqlite3_column_text(res, param++);
         acd.value.db.lookup = (const char *) sqlite3_column_text(res, param++);
         acd.value.every = (const char *) sqlite3_column_text(res, param++);
         acd.value.units = (const char *) sqlite3_column_text(res, param++);
         acd.value.calc = (const char *) sqlite3_column_text(res, param++);
         acd.selectors.families = (const char *) sqlite3_column_text(res, param++);
-        acd.selectors.plugin = (const char *) sqlite3_column_text(res, param++);
-        acd.selectors.module = (const char *) sqlite3_column_text(res, param++);
-        acd.selectors.charts = (const char *) sqlite3_column_text(res, param++);
         acd.status.green = (const char *) sqlite3_column_text(res, param++);
         acd.status.red = (const char *) sqlite3_column_text(res, param++);
         acd.status.warn = (const char *) sqlite3_column_text(res, param++);

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -966,10 +966,6 @@ int sql_alert_store_config(RRD_ALERT_PROTOTYPE *ap __maybe_unused)
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->match.os, ++param);
-    if (unlikely(rc != SQLITE_OK))
-        goto bind_fail;
-
     rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->match.host, ++param);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
@@ -990,18 +986,6 @@ int sql_alert_store_config(RRD_ALERT_PROTOTYPE *ap __maybe_unused)
         rc = sqlite3_bind_text(res, ++param, expression_source(ap->config.calculation), -1, SQLITE_STATIC);
     else
         rc = sqlite3_bind_null(res, ++param);
-    if (unlikely(rc != SQLITE_OK))
-        goto bind_fail;
-
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->match.plugin, ++param);
-    if (unlikely(rc != SQLITE_OK))
-        goto bind_fail;
-
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->match.module, ++param);
-    if (unlikely(rc != SQLITE_OK))
-        goto bind_fail;
-
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->match.charts, ++param);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -966,10 +966,6 @@ int sql_alert_store_config(RRD_ALERT_PROTOTYPE *ap __maybe_unused)
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->match.host, ++param);
-    if (unlikely(rc != SQLITE_OK))
-        goto bind_fail;
-
     rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->config.lookup, ++param);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;

--- a/src/health/REFERENCE.md
+++ b/src/health/REFERENCE.md
@@ -242,7 +242,6 @@ Netdata parses the following lines. Beneath the table is an in-depth explanation
 | [`hosts`](#alert-line-hosts)                        | no              | Which hostnames will run this alert.                                                  |
 | [`plugin`](#alert-line-plugin)                      | no              | Restrict an alert or template to only a certain plugin.                               |
 | [`module`](#alert-line-module)                      | no              | Restrict an alert or template to only a certain module.                               |
-| [`charts`](#alert-line-charts)                      | no              | Restrict an alert or template to only certain charts.                                 |
 | [`lookup`](#alert-line-lookup)                      | yes             | The database lookup to find and process metrics for the chart specified through `on`. |
 | [`calc`](#alert-line-calc)                          | yes (see above) | A calculation to apply to the value found via `lookup` or another variable.           |
 | [`every`](#alert-line-every)                        | no              | The frequency of the alert.                                                           |
@@ -431,19 +430,6 @@ example, you can create an alert that applies only on the `isc_dhcpd` module sta
 ```yaml
 plugin: python.d.plugin
 module: isc_dhcpd
-```
-
-#### Alert line `charts`
-
-The `charts` line filters which chart this alert should apply to. It is only available on entities using the
-[`template`](#alert-line-alarm-or-template) line.
-The value is a space-separated list of [simple patterns](https://github.com/netdata/netdata/blob/master/src/libnetdata/simple_pattern/README.md). For
-example, a template that applies to `disk.svctm` (Average Service Time) context, but excludes the disk `sdb` from alerts:
-
-```yaml
-template: disk_svctm_alert
-      on: disk.svctm
-  charts: !*sdb* *
 ```
 
 #### Alert line `lookup`
@@ -896,10 +882,6 @@ context are essentially identical, with the only difference being the family tha
         to the last collected value - as collected and another with suffix `_last_collected_t`
         that resolves to unix timestamp the dimension was last collected (there may be dimensions
         that fail to be collected while others continue normally).
-
-- **family variables**. Families are used to group charts together. For example all `eth0`
-     charts, have `family = eth0`. This index includes all local variables, but if there are
-     overlapping variables, only the first are exposed.
 
 - **host variables**. All the dimensions of all charts, including all alerts, in fullname.
      Fullname is `CHART.VARIABLE`, where `CHART` is either the chart id or the chart name (both

--- a/src/health/health_config.c
+++ b/src/health/health_config.c
@@ -404,7 +404,6 @@ int health_readfile(const char *filename, void *data __maybe_unused, bool stock_
             hash_host = 0,
             hash_plugin = 0,
             hash_module = 0,
-            hash_charts = 0,
             hash_calc = 0,
             hash_green = 0,
             hash_red = 0,
@@ -436,7 +435,6 @@ int health_readfile(const char *filename, void *data __maybe_unused, bool stock_
         hash_host = simple_uhash(HEALTH_HOST_KEY);
         hash_plugin = simple_uhash(HEALTH_PLUGIN_KEY);
         hash_module = simple_uhash(HEALTH_MODULE_KEY);
-        hash_charts = simple_uhash(HEALTH_CHARTS_KEY);
         hash_calc = simple_uhash(HEALTH_CALC_KEY);
         hash_lookup = simple_uhash(HEALTH_LOOKUP_KEY);
         hash_green = simple_uhash(HEALTH_GREEN_KEY);

--- a/src/health/health_config.c
+++ b/src/health/health_config.c
@@ -564,9 +564,6 @@ int health_readfile(const char *filename, void *data __maybe_unused, bool stock_
         else if(am->is_template && hash == hash_on && !strcasecmp(key, HEALTH_ON_KEY)) {
             PARSE_HEALTH_CONFIG_LINE_STRING(am, on.context);
         }
-        else if(am->is_template && hash == hash_charts && !strcasecmp(key, HEALTH_CHARTS_KEY)) {
-            PARSE_HEALTH_CONFIG_LINE_PATTERN_APPEND(am, chart_labels, "_instance");
-        }
         else if(hash == hash_os && !strcasecmp(key, HEALTH_OS_KEY)) {
             PARSE_HEALTH_CONFIG_LINE_PATTERN_APPEND(am, host_labels, "_os");
         }
@@ -702,7 +699,7 @@ int health_readfile(const char *filename, void *data __maybe_unused, bool stock_
             ac->has_custom_repeat_config = true;
         }
         else {
-            if (strcmp(key, "families") != 0)
+            if (strcmp(key, "families") != 0 && strcmp(key, "charts") != 0)
                 netdata_log_error(
                     "Health configuration at line %zu of file '%s' for alarm/template '%s' has unknown key '%s'.",
                     line, filename, string2str(ac->name), key);

--- a/src/health/health_dyncfg.c
+++ b/src/health/health_dyncfg.c
@@ -17,14 +17,6 @@ static bool parse_match(json_object *jobj, const char *path, struct rrd_alert_ma
     else
         match->on.chart = on;
 
-    JSONC_PARSE_TXT2PATTERN_OR_ERROR_AND_RETURN(jobj, path, "os", match->os, error);
-    JSONC_PARSE_TXT2PATTERN_OR_ERROR_AND_RETURN(jobj, path, "host", match->host, error);
-
-    if(match->is_template)
-        JSONC_PARSE_TXT2PATTERN_OR_ERROR_AND_RETURN(jobj, path, "instances", match->charts, error);
-
-    JSONC_PARSE_TXT2PATTERN_OR_ERROR_AND_RETURN(jobj, path, "plugin", match->plugin, error);
-    JSONC_PARSE_TXT2PATTERN_OR_ERROR_AND_RETURN(jobj, path, "module", match->module, error);
     JSONC_PARSE_TXT2PATTERN_OR_ERROR_AND_RETURN(jobj, path, "host_labels", match->host_labels, error);
     JSONC_PARSE_TXT2PATTERN_OR_ERROR_AND_RETURN(jobj, path, "instance_labels", match->chart_labels, error);
 
@@ -219,11 +211,6 @@ static inline void health_prototype_rule_to_json_array_member(BUFFER *wb, RRD_AL
             else
                 buffer_json_member_add_string(wb, "on", string2str(ap->match.on.chart));
 
-            buffer_json_member_add_string_or_empty(wb, "os", ap->match.os ? string2str(ap->match.os) : "*");
-            buffer_json_member_add_string_or_empty(wb, "host", ap->match.host ? string2str(ap->match.host) : "*");
-            buffer_json_member_add_string_or_empty(wb, "instances", ap->match.charts ? string2str(ap->match.charts) : "*");
-            buffer_json_member_add_string_or_empty(wb, "plugin", ap->match.charts ? string2str(ap->match.plugin) : "*");
-            buffer_json_member_add_string_or_empty(wb, "module", ap->match.module ? string2str(ap->match.module) : "*");
             buffer_json_member_add_string_or_empty(wb, "host_labels", ap->match.host_labels ? string2str(ap->match.host_labels) : "*");
             buffer_json_member_add_string_or_empty(wb, "instance_labels", ap->match.chart_labels ? string2str(ap->match.chart_labels) : "*");
         }

--- a/src/health/health_internals.h
+++ b/src/health/health_internals.h
@@ -22,7 +22,6 @@
 #define HEALTH_OS_KEY "os"
 #define HEALTH_PLUGIN_KEY "plugin"
 #define HEALTH_MODULE_KEY "module"
-#define HEALTH_CHARTS_KEY "charts"
 #define HEALTH_LOOKUP_KEY "lookup"
 #define HEALTH_CALC_KEY "calc"
 #define HEALTH_EVERY_KEY "every"
@@ -42,7 +41,6 @@
 #define HEALTH_OPTIONS_KEY "options"
 #define HEALTH_REPEAT_KEY "repeat"
 #define HEALTH_HOST_LABEL_KEY "host labels"
-#define HEALTH_FOREACH_KEY "foreach"
 #define HEALTH_CHART_LABEL_KEY "chart labels"
 
 void alert_action_options_to_buffer_json_array(BUFFER *wb, const char *key, ALERT_ACTION_OPTIONS options);

--- a/src/health/health_prototypes.c
+++ b/src/health/health_prototypes.c
@@ -192,7 +192,8 @@ static inline struct pattern_array *health_config_add_key_to_values(struct patte
                 snprintfz(pair, HEALTH_CONF_MAX_LINE, "!%s=%s ", key, data + 1);
             else
                 snprintfz(pair, HEALTH_CONF_MAX_LINE, "%s=%s ", key, data);
-            pattern_array_add_key_simple_pattern(pa, key, simple_pattern_create(pair, NULL, SIMPLE_PATTERN_EXACT, true));
+
+            pa = pattern_array_add_key_simple_pattern(pa, key, simple_pattern_create(pair, NULL, SIMPLE_PATTERN_EXACT, true));
             i=0;
         } else {
             data[i++] = *s;
@@ -205,7 +206,8 @@ static inline struct pattern_array *health_config_add_key_to_values(struct patte
             snprintfz(pair, HEALTH_CONF_MAX_LINE, "!%s=%s ", key, data + 1);
         else
             snprintfz(pair, HEALTH_CONF_MAX_LINE, "%s=%s ", key, data);
-        pattern_array_add_key_simple_pattern(pa, key, simple_pattern_create(pair, NULL, SIMPLE_PATTERN_EXACT, true));
+
+        pa = pattern_array_add_key_simple_pattern(pa, key, simple_pattern_create(pair, NULL, SIMPLE_PATTERN_EXACT, true));
     }
 
     return pa;
@@ -364,9 +366,8 @@ static bool prototype_matches_host(RRDHOST *host, RRD_ALERT_PROTOTYPE *ap) {
         !simple_pattern_matches(health_globals.config.enabled_alerts, string2str(ap->config.name)))
         return false;
 
-    if(host->rrdlabels && ap->match.host_labels_pattern &&
-        !rrdlabels_match_simple_pattern_parsed(
-            host->rrdlabels, ap->match.host_labels_pattern, '=', NULL))
+    if (host->rrdlabels && ap->match.host_labels_pattern &&
+        !pattern_array_label_match(ap->match.host_labels_pattern, host->rrdlabels, '=', NULL, rrdlabels_match_simple_pattern_parsed))
         return false;
 
     return true;
@@ -383,9 +384,8 @@ static bool prototype_matches_rrdset(RRDSET *st, RRD_ALERT_PROTOTYPE *ap) {
         ap->match.on.context != st->context)
         return false;
 
-    if (st->rrdlabels && ap->match.chart_labels && ap->match.chart_labels_pattern &&
-        !rrdlabels_match_simple_pattern_parsed(
-            st->rrdlabels, ap->match.chart_labels_pattern, '=', NULL))
+    if (st->rrdlabels && ap->match.chart_labels_pattern &&
+        !pattern_array_label_match(ap->match.chart_labels_pattern, st->rrdlabels, '=', NULL, rrdlabels_match_simple_pattern_parsed))
         return false;
 
     return true;

--- a/src/health/health_prototypes.c
+++ b/src/health/health_prototypes.c
@@ -209,6 +209,27 @@ static inline char *health_config_add_key_to_values(char *value) {
     return final;
 }
 
+static char *simple_pattern_trim_around_equal(const char *src) {
+    char *store = mallocz(strlen(src) + 1);
+
+    char *dst = store;
+    while (*src) {
+        if (*src == '=') {
+            if (*(dst -1) == ' ')
+                dst--;
+
+            *dst++ = *src++;
+            if (*src == ' ')
+                src++;
+        }
+
+        *dst++ = *src++;
+    }
+    *dst = 0x00;
+
+    return store;
+}
+
 static void health_prototype_activate_match_patterns(struct rrd_alert_match *am) {
     if(am->host_labels) {
         simple_pattern_free(am->host_labels_pattern);

--- a/src/health/health_prototypes.h
+++ b/src/health/health_prototypes.h
@@ -19,19 +19,9 @@ struct rrd_alert_match {
         STRING *context;
     } on;
 
-    STRING *os;
-    STRING *host;
-    STRING *charts;                         // the charts that should be linked to (for templates)
-    STRING *plugin;                         // the plugin name that should be linked to
-    STRING *module;                         // the module name that should be linked to
     STRING *host_labels;                    // the label read from an alarm file
     STRING *chart_labels;                   // the chart label read from an alarm file
 
-    SIMPLE_PATTERN *os_pattern;
-    SIMPLE_PATTERN *host_pattern;
-    SIMPLE_PATTERN *charts_pattern;         // the simple pattern of charts
-    SIMPLE_PATTERN *plugin_pattern;         // the simple pattern of plugin
-    SIMPLE_PATTERN *module_pattern;         // the simple pattern of module
     SIMPLE_PATTERN *host_labels_pattern;    // the simple pattern of labels
     SIMPLE_PATTERN *chart_labels_pattern;   // the simple pattern of chart labels
 };

--- a/src/health/health_prototypes.h
+++ b/src/health/health_prototypes.h
@@ -22,8 +22,8 @@ struct rrd_alert_match {
     STRING *host_labels;                    // the label read from an alarm file
     STRING *chart_labels;                   // the chart label read from an alarm file
 
-    SIMPLE_PATTERN *host_labels_pattern;    // the simple pattern of labels
-    SIMPLE_PATTERN *chart_labels_pattern;   // the simple pattern of chart labels
+    struct pattern_array *host_labels_pattern;
+    struct pattern_array *chart_labels_pattern;
 };
 void rrd_alert_match_cleanup(struct rrd_alert_match *am);
 

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -488,10 +488,10 @@ void rrd_alert_match_cleanup(struct rrd_alert_match *am) {
         string_freez(am->on.chart);
 
     string_freez(am->host_labels);
-    simple_pattern_free(am->host_labels_pattern);
+    pattern_array_free(am->host_labels_pattern);
 
     string_freez(am->chart_labels);
-    simple_pattern_free(am->chart_labels_pattern);
+    pattern_array_free(am->chart_labels_pattern);
 }
 
 void rrd_alert_config_cleanup(struct rrd_alert_config *ac) {

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -294,12 +294,6 @@ static inline bool rrdcalc_check_if_it_matches_rrdset(RRDCALC *rc, RRDSET *st) {
         && (rc->chart != st->name))
         return false;
 
-    if (rc->match.module_pattern && !simple_pattern_matches_string(rc->match.module_pattern, st->module_name))
-        return false;
-
-    if (rc->match.plugin_pattern && !simple_pattern_matches_string(rc->match.plugin_pattern, st->module_name))
-        return false;
-
     if (st->rrdlabels && rc->match.chart_labels_pattern && !rrdlabels_match_simple_pattern_parsed(
             st->rrdlabels, rc->match.chart_labels_pattern, '=', NULL))
         return false;
@@ -492,21 +486,6 @@ void rrd_alert_match_cleanup(struct rrd_alert_match *am) {
         string_freez(am->on.context);
     else
         string_freez(am->on.chart);
-
-    string_freez(am->os);
-    simple_pattern_free(am->os_pattern);
-
-    string_freez(am->host);
-    simple_pattern_free(am->host_pattern);
-
-    string_freez(am->plugin);
-    simple_pattern_free(am->plugin_pattern);
-
-    string_freez(am->module);
-    simple_pattern_free(am->module_pattern);
-
-    string_freez(am->charts);
-    simple_pattern_free(am->charts_pattern);
 
     string_freez(am->host_labels);
     simple_pattern_free(am->host_labels_pattern);

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -289,18 +289,6 @@ static void rrdcalc_unlink_from_rrdset(RRDCALC *rc, bool having_ll_wrlock) {
     rc->rrdset = NULL;
 }
 
-static inline bool rrdcalc_check_if_it_matches_rrdset(RRDCALC *rc, RRDSET *st) {
-    if (   (rc->chart != st->id)
-        && (rc->chart != st->name))
-        return false;
-
-    if (st->rrdlabels && rc->match.chart_labels_pattern && !rrdlabels_match_simple_pattern_parsed(
-            st->rrdlabels, rc->match.chart_labels_pattern, '=', NULL))
-        return false;
-
-    return true;
-}
-
 // ----------------------------------------------------------------------------
 // RRDCALC rrdhost index management - constructor
 

--- a/src/health/schema.d/health:alert:prototype.json
+++ b/src/health/schema.d/health:alert:prototype.json
@@ -12,11 +12,6 @@
         "default": "*",
         "title": "Only for nodes with these host labels"
       },
-      "matchHostnames": {
-        "type": "string",
-        "default": "*",
-        "title": "Only for these hostnames"
-      },
       "matchInstance": {
         "type": "object",
         "title": "Apply this rule to a single instance",
@@ -29,15 +24,10 @@
             "description": "You can find the instance names on all charts at the instances drop down menu. Do not include the host name in this field."
           },
           "host_labels": { "$ref": "#/definitions/matchHostLabels" },
-          "host": { "$ref": "#/definitions/matchHostnames" },
           "instance_labels": { "$ref": "#/definitions/matchInstanceLabels" }
         },
         "required": [
           "on",
-          "os",
-          "host",
-          "plugin",
-          "module",
           "host_labels",
           "instance_labels"
         ]
@@ -54,22 +44,11 @@
             "description": "The context is the code-name of each chart on the dashboard, that appears at the chart title bar, between the chart title and its unit of measurement, like: system.cpu, disk.io, etc."
           },
           "host_labels": { "$ref": "#/definitions/matchHostLabels" },
-          "host": { "$ref": "#/definitions/matchHostnames" },
           "instance_labels": { "$ref": "#/definitions/matchInstanceLabels" },
-          "instances": {
-            "type": "string",
-            "default": "*",
-            "title": "On on these instances"
-          }
         },
         "required": [
           "on",
-          "os",
-          "host",
-          "plugin",
-          "module",
           "host_labels",
-          "instances",
           "instance_labels"
         ]
       },
@@ -393,19 +372,11 @@
           },
           "host_labels": {
             "ui:help": "A simple pattern to match the node labels of the nodes this rule is to be applied to. A space separated list of label=value pairs is accepted. Asterisks can be placed anywhere, including the label key. The label keys and their values are available at the labels filter of the charts on the dashboard.",
-            "ui:classNames": "dyncfg-grid-col-span-1-4"
-          },
-          "host": {
-            "ui:classNames": "dyncfg-grid-col-span-5-2",
-            "ui:help": "A simple pattern to match the hostnames of the nodes this rule is to be applied to."
+            "ui:classNames": "dyncfg-grid-col-span-1-3"
           },
           "instance_labels": {
-            "ui:classNames": "dyncfg-grid-col-span-1-4",
+            "ui:classNames": "dyncfg-grid-col-span-4-3",
             "ui:help": "A simple pattern to match the instance labels of the instances this rule is to be applied to. A space separated list of label=value pairs is accepted. Asterisks can be placed anywhere, including the label key. The label keys and their values are available at the labels filter of the charts on the dashboard."
-          },
-          "instances": {
-            "ui:classNames": "dyncfg-grid-col-span-5-2",
-            "ui:help": "A simple pattern to match the instance names of the instances this rule is to be applied to."
           }
         },
         "config": {

--- a/src/health/schema.d/health:alert:prototype.json
+++ b/src/health/schema.d/health:alert:prototype.json
@@ -44,7 +44,7 @@
             "description": "The context is the code-name of each chart on the dashboard, that appears at the chart title bar, between the chart title and its unit of measurement, like: system.cpu, disk.io, etc."
           },
           "host_labels": { "$ref": "#/definitions/matchHostLabels" },
-          "instance_labels": { "$ref": "#/definitions/matchInstanceLabels" },
+          "instance_labels": { "$ref": "#/definitions/matchInstanceLabels" }
         },
         "required": [
           "on",

--- a/src/health/schema.d/health:alert:prototype.json
+++ b/src/health/schema.d/health:alert:prototype.json
@@ -84,7 +84,7 @@
           },
           "value": {
             "type": "object",
-            "title": "Alert Value Calculation",
+            "title": "",
             "description": "Each alert has a value. This section defines how this value is calculated.",
             "properties": {
               "database_lookup": {
@@ -189,7 +189,7 @@
           },
           "conditions": {
             "type": "object",
-            "title": "Conditions to trigger the alert",
+            "title": "",
             "properties": {
               "warning_condition": {
                 "type": "string",
@@ -221,7 +221,7 @@
           },
           "action": {
             "type": "object",
-            "title": "Alert Action (notification or automation)",
+            "title": "",
             "description": "The action the alert should take when it transitions states",
             "properties": {
               "execute": {
@@ -433,8 +433,8 @@
             "ui:classNames": "dyncfg-grid dyncfg-grid-col-6 dyncfg-grid-col-span-1-6",
             "database_lookup": {
               "ui:classNames": "dyncfg-grid dyncfg-grid-col-6 dyncfg-grid-col-span-1-6",
-              "ui:Collapsible": true,
-              "ui:InitiallyExpanded": true,
+              "ui:collapsible": true,
+              "ui:initiallyExpanded": true,
               "after": {
                 "ui:help": "The oldest timestamp of the time-series data to be included in the query. Negative values define a duration in seconds in the past of 'To' (so, -60 means a minute ago from 'To').",
                 "ui:classNames": "dyncfg-grid-col-span-1-1"
@@ -494,8 +494,8 @@
               "ui:help": "Options related to the actions this alert will take."
             },
             "delay": {
-              "ui:Collapsible": true,
-              "ui:InitiallyExpanded": false,
+              "ui:collapsible": true,
+              "ui:initiallyExpanded": false,
               "ui:classNames": "dyncfg-grid dyncfg-grid-col-6 dyncfg-grid-col-span-1-6",
               "up": {
                 "ui:classNames": "dyncfg-grid-col-span-1-2",
@@ -515,8 +515,8 @@
               }
             },
             "repeat": {
-              "ui:Collapsible": true,
-              "ui:InitiallyExpanded": false,
+              "ui:collapsible": true,
+              "ui:initiallyExpanded": false,
               "ui:classNames": "dyncfg-grid dyncfg-grid-col-6 dyncfg-grid-col-span-1-6",
               "enabled": {
                 "ui:classNames": "dyncfg-grid-col-span-1-2"

--- a/src/libnetdata/simple_pattern/simple_pattern.c
+++ b/src/libnetdata/simple_pattern/simple_pattern.c
@@ -396,27 +396,6 @@ extern int simple_pattern_is_potential_name(SIMPLE_PATTERN *p)
     return (alpha || wildcards) && !colon;
 }
 
-char *simple_pattern_trim_around_equal(const char *src) {
-    char *store = mallocz(strlen(src) + 1);
-
-    char *dst = store;
-    while (*src) {
-        if (*src == '=') {
-            if (*(dst -1) == ' ')
-                dst--;
-
-            *dst++ = *src++;
-            if (*src == ' ')
-                src++;
-        }
-
-        *dst++ = *src++;
-    }
-    *dst = 0x00;
-
-    return store;
-}
-
 char *simple_pattern_iterate(SIMPLE_PATTERN **p)
 {
     struct simple_pattern *root = (struct simple_pattern *) *p;

--- a/src/libnetdata/simple_pattern/simple_pattern.h
+++ b/src/libnetdata/simple_pattern/simple_pattern.h
@@ -5,7 +5,6 @@
 
 #include "../libnetdata.h"
 
-
 typedef enum __attribute__ ((__packed__)) {
     SIMPLE_PATTERN_EXACT,
     SIMPLE_PATTERN_PREFIX,
@@ -19,7 +18,8 @@ typedef enum __attribute__ ((__packed__)) {
     SP_MATCHED_POSITIVE,
 } SIMPLE_PATTERN_RESULT;
 
-typedef void SIMPLE_PATTERN;
+struct simple_pattern;
+typedef struct simple_pattern SIMPLE_PATTERN;
 
 // create a simple_pattern from the string given
 // default_mode is used in cases where EXACT matches, without an asterisk,

--- a/src/libnetdata/simple_pattern/simple_pattern.h
+++ b/src/libnetdata/simple_pattern/simple_pattern.h
@@ -47,9 +47,6 @@ void simple_pattern_dump(uint64_t debug_type, SIMPLE_PATTERN *p) ;
 int simple_pattern_is_potential_name(SIMPLE_PATTERN *p) ;
 char *simple_pattern_iterate(SIMPLE_PATTERN **p);
 
-// Auxiliary function to create a pattern
-char *simple_pattern_trim_around_equal(const char *src);
-
 #define SIMPLE_PATTERN_DEFAULT_WEB_SEPARATORS ",|\t\r\n\f\v"
 
 #define is_valid_sp(x) ((x) && *(x) && !((x)[0] == '*' && (x)[1] == '\0'))


### PR DESCRIPTION
Replaces https://github.com/netdata/netdata/pull/16953
Code of @stelfrag is copied to this one.

- [x] `charts` is now removed - the config parser will silently ignore it
- [x] `os` is now matched as `_os` in host labels
- [x] `host` is now matched as `_hostname` in host labels
- [x] `plugin` is now matched as `_collect_plugin` in instance labels
- [x] `module` is now matched as `_collect_module` in instance labels
- [x] add `_os` host label
- [x] add `_hostname` host label
- [x] updated health prototypes to eliminate `os`, `hosts`, `charts`, `plugin`, `module`, which are now part of host and chart labels (`charts` is silently removed).
- [x] change the labels matching algorithm to do AND among labels and OR among values of the same label (@stelfrag code)
- [x] change query_target to use the new labels matching (@stelfrag code)
- [x] removed references of `charts` and `families` from the health reference manual
- [x] update systemd-journal dynamic configuration for recent dyncfg development
