### PR TITLE
Improve windows installer

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -72,6 +72,8 @@ body:
         uname -a; uname -K
         # macOS
         uname -a; sw_vers
+        # Windows (prompt)
+        ver
         ```
         > NOTE: This will be automatically formatted into code, so no need for backticks.
       render: shell

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2357,7 +2357,7 @@ add_executable(netdata
 
 if(OS_WINDOWS)
         add_executable(NetdataClaim ${CLAIM_WINDOWS_FILES} ${NETDATA_CLAIM_RES_FILES})
-        target_link_libraries(NetdataClaim shell32;gdi32;msftedit)
+        target_link_libraries(NetdataClaim shell32;gdi32;msftedit;libnetdata)
         target_compile_options(NetdataClaim PUBLIC -mwindows)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1366,6 +1366,7 @@ set(CLAIM_WINDOWS_FILES
         src/claim/main.h
         src/claim/ui.c
         src/claim/ui.h
+        src/claim/cloud-conf.c
 )
 
 set(ACLK_ALWAYS_BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1366,7 +1366,6 @@ set(CLAIM_WINDOWS_FILES
         src/claim/main.h
         src/claim/ui.c
         src/claim/ui.h
-        src/claim/cloud-conf.c
 )
 
 set(ACLK_ALWAYS_BUILD
@@ -2358,7 +2357,7 @@ add_executable(netdata
 
 if(OS_WINDOWS)
         add_executable(NetdataClaim ${CLAIM_WINDOWS_FILES} ${NETDATA_CLAIM_RES_FILES})
-        target_link_libraries(NetdataClaim shell32;gdi32;msftedit;libnetdata)
+        target_link_libraries(NetdataClaim shell32 gdi32 msftedit)
         target_compile_options(NetdataClaim PUBLIC -mwindows)
 endif()
 

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -150,7 +150,7 @@ FunctionEnd
 
 Function ShowHelp
 Pop $0
-        MessageBox MB_ICONQUESTION|MB_OK "$\"Proxy URL$\" set the proxy server address to use if your network requires one.$\n$\n$\"Insecure connection$\" disable verification of the server's certificate chain and host name.$\n$\n$\"Open Terminal$\" open MSYS2 terminal to run additional commands after installation." IDOK endHelp
+        MessageBox MB_ICONQUESTION|MB_OK "$\"Cloud URL$\" The Netdata Cloud base URL.$\n$\n$\"Proxy URL$\" set the proxy server address to use if your network requires one.$\n$\n$\"Insecure connection$\" disable verification of the server's certificate chain and host name.$\n$\n$\"Open Terminal$\" open MSYS2 terminal to run additional commands after installation." IDOK endHelp
         endHelp:
 FunctionEnd
 

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -185,7 +185,7 @@ Function NetdataConfigPage
 
         ${NSD_CreateLabel} 0 75% 20% 10% "URL"
         Pop $0
-        ${NSD_CreateText} 21% 75% 79% 10% ""
+        ${NSD_CreateText} 21% 75% 79% 10% "https://api.netdata.cloud"
         Pop $hCloudURL
 
         ${NSD_CreateCheckbox} 0 90% 45% 10u "Insecure connection"

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -238,13 +238,6 @@ Function NetdataConfigLeave
                         pop $0
                 ${EndIf}
         ${EndIf}
-
-        ClearErrors
-        nsExec::ExecToLog '$SYSDIR\sc.exe start Netdata'
-        pop $0
-        ${If} $0 != 0
-	        MessageBox MB_OK "Warning: Failed to start Netdata service."
-        ${EndIf}
 FunctionEnd
 
 Function NetdataUninstallRegistry
@@ -303,6 +296,13 @@ Section "Install Netdata"
         pop $0
         ${If} $0 != 0
 	    DetailPrint "Warning: Failed to add Netdata service description."
+        ${EndIf}
+
+        ClearErrors
+        nsExec::ExecToLog '$SYSDIR\sc.exe start Netdata'
+        pop $0
+        ${If} $0 != 0
+	        MessageBox MB_OK "Warning: Failed to start Netdata service."
         ${EndIf}
 
 	WriteUninstaller "$INSTDIR\Uninstall.exe"

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -19,8 +19,8 @@ RequestExecutionLevel admin
 !insertmacro MUI_PAGE_LICENSE "C:\msys64\cloud.txt"
 !insertmacro MUI_PAGE_LICENSE "C:\msys64\gpl-3.0.txt"
 !insertmacro MUI_PAGE_DIRECTORY
-!insertmacro MUI_PAGE_INSTFILES
 Page Custom NetdataConfigPage NetdataConfigLeave
+!insertmacro MUI_PAGE_INSTFILES
 !insertmacro MUI_PAGE_FINISH
 
 !insertmacro MUI_UNPAGE_CONFIRM

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -360,7 +360,8 @@ Section "Uninstall"
 	    DetailPrint "Warning: Failed to delete Netdata service."
         ${EndIf}
 
-	RMDir /r "$INSTDIR"
+        # https://nsis.sourceforge.io/Reference/RMDir
+	RMDir /r /REBOOTOK "$INSTDIR"
 
         DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Netdata"
 SectionEnd

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -216,27 +216,6 @@ Function NetdataConfigLeave
                 ${NSD_GetText} $hProxy $proxy
                 ${NSD_GetState} $hStartMsys $startMsys
                 ${NSD_GetState} $hInsecure $insecure
-
-                StrLen $0 $cloudToken
-                StrLen $1 $cloudRooms
-                ${If} $0 == 0
-                ${OrIf} $1 == 0
-                        Goto runMsys
-                ${EndIf}
-
-                ${If} $0 == 135
-                ${AndIf} $1 >= 36
-                        nsExec::ExecToLog '$INSTDIR\usr\bin\NetdataClaim.exe /T $cloudToken /R $cloudRooms /P $proxy /I $insecure /U $cloudURL'
-                        pop $0
-                ${Else}
-                        MessageBox MB_OK "The Cloud information does not have the expected length."
-                ${EndIf}
-
-                runMsys:
-                ${If} $startMsys == ${BST_CHECKED}
-                        nsExec::ExecToLog '$INSTDIR\msys2.exe'
-                        pop $0
-                ${EndIf}
         ${EndIf}
 FunctionEnd
 
@@ -343,6 +322,27 @@ Section "Install Netdata"
                     ${EndIf}
            ${EndIf}
         goodbye:
+
+        StrLen $0 $cloudToken
+        StrLen $1 $cloudRooms
+        ${If} $0 == 0
+        ${OrIf} $1 == 0
+                Goto runMsys
+        ${EndIf}
+
+        ${If} $0 == 135
+        ${AndIf} $1 >= 36
+                nsExec::ExecToLog '$INSTDIR\usr\bin\NetdataClaim.exe /T $cloudToken /R $cloudRooms /P $proxy /I $insecure /U $cloudURL'
+                pop $0
+        ${Else}
+                MessageBox MB_OK "The Cloud information does not have the expected length."
+        ${EndIf}
+
+        runMsys:
+        ${If} $startMsys == ${BST_CHECKED}
+                nsExec::ExecToLog '$INSTDIR\msys2.exe'
+                pop $0
+        ${EndIf}
 SectionEnd
 
 Section "Uninstall"

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -188,13 +188,13 @@ Function NetdataConfigPage
         ${NSD_CreateText} 21% 75% 79% 10% "https://app.netdata.cloud"
         Pop $hCloudURL
 
-        ${NSD_CreateCheckbox} 0 90% 45% 10u "Insecure connection"
+        ${NSD_CreateCheckbox} 0 92% 25% 10u "Insecure connection"
         Pop $hInsecure
 
-        ${NSD_CreateCheckbox} 50% 90% 45% 10u "Open terminal"
+        ${NSD_CreateCheckbox} 50% 92% 25% 10u "Open terminal"
         Pop $hStartMsys
 
-        ${NSD_CreateButton} 80% 90% 30u 15u "&Help"
+        ${NSD_CreateButton} 90% 90% 30u 15u "&Help"
         Pop $hCtrlButton
         ${NSD_OnClick} $hCtrlButton ShowHelp
 

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -185,7 +185,7 @@ Function NetdataConfigPage
 
         ${NSD_CreateLabel} 0 75% 20% 10% "URL"
         Pop $0
-        ${NSD_CreateText} 21% 75% 79% 10% "https://api.netdata.cloud"
+        ${NSD_CreateText} 21% 75% 79% 10% "https://app.netdata.cloud"
         Pop $hCloudURL
 
         ${NSD_CreateCheckbox} 0 90% 45% 10u "Insecure connection"
@@ -277,57 +277,15 @@ Section "Install Netdata"
 	    DetailPrint "Warning: Failed to add Netdata service description."
         ${EndIf}
 
-        ClearErrors
-        nsExec::ExecToLog '$SYSDIR\sc.exe start Netdata'
-        pop $0
-        ${If} $0 != 0
-	        MessageBox MB_OK "Warning: Failed to start Netdata service."
-        ${EndIf}
-
-	WriteUninstaller "$INSTDIR\Uninstall.exe"
+        WriteUninstaller "$INSTDIR\Uninstall.exe"
 
         Call NetdataUninstallRegistry
-
-        IfSilent runcmds goodbye
-        runcmds:
-           nsExec::ExecToLog '$SYSDIR\sc.exe start Netdata'
-           pop $0
-
-           System::Call 'kernel32::AttachConsole(i -1)i.r0'
-           ${If} $0 != 0
-                System::Call 'kernel32::GetStdHandle(i -11)i.r0'
-                FileWrite $0 "Netdata installed with success.$\r$\n"
-           ${EndIf}
-           ${If} $startMsys == ${BST_CHECKED}
-                   nsExec::ExecToLog '$INSTDIR\msys2.exe'
-                   pop $0
-           ${EndIf}
-
-           StrLen $0 $cloudToken
-           StrLen $1 $cloudRooms
-           ${If} $0 == 0
-           ${OrIf} $1 == 0
-                   Goto goodbye
-           ${EndIf}
-
-           ${If} $0 == 135
-           ${AndIf} $1 >= 36
-                    nsExec::ExecToLog '$INSTDIR\usr\bin\NetdataClaim.exe /T $cloudToken /R $cloudRooms /P $proxy /I $insecure'
-                    pop $0
-           ${Else}         
-                    System::Call 'kernel32::AttachConsole(i -1)i.r0'
-                    ${If} $0 != 0
-                        System::Call 'kernel32::GetStdHandle(i -11)i.r0'
-                        FileWrite $0 "Room(s) or Token invalid.$\r$\n"
-                    ${EndIf}
-           ${EndIf}
-        goodbye:
 
         StrLen $0 $cloudToken
         StrLen $1 $cloudRooms
         ${If} $0 == 0
         ${OrIf} $1 == 0
-                Goto runMsys
+                Goto runCmds
         ${EndIf}
 
         ${If} $0 == 135
@@ -338,7 +296,14 @@ Section "Install Netdata"
                 MessageBox MB_OK "The Cloud information does not have the expected length."
         ${EndIf}
 
-        runMsys:
+        runCmds:
+        ClearErrors
+        nsExec::ExecToLog '$SYSDIR\sc.exe start Netdata'
+        pop $0
+        ${If} $0 != 0
+	        MessageBox MB_OK "Warning: Failed to start Netdata service."
+        ${EndIf}
+
         ${If} $startMsys == ${BST_CHECKED}
                 nsExec::ExecToLog '$INSTDIR\msys2.exe'
                 pop $0

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -183,7 +183,7 @@ Function NetdataConfigPage
         ${NSD_CreateText} 21% 60% 79% 10% ""
         Pop $hProxy
 
-        ${NSD_CreateLabel} 0 75% 20% 10% "URL"
+        ${NSD_CreateLabel} 0 75% 20% 10% "Cloud URL"
         Pop $0
         ${NSD_CreateText} 21% 75% 79% 10% "https://app.netdata.cloud"
         Pop $hCloudURL

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -66,6 +66,8 @@ var hCtrlButton
 var hStartMsys
 var startMsys
 
+var hCloudURL
+var cloudURL
 var hCloudToken
 var cloudToken
 var hCloudRooms
@@ -181,10 +183,15 @@ Function NetdataConfigPage
         ${NSD_CreateText} 21% 60% 79% 10% ""
         Pop $hProxy
 
-        ${NSD_CreateCheckbox} 0 75% 50% 10u "Insecure connection"
+        ${NSD_CreateLabel} 0 75% 20% 10% "URL"
+        Pop $0
+        ${NSD_CreateText} 21% 75% 79% 10% ""
+        Pop $hCloudURL
+
+        ${NSD_CreateCheckbox} 0 90% 45% 10u "Insecure connection"
         Pop $hInsecure
 
-        ${NSD_CreateCheckbox} 0 90% 50% 10u "Open terminal"
+        ${NSD_CreateCheckbox} 50% 90% 45% 10u "Open terminal"
         Pop $hStartMsys
 
         ${NSD_CreateButton} 80% 90% 30u 15u "&Help"
@@ -204,6 +211,7 @@ FunctionEnd
 Function NetdataConfigLeave
         ${If} $avoidClaim == ${BST_UNCHECKED}
                 ${NSD_GetText} $hCloudToken $cloudToken
+                ${NSD_GetText} $hCloudURL $cloudURL
                 ${NSD_GetText} $hCloudRooms $cloudRooms
                 ${NSD_GetText} $hProxy $proxy
                 ${NSD_GetState} $hStartMsys $startMsys
@@ -218,7 +226,7 @@ Function NetdataConfigLeave
 
                 ${If} $0 == 135
                 ${AndIf} $1 >= 36
-                        nsExec::ExecToLog '$INSTDIR\usr\bin\NetdataClaim.exe /T $cloudToken /R $cloudRooms /P $proxy /I $insecure'
+                        nsExec::ExecToLog '$INSTDIR\usr\bin\NetdataClaim.exe /T $cloudToken /R $cloudRooms /P $proxy /I $insecure /U $cloudURL'
                         pop $0
                 ${Else}
                         MessageBox MB_OK "The Cloud information does not have the expected length."

--- a/src/claim/main.c
+++ b/src/claim/main.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include "daemon/common.h"
+#include "claim.h"
 
 #define UNICODE
 #define _UNICODE
@@ -218,6 +218,19 @@ static int netdata_claim_get_path(char *path)
     return 0;
 }
 
+static void netdata_claim_update_cloud_conf()
+{
+    cloud_conf_load(1);
+
+    const char *urlValue = (aURL) ? aURL : appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "url", DEFAULT_CLOUD_BASE_URL);
+    const char *mGUID = appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "machine_guid", "");
+    const char *claimed_id = appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "claimed_id", "");
+    const char *lHostname = appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "hostname", "");
+    const char *proxyValue = (aProxy) ? aProxy : appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "proxy", "env");
+    if(!cloud_conf_regenerate(claimed_id, mGUID, lHostname, aToken, aRoom, urlValue, proxyValue, insecure))
+        MessageBoxW(NULL, L"Cannot write cloud.conf.", L"Error", MB_OK|MB_ICONERROR);
+}
+
 static void netdata_claim_write_config(char *path)
 {
     char configPath[WINDOWS_MAX_PATH + 1];
@@ -267,6 +280,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         if (!netdata_claim_get_path(basePath)) {
             netdata_claim_write_config(basePath);
         }
+        netdata_claim_update_cloud_conf();
     }
 
 exit_claim:

--- a/src/claim/main.c
+++ b/src/claim/main.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "daemon/common.h"
+
 #define UNICODE
 #define _UNICODE
 #include <windows.h>

--- a/src/claim/main.c
+++ b/src/claim/main.c
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include "claim.h"
-
 #define UNICODE
 #define _UNICODE
 #include <windows.h>
@@ -218,19 +216,6 @@ static int netdata_claim_get_path(char *path)
     return 0;
 }
 
-static void netdata_claim_update_cloud_conf()
-{
-    cloud_conf_load(1);
-
-    const char *urlValue = (aURL) ? aURL : appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "url", DEFAULT_CLOUD_BASE_URL);
-    const char *mGUID = appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "machine_guid", "");
-    const char *claimed_id = appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "claimed_id", "");
-    const char *lHostname = appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "hostname", "");
-    const char *proxyValue = (aProxy) ? aProxy : appconfig_get(&cloud_config, CONFIG_SECTION_GLOBAL, "proxy", "env");
-    if(!cloud_conf_regenerate(claimed_id, mGUID, lHostname, aToken, aRoom, urlValue, proxyValue, insecure))
-        MessageBoxW(NULL, L"Cannot write cloud.conf.", L"Error", MB_OK|MB_ICONERROR);
-}
-
 static void netdata_claim_write_config(char *path)
 {
     char configPath[WINDOWS_MAX_PATH + 1];
@@ -280,7 +265,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         if (!netdata_claim_get_path(basePath)) {
             netdata_claim_write_config(basePath);
         }
-        netdata_claim_update_cloud_conf();
     }
 
 exit_claim:

--- a/src/claim/main.c
+++ b/src/claim/main.c
@@ -14,11 +14,13 @@
 LPWSTR token = NULL;
 LPWSTR room = NULL;
 LPWSTR proxy = NULL;
+LPWSTR url = NULL;
 LPWSTR *argv = NULL;
 
 char *aToken = NULL;
 char *aRoom = NULL;
 char *aProxy = NULL;
+char *aURL = NULL;
 int insecure = 0;
 
 LPWSTR netdata_claim_get_formatted_message(LPWSTR pMessage, ...)
@@ -89,6 +91,13 @@ int nd_claim_parse_args(int argc, LPWSTR *argv)
             }
         }
 
+        if(wcscasecmp(L"/U", argv[i]) == 0) {
+            if (argc <= i + 1)
+                continue;
+            i++;
+            url = argv[i];
+        }
+
         if(wcscasecmp(L"/I", argv[i]) == 0) {
             if (argc <= i + 1)
                 continue;
@@ -142,6 +151,15 @@ static int netdata_claim_prepare_strings()
 
         netdata_claim_convert_str(aProxy, proxy, length - 1);
     }
+
+    if (url) {
+        length = wcslen(url) + 1;
+        aURL = calloc(sizeof(char), length - 1);
+        if (!aURL)
+            return -1;
+
+        netdata_claim_convert_str(aURL, url, length - 1);
+    }
     return 0;
 }
 
@@ -157,6 +175,9 @@ static void netdata_claim_exit_callback(int signal)
     if (aProxy)
         free(aProxy);
 
+    if (aURL)
+        free(aURL);
+
     if (argv)
         LocalFree(argv);
 }
@@ -165,9 +186,12 @@ static inline int netdata_claim_prepare_data(char *out, size_t length)
 {
     char *proxyLabel = (aProxy) ? "proxy = " : "#    proxy = ";
     char *proxyValue = (aProxy) ? aProxy : "";
+
+    char *urlValue = (aURL) ? aURL : "https://app.netdata.cloud";
     return snprintf(out,
                     length,
-                    "[global]\n    url = https://app.netdata.cloud\n    token = %s\n    rooms = %s\n    %s%s\n    insecure = %s",
+                    "[global]\n    url = %s\n    token = %s\n    rooms = %s\n    %s%s\n    insecure = %s",
+                    urlValue,
                     aToken,
                     aRoom,
                     proxyLabel,

--- a/src/claim/ui.c
+++ b/src/claim/ui.c
@@ -25,6 +25,7 @@ LRESULT CALLBACK WndProc(HWND hNetdatawnd, UINT message, WPARAM wParam, LPARAM l
                          L"/T TOKEN: The cloud token;",
                          L"/R ROOMS: A list of rooms to claim;",
                          L"/P PROXY: The proxy information;",
+                         L"/U URL  : The cloud URL;",
                          L"/I      : Use insecure connection;"
     };
 
@@ -83,7 +84,7 @@ int netdata_claim_window_loop(HINSTANCE hInstance, int nCmdShow)
                                       L"Netdata Claim",
                                       WS_OVERLAPPEDWINDOW,
                                       CW_USEDEFAULT, CW_USEDEFAULT,
-                                      460, 220,
+                                      460, 240,
                                       NULL,
                                       NULL,
                                       hInstance,


### PR DESCRIPTION
##### Summary
This PR addresses part of requests in https://github.com/netdata/netdata/issues/18624:

![screen1](https://github.com/user-attachments/assets/a15fac0a-3d7b-42ff-b7d5-bf378c13217c)

![screen2](https://github.com/user-attachments/assets/2cfe5687-02a2-47e4-bd37-e8e33ae12137)


- [x] Small issue - it would be good to ask for all the data before pressing install button. This is a nice tweak that will make life easier for those who install multiple agents on ie. employee laptops.
- [x] Big issue - there is no way to provide URL to the cloud. It makes it basically impossible to use with the onprem.
- [x] Fields when creating this ticket should also have something for Windows :D

##### Test Plan

1. Compile this branch
2. Install it

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
