### PR TITLE
Fix usage of sha256sum in static builds.

### DIFF
--- a/packaging/makeself/functions.sh
+++ b/packaging/makeself/functions.sh
@@ -52,7 +52,7 @@ fetch() {
     # Check SHA256 of gzip'd tar file (apparently alpine's sha256sum requires
     # two empty spaces between the checksum and the file's path)
     set +e
-    echo "${sha256}  ${NETDATA_MAKESELF_PATH}/tmp/${tar}" | sha256sum -c -s
+    echo "${sha256}  ${NETDATA_MAKESELF_PATH}/tmp/${tar}" | sha256sum --c --status
     local rc=$?
     if [ ${rc} -ne 0 ]; then
         echo >&2 "SHA256 verification of tar file ${tar} failed (rc=${rc})"


### PR DESCRIPTION
##### Summary

Our static builder images now include GNU coreutils, as it is required for proper handling of libbpf during the build process, but this broke file checksum validation in the build process as `sha256sum` from coreutils lacks a single-letter version of the `--status` option that we use.

This fixes things in the build code to work correctly.

##### Test Plan

CI passes on this PR.