### PR TITLE
Work around MS’s broken infra in CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -287,7 +287,8 @@ jobs:
       - name: Prepare tools
         id: prepare
         run: |
-          sudo apt-get update && sudo apt-get install -y python3-ruamel.yaml
+          sudo apt-get update || true
+          sudo apt-get install -y python3-ruamel.yaml
       - name: Read build matrix
         id: set-matrix
         run: |

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -62,7 +62,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get upgrade -y && sudo apt-get install -y python3-packaging
+        run: |
+          sudo apt-get update || true
+          sudo apt-get install -y python3-packaging
       - name: Get Go version and modules
         id: get-version
         run: .github/scripts/get-go-version.py

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -98,7 +98,8 @@ jobs:
       - name: Prepare tools
         id: prepare
         run: |
-          sudo apt-get update && sudo apt-get install -y python3-ruamel.yaml
+          sudo apt-get update || true
+          sudo apt-get install -y python3-ruamel.yaml
       - name: Read build matrix
         id: set-matrix
         run: |

--- a/.github/workflows/platform-eol-check.yml
+++ b/.github/workflows/platform-eol-check.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Prepare tools
         id: prepare
         run: |
-          sudo apt-get update && sudo apt-get install -y python3-ruamel.yaml
+          sudo apt-get update || true
+          sudo apt-get install -y python3-ruamel.yaml
       - name: Read build matrix
         id: set-matrix
         run: |

--- a/.github/workflows/repoconfig-packages.yml
+++ b/.github/workflows/repoconfig-packages.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Prepare tools
         id: prepare
         run: |
-          sudo apt-get update && sudo apt-get install -y python3-ruamel.yaml
+          sudo apt-get update || true
+          sudo apt-get install -y python3-ruamel.yaml
       - name: Read build matrix
         id: set-matrix
         run: |


### PR DESCRIPTION
##### Summary

Upstream issue reference: https://github.com/microsoft/linux-package-repositories/issues/130

Not a complete workaround, but this is the best we can do without modifying code that runs on user systems.

##### Test Plan

Build matrix generation for CI jobs works correctly on this PR.