### PR TITLE
go.d smartctl: add scsi read/write/verify error rate

### DIFF
--- a/src/go/plugin/go.d/modules/smartctl/charts.go
+++ b/src/go/plugin/go.d/modules/smartctl/charts.go
@@ -16,6 +16,10 @@ const (
 	prioDeviceTemperature
 	prioDevicePowerCycleCount
 
+	prioDeviceScsiReadErrors
+	prioDeviceScsiWriteErrors
+	prioDeviceScsiVerifyErrors
+
 	prioDeviceSmartAttributeDecoded
 	prioDeviceSmartAttributeNormalized
 )
@@ -92,6 +96,54 @@ var (
 	}
 )
 
+var deviceScsiErrorLogChartsTmpl = module.Charts{
+	deviceScsiReadErrorsChartTmpl.Copy(),
+	deviceScsiWriteErrorsChartTmpl.Copy(),
+	deviceScsiVerifyErrorsChartTmpl.Copy(),
+}
+
+var (
+	deviceScsiReadErrorsChartTmpl = module.Chart{
+		ID:       "device_%s_type_%s_read_errors_rate",
+		Title:    "Device read errors",
+		Units:    "errors/s",
+		Fam:      "scsi errors",
+		Ctx:      "smartctl.device_read_errors_rate",
+		Type:     module.Line,
+		Priority: prioDeviceScsiReadErrors,
+		Dims: module.Dims{
+			{ID: "device_%s_type_%s_scsi_error_log_read_total_errors_corrected", Name: "corrected", Algo: module.Incremental},
+			{ID: "device_%s_type_%s_scsi_error_log_read_total_uncorrected_errors", Name: "uncorrected", Algo: module.Incremental},
+		},
+	}
+	deviceScsiWriteErrorsChartTmpl = module.Chart{
+		ID:       "device_%s_type_%s_write_errors_rate",
+		Title:    "Device write errors",
+		Units:    "errors/s",
+		Fam:      "scsi errors",
+		Ctx:      "smartctl.device_write_errors_rate",
+		Type:     module.Line,
+		Priority: prioDeviceScsiWriteErrors,
+		Dims: module.Dims{
+			{ID: "device_%s_type_%s_scsi_error_log_write_total_errors_corrected", Name: "corrected", Algo: module.Incremental},
+			{ID: "device_%s_type_%s_scsi_error_log_read_total_uncorrected_errors", Name: "uncorrected", Algo: module.Incremental},
+		},
+	}
+	deviceScsiVerifyErrorsChartTmpl = module.Chart{
+		ID:       "device_%s_type_%s_log_verify_errors_rate",
+		Title:    "Device verify errors",
+		Units:    "errors/s",
+		Fam:      "scsi errors",
+		Ctx:      "smartctl.device_verify_errors_rate",
+		Type:     module.Line,
+		Priority: prioDeviceScsiVerifyErrors,
+		Dims: module.Dims{
+			{ID: "device_%s_type_%s_scsi_error_log_verify_total_errors_corrected", Name: "corrected", Algo: module.Incremental},
+			{ID: "device_%s_type_%s_scsi_error_log_verify_total_uncorrected_errors", Name: "uncorrected", Algo: module.Incremental},
+		},
+	}
+)
+
 var (
 	deviceSmartAttributeDecodedChartTmpl = module.Chart{
 		ID:       "device_%s_type_%s_smart_attr_%s",
@@ -128,6 +180,11 @@ func (s *Smartctl) addDeviceCharts(dev *smartDevice) {
 		}
 	}
 	if cs := s.newDeviceSmartAttrCharts(dev); cs != nil && len(*cs) > 0 {
+		if err := charts.Add(*cs...); err != nil {
+			s.Warning(err)
+		}
+	}
+	if cs := s.newDeviceScsiErrorLogCharts(dev); cs != nil && len(*cs) > 0 {
 		if err := charts.Add(*cs...); err != nil {
 			s.Warning(err)
 		}
@@ -233,6 +290,29 @@ func (s *Smartctl) newDeviceSmartAttrCharts(dev *smartDevice) *module.Charts {
 	}
 
 	return &charts
+}
+
+func (s *Smartctl) newDeviceScsiErrorLogCharts(dev *smartDevice) *module.Charts {
+	if dev.deviceType() != "scsi" || !dev.data.Get("scsi_error_counter_log").Exists() {
+		return nil
+	}
+
+	charts := deviceScsiErrorLogChartsTmpl.Copy()
+
+	for _, chart := range *charts {
+		chart.ID = fmt.Sprintf(chart.ID, dev.deviceName(), dev.deviceType())
+		chart.Labels = []module.Label{
+			{Key: "device_name", Value: dev.deviceName()},
+			{Key: "device_type", Value: dev.deviceType()},
+			{Key: "model_name", Value: dev.modelName()},
+			{Key: "serial_number", Value: dev.serialNumber()},
+		}
+		for _, dim := range chart.Dims {
+			dim.ID = fmt.Sprintf(dim.ID, dev.deviceName(), dev.deviceType())
+		}
+	}
+
+	return charts
 }
 
 var attrNameReplacer = strings.NewReplacer(" ", "_", "/", "_")

--- a/src/go/plugin/go.d/modules/smartctl/charts.go
+++ b/src/go/plugin/go.d/modules/smartctl/charts.go
@@ -130,7 +130,7 @@ var (
 		},
 	}
 	deviceScsiVerifyErrorsChartTmpl = module.Chart{
-		ID:       "device_%s_type_%s_log_verify_errors_rate",
+		ID:       "device_%s_type_%s_verify_errors_rate",
 		Title:    "Device verify errors",
 		Units:    "errors/s",
 		Fam:      "scsi errors",

--- a/src/go/plugin/go.d/modules/smartctl/collect.go
+++ b/src/go/plugin/go.d/modules/smartctl/collect.go
@@ -136,6 +136,30 @@ func (s *Smartctl) collectSmartDevice(mx map[string]int64, dev *smartDevice) {
 			}
 		}
 	}
+
+	if dev.deviceType() == "scsi" {
+		sel := dev.data.Get("scsi_error_counter_log")
+		if !sel.Exists() {
+			return
+		}
+
+		for _, v := range []string{"read", "write", "verify"} {
+			for _, n := range []string{
+				//"errors_corrected_by_eccdelayed",
+				//"errors_corrected_by_eccfast",
+				//"errors_corrected_by_rereads_rewrites",
+				"total_errors_corrected",
+				"total_uncorrected_errors",
+			} {
+				key := fmt.Sprintf("%sscsi_error_log_%s_%s", px, v, n)
+				metric := fmt.Sprintf("%s.%s", v, n)
+
+				if m := sel.Get(metric); m.Exists() {
+					mx[key] = m.Int()
+				}
+			}
+		}
+	}
 }
 
 func (s *Smartctl) isTimeToScan(now time.Time) bool {

--- a/src/go/plugin/go.d/modules/smartctl/metadata.yaml
+++ b/src/go/plugin/go.d/modules/smartctl/metadata.yaml
@@ -186,6 +186,27 @@ modules:
               chart_type: line
               dimensions:
                 - name: power
+            - name: smartctl.device_read_errors_rate
+              description: Device read errors
+              unit: errors/s
+              chart_type: line
+              dimensions:
+                - name: corrected
+                - name: uncorrected
+            - name: smartctl.device_write_errors_rate
+              description: Device write errors
+              unit: errors/s
+              chart_type: line
+              dimensions:
+                - name: corrected
+                - name: uncorrected
+            - name: smartctl.device_verify_errors_rate
+              description: Device verify errors
+              unit: errors/s
+              chart_type: line
+              dimensions:
+                - name: corrected
+                - name: uncorrected
             - name: smartctl.device_smart_attr_{attribute_name}
               description: Device smart attribute {attribute_name}
               unit: '{attribute_unit}'

--- a/src/go/plugin/go.d/modules/smartctl/testdata/type-scsi/device-sda.json
+++ b/src/go/plugin/go.d/modules/smartctl/testdata/type-scsi/device-sda.json
@@ -1,0 +1,128 @@
+{
+  "json_format_version": [
+    1,
+    0
+  ],
+  "smartctl": {
+    "version": [
+      7,
+      3
+    ],
+    "svn_revision": "5338",
+    "platform_info": "REDACTED",
+    "build_info": "(local build)",
+    "argv": [
+      "smartctl",
+      "--json",
+      "--all",
+      "/dev/sda",
+      "--device",
+      "scsi"
+    ],
+    "exit_status": 0
+  },
+  "local_time": {
+    "time_t": 1720689199,
+    "asctime": "Thu Jul 11 09:13:19 2024 UTC"
+  },
+  "device": {
+    "name": "/dev/sda",
+    "info_name": "/dev/sda",
+    "type": "scsi",
+    "protocol": "SCSI"
+  },
+  "scsi_vendor": "HGST",
+  "scsi_product": "REDACTED",
+  "scsi_model_name": "REDACTED",
+  "scsi_revision": "REDACTED",
+  "scsi_version": "REDACTED",
+  "user_capacity": {
+    "blocks": 7814037168,
+    "bytes": 4000787030016
+  },
+  "logical_block_size": 512,
+  "scsi_lb_provisioning": {
+    "name": "fully provisioned",
+    "value": 0,
+    "management_enabled": {
+      "name": "LBPME",
+      "value": 0
+    },
+    "read_zeros": {
+      "name": "LBPRZ",
+      "value": 0
+    }
+  },
+  "rotation_rate": 7200,
+  "form_factor": {
+    "scsi_value": 2,
+    "name": "3.5 inches"
+  },
+  "logical_unit_id": "REDACTED",
+  "serial_number": "REDACTED",
+  "device_type": {
+    "scsi_terminology": "Peripheral Device Type [PDT]",
+    "scsi_value": 0,
+    "name": "disk"
+  },
+  "scsi_transport_protocol": {
+    "name": "SAS (SPL-4)",
+    "value": 6
+  },
+  "smart_support": {
+    "available": true,
+    "enabled": true
+  },
+  "temperature_warning": {
+    "enabled": true
+  },
+  "smart_status": {
+    "passed": true
+  },
+  "temperature": {
+    "current": 34,
+    "drive_trip": 85
+  },
+  "power_on_time": {
+    "hours": 1641,
+    "minutes": 22
+  },
+  "scsi_start_stop_cycle_counter": {
+    "year_of_manufacture": "2013",
+    "week_of_manufacture": "51",
+    "specified_cycle_count_over_device_lifetime": 50000,
+    "accumulated_start_stop_cycles": 4,
+    "specified_load_unload_count_over_device_lifetime": 600000,
+    "accumulated_load_unload_cycles": 119
+  },
+  "scsi_grown_defect_list": 0,
+  "scsi_error_counter_log": {
+    "read": {
+      "errors_corrected_by_eccfast": 647707,
+      "errors_corrected_by_eccdelayed": 29,
+      "errors_corrected_by_rereads_rewrites": 0,
+      "total_errors_corrected": 647736,
+      "correction_algorithm_invocations": 586730,
+      "gigabytes_processed": "36537.378",
+      "total_uncorrected_errors": 0
+    },
+    "write": {
+      "errors_corrected_by_eccfast": 0,
+      "errors_corrected_by_eccdelayed": 0,
+      "errors_corrected_by_rereads_rewrites": 0,
+      "total_errors_corrected": 0,
+      "correction_algorithm_invocations": 13549,
+      "gigabytes_processed": "2811.293",
+      "total_uncorrected_errors": 0
+    },
+    "verify": {
+      "errors_corrected_by_eccfast": 0,
+      "errors_corrected_by_eccdelayed": 0,
+      "errors_corrected_by_rereads_rewrites": 0,
+      "total_errors_corrected": 0,
+      "correction_algorithm_invocations": 2146,
+      "gigabytes_processed": "0.000",
+      "total_uncorrected_errors": 0
+    }
+  }
+}

--- a/src/go/plugin/go.d/modules/smartctl/testdata/type-scsi/scan.json
+++ b/src/go/plugin/go.d/modules/smartctl/testdata/type-scsi/scan.json
@@ -1,0 +1,29 @@
+{
+  "json_format_version": [
+    1,
+    0
+  ],
+  "smartctl": {
+    "version": [
+      7,
+      3
+    ],
+    "svn_revision": "5338",
+    "platform_info": "REDACTED",
+    "build_info": "(local build)",
+    "argv": [
+      "smartctl",
+      "--scan",
+      "--json"
+    ],
+    "exit_status": 0
+  },
+  "devices": [
+    {
+      "name": "/dev/sda",
+      "info_name": "/dev/sda",
+      "type": "scsi",
+      "protocol": "SCSI"
+    }
+  ]
+}


### PR DESCRIPTION
##### Summary

The issue was reported on the [Community Forum](https://community.netdata.cloud/t/monitor-drive-error-rates-now-that-smartd-log-has-been-removed). python.d/smartd_log collected these metrics.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
