### PR TITLE
fix ram usage calculation in LXC

### DIFF
--- a/src/collectors/proc.plugin/proc_meminfo.c
+++ b/src/collectors/proc.plugin/proc_meminfo.c
@@ -235,7 +235,7 @@ int do_proc_meminfo(int update_every, usec_t dt) {
 
     // http://calimeroteknik.free.fr/blag/?article20/really-used-memory-on-gnu-linux
     // KReclaimable includes SReclaimable, it was added in kernel v4.20
-    unsigned long long reclaimable = KReclaimable > 0 ? KReclaimable : SReclaimable;
+    unsigned long long reclaimable = inside_lxc_container ? 0 : (KReclaimable > 0 ? KReclaimable : SReclaimable);
     unsigned long long MemCached = Cached + reclaimable - Shmem;
     unsigned long long MemUsed = MemTotal - MemFree - MemCached - Buffers;
     // The Linux kernel doesn't report ZFS ARC usage as cache memory (the ARC is included in the total used system memory)


### PR DESCRIPTION
##### Summary

When running within an LXC container, the KReclaimable metric is not a reliable indicator of the container's actual reclaimable memory (tested on a Proxmox server), as it reflects the host's overall value.

Noticed because of negative "used"

<img width="1228" alt="Screenshot 2024-10-06 at 18 15 55" src="https://github.com/user-attachments/assets/86945dde-6fbb-46ea-98b5-89ab10dbb41f">


Fixes 

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
