### PR TITLE
Delay retention check until agent has initialized

### DIFF
--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1917,7 +1917,7 @@ void dbengine_event_loop(void* arg) {
     main->tid = gettid_cached();
 
     fatal_assert(0 == uv_timer_start(&main->timer, timer_cb, TIMER_PERIOD_MS, TIMER_PERIOD_MS));
-    fatal_assert(0 == uv_timer_start(&main->retention_timer, retention_timer_cb, 10 * 1, 10 * 1));
+    fatal_assert(0 == uv_timer_start(&main->retention_timer, retention_timer_cb, TIMER_PERIOD_MS * 60, TIMER_PERIOD_MS * 60));
 
     bool shutdown = false;
     while (likely(!shutdown)) {

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1644,6 +1644,9 @@ bool rrdeng_ctx_tier_cap_exceeded(struct rrdengine_instance *ctx)
 
 void retention_timer_cb(uv_timer_t *handle)
 {
+    if (!localhost)
+        return;
+
     worker_is_busy(RRDENG_TIMER_CB);
     uv_stop(handle->loop);
     uv_update_time(handle->loop);
@@ -1914,7 +1917,7 @@ void dbengine_event_loop(void* arg) {
     main->tid = gettid_cached();
 
     fatal_assert(0 == uv_timer_start(&main->timer, timer_cb, TIMER_PERIOD_MS, TIMER_PERIOD_MS));
-    fatal_assert(0 == uv_timer_start(&main->retention_timer, retention_timer_cb, TIMER_PERIOD_MS * 60, TIMER_PERIOD_MS * 60));
+    fatal_assert(0 == uv_timer_start(&main->retention_timer, retention_timer_cb, 10 * 1, 10 * 1));
 
     bool shutdown = false;
     while (likely(!shutdown)) {


### PR DESCRIPTION

##### Summary
- Verify localhost is created when retention check runs
  - Agent init may take a long time in some cases (> 1 min)
