### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,13 @@
   <br />
   <a href="https://bestpractices.coreinfrastructure.org/projects/2231"><img src="https://bestpractices.coreinfrastructure.org/projects/2231/badge" alt="CII Best Practices"></a>
   <a href="https://scan.coverity.com/projects/netdata-netdata?tab=overview"><img alt="Coverity Scan" src="https://img.shields.io/coverity/scan/netdata"></a>
-  <a href="https://www.gnu.org/licenses/gpl-3.0"><img src="https://img.shields.io/badge/License-GPL%20v3%2B-blue.svg" alt="License: GPL v3+"></a>
   <br />
   <a href="https://community.netdata.cloud"><img alt="Discourse topics" src="https://img.shields.io/discourse/topics?server=https%3A%2F%2Fcommunity.netdata.cloud%2F&logo=discourse&label=discourse%20forum"></a>
   <a href="https://github.com/netdata/netdata/discussions"><img alt="GitHub Discussions" src="https://img.shields.io/github/discussions/netdata/netdata?logo=github&label=github%20discussions"></a>
+  <br />
+  <a href="https://www.gnu.org/licenses/gpl-3.0"><img src="https://img.shields.io/badge/License-GPL%20v3%2B-blue.svg" alt="License: GPL v3+"></a>
+  <br />
+  <a href="https://github.com/netdata/netdata/tree/master/src/web/gui/v2">V2 Dashboard is <img src="https://img.shields.io/badge/License-Closed%20Source-red" alt="License: Closed Source"></a>
 </p>
 
 <p align="center"><b>Visit the <a href="https://www.netdata.cloud">Project's Home Page</a></b></p>


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

Fixes: The project stating it has a GPL3 License, while it is partially closed source.
Especially since there is no GPL-only build provided to run by netdata, while the default build loads the built blobs straight from a cdn by default.

Please either add this, or add clarifying info how to produce a Build that is free of the closed V2 Dashboard for distributors.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

None needed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
This change merely correctly lists the Fact that netdata is locking Features behind login/paywalls that are closed source and community unfixable, yet extremely desirable by homelabbers and open source enthusiasts wanting to use netdata. 

It would either correct the license display, or - if you add an option to build without the option of using and including v2 - produce an actually FLOSS edition that is worthy of the GPL label.
</details>
