### PR TITLE
update dbengine retention chart family and priority

### DIFF
--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1807,13 +1807,13 @@ void dbengine_retention_statistics(void)
                 "netdata",
                 id,
                 NULL,
-                "dbengine",
+                "dbengine retention",
                 "netdata.dbengine_tier_retention",
                 "dbengine space and time retention",
                 "%",
                 "netdata",
                 "stats",
-                200000,
+                134900, // before "dbengine memory" (dbengine2_statistics_charts)
                 10,
                 RRDSET_TYPE_LINE);
 


### PR DESCRIPTION
##### Summary

- change family "dbengine" => "dbengine retention"
- update priority to move the chart above "dbengine memory"

<img width="252" alt="Screenshot 2024-06-09 at 18 47 48" src="https://github.com/netdata/netdata/assets/22274335/8ca4362c-9199-4d52-b42f-e67c81664cd6">


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
