### PR TITLE
Restore ML thread termination to original order

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -344,8 +344,6 @@ void netdata_cleanup_and_exit(int ret, const char *action, const char *action_re
     (void) rename(agent_crash_file, agent_incomplete_shutdown_file);
     watcher_step_complete(WATCHER_STEP_ID_CREATE_SHUTDOWN_FILE);
 
-    ml_stop_threads();
-
 #ifdef ENABLE_DBENGINE
     if(dbengine_enabled) {
         for (size_t tier = 0; tier < storage_tiers; tier++)
@@ -376,6 +374,7 @@ void netdata_cleanup_and_exit(int ret, const char *action, const char *action_re
     metadata_sync_shutdown_prepare();
     watcher_step_complete(WATCHER_STEP_ID_PREPARE_METASYNC_SHUTDOWN);
 
+    ml_stop_threads();
     ml_fini();
     watcher_step_complete(WATCHER_STEP_ID_DISABLE_ML_DETECTION_AND_TRAINING_THREADS);
 


### PR DESCRIPTION
##### Summary
The ML thread termination during shutdown has been restored  to it's previous order as it seems to cause some errors during shutdown or crash, so the previous thread termination order has been restored.

##### Test
- Start/Stop agent with ML enabled before and after this PR
