### PR TITLE
Rename a variable in FreeIMPI (WolfSSL support)

### DIFF
--- a/src/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/src/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -105,7 +105,7 @@ unsigned int register_spacing = 0;  /* not used if probing */
 char *driver_device = NULL;         /* not used if probing */
 
 /* Out-of-band Communication Configuration */
-int protocol_version = -1;      // IPMI_MONITORING_PROTOCOL_VERSION_1_5, etc. or -1 for default
+int freeimpi_protocol_version = -1;      // IPMI_MONITORING_PROTOCOL_VERSION_1_5, etc. or -1 for default
 char *username = "";
 char *password = "";
 unsigned char *k_g = NULL;
@@ -151,7 +151,7 @@ static void initialize_ipmi_config (struct ipmi_monitoring_ipmi_config *ipmi_con
     ipmi_config->register_spacing = register_spacing;
     ipmi_config->driver_device = driver_device;
 
-    ipmi_config->protocol_version = protocol_version;
+    ipmi_config->protocol_version = freeimpi_protocol_version;
     ipmi_config->username = username;
     ipmi_config->password = password;
     ipmi_config->k_g = k_g;
@@ -1862,9 +1862,9 @@ int main (int argc, char **argv) {
         }
         else if(strcmp("driver-type", argv[i]) == 0) {
             if (hostname) {
-                protocol_version = netdata_parse_outofband_driver_type(argv[++i]);
-                if(debug) fprintf(stderr, "%s: outband protocol version set to '%d'\n",
-                                  program_name, protocol_version);
+                freeimpi_protocol_version = netdata_parse_outofband_driver_type(argv[++i]);
+                if(debug) fprintf(stderr, "%s: outband FreeIMPI protocol version set to '%d'\n",
+                                  program_name, freeimpi_protocol_version);
             }
             else {
                 driver_type = netdata_parse_inband_driver_type(argv[++i]);

--- a/src/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/src/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -1879,7 +1879,7 @@ int main (int argc, char **argv) {
                             program_name);
 
             }
-            else if (protocol_version < 0 || protocol_version == IPMI_MONITORING_PROTOCOL_VERSION_1_5) {
+            else if (freeimpi_protocol_version < 0 || freeimpi_protocol_version == IPMI_MONITORING_PROTOCOL_VERSION_1_5) {
                 workaround_flags |= IPMI_MONITORING_WORKAROUND_FLAGS_PROTOCOL_VERSION_1_5_NO_AUTH_CODE_CHECK;
 
                 if (debug)


### PR DESCRIPTION
##### Summary
This PR address an issue reported on Slack:

```sh
[105/370] Building C object CMakeFiles/freeipmi.plugin.dir/src/collectors/freeipmi.plugin/freeipmi_plugin.c.o
FAILED: CMakeFiles/freeipmi.plugin.dir/src/collectors/freeipmi.plugin/freeipmi_plugin.c.o 
/usr/bin/cc -D_GNU_SOURCE -I/usr/include/uuid -I/home/stelios/git/netdata/cmake-build-debug -I/home/stelios/git/netdata/src -I/usr/include/json-c -I/home/stelios/git/netdata/src/libnetdata/libjudy/src -I/home/stelios/git/netdata/src/libnetdata/libjudy/src/JudyCommon -Wall -Wextra -Wmaybe-uninitialized -g -std=gnu11 -fdiagnostics-color=always -ffunction-sections -fdata-sections -Wno-builtin-macro-redefined -fexceptions -MD -MT CMakeFiles/freeipmi.plugin.dir/src/collectors/freeipmi.plugin/freeipmi_plugin.c.o -MF CMakeFiles/freeipmi.plugin.dir/src/collectors/freeipmi.plugin/freeipmi_plugin.c.o.d -o CMakeFiles/freeipmi.plugin.dir/src/collectors/freeipmi.plugin/freeipmi_plugin.c.o -c /home/stelios/git/netdata/src/collectors/freeipmi.plugin/freeipmi_plugin.c
/home/stelios/git/netdata/src/collectors/freeipmi.plugin/freeipmi_plugin.c:108:5: error: 'protocol_version' redeclared as different kind of symbol
  108 | int protocol_version = -1;      // IPMI_MONITORING_PROTOCOL_VERSION_1_5, etc. or -1 for default
      |     ^~~~~~~~~~~~~~~~
In file included from /home/stelios/git/netdata/src/libnetdata/ssl/ssl.h:32,
                 from /home/stelios/git/netdata/src/libnetdata/libnetdata.h:486,
                 from /home/stelios/git/netdata/src/collectors/freeipmi.plugin/freeipmi_plugin.c:22:
/usr/include/wolfssl/ssl.h:761:5: note: previous definition of 'protocol_version' with type 'enum AlertDescription'
  761 |     protocol_version                =  70,
````

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
