### PR TITLE
remove save-database from netdatacli usage

### DIFF
--- a/src/daemon/commands.c
+++ b/src/daemon/commands.c
@@ -115,8 +115,6 @@ static cmd_status_t cmd_help_execute(char *args, char **message)
              "    Reload health configuration.\n\n"
              "reload-labels\n"
              "    Reload all labels.\n\n"
-             "save-database\n"
-             "    Save internal DB to disk for memory mode save.\n\n"
              "reopen-logs\n"
              "    Close and reopen log files.\n\n"
              "shutdown-agent\n"


### PR DESCRIPTION
##### Summary

There is no such command.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
