### PR TITLE
health convert value to days in calc in whoisquery/x509check alarms

### DIFF
--- a/src/health/health.d/whoisquery.conf
+++ b/src/health/health.d/whoisquery.conf
@@ -4,11 +4,11 @@
     class: Utilization
      type: Other
 component: WHOIS
-     calc: $expiry
-    units: seconds
+     calc: $expiry / 86400
+    units: days
     every: 60s
-     warn: $this < $days_until_expiration_warning*24*60*60
-     crit: $this < $days_until_expiration_critical*24*60*60
+     warn: $this < $days_until_expiration_warning
+     crit: $this < $days_until_expiration_critical
   summary: Whois expiration time for domain ${label:domain}
      info: Time until the domain name registration for ${label:domain} expires
        to: webmaster

--- a/src/health/health.d/x509check.conf
+++ b/src/health/health.d/x509check.conf
@@ -4,11 +4,11 @@
     class: Latency
      type: Certificates
 component: x509 certificates
-     calc: $expiry
-    units: seconds
+     calc: $expiry / 86400
+    units: days
     every: 60s
-     warn: $this < $days_until_expiration_warning*24*60*60
-     crit: $this < $days_until_expiration_critical*24*60*60
+     warn: $this < $days_until_expiration_warning
+     crit: $this < $days_until_expiration_critical
   summary: x509 certificate expiration for ${label:source}
      info: Time until x509 certificate expires for ${label:source}
        to: webmaster


### PR DESCRIPTION
##### Summary

From https://github.com/netdata/netdata/discussions/17994

> I get for example expiration in 7468788 which is not very helpful, so i need to convert it into days

This PR addresses this issue. The value in days will improve the user experience.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
