### PR TITLE
proc/diskstats and diskspace: remove "ignore zero metrics"

### DIFF
--- a/src/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/src/collectors/diskspace.plugin/plugin_diskspace.c
@@ -212,9 +212,7 @@ static void calculate_values_and_show_charts(
 
     int rendered = 0;
 
-    if(m->do_space == CONFIG_BOOLEAN_YES || (m->do_space == CONFIG_BOOLEAN_AUTO &&
-                                             (bavail || breserved_root || bused ||
-                                              netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+    if (m->do_space == CONFIG_BOOLEAN_YES || m->do_space == CONFIG_BOOLEAN_AUTO) {
         if(unlikely(!m->st_space) || m->st_space->update_every != update_every) {
             m->do_space = CONFIG_BOOLEAN_YES;
             m->st_space = rrdset_find_active_bytype_localhost("disk_space", disk);
@@ -252,9 +250,7 @@ static void calculate_values_and_show_charts(
         rendered++;
     }
 
-    if(m->do_inodes == CONFIG_BOOLEAN_YES || (m->do_inodes == CONFIG_BOOLEAN_AUTO &&
-                                              (favail || freserved_root || fused ||
-                                               netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+    if (m->do_inodes == CONFIG_BOOLEAN_YES || m->do_inodes == CONFIG_BOOLEAN_AUTO) {
         if(unlikely(!m->st_inodes) || m->st_inodes->update_every != update_every) {
             m->do_inodes = CONFIG_BOOLEAN_YES;
             m->st_inodes = rrdset_find_active_bytype_localhost("disk_inodes", disk);

--- a/src/collectors/proc.plugin/proc_diskstats.c
+++ b/src/collectors/proc.plugin/proc_diskstats.c
@@ -1570,9 +1570,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
 
         // --------------------------------------------------------------------------
         // Do performance metrics
-        if(d->do_io == CONFIG_BOOLEAN_YES || (d->do_io == CONFIG_BOOLEAN_AUTO &&
-                                              (readsectors || writesectors || discardsectors ||
-                                               netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+        if (d->do_io == CONFIG_BOOLEAN_YES || d->do_io == CONFIG_BOOLEAN_AUTO) {
             d->do_io = CONFIG_BOOLEAN_YES;
 
             last_readsectors = d->disk_io.rd_io_reads ? d->disk_io.rd_io_reads->collector.last_collected_value / SECTOR_SIZE : 0;
@@ -1614,9 +1612,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
             rrdset_done(d->st_ext_io);
         }
 
-        if(d->do_ops == CONFIG_BOOLEAN_YES || (d->do_ops == CONFIG_BOOLEAN_AUTO &&
-                                               (reads || writes || discards || flushes ||
-                                                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+        if (d->do_ops == CONFIG_BOOLEAN_YES || d->do_ops == CONFIG_BOOLEAN_AUTO) {
             d->do_ops = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!d->st_ops)) {
@@ -1680,8 +1676,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
             rrdset_done(d->st_ext_ops);
         }
 
-        if(d->do_qops == CONFIG_BOOLEAN_YES || (d->do_qops == CONFIG_BOOLEAN_AUTO &&
-                                                (queued_ios || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+        if (d->do_qops == CONFIG_BOOLEAN_YES || d->do_qops == CONFIG_BOOLEAN_AUTO) {
             d->do_qops = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!d->st_qops)) {
@@ -1711,8 +1706,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
             rrdset_done(d->st_qops);
         }
 
-        if(d->do_backlog == CONFIG_BOOLEAN_YES || (d->do_backlog == CONFIG_BOOLEAN_AUTO &&
-                                                   (backlog_ms || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+        if (d->do_backlog == CONFIG_BOOLEAN_YES || d->do_backlog == CONFIG_BOOLEAN_AUTO) {
             d->do_backlog = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!d->st_backlog)) {
@@ -1742,8 +1736,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
             rrdset_done(d->st_backlog);
         }
 
-        if(d->do_util == CONFIG_BOOLEAN_YES || (d->do_util == CONFIG_BOOLEAN_AUTO &&
-                                                (busy_ms || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+        if (d->do_util == CONFIG_BOOLEAN_YES || d->do_util == CONFIG_BOOLEAN_AUTO) {
             d->do_util = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!d->st_busy)) {
@@ -1803,9 +1796,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
             rrdset_done(d->st_util);
         }
 
-        if(d->do_mops == CONFIG_BOOLEAN_YES || (d->do_mops == CONFIG_BOOLEAN_AUTO &&
-                                                (mreads || mwrites || mdiscards ||
-                                                 netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+        if (d->do_mops == CONFIG_BOOLEAN_YES || d->do_mops == CONFIG_BOOLEAN_AUTO) {
             d->do_mops = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!d->st_mops)) {
@@ -1867,8 +1858,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
             rrdset_done(d->st_ext_mops);
         }
 
-        if(d->do_iotime == CONFIG_BOOLEAN_YES || (d->do_iotime == CONFIG_BOOLEAN_AUTO &&
-                                                  (readms || writems || discardms || flushms || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+        if (d->do_iotime == CONFIG_BOOLEAN_YES || d->do_iotime == CONFIG_BOOLEAN_AUTO) {
             d->do_iotime = CONFIG_BOOLEAN_YES;
 
             if(unlikely(!d->st_iotime)) {
@@ -1936,13 +1926,8 @@ int do_proc_diskstats(int update_every, usec_t dt) {
         // only if this is not the first time we run
 
         if(likely(dt)) {
-            if( (d->do_iotime == CONFIG_BOOLEAN_YES || (d->do_iotime == CONFIG_BOOLEAN_AUTO &&
-                                                        (readms || writems ||
-                                                         netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) &&
-                (d->do_ops    == CONFIG_BOOLEAN_YES || (d->do_ops    == CONFIG_BOOLEAN_AUTO &&
-                                                        (reads || writes ||
-                                                         netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))) {
-
+            if ((d->do_iotime == CONFIG_BOOLEAN_YES || d->do_iotime == CONFIG_BOOLEAN_AUTO) &&
+                (d->do_ops == CONFIG_BOOLEAN_YES || d->do_ops == CONFIG_BOOLEAN_AUTO)) {
                 if(unlikely(!d->st_await)) {
                     d->st_await = rrdset_create_localhost(
                             "disk_await"
@@ -2010,11 +1995,8 @@ int do_proc_diskstats(int update_every, usec_t dt) {
                 rrdset_done(d->st_ext_await);
             }
 
-            if( (d->do_io  == CONFIG_BOOLEAN_YES || (d->do_io  == CONFIG_BOOLEAN_AUTO &&
-                                                     (readsectors || writesectors || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) &&
-                (d->do_ops == CONFIG_BOOLEAN_YES || (d->do_ops == CONFIG_BOOLEAN_AUTO &&
-                                                     (reads || writes || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))) {
-
+            if ((d->do_io == CONFIG_BOOLEAN_YES || d->do_io == CONFIG_BOOLEAN_AUTO) &&
+                (d->do_ops == CONFIG_BOOLEAN_YES || d->do_ops == CONFIG_BOOLEAN_AUTO)) {
                 if(unlikely(!d->st_avgsz)) {
                     d->st_avgsz = rrdset_create_localhost(
                             "disk_avgsz"
@@ -2075,13 +2057,8 @@ int do_proc_diskstats(int update_every, usec_t dt) {
                 rrdset_done(d->st_ext_avgsz);
             }
 
-            if( (d->do_util == CONFIG_BOOLEAN_YES || (d->do_util == CONFIG_BOOLEAN_AUTO &&
-                                                      (busy_ms ||
-                                                       netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) &&
-                (d->do_ops  == CONFIG_BOOLEAN_YES || (d->do_ops  == CONFIG_BOOLEAN_AUTO &&
-                                                      (reads || writes ||
-                                                       netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))) {
-
+            if ((d->do_util == CONFIG_BOOLEAN_YES || d->do_util == CONFIG_BOOLEAN_AUTO) &&
+                (d->do_ops == CONFIG_BOOLEAN_YES || d->do_ops == CONFIG_BOOLEAN_AUTO)) {
                 if(unlikely(!d->st_svctm)) {
                     d->st_svctm = rrdset_create_localhost(
                             "disk_svctm"
@@ -2328,12 +2305,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
                 rrdset_done(d->st_bcache_cache_read_races);
             }
 
-            if(d->do_bcache == CONFIG_BOOLEAN_YES || (d->do_bcache == CONFIG_BOOLEAN_AUTO &&
-                                                      (stats_total_cache_hits ||
-                                                       stats_total_cache_misses ||
-                                                       stats_total_cache_miss_collisions ||
-                                                       netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
-
+            if (d->do_bcache == CONFIG_BOOLEAN_YES || d->do_bcache == CONFIG_BOOLEAN_AUTO) {
                 if(unlikely(!d->st_bcache)) {
                     d->st_bcache = rrdset_create_localhost(
                             "disk_bcache"
@@ -2367,11 +2339,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
                 rrdset_done(d->st_bcache);
             }
 
-            if(d->do_bcache == CONFIG_BOOLEAN_YES || (d->do_bcache == CONFIG_BOOLEAN_AUTO &&
-                                                      (stats_total_cache_bypass_hits ||
-                                                       stats_total_cache_bypass_misses ||
-                                                       netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
-
+            if (d->do_bcache == CONFIG_BOOLEAN_YES || d->do_bcache == CONFIG_BOOLEAN_AUTO) {
                 if(unlikely(!d->st_bcache_bypass)) {
                     d->st_bcache_bypass = rrdset_create_localhost(
                             "disk_bcache_bypass"
@@ -2410,9 +2378,7 @@ int do_proc_diskstats(int update_every, usec_t dt) {
     netdata_mutex_unlock(&diskstats_dev_mutex);
     // update the system total I/O
 
-    if(global_do_io == CONFIG_BOOLEAN_YES || (global_do_io == CONFIG_BOOLEAN_AUTO &&
-                                              (system_read_kb || system_write_kb ||
-                                               netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))) {
+    if (global_do_io == CONFIG_BOOLEAN_YES || global_do_io == CONFIG_BOOLEAN_AUTO) {
         common_system_io(system_read_kb * 1024, system_write_kb * 1024, update_every);
     }
 


### PR DESCRIPTION
##### Summary

Netdata ignores some system metrics as long as their value is 0. This logic was originally applied to various types of errors, and the goal was to reduce the overall number of metrics collected (less memory usage, less disk space). This is no longer a problem with the current version of dbengine (zstd compression + gorilla compression).

Ignoring zero metrics leads to unobvious problems. For instance, missing charts after a server reboot.

There will be multiple PRs to remove this "ignore zero metrics" logic from different collectors. This PR removes it from:

- proc/diskstats
- diskspace

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
