### PR TITLE
freeipmi: add "no-restart" (workaround #17931)

### DIFF
--- a/src/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/src/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -1652,6 +1652,10 @@ int main (int argc, char **argv) {
 
     bool debug = false;
 
+    // TODO: Workaround for https://github.com/netdata/netdata/issues/17931
+    // This variable will be removed once the issue is fixed.
+    bool restart_every = true;
+
     // ------------------------------------------------------------------------
     // parse command line parameters
 
@@ -1670,6 +1674,10 @@ int main (int argc, char **argv) {
         }
         else if(strcmp("debug", argv[i]) == 0) {
             debug = true;
+            continue;
+        }
+        else if(strcmp("no-restart", argv[i]) == 0) {
+            restart_every = false;
             continue;
         }
         else if(strcmp("sel", argv[i]) == 0) {
@@ -2100,7 +2108,7 @@ int main (int argc, char **argv) {
                 "END\n");
 
         // restart check (14400 seconds)
-        if (now_monotonic_sec() - started_t > IPMI_RESTART_EVERY_SECONDS) {
+        if (restart_every && (now_monotonic_sec() - started_t > IPMI_RESTART_EVERY_SECONDS)) {
             collector_info("%s(): reached my lifetime expectancy. Exiting to restart.", __FUNCTION__);
             fprintf(stdout, "EXIT\n");
             plugin_exit(0);


### PR DESCRIPTION
##### Summary

This PR adds "no-restart" command line option:

- It disables periodic plugin restarts.
- Added as a workaround for #17931 and will be removed once the issue is fixed.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
