### PR TITLE
go.d nvme meta: remove sudoers prereq

### DIFF
--- a/src/go/collectors/go.d.plugin/modules/nvme/metadata.yaml
+++ b/src/go/collectors/go.d.plugin/modules/nvme/metadata.yaml
@@ -45,13 +45,6 @@ modules:
           - title: Install nvme-cli
             description: |
               See [Distro Support](https://github.com/linux-nvme/nvme-cli#distro-support). Install `nvme-cli` using your distribution's package manager.
-          - title: Allow netdata to execute nvme
-            description: |
-              Add the netdata user to `/etc/sudoers` (use `which nvme` to find the full path to the binary):
-
-              ```bash
-              netdata ALL=(root) NOPASSWD: /usr/sbin/nvme
-              ```
       configuration:
         file:
           name: go.d/nvme.conf


### PR DESCRIPTION
##### Summary

Is not needed because go.d/nvme relies on `ndsudo`.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
