### PR TITLE
go.d: sd local-listeners: discover /proc/net/tcp6 only apps

### DIFF
--- a/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/netlisteners_test.go
+++ b/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/netlisteners_test.go
@@ -88,14 +88,6 @@ func TestDiscoverer_Discover(t *testing.T) {
 						Cmdline:   "/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D",
 					}),
 					withHash(&target{
-						Protocol:  "TCP6",
-						IPAddress: "::1",
-						Port:      "8125",
-						Address:   "[::1]:8125",
-						Comm:      "netdata",
-						Cmdline:   "/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D",
-					}),
-					withHash(&target{
 						Protocol:  "TCP",
 						IPAddress: "127.0.0.1",
 						Port:      "8125",

--- a/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/netlisteners_test.go
+++ b/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/netlisteners_test.go
@@ -21,6 +21,8 @@ func TestDiscoverer_Discover(t *testing.T) {
 				cli.addListener("TCP|0.0.0.0|8125|/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D")
 				cli.addListener("TCP|192.0.2.1|8125|/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D")
 				cli.addListener("UDP|127.0.0.1|53768|/opt/netdata/usr/libexec/netdata/plugins.d/go.d.plugin 1")
+				cli.addListener("TCP6|::|80|/usr/sbin/apache2 -k start")
+				cli.addListener("TCP|0.0.0.0|80|/usr/sbin/apache2 -k start")
 				time.Sleep(interval * 2)
 			},
 			wantGroups: []model.TargetGroup{&targetGroup{
@@ -28,20 +30,12 @@ func TestDiscoverer_Discover(t *testing.T) {
 				source:   "discoverer=net_listeners,host=localhost",
 				targets: []model.Target{
 					withHash(&target{
-						Protocol:  "UDP6",
-						IPAddress: "::1",
-						Port:      "8125",
-						Address:   "[::1]:8125",
-						Comm:      "netdata",
-						Cmdline:   "/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D",
-					}),
-					withHash(&target{
-						Protocol:  "TCP6",
-						IPAddress: "::1",
-						Port:      "8125",
-						Address:   "[::1]:8125",
-						Comm:      "netdata",
-						Cmdline:   "/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D",
+						Protocol:  "TCP",
+						IPAddress: "127.0.0.1",
+						Port:      "80",
+						Address:   "127.0.0.1:80",
+						Comm:      "apache2",
+						Cmdline:   "/usr/sbin/apache2 -k start",
 					}),
 					withHash(&target{
 						Protocol:  "TCP",
@@ -58,6 +52,14 @@ func TestDiscoverer_Discover(t *testing.T) {
 						Address:   "127.0.0.1:53768",
 						Comm:      "go.d.plugin",
 						Cmdline:   "/opt/netdata/usr/libexec/netdata/plugins.d/go.d.plugin 1",
+					}),
+					withHash(&target{
+						Protocol:  "UDP6",
+						IPAddress: "::1",
+						Port:      "8125",
+						Address:   "[::1]:8125",
+						Comm:      "netdata",
+						Cmdline:   "/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D",
 					}),
 				},
 			}},
@@ -127,14 +129,6 @@ func TestDiscoverer_Discover(t *testing.T) {
 				provider: "sd:net_listeners",
 				source:   "discoverer=net_listeners,host=localhost",
 				targets: []model.Target{
-					withHash(&target{
-						Protocol:  "TCP6",
-						IPAddress: "::1",
-						Port:      "8125",
-						Address:   "[::1]:8125",
-						Comm:      "netdata",
-						Cmdline:   "/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D",
-					}),
 					withHash(&target{
 						Protocol:  "TCP",
 						IPAddress: "127.0.0.1",

--- a/src/go/collectors/go.d.plugin/config/go.d/sd/docker.conf
+++ b/src/go/collectors/go.d.plugin/config/go.d/sd/docker.conf
@@ -129,7 +129,7 @@ compose:
         template: |
           module: mysql
           name: docker_{{.Name}}
-          dsn: netdata@tcp({{.IPAddress}}:{{.PrivatePort}})/
+          dsn: netdata@tcp({{.Address}})/
       - selector: "nginx"
         template: |
           module: nginx
@@ -139,22 +139,22 @@ compose:
         template: |
           module: pgbouncer
           name: docker_{{.Name}}
-          dsn: postgres://netdata:postgres@{{.IPAddress}}:{{.PrivatePort}}/pgbouncer
+          dsn: postgres://netdata:postgres@{{.Address}}/pgbouncer
       - selector: "pika"
         template: |
           module: pika
           name: docker_{{.Name}}
-          address: redis://@{{.IPAddress}}:{{.PrivatePort}}
+          address: redis://@{{.Address}}
       - selector: "postgres"
         template: |
           module: postgres
           name: docker_{{.Name}}
-          dsn: postgres://netdata:postgres@{{.IPAddress}}:{{.PrivatePort}}/postgres
+          dsn: postgres://netdata:postgres@{{.Address}}/postgres
       - selector: "proxysql"
         template: |
           module: proxysql
           name: docker_{{.Name}}
-          dsn: stats:stats@tcp({{.IPAddress}}:{{.PrivatePort}})/
+          dsn: stats:stats@tcp({{.Address}})/
       - selector: "rabbitmq"
         template: |
           module: rabbitmq
@@ -164,7 +164,7 @@ compose:
         template: |
           module: redis
           name: docker_{{.Name}}
-          address: redis://@{{.IPAddress}}:{{.PrivatePort}}
+          address: redis://@{{.Address}}
       - selector: "tengine"
         template: |
           module: tengine

--- a/src/go/collectors/go.d.plugin/config/go.d/sd/net_listeners.conf
+++ b/src/go/collectors/go.d.plugin/config/go.d/sd/net_listeners.conf
@@ -15,7 +15,7 @@ classify:
       - tags: "activemq"
         expr: '{{ and (eq .Port "8161") (eq .Comm "activemq") }}'
       - tags: "apache"
-        expr: '{{ and (eq .Port "80" "8080") (eq .Comm "apache" "httpd") }}'
+        expr: '{{ and (eq .Port "80" "8080") (eq .Comm "apache" "apache2" "httpd") }}'
       - tags: "bind"
         expr: '{{ and (eq .Port "8653") (eq .Comm "bind" "named") }}'
       - tags: "cassandra"
@@ -270,7 +270,7 @@ compose:
         template: |
           module: mysql
           name: local
-          dsn: netdata@tcp({{.IPAddress}}:{{.Port}})/
+          dsn: netdata@tcp({{.Address}})/
       - selector: "nginx"
         template: |
           - module: nginx
@@ -300,7 +300,7 @@ compose:
         template: |
           module: pgbouncer
           name: local
-          dsn: postgres://netdata:postgres@{{.IPAddress}}:{{.Port}}/pgbouncer
+          dsn: postgres://netdata:postgres@{{.Address}}/pgbouncer
       - selector: "pihole"
         template: |
           module: pihole
@@ -315,7 +315,7 @@ compose:
         template: |
           module: postgres
           name: local
-          dsn: postgresql://netdata@{{.IPAddress}}:{{.Port}}/postgres
+          dsn: postgresql://netdata@{{.Address}}/postgres
       - selector: "powerdns"
         template: |
           module: powerdns
@@ -334,7 +334,7 @@ compose:
         template: |
           module: proxysql
           name: local
-          dsn: stats:stats@tcp({{.IPAddress}}:{{.Port}})/
+          dsn: stats:stats@tcp({{.Address}})/
       - selector: "rabbitmq"
         template: |
           module: rabbitmq
@@ -347,7 +347,7 @@ compose:
         template: |
           module: redis
           name: local
-          address: redis://@{{.IPAddress}}:{{.Port}}
+          address: redis://@{{.Address}}
       - selector: "supervisord"
         template: |
           module: supervisord


### PR DESCRIPTION
##### Summary

- **Enhanced process discovery**: Previously, the code only discovered applications listening on IPv4 sockets (`/proc/net/tcp`). This fix ensures applications listening on all interfaces (including IPv6) are discovered by including entries from `/proc/net/tcp6`. Note: Applications might listen on IPv4 without a `/proc/net/tcp` entry.
- **Improved IPv6 handling**: This fix updates configurations to use _Address_ instead of the combination of _IPAddress_ and _Port_. _Address_ handles IPv6 better (uses brackets `[]` for formatting).
- **Fix Apache identification**: The code now reliably identifies Apache processes based on the process name `apache2` (tested on Debian).

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
