### PR TITLE
DBENGINE: use gorilla by default

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -1170,9 +1170,12 @@ static void get_netdata_configured_variables() {
     // get default Database Engine page type
 
     const char *page_type = config_get(CONFIG_SECTION_DB, "dbengine page type", "gorilla");
-    if (strcmp(page_type, "gorilla") == 0) {
+    if (strcmp(page_type, "gorilla") == 0)
         tier_page_type[0] = PAGE_GORILLA_METRICS;
-    } else if (strcmp(page_type, "raw") != 0) {
+    else if (strcmp(page_type, "raw") == 0)
+        tier_page_type[0] = PAGE_METRICS;
+    else {
+        tier_page_type[0] = PAGE_METRICS;
         netdata_log_error("Invalid dbengine page type ''%s' given. Defaulting to 'raw'.", page_type);
     }
 
@@ -1521,6 +1524,11 @@ int main(int argc, char **argv) {
 
                         if(strcmp(optarg, "unittest") == 0) {
                             unittest_running = true;
+
+                            // set defaults for dbegnine unittest
+                            config_set(CONFIG_SECTION_DB, "dbengine page type", "gorilla");
+                            default_rrdeng_disk_quota_mb = default_multidb_disk_quota_mb = 256;
+
                             if (sqlite_library_init())
                                 return 1;
 

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -1169,7 +1169,7 @@ static void get_netdata_configured_variables() {
     // ------------------------------------------------------------------------
     // get default Database Engine page type
 
-    const char *page_type = config_get(CONFIG_SECTION_DB, "dbengine page type", "raw");
+    const char *page_type = config_get(CONFIG_SECTION_DB, "dbengine page type", "gorilla");
     if (strcmp(page_type, "gorilla") == 0) {
         tier_page_type[0] = PAGE_GORILLA_METRICS;
     } else if (strcmp(page_type, "raw") != 0) {

--- a/src/database/engine/dbengine-unittest.c
+++ b/src/database/engine/dbengine-unittest.c
@@ -5,9 +5,9 @@
 #ifdef ENABLE_DBENGINE
 
 #define CHARTS 64
-#define DIMS 8 // CHARTS * DIMS dimensions
+#define DIMS 16 // CHARTS * DIMS dimensions
 #define REGIONS 11
-#define POINTS_PER_REGION 4096
+#define POINTS_PER_REGION 16384
 static const int REGION_UPDATE_EVERY[REGIONS] = {1, 15, 3, 20, 2, 6, 30, 12, 5, 4, 10};
 
 #define START_TIMESTAMP MAX(2 * API_RELATIVE_TIME_MAX, 200000000)

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -16,7 +16,7 @@ struct rrdengine_instance multidb_ctx_storage_tier4;
 #error RRD_STORAGE_TIERS is not 5 - you need to add allocations here
 #endif
 struct rrdengine_instance *multidb_ctx[RRD_STORAGE_TIERS];
-uint8_t tier_page_type[RRD_STORAGE_TIERS] = {PAGE_METRICS, PAGE_TIER, PAGE_TIER, PAGE_TIER, PAGE_TIER};
+uint8_t tier_page_type[RRD_STORAGE_TIERS] = {PAGE_GORILLA_METRICS, PAGE_TIER, PAGE_TIER, PAGE_TIER, PAGE_TIER};
 
 #if defined(ENV32BIT)
 size_t tier_page_size[RRD_STORAGE_TIERS] = {2048, 1024, 192, 192, 192};


### PR DESCRIPTION
Switch to gorilla compression by default for dbengine.