### PR TITLE
Fix multipler on Windows ("Memory")

### DIFF
--- a/src/collectors/windows.plugin/perflib-memory.c
+++ b/src/collectors/windows.plugin/perflib-memory.c
@@ -37,7 +37,7 @@ static bool do_memory(PERF_DATA_BLOCK *pDataBlock, int update_every) {
     else if(perflibGetObjectCounter(pDataBlock, pObjectType, &availableKBytes))
         available_bytes = availableKBytes.current.Data * 1024;
     else if(perflibGetObjectCounter(pDataBlock, pObjectType, &availableMBytes))
-        available_bytes = availableMBytes.current.Data * 1024;
+        available_bytes = availableMBytes.current.Data * 1024 * 1024;
 
     common_mem_available(available_bytes, update_every);
 


### PR DESCRIPTION
##### Summary
As we have already talked in our meeting, I am adding a missing multiplier.

##### Test Plan

1. Compile on Microsoft and verify chart is working.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
