### PR TITLE
claiming: add proxy to cloud.conf if set

### DIFF
--- a/src/claim/netdata-claim.sh.in
+++ b/src/claim/netdata-claim.sh.in
@@ -413,6 +413,7 @@ if [ "${HTTP_STATUS_CODE}" = "204" ] || [ "${ERROR_KEY}" = "ErrAlreadyClaimed" ]
 [global]
   enabled = yes
   cloud base url = $URL_BASE
+${PROXY:+  proxy = $PROXY}
 HERE_DOC
         if [ "$EUID" == "0" ]; then
             chown -R "${NETDATA_USER}:${NETDATA_USER}" "${CLAIMING_DIR}" || (echo >&2 "Claiming failed"; set -e; exit 2)


### PR DESCRIPTION
##### Summary

We must set "proxy" in "cloud.conf" if a proxy was used during claiming for ACLK to continue using it.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
