### PR TITLE
Add improved handling for TLS certificates for static builds.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1811,9 +1811,15 @@ try_static_install() {
     opts="${opts} --accept"
   fi
 
+  env_cmd="env NETDATA_CERT_TEST_URL=${NETDATA_CLAIM_URL} NETDATA_CERT_MODE=check"
+
+  if [ -n "${NETDATA_OFFLINE_INSTALL_SOURCE}" ]; then
+    env_cmd="env NETDATA_CERT_TEST_URL=${NETDATA_CLAIM_URL} NETDATA_CERT_MODE=auto"
+  fi
+
   progress "Installing netdata"
   # shellcheck disable=SC2086
-  if ! run_as_root sh "${tmpdir}/${netdata_agent}" ${opts} -- ${NETDATA_INSTALLER_OPTIONS}; then
+  if ! run_as_root ${env_cmd} /bin/sh "${tmpdir}/${netdata_agent}" ${opts} -- ${NETDATA_INSTALLER_OPTIONS}; then
     warning "Failed to install static build of Netdata on ${SYSARCH}."
     run rm -rf /opt/netdata
     return 2

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -252,7 +252,7 @@ certs_selected() {
 }
 
 test_certs() {
-  /opt/netdata/bin/curl --fail --silent --output /dev/null "${NETDATA_CERT_TEST_URL}" || return 1
+  /opt/netdata/bin/curl --fail --max-time 300 --silent --output /dev/null "${NETDATA_CERT_TEST_URL}" || return 1
 }
 
 # If the user has manually set up certificates, don’t mess with it.

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -297,7 +297,7 @@ fi
 
 echo "Save install options"
 grep -qv 'IS_NETDATA_STATIC_BINARY="yes"' "${NETDATA_PREFIX}/etc/netdata/.environment" || echo IS_NETDATA_STATIC_BINARY=\"yes\" >> "${NETDATA_PREFIX}/etc/netdata/.environment"
-REINSTALL_OPTIONS="$(echo "${REINSTALL_OPTIONS}" | awk '{gsub("/", "\\\\/"); print}')"
+REINSTALL_OPTIONS="$(echo "${REINSTALL_OPTIONS}" | awk '{gsub("/", "\\/"); print}')"
 sed -i "s/REINSTALL_OPTIONS=\".*\"/REINSTALL_OPTIONS=\"${REINSTALL_OPTIONS}\"/" "${NETDATA_PREFIX}/etc/netdata/.environment"
 
 # -----------------------------------------------------------------------------

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -219,19 +219,26 @@ done
 
 # -----------------------------------------------------------------------------
 
+replace_symlink() {
+    target="${1}"
+    name="${2}"
+    rm -f "${name}"
+    ln -s "${1}" "${2}"
+}
+
 select_system_certs() {
   if [ -d /etc/pki/tls ] ; then
     echo "${1} /etc/pki/tls for TLS configuration and certificates"
-    ln -sf /etc/pki/tls /opt/netdata/etc/ssl
+    replace_symlink /etc/pki/tls /opt/netdata/etc/ssl
   elif [ -d /etc/ssl ] ; then
     echo "${1} /etc/ssl for TLS configuration and certificates"
-    ln -sf /etc/ssl /opt/netdata/etc/ssl
+    replace_symlink /etc/ssl /opt/netdata/etc/ssl
   fi
 }
 
 select_internal_certs() {
   echo "Using bundled TLS configuration and certificates"
-  ln -sf /opt/netdata/share/ssl /opt/netdata/etc/ssl
+  replace_symlink /opt/netdata/share/ssl /opt/netdata/etc/ssl
 }
 
 certs_selected() {

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -57,8 +57,14 @@ while [ "${1}" ]; do
         bundled) NETDATA_CERT_MODE="bundled" ;;
         *) run_failed "Unknown certificate handling mode '${2}'. Supported modes are auto, check, system, and bundled."; exit 1 ;;
       esac
+      REINSTALL_OPTIONS="${REINSTALL_OPTIONS} ${1} ${2}"
+      shift 1
       ;;
-    "--certificate-test-url") NETDATA_CERT_TEST_URL="${2}" ;;
+    "--certificate-test-url")
+      NETDATA_CERT_TEST_URL="${2}"
+      REINSTALL_OPTIONS="${REINSTALL_OPTIONS} ${1} ${2}"
+      shift 1
+      ;;
 
     *) echo >&2 "Unknown option '${1}'. Ignoring it." ;;
   esac
@@ -249,6 +255,7 @@ test_certs() {
   /opt/netdata/bin/curl --fail --silent --output /dev/null "${NETDATA_CERT_TEST_URL}" || return 1
 }
 
+# If the user has manually set up certificates, don’t mess with it.
 if [ ! -L /opt/netdata/etc/ssl ] && [ -d /opt/netdata/etc/ssl ] ; then
   echo "Preserving existing user configuration for TLS"
 else

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -252,7 +252,15 @@ certs_selected() {
 }
 
 test_certs() {
-  /opt/netdata/bin/curl --fail --max-time 300 --silent --output /dev/null "${NETDATA_CERT_TEST_URL}" || return 1
+  /opt/netdata/bin/curl --fail --max-time 300 --silent --output /dev/null "${NETDATA_CERT_TEST_URL}"
+
+  case "$?" in
+    35|77) echo "Failed to load certificate files for test." ; return 1 ;;
+    60|82|83) echo "Certificates cannot be used to connect to ${NETDATA_CERT_TEST_URL}" ; return 1 ;;
+    53|54|66) echo "Unable to use OpenSSL configuration associated with certificates" ; return 1 ;;
+    0) echo "Successfully connected to ${NETDATA_CERT_TEST_URL} using certificates" ;;
+    *) echo "Unable to test certificates due to networking problems, blindly assuming they work" ;;
+  esac
 }
 
 # If the user has manually set up certificates, don’t mess with it.

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -223,7 +223,7 @@ replace_symlink() {
     target="${1}"
     name="${2}"
     rm -f "${name}"
-    ln -s "${1}" "${2}"
+    ln -s "${target}" "${name}"
 }
 
 select_system_certs() {

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -57,12 +57,10 @@ while [ "${1}" ]; do
         bundled) NETDATA_CERT_MODE="bundled" ;;
         *) run_failed "Unknown certificate handling mode '${2}'. Supported modes are auto, check, system, and bundled."; exit 1 ;;
       esac
-      REINSTALL_OPTIONS="${REINSTALL_OPTIONS} ${1} ${2}"
       shift 1
       ;;
     "--certificate-test-url")
       NETDATA_CERT_TEST_URL="${2}"
-      REINSTALL_OPTIONS="${REINSTALL_OPTIONS} ${1} ${2}"
       shift 1
       ;;
 
@@ -77,6 +75,14 @@ if [ ! "${DISABLE_TELEMETRY:-0}" -eq 0 ] ||
   [ -n "$DO_NOT_TRACK" ]; then
   NETDATA_DISABLE_TELEMETRY=1
   REINSTALL_OPTIONS="${REINSTALL_OPTIONS} --disable-telemetry"
+fi
+
+if [ -n "${NETDATA_CERT_MODE}" ]; then
+  REINSTALL_OPTIONS="${REINSTALL_OPTIONS} --certificates ${NETDATA_CERT_MODE}"
+fi
+
+if [ -n "${NETDATA_CERT_TEST_URL}" ]; then
+  REINSTALL_OPTIONS="${REINSTALL_OPTIONS} --certificate-test-url ${NETDATA_CERT_TEST_URL}"
 fi
 
 # -----------------------------------------------------------------------------

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -297,6 +297,7 @@ fi
 
 echo "Save install options"
 grep -qv 'IS_NETDATA_STATIC_BINARY="yes"' "${NETDATA_PREFIX}/etc/netdata/.environment" || echo IS_NETDATA_STATIC_BINARY=\"yes\" >> "${NETDATA_PREFIX}/etc/netdata/.environment"
+REINSTALL_OPTIONS="$(echo "${REINSTALL_OPTIONS}" | awk '{gsub("/", "\\\\/"); print}')"
 sed -i "s/REINSTALL_OPTIONS=\".*\"/REINSTALL_OPTIONS=\"${REINSTALL_OPTIONS}\"/" "${NETDATA_PREFIX}/etc/netdata/.environment"
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary

Our current static builds include a bundled copy of the CA certificates available in the build environment, and will automatically fall back to using those if they can’t find a usable set of CA certificates on the target system.

This works in a majority of cases, but it has a couple of issues:

- It doesn’t properly support the case of users who want to just use our bundled certificates unconditionally for some reason.
- It doesn’t actually _test_ that the system certificates work to connect to Netdata infrastructure, and thus it’s entirely possible that we end up with an install we can’t claim because the users are refusing to follow security best practices and keep their CA certificate store up to date.

This PR works to remedy those issues. It adds additional logic to the installation code embedded in the static builds that handles the TLS certificates, adding support both for checking the usability of the selected certificates and for skipping the system certificates and just using the bundled ones. This functionality is controlled by two new options and associated environment variables:

- `--certificates` and `NETDATA_CERT_MODE` allow specifying the certificate handling mode. `auto` and `system` have the current behavior. `check` expands the current behavior by testing the detected system certificate store for usability by connecting to a well-known URL. `bundled` ignores any system certificates and unconditionally uses the bundled certificates. Defaults to `auto` if unspecified (thus preserving the existing behavior).
- `--certificate-test-url` and `NETDATA_CERT_TEST_URL` allow overriding the URL used by `check` mode for testing whether the system certificates are usable. Defaults to `https://app.netdata.cloud` if unspecified.

The options override any value specified by the environment variables. 

Additionally, the kickstart script is updated to pass the claiming URL as the certificate test URL when installing a static build, and to make the certificate handling mode default to `check` for installs other than offline installs and `auto` mode for offline installs. The values passed by the kickstart script can still be overridden by using the `--static-install-options` option to add the `--certificates` or `--certificate-test-url` options as needed.

##### Test Plan

Testing requires manually installing static builds produced from this PR on a variety of systems with various values for the `--certificates` and `--certificate-test-url` options and observing how the symlink at `/opt/netdata/etc/ssl` is updated.