### PR TITLE
Exit slabinfo.plugin on EPIPE

### DIFF
--- a/src/collectors/slabinfo.plugin/slabinfo.c
+++ b/src/collectors/slabinfo.plugin/slabinfo.c
@@ -318,6 +318,12 @@ unsigned int do_slab_stats(int update_every) {
         }
         printf("END\n");
 
+        fprintf(stdout, "\n");
+        fflush(stdout);
+        if (ferror(stdout) && errno == EPIPE) {
+            netdata_log_error("error writing to stdout: EPIPE. Exiting...");
+            return loops;
+        }
 
         loops++;
 


### PR DESCRIPTION
##### Summary

At the moment slabinfo.plugin does not exit when netdata is killed, this PR fixes the issue in exactly the same way it's handled in debugfs.plugin (https://github.com/netdata/netdata/pull/16569) and cups.plugin (https://github.com/netdata/netdata/pull/16691).

##### Additional Information

The issue may be reproduced the same way as in https://github.com/netdata/netdata/pull/16569:
* running netdata manually
* killing netdata (or spawn server and netdata if spawn server is present in used version) with SIGKILL

E.g.
```
$ docker run --rm -t -i --entrypoint bash netdata/netdata:stable
root@bc58059db6cc:/# cat >> /etc/netdata/netdata.conf << EOF
[plugins]
    slabinfo = yes
EOF
root@bc58059db6cc:/# netdata >/dev/null 2>&1 & disown
[1] 8
root@bc58059db6cc:/# ps auxf
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   4704  3840 pts/0    Ss   15:24   0:00 bash
netdata       10  2.5  0.0 1055240 30576 ?       SNl  15:24   0:00 netdata
netdata       11  0.0  0.0  71512 13560 ?        SN   15:24   0:00  \_ spawn-p
netdata      338  0.1  0.0   4188  3072 ?        SN   15:24   0:00      \_ bash /usr/libexec/netdata/plugins.d/tc-qos-helper.sh 1
root         341  0.8  0.1 1310528 61952 ?       SNl  15:24   0:00      \_ /usr/libexec/netdata/plugins.d/go.d.plugin 1
root         348  0.2  0.0  12364  4480 ?        SN   15:24   0:00      \_ /usr/libexec/netdata/plugins.d/slabinfo.plugin 1
root         406  0.1  0.0 127552  4864 ?        SNl  15:24   0:00      \_ /usr/libexec/netdata/plugins.d/network-viewer.plugin 1
root         418  0.0  0.0  12840  2384 ?        SN   15:24   0:00      |   \_ spawn-setns
root         411  0.2  0.0 144880  5888 ?        SNl  15:24   0:00      \_ /usr/libexec/netdata/plugins.d/apps.plugin 1
root         538  0.0  0.0   8100  4096 pts/0    R+   15:24   0:00 ps auxf
root@bc58059db6cc:/# kill -9 11 10  # kill both netdata and spawn server
root@bc58059db6cc:/# ps auxf
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   4704  3840 pts/0    Ss   15:24   0:00 bash
root         348  0.2  0.0  12364  4480 ?        SN   15:24   0:00 /usr/libexec/netdata/plugins.d/slabinfo.plugin 1
root         540  0.0  0.0   8100  4224 pts/0    R+   15:25   0:00 ps auxf
root@bc58059db6cc:/#
```
