### PR TITLE
Disk metrics (Windows Plugin)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1125,6 +1125,7 @@ set(INTERNAL_COLLECTORS_FILES
         src/collectors/common-contexts/common-contexts.h
         src/collectors/common-contexts/disk.io.h
         src/collectors/common-contexts/disk.ops.h
+        src/collectors/common-contexts/disk.size.h
         src/collectors/common-contexts/system.io.h
         src/collectors/common-contexts/system.interrupts.h
         src/collectors/common-contexts/system.processes.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1124,6 +1124,7 @@ endif()
 set(INTERNAL_COLLECTORS_FILES
         src/collectors/common-contexts/common-contexts.h
         src/collectors/common-contexts/disk.io.h
+        src/collectors/common-contexts/disk.ops.h
         src/collectors/common-contexts/system.io.h
         src/collectors/common-contexts/system.interrupts.h
         src/collectors/common-contexts/system.processes.h

--- a/src/collectors/all.h
+++ b/src/collectors/all.h
@@ -26,6 +26,7 @@
 #define NETDATA_CHART_PRIO_SYSTEM_AVGZ_OPS_IO           153 // windows only
 #define NETDATA_CHART_PRIO_SYSTEM_UAVGZ_OPS_IO          154 // windows only
 #define NETDATA_CHART_PRIO_SYSTEM_IOAWAIT               155 // windows only
+#define NETDATA_CHART_PRIO_SYSTEM_IOTIMEOP              156 // windows only
 #define NETDATA_CHART_PRIO_SYSTEM_RAM                   200
 #define NETDATA_CHART_PRIO_SYSTEM_NET                   500
 #define NETDATA_CHART_PRIO_SYSTEM_IPV4                  500 // freebsd only
@@ -140,6 +141,7 @@
 #define NETDATA_CHART_PRIO_DISK_SVCTM                 2070
 #define NETDATA_CHART_PRIO_DISK_MOPS                  2080
 #define NETDATA_CHART_PRIO_DISK_IOTIME                2090
+#define NETDATA_CHART_PRIO_DISK_IOTIME_OP             2091
 #define NETDATA_CHART_PRIO_DISK_LATENCY               2095
 #define NETDATA_CHART_PRIO_BCACHE_CACHE_ALLOC         2120
 #define NETDATA_CHART_PRIO_BCACHE_HIT_RATIO           2120

--- a/src/collectors/all.h
+++ b/src/collectors/all.h
@@ -22,6 +22,8 @@
 #define NETDATA_CHART_PRIO_SYSTEM_LOAD                  100
 #define NETDATA_CHART_PRIO_SYSTEM_IO                    150
 #define NETDATA_CHART_PRIO_SYSTEM_PGPGIO                151
+#define NETDATA_CHART_PRIO_SYSTEM_OPS_IO                152 // windows only
+#define NETDATA_CHART_PRIO_SYSTEM_AVGZ_OPS_IO           153 // windows only
 #define NETDATA_CHART_PRIO_SYSTEM_RAM                   200
 #define NETDATA_CHART_PRIO_SYSTEM_NET                   500
 #define NETDATA_CHART_PRIO_SYSTEM_IPV4                  500 // freebsd only

--- a/src/collectors/all.h
+++ b/src/collectors/all.h
@@ -24,6 +24,7 @@
 #define NETDATA_CHART_PRIO_SYSTEM_PGPGIO                151
 #define NETDATA_CHART_PRIO_SYSTEM_OPS_IO                152 // windows only
 #define NETDATA_CHART_PRIO_SYSTEM_AVGZ_OPS_IO           153 // windows only
+#define NETDATA_CHART_PRIO_SYSTEM_IOAWAIT               154 // windows only
 #define NETDATA_CHART_PRIO_SYSTEM_RAM                   200
 #define NETDATA_CHART_PRIO_SYSTEM_NET                   500
 #define NETDATA_CHART_PRIO_SYSTEM_IPV4                  500 // freebsd only

--- a/src/collectors/all.h
+++ b/src/collectors/all.h
@@ -24,7 +24,8 @@
 #define NETDATA_CHART_PRIO_SYSTEM_PGPGIO                151
 #define NETDATA_CHART_PRIO_SYSTEM_OPS_IO                152 // windows only
 #define NETDATA_CHART_PRIO_SYSTEM_AVGZ_OPS_IO           153 // windows only
-#define NETDATA_CHART_PRIO_SYSTEM_IOAWAIT               154 // windows only
+#define NETDATA_CHART_PRIO_SYSTEM_UAVGZ_OPS_IO          154 // windows only
+#define NETDATA_CHART_PRIO_SYSTEM_IOAWAIT               155 // windows only
 #define NETDATA_CHART_PRIO_SYSTEM_RAM                   200
 #define NETDATA_CHART_PRIO_SYSTEM_NET                   500
 #define NETDATA_CHART_PRIO_SYSTEM_IPV4                  500 // freebsd only

--- a/src/collectors/all.h
+++ b/src/collectors/all.h
@@ -141,7 +141,8 @@
 #define NETDATA_CHART_PRIO_DISK_SVCTM                 2070
 #define NETDATA_CHART_PRIO_DISK_MOPS                  2080
 #define NETDATA_CHART_PRIO_DISK_IOTIME                2090
-#define NETDATA_CHART_PRIO_DISK_IOTIME_OP             2091
+#define NETDATA_CHART_PRIO_DISK_IOTIME_OP             2091 // windows only
+#define NETDATA_CHART_PRIO_DISK_IOTIME_AVGOP          2092 // windows only
 #define NETDATA_CHART_PRIO_DISK_LATENCY               2095
 #define NETDATA_CHART_PRIO_BCACHE_CACHE_ALLOC         2120
 #define NETDATA_CHART_PRIO_BCACHE_HIT_RATIO           2120

--- a/src/collectors/common-contexts/common-contexts.h
+++ b/src/collectors/common-contexts/common-contexts.h
@@ -28,5 +28,6 @@ typedef void (*instance_labels_cb_t)(RRDSET *st, void *data);
 #include "mem.available.h"
 #include "disk.io.h"
 #include "disk.ops.h"
+#include "disk.size.h"
 
 #endif //NETDATA_COMMON_CONTEXTS_H

--- a/src/collectors/common-contexts/common-contexts.h
+++ b/src/collectors/common-contexts/common-contexts.h
@@ -18,6 +18,10 @@
 
 typedef void (*instance_labels_cb_t)(RRDSET *st, void *data);
 
+// Microsoft uses 100ns time base for some metrics
+// https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/sensorsutils/nf-sensorsutils-milliseconds_to_100nanoseconds
+#define ND_SECONDS_TO_100NS 10000000
+
 #include "system.io.h"
 #include "system.ram.h"
 #include "system.interrupts.h"

--- a/src/collectors/common-contexts/common-contexts.h
+++ b/src/collectors/common-contexts/common-contexts.h
@@ -29,5 +29,6 @@ typedef void (*instance_labels_cb_t)(RRDSET *st, void *data);
 #include "disk.io.h"
 #include "disk.ops.h"
 #include "disk.size.h"
+#include "disk.await.h"
 
 #endif //NETDATA_COMMON_CONTEXTS_H

--- a/src/collectors/common-contexts/common-contexts.h
+++ b/src/collectors/common-contexts/common-contexts.h
@@ -27,5 +27,6 @@ typedef void (*instance_labels_cb_t)(RRDSET *st, void *data);
 #include "mem.pgfaults.h"
 #include "mem.available.h"
 #include "disk.io.h"
+#include "disk.ops.h"
 
 #endif //NETDATA_COMMON_CONTEXTS_H

--- a/src/collectors/common-contexts/disk.await.h
+++ b/src/collectors/common-contexts/disk.await.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_DISK_AWAIT_H
+#define NETDATA_DISK_AWAIT_H
+
+#include "common-contexts.h"
+
+typedef struct {
+    RRDSET *st_await;
+    RRDDIM *rd_await_reads;
+    RRDDIM *rd_await_writes;
+} ND_DISK_AWAIT;
+
+static inline void common_disk_await(ND_DISK_AWAIT *d, const char *id, const char *name, uint64_t bytes_read, uint64_t bytes_write, int update_every, instance_labels_cb_t cb, void *data) {
+    if(unlikely(!d->st_await)) {
+        d->st_await = rrdset_create_localhost(
+            "disk_await"
+        , id
+        , name
+        , "iotime"
+        , "disk.await"
+        , "Average Completed I/O Operation Time"
+        , "milliseconds/operation"
+        , _COMMON_PLUGIN_NAME
+        , _COMMON_PLUGIN_MODULE_NAME
+        , NETDATA_CHART_PRIO_DISK_AWAIT
+        , update_every
+        , RRDSET_TYPE_LINE
+        );
+
+        d->rd_await_reads  = rrddim_add(d->st_await, "reads",  NULL,  1, 1024, RRD_ALGORITHM_INCREMENTAL);
+        d->rd_await_writes = rrddim_add(d->st_await, "writes", NULL, -1, 1024, RRD_ALGORITHM_INCREMENTAL);
+
+        if(cb)
+            cb(d->st_await, data);
+    }
+
+    // this always have to be in base units, so that exporting sends base units to other time-series db
+    rrddim_set_by_pointer(d->st_await, d->rd_await_reads, (collected_number)bytes_read);
+    rrddim_set_by_pointer(d->st_await, d->rd_await_writes, (collected_number)bytes_write);
+    rrdset_done(d->st_await);
+}
+
+#endif //NETDATA_DISK_AWAIT_H

--- a/src/collectors/common-contexts/disk.await.h
+++ b/src/collectors/common-contexts/disk.await.h
@@ -11,22 +11,51 @@ typedef struct {
     RRDDIM *rd_await_writes;
 } ND_DISK_AWAIT;
 
+static inline void common_system_ioawait(uint64_t bytes_read, uint64_t bytes_write, int update_every) {
+    static RRDSET *st_avgsz = NULL;
+    static RRDDIM *rd_avgsz_reads = NULL, *rd_avgsz_writes = NULL;
+
+    if(unlikely(!st_avgsz)) {
+        st_avgsz = rrdset_create_localhost("system"
+                                           , "disk_await"
+                                           , NULL
+                                           , "disk"
+                                           , NULL
+                                           , "Average Completed I/O Operation Time"
+                                           , "milliseconds/operation"
+                                           , _COMMON_PLUGIN_NAME
+                                           , _COMMON_PLUGIN_MODULE_NAME
+                                           , NETDATA_CHART_PRIO_SYSTEM_IOAWAIT
+                                           , update_every
+                                           , RRDSET_TYPE_AREA
+                                           );
+
+
+        rd_avgsz_reads  = rrddim_add(st_avgsz, "reads",  NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
+        rd_avgsz_writes = rrddim_add(st_avgsz, "writes", NULL, -1, 1024, RRD_ALGORITHM_ABSOLUTE);
+    }
+
+    // this always have to be in base units, so that exporting sends base units to other time-series db
+    rrddim_set_by_pointer(st_avgsz, rd_avgsz_reads, (collected_number)bytes_read);
+    rrddim_set_by_pointer(st_avgsz, rd_avgsz_writes, (collected_number)bytes_write);
+    rrdset_done(st_avgsz);
+}
+
 static inline void common_disk_await(ND_DISK_AWAIT *d, const char *id, const char *name, uint64_t bytes_read, uint64_t bytes_write, int update_every, instance_labels_cb_t cb, void *data) {
     if(unlikely(!d->st_await)) {
-        d->st_await = rrdset_create_localhost(
-            "disk_await"
-        , id
-        , name
-        , "iotime"
-        , "disk.await"
-        , "Average Completed I/O Operation Time"
-        , "milliseconds/operation"
-        , _COMMON_PLUGIN_NAME
-        , _COMMON_PLUGIN_MODULE_NAME
-        , NETDATA_CHART_PRIO_DISK_AWAIT
-        , update_every
-        , RRDSET_TYPE_LINE
-        );
+        d->st_await = rrdset_create_localhost("disk_await"
+                                              , id
+                                              , name
+                                              , "iotime"
+                                              , "disk.await"
+                                              , "Average Completed I/O Operation Time"
+                                              , "milliseconds/operation"
+                                              , _COMMON_PLUGIN_NAME
+                                              , _COMMON_PLUGIN_MODULE_NAME
+                                              , NETDATA_CHART_PRIO_DISK_AWAIT
+                                              , update_every
+                                              , RRDSET_TYPE_LINE
+                                              );
 
         d->rd_await_reads  = rrddim_add(d->st_await, "reads",  NULL,  1, 1024, RRD_ALGORITHM_INCREMENTAL);
         d->rd_await_writes = rrddim_add(d->st_await, "writes", NULL, -1, 1024, RRD_ALGORITHM_INCREMENTAL);

--- a/src/collectors/common-contexts/disk.io.h
+++ b/src/collectors/common-contexts/disk.io.h
@@ -96,7 +96,7 @@ static inline void common_disk_splitio(ND_DISK_SPLIT_IO *d, const char *id, cons
                                                 , RRDSET_TYPE_LINE
             );
 
-        d->rd_splitio  = rrddim_add(d->st_splitio, "io",  NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        d->rd_splitio  = rrddim_add(d->st_splitio, "io",  NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
 
         if(cb)
             cb(d->st_splitio, data);
@@ -126,7 +126,7 @@ static inline void system_disk_splitio(uint64_t ops, int update_every) {
                                         );
 
 
-        rd_io  = rrddim_add(st_io, "io",  NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
+        rd_io  = rrddim_add(st_io, "io",  NULL, 1, 1024, RRD_ALGORITHM_INCREMENTAL);
     }
 
     // this always have to be in base units, so that exporting sends base units to other time-series db

--- a/src/collectors/common-contexts/disk.io.h
+++ b/src/collectors/common-contexts/disk.io.h
@@ -49,7 +49,7 @@ static inline void common_disk_io(ND_DISK_IO *d, const char *id, const char *nam
 static inline void common_unified_disk_io(ND_DISK_UIO *d, const char *id, const char *name, uint64_t bytes, int update_every, instance_labels_cb_t cb, void *data) {
     if(unlikely(!d->st_uio)) {
         d->st_uio = rrdset_create_localhost(
-            "disk"
+            "disk_uio"
         , id
         , name
         , "io"

--- a/src/collectors/common-contexts/disk.io.h
+++ b/src/collectors/common-contexts/disk.io.h
@@ -11,6 +11,11 @@ typedef struct {
     RRDDIM *rd_io_writes;
 } ND_DISK_IO;
 
+typedef struct {
+    RRDSET *st_uio;
+    RRDDIM *rd_io_bytes;
+} ND_DISK_UIO;
+
 static inline void common_disk_io(ND_DISK_IO *d, const char *id, const char *name, uint64_t bytes_read, uint64_t bytes_write, int update_every, instance_labels_cb_t cb, void *data) {
     if(unlikely(!d->st_io)) {
         d->st_io = rrdset_create_localhost(
@@ -39,6 +44,34 @@ static inline void common_disk_io(ND_DISK_IO *d, const char *id, const char *nam
     rrddim_set_by_pointer(d->st_io, d->rd_io_reads, (collected_number)bytes_read);
     rrddim_set_by_pointer(d->st_io, d->rd_io_writes, (collected_number)bytes_write);
     rrdset_done(d->st_io);
+}
+
+static inline void common_unified_disk_io(ND_DISK_UIO *d, const char *id, const char *name, uint64_t bytes, int update_every, instance_labels_cb_t cb, void *data) {
+    if(unlikely(!d->st_uio)) {
+        d->st_uio = rrdset_create_localhost(
+            "disk"
+        , id
+        , name
+        , "io"
+        , "disk.uio"
+        , "Disk I/O Bandwidth"
+        , "KiB/s"
+        , _COMMON_PLUGIN_NAME
+        , _COMMON_PLUGIN_MODULE_NAME
+        , NETDATA_CHART_PRIO_DISK_IO + 1
+        , update_every
+        , RRDSET_TYPE_AREA
+        );
+
+        d->rd_io_bytes  = rrddim_add(d->st_uio, "io",  NULL,  1, 1024, RRD_ALGORITHM_INCREMENTAL);
+
+        if(cb)
+            cb(d->st_uio, data);
+    }
+
+    // this always have to be in base units, so that exporting sends base units to other time-series db
+    rrddim_set_by_pointer(d->st_uio, d->rd_io_bytes, (collected_number)bytes);
+    rrdset_done(d->st_uio);
 }
 
 #endif //NETDATA_DISK_IO_H

--- a/src/collectors/common-contexts/disk.io.h
+++ b/src/collectors/common-contexts/disk.io.h
@@ -16,6 +16,11 @@ typedef struct {
     RRDDIM *rd_io_bytes;
 } ND_DISK_UIO;
 
+typedef struct {
+    RRDSET *st_splitio;
+    RRDDIM *rd_splitio;
+} ND_DISK_SPLIT_IO;
+
 static inline void common_disk_io(ND_DISK_IO *d, const char *id, const char *name, uint64_t bytes_read, uint64_t bytes_write, int update_every, instance_labels_cb_t cb, void *data) {
     if(unlikely(!d->st_io)) {
         d->st_io = rrdset_create_localhost(
@@ -50,20 +55,20 @@ static inline void common_unified_disk_io(ND_DISK_UIO *d, const char *id, const 
     if(unlikely(!d->st_uio)) {
         d->st_uio = rrdset_create_localhost(
             "disk_uio"
-        , id
-        , name
-        , "io"
-        , "disk.uio"
-        , "Disk I/O Bandwidth"
-        , "KiB/s"
-        , _COMMON_PLUGIN_NAME
-        , _COMMON_PLUGIN_MODULE_NAME
-        , NETDATA_CHART_PRIO_DISK_IO + 1
-        , update_every
-        , RRDSET_TYPE_AREA
+            , id
+            , name
+            , "io"
+            , "disk.uio"
+            , "Disk I/O Bandwidth"
+            , "KiB/s"
+            , _COMMON_PLUGIN_NAME
+            , _COMMON_PLUGIN_MODULE_NAME
+            , NETDATA_CHART_PRIO_DISK_IO + 1
+            , update_every
+            , RRDSET_TYPE_AREA
         );
 
-        d->rd_io_bytes  = rrddim_add(d->st_uio, "io",  NULL,  1, 1024, RRD_ALGORITHM_INCREMENTAL);
+        d->rd_io_bytes  = rrddim_add(d->st_uio, "io",  "io",  1, 1024, RRD_ALGORITHM_INCREMENTAL);
 
         if(cb)
             cb(d->st_uio, data);
@@ -73,5 +78,61 @@ static inline void common_unified_disk_io(ND_DISK_UIO *d, const char *id, const 
     rrddim_set_by_pointer(d->st_uio, d->rd_io_bytes, (collected_number)bytes);
     rrdset_done(d->st_uio);
 }
+
+#if defined(OS_WINDOWS)
+static inline void common_disk_splitio(ND_DISK_SPLIT_IO *d, const char *id, const char *name, uint64_t ops, int update_every, instance_labels_cb_t cb, void *data) {
+    if (!d->st_splitio) {
+        d->st_splitio = rrdset_create_localhost("disk_splitio"
+                                                , id
+                                                , name
+                                                , "iops"
+                                                , "disk.splitio"
+                                                , "Rate I/O operations were split"
+                                                , "operations/s"
+                                                , _COMMON_PLUGIN_NAME
+                                                , _COMMON_PLUGIN_MODULE_NAME
+                                                , NETDATA_CHART_PRIO_DISK_OPS + 1
+                                                , update_every
+                                                , RRDSET_TYPE_LINE
+            );
+
+        d->rd_splitio  = rrddim_add(d->st_splitio, "io",  NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+
+        if(cb)
+            cb(d->st_splitio, data);
+    }
+
+    rrddim_set_by_pointer(d->st_splitio, d->rd_splitio, (collected_number)ops);
+    rrdset_done(d->st_splitio);
+}
+
+static inline void system_disk_splitio(uint64_t ops, int update_every) {
+    static RRDSET *st_io = NULL;
+    static RRDDIM *rd_io = NULL;
+
+    if(unlikely(!st_io)) {
+        st_io = rrdset_create_localhost("system"
+                                        , "splitio"
+                                        , NULL
+                                        , "disk"
+                                        , NULL
+                                        , "Rate I/O operations were split"
+                                        , "operations/s"
+                                        , _COMMON_PLUGIN_NAME
+                                        , _COMMON_PLUGIN_MODULE_NAME
+                                        , NETDATA_CHART_PRIO_SYSTEM_AVGZ_OPS_IO
+                                        , update_every
+                                        , RRDSET_TYPE_AREA
+                                        );
+
+
+        rd_io  = rrddim_add(st_io, "io",  NULL, 1, 1024, RRD_ALGORITHM_ABSOLUTE);
+    }
+
+    // this always have to be in base units, so that exporting sends base units to other time-series db
+    rrddim_set_by_pointer(st_io, rd_io, (collected_number)ops);
+    rrdset_done(st_io);
+}
+#endif
 
 #endif //NETDATA_DISK_IO_H

--- a/src/collectors/common-contexts/disk.ops.h
+++ b/src/collectors/common-contexts/disk.ops.h
@@ -25,7 +25,7 @@ static inline void common_disk_ops(ND_DISK_OPS *d, const char *id, const char *n
             , _COMMON_PLUGIN_MODULE_NAME
             , NETDATA_CHART_PRIO_DISK_OPS
             , update_every
-            , RRDSET_TYPE_AREA
+            , RRDSET_TYPE_LINE
         );
 
         d->rd_ops_reads  = rrddim_add(d->st_ops, "reads",  NULL,  1, 1, RRD_ALGORITHM_INCREMENTAL);

--- a/src/collectors/common-contexts/disk.ops.h
+++ b/src/collectors/common-contexts/disk.ops.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_DISK_OPS_H
+#define NETDATA_DISK_OPS_H
+
+#include "common-contexts.h"
+
+typedef struct {
+    RRDSET *st_ops;
+    RRDDIM *rd_ops_reads;
+    RRDDIM *rd_ops_writes;
+} ND_DISK_OPS;
+
+static inline void common_disk_ops(ND_DISK_OPS *d, const char *id, const char *name, const char *family, uint64_t bytes_read, uint64_t bytes_write, int update_every, instance_labels_cb_t cb, void *data) {
+    if(unlikely(!d->st_ops)) {
+        d->st_ops = rrdset_create_localhost(
+            "disk_ops"
+            , id
+            , name
+            , family
+            , "disk.ops"
+            , "Disk Completed I/O Operations"
+            , "operations/s"
+            , _COMMON_PLUGIN_NAME
+            , _COMMON_PLUGIN_MODULE_NAME
+            , NETDATA_CHART_PRIO_DISK_OPS
+            , update_every
+            , RRDSET_TYPE_AREA
+        );
+
+        d->rd_ops_reads  = rrddim_add(d->st_ops, "reads",  NULL,  1, 1, RRD_ALGORITHM_INCREMENTAL);
+        d->rd_ops_writes = rrddim_add(d->st_ops, "writes", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+
+        if(cb)
+            cb(d->st_ops, data);
+    }
+
+    // this always have to be in base units, so that exporting sends base units to other time-series db
+    rrddim_set_by_pointer(d->st_ops, d->rd_ops_reads, (collected_number)bytes_read);
+    rrddim_set_by_pointer(d->st_ops, d->rd_ops_writes, (collected_number)bytes_write);
+    rrdset_done(d->st_ops);
+}
+
+#endif //NETDATA_DISK_OPS_H

--- a/src/collectors/common-contexts/disk.ops.h
+++ b/src/collectors/common-contexts/disk.ops.h
@@ -29,7 +29,7 @@ static inline void common_disk_ops(ND_DISK_OPS *d, const char *id, const char *n
         );
 
         d->rd_ops_reads  = rrddim_add(d->st_ops, "reads",  NULL,  1, 1, RRD_ALGORITHM_INCREMENTAL);
-        d->rd_ops_writes = rrddim_add(d->st_ops, "writes", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
+        d->rd_ops_writes = rrddim_add(d->st_ops, "writes", NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
 
         if(cb)
             cb(d->st_ops, data);

--- a/src/collectors/common-contexts/disk.size.h
+++ b/src/collectors/common-contexts/disk.size.h
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_DISK_SIZE_H
+#define NETDATA_DISK_SIZE_H
+
+#include "common-contexts.h"
+
+typedef struct {
+    RRDSET *st_avgsz;
+    RRDDIM *rd_avgsz_reads;
+    RRDDIM *rd_avgsz_writes;
+} ND_DISK_AVGSIZE;
+
+typedef struct {
+    RRDSET *st_uavgsz;
+    RRDDIM *rd_avgsz_bytes;
+} ND_DISK_UAVGSIZE;
+
+static inline void common_disk_avgsize(ND_DISK_AVGSIZE *d, const char *id, const char *name, uint64_t bytes_read, uint64_t bytes_write, uint64_t sector_size, int update_every, instance_labels_cb_t cb, void *data) {
+    if(unlikely(!d->st_avgsz)) {
+        d->st_avgsz = rrdset_create_localhost(
+            "disk_avgsz"
+            , id
+            , name
+            , "size"
+            , "disk.avgsz"
+            , "Average Completed I/O Operation Bandwidth"
+            , "KiB/s"
+            , _COMMON_PLUGIN_NAME
+            , _COMMON_PLUGIN_MODULE_NAME
+            , NETDATA_CHART_PRIO_DISK_AVGSZ
+            , update_every
+            , RRDSET_TYPE_AREA
+        );
+
+        d->rd_avgsz_reads  = rrddim_add(d->st_avgsz, "reads",  NULL, sector_size, 1024, RRD_ALGORITHM_ABSOLUTE);
+        d->rd_avgsz_writes = rrddim_add(d->st_avgsz, "writes", NULL, sector_size * -1, 1024, RRD_ALGORITHM_ABSOLUTE);
+
+        if(cb)
+            cb(d->st_avgsz, data);
+    }
+
+    // this always have to be in base units, so that exporting sends base units to other time-series db
+    rrddim_set_by_pointer(d->st_avgsz, d->rd_avgsz_reads, (collected_number)bytes_read);
+    rrddim_set_by_pointer(d->st_avgsz, d->rd_avgsz_writes, (collected_number)bytes_write);
+    rrdset_done(d->st_avgsz);
+}
+
+static inline void common_unified_disk_avgsize(ND_DISK_UAVGSIZE *d, const char *id, const char *name, uint64_t bytes, int update_every, instance_labels_cb_t cb, void *data) {
+    if(unlikely(!d->st_uavgsz)) {
+        d->st_uavgsz = rrdset_create_localhost(
+            "disk_uavgsz"
+            , id
+            , name
+            , "size"
+            , "disk.uavgsz"
+            , "Disk I/O Bandwidth"
+            , "KiB/s"
+            , _COMMON_PLUGIN_NAME
+            , _COMMON_PLUGIN_MODULE_NAME
+            , NETDATA_CHART_PRIO_DISK_AVGSZ + 1
+            , update_every
+            , RRDSET_TYPE_AREA
+        );
+
+        d->rd_avgsz_bytes  = rrddim_add(d->st_uavgsz, "io",  NULL,  1, 1024, RRD_ALGORITHM_ABSOLUTE);
+
+        if(cb)
+            cb(d->st_uavgsz, data);
+    }
+
+    // this always have to be in base units, so that exporting sends base units to other time-series db
+    rrddim_set_by_pointer(d->st_uavgsz, d->rd_avgsz_bytes, (collected_number)bytes);
+    rrdset_done(d->st_uavgsz);
+}
+
+#endif //NETDATA_DISK_SIZE_H

--- a/src/collectors/common-contexts/disk.size.h
+++ b/src/collectors/common-contexts/disk.size.h
@@ -25,7 +25,7 @@ static inline void common_disk_avgsize(ND_DISK_AVGSIZE *d, const char *id, const
             , "size"
             , "disk.avgsz"
             , "Average Completed I/O Operation Bandwidth"
-            , "KiB/s"
+            , "operations/s"
             , _COMMON_PLUGIN_NAME
             , _COMMON_PLUGIN_MODULE_NAME
             , NETDATA_CHART_PRIO_DISK_AVGSZ
@@ -54,8 +54,8 @@ static inline void common_unified_disk_avgsize(ND_DISK_UAVGSIZE *d, const char *
             , name
             , "size"
             , "disk.uavgsz"
-            , "Disk I/O Bandwidth"
-            , "KiB/s"
+            , "Average Completed I/O Operation Bandwidth"
+            , "operations/s"
             , _COMMON_PLUGIN_NAME
             , _COMMON_PLUGIN_MODULE_NAME
             , NETDATA_CHART_PRIO_DISK_AVGSZ + 1

--- a/src/collectors/common-contexts/disk.size.h
+++ b/src/collectors/common-contexts/disk.size.h
@@ -25,7 +25,7 @@ static inline void common_disk_avgsize(ND_DISK_AVGSIZE *d, const char *id, const
             , "size"
             , "disk.avgsz"
             , "Average Completed I/O Operation Bandwidth"
-            , "operations/s"
+            , "KiB/operation"
             , _COMMON_PLUGIN_NAME
             , _COMMON_PLUGIN_MODULE_NAME
             , NETDATA_CHART_PRIO_DISK_AVGSZ
@@ -57,7 +57,7 @@ static inline void common_system_avgsize(uint64_t bytes_read, uint64_t bytes_wri
                                            , "disk"
                                            , NULL
                                            , "Disk Completed I/O Operations"
-                                           , "operations/s"
+                                           , "KiB/operation"
                                            , _COMMON_PLUGIN_NAME
                                            , _COMMON_PLUGIN_MODULE_NAME
                                            , NETDATA_CHART_PRIO_SYSTEM_AVGZ_OPS_IO

--- a/src/collectors/common-contexts/disk.size.h
+++ b/src/collectors/common-contexts/disk.size.h
@@ -118,7 +118,7 @@ static inline void common_system_uavgsize(uint64_t bytes, int update_every) {
                                             , "operations/s"
                                             , _COMMON_PLUGIN_NAME
                                             , _COMMON_PLUGIN_MODULE_NAME
-                                            , NETDATA_CHART_PRIO_SYSTEM_AVGZ_OPS_IO
+                                            , NETDATA_CHART_PRIO_SYSTEM_UAVGZ_OPS_IO
                                             , update_every
                                             , RRDSET_TYPE_AREA
                                             );

--- a/src/collectors/common-contexts/system.io.h
+++ b/src/collectors/common-contexts/system.io.h
@@ -35,4 +35,31 @@ static inline void common_system_io(uint64_t read_bytes, uint64_t write_bytes, i
     rrdset_done(st_io);
 }
 
+static inline void common_system_uio(uint64_t bytes, int update_every) {
+    static RRDSET *st_uio = NULL;
+    static RRDDIM *rd_io = NULL;
+
+    if(unlikely(!st_uio)) {
+        st_uio = rrdset_create_localhost("system"
+                                         , "uio"
+                                         , NULL
+                                         , "disk"
+                                         , NULL
+                                         , "Unified disk I/O"
+                                         , "KiB/s"
+                                         , _COMMON_PLUGIN_NAME
+                                         , _COMMON_PLUGIN_MODULE_NAME
+                                         , NETDATA_CHART_PRIO_SYSTEM_IO + 1
+                                         , update_every
+                                         , RRDSET_TYPE_AREA
+                                         );
+
+        rd_io  = rrddim_add(st_uio, "io",  "io",  1, 1024, RRD_ALGORITHM_INCREMENTAL);
+    }
+
+    // this always have to be in base units, so that exporting sends base units to other time-series db
+    rrddim_set_by_pointer(st_uio, rd_io, (collected_number)bytes);
+    rrdset_done(st_uio);
+}
+
 #endif //NETDATA_SYSTEM_IO_H

--- a/src/collectors/proc.plugin/proc_diskstats.c
+++ b/src/collectors/proc.plugin/proc_diskstats.c
@@ -85,9 +85,7 @@ static struct disk {
     RRDSET *st_ext_io;
     RRDDIM *rd_io_discards;
 
-    RRDSET *st_ops;
-    RRDDIM *rd_ops_reads;
-    RRDDIM *rd_ops_writes;
+    ND_DISK_OPS disk_ops;
 
     RRDSET *st_ext_ops;
     RRDDIM *rd_ops_discards;
@@ -1053,8 +1051,8 @@ static int diskstats_function_block_devices(BUFFER *wb, const char *function __m
         double busy_time = rrddim_get_last_stored_value(d->rd_busy_busy, &max_busy_time, 1);
         double backlog_time = rrddim_get_last_stored_value(d->rd_backlog_backlog, &max_backlog_time, 1);
         // IOPS
-        double iops_reads = rrddim_get_last_stored_value(d->rd_ops_reads, &max_iops_reads, 1);
-        double iops_writes = rrddim_get_last_stored_value(d->rd_ops_writes, &max_iops_writes, 1);
+        double iops_reads = rrddim_get_last_stored_value(d->disk_ops.rd_ops_reads, &max_iops_reads, 1);
+        double iops_writes = rrddim_get_last_stored_value(d->disk_ops.rd_ops_writes, &max_iops_writes, 1);
         // IO Time
         double iops_time_reads = rrddim_get_last_stored_value(d->rd_iotime_reads, &max_iops_time_reads, 1);
         double iops_time_writes = rrddim_get_last_stored_value(d->rd_iotime_writes, &max_iops_time_writes, 1);
@@ -1299,7 +1297,7 @@ static void diskstats_cleanup_disks() {
             rrdset_obsolete_and_pointer_null(d->st_ext_iotime);
             rrdset_obsolete_and_pointer_null(d->st_mops);
             rrdset_obsolete_and_pointer_null(d->st_ext_mops);
-            rrdset_obsolete_and_pointer_null(d->st_ops);
+            rrdset_obsolete_and_pointer_null(d->disk_ops.st_ops);
             rrdset_obsolete_and_pointer_null(d->st_ext_ops);
             rrdset_obsolete_and_pointer_null(d->st_qops);
             rrdset_obsolete_and_pointer_null(d->st_svctm);
@@ -1615,33 +1613,10 @@ int do_proc_diskstats(int update_every, usec_t dt) {
         if (d->do_ops == CONFIG_BOOLEAN_YES || d->do_ops == CONFIG_BOOLEAN_AUTO) {
             d->do_ops = CONFIG_BOOLEAN_YES;
 
-            if(unlikely(!d->st_ops)) {
-                d->st_ops = rrdset_create_localhost(
-                        "disk_ops"
-                        , d->chart_id
-                        , d->disk
-                        , family
-                        , "disk.ops"
-                        , "Disk Completed I/O Operations"
-                        , "operations/s"
-                        , PLUGIN_PROC_NAME
-                        , PLUGIN_PROC_MODULE_DISKSTATS_NAME
-                        , NETDATA_CHART_PRIO_DISK_OPS
-                        , update_every
-                        , RRDSET_TYPE_LINE
-                );
-
-                rrdset_flag_set(d->st_ops, RRDSET_FLAG_DETAIL);
-
-                d->rd_ops_reads  = rrddim_add(d->st_ops, "reads",  NULL,  1, 1, RRD_ALGORITHM_INCREMENTAL);
-                d->rd_ops_writes = rrddim_add(d->st_ops, "writes", NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
-
-                add_labels_to_disk(d, d->st_ops);
-            }
-
-            last_reads  = rrddim_set_by_pointer(d->st_ops, d->rd_ops_reads, reads);
-            last_writes = rrddim_set_by_pointer(d->st_ops, d->rd_ops_writes, writes);
-            rrdset_done(d->st_ops);
+            last_reads  = d->disk_ops.rd_ops_reads ? d->disk_ops.rd_ops_reads->collector.last_collected_value : 0;
+            last_writes = d->disk_ops.rd_ops_writes ? d->disk_ops.rd_ops_writes->collector.last_collected_value : 0;
+            common_disk_ops(&d->disk_ops, d->chart_id, d->disk, family, reads, writes, update_every,
+                            disk_labels_cb, d);
         }
 
         if (do_dc_stats && d->do_ops == CONFIG_BOOLEAN_YES && d->do_ext != CONFIG_BOOLEAN_NO) {

--- a/src/collectors/windows.plugin/perflib-memory.c
+++ b/src/collectors/windows.plugin/perflib-memory.c
@@ -133,7 +133,6 @@ static void do_memory_system_pool(PERF_DATA_BLOCK *pDataBlock, PERF_OBJECT_TYPE 
         , "system_pool", NULL
         , "mem"
         , "mem.system_pool_size"
-
         , "System Memory Pool"
         , "bytes"
         , PLUGIN_WINDOWS_NAME

--- a/src/collectors/windows.plugin/perflib-memory.c
+++ b/src/collectors/windows.plugin/perflib-memory.c
@@ -67,7 +67,6 @@ static void do_memory_swap(PERF_DATA_BLOCK *pDataBlock, PERF_OBJECT_TYPE *pObjec
         , "swap_operations", NULL
         , "swap"
         , "mem.swap_iops"
-
         , "Swap Operations"
         , "operations/s"
         , PLUGIN_WINDOWS_NAME
@@ -98,7 +97,6 @@ static void do_memory_swap(PERF_DATA_BLOCK *pDataBlock, PERF_OBJECT_TYPE *pObjec
         , "swap_pages", NULL
         , "swap"
         , "mem.swap_pages_io"
-
         , "Swap Pages"
         , "pages/s"
         , PLUGIN_WINDOWS_NAME

--- a/src/collectors/windows.plugin/perflib-storage.c
+++ b/src/collectors/windows.plugin/perflib-storage.c
@@ -47,14 +47,16 @@ struct physical_disk {
     ND_DISK_SPLIT_IO disk_split_io;
     COUNTER_DATA splitIoPerSec;
 
+    ND_DISK_AWAIT disk_await;
+    COUNTER_DATA averageDiskReadQueueLength;
+    COUNTER_DATA averageDiskWriteQueueLength;
+
     COUNTER_DATA percentIdleTime;
     COUNTER_DATA percentDiskTime;
     COUNTER_DATA percentDiskReadTime;
     COUNTER_DATA percentDiskWriteTime;
     COUNTER_DATA currentDiskQueueLength;
     COUNTER_DATA averageDiskQueueLength;
-    COUNTER_DATA averageDiskReadQueueLength;
-    COUNTER_DATA averageDiskWriteQueueLength;
     COUNTER_DATA averageDiskSecondsPerTransfer;
     COUNTER_DATA averageDiskSecondsPerRead;
     COUNTER_DATA averageDiskSecondsPerWrite;
@@ -357,19 +359,18 @@ static bool do_physical_disk(PERF_DATA_BLOCK *pDataBlock, int update_every) {
         if (perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskReadQueueLength) &&
             perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskWriteQueueLength)) {
             if (is_system)
-                common_system_avgsize(d->averageDiskBytesPerRead.current.Data,
-                                      d->averageDiskBytesPerWrite.current.Data,
+                common_system_ioawait(d->averageDiskReadQueueLength.current.Data * 1000,
+                                      d->averageDiskWriteQueueLength.current.Data * 1000,
                                       update_every);
             else
-                common_disk_avgsize(&d->disk_size,
-                                    device,
-                                    NULL,
-                                    d->averageDiskBytesPerRead.current.Data,
-                                    d->averageDiskBytesPerWrite.current.Data,
-                                    1,
-                                    update_every,
-                                    physical_disk_labels,
-                                    d);
+                common_disk_await(&d->disk_await,
+                                  device,
+                                  NULL,
+                                  d->averageDiskReadQueueLength.current.Data * 1000,
+                                  d->averageDiskWriteQueueLength.current.Data * 1000,
+                                  update_every,
+                                  physical_disk_labels,
+                                  d);
         }
 
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->percentIdleTime);

--- a/src/collectors/windows.plugin/perflib-storage.c
+++ b/src/collectors/windows.plugin/perflib-storage.c
@@ -30,6 +30,10 @@ struct physical_disk {
     COUNTER_DATA diskReadBytesPerSec;
     COUNTER_DATA diskWriteBytesPerSec;
 
+    ND_DISK_OPS disk_op;
+    COUNTER_DATA diskReadsPerSec;
+    COUNTER_DATA diskWritesPerSec;
+
     COUNTER_DATA percentIdleTime;
     COUNTER_DATA percentDiskTime;
     COUNTER_DATA percentDiskReadTime;
@@ -42,8 +46,6 @@ struct physical_disk {
     COUNTER_DATA averageDiskSecondsPerRead;
     COUNTER_DATA averageDiskSecondsPerWrite;
     COUNTER_DATA diskTransfersPerSec;
-    COUNTER_DATA diskReadsPerSec;
-    COUNTER_DATA diskWritesPerSec;
     COUNTER_DATA diskBytesPerSec;
     COUNTER_DATA averageDiskBytesPerTransfer;
     COUNTER_DATA averageDiskBytesPerRead;
@@ -271,6 +273,19 @@ static bool do_physical_disk(PERF_DATA_BLOCK *pDataBlock, int update_every) {
                     d);
         }
 
+        if (perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->diskReadsPerSec) &&
+            perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->diskWritesPerSec)) {
+            common_disk_ops(&d->disk_op,
+                            device,
+                            NULL,
+                            device,
+                            d->diskReadsPerSec.current.Data,
+                            d->diskWritesPerSec.current.Data,
+                            update_every,
+                            physical_disk_labels,
+                            d);
+        }
+
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->percentIdleTime);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->percentDiskTime);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->percentDiskReadTime);
@@ -283,8 +298,6 @@ static bool do_physical_disk(PERF_DATA_BLOCK *pDataBlock, int update_every) {
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskSecondsPerRead);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskSecondsPerWrite);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->diskTransfersPerSec);
-        perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->diskReadsPerSec);
-        perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->diskWritesPerSec);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->diskBytesPerSec);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskBytesPerTransfer);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskBytesPerRead);

--- a/src/collectors/windows.plugin/perflib-storage.c
+++ b/src/collectors/windows.plugin/perflib-storage.c
@@ -30,6 +30,9 @@ struct physical_disk {
     COUNTER_DATA diskReadBytesPerSec;
     COUNTER_DATA diskWriteBytesPerSec;
 
+    ND_DISK_UIO disk_uio;
+    COUNTER_DATA diskBytesPerSec;
+
     ND_DISK_OPS disk_op;
     COUNTER_DATA diskReadsPerSec;
     COUNTER_DATA diskWritesPerSec;
@@ -46,7 +49,6 @@ struct physical_disk {
     COUNTER_DATA averageDiskSecondsPerRead;
     COUNTER_DATA averageDiskSecondsPerWrite;
     COUNTER_DATA diskTransfersPerSec;
-    COUNTER_DATA diskBytesPerSec;
     COUNTER_DATA averageDiskBytesPerTransfer;
     COUNTER_DATA averageDiskBytesPerRead;
     COUNTER_DATA averageDiskBytesPerWrite;
@@ -273,6 +275,16 @@ static bool do_physical_disk(PERF_DATA_BLOCK *pDataBlock, int update_every) {
                     d);
         }
 
+        if (perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->diskBytesPerSec)) {
+            common_unified_disk_io(&d->disk_uio,
+                                   device,
+                                   NULL,
+                                   d->diskBytesPerSec.current.Data,
+                                   update_every,
+                                   physical_disk_labels,
+                                   d);
+        }
+
         if (perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->diskReadsPerSec) &&
             perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->diskWritesPerSec)) {
             common_disk_ops(&d->disk_op,
@@ -298,7 +310,6 @@ static bool do_physical_disk(PERF_DATA_BLOCK *pDataBlock, int update_every) {
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskSecondsPerRead);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskSecondsPerWrite);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->diskTransfersPerSec);
-        perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->diskBytesPerSec);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskBytesPerTransfer);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskBytesPerRead);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskBytesPerWrite);

--- a/src/collectors/windows.plugin/perflib-storage.c
+++ b/src/collectors/windows.plugin/perflib-storage.c
@@ -354,14 +354,30 @@ static bool do_physical_disk(PERF_DATA_BLOCK *pDataBlock, int update_every) {
                                     d);
         }
 
+        if (perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskReadQueueLength) &&
+            perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskWriteQueueLength)) {
+            if (is_system)
+                common_system_avgsize(d->averageDiskBytesPerRead.current.Data,
+                                      d->averageDiskBytesPerWrite.current.Data,
+                                      update_every);
+            else
+                common_disk_avgsize(&d->disk_size,
+                                    device,
+                                    NULL,
+                                    d->averageDiskBytesPerRead.current.Data,
+                                    d->averageDiskBytesPerWrite.current.Data,
+                                    1,
+                                    update_every,
+                                    physical_disk_labels,
+                                    d);
+        }
+
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->percentIdleTime);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->percentDiskTime);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->percentDiskReadTime);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->percentDiskWriteTime);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->currentDiskQueueLength);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskQueueLength);
-        perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskReadQueueLength);
-        perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskWriteQueueLength);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskSecondsPerTransfer);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskSecondsPerRead);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskSecondsPerWrite);

--- a/src/collectors/windows.plugin/perflib-storage.c
+++ b/src/collectors/windows.plugin/perflib-storage.c
@@ -41,6 +41,9 @@ struct physical_disk {
     COUNTER_DATA averageDiskBytesPerRead;
     COUNTER_DATA averageDiskBytesPerWrite;
 
+    ND_DISK_UAVGSIZE udisk_size;
+    COUNTER_DATA diskTransfersPerSec;
+
     COUNTER_DATA percentIdleTime;
     COUNTER_DATA percentDiskTime;
     COUNTER_DATA percentDiskReadTime;
@@ -52,7 +55,6 @@ struct physical_disk {
     COUNTER_DATA averageDiskSecondsPerTransfer;
     COUNTER_DATA averageDiskSecondsPerRead;
     COUNTER_DATA averageDiskSecondsPerWrite;
-    COUNTER_DATA diskTransfersPerSec;
     COUNTER_DATA averageDiskBytesPerTransfer;
     COUNTER_DATA splitIoPerSec;
 };
@@ -313,6 +315,16 @@ static bool do_physical_disk(PERF_DATA_BLOCK *pDataBlock, int update_every) {
                                 d);
         }
 
+        if (perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->diskTransfersPerSec)) {
+            common_unified_disk_avgsize(&d->udisk_size,
+                                        device,
+                                        NULL,
+                                        d->diskTransfersPerSec.current.Data,
+                                        update_every,
+                                        physical_disk_labels,
+                                        d);
+        }
+
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->percentIdleTime);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->percentDiskTime);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->percentDiskReadTime);
@@ -324,7 +336,6 @@ static bool do_physical_disk(PERF_DATA_BLOCK *pDataBlock, int update_every) {
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskSecondsPerTransfer);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskSecondsPerRead);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskSecondsPerWrite);
-        perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->diskTransfersPerSec);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskBytesPerTransfer);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->splitIoPerSec);
     }

--- a/src/collectors/windows.plugin/perflib-storage.c
+++ b/src/collectors/windows.plugin/perflib-storage.c
@@ -37,6 +37,10 @@ struct physical_disk {
     COUNTER_DATA diskReadsPerSec;
     COUNTER_DATA diskWritesPerSec;
 
+    ND_DISK_AVGSIZE disk_size;
+    COUNTER_DATA averageDiskBytesPerRead;
+    COUNTER_DATA averageDiskBytesPerWrite;
+
     COUNTER_DATA percentIdleTime;
     COUNTER_DATA percentDiskTime;
     COUNTER_DATA percentDiskReadTime;
@@ -50,8 +54,6 @@ struct physical_disk {
     COUNTER_DATA averageDiskSecondsPerWrite;
     COUNTER_DATA diskTransfersPerSec;
     COUNTER_DATA averageDiskBytesPerTransfer;
-    COUNTER_DATA averageDiskBytesPerRead;
-    COUNTER_DATA averageDiskBytesPerWrite;
     COUNTER_DATA splitIoPerSec;
 };
 
@@ -298,6 +300,19 @@ static bool do_physical_disk(PERF_DATA_BLOCK *pDataBlock, int update_every) {
                             d);
         }
 
+        if (perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskBytesPerRead) &&
+            perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskBytesPerWrite)) {
+            common_disk_avgsize(&d->disk_size,
+                                device,
+                                NULL,
+                                d->averageDiskBytesPerRead.current.Data,
+                                d->averageDiskBytesPerWrite.current.Data,
+                                1,
+                                update_every,
+                                physical_disk_labels,
+                                d);
+        }
+
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->percentIdleTime);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->percentDiskTime);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->percentDiskReadTime);
@@ -311,8 +326,6 @@ static bool do_physical_disk(PERF_DATA_BLOCK *pDataBlock, int update_every) {
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskSecondsPerWrite);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->diskTransfersPerSec);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskBytesPerTransfer);
-        perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskBytesPerRead);
-        perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->averageDiskBytesPerWrite);
         perflibGetInstanceCounter(pDataBlock, pObjectType, pi, &d->splitIoPerSec);
     }
 

--- a/src/collectors/windows.plugin/perflib-thermalzone.c
+++ b/src/collectors/windows.plugin/perflib-thermalzone.c
@@ -3,7 +3,7 @@
 #include "windows_plugin.h"
 #include "windows-internals.h"
 
-typedef struct thermal_zone {
+struct thermal_zone {
     RRDSET *st;
     RRDDIM *rd;
 

--- a/src/collectors/windows.plugin/windows_plugin.c
+++ b/src/collectors/windows.plugin/windows_plugin.c
@@ -28,6 +28,8 @@ static struct proc_module {
 
     {.name = "PerflibThermalZone",  .dim = "PerflibThermalZone", .enabled = CONFIG_BOOLEAN_NO, .func = do_PerflibThermalZone},
 
+    {.name = "PerflibThermalZone",      .dim = "PerflibThermalZone",          .func = do_PerflibThermalZone},
+
     // the terminator of this array
     {.name = NULL, .dim = NULL, .func = NULL}
 };


### PR DESCRIPTION
##### Summary
This PR is bringing Disk metrics for Windows Plugin.

Some metrics were still not added, because apparently they need a different algorithm.

##### Test Plan

1. Compile this branch
2. Generate installer
3. Install and verify your dashboard.

Linux was also modified, so:

1. Compile this branch on Linux
2. Start netdata to confirm charts are ok.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
