### PR TITLE
Add CI checks for Go code.

### DIFF
--- a/.github/scripts/get-go-version.py
+++ b/.github/scripts/get-go-version.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import pathlib
+
+from packaging.version import parse
+
+SCRIPT_PATH = pathlib.Path(__file__).parents[0]
+REPO_ROOT = SCRIPT_PATH.parents[1]
+GO_SRC = REPO_ROOT / 'src' / 'go'
+
+GITHUB_OUTPUT = pathlib.Path(os.environ['GITHUB_OUTPUT'])
+
+version = parse('1.0.0')
+modules = []
+
+for modfile in GO_SRC.glob('**/go.mod'):
+    modules.append(str(modfile.parent))
+    moddata = modfile.read_text()
+
+    for line in moddata.splitlines():
+        if line.startswith('go '):
+            version = max(version, parse(line.split()[1]))
+            break
+
+with GITHUB_OUTPUT.open('a') as f:
+    f.write(f'version={ str(version) }\n')
+
+with GITHUB_OUTPUT.open('a') as f:
+    f.write(f'matrix={ json.dumps({"module": modules}) }\n')

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -104,7 +104,7 @@ jobs:
         if: needs.file-check.outputs.run == 'true'
         run: |
           go fmt ./... | tee modified-files
-          [ "$(wc -l modified-files | cut -f 1 -d ' ')" -ne 0 ] && exit 1
+          [ "$(wc -l modified-files | cut -f 1 -d ' ')" -eq 0 ] || exit 1
         working-directory: ${{ matrix.module }}
       - name: Go vet
         if: needs.file-check.outputs.run == 'true'

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -125,8 +125,8 @@ jobs:
       - name: Go fmt
         if: needs.file-check.outputs.run == 'true'
         run: |
-          go fmt ./...
-          [ $(git status --porcelain=1 | wc -l) -ne 0 ] && exit 1
+          go fmt ./... | tee modified-files
+          [ $(wc -l modified-files) -ne 0 ] && exit 1
         working-directory: ${{ matrix.module }}
 
   go-test:

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -71,8 +71,8 @@ jobs:
         id: get-version
         run: .github/scripts/get-go-version.py
 
-  go-vet:
-    name: go vet
+  tests:
+    name: Go toolchain tests
     runs-on: ubuntu-latest
     needs:
       - file-check
@@ -94,70 +94,33 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Go Vet
+      - name: Go mod download
         if: needs.file-check.outputs.run == 'true'
-        run: go vet ./...
+        run: go mod download
         working-directory: ${{ matrix.module }}
-
-  go-fmt:
-    name: go fmt
-    runs-on: ubuntu-latest
-    needs:
-      - file-check
-      - check-go-version
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.check-go-version.outputs.matrix) }}
-    steps:
-      - name: Skip Check
-        id: skip
-        if: needs.file-check.outputs.run != 'true'
-        run: echo "SKIPPED"
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ needs.check-go-version.outputs.go-version }}
-      - name: Checkout
+      - name: Compile
         if: needs.file-check.outputs.run == 'true'
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+        run: |
+          CGO_ENABLED=0 go build -o /tmp/go-test-build ./...
+          /tmp/go-test-build --help || true
+        working-directory: ${{ matrix.module }}
       - name: Go fmt
         if: needs.file-check.outputs.run == 'true'
         run: |
           go fmt ./... | tee modified-files
           [ $(wc -l modified-files) -ne 0 ] && exit 1
         working-directory: ${{ matrix.module }}
-
-  go-test:
-    name: go test
-    runs-on: ubuntu-latest
-    needs:
-      - file-check
-      - check-go-version
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.check-go-version.outputs.matrix) }}
-    steps:
-      - name: Skip Check
-        id: skip
-        if: needs.file-check.outputs.run != 'true'
-        run: echo "SKIPPED"
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ needs.check-go-version.outputs.go-version }}
-      - name: Checkout
+      - name: Go vet
         if: needs.file-check.outputs.run == 'true'
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
+        run: go vet ./...
+        working-directory: ${{ matrix.module }}
       - name: Set up gotestfmt
+        if: needs.file-check.outputs.run == 'true'
         uses: GoTestTools/gotestfmt-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: v2.0.0
-      - name: Go Vet
+      - name: Go test
         if: needs.file-check.outputs.run == 'true'
         run: |
           set -euo pipefail

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -1,0 +1,165 @@
+---
+# Ci code for building release artifacts.
+name: Go Tests
+on:
+  push: # Master branch checks only validate the build and generate artifacts for testing.
+    branches:
+      - master
+  pull_request: null # PR checks only validate the build and generate artifacts for testing.
+concurrency: # This keeps multiple instances of the job from running concurrently for the same ref and event type.
+  group: go-test-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+jobs:
+  file-check: # Check what files changed if we’re being run in a PR or on a push.
+    name: Check Modified Files
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.check-run.outputs.run }}
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Check files
+        id: check-files
+        uses: tj-actions/changed-files@v42
+        with:
+          since_last_remote_commit: ${{ github.event_name != 'pull_request' }}
+          files: |
+            **/*.cmake
+            CMakeLists.txt
+            .github/workflows/go-tests.yml
+            packaging/cmake/
+            src/go/**
+          files_ignore: |
+            **/*.md
+            src/go/**/metadata.yaml
+      - name: List all changed files in pattern
+        continue-on-error: true
+        env:
+          ALL_CHANGED_FILES: ${{ steps.check-files.outputs.all_changed_files }}
+        run: |
+          for file in ${ALL_CHANGED_FILES}; do
+            echo "$file was changed"
+          done
+      - name: Check Run
+        id: check-run
+        run: |
+          if [ "${{ steps.check-files.outputs.any_modified }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo 'run=true' >> "${GITHUB_OUTPUT}"
+          else
+            echo 'run=false' >> "${GITHUB_OUTPUT}"
+          fi
+
+  check-go-version:
+    name: Determine Required Go Version
+    runs-on: ubuntu-latest
+    outputs:
+      go-version: ${{ steps.get-version.outputs.version }}
+      matrix: ${{ steps.get-version.outputs.matrix }}
+    steps:
+      - name: Skip Check
+        id: skip
+        run: echo "SKIPPED"
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get upgrade -y && sudo apt-get install -y python3-packaging
+      - name: Get Go version and modules
+        id: get-version
+        run: .github/scripts/get-go-version.py
+
+  go-vet:
+    name: go vet
+    runs-on: ubuntu-latest
+    needs:
+      - file-check
+      - check-go-version
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.check-go-version.outputs.matrix) }}
+    steps:
+      - name: Skip Check
+        id: skip
+        if: needs.file-check.outputs.run != 'true'
+        run: echo "SKIPPED"
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ needs.check-go-version.outputs.go-version }}
+      - name: Checkout
+        if: needs.file-check.outputs.run == 'true'
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Go Vet
+        if: needs.file-check.outputs.run == 'true'
+        run: go vet ./...
+        working-directory: ${{ matrix.module }}
+
+  go-fmt:
+    name: go fmt
+    runs-on: ubuntu-latest
+    needs:
+      - file-check
+      - check-go-version
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.check-go-version.outputs.matrix) }}
+    steps:
+      - name: Skip Check
+        id: skip
+        if: needs.file-check.outputs.run != 'true'
+        run: echo "SKIPPED"
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ needs.check-go-version.outputs.go-version }}
+      - name: Checkout
+        if: needs.file-check.outputs.run == 'true'
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Go fmt
+        if: needs.file-check.outputs.run == 'true'
+        run: |
+          go fmt ./...
+          [ $(git status --porcelain=1 | wc -l) -ne 0 ] && exit 1
+        working-directory: ${{ matrix.module }}
+
+  go-test:
+    name: go test
+    runs-on: ubuntu-latest
+    needs:
+      - file-check
+      - check-go-version
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.check-go-version.outputs.matrix) }}
+    steps:
+      - name: Skip Check
+        id: skip
+        if: needs.file-check.outputs.run != 'true'
+        run: echo "SKIPPED"
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ needs.check-go-version.outputs.go-version }}
+      - name: Checkout
+        if: needs.file-check.outputs.run == 'true'
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up gotestfmt
+        uses: GoTestTools/gotestfmt-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: v2.0.0
+      - name: Go Vet
+        if: needs.file-check.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          go test -json ./... -race -count=1 2>&1 | gotestfmt -hide all
+        working-directory: ${{ matrix.module }}

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -53,16 +53,12 @@ jobs:
             echo 'run=false' >> "${GITHUB_OUTPUT}"
           fi
 
-  check-go-version:
-    name: Determine Required Go Version
+  matrix:
+    name: Generate Build Matrix
     runs-on: ubuntu-latest
     outputs:
-      go-version: ${{ steps.get-version.outputs.version }}
       matrix: ${{ steps.get-version.outputs.matrix }}
     steps:
-      - name: Skip Check
-        id: skip
-        run: echo "SKIPPED"
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install dependencies
@@ -76,10 +72,10 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - file-check
-      - check-go-version
+      - matrix
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.check-go-version.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
     steps:
       - name: Skip Check
         id: skip
@@ -88,7 +84,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ needs.check-go-version.outputs.go-version }}
+          go-version: ${{ matrix.version }}
       - name: Checkout
         if: needs.file-check.outputs.run == 'true'
         uses: actions/checkout@v4
@@ -101,14 +97,14 @@ jobs:
       - name: Compile
         if: needs.file-check.outputs.run == 'true'
         run: |
-          CGO_ENABLED=0 go build -o /tmp/go-test-build ./...
+          CGO_ENABLED=0 go build -o /tmp/go-test-build ${{ matrix.build_target }}
           /tmp/go-test-build --help || true
         working-directory: ${{ matrix.module }}
       - name: Go fmt
         if: needs.file-check.outputs.run == 'true'
         run: |
           go fmt ./... | tee modified-files
-          [ $(wc -l modified-files) -ne 0 ] && exit 1
+          [ "$(wc -l modified-files | cut -f 1 -d ' ')" -ne 0 ] && exit 1
         working-directory: ${{ matrix.module }}
       - name: Go vet
         if: needs.file-check.outputs.run == 'true'


### PR DESCRIPTION
##### Summary

- Adds a GHA workflow which will run `go test`, `go fmt`, and `go vet` for each Go module located under `src/go`, auto-detecting the paths to the modules and the required version of Go.

##### Test Plan

CI passes on this PR.