### PR TITLE
Revert changes to ENABLE_CLOUD option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,8 +104,7 @@ mark_as_advanced(DEFAULT_FEATURE_STATE)
 
 # High-level features
 option(ENABLE_ACLK "Enable Netdata Cloud support (ACLK)" ${DEFAULT_FEATURE_STATE})
-cmake_dependent_option(ENABLE_CLOUD "Enable Netdata Cloud by default at runtime" True "NOT ENABLE_ACLK" False)
-mark_as_advanced(ENABLE_CLOUD)
+option(ENABLE_CLOUD "Enable Netdata Cloud by default at runtime" ${DEFAULT_FEATURE_STATE})
 option(ENABLE_ML "Enable machine learning features" ${DEFAULT_FEATURE_STATE})
 option(ENABLE_DBENGINE "Enable dbengine metrics storage" True)
 


### PR DESCRIPTION
##### Summary

 #17442 broke option handling for cloud claiming in the build system. Revert the specific part that broke this so that it works again.


Fixes: #17526

##### Test Plan

Local testing.