### PR TITLE
Add check for 64bit builtin atomics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,6 +453,15 @@ int main() {
 }
 " HAVE_BUILTIN_ATOMICS)
 
+check_cxx_source_compiles("
+#include <stdint.h>
+int main(void) {
+        uint64_t a;
+        __sync_add_and_fetch(&a, 1);
+        return 0;
+}
+" ARCH_SUPPORTS_64BIT_ATOMICS)
+
 check_c_source_compiles("
 void my_printf(char const *s, ...) __attribute__((format(gnu_printf, 1, 2)));
 int main() { return 0; }
@@ -1679,6 +1688,8 @@ if(ENABLE_H2O)
 
         target_compile_options(h2o PUBLIC -DH2O_USE_LIBUV=0)
         target_link_libraries(h2o PRIVATE PkgConfig::TLS)
+        target_compile_definitions(h2o PRIVATE
+                "$<$<NOT:$<BOOL:${ARCH_SUPPORTS_64BIT_ATOMICS}>>:H2O_NO_64BIT_ATOMICS>")
 endif()
 
 #


### PR DESCRIPTION
Compilers for some architectures e.g. RISCV32 do not have 64bit atomics therefore, its important to deduce that and use it to pass right flags to compiler to use them, e.g. h2o module

Fixes
nection.c.o): in function `h2o_create_connection': | /usr/src/debug/netdata/1.47.1/src/web/server/h2o/libh2o/include/h2o.h:1917:(.text.create_conn+0x5e): undefined reference to `__sync_add_and_fetch_8' | collect2: error: ld returned 1 exit status
