### PR TITLE
Remove Debian 10 from supported platforms.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -169,15 +169,6 @@ include:
       repo_distro: debian/bullseye
     test:
       ebpf-core: false
-  - <<: *debian
-    version: "10"
-    base_image: debian:buster
-    bundle_sentry: *default_sentry
-    packages:
-      <<: *debian_packages
-      repo_distro: debian/buster
-    test:
-      ebpf-core: false
 
   - &fedora
     distro: fedora
@@ -326,6 +317,11 @@ include:
       <<: *ubuntu_packages
       repo_distro: ubuntu/focal
 legacy: # Info for platforms we used to support and still need to handle packages for
+  - <<: *debian
+    version: "10"
+    packages:
+      <<: *debian_packages
+      repo_distro: debian/buster
   - <<: *fedora
     version: "37"
     packages:

--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -67,7 +67,6 @@ to work on these platforms with minimal user effort.
 | Docker                   | 19.03 or newer | x86\_64, i386, ARMv7, AArch64, POWER8+ | See our [Docker documentation](/packaging/docker/README.md) for more info on using Netdata on Docker |
 | Debian                   | 12.x           | x86\_64, i386, ARMv7, AArch64          |                                                                                                                                                    |
 | Debian                   | 11.x           | x86\_64, i386, ARMv7, AArch64          |                                                                                                                                                    |
-| Debian                   | 10.x           | x86\_64, i386, ARMv7, AArch64          |                                                                                                                                                    |
 | Fedora                   | 40             | x86\_64, AArch64                       |                                                                                                                                                    |
 | Fedora                   | 39             | x86\_64, AArch64                       |                                                                                                                                                    |
 | openSUSE                 | Leap 15.5      | x86\_64, AArch64                       |                                                                                                                                                    |
@@ -157,7 +156,7 @@ This is a list of platforms that we have supported in the recent past but no lon
 | Alpine Linux | 3.16      | EOL as of 2024-05-23 |
 | Alpine Linux | 3.15      | EOL as of 2023-11-01 |
 | Alpine Linux | 3.14      | EOL as of 2023-05-01 |
-| Debian       | 9.x       | EOL as of 2022-06-30 |
+| Debian       | 10.x      | EOL as of 2024-07-01 |
 | Fedora       | 38        | EOL as of 2024-05-14 |
 | Fedora       | 37        | EOL as of 2023-12-05 |
 | openSUSE     | Leap 15.4 | EOL as of 2023-12-07 |


### PR DESCRIPTION
##### Summary

It went EOL upstream on 2024-06-30.

##### Test Plan

n/a