### PR TITLE
fix installing netdata journald conf for native packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2582,7 +2582,8 @@ if(BUILD_FOR_PACKAGING)
         install(FILES
                 system/systemd/journald@netdata.conf
                 COMPONENT netdata
-                DESTINATION usr/lib/systemd/journald@netdata.conf.d/netdata.conf)
+                DESTINATION usr/lib/systemd/journald@netdata.conf.d
+                RENAME netdata.conf)
 endif()
 
 configure_file(system/systemd/netdata.service.v235.in system/systemd/netdata.service.v235 @ONLY)


### PR DESCRIPTION
##### Summary

Now

```bash
$ cat -p /usr/lib/systemd/journald@netdata.conf.d/netdata.conf/journald@netdata.conf
# See journald.conf(5) for details.

[Journal]
SystemMaxUse=256M
RuntimeMaxUse=64M
```

After fix

```bash
$ cat -p /usr/lib/systemd/journald@netdata.conf.d/netdata.conf
# See journald.conf(5) for details.

[Journal]
SystemMaxUse=256M
RuntimeMaxUse=64M
```

##### Test Plan


Tested by building & installing deb locally.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
