### PR TITLE
Add hyper-v metrics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1510,6 +1510,7 @@ set(WINDOWS_PLUGIN_FILES
         src/collectors/windows.plugin/perflib-memory.c
         src/collectors/windows.plugin/perflib-processes.c
         src/collectors/windows.plugin/perflib-web-service.c
+        src/collectors/windows.plugin/perflib-hyperv.c
 )
 
 set(PROC_PLUGIN_FILES

--- a/src/collectors/all.h
+++ b/src/collectors/all.h
@@ -56,7 +56,7 @@
 #define NETDATA_CHART_PRIO_SYSTEM_PACKETS              7001 // freebsd only
 #define NETDATA_CHART_PRIO_WINDOWS_THREADS             8001 // Windows only
 #define NETDATA_CHART_PRIO_WINDOWS_THERMAL_ZONES       8002 // Windows only
-
+#define NETDATA_CHART_PRIO_WINDOWS_HYPERV              9000 // Windows only
 
 // CPU per core
 

--- a/src/collectors/windows.plugin/windows_plugin.c
+++ b/src/collectors/windows.plugin/windows_plugin.c
@@ -25,7 +25,7 @@ static struct proc_module {
     {.name = "PerflibStorage",      .dim = "PerflibStorage",       .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibStorage},
     {.name = "PerflibNetwork",      .dim = "PerflibNetwork",       .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibNetwork},
     {.name = "PerflibObjects",      .dim = "PerflibObjects",       .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibObjects},
-    {.name = "PerflibHyperV",       .dim = "PerflibHyperV",      .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibHyperV},
+    {.name = "PerflibHyperV",       .dim = "PerflibHyperV",        .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibHyperV},
 
     {.name = "PerflibThermalZone",  .dim = "PerflibThermalZone",   .enabled = CONFIG_BOOLEAN_NO, .func = do_PerflibThermalZone},
 

--- a/src/collectors/windows.plugin/windows_plugin.c
+++ b/src/collectors/windows.plugin/windows_plugin.c
@@ -25,6 +25,7 @@ static struct proc_module {
     {.name = "PerflibStorage",      .dim = "PerflibStorage",       .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibStorage},
     {.name = "PerflibNetwork",      .dim = "PerflibNetwork",       .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibNetwork},
     {.name = "PerflibObjects",      .dim = "PerflibObjects",       .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibObjects},
+    {.name = "PerflibHyperV",       .dim = "PerflibHyperV",      .enabled = CONFIG_BOOLEAN_YES, .func = do_PerflibHyperV},
 
     {.name = "PerflibThermalZone",  .dim = "PerflibThermalZone",   .enabled = CONFIG_BOOLEAN_NO, .func = do_PerflibThermalZone},
 

--- a/src/collectors/windows.plugin/windows_plugin.h
+++ b/src/collectors/windows.plugin/windows_plugin.h
@@ -15,21 +15,6 @@ void *win_plugin_main(void *ptr);
 
 extern char windows_shared_buffer[8192];
 
-static inline void get_and_sanitize_instance_value(
-    PERF_DATA_BLOCK *pDataBlock,
-    PERF_OBJECT_TYPE *pObjectType,
-    PERF_INSTANCE_DEFINITION *pi,
-    char *buffer,
-    size_t buffer_size)
-{
-    char wstr[8192];
-    if (!getInstanceName(pDataBlock, pObjectType, pi, wstr, sizeof(wstr))) {
-        strncpyz(buffer, "[unknown]", buffer_size - 1);
-        return;
-    }
-    rrdlabels_sanitize_value(buffer, wstr, buffer_size);
-}
-
 int do_GetSystemUptime(int update_every, usec_t dt);
 int do_GetSystemRAM(int update_every, usec_t dt);
 int do_GetSystemCPU(int update_every, usec_t dt);

--- a/src/collectors/windows.plugin/windows_plugin.h
+++ b/src/collectors/windows.plugin/windows_plugin.h
@@ -15,6 +15,21 @@ void *win_plugin_main(void *ptr);
 
 extern char windows_shared_buffer[8192];
 
+static inline void get_and_sanitize_instance_value(
+    PERF_DATA_BLOCK *pDataBlock,
+    PERF_OBJECT_TYPE *pObjectType,
+    PERF_INSTANCE_DEFINITION *pi,
+    char *buffer,
+    size_t buffer_size)
+{
+    char wstr[8192];
+    if (!getInstanceName(pDataBlock, pObjectType, pi, wstr, sizeof(wstr))) {
+        strncpyz(buffer, "[unknown]", buffer_size - 1);
+        return;
+    }
+    rrdlabels_sanitize_value(buffer, wstr, buffer_size);
+}
+
 int do_GetSystemUptime(int update_every, usec_t dt);
 int do_GetSystemRAM(int update_every, usec_t dt);
 int do_GetSystemCPU(int update_every, usec_t dt);

--- a/src/collectors/windows.plugin/windows_plugin.h
+++ b/src/collectors/windows.plugin/windows_plugin.h
@@ -99,5 +99,6 @@ enum PERFLIB_PRIO {
     PRIO_NETFRAMEWORK_CLR_LOADING_CLASS_LOAD_FAILURE
 };
 
-#endif //NETDATA_WINDOWS_PLUGIN_H
+int do_PerflibHyperV(int update_every, usec_t dt);
 
+#endif //NETDATA_WINDOWS_PLUGIN_H

--- a/src/database/rrdlabels.h
+++ b/src/database/rrdlabels.h
@@ -75,6 +75,7 @@ pattern_array_add_key_simple_pattern(struct pattern_array *pa, const char *key, 
 void pattern_array_free(struct pattern_array *pa);
 
 int rrdlabels_unittest(void);
+size_t rrdlabels_sanitize_name(char *dst, const char *src, size_t dst_size);
 
 // unfortunately this break when defined in exporting_engine.h
 bool exporting_labels_filter_callback(const char *name, const char *value, RRDLABEL_SRC ls, void *data);


### PR DESCRIPTION
##### Summary
Add hyper v metrics -- charts for 
- VM Memory Pressure
- VM Assigned Memory
- VM Guest Visible Memory
- VM Physical Pages Allocated
- VM Physical Pages Not Allocated from Preferred NUMA Node
- Virtual Machines Health Status
- Root Partition Device Space Pages
- Root Partition GPA Space Pages
- Root Partition GPA Space Modifications
- Root Partition Attached Devices
- Root Partition Deposited Pages
- Root Partition Illegal DMA Requests
- Root Partition Illegal Interrupt Requests
- Root Partition Throttled Interrupts
- Root Partition Flushes of I/O TLBs
- Root Partition Address Spaces in Virtual TLB
- Root Partition Pages Used by Virtual TLB
- Root Partition Flushes of Entire Virtual TLB
- VM Storage Device IOPS
- VM Storage Device IO
- VM Storage Device Errors
- Virtual Switch Traffic
- Virtual Switch Packets
- Virtual Switch Directed Packets
- Virtual Switch Broadcast Packets
- Virtual Switch Multicast Packets
- Virtual Switch Dropped Packets
- Virtual Switch Extensions Dropped Packets
- Virtual Switch Flooded Packets
- Virtual Switch Learned MAC Addresses
- Virtual Switch Purged MAC Addresses
- VM Interface Packets Dropped
- VM CPU Usage