### PR TITLE
Fix tier statistics 

### DIFF
--- a/src/database/contexts/api_v2.c
+++ b/src/database/contexts/api_v2.c
@@ -1183,7 +1183,7 @@ void buffer_json_agents_v2(BUFFER *wb, struct query_timings *timings, time_t now
             group_seconds *= storage_tiers_grouping_iterations[tier];
             uint64_t max = storage_engine_disk_space_max(eng->seb, localhost->db[tier].si);
 #ifdef ENABLE_DBENGINE
-            if (!max)
+            if (!max && eng->seb == STORAGE_ENGINE_BACKEND_DBENGINE)
                 max = get_directory_free_bytes_space(multidb_ctx[tier]);
 #endif
             uint64_t used = storage_engine_disk_space_used(eng->seb, localhost->db[tier].si);

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1649,6 +1649,9 @@ void retention_timer_cb(uv_timer_t *handle)
     uv_update_time(handle->loop);
 
     for (size_t tier = 0; tier < storage_tiers; tier++) {
+        STORAGE_ENGINE *eng = localhost->db[tier].eng;
+        if (!eng || eng->seb != STORAGE_ENGINE_BACKEND_DBENGINE)
+            continue;
         bool cleanup = rrdeng_ctx_tier_cap_exceeded(multidb_ctx[tier]);
         if (cleanup)
             rrdeng_enq_cmd(multidb_ctx[tier], RRDENG_OPCODE_DATABASE_ROTATE, NULL, NULL, STORAGE_PRIORITY_INTERNAL_DBENGINE, NULL, NULL);


### PR DESCRIPTION
##### Summary
When memory mode is non dbengine
- Fix tier statistics when memory mode is not dbengine
  - Avoid querying disk space
- Skip retention checks for non dbengine tiers

