### PR TITLE
add typesense to apps_groups.conf

### DIFF
--- a/src/collectors/apps.plugin/apps_groups.conf
+++ b/src/collectors/apps.plugin/apps_groups.conf
@@ -375,6 +375,8 @@ inetd: inetd xinetd
 # -----------------------------------------------------------------------------
 # other application servers
 
+typesense: typesense-serve
+
 i2pd: i2pd
 
 rethinkdb: rethinkdb


### PR DESCRIPTION
##### Summary

Add [Typesense](https://github.com/typesense/typesense) search engine to apps_groups.conf.

I think this more than covers [metrics.json](https://typesense.org/docs/27.0/api/cluster-operations.html#cluster-metrics) data.

Related #15844

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
