### PR TITLE
Windows Permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,7 @@ Session.*.vim
 
 # Special exceptions
 !packaging/repoconfig/Makefile
+packaging/windows/resources/*.manifest
 
 # Jupyter notebook checkpoints
 .ipynb_checkpoints

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2247,6 +2247,9 @@ if(OS_WINDOWS)
 
         set(NETDATACLI_RES_FILES "packaging/windows/resources/netdatacli.rc")
         configure_file(packaging/windows/resources/netdatacli.manifest.in ${CMAKE_SOURCE_DIR}/packaging/windows/resources/netdatacli.manifest @ONLY)
+
+        set(NETDATA_RES_FILES "packaging/windows/resources/netdata.rc")
+        configure_file(packaging/windows/resources/netdata.manifest.in ${CMAKE_SOURCE_DIR}/packaging/windows/resources/netdata.manifest @ONLY)
 endif()
 
 add_executable(netdata
@@ -2255,6 +2258,7 @@ add_executable(netdata
         "$<$<BOOL:${ENABLE_H2O}>:${H2O_FILES}>"
         "$<$<BOOL:${ENABLE_EXPORTER_MONGODB}>:${MONGODB_EXPORTING_FILES}>"
         "$<$<BOOL:${ENABLE_EXPORTER_PROMETHEUS_REMOTE_WRITE}>:${PROMETHEUS_REMOTE_WRITE_EXPORTING_FILES}>"
+        "$<$<BOOL:${OS_WINDOWS}>:${NETDATA_RES_FILES}>"
 )
 
 if(OS_WINDOWS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3031,6 +3031,47 @@ if(OS_WINDOWS)
                       /usr/bin/whoami.exe
                 DESTINATION "${BINDIR}")
 
+        install(FILES /usr/bin/msys-2.0.dll
+                      /usr/bin/msys-asn1-8.dll
+                      /usr/bin/msys-brotlicommon-1.dll
+                      /usr/bin/msys-brotlidec-1.dll
+                      /usr/bin/msys-brotlienc-1.dll
+                      /usr/bin/msys-com_err-1.dll
+                      /usr/bin/msys-crypt-2.dll
+                      /usr/bin/msys-crypto-3.dll
+                      /usr/bin/msys-curl-4.dll
+                      /usr/bin/msys-gcc_s-seh-1.dll
+                      /usr/bin/msys-gmp-10.dll
+                      /usr/bin/msys-gssapi-3.dll
+                      /usr/bin/msys-hcrypto-4.dll
+                      /usr/bin/msys-heimbase-1.dll
+                      /usr/bin/msys-heimntlm-0.dll
+                      /usr/bin/msys-hx509-5.dll
+                      /usr/bin/msys-iconv-2.dll
+                      /usr/bin/msys-idn2-0.dll
+                      /usr/bin/msys-intl-8.dll
+                      /usr/bin/msys-krb5-26.dll
+                      /usr/bin/msys-lz4-1.dll
+                      /usr/bin/msys-mpfr-6.dll
+                      /usr/bin/msys-ncursesw6.dll
+                      /usr/bin/msys-nghttp2-14.dll
+                      /usr/bin/msys-pcre-1.dll
+                      /usr/bin/msys-protobuf-32.dll
+                      /usr/bin/msys-psl-5.dll
+                      /usr/bin/msys-readline8.dll
+                      /usr/bin/msys-roken-18.dll
+                      /usr/bin/msys-sqlite3-0.dll
+                      /usr/bin/msys-ssh2-1.dll
+                      /usr/bin/msys-ssl-3.dll
+                      /usr/bin/msys-stdc++-6.dll
+                      /usr/bin/msys-unistring-5.dll
+                      /usr/bin/msys-uuid-1.dll
+                      /usr/bin/msys-uv-1.dll
+                      /usr/bin/msys-wind-0.dll
+                      /usr/bin/msys-z.dll
+                      /usr/bin/msys-zstd-1.dll
+                DESTINATION "${BINDIR}")
+
         # Make bash & netdata happy
         install(DIRECTORY DESTINATION tmp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2241,6 +2241,14 @@ endif()
 # build netdata (only Linux ATM)
 #
 
+if(OS_WINDOWS)
+        set(NETDATA_CLAIM_RES_FILES "packaging/windows/resources/netdata_claim.rc")
+        configure_file(packaging/windows/resources/netdata_claim.manifest.in ${CMAKE_SOURCE_DIR}/packaging/windows/resources/netdata_claim.manifest @ONLY)
+
+        set(NETDATACLI_RES_FILES "packaging/windows/resources/netdatacli.rc")
+        configure_file(packaging/windows/resources/netdatacli.manifest.in ${CMAKE_SOURCE_DIR}/packaging/windows/resources/netdatacli.manifest @ONLY)
+endif()
+
 add_executable(netdata
         ${NETDATA_FILES}
         "${ACLK_FILES}"
@@ -2250,9 +2258,6 @@ add_executable(netdata
 )
 
 if(OS_WINDOWS)
-        set(NETDATA_CLAIM_RES_FILES "packaging/windows/resources/netdata_claim.rc")
-        configure_file(packaging/windows/resources/netdata_claim.manifest.in ${CMAKE_SOURCE_DIR}/packaging/windows/resources/netdata_claim.manifest @ONLY)
-
         add_executable(netdata_claim ${CLAIM_WINDOWS_FILES} ${NETDATA_CLAIM_RES_FILES})
         target_link_libraries(netdata_claim shell32;gdi32;msftedit)
 endif()
@@ -2354,7 +2359,7 @@ set(NETDATACLI_FILES
         src/cli/cli.c
 )
 
-add_executable(netdatacli ${NETDATACLI_FILES})
+add_executable(netdatacli ${NETDATACLI_FILES} "$<$<BOOL:${OS_WINDOWS}>:${NETDATACLI_RES_FILES}>")
 target_link_libraries(netdatacli libnetdata)
 
 install(TARGETS netdatacli
@@ -3020,47 +3025,6 @@ if(OS_WINDOWS)
                       /usr/bin/tr.exe
                       /usr/bin/uuidgen.exe
                       /usr/bin/whoami.exe
-                DESTINATION "${BINDIR}")
-
-        install(FILES /usr/bin/msys-2.0.dll
-                      /usr/bin/msys-asn1-8.dll
-                      /usr/bin/msys-brotlicommon-1.dll
-                      /usr/bin/msys-brotlidec-1.dll
-                      /usr/bin/msys-brotlienc-1.dll
-                      /usr/bin/msys-com_err-1.dll
-                      /usr/bin/msys-crypt-2.dll
-                      /usr/bin/msys-crypto-3.dll
-                      /usr/bin/msys-curl-4.dll
-                      /usr/bin/msys-gcc_s-seh-1.dll
-                      /usr/bin/msys-gmp-10.dll
-                      /usr/bin/msys-gssapi-3.dll
-                      /usr/bin/msys-hcrypto-4.dll
-                      /usr/bin/msys-heimbase-1.dll
-                      /usr/bin/msys-heimntlm-0.dll
-                      /usr/bin/msys-hx509-5.dll
-                      /usr/bin/msys-iconv-2.dll
-                      /usr/bin/msys-idn2-0.dll
-                      /usr/bin/msys-intl-8.dll
-                      /usr/bin/msys-krb5-26.dll
-                      /usr/bin/msys-lz4-1.dll
-                      /usr/bin/msys-mpfr-6.dll
-                      /usr/bin/msys-ncursesw6.dll
-                      /usr/bin/msys-nghttp2-14.dll
-                      /usr/bin/msys-pcre-1.dll
-                      /usr/bin/msys-protobuf-32.dll
-                      /usr/bin/msys-psl-5.dll
-                      /usr/bin/msys-readline8.dll
-                      /usr/bin/msys-roken-18.dll
-                      /usr/bin/msys-sqlite3-0.dll
-                      /usr/bin/msys-ssh2-1.dll
-                      /usr/bin/msys-ssl-3.dll
-                      /usr/bin/msys-stdc++-6.dll
-                      /usr/bin/msys-unistring-5.dll
-                      /usr/bin/msys-uuid-1.dll
-                      /usr/bin/msys-uv-1.dll
-                      /usr/bin/msys-wind-0.dll
-                      /usr/bin/msys-z.dll
-                      /usr/bin/msys-zstd-1.dll
                 DESTINATION "${BINDIR}")
 
         # Make bash & netdata happy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2251,6 +2251,7 @@ add_executable(netdata
 
 if(OS_WINDOWS)
         set(NETDATA_CLAIM_RES_FILES "packaging/windows/resources/netdata_claim.rc")
+        configure_file(packaging/windows/resources/netdata_claim.manifest.in ${CMAKE_SOURCE_DIR}/packaging/windows/resources/netdata_claim.manifest @ONLY)
 
         add_executable(netdata_claim ${CLAIM_WINDOWS_FILES} ${NETDATA_CLAIM_RES_FILES})
         target_link_libraries(netdata_claim shell32;gdi32;msftedit)

--- a/packaging/windows/resources/netdata.manifest.in
+++ b/packaging/windows/resources/netdata.manifest.in
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+	<assemblyIdentity version="@CMAKE_PROJECT_VERSION@"
+     processorArchitecture="*"
+     name="netdata"
+     type="win32"/>
+	<description>Netdata Claim!</description>
+	<!-- Identify the application security requirements. -->
+	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+		<security>
+			<requestedPrivileges>
+				<requestedExecutionLevel level="requireAdministrator" uiAccess="false"/>
+			</requestedPrivileges>
+		</security>
+	</trustInfo>
+</assembly>

--- a/packaging/windows/resources/netdata.manifest.in
+++ b/packaging/windows/resources/netdata.manifest.in
@@ -4,7 +4,7 @@
      processorArchitecture="*"
      name="netdata"
      type="win32"/>
-	<description>Netdata Claim!</description>
+	<description>Netdata is a high-performance, cloud-native, and on-premises observability platform designed to monitor metrics and logs with unparalleled efficiency.</description>
 	<!-- Identify the application security requirements. -->
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
 		<security>

--- a/packaging/windows/resources/netdata.rc
+++ b/packaging/windows/resources/netdata.rc
@@ -1,0 +1,3 @@
+#include "winuser.h"
+1 RT_MANIFEST "netdata.manifest"
+11 ICON "../NetdataWhite.ico"

--- a/packaging/windows/resources/netdata_claim.manifest.in
+++ b/packaging/windows/resources/netdata_claim.manifest.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-	<assemblyIdentity version="1.99.0.0"
+	<assemblyIdentity version="@CMAKE_PROJECT_VERSION@"
      processorArchitecture="*"
      name="netdata_claim"
      type="win32"/>

--- a/packaging/windows/resources/netdatacli.manifest.in
+++ b/packaging/windows/resources/netdatacli.manifest.in
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+	<assemblyIdentity version="@CMAKE_PROJECT_VERSION@"
+     processorArchitecture="*"
+     name="netdatacli"
+     type="win32"/>
+	<description>Netdata Claim!</description>
+	<!-- Identify the application security requirements. -->
+	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+		<security>
+			<requestedPrivileges>
+				<requestedExecutionLevel level="requireAdministrator" uiAccess="false"/>
+			</requestedPrivileges>
+		</security>
+	</trustInfo>
+</assembly>

--- a/packaging/windows/resources/netdatacli.manifest.in
+++ b/packaging/windows/resources/netdatacli.manifest.in
@@ -4,7 +4,7 @@
      processorArchitecture="*"
      name="netdatacli"
      type="win32"/>
-	<description>Netdata Claim!</description>
+	<description>The netdatacli executable provides a simple way to control the Netdata agent's operation.</description>
 	<!-- Identify the application security requirements. -->
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
 		<security>

--- a/packaging/windows/resources/netdatacli.rc
+++ b/packaging/windows/resources/netdatacli.rc
@@ -1,0 +1,3 @@
+#include "winuser.h"
+1 RT_MANIFEST "netdatacli.manifest"
+11 ICON "../NetdataWhite.ico"


### PR DESCRIPTION
##### Summary
This PR adds the missing `manifests` and `resources` for our binaries and automates the versioning process for generating them. 

A subsequent PR will further clean up the code and implement the naming pattern requested by @ilyam8 .

##### Test Plan

1. Compile this branch
2. Make an installer
3. Update your system and verify that Netdata is running on Microsoft Windows. In addition, go to your `NETDATA_INSTALL_PATH\usr\bin` and confirm all binaries have Netdata icon:

![Screenshot_20240901_180805](https://github.com/user-attachments/assets/8122d5ef-f7a7-49c6-84ca-d20e8aba3db3)

##### Additional Information

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
