### PR TITLE
Docs fixes

### DIFF
--- a/REDISTRIBUTED.md
+++ b/REDISTRIBUTED.md
@@ -1,12 +1,3 @@
-<!--
-title: "Redistributed software"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/REDISTRIBUTED.md
-sidebar_label: "Redistributed Software"
-learn_status: "Published"
-learn_topic_type: "Concepts"
-learn_rel_path: "Developers"
--->
-
 # Redistributed software
 
 Netdata copyright info:<br/>

--- a/docs/.templates/.page-level/_concept-page-template.md
+++ b/docs/.templates/.page-level/_concept-page-template.md
@@ -1,10 +1,3 @@
-<!--
-title: Noun that describes the concept
-description: Short summary (will be displayed in search engines)
-custom_edit_url: Edit URL of the source file
-keywords: [keywords, describing, the main topics]
--->
-
 # Title
 
 Why should the reader care: “What’s in it for me?”

--- a/docs/Demo-Sites.md
+++ b/docs/Demo-Sites.md
@@ -1,13 +1,3 @@
-<!--
-title: "Live demos"
-date: 2020-03-26
-custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/Demo-Sites.md
-sidebar_label: "Live demos"
-learn_status: "Published"
-learn_topic_type: "Getting started"
-learn_rel_path: "Getting started"
-sidebar_position: "90"
--->
 
 # Live demos
 

--- a/docs/dashboards-and-charts/import-export-print-snapshot.md
+++ b/docs/dashboards-and-charts/import-export-print-snapshot.md
@@ -1,17 +1,3 @@
-<!--
-title: "Import, export, and print a snapshot"
-description: >-
-    "Snapshots can be incredibly useful for diagnosing anomalies after 
-    they've already happened, and are interoperable with any other node 
-    running Netdata."
-type: "how-to"
-custom_edit_url: "/docs/dashboards-and-charts/import-export-print-snapshot.md"
-sidebar_label: "Import, export, and print a snapshot"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Operations"
--->
-
 # Import, export, and print a snapshot
 
 >❗This feature is only available on v1 dashboards, it hasn't been port-forwarded to v2.

--- a/docs/developer-and-contributor-corner/collect-unbound-metrics.md
+++ b/docs/developer-and-contributor-corner/collect-unbound-metrics.md
@@ -25,7 +25,7 @@ the TLS key files that will encrypt connections to the remote interface. Then ad
 documentation](https://nlnetlabs.nl/documentation/unbound/howto-setup/#setup-remote-control) for more details on using
 `unbound-control`, such as how to handle situations when Unbound is run under a unique user.
 
-```conf
+```text
 # enable remote-control
 remote-control:
     control-enable: yes

--- a/docs/developer-and-contributor-corner/collect-unbound-metrics.md
+++ b/docs/developer-and-contributor-corner/collect-unbound-metrics.md
@@ -1,13 +1,3 @@
-<!--
-title: "Monitor Unbound DNS servers with Netdata"
-sidebar_label: "Monitor Unbound DNS servers with Netdata"
-date: 2020-03-31
-custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/collect-unbound-metrics.md
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Miscellaneous"
--->
-
 # Monitor Unbound DNS servers with Netdata
 
 [Unbound](https://nlnetlabs.nl/projects/unbound/about/) is a "validating, recursive, caching DNS resolver" from NLNet

--- a/docs/developer-and-contributor-corner/customize.md
+++ b/docs/developer-and-contributor-corner/customize.md
@@ -66,7 +66,7 @@ dashboard.
 Save the file, then navigate to your [Netdata config directory](/docs/netdata-agent/configuration/README.md) to edit `netdata.conf`. Add
 the following line to the `[web]` section to tell Netdata where to find your custom configuration.
 
-```conf
+```text
 [web]
     custom dashboard_info.js = your_dashboard_info_file.js
 ```

--- a/docs/developer-and-contributor-corner/lamp-stack.txt
+++ b/docs/developer-and-contributor-corner/lamp-stack.txt
@@ -124,7 +124,7 @@ sudo nano /etc/php/7.4/fpm/pool.d/www.conf
 
 Find the line that reads `;pm.status_path = /status` and remove the `;` so it looks like this:
 
-```conf
+```text
 pm.status_path = /status
 ```
 

--- a/docs/developer-and-contributor-corner/monitor-debug-applications-ebpf.md
+++ b/docs/developer-and-contributor-corner/monitor-debug-applications-ebpf.md
@@ -38,7 +38,7 @@ your application's process name.
 
 Your file should now look like this:
 
-```conf
+```text
 ...
 # -----------------------------------------------------------------------------
 # Custom applications to monitor with apps.plugin and ebpf.plugin
@@ -57,7 +57,7 @@ You can set up `apps_groups.conf` to more show more precise eBPF metrics for any
 system, even if it's a standard package like Redis, Apache, or any other [application/service Netdata collects
 from](/src/collectors/COLLECTORS.md).
 
-```conf
+```text
 # -----------------------------------------------------------------------------
 # Custom applications to monitor with apps.plugin and ebpf.plugin
 
@@ -88,7 +88,7 @@ sudo ./edit-config ebpf.d.conf
 
 Replace `entry` with `return`:
 
-```conf
+```text
 [global]
     ebpf load mode = return
     disable apps = no

--- a/docs/developer-and-contributor-corner/monitor-debug-applications-ebpf.md
+++ b/docs/developer-and-contributor-corner/monitor-debug-applications-ebpf.md
@@ -1,13 +1,3 @@
-<!--
-title: "Monitor, troubleshoot, and debug applications with eBPF metrics"
-sidebar_label: "Monitor, troubleshoot, and debug applications with eBPF metrics"
-description: "Use Netdata's built-in eBPF metrics collector to monitor, troubleshoot, and debug your custom application using low-level kernel feedback."
-image: /img/seo/guides/troubleshoot/monitor-debug-applications-ebpf.png
-custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/troubleshoot/monitor-debug-applications-ebpf.md
-learn_status: "Published"
-learn_rel_path: "Operations"
--->
-
 # Monitor, troubleshoot, and debug applications with eBPF metrics
 
 When trying to troubleshoot or debug a finicky application, there's no such thing as too much information. At Netdata,

--- a/docs/developer-and-contributor-corner/monitor-hadoop-cluster.md
+++ b/docs/developer-and-contributor-corner/monitor-hadoop-cluster.md
@@ -1,12 +1,3 @@
-<!--
-title: "Monitor a Hadoop cluster with Netdata"
-sidebar_label: "Monitor a Hadoop cluster with Netdata"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/docs/guides/monitor-hadoop-cluster.md
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Miscellaneous"
--->
-
 # Monitor a Hadoop cluster with Netdata
 
 Hadoop is an [Apache project](https://hadoop.apache.org/) is a framework for processing large sets of data across a

--- a/docs/developer-and-contributor-corner/process.txt
+++ b/docs/developer-and-contributor-corner/process.txt
@@ -142,7 +142,7 @@ Inside the file are lists of process names, oftentimes using wildcards (`*`), th
 groups together. For example, the Netdata Agent looks for processes starting with `mysqld`, `mariad`, `postgres`, and
 others, and groups them into `sql`. That makes sense, since all these processes are for SQL databases.
 
-```conf
+```text
 sql: mysqld* mariad* postgres* postmaster* oracle_* ora_* sqlservr
 ```
 
@@ -170,7 +170,7 @@ the [section above](#configure-the-netdata-agent-to-recognize-a-specific-process
 the `database servers` section. Create new groups for MySQL and PostgreSQL, and move their process queries into the
 unique groups.
 
-```conf
+```text
 # -----------------------------------------------------------------------------
 # database servers
 
@@ -194,7 +194,7 @@ to `# NETDATA processes accounting`.
 Above that, paste in the following text, which creates a new `custom-app` group with the `custom-app` process. Replace
 `custom-app` with the name of your application's Linux process. `apps_groups.conf` should now look like this:
 
-```conf
+```text
 ...
 # -----------------------------------------------------------------------------
 # Custom applications to monitor with apps.plugin and ebpf.plugin

--- a/docs/developer-and-contributor-corner/raspberry-pi-anomaly-detection.txt
+++ b/docs/developer-and-contributor-corner/raspberry-pi-anomaly-detection.txt
@@ -27,7 +27,7 @@ Next, open `netdata.conf` using [`edit-config`](/docs/netdata-agent/configuratio
 from within the [Netdata config directory](/docs/netdata-agent/configuration/README.md#the-netdata-config-directory). Scroll down to the
 `[plugin:python.d]` section to pass in the `-ppython3` command option. 
 
-```conf
+```text
 [plugin:python.d]
     # update every = 1
     command options = -ppython3

--- a/docs/exporting-metrics/enable-an-exporting-connector.md
+++ b/docs/exporting-metrics/enable-an-exporting-connector.md
@@ -19,7 +19,7 @@ Use `edit-config` from your [Netdata config directory](/docs/netdata-agent/confi
 
 Enable the exporting engine itself by setting `enabled` to `yes`:
 
-```conf
+```text
 [exporting:global]
     enabled = yes
 ```
@@ -30,7 +30,7 @@ Save the file but keep it open, as you will edit it again to enable specific con
 
 Use the following configuration as a starting point. Copy and paste it into `exporting.conf`.
 
-```conf
+```text
 [opentsdb:http:my_opentsdb_http_instance]
     enabled = yes
     destination = localhost:4242

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -49,7 +49,7 @@ Please ensure that any links to a different documentation resource are fully exp
 
 e.g.
 
-```txt
+```text
 [Correct link to this document](/docs/guidelines.md)
 vs
 [Incorrect link to this document](https://learn.netdata.cloud/XYZ)

--- a/docs/netdata-agent/configuration/cheatsheet.md
+++ b/docs/netdata-agent/configuration/cheatsheet.md
@@ -31,7 +31,7 @@ You are expected to use this method in all following configuration changes.
 sudo ./edit-config netdata.conf
 ```
 
-```conf
+```text
 [plugins]
  go.d = yes # enabled
  node.d = no # disabled
@@ -94,7 +94,7 @@ sudo ./edit-config health.d/example-alert.conf
 
 ### Change the port Netdata listens to (example, set it to port 39999)
 
-```conf
+```text
 [web]
 default port = 39999
 ```

--- a/docs/netdata-agent/configuration/cheatsheet.md
+++ b/docs/netdata-agent/configuration/cheatsheet.md
@@ -77,7 +77,7 @@ sudo ./edit-config health.d/example-alert.conf
 sudo ./edit-config health.d/example-alert.conf
 ```
 
-```txt
+```text
  to: silent
 ```
 

--- a/docs/netdata-agent/configuration/common-configuration-changes.md
+++ b/docs/netdata-agent/configuration/common-configuration-changes.md
@@ -29,7 +29,7 @@ of `netdata.conf` so
 that it is greater than `1`. An `update every` of `5` means the Netdata Agent enforces a _minimum_ collection frequency
 of 5 seconds.
 
-```conf
+```text
 [global]
     update every = 5
 ```
@@ -90,7 +90,7 @@ Because the source path contains `health.d/cpu.conf`, run `sudo edit-config heal
 
 Open the configuration file for that alert and set the `to` line to `silent`.
 
-```conf
+```text
 template: disk_fill_rate
        on: disk.space
    lookup: max -1s at -30m unaligned of avail

--- a/docs/netdata-agent/configuration/optimize-the-netdata-agents-performance.md
+++ b/docs/netdata-agent/configuration/optimize-the-netdata-agents-performance.md
@@ -116,7 +116,7 @@ and makes it easier to configure or disable alerts and agent notifications.
 The parents by default run health checks for each child, as long as the child is connected (the details are
 in `stream.conf`). On the child nodes you should add to `netdata.conf` the following:
 
-```conf
+```text
 [health]
    enabled = no
 ```
@@ -136,7 +136,7 @@ actively collecting metrics.
 Open `netdata.conf` and scroll down to the `[plugins]` section. To disable any plugin, uncomment it and set the value to
 `no`. For example, to explicitly keep the `proc` and `go.d` plugins enabled while disabling `python.d` and `charts.d`.
 
-```conf
+```text
 [plugins]
     proc = yes
     python.d = no
@@ -155,7 +155,7 @@ sudo ./edit-config charts.d.conf
 
 For example, to disable a few Python collectors:
 
-```conf
+```text
 modules:
     apache: no
     dockerd: no
@@ -179,7 +179,7 @@ If you change this to `2`, Netdata enforces a minimum `update every` setting of 
 other second, which will effectively halve CPU utilization. Set this to `5` or `10` to collect metrics every 5 or 10
 seconds, respectively.
 
-```conf
+```text
 [global]
     update every = 5
 ```
@@ -197,7 +197,7 @@ an [internal_plugin/collector](/src/collectors/README.md#collector-architecture-
 open `netdata.conf` and find the appropriate section. For example, to reduce the frequency of the `apps` plugin, which
 collects and visualizes metrics on application resource utilization:
 
-```conf
+```text
 [plugin:apps]
     update every = 5
 ```
@@ -206,7 +206,7 @@ To [configure an individual collector](/src/collectors/REFERENCE.md#configure-a-
 open its specific configuration file with `edit-config` and look for the `update_every` setting. For example, to reduce
 the frequency of the `nginx` collector, run `sudo ./edit-config go.d/nginx.conf`:
 
-```conf
+```text
 # [ GLOBAL ]
 update_every: 10
 ```
@@ -227,7 +227,7 @@ on [streaming and replication](/docs/observability-centralization-points/README.
 Automated anomaly detection may be a powerful tool, but we recommend it to only be enabled on Netdata parents that sit
 outside your production infrastructure, or if you have cpu and memory to spare. You can disable ML with the following:
 
-```conf
+```text
 [ml]
    enabled = no
 ```
@@ -249,14 +249,14 @@ looking at the local Agent dashboard.
 
 To disable gzip compression, open `netdata.conf` and find the `[web]` section:
 
-```conf
+```text
 [web]
     enable gzip compression = no
 ```
 
 Or to lower the default compression level:
 
-```conf
+```text
 [web]
     enable gzip compression = yes
     gzip compression level = 1

--- a/docs/netdata-agent/configuration/optimize-the-netdata-agents-performance.md
+++ b/docs/netdata-agent/configuration/optimize-the-netdata-agents-performance.md
@@ -139,9 +139,9 @@ Open `netdata.conf` and scroll down to the `[plugins]` section. To disable any p
 ```conf
 [plugins]
     proc = yes
- python.d = no
- charts.d = no
- go.d = yes
+    python.d = no
+    charts.d = no
+    go.d = yes
 ```
 
 Disable specific collectors by opening their respective plugin configuration files, uncommenting the line for the
@@ -157,9 +157,9 @@ For example, to disable a few Python collectors:
 
 ```conf
 modules:
-  apache: no
- dockerd: no
- fail2ban: no
+    apache: no
+    dockerd: no
+    fail2ban: no
 ```
 
 ## Reduce collection frequency

--- a/docs/netdata-agent/configuration/optimizing-metrics-database/change-metrics-storage.md
+++ b/docs/netdata-agent/configuration/optimizing-metrics-database/change-metrics-storage.md
@@ -32,7 +32,7 @@ retention strategies as shown in the table below:
 
 You can change these limits in `netdata.conf`:
 
-```conf
+```text
 [db]
     mode = dbengine
     storage tiers = 3
@@ -111,7 +111,7 @@ for the parent node and all of its children.
 To configure the database engine, look for the `page cache size MB` and `dbengine multihost disk space MB` settings in
 the `[db]` section of your `netdata.conf`.
 
-```conf
+```text
 [db]
     dbengine page cache size MB = 32
     dbengine multihost disk space MB = 256

--- a/docs/netdata-agent/configuration/optimizing-metrics-database/change-metrics-storage.md
+++ b/docs/netdata-agent/configuration/optimizing-metrics-database/change-metrics-storage.md
@@ -32,7 +32,7 @@ retention strategies as shown in the table below:
 
 You can change these limits in `netdata.conf`:
 
-```text
+```conf
 [db]
     mode = dbengine
     storage tiers = 3

--- a/docs/netdata-agent/configuration/organize-systems-metrics-and-alerts.md
+++ b/docs/netdata-agent/configuration/organize-systems-metrics-and-alerts.md
@@ -90,7 +90,7 @@ sudo ./edit-config netdata.conf
 Create a new `[host labels]` section defining a new host label and its value for the system in question. Make sure not
 to violate any of the [host label naming rules](/docs/netdata-agent/configuration/common-configuration-changes.md#organize-nodes-with-host-labels).
 
-```conf
+```text
 [host labels]
     type = webserver
     location = us-seattle
@@ -154,7 +154,7 @@ alerts to them.
 
 For example, let's use configuration example from earlier:
 
-```conf
+```text
 [host labels]
     type = webserver
     location = us-seattle
@@ -201,7 +201,7 @@ If you have enabled any metrics exporting via our experimental [exporters](/src/
 labels you created manually are sent to the destination database alongside metrics. You can change this behavior by
 editing `exporting.conf`, and you can even send automatically-generated labels on with exported metrics.
 
-```conf
+```text
 [exporting:global]
 enabled = yes
 send configured labels = yes
@@ -210,7 +210,7 @@ send automatic labels = no
 
 You can also change this behavior per exporting connection:
 
-```conf
+```text
 [opentsdb:my_instance3]
 enabled = yes
 destination = localhost:4242

--- a/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/README.md
+++ b/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/README.md
@@ -26,9 +26,9 @@ The above will prevent anyone except your web server to access a Netdata dashboa
 
 You can also use `netdata.conf`:
 
-```txt
+```conf
 [web]
- allow connections from = localhost 1.2.3.4
+    allow connections from = localhost 1.2.3.4
 ```
 
 Of course, you can add more IPs.

--- a/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/README.md
+++ b/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/README.md
@@ -26,7 +26,7 @@ The above will prevent anyone except your web server to access a Netdata dashboa
 
 You can also use `netdata.conf`:
 
-```conf
+```text
 [web]
     allow connections from = localhost 1.2.3.4
 ```

--- a/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-apache.md
+++ b/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-apache.md
@@ -41,26 +41,26 @@ Add the following on top of any existing virtual host. It will allow you to acce
 ```conf
 <VirtualHost *:80>
 
- RewriteEngine On
- ProxyRequests Off
- ProxyPreserveHost On
+    RewriteEngine On
+    ProxyRequests Off
+    ProxyPreserveHost On
 
- <Proxy *>
-  Require all granted
- </Proxy>
+    <Proxy *>
+        Require all granted
+    </Proxy>
 
- # Local Netdata server accessed with '/netdata/', at localhost:19999
- ProxyPass "/netdata/" "http://localhost:19999/" connectiontimeout=5 timeout=30 keepalive=on
- ProxyPassReverse "/netdata/" "http://localhost:19999/"
+    # Local Netdata server accessed with '/netdata/', at localhost:19999
+    ProxyPass "/netdata/" "http://localhost:19999/" connectiontimeout=5 timeout=30 keepalive=on
+    ProxyPassReverse "/netdata/" "http://localhost:19999/"
 
- # if the user did not give the trailing /, add it
- # for HTTP (if the virtualhost is HTTP, use this)
- RewriteRule ^/netdata$ http://%{HTTP_HOST}/netdata/ [L,R=301]
- # for HTTPS (if the virtualhost is HTTPS, use this)
- #RewriteRule ^/netdata$ https://%{HTTP_HOST}/netdata/ [L,R=301]
+    # if the user did not give the trailing /, add it
+    # for HTTP (if the virtualhost is HTTP, use this)
+    RewriteRule ^/netdata$ http://%{HTTP_HOST}/netdata/ [L,R=301]
+    # for HTTPS (if the virtualhost is HTTPS, use this)
+    #RewriteRule ^/netdata$ https://%{HTTP_HOST}/netdata/ [L,R=301]
 
- # rest of virtual host config here
- 
+    # rest of virtual host config here
+
 </VirtualHost>
 ```
 
@@ -71,13 +71,13 @@ Add the following on top of any existing virtual host. It will allow you to acce
 ```conf
 <VirtualHost *:80>
 
- RewriteEngine On
- ProxyRequests Off
- ProxyPreserveHost On
+    RewriteEngine On
+    ProxyRequests Off
+    ProxyPreserveHost On
 
- <Proxy *>
-  Require all granted
- </Proxy>
+    <Proxy *>
+        Require all granted
+    </Proxy>
 
     # proxy any host, on port 19999
     ProxyPassMatch "^/netdata/([A-Za-z0-9\._-]+)/(.*)" "http://$1:19999/$2" connectiontimeout=5 timeout=30 keepalive=on
@@ -88,8 +88,8 @@ Add the following on top of any existing virtual host. It will allow you to acce
     # for HTTPS (if the virtualhost is HTTPS, use this)
     RewriteRule "^/netdata/([A-Za-z0-9\._-]+)$" https://%{HTTP_HOST}/netdata/$1/ [L,R=301]
 
- # rest of virtual host config here
- 
+     # rest of virtual host config here
+
 </VirtualHost>
 ```
 
@@ -98,7 +98,7 @@ Add the following on top of any existing virtual host. It will allow you to acce
 
 If you want to control the servers your users can connect to, replace the `ProxyPassMatch` line with the following. This allows only `server1`, `server2`, `server3` and `server4`.
 
-```txt
+```conf
     ProxyPassMatch "^/netdata/(server1|server2|server3|server4)/(.*)" "http://$1:19999/$2" connectiontimeout=5 timeout=30 keepalive=on
 ```
 
@@ -116,20 +116,22 @@ with this content:
 
 ```conf
 <VirtualHost *:80>
- ProxyRequests Off
- ProxyPreserveHost On
- 
- ServerName netdata.domain.tld
 
- <Proxy *>
-  Require all granted
- </Proxy>
+    ProxyRequests Off
+    ProxyPreserveHost On
 
- ProxyPass "/" "http://localhost:19999/" connectiontimeout=5 timeout=30 keepalive=on
- ProxyPassReverse "/" "http://localhost:19999/"
+    ServerName netdata.domain.tld
 
- ErrorLog ${APACHE_LOG_DIR}/netdata-error.log
- CustomLog ${APACHE_LOG_DIR}/netdata-access.log combined
+     <Proxy *>
+        Require all granted
+    </Proxy>
+
+    ProxyPass "/" "http://localhost:19999/" connectiontimeout=5 timeout=30 keepalive=on
+    ProxyPassReverse "/" "http://localhost:19999/"
+
+    ErrorLog ${APACHE_LOG_DIR}/netdata-error.log
+    CustomLog ${APACHE_LOG_DIR}/netdata-access.log combined
+
 </VirtualHost>
 ```
 
@@ -167,21 +169,21 @@ Then, generate password for user `netdata`, using `htpasswd -c /etc/apache2/.htp
 Modify the virtual host with these:
 
 ```conf
- # replace the <Proxy *> section
- <Proxy *>
-  Order deny,allow
-  Allow from all
- </Proxy>
+    # replace the <Proxy *> section
+    <Proxy *>
+        Order deny,allow
+        Allow from all
+    </Proxy>
 
- # add a <Location /netdata/> section
- <Location /netdata/>
-  AuthType Basic
-  AuthName "Protected site"
-  AuthUserFile /etc/apache2/.htpasswd
-  Require valid-user
-  Order deny,allow
-  Allow from all
- </Location>
+    # add a <Location /netdata/> section
+    <Location /netdata/>
+        AuthType Basic
+        AuthName "Protected site"
+        AuthUserFile /etc/apache2/.htpasswd
+        Require valid-user
+        Order deny,allow
+        Allow from all
+    </Location>
 ```
 
 Specify `Location /` if Netdata is running on dedicated virtual host.
@@ -190,25 +192,25 @@ Specify `Location /` if Netdata is running on dedicated virtual host.
 
 ```conf
 <VirtualHost *:80>
- RewriteEngine On
- ProxyRequests Off
- ProxyPreserveHost On
- 
- ServerName netdata.domain.tld
+    RewriteEngine On
+    ProxyRequests Off
+    ProxyPreserveHost On
+    
+    ServerName netdata.domain.tld
 
- <Proxy *>
-  AllowOverride None
-  AuthType Basic
-  AuthName "Protected site"
-  AuthUserFile /etc/apache2/.htpasswd
-  Require valid-user
- </Proxy>
+    <Proxy *>
+        AllowOverride None
+        AuthType Basic
+        AuthName "Protected site"
+        AuthUserFile /etc/apache2/.htpasswd
+        Require valid-user
+    </Proxy>
 
- ProxyPass "/" "http://localhost:19999/" connectiontimeout=5 timeout=30 keepalive=on
- ProxyPassReverse "/" "http://localhost:19999/"
+    ProxyPass "/" "http://localhost:19999/" connectiontimeout=5 timeout=30 keepalive=on
+    ProxyPassReverse "/" "http://localhost:19999/"
 
- ErrorLog ${APACHE_LOG_DIR}/netdata-error.log
- CustomLog ${APACHE_LOG_DIR}/netdata-access.log combined
+    ErrorLog ${APACHE_LOG_DIR}/netdata-error.log
+    CustomLog ${APACHE_LOG_DIR}/netdata-access.log combined
 </VirtualHost>
 ```
 
@@ -218,8 +220,8 @@ Note: Changes are applied by reloading or restarting Apache.
 
 If you want to enable CSP within your Apache, you should consider some special requirements of the headers. Modify your configuration like that:
 
-```txt
- Header always set Content-Security-Policy "default-src http: 'unsafe-inline' 'self' 'unsafe-eval'; script-src http: 'unsafe-inline' 'self' 'unsafe-eval'; style-src http: 'self' 'unsafe-inline'"
+```conf
+    Header always set Content-Security-Policy "default-src http: 'unsafe-inline' 'self' 'unsafe-eval'; script-src http: 'unsafe-inline' 'self' 'unsafe-eval'; style-src http: 'self' 'unsafe-inline'"
 ```
 
 Note: Changes are applied by reloading or restarting Apache.
@@ -258,11 +260,11 @@ following:
 
 ```conf
 <VirtualHost *:80>
- ...
- # Increase the DOSPageCount to prevent 403 errors and IP addresses being blocked.
- <IfModule mod_evasive20.c>
-  DOSPageCount        30
- </IfModule>
+    ...
+    # Increase the DOSPageCount to prevent 403 errors and IP addresses being blocked.
+    <IfModule mod_evasive20.c>
+        DOSPageCount        30
+    </IfModule>
 </VirtualHost>
 ```
 
@@ -277,7 +279,7 @@ You might edit `/etc/netdata/netdata.conf` to optimize your setup a bit. For app
 
 If you plan to use Netdata exclusively via apache, you can gain some performance by preventing double compression of its output (Netdata compresses its response, apache re-compresses it) by editing `/etc/netdata/netdata.conf` and setting:
 
-```txt
+```conf
 [web]
     enable gzip compression = no
 ```
@@ -288,48 +290,48 @@ Once you disable compression at Netdata (and restart it), please verify you rece
 
 You would also need to instruct Netdata to listen only on `localhost`, `127.0.0.1` or `::1`.
 
-```txt
+```conf
 [web]
     bind to = localhost
 ```
 
 or  
 
-```txt
+```conf
 [web]
     bind to = 127.0.0.1
 ```
 
 or  
 
-```txt
+```conf
 [web]
     bind to = ::1
 ```
 
 You can also use a unix domain socket. This will also provide a faster route between apache and Netdata:
 
-```txt
+```conf
 [web]
     bind to = unix:/tmp/netdata.sock
 ```
 
 Apache 2.4.24+ can not read from `/tmp` so create your socket in `/var/run/netdata`
 
-```txt
+```conf
 [web]
     bind to = unix:/var/run/netdata/netdata.sock
 ```
 
 At the apache side, prepend the 2nd argument to `ProxyPass` with `unix:/tmp/netdata.sock|`, like this:
 
-```txt
+```conf
 ProxyPass "/netdata/" "unix:/tmp/netdata.sock|http://localhost:19999/" connectiontimeout=5 timeout=30 keepalive=on
 ```
 
 If your apache server is not on localhost, you can set:
 
-```txt
+```conf
 [web]
     bind to = *
     allow connections from = IP_OF_APACHE_SERVER
@@ -341,7 +343,7 @@ If your apache server is not on localhost, you can set:
 
 apache logs accesses and Netdata logs them too. You can prevent Netdata from generating its access log, by setting this in `/etc/netdata/netdata.conf`:
 
-```txt
+```conf
 [logs]
     access = off
 ```

--- a/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-apache.md
+++ b/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-apache.md
@@ -38,7 +38,7 @@ On any **existing** and already **working** apache virtual host, you can redirec
 
 Add the following on top of any existing virtual host. It will allow you to access Netdata as `http://virtual.host/netdata/`.
 
-```conf
+```text
 <VirtualHost *:80>
 
     RewriteEngine On
@@ -68,7 +68,7 @@ Add the following on top of any existing virtual host. It will allow you to acce
 
 Add the following on top of any existing virtual host. It will allow you to access multiple Netdata as `http://virtual.host/netdata/HOSTNAME/`, where `HOSTNAME` is the hostname of any other Netdata server you have (to access the `localhost` Netdata, use `http://virtual.host/netdata/localhost/`).
 
-```conf
+```text
 <VirtualHost *:80>
 
     RewriteEngine On
@@ -98,7 +98,7 @@ Add the following on top of any existing virtual host. It will allow you to acce
 
 If you want to control the servers your users can connect to, replace the `ProxyPassMatch` line with the following. This allows only `server1`, `server2`, `server3` and `server4`.
 
-```conf
+```text
     ProxyPassMatch "^/netdata/(server1|server2|server3|server4)/(.*)" "http://$1:19999/$2" connectiontimeout=5 timeout=30 keepalive=on
 ```
 
@@ -114,7 +114,7 @@ nano /etc/apache2/sites-available/netdata.conf
 
 with this content:
 
-```conf
+```text
 <VirtualHost *:80>
 
     ProxyRequests Off
@@ -148,7 +148,7 @@ _Assuming the main goal is to make Netdata running in HTTPS._
 1. Make a subdomain for Netdata on which you enable and force HTTPS - You can use a free Let's Encrypt certificate
 2. Go to "Apache & nginx Settings", and in the following section, add:
 
-  ```conf
+  ```text
   RewriteEngine on
   RewriteRule (.*) http://localhost:19999/$1 [P,L]
   ```
@@ -168,7 +168,7 @@ Then, generate password for user `netdata`, using `htpasswd -c /etc/apache2/.htp
 **Apache 2.2 Example:**\
 Modify the virtual host with these:
 
-```conf
+```text
     # replace the <Proxy *> section
     <Proxy *>
         Order deny,allow
@@ -190,7 +190,7 @@ Specify `Location /` if Netdata is running on dedicated virtual host.
 
 **Apache 2.4 (dedicated virtual host) Example:**  
 
-```conf
+```text
 <VirtualHost *:80>
     RewriteEngine On
     ProxyRequests Off
@@ -220,7 +220,7 @@ Note: Changes are applied by reloading or restarting Apache.
 
 If you want to enable CSP within your Apache, you should consider some special requirements of the headers. Modify your configuration like that:
 
-```conf
+```text
     Header always set Content-Security-Policy "default-src http: 'unsafe-inline' 'self' 'unsafe-eval'; script-src http: 'unsafe-inline' 'self' 'unsafe-eval'; style-src http: 'self' 'unsafe-inline'"
 ```
 
@@ -245,7 +245,7 @@ exceed that threshold, and `mod_evasive` will add your IP address to a blocklist
 Our users have found success by setting `DOSPageCount` to `30`. Try this, and raise the value if you continue to see 403
 errors while accessing the dashboard.
 
-```conf
+```text
 DOSPageCount 30
 ```
 
@@ -258,7 +258,7 @@ To adjust the `DOSPageCount` for a specific virtual host, open your virtual host
 `/etc/httpd/conf/sites-available/my-domain.conf` or `/etc/apache2/sites-available/my-domain.conf` and add the
 following:
 
-```conf
+```text
 <VirtualHost *:80>
     ...
     # Increase the DOSPageCount to prevent 403 errors and IP addresses being blocked.
@@ -279,7 +279,7 @@ You might edit `/etc/netdata/netdata.conf` to optimize your setup a bit. For app
 
 If you plan to use Netdata exclusively via apache, you can gain some performance by preventing double compression of its output (Netdata compresses its response, apache re-compresses it) by editing `/etc/netdata/netdata.conf` and setting:
 
-```conf
+```text
 [web]
     enable gzip compression = no
 ```
@@ -290,48 +290,48 @@ Once you disable compression at Netdata (and restart it), please verify you rece
 
 You would also need to instruct Netdata to listen only on `localhost`, `127.0.0.1` or `::1`.
 
-```conf
+```text
 [web]
     bind to = localhost
 ```
 
 or  
 
-```conf
+```text
 [web]
     bind to = 127.0.0.1
 ```
 
 or  
 
-```conf
+```text
 [web]
     bind to = ::1
 ```
 
 You can also use a unix domain socket. This will also provide a faster route between apache and Netdata:
 
-```conf
+```text
 [web]
     bind to = unix:/tmp/netdata.sock
 ```
 
 Apache 2.4.24+ can not read from `/tmp` so create your socket in `/var/run/netdata`
 
-```conf
+```text
 [web]
     bind to = unix:/var/run/netdata/netdata.sock
 ```
 
 At the apache side, prepend the 2nd argument to `ProxyPass` with `unix:/tmp/netdata.sock|`, like this:
 
-```conf
+```text
 ProxyPass "/netdata/" "unix:/tmp/netdata.sock|http://localhost:19999/" connectiontimeout=5 timeout=30 keepalive=on
 ```
 
 If your apache server is not on localhost, you can set:
 
-```conf
+```text
 [web]
     bind to = *
     allow connections from = IP_OF_APACHE_SERVER
@@ -343,7 +343,7 @@ If your apache server is not on localhost, you can set:
 
 apache logs accesses and Netdata logs them too. You can prevent Netdata from generating its access log, by setting this in `/etc/netdata/netdata.conf`:
 
-```conf
+```text
 [logs]
     access = off
 ```

--- a/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-h2o.md
+++ b/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-h2o.md
@@ -1,12 +1,3 @@
-<!--
-title: "Running Netdata behind H2O"
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-h2o.md"
-sidebar_label: "Running Netdata behind H2O"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Configuration/Secure your nodes"
--->
-
 # Running Netdata behind H2O
 
 [H2O](https://h2o.examp1e.net/) is a new generation HTTP server that provides quicker response to users with less CPU utilization when compared to older generation of web servers.

--- a/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-h2o.md
+++ b/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-h2o.md
@@ -132,27 +132,27 @@ For more information on using basic authentication with H2O, see [their official
 
 If your H2O server is on `localhost`, you can use this to ensure external access is only possible through H2O:
 
-```conf
+```text
 [web]
     bind to = 127.0.0.1 ::1
 ```
 
 You can also use a unix domain socket. This will provide faster communication between H2O and Netdata as well:
 
-```conf
+```text
 [web]
     bind to = unix:/run/netdata/netdata.sock
 ```
 
 In the H2O configuration, use a line like the following to connect to Netdata via the unix socket:
 
-```conf
+```text
 proxy.reverse.url http://[unix:/run/netdata/netdata.sock]
 ```
 
 If your H2O server is not on localhost, you can set:
 
-```conf
+```text
 [web]
     bind to = *
     allow connections from = IP_OF_H2O_SERVER
@@ -168,7 +168,7 @@ the connection IP address.
 H2O logs accesses and Netdata logs them too. You can prevent Netdata from generating its access log, by setting
 this in `/etc/netdata/netdata.conf`:
 
-```conf
+```text
 [logs]
     access = off
 ```

--- a/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-h2o.md
+++ b/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-h2o.md
@@ -141,27 +141,27 @@ For more information on using basic authentication with H2O, see [their official
 
 If your H2O server is on `localhost`, you can use this to ensure external access is only possible through H2O:
 
-```txt
+```conf
 [web]
     bind to = 127.0.0.1 ::1
 ```
 
 You can also use a unix domain socket. This will provide faster communication between H2O and Netdata as well:
 
-```txt
+```conf
 [web]
     bind to = unix:/run/netdata/netdata.sock
 ```
 
 In the H2O configuration, use a line like the following to connect to Netdata via the unix socket:
 
-```txt
+```conf
 proxy.reverse.url http://[unix:/run/netdata/netdata.sock]
 ```
 
 If your H2O server is not on localhost, you can set:
 
-```txt
+```conf
 [web]
     bind to = *
     allow connections from = IP_OF_H2O_SERVER
@@ -177,7 +177,7 @@ the connection IP address.
 H2O logs accesses and Netdata logs them too. You can prevent Netdata from generating its access log, by setting
 this in `/etc/netdata/netdata.conf`:
 
-```txt
+```conf
 [logs]
     access = off
 ```

--- a/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-haproxy.md
+++ b/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-haproxy.md
@@ -129,7 +129,7 @@ In the cert list file place a mapping from a certificate file to the domain used
 
 `/etc/letsencrypt/certslist.txt`:
 
-```txt
+```text
 example.com /etc/letsencrypt/live/example.com/example.com.pem
 ```
 

--- a/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-haproxy.md
+++ b/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-haproxy.md
@@ -15,7 +15,7 @@ the following configuration can be used:
 
 For all examples, set the mode to `http`
 
-```conf
+```text
 defaults
     mode    http
 ```
@@ -28,7 +28,7 @@ A simple example where the base URL, say `http://example.com`, is used with no s
 
 Create a frontend to receive the request.
 
-```conf
+```text
 frontend http_frontend
     ## HTTP ipv4 and ipv6 on all ips ##
     bind :::80 v4v6
@@ -40,7 +40,7 @@ frontend http_frontend
 
 Create the Netdata backend which will send requests to port `19999`.
 
-```conf
+```text
 backend netdata_backend
     option       forwardfor
     server       netdata_local     127.0.0.1:19999
@@ -59,7 +59,7 @@ An example where the base URL is used with a subpath `/netdata/`:
 
 To use a subpath, create an ACL, which will set a variable based on the subpath.
 
-```conf
+```text
 frontend http_frontend
     ## HTTP ipv4 and ipv6 on all ips ##
     bind :::80 v4v6
@@ -82,7 +82,7 @@ frontend http_frontend
 
 Same as simple example, except remove `/netdata/` with regex.
 
-```conf
+```text
 backend netdata_backend
     option      forwardfor
     server      netdata_local     127.0.0.1:19999
@@ -104,7 +104,7 @@ This example will only use Netdata if host matches example.com (replace with you
 
 This frontend uses a certificate list.
 
-```conf
+```text
 frontend https_frontend
     ## HTTP ##
     bind :::80 v4v6
@@ -146,7 +146,7 @@ cat /etc/letsencrypt/live/example.com/fullchain.pem \
 
 Same as simple, except set protocol `https`.
 
-```conf
+```text
 backend netdata_backend
     option forwardfor
     server      netdata_local     127.0.0.1:19999
@@ -162,7 +162,7 @@ backend netdata_backend
 
 To use basic HTTP Authentication, create an authentication list:
 
-```conf
+```text
 # HTTP Auth
 userlist basic-auth-list
   group is-admin
@@ -179,13 +179,13 @@ $5$l7Gk0VPIpKO$f5iEcxvjfdF11khw.utzSKqP7W.0oq8wX9nJwPLwzy1
 
 Replace `YOUR_PASSWORD` with hash:
 
-```conf
+```text
 user admin password $5$l7Gk0VPIpKO$f5iEcxvjfdF11khw.utzSKqP7W.0oq8wX9nJwPLwzy1 groups is-admin
 ```
 
 Now add at the top of the backend:
 
-```conf
+```text
 acl devops-auth http_auth_group(basic-auth-list) is-admin
 http-request auth realm netdata_local unless devops-auth
 ```
@@ -194,7 +194,7 @@ http-request auth realm netdata_local unless devops-auth
 
 Full example configuration with HTTP auth over TLS with subpath:
 
-```conf
+```text
 global
     maxconn     20000
 

--- a/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-lighttpd.md
+++ b/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-lighttpd.md
@@ -2,7 +2,7 @@
 
 Here is a config for accessing Netdata in a suburl via lighttpd 1.4.46 and newer:
 
-```txt
+```conf
 $HTTP["url"] =~ "^/netdata/" {
     proxy.server  = ( "" => ("netdata" => ( "host" => "127.0.0.1", "port" => 19999 )))
     proxy.header = ( "map-urlpath" => ( "/netdata/" => "/") )
@@ -11,7 +11,7 @@ $HTTP["url"] =~ "^/netdata/" {
 
 If you have older lighttpd you have to use a chain (such as below), as explained [at this Stack Overflow answer](http://stackoverflow.com/questions/14536554/lighttpd-configuration-to-proxy-rewrite-from-one-domain-to-another).
 
-```txt
+```conf
 $HTTP["url"] =~ "^/netdata/" {
     proxy.server  = ( "" => ("" => ( "host" => "127.0.0.1", "port" => 19998 )))
 }
@@ -25,13 +25,13 @@ $SERVER["socket"] == ":19998" {
 If the only thing the server is exposing via the web is Netdata (and thus no suburl rewriting required),
 then you can get away with just
 
-```txt
+```conf
 proxy.server  = ( "" => ( ( "host" => "127.0.0.1", "port" => 19999 )))
 ```
 
 Though if it's public facing you might then want to put some authentication on it. `htdigest` support looks like:
 
-```txt
+```conf
 auth.backend = "htdigest"
 auth.backend.htdigest.userfile = "/etc/lighttpd/lighttpd.htdigest"
 auth.require = ( "" => ( "method" => "digest", 
@@ -48,7 +48,7 @@ To solve this issue, disable web response compression in Netdata.
 
 Open `/etc/netdata/netdata.conf` and set in `[global]`:
 
-```txt
+```conf
 enable web responses gzip compression = no
 ```
 

--- a/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-lighttpd.md
+++ b/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-lighttpd.md
@@ -2,7 +2,7 @@
 
 Here is a config for accessing Netdata in a suburl via lighttpd 1.4.46 and newer:
 
-```conf
+```text
 $HTTP["url"] =~ "^/netdata/" {
     proxy.server  = ( "" => ("netdata" => ( "host" => "127.0.0.1", "port" => 19999 )))
     proxy.header = ( "map-urlpath" => ( "/netdata/" => "/") )
@@ -11,7 +11,7 @@ $HTTP["url"] =~ "^/netdata/" {
 
 If you have older lighttpd you have to use a chain (such as below), as explained [at this Stack Overflow answer](http://stackoverflow.com/questions/14536554/lighttpd-configuration-to-proxy-rewrite-from-one-domain-to-another).
 
-```conf
+```text
 $HTTP["url"] =~ "^/netdata/" {
     proxy.server  = ( "" => ("" => ( "host" => "127.0.0.1", "port" => 19998 )))
 }
@@ -25,13 +25,13 @@ $SERVER["socket"] == ":19998" {
 If the only thing the server is exposing via the web is Netdata (and thus no suburl rewriting required),
 then you can get away with just
 
-```conf
+```text
 proxy.server  = ( "" => ( ( "host" => "127.0.0.1", "port" => 19999 )))
 ```
 
 Though if it's public facing you might then want to put some authentication on it. `htdigest` support looks like:
 
-```conf
+```text
 auth.backend = "htdigest"
 auth.backend.htdigest.userfile = "/etc/lighttpd/lighttpd.htdigest"
 auth.require = ( "" => ( "method" => "digest", 
@@ -48,7 +48,7 @@ To solve this issue, disable web response compression in Netdata.
 
 Open `/etc/netdata/netdata.conf` and set in `[global]`:
 
-```conf
+```text
 enable web responses gzip compression = no
 ```
 

--- a/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-nginx.md
+++ b/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-nginx.md
@@ -38,7 +38,7 @@ After making changes to the configuration files:
 
 With this method instead of `SERVER_IP_ADDRESS:19999`, the Netdata dashboard can be accessed via a human-readable URL such as `netdata.example.com` used in the configuration below.
 
-```conf
+```text
 upstream backend {
     # the Netdata server
     server 127.0.0.1:19999;
@@ -72,7 +72,7 @@ server {
 This method is recommended when Netdata is to be served from a subfolder (or directory).
 In this case, the virtual host `netdata.example.com` already exists and Netdata has to be accessed via `netdata.example.com/netdata/`.
 
-```conf
+```text
 upstream netdata {
     server 127.0.0.1:19999;
     keepalive 64;
@@ -114,7 +114,7 @@ server {
 
 This is the recommended configuration when one Nginx will be used to manage multiple Netdata servers via sub-folders.
 
-```conf
+```text
 upstream backend-server1 {
     server 10.1.1.103:19999;
     keepalive 64;
@@ -168,7 +168,7 @@ In case Netdata's web server has been [configured to use TLS](/src/web/server/RE
 necessary to specify inside the Nginx configuration that the final destination is using TLS. To do this, please, append
 the following parameters in your `nginx.conf`
 
-```conf
+```text
 proxy_set_header X-Forwarded-Proto https;
 proxy_pass https://localhost:19999;
 ```
@@ -189,7 +189,7 @@ printf "yourusername:$(openssl passwd -apr1)" > /etc/nginx/passwords
 
 And then enable the authentication inside your server directive:
 
-```conf
+```text
 server {
     # ...
     auth_basic "Protected";
@@ -202,21 +202,21 @@ server {
 
 If your Nginx is on `localhost`, you can use this to protect your Netdata:
 
-```conf
+```text
 [web]
     bind to = 127.0.0.1 ::1
 ```
 
 You can also use a unix domain socket. This will also provide a faster route between Nginx and Netdata:
 
-```conf
+```text
 [web]
     bind to = unix:/var/run/netdata/netdata.sock
 ```
 
 At the Nginx side, use something like this to use the same unix domain socket:
 
-```conf
+```text
 upstream backend {
     server unix:/var/run/netdata/netdata.sock;
     keepalive 64;
@@ -225,7 +225,7 @@ upstream backend {
 
 If your Nginx server is not on localhost, you can set:
 
-```conf
+```text
 [web]
     bind to = *
     allow connections from = IP_OF_NGINX_SERVER
@@ -238,7 +238,7 @@ connection IP address.
 
 Nginx logs accesses and Netdata logs them too. You can prevent Netdata from generating its access log, by setting this in `/etc/netdata/netdata.conf`:
 
-```conf
+```text
 [logs]
     access = off
 ```
@@ -247,7 +247,7 @@ Nginx logs accesses and Netdata logs them too. You can prevent Netdata from gene
 
 By default, netdata compresses its responses. You can have nginx do that instead, with the following options in the `location /` block:
 
-```conf
+```text
 location / {
     ...
     gzip on;
@@ -258,7 +258,7 @@ location / {
 
 To disable Netdata's gzip compression, open `netdata.conf` and in the `[web]` section put:
 
-```conf
+```text
 [web]
     enable gzip compression = no
 ```

--- a/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-nginx.md
+++ b/docs/netdata-agent/configuration/running-the-netdata-agent-behind-a-reverse-proxy/Running-behind-nginx.md
@@ -202,14 +202,14 @@ server {
 
 If your Nginx is on `localhost`, you can use this to protect your Netdata:
 
-```txt
+```conf
 [web]
     bind to = 127.0.0.1 ::1
 ```
 
 You can also use a unix domain socket. This will also provide a faster route between Nginx and Netdata:
 
-```txt
+```conf
 [web]
     bind to = unix:/var/run/netdata/netdata.sock
 ```
@@ -225,7 +225,7 @@ upstream backend {
 
 If your Nginx server is not on localhost, you can set:
 
-```txt
+```conf
 [web]
     bind to = *
     allow connections from = IP_OF_NGINX_SERVER
@@ -238,7 +238,7 @@ connection IP address.
 
 Nginx logs accesses and Netdata logs them too. You can prevent Netdata from generating its access log, by setting this in `/etc/netdata/netdata.conf`:
 
-```txt
+```conf
 [logs]
     access = off
 ```
@@ -248,12 +248,12 @@ Nginx logs accesses and Netdata logs them too. You can prevent Netdata from gene
 By default, netdata compresses its responses. You can have nginx do that instead, with the following options in the `location /` block:
 
 ```conf
-  location / {
-  ...
-  gzip on;
-  gzip_proxied any;
-  gzip_types *;
- }
+location / {
+    ...
+    gzip on;
+    gzip_proxied any;
+    gzip_types *;
+}
 ```
 
 To disable Netdata's gzip compression, open `netdata.conf` and in the `[web]` section put:

--- a/docs/netdata-agent/securing-netdata-agents.md
+++ b/docs/netdata-agent/securing-netdata-agents.md
@@ -55,7 +55,7 @@ need to view metrics and troubleshoot issues with Netdata Cloud.
 Open `netdata.conf` with `./edit-config netdata.conf`. Scroll down to the `[web]` section, and find the `mode =
 static-threaded` setting, and change it to `none`.
 
-```conf
+```text
 [web]
     mode = none
 ```
@@ -109,7 +109,7 @@ By default, this setting is `localhost *`. This setting allows connections from 
 connections, using the `*` wildcard. You can change this setting using Netdata's [simple
 patterns](/src/libnetdata/simple_pattern/README.md).
 
-```conf
+```text
 [web]
     # Allow only localhost connections
     allow connections from = localhost
@@ -124,7 +124,7 @@ patterns](/src/libnetdata/simple_pattern/README.md).
 The `allow connections from` setting is global and restricts access to the dashboard, badges, streaming, API, and
 `netdata.conf`, but you can also set each of those access lists more granularly if you choose:
 
-```conf
+```text
 [web]
     allow connections from = localhost *
     allow dashboard from = localhost *

--- a/docs/netdata-agent/securing-netdata-agents.md
+++ b/docs/netdata-agent/securing-netdata-agents.md
@@ -74,7 +74,7 @@ If you are using Netdata with Docker, make sure to set the `NETDATA_HEALTHCHECK_
 If your organization has a private administration and management LAN, you can bind Netdata on this network interface on all your servers.
 This is done in `Netdata.conf` with these settings:
 
-```txt
+```text
 [web]
     bind to = 10.1.1.1:19999 localhost:19999
 ```

--- a/docs/netdata-agent/securing-netdata-agents.md
+++ b/docs/netdata-agent/securing-netdata-agents.md
@@ -76,7 +76,7 @@ This is done in `Netdata.conf` with these settings:
 
 ```txt
 [web]
- bind to = 10.1.1.1:19999 localhost:19999
+    bind to = 10.1.1.1:19999 localhost:19999
 ```
 
 You can bind Netdata to multiple IPs and ports. If you use hostnames, Netdata will resolve them and use all the IPs

--- a/docs/netdata-agent/sizing-netdata-agents/bandwidth-requirements.md
+++ b/docs/netdata-agent/sizing-netdata-agents/bandwidth-requirements.md
@@ -23,7 +23,7 @@ The expected bandwidth consumption using `zstd` for 1 million samples per second
 
 The order compression algorithms is selected is configured in `stream.conf`, per `[API KEY]`, like this:
 
-```conf
+```text
     compression algorithms order = zstd lz4 brotli gzip
 ```
 

--- a/docs/netdata-agent/sizing-netdata-agents/bandwidth-requirements.md
+++ b/docs/netdata-agent/sizing-netdata-agents/bandwidth-requirements.md
@@ -23,7 +23,7 @@ The expected bandwidth consumption using `zstd` for 1 million samples per second
 
 The order compression algorithms is selected is configured in `stream.conf`, per `[API KEY]`, like this:
 
-```txt
+```conf
     compression algorithms order = zstd lz4 brotli gzip
 ```
 

--- a/docs/netdata-agent/sizing-netdata-agents/ram-requirements.md
+++ b/docs/netdata-agent/sizing-netdata-agents/ram-requirements.md
@@ -14,7 +14,7 @@ This number can be lowered by limiting the number of database tier or switching 
 
 The general formula, with the default configuration of database tiers, is:
 
-```conf
+```text
 memory = UNIQUE_METRICS x 16KiB + CONFIGURED_CACHES
 ```
 
@@ -22,7 +22,7 @@ The default `CONFIGURED_CACHES` is 32MiB.
 
 For 1 million concurrently collected time-series (independently of their data collection frequency), the memory required is:
 
-```conf
+```text
 UNIQUE_METRICS = 1000000
 CONFIGURED_CACHES = 32MiB
 

--- a/docs/netdata-agent/sizing-netdata-agents/ram-requirements.md
+++ b/docs/netdata-agent/sizing-netdata-agents/ram-requirements.md
@@ -14,7 +14,7 @@ This number can be lowered by limiting the number of database tier or switching 
 
 The general formula, with the default configuration of database tiers, is:
 
-```txt
+```conf
 memory = UNIQUE_METRICS x 16KiB + CONFIGURED_CACHES
 ```
 
@@ -22,7 +22,7 @@ The default `CONFIGURED_CACHES` is 32MiB.
 
 For 1 million concurrently collected time-series (independently of their data collection frequency), the memory required is:
 
-```txt
+```conf
 UNIQUE_METRICS = 1000000
 CONFIGURED_CACHES = 32MiB
 

--- a/docs/observability-centralization-points/logs-centralization-points-with-systemd-journald/active-journal-source-without-encryption.md
+++ b/docs/observability-centralization-points/logs-centralization-points-with-systemd-journald/active-journal-source-without-encryption.md
@@ -47,7 +47,7 @@ sudo systemctl enable --now systemd-journal-gatewayd.socket
 
 To use it, open your web browser and navigate to:
 
-```txt
+```url
 http://server.ip:19531/browse
 ```
 

--- a/docs/observability-centralization-points/logs-centralization-points-with-systemd-journald/passive-journal-centralization-with-encryption-using-self-signed-certificates.md
+++ b/docs/observability-centralization-points/logs-centralization-points-with-systemd-journald/passive-journal-centralization-with-encryption-using-self-signed-certificates.md
@@ -150,7 +150,7 @@ sudo apt-get install systemd-journal-remote
 
 Edit `/etc/systemd/journal-upload.conf` and set the IP address and the port of the server, like so:
 
-```conf
+```text
 [Upload]
 URL=https://centralization.server.ip:19532
 ```
@@ -165,7 +165,7 @@ sudo systemctl edit systemd-journal-upload.service
 
 At the top, add:
 
-```conf
+```text
 [Service]
 Restart=always
 ```

--- a/docs/observability-centralization-points/logs-centralization-points-with-systemd-journald/passive-journal-centralization-without-encryption.md
+++ b/docs/observability-centralization-points/logs-centralization-points-with-systemd-journald/passive-journal-centralization-without-encryption.md
@@ -74,7 +74,7 @@ sudo apt-get install systemd-journal-remote
 
 Edit `/etc/systemd/journal-upload.conf` and set the IP address and the port of the server, like so:
 
-```conf
+```text
 [Upload]
 URL=http://centralization.server.ip:19532
 ```
@@ -87,7 +87,7 @@ sudo systemctl edit systemd-journal-upload
 
 At the top, add:
 
-```conf
+```text
 [Service]
 Restart=always
 ```

--- a/docs/observability-centralization-points/metrics-centralization-points/configuration.md
+++ b/docs/observability-centralization-points/metrics-centralization-points/configuration.md
@@ -70,7 +70,7 @@ This example uses self-signed certificates.
 2. **Child node**  
    Update `stream.conf` to enable SSL/TLS and allow self-signed certificates. Append ':SSL' to the destination and uncomment 'ssl skip certificate verification'.
 
-    ```conf
+    ```text
     [stream]
         enabled = yes
         destination = 203.0.113.0:SSL

--- a/packaging/installer/methods/ansible.md
+++ b/packaging/installer/methods/ansible.md
@@ -63,7 +63,7 @@ The `hosts` file contains a list of IP addresses or hostnames that Ansible will 
 `hosts` file that comes with the repository contains two example IP addresses, which you should replace according to the
 IP address/hostname of your nodes.
 
-```conf
+```text
 203.0.113.0  hostname=node-01
 203.0.113.1  hostname=node-02 
 ```
@@ -76,7 +76,7 @@ omit the `hostname=` string entirely to use the system's default hostname.
 If you SSH into your nodes as a user other than `root`, you need to configure `hosts` according to those user names. Use
 the `ansible_user` variable to set the login user. For example:
 
-```conf
+```text
 203.0.113.0  hostname=ansible-01  ansible_user=example
 ```
 
@@ -86,7 +86,7 @@ If you use an SSH key other than `~/.ssh/id_rsa` for logging into your nodes, yo
 the `hosts` file with the `ansible_ssh_private_key_file` variable. For example, to log into a Lightsail instance using
 two different SSH keys supplied by AWS.
 
-```conf
+```text
 203.0.113.0  hostname=ansible-01  ansible_ssh_private_key_file=~/.ssh/LightsailDefaultKey-us-west-2.pem
 203.0.113.1  hostname=ansible-02  ansible_ssh_private_key_file=~/.ssh/LightsailDefaultKey-us-east-1.pem
 ```

--- a/packaging/installer/methods/aws.md
+++ b/packaging/installer/methods/aws.md
@@ -45,7 +45,7 @@ inbound rules**.
 
 Add a new rule with the following options:
 
-```conf
+```text
 Type: Custom TCP
 Protocol: TCP
 Port Range: 19999

--- a/packaging/installer/methods/azure.md
+++ b/packaging/installer/methods/azure.md
@@ -43,7 +43,7 @@ Sign in to the [Azure portal](https://portal.azure.com) and open the virtual mac
 
 Add a new rule with the following options:
 
-```conf
+```text
 Source: Any
 Source port ranges: 19999
 Destination: Any

--- a/packaging/installer/methods/gcp.md
+++ b/packaging/installer/methods/gcp.md
@@ -44,7 +44,7 @@ click **Create firewall rule**.
 The following configuration has previously worked for Netdata running on GCP instances
 ([see #7786](https://github.com/netdata/netdata/issues/7786)):
 
-```conf
+```text
 Name: <name>
 Type: Ingress
 Targets: <name-tag>

--- a/packaging/installer/methods/packages.md
+++ b/packaging/installer/methods/packages.md
@@ -81,7 +81,7 @@ These repositories are set up as what Debian calls ‘flat repositories’, and 
 
 As a result of this structure, the required APT sources entry for stable packages for Debian 11 (Bullseye) is:
 
-```txt
+```text
 deb http://repo.netdata.cloud/repos/stable/debian/ bullseye/
 ```
 

--- a/packaging/installer/methods/synology.md
+++ b/packaging/installer/methods/synology.md
@@ -43,7 +43,7 @@ installed. You'll have to do this manually:
     executable with `chmod 0755 /etc/rc.netdata`.
 2. Add or edit `/etc/rc.local` and add a line calling `/etc/rc.netdata` to have it start on boot:
 
-    ```conf
+    ```text
     # Netdata startup
     [ -x /etc/rc.netdata ] && /etc/rc.netdata start
     ```

--- a/packaging/installer/methods/systems.md
+++ b/packaging/installer/methods/systems.md
@@ -1,12 +1,3 @@
-<!--
-title: "Install on specific environments"
-description: "Netdata can be installed as a DEB/RPM package, a static binary, a docker container or from source"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/installer/methods/systems.md
-sidebar_label: "Install on specific environments"
-learn_status: "Published"
-learn_rel_path: "Installation/Install on specific environments"
--->
-
 # Install on specific environments
 
 This category contains specific instructions for some popular environments. 

--- a/packaging/makeself/README.md
+++ b/packaging/makeself/README.md
@@ -1,13 +1,3 @@
-<!--
-title: "Netdata static binary build"
-description: "Users can build the static 64-bit binary package that we ship with every release of the open-source Netdata Agent for debugging or specialize purposes."
-custom_edit_url: https://github.com/netdata/netdata/edit/master/packaging/makeself/README.md
-sidebar_label: "Static binary packages"
-learn_status: "Published"
-learn_rel_path: "Installation/Installation methods"
-sidebar_position: 30
--->
-
 # Netdata static binary build
 
 We publish pre-built static builds of Netdata for Linux systems. Currently, these are published for 64-bit x86, ARMv7,

--- a/src/aclk/README.md
+++ b/src/aclk/README.md
@@ -35,7 +35,7 @@ connecting to cloud](/src/claim/README.md).
 
 You can configure following keys in the `netdata.conf` section `[cloud]`:
 
-```conf
+```text
 [cloud]
     statistics = yes
     query thread count = 2

--- a/src/aclk/README.md
+++ b/src/aclk/README.md
@@ -35,10 +35,10 @@ connecting to cloud](/src/claim/README.md).
 
 You can configure following keys in the `netdata.conf` section `[cloud]`:
 
-```text
+```conf
 [cloud]
-  statistics = yes
-  query thread count = 2
+    statistics = yes
+    query thread count = 2
 ```
 
 - `statistics` enables/disables ACLK related statistics and their charts. You can disable this to save some space in the database and slightly reduce memory usage of Netdata Agent.

--- a/src/collectors/REFERENCE.md
+++ b/src/collectors/REFERENCE.md
@@ -27,26 +27,26 @@ This section features a list of Netdata's plugins, with a boolean setting to ena
 
 ```conf
 [plugins]
- # timex = yes
- # idlejitter = yes
- # netdata monitoring = yes
- # tc = yes
- # diskspace = yes
- # proc = yes
- # cgroups = yes
- # enable running new plugins = yes
- # check for new plugins every = 60
- # slabinfo = no
- # python.d = yes
- # perf = yes
- # ioping = yes
- # fping = yes
- # nfacct = yes
- # go.d = yes
- # apps = yes
- # ebpf = yes
- # charts.d = yes
- # statsd = yes
+    # timex = yes
+    # idlejitter = yes
+    # netdata monitoring = yes
+    # tc = yes
+    # diskspace = yes
+    # proc = yes
+    # cgroups = yes
+    # enable running new plugins = yes
+    # check for new plugins every = 60
+    # slabinfo = no
+    # python.d = yes
+    # perf = yes
+    # ioping = yes
+    # fping = yes
+    # nfacct = yes
+    # go.d = yes
+    # apps = yes
+    # ebpf = yes
+    # charts.d = yes
+    # statsd = yes
 ```
 
 By default, most plugins are enabled, so you don't need to enable them explicitly to use their collectors. To enable or

--- a/src/collectors/REFERENCE.md
+++ b/src/collectors/REFERENCE.md
@@ -25,7 +25,7 @@ You can enable or disable individual plugins by opening `netdata.conf` and scrol
 This section features a list of Netdata's plugins, with a boolean setting to enable or disable them. The exception is
 `statsd.plugin`, which has its own `[statsd]` section. Your `[plugins]` section should look similar to this:
 
-```conf
+```text
 [plugins]
     # timex = yes
     # idlejitter = yes

--- a/src/collectors/apps.plugin/README.md
+++ b/src/collectors/apps.plugin/README.md
@@ -8,6 +8,7 @@
 insightful breakdown of resource utilization:
 
 - **Tree** or **Category**: Grouped by their position in the process tree.
+<<<<<<< HEAD
    This is customizable and allows aggregation by process managers and 
    individual processes of interest. Allows also renaming the processes for
    presentation purposes.
@@ -25,6 +26,22 @@ subprocesses, such as shell scripts that fork hundreds or thousands of times
 per second. So, although processes may spawn short-lived sub-processes,
 `apps.plugin` will aggregate their resources utilization providing a holistic
 view of how resources are shared among the processes.
+=======
+   This is customizable and allows aggregation by process managers and individual
+   processes of interest. Allows also renaming the processes for presentation purposes.
+
+- **User**: Grouped by the effective user (UID) under which the processes run.
+
+- **Group**: Grouped by the effective group (GID) under which the processes run.
+
+## Short-Lived Process Handling
+
+`apps.plugin` accounts for resource utilization of both running and exited processes,
+capturing the impact of processes that spawn short-lived subprocesses, such as shell
+scripts that fork hundreds or thousands of times per second. So, although processes
+may spawn short lived sub-processes, `apps.plugin` will aggregate their resources
+utilization providing a holistic view of how resources are shared among the processes.
+>>>>>>> fedac6cde (apps plugin docs pass)
 
 ## Charts sections
 
@@ -34,10 +51,15 @@ on the dashboard.
 
 ### Custom Process Groups (Apps)
 
+<<<<<<< HEAD
 In this section, apps.plugin summarizes the resources consumed by all
 processes, grouped based on their position in the process tree and the groups
 provided in `/etc/netdata/apps_groups.conf`. You can edit this file using our
 [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config) script.
+=======
+In this section, apps.plugin summarizes the resources consumed by all processes, grouped based
+on the groups provided in `/etc/netdata/apps_groups.conf`. You can edit this file using our [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config) script.
+>>>>>>> fedac6cde (apps plugin docs pass)
 
 For this section, `apps.plugin` builds a process tree (much like `ps fax` does
 in Linux), and groups processes together (evaluating both child and parent
@@ -125,8 +147,12 @@ be once every 2 seconds.
 
 ## Configuration
 
+<<<<<<< HEAD
 The configuration file is `/etc/netdata/apps_groups.conf`. You can edit this
 file using our [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config) script.
+=======
+The configuration file is `/etc/netdata/apps_groups.conf`. You can edit this file using our [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config) script.
+>>>>>>> fedac6cde (apps plugin docs pass)
 
 ### Configuring process managers
 

--- a/src/collectors/apps.plugin/README.md
+++ b/src/collectors/apps.plugin/README.md
@@ -135,7 +135,7 @@ In such cases, you many need to lower its data collection frequency.
 
 To do this, edit `/etc/netdata/netdata.conf` and find this section:
 
-```txt
+```text
 [plugin:apps]
  # update every = 1
  # command options =
@@ -163,7 +163,7 @@ consider all their sub-processes, important to monitor.
 Process managers are configured in `apps_groups.conf` with the prefix
 `managers:`, like this:
 
-```txt
+```text
 managers: process1 process2 process3
 ```
 
@@ -187,7 +187,7 @@ the name of that filename.
 Interpreters are configured in `apps_groups.conf` with the prefix
 `interpreters:`, like this:
 
-```txt
+```text
 interpreters: process1 process2 process3
 ```
 
@@ -200,7 +200,7 @@ can be provided.
 
 The configuration file works accepts multiple lines, each having this format:
 
-```txt
+```text
 group: process1 process2 ...
 ```
 
@@ -249,7 +249,7 @@ set in the `netdata.conf` using the [`edit-config` script](/docs/netdata-agent/c
 
 For example, to disable user and user group charts you would set:
 
-```txt
+```text
 [plugin:apps]
   command options = without-users without-groups
 ```
@@ -301,7 +301,7 @@ but it will not be able to collect all the information.
 
 You can create badges that you can embed anywhere you like, with URLs like this:
 
-```txt
+```text
 https://your.netdata.ip:19999/api/v1/badge.svg?chart=apps.processes&dimensions=myapp&value_color=green%3E0%7Cred
 ```
 
@@ -357,7 +357,7 @@ If you check the total system CPU utilization, it says there is no idle CPU at a
 fails to provide a breakdown of the CPU consumption in the system. The sum of the CPU utilization
 of all processes reported by `top`, is 15.6%.
 
-```txt
+```text
 top - 18:46:28 up 3 days, 20:14,  2 users,  load average: 0.22, 0.05, 0.02
 Tasks:  76 total,   2 running,  74 sleeping,   0 stopped,   0 zombie
 %Cpu(s): 32.8 us, 65.6 sy,  0.0 ni,  0.0 id,  0.0 wa,  1.3 hi,  0.3 si,  0.0 st

--- a/src/collectors/charts.d.plugin/README.md
+++ b/src/collectors/charts.d.plugin/README.md
@@ -24,7 +24,7 @@ By default, `charts.d.plugin` is not included as part of the install when using 
 
 In this file, you can place statements like this:
 
-```conf
+```text
 enable_all_charts="yes"
 X="yes"
 Y="no"

--- a/src/collectors/charts.d.plugin/example/README.md
+++ b/src/collectors/charts.d.plugin/example/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Example"
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/src/collectors/charts.d.plugin/example/README.md"
-sidebar_label: "example-charts.d.plugin"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Integrations/Monitor/Mock Collectors"
--->
-
 # Example
 
 If you want to understand how charts.d data collector functions, check out the [charts.d example](https://raw.githubusercontent.com/netdata/netdata/master/src/collectors/charts.d.plugin/example/example.chart.sh). 

--- a/src/collectors/ebpf.plugin/README.md
+++ b/src/collectors/ebpf.plugin/README.md
@@ -49,7 +49,7 @@ To enable or disable the entire eBPF collector:
 3. Enable the collector by scrolling down to the `[plugins]` section. Uncomment the line `ebpf` (not
     `ebpf_process`) and set it to `yes`.
 
-    ```conf
+    ```text
     [plugins]
        ebpf = yes
     ```
@@ -101,7 +101,7 @@ interact with the Linux kernel.
 
 If you want to enable `apps.plugin` integration, change the "apps" setting to "yes".
 
-```conf
+```text
 [global]
    apps = yes
 ```
@@ -115,7 +115,7 @@ interacts with the Linux kernel.
 The integration with `cgroups.plugin` is disabled by default to avoid creating overhead on your system. If you want to
 _enable_ the integration with `cgroups.plugin`, change the `cgroups` setting to `yes`.
 
-```conf
+```text
 [global]
    cgroups = yes
 ```
@@ -296,7 +296,7 @@ are divided in the following sections:
 
 You can configure the information shown with function `ebpf_socket` using the settings in this section.
 
-```conf
+```text
 [network connections]
     enabled = yes
     resolve hostname ips = no
@@ -338,7 +338,7 @@ section.
 For example, Netdata's default port (`19999`) is not listed in `/etc/services`. To associate that port with the Netdata
 service in network connection charts, and thus see the name of the service instead of its port, define it:
 
-```conf
+```text
 [service name]
     19999 = Netdata
 ```
@@ -347,7 +347,7 @@ service in network connection charts, and thus see the name of the service inste
 
 The sync configuration has specific options to disable monitoring for syscalls.  All syscalls are monitored by default.
 
-```conf
+```text
 [syscalls]
     sync = yes
     msync = yes
@@ -362,7 +362,7 @@ The sync configuration has specific options to disable monitoring for syscalls. 
 The filesystem configuration has specific options to disable monitoring for filesystems; by default, all filesystems are
 monitored.
 
-```conf
+```text
 [filesystem]
     btrfsdist = yes
     ext4dist = yes
@@ -620,7 +620,7 @@ in [disk latency](#disk) charts.
 By default, MD flush is disabled. To enable it, configure your
 `/etc/netdata/ebpf.d.conf` file as:
 
-```conf
+```text
 [global]
     mdflush = yes
 ```
@@ -940,7 +940,7 @@ This will create two new files: `netdata_ebpf.te` and `netdata_ebpf.mod`.
 Edit the `netdata_ebpf.te` file to change the options `class` and `allow`. You should have the following at the end of
 the `netdata_ebpf.te` file.
 
-```conf
+```text
 module netdata_ebpf 1.0;
 require {
         type unconfined_service_t;

--- a/src/collectors/log2journal/README.md
+++ b/src/collectors/log2journal/README.md
@@ -80,7 +80,7 @@ We have an nginx server logging in this standard combined log format:
 
 First, let's find the right pattern for `log2journal`. We ask ChatGPT:
 
-```txt
+```text
 My nginx log uses this log format:
 
 log_format access '$remote_addr - $remote_user [$time_local] '
@@ -484,7 +484,7 @@ tail -F /var/log/nginx/access.log |\
 
 Create the file `/etc/systemd/system/nginx-logs.service` (change `/path/to/nginx.yaml` to the right path):
 
-```txt
+```text
 [Unit]
 Description=NGINX Log to Systemd Journal
 After=network.target
@@ -575,7 +575,7 @@ If on other hand your organization prefers to maintain the full logs and control
 
 ## `log2journal` options
 
-```txt
+```text
 
 Netdata log2journal v1.43.0-341-gdac4df856
 

--- a/src/collectors/proc.plugin/README.md
+++ b/src/collectors/proc.plugin/README.md
@@ -267,7 +267,7 @@ If your system has more than 50 processors and you would like to see the CPU the
 state charts that are automatically disabled, you can set the following boolean options in the
 `[plugin:proc:/proc/stat]` section.
 
-```conf
+```text
     keep per core files open = yes
     keep cpuidle files open = yes
     core_throttle_count = yes
@@ -319,7 +319,7 @@ each state.
 
 ### Configuration
 
-```conf
+```text
 [plugin:proc:/proc/vmstat]
  filename to monitor = /proc/vmstat
  swap i/o = auto
@@ -363,7 +363,7 @@ By default Netdata will enable monitoring metrics only when they are not zero. I
 
 The settings for monitoring wireless is in the `[plugin:proc:/proc/net/wireless]` section of your `netdata.conf` file.
 
-```conf
+```text
     status for all interfaces = yes
     quality for all interfaces = yes
     discarded packets for all interfaces = yes
@@ -408,7 +408,7 @@ The tricky ones are `inbound packets dropped` and `inbound packets dropped ratio
 
 Module configuration:
 
-```conf
+```text
 [plugin:proc:/proc/net/dev]
     # filename to monitor = /proc/net/dev 
     # path to get virtual interfaces = /sys/devices/virtual/net/%s

--- a/src/collectors/proc.plugin/README.md
+++ b/src/collectors/proc.plugin/README.md
@@ -408,21 +408,21 @@ The tricky ones are `inbound packets dropped` and `inbound packets dropped ratio
 
 Module configuration:
 
-```txt
+```conf
 [plugin:proc:/proc/net/dev]
-  # filename to monitor = /proc/net/dev
-  # path to get virtual interfaces = /sys/devices/virtual/net/%s
-  # path to get net device speed = /sys/class/net/%s/speed
-  # enable new interfaces detected at runtime = auto
-  # bandwidth for all interfaces = auto
-  # packets for all interfaces = auto
-  # errors for all interfaces = auto
-  # drops for all interfaces = auto
-  # fifo for all interfaces = auto
-  # compressed packets for all interfaces = auto
-  # frames, collisions, carrier counters for all interfaces = auto
-  # disable by default interfaces matching = lo fireqos* *-ifb
-  # refresh interface speed every seconds = 10
+    # filename to monitor = /proc/net/dev 
+    # path to get virtual interfaces = /sys/devices/virtual/net/%s
+    # path to get net device speed = /sys/class/net/%s/speed
+    # enable new interfaces detected at runtime = auto
+    # bandwidth for all interfaces = auto
+    # packets for all interfaces = auto
+    # errors for all interfaces = auto
+    # drops for all interfaces = auto
+    # fifo for all interfaces = auto
+    # compressed packets for all interfaces = auto
+    # frames, collisions, carrier counters for all interfaces = auto
+    # disable by default interfaces matching = lo fireqos* *-ifb
+    # refresh interface speed every seconds = 10
 ```
 
 Per interface configuration:

--- a/src/collectors/proc.plugin/README.md
+++ b/src/collectors/proc.plugin/README.md
@@ -118,7 +118,7 @@ mv netdata.conf.new netdata.conf
 
 Then edit `netdata.conf` and find the following section. This is the basic plugin configuration.
 
-```txt
+```text
 [plugin:proc:/proc/diskstats]
   # enable new disks detected at runtime = yes
   # performance metrics for physical disks = auto
@@ -152,7 +152,7 @@ Then edit `netdata.conf` and find the following section. This is the basic plugi
 
 For each virtual disk, physical disk and partition you will have a section like this:
 
-```txt
+```text
 [plugin:proc:/proc/diskstats:sda]
  # enable = yes
  # enable performance metrics = auto
@@ -180,14 +180,14 @@ After saving `/etc/netdata/netdata.conf`, restart your Netdata to apply them.
 
 You can pretty easy disable performance metrics for individual device, for ex.:
 
-```txt
+```text
 [plugin:proc:/proc/diskstats:sda]
  enable performance metrics = no
 ```
 
 But sometimes you need disable performance metrics for all devices with the same type, to do it you need to figure out device type from `/proc/diskstats` for ex.:
 
-```txt
+```text
    7       0 loop0 1651 0 3452 168 0 0 0 0 0 8 168
    7       1 loop1 4955 0 11924 880 0 0 0 0 0 64 880
    7       2 loop2 36 0 216 4 0 0 0 0 0 4 4
@@ -200,7 +200,7 @@ But sometimes you need disable performance metrics for all devices with the same
 All zram devices starts with `251` number and all loop devices starts with `7`.
 So, to disable performance metrics for all loop devices you could add `performance metrics for disks with major 7 = no` to `[plugin:proc:/proc/diskstats]` section.
 
-```txt
+```text
 [plugin:proc:/proc/diskstats]
        performance metrics for disks with major 7 = no
 ```
@@ -236,7 +236,7 @@ So, to disable performance metrics for all loop devices you could add `performan
 
 #### configuration
 
-```txt
+```text
 [plugin:proc:/proc/mdstat]
   # faulty devices = yes
   # nonredundant arrays availability = yes
@@ -427,7 +427,7 @@ Module configuration:
 
 Per interface configuration:
 
-```txt
+```text
 [plugin:proc:/proc/net/dev:enp0s3]
   # enabled = yes
   # virtual = no
@@ -511,7 +511,7 @@ and metrics:
 
 ### configuration
 
-```txt
+```text
 [plugin:proc:/sys/class/power_supply]
   # battery capacity = yes
   # battery charge = no
@@ -566,7 +566,7 @@ If your vendor is supported, you'll also get HW-Counters statistics. These being
 
 Default configuration will monitor only enabled infiniband ports, and refresh newly activated or created ports every 30 seconds
 
-```txt
+```text
 [plugin:proc:/sys/class/infiniband]
   # dirname to monitor = /sys/class/infiniband
   # bandwidth counters = yes
@@ -602,7 +602,7 @@ The following charts will be provided:
 
 The `drm` path can be configured if it differs from the default:
 
-```txt
+```text
 [plugin:proc:/sys/class/drm]
   # directory to monitor = /sys/class/drm
 ```
@@ -626,7 +626,7 @@ As far as the message queue charts are dynamic, sane limits are applied for the 
 
 ### configuration
 
-```txt
+```text
 [plugin:proc:ipc]
   # message queues = yes
   # semaphore totals = yes

--- a/src/collectors/profile.plugin/README.md
+++ b/src/collectors/profile.plugin/README.md
@@ -16,7 +16,7 @@ Edit the `netdata.conf` configuration file using [`edit-config`](/docs/netdata-a
 
 Scroll down to the `[plugin:profile]` section to find the available options:
 
-```conf
+```text
 [plugin:profile]
     update every = 5
     number of charts = 200

--- a/src/collectors/profile.plugin/README.md
+++ b/src/collectors/profile.plugin/README.md
@@ -16,13 +16,13 @@ Edit the `netdata.conf` configuration file using [`edit-config`](/docs/netdata-a
 
 Scroll down to the `[plugin:profile]` section to find the available options:
 
-```txt
+```conf
 [plugin:profile]
-  update every = 5
-  number of charts = 200
-  number of dimensions per chart = 5
-  seconds to backfill = 86400
-  number of threads = 16
+    update every = 5
+    number of charts = 200
+    number of dimensions per chart = 5
+    seconds to backfill = 86400
+    number of threads = 16
 ```
 
 The `number of threads` option will create the specified number of collection

--- a/src/collectors/python.d.plugin/haproxy/README.md
+++ b/src/collectors/python.d.plugin/haproxy/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "HAProxy monitoring with Netdata"
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/src/collectors/python.d.plugin/haproxy/README.md"
-sidebar_label: "haproxy-python.d.plugin"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Integrations/Monitor/Webapps"
--->
-
 # HAProxy collector
 
 Monitors frontend and backend metrics such as bytes in, bytes out, sessions current, sessions in queue current.

--- a/src/collectors/python.d.plugin/traefik/README.md
+++ b/src/collectors/python.d.plugin/traefik/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Traefik monitoring with Netdata"
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/src/collectors/python.d.plugin/traefik/README.md"
-sidebar_label: "traefik-python.d.plugin"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Integrations/Monitor/Webapps"
--->
-
 # Traefik collector
 
 Uses the `health` API to provide statistics.

--- a/src/collectors/statsd.plugin/README.md
+++ b/src/collectors/statsd.plugin/README.md
@@ -785,7 +785,7 @@ sudo ./edit-config statsd.d/k6.conf
 
 Copy the following configuration into your file as a starting point.
 
-```conf
+```text
 [app]
     name = k6
     metrics = k6*

--- a/src/collectors/statsd.plugin/README.md
+++ b/src/collectors/statsd.plugin/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "StatsD"
-description: "The Netdata Agent is a fully-featured StatsD server that collects metrics from any custom application and visualizes them in real-time."
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/src/collectors/statsd.plugin/README.md"
-sidebar_label: "StatsD"
-learn_status: "Published"
-learn_rel_path: "Integrations/Monitor/Anything"
--->
-
 # StatsD
 
 [StatsD](https://github.com/statsd/statsd) is a system to collect data from any application. Applications send metrics to it, 

--- a/src/collectors/statsd.plugin/asterisk.md
+++ b/src/collectors/statsd.plugin/asterisk.md
@@ -1,11 +1,3 @@
-<!--
-title: "Asterisk monitoring with Netdata"
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/src/collectors/statsd.plugin/asterisk.md"
-sidebar_label: "Asterisk"
-learn_status: "Published"
-learn_rel_path: "Integrations/Monitor/VoIP"
--->
-
 # Asterisk collector
 
 Monitors [Asterisk](https://www.asterisk.org/) dialplan application's statistics.

--- a/src/collectors/statsd.plugin/k6.md
+++ b/src/collectors/statsd.plugin/k6.md
@@ -1,11 +1,3 @@
-<!--
-title: "K6 load test monitoring with Netdata"
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/src/collectors/statsd.plugin/k6.md"
-sidebar_label: "K6 Load Testing"
-learn_status: "Published"
-learn_rel_path: "Integrations/Monitor/apps"
--->
-
 # K6 load test collector
 
 Monitors the impact of load testing experiments performed with [K6](https://k6.io/).

--- a/src/collectors/systemd-journal.plugin/active_journal_centralization_guide_no_encryption.md
+++ b/src/collectors/systemd-journal.plugin/active_journal_centralization_guide_no_encryption.md
@@ -47,7 +47,7 @@ sudo systemctl enable --now systemd-journal-gatewayd.socket
 
 To use it, open your web browser and navigate to:
 
-```txt
+```text
 http://server.ip:19531/browse
 ```
 

--- a/src/collectors/systemd-journal.plugin/passive_journal_centralization_guide_no_encryption.md
+++ b/src/collectors/systemd-journal.plugin/passive_journal_centralization_guide_no_encryption.md
@@ -74,7 +74,7 @@ sudo apt-get install systemd-journal-remote
 
 Edit `/etc/systemd/journal-upload.conf` and set the IP address and the port of the server, like so:
 
-```conf
+```text
 [Upload]
 URL=http://centralization.server.ip:19532
 ```
@@ -87,7 +87,7 @@ sudo systemctl edit systemd-journal-upload
 
 At the top, add:
 
-```conf
+```text
 [Service]
 Restart=always
 ```

--- a/src/collectors/systemd-journal.plugin/passive_journal_centralization_guide_self_signed_certs.md
+++ b/src/collectors/systemd-journal.plugin/passive_journal_centralization_guide_self_signed_certs.md
@@ -150,7 +150,7 @@ sudo apt-get install systemd-journal-remote
 
 Edit `/etc/systemd/journal-upload.conf` and set the IP address and the port of the server, like so:
 
-```conf
+```text
 [Upload]
 URL=https://centralization.server.ip:19532
 ```
@@ -165,7 +165,7 @@ sudo systemctl edit systemd-journal-upload.service
 
 At the top, add:
 
-```conf
+```text
 [Service]
 Restart=always
 ```

--- a/src/collectors/tc.plugin/integrations/tc_qos_classes.md
+++ b/src/collectors/tc.plugin/integrations/tc_qos_classes.md
@@ -93,7 +93,7 @@ There are no alerts configured by default for this integration.
 
 In order to view tc classes, you need to create the file `/etc/netdata/tc-qos-helper.conf` with content:
 
-```conf
+```text
 tc_show="class"
 ```
 
@@ -144,7 +144,7 @@ A basic example configuration using classes defined in `/etc/iproute2/tc_cls`.
 
 An example of class IDs mapped to names in that file can be:
 
-```conf
+```text
 2:1 Standard
 2:8 LowPriorityData
 2:10 HighThroughputData

--- a/src/collectors/tc.plugin/metadata.yaml
+++ b/src/collectors/tc.plugin/metadata.yaml
@@ -41,7 +41,7 @@ modules:
             description: |
               In order to view tc classes, you need to create the file `/etc/netdata/tc-qos-helper.conf` with content:
 
-              ```conf
+              ```text
               tc_show="class"
               ```
       configuration:
@@ -74,7 +74,7 @@ modules:
 
                 An example of class IDs mapped to names in that file can be:
 
-                ```conf
+                ```text
                 2:1 Standard
                 2:8 LowPriorityData
                 2:10 HighThroughputData

--- a/src/daemon/README.md
+++ b/src/daemon/README.md
@@ -191,7 +191,7 @@ issues with gaps in charts on busy systems while still keeping the impact on the
 
 You can set Netdata scheduling policy in `netdata.conf`, like this:
 
-```conf
+```text
 [global]
   process scheduling policy = idle
 ```
@@ -213,7 +213,7 @@ For more information see `man sched`.
 
 Once the policy is set to one of `rr` or `fifo`, the following will appear:
 
-```conf
+```text
 [global]
     process scheduling priority = 0
 ```
@@ -225,7 +225,7 @@ important.
 
 When the policy is set to `other`, `nice`, or `batch`, the following will appear:
 
-```conf
+```text
 [global]
     process nice level = 19
 ```
@@ -259,7 +259,7 @@ Run `systemctl daemon-reload` to reload these changes.
 Now, tell Netdata to keep these settings, as set by systemd, by editing
 `netdata.conf` and setting:
 
-```conf
+```text
 [global]
     process scheduling policy = keep
 ```
@@ -272,7 +272,7 @@ will be maintained by netdata.
 On a system that is not based on systemd, to make Netdata run with nice level -1 (a little bit higher to the default for
 all programs), edit `netdata.conf` and set:
 
-```conf
+```text
 [global]
   process scheduling policy = other
   process nice level = -1
@@ -285,7 +285,7 @@ then [restart Netdata](/docs/netdata-agent/start-stop-restart.md):
 On a system that is based on systemd, to make Netdata run with nice level -1 (a little bit higher to the default for all
 programs), edit `netdata.conf` and set:
 
-```conf
+```text
 [global]
   process scheduling policy = keep
 ```

--- a/src/daemon/README.md
+++ b/src/daemon/README.md
@@ -160,7 +160,7 @@ Data stored inside this file follows pattern already described for `error.log`.
 
 The `access.log` logs web requests. The format is:
 
-```txt
+```text
 DATE: ID: (sent/all = SENT_BYTES/ALL_BYTES bytes PERCENT_COMPRESSION%, prep/sent/total PREP_TIME/SENT_TIME/TOTAL_TIME ms): ACTION CODE URL
 ```
 

--- a/src/daemon/config/README.md
+++ b/src/daemon/config/README.md
@@ -1,13 +1,3 @@
-<!--
-title: "Daemon configuration"
-description: "The Netdata Agent's daemon is installed preconfigured to collect thousands of metrics every second, but is highly configurable for real-world workloads."
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/src/daemon/config/README.md"
-sidebar_label: "Daemon"
-learn_status: "Published"
-learn_rel_path: "Configuration"
-learn_doc_purpose: "Explain the daemon options, the log files, the process scheduling, virtual memory, explain how the netdata.conf is used and backlink to the netdata.conf file reference"
--->
-
 # Daemon configuration
 
 <details>

--- a/src/database/README.md
+++ b/src/database/README.md
@@ -36,7 +36,7 @@ So,
 
 You can select the database mode by editing `netdata.conf` and setting:
 
-```conf
+```text
 [db]
   # dbengine (default), ram (the default if dbengine not available), alloc, none
   mode = dbengine

--- a/src/database/ram/README.md
+++ b/src/database/ram/README.md
@@ -1,11 +1,1 @@
-<!--
-title: "RAM database modes"
-description: "Netdata's RAM database modes."
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/database/ram/README.md
-sidebar_label: "RAM database modes"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Database"
--->
-
 # RAM database modes

--- a/src/exporting/README.md
+++ b/src/exporting/README.md
@@ -106,7 +106,7 @@ different.
 You can configure each connector individually using the available [options](#options). The
 `[graphite:my_graphite_instance]` block contains examples of some of these additional options in action.
 
-```conf
+```text
 [exporting:global]
     enabled = yes
     send configured labels = no
@@ -213,13 +213,13 @@ Configure individual connectors and override any global settings with the follow
 
      Example IPv4:
 
-```conf
+```text
    destination = 10.11.14.2:4242 10.11.14.3:4242 10.11.14.4:4242
 ```
 
    Example IPv6 and IPv4 together:
 
-```conf
+```text
    destination = [ffff:...:0001]:2003 10.11.12.1:2003
 ```
 

--- a/src/exporting/README.md
+++ b/src/exporting/README.md
@@ -52,14 +52,14 @@ connector to enable and configure for your database of choice.
 Netdata can filter metrics, to send only a subset of the collected metrics. You can use the
 configuration file
 
-```txt
+```text
 [prometheus:exporter]
     send charts matching = system.*
 ```
 
 or the URL parameter `filter` in the `allmetrics` API call.
 
-```txt
+```text
 http://localhost:19999/api/v1/allmetrics?format=shell&filter=system.*
 ```
 

--- a/src/exporting/TIMESCALE.md
+++ b/src/exporting/TIMESCALE.md
@@ -15,13 +15,13 @@ To get started archiving metrics to TimescaleDB right away, check out Mahlon's [
 repository](https://github.com/mahlonsmith/netdata-timescale-relay) on GitHub. Please be aware that backends subsystem
 was removed and Netdata configuration should be moved to the new `exporting.conf` configuration file. Use
 
-```conf
+```text
 [json:my_instance]
 ```
 
 in `exporting.conf` instead of
 
-```conf
+```text
 [backend]
     type = json
 ```

--- a/src/exporting/WALKTHROUGH.md
+++ b/src/exporting/WALKTHROUGH.md
@@ -137,7 +137,7 @@ point to talk about Prometheus's data model which can be viewed here: <https://p
 As explained we have two key elements in Prometheus metrics. We have the _metric_ and its _labels_. Labels allow for
 granularity between metrics. Let's use our previous example to further explain.
 
-```conf
+```text
 netdata_disk_space_GiB_average{chart="disk_space._run",dimension="avail",family="/run",mount_point="/run",filesystem="tmpfs",mount_root="/"} 0.0298195 1684951093000
 ```
 
@@ -193,7 +193,7 @@ across a section of metrics with the first comments  `# COMMENT homogeneous char
 family "cpu", units "percentage"` followed by the metrics. This is a good start now let us drill down to the specific
 metric we would like to graph.
 
-```conf
+```text
 # COMMENT
 netdata_system_cpu_percentage_average: dimension "system", value is percentage, gauge, dt 1501275951 to 1501275951 inclusive
 netdata_system_cpu_percentage_average{chart="system.cpu",family="cpu",dimension="system"} 0.0000000 1501275951000

--- a/src/exporting/prometheus/README.md
+++ b/src/exporting/prometheus/README.md
@@ -203,7 +203,7 @@ interrupts, QoS classes, statsd synthetic charts, etc.
 
 The default is controlled in `exporting.conf`:
 
-```conf
+```text
 [prometheus:exporter]
 	send names instead of ids = yes | no
 ```
@@ -217,7 +217,7 @@ You can overwrite it from Prometheus, by appending to the URL:
 
 Netdata can filter the metrics it sends to Prometheus with this setting:
 
-```conf
+```text
 [prometheus:exporter]
 	send charts matching = *
 ```
@@ -233,7 +233,7 @@ used.
 
 Netdata sends all metrics prefixed with `netdata_`. You can change this in `netdata.conf`, like this:
 
-```conf
+```text
 [prometheus:exporter]
 	prefix = netdata
 ```

--- a/src/go/pkg/matcher/README.md
+++ b/src/go/pkg/matcher/README.md
@@ -1,11 +1,3 @@
-<!--
-title: "matcher"
-custom_edit_url: "/src/go/plugin/go.d/pkg/matcher/README.md"
-sidebar_label: "matcher"
-learn_status: "Published"
-learn_rel_path: "Developers/External plugins/go.d.plugin/Helper Packages"
--->
-
 # matcher
 ## Supported Format
 

--- a/src/go/plugin/go.d/modules/bind/README.md
+++ b/src/go/plugin/go.d/modules/bind/README.md
@@ -1,13 +1,3 @@
-<!--
-title: "Bind9 monitoring with Netdata"
-description: "Monitor the health and performance of Bind9 DNS servers with zero configuration, per-second metric granularity, and interactive visualizations."
-custom_edit_url: "https://github.com/netdata/go.d.plugin/edit/master/modules/bind/README.md"
-sidebar_label: "Bind9"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Integrations/Monitor/Webapps"
--->
-
 # Bind9 collector
 
 [`Bind9`](https://www.isc.org/bind/) (or named) is a very flexible, full-featured DNS system.

--- a/src/go/plugin/go.d/pkg/README.md
+++ b/src/go/plugin/go.d/pkg/README.md
@@ -1,11 +1,3 @@
-<!--
-title: "Helper Packages"
-custom_edit_url: "/src/go/plugin/go.d/pkg/README.md"
-sidebar_label: "Helper Packages"
-learn_status: "Published"
-learn_rel_path: "Developers/External plugins/go.d.plugin/Helper Packages"
--->
-
 # Helper Packages
 
 - if you need IP ranges consider to

--- a/src/go/plugin/go.d/pkg/iprange/README.md
+++ b/src/go/plugin/go.d/pkg/iprange/README.md
@@ -1,11 +1,3 @@
-<!--
-title: "iprange"
-custom_edit_url: "/src/go/plugin/go.d/pkg/iprange/README.md"
-sidebar_label: "iprange"
-learn_status: "Published"
-learn_rel_path: "Developers/External plugins/go.d.plugin/Helper Packages"
--->
-
 # iprange
 
 This package helps you to work with IP ranges.

--- a/src/go/plugin/go.d/pkg/prometheus/selector/README.md
+++ b/src/go/plugin/go.d/pkg/prometheus/selector/README.md
@@ -1,11 +1,3 @@
-<!--
-title: "Time series selector"
-custom_edit_url: "/src/go/plugin/go.d/pkg/prometheus/selector/README.md"
-sidebar_label: "Time series selector"
-learn_status: "Published"
-learn_rel_path: "Developers/External plugins/go.d.plugin/Helper Packages"
--->
-
 # Time series selector
 
 Selectors allow selecting and filtering of a set of time series.

--- a/src/health/notifications/README.md
+++ b/src/health/notifications/README.md
@@ -29,7 +29,7 @@ It uses **roles**. For example `sysadmin`, `webmaster`, `dba`, etc.
 
 Each alert is assigned to one or more roles, using the `to` line of the alert  configuration. For example, here is the alert configuration for `ram.conf` that defaults to the role `sysadmin`:
 
-```conf
+```text
     alarm: ram_in_use
        on: system.ram
     class: Utilization
@@ -52,7 +52,7 @@ Then `alarm-notify.sh` uses its own configuration file `health_alarm_notify.conf
 Here is an example, of the `sysadmin`'s role recipients for the email notification.  
 You can send the notification to multiple recipients by separating the emails with a space.
 
-```conf
+```text
 
 ###############################################################################
 # RECIPIENTS PER ROLE
@@ -84,7 +84,7 @@ You can edit `health_alarm_notify.conf` using the `edit-config` script to config
 
 - **Recipients** per role per notification method
 
-     ```conf
+     ```text
      role_recipients_email[sysadmin]="${DEFAULT_RECIPIENT_EMAIL}"
      role_recipients_pushover[sysadmin]="${DEFAULT_RECIPIENT_PUSHOVER}"
      role_recipients_pushbullet[sysadmin]="${DEFAULT_RECIPIENT_PUSHBULLET}"
@@ -132,7 +132,7 @@ When you define recipients per role for notification methods, you can append `|c
 In the following examples, the first recipient receives all the alerts, while the second one receives only notifications for alerts that have at some point become critical.
 The second user may still receive warning and clear notifications, but only for the event that previously caused a critical alert.
 
-```conf
+```text
  email      : "user1@example.com user2@example.com|critical"
  pushover   : "2987343...9437837 8756278...2362736|critical"
  telegram   : "111827421 112746832|critical"
@@ -158,7 +158,7 @@ This works for all notification methods (including the default recipients).
 If you need to send curl based notifications (pushover, pushbullet, slack, alerta,
 flock, discord, telegram) via a proxy, you should set these variables to your proxy address:
 
-```conf
+```text
 export http_proxy="http://10.0.0.1:3128/"
 export https_proxy="http://10.0.0.1:3128/"
 ```
@@ -173,7 +173,7 @@ If you have an Internet facing netdata (or you have copied the images/ folder
 of netdata to your web server), set its URL here, to fetch the notification
 images from it.
 
-```conf
+```text
 images_base_url="http://my.public.netdata.server:19999"
 ```
 

--- a/src/health/notifications/alerta/README.md
+++ b/src/health/notifications/alerta/README.md
@@ -71,7 +71,7 @@ You will need an API key to send messages from any source, if Alerta is configur
 
 The `DEFAULT_RECIPIENT_CUSTOM` can be edited in the following entries at the bottom of the same file:
 
-```conf
+```text
 role_recipients_alerta[sysadmin]="Systems"
 role_recipients_alerta[domainadmin]="Domains"
 role_recipients_alerta[dba]="Databases Systems"

--- a/src/health/notifications/alerta/metadata.yaml
+++ b/src/health/notifications/alerta/metadata.yaml
@@ -58,7 +58,7 @@
             detailed_description: |
               The `DEFAULT_RECIPIENT_CUSTOM` can be edited in the following entries at the bottom of the same file:
 
-              ```conf
+              ```text
               role_recipients_alerta[sysadmin]="Systems"
               role_recipients_alerta[domainadmin]="Domains"
               role_recipients_alerta[dba]="Databases Systems"

--- a/src/health/notifications/awssns/README.md
+++ b/src/health/notifications/awssns/README.md
@@ -124,7 +124,7 @@ All roles will default to this variable if left unconfigured.
 
 You can have different recipient Topics per **role**, by editing `DEFAULT_RECIPIENT_AWSSNS` with the Topic ARN you want, in the following entries at the bottom of the same file:
 
-```conf
+```text
 role_recipients_awssns[sysadmin]="arn:aws:sns:us-east-2:123456789012:Systems"
 role_recipients_awssns[domainadmin]="arn:aws:sns:us-east-2:123456789012:Domains"
 role_recipients_awssns[dba]="arn:aws:sns:us-east-2:123456789012:Databases"
@@ -143,7 +143,7 @@ role_recipients_awssns[sitemgr]="arn:aws:sns:us-east-2:123456789012:Sites"
 An example working configuration would be:
 
 ```yaml
-```conf
+```text
 #------------------------------------------------------------------------------
 # Amazon SNS notifications
 

--- a/src/health/notifications/awssns/metadata.yaml
+++ b/src/health/notifications/awssns/metadata.yaml
@@ -104,7 +104,7 @@
 
               You can have different recipient Topics per **role**, by editing `DEFAULT_RECIPIENT_AWSSNS` with the Topic ARN you want, in the following entries at the bottom of the same file:
 
-              ```conf
+              ```text
               role_recipients_awssns[sysadmin]="arn:aws:sns:us-east-2:123456789012:Systems"
               role_recipients_awssns[domainadmin]="arn:aws:sns:us-east-2:123456789012:Domains"
               role_recipients_awssns[dba]="arn:aws:sns:us-east-2:123456789012:Databases"
@@ -122,7 +122,7 @@
               enabled: false
             description: 'An example working configuration would be:'
             config: |
-              ```conf
+              ```text
               #------------------------------------------------------------------------------
               # Amazon SNS notifications
 

--- a/src/health/notifications/discord/README.md
+++ b/src/health/notifications/discord/README.md
@@ -61,7 +61,7 @@ The following options can be defined for this notification
 
 All roles will default to this variable if left unconfigured.
 You can then have different channels per role, by editing `DEFAULT_RECIPIENT_DISCORD` with the channel you want, in the following entries at the bottom of the same file:
-```conf
+```text
 role_recipients_discord[sysadmin]="systems"
 role_recipients_discord[domainadmin]="domains"
 role_recipients_discord[dba]="databases systems"

--- a/src/health/notifications/discord/metadata.yaml
+++ b/src/health/notifications/discord/metadata.yaml
@@ -45,7 +45,7 @@
             detailed_description: |
               All roles will default to this variable if left unconfigured.
               You can then have different channels per role, by editing `DEFAULT_RECIPIENT_DISCORD` with the channel you want, in the following entries at the bottom of the same file:
-              ```conf
+              ```text
               role_recipients_discord[sysadmin]="systems"
               role_recipients_discord[domainadmin]="domains"
               role_recipients_discord[dba]="databases systems"

--- a/src/health/notifications/email/README.md
+++ b/src/health/notifications/email/README.md
@@ -60,7 +60,7 @@ The following options can be defined for this notification
 
 All roles will default to this variable if left unconfigured.
 The `DEFAULT_RECIPIENT_CUSTOM` can be edited in the following entries at the bottom of the same file:
-```conf
+```text
 role_recipients_email[sysadmin]="systems@example.com"
 role_recipients_email[domainadmin]="domains@example.com"
 role_recipients_email[dba]="databases@example.com systems@example.com"

--- a/src/health/notifications/email/metadata.yaml
+++ b/src/health/notifications/email/metadata.yaml
@@ -44,7 +44,7 @@
             detailed_description: |
               All roles will default to this variable if left unconfigured.
               The `DEFAULT_RECIPIENT_CUSTOM` can be edited in the following entries at the bottom of the same file:
-              ```conf
+              ```text
               role_recipients_email[sysadmin]="systems@example.com"
               role_recipients_email[domainadmin]="domains@example.com"
               role_recipients_email[dba]="databases@example.com systems@example.com"

--- a/src/health/notifications/flock/README.md
+++ b/src/health/notifications/flock/README.md
@@ -59,7 +59,7 @@ The following options can be defined for this notification
 ##### DEFAULT_RECIPIENT_FLOCK
 
 You can have different channels per role, by editing DEFAULT_RECIPIENT_FLOCK with the channel you want, in the following entries at the bottom of the same file:
-```conf
+```text
 role_recipients_flock[sysadmin]="systems"
 role_recipients_flock[domainadmin]="domains"
 role_recipients_flock[dba]="databases systems"

--- a/src/health/notifications/flock/metadata.yaml
+++ b/src/health/notifications/flock/metadata.yaml
@@ -43,7 +43,7 @@
             required: true
             detailed_description: |
               You can have different channels per role, by editing DEFAULT_RECIPIENT_FLOCK with the channel you want, in the following entries at the bottom of the same file:
-              ```conf
+              ```text
               role_recipients_flock[sysadmin]="systems"
               role_recipients_flock[domainadmin]="domains"
               role_recipients_flock[dba]="databases systems"

--- a/src/health/notifications/irc/README.md
+++ b/src/health/notifications/irc/README.md
@@ -76,7 +76,7 @@ nc="/usr/bin/nc"
 ##### DEFAULT_RECIPIENT_IRC
 
 The `DEFAULT_RECIPIENT_IRC` can be edited in the following entries at the bottom of the same file:
-```conf
+```text
 role_recipients_irc[sysadmin]="#systems"
 role_recipients_irc[domainadmin]="#domains"
 role_recipients_irc[dba]="#databases #systems"

--- a/src/health/notifications/irc/metadata.yaml
+++ b/src/health/notifications/irc/metadata.yaml
@@ -69,7 +69,7 @@
             required: true
             detailed_description: |
               The `DEFAULT_RECIPIENT_IRC` can be edited in the following entries at the bottom of the same file:
-              ```conf
+              ```text
               role_recipients_irc[sysadmin]="#systems"
               role_recipients_irc[domainadmin]="#domains"
               role_recipients_irc[dba]="#databases #systems"

--- a/src/health/notifications/kavenegar/README.md
+++ b/src/health/notifications/kavenegar/README.md
@@ -63,7 +63,7 @@ The following options can be defined for this notification
 All roles will default to this variable if lest unconfigured.
 
 You can then have different SMS recipients per role, by editing `DEFAULT_RECIPIENT_KAVENEGAR` with the SMS recipients you want, in the following entries at the bottom of the same file:
-```conf
+```text
 role_recipients_kavenegar[sysadmin]="09100000000"
 role_recipients_kavenegar[domainadmin]="09111111111"
 role_recipients_kavenegar[dba]="0922222222"

--- a/src/health/notifications/kavenegar/metadata.yaml
+++ b/src/health/notifications/kavenegar/metadata.yaml
@@ -50,7 +50,7 @@
               All roles will default to this variable if lest unconfigured.
 
               You can then have different SMS recipients per role, by editing `DEFAULT_RECIPIENT_KAVENEGAR` with the SMS recipients you want, in the following entries at the bottom of the same file:
-              ```conf
+              ```text
               role_recipients_kavenegar[sysadmin]="09100000000"
               role_recipients_kavenegar[domainadmin]="09111111111"
               role_recipients_kavenegar[dba]="0922222222"

--- a/src/health/notifications/matrix/README.md
+++ b/src/health/notifications/matrix/README.md
@@ -77,7 +77,7 @@ All roles will default to this variable if left unconfigured.
 
 You can have different Rooms per role, by editing `DEFAULT_RECIPIENT_MATRIX` with the `!roomid:homeservername` you want, in the following entries at the bottom of the same file:
 
-```conf
+```text
 role_recipients_matrix[sysadmin]="!roomid1:homeservername"
 role_recipients_matrix[domainadmin]="!roomid2:homeservername"
 role_recipients_matrix[dba]="!roomid3:homeservername"

--- a/src/health/notifications/matrix/metadata.yaml
+++ b/src/health/notifications/matrix/metadata.yaml
@@ -61,7 +61,7 @@
 
               You can have different Rooms per role, by editing `DEFAULT_RECIPIENT_MATRIX` with the `!roomid:homeservername` you want, in the following entries at the bottom of the same file:
 
-              ```conf
+              ```text
               role_recipients_matrix[sysadmin]="!roomid1:homeservername"
               role_recipients_matrix[domainadmin]="!roomid2:homeservername"
               role_recipients_matrix[dba]="!roomid3:homeservername"

--- a/src/health/notifications/messagebird/README.md
+++ b/src/health/notifications/messagebird/README.md
@@ -62,7 +62,7 @@ The following options can be defined for this notification
 All roles will default to this variable if left unconfigured.
 
 You can then have different recipients per role, by editing `DEFAULT_RECIPIENT_MESSAGEBIRD` with the number you want, in the following entries at the bottom of the same file:
-```conf
+```text
 role_recipients_messagebird[sysadmin]="+15555555555"
 role_recipients_messagebird[domainadmin]="+15555555556"
 role_recipients_messagebird[dba]="+15555555557"

--- a/src/health/notifications/messagebird/metadata.yaml
+++ b/src/health/notifications/messagebird/metadata.yaml
@@ -49,7 +49,7 @@
               All roles will default to this variable if left unconfigured.
 
               You can then have different recipients per role, by editing `DEFAULT_RECIPIENT_MESSAGEBIRD` with the number you want, in the following entries at the bottom of the same file:
-              ```conf
+              ```text
               role_recipients_messagebird[sysadmin]="+15555555555"
               role_recipients_messagebird[domainadmin]="+15555555556"
               role_recipients_messagebird[dba]="+15555555557"

--- a/src/health/notifications/msteams/README.md
+++ b/src/health/notifications/msteams/README.md
@@ -64,7 +64,7 @@ In Microsoft Teams the channel name is encoded in the URI after `/IncomingWebhoo
 All roles will default to this variable if left unconfigured.
 
 You can have different channels per role, by editing `DEFAULT_RECIPIENT_MSTEAMS` with the channel you want, in the following entries at the bottom of the same file:
-```conf
+```text
 role_recipients_msteams[sysadmin]="CHANNEL1"
 role_recipients_msteams[domainadmin]="CHANNEL2"
 role_recipients_msteams[dba]="databases CHANNEL3"

--- a/src/health/notifications/msteams/metadata.yaml
+++ b/src/health/notifications/msteams/metadata.yaml
@@ -50,7 +50,7 @@
               All roles will default to this variable if left unconfigured.
 
               You can have different channels per role, by editing `DEFAULT_RECIPIENT_MSTEAMS` with the channel you want, in the following entries at the bottom of the same file:
-              ```conf
+              ```text
               role_recipients_msteams[sysadmin]="CHANNEL1"
               role_recipients_msteams[domainadmin]="CHANNEL2"
               role_recipients_msteams[dba]="databases CHANNEL3"

--- a/src/health/notifications/ntfy/README.md
+++ b/src/health/notifications/ntfy/README.md
@@ -67,7 +67,7 @@ You can define multiple recipient URLs like this: `https://SERVER1/TOPIC1` `http
 All roles will default to this variable if left unconfigured.
 
 You can then have different servers and/or topics per role, by editing DEFAULT_RECIPIENT_NTFY with the server-topic combination you want, in the following entries at the bottom of the same file:
-```conf
+```text
 role_recipients_ntfy[sysadmin]="https://SERVER1/TOPIC1"
 role_recipients_ntfy[domainadmin]="https://SERVER2/TOPIC2"
 role_recipients_ntfy[dba]="https://SERVER3/TOPIC3"

--- a/src/health/notifications/ntfy/metadata.yaml
+++ b/src/health/notifications/ntfy/metadata.yaml
@@ -45,7 +45,7 @@
               All roles will default to this variable if left unconfigured.
 
               You can then have different servers and/or topics per role, by editing DEFAULT_RECIPIENT_NTFY with the server-topic combination you want, in the following entries at the bottom of the same file:
-              ```conf
+              ```text
               role_recipients_ntfy[sysadmin]="https://SERVER1/TOPIC1"
               role_recipients_ntfy[domainadmin]="https://SERVER2/TOPIC2"
               role_recipients_ntfy[dba]="https://SERVER3/TOPIC3"

--- a/src/health/notifications/pagerduty/README.md
+++ b/src/health/notifications/pagerduty/README.md
@@ -63,7 +63,7 @@ The following options can be defined for this notification
 All roles will default to this variable if left unconfigured.
 
 The `DEFAULT_RECIPIENT_PD` can be edited in the following entries at the bottom of the same file:
-```conf
+```text
 role_recipients_pd[sysadmin]="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxa"
 role_recipients_pd[domainadmin]="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxb"
 role_recipients_pd[dba]="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxc"

--- a/src/health/notifications/pagerduty/metadata.yaml
+++ b/src/health/notifications/pagerduty/metadata.yaml
@@ -44,7 +44,7 @@
               All roles will default to this variable if left unconfigured.
 
               The `DEFAULT_RECIPIENT_PD` can be edited in the following entries at the bottom of the same file:
-              ```conf
+              ```text
               role_recipients_pd[sysadmin]="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxa"
               role_recipients_pd[domainadmin]="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxb"
               role_recipients_pd[dba]="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxc"

--- a/src/health/notifications/prowl/README.md
+++ b/src/health/notifications/prowl/README.md
@@ -66,7 +66,7 @@ The following options can be defined for this notification
 All roles will default to this variable if left unconfigured.
 
 The `DEFAULT_RECIPIENT_PROWL` can be edited in the following entries at the bottom of the same file:
-```conf
+```text
 role_recipients_prowl[sysadmin]="AAAAAAAA"
 role_recipients_prowl[domainadmin]="BBBBBBBBB"
 role_recipients_prowl[dba]="CCCCCCCCC"

--- a/src/health/notifications/prowl/metadata.yaml
+++ b/src/health/notifications/prowl/metadata.yaml
@@ -43,7 +43,7 @@
               All roles will default to this variable if left unconfigured.
 
               The `DEFAULT_RECIPIENT_PROWL` can be edited in the following entries at the bottom of the same file:
-              ```conf
+              ```text
               role_recipients_prowl[sysadmin]="AAAAAAAA"
               role_recipients_prowl[domainadmin]="BBBBBBBBB"
               role_recipients_prowl[dba]="CCCCCCCCC"

--- a/src/health/notifications/pushbullet/README.md
+++ b/src/health/notifications/pushbullet/README.md
@@ -63,7 +63,7 @@ You can define multiple entries like this: user1@email.com user2@email.com.
 All roles will default to this variable if left unconfigured.
 
 The `DEFAULT_RECIPIENT_PUSHBULLET` can be edited in the following entries at the bottom of the same file:
-```conf
+```text
 role_recipients_pushbullet[sysadmin]="user1@email.com"
 role_recipients_pushbullet[domainadmin]="user2@mail.com"
 role_recipients_pushbullet[dba]="#channel1"

--- a/src/health/notifications/pushbullet/metadata.yaml
+++ b/src/health/notifications/pushbullet/metadata.yaml
@@ -47,7 +47,7 @@
               All roles will default to this variable if left unconfigured.
 
               The `DEFAULT_RECIPIENT_PUSHBULLET` can be edited in the following entries at the bottom of the same file:
-              ```conf
+              ```text
               role_recipients_pushbullet[sysadmin]="user1@email.com"
               role_recipients_pushbullet[domainadmin]="user2@mail.com"
               role_recipients_pushbullet[dba]="#channel1"

--- a/src/health/notifications/pushover/README.md
+++ b/src/health/notifications/pushover/README.md
@@ -65,7 +65,7 @@ The following options can be defined for this notification
 All roles will default to this variable if left unconfigured.
 
 The `DEFAULT_RECIPIENT_PUSHOVER` can be edited in the following entries at the bottom of the same file:
-```conf
+```text
 role_recipients_pushover[sysadmin]="USERTOKEN1"
 role_recipients_pushover[domainadmin]="USERTOKEN2"
 role_recipients_pushover[dba]="USERTOKEN3 USERTOKEN4"

--- a/src/health/notifications/pushover/metadata.yaml
+++ b/src/health/notifications/pushover/metadata.yaml
@@ -49,7 +49,7 @@
               All roles will default to this variable if left unconfigured.
 
               The `DEFAULT_RECIPIENT_PUSHOVER` can be edited in the following entries at the bottom of the same file:
-              ```conf
+              ```text
               role_recipients_pushover[sysadmin]="USERTOKEN1"
               role_recipients_pushover[domainadmin]="USERTOKEN2"
               role_recipients_pushover[dba]="USERTOKEN3 USERTOKEN4"

--- a/src/health/notifications/rocketchat/README.md
+++ b/src/health/notifications/rocketchat/README.md
@@ -62,7 +62,7 @@ The following options can be defined for this notification
 All roles will default to this variable if left unconfigured.
 
 The `DEFAULT_RECIPIENT_ROCKETCHAT` can be edited in the following entries at the bottom of the same file:
-```conf
+```text
 role_recipients_rocketchat[sysadmin]="systems"
 role_recipients_rocketchat[domainadmin]="domains"
 role_recipients_rocketchat[dba]="databases systems"

--- a/src/health/notifications/rocketchat/metadata.yaml
+++ b/src/health/notifications/rocketchat/metadata.yaml
@@ -46,7 +46,7 @@
               All roles will default to this variable if left unconfigured.
 
               The `DEFAULT_RECIPIENT_ROCKETCHAT` can be edited in the following entries at the bottom of the same file:
-              ```conf
+              ```text
               role_recipients_rocketchat[sysadmin]="systems"
               role_recipients_rocketchat[domainadmin]="domains"
               role_recipients_rocketchat[dba]="databases systems"

--- a/src/health/notifications/smstools3/README.md
+++ b/src/health/notifications/smstools3/README.md
@@ -74,7 +74,7 @@ sendsms="/usr/bin/sendsms"
 All roles will default to this variable if left unconfigured.
 
 You can then have different phone numbers per role, by editing `DEFAULT_RECIPIENT_SMS` with the phone number you want, in the following entries at the bottom of the same file:
-```conf
+```text
 role_recipients_sms[sysadmin]="PHONE1"
 role_recipients_sms[domainadmin]="PHONE2"
 role_recipients_sms[dba]="PHONE3"

--- a/src/health/notifications/smstools3/metadata.yaml
+++ b/src/health/notifications/smstools3/metadata.yaml
@@ -57,7 +57,7 @@
               All roles will default to this variable if left unconfigured.
 
               You can then have different phone numbers per role, by editing `DEFAULT_RECIPIENT_SMS` with the phone number you want, in the following entries at the bottom of the same file:
-              ```conf
+              ```text
               role_recipients_sms[sysadmin]="PHONE1"
               role_recipients_sms[domainadmin]="PHONE2"
               role_recipients_sms[dba]="PHONE3"

--- a/src/health/notifications/syslog/README.md
+++ b/src/health/notifications/syslog/README.md
@@ -78,7 +78,7 @@ All roles will default to this variable if left unconfigured.
 
 You can then have different recipients per role, by editing DEFAULT_RECIPIENT_SYSLOG with the recipient you want, in the following entries at the bottom of the same file:
 
-```conf
+```text
 role_recipients_syslog[sysadmin]="daemon.notice@loghost1:514/netdata"
 role_recipients_syslog[domainadmin]="daemon.notice@loghost2:514/netdata"
 role_recipients_syslog[dba]="daemon.notice@loghost3:514/netdata"

--- a/src/health/notifications/syslog/metadata.yaml
+++ b/src/health/notifications/syslog/metadata.yaml
@@ -59,7 +59,7 @@
             detailed_description: |
               You can then have different recipients per role, by editing DEFAULT_RECIPIENT_SYSLOG with the recipient you want, in the following entries at the bottom of the same file:
 
-              ```conf
+              ```text
               role_recipients_syslog[sysadmin]="daemon.notice@loghost1:514/netdata"
               role_recipients_syslog[domainadmin]="daemon.notice@loghost2:514/netdata"
               role_recipients_syslog[dba]="daemon.notice@loghost3:514/netdata"

--- a/src/health/notifications/telegram/README.md
+++ b/src/health/notifications/telegram/README.md
@@ -63,7 +63,7 @@ All roles will default to this variable if left unconfigured.
 
 The `DEFAULT_RECIPIENT_CUSTOM` can be edited in the following entries at the bottom of the same file:
 
-```conf
+```text
 role_recipients_telegram[sysadmin]="-49999333324"
 role_recipients_telegram[domainadmin]="-49999333389"
 role_recipients_telegram[dba]="-10099992222"

--- a/src/health/notifications/telegram/metadata.yaml
+++ b/src/health/notifications/telegram/metadata.yaml
@@ -47,7 +47,7 @@
 
               The `DEFAULT_RECIPIENT_CUSTOM` can be edited in the following entries at the bottom of the same file:
 
-              ```conf
+              ```text
               role_recipients_telegram[sysadmin]="-49999333324"
               role_recipients_telegram[domainadmin]="-49999333389"
               role_recipients_telegram[dba]="-10099992222"

--- a/src/health/notifications/twilio/README.md
+++ b/src/health/notifications/twilio/README.md
@@ -62,7 +62,7 @@ The following options can be defined for this notification
 
 You can then have different recipients per role, by editing DEFAULT_RECIPIENT_TWILIO with the recipient's number you want, in the following entries at the bottom of the same file:
 
-```conf
+```text
 role_recipients_twilio[sysadmin]="+15555555555"
 role_recipients_twilio[domainadmin]="+15555555556"
 role_recipients_twilio[dba]="+15555555557"

--- a/src/health/notifications/twilio/metadata.yaml
+++ b/src/health/notifications/twilio/metadata.yaml
@@ -52,7 +52,7 @@
             detailed_description: |
               You can then have different recipients per role, by editing DEFAULT_RECIPIENT_TWILIO with the recipient's number you want, in the following entries at the bottom of the same file:
 
-              ```conf
+              ```text
               role_recipients_twilio[sysadmin]="+15555555555"
               role_recipients_twilio[domainadmin]="+15555555556"
               role_recipients_twilio[dba]="+15555555557"

--- a/src/health/notifications/web/README.md
+++ b/src/health/notifications/web/README.md
@@ -1,13 +1,3 @@
-<!--
-title: "Browser pop up agent alert notifications"
-sidebar_label: "Browser pop ups"
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/src/health/notifications/web/README.md"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Integrations/Notify/Agent alert notifications"
-learn_autogeneration_metadata: "{'part_of_cloud': False, 'part_of_agent': True}"
--->
-
 # Browser pop up agent alert notifications
 
 The Netdata dashboard shows HTML notifications, when it is open.

--- a/src/libnetdata/adaptive_resortable_list/README.md
+++ b/src/libnetdata/adaptive_resortable_list/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Adaptive Re-sortable List (ARL)"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/adaptive_resortable_list/README.md
-sidebar_label: "Adaptive Re-sortable List (ARL)"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # Adaptive Re-sortable List (ARL)
 
 This library allows Netdata to read a series of `name - value` pairs

--- a/src/libnetdata/aral/README.md
+++ b/src/libnetdata/aral/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Array Allocator"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/aral/README.md
-sidebar_label: "Array allocator"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # Array Allocator
 
 Come on! Array allocators are embedded in libc! Why do we need such a thing in Netdata?

--- a/src/libnetdata/avl/README.md
+++ b/src/libnetdata/avl/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "AVL"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/avl/README.md
-sidebar_label: "AVL"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # AVL
 
 AVL is a library indexing objects in B-Trees.

--- a/src/libnetdata/buffer/README.md
+++ b/src/libnetdata/buffer/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "BUFFER"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/buffer/README.md
-sidebar_label: "BUFFER library"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # BUFFER
 
 `BUFFER` is a convenience library for working with strings in `C`.

--- a/src/libnetdata/circular_buffer/README.md
+++ b/src/libnetdata/circular_buffer/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Circular Buffer"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/circular_buffer/README.md
-sidebar_label: "Circular Buffer"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # Circular Buffer
 
 `struct circular_buffer` is an adaptive circular buffer. It will start at an initial size

--- a/src/libnetdata/config/README.md
+++ b/src/libnetdata/config/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Netdata ini config files"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/config/README.md
-sidebar_label: "Netdata ini config files"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # Netdata ini config files
 
 Configuration files `netdata.conf` and `stream.conf` are Netdata ini files.

--- a/src/libnetdata/datetime/README.md
+++ b/src/libnetdata/datetime/README.md
@@ -1,11 +1,3 @@
-<!--
-title: "Datetime"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/datetime/README.md
-sidebar_label: "Datetime"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # Datetime
 
 Formatting dates and timestamps.

--- a/src/libnetdata/ebpf/README.md
+++ b/src/libnetdata/ebpf/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "eBPF"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/ebpf/README.md
-sidebar_label: "eBPF"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # eBPF library
 
 Netdata's eBPF library supports the [eBPF collector](/src/collectors/ebpf.plugin/README.md).

--- a/src/libnetdata/json/README.md
+++ b/src/libnetdata/json/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "json"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/json/README.md
-sidebar_label: "json"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # json
 
 `json` contains a parser for json strings, based on `jsmn` (<https://github.com/zserge/jsmn>), but case you have installed the JSON-C library, the installation script will prefer it, you can also force its use with `--enable-jsonc` in the compilation time.

--- a/src/libnetdata/line_splitter/README.md
+++ b/src/libnetdata/line_splitter/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Log"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/log/README.md
-sidebar_label: "Log"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # Log
 
 The netdata log library supports debug, info, error and fatal error logging. 

--- a/src/libnetdata/locks/README.md
+++ b/src/libnetdata/locks/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Locks"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/locks/README.md
-sidebar_label: "Locks"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # Locks
 
 ## How to trace netdata locks

--- a/src/libnetdata/log/README.md
+++ b/src/libnetdata/log/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Log"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/log/README.md
-sidebar_label: "Log"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # Netdata Logging
 
 This document describes how Netdata generates its own logs, not how Netdata manages and queries logs databases.

--- a/src/libnetdata/onewayalloc/README.md
+++ b/src/libnetdata/onewayalloc/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "One Way Allocator"
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/src/libnetdata/onewayalloc/README.md"
-sidebar_label: "One way allocator"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # One Way Allocator
 
 This is a very fast single-threaded-only memory allocator, that minimized system calls

--- a/src/libnetdata/procfile/README.md
+++ b/src/libnetdata/procfile/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "PROCFILE"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/procfile/README.md
-sidebar_label: "Procfile"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # PROCFILE
 
 procfile is a library for reading text data files (i.e `/proc` files) in the fastest possible way.

--- a/src/libnetdata/simple_pattern/README.md
+++ b/src/libnetdata/simple_pattern/README.md
@@ -1,13 +1,3 @@
-<!--
-title: "Simple patterns"
-description: "Netdata supports simple patterns, which are less cryptic versions of regular expressions. Use familiar notation for powerful results."
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/simple_pattern/README.md
-sidebar_label: "Simple patterns"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # Simple patterns
 
 Unix prefers regular expressions. But they are just too hard, too cryptic

--- a/src/libnetdata/statistical/README.md
+++ b/src/libnetdata/statistical/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Statistical functions"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/statistical/README.md
-sidebar_label: "Statistical functions"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # Statistical functions
 
 A library for easy and fast calculations of statistical measurements like average, median etc.

--- a/src/libnetdata/storage_number/README.md
+++ b/src/libnetdata/storage_number/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Netdata storage number"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/storage_number/README.md
-sidebar_label: "Storage number"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # Netdata storage number
 
 Although `netdata` does all its calculations using `long double`, it stores all values using

--- a/src/libnetdata/string/README.md
+++ b/src/libnetdata/string/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "String"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/string/README.md
-sidebar_label: "String"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # STRING
 
 STRING provides a way to allocate and free text strings, while de-duplicating them.

--- a/src/libnetdata/threads/README.md
+++ b/src/libnetdata/threads/README.md
@@ -1,12 +1,3 @@
-<!--
-title: Threads
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/threads/README.md
-sidebar_label: "Threads"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # Threads
 
 Netdata uses a custom threads library

--- a/src/libnetdata/url/README.md
+++ b/src/libnetdata/url/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "URL"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/url/README.md
-sidebar_label: "URL"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # URL
 
 The URL library contains common functions useful for URLs, like conversion from/to hex, 

--- a/src/libnetdata/uuid/README.md
+++ b/src/libnetdata/uuid/README.md
@@ -1,11 +1,3 @@
-<!--
-title: "UUID"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/uuid/README.md
-sidebar_label: "UUID"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # UUID
 
 Netdata uses libuuid for managing UUIDs.

--- a/src/libnetdata/worker_utilization/README.md
+++ b/src/libnetdata/worker_utilization/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Worker Utilization"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/libnetdata/worker_utilization/README.md
-sidebar_label: "Worker Utilization"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/libnetdata"
--->
-
 # Worker Utilization
 
 This library is to be used when there are 1 or more worker threads accepting requests

--- a/src/plugins.d/README.md
+++ b/src/plugins.d/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "External plugins"
-custom_edit_url: "https://github.com/netdata/netdata/edit/master/src/plugins.d/README.md"
-sidebar_label: "External plugins"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/External plugins"
--->
-
 # External plugins
 
 `plugins.d` is the Netdata internal plugin that collects metrics

--- a/src/registry/README.md
+++ b/src/registry/README.md
@@ -85,7 +85,7 @@ We believe, it can do it...
 
 **To turn any Netdata into a registry**, edit `/etc/netdata/netdata.conf` and set:
 
-```conf
+```text
 [registry]
     enabled = yes
     registry to announce = http://your.registry:19999
@@ -96,7 +96,7 @@ Restart your Netdata to activate it.
 Then, you need to tell **all your other Netdata servers to advertise your registry**, instead of the default. To do
 this, on each of your Netdata servers, edit `/etc/netdata/netdata.conf` and set:
 
-```conf
+```text
 [registry]
     enabled = no
     registry to announce = http://your.registry:19999
@@ -110,7 +110,7 @@ This is it. You have your registry now.
 You may also want to give your server different names under the node menu (i.e. to have them sorted / grouped). You can
 change its registry name, by setting on each Netdata server:
 
-```conf
+```text
 [registry]
     registry hostname = Group1 - Master DB
 ```
@@ -121,7 +121,7 @@ So this server will appear in the node menu as `Group1 - Master DB`. The max nam
 
 Netdata v1.9+ support limiting access to the registry from given IPs, like this:
 
-```conf
+```text
 [registry]
     allow from = *
 ```
@@ -142,7 +142,7 @@ against the name-pattern.
 Please note that this process can be expensive on a machine that is serving many connections. The behaviour of the
 pattern matching can be controlled with the following setting:
 
-```conf
+```text
 [registry]
     allow by dns = heuristic
 ```
@@ -175,7 +175,7 @@ Beginning with `v1.30.0`, when the Netdata Agent's web server processes a reques
 and `Secure` cookies. If you have problems accessing the local Agent dashboard or Netdata Cloud, disable these
 cookies by [editing `netdata.conf`](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config):
 
-```conf
+```text
 [registry]
     enable cookies SameSite and Secure = no
 ```
@@ -198,7 +198,7 @@ redirecting the browser back to itself hoping that it will receive the cookie. I
 registry will keep redirecting your web browser back to itself, which after a few redirects will fail with an error like
 this:
 
-```conf
+```text
 ERROR 409: Cannot ACCESS netdata registry: https://registry.my-netdata.io responded with: {"status":"redirect","registry":"https://registry.my-netdata.io"}
 ```
 

--- a/src/streaming/README.md
+++ b/src/streaming/README.md
@@ -111,7 +111,7 @@ the following format: `[PROTOCOL:]HOST[%INTERFACE][:PORT][:SSL]`.
 
 To enable TCP streaming to a parent node at `203.0.113.0` on port `20000` and with TLS/SSL encryption: 
 
-```conf
+```text
 [stream]
     destination = tcp:203.0.113.0:20000:SSL
 ```
@@ -125,14 +125,14 @@ The default is a single wildcard `*`, which streams all charts.
 To send only a few charts, list them explicitly, or list a group using a wildcard. To send _only_ the `apps.cpu` chart
 and charts with contexts beginning with `system.`: 
 
-```conf
+```text
 [stream]
     send charts matching = apps.cpu system.*
 ```
 
 To send all but a few charts, use `!` to create a negative match. To send _all_ charts _but_ `apps.cpu`:
 
-```conf
+```text
 [stream]
     send charts matching = !apps.cpu *
 ```
@@ -146,14 +146,14 @@ The default is `*`, which accepts all requests including the `API_KEY`.
 
 To allow from only a specific IP address:
 
-```conf
+```text
 [API_KEY]
     allow from = 203.0.113.10
 ```
 
 To allow all IPs starting with `10.*`, except `10.1.2.3`:
 
-```conf
+```text
 [API_KEY]
     allow from = !10.1.2.3 10.*
 ```
@@ -201,7 +201,7 @@ with the `[MACHINE_GUID]` section.
 For example, the metrics streamed from only the child node with `MACHINE_GUID` are saved in memory, not using the
 default `dbengine` as specified by the `API_KEY`, and alerts are disabled.
 
-```conf
+```text
 [API_KEY]
     enabled = yes
     db = dbengine
@@ -431,7 +431,7 @@ In the following example, the proxy receives metrics from a child node using the
 `66666666-7777-8888-9999-000000000000`, then stores metrics using `dbengine`. It then uses the `API_KEY` of
 `11111111-2222-3333-4444-555555555555` to proxy those same metrics on to a parent node at `203.0.113.0`.
 
-```conf
+```text
 [stream]
     enabled = yes 
     destination = 203.0.113.0
@@ -449,7 +449,7 @@ metrics to any number of permanently-running parent nodes.
 
 On the parent, set the following in `stream.conf`:
 
-```conf
+```text
 [11111111-2222-3333-4444-555555555555]
 	# enable/disable this API key
     enabled = yes
@@ -497,7 +497,7 @@ This replication process ensures data continuity even if child nodes temporarily
 
 Replication is enabled by default in Netdata, but you can customize the replication behavior by modifying the `[API_KEY]` section of the `stream.conf` file. Here's an example configuration:
 
-```conf
+```text
 [11111111-2222-3333-4444-555555555555]
     # Enable replication for all hosts using this api key. Default: yes.
     enable replication = yes

--- a/src/web/api/exporters/README.md
+++ b/src/web/api/exporters/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Exporters"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/exporters/README.md
-sidebar_label: "Exporters"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api"
--->
-
 # Exporters
 
 TBD

--- a/src/web/api/exporters/prometheus/README.md
+++ b/src/web/api/exporters/prometheus/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Prometheus exporter"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/exporters/prometheus/README.md
-sidebar_label: "Prometheus exporter"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Exporters"
--->
-
 # Prometheus exporter
 
 Read the Prometheus exporter documentation: [Using Netdata with Prometheus](/src/exporting/prometheus/README.md).

--- a/src/web/api/exporters/shell/README.md
+++ b/src/web/api/exporters/shell/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Shell exporter"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/exporters/shell/README.md
-sidebar_label: "Shell exporter"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Exporters"
--->
-
 # Shell exporter
 
 Shell scripts can now query Netdata:

--- a/src/web/api/formatters/README.md
+++ b/src/web/api/formatters/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Query formatting"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/formatters/README.md
-sidebar_label: "Query formatting"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Formatters"
--->
-
 # Query formatting
 
 API data queries need to be formatted before returned to the caller.

--- a/src/web/api/formatters/csv/README.md
+++ b/src/web/api/formatters/csv/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "CSV formatter"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/formatters/csv/README.md
-sidebar_label: "CSV formatter"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Formatters"
--->
-
 # CSV formatter
 
 The CSV formatter presents [results of database queries](/src/web/api/queries/README.md) in the following formats:

--- a/src/web/api/formatters/json/README.md
+++ b/src/web/api/formatters/json/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "JSON formatter"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/formatters/json/README.md
-sidebar_label: "JSON formatter"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Formatters"
--->
-
 # JSON formatter
 
 The CSV formatter presents [results of database queries](/src/web/api/queries/README.md) in the following formats:

--- a/src/web/api/formatters/ssv/README.md
+++ b/src/web/api/formatters/ssv/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "SSV formatter"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/formatters/ssv/README.md
-sidebar_label: "SSV formatter"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Formatters"
--->
-
 # SSV formatter
 
 The SSV formatter sums all dimensions in [results of database queries](/src/web/api/queries/README.md)

--- a/src/web/api/formatters/value/README.md
+++ b/src/web/api/formatters/value/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Value formatter"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/formatters/value/README.md
-sidebar_label: "Value formatter"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Formatters"
--->
-
 # Value formatter
 
 The Value formatter presents [results of database queries](/src/web/api/queries/README.md) as a single value.

--- a/src/web/api/health/README.md
+++ b/src/web/api/health/README.md
@@ -1,13 +1,3 @@
-<!--
-title: "Health API Calls"
-date: 2020-04-27
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/health/README.md
-sidebar_label: "Health API Calls"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api"
--->
-
 # Health API Calls
 
 ## Health Read API

--- a/src/web/api/queries/average/README.md
+++ b/src/web/api/queries/average/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Average or Mean"
-sidebar_label: "Average or Mean"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/queries/average/README.md
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Queries"
--->
-
 # Average or Mean
 
 > This query is available as `average` and `mean`.

--- a/src/web/api/queries/countif/README.md
+++ b/src/web/api/queries/countif/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "CountIf"
-sidebar_label: "CountIf"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/queries/countif/README.md
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Queries"
--->
-
 # CountIf
 
 > This query is available as `countif`.

--- a/src/web/api/queries/des/README.md
+++ b/src/web/api/queries/des/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "double exponential smoothing"
-sidebar_label: "double exponential smoothing"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/queries/des/README.md
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Queries"
--->
-
 # double exponential smoothing
 
 Exponential smoothing is one of many window functions commonly applied to smooth data in signal

--- a/src/web/api/queries/incremental_sum/README.md
+++ b/src/web/api/queries/incremental_sum/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Incremental Sum (`incremental_sum`)"
-sidebar_label: "Incremental Sum (`incremental_sum`)"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/queries/incremental_sum/README.md
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Queries"
--->
-
 # Incremental Sum (`incremental_sum`)
 
 This modules finds the incremental sum of a period, which `last value - first value`.

--- a/src/web/api/queries/max/README.md
+++ b/src/web/api/queries/max/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Max"
-sidebar_label: "Max"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/queries/max/README.md
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Queries"
--->
-
 # Max
 
 This module finds the max value in the time-frame given.

--- a/src/web/api/queries/median/README.md
+++ b/src/web/api/queries/median/README.md
@@ -1,13 +1,3 @@
-<!--
-title: "Median"
-sidebar_label: "Median"
-description: "Use median in API queries and health entities to find the 'middle' value from a sample, eliminating any unwanted spikes in the returned metrics."
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/queries/median/README.md
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Queries"
--->
-
 # Median
 
 The median is the value separating the higher half from the lower half of a data sample

--- a/src/web/api/queries/min/README.md
+++ b/src/web/api/queries/min/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Min"
-sidebar_label: "Min"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/queries/min/README.md
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Queries"
--->
-
 # Min
 
 This module finds the min value in the time-frame given.

--- a/src/web/api/queries/percentile/README.md
+++ b/src/web/api/queries/percentile/README.md
@@ -1,13 +1,3 @@
-<!--
-title: "Percentile"
-sidebar_label: "Percentile"
-description: "Use percentile in API queries and health entities to find the 'percentile' value from a sample, eliminating any unwanted spikes in the returned metrics."
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/queries/percentile/README.md
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Queries"
--->
-
 # Percentile
 
 The percentile is the average value of a series using only the smaller N percentile of the values.

--- a/src/web/api/queries/ses/README.md
+++ b/src/web/api/queries/ses/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Single (or Simple) Exponential Smoothing (`ses`)"
-sidebar_label: "Single (or Simple) Exponential Smoothing (`ses`)"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/queries/ses/README.md
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Queries"
--->
-
 # Single (or Simple) Exponential Smoothing (`ses`)
 
 > This query is also available as `ema` and `ewma`.

--- a/src/web/api/queries/stddev/README.md
+++ b/src/web/api/queries/stddev/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "standard deviation (`stddev`)"
-sidebar_label: "standard deviation (`stddev`)"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/queries/stddev/README.md
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Queries"
--->
-
 # standard deviation (`stddev`)
 
 The standard deviation is a measure that is used to quantify the amount of variation or dispersion

--- a/src/web/api/queries/sum/README.md
+++ b/src/web/api/queries/sum/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Sum"
-sidebar_label: "Sum"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/queries/sum/README.md
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Queries"
--->
-
 # Sum
 
 This module sums all the values in the time-frame requested.

--- a/src/web/api/queries/trimmed_mean/README.md
+++ b/src/web/api/queries/trimmed_mean/README.md
@@ -1,13 +1,3 @@
-<!--
-title: "Trimmed Mean"
-sidebar_label: "Trimmed Mean"
-description: "Use trimmed-mean in API queries and health entities to find the average value from a sample, eliminating any unwanted spikes in the returned metrics."
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/queries/trimmed_mean/README.md
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api/Queries"
--->
-
 # Trimmed Mean
 
 The trimmed mean is the average value of a series excluding the smallest and biggest points.

--- a/src/web/api/v1/api_v1_badge/README.md
+++ b/src/web/api/v1/api_v1_badge/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Netdata badges"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/api/badges/README.md
-sidebar_label: "Netdata badges"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers/Web/Api"
--->
-
 # Netdata badges
 
 **Badges are cool!**

--- a/src/web/gui/README.md
+++ b/src/web/gui/README.md
@@ -147,7 +147,7 @@ customDashboard.menu = {
 Finally, tell Netdata where you placed your customization file by replacing
 `your_dashboard_info_file.js` below.
 
-```conf
+```text
 [web]
  custom dashboard_info.js = your_dashboard_info_file.js
 ```

--- a/src/web/server/README.md
+++ b/src/web/server/README.md
@@ -58,7 +58,7 @@ Scroll down to the `[web]` section to find the following settings.
 
 Disable the web server by editing `netdata.conf` and setting:
 
-```txt
+```conf
 [web]
     mode = none
 ```
@@ -67,7 +67,7 @@ Disable the web server by editing `netdata.conf` and setting:
 
 Control the number of threads and sockets with the following settings:
 
-```txt
+```conf
 [web]
     web server threads = 4
     web server max sockets = 512
@@ -79,7 +79,7 @@ Netdata can bind to multiple IPs and ports, offering access to different service
 
 The ports to bind are controlled via `[web].bind to`, like this:
 
-```txt
+```conf
 [web]
    default port = 19999
    bind to = 127.0.0.1=dashboard^SSL=optional 10.1.1.1:19998=management|netdata.conf hostname:19997=badges [::]:19996=streaming^SSL=force localhost:19995=registry *:http=dashboard unix:/run/netdata/netdata.sock
@@ -123,8 +123,8 @@ To enable TLS, provide the path to your certificate and private key in the `[web
 
 ```conf
 [web]
- ssl key = /etc/netdata/ssl/key.pem
- ssl certificate = /etc/netdata/ssl/cert.pem
+    ssl key = /etc/netdata/ssl/key.pem
+    ssl certificate = /etc/netdata/ssl/cert.pem
 ```
 
 Both files must be readable by the `netdata` user. If either of these files do not exist or are unreadable, Netdata will fall back to HTTP. For a parent-child connection, only the parent needs these settings.
@@ -172,7 +172,7 @@ To change this behavior, you need to modify the `bind to` setting in the `[web]`
 
 Example:
 
-```txt
+```conf
 [web]
     bind to = *=dashboard|registry|badges|management|streaming|netdata.conf^SSL=force
 ```
@@ -181,7 +181,7 @@ For information how to configure the child to use TLS, check [securing the commu
 
 When we define the use of SSL in a Netdata agent for different ports,  Netdata will apply the behavior specified on each port. For example, using the configuration line below:
 
-```txt
+```conf
 [web]
     bind to = *=dashboard|registry|badges|management|streaming|netdata.conf^SSL=force *:20000=netdata.conf^SSL=optional *:20001=dashboard|registry
 ```
@@ -205,14 +205,14 @@ In the near future, Netdata will allow our users to change the internal configur
 
 Netdata supports access lists in `netdata.conf`:
 
-```txt
+```conf
 [web]
- allow connections from = localhost *
- allow dashboard from = localhost *
- allow badges from = *
- allow streaming from = *
- allow netdata.conf from = localhost fd* 10.* 192.168.* 172.16.* 172.17.* 172.18.* 172.19.* 172.20.* 172.21.* 172.22.* 172.23.* 172.24.* 172.25.* 172.26.* 172.27.* 172.28.* 172.29.* 172.30.* 172.31.*
- allow management from = localhost
+    allow connections from = localhost *
+    allow dashboard from = localhost *
+    allow badges from = *
+    allow streaming from = *
+    allow netdata.conf from = localhost fd* 10.* 192.168.* 172.16.* 172.17.* 172.18.* 172.19.* 172.20.* 172.21.* 172.22.* 172.23.* 172.24.* 172.25.* 172.26.* 172.27.* 172.28.* 172.29.* 172.30.* 172.31.*
+    allow management from = localhost
 ```
 
 `*` does string matches on the IPs or FQDNs of the clients.
@@ -243,12 +243,12 @@ Please note that this process can be expensive on a machine that is serving many
 associated configuration option to turn off DNS-based patterns completely to avoid incurring this cost at run-time:
 
 ```conf
- allow connections by dns = heuristic
- allow dashboard by dns = heuristic
- allow badges by dns = heuristic
- allow streaming by dns = heuristic
- allow netdata.conf by dns = no
- allow management by dns = heuristic
+    allow connections by dns = heuristic
+    allow dashboard by dns = heuristic
+    allow badges by dns = heuristic
+    allow streaming by dns = heuristic
+    allow netdata.conf by dns = no
+    allow management by dns = heuristic
 ```
 
 The three possible values for each of these options are `yes`, `no` and `heuristic`. The `heuristic` option disables

--- a/src/web/server/README.md
+++ b/src/web/server/README.md
@@ -58,7 +58,7 @@ Scroll down to the `[web]` section to find the following settings.
 
 Disable the web server by editing `netdata.conf` and setting:
 
-```conf
+```text
 [web]
     mode = none
 ```
@@ -67,7 +67,7 @@ Disable the web server by editing `netdata.conf` and setting:
 
 Control the number of threads and sockets with the following settings:
 
-```conf
+```text
 [web]
     web server threads = 4
     web server max sockets = 512
@@ -79,7 +79,7 @@ Netdata can bind to multiple IPs and ports, offering access to different service
 
 The ports to bind are controlled via `[web].bind to`, like this:
 
-```conf
+```text
 [web]
    default port = 19999
    bind to = 127.0.0.1=dashboard^SSL=optional 10.1.1.1:19998=management|netdata.conf hostname:19997=badges [::]:19996=streaming^SSL=force localhost:19995=registry *:http=dashboard unix:/run/netdata/netdata.sock
@@ -121,7 +121,7 @@ Inbound unix socket connections are unaffected, regardless of the TLS settings.
 
 To enable TLS, provide the path to your certificate and private key in the `[web]` section of `netdata.conf`:
 
-```conf
+```text
 [web]
     ssl key = /etc/netdata/ssl/key.pem
     ssl certificate = /etc/netdata/ssl/cert.pem
@@ -147,7 +147,7 @@ openssl req -newkey rsa:2048 -nodes -sha512 -x509 -days 365 -keyout key.pem -out
 
 Beginning with version `v1.21.0`, specify the TLS version and the ciphers that you want to use:
 
-```conf
+```text
 [web]
     tls version = 1.3
     tls ciphers = TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256
@@ -172,7 +172,7 @@ To change this behavior, you need to modify the `bind to` setting in the `[web]`
 
 Example:
 
-```conf
+```text
 [web]
     bind to = *=dashboard|registry|badges|management|streaming|netdata.conf^SSL=force
 ```
@@ -181,7 +181,7 @@ For information how to configure the child to use TLS, check [securing the commu
 
 When we define the use of SSL in a Netdata agent for different ports,  Netdata will apply the behavior specified on each port. For example, using the configuration line below:
 
-```conf
+```text
 [web]
     bind to = *=dashboard|registry|badges|management|streaming|netdata.conf^SSL=force *:20000=netdata.conf^SSL=optional *:20001=dashboard|registry
 ```
@@ -205,7 +205,7 @@ In the near future, Netdata will allow our users to change the internal configur
 
 Netdata supports access lists in `netdata.conf`:
 
-```conf
+```text
 [web]
     allow connections from = localhost *
     allow dashboard from = localhost *
@@ -242,7 +242,7 @@ a forward DNS resolution is made to validate the IP address against the name-pat
 Please note that this process can be expensive on a machine that is serving many connections. Each access list has an
 associated configuration option to turn off DNS-based patterns completely to avoid incurring this cost at run-time:
 
-```conf
+```text
     allow connections by dns = heuristic
     allow dashboard by dns = heuristic
     allow badges by dns = heuristic

--- a/src/web/server/static/README.md
+++ b/src/web/server/static/README.md
@@ -1,13 +1,3 @@
-<!--
-title: "`static-threaded` web server"
-description: "The Netdata Agent's static-threaded web server spawns a fixed number of threads that listen to web requests and uses non-blocking I/O."
-custom_edit_url: https://github.com/netdata/netdata/edit/master/src/web/server/static/README.md
-sidebar_label: "`static-threaded` web server"
-learn_status: "Published"
-learn_topic_type: "Tasks"
-learn_rel_path: "Developers/Web"
--->
-
 # `static-threaded` web server
 
 The `static-threaded` web server spawns a fixed number of threads.

--- a/tests/health_mgmtapi/README.md
+++ b/tests/health_mgmtapi/README.md
@@ -1,12 +1,3 @@
-<!--
-title: "Health command API tester"
-custom_edit_url: https://github.com/netdata/netdata/edit/master/tests/health_mgmtapi/README.md
-sidebar_label: "Health command API tester"
-learn_status: "Published"
-learn_topic_type: "References"
-learn_rel_path: "Developers"
--->
-
 # Health command API tester
 
 The directory `tests/health_cmdapi` contains the test script `health-cmdapi-test.sh` for the [health command API](/src/web/api/health/README.md).


### PR DESCRIPTION
##### Summary
removes old Learn metadata from everywhere, using
```
<!--\stitle: "*([\s\S]*?)\s*-->


```

fixes files that had hard tabs and due to a vscode setting (auto-detect indentation) it was messing with the formatter.