### PR TITLE
Fix coverity report

### DIFF
--- a/src/collectors/proc.plugin/sys_kernel_mm_ksm.c
+++ b/src/collectors/proc.plugin/sys_kernel_mm_ksm.c
@@ -187,7 +187,7 @@ int do_sys_kernel_mm_ksm(int update_every, usec_t dt) {
             rd_savings = rrddim_add(st_mem_ksm_ratios, "savings", NULL, 1, 10000, RRD_ALGORITHM_ABSOLUTE);
         }
 
-        rrddim_set_by_pointer(st_mem_ksm_ratios, rd_savings, offered ? (saved * 1000000) / offered : 0);
+        rrddim_set_by_pointer(st_mem_ksm_ratios, rd_savings, (saved * 1000000) / offered);
         rrdset_done(st_mem_ksm_ratios);
     }
 


### PR DESCRIPTION
##### Summary
Last e-mail reported:

```sh
*** CID 426217:  Control flow issues  (DEADCODE)
/src/collectors/proc.plugin/sys_kernel_mm_ksm.c: 190 in do_sys_kernel_mm_ksm()
184                         , RRDSET_TYPE_LINE
185                 );
186     
187                 rd_savings = rrddim_add(st_mem_ksm_ratios, "savings", NULL, 1, 10000, RRD_ALGORITHM_ABSOLUTE);
188             }
189     
>>>     CID 426217:  Control flow issues  (DEADCODE)
>>>     Execution cannot reach the expression "0ULL" inside this statement: "rrddim_set_by_pointer(st_me...".
190             rrddim_set_by_pointer(st_mem_ksm_ratios, rd_savings, offered ? (saved * 1000000) / offered : 0);
191             rrdset_done(st_mem_ksm_ratios);
192         }
193     
194         return 0;
````

This PR remove the dead code.

##### Test Plan

1. Check CI finishes compilation.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
