### PR TITLE
Relax strict version constraints for DEB package dependencies.

### DIFF
--- a/packaging/cmake/Modules/Packaging.cmake
+++ b/packaging/cmake/Modules/Packaging.cmake
@@ -51,43 +51,43 @@ set(CPACK_DEBIAN_NETDATA_PACKAGE_SECTION "net")
 set(CPACK_DEBIAN_NETDATA_PACKAGE_PREDEPENDS
 		"adduser, dpkg (>= 1.17.14), libcap2-bin (>=1:2.0), lsb-base (>= 3.1-23.2)")
 set(CPACK_DEBIAN_NETDATA_PACKAGE_SUGGESTS
-		"netdata-plugin-cups (= ${CPACK_PACKAGE_VERSION}), netdata-plugin-freeipmi (= ${CPACK_PACKAGE_VERSION})")
+		"netdata-plugin-cups, netdata-plugin-freeipmi")
 set(CPACK_DEBIAN_NETDATA_PACKAGE_RECOMMENDS
-		"netdata-plugin-systemd-journal (= ${CPACK_PACKAGE_VERSION}), \
-netdata-plugin-logs-management (= ${CPACK_PACKAGE_VERSION}), \
-netdata-plugin-network-viewer (= ${CPACK_PACKAGE_VERSION})")
+		"netdata-plugin-systemd-journal, \
+netdata-plugin-logs-management, \
+netdata-plugin-network-viewer")
 set(CPACK_DEBIAN_NETDATA_PACKAGE_CONFLICTS
 		"netdata-core, netdata-plugins-bash, netdata-plugins-python, netdata-web")
 
-list(APPEND _main_deps "netdata-plugin-chartsd (= ${CPACK_PACKAGE_VERSION})")
-list(APPEND _main_deps "netdata-plugin-pythond (= ${CPACK_PACKAGE_VERSION})")
+list(APPEND _main_deps "netdata-plugin-chartsd")
+list(APPEND _main_deps "netdata-plugin-pythond")
 
 if(ENABLE_PLUGIN_APPS)
-        list(APPEND _main_deps "netdata-plugin-apps (= ${CPACK_PACKAGE_VERSION})")
+        list(APPEND _main_deps "netdata-plugin-apps")
 endif()
 
 if(ENABLE_PLUGIN_GO)
-        list(APPEND _main_deps "netdata-plugin-go (= ${CPACK_PACKAGE_VERSION})")
+        list(APPEND _main_deps "netdata-plugin-go")
 endif()
 
 if(ENABLE_PLUGIN_DEBUGFS)
-        list(APPEND _main_deps "netdata-plugin-debugfs (= ${CPACK_PACKAGE_VERSION})")
+        list(APPEND _main_deps "netdata-plugin-debugfs")
 endif()
 
 if(ENABLE_PLUGIN_NFACCT)
-        list(APPEND _main_deps "netdata-plugin-nfacct (= ${CPACK_PACKAGE_VERSION})")
+        list(APPEND _main_deps "netdata-plugin-nfacct")
 endif()
 
 if(ENABLE_PLUGIN_SLABINFO)
-        list(APPEND _main_deps "netdata-plugin-slabinfo (= ${CPACK_PACKAGE_VERSION})")
+        list(APPEND _main_deps "netdata-plugin-slabinfo")
 endif()
 
 if(ENABLE_PLUGIN_PERF)
-        list(APPEND _main_deps "netdata-plugin-perf (= ${CPACK_PACKAGE_VERSION})")
+        list(APPEND _main_deps "netdata-plugin-perf")
 endif()
 
 if(ENABLE_PLUGIN_EBPF)
-        list(APPEND _main_deps "netdata-plugin-ebpf (= ${CPACK_PACKAGE_VERSION})")
+        list(APPEND _main_deps "netdata-plugin-ebpf")
 endif()
 
 list(JOIN _main_deps ", " CPACK_DEBIAN_NETDATA_PACKAGE_DEPENDS)


### PR DESCRIPTION
##### Summary

Outside of a few cases involving eBPF, we don’t actually need to have an exact match between individual package component versions.

Removing this constraint significantly simplifies our dependency graph, and should both speed up updates, and also make them much more reliable.

This will also simplify consolidation of dependency handling across package types, because our package names are identical between DEB and RPM packages.

##### Test Plan

Requires manually checking that the package dependencies are updated correctly.