### PR TITLE
Improve windows agent

### DIFF
--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -3,7 +3,7 @@
 
 Name "Netdata"
 Outfile "netdata-installer.exe"
-InstallDir "$PROGRAMFILES\netdata"
+InstallDir "$PROGRAMFILES\Netdata"
 RequestExecutionLevel admin
 
 !define MUI_ICON "NetdataWhite.ico"

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -183,19 +183,19 @@ static DWORD netdata_windows_get_current_build()
 
 static void netdata_windows_discover_os_version(char *os, size_t length, DWORD build)
 {
-    char productName[256];
-    if (!netdata_registry_get_string(productName,
+    char versionName[256];
+    if (!netdata_registry_get_string(versionName,
                                     255,
                                     HKEY_LOCAL_MACHINE,
                                     "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
-                                    "ProductName"))
+                                    "DisplayVersion"))
     {
-        (void)snprintf(os, length, "Windows");
+        (void)snprintf(os, length, "Microsoft Windows");
         return;
     }
 
     if (IsWindowsServer()) {
-        (void)snprintf(os, length, "%s", productName);
+        (void)snprintf(os, length, "Microsoft Windows Version %s", versionName);
         return;
     }
 
@@ -221,7 +221,7 @@ static void netdata_windows_discover_os_version(char *os, size_t length, DWORD b
     }
     // We are not testing older, because it is not supported anymore by Microsoft
 
-    (void)snprintf(os, length, "%s (%s)", productName, version);
+    (void)snprintf(os, length, "Microsoft Windows Version %s, Build %d (%s)", productName, build, version);
 }
 
 static void netdata_windows_os_version(char *out, DWORD length)

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -166,7 +166,6 @@ static void netdata_windows_get_total_disk_size(struct rrdhost_system_info *syst
 // Host
 static DWORD netdata_windows_get_current_build()
 {
-    HKEY hKey;
     char cBuild[64];
     if (!netdata_registry_get_string(
             cBuild, 63, HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", "CurrentBuild"))

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -221,7 +221,7 @@ static void netdata_windows_discover_os_version(char *os, size_t length, DWORD b
     }
     // We are not testing older, because it is not supported anymore by Microsoft
 
-    (void)snprintf(os, length, "Microsoft Windows Version %s, Build %d (Name: Windows %s)", productName, build, version);
+    (void)snprintf(os, length, "Microsoft Windows Version %s, Build %d (Name: Windows %s)", versionName, build, version);
 }
 
 static void netdata_windows_os_version(char *out, DWORD length)

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -221,7 +221,7 @@ static void netdata_windows_discover_os_version(char *os, size_t length, DWORD b
     }
     // We are not testing older, because it is not supported anymore by Microsoft
 
-    (void)snprintf(os, length, "Microsoft Windows Version %s, Build %d (%s)", productName, build, version);
+    (void)snprintf(os, length, "Microsoft Windows Version %s, Build %d (Name: Windows %s)", productName, build, version);
 }
 
 static void netdata_windows_os_version(char *out, DWORD length)

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -183,10 +183,19 @@ static DWORD netdata_windows_get_current_build()
 
 static void netdata_windows_discover_os_version(char *os, size_t length, DWORD build)
 {
-    char *commonName = {"Windows"};
+    char productName[256];
+    if (!netdata_registry_get_string(productName,
+                                    255,
+                                    HKEY_LOCAL_MACHINE,
+                                    "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+                                    "ProductName"))
+    {
+        (void)snprintf(os, length, "Windows");
+        return;
+    }
 
     if (IsWindowsServer()) {
-        (void)snprintf(os, length, "%s Server", commonName);
+        (void)snprintf(os, length, "%s", productName);
         return;
     }
 
@@ -212,7 +221,7 @@ static void netdata_windows_discover_os_version(char *os, size_t length, DWORD b
     }
     // We are not testing older, because it is not supported anymore by Microsoft
 
-    (void)snprintf(os, length, "%s %s Client", commonName, version);
+    (void)snprintf(os, length, "%s (%s)", productName, version);
 }
 
 static void netdata_windows_os_version(char *out, DWORD length)


### PR DESCRIPTION
##### Summary
This PR is bringing two changes for netdata:

- Modify default installation path as required in https://github.com/netdata/netdata/issues/18213.
- Update `os_id` to match `winver.exe` output.

##### Test Plan

1. Compile on Windows and generate the installer.
2. Take a look in default path shown.
3. When installation ends, access `/api/v1/info` and check your `os_id`.


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
