### PR TITLE
fix cgroups pressure

### DIFF
--- a/src/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/src/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -790,12 +790,8 @@ static inline void cgroup2_read_pressure(struct pressure *res) {
         }
 
         res->updated = (did_full || did_some) ? 1 : 0;
-
-        if(unlikely(res->some.enabled == CONFIG_BOOLEAN_AUTO))
-            res->some.enabled = (did_some) ? CONFIG_BOOLEAN_YES : CONFIG_BOOLEAN_NO;
-
-        if(unlikely(res->full.enabled == CONFIG_BOOLEAN_AUTO))
-            res->full.enabled = (did_full) ? CONFIG_BOOLEAN_YES : CONFIG_BOOLEAN_NO;
+        res->some.available = did_some;
+        res->full.available = did_full;
     }
 }
 
@@ -1263,44 +1259,44 @@ void update_cgroup_charts() {
 
         if (cg->options & CGROUP_OPTIONS_IS_UNIFIED) {
             if (likely(cg->cpu_pressure.updated)) {
-                    if (cg->cpu_pressure.some.enabled) {
+                    if (cg->cpu_pressure.some.available) {
                         update_cpu_some_pressure_chart(cg);
                         update_cpu_some_pressure_stall_time_chart(cg);
                     }
-                    if (cg->cpu_pressure.full.enabled) {
+                    if (cg->cpu_pressure.full.available) {
                         update_cpu_full_pressure_chart(cg);
                         update_cpu_full_pressure_stall_time_chart(cg);
                     }
             }
 
             if (likely(cg->memory_pressure.updated)) {
-                if (cg->memory_pressure.some.enabled) {
+                if (cg->memory_pressure.some.available) {
                         update_mem_some_pressure_chart(cg);
                         update_mem_some_pressure_stall_time_chart(cg);
                 }
-                if (cg->memory_pressure.full.enabled) {
+                if (cg->memory_pressure.full.available) {
                         update_mem_full_pressure_chart(cg);
                         update_mem_full_pressure_stall_time_chart(cg);
                 }
             }
 
             if (likely(cg->irq_pressure.updated)) {
-                if (cg->irq_pressure.some.enabled) {
+                if (cg->irq_pressure.some.available) {
                         update_irq_some_pressure_chart(cg);
                         update_irq_some_pressure_stall_time_chart(cg);
                 }
-                if (cg->irq_pressure.full.enabled) {
+                if (cg->irq_pressure.full.available) {
                         update_irq_full_pressure_chart(cg);
                         update_irq_full_pressure_stall_time_chart(cg);
                 }
             }
 
             if (likely(cg->io_pressure.updated)) {
-                if (cg->io_pressure.some.enabled) {
+                if (cg->io_pressure.some.available) {
                         update_io_some_pressure_chart(cg);
                         update_io_some_pressure_stall_time_chart(cg);
                 }
-                if (cg->io_pressure.full.enabled) {
+                if (cg->io_pressure.full.available) {
                         update_io_full_pressure_chart(cg);
                         update_io_full_pressure_stall_time_chart(cg);
                 }


### PR DESCRIPTION
##### Summary

This PR fixes an issue introduced in #17795: we shouldn't "full" chart if the metric is not available, e.g.:

```
$ cat /sys/fs/cgroup/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod001f7c0e_a641_4538_84c3_06e5a67f4073.slice/cri-containerd-334ee75a65caba05a913a0e9908baea20a6448364a9a61583d6669fed25e721b.scope/cpu.pressure
some avg10=0.00 avg60=0.00 avg300=0.00 total=98464
```

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
