### PR TITLE
fix proc-power-supply charts family

### DIFF
--- a/src/collectors/proc.plugin/sys_class_power_supply.c
+++ b/src/collectors/proc.plugin/sys_class_power_supply.c
@@ -352,7 +352,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                         "powersupply_capacity"
                         , ps->name
                         , NULL
-                        , ps->name
+                        , "capacity"
                         , "powersupply.capacity"
                         , "Battery capacity"
                         , "percentage"
@@ -383,7 +383,7 @@ int do_sys_class_power_supply(int update_every, usec_t dt) {
                         id
                         , ps->name
                         , NULL
-                        , ps->name
+                        , pr->name
                         , context
                         , pr->title
                         , pr->units


### PR DESCRIPTION
##### Summary

Use the property name (capacity, charge, energy, voltage) instead of the "power_supply" name (e.g. BAT0).

The issue reported in #17329

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
