### PR TITLE
Remove Warnings (ebpf)

### DIFF
--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -4074,7 +4074,6 @@ int main(int argc, char **argv)
     heartbeat_t hb;
     heartbeat_init(&hb);
     int update_apps_every = (int) EBPF_CFG_UPDATE_APPS_EVERY_DEFAULT;
-    uint32_t max_period = EBPF_CLEANUP_FACTOR;
     int update_apps_list = update_apps_every - 1;
     int process_maps_per_core = ebpf_modules[EBPF_MODULE_PROCESS_IDX].maps_per_core;
     //Plugin will be killed when it receives a signal
@@ -4097,7 +4096,7 @@ int main(int argc, char **argv)
                 pthread_mutex_lock(&collect_data_mutex);
                 ebpf_parse_proc_files();
                 if (collect_pids & (1<<EBPF_MODULE_PROCESS_IDX)) {
-                    collect_data_for_all_processes(process_pid_fd, process_maps_per_core, max_period);
+                    collect_data_for_all_processes(process_pid_fd, process_maps_per_core);
                 }
 
                 ebpf_create_apps_charts(apps_groups_root_target);

--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -1662,7 +1662,7 @@ void ebpf_clean_ip_structure(ebpf_network_viewer_ip_list_t **clean)
  * @param out a pointer to store the link list
  * @param ip the value given as parameter
  */
-static void ebpf_parse_ip_list_unsafe(void **out, char *ip)
+static void ebpf_parse_ip_list_unsafe(void **out, const char *ip)
 {
     ebpf_network_viewer_ip_list_t **list = (ebpf_network_viewer_ip_list_t **)out;
 
@@ -2773,7 +2773,7 @@ static inline void ebpf_set_load_mode(netdata_ebpf_load_mode_t load, netdata_ebp
  *  @param str      value read from configuration file.
  *  @param origin   specify the configuration file loaded
  */
-static inline void epbf_update_load_mode(char *str, netdata_ebpf_load_mode_t origin)
+static inline void epbf_update_load_mode(const char *str, netdata_ebpf_load_mode_t origin)
 {
     netdata_ebpf_load_mode_t load = epbf_convert_string_to_load_mode(str);
 

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -495,7 +495,7 @@ int ebpf_read_hash_table(void *ep, int fd, uint32_t pid);
 
 int get_pid_comm(pid_t pid, size_t n, char *dest);
 
-void collect_data_for_all_processes(int tbl_pid_stats_fd, int maps_per_core, uint32_t max_period);
+void collect_data_for_all_processes(int tbl_pid_stats_fd, int maps_per_core);
 void ebpf_process_apps_accumulator(ebpf_process_stat_t *out, int maps_per_core);
 
 // The default value is at least 32 times smaller than maximum number of PIDs allowed on system,

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -712,9 +712,8 @@ static inline void cachestat_save_pid_values(netdata_publish_cachestat_t *out, n
  * Read the apps table and store data inside the structure.
  *
  * @param maps_per_core do I need to read all cores?
- * @param max_period    limit of iterations without updates before remove data from hash table
  */
-static void ebpf_read_cachestat_apps_table(int maps_per_core, uint32_t max_period)
+static void ebpf_read_cachestat_apps_table(int maps_per_core)
 {
     netdata_cachestat_pid_t *cv = cachestat_vector;
     int fd = cachestat_maps[NETDATA_CACHESTAT_PID_STATS].map_fd;
@@ -845,7 +844,6 @@ void *ebpf_read_cachestat_thread(void *ptr)
 
     int maps_per_core = em->maps_per_core;
     int update_every = em->update_every;
-    uint32_t max_period = EBPF_CLEANUP_FACTOR;
 
     int counter = update_every - 1;
 
@@ -859,7 +857,7 @@ void *ebpf_read_cachestat_thread(void *ptr)
             continue;
 
         pthread_mutex_lock(&collect_data_mutex);
-        ebpf_read_cachestat_apps_table(maps_per_core, max_period);
+        ebpf_read_cachestat_apps_table(maps_per_core);
         ebpf_resume_apps_data();
         pthread_mutex_unlock(&collect_data_mutex);
 

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -538,9 +538,8 @@ static void ebpf_dcstat_apps_accumulator(netdata_dcstat_pid_t *out, int maps_per
  * Read the apps table and store data inside the structure.
  *
  * @param maps_per_core do I need to read all cores?
- * @param max_period    limit of iterations without updates before remove data from hash table
  */
-static void ebpf_read_dc_apps_table(int maps_per_core, uint32_t max_period)
+static void ebpf_read_dc_apps_table(int maps_per_core)
 {
     netdata_dcstat_pid_t *cv = dcstat_vector;
     int fd = dcstat_maps[NETDATA_DCSTAT_PID_STATS].map_fd;
@@ -656,7 +655,6 @@ void *ebpf_read_dcstat_thread(void *ptr)
     uint32_t lifetime = em->lifetime;
     uint32_t running_time = 0;
     usec_t period = update_every * USEC_PER_SEC;
-    uint32_t max_period = EBPF_CLEANUP_FACTOR;
     pids_fd[EBPF_PIDS_DCSTAT_IDX] = dcstat_maps[NETDATA_DCSTAT_PID_STATS].map_fd;
     while (!ebpf_plugin_stop() && running_time < lifetime) {
         (void)heartbeat_next(&hb, period);
@@ -664,7 +662,7 @@ void *ebpf_read_dcstat_thread(void *ptr)
             continue;
 
         pthread_mutex_lock(&collect_data_mutex);
-        ebpf_read_dc_apps_table(maps_per_core, max_period);
+        ebpf_read_dc_apps_table(maps_per_core);
         ebpf_dc_resume_apps_data();
         pthread_mutex_unlock(&collect_data_mutex);
 

--- a/src/collectors/ebpf.plugin/ebpf_fd.c
+++ b/src/collectors/ebpf.plugin/ebpf_fd.c
@@ -681,9 +681,8 @@ static void fd_apps_accumulator(netdata_fd_stat_t *out, int maps_per_core)
  * Read the apps table and store data inside the structure.
  *
  * @param maps_per_core do I need to read all cores?
- * @param max_period    limit of iterations without updates before remove data from hash table
  */
-static void ebpf_read_fd_apps_table(int maps_per_core, uint32_t max_period)
+static void ebpf_read_fd_apps_table(int maps_per_core)
 {
     netdata_fd_stat_t *fv = fd_vector;
     int fd = fd_maps[NETDATA_FD_PID_STATS].map_fd;
@@ -797,7 +796,6 @@ void *ebpf_read_fd_thread(void *ptr)
     uint32_t lifetime = em->lifetime;
     uint32_t running_time = 0;
     int period = USEC_PER_SEC;
-    uint32_t max_period = EBPF_CLEANUP_FACTOR;
     pids_fd[EBPF_PIDS_FD_IDX] = fd_maps[NETDATA_FD_PID_STATS].map_fd;
     while (!ebpf_plugin_stop() && running_time < lifetime) {
         (void)heartbeat_next(&hb, period);
@@ -805,7 +803,7 @@ void *ebpf_read_fd_thread(void *ptr)
             continue;
 
         pthread_mutex_lock(&collect_data_mutex);
-        ebpf_read_fd_apps_table(maps_per_core, max_period);
+        ebpf_read_fd_apps_table(maps_per_core);
         ebpf_fd_resume_apps_data();
         pthread_mutex_unlock(&collect_data_mutex);
 

--- a/src/collectors/ebpf.plugin/ebpf_shm.c
+++ b/src/collectors/ebpf.plugin/ebpf_shm.c
@@ -565,9 +565,8 @@ static void ebpf_update_shm_cgroup()
  * Read the apps table and store data inside the structure.
  *
  * @param maps_per_core do I need to read all cores?
- * @param max_period    limit of iterations without updates before remove data from hash table
  */
-static void ebpf_read_shm_apps_table(int maps_per_core, uint32_t max_period)
+static void ebpf_read_shm_apps_table(int maps_per_core)
 {
     netdata_ebpf_shm_t *cv = shm_vector;
     int fd = shm_maps[NETDATA_PID_SHM_TABLE].map_fd;
@@ -1075,7 +1074,6 @@ void *ebpf_read_shm_thread(void *ptr)
     uint32_t lifetime = em->lifetime;
     uint32_t running_time = 0;
     usec_t period = update_every * USEC_PER_SEC;
-    uint32_t max_period = EBPF_CLEANUP_FACTOR;
     pids_fd[EBPF_PIDS_SHM_IDX] = shm_maps[NETDATA_PID_SHM_TABLE].map_fd;
     while (!ebpf_plugin_stop() && running_time < lifetime) {
         (void)heartbeat_next(&hb, period);
@@ -1083,7 +1081,7 @@ void *ebpf_read_shm_thread(void *ptr)
             continue;
 
         pthread_mutex_lock(&collect_data_mutex);
-        ebpf_read_shm_apps_table(maps_per_core, max_period);
+        ebpf_read_shm_apps_table(maps_per_core);
         ebpf_shm_resume_apps_data();
         pthread_mutex_unlock(&collect_data_mutex);
 

--- a/src/collectors/ebpf.plugin/ebpf_swap.c
+++ b/src/collectors/ebpf.plugin/ebpf_swap.c
@@ -539,9 +539,8 @@ void ebpf_swap_resume_apps_data() {
  * Read the apps table and store data inside the structure.
  *
  * @param maps_per_core do I need to read all cores?
- * @param max_period    limit of iterations without updates before remove data from hash table
  */
-static void ebpf_read_swap_apps_table(int maps_per_core, uint32_t max_period)
+static void ebpf_read_swap_apps_table(int maps_per_core)
 {
     netdata_ebpf_swap_t *cv = swap_vector;
     int fd = swap_maps[NETDATA_PID_SWAP_TABLE].map_fd;
@@ -609,7 +608,6 @@ void *ebpf_read_swap_thread(void *ptr)
     uint32_t lifetime = em->lifetime;
     uint32_t running_time = 0;
     usec_t period = update_every * USEC_PER_SEC;
-    uint32_t max_period = EBPF_CLEANUP_FACTOR;
     pids_fd[EBPF_PIDS_SWAP_IDX] = swap_maps[NETDATA_PID_SWAP_TABLE].map_fd;
 
     while (!ebpf_plugin_stop() && running_time < lifetime) {
@@ -618,7 +616,7 @@ void *ebpf_read_swap_thread(void *ptr)
             continue;
 
         pthread_mutex_lock(&collect_data_mutex);
-        ebpf_read_swap_apps_table(maps_per_core, max_period);
+        ebpf_read_swap_apps_table(maps_per_core);
         ebpf_swap_resume_apps_data();
         pthread_mutex_unlock(&collect_data_mutex);
 


### PR DESCRIPTION
##### Summary
This PR removes warnings when eBPF plugin is compiled.

##### Test Plan

1. Compile this Branch with the following CFLAGS and verify there is no warnings in plugin files:

```sh
CFLAGS="-O1 -ggdb -Wall -Wextra -fno-omit-frame-pointer -Wformat-signedness -fstack-protector-all -Wformat-truncation=2 -Wunused-result
```

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
