### PR TITLE
Corrected grammar and mispelling

### DIFF
--- a/src/collectors/perf.plugin/metadata.yaml
+++ b/src/collectors/perf.plugin/metadata.yaml
@@ -23,14 +23,14 @@ modules:
     overview:
       data_collection:
         metrics_description: "This collector monitors CPU performance metrics about cycles, instructions, migrations, cache operations and more."
-        method_description: "It uses syscall (2) to open a file descriptior to monitor the perf events."
+        method_description: "It uses syscall (2) to open a file descriptor to monitor the perf events."
       supported_platforms:
         include:
           - Linux
         exclude: []
       multi_instance: true
       additional_permissions:
-        description: "It needs setuid to use necessary syscall to collect perf events. Netada sets the permission during installation time."
+        description: "It needs setuid to use the necessary syscall to collect perf events. Netdada sets the permission during installation time."
       default_behavior:
         auto_detection:
           description: ""
@@ -44,7 +44,7 @@ modules:
           - title: Install perf plugin
             description: |
               If you are [using our official native DEB/RPM packages](https://github.com/netdata/netdata/blob/master/packaging/installer/UPDATE.md#determine-which-installation-method-you-used), make sure the `netdata-plugin-perf` package is installed.
-          - title: Enable the pref plugin
+          - title: Enable the perf plugin
             description: |
               The plugin is disabled by default because the number of PMUs is usually quite limited and it is not desired to allow Netdata to struggle silently for PMUs, interfering with other performance monitoring software.
 
@@ -77,7 +77,7 @@ modules:
               default_value: 1
               required: false
             - name: command options
-              description: Command options that specify charts shown by plugin. `cycles`, `instructions`, `branch`, `cache`, `bus`, `stalled`, `migrations`, `alignment`, `emulation`, `L1D`, `L1D-prefetch`, `L1I`, `LL`, `DTLB`, `ITLB`, `PBU`.
+              description: Command options that specify charts shown by the plugin. `cycles`, `instructions`, `branch`, `cache`, `bus`, `stalled`, `migrations`, `alignment`, `emulation`, `L1D`, `L1D-prefetch`, `L1I`, `LL`, `DTLB`, `ITLB`, `PBU`.
               default_value: 1
               required: true
         examples:
@@ -102,7 +102,7 @@ modules:
         list:
           - name: Debug Mode
             description: |
-              You can run `perf.plugin` with the debug option enabled, to troubleshoot issues with it. The output should give you clues as to why the collector isn't working.
+              You can run `perf.plugin` with the debug option enabled to troubleshoot issues with it. The output should give you clues as to why the collector isn't working.
 
               - Navigate to the `plugins.d` directory, usually at `/usr/libexec/netdata/plugins.d/`. If that's not the case on your system, open `netdata.conf` and look for the `plugins` setting under `[directories]`.
 


### PR DESCRIPTION
##### Summary

Corrected some grammar mistakes in the metadata file, plus amending the misspelling of the perf command.

##### Test Plan

N/A

##### Additional Information

N/A

