### PR TITLE
Compatibility with Prometheus HELP

### DIFF
--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -598,6 +598,16 @@ static void prometheus_print_os_info(
     fclose(fp);
 }
 
+/**
+ * RRDSET to JSON
+ *
+ * From RRDSET extract content necessary to write JSON output.
+ *
+ * @param st   netdata chart structure
+ * @param data structure with necessary data and to build expected result.
+ *
+ * @return I returns 1 when content was used and 0 otherwise.
+ */
 static int prometheus_rrdset_to_json(RRDSET *st, void *data)
 {
     struct host_variables_callback_options *opts = data;
@@ -796,7 +806,18 @@ static int prometheus_rrdset_to_json(RRDSET *st, void *data)
     return 0;
 }
 
-static inline int prometheus_rrdcontext_to_json_callback(const DICTIONARY_ITEM *item, void *value, void *data)
+/**
+ * RRDCONTEXT callback
+ *
+ * Callback used to parse dictionary
+ *
+ * @param item  the dictionary structure
+ * @param value unused element
+ * @param data  structure used to store data.
+ *
+ * @return It always returns HTTP_RESP_OK
+ */
+static inline int prometheus_rrdcontext_callback(const DICTIONARY_ITEM *item, void *value, void *data)
 {
     const char *context_name = dictionary_acquired_item_name(item);
     struct host_variables_callback_options *opts = data;
@@ -894,7 +915,7 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
         goto allmetrics_cleanup;
     }
 
-    dictionary_walkthrough_read(host->rrdctx.contexts, prometheus_rrdcontext_to_json_callback, &opts);
+    dictionary_walkthrough_read(host->rrdctx.contexts, prometheus_rrdcontext_callback, &opts);
 
 allmetrics_cleanup:
     simple_pattern_free(filter);

--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -363,6 +363,7 @@ struct host_variables_callback_options {
     char name[PROMETHEUS_VARIABLE_MAX + 1];
     SIMPLE_PATTERN *pattern;
     struct instance *instance;
+    STRING *prometheus;
 };
 
 /**
@@ -620,7 +621,7 @@ static int prometheus_rrdset_to_json(RRDSET *st, void *data)
         BUFFER *plabels_buffer = opts->plabels_buffer;
         const char *plabels_prefix = opts->instance->config.label_prefix;
 
-        STRING *prometheus = string_strdupz("prometheus");
+        STRING *prometheus = opts->prometheus;
 
         char chart[PROMETHEUS_ELEMENT_MAX + 1];
         char context[PROMETHEUS_ELEMENT_MAX + 1];
@@ -901,7 +902,8 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
         .now = now_realtime_sec(),
         .host_header_printed = 0,
         .pattern = filter,
-        .instance = instance
+        .instance = instance,
+        .prometheus = string_strdupz("prometheus")
     };
 
     // send custom variables set for the host
@@ -920,6 +922,7 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
 allmetrics_cleanup:
     simple_pattern_free(filter);
     buffer_free(plabels_buffer);
+    string_freez(opts.prometheus);
 }
 
 /**

--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -718,8 +718,6 @@ static int prometheus_rrdset_to_json(RRDSET *st, void *data)
                             dimension,
                             (output_options & PROMETHEUS_OUTPUT_NAMES && rd->name) ? rrddim_name(rd) : rrddim_id(rd),
                             PROMETHEUS_ELEMENT_MAX);
-
-                        generate_as_collected_from_metric(wb, &p, homogeneous, prometheus_collector, st->rrdlabels);
                     }
                     else {
                         // the dimensions of the chart, do not have the same algorithm, multiplier or divisor
@@ -729,9 +727,8 @@ static int prometheus_rrdset_to_json(RRDSET *st, void *data)
                             dimension,
                             (output_options & PROMETHEUS_OUTPUT_NAMES && rd->name) ? rrddim_name(rd) : rrddim_id(rd),
                             PROMETHEUS_ELEMENT_MAX);
-
-                        generate_as_collected_from_metric(wb, &p, homogeneous, prometheus_collector, st->rrdlabels);
                     }
+                    generate_as_collected_from_metric(wb, &p, homogeneous, prometheus_collector, st->rrdlabels);
                 }
                 else {
                     // we need average or sum of the data

--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -442,9 +442,14 @@ struct gen_parameters {
  * @param wb the buffer to write the comment to.
  * @param context context name we are using
  */
-static inline void generate_as_collected_prom_help(BUFFER *wb, char *context, RRDSET *st)
+static inline void generate_as_collected_prom_help(BUFFER *wb,
+                                                   const char *prefix,
+                                                   char *context,
+                                                   char *units,
+                                                   char *suffix,
+                                                   RRDSET *st)
 {
-    buffer_sprintf(wb, "# HELP %s %s\n", context, rrdset_title(st));
+    buffer_sprintf(wb, "# HELP %s_%s%s%s %s\n", prefix, context, units, suffix, rrdset_title(st));
 }
 
 /**
@@ -743,6 +748,11 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
                                 p.suffix = "_total";
                         }
 
+                        if (plot_help) {
+                            generate_as_collected_prom_help(wb, prefix, context, units, suffix, st);
+                            plot_help = false;
+                        }
+
                         if (plot_type) {
                             plot_type = false;
                             generate_as_collected_prom_type(wb, prefix, context, units, p.suffix, p.type);
@@ -789,7 +799,7 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
                                 PROMETHEUS_ELEMENT_MAX);
 
                             if (plot_help) {
-                                generate_as_collected_prom_help(wb, context, st);
+                                generate_as_collected_prom_help(wb, prefix, context, units, suffix, st);
                                 plot_help = false;
                             }
 

--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -377,14 +377,14 @@ static int print_host_variables_callback(const DICTIONARY_ITEM *item __maybe_unu
     if (!opts->host_header_printed) {
         opts->host_header_printed = 1;
 
-        if (opts->output_options & PROMETHEUS_OUTPUT_HELP) {
+        if (opts->output_options & PROMETHEUS_OUTPUT_COMMENT) {
             buffer_sprintf(opts->wb, "\n# COMMENT global host and chart variables\n");
         }
     }
 
     NETDATA_DOUBLE value = rrdvar2number(rv);
     if (isnan(value) || isinf(value)) {
-        if (opts->output_options & PROMETHEUS_OUTPUT_HELP)
+        if (opts->output_options & PROMETHEUS_OUTPUT_COMMENT)
             buffer_sprintf(
                 opts->wb, "# COMMENT variable \"%s\" is %s. Skipped.\n", rrdvar_name(rv), (isnan(value)) ? "NAN" : "INF");
 
@@ -743,7 +743,7 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
                         units, rrdset_units(st), PROMETHEUS_ELEMENT_MAX, output_options & PROMETHEUS_OUTPUT_OLDUNITS);
             }
 
-            if (unlikely(output_options & PROMETHEUS_OUTPUT_HELP)) {
+            if (unlikely(output_options & PROMETHEUS_OUTPUT_COMMENT)) {
                 buffer_sprintf(
                     wb,
                     "\n# COMMENT %s chart \"%s\", context \"%s\", family \"%s\", units \"%s\"\n",
@@ -752,6 +752,9 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
                     rrdset_context(st),
                     rrdset_family(st),
                     rrdset_units(st));
+            }
+
+            if (unlikely(output_options & PROMETHEUS_OUTPUT_HELP)) {
                 generate_as_collected_prom_help(wb, &p, prometheus_collector);
             }
 
@@ -792,8 +795,11 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
                                 (output_options & PROMETHEUS_OUTPUT_NAMES && rd->name) ? rrddim_name(rd) : rrddim_id(rd),
                                 PROMETHEUS_ELEMENT_MAX);
 
-                            if (unlikely(output_options & PROMETHEUS_OUTPUT_HELP)) {
+                            if (unlikely(output_options & PROMETHEUS_OUTPUT_COMMENT)) {
                                 generate_as_collected_prom_comment(wb, &p, homogeneous, prometheus_collector);
+                            }
+
+                            if (unlikely(output_options & PROMETHEUS_OUTPUT_HELP)) {
                                 generate_as_collected_prom_help(wb, &p, prometheus_collector);
                             }
 
@@ -811,8 +817,11 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
                                 (output_options & PROMETHEUS_OUTPUT_NAMES && rd->name) ? rrddim_name(rd) : rrddim_id(rd),
                                 PROMETHEUS_ELEMENT_MAX);
 
-                            if (unlikely(output_options & PROMETHEUS_OUTPUT_HELP)) {
+                            if (unlikely(output_options & PROMETHEUS_OUTPUT_COMMENT)) {
                                 generate_as_collected_prom_comment(wb, &p, homogeneous, prometheus_collector);
+                            }
+
+                            if (unlikely(output_options & PROMETHEUS_OUTPUT_HELP)) {
                                 generate_as_collected_prom_help(wb, &p, prometheus_collector);
                             }
 
@@ -845,7 +854,7 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
                             buffer_sprintf(plabels_buffer, "%1$schart=\"%2$s\",%1$sdimension=\"%3$s\",%1$sfamily=\"%4$s\"", plabels_prefix, chart, dimension, family);
                             rrdlabels_walkthrough_read(st->rrdlabels, format_prometheus_chart_label_callback, plabels_buffer);
 
-                            if (unlikely(output_options & PROMETHEUS_OUTPUT_HELP)) {
+                            if (unlikely(output_options & PROMETHEUS_OUTPUT_COMMENT)) {
                                 buffer_sprintf(
                                     wb,
                                     "# COMMENT %s_%s%s%s: dimension \"%s\", value is %s, gauge, dt %llu to %llu inclusive\n",
@@ -857,6 +866,9 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
                                     rrdset_units(st),
                                     (unsigned long long)first_time,
                                     (unsigned long long)last_time);
+                            }
+
+                            if (unlikely(output_options & PROMETHEUS_OUTPUT_HELP)) {
                                 generate_as_collected_prom_help(wb, &p, prometheus_collector);
                             }
 
@@ -941,7 +953,7 @@ static inline time_t prometheus_preparation(
         after = now - instance->config.update_every;
     }
 
-    if (output_options & PROMETHEUS_OUTPUT_HELP) {
+    if (output_options & PROMETHEUS_OUTPUT_COMMENT) {
         char *mode;
         if (EXPORTING_OPTIONS_DATA_SOURCE(exporting_options) == EXPORTING_SOURCE_DATA_AS_COLLECTED)
             mode = "as collected";

--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -694,6 +694,16 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
             prometheus_label_copy(family, rrdset_family(st), PROMETHEUS_ELEMENT_MAX);
             prometheus_name_copy(context, rrdset_context(st), PROMETHEUS_ELEMENT_MAX);
 
+            struct gen_parameters p;
+            p.prefix = prefix;
+            p.labels_prefix = plabels_prefix;
+            p.context = context;
+            p.chart = chart;
+            p.family = family;
+            p.output_options = output_options;
+            p.st = st;
+            p.rd = NULL;
+
             int as_collected = (EXPORTING_OPTIONS_DATA_SOURCE(exporting_options) == EXPORTING_SOURCE_DATA_AS_COLLECTED);
             int homogeneous = 1;
             int prometheus_collector = 0;
@@ -735,17 +745,9 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
                     if (as_collected) {
                         // we need as-collected / raw data
 
-                        struct gen_parameters p;
-                        p.prefix = prefix;
-                        p.labels_prefix = instance->config.label_prefix;
-                        p.context = context;
                         p.suffix = suffix;
-                        p.chart = chart;
                         p.dimension = dimension;
-                        p.family = family;
                         p.labels = labels;
-                        p.output_options = output_options;
-                        p.st = st;
                         p.rd = rd;
 
                         if (unlikely(rd->collector.last_collected_time.tv_sec < instance->after))

--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -452,7 +452,7 @@ struct gen_parameters {
  * @param homogeneous a flag for homogeneous charts.
  * @param prometheus_collector a flag for metrics from prometheus collector.
  */
-static void generate_as_collected_prom_help(BUFFER *wb, struct gen_parameters *p, int homogeneous, int prometheus_collector)
+static void generate_as_collected_prom_comment(BUFFER *wb, struct gen_parameters *p, int homogeneous, int prometheus_collector)
 {
     buffer_sprintf(wb, "# COMMENT %s_%s", p->prefix, p->context);
 
@@ -771,7 +771,7 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
                                 PROMETHEUS_ELEMENT_MAX);
 
                             if (unlikely(output_options & PROMETHEUS_OUTPUT_HELP))
-                                generate_as_collected_prom_help(wb, &p, homogeneous, prometheus_collector);
+                                generate_as_collected_prom_comment(wb, &p, homogeneous, prometheus_collector);
 
                             if (unlikely(output_options & PROMETHEUS_OUTPUT_TYPES))
                                 buffer_sprintf(wb, "# TYPE %s_%s%s %s\n", prefix, context, suffix, p.type);
@@ -788,7 +788,7 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
                                 PROMETHEUS_ELEMENT_MAX);
 
                             if (unlikely(output_options & PROMETHEUS_OUTPUT_HELP))
-                                generate_as_collected_prom_help(wb, &p, homogeneous, prometheus_collector);
+                                generate_as_collected_prom_comment(wb, &p, homogeneous, prometheus_collector);
 
                             if (unlikely(output_options & PROMETHEUS_OUTPUT_TYPES))
                                 buffer_sprintf(

--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -687,8 +687,10 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
                         units, rrdset_units(st), PROMETHEUS_ELEMENT_MAX, output_options & PROMETHEUS_OUTPUT_OLDUNITS);
             }
 
-            generate_as_collected_prom_help(wb, context, st);
-            bool plot_type = true;
+            if (output_options & PROMETHEUS_OUTPUT_HELP)
+                generate_as_collected_prom_help(wb, context, st);
+
+            bool plot_type = (output_options & PROMETHEUS_OUTPUT_TYPES) ? true : false;
 
             // for each dimension
             RRDDIM *rd;

--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -485,7 +485,7 @@ static void generate_as_collected_prom_help(BUFFER *wb, struct gen_parameters *p
  * @param prometheus_collector a flag for metrics from prometheus collector.
  * @param chart_labels the dictionary with chart labels
  */
-static void generate_as_collected_prom_metric(BUFFER *wb,
+static void generate_as_collected_from_metric(BUFFER *wb,
                                               struct gen_parameters *p,
                                               int homogeneous,
                                               int prometheus_collector,
@@ -776,7 +776,7 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
                             if (unlikely(output_options & PROMETHEUS_OUTPUT_TYPES))
                                 buffer_sprintf(wb, "# TYPE %s_%s%s %s\n", prefix, context, suffix, p.type);
 
-                            generate_as_collected_prom_metric(wb, &p, homogeneous, prometheus_collector, st->rrdlabels);
+                            generate_as_collected_from_metric(wb, &p, homogeneous, prometheus_collector, st->rrdlabels);
                         }
                         else {
                             // the dimensions of the chart, do not have the same algorithm, multiplier or divisor
@@ -794,7 +794,7 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
                                 buffer_sprintf(
                                     wb, "# TYPE %s_%s_%s%s %s\n", prefix, context, dimension, suffix, p.type);
 
-                            generate_as_collected_prom_metric(wb, &p, homogeneous, prometheus_collector, st->rrdlabels);
+                            generate_as_collected_from_metric(wb, &p, homogeneous, prometheus_collector, st->rrdlabels);
                         }
                     }
                     else {

--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -771,7 +771,6 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
                     else {
                         // we need average or sum of the data
 
-                        time_t first_time = instance->after;
                         time_t last_time = instance->before;
                         NETDATA_DOUBLE value = exporting_calculate_value_from_stored_data(instance, rd, &last_time);
 
@@ -857,11 +856,8 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
 static inline time_t prometheus_preparation(
     struct instance *instance,
     RRDHOST *host,
-    BUFFER *wb,
-    EXPORTING_OPTIONS exporting_options,
     const char *server,
-    time_t now,
-    PROMETHEUS_OUTPUT_OPTIONS output_options)
+    time_t now)
 {
 #ifndef UNIT_TESTING
     analytics_log_prometheus();
@@ -871,10 +867,8 @@ static inline time_t prometheus_preparation(
 
     time_t after = prometheus_server_last_access(server, host, now);
 
-    int first_seen = 0;
     if (!after) {
         after = now - instance->config.update_every;
-        first_seen = 1;
     }
 
     if (after > now) {
@@ -914,11 +908,8 @@ void rrd_stats_api_v1_charts_allmetrics_prometheus_single_host(
     prometheus_exporter_instance->after = prometheus_preparation(
         prometheus_exporter_instance,
         host,
-        wb,
-        exporting_options,
         server,
-        prometheus_exporter_instance->before,
-        output_options);
+        prometheus_exporter_instance->before);
 
     rrd_stats_api_v1_charts_allmetrics_prometheus(
         prometheus_exporter_instance, host, filter_string, wb, prefix, exporting_options, 0, output_options);
@@ -953,11 +944,8 @@ void rrd_stats_api_v1_charts_allmetrics_prometheus_all_hosts(
     prometheus_exporter_instance->after = prometheus_preparation(
         prometheus_exporter_instance,
         host,
-        wb,
-        exporting_options,
         server,
-        prometheus_exporter_instance->before,
-        output_options);
+        prometheus_exporter_instance->before);
 
     dfe_start_reentrant(rrdhost_root_index, host)
     {

--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -440,16 +440,11 @@ struct gen_parameters {
  * Write an as-collected help comment to a buffer.
  *
  * @param wb the buffer to write the comment to.
- * @param p parameters for generating the comment string.
- * @param homogeneous a flag for homogeneous charts.
+ * @param context context name we are using
  */
-static inline void generate_as_collected_prom_help(BUFFER *wb, struct gen_parameters *p, int homogeneous)
+static inline void generate_as_collected_prom_help(BUFFER *wb, char *context, RRDSET *st)
 {
-    buffer_sprintf(wb, "# HELP ");
-    if (p->prefix)
-        buffer_sprintf(wb, "%s_", p->prefix);
-
-    buffer_sprintf(wb, "%s %s\n", p->context, rrdset_title(p->st));
+    buffer_sprintf(wb, "# HELP %s %s\n", context, rrdset_title(st));
 }
 
 /**
@@ -692,12 +687,7 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
                         units, rrdset_units(st), PROMETHEUS_ELEMENT_MAX, output_options & PROMETHEUS_OUTPUT_OLDUNITS);
             }
 
-            struct gen_parameters par;
-            par.prefix = prefix;
-            par.context = context;
-            par.st = st;
-
-            generate_as_collected_prom_help(wb, &par, prometheus_collector);
+            generate_as_collected_prom_help(wb, context, st);
             bool plot_type = true;
 
             // for each dimension

--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -689,11 +689,13 @@ static int prometheus_rrdset_to_json(RRDSET *st, void *data)
                     if (plot_help) {
                         generate_as_collected_prom_help(wb, prefix, context, units, suffix, st);
                         plot_help = false;
+                        opts->output_options &= ~PROMETHEUS_OUTPUT_HELP;
                     }
 
                     if (plot_type) {
-                        plot_type = false;
                         generate_as_collected_prom_type(wb, prefix, context, units, p.suffix, p.type);
+                        plot_type = false;
+                        opts->output_options &= ~PROMETHEUS_OUTPUT_TYPES;
                     }
 
                     if (homogeneous) {
@@ -741,11 +743,13 @@ static int prometheus_rrdset_to_json(RRDSET *st, void *data)
                         if (plot_help) {
                             generate_as_collected_prom_help(wb, prefix, context, units, suffix, st);
                             plot_help = false;
+                            opts->output_options &= ~PROMETHEUS_OUTPUT_HELP;
                         }
 
                         if (plot_type) {
-                            plot_type = false;
                             generate_as_collected_prom_type(wb, prefix, context, units, suffix, "gauge");
+                            plot_type = false;
+                            opts->output_options &= ~PROMETHEUS_OUTPUT_TYPES;
                         }
 
                         buffer_flush(plabels_buffer);
@@ -799,7 +803,10 @@ static inline int prometheus_rrdcontext_to_json_callback(const DICTIONARY_ITEM *
     struct host_variables_callback_options *opts = data;
     (void)value;
 
+    PROMETHEUS_OUTPUT_OPTIONS output_options = opts->output_options;
     (void)rrdcontext_foreach_instance_with_rrdset_in_context(opts->host, context_name, prometheus_rrdset_to_json, data);
+
+    opts->output_options = output_options;
 
     return HTTP_RESP_OK;
 }

--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -711,15 +711,6 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
             prometheus_label_copy(family, rrdset_family(st), PROMETHEUS_ELEMENT_MAX);
             prometheus_name_copy(context, rrdset_context(st), PROMETHEUS_ELEMENT_MAX);
 
-            struct gen_parameters p;
-            p.prefix = prefix;
-            p.labels_prefix = plabels_prefix;
-            p.context = context;
-            p.chart = chart;
-            p.family = family;
-            p.output_options = output_options;
-            p.st = st;
-            p.rd = NULL;
 
             int as_collected = (EXPORTING_OPTIONS_DATA_SOURCE(exporting_options) == EXPORTING_SOURCE_DATA_AS_COLLECTED);
             int homogeneous = 1;
@@ -756,15 +747,23 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
             // for each dimension
             RRDDIM *rd;
             rrddim_foreach_read(rd, st) {
-                p.rd = rd;
 
                 if (rd->collector.counter && !rrddim_flag_check(rd, RRDDIM_FLAG_OBSOLETE)) {
                     char dimension[PROMETHEUS_ELEMENT_MAX + 1];
                     char *suffix = "";
 
+                    struct gen_parameters p;
+                    p.prefix = prefix;
+                    p.labels_prefix = plabels_prefix;
+                    p.context = context;
                     p.suffix = suffix;
+                    p.chart = chart;
                     p.dimension = dimension;
+                    p.family = family;
                     p.labels = labels;
+                    p.output_options = output_options;
+                    p.st = st;
+                    p.rd = rd;
 
                     if (as_collected) {
                         // we need as-collected / raw data

--- a/src/exporting/prometheus/prometheus.h
+++ b/src/exporting/prometheus/prometheus.h
@@ -16,8 +16,9 @@ typedef enum prometheus_output_flags {
     PROMETHEUS_OUTPUT_NAMES      = (1 << 2),
     PROMETHEUS_OUTPUT_TIMESTAMPS = (1 << 3),
     PROMETHEUS_OUTPUT_VARIABLES  = (1 << 4),
-	PROMETHEUS_OUTPUT_OLDUNITS   = (1 << 5),
-	PROMETHEUS_OUTPUT_HIDEUNITS  = (1 << 6)
+    PROMETHEUS_OUTPUT_OLDUNITS   = (1 << 5),
+    PROMETHEUS_OUTPUT_HIDEUNITS  = (1 << 6),
+    PROMETHEUS_OUTPUT_COMMENT    = (1 << 7)
 } PROMETHEUS_OUTPUT_OPTIONS;
 
 void rrd_stats_api_v1_charts_allmetrics_prometheus_single_host(

--- a/src/exporting/prometheus/prometheus.h
+++ b/src/exporting/prometheus/prometheus.h
@@ -17,8 +17,7 @@ typedef enum prometheus_output_flags {
     PROMETHEUS_OUTPUT_TIMESTAMPS = (1 << 3),
     PROMETHEUS_OUTPUT_VARIABLES  = (1 << 4),
     PROMETHEUS_OUTPUT_OLDUNITS   = (1 << 5),
-    PROMETHEUS_OUTPUT_HIDEUNITS  = (1 << 6),
-    PROMETHEUS_OUTPUT_COMMENT    = (1 << 7)
+    PROMETHEUS_OUTPUT_HIDEUNITS  = (1 << 6)
 } PROMETHEUS_OUTPUT_OPTIONS;
 
 void rrd_stats_api_v1_charts_allmetrics_prometheus_single_host(

--- a/src/exporting/prometheus/prometheus.h
+++ b/src/exporting/prometheus/prometheus.h
@@ -11,11 +11,12 @@
 
 typedef enum prometheus_output_flags {
     PROMETHEUS_OUTPUT_NONE       = 0,
-    PROMETHEUS_OUTPUT_NAMES      = (1 << 1),
-    PROMETHEUS_OUTPUT_TIMESTAMPS = (1 << 2),
-    PROMETHEUS_OUTPUT_VARIABLES  = (1 << 3),
-    PROMETHEUS_OUTPUT_OLDUNITS   = (1 << 4),
-    PROMETHEUS_OUTPUT_HIDEUNITS  = (1 << 5)
+    PROMETHEUS_OUTPUT_HELP_TYPE  = (1 << 1),
+    PROMETHEUS_OUTPUT_NAMES      = (1 << 2),
+    PROMETHEUS_OUTPUT_TIMESTAMPS = (1 << 3),
+    PROMETHEUS_OUTPUT_VARIABLES  = (1 << 4),
+    PROMETHEUS_OUTPUT_OLDUNITS   = (1 << 5),
+    PROMETHEUS_OUTPUT_HIDEUNITS  = (1 << 6)
 } PROMETHEUS_OUTPUT_OPTIONS;
 
 void rrd_stats_api_v1_charts_allmetrics_prometheus_single_host(

--- a/src/exporting/prometheus/prometheus.h
+++ b/src/exporting/prometheus/prometheus.h
@@ -11,13 +11,11 @@
 
 typedef enum prometheus_output_flags {
     PROMETHEUS_OUTPUT_NONE       = 0,
-    PROMETHEUS_OUTPUT_HELP       = (1 << 0),
-    PROMETHEUS_OUTPUT_TYPES      = (1 << 1),
-    PROMETHEUS_OUTPUT_NAMES      = (1 << 2),
-    PROMETHEUS_OUTPUT_TIMESTAMPS = (1 << 3),
-    PROMETHEUS_OUTPUT_VARIABLES  = (1 << 4),
-    PROMETHEUS_OUTPUT_OLDUNITS   = (1 << 5),
-    PROMETHEUS_OUTPUT_HIDEUNITS  = (1 << 6)
+    PROMETHEUS_OUTPUT_NAMES      = (1 << 1),
+    PROMETHEUS_OUTPUT_TIMESTAMPS = (1 << 2),
+    PROMETHEUS_OUTPUT_VARIABLES  = (1 << 3),
+    PROMETHEUS_OUTPUT_OLDUNITS   = (1 << 4),
+    PROMETHEUS_OUTPUT_HIDEUNITS  = (1 << 5)
 } PROMETHEUS_OUTPUT_OPTIONS;
 
 void rrd_stats_api_v1_charts_allmetrics_prometheus_single_host(

--- a/src/web/api/exporters/allmetrics.c
+++ b/src/web/api/exporters/allmetrics.c
@@ -38,6 +38,7 @@ inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client
     else
         prometheus_prefix = global_exporting_prefix;
 
+    PROMETHEUS_OUTPUT_OPTIONS set_prometheus = PROMETHEUS_OUTPUT_HELP | PROMETHEUS_OUTPUT_TYPES;
     while(url) {
         char *value = strsep_skip_consecutive_separators(&url, "&");
         if (!value || !*value) continue;
@@ -76,14 +77,18 @@ inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client
                 if(!strcmp(name, prometheus_output_flags_root[i].name)) {
                     if(!strcmp(value, "yes") || !strcmp(value, "1") || !strcmp(value, "true"))
                         prometheus_output_options |= prometheus_output_flags_root[i].flag;
-                    else
+                    else {
                         prometheus_output_options &= ~prometheus_output_flags_root[i].flag;
+                        set_prometheus &= ~prometheus_output_flags_root[i].flag;
+                    }
 
                     break;
                 }
             }
         }
     }
+
+    prometheus_output_options |= set_prometheus;
 
     buffer_flush(w->response.data);
     buffer_no_cacheable(w->response.data);

--- a/src/web/api/exporters/allmetrics.c
+++ b/src/web/api/exporters/allmetrics.c
@@ -13,7 +13,6 @@ struct prometheus_output_options {
     { "variables",  PROMETHEUS_OUTPUT_VARIABLES  },
     { "oldunits",   PROMETHEUS_OUTPUT_OLDUNITS   },
     { "hideunits",  PROMETHEUS_OUTPUT_HIDEUNITS  },
-    { "comment",    PROMETHEUS_OUTPUT_COMMENT    },
     // terminator
     { NULL, PROMETHEUS_OUTPUT_NONE },
 };

--- a/src/web/api/exporters/allmetrics.c
+++ b/src/web/api/exporters/allmetrics.c
@@ -6,8 +6,6 @@ struct prometheus_output_options {
     char *name;
     PROMETHEUS_OUTPUT_OPTIONS flag;
 } prometheus_output_flags_root[] = {
-    { "help",       PROMETHEUS_OUTPUT_HELP       },
-    { "types",      PROMETHEUS_OUTPUT_TYPES      },
     { "names",      PROMETHEUS_OUTPUT_NAMES      },
     { "timestamps", PROMETHEUS_OUTPUT_TIMESTAMPS },
     { "variables",  PROMETHEUS_OUTPUT_VARIABLES  },
@@ -38,7 +36,6 @@ inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client
     else
         prometheus_prefix = global_exporting_prefix;
 
-    PROMETHEUS_OUTPUT_OPTIONS set_prometheus = PROMETHEUS_OUTPUT_HELP | PROMETHEUS_OUTPUT_TYPES;
     while(url) {
         char *value = strsep_skip_consecutive_separators(&url, "&");
         if (!value || !*value) continue;
@@ -79,7 +76,6 @@ inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client
                         prometheus_output_options |= prometheus_output_flags_root[i].flag;
                     else {
                         prometheus_output_options &= ~prometheus_output_flags_root[i].flag;
-                        set_prometheus &= ~prometheus_output_flags_root[i].flag;
                     }
 
                     break;
@@ -87,8 +83,6 @@ inline int web_client_api_request_v1_allmetrics(RRDHOST *host, struct web_client
             }
         }
     }
-
-    prometheus_output_options |= set_prometheus;
 
     buffer_flush(w->response.data);
     buffer_no_cacheable(w->response.data);

--- a/src/web/api/exporters/allmetrics.c
+++ b/src/web/api/exporters/allmetrics.c
@@ -13,6 +13,7 @@ struct prometheus_output_options {
     { "variables",  PROMETHEUS_OUTPUT_VARIABLES  },
     { "oldunits",   PROMETHEUS_OUTPUT_OLDUNITS   },
     { "hideunits",  PROMETHEUS_OUTPUT_HIDEUNITS  },
+    { "comment",    PROMETHEUS_OUTPUT_COMMENT    },
     // terminator
     { NULL, PROMETHEUS_OUTPUT_NONE },
 };

--- a/src/web/api/netdata-swagger.json
+++ b/src/web/api/netdata-swagger.json
@@ -916,6 +916,20 @@
             }
           },
           {
+            "name": "comment",
+            "in": "query",
+            "description": "Enable or disable COMMENT lines in prometheus output.\n",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "yes",
+                "no"
+              ],
+              "default": "no"
+            }
+          },
+          {
             "name": "types",
             "in": "query",
             "description": "Enable or disable TYPE lines in prometheus output.\n",

--- a/src/web/api/netdata-swagger.json
+++ b/src/web/api/netdata-swagger.json
@@ -916,20 +916,6 @@
             }
           },
           {
-            "name": "comment",
-            "in": "query",
-            "description": "Enable or disable COMMENT lines in prometheus output.\n",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "yes",
-                "no"
-              ],
-              "default": "no"
-            }
-          },
-          {
             "name": "types",
             "in": "query",
             "description": "Enable or disable TYPE lines in prometheus output.\n",

--- a/src/web/api/netdata-swagger.json
+++ b/src/web/api/netdata-swagger.json
@@ -912,7 +912,7 @@
                 "yes",
                 "no"
               ],
-              "default": "no"
+              "default": "yes"
             }
           },
           {
@@ -926,7 +926,7 @@
                 "yes",
                 "no"
               ],
-              "default": "no"
+              "default": "yes"
             }
           },
           {

--- a/src/web/api/netdata-swagger.json
+++ b/src/web/api/netdata-swagger.json
@@ -902,34 +902,6 @@
             }
           },
           {
-            "name": "help",
-            "in": "query",
-            "description": "Enable or disable HELP lines in prometheus output.\n",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "yes",
-                "no"
-              ],
-              "default": "yes"
-            }
-          },
-          {
-            "name": "types",
-            "in": "query",
-            "description": "Enable or disable TYPE lines in prometheus output.\n",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "yes",
-                "no"
-              ],
-              "default": "yes"
-            }
-          },
-          {
             "name": "timestamps",
             "in": "query",
             "description": "Enable or disable timestamps in prometheus output.\n",

--- a/src/web/api/netdata-swagger.yaml
+++ b/src/web/api/netdata-swagger.yaml
@@ -565,17 +565,6 @@ paths:
               - yes
               - no
             default: no
-        - name: comment
-          in: query
-          description: |
-            Enable or disable COMMENT lines in prometheus output.
-          required: false
-          schema:
-            type: string
-            enum:
-              - yes
-              - no
-            default: no
         - name: types
           in: query
           description: |

--- a/src/web/api/netdata-swagger.yaml
+++ b/src/web/api/netdata-swagger.yaml
@@ -565,6 +565,17 @@ paths:
               - yes
               - no
             default: no
+        - name: comment
+          in: query
+          description: |
+            Enable or disable COMMENT lines in prometheus output.
+          required: false
+          schema:
+            type: string
+            enum:
+              - yes
+              - no
+            default: no
         - name: types
           in: query
           description: |

--- a/src/web/api/netdata-swagger.yaml
+++ b/src/web/api/netdata-swagger.yaml
@@ -554,28 +554,6 @@ paths:
               - yes
               - no
             default: no
-        - name: help
-          in: query
-          description: |
-            Enable or disable HELP lines in prometheus output.
-          required: false
-          schema:
-            type: string
-            enum:
-              - yes
-              - no
-            default: yes
-        - name: types
-          in: query
-          description: |
-            Enable or disable TYPE lines in prometheus output.
-          required: false
-          schema:
-            type: string
-            enum:
-              - yes
-              - no
-            default: yes
         - name: timestamps
           in: query
           description: |

--- a/src/web/api/netdata-swagger.yaml
+++ b/src/web/api/netdata-swagger.yaml
@@ -564,7 +564,7 @@ paths:
             enum:
               - yes
               - no
-            default: no
+            default: yes
         - name: types
           in: query
           description: |
@@ -575,7 +575,7 @@ paths:
             enum:
               - yes
               - no
-            default: no
+            default: yes
         - name: timestamps
           in: query
           description: |


### PR DESCRIPTION
##### Summary
Fixes https://github.com/netdata/netdata/issues/17161

Our exporter was not showing the expected result for `HELP`, instead we were delivering for users `COMMENTS`. This PR address this issue, bringing the expected `HELP` and `TYPE` for prometheus exporter.

##### Test Plan

1. Compile this branch
2. Access local URL `http://localhost:19999/api/v1/allmetrics?format=prometheus`. You must have `HELP` and `TYPE`
3. Access local URL `http://localhost:19999/api/v1/allmetrics?format=prometheus&types=0`. You should have only `HELP`.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? Exporter
- Can they see the change or is it an under the hood? If they can see it, where? When they are using exporter or access endpoint.
- How is the user impacted by the change? An output compatible with Prometheus HELP.
- What are there any benefits of the change? Netdata is now having HELP command like official documentation.
</details>
