### PR TITLE
Don’t unnescesarily clean repo during static builds.

### DIFF
--- a/packaging/makeself/build.sh
+++ b/packaging/makeself/build.sh
@@ -33,9 +33,6 @@ chown -R root:root /usr/src/netdata
 
 cd /usr/src/netdata/packaging/makeself || exit 1
 
-git clean -dxf
-git submodule foreach --recursive git clean -dxf
-
 cat >&2 << EOF
 This program will create a self-extracting shell package containing
 a statically linked netdata, able to run on any 64bit Linux system,


### PR DESCRIPTION
##### Summary

We’re using a separate build directory in all cases, so there is no longer any need to try to clean the repository before a static build. This enables running static builds in linked git worktrees.

##### Test Plan

Without this change, trying to run a static build in a linked git worktree will fail very early on with a complaint about something not being a git directory.

With this change, this failure will not happen.