### PR TITLE
Remove Fedora 38 from CI.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -204,13 +204,6 @@ include:
       repo_distro: fedora/39
     test:
       ebpf-core: true
-  - <<: *fedora
-    version: "38"
-    packages:
-      <<: *fedora_packages
-      repo_distro: fedora/38
-    test:
-      ebpf-core: true
 
   - &opensuse
     distro: opensuse
@@ -328,6 +321,11 @@ legacy: # Info for platforms we used to support and still need to handle package
     packages:
       <<: *fedora_packages
       repo_distro: fedora/37
+  - <<: *fedora
+    version: "38"
+    packages:
+      <<: *fedora_packages
+      repo_distro: fedora/38
   - <<: *opensuse
     version: "15.4"
     packages:

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -70,7 +70,6 @@ to work on these platforms with minimal user effort.
 | Debian                   | 10.x           | x86\_64, i386, ARMv7, AArch64          |                                                                                                                                                    |
 | Fedora                   | 40             | x86\_64, AArch64                       |                                                                                                                                                    |
 | Fedora                   | 39             | x86\_64, AArch64                       |                                                                                                                                                    |
-| Fedora                   | 38             | x86\_64, AArch64                       |                                                                                                                                                    |
 | openSUSE                 | Leap 15.5      | x86\_64, AArch64                       |                                                                                                                                                    |
 | openSUSE                 | Leap 15.4      | x86\_64, AArch64                       |                                                                                                                                                    |
 | Oracle Linux             | 9.x            | x86\_64, AArch64                       |                                                                                                                                                    |
@@ -159,9 +158,8 @@ This is a list of platforms that we have supported in the recent past but no lon
 | Alpine Linux | 3.14      | EOL as of 2023-05-01 |
 | Alpine Linux | 3.13      | EOL as of 2022-11-01 |
 | Debian       | 9.x       | EOL as of 2022-06-30 |
+| Fedora       | 38        | EOL as of 2024-05-14 |
 | Fedora       | 37        | EOL as of 2023-12-05 |
-| Fedora       | 36        | EOL as of 2023-05-18 |
-| Fedora       | 35        | EOL as of 2022-12-13 |
 | openSUSE     | Leap 15.4 | EOL as of 2023-12-07 |
 | openSUSE     | Leap 15.3 | EOL as of 2022-12-01 |
 | Ubuntu       | 23.04     | EOL as of 2024-01-20 |


### PR DESCRIPTION
##### Summary

EOL upstream as of 2024-05-14.

##### Test Plan

n/a

##### Additional Information

Closes: #17546