### PR TITLE
Patch release 1.45.6

### DIFF
--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -441,7 +441,8 @@ static int http_proxy_connect(mqtt_wss_client client)
     poll_fd.events = POLLIN;
 
     r_buf_ptr = rbuf_get_linear_insert_range(r_buf, &r_buf_linear_insert_capacity);
-    snprintf(r_buf_ptr, r_buf_linear_insert_capacity,"%s %s:%d %s" HTTP_ENDLINE, PROXY_CONNECT, client->target_host, client->target_port, PROXY_HTTP);
+    snprintf(r_buf_ptr, r_buf_linear_insert_capacity,"%s %s:%d %s" HTTP_ENDLINE "Host: %s" HTTP_ENDLINE, PROXY_CONNECT,
+             client->target_host, client->target_port, PROXY_HTTP, client->target_host);
     write(client->sockfd, r_buf_ptr, strlen(r_buf_ptr));
 
     if (client->proxy_uname) {

--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -202,6 +202,7 @@ static cmd_status_t cmd_reload_labels_execute(char *args, char **message)
     (void)args;
     netdata_log_info("COMMAND: reloading host labels.");
     reload_host_labels();
+    aclk_queue_node_info(localhost, 1);
 
     BUFFER *wb = buffer_create(10, NULL);
     rrdlabels_log_to_buffer(localhost->rrdlabels, wb);

--- a/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/netlisteners.go
+++ b/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/netlisteners.go
@@ -308,12 +308,11 @@ func (e *localListenersExec) discover(ctx context.Context) ([]byte, error) {
 }
 
 func extractComm(cmdLine string) string {
-	i := strings.IndexByte(cmdLine, ' ')
-	if i <= 0 {
-		return cmdLine
+	if i := strings.IndexByte(cmdLine, ' '); i != -1 {
+		cmdLine = cmdLine[:i]
 	}
-	_, comm := filepath.Split(cmdLine[:i])
-	return comm
+	_, comm := filepath.Split(cmdLine)
+	return strings.TrimSuffix(comm, ":")
 }
 
 func calcHash(obj any) (uint64, error) {

--- a/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/netlisteners_test.go
+++ b/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/netlisteners_test.go
@@ -13,6 +13,7 @@ func TestDiscoverer_Discover(t *testing.T) {
 	tests := map[string]discoverySim{
 		"add listeners": {
 			listenersCli: func(cli listenersCli, interval, expiry time.Duration) {
+				cli.addListener("UDP|127.0.0.1|323|/usr/sbin/chronyd")
 				cli.addListener("UDP6|::1|8125|/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D")
 				cli.addListener("TCP6|::1|8125|/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D")
 				cli.addListener("TCP6|::|8125|/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D")
@@ -31,6 +32,14 @@ func TestDiscoverer_Discover(t *testing.T) {
 				provider: "sd:net_listeners",
 				source:   "discoverer=net_listeners,host=localhost",
 				targets: []model.Target{
+					withHash(&target{
+						Protocol:  "UDP",
+						IPAddress: "127.0.0.1",
+						Port:      "323",
+						Address:   "127.0.0.1:323",
+						Comm:      "chronyd",
+						Cmdline:   "/usr/sbin/chronyd",
+					}),
 					withHash(&target{
 						Protocol:  "TCP",
 						IPAddress: "127.0.0.1",


### PR DESCRIPTION
##### Summary
- go.d sd local-listeners fix extractComm (#17763)
- Schedule a node info on label reload (#17762)
- Include the Host in the HTTP header (mqtt) (#17731)
