### PR TITLE
Adjust content api/v1/info (Windows)

### DIFF
--- a/packaging/windows/resources/netdata.manifest.in
+++ b/packaging/windows/resources/netdata.manifest.in
@@ -5,7 +5,20 @@
      name="netdata"
      type="win32"/>
 	<description>Netdata is a high-performance, cloud-native, and on-premises observability platform designed to monitor metrics and logs with unparalleled efficiency.</description>
-	<!-- Identify the application security requirements. -->
+        <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+                <!-- Windows 10 and Windows 11 -->
+                <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+                <!-- Windows 8.1 -->
+                <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+                <!-- Windows 8 -->
+                <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+                <!-- Windows 7 -->
+                <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+                <!-- Windows Vista -->
+                <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+            </application>
+        </compatibility>
 	<trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
 		<security>
 			<requestedPrivileges>

--- a/src/daemon/buildinfo.c
+++ b/src/daemon/buildinfo.c
@@ -1332,6 +1332,7 @@ char *get_value_from_key(char *buffer, char *key) {
 }
 
 void get_install_type(char **install_type, char **prebuilt_arch, char **prebuilt_dist) {
+#ifndef OS_WINDOWS
     char *install_type_filename;
 
     int install_type_filename_len = (strlen(netdata_configured_user_config_dir) + strlen(".install-type") + 3);
@@ -1354,6 +1355,9 @@ void get_install_type(char **install_type, char **prebuilt_arch, char **prebuilt
         fclose(fp);
     }
     freez(install_type_filename);
+#else
+    *install_type = strdupz("netdata_installer.exe");
+#endif
 }
 
 static struct {

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -294,6 +294,11 @@ static void netdata_windows_container(struct rrdhost_system_info *systemInfo)
         systemInfo, "NETDATA_CONTAINER_IS_OFFICIAL_IMAGE", NETDATA_DEFAULT_SYSTEM_INFO_VALUE_FALSE);
 }
 
+static void netdata_windows_install_type(struct rrdhost_system_info *systemInfo)
+{
+    (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_INSTALL_TYPE", "netdata-installer.exe");
+}
+
 void netdata_windows_get_system_info(struct rrdhost_system_info *systemInfo)
 {
     netdata_windows_cloud(systemInfo);
@@ -302,5 +307,6 @@ void netdata_windows_get_system_info(struct rrdhost_system_info *systemInfo)
     netdata_windows_get_cpu(systemInfo);
     netdata_windows_get_mem(systemInfo);
     netdata_windows_get_total_disk_size(systemInfo);
+    netdata_windows_install_type(systemInfo);
 }
 #endif

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -224,18 +224,6 @@ static void netdata_windows_discover_os_version(char *os, size_t length, DWORD b
     (void)snprintf(os, length, "Microsoft Windows Version %s, Build %d", version, build);
 }
 
-static void netdata_windows_os_version(char *out, DWORD length)
-{
-    if (netdata_registry_get_string(out,
-                                    length,
-                                    HKEY_LOCAL_MACHINE,
-                                    "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
-                                    "ProductName"))
-        return;
-
-    (void)snprintf(out, length, "%s", NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN);
-}
-
 static void netdata_windows_os_kernel_version(char *out, DWORD length, DWORD build)
 {
     char version[8];
@@ -262,7 +250,6 @@ static void netdata_windows_host(struct rrdhost_system_info *systemInfo)
     (void)rrdhost_set_system_info_variable(
         systemInfo, "NETDATA_HOST_OS_ID_LIKE", NETDATA_DEFAULT_SYSTEM_INFO_VALUE_UNKNOWN);
 
-    netdata_windows_os_version(osVersion, 4095);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_VERSION", osVersion);
     (void)rrdhost_set_system_info_variable(systemInfo, "NETDATA_HOST_OS_VERSION_ID", osVersion);
 

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -226,15 +226,20 @@ static void netdata_windows_discover_os_version(char *os, size_t length, DWORD b
 
 static void netdata_windows_os_kernel_version(char *out, DWORD length, DWORD build)
 {
-    char version[8];
-    if (!netdata_registry_get_string(version,
-                                    7,
+    DWORD major, minor;
+    if (!netdata_registry_get_dword(&major,
                                     HKEY_LOCAL_MACHINE,
                                     "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
-                                    "CurrentVersion"))
-        version[0] = '\0';
+                                    "CurrentMajorVersionNumber"))
+        major = 0;
 
-    (void)snprintf(out, length, "%s (build: %u)", version, build);
+    if (!netdata_registry_get_dword(&minor,
+                                    HKEY_LOCAL_MACHINE,
+                                    "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+                                    "CurrentMinorVersionNumber"))
+        minor = 0;
+
+    (void)snprintf(out, length, "Windows %u.%u.%u Build: %u", major, minor, build, build);
 }
 
 static void netdata_windows_host(struct rrdhost_system_info *systemInfo)

--- a/src/daemon/win_system-info.c
+++ b/src/daemon/win_system-info.c
@@ -221,7 +221,7 @@ static void netdata_windows_discover_os_version(char *os, size_t length, DWORD b
     }
     // We are not testing older, because it is not supported anymore by Microsoft
 
-    (void)snprintf(os, length, "Microsoft Windows Version %s, Build %d (Name: Windows %s)", versionName, build, version);
+    (void)snprintf(os, length, "Microsoft Windows Version %s, Build %d", version, build);
 }
 
 static void netdata_windows_os_version(char *out, DWORD length)


### PR DESCRIPTION
##### Summary
This PR address the following issues in https://github.com/netdata/netdata/issues/18624:

- [x] I have W11 Pro but node info indicates: `Microsoft Windows, Windows 10 Pro`
- [x] in labels i have `"_install_type": "custom_"` - it should be exe/msi or something similar.
- [x] kernel version is wrong `"_kernel_version": "6.3 (build: 22000)"`, instead of `Version	10.0.22000 Build 22000`

##### Test Plan

1. Compile this PR on windows
2. Create an installer
3. After installation, check `api/v1/info`.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
