### PR TITLE
Call with resize true when dictionary has DICT_OPTION_INDEX_HASHTABLE

### DIFF
--- a/src/libnetdata/dictionary/dictionary-hashtable.h
+++ b/src/libnetdata/dictionary/dictionary-hashtable.h
@@ -95,7 +95,7 @@ static inline DICTIONARY_ITEM *hashtable_get_hashtable(DICTIONARY *dict, const c
     key[name_len] = '\0';
 
     XXH64_hash_t hash = XXH3_64bits(name, name_len);
-    SIMPLE_HASHTABLE_SLOT_DICTIONARY *sl = simple_hashtable_get_slot_DICTIONARY(ht, hash, key, false);
+    SIMPLE_HASHTABLE_SLOT_DICTIONARY *sl = simple_hashtable_get_slot_DICTIONARY(ht, hash, key, true);
     return SIMPLE_HASHTABLE_SLOT_DATA(sl);
 }
 


### PR DESCRIPTION
##### Summary
- The default option for dictionaries is DICT_OPTION_INDEX_JUDY but when DICT_OPTION_INDEX_HASHTABLE is used, it can fail with 

```
#5  0x000074e954a267db in __assert_fail_base (fmt=0x74e954bc5168 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=assertion@entry=0x5fb5908579c3 "sl != sl_started", 
    function=function@entry=0x5fb5908581a0 <__PRETTY_FUNCTION__.19> "simple_hashtable_get_slot_DICTIONARY") at ./assert/assert.c:92
#6  0x000074e954a39206 in __assert_fail (assertion=0x5fb5908579c3 "sl != sl_started", 
#7  0x00005fb5904f9847 in simple_hashtable_get_slot_DICTIONARY (ht=0x5fb5927106b0, hash=18104129637449712647, key=0x7ffde467b590, resize=false)
```
