### PR TITLE
Switch to using protobuf target for linking.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2058,7 +2058,7 @@ target_link_libraries(netdata PRIVATE
         libnetdata
         "$<$<BOOL:${LINUX}>:rt>"
         "$<$<BOOL:${ENABLE_MQTTWEBSOCKETS}>:mqttwebsockets>"
-        "$<$<BOOL:${ENABLE_PROTOBUF}>:${PROTOBUF_LIBRARIES}>"
+        "$<$<BOOL:${ENABLE_PROTOBUF}>:protobuf::libprotobuf>"
         "$<$<BOOL:${ENABLE_EXPORTER_MONGODB}>:${MONGOC_LIBRARIES}>"
         "$<$<BOOL:${ENABLE_EXPORTER_PROMETHEUS_REMOTE_WRITE}>:${SNAPPY_LIBRARIES}>"
         "$<$<BOOL:${MACOS}>:${IOKIT};${FOUNDATION}>"


### PR DESCRIPTION


##### Summary

This should resolve the issues with linking against the latest versions of libprotobuf.

The relevant syntax has been supported since before the minimum version of CMake that we are requiring, so this should not break things on older systems.

##### Test Plan

CI passes on this PR