### PR TITLE
add intel_gpu_top to apps_groups.conf

### DIFF
--- a/src/collectors/apps.plugin/apps_groups.conf
+++ b/src/collectors/apps.plugin/apps_groups.conf
@@ -172,6 +172,7 @@ edgedelta: edgedelta
 newrelic: newrelic*
 google-agent: *google_guest_agent* *google_osconfig_agent*
 nvidia-smi: nvidia-smi
+intel_gpu_top: intel_gpu_top
 htop: htop
 watchdog: watchdog
 telegraf: telegraf


### PR DESCRIPTION
##### Summary


A collector that uses `intel_gpu_top` was added in #17344.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
