### PR TITLE
Fix ebpf compilation warnings

### DIFF
--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -241,6 +241,7 @@ extern ARAL *ebpf_aral_shm_pid;
 void ebpf_shm_aral_init();
 netdata_publish_shm_t *ebpf_shm_stat_get(void);
 void ebpf_shm_release(netdata_publish_shm_t *stat);
+void ebpf_cleanup_exited_pids(int max);
 
 // ARAL Section end
 

--- a/src/collectors/ebpf.plugin/ebpf_shm.c
+++ b/src/collectors/ebpf.plugin/ebpf_shm.c
@@ -1205,6 +1205,7 @@ void ebpf_shm_create_apps_charts(struct ebpf_module *em, void *ptr)
  */
 static void ebpf_shm_allocate_global_vectors(int apps)
 {
+    UNUSED(apps);
     shm_vector = callocz((size_t)ebpf_nprocs, sizeof(netdata_publish_shm_t));
     shm_values = callocz((size_t)ebpf_nprocs, sizeof(netdata_idx_t));
 


### PR DESCRIPTION
##### Summary
Fix compilation warnings

- ebpf_shm.c:1206:50: warning: unused parameter ‘apps’ [-Wunused-parameter]
- ebpf.c:4055:13: warning: implicit declaration of function ‘ebpf_cleanup_exited_pids’; did you mean ‘cleanup_exited_pids’? 
