### PR TITLE
Disable updater jitter when run from anacron.

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -151,24 +151,24 @@ issystemd() {
 
 # shellcheck disable=SC2009
 running_under_anacron() {
-    if [ "$(uname -s)" = "Linux" ] && [ -d "/proc/$$" ]; then
+    if [ "$(uname -s)" = "Linux" ] && [ -r "/proc/$$/stat" ]; then
         ppid="$(cut -f 4 -d ' ' "/proc/$$/stat")"
-        if [ -n "${ppid}" ] && [ -d "/proc/${ppid}" ]; then
+        if [ -n "${ppid}" ] && [ -r "/proc/${ppid}/comm" ]; then
             grep -q anacron "/proc/${ppid}/comm" && return 0
 
             ppid2="$(cut -f 4 -d ' ' "/proc/${ppid}/stat")"
 
-            if [ -n "${ppid2}" ] && [ -d "/proc/${ppid2}" ]; then
-                grep -q anacron "/proc/${ppid2}/comm" && return 0
+            if [ -n "${ppid2}" ] && [ -r "/proc/${ppid2}/comm" ]; then
+                grep -q anacron "/proc/${ppid2}/comm" 2>/dev/null && return 0
             fi
         fi
     else
-        ppid="$(ps -o pid=,ppid= | grep -e "^ *$$" | xargs | cut -f 2 -d ' ')"
+        ppid="$(ps -o pid= -o ppid= 2>/dev/null | grep -e "^ *$$" | xargs | cut -f 2 -d ' ')"
         if [ -n "${ppid}" ]; then
-            ps -o pid=,command= | grep -e "^ ${ppid}" | grep -q anacron && return 0
+            ps -o pid= -o command= 2>/dev/null | grep -e "^ ${ppid}" | grep -q anacron && return 0
 
-            ppid2="$(ps -o pid=,ppid= | grep -e "^ *${ppid}" | xargs | cut -f 2 -d ' ')"
-            ps -o pid=,command= | grep -e "^ ${ppid2}" | grep -q anacron && return 0
+            ppid2="$(ps -o pid= -o ppid= 2>/dev/null | grep -e "^ *${ppid}" | xargs | cut -f 2 -d ' ')"
+            ps -o pid= -o command= 2>/dev/null | grep -e "^ ${ppid2}" | grep -q anacron && return 0
         fi
     fi
 

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -165,10 +165,10 @@ running_under_anacron() {
     else
         ppid="$(ps -o pid= -o ppid= 2>/dev/null | grep -e "^ *$$" | xargs | cut -f 2 -d ' ')"
         if [ -n "${ppid}" ]; then
-            ps -o pid= -o command= 2>/dev/null | grep -e "^ ${ppid}" | grep -q anacron && return 0
+            ps -o pid= -o command= 2>/dev/null | grep -e "^ *${ppid}" | grep -q anacron && return 0
 
             ppid2="$(ps -o pid= -o ppid= 2>/dev/null | grep -e "^ *${ppid}" | xargs | cut -f 2 -d ' ')"
-            ps -o pid= -o command= 2>/dev/null | grep -e "^ ${ppid2}" | grep -q anacron && return 0
+            ps -o pid= -o command= 2>/dev/null | grep -e "^ *${ppid2}" | grep -q anacron && return 0
         fi
     fi
 

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -149,6 +149,12 @@ issystemd() {
   return 1
 }
 
+running_under_anacron() {
+    ppid="$(ps -p "$$" -o ppid= | tr -d ' ')"
+    ps -p "${ppid}" -o command= | grep -q anacron && return 0
+    return 1
+}
+
 _get_intervaldir() {
   if [ -d /etc/cron.daily ]; then
     echo /etc/cron.daily
@@ -1079,6 +1085,12 @@ if [ -n "${NETDATA_OFFLINE_INSTALL_SOURCE}" ]; then
   NETDATA_NO_UPDATER_SELF_UPDATE=1
   NETDATA_UPDATER_JITTER=0
   NETDATA_FORCE_UPDATE=1
+fi
+
+# If we seem to be running under anacron, act as if we’re not running from cron.
+# This is mostly to disable jitter, which should not be needed when run from anacron.
+if running_under_anacron; then
+  NETDATA_NOT_RUNNING_FROM_CRON="${NETDATA_NOT_RUNNING_FROM_CRON:-1}"
 fi
 
 # Random sleep to alleviate stampede effect of Agents upgrading

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -149,9 +149,11 @@ issystemd() {
   return 1
 }
 
+# shellcheck disable=SC2009
 running_under_anacron() {
-    ppid="$(ps -p "$$" -o ppid= | tr -d ' ')"
-    ps -p "${ppid}" -o command= | grep -q anacron && return 0
+    ppid="$(ps -o pid=,ppid= | grep -e "^ $$" | xargs | cut -f 2 -d ' ')"
+    ps -o pid=,command= | grep -e "^ ${ppid}" | grep -q anacron && return 0
+
     return 1
 }
 

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -154,6 +154,9 @@ running_under_anacron() {
     ppid="$(ps -o pid=,ppid= | grep -e "^ $$" | xargs | cut -f 2 -d ' ')"
     ps -o pid=,command= | grep -e "^ ${ppid}" | grep -q anacron && return 0
 
+    ppid2="$(ps -o pid=,ppid= | grep -e "^ ${ppid}" | xargs | cut -f 2 -d ' ')"
+    ps -o pid=,command= | grep -e "^ ${ppid2}" | grep -q anacron && return 0
+
     return 1
 }
 


### PR DESCRIPTION
##### Summary

This attempts to detect when run under Anacron (by inspecting the parent process ID of the script itself), and if so it overrides the interactivity detection to disable the random delay during the update process. The detection is a bit fragile and may not work in all cases, but it should run properly (even if it may give a false negative) on any system that provides a version of `ps` that is either POSIX compliant _or_ that is provided by Busybox.

##### Test Plan

Testing is unfortunately complicated for this, but basic confirmation that it still works as intended for the normal case is relatively easy and should be mostly sufficient.

##### Additional Information

Fixes: #17745 