### PR TITLE
Add agent CLI command to remove a stale node

### DIFF
--- a/src/collectors/plugins.d/pluginsd_parser.c
+++ b/src/collectors/plugins.d/pluginsd_parser.c
@@ -649,10 +649,12 @@ static inline PARSER_RC pluginsd_label(char **words, size_t num_words, PARSER *p
 
     if (strcmp(name,HOST_LABEL_IS_EPHEMERAL) == 0) {
         int is_ephemeral = appconfig_test_boolean_value((char *) value);
-        if (is_ephemeral) {
-            RRDHOST *host = pluginsd_require_scope_host(parser, PLUGINSD_KEYWORD_LABEL);
-            if (likely(host))
+        RRDHOST *host = pluginsd_require_scope_host(parser, PLUGINSD_KEYWORD_LABEL);
+        if (host) {
+            if (is_ephemeral)
                 rrdhost_option_set(host, RRDHOST_OPTION_EPHEMERAL_HOST);
+            else
+                rrdhost_option_clear(host, RRDHOST_OPTION_EPHEMERAL_HOST);
         }
     }
 

--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -47,6 +47,7 @@ static cmd_status_t cmd_ping_execute(char *args, char **message);
 static cmd_status_t cmd_aclk_state(char *args, char **message);
 static cmd_status_t cmd_version(char *args, char **message);
 static cmd_status_t cmd_dumpconfig(char *args, char **message);
+static cmd_status_t cmd_remove_node(char *args, char **message);
 
 static command_info_t command_info_array[] = {
         {"help", cmd_help_execute, CMD_TYPE_HIGH_PRIORITY},                  // show help menu
@@ -61,7 +62,8 @@ static command_info_t command_info_array[] = {
         {"ping", cmd_ping_execute, CMD_TYPE_ORTHOGONAL},
         {"aclk-state", cmd_aclk_state, CMD_TYPE_ORTHOGONAL},
         {"version", cmd_version, CMD_TYPE_ORTHOGONAL},
-        {"dumpconfig", cmd_dumpconfig, CMD_TYPE_ORTHOGONAL}
+        {"dumpconfig", cmd_dumpconfig, CMD_TYPE_ORTHOGONAL},
+        {"remove-stale-node", cmd_remove_node, CMD_TYPE_ORTHOGONAL}
 };
 
 /* Mutexes for commands of type CMD_TYPE_ORTHOGONAL */
@@ -129,6 +131,8 @@ static cmd_status_t cmd_help_execute(char *args, char **message)
              "    Returns current state of ACLK and Cloud connection. (optionally in json).\n"
              "dumpconfig\n"
              "    Returns the current netdata.conf on stdout.\n"
+             "remove-stale-node node_id|machine_guid\n"
+             "    Unregisters and removes a node from the cloud.\n"
              "version\n"
              "    Returns the netdata version.\n",
              MAX_COMMAND_LENGTH - 1);
@@ -328,6 +332,41 @@ static cmd_status_t cmd_dumpconfig(char *args, char **message)
 
     BUFFER *wb = buffer_create(1024, NULL);
     config_generate(wb, 0);
+    *message = strdupz(buffer_tostring(wb));
+    buffer_free(wb);
+    return CMD_STATUS_SUCCESS;
+}
+
+static cmd_status_t cmd_remove_node(char *args, char **message)
+{
+    (void)args;
+
+    BUFFER *wb = buffer_create(1024, NULL);
+    if (strlen(args) == 0) {
+        buffer_sprintf(wb, "Please specify a machine or node UUID");
+        goto done;
+    }
+
+    RRDHOST *host = NULL;
+    host = rrdhost_find_by_guid(args);
+    if (!host)
+        host = find_host_by_node_id(args);
+
+    if (!host)
+        buffer_sprintf(wb, "Node with machine or node UUID \"%s\" not found", args);
+    else {
+        if (!rrdhost_option_check(host, RRDHOST_OPTION_EPHEMERAL_HOST)) {
+            rrdhost_option_set(host, RRDHOST_OPTION_EPHEMERAL_HOST);
+            sql_set_host_label(&host->host_uuid, "_is_ephemeral", "true");
+            aclk_host_state_update(host, 0, 0);
+            unregister_node(host->machine_guid);
+            buffer_sprintf(wb, "Unregistering node with machine guid %s, hostname = %s", host->machine_guid, rrdhost_hostname(host));
+        }
+        else
+            buffer_sprintf(wb, "Node with machine guid %s, hostname = %s is already unregistered", host->machine_guid, rrdhost_hostname(host));
+    }
+
+done:
     *message = strdupz(buffer_tostring(wb));
     buffer_free(wb);
     return CMD_STATUS_SUCCESS;

--- a/src/daemon/commands.h
+++ b/src/daemon/commands.h
@@ -20,6 +20,7 @@ typedef enum cmd {
     CMD_ACLK_STATE,
     CMD_VERSION,
     CMD_DUMPCONFIG,
+    CMD_REMOVE_NODE,
     CMD_TOTAL_COMMANDS
 } cmd_t;
 

--- a/src/database/sqlite/sqlite_metadata.h
+++ b/src/database/sqlite/sqlite_metadata.h
@@ -49,6 +49,7 @@ void sql_load_node_id(RRDHOST *host);
 void sql_build_host_system_info(nd_uuid_t *host_id, struct rrdhost_system_info *system_info);
 void invalidate_node_instances(nd_uuid_t *host_id, nd_uuid_t *claim_id);
 RRDLABELS *sql_load_host_labels(nd_uuid_t *host_id);
+bool sql_set_host_label(nd_uuid_t *host_id, const char *label_key, const char *label_value);
 
 uint64_t sqlite_get_meta_space(void);
 int sql_init_meta_database(db_check_action_type_t rebuild, int memory);


### PR DESCRIPTION
##### Summary
- Adds a new command `remove-stale-node` to `netdatacli`. It takes as a parameter a machine guid or a node id and it will unregister this node from the cloud
- Checks and prevents the local agent (parent) from being removed
- Checks and prevents a live child from being removed