### PR TITLE
Stop a bit more quickly on a failure when using Ninja.

### DIFF
--- a/netdata-installer.sh
+++ b/netdata-installer.sh
@@ -511,7 +511,7 @@ fi
 
 CMAKE_OPTS="${ninja:+-G Ninja}"
 BUILD_OPTS="VERBOSE=1"
-[ -n "${ninja}" ] && BUILD_OPTS="-v"
+[ -n "${ninja}" ] && BUILD_OPTS="-k 1"
 
 if [ ${DONOTWAIT} -eq 0 ]; then
   if [ -n "${NETDATA_PREFIX}" ]; then

--- a/packaging/build-package.sh
+++ b/packaging/build-package.sh
@@ -18,7 +18,7 @@ SCRIPT_SOURCE="$(
 )"
 SOURCE_DIR="$(dirname "$(dirname "${SCRIPT_SOURCE}")")"
 
-CMAKE_ARGS="-S ${SOURCE_DIR} -B ${BUILD_DIR} -G Ninja"
+CMAKE_ARGS="-S ${SOURCE_DIR} -B ${BUILD_DIR}"
 
 add_cmake_option() {
     CMAKE_ARGS="${CMAKE_ARGS} -D${1}=${2}"
@@ -89,8 +89,8 @@ else
 fi
 
 # shellcheck disable=SC2086
-cmake ${CMAKE_ARGS}
-cmake --build "${BUILD_DIR}" --parallel "$(nproc)"
+cmake ${CMAKE_ARGS} -G Ninja
+cmake --build "${BUILD_DIR}" --parallel "$(nproc)" -- -k 1
 
 if [ "${ENABLE_SENTRY}" = "true" ] && [ "${UPLOAD_SENTRY}" = "true" ]; then
     sentry-cli debug-files upload -o netdata-inc -p netdata-agent --force-foreground --log-level=debug --wait --include-sources build/netdata


### PR DESCRIPTION
##### Summary

Ninja has a tendency to continue on after a failed build command in some cases, making it difficult to see where a build error actually happened.

This PR does two things to mitigate this issue:

- It disables verbose mode for Ninja by default. This makes the output significantly more terse, especially for interactive runs attached to a terminal (where Ninja will _rewrite_ the line indicating the job that just finished instead of appending it to the terminal like is done in verbose mode). This, in turn, should make it much easier to find the error messages. When the actual command is needed, it can be looked up relatively easily in the Ninja build file itself (by simply searching for the file name of the file that had the error).
- It tells Ninja to not create any new jobs after the first failure happens. For some reason this is not the default on some systems, which makes it much harder on those systems to actually find errors.

##### Test Plan

There’s not much that can be done to test this other than confirming that CI passes on it.

##### Additional Information

Ninja currently does not have a ‘fail-fast’ mode that we can enable, but there is a PR for that apparently: https://github.com/ninja-build/ninja/pull/2308.