### PR TITLE
Patch release 1.45.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2096,14 +2096,7 @@ if(PCRE2_FOUND)
         target_compile_definitions(log2journal PUBLIC ${PCRE2_CFLAGS_OTHER})
         target_link_libraries(log2journal PUBLIC "${PCRE2_LDFLAGS}")
 
-        if(ENABLE_BUNDLED_YAML)
-                target_include_directories(log2journal BEFORE PUBLIC "${CMAKE_SOURCE_DIR}/externaldeps/libyaml")
-                target_link_libraries(log2journal PUBLIC yaml)
-        else()
-                target_include_directories(log2journal BEFORE PUBLIC ${YAML_INCLUDE_DIRS})
-                target_compile_definitions(log2journal PUBLIC ${YAML_CFLAGS_OTHER})
-                target_link_libraries(log2journal PUBLIC ${YAML_LDFLAGS})
-        endif()
+        netdata_add_libyaml_to_target(log2journal)
 
         install(TARGETS log2journal
                 COMPONENT log2journal

--- a/packaging/cmake/Modules/NetdataGoTools.cmake
+++ b/packaging/cmake/Modules/NetdataGoTools.cmake
@@ -5,9 +5,9 @@
 # SPDX-License-Identifier: GPL
 
 if(CMAKE_BUILD_TYPE STREQUAL Debug OR CMAKE_BUILD_TYPE STREQUAL RelWithDebInfo)
-    set(GO_LDFLAGS "-X main.version=${NETDATA_VERSION}")
+    set(GO_LDFLAGS "-X github.com/netdata/netdata/go/go.d.plugin/pkg/buildinfo.Version=${NETDATA_VERSION}")
 else()
-    set(GO_LDFLAGS "-w -s -X main.version=${NETDATA_VERSION}")
+    set(GO_LDFLAGS "-w -s -X github.com/netdata/netdata/go/go.d.plugin/pkg/buildinfo.Version=${NETDATA_VERSION}")
 endif()
 
 # add_go_target: Add a new target that needs to be built using the Go toolchain.

--- a/packaging/repoconfig/netdata-repo.spec
+++ b/packaging/repoconfig/netdata-repo.spec
@@ -49,19 +49,18 @@ install -pm 644 %{SOURCE3} ./netdata-edge.repo
 %endif
 
 %if 0%{?centos_ver}
-# Amazon Linux 2 looks like CentOS, but with extra macros.
-%if 0%{?amzn2}
-install -pm 644 %{SOURCE8} ./netdata.repo
-install -pm 644 %{SOURCE9} ./netdata-edge.repo
-%else
 install -pm 644 %{SOURCE4} ./netdata.repo
 install -pm 644 %{SOURCE5} ./netdata-edge.repo
-%endif
 %endif
 
 %if 0%{?oraclelinux}
 install -pm 644 %{SOURCE6} ./netdata.repo
 install -pm 644 %{SOURCE7} ./netdata-edge.repo
+%endif
+
+%if 0%{?amzn}
+install -pm 644 %{SOURCE8} ./netdata.repo
+install -pm 644 %{SOURCE9} ./netdata-edge.repo
 %endif
 
 %build

--- a/src/database/contexts/api_v1.c
+++ b/src/database/contexts/api_v1.c
@@ -131,13 +131,13 @@ static inline int rrdinstance_to_json_callback(const DICTIONARY_ITEM *item, void
     if(before && (!ri->first_time_s || before < ri->first_time_s))
         return 0;
 
-    if(t_parent->chart_label_key && !rrdlabels_match_simple_pattern_parsed(ri->rrdlabels, t_parent->chart_label_key,
-                                                                           '\0', NULL))
+    if(t_parent->chart_label_key && rrdlabels_match_simple_pattern_parsed(ri->rrdlabels, t_parent->chart_label_key,
+                                                                           '\0', NULL) != SP_MATCHED_POSITIVE)
         return 0;
 
-    if(t_parent->chart_labels_filter && !rrdlabels_match_simple_pattern_parsed(ri->rrdlabels,
+    if(t_parent->chart_labels_filter && rrdlabels_match_simple_pattern_parsed(ri->rrdlabels,
                                                                                t_parent->chart_labels_filter, ':',
-                                                                               NULL))
+                                                                               NULL) != SP_MATCHED_POSITIVE)
         return 0;
 
     time_t first_time_s = ri->first_time_s;

--- a/src/database/contexts/api_v2.c
+++ b/src/database/contexts/api_v2.c
@@ -473,7 +473,7 @@ static FTS_MATCH rrdcontext_to_json_v2_full_text_search(struct rrdcontext_to_jso
 
         size_t label_searches = 0;
         if(unlikely(ri->rrdlabels && rrdlabels_entries(ri->rrdlabels) &&
-                    rrdlabels_match_simple_pattern_parsed(ri->rrdlabels, q, ':', &label_searches))) {
+                    rrdlabels_match_simple_pattern_parsed(ri->rrdlabels, q, ':', &label_searches) == SP_MATCHED_POSITIVE)) {
             ctl->q.fts.searches += label_searches;
             ctl->q.fts.char_searches += label_searches;
             matched = FTS_MATCHED_LABEL;

--- a/src/database/contexts/query_target.c
+++ b/src/database/contexts/query_target.c
@@ -732,12 +732,12 @@ static inline bool query_instance_matches_labels(
     SIMPLE_PATTERN *labels_sp)
 {
 
-    if (chart_label_key_sp && !rrdlabels_match_simple_pattern_parsed(ri->rrdlabels, chart_label_key_sp, '\0', NULL))
+    if (chart_label_key_sp && rrdlabels_match_simple_pattern_parsed(ri->rrdlabels, chart_label_key_sp, '\0', NULL) != SP_MATCHED_POSITIVE)
         return false;
 
     if (labels_sp) {
         struct pattern_array *pa = pattern_array_add_simple_pattern(NULL, labels_sp, ':');
-        bool found = pattern_array_label_match(pa, ri->rrdlabels, ':', NULL, rrdlabels_match_simple_pattern_parsed);
+        bool found = pattern_array_label_match(pa, ri->rrdlabels, ':', NULL);
         pattern_array_free(pa);
         return found;
     }

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -977,7 +977,7 @@ int rrdlabels_walkthrough_read(RRDLABELS *labels, int (*callback)(const char *na
     lfe_start_read(labels, lb, ls)
     {
         ret = callback(string2str(lb->index.key), string2str(lb->index.value), ls, data);
-        if (ret < 0)
+        if (ret != 0)
             break;
     }
     lfe_done(labels);
@@ -1125,9 +1125,12 @@ static int simple_pattern_match_name_only_callback(const char *name, const char 
 
     // we return -1 to stop the walkthrough on first match
     t->searches++;
-    if(simple_pattern_matches(t->pattern, name)) return -1;
+    SIMPLE_PATTERN_RESULT rc = simple_pattern_matches_extract(t->pattern, name, NULL, 0);
 
-    return 0;
+    if(rc == SP_MATCHED_NEGATIVE)
+        return -1;
+
+    return rc == SP_MATCHED_POSITIVE;
 }
 
 static int simple_pattern_match_name_and_value_callback(const char *name, const char *value, RRDLABEL_SRC ls __maybe_unused, void *data) {
@@ -1154,13 +1157,15 @@ static int simple_pattern_match_name_and_value_callback(const char *name, const 
     *dst = '\0';
 
     t->searches++;
-    if(simple_pattern_matches_length_extract(t->pattern, tmp, dst - tmp, NULL, 0) == SP_MATCHED_POSITIVE)
+    SIMPLE_PATTERN_RESULT rc = simple_pattern_matches_length_extract(t->pattern, tmp, dst - tmp, NULL, 0);
+
+    if(rc == SP_MATCHED_NEGATIVE)
         return -1;
 
-    return 0;
+    return rc == SP_MATCHED_POSITIVE ? 1 : 0;
 }
 
-bool rrdlabels_match_simple_pattern_parsed(RRDLABELS *labels, SIMPLE_PATTERN *pattern, char equal, size_t *searches) {
+SIMPLE_PATTERN_RESULT rrdlabels_match_simple_pattern_parsed(RRDLABELS *labels, SIMPLE_PATTERN *pattern, char equal, size_t *searches) {
     if (!labels) return false;
 
     struct simple_pattern_match_name_value t = {
@@ -1174,7 +1179,10 @@ bool rrdlabels_match_simple_pattern_parsed(RRDLABELS *labels, SIMPLE_PATTERN *pa
     if(searches)
         *searches = t.searches;
 
-    return (ret == -1)?true:false;
+    if(ret < 0)
+        return SP_MATCHED_NEGATIVE;
+
+    return (ret > 0)?SP_MATCHED_POSITIVE:SP_NOT_MATCHED;
 }
 
 bool rrdlabels_match_simple_pattern(RRDLABELS *labels, const char *simple_pattern_txt) {
@@ -1191,11 +1199,11 @@ bool rrdlabels_match_simple_pattern(RRDLABELS *labels, const char *simple_patter
         }
     }
 
-    bool ret = rrdlabels_match_simple_pattern_parsed(labels, pattern, equal, NULL);
+    SIMPLE_PATTERN_RESULT ret = rrdlabels_match_simple_pattern_parsed(labels, pattern, equal, NULL);
 
     simple_pattern_free(pattern);
 
-    return ret;
+    return ret == SP_MATCHED_POSITIVE;
 }
 
 
@@ -1388,8 +1396,7 @@ bool pattern_array_label_match(
     struct pattern_array *pa,
     RRDLABELS *labels,
     char eq,
-    size_t *searches,
-    bool (*callback_function)(RRDLABELS *, SIMPLE_PATTERN *, char, size_t *))
+    size_t *searches)
 {
     if (!pa || !labels)
         return true;
@@ -1398,14 +1405,23 @@ bool pattern_array_label_match(
     Word_t Index = 0;
     bool first_then_next = true;
     while ((Pvalue = JudyLFirstThenNext(pa->JudyL, &Index, &first_then_next))) {
+        // for each label key in the patterns array
+
         struct pattern_array_item *pai = *Pvalue;
-        bool match = false;
-        for (Word_t i = 1; !match && i <= pai->size; i++) {
+        SIMPLE_PATTERN_RESULT match = SP_NOT_MATCHED ;
+        for (Word_t i = 1; i <= pai->size; i++) {
+            // for each pattern in the label key pattern list
+
             if (!(Pvalue = JudyLGet(pai->JudyL, i, PJE0)) || !*Pvalue)
                 continue;
-            match = callback_function(labels, (SIMPLE_PATTERN *)(*Pvalue), eq, searches);
+
+            match = rrdlabels_match_simple_pattern_parsed(labels, (SIMPLE_PATTERN *)(*Pvalue), eq, searches);
+
+            if(match != SP_NOT_MATCHED)
+                break;
         }
-        if (!match)
+
+        if (match != SP_MATCHED_POSITIVE)
             return false;
     }
     return true;
@@ -1481,6 +1497,7 @@ void pattern_array_free(struct pattern_array *pa)
 
         string_freez((STRING *)Index);
         (void) JudyLDel(&(pa->JudyL), Index, PJE0);
+        freez(pai);
         Index = 0;
     }
     freez(pa);
@@ -1669,7 +1686,7 @@ static int rrdlabels_walkthrough_index_read(RRDLABELS *labels, int (*callback)(c
     lfe_start_read(labels, lb, ls)
     {
         ret = callback(string2str(lb->index.key), string2str(lb->index.value), ls, index, data);
-        if (ret < 0)
+        if (ret != 0)
             break;
         index++;
     }
@@ -1705,25 +1722,25 @@ static int rrdlabels_unittest_pattern_check()
 
     bool match;
     struct pattern_array *pa = pattern_array_add_key_value(NULL, "_module", "wrong_module", '=');
-    match = pattern_array_label_match(pa, labels, '=', NULL, rrdlabels_match_simple_pattern_parsed);
+    match = pattern_array_label_match(pa, labels, '=', NULL);
     // This should not match:  _module in ("wrong_module")
     if (match)
         rc++;
 
     pattern_array_add_key_value(pa, "_module", "disk_detection", '=');
-    match = pattern_array_label_match(pa, labels, '=', NULL, rrdlabels_match_simple_pattern_parsed);
+    match = pattern_array_label_match(pa, labels, '=', NULL);
     // This should match: _module in ("wrong_module","disk_detection")
     if (!match)
         rc++;
 
     pattern_array_add_key_value(pa, "key1", "wrong_key1_value", '=');
-    match = pattern_array_label_match(pa, labels, '=', NULL, rrdlabels_match_simple_pattern_parsed);
+    match = pattern_array_label_match(pa, labels, '=', NULL);
     // This should not match: _module in ("wrong_module","disk_detection") AND key1 in ("wrong_key1_value")
     if (match)
         rc++;
 
     pattern_array_add_key_value(pa, "key1", "value1", '=');
-    match = pattern_array_label_match(pa, labels, '=', NULL, rrdlabels_match_simple_pattern_parsed);
+    match = pattern_array_label_match(pa, labels, '=', NULL);
     // This should match: _module in ("wrong_module","disk_detection") AND key1 in ("wrong_key1_value", "value1")
     if (!match)
         rc++;
@@ -1734,13 +1751,13 @@ static int rrdlabels_unittest_pattern_check()
     sp = simple_pattern_create("key3=*phant", SIMPLE_PATTERN_DEFAULT_WEB_SEPARATORS, SIMPLE_PATTERN_EXACT, true);
     pattern_array_add_lblkey_with_sp(pa, "key3", sp);
 
-    match = pattern_array_label_match(pa, labels, '=', NULL, rrdlabels_match_simple_pattern_parsed);
+    match = pattern_array_label_match(pa, labels, '=', NULL);
     // This should match: _module in ("wrong_module","disk_detection") AND key1 in ("wrong_key1_value", "value1") AND key2 in ("cat* !d*") AND key3 in ("*phant")
     if (!match)
         rc++;
 
     rrdlabels_add(labels, "key3", "now_fail", RRDLABEL_SRC_CONFIG);
-    match = pattern_array_label_match(pa, labels, '=', NULL, rrdlabels_match_simple_pattern_parsed);
+    match = pattern_array_label_match(pa, labels, '=', NULL);
     // This should not match: _module in ("wrong_module","disk_detection") AND key1 in ("wrong_key1_value", "value1") AND key2 in ("cat* !d*") AND key3 in ("*phant")
     if (match)
         rc++;
@@ -1830,6 +1847,69 @@ static int rrdlabels_unittest_migrate_check()
     rrdlabels_destroy(labels2);
 
     return rc;
+}
+
+struct pattern_array *trim_and_add_key_to_values(struct pattern_array *pa, const char *key, STRING *input);
+static int rrdlabels_unittest_check_pattern_list(RRDLABELS *labels, const char *pattern, bool expected) {
+    fprintf(stderr, "rrdlabels_match_simple_pattern(labels, \"%s\") ... ", pattern);
+
+    STRING *str = string_strdupz(pattern);
+    struct pattern_array *pa = trim_and_add_key_to_values(NULL, NULL, str);
+
+    bool ret = pattern_array_label_match(pa, labels, '=', NULL);
+
+    fprintf(stderr, "%s, got %s expected %s\n", (ret == expected)?"OK":"FAILED", ret?"true":"false", expected?"true":"false");
+
+    string_freez(str);
+    pattern_array_free(pa);
+
+    return (ret == expected)?0:1;
+}
+
+static int rrdlabels_unittest_host_chart_labels() {
+    fprintf(stderr, "\n%s() tests\n", __FUNCTION__);
+
+    int errors = 0;
+
+    RRDLABELS *labels = rrdlabels_create();
+    rrdlabels_add(labels, "_hostname", "hostname1", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(labels, "_os", "linux", RRDLABEL_SRC_CONFIG);
+    rrdlabels_add(labels, "_distro", "ubuntu", RRDLABEL_SRC_CONFIG);
+
+    // match a single key
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_hostname=*", true);
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_hostname=!*", false);
+
+    // conflicting keys (some positive, some negative)
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_hostname=* _os=!*", false);
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_hostname=!* _os=*", false);
+
+    // the user uses a key that is not there
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_not_a_key=*", false);
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_not_a_key=!*", false);
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_not_a_key=* _hostname=* _os=*", false);
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_not_a_key=!* _hostname=* _os=*", false);
+
+    // positive and negative matches on the same key
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_hostname=!*invalid* !*bad* *name*", true);
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_hostname=*name* !*invalid* !*bad*", true);
+
+    // positive and negative matches on the same key with catch all
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_hostname=!*invalid* !*bad* *", true);
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_hostname=* !*invalid* !*bad*", true);
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_hostname=!*invalid* !*name* *", false);
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_hostname=* !*invalid* !*name*", true);
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_hostname=*name* !*", true);
+
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_hostname=!*name* _os=l*", false);
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_os=l* hostname=!*name*", false);
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_hostname=*name* _hostname=*", true);
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_hostname=*name* _os=l*", true);
+    errors += rrdlabels_unittest_check_pattern_list(labels, "_os=l* _hostname=*name*", true);
+
+    rrdlabels_destroy(labels);
+
+    return errors;
 }
 
 static int rrdlabels_unittest_check_simple_pattern(RRDLABELS *labels, const char *pattern, bool expected) {
@@ -1924,6 +2004,7 @@ int rrdlabels_unittest(void) {
     errors += rrdlabels_unittest_sanitization();
     errors += rrdlabels_unittest_add_pairs();
     errors += rrdlabels_unittest_simple_pattern();
+    errors += rrdlabels_unittest_host_chart_labels();
     errors += rrdlabels_unittest_double_check();
     errors += rrdlabels_unittest_migrate_check();
     errors += rrdlabels_unittest_pattern_check();

--- a/src/database/rrdlabels.h
+++ b/src/database/rrdlabels.h
@@ -51,7 +51,7 @@ int rrdlabels_walkthrough_read(RRDLABELS *labels, int (*callback)(const char *na
 void rrdlabels_log_to_buffer(RRDLABELS *labels, BUFFER *wb);
 bool rrdlabels_match_simple_pattern(RRDLABELS *labels, const char *simple_pattern_txt);
 
-bool rrdlabels_match_simple_pattern_parsed(RRDLABELS *labels, SIMPLE_PATTERN *pattern, char equal, size_t *searches);
+SIMPLE_PATTERN_RESULT rrdlabels_match_simple_pattern_parsed(RRDLABELS *labels, SIMPLE_PATTERN *pattern, char equal, size_t *searches);
 int rrdlabels_to_buffer(RRDLABELS *labels, BUFFER *wb, const char *before_each, const char *equal, const char *quote, const char *between_them,
                         bool (*filter_callback)(const char *name, const char *value, RRDLABEL_SRC ls, void *data), void *filter_data,
                         void (*name_sanitizer)(char *dst, const char *src, size_t dst_size),
@@ -69,8 +69,7 @@ bool pattern_array_label_match(
     struct pattern_array *pa,
     RRDLABELS *labels,
     char eq,
-    size_t *searches,
-    bool (*callback_function)(RRDLABELS *, SIMPLE_PATTERN *, char, size_t *));
+    size_t *searches);
 struct pattern_array *pattern_array_add_simple_pattern(struct pattern_array *pa, SIMPLE_PATTERN *pattern, char sep);
 struct pattern_array *
 pattern_array_add_key_simple_pattern(struct pattern_array *pa, const char *key, SIMPLE_PATTERN *pattern);

--- a/src/go/collectors/go.d.plugin/agent/jobmgr/manager.go
+++ b/src/go/collectors/go.d.plugin/agent/jobmgr/manager.go
@@ -152,7 +152,7 @@ func (m *Manager) run() {
 }
 
 func (m *Manager) addConfig(cfg confgroup.Config) {
-	if cfg.Module() == "" {
+	if _, ok := m.Modules.Lookup(cfg.Module()); !ok {
 		return
 	}
 

--- a/src/go/collectors/go.d.plugin/cmd/godplugin/main.go
+++ b/src/go/collectors/go.d.plugin/cmd/godplugin/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/netdata/netdata/go/go.d.plugin/agent/executable"
 	"github.com/netdata/netdata/go/go.d.plugin/cli"
 	"github.com/netdata/netdata/go/go.d.plugin/logger"
+	"github.com/netdata/netdata/go/go.d.plugin/pkg/buildinfo"
 	"github.com/netdata/netdata/go/go.d.plugin/pkg/multipath"
 
 	"github.com/jessevdk/go-flags"
@@ -32,8 +33,6 @@ var (
 	lockDir     = os.Getenv("NETDATA_LOCK_DIR")
 	watchPath   = os.Getenv("NETDATA_PLUGINS_GOD_WATCH_PATH")
 	envLogLevel = os.Getenv("NETDATA_LOG_LEVEL")
-
-	version = "unknown"
 )
 
 func confDir(opts *cli.Option) multipath.MultiPath {
@@ -115,7 +114,7 @@ func main() {
 	opts := parseCLI()
 
 	if opts.Version {
-		fmt.Printf("go.d.plugin, version: %s\n", version)
+		fmt.Printf("go.d.plugin, version: %s\n", buildinfo.Version)
 		return
 	}
 
@@ -142,7 +141,7 @@ func main() {
 		MinUpdateEvery:       opts.UpdateEvery,
 	})
 
-	a.Debugf("plugin: name=%s, version=%s", a.Name, version)
+	a.Debugf("plugin: name=%s, version=%s", a.Name, buildinfo.Version)
 	if u, err := user.Current(); err == nil {
 		a.Debugf("current user: name=%s, uid=%s", u.Username, u.Uid)
 	}

--- a/src/go/collectors/go.d.plugin/config/go.d/mysql.conf
+++ b/src/go/collectors/go.d.plugin/config/go.d/mysql.conf
@@ -1,15 +1,12 @@
 ## All available configuration options, their descriptions and default values:
 ## https://github.com/netdata/netdata/tree/master/src/go/collectors/go.d.plugin/modules/mysql#readme
 
-jobs:
-  - name: local
-    dsn: netdata@unix(/var/run/mysqld/mysqld.sock)/
-
-  - name: local
-    dsn: netdata@unix(/var/run/mysqld/mysql.sock)/
-
-  - name: local
-    dsn: netdata@unix(/var/lib/mysql/mysql.sock)/
-
-  - name: local
-    dsn: netdata@unix(/tmp/mysql.sock)/
+#jobs:
+#  - name: local
+#    dsn: netdata@unix(/var/run/mysqld/mysql.sock)/
+#
+#  - name: local
+#    dsn: netdata@unix(/var/lib/mysql/mysql.sock)/
+#
+#  - name: local
+#    dsn: netdata@unix(/tmp/mysql.sock)/

--- a/src/go/collectors/go.d.plugin/config/go.d/postgres.conf
+++ b/src/go/collectors/go.d.plugin/config/go.d/postgres.conf
@@ -1,9 +1,10 @@
 ## All available configuration options, their descriptions and default values:
 ## https://github.com/netdata/netdata/tree/master/src/go/collectors/go.d.plugin/modules/postgres#readme
 
-jobs:
-  - name: local
-    dsn: 'host=/var/run/postgresql dbname=postgres user=netdata'
-    #collect_databases_matching: '*'
+#jobs:
+#  - name: local
+#    dsn: 'host=/var/run/postgresql dbname=postgres user=netdata'
+#    #collect_databases_matching: '*'
+#
 #  - name: local
 #    dsn: 'postgresql://netdata@127.0.0.1:5432/postgres'

--- a/src/go/collectors/go.d.plugin/config/go.d/sd/docker.conf
+++ b/src/go/collectors/go.d.plugin/config/go.d/sd/docker.conf
@@ -132,9 +132,18 @@ compose:
           dsn: netdata@tcp({{.Address}})/
       - selector: "nginx"
         template: |
-          module: nginx
-          name: docker_{{.Name}}
-          url: http://{{.Address}}/stub_status
+          - module: nginx
+            name: docker_{{.Name}}
+            url: http://{{.Address}}/stub_status
+          - module: nginx
+            name: docker_{{.Name}}
+            url: http://{{.Address}}/basic_status
+          - module: nginx
+            name: docker_{{.Name}}
+            url: http://{{.Address}}/nginx_status
+          - module: nginx
+            name: docker_{{.Name}}
+            url: http://{{.Address}}/status
       - selector: "pgbouncer"
         template: |
           module: pgbouncer

--- a/src/go/collectors/go.d.plugin/config/go.d/sd/net_listeners.conf
+++ b/src/go/collectors/go.d.plugin/config/go.d/sd/net_listeners.conf
@@ -268,9 +268,12 @@ compose:
           uri: mongodb://{{.Address}}
       - selector: "mysql"
         template: |
-          module: mysql
-          name: local
-          dsn: netdata@tcp({{.Address}})/
+          - module: mysql
+            name: local
+            dsn: netdata@unix(/var/run/mysqld/mysqld.sock)/
+          - module: mysql
+            name: local
+            dsn: netdata@tcp({{.Address}})/
       - selector: "nginx"
         template: |
           - module: nginx

--- a/src/go/collectors/go.d.plugin/config/go.d/sd/net_listeners.conf
+++ b/src/go/collectors/go.d.plugin/config/go.d/sd/net_listeners.conf
@@ -238,7 +238,7 @@ compose:
           url: http://{{.Address}}/jmx
       - selector: "kubelet"
         template: |
-          module: kubelet
+          module: k8s_kubelet
           name: local
           {{- if eq .Port "10255" }}
           url: http://{{.Address}}/metrics
@@ -248,7 +248,7 @@ compose:
           {{- end }}
       - selector: "kubeproxy"
         template: |
-          module: kubeproxy
+          module: k8s_kubeproxy
           name: local
           url: http://{{.Address}}/metrics
       - selector: "lighttpd"

--- a/src/go/collectors/go.d.plugin/config/go.d/sd/net_listeners.conf
+++ b/src/go/collectors/go.d.plugin/config/go.d/sd/net_listeners.conf
@@ -313,9 +313,15 @@ compose:
           address: redis://@{{.IPAddress}}:{{.Port}}
       - selector: "postgres"
         template: |
-          module: postgres
-          name: local
-          dsn: postgresql://netdata@{{.Address}}/postgres
+          - module: postgres
+            name: local
+            dsn: 'host=/var/run/postgresql dbname=postgres user=postgres'
+          - module: postgres
+            name: local
+            dsn: 'host=/var/run/postgresql dbname=postgres user=netdata'
+          - module: postgres
+            name: local
+            dsn: postgresql://netdata@{{.Address}}/postgres
       - selector: "powerdns"
         template: |
           module: powerdns

--- a/src/go/collectors/go.d.plugin/hack/go-build.sh
+++ b/src/go/collectors/go.d.plugin/hack/go-build.sh
@@ -36,7 +36,7 @@ WHICH="$1"
 VERSION="${TRAVIS_TAG:-$(git describe --tags --always --dirty)}"
 
 GOLDFLAGS=${GLDFLAGS:-}
-GOLDFLAGS="$GOLDFLAGS -w -s -X main.version=$VERSION"
+GOLDFLAGS="$GOLDFLAGS -w -s -X github.com/netdata/netdata/go/go.d.plugin/pkg/buildinfo.Version=$VERSION"
 
 build() {
   echo "Building ${GOOS}/${GOARCH}"

--- a/src/go/collectors/go.d.plugin/modules/activemq/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/activemq/config_schema.json
@@ -131,7 +131,8 @@
     "required": [
       "url",
       "webadmin"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/activemq/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/activemq/config_schema.json
@@ -132,7 +132,10 @@
       "url",
       "webadmin"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/apache/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/apache/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/apache/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/apache/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/bind/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/bind/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/bind/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/bind/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/cassandra/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/cassandra/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/cassandra/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/cassandra/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/chrony/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/chrony/config_schema.json
@@ -26,7 +26,8 @@
     },
     "required": [
       "address"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/chrony/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/chrony/config_schema.json
@@ -27,7 +27,10 @@
     "required": [
       "address"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/cockroachdb/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/cockroachdb/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/cockroachdb/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/cockroachdb/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/consul/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/consul/config_schema.json
@@ -102,7 +102,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/consul/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/consul/config_schema.json
@@ -103,7 +103,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/coredns/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/coredns/config_schema.json
@@ -168,7 +168,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/coredns/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/coredns/config_schema.json
@@ -169,7 +169,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/couchbase/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/couchbase/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/couchbase/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/couchbase/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/couchdb/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/couchdb/config_schema.json
@@ -108,7 +108,8 @@
     "required": [
       "url",
       "node"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/couchdb/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/couchdb/config_schema.json
@@ -109,7 +109,10 @@
       "url",
       "node"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/dnsdist/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/dnsdist/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/dnsdist/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/dnsdist/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/dnsmasq/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/dnsmasq/config_schema.json
@@ -39,7 +39,10 @@
       "address",
       "protocol"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/dnsmasq/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/dnsmasq/config_schema.json
@@ -38,7 +38,8 @@
     "required": [
       "address",
       "protocol"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/dnsmasq_dhcp/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/dnsmasq_dhcp/config_schema.json
@@ -36,7 +36,8 @@
     "required": [
       "leases_path",
       "conf_path"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/dnsmasq_dhcp/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/dnsmasq_dhcp/config_schema.json
@@ -37,7 +37,10 @@
       "leases_path",
       "conf_path"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/dnsquery/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/dnsquery/config_schema.json
@@ -104,7 +104,8 @@
       "domains",
       "servers",
       "network"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/dnsquery/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/dnsquery/config_schema.json
@@ -105,7 +105,10 @@
       "servers",
       "network"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/docker/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/docker/config_schema.json
@@ -33,7 +33,10 @@
     "required": [
       "address"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/docker/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/docker/config_schema.json
@@ -32,7 +32,8 @@
     },
     "required": [
       "address"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/docker_engine/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/docker_engine/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/docker_engine/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/docker_engine/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/dockerhub/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/dockerhub/config_schema.json
@@ -112,7 +112,8 @@
     "required": [
       "url",
       "repositories"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/dockerhub/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/dockerhub/config_schema.json
@@ -113,7 +113,10 @@
       "url",
       "repositories"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/elasticsearch/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/elasticsearch/config_schema.json
@@ -126,7 +126,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/elasticsearch/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/elasticsearch/config_schema.json
@@ -127,7 +127,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/envoy/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/envoy/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/envoy/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/envoy/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/example/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/example/config_schema.json
@@ -125,7 +125,10 @@
     "required": [
       "charts"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/example/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/example/config_schema.json
@@ -124,7 +124,8 @@
     },
     "required": [
       "charts"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/filecheck/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/filecheck/config_schema.json
@@ -100,7 +100,10 @@
         ]
       }
     },
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/filecheck/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/filecheck/config_schema.json
@@ -99,7 +99,8 @@
           "include"
         ]
       }
-    }
+    },
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/fluentd/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/fluentd/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/fluentd/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/fluentd/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/freeradius/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/freeradius/config_schema.json
@@ -41,7 +41,10 @@
       "port",
       "secret"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/freeradius/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/freeradius/config_schema.json
@@ -40,7 +40,8 @@
       "address",
       "port",
       "secret"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/geth/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/geth/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/geth/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/geth/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/haproxy/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/haproxy/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/haproxy/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/haproxy/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/hdfs/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/hdfs/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/hdfs/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/hdfs/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/httpcheck/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/httpcheck/config_schema.json
@@ -155,7 +155,8 @@
     "required": [
       "url",
       "accepted_statuses"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/httpcheck/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/httpcheck/config_schema.json
@@ -100,6 +100,11 @@
         "type": "string",
         "sensitive": true
       },
+      "cookie_file": {
+        "title": "Cookie file",
+        "description": "Specifies the path to the file containing cookies. For more information about the cookie file format, see [cookie file format](https://everything.curl.dev/http/cookies/fileformat).",
+        "type": "string"
+      },
       "proxy_url": {
         "title": "Proxy URL",
         "description": "The URL of the proxy server.",
@@ -156,7 +161,10 @@
       "url",
       "accepted_statuses"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",
@@ -183,7 +191,8 @@
           "title": "Auth",
           "fields": [
             "username",
-            "password"
+            "password",
+            "cookie_file"
           ]
         },
         {

--- a/src/go/collectors/go.d.plugin/modules/isc_dhcpd/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/isc_dhcpd/config_schema.json
@@ -57,7 +57,10 @@
       "leases_path",
       "pools"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/isc_dhcpd/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/isc_dhcpd/config_schema.json
@@ -56,7 +56,8 @@
     "required": [
       "leases_path",
       "pools"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/k8s_kubelet/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/k8s_kubelet/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/k8s_kubelet/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/k8s_kubelet/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/k8s_kubeproxy/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/k8s_kubeproxy/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/k8s_kubeproxy/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/k8s_kubeproxy/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/k8s_state/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/k8s_state/config_schema.json
@@ -11,7 +11,8 @@
         "minimum": 1,
         "default": 1
       }
-    }
+    },
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/k8s_state/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/k8s_state/config_schema.json
@@ -12,7 +12,10 @@
         "default": 1
       }
     },
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/lighttpd/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/lighttpd/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/lighttpd/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/lighttpd/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/logind/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/logind/config_schema.json
@@ -18,7 +18,8 @@
         "minimum": 0.5,
         "default": 1
       }
-    }
+    },
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/logind/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/logind/config_schema.json
@@ -19,7 +19,10 @@
         "default": 1
       }
     },
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/logstash/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/logstash/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/logstash/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/logstash/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/mongodb/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/mongodb/config_schema.json
@@ -64,7 +64,10 @@
     "required": [
       "uri"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/mongodb/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/mongodb/config_schema.json
@@ -63,7 +63,8 @@
     },
     "required": [
       "uri"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/mysql/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/mysql/config_schema.json
@@ -33,7 +33,10 @@
     "required": [
       "dsn"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/mysql/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/mysql/config_schema.json
@@ -32,7 +32,8 @@
     },
     "required": [
       "dsn"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/nginx/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/nginx/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/nginx/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/nginx/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/nginxplus/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/nginxplus/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/nginxplus/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/nginxplus/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/nginxvts/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/nginxvts/config_schema.json
@@ -96,7 +96,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/nginxvts/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/nginxvts/config_schema.json
@@ -95,7 +95,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/ntpd/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/ntpd/config_schema.json
@@ -33,7 +33,10 @@
     "required": [
       "address"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/ntpd/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/ntpd/config_schema.json
@@ -32,7 +32,8 @@
     },
     "required": [
       "address"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/nvidia_smi/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/nvidia_smi/config_schema.json
@@ -34,7 +34,10 @@
     "required": [
       "binary_path"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/nvidia_smi/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/nvidia_smi/config_schema.json
@@ -33,7 +33,8 @@
     },
     "required": [
       "binary_path"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/nvme/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/nvme/config_schema.json
@@ -28,7 +28,10 @@
     "required": [
       "binary_path"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/nvme/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/nvme/config_schema.json
@@ -27,7 +27,8 @@
     },
     "required": [
       "binary_path"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/openvpn/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/openvpn/config_schema.json
@@ -64,7 +64,10 @@
     "required": [
       "address"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/openvpn/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/openvpn/config_schema.json
@@ -63,7 +63,8 @@
     },
     "required": [
       "address"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/openvpn_status_log/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/openvpn_status_log/config_schema.json
@@ -58,7 +58,10 @@
     "required": [
       "address"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/openvpn_status_log/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/openvpn_status_log/config_schema.json
@@ -57,7 +57,8 @@
     },
     "required": [
       "address"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/pgbouncer/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/pgbouncer/config_schema.json
@@ -27,7 +27,8 @@
     },
     "required": [
       "dsn"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/pgbouncer/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/pgbouncer/config_schema.json
@@ -28,7 +28,10 @@
     "required": [
       "dsn"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/phpdaemon/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/phpdaemon/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/phpdaemon/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/phpdaemon/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/pihole/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/pihole/config_schema.json
@@ -102,7 +102,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/pihole/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/pihole/config_schema.json
@@ -103,7 +103,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/pika/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/pika/config_schema.json
@@ -50,7 +50,8 @@
     },
     "required": [
       "address"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/pika/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/pika/config_schema.json
@@ -51,7 +51,10 @@
     "required": [
       "address"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/ping/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/ping/config_schema.json
@@ -59,7 +59,8 @@
     },
     "required": [
       "hosts"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/ping/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/ping/config_schema.json
@@ -60,7 +60,10 @@
     "required": [
       "hosts"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/portcheck/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/portcheck/config_schema.json
@@ -44,7 +44,10 @@
       "host",
       "ports"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/portcheck/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/portcheck/config_schema.json
@@ -43,7 +43,8 @@
     "required": [
       "host",
       "ports"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/postgres/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/postgres/config_schema.json
@@ -90,7 +90,8 @@
     },
     "required": [
       "dsn"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/postgres/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/postgres/config_schema.json
@@ -91,7 +91,10 @@
     "required": [
       "dsn"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/powerdns/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/powerdns/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/powerdns/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/powerdns/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/powerdns_recursor/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/powerdns_recursor/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/powerdns_recursor/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/powerdns_recursor/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/prometheus/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/prometheus/config_schema.json
@@ -197,7 +197,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/prometheus/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/prometheus/config_schema.json
@@ -196,7 +196,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/proxysql/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/proxysql/config_schema.json
@@ -27,7 +27,8 @@
     },
     "required": [
       "dsn"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/proxysql/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/proxysql/config_schema.json
@@ -28,7 +28,10 @@
     "required": [
       "dsn"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/pulsar/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/pulsar/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/pulsar/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/pulsar/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/rabbitmq/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/rabbitmq/config_schema.json
@@ -104,7 +104,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/rabbitmq/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/rabbitmq/config_schema.json
@@ -105,7 +105,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/redis/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/redis/config_schema.json
@@ -67,7 +67,10 @@
     "required": [
       "address"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/redis/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/redis/config_schema.json
@@ -66,7 +66,8 @@
     },
     "required": [
       "address"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/scaleio/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/scaleio/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/scaleio/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/scaleio/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/snmp/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/snmp/config_schema.json
@@ -287,7 +287,10 @@
       "options",
       "charts"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/snmp/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/snmp/config_schema.json
@@ -286,7 +286,8 @@
       "community",
       "options",
       "charts"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/squidlog/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/squidlog/config_schema.json
@@ -41,6 +41,9 @@
       "log_type"
     ],
     "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    },
     "dependencies": {
       "log_type": {
         "oneOf": [

--- a/src/go/collectors/go.d.plugin/modules/squidlog/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/squidlog/config_schema.json
@@ -40,6 +40,7 @@
       "path",
       "log_type"
     ],
+    "additionalProperties": false,
     "dependencies": {
       "log_type": {
         "oneOf": [

--- a/src/go/collectors/go.d.plugin/modules/supervisord/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/supervisord/config_schema.json
@@ -48,7 +48,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/supervisord/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/supervisord/config_schema.json
@@ -49,7 +49,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/systemdunits/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/systemdunits/config_schema.json
@@ -38,7 +38,8 @@
     },
     "required": [
       "include"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/systemdunits/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/systemdunits/config_schema.json
@@ -39,7 +39,10 @@
     "required": [
       "include"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/tengine/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/tengine/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/tengine/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/tengine/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/traefik/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/traefik/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/traefik/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/traefik/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/unbound/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/unbound/config_schema.json
@@ -72,7 +72,10 @@
     "required": [
       "address"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/unbound/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/unbound/config_schema.json
@@ -71,7 +71,8 @@
     },
     "required": [
       "address"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/upsd/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/upsd/config_schema.json
@@ -39,6 +39,9 @@
       "address"
     ],
     "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    },
     "dependencies": {
       "username": [
         "password"

--- a/src/go/collectors/go.d.plugin/modules/upsd/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/upsd/config_schema.json
@@ -38,6 +38,7 @@
     "required": [
       "address"
     ],
+    "additionalProperties": false,
     "dependencies": {
       "username": [
         "password"

--- a/src/go/collectors/go.d.plugin/modules/vcsa/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/vcsa/config_schema.json
@@ -96,7 +96,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/vcsa/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/vcsa/config_schema.json
@@ -95,7 +95,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/vernemq/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/vernemq/config_schema.json
@@ -96,7 +96,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/vernemq/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/vernemq/config_schema.json
@@ -97,7 +97,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/vsphere/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/vsphere/config_schema.json
@@ -144,7 +144,8 @@
       "password",
       "host_include",
       "vm_include"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/vsphere/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/vsphere/config_schema.json
@@ -145,7 +145,10 @@
       "host_include",
       "vm_include"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/weblog/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/weblog/config_schema.json
@@ -249,6 +249,9 @@
       "log_type"
     ],
     "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    },
     "dependencies": {
       "log_type": {
         "oneOf": [

--- a/src/go/collectors/go.d.plugin/modules/weblog/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/weblog/config_schema.json
@@ -248,6 +248,7 @@
       "path",
       "log_type"
     ],
+    "additionalProperties": false,
     "dependencies": {
       "log_type": {
         "oneOf": [

--- a/src/go/collectors/go.d.plugin/modules/whoisquery/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/whoisquery/config_schema.json
@@ -40,7 +40,8 @@
     },
     "required": [
       "source"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/whoisquery/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/whoisquery/config_schema.json
@@ -41,7 +41,10 @@
     "required": [
       "source"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/windows/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/windows/config_schema.json
@@ -94,7 +94,8 @@
     },
     "required": [
       "url"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/windows/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/windows/config_schema.json
@@ -95,7 +95,10 @@
     "required": [
       "url"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "ui:flavour": "tabs",

--- a/src/go/collectors/go.d.plugin/modules/wireguard/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/wireguard/config_schema.json
@@ -11,7 +11,8 @@
         "minimum": 1,
         "default": 1
       }
-    }
+    },
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/wireguard/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/wireguard/config_schema.json
@@ -12,7 +12,10 @@
         "default": 1
       }
     },
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/x509check/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/x509check/config_schema.json
@@ -68,7 +68,8 @@
     },
     "required": [
       "source"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/x509check/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/x509check/config_schema.json
@@ -69,7 +69,10 @@
     "required": [
       "source"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/zookeeper/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/zookeeper/config_schema.json
@@ -56,7 +56,10 @@
     "required": [
       "address"
     ],
-    "additionalProperties": false
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/modules/zookeeper/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/zookeeper/config_schema.json
@@ -55,7 +55,8 @@
     },
     "required": [
       "address"
-    ]
+    ],
+    "additionalProperties": false
   },
   "uiSchema": {
     "uiOptions": {

--- a/src/go/collectors/go.d.plugin/pkg/buildinfo/version.go
+++ b/src/go/collectors/go.d.plugin/pkg/buildinfo/version.go
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package buildinfo
+
+// Version stores the agent's version number. It's set during the build process using build flags.
+var Version = "v0.0.0"

--- a/src/go/collectors/go.d.plugin/pkg/prometheus/client.go
+++ b/src/go/collectors/go.d.plugin/pkg/prometheus/client.go
@@ -42,8 +42,7 @@ type (
 )
 
 const (
-	acceptHeader    = `text/plain;version=0.0.4;q=1,*/*;q=0.1`
-	userAgentHeader = `netdata/go.d.plugin`
+	acceptHeader = `text/plain;version=0.0.4;q=1,*/*;q=0.1`
 )
 
 // New creates a Prometheus instance.
@@ -118,7 +117,6 @@ func (p *prometheus) fetch(w io.Writer) error {
 
 	req.Header.Add("Accept", acceptHeader)
 	req.Header.Add("Accept-Encoding", "gzip")
-	req.Header.Set("User-Agent", userAgentHeader)
 
 	resp, err := p.client.Do(req)
 	if err != nil {

--- a/src/go/collectors/go.d.plugin/pkg/socket/client.go
+++ b/src/go/collectors/go.d.plugin/pkg/socket/client.go
@@ -31,16 +31,25 @@ type Socket struct {
 // If the address is a domain name it will also perform the DNS resolution.
 // Address like :80 will attempt to connect to the localhost.
 // The config timeout and TLS config will be used.
-func (s *Socket) Connect() (err error) {
+func (s *Socket) Connect() error {
 	network, address := networkType(s.Address)
+	var conn net.Conn
+	var err error
+
 	if s.TLSConf == nil {
-		s.conn, err = net.DialTimeout(network, address, s.ConnectTimeout)
+		conn, err = net.DialTimeout(network, address, s.ConnectTimeout)
 	} else {
 		var d net.Dialer
 		d.Timeout = s.ConnectTimeout
-		s.conn, err = tls.DialWithDialer(&d, network, address, s.TLSConf)
+		conn, err = tls.DialWithDialer(&d, network, address, s.TLSConf)
 	}
-	return err
+	if err != nil {
+		return err
+	}
+
+	s.conn = conn
+
+	return nil
 }
 
 // Disconnect closes the connection.

--- a/src/go/collectors/go.d.plugin/pkg/web/request.go
+++ b/src/go/collectors/go.d.plugin/pkg/web/request.go
@@ -4,9 +4,13 @@ package web
 
 import (
 	"encoding/base64"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/netdata/netdata/go/go.d.plugin/agent/executable"
+	"github.com/netdata/netdata/go/go.d.plugin/pkg/buildinfo"
 )
 
 // Request is the configuration of the HTTP request.
@@ -50,6 +54,8 @@ func (r Request) Copy() Request {
 	return r
 }
 
+var userAgent = fmt.Sprintf("Netdata %s.plugin/%s", executable.Name, buildinfo.Version)
+
 // NewHTTPRequest returns a new *http.Requests given a Request configuration and an error if any.
 func NewHTTPRequest(cfg Request) (*http.Request, error) {
 	var body io.Reader
@@ -61,6 +67,8 @@ func NewHTTPRequest(cfg Request) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Set("User-Agent", userAgent)
 
 	if cfg.Username != "" || cfg.Password != "" {
 		req.SetBasicAuth(cfg.Username, cfg.Password)

--- a/src/health/health_prototypes.c
+++ b/src/health/health_prototypes.c
@@ -350,7 +350,7 @@ static char *simple_pattern_trim_around_equal(const char *src) {
     return store;
 }
 
-static struct pattern_array *trim_and_add_key_to_values(struct pattern_array *pa, const char *key, STRING *input) {
+struct pattern_array *trim_and_add_key_to_values(struct pattern_array *pa, const char *key, STRING *input) {
     char *tmp = simple_pattern_trim_around_equal(string2str(input));
     pa = health_config_add_key_to_values(pa, key, tmp);
     freez(tmp);
@@ -483,7 +483,7 @@ static bool prototype_matches_host(RRDHOST *host, RRD_ALERT_PROTOTYPE *ap) {
         return false;
 
     if (host->rrdlabels && ap->match.host_labels_pattern &&
-        !pattern_array_label_match(ap->match.host_labels_pattern, host->rrdlabels, '=', NULL, rrdlabels_match_simple_pattern_parsed))
+        !pattern_array_label_match(ap->match.host_labels_pattern, host->rrdlabels, '=', NULL))
         return false;
 
     return true;
@@ -501,7 +501,7 @@ static bool prototype_matches_rrdset(RRDSET *st, RRD_ALERT_PROTOTYPE *ap) {
         return false;
 
     if (st->rrdlabels && ap->match.chart_labels_pattern &&
-        !pattern_array_label_match(ap->match.chart_labels_pattern, st->rrdlabels, '=', NULL, rrdlabels_match_simple_pattern_parsed))
+        !pattern_array_label_match(ap->match.chart_labels_pattern, st->rrdlabels, '=', NULL))
         return false;
 
     return true;


### PR DESCRIPTION
##### Summary
- go.d: sd ll: add mysql socket jobs (#17305)
- go.d: sd local listeners: add unix socket job (#17304)
- fix rrdlabels traversal (#17292)
- fix positive and negative matches on labels (#17290)
- Correctly handle libyaml linking for log2journal. (#17276)
- Fix conditional for Amazon Linux 2023 in repoconfig spec file. (#17056)
- go.d: don't create jobs with unknown module (#17289)
- go.d: set User-Agent automatically when creating HTTP req (#17286)
- go.d: socket package: don't set client on connect() err (#17283)
- go.d: sd docker: create multiple nginx configs (#17285)
- go.d: dyncfg: allow "name" additional property (#17272)
- go.d: config schemas update: prohibit additional properties (#17269)
