### PR TITLE
add authorization to spawn requests

### DIFF
--- a/src/collectors/network-viewer.plugin/network-viewer.c
+++ b/src/collectors/network-viewer.plugin/network-viewer.c
@@ -940,7 +940,7 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
 
     uc = system_usernames_cache_init();
 
-    spawn_srv = spawn_server_create("setns", local_sockets_spawn_server_callback, argc, (const char **)argv);
+    spawn_srv = spawn_server_create(SPAWN_SERVER_OPTION_CALLBACK, "setns", local_sockets_spawn_server_callback, argc, (const char **)argv);
     if(spawn_srv == NULL) {
         fprintf(stderr, "Cannot create spawn server.\n");
         exit(1);

--- a/src/collectors/plugins.d/local_listeners.c
+++ b/src/collectors/plugins.d/local_listeners.c
@@ -291,7 +291,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    SPAWN_SERVER *spawn_server = spawn_server_create(NULL, local_sockets_spawn_server_callback, argc, (const char **)argv);
+    SPAWN_SERVER *spawn_server = spawn_server_create(SPAWN_SERVER_OPTION_CALLBACK, NULL, local_sockets_spawn_server_callback, argc, (const char **)argv);
     if(spawn_server == NULL) {
         fprintf(stderr, "Cannot create spawn server.\n");
         exit(1);

--- a/src/libnetdata/libnetdata.c
+++ b/src/libnetdata/libnetdata.c
@@ -493,7 +493,7 @@ char *strndupz(const char *s, size_t len) {
 
 // If ptr is NULL, no operation is performed.
 void freez(void *ptr) {
-    free(ptr);
+    if(likely(ptr)) free(ptr);
 }
 
 void *mallocz(size_t size) {

--- a/src/libnetdata/maps/local-sockets.h
+++ b/src/libnetdata/maps/local-sockets.h
@@ -1016,7 +1016,7 @@ static inline void local_sockets_init(LS_STATE *ls) {
 #endif
 
     if(ls->config.namespaces && ls->spawn_server == NULL) {
-        ls->spawn_server = spawn_server_create(NULL, local_sockets_spawn_server_callback, 0, NULL);
+        ls->spawn_server = spawn_server_create(SPAWN_SERVER_OPTION_CALLBACK, NULL, local_sockets_spawn_server_callback, 0, NULL);
         ls->spawn_server_is_mine = true;
     }
     else

--- a/src/libnetdata/spawn_server/spawn_popen.c
+++ b/src/libnetdata/spawn_server/spawn_popen.c
@@ -9,7 +9,7 @@ bool netdata_main_spawn_server_init(const char *name, int argc, const char **arg
         static SPINLOCK spinlock = NETDATA_SPINLOCK_INITIALIZER;
         spinlock_lock(&spinlock);
         if(netdata_main_spawn_server == NULL)
-            netdata_main_spawn_server = spawn_server_create(name, NULL, argc, argv);
+            netdata_main_spawn_server = spawn_server_create(SPAWN_SERVER_OPTION_EXEC, name, NULL, argc, argv);
         spinlock_unlock(&spinlock);
     }
 

--- a/src/libnetdata/spawn_server/spawn_server.h
+++ b/src/libnetdata/spawn_server/spawn_server.h
@@ -5,12 +5,19 @@
 
 #define SPAWN_SERVER_TRANSFER_FDS 4
 
-typedef enum {
+typedef enum __attribute__((packed)) {
     SPAWN_INSTANCE_TYPE_EXEC = 0,
 #if !defined(OS_WINDOWS)
     SPAWN_INSTANCE_TYPE_CALLBACK = 1
 #endif
 } SPAWN_INSTANCE_TYPE;
+
+typedef enum __attribute__((packed)) {
+    SPAWN_SERVER_OPTION_EXEC = (1 << 0),
+#if !defined(OS_WINDOWS)
+    SPAWN_SERVER_OPTION_CALLBACK = (1 << 1),
+#endif
+} SPAWN_SERVER_OPTIONS;
 
 // this is only used publicly for SPAWN_INSTANCE_TYPE_CALLBACK
 // which is not available in Windows
@@ -32,7 +39,7 @@ typedef void (*spawn_request_callback_t)(SPAWN_REQUEST *request);
 typedef struct spawm_instance SPAWN_INSTANCE;
 typedef struct spawn_server SPAWN_SERVER;
 
-SPAWN_SERVER* spawn_server_create(const char *name, spawn_request_callback_t child_callback, int argc, const char **argv);
+SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name, spawn_request_callback_t child_callback, int argc, const char **argv);
 void spawn_server_destroy(SPAWN_SERVER *server);
 
 SPAWN_INSTANCE* spawn_server_exec(SPAWN_SERVER *server, int stderr_fd, int custom_fd, const char **argv, const void *data, size_t data_size, SPAWN_INSTANCE_TYPE type);


### PR DESCRIPTION
The spawn server creates a socket file in the filesystem.

To protect from unauthorized access, there is now a token that only the valid clients and the spawn server know. Failure to put the right token in the request, leads to denied requests.

Each spawn server can now be configured to accept callback or exec requests, or both. Sending the wrong type of request will lead to denied requests.

A socket was leaked at the spawn server, in case of errors. Fixed it.
