### PR TITLE
Update hpssa.chart.py

### DIFF
--- a/src/collectors/python.d.plugin/hpssa/hpssa.chart.py
+++ b/src/collectors/python.d.plugin/hpssa/hpssa.chart.py
@@ -86,7 +86,7 @@ ignored_sections_regex = re.compile(
         Physical[ ]Drives
         | None[ ]attached
         | (?:Expander|Enclosure|SEP|Port[ ]Name:)[ ].+
-        | .+[ ]at[ ]Port[ ]\S+,[ ]Box[ ]\d+,[ ].+
+        | .+[ ]at[ ]Port[ ]\S+,[ ]Box[ ]\d+(\s\(Index[ ]\d+\))?,[ ].+
         | Mirror[ ]Group[ ]\d+:
     $
     ''',


### PR DESCRIPTION
##### Summary
Fix HPSSA collector panic on drive cage index
Fixes #17293

##### Test Plan
Tested on the machine that originally caused #17293 and two other machines that did not have #17293.
Collection was successful for all three machines.


<details> <summary>For users: How does this change affect me?</summary>
No change is expected.
</details>
