### PR TITLE
Fix incorrect bind failure warning

### DIFF
--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -907,6 +907,7 @@ void sql_aclk_alert_clean_dead_entries(RRDHOST *host)
     int param = 0;
     SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, MAX_REMOVED_PERIOD));
 
+    param = 0;
     int rc = sqlite3_step_monitored(res);
     if (rc != SQLITE_DONE)
         error_report("Failed to execute DELETE query for cleaning stale ACLK alert entries.");


### PR DESCRIPTION
##### Summary
- Fix incorrect bind warning that may appear in the logfile e.g.
  `Failed to bind parameter 1 (@period) in sql_aclk_alert_clean_dead_entries`
