### PR TITLE
Add option to cleanup health_log table 

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -795,6 +795,7 @@ int help(int exitcode) {
             "  -W sqlite-meta-recover   Run recovery on the metadata database and exit.\n\n"
             "  -W sqlite-compact        Reclaim metadata database unused space and exit.\n\n"
             "  -W sqlite-analyze        Run update statistics and exit.\n\n"
+            "  -W sqlite-alert-cleanup  Perform maintenance on the alerts table.\n\n"
 #ifdef ENABLE_DBENGINE
             "  -W createdataset=N       Create a DB engine dataset of N seconds and exit.\n\n"
             "  -W stresstest=A,B,C,D,E,F,G\n"
@@ -1512,6 +1513,11 @@ int main(int argc, char **argv) {
 
                         if(strcmp(optarg, "sqlite-analyze") == 0) {
                             sql_init_meta_database(DB_CHECK_ANALYZE, 0);
+                            return 0;
+                        }
+
+                        if(strcmp(optarg, "sqlite-alert-cleanup") == 0) {
+                            sql_alert_cleanup(true);
                             return 0;
                         }
 

--- a/src/database/sqlite/sqlite_context.c
+++ b/src/database/sqlite/sqlite_context.c
@@ -43,6 +43,7 @@ int sql_init_context_database(int memory)
         return 1;
     }
 
+    errno = 0;
     netdata_log_info("SQLite database %s initialization", sqlite_database);
 
     char buf[1024 + 1] = "";

--- a/src/database/sqlite/sqlite_db_migration.c
+++ b/src/database/sqlite/sqlite_db_migration.c
@@ -530,6 +530,7 @@ static int migrate_database(sqlite3 *database, int target_version, char *db_name
     }
 
     if (likely(user_version == target_version)) {
+        errno = 0;
         netdata_log_info("%s database version is %d (no migration needed)", db_name, target_version);
         return target_version;
     }

--- a/src/database/sqlite/sqlite_health.h
+++ b/src/database/sqlite/sqlite_health.h
@@ -36,4 +36,5 @@ int sql_get_alert_configuration(
     bool debug __maybe_unused);
 
 bool sql_find_alert_transition(const char *transition, void (*cb)(const char *machine_guid, const char *context, time_t alert_id, void *data), void *data);
+void sql_alert_cleanup(bool cli);
 #endif //NETDATA_SQLITE_HEALTH_H

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -747,6 +747,7 @@ int sql_init_meta_database(db_check_action_type_t rebuild, int memory)
         return 1;
     }
 
+    errno = 0;
     netdata_log_info("SQLite database %s initialization", sqlite_database);
 
     rc = sqlite3_create_function(db_meta, "u2h", 1, SQLITE_ANY | SQLITE_DETERMINISTIC, 0, sqlite_uuid_parse, 0, 0);


### PR DESCRIPTION
##### Summary
- Add option to perform a health table cleanup (`netdata -W sqlite-alert-cleanup`)

This operation will be added as a regular cleanup process when the agent is running in a future PR