### PR TITLE
go.d systemdunits: remove "omitempty" tag from collect_unit_files

### DIFF
--- a/src/go/collectors/go.d.plugin/modules/systemdunits/systemdunits.go
+++ b/src/go/collectors/go.d.plugin/modules/systemdunits/systemdunits.go
@@ -54,7 +54,7 @@ type Config struct {
 	Timeout               web.Duration `yaml:"timeout,omitempty" json:"timeout"`
 	Include               []string     `yaml:"include,omitempty" json:"include"`
 	SkipTransient         bool         `yaml:"skip_transient" json:"skip_transient"`
-	CollectUnitFiles      bool         `yaml:"collect_unit_files,omitempty" json:"collect_unit_files"`
+	CollectUnitFiles      bool         `yaml:"collect_unit_files" json:"collect_unit_files"`
 	IncludeUnitFiles      []string     `yaml:"include_unit_files,omitempty" json:"include_unit_files"`
 	CollectUnitFilesEvery web.Duration `yaml:"collect_unit_files_every,omitempty" json:"collect_unit_files_every"`
 }


### PR DESCRIPTION
##### Summary

Otherwise, "collect_unit_files" is not displayed if it is set to "false" (default).

<img width="360" alt="Screenshot 2024-06-19 at 12 36 35" src="https://github.com/netdata/netdata/assets/22274335/1afc302c-2166-496d-a6f4-3badc2d9e239">

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
