### PR TITLE
Improve agent shutdown

### DIFF
--- a/src/collectors/freebsd.plugin/plugin_freebsd.c
+++ b/src/collectors/freebsd.plugin/plugin_freebsd.c
@@ -109,12 +109,12 @@ void *freebsd_main(void *ptr)
     heartbeat_t hb;
     heartbeat_init(&hb);
 
-    while (!netdata_exit) {
+    while(service_running(SERVICE_COLLECTORS))  {
         worker_is_idle();
 
         usec_t hb_dt = heartbeat_next(&hb, step);
 
-        if (unlikely(netdata_exit))
+       if (!service_running(SERVICE_COLLECTORS))
             break;
 
         for (i = 0; freebsd_modules[i].name; i++) {
@@ -127,7 +127,7 @@ void *freebsd_main(void *ptr)
             worker_is_busy(i);
             pm->enabled = !pm->func(localhost->rrd_update_every, hb_dt);
 
-            if (unlikely(netdata_exit))
+           if (!service_running(SERVICE_COLLECTORS))
                 break;
         }
     }

--- a/src/collectors/macos.plugin/plugin_macos.c
+++ b/src/collectors/macos.plugin/plugin_macos.c
@@ -58,9 +58,12 @@ void *macos_main(void *ptr)
     heartbeat_t hb;
     heartbeat_init(&hb);
 
-    while (!netdata_exit) {
+    while(service_running(SERVICE_COLLECTORS)) {
         worker_is_idle();
         usec_t hb_dt = heartbeat_next(&hb, step);
+
+        if (!service_running(SERVICE_COLLECTORS))
+            break;
 
         for (int i = 0; macos_modules[i].name; i++) {
             struct macos_module *pm = &macos_modules[i];
@@ -72,7 +75,7 @@ void *macos_main(void *ptr)
             worker_is_busy(i);
             pm->enabled = !pm->func(localhost->rrd_update_every, hb_dt);
 
-            if (unlikely(netdata_exit))
+            if (!service_running(SERVICE_COLLECTORS))
                 break;
         }
     }

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -121,7 +121,11 @@ bool service_running(SERVICE_TYPE service) {
 
     sth->services |= service;
 
-    return !sth->stop_immediately && !netdata_exit && !nd_thread_signaled_to_cancel();
+	bool cancelled = false;
+	if (sth->type == SERVICE_THREAD_TYPE_NETDATA)
+		cancelled = nd_thread_signaled_to_cancel();
+
+    return !sth->stop_immediately && !netdata_exit && !cancelled;
 }
 
 void service_signal_exit(SERVICE_TYPE service) {
@@ -136,8 +140,16 @@ void service_signal_exit(SERVICE_TYPE service) {
         if((sth->services & service)) {
             sth->stop_immediately = true;
 
-            // this does not harm - it just raises a flag
-            nd_thread_signal_cancel(sth->netdata_thread);
+			switch(sth->type) {
+               default:
+               case SERVICE_THREAD_TYPE_NETDATA:
+                  nd_thread_signal_cancel(sth->netdata_thread);
+                  break;
+
+               case SERVICE_THREAD_TYPE_EVENT_LOOP:
+               case SERVICE_THREAD_TYPE_LIBUV:
+                  break;
+            }
 
             if(sth->request_quit_callback) {
                 spinlock_unlock(&service_globals.lock);

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -344,6 +344,8 @@ void netdata_cleanup_and_exit(int ret, const char *action, const char *action_re
     (void) rename(agent_crash_file, agent_incomplete_shutdown_file);
     watcher_step_complete(WATCHER_STEP_ID_CREATE_SHUTDOWN_FILE);
 
+    ml_stop_threads();
+
 #ifdef ENABLE_DBENGINE
     if(dbengine_enabled) {
         for (size_t tier = 0; tier < storage_tiers; tier++)
@@ -374,7 +376,6 @@ void netdata_cleanup_and_exit(int ret, const char *action, const char *action_re
     metadata_sync_shutdown_prepare();
     watcher_step_complete(WATCHER_STEP_ID_PREPARE_METASYNC_SHUTDOWN);
 
-    ml_stop_threads();
     ml_fini();
     watcher_step_complete(WATCHER_STEP_ID_DISABLE_ML_DETECTION_AND_TRAINING_THREADS);
 


### PR DESCRIPTION
##### Summary
- Handle event loop threads differently during shutdown (when attempting to signal the thread to stop)
- Check if collectors are still running in the freebsd plugin instead of netdata_exit variable
- Signal ML to stop earlier in the shutdown sequence
