### PR TITLE
Semaphore (common context)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1299,6 +1299,7 @@ set(WINDOWS_PLUGIN_FILES
         src/collectors/windows.plugin/perflib-dump.c
         src/collectors/windows.plugin/perflib-storage.c
         src/collectors/windows.plugin/perflib-processor.c
+        src/collectors/windows.plugin/perflib-objects.c
         src/collectors/windows.plugin/perflib-network.c
         src/collectors/windows.plugin/perflib-memory.c
         src/collectors/windows.plugin/perflib-processes.c

--- a/src/collectors/common-contexts/common-contexts.h
+++ b/src/collectors/common-contexts/common-contexts.h
@@ -22,6 +22,7 @@ typedef void (*instance_labels_cb_t)(RRDSET *st, void *data);
 #include "system.ram.h"
 #include "system.interrupts.h"
 #include "system.processes.h"
+#include "system.ipc.h"
 #include "mem.swap.h"
 #include "mem.pgfaults.h"
 #include "mem.available.h"

--- a/src/collectors/common-contexts/system.ipc.h
+++ b/src/collectors/common-contexts/system.ipc.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_SYSTEM_IPC_H
+#define NETDATA_SYSTEM_IPC_H
+
+#include "common-contexts.h"
+
+static inline void common_ipc(uint64_t semathore, NETDATA_DOUBLE red, char *module, int update_every) {
+    static RRDSET *st_semaphores = NULL;
+    static RRDDIM *rd_semaphores = NULL;
+    if(unlikely(!st_semaphores)) {
+        st_semaphores = rrdset_create_localhost("system"
+                                                , "ipc_semaphores"
+                                                , NULL
+                                                , "ipc semaphores"
+                                                , NULL
+                                                , "IPC Semaphores"
+                                                , "semaphores"
+                                                , _COMMON_PLUGIN_NAME
+                                                , module
+                                                , NETDATA_CHART_PRIO_SYSTEM_IPC_SEMAPHORES
+                                                , update_every
+                                                , RRDSET_TYPE_AREA
+                                                );
+        rd_semaphores = rrddim_add(st_semaphores, "semaphores", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+    }
+
+    rrddim_set_by_pointer(st_semaphores, rd_semaphores, semathore);
+    rrdset_done(st_semaphores);
+    if (!strcmp(module, "ipc"))
+        st_semaphores->red = red;
+}
+
+#endif //NETDATA_SYSTEM_IPC_H

--- a/src/collectors/common-contexts/system.ipc.h
+++ b/src/collectors/common-contexts/system.ipc.h
@@ -5,7 +5,7 @@
 
 #include "common-contexts.h"
 
-static inline void common_ipc(uint64_t semathore, NETDATA_DOUBLE red, char *module, int update_every) {
+static inline void common_semaphore_ipc(uint64_t semaphore, NETDATA_DOUBLE red, char *module, int update_every) {
     static RRDSET *st_semaphores = NULL;
     static RRDDIM *rd_semaphores = NULL;
     if(unlikely(!st_semaphores)) {
@@ -25,7 +25,7 @@ static inline void common_ipc(uint64_t semathore, NETDATA_DOUBLE red, char *modu
         rd_semaphores = rrddim_add(st_semaphores, "semaphores", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
     }
 
-    rrddim_set_by_pointer(st_semaphores, rd_semaphores, semathore);
+    rrddim_set_by_pointer(st_semaphores, rd_semaphores, semaphore);
     rrdset_done(st_semaphores);
     if (!strcmp(module, "ipc"))
         st_semaphores->red = red;

--- a/src/collectors/freebsd.plugin/freebsd_sysctl.c
+++ b/src/collectors/freebsd.plugin/freebsd_sysctl.c
@@ -1142,30 +1142,10 @@ int do_kern_ipc_sem(int update_every, usec_t dt) {
                 }
             }
 
-            static RRDSET *st_semaphores = NULL, *st_semaphore_arrays = NULL;
-            static RRDDIM *rd_semaphores = NULL, *rd_semaphore_arrays = NULL;
+            static RRDSET *st_semaphore_arrays = NULL;
+            static RRDDIM *rd_semaphore_arrays = NULL;
 
-            if (unlikely(!st_semaphores)) {
-                st_semaphores = rrdset_create_localhost(
-                        "system",
-                        "ipc_semaphores",
-                        NULL,
-                        "ipc semaphores",
-                        NULL,
-                        "IPC Semaphores",
-                        "semaphores",
-                        "freebsd.plugin",
-                        "kern.ipc.sem",
-                        NETDATA_CHART_PRIO_SYSTEM_IPC_SEMAPHORES,
-                        update_every,
-                        RRDSET_TYPE_AREA
-                );
-
-                rd_semaphores = rrddim_add(st_semaphores, "semaphores", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-            }
-
-            rrddim_set_by_pointer(st_semaphores, rd_semaphores, ipc_sem.semaphores);
-            rrdset_done(st_semaphores);
+            common_semaphore_ipc(ipc_sem.semaphores, 0.0, "kern.ipc.sem", update_every);
 
             if (unlikely(!st_semaphore_arrays)) {
                 st_semaphore_arrays = rrdset_create_localhost(

--- a/src/collectors/windows.plugin/perflib-objects.c
+++ b/src/collectors/windows.plugin/perflib-objects.c
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "windows_plugin.h"
+#include "windows-internals.h"
+
+#define _COMMON_PLUGIN_NAME "windows.plugin"
+#define _COMMON_PLUGIN_MODULE_NAME "PerflibObjects"
+#include "../common-contexts/common-contexts.h"
+
+static void initialize(void) {
+    ;
+}
+
+static bool do_objects(PERF_DATA_BLOCK *pDataBlock, int update_every) {
+    PERF_OBJECT_TYPE *pObjectType = perflibFindObjectTypeByName(pDataBlock, "Objects");
+    if (!pObjectType)
+        return false;
+
+    static COUNTER_DATA semaphores = { .key = "Semaphores" };
+
+    if(perflibGetObjectCounter(pDataBlock, pObjectType, &semaphores)) {
+        ULONGLONG sem = semaphores.current.Data;
+        common_semaphore_ipc(sem, WINDOWS_MAX_KERNEL_OBJECT, _COMMON_PLUGIN_MODULE_NAME, update_every);
+    }
+
+    return true;
+}
+
+int do_PerflibObjects(int update_every, usec_t dt __maybe_unused) {
+    static bool initialized = false;
+
+    if(unlikely(!initialized)) {
+        initialize();
+        initialized = true;
+    }
+
+    DWORD id = RegistryFindIDByName("Objects");
+    if(id == PERFLIB_REGISTRY_NAME_NOT_FOUND)
+        return -1;
+
+    PERF_DATA_BLOCK *pDataBlock = perflibGetPerformanceData(id);
+    if(!pDataBlock) return -1;
+
+    do_objects(pDataBlock, update_every);
+
+    return 0;
+}

--- a/src/collectors/windows.plugin/windows_plugin.c
+++ b/src/collectors/windows.plugin/windows_plugin.c
@@ -24,6 +24,7 @@ static struct proc_module {
     {.name = "PerflibMemory",       .dim = "PerflibMemory",           .func = do_PerflibMemory},
     {.name = "PerflibStorage",      .dim = "PerflibStorage",          .func = do_PerflibStorage},
     {.name = "PerflibNetwork",      .dim = "PerflibNetwork",          .func = do_PerflibNetwork},
+    {.name = "PerflibObjects",      .dim = "PerflibObjects",          .func = do_PerflibObjects},
 
     // the terminator of this array
     {.name = NULL, .dim = NULL, .func = NULL}

--- a/src/collectors/windows.plugin/windows_plugin.h
+++ b/src/collectors/windows.plugin/windows_plugin.h
@@ -7,6 +7,10 @@
 
 #define PLUGIN_WINDOWS_NAME "windows.plugin"
 
+// https://learn.microsoft.com/es-es/windows/win32/sysinfo/kernel-objects?redirectedfrom=MSDN
+// 2^24
+#define WINDOWS_MAX_KERNEL_OBJECT 16777216
+
 void *win_plugin_main(void *ptr);
 
 extern char windows_shared_buffer[8192];
@@ -19,6 +23,7 @@ int do_PerflibNetwork(int update_every, usec_t dt);
 int do_PerflibProcesses(int update_every, usec_t dt);
 int do_PerflibProcessor(int update_every, usec_t dt);
 int do_PerflibMemory(int update_every, usec_t dt);
+int do_PerflibObjects(int update_every, usec_t dt);
 
 #include "perflib.h"
 


### PR DESCRIPTION
##### Summary
This PR is adding one more metric to windows dashboard. It also creates the basis to bring more metrics from `Objects` object.

![sem](https://github.com/netdata/netdata/assets/49162938/8a234b64-5a38-4473-8220-167acf959caa)



##### Test Plan

Ideally this PR should be tested on FreeBSD, Windows and Linux.

1. Compile this branch
2. Take a look on dashboard and verify if metric is present.

##### Additional Information
This PR was tested on:

| Operate System | Version/Distribution | 
|-------------------------|-------------------------------|
|Linux                      | Slackware current | 
|FreeBSD                 |  14 | 
| Windows               | 11 Home|
|Linux                       | Arch |


<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
