### PR TITLE
go.d dnsmasq: query metrics individually to handle v2.90+ SERVFAIL

### DIFF
--- a/src/go/plugin/go.d/modules/dnsmasq/collect.go
+++ b/src/go/plugin/go.d/modules/dnsmasq/collect.go
@@ -11,20 +11,16 @@ import (
 )
 
 func (d *Dnsmasq) collect() (map[string]int64, error) {
-	r, err := d.queryCacheStatistics()
-	if err != nil {
+	mx := make(map[string]int64)
+
+	if err := d.collectCacheStatistics(mx); err != nil {
 		return nil, err
 	}
 
-	ms := make(map[string]int64)
-	if err = d.collectResponse(ms, r); err != nil {
-		return nil, err
-	}
-
-	return ms, nil
+	return mx, nil
 }
 
-func (d *Dnsmasq) collectResponse(ms map[string]int64, resp *dns.Msg) error {
+func (d *Dnsmasq) collectCacheStatistics(mx map[string]int64) error {
 	/*
 		;; flags: qr aa rd ra; QUERY: 7, ANSWER: 7, AUTHORITY: 0, ADDITIONAL: 0
 
@@ -46,68 +42,82 @@ func (d *Dnsmasq) collectResponse(ms map[string]int64, resp *dns.Msg) error {
 		auth.bind.			0	CH	TXT	"0"
 		servers.bind.		0	CH	TXT	"10.0.0.1#53 0 0" "1.1.1.1#53 4 3" "1.0.0.1#53 3 0"
 	*/
-	for _, a := range resp.Answer {
-		txt, ok := a.(*dns.TXT)
-		if !ok {
-			continue
+
+	questions := []string{
+		"servers.bind.",
+		"cachesize.bind.",
+		"insertions.bind.",
+		"evictions.bind.",
+		"hits.bind.",
+		"misses.bind.",
+		// auth.bind query is only supported if dnsmasq has been built to support running as an authoritative name server
+		// See https://github.com/netdata/netdata/issues/13766
+		//"auth.bind.",
+	}
+
+	for _, q := range questions {
+		resp, err := d.query(q)
+		if err != nil {
+			return err
 		}
 
-		idx := strings.IndexByte(txt.Hdr.Name, '.')
-		if idx == -1 {
-			continue
-		}
+		for _, a := range resp.Answer {
+			txt, ok := a.(*dns.TXT)
+			if !ok {
+				continue
+			}
 
-		switch name := txt.Hdr.Name[:idx]; name {
-		case "servers":
-			for _, entry := range txt.Txt {
-				parts := strings.Fields(entry)
-				if len(parts) != 3 {
-					return fmt.Errorf("parse %s (%s): unexpected format", txt.Hdr.Name, entry)
+			idx := strings.IndexByte(txt.Hdr.Name, '.')
+			if idx == -1 {
+				continue
+			}
+
+			name := txt.Hdr.Name[:idx]
+
+			switch name {
+			case "servers":
+				for _, entry := range txt.Txt {
+					parts := strings.Fields(entry)
+					if len(parts) != 3 {
+						return fmt.Errorf("parse %s (%s): unexpected format", txt.Hdr.Name, entry)
+					}
+					queries, err := strconv.ParseFloat(parts[1], 64)
+					if err != nil {
+						return fmt.Errorf("parse '%s' (%s): %v", txt.Hdr.Name, entry, err)
+					}
+					failedQueries, err := strconv.ParseFloat(parts[2], 64)
+					if err != nil {
+						return fmt.Errorf("parse '%s' (%s): %v", txt.Hdr.Name, entry, err)
+					}
+
+					mx["queries"] += int64(queries)
+					mx["failed_queries"] += int64(failedQueries)
 				}
-				queries, err := strconv.ParseFloat(parts[1], 64)
+			case "cachesize", "insertions", "evictions", "hits", "misses", "auth":
+				if len(txt.Txt) != 1 {
+					return fmt.Errorf("parse '%s' (%v): unexpected format", txt.Hdr.Name, txt.Txt)
+				}
+				v, err := strconv.ParseFloat(txt.Txt[0], 64)
 				if err != nil {
-					return fmt.Errorf("parse '%s' (%s): %v", txt.Hdr.Name, entry, err)
-				}
-				failedQueries, err := strconv.ParseFloat(parts[2], 64)
-				if err != nil {
-					return fmt.Errorf("parse '%s' (%s): %v", txt.Hdr.Name, entry, err)
+					return fmt.Errorf("parse '%s' (%s): %v", txt.Hdr.Name, txt.Txt[0], err)
 				}
 
-				ms["queries"] += int64(queries)
-				ms["failed_queries"] += int64(failedQueries)
+				mx[name] = int64(v)
 			}
-		case "cachesize", "insertions", "evictions", "hits", "misses", "auth":
-			if len(txt.Txt) != 1 {
-				return fmt.Errorf("parse '%s' (%v): unexpected format", txt.Hdr.Name, txt.Txt)
-			}
-			v, err := strconv.ParseFloat(txt.Txt[0], 64)
-			if err != nil {
-				return fmt.Errorf("parse '%s' (%s): %v", txt.Hdr.Name, txt.Txt[0], err)
-			}
-
-			ms[name] = int64(v)
 		}
 	}
+
 	return nil
 }
 
-func (d *Dnsmasq) queryCacheStatistics() (*dns.Msg, error) {
+func (d *Dnsmasq) query(question string) (*dns.Msg, error) {
 	msg := &dns.Msg{
 		MsgHdr: dns.MsgHdr{
 			Id:               dns.Id(),
 			RecursionDesired: true,
 		},
 		Question: []dns.Question{
-			{Name: "cachesize.bind.", Qtype: dns.TypeTXT, Qclass: dns.ClassCHAOS},
-			{Name: "insertions.bind.", Qtype: dns.TypeTXT, Qclass: dns.ClassCHAOS},
-			{Name: "evictions.bind.", Qtype: dns.TypeTXT, Qclass: dns.ClassCHAOS},
-			{Name: "hits.bind.", Qtype: dns.TypeTXT, Qclass: dns.ClassCHAOS},
-			{Name: "misses.bind.", Qtype: dns.TypeTXT, Qclass: dns.ClassCHAOS},
-			// TODO: collect auth.bind if available
-			// auth.bind query is only supported if dnsmasq has been built
-			// to support running as an authoritative name server. See https://github.com/netdata/netdata/issues/13766
-			//{Name: "auth.bind.", Qtype: dns.TypeTXT, Qclass: dns.ClassCHAOS},
-			{Name: "servers.bind.", Qtype: dns.TypeTXT, Qclass: dns.ClassCHAOS},
+			{Name: question, Qtype: dns.TypeTXT, Qclass: dns.ClassCHAOS},
 		},
 	}
 
@@ -115,12 +125,15 @@ func (d *Dnsmasq) queryCacheStatistics() (*dns.Msg, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if r == nil {
-		return nil, fmt.Errorf("'%s' returned an empty response", d.Address)
+		return nil, fmt.Errorf("'%s' question '%s', returned an empty response", d.Address, question)
 	}
+
 	if r.Rcode != dns.RcodeSuccess {
 		s := dns.RcodeToString[r.Rcode]
-		return nil, fmt.Errorf("'%s' returned '%s' (%d) response code", d.Address, s, r.Rcode)
+		return nil, fmt.Errorf("'%s' question '%s' returned '%s' (%d) response code", d.Address, question, s, r.Rcode)
 	}
+
 	return r, nil
 }


### PR DESCRIPTION
##### Summary

v2.90+ returns SERVFAIL if there is more than one question in the message.

Fixes: #18375

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
