### PR TITLE
Split Sentry enablement to be per-architecture.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -16,6 +16,14 @@ arch_order:  # sort order for per-architecture jobs in CI
   - armhfp
   - arm64
   - aarch64
+default_sentry: &default_sentry # Default configuration for Sentry usage
+  amd64: false
+  x86_64: false
+  i386: false
+  armhf: false
+  armhfp: false
+  arm64: false
+  aarch64: false
 include:
   - &alpine
     distro: alpine
@@ -23,6 +31,7 @@ include:
     support_type: Community
     notes: ''
     eol_check: false
+    bundle_sentry: *default_sentry
     env_prep: |
       apk add -U bash
     jsonc_removal: |
@@ -34,7 +43,6 @@ include:
     support_type: Core
     notes: ''
     eol_check: true
-    bundle_sentry: false
   - <<: *alpine
     version: "3.18"
     support_type: Core
@@ -56,7 +64,7 @@ include:
     support_type: Intermediate
     notes: ''
     eol_check: false
-    bundle_sentry: false
+    bundle_sentry: *default_sentry
     env_prep: |
       pacman --noconfirm -Syu && pacman --noconfirm -Sy grep libffi
     test:
@@ -68,7 +76,7 @@ include:
     support_type: Core
     notes: ''
     eol_check: 'amazon-linux'
-    bundle_sentry: false
+    bundle_sentry: *default_sentry
     packages: &amzn_packages
       type: rpm
       repo_distro: amazonlinux/2
@@ -92,7 +100,7 @@ include:
     support_type: Core
     notes: ''
     eol_check: false
-    bundle_sentry: false
+    bundle_sentry: *default_sentry
     packages:
       type: rpm
       repo_distro: el/7
@@ -114,7 +122,7 @@ include:
     jsonc_removal: |
       dnf remove -y json-c-devel
     eol_check: true
-    bundle_sentry: false
+    bundle_sentry: *default_sentry
     packages: &cs_packages
       type: rpm
       repo_distro: el/c9s
@@ -137,7 +145,9 @@ include:
     notes: ''
     base_image: debian:bookworm
     eol_check: true
-    bundle_sentry: true
+    bundle_sentry:
+      <<: *default_sentry
+      amd64: true
     env_prep: |
       apt-get update
     jsonc_removal: |
@@ -163,7 +173,7 @@ include:
   - <<: *debian
     version: "10"
     base_image: debian:buster
-    bundle_sentry: false
+    bundle_sentry: *default_sentry
     packages:
       <<: *debian_packages
       repo_distro: debian/buster
@@ -176,7 +186,7 @@ include:
     support_type: Core
     notes: ''
     eol_check: true
-    bundle_sentry: false
+    bundle_sentry: *default_sentry
     jsonc_removal: |
       dnf remove -y json-c-devel
     packages: &fedora_packages
@@ -208,7 +218,7 @@ include:
     support_type: Core
     notes: ''
     eol_check: true
-    bundle_sentry: false
+    bundle_sentry: *default_sentry
     base_image: opensuse/leap:15.5
     jsonc_removal: |
       zypper rm -y libjson-c-devel
@@ -227,7 +237,7 @@ include:
     support_type: Core
     notes: ''
     eol_check: true
-    bundle_sentry: false
+    bundle_sentry: *default_sentry
     jsonc_removal: |
       dnf remove -y json-c-devel
     packages: &oracle_packages
@@ -252,7 +262,7 @@ include:
     jsonc_removal: |
       dnf remove -y json-c-devel
     eol_check: true
-    bundle_sentry: false
+    bundle_sentry: *default_sentry
     packages: &rocky_packages
       type: rpm
       repo_distro: el/9
@@ -281,7 +291,9 @@ include:
     support_type: Core
     notes: ''
     eol_check: true
-    bundle_sentry: true
+    bundle_sentry:
+      <<: *default_sentry
+      amd64: true
     env_prep: |
       rm -f /etc/apt/apt.conf.d/docker && apt-get update
     jsonc_removal: |
@@ -308,13 +320,11 @@ include:
 legacy: # Info for platforms we used to support and still need to handle packages for
   - <<: *fedora
     version: "37"
-    bundle_sentry: false
     packages:
       <<: *fedora_packages
       repo_distro: fedora/37
   - <<: *opensuse
     version: "15.4"
-    bundle_sentry: false
     packages:
       <<: *opensuse_packages
       repo_distro: opensuse/15.4

--- a/.github/scripts/gen-matrix-packaging.py
+++ b/.github/scripts/gen-matrix-packaging.py
@@ -28,7 +28,7 @@ for i, v in enumerate(data['include']):
                     'format': data['include'][i]['packages']['type'],
                     'base_image': data['include'][i]['base_image'] if 'base_image' in data['include'][i] else ':'.join([data['include'][i]['distro'], data['include'][i]['version']]),
                     'platform': data['platform_map'][arch],
-                    'bundle_sentry': data['include'][i]['bundle_sentry'],
+                    'bundle_sentry': data['include'][i]['bundle_sentry'][arch],
                     'arch': arch
                 })
 


### PR DESCRIPTION
##### Summary

And only enable it on 64-bit x86 for the moment.

##### Test Plan

Confirmation that this is working correctly consists of inspecting the generated build matrix for the packaging jobs and confirming that platforms other than 64-bit x86 have a value of `false` for the `bundle_sentry` key. Inspection can be done locally by checking out this PR and running `.github/scripts/gen-matrix-packaging.py 0` to produce the JSON representation of the build matrix.