### PR TITLE
Fix invalid item in postinst script for Netdata package.

### DIFF
--- a/packaging/cmake/control/netdata/postinst
+++ b/packaging/cmake/control/netdata/postinst
@@ -28,8 +28,7 @@ case "$1" in
 
     grep /usr/libexec/netdata /var/lib/dpkg/info/netdata.list | xargs -n 30 chown root:netdata
 
-    # TODO: Ask Austin to review this.
-    for f in ndsudo cgroup-network local-listeners ioping.plugin network-viewer.plugin; do
+    for f in ndsudo cgroup-network local-listeners ioping.plugin; do
         chmod 4750 "/usr/libexec/netdata/plugins.d/${f}" || true
     done
 


### PR DESCRIPTION
##### Summary

We should not be referencing files from other packages in our postinst script.

##### Test Plan

To test, install the generated `netdata` package without installing recommended packages (just regular dependencies). Without this PR, there will be an error logged by chmod about the network-viewer plugin not being found. With this PR, there will be no such error.