### PR TITLE
Add valkey to apps_groups.conf

### DIFF
--- a/src/collectors/apps.plugin/apps_groups.conf
+++ b/src/collectors/apps.plugin/apps_groups.conf
@@ -118,7 +118,7 @@ puma: *puma*
 # database servers
 
 sql: mysqld* mariad* postgres* postmaster* oracle_* ora_* sqlservr
-nosql: mongod redis* memcached *couchdb*
+nosql: mongod redis* valkey* memcached *couchdb*
 timedb: prometheus *carbon-cache.py* *carbon-aggregator.py* *graphite/manage.py* *net.opentsdb.tools.TSDMain* influxd*
 columndb: clickhouse-server*
 


### PR DESCRIPTION
##### Summary

[Valkey](https://valkey.io) is a Redis alternative under the Linux Foundation.