### PR TITLE
add missing "gotify" to list of notification methods in alarm-notify.sh

### DIFF
--- a/src/health/notifications/alarm-notify.sh.in
+++ b/src/health/notifications/alarm-notify.sh.in
@@ -248,31 +248,31 @@ docurl() {
 # Used in a couple of places to write more compact code.
 
 method_names="
-email
-pushover
-pushbullet
-telegram
-slack
 alerta
-flock
-discord
-hipchat
-twilio
-messagebird
-pd
-fleep
-syslog
-custom
-msteams
-kavenegar
-prowl
-irc
 awssns
-rocketchat
-sms
+custom
+discord
 dynatrace
+email
+fleep
+flock
+hipchat
+irc
+kavenegar
 matrix
+messagebird
+msteams
 ntfy
+pd
+prowl
+pushbullet
+pushover
+rocketchat
+slack
+sms
+syslog
+telegram
+twilio
 "
 
 # -----------------------------------------------------------------------------

--- a/src/health/notifications/alarm-notify.sh.in
+++ b/src/health/notifications/alarm-notify.sh.in
@@ -256,6 +256,7 @@ dynatrace
 email
 fleep
 flock
+gotify
 hipchat
 irc
 kavenegar


### PR DESCRIPTION
##### Summary

Fixes: https://github.com/netdata/netdata/pull/12639#issuecomment-1965956418

Changes to method_names array in alarm-notify.sh: add "gotify" and sort it.

##### Test Plan

Not needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
