### PR TITLE
Windows Alerts Improvements

### DIFF
--- a/src/collectors/proc.plugin/proc_net_dev.c
+++ b/src/collectors/proc.plugin/proc_net_dev.c
@@ -252,6 +252,8 @@ static struct netdev {
 // ----------------------------------------------------------------------------
 
 static void netdev_charts_release(struct netdev *d) {
+    rrdvar_chart_variable_release(d->st_bandwidth, d->chart_var_speed);
+
     if(d->st_bandwidth) rrdset_is_obsolete___safe_from_collector_thread(d->st_bandwidth);
     if(d->st_packets) rrdset_is_obsolete___safe_from_collector_thread(d->st_packets);
     if(d->st_errors) rrdset_is_obsolete___safe_from_collector_thread(d->st_errors);

--- a/src/database/rrdset.c
+++ b/src/database/rrdset.c
@@ -732,6 +732,8 @@ void rrdset_get_retention_of_tier_for_collected_chart(RRDSET *st, time_t *first_
 }
 
 inline void rrdset_is_obsolete___safe_from_collector_thread(RRDSET *st) {
+    if(!st) return;
+
     rrdset_pluginsd_receive_unslot(st);
 
     if(unlikely(!(rrdset_flag_check(st, RRDSET_FLAG_OBSOLETE)))) {

--- a/src/health/health.d/net.conf
+++ b/src/health/health.d/net.conf
@@ -235,3 +235,21 @@ host labels: _os=linux
        info: Ratio of average number of received packets for the network interface ${label:device} over the last 10 seconds, \
              compared to the rate over the last minute
          to: silent
+
+# -----------------------------------------------------------------------------
+# output queue length
+
+   template: network_interface_output_queue_length
+         on: net.queue_length
+      class: Errors
+       type: System
+  component: Network
+host labels: _os=windows
+      units: packets
+      every: 10s
+       warn: $length > 2
+      delay: up 1m down 1m multiplier 1.5 max 1h
+    summary: System network interface ${label:device} output queue length
+       info: The Output Queue Length on interface ${label:device} should be zero, otherwise there are delays and bottlenecks.
+         to: silent
+

--- a/src/health/health.d/net.conf
+++ b/src/health/health.d/net.conf
@@ -19,7 +19,7 @@ component: Network
       class: Workload
        type: System
   component: Network
-host labels: _os=linux
+host labels: _os=linux windows
      lookup: average -1m unaligned absolute of received
        calc: ($interface_speed > 0) ? ($this * 100 / ($interface_speed * 1000)) : ( nan )
       units: %
@@ -35,7 +35,7 @@ host labels: _os=linux
       class: Workload
        type: System
   component: Network
-host labels: _os=linux
+host labels: _os=linux windows
      lookup: average -1m unaligned absolute of sent
        calc: ($interface_speed > 0) ? ($this * 100 / ($interface_speed * 1000)) : ( nan )
       units: %

--- a/src/health/health.d/net.conf
+++ b/src/health/health.d/net.conf
@@ -214,7 +214,6 @@ host labels: _os=linux
       class: Workload
        type: System
   component: Network
-host labels: _os=linux freebsd
      lookup: average -1m unaligned of received
       units: packets
       every: 10s
@@ -225,7 +224,6 @@ host labels: _os=linux freebsd
       class: Workload
        type: System
   component: Network
-host labels: _os=linux freebsd
      lookup: average -10s unaligned of received
        calc: $this * 100 / (($1m_received_packets_rate < 1000)?(1000):($1m_received_packets_rate))
       every: 10s

--- a/src/health/rrdvar.c
+++ b/src/health/rrdvar.c
@@ -93,7 +93,7 @@ void rrdvar_host_variable_set(RRDHOST *host, const RRDVAR_ACQUIRED *rva, NETDATA
 // CUSTOM CHART VARIABLES
 
 const RRDVAR_ACQUIRED *rrdvar_chart_variable_add_and_acquire(RRDSET *st, const char *name) {
-    if(unlikely(!st->rrdvars)) return NULL;
+    if(unlikely(!st || !st->rrdvars)) return NULL;
 
     STRING *name_string = rrdvar_name_to_string(name);
     const RRDVAR_ACQUIRED *rs = rrdvar_add_and_acquire(st->rrdvars, name_string, NAN);
@@ -102,7 +102,7 @@ const RRDVAR_ACQUIRED *rrdvar_chart_variable_add_and_acquire(RRDSET *st, const c
 }
 
 void rrdvar_chart_variable_set(RRDSET *st, const RRDVAR_ACQUIRED *rva, NETDATA_DOUBLE value) {
-    if(unlikely(!st->rrdvars || !rva)) return;
+    if(unlikely(!st || !st->rrdvars || !rva)) return;
 
     RRDVAR *rv = dictionary_acquired_item_value((const DICTIONARY_ITEM *)rva);
     if(rv->value != value) {

--- a/src/health/rrdvar.h
+++ b/src/health/rrdvar.h
@@ -17,7 +17,7 @@ void rrdvar_host_variable_set(RRDHOST *host, const RRDVAR_ACQUIRED *rva, NETDATA
 int rrdvar_walkthrough_read(DICTIONARY *dict, int (*callback)(const DICTIONARY_ITEM *item, void *rrdvar, void *data), void *data);
 
 #define rrdvar_host_variable_release(host, rva) rrdvar_release((host)->rrdvars, rva)
-#define rrdvar_chart_variable_release(st, rva) rrdvar_release((st)->rrdvars, rva)
+#define rrdvar_chart_variable_release(st, rva) do { if(st) rrdvar_release((st)->rrdvars, rva); } while(0)
 void rrdvar_release(DICTIONARY *dict, const RRDVAR_ACQUIRED *rva);
 
 NETDATA_DOUBLE rrdvar2number(const RRDVAR_ACQUIRED *rva);


### PR DESCRIPTION
- [x] add network interface speed chart and variables
- [x] add network interface drops
- [x] add network interface errors
- [x] enabled drops alert
- [x] enabled packet storm alert
- [x] add network interface output queue length and related alert
- [x] add network interfaces chimney offloaded connections
- [x] add network interfaces RSC offloading performance charts