### PR TITLE
docs: add "For Netdata running in a Docker container" to go.d/smartcl

### DIFF
--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -372,6 +372,8 @@ to Caddyfile.
 
 ### With Docker socket proxy
 
+> **Note**: Using Netdata with a Docker socket proxy might have some features not working as expected. It hasn't been fully tested by the Netdata team.
+
 Deploy a Docker socket proxy that accepts and filters out requests using something like
 [HAProxy](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-haproxy.md) or
 [CetusGuard](https://github.com/hectorm/cetusguard) so that it restricts connections to read-only access to

--- a/src/go/collectors/go.d.plugin/modules/smartctl/metadata.yaml
+++ b/src/go/collectors/go.d.plugin/modules/smartctl/metadata.yaml
@@ -52,6 +52,30 @@ modules:
           - title: Install smartmontools (v7.0+)
             description: |
               Install `smartmontools` version 7.0 or later using your distribution's package manager. Version 7.0 introduced the `--json` output mode, which is required for this collector to function properly.
+          - title: For Netdata running in a Docker container
+            description: |
+              Netdata requires the `SYS_RAWIO` capability and access to the storage devices to run the `smartctl` collector inside a Docker container. Here's how you can achieve this:
+
+              - `docker run`
+                ```bash
+                docker run --cap-add SYS_RAWIO --device /dev/sda:/dev/sda ...
+                ```
+
+              - `docker-compose.yml`
+                ```yaml
+                services:
+                  netdata:
+                    cap_add:
+                      - SYS_PTRACE
+                      - SYS_ADMIN
+                      - SYS_RAWIO # smartctl
+                    devices:
+                      - "/dev/sda:/dev/sda"
+                ```
+              
+              > **Multiple Devices**: These examples only show mapping of one device (/dev/sda). You'll need to add additional `--device` options (in docker run) or entries in the `devices` list (in docker-compose.yml) for each storage device you want Netdata's smartctl collector to monitor.
+              
+              > **NVMe Devices**: Do not map NVMe devices using this method. Netdata uses a [dedicated collector](https://github.com/netdata/netdata/tree/master/src/go/collectors/go.d.plugin/modules/nvme#readme) to monitor NVMe devices.
       configuration:
         file:
           name: go.d/smartctl.conf

--- a/src/go/collectors/go.d.plugin/modules/smartctl/metadata.yaml
+++ b/src/go/collectors/go.d.plugin/modules/smartctl/metadata.yaml
@@ -57,11 +57,13 @@ modules:
               Netdata requires the `SYS_RAWIO` capability and access to the storage devices to run the `smartctl` collector inside a Docker container. Here's how you can achieve this:
 
               - `docker run`
+
                 ```bash
                 docker run --cap-add SYS_RAWIO --device /dev/sda:/dev/sda ...
                 ```
 
               - `docker-compose.yml`
+
                 ```yaml
                 services:
                   netdata:
@@ -72,9 +74,9 @@ modules:
                     devices:
                       - "/dev/sda:/dev/sda"
                 ```
-              
+
               > **Multiple Devices**: These examples only show mapping of one device (/dev/sda). You'll need to add additional `--device` options (in docker run) or entries in the `devices` list (in docker-compose.yml) for each storage device you want Netdata's smartctl collector to monitor.
-              
+
               > **NVMe Devices**: Do not map NVMe devices using this method. Netdata uses a [dedicated collector](https://github.com/netdata/netdata/tree/master/src/go/collectors/go.d.plugin/modules/nvme#readme) to monitor NVMe devices.
       configuration:
         file:


### PR DESCRIPTION
##### Summary

Fixes: #17977

1. Add an additional step to go.d/smartctl setup for Netdata running in a Docker container.
2. Add a note that the "With Docker socket proxy" setup hasn't been tested by the Netdata team.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
