### PR TITLE
explicitly disable removed collectors in python.d.conf

### DIFF
--- a/src/collectors/python.d.plugin/python.d.conf
+++ b/src/collectors/python.d.plugin/python.d.conf
@@ -1,28 +1,28 @@
-# netdata python.d.plugin configuration
-#
-# This file is in YaML format.
-# Generally the format is:
-#
-# name: value
-#
+## netdata python.d.plugin configuration
+##
+## This file is in YaML format.
+## Generally the format is:
+##
+## name: value
+##
 
-# Enable / disable the whole python.d.plugin (all its modules)
+## Enable / disable the whole python.d.plugin (all its modules)
 enabled: yes
 
-# ----------------------------------------------------------------------
-# Enable / Disable python.d.plugin modules
+## ----------------------------------------------------------------------
+## Enable / Disable python.d.plugin modules
 #default_run: yes
-#
-# If "default_run" = "yes" the default for all modules is enabled (yes).
-# Setting any of these to "no" will disable it.
-#
-# If "default_run" = "no" the default for all modules is disabled (no).
-# Setting any of these to "yes" will enable it.
+##
+## If "default_run" = "yes" the default for all modules is enabled (yes).
+## Setting any of these to "no" will disable it.
+##
+## If "default_run" = "no" the default for all modules is disabled (no).
+## Setting any of these to "yes" will enable it.
 
-# Enable / Disable explicit garbage collection (full collection run). Default is enabled.
+## Enable / Disable explicit garbage collection (full collection run). Default is enabled.
 gc_run: yes
 
-# Garbage collection interval in seconds. Default is 300.
+## Garbage collection interval in seconds. Default is 300.
 gc_interval: 300
 
 # alarms: yes
@@ -34,23 +34,15 @@ gc_interval: 300
 # ceph: yes
 # changefinder: no
 # dovecot: yes
-
 # this is just an example
 example: no
-
 # exim: yes
-fail2ban: no  # Removed (replaced with go.d/fail2ban). Disabled for existing installations.
 # gearman: yes
 go_expvar: no
-
 # haproxy: yes
-hddtemp: no  # Removed (replaced with go.d/hddtemp). Disabled for existing installations.
-hpssa: no
 # icecast: yes
 # ipfs: yes
-litespeed: no  # Removed (replaced with go.d/litespeed). Disabled for existing installations.
 # memcached: yes
-# mongodb: yes
 # monit: yes
 # nvidia_smi: yes
 # nsd: yes
@@ -63,7 +55,6 @@ litespeed: no  # Removed (replaced with go.d/litespeed). Disabled for existing i
 # retroshare: yes
 # riakkv: yes
 # samba: yes
-sensors: no  # Removed (replaced with go.d/sensors). Disabled for existing installations.
 # smartd_log: yes
 # spigotmc: yes
 # squid: yes
@@ -74,3 +65,22 @@ sensors: no  # Removed (replaced with go.d/sensors). Disabled for existing insta
 # varnish: yes
 # w1sensor: yes
 # zscores: no
+
+
+## Disabled for existing installations.
+adaptec_raid: no   # Removed (replaced with go.d/adaptercraid).
+apache: no         # Removed (replaced with go.d/apache).
+elasticsearch: no  # Removed (replaced with go.d/elasticsearch).
+fail2ban: no       # Removed (replaced with go.d/fail2ban).
+freeradius: no     # Removed (replaced with go.d/freeradius).
+hddtemp: no        # Removed (replaced with go.d/hddtemp).
+hpssa: no          # Removed (replaced with go.d/hpssa).
+litespeed: no      # Removed (replaced with go.d/litespeed).
+megacli: no        # Removed (replaced with go.d/megacli).
+mongodb: no        # Removed (replaced with go.d/mongodb).
+mysql: no          # Removed (replaced with go.d/mysql).
+nginx: no          # Removed (replaced with go.d/nginx).
+postgres: no       # Removed (replaced with go.d/postgres).
+proxysql: no       # Removed (replaced with go.d/proxysql).
+redis: no          # Removed (replaced with go.d/redis).
+sensors: no        # Removed (replaced with go.d/sensors).


### PR DESCRIPTION
##### Summary

Fixes issues like ([mentioned on the forum](https://community.netdata.cloud/t/monitoring-netdata-itself/5499)):

> After Netdata update, MySQL monitoring stops running because the plugin changed from Python.d to go.d or something like that.

for existing installations.

Without explicit disabling, a race condition occurs depending on whichever starts first.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
