### PR TITLE
go.d phpfpm add config schema

### DIFF
--- a/src/go/collectors/go.d.plugin/modules/phpfpm/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/phpfpm/config_schema.json
@@ -1,46 +1,87 @@
 {
   "jsonSchema": {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "go.d/phpfpm job configuration schema.",
+    "title": "PHP-FPM collector configuration.",
     "type": "object",
     "properties": {
-      "name": {
-        "type": "string"
-      },
-      "url": {
-        "type": "string"
-      },
-      "socket": {
-        "type": "string"
-      },
-      "address": {
-        "type": "string"
-      },
-      "fcgi_path": {
-        "type": "string"
+      "update_every": {
+        "title": "Update every",
+        "description": "Data collection interval, measured in seconds.",
+        "type": "integer",
+        "minimum": 1,
+        "default": 1
       },
       "timeout": {
-        "type": [
-          "string",
-          "integer"
-        ]
+        "title": "Timeout",
+        "description": "The timeout in seconds for requests.",
+        "type": "number",
+        "minimum": 0.5,
+        "default": 1
+      },
+      "url": {
+        "title": "URL",
+        "description": "The URL of the PHP-FPM [status page](https://www.php.net/manual/en/fpm.status.php).",
+        "type": "string",
+        "default": "http://127.0.0.1/status?full&json",
+        "format": "uri"
+      },
+      "address": {
+        "title": "Address",
+        "description": "The PHP-FPM daemon's TCP listening address. This will be preferred over the **URL** if set.",
+        "type": "string",
+        "default": ""
+      },
+      "socket": {
+        "title": "Socket",
+        "description": "The PHP-FPM daemon's Unix socket. This will be preferred over both the **URL** and **Address** if set.",
+        "type": "string",
+        "default": "",
+        "pattern": "^$|^/"
+      },
+      "fcgi_path": {
+        "title": "FCGI status path",
+        "description": "The URI to view the [FPM status page](https://www.php.net/manual/en/fpm.status.php).",
+        "type": "string",
+        "default": "/status",
+        "pattern": "^$|^/"
+      },
+      "not_follow_redirects": {
+        "title": "Not follow redirects",
+        "description": "If set, the client will not follow HTTP redirects automatically.",
+        "type": "boolean"
       },
       "username": {
-        "type": "string"
+        "title": "Username",
+        "description": "The username for basic authentication.",
+        "type": "string",
+        "sensitive": true
       },
       "password": {
-        "type": "string"
+        "title": "Password",
+        "description": "The password for basic authentication.",
+        "type": "string",
+        "sensitive": true
       },
       "proxy_url": {
+        "title": "Proxy URL",
+        "description": "The URL of the proxy server.",
         "type": "string"
       },
       "proxy_username": {
-        "type": "string"
+        "title": "Proxy username",
+        "description": "The username for proxy authentication.",
+        "type": "string",
+        "sensitive": true
       },
       "proxy_password": {
-        "type": "string"
+        "title": "Proxy password",
+        "description": "The password for proxy authentication.",
+        "type": "string",
+        "sensitive": true
       },
       "headers": {
+        "title": "Headers",
+        "description": "Additional HTTP headers to include in the request.",
         "type": [
           "object",
           "null"
@@ -49,46 +90,116 @@
           "type": "string"
         }
       },
-      "not_follow_redirects": {
+      "tls_skip_verify": {
+        "title": "Skip TLS verification",
+        "description": "If set, TLS certificate verification will be skipped.",
         "type": "boolean"
       },
       "tls_ca": {
-        "type": "string"
+        "title": "TLS CA",
+        "description": "The path to the CA certificate file for TLS verification.",
+        "type": "string",
+        "pattern": "^$|^/"
       },
       "tls_cert": {
-        "type": "string"
+        "title": "TLS certificate",
+        "description": "The path to the client certificate file for TLS authentication.",
+        "type": "string",
+        "pattern": "^$|^/"
       },
       "tls_key": {
+        "title": "TLS key",
+        "description": "The path to the client key file for TLS authentication.",
+        "type": "string",
+        "pattern": "^$|^/"
+      },
+      "body": {
+        "title": "Body",
         "type": "string"
       },
-      "insecure_skip_verify": {
-        "type": "boolean"
+      "method": {
+        "title": "Method",
+        "type": "string"
       }
     },
-    "oneOf": [
-      {
-        "required": [
-          "name",
-          "url"
-        ]
-      },
-      {
-        "required": [
-          "name",
-          "socket"
-        ]
-      },
-      {
-        "required": [
-          "name",
-          "address"
-        ]
-      }
-    ]
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
   },
   "uiSchema": {
     "uiOptions": {
       "fullPage": true
+    },
+    "address": {
+      "ui:placeholder": "127.0.0.1:9000"
+    },
+    "socket": {
+      "ui:placeholder": "/tmp/php-fpm.sock"
+    },
+    "fcgi_path": {
+      "ui:widget": "hidden"
+    },
+    "body": {
+      "ui:widget": "hidden"
+    },
+    "method": {
+      "ui:widget": "hidden"
+    },
+    "timeout": {
+      "ui:help": "Accepts decimals for precise control (e.g., type 1.5 for 1.5 seconds)."
+    },
+    "password": {
+      "ui:widget": "password"
+    },
+    "proxy_password": {
+      "ui:widget": "password"
+    },
+    "ui:flavour": "tabs",
+    "ui:options": {
+      "tabs": [
+        {
+          "title": "Base",
+          "fields": [
+            "update_every",
+            "timeout",
+            "url",
+            "address",
+            "socket",
+            "not_follow_redirects"
+          ]
+        },
+        {
+          "title": "Auth",
+          "fields": [
+            "username",
+            "password"
+          ]
+        },
+        {
+          "title": "TLS",
+          "fields": [
+            "tls_skip_verify",
+            "tls_ca",
+            "tls_cert",
+            "tls_key"
+          ]
+        },
+        {
+          "title": "Proxy",
+          "fields": [
+            "proxy_url",
+            "proxy_username",
+            "proxy_password"
+          ]
+        },
+        {
+          "title": "Headers",
+          "fields": [
+            "headers"
+          ]
+        }
+      ]
     }
   }
 }

--- a/src/go/collectors/go.d.plugin/modules/phpfpm/phpfpm.go
+++ b/src/go/collectors/go.d.plugin/modules/phpfpm/phpfpm.go
@@ -11,9 +11,7 @@ import (
 	"github.com/netdata/netdata/go/go.d.plugin/pkg/web"
 )
 
-////go:embed "config_schema.json"
-//var configSchema string
-
+//go:embed "config_schema.json"
 var configSchema string
 
 func init() {
@@ -43,9 +41,9 @@ func New() *Phpfpm {
 type Config struct {
 	UpdateEvery int `yaml:"update_every,omitempty" json:"update_every"`
 	web.HTTP    `yaml:",inline" json:""`
-	Socket      string `yaml:"socket" json:"socket"`
-	Address     string `yaml:"address" json:"address"`
-	FcgiPath    string `yaml:"fcgi_path" json:"fcgi_path"`
+	Socket      string `yaml:"socket,omitempty" json:"socket"`
+	Address     string `yaml:"address,omitempty" json:"address"`
+	FcgiPath    string `yaml:"fcgi_path,omitempty" json:"fcgi_path"`
 }
 
 type Phpfpm struct {


### PR DESCRIPTION
##### Summary

Dyncfg doesn't work for `go.d/phpfpm` because it doesn't have a configuration schema. The issue is [reported on the community forum](https://community.netdata.cloud/t/help-request-php-fpm-collector-something-went-wrong/5534/1).

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
