### PR TITLE
remove "os" "hosts" "plugin" and "module" from stock alarms

### DIFF
--- a/src/health/health.d/apcupsd.conf
+++ b/src/health/health.d/apcupsd.conf
@@ -5,8 +5,6 @@
     class: Utilization
      type: Power Supply
 component: UPS
-       os: *
-    hosts: *
    lookup: average -10m unaligned of percentage
     units: %
     every: 1m
@@ -23,8 +21,6 @@ component: UPS
     class: Errors
      type: Power Supply
 component: UPS
-       os: *
-    hosts: *
    lookup: average -60s unaligned of charge
     units: %
     every: 60s

--- a/src/health/health.d/boinc.conf
+++ b/src/health/health.d/boinc.conf
@@ -1,4 +1,4 @@
-# Alarms for various BOINC issues.
+# you can disable an alarm notification by setting the 'to' line to: silent
 
 # Warn on any compute errors encountered.
  template: boinc_compute_errors
@@ -6,8 +6,6 @@
     class: Errors
      type: Computing
 component: BOINC
-       os: *
-    hosts: *
    lookup: average -10m unaligned of comperror
     units: tasks
     every: 1m
@@ -23,8 +21,6 @@ component: BOINC
     class: Errors
      type: Computing
 component: BOINC
-       os: *
-    hosts: *
    lookup: average -10m unaligned of upload_failed
     units: tasks
     every: 1m
@@ -40,8 +36,6 @@ component: BOINC
     class: Utilization
      type: Computing
 component: BOINC
-       os: *
-    hosts: *
    lookup: average -10m unaligned of total
     units: tasks
     every: 1m
@@ -57,8 +51,6 @@ component: BOINC
     class: Utilization
      type: Computing
 component: BOINC
-       os: *
-    hosts: *
    lookup: average -10m unaligned of active
      calc: ($boinc_total_tasks >= 1) ? ($this) : (inf)
     units: tasks

--- a/src/health/health.d/btrfs.conf
+++ b/src/health/health.d/btrfs.conf
@@ -1,11 +1,10 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
 
  template: btrfs_allocated
        on: btrfs.disk
     class: Utilization
      type: System
 component: File system
-       os: *
-    hosts: *
      calc: 100 - ($unallocated * 100 / ($unallocated + $data_used + $data_free + $meta_used + $meta_free + $sys_used + $sys_free))
     units: %
     every: 10s
@@ -20,8 +19,6 @@ component: File system
     class: Utilization
      type: System
 component: File system
-       os: *
-    hosts: *
      calc: $used * 100 / ($used + $free)
     units: %
     every: 10s
@@ -37,8 +34,6 @@ component: File system
     class: Utilization
      type: System
 component: File system
-       os: *
-    hosts: *
      calc: ($used + $reserved) * 100 / ($used + $free + $reserved)
     units: %
     every: 10s
@@ -54,8 +49,6 @@ component: File system
     class: Utilization
      type: System
 component: File system
-       os: *
-    hosts: *
      calc: $used * 100 / ($used + $free)
     units: %
     every: 10s
@@ -71,8 +64,6 @@ component: File system
     class: Errors
      type: System
 component: File system
-       os: *
-    hosts: *
     units: errors
    lookup: max -10m every 1m of read_errs
      warn: $this > 0
@@ -86,8 +77,6 @@ component: File system
     class: Errors
      type: System
 component: File system
-       os: *
-    hosts: *
     units: errors
    lookup: max -10m every 1m of write_errs
      crit: $this > 0
@@ -101,8 +90,6 @@ component: File system
     class: Errors
      type: System
 component: File system
-       os: *
-    hosts: *
     units: errors
    lookup: max -10m every 1m of flush_errs
      crit: $this > 0
@@ -116,8 +103,6 @@ component: File system
     class: Errors
      type: System
 component: File system
-       os: *
-    hosts: *
     units: errors
    lookup: max -10m every 1m of corruption_errs
      warn: $this > 0
@@ -131,8 +116,6 @@ component: File system
     class: Errors
      type: System
 component: File system
-       os: *
-    hosts: *
     units: errors
    lookup: max -10m every 1m of generation_errs
      warn: $this > 0

--- a/src/health/health.d/cgroups.conf
+++ b/src/health/health.d/cgroups.conf
@@ -1,72 +1,67 @@
-
 # you can disable an alarm notification by setting the 'to' line to: silent
 
- template: cgroup_10min_cpu_usage
-       on: cgroup.cpu_limit
-    class: Utilization
-     type: Cgroups
-component: CPU
-       os: linux
-    hosts: *
-   lookup: average -10m unaligned
-    units: %
-    every: 1m
-     warn: $this > (($status == $CRITICAL) ? (85) : (95))
-    delay: down 15m multiplier 1.5 max 1h
-  summary: Cgroup ${label:cgroup_name} CPU utilization
-     info: Cgroup ${label:cgroup_name} average CPU utilization over the last 10 minutes
-       to: silent
+   template: cgroup_10min_cpu_usage
+         on: cgroup.cpu_limit
+      class: Utilization
+       type: Cgroups
+  component: CPU
+host labels: _os=linux
+     lookup: average -10m unaligned
+      units: %
+      every: 1m
+       warn: $this > (($status == $CRITICAL) ? (85) : (95))
+      delay: down 15m multiplier 1.5 max 1h
+    summary: Cgroup ${label:cgroup_name} CPU utilization
+       info: Cgroup ${label:cgroup_name} average CPU utilization over the last 10 minutes
+         to: silent
 
- template: cgroup_ram_in_use
-       on: cgroup.mem_usage
-    class: Utilization
-     type: Cgroups
-component: Memory
-       os: linux
-    hosts: *
-     calc: ($ram) * 100 / $memory_limit
-    units: %
-    every: 10s
-     warn: $this > (($status >= $WARNING)  ? (80) : (90))
-     crit: $this > (($status == $CRITICAL) ? (90) : (98))
-    delay: down 15m multiplier 1.5 max 1h
-  summary: Cgroup ${label:cgroup_name} memory utilization
-     info: Cgroup ${label:cgroup_name} memory utilization
-       to: silent
+   template: cgroup_ram_in_use
+         on: cgroup.mem_usage
+      class: Utilization
+       type: Cgroups
+  component: Memory
+host labels: _os=linux
+       calc: ($ram) * 100 / $memory_limit
+      units: %
+      every: 10s
+       warn: $this > (($status >= $WARNING)  ? (80) : (90))
+       crit: $this > (($status == $CRITICAL) ? (90) : (98))
+      delay: down 15m multiplier 1.5 max 1h
+    summary: Cgroup ${label:cgroup_name} memory utilization
+       info: Cgroup ${label:cgroup_name} memory utilization
+         to: silent
 
 # ---------------------------------K8s containers--------------------------------------------
 
- template: k8s_cgroup_10min_cpu_usage
-       on: k8s.cgroup.cpu_limit
-    class: Utilization
-     type: Cgroups
-component: CPU
-       os: linux
-    hosts: *
-   lookup: average -10m unaligned
-    units: %
-    every: 1m
-     warn: $this > (($status >= $WARNING)  ? (75) : (85))
-    delay: down 15m multiplier 1.5 max 1h
-  summary: Container ${label:k8s_container_name} pod ${label:k8s_pod_name} CPU utilization
-     info: Container ${label:k8s_container_name} of pod ${label:k8s_pod_name} of namespace ${label:k8s_namespace}, \
-           average CPU utilization over the last 10 minutes
-       to: silent
+   template: k8s_cgroup_10min_cpu_usage
+         on: k8s.cgroup.cpu_limit
+      class: Utilization
+       type: Cgroups
+  component: CPU
+host labels: _os=linux
+     lookup: average -10m unaligned
+      units: %
+      every: 1m
+       warn: $this > (($status >= $WARNING)  ? (75) : (85))
+      delay: down 15m multiplier 1.5 max 1h
+    summary: Container ${label:k8s_container_name} pod ${label:k8s_pod_name} CPU utilization
+       info: Container ${label:k8s_container_name} of pod ${label:k8s_pod_name} of namespace ${label:k8s_namespace}, \
+             average CPU utilization over the last 10 minutes
+         to: silent
 
- template: k8s_cgroup_ram_in_use
-       on: k8s.cgroup.mem_usage
-    class: Utilization
-     type: Cgroups
-component: Memory
-       os: linux
-    hosts: *
-     calc: ($ram) * 100 / $memory_limit
-    units: %
-    every: 10s
-     warn: $this > (($status >= $WARNING)  ? (80) : (90))
-     crit: $this > (($status == $CRITICAL) ? (90) : (98))
-    delay: down 15m multiplier 1.5 max 1h
-  summary: Container ${label:k8s_container_name} pod ${label:k8s_pod_name} memory utilization
-     info: container ${label:k8s_container_name} of pod ${label:k8s_pod_name} of namespace ${label:k8s_namespace}, \
-           memory utilization
-       to: silent
+   template: k8s_cgroup_ram_in_use
+         on: k8s.cgroup.mem_usage
+      class: Utilization
+       type: Cgroups
+  component: Memory
+host labels: _os=linux
+       calc: ($ram) * 100 / $memory_limit
+      units: %
+      every: 10s
+       warn: $this > (($status >= $WARNING)  ? (80) : (90))
+       crit: $this > (($status == $CRITICAL) ? (90) : (98))
+      delay: down 15m multiplier 1.5 max 1h
+    summary: Container ${label:k8s_container_name} pod ${label:k8s_pod_name} memory utilization
+       info: container ${label:k8s_container_name} of pod ${label:k8s_pod_name} of namespace ${label:k8s_namespace}, \
+             memory utilization
+         to: silent

--- a/src/health/health.d/cpu.conf
+++ b/src/health/health.d/cpu.conf
@@ -1,69 +1,65 @@
 
 # you can disable an alarm notification by setting the 'to' line to: silent
 
- template: 10min_cpu_usage
-       on: system.cpu
-    class: Utilization
-     type: System
-component: CPU
-       os: linux
-    hosts: *
-   lookup: average -10m unaligned of user,system,softirq,irq,guest
-    units: %
-    every: 1m
-     warn: $this > (($status >= $WARNING)  ? (75) : (85))
-     crit: $this > (($status == $CRITICAL) ? (85) : (95))
-    delay: down 15m multiplier 1.5 max 1h
-  summary: System CPU utilization
-     info: Average CPU utilization over the last 10 minutes (excluding iowait, nice and steal)
-       to: silent
+   template: 10min_cpu_usage
+         on: system.cpu
+      class: Utilization
+       type: System
+  component: CPU
+host labels: _os=linux
+     lookup: average -10m unaligned of user,system,softirq,irq,guest
+      units: %
+      every: 1m
+       warn: $this > (($status >= $WARNING)  ? (75) : (85))
+       crit: $this > (($status == $CRITICAL) ? (85) : (95))
+      delay: down 15m multiplier 1.5 max 1h
+    summary: System CPU utilization
+       info: Average CPU utilization over the last 10 minutes (excluding iowait, nice and steal)
+         to: silent
 
- template: 10min_cpu_iowait
-       on: system.cpu
-    class: Utilization
-     type: System
-component: CPU
-       os: linux
-    hosts: *
-   lookup: average -10m unaligned of iowait
-    units: %
-    every: 1m
-     warn: $this > (($status >= $WARNING)  ? (20) : (40))
-    delay: up 30m down 30m multiplier 1.5 max 2h
-  summary: System CPU iowait time
-     info: Average CPU iowait time over the last 10 minutes
-       to: silent
+   template: 10min_cpu_iowait
+         on: system.cpu
+      class: Utilization
+       type: System
+  component: CPU
+host labels: _os=linux
+     lookup: average -10m unaligned of iowait
+      units: %
+      every: 1m
+       warn: $this > (($status >= $WARNING)  ? (20) : (40))
+      delay: up 30m down 30m multiplier 1.5 max 2h
+    summary: System CPU iowait time
+       info: Average CPU iowait time over the last 10 minutes
+         to: silent
 
- template: 20min_steal_cpu
-       on: system.cpu
-    class: Latency
-     type: System
-component: CPU
-       os: linux
-    hosts: *
-   lookup: average -20m unaligned of steal
-    units: %
-    every: 5m
-     warn: $this > (($status >= $WARNING)  ? (5)  : (10))
-    delay: down 1h multiplier 1.5 max 2h
-  summary: System CPU steal time
-     info: Average CPU steal time over the last 20 minutes
-       to: silent
+   template: 20min_steal_cpu
+         on: system.cpu
+      class: Latency
+       type: System
+  component: CPU
+host labels: _os=linux
+     lookup: average -20m unaligned of steal
+      units: %
+      every: 5m
+       warn: $this > (($status >= $WARNING)  ? (5)  : (10))
+      delay: down 1h multiplier 1.5 max 2h
+    summary: System CPU steal time
+       info: Average CPU steal time over the last 20 minutes
+         to: silent
 
 ## FreeBSD
- template: 10min_cpu_usage
-       on: system.cpu
-    class: Utilization
-     type: System
-component: CPU
-       os: freebsd
-    hosts: *
-   lookup: average -10m unaligned of user,system,interrupt
-    units: %
-    every: 1m
-     warn: $this > (($status >= $WARNING)  ? (75) : (85))
-     crit: $this > (($status == $CRITICAL) ? (85) : (95))
-    delay: down 15m multiplier 1.5 max 1h
-  summary: System CPU utilization
-     info: Average CPU utilization over the last 10 minutes (excluding nice)
-       to: silent
+   template: 10min_cpu_usage
+         on: system.cpu
+      class: Utilization
+       type: System
+  component: CPU
+host labels: _os=freebsd
+     lookup: average -10m unaligned of user,system,interrupt
+      units: %
+      every: 1m
+       warn: $this > (($status >= $WARNING)  ? (75) : (85))
+       crit: $this > (($status == $CRITICAL) ? (85) : (95))
+      delay: down 15m multiplier 1.5 max 1h
+    summary: System CPU utilization
+       info: Average CPU utilization over the last 10 minutes (excluding nice)
+         to: silent

--- a/src/health/health.d/dbengine.conf
+++ b/src/health/health.d/dbengine.conf
@@ -1,4 +1,3 @@
-
 # you can disable an alarm notification by setting the 'to' line to: silent
 
     alarm: 10min_dbengine_global_fs_errors
@@ -6,8 +5,6 @@
     class: Errors
      type: Netdata
 component: DB engine
-       os: linux freebsd macos
-    hosts: *
    lookup: sum -10m unaligned of fs_errors
     units: errors
     every: 10s
@@ -22,8 +19,6 @@ component: DB engine
     class: Errors
      type: Netdata
 component: DB engine
-       os: linux freebsd macos
-    hosts: *
    lookup: sum -10m unaligned of io_errors
     units: errors
     every: 10s
@@ -38,8 +33,6 @@ component: DB engine
     class: Errors
      type: Netdata
 component: DB engine
-       os: linux freebsd macos
-    hosts: *
    lookup: sum -10m unaligned of pg_cache_over_half_dirty_events
     units: errors
     every: 10s
@@ -55,8 +48,6 @@ component: DB engine
     class: Errors
      type: Netdata
 component: DB engine
-       os: linux freebsd macos
-    hosts: *
    lookup: sum -10m unaligned of flushing_pressure_deletions
     units: pages
     every: 10s

--- a/src/health/health.d/disks.conf
+++ b/src/health/health.d/disks.conf
@@ -1,6 +1,4 @@
-
 # you can disable an alarm notification by setting the 'to' line to: silent
-
 
 # -----------------------------------------------------------------------------
 # low disk space
@@ -9,41 +7,39 @@
 # raise an alarm if the disk is low on
 # available disk space
 
- template: disk_space_usage
-       on: disk.space
-    class: Utilization
-     type: System
-component: Disk
-       os: linux freebsd
-    hosts: *
+    template: disk_space_usage
+          on: disk.space
+       class: Utilization
+        type: System
+   component: Disk
+ host labels: _os=linux freebsd
 chart labels: mount_point=!/dev !/dev/* !/run !/run/* *
-     calc: $used * 100 / ($avail + $used)
-    units: %
-    every: 1m
-     warn: $this > (($status >= $WARNING ) ? (80) : (90))
-     crit: ($this > (($status == $CRITICAL) ? (90) : (98))) && $avail < 5
-    delay: up 1m down 15m multiplier 1.5 max 1h
-  summary: Disk ${label:mount_point} space usage
-     info: Total space utilization of disk ${label:mount_point}
-       to: sysadmin
+         calc: $used * 100 / ($avail + $used)
+        units: %
+        every: 1m
+         warn: $this > (($status >= $WARNING ) ? (80) : (90))
+         crit: ($this > (($status == $CRITICAL) ? (90) : (98))) && $avail < 5
+        delay: up 1m down 15m multiplier 1.5 max 1h
+      summary: Disk ${label:mount_point} space usage
+         info: Total space utilization of disk ${label:mount_point}
+           to: sysadmin
 
- template: disk_inode_usage
-       on: disk.inodes
-    class: Utilization
-     type: System
-component: Disk
-       os: linux freebsd
-    hosts: *
+    template: disk_inode_usage
+          on: disk.inodes
+       class: Utilization
+        type: System
+   component: Disk
+ host labels: _os=linux freebsd
 chart labels: mount_point=!/dev !/dev/* !/run !/run/* *
-     calc: $used * 100 / ($avail + $used)
-    units: %
-    every: 1m
-     warn: $this > (($status >= $WARNING)  ? (80) : (90))
-     crit: $this > (($status == $CRITICAL) ? (90) : (98))
-    delay: up 1m down 15m multiplier 1.5 max 1h
-  summary: Disk ${label:mount_point} inode usage
-     info: Total inode utilization of disk ${label:mount_point}
-       to: sysadmin
+        calc: $used * 100 / ($avail + $used)
+       units: %
+       every: 1m
+        warn: $this > (($status >= $WARNING)  ? (80) : (90))
+        crit: $this > (($status == $CRITICAL) ? (90) : (98))
+       delay: up 1m down 15m multiplier 1.5 max 1h
+     summary: Disk ${label:mount_point} inode usage
+        info: Total inode utilization of disk ${label:mount_point}
+          to: sysadmin
 
 
 # -----------------------------------------------------------------------------
@@ -57,33 +53,30 @@ chart labels: mount_point=!/dev !/dev/* !/run !/run/* *
 # we will use it in the next template to find
 # the hours remaining
 
-template: disk_fill_rate
-      on: disk.space
-      os: linux freebsd
-   hosts: *
-  lookup: min -10m at -50m unaligned of avail
-    calc: ($this - $avail) / (($now - $after) / 3600)
-   every: 1m
-   units: GB/hour
-    info: average rate the disk fills up (positive), or frees up (negative) space, for the last hour
+   template: disk_fill_rate
+         on: disk.space
+host labels: _os=linux freebsd
+     lookup: min -10m at -50m unaligned of avail
+       calc: ($this - $avail) / (($now - $after) / 3600)
+      every: 1m
+      units: GB/hour
+       info: average rate the disk fills up (positive), or frees up (negative) space, for the last hour
 
 # calculate the hours remaining
-# if the disk continues to fill
-# in this rate
+# if the disk continues to fill in this rate
 
-template: out_of_disk_space_time
-      on: disk.space
-      os: linux freebsd
-   hosts: *
-    calc: ($disk_fill_rate > 0) ? ($avail / $disk_fill_rate) : (inf)
-   units: hours
-   every: 10s
-    warn: $this > 0 and $this < (($status >= $WARNING)  ? (48) : (8))
-    crit: $this > 0 and $this < (($status == $CRITICAL) ? (24) : (2))
-   delay: down 15m multiplier 1.2 max 1h
- summary: Disk ${label:mount_point} estimation of lack of space
-    info: Estimated time the disk ${label:mount_point} will run out of space, if the system continues to add data with the rate of the last hour
-      to: silent
+   template: out_of_disk_space_time
+         on: disk.space
+host labels: _os=linux freebsd
+       calc: ($disk_fill_rate > 0) ? ($avail / $disk_fill_rate) : (inf)
+      units: hours
+      every: 10s
+       warn: $this > 0 and $this < (($status >= $WARNING)  ? (48) : (8))
+       crit: $this > 0 and $this < (($status == $CRITICAL) ? (24) : (2))
+      delay: down 15m multiplier 1.2 max 1h
+    summary: Disk ${label:mount_point} estimation of lack of space
+       info: Estimated time the disk ${label:mount_point} will run out of space, if the system continues to add data with the rate of the last hour
+         to: silent
 
 
 # -----------------------------------------------------------------------------
@@ -97,33 +90,31 @@ template: out_of_disk_space_time
 # we will use it in the next template to find
 # the hours remaining
 
-template: disk_inode_rate
-      on: disk.inodes
-      os: linux freebsd
-   hosts: *
-  lookup: min -10m at -50m unaligned of avail
-    calc: ($this - $avail) / (($now - $after) / 3600)
-   every: 1m
-   units: inodes/hour
-    info: average rate at which disk inodes are allocated (positive), or freed (negative), for the last hour
+   template: disk_inode_rate
+         on: disk.inodes
+host labels: _os=linux freebsd
+     lookup: min -10m at -50m unaligned of avail
+       calc: ($this - $avail) / (($now - $after) / 3600)
+      every: 1m
+      units: inodes/hour
+       info: average rate at which disk inodes are allocated (positive), or freed (negative), for the last hour
 
 # calculate the hours remaining
 # if the disk inodes are allocated
 # in this rate
 
-template: out_of_disk_inodes_time
-      on: disk.inodes
-      os: linux freebsd
-   hosts: *
-    calc: ($disk_inode_rate > 0) ? ($avail / $disk_inode_rate) : (inf)
-   units: hours
-   every: 10s
-    warn: $this > 0 and $this < (($status >= $WARNING)  ? (48) : (8))
-    crit: $this > 0 and $this < (($status == $CRITICAL) ? (24) : (2))
-   delay: down 15m multiplier 1.2 max 1h
- summary: Disk ${label:mount_point} estimation of lack of inodes
-    info: Estimated time the disk ${label:mount_point} will run out of inodes, if the system continues to allocate inodes with the rate of the last hour
-      to: silent
+   template: out_of_disk_inodes_time
+         on: disk.inodes
+host labels: _os=linux freebsd
+       calc: ($disk_inode_rate > 0) ? ($avail / $disk_inode_rate) : (inf)
+      units: hours
+      every: 10s
+       warn: $this > 0 and $this < (($status >= $WARNING)  ? (48) : (8))
+       crit: $this > 0 and $this < (($status == $CRITICAL) ? (24) : (2))
+      delay: down 15m multiplier 1.2 max 1h
+    summary: Disk ${label:mount_point} estimation of lack of inodes
+       info: Estimated time the disk ${label:mount_point} will run out of inodes, if the system continues to allocate inodes with the rate of the last hour
+         to: silent
 
 
 # -----------------------------------------------------------------------------
@@ -133,21 +124,20 @@ template: out_of_disk_inodes_time
 # by calculating the average disk utilization
 # for the last 10 minutes
 
- template: 10min_disk_utilization
-       on: disk.util
-    class: Utilization
-     type: System
-component: Disk
-       os: linux freebsd
-    hosts: *
-   lookup: average -10m unaligned
-    units: %
-    every: 1m
-     warn: $this > 98 * (($status >= $WARNING)  ? (0.7) : (1))
-    delay: down 15m multiplier 1.2 max 1h
-  summary: Disk ${label:device} utilization
-     info: Average percentage of time ${label:device} disk was busy over the last 10 minutes
-       to: silent
+   template: 10min_disk_utilization
+         on: disk.util
+      class: Utilization
+       type: System
+  component: Disk
+host labels: _os=linux freebsd
+     lookup: average -10m unaligned
+      units: %
+      every: 1m
+       warn: $this > 98 * (($status >= $WARNING)  ? (0.7) : (1))
+      delay: down 15m multiplier 1.2 max 1h
+    summary: Disk ${label:device} utilization
+       info: Average percentage of time ${label:device} disk was busy over the last 10 minutes
+         to: silent
 
 
 # raise an alarm if the disk backlog
@@ -155,18 +145,17 @@ component: Disk
 # for 10 minutes
 # (i.e. the disk cannot catch up)
 
- template: 10min_disk_backlog
-       on: disk.backlog
-    class: Latency
-     type: System
-component: Disk
-       os: linux
-    hosts: *
-   lookup: average -10m unaligned
-    units: ms
-    every: 1m
-     warn: $this > 5000 * (($status >= $WARNING)  ? (0.7) : (1))
-    delay: down 15m multiplier 1.2 max 1h
-  summary: Disk ${label:device} backlog
-     info: Average backlog size of the ${label:device} disk over the last 10 minutes
-       to: silent
+   template: 10min_disk_backlog
+         on: disk.backlog
+      class: Latency
+       type: System
+  component: Disk
+host labels: _os=linux freebsd
+     lookup: average -10m unaligned
+      units: ms
+      every: 1m
+       warn: $this > 5000 * (($status >= $WARNING)  ? (0.7) : (1))
+      delay: down 15m multiplier 1.2 max 1h
+    summary: Disk ${label:device} backlog
+       info: Average backlog size of the ${label:device} disk over the last 10 minutes
+         to: silent

--- a/src/health/health.d/entropy.conf
+++ b/src/health/health.d/entropy.conf
@@ -3,18 +3,17 @@
 # the alarm is checked every 1 minute
 # and examines the last hour of data
 
-    alarm: lowest_entropy
-       on: system.entropy
-    class: Utilization
-     type: System
-component: Cryptography
-       os: linux
-    hosts: *
-   lookup: min -5m unaligned
-    units: entries
-    every: 5m
-     warn: $this < (($status >= $WARNING) ? (200) : (100))
-    delay: down 1h multiplier 1.5 max 2h
-  summary: System entropy pool number of entries
-     info: Minimum number of entries in the random numbers pool in the last 5 minutes
-       to: silent
+      alarm: lowest_entropy
+         on: system.entropy
+      class: Utilization
+       type: System
+  component: Cryptography
+host labels: _os=linux
+     lookup: min -5m unaligned
+      units: entries
+      every: 5m
+       warn: $this < (($status >= $WARNING) ? (200) : (100))
+      delay: down 1h multiplier 1.5 max 2h
+    summary: System entropy pool number of entries
+       info: Minimum number of entries in the random numbers pool in the last 5 minutes
+         to: silent

--- a/src/health/health.d/file_descriptors.conf
+++ b/src/health/health.d/file_descriptors.conf
@@ -5,7 +5,6 @@
      class: Utilization
       type: System
  component: Processes
-     hosts: *
     lookup: max -1m unaligned
      units: %
      every: 1m
@@ -15,19 +14,17 @@
       info: System-wide utilization of open files
         to: sysadmin
 
- template: apps_group_file_descriptors_utilization
-       on: app.fds_open_limit
-    class: Utilization
-     type: System
-component: Process
-       os: linux
-   module: *
-    hosts: *
-   lookup: max -10s unaligned
-    units: %
-    every: 10s
-     warn: $this > (($status >= $WARNING)  ? (85) : (95))
-    delay: down 15m multiplier 1.5 max 1h
-  summary: App group ${label:app_group} file descriptors utilization
-     info: Open files percentage against the processes limits, among all PIDs in application group
-       to: sysadmin
+   template: apps_group_file_descriptors_utilization
+         on: app.fds_open_limit
+      class: Utilization
+       type: System
+  component: Process
+host labels: _os=linux
+     lookup: max -10s unaligned
+      units: %
+      every: 10s
+       warn: $this > (($status >= $WARNING)  ? (85) : (95))
+      delay: down 15m multiplier 1.5 max 1h
+    summary: App group ${label:app_group} file descriptors utilization
+       info: Open files percentage against the processes limits, among all PIDs in application group
+         to: sysadmin

--- a/src/health/health.d/go.d.plugin.conf
+++ b/src/health/health.d/go.d.plugin.conf
@@ -1,18 +1,17 @@
-
 # make sure go.d.plugin data collection job is running
 
- template: go.d_job_last_collected_secs
-       on: netdata.go_plugin_execution_time
-    class: Errors
-     type: Netdata
-component: go.d.plugin
-   module: !* *
-     calc: $now - $last_collected_t
-    units: seconds ago
-    every: 10s
-     warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
-     crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
-    delay: down 5m multiplier 1.5 max 1h
-  summary: Go.d plugin last collection
-     info: Number of seconds since the last successful data collection
-       to: webmaster
+   template: go.d_job_last_collected_secs
+         on: netdata.go_plugin_execution_time
+      class: Errors
+       type: Netdata
+  component: go.d.plugin
+host labels: _hostname=!*
+       calc: $now - $last_collected_t
+      units: seconds ago
+      every: 10s
+       warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
+       crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
+      delay: down 5m multiplier 1.5 max 1h
+    summary: Go.d plugin last collection
+       info: Number of seconds since the last successful data collection
+         to: webmaster

--- a/src/health/health.d/ipc.conf
+++ b/src/health/health.d/ipc.conf
@@ -1,34 +1,32 @@
 
 # you can disable an alarm notification by setting the 'to' line to: silent
 
-    alarm: semaphores_used
-       on: system.ipc_semaphores
-    class: Utilization
-     type: System
-component: IPC
-       os: linux
-    hosts: *
-     calc: $semaphores * 100 / $ipc_semaphores_max
-    units: %
-    every: 10s
-     warn: $this > (($status >= $WARNING)  ? (70) : (80))
-    delay: down 5m multiplier 1.5 max 1h
-  summary: IPC semaphores used
-     info: IPC semaphore utilization
-       to: sysadmin
+      alarm: semaphores_used
+         on: system.ipc_semaphores
+      class: Utilization
+       type: System
+  component: IPC
+host labels: _os=linux
+       calc: $semaphores * 100 / $ipc_semaphores_max
+      units: %
+      every: 10s
+       warn: $this > (($status >= $WARNING)  ? (70) : (80))
+      delay: down 5m multiplier 1.5 max 1h
+    summary: IPC semaphores used
+       info: IPC semaphore utilization
+         to: sysadmin
 
-    alarm: semaphore_arrays_used
-       on: system.ipc_semaphore_arrays
-    class: Utilization
-     type: System
-component: IPC
-       os: linux
-    hosts: *
-     calc: $arrays * 100 / $ipc_semaphores_arrays_max
-    units: %
-    every: 10s
-     warn: $this > (($status >= $WARNING)  ? (70) : (80))
-    delay: down 5m multiplier 1.5 max 1h
-  summary: IPC semaphore arrays used
-     info: IPC semaphore arrays utilization
-       to: sysadmin
+      alarm: semaphore_arrays_used
+         on: system.ipc_semaphore_arrays
+      class: Utilization
+       type: System
+  component: IPC
+host labels: _os=linux
+       calc: $arrays * 100 / $ipc_semaphores_arrays_max
+      units: %
+      every: 10s
+       warn: $this > (($status >= $WARNING)  ? (70) : (80))
+      delay: down 5m multiplier 1.5 max 1h
+    summary: IPC semaphore arrays used
+       info: IPC semaphore arrays utilization
+         to: sysadmin

--- a/src/health/health.d/load.conf
+++ b/src/health/health.d/load.conf
@@ -1,72 +1,67 @@
-
 # you can disable an alarm notification by setting the 'to' line to: silent
 
 # Calculate the base trigger point for the load average alarms.
 # This is the maximum number of CPU's in the system over the past 1
 # minute, with a special case for a single CPU of setting the trigger at 2.
-    alarm: load_cpu_number
-       on: system.load
-    class: Utilization
-     type: System
-component: Load
-       os: linux
-    hosts: *
-     calc: ($active_processors == nan or $active_processors == 0) ? (nan) : ( ($active_processors < 2) ? ( 2 ) : ( $active_processors ) )
-    units: cpus
-    every: 1m
-     info: Number of active CPU cores in the system
+      alarm: load_cpu_number
+         on: system.load
+      class: Utilization
+       type: System
+  component: Load
+host labels: _os=linux
+       calc: ($active_processors == nan or $active_processors == 0) ? (nan) : ( ($active_processors < 2) ? ( 2 ) : ( $active_processors ) )
+      units: cpus
+      every: 1m
+       info: Number of active CPU cores in the system
 
 # Send alarms if the load average is unusually high.
 # These intentionally _do not_ calculate the average over the sampled
 # time period because the values being checked already are averages.
 
-    alarm: load_average_15
-       on: system.load
-    class: Utilization
-     type: System
-component: Load
-       os: linux
-    hosts: *
-   lookup: max -1m unaligned of load15
-     calc: ($load_cpu_number == nan) ? (nan) : ($this)
-    units: load
-    every: 1m
-     warn: ($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 175 : 200)
-    delay: down 15m multiplier 1.5 max 1h
-  summary: Host load average (15 minutes)
-     info: System load average for the past 15 minutes
-       to: silent
+      alarm: load_average_15
+         on: system.load
+      class: Utilization
+       type: System
+  component: Load
+host labels: _os=linux
+     lookup: max -1m unaligned of load15
+       calc: ($load_cpu_number == nan) ? (nan) : ($this)
+      units: load
+      every: 1m
+       warn: ($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 175 : 200)
+      delay: down 15m multiplier 1.5 max 1h
+    summary: Host load average (15 minutes)
+       info: System load average for the past 15 minutes
+         to: silent
 
-    alarm: load_average_5
-       on: system.load
-    class: Utilization
-     type: System
-component: Load
-       os: linux
-    hosts: *
-   lookup: max -1m unaligned of load5
-     calc: ($load_cpu_number == nan) ? (nan) : ($this)
-    units: load
-    every: 1m
-     warn: ($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 350 : 400)
-    delay: down 15m multiplier 1.5 max 1h
-  summary: System load average (5 minutes)
-     info: System load average for the past 5 minutes
-       to: silent
+      alarm: load_average_5
+         on: system.load
+      class: Utilization
+       type: System
+  component: Load
+host labels: _os=linux
+     lookup: max -1m unaligned of load5
+       calc: ($load_cpu_number == nan) ? (nan) : ($this)
+      units: load
+      every: 1m
+       warn: ($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 350 : 400)
+      delay: down 15m multiplier 1.5 max 1h
+    summary: System load average (5 minutes)
+       info: System load average for the past 5 minutes
+         to: silent
 
-    alarm: load_average_1
-       on: system.load
-    class: Utilization
-     type: System
-component: Load
-       os: linux
-    hosts: *
-   lookup: max -1m unaligned of load1
-     calc: ($load_cpu_number == nan) ? (nan) : ($this)
-    units: load
-    every: 1m
-     warn: ($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 700 : 800)
-    delay: down 15m multiplier 1.5 max 1h
-  summary: System load average (1 minute)
-     info: System load average for the past 1 minute
-       to: silent
+      alarm: load_average_1
+         on: system.load
+      class: Utilization
+       type: System
+  component: Load
+host labels: _os=linux
+     lookup: max -1m unaligned of load1
+       calc: ($load_cpu_number == nan) ? (nan) : ($this)
+      units: load
+      every: 1m
+       warn: ($this * 100 / $load_cpu_number) > (($status >= $WARNING) ? 700 : 800)
+      delay: down 15m multiplier 1.5 max 1h
+    summary: System load average (1 minute)
+       info: System load average for the past 1 minute
+         to: silent

--- a/src/health/health.d/memory.conf
+++ b/src/health/health.d/memory.conf
@@ -1,81 +1,76 @@
 # you can disable an alarm notification by setting the 'to' line to: silent
 
-    alarm: 1hour_memory_hw_corrupted
-       on: mem.hwcorrupt
-    class: Errors
-     type: System
-component: Memory
-       os: linux
-    hosts: *
-     calc: $HardwareCorrupted
-    units: MB
-    every: 10s
-     warn: $this > 0
-    delay: down 1h multiplier 1.5 max 1h
-  summary: System corrupted memory
-     info: Amount of memory corrupted due to a hardware failure
-       to: sysadmin
+      alarm: 1hour_memory_hw_corrupted
+         on: mem.hwcorrupt
+      class: Errors
+       type: System
+  component: Memory
+host labels: _os=linux
+       calc: $HardwareCorrupted
+      units: MB
+      every: 10s
+       warn: $this > 0
+      delay: down 1h multiplier 1.5 max 1h
+    summary: System corrupted memory
+       info: Amount of memory corrupted due to a hardware failure
+         to: sysadmin
 
 ## ECC Controller
 
- template: ecc_memory_mc_correctable
-       on: mem.edac_mc_errors
-    class: Errors
-     type: System
-component: Memory
-       os: linux
-    hosts: *
-     calc: $correctable + $correctable_noinfo
-    units: errors
-    every: 1m
-     warn: $this > 0
-  summary: System ECC memory ${label:controller} correctable errors
-     info: Memory controller ${label:controller} ECC correctable errors
-       to: sysadmin
+   template: ecc_memory_mc_correctable
+         on: mem.edac_mc_errors
+      class: Errors
+       type: System
+  component: Memory
+host labels: _os=linux
+       calc: $correctable + $correctable_noinfo
+      units: errors
+      every: 1m
+       warn: $this > 0
+    summary: System ECC memory ${label:controller} correctable errors
+       info: Memory controller ${label:controller} ECC correctable errors
+         to: sysadmin
 
- template: ecc_memory_mc_uncorrectable
-       on: mem.edac_mc_errors
-    class: Errors
-     type: System
-component: Memory
-       os: linux
-    hosts: *
-    calc: $uncorrectable + $uncorrectable_noinfo
-    units: errors
-    every: 1m
-     crit: $this > 0
-  summary: System ECC memory ${label:controller} uncorrectable errors
-     info: Memory controller ${label:controller} ECC uncorrectable errors
-       to: sysadmin
+   template: ecc_memory_mc_uncorrectable
+         on: mem.edac_mc_errors
+      class: Errors
+       type: System
+  component: Memory
+host labels: _os=linux
+       calc: $uncorrectable + $uncorrectable_noinfo
+      units: errors
+      every: 1m
+       crit: $this > 0
+    summary: System ECC memory ${label:controller} uncorrectable errors
+       info: Memory controller ${label:controller} ECC uncorrectable errors
+         to: sysadmin
 
 ## ECC DIMM
 
- template: ecc_memory_dimm_correctable
-       on: mem.edac_mc_dimm_errors
-    class: Errors
-     type: System
-component: Memory
-       os: linux
-    hosts: *
-    calc: $correctable
-    units: errors
-    every: 1m
-     warn: $this > 0
-  summary: System ECC memory DIMM ${label:dimm} correctable errors
-     info: DIMM ${label:dimm} controller ${label:controller} (location ${label:dimm_location}) ECC correctable errors
-       to: sysadmin
+   template: ecc_memory_dimm_correctable
+         on: mem.edac_mc_dimm_errors
+      class: Errors
+       type: System
+  component: Memory
+host labels: _os=linux
+      calc: $correctable
+      units: errors
+      every: 1m
+       warn: $this > 0
+    summary: System ECC memory DIMM ${label:dimm} correctable errors
+       info: DIMM ${label:dimm} controller ${label:controller} (location ${label:dimm_location}) ECC correctable errors
+         to: sysadmin
 
- template: ecc_memory_dimm_uncorrectable
-       on: mem.edac_mc_dimm_errors
-    class: Errors
-     type: System
-component: Memory
-       os: linux
-    hosts: *
-    calc: $uncorrectable
-    units: errors
-    every: 1m
-     crit: $this > 0
-  summary: System ECC memory DIMM ${label:dimm} uncorrectable errors
-     info: DIMM ${label:dimm} controller ${label:controller} (location ${label:dimm_location}) ECC uncorrectable errors
-       to: sysadmin
+   template: ecc_memory_dimm_uncorrectable
+         on: mem.edac_mc_dimm_errors
+      class: Errors
+       type: System
+  component: Memory
+host labels: _os=linux
+       calc: $uncorrectable
+      units: errors
+      every: 1m
+       crit: $this > 0
+    summary: System ECC memory DIMM ${label:dimm} uncorrectable errors
+       info: DIMM ${label:dimm} controller ${label:controller} (location ${label:dimm_location}) ECC uncorrectable errors
+         to: sysadmin

--- a/src/health/health.d/ml.conf
+++ b/src/health/health.d/ml.conf
@@ -13,8 +13,6 @@
     class: Workload
      type: System
 component: ML
-       os: *
-    hosts: *
    lookup: average -1m of anomaly_rate
      calc: $this
     units: %
@@ -29,8 +27,6 @@ component: ML
 # if anomaly rate is above 20% then critical (pick your own threshold that works best via tial and error).
 # template: ml_5min_cpu_dims
 #       on: system.cpu
-#       os: linux
-#    hosts: *
 #   lookup: average -5m anomaly-bit foreach *
 #     calc: $this
 #    units: %
@@ -44,8 +40,6 @@ component: ML
 # if anomaly rate is above 20% then critical (pick your own threshold that works best via tial and error).
 # template: ml_5min_cpu_chart
 #       on: system.cpu
-#       os: linux
-#    hosts: *
 #   lookup: average -5m anomaly-bit of *
 #     calc: $this
 #    units: %
@@ -53,4 +47,3 @@ component: ML
 #     warn: $this > (($status >= $WARNING)  ? (5) : (20))
 #     crit: $this > (($status == $CRITICAL) ? (20) : (100))
 #     info: rolling 5min anomaly rate for system.cpu chart
-

--- a/src/health/health.d/net.conf
+++ b/src/health/health.d/net.conf
@@ -9,46 +9,42 @@
     class: Latency
      type: System
 component: Network
-       os: *
-    hosts: *
      calc: ( $nic_speed_max > 0 ) ? ( $nic_speed_max / 1000) : ( nan )
     units: Mbit
     every: 10s
      info: Network interface ${label:device} current speed
 
- template: 1m_received_traffic_overflow
-       on: net.net
-    class: Workload
-     type: System
-component: Network
-       os: linux
-    hosts: *
-   lookup: average -1m unaligned absolute of received
-     calc: ($interface_speed > 0) ? ($this * 100 / ($interface_speed * 1000)) : ( nan )
-    units: %
-    every: 10s
-     warn: $this > (($status >= $WARNING)  ? (85) : (90))
-    delay: up 1m down 1m multiplier 1.5 max 1h
-  summary: System network interface ${label:device} inbound utilization
-     info: Average inbound utilization for the network interface ${label:device} over the last minute
-       to: silent
+   template: 1m_received_traffic_overflow
+         on: net.net
+      class: Workload
+       type: System
+  component: Network
+host labels: _os=linux
+     lookup: average -1m unaligned absolute of received
+       calc: ($interface_speed > 0) ? ($this * 100 / ($interface_speed * 1000)) : ( nan )
+      units: %
+      every: 10s
+       warn: $this > (($status >= $WARNING)  ? (85) : (90))
+      delay: up 1m down 1m multiplier 1.5 max 1h
+    summary: System network interface ${label:device} inbound utilization
+       info: Average inbound utilization for the network interface ${label:device} over the last minute
+         to: silent
 
- template: 1m_sent_traffic_overflow
-       on: net.net
-    class: Workload
-     type: System
-component: Network
-       os: linux
-    hosts: *
-   lookup: average -1m unaligned absolute of sent
-     calc: ($interface_speed > 0) ? ($this * 100 / ($interface_speed * 1000)) : ( nan )
-    units: %
-    every: 10s
-     warn: $this > (($status >= $WARNING)  ? (85) : (90))
-    delay: up 1m down 1m multiplier 1.5 max 1h
-  summary: System network interface ${label:device} outbound utilization
-     info: Average outbound utilization for the network interface ${label:device} over the last minute
-       to: silent
+   template: 1m_sent_traffic_overflow
+         on: net.net
+      class: Workload
+       type: System
+  component: Network
+host labels: _os=linux
+     lookup: average -1m unaligned absolute of sent
+       calc: ($interface_speed > 0) ? ($this * 100 / ($interface_speed * 1000)) : ( nan )
+      units: %
+      every: 10s
+       warn: $this > (($status >= $WARNING)  ? (85) : (90))
+      delay: up 1m down 1m multiplier 1.5 max 1h
+    summary: System network interface ${label:device} outbound utilization
+       info: Average outbound utilization for the network interface ${label:device} over the last minute
+         to: silent
 
 # -----------------------------------------------------------------------------
 # dropped packets
@@ -65,8 +61,6 @@ component: Network
     class: Workload
      type: System
 component: Network
-       os: *
-    hosts: *
    lookup: sum -10m unaligned absolute of received
     units: packets
     every: 1m
@@ -78,120 +72,110 @@ component: Network
     class: Workload
      type: System
 component: Network
-       os: *
-    hosts: *
    lookup: sum -10m unaligned absolute of sent
     units: packets
     every: 1m
   summary: Network interface ${label:device} sent packets
      info: Sent packets for the network interface ${label:device} in the last 10 minutes
 
- template: inbound_packets_dropped_ratio
-       on: net.drops
-    class: Errors
-     type: System
-component: Network
-       os: *
-    hosts: *
+    template: inbound_packets_dropped_ratio
+          on: net.drops
+       class: Errors
+        type: System
+   component: Network
 chart labels: device=!wl* *
-   lookup: sum -10m unaligned absolute of inbound
-     calc: (($net_interface_inbound_packets > 10000) ? ($this * 100 / $net_interface_inbound_packets) : (0))
-    units: %
-    every: 1m
-     warn: $this >= 2
-    delay: up 1m down 1h multiplier 1.5 max 2h
-  summary: System network interface ${label:device} inbound drops
-     info: Ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
-       to: silent
+      lookup: sum -10m unaligned absolute of inbound
+        calc: (($net_interface_inbound_packets > 10000) ? ($this * 100 / $net_interface_inbound_packets) : (0))
+       units: %
+       every: 1m
+        warn: $this >= 2
+       delay: up 1m down 1h multiplier 1.5 max 2h
+     summary: System network interface ${label:device} inbound drops
+        info: Ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
+          to: silent
 
- template: outbound_packets_dropped_ratio
-       on: net.drops
-    class: Errors
-     type: System
-component: Network
-       os: *
-    hosts: *
+    template: outbound_packets_dropped_ratio
+          on: net.drops
+       class: Errors
+        type: System
+   component: Network
 chart labels: device=!wl* *
-   lookup: sum -10m unaligned absolute of outbound
-     calc: (($net_interface_outbound_packets > 1000) ? ($this * 100 / $net_interface_outbound_packets) : (0))
-    units: %
-    every: 1m
-     warn: $this >= 2
-    delay: up 1m down 1h multiplier 1.5 max 2h
-  summary: System network interface ${label:device} outbound drops
-     info: Ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
-       to: silent
+      lookup: sum -10m unaligned absolute of outbound
+        calc: (($net_interface_outbound_packets > 1000) ? ($this * 100 / $net_interface_outbound_packets) : (0))
+       units: %
+       every: 1m
+        warn: $this >= 2
+       delay: up 1m down 1h multiplier 1.5 max 2h
+     summary: System network interface ${label:device} outbound drops
+        info: Ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
+          to: silent
 
- template: wifi_inbound_packets_dropped_ratio
-       on: net.drops
-    class: Errors
-     type: System
-component: Network
-       os: linux
-    hosts: *
+    template: wifi_inbound_packets_dropped_ratio
+          on: net.drops
+       class: Errors
+        type: System
+   component: Network
+ host labels: _os=linux
 chart labels: device=wl*
-   lookup: sum -10m unaligned absolute of received
-     calc: (($net_interface_inbound_packets > 10000) ? ($this * 100 / $net_interface_inbound_packets) : (0))
-    units: %
-    every: 1m
-     warn: $this >= 10
-    delay: up 1m down 1h multiplier 1.5 max 2h
-  summary: System network interface ${label:device} inbound drops ratio
-     info: Ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
-       to: silent
+      lookup: sum -10m unaligned absolute of received
+        calc: (($net_interface_inbound_packets > 10000) ? ($this * 100 / $net_interface_inbound_packets) : (0))
+       units: %
+       every: 1m
+        warn: $this >= 10
+       delay: up 1m down 1h multiplier 1.5 max 2h
+     summary: System network interface ${label:device} inbound drops ratio
+        info: Ratio of inbound dropped packets for the network interface ${label:device} over the last 10 minutes
+          to: silent
 
- template: wifi_outbound_packets_dropped_ratio
-       on: net.drops
-    class: Errors
-     type: System
-component: Network
-       os: linux
-    hosts: *
+    template: wifi_outbound_packets_dropped_ratio
+          on: net.drops
+       class: Errors
+        type: System
+   component: Network
+ host labels: _os=linux
 chart labels: device=wl*
-   lookup: sum -10m unaligned absolute of sent
-     calc: (($net_interface_outbound_packets > 1000) ? ($this * 100 / $net_interface_outbound_packets) : (0))
-    units: %
-    every: 1m
-     warn: $this >= 10
-    delay: up 1m down 1h multiplier 1.5 max 2h
-  summary: System network interface ${label:device} outbound drops ratio
-     info: Ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
-       to: silent
+      lookup: sum -10m unaligned absolute of sent
+        calc: (($net_interface_outbound_packets > 1000) ? ($this * 100 / $net_interface_outbound_packets) : (0))
+       units: %
+       every: 1m
+        warn: $this >= 10
+       delay: up 1m down 1h multiplier 1.5 max 2h
+     summary: System network interface ${label:device} outbound drops ratio
+        info: Ratio of outbound dropped packets for the network interface ${label:device} over the last 10 minutes
+          to: silent
 
 # -----------------------------------------------------------------------------
 # interface errors
 
- template: interface_inbound_errors
-       on: net.errors
-    class: Errors
-     type: System
-component: Network
-       os: freebsd
-    hosts: *
-   lookup: sum -10m unaligned absolute of inbound
-    units: errors
-    every: 1m
-     warn: $this >= 5
-    delay: down 1h multiplier 1.5 max 2h
-  summary: System network interface ${label:device} inbound errors
-     info: Number of inbound errors for the network interface ${label:device} in the last 10 minutes
-       to: silent
+   template: interface_inbound_errors
+         on: net.errors
+      class: Errors
+       type: System
+  component: Network
+host labels: _os=freebsd
+     lookup: sum -10m unaligned absolute of inbound
+      units: errors
+      every: 1m
+       warn: $this >= 5
+      delay: down 1h multiplier 1.5 max 2h
+    summary: System network interface ${label:device} inbound errors
+       info: Number of inbound errors for the network interface ${label:device} in the last 10 minutes
+         to: silent
 
- template: interface_outbound_errors
-       on: net.errors
-    class: Errors
-     type: System
-component: Network
-       os: freebsd
-    hosts: *
-   lookup: sum -10m unaligned absolute of outbound
-    units: errors
-    every: 1m
-     warn: $this >= 5
-    delay: down 1h multiplier 1.5 max 2h
-  summary: System network interface ${label:device} outbound errors
-     info: Number of outbound errors for the network interface ${label:device} in the last 10 minutes
-       to: silent
+   template: interface_outbound_errors
+         on: net.errors
+      class: Errors
+       type: System
+  component: Network
+host labels: _os=freebsd
+     lookup: sum -10m unaligned absolute of outbound
+      units: errors
+      every: 1m
+       warn: $this >= 5
+      delay: down 1h multiplier 1.5 max 2h
+    summary: System network interface ${label:device} outbound errors
+       info: Number of outbound errors for the network interface ${label:device} in the last 10 minutes
+         to: silent
 
 # -----------------------------------------------------------------------------
 # FIFO errors
@@ -201,21 +185,20 @@ component: Network
 # the alarm is checked every 1 minute
 # and examines the last 10 minutes of data
 
- template: 10min_fifo_errors
-       on: net.fifo
-    class: Errors
-     type: System
-component: Network
-       os: linux
-    hosts: *
-   lookup: sum -10m unaligned absolute
-    units: errors
-    every: 1m
-     warn: $this > 0
-    delay: down 1h multiplier 1.5 max 2h
-  summary: System network interface ${label:device} FIFO errors
-     info: Number of FIFO errors for the network interface ${label:device} in the last 10 minutes
-       to: silent
+   template: 10min_fifo_errors
+         on: net.fifo
+      class: Errors
+       type: System
+  component: Network
+host labels: _os=linux
+     lookup: sum -10m unaligned absolute
+      units: errors
+      every: 1m
+       warn: $this > 0
+      delay: down 1h multiplier 1.5 max 2h
+    summary: System network interface ${label:device} FIFO errors
+       info: Number of FIFO errors for the network interface ${label:device} in the last 10 minutes
+         to: silent
 
 # -----------------------------------------------------------------------------
 # check for packet storms
@@ -226,33 +209,31 @@ component: Network
 # we assume the minimum packet storm should at least have
 # 10000 packets/s, average of the last 10 seconds
 
- template: 1m_received_packets_rate
-       on: net.packets
-    class: Workload
-     type: System
-component: Network
-       os: linux freebsd
-    hosts: *
-   lookup: average -1m unaligned of received
-    units: packets
-    every: 10s
-     info: Average number of packets received by the network interface ${label:device} over the last minute
+   template: 1m_received_packets_rate
+         on: net.packets
+      class: Workload
+       type: System
+  component: Network
+host labels: _os=linux freebsd
+     lookup: average -1m unaligned of received
+      units: packets
+      every: 10s
+       info: Average number of packets received by the network interface ${label:device} over the last minute
 
- template: 10s_received_packets_storm
-       on: net.packets
-    class: Workload
-     type: System
-component: Network
-       os: linux freebsd
-    hosts: *
-   lookup: average -10s unaligned of received
-     calc: $this * 100 / (($1m_received_packets_rate < 1000)?(1000):($1m_received_packets_rate))
-    every: 10s
-    units: %
-     warn: $this > (($status >= $WARNING)?(200):(5000))
-     crit: $this > (($status == $CRITICAL)?(5000):(6000))
-  options: no-clear-notification
-  summary: System network interface ${label:device} inbound packet storm
-     info: Ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, \
-           compared to the rate over the last minute
-       to: silent
+   template: 10s_received_packets_storm
+         on: net.packets
+      class: Workload
+       type: System
+  component: Network
+host labels: _os=linux freebsd
+     lookup: average -10s unaligned of received
+       calc: $this * 100 / (($1m_received_packets_rate < 1000)?(1000):($1m_received_packets_rate))
+      every: 10s
+      units: %
+       warn: $this > (($status >= $WARNING)?(200):(5000))
+       crit: $this > (($status == $CRITICAL)?(5000):(6000))
+    options: no-clear-notification
+    summary: System network interface ${label:device} inbound packet storm
+       info: Ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, \
+             compared to the rate over the last minute
+         to: silent

--- a/src/health/health.d/netfilter.conf
+++ b/src/health/health.d/netfilter.conf
@@ -1,20 +1,18 @@
-
 # you can disable an alarm notification by setting the 'to' line to: silent
 
-    alarm: netfilter_conntrack_full
-       on: netfilter.conntrack_sockets
-    class: Workload
-     type: System
-component: Network
-       os: linux
-    hosts: *
-   lookup: max -10s unaligned of connections
-     calc: $this * 100 / $netfilter_conntrack_max
-    units: %
-    every: 10s
-     warn: $this > (($status >= $WARNING)  ? (85) : (90))
-     crit: $this > (($status == $CRITICAL) ? (90) : (95))
-    delay: down 5m multiplier 1.5 max 1h
-  summary: System Netfilter connection tracker utilization
-     info: Netfilter connection tracker table size utilization
-       to: sysadmin
+      alarm: netfilter_conntrack_full
+         on: netfilter.conntrack_sockets
+      class: Workload
+       type: System
+  component: Network
+host labels: _os=linux
+     lookup: max -10s unaligned of connections
+       calc: $this * 100 / $netfilter_conntrack_max
+      units: %
+      every: 10s
+       warn: $this > (($status >= $WARNING)  ? (85) : (90))
+       crit: $this > (($status == $CRITICAL) ? (90) : (95))
+      delay: down 5m multiplier 1.5 max 1h
+    summary: System Netfilter connection tracker utilization
+       info: Netfilter connection tracker table size utilization
+         to: sysadmin

--- a/src/health/health.d/postgres.conf
+++ b/src/health/health.d/postgres.conf
@@ -5,7 +5,6 @@
     class: Utilization
      type: Database
 component: PostgreSQL
-    hosts: *
    lookup: average -1m unaligned of used
     units: %
     every: 1m
@@ -21,7 +20,6 @@ component: PostgreSQL
     class: Utilization
      type: Database
 component: PostgreSQL
-    hosts: *
    lookup: average -1m unaligned of used
     units: %
     every: 1m
@@ -36,7 +34,6 @@ component: PostgreSQL
     class: Utilization
      type: Database
 component: PostgreSQL
-    hosts: *
      calc: $txid_exhaustion	
     units: %
     every: 1m
@@ -53,7 +50,6 @@ component: PostgreSQL
     class: Workload
      type: Database
 component: PostgreSQL
-    hosts: *
    lookup: average -1m unaligned of miss
      calc: 100 - $this
     units: %
@@ -70,7 +66,6 @@ component: PostgreSQL
     class: Workload
      type: Database
 component: PostgreSQL
-    hosts: *
    lookup: average -5m unaligned of rollback
     units: %
     every: 1m
@@ -85,7 +80,6 @@ component: PostgreSQL
     class: Errors
      type: Database
 component: PostgreSQL
-    hosts: *
    lookup: sum -1m unaligned of deadlocks
     units: deadlocks
     every: 1m
@@ -102,7 +96,6 @@ component: PostgreSQL
     class: Workload
      type: Database
 component: PostgreSQL
-    hosts: *
    lookup: average -1m unaligned of miss
      calc: 100 - $this
     units: %
@@ -119,7 +112,6 @@ component: PostgreSQL
     class: Workload
      type: Database
 component: PostgreSQL
-    hosts: *
    lookup: average -1m unaligned of miss
      calc: 100 - $this
     units: %
@@ -136,7 +128,6 @@ component: PostgreSQL
     class: Workload
      type: Database
 component: PostgreSQL
-    hosts: *
    lookup: average -1m unaligned of miss
      calc: 100 - $this
     units: %
@@ -153,7 +144,6 @@ component: PostgreSQL
     class: Workload
      type: Database
 component: PostgreSQL
-    hosts: *
    lookup: average -1m unaligned of miss
      calc: 100 - $this
     units: %
@@ -170,7 +160,6 @@ component: PostgreSQL
     class: Errors
      type: Database
 component: PostgreSQL
-    hosts: *
      calc: ($table_size > (1024 * 1024 * 100)) ? ($bloat) : (0)
     units: %
     every: 1m
@@ -186,7 +175,7 @@ component: PostgreSQL
     class: Errors
      type: Database
 component: PostgreSQL
-    hosts: !*
+host labels: _hostname=!*
      calc: $time
     units: seconds
     every: 1m
@@ -200,7 +189,7 @@ component: PostgreSQL
     class: Errors
      type: Database
 component: PostgreSQL
-    hosts: !*
+host labels: _hostname=!*
      calc: $time
     units: seconds
     every: 1m
@@ -216,7 +205,6 @@ component: PostgreSQL
     class: Errors
      type: Database
 component: PostgreSQL
-    hosts: *
      calc: ($index_size > (1024 * 1024 * 10)) ? ($bloat) : (0)
     units: %
     every: 1m

--- a/src/health/health.d/processes.conf
+++ b/src/health/health.d/processes.conf
@@ -5,7 +5,6 @@
     class: Workload
      type: System
 component: Processes
-    hosts: *
      calc: $active * 100 / $pidmax
     units: %
     every: 5s

--- a/src/health/health.d/python.d.plugin.conf
+++ b/src/health/health.d/python.d.plugin.conf
@@ -1,18 +1,17 @@
-
 # make sure python.d.plugin data collection job is running
 
- template: python.d_job_last_collected_secs
-       on: netdata.pythond_runtime
-    class: Errors
-     type: Netdata
-component: python.d.plugin
-   module: !* *
-     calc: $now - $last_collected_t
-    units: seconds ago
-    every: 10s
-     warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
-     crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
-    delay: down 5m multiplier 1.5 max 1h
-  summary: Python.d plugin last collection
-     info: Number of seconds since the last successful data collection
-       to: webmaster
+   template: python.d_job_last_collected_secs
+         on: netdata.pythond_runtime
+      class: Errors
+       type: Netdata
+  component: python.d.plugin
+host labels: _hostname=!*
+       calc: $now - $last_collected_t
+      units: seconds ago
+      every: 10s
+       warn: $this > (($status >= $WARNING)  ? ($update_every) : ( 5 * $update_every))
+       crit: $this > (($status == $CRITICAL) ? ($update_every) : (60 * $update_every))
+      delay: down 5m multiplier 1.5 max 1h
+    summary: Python.d plugin last collection
+       info: Number of seconds since the last successful data collection
+         to: webmaster

--- a/src/health/health.d/qos.conf
+++ b/src/health/health.d/qos.conf
@@ -1,18 +1,16 @@
-
 # you can disable an alarm notification by setting the 'to' line to: silent
 
 # check if a QoS class is dropping packets
 # the alarm is checked every 10 seconds
 # and examines the last minute of data
 
-template: 10min_qos_packet_drops
-      on: tc.qos_dropped
-      os: linux
-   hosts: *
-  lookup: sum -5m unaligned absolute
-   every: 30s
-    warn: $this > 0
-   units: packets
- summary: QOS packet drops
-    info: Dropped packets in the last 5 minutes
-      to: silent
+   template: 10min_qos_packet_drops
+         on: tc.qos_dropped
+host labels: _os=linux
+     lookup: sum -5m unaligned absolute
+      every: 30s
+       warn: $this > 0
+      units: packets
+    summary: QOS packet drops
+       info: Dropped packets in the last 5 minutes
+         to: silent

--- a/src/health/health.d/ram.conf
+++ b/src/health/health.d/ram.conf
@@ -1,82 +1,76 @@
-
 # you can disable an alarm notification by setting the 'to' line to: silent
 
-    alarm: ram_in_use
-       on: system.ram
-    class: Utilization
-     type: System
-component: Memory
-       os: linux
-    hosts: *
-     calc: $used * 100 / ($used + $cached + $free + $buffers)
-    units: %
-    every: 10s
-     warn: $this > (($status >= $WARNING)  ? (80) : (90))
-     crit: $this > (($status == $CRITICAL) ? (90) : (98))
-    delay: down 15m multiplier 1.5 max 1h
-  summary: System memory utilization
-     info: System memory utilization
-       to: sysadmin
+      alarm: ram_in_use
+         on: system.ram
+      class: Utilization
+       type: System
+  component: Memory
+host labels: _os=linux
+       calc: $used * 100 / ($used + $cached + $free + $buffers)
+      units: %
+      every: 10s
+       warn: $this > (($status >= $WARNING)  ? (80) : (90))
+       crit: $this > (($status == $CRITICAL) ? (90) : (98))
+      delay: down 15m multiplier 1.5 max 1h
+    summary: System memory utilization
+       info: System memory utilization
+         to: sysadmin
 
-    alarm: ram_available
-       on: mem.available
-    class: Utilization
-     type: System
-component: Memory
-       os: linux
-    hosts: *
-     calc: $avail * 100 / ($system.ram.used + $system.ram.cached + $system.ram.free + $system.ram.buffers)
-    units: %
-    every: 10s
-     warn: $this < (($status >= $WARNING)  ? (15) : (10))
-    delay: down 15m multiplier 1.5 max 1h
-  summary: System available memory
-     info: Percentage of estimated amount of RAM available for userspace processes, without causing swapping
-       to: silent
+      alarm: ram_available
+         on: mem.available
+      class: Utilization
+       type: System
+  component: Memory
+host labels: _os=linux
+       calc: $avail * 100 / ($system.ram.used + $system.ram.cached + $system.ram.free + $system.ram.buffers)
+      units: %
+      every: 10s
+       warn: $this < (($status >= $WARNING)  ? (15) : (10))
+      delay: down 15m multiplier 1.5 max 1h
+    summary: System available memory
+       info: Percentage of estimated amount of RAM available for userspace processes, without causing swapping
+         to: silent
 
-    alarm: oom_kill
-       on: mem.oom_kill
-       os: linux
-    hosts: *
-   lookup: sum -30m unaligned
-    units: kills
-    every: 5m
-     warn: $this > 0
-    delay: down 10m
-  summary: System OOM kills
-     info: Number of out of memory kills in the last 30 minutes
-       to: silent
+      alarm: oom_kill
+         on: mem.oom_kill
+host labels: _os=linux
+     lookup: sum -30m unaligned
+      units: kills
+      every: 5m
+       warn: $this > 0
+      delay: down 10m
+    summary: System OOM kills
+       info: Number of out of memory kills in the last 30 minutes
+         to: silent
 
 ## FreeBSD
-    alarm: ram_in_use
-       on: system.ram
-    class: Utilization
-     type: System
-component: Memory
-       os: freebsd
-    hosts: *
-     calc: ($active + $wired + $laundry + $buffers) * 100 / ($active + $wired + $laundry + $buffers + $cache + $free + $inactive)
-    units: %
-    every: 10s
-     warn: $this > (($status >= $WARNING)  ? (80) : (90))
-     crit: $this > (($status == $CRITICAL) ? (90) : (98))
-    delay: down 15m multiplier 1.5 max 1h
-  summary: System memory utilization
-     info: System memory utilization
-       to: sysadmin
+      alarm: ram_in_use
+         on: system.ram
+      class: Utilization
+       type: System
+  component: Memory
+host labels: _os=freebsd
+       calc: ($active + $wired + $laundry + $buffers) * 100 / ($active + $wired + $laundry + $buffers + $cache + $free + $inactive)
+      units: %
+      every: 10s
+       warn: $this > (($status >= $WARNING)  ? (80) : (90))
+       crit: $this > (($status == $CRITICAL) ? (90) : (98))
+      delay: down 15m multiplier 1.5 max 1h
+    summary: System memory utilization
+       info: System memory utilization
+         to: sysadmin
 
-    alarm: ram_available
-       on: mem.available
-    class: Utilization
-     type: System
-component: Memory
-       os: freebsd
-    hosts: *
-     calc: $avail * 100 / ($system.ram.free + $system.ram.active + $system.ram.inactive + $system.ram.wired + $system.ram.cache + $system.ram.laundry + $system.ram.buffers)
-    units: %
-    every: 10s
-     warn: $this < (($status >= $WARNING)  ? (15) : (10))
-    delay: down 15m multiplier 1.5 max 1h
-  summary: System available memory
-     info: Percentage of estimated amount of RAM available for userspace processes, without causing swapping
-       to: silent
+      alarm: ram_available
+         on: mem.available
+      class: Utilization
+       type: System
+  component: Memory
+host labels: _os=freebsd
+       calc: $avail * 100 / ($system.ram.free + $system.ram.active + $system.ram.inactive + $system.ram.wired + $system.ram.cache + $system.ram.laundry + $system.ram.buffers)
+      units: %
+      every: 10s
+       warn: $this < (($status >= $WARNING)  ? (15) : (10))
+      delay: down 15m multiplier 1.5 max 1h
+    summary: System available memory
+       info: Percentage of estimated amount of RAM available for userspace processes, without causing swapping
+         to: silent

--- a/src/health/health.d/softnet.conf
+++ b/src/health/health.d/softnet.conf
@@ -1,57 +1,53 @@
-
 # you can disable an alarm notification by setting the 'to' line to: silent
 
 # check for common /proc/net/softnet_stat errors
 
-    alarm: 1min_netdev_backlog_exceeded
-       on: system.softnet_stat
-    class: Errors
-     type: System
-component: Network
-       os: linux
-    hosts: *
-   lookup: average -1m unaligned absolute of dropped
-    units: packets
-    every: 10s
-     warn: $this > (($status >= $WARNING) ? (0) : (10))
-    delay: down 1h multiplier 1.5 max 2h
-  summary: System netdev dropped packets
-     info: Average number of dropped packets in the last minute \
-           due to exceeded net.core.netdev_max_backlog
-       to: silent
+      alarm: 1min_netdev_backlog_exceeded
+         on: system.softnet_stat
+      class: Errors
+       type: System
+  component: Network
+host labels: _os=linux
+     lookup: average -1m unaligned absolute of dropped
+      units: packets
+      every: 10s
+       warn: $this > (($status >= $WARNING) ? (0) : (10))
+      delay: down 1h multiplier 1.5 max 2h
+    summary: System netdev dropped packets
+       info: Average number of dropped packets in the last minute \
+             due to exceeded net.core.netdev_max_backlog
+         to: silent
 
-    alarm: 1min_netdev_budget_ran_outs
-       on: system.softnet_stat
-    class: Errors
-     type: System
-component: Network
-       os: linux
-    hosts: *
-   lookup: average -1m unaligned absolute of squeezed
-    units: events
-    every: 10s
-     warn: $this > (($status >= $WARNING) ? (0) : (10))
-    delay: down 1h multiplier 1.5 max 2h
-  summary: System netdev budget run outs
-     info: Average number of times ksoftirq ran out of sysctl net.core.netdev_budget or \
-           net.core.netdev_budget_usecs with work remaining over the last minute \
-           (this can be a cause for dropped packets)
-       to: silent
+      alarm: 1min_netdev_budget_ran_outs
+         on: system.softnet_stat
+      class: Errors
+       type: System
+  component: Network
+host labels: _os=linux
+     lookup: average -1m unaligned absolute of squeezed
+      units: events
+      every: 10s
+       warn: $this > (($status >= $WARNING) ? (0) : (10))
+      delay: down 1h multiplier 1.5 max 2h
+    summary: System netdev budget run outs
+       info: Average number of times ksoftirq ran out of sysctl net.core.netdev_budget or \
+             net.core.netdev_budget_usecs with work remaining over the last minute \
+             (this can be a cause for dropped packets)
+         to: silent
 
-    alarm: 10min_netisr_backlog_exceeded
-       on: system.softnet_stat
-    class: Errors
-     type: System
-component: Network
-       os: freebsd
-    hosts: *
-   lookup: average -1m unaligned absolute of qdrops
-    units: packets
-    every: 10s
-     warn: $this > (($status >= $WARNING) ? (0) : (10))
-    delay: down 1h multiplier 1.5 max 2h
-  summary: System netisr drops
-     info: Average number of drops in the last minute \
-           due to exceeded sysctl net.route.netisr_maxqlen \
-           (this can be a cause for dropped packets)
-       to: silent
+      alarm: 10min_netisr_backlog_exceeded
+         on: system.softnet_stat
+      class: Errors
+       type: System
+  component: Network
+host labels: _os=freebsd
+     lookup: average -1m unaligned absolute of qdrops
+      units: packets
+      every: 10s
+       warn: $this > (($status >= $WARNING) ? (0) : (10))
+      delay: down 1h multiplier 1.5 max 2h
+    summary: System netisr drops
+       info: Average number of drops in the last minute \
+             due to exceeded sysctl net.route.netisr_maxqlen \
+             (this can be a cause for dropped packets)
+         to: silent

--- a/src/health/health.d/swap.conf
+++ b/src/health/health.d/swap.conf
@@ -1,37 +1,34 @@
-
 # you can disable an alarm notification by setting the 'to' line to: silent
 
-    alarm: 30min_ram_swapped_out
-       on: mem.swapio
-    class: Workload
-     type: System
-component: Memory
-       os: linux freebsd
-    hosts: *
-   lookup: sum -30m unaligned absolute of out
-           # we have to convert KB to MB by dividing $this (i.e. the result of the lookup) with 1024
-     calc: $this / 1024 * 100 / ( $system.ram.used + $system.ram.cached + $system.ram.free )
-    units: % of RAM
-    every: 1m
-     warn: $this > (($status >= $WARNING)  ? (20) : (30))
-    delay: down 15m multiplier 1.5 max 1h
-  summary: System memory swapped out
-     info: Percentage of the system RAM swapped in the last 30 minutes
-       to: silent
+      alarm: 30min_ram_swapped_out
+         on: mem.swapio
+      class: Workload
+       type: System
+  component: Memory
+host labels: _os=linux freebsd
+     lookup: sum -30m unaligned absolute of out
+             # we have to convert KB to MB by dividing $this (i.e. the result of the lookup) with 1024
+       calc: $this / 1024 * 100 / ( $system.ram.used + $system.ram.cached + $system.ram.free )
+      units: % of RAM
+      every: 1m
+       warn: $this > (($status >= $WARNING)  ? (20) : (30))
+      delay: down 15m multiplier 1.5 max 1h
+    summary: System memory swapped out
+       info: Percentage of the system RAM swapped in the last 30 minutes
+         to: silent
 
-    alarm: used_swap
-       on: mem.swap
-    class: Utilization
-     type: System
-component: Memory
-       os: linux freebsd
-    hosts: *
-     calc: (($used + $free) > 0) ? ($used * 100 / ($used + $free)) : 0
-    units: %
-    every: 10s
-     warn: $this > (($status >= $WARNING)  ? (80) : (90))
-     crit: $this > (($status == $CRITICAL) ? (90) : (98))
-    delay: up 30s down 15m multiplier 1.5 max 1h
-  summary: System swap memory utilization
-     info: Swap memory utilization
-       to: sysadmin
+      alarm: used_swap
+         on: mem.swap
+      class: Utilization
+       type: System
+  component: Memory
+host labels: _os=linux freebsd
+       calc: (($used + $free) > 0) ? ($used * 100 / ($used + $free)) : 0
+      units: %
+      every: 10s
+       warn: $this > (($status >= $WARNING)  ? (80) : (90))
+       crit: $this > (($status == $CRITICAL) ? (90) : (98))
+      delay: up 30s down 15m multiplier 1.5 max 1h
+    summary: System swap memory utilization
+       info: Swap memory utilization
+         to: sysadmin

--- a/src/health/health.d/synchronization.conf
+++ b/src/health/health.d/synchronization.conf
@@ -2,7 +2,6 @@
       on: mem.sync
   lookup: sum -1m of sync
    units: calls
-  plugin: ebpf.plugin
    every: 1m
     warn: $this > 6
    delay: up 1m down 10m multiplier 1.5 max 1h

--- a/src/health/health.d/systemdunits.conf
+++ b/src/health/health.d/systemdunits.conf
@@ -1,177 +1,177 @@
 # you can disable an alarm notification by setting the 'to' line to: silent
 
 ## Service units
- template: systemd_service_unit_failed_state
-       on: systemd.service_unit_state
-    class: Errors
-     type: Linux
-component: Systemd units
-   module: !* *
-     calc: $failed
-    units: state
-    every: 10s
-     warn: $this != nan AND $this == 1
-    delay: down 5m multiplier 1.5 max 1h
-  summary: systemd unit ${label:unit_name} state
-     info: systemd service unit in the failed state
-       to: sysadmin
+    template: systemd_service_unit_failed_state
+          on: systemd.service_unit_state
+       class: Errors
+        type: Linux
+   component: Systemd units
+chart labels: unit_name=!*
+        calc: $failed
+       units: state
+       every: 10s
+        warn: $this != nan AND $this == 1
+       delay: down 5m multiplier 1.5 max 1h
+     summary: systemd unit ${label:unit_name} state
+        info: systemd service unit in the failed state
+          to: sysadmin
 
 ## Socket units
- template: systemd_socket_unit_failed_state
-       on: systemd.socket_unit_state
-    class: Errors
-     type: Linux
-component: Systemd units
-   module: !* *
-     calc: $failed
-    units: state
-    every: 10s
-     warn: $this != nan AND $this == 1
-    delay: down 5m multiplier 1.5 max 1h
-  summary: systemd unit ${label:unit_name} state
-     info: systemd socket unit in the failed state
-       to: sysadmin
+    template: systemd_socket_unit_failed_state
+          on: systemd.socket_unit_state
+       class: Errors
+        type: Linux
+   component: Systemd units
+chart labels: unit_name=!*
+        calc: $failed
+       units: state
+       every: 10s
+        warn: $this != nan AND $this == 1
+       delay: down 5m multiplier 1.5 max 1h
+     summary: systemd unit ${label:unit_name} state
+        info: systemd socket unit in the failed state
+          to: sysadmin
 
 ## Target units
- template: systemd_target_unit_failed_state
-       on: systemd.target_unit_state
-    class: Errors
-     type: Linux
-component: Systemd units
-   module: !* *
-     calc: $failed
-    units: state
-    every: 10s
-     warn: $this != nan AND $this == 1
-    delay: down 5m multiplier 1.5 max 1h
-  summary: systemd unit ${label:unit_name} state
-     info: systemd target unit in the failed state
-       to: sysadmin
+    template: systemd_target_unit_failed_state
+          on: systemd.target_unit_state
+       class: Errors
+        type: Linux
+   component: Systemd units
+chart labels: unit_name=!*
+        calc: $failed
+       units: state
+       every: 10s
+        warn: $this != nan AND $this == 1
+       delay: down 5m multiplier 1.5 max 1h
+     summary: systemd unit ${label:unit_name} state
+        info: systemd target unit in the failed state
+          to: sysadmin
 
 ## Path units
- template: systemd_path_unit_failed_state
-       on: systemd.path_unit_state
-    class: Errors
-     type: Linux
-component: Systemd units
-   module: !* *
-     calc: $failed
-    units: state
-    every: 10s
-     warn: $this != nan AND $this == 1
-    delay: down 5m multiplier 1.5 max 1h
-  summary: systemd unit ${label:unit_name} state
-     info: systemd path unit in the failed state
-       to: sysadmin
+    template: systemd_path_unit_failed_state
+          on: systemd.path_unit_state
+       class: Errors
+        type: Linux
+   component: Systemd units
+chart labels: unit_name=!*
+        calc: $failed
+       units: state
+       every: 10s
+        warn: $this != nan AND $this == 1
+       delay: down 5m multiplier 1.5 max 1h
+     summary: systemd unit ${label:unit_name} state
+        info: systemd path unit in the failed state
+          to: sysadmin
 
 ## Device units
- template: systemd_device_unit_failed_state
-       on: systemd.device_unit_state
-    class: Errors
-     type: Linux
-component: Systemd units
-   module: !* *
-     calc: $failed
-    units: state
-    every: 10s
-     warn: $this != nan AND $this == 1
-    delay: down 5m multiplier 1.5 max 1h
-  summary: systemd unit ${label:unit_name} state
-     info: systemd device unit in the failed state
-       to: sysadmin
+    template: systemd_device_unit_failed_state
+          on: systemd.device_unit_state
+       class: Errors
+        type: Linux
+   component: Systemd units
+chart labels: unit_name=!*
+        calc: $failed
+       units: state
+       every: 10s
+        warn: $this != nan AND $this == 1
+       delay: down 5m multiplier 1.5 max 1h
+     summary: systemd unit ${label:unit_name} state
+        info: systemd device unit in the failed state
+          to: sysadmin
 
 ## Mount units
- template: systemd_mount_unit_failed_state
-       on: systemd.mount_unit_state
-    class: Errors
-     type: Linux
-component: Systemd units
-   module: !* *
-     calc: $failed
-    units: state
-    every: 10s
-     warn: $this != nan AND $this == 1
-    delay: down 5m multiplier 1.5 max 1h
-  summary: systemd unit ${label:unit_name} state
-     info: systemd mount units in the failed state
-       to: sysadmin
+    template: systemd_mount_unit_failed_state
+          on: systemd.mount_unit_state
+       class: Errors
+        type: Linux
+   component: Systemd units
+chart labels: unit_name=!*
+        calc: $failed
+       units: state
+       every: 10s
+        warn: $this != nan AND $this == 1
+       delay: down 5m multiplier 1.5 max 1h
+     summary: systemd unit ${label:unit_name} state
+        info: systemd mount units in the failed state
+          to: sysadmin
 
 ## Automount units
- template: systemd_automount_unit_failed_state
-       on: systemd.automount_unit_state
-    class: Errors
-     type: Linux
-component: Systemd units
-   module: !* *
-     calc: $failed
-    units: state
-    every: 10s
-     warn: $this != nan AND $this == 1
-    delay: down 5m multiplier 1.5 max 1h
-  summary: systemd unit ${label:unit_name} state
-     info: systemd automount unit in the failed state
-       to: sysadmin
+    template: systemd_automount_unit_failed_state
+          on: systemd.automount_unit_state
+       class: Errors
+        type: Linux
+   component: Systemd units
+chart labels: unit_name=!*
+        calc: $failed
+       units: state
+       every: 10s
+        warn: $this != nan AND $this == 1
+       delay: down 5m multiplier 1.5 max 1h
+     summary: systemd unit ${label:unit_name} state
+        info: systemd automount unit in the failed state
+          to: sysadmin
 
 ## Swap units
- template: systemd_swap_unit_failed_state
-       on: systemd.swap_unit_state
-    class: Errors
-     type: Linux
-component: Systemd units
-   module: !* *
-     calc: $failed
-    units: state
-    every: 10s
-     warn: $this != nan AND $this == 1
-    delay: down 5m multiplier 1.5 max 1h
-  summary: systemd unit ${label:unit_name} state
-     info: systemd swap units in the failed state
-       to: sysadmin
+    template: systemd_swap_unit_failed_state
+          on: systemd.swap_unit_state
+       class: Errors
+        type: Linux
+   component: Systemd units
+chart labels: unit_name=!*
+        calc: $failed
+       units: state
+       every: 10s
+        warn: $this != nan AND $this == 1
+       delay: down 5m multiplier 1.5 max 1h
+     summary: systemd unit ${label:unit_name} state
+        info: systemd swap units in the failed state
+          to: sysadmin
 
 ## Scope units
- template: systemd_scope_unit_failed_state
-       on: systemd.scope_unit_state
-    class: Errors
-     type: Linux
-component: Systemd units
-   module: !* *
-     calc: $failed
-    units: state
-    every: 10s
-     warn: $this != nan AND $this == 1
-    delay: down 5m multiplier 1.5 max 1h
-  summary: systemd unit ${label:unit_name} state
-     info: systemd scope units in the failed state
-       to: sysadmin
+    template: systemd_scope_unit_failed_state
+          on: systemd.scope_unit_state
+       class: Errors
+        type: Linux
+   component: Systemd units
+chart labels: unit_name=!*
+        calc: $failed
+       units: state
+       every: 10s
+        warn: $this != nan AND $this == 1
+       delay: down 5m multiplier 1.5 max 1h
+     summary: systemd unit ${label:unit_name} state
+        info: systemd scope units in the failed state
+          to: sysadmin
 
 ## Slice units
- template: systemd_slice_unit_failed_state
-       on: systemd.slice_unit_state
-    class: Errors
-     type: Linux
-component: Systemd units
-   module: !* *
-     calc: $failed
-    units: state
-    every: 10s
-     warn: $this != nan AND $this == 1
-    delay: down 5m multiplier 1.5 max 1h
-  summary: systemd unit ${label:unit_name} state
-     info: systemd slice units in the failed state
-       to: sysadmin
+    template: systemd_slice_unit_failed_state
+          on: systemd.slice_unit_state
+       class: Errors
+        type: Linux
+   component: Systemd units
+chart labels: unit_name=!*
+        calc: $failed
+       units: state
+       every: 10s
+        warn: $this != nan AND $this == 1
+       delay: down 5m multiplier 1.5 max 1h
+     summary: systemd unit ${label:unit_name} state
+        info: systemd slice units in the failed state
+          to: sysadmin
 
 ## Timer units
- template: systemd_timer_unit_failed_state
-       on: systemd.timer_unit_state
-    class: Errors
-     type: Linux
-component: Systemd units
-   module: !* *
-     calc: $failed
-    units: state
-    every: 10s
-     warn: $this != nan AND $this == 1
-    delay: down 5m multiplier 1.5 max 1h
-  summary: systemd unit ${label:unit_name} state
-     info: systemd timer unit in the failed state
-       to: sysadmin
+    template: systemd_timer_unit_failed_state
+          on: systemd.timer_unit_state
+       class: Errors
+        type: Linux
+   component: Systemd units
+chart labels: unit_name=!*
+        calc: $failed
+       units: state
+       every: 10s
+        warn: $this != nan AND $this == 1
+       delay: down 5m multiplier 1.5 max 1h
+     summary: systemd unit ${label:unit_name} state
+        info: systemd timer unit in the failed state
+          to: sysadmin

--- a/src/health/health.d/tcp_conn.conf
+++ b/src/health/health.d/tcp_conn.conf
@@ -1,23 +1,21 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
 
-#
 # ${tcp_max_connections} may be nan or -1 if the system
 # supports dynamic threshold for TCP connections.
 # In this case, the alarm will always be zero.
-#
 
-    alarm: tcp_connections
-       on: ip.tcpsock
-    class: Workload
-     type: System
-component: Network
-       os: linux
-    hosts: *
-     calc: (${tcp_max_connections} > 0) ? ( ${connections} * 100 / ${tcp_max_connections} ) : 0
-    units: %
-    every: 10s
-     warn: $this > (($status >= $WARNING ) ? ( 60 ) : ( 80 ))
-     crit: $this > (($status == $CRITICAL) ? ( 80 ) : ( 90 ))
-    delay: up 0 down 5m multiplier 1.5 max 1h
-  summary: System TCP connections utilization
-     info: IPv4 TCP connections utilization
-       to: sysadmin
+      alarm: tcp_connections
+         on: ip.tcpsock
+      class: Workload
+       type: System
+  component: Network
+host labels: _os=linux
+       calc: (${tcp_max_connections} > 0) ? ( ${connections} * 100 / ${tcp_max_connections} ) : 0
+      units: %
+      every: 10s
+       warn: $this > (($status >= $WARNING ) ? ( 60 ) : ( 80 ))
+       crit: $this > (($status == $CRITICAL) ? ( 80 ) : ( 90 ))
+      delay: up 0 down 5m multiplier 1.5 max 1h
+    summary: System TCP connections utilization
+       info: IPv4 TCP connections utilization
+         to: sysadmin

--- a/src/health/health.d/tcp_listen.conf
+++ b/src/health/health.d/tcp_listen.conf
@@ -1,4 +1,3 @@
-#
 # There are two queues involved when incoming TCP connections are handled
 # (both at the kernel):
 #
@@ -18,42 +17,39 @@
 # -----------------------------------------------------------------------------
 # tcp accept queue (at the kernel)
 
-    alarm: 1m_tcp_accept_queue_overflows
-       on: ip.tcp_accept_queue
-    class: Workload
-     type: System
-component: Network
-       os: linux
-    hosts: *
-   lookup: average -60s unaligned absolute of ListenOverflows
-    units: overflows
-    every: 10s
-     warn: $this > 1
-     crit: $this > (($status == $CRITICAL) ? (1) : (5))
-    delay: up 0 down 5m multiplier 1.5 max 1h
-  summary: System TCP accept queue overflows
-     info: Average number of overflows in the TCP accept queue over the last minute
-       to: silent
+      alarm: 1m_tcp_accept_queue_overflows
+         on: ip.tcp_accept_queue
+      class: Workload
+       type: System
+  component: Network
+host labels: _os=linux
+     lookup: average -60s unaligned absolute of ListenOverflows
+      units: overflows
+      every: 10s
+       warn: $this > 1
+       crit: $this > (($status == $CRITICAL) ? (1) : (5))
+      delay: up 0 down 5m multiplier 1.5 max 1h
+    summary: System TCP accept queue overflows
+       info: Average number of overflows in the TCP accept queue over the last minute
+         to: silent
 
 # THIS IS TOO GENERIC
 # CHECK: https://github.com/netdata/netdata/issues/3234#issuecomment-423935842
-    alarm: 1m_tcp_accept_queue_drops
-       on: ip.tcp_accept_queue
-    class: Workload
-     type: System
-component: Network
-       os: linux
-    hosts: *
-   lookup: average -60s unaligned absolute of ListenDrops
-    units: drops
-    every: 10s
-     warn: $this > 1
-     crit: $this > (($status == $CRITICAL) ? (1) : (5))
-    delay: up 0 down 5m multiplier 1.5 max 1h
-  summary: System TCP accept queue dropped packets
-     info: Average number of dropped packets in the TCP accept queue over the last minute
-       to: silent
-
+      alarm: 1m_tcp_accept_queue_drops
+         on: ip.tcp_accept_queue
+      class: Workload
+       type: System
+  component: Network
+host labels: _os=linux
+     lookup: average -60s unaligned absolute of ListenDrops
+      units: drops
+      every: 10s
+       warn: $this > 1
+       crit: $this > (($status == $CRITICAL) ? (1) : (5))
+      delay: up 0 down 5m multiplier 1.5 max 1h
+    summary: System TCP accept queue dropped packets
+       info: Average number of dropped packets in the TCP accept queue over the last minute
+         to: silent
 
 # -----------------------------------------------------------------------------
 # tcp SYN queue (at the kernel)
@@ -63,38 +59,35 @@ component: Network
 # enabled or not. In both cases this probably indicates a SYN flood attack,
 # so i guess a notification should be sent.
 
-    alarm: 1m_tcp_syn_queue_drops
-       on: ip.tcp_syn_queue
-    class: Workload
-     type: System
-component: Network
-       os: linux
-    hosts: *
-   lookup: average -60s unaligned absolute of TCPReqQFullDrop
-    units: drops
-    every: 10s
-     warn: $this > 1
-     crit: $this > (($status == $CRITICAL) ? (0) : (5))
-    delay: up 10 down 5m multiplier 1.5 max 1h
-  summary: System  TCP SYN queue drops
-     info: Average number of SYN requests was dropped due to the full TCP SYN queue over the last minute \
-           (SYN cookies were not enabled)
-       to: silent
+      alarm: 1m_tcp_syn_queue_drops
+         on: ip.tcp_syn_queue
+      class: Workload
+       type: System
+  component: Network
+host labels: _os=linux
+     lookup: average -60s unaligned absolute of TCPReqQFullDrop
+      units: drops
+      every: 10s
+       warn: $this > 1
+       crit: $this > (($status == $CRITICAL) ? (0) : (5))
+      delay: up 10 down 5m multiplier 1.5 max 1h
+    summary: System  TCP SYN queue drops
+       info: Average number of SYN requests was dropped due to the full TCP SYN queue over the last minute \
+             (SYN cookies were not enabled)
+         to: silent
 
-    alarm: 1m_tcp_syn_queue_cookies
-       on: ip.tcp_syn_queue
-    class: Workload
-     type: System
-component: Network
-       os: linux
-    hosts: *
-   lookup: average -60s unaligned absolute of TCPReqQFullDoCookies
-    units: cookies
-    every: 10s
-     warn: $this > 1
-     crit: $this > (($status == $CRITICAL) ? (0) : (5))
-    delay: up 10 down 5m multiplier 1.5 max 1h
-  summary: System TCP SYN queue cookies
-     info: Average number of sent SYN cookies due to the full TCP SYN queue over the last minute
-       to: silent
-
+      alarm: 1m_tcp_syn_queue_cookies
+         on: ip.tcp_syn_queue
+      class: Workload
+       type: System
+  component: Network
+host labels: _os=linux
+     lookup: average -60s unaligned absolute of TCPReqQFullDoCookies
+      units: cookies
+      every: 10s
+       warn: $this > 1
+       crit: $this > (($status == $CRITICAL) ? (0) : (5))
+      delay: up 10 down 5m multiplier 1.5 max 1h
+    summary: System TCP SYN queue cookies
+       info: Average number of sent SYN cookies due to the full TCP SYN queue over the last minute
+         to: silent

--- a/src/health/health.d/tcp_mem.conf
+++ b/src/health/health.d/tcp_mem.conf
@@ -1,4 +1,3 @@
-#
 # check
 # http://blog.tsunanet.net/2011/03/out-of-socket-memory.html
 #
@@ -6,19 +5,18 @@
 # and a critical when TCP is 90% of its upper memory limit
 #
 
-    alarm: tcp_memory
-       on: ipv4.sockstat_tcp_mem
-    class: Utilization
-     type: System
-component: Network
-       os: linux
-    hosts: *
-     calc: ${mem} * 100 / ${tcp_mem_high}
-    units: %
-    every: 10s
-     warn: ${mem} > (($status >= $WARNING  ) ? ( ${tcp_mem_pressure} * 0.8 ) : ( ${tcp_mem_pressure}   ))
-     crit: ${mem} > (($status == $CRITICAL ) ? ( ${tcp_mem_pressure}       ) : ( ${tcp_mem_high} * 0.9 ))
-    delay: up 0 down 5m multiplier 1.5 max 1h
-  summary: System TCP memory utilization
-     info: TCP memory utilization
-       to: silent
+      alarm: tcp_memory
+         on: ipv4.sockstat_tcp_mem
+      class: Utilization
+       type: System
+  component: Network
+host labels: _os=linux
+       calc: ${mem} * 100 / ${tcp_mem_high}
+      units: %
+      every: 10s
+       warn: ${mem} > (($status >= $WARNING  ) ? ( ${tcp_mem_pressure} * 0.8 ) : ( ${tcp_mem_pressure}   ))
+       crit: ${mem} > (($status == $CRITICAL ) ? ( ${tcp_mem_pressure}       ) : ( ${tcp_mem_high} * 0.9 ))
+      delay: up 0 down 5m multiplier 1.5 max 1h
+    summary: System TCP memory utilization
+       info: TCP memory utilization
+         to: silent

--- a/src/health/health.d/tcp_orphans.conf
+++ b/src/health/health.d/tcp_orphans.conf
@@ -1,5 +1,3 @@
-
-#
 # check
 # http://blog.tsunanet.net/2011/03/out-of-socket-memory.html
 #
@@ -7,19 +5,18 @@
 # so we alarm warning at 25% and critical at 50%
 #
 
-    alarm: tcp_orphans
-       on: ipv4.sockstat_tcp_sockets
-    class: Errors
-     type: System
-component: Network
-       os: linux
-    hosts: *
-     calc: ${orphan} * 100 / ${tcp_max_orphans}
-    units: %
-    every: 10s
-     warn: $this > (($status >= $WARNING ) ? ( 20 ) : ( 25 ))
-     crit: $this > (($status == $CRITICAL) ? ( 25 ) : ( 50 ))
-    delay: up 0 down 5m multiplier 1.5 max 1h
-  summary: System TCP orphan sockets utilization
-     info: Orphan IPv4 TCP sockets utilization
-       to: silent
+      alarm: tcp_orphans
+         on: ipv4.sockstat_tcp_sockets
+      class: Errors
+       type: System
+  component: Network
+host labels: _os=linux
+       calc: ${orphan} * 100 / ${tcp_max_orphans}
+      units: %
+      every: 10s
+       warn: $this > (($status >= $WARNING ) ? ( 20 ) : ( 25 ))
+       crit: $this > (($status == $CRITICAL) ? ( 25 ) : ( 50 ))
+      delay: up 0 down 5m multiplier 1.5 max 1h
+    summary: System TCP orphan sockets utilization
+       info: Orphan IPv4 TCP sockets utilization
+         to: silent

--- a/src/health/health.d/tcp_resets.conf
+++ b/src/health/health.d/tcp_resets.conf
@@ -1,71 +1,66 @@
-
 # you can disable an alarm notification by setting the 'to' line to: silent
 
 # -----------------------------------------------------------------------------
 # tcp resets this host sends
 
-    alarm: 1m_ip_tcp_resets_sent
-       on: ip.tcphandshake
-    class: Errors
-     type: System
-component: Network
-       os: linux
-    hosts: *
-   lookup: average -1m at -10s unaligned absolute of OutRsts
-    units: tcp resets/s
-    every: 10s
-     info: average number of sent TCP RESETS over the last minute
+      alarm: 1m_ip_tcp_resets_sent
+         on: ip.tcphandshake
+      class: Errors
+       type: System
+  component: Network
+host labels: _os=linux
+     lookup: average -1m at -10s unaligned absolute of OutRsts
+      units: tcp resets/s
+      every: 10s
+       info: average number of sent TCP RESETS over the last minute
 
-    alarm: 10s_ip_tcp_resets_sent
-       on: ip.tcphandshake
-    class: Errors
-     type: System
-component: Network
-       os: linux
-    hosts: *
-   lookup: average -10s unaligned absolute of OutRsts
-    units: tcp resets/s
-    every: 10s
-     warn: $netdata.uptime.uptime > (1 * 60) AND $this > ((($1m_ip_tcp_resets_sent < 5)?(5):($1m_ip_tcp_resets_sent)) * (($status >= $WARNING)  ? (1) : (10)))
-    delay: up 20s down 60m multiplier 1.2 max 2h
-  options: no-clear-notification
-  summary: System TCP outbound resets
-     info: Average number of sent TCP RESETS over the last 10 seconds. \
-           This can indicate a port scan, \
-           or that a service running on this host has crashed. \
-           Netdata will not send a clear notification for this alarm.
-       to: silent
+      alarm: 10s_ip_tcp_resets_sent
+         on: ip.tcphandshake
+      class: Errors
+       type: System
+  component: Network
+host labels: _os=linux
+     lookup: average -10s unaligned absolute of OutRsts
+      units: tcp resets/s
+      every: 10s
+       warn: $netdata.uptime.uptime > (1 * 60) AND $this > ((($1m_ip_tcp_resets_sent < 5)?(5):($1m_ip_tcp_resets_sent)) * (($status >= $WARNING)  ? (1) : (10)))
+      delay: up 20s down 60m multiplier 1.2 max 2h
+    options: no-clear-notification
+    summary: System TCP outbound resets
+       info: Average number of sent TCP RESETS over the last 10 seconds. \
+             This can indicate a port scan, \
+             or that a service running on this host has crashed. \
+             Netdata will not send a clear notification for this alarm.
+         to: silent
 
 # -----------------------------------------------------------------------------
 # tcp resets this host receives
 
-    alarm: 1m_ip_tcp_resets_received
-       on: ip.tcphandshake
-    class: Errors
-     type: System
-component: Network
-       os: linux freebsd
-    hosts: *
-   lookup: average -1m at -10s unaligned absolute of AttemptFails
-    units: tcp resets/s
-    every: 10s
-     info: average number of received TCP RESETS over the last minute
+      alarm: 1m_ip_tcp_resets_received
+         on: ip.tcphandshake
+      class: Errors
+       type: System
+  component: Network
+host labels: _os=linux freebsd
+     lookup: average -1m at -10s unaligned absolute of AttemptFails
+      units: tcp resets/s
+      every: 10s
+       info: average number of received TCP RESETS over the last minute
 
-    alarm: 10s_ip_tcp_resets_received
-       on: ip.tcphandshake
-    class: Errors
-     type: System
-component: Network
-       os: linux freebsd
-    hosts: *
-   lookup: average -10s unaligned absolute of AttemptFails
-    units: tcp resets/s
-    every: 10s
-     warn: $netdata.uptime.uptime > (1 * 60) AND $this > ((($1m_ip_tcp_resets_received < 5)?(5):($1m_ip_tcp_resets_received)) * (($status >= $WARNING)  ? (1) : (10)))
-    delay: up 20s down 60m multiplier 1.2 max 2h
-  options: no-clear-notification
-  summary: System TCP inbound resets
-     info: average number of received TCP RESETS over the last 10 seconds. \
-           This can be an indication that a service this host needs has crashed. \
-           Netdata will not send a clear notification for this alarm.
-       to: silent
+      alarm: 10s_ip_tcp_resets_received
+         on: ip.tcphandshake
+      class: Errors
+       type: System
+  component: Network
+host labels: _os=linux freebsd
+     lookup: average -10s unaligned absolute of AttemptFails
+      units: tcp resets/s
+      every: 10s
+       warn: $netdata.uptime.uptime > (1 * 60) AND $this > ((($1m_ip_tcp_resets_received < 5)?(5):($1m_ip_tcp_resets_received)) * (($status >= $WARNING)  ? (1) : (10)))
+      delay: up 20s down 60m multiplier 1.2 max 2h
+    options: no-clear-notification
+    summary: System TCP inbound resets
+       info: average number of received TCP RESETS over the last 10 seconds. \
+             This can be an indication that a service this host needs has crashed. \
+             Netdata will not send a clear notification for this alarm.
+         to: silent

--- a/src/health/health.d/timex.conf
+++ b/src/health/health.d/timex.conf
@@ -1,18 +1,17 @@
-
 # It can take several minutes before ntpd selects a server to synchronize with;
 # try checking after 17 minutes (1024 seconds).
 
-    alarm: system_clock_sync_state
-       on: system.clock_sync_state
-       os: linux
-    class: Errors
-     type: System
-component: Clock
-     calc: $state
-    units: synchronization state
-    every: 10s
-     warn: $system.uptime.uptime > 17 * 60 AND $this == 0
-    delay: down 5m
-  summary: System clock sync state
-     info: When set to 0, the system kernel believes the system clock is not properly synchronized to a reliable server
-       to: silent
+      alarm: system_clock_sync_state
+         on: system.clock_sync_state
+      class: Errors
+       type: System
+  component: Clock
+host labels: _os=linux
+       calc: $state
+      units: synchronization state
+      every: 10s
+       warn: $system.uptime.uptime > 17 * 60 AND $this == 0
+      delay: down 5m
+    summary: System clock sync state
+       info: When set to 0, the system kernel believes the system clock is not properly synchronized to a reliable server
+         to: silent

--- a/src/health/health.d/udp_errors.conf
+++ b/src/health/health.d/udp_errors.conf
@@ -1,40 +1,37 @@
-
 # you can disable an alarm notification by setting the 'to' line to: silent
 
 # -----------------------------------------------------------------------------
 # UDP receive buffer errors
 
-    alarm: 1m_ipv4_udp_receive_buffer_errors
-       on: ipv4.udperrors
-    class: Errors
-     type: System
-component: Network
-       os: linux freebsd
-    hosts: *
-   lookup: average -1m unaligned absolute of RcvbufErrors
-    units: errors
-    every: 10s
-     warn: $this > (($status >= $WARNING) ? (0) : (10))
-  summary: System UDP receive buffer errors
-     info: Average number of UDP receive buffer errors over the last minute
-    delay: up 1m down 60m multiplier 1.2 max 2h
-       to: silent
+      alarm: 1m_ipv4_udp_receive_buffer_errors
+         on: ipv4.udperrors
+      class: Errors
+       type: System
+  component: Network
+host labels: _os=linux freebsd
+     lookup: average -1m unaligned absolute of RcvbufErrors
+      units: errors
+      every: 10s
+       warn: $this > (($status >= $WARNING) ? (0) : (10))
+    summary: System UDP receive buffer errors
+       info: Average number of UDP receive buffer errors over the last minute
+      delay: up 1m down 60m multiplier 1.2 max 2h
+         to: silent
 
 # -----------------------------------------------------------------------------
 # UDP send buffer errors
 
-    alarm: 1m_ipv4_udp_send_buffer_errors
-       on: ipv4.udperrors
-    class: Errors
-     type: System
-component: Network
-       os: linux
-    hosts: *
-   lookup: average -1m unaligned absolute of SndbufErrors
-    units: errors
-    every: 10s
-     warn: $this > (($status >= $WARNING) ? (0) : (10))
-  summary: System UDP send buffer errors
-     info: Average number of UDP send buffer errors over the last minute
-    delay: up 1m down 60m multiplier 1.2 max 2h
-       to: silent
+      alarm: 1m_ipv4_udp_send_buffer_errors
+         on: ipv4.udperrors
+      class: Errors
+       type: System
+  component: Network
+host labels: _os=linux
+     lookup: average -1m unaligned absolute of SndbufErrors
+      units: errors
+      every: 10s
+       warn: $this > (($status >= $WARNING) ? (0) : (10))
+    summary: System UDP send buffer errors
+       info: Average number of UDP send buffer errors over the last minute
+      delay: up 1m down 60m multiplier 1.2 max 2h
+         to: silent

--- a/src/health/health.d/upsd.conf
+++ b/src/health/health.d/upsd.conf
@@ -5,8 +5,6 @@
     class: Utilization
      type: Power Supply
 component: UPS
-       os: *
-    hosts: *
    lookup: average -10m unaligned of load
     units: %
     every: 1m
@@ -22,8 +20,6 @@ component: UPS
     class: Errors
      type: Power Supply
 component: UPS
-       os: *
-    hosts: *
    lookup: average -60s unaligned of charge
     units: %
     every: 60s

--- a/src/health/health.d/vsphere.conf
+++ b/src/health/health.d/vsphere.conf
@@ -8,7 +8,6 @@
     class: Utilization
      type: Virtual Machine
 component: CPU
-    hosts: *
    lookup: average -10m unaligned match-names of used
     units: %
     every: 20s
@@ -24,7 +23,6 @@ component: CPU
     class: Utilization
      type: Virtual Machine
 component: Memory
-    hosts: *
      calc: $used
     units: %
     every: 20s
@@ -42,7 +40,6 @@ component: Memory
     class: Utilization
      type: Virtual Machine
 component: CPU
-    hosts: *
    lookup: average -10m unaligned match-names of used
     units: %
     every: 20s
@@ -58,7 +55,6 @@ component: CPU
     class: Utilization
      type: Virtual Machine
 component: Memory
-    hosts: *
      calc: $used
     units: %
     every: 20s

--- a/src/health/health.d/windows.conf
+++ b/src/health/health.d/windows.conf
@@ -1,4 +1,3 @@
-
 ## CPU
 
  template: windows_10min_cpu_usage
@@ -6,8 +5,6 @@
     class: Utilization
      type: Windows
 component: CPU
-       os: *
-    hosts: *
    lookup: average -10m unaligned match-names of dpc,user,privileged,interrupt
     units: %
     every: 1m
@@ -18,7 +15,6 @@ component: CPU
      info: Average CPU utilization over the last 10 minutes
        to: silent
 
-
 ## Memory
 
  template: windows_ram_in_use
@@ -26,8 +22,6 @@ component: CPU
     class: Utilization
      type: Windows
 component: Memory
-       os: *
-    hosts: *
      calc: ($used) * 100 / ($used + $available)
     units: %
     every: 10s
@@ -38,7 +32,6 @@ component: Memory
      info: Memory utilization
        to: sysadmin
 
-
 ## Network
 
  template: windows_inbound_packets_discarded
@@ -46,8 +39,6 @@ component: Memory
     class: Errors
      type: Windows
 component: Network
-       os: *
-    hosts: *
    lookup: sum -10m unaligned absolute match-names of inbound
     units: packets
     every: 1m
@@ -62,8 +53,6 @@ component: Network
     class: Errors
      type: Windows
 component: Network
-       os: *
-    hosts: *
    lookup: sum -10m unaligned absolute match-names of outbound
     units: packets
     every: 1m
@@ -78,8 +67,6 @@ component: Network
     class: Errors
      type: Windows
 component: Network
-       os: *
-    hosts: *
    lookup: sum -10m unaligned absolute match-names of inbound
     units: packets
     every: 1m
@@ -94,8 +81,6 @@ component: Network
     class: Errors
      type: Windows
 component: Network
-       os: *
-    hosts: *
    lookup: sum -10m unaligned absolute match-names of outbound
     units: packets
     every: 1m
@@ -105,7 +90,6 @@ component: Network
      info: Number of outbound errors for the network interface in the last 10 minutes
        to: silent
 
-
 ## Disk
 
  template: windows_disk_in_use
@@ -113,8 +97,6 @@ component: Network
     class: Utilization
      type: Windows
 component: Disk
-       os: *
-    hosts: *
      calc: ($used) * 100 / ($used + $free)
     units: %
     every: 10s


### PR DESCRIPTION
##### Summary

Follow-up on #17048

health reference doc will be updated in a separate PR.

Stock alerts:
 - remove `hosts: *`
 - replace `os: x` with `host labels: _os=x`

##### Test Plan

Install, and check loaded alerts.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
