### PR TITLE
Canonicalize paths before comparison when checking for multiple installs.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -368,6 +368,15 @@ trap 'trap_handler 15 0' TERM
 # ======================================================================
 # Utility functions
 
+cannonical_path() {
+  cd "$(dirname "${1}")" || exit 1
+  case "$(basename "${1}")" in
+    ..) dirname "$(pwd -P)" ;;
+    .) pwd -P ;;
+    *) echo "$(pwd -P)/$(basename "${1}")" ;;
+  esac
+}
+
 setup_terminal() {
   TPUT_RESET=""
   TPUT_WHITE=""
@@ -885,6 +894,10 @@ detect_existing_install() {
 
   while [ -n "${searchpath}" ]; do
     _ndpath="$(PATH="${searchpath}" command -v netdata 2>/dev/null)"
+
+    if [ -n "${_ndpath}" ]; then
+      _ndpath="$(canonical_path "$(ndpath)")"
+    fi
 
     if [ -z "${ndpath}" ] && [ -n "${_ndpath}" ]; then
       ndpath="${_ndpath}"


### PR DESCRIPTION
##### Summary

For some arcane reason, many distros that have chose a merged `/usr` layout (https://www.freedesktop.org/wiki/Software/systemd/TheCaseForTheUsrMerge/) insist on still putting both `/bin` and `/usr/bin` (and `/sbin` and `/usr/sbin`) in their default `$PATH`, despite the fact that this provides no real benefit (it’s questionable even for ‘backwards compatibility’, anything that truly _needs_ this on a system with a merged `/usr` layout is fundamentally broken).

To correctly handle the fact that it’s not only possible but actually extremely likely that Netdata will show up in more than one place in `$PATH` even if it’s a single install, we need to canonicalize the paths before comparing them when checking for multiple installs.

Unfortunately, despite path canonicalization being an extremely common need, there is no POSIX utility for doing it with arbitrary paths, so we have to resort to some trickery to achieve this portably. The exact implementation used by this change is somewhat naive and only works if the directory the target path indicates actually exists, but we can count on this being the case in this particular usage because we know that we found a file within that directory.

##### Test Plan

Testing is the same as for #17369.

##### Additional Information

Fixes: #17368 (correctly this time).