### PR TITLE
Fetch metadata by hash for DEB repos.

### DIFF
--- a/packaging/repoconfig/CMakeLists.txt
+++ b/packaging/repoconfig/CMakeLists.txt
@@ -10,7 +10,7 @@ list(APPEND DEB_DISTROS debian ubuntu)
 set(DEB_GPG_KEY_SOURCE "https://repo.netdata.cloud/netdatabot.gpg.key")
 
 set(PACKAGE_VERSION 3)
-set(PACKAGE_RELEASE 4)
+set(PACKAGE_RELEASE 5)
 
 set(CPACK_THREADS 0)
 set(CPACK_STRIP_FILES NO)

--- a/packaging/repoconfig/deb.changelog
+++ b/packaging/repoconfig/deb.changelog
@@ -1,3 +1,9 @@
+@PKG_NAME@ (3-5) unstable; urgency=medium
+
+  * Swithc DEB packages to fetch repo metadata by hash.
+
+ -- Austin Hemmelgarn <austin@netdata.cloud>  Thu, 12 Sep 2024 07:27:00 -0400
+
 @PKG_NAME@ (3-4) unstable; urgency=medium
 
   * Convert sources to DEB822 format

--- a/packaging/repoconfig/netdata.sources.in
+++ b/packaging/repoconfig/netdata.sources.in
@@ -3,7 +3,7 @@ Types: deb
 URIs: http://repo.netdata.cloud/repos/@VARIANT@/@DIST_NAME@/
 Suites: @SUITE@/
 Signed-By: /usr/share/keyrings/netdata-archive-keyring.gpg
-By-Hash: No
+By-Hash: Yes
 Enabled: Yes
 
 X-Repolib-Name: Netdata repository configuration repository
@@ -11,5 +11,5 @@ Types: deb
 URIs: http://repo.netdata.cloud/repos/repoconfig/@DIST_NAME@/
 Suites: @SUITE@/
 Signed-By: /usr/share/keyrings/netdata-archive-keyring.gpg
-By-Hash: No
+By-Hash: Yes
 Enabled: Yes

--- a/packaging/repoconfig/rpm.changelog
+++ b/packaging/repoconfig/rpm.changelog
@@ -1,4 +1,6 @@
-* Mon Aug 19 2024 Austin Hemmelgarn <austin@netdata.cloud
+* Thu Sep 17 2024 Austin Hemmelgarn <austin@netdata.cloud> 3-5
+- Fix changelog formatting.
+* Mon Aug 19 2024 Austin Hemmelgarn <austin@netdata.cloud> 3-4
 - Version bump to stay in sync with DEB packages.
 * Fri Aug 9 2024 Austin Hemmelgarn <austin@netdata.cloud> 3-3
 - Use system certificate config for Yum/DNF repos.


### PR DESCRIPTION
##### Summary

This enables atomic updates to the repository metadata on the server side, which should mitigate some of the issues we’ve seen with bad hashes for packages.

It’s unlikely this will be a complete fix for issues like #18510, but combined with some other changes in how the repo metadata is being generated on the servers it should significantly reduce the prevalance of such issues.

##### Test Plan

Requires generating local copies of the repoconfig packages for testing.

To build locally, run the `packaging/repoconfig/build-*.sh` script for the package type in a Docker image for the target platform. For example, for Debian 12 run `docker run -it --rm -v $PWD:/netdata debian:12 /netdata/packaging/repoconfig/build-deb.sh` from the root of the repository.

Verifying the changes just requires confirming that systems with the modified repository configuration correctly fetch repository metadata.

##### Additional Information

This also fixes a formatting issue in the RPM repoconfig package changelog.