### PR TITLE
Update CMake to request new behavior for all policies through v3.28.0.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-cmake_minimum_required(VERSION 3.13.0)
-
-if(POLICY CMP0135)
-    cmake_policy(SET CMP0135 NEW)
-endif()
+cmake_minimum_required(VERSION 3.13.0...3.28)
 
 #
 # version atrocities


### PR DESCRIPTION
##### Summary

Our CMake code definitely works fine with all versions from our minimum suppored version of 3.13 up to and including 3.28, and any of the policies that are likely to affect us should use the new behavior anyway because the old behavior leads to the possiblity of incorrect builds, so explicitly request that CMake all CMake policies provided by the used version up to those provided by v3.28.0 are set to the new behavior.

##### Test Plan

CI passes on this PR.

##### Additional Information

Relevant CMake documentation entries explaining the implications of the change:
- https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-settings
- https://cmake.org/cmake/help/latest/command/cmake_policy.html#setting-policies-by-cmake-version