### PR TITLE
Add detailed reporting of failed checksums in kickstart script.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -743,8 +743,6 @@ get_redirect() {
 }
 
 safe_sha256sum() {
-  # Within the context of the installer, we only use -c option that is common between the two commands
-  # We will have to reconsider if we start using non-common options
   if command -v shasum > /dev/null 2>&1; then
     shasum -a 256 "$@"
   elif command -v sha256sum > /dev/null 2>&1; then
@@ -752,6 +750,17 @@ safe_sha256sum() {
   else
     fatal "Could not find a usable checksum tool. Either sha256sum, or a version of shasum supporting SHA256 checksums is required to proceed with installation." F0004
   fi
+}
+
+report_bad_sha256sum() {
+    file="${1}"
+    sums="${2}"
+
+    actual="$(safe_sha256sum "${file}" | awk '{ print $1 }')"
+    expected="$(grep "${file}" "${sums}" | awk '{ print $1 }')"
+
+    printf "Expected: %s\n" "${expected}"
+    printf "Actual: %s\n" "${actual}"
 }
 
 get_system_info() {
@@ -1809,7 +1818,8 @@ try_static_install() {
   else
     if [ -z "${INSTALL_VERSION}" ]; then
       if ! grep "${netdata_agent}" ./sha256sum.txt | safe_sha256sum -c - > /dev/null 2>&1; then
-        fatal "Static binary checksum validation failed. ${BADCACHE_MSG}." F0207
+        bad_sums_report="$(report_bad_sha256sum "${netdata_agent}" "./sha256sum.txt")"
+        fatal "Static binary checksum validation failed.\n${bad_sums_report}\n${BADCACHE_MSG}." F0207
       fi
     fi
   fi
@@ -1984,7 +1994,8 @@ try_build_install() {
     if [ -z "${INSTALL_VERSION}" ]; then
       # shellcheck disable=SC2086
       if ! grep netdata-latest.tar.gz "./sha256sum.txt" | safe_sha256sum -c - > /dev/null 2>&1; then
-        fatal "Tarball checksum validation failed. ${BADCACHE_MSG}." F0005
+        bad_sums_report="$(report_bad_sha256sum netdata-latest.tar.gz "./sha256sum.txt")"
+        fatal "Tarball checksum validation failed.\n${bad_sums_report}\n${BADCACHE_MSG}." F0005
       fi
     fi
   fi
@@ -2077,8 +2088,16 @@ prepare_offline_install_source() {
 
   if [ "${DRY_RUN}" -ne 1 ]; then
     progress "Verifying checksums."
-    if ! grep -e "$(find . -name '*.gz.run')" sha256sums.txt | safe_sha256sum -c -; then
-      fatal "Checksums for offline install files are incorrect. ${BADCACHE_MSG}." F0507
+
+    failed_files=""
+    for file in $(find . -name '*.gz.run'); do
+      if ! grep -e "${file}" sha256sums.txt | safe_sha256sum -c -; then
+        failed_files="${failed_files}\n${file}\n$(report_bad_sha256sums "${file}" sha256sums.txt)"
+      fi
+    done
+
+    if [ -n "${failed_files}" ]; then
+      fatal "Checksums for offline install files are incorrect.\n${failed_files}\n${BADCACHE_MSG}." F0507
     fi
   else
     progress "Would verify SHA256 checksums of downloaded installation files."

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -455,7 +455,7 @@ deferred_warnings() {
 
 fatal() {
   deferred_warnings
-  printf >&2 "%s\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ABORTED ${TPUT_RESET} ${1}"
+  printf >&2 "%b\n\n" "${TPUT_BGRED}${TPUT_WHITE}${TPUT_BOLD} ABORTED ${TPUT_RESET} ${1}"
   printf >&2 "%s\n" "For community support, you can connect with us on:"
   support_list
   telemetry_event "INSTALL_FAILED" "${1}" "${2}"


### PR DESCRIPTION
##### Summary

This adds info to the failure messages in the kickstart script to report the expected and actual checksum when a file fails validation. This allows us to verify if the issue is more likely to be a problem of at-rest data corruption, or something with the data transport mangling the data.

##### Test Plan

n/a