### PR TITLE
dont overwrite static thread env var

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -2112,7 +2112,7 @@ int main(int argc, char **argv) {
                 st->init_routine();
 
             if(st->env_name)
-                setenv(st->env_name, st->enabled?"YES":"NO", 1);
+                setenv(st->env_name, st->enabled ? "YES" : "NO", 0);
 
             if(st->global_variable)
                 *st->global_variable = (st->enabled) ? true : false;


### PR DESCRIPTION
##### Summary

External plugins use "NETDATA_INTERNALS_MONITORING". 

I expect it to be set if `netdata monitoring = yes`. It doesn't work because the extended internal monitoring is disabled and we are overwriting "NETDATA_INTERNALS_MONITORING".

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
