### PR TITLE
go.d replace colon in job name

### DIFF
--- a/src/go/collectors/go.d.plugin/agent/confgroup/config.go
+++ b/src/go/collectors/go.d.plugin/agent/confgroup/config.go
@@ -125,7 +125,7 @@ func (c Config) ApplyDefaults(def Default) {
 	}
 }
 
-var reInvalidCharacters = regexp.MustCompile(`\s+|\.+`)
+var reInvalidCharacters = regexp.MustCompile(`\s+|\.+|:+`)
 
 func cleanName(name string) string {
 	return reInvalidCharacters.ReplaceAllString(name, "_")


### PR DESCRIPTION
##### Summary

Because it breaks dyncfg (dyncfg id is a ":" separated path). 

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
