### PR TITLE
Remove hard-coded url from python.d puppet chart plugin

### DIFF
--- a/src/collectors/python.d.plugin/puppet/puppet.chart.py
+++ b/src/collectors/python.d.plugin/puppet/puppet.chart.py
@@ -75,7 +75,7 @@ class Service(UrlService):
         UrlService.__init__(self, configuration=configuration, name=name)
         self.order = ORDER
         self.definitions = CHARTS
-        self.url = 'https://{0}:8140'.format(socket.getfqdn())
+        self.url = self.configuration.get('url', 'https://{0}:8140'.format(socket.getfqdn()))
 
     def _get_data(self):
         # NOTE: there are several ways to retrieve data


### PR DESCRIPTION
##### Summary
Simple fix that removes the hard-coded chart `url` setting/pinning from the python.d puppet plugin.

While this is not a _direct_ problem when monitoring the puppetserver in its default configuration as it usually runs bound to the FQDN address and on port 8140 this has at least two issues:

a) It prevents you from monitoring puppetserver on non-standard ports
b) It does not work with monitoring puppetdb as this one by default runs on port 8081 [*]

Without this fix any given config `url` chart parameter is overwritten by the url's fqdn, pinning the request to port 8140 without any way to disable this behaviour.

[*] See accompanying [example config](https://github.com/Hufschmidt/netdata/blob/master/src/collectors/python.d.plugin/puppet/puppet.conf) for this fact.

##### Test Plan

Running puppetserver and puppetdb, ideally on different hosts.

Tested modification(s) on our puppet testing infra, but feasably one should be able to reproduce and test this using docker:
- Puppetserver: https://hub.docker.com/r/voxpupuli/container-puppetserver
- PuppetDB: https://hub.docker.com/r/voxpupuli/container-puppetdb
- Example Composer File: https://github.com/voxpupuli/crafty/blob/main/puppet/oss/compose.yaml

##### Additional Information

Without this fix any `url` given, eg. such as:

```
# netdata/python.d/puppet.conf

puppetdb:
  url: https://puppetdb.example.de:8081
  tls_ca_file: "/etc/puppetlabs/puppet/ssl/certs/ca.pem"
  tls_cert_file: "/etc/puppetlabs/puppet/ssl/certs/puppetdb.example.de.pem"
  tls_key_file: "/etc/puppetlabs/puppet/ssl/private_keys/puppetdb.example.de.pem"

puppet:
  url: https://puppetserver.example.de:8140
  tls_ca_file: "/etc/puppetlabs/puppet/ssl/certs/ca.pem"
  tls_cert_file: "/etc/puppetlabs/puppet/ssl/certs/puppetserver.example.de.pem"
  tls_key_file: "/etc/puppetlabs/puppet/ssl/private_keys/puppetserver.example.de.pem"
```

Will try and query for both jobs: `https://<local-fqdn>:8140/status/v1/services?level=debug` 

Instead of using the following requests:
- `https://puppetdb.example.de:8081/status/v1/services?level=debug` 
- `https://puppetserver.example.de:8140/status/v1/services?level=debug`

This change only affects the puppet python.d plugin.
