### PR TITLE
sys_block_zram: don't use "/dev"

### DIFF
--- a/src/collectors/proc.plugin/sys_block_zram.c
+++ b/src/collectors/proc.plugin/sys_block_zram.c
@@ -62,7 +62,7 @@ static inline void init_rrd(const char *name, ZRAM_DEVICE *d, int update_every) 
         "mem"
         , chart_name
         , chart_name
-        , name
+        , "zram"
         , "mem.zram_usage"
         , "ZRAM Memory Usage"
         , "MiB"
@@ -80,7 +80,7 @@ static inline void init_rrd(const char *name, ZRAM_DEVICE *d, int update_every) 
         "mem"
         , chart_name
         , chart_name
-        , name
+        , "zram"
         , "mem.zram_savings"
         , "ZRAM Memory Savings"
         , "MiB"
@@ -98,7 +98,7 @@ static inline void init_rrd(const char *name, ZRAM_DEVICE *d, int update_every) 
         "mem"
         , chart_name
         , chart_name
-        , name
+        , "zram"
         , "mem.zram_ratio"
         , "ZRAM Compression Ratio (original to compressed)"
         , "ratio"
@@ -115,7 +115,7 @@ static inline void init_rrd(const char *name, ZRAM_DEVICE *d, int update_every) 
         "mem"
         , chart_name
         , chart_name
-        , name
+        , "zram"
         , "mem.zram_efficiency"
         , "ZRAM Efficiency"
         , "percentage"
@@ -136,36 +136,31 @@ static int init_devices(DICTIONARY *devices, unsigned int zram_id, int update_ev
     ZRAM_DEVICE device;
     char filename[FILENAME_MAX + 1];
 
-    snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/dev");
+    snprintfz(filename, FILENAME_MAX, "%s%s", netdata_configured_host_prefix, "/sys/block");
     DIR *dir = opendir(filename);
 
     if (unlikely(!dir))
         return 0;
-    while ((de = readdir(dir)))
-    {
-        snprintfz(filename, FILENAME_MAX, "%s/dev/%s", netdata_configured_host_prefix, de->d_name);
-        if (unlikely(stat(filename, &st) != 0))
-        {
-            collector_error("ZRAM : Unable to stat %s: %s", filename, strerror(errno));
+
+    while ((de = readdir(dir))) {
+        snprintfz(filename, FILENAME_MAX, "%s/sys/block/%s/mm_stat", netdata_configured_host_prefix, de->d_name);
+        if (unlikely(stat(filename, &st) != 0)) {
             continue;
         }
-        if (major(st.st_rdev) == zram_id)
-        {
-            collector_info("ZRAM : Found device %s", filename);
-            snprintfz(filename, FILENAME_MAX, "%s/sys/block/%s/mm_stat", netdata_configured_host_prefix, de->d_name);
-            ff = procfile_open(filename, " \t:", PROCFILE_FLAG_DEFAULT);
-            if (ff == NULL)
-            {
-                collector_error("ZRAM : Failed to open %s: %s", filename, strerror(errno));
-                continue;
-            }
-            device.file = ff;
-            init_rrd(de->d_name, &device, update_every);
-            dictionary_set(devices, de->d_name, &device, sizeof(ZRAM_DEVICE));
-            count++;
+        ff = procfile_open(filename, " \t:", PROCFILE_FLAG_DEFAULT);
+        if (ff == NULL) {
+            collector_error("ZRAM : Failed to open %s: %s", filename, strerror(errno));
+            continue;
         }
+
+        device.file = ff;
+        init_rrd(de->d_name, &device, update_every);
+        dictionary_set(devices, de->d_name, &device, sizeof(ZRAM_DEVICE));
+        count++;
     }
+
     closedir(dir);
+
     return count;
 }
 


### PR DESCRIPTION
##### Summary

Addresses 1st point from #17899

##### Test Plan

Start container with `-v /sys:/host/sys:ro` and check "zram" charts.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
