### PR TITLE
sysinfo (WinAPI)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -841,6 +841,8 @@ set(DAEMON_FILES
         src/daemon/analytics.h
         src/daemon/main.c
         src/daemon/main.h
+        src/daemon/win_system-info.c
+        src/daemon/win_system-info.h
         src/daemon/signals.c
         src/daemon/signals.h
         src/daemon/service.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -725,6 +725,8 @@ set(LIBNETDATA_FILES
         src/libnetdata/os/os-freebsd-wrappers.h
         src/libnetdata/os/os-macos-wrappers.c
         src/libnetdata/os/os-macos-wrappers.h
+        src/libnetdata/os/os-windows-wrappers.c
+        src/libnetdata/os/os-windows-wrappers.h
         src/libnetdata/os/get_system_cpus.c
         src/libnetdata/os/get_system_cpus.h
         src/libnetdata/os/tinysleep.c

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -1407,7 +1407,7 @@ int get_system_info(struct rrdhost_system_info *system_info) {
     }
     freez(script);
 #else
-    windowsget_system_info(system_info);
+    netdata_windows_get_system_info(system_info);
 #endif
     return 0;
 }

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -7,6 +7,10 @@
 
 #include "database/engine/page_test.h"
 
+#ifdef OS_WINDOWS
+#include "win_system-info.h"
+#endif
+
 #ifdef ENABLE_SENTRY
 #include "sentry-native/sentry-native.h"
 #endif

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -1362,6 +1362,7 @@ static inline void coverity_remove_taint(char *s)
 }
 
 int get_system_info(struct rrdhost_system_info *system_info) {
+#if !defined(OS_WINDOWS)
     char *script;
     script = mallocz(sizeof(char) * (strlen(netdata_configured_primary_plugins_dir) + strlen("system-info.sh") + 2));
     sprintf(script, "%s/%s", netdata_configured_primary_plugins_dir, "system-info.sh");
@@ -1401,6 +1402,7 @@ int get_system_info(struct rrdhost_system_info *system_info) {
         netdata_pclose(fp_child_input, fp_child_output, command_pid);
     }
     freez(script);
+#endif
     return 0;
 }
 

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -1406,6 +1406,8 @@ int get_system_info(struct rrdhost_system_info *system_info) {
         netdata_pclose(fp_child_input, fp_child_output, command_pid);
     }
     freez(script);
+#else
+    windowsget_system_info(system_info);
 #endif
     return 0;
 }

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -25,23 +25,14 @@ char *netdata_windows_arch(DWORD value)
 
 DWORD netdata_windows_cpu_frequency()
 {
-    HKEY hKey;
-    long ret = RegOpenKeyEx(HKEY_LOCAL_MACHINE,
-                            "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0",
-                            0,
-                            KEY_READ,
-                            &hKey);
-    if (ret != ERROR_SUCCESS)
-        return 0;
+    DWORD freq;
+    if (!netdata_registry_get_dword(&freq,
+                                    HKEY_LOCAL_MACHINE,
+                                    "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0",
+                                    "~MHz"))
+        return freq;
 
-    DWORD length = 260, freq = 260;
-    ret = RegQueryValueEx(hKey, "~MHz", NULL, NULL, (LPBYTE) &freq, &length);
-    if (ret != ERROR_SUCCESS)
-        freq = 0;
-
-    RegCloseKey(hKey);
     freq *= 1000000;
-
     return freq;
 }
 

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -35,7 +35,7 @@ void netdata_windows_get_system_info(struct rrdhost_system_info *systemInfo) {
 
     netdata_windows_cloud(systemInfo, unknowValue);
     netdata_windows_container(systemInfo, unknowValue);
-    netdata_windows_host(systemInfo, defaultValue);
+    netdata_windows_host(systemInfo, unknowValue);
 
 }
 #endif

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -158,6 +158,7 @@ static DWORD netdata_windows_get_current_build()
 
 void netdata_windows_discover_os_version(char *os, size_t length) {
     char *commonName = { "Windows" };
+
     if (IsWindowsServer()) {
         (void)snprintf(os, length, "%s Server", commonName);
         return;
@@ -202,7 +203,7 @@ static inline void netdata_windows_os_version(char *out, DWORD length)
 
 static inline void netdata_windows_host(struct rrdhost_system_info *systemInfo) {
     char osVersion[4096];
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_NAME", "Windows");
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_NAME", "Microsoft Windows");
 
     netdata_windows_discover_os_version(osVersion, 4095);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_ID", osVersion);
@@ -215,11 +216,11 @@ static inline void netdata_windows_host(struct rrdhost_system_info *systemInfo) 
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_VERSION", osVersion);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_VERSION_ID", osVersion);
 
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_DETECTION", "Windows API");
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_DETECTION", "Windows API/Registry");
 
     (void)rrdhost_set_system_info_variable(systemInfo,
                                            "NETDATA_SYSTEM_KERNEL_NAME",
-                                           NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN);
+                                           "Windows");
 }
 
 // Cloud

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -196,7 +196,7 @@ static inline void netdata_windows_os_kernel_version(char *out, DWORD length, DW
                                     "CurrentVersion"))
         version[0] = '\0';
 
-    (void)snprintf(out, length, "%s %u", version, build);
+    (void)snprintf(out, length, "%s (build: %u)", version, build);
 }
 
 static inline void netdata_windows_host(struct rrdhost_system_info *systemInfo)

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -61,7 +61,7 @@ ULONGLONG netdata_windows_get_disk_size(char volume)
 {
     DISK_SPACE_INFORMATION dsi;
     char cVolume[8];
-    snprintf(cVolume, 7, "%d:\\", volume);
+    snprintf(cVolume, 7, "%c:\\", volume);
     if (!GetDiskSpaceInformation(cVolume, &dsi))
         return 0;
 
@@ -100,21 +100,21 @@ void netdata_windows_discover_os_version(char *os, size_t length) {
 #define ND_WIN_VER_LENGTH 16
     char version[ND_WIN_VER_LENGTH + 1];
     if (IsWindows10OrGreater()) {
-        (void)snprintf(os, ND_WIN_VER_LENGTH, "10");
+        (void)snprintf(version, ND_WIN_VER_LENGTH, "10");
     } else if (IsWindows8Point1OrGreater()) {
-        (void)snprintf(os, ND_WIN_VER_LENGTH, "8.1");
+        (void)snprintf(version, ND_WIN_VER_LENGTH, "8.1");
     } else if (IsWindows8OrGreater()) {
-        (void)snprintf(os, ND_WIN_VER_LENGTH, "8");
+        (void)snprintf(version, ND_WIN_VER_LENGTH, "8");
     } else if (IsWindows7SP1OrGreater()) {
-        (void)snprintf(os, ND_WIN_VER_LENGTH, "7 SP1");
+        (void)snprintf(version, ND_WIN_VER_LENGTH, "7 SP1");
     } else if (IsWindows7OrGreater()) {
-        (void)snprintf(os, ND_WIN_VER_LENGTH, "7");
+        (void)snprintf(version, ND_WIN_VER_LENGTH, "7");
     } else if (IsWindowsVistaSP2OrGreater()) {
-        (void)snprintf(os, ND_WIN_VER_LENGTH, "Vista SP2");
+        (void)snprintf(version, ND_WIN_VER_LENGTH, "Vista SP2");
     } else if (IsWindowsVistaSP1OrGreater()) {
-        (void)snprintf(os, ND_WIN_VER_LENGTH, "Vista SP1");
+        (void)snprintf(version, ND_WIN_VER_LENGTH, "Vista SP1");
     } else if (IsWindowsVistaOrGreater()) {
-        (void)snprintf(os, ND_WIN_VER_LENGTH, "Vista");
+        (void)snprintf(version, ND_WIN_VER_LENGTH, "Vista");
     }
 	// We are not testing older, because it is not supported anymore by Microsoft
 

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -1,12 +1,26 @@
 #include "win_system-info.h"
 
 #ifdef OS_WINDOWS
+
+#include "win_system-info.h"
+
+// Host
+
+
+static inline void netdata_windows_host(struct rrdhost_system_info *systemInfo, char *defaultValue) {
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_NAME", "Windows");
+
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_DETECTION", "Windows API");
+}
+
+// Cloud
 static inline void netdata_windows_cloud(struct rrdhost_system_info *systemInfo, char *defaultValue) {
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_INSTANCE_CLOUD_TYPE", defaultValue);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_INSTANCE_CLOUD_INSTANCE_TYPE", defaultValue);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_INSTANCE_CLOUD_INSTANCE_REGION", defaultValue);
 }
 
+// Container
 static inline void netdata_windows_container(struct rrdhost_system_info *systemInfo, char *defaultValue) {
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_CONTAINER_OS_NAME", defaultValue);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_CONTAINER_OS_ID", defaultValue);
@@ -21,5 +35,7 @@ void netdata_windows_get_system_info(struct rrdhost_system_info *systemInfo) {
 
     netdata_windows_cloud(systemInfo, unknowValue);
     netdata_windows_container(systemInfo, unknowValue);
+    netdata_windows_host(systemInfo, defaultValue);
+
 }
 #endif

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#ifdef OS_WINDOWS
-
 #include "win_system-info.h"
+
+#ifdef OS_WINDOWS
 
 // Hardware
 static char *netdata_windows_arch(DWORD value)
@@ -136,7 +136,7 @@ static ULONGLONG netdata_windows_get_disk_size(char *cVolume)
     return length.Length.QuadPart;
 }
 
-void netdata_windows_get_total_disk_size(struct rrdhost_system_info *systemInfo)
+static void netdata_windows_get_total_disk_size(struct rrdhost_system_info *systemInfo)
 {
     ULONGLONG total = 0;
     char cVolume[8];

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -173,7 +173,7 @@ void netdata_windows_discover_os_version(char *os, size_t length) {
 
 static inline void netdata_windows_os_version(char *out, DWORD length)
 {
-    if (!netdata_registry_get_string(out,
+    if (netdata_registry_get_string(out,
                                      length,
                                      HKEY_LOCAL_MACHINE,
                                      "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -43,6 +43,18 @@ void netdata_windows_get_cpu(struct rrdhost_system_info *systemInfo, char *defau
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_ARCHITECTURE", arch);
 }
 
+void netdata_windows_get_mem(struct rrdhost_system_info *systemInfo, char *defaultValue)
+{
+    ULONGLONG size;
+    char temp[256];
+    if (!GetPhysicallyInstalledSystemMemory(&size))
+        size = 0;
+    else
+        (void)snprintf(temp, 255, "%lu", size);
+
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_TOTAL_RAM", (!size) ? defaultValue : temp);
+}
+
 // Host
 void netdata_windows_discover_os_version(char *os, size_t length) {
     char *commonName = { "Windows" };
@@ -116,5 +128,6 @@ void netdata_windows_get_system_info(struct rrdhost_system_info *systemInfo) {
     netdata_windows_container(systemInfo, unknowValue);
     netdata_windows_host(systemInfo, unknowValue);
     netdata_windows_get_cpu(systemInfo, unknowValue);
+    netdata_windows_get_mem(systemInfo, unknowValue);
 }
 #endif

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -60,6 +60,15 @@ static void netdata_windows_cpu_from_system_info(struct rrdhost_system_info *sys
 
 }
 
+static inline void netdata_windows_cpu_vendor_model(HKEY lKey, char *variable, char *key)
+{
+    char cpuData[256];
+    long ret = netdata_registry_get_string_from_open_key(cpuData, 255, lKey, "VendorIdentifier");
+    (void)rrdhost_set_system_info_variable(systemInfo,
+                                           "NETDATA_SYSTEM_CPU_VENDOR",
+                                           (ret == ERROR_SUCCESS) ? cpuData : NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN);
+}
+
 static void netdata_windows_cpu_from_registry(struct rrdhost_system_info *systemInfo)
 {
     HKEY lKey;
@@ -80,6 +89,9 @@ static void netdata_windows_cpu_from_registry(struct rrdhost_system_info *system
                                            "NETDATA_SYSTEM_CPU_FREQ",
                                            (!cpuFreq) ? NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN : cpuData);
 
+    netdata_windows_cpu_vendor_model(lKey, "NETDATA_SYSTEM_CPU_VENDOR", "VendorIdentifier");
+    netdata_windows_cpu_vendor_model(lKey, "NETDATA_SYSTEM_CPU_MODEL", "ProcessorNameString");
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_CPU_DETECTION", NETDATA_WIN_DETECTION_METHOD);
 }
 
 void netdata_windows_get_cpu(struct rrdhost_system_info *systemInfo)
@@ -239,7 +251,7 @@ static inline void netdata_windows_host(struct rrdhost_system_info *systemInfo)
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_VERSION", osVersion);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_VERSION_ID", osVersion);
 
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_DETECTION", "Windows API/Registry");
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_DETECTION", NETDATA_WIN_DETECTION_METHOD);
 
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_KERNEL_NAME", "Windows");
 

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -63,7 +63,6 @@ static void netdata_windows_cpu_from_system_info(struct rrdhost_system_info *sys
 static void netdata_windows_cpu_from_registry(struct rrdhost_system_info *systemInfo)
 {
     HKEY lKey;
-    bool status = true;
     long ret = RegOpenKeyEx(HKEY_LOCAL_MACHINE,
                             "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0",
                             0,
@@ -72,7 +71,8 @@ static void netdata_windows_cpu_from_registry(struct rrdhost_system_info *system
     if (ret != ERROR_SUCCESS)
         return;
 
-    ULONGLONG cpuFreq = netdata_windows_cpu_frequency(lkey);
+    ULONGLONG cpuFreq = netdata_windows_cpu_frequency(lKey);
+    char cpuData[256];
     if (cpuFreq)
         (void)snprintf(cpuData, 255, "%lu", (unsigned long)cpuFreq);
 

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -60,12 +60,15 @@ static void netdata_windows_cpu_from_system_info(struct rrdhost_system_info *sys
 
 }
 
-static inline void netdata_windows_cpu_vendor_model(HKEY lKey, char *variable, char *key)
+static inline void netdata_windows_cpu_vendor_model(struct rrdhost_system_info *systemInfo,
+                                                    HKEY lKey,
+                                                    char *variable,
+                                                    char *key)
 {
     char cpuData[256];
-    long ret = netdata_registry_get_string_from_open_key(cpuData, 255, lKey, "VendorIdentifier");
+    long ret = netdata_registry_get_string_from_open_key(cpuData, 255, lKey, key);
     (void)rrdhost_set_system_info_variable(systemInfo,
-                                           "NETDATA_SYSTEM_CPU_VENDOR",
+                                           variable,
                                            (ret == ERROR_SUCCESS) ? cpuData : NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN);
 }
 
@@ -89,8 +92,8 @@ static void netdata_windows_cpu_from_registry(struct rrdhost_system_info *system
                                            "NETDATA_SYSTEM_CPU_FREQ",
                                            (!cpuFreq) ? NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN : cpuData);
 
-    netdata_windows_cpu_vendor_model(lKey, "NETDATA_SYSTEM_CPU_VENDOR", "VendorIdentifier");
-    netdata_windows_cpu_vendor_model(lKey, "NETDATA_SYSTEM_CPU_MODEL", "ProcessorNameString");
+    netdata_windows_cpu_vendor_model(systemInfo, lKey, "NETDATA_SYSTEM_CPU_VENDOR", "VendorIdentifier");
+    netdata_windows_cpu_vendor_model(systemInfo, lKey, "NETDATA_SYSTEM_CPU_MODEL", "ProcessorNameString");
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_CPU_DETECTION", NETDATA_WIN_DETECTION_METHOD);
 }
 

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -117,20 +117,6 @@ void netdata_windows_get_total_disk_size(struct rrdhost_system_info *systemInfo)
 }
 
 // Host
-static inline bool netdata_windows_open_current_version(HKEY *hKey)
-{
-    long ret = RegOpenKeyEx(HKEY_LOCAL_MACHINE,
-                            "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
-                            0,
-                            KEY_READ,
-                            hKey);
-
-    if (ret != ERROR_SUCCESS)
-        return false;
-
-    return true;
-}
-
 static DWORD netdata_windows_get_current_build()
 {
     HKEY hKey;
@@ -187,13 +173,14 @@ void netdata_windows_discover_os_version(char *os, size_t length) {
 
 static inline void netdata_windows_os_version(char *out, DWORD length)
 {
-    HKEY hKey;
-    if (!netdata_windows_open_current_version(&hKey))
+    if (!netdata_registry_get_string(out,
+                                     length,
+                                     HKEY_LOCAL_MACHINE,
+                                     "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+                                     "ProductName"))
         return;
 
-    (void)RegQueryValueEx(hKey, "ProductName", NULL, NULL, out, &length);
-
-    RegCloseKey(hKey);
+    (void)snprintf(out, length, "%s", NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN);
 }
 
 static inline void netdata_windows_host(struct rrdhost_system_info *systemInfo) {

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -5,7 +5,7 @@
 #include "win_system-info.h"
 
 // Hardware
-char *netdata_windows_arch(DWORD value)
+static char *netdata_windows_arch(DWORD value)
 {
     switch (value) {
         case 9:
@@ -23,7 +23,7 @@ char *netdata_windows_arch(DWORD value)
     }
 }
 
-DWORD netdata_windows_cpu_frequency(HKEY lKey)
+static DWORD netdata_windows_cpu_frequency(HKEY lKey)
 {
     DWORD freq = 0;
     long ret = netdata_registry_get_dword_from_open_key(&freq, lKey, "~MHz");
@@ -60,7 +60,7 @@ static void netdata_windows_cpu_from_system_info(struct rrdhost_system_info *sys
 
 }
 
-static inline void netdata_windows_cpu_vendor_model(struct rrdhost_system_info *systemInfo,
+static void netdata_windows_cpu_vendor_model(struct rrdhost_system_info *systemInfo,
                                                     HKEY lKey,
                                                     char *variable,
                                                     char *key)
@@ -97,14 +97,14 @@ static void netdata_windows_cpu_from_registry(struct rrdhost_system_info *system
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_CPU_DETECTION", NETDATA_WIN_DETECTION_METHOD);
 }
 
-void netdata_windows_get_cpu(struct rrdhost_system_info *systemInfo)
+static void netdata_windows_get_cpu(struct rrdhost_system_info *systemInfo)
 {
     netdata_windows_cpu_from_system_info(systemInfo);
 
     netdata_windows_cpu_from_registry(systemInfo);
 }
 
-void netdata_windows_get_mem(struct rrdhost_system_info *systemInfo)
+static void netdata_windows_get_mem(struct rrdhost_system_info *systemInfo)
 {
     ULONGLONG size;
     char memSize[256];
@@ -119,7 +119,7 @@ void netdata_windows_get_mem(struct rrdhost_system_info *systemInfo)
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_RAM_DETECTION", NETDATA_WIN_DETECTION_METHOD);
 }
 
-inline ULONGLONG netdata_windows_get_disk_size(char *cVolume)
+static ULONGLONG netdata_windows_get_disk_size(char *cVolume)
 {
     HANDLE disk = CreateFile(cVolume, GENERIC_READ, FILE_SHARE_VALID_FLAGS, 0, OPEN_EXISTING, 0, 0);
     if (!disk)
@@ -181,7 +181,7 @@ static DWORD netdata_windows_get_current_build()
     return version;
 }
 
-void netdata_windows_discover_os_version(char *os, size_t length, DWORD build)
+static void netdata_windows_discover_os_version(char *os, size_t length, DWORD build)
 {
     char *commonName = {"Windows"};
 
@@ -215,7 +215,7 @@ void netdata_windows_discover_os_version(char *os, size_t length, DWORD build)
     (void)snprintf(os, length, "%s %s Client", commonName, version);
 }
 
-static inline void netdata_windows_os_version(char *out, DWORD length)
+static void netdata_windows_os_version(char *out, DWORD length)
 {
     if (netdata_registry_get_string(out,
                                     length,
@@ -227,7 +227,7 @@ static inline void netdata_windows_os_version(char *out, DWORD length)
     (void)snprintf(out, length, "%s", NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN);
 }
 
-static inline void netdata_windows_os_kernel_version(char *out, DWORD length, DWORD build)
+static void netdata_windows_os_kernel_version(char *out, DWORD length, DWORD build)
 {
     char version[8];
     if (!netdata_registry_get_string(version,
@@ -240,7 +240,7 @@ static inline void netdata_windows_os_kernel_version(char *out, DWORD length, DW
     (void)snprintf(out, length, "%s (build: %u)", version, build);
 }
 
-static inline void netdata_windows_host(struct rrdhost_system_info *systemInfo)
+static void netdata_windows_host(struct rrdhost_system_info *systemInfo)
 {
     char osVersion[4096];
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_NAME", "Microsoft Windows");
@@ -269,7 +269,7 @@ static inline void netdata_windows_host(struct rrdhost_system_info *systemInfo)
 }
 
 // Cloud
-static inline void netdata_windows_cloud(struct rrdhost_system_info *systemInfo)
+static void netdata_windows_cloud(struct rrdhost_system_info *systemInfo)
 {
     (void)rrdhost_set_system_info_variable(
         systemInfo, "NETDATA_INSTANCE_CLOUD_TYPE", NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN);
@@ -280,7 +280,7 @@ static inline void netdata_windows_cloud(struct rrdhost_system_info *systemInfo)
 }
 
 // Container
-static inline void netdata_windows_container(struct rrdhost_system_info *systemInfo)
+static void netdata_windows_container(struct rrdhost_system_info *systemInfo)
 {
     (void)rrdhost_set_system_info_variable(
         systemInfo, "NETDATA_CONTAINER_OS_NAME", NETDATA_DEFAULT_SYSTEM_INFO_VALUE_NONE);

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -19,7 +19,7 @@ char *netdata_windows_arch(DWORD value)
         case 0:
             return "x86";
         default:
-            return NETDATA_DEFAULT_VALUE_SYSTEM_INFO;
+            return NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN;
     }
 }
 
@@ -60,7 +60,7 @@ void netdata_windows_get_cpu(struct rrdhost_system_info *systemInfo)
 
     (void)rrdhost_set_system_info_variable(systemInfo,
                                            "NETDATA_SYSTEM_CPU_FREQ",
-                                           (!cpuFreq) ? NETDATA_DEFAULT_VALUE_SYSTEM_INFO : cpuData);
+                                           (!cpuFreq) ? NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN : cpuData);
 
     char *arch = netdata_windows_arch(sysInfo.wProcessorArchitecture);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_ARCHITECTURE", arch);
@@ -77,7 +77,7 @@ void netdata_windows_get_mem(struct rrdhost_system_info *systemInfo)
 
     (void)rrdhost_set_system_info_variable(systemInfo,
                                            "NETDATA_SYSTEM_TOTAL_RAM",
-                                           (!size) ? NETDATA_DEFAULT_VALUE_SYSTEM_INFO : memSize);
+                                           (!size) ? NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN : memSize);
 }
 
 inline ULONGLONG netdata_windows_get_disk_size(char *cVolume)
@@ -207,7 +207,9 @@ static inline void netdata_windows_host(struct rrdhost_system_info *systemInfo) 
     netdata_windows_discover_os_version(osVersion, 4095);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_ID", osVersion);
 
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_ID_LIKE", NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
+    (void)rrdhost_set_system_info_variable(systemInfo,
+                                           "NETDATA_HOST_OS_ID_LIKE",
+                                           NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN);
 
     netdata_windows_os_version(osVersion, 4095);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_VERSION", osVersion);
@@ -215,36 +217,47 @@ static inline void netdata_windows_host(struct rrdhost_system_info *systemInfo) 
 
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_DETECTION", "Windows API");
 
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_KERNEL_NAME", NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
+    (void)rrdhost_set_system_info_variable(systemInfo,
+                                           "NETDATA_SYSTEM_KERNEL_NAME",
+                                           NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN);
 }
 
 // Cloud
 static inline void netdata_windows_cloud(struct rrdhost_system_info *systemInfo) {
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_INSTANCE_CLOUD_TYPE", NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
+    (void)rrdhost_set_system_info_variable(systemInfo,
+                                           "NETDATA_INSTANCE_CLOUD_TYPE",
+                                           NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN);
     (void)rrdhost_set_system_info_variable(systemInfo,
                                            "NETDATA_INSTANCE_CLOUD_INSTANCE_TYPE",
-                                           NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
+                                           NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN);
     (void)rrdhost_set_system_info_variable(systemInfo,
                                            "NETDATA_INSTANCE_CLOUD_INSTANCE_REGION",
-                                           NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
+                                           NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN);
 }
 
 // Container
 static inline void netdata_windows_container(struct rrdhost_system_info *systemInfo) {
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_CONTAINER_OS_NAME", NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_CONTAINER_OS_ID", NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
+    (void)rrdhost_set_system_info_variable(systemInfo,
+                                           "NETDATA_CONTAINER_OS_NAME",
+                                           NETDATA_DEFAULT_SYSTEM_INFO_VALUE_NONE);
+    (void)rrdhost_set_system_info_variable(systemInfo,
+                                           "NETDATA_CONTAINER_OS_ID",
+                                           NETDATA_DEFAULT_SYSTEM_INFO_VALUE_NONE);
     (void)rrdhost_set_system_info_variable(systemInfo,
                                            "NETDATA_CONTAINER_OS_ID_LIKE",
-                                           NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
+                                           NETDATA_DEFAULT_SYSTEM_INFO_VALUE_NONE);
     (void)rrdhost_set_system_info_variable(systemInfo,
                                            "NETDATA_CONTAINER_OS_VERSION",
-                                           NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
+                                           NETDATA_DEFAULT_SYSTEM_INFO_VALUE_NONE);
     (void)rrdhost_set_system_info_variable(systemInfo,
                                            "NETDATA_CONTAINER_OS_VERSION_ID",
-                                           NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
+                                           NETDATA_DEFAULT_SYSTEM_INFO_VALUE_NONE);
     (void)rrdhost_set_system_info_variable(systemInfo,
                                            "NETDATA_CONTAINER_OS_DETECTION",
-                                           NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
+                                           NETDATA_DEFAULT_SYSTEM_INFO_VALUE_NONE);
+    (void)rrdhost_set_system_info_variable(systemInfo,
+                                           "NETDATA_CONTAINER_IS_OFFICIAL_IMAGE",
+                                           NETDATA_DEFAULT_SYSTEM_INFO_VALUE_FALSE);
 }
 
 void netdata_windows_get_system_info(struct rrdhost_system_info *systemInfo) {

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -47,8 +47,9 @@ void netdata_windows_get_cpu(struct rrdhost_system_info *systemInfo)
     if (cpuFreq)
         (void)snprintf(cpuData, 255, "%lu", (unsigned long)cpuFreq);
 
-    (void)rrdhost_set_system_info_variable(
-        systemInfo, "NETDATA_SYSTEM_CPU_FREQ", (!cpuFreq) ? NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN : cpuData);
+    (void)rrdhost_set_system_info_variable(systemInfo,
+                                           "NETDATA_SYSTEM_CPU_FREQ",
+                                           (!cpuFreq) ? NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN : cpuData);
 
     char *arch = netdata_windows_arch(sysInfo.wProcessorArchitecture);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_ARCHITECTURE", arch);

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -1,0 +1,4 @@
+#include "win_system-info.h"
+
+#ifdef OS_WINDOWS
+#endif

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -203,6 +203,10 @@ static inline void netdata_windows_host(struct rrdhost_system_info *systemInfo) 
     (void)rrdhost_set_system_info_variable(systemInfo,
                                            "NETDATA_SYSTEM_KERNEL_NAME",
                                            "Windows");
+
+    (void)rrdhost_set_system_info_variable(systemInfo,
+                                           "NETDATA_HOST_IS_K8S_NODE",
+                                           NETDATA_DEFAULT_SYSTEM_INFO_VALUE_FALSE);
 }
 
 // Cloud

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -28,16 +28,16 @@ void netdata_windows_get_cpu(struct rrdhost_system_info *systemInfo)
     SYSTEM_INFO sysInfo;
     GetSystemInfo(&sysInfo);
 
-    char temp[256];
-    (void)snprintf(temp, 255, "%d", sysInfo.dwNumberOfProcessors);
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_CPU_LOGICAL_CPU_COUNT", temp);
+    char cpuData[256];
+    (void)snprintf(cpuData, 255, "%d", sysInfo.dwNumberOfProcessors);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_CPU_LOGICAL_CPU_COUNT", cpuData);
 
     LARGE_INTEGER freq;
     if (!QueryPerformanceFrequency(&freq))
         freq.QuadPart = 0;
 
-    (void)snprintf(temp, 255, "%lu", (unsigned long) freq.QuadPart);
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_CPU_FREQ", temp);
+    (void)snprintf(cpuData, 255, "%lu", (unsigned long) freq.QuadPart);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_CPU_FREQ", cpuData);
 
     char *arch = netdata_windows_arch(sysInfo.wProcessorArchitecture);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_ARCHITECTURE", arch);
@@ -46,15 +46,15 @@ void netdata_windows_get_cpu(struct rrdhost_system_info *systemInfo)
 void netdata_windows_get_mem(struct rrdhost_system_info *systemInfo)
 {
     ULONGLONG size;
-    char temp[256];
+    char memSize[256];
     if (!GetPhysicallyInstalledSystemMemory(&size))
         size = 0;
     else
-        (void)snprintf(temp, 255, "%llu", size);
+        (void)snprintf(memSize, 255, "%llu", size);
 
     (void)rrdhost_set_system_info_variable(systemInfo,
                                            "NETDATA_SYSTEM_TOTAL_RAM",
-                                           (!size) ? NETDATA_DEFAULT_VALUE_SYSTEM_INFO : temp);
+                                           (!size) ? NETDATA_DEFAULT_VALUE_SYSTEM_INFO : memSize);
 }
 
 ULONGLONG netdata_windows_get_disk_size(char volume)
@@ -122,16 +122,16 @@ void netdata_windows_discover_os_version(char *os, size_t length) {
 }
 
 static inline void netdata_windows_host(struct rrdhost_system_info *systemInfo) {
-	char temp[4096];
+	char osVersion[4096];
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_NAME", "Windows");
 
-    netdata_windows_discover_os_version(temp, 4095);
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_ID", temp);
+    netdata_windows_discover_os_version(osVersion, 4095);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_ID", osVersion);
 
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_ID_LIKE", NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
 
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_VERSION", temp);
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_VERSION_ID", temp);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_VERSION", osVersion);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_VERSION_ID", osVersion);
 
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_DETECTION", "Windows API");
 

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -134,15 +134,19 @@ static inline bool netdata_windows_open_current_version(HKEY *hKey)
 static DWORD netdata_windows_get_current_build()
 {
     HKEY hKey;
-    if (!netdata_windows_open_current_version(&hKey))
+    char cBuild[64];
+    if (!netdata_registry_get_string(cBuild,
+                                     63,
+                                     HKEY_LOCAL_MACHINE,
+                                     "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+                                     "CurrentBuild"))
         return 0;
 
-    DWORD length = 260, version = 260;
-    int ret = RegQueryValueEx(hKey, "CurrentBuild", NULL, NULL, (LPBYTE) &version, &length);
-    if (ret != ERROR_SUCCESS)
-        version = 0;
+    errno = 0;
 
-    RegCloseKey(hKey);
+    DWORD version = strtol(cBuild, NULL, 10);
+    if (errno == ERANGE)
+        return 0;
 
     return version;
 }

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -52,6 +52,18 @@ void netdata_windows_get_cpu(struct rrdhost_system_info *systemInfo)
 
     char *arch = netdata_windows_arch(sysInfo.wProcessorArchitecture);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_ARCHITECTURE", arch);
+
+    (void)rrdhost_set_system_info_variable(
+        systemInfo, "NETDATA_SYSTEM_VIRTUALIZATION", NETDATA_DEFAULT_SYSTEM_INFO_VALUE_NONE);
+
+    (void)rrdhost_set_system_info_variable(
+        systemInfo, "NETDATA_SYSTEM_VIRT_DETECTION", NETDATA_DEFAULT_SYSTEM_INFO_VALUE_NONE);
+
+    (void)rrdhost_set_system_info_variable(
+        systemInfo, "NETDATA_SYSTEM_CONTAINER", NETDATA_DEFAULT_SYSTEM_INFO_VALUE_NONE);
+
+    (void)rrdhost_set_system_info_variable(
+        systemInfo, "NETDATA_SYSTEM_CONTAINER_DETECTION", NETDATA_DEFAULT_SYSTEM_INFO_VALUE_NONE);
 }
 
 void netdata_windows_get_mem(struct rrdhost_system_info *systemInfo)

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -110,8 +110,10 @@ void netdata_windows_get_mem(struct rrdhost_system_info *systemInfo)
     else
         (void)snprintf(memSize, 255, "%llu", size);
 
-    (void)rrdhost_set_system_info_variable(
-        systemInfo, "NETDATA_SYSTEM_TOTAL_RAM", (!size) ? NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN : memSize);
+    (void)rrdhost_set_system_info_variable(systemInfo,
+                                           "NETDATA_SYSTEM_TOTAL_RAM",
+                                           (!size) ? NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN : memSize);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_RAM_DETECTION", NETDATA_WIN_DETECTION_METHOD);
 }
 
 inline ULONGLONG netdata_windows_get_disk_size(char *cVolume)
@@ -155,6 +157,7 @@ void netdata_windows_get_total_disk_size(struct rrdhost_system_info *systemInfo)
     char diskSize[256];
     (void)snprintf(diskSize, 255, "%llu", total);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_TOTAL_DISK_SIZE", diskSize);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_DISK_DETECTION", NETDATA_WIN_DETECTION_METHOD);
 }
 
 // Host

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -1,4 +1,4 @@
-#include "win_system-info.h"
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #ifdef OS_WINDOWS
 

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -5,7 +5,7 @@
 #include "win_system-info.h"
 
 // Hardware
-char *netdata_windows_arch(DWORD value, char *defaultValue)
+char *netdata_windows_arch(DWORD value)
 {
     switch(value) {
         case 9:
@@ -19,11 +19,11 @@ char *netdata_windows_arch(DWORD value, char *defaultValue)
         case 0:
             return "x86";
         default:
-            return defaultValue;
+            return NETDATA_DEFAULT_VALUE_SYSTEM_INFO;
     }
 }
 
-void netdata_windows_get_cpu(struct rrdhost_system_info *systemInfo, char *defaultValue)
+void netdata_windows_get_cpu(struct rrdhost_system_info *systemInfo)
 {
     SYSTEM_INFO sysInfo;
     GetSystemInfo(&sysInfo);
@@ -39,20 +39,22 @@ void netdata_windows_get_cpu(struct rrdhost_system_info *systemInfo, char *defau
     (void)snprintf(temp, 255, "%lu", (unsigned long) freq.QuadPart);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_CPU_FREQ", temp);
 
-    char *arch = netdata_windows_arch(sysInfo.wProcessorArchitecture, defaultValue);
+    char *arch = netdata_windows_arch(sysInfo.wProcessorArchitecture);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_ARCHITECTURE", arch);
 }
 
-void netdata_windows_get_mem(struct rrdhost_system_info *systemInfo, char *defaultValue)
+void netdata_windows_get_mem(struct rrdhost_system_info *systemInfo)
 {
     ULONGLONG size;
     char temp[256];
     if (!GetPhysicallyInstalledSystemMemory(&size))
         size = 0;
     else
-        (void)snprintf(temp, 255, "%lu", size);
+        (void)snprintf(temp, 255, "%llu", size);
 
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_TOTAL_RAM", (!size) ? defaultValue : temp);
+    (void)rrdhost_set_system_info_variable(systemInfo,
+                                           "NETDATA_SYSTEM_TOTAL_RAM",
+                                           (!size) ? NETDATA_DEFAULT_VALUE_SYSTEM_INFO : temp);
 }
 
 // Host
@@ -87,47 +89,57 @@ void netdata_windows_discover_os_version(char *os, size_t length) {
     (void)snprintf(os, length, "%s Client %s", commonName, version);
 }
 
-static inline void netdata_windows_host(struct rrdhost_system_info *systemInfo, char *defaultValue) {
+static inline void netdata_windows_host(struct rrdhost_system_info *systemInfo) {
 	char temp[4096];
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_NAME", "Windows");
 
     netdata_windows_discover_os_version(temp, 4095);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_ID", temp);
 
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_ID_LIKE", defaultValue);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_ID_LIKE", NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
 
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_VERSION", temp);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_VERSION_ID", temp);
 
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_DETECTION", "Windows API");
 
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_KERNEL_NAME", defaultValue);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_KERNEL_NAME", NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
 }
 
 // Cloud
-static inline void netdata_windows_cloud(struct rrdhost_system_info *systemInfo, char *defaultValue) {
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_INSTANCE_CLOUD_TYPE", defaultValue);
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_INSTANCE_CLOUD_INSTANCE_TYPE", defaultValue);
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_INSTANCE_CLOUD_INSTANCE_REGION", defaultValue);
+static inline void netdata_windows_cloud(struct rrdhost_system_info *systemInfo) {
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_INSTANCE_CLOUD_TYPE", NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
+    (void)rrdhost_set_system_info_variable(systemInfo,
+                                           "NETDATA_INSTANCE_CLOUD_INSTANCE_TYPE",
+                                           NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
+    (void)rrdhost_set_system_info_variable(systemInfo,
+                                           "NETDATA_INSTANCE_CLOUD_INSTANCE_REGION",
+                                           NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
 }
 
 // Container
-static inline void netdata_windows_container(struct rrdhost_system_info *systemInfo, char *defaultValue) {
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_CONTAINER_OS_NAME", defaultValue);
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_CONTAINER_OS_ID", defaultValue);
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_CONTAINER_OS_ID_LIKE", defaultValue);
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_CONTAINER_OS_VERSION", defaultValue);
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_CONTAINER_OS_VERSION_ID", defaultValue);
-    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_CONTAINER_OS_DETECTION", defaultValue);
+static inline void netdata_windows_container(struct rrdhost_system_info *systemInfo) {
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_CONTAINER_OS_NAME", NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_CONTAINER_OS_ID", NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
+    (void)rrdhost_set_system_info_variable(systemInfo,
+                                           "NETDATA_CONTAINER_OS_ID_LIKE",
+                                           NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
+    (void)rrdhost_set_system_info_variable(systemInfo,
+                                           "NETDATA_CONTAINER_OS_VERSION",
+                                           NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
+    (void)rrdhost_set_system_info_variable(systemInfo,
+                                           "NETDATA_CONTAINER_OS_VERSION_ID",
+                                           NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
+    (void)rrdhost_set_system_info_variable(systemInfo,
+                                           "NETDATA_CONTAINER_OS_DETECTION",
+                                           NETDATA_DEFAULT_VALUE_SYSTEM_INFO);
 }
 
 void netdata_windows_get_system_info(struct rrdhost_system_info *systemInfo) {
-    char *unknowValue = { "unknown" };
-
-    netdata_windows_cloud(systemInfo, unknowValue);
-    netdata_windows_container(systemInfo, unknowValue);
-    netdata_windows_host(systemInfo, unknowValue);
-    netdata_windows_get_cpu(systemInfo, unknowValue);
-    netdata_windows_get_mem(systemInfo, unknowValue);
+    netdata_windows_cloud(systemInfo);
+    netdata_windows_container(systemInfo);
+    netdata_windows_host(systemInfo);
+    netdata_windows_get_cpu(systemInfo);
+    netdata_windows_get_mem(systemInfo);
 }
 #endif

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -1,4 +1,25 @@
 #include "win_system-info.h"
 
 #ifdef OS_WINDOWS
+static inline void netdata_windows_cloud(struct rrdhost_system_info *systemInfo, char *defaultValue) {
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_INSTANCE_CLOUD_TYPE", defaultValue);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_INSTANCE_CLOUD_INSTANCE_TYPE", defaultValue);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_INSTANCE_CLOUD_INSTANCE_REGION", defaultValue);
+}
+
+static inline void netdata_windows_container(struct rrdhost_system_info *systemInfo, char *defaultValue) {
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_CONTAINER_OS_NAME", defaultValue);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_CONTAINER_OS_ID", defaultValue);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_CONTAINER_OS_ID_LIKE", defaultValue);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_CONTAINER_OS_VERSION", defaultValue);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_CONTAINER_OS_VERSION_ID", defaultValue);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_CONTAINER_OS_DETECTION", defaultValue);
+}
+
+void netdata_windows_get_system_info(struct rrdhost_system_info *systemInfo) {
+    static char *unknowValue = { "unknown" };
+
+    netdata_windows_cloud(systemInfo, unknowValue);
+    netdata_windows_container(systemInfo, unknowValue);
+}
 #endif

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -5,12 +5,52 @@
 #include "win_system-info.h"
 
 // Host
+void netdata_windows_discover_os_version(char *os, size_t length) {
+    char *commonName = { "Windows" };
+    if (IsWindowsServer()) {
+        (void)snprintf(os, length, "%s Server", commonName);
+        return;
+    }
 
+#define ND_WIN_VER_LENGTH 16
+    char version[ND_WIN_VER_LENGTH + 1];
+    if (IsWindows10OrGreater()) {
+        (void)snprintf(os, ND_WIN_VER_LENGTH, "10");
+    } else if (IsWindows8Point1OrGreater()) {
+        (void)snprintf(os, ND_WIN_VER_LENGTH, "8.1");
+    } else if (IsWindows8OrGreater()) {
+        (void)snprintf(os, ND_WIN_VER_LENGTH, "8");
+    } else if (IsWindows7SP1OrGreater()) {
+        (void)snprintf(os, ND_WIN_VER_LENGTH, "7 SP1");
+    } else if (IsWindows7OrGreater()) {
+        (void)snprintf(os, ND_WIN_VER_LENGTH, "7");
+    } else if (IsWindowsVistaSP2OrGreater()) {
+        (void)snprintf(os, ND_WIN_VER_LENGTH, "Vista SP2");
+    } else if (IsWindowsVistaSP1OrGreater()) {
+        (void)snprintf(os, ND_WIN_VER_LENGTH, "Vista SP1");
+    } else if (IsWindowsVistaOrGreater()) {
+        (void)snprintf(os, ND_WIN_VER_LENGTH, "Vista");
+    }
+	// We are not testing older, because it is not supported anymore by Microsoft
+
+    (void)snprintf(os, length, "%s Client %s", commonName, version);
+}
 
 static inline void netdata_windows_host(struct rrdhost_system_info *systemInfo, char *defaultValue) {
+	char temp[4096];
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_NAME", "Windows");
 
+    netdata_windows_discover_os_version(temp, 4095);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_ID", temp);
+
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_ID_LIKE", defaultValue);
+
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_VERSION", temp);
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_VERSION_ID", temp);
+
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_DETECTION", "Windows API");
+
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_SYSTEM_KERNEL_NAME", defaultValue);
 }
 
 // Cloud

--- a/src/daemon/win_system-info.h
+++ b/src/daemon/win_system-info.h
@@ -1,0 +1,9 @@
+#ifndef _NETDATA_WIN_SYSTEM_INFO_H_
+#define _NETDATA_WIN_SYSTEM_INFO_H_
+
+#ifdef OS_WINDOWS
+#include "windows.h"
+
+#endif
+
+#endif // _NETDATA_WIN_SYSTEM_INFO_H_

--- a/src/daemon/win_system-info.h
+++ b/src/daemon/win_system-info.h
@@ -7,7 +7,7 @@
 #ifdef OS_WINDOWS
 #include "windows.h"
 
-void windowsget_system_info(struct rrdhost_system_info *system_info);
+void netdata_windows_get_system_info(struct rrdhost_system_info *system_info);
 #endif
 
 #endif // _NETDATA_WIN_SYSTEM_INFO_H_

--- a/src/daemon/win_system-info.h
+++ b/src/daemon/win_system-info.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 #ifndef _NETDATA_WIN_SYSTEM_INFO_H_
 #define _NETDATA_WIN_SYSTEM_INFO_H_
 

--- a/src/daemon/win_system-info.h
+++ b/src/daemon/win_system-info.h
@@ -4,7 +4,9 @@
 // the netdata database
 #include "database/rrd.h"
 
-#define NETDATA_DEFAULT_VALUE_SYSTEM_INFO "unknown"
+#define NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN "unknown"
+#define NETDATA_DEFAULT_SYSTEM_INFO_VALUE_NONE "none"
+#define NETDATA_DEFAULT_SYSTEM_INFO_VALUE_FALSE "false"
 
 #ifdef OS_WINDOWS
 #include "windows.h"

--- a/src/daemon/win_system-info.h
+++ b/src/daemon/win_system-info.h
@@ -4,6 +4,8 @@
 // the netdata database
 #include "database/rrd.h"
 
+#define NETDATA_DEFAULT_VALUE_SYSTEM_INFO "unknown"
+
 #ifdef OS_WINDOWS
 #include "windows.h"
 #include "versionhelpers.h"

--- a/src/daemon/win_system-info.h
+++ b/src/daemon/win_system-info.h
@@ -6,6 +6,7 @@
 
 #ifdef OS_WINDOWS
 #include "windows.h"
+#include "versionhelpers.h"
 
 void netdata_windows_get_system_info(struct rrdhost_system_info *system_info);
 #endif

--- a/src/daemon/win_system-info.h
+++ b/src/daemon/win_system-info.h
@@ -1,9 +1,13 @@
 #ifndef _NETDATA_WIN_SYSTEM_INFO_H_
 #define _NETDATA_WIN_SYSTEM_INFO_H_
 
+// the netdata database
+#include "database/rrd.h"
+
 #ifdef OS_WINDOWS
 #include "windows.h"
 
+void windowsget_system_info(struct rrdhost_system_info *system_info);
 #endif
 
 #endif // _NETDATA_WIN_SYSTEM_INFO_H_

--- a/src/libnetdata/os/os-windows-wrappers.c
+++ b/src/libnetdata/os/os-windows-wrappers.c
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "../libnetdata.h"
+
+#if defined(OS_WINDOWS)
+
+bool netdata_registry_get_dword(DOWRD *out, HKEY hKey, char *subKey, char *name)
+{
+    HKEY lKey;
+    bool status = true;
+    long ret = RegOpenKeyEx(hKey,
+                            subKey,
+                            0,
+                            KEY_READ,
+                            &lKey);
+    if (ret != ERROR_SUCCESS)
+        return 0;
+
+    DWORD length = 260, value = 260, type;
+    ret = RegQueryValueEx(lKey, name, NULL, NULL, (LPBYTE) &value, &length);
+    if (ret != ERROR_SUCCESS)
+        status = false;
+
+    RegCloseKey(lKey);
+
+    *out = value;
+
+    return status;
+}
+
+#endif
+

--- a/src/libnetdata/os/os-windows-wrappers.c
+++ b/src/libnetdata/os/os-windows-wrappers.c
@@ -4,7 +4,7 @@
 
 #if defined(OS_WINDOWS)
 
-bool netdata_registry_get_dword(DOWRD *out, HKEY hKey, char *subKey, char *name)
+bool netdata_registry_get_dword(DWORD *out, HKEY hKey, char *subKey, char *name)
 {
     HKEY lKey;
     bool status = true;

--- a/src/libnetdata/os/os-windows-wrappers.c
+++ b/src/libnetdata/os/os-windows-wrappers.c
@@ -15,7 +15,7 @@ bool netdata_registry_get_dword(unsigned int *out, void *hKey, char *subKey, cha
                             KEY_READ,
                             &lKey);
     if (ret != ERROR_SUCCESS)
-        return 0;
+        return false;
 
     DWORD length = 260, value = 260;
     ret = RegQueryValueEx(lKey, name, NULL, NULL, (LPBYTE) &value, &length);
@@ -25,6 +25,27 @@ bool netdata_registry_get_dword(unsigned int *out, void *hKey, char *subKey, cha
     RegCloseKey(lKey);
 
     *out = value;
+
+    return status;
+}
+
+bool netdata_registry_get_string(char *out, size_t length, void *hKey, char *subKey, char *name)
+{
+    HKEY lKey;
+    bool status = true;
+    long ret = RegOpenKeyEx(hKey,
+                            subKey,
+                            0,
+                            KEY_READ,
+                            &lKey);
+    if (ret != ERROR_SUCCESS)
+        return false;
+
+    ret = RegQueryValueEx(lKey, name, NULL, NULL, out, &length);
+    if (ret != ERROR_SUCCESS)
+        status = false;
+
+    RegCloseKey(lKey);
 
     return status;
 }

--- a/src/libnetdata/os/os-windows-wrappers.c
+++ b/src/libnetdata/os/os-windows-wrappers.c
@@ -5,7 +5,7 @@
 #if defined(OS_WINDOWS)
 #include <windows.h>
 
-bool netdata_registry_get_dword(int *out, void *hKey, char *subKey, char *name)
+bool netdata_registry_get_dword(unsigned int *out, void *hKey, char *subKey, char *name)
 {
     HKEY lKey;
     bool status = true;
@@ -17,7 +17,7 @@ bool netdata_registry_get_dword(int *out, void *hKey, char *subKey, char *name)
     if (ret != ERROR_SUCCESS)
         return 0;
 
-    DWORD length = 260, value = 260, type;
+    DWORD length = 260, value = 260;
     ret = RegQueryValueEx(lKey, name, NULL, NULL, (LPBYTE) &value, &length);
     if (ret != ERROR_SUCCESS)
         status = false;

--- a/src/libnetdata/os/os-windows-wrappers.c
+++ b/src/libnetdata/os/os-windows-wrappers.c
@@ -5,7 +5,7 @@
 #if defined(OS_WINDOWS)
 #include <windows.h>
 
-long netdata_registry_get_dword_from_open_key(unsigned int *out, HKEY lKey, char *name)
+long netdata_registry_get_dword_from_open_key(unsigned int *out, void *lKey, char *name)
 {
     DWORD length = 260;
     return RegQueryValueEx(lKey, name, NULL, NULL, (LPBYTE) out, &length);
@@ -32,7 +32,7 @@ bool netdata_registry_get_dword(unsigned int *out, void *hKey, char *subKey, cha
     return status;
 }
 
-long netdata_registry_get_string_from_open_key(char *out, unsigned int length, HKEY lKey, char *name)
+long netdata_registry_get_string_from_open_key(char *out, unsigned int length, void *lKey, char *name)
 {
     return RegQueryValueEx(lKey, name, NULL, NULL, (LPBYTE) out, &length);
 }

--- a/src/libnetdata/os/os-windows-wrappers.c
+++ b/src/libnetdata/os/os-windows-wrappers.c
@@ -29,7 +29,7 @@ bool netdata_registry_get_dword(unsigned int *out, void *hKey, char *subKey, cha
     return status;
 }
 
-bool netdata_registry_get_string(char *out, size_t length, void *hKey, char *subKey, char *name)
+bool netdata_registry_get_string(char *out, unsigned int length, void *hKey, char *subKey, char *name)
 {
     HKEY lKey;
     bool status = true;
@@ -41,7 +41,7 @@ bool netdata_registry_get_string(char *out, size_t length, void *hKey, char *sub
     if (ret != ERROR_SUCCESS)
         return false;
 
-    ret = RegQueryValueEx(lKey, name, NULL, NULL, out, &length);
+    ret = RegQueryValueEx(lKey, name, NULL, NULL, (LPBYTE) out, &length);
     if (ret != ERROR_SUCCESS)
         status = false;
 

--- a/src/libnetdata/os/os-windows-wrappers.c
+++ b/src/libnetdata/os/os-windows-wrappers.c
@@ -5,7 +5,7 @@
 #if defined(OS_WINDOWS)
 #include <windows.h>
 
-bool netdata_registry_get_dword(DWORD *out, HKEY hKey, char *subKey, char *name)
+bool netdata_registry_get_dword(int *out, void *hKey, char *subKey, char *name)
 {
     HKEY lKey;
     bool status = true;

--- a/src/libnetdata/os/os-windows-wrappers.c
+++ b/src/libnetdata/os/os-windows-wrappers.c
@@ -5,6 +5,12 @@
 #if defined(OS_WINDOWS)
 #include <windows.h>
 
+long netdata_registry_get_dword_from_open_key(unsigned int *out, HKEY lKey, char *name)
+{
+    DWORD length = 260;
+    return RegQueryValueEx(lKey, name, NULL, NULL, (LPBYTE) out, &length);
+}
+
 bool netdata_registry_get_dword(unsigned int *out, void *hKey, char *subKey, char *name)
 {
     HKEY lKey;
@@ -17,16 +23,18 @@ bool netdata_registry_get_dword(unsigned int *out, void *hKey, char *subKey, cha
     if (ret != ERROR_SUCCESS)
         return false;
 
-    DWORD length = 260, value = 260;
-    ret = RegQueryValueEx(lKey, name, NULL, NULL, (LPBYTE) &value, &length);
+    ret = netdata_registry_get_dword_from_open_key(out, lKey, name);
     if (ret != ERROR_SUCCESS)
         status = false;
 
     RegCloseKey(lKey);
 
-    *out = value;
-
     return status;
+}
+
+long netdata_registry_get_string_from_open_key(char *out, unsigned int length, HKEY lKey, char *name)
+{
+    return RegQueryValueEx(lKey, name, NULL, NULL, (LPBYTE) out, &length);
 }
 
 bool netdata_registry_get_string(char *out, unsigned int length, void *hKey, char *subKey, char *name)
@@ -41,7 +49,7 @@ bool netdata_registry_get_string(char *out, unsigned int length, void *hKey, cha
     if (ret != ERROR_SUCCESS)
         return false;
 
-    ret = RegQueryValueEx(lKey, name, NULL, NULL, (LPBYTE) out, &length);
+    ret = netdata_registry_get_string_from_open_key(out, length, lKey, name);
     if (ret != ERROR_SUCCESS)
         status = false;
 
@@ -51,4 +59,3 @@ bool netdata_registry_get_string(char *out, unsigned int length, void *hKey, cha
 }
 
 #endif
-

--- a/src/libnetdata/os/os-windows-wrappers.c
+++ b/src/libnetdata/os/os-windows-wrappers.c
@@ -3,6 +3,7 @@
 #include "../libnetdata.h"
 
 #if defined(OS_WINDOWS)
+#include <windows.h>
 
 bool netdata_registry_get_dword(DWORD *out, HKEY hKey, char *subKey, char *name)
 {

--- a/src/libnetdata/os/os-windows-wrappers.h
+++ b/src/libnetdata/os/os-windows-wrappers.h
@@ -7,10 +7,10 @@
 
 #if defined(OS_WINDOWS)
 
-long netdata_registry_get_dword_from_open_key(unsigned int *out, HKEY lKey, char *name);
+long netdata_registry_get_dword_from_open_key(unsigned int *out, void *lKey, char *name);
 bool netdata_registry_get_dword(unsigned int *out, void *hKey, char *subKey, char *name);
 
-long netdata_registry_get_string_from_open_key(char *out, unsigned int length, HKEY lKey, char *name);
+long netdata_registry_get_string_from_open_key(char *out, unsigned int length, void *lKey, char *name);
 bool netdata_registry_get_string(char *out, unsigned int length, void *hKey, char *subKey, char *name);
 
 #endif // OS_WINDOWS

--- a/src/libnetdata/os/os-windows-wrappers.h
+++ b/src/libnetdata/os/os-windows-wrappers.h
@@ -7,7 +7,10 @@
 
 #if defined(OS_WINDOWS)
 
+long netdata_registry_get_dword_from_open_key(unsigned int *out, HKEY lKey, char *name);
 bool netdata_registry_get_dword(unsigned int *out, void *hKey, char *subKey, char *name);
+
+long netdata_registry_get_string_from_open_key(char *out, unsigned int length, HKEY lKey, char *name);
 bool netdata_registry_get_string(char *out, unsigned int length, void *hKey, char *subKey, char *name);
 
 #endif // OS_WINDOWS

--- a/src/libnetdata/os/os-windows-wrappers.h
+++ b/src/libnetdata/os/os-windows-wrappers.h
@@ -7,6 +7,6 @@
 
 #if defined(OS_WINDOWS)
 
-bool netdata_registry_get_dword(DWORD *out, HKEY hKey, char *subKey, char *name);
+bool netdata_registry_get_dword(int *out, void *hKey, char *subKey, char *name);
 #endif
 #endif //NETDATA_OS_WINDOWS_WRAPPERS_H

--- a/src/libnetdata/os/os-windows-wrappers.h
+++ b/src/libnetdata/os/os-windows-wrappers.h
@@ -6,6 +6,7 @@
 #include "../libnetdata.h"
 
 #if defined(OS_WINDOWS)
+#define NETDATA_WIN_DETECTION_METHOD "Windows API/Registry)
 
 long netdata_registry_get_dword_from_open_key(unsigned int *out, void *lKey, char *name);
 bool netdata_registry_get_dword(unsigned int *out, void *hKey, char *subKey, char *name);

--- a/src/libnetdata/os/os-windows-wrappers.h
+++ b/src/libnetdata/os/os-windows-wrappers.h
@@ -8,6 +8,7 @@
 #if defined(OS_WINDOWS)
 
 bool netdata_registry_get_dword(unsigned int *out, void *hKey, char *subKey, char *name);
+bool netdata_registry_get_string(char *out, size_t length, void *hKey, char *subKey, char *name);
 
 #endif // OS_WINDOWS
 #endif //NETDATA_OS_WINDOWS_WRAPPERS_H

--- a/src/libnetdata/os/os-windows-wrappers.h
+++ b/src/libnetdata/os/os-windows-wrappers.h
@@ -7,6 +7,7 @@
 
 #if defined(OS_WINDOWS)
 
-bool netdata_registry_get_dword(int *out, void *hKey, char *subKey, char *name);
-#endif
+bool netdata_registry_get_dword(unsigned int *out, void *hKey, char *subKey, char *name);
+
+#endif // OS_WINDOWS
 #endif //NETDATA_OS_WINDOWS_WRAPPERS_H

--- a/src/libnetdata/os/os-windows-wrappers.h
+++ b/src/libnetdata/os/os-windows-wrappers.h
@@ -8,7 +8,7 @@
 #if defined(OS_WINDOWS)
 
 bool netdata_registry_get_dword(unsigned int *out, void *hKey, char *subKey, char *name);
-bool netdata_registry_get_string(char *out, unsigned int_t length, void *hKey, char *subKey, char *name);
+bool netdata_registry_get_string(char *out, unsigned int length, void *hKey, char *subKey, char *name);
 
 #endif // OS_WINDOWS
 #endif //NETDATA_OS_WINDOWS_WRAPPERS_H

--- a/src/libnetdata/os/os-windows-wrappers.h
+++ b/src/libnetdata/os/os-windows-wrappers.h
@@ -8,4 +8,6 @@
 #if defined(OS_WINDOWS)
 #include <windows.h>
 
+bool netdata_registry_get_dword(DOWRD *out, HKEY hKey, char *subKey, char *name);
+#endif
 #endif //NETDATA_OS_WINDOWS_WRAPPERS_H

--- a/src/libnetdata/os/os-windows-wrappers.h
+++ b/src/libnetdata/os/os-windows-wrappers.h
@@ -8,7 +8,7 @@
 #if defined(OS_WINDOWS)
 
 bool netdata_registry_get_dword(unsigned int *out, void *hKey, char *subKey, char *name);
-bool netdata_registry_get_string(char *out, size_t length, void *hKey, char *subKey, char *name);
+bool netdata_registry_get_string(char *out, unsigned int_t length, void *hKey, char *subKey, char *name);
 
 #endif // OS_WINDOWS
 #endif //NETDATA_OS_WINDOWS_WRAPPERS_H

--- a/src/libnetdata/os/os-windows-wrappers.h
+++ b/src/libnetdata/os/os-windows-wrappers.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_OS_WINDOWS_WRAPPERS_H
+#define NETDATA_OS_WINDOWS_WRAPPERS_H
+
+#include "../libnetdata.h"
+
+#if defined(OS_WINDOWS)
+#include <windows.h>
+
+#endif //NETDATA_OS_WINDOWS_WRAPPERS_H

--- a/src/libnetdata/os/os-windows-wrappers.h
+++ b/src/libnetdata/os/os-windows-wrappers.h
@@ -6,7 +6,7 @@
 #include "../libnetdata.h"
 
 #if defined(OS_WINDOWS)
-#define NETDATA_WIN_DETECTION_METHOD "Windows API/Registry)
+#define NETDATA_WIN_DETECTION_METHOD "Windows API/Registry"
 
 long netdata_registry_get_dword_from_open_key(unsigned int *out, void *lKey, char *name);
 bool netdata_registry_get_dword(unsigned int *out, void *hKey, char *subKey, char *name);

--- a/src/libnetdata/os/os-windows-wrappers.h
+++ b/src/libnetdata/os/os-windows-wrappers.h
@@ -8,6 +8,6 @@
 #if defined(OS_WINDOWS)
 #include <windows.h>
 
-bool netdata_registry_get_dword(DOWRD *out, HKEY hKey, char *subKey, char *name);
+bool netdata_registry_get_dword(DWORD *out, HKEY hKey, char *subKey, char *name);
 #endif
 #endif //NETDATA_OS_WINDOWS_WRAPPERS_H

--- a/src/libnetdata/os/os-windows-wrappers.h
+++ b/src/libnetdata/os/os-windows-wrappers.h
@@ -6,7 +6,6 @@
 #include "../libnetdata.h"
 
 #if defined(OS_WINDOWS)
-#include <windows.h>
 
 bool netdata_registry_get_dword(DWORD *out, HKEY hKey, char *subKey, char *name);
 #endif

--- a/src/libnetdata/os/os.h
+++ b/src/libnetdata/os/os.h
@@ -20,6 +20,7 @@
 #include "setenv.h"
 #include "os-freebsd-wrappers.h"
 #include "os-macos-wrappers.h"
+#include "os-windows-wrappers.h"
 
 // =====================================================================================================================
 // common defs for Apple/FreeBSD/Linux


### PR DESCRIPTION
##### Summary

This PR enhances the Windows agent by enabling it to retrieve system information without the need for msys.

![win](https://github.com/netdata/netdata/assets/49162938/a931e157-4826-4cda-b972-27177672268b)

Please note that this update does not include support for containers, as further research is required to properly configure and utilize them on Microsoft platforms.

Additionally, I have not used WinSock to obtain cloud information. Incorporating WinSock would introduce an additional layer of complexity to Netdata, which we are not yet utilizing but should consider in the future.

##### Test Plan

1. Compile this branch on `msys` terminal
2. Start the agent 
3. Access http://localhost/api/v1/info

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
