### PR TITLE
Improve message in kickstart if a static build can’t be found.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1667,7 +1667,7 @@ try_static_install() {
     netdata_agent="${NETDATA_STATIC_ARCHIVE_OLD_NAME}"
     export NETDATA_STATIC_ARCHIVE_URL="${NETDATA_STATIC_ARCHIVE_OLD_URL}"
   else
-    warning "There is no static build available for ${SYSARCH} CPUs. This usually means we simply do not currently provide static builds for ${SYSARCH} CPUs."
+    warning "Could not find a ${SELECTED_RELEASE_CHANNEL} static build for ${SYSARCH} CPUs. This usually means there is some networking issue preventing access to https://github.com/ from this system."
     return 2
   fi
 


### PR DESCRIPTION
##### Summary

Given our current platform support spread, it’s far more likely that the user’s system has networking issues preventing access to GitHub than that they happen to be trying to install on a platform we don’t provide static builds for.

##### Test Plan

n/a

##### Additional Information

Based on discussion in https://github.com/netdata/netdata/issues/17068