### PR TITLE
updater: handle json decode error in newer_commit_date()

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -533,7 +533,17 @@ newer_commit_date() {
   info "Checking if a newer version of the updater script is available."
 
   commit_check_url="https://api.github.com/repos/netdata/netdata/commits?path=packaging%2Finstaller%2Fnetdata-updater.sh&page=1&per_page=1"
-  python_version_check="from __future__ import print_function;import sys,json;data = json.load(sys.stdin);print(data[0]['commit']['committer']['date'] if isinstance(data, list) else '')"
+  python_version_check="
+from __future__ import print_function
+import sys, json
+
+try:
+    data = json.load(sys.stdin)
+except:
+    print('')
+else:
+    print(data[0]['commit']['committer']['date'] if isinstance(data, list) and data else '')
+"
 
   if command -v jq > /dev/null 2>&1; then
     commit_date="$(_safe_download "${commit_check_url}" /dev/stdout | jq '.[0].commit.committer.date' 2>/dev/null | tr -d '"')"


### PR DESCRIPTION
##### Summary

Fixes: #17887

I think the issue is [_safe_download "${commit_check_url}"](https://github.com/netdata/netdata/blob/9c4aae6869c54c79a65160fa32e88240fd24cb88/packaging/installer/netdata-updater.sh#L541C20-L541C56) doesn't return any output if `curl` fails and the python script doesn't handle it. This PR fixes it. 



##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
