### PR TITLE
Fix issues with permissions when installing from source on macOS

### DIFF
--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -630,6 +630,8 @@ install_darwin_service() {
     exit 4
   fi
 
+  launchctl unload /Library/LaunchDaemons/com.github.netdata.plist 2>/dev/null
+
   if ! launchctl load /Library/LaunchDaemons/com.github.netdata.plist; then
     error "Failed to load plist file."
     exit 4


### PR DESCRIPTION
##### Summary

This is not a proper fix but a workaround:

1. set the shell to false to hide from the login screen.
2. set the `IsHidden` flag to hide from System Preferences.
3. set home to a non-existent dir to not create a dir in /Users/.
4. set the user's GID to the `netdata` group GID. This fixes the problem with permissions: NETDATA_GROUP will be `netdata` and not `staff`, see [this line](https://github.com/netdata/netdata/blob/b2f1a09b05dac707a2e82c6f3cc28e5159ff7cf0/netdata-installer.sh#L1106).

The group is still visible in the System Preferences.

A proper fix would be:

- User: create a role account, not a system user. These are the requirements:
  - name must be starting with `_`.
  - UID must be in the 200-400 range.
- Group: GID must be < 500 to hide the group from System Preferences.

Unfortunately, there is no option to "find an available UID from 200-400/GID below 500". We need to:

- find all used UIDs/GIDs.
- find available and use it when creating a user/group.

It doesn't look trivial to me. I will open an issue.

##### Test Plan

- Clean install
- Reinstall

Check errors during installation and permissions (running plugins/claiming).

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
