### PR TITLE
go.d megacli: add bbu absolute charge

### DIFF
--- a/src/go/plugin/go.d/modules/megacli/charts.go
+++ b/src/go/plugin/go.d/modules/megacli/charts.go
@@ -14,6 +14,7 @@ const (
 	prioPhysDriveMediaErrorsRate
 	prioPhysDrivePredictiveFailuresRate
 
+	prioBBUAbsoluteCharge
 	prioBBURelativeCharge
 	prioBBURechargeCycles
 	prioBBUTemperature
@@ -74,18 +75,31 @@ var (
 )
 
 var bbuChartsTmpl = module.Charts{
+	bbuAbsoluteChargeChartsTmpl.Copy(),
 	bbuRelativeChargeChartsTmpl.Copy(),
 	bbuRechargeCyclesChartsTmpl.Copy(),
 	bbuTemperatureChartsTmpl.Copy(),
 }
 
 var (
+	bbuAbsoluteChargeChartsTmpl = module.Chart{
+		ID:       "bbu_adapter_%s_absolute_charge",
+		Title:    "BBU absolute charge",
+		Units:    "percentage",
+		Fam:      "bbu charge",
+		Ctx:      "megacli.bbu_absolute_charge",
+		Type:     module.Area,
+		Priority: prioBBUAbsoluteCharge,
+		Dims: module.Dims{
+			{ID: "bbu_adapter_%s_absolute_state_of_charge", Name: "charge"},
+		},
+	}
 	bbuRelativeChargeChartsTmpl = module.Chart{
 		ID:       "bbu_adapter_%s_relative_charge",
 		Title:    "BBU relative charge",
 		Units:    "percentage",
 		Fam:      "bbu charge",
-		Ctx:      "megacli.bbu_charge",
+		Ctx:      "megacli.bbu_relative_charge",
 		Type:     module.Area,
 		Priority: prioBBURelativeCharge,
 		Dims: module.Dims{

--- a/src/go/plugin/go.d/modules/megacli/megacli_test.go
+++ b/src/go/plugin/go.d/modules/megacli/megacli_test.go
@@ -235,6 +235,9 @@ func TestMegaCli_Collect(t *testing.T) {
 
 			assert.Equal(t, test.wantMetrics, mx)
 			assert.Len(t, *mega.Charts(), test.wantCharts)
+			if len(test.wantMetrics) > 0 {
+				module.TestMetricsHasAllChartsDims(t, mega.Charts(), mx)
+			}
 		})
 	}
 }

--- a/src/go/plugin/go.d/modules/megacli/metadata.yaml
+++ b/src/go/plugin/go.d/modules/megacli/metadata.yaml
@@ -157,6 +157,12 @@ modules:
             - name: battery_type
               description: Battery type (e.g. BBU)
           metrics:
+            - name: megacli.bbu_absolute_charge
+              description: BBU absolute charge
+              unit: percentage
+              chart_type: area
+              dimensions:
+                - name: charge
             - name: megacli.bbu_relative_charge
               description: BBU relative charge
               unit: percentage

--- a/src/health/health.d/megacli.conf
+++ b/src/health/health.d/megacli.conf
@@ -48,8 +48,8 @@ component: RAID
 
 # Backup Battery Unit
 
- template: megacli_bbu_charge
-       on: megacli.bbu_charge
+ template: megacli_bbu_absolute_charge
+       on: megacli.bbu_absolute_charge
     class: Workload
      type: System
 component: RAID


### PR DESCRIPTION
##### Summary

~~And change the alarm to use it. Relative State of Charge (RSOC) shows BBU capacity degradation, we need an alarm for it but it should be a different alarm.~~

Wrong. Using BBU info data


```
Remaining Capacity: 970 mAh
Full Charge Capacity: 1400 mAh
Design Capacity: 1530 mAh
Relative State of Charge: 70 % 
Absolute State of charge: 63 %. 
```

- `Absolute State of charge: 63 %` is `970.0 / 1530 * 100` (RemainingCap / DesignCap)
- `Relative State of Charge: 70 %` is `970.0 / 1400 * 100` (RemainingCap / FullChargeCap)

So Absolute uses the battery's initial (design) capacity and Relative uses the current actual capacity. Both show charge %, but none show capacity degradation % which would be `100 - FullChargeCap / DesignCap * 100`.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
