### PR TITLE
fix(cgroups.plugin): handle containers no env vars

### DIFF
--- a/src/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/src/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -155,7 +155,7 @@ function docker_like_get_name_api() {
     info "Running API command: curl \"${host}${path}\""
     JSON=$(curl -sS "${host}${path}")
   fi
-  if OUTPUT=$(echo "${JSON}" | jq -r '.Config.Env[],"CONT_NAME=\(.Name)","IMAGE_NAME=\(.Config.Image)"') && [ -n "$OUTPUT" ]; then
+  if OUTPUT=$(echo "${JSON}" | jq -r '.Config.Env[]?,"CONT_NAME=\(.Name)","IMAGE_NAME=\(.Config.Image)"') && [ -n "$OUTPUT" ]; then
     parse_docker_like_inspect_output "$OUTPUT"
   fi
   return 0


### PR DESCRIPTION
##### Summary
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

When building container images "manually" (i.e., not with "docker build"), it is possible to create them with no environment variables specified. When containers are run with these images, they will have a non-existent `.Config.Env`.

This causes no problems for `docker_like_get_name_command()`, however, `docker_like_get_name_api()` will fail with:

> jq: error (at <stdin>:1): Cannot iterate over null (null)

When running netdata inside docker (or on a host that doesn't have docker/podman binaries available), the end result is that it is not able to resolve the cgroup IDs of those containers to their friendly display names.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

Confirmed that cgroup names are able to resolve correctly for all containers. Both "normal" docker-built ones and "funny" manual ones with empty `.Config.Env`).

Example "funny" container image:
```docker pull ghcr.io/daniel-sampliner/nixos/pause:7f40b7d20df8473e42878b5f69b13a0ef4b2c072```

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
-->

- Which area of Netdata is affected by the change?

[plugin:cgroups]

- Can they see the change or is it an under the hood? If they can see it, where?

All cgroup cpu/mem/etc. charts.

- How is the user impacted by the change?

No expected impacts.

- What are there any benefits of the change? 

"Funny" containers will display their correct name instead of a UUID.

</details>
