### PR TITLE
Properly set start/shutdown times to parent/child

### DIFF
--- a/src/streaming/stream_path.c
+++ b/src/streaming/stream_path.c
@@ -24,6 +24,8 @@ static void stream_path_clear(STREAM_PATH *p) {
     p->first_time_t = 0;
     p->capabilities = 0;
     p->flags = STREAM_PATH_FLAG_NONE;
+    p->start_time = 0;
+    p->shutdown_time = 0;
 }
 
 static void rrdhost_stream_path_clear_unsafe(RRDHOST *host, bool destroy) {
@@ -220,6 +222,8 @@ static bool parse_single_path(json_object *jobj, const char *path, STREAM_PATH *
     JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "hops", p->hops, error, true);
     JSONC_PARSE_UINT64_OR_ERROR_AND_RETURN(jobj, path, "since", p->since, error, true);
     JSONC_PARSE_UINT64_OR_ERROR_AND_RETURN(jobj, path, "first_time_t", p->first_time_t, error, true);
+    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "start_time", p->start_time, error, true);
+    JSONC_PARSE_INT64_OR_ERROR_AND_RETURN(jobj, path, "shutdown_time", p->shutdown_time, error, true);
     JSONC_PARSE_ARRAY_OF_TXT2BITMAP_OR_ERROR_AND_RETURN(jobj, path, "flags", STREAM_PATH_FLAGS_2id_one, p->flags, error, true);
     JSONC_PARSE_ARRAY_OF_TXT2BITMAP_OR_ERROR_AND_RETURN(jobj, path, "capabilities", stream_capabilities_parse_one, p->capabilities, error, true);
 


### PR DESCRIPTION
##### Summary
- Stream path processing was missing the parsing of the new fields on the remote side (parent or child) 

This PR fixes this

##### Test
- Setup parent/child  with current master
- Execute /api/v3/nodes on parent
  - You will notice that start_time, shutdown_time report 0 for the child
- Install PR and do the test again

