### PR TITLE
go.d.plugin: sd compose: allow multi config template

### DIFF
--- a/src/go/collectors/go.d.plugin/agent/discovery/sd/pipeline/compose_test.go
+++ b/src/go/collectors/go.d.plugin/agent/discovery/sd/pipeline/compose_test.go
@@ -38,7 +38,8 @@ func TestConfigComposer_compose(t *testing.T) {
         name: {{ .Name }}-5
     - selector: "bar6"
       template: |
-        name: {{ .Name }}-6
+        - name: {{ .Name }}-6
+        - name: {{ .Name }}-7
 `
 	tests := map[string]struct {
 		target      model.Target
@@ -70,6 +71,7 @@ func TestConfigComposer_compose(t *testing.T) {
 				{"name": "mock-4"},
 				{"name": "mock-5"},
 				{"name": "mock-6"},
+				{"name": "mock-7"},
 			},
 		},
 	}

--- a/src/go/collectors/go.d.plugin/config/go.d/sd/net_listeners.conf
+++ b/src/go/collectors/go.d.plugin/config/go.d/sd/net_listeners.conf
@@ -278,9 +278,18 @@ compose:
           dsn: netdata@tcp(127.0.0.1:{{.Port}})/
       - selector: "nginx"
         template: |
-          module: nginx
-          name: local
-          url: http://localhost:{{.Port}}/stub_status
+          - module: nginx
+            name: local
+            url: http://localhost:{{.Port}}/stub_status
+          - module: nginx
+            name: local
+            url: http://localhost:{{.Port}}/basic_status
+          - module: nginx
+            name: local
+            url: http://localhost:{{.Port}}/nginx_status
+          - module: nginx
+            name: local
+            url: http://localhost:{{.Port}}/status
       - selector: "ntpd"
         template: |
           module: ntpd


### PR DESCRIPTION
##### Summary

Needed to create multiple configs in a template instead of multiple compose config rules.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
