### PR TITLE
WIP: Support for Canonical Snap builds to run on Ubuntu Core 

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Initialize configuration and var directory skeleton
+cp -rp "$SNAP/opt/netdata/etc" "$SNAP_COMMON/etc"
+cp -rp "$SNAP/opt/netdata/var" "$SNAP_DATA/var"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,59 @@
+name: netdata # you probably want to 'snapcraft register <name>'
+base: core22 # the base snap is the execution environment for this snap
+version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
+summary: Netdata Agent
+description: |
+  Netdata is distributed, real-time, performance and health monitoring for
+  systems and applications. It provides insights of everything happening on the
+  systems it runs using interactive web dashboards.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict # use 'strict' once you have the right plugs and slots
+
+layout:
+  /opt/netdata/bin:
+    symlink: $SNAP/opt/netdata/bin
+  /opt/netdata/etc:
+    symlink: $SNAP_COMMON/etc
+  /opt/netdata/share:
+    symlink: $SNAP/opt/netdata/share
+  /opt/netdata/usr:
+    symlink: $SNAP/opt/netdata/usr
+  /opt/netdata/var:
+    symlink: $SNAP_DATA/var
+
+parts:
+  netdata:
+    plugin: nil
+    build-packages:
+      - wget
+    override-pull: |
+      wget https://get.netdata.cloud/kickstart.sh
+    override-build: |
+      sh ./kickstart.sh --static-only --dont-start-it
+      mkdir -p $SNAPCRAFT_PART_INSTALL/opt
+      mv /opt/netdata $SNAPCRAFT_PART_INSTALL/opt/netdata
+    stage-packages:
+      - wget
+    prime:
+      - -opt/netdata/var/cache/netdata/.keep
+      - -opt/netdata/var/lib/netdata/.keep
+      - -opt/netdata/var/log/netdata/.keep
+
+apps:
+  agent:
+    command: opt/netdata/bin/netdata -u root -P /opt/netdata/var/run/netdata.pid -D
+    daemon: simple
+    plugs:
+      - network
+      - network-bind
+  claim:
+    command: opt/netdata/bin/netdata-claim.sh
+    plugs:
+      - network
+  cli:
+    command: opt/netdata/bin/netdatacli
+  log2journal:
+    command: opt/netdata/bin/log2journal
+  systemd-cat-native:
+    command: opt/netdata/bin/systemd-cat-native

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,6 +45,7 @@ apps:
     command: opt/netdata/bin/netdata -u root -P /opt/netdata/var/run/netdata.pid -D
     daemon: simple
     plugs:
+      - docker-support
       - login-session-observe
       - mount-observe
       - network-observe

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,6 +46,7 @@ apps:
     daemon: simple
     plugs:
       - login-session-observe
+      - mount-observe
       - network
       - network-bind
   claim:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,6 +45,7 @@ apps:
     command: opt/netdata/bin/netdata -u root -P /opt/netdata/var/run/netdata.pid -D
     daemon: simple
     plugs:
+      - login-session-observe
       - network
       - network-bind
   claim:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,6 +47,7 @@ apps:
     plugs:
       - login-session-observe
       - mount-observe
+      - network-observe
       - network
       - network-bind
       - system-observe

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,6 +49,7 @@ apps:
       - mount-observe
       - network
       - network-bind
+      - system-observe
   claim:
     command: opt/netdata/bin/netdata-claim.sh
     plugs:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,6 +48,7 @@ apps:
       - login-session-observe
       - mount-observe
       - network-observe
+      - network-setup-observe
       - network
       - network-bind
       - system-observe


### PR DESCRIPTION
##### Summary

Provide the ability to create a Snap package for Netdata Agent and associated utilities.

##### Test Plan

TBD

##### Additional Information

This worked is based on a request for supporting Ubuntu Core, which is primarily used in IoT settings, but is also the framework within which (most) Snaps run.

This PR takes a different approach than #1991, in that instead of a full build as part of the snapcraft building process, it takes the static builds and packages them. That PR had a request to move the `snap` directory to another place than the root of the repo, but snapcraft makes this *very* hard, and if we decide to make a huge point on this, there may be some avenues I can try, but it most likely means that the YAML file will be `.snapcraft.yaml` and other things like hooks need to be populated explicitly.

The major issue with running the Agent in this environment is providing sufficient permissions in the strict confinement model, through so-called _plugs_ for [_interfaces_](https://snapcraft.io/docs/supported-interfaces).