### PR TITLE
Update windows installer

### DIFF
--- a/packaging/installer/installer.nsi
+++ b/packaging/installer/installer.nsi
@@ -1,0 +1,128 @@
+!include "MUI2.nsh"
+!include "nsDialogs.nsh"
+!include "FileFunc.nsh"
+
+Name "Netdata"
+Outfile "netdata-installer.exe"
+InstallDir "$PROGRAMFILES\Netdata"
+RequestExecutionLevel admin
+
+!define MUI_ICON "NetdataWhite.ico"
+!define MUI_UNICON "NetdataWhite.ico"
+
+!define ND_UININSTALL_REG "Software\Microsoft\Windows\CurrentVersion\Uninstall\Netdata"
+
+!define MUI_ABORTWARNING
+!define MUI_UNABORTWARNING
+
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_LICENSE "C:\msys64\gpl-3.0.txt"
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+!insertmacro MUI_UNPAGE_FINISH
+
+!insertmacro MUI_LANGUAGE "English"
+
+Function .onInit
+        nsExec::ExecToLog '$SYSDIR\sc.exe stop Netdata'
+        pop $0
+        ${If} $0 == 0
+            nsExec::ExecToLog '$SYSDIR\sc.exe delete Netdata'
+            pop $0
+        ${EndIf}
+FunctionEnd
+
+Function NetdataUninstallRegistry
+        ClearErrors
+        WriteRegStr HKLM "${ND_UININSTALL_REG}" \
+                         "DisplayName" "Netdata - Real-time system monitoring."
+        WriteRegStr HKLM "${ND_UININSTALL_REG}" \
+                         "DisplayIcon" "$INSTDIR\Uninstall.exe,0"
+        WriteRegStr HKLM "${ND_UININSTALL_REG}" \
+                         "UninstallString" "$INSTDIR\Uninstall.exe"
+        WriteRegStr HKLM "${ND_UININSTALL_REG}" \
+                         "RegOwner" "Netdata Inc."
+        WriteRegStr HKLM "${ND_UININSTALL_REG}" \
+                         "RegCompany" "Netdata Inc."
+        WriteRegStr HKLM "${ND_UININSTALL_REG}" \
+                         "Publisher" "Netdata Inc."
+        WriteRegStr HKLM "${ND_UININSTALL_REG}" \
+                         "HelpLink" "https://learn.netdata.cloud/"
+        WriteRegStr HKLM "${ND_UININSTALL_REG}" \
+                         "URLInfoAbout" "https://www.netdata.cloud/"
+        WriteRegStr HKLM "${ND_UININSTALL_REG}" \
+                         "DisplayVersion" "${CURRVERSION}"
+        WriteRegStr HKLM "${ND_UININSTALL_REG}" \
+                         "VersionMajor" "${MAJORVERSION}"
+        WriteRegStr HKLM "${ND_UININSTALL_REG}" \
+                         "VersionMinor" "${MINORVERSION}"
+
+        IfErrors 0 +2
+        MessageBox MB_ICONEXCLAMATION|MB_OK "Unable to create an entry in the Control Panel!" IDOK end
+
+        ClearErrors
+        ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
+        IntFmt $0 "0x%08X" $0
+        WriteRegDWORD HKLM "${ND_UININSTALL_REG}" "EstimatedSize" "$0"
+
+        IfErrors 0 +2
+        MessageBox MB_ICONEXCLAMATION|MB_OK "Cannot estimate the installation size." IDOK end
+        end:
+FunctionEnd
+
+Section "Install Netdata"
+	SetOutPath $INSTDIR
+	SetCompress off
+
+	File /r "C:\msys64\opt\netdata\*.*"
+
+	ClearErrors
+        nsExec::ExecToLog '$SYSDIR\sc.exe create Netdata binPath= "$INSTDIR\usr\bin\netdata.exe" start= delayed-auto'
+        pop $0
+        ${If} $0 != 0
+	    DetailPrint "Warning: Failed to create Netdata service."
+        ${EndIf}
+
+	ClearErrors
+        nsExec::ExecToLog '$SYSDIR\sc.exe description Netdata "Real-time system monitoring service"'
+        pop $0
+        ${If} $0 != 0
+	    DetailPrint "Warning: Failed to add Netdata service description."
+        ${EndIf}
+
+	ClearErrors
+        nsExec::ExecToLog '$SYSDIR\sc.exe start Netdata'
+        pop $0
+        ${If} $0 != 0
+	    DetailPrint "Warning: Failed to start Netdata service."
+        ${EndIf}
+
+	WriteUninstaller "$INSTDIR\Uninstall.exe"
+
+        Call NetdataUninstallRegistry
+SectionEnd
+
+Section "Uninstall"
+	ClearErrors
+        nsExec::ExecToLog '$SYSDIR\sc.exe stop Netdata'
+        pop $0
+        ${If} $0 != 0
+	    DetailPrint "Warning: Failed to stop Netdata service."
+        ${EndIf}
+
+	ClearErrors
+        nsExec::ExecToLog '$SYSDIR\sc.exe delete Netdata'
+        pop $0
+        ${If} $0 != 0
+	    DetailPrint "Warning: Failed to delete Netdata service."
+        ${EndIf}
+
+	RMDir /r "$INSTDIR"
+
+        DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Netdata"
+SectionEnd
+

--- a/packaging/installer/package-windows.sh
+++ b/packaging/installer/package-windows.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+repo_root="$(dirname "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd -P)")")"
+
+if [ -n "${BUILD_DIR}" ]; then
+    build="${BUILD_DIR}"
+elif [ -n "${OSTYPE}" ]; then
+    if [ -n "${MSYSTEM}" ]; then
+        build="${repo_root}/build-${OSTYPE}-${MSYSTEM}"
+    else
+        build="${repo_root}/build-${OSTYPE}"
+    fi
+elif [ "$USER" = "vk" ]; then
+    build="${repo_root}/build"
+else
+    build="${repo_root}/build"
+fi
+
+set -exu -o pipefail
+
+${GITHUB_ACTIONS+echo "::group::Installing"}
+cmake --install "${build}"
+${GITHUB_ACTIONS+echo "::endgroup::"}
+
+if [ ! -f "/msys2-installer.exe" ]; then
+    ${GITHUB_ACTIONS+echo "::group::Fetching MSYS2 installer"}
+    "${repo_root}/packaging/windows/fetch-msys2-installer.py" /msys2-installer.exe
+    ${GITHUB_ACTIONS+echo "::endgroup::"}
+fi
+
+${GITHUB_ACTIONS+echo "::group::Packaging"}
+NDVERSION=$"$(grep 'CMAKE_PROJECT_VERSION:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
+NDMAJORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MAJOR:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
+NDMINORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MINOR:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
+
+if [ -f "/gpl-3.0.txt" ]; then
+    ${GITHUB_ACTIONS+echo "::group::Fetching GPL3 License"}
+    curl -o /gpl-3.0.txt "https://www.gnu.org/licenses/gpl-3.0.txt"
+    ${GITHUB_ACTIONS+echo "::endgroup::"}
+fi
+
+/mingw64/bin/makensis.exe -DCURRVERSION="${NDVERSION}" -DMAJORVERSION="${NDMAJORVERSION}" -DMINORVERSION="${NDMINORVERSION}" "${repo_root}/packaging/windows/installer.nsi"
+${GITHUB_ACTIONS+echo "::endgroup::"}

--- a/packaging/windows/fetch-msys2-installer.py
+++ b/packaging/windows/fetch-msys2-installer.py
@@ -78,8 +78,8 @@ def main() -> None:
     with TemporaryDirectory() as tmpdir:
         tmppath = Path(tmpdir)
 
-        installer = fetch_release_asset(tmppath, name, f'msys2-base-x86_64-{version}.sfx.exe')
-        checksums = fetch_release_asset(tmppath, name, f'msys2-base-x86_64-{version}.sfx.exe.sha256')
+        installer = fetch_release_asset(tmppath, name, f'msys2-base-x86_64-{version}.tar.zst')
+        checksums = fetch_release_asset(tmppath, name, f'msys2-base-x86_64-{version}.tar.zst.sha256')
 
         print('>>> Verifying SHA256 checksum')
         expected_checksum = checksums.read_text().partition(' ')[0].casefold()

--- a/packaging/windows/fetch-msys2-installer.py
+++ b/packaging/windows/fetch-msys2-installer.py
@@ -78,8 +78,8 @@ def main() -> None:
     with TemporaryDirectory() as tmpdir:
         tmppath = Path(tmpdir)
 
-        installer = fetch_release_asset(tmppath, name, f'msys2-x86_64-{version}.exe')
-        checksums = fetch_release_asset(tmppath, name, f'msys2-x86_64-{version}.exe.sha256')
+        installer = fetch_release_asset(tmppath, name, f'msys2-base-x86_64-{version}.sfx.exe')
+        checksums = fetch_release_asset(tmppath, name, f'msys2-base-x86_64-{version}.sfx.exe.sha256')
 
         print('>>> Verifying SHA256 checksum')
         expected_checksum = checksums.read_text().partition(' ')[0].casefold()

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -20,7 +20,7 @@ RequestExecutionLevel admin
 !insertmacro MUI_PAGE_LICENSE "C:\msys64\gpl-3.0.txt"
 !insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_INSTFILES
-Page Custom NetdataConfigPage
+Page Custom NetdataConfigPage NetdataConfigLeave
 !insertmacro MUI_PAGE_FINISH
 
 !insertmacro MUI_UNPAGE_CONFIRM
@@ -29,9 +29,13 @@ Page Custom NetdataConfigPage
 
 !insertmacro MUI_LANGUAGE "English"
 
-var StartMsys
+var hStartMsys
+var startMsys
+
+var hCloudToken
 var cloudToken
-var cloudID
+var hCloudRoom
+var cloudRoom
 
 Function .onInit
         nsExec::ExecToLog '$SYSDIR\sc.exe stop Netdata'
@@ -40,6 +44,8 @@ Function .onInit
             nsExec::ExecToLog '$SYSDIR\sc.exe delete Netdata'
             pop $0
         ${EndIf}
+
+        StrCpy $startMsys ${BST_UNCHECKED}
 FunctionEnd
 
 Function NetdataConfigPage
@@ -51,22 +57,41 @@ Function NetdataConfigPage
             Abort
         ${EndIf}
 
-        ${NSD_CreateLabel} 0 0 100% 12u "Enter your token and Cloud ID."
+        ${NSD_CreateLabel} 0 0 100% 12u "Enter your Token and Cloud Room."
         ${NSD_CreateLabel} 0 15% 100% 12u "Optionally, you can open a terminal to execute additional commands."
 
         ${NSD_CreateLabel} 0 35% 20% 10% "Token"
         Pop $0
         ${NSD_CreateText} 21% 35% 79% 10% ""
-        Pop $cloudToken
+        Pop $hCloudToken
 
-        ${NSD_CreateLabel} 0 55% 20% 10% "ID"
+        ${NSD_CreateLabel} 0 55% 20% 10% "Room"
         Pop $0
         ${NSD_CreateText} 21% 55% 79% 10% ""
-        Pop $cloudID
+        Pop $hCloudRoom
 
         ${NSD_CreateCheckbox} 0 70% 100% 10u "Open terminal"
-        Pop $StartMsys
+        Pop $hStartMsys
         nsDialogs::Show
+FunctionEnd
+
+Function NetdataConfigLeave
+        ${NSD_GetText} $hCloudToken $cloudToken
+        ${NSD_GetText} $hCloudRoom $cloudRoom
+        ${NSD_GetState} $hStartMsys $startMsys
+
+        StrLen $0 $cloudToken
+        StrLen $1 $cloudRoom
+        ${If} $0 == 125
+        ${AndIf} $0 == 36
+                # We should start our new claiming software here
+                MessageBox MB_OK "$cloudToken | $cloudRoom | $startMsys"
+        ${EndIf}
+
+        ${If} $startMsys == 1
+            nsExec::ExecToLog '$INSTDIR\msys2.exe'
+            pop $0
+        ${EndIf}
 FunctionEnd
 
 Function NetdataUninstallRegistry

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -20,7 +20,7 @@ RequestExecutionLevel admin
 !insertmacro MUI_PAGE_LICENSE "C:\msys64\gpl-3.0.txt"
 !insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_INSTFILES
-Page Custom NetdataStartMsys
+Page Custom NetdataConfigPage
 !insertmacro MUI_PAGE_FINISH
 
 !insertmacro MUI_UNPAGE_CONFIRM
@@ -42,7 +42,7 @@ Function .onInit
         ${EndIf}
 FunctionEnd
 
-Function NetdataStartMsys
+Function NetdataConfigPage
         !insertmacro MUI_HEADER_TEXT "Netdata configuration" "Claim your agent on Netdata Cloud"
 
         nsDialogs::Create 1018

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -29,6 +29,10 @@ RequestExecutionLevel admin
 Function .onInit
         nsExec::ExecToLog '$SYSDIR\sc.exe stop Netdata'
         pop $0
+        ${If} $0 == 0
+            nsExec::ExecToLog '$SYSDIR\sc.exe delete Netdata'
+            pop $0
+        ${EndIf}
 FunctionEnd
 
 Function NetdataUninstallRegistry

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -16,6 +16,7 @@ RequestExecutionLevel admin
 !define MUI_UNABORTWARNING
 
 !insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_LICENSE "C:\msys64\cloud.txt"
 !insertmacro MUI_PAGE_LICENSE "C:\msys64\gpl-3.0.txt"
 !insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_INSTFILES
@@ -42,25 +43,28 @@ Function .onInit
 FunctionEnd
 
 Function NetdataStartMsys
+        !insertmacro MUI_HEADER_TEXT "Netdata configuration" "Claim your agent on Netdata Cloud"
+
         nsDialogs::Create 1018
         Pop $0
         ${If} $0 == error
             Abort
         ${EndIf}
 
-        ${NSD_CreateLabel} 0 0 100% 12u "Configuration options. Enter your token and ID to claim your agent. Additionaly, you can also open a terminal to execute optional commands:"
+        ${NSD_CreateLabel} 0 0 100% 12u "Enter your token and Cloud ID."
+        ${NSD_CreateLabel} 0 15% 100% 12u "Optionally, you can open a terminal to execute additional commands."
 
-        ${NSD_CreateLabel} 0 20% 20% 10% "Token"
+        ${NSD_CreateLabel} 0 35% 20% 10% "Token"
         Pop $0
-        ${NSD_CreateText} 0 20% 80% 10% ""
+        ${NSD_CreateText} 21% 35% 79% 10% ""
         Pop $cloudToken
 
-        ${NSD_CreateLabel} 0 40% 20% 10% "ID"
+        ${NSD_CreateLabel} 0 55% 20% 10% "ID"
         Pop $0
-        ${NSD_CreateText} 0 40% 80% 10% ""
+        ${NSD_CreateText} 21% 55% 79% 10% ""
         Pop $cloudID
 
-        ${NSD_CreateCheckbox} 0 60% 100% 10u "Open terminal"
+        ${NSD_CreateCheckbox} 0 70% 100% 10u "Open terminal"
         Pop $StartMsys
         nsDialogs::Show
 FunctionEnd

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -16,8 +16,10 @@ RequestExecutionLevel admin
 !define MUI_UNABORTWARNING
 
 !insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_LICENSE "C:\msys64\gpl-3.0.txt"
 !insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_INSTFILES
+Page Custom NetdataStartMsys
 !insertmacro MUI_PAGE_FINISH
 
 !insertmacro MUI_UNPAGE_CONFIRM
@@ -26,6 +28,10 @@ RequestExecutionLevel admin
 
 !insertmacro MUI_LANGUAGE "English"
 
+var StartMsys
+var cloudToken
+var cloudID
+
 Function .onInit
         nsExec::ExecToLog '$SYSDIR\sc.exe stop Netdata'
         pop $0
@@ -33,6 +39,30 @@ Function .onInit
             nsExec::ExecToLog '$SYSDIR\sc.exe delete Netdata'
             pop $0
         ${EndIf}
+FunctionEnd
+
+Function NetdataStartMsys
+        nsDialogs::Create 1018
+        Pop $0
+        ${If} $0 == error
+            Abort
+        ${EndIf}
+
+        ${NSD_CreateLabel} 0 0 100% 12u "Configuration options. Enter your token and ID to claim your agent. Additionaly, you can also open a terminal to execute optional commands:"
+
+        ${NSD_CreateLabel} 0 20% 20% 10% "Token"
+        Pop $0
+        ${NSD_CreateText} 0 20% 80% 10% ""
+        Pop $cloudToken
+
+        ${NSD_CreateLabel} 0 40% 20% 10% "ID"
+        Pop $0
+        ${NSD_CreateText} 0 40% 80% 10% ""
+        Pop $cloudID
+
+        ${NSD_CreateCheckbox} 0 60% 100% 10u "Open terminal"
+        Pop $StartMsys
+        nsDialogs::Show
 FunctionEnd
 
 Function NetdataUninstallRegistry

--- a/packaging/windows/package-windows.sh
+++ b/packaging/windows/package-windows.sh
@@ -38,6 +38,12 @@ if [ ! -f "/cloud.txt" ]; then
 fi
 ${GITHUB_ACTIONS+echo "::endgroup::"}
 
+${GITHUB_ACTIONS+echo "::group::Prompt"}
+cp /msys2.exe /msys2.ini /msys2_shell.cmd /opt/netdata
+cd /usr/bin && cp ls.exe nano.exe msys-magic-1.dll msys-bz2-1.dll msys-lzma-5.dll /opt/netdata/usr/bin
+echo "export PATH=\"/usr/bin:/bin:/\"" > /opt/netdata/etc/profile
+${GITHUB_ACTIONS+echo "::endgroup::"}
+
 ${GITHUB_ACTIONS+echo "::group::Packaging"}
 NDVERSION=$"$(grep 'CMAKE_PROJECT_VERSION:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
 NDMAJORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MAJOR:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"

--- a/packaging/windows/package-windows.sh
+++ b/packaging/windows/package-windows.sh
@@ -22,9 +22,9 @@ ${GITHUB_ACTIONS+echo "::group::Installing"}
 cmake --install "${build}"
 ${GITHUB_ACTIONS+echo "::endgroup::"}
 
-if [ ! -f "/msys2-installer.exe" ]; then
+if [ ! -f "/msys2-x86_64-latest.sfx.exe" ]; then
     ${GITHUB_ACTIONS+echo "::group::Fetching MSYS2 installer"}
-    "${repo_root}/packaging/windows/fetch-msys2-installer.py" /msys2-installer.exe
+    "${repo_root}/packaging/windows/fetch-msys2-installer.py" /msys2-x86_64-latest.sfx.exe
     ${GITHUB_ACTIONS+echo "::endgroup::"}
 fi
 
@@ -39,6 +39,7 @@ fi
 ${GITHUB_ACTIONS+echo "::endgroup::"}
 
 ${GITHUB_ACTIONS+echo "::group::Packaging"}
+cp /msys2-x86_64-latest.sfx.exe /opt/netdata/ || exit 1
 NDVERSION=$"$(grep 'CMAKE_PROJECT_VERSION:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
 NDMAJORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MAJOR:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
 NDMINORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MINOR:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"

--- a/packaging/windows/package-windows.sh
+++ b/packaging/windows/package-windows.sh
@@ -38,12 +38,6 @@ if [ ! -f "/cloud.txt" ]; then
 fi
 ${GITHUB_ACTIONS+echo "::endgroup::"}
 
-${GITHUB_ACTIONS+echo "::group::Prompt"}
-cp /msys2.exe /msys2.ini /msys2_shell.cmd /opt/netdata
-cd /usr/bin && cp ls.exe nano.exe msys-magic-1.dll msys-bz2-1.dll msys-lzma-5.dll /opt/netdata/usr/bin
-echo "export PATH=\"/usr/bin:/bin:/\"" > /opt/netdata/etc/profile
-${GITHUB_ACTIONS+echo "::endgroup::"}
-
 ${GITHUB_ACTIONS+echo "::group::Packaging"}
 NDVERSION=$"$(grep 'CMAKE_PROJECT_VERSION:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
 NDMAJORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MAJOR:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"

--- a/packaging/windows/package-windows.sh
+++ b/packaging/windows/package-windows.sh
@@ -28,22 +28,21 @@ if [ ! -f "/msys2-installer.exe" ]; then
     ${GITHUB_ACTIONS+echo "::endgroup::"}
 fi
 
+${GITHUB_ACTIONS+echo "::group::Licenses"}
+if [ ! -f "/gpl-3.0.txt" ]; then
+    curl -o /gpl-3.0.txt "https://www.gnu.org/licenses/gpl-3.0.txt"
+fi
+
+if [ ! -f "/cloud.txt" ]; then
+    curl -o /cloud.txt "https://raw.githubusercontent.com/netdata/netdata/master/src/web/gui/v2/LICENSE.md"
+fi
+${GITHUB_ACTIONS+echo "::endgroup::"}
+
 ${GITHUB_ACTIONS+echo "::group::Packaging"}
 NDVERSION=$"$(grep 'CMAKE_PROJECT_VERSION:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
 NDMAJORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MAJOR:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
 NDMINORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MINOR:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
 
-if [ ! -f "/gpl-3.0.txt" ]; then
-    ${GITHUB_ACTIONS+echo "::group::Fetching GPL3 License"}
-    curl -o /gpl-3.0.txt "https://www.gnu.org/licenses/gpl-3.0.txt"
-    ${GITHUB_ACTIONS+echo "::endgroup::"}
-fi
-
-if [ ! -f "/cloud.txt" ]; then
-    ${GITHUB_ACTIONS+echo "::group::Fetching Cloud License"}
-    curl -o /cloud.txt "https://raw.githubusercontent.com/netdata/netdata/master/src/web/gui/v2/LICENSE.md"
-    ${GITHUB_ACTIONS+echo "::endgroup::"}
-fi
-
 /mingw64/bin/makensis.exe -DCURRVERSION="${NDVERSION}" -DMAJORVERSION="${NDMAJORVERSION}" -DMINORVERSION="${NDMINORVERSION}" "${repo_root}/packaging/windows/installer.nsi"
 ${GITHUB_ACTIONS+echo "::endgroup::"}
+

--- a/packaging/windows/package-windows.sh
+++ b/packaging/windows/package-windows.sh
@@ -33,9 +33,15 @@ NDVERSION=$"$(grep 'CMAKE_PROJECT_VERSION:STATIC' "${build}/CMakeCache.txt"| cut
 NDMAJORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MAJOR:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
 NDMINORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MINOR:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
 
-if [ -f "/gpl-3.0.txt" ]; then
+if [ ! -f "/gpl-3.0.txt" ]; then
     ${GITHUB_ACTIONS+echo "::group::Fetching GPL3 License"}
     curl -o /gpl-3.0.txt "https://www.gnu.org/licenses/gpl-3.0.txt"
+    ${GITHUB_ACTIONS+echo "::endgroup::"}
+fi
+
+if [ ! -f "/cloud.txt" ]; then
+    ${GITHUB_ACTIONS+echo "::group::Fetching Cloud License"}
+    curl -o /cloud.txt "https://raw.githubusercontent.com/netdata/netdata/master/src/web/gui/v2/LICENSE.md"
     ${GITHUB_ACTIONS+echo "::endgroup::"}
 fi
 

--- a/packaging/windows/package-windows.sh
+++ b/packaging/windows/package-windows.sh
@@ -40,6 +40,8 @@ ${GITHUB_ACTIONS+echo "::endgroup::"}
 
 ${GITHUB_ACTIONS+echo "::group::Packaging"}
 tar -xf /msys2-latest.tar.zst -C /opt/netdata/ || exit 1
+cp -R /opt/netdata/msys64/* /opt/netdata/ || exit 1
+rm -rf /opt/netdata/msys64/
 NDVERSION=$"$(grep 'CMAKE_PROJECT_VERSION:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
 NDMAJORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MAJOR:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
 NDMINORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MINOR:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"

--- a/packaging/windows/package-windows.sh
+++ b/packaging/windows/package-windows.sh
@@ -1,9 +1,20 @@
 #!/bin/bash
 
-REPO_ROOT="$(dirname "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd -P)")")"
+repo_root="$(dirname "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd -P)")")"
 
-# shellcheck source=./win-build-dir.sh
-. "${REPO_ROOT}/packaging/windows/win-build-dir.sh"
+if [ -n "${BUILD_DIR}" ]; then
+    build="${BUILD_DIR}"
+elif [ -n "${OSTYPE}" ]; then
+    if [ -n "${MSYSTEM}" ]; then
+        build="${repo_root}/build-${OSTYPE}-${MSYSTEM}"
+    else
+        build="${repo_root}/build-${OSTYPE}"
+    fi
+elif [ "$USER" = "vk" ]; then
+    build="${repo_root}/build"
+else
+    build="${repo_root}/build"
+fi
 
 set -exu -o pipefail
 
@@ -13,7 +24,7 @@ ${GITHUB_ACTIONS+echo "::endgroup::"}
 
 if [ ! -f "/msys2-installer.exe" ]; then
     ${GITHUB_ACTIONS+echo "::group::Fetching MSYS2 installer"}
-    "${REPO_ROOT}/packaging/windows/fetch-msys2-installer.py" /msys2-installer.exe
+    "${repo_root}/packaging/windows/fetch-msys2-installer.py" /msys2-installer.exe
     ${GITHUB_ACTIONS+echo "::endgroup::"}
 fi
 
@@ -22,5 +33,11 @@ NDVERSION=$"$(grep 'CMAKE_PROJECT_VERSION:STATIC' "${build}/CMakeCache.txt"| cut
 NDMAJORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MAJOR:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
 NDMINORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MINOR:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
 
-/mingw64/bin/makensis.exe -DCURRVERSION="${NDVERSION}" -DMAJORVERSION="${NDMAJORVERSION}" -DMINORVERSION="${NDMINORVERSION}" "${REPO_ROOT}/packaging/windows/installer.nsi"
+if [ -f "/gpl-3.0.txt" ]; then
+    ${GITHUB_ACTIONS+echo "::group::Fetching GPL3 License"}
+    curl -o /gpl-3.0.txt "https://www.gnu.org/licenses/gpl-3.0.txt"
+    ${GITHUB_ACTIONS+echo "::endgroup::"}
+fi
+
+/mingw64/bin/makensis.exe -DCURRVERSION="${NDVERSION}" -DMAJORVERSION="${NDMAJORVERSION}" -DMINORVERSION="${NDMINORVERSION}" "${repo_root}/packaging/windows/installer.nsi"
 ${GITHUB_ACTIONS+echo "::endgroup::"}

--- a/packaging/windows/package-windows.sh
+++ b/packaging/windows/package-windows.sh
@@ -22,9 +22,9 @@ ${GITHUB_ACTIONS+echo "::group::Installing"}
 cmake --install "${build}"
 ${GITHUB_ACTIONS+echo "::endgroup::"}
 
-if [ ! -f "/msys2-x86_64-latest.sfx.exe" ]; then
-    ${GITHUB_ACTIONS+echo "::group::Fetching MSYS2 installer"}
-    "${repo_root}/packaging/windows/fetch-msys2-installer.py" /msys2-x86_64-latest.sfx.exe
+if [ ! -f "/msys2-latest.tar.zst" ]; then
+    ${GITHUB_ACTIONS+echo "::group::Fetching MSYS2 files"}
+    "${repo_root}/packaging/windows/fetch-msys2-installer.py" /msys2-latest.tar.zst
     ${GITHUB_ACTIONS+echo "::endgroup::"}
 fi
 
@@ -39,7 +39,7 @@ fi
 ${GITHUB_ACTIONS+echo "::endgroup::"}
 
 ${GITHUB_ACTIONS+echo "::group::Packaging"}
-cp /msys2-x86_64-latest.sfx.exe /opt/netdata/ || exit 1
+tar -xf /msys2-latest.tar.zst -C /opt/netdata/ || exit 1
 NDVERSION=$"$(grep 'CMAKE_PROJECT_VERSION:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
 NDMAJORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MAJOR:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
 NDMINORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MINOR:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"


### PR DESCRIPTION
l##### Summary
This PR is addressing https://github.com/netdata/netdata/issues/18213 some of remaining requirements for our installer. The unique missing action is the creation of a software to claim the agent instead to use our script. 

The following new features were added:

- Now installer have licenses (Cloud and GPL/3)
- Fields to add token and room (they are not used yet)
- Possibility to open a terminal
- Msys files were added to final installation without necessity to run another installer

##### Test Plan

1. Remove any previous installation in your `C:\msys64\opt\netdata`
2. Compile on windows using our script: `packaging/windows/compile-on-windows.sh`
3. Create the package: `packaging/windows/package-windows.sh`
4. Install the binary

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
