### PR TITLE
cgroup plugin: simplify and remove "ignore zero metrics"

### DIFF
--- a/src/collectors/cgroups.plugin/README.md
+++ b/src/collectors/cgroups.plugin/README.md
@@ -17,9 +17,9 @@ processes. When cgroups are bundled with namespaces (i.e. isolation), they form 
 cgroups are hierarchical, meaning that cgroups can contain child cgroups, which can contain more cgroups, etc. All
 accounting is reported (and resource usage limits are applied) also in a hierarchical way.
 
-To visualize cgroup metrics Netdata provides configuration for cherry picking the cgroups of interest. By default (
-without any configuration) Netdata should pick **systemd services**, all kinds of **containers** (lxc, docker, etc)
-and **virtual machines** spawn by managers that register them with cgroups (qemu, libvirt, etc).
+To visualize cgroup metrics Netdata provides configuration for cherry-picking the cgroups of interest. By default,
+Netdata should pick **systemd services**, all kinds of **containers** (lxc, docker, etc.) and **virtual machines** spawn
+by managers that register them with cgroups (qemu, libvirt, etc.).
 
 ## Configuring Netdata for cgroups
 
@@ -29,19 +29,10 @@ collects their metrics.
 ### How Netdata finds the available cgroups
 
 Linux exposes resource usage reporting and provides dynamic configuration for cgroups, using virtual files (usually)
-under `/sys/fs/cgroup`. Netdata reads `/proc/self/mountinfo` to detect the exact mount point of cgroups. Netdata also
-allows manual configuration of this mount point, using these settings:
+under `/sys/fs/cgroup`. Netdata reads `/proc/self/mountinfo` to detect the exact mount point of cgroups.
 
-```text
-[plugin:cgroups]
-	check for new cgroups every = 10
-	path to /sys/fs/cgroup/cpuacct = /sys/fs/cgroup/cpuacct
-	path to /sys/fs/cgroup/blkio = /sys/fs/cgroup/blkio
-	path to /sys/fs/cgroup/memory = /sys/fs/cgroup/memory
-	path to /sys/fs/cgroup/devices = /sys/fs/cgroup/devices
-```
-
-Netdata rescans these directories for added or removed cgroups every `check for new cgroups every` seconds.
+Netdata rescans directories inside `/sys/fs/cgroup` for added or removed cgroups every `checking for new cgroups every`
+seconds.
 
 ### Hierarchical search for cgroups
 
@@ -60,20 +51,6 @@ So, we disable checking for **child cgroups** in systemd internal
 cgroups ([systemd services are monitored by Netdata](#monitoring-systemd-services)), user cgroups (normally used for
 desktop and remote user sessions), qemu virtual machines (child cgroups of virtual machines) and `init.scope`. All
 others are enabled.
-
-### Unified cgroups (cgroups v2) support
-
-Netdata automatically detects cgroups version. If detection fails Netdata assumes v1.
-To switch to v2 manually add:
-
-```text
-[plugin:cgroups]
-	use unified cgroups = yes
-	path to unified cgroups = /sys/fs/cgroup
-```
-
-Unified cgroups use same name pattern matching as v1 cgroups. `cgroup_enable_systemd_services_detailed_memory` is
-currently unsupported when using unified cgroups.
 
 ### Enabled cgroups
 
@@ -120,36 +97,21 @@ container names. To do this, ensure `podman system service` is running and Netda
 to `/run/podman/podman.sock` (the default permissions as specified by upstream are `0600`, with owner `root`, so you
 will have to adjust the configuration).
 
-[Docker Socket Proxy (HAProxy)](https://github.com/Tecnativa/docker-socket-proxy) or [CetusGuard](https://github.com/hectorm/cetusguard)
-can also be used to give Netdata restricted access to the socket. Note that `PODMAN_HOST` in Netdata's environment should
-be set to the proxy's URL in this case.
-
-### Charts with zero metrics
-
-By default, Netdata will enable monitoring metrics only when they are not zero. If they are constantly zero they are
-ignored. Metrics that will start having values, after Netdata is started, will be detected and charts will be
-automatically added to the dashboard (a refresh of the dashboard is needed for them to appear though). Set `yes` for a
-chart instead of `auto` to enable it permanently. For example:
-
-```text
-[plugin:cgroups]
-	enable memory (used mem including cache) = yes
-```
-
-You can also set the `enable zero metrics` option to `yes` in the `[global]` section which enables charts with zero
-metrics for all internal Netdata plugins.
+[Docker Socket Proxy (HAProxy)](https://github.com/Tecnativa/docker-socket-proxy)
+or [CetusGuard](https://github.com/hectorm/cetusguard)
+can also be used to give Netdata restricted access to the socket. Note that `PODMAN_HOST` in Netdata's environment
+should be set to the proxy's URL in this case.
 
 ### Alerts
 
 CPU and memory limits are watched and used to rise alerts. Memory usage for every cgroup is checked against `ram`
-and `ram+swap` limits. CPU usage for every cgroup is checked against `cpuset.cpus` and `cpu.cfs_period_us` + `cpu.cfs_quota_us` pair assigned for the cgroup. Configuration for the alerts is available in `health.d/cgroups.conf`
-file.
+and `ram+swap` limits. CPU usage for every cgroup is checked against `cpuset.cpus`
+and `cpu.cfs_period_us` + `cpu.cfs_quota_us` pair assigned for the cgroup. Configuration for the alerts is available
+in `health.d/cgroups.conf` file.
 
 ## Monitoring systemd services
 
-Netdata monitors **systemd services**. Example:
-
-![image](https://cloud.githubusercontent.com/assets/2662304/21964372/20cd7b84-db53-11e6-98a2-b9c986b082c0.png)
+Netdata monitors **systemd services**.
 
 Support per distribution:
 
@@ -233,7 +195,8 @@ sudo systemctl daemon-reexec
 (`systemctl daemon-reload` does not reload the configuration of the server - so you have to
 execute `systemctl daemon-reexec`).
 
-Now, when you run `systemd-cgtop`, services will start reporting usage (if it does not, restart any service to wake it up). Refresh your Netdata dashboard, and you will have the charts too.
+Now, when you run `systemd-cgtop`, services will start reporting usage (if it does not, restart any service to wake it
+up). Refresh your Netdata dashboard, and you will have the charts too.
 
 In case memory accounting is missing, you will need to enable it at your kernel, by appending the following kernel boot
 options and rebooting:
@@ -260,15 +223,15 @@ Which systemd services are monitored by Netdata is determined by the following p
 Netdata monitors containers automatically when it is installed at the host, or when it is installed in a container that
 has access to the `/proc` and `/sys` filesystems of the host.
 
-Network interfaces and cgroups (containers) are self-cleaned. When a network interface or container stops, Netdata might log 
-a few errors in error.log complaining about files it cannot find, but immediately:
+Network interfaces and cgroups (containers) are self-cleaned. When a network interface or container stops, Netdata might
+log a few errors in error.log complaining about files it cannot find, but immediately:
 
 1. It will detect this is a removed container or network interface
 2. It will freeze/pause all alerts for them
 3. It will mark their charts as obsolete
 4. Obsolete charts are not be offered on new dashboard sessions (so hit F5 and the charts are gone)
 5. Existing dashboard sessions will continue to see them, but of course they will not refresh
-6. Obsolete charts will be removed from memory, 1 hour after the last user viewed them (configurable
+6. Obsolete charts will be removed from memory, 1 hour after the last user viewed them (configurable)
    with `[global].cleanup obsolete charts after seconds = 3600` (at `netdata.conf`).
 
 ### Monitored container metrics

--- a/src/collectors/cgroups.plugin/cgroup-charts.c
+++ b/src/collectors/cgroups.plugin/cgroup-charts.c
@@ -17,7 +17,7 @@ void update_cpu_utilization_chart(struct cgroup *cg) {
         } else {
             title = k8s_is_kubepod(cg) ? "CPU Usage (100%% = 1000 mCPU)" : "CPU Usage (100%% = 1 core)";
             context = k8s_is_kubepod(cg) ? "k8s.cgroup.cpu" : "cgroup.cpu";
-            prio = cgroup_containers_chart_priority;
+            prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS;
         }
 
         char buff[RRD_ID_LENGTH_MAX + 1];
@@ -60,7 +60,7 @@ void update_cpu_utilization_limit_chart(struct cgroup *cg, NETDATA_DOUBLE cpu_li
     if (unlikely(!cg->st_cpu_limit)) {
         char *title = "CPU Usage within the limits";
         char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.cpu_limit" : "cgroup.cpu_limit";
-        int prio = cgroup_containers_chart_priority - 1;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS - 1;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = cg->st_cpu_limit = rrdset_create_localhost(
@@ -109,7 +109,7 @@ void update_cpu_throttled_chart(struct cgroup *cg) {
     if (unlikely(!cg->st_cpu_nr_throttled)) {
         char *title = "CPU Throttled Runnable Periods";
         char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.throttled" : "cgroup.throttled";
-        int prio = cgroup_containers_chart_priority + 10;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 10;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = cg->st_cpu_nr_throttled = rrdset_create_localhost(
@@ -143,7 +143,7 @@ void update_cpu_throttled_duration_chart(struct cgroup *cg) {
     if (unlikely(!cg->st_cpu_throttled_time)) {
         char *title = "CPU Throttled Time Duration";
         char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.throttled_duration" : "cgroup.throttled_duration";
-        int prio = cgroup_containers_chart_priority + 15;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 15;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = cg->st_cpu_throttled_time = rrdset_create_localhost(
@@ -177,7 +177,7 @@ void update_cpu_shares_chart(struct cgroup *cg) {
     if (unlikely(!cg->st_cpu_shares)) {
         char *title = "CPU Time Relative Share";
         char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.cpu_shares" : "cgroup.cpu_shares";
-        int prio = cgroup_containers_chart_priority + 20;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 20;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = cg->st_cpu_shares = rrdset_create_localhost(
@@ -212,7 +212,7 @@ void update_cpu_per_core_usage_chart(struct cgroup *cg) {
     if (unlikely(!cg->st_cpu_per_core)) {
         char *title = k8s_is_kubepod(cg) ? "CPU Usage (100%% = 1000 mCPU) Per Core" : "CPU Usage (100%% = 1 core) Per Core";
         char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.cpu_per_core" : "cgroup.cpu_per_core";
-        int prio = cgroup_containers_chart_priority + 100;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 100;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         cg->st_cpu_per_core = rrdset_create_localhost(
@@ -258,7 +258,7 @@ void update_mem_usage_detailed_chart(struct cgroup *cg) {
         } else {
             title = "Memory Usage";
             context = k8s_is_kubepod(cg) ? "k8s.cgroup.mem" : "cgroup.mem";
-            prio = cgroup_containers_chart_priority + 220;
+            prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 220;
         }
 
         char buff[RRD_ID_LENGTH_MAX + 1];
@@ -333,7 +333,7 @@ void update_mem_writeback_chart(struct cgroup *cg) {
         } else {
             title = "Writeback Memory";
             context = k8s_is_kubepod(cg) ? "k8s.cgroup.writeback" : "cgroup.writeback";
-            prio = cgroup_containers_chart_priority + 300;
+            prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 300;
         }
 
         char buff[RRD_ID_LENGTH_MAX + 1];
@@ -377,7 +377,7 @@ void update_mem_activity_chart(struct cgroup *cg) {
         } else {
             title = "Memory Activity";
             context = k8s_is_kubepod(cg) ? "k8s.cgroup.mem_activity" : "cgroup.mem_activity";
-            prio = cgroup_containers_chart_priority + 400;
+            prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 400;
         }
 
         char buff[RRD_ID_LENGTH_MAX + 1];
@@ -420,7 +420,7 @@ void update_mem_pgfaults_chart(struct cgroup *cg) {
         } else {
             title = "Memory Page Faults";
             context = k8s_is_kubepod(cg) ? "k8s.cgroup.pgfaults" : "cgroup.pgfaults";
-            prio = cgroup_containers_chart_priority + 500;
+            prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 500;
         }
 
         char buff[RRD_ID_LENGTH_MAX + 1];
@@ -457,7 +457,7 @@ void update_mem_usage_limit_chart(struct cgroup *cg, unsigned long long memory_l
     if (unlikely(!cg->st_mem_usage_limit)) {
         char *title = "Used RAM within the limits";
         char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.mem_usage_limit" : "cgroup.mem_usage_limit";
-        int prio = cgroup_containers_chart_priority + 200;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 200;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = cg->st_mem_usage_limit = rrdset_create_localhost(
@@ -496,7 +496,7 @@ void update_mem_utilization_chart(struct cgroup *cg, unsigned long long memory_l
     if (unlikely(!cg->st_mem_utilization)) {
         char *title = "Memory Utilization";
         char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.mem_utilization" : "cgroup.mem_utilization";
-        int prio = cgroup_containers_chart_priority + 199;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 199;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = cg->st_mem_utilization = rrdset_create_localhost(
@@ -538,7 +538,7 @@ void update_mem_failcnt_chart(struct cgroup *cg) {
         } else {
             title = "Memory Limit Failures";
             context = k8s_is_kubepod(cg) ? "k8s.cgroup.mem_failcnt" : "cgroup.mem_failcnt";
-            prio = cgroup_containers_chart_priority + 250;
+            prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 250;
         }
 
         char buff[RRD_ID_LENGTH_MAX + 1];
@@ -578,7 +578,7 @@ void update_mem_usage_chart(struct cgroup *cg) {
         } else {
             title = "Used Memory";
             context = k8s_is_kubepod(cg) ? "k8s.cgroup.mem_usage" : "cgroup.mem_usage";
-            prio = cgroup_containers_chart_priority + 210;
+            prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 210;
         }
 
         char buff[RRD_ID_LENGTH_MAX + 1];
@@ -633,7 +633,7 @@ void update_io_serviced_bytes_chart(struct cgroup *cg) {
         } else {
             title = "I/O Bandwidth (all disks)";
             context = k8s_is_kubepod(cg) ? "k8s.cgroup.io" : "cgroup.io";
-            prio = cgroup_containers_chart_priority + 1200;
+            prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 1200;
         }
 
         char buff[RRD_ID_LENGTH_MAX + 1];
@@ -675,7 +675,7 @@ void update_io_serviced_ops_chart(struct cgroup *cg) {
         } else {
             title = "Serviced I/O Operations (all disks)";
             context = k8s_is_kubepod(cg) ? "k8s.cgroup.serviced_ops" : "cgroup.serviced_ops";
-            prio = cgroup_containers_chart_priority + 1200;
+            prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 1200;
         }
 
         char buff[RRD_ID_LENGTH_MAX + 1];
@@ -717,7 +717,7 @@ void update_throttle_io_serviced_bytes_chart(struct cgroup *cg) {
         } else {
             title = "Throttle I/O Bandwidth (all disks)";
             context = k8s_is_kubepod(cg) ? "k8s.cgroup.throttle_io" : "cgroup.throttle_io";
-            prio = cgroup_containers_chart_priority + 1200;
+            prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 1200;
         }
 
         char buff[RRD_ID_LENGTH_MAX + 1];
@@ -760,7 +760,7 @@ void update_throttle_io_serviced_ops_chart(struct cgroup *cg) {
         } else {
             title = "Throttle Serviced I/O Operations (all disks)";
             context = k8s_is_kubepod(cg) ? "k8s.cgroup.throttle_serviced_ops" : "cgroup.throttle_serviced_ops";
-            prio = cgroup_containers_chart_priority + 1200;
+            prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 1200;
         }
 
         char buff[RRD_ID_LENGTH_MAX + 1];
@@ -802,7 +802,7 @@ void update_io_queued_ops_chart(struct cgroup *cg) {
         } else {
             title = "Queued I/O Operations (all disks)";
             context = k8s_is_kubepod(cg) ? "k8s.cgroup.queued_ops" : "cgroup.queued_ops";
-            prio = cgroup_containers_chart_priority + 2000;
+            prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2000;
         }
 
         char buff[RRD_ID_LENGTH_MAX + 1];
@@ -844,7 +844,7 @@ void update_io_merged_ops_chart(struct cgroup *cg) {
         } else {
             title = "Merged I/O Operations (all disks)";
             context = k8s_is_kubepod(cg) ? "k8s.cgroup.merged_ops" : "cgroup.merged_ops";
-            prio = cgroup_containers_chart_priority + 2100;
+            prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2100;
         }
 
         char buff[RRD_ID_LENGTH_MAX + 1];
@@ -883,7 +883,7 @@ void update_cpu_some_pressure_chart(struct cgroup *cg) {
     if (unlikely(!pcs->share_time.st)) {
         char *title = "CPU some pressure";
         char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.cpu_some_pressure" : "cgroup.cpu_some_pressure";
-        int prio = cgroup_containers_chart_priority + 2200;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2200;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = pcs->share_time.st = rrdset_create_localhost(
@@ -924,7 +924,7 @@ void update_cpu_some_pressure_stall_time_chart(struct cgroup *cg) {
         char *title = "CPU some pressure stall time";
         char *context =
             k8s_is_kubepod(cg) ? "k8s.cgroup.cpu_some_pressure_stall_time" : "cgroup.cpu_some_pressure_stall_time";
-        int prio = cgroup_containers_chart_priority + 2220;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2220;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = pcs->total_time.st = rrdset_create_localhost(
@@ -959,7 +959,7 @@ void update_cpu_full_pressure_chart(struct cgroup *cg) {
     if (unlikely(!pcs->share_time.st)) {
         char *title = "CPU full pressure";
         char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.cpu_full_pressure" : "cgroup.cpu_full_pressure";
-        int prio = cgroup_containers_chart_priority + 2240;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2240;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = pcs->share_time.st = rrdset_create_localhost(
@@ -1000,7 +1000,7 @@ void update_cpu_full_pressure_stall_time_chart(struct cgroup *cg) {
         char *title = "CPU full pressure stall time";
         char *context =
             k8s_is_kubepod(cg) ? "k8s.cgroup.cpu_full_pressure_stall_time" : "cgroup.cpu_full_pressure_stall_time";
-        int prio = cgroup_containers_chart_priority + 2260;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2260;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = pcs->total_time.st = rrdset_create_localhost(
@@ -1036,7 +1036,7 @@ void update_mem_some_pressure_chart(struct cgroup *cg) {
     if (unlikely(!pcs->share_time.st)) {
         char *title = "Memory some pressure";
         char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.memory_some_pressure" : "cgroup.memory_some_pressure";
-        int prio = cgroup_containers_chart_priority + 2300;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2300;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = pcs->share_time.st = rrdset_create_localhost(
@@ -1077,7 +1077,7 @@ void update_mem_some_pressure_stall_time_chart(struct cgroup *cg) {
         char *title = "Memory some pressure stall time";
         char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.memory_some_pressure_stall_time" :
                                              "cgroup.memory_some_pressure_stall_time";
-        int prio = cgroup_containers_chart_priority + 2320;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2320;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = pcs->total_time.st = rrdset_create_localhost(
@@ -1113,7 +1113,7 @@ void update_mem_full_pressure_chart(struct cgroup *cg) {
     if (unlikely(!pcs->share_time.st)) {
         char *title = "Memory full pressure";
         char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.memory_full_pressure" : "cgroup.memory_full_pressure";
-        int prio = cgroup_containers_chart_priority + 2340;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2340;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = pcs->share_time.st = rrdset_create_localhost(
@@ -1154,7 +1154,7 @@ void update_mem_full_pressure_stall_time_chart(struct cgroup *cg) {
         char *title = "Memory full pressure stall time";
         char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.memory_full_pressure_stall_time" :
                                              "cgroup.memory_full_pressure_stall_time";
-        int prio = cgroup_containers_chart_priority + 2360;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2360;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = pcs->total_time.st = rrdset_create_localhost(
@@ -1189,7 +1189,7 @@ void update_irq_some_pressure_chart(struct cgroup *cg) {
     if (unlikely(!pcs->share_time.st)) {
         char *title = "IRQ some pressure";
         char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.irq_some_pressure" : "cgroup.irq_some_pressure";
-        int prio = cgroup_containers_chart_priority + 2310;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2310;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = pcs->share_time.st = rrdset_create_localhost(
@@ -1230,7 +1230,7 @@ void update_irq_some_pressure_stall_time_chart(struct cgroup *cg) {
         char *title = "IRQ some pressure stall time";
         char *context =
             k8s_is_kubepod(cg) ? "k8s.cgroup.irq_some_pressure_stall_time" : "cgroup.irq_some_pressure_stall_time";
-        int prio = cgroup_containers_chart_priority + 2330;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2330;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = pcs->total_time.st = rrdset_create_localhost(
@@ -1266,7 +1266,7 @@ void update_irq_full_pressure_chart(struct cgroup *cg) {
     if (unlikely(!pcs->share_time.st)) {
         char *title = "IRQ full pressure";
         char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.irq_full_pressure" : "cgroup.irq_full_pressure";
-        int prio = cgroup_containers_chart_priority + 2350;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2350;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = pcs->share_time.st = rrdset_create_localhost(
@@ -1307,7 +1307,7 @@ void update_irq_full_pressure_stall_time_chart(struct cgroup *cg) {
         char *title = "IRQ full pressure stall time";
         char *context =
             k8s_is_kubepod(cg) ? "k8s.cgroup.irq_full_pressure_stall_time" : "cgroup.irq_full_pressure_stall_time";
-        int prio = cgroup_containers_chart_priority + 2370;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2370;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = pcs->total_time.st = rrdset_create_localhost(
@@ -1343,7 +1343,7 @@ void update_io_some_pressure_chart(struct cgroup *cg) {
     if (unlikely(!pcs->share_time.st)) {
         char *title = "I/O some pressure";
         char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.io_some_pressure" : "cgroup.io_some_pressure";
-        int prio = cgroup_containers_chart_priority + 2400;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2400;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = pcs->share_time.st = rrdset_create_localhost(
@@ -1384,7 +1384,7 @@ void update_io_some_pressure_stall_time_chart(struct cgroup *cg) {
         char *title = "I/O some pressure stall time";
         char *context =
             k8s_is_kubepod(cg) ? "k8s.cgroup.io_some_pressure_stall_time" : "cgroup.io_some_pressure_stall_time";
-        int prio = cgroup_containers_chart_priority + 2420;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2420;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = pcs->total_time.st = rrdset_create_localhost(
@@ -1419,7 +1419,7 @@ void update_io_full_pressure_chart(struct cgroup *cg) {
     if (unlikely(!pcs->share_time.st)) {
         char *title = "I/O full pressure";
         char *context = k8s_is_kubepod(cg) ? "k8s.cgroup.io_full_pressure" : "cgroup.io_full_pressure";
-        int prio = cgroup_containers_chart_priority + 2440;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2440;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = pcs->share_time.st = rrdset_create_localhost(
@@ -1460,7 +1460,7 @@ void update_io_full_pressure_stall_time_chart(struct cgroup *cg) {
         char *title = "I/O full pressure stall time";
         char *context =
             k8s_is_kubepod(cg) ? "k8s.cgroup.io_full_pressure_stall_time" : "cgroup.io_full_pressure_stall_time";
-        int prio = cgroup_containers_chart_priority + 2460;
+        int prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2460;
 
         char buff[RRD_ID_LENGTH_MAX + 1];
         chart = pcs->total_time.st = rrdset_create_localhost(
@@ -1499,7 +1499,7 @@ void update_pids_current_chart(struct cgroup *cg) {
         } else {
             title = "Number of processes";
             context = k8s_is_kubepod(cg) ? "k8s.cgroup.pids_current" : "cgroup.pids_current";
-            prio = cgroup_containers_chart_priority + 2150;
+            prio = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS + 2150;
         }
 
         char buff[RRD_ID_LENGTH_MAX + 1];
@@ -1521,6 +1521,6 @@ void update_pids_current_chart(struct cgroup *cg) {
         cg->st_pids_rd_pids_current = rrddim_add(chart, "pids", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
     }
 
-    rrddim_set_by_pointer(chart, cg->st_pids_rd_pids_current, (collected_number)cg->pids.pids_current);
+    rrddim_set_by_pointer(chart, cg->st_pids_rd_pids_current, (collected_number)cg->pids_current.pids_current);
     rrdset_done(chart);
 }

--- a/src/collectors/cgroups.plugin/cgroup-discovery.c
+++ b/src/collectors/cgroups.plugin/cgroup-discovery.c
@@ -110,7 +110,7 @@ static inline void cgroup_free(struct cgroup *cg) {
 
     freez(cg->io_merged.filename);
     freez(cg->io_queued.filename);
-    freez(cg->pids.pids_current_filename);
+    freez(cg->pids_current.filename);
 
     free_pressure(&cg->cpu_pressure);
     free_pressure(&cg->io_pressure);
@@ -249,11 +249,6 @@ static void is_cgroup_procs_exist(netdata_ebpf_cgroup_shm_body_t *out, char *id)
         return;
     }
 
-    snprintfz(out->path, FILENAME_MAX, "%s%s/cgroup.procs", cgroup_devices_base, id);
-    if (likely(stat(out->path, &buf) == 0)) {
-        return;
-    }
-
     out->path[0] = '\0';
     out->enabled = 0;
 }
@@ -351,12 +346,10 @@ static int calc_cgroup_depth(const char *id) {
     return depth;
 }
 
-static inline void discovery_find_cgroup_in_dir_callback(const char *dir) {
+static inline void discovery_find_cgroup_in_dir(const char *dir) {
     if (!dir || !*dir) {
         dir = "/";
     }
-
-    netdata_log_debug(D_CGROUP, "examining cgroup dir '%s'", dir);
 
     struct cgroup *cg = discovery_cgroup_find(dir);
     if (cg) {
@@ -385,40 +378,41 @@ static inline void discovery_find_cgroup_in_dir_callback(const char *dir) {
     cgroup_root_count++;
 }
 
-static inline int discovery_find_dir_in_subdirs(const char *base, const char *this, void (*callback)(const char *)) {
-    if(!this) this = base;
-    netdata_log_debug(D_CGROUP, "searching for directories in '%s' (base '%s')", this?this:"", base);
+static inline int discovery_find_walkdir(const char *base, const char *dirpath) {
+    if (!dirpath)
+        dirpath = base;
 
-    size_t dirlen = strlen(this), baselen = strlen(base);
+    netdata_log_debug(D_CGROUP, "searching for directories in '%s' (base '%s')", dirpath ? dirpath : "", base);
+
+    size_t dirlen = strlen(dirpath), baselen = strlen(base);
 
     int ret = -1;
     int enabled = -1;
 
-    const char *relative_path = &this[baselen];
-    if(!*relative_path) relative_path = "/";
+    const char *relative_path = &dirpath[baselen];
+    if (!*relative_path)
+        relative_path = "/";
 
-    DIR *dir = opendir(this);
+    DIR *dir = opendir(dirpath);
     if(!dir) {
-        collector_error("CGROUP: cannot read directory '%s'", base);
+        collector_error("CGROUP: cannot open directory '%s'", base);
         return ret;
     }
     ret = 1;
 
-    callback(relative_path);
+    discovery_find_cgroup_in_dir(relative_path);
 
     struct dirent *de = NULL;
     while((de = readdir(dir))) {
-        if(de->d_type == DT_DIR
-           && (
-                   (de->d_name[0] == '.' && de->d_name[1] == '\0')
-                   || (de->d_name[0] == '.' && de->d_name[1] == '.' && de->d_name[2] == '\0')
-           ))
+        if (de->d_type == DT_DIR && ((de->d_name[0] == '.' && de->d_name[1] == '\0') ||
+                                     (de->d_name[0] == '.' && de->d_name[1] == '.' && de->d_name[2] == '\0')))
             continue;
 
         if(de->d_type == DT_DIR) {
             if(enabled == -1) {
                 const char *r = relative_path;
-                if(*r == '\0') r = "/";
+                if (*r == '\0')
+                    r = "/";
 
                 // do not decent in directories we are not interested
                 enabled = matches_search_cgroup_paths(r);
@@ -426,11 +420,12 @@ static inline int discovery_find_dir_in_subdirs(const char *base, const char *th
 
             if(enabled) {
                 char *s = mallocz(dirlen + strlen(de->d_name) + 2);
-                strcpy(s, this);
+                strcpy(s, dirpath);
                 strcat(s, "/");
                 strcat(s, de->d_name);
-                int ret2 = discovery_find_dir_in_subdirs(base, s, callback);
-                if(ret2 > 0) ret += ret2;
+                int ret2 = discovery_find_walkdir(base, s);
+                if (ret2 > 0)
+                    ret += ret2;
                 freez(s);
             }
         }
@@ -451,290 +446,277 @@ static inline void discovery_update_filenames_cgroup_v1(struct cgroup *cg) {
     struct stat buf;
 
     // CPU
-    if (unlikely(cgroup_enable_cpuacct_stat && !cg->cpuacct_stat.filename)) {
-        snprintfz(filename, FILENAME_MAX, "%s%s/cpuacct.stat", cgroup_cpuacct_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
-            cg->cpuacct_stat.filename = strdupz(filename);
-            cg->cpuacct_stat.enabled = cgroup_enable_cpuacct_stat;
-            snprintfz(filename, FILENAME_MAX, "%s%s/cpuset.cpus", cgroup_cpuset_base, cg->id);
-            cg->filename_cpuset_cpus = strdupz(filename);
-            snprintfz(filename, FILENAME_MAX, "%s%s/cpu.cfs_period_us", cgroup_cpuacct_base, cg->id);
-            cg->filename_cpu_cfs_period = strdupz(filename);
-            snprintfz(filename, FILENAME_MAX, "%s%s/cpu.cfs_quota_us", cgroup_cpuacct_base, cg->id);
-            cg->filename_cpu_cfs_quota = strdupz(filename);
+    if (likely(cgroup_enable_cpuacct)) {
+        if (unlikely(!cg->cpuacct_stat.staterr && !cg->cpuacct_stat.filename)) {
+            snprintfz(filename, FILENAME_MAX, "%s%s/cpuacct.stat", cgroup_cpuacct_base, cg->id);
+            if (!(cg->cpuacct_stat.staterr = stat(filename, &buf) != 0)) {
+                cg->cpuacct_stat.filename = strdupz(filename);
+
+                snprintfz(filename, FILENAME_MAX, "%s%s/cpuset.cpus", cgroup_cpuset_base, cg->id);
+                cg->filename_cpuset_cpus = strdupz(filename);
+
+                snprintfz(filename, FILENAME_MAX, "%s%s/cpu.cfs_period_us", cgroup_cpuacct_base, cg->id);
+                cg->filename_cpu_cfs_period = strdupz(filename);
+
+                snprintfz(filename, FILENAME_MAX, "%s%s/cpu.cfs_quota_us", cgroup_cpuacct_base, cg->id);
+                cg->filename_cpu_cfs_quota = strdupz(filename);
+            }
         }
-    }
-    // FIXME: remove usage_percpu
-    if (unlikely(cgroup_enable_cpuacct_usage && !cg->cpuacct_usage.filename && !is_cgroup_systemd_service(cg))) {
-        snprintfz(filename, FILENAME_MAX, "%s%s/cpuacct.usage_percpu", cgroup_cpuacct_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
-            cg->cpuacct_usage.filename = strdupz(filename);
-            cg->cpuacct_usage.enabled = cgroup_enable_cpuacct_usage;
-        }
-    }
-    if (unlikely(
-            cgroup_enable_cpuacct_cpu_throttling && !cg->cpuacct_cpu_throttling.filename &&
-            !is_cgroup_systemd_service(cg))) {
-        snprintfz(filename, FILENAME_MAX, "%s%s/cpu.stat", cgroup_cpuacct_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
-            cg->cpuacct_cpu_throttling.filename = strdupz(filename);
-            cg->cpuacct_cpu_throttling.enabled = cgroup_enable_cpuacct_cpu_throttling;
-        }
-    }
-    if (unlikely(
-            cgroup_enable_cpuacct_cpu_shares && !cg->cpuacct_cpu_shares.filename && !is_cgroup_systemd_service(cg))) {
-        snprintfz(filename, FILENAME_MAX, "%s%s/cpu.shares", cgroup_cpuacct_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
-            cg->cpuacct_cpu_shares.filename = strdupz(filename);
-            cg->cpuacct_cpu_shares.enabled = cgroup_enable_cpuacct_cpu_shares;
+        if (!is_cgroup_systemd_service(cg)) {
+            if (unlikely(!cg->cpuacct_cpu_throttling.staterr && !cg->cpuacct_cpu_throttling.filename)) {
+                snprintfz(filename, FILENAME_MAX, "%s%s/cpu.stat", cgroup_cpuacct_base, cg->id);
+                if (!(cg->cpuacct_cpu_throttling.staterr = stat(filename, &buf) != 0)) {
+                    cg->cpuacct_cpu_throttling.filename = strdupz(filename);
+                }
+            }
+
+            if (cgroup_enable_cpuacct_cpu_shares) {
+                if (unlikely(!cg->cpuacct_cpu_shares.staterr && !cg->cpuacct_cpu_shares.filename)) {
+                    snprintfz(filename, FILENAME_MAX, "%s%s/cpu.shares", cgroup_cpuacct_base, cg->id);
+
+                    if (!(cg->cpuacct_cpu_shares.staterr = stat(filename, &buf) != 0)) {
+                        cg->cpuacct_cpu_shares.filename = strdupz(filename);
+                    }
+                }
+            }
         }
     }
 
     // Memory
-    if (unlikely(
-            (cgroup_enable_detailed_memory || cgroup_used_memory) && !cg->memory.filename_detailed &&
-            (cgroup_used_memory || cgroup_enable_systemd_services_detailed_memory || !is_cgroup_systemd_service(cg)))) {
-        snprintfz(filename, FILENAME_MAX, "%s%s/memory.stat", cgroup_memory_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
-            cg->memory.filename_detailed = strdupz(filename);
-            cg->memory.enabled_detailed =
-                (cgroup_enable_detailed_memory == CONFIG_BOOLEAN_YES) ? CONFIG_BOOLEAN_YES : CONFIG_BOOLEAN_AUTO;
+    if (likely(cgroup_enable_memory)) {
+        if (unlikely(!cg->memory.staterr_mem_current && !cg->memory.filename_usage_in_bytes)) {
+            snprintfz(filename, FILENAME_MAX, "%s%s/memory.usage_in_bytes", cgroup_memory_base, cg->id);
+            if (!(cg->memory.staterr_mem_current = stat(filename, &buf) != 0)) {
+                cg->memory.filename_usage_in_bytes = strdupz(filename);
+
+                snprintfz(filename, FILENAME_MAX, "%s%s/memory.limit_in_bytes", cgroup_memory_base, cg->id);
+                cg->filename_memory_limit = strdupz(filename);
+            }
         }
-    }
-    if (unlikely(cgroup_enable_memory && !cg->memory.filename_usage_in_bytes)) {
-        snprintfz(filename, FILENAME_MAX, "%s%s/memory.usage_in_bytes", cgroup_memory_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
-            cg->memory.filename_usage_in_bytes = strdupz(filename);
-            cg->memory.enabled_usage_in_bytes = cgroup_enable_memory;
-            snprintfz(filename, FILENAME_MAX, "%s%s/memory.limit_in_bytes", cgroup_memory_base, cg->id);
-            cg->filename_memory_limit = strdupz(filename);
+
+        if (unlikely(!cg->memory.staterr_mem_stat && !cg->memory.filename_detailed)) {
+            snprintfz(filename, FILENAME_MAX, "%s%s/memory.stat", cgroup_memory_base, cg->id);
+            if (!(cg->memory.staterr_mem_stat = stat(filename, &buf) != 0)) {
+                cg->memory.filename_detailed = strdupz(filename);
+            }
         }
-    }
-    if (unlikely(cgroup_enable_swap && !cg->memory.filename_msw_usage_in_bytes)) {
-        snprintfz(filename, FILENAME_MAX, "%s%s/memory.memsw.usage_in_bytes", cgroup_memory_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
-            cg->memory.filename_msw_usage_in_bytes = strdupz(filename);
-            cg->memory.enabled_msw_usage_in_bytes = cgroup_enable_swap;
-            snprintfz(filename, FILENAME_MAX, "%s%s/memory.memsw.limit_in_bytes", cgroup_memory_base, cg->id);
-            cg->filename_memoryswap_limit = strdupz(filename);
+
+        if (unlikely(!cg->memory.staterr_swap && !cg->memory.filename_msw_usage_in_bytes)) {
+            snprintfz(filename, FILENAME_MAX, "%s%s/memory.memsw.usage_in_bytes", cgroup_memory_base, cg->id);
+            if (!(cg->memory.staterr_swap = stat(filename, &buf) != 0)) {
+                cg->memory.filename_msw_usage_in_bytes = strdupz(filename);
+
+                snprintfz(filename, FILENAME_MAX, "%s%s/memory.memsw.limit_in_bytes", cgroup_memory_base, cg->id);
+                cg->filename_memoryswap_limit = strdupz(filename);
+            }
         }
-    }
-    if (unlikely(cgroup_enable_memory_failcnt && !cg->memory.filename_failcnt)) {
-        snprintfz(filename, FILENAME_MAX, "%s%s/memory.failcnt", cgroup_memory_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
-            cg->memory.filename_failcnt = strdupz(filename);
-            cg->memory.enabled_failcnt = cgroup_enable_memory_failcnt;
+
+        if (unlikely(!cg->memory.staterr_failcnt && !cg->memory.filename_failcnt)) {
+            snprintfz(filename, FILENAME_MAX, "%s%s/memory.failcnt", cgroup_memory_base, cg->id);
+            if (!(cg->memory.staterr_failcnt = stat(filename, &buf) != 0)) {
+                cg->memory.filename_failcnt = strdupz(filename);
+            }
         }
     }
 
     // Blkio
-    if (unlikely(cgroup_enable_blkio_io && !cg->io_service_bytes.filename)) {
-        snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_service_bytes_recursive", cgroup_blkio_base, cg->id);
-        if (unlikely(stat(filename, &buf) != -1)) {
-            cg->io_service_bytes.filename = strdupz(filename);
-            cg->io_service_bytes.enabled = cgroup_enable_blkio_io;
-        } else {
-            snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_service_bytes", cgroup_blkio_base, cg->id);
-            if (likely(stat(filename, &buf) != -1)) {
+    if (likely(cgroup_enable_blkio)) {
+        if (unlikely(!cg->io_service_bytes.staterr && !cg->io_service_bytes.filename)) {
+            snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_service_bytes_recursive", cgroup_blkio_base, cg->id);
+            if (!(cg->io_service_bytes.staterr = stat(filename, &buf) != 0)) {
                 cg->io_service_bytes.filename = strdupz(filename);
-                cg->io_service_bytes.enabled = cgroup_enable_blkio_io;
+            } else {
+                snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_service_bytes", cgroup_blkio_base, cg->id);
+                if (!(cg->io_service_bytes.staterr = stat(filename, &buf) != 0)) {
+                    cg->io_service_bytes.filename = strdupz(filename);
+                }
             }
         }
-    }
-    if (unlikely(cgroup_enable_blkio_ops && !cg->io_serviced.filename)) {
-        snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_serviced_recursive", cgroup_blkio_base, cg->id);
-        if (unlikely(stat(filename, &buf) != -1)) {
-            cg->io_serviced.filename = strdupz(filename);
-            cg->io_serviced.enabled = cgroup_enable_blkio_ops;
-        } else {
-            snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_serviced", cgroup_blkio_base, cg->id);
-            if (likely(stat(filename, &buf) != -1)) {
+
+        if (unlikely(!cg->io_serviced.staterr && !cg->io_serviced.filename)) {
+            snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_serviced_recursive", cgroup_blkio_base, cg->id);
+            if (!(cg->io_serviced.staterr = stat(filename, &buf) != 0)) {
                 cg->io_serviced.filename = strdupz(filename);
-                cg->io_serviced.enabled = cgroup_enable_blkio_ops;
+            } else {
+                snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_serviced", cgroup_blkio_base, cg->id);
+                if (!(cg->io_serviced.staterr = stat(filename, &buf) != 0)) {
+                    cg->io_serviced.filename = strdupz(filename);
+                }
             }
         }
-    }
-    if (unlikely(cgroup_enable_blkio_throttle_io && !cg->throttle_io_service_bytes.filename)) {
-        snprintfz(filename, FILENAME_MAX, "%s%s/blkio.throttle.io_service_bytes_recursive", cgroup_blkio_base, cg->id);
-        if (unlikely(stat(filename, &buf) != -1)) {
-            cg->throttle_io_service_bytes.filename = strdupz(filename);
-            cg->throttle_io_service_bytes.enabled = cgroup_enable_blkio_throttle_io;
-        } else {
-            snprintfz(filename, FILENAME_MAX, "%s%s/blkio.throttle.io_service_bytes", cgroup_blkio_base, cg->id);
-            if (likely(stat(filename, &buf) != -1)) {
+
+        if (unlikely(!cg->throttle_io_service_bytes.staterr && !cg->throttle_io_service_bytes.filename)) {
+            snprintfz(
+                filename, FILENAME_MAX, "%s%s/blkio.throttle.io_service_bytes_recursive", cgroup_blkio_base, cg->id);
+            if (!(cg->throttle_io_service_bytes.staterr = stat(filename, &buf) != 0)) {
                 cg->throttle_io_service_bytes.filename = strdupz(filename);
-                cg->throttle_io_service_bytes.enabled = cgroup_enable_blkio_throttle_io;
+            } else {
+                snprintfz(filename, FILENAME_MAX, "%s%s/blkio.throttle.io_service_bytes", cgroup_blkio_base, cg->id);
+                if (!(cg->throttle_io_service_bytes.staterr = stat(filename, &buf) != 0)) {
+                    cg->throttle_io_service_bytes.filename = strdupz(filename);
+                }
             }
         }
-    }
-    if (unlikely(cgroup_enable_blkio_throttle_ops && !cg->throttle_io_serviced.filename)) {
-        snprintfz(filename, FILENAME_MAX, "%s%s/blkio.throttle.io_serviced_recursive", cgroup_blkio_base, cg->id);
-        if (unlikely(stat(filename, &buf) != -1)) {
-            cg->throttle_io_serviced.filename = strdupz(filename);
-            cg->throttle_io_serviced.enabled = cgroup_enable_blkio_throttle_ops;
-        } else {
-            snprintfz(filename, FILENAME_MAX, "%s%s/blkio.throttle.io_serviced", cgroup_blkio_base, cg->id);
-            if (likely(stat(filename, &buf) != -1)) {
+
+        if (unlikely(!cg->throttle_io_serviced.staterr && !cg->throttle_io_serviced.filename)) {
+            snprintfz(filename, FILENAME_MAX, "%s%s/blkio.throttle.io_serviced_recursive", cgroup_blkio_base, cg->id);
+            if(!(cg->throttle_io_serviced.staterr = stat(filename, &buf) != 0)) {
                 cg->throttle_io_serviced.filename = strdupz(filename);
-                cg->throttle_io_serviced.enabled = cgroup_enable_blkio_throttle_ops;
+            } else {
+                snprintfz(filename, FILENAME_MAX, "%s%s/blkio.throttle.io_serviced", cgroup_blkio_base, cg->id);
+                if (!(cg->throttle_io_serviced.staterr = stat(filename, &buf) != 0)) {
+                    cg->throttle_io_serviced.filename = strdupz(filename);
+                }
             }
         }
-    }
-    if (unlikely(cgroup_enable_blkio_merged_ops && !cg->io_merged.filename)) {
-        snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_merged_recursive", cgroup_blkio_base, cg->id);
-        if (unlikely(stat(filename, &buf) != -1)) {
-            cg->io_merged.filename = strdupz(filename);
-            cg->io_merged.enabled = cgroup_enable_blkio_merged_ops;
-        } else {
-            snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_merged", cgroup_blkio_base, cg->id);
-            if (likely(stat(filename, &buf) != -1)) {
+
+        if (unlikely(!cg->io_merged.staterr && !cg->io_merged.filename)) {
+            snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_merged_recursive", cgroup_blkio_base, cg->id);
+            if (!(cg->io_merged.staterr = stat(filename, &buf) != 0)) {
                 cg->io_merged.filename = strdupz(filename);
-                cg->io_merged.enabled = cgroup_enable_blkio_merged_ops;
+            } else {
+                snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_merged", cgroup_blkio_base, cg->id);
+                if (!(cg->io_merged.staterr = stat(filename, &buf) != 0)) {
+                    cg->io_merged.filename = strdupz(filename);
+                }
             }
         }
-    }
-    if (unlikely(cgroup_enable_blkio_queued_ops && !cg->io_queued.filename)) {
-        snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_queued_recursive", cgroup_blkio_base, cg->id);
-        if (unlikely(stat(filename, &buf) != -1)) {
-            cg->io_queued.filename = strdupz(filename);
-            cg->io_queued.enabled = cgroup_enable_blkio_queued_ops;
-        } else {
-            snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_queued", cgroup_blkio_base, cg->id);
-            if (likely(stat(filename, &buf) != -1)) {
+
+        if (unlikely(!cg->io_queued.staterr && !cg->io_queued.filename)) {
+            snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_queued_recursive", cgroup_blkio_base, cg->id);
+            if (!(cg->io_queued.staterr = stat(filename, &buf) != 0)) {
                 cg->io_queued.filename = strdupz(filename);
-                cg->io_queued.enabled = cgroup_enable_blkio_queued_ops;
+            } else {
+                snprintfz(filename, FILENAME_MAX, "%s%s/blkio.io_queued", cgroup_blkio_base, cg->id);
+                if (!(cg->io_queued.staterr = stat(filename, &buf) != 0)) {
+                    cg->io_queued.filename = strdupz(filename);
+                }
             }
         }
     }
 
     // Pids
-    if (unlikely(!cg->pids.pids_current_filename)) {
+    if (unlikely(!cg->pids_current.staterr && !cg->pids_current.filename)) {
         snprintfz(filename, FILENAME_MAX, "%s%s/pids.current", cgroup_pids_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
-            cg->pids.pids_current_filename = strdupz(filename);
+        if (!(cg->pids_current.staterr = stat(filename, &buf) != 0)) {
+            cg->pids_current.filename = strdupz(filename);
         }
     }
 }
 
 static inline void discovery_update_filenames_cgroup_v2(struct cgroup *cg) {
+    if (!cgroup_unified_exist)
+        return;
+
     char filename[FILENAME_MAX + 1];
     struct stat buf;
 
     // CPU
-    if (unlikely((cgroup_enable_cpuacct_stat || cgroup_enable_cpuacct_cpu_throttling) && !cg->cpuacct_stat.filename)) {
+    if (unlikely((!cg->cpuacct_stat.staterr && !cg->cpuacct_stat.filename))) {
         snprintfz(filename, FILENAME_MAX, "%s%s/cpu.stat", cgroup_unified_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
+        if (!(cg->cpuacct_stat.staterr = stat(filename, &buf) != 0)) {
             cg->cpuacct_stat.filename = strdupz(filename);
-            cg->cpuacct_stat.enabled = cgroup_enable_cpuacct_stat;
-            cg->cpuacct_cpu_throttling.enabled = cgroup_enable_cpuacct_cpu_throttling;
             cg->filename_cpuset_cpus = NULL;
             cg->filename_cpu_cfs_period = NULL;
+
             snprintfz(filename, FILENAME_MAX, "%s%s/cpu.max", cgroup_unified_base, cg->id);
             cg->filename_cpu_cfs_quota = strdupz(filename);
         }
     }
-    if (unlikely(cgroup_enable_cpuacct_cpu_shares && !cg->cpuacct_cpu_shares.filename)) {
-        snprintfz(filename, FILENAME_MAX, "%s%s/cpu.weight", cgroup_unified_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
-            cg->cpuacct_cpu_shares.filename = strdupz(filename);
-            cg->cpuacct_cpu_shares.enabled = cgroup_enable_cpuacct_cpu_shares;
+    if (cgroup_enable_cpuacct_cpu_shares) {
+        if (unlikely(!cg->cpuacct_cpu_shares.staterr && !cg->cpuacct_cpu_shares.filename)) {
+            snprintfz(filename, FILENAME_MAX, "%s%s/cpu.weight", cgroup_unified_base, cg->id);
+            if (!(cg->cpuacct_cpu_shares.staterr = stat(filename, &buf) != 0)) {
+                cg->cpuacct_cpu_shares.filename = strdupz(filename);
+            }
         }
     }
 
-    // Memory 
-    // FIXME: this if condition!
-    if (unlikely(
-            (cgroup_enable_detailed_memory || cgroup_used_memory) && !cg->memory.filename_detailed &&
-            (cgroup_used_memory || cgroup_enable_systemd_services_detailed_memory || !is_cgroup_systemd_service(cg)))) {
-        snprintfz(filename, FILENAME_MAX, "%s%s/memory.stat", cgroup_unified_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
-            cg->memory.filename_detailed = strdupz(filename);
-            cg->memory.enabled_detailed =
-                (cgroup_enable_detailed_memory == CONFIG_BOOLEAN_YES) ? CONFIG_BOOLEAN_YES : CONFIG_BOOLEAN_AUTO;
-        }
-    }
-
-    if (unlikely(cgroup_enable_memory && !cg->memory.filename_usage_in_bytes)) {
+    // Memory
+    if (unlikely(!cg->memory.staterr_mem_current && !cg->memory.filename_usage_in_bytes)) {
         snprintfz(filename, FILENAME_MAX, "%s%s/memory.current", cgroup_unified_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
+        if (!(cg->memory.staterr_mem_current = stat(filename, &buf) != 0)) {
             cg->memory.filename_usage_in_bytes = strdupz(filename);
-            cg->memory.enabled_usage_in_bytes = cgroup_enable_memory;
+
             snprintfz(filename, FILENAME_MAX, "%s%s/memory.max", cgroup_unified_base, cg->id);
             cg->filename_memory_limit = strdupz(filename);
         }
     }
 
-    if (unlikely(cgroup_enable_swap && !cg->memory.filename_msw_usage_in_bytes)) {
+    if (unlikely(!cg->memory.staterr_mem_stat && !cg->memory.filename_detailed)) {
+        snprintfz(filename, FILENAME_MAX, "%s%s/memory.stat", cgroup_unified_base, cg->id);
+        if (!(cg->memory.staterr_mem_stat = stat(filename, &buf) != 0)) {
+            cg->memory.filename_detailed = strdupz(filename);
+        }
+    }
+
+    if (unlikely(!cg->memory.staterr_swap && !cg->memory.filename_msw_usage_in_bytes)) {
         snprintfz(filename, FILENAME_MAX, "%s%s/memory.swap.current", cgroup_unified_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
+        if (!(cg->memory.staterr_swap = stat(filename, &buf) != 0)) {
             cg->memory.filename_msw_usage_in_bytes = strdupz(filename);
-            cg->memory.enabled_msw_usage_in_bytes = cgroup_enable_swap;
+
             snprintfz(filename, FILENAME_MAX, "%s%s/memory.swap.max", cgroup_unified_base, cg->id);
             cg->filename_memoryswap_limit = strdupz(filename);
         }
     }
 
     // Blkio
-    if (unlikely(cgroup_enable_blkio_io && !cg->io_service_bytes.filename)) {
+    if (unlikely(!cg->io_service_bytes.staterr && !cg->io_service_bytes.filename)) {
         snprintfz(filename, FILENAME_MAX, "%s%s/io.stat", cgroup_unified_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
+        if (!(cg->io_service_bytes.staterr = stat(filename, &buf) != 0)) {
             cg->io_service_bytes.filename = strdupz(filename);
-            cg->io_service_bytes.enabled = cgroup_enable_blkio_io;
         }
     }
 
-    if (unlikely(cgroup_enable_blkio_ops && !cg->io_serviced.filename)) {
+    if (unlikely(!cg->io_serviced.staterr && !cg->io_serviced.filename)) {
         snprintfz(filename, FILENAME_MAX, "%s%s/io.stat", cgroup_unified_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
+        if (!(cg->io_serviced.staterr = stat(filename, &buf) != 0)) {
             cg->io_serviced.filename = strdupz(filename);
-            cg->io_serviced.enabled = cgroup_enable_blkio_ops;
         }
     }
 
     // PSI
-    if (unlikely(cgroup_enable_pressure_cpu && !cg->cpu_pressure.filename)) {
+    if (unlikely(!cg->cpu_pressure.staterr && !cg->cpu_pressure.filename)) {
         snprintfz(filename, FILENAME_MAX, "%s%s/cpu.pressure", cgroup_unified_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
+        if (!(cg->cpu_pressure.staterr = stat(filename, &buf) != 0)) {
             cg->cpu_pressure.filename = strdupz(filename);
-            cg->cpu_pressure.some.enabled = cgroup_enable_pressure_cpu;
-            cg->cpu_pressure.full.enabled = CONFIG_BOOLEAN_NO;
+            cg->cpu_pressure.some.enabled = CONFIG_BOOLEAN_YES;
+            cg->cpu_pressure.full.enabled = CONFIG_BOOLEAN_YES;
         }
     }
 
-    if (unlikely((cgroup_enable_pressure_io_some || cgroup_enable_pressure_io_full) && !cg->io_pressure.filename)) {
+    if (unlikely(!cg->io_pressure.staterr && !cg->io_pressure.filename)) {
         snprintfz(filename, FILENAME_MAX, "%s%s/io.pressure", cgroup_unified_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
+        if (!(cg->io_pressure.staterr = stat(filename, &buf) != 0)) {
             cg->io_pressure.filename = strdupz(filename);
-            cg->io_pressure.some.enabled = cgroup_enable_pressure_io_some;
-            cg->io_pressure.full.enabled = cgroup_enable_pressure_io_full;
+            cg->io_pressure.some.enabled = CONFIG_BOOLEAN_YES;
+            cg->io_pressure.full.enabled = CONFIG_BOOLEAN_YES;
         }
     }
 
-    if (unlikely(
-            (cgroup_enable_pressure_memory_some || cgroup_enable_pressure_memory_full) &&
-            !cg->memory_pressure.filename)) {
+    if (unlikely(!cg->memory_pressure.staterr && !cg->memory_pressure.filename)) {
         snprintfz(filename, FILENAME_MAX, "%s%s/memory.pressure", cgroup_unified_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
+        if (!(cg->memory_pressure.staterr = stat(filename, &buf) != 0)) {
             cg->memory_pressure.filename = strdupz(filename);
-            cg->memory_pressure.some.enabled = cgroup_enable_pressure_memory_some;
-            cg->memory_pressure.full.enabled = cgroup_enable_pressure_memory_full;
+            cg->memory_pressure.some.enabled = CONFIG_BOOLEAN_YES;
+            cg->memory_pressure.full.enabled = CONFIG_BOOLEAN_YES;
         }
     }
 
-    if (unlikely((cgroup_enable_pressure_irq_some || cgroup_enable_pressure_irq_full) && !cg->irq_pressure.filename)) {
+    if (unlikely(!cg->irq_pressure.staterr && !cg->irq_pressure.filename)) {
         snprintfz(filename, FILENAME_MAX, "%s%s/irq.pressure", cgroup_unified_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
+        if (!(cg->irq_pressure.staterr = stat(filename, &buf) != 0)) {
             cg->irq_pressure.filename = strdupz(filename);
-            cg->irq_pressure.some.enabled = cgroup_enable_pressure_irq_some;
-            cg->irq_pressure.full.enabled = cgroup_enable_pressure_irq_full;
+            cg->irq_pressure.some.enabled = CONFIG_BOOLEAN_YES;
+            cg->irq_pressure.full.enabled = CONFIG_BOOLEAN_YES;
         }
     }
 
     // Pids
-    if (unlikely(!cg->pids.pids_current_filename)) {
+    if (unlikely(!cg->pids_current.staterr && !cg->pids_current.filename)) {
         snprintfz(filename, FILENAME_MAX, "%s%s/pids.current", cgroup_unified_base, cg->id);
-        if (likely(stat(filename, &buf) != -1)) {
-            cg->pids.pids_current_filename = strdupz(filename);
+        if (!(cg->pids_current.staterr = stat(filename, &buf) != 0)) {
+            cg->pids_current.filename = strdupz(filename);
         }
     }
 }
@@ -746,7 +728,7 @@ static inline void discovery_update_filenames_all_cgroups() {
 
         if (!cgroup_use_unified_cgroups)
             discovery_update_filenames_cgroup_v1(cg);
-        else if (likely(cgroup_unified_exist))
+        else
             discovery_update_filenames_cgroup_v2(cg);
     }
 }
@@ -837,43 +819,34 @@ static inline void discovery_share_cgroups_with_ebpf() {
 }
 
 static inline void discovery_find_all_cgroups_v1() {
-    if (cgroup_enable_cpuacct_stat || cgroup_enable_cpuacct_usage) {
-        if (discovery_find_dir_in_subdirs(cgroup_cpuacct_base, NULL, discovery_find_cgroup_in_dir_callback) == -1) {
-            cgroup_enable_cpuacct_stat = cgroup_enable_cpuacct_usage = CONFIG_BOOLEAN_NO;
+    if (cgroup_enable_cpuacct) {
+        if (discovery_find_walkdir(cgroup_cpuacct_base, NULL) == -1) {
+            cgroup_enable_cpuacct = false;
             collector_error("CGROUP: disabled cpu statistics.");
         }
     }
 
-    if (cgroup_enable_blkio_io || cgroup_enable_blkio_ops || cgroup_enable_blkio_throttle_io ||
-        cgroup_enable_blkio_throttle_ops || cgroup_enable_blkio_merged_ops || cgroup_enable_blkio_queued_ops) {
-        if (discovery_find_dir_in_subdirs(cgroup_blkio_base, NULL, discovery_find_cgroup_in_dir_callback) == -1) {
-            cgroup_enable_blkio_io = cgroup_enable_blkio_ops = cgroup_enable_blkio_throttle_io =
-            cgroup_enable_blkio_throttle_ops = cgroup_enable_blkio_merged_ops = cgroup_enable_blkio_queued_ops =
-                    CONFIG_BOOLEAN_NO;
+    if (cgroup_enable_blkio) {
+        if (discovery_find_walkdir(cgroup_blkio_base, NULL) == -1) {
+            cgroup_enable_blkio = false;
             collector_error("CGROUP: disabled blkio statistics.");
         }
     }
 
-    if (cgroup_enable_memory || cgroup_enable_detailed_memory || cgroup_enable_swap || cgroup_enable_memory_failcnt) {
-        if (discovery_find_dir_in_subdirs(cgroup_memory_base, NULL, discovery_find_cgroup_in_dir_callback) == -1) {
-            cgroup_enable_memory = cgroup_enable_detailed_memory = cgroup_enable_swap = cgroup_enable_memory_failcnt =
-                    CONFIG_BOOLEAN_NO;
+    if (cgroup_enable_memory) {
+        if (discovery_find_walkdir(cgroup_memory_base, NULL) == -1) {
+            cgroup_enable_memory = false;
             collector_error("CGROUP: disabled memory statistics.");
-        }
-    }
-
-    if (cgroup_search_in_devices) {
-        if (discovery_find_dir_in_subdirs(cgroup_devices_base, NULL, discovery_find_cgroup_in_dir_callback) == -1) {
-            cgroup_search_in_devices = 0;
-            collector_error("CGROUP: disabled devices statistics.");
         }
     }
 }
 
 static inline void discovery_find_all_cgroups_v2() {
-    if (discovery_find_dir_in_subdirs(cgroup_unified_base, NULL, discovery_find_cgroup_in_dir_callback) == -1) {
-        cgroup_unified_exist = CONFIG_BOOLEAN_NO;
-        collector_error("CGROUP: disabled unified cgroups statistics.");
+    if (cgroup_unified_exist) {
+        if (discovery_find_walkdir(cgroup_unified_base, NULL) == -1) {
+            cgroup_unified_exist = false;
+            collector_error("CGROUP: disabled unified cgroups statistics.");
+        }
     }
 }
 
@@ -995,7 +968,7 @@ static inline void discovery_process_first_time_seen_cgroup(struct cgroup *cg) {
         }
     }
 
-    if (cgroup_enable_systemd_services && matches_systemd_services_cgroups(cg->id)) {
+    if (matches_systemd_services_cgroups(cg->id)) {
         netdata_log_debug(D_CGROUP, "cgroup '%s' (name '%s') matches 'cgroups to match as systemd services'", cg->id, cg->chart_id);
         convert_cgroup_to_systemd_service(cg);
         return;
@@ -1038,9 +1011,7 @@ static void netdata_cgroup_ebpf_set_values(size_t length)
     sem_wait(shm_mutex_cgroup_ebpf);
 
     shm_cgroup_ebpf.header->cgroup_max = cgroup_root_max;
-    shm_cgroup_ebpf.header->systemd_enabled = cgroup_enable_systemd_services |
-                                              cgroup_enable_systemd_services_detailed_memory |
-                                              cgroup_used_memory;
+    shm_cgroup_ebpf.header->systemd_enabled = CONFIG_BOOLEAN_YES;
     shm_cgroup_ebpf.header->body_length = length;
 
     sem_post(shm_mutex_cgroup_ebpf);
@@ -1175,7 +1146,6 @@ static inline void read_cgroup_network_interfaces(struct cgroup *cg) {
     }
 
     netdata_pclose(fp_child_input, fp_child_output, cgroup_pid);
-    // netdata_log_debug(D_CGROUP, "closed cgroup_identifier for cgroup '%s'", cg->id);
 }
 
 static inline void discovery_process_cgroup(struct cgroup *cg) {

--- a/src/collectors/cgroups.plugin/cgroup-internals.h
+++ b/src/collectors/cgroups.plugin/cgroup-internals.h
@@ -10,24 +10,21 @@
 #endif
 
 struct blkio {
-    int updated;
-    int enabled; // CONFIG_BOOLEAN_YES or CONFIG_BOOLEAN_AUTO
-    int delay_counter;
-
     char *filename;
+    bool staterr;
+
+    int updated;
 
     unsigned long long Read;
     unsigned long long Write;
-/*
-    unsigned long long Sync;
-    unsigned long long Async;
-    unsigned long long Total;
-*/
 };
 
 struct pids {
-    char *pids_current_filename;
-    int pids_current_updated;
+    char *filename;
+    bool staterr;
+
+    int updated;
+
     unsigned long long pids_current;
 };
 
@@ -37,57 +34,29 @@ struct memory {
     ARL_ENTRY *arl_dirty;
     ARL_ENTRY *arl_swap;
 
-    int updated_detailed;
-    int updated_usage_in_bytes;
-    int updated_msw_usage_in_bytes;
-    int updated_failcnt;
-
-    int enabled_detailed;           // CONFIG_BOOLEAN_YES or CONFIG_BOOLEAN_AUTO
-    int enabled_usage_in_bytes;     // CONFIG_BOOLEAN_YES or CONFIG_BOOLEAN_AUTO
-    int enabled_msw_usage_in_bytes; // CONFIG_BOOLEAN_YES or CONFIG_BOOLEAN_AUTO
-    int enabled_failcnt;            // CONFIG_BOOLEAN_YES or CONFIG_BOOLEAN_AUTO
-
-    int delay_counter_detailed;
-    int delay_counter_failcnt;
-
-    char *filename_detailed;
     char *filename_usage_in_bytes;
+    char *filename_detailed;
     char *filename_msw_usage_in_bytes;
     char *filename_failcnt;
+
+    bool staterr_mem_current;
+    bool staterr_mem_stat;
+    bool staterr_failcnt;
+    bool staterr_swap;
+
+    int updated_usage_in_bytes;
+    int updated_detailed;
+    int updated_msw_usage_in_bytes;
+    int updated_failcnt;
 
     int detailed_has_dirty;
     int detailed_has_swap;
 
-    // detailed metrics
-/*
-    unsigned long long cache;
-    unsigned long long rss;
-    unsigned long long rss_huge;
-    unsigned long long mapped_file;
-    unsigned long long writeback;
-    unsigned long long dirty;
-    unsigned long long swap;
-    unsigned long long pgpgin;
-    unsigned long long pgpgout;
-    unsigned long long pgfault;
-    unsigned long long pgmajfault;
-    unsigned long long inactive_anon;
-    unsigned long long active_anon;
-    unsigned long long inactive_file;
-    unsigned long long active_file;
-    unsigned long long unevictable;
-    unsigned long long hierarchical_memory_limit;
-*/
-    //unified cgroups metrics
     unsigned long long anon;
     unsigned long long kernel_stack;
     unsigned long long slab;
     unsigned long long sock;
-    // unsigned long long shmem;
     unsigned long long anon_thp;
-    //unsigned long long file_writeback;
-    //unsigned long long file_dirty;
-    //unsigned long long file;
 
     unsigned long long total_cache;
     unsigned long long total_rss;
@@ -100,17 +69,8 @@ struct memory {
     unsigned long long total_pgpgout;
     unsigned long long total_pgfault;
     unsigned long long total_pgmajfault;
-/*
-    unsigned long long total_inactive_anon;
-    unsigned long long total_active_anon;
-*/
 
     unsigned long long total_inactive_file;
-
-/*
-    unsigned long long total_active_file;
-    unsigned long long total_unevictable;
-*/
 
     // single file metrics
     unsigned long long usage_in_bytes;
@@ -120,10 +80,10 @@ struct memory {
 
 // https://www.kernel.org/doc/Documentation/cgroup-v1/cpuacct.txt
 struct cpuacct_stat {
-    int updated;
-    int enabled;            // CONFIG_BOOLEAN_YES or CONFIG_BOOLEAN_AUTO
-
     char *filename;
+    bool staterr;
+
+    int updated;
 
     unsigned long long user;           // v1, v2(user_usec)
     unsigned long long system;         // v1, v2(system_usec)
@@ -131,10 +91,9 @@ struct cpuacct_stat {
 
 // https://www.kernel.org/doc/Documentation/cgroup-v1/cpuacct.txt
 struct cpuacct_usage {
-    int updated;
-    int enabled; // CONFIG_BOOLEAN_YES or CONFIG_BOOLEAN_AUTO
-
     char *filename;
+    bool disabled;
+    int updated;
 
     unsigned int cpus;
     unsigned long long *cpu_percpu;
@@ -142,10 +101,10 @@ struct cpuacct_usage {
 
 // represents cpuacct/cpu.stat, for v2 'cpuacct_stat' is used for 'user_usec', 'system_usec'
 struct cpuacct_cpu_throttling {
-    int updated;
-    int enabled; // CONFIG_BOOLEAN_YES or CONFIG_BOOLEAN_AUTO
-
     char *filename;
+    bool staterr;
+
+    int updated;
 
     unsigned long long nr_periods;
     unsigned long long nr_throttled;
@@ -157,10 +116,10 @@ struct cpuacct_cpu_throttling {
 // https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/resource_management_guide/sec-cpu#sect-cfs
 // https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_monitoring_and_updating_the_kernel/using-cgroups-v2-to-control-distribution-of-cpu-time-for-applications_managing-monitoring-and-updating-the-kernel#proc_controlling-distribution-of-cpu-time-for-applications-by-adjusting-cpu-weight_using-cgroups-v2-to-control-distribution-of-cpu-time-for-applications
 struct cpuacct_cpu_shares {
-    int updated;
-    int enabled; // CONFIG_BOOLEAN_YES or CONFIG_BOOLEAN_AUTO
-
     char *filename;
+    bool staterr;
+
+    int updated;
 
     unsigned long long shares;
 };
@@ -224,7 +183,7 @@ struct cgroup {
     struct blkio io_merged;                     // operations
     struct blkio io_queued;                     // operations
 
-    struct pids pids;
+    struct pids pids_current;
 
     struct cgroup_network_interface *interfaces;
 
@@ -321,59 +280,43 @@ extern uv_mutex_t cgroup_root_mutex;
 
 void cgroup_discovery_worker(void *ptr);
 
-extern int is_inside_k8s;
+extern bool is_inside_k8s;
 extern long system_page_size;
-extern int cgroup_enable_cpuacct_stat;
-extern int cgroup_enable_cpuacct_usage;
-extern int cgroup_enable_cpuacct_cpu_throttling;
-extern int cgroup_enable_cpuacct_cpu_shares;
-extern int cgroup_enable_memory;
-extern int cgroup_enable_detailed_memory;
-extern int cgroup_enable_memory_failcnt;
-extern int cgroup_enable_swap;
-extern int cgroup_enable_blkio_io;
-extern int cgroup_enable_blkio_ops;
-extern int cgroup_enable_blkio_throttle_io;
-extern int cgroup_enable_blkio_throttle_ops;
-extern int cgroup_enable_blkio_merged_ops;
-extern int cgroup_enable_blkio_queued_ops;
-extern int cgroup_enable_pressure_cpu;
-extern int cgroup_enable_pressure_io_some;
-extern int cgroup_enable_pressure_io_full;
-extern int cgroup_enable_pressure_memory_some;
-extern int cgroup_enable_pressure_memory_full;
-extern int cgroup_enable_pressure_irq_some;
-extern int cgroup_enable_pressure_irq_full;
-extern int cgroup_enable_systemd_services;
-extern int cgroup_enable_systemd_services_detailed_memory;
-extern int cgroup_used_memory;
-extern int cgroup_use_unified_cgroups;
-extern int cgroup_unified_exist;
-extern int cgroup_search_in_devices;
+
+extern bool cgroup_use_unified_cgroups;
+extern bool cgroup_unified_exist;
+
+extern bool cgroup_enable_cpuacct;
+extern bool cgroup_enable_memory;
+extern bool cgroup_enable_blkio;
+extern bool cgroup_enable_pressure;
+extern bool cgroup_enable_cpuacct_cpu_shares;
+
 extern int cgroup_check_for_new_every;
 extern int cgroup_update_every;
-extern int cgroup_containers_chart_priority;
-extern int cgroup_recheck_zero_blkio_every_iterations;
-extern int cgroup_recheck_zero_mem_failcnt_every_iterations;
-extern int cgroup_recheck_zero_mem_detailed_every_iterations;
+
 extern char *cgroup_cpuacct_base;
 extern char *cgroup_cpuset_base;
 extern char *cgroup_blkio_base;
 extern char *cgroup_memory_base;
 extern char *cgroup_pids_base;
-extern char *cgroup_devices_base;
 extern char *cgroup_unified_base;
+
 extern int cgroup_root_count;
 extern int cgroup_root_max;
 extern int cgroup_max_depth;
+
 extern SIMPLE_PATTERN *enabled_cgroup_paths;
 extern SIMPLE_PATTERN *enabled_cgroup_names;
 extern SIMPLE_PATTERN *search_cgroup_paths;
 extern SIMPLE_PATTERN *enabled_cgroup_renames;
 extern SIMPLE_PATTERN *systemd_services_cgroups;
 extern SIMPLE_PATTERN *entrypoint_parent_process_comm;
+
 extern char *cgroups_network_interface_script;
+
 extern int cgroups_check;
+
 extern uint32_t Read_hash;
 extern uint32_t Write_hash;
 extern uint32_t user_hash;
@@ -384,6 +327,7 @@ extern uint32_t nr_periods_hash;
 extern uint32_t nr_throttled_hash;
 extern uint32_t throttled_time_hash;
 extern uint32_t throttled_usec_hash;
+
 extern struct cgroup *cgroup_root;
 
 enum cgroups_type { CGROUPS_AUTODETECT_FAIL, CGROUPS_V1, CGROUPS_V2 };

--- a/src/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/src/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -10,46 +10,24 @@
 // ----------------------------------------------------------------------------
 // cgroup globals
 unsigned long long host_ram_total = 0;
-int is_inside_k8s = 0;
+bool is_inside_k8s = false;
 long system_page_size = 4096; // system will be queried via sysconf() in configuration()
-int cgroup_enable_cpuacct_stat = CONFIG_BOOLEAN_AUTO;
-int cgroup_enable_cpuacct_usage = CONFIG_BOOLEAN_NO;
-int cgroup_enable_cpuacct_cpu_throttling = CONFIG_BOOLEAN_YES;
-int cgroup_enable_cpuacct_cpu_shares = CONFIG_BOOLEAN_NO;
-int cgroup_enable_memory = CONFIG_BOOLEAN_AUTO;
-int cgroup_enable_detailed_memory = CONFIG_BOOLEAN_AUTO;
-int cgroup_enable_memory_failcnt = CONFIG_BOOLEAN_AUTO;
-int cgroup_enable_swap = CONFIG_BOOLEAN_AUTO;
-int cgroup_enable_blkio_io = CONFIG_BOOLEAN_AUTO;
-int cgroup_enable_blkio_ops = CONFIG_BOOLEAN_AUTO;
-int cgroup_enable_blkio_throttle_io = CONFIG_BOOLEAN_AUTO;
-int cgroup_enable_blkio_throttle_ops = CONFIG_BOOLEAN_AUTO;
-int cgroup_enable_blkio_merged_ops = CONFIG_BOOLEAN_AUTO;
-int cgroup_enable_blkio_queued_ops = CONFIG_BOOLEAN_AUTO;
-int cgroup_enable_pressure_cpu = CONFIG_BOOLEAN_AUTO;
-int cgroup_enable_pressure_io_some = CONFIG_BOOLEAN_AUTO;
-int cgroup_enable_pressure_io_full = CONFIG_BOOLEAN_AUTO;
-int cgroup_enable_pressure_memory_some = CONFIG_BOOLEAN_AUTO;
-int cgroup_enable_pressure_memory_full = CONFIG_BOOLEAN_AUTO;
-int cgroup_enable_pressure_irq_some = CONFIG_BOOLEAN_NO;
-int cgroup_enable_pressure_irq_full = CONFIG_BOOLEAN_AUTO;
-int cgroup_enable_systemd_services = CONFIG_BOOLEAN_YES;
-int cgroup_enable_systemd_services_detailed_memory = CONFIG_BOOLEAN_NO;
-int cgroup_used_memory = CONFIG_BOOLEAN_YES;
-int cgroup_use_unified_cgroups = CONFIG_BOOLEAN_NO;
-int cgroup_unified_exist = CONFIG_BOOLEAN_AUTO;
-int cgroup_search_in_devices = 1;
+
+bool cgroup_use_unified_cgroups = false;
+bool cgroup_unified_exist = true;
+
+bool cgroup_enable_blkio = true;
+bool cgroup_enable_pressure = true;
+bool cgroup_enable_memory = true;
+bool cgroup_enable_cpuacct = true;
+bool cgroup_enable_cpuacct_cpu_shares = false;
+
 int cgroup_check_for_new_every = 10;
 int cgroup_update_every = 1;
-int cgroup_containers_chart_priority = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS;
-int cgroup_recheck_zero_blkio_every_iterations = 10;
-int cgroup_recheck_zero_mem_failcnt_every_iterations = 10;
-int cgroup_recheck_zero_mem_detailed_every_iterations = 10;
 char *cgroup_cpuacct_base = NULL;
 char *cgroup_cpuset_base = NULL;
 char *cgroup_blkio_base = NULL;
 char *cgroup_memory_base = NULL;
-char *cgroup_devices_base = NULL;
 char *cgroup_pids_base = NULL;
 char *cgroup_unified_base = NULL;
 int cgroup_root_count = 0;
@@ -254,57 +232,12 @@ void read_cgroup_plugin_configuration() {
     if(cgroup_check_for_new_every < cgroup_update_every)
         cgroup_check_for_new_every = cgroup_update_every;
 
-    cgroup_use_unified_cgroups = config_get_boolean_ondemand("plugin:cgroups", "use unified cgroups", CONFIG_BOOLEAN_AUTO);
-    if(cgroup_use_unified_cgroups == CONFIG_BOOLEAN_AUTO)
-        cgroup_use_unified_cgroups = (cgroups_try_detect_version() == CGROUPS_V2);
-
+    cgroup_use_unified_cgroups = (cgroups_try_detect_version() == CGROUPS_V2);
     collector_info("use unified cgroups %s", cgroup_use_unified_cgroups ? "true" : "false");
-
-    cgroup_containers_chart_priority = (int)config_get_number("plugin:cgroups", "containers priority", cgroup_containers_chart_priority);
-    if(cgroup_containers_chart_priority < 1)
-        cgroup_containers_chart_priority = NETDATA_CHART_PRIO_CGROUPS_CONTAINERS;
-
-    cgroup_enable_cpuacct_stat = config_get_boolean_ondemand("plugin:cgroups", "enable cpuacct stat (total CPU)", cgroup_enable_cpuacct_stat);
-    cgroup_enable_cpuacct_usage = config_get_boolean_ondemand("plugin:cgroups", "enable cpuacct usage (per core CPU)", cgroup_enable_cpuacct_usage);
-    cgroup_enable_cpuacct_cpu_throttling = config_get_boolean_ondemand("plugin:cgroups", "enable cpuacct cpu throttling", cgroup_enable_cpuacct_cpu_throttling);
-    cgroup_enable_cpuacct_cpu_shares = config_get_boolean_ondemand("plugin:cgroups", "enable cpuacct cpu shares", cgroup_enable_cpuacct_cpu_shares);
-
-    cgroup_enable_memory = config_get_boolean_ondemand("plugin:cgroups", "enable memory", cgroup_enable_memory);
-    cgroup_enable_detailed_memory = config_get_boolean_ondemand("plugin:cgroups", "enable detailed memory", cgroup_enable_detailed_memory);
-    cgroup_enable_memory_failcnt = config_get_boolean_ondemand("plugin:cgroups", "enable memory limits fail count", cgroup_enable_memory_failcnt);
-    cgroup_enable_swap = config_get_boolean_ondemand("plugin:cgroups", "enable swap memory", cgroup_enable_swap);
-
-    cgroup_enable_blkio_io = config_get_boolean_ondemand("plugin:cgroups", "enable blkio bandwidth", cgroup_enable_blkio_io);
-    cgroup_enable_blkio_ops = config_get_boolean_ondemand("plugin:cgroups", "enable blkio operations", cgroup_enable_blkio_ops);
-    cgroup_enable_blkio_throttle_io = config_get_boolean_ondemand("plugin:cgroups", "enable blkio throttle bandwidth", cgroup_enable_blkio_throttle_io);
-    cgroup_enable_blkio_throttle_ops = config_get_boolean_ondemand("plugin:cgroups", "enable blkio throttle operations", cgroup_enable_blkio_throttle_ops);
-    cgroup_enable_blkio_queued_ops = config_get_boolean_ondemand("plugin:cgroups", "enable blkio queued operations", cgroup_enable_blkio_queued_ops);
-    cgroup_enable_blkio_merged_ops = config_get_boolean_ondemand("plugin:cgroups", "enable blkio merged operations", cgroup_enable_blkio_merged_ops);
-
-    cgroup_enable_pressure_cpu = config_get_boolean_ondemand("plugin:cgroups", "enable cpu pressure", cgroup_enable_pressure_cpu);
-    cgroup_enable_pressure_io_some = config_get_boolean_ondemand("plugin:cgroups", "enable io some pressure", cgroup_enable_pressure_io_some);
-    cgroup_enable_pressure_io_full = config_get_boolean_ondemand("plugin:cgroups", "enable io full pressure", cgroup_enable_pressure_io_full);
-    cgroup_enable_pressure_memory_some = config_get_boolean_ondemand("plugin:cgroups", "enable memory some pressure", cgroup_enable_pressure_memory_some);
-    cgroup_enable_pressure_memory_full = config_get_boolean_ondemand("plugin:cgroups", "enable memory full pressure", cgroup_enable_pressure_memory_full);
-
-    cgroup_recheck_zero_blkio_every_iterations = (int)config_get_number("plugin:cgroups", "recheck zero blkio every iterations", cgroup_recheck_zero_blkio_every_iterations);
-    cgroup_recheck_zero_mem_failcnt_every_iterations = (int)config_get_number("plugin:cgroups", "recheck zero memory failcnt every iterations", cgroup_recheck_zero_mem_failcnt_every_iterations);
-    cgroup_recheck_zero_mem_detailed_every_iterations = (int)config_get_number("plugin:cgroups", "recheck zero detailed memory every iterations", cgroup_recheck_zero_mem_detailed_every_iterations);
-
-    cgroup_enable_systemd_services = config_get_boolean("plugin:cgroups", "enable systemd services", cgroup_enable_systemd_services);
-    cgroup_enable_systemd_services_detailed_memory = config_get_boolean("plugin:cgroups", "enable systemd services detailed memory", cgroup_enable_systemd_services_detailed_memory);
-    cgroup_used_memory = config_get_boolean("plugin:cgroups", "report used memory", cgroup_used_memory);
 
     char filename[FILENAME_MAX + 1], *s;
     struct mountinfo *mi, *root = mountinfo_read(0);
-    if(!cgroup_use_unified_cgroups) {
-        // cgroup v1 does not have pressure metrics
-        cgroup_enable_pressure_cpu =
-        cgroup_enable_pressure_io_some =
-        cgroup_enable_pressure_io_full =
-        cgroup_enable_pressure_memory_some =
-        cgroup_enable_pressure_memory_full = CONFIG_BOOLEAN_NO;
-
+    if (!cgroup_use_unified_cgroups) {
         mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "cpuacct");
         if (!mi)
             mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "cpuacct");
@@ -314,7 +247,7 @@ void read_cgroup_plugin_configuration() {
         } else
             s = mi->mount_point;
         set_cgroup_base_path(filename, s);
-        cgroup_cpuacct_base = config_get("plugin:cgroups", "path to /sys/fs/cgroup/cpuacct", filename);
+        cgroup_cpuacct_base = strdupz(filename);
 
         mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "cpuset");
         if (!mi)
@@ -325,7 +258,7 @@ void read_cgroup_plugin_configuration() {
         } else
             s = mi->mount_point;
         set_cgroup_base_path(filename, s);
-        cgroup_cpuset_base = config_get("plugin:cgroups", "path to /sys/fs/cgroup/cpuset", filename);
+        cgroup_cpuset_base = strdupz(filename);
 
         mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "blkio");
         if (!mi)
@@ -336,7 +269,7 @@ void read_cgroup_plugin_configuration() {
         } else
             s = mi->mount_point;
         set_cgroup_base_path(filename, s);
-        cgroup_blkio_base = config_get("plugin:cgroups", "path to /sys/fs/cgroup/blkio", filename);
+        cgroup_blkio_base = strdupz(filename);
 
         mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "memory");
         if (!mi)
@@ -344,21 +277,11 @@ void read_cgroup_plugin_configuration() {
         if (!mi) {
             collector_error("CGROUP: cannot find memory mountinfo. Assuming default: /sys/fs/cgroup/memory");
             s = "/sys/fs/cgroup/memory";
-        } else
+        } else {
             s = mi->mount_point;
+        }
         set_cgroup_base_path(filename, s);
-        cgroup_memory_base = config_get("plugin:cgroups", "path to /sys/fs/cgroup/memory", filename);
-
-        mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "devices");
-        if (!mi)
-            mi = mountinfo_find_by_filesystem_mount_source(root, "cgroup", "devices");
-        if (!mi) {
-            collector_error("CGROUP: cannot find devices mountinfo. Assuming default: /sys/fs/cgroup/devices");
-            s = "/sys/fs/cgroup/devices";
-        } else
-            s = mi->mount_point;
-        set_cgroup_base_path(filename, s);
-        cgroup_devices_base = config_get("plugin:cgroups", "path to /sys/fs/cgroup/devices", filename);
+        cgroup_memory_base = strdupz(filename);
 
         mi = mountinfo_find_by_filesystem_super_option(root, "cgroup", "pids");
         if (!mi)
@@ -366,28 +289,13 @@ void read_cgroup_plugin_configuration() {
         if (!mi) {
             collector_error("CGROUP: cannot find pids mountinfo. Assuming default: /sys/fs/cgroup/pids");
             s = "/sys/fs/cgroup/pids";
-        } else
+        } else {
             s = mi->mount_point;
-        set_cgroup_base_path(filename, s);
-        cgroup_pids_base = config_get("plugin:cgroups", "path to /sys/fs/cgroup/pids", filename);
-    }
-    else {
-        //cgroup_enable_cpuacct_stat =
-        cgroup_enable_cpuacct_usage =
-        //cgroup_enable_memory =
-        //cgroup_enable_detailed_memory =
-        cgroup_enable_memory_failcnt =
-        //cgroup_enable_swap =
-        //cgroup_enable_blkio_io =
-        //cgroup_enable_blkio_ops =
-        cgroup_enable_blkio_throttle_io =
-        cgroup_enable_blkio_throttle_ops =
-        cgroup_enable_blkio_merged_ops =
-        cgroup_enable_blkio_queued_ops = CONFIG_BOOLEAN_NO;
-        cgroup_search_in_devices = 0;
-        cgroup_enable_systemd_services_detailed_memory = CONFIG_BOOLEAN_NO;
-        cgroup_used_memory = CONFIG_BOOLEAN_NO; //unified cgroups use different values
+        }
 
+        set_cgroup_base_path(filename, s);
+        cgroup_pids_base = strdupz(filename);
+    } else {
         //TODO: can there be more than 1 cgroup2 mount point?
         //there is no cgroup2 specific super option - for now use 'rw' option
         mi = mountinfo_find_by_filesystem_super_option(root, "cgroup2", "rw");
@@ -401,7 +309,7 @@ void read_cgroup_plugin_configuration() {
             s = mi->mount_point;
 
         set_cgroup_base_path(filename, s);
-        cgroup_unified_base = config_get("plugin:cgroups", "path to unified cgroups", filename);
+        cgroup_unified_base = strdupz(filename);
     }
 
     cgroup_root_max = (int)config_get_number("plugin:cgroups", "max cgroups to allow", cgroup_root_max);
@@ -512,13 +420,15 @@ void read_cgroup_plugin_configuration() {
                        " * "
             ), NULL, SIMPLE_PATTERN_EXACT, true);
 
-    if(cgroup_enable_systemd_services) {
-        systemd_services_cgroups = simple_pattern_create(
-                config_get("plugin:cgroups", "cgroups to match as systemd services",
-                           " !/system.slice/*/*.service "
-                           " /system.slice/*.service "
-                ), NULL, SIMPLE_PATTERN_EXACT, true);
-    }
+    systemd_services_cgroups = simple_pattern_create(
+        config_get(
+            "plugin:cgroups",
+            "cgroups to match as systemd services",
+            " !/system.slice/*/*.service "
+            " /system.slice/*.service "),
+        NULL,
+        SIMPLE_PATTERN_EXACT,
+        true);
 
     mountinfo_free_all(root);
 }
@@ -580,10 +490,6 @@ static inline void cgroup_read_cpuacct_stat(struct cpuacct_stat *cp) {
         }
 
         cp->updated = 1;
-
-        if(unlikely(cp->enabled == CONFIG_BOOLEAN_AUTO &&
-                    (cp->user || cp->system || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
-            cp->enabled = CONFIG_BOOLEAN_YES;
     }
 }
 
@@ -633,14 +539,6 @@ static inline void cgroup_read_cpuacct_cpu_stat(struct cpuacct_cpu_throttling *c
         calc_percentage(calc_delta(cp->nr_throttled, nr_throttled_last), calc_delta(cp->nr_periods, nr_periods_last));
 
     cp->updated = 1;
-
-    if (unlikely(cp->enabled == CONFIG_BOOLEAN_AUTO)) {
-        if (likely(
-                cp->nr_periods || cp->nr_throttled || cp->throttled_time ||
-                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)) {
-            cp->enabled = CONFIG_BOOLEAN_YES;
-        }
-    }
 }
 
 static inline void cgroup2_read_cpuacct_cpu_stat(struct cpuacct_stat *cp, struct cpuacct_cpu_throttling *cpt) {
@@ -695,19 +593,6 @@ static inline void cgroup2_read_cpuacct_cpu_stat(struct cpuacct_stat *cp, struct
 
     cp->updated = 1;
     cpt->updated = 1;
-
-    if (unlikely(cp->enabled == CONFIG_BOOLEAN_AUTO)) {
-        if (likely(cp->user || cp->system || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)) {
-            cp->enabled = CONFIG_BOOLEAN_YES;
-        }
-    }
-    if (unlikely(cpt->enabled == CONFIG_BOOLEAN_AUTO)) {
-        if (likely(
-                cpt->nr_periods || cpt->nr_throttled || cpt->throttled_time ||
-                netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)) {
-            cpt->enabled = CONFIG_BOOLEAN_YES;
-        }
-    }
 }
 
 static inline void cgroup_read_cpuacct_cpu_shares(struct cpuacct_cpu_shares *cp) {
@@ -722,10 +607,6 @@ static inline void cgroup_read_cpuacct_cpu_shares(struct cpuacct_cpu_shares *cp)
     }
 
     cp->updated = 1;
-    if (unlikely((cp->enabled == CONFIG_BOOLEAN_AUTO)) &&
-        (cp->shares || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)) {
-        cp->enabled = CONFIG_BOOLEAN_YES;
-    }
 }
 
 static inline void cgroup_read_cpuacct_usage(struct cpuacct_usage *ca) {
@@ -779,31 +660,22 @@ static inline void cgroup_read_cpuacct_usage(struct cpuacct_usage *ca) {
         }
 
         ca->updated = 1;
-
-        if(unlikely(ca->enabled == CONFIG_BOOLEAN_AUTO &&
-                    (total || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
-            ca->enabled = CONFIG_BOOLEAN_YES;
     }
 }
 
 static inline void cgroup_read_blkio(struct blkio *io) {
-    if(unlikely(io->enabled == CONFIG_BOOLEAN_AUTO && io->delay_counter > 0)) {
-        io->delay_counter--;
-        return;
-    }
-
-    if(likely(io->filename)) {
+    if (likely(io->filename)) {
         static procfile *ff = NULL;
 
         ff = procfile_reopen(ff, io->filename, NULL, CGROUP_PROCFILE_FLAG);
-        if(unlikely(!ff)) {
+        if (unlikely(!ff)) {
             io->updated = 0;
             cgroups_check = 1;
             return;
         }
 
         ff = procfile_readall(ff);
-        if(unlikely(!ff)) {
+        if (unlikely(!ff)) {
             io->updated = 0;
             cgroups_check = 1;
             return;
@@ -811,7 +683,7 @@ static inline void cgroup_read_blkio(struct blkio *io) {
 
         unsigned long i, lines = procfile_lines(ff);
 
-        if(unlikely(lines < 1)) {
+        if (unlikely(lines < 1)) {
             collector_error("CGROUP: file '%s' should have 1+ lines.", io->filename);
             io->updated = 0;
             return;
@@ -819,93 +691,57 @@ static inline void cgroup_read_blkio(struct blkio *io) {
 
         io->Read = 0;
         io->Write = 0;
-/*
-        io->Sync = 0;
-        io->Async = 0;
-        io->Total = 0;
-*/
 
-        for(i = 0; i < lines ; i++) {
+        for (i = 0; i < lines; i++) {
             char *s = procfile_lineword(ff, i, 1);
             uint32_t hash = simple_hash(s);
 
-            if(unlikely(hash == Read_hash && !strcmp(s, "Read")))
+            if (unlikely(hash == Read_hash && !strcmp(s, "Read")))
                 io->Read += str2ull(procfile_lineword(ff, i, 2), NULL);
-
-            else if(unlikely(hash == Write_hash && !strcmp(s, "Write")))
+            else if (unlikely(hash == Write_hash && !strcmp(s, "Write")))
                 io->Write += str2ull(procfile_lineword(ff, i, 2), NULL);
-
-/*
-            else if(unlikely(hash == Sync_hash && !strcmp(s, "Sync")))
-                io->Sync += str2ull(procfile_lineword(ff, i, 2));
-
-            else if(unlikely(hash == Async_hash && !strcmp(s, "Async")))
-                io->Async += str2ull(procfile_lineword(ff, i, 2));
-
-            else if(unlikely(hash == Total_hash && !strcmp(s, "Total")))
-                io->Total += str2ull(procfile_lineword(ff, i, 2));
-*/
         }
 
         io->updated = 1;
-
-        if(unlikely(io->enabled == CONFIG_BOOLEAN_AUTO)) {
-            if(unlikely(io->Read || io->Write || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))
-                io->enabled = CONFIG_BOOLEAN_YES;
-            else
-                io->delay_counter = cgroup_recheck_zero_blkio_every_iterations;
-        }
     }
 }
 
 static inline void cgroup2_read_blkio(struct blkio *io, unsigned int word_offset) {
-    if(unlikely(io->enabled == CONFIG_BOOLEAN_AUTO && io->delay_counter > 0)) {
-            io->delay_counter--;
+    if (likely(io->filename)) {
+        static procfile *ff = NULL;
+
+        ff = procfile_reopen(ff, io->filename, NULL, CGROUP_PROCFILE_FLAG);
+        if (unlikely(!ff)) {
+            io->updated = 0;
+            cgroups_check = 1;
             return;
         }
 
-        if(likely(io->filename)) {
-            static procfile *ff = NULL;
-
-            ff = procfile_reopen(ff, io->filename, NULL, CGROUP_PROCFILE_FLAG);
-            if(unlikely(!ff)) {
-                io->updated = 0;
-                cgroups_check = 1;
-                return;
-            }
-
-            ff = procfile_readall(ff);
-            if(unlikely(!ff)) {
-                io->updated = 0;
-                cgroups_check = 1;
-                return;
-            }
-
-            unsigned long i, lines = procfile_lines(ff);
-
-            if (unlikely(lines < 1)) {
-                collector_error("CGROUP: file '%s' should have 1+ lines.", io->filename);
-                io->updated = 0;
-                return;
-            }
-
-            io->Read = 0;
-            io->Write = 0;
-
-            for (i = 0; i < lines; i++) {
-                io->Read += str2ull(procfile_lineword(ff, i, 2 + word_offset), NULL);
-                io->Write += str2ull(procfile_lineword(ff, i, 4 + word_offset), NULL);
-            }
-
-            io->updated = 1;
-
-            if(unlikely(io->enabled == CONFIG_BOOLEAN_AUTO)) {
-                if(unlikely(io->Read || io->Write || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))
-                    io->enabled = CONFIG_BOOLEAN_YES;
-                else
-                    io->delay_counter = cgroup_recheck_zero_blkio_every_iterations;
-            }
+        ff = procfile_readall(ff);
+        if (unlikely(!ff)) {
+            io->updated = 0;
+            cgroups_check = 1;
+            return;
         }
+
+        unsigned long i, lines = procfile_lines(ff);
+
+        if (unlikely(lines < 1)) {
+            collector_error("CGROUP: file '%s' should have 1+ lines.", io->filename);
+            io->updated = 0;
+            return;
+        }
+
+        io->Read = 0;
+        io->Write = 0;
+
+        for (i = 0; i < lines; i++) {
+            io->Read += str2ull(procfile_lineword(ff, i, 2 + word_offset), NULL);
+            io->Write += str2ull(procfile_lineword(ff, i, 4 + word_offset), NULL);
+        }
+
+        io->updated = 1;
+    }
 }
 
 static inline void cgroup2_read_pressure(struct pressure *res) {
@@ -966,13 +802,7 @@ static inline void cgroup2_read_pressure(struct pressure *res) {
 static inline void cgroup_read_memory(struct memory *mem, char parent_cg_is_unified) {
     static procfile *ff = NULL;
 
-    // read detailed ram usage
     if(likely(mem->filename_detailed)) {
-        if(unlikely(mem->enabled_detailed == CONFIG_BOOLEAN_AUTO && mem->delay_counter_detailed > 0)) {
-            mem->delay_counter_detailed--;
-            goto memory_next;
-        }
-
         ff = procfile_reopen(ff, mem->filename_detailed, NULL, CGROUP_PROCFILE_FLAG);
         if(unlikely(!ff)) {
             mem->updated_detailed = 0;
@@ -1031,42 +861,24 @@ static inline void cgroup_read_memory(struct memory *mem, char parent_cg_is_unif
 
         arl_begin(mem->arl_base);
 
-        for(i = 0; i < lines ; i++) {
-            if(arl_check(mem->arl_base,
-                    procfile_lineword(ff, i, 0),
-                    procfile_lineword(ff, i, 1))) break;
+        for (i = 0; i < lines; i++) {
+            if (arl_check(mem->arl_base, procfile_lineword(ff, i, 0), procfile_lineword(ff, i, 1)))
+                break;
         }
 
-        if(unlikely(mem->arl_dirty->flags & ARL_ENTRY_FLAG_FOUND))
+        if (unlikely(mem->arl_dirty->flags & ARL_ENTRY_FLAG_FOUND))
             mem->detailed_has_dirty = 1;
 
-        if(unlikely(parent_cg_is_unified == 0 && mem->arl_swap->flags & ARL_ENTRY_FLAG_FOUND))
+        if (unlikely(parent_cg_is_unified == 0 && mem->arl_swap->flags & ARL_ENTRY_FLAG_FOUND))
             mem->detailed_has_swap = 1;
 
-        // fprintf(stderr, "READ: '%s', cache: %llu, rss: %llu, rss_huge: %llu, mapped_file: %llu, writeback: %llu, dirty: %llu, swap: %llu, pgpgin: %llu, pgpgout: %llu, pgfault: %llu, pgmajfault: %llu, inactive_anon: %llu, active_anon: %llu, inactive_file: %llu, active_file: %llu, unevictable: %llu, hierarchical_memory_limit: %llu, total_cache: %llu, total_rss: %llu, total_rss_huge: %llu, total_mapped_file: %llu, total_writeback: %llu, total_dirty: %llu, total_swap: %llu, total_pgpgin: %llu, total_pgpgout: %llu, total_pgfault: %llu, total_pgmajfault: %llu, total_inactive_anon: %llu, total_active_anon: %llu, total_inactive_file: %llu, total_active_file: %llu, total_unevictable: %llu\n", mem->filename, mem->cache, mem->rss, mem->rss_huge, mem->mapped_file, mem->writeback, mem->dirty, mem->swap, mem->pgpgin, mem->pgpgout, mem->pgfault, mem->pgmajfault, mem->inactive_anon, mem->active_anon, mem->inactive_file, mem->active_file, mem->unevictable, mem->hierarchical_memory_limit, mem->total_cache, mem->total_rss, mem->total_rss_huge, mem->total_mapped_file, mem->total_writeback, mem->total_dirty, mem->total_swap, mem->total_pgpgin, mem->total_pgpgout, mem->total_pgfault, mem->total_pgmajfault, mem->total_inactive_anon, mem->total_active_anon, mem->total_inactive_file, mem->total_active_file, mem->total_unevictable);
-
         mem->updated_detailed = 1;
-
-        if(unlikely(mem->enabled_detailed == CONFIG_BOOLEAN_AUTO)) {
-            if(( (!parent_cg_is_unified) && ( mem->total_cache || mem->total_dirty || mem->total_rss || mem->total_rss_huge || mem->total_mapped_file || mem->total_writeback
-                    || mem->total_swap || mem->total_pgpgin || mem->total_pgpgout || mem->total_pgfault || mem->total_pgmajfault || mem->total_inactive_file))
-               || (parent_cg_is_unified && ( mem->anon || mem->total_dirty || mem->kernel_stack || mem->slab || mem->sock || mem->total_writeback
-                    || mem->anon_thp || mem->total_pgfault || mem->total_pgmajfault || mem->total_inactive_file))
-               || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)
-                mem->enabled_detailed = CONFIG_BOOLEAN_YES;
-            else
-                mem->delay_counter_detailed = cgroup_recheck_zero_mem_detailed_every_iterations;
-        }
     }
 
 memory_next:
 
-    // read usage_in_bytes
-    if(likely(mem->filename_usage_in_bytes)) {
+    if (likely(mem->filename_usage_in_bytes)) {
         mem->updated_usage_in_bytes = !read_single_number_file(mem->filename_usage_in_bytes, &mem->usage_in_bytes);
-        if(unlikely(mem->updated_usage_in_bytes && mem->enabled_usage_in_bytes == CONFIG_BOOLEAN_AUTO &&
-                    (mem->usage_in_bytes || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
-            mem->enabled_usage_in_bytes = CONFIG_BOOLEAN_YES;
     }
 
     if (likely(mem->updated_usage_in_bytes && mem->updated_detailed)) {
@@ -1074,44 +886,28 @@ memory_next:
             (mem->usage_in_bytes > mem->total_inactive_file) ? (mem->usage_in_bytes - mem->total_inactive_file) : 0;
     }
 
-    // read msw_usage_in_bytes
-    if(likely(mem->filename_msw_usage_in_bytes)) {
-        mem->updated_msw_usage_in_bytes = !read_single_number_file(mem->filename_msw_usage_in_bytes, &mem->msw_usage_in_bytes);
-        if(unlikely(mem->updated_msw_usage_in_bytes && mem->enabled_msw_usage_in_bytes == CONFIG_BOOLEAN_AUTO &&
-                    (mem->msw_usage_in_bytes || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES)))
-            mem->enabled_msw_usage_in_bytes = CONFIG_BOOLEAN_YES;
+    if (likely(mem->filename_msw_usage_in_bytes)) {
+        mem->updated_msw_usage_in_bytes =
+            !read_single_number_file(mem->filename_msw_usage_in_bytes, &mem->msw_usage_in_bytes);
     }
 
-    // read failcnt
-    if(likely(mem->filename_failcnt)) {
-        if(unlikely(mem->enabled_failcnt == CONFIG_BOOLEAN_AUTO && mem->delay_counter_failcnt > 0)) {
-            mem->updated_failcnt = 0;
-            mem->delay_counter_failcnt--;
-        }
-        else {
-            mem->updated_failcnt = !read_single_number_file(mem->filename_failcnt, &mem->failcnt);
-            if(unlikely(mem->updated_failcnt && mem->enabled_failcnt == CONFIG_BOOLEAN_AUTO)) {
-                if(unlikely(mem->failcnt || netdata_zero_metrics_enabled == CONFIG_BOOLEAN_YES))
-                    mem->enabled_failcnt = CONFIG_BOOLEAN_YES;
-                else
-                    mem->delay_counter_failcnt = cgroup_recheck_zero_mem_failcnt_every_iterations;
-            }
-        }
+    if (likely(mem->filename_failcnt)) {
+        mem->updated_failcnt = !read_single_number_file(mem->filename_failcnt, &mem->failcnt);
     }
 }
 
 static void cgroup_read_pids_current(struct pids *pids) {
-    pids->pids_current_updated = 0;
+    pids->updated = 0;
 
-    if (unlikely(!pids->pids_current_filename))
+    if (unlikely(!pids->filename))
         return;
 
-    pids->pids_current_updated = !read_single_number_file(pids->pids_current_filename, &pids->pids_current);
+    pids->updated = !read_single_number_file(pids->filename, &pids->pids_current);
 }
 
 static inline void read_cgroup(struct cgroup *cg) {
     netdata_log_debug(D_CGROUP, "reading metrics for cgroups '%s'", cg->id);
-    if(!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) {
+    if (!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) {
         cgroup_read_cpuacct_stat(&cg->cpuacct_stat);
         cgroup_read_cpuacct_usage(&cg->cpuacct_usage);
         cgroup_read_cpuacct_cpu_stat(&cg->cpuacct_cpu_throttling);
@@ -1123,10 +919,8 @@ static inline void read_cgroup(struct cgroup *cg) {
         cgroup_read_blkio(&cg->throttle_io_serviced);
         cgroup_read_blkio(&cg->io_merged);
         cgroup_read_blkio(&cg->io_queued);
-        cgroup_read_pids_current(&cg->pids);
-    }
-    else {
-        //TODO: io_service_bytes and io_serviced use same file merge into 1 function
+        cgroup_read_pids_current(&cg->pids_current);
+    } else {
         cgroup2_read_blkio(&cg->io_service_bytes, 0);
         cgroup2_read_blkio(&cg->io_serviced, 4);
         cgroup2_read_cpuacct_cpu_stat(&cg->cpuacct_stat, &cg->cpuacct_cpu_throttling);
@@ -1136,7 +930,7 @@ static inline void read_cgroup(struct cgroup *cg) {
         cgroup2_read_pressure(&cg->memory_pressure);
         cgroup2_read_pressure(&cg->irq_pressure);
         cgroup_read_memory(&cg->memory, 1);
-        cgroup_read_pids_current(&cg->pids);
+        cgroup_read_pids_current(&cg->pids_current);
     }
 }
 
@@ -1314,7 +1108,7 @@ void update_cgroup_systemd_services_charts() {
             update_io_merged_ops_chart(cg);
         }
 
-        if (likely(cg->pids.pids_current_updated)) {
+        if (likely(cg->pids_current.updated)) {
             update_pids_current_chart(cg);
         }
 
@@ -1324,14 +1118,14 @@ void update_cgroup_systemd_services_charts() {
 
 void update_cgroup_charts() {
     for (struct cgroup *cg = cgroup_root; cg; cg = cg->next) {
-        if(unlikely(!cg->enabled || cg->pending_renames || is_cgroup_systemd_service(cg)))
+        if (unlikely(!cg->enabled || cg->pending_renames || is_cgroup_systemd_service(cg)))
             continue;
 
-        if (likely(cg->cpuacct_stat.updated && cg->cpuacct_stat.enabled == CONFIG_BOOLEAN_YES)) {
+        if (likely(cg->cpuacct_stat.updated)) {
             update_cpu_utilization_chart(cg);
 
-            if(likely(cg->filename_cpuset_cpus || cg->filename_cpu_cfs_period || cg->filename_cpu_cfs_quota)) {
-                if(!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) {
+            if (likely(cg->filename_cpuset_cpus || cg->filename_cpu_cfs_period || cg->filename_cpu_cfs_quota)) {
+                if (!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) {
                     update_cpu_limits(&cg->filename_cpuset_cpus, &cg->cpuset_cpus, cg);
                     update_cpu_limits(&cg->filename_cpu_cfs_period, &cg->cpu_cfs_period, cg);
                     update_cpu_limits(&cg->filename_cpu_cfs_quota, &cg->cpu_cfs_quota, cg);
@@ -1339,31 +1133,39 @@ void update_cgroup_charts() {
                     update_cpu_limits2(cg);
                 }
 
-                if(unlikely(!cg->chart_var_cpu_limit)) {
+                if (unlikely(!cg->chart_var_cpu_limit)) {
                     cg->chart_var_cpu_limit = rrdvar_chart_variable_add_and_acquire(cg->st_cpu, "cpu_limit");
-                    if(!cg->chart_var_cpu_limit) {
-                        collector_error("Cannot create cgroup %s chart variable 'cpu_limit'. Will not update its limit anymore.", cg->id);
-                        if(cg->filename_cpuset_cpus) freez(cg->filename_cpuset_cpus);
+                    if (!cg->chart_var_cpu_limit) {
+                        collector_error(
+                            "Cannot create cgroup %s chart variable 'cpu_limit'. Will not update its limit anymore.",
+                            cg->id);
+                        if (cg->filename_cpuset_cpus)
+                            freez(cg->filename_cpuset_cpus);
                         cg->filename_cpuset_cpus = NULL;
-                        if(cg->filename_cpu_cfs_period) freez(cg->filename_cpu_cfs_period);
+                        if (cg->filename_cpu_cfs_period)
+                            freez(cg->filename_cpu_cfs_period);
                         cg->filename_cpu_cfs_period = NULL;
-                        if(cg->filename_cpu_cfs_quota) freez(cg->filename_cpu_cfs_quota);
+                        if (cg->filename_cpu_cfs_quota)
+                            freez(cg->filename_cpu_cfs_quota);
                         cg->filename_cpu_cfs_quota = NULL;
                     }
                 } else {
                     NETDATA_DOUBLE value = 0, quota = 0;
 
-                    if(likely( ((!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) && (cg->filename_cpuset_cpus || (cg->filename_cpu_cfs_period && cg->filename_cpu_cfs_quota)))
-                            || ((cg->options & CGROUP_OPTIONS_IS_UNIFIED) && cg->filename_cpu_cfs_quota))) {
-                        if(unlikely(cg->cpu_cfs_quota > 0))
+                    if (likely(
+                            ((!(cg->options & CGROUP_OPTIONS_IS_UNIFIED)) &&
+                             (cg->filename_cpuset_cpus ||
+                              (cg->filename_cpu_cfs_period && cg->filename_cpu_cfs_quota))) ||
+                            ((cg->options & CGROUP_OPTIONS_IS_UNIFIED) && cg->filename_cpu_cfs_quota))) {
+                        if (unlikely(cg->cpu_cfs_quota > 0))
                             quota = (NETDATA_DOUBLE)cg->cpu_cfs_quota / (NETDATA_DOUBLE)cg->cpu_cfs_period;
 
-                        if(unlikely(quota > 0 && quota < cg->cpuset_cpus))
+                        if (unlikely(quota > 0 && quota < cg->cpuset_cpus))
                             value = quota * 100;
                         else
                             value = (NETDATA_DOUBLE)cg->cpuset_cpus * 100;
                     }
-                    if(likely(value)) {
+                    if (likely(value)) {
                         update_cpu_utilization_limit_chart(cg, value);
                     } else {
                         if (unlikely(cg->st_cpu_limit)) {
@@ -1376,20 +1178,20 @@ void update_cgroup_charts() {
             }
         }
 
-        if (likely(cg->cpuacct_cpu_throttling.updated && cg->cpuacct_cpu_throttling.enabled == CONFIG_BOOLEAN_YES)) {
+        if (likely(cg->cpuacct_cpu_throttling.updated)) {
             update_cpu_throttled_chart(cg);
             update_cpu_throttled_duration_chart(cg);
         }
 
-        if (likely(cg->cpuacct_cpu_shares.updated && cg->cpuacct_cpu_shares.enabled == CONFIG_BOOLEAN_YES)) {
+        if (unlikely(cg->cpuacct_cpu_shares.updated)) {
             update_cpu_shares_chart(cg);
         }
 
-        if (likely(cg->cpuacct_usage.updated && cg->cpuacct_usage.enabled == CONFIG_BOOLEAN_YES)) {
+        if (likely(cg->cpuacct_usage.updated)) {
             update_cpu_per_core_usage_chart(cg);
         }
 
-        if (likely(cg->memory.updated_detailed && cg->memory.enabled_detailed == CONFIG_BOOLEAN_YES)) {
+        if (likely(cg->memory.updated_detailed)) {
             update_mem_usage_detailed_chart(cg);
             update_mem_writeback_chart(cg);
 
@@ -1400,14 +1202,13 @@ void update_cgroup_charts() {
             update_mem_pgfaults_chart(cg);
         }
 
-        if (likely(cg->memory.updated_usage_in_bytes && cg->memory.enabled_usage_in_bytes == CONFIG_BOOLEAN_YES)) {
+        if (likely(cg->memory.updated_usage_in_bytes)) {
             update_mem_usage_chart(cg);
 
-            // FIXME: this if should be only for unlimited charts
-            if(likely(host_ram_total)) {
+            // FIXME: this "if" should be only for unlimited charts
+            if (likely(host_ram_total)) {
                 // FIXME: do we need to update mem limits on every data collection?
                 if (likely(update_memory_limits(cg))) {
-
                     unsigned long long memory_limit = host_ram_total;
                     if (unlikely(cg->memory_limit < host_ram_total))
                         memory_limit = cg->memory_limit;
@@ -1428,35 +1229,35 @@ void update_cgroup_charts() {
             }
         }
 
-        if (likely(cg->memory.updated_failcnt && cg->memory.enabled_failcnt == CONFIG_BOOLEAN_YES)) {
+        if (likely(cg->memory.updated_failcnt)) {
             update_mem_failcnt_chart(cg);
         }
 
-        if (likely(cg->io_service_bytes.updated && cg->io_service_bytes.enabled == CONFIG_BOOLEAN_YES)) {
+        if (likely(cg->io_service_bytes.updated)) {
             update_io_serviced_bytes_chart(cg);
         }
 
-        if (likely(cg->io_serviced.updated && cg->io_serviced.enabled == CONFIG_BOOLEAN_YES)) {
+        if (likely(cg->io_serviced.updated)) {
             update_io_serviced_ops_chart(cg);
         }
 
-        if (likely(cg->throttle_io_service_bytes.updated && cg->throttle_io_service_bytes.enabled == CONFIG_BOOLEAN_YES)) {
-                update_throttle_io_serviced_bytes_chart(cg);
+        if (likely(cg->throttle_io_service_bytes.updated)) {
+            update_throttle_io_serviced_bytes_chart(cg);
         }
 
-        if (likely(cg->throttle_io_serviced.updated && cg->throttle_io_serviced.enabled == CONFIG_BOOLEAN_YES)) {
-                update_throttle_io_serviced_ops_chart(cg);
+        if (likely(cg->throttle_io_serviced.updated)) {
+            update_throttle_io_serviced_ops_chart(cg);
         }
 
-        if (likely(cg->io_queued.updated && cg->io_queued.enabled == CONFIG_BOOLEAN_YES)) {
-                update_io_queued_ops_chart(cg);
+        if (likely(cg->io_queued.updated)) {
+            update_io_queued_ops_chart(cg);
         }
 
-        if (likely(cg->io_merged.updated && cg->io_merged.enabled == CONFIG_BOOLEAN_YES)) {
-                update_io_merged_ops_chart(cg);
+        if (likely(cg->io_merged.updated)) {
+            update_io_merged_ops_chart(cg);
         }
 
-        if (likely(cg->pids.pids_current_updated)) {
+        if (likely(cg->pids_current.updated)) {
                 update_pids_current_chart(cg);
         }
 
@@ -1541,10 +1342,9 @@ static void cgroup_main_cleanup(void *pptr) {
 void cgroup_read_host_total_ram() {
     procfile *ff = NULL;
     char filename[FILENAME_MAX + 1];
-    snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/meminfo");
 
-    ff = procfile_open(
-        config_get("plugin:cgroups", "meminfo filename to monitor", filename), " \t:", PROCFILE_FLAG_DEFAULT);
+    snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/proc/meminfo");
+    ff = procfile_open(filename, " \t:", PROCFILE_FLAG_DEFAULT);
 
     if (likely((ff = procfile_readall(ff)) && procfile_lines(ff) && !strncmp(procfile_word(ff, 0), "MemTotal", 8)))
         host_ram_total = str2ull(procfile_word(ff, 1), NULL) * 1024;
@@ -1563,8 +1363,8 @@ void *cgroups_main(void *ptr) {
     worker_register_job_name(WORKER_CGROUPS_CHART, "chart");
 
     if (getenv("KUBERNETES_SERVICE_HOST") != NULL && getenv("KUBERNETES_SERVICE_PORT") != NULL) {
-        is_inside_k8s = 1;
-        cgroup_enable_cpuacct_cpu_shares = CONFIG_BOOLEAN_YES;
+        is_inside_k8s = true;
+        cgroup_enable_cpuacct_cpu_shares = true;
     }
 
     read_cgroup_plugin_configuration();
@@ -1643,8 +1443,7 @@ void *cgroups_main(void *ptr) {
         worker_is_busy(WORKER_CGROUPS_CHART);
 
         update_cgroup_charts();
-        if (cgroup_enable_systemd_services)
-            update_cgroup_systemd_services_charts();
+        update_cgroup_systemd_services_charts();
 
         if (unlikely(!service_running(SERVICE_COLLECTORS))) {
            uv_mutex_unlock(&cgroup_root_mutex);

--- a/src/collectors/proc.plugin/proc_pressure.h
+++ b/src/collectors/proc.plugin/proc_pressure.h
@@ -6,8 +6,9 @@
 #define PRESSURE_NUM_RESOURCES 4
 
 struct pressure {
-    int updated;
     char *filename;
+    bool staterr;
+    int updated;
 
     struct pressure_charts {
         bool available;


### PR DESCRIPTION
##### Summary

This PR adds the following updates to the groups plugin:

- Removes "ingore zero metrics" (reasoning in [17775](https://github.com/netdata/netdata/pull/17775)).
- Removes enable/disable specific metrics and path settings. There are a lot them and they don't provide any value in general.

<details>
<summary>all removed settings </summary>

```
	# use unified cgroups = auto
	# containers priority = 40000
	# enable cpuacct stat (total CPU) = auto
	# enable cpuacct usage (per core CPU) = no
	# enable cpuacct cpu throttling = yes
	# enable cpuacct cpu shares = no
	# enable memory = auto
	# enable detailed memory = auto
	# enable memory limits fail count = auto
	# enable swap memory = auto
	# enable blkio bandwidth = auto
	# enable blkio operations = auto
	# enable blkio throttle bandwidth = auto
	# enable blkio throttle operations = auto
	# enable blkio queued operations = auto
	# enable blkio merged operations = auto
	# enable cpu pressure = auto
	# enable io some pressure = auto
	# enable io full pressure = auto
	# enable memory some pressure = auto
	# enable memory full pressure = auto
	# recheck zero blkio every iterations = 10
	# recheck zero memory failcnt every iterations = 10
	# recheck zero detailed memory every iterations = 10
	# enable systemd services = yes
	# enable systemd services detailed memory = no
	# report used memory = yes
	# path to unified cgroups = /sys/fs/cgroup
	# meminfo filename to monitor = /proc/meminfo

	# path to /sys/fs/cgroup/cpuacct = /sys/fs/cgroup/cpu,cpuacct
	# path to /sys/fs/cgroup/cpuset = /sys/fs/cgroup/cpuset
	# path to /sys/fs/cgroup/blkio = /sys/fs/cgroup/blkio
	# path to /sys/fs/cgroup/memory = /sys/fs/cgroup/memory
	# path to /sys/fs/cgroup/devices = /sys/fs/cgroup/devices
	# path to /sys/fs/cgroup/pids = /sys/fs/cgroup/pids
```

</details>

##### Test Plan

Add/remove containers, and check charts on hosts with cgroup v1 and v2.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
