### PR TITLE
Fix conditional for Amazon Linux 2023 in repoconfig spec file.

### DIFF
--- a/packaging/repoconfig/netdata-repo.spec
+++ b/packaging/repoconfig/netdata-repo.spec
@@ -49,19 +49,18 @@ install -pm 644 %{SOURCE3} ./netdata-edge.repo
 %endif
 
 %if 0%{?centos_ver}
-# Amazon Linux 2 looks like CentOS, but with extra macros.
-%if 0%{?amzn2}
-install -pm 644 %{SOURCE8} ./netdata.repo
-install -pm 644 %{SOURCE9} ./netdata-edge.repo
-%else
 install -pm 644 %{SOURCE4} ./netdata.repo
 install -pm 644 %{SOURCE5} ./netdata-edge.repo
-%endif
 %endif
 
 %if 0%{?oraclelinux}
 install -pm 644 %{SOURCE6} ./netdata.repo
 install -pm 644 %{SOURCE7} ./netdata-edge.repo
+%endif
+
+%if 0%{?amzn}
+install -pm 644 %{SOURCE8} ./netdata.repo
+install -pm 644 %{SOURCE9} ./netdata-edge.repo
 %endif
 
 %build


### PR DESCRIPTION


##### Summary

In Amazon Linux 2 the macros `centos_ver`, `amzn2` and `amzn` are defined.
Amazon Linux 2023 defines `fedora`, `amzn2023` and `amzn`.

##### Test Plan
I don't have the setup to test my changes. 
<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information

While running the kickstart.sh installer on my Amazon Linux 2023 instance I noticed a 404 while attempting to download the metadata for the repos 'netdata' and 'netdata-repoconfig'.

```
[/tmp/netdata-kickstart-FxlNJ0FCvi]$ sudo env dnf makecache 
Amazon Linux 2023 repository                                                                                                                                                 31 kB/s | 3.6 kB     00:00    
Amazon Linux 2023 Kernel Livepatch repository                                                                                                                                26 kB/s | 2.9 kB     00:00    
Netdata                                                                                                                                                                     327  B/s | 153  B     00:00    
Errors during downloading metadata for repository 'netdata':
  - Status code: 404 for https://repo.netdata.cloud/repos/stable/fedora/2023.3.20240219/aarch64/repodata/repomd.xml (IP: 104.26.9.141)
Error: Failed to download metadata for repo 'netdata': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
Netdata Repository Config                                                                                                                                                   317  B/s | 153  B     00:00    
Errors during downloading metadata for repository 'netdata-repoconfig':
  - Status code: 404 for https://repo.netdata.cloud/repos/repoconfig/fedora/2023.3.20240219/aarch64/repodata/repomd.xml (IP: 104.26.8.141)
Error: Failed to download metadata for repo 'netdata-repoconfig': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
```

Notice that it tried to download the the fedora configs.

Inspecting [`netdata-repo-2-2.noarch.rpm`](https://repo.netdata.cloud/repos/stable/amazonlinux/2023/aarch64/netdata-repo-2-2.noarch.rpm) reveales that indeed the baseurl in the spec file is mistakenly set to the fedora repo.

This change (not quite) enables us to install Netdata from pre-build binaries instead of letting the kickstart script building it from source. Notice that the `$releasever` part of the baseurl is still wrong (`2023.3.20240219` instead of `2023`). I don't know what's going on there.
