### PR TITLE
cgroups.plugin: call `setresuid` before spawn server init

### DIFF
--- a/src/collectors/cgroups.plugin/cgroup-network.c
+++ b/src/collectors/cgroups.plugin/cgroup-network.c
@@ -522,9 +522,6 @@ cleanup:
 
 #define CGROUP_NETWORK_INTERFACE_MAX_LINE 2048
 void call_the_helper(pid_t pid, const char *cgroup) {
-    if(setresuid(0, 0, 0) == -1)
-        collector_error("setresuid(0, 0, 0) failed.");
-
     char command[CGROUP_NETWORK_INTERFACE_MAX_LINE + 1];
     if(cgroup)
         snprintfz(command, CGROUP_NETWORK_INTERFACE_MAX_LINE, "exec " PLUGINS_DIR "/cgroup-network-helper.sh --cgroup '%s'", cgroup);
@@ -675,6 +672,10 @@ int main(int argc, const char **argv) {
     pid_t pid = 0;
 
     clocks_init();
+
+    if (setresuid(0, 0, 0) == -1)
+        collector_error("setresuid(0, 0, 0) failed.");
+
     nd_log_initialize_for_external_plugins("cgroup-network");
     netdata_main_spawn_server_init(NULL, argc, argv);
 


### PR DESCRIPTION
##### Summary

Fixes a permission issue with the `cgroup-network-helper.sh` script.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
