### PR TITLE
Fix warnings

### DIFF
--- a/src/collectors/log2journal/log2journal-yaml.c
+++ b/src/collectors/log2journal/log2journal-yaml.c
@@ -85,7 +85,7 @@ static void yaml_error_with_trace(yaml_parser_t *parser, yaml_event_t *event, si
 #define yaml_parse(parser, event) yaml_parse_with_trace(parser, event, __LINE__, __FUNCTION__, __FILE__)
 static bool yaml_parse_with_trace(yaml_parser_t *parser, yaml_event_t *event, size_t line __maybe_unused, const char *function __maybe_unused, const char *file __maybe_unused) {
     if (!yaml_parser_parse(parser, event)) {
-        yaml_error(parser, NULL, "YAML parser error %d", parser->error);
+        yaml_error(parser, NULL, "YAML parser error %u", parser->error);
         return false;
     }
 

--- a/src/collectors/network-viewer.plugin/network-viewer.c
+++ b/src/collectors/network-viewer.plugin/network-viewer.c
@@ -125,10 +125,10 @@ static void local_socket_to_json_array(BUFFER *wb, LOCAL_SOCKET *n, uint64_t pro
         }
         buffer_json_add_array_item_string(wb, n->network_viewer.remote_address_space);
 
-        uint16_t server_port;
-        const char *server_address;
-        const char *client_address_space;
-        const char *server_address_space;
+        uint16_t server_port = 0;
+        const char *server_address = NULL;
+        const char *client_address_space = NULL;
+        const char *server_address_space = NULL;
         switch (n->direction) {
             case SOCKET_DIRECTION_LISTEN:
             case SOCKET_DIRECTION_INBOUND:

--- a/src/collectors/plugins.d/local_listeners.c
+++ b/src/collectors/plugins.d/local_listeners.c
@@ -64,7 +64,7 @@ static void print_local_listeners_debug(LS_STATE *ls __maybe_unused, LOCAL_SOCKE
            (n->direction & (SOCKET_DIRECTION_LOCAL_INBOUND|SOCKET_DIRECTION_LOCAL_OUTBOUND)) ? "LOCAL," : "",
            (n->direction == 0) ? "NONE," : "",
            n->pid,
-           n->state,
+           (unsigned int)n->state,
            n->net_ns_inode,
            local_address, n->local.port,
            remote_address, n->remote.port,

--- a/src/collectors/proc.plugin/sys_block_zram.c
+++ b/src/collectors/proc.plugin/sys_block_zram.c
@@ -128,7 +128,7 @@ static inline void init_rrd(const char *name, ZRAM_DEVICE *d, int update_every) 
     rrdlabels_add(d->st_alloc_efficiency->rrdlabels, "device", name, RRDLABEL_SRC_AUTO);
 }
 
-static int init_devices(DICTIONARY *devices, unsigned int zram_id, int update_every) {
+static int init_devices(DICTIONARY *devices, int update_every) {
     int count = 0;
     struct dirent *de;
     struct stat st;
@@ -269,7 +269,7 @@ int do_sys_block_zram(int update_every, usec_t dt) {
         procfile_close(ff);
 
         devices = dictionary_create_advanced(DICT_OPTION_SINGLE_THREADED, &dictionary_stats_category_collectors, 0);
-        device_count = init_devices(devices, (unsigned int)zram_id, update_every);
+        device_count = init_devices(devices, update_every);
     }
 
     if (unlikely(device_count < 1))

--- a/src/database/KolmogorovSmirnovDist.c
+++ b/src/database/KolmogorovSmirnovDist.c
@@ -697,8 +697,8 @@ static double DurbinMatrix (int n, double d)
    k = (int) (n * d) + 1;
    m = 2 * k - 1;
    h = k - n * d;
-   H = (double *) malloc ((m * m) * sizeof (double));
-   Q = (double *) malloc ((m * m) * sizeof (double));
+   H = (double *) calloc ((m * m), sizeof (double));
+   Q = (double *) calloc ((m * m), sizeof (double));
    for (i = 0; i < m; i++)
       for (j = 0; j < m; j++)
          if (i - j + 1 < 0)

--- a/src/database/engine/datafile.c
+++ b/src/database/engine/datafile.c
@@ -245,7 +245,7 @@ int create_data_file(struct rrdengine_datafile *datafile)
     uv_fs_t req;
     uv_file file;
     int ret, fd;
-    struct rrdeng_df_sb *superblock;
+    struct rrdeng_df_sb *superblock = NULL;
     uv_buf_t iov;
     char path[RRDENG_PATH_MAX];
 
@@ -291,7 +291,7 @@ int create_data_file(struct rrdengine_datafile *datafile)
 static int check_data_file_superblock(uv_file file)
 {
     int ret;
-    struct rrdeng_df_sb *superblock;
+    struct rrdeng_df_sb *superblock = NULL;
     uv_buf_t iov;
     uv_fs_t req;
 

--- a/src/database/engine/dbengine-compression.c
+++ b/src/database/engine/dbengine-compression.c
@@ -60,8 +60,11 @@ size_t dbengine_max_compressed_size(size_t uncompressed_size, uint8_t algorithm)
         case RRDENG_COMPRESSION_NONE:
             return uncompressed_size;
 
-        default:
+        default: {
             fatal("DBENGINE: unknown compression algorithm %u", algorithm);
+            //we will never reach this point, but we have warnings from compiler
+            return 0;
+        }
     }
 }
 
@@ -117,8 +120,11 @@ size_t dbengine_compress(void *payload, size_t uncompressed_size, uint8_t algori
         case RRDENG_COMPRESSION_NONE:
             return 0;
 
-        default:
+        default: {
             fatal("DBENGINE: unknown compression algorithm %u", algorithm);
+            //we will never reach this point, but we have warnings from compiler
+            return 0;
+        }
     }
 }
 

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -573,7 +573,7 @@ int journalfile_create(struct rrdengine_journalfile *journalfile, struct rrdengi
     uv_fs_t req;
     uv_file file;
     int ret, fd;
-    struct rrdeng_jf_sb *superblock;
+    struct rrdeng_jf_sb *superblock = NULL;
     uv_buf_t iov;
     char path[RRDENG_PATH_MAX];
 
@@ -811,7 +811,7 @@ static uint64_t journalfile_iterate_transactions(struct rrdengine_instance *ctx,
     int ret;
     uint64_t pos, pos_i, max_id, id;
     unsigned size_bytes;
-    void *buf;
+    void *buf = NULL;
     uv_buf_t iov;
     uv_fs_t req;
 

--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -619,7 +619,7 @@ int journalfile_create(struct rrdengine_journalfile *journalfile, struct rrdengi
 static int journalfile_check_superblock(uv_file file)
 {
     int ret;
-    struct rrdeng_jf_sb *superblock;
+    struct rrdeng_jf_sb *superblock = NULL;
     uv_buf_t iov;
     uv_fs_t req;
 

--- a/src/database/engine/pdc.c
+++ b/src/database/engine/pdc.c
@@ -1179,7 +1179,7 @@ static bool epdl_populate_pages_from_extent_data(
 
 static inline void *datafile_extent_read(struct rrdengine_instance *ctx, uv_file file, unsigned pos, unsigned size_bytes)
 {
-    void *buffer;
+    void *buffer = NULL;
     uv_fs_t request;
 
     unsigned real_io_size = ALIGN_BYTES_CEILING(size_bytes);

--- a/src/health/health_dyncfg.c
+++ b/src/health/health_dyncfg.c
@@ -152,7 +152,7 @@ static bool parse_config(json_object *jobj, const char *path, RRD_ALERT_PROTOTYP
 }
 
 static bool parse_prototype(json_object *jobj, const char *path, RRD_ALERT_PROTOTYPE *base, BUFFER *error, const char *name, bool strict) {
-    int64_t version;
+    int64_t version = 0;
     JSONC_PARSE_INT_OR_ERROR_AND_RETURN(jobj, path, "format_version", version, error, strict);
 
     if(version != 1) {


### PR DESCRIPTION
##### Summary
This PR is fixing [these](https://github.com/user-attachments/files/15879366/warnings.txt) warnings that appear when we are using CFLAGS:

```sh
CFLAGS="-O1 -ggdb -Wall -Wextra -fno-omit-frame-pointer -Wformat-signedness -fstack-protector-all -Wformat-truncation=2 -Wunused-result -DNETDATA_DEV_MODE=1 -DNETDATA_VERIFY_LOCKS=1"
```

##### Test Plan

1. Compile `master` branch with CFLAGS redirecting `stderr` and `stdout` to file that you can compare.
2. Compile current branch and check we do not have the same warnigs.
3. Run netdata to confirm everything is working.

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
