### PR TITLE
feat: offer dashboard v2 enablement features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ set(CONFIG_H_DIR ${CMAKE_BINARY_DIR})
 set(CONFIG_H ${CONFIG_H_DIR}/config.h)
 
 option(ENABLE_CLOUD "enable cloud" True)
+option(ENABLE_DASHBOARD_V2 "enable dashboard v2" True)
 option(ENABLE_ACLK "enable aclk" True)
 option(ENABLE_ML "enable machine learning" True)
 option(ENABLE_H2O "enable h2o" True)
@@ -2674,7 +2675,9 @@ endif()
 #
 
 include(src/web/gui/v1/dashboard_v1.cmake)
-include(src/web/gui/v2/dashboard_v2.cmake)
+if(ENABLE_DASHBOARD_V2)
+        include(src/web/gui/v2/dashboard_v2.cmake)
+endif()
 include(src/web/gui/gui.cmake)
 
 function(cat IN_FILE OUT_FILE)


### PR DESCRIPTION
##### Summary

Fixes #15640 https://github.com/netdata/netdata/issues/16035.

Dashboard V2 is under NCUL1 (https://raw.githubusercontent.com/netdata/netdata/master/src/web/gui/v2/LICENSE.md).

For packagers, to convey the accurate set of licenses, it is helpful to distinguish free licenses from free + unfree redistributable components.

In NixOS, we have two expressions of netdata: `netdataCloud` containing all the cloud features, including the cloud UI (unfree) and `netdata` (free) stripped of all cloud features.

We carried another version of this patch for the Makefile, this would make the packager's work easier to put it at the build system level.

##### Test Plan

Deploying this with `-DENABLE_DASHBOARD_V2=off` just fallback to the v1 dashboard.

##### Additional Information

FWIW, I completely understand the need of NCUL1, but I need to abide the rules of licensing as a NixOS developer. Some folks would like to use software while abiding a 100% free software rule, we offer that possibility, and, we would like to keep it. I personally use the cloud UI because of the value it brings me, but carrying a weird patch downstream is worse for our users in terms of security. I would like this to come to an end with this PR, if that's possible.