### PR TITLE
fix order of loading schema files in dyncfg_get_schema_from

### DIFF
--- a/src/daemon/config/dyncfg-files.c
+++ b/src/daemon/config/dyncfg-files.c
@@ -241,12 +241,12 @@ static bool dyncfg_read_file_to_buffer(const char *filename, BUFFER *dst) {
 static bool dyncfg_get_schema_from(const char *dir, const char *id, BUFFER *dst) {
     char filename[FILENAME_MAX + 1];
 
-    snprintfz(filename, sizeof(filename), "%s/schema.d/%s.json", dir, id);
+    CLEAN_CHAR_P *escaped_id = dyncfg_escape_id_for_filename(id);
+    snprintfz(filename, sizeof(filename), "%s/schema.d/%s.json", dir, escaped_id);
     if(dyncfg_read_file_to_buffer(filename, dst))
         return true;
 
-    CLEAN_CHAR_P *escaped_id = dyncfg_escape_id_for_filename(id);
-    snprintfz(filename, sizeof(filename), "%s/schema.d/%s.json", dir, escaped_id);
+    snprintfz(filename, sizeof(filename), "%s/schema.d/%s.json", dir, id);
     if(dyncfg_read_file_to_buffer(filename, dst))
         return true;
 


### PR DESCRIPTION
##### Summary

Fixes: https://github.com/netdata/netdata/pull/17694#issuecomment-2146918353

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
