### PR TITLE
Remove coredump

### DIFF
--- a/src/collectors/ebpf.plugin/ebpf.h
+++ b/src/collectors/ebpf.plugin/ebpf.h
@@ -390,4 +390,9 @@ extern netdata_ebpf_judy_pid_t ebpf_judy_pid;
 
 #define EBPF_MAX_SYNCHRONIZATION_TIME 300
 
+// On Kernel 6.9.8 we observe an anomalous PID inside hash table. We are adding this avoiding issues
+static inline bool ebpf_is_wrong_pid_jump(uint32_t pid, uint32_t limit){
+    return (pid >= limit) ? true : false;
+}
+
 #endif /* NETDATA_COLLECTOR_EBPF_H */

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -1118,6 +1118,9 @@ void collect_data_for_all_processes(int tbl_pid_stats_fd, int maps_per_core)
 
         uint32_t key = 0, next_key = 0;
         while (bpf_map_get_next_key(tbl_pid_stats_fd, &key, &next_key) == 0) {
+            if (ebpf_is_wrong_pid_jump(key, pid_max))
+                goto end_process_loop;
+
             ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(key, 0);
             if (!local_pid)
                 goto end_process_loop;

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -722,6 +722,9 @@ static void ebpf_read_cachestat_apps_table(int maps_per_core, int max_period)
             goto end_cachestat_loop;
         }
 
+        if (ebpf_is_wrong_pid_jump(key, pid_max))
+            goto end_cachestat_loop;
+
         cachestat_apps_accumulator(cv, maps_per_core);
 
         ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(key, cv->tgid);

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -549,6 +549,9 @@ static void ebpf_read_dc_apps_table(int maps_per_core, int max_period)
             goto end_dc_loop;
         }
 
+        if (ebpf_is_wrong_pid_jump(key, pid_max))
+            goto end_dc_loop;
+
         ebpf_dcstat_apps_accumulator(cv, maps_per_core);
 
         ebpf_pid_stat_t *pid_stat = ebpf_get_pid_entry(key, cv->tgid);

--- a/src/collectors/ebpf.plugin/ebpf_fd.c
+++ b/src/collectors/ebpf.plugin/ebpf_fd.c
@@ -686,6 +686,9 @@ static void ebpf_read_fd_apps_table(int maps_per_core, int max_period)
             goto end_fd_loop;
         }
 
+        if (ebpf_is_wrong_pid_jump(key, pid_max))
+            goto end_fd_loop;
+
         fd_apps_accumulator(fv, maps_per_core);
 
         ebpf_pid_stat_t *pid_stat = ebpf_get_pid_entry(key, fv->tgid);

--- a/src/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/src/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -375,6 +375,9 @@ static uint32_t oomkill_read_data(int32_t *keys)
     while (bpf_map_get_next_key(mapfd, &curr_key, &key) == 0) {
         curr_key = key;
 
+        if (ebpf_is_wrong_pid_jump(key, pid_max))
+            continue;
+
         keys[i] = (int32_t)key;
         i += 1;
 

--- a/src/collectors/ebpf.plugin/ebpf_shm.c
+++ b/src/collectors/ebpf.plugin/ebpf_shm.c
@@ -573,6 +573,9 @@ static void ebpf_read_shm_apps_table(int maps_per_core, int max_period)
             goto end_shm_loop;
         }
 
+        if (ebpf_is_wrong_pid_jump(key, pid_max))
+            goto end_shm_loop;
+
         shm_apps_accumulator(cv, maps_per_core);
 
         ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(key, 0);

--- a/src/collectors/ebpf.plugin/ebpf_socket.c
+++ b/src/collectors/ebpf.plugin/ebpf_socket.c
@@ -1718,6 +1718,9 @@ static void ebpf_update_array_vectors(ebpf_module_t *em)
             goto end_socket_loop;
         }
 
+        if (ebpf_is_wrong_pid_jump(key.pid, pid_max))
+            goto end_socket_loop;
+
         if (key.pid > (uint32_t)pid_max) {
             goto end_socket_loop;
         }

--- a/src/collectors/ebpf.plugin/ebpf_swap.c
+++ b/src/collectors/ebpf.plugin/ebpf_swap.c
@@ -547,6 +547,9 @@ static void ebpf_read_swap_apps_table(int maps_per_core, int max_period)
             goto end_swap_loop;
         }
 
+        if (ebpf_is_wrong_pid_jump(key, pid_max))
+            goto end_swap_loop;
+
         swap_apps_accumulator(cv, maps_per_core);
 
         ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(key, cv->tgid);

--- a/src/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/src/collectors/ebpf.plugin/ebpf_vfs.c
@@ -1226,6 +1226,9 @@ static void ebpf_vfs_read_apps(int maps_per_core, int max_period)
             goto end_vfs_loop;
         }
 
+        if (ebpf_is_wrong_pid_jump(key, pid_max))
+            goto end_vfs_loop;
+
         vfs_apps_accumulator(vv, maps_per_core);
 
         ebpf_pid_stat_t *local_pid = ebpf_get_pid_entry(key, vv->tgid);


### PR DESCRIPTION
##### Summary
After to compile from scratch the kernel `6.9.8`, I observed that my hash table was having PIDs with the maximum integer value possible. This value was bigger than value present inside my `/proc/sys/kernel/pid_max` and this result in a coredump:

```sh
(gdb) bt
#0  ebpf_get_pid_entry (pid=-437918235, tgid=0) at /home/thiago/Netdata/netdata/src/collectors/ebpf.plugin/ebpf_apps.c:465
#1  0x000000000043279d in collect_data_for_all_processes (tbl_pid_stats_fd=7, maps_per_core=maps_per_core@entry=1)
    at /home/thiago/Netdata/netdata/src/collectors/ebpf.plugin/ebpf_apps.c:1121
#2  0x0000000000408e81 in main (argc=<optimized out>, argv=<optimized out>)
    at /home/thiago/Netdata/netdata/src/collectors/ebpf.plugin/ebpf.c:4062
```

This PR is modifying internal code avoiding coredumps on systems.

##### Test Plan
I am not sure if this is happening because I had an issue when kernel was generated, but if this is happening on other OS, it will be necessary to test this PR on kernel `6.9.8` or newer, because this behavior was not observed in previous versions.

1. Compile branch
2. Verify eBPF.plugin is running with default options.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
