### PR TITLE
Remove pointless `ENABLE_ACLK`/`ENABLE_CLOUD` split.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,8 +192,7 @@ option(DEFAULT_FEATURE_STATE "Specify the default state for most optional featur
 mark_as_advanced(DEFAULT_FEATURE_STATE)
 
 # High-level features
-option(ENABLE_ACLK "Enable Netdata Cloud support (ACLK)" ${DEFAULT_FEATURE_STATE})
-option(ENABLE_CLOUD "Enable Netdata Cloud by default at runtime" ${DEFAULT_FEATURE_STATE})
+option(ENABLE_CLOUD "Enable Netdata Cloud support (ACLK)" ${DEFAULT_FEATURE_STATE})
 option(ENABLE_ML "Enable machine learning features" ${DEFAULT_FEATURE_STATE})
 option(ENABLE_DBENGINE "Enable dbengine metrics storage" True)
 
@@ -248,7 +247,7 @@ mark_as_advanced(BUILD_FOR_PACKAGING)
 cmake_dependent_option(FORCE_LEGACY_LIBBPF "Force usage of libbpf 0.0.9 instead of the latest version." False "ENABLE_PLUGIN_EBPF" False)
 mark_as_advanced(FORCE_LEGACY_LIBBPF)
 
-if(ENABLE_ACLK OR ENABLE_EXPORTER_PROMETHEUS_REMOTE_WRITE)
+if(ENABLE_CLOUD OR ENABLE_EXPORTER_PROMETHEUS_REMOTE_WRITE)
         set(NEED_PROTOBUF True)
 else()
         set(NEED_PROTOBUF False)
@@ -296,6 +295,8 @@ if(ENABLE_PLUGIN_EBPF)
         netdata_bundle_libbpf()
         netdata_fetch_ebpf_co_re()
 endif()
+
+set(ENABLE_ACLK ${ENABLE_CLOUD})
 
 #
 # Libm
@@ -1746,7 +1747,7 @@ endif()
 #
 # mqtt library
 #
-if (ENABLE_H2O OR ENABLE_ACLK)
+if (ENABLE_H2O OR ENABLE_CLOUD)
         set(ENABLE_MQTTWEBSOCKETS True)
 endif()
 
@@ -1770,7 +1771,7 @@ if(ENABLE_MQTTWEBSOCKETS)
 
 endif()
 
-if(ENABLE_ACLK)
+if(ENABLE_CLOUD)
         #
         # proto definitions
         #
@@ -2276,7 +2277,7 @@ endif()
 
 add_executable(netdata
         ${NETDATA_FILES}
-        "$<$<BOOL:${ENABLE_ACLK}>:${ACLK_FILES}>"
+        "$<$<BOOL:${ENABLE_CLOUD}>:${ACLK_FILES}>"
         "$<$<BOOL:${ENABLE_H2O}>:${H2O_FILES}>"
         "$<$<BOOL:${ENABLE_EXPORTER_MONGODB}>:${MONGODB_EXPORTING_FILES}>"
         "$<$<BOOL:${ENABLE_EXPORTER_PROMETHEUS_REMOTE_WRITE}>:${PROMETHEUS_REMOTE_WRITE_EXPORTING_FILES}>"
@@ -2292,7 +2293,7 @@ target_compile_options(netdata PRIVATE
 )
 
 target_include_directories(netdata PRIVATE
-        "$<$<BOOL:${ENABLE_ACLK}>:${CMAKE_SOURCE_DIR}/src/aclk/aclk-schemas>"
+        "$<$<BOOL:${ENABLE_CLOUD}>:${CMAKE_SOURCE_DIR}/src/aclk/aclk-schemas>"
         "$<$<BOOL:${ENABLE_EXPORTER_MONGODB}>:${MONGOC_INCLUDE_DIRS}>"
         "$<$<BOOL:${ENABLE_EXPORTER_PROMETHEUS_REMOTE_WRITE}>:${SNAPPY_INCLUDE_DIRS}>"
 )
@@ -2466,12 +2467,6 @@ set(netdata_user_POST "${NETDATA_USER}")
 
 # netdata-claim.sh
 if(ENABLE_CLOUD)
-        set(enable_cloud_POST "yes")
-else()
-        set(enable_cloud_POST "no")
-endif()
-
-if(ENABLE_ACLK)
         set(enable_aclk_POST "yes")
 else()
         set(enable_aclk_POST "no")

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -372,7 +372,6 @@ happened, on your systems and applications.
 	%else
 	-DENABLE_EXPORTER_MONGODB=Off \
 	%endif
-	-DENABLE_ACLK=On \
 	-DENABLE_CLOUD=On \
 	-DENABLE_DBENGINE=On \
 	-DENABLE_H2O=On \

--- a/packaging/build-package.sh
+++ b/packaging/build-package.sh
@@ -26,7 +26,6 @@ add_cmake_option() {
 
 add_cmake_option CMAKE_BUILD_TYPE RelWithDebInfo
 add_cmake_option CMAKE_INSTALL_PREFIX /
-add_cmake_option ENABLE_ACLK On
 add_cmake_option ENABLE_CLOUD On
 add_cmake_option ENABLE_DBENGINE On
 add_cmake_option ENABLE_H2O On

--- a/packaging/cmake/config.cmake.h.in
+++ b/packaging/cmake/config.cmake.h.in
@@ -105,7 +105,6 @@
 // enabled features
 
 #cmakedefine ENABLE_OPENSSL
-#cmakedefine ENABLE_CLOUD
 #cmakedefine ENABLE_ACLK
 #cmakedefine ENABLE_ML
 #cmakedefine ENABLE_EXPORTING_MONGODB

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -343,7 +343,6 @@ prepare_cmake_options() {
   enable_feature PLUGIN_LOGS_MANAGEMENT "${ENABLE_LOGS_MANAGEMENT:-0}"
   enable_feature LOGS_MANAGEMENT_TESTS "${ENABLE_LOGS_MANAGEMENT_TESTS:-0}"
 
-  enable_feature ACLK "${ENABLE_CLOUD:-1}"
   enable_feature CLOUD "${ENABLE_CLOUD:-1}"
   enable_feature BUNDLED_JSONC "${NETDATA_BUILD_JSON_C:-0}"
   enable_feature DBENGINE "${ENABLE_DBENGINE:-1}"

--- a/src/claim/netdata-claim.sh.in
+++ b/src/claim/netdata-claim.sh.in
@@ -118,13 +118,8 @@ if ! command -v openssl >/dev/null 2>&1 ; then
 fi
 
 # shellcheck disable=SC2050
-if [ "@enable_cloud_POST@" = "no" ]; then
-    echo >&2 "This agent was built with --disable-cloud and cannot be claimed"
-    exit 3
-fi
-# shellcheck disable=SC2050
 if [ "@enable_aclk_POST@" != "yes" ]; then
-    echo >&2 "This agent was built without the dependencies for Cloud and cannot be claimed"
+    echo >&2 "This agent was built without Netdata Cloud support and cannot be claimed"
     exit 3
 fi
 


### PR DESCRIPTION
##### Summary

The distinction is a holdover from years ago when we had multiple versions of the agent-cloud link in our code. These days, everything in the code cares only about `ENABLE_ACLK`, and `ENABLE_CLOUD` is just used in the claiming script.

This PR:

- Removes the `ENABLE_CLOUD` check in the claiming script so that it looks at only the things that the agent code looks at to determine cloud support.
- Removes the current `ENABLE_CLOUD` option and define as it now does nothing.
- Renames the existing `ENABLE_ACLK` CMake option to `ENABLE_CLOUD`, because that is properly descriptive of what the option actually does.

##### Test Plan

Local testing is required for this PR.