### PR TITLE
Add label for cgroup

### DIFF
--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -1267,7 +1267,7 @@ static void ebpf_create_specific_cachestat_charts(char *type, int update_every)
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5200,
                       ebpf_create_global_dimension,
                       cachestat_counter_publish_aggregated, 1, update_every, NETDATA_EBPF_MODULE_NAME_CACHESTAT);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_CACHESTAT_DIRTY_CHART,
@@ -1278,7 +1278,7 @@ static void ebpf_create_specific_cachestat_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &cachestat_counter_publish_aggregated[NETDATA_CACHESTAT_IDX_DIRTY], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_CACHESTAT);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_CACHESTAT_HIT_CHART,
@@ -1289,7 +1289,7 @@ static void ebpf_create_specific_cachestat_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &cachestat_counter_publish_aggregated[NETDATA_CACHESTAT_IDX_HIT], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_CACHESTAT);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_CACHESTAT_MISSES_CHART,
@@ -1300,7 +1300,7 @@ static void ebpf_create_specific_cachestat_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &cachestat_counter_publish_aggregated[NETDATA_CACHESTAT_IDX_MISS], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_CACHESTAT);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -895,7 +895,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20260,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION ratio '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 
@@ -911,7 +911,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20261,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION pages '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -926,7 +926,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20262,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION hits '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 
@@ -941,7 +941,7 @@ void ebpf_cachestat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20263,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_CACHESTAT);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION misses '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
         w->charts_created |= 1<<EBPF_MODULE_CACHESTAT_IDX;

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -1259,6 +1259,7 @@ static void ebpf_send_specific_cachestat_data(char *type, netdata_publish_caches
  */
 static void ebpf_create_specific_cachestat_charts(char *type, int update_every)
 {
+    char *label = (!strncmp(type, "cgroup_", 7)) ? &type[7] : type;
     ebpf_create_chart(type, NETDATA_CACHESTAT_HIT_RATIO_CHART,
                       "Hit ratio",
                       EBPF_COMMON_DIMENSION_PERCENTAGE, NETDATA_CACHESTAT_SUBMENU,
@@ -1266,6 +1267,8 @@ static void ebpf_create_specific_cachestat_charts(char *type, int update_every)
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5200,
                       ebpf_create_global_dimension,
                       cachestat_counter_publish_aggregated, 1, update_every, NETDATA_EBPF_MODULE_NAME_CACHESTAT);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_CACHESTAT_DIRTY_CHART,
                       "Number of dirty pages",
@@ -1275,6 +1278,8 @@ static void ebpf_create_specific_cachestat_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &cachestat_counter_publish_aggregated[NETDATA_CACHESTAT_IDX_DIRTY], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_CACHESTAT);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_CACHESTAT_HIT_CHART,
                       "Number of accessed files",
@@ -1284,6 +1289,8 @@ static void ebpf_create_specific_cachestat_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &cachestat_counter_publish_aggregated[NETDATA_CACHESTAT_IDX_HIT], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_CACHESTAT);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_CACHESTAT_MISSES_CHART,
                       "Files out of page cache",
@@ -1293,6 +1300,8 @@ static void ebpf_create_specific_cachestat_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &cachestat_counter_publish_aggregated[NETDATA_CACHESTAT_IDX_MISS], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_CACHESTAT);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 }
 
 /**

--- a/src/collectors/ebpf.plugin/ebpf_cgroup.c
+++ b/src/collectors/ebpf.plugin/ebpf_cgroup.c
@@ -340,7 +340,7 @@ void ebpf_create_charts_on_systemd(ebpf_systemd_args_t *chart)
                          chart->order,
                          chart->update_every,
                          chart->module);
-    ebpf_create_chart_labels("service_name", chart->id, 0);
+    ebpf_create_chart_labels("service_name", chart->id, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
     fprintf(stdout, "DIMENSION %s '' %s 1 1\n", chart->dimension, chart->algorithm);
 }

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -910,12 +910,15 @@ static void dcstat_send_global(netdata_publish_dcstat_t *publish)
  */
 static void ebpf_create_specific_dc_charts(char *type, int update_every)
 {
+    char *label = (!strncmp(type, "cgroup_", 7)) ? &type[7] : type;
     ebpf_create_chart(type, NETDATA_DC_HIT_CHART, "Percentage of files inside directory cache",
                       EBPF_COMMON_DIMENSION_PERCENTAGE, NETDATA_DIRECTORY_CACHE_SUBMENU,
                       NETDATA_CGROUP_DC_HIT_RATIO_CONTEXT, NETDATA_EBPF_CHART_TYPE_LINE,
                       NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5700,
                       ebpf_create_global_dimension,
                       dcstat_counter_publish_aggregated, 1, update_every, NETDATA_EBPF_MODULE_NAME_DCSTAT);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_DC_REFERENCE_CHART, "Count file access",
                       EBPF_COMMON_DIMENSION_FILES, NETDATA_DIRECTORY_CACHE_SUBMENU,
@@ -924,6 +927,8 @@ static void ebpf_create_specific_dc_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &dcstat_counter_publish_aggregated[NETDATA_DCSTAT_IDX_REFERENCE], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_DCSTAT);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_DC_REQUEST_NOT_CACHE_CHART,
                       "Files not present inside directory cache",
@@ -933,6 +938,8 @@ static void ebpf_create_specific_dc_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &dcstat_counter_publish_aggregated[NETDATA_DCSTAT_IDX_SLOW], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_DCSTAT);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_DC_REQUEST_NOT_FOUND_CHART,
                       "Files not found",
@@ -942,6 +949,8 @@ static void ebpf_create_specific_dc_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &dcstat_counter_publish_aggregated[NETDATA_DCSTAT_IDX_MISS], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_DCSTAT);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 }
 
 /**

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -696,7 +696,7 @@ void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20265,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_DCSTAT);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION ratio '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 
@@ -711,7 +711,7 @@ void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20266,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_DCSTAT);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION files '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 
@@ -726,7 +726,7 @@ void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20267,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_DCSTAT);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION files '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 
@@ -741,7 +741,7 @@ void ebpf_dcstat_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20268,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_DCSTAT);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION files '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -917,7 +917,7 @@ static void ebpf_create_specific_dc_charts(char *type, int update_every)
                       NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5700,
                       ebpf_create_global_dimension,
                       dcstat_counter_publish_aggregated, 1, update_every, NETDATA_EBPF_MODULE_NAME_DCSTAT);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_DC_REFERENCE_CHART, "Count file access",
@@ -927,7 +927,7 @@ static void ebpf_create_specific_dc_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &dcstat_counter_publish_aggregated[NETDATA_DCSTAT_IDX_REFERENCE], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_DCSTAT);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_DC_REQUEST_NOT_CACHE_CHART,
@@ -938,7 +938,7 @@ static void ebpf_create_specific_dc_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &dcstat_counter_publish_aggregated[NETDATA_DCSTAT_IDX_SLOW], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_DCSTAT);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_DC_REQUEST_NOT_FOUND_CHART,
@@ -949,7 +949,7 @@ static void ebpf_create_specific_dc_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &dcstat_counter_publish_aggregated[NETDATA_DCSTAT_IDX_MISS], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_DCSTAT);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_fd.c
+++ b/src/collectors/ebpf.plugin/ebpf_fd.c
@@ -904,6 +904,7 @@ static void ebpf_fd_sum_cgroup_pids(netdata_fd_stat_t *fd, struct pid_on_target2
  */
 static void ebpf_create_specific_fd_charts(char *type, ebpf_module_t *em)
 {
+    char *label = (!strncmp(type, "cgroup_", 7)) ? &type[7] : type;
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_FILE_OPEN, "Number of open files",
                       EBPF_COMMON_DIMENSION_CALL, NETDATA_APPS_FILE_GROUP,
                       NETDATA_CGROUP_FD_OPEN_CONTEXT, NETDATA_EBPF_CHART_TYPE_LINE,
@@ -911,6 +912,8 @@ static void ebpf_create_specific_fd_charts(char *type, ebpf_module_t *em)
                       ebpf_create_global_dimension,
                       &fd_publish_aggregated[NETDATA_FD_SYSCALL_OPEN],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_FD);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     if (em->mode < MODE_ENTRY) {
         ebpf_create_chart(type, NETDATA_SYSCALL_APPS_FILE_OPEN_ERROR, "Fails to open files",
@@ -921,6 +924,8 @@ static void ebpf_create_specific_fd_charts(char *type, ebpf_module_t *em)
                           &fd_publish_aggregated[NETDATA_FD_SYSCALL_OPEN],
                           1, em->update_every,
                           NETDATA_EBPF_MODULE_NAME_FD);
+        ebpf_create_chart_labels("cgroup_name", label, 0);
+        ebpf_commit_label();
     }
 
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_FILE_CLOSED, "Files closed",
@@ -930,6 +935,8 @@ static void ebpf_create_specific_fd_charts(char *type, ebpf_module_t *em)
                       ebpf_create_global_dimension,
                       &fd_publish_aggregated[NETDATA_FD_SYSCALL_CLOSE],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_FD);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     if (em->mode < MODE_ENTRY) {
         ebpf_create_chart(type, NETDATA_SYSCALL_APPS_FILE_CLOSE_ERROR, "Fails to close files",
@@ -940,6 +947,8 @@ static void ebpf_create_specific_fd_charts(char *type, ebpf_module_t *em)
                           &fd_publish_aggregated[NETDATA_FD_SYSCALL_CLOSE],
                           1, em->update_every,
                           NETDATA_EBPF_MODULE_NAME_FD);
+        ebpf_create_chart_labels("cgroup_name", label, 0);
+        ebpf_commit_label();
     }
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_fd.c
+++ b/src/collectors/ebpf.plugin/ebpf_fd.c
@@ -912,7 +912,7 @@ static void ebpf_create_specific_fd_charts(char *type, ebpf_module_t *em)
                       ebpf_create_global_dimension,
                       &fd_publish_aggregated[NETDATA_FD_SYSCALL_OPEN],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_FD);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     if (em->mode < MODE_ENTRY) {
@@ -924,7 +924,7 @@ static void ebpf_create_specific_fd_charts(char *type, ebpf_module_t *em)
                           &fd_publish_aggregated[NETDATA_FD_SYSCALL_OPEN],
                           1, em->update_every,
                           NETDATA_EBPF_MODULE_NAME_FD);
-        ebpf_create_chart_labels("cgroup_name", label, 0);
+        ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
     }
 
@@ -935,7 +935,7 @@ static void ebpf_create_specific_fd_charts(char *type, ebpf_module_t *em)
                       ebpf_create_global_dimension,
                       &fd_publish_aggregated[NETDATA_FD_SYSCALL_CLOSE],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_FD);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     if (em->mode < MODE_ENTRY) {
@@ -947,7 +947,7 @@ static void ebpf_create_specific_fd_charts(char *type, ebpf_module_t *em)
                           &fd_publish_aggregated[NETDATA_FD_SYSCALL_CLOSE],
                           1, em->update_every,
                           NETDATA_EBPF_MODULE_NAME_FD);
-        ebpf_create_chart_labels("cgroup_name", label, 0);
+        ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
     }
 }

--- a/src/collectors/ebpf.plugin/ebpf_fd.c
+++ b/src/collectors/ebpf.plugin/ebpf_fd.c
@@ -1272,7 +1272,7 @@ void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20220,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_FD);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -1288,7 +1288,7 @@ void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr)
                                  20221,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_FD);
-            ebpf_create_chart_labels("app_group", w->name, 1);
+            ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
             ebpf_commit_label();
             fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
         }
@@ -1304,7 +1304,7 @@ void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20222,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_FD);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -1320,7 +1320,7 @@ void ebpf_fd_create_apps_charts(struct ebpf_module *em, void *ptr)
                                  20223,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_FD);
-            ebpf_create_chart_labels("app_group", w->name, 1);
+            ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
             ebpf_commit_label();
             fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
         }

--- a/src/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/src/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -514,7 +514,7 @@ void ebpf_oomkill_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20072,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_OOMKILL);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION kills '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_ABSOLUTE_IDX]);
 

--- a/src/collectors/ebpf.plugin/ebpf_process.c
+++ b/src/collectors/ebpf.plugin/ebpf_process.c
@@ -827,7 +827,7 @@ static void ebpf_create_specific_process_charts(char *type, ebpf_module_t *em)
                       NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5000,
                       ebpf_create_global_dimension, &process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_FORK],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_PROCESS);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_TASK_THREAD, "Threads started",
@@ -837,7 +837,7 @@ static void ebpf_create_specific_process_charts(char *type, ebpf_module_t *em)
                       ebpf_create_global_dimension,
                       &process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_CLONE],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_PROCESS);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_TASK_EXIT, "Tasks starts exit process.",
@@ -847,7 +847,7 @@ static void ebpf_create_specific_process_charts(char *type, ebpf_module_t *em)
                       ebpf_create_global_dimension,
                       &process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_EXIT],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_PROCESS);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_TASK_CLOSE, "Tasks closed",
@@ -857,7 +857,7 @@ static void ebpf_create_specific_process_charts(char *type, ebpf_module_t *em)
                       ebpf_create_global_dimension,
                       &process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_RELEASE_TASK],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_PROCESS);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     if (em->mode < MODE_ENTRY) {
@@ -868,7 +868,7 @@ static void ebpf_create_specific_process_charts(char *type, ebpf_module_t *em)
                           ebpf_create_global_dimension,
                           &process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_EXIT],
                           1, em->update_every, NETDATA_EBPF_MODULE_NAME_PROCESS);
-        ebpf_create_chart_labels("cgroup_name", label, 0);
+        ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
     }
 }

--- a/src/collectors/ebpf.plugin/ebpf_process.c
+++ b/src/collectors/ebpf.plugin/ebpf_process.c
@@ -820,12 +820,15 @@ static void ebpf_send_specific_process_data(char *type, ebpf_process_stat_t *val
  */
 static void ebpf_create_specific_process_charts(char *type, ebpf_module_t *em)
 {
+    char *label = (!strncmp(type, "cgroup_", 7)) ? &type[7] : type;
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_TASK_PROCESS, "Process started",
                       EBPF_COMMON_DIMENSION_CALL, NETDATA_PROCESS_GROUP,
                       NETDATA_CGROUP_PROCESS_CREATE_CONTEXT, NETDATA_EBPF_CHART_TYPE_LINE,
                       NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5000,
                       ebpf_create_global_dimension, &process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_FORK],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_PROCESS);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_TASK_THREAD, "Threads started",
                       EBPF_COMMON_DIMENSION_CALL, NETDATA_PROCESS_GROUP,
@@ -834,6 +837,8 @@ static void ebpf_create_specific_process_charts(char *type, ebpf_module_t *em)
                       ebpf_create_global_dimension,
                       &process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_CLONE],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_PROCESS);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_TASK_EXIT, "Tasks starts exit process.",
                       EBPF_COMMON_DIMENSION_CALL, NETDATA_PROCESS_GROUP,
@@ -842,6 +847,8 @@ static void ebpf_create_specific_process_charts(char *type, ebpf_module_t *em)
                       ebpf_create_global_dimension,
                       &process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_EXIT],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_PROCESS);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_TASK_CLOSE, "Tasks closed",
                       EBPF_COMMON_DIMENSION_CALL, NETDATA_PROCESS_GROUP,
@@ -850,6 +857,8 @@ static void ebpf_create_specific_process_charts(char *type, ebpf_module_t *em)
                       ebpf_create_global_dimension,
                       &process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_RELEASE_TASK],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_PROCESS);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     if (em->mode < MODE_ENTRY) {
         ebpf_create_chart(type, NETDATA_SYSCALL_APPS_TASK_ERROR, "Errors to create process or threads.",
@@ -859,6 +868,8 @@ static void ebpf_create_specific_process_charts(char *type, ebpf_module_t *em)
                           ebpf_create_global_dimension,
                           &process_publish_aggregated[NETDATA_KEY_PUBLISH_PROCESS_EXIT],
                           1, em->update_every, NETDATA_EBPF_MODULE_NAME_PROCESS);
+        ebpf_create_chart_labels("cgroup_name", label, 0);
+        ebpf_commit_label();
     }
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_process.c
+++ b/src/collectors/ebpf.plugin/ebpf_process.c
@@ -357,7 +357,7 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20161,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_PROCESS);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -372,7 +372,7 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20162,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_PROCESS);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -387,7 +387,7 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20163,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_PROCESS);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -402,7 +402,7 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20164,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_PROCESS);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -418,7 +418,7 @@ void ebpf_process_create_apps_charts(struct ebpf_module *em, void *ptr)
                                  20165,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_PROCESS);
-            ebpf_create_chart_labels("app_group", w->name, 1);
+            ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
             ebpf_commit_label();
             fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
         }

--- a/src/collectors/ebpf.plugin/ebpf_shm.c
+++ b/src/collectors/ebpf.plugin/ebpf_shm.c
@@ -748,7 +748,7 @@ static void ebpf_create_specific_shm_charts(char *type, int update_every)
                       1,
                       update_every,
                       NETDATA_EBPF_MODULE_NAME_SHM);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_SHMAT_CHART,
@@ -763,7 +763,7 @@ static void ebpf_create_specific_shm_charts(char *type, int update_every)
                       1,
                       update_every,
                       NETDATA_EBPF_MODULE_NAME_SHM);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_SHMDT_CHART,
@@ -778,7 +778,7 @@ static void ebpf_create_specific_shm_charts(char *type, int update_every)
                       1,
                       update_every,
                       NETDATA_EBPF_MODULE_NAME_SHM);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_SHMCTL_CHART,
@@ -793,7 +793,7 @@ static void ebpf_create_specific_shm_charts(char *type, int update_every)
                       1,
                       update_every,
                       NETDATA_EBPF_MODULE_NAME_SHM);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_shm.c
+++ b/src/collectors/ebpf.plugin/ebpf_shm.c
@@ -735,6 +735,7 @@ static void ebpf_shm_sum_cgroup_pids(netdata_publish_shm_t *shm, struct pid_on_t
  */
 static void ebpf_create_specific_shm_charts(char *type, int update_every)
 {
+    char *label = (!strncmp(type, "cgroup_", 7)) ? &type[7] : type;
     ebpf_create_chart(type, NETDATA_SHMGET_CHART,
                       "Calls to syscall shmget(2).",
                       EBPF_COMMON_DIMENSION_CALL,
@@ -747,6 +748,8 @@ static void ebpf_create_specific_shm_charts(char *type, int update_every)
                       1,
                       update_every,
                       NETDATA_EBPF_MODULE_NAME_SHM);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_SHMAT_CHART,
                       "Calls to syscall shmat(2).",
@@ -760,6 +763,8 @@ static void ebpf_create_specific_shm_charts(char *type, int update_every)
                       1,
                       update_every,
                       NETDATA_EBPF_MODULE_NAME_SHM);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_SHMDT_CHART,
                       "Calls to syscall shmdt(2).",
@@ -773,6 +778,8 @@ static void ebpf_create_specific_shm_charts(char *type, int update_every)
                       1,
                       update_every,
                       NETDATA_EBPF_MODULE_NAME_SHM);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_SHMCTL_CHART,
                       "Calls to syscall shmctl(2).",
@@ -786,6 +793,8 @@ static void ebpf_create_specific_shm_charts(char *type, int update_every)
                       1,
                       update_every,
                       NETDATA_EBPF_MODULE_NAME_SHM);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 }
 
 /**

--- a/src/collectors/ebpf.plugin/ebpf_shm.c
+++ b/src/collectors/ebpf.plugin/ebpf_shm.c
@@ -1177,7 +1177,7 @@ void ebpf_shm_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20191,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SHM);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -1192,7 +1192,7 @@ void ebpf_shm_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20192,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SHM);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -1207,7 +1207,7 @@ void ebpf_shm_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20193,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SHM);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -1222,7 +1222,7 @@ void ebpf_shm_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20194,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SHM);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 

--- a/src/collectors/ebpf.plugin/ebpf_socket.c
+++ b/src/collectors/ebpf.plugin/ebpf_socket.c
@@ -2118,7 +2118,7 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &socket_publish_aggregated[NETDATA_IDX_TCP_CONNECTION_V4], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     if (tcp_v6_connect_address.type == 'T') {
@@ -2135,7 +2135,7 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                           1,
                           update_every,
                           NETDATA_EBPF_MODULE_NAME_SOCKET);
-        ebpf_create_chart_labels("cgroup_name", label, 0);
+        ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
     }
 
@@ -2148,7 +2148,7 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &socket_publish_aggregated[NETDATA_IDX_TCP_CLEANUP_RBUF], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_NET_APPS_BANDWIDTH_SENT,
@@ -2160,7 +2160,7 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       socket_publish_aggregated, 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS,
@@ -2172,7 +2172,7 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &socket_publish_aggregated[NETDATA_IDX_TCP_CLEANUP_RBUF], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS,
@@ -2184,7 +2184,7 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       socket_publish_aggregated, 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT,
@@ -2196,7 +2196,7 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &socket_publish_aggregated[NETDATA_IDX_TCP_RETRANSMIT], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS,
@@ -2208,7 +2208,7 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &socket_publish_aggregated[NETDATA_IDX_UDP_SENDMSG], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS,
@@ -2220,7 +2220,7 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &socket_publish_aggregated[NETDATA_IDX_UDP_RECVBUF], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_socket.c
+++ b/src/collectors/ebpf.plugin/ebpf_socket.c
@@ -2108,6 +2108,7 @@ static void ebpf_socket_sum_cgroup_pids(ebpf_socket_publish_apps_t *socket, stru
 static void ebpf_create_specific_socket_charts(char *type, int update_every)
 {
     int order_basis = 5300;
+    char *label = (!strncmp(type, "cgroup_", 7)) ? &type[7] : type;
     ebpf_create_chart(type, NETDATA_NET_APPS_CONNECTION_TCP_V4,
                       "Calls to tcp_v4_connection",
                       EBPF_COMMON_DIMENSION_CONNECTIONS, NETDATA_CGROUP_NET_GROUP,
@@ -2117,6 +2118,8 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &socket_publish_aggregated[NETDATA_IDX_TCP_CONNECTION_V4], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     if (tcp_v6_connect_address.type == 'T') {
         ebpf_create_chart(type,
@@ -2132,6 +2135,8 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                           1,
                           update_every,
                           NETDATA_EBPF_MODULE_NAME_SOCKET);
+        ebpf_create_chart_labels("cgroup_name", label, 0);
+        ebpf_commit_label();
     }
 
     ebpf_create_chart(type, NETDATA_NET_APPS_BANDWIDTH_RECV,
@@ -2143,6 +2148,8 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &socket_publish_aggregated[NETDATA_IDX_TCP_CLEANUP_RBUF], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_NET_APPS_BANDWIDTH_SENT,
                       "Bytes sent",
@@ -2153,6 +2160,8 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       socket_publish_aggregated, 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_NET_APPS_BANDWIDTH_TCP_RECV_CALLS,
                       "Calls to tcp_cleanup_rbuf.",
@@ -2163,6 +2172,8 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &socket_publish_aggregated[NETDATA_IDX_TCP_CLEANUP_RBUF], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_NET_APPS_BANDWIDTH_TCP_SEND_CALLS,
                       "Calls to tcp_sendmsg.",
@@ -2173,6 +2184,8 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       socket_publish_aggregated, 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_NET_APPS_BANDWIDTH_TCP_RETRANSMIT,
                       "Calls to tcp_retransmit.",
@@ -2183,6 +2196,8 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &socket_publish_aggregated[NETDATA_IDX_TCP_RETRANSMIT], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_NET_APPS_BANDWIDTH_UDP_SEND_CALLS,
                       "Calls to udp_sendmsg",
@@ -2193,6 +2208,8 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &socket_publish_aggregated[NETDATA_IDX_UDP_SENDMSG], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_NET_APPS_BANDWIDTH_UDP_RECV_CALLS,
                       "Calls to udp_recvmsg",
@@ -2203,6 +2220,8 @@ static void ebpf_create_specific_socket_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &socket_publish_aggregated[NETDATA_IDX_UDP_RECVBUF], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SOCKET);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 }
 
 /**

--- a/src/collectors/ebpf.plugin/ebpf_socket.c
+++ b/src/collectors/ebpf.plugin/ebpf_socket.c
@@ -1236,7 +1236,7 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SOCKET);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION connections '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -1252,7 +1252,7 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
                                  order++,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_SOCKET);
-            ebpf_create_chart_labels("app_group", w->name, 1);
+            ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
             ebpf_commit_label();
             fprintf(stdout, "DIMENSION connections '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
         }
@@ -1268,7 +1268,7 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SOCKET);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION bandwidth '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -1283,7 +1283,7 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SOCKET);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION bandwidth '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -1298,7 +1298,7 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SOCKET);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -1313,7 +1313,7 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SOCKET);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -1328,7 +1328,7 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SOCKET);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -1343,7 +1343,7 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SOCKET);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -1358,7 +1358,7 @@ void ebpf_socket_create_apps_charts(struct ebpf_module *em, void *ptr)
                              order,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SOCKET);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 

--- a/src/collectors/ebpf.plugin/ebpf_swap.c
+++ b/src/collectors/ebpf.plugin/ebpf_swap.c
@@ -695,6 +695,7 @@ static void ebpf_send_systemd_swap_charts()
  */
 static void ebpf_create_specific_swap_charts(char *type, int update_every)
 {
+    char *label = (!strncmp(type, "cgroup_", 7)) ? &type[7] : type;
     ebpf_create_chart(type, NETDATA_MEM_SWAP_READ_CHART,
                       "Calls to function swap_readpage.",
                       EBPF_COMMON_DIMENSION_CALL, NETDATA_SYSTEM_SWAP_SUBMENU,
@@ -702,6 +703,8 @@ static void ebpf_create_specific_swap_charts(char *type, int update_every)
                       NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5100,
                       ebpf_create_global_dimension,
                       swap_publish_aggregated, 1, update_every, NETDATA_EBPF_MODULE_NAME_SWAP);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_MEM_SWAP_WRITE_CHART,
                       "Calls to function swap_writepage.",
@@ -711,6 +714,8 @@ static void ebpf_create_specific_swap_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &swap_publish_aggregated[NETDATA_KEY_SWAP_WRITEPAGE_CALL], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SWAP);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 }
 
 /**

--- a/src/collectors/ebpf.plugin/ebpf_swap.c
+++ b/src/collectors/ebpf.plugin/ebpf_swap.c
@@ -938,7 +938,7 @@ void ebpf_swap_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20070,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SWAP);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -953,7 +953,7 @@ void ebpf_swap_create_apps_charts(struct ebpf_module *em, void *ptr)
                              20071,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_SWAP);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 

--- a/src/collectors/ebpf.plugin/ebpf_swap.c
+++ b/src/collectors/ebpf.plugin/ebpf_swap.c
@@ -703,7 +703,7 @@ static void ebpf_create_specific_swap_charts(char *type, int update_every)
                       NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5100,
                       ebpf_create_global_dimension,
                       swap_publish_aggregated, 1, update_every, NETDATA_EBPF_MODULE_NAME_SWAP);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_MEM_SWAP_WRITE_CHART,
@@ -714,7 +714,7 @@ static void ebpf_create_specific_swap_charts(char *type, int update_every)
                       ebpf_create_global_dimension,
                       &swap_publish_aggregated[NETDATA_KEY_SWAP_WRITEPAGE_CALL], 1,
                       update_every, NETDATA_EBPF_MODULE_NAME_SWAP);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/src/collectors/ebpf.plugin/ebpf_vfs.c
@@ -1356,17 +1356,22 @@ static void ebpf_vfs_sum_cgroup_pids(netdata_publish_vfs_t *vfs, struct pid_on_t
  */
 static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
 {
+    char *label = (!strncmp(type, "cgroup_", 7)) ? &type[7] : type;
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_FILE_DELETED,"Files deleted",
                       EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_GROUP, NETDATA_CGROUP_VFS_UNLINK_CONTEXT,
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5500,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_UNLINK],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS, "Write to disk",
                       EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_GROUP, NETDATA_CGROUP_VFS_WRITE_CONTEXT,
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5501,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_WRITE],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     if (em->mode < MODE_ENTRY) {
         ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS_ERROR, "Fails to write",
@@ -1374,6 +1379,8 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                           NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5502,
                           ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_WRITE],
                           1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_create_chart_labels("cgroup_name", label, 0);
+        ebpf_commit_label();
     }
 
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_READ_CALLS, "Read from disk",
@@ -1381,6 +1388,8 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5503,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_READ],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     if (em->mode < MODE_ENTRY) {
         ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_READ_CALLS_ERROR, "Fails to read",
@@ -1388,6 +1397,8 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                           NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5504,
                           ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_READ],
                           1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_create_chart_labels("cgroup_name", label, 0);
+        ebpf_commit_label();
     }
 
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_WRITE_BYTES, "Bytes written on disk",
@@ -1395,18 +1406,24 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5505,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_WRITE],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_READ_BYTES, "Bytes read from disk",
                       EBPF_COMMON_DIMENSION_BYTES, NETDATA_VFS_GROUP, NETDATA_CGROUP_VFS_READ_BYTES_CONTEXT,
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5506,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_READ],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_FSYNC, "Calls to vfs_fsync.",
                       EBPF_COMMON_DIMENSION_CALL, NETDATA_VFS_GROUP, NETDATA_CGROUP_VFS_FSYNC_CONTEXT,
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5507,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_FSYNC],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     if (em->mode < MODE_ENTRY) {
         ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_FSYNC_CALLS_ERROR, "Sync error",
@@ -1414,6 +1431,8 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                           NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5508,
                           ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_FSYNC],
                           1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_create_chart_labels("cgroup_name", label, 0);
+        ebpf_commit_label();
     }
 
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_OPEN, "Calls to vfs_open.",
@@ -1421,6 +1440,8 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5509,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_OPEN],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     if (em->mode < MODE_ENTRY) {
         ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_OPEN_CALLS_ERROR, "Open error",
@@ -1428,6 +1449,8 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                           NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5510,
                           ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_OPEN],
                           1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_create_chart_labels("cgroup_name", label, 0);
+        ebpf_commit_label();
     }
 
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_CREATE, "Calls to vfs_create.",
@@ -1435,6 +1458,8 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5511,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_CREATE],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_commit_label();
 
     if (em->mode < MODE_ENTRY) {
         ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_CREATE_CALLS_ERROR, "Create error",
@@ -1442,6 +1467,8 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                           NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5512,
                           ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_CREATE],
                           1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
+        ebpf_create_chart_labels("cgroup_name", label, 0);
+        ebpf_commit_label();
     }
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/src/collectors/ebpf.plugin/ebpf_vfs.c
@@ -2332,7 +2332,7 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_VFS);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -2347,7 +2347,7 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_VFS);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -2363,7 +2363,7 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
                                  order++,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_VFS);
-            ebpf_create_chart_labels("app_group", w->name, 1);
+            ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
             ebpf_commit_label();
             fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
         }
@@ -2379,7 +2379,7 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_VFS);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -2395,7 +2395,7 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
                                  order++,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_VFS);
-            ebpf_create_chart_labels("app_group", w->name, 1);
+            ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
             ebpf_commit_label();
             fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
         }
@@ -2411,7 +2411,7 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_VFS);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION writes '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -2426,7 +2426,7 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_VFS);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION reads '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -2441,7 +2441,7 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_VFS);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -2457,7 +2457,7 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
                                  order++,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_VFS);
-            ebpf_create_chart_labels("app_group", w->name, 1);
+            ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
             ebpf_commit_label();
             fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
         }
@@ -2473,7 +2473,7 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_VFS);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -2489,7 +2489,7 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
                                  order++,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_VFS);
-            ebpf_create_chart_labels("app_group", w->name, 1);
+            ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
             ebpf_commit_label();
             fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
         }
@@ -2505,7 +2505,7 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
                              order++,
                              update_every,
                              NETDATA_EBPF_MODULE_NAME_VFS);
-        ebpf_create_chart_labels("app_group", w->name, 1);
+        ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
         fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
 
@@ -2521,7 +2521,7 @@ void ebpf_vfs_create_apps_charts(struct ebpf_module *em, void *ptr)
                                  order++,
                                  update_every,
                                  NETDATA_EBPF_MODULE_NAME_VFS);
-            ebpf_create_chart_labels("app_group", w->name, 1);
+            ebpf_create_chart_labels("app_group", w->name, RRDLABEL_SRC_AUTO);
             ebpf_commit_label();
             fprintf(stdout, "DIMENSION calls '' %s 1 1\n", ebpf_algorithms[NETDATA_EBPF_INCREMENTAL_IDX]);
         }

--- a/src/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/src/collectors/ebpf.plugin/ebpf_vfs.c
@@ -1362,7 +1362,7 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5500,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_UNLINK],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_WRITE_CALLS, "Write to disk",
@@ -1370,7 +1370,7 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5501,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_WRITE],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     if (em->mode < MODE_ENTRY) {
@@ -1379,7 +1379,7 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                           NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5502,
                           ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_WRITE],
                           1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
-        ebpf_create_chart_labels("cgroup_name", label, 0);
+        ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
     }
 
@@ -1388,7 +1388,7 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5503,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_READ],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     if (em->mode < MODE_ENTRY) {
@@ -1397,7 +1397,7 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                           NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5504,
                           ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_READ],
                           1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
-        ebpf_create_chart_labels("cgroup_name", label, 0);
+        ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
     }
 
@@ -1406,7 +1406,7 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5505,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_WRITE],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_READ_BYTES, "Bytes read from disk",
@@ -1414,7 +1414,7 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5506,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_READ],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     ebpf_create_chart(type, NETDATA_SYSCALL_APPS_VFS_FSYNC, "Calls to vfs_fsync.",
@@ -1422,7 +1422,7 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5507,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_FSYNC],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     if (em->mode < MODE_ENTRY) {
@@ -1431,7 +1431,7 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                           NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5508,
                           ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_FSYNC],
                           1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
-        ebpf_create_chart_labels("cgroup_name", label, 0);
+        ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
     }
 
@@ -1440,7 +1440,7 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5509,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_OPEN],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     if (em->mode < MODE_ENTRY) {
@@ -1449,7 +1449,7 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                           NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5510,
                           ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_OPEN],
                           1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
-        ebpf_create_chart_labels("cgroup_name", label, 0);
+        ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
     }
 
@@ -1458,7 +1458,7 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                       NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5511,
                       ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_CREATE],
                       1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
-    ebpf_create_chart_labels("cgroup_name", label, 0);
+    ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
     ebpf_commit_label();
 
     if (em->mode < MODE_ENTRY) {
@@ -1467,7 +1467,7 @@ static void ebpf_create_specific_vfs_charts(char *type, ebpf_module_t *em)
                           NETDATA_EBPF_CHART_TYPE_LINE, NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 5512,
                           ebpf_create_global_dimension, &vfs_publish_aggregated[NETDATA_KEY_PUBLISH_VFS_CREATE],
                           1, em->update_every, NETDATA_EBPF_MODULE_NAME_VFS);
-        ebpf_create_chart_labels("cgroup_name", label, 0);
+        ebpf_create_chart_labels("cgroup_name", label, RRDLABEL_SRC_AUTO);
         ebpf_commit_label();
     }
 }


### PR DESCRIPTION
##### Summary
eBPF.plugin was adding label for `services`, but we did not have for `cgorups`. This PR address this issue.

##### Test Plan

The `cgroup_name` will appear only for cgroups that are not services, to show them you can do the following steps:

1. Install docker 
2. Run `docker run -it alpine /bin/sh`

Now

1. Compile this branch
3. Enable integration with cgroup:
```sh
[global]
    cgroups = yes
```
4. Start netdata
5. Access `http://localhost:19999/api/v1/charts?all` and confirm `cgroup_name` appears.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
