### PR TITLE
Fix atomic builtins test that currently fails for llvm+compiler_rt when gcc is not present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,7 +448,8 @@ int main() {
 
 check_cxx_source_compiles("
 int main() {
-        __atomic_load_8(nullptr, 0);
+        int test;
+        __atomic_load_n(&test, 0);
         return 0;
 }
 " HAVE_BUILTIN_ATOMICS)


### PR DESCRIPTION
In a system like llvm+clang+compiler_rt+musl with no gcc neither binutils at all, netdata currently fails to compile because the atomic builtin check is invalid for this combination and then forces the linkage with the non existant libatomic.so.

This PR changes the test so that it looks for an implemented (and used in the code) `__atomic_load_n` instead of the current `__atomic_load_8` which is not implemented in compiler_rt neither used in the code.