### PR TITLE
Track LTS for Debian EOL status.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -143,6 +143,7 @@ include:
     notes: ''
     base_image: debian:bookworm
     eol_check: true
+    eol_lts: true
     bundle_sentry:
       <<: *default_sentry
       amd64: true

--- a/.github/scripts/gen-matrix-eol-check.py
+++ b/.github/scripts/gen-matrix-eol-check.py
@@ -21,7 +21,8 @@ for item in data['include']:
         entries.append({
             'distro': distro,
             'release': item['version'],
-            'full_name': f'{ item["distro"] } { item["version"] }'
+            'full_name': f'{ item["distro"] } { item["version"] }',
+            'lts': 1 if 'eol_lts' in item and item['eol_lts'] else 0,
         })
 
 entries.sort(key=lambda k: (k['distro'], k['release']))

--- a/.github/scripts/platform-impending-eol.py
+++ b/.github/scripts/platform-impending-eol.py
@@ -16,6 +16,7 @@ LEAD_DAYS = datetime.timedelta(days=30)
 
 DISTRO = sys.argv[1]
 RELEASE = sys.argv[2]
+LTS = sys.argv[3]
 
 EXIT_NOT_IMPENDING = 0
 EXIT_IMPENDING = 1
@@ -49,10 +50,19 @@ except urllib.error.HTTPError as e:
 
 eol = datetime.date.fromisoformat(data['eol'])
 
+if LTS == '1' and 'extendedSupport' in data:
+    datetime.date.fromisoformat(data['extendedSupport'])
+else:
+    LTS = False
+
 offset = abs(eol - NOW)
 
 if offset <= LEAD_DAYS:
-    print(data['eol'])
+    if LTS:
+        print(data['extendedSupport'])
+    else:
+        print(data['eol'])
+
     sys.exit(EXIT_IMPENDING)
 else:
     sys.exit(EXIT_NOT_IMPENDING)

--- a/.github/workflows/platform-eol-check.yml
+++ b/.github/workflows/platform-eol-check.yml
@@ -73,7 +73,7 @@ jobs:
         id: check
         shell: sh {0}
         run: |
-          d="$(.github/scripts/platform-impending-eol.py ${{ matrix.distro }} ${{ matrix.release }})"
+          d="$(.github/scripts/platform-impending-eol.py ${{ matrix.distro }} ${{ matrix.release }}) ${{ matrix.lts }}"
           case $? in
             0) echo "pending=false" >> "${GITHUB_OUTPUT}" ;;
             1)


### PR DESCRIPTION
##### Summary

Unlike most other platforms we support, it’s trivial for us to support Debian’s LTS distros, and we’ve effectively been doing that for quite some time now, so just make it official in the CI jobs.

##### Test Plan

n/a