### PR TITLE
spawn server fixes 3

### DIFF
--- a/src/libnetdata/spawn_server/spawn_server.h
+++ b/src/libnetdata/spawn_server/spawn_server.h
@@ -22,17 +22,18 @@ typedef enum __attribute__((packed)) {
 // this is only used publicly for SPAWN_INSTANCE_TYPE_CALLBACK
 // which is not available in Windows
 typedef struct spawn_request {
-    const char *cmdline;
-    size_t request_id;
-    pid_t pid;
-    int socket;
+    const char *cmdline;                // the cmd line of the command we should run
+    size_t request_id;                  // the incremental request id
+    pid_t pid;                          // the pid of the child
+    int sock;                           // the socket for this request
     int fds[SPAWN_SERVER_TRANSFER_FDS]; // 0 = stdin, 1 = stdout, 2 = stderr, 3 = custom
-    const char **environment;
-    const char **argv;
-    const void *data;
-    size_t data_size;
-    SPAWN_INSTANCE_TYPE type;
-    struct spawn_request *prev, *next;
+    const char **environment;           // the environment of the parent process
+    const char **argv;                  // the command line and its parameters
+    const void *data;                   // the data structure for the callback
+    size_t data_size;                   // the data structure size
+    SPAWN_INSTANCE_TYPE type;           // the type of the request
+
+    struct spawn_request *prev, *next;  // linking of active requests at the spawn server
 } SPAWN_REQUEST;
 
 typedef void (*spawn_request_callback_t)(SPAWN_REQUEST *request);


### PR DESCRIPTION
- [x] always send back the spawn server response to the socket
- [x] simplify memory management at the spawn server to avoid accidental memory leaks during improvements