### PR TITLE
Fix logic in detection of multiple installs.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -886,13 +886,15 @@ detect_existing_install() {
   while [ -n "${searchpath}" ]; do
     _ndpath="$(PATH="${searchpath}" command -v netdata 2>/dev/null)"
 
-    if [ -z "${ndpath}" ]; then
+    if [ -z "${ndpath}" ] && [ -n "${_ndpath}" ]; then
       ndpath="${_ndpath}"
-    elif [ -n "${_ndpath}" ]; then
+    elif [ -n "${_ndpath}" ] && [ "${ndpath}" != "${_ndpath}" ]; then
       fatal "Multiple installs of Netdata agent detected (located at '${ndpath}' and '${_ndpath}'). Such a setup is not generally supported. If you are certain you want to operate on one of them despite this, use the '--install-prefix' option to specifiy the install you want to operate on." F0517
     fi
 
     if [ -n "${INSTALL_PREFIX}" ] && [ -n "${ndpath}" ]; then
+      break
+    elif [ -z "${_ndpath}" ]; then
       break
     elif echo "${searchpath}" | grep -v ':'; then
       searchpath=""


### PR DESCRIPTION
##### Summary

- Only flag multiple installs if subsequent searches produce a different install path.
- Only set the detected install path if a search actually finds an install path.
- Bail early if the initial search finds nothing.

The first two parts are required for correct operation of the code. The third is a performance optimization in the case of there being no existing install of the agent that would be detected by the kickstart script.

##### Test Plan

Testing involves using the script from this PR on a system with an existing install. Without these changes, it will always fail early claiming it found a duplicate install. With these changes, it should work correctly.

##### Additional Info

Fixes: #17368 