### PR TITLE
Add constant page type

### DIFF
--- a/src/daemon/global_statistics.h
+++ b/src/daemon/global_statistics.h
@@ -50,6 +50,10 @@ void global_statistics_gorilla_buffer_add_hot();
 void global_statistics_tier0_disk_compressed_bytes(uint32_t size);
 void global_statistics_tier0_disk_uncompressed_bytes(uint32_t size);
 
+void global_statistic_raw_page_new();
+void global_statistic_constant_page_new();
+void global_statistic_constant_page_rm();
+
 void global_statistics_web_request_completed(uint64_t dt,
                                              uint64_t bytes_received,
                                              uint64_t bytes_sent,

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -1169,11 +1169,14 @@ static void get_netdata_configured_variables() {
     // ------------------------------------------------------------------------
     // get default Database Engine page type
 
-    const char *page_type = config_get(CONFIG_SECTION_DB, "dbengine page type", "raw");
+    const char *page_type = config_get(CONFIG_SECTION_DB, "dbengine page type", "constant");
     if (strcmp(page_type, "gorilla") == 0) {
         tier_page_type[0] = PAGE_GORILLA_METRICS;
+    }
+    else if (strcmp(page_type, "constant") == 0) {
+        tier_page_type[0] = PAGE_CONSTANT_METRICS;
     } else if (strcmp(page_type, "raw") != 0) {
-        netdata_log_error("Invalid dbengine page type ''%s' given. Defaulting to 'raw'.", page_type);
+        netdata_log_error("Invalid dbengine page type '%s' (expected one of 'constant', 'gorilla', 'raw'). Defaulting to 'constant'.", page_type);
     }
 
     // ------------------------------------------------------------------------

--- a/src/database/engine/page.c
+++ b/src/database/engine/page.c
@@ -727,6 +727,7 @@ bool pgdc_get_next_point(PGDC *pgdc, uint32_t expected_position __maybe_unused, 
             return true;
         }
         case PAGE_CONSTANT_METRICS: {
+            pgdc->position++;
             storage_number n = pgdc->pgd->constant.v;
 
             sp->min = sp->max = sp->sum = unpack_storage_number(n);

--- a/src/database/engine/page_test.cc
+++ b/src/database/engine/page_test.cc
@@ -38,7 +38,7 @@ static uint8_t page_type = PAGE_GORILLA_METRICS;
 
 static size_t slots_for_page(size_t n) {
     switch (page_type) {
-        case PAGE_METRICS:
+        case PAGE_RAW_METRICS:
             return 1024;
         case PAGE_GORILLA_METRICS:
             return n;
@@ -200,7 +200,7 @@ TEST(PGD, MemoryFootprint) {
 
     uint32_t footprint = 0;
     switch (pgd_type(pg)) {
-        case PAGE_METRICS:
+        case PAGE_RAW_METRICS:
             footprint = slots * sizeof(uint32_t);
             break;
         case PAGE_GORILLA_METRICS:
@@ -225,7 +225,7 @@ TEST(PGD, MemoryFootprint) {
 
     uint32_t abs_error = 0;
     switch (pgd_type(pg)) {
-        case PAGE_METRICS:
+        case PAGE_RAW_METRICS:
             abs_error = 128;
             break;
         case PAGE_GORILLA_METRICS:
@@ -256,7 +256,7 @@ TEST(PGD, DiskFootprint) {
 
     uint32_t footprint = 0;
     switch (pgd_type(pg)) {
-        case PAGE_METRICS:
+        case PAGE_RAW_METRICS:
             footprint = used_slots * sizeof(uint32_t);
             break;
         case PAGE_GORILLA_METRICS:
@@ -279,7 +279,7 @@ TEST(PGD, DiskFootprint) {
     }
 
     switch (pgd_type(pg)) {
-        case PAGE_METRICS:
+        case PAGE_RAW_METRICS:
             footprint = used_slots * sizeof(uint32_t);
             break;
         case PAGE_GORILLA_METRICS:

--- a/src/database/engine/rrddiskprotocol.h
+++ b/src/database/engine/rrddiskprotocol.h
@@ -36,10 +36,11 @@ struct rrdeng_df_sb {
 /*
  * Page types
  */
-#define PAGE_METRICS    (0)
+#define PAGE_RAW_METRICS    (0)
 #define PAGE_TIER       (1)
 #define PAGE_GORILLA_METRICS    (2)
-#define PAGE_TYPE_MAX   2   // Maximum page type (inclusive)
+#define PAGE_CONSTANT_METRICS    (3)
+#define PAGE_TYPE_MAX   3   // Maximum page type (inclusive)
 
 /*
  * Data file page descriptor
@@ -55,6 +56,11 @@ struct rrdeng_extent_page_descr {
             uint32_t entries;
             uint32_t delta_time_s;
         } gorilla  __attribute__((packed));
+
+        struct {
+            uint32_t entries;
+            uint32_t delta_time_s;
+        } constant  __attribute__((packed));
 
         uint64_t end_time_ut;
     };

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -844,13 +844,17 @@ static struct extent_io_descriptor *datafile_extent_build(struct rrdengine_insta
         header->descr[i].start_time_ut = descr->start_time_ut;
 
         switch (descr->type) {
-            case PAGE_METRICS:
+            case PAGE_RAW_METRICS:
             case PAGE_TIER:
                 header->descr[i].end_time_ut = descr->end_time_ut;
                 break;
             case PAGE_GORILLA_METRICS:
                 header->descr[i].gorilla.delta_time_s = (uint32_t) ((descr->end_time_ut - descr->start_time_ut) / USEC_PER_SEC);
                 header->descr[i].gorilla.entries = pgd_slots_used(descr->pgd);
+                break;
+            case PAGE_CONSTANT_METRICS:
+                header->descr[i].constant.delta_time_s = (uint32_t) ((descr->end_time_ut - descr->start_time_ut) / USEC_PER_SEC);
+                header->descr[i].constant.entries = pgd_slots_used(descr->pgd);
                 break;
             default:
                 fatal("Unknown page type: %uc", descr->type);

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -16,7 +16,7 @@ struct rrdengine_instance multidb_ctx_storage_tier4;
 #error RRD_STORAGE_TIERS is not 5 - you need to add allocations here
 #endif
 struct rrdengine_instance *multidb_ctx[RRD_STORAGE_TIERS];
-uint8_t tier_page_type[RRD_STORAGE_TIERS] = {PAGE_METRICS, PAGE_TIER, PAGE_TIER, PAGE_TIER, PAGE_TIER};
+uint8_t tier_page_type[RRD_STORAGE_TIERS] = {PAGE_CONSTANT_METRICS, PAGE_TIER, PAGE_TIER, PAGE_TIER, PAGE_TIER};
 
 #if defined(ENV32BIT)
 size_t tier_page_size[RRD_STORAGE_TIERS] = {2048, 1024, 192, 192, 192};
@@ -24,14 +24,15 @@ size_t tier_page_size[RRD_STORAGE_TIERS] = {2048, 1024, 192, 192, 192};
 size_t tier_page_size[RRD_STORAGE_TIERS] = {4096, 2048, 384, 384, 384};
 #endif
 
-#if PAGE_TYPE_MAX != 2
-#error PAGE_TYPE_MAX is not 2 - you need to add allocations here
+#if PAGE_TYPE_MAX != 3
+#error PAGE_TYPE_MAX is not 3 - you need to add allocations here
 #endif
 
 size_t page_type_size[256] = {
-        [PAGE_METRICS] = sizeof(storage_number),
+        [PAGE_RAW_METRICS] = sizeof(storage_number),
         [PAGE_TIER] = sizeof(storage_number_tier1_t),
-        [PAGE_GORILLA_METRICS] = sizeof(storage_number)
+        [PAGE_GORILLA_METRICS] = sizeof(storage_number),
+        [PAGE_CONSTANT_METRICS] = sizeof(storage_number),
 };
 
 __attribute__((constructor)) void initialize_multidb_ctx(void) {
@@ -457,7 +458,8 @@ static PGD *rrdeng_alloc_new_page_data(struct rrdeng_collect_handle *handle, siz
     *data_size = size;
 
     switch (ctx->config.page_type) {
-        case PAGE_METRICS:
+        case PAGE_CONSTANT_METRICS:
+        case PAGE_RAW_METRICS:
         case PAGE_TIER:
             d = pgd_create(ctx->config.page_type, slots);
             break;


### PR DESCRIPTION
##### Summary

Adds a constant page type that stores efficiently pages that contain the same value.

Experimental results show that we achieve the same memory reduction as the gorilla page type, ie. around 50-75% of the pages are of constant type. However: (a) the implementation is far simpler, (b) it's easy to extend the concept to non-zero tiers (whereas the gorilla implementation is not applicable to non-zero tiers).

##### Test Plan

- CI jobs
- Running agent on parent 3.