### PR TITLE
Switch to DEB822 format for APT repository configuration.

### DIFF
--- a/packaging/repoconfig/CMakeLists.txt
+++ b/packaging/repoconfig/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-cmake_minimum_required(VERSION 3.13.0...3.28)
+cmake_minimum_required(VERSION 3.16.0...3.30)
 
 list(APPEND RHEL_DISTROS centos centos-stream rocky almalinux cloudlinux)
 list(APPEND SUSE_DISTROS opensuse-leap opensuse-tumbleweed)
@@ -10,7 +10,7 @@ list(APPEND DEB_DISTROS debian ubuntu)
 set(DEB_GPG_KEY_SOURCE "https://repo.netdata.cloud/netdatabot.gpg.key")
 
 set(PACKAGE_VERSION 3)
-set(PACKAGE_RELEASE 2)
+set(PACKAGE_RELEASE 4)
 
 set(CPACK_THREADS 0)
 set(CPACK_STRIP_FILES NO)
@@ -117,10 +117,10 @@ if(${DISTRO} IN_LIST DEB_DISTROS)
   set(DIST_NAME ${DISTRO})
   message(STATUS "Generating stable repository configuration for ${DISTRO} ${SUITE}")
   set(VARIANT stable)
-  configure_file(netdata.list.in netdata.list @ONLY)
+  configure_file(netdata.sources.in netdata.sources @ONLY)
   message(STATUS "Generating edge repository configuration for ${DISTRO} ${SUITE}")
   set(VARIANT edge)
-  configure_file(netdata.list.in netdata-edge.list @ONLY)
+  configure_file(netdata.sources.in netdata-edge.sources @ONLY)
   message(STATUS "Preparing changelogs")
   set(PKG_NAME netdata-repo)
   file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/netdata-repo)
@@ -129,10 +129,10 @@ if(${DISTRO} IN_LIST DEB_DISTROS)
   file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/netdata-repo-edge)
   configure_file(deb.changelog netdata-repo-edge/changelog @ONLY)
 
-  install(FILES ${CMAKE_BINARY_DIR}/netdata.list
+  install(FILES ${CMAKE_BINARY_DIR}/netdata.sources
           DESTINATION etc/apt/sources.list.d
           COMPONENT netdata-repo)
-  install(FILES ${CMAKE_BINARY_DIR}/netdata-edge.list
+  install(FILES ${CMAKE_BINARY_DIR}/netdata-edge.sources
           DESTINATION etc/apt/sources.list.d
           COMPONENT netdata-repo-edge)
 
@@ -150,24 +150,14 @@ if(${DISTRO} IN_LIST DEB_DISTROS)
                     DEPENDS ${CMAKE_BINARY_DIR}/netdata.gpg)
 
   install(FILES ${CMAKE_BINARY_DIR}/netdata.gpg
-          DESTINATION etc/apt/trusted.gpg.d
+          DESTINATION usr/share/keyrings
           RENAME netdata-archive-keyring.gpg
-          PERMISSIONS OWNER_READ GROUP_READ WORLD_READ
-          COMPONENT netdata-repo)
-  install(FILES ${CMAKE_BINARY_DIR}/netdata.gpg
-          DESTINATION etc/apt/trusted.gpg.d
-          RENAME netdata-repoconfig-archive-keyring.gpg
           PERMISSIONS OWNER_READ GROUP_READ WORLD_READ
           COMPONENT netdata-repo)
 
   install(FILES ${CMAKE_BINARY_DIR}/netdata.gpg
-          DESTINATION etc/apt/trusted.gpg.d
-          RENAME netdata-edge-archive-keyring.gpg
-          PERMISSIONS OWNER_READ GROUP_READ WORLD_READ
-          COMPONENT netdata-repo-edge)
-  install(FILES ${CMAKE_BINARY_DIR}/netdata.gpg
-          DESTINATION etc/apt/trusted.gpg.d
-          RENAME netdata-repoconfig-archive-keyring.gpg
+          DESTINATION usr/share/keyrings
+          RENAME netdata-archive-keyring.gpg
           PERMISSIONS OWNER_READ GROUP_READ WORLD_READ
           COMPONENT netdata-repo-edge)
 

--- a/packaging/repoconfig/deb.changelog
+++ b/packaging/repoconfig/deb.changelog
@@ -1,3 +1,9 @@
+@PKG_NAME@ (3-4) unstable; urgency=medium
+
+  * Convert sources to DEB822 format
+
+ -- Netdata Builder <bot@netdata.cloud>  Mon, 19 Aug 2024 07:49:00 -0400
+
 @PKG_NAME@ (3-3) unstable; urgency=medium
 
   * Version bump to keep in sync with RPM repo packages

--- a/packaging/repoconfig/netdata.list.in
+++ b/packaging/repoconfig/netdata.list.in
@@ -1,2 +1,0 @@
-deb http://repo.netdata.cloud/repos/@VARIANT@/@DIST_NAME@/ @SUITE@/
-deb http://repo.netdata.cloud/repos/repoconfig/@DIST_NAME@/ @SUITE@/

--- a/packaging/repoconfig/netdata.sources.in
+++ b/packaging/repoconfig/netdata.sources.in
@@ -1,5 +1,5 @@
 X-Repolib-Name: Netdata @VARIANT@ repository
-Type: deb
+Types: deb
 URIs: http://repo.netdata.cloud/repos/@VARIANT@/@DIST_NAME@/
 Suites: @SUITE@/
 Signed-By: /usr/share/keyrings/netdata-archive-keyring.gpg
@@ -7,7 +7,7 @@ By-Hash: No
 Enabled: Yes
 
 X-Repolib-Name: Netdata repository configuration repository
-Type: deb
+Types: deb
 URIs: http://repo.netdata.cloud/repos/repoconfig/@DIST_NAME@/
 Suites: @SUITE@/
 Signed-By: /usr/share/keyrings/netdata-archive-keyring.gpg

--- a/packaging/repoconfig/netdata.sources.in
+++ b/packaging/repoconfig/netdata.sources.in
@@ -1,0 +1,15 @@
+X-Repolib-Name: Netdata @VARIANT@ repository
+Type: deb
+URIs: http://repo.netdata.cloud/repos/@VARIANT@/@DIST_NAME@/
+Suites: @SUITE@/
+Signed-By: /usr/share/keyrings/netdata-archive-keyring.gpg
+By-Hash: No
+Enabled: Yes
+
+X-Repolib-Name: Netdata repository configuration repository
+Type: deb
+URIs: http://repo.netdata.cloud/repos/repoconfig/@DIST_NAME@/
+Suites: @SUITE@/
+Signed-By: /usr/share/keyrings/netdata-archive-keyring.gpg
+By-Hash: No
+Enabled: Yes

--- a/packaging/repoconfig/rpm.changelog
+++ b/packaging/repoconfig/rpm.changelog
@@ -1,3 +1,5 @@
+* Mon Aug 19 2024 Austin Hemmelgarn <austin@netdata.cloud
+- Version bump to stay in sync with DEB packages.
 * Fri Aug 9 2024 Austin Hemmelgarn <austin@netdata.cloud> 3-3
 - Use system certificate config for Yum/DNF repos.
 * Mon Jun 24 2024 Austin Hemmelgarn <austin@netdata.cloud> 3-2


### PR DESCRIPTION
##### Summary

Most third-party repositories have long-since made the equivalent switch, and Ubuntu is apparently forcibly converting existing configuration when upgrading to 24.04 even if the configuration is owned by a package on the system.

This change also is required for us to eventually provide redundancy in our repository hosting, and will indirectly simplify a handful of other possible improvements.

##### Test Plan

Requires manual testing of the generated DEB repository configuration packages.

To build locally, run `docker run -it -v $PWD:/netdata <distroimage> /netdata/packaging/repoconfig/build-deb.sh` from the root of the git repository, replacing `<distroimage>` with the official Docker image for the target distribution (for example, `debian:12` for Debian 12). The packages will be put in `packaging/repoconfig/artifacts`.