### PR TITLE
Remove CentOS Stream 8 from CI.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -135,12 +135,6 @@ include:
         - aarch64
     test:
       ebpf-core: true
-  - <<: *centos_stream
-    version: '8'
-    base_image: 'quay.io/centos/centos:stream8'
-    packages:
-      <<: *cs_packages
-      repo_distro: el/c8s
 
   - &debian
     distro: debian
@@ -343,6 +337,12 @@ legacy: # Info for platforms we used to support and still need to handle package
     packages:
       <<: *opensuse_packages
       repo_distro: opensuse/15.4
+  - <<: *centos_stream
+    version: '8'
+    base_image: 'quay.io/centos/centos:stream8'
+    packages:
+      <<: *cs_packages
+      repo_distro: el/c8s
 no_include: # Info for platforms not covered in CI
   - distro: docker
     version: "19.03 or newer"


### PR DESCRIPTION
##### Summary

It’s EOL as of 2024-05-31.

##### Test Plan

n/a

##### Additional Information

Closes: #17595 