### PR TITLE
Fixes for CPack based DEB packages.

### DIFF
--- a/packaging/cmake/Modules/Packaging.cmake
+++ b/packaging/cmake/Modules/Packaging.cmake
@@ -96,9 +96,9 @@ if(ENABLE_PLUGIN_EBPF)
         list(APPEND _main_deps "netdata-plugin-ebpf (= ${CPACK_PACKAGE_VERSION})")
 endif()
 
-list(JOIN "${_main_deps}" ", " CPACK_DEBIAN_NETDATA_PACKAGE_DEPENDS)
+list(JOIN _main_deps ", " CPACK_DEBIAN_NETDATA_PACKAGE_DEPENDS)
 
-set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
+set(CPACK_DEBIAN_NETDATA_PACKAGE_CONTROL_EXTRA
 	  "${CMAKE_SOURCE_DIR}/packaging/cmake/control/netdata/conffiles;"
 	  "${CMAKE_SOURCE_DIR}/packaging/cmake/control/netdata/preinst"
 	  "${CMAKE_SOURCE_DIR}/packaging/cmake/control/netdata/postinst"

--- a/packaging/cmake/control/netdata/postinst
+++ b/packaging/cmake/control/netdata/postinst
@@ -28,8 +28,7 @@ case "$1" in
 
     grep /usr/libexec/netdata /var/lib/dpkg/info/netdata.list | xargs -n 30 chown root:netdata
 
-    # TODO: Ask Austin to review this.
-    for f in ndsudo cgroup-network local-listeners ioping.plugin network-viewer.plugin; do
+    for f in ndsudo cgroup-network local-listeners ioping.plugin; do
         chmod 4750 "/usr/libexec/netdata/plugins.d/${f}" || true
     done
 


### PR DESCRIPTION
##### Summary

- Correctly compute the dependency list for the main package.
- Don’t reference files from other packages in package maintainer scripts.

##### Test Plan

Needs to be tested locally.