### PR TITLE
go.d: sd local listeners: add unix socket job

### DIFF
--- a/src/go/collectors/go.d.plugin/config/go.d/postgres.conf
+++ b/src/go/collectors/go.d.plugin/config/go.d/postgres.conf
@@ -1,9 +1,10 @@
 ## All available configuration options, their descriptions and default values:
 ## https://github.com/netdata/netdata/tree/master/src/go/collectors/go.d.plugin/modules/postgres#readme
 
-jobs:
-  - name: local
-    dsn: 'host=/var/run/postgresql dbname=postgres user=netdata'
-    #collect_databases_matching: '*'
+#jobs:
+#  - name: local
+#    dsn: 'host=/var/run/postgresql dbname=postgres user=netdata'
+#    #collect_databases_matching: '*'
+#
 #  - name: local
 #    dsn: 'postgresql://netdata@127.0.0.1:5432/postgres'

--- a/src/go/collectors/go.d.plugin/config/go.d/sd/net_listeners.conf
+++ b/src/go/collectors/go.d.plugin/config/go.d/sd/net_listeners.conf
@@ -313,9 +313,15 @@ compose:
           address: redis://@{{.IPAddress}}:{{.Port}}
       - selector: "postgres"
         template: |
-          module: postgres
-          name: local
-          dsn: postgresql://netdata@{{.Address}}/postgres
+          - module: postgres
+            name: local
+            dsn: 'host=/var/run/postgresql dbname=postgres user=postgres'
+          - module: postgres
+            name: local
+            dsn: 'host=/var/run/postgresql dbname=postgres user=netdata'
+          - module: postgres
+            name: local
+            dsn: postgresql://netdata@{{.Address}}/postgres
       - selector: "powerdns"
         template: |
           module: powerdns


### PR DESCRIPTION
##### Summary

Fixes: #17302

We didn't recommend this, but apparently, people use a passwordless connection over a Unix socket.

This PR

##### Test Plan


- Set method to `trust` for Unix connection in `pg_hba.conf`
- Check Postgres data collection job.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
