### PR TITLE
fix warnings in Dockerfile

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -3,7 +3,7 @@
 
 # This image contains preinstalled dependencies
 # hadolint ignore=DL3007
-FROM netdata/builder:v2 as builder
+FROM netdata/builder:v2 AS builder
 
 # One of 'nightly' or 'stable'
 ARG RELEASE_CHANNEL=nightly
@@ -60,7 +60,7 @@ RUN mkdir -p /app/usr/sbin/ \
 #####################################################################
 # This image contains preinstalled dependencies
 # hadolint ignore=DL3007
-FROM netdata/base:v2 as base
+FROM netdata/base:v2 AS base
 
 LABEL org.opencontainers.image.authors="Netdatabot <bot@netdata.cloud>"
 LABEL org.opencontainers.image.url="https://netdata.cloud"
@@ -77,11 +77,11 @@ ONBUILD ENV NETDATA_OFFICIAL_IMAGE=false
 
 ARG NETDATA_UID=201
 ARG NETDATA_GID=201
-ENV DOCKER_GRP netdata
-ENV DOCKER_USR netdata
+ENV DOCKER_GRP=netdata
+ENV DOCKER_USR=netdata
 # If DISABLE_TELEMETRY is set, it will disable anonymous stats collection and reporting
 #ENV DISABLE_TELEMETRY=1
-ENV NETDATA_LISTENER_PORT 19999
+ENV NETDATA_LISTENER_PORT=19999
 EXPOSE $NETDATA_LISTENER_PORT
 
 ENV NETDATA_EXTRA_DEB_PACKAGES=""


### PR DESCRIPTION
### Summary
Current Dockerfile emits warnings, this patch fixes them.

The warnings are visible on the Docker action:
![2024-08-22-172911_1326x738_scrot](https://github.com/user-attachments/assets/18caa12b-0e11-481f-853c-e5b27af3c96a)

Fixed with:
* use correct casing for "as" keyword
* remove legacy key/value format with whitespace separator for ENV

### Test Plan

Running a Docker build action should show no more warnings.

### Additional Information

Nobody likes warnings. This change has no impact on the behavior of the code, or on users.
