### PR TITLE
Add alert meta info

### DIFF
--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -849,6 +849,18 @@ void rrdlabels_value_to_buffer_array_item_or_null(RRDLABELS *labels, BUFFER *wb,
     string_freez(this_key);
 }
 
+void rrdlabels_key_to_buffer_array_item(RRDLABELS *labels, BUFFER *wb)
+{
+    if(!labels) return;
+
+    RRDLABEL *lb;
+    RRDLABEL_SRC ls;
+    lfe_start_read(labels, lb, ls) {
+        buffer_json_add_array_item_string(wb, string2str(lb->index.key));
+    }
+    lfe_done(labels);
+}
+
 // ----------------------------------------------------------------------------
 
 void rrdlabels_get_value_strcpyz(RRDLABELS *labels, char *dst, size_t dst_len, const char *key) {

--- a/src/database/rrdlabels.h
+++ b/src/database/rrdlabels.h
@@ -37,6 +37,7 @@ void rrdlabels_destroy(RRDLABELS *labels_dict);
 void rrdlabels_add(RRDLABELS *labels, const char *name, const char *value, RRDLABEL_SRC ls);
 void rrdlabels_add_pair(RRDLABELS *labels, const char *string, RRDLABEL_SRC ls);
 void rrdlabels_value_to_buffer_array_item_or_null(RRDLABELS *labels, BUFFER *wb, const char *key);
+void rrdlabels_key_to_buffer_array_item(RRDLABELS *labels, BUFFER *wb);
 void rrdlabels_get_value_strdup_or_null(RRDLABELS *labels, char **value, const char *key);
 void rrdlabels_get_value_to_buffer_or_unset(RRDLABELS *labels, BUFFER *wb, const char *key, const char *unset);
 bool rrdlabels_exist(RRDLABELS *labels, const char *key);


### PR DESCRIPTION
##### Summary
- Adds additional information to /api/v2/alerts endpoint

Sample:

Before
```
{
            "ati":8,
            "nm":"ram_in_use",
            "sum":"System memory utilization",
            "cr":0,
            "wr":0,
            "cl":6,
            "er":0,
            "in":6,
            "nd":6,
            "cfg":2
}
```

After
```
{
            "ati":8,
            "nm":"ram_in_use",
            "sum":"System memory utilization",
            "cr":0,
            "wr":0,
            "cl":6,
            "er":0,
            "in":6,
            "nd":6,
            "cfg":2,
            "ctx":["system.ram"],
            "cl":["utilization"],
            "cp":["memory"],
            "ty":["system"],
            "to":["sysadmin"]
}
```
- ctx -- context
- cl -- classification
- cp -- component
- ty -- type
- to -- receipient
