### PR TITLE
Drop legacy dbengine support

### DIFF
--- a/src/daemon/global_statistics.c
+++ b/src/daemon/global_statistics.c
@@ -2562,12 +2562,10 @@ static void dbengine2_statistics_charts(void) {
                     if(host->db[tier].mode != RRD_MEMORY_MODE_DBENGINE) continue;
                     if(!host->db[tier].si) continue;
 
-                    if(is_storage_engine_shared(host->db[tier].si)) {
-                        if(counted_multihost_db[tier])
-                            continue;
-                        else
-                            counted_multihost_db[tier] = 1;
-                    }
+                    if(counted_multihost_db[tier])
+                        continue;
+                    else
+                        counted_multihost_db[tier] = 1;
 
                     ++dbengine_contexts;
                     rrdeng_get_37_statistics((struct rrdengine_instance *)host->db[tier].si, local_stats_array);

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1366,8 +1366,7 @@ static void *ctx_shutdown_tp_worker(struct rrdengine_instance *ctx __maybe_unuse
         if(!logged) {
             logged = true;
             netdata_log_info("DBENGINE: waiting for %zu inflight queries to finish to shutdown tier %d...",
-                 __atomic_load_n(&ctx->atomic.inflight_queries, __ATOMIC_RELAXED),
-                 (ctx->config.legacy) ? -1 : ctx->config.tier);
+                 __atomic_load_n(&ctx->atomic.inflight_queries, __ATOMIC_RELAXED), ctx->config.tier);
         }
         sleep_usec(1 * USEC_PER_MS);
     }

--- a/src/database/engine/rrdengine.h
+++ b/src/database/engine/rrdengine.h
@@ -350,8 +350,6 @@ extern rrdeng_stats_t global_flushing_pressure_page_deletions; /* number of dele
 
 struct rrdengine_instance {
     struct {
-        bool legacy;                                // true when the db is autonomous for a single host
-
         int tier;                                   // the tier of this ctx
         uint8_t page_type;                          // default page type for this context
 

--- a/src/database/engine/rrdengineapi.h
+++ b/src/database/engine/rrdengineapi.h
@@ -24,8 +24,6 @@ extern uint8_t tier_page_type[];
 
 #define CTX_POINT_SIZE_BYTES(ctx) page_type_size[(ctx)->config.page_type]
 
-void rrdeng_generate_legacy_uuid(const char *dim_id, const char *chart_id, uuid_t *ret_uuid);
-
 STORAGE_METRIC_HANDLE *rrdeng_metric_get_or_create(RRDDIM *rd, STORAGE_INSTANCE *si);
 STORAGE_METRIC_HANDLE *rrdeng_metric_get(STORAGE_INSTANCE *si, uuid_t *uuid);
 void rrdeng_metric_release(STORAGE_METRIC_HANDLE *smh);
@@ -221,6 +219,5 @@ struct rrdeng_cache_efficiency_stats rrdeng_get_cache_efficiency_stats(void);
 
 RRDENG_SIZE_STATS rrdeng_size_statistics(struct rrdengine_instance *ctx);
 size_t rrdeng_collectors_running(struct rrdengine_instance *ctx);
-bool rrdeng_is_legacy(STORAGE_INSTANCE *si);
 
 #endif /* NETDATA_RRDENGINEAPI_H */

--- a/src/database/engine/rrdenginelib.c
+++ b/src/database/engine/rrdenginelib.c
@@ -76,51 +76,6 @@ int open_file_for_io(char *path, int flags, uv_file *file, int direct)
     return fd;
 }
 
-int is_legacy_child(const char *machine_guid)
-{
-    uuid_t uuid;
-    char  dbengine_file[FILENAME_MAX+1];
-
-    if (unlikely(!strcmp(machine_guid, "unittest-dbengine") || !strcmp(machine_guid, "dbengine-dataset") ||
-                 !strcmp(machine_guid, "dbengine-stress-test"))) {
-        return 1;
-    }
-    if (!uuid_parse(machine_guid, uuid)) {
-        uv_fs_t stat_req;
-        snprintfz(dbengine_file, FILENAME_MAX, "%s/%s/dbengine", netdata_configured_cache_dir, machine_guid);
-        int rc = uv_fs_stat(NULL, &stat_req, dbengine_file, NULL);
-        if (likely(rc == 0 && ((stat_req.statbuf.st_mode & S_IFMT) == S_IFDIR))) {
-            //netdata_log_info("Found legacy engine folder \"%s\"", dbengine_file);
-            return 1;
-        }
-    }
-    return 0;
-}
-
-int count_legacy_children(char *dbfiles_path)
-{
-    int ret;
-    uv_fs_t req;
-    uv_dirent_t dent;
-    int legacy_engines = 0;
-
-    ret = uv_fs_scandir(NULL, &req, dbfiles_path, 0, NULL);
-    if (ret < 0) {
-        uv_fs_req_cleanup(&req);
-        netdata_log_error("uv_fs_scandir(%s): %s", dbfiles_path, uv_strerror(ret));
-        return ret;
-    }
-
-    while(UV_EOF != uv_fs_scandir_next(&req, &dent)) {
-        if (dent.type == UV_DIRENT_DIR) {
-            if (is_legacy_child(dent.name))
-                legacy_engines++;
-        }
-    }
-    uv_fs_req_cleanup(&req);
-    return legacy_engines;
-}
-
 int compute_multidb_diskspace()
 {
     char multidb_disk_space_file[FILENAME_MAX + 1];
@@ -139,23 +94,8 @@ int compute_multidb_diskspace()
         }
     }
 
-    if (computed_multidb_disk_quota_mb == -1) {
-        int rc = count_legacy_children(netdata_configured_cache_dir);
-        if (likely(rc >= 0)) {
-            computed_multidb_disk_quota_mb = (rc + 1) * default_rrdeng_disk_quota_mb;
-            netdata_log_info("Found %d legacy dbengines, setting multidb diskspace to %dMB", rc, computed_multidb_disk_quota_mb);
-
-            fp = fopen(multidb_disk_space_file, "w");
-            if (likely(fp)) {
-                fprintf(fp, "%d", computed_multidb_disk_quota_mb);
-                netdata_log_info("Created file '%s' to store the computed value", multidb_disk_space_file);
-                fclose(fp);
-            } else
-                netdata_log_error("Failed to store the default multidb disk quota size on '%s'", multidb_disk_space_file);
-        }
-        else
-            computed_multidb_disk_quota_mb = default_rrdeng_disk_quota_mb;
-    }
+    if (computed_multidb_disk_quota_mb == -1)
+        computed_multidb_disk_quota_mb = default_rrdeng_disk_quota_mb;
 
     return computed_multidb_disk_quota_mb;
 }

--- a/src/database/engine/rrdenginelib.h
+++ b/src/database/engine/rrdenginelib.h
@@ -89,6 +89,5 @@ static inline int open_file_buffered_io(char *path, int flags, uv_file *file)
     return open_file_for_io(path, flags, file, 0);
 }
 int compute_multidb_diskspace();
-int is_legacy_child(const char *machine_guid);
 
 #endif /* NETDATA_RRDENGINELIB_H */

--- a/src/database/rrd.h
+++ b/src/database/rrd.h
@@ -1369,7 +1369,6 @@ extern netdata_rwlock_t rrd_rwlock;
 
 // ----------------------------------------------------------------------------
 
-bool is_storage_engine_shared(STORAGE_INSTANCE *si);
 void rrdset_index_init(RRDHOST *host);
 void rrdset_index_destroy(RRDHOST *host);
 


### PR DESCRIPTION
##### Summary
With the introduction of the multihost database, all children connected to a parent now store metrics in the same database (dbengine). 

Previously, each child was storing metrics in a separate folder (i.e., dbengine instance). However, this functionality has not been supported for some time now; in fact, it stopped working properly a while back, affecting both metric storage and querying capabilities.

This pull request removes the code related to that functionality
