### PR TITLE
Fix compilation with disable-cloud

### DIFF
--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -47,7 +47,9 @@ static cmd_status_t cmd_ping_execute(char *args, char **message);
 static cmd_status_t cmd_aclk_state(char *args, char **message);
 static cmd_status_t cmd_version(char *args, char **message);
 static cmd_status_t cmd_dumpconfig(char *args, char **message);
+#ifdef ENABLE_ACLK
 static cmd_status_t cmd_remove_node(char *args, char **message);
+#endif
 
 static command_info_t command_info_array[] = {
         {"help", cmd_help_execute, CMD_TYPE_HIGH_PRIORITY},                  // show help menu
@@ -63,7 +65,9 @@ static command_info_t command_info_array[] = {
         {"aclk-state", cmd_aclk_state, CMD_TYPE_ORTHOGONAL},
         {"version", cmd_version, CMD_TYPE_ORTHOGONAL},
         {"dumpconfig", cmd_dumpconfig, CMD_TYPE_ORTHOGONAL},
+#ifdef ENABLE_ACLK
         {"remove-stale-node", cmd_remove_node, CMD_TYPE_ORTHOGONAL}
+#endif
 };
 
 /* Mutexes for commands of type CMD_TYPE_ORTHOGONAL */
@@ -131,8 +135,10 @@ static cmd_status_t cmd_help_execute(char *args, char **message)
              "    Returns current state of ACLK and Cloud connection. (optionally in json).\n"
              "dumpconfig\n"
              "    Returns the current netdata.conf on stdout.\n"
+#ifdef ENABLE_ACLK
              "remove-stale-node node_id|machine_guid\n"
              "    Unregisters and removes a node from the cloud.\n"
+#endif
              "version\n"
              "    Returns the netdata version.\n",
              MAX_COMMAND_LENGTH - 1);
@@ -330,6 +336,7 @@ static cmd_status_t cmd_dumpconfig(char *args, char **message)
     return CMD_STATUS_SUCCESS;
 }
 
+#ifdef ENABLE_ACLK
 static cmd_status_t cmd_remove_node(char *args, char **message)
 {
     (void)args;
@@ -377,6 +384,7 @@ done:
     buffer_free(wb);
     return CMD_STATUS_SUCCESS;
 }
+#endif
 
 static void cmd_lock_exclusive(unsigned index)
 {

--- a/src/daemon/commands.h
+++ b/src/daemon/commands.h
@@ -20,7 +20,9 @@ typedef enum cmd {
     CMD_ACLK_STATE,
     CMD_VERSION,
     CMD_DUMPCONFIG,
+#ifdef ENABLE_ACLK
     CMD_REMOVE_NODE,
+#endif
     CMD_TOTAL_COMMANDS
 } cmd_t;
 


### PR DESCRIPTION
##### Summary
- Fix compilation error when `disable-cloud` is specified
- `remove-stale-node` CLI command is not available when compiling with cloud disabled
