### PR TITLE
Increase number of pages per extent in dbengine

### DIFF
--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -11,7 +11,7 @@ rrdeng_stats_t rrdeng_reserved_file_descriptors = 0;
 rrdeng_stats_t global_pg_cache_over_half_dirty_events = 0;
 rrdeng_stats_t global_flushing_pressure_page_deletions = 0;
 
-unsigned rrdeng_pages_per_extent = MAX_PAGES_PER_EXTENT;
+unsigned rrdeng_pages_per_extent = DEFAULT_PAGES_PER_EXTENT;
 
 #if WORKER_UTILIZATION_MAX_JOB_TYPES < (RRDENG_OPCODE_MAX + 2)
 #error Please increase WORKER_UTILIZATION_MAX_JOB_TYPES to at least (RRDENG_MAX_OPCODE + 2)

--- a/src/database/engine/rrdengine.h
+++ b/src/database/engine/rrdengine.h
@@ -30,7 +30,8 @@ extern unsigned rrdeng_pages_per_extent;
 struct rrdengine_instance;
 struct rrdeng_cmd;
 
-#define MAX_PAGES_PER_EXTENT (64) /* TODO: can go higher only when journal supports bigger than 4KiB transactions */
+#define MAX_PAGES_PER_EXTENT (109) /* TODO: can go higher only when journal supports bigger than 4KiB transactions */
+#define DEFAULT_PAGES_PER_EXTENT (64)
 
 #define RRDENG_FILE_NUMBER_SCAN_TMPL "%1u-%10u"
 #define RRDENG_FILE_NUMBER_PRINT_TMPL "%1.1u-%10.10u"

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -827,8 +827,8 @@ void dbengine_init(char *hostname) {
 #ifdef ENABLE_DBENGINE
     use_direct_io = config_get_boolean(CONFIG_SECTION_DB, "dbengine use direct io", use_direct_io);
 
-    unsigned read_num = (unsigned)config_get_number(CONFIG_SECTION_DB, "dbengine pages per extent", MAX_PAGES_PER_EXTENT);
-    if (read_num > 0 && read_num <= MAX_PAGES_PER_EXTENT)
+    unsigned read_num = (unsigned)config_get_number(CONFIG_SECTION_DB, "dbengine pages per extent", DEFAULT_PAGES_PER_EXTENT);
+    if (read_num > 0 && read_num <= DEFAULT_PAGES_PER_EXTENT)
         rrdeng_pages_per_extent = read_num;
     else {
         nd_log(NDLS_DAEMON, NDLP_WARNING,


### PR DESCRIPTION
##### Summary
Presently, each extent accommodates up to 64 pages, although theoretically, an extent could hold up to 109 pages. However, modifying the number of pages per extent and permitting pages exceeding 64 would lead to rejection by older versions of the agent due to certain checks in the code. This pull request aims to loosen this restriction, enabling future agents to utilize more pages per extent.

##### Test Plan
- Compile this PR and start the agent.
- Let it run for a few minutes (time A to time B)
- Switch to master branch, compile and restart the agent
- All data should be there (esp time frame A --> B)
