### PR TITLE
Reconnect to the cloud when resuming from suspension

### DIFF
--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -201,6 +201,7 @@ static void health_event_loop(void) {
                    "Postponing alarm checks for %"PRId32" seconds, "
                    "because it seems that the system was just resumed from suspension.",
                    (int32_t)health_globals.config.postpone_alarms_during_hibernation_for_seconds);
+            schedule_node_info_update(localhost);
         }
 
         if (unlikely(silencers->all_alarms && silencers->stype == STYPE_DISABLE_ALARMS)) {


### PR DESCRIPTION

##### Summary
- If resume from suspension is detected, schedule an node update to revive the connection
