### PR TITLE
Expand ml enabled option

### DIFF
--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -2085,12 +2085,6 @@ int netdata_main(int argc, char **argv) {
         health_set_silencers_filename();
         health_initialize_global_silencers();
 
-//        // --------------------------------------------------------------------
-//        // Initialize ML configuration
-//
-//        delta_startup_time("initialize ML");
-//        ml_init();
-
         // --------------------------------------------------------------------
         // setup process signals
 

--- a/src/ml/Config.cc
+++ b/src/ml/Config.cc
@@ -19,7 +19,7 @@ static T clamp(const T& Value, const T& Min, const T& Max) {
 void ml_config_load(ml_config_t *cfg) {
     const char *config_section_ml = CONFIG_SECTION_ML;
 
-    bool enable_anomaly_detection = config_get_boolean(config_section_ml, "enabled", true);
+    int enable_anomaly_detection = config_get_boolean_ondemand(config_section_ml, "enabled", CONFIG_BOOLEAN_AUTO);
 
     /*
      * Read values
@@ -139,4 +139,10 @@ void ml_config_load(ml_config_t *cfg) {
     cfg->suppression_threshold = suppression_threshold;
 
     cfg->enable_statistics_charts = enable_statistics_charts;
+
+    if (cfg->enable_anomaly_detection == CONFIG_BOOLEAN_AUTO && default_rrd_memory_mode != RRD_MEMORY_MODE_DBENGINE) {
+        Cfg.enable_anomaly_detection = 0;
+        config_set_boolean(config_section_ml, "enabled", CONFIG_BOOLEAN_NO);
+        return;
+    }
 }

--- a/src/ml/ml-private.h
+++ b/src/ml/ml-private.h
@@ -313,7 +313,7 @@ typedef struct {
 } ml_training_thread_t;
 
 typedef struct {
-    bool enable_anomaly_detection;
+    int enable_anomaly_detection;
 
     unsigned max_train_samples;
     unsigned min_train_samples;


### PR DESCRIPTION
##### Summary
This PR changes the accepted values for the ML enabled option to  `auto`, `yes`, `no`. The `auto` option is now the default

The behavior will be the same on systems using `dbengine`, that is ML will be enabled. 

On systems not using `dbengine` the `auto` setting will not enable ML.

ML can always be enabled / disabled by setting this option explicitly to `yes`  or `no` respectively

##### Test Plan
- Start agent in dbengine mode with default settings
  - *ML should be enabled*
- Start agent in RAM mode with default settings. 
  - *ML should be disabled*
- Start agent in RAM mode with `enabled` set to  `yes`. 
  - *ML should be enabled*