### PR TITLE
Improve processing on removed alerts after agent restart

### DIFF
--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -430,10 +430,8 @@ static void sql_inject_removed_status(
         int64_t health_log_id = sqlite3_column_int64(res, 0);
         RRDCALC_STATUS old_status = (RRDCALC_STATUS)sqlite3_column_double(res, 1);
         insert_alert_queue(
-            host, health_log_id, (int64_t)unique_id, (int64_t)alarm_id, old_status, RRDCALC_STATUS_REMOVED);
+            host, health_log_id, (int64_t)max_unique_id, (int64_t)alarm_id, old_status, RRDCALC_STATUS_REMOVED);
     }
-    //else
-    //   error_report("HEALTH [N/A]: Failed to execute SQL_INJECT_REMOVED, rc = %d", rc);
 
 done:
     REPORT_BIND_FAIL(res, param);


### PR DESCRIPTION
##### Summary
There is a bug when scheduling removed (deleted) alerts after an agent restart. If an alert has been in WARNING or CRITICAL it is not removed and appears stale.

This PR fixes this issue

