### PR TITLE
Spawn server fixes 6

### DIFF
--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -164,7 +164,7 @@ static cmd_status_t cmd_reopen_logs_execute(char *args, char **message)
     (void)message;
 
     nd_log_limits_unlimited();
-    nd_log_reopen_log_files();
+    nd_log_reopen_log_files(true);
     nd_log_limits_reset();
 
     return CMD_STATUS_SUCCESS;

--- a/src/libnetdata/log/log.c
+++ b/src/libnetdata/log/log.c
@@ -992,14 +992,27 @@ void nd_log_initialize(void) {
         nd_log_open(&nd_log.sources[i], i);
 }
 
-void nd_log_reopen_log_files(void) {
-    netdata_log_info("Reopening all log files.");
+void nd_log_reopen_log_files(bool log) {
+    if(log)
+        netdata_log_info("Reopening all log files.");
+
+    if(nd_log.syslog.initialized) {
+        closelog();
+        nd_log.syslog.initialized = true;
+    }
+
+    if(nd_log.journal_direct.initialized) {
+        close(nd_log.journal_direct.fd);
+        nd_log.journal_direct.fd = -1;
+        nd_log.journal_direct.initialized = false;
+    }
 
     nd_log.std_output.initialized = false;
     nd_log.std_error.initialized = false;
     nd_log_initialize();
 
-    netdata_log_info("Log files re-opened.");
+    if(log)
+        netdata_log_info("Log files re-opened.");
 }
 
 void chown_open_file(int fd, uid_t uid, gid_t gid) {

--- a/src/libnetdata/log/log.c
+++ b/src/libnetdata/log/log.c
@@ -996,23 +996,34 @@ void nd_log_reopen_log_files(bool log) {
     if(log)
         netdata_log_info("Reopening all log files.");
 
-    if(nd_log.syslog.initialized) {
-        closelog();
-        nd_log.syslog.initialized = true;
-    }
-
-    if(nd_log.journal_direct.initialized) {
-        close(nd_log.journal_direct.fd);
-        nd_log.journal_direct.fd = -1;
-        nd_log.journal_direct.initialized = false;
-    }
-
     nd_log.std_output.initialized = false;
     nd_log.std_error.initialized = false;
     nd_log_initialize();
 
     if(log)
         netdata_log_info("Log files re-opened.");
+}
+
+void nd_log_reopen_log_files_for_spawn_server(void) {
+    if(nd_log.syslog.initialized) {
+        closelog();
+        nd_log.syslog.initialized = false;
+        nd_log_syslog_init();
+    }
+
+    if(nd_log.journal_direct.initialized) {
+        close(nd_log.journal_direct.fd);
+        nd_log.journal_direct.fd = -1;
+        nd_log.journal_direct.initialized = false;
+        nd_log_journal_direct_init(NULL);
+    }
+
+    nd_log.sources[NDLS_UNSET].method = NDLM_DISABLED;
+    nd_log.sources[NDLS_ACCESS].method = NDLM_DISABLED;
+    nd_log.sources[NDLS_ACLK].method = NDLM_DISABLED;
+    nd_log.sources[NDLS_DEBUG].method = NDLM_DISABLED;
+    nd_log.sources[NDLS_HEALTH].method = NDLM_DISABLED;
+    nd_log_reopen_log_files(false);
 }
 
 void chown_open_file(int fd, uid_t uid, gid_t gid) {

--- a/src/libnetdata/log/log.h
+++ b/src/libnetdata/log/log.h
@@ -154,6 +154,7 @@ void chown_open_file(int fd, uid_t uid, gid_t gid);
 void nd_log_chown_log_files(uid_t uid, gid_t gid);
 void nd_log_set_flood_protection(size_t logs, time_t period);
 void nd_log_initialize_for_external_plugins(const char *name);
+void nd_log_reopen_log_files_for_spawn_server(void);
 bool nd_log_journal_socket_available(void);
 ND_LOG_FIELD_ID nd_log_field_id_by_name(const char *field, size_t len);
 int nd_log_priority2id(const char *priority);

--- a/src/libnetdata/log/log.h
+++ b/src/libnetdata/log/log.h
@@ -149,7 +149,7 @@ void nd_log_set_user_settings(ND_LOG_SOURCES source, const char *setting);
 void nd_log_set_facility(const char *facility);
 void nd_log_set_priority_level(const char *setting);
 void nd_log_initialize(void);
-void nd_log_reopen_log_files(void);
+void nd_log_reopen_log_files(bool log);
 void chown_open_file(int fd, uid_t uid, gid_t gid);
 void nd_log_chown_log_files(uid_t uid, gid_t gid);
 void nd_log_set_flood_protection(size_t logs, time_t period);

--- a/src/libnetdata/spawn_server/spawn_server.c
+++ b/src/libnetdata/spawn_server/spawn_server.c
@@ -1337,6 +1337,7 @@ SPAWN_SERVER* spawn_server_create(SPAWN_SERVER_OPTIONS options, const char *name
 
         replace_stdio_with_dev_null();
         os_close_all_non_std_open_fds_except((int[]){ server->sock, server->pipe[1] }, 2);
+        nd_log_reopen_log_files(false);
         spawn_server_event_loop(server);
     }
     else if (pid > 0) {


### PR DESCRIPTION
Corrupted data are found in the spawn server socket, because of the logging system.

The spawn server and its children uses the same logging system as netdata. So, the logs files and sockets need to be reopened when the spawn server starts.

Without this, an fd of the parent that is now closed, may use the same fd number of a random socket, which leads to corrupted data in the socket.