### PR TITLE
Log  agent start / stop timing events

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -2314,7 +2314,7 @@ int netdata_main(int argc, char **argv) {
     add_agent_event(EVENT_AGENT_START_TIME, (int64_t ) (ready_ut - started_ut));
     usec_t median_start_time = get_agent_event_time_median(EVENT_AGENT_START_TIME);
     netdata_log_info(
-        "NETDATA STARTUP: completed in %llu ms (average start up time is %llu ms). Enjoy real-time performance monitoring!",
+        "NETDATA STARTUP: completed in %llu ms (median start up time is %llu ms). Enjoy real-time performance monitoring!",
         (ready_ut - started_ut) / USEC_PER_MS, median_start_time / USEC_PER_MS);
 
     cleanup_agent_event_log();

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -2312,10 +2312,10 @@ int netdata_main(int argc, char **argv) {
 
     usec_t ready_ut = now_monotonic_usec();
     add_agent_event(EVENT_AGENT_START_TIME, (int64_t ) (ready_ut - started_ut));
-    usec_t avg_start_time = get_agent_event_time_average(EVENT_AGENT_START_TIME);
+    usec_t median_start_time = get_agent_event_time_median(EVENT_AGENT_START_TIME);
     netdata_log_info(
         "NETDATA STARTUP: completed in %llu ms (average start up time is %llu ms). Enjoy real-time performance monitoring!",
-        (ready_ut - started_ut) / USEC_PER_MS, avg_start_time / USEC_PER_MS);
+        (ready_ut - started_ut) / USEC_PER_MS, median_start_time / USEC_PER_MS);
 
     cleanup_agent_event_log();
     netdata_ready = true;

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2379,19 +2379,18 @@ usec_t get_agent_event_time_average(event_log_type_t event_id)
     if (!PREPARE_STATEMENT(db_meta, SQL_GET_AGENT_EVENT_TYPE_AVERAGE, &res))
         return 0;
 
+    usec_t avg_time = 0;
     int param = 0;
     SQLITE_BIND_FAIL(done, sqlite3_bind_int(res, ++param, event_id));
-    usec_t avg_time = 0;
+
     param = 0;
-    if (sqlite3_step_monitored(res) == SQLITE_ROW) {
+    if (sqlite3_step_monitored(res) == SQLITE_ROW)
         avg_time = sqlite3_column_int64(res, 0);
-    }
-    sqlite3_finalize(res);
-    return avg_time;
+
 done:
     REPORT_BIND_FAIL(res, param);
     SQLITE_FINALIZE(res);
-    return -1;
+    return avg_time;
 }
 
 //

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -78,6 +78,9 @@ const char *database_config[] = {
     "CREATE INDEX IF NOT EXISTS health_log_d_ind_7 on health_log_detail (alarm_id)",
     "CREATE INDEX IF NOT EXISTS health_log_d_ind_8 on health_log_detail (new_status, updated_by_id)",
 
+    "CREATE TABLE IF NOT EXISTS agent_event_log (id INTEGER PRIMARY KEY, version TEXT, event_type INT, value, date_created INT)",
+    "CREATE INDEX IF NOT EXISTS idx_agent_event_log1 on agent_event_log (event_type)",
+
     "CREATE TABLE IF NOT EXISTS alert_queue "
     " (host_id BLOB, health_log_id INT, unique_id INT, alarm_id INT, status INT, date_scheduled INT, "
     " UNIQUE(host_id, health_log_id, alarm_id))",
@@ -2335,6 +2338,60 @@ void metadata_delete_host_chart_labels(char *machine_guid)
 uint64_t sqlite_get_meta_space(void)
 {
     return sqlite_get_db_space(db_meta);
+}
+
+#define SQL_ADD_AGENT_EVENT_LOG      \
+    "INSERT INTO agent_event_log (event_type, version, value, date_created) VALUES " \
+    " (@event_type, @version, @value, UNIXEPOCH())"
+
+void add_agent_event(event_log_type_t event_id, int64_t value)
+{
+    sqlite3_stmt *res = NULL;
+
+    if (!PREPARE_STATEMENT(db_meta, SQL_ADD_AGENT_EVENT_LOG, &res))
+        return;
+
+    int param = 0;
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int(res, ++param, event_id));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_text(res, ++param, NETDATA_VERSION, -1, SQLITE_STATIC));
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, value));
+
+    param = 0;
+    int rc = execute_insert(res);
+    if (rc != SQLITE_DONE)
+        error_report("Failed to store agent event information, rc = %d", rc);
+done:
+    REPORT_BIND_FAIL(res, param);
+    SQLITE_FINALIZE(res);
+}
+
+void cleanup_agent_event_log(void)
+{
+    db_execute(db_meta, "DELETE FROM agent_event_log WHERE date_created < UNIXEPOCH() - 30 * 86400");
+}
+
+#define SQL_GET_AGENT_EVENT_TYPE_AVERAGE \
+        "SELECT CAST(AVG(value) AS INT) FROM agent_event_log WHERE event_type = @event"
+
+usec_t get_agent_event_time_average(event_log_type_t event_id)
+{
+    sqlite3_stmt *res = NULL;
+    if (!PREPARE_STATEMENT(db_meta, SQL_GET_AGENT_EVENT_TYPE_AVERAGE, &res))
+        return 0;
+
+    int param = 0;
+    SQLITE_BIND_FAIL(done, sqlite3_bind_int(res, ++param, event_id));
+    usec_t avg_time = 0;
+    param = 0;
+    if (sqlite3_step_monitored(res) == SQLITE_ROW) {
+        avg_time = sqlite3_column_int64(res, 0);
+    }
+    sqlite3_finalize(res);
+    return avg_time;
+done:
+    REPORT_BIND_FAIL(res, param);
+    SQLITE_FINALIZE(res);
+    return -1;
 }
 
 //

--- a/src/database/sqlite/sqlite_metadata.h
+++ b/src/database/sqlite/sqlite_metadata.h
@@ -6,6 +6,11 @@
 #include "sqlite3.h"
 #include "sqlite_functions.h"
 
+typedef enum event_log_type {
+    EVENT_AGENT_START_TIME  = 1,
+    EVENT_AGENT_SHUTDOWN_TIME,
+} event_log_type_t;
+
 // return a node list
 struct node_instance_list {
     nd_uuid_t  node_id;
@@ -53,6 +58,10 @@ bool sql_set_host_label(nd_uuid_t *host_id, const char *label_key, const char *l
 
 uint64_t sqlite_get_meta_space(void);
 int sql_init_meta_database(db_check_action_type_t rebuild, int memory);
+
+void cleanup_agent_event_log(void);
+void add_agent_event(event_log_type_t event_id, int64_t value);
+usec_t get_agent_event_time_average(event_log_type_t event_id);
 
 // UNIT TEST
 int metadata_unittest(void);

--- a/src/database/sqlite/sqlite_metadata.h
+++ b/src/database/sqlite/sqlite_metadata.h
@@ -61,7 +61,7 @@ int sql_init_meta_database(db_check_action_type_t rebuild, int memory);
 
 void cleanup_agent_event_log(void);
 void add_agent_event(event_log_type_t event_id, int64_t value);
-usec_t get_agent_event_time_average(event_log_type_t event_id);
+usec_t get_agent_event_time_median(event_log_type_t event_id);
 
 // UNIT TEST
 int metadata_unittest(void);

--- a/src/streaming/stream_path.c
+++ b/src/streaming/stream_path.c
@@ -54,6 +54,8 @@ static void stream_path_to_json_object(BUFFER *wb, STREAM_PATH *p) {
     buffer_json_member_add_int64(wb, "hops", p->hops);
     buffer_json_member_add_uint64(wb, "since", p->since);
     buffer_json_member_add_uint64(wb, "first_time_t", p->first_time_t);
+    buffer_json_member_add_uint64(wb, "start_time", p->start_time);
+    buffer_json_member_add_uint64(wb, "shutdown_time", p->shutdown_time);
     stream_capabilities_to_json_array(wb, p->capabilities, "capabilities");
     STREAM_PATH_FLAGS_2json(wb, "flags", p->flags);
     buffer_json_object_close(wb);
@@ -68,6 +70,8 @@ static STREAM_PATH rrdhost_stream_path_self(RRDHOST *host) {
     p.host_id = localhost->host_id;
     p.node_id = localhost->node_id;
     p.claim_id = claim_id_get_uuid();
+    p.start_time = get_agent_event_time_average(EVENT_AGENT_START_TIME) / USEC_PER_MS;
+    p.shutdown_time = get_agent_event_time_average(EVENT_AGENT_SHUTDOWN_TIME) / USEC_PER_MS;
 
     p.flags = STREAM_PATH_FLAG_NONE;
     if(!UUIDiszero(p.claim_id))

--- a/src/streaming/stream_path.c
+++ b/src/streaming/stream_path.c
@@ -70,8 +70,8 @@ static STREAM_PATH rrdhost_stream_path_self(RRDHOST *host) {
     p.host_id = localhost->host_id;
     p.node_id = localhost->node_id;
     p.claim_id = claim_id_get_uuid();
-    p.start_time = get_agent_event_time_average(EVENT_AGENT_START_TIME) / USEC_PER_MS;
-    p.shutdown_time = get_agent_event_time_average(EVENT_AGENT_SHUTDOWN_TIME) / USEC_PER_MS;
+    p.start_time = get_agent_event_time_median(EVENT_AGENT_START_TIME) / USEC_PER_MS;
+    p.shutdown_time = get_agent_event_time_median(EVENT_AGENT_SHUTDOWN_TIME) / USEC_PER_MS;
 
     p.flags = STREAM_PATH_FLAG_NONE;
     if(!UUIDiszero(p.claim_id))

--- a/src/streaming/stream_path.h
+++ b/src/streaming/stream_path.h
@@ -22,6 +22,8 @@ typedef struct stream_path {
     int16_t hops;                   // -1 = stale node, 0 = localhost, >0 the hops count
     STREAM_PATH_FLAGS flags;        // ACLK or NONE for the moment
     STREAM_CAPABILITIES capabilities; // streaming connection capabilities
+    uint32_t start_time;            // Average time in ms the agent needs to start
+    uint32_t shutdown_time;         // Average time in ms the agent needs to shutdown
 } STREAM_PATH;
 
 typedef struct rrdhost_stream_path {

--- a/src/streaming/stream_path.h
+++ b/src/streaming/stream_path.h
@@ -22,8 +22,8 @@ typedef struct stream_path {
     int16_t hops;                   // -1 = stale node, 0 = localhost, >0 the hops count
     STREAM_PATH_FLAGS flags;        // ACLK or NONE for the moment
     STREAM_CAPABILITIES capabilities; // streaming connection capabilities
-    uint32_t start_time;            // Average time in ms the agent needs to start
-    uint32_t shutdown_time;         // Average time in ms the agent needs to shutdown
+    uint32_t start_time;            // median time in ms the agent needs to start
+    uint32_t shutdown_time;         // median time in ms the agent needs to shutdown
 } STREAM_PATH;
 
 typedef struct rrdhost_stream_path {


### PR DESCRIPTION
##### Summary
- Store in the database agent startup and shutdown times. 
- Add the median start_time / shutdown_time in ms in the stream path payload

The median startup time of the last 30 days is reported when the agent starts.
Example
```
NETDATA STARTUP: completed in 1239 ms. Enjoy real-time performance monitoring!
```

after

```
NETDATA STARTUP: completed in 1308 ms (median start up time is 1303 ms). Enjoy real-time performance monitoring!
```

This information will be used in a future PR to estimate agent restart times (e.g. when a child disconnects for a version update)