### PR TITLE
Ensure that the choice of compiler and target is passed to sub-projects.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,7 @@ endif()
 
 if(ENABLE_WEBRTC)
         include(FetchContent)
+        include(NetdataFetchContentExtra)
 
         # ignore debhelper
         set(FETCHCONTENT_FULLY_DISCONNECTED Off)
@@ -277,6 +278,7 @@ if(ENABLE_WEBRTC)
         FetchContent_Declare(libdatachannel
             GIT_REPOSITORY https://github.com/paullouisageneau/libdatachannel.git
             GIT_TAG v0.20.1
+            CMAKE_ARGS ${NETDATA_PROPAGATE_TOOLCHAIN_ARGS}
         )
         FetchContent_MakeAvailable(libdatachannel)
 endif()

--- a/packaging/cmake/Modules/NetdataFetchContentExtra.cmake
+++ b/packaging/cmake/Modules/NetdataFetchContentExtra.cmake
@@ -25,3 +25,17 @@ macro(FetchContent_MakeAvailable_NoInstall name)
         add_subdirectory(${${name}_SOURCE_DIR} ${${name}_BINARY_DIR} EXCLUDE_FROM_ALL)
     endif()
 endmacro()
+
+# NETDATA_PROPAGATE_TOOLCHAIN_ARGS
+#
+# Defines a set of CMake flags to be passed to CMAKE_ARGS for
+# FetchContent_Declare and ExternalProject_Add to ensure that toolchain
+# configuration propagates correctly to sub-projects.
+#
+# This needs to be explicitly included for any sub-project that needs
+# to be built for the target system.
+set(NETDATA_PROPAGATE_TOOLCHAIN_ARGS
+    "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+     -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+     $<$<BOOL:${CMAKE_C_COMPILER_TARGET}>:-DCMAKE_C_COMPILER_TARGET=${CMAKE_C_COMPILER_TARGET}
+     $<$<BOOL:${CMAKE_CXX_COMPILER_TARGET}>:-DCMAKE_CXX_COMPILER_TARGET=${CMAKE_CXX_COMPILER_TARGET}")

--- a/packaging/cmake/Modules/NetdataJSONC.cmake
+++ b/packaging/cmake/Modules/NetdataJSONC.cmake
@@ -40,6 +40,7 @@ function(netdata_bundle_jsonc)
         FetchContent_Declare(json-c
                 GIT_REPOSITORY https://github.com/json-c/json-c
                 GIT_TAG b4c371fa0cbc4dcbaccc359ce9e957a22988fb34 # json-c-0.17-20230812
+                CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
         )
 
         FetchContent_MakeAvailable_NoInstall(json-c)

--- a/packaging/cmake/Modules/NetdataProtobuf.cmake
+++ b/packaging/cmake/Modules/NetdataProtobuf.cmake
@@ -33,6 +33,7 @@ function(netdata_bundle_protobuf)
                 FetchContent_Declare(absl
                         GIT_REPOSITORY https://github.com/abseil/abseil-cpp
                         GIT_TAG ${ABSL_TAG}
+                        CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
                 )
                 FetchContent_MakeAvailable_NoInstall(absl)
                 message(STATUS "Finished preparing bundled Abseil")
@@ -47,6 +48,7 @@ function(netdata_bundle_protobuf)
         FetchContent_Declare(protobuf
                 GIT_REPOSITORY https://github.com/protocolbuffers/protobuf.git
                 GIT_TAG ${PROTOBUF_TAG}
+                CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
         )
         FetchContent_MakeAvailable_NoInstall(protobuf)
         message(STATUS "Finished preparing bundled Protobuf.")

--- a/packaging/cmake/Modules/NetdataSentry.cmake
+++ b/packaging/cmake/Modules/NetdataSentry.cmake
@@ -28,6 +28,7 @@ function(netdata_bundle_sentry)
                 sentry
                 GIT_REPOSITORY https://github.com/getsentry/sentry-native.git
                 GIT_TAG c97bcc63fa89ae557cef9c9b6e3acb11a72ff97d # v0.6.6
+                CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
         )
         FetchContent_MakeAvailable(sentry)
 endfunction()

--- a/packaging/cmake/Modules/NetdataYAML.cmake
+++ b/packaging/cmake/Modules/NetdataYAML.cmake
@@ -23,6 +23,7 @@ function(netdata_bundle_libyaml)
         FetchContent_Declare(yaml
                 GIT_REPOSITORY https://github.com/yaml/libyaml
                 GIT_TAG 2c891fc7a770e8ba2fec34fc6b545c672beb37e6 # v0.2.5
+                CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
         )
 
         FetchContent_MakeAvailable_NoInstall(yaml)


### PR DESCRIPTION
##### Summary

If not explicitly set using exported environment variables (or a toolchain file specified via the environment), the choice of compilers and compiler targets used by CMake does not get propagated to sub-porjects created with ExternalProject_Add or FetchContent_Declare in some situations.

In most cases this does not matter, because very few people are building using non-default compilers for their environment, but it can cause issues in two specific cases:

- If building for the same system that the build is happening on, but using a non-default compiler specified using CMake arguments (instead of via exported environment variables), sub-projects will still use the default compiler for the system, which may result in linking errors (or runtime failures even if the link succeeds).
- If cross-compiling and not using the preferred approaches of either a toolchain file or exported environment variables, sub-projects may not even build for the correct CPU architecture, causing the build to fail.

This adds logic to ensure that the compiler and compiler targets get propagated correctly even if they are just specified on the command line, thus avoiding the above two possibilities.

##### Test Plan

Primary testing involves ensuring that this builds correctly in CI.

Manual testing is required to ensure the propagation works correctly.