### PR TITLE
add Win CPU interrupts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1013,6 +1013,7 @@ set(INTERNAL_COLLECTORS_FILES
         src/collectors/common-contexts/common-contexts.h
         src/collectors/common-contexts/disk.io.h
         src/collectors/common-contexts/system.io.h
+        src/collectors/common-contexts/system.interrupts.h
         src/collectors/common-contexts/system.processes.h
         src/collectors/common-contexts/system.ram.h
         src/collectors/common-contexts/mem.swap.h

--- a/src/collectors/common-contexts/common-contexts.h
+++ b/src/collectors/common-contexts/common-contexts.h
@@ -20,6 +20,7 @@ typedef void (*instance_labels_cb_t)(RRDSET *st, void *data);
 
 #include "system.io.h"
 #include "system.ram.h"
+#include "system.interrupts.h"
 #include "system.processes.h"
 #include "mem.swap.h"
 #include "mem.pgfaults.h"

--- a/src/collectors/common-contexts/system.interrupts.h
+++ b/src/collectors/common-contexts/system.interrupts.h
@@ -5,45 +5,25 @@
 
 #include "common-contexts.h"
 
-#define _system_interrupt_chart() \
-   rrdset_create_localhost( \
-        "system" \
-        , "intr" \
-        , NULL \
-        , "interrupts" \
-        , NULL \
-        , "CPU Interrupts" \
-        , "interrupts/s" \
-        , _COMMON_PLUGIN_NAME \
-        , _COMMON_PLUGIN_MODULE_NAME \
-        , NETDATA_CHART_PRIO_SYSTEM_INTR \
-        , update_every \
-        , RRDSET_TYPE_LINE \
-        )
+#define _
 
-#ifdef OS_WINDOWS
-static inline void common_interrupts(COUNTER_DATA *interrupts, int update_every) {
-    static RRDSET *st_intr = NULL;
-    static RRDDIM *rd_interrupts = NULL;
-
-    if(unlikely(!st_intr)) {
-        st_intr = _system_interrupt_chart();
-
-        rrdset_flag_set(st_intr, RRDSET_FLAG_DETAIL);
-
-        rd_interrupts = perflib_rrddim_add(st_intr, "interrupts", NULL, 1, 1, interrupts);
-    }
-
-    (void)perflib_rrddim_set_by_pointer(st_intr, rd_interrupts, interrupts);
-    rrdset_done(st_intr);
-}
-#else
 static inline void common_interrupts(uint64_t interrupts, int update_every) {
     static RRDSET *st_intr = NULL;
     static RRDDIM *rd_interrupts = NULL;
 
     if(unlikely(!st_intr)) {
-        st_intr = _system_interrupt_chart();
+        st_intr = rrdset_create_localhost( "system"
+                                          , "intr"
+                                          , NULL
+                                          , "interrupts"
+                                          , NULL
+                                          , "CPU Interrupts"
+                                          , "interrupts/s"
+                                          , _COMMON_PLUGIN_NAME
+                                          , _COMMON_PLUGIN_MODULE_NAME
+                                          , NETDATA_CHART_PRIO_SYSTEM_INTR
+                                          , update_every
+                                          , RRDSET_TYPE_LINE);
 
         rrdset_flag_set(st_intr, RRDSET_FLAG_DETAIL);
 
@@ -53,6 +33,5 @@ static inline void common_interrupts(uint64_t interrupts, int update_every) {
     rrddim_set_by_pointer(st_intr, rd_interrupts, (collected_number)interrupts);
     rrdset_done(st_intr);
 }
-#endif
 
 #endif //NETDATA_SYSTEM_INTERRUPTS_H

--- a/src/collectors/common-contexts/system.interrupts.h
+++ b/src/collectors/common-contexts/system.interrupts.h
@@ -7,9 +7,11 @@
 
 #define _
 
-static inline void common_interrupts(uint64_t interrupts, int update_every) {
+static inline void common_interrupts(uint64_t interrupts, int update_every, char *ext_module) {
     static RRDSET *st_intr = NULL;
     static RRDDIM *rd_interrupts = NULL;
+
+    char *module =  (!ext_module) ? _COMMON_PLUGIN_MODULE_NAME: ext_module;
 
     if(unlikely(!st_intr)) {
         st_intr = rrdset_create_localhost( "system"
@@ -20,7 +22,7 @@ static inline void common_interrupts(uint64_t interrupts, int update_every) {
                                           , "CPU Interrupts"
                                           , "interrupts/s"
                                           , _COMMON_PLUGIN_NAME
-                                          , _COMMON_PLUGIN_MODULE_NAME
+                                          , module
                                           , NETDATA_CHART_PRIO_SYSTEM_INTR
                                           , update_every
                                           , RRDSET_TYPE_LINE);

--- a/src/collectors/common-contexts/system.interrupts.h
+++ b/src/collectors/common-contexts/system.interrupts.h
@@ -5,7 +5,7 @@
 
 #include "common-contexts.h"
 
-static inline void common_interrupts(uint64_t interrupts, int update_every) {
+static inline void common_interrupts(uint64_t interrupts, int update_every, RRD_ALGORITHM alg) {
     static RRDSET *st_intr = NULL;
     static RRDDIM *rd_interrupts = NULL;
 
@@ -27,7 +27,7 @@ static inline void common_interrupts(uint64_t interrupts, int update_every) {
 
         rrdset_flag_set(st_intr, RRDSET_FLAG_DETAIL);
 
-        rd_interrupts = rrddim_add(st_intr, "interrupts", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rd_interrupts = rrddim_add(st_intr, "interrupts", NULL, 1, 1, alg);
     }
 
     rrddim_set_by_pointer(st_intr, rd_interrupts, (collected_number)interrupts);

--- a/src/collectors/common-contexts/system.interrupts.h
+++ b/src/collectors/common-contexts/system.interrupts.h
@@ -5,25 +5,48 @@
 
 #include "common-contexts.h"
 
+#define _system_interrupt_chart() \
+   rrdset_create_localhost( \
+        "system" \
+        , "intr" \
+        , NULL \
+        , "interrupts" \
+        , NULL \
+        , "CPU Interrupts" \
+        , "interrupts/s" \
+        , _COMMON_PLUGIN_NAME \
+        , _COMMON_PLUGIN_MODULE_NAME \
+        , NETDATA_CHART_PRIO_SYSTEM_INTR \
+        , update_every \
+        , RRDSET_TYPE_LINE \
+        )
+
+#ifdef OS_WINDOWS
+static inline void common_interrupts(COUNTER_DATA *interrupts, int update_every) {
+    static RRDSET *st_intr = NULL;
+    static RRDDIM *rd_interrupts = NULL;
+
+    if(unlikely(!st_intr)) {
+        st_intr = _system_interrupt_chart();
+
+        rrdset_flag_set(st_intr, RRDSET_FLAG_DETAIL);
+
+        rd_interrupts = rrddim_add(, , NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        rd_interrupts = perflib_rrddim_add(st_intr, "interrupts", NULL, 1, 1, interrupts);
+    }
+
+    (void)perflib_rrddim_set_by_pointer(st_intr, rd_interrupts, interrupts);
+    rrdset_done(st_intr);
+}
+#endif
+
+#ifdef OS_LINUX
 static inline void common_interrupts(uint64_t interrupts, int update_every) {
     static RRDSET *st_intr = NULL;
     static RRDDIM *rd_interrupts = NULL;
 
     if(unlikely(!st_intr)) {
-        st_intr = rrdset_create_localhost(
-        "system"
-        , "intr"
-        , NULL
-        , "interrupts"
-        , NULL
-        , "CPU Interrupts"
-        , "interrupts/s"
-        , _COMMON_PLUGIN_NAME
-        , _COMMON_PLUGIN_MODULE_NAME
-        , NETDATA_CHART_PRIO_SYSTEM_INTR
-        , update_every
-        , RRDSET_TYPE_LINE
-        );
+        st_intr = _system_interrupt_chart();
 
         rrdset_flag_set(st_intr, RRDSET_FLAG_DETAIL);
 
@@ -33,5 +56,6 @@ static inline void common_interrupts(uint64_t interrupts, int update_every) {
     rrddim_set_by_pointer(st_intr, rd_interrupts, (collected_number)interrupts);
     rrdset_done(st_intr);
 }
+#endif
 
 #endif //NETDATA_SYSTEM_INTERRUPTS_H

--- a/src/collectors/common-contexts/system.interrupts.h
+++ b/src/collectors/common-contexts/system.interrupts.h
@@ -31,7 +31,6 @@ static inline void common_interrupts(COUNTER_DATA *interrupts, int update_every)
 
         rrdset_flag_set(st_intr, RRDSET_FLAG_DETAIL);
 
-        rd_interrupts = rrddim_add(, , NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
         rd_interrupts = perflib_rrddim_add(st_intr, "interrupts", NULL, 1, 1, interrupts);
     }
 

--- a/src/collectors/common-contexts/system.interrupts.h
+++ b/src/collectors/common-contexts/system.interrupts.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_SYSTEM_INTERRUPTS_H
+#define NETDATA_SYSTEM_INTERRUPTS_H
+
+#include "common-contexts.h"
+
+static inline void common_interrupts(uint64_t interrupts, int update_every) {
+    static RRDSET *st_intr = NULL;
+    static RRDDIM *rd_interrupts = NULL;
+
+    if(unlikely(!st_intr)) {
+        st_intr = rrdset_create_localhost(
+        "system"
+        , "intr"
+        , NULL
+        , "interrupts"
+        , NULL
+        , "CPU Interrupts"
+        , "interrupts/s"
+        , _COMMON_PLUGIN_NAME
+        , _COMMON_PLUGIN_MODULE_NAME
+        , NETDATA_CHART_PRIO_SYSTEM_INTR
+        , update_every
+        , RRDSET_TYPE_LINE
+        );
+
+        rrdset_flag_set(st_intr, RRDSET_FLAG_DETAIL);
+
+        rd_interrupts = rrddim_add(st_intr, "interrupts", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+    }
+
+    rrddim_set_by_pointer(st_intr, rd_interrupts, (collected_number)interrupts);
+    rrdset_done(st_intr);
+}
+
+#endif //NETDATA_SYSTEM_INTERRUPTS_H

--- a/src/collectors/common-contexts/system.interrupts.h
+++ b/src/collectors/common-contexts/system.interrupts.h
@@ -5,7 +5,7 @@
 
 #include "common-contexts.h"
 
-static inline void common_interrupts(uint64_t interrupts, int update_every, RRD_ALGORITHM alg) {
+static inline void common_interrupts(uint64_t interrupts, int update_every) {
     static RRDSET *st_intr = NULL;
     static RRDDIM *rd_interrupts = NULL;
 
@@ -27,7 +27,7 @@ static inline void common_interrupts(uint64_t interrupts, int update_every, RRD_
 
         rrdset_flag_set(st_intr, RRDSET_FLAG_DETAIL);
 
-        rd_interrupts = rrddim_add(st_intr, "interrupts", NULL, 1, 1, alg);
+        rd_interrupts = rrddim_add(st_intr, "interrupts", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
     }
 
     rrddim_set_by_pointer(st_intr, rd_interrupts, (collected_number)interrupts);

--- a/src/collectors/common-contexts/system.interrupts.h
+++ b/src/collectors/common-contexts/system.interrupts.h
@@ -37,9 +37,7 @@ static inline void common_interrupts(COUNTER_DATA *interrupts, int update_every)
     (void)perflib_rrddim_set_by_pointer(st_intr, rd_interrupts, interrupts);
     rrdset_done(st_intr);
 }
-#endif
-
-#ifdef OS_LINUX
+#else
 static inline void common_interrupts(uint64_t interrupts, int update_every) {
     static RRDSET *st_intr = NULL;
     static RRDDIM *rd_interrupts = NULL;

--- a/src/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/src/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -574,28 +574,7 @@ int do_hw_intcnt(int update_every, usec_t dt) {
             static RRDSET *st_intr = NULL;
             static RRDDIM *rd_intr = NULL;
 
-            if (unlikely(!st_intr)) {
-                st_intr = rrdset_create_localhost(
-                        "system",
-                        "intr",
-                        NULL,
-                        "interrupts",
-                        NULL,
-                        "Total Hardware Interrupts",
-                        "interrupts/s",
-                        "freebsd.plugin",
-                        "hw.intrcnt",
-                        NETDATA_CHART_PRIO_SYSTEM_INTR,
-                        update_every,
-                        RRDSET_TYPE_LINE
-                );
-                rrdset_flag_set(st_intr, RRDSET_FLAG_DETAIL);
-
-                rd_intr = rrddim_add(st_intr, "interrupts", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
-            }
-
-            rrddim_set_by_pointer(st_intr, rd_intr, totalintr);
-            rrdset_done(st_intr);
+            common_interrupts(totalintr, update_every);
 
             size_t size;
             static int mib_hw_intrnames[2] = {0, 0};

--- a/src/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/src/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -24,6 +24,10 @@
 #include <netinet/udp.h>
 #include <netinet/udp_var.h>
 
+#define _COMMON_PLUGIN_NAME "windows.plugin"
+#define _COMMON_PLUGIN_MODULE_NAME "PerflibProcessor"
+#include "../common-contexts/common-contexts.h"
+
 // --------------------------------------------------------------------------------------------------------------------
 // common definitions and variables
 

--- a/src/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/src/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -578,7 +578,7 @@ int do_hw_intcnt(int update_every, usec_t dt) {
             static RRDSET *st_intr = NULL;
             static RRDDIM *rd_intr = NULL;
 
-            common_interrupts(totalintr, update_every);
+            common_interrupts(totalintr, update_every, "hw.intrcnt");
 
             size_t size;
             static int mib_hw_intrnames[2] = {0, 0};

--- a/src/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/src/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -24,8 +24,8 @@
 #include <netinet/udp.h>
 #include <netinet/udp_var.h>
 
-#define _COMMON_PLUGIN_NAME "windows.plugin"
-#define _COMMON_PLUGIN_MODULE_NAME "PerflibProcessor"
+#define _COMMON_PLUGIN_NAME "freebsd.plugin"
+#define _COMMON_PLUGIN_MODULE_NAME "freebsd"
 #include "../common-contexts/common-contexts.h"
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/collectors/proc.plugin/proc_stat.c
+++ b/src/collectors/proc.plugin/proc_stat.c
@@ -752,33 +752,8 @@ int do_proc_stat(int update_every, usec_t dt) {
         }
         else if(unlikely(hash == hash_intr && strcmp(row_key, "intr") == 0)) {
             if(likely(do_interrupts)) {
-                static RRDSET *st_intr = NULL;
-                static RRDDIM *rd_interrupts = NULL;
                 unsigned long long value = str2ull(procfile_lineword(ff, l, 1), NULL);
-
-                if(unlikely(!st_intr)) {
-                    st_intr = rrdset_create_localhost(
-                            "system"
-                            , "intr"
-                            , NULL
-                            , "interrupts"
-                            , NULL
-                            , "CPU Interrupts"
-                            , "interrupts/s"
-                            , PLUGIN_PROC_NAME
-                            , PLUGIN_PROC_MODULE_STAT_NAME
-                            , NETDATA_CHART_PRIO_SYSTEM_INTR
-                            , update_every
-                            , RRDSET_TYPE_LINE
-                    );
-
-                    rrdset_flag_set(st_intr, RRDSET_FLAG_DETAIL);
-
-                    rd_interrupts = rrddim_add(st_intr, "interrupts", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
-                }
-
-                rrddim_set_by_pointer(st_intr, rd_interrupts, value);
-                rrdset_done(st_intr);
+                common_interrupts(value, update_every);
             }
         }
         else if(unlikely(hash == hash_ctxt && strcmp(row_key, "ctxt") == 0)) {

--- a/src/collectors/proc.plugin/proc_stat.c
+++ b/src/collectors/proc.plugin/proc_stat.c
@@ -753,7 +753,7 @@ int do_proc_stat(int update_every, usec_t dt) {
         else if(unlikely(hash == hash_intr && strcmp(row_key, "intr") == 0)) {
             if(likely(do_interrupts)) {
                 unsigned long long value = str2ull(procfile_lineword(ff, l, 1), NULL);
-                common_interrupts(value, update_every);
+                common_interrupts(value, update_every, RRD_ALGORITHM_INCREMENTAL);
             }
         }
         else if(unlikely(hash == hash_ctxt && strcmp(row_key, "ctxt") == 0)) {

--- a/src/collectors/proc.plugin/proc_stat.c
+++ b/src/collectors/proc.plugin/proc_stat.c
@@ -753,7 +753,7 @@ int do_proc_stat(int update_every, usec_t dt) {
         else if(unlikely(hash == hash_intr && strcmp(row_key, "intr") == 0)) {
             if(likely(do_interrupts)) {
                 unsigned long long value = str2ull(procfile_lineword(ff, l, 1), NULL);
-                common_interrupts(value, update_every, RRD_ALGORITHM_INCREMENTAL);
+                common_interrupts(value, update_every);
             }
         }
         else if(unlikely(hash == hash_ctxt && strcmp(row_key, "ctxt") == 0)) {

--- a/src/collectors/proc.plugin/proc_stat.c
+++ b/src/collectors/proc.plugin/proc_stat.c
@@ -753,7 +753,7 @@ int do_proc_stat(int update_every, usec_t dt) {
         else if(unlikely(hash == hash_intr && strcmp(row_key, "intr") == 0)) {
             if(likely(do_interrupts)) {
                 unsigned long long value = str2ull(procfile_lineword(ff, l, 1), NULL);
-                common_interrupts(value, update_every);
+                common_interrupts(value, update_every, NULL);
             }
         }
         else if(unlikely(hash == hash_ctxt && strcmp(row_key, "ctxt") == 0)) {

--- a/src/collectors/windows.plugin/perflib-processor.c
+++ b/src/collectors/windows.plugin/perflib-processor.c
@@ -179,7 +179,7 @@ static bool do_processors(PERF_DATA_BLOCK *pDataBlock, int update_every) {
     if(cpus_var)
         rrdvar_host_variable_set(localhost, cpus_var, cores_found);
 
-    common_interrupts(totalIPC, update_every);
+    common_interrupts(totalIPC, update_every, NULL);
 
     return true;
 }

--- a/src/collectors/windows.plugin/perflib-processor.c
+++ b/src/collectors/windows.plugin/perflib-processor.c
@@ -147,7 +147,7 @@ static bool do_processors(PERF_DATA_BLOCK *pDataBlock, int update_every) {
         rrdset_done(p->st);
 
         uint64_t interrupts = p->interruptsPerSec.current.Data;
-        common_interrupts(interrupts, update_every);
+        common_interrupts(interrupts, update_every, RRD_ALGORITHM_ABSOLUTE);
 //        if(!p->st2) {
 //            p->st2 = rrdset_create_localhost(
 //                is_total ? "system" : "cpu2"

--- a/src/collectors/windows.plugin/perflib-processor.c
+++ b/src/collectors/windows.plugin/perflib-processor.c
@@ -3,8 +3,8 @@
 #include "windows_plugin.h"
 #include "windows-internals.h"
 
-#define _COMMON_PLUGIN_NAME "windows.plugin"
-#define _COMMON_PLUGIN_MODULE_NAME "PerflibProcessor"
+#define _COMMON_PLUGIN_NAME "freebsd.plugin"
+#define _COMMON_PLUGIN_MODULE_NAME "freebsd"
 #include "../common-contexts/common-contexts.h"
 
 struct processor {

--- a/src/collectors/windows.plugin/perflib-processor.c
+++ b/src/collectors/windows.plugin/perflib-processor.c
@@ -64,6 +64,7 @@ static bool do_processors(PERF_DATA_BLOCK *pDataBlock, int update_every) {
 
     static const RRDVAR_ACQUIRED *cpus_var = NULL;
     int cores_found = 0;
+    uint64_t totalIPC = 0;
 
     PERF_INSTANCE_DEFINITION *pi = NULL;
     for(LONG i = 0; i < pObjectType->NumInstances ; i++) {
@@ -139,6 +140,8 @@ static bool do_processors(PERF_DATA_BLOCK *pDataBlock, int update_every) {
         uint64_t irq = p->percentInterruptTime.current.Data;
         uint64_t idle = p->percentIdleTime.current.Data;
 
+        totalIPC += p->interruptsPerSec.current.Data;
+
         rrddim_set_by_pointer(p->st, p->rd_user, (collected_number)user);
         rrddim_set_by_pointer(p->st, p->rd_system, (collected_number)system);
         rrddim_set_by_pointer(p->st, p->rd_irq, (collected_number)irq);
@@ -146,7 +149,6 @@ static bool do_processors(PERF_DATA_BLOCK *pDataBlock, int update_every) {
         rrddim_set_by_pointer(p->st, p->rd_idle, (collected_number)idle);
         rrdset_done(p->st);
 
-        common_interrupts(&p->interruptsPerSec, update_every);
 //        if(!p->st2) {
 //            p->st2 = rrdset_create_localhost(
 //                is_total ? "system" : "cpu2"
@@ -176,6 +178,8 @@ static bool do_processors(PERF_DATA_BLOCK *pDataBlock, int update_every) {
 
     if(cpus_var)
         rrdvar_host_variable_set(localhost, cpus_var, cores_found);
+
+    common_interrupts(totalIPC, update_every);
 
     return true;
 }

--- a/src/collectors/windows.plugin/perflib-processor.c
+++ b/src/collectors/windows.plugin/perflib-processor.c
@@ -3,8 +3,8 @@
 #include "windows_plugin.h"
 #include "windows-internals.h"
 
-#define _COMMON_PLUGIN_NAME "freebsd.plugin"
-#define _COMMON_PLUGIN_MODULE_NAME "freebsd"
+#define _COMMON_PLUGIN_NAME "windows.plugin"
+#define _COMMON_PLUGIN_MODULE_NAME "PerflibProcesses"
 #include "../common-contexts/common-contexts.h"
 
 struct processor {

--- a/src/collectors/windows.plugin/perflib-processor.c
+++ b/src/collectors/windows.plugin/perflib-processor.c
@@ -146,8 +146,7 @@ static bool do_processors(PERF_DATA_BLOCK *pDataBlock, int update_every) {
         rrddim_set_by_pointer(p->st, p->rd_idle, (collected_number)idle);
         rrdset_done(p->st);
 
-        uint64_t interrupts = p->interruptsPerSec.current.Data;
-        common_interrupts(interrupts, update_every);
+        common_interrupts(&p->interruptsPerSec, update_every);
 //        if(!p->st2) {
 //            p->st2 = rrdset_create_localhost(
 //                is_total ? "system" : "cpu2"

--- a/src/collectors/windows.plugin/perflib-processor.c
+++ b/src/collectors/windows.plugin/perflib-processor.c
@@ -147,7 +147,7 @@ static bool do_processors(PERF_DATA_BLOCK *pDataBlock, int update_every) {
         rrdset_done(p->st);
 
         uint64_t interrupts = p->interruptsPerSec.current.Data;
-        common_interrupts(interrupts, update_every, RRD_ALGORITHM_ABSOLUTE);
+        common_interrupts(interrupts, update_every);
 //        if(!p->st2) {
 //            p->st2 = rrdset_create_localhost(
 //                is_total ? "system" : "cpu2"


### PR DESCRIPTION
##### Summary
Add interrupt chart to Microsoft.

![Screenshot_20240607_013010](https://github.com/netdata/netdata/assets/49162938/6669737d-0db4-4907-b3e5-d2bf674d4f5d)


##### Test Plan

1. Compile this branch on Windows and take a look on charts.
2. Compile on Linux and verify it is still working.

##### Additional Information
This PR was tested on Slackware current and Microsoft Windows 11 Home
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
