### PR TITLE
Fix required toolchain version for Go code.

### DIFF
--- a/src/go/collectors/go.d.plugin/go.mod
+++ b/src/go/collectors/go.d.plugin/go.mod
@@ -1,6 +1,6 @@
 module github.com/netdata/netdata/go/go.d.plugin
 
-go 1.21
+go 1.21.0
 
 replace github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.50.1
 


### PR DESCRIPTION
##### Summary

As of Go 1.21, version 1.21.0 is the first official Go 1.21 release, and we should thus be explicitly calling out that as the required toolchain version, since depending on version 1.21 would allow use of prerelease versions of the toolchain for Go 1.21, which we very much do not want.

Versioning explanation in the official docs is here: https://go.dev/doc/toolchain#version

This discrepancy was originally spotted because it was flagged as a warning by CodeQL.

##### Test Plan

CI passes on this PR.