### PR TITLE
Remove seemingly dead logging related code from libnetdata.

### DIFF
--- a/src/libnetdata/log/log.c
+++ b/src/libnetdata/log/log.c
@@ -367,12 +367,6 @@ struct nd_log_source {
     struct nd_log_limit limits;
 };
 
-static __thread ND_LOG_SOURCES overwrite_thread_source = 0;
-
-void nd_log_set_thread_source(ND_LOG_SOURCES source) {
-    overwrite_thread_source = source;
-}
-
 static struct {
     uuid_t invocation_id;
 
@@ -2236,9 +2230,6 @@ static void nd_logger(const char *file, const char *function, const unsigned lon
 static ND_LOG_SOURCES nd_log_validate_source(ND_LOG_SOURCES source) {
     if(source >= _NDLS_MAX)
         source = NDLS_DAEMON;
-
-    if(overwrite_thread_source)
-        source = overwrite_thread_source;
 
     if(nd_log.overwrite_process_source)
         source = nd_log.overwrite_process_source;

--- a/src/libnetdata/log/log.h
+++ b/src/libnetdata/log/log.h
@@ -150,7 +150,6 @@ void chown_open_file(int fd, uid_t uid, gid_t gid);
 void nd_log_chown_log_files(uid_t uid, gid_t gid);
 void nd_log_set_flood_protection(size_t logs, time_t period);
 void nd_log_initialize_for_external_plugins(const char *name);
-void nd_log_set_thread_source(ND_LOG_SOURCES source);
 bool nd_log_journal_socket_available(void);
 ND_LOG_FIELD_ID nd_log_field_id_by_name(const char *field, size_t len);
 int nd_log_priority2id(const char *priority);


### PR DESCRIPTION
##### Summary

`overwrite_thread_source` is only accessed in two locations:

- It gets written to only by `nd_log_set_thread_source`, which does not appear to ever be called anywhere in our current code.
- It is only ever read by `nd_log_validate_source`, which, because `nd_log_set_thread_source` is never called, should never end up resulting in any actual behavioral changes (since it will always be 0).

Based on this, the code is functionally dead, and therefore can safely be removed since libnetdata is intended to be for internal use only (and this seems to be relatively low-level even within libnetdata).

From a cursory look at changes, this code has actually _never_ been used in any version of the agent code that is publicly available, though there may have been some intent behind including them that I am not aware of.

##### Test Plan

Preliminary testing consists of verifying that CI passes on this PR.

Additional testing may be needed to confirm that logging still works correctly.

##### Additional Information

Discovered while debugging issues with #17027, where this particular code seems to be tripping things up on openSUSE when built with LTO enabled.