### PR TITLE
fix sending CLEAR notifications with critical severity modifier

### DIFF
--- a/src/health/notifications/alarm-notify.sh.in
+++ b/src/health/notifications/alarm-notify.sh.in
@@ -641,8 +641,12 @@ filter_recipient_by_criticality() {
       ;;
 
     CLEAR)
-      # remove tracking file
-      [ -f "${tracking_file}" ] && rm "${tracking_file}"
+      if [ -f "${tracking_file}" ]; then
+        tracking_file_existed="yes"
+        rm "${tracking_file}"
+      else
+        tracking_file_existed=""
+      fi
 
       # "noclear" modifier set, block notification
       if [ "${mod_noclear}" == "1" ]; then
@@ -657,7 +661,7 @@ filter_recipient_by_criticality() {
       fi
 
       # "critical" modifier set, send notification if tracking file exists
-      if [ "${mod_critical}" == "1" ] && [ -f "${tracking_file}" ]; then
+      if [ "${mod_critical}" == "1" ] && [ -n "${tracking_file_existed}" ]; then
         debug "SEVERITY FILTERING for ${recipient_arg} VIA ${method}: ALLOW: recipient has been notified for this alarm in the past (no status change will be sent from now)"
         return 0
       fi


### PR DESCRIPTION
##### Summary

The issue is [reported on Discord](https://discord.com/channels/847502280503590932/1273564499374247968/1273564499374247968).

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
