### PR TITLE
Support IPV6 when establishing MQTT connection to the cloud

### DIFF
--- a/src/aclk/helpers/mqtt_wss_pal.h
+++ b/src/aclk/helpers/mqtt_wss_pal.h
@@ -10,10 +10,4 @@
 #undef OPENSSL_VERSION_110
 #undef OPENSSL_VERSION_111
 
-#define mw_malloc(...) mallocz(__VA_ARGS__)
-#define mw_calloc(...) callocz(__VA_ARGS__)
-#define mw_free(...) freez(__VA_ARGS__)
-#define mw_strdup(...) strdupz(__VA_ARGS__)
-#define mw_realloc(...) reallocz(__VA_ARGS__)
-
 #endif /* MQTT_WSS_PAL_H */

--- a/src/aclk/https_client.c
+++ b/src/aclk/https_client.c
@@ -696,7 +696,7 @@ int https_request(https_req_t *request, https_req_response_t *response) {
         goto exit_CTX;
     }
 
-    if (!SSL_set_tlsext_host_name(ctx->ssl, connect_host)) {
+    if (!SSL_set_tlsext_host_name(ctx->ssl, request->host)) {
         netdata_log_error("Error setting TLS SNI host");
         goto exit_CTX;
     }

--- a/src/aclk/mqtt_websockets/mqtt_ng.c
+++ b/src/aclk/mqtt_websockets/mqtt_ng.c
@@ -423,7 +423,7 @@ static void buffer_frag_free_data(struct buffer_fragment *frag)
     if ( frag->flags & BUFFER_FRAG_DATA_EXTERNAL && frag->data != NULL) {
         switch (ptr2memory_mode(frag->free_fnc)) {
             case MEMCPY:
-                mw_free(frag->data);
+                freez(frag->data);
                 break;
             case EXTERNAL_FREE_AFTER_USE:
                 frag->free_fnc(frag->data);
@@ -563,7 +563,7 @@ static int transaction_buffer_grow(struct transaction_buffer *buf, mqtt_wss_log_
     if (buf->hdr_buffer.size > max)
         buf->hdr_buffer.size = max;
 
-    void *ret = mw_realloc(buf->hdr_buffer.data, buf->hdr_buffer.size);
+    void *ret = reallocz(buf->hdr_buffer.data, buf->hdr_buffer.size);
     if (ret == NULL) {
         mws_warn(log_ctx, "Buffer growth failed (realloc)");
         return 1;
@@ -581,7 +581,7 @@ inline static int transaction_buffer_init(struct transaction_buffer *to_init, si
     pthread_mutex_init(&to_init->mutex, NULL);
 
     to_init->hdr_buffer.size = size;
-    to_init->hdr_buffer.data = mw_malloc(size);
+    to_init->hdr_buffer.data = mallocz(size);
     if (to_init->hdr_buffer.data == NULL)
         return 1;
 
@@ -594,7 +594,7 @@ static void transaction_buffer_destroy(struct transaction_buffer *to_init)
 {
     buffer_purge(&to_init->hdr_buffer);
     pthread_mutex_destroy(&to_init->mutex);
-    mw_free(to_init->hdr_buffer.data);
+    freez(to_init->hdr_buffer.data);
 }
 
 // Creates transaction
@@ -628,7 +628,7 @@ void transaction_buffer_transaction_rollback(struct transaction_buffer *buf, str
 #define RX_ALIASES_INITIALIZE() c_rhash_new(UINT16_MAX >> 8)
 struct mqtt_ng_client *mqtt_ng_init(struct mqtt_ng_init *settings)
 {
-    struct mqtt_ng_client *client = mw_calloc(1, sizeof(struct mqtt_ng_client));
+    struct mqtt_ng_client *client = callocz(1, sizeof(struct mqtt_ng_client));
     if (client == NULL)
         return NULL;
 
@@ -672,7 +672,7 @@ err_free_rx_alias:
 err_free_trx_buf:
     transaction_buffer_destroy(&client->main_buffer);
 err_free_client:
-    mw_free(client);
+    freez(client);
     return NULL;
 }
 
@@ -688,7 +688,7 @@ static void mqtt_ng_destroy_rx_alias_hash(c_rhash hash)
     void *to_free;
     while(!c_rhash_iter_uint64_keys(hash, &i, &stored_key)) {
         c_rhash_get_ptr_by_uint64(hash, stored_key, &to_free);
-        mw_free(to_free);
+        freez(to_free);
     }
     c_rhash_destroy(hash);
 }
@@ -700,7 +700,7 @@ static void mqtt_ng_destroy_tx_alias_hash(c_rhash hash)
     void *to_free;
     while(!c_rhash_iter_str_keys(hash, &i, &stored_key)) {
         c_rhash_get_ptr_by_str(hash, stored_key, &to_free);
-        mw_free(to_free);
+        freez(to_free);
     }
     c_rhash_destroy(hash);
 }
@@ -714,7 +714,7 @@ void mqtt_ng_destroy(struct mqtt_ng_client *client)
     pthread_rwlock_destroy(&client->tx_topic_aliases.rwlock);
     mqtt_ng_destroy_rx_alias_hash(client->rx_aliases);
 
-    mw_free(client);
+    freez(client);
 }
 
 int frag_set_external_data(mqtt_wss_log_ctx_t log, struct buffer_fragment *frag, void *data, size_t data_len, free_fnc_t data_free_fnc)
@@ -730,7 +730,7 @@ int frag_set_external_data(mqtt_wss_log_ctx_t log, struct buffer_fragment *frag,
 
     switch (ptr2memory_mode(data_free_fnc)) {
         case MEMCPY:
-            frag->data = mw_malloc(data_len);
+            frag->data = mallocz(data_len);
             if (frag->data == NULL) {
                 mws_error(log, UNIT_LOG_PREFIX "OOM while malloc @_optimized_add");
                 return 1;
@@ -1408,12 +1408,12 @@ static void mqtt_properties_parser_ctx_reset(struct mqtt_properties_parser_ctx *
         struct mqtt_property *f = ctx->head;
         ctx->head = ctx->head->next;
         if (f->type == MQTT_TYPE_STR || f->type == MQTT_TYPE_STR_PAIR)
-            mw_free(f->data.strings[0]);
+            freez(f->data.strings[0]);
         if (f->type == MQTT_TYPE_STR_PAIR)
-            mw_free(f->data.strings[1]);
+            freez(f->data.strings[1]);
         if (f->type == MQTT_TYPE_BIN)
-            mw_free(f->data.bindata);
-        mw_free(f);
+            freez(f->data.bindata);
+        freez(f);
     }
     ctx->tail = NULL;
     ctx->properties_length = 0;
@@ -1498,7 +1498,7 @@ static int parse_properties_array(struct mqtt_properties_parser_ctx *ctx, rbuf_t
             return rc;
         case PROPERTY_CREATE:
             BUF_READ_CHECK_AT_LEAST(data, 1);
-            struct mqtt_property *prop = mw_calloc(1, sizeof(struct mqtt_property));
+            struct mqtt_property *prop = callocz(1, sizeof(struct mqtt_property));
             if (ctx->head == NULL) {
                 ctx->head = prop;
                 ctx->tail = prop;
@@ -1558,7 +1558,7 @@ static int parse_properties_array(struct mqtt_properties_parser_ctx *ctx, rbuf_t
             break;
         case PROPERTY_TYPE_STR:
             BUF_READ_CHECK_AT_LEAST(data, ctx->tail->bindata_len);
-            ctx->tail->data.strings[ctx->str_idx] = mw_malloc(ctx->tail->bindata_len + 1);
+            ctx->tail->data.strings[ctx->str_idx] = mallocz(ctx->tail->bindata_len + 1);
             rbuf_pop(data, ctx->tail->data.strings[ctx->str_idx], ctx->tail->bindata_len);
             ctx->tail->data.strings[ctx->str_idx][ctx->tail->bindata_len] = 0;
             ctx->str_idx++;
@@ -1571,7 +1571,7 @@ static int parse_properties_array(struct mqtt_properties_parser_ctx *ctx, rbuf_t
             break;
         case PROPERTY_TYPE_BIN:
             BUF_READ_CHECK_AT_LEAST(data, ctx->tail->bindata_len);
-            ctx->tail->data.bindata = mw_malloc(ctx->tail->bindata_len);
+            ctx->tail->data.bindata = mallocz(ctx->tail->bindata_len);
             rbuf_pop(data, ctx->tail->data.bindata, ctx->tail->bindata_len);
             ctx->bytes_consumed += ctx->tail->bindata_len;
             ctx->state = PROPERTY_NEXT;
@@ -1721,7 +1721,7 @@ static int parse_suback_varhdr(struct mqtt_ng_client *client)
                 return rc;
             parser->mqtt_parsed_len += parser->properties_parser.bytes_consumed;
             suback->reason_code_count = parser->mqtt_fixed_hdr_remaining_length - parser->mqtt_parsed_len;
-            suback->reason_codes = mw_calloc(suback->reason_code_count, sizeof(*suback->reason_codes));
+            suback->reason_codes = callocz(suback->reason_code_count, sizeof(*suback->reason_codes));
             suback->reason_codes_pending = suback->reason_code_count;
             parser->varhdr_state = MQTT_PARSE_REASONCODES;
             /* FALLTHROUGH */
@@ -1760,7 +1760,7 @@ static int parse_publish_varhdr(struct mqtt_ng_client *client)
                 parser->varhdr_state = MQTT_PARSE_VARHDR_POST_TOPICNAME;
                 break;
             }
-            publish->topic = mw_calloc(1, publish->topic_len + 1 /* add 0x00 */);
+            publish->topic = callocz(1, publish->topic_len + 1 /* add 0x00 */);
             if (publish->topic == NULL)
                 return MQTT_NG_CLIENT_OOM;
             parser->varhdr_state = MQTT_PARSE_VARHDR_TOPICNAME;
@@ -1796,7 +1796,7 @@ static int parse_publish_varhdr(struct mqtt_ng_client *client)
             /* FALLTHROUGH */
         case MQTT_PARSE_PAYLOAD:
             if (parser->mqtt_fixed_hdr_remaining_length < parser->mqtt_parsed_len) {
-                mw_free(publish->topic);
+                freez(publish->topic);
                 publish->topic = NULL;
                 ERROR("Error parsing PUBLISH message");
                 return MQTT_NG_CLIENT_PROTOCOL_ERROR;
@@ -1808,9 +1808,9 @@ static int parse_publish_varhdr(struct mqtt_ng_client *client)
             }
             BUF_READ_CHECK_AT_LEAST(parser->received_data, publish->data_len);
 
-            publish->data = mw_malloc(publish->data_len);
+            publish->data = mallocz(publish->data_len);
             if (publish->data == NULL) {
-                mw_free(publish->topic);
+                freez(publish->topic);
                 publish->topic = NULL;
                 return MQTT_NG_CLIENT_OOM;
             }
@@ -1867,7 +1867,7 @@ static int parse_data(struct mqtt_ng_client *client)
                 case MQTT_CPT_SUBACK:
                     rc = parse_suback_varhdr(client);
                     if (rc != MQTT_NG_CLIENT_NEED_MORE_BYTES && rc != MQTT_NG_CLIENT_OK_CALL_AGAIN) {
-                        mw_free(parser->mqtt_packet.suback.reason_codes);
+                        freez(parser->mqtt_packet.suback.reason_codes);
                     }
                     if (rc == MQTT_NG_CLIENT_PARSE_DONE) {
                         parser->state = MQTT_PARSE_MQTT_PACKET_DONE;
@@ -2096,8 +2096,8 @@ int handle_incoming_traffic(struct mqtt_ng_client *client)
 #endif
                 pub = &client->parser.mqtt_packet.publish;
                 if (pub->qos > 1) {
-                    mw_free(pub->topic);
-                    mw_free(pub->data);
+                    freez(pub->topic);
+                    freez(pub->data);
                     return MQTT_NG_CLIENT_NOT_IMPL_YET;
                 }
                 if ( pub->qos == 1 && (rc = mqtt_ng_puback(client, pub->packet_id, 0)) ) {
@@ -2127,8 +2127,8 @@ int handle_incoming_traffic(struct mqtt_ng_client *client)
                 // in case we have property topic alias and we have topic we take over the string
                 // and add pointer to it into topic alias list
                 if (prop == NULL)
-                    mw_free(pub->topic);
-                mw_free(pub->data);
+                    freez(pub->topic);
+                freez(pub->data);
                 return MQTT_NG_CLIENT_WANT_WRITE;
             case MQTT_CPT_DISCONNECT:
                 INFO ("Got MQTT DISCONNECT control packet from server. Reason code: %d", (int)client->parser.mqtt_packet.disconnect.reason_code);
@@ -2225,7 +2225,7 @@ int mqtt_ng_set_topic_alias(struct mqtt_ng_client *client, const char *topic)
         return idx;
     }
 
-    alias = mw_malloc(sizeof(struct topic_alias_data));
+    alias = mallocz(sizeof(struct topic_alias_data));
     idx = ++client->tx_topic_aliases.idx_assigned;
     alias->idx = idx;
     __atomic_store_n(&alias->usage_count, 0, __ATOMIC_SEQ_CST);

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-only
-// Copyright (C) 2020 Timotej Šiškovič
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
@@ -19,9 +18,6 @@
 
 #include <sys/socket.h>
 #include <netinet/in.h>
-#include <arpa/inet.h>
-#include <netinet/tcp.h> //TCP_NODELAY
-#include <netdb.h>
 
 #include <openssl/err.h>
 #include <openssl/ssl.h>
@@ -173,7 +169,7 @@ mqtt_wss_client mqtt_wss_new(const char *log_prefix,
     SSL_library_init();
     SSL_load_error_strings();
 
-    mqtt_wss_client client = mw_calloc(1, sizeof(struct mqtt_wss_client_struct));
+    mqtt_wss_client client = callocz(1, sizeof(struct mqtt_wss_client_struct));
     if (!client) {
         mws_error(log, "OOM alocating mqtt_wss_client");
         goto fail;
@@ -229,7 +225,7 @@ fail_3:
 fail_2:
     ws_client_destroy(client->ws_client);
 fail_1:
-    mw_free(client);
+    freez(client);
 fail:
     mqtt_wss_log_ctx_destroy(log);
     return NULL;
@@ -253,12 +249,15 @@ void mqtt_wss_destroy(mqtt_wss_client client)
     // as it "borrows" this pointer and might use it
     if (client->target_host == client->host)
         client->target_host = NULL;
+
     if (client->target_host)
-        mw_free(client->target_host);
+        freez(client->target_host);
+
     if (client->host)
-        mw_free(client->host);
-    mw_free(client->proxy_passwd);
-    mw_free(client->proxy_uname);
+        freez(client->host);
+
+    freez(client->proxy_passwd);
+    freez(client->proxy_uname);
 
     if (client->ssl)
         SSL_free(client->ssl);
@@ -273,7 +272,7 @@ void mqtt_wss_destroy(mqtt_wss_client client)
     pthread_mutex_destroy(&client->stat_lock);
 
     mqtt_wss_log_ctx_destroy(client->log);
-    mw_free(client);
+    freez(client);
 }
 
 static int cert_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
@@ -298,7 +297,7 @@ static int cert_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
         mws_error(client->log, "verify error:num=%d:%s:depth=%d:%s", err,
                  X509_verify_cert_error_string(err), depth, err_str);
 
-        mw_free(err_str);
+        freez(err_str);
     }
 
     if (!preverify_ok && err == X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT &&
@@ -362,14 +361,14 @@ static int http_parse_reply(mqtt_wss_client client, rbuf_t buf)
     }
 
     if (http_code != 200) {
-        ptr = mw_malloc(idx + 1);
+        ptr = mallocz(idx + 1);
         if (!ptr)
             return 6;
         rbuf_pop(buf, ptr, idx);
         ptr[idx] = 0;
 
         mws_error(client->log, "http_proxy returned error code %d \"%s\"", http_code, ptr);
-        mw_free(ptr);
+        freez(ptr);
         return 7;
     }/* else
         rbuf_bump_tail(buf, idx);*/
@@ -450,7 +449,7 @@ static int http_proxy_connect(mqtt_wss_client client)
 
     if (client->proxy_uname) {
         size_t creds_plain_len = strlen(client->proxy_uname) + strlen(client->proxy_passwd) + 2;
-        char *creds_plain = mw_malloc(creds_plain_len);
+        char *creds_plain = mallocz(creds_plain_len);
         if (!creds_plain) {
             mws_error(client->log, "OOM creds_plain");
             rc = 6;
@@ -460,9 +459,9 @@ static int http_proxy_connect(mqtt_wss_client client)
         // OpenSSL encoder puts newline every 64 output bytes
         // we remove those but during encoding we need that space in the buffer
         creds_base64_len += (1+(creds_base64_len/64)) * strlen("\n");
-        char *creds_base64 = mw_malloc(creds_base64_len + 1);
+        char *creds_base64 = mallocz(creds_base64_len + 1);
         if (!creds_base64) {
-            mw_free(creds_plain);
+            freez(creds_plain);
             mws_error(client->log, "OOM creds_base64");
             rc = 6;
             goto cleanup;
@@ -475,12 +474,12 @@ static int http_proxy_connect(mqtt_wss_client client)
 
         int b64_len;
         base64_encode_helper((unsigned char*)creds_base64, &b64_len, (unsigned char*)creds_plain, strlen(creds_plain));
-        mw_free(creds_plain);
+        freez(creds_plain);
 
         r_buf_ptr = rbuf_get_linear_insert_range(r_buf, &r_buf_linear_insert_capacity);
         snprintf(r_buf_ptr, r_buf_linear_insert_capacity,"Proxy-Authorization: Basic %s" HTTP_ENDLINE, creds_base64);
         write(client->sockfd, r_buf_ptr, strlen(r_buf_ptr));
-        mw_free(creds_base64);
+        freez(creds_base64);
     }
     write(client->sockfd, HTTP_ENDLINE, strlen(HTTP_ENDLINE));
 
@@ -523,15 +522,14 @@ cleanup:
     return rc;
 }
 
-int mqtt_wss_connect(mqtt_wss_client client, char *host, int port, struct mqtt_connect_params *mqtt_params, int ssl_flags, struct mqtt_wss_proxy *proxy)
+int mqtt_wss_connect(
+    mqtt_wss_client client,
+    char *host,
+    int port,
+    struct mqtt_connect_params *mqtt_params,
+    int ssl_flags,
+    struct mqtt_wss_proxy *proxy)
 {
-    struct sockaddr_in addr;
-    memset(&addr, 0, sizeof(addr));
-    addr.sin_family = AF_INET;
-
-    struct hostent *he;
-    struct in_addr **addr_list;
-
     if (!mqtt_params) {
         mws_error(client->log, "mqtt_params can't be null!");
         return -1;
@@ -545,23 +543,35 @@ int mqtt_wss_connect(mqtt_wss_client client, char *host, int port, struct mqtt_c
 
     if (client->target_host == client->host)
         client->target_host = NULL;
+
     if (client->target_host)
-        mw_free(client->target_host);
+        freez(client->target_host);
+
     if (client->host)
-        mw_free(client->host);
+        freez(client->host);
+
+    if (client->proxy_uname) {
+        freez(client->proxy_uname);
+        client->proxy_uname = NULL;
+    }
+
+    if (client->proxy_passwd) {
+        freez(client->proxy_passwd);
+        client->proxy_passwd = NULL;
+    }
 
     if (proxy && proxy->type != MQTT_WSS_DIRECT) {
-        client->host = mw_strdup(proxy->host);
+        client->host = strdupz(proxy->host);
         client->port = proxy->port;
-        client->target_host = mw_strdup(host);
+        client->target_host = strdupz(host);
         client->target_port = port;
         client->proxy_type = proxy->type;
         if (proxy->username)
-            client->proxy_uname = mw_strdup(proxy->username);
+            client->proxy_uname = strdupz(proxy->username);
         if (proxy->password)
-            client->proxy_passwd = mw_strdup(proxy->password);
+            client->proxy_passwd = strdupz(proxy->password);
     } else {
-        client->host = mw_strdup(host);
+        client->host = strdupz(host);
         client->port = port;
         client->target_host = client->host;
         client->target_port = port;
@@ -569,29 +579,18 @@ int mqtt_wss_connect(mqtt_wss_client client, char *host, int port, struct mqtt_c
 
     client->ssl_flags = ssl_flags;
 
-    //TODO gethostbyname -> getaddinfo
-    //     hstrerror -> gai_strerror
-    if ((he = gethostbyname(client->host)) == NULL) {
-        mws_error(client->log, "gethostbyname() error \"%s\"", hstrerror(h_errno));
-        return -1;
-    }
-
-    addr_list = (struct in_addr **)he->h_addr_list;
-    if(!addr_list[0]) {
-        mws_error(client->log, "No IP addr resolved");
-        return -1;
-    }
-    mws_debug(client->log, "Resolved IP: %s", inet_ntoa(*addr_list[0]));
-    addr.sin_addr = *addr_list[0];
-    addr.sin_port = htons(client->port);
-
     if (client->sockfd > 0)
         close(client->sockfd);
-    client->sockfd = socket(AF_INET, SOCK_STREAM | DEFAULT_SOCKET_FLAGS, 0);
-    if (client->sockfd < 0) {
-        mws_error(client->log, "Couldn't create socket()");
-        return -1;
+
+    char port_str[16];
+    snprintf(port_str, sizeof(port_str) -1, "%d", client->port);
+    int fd = connect_to_this_ip46(IPPROTO_TCP, SOCK_STREAM, client->host, 0, port_str, NULL);
+    if (fd < 0) {
+        mws_error(client->log, "Could not connect to remote endpoint \"%s\", port %d.\n", client->host, port);
+        return -3;
     }
+
+    client->sockfd = fd;
 
 #ifndef SOCK_CLOEXEC
     int flags = fcntl(client->sockfd, F_GETFD);
@@ -600,18 +599,9 @@ int mqtt_wss_connect(mqtt_wss_client client, char *host, int port, struct mqtt_c
 #endif
 
     int flag = 1;
-    int result = setsockopt(client->sockfd,
-                            IPPROTO_TCP,
-                            TCP_NODELAY,
-                            &flag,
-                            sizeof(int));
+    int result = setsockopt(client->sockfd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(int));
     if (result < 0)
        mws_error(client->log, "Could not dissable NAGLE");
-
-    if (connect(client->sockfd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-        mws_error(client->log, "Could not connect to remote endpoint \"%s\", port %d.\n", client->host, client->port);
-        return -3;
-    }
 
     client->poll_fds[POLLFD_SOCKET].fd = client->sockfd;
 
@@ -640,6 +630,7 @@ int mqtt_wss_connect(mqtt_wss_client client, char *host, int port, struct mqtt_c
     // free SSL structs from possible previous connections
     if (client->ssl)
         SSL_free(client->ssl);
+
     if (client->ssl_ctx)
         SSL_CTX_free(client->ssl_ctx);
 
@@ -675,6 +666,7 @@ int mqtt_wss_connect(mqtt_wss_client client, char *host, int port, struct mqtt_c
         mws_error(client->log, "SSL could not connect");
         return -5;
     }
+
     if (result == -1) {
         int ec = SSL_get_error(client->ssl, result);
         if (ec != SSL_ERROR_WANT_READ && ec != SSL_ERROR_WANT_WRITE) {
@@ -693,14 +685,16 @@ int mqtt_wss_connect(mqtt_wss_client client, char *host, int port, struct mqtt_c
     auth.username_free = NULL;
     auth.password = (char*)mqtt_params->password;
     auth.password_free = NULL;
+
     struct mqtt_lwt_properties lwt;
     lwt.will_topic = (char*)mqtt_params->will_topic;
     lwt.will_topic_free = NULL;
     lwt.will_message = (void*)mqtt_params->will_msg;
     lwt.will_message_free = NULL; // TODO expose no copy version to API
     lwt.will_message_size = mqtt_params->will_msg_len;
-    lwt.will_qos = (mqtt_params->will_flags & MQTT_WSS_PUB_QOSMASK);
-    lwt.will_retain = mqtt_params->will_flags & MQTT_WSS_PUB_RETAIN;
+    lwt.will_qos = (int) (mqtt_params->will_flags & MQTT_WSS_PUB_QOSMASK);
+    lwt.will_retain = (int) mqtt_params->will_flags & MQTT_WSS_PUB_RETAIN;
+
     int ret = mqtt_ng_connect(client->mqtt, &auth, mqtt_params->will_msg ? &lwt : NULL, 1, client->mqtt_keepalive);
     if (ret) {
         mws_error(client->log, "Error generating MQTT connect");

--- a/src/aclk/mqtt_websockets/mqtt_wss_log.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_log.c
@@ -25,13 +25,13 @@ struct mqtt_wss_log_ctx {
 #endif
 mqtt_wss_log_ctx_t mqtt_wss_log_ctx_create(const char *ctx_prefix, mqtt_wss_log_callback_t log_callback)
 {
-    mqtt_wss_log_ctx_t ctx = mw_calloc(1, sizeof(struct mqtt_wss_log_ctx));
+    mqtt_wss_log_ctx_t ctx = callocz(1, sizeof(struct mqtt_wss_log_ctx));
     if(!ctx)
         return NULL;
 
     if(log_callback) {
         ctx->extern_log_fnc = log_callback;
-        ctx->buffer = mw_calloc(1, LOG_BUFFER_SIZE);
+        ctx->buffer = callocz(1, LOG_BUFFER_SIZE);
         if(!ctx->buffer)
             goto cleanup;
 
@@ -60,15 +60,15 @@ mqtt_wss_log_ctx_t mqtt_wss_log_ctx_create(const char *ctx_prefix, mqtt_wss_log_
     return ctx;
 
 cleanup:
-    mw_free(ctx);
+    freez(ctx);
     return NULL;
 }
 
 void mqtt_wss_log_ctx_destroy(mqtt_wss_log_ctx_t ctx)
 {
-    mw_free(ctx->ctx_prefix);
-    mw_free(ctx->buffer);
-    mw_free(ctx);
+    freez(ctx->ctx_prefix);
+    freez(ctx->buffer);
+    freez(ctx);
 }
 
 static inline char severity_to_c(int severity)


### PR DESCRIPTION
##### Summary
- Replace the mqtt ipv4-only connect function with connect_to_this_ip46 
- Replace mw_malloc, mw_calloc, mw_free, mw_strdup, mw_realloc
- Remove ws_client_get_nonce, (generate and use a UUID instead)
- Replace statistics pthread_lock with spinlock

##### Test
- Start agent normally, it should connect to the cloud
- Test IPV6 connectivity (we have it enabled only in the **testing** environment)
- Check with direct connection
- Check via a proxy (add `proxy = http://host:port` in netdata.conf `[cloud]` section)
   - Ideally check with a proxy on a VM that supports IPV6 and one that doesn't
   - You can force IPV4 connection on an otherwise IPV6 capable system by editing /etc/gai.conf -- adjust 
     `precedence ::ffff:0:0/96` 
