### PR TITLE
Start watcher thread after fork

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -2110,6 +2110,8 @@ int main(int argc, char **argv) {
     if(become_daemon(dont_fork, user) == -1)
         fatal("Cannot daemonize myself.");
 
+    watcher_thread_start();
+
     // init sentry
 #ifdef ENABLE_SENTRY
         sentry_native_init();

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -1889,9 +1889,6 @@ int main(int argc, char **argv) {
         load_cloud_conf(0);
     }
 
-    // @stelfrag: Where is the right place to call this?
-    watcher_thread_start();
-
     // ------------------------------------------------------------------------
     // initialize netdata
     {


### PR DESCRIPTION
##### Summary
- Start the watcher thread after fork (`-D` option not specified)

Fixes #17435