### PR TITLE
fix(freebsd.plugin): fix sysctl arcstats.p fails on FreeBSD 14

### DIFF
--- a/src/collectors/freebsd.plugin/freebsd_kstat_zfs.c
+++ b/src/collectors/freebsd.plugin/freebsd_kstat_zfs.c
@@ -43,6 +43,8 @@ int do_kstat_zfs_misc_arcstats(int update_every, usec_t dt) {
         int hash_chains[5];
         int hash_chain_max[5];
         int p[5];
+        int pd[5];
+        int pm[5];
         int c[5];
         int c_min[5];
         int c_max[5];
@@ -145,7 +147,14 @@ int do_kstat_zfs_misc_arcstats(int update_every, usec_t dt) {
     GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.hash_collisions", mibs.hash_collisions, arcstats.hash_collisions);
     GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.hash_chains", mibs.hash_chains, arcstats.hash_chains);
     GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.hash_chain_max", mibs.hash_chain_max, arcstats.hash_chain_max);
+
+#if __FreeBSD_version >= 1400000
+    GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.pd", mibs.pd, arcstats.pd);
+    GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.pm", mibs.pm, arcstats.pm);
+#else
     GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.p", mibs.p, arcstats.p);
+#endif
+
     GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.c", mibs.c, arcstats.c);
     GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.c_min", mibs.c_min, arcstats.c_min);
     GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.c_max", mibs.c_max, arcstats.c_max);

--- a/src/collectors/proc.plugin/proc_spl_kstat_zfs.c
+++ b/src/collectors/proc.plugin/proc_spl_kstat_zfs.c
@@ -54,6 +54,8 @@ int do_proc_spl_kstat_zfs_arcstats(int update_every, usec_t dt) {
         arl_expect(arl_base, "hash_chains", &arcstats.hash_chains);
         arl_expect(arl_base, "hash_chain_max", &arcstats.hash_chain_max);
         arl_expect(arl_base, "p", &arcstats.p);
+        arl_expect(arl_base, "pd", &arcstats.pd);
+        arl_expect(arl_base, "pm", &arcstats.pd);
         arl_expect(arl_base, "c", &arcstats.c);
         arl_expect(arl_base, "c_min", &arcstats.c_min);
         arl_expect(arl_base, "c_max", &arcstats.c_max);

--- a/src/collectors/proc.plugin/zfs_common.c
+++ b/src/collectors/proc.plugin/zfs_common.c
@@ -560,7 +560,7 @@ void generate_charts_arc_summary(const char *plugin, const char *module, int upd
     //unsigned long long anon_hits = arcstats.hits - (arcstats.mfu_hits + arcstats.mru_hits + arcstats.mfu_ghost_hits + arcstats.mru_ghost_hits);
 
     unsigned long long arc_size = arcstats.size;
-    unsigned long long mru_size = arcstats.p;
+    unsigned long long mru_size = arcstats.p > 0 ? arcstats.p : arcstats.pd + arcstats.pm;
     //unsigned long long target_min_size = arcstats.c_min;
     //unsigned long long target_max_size = arcstats.c_max;
     unsigned long long target_size = arcstats.c;

--- a/src/collectors/proc.plugin/zfs_common.h
+++ b/src/collectors/proc.plugin/zfs_common.h
@@ -41,6 +41,8 @@ struct arcstats {
     unsigned long long hash_chains;
     unsigned long long hash_chain_max;
     unsigned long long p;
+    unsigned long long pd;
+    unsigned long long pm;
     unsigned long long c;
     unsigned long long c_min;
     unsigned long long c_max;


### PR DESCRIPTION
##### Summary

Fixes: #16644

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
