### PR TITLE
Add alert meta info (node index)

### DIFF
--- a/src/database/contexts/api_v2.c
+++ b/src/database/contexts/api_v2.c
@@ -1580,6 +1580,16 @@ static void contexts_v2_alerts_to_json(BUFFER *wb, struct rrdcontext_to_json_v2_
                         buffer_json_add_array_item_object(wb);
                         {
                             buffer_json_member_add_uint64(wb, "ati", t->ati);
+
+                            buffer_json_member_add_array(wb, "ni");
+                            void *host_guid;
+                            dfe_start_read(t->nodes, host_guid) {
+                                struct contexts_v2_node *cn = dictionary_get(ctl->nodes.dict,host_guid_dfe.name);
+                                buffer_json_add_array_item_int64(wb, (int64_t) cn->ni);
+                            }
+                            dfe_done(host_guid);
+                            buffer_json_array_close(wb);
+
                             buffer_json_member_add_string(wb, "nm", string2str(t->name));
                             buffer_json_member_add_string(wb, "sum", string2str(t->summary));
 


### PR DESCRIPTION
##### Summary
- Add an ni array (index to nodes that the alert applies)

Before

```
        {
            "ati":4,
            "nm":"active_processes",
            "sum":"System PIDs utilization",
            "cr":0,
            "wr":0,
            "cl":1,
            "er":0,
            "in":2,
            "nd":2,
            "cfg":1,
            "ctx":["system.active_processes"],
            "cls":["workload"],
            "cp":["processes"],
            "ty":["system"],
            "to":["sysadmin"]
        }
```
after

Adding `"ni": [0,7]` index array to the nodes that the alert applies

```
        {
            "ati":4,
            "ni":[0,7],
            "nm":"active_processes",
            "sum":"System PIDs utilization",
            "cr":0,
            "wr":0,
            "cl":1,
            "er":0,
            "in":2,
            "nd":2,
            "cfg":1,
            "ctx":["system.active_processes"],
            "cls":["workload"],
            "cp":["processes"],
            "ty":["system"],
            "to":["sysadmin"]
        }
```