### PR TITLE
Add Ubuntu 24.10 and Fedora 41 to CI.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -174,7 +174,7 @@ include:
 
   - &fedora
     distro: fedora
-    version: "40"
+    version: "41"
     support_type: Core
     notes: ''
     eol_check: true
@@ -183,11 +183,18 @@ include:
       dnf remove -y json-c-devel
     packages: &fedora_packages
       type: rpm
-      repo_distro: fedora/40
+      repo_distro: fedora/41
       builder_rev: *def_builder_rev
       arches:
         - x86_64
         - aarch64
+    test:
+      ebpf-core: true
+  - <<: *fedora
+    version: "40"
+    packages:
+      <<: *fedora_packages
+      repo_distro: fedora/40
     test:
       ebpf-core: true
   - <<: *fedora
@@ -303,6 +310,11 @@ include:
         - arm64
     test:
       ebpf-core: true
+  - <<: *ubuntu
+    version: "24.10"
+    packages:
+      <<: *ubuntu_packages
+      repo_distro: ubuntu/oracular
   - <<: *ubuntu
     version: "22.04"
     packages:

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -411,8 +411,8 @@ detect_package_manager_from_distribution() {
     centos* | clearos* | rocky* | almalinux*)
       package_installer=""
       tree="centos"
-      [[ -n "${yum}" ]] && package_installer="install_yum"
       [[ -n "${dnf}" ]] && package_installer="install_dnf"
+      [[ -n "${yum}" ]] && package_installer="install_yum"
       if [[ "${IGNORE_INSTALLED}" -eq 0 ]] && [[ -z "${package_installer}" ]]; then
         echo >&2 "command 'yum' or 'dnf' is required to install packages on a '${distribution} ${version}' system."
         exit 1
@@ -422,8 +422,8 @@ detect_package_manager_from_distribution() {
     fedora* | redhat* | red\ hat* | rhel*)
       package_installer=
       tree="rhel"
-      [[ -n "${yum}" ]] && package_installer="install_yum"
       [[ -n "${dnf}" ]] && package_installer="install_dnf"
+      [[ -n "${yum}" ]] && package_installer="install_yum"
       if [[ "${IGNORE_INSTALLED}" -eq 0 ]] && [[ -z "${package_installer}" ]]; then
         echo >&2 "command 'yum' or 'dnf' is required to install packages on a '${distribution} ${version}' system."
         exit 1
@@ -1543,7 +1543,7 @@ install_yum() {
 
 validate_install_dnf() {
   echo >&2 " > Checking if package '${*}' is installed..."
-  dnf list installed "${*}" > /dev/null 2>&1 || echo "${*}"
+  dnf list --installed "${*}" > /dev/null 2>&1 || echo "${*}"
 }
 
 install_dnf() {

--- a/packaging/installer/install-required-packages.sh
+++ b/packaging/installer/install-required-packages.sh
@@ -419,7 +419,7 @@ detect_package_manager_from_distribution() {
       fi
       ;;
 
-    fedora* | redhat* | red\ hat* | rhel*)
+    redhat* | red\ hat* | rhel*)
       package_installer=
       tree="rhel"
       [[ -n "${dnf}" ]] && package_installer="install_dnf"
@@ -429,6 +429,16 @@ detect_package_manager_from_distribution() {
         exit 1
       fi
       ;;
+
+    fedora*)
+      package_installer="install_dnf"
+      tree="rhel"
+      if [[ "${IGNORE_INSTALLED}" -eq 0 ]] && [[ -z "${package_installer}" ]]; then
+        echo >&2 "command 'yum' or 'dnf' is required to install packages on a '${distribution} ${version}' system."
+        exit 1
+      fi
+      ;;
+
 
     ol*)
       package_installer=


### PR DESCRIPTION
##### Summary

Ubuntu 24.10 was released on 2024-10-10

Fedora 41 is expected to release on 2024-10-22

##### Test Plan

CI jobs pass on this PR.