### PR TITLE
Restructure dependency handling in CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,18 +257,6 @@ else()
         add_definitions(-D_GNU_SOURCE)
 endif()
 
-if(ENABLE_PLUGIN_EBPF)
-        include(NetdataLibBPF)
-        include(NetdataEBPFCORE)
-
-        if(NOT LINUX)
-            message(FATAL_ERROR "The eBPF plugin is not supported on non-Linux systems")
-        endif()
-
-        netdata_bundle_libbpf()
-        netdata_fetch_ebpf_co_re()
-endif()
-
 #
 # Libm
 #
@@ -328,6 +316,19 @@ endif()
 netdata_detect_lz4()
 netdata_detect_zstd()
 netdata_detect_brotli()
+
+# Optional component dependencies
+if(ENABLE_PLUGIN_EBPF)
+        include(NetdataLibBPF)
+        include(NetdataEBPFCORE)
+
+        if(NOT LINUX)
+            message(FATAL_ERROR "The eBPF plugin is not supported on non-Linux systems")
+        endif()
+
+        netdata_bundle_libbpf()
+        netdata_fetch_ebpf_co_re()
+endif()
 
 if(ENABLE_SENTRY)
         netdata_bundle_sentry()
@@ -1519,14 +1520,14 @@ target_link_libraries(libnetdata PUBLIC
 
 # ebpf
 if(ENABLE_PLUGIN_EBPF)
-        netdata_add_libbpf_to_target(libnetdata)
+    netdata_add_libbpf_to_target(libnetdata PUBLIC)
 endif()
 
 # judy
 target_link_libraries(libnetdata PUBLIC judy)
 
-netdata_add_jsonc_to_target(libnetdata)
-netdata_add_libyaml_to_target(libnetdata)
+netdata_add_jsonc_to_target(libnetdata PUBLIC)
+netdata_add_libyaml_to_target(libnetdata PUBLIC)
 netdata_add_zlib_to_target(libnetdata PUBLIC)
 netdata_add_libuuid_to_target(libnetdata PUBLIC)
 netdata_add_libuv_to_target(libnetdata PUBLIC)
@@ -1989,7 +1990,7 @@ target_link_libraries(netdata PRIVATE
 )
 
 if(NEED_PROTOBUF)
-        netdata_add_protobuf(netdata)
+        netdata_add_protobuf_to_target(netdata PRIVATE)
 endif()
 
 #
@@ -2034,7 +2035,7 @@ if(PCRE2_FOUND)
         target_compile_definitions(log2journal PUBLIC ${PCRE2_CFLAGS_OTHER})
         target_link_libraries(log2journal PUBLIC "${PCRE2_LDFLAGS}")
 
-        netdata_add_libyaml_to_target(log2journal)
+        netdata_add_libyaml_to_target(log2journal PUBLIC)
 
         install(TARGETS log2journal
                 COMPONENT log2journal

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,6 +294,8 @@ endif()
 # Custom Modules
 #
 
+include(NetdataRequiredDeps)
+include(NetdataTLS)
 include(NetdataJSONC)
 include(NetdataYAML)
 
@@ -309,6 +311,10 @@ endif()
 # Checks from custom modules
 #
 
+netdata_detect_zlib()
+netdata_detect_libuuid()
+netdata_detect_libuv()
+netdata_detect_tls_and_crypto()
 netdata_detect_jsonc()
 netdata_detect_libyaml()
 
@@ -504,34 +510,6 @@ int my_function() {
 
 if(FREEBSD OR MACOS)
         set(HAVE_BUILTIN_ATOMICS True)
-endif()
-
-# openssl/crypto
-set(ENABLE_OPENSSL True)
-pkg_check_modules(OPENSSL openssl)
-
-if(NOT OPENSSL_FOUND)
-        if(MACOS)
-                execute_process(COMMAND
-                                brew --prefix --installed openssl
-                                RESULT_VARIABLE BREW_OPENSSL
-                                OUTPUT_VARIABLE BREW_OPENSSL_PREFIX
-                                OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-                if((BREW_OPENSSL NOT EQUAL 0) OR (NOT EXISTS "${BREW_OPENSSL_PREFIX}"))
-                        message(FATAL_ERROR "OpenSSL (or LibreSSL) is required for building Netdata, but could not be found.")
-                endif()
-
-                set(OPENSSL_INCLUDE_DIRS "${BREW_OPENSSL_PREFIX}/include")
-                set(OPENSSL_CFLAGS_OTHER "")
-                set(OPENSSL_LDFLAGS "-L${BREW_OPENSSL_PREFIX}/lib;-lssl;-lcrypto")
-        else()
-            message(FATAL_ERROR "OpenSSL (or LibreSSL) is required for building Netdata, but could not be found.")
-        endif()
-endif()
-
-if(NOT MACOS)
-        pkg_check_modules(CRYPTO libcrypto)
 endif()
 
 #
@@ -1473,9 +1451,7 @@ if(ENABLE_H2O)
 
         target_compile_options(h2o PUBLIC -DH2O_USE_LIBUV=0)
 
-        target_include_directories(h2o BEFORE PRIVATE ${OPENSSL_INCLUDE_DIRS})
-        target_compile_options(h2o PRIVATE ${OPENSSL_CFLAGS_OTHER})
-        target_link_libraries(h2o PRIVATE ${OPENSSL_LIBRARIES})
+        netdata_add_tls_to_target(h2o PRIVATE)
 endif()
 
 #
@@ -1543,20 +1519,12 @@ endif()
 target_link_libraries(libnetdata PUBLIC judy)
 
 netdata_add_jsonc_to_target(libnetdata)
-
 netdata_add_libyaml_to_target(libnetdata)
-
-# zlib
-if(MACOS)
-        find_package(ZLIB REQUIRED)
-        target_include_directories(libnetdata BEFORE PUBLIC ${ZLIB_INCLUDE_DIRS})
-        target_link_libraries(libnetdata PUBLIC ZLIB::ZLIB)
-else()
-        pkg_check_modules(ZLIB REQUIRED zlib)
-        target_include_directories(libnetdata BEFORE PUBLIC ${ZLIB_INCLUDE_DIRS})
-        target_compile_definitions(libnetdata PUBLIC ${ZLIB_CFLAGS_OTHER})
-        target_link_libraries(libnetdata PUBLIC ${ZLIB_LDFLAGS})
-endif()
+netdata_add_zlib_to_target(libnetdata PUBLIC)
+netdata_add_libuuid_to_target(libnetdata PUBLIC)
+netdata_add_libuv_to_target(libnetdata PUBLIC)
+netdata_add_crypto_to_target(libnetdata PUBLIC)
+netdata_add_tls_to_target(libnetdata PUBLIC)
 
 # lz4 - try to find a version that is compatible with streaming compression
 # otherwise pick whichever one we can find to support dbengine but don't set
@@ -1589,33 +1557,6 @@ if(LIBBROTLI_FOUND)
         target_compile_definitions(libnetdata PUBLIC ${LIBBROTLI_CFLAGS_OTHER})
         target_link_libraries(libnetdata PUBLIC ${LIBBROTLI_LDFLAGS})
 endif()
-
-# uuid
-if(MACOS)
-        # UUID functionality is part of the system libraries here, so no extra
-        # stuff needed.
-else()
-        pkg_check_modules(UUID REQUIRED uuid)
-        target_include_directories(libnetdata BEFORE PUBLIC ${UUID_INCLUDE_DIRS})
-        target_compile_definitions(libnetdata PUBLIC ${UUID_CFLAGS_OTHER})
-        target_link_libraries(libnetdata PUBLIC ${UUID_LDFLAGS})
-endif()
-
-# uv
-pkg_check_modules(LIBUV REQUIRED libuv)
-target_include_directories(libnetdata BEFORE PUBLIC ${LIBUV_INCLUDE_DIRS})
-target_compile_definitions(libnetdata PUBLIC ${LIBUV_CFLAGS_OTHER})
-target_link_libraries(libnetdata PUBLIC ${LIBUV_LDFLAGS})
-
-# crypto
-target_include_directories(libnetdata BEFORE PUBLIC ${CRYPTO_INCLUDE_DIRS})
-target_compile_options(libnetdata PUBLIC ${CRYPTO_CFLAGS_OTHER})
-target_link_libraries(libnetdata PUBLIC ${CRYPTO_LDFLAGS})
-
-# openssl
-target_include_directories(libnetdata BEFORE PUBLIC ${OPENSSL_INCLUDE_DIRS})
-target_compile_options(libnetdata PUBLIC ${OPENSSL_CFLAGS_OTHER})
-target_link_libraries(libnetdata PUBLIC ${OPENSSL_LDFLAGS})
 
 # mnl
 if(NOT MACOS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,7 @@ include(NetdataRequiredDeps)
 include(NetdataTLS)
 include(NetdataJSONC)
 include(NetdataYAML)
+include(NetdataCompression)
 
 if(ENABLE_LEGACY_EBPF_PROGRAMS)
         include(NetdataEBPFLegacy)
@@ -311,6 +312,7 @@ endif()
 # Checks from custom modules
 #
 
+# Required dependencies
 netdata_detect_zlib()
 netdata_detect_libuuid()
 netdata_detect_libuv()
@@ -321,6 +323,11 @@ netdata_detect_libyaml()
 if(ENABLE_LEGACY_EBPF_PROGRAMS)
         netdata_fetch_legacy_ebpf_code()
 endif()
+
+# Optional dependencies
+netdata_detect_lz4()
+netdata_detect_zstd()
+netdata_detect_brotli()
 
 if(ENABLE_SENTRY)
         netdata_bundle_sentry()
@@ -1525,38 +1532,9 @@ netdata_add_libuuid_to_target(libnetdata PUBLIC)
 netdata_add_libuv_to_target(libnetdata PUBLIC)
 netdata_add_crypto_to_target(libnetdata PUBLIC)
 netdata_add_tls_to_target(libnetdata PUBLIC)
-
-# lz4 - try to find a version that is compatible with streaming compression
-# otherwise pick whichever one we can find to support dbengine but don't set
-# ENABLE_LZ4.
-pkg_check_modules(LIBLZ4 liblz4>=1.9.0)
-if(LIBLZ4_FOUND)
-        set(ENABLE_LZ4 On)
-else()
-        pkg_check_modules(LIBLZ4 REQUIRED liblz4)
-endif()
-
-target_include_directories(libnetdata BEFORE PUBLIC ${LIBLZ4_INCLUDE_DIRS})
-target_compile_definitions(libnetdata PUBLIC ${LIBLZ4_CFLAGS_OTHER})
-target_link_libraries(libnetdata PUBLIC ${LIBLZ4_LDFLAGS})
-
-# zstd
-pkg_check_modules(LIBZSTD libzstd)
-if(LIBZSTD_FOUND)
-        set(ENABLE_ZSTD On)
-        target_include_directories(libnetdata BEFORE PUBLIC ${LIBZSTD_INCLUDE_DIRS})
-        target_compile_definitions(libnetdata PUBLIC ${LIBZSTD_CFLAGS_OTHER})
-        target_link_libraries(libnetdata PUBLIC ${LIBZSTD_LDFLAGS})
-endif()
-
-# brotli
-pkg_check_modules(LIBBROTLI libbrotlidec libbrotlienc libbrotlicommon)
-if(LIBBROTLI_FOUND)
-        set(ENABLE_BROTLI On)
-        target_include_directories(libnetdata PUBLIC ${LIBBROTLI_INCLUDE_DIRS})
-        target_compile_definitions(libnetdata PUBLIC ${LIBBROTLI_CFLAGS_OTHER})
-        target_link_libraries(libnetdata PUBLIC ${LIBBROTLI_LDFLAGS})
-endif()
+netdata_add_lz4_to_target(libnetdata PUBLIC)
+netdata_add_zstd_to_target(libnetdata PUBLIC)
+netdata_add_brotli_to_target(libnetdata PUBLIC)
 
 # mnl
 if(NOT MACOS)

--- a/packaging/cmake/Modules/NetdataCompression.cmake
+++ b/packaging/cmake/Modules/NetdataCompression.cmake
@@ -1,0 +1,62 @@
+# Handling for compression libraries
+#
+# Copyright (c) 2024 Netdata Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+include(NetdataUtil)
+
+# Look for a usable copy of LZ4
+#
+# Special handling is required here because the dbengine requires LZ4,
+# but we want a specific minimum version if possible.
+macro(netdata_detect_lz4)
+    pkg_check_modules(LZ4 liblz4>=1.9.0)
+    if(LZ4_FOUND)
+        set(ENABLE_LZ4 True)
+    elseif(ENABLE_DBENGINE)
+        pkg_check_modules(LZ4 REQUIRED liblz4)
+    endif()
+
+    if(LZ4_FOUND)
+        set(NETDATA_LINK_LZ4 True)
+    endif()
+endmacro()
+
+# Add lz4 to a target with the given scope
+function(netdata_add_lz4_to_target _target _scope)
+    if(NETDATA_LINK_LZ4)
+        netdata_add_lib_to_target(${_target} ${_scope} LZ4)
+    endif()
+endfunction()
+
+# Look for a usable copy of zstd
+macro(netdata_detect_zstd)
+    pkg_check_modules(ZSTD libzstd)
+
+    if(ZSTD_FOUND)
+        set(ENABLE_ZSTD True)
+    endif()
+endmacro()
+
+# Add zstd to a target with the given scope
+function(netdata_add_zstd_to_target _target _scope)
+    if(ENABLE_ZSTD)
+        netdata_add_lib_to_target(${_target} ${_scope} ZSTD)
+    endif()
+endfunction()
+
+# Look for a usable copy of brotli
+macro(netdata_detect_brotli)
+    pkg_check_modules(BROTLI libbrotlidec libbrotlienc libbrotlicommon)
+
+    if(BROTLI_FOUND)
+        set(ENABLE_BROTLI True)
+    endif()
+endmacro()
+
+# Add brotli to a target with the given scope
+function(netdata_add_brotli_to_target _target _scope)
+    if(ENABLE_BROTLI)
+        netdata_add_lib_to_target(${_target} ${_scope} BROTLI)
+    endif()
+endfunction()

--- a/packaging/cmake/Modules/NetdataJSONC.cmake
+++ b/packaging/cmake/Modules/NetdataJSONC.cmake
@@ -3,6 +3,8 @@
 # Copyright (c) 2024 Netdata Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+include(NetdataUtil)
+
 # Handle bundling of json-c.
 #
 # This pulls it in as a sub-project using FetchContent functionality.
@@ -63,13 +65,8 @@ macro(netdata_detect_jsonc)
 
         if(NOT JSONC_FOUND)
                 netdata_bundle_jsonc()
-                set(NETDATA_JSONC_LDFLAGS json-c)
-                set(NETDATA_JSONC_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/include)
-                get_target_property(NETDATA_JSONC_CFLAGS_OTHER json-c INTERFACE_COMPILE_DEFINITIONS)
-
-                if(NETDATA_JSONC_CFLAGS_OTHER STREQUAL NETDATA_JSONC_CFLAGS_OTHER-NOTFOUND)
-                        set(NETDATA_JSONC_CFLAGS_OTHER "")
-                endif()
+                set(JSONC_LIBRARIES json-c)
+                set(JSONC_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/include)
 
                 add_custom_command(
                         OUTPUT ${PROJECT_BINARY_DIR}/include/json-c
@@ -83,9 +80,6 @@ macro(netdata_detect_jsonc)
                         DEPENDS ${PROJECT_BINARY_DIR}/include/json-c
                 )
         else()
-                set(NETDATA_JSONC_LDFLAGS ${JSONC_LDFLAGS})
-                set(NETDATA_JSONC_CFLAGS_OTHER ${JSONC_CFLAGS_OTHER})
-                set(NETDATA_JSONC_INCLUDE_DIRS ${JSONC_INCLUDE_DIRS})
                 add_custom_target(json-c-compat-link)
         endif()
 endmacro()
@@ -94,9 +88,7 @@ endmacro()
 #
 # The specified target must already exist, and the netdata_detect_json-c
 # macro must have already been run at least once for this to work correctly.
-function(netdata_add_jsonc_to_target _target)
-        target_include_directories(${_target} PUBLIC ${NETDATA_JSONC_INCLUDE_DIRS})
-        target_compile_definitions(${_target} PUBLIC ${NETDATA_JSONC_CFLAGS_OTHER})
-        target_link_libraries(${_target} PUBLIC ${NETDATA_JSONC_LDFLAGS})
+function(netdata_add_jsonc_to_target _target _scope)
+        netdata_add_lib_to_target(${_target} ${_scope} JSONC)
         add_dependencies(${_target} json-c-compat-link)
 endfunction()

--- a/packaging/cmake/Modules/NetdataLibBPF.cmake
+++ b/packaging/cmake/Modules/NetdataLibBPF.cmake
@@ -86,9 +86,9 @@ function(netdata_bundle_libbpf)
 endfunction()
 
 # Add libbpf as a link dependency for the given target.
-function(netdata_add_libbpf_to_target _target)
-    target_link_libraries(${_target} PUBLIC libbpf_library)
-    target_include_directories(${_target} BEFORE PUBLIC "${NETDATA_LIBBPF_INCLUDE_DIRECTORIES}")
-    target_compile_definitions(${_target} PUBLIC "${NETDATA_LIBBPF_COMPILE_DEFINITIONS}")
+function(netdata_add_libbpf_to_target _target _scope)
+    target_link_libraries(${_target} ${_scope} libbpf_library)
+    target_include_directories(${_target} BEFORE ${_scope} "${NETDATA_LIBBPF_INCLUDE_DIRECTORIES}")
+    target_compile_definitions(${_target} ${_scope} "${NETDATA_LIBBPF_COMPILE_DEFINITIONS}")
     add_dependencies(${_target} libbpf)
 endfunction()

--- a/packaging/cmake/Modules/NetdataProtobuf.cmake
+++ b/packaging/cmake/Modules/NetdataProtobuf.cmake
@@ -3,6 +3,8 @@
 # Copyright (c) 2024 Netdata Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+include(NetdataUtil)
+
 macro(netdata_protobuf_21_tags)
         set(PROTOBUF_TAG f0dc78d7e6e331b8c6bb2d5283e06aa26883ca7c) # v21.12
         set(NEED_ABSL False)
@@ -146,27 +148,8 @@ macro(netdata_detect_protobuf)
                         message(FATAL_ERROR "Could not determine the location of the protobuf compiler for the detected version of protobuf.")
                 endif()
 
-                set(NETDATA_PROTOBUF_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
-                set(NETDATA_PROTOBUF_LIBS protobuf::libprotobuf)
-                get_target_property(NETDATA_PROTOBUF_CFLAGS_OTHER
-                                    protobuf::libprotobuf
-                                    INTERFACE_COMPILE_DEFINITIONS)
-                get_target_property(NETDATA_PROTOBUF_INCLUDE_DIRS
-                                    protobuf::libprotobuf
-                                    INTERFACE_INCLUDE_DIRECTORIES)
-
-                if(NETDATA_PROTOBUF_CFLAGS_OTHER STREQUAL NETDATA_PROTOBUF_CFLAGS_OTHER-NOTFOUND)
-                        set(NETDATA_PROTOBUF_CFLAGS_OTHER "")
-                endif()
-
-                if(NETDATA_PROTOBUF_INCLUDE_DIRS STREQUAL NETDATA_PROTOBUF_INCLUDE_DIRS-NOTFOUND)
-                        set(NETDATA_PROTOBUF_INCLUDE_DIRS "")
-                endif()
-        else()
-                set(NETDATA_PROTOBUF_PROTOC_EXECUTABLE ${PROTOBUF_PROTOC_EXECUTABLE})
-                set(NETDATA_PROTOBUF_CFLAGS_OTHER ${PROTOBUF_CFLAGS_OTHER})
-                set(NETDATA_PROTOBUF_INCLUDE_DIRS ${PROTOBUF_INCLUDE_DIRS})
-                set(NETDATA_PROTOBUF_LIBS ${PROTOBUF_LIBRARIES})
+                set(PROTOBUF_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
+                set(PROTOBUF_LIBRARIES protobuf::libprotobuf)
         endif()
 
         set(ENABLE_PROTOBUF True)
@@ -203,9 +186,9 @@ function(netdata_protoc_generate_cpp INC_DIR OUT_DIR SRCS HDRS)
                 endif()
 
                 add_custom_command(OUTPUT ${GENERATED_PB_CC} ${GENERATED_PB_H}
-                                   COMMAND ${NETDATA_PROTOBUF_PROTOC_EXECUTABLE}
+                                   COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
                                    ARGS "-I$<JOIN:${_PROTOC_INCLUDE_DIRS},;-I>" --cpp_out=${OUT_DIR} ${ABS_FIL}
-                                   DEPENDS ${ABS_FIL} ${NETDATA_PROTOBUF_PROTOC_EXECUTABLE}
+                                   DEPENDS ${ABS_FIL} ${PROTOBUF_PROTOC_EXECUTABLE}
                                    COMMENT "Running C++ protocol buffer compiler on ${FIL}"
                                    COMMAND_EXPAND_LISTS)
         endforeach()
@@ -218,8 +201,6 @@ function(netdata_protoc_generate_cpp INC_DIR OUT_DIR SRCS HDRS)
 endfunction()
 
 # Add protobuf to a specified target.
-function(netdata_add_protobuf _target)
-        target_compile_definitions(${_target} PRIVATE ${NETDATA_PROTOBUF_CFLAGS_OTHER})
-        target_include_directories(${_target} PRIVATE ${NETDATA_PROTOBUF_INCLUDE_DIRS})
-        target_link_libraries(${_target} PRIVATE ${NETDATA_PROTOBUF_LIBS})
+function(netdata_add_protobuf_to_target _target _scope)
+        netdata_add_lib_to_target(${_target} ${_scope} PROTOBUF)
 endfunction()

--- a/packaging/cmake/Modules/NetdataRequiredDeps.cmake
+++ b/packaging/cmake/Modules/NetdataRequiredDeps.cmake
@@ -1,0 +1,45 @@
+# Handling for mandatory dependencies.
+#
+# Copyright (c) 2024 Netdata Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+include(NetdataUtil)
+
+# Locate a usable copy of zlib
+macro(netdata_detect_zlib)
+    if(MACOS)
+        find_package(ZLIB REQUIRED)
+        set(ZLIB_LIBRARIES "ZLIB::ZLIB")
+    else()
+        pkg_check_modules(ZLIB REQUIRED zlib)
+    endif()
+endmacro()
+
+# Add zlib to a target with the given scope
+function(netdata_add_zlib_to_target _target _scope)
+    netdata_add_lib_to_target(${_target} ${_scope} ZLIB)
+endfunction()
+
+# Locate a usable copy of libuuid
+#
+# macOS includes the required functionality in the system libraries, so skip this there.
+macro(netdata_detect_libuuid)
+    if(NOT MACOS)
+        pkg_check_modules(UUID REQUIRED uuid)
+    endif()
+endmacro()
+
+# Add libuuid to a target with the given scope
+function(netdata_add_libuuid_to_target _target _scope)
+    netdata_add_lib_to_target(${_target} ${_scope} UUID)
+endfunction()
+
+# Locate a usable copy of libuv
+macro(netdata_detect_libuv)
+    pkg_check_modules(LIBUV REQUIRED libuv)
+endmacro()
+
+# Add libuv to a target with the given scope
+function(netdata_add_libuv_to_target _target _scope)
+    netdata_add_lib_to_target(${_target} ${_scope} LIBUV)
+endfunction()

--- a/packaging/cmake/Modules/NetdataTLS.cmake
+++ b/packaging/cmake/Modules/NetdataTLS.cmake
@@ -1,0 +1,47 @@
+# Handling for TLS implementation and libcrypto
+#
+# Copyright (c) 2024 Netdata Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+include(NetdataUtil)
+
+set(ENABLE_OPENSSL True)
+
+# Locate a usable TLS implementation and libcrypto equivalent
+macro(netdata_detect_tls_and_crypto)
+    pkg_check_modules(TLS openssl)
+    pkg_check_modules(CRYPTO libcrypto)
+
+    if(NOT TLS_FOUND)
+        if(MACOS)
+            execute_process(COMMAND
+                            brew --prefix --installed openssl
+                            RESULT_VARIABLE BREW_OPENSSL
+                            OUTPUT_VARIABLE BREW_OPENSSL_PREFIX
+                            OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+            if((BREW_OPENSSL NOT EQUAL 0) OR (NOT EXISTS "${BREW_OPENSSL_PREFIX}"))
+                message(FATAL_ERROR "OpenSSL (or LibreSSL) is required for building Netdata, but could not be found.")
+            endif()
+
+            set(TLS_INCLUDE_DIRS "${BREW_OPENSSL_PREFIX}/include")
+            set(TLS_LIBRARIES "ssl;crypto")
+            set(TLS_LIBRARY_DIRS "${BREW_OPENSSL_PREFIX}/lib")
+            set(CRYPTO_INCLUDE_DIRS "${TLS_INCLUDE_DIRS}")
+            set(CRYPTO_LIBRARIES "crypto")
+            set(CRYPTO_LIBRARY_DIRS "${TLS_LIBRARY_DIRS}")
+        else()
+            message(FATAL_ERROR "OpenSSL (or LibreSSL) is required for building Netdata, but could not be found.")
+        endif()
+    endif()
+endmacro()
+
+# Add TLS implementation to a target with the given scope
+function(netdata_add_tls_to_target _target _scope)
+    netdata_add_lib_to_target(${_target} ${_scope} TLS)
+endfunction()
+
+# Add libcrypto to a target with the given scope
+function(netdata_add_crypto_to_target _target _scope)
+    netdata_add_lib_to_target(${_target} ${_scope} CRYPTO)
+endfunction()

--- a/packaging/cmake/Modules/NetdataUtil.cmake
+++ b/packaging/cmake/Modules/NetdataUtil.cmake
@@ -68,3 +68,30 @@ function(netdata_identify_libc _libc_name)
         set(${_libc_name} ${_ND_DETECTED_LIBC} PARENT_SCOPE)
     endif()
 endfunction()
+
+# Handle adding a library to a target with the given scope.
+#
+# Expects the target name, scope, and variable prefix in that order.
+function(netdata_add_lib_to_target _target _scope _prefix)
+    target_link_libraries(${_target} ${_scope} ${${_prefix}_LIBRARIES})
+
+    if(DEFINED ${_prefix}_LINK_DIRS)
+        target_link_directories(${_target} ${_scope} ${${_prefix}_LINK_DIRS})
+    endif()
+
+    if(DEFINED ${_prefix}_LDFLAGS_OTHER)
+        target_link_options(${_target} ${_scope} ${${_prefix}_LDFLAGS_OTHER})
+    endif()
+
+    if(DEFINED ${_prefix}_INCLUDE_DIRS)
+        target_include_directories(${_target} BEFORE ${_scope} ${${_prefix}_INCLUDE_DIRS})
+    endif()
+
+    if(DEFINED ${_prefix}_CFLAGS_OTHER)
+        target_compile_options(${_target} ${_scope} ${${_prefix}_CFLAGS_OTHER})
+    endif()
+
+    if(DEFINED ${_prefix}_DEFINITIONS)
+        target_compile_definitions(${_target} ${_scope} ${${_prefix}_DEFINITIONS})
+    endif()
+endfunction()

--- a/packaging/cmake/Modules/NetdataYAML.cmake
+++ b/packaging/cmake/Modules/NetdataYAML.cmake
@@ -3,6 +3,8 @@
 # Copyright (c) 2024 Netdata Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+include(NetdataUtil)
+
 # Handle bundling of libyaml.
 #
 # This pulls it in as a sub-project using FetchContent functionality.
@@ -44,13 +46,7 @@ macro(netdata_detect_libyaml)
 
         if(ENABLE_BUNDLED_LIBYAML OR NOT YAML_FOUND)
                 netdata_bundle_libyaml()
-                set(NETDATA_YAML_LDFLAGS yaml)
-                get_target_property(NETDATA_YAML_INCLUDE_DIRS yaml INTERFACE_INCLUDE_DIRECTORIES)
-                get_target_property(NETDATA_YAML_CFLAGS_OTHER yaml INTERFACE_COMPILE_DEFINITIONS)
-        else()
-                set(NETDATA_YAML_LDFLAGS ${YAML_LDFLAGS})
-                set(NETDATA_YAML_CFLAGS_OTHER ${YAML_CFLAGS_OTHER})
-                set(NETDATA_YAML_INCLUDE_DIRS ${YAML_INCLUDE_DIRS})
+                set(YAML_LIBRARIES yaml)
         endif()
 endmacro()
 
@@ -58,8 +54,6 @@ endmacro()
 #
 # The specified target must already exist, and the netdata_detect_libyaml
 # macro must have already been run at least once for this to work correctly.
-function(netdata_add_libyaml_to_target _target)
-        target_include_directories(${_target} PUBLIC ${NETDATA_YAML_INCLUDE_DIRS})
-        target_compile_definitions(${_target} PUBLIC ${NETDATA_YAML_CFLAGS_OTHER})
-        target_link_libraries(${_target} PUBLIC ${NETDATA_YAML_LDFLAGS})
+function(netdata_add_libyaml_to_target _target _scope)
+        netdata_add_lib_to_target(${_target} ${_scope} YAML)
 endfunction()


### PR DESCRIPTION
##### Summary

First pass at cleaning up dependency handling in CMake:

- Move handling of truly mandatory dependencies to it’s own module.
- Move handling of TLS implementation to it’s own module.
- Move handling of optional compression libraries to their own module.
- For all above listed dependencies, reorder them to be checked early, with mandatory dependencies being checked first.
- For all above listed dependencies, shift to using the correct `target_link_*`, `target_compile_*`, and target_include_*` options for each part of the process of adding them to a target.
- Perform the same correctness fix mentioned above for most of the dependencies that are already modularized.

##### Test Plan

CI passes on this PR

##### Additional Information

There will likely be further PRs opened with similar changes in the future, but this one has intentionally been kept relatively small to simplify review.