### PR TITLE
Detect when swap is disabled when agent is running

### DIFF
--- a/src/collectors/common-contexts/mem-swap.h
+++ b/src/collectors/common-contexts/mem-swap.h
@@ -6,6 +6,14 @@ static inline void common_mem_swap(uint64_t free_bytes, uint64_t used_bytes, int
     static RRDSET *st_system_swap = NULL;
     static RRDDIM *rd_free = NULL, *rd_used = NULL;
 
+    if (free_bytes == 0 && used_bytes == 0 && st_system_swap) {
+        rrdset_is_obsolete___safe_from_collector_thread(st_system_swap);
+        st_system_swap = NULL;
+        rd_free = NULL;
+        rd_used = NULL;
+        return;
+    }
+
     if(unlikely(!st_system_swap)) {
         st_system_swap = rrdset_create_localhost(
             "mem"

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -75,10 +75,13 @@ static inline int rrdcalc_isrunnable(RRDCALC *rc, time_t now, time_t *next_run) 
         time_t needed = now + rc->config.before + rc->config.after;
 
         if(needed + update_every < first || needed - update_every > last) {
-            netdata_log_debug(D_HEALTH
-                              , "Health not examining alarm '%s.%s' yet (not enough data yet - we need %lu but got %lu - %lu)."
-                              , rrdcalc_chart_name(rc), rrdcalc_name(rc), (unsigned long) needed, (unsigned long) first
-                              , (unsigned long) last);
+            netdata_log_info(
+                "Health not examining alarm '%s.%s' yet (not enough data yet - we need %lu but got %lu - %lu).",
+                rrdcalc_chart_name(rc),
+                rrdcalc_name(rc),
+                (unsigned long) needed,
+                (unsigned long) first,
+                (unsigned long) last);
             return 0;
         }
     }


### PR DESCRIPTION
##### Summary
When swap is enabled but it is later on disabled when the agent is running, the corresponding chart stops being collected but it is not marked as obsolete. 

When a chart is marked as obsolete the health engine will automatically generate a REMOVED event. This will clear any warning or critical events
