### PR TITLE
Use bundled protobuf for openSUSE packages.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -360,7 +360,11 @@ happened, on your systems and applications.
 	-DENABLE_BUNDLED_PROTOBUF=Off \
 	%endif
 	%else
+	%if 0%{?suse_version:1}
+	-DENABLE_BUNDLED_PROTOBUF=On \
+	%else
 	-DENABLE_BUNDLED_PROTOBUF=Off \
+	%endif
 	%endif
 	%if %{_have_ml}
 	-DENABLE_ML=On \

--- a/packaging/cmake/Modules/NetdataProtobuf.cmake
+++ b/packaging/cmake/Modules/NetdataProtobuf.cmake
@@ -28,6 +28,7 @@ function(netdata_bundle_protobuf)
         if(NEED_ABSL)
                 set(ABSL_PROPAGATE_CXX_STD On)
                 set(ABSL_ENABLE_INSTALL Off)
+                set(BUILD_SHARED_LIBS Off)
 
                 message(STATUS "Preparing bundled Abseil (required by bundled Protobuf)")
                 FetchContent_Declare(absl


### PR DESCRIPTION
##### Summary

Their system copy is demonstrably problematic, and months of searching for a solution has so far been unsuccessful, so just use a bundled copy instead.

##### Test Plan

openSUSE package build CI jobs pass on this PR.