### PR TITLE
Add DLLs to CmakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3083,6 +3083,10 @@ if(NOT OS_WINDOWS)
 endif()
 
 if(OS_WINDOWS)
+        install(FILES /usr/bin/msys-protobuf-32.dll
+                      /usr/bin/msys-uv-1.dll
+                      DESTINATION "${BINDIR}")
+
         # Make bash & netdata happy
         install(DIRECTORY DESTINATION tmp)
 


### PR DESCRIPTION
##### Summary
After @stelfrag reports issues on his new environment, we are bringing back some DLLs installation inside our `CMakeLists.txt`.

##### Test Plan

1. Uninstall netdata on Windows and remove possible remaining files in installation directory.
2. Compile this branch
3. Make the installer
4. Install netdata on your host. You should not have issues to start service.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
