### PR TITLE
Windows deploy metadata

### DIFF
--- a/integrations/deploy.yaml
+++ b/integrations/deploy.yaml
@@ -568,7 +568,11 @@
 
     ## Silent Mode (Command line)
 
-    If you prefer to install Netdata through the command line, you can do so by running the following command on Windows Powershell with administrator rights:
+    If you prefer to install Netdata through the command line, you can do so by running the following command on Windows Powershell with administrator rights.
+
+    > **Note**
+    >
+    > The Windows installer is currently under beta, and thus it is only available in the nightly release channel. A stable version will be released soon.
 
   methods:
     - method: Silent Mode (Command line)
@@ -580,7 +584,7 @@
             .\netdata-installer-x64.exe /S /A `
             {% if $showClaimingOptions %}/TOKEN={% claim_token %} /ROOMS={% $claim_rooms %}{% /if %}
         - channel: nightly
-          command: >
+          command: |
             $ProgressPreference = 'SilentlyContinue';
             Invoke-WebRequest https://github.com/netdata/netdata-nightlies/releases/latest/download/netdata-installer-x64.exe -OutFile "netdata-installer-x64.exe";
             .\netdata-installer-x64.exe /S /A `

--- a/integrations/deploy.yaml
+++ b/integrations/deploy.yaml
@@ -560,6 +560,8 @@
   install_description: |
     Netdata offers a convenient Windows installer for easy setup. This executable provides two distinct installation modes, outlined below.
 
+    The Windows installer is currently under beta, and thus it is only available in the nightly release channel. A stable version will be released soon.
+
     ## Graphical User Interface (GUI)
 
     1. Download the Netdata [Windows installer](https://github.com/netdata/netdata-nightlies/releases) from the latest nightly release.
@@ -569,9 +571,6 @@
     ## Silent Mode (Command line)
 
     If you prefer to install Netdata through the command line, you can do so by running the following command on Windows Powershell with administrator rights.
-
-    The Windows installer is currently under beta, and thus it is only available in the nightly release channel. A stable version will be released soon.
-
   methods:
     - method: Silent Mode (Command line)
       commands:

--- a/integrations/deploy.yaml
+++ b/integrations/deploy.yaml
@@ -570,9 +570,7 @@
 
     If you prefer to install Netdata through the command line, you can do so by running the following command on Windows Powershell with administrator rights.
 
-    > **Note**
-    >
-    > The Windows installer is currently under beta, and thus it is only available in the nightly release channel. A stable version will be released soon.
+    The Windows installer is currently under beta, and thus it is only available in the nightly release channel. A stable version will be released soon.
 
   methods:
     - method: Silent Mode (Command line)

--- a/integrations/deploy.yaml
+++ b/integrations/deploy.yaml
@@ -576,13 +576,13 @@
         - channel: stable
           command: |
             $ProgressPreference = 'SilentlyContinue';
-            Invoke-WebRequest https://github.com/netdata/netdata-nightlies/releases/download/v1.99.0-267-nightly/netdata-installer-x64.exe -OutFile "netdata-installer-x64.exe";
+            Invoke-WebRequest https://github.com/netdata/netdata-nightlies/releases/latest/download/netdata-installer-x64.exe -OutFile "netdata-installer-x64.exe";
             .\netdata-installer-x64.exe /S /A `
             {% if $showClaimingOptions %}/TOKEN={% claim_token %} /ROOMS={% $claim_rooms %}{% /if %}
         - channel: nightly
           command: >
             $ProgressPreference = 'SilentlyContinue';
-            Invoke-WebRequest https://github.com/netdata/netdata-nightlies/releases/download/v1.99.0-267-nightly/netdata-installer-x64.exe -OutFile "netdata-installer-x64.exe";
+            Invoke-WebRequest https://github.com/netdata/netdata-nightlies/releases/latest/download/netdata-installer-x64.exe -OutFile "netdata-installer-x64.exe";
             .\netdata-installer-x64.exe /S /A `
             {% if $showClaimingOptions %}/TOKEN={% claim_token %} /ROOMS={% $claim_rooms %}{% /if %}
   additional_info: |

--- a/integrations/deploy.yaml
+++ b/integrations/deploy.yaml
@@ -574,11 +574,17 @@
     - method: Silent Mode (Command line)
       commands:
         - channel: stable
-          command: >
-            $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest https://github.com/netdata/netdata-nightlies/releases/download/v1.99.0-267-nightly/netdata-installer-x64.exe -OutFile "netdata-installer-x64.exe"; .\netdata-installer-x64.exe /S /A {% if $showClaimingOptions %}/TOKEN={% claim_token %} /ROOMS={% $claim_rooms %}{% /if %}
+          command: |
+            $ProgressPreference = 'SilentlyContinue';
+            Invoke-WebRequest https://github.com/netdata/netdata-nightlies/releases/download/v1.99.0-267-nightly/netdata-installer-x64.exe -OutFile "netdata-installer-x64.exe";
+            .\netdata-installer-x64.exe /S /A `
+            {% if $showClaimingOptions %}/TOKEN={% claim_token %} /ROOMS={% $claim_rooms %}{% /if %}
         - channel: nightly
           command: >
-            $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest https://github.com/netdata/netdata-nightlies/releases/download/v1.99.0-267-nightly/netdata-installer-x64.exe -OutFile "netdata-installer-x64.exe"; .\netdata-installer-x64.exe /S /A {% if $showClaimingOptions %}/TOKEN={% claim_token %} /ROOMS={% $claim_rooms %}{% /if %}
+            $ProgressPreference = 'SilentlyContinue';
+            Invoke-WebRequest https://github.com/netdata/netdata-nightlies/releases/download/v1.99.0-267-nightly/netdata-installer-x64.exe -OutFile "netdata-installer-x64.exe";
+            .\netdata-installer-x64.exe /S /A `
+            {% if $showClaimingOptions %}/TOKEN={% claim_token %} /ROOMS={% $claim_rooms %}{% /if %}
   additional_info: |
     ### Available Options
 

--- a/integrations/deploy.yaml
+++ b/integrations/deploy.yaml
@@ -16,23 +16,19 @@
       commands:
         - channel: nightly
           command: >
-            wget -O /tmp/netdata-kickstart.sh https://get.netdata.cloud/kickstart.sh && sh /tmp/netdata-kickstart.sh
-            --nightly-channel{% if $showClaimingOptions %} --claim-token {% claim_token %} --claim-rooms {% $claim_rooms %} --claim-url {% claim_url %}{% /if %}
+            wget -O /tmp/netdata-kickstart.sh https://get.netdata.cloud/kickstart.sh && sh /tmp/netdata-kickstart.sh --nightly-channel{% if $showClaimingOptions %} --claim-token {% claim_token %} --claim-rooms {% $claim_rooms %} --claim-url {% claim_url %}{% /if %}
         - channel: stable
           command: >
-            wget -O /tmp/netdata-kickstart.sh https://get.netdata.cloud/kickstart.sh && sh /tmp/netdata-kickstart.sh
-            --stable-channel{% if $showClaimingOptions %} --claim-token {% claim_token %} --claim-rooms {% $claim_rooms %} --claim-url {% claim_url %}{% /if %}
+            wget -O /tmp/netdata-kickstart.sh https://get.netdata.cloud/kickstart.sh && sh /tmp/netdata-kickstart.sh --stable-channel{% if $showClaimingOptions %} --claim-token {% claim_token %} --claim-rooms {% $claim_rooms %} --claim-url {% claim_url %}{% /if %}
     - &ks_curl
       method: curl
       commands:
         - channel: nightly
           command: >
-            curl https://get.netdata.cloud/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh
-            --nightly-channel{% if $showClaimingOptions %} --claim-token {% claim_token %} --claim-rooms {% $claim_rooms %} --claim-url {% claim_url %}{% /if %}
+            curl https://get.netdata.cloud/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh --nightly-channel{% if $showClaimingOptions %} --claim-token {% claim_token %} --claim-rooms {% $claim_rooms %} --claim-url {% claim_url %}{% /if %}
         - channel: stable
           command: >
-            curl https://get.netdata.cloud/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh
-            --stable-channel{% if $showClaimingOptions %} --claim-token {% claim_token %} --claim-rooms {% $claim_rooms %} --claim-url {% claim_url %}{% /if %}
+            curl https://get.netdata.cloud/kickstart.sh > /tmp/netdata-kickstart.sh && sh /tmp/netdata-kickstart.sh --stable-channel{% if $showClaimingOptions %} --claim-token {% claim_token %} --claim-rooms {% $claim_rooms %} --claim-url {% claim_url %}{% /if %}
   additional_info: &ref_containers >
     Did you know you can also deploy Netdata on your OS using {% goToCategory navigateToSettings=$navigateToSettings categoryId="deploy.docker-kubernetes" %}Kubernetes{% /goToCategory %} or {% goToCategory categoryId="deploy.docker-kubernetes" %}Docker{% /goToCategory %}?
   clean_additional_info: &ref_clean_containers >
@@ -562,14 +558,40 @@
   keywords:
     - windows
   install_description: |
-    1. Install [Windows Exporter](https://github.com/prometheus-community/windows_exporter) on every Windows host you want to monitor.
-    2. Install Netdata agent on Linux, FreeBSD or Mac.
-    3. Configure Netdata to collect data remotely from your Windows hosts by adding one job per host to windows.conf file. See the [configuration section](https://learn.netdata.cloud/docs/data-collection/monitor-anything/System%20Metrics/Windows-machines#configuration) for details.
-    4. Enable [virtual nodes](https://learn.netdata.cloud/docs/data-collection/windows-systems#virtual-nodes) configuration so the windows nodes are displayed as separate nodes.
+    Netdata offers a convenient Windows installer for easy setup. This executable provides two distinct installation modes, outlined below.
+
+    ## Graphical User Interface (GUI)
+
+    1. Download the Netdata [Windows installer](https://github.com/netdata/netdata-nightlies/releases) from the latest nightly release.
+    2. Run the `.exe` file and proceed with the installation process.
+    3. At a minimum, you will need your Netdata Cloud Space's claim token to connect your Agent to your Space.
+
+    ## Silent Mode (Command line)
+
+    If you prefer to install Netdata through the command line, you can do so by running the following command on Windows Powershell with administrator rights:
+
   methods:
-    - *ks_wget
-    - *ks_curl
-  additional_info: ""
+    - method: Silent Mode (Command line)
+      commands:
+        - channel: stable
+          command: >
+            $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest https://github.com/netdata/netdata-nightlies/releases/download/v1.99.0-267-nightly/netdata-installer-x64.exe -OutFile "netdata-installer-x64.exe"; .\netdata-installer-x64.exe /S /A {% if $showClaimingOptions %}/TOKEN={% claim_token %} /ROOMS={% $claim_rooms %}{% /if %}
+        - channel: nightly
+          command: >
+            $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest https://github.com/netdata/netdata-nightlies/releases/download/v1.99.0-267-nightly/netdata-installer-x64.exe -OutFile "netdata-installer-x64.exe"; .\netdata-installer-x64.exe /S /A {% if $showClaimingOptions %}/TOKEN={% claim_token %} /ROOMS={% $claim_rooms %}{% /if %}
+  additional_info: |
+    ### Available Options
+
+    | Option    | Description                                                                                      |
+    |-----------|--------------------------------------------------------------------------------------------------|
+    | `/S`      | Enables silent mode installation.                                                                |
+    | `/A`      | Accepts all Netdata licenses. This option is mandatory for silent installations.                 |
+    | `/D`      | Specifies the desired installation directory (defaults to `C:\Program Files\Netdata`).           |
+    | `/T`      | Opens the `MSYS2` terminal after installation.                                                   |
+    | `/I`      | Forces insecure connections, bypassing hostname verification (use only if absolutely necessary). |
+    | `/TOKEN=` | Sets the Claim Token for your Netdata Cloud Space.                                               |
+    | `/ROOMS=` | Comma-separated list of Room IDs where you want your node to appear.                             |
+    | `/PROXY=` | Sets the proxy server address if your network requires one.                                      |
   related_resources: {}
   most_popular: true
   platform_info:
@@ -600,12 +622,10 @@
       commands:
         - channel: nightly
           command: >
-            fetch -o /tmp/netdata-kickstart.sh https://get.netdata.cloud/kickstart.sh && sh /tmp/netdata-kickstart.sh
-            --nightly-channel{% if $showClaimingOptions %} --claim-token {% claim_token %} --claim-rooms {% $claim_rooms %} --claim-url {% claim_url %}{% /if %}
+            fetch -o /tmp/netdata-kickstart.sh https://get.netdata.cloud/kickstart.sh && sh /tmp/netdata-kickstart.sh --nightly-channel{% if $showClaimingOptions %} --claim-token {% claim_token %} --claim-rooms {% $claim_rooms %} --claim-url {% claim_url %}{% /if %}
         - channel: stable
           command: >
-            fetch -o /tmp/netdata-kickstart.sh https://get.netdata.cloud/kickstart.sh && sh /tmp/netdata-kickstart.sh
-            --stable-channel{% if $showClaimingOptions %} --claim-token {% claim_token %} --claim-rooms {% $claim_rooms %} --claim-url {% claim_url %}{% /if %}
+            fetch -o /tmp/netdata-kickstart.sh https://get.netdata.cloud/kickstart.sh && sh /tmp/netdata-kickstart.sh --stable-channel{% if $showClaimingOptions %} --claim-token {% claim_token %} --claim-rooms {% $claim_rooms %} --claim-url {% claim_url %}{% /if %}
   additional_info: |
     Netdata can also be installed via [FreeBSD ports](https://www.freshports.org/net-mgmt/netdata).
   related_resources: {}

--- a/integrations/templates/platform_info.md
+++ b/integrations/templates/platform_info.md
@@ -6,6 +6,6 @@ We build native packages for the following releases:
 [% for e in entries %]
 | [[ e.version ]] | [[ e.support ]] | [[ ', '.join(e.arches) ]] | [[ e.notes ]] |
 [% endfor %]
-[% endif %]
 
 On other releases of this distribution, a static binary will be installed in `/opt/netdata`.
+[% endif %]

--- a/packaging/windows/WINDOWS_INSTALLER.md
+++ b/packaging/windows/WINDOWS_INSTALLER.md
@@ -63,7 +63,7 @@ Replace `<YOUR_TOKEN>` and `<YOUR_ROOM>` with your actual Netdata Cloud Space cl
 >
 > The Windows version of Netdata is intended for users on paid plans.
 >
-> The Windows installer is currently under beta, and thus it is only available in the nightly release channel. A stable version will be released soon.
+> The Windows installer is currently under beta. A stable version will be released soon.
 
 ## Uninstalling
 

--- a/packaging/windows/WINDOWS_INSTALLER.md
+++ b/packaging/windows/WINDOWS_INSTALLER.md
@@ -4,7 +4,7 @@ Netdata offers a convenient Windows installer for easy setup. This executable pr
 
 > **Note**
 >
-> This feature is currently only available for Nightly releases, and the installer can be found in our [nightlies repo](https://github.com/netdata/netdata-nightlies)
+> This feature is currently under beta and only available for Nightly releases, and the installer can be found in our [nightlies repo](https://github.com/netdata/netdata-nightlies). A stable version will be released soon.
 
 ## Graphical User Interface (GUI)
 
@@ -62,8 +62,6 @@ Replace `<YOUR_TOKEN>` and `<YOUR_ROOM>` with your actual Netdata Cloud Space cl
 > **Note**
 >
 > The Windows version of Netdata is intended for users on paid plans.
->
-> The Windows installer is currently under beta. A stable version will be released soon.
 
 ## Uninstalling
 

--- a/packaging/windows/WINDOWS_INSTALLER.md
+++ b/packaging/windows/WINDOWS_INSTALLER.md
@@ -54,7 +54,7 @@ This section provides instructions for installing Netdata in silent mode, which 
 Connect your Agent to your Netdata Cloud Space with token `<YOUR_TOKEN>` and room `<YOUR_ROOM>`:
 
 ```bash
-netdata-installer.exe /S /A /TOKEN=<YOUR_TOKEN> /ROOMS=<YOUR_ROOM>
+netdata-installer-x64.exe /S /A /TOKEN=<YOUR_TOKEN> /ROOMS=<YOUR_ROOM>
 ```
 
 Replace `<YOUR_TOKEN>` and `<YOUR_ROOM>` with your actual Netdata Cloud Space claim token and room ID, respectively.

--- a/packaging/windows/WINDOWS_INSTALLER.md
+++ b/packaging/windows/WINDOWS_INSTALLER.md
@@ -59,6 +59,12 @@ netdata-installer-x64.exe /S /A /TOKEN=<YOUR_TOKEN> /ROOMS=<YOUR_ROOM>
 
 Replace `<YOUR_TOKEN>` and `<YOUR_ROOM>` with your actual Netdata Cloud Space claim token and room ID, respectively.
 
+> **Note**
+>
+> The Windows version of Netdata is intended for users on paid plans.
+>
+> The Windows installer is currently under beta, and thus it is only available in the nightly release channel. A stable version will be released soon.
+
 ## Uninstalling
 
 To uninstall Netdata, run the `uninstall.exe` file in your Netdata installation directory, typically `<YOUR_INSTALL_LOCATION>\Netdata`.


### PR DESCRIPTION
##### Summary

integrations/deploy.yaml :point_right: format the file and replace the windows exporter deployment with the windows installer

integrations/templates/platform_info.md :point_right: include a sentence inside the if clause, so it does not appear everywhere

packaging/windows/WINDOWS_INSTALLER.md :point_right: the name of the .exe has changed

cc @netdata/product 

I tested the v3 UI locally and the result looks like:

![image](https://github.com/user-attachments/assets/c9ebec70-1f4b-46d2-9130-714fe76d0793)

and should have the `/TOKEN=` and `/ROOMS=` once it is merged and viewed in prod.