### PR TITLE
Enable Sentry for Ubuntu and Debian native packages.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -155,7 +155,6 @@ include:
   - <<: *debian
     version: "11"
     base_image: debian:bullseye
-    bundle_sentry: false
     packages:
       <<: *debian_packages
       repo_distro: debian/bullseye
@@ -282,7 +281,7 @@ include:
     support_type: Core
     notes: ''
     eol_check: true
-    bundle_sentry: false
+    bundle_sentry: true
     env_prep: |
       rm -f /etc/apt/apt.conf.d/docker && apt-get update
     jsonc_removal: |


### PR DESCRIPTION
##### Summary

Skip Debian 10 because it’s known to not work with this, and will be EOL in a few months anyway.

##### Test Plan

CI passes on this PR.