### PR TITLE
Sign DEB packages in the GHA runners that build them.

### DIFF
--- a/.github/scripts/deb-sign.sh
+++ b/.github/scripts/deb-sign.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+pkgdir="${1}"
+keyid="${2}"
+
+echo "::group::Installing Dependencies"
+apt update
+apt upgrade -y
+apt install -y debsigs
+echo "::endgroup::"
+
+echo "::group::Signing packages"
+debsigs --sign=origin --default-keyid="${keyid}" "${pkgdir}"/*.{,d}deb
+echo "::endgroup::"

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -312,13 +312,13 @@ jobs:
           ${{ needs.version-check.outputs.repo }}
       - name: Import GPG Keys
         id: import-keys
-        if: needs.file-check.outputs.run == 'true' && matrix.format == 'deb'
+        if: needs.file-check.outputs.run == 'true' && matrix.format == 'deb' && github.event_name != 'pull_request'
         uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.NETDATABOT_PACKAGE_SIGNING_KEY }}
       - name: Sign DEB Packages
         id: sign-deb
-        if: needs.file-check.outputs.run == 'true' && matrix.format == 'deb'
+        if: needs.file-check.outputs.run == 'true' && matrix.format == 'deb' && github.event_name != 'pull_request'
         shell: bash
         run: /netdata/.github/scripts/deb-sign.sh artifacts Netdatabot
       - name: Upload to packages2.netdata.cloud

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -310,6 +310,17 @@ jobs:
           ${{ matrix.arch }} \
           ${{ matrix.format }} \
           ${{ needs.version-check.outputs.repo }}
+      - name: Import GPG Keys
+        id: import-keys
+        if: needs.file-check.outputs.run == 'true' && matrix.format == 'deb'
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.NETDATABOT_PACKAGE_SIGNING_KEY }}
+      - name: Sign DEB Packages
+        id: sign-deb
+        if: needs.file-check.outputs.run == 'true' && matrix.format == 'deb'
+        shell: bash
+        run: /netdata/.github/scripts/deb-sign.sh artifacts Netdatabot
       - name: Upload to packages2.netdata.cloud
         id: package2-upload
         if: github.event_name == 'workflow_dispatch' && github.repository == 'netdata/netdata' && needs.file-check.outputs.run == 'true'

--- a/.github/workflows/repoconfig-packages.yml
+++ b/.github/workflows/repoconfig-packages.yml
@@ -132,6 +132,17 @@ jobs:
               netdata/netdata-repoconfig \
               packaging/repoconfig/artifacts
           done
+      - name: Import GPG Keys
+        id: import-keys
+        if: matrix.format == 'deb'
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.NETDATABOT_PACKAGE_SIGNING_KEY }}
+      - name: Sign DEB Packages
+        id: sign-deb
+        if: matrix.format == 'deb'
+        shell: bash
+        run: /netdata/.github/scripts/deb-sign.sh packaging/repoconfig/artifacts Netdatabot
       - name: Upload to packages2.netdata.cloud
         id: package2-upload
         if: github.event_name != 'pull_request' && github.repository == 'netdata/netdata'

--- a/.github/workflows/repoconfig-packages.yml
+++ b/.github/workflows/repoconfig-packages.yml
@@ -134,13 +134,13 @@ jobs:
           done
       - name: Import GPG Keys
         id: import-keys
-        if: matrix.format == 'deb'
+        if: matrix.format == 'deb' && github.event_name != 'pull_request'
         uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.NETDATABOT_PACKAGE_SIGNING_KEY }}
       - name: Sign DEB Packages
         id: sign-deb
-        if: matrix.format == 'deb'
+        if: matrix.format == 'deb' && github.event_name != 'pull_request'
         shell: bash
         run: /netdata/.github/scripts/deb-sign.sh packaging/repoconfig/artifacts Netdatabot
       - name: Upload to packages2.netdata.cloud


### PR DESCRIPTION
##### Summary

This provides a stronger signature guarantee than we currently provide, and simplifies handling of multiple repository servers.

Currently, this only signs packages going to the backup repository server (repo2.netdata.cloud), allowing us to test the resultant packages more easily with minimal disruption for users.

RPM package signing will be handled in a separate PR.

##### Test Plan

This needs to be merged to be tested, as it was created from a branch from a fork, and therefore the signing keys are not accessible to the workflow run.

##### Additional Information

This signing will be, at least initially, happening in-parallel with the archive signing already being done by the repository servers themselves. Once we’ve confirmed that the origin signing from this PR is working, we will remove the archive signing, allowing us to ensure identical package hashes between the repository servers.