### PR TITLE
Fix compilation without `dbengine`

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -1526,7 +1526,9 @@ int main(int argc, char **argv) {
 
                             // set defaults for dbegnine unittest
                             config_set(CONFIG_SECTION_DB, "dbengine page type", "gorilla");
+#ifdef ENABLE_DBENGINE
                             default_rrdeng_disk_quota_mb = default_multidb_disk_quota_mb = 256;
+#endif
 
                             if (sqlite_library_init())
                                 return 1;

--- a/src/database/rrdhost.c
+++ b/src/database/rrdhost.c
@@ -260,6 +260,7 @@ static void rrdhost_initialize_rrdpush_sender(RRDHOST *host,
         rrdhost_option_clear(host, RRDHOST_OPTION_SENDER_ENABLED);
 }
 
+#ifdef ENABLE_DBENGINE
 //
 //  true on success
 //
@@ -323,6 +324,7 @@ static RRDHOST *prepare_host_for_unittest(RRDHOST *host)
     }
     return host;
 }
+#endif
 
 static RRDHOST *rrdhost_create(
         const char *hostname,


### PR DESCRIPTION
##### Summary
If we try to compile our current master with option `--disable-dbengine`, the compilation does not end due two different errors. 
This PR  addresses these two isseus.

##### Test Plan

1. Compile this PR with `dbengine` enabled. Run `netdata`.
2. Recompile this PR with option `--disable-dbengine`, and `netdata` should finish the compilation normally. When you start, it should use `memory mode = ram`.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
