### PR TITLE
add go.d runit

### DIFF
--- a/src/collectors/plugins.d/ndsudo.c
+++ b/src/collectors/plugins.d/ndsudo.c
@@ -14,6 +14,14 @@ struct command {
     const char *search[MAX_SEARCH];
 } allowed_commands[] = {
     {
+        .name = "sv-status-all",
+        .params = "-p -c $*/* - exec sv status {{serviceDir}}",
+        .search = {
+            [0] = "sh",
+            [1] = NULL,
+        },
+    },
+    {
         .name = "dmsetup-status-cache",
         .params = "status --target cache --noflush",
         .search = {

--- a/src/go/collectors/go.d.plugin/README.md
+++ b/src/go/collectors/go.d.plugin/README.md
@@ -117,6 +117,7 @@ see the appropriate collector readme.
 | [rabbitmq](https://github.com/netdata/netdata/tree/master/src/go/collectors/go.d.plugin/modules/rabbitmq)                     |           RabbitMQ            |
 | [redis](https://github.com/netdata/netdata/tree/master/src/go/collectors/go.d.plugin/modules/redis)                           |             Redis             |
 | [rspamd](https://github.com/netdata/netdata/tree/master/src/go/collectors/go.d.plugin/modules/rspamd)                         |            Rspamd             |
+| [runit](https://github.com/netdata/netdata/tree/master/src/go/collectors/go.d.plugin/modules/runit)                           |             Runit             |
 | [scaleio](https://github.com/netdata/netdata/tree/master/src/go/collectors/go.d.plugin/modules/scaleio)                       |       Dell EMC ScaleIO        |
 | [sensors](https://github.com/netdata/netdata/tree/master/src/go/collectors/go.d.plugin/modules)                               |       Hardware Sensors        |
 | [SNMP](https://github.com/netdata/netdata/blob/master/src/go/collectors/go.d.plugin/modules/snmp)                             |             SNMP              |

--- a/src/go/collectors/go.d.plugin/config/go.d.conf
+++ b/src/go/collectors/go.d.plugin/config/go.d.conf
@@ -81,6 +81,7 @@ modules:
 #  rabbitmq: yes
 #  redis: yes
 #  rspamd: yes
+#  runit: yes
 #  scaleio: yes
 #  sensors: yes
 #  snmp: yes

--- a/src/go/collectors/go.d.plugin/config/go.d/runit.conf
+++ b/src/go/collectors/go.d.plugin/config/go.d/runit.conf
@@ -1,0 +1,9 @@
+## All available configuration options, their descriptions and default values:
+## https://github.com/netdata/netdata/tree/master/src/go/collectors/go.d.plugin/modules/runit#readme
+
+jobs:
+  - name: system
+    # Use default directory: $SVDIR or /service.
+
+# - name: user
+#   dir: /home/USER/service

--- a/src/go/collectors/go.d.plugin/modules/init.go
+++ b/src/go/collectors/go.d.plugin/modules/init.go
@@ -73,6 +73,7 @@ import (
 	_ "github.com/netdata/netdata/go/go.d.plugin/modules/rabbitmq"
 	_ "github.com/netdata/netdata/go/go.d.plugin/modules/redis"
 	_ "github.com/netdata/netdata/go/go.d.plugin/modules/rspamd"
+	_ "github.com/netdata/netdata/go/go.d.plugin/modules/runit"
 	_ "github.com/netdata/netdata/go/go.d.plugin/modules/scaleio"
 	_ "github.com/netdata/netdata/go/go.d.plugin/modules/sensors"
 	_ "github.com/netdata/netdata/go/go.d.plugin/modules/smartctl"

--- a/src/go/collectors/go.d.plugin/modules/runit/README.md
+++ b/src/go/collectors/go.d.plugin/modules/runit/README.md
@@ -1,0 +1,1 @@
+integrations/runit.md

--- a/src/go/collectors/go.d.plugin/modules/runit/charts.go
+++ b/src/go/collectors/go.d.plugin/modules/runit/charts.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !windows
+// +build !windows
+
+package runit
+
+import (
+	"fmt"
+
+	"github.com/netdata/netdata/go/go.d.plugin/agent/module"
+)
+
+type (
+	ChartID   string
+	DimIDElem string
+)
+
+const (
+	prioState = module.Priority + iota
+	prioStateDuration
+)
+
+const (
+	dimStateDown       DimIDElem = "down"
+	dimStateDownWantUp DimIDElem = "starting"
+	dimStateRun        DimIDElem = "up"
+	dimStateFinish     DimIDElem = "finishing"
+	dimStatePaused     DimIDElem = "paused"
+	dimStateEnabled    DimIDElem = "enabled"
+)
+
+func stateChartID(service string) ChartID {
+	return ChartID(fmt.Sprintf("service_%s_state", service))
+}
+
+func (s *Runit) newStateChart(service string) *module.Chart {
+	chart := &module.Chart{
+		ID:       string(stateChartID(service)),
+		Title:    "Service State",
+		Units:    "state",
+		Fam:      "state",
+		Ctx:      "runit.service_state",
+		Type:     module.Stacked,
+		Priority: prioState,
+		Labels: []module.Label{
+			{Key: "service", Value: service},
+		},
+	}
+	addDim(chart, dimStateDown)
+	addDim(chart, dimStateDownWantUp)
+	addDim(chart, dimStateRun)
+	addDim(chart, dimStateFinish)
+	addDim(chart, dimStatePaused)
+	addDim(chart, dimStateEnabled).Hidden = true
+	return chart
+}
+
+func stateDurationChartID(service string) ChartID {
+	return ChartID(fmt.Sprintf("service_%s_state_duration", service))
+}
+
+func (s *Runit) newStateDurationChart(service string) *module.Chart {
+	chart := &module.Chart{
+		ID:       string(stateDurationChartID(service)),
+		Title:    "Service State Duration",
+		Units:    "seconds",
+		Fam:      "uptime",
+		Ctx:      "runit.service_state_duration",
+		Type:     module.Line,
+		Priority: prioStateDuration,
+		Labels: []module.Label{
+			{Key: "service", Value: service},
+		},
+	}
+	addDim(chart, dimStateDown)
+	addDim(chart, dimStateRun)
+	return chart
+}
+
+func addDim(chart *module.Chart, dimIDElem DimIDElem) *module.Dim {
+	dim := &module.Dim{
+		ID:   dimID(ChartID(chart.ID), dimIDElem),
+		Name: string(dimIDElem),
+	}
+	chart.Dims = append(chart.Dims, dim)
+	return dim
+}
+
+func dimID(chartID ChartID, dim DimIDElem) string {
+	return fmt.Sprintf("%s:%s", chartID, dim)
+}
+
+func (s *Runit) addStateCharts(service string) {
+	s.addChart(s.newStateChart(service))
+	s.addChart(s.newStateDurationChart(service))
+}
+
+func (s *Runit) delStateCharts(service string) {
+	s.delChart(stateChartID(service))
+	s.delChart(stateDurationChartID(service))
+}
+
+func (s *Runit) addChart(chart *module.Chart) {
+	err := s.Charts().Add(chart)
+	if err != nil {
+		s.Warningf("addChart(%q): %v", chart.ID, err)
+	}
+}
+
+func (s *Runit) delChart(delID ChartID) {
+	found := 0
+	for _, chart := range *s.Charts() {
+		alreadyRemoved := chart.Obsolete // XXX For now only MarkRemove sets Obsolete.
+		if ChartID(chart.ID) == delID && !alreadyRemoved {
+			chart.MarkRemove()
+			chart.MarkNotCreated()
+			found++
+		}
+	}
+	if found != 1 {
+		s.Warningf("delChart(%q): removed %d charts instead of 1", delID, found)
+	}
+}

--- a/src/go/collectors/go.d.plugin/modules/runit/collect.go
+++ b/src/go/collectors/go.d.plugin/modules/runit/collect.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !windows
+// +build !windows
+
+package runit
+
+const hintDimensions = hintServices * (6 + 2) // There are 8 dimensions per service.
+
+func (s *Runit) collect() (map[string]int64, error) {
+	ms := make(map[string]int64, hintDimensions)
+
+	err := s.collectStates(ms)
+	if err != nil {
+		return nil, err
+	}
+
+	return ms, nil
+}
+
+func (s *Runit) collectStates(ms map[string]int64) error {
+	services, err := s.servicesCli()
+	if err != nil {
+		return err
+	}
+
+	seen := make(map[string]bool)
+
+	for service, status := range services {
+		seen[service] = true
+		if !s.seen[service] {
+			s.seen[service] = true
+			s.addStateCharts(service)
+		}
+
+		// Actual service state is one of these combinations:
+		// - "down"   + optional "normally up"   + optional "want up"
+		// - "run"    + optional "normally down" + optional "want down" + optional "paused" + optional "got TERM"
+		// - "finish" + optional "normally down" + optional "want down" + optional "paused"
+		// These flags/combinations are considered useless for dashboard/alerting needs:
+		// - "normally up"
+		// - "normally down"
+		// - "want down"
+		// - "got TERM"
+		// - any states added to "paused"
+		chartID := stateChartID(service)
+		ms[dimID(chartID, dimStateDown)] = 0
+		ms[dimID(chartID, dimStateDownWantUp)] = 0
+		ms[dimID(chartID, dimStateRun)] = 0
+		ms[dimID(chartID, dimStateFinish)] = 0
+		ms[dimID(chartID, dimStatePaused)] = 0
+		ms[dimID(chartID, dimStateEnabled)] = fromBool(status.Enabled)
+		switch {
+		case status.Paused:
+			ms[dimID(chartID, dimStatePaused)] = 1
+		case status.State == ServiceStateFinish:
+			ms[dimID(chartID, dimStateFinish)] = 1
+		case status.State == ServiceStateRun:
+			ms[dimID(chartID, dimStateRun)] = 1
+		case status.WantUp:
+			ms[dimID(chartID, dimStateDownWantUp)] = 1
+		default:
+			ms[dimID(chartID, dimStateDown)] = 1
+		}
+
+		// Duration is reported only per down/run/finish state.
+		// But finish duration includes previous run duration and thus useless.
+		chartID = stateDurationChartID(service)
+		ms[dimID(chartID, dimStateDown)] = 0
+		ms[dimID(chartID, dimStateRun)] = 0
+		switch {
+		case status.State == ServiceStateDown:
+			ms[dimID(chartID, dimStateDown)] = int64(status.StateDuration.Seconds())
+		case status.State == ServiceStateRun:
+			ms[dimID(chartID, dimStateRun)] = int64(status.StateDuration.Seconds())
+		case status.State == ServiceStateFinish:
+			// Ignore.
+		}
+	}
+
+	for service := range s.seen {
+		if !seen[service] {
+			delete(s.seen, service)
+			s.delStateCharts(service)
+		}
+	}
+
+	return nil
+}
+
+func fromBool(condition bool) int64 {
+	if condition {
+		return 1
+	}
+	return 0
+}

--- a/src/go/collectors/go.d.plugin/modules/runit/config_schema.json
+++ b/src/go/collectors/go.d.plugin/modules/runit/config_schema.json
@@ -1,0 +1,44 @@
+{
+  "jsonSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Runit collector configuration.",
+    "type": "object",
+    "properties": {
+      "update_every": {
+        "title": "Update every",
+        "description": "Data collection interval, measured in seconds.",
+        "type": "integer",
+        "minimum": 1,
+        "default": 1
+      },
+      "dir": {
+        "title": "Service dir",
+        "description": "Directory with runit services",
+        "type": "string",
+        "default": "/service"
+      }
+    },
+    "required": [
+    ],
+    "additionalProperties": false,
+    "patternProperties": {
+      "^name$": {}
+    }
+  },
+  "uiSchema": {
+    "uiOptions": {
+      "fullPage": true
+    },
+    "ui:flavour": "tabs",
+    "ui:options": {
+      "tabs": [
+        {
+          "title": "Base",
+          "fields": [
+            "update_every"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/go/collectors/go.d.plugin/modules/runit/doc.go
+++ b/src/go/collectors/go.d.plugin/modules/runit/doc.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !windows
+// +build !windows
+
+// Package runit is a runit service states collector.
+package runit

--- a/src/go/collectors/go.d.plugin/modules/runit/exec.go
+++ b/src/go/collectors/go.d.plugin/modules/runit/exec.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !windows
+// +build !windows
+
+package runit
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/netdata/netdata/go/go.d.plugin/logger"
+)
+
+func newSvCliExec(ndsudoPath string, timeout time.Duration, log *logger.Logger) *svCliExec {
+	return &svCliExec{
+		Logger:     log,
+		ndsudoPath: ndsudoPath,
+		timeout:    timeout,
+	}
+}
+
+type svCliExec struct {
+	*logger.Logger
+
+	ndsudoPath string
+	timeout    time.Duration
+}
+
+func (e *svCliExec) StatusAll(dir string) ([]byte, error) {
+	return e.execute("sv-status-all", "--serviceDir", dir)
+}
+
+// `sv` always output "warning: " at beginning of each line on stderr.
+var svStderrPrefix = []byte("warning: ")
+
+func (e *svCliExec) execute(args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, e.ndsudoPath, args...)
+	e.Debugf("executing '%s'", cmd)
+
+	bs, err := cmd.Output()
+	if err != nil {
+		// Exit codes:
+		// - None: means context deadline exceeded.
+		// - 1-6 are used by `ndsudo`: means permanent fatal error.
+		// - 0-99 are used by `sv`: means (partially) okay.
+		// - 100 is used by `sv`: means temporary fatal error.
+		// - 126, 127 is used by `sh`: means missing `sv` executable.
+		// - 129-255: means killed by a signal.
+		// - Other: means unknown error.
+		// Stderr output:
+		// - `ndsudo` never begins line with "warning: ".
+		// - `sv status` always begins line with "warning: ".
+		var errExit *exec.ExitError
+		if errors.As(err, &errExit) {
+			e.Warning(string(errExit.Stderr))
+		}
+		switch {
+		case errExit == nil: // Context deadline exceeded while running ndsudo or sh or sv.
+			e.Errorf("error on '%s': %v", cmd, err)
+		case errExit.ExitCode() > 128: // ndsudo or sh or sv was killed by a signal.
+			e.Errorf("killed on '%s': %v", cmd, err)
+		case len(errExit.Stderr) > 0 && !bytes.HasPrefix(errExit.Stderr, svStderrPrefix): // ndsudo error.
+			return nil, fmt.Errorf("ndsudo error on '%s': %w", cmd, err)
+		case errExit.ExitCode() == 126 || errExit.ExitCode() == 127: // sh error: command not found.
+			return nil, fmt.Errorf("shell error on '%s': %w", cmd, err)
+		case errExit.ExitCode() <= 100: // sv partial/temporary error.
+			// Ignore.
+		default: // Unknown error.
+			return nil, fmt.Errorf("unknown error on '%s': %w", cmd, err)
+		}
+	}
+
+	return bs, nil
+}

--- a/src/go/collectors/go.d.plugin/modules/runit/init.go
+++ b/src/go/collectors/go.d.plugin/modules/runit/init.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !windows
+// +build !windows
+
+package runit
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/netdata/netdata/go/go.d.plugin/agent/executable"
+)
+
+// DefaultDir returns default service directory in a way used by runit sv(8) tool.
+func defaultDir() string {
+	if dir := os.Getenv("SVDIR"); dir != "" {
+		return dir
+	}
+	return "/service"
+}
+
+func (s Runit) validateConfig() error {
+	if s.Dir == "" {
+		return errors.New("'path' option not set")
+	}
+	s.Dir = filepath.Clean(s.Dir)
+
+	switch fi, err := os.Stat(s.Dir); {
+	case err != nil:
+		return fmt.Errorf("'path' invalid: %w", err)
+	case !fi.IsDir():
+		return errors.New("'path' must be a directory")
+	}
+
+	return nil
+}
+
+func (s *Runit) initSvCli() error {
+	ndsudoPath := filepath.Join(executable.Directory, "ndsudo")
+	if _, err := os.Stat(ndsudoPath); err != nil {
+		return fmt.Errorf("ndsudo executable not found: %w", err)
+	}
+
+	s.exec = newSvCliExec(ndsudoPath, s.execTimeout, s.Logger)
+
+	return nil
+}

--- a/src/go/collectors/go.d.plugin/modules/runit/metadata.yaml
+++ b/src/go/collectors/go.d.plugin/modules/runit/metadata.yaml
@@ -1,0 +1,149 @@
+plugin_name: go.d.plugin
+modules:
+  - meta:
+      id: collector-go.d.plugin-runit
+      plugin_name: go.d.plugin
+      module_name: runit
+      monitored_instance:
+        name: Runit services
+        link: https://smarden.org/runit/
+        icon_filename: runit.png
+        categories:
+          - data-collection.processes-and-system-services
+      keywords:
+        - runit
+        - service
+      related_resources:
+        integrations:
+          list: []
+      info_provided_to_referring_integrations:
+        description: ""
+      most_popular: false
+    overview:
+      data_collection:
+        metrics_description: |
+          This collector monitors the state of Runit services.
+          It relies on the [`sv`](https://smarden.org/runit/sv.8) CLI tool but avoids directly executing the binary.
+          Instead, it utilizes `ndsudo`, a Netdata helper specifically designed to run privileged commands securely within the Netdata environment.
+          This approach eliminates the need to use `sudo`, improving security and potentially simplifying permission management.
+        method_description: ""
+      supported_platforms:
+        include: []
+        exclude: []
+      multi_instance: true
+      additional_permissions:
+        description: ""
+      default_behavior:
+        auto_detection:
+          description: |
+            By default, it detects services running in
+            $SVDIR or (if $SVDIR is empty) /service directory.
+        limits:
+          description: ""
+        performance_impact:
+          description: ""
+    setup:
+      prerequisites:
+        list:
+          - title: Install sv (included in runit package)
+            description: |
+              If you want this collector then you already have runit package installed.
+              But if you'll run Netdata in a Docker then you need to also install runit in Netdata container.
+      configuration:
+        file:
+          name: go.d/runit.conf
+        options:
+          description: |
+            The following options can be defined globally: update_every, autodetection_retry.
+          folding:
+            title: Config options
+            enabled: true
+          list:
+            - name: update_every
+              description: Data collection frequency.
+              default_value: 1
+              required: false
+            - name: autodetection_retry
+              description: Recheck interval in seconds. Zero means no recheck will be scheduled.
+              default_value: 60
+              required: false
+            - name: dir
+              description: Directory with runit services.
+              default_value: "/service"
+              required: false
+              detailed_description: |
+                If environment variable $SVDIR is set to non-empty value then it will be used
+                as default instead of /service.
+        examples:
+          folding:
+            title: Config
+            enabled: true
+          list:
+            - name: System services in non-default dir
+              description: Set custom directory for system services.
+              config: |
+                jobs:
+                  - name: system
+                    dir: /etc/service
+            - name: Some user also run services in addition to system ones
+              description: |
+                > **Note**: When you define multiple jobs, their names must be unique.
+
+                Add directory with user services.
+               config: |
+                jobs:
+                  - name: system
+
+                  - name: someone
+                    dir: /home/someone/service
+    troubleshooting:
+      problems:
+        list: []
+    alerts:
+      - name: runit_service_undesired_state
+        metric: runit.service_state
+        info: runit service is not in desired state
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/runit.conf
+      - name: runit_service_paused
+        metric: runit.service_state
+        info: runit service is paused
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/runit.conf
+      - name: runit_service_failed
+        metric: runit.service_state
+        info: runit service is failed
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/runit.conf
+      - name: runit_service_hangs_on_finish
+        metric: runit.service_state
+        info: runit service finishing takes too long
+        link: https://github.com/netdata/netdata/blob/master/src/health/health.d/runit.conf
+    metrics:
+      folding:
+        title: Metrics
+        enabled: false
+      description: ""
+      availability: []
+      scopes:
+        - name: service
+          description: These metrics refer to the runit service.
+          labels:
+            - name: service
+              description: runit service name
+          metrics:
+            - name: runit.service_state
+              description: Service State
+              unit: state
+              chart_type: stacked
+              dimensions:
+                - name: down
+                - name: starting
+                - name: up
+                - name: finishing
+                - name: paused
+                - name: enabled
+            - name: runit.service_state_duration
+              description: Service State Duration
+              unit: seconds
+              chart_type: line
+              dimensions:
+                - name: down
+                - name: up

--- a/src/go/collectors/go.d.plugin/modules/runit/runit.go
+++ b/src/go/collectors/go.d.plugin/modules/runit/runit.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !windows
+// +build !windows
+
+package runit
+
+import (
+	_ "embed"
+	"errors"
+	"time"
+
+	"github.com/netdata/netdata/go/go.d.plugin/agent/module"
+)
+
+//go:embed "config_schema.json"
+var configSchema string
+
+func init() {
+	module.Register("runit", module.Creator{
+		JobConfigSchema: configSchema,
+		Defaults: module.Defaults{
+			UpdateEvery:        module.UpdateEvery,
+			AutoDetectionRetry: 60,
+		},
+		Create: func() module.Module { return New() },
+		Config: func() any { return &Config{} },
+	})
+}
+
+func New() *Runit {
+	return &Runit{
+		Config: Config{
+			Dir: defaultDir(),
+		},
+		charts:      &module.Charts{},
+		execTimeout: time.Second,
+		seen:        make(map[string]bool),
+	}
+}
+
+type (
+	Config struct {
+		UpdateEvery int    `yaml:"update_every,omitempty" json:"update_every"`
+		Dir         string `yaml:"dir" json:"dir"`
+	}
+
+	Runit struct {
+		module.Base
+		Config `yaml:",inline" json:""`
+
+		charts *module.Charts
+
+		exec        svCli
+		execTimeout time.Duration
+
+		seen map[string]bool // Key: service name.
+	}
+
+	svCli interface {
+		StatusAll(dir string) ([]byte, error)
+	}
+)
+
+func (s *Runit) Configuration() any {
+	return s.Config
+}
+
+func (s *Runit) Init() error {
+	err := s.validateConfig()
+	if err != nil {
+		s.Errorf("config validation: %v", err)
+		return err
+	}
+
+	err = s.initSvCli()
+	if err != nil {
+		s.Errorf("sv exec initialization: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+func (s *Runit) Check() (err error) {
+	ms, err := s.collect()
+	if err != nil {
+		s.Error(err)
+		return err
+	}
+
+	if len(ms) == 0 {
+		return errors.New("no metrics collected")
+	}
+
+	return nil
+}
+
+func (s *Runit) Charts() *module.Charts {
+	return s.charts
+}
+
+func (s *Runit) Collect() map[string]int64 {
+	mx, err := s.collect()
+	if err != nil {
+		s.Error(err)
+	}
+
+	if len(mx) == 0 {
+		return nil
+	}
+	return mx
+}
+
+func (*Runit) Cleanup() {}

--- a/src/go/collectors/go.d.plugin/modules/runit/runit_test.go
+++ b/src/go/collectors/go.d.plugin/modules/runit/runit_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package runit
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/netdata/netdata/go/go.d.plugin/agent/executable"
+	"github.com/netdata/netdata/go/go.d.plugin/agent/module"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	dataConfigJSON, _ = os.ReadFile("testdata/config.json")
+	dataConfigYAML, _ = os.ReadFile("testdata/config.yaml")
+)
+
+func Test_testDataIsValid(t *testing.T) {
+	for name, data := range map[string][]byte{
+		"dataConfigJSON": dataConfigJSON,
+		"dataConfigYAML": dataConfigYAML,
+	} {
+		require.NotNil(t, data, name)
+	}
+}
+
+func TestRunit_ConfigurationSerialize(t *testing.T) {
+	module.TestConfigurationSerialize(t, &Runit{}, dataConfigJSON, dataConfigYAML)
+}
+
+func TestNew(t *testing.T) {
+	// We want to ensure that module is a reference type, nothing more.
+
+	assert.IsType(t, (*Runit)(nil), New())
+}
+
+func TestRunit_Init(t *testing.T) {
+	// 'Init() bool' initializes the module with an appropriate config, so to test it we need:
+	// - provide the config.
+	// - set module.Config field with the config.
+	// - call Init() and compare its return value with the expected value.
+
+	// 'test' map contains different test cases.
+	tests := map[string]struct {
+		wantFail bool
+		config   Config
+	}{
+		"success on default config": {
+			config: New().Config,
+		},
+		"fails if 'ndsudo' not found": {
+			wantFail: true, // Triggered because test name contains "ndsudo".
+			config:   New().Config,
+		},
+		"success when 'dir' is existing directory": {
+			config: Config{
+				Dir: "testdata",
+			},
+		},
+		"fails when 'dir' is empty": {
+			wantFail: true,
+			config: Config{
+				Dir: "",
+			},
+		},
+		"fails when 'dir' is not a directory": {
+			wantFail: true,
+			config: Config{
+				Dir: "runit_test.go",
+			},
+		},
+		"fails when 'dir' is not exist": {
+			wantFail: true,
+			config: Config{
+				Dir: "nosuch",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			runit := New()
+			runit.Config = test.config
+
+			executable.Directory = "testdata"
+			if strings.Contains(name, "ndsudo") {
+				executable.Directory = ""
+			}
+
+			if test.wantFail {
+				assert.Error(t, runit.Init())
+			} else {
+				assert.NoError(t, runit.Init())
+			}
+		})
+	}
+}

--- a/src/go/collectors/go.d.plugin/modules/runit/services.go
+++ b/src/go/collectors/go.d.plugin/modules/runit/services.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//go:build !windows
+// +build !windows
+
+package runit
+
+import (
+	"bytes"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const hintServices = 64 // Large enough amount of services for most service directories.
+
+type ServiceStatus struct {
+	StateDuration time.Duration
+	Paused        bool
+	WantUp        bool
+	State         ServiceState
+	Enabled       bool
+}
+
+type ServiceState uint8
+
+const (
+	ServiceStateDown   ServiceState = 0
+	ServiceStateRun    ServiceState = 1
+	ServiceStateFinish ServiceState = 2
+)
+
+// Constants.
+var (
+	tokenUp    = []byte("up")
+	tokenRun   = []byte("run")
+	tokenDown  = []byte("down")
+	pfxSvFail  = []byte("fail:")
+	pfxSvWarn  = []byte("warning:")
+	elemSvInfo = `(?:\(pid \d+\) )?` +
+		`(\d+)s` + // uptime/downtime
+		`(?:, normally (up|down))?` +
+		`(, paused)?` +
+		`(?:, want (up|down))?` +
+		`(, got TERM)?`
+	reSvStatus = regexp.MustCompile(`^` +
+		`(down|run|finish): ` +
+		`(.*?): ` + // service directory
+		elemSvInfo +
+		`(?:; warning:.*|; (down|run|finish): (log): ` + elemSvInfo + `)?` +
+		`\n$`)
+)
+
+const (
+	idxState = iota
+	idxName
+	idxDuration
+	idxNormally
+	idxPaused
+	idxWant
+	idxTERM
+	offsetLog
+)
+
+func (s *Runit) servicesCli() (map[string]*ServiceStatus, error) {
+	ms := make(map[string]*ServiceStatus, hintServices)
+
+	out, err := s.exec.StatusAll(s.Config.Dir)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := bytes.NewBuffer(out)
+	for {
+		line, err := buf.ReadBytes('\n')
+		match := reSvStatus.FindSubmatch(line)
+
+		switch {
+		case match != nil:
+			match = match[1:]
+			matchSv := match[:offsetLog]
+			matchLog := match[offsetLog:]
+			name := strings.TrimPrefix(string(matchSv[idxName]), s.Config.Dir+"/")
+			ms[name] = parseServiceStatus(matchSv)
+			if string(matchLog[idxName]) == "log" {
+				ms[name+"/log"] = parseServiceStatus(matchLog)
+			}
+		case bytes.HasPrefix(line, pfxSvFail):
+		case bytes.HasPrefix(line, pfxSvWarn):
+		case len(line) > 0:
+			s.Warningf("failed to parse sv status: %q", string(line))
+		}
+
+		if err != nil {
+			break
+		}
+	}
+
+	return ms, nil
+}
+
+func parseServiceStatus(match [][]byte) *ServiceStatus {
+	status := &ServiceStatus{
+		StateDuration: parseServiceDuration(match[idxDuration]),
+		Paused:        len(match[idxPaused]) != 0,
+		WantUp:        bytes.Equal(match[idxWant], tokenUp),
+		State:         parseServiceState(match[idxState]),
+	}
+	if status.State == ServiceStateDown {
+		status.Enabled = bytes.Equal(match[idxNormally], tokenUp)
+	} else {
+		status.Enabled = !bytes.Equal(match[idxNormally], tokenDown)
+	}
+	return status
+}
+
+func parseServiceState(state []byte) ServiceState {
+	switch {
+	case bytes.Equal(state, tokenDown):
+		return ServiceStateDown
+	case bytes.Equal(state, tokenRun):
+		return ServiceStateRun
+	default:
+		return ServiceStateFinish
+	}
+}
+
+func parseServiceDuration(seconds []byte) time.Duration {
+	sec, _ := strconv.Atoi(string(seconds))
+	return time.Duration(sec) * time.Second
+}

--- a/src/go/collectors/go.d.plugin/modules/runit/testdata/config.json
+++ b/src/go/collectors/go.d.plugin/modules/runit/testdata/config.json
@@ -1,0 +1,4 @@
+{
+  "update_every": 123,
+  "dir": "/etc/service"
+}

--- a/src/go/collectors/go.d.plugin/modules/runit/testdata/config.yaml
+++ b/src/go/collectors/go.d.plugin/modules/runit/testdata/config.yaml
@@ -1,0 +1,2 @@
+update_every: 123
+dir: "/etc/service"

--- a/src/health/health.d/runit.conf
+++ b/src/health/health.d/runit.conf
@@ -1,0 +1,59 @@
+# you can disable an alarm notification by setting the 'to' line to: silent
+
+    template: runit_service_undesired_state
+          on: runit.service_state
+       class: Errors
+        type: Linux
+   component: Runit
+       units: up
+       every: 30s
+        calc: 1 - $down
+        warn: $this != nan AND $this != $enabled
+       delay: up 5s down 1m multiplier 1.5 max 1h
+     summary: runit ${label:_collect_job} service ${label:service} state
+        info: runit service is not in desired state
+          to: sysadmin
+
+    template: runit_service_paused
+          on: runit.service_state
+       class: Errors
+        type: Linux
+   component: Runit
+       units: paused
+       every: 30s
+      lookup: max -30s unaligned of paused
+        warn: $this != nan AND $this == 1
+       delay: down 1m multiplier 1.5 max 1h
+     summary: runit ${label:_collect_job} service ${label:service} state
+        info: runit service is paused
+          to: sysadmin
+
+    template: runit_service_failed
+          on: runit.service_state
+       class: Errors
+        type: Linux
+   component: Runit
+       units: failed
+       every: 30s
+      lookup: max -30s unaligned of starting
+        crit: $this != nan AND $starting != nan AND $this == 1 AND $starting == 1
+       delay: down 1m multiplier 1.5 max 1h
+     summary: runit ${label:_collect_job} service ${label:service} state
+        info: runit service is failed
+          to: sysadmin
+
+    template: runit_service_hangs_on_finish
+          on: runit.service_state
+       class: Latency
+        type: Linux
+   component: Runit
+       units: seconds
+       every: 5s
+      lookup: sum -50s unaligned of finishing
+        calc: $this * $update_every
+        warn: $this != nan AND $this > 10
+        crit: $this != nan AND $this > 30
+       delay: down 1m multiplier 1.5 max 1h
+     summary: runit ${label:_collect_job} service ${label:service} state
+        info: runit service finishing takes too long
+          to: sysadmin


### PR DESCRIPTION
I'd like to add more tests before merging, but decided to open PR now to get some feedback first - if some significant changes will be required they might break tests, so it's nice to find out this earlier. Except for adding more tests no other changes are planned, so it's okay to review the whole PR now.

##### Summary

This PR adds go.d collector module for [runit](https://smarden.org/runit/) service supervision.
Runit can be used both to run system services and user's (or some app's) services (think: basic systemd).
So, it's important to monitor these services and alert if anything goes wrong.

##### Test Plan

- `golangci-lint` has passed.
- Basic unit tests has already added.
- I've tested everything manually (by adding/replacing affected files in Netdata docker image):
  - Default config.
  - User config with multiple jobs (and thus multiple directories with runit services).
  - Every possible state change for some service.
  - Adding/removing same service (to trigger CHART removal and re-adding).
  - Trigger all configured alerts.
- I'm planning to add more unit tests to cover as much as possible of listed above use cases.

Reviewer will need to install `runit` and setup a directory with a couple services to manually test this collector. I can help with this, if needed.

##### Additional Information

This collector includes `ndsudo` change, and I'd like to explain rationale for this change.

Runit services are controlled using few files in `supervise/` subdirectory in each service's directory.
Example (`/etc/service` here is a directory containing runit services - each in it's own subdirectory, `agetty-tty2` is one of such services):
```sh
# ls -al /etc/service/agetty-tty2/
total 20
drwxr-xr-x  3 root root 4096 Jun 19 20:38 .
drwxr-xr-x 97 root root 4096 Jun 13 21:18 ..
-rwxr-xr-x  1 root root   31 Jun 19 20:36 finish
-rwxr-xr-x  1 root root  104 Jun 19 20:38 run
drwx------  2 root root 4096 Jun 19 20:45 supervise
# ls -al /etc/service/agetty-tty2/supervise
total 20
drwx------ 2 root root 4096 Jun 19 20:45 .
drwxr-xr-x 3 root root 4096 Jun 19 20:38 ..
prw------- 1 root root    0 Jun 19 20:36 control
-rw------- 1 root root    0 Feb 14  2012 lock
prw------- 1 root root    0 Feb 14  2012 ok
-rw-r--r-- 1 root root    6 Jun 19 20:45 pid
-rw-r--r-- 1 root root    4 Jun 19 20:45 stat
-rw-r--r-- 1 root root   20 Jun 19 20:45 status
```
To collect information about runit services we need to access few files in `supervise/` dir.
The problem is that dir's permissions are always `0700` (`supervise/` is created by runit).
This is wise from security point of view (other users must not control my services), but became an issue for Netdata: go.d collectors are running as user `netdata` and thus won't be able to access these files.
Unlike systemd etc. runit does not provide any way to access service status by network or so - only way is to access these files.
So, any runit collector will require `ndsudo`.

Second issue is CLI of runit's `sv status` tool: it is not able to handle whole directory with services and require each service directory enumerated in it's arguments. So, to get information about all services performance wise (i.e. avoid running `sv` tool per each directory) we need to run it like this:
```
# sv status /etc/service/*
run: /etc/service/acpid: (pid 1277) 386751s; run: log: (pid 919) 386752s
run: /etc/service/agetty-tty1: (pid 902) 386752s
run: /etc/service/agetty-tty2: (pid 21441) 10592s
...
```
The `ndsudo` won't allow to run command with unknown number of arguments. And even if it does allow such use case, we still may have issues reading service (subdirectory) names in directory containing all services - permissions to that directory (and it's parent dirs) is controlled by user and it may be set in a way `netdata` user won't be able to read that dir.
So, someone has to do this pathname glob operation, either shell or some new tool developed to do just this.

At a glance I don't found a way to add extra Go binaries (to be compiled, installed, and available to `ndsudo`) in existing Netdata source tree, so I've tried to solve this task using existing tool: shell.

The command I've added to `ndsudo` may looks a bit cryptic (because I had to conform to `ndsudo` restrictions), but to my best knowledge it's safe and won't allow any unexpected use cases.

The command it runs is: `sh -p -c $*/* - exec sv status {{serviceDir}}`:
- `-p` force shell to not drop EUID=0 privileges
- `-` became sh's `$0` and not used (I suppose `ndsudo` controls `argv[0]` of executed commands so using `-` here won't make shell a login shell, but TBH I didn't tested this because in a docker this doesn't makes any difference… maybe it's safer to change `-` to `sh`)
- Command `$*/*` expands to `exec sv status {{serviceDir}}/*`
- Only other expansion done by shell after expanding `$*` is pathname expansion. This means only special symbols inside `{{serviceDir}}` will be `*`, `?` and `[…]`. I suppose these are not allowed in `ndsudo` variables anyway, but even if they were allowed this is still safe and can't result in executing any other command as root or redirecting output to random files etc.