### PR TITLE
Amend the logic of ebpf-plugin package suggestion for network-viewer plugin

### DIFF
--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -230,7 +230,7 @@ Architecture: any
 Depends: ${shlibs:Depends},
          netdata (= ${source:Version})
 Pre-Depends: libcap2-bin, adduser
-Recommends: netdata-plugin-ebpf (= ${source:Version} )
+Recommends: netdata-plugin-ebpf (= ${source:Version}) [amd64]
 Conflicts: netdata (<< ${source:Version})
 Description: The network viewer plugin for the Netdata Agent
  This plugin allows the Netdata Agent to provide network connection

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -1000,10 +1000,12 @@ Summary: The network viewer plugin for the Netdata Agent
 Group: Applications/System
 Requires: %{name} = %{version}
 Conflicts: %{name} < %{version}
+%if 0%{?_have_ebpf}
 %if 0%{?centos_ver} != 7
 Recommends: %{name}-plugin-ebpf = %{version}
 %else
 Requires: %{name}-plugin-ebpf = %{version}
+%endif
 %endif
 
 %description plugin-network-viewer


### PR DESCRIPTION
##### Summary

We dont provide ebpf plugin for architectures other than x86_64 i386. We enhance network viewer plugin capabilities with the ebpf-plugin. The previous workflow assumed that in any case, during installation of network viewer plugin we suggest or require the ebpf-plugin. This doesn't work in archs other that (x86_64 i386)

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
