### PR TITLE
add netdata journald configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2576,10 +2576,13 @@ if(BUILD_FOR_PACKAGING)
                 ${CMAKE_BINARY_DIR}/system/systemd/netdata.service
                 COMPONENT netdata
                 DESTINATION lib/systemd/system)
+        install(DIRECTORY
+                COMPONENT netdata
+                DESTINATION lib/systemd/journald@netdata.conf.d
         install(FILES
                 system/systemd/journald@netdata.conf
                 COMPONENT netdata
-                DESTINATION lib/systemd/system)
+                DESTINATION lib/systemd/journald@netdata.conf.d/netdata.conf)
 endif()
 
 configure_file(system/systemd/netdata.service.v235.in system/systemd/netdata.service.v235 @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2566,9 +2566,18 @@ install(FILES
         COMPONENT netdata
         DESTINATION usr/lib/netdata/system/systemd)
 
+install(FILES
+        system/systemd/journald@netdata.conf
+        COMPONENT netdata
+        DESTINATION usr/lib/netdata/system/systemd)
+
 if(BUILD_FOR_PACKAGING)
         install(FILES
                 ${CMAKE_BINARY_DIR}/system/systemd/netdata.service
+                COMPONENT netdata
+                DESTINATION lib/systemd/system)
+        install(FILES
+                system/systemd/journald@netdata.conf
                 COMPONENT netdata
                 DESTINATION lib/systemd/system)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2578,7 +2578,7 @@ if(BUILD_FOR_PACKAGING)
                 DESTINATION lib/systemd/system)
         install(DIRECTORY
                 COMPONENT netdata
-                DESTINATION lib/systemd/journald@netdata.conf.d
+                DESTINATION lib/systemd/journald@netdata.conf.d)
         install(FILES
                 system/systemd/journald@netdata.conf
                 COMPONENT netdata

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2578,11 +2578,11 @@ if(BUILD_FOR_PACKAGING)
                 DESTINATION lib/systemd/system)
         install(DIRECTORY
                 COMPONENT netdata
-                DESTINATION lib/systemd/journald@netdata.conf.d)
+                DESTINATION usr/lib/systemd/journald@netdata.conf.d)
         install(FILES
                 system/systemd/journald@netdata.conf
                 COMPONENT netdata
-                DESTINATION lib/systemd/journald@netdata.conf.d/netdata.conf)
+                DESTINATION usr/lib/systemd/journald@netdata.conf.d/netdata.conf)
 endif()
 
 configure_file(system/systemd/netdata.service.v235.in system/systemd/netdata.service.v235 @ONLY)

--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -799,6 +799,10 @@ progress "Install logrotate configuration for netdata"
 
 install_netdata_logrotate
 
+progress "Install journald configuration for netdata"
+
+install_netdata_journald_conf
+
 # -----------------------------------------------------------------------------
 progress "Read installation options from netdata.conf"
 

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -915,15 +915,17 @@ install_netdata_logrotate() {
 install_netdata_journald_conf() {
   src="${NETDATA_PREFIX}/usr/lib/netdata/system/systemd/journald@netdata.conf"
 
-  [ ! -d /etc/systemd ] && return 0
+  [ ! -d /usr/lib/systemd/ ] && return 0
   [ "${UID}" -ne 0 ] && return 1
 
-  # This file has the lowest precedence.
-  # https://manpages.debian.org/testing/systemd/journald.conf.5.en.html
-  run cp "${src}" /etc/systemd/journald@netdata.conf
+  if [ ! -d /usr/lib/systemd/journald@netdata.conf.d/ ]; then
+    run mkdir /usr/lib/systemd/journald@netdata.conf.d/
+  fi
 
-  if [ -f /etc/systemd/journald@netdata.conf ]; then
-    run chmod 644 /etc/systemd/journald@netdata.conf
+  run cp "${src}" /usr/lib/systemd/journald@netdata.conf.d/netdata.conf
+
+  if [ -f /usr/lib/systemd/journald@netdata.conf.d/netdata.conf ]; then
+    run chmod 644 /usr/lib/systemd/journald@netdata.conf.d/netdata.conf
   fi
 
   return 0

--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -910,6 +910,26 @@ install_netdata_logrotate() {
 }
 
 # -----------------------------------------------------------------------------
+# install netdata journald configuration
+
+install_netdata_journald_conf() {
+  src="${NETDATA_PREFIX}/usr/lib/netdata/system/systemd/journald@netdata.conf"
+
+  [ ! -d /etc/systemd ] && return 0
+  [ "${UID}" -ne 0 ] && return 1
+
+  # This file has the lowest precedence.
+  # https://manpages.debian.org/testing/systemd/journald.conf.5.en.html
+  run cp "${src}" /etc/systemd/journald@netdata.conf
+
+  if [ -f /etc/systemd/journald@netdata.conf ]; then
+    run chmod 644 /etc/systemd/journald@netdata.conf
+  fi
+
+  return 0
+}
+
+# -----------------------------------------------------------------------------
 # create netdata.conf
 
 create_netdata_conf() {

--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -729,6 +729,7 @@ fi
 
 #### REMOVE NETDATA FILES
 rm_file /etc/logrotate.d/netdata
+rm_file /etc/systemd/journald@netdata.conf
 rm_file /etc/systemd/system/netdata.service
 rm_file /lib/systemd/system/netdata.service
 rm_file /usr/lib/systemd/system/netdata.service

--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -729,7 +729,7 @@ fi
 
 #### REMOVE NETDATA FILES
 rm_file /etc/logrotate.d/netdata
-rm_file /etc/systemd/journald@netdata.conf
+rm_file /usr/lib/systemd/journald@netdata.conf.d/netdata.conf
 rm_file /etc/systemd/system/netdata.service
 rm_file /lib/systemd/system/netdata.service
 rm_file /usr/lib/systemd/system/netdata.service
@@ -765,6 +765,7 @@ else
   rm_dir "${NETDATA_PREFIX}/var/cache/netdata"
   rm_dir "${NETDATA_PREFIX}/var/log/netdata"
   rm_dir "${NETDATA_PREFIX}/etc/netdata"
+  rm_dir /usr/lib/systemd/journald@netdata.conf.d/
 fi
 
 if [ -n "${tmpdir}" ]; then

--- a/packaging/makeself/install-or-update.sh
+++ b/packaging/makeself/install-or-update.sh
@@ -124,6 +124,10 @@ progress "Install logrotate configuration for netdata"
 
 install_netdata_logrotate || run_failed "Cannot install logrotate file for netdata."
 
+progress "Install journald configuration for netdata"
+
+install_netdata_journald_conf || run_failed "Cannot install journald file for netdata."
+
 # -----------------------------------------------------------------------------
 progress "Telemetry configuration"
 

--- a/system/systemd/journald@netdata.conf
+++ b/system/systemd/journald@netdata.conf
@@ -2,4 +2,4 @@
 
 [Journal]
 SystemMaxUse=256M
-RuntimeMaxUse=256M
+RuntimeMaxUse=64M

--- a/system/systemd/journald@netdata.conf
+++ b/system/systemd/journald@netdata.conf
@@ -1,0 +1,5 @@
+# See journald.conf(5) for details.
+
+[Journal]
+SystemMaxUse=256M
+RuntimeMaxUse=256M


### PR DESCRIPTION
##### Summary

Related: #17737

The default limit for journal files (`SystemMaxUse`/`RuntimeMaxUse`) is 4GB.

It makes sense to install netdata journald config file with smaller values.

- [x] from source
- [x] static
- [ ] deb
- [ ] rpm


@Ferroin please update deb/rpm packages

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
