### PR TITLE
Use correct path for package files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,7 +231,7 @@ if(NEED_PROTOBUF)
         endif()
 endif()
 
-set(PKG_FILES_PATH "packaging/cmake/pkg-files")
+set(PKG_FILES_PATH "${CMAKE_SOURCE_DIR}/packaging/cmake/pkg-files")
 
 if(ENABLE_PLUGIN_EBPF)
         include(NetdataLibBPF)


### PR DESCRIPTION
##### Summary

SSIA.

##### Test Plan

`cpack -G DEB` should not print any missing files warnings.
