### PR TITLE
Embed CPU architecture info in Windows installer filename.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -342,7 +342,8 @@ jobs:
           endpoint: "https://eus.codesigning.azure.net/"
           trusted-signing-account-name: Netdata
           certificate-profile-name: Netdata
-          files: ${{ github.workspace }}\packaging\windows\netdata-installer.exe
+          files-folder: ${{ github.workspace }}\packaging\windows
+          files-folder-filter: exe
           file-digest: SHA256
           timestamp-rfc3161: "http://timestamp.acs.microsoft.com"
           timestamp-digest: SHA256
@@ -351,7 +352,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: windows-x86_64-installer
-          path: packaging\windows\netdata-installer.exe
+          path: packaging\windows\netdata*.exe
           retention-days: 30
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -3,7 +3,7 @@
 !include "FileFunc.nsh"
 
 Name "Netdata"
-Outfile "netdata-installer.exe"
+Outfile "netdata-installer-x64.exe"
 InstallDir "$PROGRAMFILES\Netdata"
 RequestExecutionLevel admin
 

--- a/packaging/windows/package-windows.sh
+++ b/packaging/windows/package-windows.sh
@@ -58,4 +58,3 @@ NDMINORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MINOR:STATIC' "${build}/CMakeCach
 
 /mingw64/bin/makensis.exe -DCURRVERSION="${NDVERSION}" -DMAJORVERSION="${NDMAJORVERSION}" -DMINORVERSION="${NDMINORVERSION}" "${repo_root}/packaging/windows/installer.nsi"
 ${GITHUB_ACTIONS+echo "::endgroup::"}
-


### PR DESCRIPTION
##### Summary

This ensures forward-portability, because I can all but guarantee that we _will_ eventually want to publish 64-bit ARM binaries for Windows, and we will then need to differentiate between the installer files.

##### Test Plan

Confirm that building the installer for Windows produces a file named `netdata-installer-x64.exe` instead of the older `netdata-installer.exe`.