### PR TITLE
packaging: remove Suggests nut

### DIFF
--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -105,7 +105,7 @@ Conflicts: netdata (<< ${source:Version})
 Suggests: apcupsd, iw, sudo
 Description: The charts.d metrics collection plugin for the Netdata Agent
  This plugin adds a selection of additional collectors written in shell
- script to the Netdata Agent. It includes collectors for NUT, APCUPSD,
+ script to the Netdata Agent. It includes collectors for APCUPSD,
  LibreSWAN, OpenSIPS, and Wireless access point statistics.
 
 Package: netdata-plugin-ebpf

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -102,7 +102,7 @@ Depends: bash,
          netdata (= ${source:Version})
 Pre-Depends: adduser
 Conflicts: netdata (<< ${source:Version})
-Suggests: apcupsd, nut, iw, sudo
+Suggests: apcupsd, iw, sudo
 Description: The charts.d metrics collection plugin for the Netdata Agent
  This plugin adds a selection of additional collectors written in shell
  script to the Netdata Agent. It includes collectors for NUT, APCUPSD,

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -703,7 +703,6 @@ Requires: bash
 Requires: %{name} = %{version}
 Conflicts: %{name} < %{version}
 %if 0%{?centos_ver} != 7
-Suggests: nut
 Suggests: apcupsd
 Suggests: iw
 Suggests: sudo

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -710,7 +710,7 @@ Suggests: sudo
 
 %description plugin-chartsd
  This plugin adds a selection of additional collectors written in shell script to the Netdata Agent.
-It includes collectors for NUT, APCUPSD, LibreSWAN, OpenSIPS, and Wireless access point statistics.
+It includes collectors for APCUPSD, LibreSWAN, OpenSIPS, and Wireless access point statistics.
 
 %pre plugin-chartsd
 


### PR DESCRIPTION
##### Summary

`nut` is not needed. @netdata/agent-sre please check if I missed something, changes are based on `git grep`.

##### Test Plan

ci and @netdata/agent-sre review

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
