### PR TITLE
Update metadata frequency

### DIFF
--- a/src/daemon/analytics.h
+++ b/src/daemon/analytics.h
@@ -9,7 +9,7 @@
 #define ANALYTICS_INIT_SLEEP_SEC 120
 
 /* Send a META event every X seconds */
-#define ANALYTICS_HEARTBEAT 7200
+#define ANALYTICS_HEARTBEAT (6 * 3600)
 
 /* Maximum number of hits to log */
 #define ANALYTICS_MAX_PROMETHEUS_HITS 255


### PR DESCRIPTION
##### Summary
- Change the metadata (alive) event interval to 6 hours (was every 2 hours)
