### PR TITLE
eBPF (reduce CPU and memory usage)

### DIFF
--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -3037,6 +3037,7 @@ static void ebpf_set_global_variables()
     isrh = get_redhat_release();
     pid_max = os_get_system_pid_max();
     running_on_kernel = ebpf_get_kernel_version();
+    memset(pids_fd, -1, sizeof(pids_fd));
 }
 
 /**

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -320,6 +320,8 @@ struct ebpf_target
 
 size_t apps_groups_targets_count = 0; // # of apps_groups.conf targets
 
+int pids_fd[EBPF_PIDS_END_IDX];
+
 // ----------------------------------------------------------------------------
 // internal counters
 

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -746,6 +746,10 @@ void ebpf_del_pid_entry(pid_t pid)
     if (p->prev)
         p->prev->next = p->next;
 
+
+    if (p->thread_collecting & EBPF_PIDS_PROC_FILE)
+        ebpf_all_pids_count--;
+
     memset(p, 0, sizeof(ebpf_pid_data_t));
 
     rw_spinlock_write_lock(&ebpf_judy_pid.index.rw_spinlock);
@@ -765,8 +769,6 @@ void ebpf_del_pid_entry(pid_t pid)
         JudyLDel(&ebpf_judy_pid.index.JudyLArray, p->pid, PJE0);
     }
     rw_spinlock_write_unlock(&ebpf_judy_pid.index.rw_spinlock);
-
-    ebpf_all_pids_count--;
 }
 
 /**

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -956,7 +956,7 @@ end_process_loop:
  */
 void ebpf_parse_proc_files()
 {
-    ebpf_pid_data_t *pids = ebpf_pids_link_list;
+    ebpf_pid_data_t *pids;
     for (pids = ebpf_pids_link_list; pids;) {
         if (kill(pids->pid, 0)) { // No PID found
             ebpf_pid_data_t *next = pids->next;

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -542,7 +542,7 @@ static inline int ebpf_collect_data_for_pid(pid_t pid)
         return 0;
     }
 
-    ebpf_pid_data_t *p = ebpf_get_pid_data((uint32_t)pid, 0, NULL, EBPF_OPTION_ALL_CHARTS);
+    ebpf_pid_data_t *p = ebpf_get_pid_data((uint32_t)pid, 0, NULL, EBPF_PIDS_PROC_FILE);
     read_proc_pid_stat(p);
 
     // check its parent pid

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -880,7 +880,7 @@ void ebpf_process_sum_values_for_pids(ebpf_process_stat_t *process, struct ebpf_
     memset(process, 0, sizeof(ebpf_process_stat_t));
     for (; root; root = root->next) {
         int32_t pid = root->pid;
-        ebpf_pid_data_t *local_pid = ebpf_get_pid_data(pid, 0, NULL, EBPF_MODULE_PROCESS_IDX);
+        ebpf_pid_data_t *local_pid = ebpf_get_pid_data(pid, 0, NULL, EBPF_PIDS_PROCESS_IDX);
         ebpf_publish_process_t *in = local_pid->process;
         if (!in)
             continue;
@@ -908,6 +908,7 @@ void collect_data_for_all_processes(int tbl_pid_stats_fd, int maps_per_core, uin
     if (tbl_pid_stats_fd == -1)
         return;
 
+    pids_fd[EBPF_PIDS_PROCESS_IDX] = tbl_pid_stats_fd;
     size_t length =  sizeof(ebpf_process_stat_t);
     if (maps_per_core)
         length *= ebpf_nprocs;
@@ -922,7 +923,7 @@ void collect_data_for_all_processes(int tbl_pid_stats_fd, int maps_per_core, uin
 
             ebpf_process_apps_accumulator(process_stat_vector, maps_per_core);
 
-            ebpf_pid_data_t *local_pid = ebpf_get_pid_data(key, 0, NULL, EBPF_MODULE_PROCESS_IDX);
+            ebpf_pid_data_t *local_pid = ebpf_get_pid_data(key, 0, NULL, EBPF_PIDS_PROCESS_IDX);
             ebpf_publish_process_t *w = local_pid->process;
             if (!w)
                 local_pid->process = w = ebpf_process_allocate_publish();

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -273,7 +273,7 @@ static inline void *ebpf_swap_allocate_publish_swap()
     return callocz(1, sizeof(netdata_publish_swap_t));
 }
 
-static inline void ebpf_release_publish_swap(netdata_publish_swap_t *ptr)
+static inline void ebpf_swap_release_publish(netdata_publish_swap_t *ptr)
 {
     ebpf_hash_table_pids_count--;
     freez(ptr);

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -54,6 +54,7 @@ enum ebpf_pids_index {
     EBPF_PIDS_FD_IDX,
     EBPF_PIDS_SHM_IDX,
 
+    EBPF_PIDS_PROC_FILE,
     EBPF_PIDS_END_IDX
 };
 
@@ -306,7 +307,7 @@ static inline ebpf_pid_data_t *ebpf_get_pid_data(uint32_t pid, uint32_t tgid, ch
 
     ebpf_pid_data_t *ptr = &ebpf_pids[pid];
     // The caller is getting data to work.
-    if (!name && idx != EBPF_OPTION_ALL_CHARTS)
+    if (!name && idx != EBPF_PIDS_PROC_FILE)
         return ptr;
 
     ptr->thread_collecting |= 1<<idx;

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -44,6 +44,21 @@
 
 #define EBPF_CLEANUP_FACTOR 2
 
+enum ebpf_pids_index {
+    EBPF_PIDS_PROCESS_IDX,
+    EBPF_PIDS_SOCKET_IDX,
+    EBPF_PIDS_CACHESTAT_IDX,
+    EBPF_PIDS_DCSTAT_IDX,
+    EBPF_PIDS_SWAP_IDX,
+    EBPF_PIDS_VFS_IDX,
+    EBPF_PIDS_FD_IDX,
+    EBPF_PIDS_SHM_IDX,
+
+    EBPF_PIDS_END_IDX
+};
+
+extern int pids_fd[EBPF_PIDS_END_IDX];
+
 enum ebpf_main_index {
     EBPF_MODULE_PROCESS_IDX,
     EBPF_MODULE_SOCKET_IDX,

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -525,6 +525,7 @@ void ebpf_obsolete_cachestat_apps_charts(struct ebpf_module *em)
  */
 static void ebpf_cachestat_exit(void *pptr)
 {
+    pids_fd[EBPF_PIDS_CACHESTAT_IDX] = -1;
     ebpf_module_t *em = CLEANUP_FUNCTION_GET_PTR(pptr);
     if(!em) return;
 

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -733,7 +733,7 @@ static void ebpf_read_cachestat_apps_table(int maps_per_core, uint32_t max_perio
 
         cachestat_apps_accumulator(cv, maps_per_core);
 
-        ebpf_pid_data_t *local_pid = ebpf_get_pid_data(key, cv->tgid, cv->name, EBPF_MODULE_CACHESTAT_IDX);
+        ebpf_pid_data_t *local_pid = ebpf_get_pid_data(key, cv->tgid, cv->name, EBPF_PIDS_CACHESTAT_IDX);
         netdata_publish_cachestat_t *publish = local_pid->cachestat;
         if (!publish)
             local_pid->cachestat = publish = ebpf_cachestat_allocate_publish();
@@ -771,7 +771,7 @@ static void ebpf_update_cachestat_cgroup()
             int pid = pids->pid;
             netdata_publish_cachestat_t *out = &pids->cachestat;
 
-            ebpf_pid_data_t *local_pid = ebpf_get_pid_data(pid, 0, NULL, EBPF_MODULE_CACHESTAT_IDX);
+            ebpf_pid_data_t *local_pid = ebpf_get_pid_data(pid, 0, NULL, EBPF_PIDS_CACHESTAT_IDX);
             netdata_publish_cachestat_t *in = local_pid->cachestat;
             if (!in)
                 continue;
@@ -798,7 +798,7 @@ void ebpf_cachestat_sum_pids(netdata_publish_cachestat_t *publish, struct ebpf_p
     netdata_cachestat_t *dst = &publish->current;
     for (; root; root = root->next) {
         int32_t pid = root->pid;
-        ebpf_pid_data_t *local_pid = ebpf_get_pid_data(pid, 0, NULL, EBPF_MODULE_CACHESTAT_IDX);
+        ebpf_pid_data_t *local_pid = ebpf_get_pid_data(pid, 0, NULL, EBPF_PIDS_CACHESTAT_IDX);
         netdata_publish_cachestat_t *w = local_pid->cachestat;
         if (!w)
             continue;
@@ -851,6 +851,7 @@ void *ebpf_read_cachestat_thread(void *ptr)
     uint32_t lifetime = em->lifetime;
     uint32_t running_time = 0;
     usec_t period = update_every * USEC_PER_SEC;
+    pids_fd[EBPF_PIDS_CACHESTAT_IDX] = cachestat_maps[NETDATA_CACHESTAT_PID_STATS].map_fd;
     while (!ebpf_plugin_stop() && running_time < lifetime) {
         (void)heartbeat_next(&hb, period);
         if (ebpf_plugin_stop() || ++counter != update_every)

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -742,10 +742,14 @@ static void ebpf_read_cachestat_apps_table(int maps_per_core, uint32_t max_perio
         if (!publish->ct || publish->ct != cv->ct){
             cachestat_save_pid_values(publish, cv);
             local_pid->not_updated = 0;
-        } else if (++local_pid->not_updated >= max_period) {
-            ebpf_release_pid_data(local_pid, fd, key, EBPF_MODULE_CACHESTAT_IDX);
-            ebpf_cachestat_release_publish(publish);
-            local_pid->cachestat = NULL;
+        } else {
+            if (kill(key, 0)) { // No PID found
+                ebpf_reset_specific_pid_data(local_pid);
+            } else { // There is PID, but there is not data anymore
+                ebpf_release_pid_data(local_pid, fd, key, EBPF_PIDS_CACHESTAT_IDX);
+                ebpf_cachestat_release_publish(publish);
+                local_pid->cachestat = NULL;
+            }
         }
 
 end_cachestat_loop:

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -453,6 +453,7 @@ static void ebpf_obsolete_dc_global(ebpf_module_t *em)
  */
 static void ebpf_dcstat_exit(void *pptr)
 {
+    pids_fd[EBPF_PIDS_DCSTAT_IDX] = -1;
     ebpf_module_t *em = CLEANUP_FUNCTION_GET_PTR(pptr);
     if(!em) return;
 

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -576,7 +576,7 @@ static void ebpf_read_dc_apps_table(int maps_per_core, uint32_t max_period)
             if (kill(key, 0)) { // No PID found
                 ebpf_reset_specific_pid_data(pid_stat);
             } else { // There is PID, but there is not data anymore
-                ebpf_release_pid_data(pid_stat, fd, key, EBPF_MODULE_DCSTAT_IDX);
+                ebpf_release_pid_data(pid_stat, fd, key, EBPF_PIDS_DCSTAT_IDX);
                 ebpf_dc_release_publish(publish);
                 pid_stat->dc = NULL;
             }

--- a/src/collectors/ebpf.plugin/ebpf_fd.c
+++ b/src/collectors/ebpf.plugin/ebpf_fd.c
@@ -548,6 +548,7 @@ static void ebpf_obsolete_fd_global(ebpf_module_t *em)
  */
 static void ebpf_fd_exit(void *pptr)
 {
+    pids_fd[EBPF_PIDS_FD_IDX] = -1;
     ebpf_module_t *em = CLEANUP_FUNCTION_GET_PTR(pptr);
     if(!em) return;
 

--- a/src/collectors/ebpf.plugin/ebpf_fd.c
+++ b/src/collectors/ebpf.plugin/ebpf_fd.c
@@ -718,7 +718,7 @@ static void ebpf_read_fd_apps_table(int maps_per_core, uint32_t max_period)
             if (kill(key, 0)) { // No PID found
                 ebpf_reset_specific_pid_data(pid_stat);
             } else { // There is PID, but there is not data anymore
-                ebpf_release_pid_data(pid_stat, fd, key, EBPF_MODULE_FD_IDX);
+                ebpf_release_pid_data(pid_stat, fd, key, EBPF_PIDS_FD_IDX);
                 ebpf_fd_release_publish(publish_fd);
                 pid_stat->fd = NULL;
             }

--- a/src/collectors/ebpf.plugin/ebpf_fd.c
+++ b/src/collectors/ebpf.plugin/ebpf_fd.c
@@ -700,7 +700,7 @@ static void ebpf_read_fd_apps_table(int maps_per_core, uint32_t max_period)
 
         fd_apps_accumulator(fv, maps_per_core);
 
-        ebpf_pid_data_t *pid_stat = ebpf_get_pid_data(key, fv->tgid, fv->name, EBPF_MODULE_FD_IDX);
+        ebpf_pid_data_t *pid_stat = ebpf_get_pid_data(key, fv->tgid, fv->name, EBPF_PIDS_FD_IDX);
         netdata_publish_fd_stat_t *publish_fd = pid_stat->fd;
         if (!publish_fd)
             pid_stat->fd = publish_fd = ebpf_fd_allocate_publish();
@@ -740,7 +740,7 @@ static void ebpf_fd_sum_pids(netdata_fd_stat_t *fd, struct ebpf_pid_on_target *r
 
     for (; root; root = root->next) {
         int32_t pid = root->pid;
-        ebpf_pid_data_t *pid_stat = ebpf_get_pid_data(pid, 0, NULL, EBPF_MODULE_FD_IDX);
+        ebpf_pid_data_t *pid_stat = ebpf_get_pid_data(pid, 0, NULL, EBPF_PIDS_FD_IDX);
         netdata_publish_fd_stat_t *w = pid_stat->fd;
         if (!w)
             continue;
@@ -795,6 +795,7 @@ void *ebpf_read_fd_thread(void *ptr)
     uint32_t running_time = 0;
     int period = USEC_PER_SEC;
     uint32_t max_period = EBPF_CLEANUP_FACTOR;
+    pids_fd[EBPF_PIDS_FD_IDX] = fd_maps[NETDATA_FD_PID_STATS].map_fd;
     while (!ebpf_plugin_stop() && running_time < lifetime) {
         (void)heartbeat_next(&hb, period);
         if (ebpf_plugin_stop() || ++counter != update_every)
@@ -837,7 +838,7 @@ static void ebpf_update_fd_cgroup()
         for (pids = ect->pids; pids; pids = pids->next) {
             int pid = pids->pid;
             netdata_publish_fd_stat_t *out = &pids->fd;
-            ebpf_pid_data_t *local_pid = ebpf_get_pid_data(pid, 0, NULL, EBPF_MODULE_FD_IDX);
+            ebpf_pid_data_t *local_pid = ebpf_get_pid_data(pid, 0, NULL, EBPF_PIDS_FD_IDX);
             netdata_publish_fd_stat_t *in = local_pid->fd;
             if (!in)
                 continue;

--- a/src/collectors/ebpf.plugin/ebpf_process.c
+++ b/src/collectors/ebpf.plugin/ebpf_process.c
@@ -230,7 +230,7 @@ static void ebpf_update_process_cgroup()
         for (pids = ect->pids; pids; pids = pids->next) {
             int pid = pids->pid;
             ebpf_publish_process_t *out = &pids->ps;
-            ebpf_pid_data_t *local_pid = ebpf_get_pid_data(pid, 0, NULL, EBPF_MODULE_PROCESS_IDX);
+            ebpf_pid_data_t *local_pid = ebpf_get_pid_data(pid, 0, NULL, EBPF_PIDS_PROCESS_IDX);
             ebpf_publish_process_t *in = local_pid->process;
             if (!in)
                 continue;

--- a/src/collectors/ebpf.plugin/ebpf_process.c
+++ b/src/collectors/ebpf.plugin/ebpf_process.c
@@ -691,6 +691,7 @@ static void ebpf_process_disable_tracepoints()
  */
 static void ebpf_process_exit(void *pptr)
 {
+    pids_fd[EBPF_PIDS_PROCESS_IDX] = -1;
     ebpf_module_t *em = CLEANUP_FUNCTION_GET_PTR(pptr);
     if(!em) return;
 

--- a/src/collectors/ebpf.plugin/ebpf_shm.c
+++ b/src/collectors/ebpf.plugin/ebpf_shm.c
@@ -1335,6 +1335,7 @@ static int ebpf_shm_load_bpf(ebpf_module_t *em)
  */
 void *ebpf_shm_thread(void *ptr)
 {
+    pids_fd[EBPF_PIDS_SHM_IDX] = -1;
     ebpf_module_t *em = (ebpf_module_t *)ptr;
 
     CLEANUP_FUNCTION_REGISTER(ebpf_shm_exit) cleanup_ptr = em;

--- a/src/collectors/ebpf.plugin/ebpf_socket.c
+++ b/src/collectors/ebpf.plugin/ebpf_socket.c
@@ -2850,6 +2850,7 @@ static int ebpf_socket_load_bpf(ebpf_module_t *em)
  */
 void *ebpf_socket_thread(void *ptr)
 {
+    pids_fd[EBPF_PIDS_SOCKET_IDX] = -1;
     ebpf_module_t *em = (ebpf_module_t *)ptr;
 
     CLEANUP_FUNCTION_REGISTER(ebpf_socket_exit) cleanup_ptr = em;

--- a/src/collectors/ebpf.plugin/ebpf_swap.c
+++ b/src/collectors/ebpf.plugin/ebpf_swap.c
@@ -391,6 +391,7 @@ static void ebpf_obsolete_swap_global(ebpf_module_t *em)
  */
 static void ebpf_swap_exit(void *ptr)
 {
+    pids_fd[EBPF_PIDS_SWAP_IDX] = -1;
     ebpf_module_t *em = (ebpf_module_t *)ptr;
 
     pthread_mutex_lock(&lock);

--- a/src/collectors/ebpf.plugin/ebpf_swap.c
+++ b/src/collectors/ebpf.plugin/ebpf_swap.c
@@ -483,7 +483,7 @@ static void ebpf_update_swap_cgroup()
         for (pids = ect->pids; pids; pids = pids->next) {
             int pid = pids->pid;
             netdata_publish_swap_t *out = &pids->swap;
-            ebpf_pid_data_t *local_pid = ebpf_get_pid_data(pid, 0, NULL, EBPF_MODULE_SWAP_IDX);
+            ebpf_pid_data_t *local_pid = ebpf_get_pid_data(pid, 0, NULL, EBPF_PIDS_SWAP_IDX);
             netdata_publish_swap_t *in = local_pid->swap;
             if (!in)
                 continue;
@@ -508,7 +508,7 @@ static void ebpf_swap_sum_pids(netdata_publish_swap_t *swap, struct ebpf_pid_on_
 
     for (; root; root = root->next) {
         int32_t pid = root->pid;
-        ebpf_pid_data_t *local_pid = ebpf_get_pid_data(pid, 0, NULL, EBPF_MODULE_SWAP_IDX);
+        ebpf_pid_data_t *local_pid = ebpf_get_pid_data(pid, 0, NULL, EBPF_PIDS_SWAP_IDX);
         netdata_publish_swap_t *w = local_pid->swap;
         if (!w)
             continue;
@@ -560,7 +560,7 @@ static void ebpf_read_swap_apps_table(int maps_per_core, uint32_t max_period)
 
         swap_apps_accumulator(cv, maps_per_core);
 
-        ebpf_pid_data_t *local_pid = ebpf_get_pid_data(key, cv->tgid, cv->name, EBPF_MODULE_SWAP_IDX);
+        ebpf_pid_data_t *local_pid = ebpf_get_pid_data(key, cv->tgid, cv->name, EBPF_PIDS_SWAP_IDX);
         netdata_publish_swap_t *publish = local_pid->swap;
         if (!publish)
             local_pid->swap = publish = ebpf_swap_allocate_publish_swap();
@@ -608,6 +608,7 @@ void *ebpf_read_swap_thread(void *ptr)
     uint32_t running_time = 0;
     usec_t period = update_every * USEC_PER_SEC;
     uint32_t max_period = EBPF_CLEANUP_FACTOR;
+    pids_fd[EBPF_PIDS_SWAP_IDX] = swap_maps[NETDATA_PID_SWAP_TABLE].map_fd;
 
     while (!ebpf_plugin_stop() && running_time < lifetime) {
         (void)heartbeat_next(&hb, period);

--- a/src/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/src/collectors/ebpf.plugin/ebpf_vfs.c
@@ -2625,6 +2625,7 @@ static int ebpf_vfs_load_bpf(ebpf_module_t *em)
  */
 void *ebpf_vfs_thread(void *ptr)
 {
+    pids_fd[EBPF_PIDS_VFS_IDX] = -1;
     ebpf_module_t *em = (ebpf_module_t *)ptr;
 
     CLEANUP_FUNCTION_REGISTER(ebpf_vfs_exit) cleanup_ptr = em;

--- a/src/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/src/collectors/ebpf.plugin/ebpf_vfs.c
@@ -1114,7 +1114,7 @@ static void ebpf_vfs_sum_pids(netdata_publish_vfs_t *vfs, struct ebpf_pid_on_tar
 
     for (; root; root = root->next) {
         int32_t pid = root->pid;
-        ebpf_pid_data_t *local_pid = ebpf_get_pid_data(pid, 0, NULL, EBPF_MODULE_VFS_IDX);
+        ebpf_pid_data_t *local_pid = ebpf_get_pid_data(pid, 0, NULL, EBPF_PIDS_VFS_IDX);
         netdata_publish_vfs_t *w = local_pid->vfs;
         if (!w)
             continue;
@@ -1261,7 +1261,7 @@ static void ebpf_vfs_read_apps(int maps_per_core, uint32_t max_period)
 
         vfs_apps_accumulator(vv, maps_per_core);
 
-        ebpf_pid_data_t *local_pid = ebpf_get_pid_data(key, vv->tgid, vv->name, EBPF_MODULE_VFS_IDX);
+        ebpf_pid_data_t *local_pid = ebpf_get_pid_data(key, vv->tgid, vv->name, EBPF_PIDS_VFS_IDX);
         netdata_publish_vfs_t *publish = local_pid->vfs;
         if (!publish)
             local_pid->vfs = publish = ebpf_vfs_allocate_publish();
@@ -1299,7 +1299,7 @@ static void read_update_vfs_cgroup()
             netdata_publish_vfs_t *out = &pids->vfs;
             memset(out, 0, sizeof(netdata_publish_vfs_t));
 
-            ebpf_pid_data_t *local_pid = ebpf_get_pid_data(pid, 0, NULL, EBPF_MODULE_VFS_IDX);
+            ebpf_pid_data_t *local_pid = ebpf_get_pid_data(pid, 0, NULL, EBPF_PIDS_VFS_IDX);
             netdata_publish_vfs_t *in = local_pid->vfs;
             if (!in)
                 continue;
@@ -2076,6 +2076,7 @@ void *ebpf_read_vfs_thread(void *ptr)
     uint32_t running_time = 0;
     usec_t period = update_every * USEC_PER_SEC;
     uint32_t max_period = EBPF_CLEANUP_FACTOR;
+    pids_fd[EBPF_PIDS_VFS_IDX] = vfs_maps[NETDATA_VFS_PID].map_fd;
     while (!ebpf_plugin_stop() && running_time < lifetime) {
         (void)heartbeat_next(&hb, period);
         if (ebpf_plugin_stop() || ++counter != update_every)


### PR DESCRIPTION
##### Summary
In this PR, we are enhancing the plugin by adjusting the algorithm to discard and clean up data in the user and kernel ring when the PID is no longer active.

##### Test Plan

1. Compile this branch and enable at least one thread monitoring PIDs,  for example, `fd`.
2. Start netdata and check number of PIDs stored:

```sh
bpftool map dump name tbl_fd_pid| grep key| wc -l
```

Instead to have data increasing in your hash table, it should be more or less stable.

3. Repeat steps with current master.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
