### PR TITLE
Update x509check/metadata: add missing smtp schema

### DIFF
--- a/src/go/collectors/go.d.plugin/modules/x509check/metadata.yaml
+++ b/src/go/collectors/go.d.plugin/modules/x509check/metadata.yaml
@@ -59,7 +59,7 @@ modules:
               default_value: 0
               required: false
             - name: source
-              description: "Certificate source. Allowed schemes: https, tcp, tcp4, tcp6, udp, udp4, udp6, file."
+              description: "Certificate source. Allowed schemes: https, tcp, tcp4, tcp6, udp, udp4, udp6, file, smtp."
               default_value: ""
               required: false
             - name: days_until_expiration_warning


### PR DESCRIPTION
##### Summary

Schema smtp already works, it is already used in this file in an example, and it is mentioned in config_schema.json.