### PR TITLE
fix grep warning in kickstart

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1371,7 +1371,7 @@ set_auto_updates() {
     if [ "${DRY_RUN}" -eq 1 ]; then
       progress "Would have attempted to enable automatic updates."
     # This first case is for catching using a new kickstart script with an old build. It can be safely removed after v1.34.0 is released.
-    elif ! run_as_root grep -q '\-\-enable-auto-updates' "${updater}"; then
+    elif ! run_as_root grep -q '\--enable-auto-updates' "${updater}"; then
       echo
     elif ! run_as_root "${updater}" --enable-auto-updates "${NETDATA_AUTO_UPDATE_TYPE}"; then
       warning "Failed to enable auto updates. Netdata will still work, but you will need to update manually."


### PR DESCRIPTION
##### Summary

Fixes

> grep: warning: stray \ before -

I get it on Fedora40.

```bash
$ sudo grep '\-\-enable-auto-updates' /usr/libexec/netdata/netdata-updater.sh
grep: warning: stray \ before -
    --enable-auto-updates)

$ sudo grep '\--enable-auto-updates' /usr/libexec/netdata/netdata-updater.sh
    --enable-auto-updates)
```

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
