### PR TITLE
integrations make `<details>` open

### DIFF
--- a/integrations/gen_docs_integrations.py
+++ b/integrations/gen_docs_integrations.py
@@ -61,8 +61,10 @@ def clean_and_write(md, path):
     Then it writes the buffer on the file provided.
     """
     # clean first, replace
-    md = md.replace("{% details summary=\"", "<details><summary>").replace(
-        "\" %}", "</summary>\n").replace("{% /details %}", "</details>\n")
+    md = md.replace("{% details summary=\"", "<details><summary>")
+    md = md.replace("{% details open=true summary=\"", "<details open><summary>")
+    md = md.replace("\" %}", "</summary>\n")
+    md = md.replace("{% /details %}", "</details>\n")
 
     path.write_text(md)
 

--- a/integrations/templates/metrics.md
+++ b/integrations/templates/metrics.md
@@ -2,7 +2,7 @@
 ## Metrics
 
 [% if entry.metrics.folding.enabled and not clean %]
-{% details summary="[[ entry.metrics.folding.title ]]" %}
+{% details open=true summary="[[ entry.metrics.folding.title ]]" %}
 [% endif %]
 Metrics grouped by *scope*.
 

--- a/integrations/templates/setup.md
+++ b/integrations/templates/setup.md
@@ -60,7 +60,7 @@ There is no configuration file.
 
 [% if entry.setup.configuration.options.list %]
 [% if entry.setup.configuration.options.folding.enabled and not clean %]
-{% details summary="[[ entry.setup.configuration.options.folding.title ]]" %}
+{% details open=true summary="[[ entry.setup.configuration.options.folding.title ]]" %}
 [% endif %]
 | Name | Description | Default | Required |
 |:----|:-----------|:-------|:--------:|
@@ -92,7 +92,7 @@ There are no configuration options.
 [[ example.description ]]
 
 [% if example.folding.enabled and not clean %]
-{% details summary="[[ entry.setup.configuration.examples.folding.title ]]" %}
+{% details open=true summary="[[ entry.setup.configuration.examples.folding.title ]]" %}
 [% endif %]
 ```yaml
 [[ example.config ]]


### PR DESCRIPTION
##### Summary

It seemed like all folded sections should be closed by default, but after using our documentation I changed my mind.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
