### PR TITLE
ndsudo add 'chronyc serverstats'

### DIFF
--- a/src/collectors/plugins.d/ndsudo.c
+++ b/src/collectors/plugins.d/ndsudo.c
@@ -14,6 +14,14 @@ struct command {
     const char *search[MAX_SEARCH];
 } allowed_commands[] = {
     {
+        .name = "chronyc-serverstats",
+        .params = "serverstats",
+        .search = {
+            [0] = "chronyc",
+            [1] = NULL,
+        },
+    },
+    {
         .name = "dmsetup-status-cache",
         .params = "status --target cache --noflush",
         .search = {


### PR DESCRIPTION
##### Summary

- Currently, `chronyc serverstats` is restricted to connections via the Unix domain socket.
- To add this functionality to netdata, it would require adding the user to the "_chrony" group. However, attempts to establish a Unix socket connection weren't successful (I tried [chrony_exporter](https://github.com/SuperQ/chrony_exporter) - same problem, no response from chronyd). Additional chronyd configuration might be needed.


Solution: We'll grant netdata user access to chronyd serverstats through the `ndsudo` tool. Thus, it will work out of the box without any additional configuration.

Related PR #18055.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
