### PR TITLE
Remove Ubuntu 23.10 from supported platforms.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -311,11 +311,6 @@ include:
     test:
       ebpf-core: true
   - <<: *ubuntu
-    version: "23.10"
-    packages:
-      <<: *ubuntu_packages
-      repo_distro: ubuntu/mantic
-  - <<: *ubuntu
     version: "22.04"
     packages:
       <<: *ubuntu_packages
@@ -347,6 +342,11 @@ legacy: # Info for platforms we used to support and still need to handle package
     packages:
       <<: *cs_packages
       repo_distro: el/c8s
+  - <<: *ubuntu
+    version: "23.10"
+    packages:
+      <<: *ubuntu_packages
+      repo_distro: ubuntu/mantic
 no_include: # Info for platforms not covered in CI
   - distro: docker
     version: "19.03 or newer"

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -78,7 +78,6 @@ to work on these platforms with minimal user effort.
 | Red Hat Enterprise Linux | 8.x            | x86\_64, AArch64                       |                                                                                                                                                    |
 | Red Hat Enterprise Linux | 7.x            | x86\_64                                |                                                                                                                                                    |
 | Ubuntu                   | 24.04          | x86\_64, AArch64, ARMv7                |                                                                                                                                                    |
-| Ubuntu                   | 23.10          | x86\_64, AArch64, ARMv7                |                                                                                                                                                    |
 | Ubuntu                   | 22.04          | x86\_64, ARMv7, AArch64                |                                                                                                                                                    |
 | Ubuntu                   | 20.04          | x86\_64, ARMv7, AArch64                |                                                                                                                                                    |
 
@@ -162,9 +161,9 @@ This is a list of platforms that we have supported in the recent past but no lon
 | Fedora       | 37        | EOL as of 2023-12-05 |
 | openSUSE     | Leap 15.4 | EOL as of 2023-12-07 |
 | openSUSE     | Leap 15.3 | EOL as of 2022-12-01 |
+| Ubuntu       | 23.10     | EOL as of 2024-07-01 |
 | Ubuntu       | 23.04     | EOL as of 2024-01-20 |
 | Ubuntu       | 22.10     | EOL as of 2023-07-20 |
-| Ubuntu       | 21.10     | EOL as of 2022-07-31 |
 | Ubuntu       | 18.04     | EOL as of 2023-04-02 |
 
 ## Static builds


### PR DESCRIPTION
##### Summary

It went EOL upstream on 2024-07-01.

##### Test Plan

n/a