### PR TITLE
Docs lint on `packaging/` dir

### DIFF
--- a/packaging/PLATFORM_SUPPORT.md
+++ b/packaging/PLATFORM_SUPPORT.md
@@ -1,14 +1,3 @@
-<!--
-title: "Platform support policy"
-sidebar_label: "Platform support policy"
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/packaging/PLATFORM_SUPPORT.md"
-learn_status: "Published"
-sidebar_position: "1"
-learn_topic_type: "Tasks"
-learn_rel_path: "Installation"
-learn_docs_purpose: "Present all the supported platform in the Netdata solution"
--->
-
 # Platform support policy
 
 Netdata defines three tiers of official support:
@@ -30,13 +19,13 @@ Any platforms not listed in any of these categories may or may not work.
 
 The following table shows a general outline of the various support tiers and categories.
 
-|   | Bug Support | Guaranteed Configurations | CI Coverage | Native Packages | Static Build Support |
-| - | ----------- | ------------------------- | ----------- | --------------- | -------------------- |
-| Core | High priority | Everything but rare edge cases | Full | Yes, if we can provide them | Full |
-| Intermediate | Normal priority | Common cases | Partial (CI mostly equivalent to **Core**, but possibly with some gaps, and not required to pass) | Possibly | Full |
-| Community | Best Effort | Default only | None | No | Best Effort |
-| Third-party Supported | Users directed to platform maintainers | None | None | No | Best Effort |
-| Previously Supported | Users asked to upgrade | None | None | Yes, but only already published versions | Best Effort |
+|                       | Bug Support                            | Guaranteed Configurations      | CI Coverage                                                                                       | Native Packages                          | Static Build Support |
+|-----------------------|----------------------------------------|--------------------------------|---------------------------------------------------------------------------------------------------|------------------------------------------|----------------------|
+| Core                  | High priority                          | Everything but rare edge cases | Full                                                                                              | Yes, if we can provide them              | Full                 |
+| Intermediate          | Normal priority                        | Common cases                   | Partial (CI mostly equivalent to **Core**, but possibly with some gaps, and not required to pass) | Possibly                                 | Full                 |
+| Community             | Best Effort                            | Default only                   | None                                                                                              | No                                       | Best Effort          |
+| Third-party Supported | Users directed to platform maintainers | None                           | None                                                                                              | No                                       | Best Effort          |
+| Previously Supported  | Users asked to upgrade                 | None                           | None                                                                                              | Yes, but only already published versions | Best Effort          |
 
 - ‘Bug Support’: How we handle of platform-specific bugs.
 - ‘Guaranteed Configurations’: Which runtime configurations for the agent we try to guarantee will work with minimal
@@ -56,30 +45,29 @@ Our [static builds](#static-builds) are expected to work on these platforms if a
 expected
 to work on these platforms with minimal user effort.
 
-| Platform                 | Version        | Official Native Packages               | Notes                                                                                                                                              |
-|--------------------------|----------------|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| Alpine Linux             | 3.18           | No                                     | The latest release of Alpine Linux is guaranteed to remain at **Core** tier due to usage for our Docker images                                     |
-| Alma Linux               | 9.x            | x86\_64, AArch64                       | Also includes support for Rocky Linux and other ABI compatible RHEL derivatives                                                                    |
-| Alma Linux               | 8.x            | x86\_64, AArch64                       | Also includes support for Rocky Linux and other ABI compatible RHEL derivatives                                                                    |
-| Amazon Linux             | 2023           | x86\_64, AArch64                       |                                                                                                                                                    |
-| Amazon Linux             | 2              | x86\_64, AArch64                       |                                                                                                                                                    |
-| CentOS                   | 7.x            | x86\_64                                |                                                                                                                                                    |
-| Docker                   | 19.03 or newer | x86\_64, i386, ARMv7, AArch64, POWER8+ | See our [Docker documentation](/packaging/docker/README.md) for more info on using Netdata on Docker |
-| Debian                   | 12.x           | x86\_64, i386, ARMv7, AArch64          |                                                                                                                                                    |
-| Debian                   | 11.x           | x86\_64, i386, ARMv7, AArch64          |                                                                                                                                                    |
-| Fedora                   | 40             | x86\_64, AArch64                       |                                                                                                                                                    |
-| Fedora                   | 39             | x86\_64, AArch64                       |                                                                                                                                                    |
-| openSUSE                 | Leap 15.5      | x86\_64, AArch64                       |                                                                                                                                                    |
-| openSUSE                 | Leap 15.4      | x86\_64, AArch64                       |                                                                                                                                                    |
-| Oracle Linux             | 9.x            | x86\_64, AArch64                       |                                                                                                                                                    |
-| Oracle Linux             | 8.x            | x86\_64, AArch64                       |                                                                                                                                                    |
-| Red Hat Enterprise Linux | 9.x            | x86\_64, AArch64                       |                                                                                                                                                    |
-| Red Hat Enterprise Linux | 8.x            | x86\_64, AArch64                       |                                                                                                                                                    |
-| Red Hat Enterprise Linux | 7.x            | x86\_64                                |                                                                                                                                                    |
-| Ubuntu                   | 24.04          | x86\_64, AArch64, ARMv7                |                                                                                                                                                    |
-| Ubuntu                   | 22.04          | x86\_64, ARMv7, AArch64                |                                                                                                                                                    |
-| Ubuntu                   | 20.04          | x86\_64, ARMv7, AArch64                |                                                                                                                                                    |
-
+| Platform                 | Version        | Official Native Packages               | Notes                                                                                                          |
+|--------------------------|----------------|----------------------------------------|----------------------------------------------------------------------------------------------------------------|
+| Alpine Linux             | 3.18           | No                                     | The latest release of Alpine Linux is guaranteed to remain at **Core** tier due to usage for our Docker images |
+| Alma Linux               | 9.x            | x86\_64, AArch64                       | Also includes support for Rocky Linux and other ABI compatible RHEL derivatives                                |
+| Alma Linux               | 8.x            | x86\_64, AArch64                       | Also includes support for Rocky Linux and other ABI compatible RHEL derivatives                                |
+| Amazon Linux             | 2023           | x86\_64, AArch64                       |                                                                                                                |
+| Amazon Linux             | 2              | x86\_64, AArch64                       |                                                                                                                |
+| CentOS                   | 7.x            | x86\_64                                |                                                                                                                |
+| Docker                   | 19.03 or newer | x86\_64, i386, ARMv7, AArch64, POWER8+ | See our [Docker documentation](/packaging/docker/README.md) for more info on using Netdata on Docker           |
+| Debian                   | 12.x           | x86\_64, i386, ARMv7, AArch64          |                                                                                                                |
+| Debian                   | 11.x           | x86\_64, i386, ARMv7, AArch64          |                                                                                                                |
+| Fedora                   | 40             | x86\_64, AArch64                       |                                                                                                                |
+| Fedora                   | 39             | x86\_64, AArch64                       |                                                                                                                |
+| openSUSE                 | Leap 15.5      | x86\_64, AArch64                       |                                                                                                                |
+| openSUSE                 | Leap 15.4      | x86\_64, AArch64                       |                                                                                                                |
+| Oracle Linux             | 9.x            | x86\_64, AArch64                       |                                                                                                                |
+| Oracle Linux             | 8.x            | x86\_64, AArch64                       |                                                                                                                |
+| Red Hat Enterprise Linux | 9.x            | x86\_64, AArch64                       |                                                                                                                |
+| Red Hat Enterprise Linux | 8.x            | x86\_64, AArch64                       |                                                                                                                |
+| Red Hat Enterprise Linux | 7.x            | x86\_64                                |                                                                                                                |
+| Ubuntu                   | 24.04          | x86\_64, AArch64, ARMv7                |                                                                                                                |
+| Ubuntu                   | 22.04          | x86\_64, ARMv7, AArch64                |                                                                                                                |
+| Ubuntu                   | 20.04          | x86\_64, ARMv7, AArch64                |                                                                                                                |
 
 ### Intermediate
 
@@ -106,16 +94,16 @@ to add support for a new platform, that platform generally will start in this ti
 are expected to work on these platforms if available. Source-based installs are usually expected to work on these
 platforms, but may require some extra effort from users.
 
-| Platform     | Version    | Official Native Packages | Notes                                                                                                     |
-|--------------|------------|--------------------------|-----------------------------------------------------------------------------------------------------------|
-| Clear Linux  | Latest     | No                       |                                                                                                           |
-| Debian       | Sid        | No                       |                                                                                                           |
-| Fedora       | Rawhide    | No                       |                                                                                                           |
-| FreeBSD      | 13-STABLE  | No                       | Netdata is included in the FreeBSD Ports Tree, and this is the recommended installation method on FreeBSD |
-| Gentoo       | Latest     | No                       |                                                                                                           |
-| macOS        | 13         | No                       | Currently only works for Intel-based hardware. Requires Homebrew for dependencies                         |
-| macOS        | 12         | No                       | Currently only works for Intel-based hardware. Requires Homebrew for dependencies                         |
-| macOS        | 11         | No                       | Currently only works for Intel-based hardware. Requires Homebrew for dependencies.                        |
+| Platform    | Version   | Official Native Packages | Notes                                                                                                     |
+|-------------|-----------|--------------------------|-----------------------------------------------------------------------------------------------------------|
+| Clear Linux | Latest    | No                       |                                                                                                           |
+| Debian      | Sid       | No                       |                                                                                                           |
+| Fedora      | Rawhide   | No                       |                                                                                                           |
+| FreeBSD     | 13-STABLE | No                       | Netdata is included in the FreeBSD Ports Tree, and this is the recommended installation method on FreeBSD |
+| Gentoo      | Latest    | No                       |                                                                                                           |
+| macOS       | 13        | No                       | Currently only works for Intel-based hardware. Requires Homebrew for dependencies                         |
+| macOS       | 12        | No                       | Currently only works for Intel-based hardware. Requires Homebrew for dependencies                         |
+| macOS       | 11        | No                       | Currently only works for Intel-based hardware. Requires Homebrew for dependencies.                        |
 
 ## Third-party supported platforms
 

--- a/packaging/VERSIONING_AND_PUBLIC_API.md
+++ b/packaging/VERSIONING_AND_PUBLIC_API.md
@@ -36,7 +36,7 @@ will be as up-to-date as possible.
 Versions for nightly builds of the Netdata Agent consist of four parts, a major version, a minor version, a revision
 number, and an optional commit ID, presented like `<major>.<minor>.0-<revision>-<commit>`. For example, a version
 of `1.43.0-11-gb15437502` has a major version of 1, a minor version of 43, a revision of 11, and a commit ID of
-`gb15437502`. A commit ID consists of a lowercaase letter `g`, followed by the short commit hash for the corresponding
+`gb15437502`. A commit ID consists of a lowercase letter `g`, followed by the short commit hash for the corresponding
 commit. If the commit ID is not included, it may be replaced by the word ‘nightly’.
 
 The major and minor version numbers for a nightly build correspond exactly to an associated stable release. A
@@ -80,9 +80,9 @@ notes at least one minor release prior to being merged:
 
 - All mandatory build dependencies which are not vendored in the Netdata Agent code. This includes, but is not
   limited to:
-    - The underlying build system (such as autotools or CMake).
-    - Primary library dependencies (such as libuv).
-    - Any external tooling that is required at build time.
+  - The underlying build system (such as autotools or CMake).
+  - Primary library dependencies (such as libuv).
+  - Any external tooling that is required at build time.
 - The REST API provided by the Netdata Agent’s internal web server, accessible via the `/api` endpoint. This
   does not extend to the charts, labels, or other system-specific data returned by some API endpoints.
 - The protocol used for streaming and replicating data between Netdata Agents.
@@ -138,7 +138,7 @@ Any components which are not explicitly listed above as being part of the public
 API. This includes, but is not limited to:
 
 - Any mandatory build components which are vendored as part of the Netdata sources, such as SQLite3 or libJudy. This
-  extends to both the presence or abscence of such components, as well as the exact version being bundled.
+  extends to both the presence or absence of such components, as well as the exact version being bundled.
 - The exact installation mechanism that will be used on any given system when using our `kickstart.sh` installation
   script.
 - The exact underlying implementation of any data collection plugin.

--- a/packaging/building-native-packages-locally.md
+++ b/packaging/building-native-packages-locally.md
@@ -39,16 +39,16 @@ inspect the state of the container and look at build logs.
 
 ### Detailed explanation
 
-The environments used for building our packages are fully self-contianed Docker images built from [Dockerfiles](https://github.com/netdata/helper-images/tree/master/package-builders)
+The environments used for building our packages are fully self-contained Docker images built from [Dockerfiles](https://github.com/netdata/helper-images/tree/master/package-builders)
 These are published on Docker
 Hub with the image name `netdata/package-builders`, and tagged using the name and version of the distribution
 (with the tag corresponding to the suffix on the associated Dockerfile).
 
 The build code expects the following requirements to be met:
 
-- It expects the source tree it should build from to be located at `/netdata`, and expects that said source tree
+* It expects the source tree it should build from to be located at `/netdata`, and expects that said source tree
   is clean (no artifacts left over from previous builds).
-- It expects an environment variable named `VERSION` to be defined, and uses this to control what version number
+* It expects an environment variable named `VERSION` to be defined, and uses this to control what version number
   will be shown in the package metadata and filenames.
 
 Internally, the source tree gets copied to a temporary location for the build process so that the source tree can
@@ -95,7 +95,7 @@ Once you have that set up, the command to build the packages is the same as abov
 `--platform` option to the `docker run` or `podman run` command. The current list of architectures we build for,
 and the correct value for the `--platform` option is:
 
-- 32-bit ARMv7: `linux/arm/v7`
-- 64-bit ARMv8: `linux/arm64/v8`
-- 32-bit x86: `linux/i386`
-- 64-bit x86: `linux/amd64`
+* 32-bit ARMv7: `linux/arm/v7`
+* 64-bit ARMv8: `linux/arm64/v8`
+* 32-bit x86: `linux/i386`
+* 64-bit x86: `linux/amd64`

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Install Netdata with Docker"
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/packaging/docker/README.md"
-sidebar_label: "Docker"
-learn_status: "Published"
-learn_rel_path: "Installation/Installation methods"
-sidebar_position: 40
--->
-
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -34,7 +25,7 @@ along with their descriptions.
 <details open>
 <summary>Privileges</summary>
 
-|       Component       |          Privileges           | Description                                                                                                              | 
+|       Component       |          Privileges           | Description                                                                                                              |
 |:---------------------:|:-----------------------------:|--------------------------------------------------------------------------------------------------------------------------|
 |    cgroups.plugin     |   host PID mode, SYS_ADMIN    | Container network interfaces monitoring. Map virtual interfaces in the system namespace to interfaces inside containers. |
 |      proc.plugin      |       host network mode       | Host system networking stack monitoring.                                                                                 |
@@ -47,7 +38,7 @@ along with their descriptions.
 <details open>
 <summary>Mounts</summary>
 
-|       Component        |           Mounts           | Description                                                                                                                                | 
+|       Component        |           Mounts           | Description                                                                                                                                |
 |:----------------------:|:--------------------------:|--------------------------------------------------------------------------------------------------------------------------------------------|
 |        netdata         |      /etc/os-release       | Host info detection.                                                                                                                       |
 |    diskspace.plugin    |             /              | Host mount points monitoring.                                                                                                              |
@@ -177,13 +168,11 @@ Add `- /run/dbus:/run/dbus:ro` to the netdata service `volumes`.
 
 ### With NVIDIA GPUs monitoring
 
-
 Monitoring NVIDIA GPUs requires:
 
 - Using official [NVIDIA driver](https://www.nvidia.com/Download/index.aspx).
 - Installing [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
 - Allowing the Netdata container to access GPU resources.
-
 
 <Tabs>
 <TabItem value="docker_run" label="docker run">

--- a/packaging/installer/UNINSTALL.md
+++ b/packaging/installer/UNINSTALL.md
@@ -1,7 +1,7 @@
 # Uninstall Netdata
 
-> ### Note 
-> 
+> **Note**
+>
 > If you're having trouble updating Netdata, moving from one installation method to another, or generally having
 > issues with your Netdata Agent installation, consider our [reinstalling Netdata](/packaging/installer/REINSTALL.md) instead of removing the Netdata Agent entirely.
 
@@ -40,15 +40,15 @@ installation prefix it will usually be located in a similar place under that pre
 
 A workflow for uninstallation looks like this:
 
-1.  Find your `.environment` file, which is usually `/etc/netdata/.environment` in a default installation.
-2.  If you cannot find that file and would like to uninstall Netdata, then create a new file with the following content:
+1. Find your `.environment` file, which is usually `/etc/netdata/.environment` in a default installation.
+2. If you cannot find that file and would like to uninstall Netdata, then create a new file with the following content:
 
-```sh
-NETDATA_PREFIX="<installation prefix>"   # put what you used as a parameter to shell installed `--install-prefix` flag. Otherwise it should be empty
-NETDATA_ADDED_TO_GROUPS="<additional groups>"  # Additional groups for a user running the Netdata process
-```
+    ```sh
+    NETDATA_PREFIX="<installation prefix>"   # put what you used as a parameter to shell installed `--install-prefix` flag. Otherwise it should be empty
+    NETDATA_ADDED_TO_GROUPS="<additional groups>"  # Additional groups for a user running the Netdata process
+    ```
 
-3.  Run `netdata-uninstaller.sh` as follows
+3. Run `netdata-uninstaller.sh` as follows
 
     3.1 **Interactive mode (Default)**
 

--- a/packaging/installer/UPDATE.md
+++ b/packaging/installer/UPDATE.md
@@ -13,15 +13,15 @@ icon in the local Agent dashboard's top navigation. This modal informs you wheth
 
 The exact update method to use depends on the install type:
 
--   Installs with an install type of 'custom' usually indicate installing a third-party package through the system
+- Installs with an install type of 'custom' usually indicate installing a third-party package through the system
     package manager. To update these installs, you should update the package just like you would any other package
     on your system.
--   Installs with an install type starting with `binpkg` or ending with `build` or `static` can be updated using
+- Installs with an install type starting with `binpkg` or ending with `build` or `static` can be updated using
     our [regular update method](#updates-for-most-systems).
--   Installs with an install type of 'oci' were created from our official Docker images, and should be updated
+- Installs with an install type of 'oci' were created from our official Docker images, and should be updated
     using our [Docker](#docker) update procedure.
--   macOS users should check [our update instructions for macOS](#macos).
--   Manually built installs should check [our update instructions for manual builds](#manual-installation-from-git).
+- macOS users should check [our update instructions for macOS](#macos).
+- Manually built installs should check [our update instructions for manual builds](#manual-installation-from-git).
 
 ## Determine which installation method you used
 
@@ -45,7 +45,6 @@ The following table contains all possible installation types:
 | oci                | Installed using official Docker images from Netdata, though not necessarily running on Docker                                                               |
 | custom             | Anything not covered by the other identifiers, including manual builds, manually running netdata-installer.sh, and third-party packages (community).        |
 | Unknown            | Same as custom.                                                                                                                                             |
-
 
 If you are using an older version of Netdata, or the above command produces no output, you can run our one-line
 installation script in dry-run mode to attempt to determine what method to use to update by running the following
@@ -189,7 +188,7 @@ and:
 /opt/netdata/usr/libexec/netdata/netdata-updater.sh --disable-auto-updates
 ```
 
-## Control runtime behavior of the updater script.
+## Control runtime behavior of the updater script
 
 Starting with v1.40.0, the `netdata-updater.sh` script supports a config file called `netdata-updater.conf`,
 located in the same directory as the main `netdata.conf` file. This file uses POSIX shell script syntax to define

--- a/packaging/installer/methods/ansible.md
+++ b/packaging/installer/methods/ansible.md
@@ -1,13 +1,3 @@
-<!--
-title: "Deploy Netdata with Ansible"
-description: "Deploy an infrastructure monitoring solution in minutes with the Netdata Agent and Ansible. Use and customize a simple playbook for monitoring as code."
-image: /img/seo/guides/deploy/ansible.png
-custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/methods/ansible.md
-sidebar_label: "Ansible"
-learn_status: "Published"
-learn_rel_path: "Installation/Install on specific environments"
--->
-
 # Deploy Netdata with Ansible
 
 Netdata's [one-line kickstart](/packaging/installer/README.md) is zero-configuration, highly adaptable, and compatible with tons
@@ -22,7 +12,7 @@ code?
 Enter [Ansible](https://ansible.com), a popular system provisioning, configuration management, and infrastructure as
 code (IaC) tool. Ansible uses **playbooks** to glue many standardized operations together with a simple syntax, then run
 those operations over standard and secure SSH connections. There's no agent to install on the remote system, so all you
-have to worry about is your application and your monitoring software. 
+have to worry about is your application and your monitoring software.
 
 Ansible has some competition from the likes of [Puppet](https://puppet.com/) or [Chef](https://www.chef.io/), but the
 most valuable feature about Ansible is **idempotent**. From the [Ansible
@@ -42,9 +32,9 @@ minutes.
 
 ## Prerequisites
 
--   A Netdata Cloud account. [Sign in and create one](https://app.netdata.cloud) if you don't have one already.
--   An administration system with [Ansible](https://www.ansible.com/) installed.
--   One or more nodes that your administration system can access via [SSH public
+- A Netdata Cloud account. [Sign in and create one](https://app.netdata.cloud) if you don't have one already.
+- An administration system with [Ansible](https://www.ansible.com/) installed.
+- One or more nodes that your administration system can access via [SSH public
     keys](https://git-scm.com/book/en/v2/Git-on-the-Server-Generating-Your-SSH-Public-Key) (preferably password-less).
 
 ## Download and configure the playbook
@@ -71,7 +61,7 @@ cd ansible-quickstart
 
 The `hosts` file contains a list of IP addresses or hostnames that Ansible will try to run the playbook against. The
 `hosts` file that comes with the repository contains two example IP addresses, which you should replace according to the
-IP address/hostname of your nodes. 
+IP address/hostname of your nodes.
 
 ```conf
 203.0.113.0  hostname=node-01
@@ -110,7 +100,7 @@ and `claim_room` variables.
 
 To find your `claim_token` and `claim_room`, go to Netdata Cloud, then click on your Space's name in the top navigation,
 then click on **Manage your Space**. Click on the **Nodes** tab in the panel that appears, which displays a script with
-`token` and `room` strings. 
+`token` and `room` strings.
 
 ![Animated GIF of finding the claiming script and the token and room
 strings](https://user-images.githubusercontent.com/1153921/98740235-f4c3ac00-2367-11eb-8ffd-e9ab0f04c463.gif)
@@ -123,7 +113,7 @@ claim_rooms: XXXXX
 ```
 
 Change the `dbengine_multihost_disk_space` if you want to change the metrics retention policy by allocating more or less
-disk space for storing metrics. The default is 2048 Mib, or 2 GiB. 
+disk space for storing metrics. The default is 2048 Mib, or 2 GiB.
 
 Because we're connecting this node to Netdata Cloud, and will view its dashboards there instead of via the IP address or
 hostname of the node, the playbook disables that local dashboard by setting `web_mode` to `none`. This gives a small

--- a/packaging/installer/methods/aws.md
+++ b/packaging/installer/methods/aws.md
@@ -1,12 +1,3 @@
-<!--
-title: "Install Netdata on AWS"
-description: "The Netdata Agent runs on all popular cloud providers, but often requires additional steps and configuration for full functionality."
-custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/methods/aws.md
-sidebar_label: "AWS"
-learn_status: "Published"
-learn_rel_path: "Installation/Install on specific environments"
--->
-
 # Install Netdata on AWS
 
 Netdata is fully compatible with Amazon Web Services (AWS).
@@ -41,11 +32,11 @@ command from a remote system, and it fails, it's likely that a firewall is block
 Another option is to put Netdata behind web server, which will proxy requests through standard HTTP/HTTPS ports
 (80/443), which are likely already open on your instance. We have a number of guides available:
 
--   [Apache](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-apache.md)
--   [Nginx](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-nginx.md)
--   [Caddy](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-caddy.md)
--   [HAProxy](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-haproxy.md)
--   [lighttpd](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-lighttpd.md)
+- [Apache](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-apache.md)
+- [Nginx](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-nginx.md)
+- [Caddy](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-caddy.md)
+- [HAProxy](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-haproxy.md)
+- [lighttpd](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-lighttpd.md)
 
 Sign in to the [AWS console](https://console.aws.amazon.com/) and navigate to the EC2 dashboard. Click on the **Security
 Groups** link in the navigation, beneath the **Network & Security** heading. Find the Security Group your instance

--- a/packaging/installer/methods/azure.md
+++ b/packaging/installer/methods/azure.md
@@ -1,15 +1,6 @@
-<!--
-title: "Install Netdata on Azure"
-description: "The Netdata Agent runs on all popular cloud providers, but often requires additional steps and configuration for full functionality."
-custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/methods/azure.md
-sidebar_label: "Azure"
-learn_status: "Published"
-learn_rel_path: "Installation/Install on specific environments"
--->
-
 # Install Netdata on Azure
 
-Netdata is fully compatible with Azure. 
+Netdata is fully compatible with Azure.
 You can install Netdata on cloud instances to monitor the apps/services running there, or use
 multiple instances in a [parent-child streaming](/src/streaming/README.md) configuration.
 
@@ -41,11 +32,11 @@ command from a remote system, and it fails, it's likely that a firewall is block
 Another option is to put Netdata behind web server, which will proxy requests through standard HTTP/HTTPS ports
 (80/443), which are likely already open on your instance. We have a number of guides available:
 
--   [Apache](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-apache.md)
--   [Nginx](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-nginx.md)
--   [Caddy](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-caddy.md)
--   [HAProxy](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-haproxy.md)
--   [lighttpd](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-lighttpd.md)
+- [Apache](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-apache.md)
+- [Nginx](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-nginx.md)
+- [Caddy](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-caddy.md)
+- [HAProxy](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-haproxy.md)
+- [lighttpd](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-lighttpd.md)
 
 Sign in to the [Azure portal](https://portal.azure.com) and open the virtual machine running Netdata. Click on the
 **Networking** link beneath the **Settings** header, then click on the **Add inbound security rule** button.
@@ -64,5 +55,3 @@ Name: Netdata
 ```
 
 Click **Add** to apply your new inbound security rule.
-
-

--- a/packaging/installer/methods/freebsd.md
+++ b/packaging/installer/methods/freebsd.md
@@ -1,12 +1,3 @@
-<!--
-title: "Install Netdata on FreeBSD"
-description: "Install Netdata on FreeBSD to monitor the health and performance of bare metal or VMs with thousands of real-time, per-second metrics."
-custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/methods/freebsd.md
-sidebar_label: "FreeBSD"
-learn_status: "Published"
-learn_rel_path: "Installation/Install on specific environments"
--->
-
 # Install Netdata on FreeBSD
 
 > 💡 This document is maintained by Netdata's community, and may not be completely up-to-date. Please double-check the
@@ -24,7 +15,7 @@ This step needs root privileges.
 pkg install bash e2fsprogs-libuuid git curl autoconf automake pkgconf pidof liblz4 libuv json-c cmake gmake
 ```
 
-Please respond in the affirmative for any relevant prompts during the installation process. 
+Please respond in the affirmative for any relevant prompts during the installation process.
 
 ## Install Netdata
 
@@ -35,9 +26,10 @@ If you have a Netdata cloud account then clicking on the **Connect Nodes** butto
 ```sh
 wget -O /tmp/netdata-kickstart.sh https://get.netdata.cloud/kickstart.sh && sh /tmp/netdata-kickstart.sh --claim-token <CLAIM_TOKEN> --claim-url https://app.netdata.cloud
 ```
-Please respond in the affirmative for any relevant prompts during the installation process. 
 
-Once the installation is completed, you should be able to start monitoring the FreeBSD server using Netdata. 
+Please respond in the affirmative for any relevant prompts during the installation process.
+
+Once the installation is completed, you should be able to start monitoring the FreeBSD server using Netdata.
 
 Netdata can also be installed via [FreeBSD ports](https://www.freshports.org/net-mgmt/netdata).
 
@@ -89,7 +81,8 @@ more about the information collected and how to opt-out, check the [anonymous st
 page](/docs/netdata-agent/configuration/anonymous-telemetry-events.md).
 
 ## Updating the Agent on FreeBSD
-If you have not passed the `--auto-update` or `-u` parameter for the installer to enable automatic updating, repeat the last step to update Netdata whenever a new version becomes available. 
+
+If you have not passed the `--auto-update` or `-u` parameter for the installer to enable automatic updating, repeat the last step to update Netdata whenever a new version becomes available.
 The `netdata-updater.sh` script will update your Agent.
 
 ## Optional parameters to alter your installation
@@ -102,9 +95,9 @@ The `kickstart.sh` script accepts a number of optional parameters to control how
 - `--dry-run`: Show what the installer would do, but don’t actually do any of it.
 - `--dont-start-it`: Don’t auto-start the daemon after installing. This parameter is not guaranteed to work.
 - `--release-channel`: Specify a particular release channel to install from. Currently supported release channels are:
-    - `nightly`: Installs a nightly build (this is currently the default).
-    - `stable`: Installs a stable release.
-    - `default`: Explicitly request whatever the current default is.
+  - `nightly`: Installs a nightly build (this is currently the default).
+  - `stable`: Installs a stable release.
+  - `default`: Explicitly request whatever the current default is.
 - `--nightly-channel`: Synonym for `--release-channel nightly`.
 - `--stable-channel`: Synonym for `--release-channel stable`.
 - `--auto-update`: Enable automatic updates (this is the default).
@@ -119,15 +112,15 @@ The `kickstart.sh` script accepts a number of optional parameters to control how
 - `--local-build-options`: Specify additional options to pass to the installer code when building locally. Only valid if `--build-only` is also specified.
 - `--static-install-options`: Specify additional options to pass to the static installer code. Only valid if --static-only is also specified.
 
-The following options are mutually exclusive and specifiy special operations other than trying to install Netdata normally or update an existing install:
+The following options are mutually exclusive and specify special operations other than trying to install Netdata normally or update an existing install:
 
 - `--reinstall`: If there is an existing install, reinstall it instead of trying to update it. If there is not an existing install, install netdata normally.
-- `--reinstall-even-if-unsafe`: If there is an existing install, reinstall it instead of trying to update it, even if doing so is known to potentially break things (for example, if we cannot detect what tyep of installation it is). If there is not an existing install, install Netdata normally.
+- `--reinstall-even-if-unsafe`: If there is an existing install, reinstall it instead of trying to update it, even if doing so is known to potentially break things (for example, if we cannot detect what type of installation it is). If there is not an existing install, install Netdata normally.
 - `--reinstall-clean`: If there is an existing install, uninstall it before trying to install Netdata. Fails if there is no existing install.
 - `--uninstall`: Uninstall an existing installation of Netdata. Fails if there is no existing install.
 - `--claim-only`: If there is an existing install, only try to claim it without attempting to update it. If there is no existing install, install and claim Netdata normally.
 - `--repositories-only`: Only install repository configuration packages instead of doing a full install of Netdata. Automatically sets --native-only.
-- `--prepare-offline-install-source`: Instead of insallling the agent, prepare a directory that can be used to install on another system without needing to download anything. See our [offline installation documentation](/packaging/installer/methods/offline.md) for more info.
+- `--prepare-offline-install-source`: Instead of installing the agent, prepare a directory that can be used to install on another system without needing to download anything. See our [offline installation documentation](/packaging/installer/methods/offline.md) for more info.
 
 Additionally, the following environment variables may be used to further customize how the script runs (most users
 should not need to use special values for any of these):

--- a/packaging/installer/methods/gcp.md
+++ b/packaging/installer/methods/gcp.md
@@ -1,13 +1,3 @@
-<!--
-title: "Install Netdata on GCP"
-description: "The Netdata Agent runs on all popular cloud providers, but often requires additional steps and configuration for full functionality."
-custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/methods/gcp.md
-sidebar_label: "GCP"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Installation/Install on specific environments"
--->
-
 # Install Netdata on GCP
 
 Netdata is fully compatible with the Google Cloud Platform (GCP).
@@ -42,12 +32,11 @@ command from a remote system, and it fails, it's likely that a firewall is block
 Another option is to put Netdata behind web server, which will proxy requests through standard HTTP/HTTPS ports
 (80/443), which are likely already open on your instance. We have a number of guides available:
 
--   [Apache](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-apache.md)
--   [Nginx](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-nginx.md)
--   [Caddy](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-caddy.md)
--   [HAProxy](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-haproxy.md)
--   [lighttpd](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-lighttpd.md)
-
+- [Apache](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-apache.md)
+- [Nginx](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-nginx.md)
+- [Caddy](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-caddy.md)
+- [HAProxy](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-haproxy.md)
+- [lighttpd](/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-lighttpd.md)
 
 To add a firewall rule, go to the [Firewall rules page](https://console.cloud.google.com/networking/firewalls/list) and
 click **Create firewall rule**.
@@ -67,4 +56,3 @@ Priority: 1000
 
 Read GCP's [firewall documentation](https://cloud.google.com/vpc/docs/using-firewalls) for specific instructions on how
 to create a new firewall rule.
-

--- a/packaging/installer/methods/kickstart.md
+++ b/packaging/installer/methods/kickstart.md
@@ -5,7 +5,7 @@ import TabItem from '@theme/TabItem';
 
 # Install Netdata with kickstart.sh
 
-![](https://registry.my-netdata.io/api/v1/badge.svg?chart=web_log_nginx.requests_by_url_pattern&options=unaligned&dimensions=kickstart&group=sum&after=-3600&label=last+hour&units=kickstart%20downloads&value_color=orange&precision=0) ![](https://registry.my-netdata.io/api/v1/badge.svg?chart=web_log_nginx.requests_by_url_pattern&options=unaligned&dimensions=kickstart&group=sum&after=-86400&label=today&units=kickstart%20downloads&precision=0)
+![last hour badge](https://registry.my-netdata.io/api/v1/badge.svg?chart=web_log_nginx.requests_by_url_pattern&options=unaligned&dimensions=kickstart&group=sum&after=-3600&label=last+hour&units=kickstart%20downloads&value_color=orange&precision=0) ![today badge](https://registry.my-netdata.io/api/v1/badge.svg?chart=web_log_nginx.requests_by_url_pattern&options=unaligned&dimensions=kickstart&group=sum&after=-86400&label=today&units=kickstart%20downloads&precision=0)
 
 `kickstart.sh` is the recommended way of installing Netdata.
 
@@ -242,7 +242,7 @@ By default, the kickstart script will provide a Netdata agent installation that 
 - `--claim-rooms`
   Specify a comma-separated list of tokens for each Room this node should appear in.
 - `--claim-proxy`
-  Specify a proxy to use when connecting to the cloud in the form of `http://[user:pass@]host:ip` for an HTTP(S) proxy. See [connecting through a proxy](/src/claim/README.md#connect-through-a-proxy) for details.
+  Specify a proxy to use when connecting to the cloud in the form of `http://[user:pass@]host:ip` for an HTTP(S) proxy. See [connecting through a proxy](/src/claim/README.md#automatically-via-a-provisioning-system-or-the-command-line) for details.
 - `--claim-only`
   If there is an existing install, only try to claim it without attempting to update it. If there is no existing install, install and claim Netdata normally.
 
@@ -281,7 +281,7 @@ The following options are mutually exclusive and specify special operations othe
 - `--repositories-only`
   Only install repository configuration packages instead of doing a full install of Netdata. Automatically sets --native-only.
 - `--prepare-offline-install-source`
-  Instead of insallling the agent, prepare a directory that can be used to install on another system without needing to download anything. See our [offline installation documentation](/packaging/installer/methods/offline.md) for more info.
+  Instead of installing the agent, prepare a directory that can be used to install on another system without needing to download anything. See our [offline installation documentation](/packaging/installer/methods/offline.md) for more info.
 
 ### environment variables
 

--- a/packaging/installer/methods/kubernetes.md
+++ b/packaging/installer/methods/kubernetes.md
@@ -35,21 +35,21 @@ The installation process securely connects your Kubernetes cluster to stream met
 
 1. Add the Netdata Helm chart repository by running:
 
-  ```bash
-  helm repo add netdata https://netdata.github.io/helmchart/
-  ```
+    ```bash
+    helm repo add netdata https://netdata.github.io/helmchart/
+    ```
 
 2. To install Netdata using the `helm install` command, run:
 
-  ```bash
-  helm install netdata netdata/netdata 
-  ```
+    ```bash
+    helm install netdata netdata/netdata 
+    ```
 
-  > ### Note
-  >  
-  > If you plan to connect the node to Netdata Cloud, you can find the command with the right parameters by clicking the "Add Nodes" button in your Space's Nodes tab.
+    > **Note**
+    >
+    > If you plan to connect the node to Netdata Cloud, you can find the command with the right parameters by clicking the "Add Nodes" button in your Space's Nodes tab.
 
-  For more installation options, please read our [Netdata Helm chart for Kubernetes](https://github.com/netdata/helmchart/blob/master/charts/netdata/README.md) reference.
+    For more installation options, please read our [Netdata Helm chart for Kubernetes](https://github.com/netdata/helmchart/blob/master/charts/netdata/README.md) reference.
 
 #### Expected Result
 
@@ -66,50 +66,50 @@ On an existing installation, in order to connect it to Netdata Cloud you will ne
 
 1. You can start with creating a file called `override.yml`
 
-  ```bash
-  touch override.yml
-  ```
-  
+    ```bash
+    touch override.yml
+    ```
+
 2. Paste the following into your `override.yml` file.
 
-  ```yaml
-  parent:
-    claiming:
-      enabled: true
-      token: YOUR_CLAIM_TOKEN
-      rooms: YOUR_ROOM_ID_A,YOUR_ROOM_ID_B
+    ```yaml
+    parent:
+      claiming:
+        enabled: true
+        token: YOUR_CLAIM_TOKEN
+        rooms: YOUR_ROOM_ID_A,YOUR_ROOM_ID_B
 
-  child:
-    claiming:
-      enabled: true
-      token: YOUR_CLAIM_TOKEN
-      rooms: YOUR_ROOM_ID_A,YOUR_ROOM_ID_B
-    configs:
-      netdata:
-        data: |
-          [db]
-            db = ram
-            retention = 3600
-          [health]
-            enabled = no
-  ```
+    child:
+      claiming:
+        enabled: true
+        token: YOUR_CLAIM_TOKEN
+        rooms: YOUR_ROOM_ID_A,YOUR_ROOM_ID_B
+      configs:
+        netdata:
+          data: |
+            [db]
+              db = ram
+              retention = 3600
+            [health]
+              enabled = no
+    ```
 
-  > :bookmark_tabs: Note
-  >  
-  > Make sure to replace `YOUR_CLAIM_TOKEN` with the claim token of your space,
-  > and `YOUR_ROOM_ID` with the ID of the Room you are willing to connect to.
+    > **Note**
+    >
+    > Make sure to replace `YOUR_CLAIM_TOKEN` with the claim token of your space,
+    > and `YOUR_ROOM_ID` with the ID of the Room you are willing to connect to.
 
-  These settings connect your `parent`/`child` nodes to Netdata Cloud and store more metrics in the nodes' time-series databases.
+    These settings connect your `parent`/`child` nodes to Netdata Cloud and store more metrics in the nodes' time-series databases.
 
-  > :bookmark_tabs: Info
-  >  
-  > These override settings, along with the Helm chart's defaults, will retain an hour's worth of metrics (`retention = 3600`, or `3600 seconds`) on each child node. Based on your metrics retention needs, and the resources available on your cluster, you may want to increase the `history` setting.
+    > **Info**
+    >
+    > These override settings, along with the Helm chart's defaults, will retain an hour's worth of metrics (`retention = 3600`, or `3600 seconds`) on each child node. Based on your metrics retention needs, and the resources available on your cluster, you may want to increase the `history` setting.
 
 3. To apply these new settings, run:
 
-  ```bash
-  helm upgrade -f override.yml netdata netdata/netdata
-  ```
+    ```bash
+    helm upgrade -f override.yml netdata netdata/netdata
+    ```
 
 #### Expected Result
 
@@ -188,13 +188,3 @@ To update Netdata's Helm chart to the latest version, run `helm repo update`, th
 helm repo update
 helm upgrade netdata netdata/netdata
 ```
-
-## What's next?
-
-[Start Kubernetes monitoring](/docs/dashboards-and-charts/kubernetes-tab.md) in Netdata Cloud, which comes with meaningful visualizations out of the box.
-
-### Related reference documentation
-
-- [Netdata Cloud · Kubernetes monitoring](/docs/dashboards-and-charts/kubernetes-tab.md)
-- [Netdata Helm chart](https://github.com/netdata/helmchart)
-- [Netdata service discovery](https://github.com/netdata/agent-service-discovery/)

--- a/packaging/installer/methods/macos.md
+++ b/packaging/installer/methods/macos.md
@@ -1,39 +1,33 @@
-<!--
-title: "Install Netdata on macOS"
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/packaging/installer/methods/macos.md"
-sidebar_label: "macOS"
-learn_status: "Published"
-learn_rel_path: "Installation/Install on specific environments"
--->
-
 # Install Netdata on macOS
 
-Netdata works on macOS, albeit with some limitations. 
-The number of charts displaying system metrics is limited, but you can use any of Netdata's [external plugins](/src/plugins.d/README.md) to monitor any services you might have installed on your macOS system. 
+Netdata works on macOS, albeit with some limitations.
+The number of charts displaying system metrics is limited, but you can use any of Netdata's [external plugins](/src/plugins.d/README.md) to monitor any services you might have installed on your macOS system.
 You could also use a macOS system as the parent node in a [streaming configuration](/src/streaming/README.md).
 
-You can install Netdata in one of the three following ways: 
+You can install Netdata in one of the three following ways:
 
-- **[Install Netdata with the our automatic one-line installation script (recommended)](#install-netdata-with-our-automatic-one-line-installation-script)**, 
+- **[Install Netdata with the our automatic one-line installation script (recommended)](#install-netdata-with-our-automatic-one-line-installation-script)**,
 - [Install Netdata via Homebrew](#install-netdata-via-homebrew)
 - [Install Netdata from source](#install-netdata-from-source)
 
-Each of these installation option requires [Homebrew](https://brew.sh/) for handling dependencies. 
+Each of these installation option requires [Homebrew](https://brew.sh/) for handling dependencies.
 
 > The Netdata Homebrew package is community-created and -maintained.
 > Community-maintained packages _may_ receive support from Netdata, but are only a best-effort affair. Learn more about [Netdata's platform support policy](/docs/netdata-agent/versions-and-platforms.md).
 
 ## Install Netdata with our automatic one-line installation script
 
-**Local Netdata Agent installation**
-To install Netdata using our automatic [kickstart](/packaging/installer/README.md#automatic-one-line-installation-script) open a new terminal and run:
+### Local Netdata Agent installation
+
+To install Netdata using our automatic [kickstart](/packaging/installer/methods/kickstart.md) open a new terminal and run:
 
 ```bash
 curl https://get.netdata.cloud/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh
 ```
+
 The Netdata Agent is installed under `/usr/local/netdata`. Dependencies are handled via Homebrew.
 
-**Automatically connect to Netdata Cloud during installation**
+### Automatically connect to Netdata Cloud during installation
 
 The `kickstart.sh` script accepts additional parameters to automatically [connect](/src/claim/README.md) your node to Netdata
 Cloud immediately after installation. Find the `token` and `rooms` strings by [signing in to Netdata
@@ -44,38 +38,42 @@ area](/docs/netdata-cloud/organize-your-infrastructure-invite-your-team.md#netda
   after the install.
 - `--claim-rooms`: Specify a comma-separated list of tokens for each Room this node should appear in.
 - `--claim-proxy`: Specify a proxy to use when connecting to the cloud in the form of `http://[user:pass@]host:ip` for an HTTP(S) proxy.
-  See [connecting through a proxy](/src/claim/README.md#connect-through-a-proxy) for details.
+  See [connecting through a proxy](/src/claim/README.md#automatically-via-a-provisioning-system-or-the-command-line) for details.
 - `--claim-url`: Specify a URL to use when connecting to the cloud. Defaults to `https://app.netdata.cloud`.
 
-For example: 
+For example:
+
 ```bash
 curl https://get.netdata.cloud/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh --install-prefix /usr/local/ --claim-token TOKEN --claim-rooms ROOM1,ROOM2 --claim-url https://app.netdata.cloud
 ```
+
 The Netdata Agent is installed under `/usr/local/netdata` on your machine. Your machine will also show up as a node in your Netdata Cloud.
 
-If you experience issues while claiming your node, follow the steps in our [Troubleshooting](/src/claim/README.md#troubleshooting) documentation.
+If you experience issues while claiming your node, follow the steps in our [Troubleshoot](/src/claim/README.md#troubleshoot) documentation.
+
 ## Install Netdata via Homebrew
 
 ### For macOS Intel
 
-To install Netdata and all its dependencies, run Homebrew using the following command: 
+To install Netdata and all its dependencies, run Homebrew using the following command:
 
 ```sh
 brew install netdata
 ```
-Homebrew will place your Netdata configuration directory at `/usr/local/etc/netdata/`. 
+
+Homebrew will place your Netdata configuration directory at `/usr/local/etc/netdata/`.
 
 Use the `edit-config` script and the files in this directory to configure Netdata. For reference, you can find stock configuration files at `/usr/local/Cellar/netdata/{NETDATA_VERSION}/lib/netdata/conf.d/`.
 
 ### For Apple Silicon
 
-To install Netdata and all its dependencies, run Homebrew using the following command: 
+To install Netdata and all its dependencies, run Homebrew using the following command:
 
 ```sh
 brew install netdata
 ```
 
-Homebrew will place your Netdata configuration directory at `/opt/homebrew/etc/netdata/`. 
+Homebrew will place your Netdata configuration directory at `/opt/homebrew/etc/netdata/`.
 
 Use the `edit-config` script and the files in this directory to configure Netdata. For reference, you can find stock configuration files at `/opt/homebrew/Cellar/netdata/{NETDATA_VERSION}/lib/netdata/conf.d/`.
 
@@ -89,13 +87,13 @@ We don't recommend installing Netdata from source on macOS, as it can be difficu
    xcode-select --install
    ```
 
-2. Click **Install** on the Software Update popup window that appears. 
+2. Click **Install** on the Software Update popup window that appears.
 3. Use the same terminal session to install some of Netdata's prerequisites using Homebrew. If you don't want to use [Netdata Cloud](/docs/netdata-cloud/README.md), you can omit `cmake`.
 
    ```bash
    brew install ossp-uuid autoconf automake pkg-config libuv lz4 json-c openssl libtool cmake
    ```
-   
+
 4. Download Netdata from our GitHub repository:
 
    ```bash
@@ -109,6 +107,6 @@ We don't recommend installing Netdata from source on macOS, as it can be difficu
    sudo ./netdata-installer.sh --install-prefix /usr/local
    ```
 
-> Your Netdata configuration directory will be at `/usr/local/netdata/`. 
+> Your Netdata configuration directory will be at `/usr/local/netdata/`.
 > Your stock configuration directory will be at `/usr/local/lib/netdata/conf.d/`.
 > The installer will also install a startup plist to start Netdata when your macOS system boots.

--- a/packaging/installer/methods/manual.md
+++ b/packaging/installer/methods/manual.md
@@ -1,22 +1,12 @@
-<!--
-title: "Install Netdata on Linux from a Git checkout"
-description: "Use the Netdata Agent source code from GitHub, plus helper scripts to set up your system, to install Netdata without packages or binaries."
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/packaging/installer/methods/manual.md"
-sidebar_label: "From a Git checkout"
-learn_status: "Published"
-learn_rel_path: "Installation/Installation methods"
-sidebar_position: 30
--->
-
 # Install Netdata on Linux from a Git checkout
 
 To install the latest git version of Netdata, please follow these 2 steps:
 
-1.  [Prepare your system](#prepare-your-system)
+1. [Prepare your system](#prepare-your-system)
 
     Install the required packages on your system.
 
-2.  [Install Netdata](#install-netdata)
+2. [Install Netdata](#install-netdata)
 
     Download and install Netdata. You can also update it the same way.
 
@@ -29,23 +19,23 @@ Use our automatic requirements installer (_no need to be `root`_), which attempt
 should be installed on your system to build and run Netdata. It supports a large variety of major Linux distributions
 and other operating systems and is regularly tested. You can find this tool [here](https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh) or run it directly with `bash <(curl -sSL https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh)`. Otherwise read on for how to get requires packages manually:
 
--   **Alpine** Linux and its derivatives
-    -   You have to install `bash` yourself, before using the installer.
+- **Alpine** Linux and its derivatives
+  - You have to install `bash` yourself, before using the installer.
 
--   **Gentoo** Linux and its derivatives
+- **Gentoo** Linux and its derivatives
 
--   **Debian** Linux and its derivatives (including **Ubuntu**, **Mint**)
+- **Debian** Linux and its derivatives (including **Ubuntu**, **Mint**)
 
--   **Red Hat Enterprise Linux** and its derivatives (including **Fedora**, **CentOS**, **Amazon Machine Image**)
-    -   Please note that for RHEL/CentOS you need
+- **Red Hat Enterprise Linux** and its derivatives (including **Fedora**, **CentOS**, **Amazon Machine Image**)
+  - Please note that for RHEL/CentOS you need
         [EPEL](http://www.tecmint.com/how-to-enable-epel-repository-for-rhel-centos-6-5/).
         In addition, RHEL/CentOS version 6 also need
         [OKay](https://okay.com.mx) for package libuv version 1.
-    -   CentOS 8 / RHEL 8 requires a bit of extra work. See the dedicated section below.
+  - CentOS 8 / RHEL 8 requires a bit of extra work. See the dedicated section below.
 
--   **SUSE** Linux and its derivatives (including **openSUSE**)
+- **SUSE** Linux and its derivatives (including **openSUSE**)
 
--   **SLE12** Must have your system registered with SUSE Customer Center or have the DVD. See
+- **SLE12** Must have your system registered with SUSE Customer Center or have the DVD. See
     [#1162](https://github.com/netdata/netdata/issues/1162)
 
 Install the packages for having a **basic Netdata installation** (system monitoring and many applications, without  `mysql` / `mariadb`, `named`, hardware sensors and `SNMP`):
@@ -85,51 +75,51 @@ zypper install zlib-devel libuuid-devel libuv-devel liblz4-devel libopenssl-deve
 
 Once Netdata is compiled, to run it the following packages are required (already installed using the above commands):
 
-| package   | description|
-|:-----:|-----------|
-| `libuuid` | part of `util-linux` for GUIDs management|
-| `zlib`    | gzip compression for the internal Netdata web server|
-| `libuv`   | Multi-platform support library with a focus on asynchronous I/O, version 1 or greater|
+|  package  | description                                                                           |
+|:---------:|---------------------------------------------------------------------------------------|
+| `libuuid` | part of `util-linux` for GUIDs management                                             |
+|  `zlib`   | gzip compression for the internal Netdata web server                                  |
+|  `libuv`  | Multi-platform support library with a focus on asynchronous I/O, version 1 or greater |
 
-*Netdata will fail to start without the above.*
+_Netdata will fail to start without the above._
 
 Netdata plugins and various aspects of Netdata can be enabled or benefit when these are installed (they are optional):
 
-| package |description|
-|:-----:|-----------|
-| `bash`|for shell plugins and **alert notifications**|
-| `curl`|for shell plugins and **alert notifications**|
-| `iproute` or `iproute2`|for monitoring **Linux traffic QoS**<br/>use `iproute2` if `iproute` reports as not available or obsolete|
-| `python`|for most of the external plugins|
-| `python-yaml`|used for monitoring **beanstalkd**|
-| `python-beanstalkc`|used for monitoring **beanstalkd**|
-| `python-mysqldb`<br/>or<br/>`python-pymysql`|used for monitoring **mysql** or **mariadb** databases<br/>`python-mysqldb` is a lot faster and thus preferred|
-| `nodejs`|used for `node.js` plugins for monitoring **named** and **SNMP** devices|
-| `lm-sensors`|for monitoring **hardware sensors**|
-| `libelf`|for monitoring kernel-level metrics using eBPF|
-| `libmnl`|for collecting netfilter metrics|
-| `netcat`|for shell plugins to collect metrics from remote systems|
+|                   package                    | description                                                                                                    |
+|:--------------------------------------------:|----------------------------------------------------------------------------------------------------------------|
+|                    `bash`                    | for shell plugins and **alert notifications**                                                                  |
+|                    `curl`                    | for shell plugins and **alert notifications**                                                                  |
+|           `iproute` or `iproute2`            | for monitoring **Linux traffic QoS**<br/>use `iproute2` if `iproute` reports as not available or obsolete      |
+|                   `python`                   | for most of the external plugins                                                                               |
+|                `python-yaml`                 | used for monitoring **beanstalkd**                                                                             |
+|             `python-beanstalkc`              | used for monitoring **beanstalkd**                                                                             |
+| `python-mysqldb`<br/>or<br/>`python-pymysql` | used for monitoring **mysql** or **mariadb** databases<br/>`python-mysqldb` is a lot faster and thus preferred |
+|                   `nodejs`                   | used for `node.js` plugins for monitoring **named** and **SNMP** devices                                       |
+|                 `lm-sensors`                 | for monitoring **hardware sensors**                                                                            |
+|                   `libelf`                   | for monitoring kernel-level metrics using eBPF                                                                 |
+|                   `libmnl`                   | for collecting netfilter metrics                                                                               |
+|                   `netcat`                   | for shell plugins to collect metrics from remote systems                                                       |
 
-*Netdata will greatly benefit if you have the above packages installed, but it will still work without them.*
+_Netdata will greatly benefit if you have the above packages installed, but it will still work without them._
 
 Netdata DB engine can be enabled when these are installed (they are optional):
 
-| package  | description|
-|:-----:|-----------|
-| `liblz4` | Extremely fast compression algorithm, version r129 or greater|
-| `openssl`| Cryptography and SSL/TLS toolkit|
+|  package  | description                                                   |
+|:---------:|---------------------------------------------------------------|
+| `liblz4`  | Extremely fast compression algorithm, version r129 or greater |
+| `openssl` | Cryptography and SSL/TLS toolkit                              |
 
-*Netdata will greatly benefit if you have the above packages installed, but it will still work without them.*
+_Netdata will greatly benefit if you have the above packages installed, but it will still work without them._
 
 Netdata Cloud support may require the following packages to be installed:
 
-|  package  | description                                                                                                                          |
-|:---------:|--------------------------------------------------------------------------------------------------------------------------------------|
-|  `cmake`  | Needed at build time if you aren't using your distribution's version of libwebsockets or are building on a platform other than Linux |
-| `openssl` | Needed to secure communications with the Netdata Cloud                                                                               |
-| `protobuf`| Used for the new Cloud<->Agent binary protocol |
+|  package   | description                                                                                                                          |
+|:----------:|--------------------------------------------------------------------------------------------------------------------------------------|
+|  `cmake`   | Needed at build time if you aren't using your distribution's version of libwebsockets or are building on a platform other than Linux |
+| `openssl`  | Needed to secure communications with the Netdata Cloud                                                                               |
+| `protobuf` | Used for the new Cloud<->Agent binary protocol                                                                                       |
 
-*Netdata will greatly benefit if you have the above packages installed, but it will still work without them.*
+_Netdata will greatly benefit if you have the above packages installed, but it will still work without them._
 
 ### CentOS / RHEL 6.x
 
@@ -189,28 +179,28 @@ cd netdata
 ./netdata-installer.sh
 ```
 
--   If you don't want to run it straight-away, add `--dont-start-it` option.
+- If you don't want to run it straight-away, add `--dont-start-it` option.
 
--   You can also append `--stable-channel` to fetch and install only the official releases from GitHub, instead of the nightly builds.
+- You can also append `--stable-channel` to fetch and install only the official releases from GitHub, instead of the nightly builds.
 
--   If you don't want to install it on the default directories, you can run the installer like this: `./netdata-installer.sh --install-prefix /opt`. This one will install Netdata in `/opt/netdata`.
+- If you don't want to install it on the default directories, you can run the installer like this: `./netdata-installer.sh --install-prefix /opt`. This one will install Netdata in `/opt/netdata`.
 
--   If your server does not have access to the internet and you have manually put the installation directory on your server, you will need to pass the option `--disable-go` to the installer. The option will prevent the installer from attempting to download and install `go.d.plugin`. 
+- If your server does not have access to the internet and you have manually put the installation directory on your server, you will need to pass the option `--disable-go` to the installer. The option will prevent the installer from attempting to download and install `go.d.plugin`.
 
 ## Optional parameters to alter your installation
 
 `netdata-installer.sh` accepts a few parameters to customize your installation:
 
--   `--dont-wait`: Enable automated installs by not prompting for permission to install any required packages.
--   `--dont-start-it`: Prevent the installer from starting Netdata automatically.
--   `--stable-channel`: Automatically update only on the release of new major versions.
--   `--nightly-channel`: Automatically update on every new nightly build.
--   `--disable-telemetry`: Opt-out of [anonymous statistics](/docs/netdata-agent/configuration/anonymous-telemetry-events.md) we use to make
+- `--dont-wait`: Enable automated installs by not prompting for permission to install any required packages.
+- `--dont-start-it`: Prevent the installer from starting Netdata automatically.
+- `--stable-channel`: Automatically update only on the release of new major versions.
+- `--nightly-channel`: Automatically update on every new nightly build.
+- `--disable-telemetry`: Opt-out of [anonymous statistics](/docs/netdata-agent/configuration/anonymous-telemetry-events.md) we use to make
     Netdata better.
--   `--no-updates`: Prevent automatic updates of any kind.
--   `--reinstall`: If an existing install is detected, reinstall instead of trying to update it. Note that this
+- `--no-updates`: Prevent automatic updates of any kind.
+- `--reinstall`: If an existing install is detected, reinstall instead of trying to update it. Note that this
     cannot be used to change installation types.
--   `--local-files`: Used for [offline installations](/packaging/installer/methods/offline.md). Pass four file paths: the Netdata
+- `--local-files`: Used for [offline installations](/packaging/installer/methods/offline.md). Pass four file paths: the Netdata
     tarball, the checksum file, the go.d plugin tarball, and the go.d plugin config tarball, to force kickstart run the
     process using those files. This option conflicts with the `--stable-channel` option. If you set this _and_
     `--stable-channel`, Netdata will use the local files.
@@ -226,23 +216,19 @@ See the [connect to cloud](/src/claim/README.md) doc for details on connecting a
 
 Our current build process unfortunately has some issues when using certain configurations of the `clang` C compiler on Linux.
 
-If the installation fails with errors like `/bin/ld: externaldeps/libwebsockets/libwebsockets.a(context.c.o): relocation R_X86_64_32 against '.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC`, and you are trying to build with `clang` on Linux, you will need to build Netdata using GCC to get a fully functional install. 
+If the installation fails with errors like `/bin/ld: externaldeps/libwebsockets/libwebsockets.a(context.c.o): relocation R_X86_64_32 against '.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC`, and you are trying to build with `clang` on Linux, you will need to build Netdata using GCC to get a fully functional install.
 
 In most cases, you can do this by running `CC=gcc ./netdata-installer.sh`.
-
 
 ### Perform a cleanup in your netdata repo
 
 The Netdata repo consist of the main git tree and it's submodules. Either working on a fork or on the main repo you need to make sure that there
 are no "leftover" artifacts from previous builds and that your submodules are up to date to the **corresponding checkouts**.
 
-> #### Important: Make sure that you have commited any work in progress, before you proceed the with the clean up instruction below
-
+> #### Important: Make sure that you have committed any work in progress, before you proceed the with the clean up instruction below
 
 ```sh
 git clean -dfx && git submodule foreach 'git clean -dfx' && git submodule update --recursive --init
 ```
 
-
-> Note: In previous builds, you may have created artifacts belonging to an another user (e.g root), so you may need to run
-> each of the _git clean_ commands as sudoer.
+> Note: In previous builds, you may have created artifacts belonging to an another user (e.g root), so you may need to run each of the _git clean_ commands as a sudoer.

--- a/packaging/installer/methods/methods.md
+++ b/packaging/installer/methods/methods.md
@@ -1,13 +1,3 @@
-<!--
-title: "Installation methods"
-description: "Netdata can be installed as a DEB/RPM package, a static binary, a docker container or from source"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/methods/methods.md
-sidebar_label: "Installation methods"
-learn_status: "Published"
-learn_rel_path: "Installation/Installation methods"
-sidebar_position: 30
--->
-
 # Installation methods
 
 Netdata can be installed:
@@ -21,6 +11,4 @@ The [one line installer kickstart.sh](/packaging/installer/methods/kickstart.md)
 picks the most appropriate method out of the first three for any system
 and is the recommended installation method, if you don't use containers.
 
-`kickstart.sh` can also be used for 
-[offline installation](/packaging/installer/methods/offline.md),
-suitable for air-gapped systems.
+`kickstart.sh` can also be used for [offline installation](/packaging/installer/methods/offline.md), suitable for air-gapped systems.

--- a/packaging/installer/methods/offline.md
+++ b/packaging/installer/methods/offline.md
@@ -1,13 +1,3 @@
-<!--
-title: "Install Netdata on offline systems"
-description: "Install the Netdata Agent on offline/air gapped systems to benefit from real-time, per-second monitoring without connecting to the internet."
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/packaging/installer/methods/offline.md"
-sidebar_label: "Offline systems"
-learn_status: "Published"
-learn_rel_path: "Installation/Installation methods"
-sidebar_position: 50
--->
-
 # Install Netdata on offline systems
 
 Our kickstart install script provides support for installing the Netdata Agent on air-gapped systems which do not have a

--- a/packaging/installer/methods/packages.md
+++ b/packaging/installer/methods/packages.md
@@ -1,13 +1,3 @@
-<!--
-title: "Install Netdata using native DEB/RPM packages."
-description: "Instructions for how to install Netdata using native DEB or RPM packages."
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/packaging/installer/methods/packages.md"
-sidebar_label: "Native DEB/RPM packages"
-learn_status: "Published"
-learn_rel_path: "Installation/Installation methods"
-sidebar_position: 20
--->
-
 # Install Netdata using native DEB/RPM packages
 
 For most common Linux distributions that use either DEB or RPM packages, Netdata provides pre-built native packages
@@ -20,7 +10,7 @@ When using the kickstart script, you can force usage of native DEB or RPM packag
 `--native-only` when invoking the script. This will cause it to only attempt to use native packages for the install,
 and fail if it cannot do so.
 
-> ### Note
+> **Note**
 >
 > In July 2022, we switched hosting of our native packages from Package Cloud to self-hosted repositories.
 > We still maintain the Package cloud repositories, but they are not guaranteed to work and may be removed
@@ -63,9 +53,9 @@ appropriate repository configuration package from <https://repo.netdata.cloud/re
 directly on the target system using the system package manager. This will ensure any packages needed to use the
 repository are also installed, and will help enable a seamless transition if we ever need to change our infrastructure.
 
-> ### Note
+> **Note**
 >
-> On RHEL and other systems that use the `el` repostiroies, some of the dependencies for Netdata can only be found
+> On RHEL and other systems that use the `el` repositories, some of the dependencies for Netdata can only be found
 > in the EPEL repository, which is not enabled or installed by default on most of these systems. This additional
 > repository _should_ be pulled in automatically by our repository config packages, but if it is not you may need
 > to manually install `epel-release` to be able to successfully install the Netdata packages.
@@ -91,7 +81,7 @@ These repositories are set up as what Debian calls ‘flat repositories’, and 
 
 As a result of this structure, the required APT sources entry for stable packages for Debian 11 (Bullseye) is:
 
-```
+```txt
 deb http://repo.netdata.cloud/repos/stable/debian/ bullseye/
 ```
 
@@ -134,7 +124,7 @@ but we do have some tips for anyone looking to do so:
 - A full mirror of all of our repositories currently requires up to 100 GB of storage space, though the exact
   amount of space needed fluctuates over time. Because of this, users seeking to mirror our repositories are
   encouraged to mirror only those repositories they actually need instead of mirroring everything.
-- If syncing daily (or less frequently), some time between 05:00 and 08:00 UTC each day is usually the saftest
+- If syncing daily (or less frequently), some time between 05:00 and 08:00 UTC each day is usually the safest
   time to do so, as publishing nightly packages will almost always be done by this point, and publishing of stable
   releases typically happens after that time window.
 - If you intend to use our existing GPG signatures on the repository metadata and packages, you probably also want

--- a/packaging/installer/methods/pfsense.md
+++ b/packaging/installer/methods/pfsense.md
@@ -1,15 +1,8 @@
-<!--
-title: "Install Netdata on pfSense"
-description: "Install Netdata on pfSense to monitor the health and performance of firewalls with thousands of real-time, per-second metrics."
-custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/methods/pfsense.md
-sidebar_label: "pfSense"
-learn_status: "Published"
-learn_rel_path: "Installation/Install on specific environments"
--->
-
 # Install Netdata on pfSense CE
 
-> 💡 This document is maintained by Netdata's community, and may not be completely up-to-date. Please double-check the
+> **Info**
+>
+> This document is maintained by Netdata's community, and may not be completely up-to-date. Please double-check the
 > details of the installation process, such as version numbers for downloadable packages, before proceeding.
 >
 > You can help improve this document by [submitting a
@@ -46,10 +39,10 @@ pkg install py39-yaml
 > ⚠️ If any of the above commands return a `Not Found` error, you need to manually search for the latest package in the
 > [FreeBSD repository](https://www.freebsd.org/ports/) or by running `pkg search`. Search for the package's name, such as `py37-cffi`, find the
 > latest version number, and update the command accordingly.
-
+>
 > ⚠️ On pfSense 2.4.5, Python version 3.7 may be installed by the system, in which case you should should not install
 > Python from the FreeBSD repository as instructed above.
-
+>
 > ⚠️ If you are using the `apcupsd` collector, you need to make sure that apcupsd is up before starting Netdata.
 > Otherwise a infinitely running `cat` process triggered by the default activated apcupsd charts plugin will eat up CPU
 > and RAM (`/tmp/.netdata-charts.d-*/run-*`). This also applies to `OPNsense`.
@@ -75,7 +68,7 @@ Visit the Netdata dashboard to confirm it's working: `http://<pfsenseIP>:19999`
 To start Netdata automatically every boot, add `service netdata onestart` as a Shellcmd entry within the pfSense web
 interface under **Services/Shellcmd**. You'll need to install the Shellcmd package beforehand under **System/Package
 Manager/Available Packages**. The Shellcmd Type should be set to `Shellcmd`.  
-![](https://i.imgur.com/wcKiPe1.png) Alternatively more information can be found in
+![interface](https://i.imgur.com/wcKiPe1.png) Alternatively more information can be found in
 <https://doc.pfsense.org/index.php/Installing_FreeBSD_Packages>, for achieving the same via the command line and
 scripts.
 
@@ -83,5 +76,3 @@ If you experience an issue with `/usr/bin/install` being absent in pfSense 2.3 o
 workaround from <https://redmine.pfsense.org/issues/6643>  
 
 **Note:** In pfSense, the Netdata configuration files are located under `/usr/local/etc/netdata`.
-
-

--- a/packaging/installer/methods/source.md
+++ b/packaging/installer/methods/source.md
@@ -1,13 +1,3 @@
-<!--
-title: "Manually build Netdata from source"
-description: "Package maintainers and power users may be interested in manually building Netdata from source without using any of our installation scripts."
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/packaging/installer/methods/source.md"
-sidebar_label: "Manually build Netdata from source"
-learn_status: "Published"
-learn_rel_path: "Installation/Package maintainers"
-sidebar_position: 100
--->
-
 # Manually build Netdata from source
 
 These instructions are for advanced users and distribution package
@@ -20,33 +10,33 @@ checkout](/packaging/installer/methods/manual.md) instead.
 At a bare minimum, Netdata requires the following libraries and tools
 to build and run successfully:
 
--   libuuid
--   libuv version 1.0 or newer
--   zlib
--   CMake 3.13 or newer
--   GCC or Xcode (Clang is known to have issues in certain configurations, see [Using Clang](#using-clang))
--   Ninja or Make (Ninja is preferred as it results in significantly faster builds)
--   Git (we use git in the build system to generate version info, you don't need a full install, just a working `git show` command)
+- libuuid
+- libuv version 1.0 or newer
+- zlib
+- CMake 3.13 or newer
+- GCC or Xcode (Clang is known to have issues in certain configurations, see [Using Clang](#using-clang))
+- Ninja or Make (Ninja is preferred as it results in significantly faster builds)
+- Git (we use git in the build system to generate version info, you don't need a full install, just a working `git show` command)
 
 The following additional dependencies are also needed, but will be prepared automatically by CMake if they are not available on the build system.
 
--   libyaml
--   JSON-C
+- libyaml
+- JSON-C
 
 Additionally, the following build time features require additional dependencies:
 
--   TLS support for the web GUI:
-    -   OpenSSL 1.0.2 or newer _or_ LibreSSL 3.0.0 or newer.
--   dbengine metric storage:
-    -   liblz4 r129 or newer
-    -   OpenSSL 1.0 or newer (LibreSSL _amy_ work, but is largely untested).
--   Netdata Cloud support:
-    -   A working internet connection
-    -   OpenSSL 1.0.2 or newer _or_ LibreSSL 3.0.0 or newer.
-    -   protobuf (Google Protocol Buffers) and protoc compiler. If protobuf is not available on the system,
+- TLS support for the web GUI:
+  - OpenSSL 1.0.2 or newer _or_ LibreSSL 3.0.0 or newer.
+- dbengine metric storage:
+  - liblz4 r129 or newer
+  - OpenSSL 1.0 or newer (LibreSSL _amy_ work, but is largely untested).
+- Netdata Cloud support:
+  - A working internet connection
+  - OpenSSL 1.0.2 or newer _or_ LibreSSL 3.0.0 or newer.
+  - protobuf (Google Protocol Buffers) and protoc compiler. If protobuf is not available on the system,
         CMake can be instructed to fetch and build a usable version for Netdata.
--   Netdata Go collectors:
-    -   Go 1.21 or newer
+- Netdata Go collectors:
+  - Go 1.21 or newer
 
 ## Preparing the source tree
 
@@ -111,12 +101,12 @@ a pre-built copy of the required code, or build it locally.
 We provide pre-built copies of the eBPF code for 64-bit x86 systems
 using glibc or musl. To use one of these:
 
-1.  Verify the release version that Netdata expects to be used by checking
+1. Verify the release version that Netdata expects to be used by checking
     the contents of `packaging/ebpf.version` in your Netdata sources.
-2.  Go to https://github.com/netdata/kernel-collector/releases, select the
+2. Go to <https://github.com/netdata/kernel-collector/releases>, select the
     required release, and download the `netdata-kernel-collector-*.tar.xz`
     file for the libc variant your system uses (either rmusl or glibc).
-3.  Extract the contents of the archive to a temporary location, and then
+3. Extract the contents of the archive to a temporary location, and then
     copy all of the `.o` and `.so.*` files and the contents of the `library/`
     directory to `/usr/libexec/netdata/plugins.d` or the equivalent location
     for your build of Netdata.
@@ -128,5 +118,3 @@ instructions, please consult [the README file for our kernel-collector
 repository](https://github.com/netdata/kernel-collector/#readme),
 which outlines both the required dependencies, as well as multiple
 options for building the code.
-
-

--- a/packaging/installer/methods/synology.md
+++ b/packaging/installer/methods/synology.md
@@ -1,24 +1,14 @@
-<!--
-title: "Install Netdata on Synology"
-description: "The Netdata Agent can be installed on AMD64-compatible NAS systems using the 64-bit pre-compiled static binary."
-custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/methods/synology.md
-sidebar_label: "Synology"
-learn_status: "Published"
-learn_rel_path: "Installation/Install on specific environments"
--->
-
 # Install Netdata on Synology
 
 > 💡 This document is maintained by Netdata's community, and may not be completely up-to-date. Please double-check the
 > details of the installation process, before proceeding.
 >
-> You can help improve this document by 
-> [submitting a PR](https://github.com/netdata/netdata/edit/master/packaging/installer/methods/synology.md) 
+> You can help improve this document by
+> [submitting a PR](https://github.com/netdata/netdata/edit/master/packaging/installer/methods/synology.md)
 > with your recommended improvements or changes. Thank you!
 
-
-The good news is that our 
-[one-line installation script](/packaging/installer/methods/kickstart.md) 
+The good news is that our
+[one-line installation script](/packaging/installer/methods/kickstart.md)
 works fine if your NAS is one that uses the amd64 architecture. It
 will install the content into `/opt/netdata`, making future removal safe and simple.
 
@@ -49,15 +39,13 @@ installations run it as the `netdata` user, you might wish to do the same. This 
 Additionally, as of 2018/06/24, the Netdata installer doesn't recognize DSM as an operating system, so no init script is
 installed. You'll have to do this manually:
 
-1.  Add [this file](https://gist.github.com/oskapt/055d474d7bfef32c49469c1b53e8225f) as `/etc/rc.netdata`. Make it
+1. Add [this file](https://gist.github.com/oskapt/055d474d7bfef32c49469c1b53e8225f) as `/etc/rc.netdata`. Make it
     executable with `chmod 0755 /etc/rc.netdata`.
-2.  Add or edit `/etc/rc.local` and add a line calling `/etc/rc.netdata` to have it start on boot:
+2. Add or edit `/etc/rc.local` and add a line calling `/etc/rc.netdata` to have it start on boot:
 
-```conf
-# Netdata startup
-[ -x /etc/rc.netdata ] && /etc/rc.netdata start
-```
+    ```conf
+    # Netdata startup
+    [ -x /etc/rc.netdata ] && /etc/rc.netdata start
+    ```
 
 3. Make sure `/etc/rc.local` is executable: `chmod 0755 /etc/rc.local`.
-
-

--- a/packaging/maintainers/README.md
+++ b/packaging/maintainers/README.md
@@ -39,9 +39,9 @@ This page tracks the package maintainers for Netdata, for various operating syst
 
 ## Unofficial Linux Packages
 
-| Linux Distribution | Netdata Version | Maintainer | Related URL                                                                                                                                     |
-|:------------------:|:---------------:|:----------:|:------------------------------------------------------------------------------------------------------------------------------------------------|
-|       Ubuntu       |     Release     |   @gslin   | [netdata @ gslin ppa](https://launchpad.net/~gslin/+archive/ubuntu/netdata) https://github.com/netdata/netdata/issues/69#issuecomment-217458543 |
+| Linux Distribution | Netdata Version | Maintainer | Related URL                                                                                                                                       |
+|:------------------:|:---------------:|:----------:|:--------------------------------------------------------------------------------------------------------------------------------------------------|
+|       Ubuntu       |     Release     |   @gslin   | [netdata @ gslin ppa](https://launchpad.net/~gslin/+archive/ubuntu/netdata) <https://github.com/netdata/netdata/issues/69#issuecomment-217458543> |
 
 ---
 
@@ -50,23 +50,21 @@ This page tracks the package maintainers for Netdata, for various operating syst
 | Embedded Linux | Netdata Version |  Maintainer   | Related URL                                                                      |
 |:--------------:|:---------------:|:-------------:|:---------------------------------------------------------------------------------|
 |    OpenWRT     |     Release     |  @nitroshift  | [openwrt package](https://github.com/openwrt/packages/tree/master/admin/netdata) |
-|    ReadyNAS    |     Release     |   @NAStools   | https://github.com/nastools/netdata                                              |
-|      QNAP      |     Release     | QNAP_Stephane | https://forum.qnap.com/viewtopic.php?t=121518                                    |
-|     DietPi     |     Release     |   @Fourdee    | https://github.com/Fourdee/DietPi                                                |
+|    ReadyNAS    |     Release     |   @NAStools   | <https://github.com/nastools/netdata>                                            |
+|      QNAP      |     Release     | QNAP_Stephane | <https://forum.qnap.com/viewtopic.php?t=121518>                                  |
+|     DietPi     |     Release     |   @Fourdee    | <https://github.com/Fourdee/DietPi>                                              |
 
 ---
 
 ## Automation Systems
 
-| Automation Systems | Netdata Version | Maintainer  | Related URL                                    |
-|:------------------:|:---------------:|:-----------:|:-----------------------------------------------|
-|      Ansible       |       git       |    @jffz    | https://galaxy.ansible.com/jffz/netdata/       |
-|        Chef        |        ?        | @sergiopena | https://github.com/sergiopena/netdata-cookbook |
+| Automation Systems | Netdata Version | Maintainer  | Related URL                                      |
+|:------------------:|:---------------:|:-----------:|:-------------------------------------------------|
+|      Ansible       |       git       |    @jffz    | <https://galaxy.ansible.com/jffz/netdata/>       |
+|        Chef        |        ?        | @sergiopena | <https://github.com/sergiopena/netdata-cookbook> |
 
 ---
 
 ## Packages summary from repology.org
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/netdata.svg)](https://repology.org/metapackage/netdata/versions)
-
-

--- a/packaging/windows/WINDOWS_INSTALLER.md
+++ b/packaging/windows/WINDOWS_INSTALLER.md
@@ -26,7 +26,7 @@ The installer will then guide you through these steps:
 This section provides instructions for installing Netdata in silent mode, which is ideal for automated deployments.
 Silent mode skips displaying license agreements, but requires explicitly accepting them using the `/A` option.
 
-**Available Options**:
+### Available Options
 
 | Option    | Description                                                                                      |
 |-----------|--------------------------------------------------------------------------------------------------|
@@ -39,7 +39,7 @@ Silent mode skips displaying license agreements, but requires explicitly accepti
 | `/ROOMS=` | Comma-separated list of Room IDs where you want your node to appear.                             |
 | `/PROXY=` | Sets the proxy server address if your network requires one.                                      |
 
-**Example Usage**
+### Example Usage
 
 Connect your Agent to your Netdata Cloud Space with token `<YOUR_TOKEN>` and room `<YOUR_ROOM>`:
 


### PR DESCRIPTION
##### Summary

Let there be ~rock~ docs!

related to #18553 

I passed and checked the errors, warnings and info "Problems" on VScode, and fixed mistakes in links, typos and formatted all `.md` files. 

I will do some follow-up PRs once I am done to enforce some uppercase in-house words and also check block quote formatting, as right now there is not a default way of doing it across our docs.