### PR TITLE
New wording about edit-config script in docs

### DIFF
--- a/docs/deployment-guides/deployment-strategies.md
+++ b/docs/deployment-guides/deployment-strategies.md
@@ -32,7 +32,7 @@ In this example, Machine Learning and Alerting are disabled for the Child, so th
 
 ##### netdata.conf
 
-On the child node, edit `netdata.conf` by using the [edit-config](/docs/netdata-agent/configuration/README.md#edit-netdataconf) script and set the following parameters:
+On the child node, edit `netdata.conf` by using the [edit-config](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config) script and set the following parameters:
 
 ```yaml
 [db]
@@ -63,7 +63,7 @@ On the child node, edit `netdata.conf` by using the [edit-config](/docs/netdata-
 
 ##### stream.conf
 
-To edit `stream.conf`, use again the [edit-config](/docs/netdata-agent/configuration/README.md#edit-netdataconf) script and set the following parameters:
+To edit `stream.conf`, use again the [edit-config](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config) script and set the following parameters:
 
 ```yaml
 [stream]
@@ -90,7 +90,7 @@ Requiring:
 
 ##### netdata.conf
 
-On the Parent, edit `netdata.conf` by using the [edit-config](/docs/netdata-agent/configuration/README.md#edit-netdataconf) script and set the following parameters:
+On the Parent, edit `netdata.conf` by using the [edit-config](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config) script and set the following parameters:
 
 ```yaml
 [db]
@@ -120,7 +120,7 @@ On the Parent, edit `netdata.conf` by using the [edit-config](/docs/netdata-agen
 
 ##### stream.conf
 
-On the Parent node, edit `stream.conf` by using the [edit-config](/docs/netdata-agent/configuration/README.md#edit-netdataconf) script and set the following parameters:
+On the Parent node, edit `stream.conf` by using the [edit-config](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config) script and set the following parameters:
 
 ```yaml
 [API_KEY]
@@ -132,7 +132,7 @@ On the Parent node, edit `stream.conf` by using the [edit-config](/docs/netdata-
 
 In order to setup active–active streaming between Parent 1 and Parent 2, Parent 1 needs to be instructed to stream data to Parent 2 and Parent 2 to stream data to Parent 1. The Child Agents need to be configured with the addresses of both Parent Agents. An Agent will only connect to one Parent at a time, falling back to the next upon failure. These examples use the same API key between Parent Agents and for connections for Child Agents.
 
-On both Netdata Parent and all Child Agents, edit `stream.conf` by using the [edit-config](/docs/netdata-agent/configuration/README.md#edit-netdataconf) script:
+On both Netdata Parent and all Child Agents, edit `stream.conf` by using the [edit-config](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config) script:
 
 #### stream.conf on Parent 1
 

--- a/docs/developer-and-contributor-corner/raspberry-pi-anomaly-detection.md
+++ b/docs/developer-and-contributor-corner/raspberry-pi-anomaly-detection.md
@@ -23,7 +23,7 @@ Read on to learn all the steps and enable unsupervised anomaly detection on your
 
 First make sure Netdata is using Python 3 when it runs Python-based data collectors. 
 
-Next, open `netdata.conf` using [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-netdataconf)
+Next, open `netdata.conf` using [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config)
 from within the [Netdata config directory](/docs/netdata-agent/configuration/README.md#the-netdata-config-directory). Scroll down to the
 `[plugin:python.d]` section to pass in the `-ppython3` command option. 
 

--- a/docs/netdata-agent/configuration/README.md
+++ b/docs/netdata-agent/configuration/README.md
@@ -1,6 +1,6 @@
 # Netdata Agent Configuration
 
-The main Netdata agent configuration is `netdata.conf`.
+The main Netdata Agent configuration is `netdata.conf`.
 
 ## The Netdata config directory
 
@@ -10,12 +10,15 @@ few directories, and a shell script named `edit-config`.
 
 > Some operating systems will use `/opt/netdata/etc/netdata/` as the config directory. If you're not sure where yours
 > is, navigate to `http://NODE:19999/netdata.conf` in your browser, replacing `NODE` with the IP address or hostname of
-> your node, and find the `# config directory = ` setting. The value listed is the config directory for your system.
+> your node, and find the `# config directory =` setting. The value listed is the config directory for your system.
 
 All of Netdata's documentation assumes that your config directory is at `/etc/netdata`, and that you're running any scripts from inside that directory.
 
+## Edit a configuration file using `edit-config`
 
-## edit `netdata.conf`
+We recommend the use of the `edit-config` script for configuration changes.
+
+It exists inside your config directory (read above) and helps manage and safely edit configuration files.
 
 To edit `netdata.conf`, run this on your terminal:
 
@@ -28,7 +31,7 @@ Your editor will open.
 
 ## downloading `netdata.conf`
 
-The running version of `netdata.conf` can be downloaded from a running Netdata agent, at this URL:
+The running version of `netdata.conf` can be downloaded from a running Netdata Agent, at this URL:
 
 ```
 http://agent-ip:19999/netdata.conf
@@ -40,4 +43,3 @@ You can save and use this version, using these commands:
 cd /etc/netdata 2>/dev/null || cd /opt/netdata/etc/netdata
 curl -ksSLo /tmp/netdata.conf.new http://localhost:19999/netdata.conf && sudo mv -i /tmp/netdata.conf.new netdata.conf 
 ```
-

--- a/src/collectors/charts.d.plugin/README.md
+++ b/src/collectors/charts.d.plugin/README.md
@@ -21,7 +21,7 @@ By default, `charts.d.plugin` is not included as part of the install when using 
 
 ## Configuration
 
-`charts.d.plugin` itself can be [configured](/docs/netdata-agent/configuration/README.md#edit-netdataconf)using the configuration file `/etc/netdata/charts.d.conf`. This file is also a BASH script.
+`charts.d.plugin` itself can be [configured](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config)using the configuration file `/etc/netdata/charts.d.conf`. This file is also a BASH script.
 
 In this file, you can place statements like this:
 

--- a/src/collectors/ebpf.plugin/README.md
+++ b/src/collectors/ebpf.plugin/README.md
@@ -49,7 +49,7 @@ To enable or disable the entire eBPF collector:
     cd /etc/netdata
     ```
 
-2.  Use the [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-netdataconf) script to edit `netdata.conf`.
+2.  Use the [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config) script to edit `netdata.conf`.
 
     ```bash
     ./edit-config netdata.conf
@@ -73,7 +73,7 @@ To edit the `ebpf.d.conf`:
     ```bash
     cd /etc/netdata
     ```
-2.  Use the [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-netdataconf) script to edit [`ebpf.d.conf`](https://github.com/netdata/netdata/blob/master/src/collectors/ebpf.plugin/ebpf.d.conf).
+2.  Use the [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config) script to edit [`ebpf.d.conf`](https://github.com/netdata/netdata/blob/master/src/collectors/ebpf.plugin/ebpf.d.conf).
 
     ```bash
     ./edit-config ebpf.d.conf
@@ -276,7 +276,7 @@ To configure an eBPF thread:
     ```bash
     cd /etc/netdata
     ```
-2.  Use the [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-netdataconf) script to edit a thread configuration file. The following configuration files are available:
+2.  Use the [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config) script to edit a thread configuration file. The following configuration files are available:
 
     -   `network.conf`: Configuration for the [`network` thread](#network-configuration). This config file overwrites the global options and also
         lets you specify which network the eBPF collector monitors.

--- a/src/collectors/profile.plugin/README.md
+++ b/src/collectors/profile.plugin/README.md
@@ -12,7 +12,7 @@ A user can specify:
 
 ## Configuration
 
-Edit the `netdata.conf` configuration file using [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-netdataconf) from the [Netdata config directory](/docs/netdata-agent/configuration/README.md#the-netdata-config-directory), which is typically at `/etc/netdata`.
+Edit the `netdata.conf` configuration file using [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config) from the [Netdata config directory](/docs/netdata-agent/configuration/README.md#the-netdata-config-directory), which is typically at `/etc/netdata`.
 
 Scroll down to the `[plugin:profile]` section to find the available options:
 

--- a/src/collectors/statsd.plugin/README.md
+++ b/src/collectors/statsd.plugin/README.md
@@ -785,7 +785,7 @@ visualize all the available operations.
 
 Start by creating a new configuration file under the `statsd.d/` folder in the 
 [Netdata config directory](/docs/netdata-agent/configuration/README.md#the-netdata-config-directory). 
-Use [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-netdataconf) 
+Use [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config) 
 to create a new file called `k6.conf`.
 
 ```bash=

--- a/src/health/notifications/README.md
+++ b/src/health/notifications/README.md
@@ -10,7 +10,7 @@ The default script is `alarm-notify.sh`.
 >
 > This file mentions editing configuration files.  
 >
-> - To edit configuration files in a safe way, we provide the [`edit config` script](/docs/netdata-agent/configuration/README.md#edit-netdataconf)located in your [Netdata config directory](/docs/netdata-agent/configuration/README.md#the-netdata-config-directory) (typically is `/etc/netdata`) that creates the proper file and opens it in an editor automatically.  
+> - To edit configuration files in a safe way, we provide the [`edit config` script](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config)located in your [Netdata config directory](/docs/netdata-agent/configuration/README.md#the-netdata-config-directory) (typically is `/etc/netdata`) that creates the proper file and opens it in an editor automatically.  
 > Note that to run the script you need to be inside your Netdata config directory.
 >
 > - Please also note that after most configuration changes you will need to [restart the Agent](/packaging/installer/README.md#maintaining-a-netdata-agent-installation) for the changes to take effect.

--- a/src/ml/ml-configuration.md
+++ b/src/ml/ml-configuration.md
@@ -4,7 +4,7 @@ Netdata's [Machine Learning](/src/ml/README.md) capabilities are enabled by defa
 
 To enable or disable Machine Learning capabilities on a node:
 
-1. [Edit `netdata.conf`](/docs/netdata-agent/configuration/README.md#edit-netdataconf)
+1. [Edit `netdata.conf`](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config)
 2. In the `[ml]` section, set `enabled = yes` to enable or `enabled = no` to disable
 3. [Restart Netdata](/docs/netdata-agent/start-stop-restart.md)
 

--- a/src/registry/README.md
+++ b/src/registry/README.md
@@ -183,7 +183,7 @@ Both files are machine readable text files.
 
 Beginning with `v1.30.0`, when the Netdata Agent's web server processes a request, it delivers the `SameSite=none`
 and `Secure` cookies. If you have problems accessing the local Agent dashboard or Netdata Cloud, disable these
-cookies by [editing `netdata.conf`](/docs/netdata-agent/configuration/README.md#edit-netdataconf):
+cookies by [editing `netdata.conf`](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config):
 
 ```conf
 [registry]


### PR DESCRIPTION
##### Summary

We should more explicitly mention the use of edit-config for **all** configuration changes, so we can link from anywhere to this.