### PR TITLE
Provide better info in the default netdata.conf, and unfiy it with the header used for generating config at runtime.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1636,7 +1636,18 @@ if(LINUX)
         detect_systemd()
 endif()
 
-add_library(libnetdata STATIC ${LIBNETDATA_FILES})
+add_custom_command(
+        COMMAND ${CMAKE_COMMAND}
+                -DSRC=${CMAKE_SOURCE_DIR}/system/netdata.conf
+                -DDEST=${CMAKE_BINARY_DIR}/netdata_conf_header.h
+                -DNAME=NETDATA_CONF_HEADER
+                -P ${CMAKE_SOURCE_DIR}/packaging/cmake/txt2header.cmake
+        OUTPUT netdata_conf_header.h
+        DEPENDS packaging/cmake/txt2header.cmake system/netdata.conf
+        COMMENT "Generating netdata_conf_header.h from system/netdata.conf"
+)
+
+add_library(libnetdata STATIC netdata_conf_header.h ${LIBNETDATA_FILES})
 
 target_include_directories(libnetdata BEFORE PUBLIC ${CONFIG_H_DIR} ${CMAKE_SOURCE_DIR}/src)
 

--- a/packaging/cmake/txt2header.cmake
+++ b/packaging/cmake/txt2header.cmake
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-3.0
+#
+# CMake script to generate a C header file from a text file.
+#
+# The source (SRC), destination (DEST), and define name (NAME) must be
+# specified using `-D` options.
+
+# Get CMake to shut up about empty list elements (we want the new behavior anyway).
+cmake_policy(SET CMP0007 NEW)
+
+# Read the source file as a list of lines.
+file(STRINGS ${SRC} lines)
+
+# Escape everything that needs to be escaped in C strings.
+# The replacement arguments below use bracket arguments instead of
+# quoted arguments, because some varieties of CMake seem to choke on \"
+# in a single-line quoted argument.
+list(TRANSFORM lines REPLACE "\\\\" [[\\\\]])
+list(TRANSFORM lines REPLACE "\\\"" [[\\"]])
+list(TRANSFORM lines REPLACE "'" [[\\']])
+list(TRANSFORM lines REPLACE "\\\n" [[\\n]])
+list(TRANSFORM lines REPLACE "\\\r" [[\\r]])
+list(TRANSFORM lines REPLACE "\\\t" [[\\t]])
+
+# Prepare each line to be a string in a multi-line macro.
+list(TRANSFORM lines PREPEND "\"")
+list(TRANSFORM lines APPEND "\\n\" \\\n")
+
+# Add the required header lines
+list(INSERT lines 0
+    "// DO NOT EDIT DIRECTLY\n"
+    "// Generated at build time by CMake from ${SRC}\n"
+    "\n"
+    "#define ${NAME} \\\n"
+)
+list(APPEND lines "\n")
+
+# Join the lines into one string.
+list(JOIN lines "" content)
+
+# Write the output file
+file(WRITE ${DEST} "${content}")

--- a/src/libnetdata/config/appconfig.c
+++ b/src/libnetdata/config/appconfig.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "../libnetdata.h"
+#include "netdata_conf_header.h"
 
 /*
  * @Input:
@@ -817,19 +818,7 @@ void appconfig_generate(struct config *root, BUFFER *wb, int only_changed)
         }
     }
 
-    buffer_strcat(wb,
-                  "# netdata configuration\n"
-                  "#\n"
-                  "# You can download the latest version of this file, using:\n"
-                  "#\n"
-                  "#  wget -O /etc/netdata/netdata.conf http://localhost:19999/netdata.conf\n"
-                  "# or\n"
-                  "#  curl -o /etc/netdata/netdata.conf http://localhost:19999/netdata.conf\n"
-                  "#\n"
-                  "# You can uncomment and change any of the options below.\n"
-                  "# The value shown in the commented settings, is the default value.\n"
-                  "#\n"
-                  "\n# global netdata configuration\n");
+    buffer_strcat(wb, NETDATA_CONF_HEADER);
 
     for(i = 0; i <= 17 ;i++) {
         appconfig_wrlock(root);

--- a/system/netdata.conf
+++ b/system/netdata.conf
@@ -1,12 +1,18 @@
 # netdata configuration
 #
-# You can get the latest version of this file, using:
+# Documentation can be found at:
 #
-#  netdatacli dumpconfig > /etc/netdata/netdata.conf
+# https://learn.netdata.cloud/docs/netdata-agent/configuration/daemon-configuration
 #
-# You can also download it using:
+# You can retrieve the current effective configuration of the Netdata agent
+# while it is running using:
 #
-#  wget -O /etc/netdata/netdata.conf http://localhost:19999/netdata.conf
+#  netdatacli dumpconfig
+#
+# Alternatively, it can be downloaded from the `/netdata.conf` endpoint
+# of the web API of the agent:
+#
+#  wget -O - http://localhost:19999/netdata.conf
 # or
-#  curl -o /etc/netdata/netdata.conf http://localhost:19999/netdata.conf
+#  curl http://localhost:19999/netdata.conf
 #


### PR DESCRIPTION
##### Summary

The first half of this PR is simply clean up and improvements in the default config file (`system/netdata.conf`) that gets installed at build time. Most of that should be completely non-controversial, and should better help users who are looking to configure the agent.

The second half of the PR involves adjusting `src/libnetdata/config/appconfig.c` to use `system/netdata.conf` as the header when it generates the config that gets output by `netdatacli dumpconfig` or the `/netdata.conf` API endpoint. This ensures that the information in both places stays in sync properly, and also makes the function responsible for this generation a bit easier to read.

The majority of the changes involved in the second half of the PR revolve around a new CMake script (`packaging/cmake/txt2header.cmake`) that converts a text file to a C header file that defines a macro which expands to a string consisting of the contents of that text file. This was done in CMake mostly to ensure portability, but it’s also significantly simpler and faster to do this type of simple text transformation in CMake.

##### Test Plan

Primary testing involves verifying that CI passes on this PR.

Secondary testing involves building the agent, running it, and then inspecting the output of `netdatacli dumpconfig` or the `/netdata.conf `web API endpoint to confirm that the headers there match the contents of `system/netdata.conf`.