### PR TITLE
Move vendoring of Sentry to it’s own module and switch to using Git instead of the releases page.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,11 +276,19 @@ endif()
 
 include(NetdataYAML)
 
+if(ENABLE_SENTRY)
+        include(NetdataSentry)
+endif()
+
 #
 # Checks from custom modules
 #
 
 netdata_detect_libyaml()
+
+if(ENABLE_SENTRY)
+        netdata_bundle_sentry()
+endif()
 
 #
 # check include files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,24 +142,6 @@ if(ENABLE_PLUGIN_GO)
     find_package(Go "${MIN_GO_VERSION}" REQUIRED)
 endif()
 
-if(ENABLE_SENTRY)
-        include(FetchContent)
-
-        # ignore debhelper
-        set(FETCHCONTENT_FULLY_DISCONNECTED Off)
-
-        set(SENTRY_VERSION 0.6.6)
-        set(SENTRY_BACKEND "breakpad")
-        set(SENTRY_BUILD_SHARED_LIBS OFF)
-
-        FetchContent_Declare(
-                sentry
-                URL https://github.com/getsentry/sentry-native/releases/download/${SENTRY_VERSION}/sentry-native.zip
-                URL_HASH SHA256=7a98467c0b2571380a3afc5e681cb13aa406a709529be12d74610b0015ccde0c
-        )
-        FetchContent_MakeAvailable(sentry)
-endif()
-
 if(ENABLE_WEBRTC)
         include(FetchContent)
 

--- a/packaging/cmake/Modules/NetdataSentry.cmake
+++ b/packaging/cmake/Modules/NetdataSentry.cmake
@@ -1,0 +1,29 @@
+# Functions and macros for handling of Sentry
+#
+# Copyright (c) 2024 Netdata Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Handle bundling of Sentry.
+#
+# This pulls it in as a sub-project using FetchContent functionality.
+#
+# This needs to be a function and not a macro for variable scoping
+# reasons. All the things we care about from the sub-project are exposed
+# as targets, which are globally scoped and not function scoped.
+function(netdata_bundle_sentry)
+        include(FetchContent)
+
+        # ignore debhelper
+        set(FETCHCONTENT_FULLY_DISCONNECTED Off)
+
+        set(SENTRY_VERSION 0.6.6)
+        set(SENTRY_BACKEND "breakpad")
+        set(SENTRY_BUILD_SHARED_LIBS OFF)
+
+        FetchContent_Declare(
+                sentry
+                GIT_REPOSITORY https://github.com/getsentry/sentry-native.git
+                GIT_TAG c97bcc63fa89ae557cef9c9b6e3acb11a72ff97d # v0.6.6
+        )
+        FetchContent_MakeAvailable(sentry)
+endfunction()


### PR DESCRIPTION
##### Summary

This brings it in-line with how we’re handling vendoring of other components as CMake subprojects.

##### Test Plan

CI passes on this PR.