### PR TITLE
Fix handling of netdata.conf on install in build system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2523,20 +2523,22 @@ install(FILES
         COMPONENT netdata
         DESTINATION etc/netdata)
 
-install(FILES
-        system/netdata-updater.conf
-        COMPONENT netdata
-        DESTINATION etc/netdata)
-
 install(PROGRAMS
         system/edit-config
         COMPONENT netdata
         DESTINATION etc/netdata)
 
+if(BUILD_FOR_PACKAGING)
+        set(NETDATA_CONF_DEST "etc/netdata")
+else()
+        set(NETDATA_CONF_DEST "usr/lib/netdata/conf.d")
+endif()
+
 install(FILES
         system/netdata.conf
+        system/netdata-updater.conf
         COMPONENT netdata
-        DESTINATION etc/netdata)
+        DESTINATION ${NETDATA_CONF_DEST})
 
 #
 # misc files

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -396,8 +396,8 @@ happened, on your systems and applications.
 rm -rf "${RPM_BUILD_ROOT}"
 %{cmake_install}
 
-install -m 644 -p "${RPM_BUILD_ROOT}%{_libdir}/conf.d/%{name}.conf" "${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}"
-install -m 644 -p "${RPM_BUILD_ROOT}%{_libdir}/conf.d/%{name}-updater.conf" "${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}"
+install -m 644 -p "${RPM_BUILD_ROOT}%{_libdir}/%{name}/conf.d/%{name}.conf" "${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}"
+install -m 644 -p "${RPM_BUILD_ROOT}%{_libdir}/%{name}/conf.d/%{name}-updater.conf" "${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}"
 
 # ###########################################################
 # Install updater script

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -396,7 +396,8 @@ happened, on your systems and applications.
 rm -rf "${RPM_BUILD_ROOT}"
 %{cmake_install}
 
-install -m 644 -p "system/%{name}.conf" "${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}"
+install -m 644 -p "${RPM_BUILD_ROOT}%{_libdir}/conf.d/%{name}.conf" "${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}"
+install -m 644 -p "${RPM_BUILD_ROOT}%{_libdir}/conf.d/%{name}-updater.conf" "${RPM_BUILD_ROOT}%{_sysconfdir}/%{name}"
 
 # ###########################################################
 # Install updater script


### PR DESCRIPTION
##### Summary

Both `netdata.conf` and `netdata-updater.conf` should not be touched in `/etc/netdata` by the build system, but they currently are overwritten with the defaults on each install.

Originally broken by #17475.

Does not affect Docker images or native packages, only static builds and local builds.

##### Test Plan

Local testing is required to confirm that the files are not modified.