### PR TITLE
remove USR1 "Save internal DB to disk"

### DIFF
--- a/src/daemon/README.md
+++ b/src/daemon/README.md
@@ -110,7 +110,6 @@ The command line options of the Netdata 1.10.0 version are the following:
  Signals netdata handles:
 
   - HUP                    Close and reopen log files.
-  - USR1                   Save internal DB to disk.
   - USR2                   Reload health configuration.
 ```
 

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -820,7 +820,6 @@ int help(int exitcode) {
 
     fprintf(stream, "\n Signals netdata handles:\n\n"
             "  - HUP                    Close and reopen log files.\n"
-            "  - USR1                   Save internal DB to disk.\n"
             "  - USR2                   Reload health configuration.\n"
             "\n"
     );

--- a/system/freebsd/rc.d/netdata.in
+++ b/system/freebsd/rc.d/netdata.in
@@ -17,10 +17,9 @@ required_files="@configdir_POST@/netdata.conf"
 start_precmd="netdata_prestart"
 stop_postcmd="netdata_poststop"
 
-extra_commands="reloadhealth savedb"
+extra_commands="reloadhealth"
 
 reloadhealth_cmd="netdata_reloadhealth"
-savedb_cmd="netdata_savedb"
 
 netdata_prestart()
 {
@@ -39,13 +38,6 @@ netdata_reloadhealth()
 {
     p=`cat ${pidfile}`
     kill -USR2 ${p} && echo "Sent USR2 (reload health) to pid ${p}"
-    return 0
-}
-
-netdata_savedb()
-{
-    p=`cat ${pidfile}`
-    kill -USR2 ${p} && echo "Sent USR1 (save db) to pid ${p}"
     return 0
 }
 

--- a/system/openrc/init.d/netdata.in
+++ b/system/openrc/init.d/netdata.in
@@ -6,10 +6,9 @@ NETDATA_PIDFILE="@localstatedir_POST@/run/netdata/netdata.pid"
 
 description="Run the Netdata system monitoring agent."
 
-extra_started_commands="reload rotate save"
+extra_started_commands="reload rotate"
 description_reload="Reload health configuration."
 description_rotate="Reopen log files."
-description_save="Force sync of database to disk."
 
 command_prefix="@sbindir_POST@"
 command="${command_prefix}/netdata"
@@ -69,11 +68,4 @@ rotate() {
             "Reopening Netdata log files" \
             "Failed to reopen Netdata log files" \
             SIGHUP
-}
-
-save() {
-    run_cmd save-database \
-            "Saving Netdata database" \
-            "Failed to save Netdata database" \
-            SIGUSR1
 }


### PR DESCRIPTION
##### Summary

Fixes: #16981

I think  USR1 "Save internal DB to disk" was used by memory mode save/map - these modes were removed in #16604.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
