### PR TITLE
Fix timex slow shutdown

### DIFF
--- a/src/collectors/timex.plugin/plugin_timex.c
+++ b/src/collectors/timex.plugin/plugin_timex.c
@@ -62,11 +62,19 @@ void *timex_main(void *ptr)
     }
 
     usec_t step = update_every * USEC_PER_SEC;
+    usec_t real_step = USEC_PER_SEC;
     heartbeat_t hb;
     heartbeat_init(&hb);
     while (service_running(SERVICE_COLLECTORS)) {
         worker_is_idle();
-        heartbeat_next(&hb, step);
+        heartbeat_next(&hb, USEC_PER_SEC);
+
+        if (real_step < step) {
+            real_step += USEC_PER_SEC;
+            continue;
+        }
+        real_step = USEC_PER_SEC;
+
         worker_is_busy(0);
 
         struct timex timex_buf = {};


### PR DESCRIPTION
##### Summary
- Sleep per second and iterate as needed (be more responsive during shutdown)