### PR TITLE
Fix mongodb default config indentation

### DIFF
--- a/src/go/collectors/go.d.plugin/config/go.d/mongodb.conf
+++ b/src/go/collectors/go.d.plugin/config/go.d/mongodb.conf
@@ -5,6 +5,6 @@
 #  - name: local
 #    uri: 'mongodb://localhost:27017'
 #    timeout: 2
-#     databases:
-#       include:
-#         - "* *"
+#    databases:
+#      include:
+#        - "* *"


### PR DESCRIPTION
Indentation for the default mongodb config is wrong. This causes a lot of confusion when you just uncomment the provided config, and it doesn't work.
