### PR TITLE
Windows build fix

### DIFF
--- a/packaging/windows/compile-on-windows.sh
+++ b/packaging/windows/compile-on-windows.sh
@@ -23,10 +23,18 @@ if [ -d "${build}" ]; then
 	rm -rf "${build}"
 fi
 
+generator="Unix Makefiles"
+build_args="-j $(nproc)"
+
+if command -v ninja >/dev/null 2>&1; then
+    generator="Ninja"
+    build_args="-k 1"
+fi
+
 ${GITHUB_ACTIONS+echo "::group::Configuring"}
 # shellcheck disable=SC2086
 /usr/bin/cmake -S "${repo_root}" -B "${build}" \
-    -G Ninja \
+    -G "${generator}" \
     -DCMAKE_INSTALL_PREFIX="/opt/netdata" \
     -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
     -DCMAKE_C_FLAGS="-fstack-protector-all -O0 -ggdb -Wall -Wextra -Wno-char-subscripts -Wa,-mbig-obj -pipe -DNETDATA_INTERNAL_CHECKS=1 -D_FILE_OFFSET_BITS=64 -D__USE_MINGW_ANSI_STDIO=1" \
@@ -39,15 +47,16 @@ ${GITHUB_ACTIONS+echo "::group::Configuring"}
     -DENABLE_ML=On \
     -DENABLE_BUNDLED_JSONC=On \
     -DENABLE_BUNDLED_PROTOBUF=Off \
-    ${EXTRA_CMAKE_OPTIONS:-''}
+    ${EXTRA_CMAKE_OPTIONS:-}
 ${GITHUB_ACTIONS+echo "::endgroup::"}
 
 ${GITHUB_ACTIONS+echo "::group::Building"}
-ninja -C "${build}" -k 1
+# shellcheck disable=SC2086
+cmake --build "${build}" -- ${build_args}
 ${GITHUB_ACTIONS+echo "::endgroup::"}
 
 if [ -t 1 ]; then
     echo
     echo "Compile with:"
-    echo "ninja -v -C \"${build}\" || ninja -v -C \"${build}\" -j 1"
+    echo "cmake --build \"${build}\""
 fi

--- a/packaging/windows/msys2-dependencies.sh
+++ b/packaging/windows/msys2-dependencies.sh
@@ -36,7 +36,6 @@ pacman -S --noconfirm \
     msys/libuv-devel \
     msys/pcre2-devel \
     msys/zlib-devel \
-    ninja \
     openssl-devel \
     protobuf-devel \
     python \

--- a/packaging/windows/package-windows.sh
+++ b/packaging/windows/package-windows.sh
@@ -19,7 +19,7 @@ fi
 set -exu -o pipefail
 
 ${GITHUB_ACTIONS+echo "::group::Installing"}
-ninja -C "${build}" -k 1 install
+cmake --install "${build}"
 ${GITHUB_ACTIONS+echo "::endgroup::"}
 
 if [ ! -f "/msys2-installer.exe" ]; then


### PR DESCRIPTION
##### Summary

Instead of hard depending on Ninja for the Windows build, use it if available but still allow usage of Make if not. Also, skip installing Ninja by default as a dependency. This works around an issue with either MSYS2 or CMake as provided by MSYS2 in the GitHub Actions runners that is causing the build to fail during configuration.

While it’s theoretically preferable that we use Ninja for build performance, the CI process for Windows is already horribly dominated by the dependency handling step due to inefficiencies in pacman, so the overall relatively small difference in build time should be a non-issue.

##### Test Plan

Windows CI passes on this PR.