### PR TITLE
Fix handling of kernel version detection in CMake.

### DIFF
--- a/packaging/cmake/Modules/NetdataUtil.cmake
+++ b/packaging/cmake/Modules/NetdataUtil.cmake
@@ -11,9 +11,7 @@ include_guard()
 # variable HOST_KERNEL_VERSION.
 function(netdata_detect_host_kernel_version)
     if(DEFINED HOST_KERNEL_VERSION)
-        if(NOT DEFINED CACHE HOST_KERNEL_VERSION)
-            message(STATUS "Using user supplied kernel version (${HOST_KERNEL_VERSION}) instead of detecting it.")
-        endif()
+        return()
     endif()
 
     message(CHECK_START "Determining host kernel version")


### PR DESCRIPTION
##### Summary

The syntax in the conditionals at the start was wrong, but the control flow was also semantically wrong as well. Fixing the semantic issue gets rid of the conditional with the incorrect syntax as well.

##### Test Plan

CI passes on this PR.