### PR TITLE
[storcli] Support for controller ROC temperature.

### DIFF
--- a/src/go/plugin/go.d/modules/storcli/charts.go
+++ b/src/go/plugin/go.d/modules/storcli/charts.go
@@ -14,6 +14,7 @@ const (
 	prioControllerHealthStatus = module.Priority + iota
 	prioControllerStatus
 	prioControllerBBUStatus
+	prioControllerROCTemperature
 
 	prioPhysDriveErrors
 	prioPhysDrivePredictiveFailures
@@ -31,6 +32,7 @@ var controllerMegaraidChartsTmpl = module.Charts{
 
 var controllerMpt3sasChartsTmpl = module.Charts{
 	controllerHealthStatusChartTmpl.Copy(),
+	controllerROCTemperatureChartTmpl.Copy(),
 }
 
 var (
@@ -74,6 +76,18 @@ var (
 			{ID: "cntrl_%s_bbu_status_healthy", Name: "healthy"},
 			{ID: "cntrl_%s_bbu_status_unhealthy", Name: "unhealthy"},
 			{ID: "cntrl_%s_bbu_status_na", Name: "na"},
+		},
+	}
+	controllerROCTemperatureChartTmpl = module.Chart{
+		ID:       "controller_%s_roc_temperature_celsius",
+		Title:    "Controller ROC Temperature Celsius",
+		Units:    "Celsius",
+		Fam:      "cntrl roc temperature",
+		Ctx:      "storcli.controller_roc_temperature_celsius",
+		Type:     module.Line,
+		Priority: prioControllerROCTemperature,
+		Dims: module.Dims{
+			{ID: "cntrl_%s_roc_temperature_celsius", Name: "temperature"},
 		},
 	}
 )

--- a/src/go/plugin/go.d/modules/storcli/charts.go
+++ b/src/go/plugin/go.d/modules/storcli/charts.go
@@ -79,11 +79,11 @@ var (
 		},
 	}
 	controllerROCTemperatureChartTmpl = module.Chart{
-		ID:       "controller_%s_roc_temperature_celsius",
-		Title:    "Controller ROC Temperature Celsius",
+		ID:       "controller_%s_roc_temperature",
+		Title:    "Controller ROC temperature",
 		Units:    "Celsius",
 		Fam:      "cntrl roc temperature",
-		Ctx:      "storcli.controller_roc_temperature_celsius",
+		Ctx:      "storcli.controller_roc_temperature",
 		Type:     module.Line,
 		Priority: prioControllerROCTemperature,
 		Dims: module.Dims{
@@ -179,6 +179,9 @@ func (s *StorCli) addControllerCharts(cntrl controllerInfo) {
 		charts = controllerMegaraidChartsTmpl.Copy()
 	case driverNameSas:
 		charts = controllerMpt3sasChartsTmpl.Copy()
+		if !strings.EqualFold(cntrl.HwCfg.TemperatureSensorForROC, "present") {
+			_ = charts.Remove(controllerROCTemperatureChartTmpl.ID)
+		}
 	default:
 		return
 	}

--- a/src/go/plugin/go.d/modules/storcli/collect_controllers.go
+++ b/src/go/plugin/go.d/modules/storcli/collect_controllers.go
@@ -35,7 +35,7 @@ type (
 		} `json:"Status"`
 		HwCfg struct {
 			TemperatureSensorForROC string `json:"Temperature Sensor for ROC"`
-			ROCTemperatureC int `json:"ROC temperature(Degree Celsius)"`
+			ROCTemperatureC         int    `json:"ROC temperature(Degree Celsius)"`
 		} `json:"HwCfg"`
 		BBUInfo []struct {
 			Model string `json:"Model"`
@@ -123,13 +123,14 @@ func (s *StorCli) collectMpt3sasControllersInfo(mx map[string]int64, resp *contr
 		for _, st := range []string{"healthy", "unhealthy"} {
 			mx[px+"health_status_"+st] = 0
 		}
-		if strings.ToLower(cntrl.Status.ControllerStatus) == "ok" {
+
+		if strings.EqualFold(cntrl.Status.ControllerStatus, "ok") {
 			mx[px+"health_status_healthy"] = 1
 		} else {
 			mx[px+"health_status_unhealthy"] = 1
 		}
 
-		if strings.ToLower(cntrl.HwCfg.TemperatureSensorForROC) == "present" {
+		if strings.EqualFold(cntrl.HwCfg.TemperatureSensorForROC, "present") {
 			mx[px+"roc_temperature_celsius"] = int64(cntrl.HwCfg.ROCTemperatureC)
 		}
 	}

--- a/src/go/plugin/go.d/modules/storcli/collect_controllers.go
+++ b/src/go/plugin/go.d/modules/storcli/collect_controllers.go
@@ -33,6 +33,10 @@ type (
 			ControllerStatus string      `json:"Controller Status"`
 			BBUStatus        *storNumber `json:"BBU Status"`
 		} `json:"Status"`
+		HwCfg struct {
+			TemperatureSensorForROC string `json:"Temperature Sensor for ROC"`
+			ROCTemperatureC int `json:"ROC temperature(Degree Celsius)"`
+		} `json:"HwCfg"`
 		BBUInfo []struct {
 			Model string `json:"Model"`
 			State string `json:"State"`
@@ -123,6 +127,10 @@ func (s *StorCli) collectMpt3sasControllersInfo(mx map[string]int64, resp *contr
 			mx[px+"health_status_healthy"] = 1
 		} else {
 			mx[px+"health_status_unhealthy"] = 1
+		}
+
+		if strings.ToLower(cntrl.HwCfg.TemperatureSensorForROC) == "present" {
+			mx[px+"roc_temperature_celsius"] = int64(cntrl.HwCfg.ROCTemperatureC)
 		}
 	}
 

--- a/src/go/plugin/go.d/modules/storcli/metadata.yaml
+++ b/src/go/plugin/go.d/modules/storcli/metadata.yaml
@@ -138,6 +138,12 @@ modules:
                 - name: healthy
                 - name: unhealthy
                 - name: na
+            - name: storcli.controller_roc_temperature
+              description: Controller ROC temperature
+              unit: Celsius
+              chart_type: line
+              dimensions:
+                - name: temperature
         - name: physical drive
           description: These metrics refer to the Physical Drive.
           labels:

--- a/src/go/plugin/go.d/modules/storcli/storcli_test.go
+++ b/src/go/plugin/go.d/modules/storcli/storcli_test.go
@@ -205,6 +205,7 @@ func TestStorCli_Collect(t *testing.T) {
 			wantMetrics: map[string]int64{
 				"cntrl_0_health_status_healthy":   1,
 				"cntrl_0_health_status_unhealthy": 0,
+				"cntrl_0_roc_temperature_celsius": 44,
 			},
 		},
 		"err on exec": {


### PR DESCRIPTION
This change adds support for reported Raid-on-Chip (ROC) controller temperatures to be published into netdata.

##### Summary
The current storcli plugin doesn't report temperature information that's available on my card. This change adds it.

##### Test Plan
I manually tested this by running it on my netdata instance.

Attached is a screenshot of it working
![Screenshot 2024-10-08 at 22 00 30](https://github.com/user-attachments/assets/dd6b5f9a-2be2-4dbc-9832-47f11f77827a)
