### PR TITLE
go.d smartctl: use scan-open when "no_check_power_mode" is "never"

### DIFF
--- a/src/go/plugin/go.d/modules/smartctl/exec.go
+++ b/src/go/plugin/go.d/modules/smartctl/exec.go
@@ -33,6 +33,10 @@ func (e *smartctlCliExec) scan() (*gjson.Result, error) {
 	return e.execute("smartctl-json-scan")
 }
 
+func (e *smartctlCliExec) scanOpen() (*gjson.Result, error) {
+	return e.execute("smartctl-json-scan-open")
+}
+
 func (e *smartctlCliExec) deviceInfo(deviceName, deviceType, powerMode string) (*gjson.Result, error) {
 	return e.execute("smartctl-json-device-info",
 		"--deviceName", deviceName,

--- a/src/go/plugin/go.d/modules/smartctl/smartctl.go
+++ b/src/go/plugin/go.d/modules/smartctl/smartctl.go
@@ -83,6 +83,7 @@ type (
 	}
 	smartctlCli interface {
 		scan() (*gjson.Result, error)
+		scanOpen() (*gjson.Result, error)
 		deviceInfo(deviceName, deviceType, powerMode string) (*gjson.Result, error)
 	}
 )

--- a/src/go/plugin/go.d/modules/smartctl/smartctl_test.go
+++ b/src/go/plugin/go.d/modules/smartctl/smartctl_test.go
@@ -477,6 +477,10 @@ func (m *mockSmartctlCliExec) scan() (*gjson.Result, error) {
 	return &res, nil
 }
 
+func (m *mockSmartctlCliExec) scanOpen() (*gjson.Result, error) {
+	return m.scan()
+}
+
 func (m *mockSmartctlCliExec) deviceInfo(deviceName, deviceType, powerMode string) (*gjson.Result, error) {
 	if m.deviceDataFunc == nil {
 		return nil, nil


### PR DESCRIPTION
##### Summary

[Issue on Discord](https://discord.com/channels/847502280503590932/1261747175361347644/1261747175361347644)

"sat" devices are identified as "scsi" with `--scan`, and then later code attempts to validate the type by calling `smartctl` with the "scsi" type. This validation can trigger unintended "Enabling discard_zeroes_data" messages in system logs (dmesg). To address this specific issue we use `--scan-open` as a workaround. This method reliably identifies device types.

The "Enabling discard_zeroes_data" message might be harmless. More investigation is needed.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
