### PR TITLE
Properly initialize spinlock in ARAL.

### DIFF
--- a/src/libnetdata/aral/aral.c
+++ b/src/libnetdata/aral/aral.c
@@ -720,6 +720,7 @@ ARAL *aral_create(const char *name, size_t element_size, size_t initial_page_ele
     ar->config.mmap.enabled = mmap;
     strncpyz(ar->config.name, name, ARAL_MAX_NAME);
     spinlock_init(&ar->aral_lock.spinlock);
+    spinlock_init(&ar->adders.spinlock);
 
     if(stats) {
         ar->stats = stats;


### PR DESCRIPTION
##### Summary

SSIA.

##### Test Plan

- CI jobs

##### Additional Information

Not sure why this does not cause problems on non-Windows platforms. In theory, the spinlock would get the wrong initial value 50% of the time because the lock is just a boolean. A major difference between Windows vs. non-Windows platforms is that the minimum sleep duration on Windows is at least 1ms which is a pretty long time in comparison to the other platforms.