### PR TITLE
go.d phpfpm switch to github.com/kanocz/fcgi_client

### DIFF
--- a/src/go/collectors/go.d.plugin/go.mod
+++ b/src/go/collectors/go.d.plugin/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/ilyam8/hashstructure v1.1.0
 	github.com/jackc/pgx/v4 v4.18.3
 	github.com/jessevdk/go-flags v1.5.0
+	github.com/kanocz/fcgi_client v0.0.0-20210113082628-fff85c8adfb7
 	github.com/likexian/whois v1.15.3
 	github.com/likexian/whois-parser v1.24.16
 	github.com/lmittmann/tint v1.0.4
@@ -41,7 +42,6 @@ require (
 	github.com/prometheus/prometheus v2.5.0+incompatible
 	github.com/stretchr/testify v1.9.0
 	github.com/tidwall/gjson v1.17.1
-	github.com/tomasen/fcgi_client v0.0.0-20180423082037-2bb3d819fd19
 	github.com/valyala/fastjson v1.6.4
 	github.com/vmware/govmomi v0.37.2
 	go.mongodb.org/mongo-driver v1.15.0

--- a/src/go/collectors/go.d.plugin/go.sum
+++ b/src/go/collectors/go.d.plugin/go.sum
@@ -195,6 +195,8 @@ github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtL
 github.com/josharian/native v1.1.0/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kanocz/fcgi_client v0.0.0-20210113082628-fff85c8adfb7 h1:W0fAsQ7bC1db4k9O2X6yZvatz/0c/ISyxhmNnc6arZA=
+github.com/kanocz/fcgi_client v0.0.0-20210113082628-fff85c8adfb7/go.mod h1:dHpIS7C6YjFguh5vo9QBVEojDoL3vh3v6oEho2HtNyA=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
@@ -338,8 +340,6 @@ github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
-github.com/tomasen/fcgi_client v0.0.0-20180423082037-2bb3d819fd19 h1:ZCmSnT6CLGhfoQ2lPEhL4nsJstKDCw1F1RfN8/smTCU=
-github.com/tomasen/fcgi_client v0.0.0-20180423082037-2bb3d819fd19/go.mod h1:SXTY+QvI+KTTKXQdg0zZ7nx0u94QWh8ZAwBQYsW9cqk=
 github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXVQ=
 github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/vmware/govmomi v0.37.2 h1:5ANLoaTxWv600ZnoosJ2zXbM3A+EaxqGheEZbRN8YVE=

--- a/src/go/collectors/go.d.plugin/modules/phpfpm/client.go
+++ b/src/go/collectors/go.d.plugin/modules/phpfpm/client.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/netdata/netdata/go/go.d.plugin/pkg/web"
 
-	fcgiclient "github.com/tomasen/fcgi_client"
+	fcgiclient "github.com/kanocz/fcgi_client"
 )
 
 type (
@@ -128,6 +128,10 @@ func (c *socketClient) getStatus() (*status, error) {
 	}
 	defer socket.Close()
 
+	if err := socket.SetTimeout(c.timeout); err != nil {
+		return nil, fmt.Errorf("error on setting socket timeout: %v", err)
+	}
+
 	resp, err := socket.Get(c.env)
 	if err != nil {
 		return nil, fmt.Errorf("error on getting data from socket '%s': %v", c.socket, err)
@@ -142,6 +146,7 @@ func (c *socketClient) getStatus() (*status, error) {
 	if err := json.Unmarshal(content, st); err != nil {
 		return nil, fmt.Errorf("error on decoding response from socket '%s': %v", c.socket, err)
 	}
+
 	return st, nil
 }
 


### PR DESCRIPTION
##### Summary

Because the upstream fcgi_client library:
- doesn't implement connection read/write timeout
- seems to be unmaintained: PR with read/write timeout has been hanging since 2021

Switching to fork with timeout - https://github.com/kanocz/fcgi_client.

See https://github.com/netdata/netdata/issues/17780#issuecomment-2139227972 for details.

Fixes: #17780

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
