### PR TITLE
Check for Snappy only when required.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,15 +303,6 @@ check_include_file("stdint.h" HAVE_STDINT_H)
 check_include_file("sys/capability.h" HAVE_SYS_CAPABILITY_H)
 
 #
-# check libraries we need
-#
-
-include(CheckLibraryExists)
-
-check_library_exists(snappy snappy_compress "" HAVE_SNAPPY_LIB)
-#check_include_file("snappy.h" HAVE_SNAPPY_H)
-
-#
 # check symbols
 #
 
@@ -1991,6 +1982,9 @@ endif()
 if(ENABLE_EXPORTER_PROMETHEUS_REMOTE_WRITE)
         pkg_check_modules(SNAPPY snappy)
         if (NOT SNAPPY_FOUND)
+                include(CheckLibraryExists)
+                check_library_exists(snappy snappy_compress "" HAVE_SNAPPY_LIB)
+
                 if(HAVE_SNAPPY_LIB)
                         set(SNAPPY_INCLUDE_DIRS "")
                         set(SNAPPY_CFLAGS_OTHER "")


### PR DESCRIPTION
##### Summary

Snappy is only used by the Prometheus Remote Write exporter, so we should only be checking for it if that is enabled. We also should be checking with pkg-config _first_ instead of doing so after searching for the library directly.

##### Test Plan

CI passes on this PR.