### PR TITLE
Reduce connection timeout and fallback to IPV4 for ACLK connections

### DIFF
--- a/src/aclk/aclk_otp.h
+++ b/src/aclk/aclk_otp.h
@@ -9,10 +9,10 @@
 #include "aclk_util.h"
 
 #if OPENSSL_VERSION_NUMBER >= OPENSSL_VERSION_300
-int aclk_get_mqtt_otp(EVP_PKEY *p_key, char **mqtt_id, char **mqtt_usr, char **mqtt_pass, url_t *target);
+int aclk_get_mqtt_otp(EVP_PKEY *p_key, char **mqtt_id, char **mqtt_usr, char **mqtt_pass, url_t *target, bool *fallback_ipv4);
 #else
-int aclk_get_mqtt_otp(RSA *p_key, char **mqtt_id, char **mqtt_usr, char **mqtt_pass, url_t *target);
+int aclk_get_mqtt_otp(RSA *p_key, char **mqtt_id, char **mqtt_usr, char **mqtt_pass, url_t *target, bool *fallback_ipv4);
 #endif
-int aclk_get_env(aclk_env_t *env, const char *aclk_hostname, int aclk_port);
+int aclk_get_env(aclk_env_t *env, const char *aclk_hostname, int aclk_port, bool *fallback_ipv4);
 
 #endif /* ACLK_OTP_H */

--- a/src/aclk/https_client.h
+++ b/src/aclk/https_client.h
@@ -75,7 +75,7 @@ void https_req_response_free(https_req_response_t *res);
         .proxy_port = 8080                          \
     }
 
-int https_request(https_req_t *request, https_req_response_t *response);
+int https_request(https_req_t *request, https_req_response_t *response, bool *fallback_ipv4);
 
 // we expose previously internal parser as this is usefull also from
 // other parts of the code

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -510,7 +510,8 @@ int mqtt_wss_connect(
     int port,
     struct mqtt_connect_params *mqtt_params,
     int ssl_flags,
-    struct mqtt_wss_proxy *proxy)
+    struct mqtt_wss_proxy *proxy,
+    bool *fallback_ipv4)
 {
     if (!mqtt_params) {
         mws_error(client->log, "mqtt_params can't be null!");
@@ -566,7 +567,9 @@ int mqtt_wss_connect(
 
     char port_str[16];
     snprintf(port_str, sizeof(port_str) -1, "%d", client->port);
-    int fd = connect_to_this_ip46(IPPROTO_TCP, SOCK_STREAM, client->host, 0, port_str, NULL);
+
+    struct timeval timeout = { .tv_sec = 10, .tv_usec = 0 };
+    int fd = connect_to_this_ip46(IPPROTO_TCP, SOCK_STREAM, client->host, 0, port_str, &timeout, fallback_ipv4);
     if (fd < 0) {
         mws_error(client->log, "Could not connect to remote endpoint \"%s\", port %d.\n", client->host, port);
         return -3;

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.h
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.h
@@ -65,7 +65,14 @@ struct mqtt_wss_proxy;
  * @param mqtt_params pointer to mqtt_connect_params structure which contains MQTT credentials and settings
  * @param ssl_flags parameters for OpenSSL, 0=MQTT_WSS_SSL_CERT_CHECK_FULL
  */
-int mqtt_wss_connect(mqtt_wss_client client, char *host, int port, struct mqtt_connect_params *mqtt_params, int ssl_flags, struct mqtt_wss_proxy *proxy);
+int mqtt_wss_connect(
+    mqtt_wss_client client,
+    char *host,
+    int port,
+    struct mqtt_connect_params *mqtt_params,
+    int ssl_flags,
+    struct mqtt_wss_proxy *proxy,
+    bool *fallback_ipv4);
 int mqtt_wss_service(mqtt_wss_client client, int timeout_ms);
 void mqtt_wss_disconnect(mqtt_wss_client client, int timeout_ms);
 

--- a/src/libnetdata/socket/socket.c
+++ b/src/libnetdata/socket/socket.c
@@ -857,7 +857,15 @@ static inline int connect_to_unix(const char *path, struct timeval *timeout) {
 // service     the service name or port to connect to
 // timeout     the timeout for establishing a connection
 
-int connect_to_this_ip46(int protocol, int socktype, const char *host, uint32_t scope_id, const char *service, struct timeval *timeout) {
+int connect_to_this_ip46(
+    int protocol,
+    int socktype,
+    const char *host,
+    uint32_t scope_id,
+    const char *service,
+    struct timeval *timeout,
+    bool *fallback_ipv4)
+{
     struct addrinfo hints;
     struct addrinfo *ai_head = NULL, *ai = NULL;
 
@@ -889,6 +897,9 @@ int connect_to_this_ip46(int protocol, int socktype, const char *host, uint32_t 
     int fd = -1;
     for (ai = ai_head; ai != NULL && fd == -1; ai = ai->ai_next) {
         if(nd_thread_signaled_to_cancel()) break;
+
+        if (fallback_ipv4 && *fallback_ipv4 && ai->ai_family == PF_INET6)
+            continue;
 
         if (ai->ai_family == PF_INET6) {
             struct sockaddr_in6 *pSadrIn6 = (struct sockaddr_in6 *) ai->ai_addr;
@@ -969,6 +980,9 @@ int connect_to_this_ip46(int protocol, int socktype, const char *host, uint32_t 
 
                             close(fd);
                             fd = -1;
+
+                            if (fallback_ipv4 && ai->ai_family == PF_INET6)
+                                *fallback_ipv4 = true;
                             break;
 
                         default:
@@ -1090,7 +1104,7 @@ int connect_to_this(const char *definition, int default_port, struct timeval *ti
         service = default_service;
 
 
-    return connect_to_this_ip46(protocol, socktype, host, scope_id, service, timeout);
+    return connect_to_this_ip46(protocol, socktype, host, scope_id, service, timeout,NULL);
 }
 
 void foreach_entry_in_connection_string(const char *destination, bool (*callback)(char *entry, void *data), void *data) {

--- a/src/libnetdata/socket/socket.h
+++ b/src/libnetdata/socket/socket.h
@@ -33,7 +33,14 @@ int listen_sockets_setup(LISTEN_SOCKETS *sockets);
 void listen_sockets_close(LISTEN_SOCKETS *sockets);
 
 void foreach_entry_in_connection_string(const char *destination, bool (*callback)(char *entry, void *data), void *data);
-int connect_to_this_ip46(int protocol, int socktype, const char *host, uint32_t scope_id, const char *service, struct timeval *timeout);
+int connect_to_this_ip46(
+    int protocol,
+    int socktype,
+    const char *host,
+    uint32_t scope_id,
+    const char *service,
+    struct timeval *timeout,
+    bool *fallback_ipv4);
 int connect_to_this(const char *definition, int default_port, struct timeval *timeout);
 int connect_to_one_of(const char *destination, int default_port, struct timeval *timeout, size_t *reconnects_counter, char *connected_to, size_t connected_to_size);
 int connect_to_one_of_urls(const char *destination, int default_port, struct timeval *timeout, size_t *reconnects_counter, char *connected_to, size_t connected_to_size);


### PR DESCRIPTION
##### Summary

When establishing an ACLK connection:

- Reduce initial connection timeout to 10 seconds (down from 30)
- Fallback to IPV4 connection if we get IPV6 connection timeout
  - On successful connection the fallback flag is reset so that connecting with IPV6 will be retried if the connection needs to be reestablished
