### PR TITLE
Correctly propagate errors from child scripts in kickstart.sh.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -534,11 +534,15 @@ run_script() {
   # shellcheck disable=SC2086
   run ${ROOTCMD} "${@}"
 
+  ret="$?"
+
   if [ -r "${NETDATA_SCRIPT_STATUS_PATH}" ]; then
     # shellcheck disable=SC1090
     . "${NETDATA_SCRIPT_STATUS_PATH}"
     rm -f "${NETDATA_SCRIPT_STATUS_PATH}"
   fi
+
+  return "${ret}"
 }
 
 warning() {


### PR DESCRIPTION
##### Summary

This fixes a bug introduced by #13802 which would cause errors in scripts run by the kickstart script to correctly be reported as warnings by the kickstart script, but not actually cause the script to fail in cases when it should have.

##### Test Plan

The simplest test case involves forcing a local build on a system where a local build is not actually possible.