### PR TITLE
do not rely on the queued flag to queue a context

### DIFF
--- a/src/database/contexts/context.c
+++ b/src/database/contexts/context.c
@@ -255,6 +255,10 @@ static void rrdcontext_post_processing_queue_insert_callback(const DICTIONARY_IT
 
 static void rrdcontext_post_processing_queue_delete_callback(const DICTIONARY_ITEM *item __maybe_unused, void *context, void *nothing __maybe_unused) {
     RRDCONTEXT *rc = context;
+
+    // IMPORTANT:
+    // Do not rely on this flag being absent, because the dictionaries have delayed deletions (garbage collect)
+    // so, this flag may not be deleted immediately from the context.
     rrd_flag_clear(rc, RRD_FLAG_QUEUED_FOR_PP);
     rc->pp.dequeued_ut = now_realtime_usec();
 }


### PR DESCRIPTION
On a just installed netdata, some contexts were not available on the dashboard until netdata was restarted, or deepscan was requested on the contexts API.

The problem was an optimization that prevent re-queuing of contexts, that was relaying on a flag that was managed by dictionary destructors. However the dictionaries support late destruction and the flag was not unset, even though the item was marked as deleted in the dictionary.

The new logic removes this optimization and now relies on dictionary conflict constructor to do the right job.
