### PR TITLE
Clean up unneeded depencdencies.

### DIFF
--- a/packaging/installer/dependencies/alpine.sh
+++ b/packaging/installer/dependencies/alpine.sh
@@ -9,33 +9,27 @@ DONT_WAIT=0
 
 package_tree="
   alpine-sdk
-  coreutils
-  git
-  gcc
-  g++
-  automake
-  autoconf
   cmake
-  make
-  libatomic
-  libtool
-  pkgconfig
-  tar
+  coreutils
   curl
+  elfutils-dev
+  g++
+  gcc
+  git
   gzip
+  json-c-dev
+  libatomic
+  libmnl-dev
   libuv-dev
   lz4-dev
+  make
   openssl-dev
-  elfutils-dev
+  pkgconfig
   python3
-  zlib-dev
+  tar
   util-linux-dev
-  libmnl-dev
-  json-c-dev
-  musl-fts-dev
-  bison
-  flex
   yaml-dev
+  zlib-dev
   "
 
 usage() {

--- a/packaging/installer/dependencies/arch.sh
+++ b/packaging/installer/dependencies/arch.sh
@@ -8,32 +8,25 @@ NON_INTERACTIVE=0
 DONT_WAIT=0
 
 declare -a package_tree=(
-  gcc
-  make
-  autoconf
-  autoconf-archive
-  autogen
-  automake
-  libtool
-  cmake
-  zlib
-  util-linux
-  libmnl
-  json-c
-  libyaml
-  libuv
-  lz4
-  openssl
-  libelf
-  git
-  pkgconfig
-  tar
-  curl
-  gzip
-  python3
   binutils
-  bison
-  flex
+  cmake
+  curl
+  gcc
+  git
+  gzip
+  json-c
+  libelf
+  libmnl
+  libuv
+  libyaml
+  lz4
+  make
+  openssl
+  pkgconfig
+  python3
+  tar
+  util-linux
+  zlib
 )
 
 usage() {

--- a/packaging/installer/dependencies/centos.sh
+++ b/packaging/installer/dependencies/centos.sh
@@ -5,15 +5,9 @@
 set -e
 
 declare -a package_tree=(
-  autoconf
-  autoconf-archive
-  automake
-  bison
   cmake
-  cmake3
   curl
   elfutils-libelf-devel
-  flex
   findutils
   gcc
   gcc-c++
@@ -22,7 +16,6 @@ declare -a package_tree=(
   json-c-devel
   libatomic
   libmnl-devel
-  libtool
   libuuid-devel
   libuv-devel
   libyaml-devel

--- a/packaging/installer/dependencies/debian.sh
+++ b/packaging/installer/dependencies/debian.sh
@@ -8,14 +8,8 @@ NON_INTERACTIVE=0
 DONT_WAIT=0
 
 package_tree="
-  autoconf
-  autoconf-archive
-  autogen
-  automake
-  bison
   cmake
   curl
-  flex
   g++
   gcc
   git
@@ -27,12 +21,10 @@ package_tree="
   libmnl-dev
   libssl-dev
   libsystemd-dev
-  libtool
   libuv1-dev
   libyaml-dev
   make
   pkg-config
-  python
   python3
   tar
   uuid-dev

--- a/packaging/installer/dependencies/fedora.sh
+++ b/packaging/installer/dependencies/fedora.sh
@@ -17,23 +17,11 @@ os_version() {
   fi
 }
 
-if [[ $(os_version) -gt 24 ]]; then
-  ulogd_pkg=
-else
-  ulogd_pkg=ulogd
-fi
-
 declare -a package_tree=(
-  autoconf
-  autoconf-archive
-  autogen
-  automake
-  bison
   cmake
   curl
   elfutils-libelf-devel
   findutils
-  flex
   gcc
   gcc-c++
   git
@@ -41,7 +29,6 @@ declare -a package_tree=(
   json-c-devel
   libatomic
   libmnl-devel
-  libtool
   libuuid-devel
   libuv-devel
   libyaml-devel
@@ -53,7 +40,6 @@ declare -a package_tree=(
   systemd-devel
   tar
   zlib-devel
-  "${ulogd_pkg}"
 )
 
 usage() {

--- a/packaging/installer/dependencies/freebsd.sh
+++ b/packaging/installer/dependencies/freebsd.sh
@@ -8,26 +8,19 @@ NON_INTERACTIVE=0
 DONT_WAIT=0
 
 package_tree="
-  git
-  autoconf
-  autoconf-archive
-  autogen
-  automake
-  libtool
-  pkgconf
   cmake
   curl
-  gzip
-  lzlib
   e2fsprogs-libuuid
+  git
+  gzip
   json-c
-  libyaml
-  libuv
   liblz4
+  libuv
+  libyaml
+  lzlib
   openssl
+  pkgconf
   python3
-  bison
-  flex
   "
 
 prompt() {

--- a/packaging/installer/dependencies/gentoo.sh
+++ b/packaging/installer/dependencies/gentoo.sh
@@ -8,32 +8,26 @@ NON_INTERACTIVE=0
 DONT_WAIT=0
 
 package_tree="
+  app-alternatives/gzip
+  app-alternatives/tar
+  app-arch/lz4
+  dev-lang/python
+  dev-libs/json-c
+  dev-libs/libuv
+  dev-libs/libyaml
+  dev-libs/openssl
+  dev-util/cmake
   dev-vcs/git
+  net-libs/libmnl
+  net-misc/curl
   sys-apps/findutils
+  sys-apps/util-linux
   sys-devel/gcc
   sys-devel/make
-  sys-devel/autoconf
-  sys-devel/autoconf-archive
-  sys-devel/autogen
-  sys-devel/automake
-  virtual/pkgconfig
-  dev-util/cmake
-  app-arch/tar
-  net-misc/curl
-  app-arch/gzip
-  sys-apps/util-linux
-  net-libs/libmnl
-  dev-libs/json-c
-  dev-libs/libyaml
-  dev-libs/libuv
-  app-arch/lz4
-  dev-libs/openssl
   virtual/libelf
-  dev-lang/python
-  dev-libs/libuv
-  sys-devel/bison
-  sys-devel/flex
+  virtual/pkgconfig
   "
+
 usage() {
   cat << EOF
 OPTIONS:

--- a/packaging/installer/dependencies/ol.sh
+++ b/packaging/installer/dependencies/ol.sh
@@ -8,15 +8,9 @@ NON_INTERACTIVE=0
 DONT_WAIT=0
 
 declare -a package_tree=(
-  autoconf
-  autoconf-archive
-  autogen
-  automake
-  bison
   cmake
   curl
   elfutils-libelf-devel
-  flex
   gcc
   gcc-c++
   git
@@ -24,7 +18,6 @@ declare -a package_tree=(
   json-c-devel
   libatomic
   libmnl-devel
-  libtool
   libuuid-devel
   libuv-devel
   libyaml-devel

--- a/packaging/installer/dependencies/opensuse.sh
+++ b/packaging/installer/dependencies/opensuse.sh
@@ -10,14 +10,8 @@ NON_INTERACTIVE=0
 DONT_WAIT=0
 
 declare -a package_tree=(
-  autoconf
-  autoconf-archive
-  autogen
-  automake
-  bison
   cmake
   curl
-  flex
   gcc
   gcc-c++
   git
@@ -28,7 +22,6 @@ declare -a package_tree=(
   liblz4-devel
   libmnl-devel
   libopenssl-devel
-  libtool
   libuuid-devel
   libuv-devel
   libyaml-devel

--- a/packaging/installer/dependencies/rockylinux.sh
+++ b/packaging/installer/dependencies/rockylinux.sh
@@ -8,16 +8,10 @@ NON_INTERACTIVE=0
 DONT_WAIT=0
 
 declare -a package_tree=(
-  autoconf
-  autoconf-archive
-  autogen
-  automake
-  bison
   cmake
   curl
   elfutils-libelf-devel
   findutils
-  flex
   gcc
   gcc-c++
   git
@@ -25,7 +19,6 @@ declare -a package_tree=(
   json-c-devel
   libatomic
   libmnl-devel
-  libtool
   libuuid-devel
   libuv-devel
   libyaml-devel

--- a/packaging/installer/dependencies/ubuntu.sh
+++ b/packaging/installer/dependencies/ubuntu.sh
@@ -8,14 +8,8 @@ NON_INTERACTIVE=0
 DONT_WAIT=0
 
 package_tree="
-  autoconf
-  autoconf-archive
-  autogen
-  automake
-  bison
   cmake
   curl
-  flex
   g++
   gcc
   git
@@ -27,7 +21,6 @@ package_tree="
   libmnl-dev
   libssl-dev
   libsystemd-dev
-  libtool
   libuv1-dev
   libyaml-dev
   make

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -632,72 +632,10 @@ declare -A pkg_coreutils=(
   ['default']="NOTREQUIRED"
 )
 
-declare -A pkg_autoconf=(
-  ['gentoo']="sys-devel/autoconf"
-  ['clearlinux']="c-basic"
-  ['default']="autoconf"
-)
-
-# required to compile netdata with --enable-sse
-# https://github.com/firehol/netdata/pull/450
-declare -A pkg_autoconf_archive=(
-  ['gentoo']="sys-devel/autoconf-archive"
-  ['clearlinux']="c-basic"
-  ['alpine']="WARNING|"
-  ['default']="autoconf-archive"
-
-  # exceptions
-  ['centos-6']="WARNING|"
-  ['rhel-6']="WARNING|"
-  ['rhel-7']="WARNING|"
-)
-
-declare -A pkg_autogen=(
-  ['gentoo']="sys-devel/autogen"
-  ['clearlinux']="c-basic"
-  ['alpine']="WARNING|"
-  ['default']="autogen"
-
-  # exceptions
-  ['centos-6']="WARNING|"
-  ['rhel-6']="WARNING|"
-  ['centos-9']="NOTREQUIRED|"
-  ['rhel-9']="NOTREQUIRED|"
-)
-
-declare -A pkg_automake=(
-  ['gentoo']="sys-devel/automake"
-  ['clearlinux']="c-basic"
-  ['default']="automake"
-)
-
-# Required to build libwebsockets and libmosquitto on some systems.
 declare -A pkg_cmake=(
   ['gentoo']="dev-util/cmake"
   ['clearlinux']="c-basic"
   ['default']="cmake"
-)
-
-# bison and flex are required by Fluent-Bit
-declare -A pkg_bison=(
-  ['default']="bison"
-)
-
-declare -A pkg_flex=(
-  ['default']="flex"
-)
-
-# fts-dev is required by Fluent-Bit on Alpine
-declare -A pkg_fts_dev=(
-  ['default']="NOTREQUIRED"
-  ['alpine']="musl-fts-dev" 
-  ['alpine-3.16.9']="fts-dev"
-)
-
-# cmake3 is required by Fluent-Bit on CentOS 7
-declare -A pkg_cmake3=(
-  ['default']="NOTREQUIRED"
-  ['centos-7']="cmake3"
 )
 
 declare -A pkg_json_c_dev=(
@@ -772,13 +710,13 @@ declare -A pkg_curl=(
 )
 
 declare -A pkg_gzip=(
-  ['gentoo']="app-arch/gzip"
+  ['gentoo']="app-alternatives/gzip"
   ['macos']="NOTREQUIRED"
   ['default']="gzip"
 )
 
 declare -A pkg_tar=(
-  ['gentoo']="app-arch/tar"
+  ['gentoo']="app-alternatives/tar"
   ['clearlinux']="os-core-update"
   ['macos']="NOTREQUIRED"
   ['freebsd']="NOTREQUIRED"
@@ -1249,14 +1187,9 @@ packages() {
     require_cmd gcc-multilib || suitable_package gcc
   require_cmd g++ || require_cmd clang++ || suitable_package gxx
 
-  require_cmd make || suitable_package make
-  require_cmd autoconf || suitable_package autoconf
-  suitable_package autoconf-archive
-  require_cmd autogen || suitable_package autogen
-  require_cmd automake || suitable_package automake
   require_cmd pkg-config || suitable_package pkg-config
   require_cmd cmake || suitable_package cmake
-  require_cmd cmake3 || suitable_package cmake3
+  require_cmd make || suitable_package make
 
   # -------------------------------------------------------------------------
   # debugging tools for development
@@ -1279,8 +1212,6 @@ packages() {
     require_cmd tar || suitable_package tar
     require_cmd curl || suitable_package curl
     require_cmd gzip || suitable_package gzip
-    require_cmd bison || suitable_package bison
-    require_cmd flex || suitable_package flex
   fi
 
   # -------------------------------------------------------------------------
@@ -1312,7 +1243,6 @@ packages() {
     suitable_package libuuid-dev
     suitable_package libmnl-dev
     suitable_package json-c-dev
-    suitable_package fts-dev
     suitable_package libyaml-dev
     suitable_package libsystemd-dev
     suitable_package pcre2
@@ -1348,9 +1278,6 @@ packages() {
 
   if [ "${PACKAGES_NETDATA_PYTHON}" -ne 0 ]; then
     require_cmd python || suitable_package python
-
-    # suitable_package python-requests
-    # suitable_package python-pip
   fi
 
   # -------------------------------------------------------------------------
@@ -1358,9 +1285,6 @@ packages() {
 
   if [ "${PACKAGES_NETDATA_PYTHON3}" -ne 0 ]; then
     require_cmd python3 || suitable_package python3
-
-    # suitable_package python3-requests
-    # suitable_package python3-pip
   fi
 
   # -------------------------------------------------------------------------


### PR DESCRIPTION
##### Summary

This removes the following dependencies from our dependency handling scripts, as they are no longer needed:

- automake
- autoconf
- autoconf-archive
- autogen
- bison
- flex
- libtool

It also ensures proper sorting of dependencies in most of the scripts, drops a few platform-specific dependencies we don’t really need anymore, and updates the Gentoo dependencies for gzip/tar to use the newer `app-alternatives` packages for those commands (thus ensuring consistency with best-current-practices for packaging on Gentoo).

##### Test Plan

CI passes on this PR.