### PR TITLE
Create retention charts for higher tiers

### DIFF
--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -315,8 +315,7 @@ void *service_main(void *ptr)
         real_step = USEC_PER_SEC;
 
 #ifdef ENABLE_DBENGINE
-        if (default_rrd_memory_mode == RRD_MEMORY_MODE_DBENGINE)
-            dbengine_retention_statistics();
+       dbengine_retention_statistics();
 #endif
 
         svc_rrd_cleanup_obsolete_charts_from_all_hosts();


### PR DESCRIPTION
##### Summary
An agent with memory mode RAM or ALLOC may initialize dbengine if incoming children have requested
dbengine storage.

This PR will allow the creation of dbengine retention charts for tiers > 0
