### PR TITLE
Use `/var/run/netdata` for the netdatacli pipe.

### DIFF
--- a/src/daemon/pipename.c
+++ b/src/daemon/pipename.c
@@ -12,6 +12,6 @@ const char *daemon_pipename(void) {
 #ifdef _WIN32
     return "\\\\?\\pipe\\netdata-cli";
 #else
-    return "/tmp/netdata-ipc";
+    return "/var/run/netdata/netdata-cli";
 #endif
 }


### PR DESCRIPTION
##### Summary

The current approach using `/tmp` is problematic because:

1. The fact that `/tmp` is world writable _and_ we don’t do rigorous checks before trying to use the current path means that it’s trivial for _ANY USER ON THE SYSTEM_ to effect a DoS attack on netdatacli usage by simply touching `/tmp/netdata-ipc` while Netdata is not running.
2. `/tmp` is not universally presented as a unified hierarchy shared between all users, and it’s becoming more common to use a split approach because of issues like the above mentioned DoS opportunity. On systems that have a split `/tmp`, there is no guarantee that anybody, even the root user, will actually see or be able to access the pipe to run the `netdatacli` command.
3. `/tmp` is not where this should have been in the first place since it’s not a temporary file but a runtime file.

`/var/run/netdata` was chosen as it is the default location for our pidfile, and thus can be counted on to exist on a standard install.

This also updates the name of the pipe itself to be consistent with what we use on Windows.

##### Test Plan

Needs manual confirmation that the new path is used.

##### Additional Information

Fixes: #7587 (finally)