### PR TITLE
Switch to legacy images for CentOS 7 CI.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -99,6 +99,7 @@ include:
 
   - distro: centos
     version: "7"
+    base_image: "netdata/legacy:centos7"
     support_type: Core
     notes: ''
     eol_check: false


### PR DESCRIPTION
##### Summary

This is required to ensure correct CI for existing releases where we support this platform.

##### Test Plan

CI jobs for CentOS 7 pass on this PR.

##### Additional Information

@netdata/agent Once merged this needs to be included in the v1.46.2 patch release, but can be skipped in the release notes.