### PR TITLE
alert prototype: set default "after" to -600

### DIFF
--- a/src/health/schema.d/health%3Aalert%3Aprototype.json
+++ b/src/health/schema.d/health%3Aalert%3Aprototype.json
@@ -122,7 +122,7 @@
               },
               "after": {
                 "type": "integer",
-                "default": 0,
+                "default": -600,
                 "title": "From",
                 "description": "Relative to 'To'"
               },


### PR DESCRIPTION
##### Summary

When creating an Alert you can:

1. use only `lookup`
2. use only `calc`
3. or both

The only way to remove the `lookup` line is to set "From" (after) to 0 (which is not intuitive). By default we set it to 0, so the user can choose 1, 2 or 3. But this is no less confusing, so we change it back.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
