### PR TITLE
Update metadata.yaml

### DIFF
--- a/src/go/plugin/go.d/modules/postgres/metadata.yaml
+++ b/src/go/plugin/go.d/modules/postgres/metadata.yaml
@@ -67,6 +67,12 @@ modules:
               CREATE USER netdata;
               GRANT pg_monitor TO netdata;
               ```
+
+              If you are using postgres with docker, you should set password for netdata user:
+
+              ```postgresql
+              ALTER USER netdata WITH PASSWORD 'postgres';
+              ```
               
               After creating the new user, restart the Netdata agent with `sudo systemctl restart netdata`, or
               the [appropriate method](/docs/netdata-agent/start-stop-restart.md) for your


### PR DESCRIPTION
Additional action for using postgres in docker

##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

When you are using postgres in docker, you should set some password for netdata user in postgres.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

No need.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

In my case, I can't connect netdata to postgres in docker with no password. I use postgres:16.3 and netdata:v1.46

```log
time=2024-07-09T13:23:54.945Z level=error msg="error on pinging the Postgres database [postgres://netdata:postgres@172.18.0.2:5432/postgres]: failed to connect to `host=172.18.0.2 user=netdata database=postgres`: failed SASL auth (FATAL: password authentication failed for user \"netdata\" (SQLSTATE 28P01))" plugin=go.d collector=postgres job=docker_db-1
```

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
Knowledge how to correctly use netdata with postgres in Docker.
</details>
