### PR TITLE
Change default pages per extent

### DIFF
--- a/src/database/engine/rrdengine.h
+++ b/src/database/engine/rrdengine.h
@@ -28,7 +28,7 @@ struct rrdengine_instance;
 struct rrdeng_cmd;
 
 #define MAX_PAGES_PER_EXTENT (109) /* TODO: can go higher only when journal supports bigger than 4KiB transactions */
-#define DEFAULT_PAGES_PER_EXTENT (64)
+#define DEFAULT_PAGES_PER_EXTENT (109)
 
 #define RRDENG_FILE_NUMBER_SCAN_TMPL "%1u-%10u"
 #define RRDENG_FILE_NUMBER_PRINT_TMPL "%1.1u-%10.10u"


### PR DESCRIPTION
##### Summary
- Changes the default number of pages that can be added to an extent from 64 to 109
- This can improve
   - Data compression when storing metrics to datafile
   - Reduce journal file v1 fragmentation.
   - Improve I/O under certain workloads as an extent will transfer ~70% more pages

**Note**: Agents up to version v1.45.0-113-nightly will not be able to read newly created datafiles. 
If that is needed you need to overwrite the new default by adding 
```
[db]
     dbengine pages per extent = 64
```
so that the agent will keep using up to 64 pages per extent

