### PR TITLE
go.d ll netlisteners add support for wildcard address

### DIFF
--- a/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/netlisteners.go
+++ b/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/netlisteners.go
@@ -223,6 +223,12 @@ func (d *Discoverer) parseLocalListeners(bs []byte) ([]model.Target, error) {
 			tgt.IPAddress = local6
 		}
 
+		// quick support for https://github.com/netdata/netdata/pull/17866
+		// TODO: create both ipv4 and ipv6 targets?
+		if tgt.IPAddress == "*" {
+			tgt.IPAddress = local4
+		}
+
 		tgt.Address = net.JoinHostPort(tgt.IPAddress, tgt.Port)
 
 		hash, err := calcHash(tgt)

--- a/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/netlisteners_test.go
+++ b/src/go/collectors/go.d.plugin/agent/discovery/sd/discoverer/netlisteners/netlisteners_test.go
@@ -22,6 +22,7 @@ func TestDiscoverer_Discover(t *testing.T) {
 				cli.addListener("TCP|0.0.0.0|8125|/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D")
 				cli.addListener("TCP|192.0.2.1|8125|/opt/netdata/usr/sbin/netdata -P /run/netdata/netdata.pid -D")
 				cli.addListener("UDP|127.0.0.1|53768|/opt/netdata/usr/libexec/netdata/plugins.d/go.d.plugin 1")
+				cli.addListener("TCP46|*|80|/usr/sbin/httpd -k start")
 				cli.addListener("TCP6|::|80|/usr/sbin/apache2 -k start")
 				cli.addListener("TCP|0.0.0.0|80|/usr/sbin/apache2 -k start")
 				cli.addListener("TCP|0.0.0.0|8080|/usr/sbin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8080 -container-ip 172.17.0.4 -container-port 80")
@@ -39,6 +40,14 @@ func TestDiscoverer_Discover(t *testing.T) {
 						Address:   "127.0.0.1:323",
 						Comm:      "chronyd",
 						Cmdline:   "/usr/sbin/chronyd",
+					}),
+					withHash(&target{
+						Protocol:  "TCP46",
+						IPAddress: "127.0.0.1",
+						Port:      "80",
+						Address:   "127.0.0.1:80",
+						Comm:      "httpd",
+						Cmdline:   "/usr/sbin/httpd -k start",
 					}),
 					withHash(&target{
 						Protocol:  "TCP",


### PR DESCRIPTION
##### Summary

Quick support for #17866 (if it will be merged). Use IPv4 for dual-stack LISTEN connections.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
