### PR TITLE
make claiming work again

### DIFF
--- a/src/claim/claim.c
+++ b/src/claim/claim.c
@@ -89,7 +89,7 @@ CLAIM_AGENT_RESPONSE claim_agent(const char *claiming_arguments, bool force, con
               claiming_arguments);
 
     netdata_log_info("Executing agent claiming command: %s", command_exec_buffer);
-    POPEN_INSTANCE *instance = spawn_popen_run(command_exec_buffer);
+    POPEN_INSTANCE *instance = spawn_popen_run(command_line_buffer);
     if(!instance) {
         netdata_log_error("Cannot popen(\"%s\").", command_exec_buffer);
         return CLAIM_AGENT_CANNOT_EXECUTE_CLAIM_SCRIPT;

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -2178,6 +2178,7 @@ int netdata_main(int argc, char **argv) {
     // initialize internal registry
     delta_startup_time("initialize registry");
     registry_init();
+    netdata_random_session_id_generate();
 
     // ------------------------------------------------------------------------
     // initialize rrd, registry, health, rrdpush, etc.


### PR DESCRIPTION
Wrong parameters were passed to claiming scripts.
Make the UI work on netdata restart.