### PR TITLE
Pass correct GOOS and GOARCH on to package builders in CI.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -6,7 +6,7 @@ platform_map:  # map packaging architectures to docker platforms
   arm64: linux/arm64/v8
   armhf: linux/arm/v7
   armhfp: linux/arm/v7
-  i386: linux/i386
+  i386: linux/386
   x86_64: linux/amd64
 arch_order:  # sort order for per-architecture jobs in CI
   - amd64

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -256,9 +256,10 @@ jobs:
         shell: bash
         run: |
           docker run --security-opt seccomp=unconfined -e DISABLE_TELEMETRY=1 -e VERSION=${{ needs.version-check.outputs.version }} \
-                    -e ENABLE_SENTRY=${{ matrix.bundle_sentry }} -e RELEASE_PIPELINE=${{ env.RELEASE_PIPELINE }} \
-                    -e BUILD_DESTINATION=${{ matrix.distro }}${{ matrix.version }}_${{ matrix.arch }} -e UPLOAD_SENTRY=${{ env.UPLOAD_SENTRY }} \
-                    -e SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_CLI_TOKEN }} -e NETDATA_SENTRY_DSN=${{ secrets.SENTRY_DSN }} \
+                     -e ENABLE_SENTRY=${{ matrix.bundle_sentry }} -e RELEASE_PIPELINE=${{ env.RELEASE_PIPELINE }} \
+                     -e BUILD_DESTINATION=${{ matrix.distro }}${{ matrix.version }}_${{ matrix.arch }} -e UPLOAD_SENTRY=${{ env.UPLOAD_SENTRY }} \
+                     -e SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_CLI_TOKEN }} -e NETDATA_SENTRY_DSN=${{ secrets.SENTRY_DSN }} \
+                     -e GOOS=$(echo ${{ matrix.platform }} | cut -f 1 -d '/') -e GOARCH=$(echo ${{ matrix.platform }} | cut -f 2 -d '/') \
                      --platform=${{ matrix.platform }} -v "$PWD":/netdata netdata/package-builders:${{ matrix.distro }}${{ matrix.version }}-${{ matrix.builder_rev }}
       - name: Save Packages
         id: artifacts


### PR DESCRIPTION
##### Summary

This ensures that they don’t pick up the host CPU and build for that instead, because apparently Go looks at the host CPU instead of itself to decide what the default build target is, so if you’re running a 32-bit build of Go on a 64-bit kernel, you get 64-bit binaries by default...

##### Test Plan

Once CI is complete on the PR, the packages produced as part of the build need to be inspected to confirm that the go plugin was built for the right architecture.

##### Additional Information

Fixes: #18716

@netdata/agent this needs to be included in our next patch release, and the issue probably is major enough to warrant a new patch release on it’s own.