### PR TITLE
Improve handling of an alert that transitions to the REMOVED state

### DIFF
--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -80,7 +80,9 @@ static bool should_send_to_cloud(RRDHOST *host, ALARM_ENTRY *ae)
 {
     sqlite3_stmt *res = NULL;
 
-    if (ae->new_status == RRDCALC_STATUS_REMOVED || ae->new_status == RRDCALC_STATUS_UNINITIALIZED)
+    if (ae->new_status == RRDCALC_STATUS_UNINITIALIZED ||
+        (ae->new_status == RRDCALC_STATUS_REMOVED &&
+         !(ae->old_status == RRDCALC_STATUS_WARNING || ae->old_status == RRDCALC_STATUS_CRITICAL)))
         return 0;
 
     if (unlikely(uuid_is_null(ae->config_hash_id) || !host->aclk_config))


### PR DESCRIPTION
##### Summary
In a claimed parent and child agent setup, when a child disconnects, all the child's alerts are removed. Up until now the REMOVED alert transition was not submitted to the cloud. This can result in an inconsistency when viewing alerts on the cloud dashboard.

This PR changes this behavior to send the REMOVED alert transition to the cloud if previous status of the alert is WARNING or CRITICAL.

