### PR TITLE
fix installing netdata-updater svc/timer for native packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2582,21 +2582,6 @@ install(FILES
         COMPONENT netdata
         DESTINATION usr/lib/netdata/system/systemd)
 
-if(BUILD_FOR_PACKAGING)
-        install(FILES
-                ${CMAKE_BINARY_DIR}/system/systemd/netdata.service
-                COMPONENT netdata
-                DESTINATION lib/systemd/system)
-        install(DIRECTORY
-                COMPONENT netdata
-                DESTINATION usr/lib/systemd/journald@netdata.conf.d)
-        install(FILES
-                system/systemd/journald@netdata.conf
-                COMPONENT netdata
-                DESTINATION usr/lib/systemd/journald@netdata.conf.d
-                RENAME netdata.conf)
-endif()
-
 configure_file(system/systemd/netdata.service.v235.in system/systemd/netdata.service.v235 @ONLY)
 install(FILES
         ${CMAKE_BINARY_DIR}/system/systemd/netdata.service.v235
@@ -2613,6 +2598,29 @@ install(FILES
         system/systemd/netdata-updater.timer
         COMPONENT netdata
         DESTINATION usr/lib/netdata/system/systemd)
+
+if(BUILD_FOR_PACKAGING)
+        install(FILES
+                ${CMAKE_BINARY_DIR}/system/systemd/netdata.service
+                COMPONENT netdata
+                DESTINATION lib/systemd/system)
+        install(FILES
+                ${CMAKE_BINARY_DIR}/system/systemd/netdata-updater.service
+                COMPONENT netdata
+                DESTINATION lib/systemd/system)
+        install(FILES
+                system/systemd/netdata-updater.timer
+                COMPONENT netdata
+                DESTINATION lib/systemd/system)
+        install(DIRECTORY
+                COMPONENT netdata
+                DESTINATION usr/lib/systemd/journald@netdata.conf.d)
+        install(FILES
+                system/systemd/journald@netdata.conf
+                COMPONENT netdata
+                DESTINATION usr/lib/systemd/journald@netdata.conf.d
+                RENAME netdata.conf)
+endif()
 
 install(FILES
         system/systemd/50-netdata.preset

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -447,8 +447,12 @@ install -m 644 -p "%{__cmake_builddir}/system/systemd/%{name}.service" "${RPM_BU
 %else
 install -m 644 -p "%{__cmake_builddir}/system/systemd/%{name}.service.v235" "${RPM_BUILD_ROOT}%{_unitdir}/%{name}.service"
 %endif
+install -m 644 -p "system/systemd/netdata-updater.timer" "${RPM_BUILD_ROOT}%{_unitdir}/%{name}-updater.timer"
+install -m 644 -p "%{__cmake_builddir}/system/systemd/%{name}-updater.service" "${RPM_BUILD_ROOT}%{_unitdir}/%{name}-updater.service"
 install -m 755 -d "${RPM_BUILD_ROOT}%{_presetdir}"
 install -m 644 -p "system/systemd/50-%{name}.preset" "${RPM_BUILD_ROOT}%{_presetdir}/50-%{name}.preset"
+install -m 755 -d "${RPM_BUILD_ROOT}%{_systemd_util_dir}/journal@%{name}.conf.d"
+install -m 644 -p "system/systemd/journal@%{name}.conf" "${RPM_BUILD_ROOT}%{_systemd_util_dir}/journal@%{name}.conf.d/%{name}.conf"
 
 %pre
 
@@ -510,7 +514,10 @@ rm -rf "${RPM_BUILD_ROOT}"
 %{_sbindir}/%{name}-claim.sh
 
 %{_unitdir}/%{name}.service
+%{_unitdir}/%{name}-updater.timer
+%{_unitdir}/%{name}-updater.service
 %{_presetdir}/50-%{name}.preset
+%{_systemd_util_dir}/journal@%{name}.conf.d/%{name}.conf
 
 %dir %{_libexecdir}/%{name}
 %dir %{_libexecdir}/%{name}/plugins.d

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -54,6 +54,8 @@ AutoReqProv: yes
 %define _libexecdir /usr/libexec
 %define _libdir /usr/lib
 
+%{!?_systemd_util_dir:%global _systemd_util_dir /usr/lib/systemd}
+
 # Fedora doesn’t define this, but other distros do
 %{!?_presetdir:%global _presetdir %{_libdir}/systemd/system-preset}
 

--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -451,8 +451,8 @@ install -m 644 -p "system/systemd/netdata-updater.timer" "${RPM_BUILD_ROOT}%{_un
 install -m 644 -p "%{__cmake_builddir}/system/systemd/%{name}-updater.service" "${RPM_BUILD_ROOT}%{_unitdir}/%{name}-updater.service"
 install -m 755 -d "${RPM_BUILD_ROOT}%{_presetdir}"
 install -m 644 -p "system/systemd/50-%{name}.preset" "${RPM_BUILD_ROOT}%{_presetdir}/50-%{name}.preset"
-install -m 755 -d "${RPM_BUILD_ROOT}%{_systemd_util_dir}/journal@%{name}.conf.d"
-install -m 644 -p "system/systemd/journal@%{name}.conf" "${RPM_BUILD_ROOT}%{_systemd_util_dir}/journal@%{name}.conf.d/%{name}.conf"
+install -m 755 -d "${RPM_BUILD_ROOT}%{_systemd_util_dir}/journald@%{name}.conf.d"
+install -m 644 -p "system/systemd/journald@%{name}.conf" "${RPM_BUILD_ROOT}%{_systemd_util_dir}/journald@%{name}.conf.d/%{name}.conf"
 
 %pre
 
@@ -517,7 +517,7 @@ rm -rf "${RPM_BUILD_ROOT}"
 %{_unitdir}/%{name}-updater.timer
 %{_unitdir}/%{name}-updater.service
 %{_presetdir}/50-%{name}.preset
-%{_systemd_util_dir}/journal@%{name}.conf.d/%{name}.conf
+%{_systemd_util_dir}/journald@%{name}.conf.d/%{name}.conf
 
 %dir %{_libexecdir}/%{name}
 %dir %{_libexecdir}/%{name}/plugins.d


### PR DESCRIPTION
##### Summary

- [X] deb
- [x] rpm

##### Test Plan

Build and install the package, check `ls -l /lib/systemd/system | grep -Eo "netdata-updater.(service|timer)"`

- [X] deb
- [ ] rpm

I didn't build and install the rpm packages, but I did check the ci packages/build of Centos7 and Fedora40. Everything seems to be fine.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
