### PR TITLE
Fix handling of OpenSSL linking on macOS

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -105,7 +105,7 @@ jobs:
         id: install-nd-dep
         if: needs.file-check.outputs.run == 'true'
         run: |
-          bash ./packaging/installer/install-required-packages.sh --dont-wait --non-interactive netdata
+          bash ./packaging/installer/install-required-packages.sh --dont-wait --non-interactive netdata-all
       - name: Build from source
         id: build-source
         if: needs.file-check.outputs.run == 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -570,7 +570,7 @@ if(NOT OPENSSL_FOUND)
 endif()
 
 if(NOT MACOS)
-        pkg_check_modules(CRYPTO libcrypto)
+        pkg_check_modules(CRYPTO IMPORTED_TARGET libcrypto)
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -589,11 +589,10 @@ if(NOT TARGET PkgConfig::TLS)
         else()
             message(FATAL_ERROR "OpenSSL (or LibreSSL) is required for building Netdata, but could not be found.")
         endif()
+else()
+        pkg_check_modules(CRYPTO IMPORTED_TARGET REQUIRED libcrypto)
 endif()
 
-if(NOT MACOS)
-        pkg_check_modules(CRYPTO IMPORTED_TARGET libcrypto)
-endif()
 
 #
 # figure out if we need protoc/protobuf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1598,7 +1598,7 @@ if(ENABLE_H2O)
         )
 
         target_compile_options(h2o PUBLIC -DH2O_USE_LIBUV=0)
-        target_link_libraries(h2o PRIVATE PkgConfig::OPENSSL)
+        target_link_libraries(h2o PRIVATE PkgConfig::TLS)
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,14 +66,20 @@ project(netdata
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/packaging/cmake/Modules")
 include(CMakeDependentOption)
 
-if(NOT BUILD_SHARED_LIBS)
+if(DEFINED BUILD_SHARED_LIBS)
+    if(NOT BUILD_SHARED_LIBS)
+        set(STATIC_BUILD TRUE)
+    endif()
+endif()
+
+if(STATIC_BUILD)
     set(CMAKE_FIND_LIBRARY_PREFIXES "${CMAKE_STATIC_LIBRARY_PREFIX}")
     set(CMAKE_FIND_LIBRARY_SUFFIXES "${CMAKE_STATIC_LIBRARY_SUFFIX}")
 endif()
 
 find_package(PkgConfig REQUIRED)
 
-if(NOT BUILD_SHARED_LIBS)
+if(STATIC_BUILD)
     list(APPEND PKG_CONFIG_EXECUTABLE "--static")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -547,9 +547,9 @@ endif()
 
 # openssl/crypto
 set(ENABLE_OPENSSL True)
-pkg_check_modules(OPENSSL openssl)
+pkg_check_modules(TLS IMPORTED_TARGET openssl)
 
-if(NOT OPENSSL_FOUND)
+if(NOT TARGET PkgConfig::OPENSSL)
         if(MACOS)
                 execute_process(COMMAND
                                 brew --prefix --installed openssl
@@ -561,9 +561,16 @@ if(NOT OPENSSL_FOUND)
                         message(FATAL_ERROR "OpenSSL (or LibreSSL) is required for building Netdata, but could not be found.")
                 endif()
 
-                set(OPENSSL_INCLUDE_DIRS "${BREW_OPENSSL_PREFIX}/include")
-                set(OPENSSL_CFLAGS_OTHER "")
-                set(OPENSSL_LDFLAGS "-L${BREW_OPENSSL_PREFIX}/lib;-lssl;-lcrypto")
+                add_library(PkgConfig::CRYPTO IMPORTED)
+                set_target_properties(PkgConfig::CRYPTO
+                        IMPORTED_LOCATION ${BREW_OPENSSL_PREFIX}/lib/libcrypto.dylib
+                        INTERFACE_INCLUDE_DIRECTORIES ${BREW_OPENSSL_PREFIX}/include)
+
+                add_library(PkgConfig::TLS IMPORTED)
+                set_target_properties(PkgConfig::TLS
+                        IMPORTED_LOCATION ${BREW_OPENSSL_PREFIX}/lib/libssl.dylib
+                        INTERFACE_LINK_LIBRARIES PkgConfig::CRYPTO
+                        INTERFACE_INCLUDE_DIRECTORIES ${BREW_OPENSSL_PREFIX}/include)
         else()
             message(FATAL_ERROR "OpenSSL (or LibreSSL) is required for building Netdata, but could not be found.")
         endif()
@@ -1576,10 +1583,7 @@ if(ENABLE_H2O)
         )
 
         target_compile_options(h2o PUBLIC -DH2O_USE_LIBUV=0)
-
-        target_include_directories(h2o BEFORE PRIVATE ${OPENSSL_INCLUDE_DIRS})
-        target_compile_options(h2o PRIVATE ${OPENSSL_CFLAGS_OTHER})
-        target_link_libraries(h2o PRIVATE ${OPENSSL_LIBRARIES})
+        target_link_libraries(h2o PRIVATE PkgConfig::OPENSSL)
 endif()
 
 #
@@ -1713,14 +1717,10 @@ target_compile_options(libnetdata PUBLIC ${LIBUV_CFLAGS_OTHER})
 target_link_libraries(libnetdata PUBLIC ${LIBUV_LDFLAGS})
 
 # crypto
-target_include_directories(libnetdata BEFORE PUBLIC ${CRYPTO_INCLUDE_DIRS})
-target_compile_options(libnetdata PUBLIC ${CRYPTO_CFLAGS_OTHER})
-target_link_libraries(libnetdata PUBLIC ${CRYPTO_LDFLAGS})
+target_link_libraries(libnetdata PUBLIC PkgConfig::CRYPTO)
 
 # openssl
-target_include_directories(libnetdata BEFORE PUBLIC ${OPENSSL_INCLUDE_DIRS})
-target_compile_options(libnetdata PUBLIC ${OPENSSL_CFLAGS_OTHER})
-target_link_libraries(libnetdata PUBLIC ${OPENSSL_LDFLAGS})
+target_link_libraries(libnetdata PUBLIC PkgConfig::TLS)
 
 # mnl
 if(NOT MACOS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,16 @@ project(netdata
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/packaging/cmake/Modules")
 include(CMakeDependentOption)
 
+if(NOT BUILD_SHARED_LIBS)
+    set(CMAKE_FIND_LIBRARY_PREFIXES "${CMAKE_STATIC_LIBRARY_PREFIX}")
+    set(CMAKE_FIND_LIBRARY_SUFFIXES "${CMAKE_STATIC_LIBRARY_SUFFIX}")
+endif()
+
 find_package(PkgConfig REQUIRED)
+
+if(NOT BUILD_SHARED_LIBS)
+    list(APPEND PKG_CONFIG_EXECUTABLE "--static")
+endif()
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 14)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -564,7 +564,7 @@ endif()
 set(ENABLE_OPENSSL True)
 pkg_check_modules(TLS IMPORTED_TARGET openssl)
 
-if(NOT TARGET PkgConfig::OPENSSL)
+if(NOT TARGET PkgConfig::TLS)
         if(MACOS)
                 execute_process(COMMAND
                                 brew --prefix --installed openssl


### PR DESCRIPTION
##### Summary

- Fix dependency installation in CI.
- Switch to using an imported target for the TLS implementation.
- Keep the TLS related stuff together.
- Use the same name for the WolfSSL and OpenSSL targets, once detected the build system does not care which is being used beyond what the imported target tells it.

##### Test Plan

CI passes on this PR.