### PR TITLE
go.d/varnish: add docker support

### DIFF
--- a/src/go/plugin/go.d/config/go.d/sd/docker.conf
+++ b/src/go/plugin/go.d/config/go.d/sd/docker.conf
@@ -82,6 +82,8 @@ classify:
         expr: '{{ and (eq .PrivatePort "9051") (match "sp" .Image "*/tor */tor:*") }}'
       - tags: "tomcat"
         expr: '{{ match "sp" .Image "tomcat tomcat:* */tomcat */tomcat:*" }}'
+      - tags: "varnish"
+        expr: '{{ match "sp" .Image "varnish varnish:*" }}'
       - tags: "vernemq"
         expr: '{{ match "sp" .Image "*/vernemq */vernemq:*" }}'
       - tags: "zookeeper"
@@ -257,6 +259,11 @@ compose:
           module: tor
           name: docker_{{.Name}}
           address: {{.Address}}
+      - selector: "varnish"
+        template: |
+          module: varnish
+          name: docker_{{.Name}}
+          docker_container: {{.Name}}
       - selector: "vernemq"
         template: |
           module: vernemq

--- a/src/go/plugin/go.d/modules/varnish/config_schema.json
+++ b/src/go/plugin/go.d/modules/varnish/config_schema.json
@@ -22,6 +22,11 @@
         "title": "Instance name",
         "description": "Specifies the name of the Varnish instance to collect metrics from.",
         "type": "string"
+      },
+      "docker_container": {
+        "title": "Docker container name",
+        "description": "Specifies the name of the Docker container where the Varnish instance is running. If set, the `varnishstat` command will be executed within this container.",
+        "type": "string"
       }
     },
     "required": [],

--- a/src/go/plugin/go.d/modules/varnish/exec.go
+++ b/src/go/plugin/go.d/modules/varnish/exec.go
@@ -6,16 +6,18 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/logger"
+	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/dockerhost"
 )
 
 type varnishstatBinary interface {
 	statistics() ([]byte, error)
 }
 
-func newVarnishstatBinary(binPath string, cfg Config, log *logger.Logger) varnishstatBinary {
+func newVarnishstatExecBinary(binPath string, cfg Config, log *logger.Logger) varnishstatBinary {
 	return &varnishstatExec{
 		Logger:       log,
 		binPath:      binPath,
@@ -45,4 +47,35 @@ func (e *varnishstatExec) statistics() ([]byte, error) {
 	}
 
 	return bs, nil
+}
+
+func newVarnishstatDockerExecBinary(cfg Config, log *logger.Logger) varnishstatBinary {
+	return &varnishstatDockerExec{
+		Logger:       log,
+		timeout:      cfg.Timeout.Duration(),
+		instanceName: cfg.InstanceName,
+		container:    cfg.DockerContainer,
+	}
+}
+
+type varnishstatDockerExec struct {
+	*logger.Logger
+
+	timeout      time.Duration
+	instanceName string
+	container    string
+}
+
+func (e *varnishstatDockerExec) statistics() ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
+	defer cancel()
+
+	timeS := strconv.Itoa(max(int(e.timeout.Seconds()), 1))
+
+	args := []string{"-1", "-t", timeS}
+	if e.instanceName != "" {
+		args = append(args, "-n", e.instanceName)
+	}
+
+	return dockerhost.Exec(ctx, e.container, "varnishstat", args...)
 }

--- a/src/go/plugin/go.d/modules/varnish/init.go
+++ b/src/go/plugin/go.d/modules/varnish/init.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (v *Varnish) initVarnishstatBinary() (varnishstatBinary, error) {
+	if v.Config.DockerContainer != "" {
+		return newVarnishstatDockerExecBinary(v.Config, v.Logger), nil
+	}
+
 	ndsudoPath := filepath.Join(executable.Directory, "ndsudo")
 
 	if _, err := os.Stat(ndsudoPath); err != nil {
@@ -18,7 +22,7 @@ func (v *Varnish) initVarnishstatBinary() (varnishstatBinary, error) {
 
 	}
 
-	varnishstat := newVarnishstatBinary(ndsudoPath, v.Config, v.Logger)
+	varnishstat := newVarnishstatExecBinary(ndsudoPath, v.Config, v.Logger)
 
 	return varnishstat, nil
 }

--- a/src/go/plugin/go.d/modules/varnish/metadata.yaml
+++ b/src/go/plugin/go.d/modules/varnish/metadata.yaml
@@ -71,6 +71,10 @@ modules:
               description: "Specifies the name of the Varnish instance to collect metrics from. This corresponds to the `-n` argument used with the [varnishstat](https://varnish-cache.org/docs/trunk/reference/varnishstat.html) command."
               default_value: ""
               required: false
+            - name: docker_container
+              description: "Specifies the name of the Docker container where the Varnish instance is running. If set, the `varnishstat` command will be executed within this container."
+              default_value: ""
+              required: false
         examples:
           folding:
             title: ""

--- a/src/go/plugin/go.d/modules/varnish/testdata/config.json
+++ b/src/go/plugin/go.d/modules/varnish/testdata/config.json
@@ -1,5 +1,6 @@
 {
   "update_every": 123,
   "timeout": 123.123,
-  "instance_name": "ok"
+  "instance_name": "ok",
+  "docker_container": "ok"
 }

--- a/src/go/plugin/go.d/modules/varnish/testdata/config.yaml
+++ b/src/go/plugin/go.d/modules/varnish/testdata/config.yaml
@@ -1,3 +1,4 @@
 update_every: 123
 timeout: 123.123
 instance_name: "ok"
+docker_container: "ok"

--- a/src/go/plugin/go.d/modules/varnish/varnish.go
+++ b/src/go/plugin/go.d/modules/varnish/varnish.go
@@ -39,9 +39,10 @@ func New() *Varnish {
 }
 
 type Config struct {
-	UpdateEvery  int          `yaml:"update_every,omitempty" json:"update_every"`
-	Timeout      web.Duration `yaml:"timeout,omitempty" json:"timeout"`
-	InstanceName string       `yaml:"instance_name,omitempty" json:"instance_name,omitempty"`
+	UpdateEvery     int          `yaml:"update_every,omitempty" json:"update_every"`
+	Timeout         web.Duration `yaml:"timeout,omitempty" json:"timeout"`
+	InstanceName    string       `yaml:"instance_name,omitempty" json:"instance_name,omitempty"`
+	DockerContainer string       `yaml:"docker_container,omitempty" json:"docker_container,omitempty"`
 }
 
 type Varnish struct {


### PR DESCRIPTION
##### Summary

- go.d/varnish: add support for executing `varnishstat` inside a Docker container (`docker_container` option).
- sd: discover Varnish containers and create data collection jobs using the new option.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
