### PR TITLE
Explicitly require systemd for systemd journal plugin.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1870,6 +1870,10 @@ if(ENABLE_PLUGIN_CGROUP_NETWORK)
 endif()
 
 if(ENABLE_PLUGIN_SYSTEMD_JOURNAL)
+        if(NOT SYSTEMD_FOUND)
+                message(FATAL_ERROR "Systemd journal plugin requires systemd, but systemd was not found.")
+        endif()
+
         add_executable(systemd-journal.plugin ${SYSTEMD_JOURNAL_PLUGIN_FILES})
         target_link_libraries(systemd-journal.plugin libnetdata)
 


### PR DESCRIPTION
##### Summary

Without this change, it doesn’t fail until the build itself if the plugin is enabled but systemd could not be found.

##### Test Plan

CI passes on this PR.

Secondary testing involves checking a manual build (_without_ using the installer script) on a non-systemd system. Without this change, no failure will be seen until late in the actual build process, while with this change we will bail out during the CMake checks if the plugin is enabled.

##### Additional Info

Discovered while manually testing a different PR on Alpine.