### PR TITLE
Remove double quotes from the sysctl.conf snippet

### DIFF
--- a/src/go/collectors/go.d.plugin/modules/ping/metadata.yaml
+++ b/src/go/collectors/go.d.plugin/modules/ping/metadata.yaml
@@ -39,7 +39,7 @@ modules:
             ```bash
             sudo sysctl -w net.ipv4.ping_group_range="0 2147483647"
             ```
-            To persist the change add `net.ipv4.ping_group_range="0 2147483647"` to `/etc/sysctl.conf` and
+            To persist the change add `net.ipv4.ping_group_range=0 2147483647` to `/etc/sysctl.conf` and
             execute `sudo sysctl -p`.
         method_description: ""
       supported_platforms:


### PR DESCRIPTION
With double quotes, when I run "sysctl -p", I get: 

    sysctl: setting key "net.ipv4.ping_group_range": Invalid argument

Without double quotes it works.

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
