### PR TITLE
fix on link

### DIFF
--- a/integrations/cloud-authentication/metadata.yaml
+++ b/integrations/cloud-authentication/metadata.yaml
@@ -76,9 +76,9 @@
 
       | field                    | value                                                 |
       | :--                      | :--                                                   |
-      | Root URL                 | https://app.netdata.cloud/                            |
-      | Home/Initiate login URL  | https://app.netdata.cloud/api/v2/auth/account/auth-server?iss={your-server-issuer-url}&redirect_uri=https://app.netdata.cloud/sign-in&register_uri=https://app.netdata.cloud/sign-up/verify  |
-      | Redirect URL             | https://app.netdata.cloud/api/v2/auth/account/auth-server/callback  |
+      | Root URL                 | `https://app.netdata.cloud/``                           |
+      | Home/Initiate login URL  | `https://app.netdata.cloud/api/v2/auth/account/auth-server?iss={your-server-issuer-url}&redirect_uri=https://app.netdata.cloud/sign-in&register_uri=https://app.netdata.cloud/sign-up/verify`  |
+      | Redirect URL             | `https://app.netdata.cloud/api/v2/auth/account/auth-server/callback`  |
 
       ### Netdata Configuration Steps
       1. Click on the Space settings cog (located above your profile icon)


### PR DESCRIPTION
##### Summary

related to https://github.com/netdata/learn/issues/2086, the `&` is not escaped in plaintext, thus interferes with a symbol on Learn rendering, messing up the link