### PR TITLE
Add missing initial slashes for internal documation links

### DIFF
--- a/docs/deployment-guides/deployment-strategies.md
+++ b/docs/deployment-guides/deployment-strategies.md
@@ -16,7 +16,7 @@ The stand-alone setup is configured out of the box with reasonable defaults, but
 
 ### Parent – Child
 
-For setups involving Parent and Child Agents, they need to be configured for [streaming](docs/observability-centralization-points/metrics-centralization-points/configuration.md), through the configuration file `stream.conf`.
+For setups involving Parent and Child Agents, they need to be configured for [streaming](/docs/observability-centralization-points/metrics-centralization-points/configuration.md), through the configuration file `stream.conf`.
 
 This will instruct the Child to stream data to the Parent and the Parent to accept streaming connections for one or more Child Agents. To secure this connection, both need a shared API key (to replace the string `API_KEY` in the examples below). Additionally, the Child can be configured with one or more addresses of Parent Agents (`PARENT_IP_ADDRESS`).
 
@@ -32,7 +32,7 @@ In this example, Machine Learning and Alerting are disabled for the Child, so th
 
 ##### netdata.conf
 
-On the child node, edit `netdata.conf` by using the [edit-config](docs/netdata-agent/configuration/README.md#edit-netdataconf) script and set the following parameters:
+On the child node, edit `netdata.conf` by using the [edit-config](/docs/netdata-agent/configuration/README.md#edit-netdataconf) script and set the following parameters:
 
 ```yaml
 [db]
@@ -63,7 +63,7 @@ On the child node, edit `netdata.conf` by using the [edit-config](docs/netdata-a
 
 ##### stream.conf
 
-To edit `stream.conf`, use again the [edit-config](docs/netdata-agent/configuration/README.md#edit-netdataconf) script and set the following parameters:
+To edit `stream.conf`, use again the [edit-config](/docs/netdata-agent/configuration/README.md#edit-netdataconf) script and set the following parameters:
 
 ```yaml
 [stream]
@@ -90,7 +90,7 @@ Requiring:
 
 ##### netdata.conf
 
-On the Parent, edit `netdata.conf` by using the [edit-config](docs/netdata-agent/configuration/README.md#edit-netdataconf) script and set the following parameters:
+On the Parent, edit `netdata.conf` by using the [edit-config](/docs/netdata-agent/configuration/README.md#edit-netdataconf) script and set the following parameters:
 
 ```yaml
 [db]
@@ -125,7 +125,7 @@ On the Parent, edit `netdata.conf` by using the [edit-config](docs/netdata-agent
 
 ##### stream.conf
 
-On the Parent node, edit `stream.conf` by using the [edit-config](docs/netdata-agent/configuration/README.md#edit-netdataconf) script and set the following parameters:
+On the Parent node, edit `stream.conf` by using the [edit-config](/docs/netdata-agent/configuration/README.md#edit-netdataconf) script and set the following parameters:
 
 ```yaml
 [API_KEY]
@@ -137,7 +137,7 @@ On the Parent node, edit `stream.conf` by using the [edit-config](docs/netdata-a
 
 In order to setup active–active streaming between Parent 1 and Parent 2, Parent 1 needs to be instructed to stream data to Parent 2 and Parent 2 to stream data to Parent 1. The Child Agents need to be configured with the addresses of both Parent Agents. An Agent will only connect to one Parent at a time, falling back to the next upon failure. These examples use the same API key between Parent Agents and for connections for Child Agents.
 
-On both Netdata Parent and all Child Agents, edit `stream.conf` by using the [edit-config](docs/netdata-agent/configuration/README.md#edit-netdataconf) script:
+On both Netdata Parent and all Child Agents, edit `stream.conf` by using the [edit-config](/docs/netdata-agent/configuration/README.md#edit-netdataconf) script:
 
 #### stream.conf on Parent 1
 

--- a/docs/metric-correlations.md
+++ b/docs/metric-correlations.md
@@ -52,7 +52,7 @@ When a Metric Correlations request is made to Netdata Cloud, if any node instanc
 
 ## Usage tips
 
-- When running Metric Correlations from the [Metrics tab](docs/dashboards-and-charts/metrics-tab-and-single-node-tabs.md) across multiple nodes, you might find better results if you iterate on the initial results by grouping by node to then filter to nodes of interest and rerun the Metric Correlations. So a typical workflow in this case would be to:
+- When running Metric Correlations from the [Metrics tab](/docs/dashboards-and-charts/metrics-tab-and-single-node-tabs.md) across multiple nodes, you might find better results if you iterate on the initial results by grouping by node to then filter to nodes of interest and rerun the Metric Correlations. So a typical workflow in this case would be to:
   - If unsure which nodes you are interested in then run MC on all nodes.
   - Within the initial results returned group the most interesting chart by node to see if the changes are across all nodes or a subset of nodes.
   - If you see a subset of nodes clearly jump out when you group by node, then filter for just those nodes of interest and run the MC again. This will result in less aggregation needing to be done by Netdata and so should help give clearer results as you interact with the slider.


### PR DESCRIPTION
##### Summary

Some links, particularly in the deployment guides, were broken due to a missing initial slash in the link target.
 
##### Test Plan

Verify that the newly generated docs have the affected links work properly, as well as in the GitHub repo browser.