### PR TITLE
Alert transitions code cleanup

### DIFF
--- a/src/database/sqlite/sqlite_context.h
+++ b/src/database/sqlite/sqlite_context.h
@@ -66,6 +66,5 @@ int ctx_delete_context(uuid_t *host_id, VERSIONED_CONTEXT_DATA *context_data);
 
 int sql_init_context_database(int memory);
 uint64_t sqlite_get_context_space(void);
-void sql_close_context_database(void);
 int ctx_unittest(void);
 #endif //NETDATA_SQLITE_CONTEXT_H

--- a/src/database/sqlite/sqlite_functions.h
+++ b/src/database/sqlite/sqlite_functions.h
@@ -8,7 +8,7 @@
 
 void analytics_set_data_str(char **name, const char *value);
 
-#define SQLITE_BIND_FAIL(rc, label)                                                                                    \
+#define SQLITE_BIND_FAIL(label, rc)                                                                                    \
     do {                                                                                                               \
         if ((rc) != SQLITE_OK)                                                                                         \
             goto label;                                                                                                \

--- a/src/database/sqlite/sqlite_functions.h
+++ b/src/database/sqlite/sqlite_functions.h
@@ -14,6 +14,20 @@ void analytics_set_data_str(char **name, const char *value);
             goto label;                                                                                                \
     } while (0)
 
+#define REPORT_BIND_FAIL(res, param)                                                                                   \
+    do {                                                                                                               \
+        if (unlikely((param))) {                                                                                       \
+            const char *failed_param = sqlite3_bind_parameter_name((res), (param));                                    \
+            nd_log(                                                                                                    \
+                NDLS_DAEMON,                                                                                           \
+                NDLP_ERR,                                                                                              \
+                "Failed to bind parameter %d (%s) in %s",                                                              \
+                (param),                                                                                               \
+                failed_param ? failed_param : "?",                                                                     \
+                __FUNCTION__);                                                                                         \
+        }                                                                                                              \
+    } while (0)
+
 #define SQL_MAX_RETRY (100)
 #define SQLITE_INSERT_DELAY (10)        // Insert delay in case of lock
 

--- a/src/database/sqlite/sqlite_functions.h
+++ b/src/database/sqlite/sqlite_functions.h
@@ -8,6 +8,12 @@
 
 void analytics_set_data_str(char **name, const char *value);
 
+#define SQLITE_BIND_FAIL(rc, label)                                                                                    \
+    do {                                                                                                               \
+        if ((rc) != SQLITE_OK)                                                                                         \
+            goto label;                                                                                                \
+    } while (0)
+
 #define SQL_MAX_RETRY (100)
 #define SQLITE_INSERT_DELAY (10)        // Insert delay in case of lock
 

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -97,13 +97,6 @@ failed:
    Inserts an entry in the table
 */
 
-#define SQL_INSERT_HEALTH_LOG                                                                                          \
-    "INSERT INTO health_log (host_id, alarm_id, "                                                                      \
-    "config_hash_id, name, chart, exec, recipient, units, chart_context, last_transition_id, chart_name) "             \
-    "VALUES (@host_id,@alarm_id, @config_hash_id,@name,@chart,@exec,@recipient,@units,@chart_context,"                 \
-    "@last_transition_id,@chart_name) ON CONFLICT (host_id, alarm_id) DO UPDATE "                                      \
-    "SET last_transition_id = excluded.last_transition_id, chart_name = excluded.chart_name, "                         \
-    "config_hash_id=excluded.config_hash_id RETURNING health_log_id"
 
 #define SQL_INSERT_HEALTH_LOG_DETAIL                                                                                         \
     "INSERT INTO health_log_detail (health_log_id, unique_id, alarm_id, alarm_event_id, "                                    \
@@ -113,7 +106,178 @@ failed:
     "@non_clear_duration,@flags,@exec_run_timestamp,@delay_up_to_timestamp, @info,@exec_code,@new_status,@old_status,"       \
     "@delay,@new_value,@old_value,@last_repeat,@transition_id,@global_id,@summary)"
 
-static void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae) {
+static int sql_health_alarm_log_insert_detail(RRDHOST *host, uint64_t health_log_id, ALARM_ENTRY *ae)
+{
+    sqlite3_stmt *res = NULL;
+    int rc;
+
+    rc = sqlite3_prepare_v2(db_meta, SQL_INSERT_HEALTH_LOG_DETAIL, -1, &res, 0);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report(
+            "HEALTH [%s]: Failed to prepare statement for SQL_INSERT_HEALTH_LOG_DETAIL", rrdhost_hostname(host));
+        return 1;
+    }
+
+    rc = sqlite3_bind_int64(res, 1, (sqlite3_int64)health_log_id);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind unique_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_int64(res, 2, (sqlite3_int64)ae->unique_id);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind unique_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_int64(res, 3, (sqlite3_int64)ae->alarm_id);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind unique_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_int64(res, 4, (sqlite3_int64)ae->alarm_event_id);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind alarm_event_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_int64(res, 5, (sqlite3_int64)ae->updated_by_id);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind updated_by_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_int64(res, 6, (sqlite3_int64)ae->updates_id);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind updates_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_int64(res, 7, (sqlite3_int64)ae->when);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind when parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_int64(res, 8, (sqlite3_int64)ae->duration);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind duration parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_int64(res, 9, (sqlite3_int64)ae->non_clear_duration);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind non_clear_duration parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_int64(res, 10, (sqlite3_int64)ae->flags);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind flags parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_int64(res, 11, (sqlite3_int64)ae->exec_run_timestamp);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind exec_run_timestamp parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_int64(res, 12, (sqlite3_int64)ae->delay_up_to_timestamp);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind delay_up_to_timestamp parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = SQLITE3_BIND_STRING_OR_NULL(res, ae->info, 13);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind info parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_int(res, 14, ae->exec_code);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind exec_code parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_int(res, 15, ae->new_status);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind new_status parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_int(res, 16, ae->old_status);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind old_status parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_int(res, 17, ae->delay);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind delay parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_double(res, 18, ae->new_value);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind new_value parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_double(res, 19, ae->old_value);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind old_value parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_int64(res, 20, (sqlite3_int64)ae->last_repeat);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind last_repeat parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_blob(res, 21, &ae->transition_id, sizeof(ae->transition_id), SQLITE_STATIC);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind transition_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = sqlite3_bind_int64(res, 22, (sqlite3_int64)ae->global_id);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind global_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = SQLITE3_BIND_STRING_OR_NULL(res, ae->summary, 23);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to bind summary parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
+        goto failed;
+    }
+
+    rc = execute_insert(res);
+    if (rc == SQLITE_DONE)
+        ae->flags |= HEALTH_ENTRY_FLAG_SAVED;
+    else
+        error_report(
+            "HEALTH [%s]: Failed to execute SQL_INSERT_HEALTH_LOG_DETAIL, rc = %d", rrdhost_hostname(host), rc);
+
+failed:
+    if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
+        error_report("HEALTH [%s]: Failed to finalize the prepared statement for inserting to health log detail", rrdhost_hostname(host));
+}
+
+#define SQL_INSERT_HEALTH_LOG                                                                                          \
+    "INSERT INTO health_log (host_id, alarm_id, "                                                                      \
+    "config_hash_id, name, chart, exec, recipient, units, chart_context, last_transition_id, chart_name) "             \
+    "VALUES (@host_id,@alarm_id, @config_hash_id,@name,@chart,@exec,@recipient,@units,@chart_context,"                 \
+    "@last_transition_id,@chart_name) ON CONFLICT (host_id, alarm_id) DO UPDATE "                                      \
+    "SET last_transition_id = excluded.last_transition_id, chart_name = excluded.chart_name, "                         \
+    "config_hash_id=excluded.config_hash_id RETURNING health_log_id"
+
+static void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae)
+{
     sqlite3_stmt *res = NULL;
     int rc;
     uint64_t health_log_id = 0;
@@ -197,168 +361,12 @@ static void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae) {
     }
 
     rc = sqlite3_step_monitored(res);
-    if (likely(rc == SQLITE_ROW))
-        health_log_id = (size_t) sqlite3_column_int64(res, 0);
-    else {
+    if (rc == SQLITE_ROW) {
+        health_log_id = (size_t)sqlite3_column_int64(res, 0);
+        sql_health_alarm_log_insert_detail(host, health_log_id, ae);
+    }
+    else
         error_report("HEALTH [%s]: Failed to execute SQL_INSERT_HEALTH_LOG, rc = %d", rrdhost_hostname(host), rc);
-        goto failed;
-    }
-
-    rc = sqlite3_finalize(res);
-    if (unlikely(rc != SQLITE_OK))
-        error_report("HEALTH [%s]: Failed to finalize the prepared statement for inserting to health log.", rrdhost_hostname(host));
-
-    rc = sqlite3_prepare_v2(db_meta, SQL_INSERT_HEALTH_LOG_DETAIL, -1, &res, 0);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("HEALTH [%s]: Failed to prepare statement for SQL_INSERT_HEALTH_LOG_DETAIL", rrdhost_hostname(host));
-        return;
-    }
-
-    rc = sqlite3_bind_int64(res, 1, (sqlite3_int64) health_log_id);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind unique_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 2, (sqlite3_int64) ae->unique_id);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind unique_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 3, (sqlite3_int64) ae->alarm_id);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind unique_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 4, (sqlite3_int64) ae->alarm_event_id);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind alarm_event_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 5, (sqlite3_int64) ae->updated_by_id);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind updated_by_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 6, (sqlite3_int64) ae->updates_id);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind updates_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 7, (sqlite3_int64) ae->when);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind when parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 8, (sqlite3_int64) ae->duration);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind duration parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 9, (sqlite3_int64) ae->non_clear_duration);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind non_clear_duration parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 10, (sqlite3_int64) ae->flags);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind flags parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 11, (sqlite3_int64) ae->exec_run_timestamp);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind exec_run_timestamp parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 12, (sqlite3_int64) ae->delay_up_to_timestamp);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind delay_up_to_timestamp parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ae->info, 13);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind info parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int(res, 14, ae->exec_code);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind exec_code parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int(res, 15, ae->new_status);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind new_status parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int(res, 16, ae->old_status);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind old_status parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int(res, 17, ae->delay);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind delay parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_double(res, 18, ae->new_value);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind new_value parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_double(res, 19, ae->old_value);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind old_value parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 20, (sqlite3_int64) ae->last_repeat);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind last_repeat parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_blob(res, 21, &ae->transition_id, sizeof(ae->transition_id), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind transition_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 22, (sqlite3_int64) ae->global_id);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind global_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ae->summary, 23);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind summary parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = execute_insert(res);
-    if (unlikely(rc != SQLITE_DONE)) {
-        error_report("HEALTH [%s]: Failed to execute SQL_INSERT_HEALTH_LOG_DETAIL, rc = %d", rrdhost_hostname(host), rc);
-        goto failed;
-    }
-
-    ae->flags |= HEALTH_ENTRY_FLAG_SAVED;
 
 failed:
     if (unlikely(sqlite3_finalize(res) != SQLITE_OK))

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -122,144 +122,32 @@ static void sql_health_alarm_log_insert_detail(RRDHOST *host, uint64_t health_lo
         }
     }
 
-    rc = sqlite3_bind_int64(res, 1, (sqlite3_int64)health_log_id);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind unique_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
+    int param = 0;
+    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)health_log_id), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->unique_id),done);
+    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->alarm_id), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->alarm_event_id), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->updated_by_id), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->updates_id), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->when), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->duration), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->non_clear_duration), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->flags), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->exec_run_timestamp), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->delay_up_to_timestamp), done);
+    SQLITE_BIND_FAIL(SQLITE3_BIND_STRING_OR_NULL(res, ae->info, ++param), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_int(res, ++param, ae->exec_code), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_int(res, ++param, ae->new_status), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_int(res, ++param, ae->old_status), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_int(res, ++param, ae->delay), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_double(res, ++param, ae->new_value), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_double(res, ++param, ae->old_value), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->last_repeat), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_blob(res, ++param, &ae->transition_id, sizeof(ae->transition_id), SQLITE_STATIC), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->global_id), done);
+    SQLITE_BIND_FAIL(SQLITE3_BIND_STRING_OR_NULL(res, ae->summary, ++param), done);
 
-    rc = sqlite3_bind_int64(res, 2, (sqlite3_int64)ae->unique_id);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind unique_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 3, (sqlite3_int64)ae->alarm_id);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind unique_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 4, (sqlite3_int64)ae->alarm_event_id);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind alarm_event_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 5, (sqlite3_int64)ae->updated_by_id);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind updated_by_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 6, (sqlite3_int64)ae->updates_id);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind updates_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 7, (sqlite3_int64)ae->when);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind when parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 8, (sqlite3_int64)ae->duration);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind duration parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 9, (sqlite3_int64)ae->non_clear_duration);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind non_clear_duration parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 10, (sqlite3_int64)ae->flags);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind flags parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 11, (sqlite3_int64)ae->exec_run_timestamp);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind exec_run_timestamp parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 12, (sqlite3_int64)ae->delay_up_to_timestamp);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind delay_up_to_timestamp parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ae->info, 13);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind info parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int(res, 14, ae->exec_code);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind exec_code parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int(res, 15, ae->new_status);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind new_status parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int(res, 16, ae->old_status);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind old_status parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int(res, 17, ae->delay);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind delay parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_double(res, 18, ae->new_value);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind new_value parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_double(res, 19, ae->old_value);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind old_value parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 20, (sqlite3_int64)ae->last_repeat);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind last_repeat parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_blob(res, 21, &ae->transition_id, sizeof(ae->transition_id), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind transition_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_int64(res, 22, (sqlite3_int64)ae->global_id);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind global_id parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ae->summary, 23);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind summary parameter for SQL_INSERT_HEALTH_LOG_DETAIL");
-        goto failed;
-    }
-
+    param = 0;
     rc = execute_insert(res);
     if (rc == SQLITE_DONE)
         ae->flags |= HEALTH_ENTRY_FLAG_SAVED;
@@ -267,7 +155,16 @@ static void sql_health_alarm_log_insert_detail(RRDHOST *host, uint64_t health_lo
         error_report(
             "HEALTH [%s]: Failed to execute SQL_INSERT_HEALTH_LOG_DETAIL, rc = %d", rrdhost_hostname(host), rc);
 
-failed:
+done:
+    if (param) {
+        const char *failed_param = sqlite3_bind_parameter_name(res, param);
+        error_report(
+            "HEALTH [%s]: Failed to bind paramater %d (%s) when inserting in health_log_detail",
+            rrdhost_hostname(host),
+            param,
+            failed_param ? failed_param : "anonymous");
+    }
+
     if (unlikely(sqlite3_reset(res) != SQLITE_OK))
         error_report("HEALTH [%s]: Failed to reset statement for inserting to health log detail", rrdhost_hostname(host));
 }
@@ -300,81 +197,39 @@ static void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae)
         }
     }
 
-    rc = sqlite3_bind_blob(res, 1, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind host_id for SQL_INSERT_HEALTH_LOG.");
-        goto failed;
-    }
+    int param = 0;
+    SQLITE_BIND_FAIL(sqlite3_bind_blob(res, ++param, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64) ae->alarm_id), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_blob(res, ++param, &ae->config_hash_id, sizeof(ae->config_hash_id), SQLITE_STATIC), done);
+    SQLITE_BIND_FAIL(SQLITE3_BIND_STRING_OR_NULL(res, ae->name, ++param), done);
+    SQLITE_BIND_FAIL(SQLITE3_BIND_STRING_OR_NULL(res, ae->chart, ++param), done);
+    SQLITE_BIND_FAIL(SQLITE3_BIND_STRING_OR_NULL(res, ae->exec, ++param), done);
+    SQLITE_BIND_FAIL(SQLITE3_BIND_STRING_OR_NULL(res, ae->recipient, ++param), done);
+    SQLITE_BIND_FAIL(SQLITE3_BIND_STRING_OR_NULL(res, ae->units, ++param), done);
+    SQLITE_BIND_FAIL(SQLITE3_BIND_STRING_OR_NULL(res, ae->chart_context, ++param), done);
+    SQLITE_BIND_FAIL(sqlite3_bind_blob(res, ++param, &ae->transition_id, sizeof(ae->transition_id), SQLITE_STATIC), done);
+    SQLITE_BIND_FAIL(SQLITE3_BIND_STRING_OR_NULL(res, ae->chart_name, ++param), done);
 
-    rc = sqlite3_bind_int64(res, 2, (sqlite3_int64) ae->alarm_id);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind alarm_id parameter for SQL_INSERT_HEALTH_LOG");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_blob(res, 3, &ae->config_hash_id, sizeof(ae->config_hash_id), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind config_hash_id parameter for SQL_INSERT_HEALTH_LOG");
-        goto failed;
-    }
-
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ae->name, 4);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind name parameter for SQL_INSERT_HEALTH_LOG");
-        goto failed;
-    }
-
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ae->chart, 5);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind chart parameter for SQL_INSERT_HEALTH_LOG");
-        goto failed;
-    }
-
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ae->exec, 6);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind exec parameter for SQL_INSERT_HEALTH_LOG");
-        goto failed;
-    }
-
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ae->recipient, 7);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind recipient parameter for SQL_INSERT_HEALTH_LOG");
-        goto failed;
-    }
-
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ae->units, 8);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind host_id parameter to store node instance information");
-        goto failed;
-    }
-
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ae->chart_context, 9);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind chart_context parameter for SQL_INSERT_HEALTH_LOG");
-        goto failed;
-    }
-
-    rc = sqlite3_bind_blob(res, 10, &ae->transition_id, sizeof(ae->transition_id), SQLITE_STATIC);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind transition_id parameter for SQL_INSERT_HEALTH_LOG");
-        goto failed;
-    }
-
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ae->chart_name, 11);
-    if (unlikely(rc != SQLITE_OK)) {
-        error_report("Failed to bind chart_name parameter for SQL_INSERT_HEALTH_LOG");
-        goto failed;
-    }
+    // Reset param to mark all bind commands succedeed
+    param = 0;
 
     rc = sqlite3_step_monitored(res);
     if (rc == SQLITE_ROW) {
         health_log_id = (size_t)sqlite3_column_int64(res, 0);
         sql_health_alarm_log_insert_detail(host, health_log_id, ae);
-    }
-    else
+    } else
         error_report("HEALTH [%s]: Failed to execute SQL_INSERT_HEALTH_LOG, rc = %d", rrdhost_hostname(host), rc);
 
-failed:
+done:
+    if (param) {
+        const char *failed_param = sqlite3_bind_parameter_name(res, param);
+        error_report(
+            "HEALTH [%s]: Failed to bind paramater %d (%s) when inserting in health_log",
+            rrdhost_hostname(host),
+            param,
+            failed_param ? failed_param : "anonymous");
+    }
+
     if (unlikely(sqlite3_reset(res) != SQLITE_OK))
         error_report("HEALTH [%s]: Failed to reset statement for inserting to health log", rrdhost_hostname(host));
 }

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -280,7 +280,7 @@ static void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae)
 {
     sqlite3_stmt *res = NULL;
     int rc;
-    uint64_t health_log_id = 0;
+    uint64_t health_log_id;
 
     if (unlikely(!db_meta)) {
         if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -106,7 +106,7 @@ failed:
     "@non_clear_duration,@flags,@exec_run_timestamp,@delay_up_to_timestamp, @info,@exec_code,@new_status,@old_status,"       \
     "@delay,@new_value,@old_value,@last_repeat,@transition_id,@global_id,@summary)"
 
-static int sql_health_alarm_log_insert_detail(RRDHOST *host, uint64_t health_log_id, ALARM_ENTRY *ae)
+static void sql_health_alarm_log_insert_detail(RRDHOST *host, uint64_t health_log_id, ALARM_ENTRY *ae)
 {
     sqlite3_stmt *res = NULL;
     int rc;
@@ -115,7 +115,7 @@ static int sql_health_alarm_log_insert_detail(RRDHOST *host, uint64_t health_log
     if (unlikely(rc != SQLITE_OK)) {
         error_report(
             "HEALTH [%s]: Failed to prepare statement for SQL_INSERT_HEALTH_LOG_DETAIL", rrdhost_hostname(host));
-        return 1;
+        return;
     }
 
     rc = sqlite3_bind_int64(res, 1, (sqlite3_int64)health_log_id);

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -6,8 +6,8 @@
 #include "health/health_internals.h"
 
 #define MAX_HEALTH_SQL_SIZE 2048
-#define SQLITE3_BIND_STRING_OR_NULL(res, key, param)                                                                   \
-    ((key) ? sqlite3_bind_text(res, param, string2str(key), -1, SQLITE_STATIC) : sqlite3_bind_null(res, param))
+#define SQLITE3_BIND_STRING_OR_NULL(res, param, key)                                                                   \
+    ((key) ? sqlite3_bind_text((res), (param), string2str(key), -1, SQLITE_STATIC) : sqlite3_bind_null((res), (param)))
 
 #define SQLITE3_COLUMN_STRINGDUP_OR_NULL(res, param)                                                                   \
     ({                                                                                                                 \
@@ -135,7 +135,7 @@ static void sql_health_alarm_log_insert_detail(RRDHOST *host, uint64_t health_lo
     SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->flags));
     SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->exec_run_timestamp));
     SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->delay_up_to_timestamp));
-    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ae->info, ++param));
+    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ++param, ae->info));
     SQLITE_BIND_FAIL(done, sqlite3_bind_int(res, ++param, ae->exec_code));
     SQLITE_BIND_FAIL(done, sqlite3_bind_int(res, ++param, ae->new_status));
     SQLITE_BIND_FAIL(done, sqlite3_bind_int(res, ++param, ae->old_status));
@@ -145,7 +145,7 @@ static void sql_health_alarm_log_insert_detail(RRDHOST *host, uint64_t health_lo
     SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->last_repeat));
     SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, &ae->transition_id, sizeof(ae->transition_id), SQLITE_STATIC));
     SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->global_id));
-    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ae->summary, ++param));
+    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ++param, ae->summary));
 
     param = 0;
     rc = execute_insert(res);
@@ -201,14 +201,14 @@ static void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae)
     SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC));
     SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64) ae->alarm_id));
     SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, &ae->config_hash_id, sizeof(ae->config_hash_id), SQLITE_STATIC));
-    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ae->name, ++param));
-    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ae->chart, ++param));
-    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ae->exec, ++param));
-    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ae->recipient, ++param));
-    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ae->units, ++param));
-    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ae->chart_context, ++param));
+    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ++param, ae->name));
+    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ++param, ae->chart));
+    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ++param, ae->exec));
+    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ++param, ae->recipient));
+    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ++param, ae->units));
+    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ++param, ae->chart_context));
     SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, &ae->transition_id, sizeof(ae->transition_id), SQLITE_STATIC));
-    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ae->chart_name, ++param));
+    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ++param, ae->chart_name));
 
     // Reset param to mark all bind commands succedeed
     param = 0;
@@ -874,42 +874,41 @@ int sql_alert_store_config(RRD_ALERT_PROTOTYPE *ap __maybe_unused)
         goto bind_fail;
 
     if (ap->match.is_template)
-        rc = SQLITE3_BIND_STRING_OR_NULL(res, NULL, ++param);
+        rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, NULL);
     else
-        rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->config.name, ++param);
+        rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->config.name);
 
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
     if (ap->match.is_template)
-        rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->config.name, ++param);
+        rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->config.name);
     else
-        rc = SQLITE3_BIND_STRING_OR_NULL(res, NULL, ++param);
+        rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, NULL);
 
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
     if (ap->match.is_template)
-        rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->match.on.context, ++param);
+        rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->match.on.context);
     else
-        rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->match.on.chart, ++param);
+        rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->match.on.chart);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->config.classification, ++param);
+    rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->config.classification);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->config.component, ++param);
+    rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->config.component);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->config.type, ++param);
+    rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->config.type);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    // Rebuild lookup
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, NULL, ++param); // lookup line
+    rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, NULL); // lookup line
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
@@ -917,7 +916,7 @@ int sql_alert_store_config(RRD_ALERT_PROTOTYPE *ap __maybe_unused)
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->config.units, ++param);
+    rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->config.units);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
@@ -952,15 +951,15 @@ int sql_alert_store_config(RRD_ALERT_PROTOTYPE *ap __maybe_unused)
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->config.exec, ++param);
+    rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->config.exec);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->config.recipient, ++param);
+    rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->config.recipient);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->config.info, ++param);
+    rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->config.info);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
@@ -992,12 +991,12 @@ int sql_alert_store_config(RRD_ALERT_PROTOTYPE *ap __maybe_unused)
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->match.host_labels, ++param);
+    rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->match.host_labels);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
     if (ap->config.after) {
-        rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->config.dimensions, ++param);
+        rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->config.dimensions);
         if (unlikely(rc != SQLITE_OK))
             goto bind_fail;
 
@@ -1042,15 +1041,15 @@ int sql_alert_store_config(RRD_ALERT_PROTOTYPE *ap __maybe_unused)
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->config.source, ++param);
+    rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->config.source);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->match.chart_labels, ++param);
+    rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->match.chart_labels);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, ap->config.summary, ++param);
+    rc = SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->config.summary);
     if (unlikely(rc != SQLITE_OK))
         goto bind_fail;
 
@@ -1515,14 +1514,14 @@ uint32_t sql_get_alarm_id(RRDHOST *host, STRING *chart, STRING *name, uint32_t *
         return alarm_id;
     }
 
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, chart, 2);
+    rc = SQLITE3_BIND_STRING_OR_NULL(res, 2, chart);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to bind char parameter for SQL_GET_ALARM_ID.");
         sqlite3_finalize(res);
         return alarm_id;
     }
 
-    rc = SQLITE3_BIND_STRING_OR_NULL(res, name, 3);
+    rc = SQLITE3_BIND_STRING_OR_NULL(res, 3, name);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to bind name parameter for SQL_GET_ALARM_ID.");
         sqlite3_finalize(res);

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -860,21 +860,10 @@ void sql_alert_store_config(RRD_ALERT_PROTOTYPE *ap __maybe_unused)
     SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->match.chart_labels));
     SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->config.summary));
 
-    rc = sqlite3_bind_int(res, ++param, ap->config.time_group_condition);
-    if (unlikely(rc != SQLITE_OK))
-        goto bind_fail;
-
-    rc = sqlite3_bind_double(res, ++param, ap->config.time_group_value);
-    if (unlikely(rc != SQLITE_OK))
-        goto bind_fail;
-
-    rc = sqlite3_bind_int(res, ++param, ap->config.dims_group);
-    if (unlikely(rc != SQLITE_OK))
-        goto bind_fail;
-
-    rc = sqlite3_bind_int(res, ++param, ap->config.data_source);
-    if (unlikely(rc != SQLITE_OK))
-        goto bind_fail;
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int(res, ++param, ap->config.time_group_condition));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_double(res, ++param, ap->config.time_group_value));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int(res, ++param, ap->config.dims_group));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int(res, ++param, ap->config.data_source));
 
     param = 0;
     rc = execute_insert(res);

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -123,29 +123,29 @@ static void sql_health_alarm_log_insert_detail(RRDHOST *host, uint64_t health_lo
     }
 
     int param = 0;
-    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)health_log_id), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->unique_id),done);
-    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->alarm_id), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->alarm_event_id), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->updated_by_id), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->updates_id), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->when), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->duration), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->non_clear_duration), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->flags), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->exec_run_timestamp), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->delay_up_to_timestamp), done);
-    SQLITE_BIND_FAIL(SQLITE3_BIND_STRING_OR_NULL(res, ae->info, ++param), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_int(res, ++param, ae->exec_code), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_int(res, ++param, ae->new_status), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_int(res, ++param, ae->old_status), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_int(res, ++param, ae->delay), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_double(res, ++param, ae->new_value), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_double(res, ++param, ae->old_value), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->last_repeat), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_blob(res, ++param, &ae->transition_id, sizeof(ae->transition_id), SQLITE_STATIC), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->global_id), done);
-    SQLITE_BIND_FAIL(SQLITE3_BIND_STRING_OR_NULL(res, ae->summary, ++param), done);
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)health_log_id));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->unique_id));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->alarm_id));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->alarm_event_id));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->updated_by_id));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->updates_id));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->when));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->duration));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->non_clear_duration));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->flags));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->exec_run_timestamp));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->delay_up_to_timestamp));
+    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ae->info, ++param));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int(res, ++param, ae->exec_code));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int(res, ++param, ae->new_status));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int(res, ++param, ae->old_status));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int(res, ++param, ae->delay));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_double(res, ++param, ae->new_value));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_double(res, ++param, ae->old_value));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->last_repeat));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, &ae->transition_id, sizeof(ae->transition_id), SQLITE_STATIC));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64)ae->global_id));
+    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ae->summary, ++param));
 
     param = 0;
     rc = execute_insert(res);
@@ -198,17 +198,17 @@ static void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae)
     }
 
     int param = 0;
-    SQLITE_BIND_FAIL(sqlite3_bind_blob(res, ++param, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_int64(res, ++param, (sqlite3_int64) ae->alarm_id), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_blob(res, ++param, &ae->config_hash_id, sizeof(ae->config_hash_id), SQLITE_STATIC), done);
-    SQLITE_BIND_FAIL(SQLITE3_BIND_STRING_OR_NULL(res, ae->name, ++param), done);
-    SQLITE_BIND_FAIL(SQLITE3_BIND_STRING_OR_NULL(res, ae->chart, ++param), done);
-    SQLITE_BIND_FAIL(SQLITE3_BIND_STRING_OR_NULL(res, ae->exec, ++param), done);
-    SQLITE_BIND_FAIL(SQLITE3_BIND_STRING_OR_NULL(res, ae->recipient, ++param), done);
-    SQLITE_BIND_FAIL(SQLITE3_BIND_STRING_OR_NULL(res, ae->units, ++param), done);
-    SQLITE_BIND_FAIL(SQLITE3_BIND_STRING_OR_NULL(res, ae->chart_context, ++param), done);
-    SQLITE_BIND_FAIL(sqlite3_bind_blob(res, ++param, &ae->transition_id, sizeof(ae->transition_id), SQLITE_STATIC), done);
-    SQLITE_BIND_FAIL(SQLITE3_BIND_STRING_OR_NULL(res, ae->chart_name, ++param), done);
+    SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, &host->host_uuid, sizeof(host->host_uuid), SQLITE_STATIC));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, (sqlite3_int64) ae->alarm_id));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, &ae->config_hash_id, sizeof(ae->config_hash_id), SQLITE_STATIC));
+    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ae->name, ++param));
+    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ae->chart, ++param));
+    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ae->exec, ++param));
+    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ae->recipient, ++param));
+    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ae->units, ++param));
+    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ae->chart_context, ++param));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, &ae->transition_id, sizeof(ae->transition_id), SQLITE_STATIC));
+    SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ae->chart_name, ++param));
 
     // Reset param to mark all bind commands succedeed
     param = 0;

--- a/src/database/sqlite/sqlite_health.h
+++ b/src/database/sqlite/sqlite_health.h
@@ -12,7 +12,7 @@ struct rrd_alert_prototype;
 void sql_health_alarm_log_load(RRDHOST *host);
 void sql_health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae);
 void sql_health_alarm_log_cleanup(RRDHOST *host, bool claimed);
-int sql_alert_store_config(struct rrd_alert_prototype *ap);
+void sql_alert_store_config(struct rrd_alert_prototype *ap);
 void sql_aclk_alert_clean_dead_entries(RRDHOST *host);
 int sql_health_get_last_executed_event(RRDHOST *host, ALARM_ENTRY *ae, RRDCALC_STATUS *last_executed_status);
 void sql_health_alarm_log2json(RRDHOST *host, BUFFER *wb, time_t after, const char *chart);

--- a/src/database/sqlite/sqlite_metadata.h
+++ b/src/database/sqlite/sqlite_metadata.h
@@ -52,7 +52,6 @@ RRDLABELS *sql_load_host_labels(uuid_t *host_id);
 
 uint64_t sqlite_get_meta_space(void);
 int sql_init_meta_database(db_check_action_type_t rebuild, int memory);
-void sql_close_meta_database(void);
 
 // UNIT TEST
 int metadata_unittest(void);

--- a/src/health/health_prototypes.c
+++ b/src/health/health_prototypes.c
@@ -377,7 +377,7 @@ void health_prototype_hash_id(RRD_ALERT_PROTOTYPE *ap) {
     UUID uuid = UUID_generate_from_hash(buffer_tostring(wb), buffer_strlen(wb));
     uuid_copy(ap->config.hash_id, uuid.uuid);
 
-    (void) sql_alert_store_config(ap);
+    sql_alert_store_config(ap);
 }
 
 bool health_prototype_add(RRD_ALERT_PROTOTYPE *ap) {


### PR DESCRIPTION
##### Summary
- Cleanup function sql_health_alarm_log_insert (use a separate function to write entries in health_log_detail)
- Use prepared statements to add and update records
- Use macros to simplify error checking and improve core readability
