### PR TITLE
Writeback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1040,6 +1040,7 @@ set(INTERNAL_COLLECTORS_FILES
         src/collectors/common-contexts/mem.swap.h
         src/collectors/common-contexts/mem.pgfaults.h
         src/collectors/common-contexts/mem.available.h
+        src/collectors/common-contexts/mem.writeback.h
 )
 
 set(PLUGINSD_PLUGIN_FILES

--- a/src/collectors/common-contexts/common-contexts.h
+++ b/src/collectors/common-contexts/common-contexts.h
@@ -26,6 +26,7 @@ typedef void (*instance_labels_cb_t)(RRDSET *st, void *data);
 #include "mem.swap.h"
 #include "mem.pgfaults.h"
 #include "mem.available.h"
+#include "mem.writeback.h"
 #include "disk.io.h"
 
 #endif //NETDATA_COMMON_CONTEXTS_H

--- a/src/collectors/common-contexts/mem.writeback.h
+++ b/src/collectors/common-contexts/mem.writeback.h
@@ -28,6 +28,8 @@ static inline void common_mem_writeback(uint64_t writeback,
                                                    );
         rrdset_flag_set(st_mem_writeback, RRDSET_FLAG_DETAIL);
 
+        // Users can configure Windows Page Syze to improve performance, but by default on x86_64
+        // the value is 4096 bytes
         rd_writeback     = rrddim_add(st_mem_writeback, "Writeback",     NULL, multiplier, 1024, RRD_ALGORITHM_ABSOLUTE);
     }
 

--- a/src/collectors/common-contexts/mem.writeback.h
+++ b/src/collectors/common-contexts/mem.writeback.h
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_MEM_WRITEBACK_H
+#define NETDATA_MEM_WRITEBACK_H
+
+#include "common-contexts.h"
+
+static inline void common_mem_writeback(uint64_t dirty,
+                                        uint64_t writeback,
+                                        uint64_t fuseWriteback,
+                                        uint64_t NFSWriteback,
+                                        uint64_t Bounce,
+                                        int update_every,
+                                        char *module) {
+    static RRDSET *st_mem_writeback = NULL;
+    static RRDDIM *rd_dirty = NULL, *rd_writeback = NULL, *rd_fusewriteback = NULL,
+                  *rd_nfs_writeback = NULL, *rd_bounce = NULL;
+
+    if(unlikely(!st_mem_writeback)) {
+        st_mem_writeback = rrdset_create_localhost("mem"
+                                                   , "writeback"
+                                                   , NULL
+                                                   , "writeback"
+                                                   , NULL
+                                                   , "Writeback Memory"
+                                                   , "MiB"
+                                                   , _COMMON_PLUGIN_NAME
+                                                   , module
+                                                   , NETDATA_CHART_PRIO_MEM_KERNEL
+                                                   , update_every
+                                                   , RRDSET_TYPE_LINE
+                                                   );
+        rrdset_flag_set(st_mem_writeback, RRDSET_FLAG_DETAIL);
+
+        rd_dirty         = rrddim_add(st_mem_writeback, "Dirty",         NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
+        rd_writeback     = rrddim_add(st_mem_writeback, "Writeback",     NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
+        rd_fusewriteback = rrddim_add(st_mem_writeback, "FuseWriteback", NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
+        rd_nfs_writeback = rrddim_add(st_mem_writeback, "NfsWriteback",  NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
+        rd_bounce        = rrddim_add(st_mem_writeback, "Bounce",        NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
+    }
+
+    rrddim_set_by_pointer(st_mem_writeback, rd_dirty,         (collected_number)dirty);
+    rrddim_set_by_pointer(st_mem_writeback, rd_writeback,     (collected_number)writeback);
+    rrddim_set_by_pointer(st_mem_writeback, rd_fusewriteback, (collected_number)fuseWriteback);
+    rrddim_set_by_pointer(st_mem_writeback, rd_nfs_writeback, (collected_number)NFSWriteback);
+    rrddim_set_by_pointer(st_mem_writeback, rd_bounce,        (collected_number)Bounce);
+    rrdset_done(st_mem_writeback);
+}
+
+#endif //NETDATA_MEM_WRITEBACK_H
+

--- a/src/collectors/proc.plugin/proc_meminfo.c
+++ b/src/collectors/proc.plugin/proc_meminfo.c
@@ -382,8 +382,7 @@ int do_proc_meminfo(int update_every, usec_t dt) {
                              WritebackTmp,
                              NFS_Unstable,
                              Bounce,
-                             update_every,
-                             _COMMON_PLUGIN_MODULE_NAME);
+                             update_every);
     }
 
     // --------------------------------------------------------------------

--- a/src/collectors/proc.plugin/proc_meminfo.c
+++ b/src/collectors/proc.plugin/proc_meminfo.c
@@ -377,39 +377,13 @@ int do_proc_meminfo(int update_every, usec_t dt) {
     }
 
     if(do_writeback) {
-        static RRDSET *st_mem_writeback = NULL;
-        static RRDDIM *rd_dirty = NULL, *rd_writeback = NULL, *rd_fusewriteback = NULL, *rd_nfs_writeback = NULL, *rd_bounce = NULL;
-
-        if(unlikely(!st_mem_writeback)) {
-            st_mem_writeback = rrdset_create_localhost(
-                    "mem"
-                    , "writeback"
-                    , NULL
-                    , "writeback"
-                    , NULL
-                    , "Writeback Memory"
-                    , "MiB"
-                    , PLUGIN_PROC_NAME
-                    , PLUGIN_PROC_MODULE_MEMINFO_NAME
-                    , NETDATA_CHART_PRIO_MEM_KERNEL
-                    , update_every
-                    , RRDSET_TYPE_LINE
-            );
-            rrdset_flag_set(st_mem_writeback, RRDSET_FLAG_DETAIL);
-
-            rd_dirty         = rrddim_add(st_mem_writeback, "Dirty",         NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
-            rd_writeback     = rrddim_add(st_mem_writeback, "Writeback",     NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
-            rd_fusewriteback = rrddim_add(st_mem_writeback, "FuseWriteback", NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
-            rd_nfs_writeback = rrddim_add(st_mem_writeback, "NfsWriteback",  NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
-            rd_bounce        = rrddim_add(st_mem_writeback, "Bounce",        NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
-        }
-
-        rrddim_set_by_pointer(st_mem_writeback, rd_dirty,         Dirty);
-        rrddim_set_by_pointer(st_mem_writeback, rd_writeback,     Writeback);
-        rrddim_set_by_pointer(st_mem_writeback, rd_fusewriteback, WritebackTmp);
-        rrddim_set_by_pointer(st_mem_writeback, rd_nfs_writeback, NFS_Unstable);
-        rrddim_set_by_pointer(st_mem_writeback, rd_bounce,        Bounce);
-        rrdset_done(st_mem_writeback);
+        common_mem_writeback(Dirty,
+                             Writeback,
+                             WritebackTmp,
+                             NFS_Unstable,
+                             Bounce,
+                             update_every,
+                             _COMMON_PLUGIN_MODULE_NAME);
     }
 
     // --------------------------------------------------------------------

--- a/src/collectors/windows.plugin/perflib-memory.c
+++ b/src/collectors/windows.plugin/perflib-memory.c
@@ -41,6 +41,22 @@ static bool do_memory(PERF_DATA_BLOCK *pDataBlock, int update_every) {
 
     common_mem_available(available_bytes, update_every);
 
+    static DWORD page_size = 0;
+    ULONGLONG writeBackSize = 0;
+
+    if (!page_size) {
+        SYSTEM_INFO sysInfo;
+        GetSystemInfo(&sysInfo);
+        page_size = sysInfo.dwPageSize;
+    }
+    static COUNTER_DATA writeBack = { .key = "Page Writes/sec" };
+   /* static COUNTER_DATA dirty = { .key = "Pool Paged Allocs" }; // These are calls, not page or bytes */
+
+   if(perflibGetObjectCounter(pDataBlock, pObjectType, &writeBack))
+       writeBackSize = writeBack.current.Data;
+
+    common_mem_writeback(writeBackSize, page_size, update_every);
+
     return true;
 }
 


### PR DESCRIPTION
##### Summary
This PR modifies the mem.writeback chart to support Microsoft Windows.

Note that this PR does not address cgroup writeback, as cgroups are not available on Windows.

![write](https://github.com/user-attachments/assets/0a27161a-e830-458a-a347-4fb91f55480e)

On Windows, we will have only one dimension. `FUSE` and `NFS` are Unix-like measures, and I did not find a variable on my system for `Bounce`.

@stelfrag and @Ferroin   the `Committed Bytes` could be considered analogous to our `Dirty` dimension. However, I did not include it in this PR because it is not explicitly stated that reserved memory is also changed memory. To stay as close to reality as possible, I prefer to leave it out. Please let me know if you have any objections. Below is the official definition for your reference:

`Committed Bytes is the amount of committed virtual memory, in bytes. Committed memory is the physical memory which has space reserved on the disk paging file(s). There can be one or more paging files on each physical drive. This counter displays the last observed value only; it is not an average.`

##### Test Plan

1. Compile on Windows and Linux and verify we have charts.

##### Additional Information
This PR was tested on:

|OS | Version |
|-----|-------------|
|Linux | Slackware Current|
|Windows |11 Home|

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
