### PR TITLE
apps_proc_pid_fd: ignore kf_sock_inpcb on modern FreeBSD

### DIFF
--- a/src/collectors/apps.plugin/apps_proc_pid_fd.c
+++ b/src/collectors/apps.plugin/apps_proc_pid_fd.c
@@ -551,9 +551,11 @@ static bool read_pid_file_descriptors_per_os(struct pid_stat *p, void *ptr) {
                     switch (fds->kf_sock_domain) {
                         case AF_INET:
                         case AF_INET6:
+#if __FreeBSD_version < 1400074
                             if (fds->kf_sock_protocol == IPPROTO_TCP)
                                 sprintf(fdsname, "socket: %d %lx", fds->kf_sock_protocol, fds->kf_un.kf_sock.kf_sock_inpcb);
                             else
+#endif
                                 sprintf(fdsname, "socket: %d %lx", fds->kf_sock_protocol, fds->kf_un.kf_sock.kf_sock_pcb);
                             break;
                         case AF_UNIX:


### PR DESCRIPTION
In legacy versions TCP control block had a different pointer.  In modern FreeBSD the generic inpcb and protocol specific pcb is the same pointer.

For reference two FreeBSD commits:
* merge inpcb with tcpcb e68b3792440cac248347afe08ba5881a00ba6523
* netstat(1) to use the new pointer 8e813d07c6804f80e1380b54f6e5fa6d34a3be52 and a test build to detect software that uses legacy pointer:
* https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=277659