### PR TITLE
reset health when children disconnect

### DIFF
--- a/src/database/rrd.h
+++ b/src/database/rrd.h
@@ -226,7 +226,6 @@ typedef enum __attribute__ ((__packed__)) rrddim_options {
 // flags are runtime changing status flags (atomics are required to alter/access them)
 typedef enum __attribute__ ((__packed__)) rrddim_flags {
     RRDDIM_FLAG_NONE                            = 0,
-    RRDDIM_FLAG_PENDING_HEALTH_INITIALIZATION   = (1 << 0),
 
     RRDDIM_FLAG_OBSOLETE                        = (1 << 1),  // this is marked by the collector/module as obsolete
     // No new values have been collected for this dimension since agent start, or it was marked RRDDIM_FLAG_OBSOLETE at

--- a/src/database/rrd.h
+++ b/src/database/rrd.h
@@ -227,14 +227,15 @@ typedef enum __attribute__ ((__packed__)) rrddim_options {
 typedef enum __attribute__ ((__packed__)) rrddim_flags {
     RRDDIM_FLAG_NONE                            = 0,
 
-    RRDDIM_FLAG_OBSOLETE                        = (1 << 1),  // this is marked by the collector/module as obsolete
+    RRDDIM_FLAG_OBSOLETE                        = (1 << 0),  // this is marked by the collector/module as obsolete
     // No new values have been collected for this dimension since agent start, or it was marked RRDDIM_FLAG_OBSOLETE at
     // least rrdset_free_obsolete_time seconds ago.
-    RRDDIM_FLAG_ARCHIVED                        = (1 << 2),
-    RRDDIM_FLAG_METADATA_UPDATE                 = (1 << 3),  // Metadata needs to go to the database
 
-    RRDDIM_FLAG_META_HIDDEN                     = (1 << 4),  // Status of hidden option in the metadata database
-    RRDDIM_FLAG_ML_MODEL_LOAD                   = (1 << 5),  // Do ML LOAD for this dimension
+    RRDDIM_FLAG_ARCHIVED                        = (1 << 1),
+    RRDDIM_FLAG_METADATA_UPDATE                 = (1 << 2),  // Metadata needs to go to the database
+
+    RRDDIM_FLAG_META_HIDDEN                     = (1 << 3),  // Status of hidden option in the metadata database
+    RRDDIM_FLAG_ML_MODEL_LOAD                   = (1 << 4),  // Do ML LOAD for this dimension
 
     // this is 8 bit
 } RRDDIM_FLAGS;

--- a/src/database/rrddim.c
+++ b/src/database/rrddim.c
@@ -150,10 +150,6 @@ static void rrddim_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
         }
     }
 
-    rrddim_flag_set(rd, RRDDIM_FLAG_PENDING_HEALTH_INITIALIZATION);
-    rrdset_flag_set(rd->rrdset, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
-    rrdhost_flag_set(rd->rrdset->rrdhost, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
-
     // let the chart resync
     rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
 
@@ -259,13 +255,8 @@ static bool rrddim_conflict_callback(const DICTIONARY_ITEM *item __maybe_unused,
                     storage_metric_store_init(rd->tiers[tier].seb, rd->tiers[tier].smh, st->rrdhost->db[tier].tier_grouping * st->update_every, rd->rrdset->smg[tier]);
     }
 
-    if(rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED)) {
+    if(rrddim_flag_check(rd, RRDDIM_FLAG_ARCHIVED))
         rrddim_flag_clear(rd, RRDDIM_FLAG_ARCHIVED);
-
-        rrddim_flag_set(rd, RRDDIM_FLAG_PENDING_HEALTH_INITIALIZATION);
-        rrdset_flag_set(rd->rrdset, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
-        rrdhost_flag_set(rd->rrdset->rrdhost, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
-    }
 
     if(unlikely(rc))
         ctr->react_action = RRDDIM_REACT_UPDATED;

--- a/src/database/rrdset.c
+++ b/src/database/rrdset.c
@@ -478,10 +478,8 @@ static void rrdset_react_callback(const DICTIONARY_ITEM *item __maybe_unused, vo
 
     st->last_accessed_time_s = now_realtime_sec();
 
-    if(host->health.health_enabled && (ctr->react_action & (RRDSET_REACT_NEW | RRDSET_REACT_CHART_ACTIVATED))) {
-        rrdset_flag_set(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
-        rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
-    }
+    rrdset_flag_set(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
+    rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
 
     if(ctr->react_action & (RRDSET_REACT_NEW | RRDSET_REACT_PLUGIN_UPDATED | RRDSET_REACT_MODULE_UPDATED)) {
         if (ctr->react_action & RRDSET_REACT_NEW) {

--- a/src/database/rrdset.c
+++ b/src/database/rrdset.c
@@ -479,7 +479,7 @@ static void rrdset_react_callback(const DICTIONARY_ITEM *item __maybe_unused, vo
     st->last_accessed_time_s = now_realtime_sec();
 
     rrdset_flag_set(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
-    rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
+    rrdhost_flag_set(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
 
     if(ctr->react_action & (RRDSET_REACT_NEW | RRDSET_REACT_PLUGIN_UPDATED | RRDSET_REACT_MODULE_UPDATED)) {
         if (ctr->react_action & RRDSET_REACT_NEW) {

--- a/src/database/rrdset.c
+++ b/src/database/rrdset.c
@@ -290,6 +290,9 @@ static void rrdset_insert_callback(const DICTIONARY_ITEM *item __maybe_unused, v
 
     rrdset_pluginsd_receive_slots_initialize(st);
 
+    rrdset_flag_set(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
+    rrdhost_flag_set(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
+
     ctr->react_action = RRDSET_REACT_NEW;
 
     ml_chart_new(st);
@@ -465,6 +468,8 @@ static bool rrdset_conflict_callback(const DICTIONARY_ITEM *item __maybe_unused,
     rrdset_update_permanent_labels(st);
 
     rrdset_flag_set(st, RRDSET_FLAG_SYNC_CLOCK);
+    rrdset_flag_set(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
+    rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
 
     return ctr->react_action != RRDSET_REACT_NONE;
 }
@@ -478,16 +483,13 @@ static void rrdset_react_callback(const DICTIONARY_ITEM *item __maybe_unused, vo
 
     st->last_accessed_time_s = now_realtime_sec();
 
-    rrdset_flag_set(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
-    rrdhost_flag_set(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
-
     if(ctr->react_action & (RRDSET_REACT_NEW | RRDSET_REACT_PLUGIN_UPDATED | RRDSET_REACT_MODULE_UPDATED)) {
         if (ctr->react_action & RRDSET_REACT_NEW) {
             if(unlikely(rrdcontext_find_chart_uuid(st,  &st->chart_uuid)))
                 uuid_generate(st->chart_uuid);
         }
         rrdset_flag_set(st, RRDSET_FLAG_METADATA_UPDATE);
-        rrdhost_flag_set(st->rrdhost, RRDHOST_FLAG_METADATA_UPDATE);
+        rrdhost_flag_set(host, RRDHOST_FLAG_METADATA_UPDATE);
     }
 
     rrdset_metadata_updated(st);

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -287,6 +287,7 @@ static void health_event_loop(void) {
                 if (unlikely(rc->rrdset && rc->status != RRDCALC_STATUS_REMOVED &&
                              rrdset_flag_check(rc->rrdset, RRDSET_FLAG_OBSOLETE) &&
                              now > (rc->rrdset->last_collected_time.tv_sec + 60))) {
+
                     if (!rrdcalc_isrepeating(rc)) {
                         worker_is_busy(WORKER_HEALTH_JOB_ALARM_LOG_ENTRY);
                         time_t now_tmp = now_realtime_sec();

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -463,6 +463,17 @@ void rrdcalc_delete_all(RRDHOST *host) {
     dictionary_flush(host->rrdcalc_root_index);
 }
 
+void rrdcalc_child_disconnected(RRDHOST *host) {
+    rrdcalc_delete_all(host);
+
+    rrdhost_flag_set(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
+    RRDSET *st;
+    rrdset_foreach_read(st, host) {
+        rrdset_flag_set(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
+    }
+    rrdset_foreach_done(st);
+}
+
 void rrd_alert_match_cleanup(struct rrd_alert_match *am) {
     if(am->is_template)
         string_freez(am->on.context);

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -465,13 +465,6 @@ void rrdcalc_delete_all(RRDHOST *host) {
 
 void rrdcalc_child_disconnected(RRDHOST *host) {
     rrdcalc_delete_all(host);
-
-    rrdhost_flag_set(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
-    RRDSET *st;
-    rrdset_foreach_read(st, host) {
-        rrdset_flag_set(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
-    }
-    rrdset_foreach_done(st);
 }
 
 void rrd_alert_match_cleanup(struct rrd_alert_match *am) {

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -465,6 +465,13 @@ void rrdcalc_delete_all(RRDHOST *host) {
 
 void rrdcalc_child_disconnected(RRDHOST *host) {
     rrdcalc_delete_all(host);
+
+    rrdhost_flag_set(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
+    RRDSET *st;
+    rrdset_foreach_read(st, host) {
+        rrdset_flag_set(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
+    }
+    rrdset_foreach_done(st);
 }
 
 void rrd_alert_match_cleanup(struct rrd_alert_match *am) {

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -466,10 +466,10 @@ void rrdcalc_delete_all(RRDHOST *host) {
 void rrdcalc_child_disconnected(RRDHOST *host) {
     rrdcalc_delete_all(host);
 
-    rrdhost_flag_set(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
+    rrdhost_flag_clear(host, RRDHOST_FLAG_PENDING_HEALTH_INITIALIZATION);
     RRDSET *st;
     rrdset_foreach_read(st, host) {
-        rrdset_flag_set(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
+        rrdset_flag_clear(st, RRDSET_FLAG_PENDING_HEALTH_INITIALIZATION);
     }
     rrdset_foreach_done(st);
 }

--- a/src/health/rrdcalc.h
+++ b/src/health/rrdcalc.h
@@ -143,4 +143,6 @@ void rrdcalc_unlink_and_delete(RRDHOST *host, RRDCALC *rc, bool having_ll_wrlock
 #define RRDCALC_VAR_LABEL "${label:"
 #define RRDCALC_VAR_LABEL_LEN (sizeof(RRDCALC_VAR_LABEL)-1)
 
+void rrdcalc_child_disconnected(RRDHOST *host);
+
 #endif //NETDATA_RRDCALC_H

--- a/src/streaming/receiver.c
+++ b/src/streaming/receiver.c
@@ -444,7 +444,6 @@ static void rrdhost_clear_receiver(struct receiver_state *rpt) {
             host->child_connect_time = 0;
             host->child_disconnected_time = now_realtime_sec();
 
-            const bool cleanup_health = rpt->config.health_enabled != CONFIG_BOOLEAN_NO;
             host->health.health_enabled = 0;
 
             rrdpush_sender_thread_stop(host, STREAM_HANDSHAKE_DISCONNECT_RECEIVER_LEFT, false);
@@ -456,7 +455,7 @@ static void rrdhost_clear_receiver(struct receiver_state *rpt) {
             host->receiver = NULL;
             host->rrdpush_last_receiver_exit_reason = rpt->exit.reason;
 
-            if(cleanup_health)
+            if(rpt->config.health_enabled)
                 rrdcalc_child_disconnected(host);
         }
 

--- a/src/streaming/receiver.c
+++ b/src/streaming/receiver.c
@@ -456,6 +456,9 @@ static void rrdhost_clear_receiver(struct receiver_state *rpt) {
             rrdhost_flag_set(host, RRDHOST_FLAG_ORPHAN);
             host->receiver = NULL;
             host->rrdpush_last_receiver_exit_reason = rpt->exit.reason;
+
+            if(rpt->config.health_enabled)
+                rrdcalc_child_disconnected(host);
         }
 
         netdata_mutex_unlock(&host->receiver_lock);

--- a/src/streaming/receiver.c
+++ b/src/streaming/receiver.c
@@ -445,6 +445,7 @@ static void rrdhost_clear_receiver(struct receiver_state *rpt) {
             host->child_connect_time = 0;
             host->child_disconnected_time = now_realtime_sec();
 
+            bool cleanup_health = rpt->config.health_enabled != CONFIG_BOOLEAN_NO;
             if (rpt->config.health_enabled == CONFIG_BOOLEAN_AUTO)
                 host->health.health_enabled = 0;
 
@@ -457,7 +458,7 @@ static void rrdhost_clear_receiver(struct receiver_state *rpt) {
             host->receiver = NULL;
             host->rrdpush_last_receiver_exit_reason = rpt->exit.reason;
 
-            if(rpt->config.health_enabled)
+            if(cleanup_health)
                 rrdcalc_child_disconnected(host);
         }
 

--- a/src/streaming/receiver.c
+++ b/src/streaming/receiver.c
@@ -430,10 +430,9 @@ static bool rrdhost_set_receiver(RRDHOST *host, struct receiver_state *rpt) {
 }
 
 static void rrdhost_clear_receiver(struct receiver_state *rpt) {
-    bool signal_rrdcontext = false;
-
     RRDHOST *host = rpt->host;
     if(host) {
+        bool signal_rrdcontext = false;
         netdata_mutex_lock(&host->receiver_lock);
 
         // Make sure that we detach this thread and don't kill a freshly arriving receiver
@@ -445,9 +444,8 @@ static void rrdhost_clear_receiver(struct receiver_state *rpt) {
             host->child_connect_time = 0;
             host->child_disconnected_time = now_realtime_sec();
 
-            bool cleanup_health = rpt->config.health_enabled != CONFIG_BOOLEAN_NO;
-            if (rpt->config.health_enabled == CONFIG_BOOLEAN_AUTO)
-                host->health.health_enabled = 0;
+            const bool cleanup_health = rpt->config.health_enabled != CONFIG_BOOLEAN_NO;
+            host->health.health_enabled = 0;
 
             rrdpush_sender_thread_stop(host, STREAM_HANDSHAKE_DISCONNECT_RECEIVER_LEFT, false);
 


### PR DESCRIPTION
When a child disconnects from a parent, remove all the running alerts from all charts.