### PR TITLE
fix prometeus export: missing comma before "instance" label

### DIFF
--- a/src/exporting/prometheus/prometheus.c
+++ b/src/exporting/prometheus/prometheus.c
@@ -403,7 +403,7 @@ static int print_host_variables_callback(const DICTIONARY_ITEM *item __maybe_unu
             opts->prefix,
             opts->name,
             label_pre,
-            opts->labels,
+            (opts->labels[0] == ',') ? &opts->labels[1] : opts->labels,
             label_post,
             value,
             opts->now * 1000ULL);
@@ -414,7 +414,7 @@ static int print_host_variables_callback(const DICTIONARY_ITEM *item __maybe_unu
             opts->prefix,
             opts->name,
             label_pre,
-            opts->labels,
+            (opts->labels[0] == ',') ? &opts->labels[1] : opts->labels,
             label_post,
             value);
 
@@ -875,7 +875,7 @@ static void rrd_stats_api_v1_charts_allmetrics_prometheus(
         .host = host,
         .wb = wb,
         .plabels_buffer = plabels_buffer,
-        .labels = (labels[0] == ',') ? &labels[1] : labels,
+        .labels = labels, // FIX: very misleading name and poor implementation of adding the "instance" label
         .exporting_options = exporting_options,
         .output_options = output_options,
         .prefix = prefix,


### PR DESCRIPTION
##### Summary

Fixes: #18059

The bug was added in #17191

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
