### PR TITLE
Windows Plugin Metrics (Thermal and Memory)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -430,8 +430,6 @@
 - Regenerate integrations.js [\#17933](https://github.com/netdata/netdata/pull/17933) ([netdatabot](https://github.com/netdatabot))
 - go.d whoisquery fix defaults in config\_schema [\#17932](https://github.com/netdata/netdata/pull/17932) ([ilyam8](https://github.com/ilyam8))
 - Move to using CPack for repository configuration packages. [\#17930](https://github.com/netdata/netdata/pull/17930) ([Ferroin](https://github.com/Ferroin))
-- go.d bump github.com/docker/docker v27.0.0+incompatible [\#17921](https://github.com/netdata/netdata/pull/17921) ([ilyam8](https://github.com/ilyam8))
-- Bump github.com/jessevdk/go-flags from 1.5.0 to 1.6.1 in /src/go/collectors/go.d.plugin [\#17919](https://github.com/netdata/netdata/pull/17919) ([dependabot[bot]](https://github.com/apps/dependabot))
 
 ## [v1.45.6](https://github.com/netdata/netdata/tree/v1.45.6) (2024-06-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -430,6 +430,8 @@
 - Regenerate integrations.js [\#17933](https://github.com/netdata/netdata/pull/17933) ([netdatabot](https://github.com/netdatabot))
 - go.d whoisquery fix defaults in config\_schema [\#17932](https://github.com/netdata/netdata/pull/17932) ([ilyam8](https://github.com/ilyam8))
 - Move to using CPack for repository configuration packages. [\#17930](https://github.com/netdata/netdata/pull/17930) ([Ferroin](https://github.com/Ferroin))
+- go.d bump github.com/docker/docker v27.0.0+incompatible [\#17921](https://github.com/netdata/netdata/pull/17921) ([ilyam8](https://github.com/ilyam8))
+- Bump github.com/jessevdk/go-flags from 1.5.0 to 1.6.1 in /src/go/collectors/go.d.plugin [\#17919](https://github.com/netdata/netdata/pull/17919) ([dependabot[bot]](https://github.com/apps/dependabot))
 
 ## [v1.45.6](https://github.com/netdata/netdata/tree/v1.45.6) (2024-06-05)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1426,6 +1426,7 @@ set(WINDOWS_PLUGIN_FILES
         src/collectors/windows.plugin/perflib-dump.c
         src/collectors/windows.plugin/perflib-storage.c
         src/collectors/windows.plugin/perflib-processor.c
+        src/collectors/windows.plugin/perflib-thermalzone.c
         src/collectors/windows.plugin/perflib-objects.c
         src/collectors/windows.plugin/perflib-network.c
         src/collectors/windows.plugin/perflib-memory.c

--- a/src/collectors/all.h
+++ b/src/collectors/all.h
@@ -79,6 +79,7 @@
 #define NETDATA_CHART_PRIO_MEM_SWAP_CALLS             1037
 #define NETDATA_CHART_PRIO_MEM_SWAP_PAGES             1037 // Windows only
 #define NETDATA_CHART_PRIO_MEM_SWAPIO                 1038
+#define NETDATA_CHART_PRIO_MEM_SYSTEM_POOL            1039 // Windows only
 #define NETDATA_CHART_PRIO_MEM_ZSWAP                  1036
 #define NETDATA_CHART_PRIO_MEM_ZSWAPIO                1037
 #define NETDATA_CHART_PRIO_MEM_ZSWAP_COMPRESS_RATIO   1038

--- a/src/collectors/all.h
+++ b/src/collectors/all.h
@@ -55,6 +55,7 @@
 #define NETDATA_CHART_PRIO_SYSTEM_IPC_SHARED_MEM_CALLS 1207
 #define NETDATA_CHART_PRIO_SYSTEM_PACKETS              7001 // freebsd only
 #define NETDATA_CHART_PRIO_WINDOWS_THREADS             8001 // Windows only
+#define NETDATA_CHART_PRIO_WINDOWS_THERMAL_ZONES       8002 // Windows only
 
 
 // CPU per core

--- a/src/collectors/all.h
+++ b/src/collectors/all.h
@@ -77,6 +77,7 @@
 #define NETDATA_CHART_PRIO_MEM_SYSTEM_COMMITTED       1030
 #define NETDATA_CHART_PRIO_MEM_SWAP                   1035
 #define NETDATA_CHART_PRIO_MEM_SWAP_CALLS             1037
+#define NETDATA_CHART_PRIO_MEM_SWAP_PAGES             1037 // Windows only
 #define NETDATA_CHART_PRIO_MEM_SWAPIO                 1038
 #define NETDATA_CHART_PRIO_MEM_ZSWAP                  1036
 #define NETDATA_CHART_PRIO_MEM_ZSWAPIO                1037

--- a/src/collectors/windows.plugin/perflib-memory.c
+++ b/src/collectors/windows.plugin/perflib-memory.c
@@ -134,7 +134,8 @@ static void do_memory_system_pool(PERF_DATA_BLOCK *pDataBlock, PERF_OBJECT_TYPE 
             "mem"
         , "system_pool", NULL
         , "mem"
-        , "mem.system_pool"
+        , "mem.system_pool_size"
+
         , "System Memory Pool"
         , "bytes"
         , PLUGIN_WINDOWS_NAME

--- a/src/collectors/windows.plugin/perflib-memory.c
+++ b/src/collectors/windows.plugin/perflib-memory.c
@@ -66,7 +66,8 @@ static void do_memory_swap(PERF_DATA_BLOCK *pDataBlock, PERF_OBJECT_TYPE *pObjec
             "mem"
         , "swap_operations", NULL
         , "swap"
-        , "mem.swap_operations"
+        , "mem.swap_iops"
+
         , "Swap Operations"
         , "operations/s"
         , PLUGIN_WINDOWS_NAME

--- a/src/collectors/windows.plugin/perflib-memory.c
+++ b/src/collectors/windows.plugin/perflib-memory.c
@@ -97,7 +97,8 @@ static void do_memory_swap(PERF_DATA_BLOCK *pDataBlock, PERF_OBJECT_TYPE *pObjec
             "mem"
         , "swap_pages", NULL
         , "swap"
-        , "mem.swap_pages"
+        , "mem.swap_pages_io"
+
         , "Swap Pages"
         , "pages/s"
         , PLUGIN_WINDOWS_NAME

--- a/src/collectors/windows.plugin/perflib-thermalzone.c
+++ b/src/collectors/windows.plugin/perflib-thermalzone.c
@@ -60,7 +60,7 @@ static bool do_thermal_zones(PERF_DATA_BLOCK *pDataBlock, int update_every) {
                 , "ThermalZone"
                 , NETDATA_CHART_PRIO_WINDOWS_THERMAL_ZONES
                 , update_every
-                , RRDSET_TYPE_STACKED
+                , RRDSET_TYPE_LINE
             );
 
             p->rd  = rrddim_add(p->st,

--- a/src/collectors/windows.plugin/perflib-thermalzone.c
+++ b/src/collectors/windows.plugin/perflib-thermalzone.c
@@ -69,6 +69,8 @@ static bool do_thermal_zones(PERF_DATA_BLOCK *pDataBlock, int update_every) {
                                1,
                                1,
                                RRD_ALGORITHM_ABSOLUTE);
+
+            rrdlabels_add(st->rrdlabels, "thermalzone", windows_shared_buffer, RRDLABEL_SRC_AUTO);
         }
 
         // Convert to Celsius before to plot

--- a/src/collectors/windows.plugin/perflib-thermalzone.c
+++ b/src/collectors/windows.plugin/perflib-thermalzone.c
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "windows_plugin.h"
+#include "windows-internals.h"
+
+typedef struct thermal_zone {
+    RRDSET *st;
+    RRDDIM *rd;
+
+    COUNTER_DATA thermalZoneTemperature;
+};
+
+static inline void initialize_thermal_zone_keys(struct thermal_zone *p) {
+    p->thermalZoneTemperature.key = "Temperature";
+}
+
+void dict_thermal_zone_insert_cb(const DICTIONARY_ITEM *item __maybe_unused, void *value, void *data __maybe_unused) {
+    struct thermal_zone *p = value;
+    initialize_thermal_zone_keys(p);
+}
+
+static DICTIONARY *thermal_zones = NULL;
+
+static void initialize(void) {
+    thermal_zones = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE |
+                                                DICT_OPTION_FIXED_SIZE, NULL, sizeof(struct thermal_zone));
+
+    dictionary_register_insert_callback(thermal_zones, dict_thermal_zone_insert_cb, NULL);
+}
+
+static bool do_thermal_zones(PERF_DATA_BLOCK *pDataBlock, int update_every) {
+    PERF_OBJECT_TYPE *pObjectType = perflibFindObjectTypeByName(pDataBlock, "Thermal Zone Information");
+    if(!pObjectType) return false;
+
+    PERF_INSTANCE_DEFINITION *pi = NULL;
+    for(LONG i = 0; i < pObjectType->NumInstances ; i++) {
+        pi = perflibForEachInstance(pDataBlock, pObjectType, pi);
+        if(!pi) break;
+
+        if(!getInstanceName(pDataBlock, pObjectType, pi, windows_shared_buffer, sizeof(windows_shared_buffer)))
+            strncpyz(windows_shared_buffer, "[unknown]", sizeof(windows_shared_buffer) - 1);
+
+        netdata_fix_chart_name(windows_shared_buffer);
+        struct thermal_zone *p = dictionary_set(thermal_zones, windows_shared_buffer, NULL, sizeof(*p));
+
+        perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &p->thermalZoneTemperature);
+
+        // https://learn.microsoft.com/en-us/windows-hardware/design/device-experiences/design-guide
+        if(!p->st) {
+            char id[RRD_ID_LENGTH_MAX + 1];
+            snprintfz(id, RRD_ID_LENGTH_MAX, "thermalzone_%s_temperature", windows_shared_buffer);
+            p->st = rrdset_create_localhost(
+                "system"
+                , id, NULL
+                , "thermalzone"
+                , "system.thermalzone_temperature"
+                , "Thermal zone temperature"
+                , "Celsius"
+                , PLUGIN_WINDOWS_NAME
+                , "ThermalZone"
+                , NETDATA_CHART_PRIO_WINDOWS_THERMAL_ZONES
+                , update_every
+                , RRDSET_TYPE_STACKED
+            );
+
+            p->rd  = rrddim_add(p->st,
+                               id,
+                               "temperature",
+                               1,
+                               1,
+                               RRD_ALGORITHM_ABSOLUTE);
+        }
+
+        // Convert to Celsius before to plot
+        NETDATA_DOUBLE kTemperature = (NETDATA_DOUBLE)p->thermalZoneTemperature.current.Data;
+        kTemperature -= 273.15;
+
+        rrddim_set_by_pointer(p->st, p->rd, (collected_number)kTemperature);
+        rrdset_done(p->st);
+    }
+
+    return true;
+}
+
+int do_PerflibThermalZone(int update_every, usec_t dt __maybe_unused) {
+    static bool initialized = false;
+
+    if(unlikely(!initialized)) {
+        initialize();
+        initialized = true;
+    }
+
+    DWORD id = RegistryFindIDByName("Thermal Zone Information");
+    if(id == PERFLIB_REGISTRY_NAME_NOT_FOUND)
+        return -1;
+
+    PERF_DATA_BLOCK *pDataBlock = perflibGetPerformanceData(id);
+    if(!pDataBlock) return -1;
+
+    do_thermal_zones(pDataBlock, update_every);
+
+    return 0;
+}

--- a/src/collectors/windows.plugin/perflib-thermalzone.c
+++ b/src/collectors/windows.plugin/perflib-thermalzone.c
@@ -70,7 +70,7 @@ static bool do_thermal_zones(PERF_DATA_BLOCK *pDataBlock, int update_every) {
                                1,
                                RRD_ALGORITHM_ABSOLUTE);
 
-            rrdlabels_add(st->rrdlabels, "thermalzone", windows_shared_buffer, RRDLABEL_SRC_AUTO);
+            rrdlabels_add(p->st->rrdlabels, "thermalzone", windows_shared_buffer, RRDLABEL_SRC_AUTO);
         }
 
         // Convert to Celsius before to plot

--- a/src/collectors/windows.plugin/windows_plugin.c
+++ b/src/collectors/windows.plugin/windows_plugin.c
@@ -26,6 +26,8 @@ static struct proc_module {
     {.name = "PerflibNetwork",      .dim = "PerflibNetwork",          .func = do_PerflibNetwork},
     {.name = "PerflibObjects",      .dim = "PerflibObjects",          .func = do_PerflibObjects},
 
+    {.name = "PerflibThermalZone",      .dim = "PerflibThermalZone",          .func = do_PerflibThermalZone},
+
     // the terminator of this array
     {.name = NULL, .dim = NULL, .func = NULL}
 };

--- a/src/collectors/windows.plugin/windows_plugin.c
+++ b/src/collectors/windows.plugin/windows_plugin.c
@@ -13,20 +13,20 @@ static struct proc_module {
 } win_modules[] = {
 
     // system metrics
-    {.name = "GetSystemUptime",     .dim = "GetSystemUptime",         .func = do_GetSystemUptime},
-    {.name = "GetSystemRAM",        .dim = "GetSystemRAM",            .func = do_GetSystemRAM},
+    {.name = "GetSystemUptime",     .dim = "GetSystemUptime",    .enabled = CONFIG_BOOLEAN_YES, .func = do_GetSystemUptime},
+    {.name = "GetSystemRAM",        .dim = "GetSystemRAM",       .enabled = CONFIG_BOOLEAN_YES, .func = do_GetSystemRAM},
 
     // the same is provided by PerflibProcessor, with more detailed analysis
-    //{.name = "GetSystemCPU",        .dim = "GetSystemCPU",            .func = do_GetSystemCPU},
+    //{.name = "GetSystemCPU",        .dim = "GetSystemCPU",     .enabled = CONFIG_BOOLEAN_YES, .func = do_GetSystemCPU},
 
-    {.name = "PerflibProcesses",    .dim = "PerflibProcesses",        .func = do_PerflibProcesses},
-    {.name = "PerflibProcessor",    .dim = "PerflibProcessor",        .func = do_PerflibProcessor},
-    {.name = "PerflibMemory",       .dim = "PerflibMemory",           .func = do_PerflibMemory},
-    {.name = "PerflibStorage",      .dim = "PerflibStorage",          .func = do_PerflibStorage},
-    {.name = "PerflibNetwork",      .dim = "PerflibNetwork",          .func = do_PerflibNetwork},
-    {.name = "PerflibObjects",      .dim = "PerflibObjects",          .func = do_PerflibObjects},
+    {.name = "PerflibProcesses",    .dim = "PerflibProcesses",   .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibProcesses},
+    {.name = "PerflibProcessor",    .dim = "PerflibProcessor",   .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibProcessor},
+    {.name = "PerflibMemory",       .dim = "PerflibMemory",      .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibMemory},
+    {.name = "PerflibStorage",      .dim = "PerflibStorage",     .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibStorage},
+    {.name = "PerflibNetwork",      .dim = "PerflibNetwork",     .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibNetwork},
+    {.name = "PerflibObjects",      .dim = "PerflibObjects",     .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibObjects},
 
-    {.name = "PerflibThermalZone",      .dim = "PerflibThermalZone",          .func = do_PerflibThermalZone},
+    {.name = "PerflibThermalZone",  .dim = "PerflibThermalZone", .enabled = CONFIG_BOOLEAN_NO, .func = do_PerflibThermalZone},
 
     // the terminator of this array
     {.name = NULL, .dim = NULL, .func = NULL}
@@ -68,7 +68,7 @@ void *win_plugin_main(void *ptr) {
     for(i = 0; win_modules[i].name; i++) {
         struct proc_module *pm = &win_modules[i];
 
-        pm->enabled = config_get_boolean("plugin:windows", pm->name, CONFIG_BOOLEAN_YES);
+        pm->enabled = config_get_boolean("plugin:windows", pm->name, pm->enabled);
         pm->rd = NULL;
 
         worker_register_job_name(i, win_modules[i].dim);

--- a/src/collectors/windows.plugin/windows_plugin.h
+++ b/src/collectors/windows.plugin/windows_plugin.h
@@ -24,6 +24,7 @@ int do_PerflibProcesses(int update_every, usec_t dt);
 int do_PerflibProcessor(int update_every, usec_t dt);
 int do_PerflibMemory(int update_every, usec_t dt);
 int do_PerflibObjects(int update_every, usec_t dt);
+int do_PerflibThermalZone(int update_every, usec_t dt);
 
 #include "perflib.h"
 


### PR DESCRIPTION
##### Summary

This PR enhances the `windows.plugin` by adding support for the following metrics:

- Thermal Zone
- SWAP
- System POOL

These metrics were previously collected through the Windows Exporter, and this PR marks the first phase of migrating them.

This PR addresses two areas outlined in https://github.com/netdata/netdata/issues/18461. It introduces Memory Metrics and begins the migration of Windows Exporter metrics, which will be delivered via the `go.d.plugin`.

##### Test Plan

1. Compile on Windows.
2. Build the package.
3. Install and review the charts to ensure proper display of the metrics.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
