### PR TITLE
update Telegram Cloud notification docs to include new topic ID field

### DIFF
--- a/integrations/cloud-notifications/integrations/telegram.md
+++ b/integrations/cloud-notifications/integrations/telegram.md
@@ -27,7 +27,7 @@ To add Telegram notification you need:
 - A Netdata Cloud account
 - Access to the space as an **Admin**
 - The Space needs to be on a paid plan
-- The Telegram bot token, chat ID and _optionally_ the topic ID
+- The Telegram bot token and chat ID
 
 ### Steps
 
@@ -43,15 +43,12 @@ To add Telegram notification you need:
   - **Integration configuration** are the specific notification integration required settings, which vary by notification method. For Telegram:
       - Bot Token - the token of your bot
       - Chat ID - the chat id where your bot will deliver messages to
-      - Topic ID - the topic id of the chat where your bot will deliver messages to. If omitted or 0, messages are sent to the General topic. In case topics are not supported, messages are simply sent to the chat.
 
-### Getting the Telegram bot token, chat ID and topic ID
+### Getting the Telegram bot token and chat ID
 
 - Bot token: To create one bot, contact the [@BotFather](https://t.me/BotFather) bot and send the command `/newbot` and follow the instructions. **Start a conversation with your bot or invite it into the group where you want it to send notifications**.
 - To get the chat ID you have two options:
     - Contact the [@myidbot](https://t.me/myidbot) bot and send the `/getid` command to get your personal chat ID, or invite it into a group and use the `/getgroupid` command to get the group chat ID.
     - Alternatively, you can get the chat ID directly from the bot API. Send your bot a command in the chat you want to use, then check `https://api.telegram.org/bot{YourBotToken}/getUpdates`, eg. `https://api.telegram.org/bot111122223:7OpFlFFRzRBbrUUmIjj5HF9Ox2pYJZy5/getUpdates`
-- To get the topic ID the simplest way is the following: Post a message to that topic and then right-click on it and select `Copy Message Link`. Paste it on a scratchpad and notice that it has the following structure
-`https://t.me/c/XXXXXXXXXX/YY/ZZ`. The topic ID is `YY` (integer).
 
 

--- a/integrations/cloud-notifications/integrations/telegram.md
+++ b/integrations/cloud-notifications/integrations/telegram.md
@@ -27,7 +27,7 @@ To add Telegram notification you need:
 - A Netdata Cloud account
 - Access to the space as an **Admin**
 - The Space needs to be on a paid plan
-- The Telegram bot token and chat ID
+- The Telegram bot token, chat ID and _optionally_ the topic ID
 
 ### Steps
 
@@ -43,12 +43,15 @@ To add Telegram notification you need:
   - **Integration configuration** are the specific notification integration required settings, which vary by notification method. For Telegram:
       - Bot Token - the token of your bot
       - Chat ID - the chat id where your bot will deliver messages to
+      - Topic ID - the topic id of the chat where your bot will deliver messages to. If omitted or 0, messages are sent to the General topic. In case topics are not supported, messages are simply sent to the chat.
 
-### Getting the Telegram bot token and chat ID
+### Getting the Telegram bot token, chat ID and topic ID
 
 - Bot token: To create one bot, contact the [@BotFather](https://t.me/BotFather) bot and send the command `/newbot` and follow the instructions. **Start a conversation with your bot or invite it into the group where you want it to send notifications**.
 - To get the chat ID you have two options:
     - Contact the [@myidbot](https://t.me/myidbot) bot and send the `/getid` command to get your personal chat ID, or invite it into a group and use the `/getgroupid` command to get the group chat ID.
     - Alternatively, you can get the chat ID directly from the bot API. Send your bot a command in the chat you want to use, then check `https://api.telegram.org/bot{YourBotToken}/getUpdates`, eg. `https://api.telegram.org/bot111122223:7OpFlFFRzRBbrUUmIjj5HF9Ox2pYJZy5/getUpdates`
+- To get the topic ID the simplest way is the following: Post a message to that topic and then right-click on it and select `Copy Message Link`. Paste it on a scratchpad and notice that it has the following structure
+`https://t.me/c/XXXXXXXXXX/YY/ZZ`. The topic ID is `YY` (integer).
 
 

--- a/integrations/cloud-notifications/metadata.yaml
+++ b/integrations/cloud-notifications/metadata.yaml
@@ -432,7 +432,7 @@
       - A Netdata Cloud account
       - Access to the space as an **Admin**
       - The Space needs to be on a paid plan
-      - The Telegram bot token and chat ID
+      - The Telegram bot token, chat ID and _optionally_ the topic ID
 
       ### Steps
 
@@ -448,14 +448,16 @@
         - **Integration configuration** are the specific notification integration required settings, which vary by notification method. For Telegram:
             - Bot Token - the token of your bot
             - Chat ID - the chat id where your bot will deliver messages to
+            - Topic ID - the topic id of the chat where your bot will deliver messages to. If omitted or 0, messages are sent to the General topic. In case topics are not supported, messages are simply sent to the chat
 
-      ### Getting the Telegram bot token and chat ID
+      ### Getting the Telegram bot token, chat ID and topic ID
 
       - Bot token: To create one bot, contact the [@BotFather](https://t.me/BotFather) bot and send the command `/newbot` and follow the instructions. **Start a conversation with your bot or invite it into the group where you want it to send notifications**.
       - To get the chat ID you have two options:
           - Contact the [@myidbot](https://t.me/myidbot) bot and send the `/getid` command to get your personal chat ID, or invite it into a group and use the `/getgroupid` command to get the group chat ID.
           - Alternatively, you can get the chat ID directly from the bot API. Send your bot a command in the chat you want to use, then check `https://api.telegram.org/bot{YourBotToken}/getUpdates`, eg. `https://api.telegram.org/bot111122223:7OpFlFFRzRBbrUUmIjj5HF9Ox2pYJZy5/getUpdates`
-
+      - To get the topic ID the simplest way is the following: Post a message to that topic and then right-click on it and select `Copy Message Link`. Paste it on a scratchpad and notice that it has the following structure `https://t.me/c/XXXXXXXXXX/YY/ZZ`. The topic ID is `YY` (integer).
+      
 - id: 'notify-cloud-splunk'
   meta:
     name: 'Splunk'

--- a/integrations/cloud-notifications/metadata.yaml
+++ b/integrations/cloud-notifications/metadata.yaml
@@ -457,7 +457,6 @@
           - Contact the [@myidbot](https://t.me/myidbot) bot and send the `/getid` command to get your personal chat ID, or invite it into a group and use the `/getgroupid` command to get the group chat ID.
           - Alternatively, you can get the chat ID directly from the bot API. Send your bot a command in the chat you want to use, then check `https://api.telegram.org/bot{YourBotToken}/getUpdates`, eg. `https://api.telegram.org/bot111122223:7OpFlFFRzRBbrUUmIjj5HF9Ox2pYJZy5/getUpdates`
       - To get the topic ID the simplest way is the following: Post a message to that topic and then right-click on it and select `Copy Message Link`. Paste it on a scratchpad and notice that it has the following structure `https://t.me/c/XXXXXXXXXX/YY/ZZ`. The topic ID is `YY` (integer).
-      
 - id: 'notify-cloud-splunk'
   meta:
     name: 'Splunk'

--- a/integrations/cloud-notifications/metadata.yaml
+++ b/integrations/cloud-notifications/metadata.yaml
@@ -448,7 +448,7 @@
         - **Integration configuration** are the specific notification integration required settings, which vary by notification method. For Telegram:
             - Bot Token - the token of your bot
             - Chat ID - the chat id where your bot will deliver messages to
-            - Topic ID - the topic id of the chat where your bot will deliver messages to. If omitted or 0, messages are sent to the General topic. In case topics are not supported, messages are simply sent to the chat
+            - Topic ID - the identifier of the chat topic to which your bot will send messages. If omitted or 0, messages will be sent to the General topic. If topics are not supported, messages will be sent to the chat.
 
       ### Getting the Telegram bot token, chat ID and topic ID
 
@@ -456,7 +456,7 @@
       - To get the chat ID you have two options:
           - Contact the [@myidbot](https://t.me/myidbot) bot and send the `/getid` command to get your personal chat ID, or invite it into a group and use the `/getgroupid` command to get the group chat ID.
           - Alternatively, you can get the chat ID directly from the bot API. Send your bot a command in the chat you want to use, then check `https://api.telegram.org/bot{YourBotToken}/getUpdates`, eg. `https://api.telegram.org/bot111122223:7OpFlFFRzRBbrUUmIjj5HF9Ox2pYJZy5/getUpdates`
-      - To get the topic ID the simplest way is the following: Post a message to that topic and then right-click on it and select `Copy Message Link`. Paste it on a scratchpad and notice that it has the following structure `https://t.me/c/XXXXXXXXXX/YY/ZZ`. The topic ID is `YY` (integer).
+      - To get the topic ID, the easiest way is this: Post a message to that topic, then right-click on it and select `Copy Message Link`. Paste it on a scratchpad and notice that it has the following structure `https://t.me/c/XXXXXXXXXX/YY/ZZ`. The topic ID is `YY` (integer).
 - id: 'notify-cloud-splunk'
   meta:
     name: 'Splunk'


### PR DESCRIPTION
##### Summary

Updates the Telegram Cloud notification integration method docs, to include a new optional field

##### Test Plan

This was tested and validated in `staging` env.

##### Additional Information

Users asked for the addition of this optional field and we listened.
