### PR TITLE
Fix up CMake feature handling for Windows.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1065,6 +1065,12 @@ jobs:
         with:
           submodules: recursive
           lfs: true
+      - name: Set Up Go
+        id: golang
+        if: needs.file-check.outputs.run == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version: "^1.22"
       - name: Set Up Dependencies
         id: deps
         if: needs.file-check.outputs.run == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1071,6 +1071,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "^1.22"
+      - name: Set GOROOT
+        id: goroot
+        if: needs.file-check.outputs.run == 'true'
+        run: Add-Content -Path "$env:GITHUB_ENV" -Value "GOROOT=$(go.exe env GOROOT)"
       - name: Set Up Dependencies
         id: deps
         if: needs.file-check.outputs.run == 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,8 @@ endif()
 
 # This is intended to make life easier for developers who are working on one
 # specific feature.
+#
+# NOTE: DO NOT USE THIS OPTION FOR PRODUCTION BUILDS.
 option(DEFAULT_FEATURE_STATE "Specify the default state for most optional features" True)
 mark_as_advanced(DEFAULT_FEATURE_STATE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,10 +151,10 @@ option(ENABLE_ML "Enable machine learning features" ${DEFAULT_FEATURE_STATE})
 option(ENABLE_DBENGINE "Enable dbengine metrics storage" True)
 
 # Data collection plugins
-option(ENABLE_PLUGIN_APPS "Enable per-process resource usage monitoring" ${DEFAULT_FEATURE_STATE})
 option(ENABLE_PLUGIN_GO "Enable metric collectors written in Go" ${DEFAULT_FEATURE_STATE})
 
-cmake_dependent_option(ENABLE_PLUGIN_CUPS "Enable CUPS monitoring" ${DEFAULT_FEATURE_STATE} "OS_LINUX OR OS_FREEBSD OR OS_MACOS" False)
+cmake_dependent_option(ENABLE_PLUGIN_APPS "Enable per-process resource usage monitoring" ${DEFAULT_FEATURE_STATE} "NOT OS_WINDOWS" False)
+cmake_dependent_option(ENABLE_PLUGIN_CUPS "Enable CUPS monitoring" ${DEFAULT_FEATURE_STATE} "NOT OS_WINDOWS" False)
 
 cmake_dependent_option(ENABLE_PLUGIN_FREEIPMI "Enable IPMI monitoring" ${DEFAULT_FEATURE_STATE} "OS_LINUX OR OS_FREEBSD" False)
 

--- a/packaging/cmake/Modules/FindGo.cmake
+++ b/packaging/cmake/Modules/FindGo.cmake
@@ -15,8 +15,21 @@ if(GO_FOUND)
     return()
 endif()
 
-# Two passes are needed here so that we prefer a copy in `/usr/local/go/bin` over a system copy.
-find_program(GO_EXECUTABLE go PATHS /usr/local/go/bin DOC "Go toolchain" NO_DEFAULT_PATH)
+# The complexity below is needed to account for the complex rules we use for finding the Go install.
+#
+# If GOROOT is set, we honor that. Otherwise, we check known third-party install paths for the platform in question
+# and fall back to looking in PATH. For the specific case of MSYS2, we prefer a Windows install over an MSYS2 install.
+if(DEFINED $ENV{GOROOT})
+  find_program(GO_EXECUTABLE go PATHS "$ENV{GOROOT}/bin" DOC "Go toolchain" NO_DEFAULT_PATH)
+elseif(OS_WINDOWS)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    find_program(GO_EXECUTABLE go PATHS C:/go/bin "C:/Program Files/go/bin" DOC "Go toolchain" NO_DEFAULT_PATH)
+  else()
+    find_program(GO_EXECUTABLE go PATHS /c/go/bin "/c/Program Files/go/bin" /mingw64/bin /ucrt64/bin /clang64/bin DOC "Go toolchain" NO_DEFAULT_PATH)
+  endif()
+else()
+  find_program(GO_EXECUTABLE go PATHS /usr/local/go/bin DOC "Go toolchain" NO_DEFAULT_PATH)
+endif()
 find_program(GO_EXECUTABLE go DOC "Go toolchain")
 
 if (GO_EXECUTABLE)

--- a/packaging/windows/compile-on-windows.sh
+++ b/packaging/windows/compile-on-windows.sh
@@ -40,11 +40,12 @@ ${GITHUB_ACTIONS+echo "::group::Configuring"}
     -DCMAKE_C_FLAGS="-fstack-protector-all -O0 -ggdb -Wall -Wextra -Wno-char-subscripts -Wa,-mbig-obj -pipe -DNETDATA_INTERNAL_CHECKS=1 -D_FILE_OFFSET_BITS=64 -D__USE_MINGW_ANSI_STDIO=1" \
     -DBUILD_FOR_PACKAGING=On \
     -DNETDATA_USER="${USER}" \
-    -DENABLE_PLUGIN_GO=On \
-    -DENABLE_H2O=Off \
     -DENABLE_ACLK=On \
     -DENABLE_CLOUD=On \
+    -DENABLE_H2O=Off \
     -DENABLE_ML=On \
+    -DENABLE_PLUGIN_GO=On \
+    -DENABLE_EXPORTER_PROMETHEUS_REMOTE_WRITE=Off \
     -DENABLE_BUNDLED_JSONC=On \
     -DENABLE_BUNDLED_PROTOBUF=Off \
     ${EXTRA_CMAKE_OPTIONS:-}

--- a/packaging/windows/compile-on-windows.sh
+++ b/packaging/windows/compile-on-windows.sh
@@ -40,7 +40,7 @@ ${GITHUB_ACTIONS+echo "::group::Configuring"}
     -DCMAKE_C_FLAGS="-fstack-protector-all -O0 -ggdb -Wall -Wextra -Wno-char-subscripts -Wa,-mbig-obj -pipe -DNETDATA_INTERNAL_CHECKS=1 -D_FILE_OFFSET_BITS=64 -D__USE_MINGW_ANSI_STDIO=1" \
     -DBUILD_FOR_PACKAGING=On \
     -DNETDATA_USER="${USER}" \
-    -DDEFAULT_FEATURE_STATE=Off \
+    -DENABLE_PLUGIN_GO=On \
     -DENABLE_H2O=Off \
     -DENABLE_ACLK=On \
     -DENABLE_CLOUD=On \


### PR DESCRIPTION
##### Summary

This gets rid of `-DDEFAULT_FEATURE_STATE` in our Windows build CMake options (this option was _NEVER_ intended to be used for anything but testing), enables the Go plugin, and hard-disables the known non-working Apps plugin on Windows.

##### Test Plan

CI passes on this PR.

##### Additional Information

Relevant to: #18213 