### PR TITLE
Patch release 1.45.4

### DIFF
--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -192,13 +192,13 @@ if command -v setcap >/dev/null 2>&1; then
 
     run setcap "cap_dac_read_search+epi cap_net_admin+epi cap_net_raw=eip" "usr/libexec/netdata/plugins.d/go.d.plugin"
 else
-  for x in ndsudo apps.plugin perf.plugin slabinfo.plugin debugfs.plugin; do
+  for x in apps.plugin perf.plugin slabinfo.plugin debugfs.plugin; do
     f="usr/libexec/netdata/plugins.d/${x}"
     run chmod 4750 "${f}"
   done
 fi
 
-for x in freeipmi.plugin ioping cgroup-network local-listeners network-viewer.plugin ebpf.plugin nfacct.plugin xenstat.plugin; do
+for x in ndsudo freeipmi.plugin ioping cgroup-network local-listeners network-viewer.plugin ebpf.plugin nfacct.plugin xenstat.plugin; do
   f="usr/libexec/netdata/plugins.d/${x}"
 
   if [ -f "${f}" ]; then

--- a/src/daemon/commands.h
+++ b/src/daemon/commands.h
@@ -3,7 +3,7 @@
 #ifndef NETDATA_COMMANDS_H
 #define NETDATA_COMMANDS_H 1
 
-#define MAX_COMMAND_LENGTH 4096
+#define MAX_COMMAND_LENGTH (8192)
 #define MAX_EXIT_STATUS_LENGTH 23 /* Can't ever be bigger than "X-18446744073709551616" */
 
 typedef enum cmd {

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -23,6 +23,7 @@ int libuv_worker_threads = MIN_LIBUV_WORKER_THREADS;
 bool ieee754_doubles = false;
 time_t netdata_start_time = 0;
 struct netdata_static_thread *static_threads;
+bool i_am_the_spawn_server = false;
 
 struct config netdata_config = {
         .first_section = NULL,
@@ -303,6 +304,9 @@ static bool service_wait_exit(SERVICE_TYPE service, usec_t timeout_ut) {
 void web_client_cache_destroy(void);
 
 void netdata_cleanup_and_exit(int ret, const char *action, const char *action_result, const char *action_data) {
+    if (i_am_the_spawn_server)
+        exit(ret);
+
     watcher_shutdown_begin();
 
     nd_log_limits_unlimited();
@@ -1420,6 +1424,7 @@ int main(int argc, char **argv) {
 
     if (argc > 1 && strcmp(argv[1], SPAWN_SERVER_COMMAND_LINE_ARGUMENT) == 0) {
         // don't run netdata, this is the spawn server
+        i_am_the_spawn_server = true;
         spawn_server();
         exit(0);
     }

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -795,6 +795,7 @@ int help(int exitcode) {
             "  -W sqlite-meta-recover   Run recovery on the metadata database and exit.\n\n"
             "  -W sqlite-compact        Reclaim metadata database unused space and exit.\n\n"
             "  -W sqlite-analyze        Run update statistics and exit.\n\n"
+            "  -W sqlite-alert-cleanup  Perform maintenance on the alerts table.\n\n"
 #ifdef ENABLE_DBENGINE
             "  -W createdataset=N       Create a DB engine dataset of N seconds and exit.\n\n"
             "  -W stresstest=A,B,C,D,E,F,G\n"
@@ -1512,6 +1513,11 @@ int main(int argc, char **argv) {
 
                         if(strcmp(optarg, "sqlite-analyze") == 0) {
                             sql_init_meta_database(DB_CHECK_ANALYZE, 0);
+                            return 0;
+                        }
+
+                        if(strcmp(optarg, "sqlite-alert-cleanup") == 0) {
+                            sql_alert_cleanup(true);
                             return 0;
                         }
 

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -1531,7 +1531,9 @@ int main(int argc, char **argv) {
 
                             // set defaults for dbegnine unittest
                             config_set(CONFIG_SECTION_DB, "dbengine page type", "gorilla");
+#ifdef ENABLE_DBENGINE
                             default_rrdeng_disk_quota_mb = default_multidb_disk_quota_mb = 256;
+#endif
 
                             if (sqlite_library_init())
                                 return 1;

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -1890,9 +1890,6 @@ int main(int argc, char **argv) {
         load_cloud_conf(0);
     }
 
-    // @stelfrag: Where is the right place to call this?
-    watcher_thread_start();
-
     // ------------------------------------------------------------------------
     // initialize netdata
     {
@@ -2110,6 +2107,8 @@ int main(int argc, char **argv) {
     // fork, switch user, create pid file, set process priority
     if(become_daemon(dont_fork, user) == -1)
         fatal("Cannot daemonize myself.");
+
+    watcher_thread_start();
 
     // init sentry
 #ifdef ENABLE_SENTRY

--- a/src/database/rrd.h
+++ b/src/database/rrd.h
@@ -226,16 +226,16 @@ typedef enum __attribute__ ((__packed__)) rrddim_options {
 // flags are runtime changing status flags (atomics are required to alter/access them)
 typedef enum __attribute__ ((__packed__)) rrddim_flags {
     RRDDIM_FLAG_NONE                            = 0,
-    RRDDIM_FLAG_PENDING_HEALTH_INITIALIZATION   = (1 << 0),
 
-    RRDDIM_FLAG_OBSOLETE                        = (1 << 1),  // this is marked by the collector/module as obsolete
+    RRDDIM_FLAG_OBSOLETE                        = (1 << 0),  // this is marked by the collector/module as obsolete
     // No new values have been collected for this dimension since agent start, or it was marked RRDDIM_FLAG_OBSOLETE at
     // least rrdset_free_obsolete_time seconds ago.
-    RRDDIM_FLAG_ARCHIVED                        = (1 << 2),
-    RRDDIM_FLAG_METADATA_UPDATE                 = (1 << 3),  // Metadata needs to go to the database
 
-    RRDDIM_FLAG_META_HIDDEN                     = (1 << 4),  // Status of hidden option in the metadata database
-    RRDDIM_FLAG_ML_MODEL_LOAD                   = (1 << 5),  // Do ML LOAD for this dimension
+    RRDDIM_FLAG_ARCHIVED                        = (1 << 1),
+    RRDDIM_FLAG_METADATA_UPDATE                 = (1 << 2),  // Metadata needs to go to the database
+
+    RRDDIM_FLAG_META_HIDDEN                     = (1 << 3),  // Status of hidden option in the metadata database
+    RRDDIM_FLAG_ML_MODEL_LOAD                   = (1 << 4),  // Do ML LOAD for this dimension
 
     // this is 8 bit
 } RRDDIM_FLAGS;

--- a/src/database/rrddim.c
+++ b/src/database/rrddim.c
@@ -150,10 +150,6 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
         }
     }
 
-    rrddim_flag_set(rd, RRDDIM_FLAG_PENDING_HEALTH_INITIALIZATION);
-    rrdset_flag_set(rd->rrdset, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
-    rrdhost_flag_set(rd->rrdset->rrdhost, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
-
     // let the chart resync
     rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
 
@@ -259,13 +255,8 @@ static bool rrddim_conflict_callback(const DICTIONARY_ITEM *item __maybe_unused,
                     storage_metric_store_init(rd->tiers[tier].seb, rd->tiers[tier].smh, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->smg[tier]);
     }
 
-    if(rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED)) {
+    if(rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED))
         rrddim_flag_clear(rd, RRDDIM_FLAG_ARCHIVED);
-
-        rrddim_flag_set(rd, RRDDIM_FLAG_PENDING_HEALTH_INITIALIZATION);
-        rrdset_flag_set(rd->rrdset, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
-        rrdhost_flag_set(rd->rrdset->rrdhost, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
-    }
 
     if(unlikely(rc))
         ctr->react_action = RRDDIM_REACT_UPDATED;

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -1144,7 +1144,10 @@ static SIMPLE_PATTERN_RESULT simple_pattern_match_name_only_callback(const char 
 
     // we return -1 to stop the walkthrough on first match
     t->searches++;
-    return simple_pattern_matches_extract(t->pattern, name, NULL, 0);
+    SIMPLE_PATTERN_RESULT ret = simple_pattern_matches_extract(t->pattern, name, NULL, 0);
+    if (ret == SP_MATCHED_NEGATIVE)
+        ret = SP_NOT_MATCHED;
+    return ret;
 }
 
 static SIMPLE_PATTERN_RESULT simple_pattern_match_name_and_value_callback(const char *name, const char *value, RRDLABEL_SRC ls __maybe_unused, void *data) {

--- a/src/database/sqlite/sqlite_context.c
+++ b/src/database/sqlite/sqlite_context.c
@@ -43,6 +43,7 @@ int sql_init_context_database(int memory)
         return 1;
     }
 
+    errno = 0;
     netdata_log_info("SQLite database %s initialization", sqlite_database);
 
     char buf[1024 + 1] = "";

--- a/src/database/sqlite/sqlite_db_migration.c
+++ b/src/database/sqlite/sqlite_db_migration.c
@@ -530,6 +530,7 @@ static int migrate_database(sqlite3 *database, int target_version, char *db_name
     }
 
     if (likely(user_version == target_version)) {
+        errno = 0;
         netdata_log_info("%s database version is %d (no migration needed)", db_name, target_version);
         return target_version;
     }

--- a/src/database/sqlite/sqlite_health.h
+++ b/src/database/sqlite/sqlite_health.h
@@ -36,4 +36,5 @@ int sql_get_alert_configuration(
     bool debug __maybe_unused);
 
 bool sql_find_alert_transition(const char *transition, void (*cb)(const char *machine_guid, const char *context, time_t alert_id, void *data), void *data);
+void sql_alert_cleanup(bool cli);
 #endif //NETDATA_SQLITE_HEALTH_H

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -747,6 +747,7 @@ int sql_init_meta_database(db_check_action_type_t rebuild, int memory)
         return 1;
     }
 
+    errno = 0;
     netdata_log_info("SQLite database %s initialization", sqlite_database);
 
     rc = sqlite3_create_function(db_meta, "u2h", 1, SQLITE_ANY | SQLITE_DETERMINISTIC, 0, sqlite_uuid_parse, 0, 0);

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -1091,7 +1091,7 @@ static int add_host_sysinfo_key_value(const char *name, const char *value, uuid_
 
     int store_rc = sqlite3_step_monitored(res);
     if (unlikely(store_rc != SQLITE_DONE))
-        error_report("Failed to store host info value %s, rc = %d", name, rc);
+        error_report("Failed to store host info value %s, rc = %d", name, store_rc);
 
     rc = sqlite3_reset(res);
     if (unlikely(rc != SQLITE_OK))

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -287,6 +287,7 @@ static void health_event_loop(void) {
                 if (unlikely(rc->rrdset && rc->status != RRDCALC_STATUS_REMOVED &&
                              rrdset_flag_check(rc->rrdset, RRDSET_FLAG_OBSOLETE) &&
                              now > (rc->rrdset->last_collected_time.tv_sec + 60))) {
+
                     if (!rrdcalc_isrepeating(rc)) {
                         worker_is_busy(WORKER_HEALTH_JOB_ALARM_LOG_ENTRY);
                         time_t now_tmp = now_realtime_sec();

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -201,6 +201,7 @@ static void health_event_loop(void) {
                    "Postponing alarm checks for %"PRId32" seconds, "
                    "because it seems that the system was just resumed from suspension.",
                    (int32_t)health_globals.config.postpone_alarms_during_hibernation_for_seconds);
+            schedule_node_info_update(localhost);
         }
 
         if (unlikely(silencers->all_alarms && silencers->stype == STYPE_DISABLE_ALARMS)) {

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -463,6 +463,17 @@ void rrdcalc_delete_all(RRDHOST *host) {
     dictionary_flush(host->rrdcalc_root_index);
 }
 
+void rrdcalc_child_disconnected(RRDHOST *host) {
+    rrdcalc_delete_all(host);
+
+    rrdhost_flag_clear(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
+    RRDSET *st;
+    rrdset_foreach_read(st, host) {
+        rrdset_flag_clear(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
+    }
+    rrdset_foreach_done(st);
+}
+
 void rrd_alert_match_cleanup(struct rrd_alert_match *am) {
     if(am->is_template)
         string_freez(am->on.context);

--- a/src/health/rrdcalc.h
+++ b/src/health/rrdcalc.h
@@ -143,4 +143,6 @@ void rrdcalc_unlink_and_delete(RRDHOST *host, RRDCALC *rc, bool having_ll_wrlock
 #define RRDCALC_VAR_LABEL "${label:"
 #define RRDCALC_VAR_LABEL_LEN (sizeof(RRDCALC_VAR_LABEL)-1)
 
+void rrdcalc_child_disconnected(RRDHOST *host);
+
 #endif //NETDATA_RRDCALC_H

--- a/src/health/schema.d/health:alert:prototype.json
+++ b/src/health/schema.d/health:alert:prototype.json
@@ -274,6 +274,13 @@
             "type": "string",
             "title": "Unit",
             "description": "of measurement"
+          },
+          "update_every": {
+            "type": "integer",
+            "default": 10,
+            "minimum": 1,
+            "title": "Frequency",
+            "description": "of evaluation"
           }
         }
       },
@@ -590,11 +597,15 @@
             },
             "calculation": {
               "ui:help": "The database value is available as '$this'. This expression can utilize variables to transform the value of the alert.",
-              "ui:classNames": "dyncfg-grid-col-span-1-5",
+              "ui:classNames": "dyncfg-grid-col-span-1-4",
               "ui:placeholder": "$this * 1"
             },
             "units": {
               "ui:help": "The unit of measurement the alert value is expressed with. If unset, the units of the instance the alert is attached to will be used.",
+              "ui:classNames": "dyncfg-grid-col-span-5-1"
+            },
+            "update_every": {
+              "ui:help": "The frequency this alarm is to be evaluated, in seconds.",
               "ui:classNames": "dyncfg-grid-col-span-6-1"
             }
           },


### PR DESCRIPTION
##### Summary
- add update every to json schema (#17613)
- reset health when children disconnect (#17612)
- fix ndsudo setuid bit for static builds (#17583)
- fix compilation with `--disable-dbengine` : Add missing ifdef to daemon/main 
- Increase the message size to the spawn server (#17566)
- Report correct error code when data insert fails (#17508)
- Fix labels name-only matching (#17482)
- Reconnect to the cloud when resuming from suspension (#17444)
- Start watcher thread after fork (#17436)
- Add option to cleanup health_log table  (#17385)
- apply first alarms, then alarm templates (#17398)

---

Fixes: #17563
Fixes: #17549