### PR TITLE
Support offline installs in the updater code.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
-# Next unused error code: F0519
+# Next unused error code: F051A
 
 # ======================================================================
 # Constants
@@ -891,6 +891,10 @@ update() {
         opts="--non-interactive"
     else
         opts="--interactive"
+    fi
+
+    if [ -n "${NETDATA_OFFLINE_INSTALL_SOURCE}" ]; then
+      export NETDATA_OFFLINE_INSTALL_SOURCE="${NETDATA_OFFLINE_INSTALL_SOURCE}"
     fi
 
     if run_script "${updater}" ${opts} --not-running-from-cron; then
@@ -2241,6 +2245,10 @@ validate_args() {
     case "${NETDATA_FORCE_METHOD}" in
       native|build) fatal "Offline installs are only supported for static builds currently." F0502 ;;
     esac
+
+    if [ ! -d "${NETDATA_OFFLINE_INSTALL_SOURCE}" ]; then
+      fatal "Offline install source must be a directory." F0519
+    fi
   fi
 
   if [ -n "${LOCAL_BUILD_OPTIONS}" ]; then

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -399,6 +399,11 @@ _safe_download() {
   succeeded=0
   checked=0
 
+  if echo "${url}" | grep -Eq "^file:///"; then
+    run cp "${url#file://}" "${dest}" || return 1
+    return 0
+  fi
+
   check_for_curl
 
   if [ -n "${curl}" ]; then
@@ -660,7 +665,11 @@ set_tarball_urls() {
     fi
   fi
 
-  if [ "$1" = "stable" ]; then
+  if [ -n "${NETDATA_OFFLINE_INSTALL_SOURCE}" ]; then
+    path="$(cd "${NETDATA_OFFLINE_INSTALL_SOURCE}" || exit 1; pwd)"
+    export NETDATA_TARBALL_URL="file://${path}/${filename}"
+    export NETDATA_TARBALL_CHECKSUM_URL="file://${path}/sha256sums.txt"
+  elif [ "$1" = "stable" ]; then
     latest="$(get_netdata_latest_tag "${NETDATA_STABLE_BASE_URL}")"
     export NETDATA_TARBALL_URL="${NETDATA_STABLE_BASE_URL}/download/$latest/${filename}"
     export NETDATA_TARBALL_CHECKSUM_URL="${NETDATA_STABLE_BASE_URL}/download/$latest/sha256sums.txt"
@@ -1044,6 +1053,10 @@ while [ -n "${1}" ]; do
     --force-update) NETDATA_FORCE_UPDATE=1 ;;
     --non-interactive) INTERACTIVE=0 ;;
     --interactive) INTERACTIVE=1 ;;
+    --offline-install-source)
+      NETDATA_OFFLINE_INSTALL_SOURCE="${2}"
+      shift 1
+      ;;
     --tmpdir-path)
       NETDATA_TMPDIR_PATH="${2}"
       shift 1
@@ -1061,6 +1074,12 @@ while [ -n "${1}" ]; do
 
   shift 1
 done
+
+if [ -n "${NETDATA_OFFLINE_INSTALL_SOURCE}" ]; then
+  NETDATA_NO_UPDATER_SELF_UPDATE=1
+  NETDATA_UPDATER_JITTER=0
+  NETDATA_FORCE_UPDATE=1
+fi
 
 # Random sleep to alleviate stampede effect of Agents upgrading
 # and disconnecting/reconnecting at the same time (or near to).


### PR DESCRIPTION
##### Summary

Add limited support for offline installs to the updater code.

This allows use of a prepared offline install source to update an existing offline install by simply following the usual offline installation instructions, instead of needing to manually specify the `--reinstall` option to run an update. This particular implementation has a couple of specific limitations:

- It only works if the _current_ version of the offline install includes the changes in this PR. This is because the updater script in an offline install cannot update itself, and thus is stuck with whatever functionality it had when installed.
- It does not support version comparison. There is little benefit to having support for this, and not implementing it significantly simplifies the code.
- The offline install source still must be manually prepared.

##### Test Plan

This requires manual testing with some special effort involved.

Steps to test:

1. Create a ‘normal’ offline install.
2. Replace the updater script (`/opt/netdata/usr/libexec/netdata/netdata-updater.sh`) with the updater script from this PR.
3. Prepare a new offline install source using the kickstart script from this PR.
4. Use the offline install source from step 3 to install on the same system where the offline install in step 1 was installed.

Attempting the above procedure either without step 2, or with step 3 using the currently published kickstart script instead of the one from this PR should cause a failure in the update process in step 4.