### PR TITLE
add pcre2 to install-required-packages "netdata" for macOS

### DIFF
--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -753,6 +753,11 @@ declare -A pkg_libsystemd_dev=(
   ['default']="systemd-devel"
 )
 
+declare -A pkg_pcre2=(
+  ['macos']="pcre2"
+  ['default']="NOTREQUIRED"
+)
+
 declare -A pkg_bridge_utils=(
   ['gentoo']="net-misc/bridge-utils"
   ['clearlinux']="network-basic"
@@ -1310,6 +1315,7 @@ packages() {
     suitable_package fts-dev
     suitable_package libyaml-dev
     suitable_package libsystemd-dev
+    suitable_package pcre2
   fi
 
   # -------------------------------------------------------------------------

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -471,7 +471,7 @@ detect_package_manager_from_distribution() {
       package_installer="install_brew"
       tree="macos"
       if [ "${IGNORE_INSTALLED}" -eq 0 ] && [ -z "${brew}" ]; then
-        echo >&2 "command 'brew' is required to install packages on a '${distribution} ${version}' system."
+        echo >&2 "command 'brew' is required to install packages on a '${distribution} ${version}' system. Get instructions at https://brew.sh/"
         exit 1
       fi
       ;;


### PR DESCRIPTION
##### Summary

It is required - building on macOS (newly created VM) failed without this package.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
