### PR TITLE
go.d.plugin: execute local-listeners periodically

### DIFF
--- a/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/netlisteners.go
+++ b/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/netlisteners.go
@@ -51,7 +51,7 @@ func NewDiscoverer(cfg Config) (*Discoverer, error) {
 			binPath: filepath.Join(dir, "local-listeners"),
 			timeout: time.Second * 5,
 		},
-		interval:   time.Second * 60,
+		interval:   time.Minute * 2,
 		expiryTime: time.Minute * 10,
 		cache:      make(map[uint64]*cacheItem),
 		started:    make(chan struct{}),

--- a/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/netlisteners.go
+++ b/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/netlisteners.go
@@ -155,7 +155,7 @@ func (d *Discoverer) processTargets(tgts []model.Target) []model.TargetGroup {
 		tgg.source += fmt.Sprintf(",%s", d.cfgSource)
 	}
 
-	if d.expiryTime.Seconds() == 0 {
+	if d.expiryTime.Milliseconds() == 0 {
 		tgg.targets = tgts
 		return []model.TargetGroup{tgg}
 	}

--- a/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/netlisteners_test.go
+++ b/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/netlisteners_test.go
@@ -3,28 +3,22 @@
 package netlisteners
 
 import (
-	"context"
-	"errors"
 	"testing"
+	"time"
 
 	"github.com/netdata/netdata/go/go.d.plugin/agent/discovery/sd/model"
 )
 
-var (
-	localListenersOutputSample = []byte(`
-UDP6|::1|8125|/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D
-TCP6|::1|8125|/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D
-TCP|127.0.0.1|8125|/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D
-UDP|127.0.0.1|53768|/opt/netdata/usr/libexec/netdata/plugins.d/go.d.plugin 1
-`)
-)
-
 func TestDiscoverer_Discover(t *testing.T) {
 	tests := map[string]discoverySim{
-		"valid response": {
-			mock:                 &mockLocalListenersExec{},
-			wantDoneBeforeCancel: false,
-			wantTargetGroups: []model.TargetGroup{&targetGroup{
+		"add listeners": {
+			listenersCli: func(cli listenersCli, interval, expiry time.Duration) {
+				cli.addListener("UDP6|::1|8125|/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D")
+				cli.addListener("TCP6|::1|8125|/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D")
+				cli.addListener("TCP|127.0.0.1|8125|/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D")
+				cli.addListener("UDP|127.0.0.1|53768|/opt/netdata/usr/libexec/netdata/plugins.d/go.d.plugin 1")
+			},
+			wantGroups: []model.TargetGroup{&targetGroup{
 				provider: "sd:net_listeners",
 				source:   "discoverer=net_listeners,host=localhost",
 				targets: []model.Target{
@@ -59,23 +53,36 @@ func TestDiscoverer_Discover(t *testing.T) {
 				},
 			}},
 		},
-		"empty response": {
-			mock:                 &mockLocalListenersExec{emptyResponse: true},
-			wantDoneBeforeCancel: false,
-			wantTargetGroups: []model.TargetGroup{&targetGroup{
+		"remove listeners": {
+			listenersCli: func(cli listenersCli, interval, expiry time.Duration) {
+				cli.addListener("UDP6|::1|8125|/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D")
+				cli.addListener("TCP6|::1|8125|/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D")
+				cli.addListener("TCP|127.0.0.1|8125|/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D")
+				cli.addListener("UDP|127.0.0.1|53768|/opt/netdata/usr/libexec/netdata/plugins.d/go.d.plugin 1")
+				time.Sleep(expiry * 2)
+				cli.removeListener("UDP6|::1|8125|/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D")
+				cli.removeListener("UDP|127.0.0.1|53768|/opt/netdata/usr/libexec/netdata/plugins.d/go.d.plugin 1")
+			},
+			wantGroups: []model.TargetGroup{&targetGroup{
 				provider: "sd:net_listeners",
 				source:   "discoverer=net_listeners,host=localhost",
+				targets: []model.Target{
+					withHash(&target{
+						Protocol: "TCP6",
+						Address:  "::1",
+						Port:     "8125",
+						Comm:     "netdata",
+						Cmdline:  "/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D",
+					}),
+					withHash(&target{
+						Protocol: "TCP",
+						Address:  "127.0.0.1",
+						Port:     "8125",
+						Comm:     "netdata",
+						Cmdline:  "/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D",
+					}),
+				},
 			}},
-		},
-		"error on exec": {
-			mock:                 &mockLocalListenersExec{err: true},
-			wantDoneBeforeCancel: true,
-			wantTargetGroups:     nil,
-		},
-		"invalid data": {
-			mock:                 &mockLocalListenersExec{invalidResponse: true},
-			wantDoneBeforeCancel: true,
-			wantTargetGroups:     nil,
 		},
 	}
 
@@ -88,26 +95,7 @@ func TestDiscoverer_Discover(t *testing.T) {
 
 func withHash(l *target) *target {
 	l.hash, _ = calcHash(l)
-	tags, _ := model.ParseTags("hostnetsocket")
+	tags, _ := model.ParseTags("netlisteners")
 	l.Tags().Merge(tags)
 	return l
-}
-
-type mockLocalListenersExec struct {
-	err             bool
-	emptyResponse   bool
-	invalidResponse bool
-}
-
-func (m *mockLocalListenersExec) discover(context.Context) ([]byte, error) {
-	if m.err {
-		return nil, errors.New("mock discover() error")
-	}
-	if m.emptyResponse {
-		return nil, nil
-	}
-	if m.invalidResponse {
-		return []byte("this is very incorrect data"), nil
-	}
-	return localListenersOutputSample, nil
 }

--- a/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/sim_test.go
+++ b/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/sim_test.go
@@ -39,7 +39,7 @@ func (sim *discoverySim) run(t *testing.T) {
 	d.ll = mock
 
 	d.interval = time.Millisecond * 100
-	d.expiryTime = time.Millisecond * 500
+	d.expiryTime = time.Second * 1
 
 	seen := make(map[string]model.TargetGroup)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -80,7 +80,6 @@ func (sim *discoverySim) run(t *testing.T) {
 	}
 
 	sim.listenersCli(mock, d.interval, d.expiryTime)
-	time.Sleep(time.Second)
 
 	cancel()
 
@@ -98,7 +97,7 @@ func (sim *discoverySim) run(t *testing.T) {
 	sortTargetGroups(tggs)
 	sortTargetGroups(sim.wantGroups)
 
-	wantLen, gotLen := len(sim.wantGroups), len(tggs)
+	wantLen, gotLen := calcTargets(sim.wantGroups), calcTargets(tggs)
 	assert.Equalf(t, wantLen, gotLen, "different len (want %d got %d)", wantLen, gotLen)
 	assert.Equal(t, sim.wantGroups, tggs)
 }
@@ -144,6 +143,14 @@ func (m *mockLocalListenersExec) discover(context.Context) ([]byte, error) {
 	}
 
 	return []byte(buf.String()), nil
+}
+
+func calcTargets(tggs []model.TargetGroup) int {
+	var n int
+	for _, tgg := range tggs {
+		n += len(tgg.Targets())
+	}
+	return n
 }
 
 func sortTargetGroups(tggs []model.TargetGroup) {

--- a/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/sim_test.go
+++ b/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/sim_test.go
@@ -4,6 +4,10 @@ package netlisteners
 
 import (
 	"context"
+	"errors"
+	"sort"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,63 +17,143 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type listenersCli interface {
+	addListener(s string)
+	removeListener(s string)
+}
+
 type discoverySim struct {
-	mock                 *mockLocalListenersExec
-	wantDoneBeforeCancel bool
-	wantTargetGroups     []model.TargetGroup
+	listenersCli func(cli listenersCli, interval, expiry time.Duration)
+	wantGroups   []model.TargetGroup
 }
 
 func (sim *discoverySim) run(t *testing.T) {
-	d, err := NewDiscoverer(Config{Tags: "hostnetsocket"})
+	d, err := NewDiscoverer(Config{
+		Source: "",
+		Tags:   "netlisteners",
+	})
 	require.NoError(t, err)
 
-	d.ll = sim.mock
+	mock := newMockLocalListenersExec()
 
+	d.ll = mock
+
+	d.interval = time.Millisecond * 100
+	d.expiryTime = time.Millisecond * 500
+
+	seen := make(map[string]model.TargetGroup)
 	ctx, cancel := context.WithCancel(context.Background())
-	tggs, done := sim.collectTargetGroups(t, ctx, d)
-
-	if sim.wantDoneBeforeCancel {
-		select {
-		case <-done:
-		default:
-			assert.Fail(t, "discovery hasn't finished before cancel")
-		}
-	}
-	assert.Equal(t, sim.wantTargetGroups, tggs)
-
-	cancel()
-	select {
-	case <-done:
-	case <-time.After(time.Second * 3):
-		assert.Fail(t, "discovery hasn't finished after cancel")
-	}
-}
-
-func (sim *discoverySim) collectTargetGroups(t *testing.T, ctx context.Context, d *Discoverer) ([]model.TargetGroup, chan struct{}) {
-
 	in := make(chan []model.TargetGroup)
-	done := make(chan struct{})
+	var wg sync.WaitGroup
 
-	go func() { defer close(done); d.Discover(ctx, in) }()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		d.Discover(ctx, in)
+	}()
 
-	timeout := time.Second * 5
-	var tggs []model.TargetGroup
-
-	func() {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 		for {
 			select {
-			case groups := <-in:
-				if tggs = append(tggs, groups...); len(tggs) == len(sim.wantTargetGroups) {
-					return
+			case <-ctx.Done():
+				return
+			case tggs := <-in:
+				for _, tgg := range tggs {
+					seen[tgg.Source()] = tgg
 				}
-			case <-done:
-				return
-			case <-time.After(timeout):
-				t.Logf("discovery timed out after %s", timeout)
-				return
 			}
 		}
 	}()
 
-	return tggs, done
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		wg.Wait()
+	}()
+
+	select {
+	case <-d.started:
+	case <-time.After(time.Second * 3):
+		require.Fail(t, "discovery failed to start")
+	}
+
+	sim.listenersCli(mock, d.interval, d.expiryTime)
+	time.Sleep(time.Second)
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second * 3):
+		require.Fail(t, "discovery hasn't finished after cancel")
+	}
+
+	var tggs []model.TargetGroup
+	for _, tgg := range seen {
+		tggs = append(tggs, tgg)
+	}
+
+	sortTargetGroups(tggs)
+	sortTargetGroups(sim.wantGroups)
+
+	wantLen, gotLen := len(sim.wantGroups), len(tggs)
+	assert.Equalf(t, wantLen, gotLen, "different len (want %d got %d)", wantLen, gotLen)
+	assert.Equal(t, sim.wantGroups, tggs)
+}
+
+func newMockLocalListenersExec() *mockLocalListenersExec {
+	return &mockLocalListenersExec{
+		listeners: make(map[string]bool),
+	}
+}
+
+type mockLocalListenersExec struct {
+	errResponse bool
+	mux         sync.Mutex
+	listeners   map[string]bool
+}
+
+func (m *mockLocalListenersExec) addListener(s string) {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	m.listeners[s] = true
+}
+
+func (m *mockLocalListenersExec) removeListener(s string) {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	delete(m.listeners, s)
+}
+
+func (m *mockLocalListenersExec) discover(context.Context) ([]byte, error) {
+	if m.errResponse {
+		return nil, errors.New("mock discover() error")
+	}
+
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	var buf strings.Builder
+	for s := range m.listeners {
+		buf.WriteString(s)
+		buf.WriteByte('\n')
+	}
+
+	return []byte(buf.String()), nil
+}
+
+func sortTargetGroups(tggs []model.TargetGroup) {
+	if len(tggs) == 0 {
+		return
+	}
+	sort.Slice(tggs, func(i, j int) bool { return tggs[i].Source() < tggs[j].Source() })
+
+	for idx := range tggs {
+		tgts := tggs[idx].Targets()
+		sort.Slice(tgts, func(i, j int) bool { return tgts[i].Hash() < tgts[j].Hash() })
+	}
 }


### PR DESCRIPTION
##### Summary

Before:

Discover local listeners only once on start.

After:

Discover local listeners periodically (every minute by default). Remove listeners if they are unavailable for more than the configured threshold (10 minutes by default). This is necessary so that data collection jobs are not immediately deleted if the application stops responding.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
