### PR TITLE
Bump CMake supported versions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-cmake_minimum_required(VERSION 3.13.0...3.28)
+cmake_minimum_required(VERSION 3.16.0...3.30)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/packaging/cmake/Modules")
 

--- a/packaging/cmake/Modules/NetdataFetchContentExtra.cmake
+++ b/packaging/cmake/Modules/NetdataFetchContentExtra.cmake
@@ -18,11 +18,15 @@
 macro(FetchContent_MakeAvailable_NoInstall name)
     include(FetchContent)
 
-    FetchContent_GetProperties(${name})
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+        FetchContent_MakeAvailable(${name})
+    else()
+        FetchContent_GetProperties(${name})
 
-    if(NOT ${name}_POPULATED)
-        FetchContent_Populate(${name})
-        add_subdirectory(${${name}_SOURCE_DIR} ${${name}_BINARY_DIR} EXCLUDE_FROM_ALL)
+        if(NOT ${name}_POPULATED)
+            FetchContent_Populate(${name})
+            add_subdirectory(${${name}_SOURCE_DIR} ${${name}_BINARY_DIR} EXCLUDE_FROM_ALL)
+        endif()
     endif()
 endmacro()
 

--- a/packaging/cmake/Modules/NetdataJSONC.cmake
+++ b/packaging/cmake/Modules/NetdataJSONC.cmake
@@ -37,11 +37,23 @@ function(netdata_bundle_jsonc)
         set(BUILD_STATIC_LIBS ON)
         set(BUILD_APPS OFF)
 
-        FetchContent_Declare(json-c
-                GIT_REPOSITORY https://github.com/json-c/json-c
-                GIT_TAG b4c371fa0cbc4dcbaccc359ce9e957a22988fb34 # json-c-0.17-20230812
-                CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
-        )
+        set(repo https://github.com/json-c/json-c)
+        set(tag b4c371fa0cbc4dcbaccc359ce9e957a22988fb34) # json-c-0.17-20230812
+
+        if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+                FetchContent_Declare(json-c
+                        GIT_REPOSITORY ${repo}
+                        GIT_TAG ${tag}
+                        CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
+                        EXCLUDE_FROM_ALL
+                )
+        else()
+                FetchContent_Declare(json-c
+                        GIT_REPOSITORY ${repo}
+                        GIT_TAG ${tag}
+                        CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
+                )
+        endif()
 
         FetchContent_MakeAvailable_NoInstall(json-c)
 

--- a/packaging/cmake/Modules/NetdataProtobuf.cmake
+++ b/packaging/cmake/Modules/NetdataProtobuf.cmake
@@ -29,13 +29,23 @@ function(netdata_bundle_protobuf)
                 set(ABSL_PROPAGATE_CXX_STD On)
                 set(ABSL_ENABLE_INSTALL Off)
                 set(BUILD_SHARED_LIBS Off)
+                set(absl_repo https://github.com/abseil/abseil-cpp)
 
                 message(STATUS "Preparing bundled Abseil (required by bundled Protobuf)")
-                FetchContent_Declare(absl
-                        GIT_REPOSITORY https://github.com/abseil/abseil-cpp
-                        GIT_TAG ${ABSL_TAG}
-                        CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
-                )
+                if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+                        FetchContent_Declare(absl
+                                GIT_REPOSITORY ${absl_repo}
+                                GIT_TAG ${ABSL_TAG}
+                                CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
+                                EXCLUDE_FROM_ALL
+                        )
+                else()
+                        FetchContent_Declare(absl
+                                GIT_REPOSITORY ${absl_repo}
+                                GIT_TAG ${ABSL_TAG}
+                                CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
+                        )
+                endif()
                 FetchContent_MakeAvailable_NoInstall(absl)
                 message(STATUS "Finished preparing bundled Abseil")
         endif()
@@ -44,13 +54,23 @@ function(netdata_bundle_protobuf)
         set(protobuf_BUILD_LIBPROTOC Off)
         set(protobuf_BUILD_TESTS Off)
         set(protobuf_BUILD_SHARED_LIBS Off)
+        set(protobuf_repo https://github.com/protocolbuffers/protobuf)
 
         message(STATUS "Preparing bundled Protobuf")
-        FetchContent_Declare(protobuf
-                GIT_REPOSITORY https://github.com/protocolbuffers/protobuf.git
-                GIT_TAG ${PROTOBUF_TAG}
-                CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
-        )
+        if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+                FetchContent_Declare(protobuf
+                        GIT_REPOSITORY ${protobuf_repo}
+                        GIT_TAG ${PROTOBUF_TAG}
+                        CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
+                        EXCLUDE_FROM_ALL
+                )
+        else()
+                FetchContent_Declare(protobuf
+                        GIT_REPOSITORY ${protobuf_repo}
+                        GIT_TAG ${PROTOBUF_TAG}
+                        CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
+                )
+        endif()
         FetchContent_MakeAvailable_NoInstall(protobuf)
         message(STATUS "Finished preparing bundled Protobuf.")
 

--- a/packaging/cmake/Modules/NetdataYAML.cmake
+++ b/packaging/cmake/Modules/NetdataYAML.cmake
@@ -19,12 +19,23 @@ function(netdata_bundle_libyaml)
         endif()
 
         set(FETCHCONTENT_FULLY_DISCONNECTED Off)
+        set(repo https://github.com/yaml/libyaml)
+        set(tag 2c891fc7a770e8ba2fec34fc6b545c672beb37e6) # v0.2.5
 
-        FetchContent_Declare(yaml
-                GIT_REPOSITORY https://github.com/yaml/libyaml
-                GIT_TAG 2c891fc7a770e8ba2fec34fc6b545c672beb37e6 # v0.2.5
-                CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
-        )
+        if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+                FetchContent_Declare(yaml
+                        GIT_REPOSITORY ${repo}
+                        GIT_TAG ${tag}
+                        CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
+                        EXCLUDE_FROM_ALL
+                )
+        else()
+                FetchContent_Declare(yaml
+                        GIT_REPOSITORY ${repo}
+                        GIT_TAG ${tag}
+                        CMAKE_ARGS ${NETDATA_CMAKE_PROPAGATE_TOOLCHAIN_ARGS}
+                )
+        endif()
 
         FetchContent_MakeAvailable_NoInstall(yaml)
 endfunction()


### PR DESCRIPTION
##### Summary

- Fix warnings for [CMP0169](https://cmake.org/cmake/help/latest/policy/CMP0169.html) (required for proper support for CMake 3.30).
- Bump CMake supported versions to 3.16-3.30. We no longer support platforms that ship anything older than 3.16, and we need support for 3.30 for a clean build in some environments.

##### Test Plan

CI passes on this PR.