### PR TITLE
Correctly handle required compilation flags for dependencies.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1541,7 +1541,7 @@ if(MACOS)
 else()
         pkg_check_modules(ZLIB REQUIRED zlib)
         target_include_directories(libnetdata BEFORE PUBLIC ${ZLIB_INCLUDE_DIRS})
-        target_compile_definitions(libnetdata PUBLIC ${ZLIB_CFLAGS_OTHER})
+        target_compile_options(libnetdata PUBLIC ${ZLIB_CFLAGS_OTHER})
         target_link_libraries(libnetdata PUBLIC ${ZLIB_LDFLAGS})
 endif()
 
@@ -1556,7 +1556,7 @@ else()
 endif()
 
 target_include_directories(libnetdata BEFORE PUBLIC ${LIBLZ4_INCLUDE_DIRS})
-target_compile_definitions(libnetdata PUBLIC ${LIBLZ4_CFLAGS_OTHER})
+target_compile_options(libnetdata PUBLIC ${LIBLZ4_CFLAGS_OTHER})
 target_link_libraries(libnetdata PUBLIC ${LIBLZ4_LDFLAGS})
 
 # zstd
@@ -1564,7 +1564,7 @@ pkg_check_modules(LIBZSTD libzstd)
 if(LIBZSTD_FOUND)
         set(ENABLE_ZSTD On)
         target_include_directories(libnetdata BEFORE PUBLIC ${LIBZSTD_INCLUDE_DIRS})
-        target_compile_definitions(libnetdata PUBLIC ${LIBZSTD_CFLAGS_OTHER})
+        target_compile_options(libnetdata PUBLIC ${LIBZSTD_CFLAGS_OTHER})
         target_link_libraries(libnetdata PUBLIC ${LIBZSTD_LDFLAGS})
 endif()
 
@@ -1573,7 +1573,7 @@ pkg_check_modules(LIBBROTLI libbrotlidec libbrotlienc libbrotlicommon)
 if(LIBBROTLI_FOUND)
         set(ENABLE_BROTLI On)
         target_include_directories(libnetdata PUBLIC ${LIBBROTLI_INCLUDE_DIRS})
-        target_compile_definitions(libnetdata PUBLIC ${LIBBROTLI_CFLAGS_OTHER})
+        target_compile_options(libnetdata PUBLIC ${LIBBROTLI_CFLAGS_OTHER})
         target_link_libraries(libnetdata PUBLIC ${LIBBROTLI_LDFLAGS})
 endif()
 
@@ -1584,14 +1584,14 @@ if(MACOS)
 else()
         pkg_check_modules(UUID REQUIRED uuid)
         target_include_directories(libnetdata BEFORE PUBLIC ${UUID_INCLUDE_DIRS})
-        target_compile_definitions(libnetdata PUBLIC ${UUID_CFLAGS_OTHER})
+        target_compile_options(libnetdata PUBLIC ${UUID_CFLAGS_OTHER})
         target_link_libraries(libnetdata PUBLIC ${UUID_LDFLAGS})
 endif()
 
 # uv
 pkg_check_modules(LIBUV REQUIRED libuv)
 target_include_directories(libnetdata BEFORE PUBLIC ${LIBUV_INCLUDE_DIRS})
-target_compile_definitions(libnetdata PUBLIC ${LIBUV_CFLAGS_OTHER})
+target_compile_options(libnetdata PUBLIC ${LIBUV_CFLAGS_OTHER})
 target_link_libraries(libnetdata PUBLIC ${LIBUV_LDFLAGS})
 
 # crypto
@@ -2153,6 +2153,9 @@ add_executable(netdata
 
 target_compile_definitions(netdata PRIVATE
         "$<$<BOOL:${ENABLE_ML}>:DLIB_NO_GUI_SUPPORT>"
+)
+
+target_compile_options(netdata PRIVATE
         "$<$<BOOL:${ENABLE_EXPORTER_MONGODB}>:${MONGOC_CFLAGS_OTHER}>"
         "$<$<BOOL:${ENABLE_EXPORTER_PROMETHEUS_REMOTE_WRITE}>:${SNAPPY_CFLAGS_OTHER}>"
 )
@@ -2219,7 +2222,7 @@ if(PCRE2_FOUND)
 
         add_executable(log2journal ${LOG2JOURNAL_FILES})
         target_include_directories(log2journal BEFORE PUBLIC ${CONFIG_H_DIR} ${CMAKE_SOURCE_DIR}/src ${PCRE2_INCLUDE_DIRS})
-        target_compile_definitions(log2journal PUBLIC ${PCRE2_CFLAGS_OTHER})
+        target_compile_options(log2journal PUBLIC ${PCRE2_CFLAGS_OTHER})
         target_link_libraries(log2journal PUBLIC "${PCRE2_LDFLAGS}")
 
         netdata_add_libyaml_to_target(log2journal)

--- a/packaging/cmake/Modules/NetdataJSONC.cmake
+++ b/packaging/cmake/Modules/NetdataJSONC.cmake
@@ -96,7 +96,7 @@ endmacro()
 # macro must have already been run at least once for this to work correctly.
 function(netdata_add_jsonc_to_target _target)
         target_include_directories(${_target} PUBLIC ${NETDATA_JSONC_INCLUDE_DIRS})
-        target_compile_definitions(${_target} PUBLIC ${NETDATA_JSONC_CFLAGS_OTHER})
+        target_compile_options(${_target} PUBLIC ${NETDATA_JSONC_CFLAGS_OTHER})
         target_link_libraries(${_target} PUBLIC ${NETDATA_JSONC_LDFLAGS})
         add_dependencies(${_target} json-c-compat-link)
 endfunction()

--- a/packaging/cmake/Modules/NetdataLibBPF.cmake
+++ b/packaging/cmake/Modules/NetdataLibBPF.cmake
@@ -90,13 +90,13 @@ function(netdata_bundle_libbpf)
         PROPERTY INTERFACE_LINK_LIBRARIES "${ELF_LIBRARIES};${ZLIB_LIBRARIES}"
     )
     set(NETDATA_LIBBPF_INCLUDE_DIRECTORIES "${libbpf_SOURCE_DIR}/usr/include;${libbpf_SOURCE_DIR}/include;${ELF_INCLUDE_DIRECTORIES};${ZLIB_INCLUDE_DIRECTORIES}" PARENT_SCOPE)
-    set(NETDATA_LIBBPF_COMPILE_DEFINITIONS "${ELF_CFLAGS_OTHER};${ZLIB_CFLAGS_OTHER}" PARENT_SCOPE)
+    set(NETDATA_LIBBPF_COMPILE_OPTIONS "${ELF_CFLAGS_OTHER};${ZLIB_CFLAGS_OTHER}" PARENT_SCOPE)
 endfunction()
 
 # Add libbpf as a link dependency for the given target.
 function(netdata_add_libbpf_to_target _target)
     target_link_libraries(${_target} PUBLIC libbpf_library)
     target_include_directories(${_target} BEFORE PUBLIC "${NETDATA_LIBBPF_INCLUDE_DIRECTORIES}")
-    target_compile_definitions(${_target} PUBLIC "${NETDATA_LIBBPF_COMPILE_DEFINITIONS}")
+    target_compile_options(${_target} PUBLIC "${NETDATA_LIBBPF_COMPILE_OPTIONS}")
     add_dependencies(${_target} libbpf)
 endfunction()

--- a/packaging/cmake/Modules/NetdataProtobuf.cmake
+++ b/packaging/cmake/Modules/NetdataProtobuf.cmake
@@ -152,7 +152,7 @@ endfunction()
 
 # Add protobuf to a specified target.
 function(netdata_add_protobuf _target)
-        target_compile_definitions(${_target} PRIVATE ${PROTOBUF_CFLAGS_OTHER})
+        target_compile_options(${_target} PRIVATE ${PROTOBUF_CFLAGS_OTHER})
         target_include_directories(${_target} PRIVATE ${PROTOBUF_INCLUDE_DIRS})
         target_link_libraries(${_target} PRIVATE ${PROTOBUF_LIBRARIES})
 endfunction()

--- a/packaging/cmake/Modules/NetdataYAML.cmake
+++ b/packaging/cmake/Modules/NetdataYAML.cmake
@@ -60,6 +60,6 @@ endmacro()
 # macro must have already been run at least once for this to work correctly.
 function(netdata_add_libyaml_to_target _target)
         target_include_directories(${_target} PUBLIC ${NETDATA_YAML_INCLUDE_DIRS})
-        target_compile_definitions(${_target} PUBLIC ${NETDATA_YAML_CFLAGS_OTHER})
+        target_compile_options(${_target} PUBLIC ${NETDATA_YAML_CFLAGS_OTHER})
         target_link_libraries(${_target} PUBLIC ${NETDATA_YAML_LDFLAGS})
 endfunction()


### PR DESCRIPTION
##### Summary

`target_compile_definitions` can only be used for actual command line _macro definitions_. But the `*_CFLAGS_OTHER` may contain flags that are _not_ macro definitions, and when that happens, any use of `target_compile_definitions` with the relevant `*_CFLAGS_OTHER` variable will break the build.

Instead, we should be using `target_compile_options` for these variables.

##### Test Plan

Observe that the CI jobs for Rocky Linux 8 and CentOS 8 Stream pass on this PR, despite failing on the master branch.