### PR TITLE
Add -Wno-builtin-macro-redefined to compiler flags.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,8 @@ foreach(FLAG function-sections data-sections)
         add_simple_extra_compiler_flag("${FLAG}" "-f${FLAG}" EXTRA_OPT)
 endforeach()
 
+add_simple_extra_compiler_flag("-Wbuiltin-macro-redefined" "-Wno-builtin-macro-redefined" EXTRA_OPT)
+
 foreach(RELTYP RELEASE DEBUG RELWITHDEBINFO MINSIZEREL)
         foreach(L C CXX)
                 set(CMAKE_${L}_FLAGS_${RELTYP} "${CMAKE_${L}_FLAGS_${RELTYP}} ${EXTRA_HARDENING_C_FLAGS} ${EXTRA_OPT_C_FLAGS}")


### PR DESCRIPTION
##### Summary

This silences warnings about macros that are provided by the preprocessor/compiler itself being redefined.

This is needed to silence warnings about `_FORTIFY_SOURCE` being redefined, which are being generated as we prefer a more aggressive value for it than what most distros provide by default. Without this change, the build is really noisy on many systems, and also fails when run with `-Werror`.

It is also required long-term to allow for reproducible builds without throwing errors, as they need to redefine a number of macros provided by the preprocessor at build time.

##### Test Plan

CI passes on this PR.