### PR TITLE
deb packages fix on ioping perms

### DIFF
--- a/contrib/debian/netdata.postinst
+++ b/contrib/debian/netdata.postinst
@@ -28,7 +28,7 @@ case "$1" in
 
     grep /usr/libexec/netdata /var/lib/dpkg/info/netdata.list | xargs -n 30 chown root:netdata
 
-    for f in ndsudo cgroup-network local-listeners ioping; do
+    for f in ndsudo cgroup-network local-listeners ioping.plugin; do
         chmod 4750 "/usr/libexec/netdata/plugins.d/${f}" || true
     done
 


### PR DESCRIPTION
##### Summary

We applied changes on `ioping`, not to `ioping.plugin` 


deb package configurator logs  (ignore the versions)
```
Unpacking netdata-plugin-chartsd (1.52) over (1.50) ...
Preparing to unpack .../15-netdata-plugin-apps_1.52+ubuntu23.10_amd64.deb ...
Unpacking netdata-plugin-apps (1.52) over (1.50) ...
Preparing to unpack .../16-netdata-plugin-xenstat_1.52+ubuntu23.10_amd64.deb ...
Unpacking netdata-plugin-xenstat (1.52) over (1.50) ...
Setting up netdata (1.52) ...
chmod: cannot access '/usr/libexec/netdata/plugins.d/ioping': No such file or directory
Setting up netdata-plugin-pythond (1.52) ...
Setting up netdata-plugin-systemd-journal (1.52) ...
```

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
