### PR TITLE
Update libbpf (1.45.0)

### DIFF
--- a/packaging/cmake/Modules/NetdataEBPFCORE.cmake
+++ b/packaging/cmake/Modules/NetdataEBPFCORE.cmake
@@ -11,8 +11,8 @@ set(ebpf-co-re_SOURCE_DIR "${CMAKE_BINARY_DIR}/ebpf-co-re")
 function(netdata_fetch_ebpf_co_re)
     ExternalProject_Add(
         ebpf-co-re
-        URL https://github.com/netdata/ebpf-co-re/releases/download/v1.4.3/netdata-ebpf-co-re-glibc-v1.4.3.tar.xz
-        URL_HASH SHA256=52a8cf65b4659d173ec3d9fb69315ba48c1f091d1882968748b37a8f7bf9f92d
+        URL https://github.com/netdata/ebpf-co-re/releases/download/v1.4.5/netdata-ebpf-co-re-glibc-v1.4.5.tar.xz
+        URL_HASH SHA256=6937a167f6f8c65a0b0528a297df9944d15a649c9af34a70a678d4eabbbf22d1
         SOURCE_DIR "${ebpf-co-re_SOURCE_DIR}"
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""

--- a/packaging/cmake/Modules/NetdataEBPFLegacy.cmake
+++ b/packaging/cmake/Modules/NetdataEBPFLegacy.cmake
@@ -20,19 +20,19 @@ function(netdata_fetch_legacy_ebpf_code)
     endif()
 
     if(need_static)
-        set(_hash 73cfe6ceb0098447c2a016d8f9674ad8a80ba6dd61cfdd8646710a0dc5c52d9f)
+        set(_hash 3f97034a595b5fd52ac4c5f43ce43085cc1391f39f2a281191efb15cc9666af4)
         set(_libc "static")
     elseif(_libc STREQUAL "glibc")
-        set(_hash e9b89ff215c56f04249a2169bee15cdae6e61ef913468add258719e8afe6eac2)
+        set(_hash 66094175e4d79b8a7222bc20d9e0d1bfbd37414891f88fc0113da53a97f8896a)
     elseif(_libc STREQUAL "musl")
-        set(_hash 1574e3bbdcac7dae534d783fa6fc6452268240d7477aefd87fadc4e7f705d48e)
+        set(_hash 58daad4a82cf3c511372892dd21b2825fcb138aad22c1db6bc889b1965439f5e)
     else()
         message(FATAL_ERROR "Could not determine libc implementation, unable to install eBPF legacy code.")
     endif()
 
     ExternalProject_Add(
         ebpf-code-legacy
-        URL https://github.com/netdata/kernel-collector/releases/download/v1.4.3/netdata-kernel-collector-${_libc}-v1.4.3.tar.xz
+        URL https://github.com/netdata/kernel-collector/releases/download/v1.4.5/netdata-kernel-collector-${_libc}-v1.4.5.tar.xz
         URL_HASH SHA256=${_hash}
         SOURCE_DIR "${ebpf-legacy_SOURCE_DIR}"
         CONFIGURE_COMMAND ""

--- a/packaging/cmake/Modules/NetdataLibBPF.cmake
+++ b/packaging/cmake/Modules/NetdataLibBPF.cmake
@@ -31,7 +31,7 @@ function(netdata_bundle_libbpf)
     if(USE_LEGACY_LIBBPF)
         set(_libbpf_tag 673424c56127bb556e64095f41fd60c26f9083ec) # v0.0.9_netdata-1
     else()
-        set(_libbpf_tag 3d78a726c618560ad7fb03ceaf0fd03e8b2656b4) # v1.4.3p_netdata
+        set(_libbpf_tag 6923eb970e22682eaedff79f5be4f9934b99cf50) # v1.4.5p_netdata
     endif()
 
     if(DEFINED BUILD_SHARED_LIBS)


### PR DESCRIPTION
##### Summary

This pull request updates Netdata with the latest version of libbpf. While we have changed the way we work with the CentOS 7.x family, this pull request does not affect them, as we use a different libbpf version for CentOS 7.x.

##### Test Plan

1. Compile this branch and there is not error during compilation time.
2. Check `eBPF.plugin` is running.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
