### PR TITLE
Detect self thread when exiting.

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -680,8 +680,14 @@ void cancel_main_threads() {
         sleep_usec(step);
         found = 0;
         for (i = 0; static_threads[i].name != NULL ; i++) {
-            if (static_threads[i].enabled != NETDATA_MAIN_THREAD_EXITED)
-                found++;
+            if (static_threads[i].enabled == NETDATA_MAIN_THREAD_EXITED)
+                continue;
+
+            // Don't wait ourselves.
+            if (static_threads[i].thread && (*static_threads[i].thread == pthread_self()))
+                continue;
+
+            found++;
         }
     }
 


### PR DESCRIPTION
##### Summary

Skip waiting when a static thread causes the
agent to exit (eg. the service thread by calling
a fatal).

##### Test Plan

- Add a non-aborting fatal somewhere in the service thread. Check waiting times with/without this PR.
- CI jobs.