### PR TITLE
gh labeler: go.d.plugin rm suffix

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -137,7 +137,7 @@ collectors/freeipmi:
           - any-glob-to-any-file:
               - src/collectors/freeipmi.plugin/**
 
-collectors/go.d.plugin:
+collectors/go.d:
   - any:
       - changed-files:
           - any-glob-to-any-file:


### PR DESCRIPTION
##### Summary

I noticed that 

- issues have `collectors/go.d` label.
- PRs have `collectors/go.d.plugin` label. 

Removing the latter since other `collector/*` labels do not have the .plugin suffix.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
