### PR TITLE
kickstart: fix write_claim_config when executed as a regular user

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1275,7 +1275,7 @@ write_claim_config() {
   run_as_root touch "${claim_config}.tmp" || return 1
   run_as_root chmod 0640 "${claim_config}.tmp" || return 1
   run_as_root chown ":${NETDATA_CLAIM_GROUP:-netdata}" "${claim_config}.tmp" || return 1
-  run_as_root echo "${config}" > "${claim_config}.tmp" || return 1
+  run_as_root sh -c "echo \"${config}\" > \"${claim_config}.tmp\" || exit 1"
   run_as_root mv -f "${claim_config}.tmp" "${claim_config}" || return 1
 
   if [ -z "${NETDATA_CLAIM_NORELOAD}" ]; then

--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1275,7 +1275,7 @@ write_claim_config() {
   run_as_root touch "${claim_config}.tmp" || return 1
   run_as_root chmod 0640 "${claim_config}.tmp" || return 1
   run_as_root chown ":${NETDATA_CLAIM_GROUP:-netdata}" "${claim_config}.tmp" || return 1
-  run_as_root sh -c "echo \"${config}\" > \"${claim_config}.tmp\" || exit 1"
+  run_as_root sh -c "echo \"${config}\" > \"${claim_config}.tmp\"" || return 1
   run_as_root mv -f "${claim_config}.tmp" "${claim_config}" || return 1
 
   if [ -z "${NETDATA_CLAIM_NORELOAD}" ]; then


### PR DESCRIPTION
##### Summary

[Reported on Discord](https://discord.com/channels/847502280503590932/1277069220575838229)

Fixes

> ./kickstart.sh: 1278: cannot create /opt/netdata/etc/netdata/claim.conf.tmp: Permission denied
 WARNING  Failed to write claiming configuration. This usually means you do not have permissions to access the configuration directory.


This line is a problem

https://github.com/netdata/netdata/blob/c4ad1e0174776ee128cfcde957b71db582854437/packaging/installer/kickstart.sh#L1278


When you run a command with sudo, it runs with elevated privileges. However, the shell handles the redirection, which is still running with your regular user's privileges.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
