### PR TITLE
fix discovered config default values

### DIFF
--- a/src/go/collectors/go.d.plugin/agent/discovery/manager.go
+++ b/src/go/collectors/go.d.plugin/agent/discovery/manager.go
@@ -101,6 +101,7 @@ func (m *Manager) registerDiscoverers(cfg Config) error {
 	}
 
 	if len(cfg.SD.ConfDir) != 0 {
+		cfg.SD.ConfigDefaults = cfg.Registry
 		d, err := sd.NewServiceDiscovery(cfg.SD)
 		if err != nil {
 			return err

--- a/src/go/collectors/go.d.plugin/agent/discovery/sd/pipeline/config.go
+++ b/src/go/collectors/go.d.plugin/agent/discovery/sd/pipeline/config.go
@@ -6,12 +6,15 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/netdata/netdata/go/go.d.plugin/agent/confgroup"
 	"github.com/netdata/netdata/go/go.d.plugin/agent/discovery/sd/discoverer/kubernetes"
 	"github.com/netdata/netdata/go/go.d.plugin/agent/discovery/sd/discoverer/netlisteners"
 )
 
 type Config struct {
-	Source   string               `yaml:"-"`
+	Source         string             `yaml:"-"`
+	ConfigDefaults confgroup.Registry `yaml:"-"`
+
 	Name     string               `yaml:"name"`
 	Discover []DiscoveryConfig    `yaml:"discover"`
 	Classify []ClassifyRuleConfig `yaml:"classify"`


### PR DESCRIPTION
##### Summary

Job charts created from discovered (local listeners) configs have priority 0 because default configuration settings are not applied. This PR fixes it.

##### Test Plan


Before

```
DBG jobmgr/manager.go:293 creating ntpd[local] job, config: map[__provider__:sd:net_listeners __source__:discoverer=net_listeners,host=localhost,file=/opt/netdata/usr/lib/netdata/conf.d/go.d/sd/net_listeners.conf __source_type__:discovered address:127.0.0.1:123 collect_peers:false module:ntpd name:local] component="job manager"
```

After

```
DBG jobmgr/manager.go:293 creating ntpd[local] job, config: map[__provider__:sd:net_listeners __source__:discoverer=net_listeners,host=localhost,file=/opt/netdata/usr/lib/netdata/conf.d/go.d/sd/net_listeners.conf __source_type__:discovered address:127.0.0.1:123 autodetection_retry:0 collect_peers:false module:ntpd name:local priority:70000 update_every:1] component="job manager
```

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
