### PR TITLE
Vendor protobuf in static builds.

### DIFF
--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -33,7 +33,6 @@ run ./netdata-installer.sh \
   --dont-start-it \
   --disable-exporting-mongodb \
   --require-cloud \
-  --use-system-protobuf \
   --dont-scrub-cflags-even-though-it-may-break-things \
   --one-time-build \
   --disable-logsmanagement \


### PR DESCRIPTION
##### Summary

There are issues detecting a system copy of Protobuf properly on newer versions of Alpine, and we’re functionally bundling whatever copy we link to for static builds _anyway_, so just use a vendored copy instead of a system copy.

This is a prerequisite for updating the base image used for building static builds tto ALpine 3.20.

##### Test Plan

CI passes for this PR.