### PR TITLE
Fix handling of service startup in DEB packages.

### DIFF
--- a/packaging/cmake/control/netdata/postinst
+++ b/packaging/cmake/control/netdata/postinst
@@ -36,13 +36,18 @@ case "$1" in
 esac
 
 if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
-	deb-systemd-helper unmask 'netdata.service' >/dev/null || true
+    deb-systemd-helper unmask 'netdata.service' >/dev/null || true
 
-	if deb-systemd-helper --quiet was-enabled 'netdata.service'; then
-		deb-systemd-helper enable 'netdata.service' >/dev/null || true
-	else
-		deb-systemd-helper update-state 'netdata.service' >/dev/null || true
-	fi
+    if deb-systemd-helper --quiet was-enabled 'netdata.service'; then
+        deb-systemd-helper enable 'netdata.service' >/dev/null || true
+    else
+        deb-systemd-helper update-state 'netdata.service' >/dev/null || true
+    fi
+
+    if [ -z "${DPKG_ROOT:-}" ] && [ -d /run/systemd/system ]; then
+        systemctl --system daemon-reload >/dev/null || true
+        deb-systemd-invoke restart 'netdata.service' >/dev/null || true
+    fi
 fi
 
 exit 0


### PR DESCRIPTION
##### Summary

It was previously working before the shift to CPack because the old dh_installinit code happened to also work to start systemd services. That part was not copied over though because we don’t really officially support non-systemd Debian/Ubuntu systems, which in turn broke things.

This updates the postinstall script to correctly handle this

##### Test Plan

Build the packages locally, install them, and confirm that the agent is running.

##### Additional Information

Fixes: #17588