### PR TITLE
ndsudo set uid/gid/egid to 0 before executing command

### DIFF
--- a/src/collectors/plugins.d/ndsudo.c
+++ b/src/collectors/plugins.d/ndsudo.c
@@ -422,6 +422,8 @@ int main(int argc, char *argv[]) {
     }
     else {
         setuid(0);
+        setgid(0);
+        setegid(0);
 
         char *clean_env[] = {NULL};
         execve(filename, params, clean_env);

--- a/src/collectors/plugins.d/ndsudo.c
+++ b/src/collectors/plugins.d/ndsudo.c
@@ -421,6 +421,8 @@ int main(int argc, char *argv[]) {
         exit(0);
     }
     else {
+        setuid(0);
+
         char *clean_env[] = {NULL};
         execve(filename, params, clean_env);
         perror("execve"); // execve only returns on error


### PR DESCRIPTION
##### Summary

#18089 reports that running `megacli` via `ndsudo` does not produce results due to insufficient permissions.

The effective user ID is 0 when executing but the real is not. Some programs check for both uid/euid ([example](https://github.com/lvmteam/lvm2/blob/f8aa073a8d1028173441771c687b458752b453dc/tools/lvmcmdline.c#L3540C6-L3541)). I assume that is the case for `megacli` (not open-source, can't check).

Fixes: #18089

Thanks to @ClaraCrazy for testing the fix.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
