### PR TITLE
Windows fixes (chart labels and warnings)

### DIFF
--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -1411,7 +1411,7 @@ void ebpf_send_data_aral_chart(ARAL *memory, ebpf_module_t *em)
     char *mem = { NETDATA_EBPF_STAT_DIMENSION_MEMORY };
     char *aral = { NETDATA_EBPF_STAT_DIMENSION_ARAL };
 
-    struct aral_statistics *stats = aral_statistics(memory);
+    struct aral_statistics *stats = aral_get_statistics(memory);
 
     ebpf_write_begin_chart(NETDATA_MONITORING_FAMILY, em->memory_usage, "");
     write_chart_dimension(mem, (long long)stats->structures.allocated_bytes);

--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -870,11 +870,12 @@ int dict_mssql_locks_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, void 
     rrddim_set_by_pointer(mli->parent->st_deadLocks,
                           mli->rd_deadLocks,
                           (collected_number)mli->deadLocks.current.Data);
+
+    return 1;
 }
 
 static void do_mssql_locks(PERF_DATA_BLOCK *pDataBlock, struct mssql_instance *p, int update_every)
 {
-    char id[RRD_ID_LENGTH_MAX + 1];
     PERF_OBJECT_TYPE *pObjectType = perflibFindObjectTypeByName(pDataBlock, p->objectName[NETDATA_MSSQL_LOCKS]);
     if (!pObjectType) return;
 
@@ -1250,11 +1251,12 @@ int dict_mssql_databases_charts_cb(const DICTIONARY_ITEM *item __maybe_unused, v
     for (i = 0; transaction_chart[i]; i++) {
         transaction_chart[i](mli, db, *update_every);
     }
+
+    return 1;
 }
 
 static void do_mssql_databases(PERF_DATA_BLOCK *pDataBlock, struct mssql_instance *p, int update_every)
 {
-    char id[RRD_ID_LENGTH_MAX + 1];
     PERF_OBJECT_TYPE *pObjectType = perflibFindObjectTypeByName(pDataBlock, p->objectName[NETDATA_MSSQL_DATABASE]);
     if (!pObjectType) return;
 

--- a/src/collectors/windows.plugin/perflib-network.c
+++ b/src/collectors/windows.plugin/perflib-network.c
@@ -718,7 +718,7 @@ static bool do_network_interface(PERF_DATA_BLOCK *pDataBlock, int update_every, 
 
                 rrdset_flag_set(d->packets.st, RRDSET_FLAG_DETAIL);
 
-                add_interface_labels(d->traffic.st, windows_shared_buffer, physical);
+                add_interface_labels(d->packets.st, windows_shared_buffer, physical);
 
                 d->packets.rd_received = rrddim_add(d->packets.st, "received", NULL, 1, 1, RRD_ALGORITHM_INCREMENTAL);
                 d->packets.rd_sent = rrddim_add(d->packets.st, "sent", NULL, -1, 1, RRD_ALGORITHM_INCREMENTAL);
@@ -748,7 +748,7 @@ static bool do_network_interface(PERF_DATA_BLOCK *pDataBlock, int update_every, 
 
                 rrdset_flag_set(d->speed.st, RRDSET_FLAG_DETAIL);
 
-                add_interface_labels(d->traffic.st, windows_shared_buffer, physical);
+                add_interface_labels(d->speed.st, windows_shared_buffer, physical);
 
                 d->speed.rd = rrddim_add(d->speed.st, "speed",  NULL,  1, BITS_IN_A_KILOBIT, RRD_ALGORITHM_ABSOLUTE);
             }

--- a/src/daemon/winsvc.cc
+++ b/src/daemon/winsvc.cc
@@ -74,7 +74,7 @@ static HANDLE CreateEventHandle(const char *msg)
 
     if (!h)
     {
-        netdata_service_log(msg);
+        netdata_service_log("%s", msg);
 
         if (!ReportSvcStatus(SERVICE_STOPPED, GetLastError(), 1000, 0))
         {

--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -1786,7 +1786,7 @@ PGC *pgc_create(const char *name,
                 sizeof(PGC_PAGE) + cache->config.additional_bytes_per_page,
                 0,
                 16384,
-                aral_statistics(pgc_section_pages_aral),
+                aral_get_statistics(pgc_section_pages_aral),
                 NULL, NULL, false, false);
     }
 #endif
@@ -1797,7 +1797,7 @@ PGC *pgc_create(const char *name,
 }
 
 struct aral_statistics *pgc_aral_statistics(void) {
-    return aral_statistics(pgc_section_pages_aral);
+    return aral_get_statistics(pgc_section_pages_aral);
 }
 
 size_t pgc_aral_structures(void) {

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -437,6 +437,7 @@ void rrdlabels_get_value_to_buffer_or_unset(RRDLABELS *labels, BUFFER *wb, const
     RRDLABEL *lb;
     RRDLABEL_SRC ls;
 
+    bool set = false;
     lfe_start_read(labels, lb, ls)
     {
         if (lb->index.key == this_key) {
@@ -444,10 +445,15 @@ void rrdlabels_get_value_to_buffer_or_unset(RRDLABELS *labels, BUFFER *wb, const
                 buffer_strcat(wb, string2str(lb->index.value));
             else
                 buffer_strcat(wb, unset);
+            set = true;
             break;
         }
     }
     lfe_done(labels);
+
+    if(!set)
+        buffer_strcat(wb, unset);
+
     string_freez(this_key);
 }
 

--- a/src/libnetdata/aral/aral.c
+++ b/src/libnetdata/aral/aral.c
@@ -117,7 +117,7 @@ size_t aral_structures(ARAL *ar) {
     return aral_structures_from_stats(ar->stats);
 }
 
-struct aral_statistics *aral_statistics(ARAL *ar) {
+struct aral_statistics *aral_get_statistics(ARAL *ar) {
     return ar->stats;
 }
 

--- a/src/libnetdata/aral/aral.h
+++ b/src/libnetdata/aral/aral.h
@@ -32,7 +32,7 @@ ARAL *aral_create(const char *name, size_t element_size, size_t initial_page_ele
 size_t aral_element_size(ARAL *ar);
 size_t aral_overhead(ARAL *ar);
 size_t aral_structures(ARAL *ar);
-struct aral_statistics *aral_statistics(ARAL *ar);
+struct aral_statistics *aral_get_statistics(ARAL *ar);
 size_t aral_structures_from_stats(struct aral_statistics *stats);
 size_t aral_overhead_from_stats(struct aral_statistics *stats);
 

--- a/src/libnetdata/socket/socket.h
+++ b/src/libnetdata/socket/socket.h
@@ -194,7 +194,7 @@ void poll_events(LISTEN_SOCKETS *sockets
 #define INET6_ADDRSTRLEN 46
 #endif
 
-typedef struct socket_peers {
+typedef struct {
     struct {
         char ip[INET6_ADDRSTRLEN];
         int port;

--- a/src/registry/registry.c
+++ b/src/registry/registry.c
@@ -517,16 +517,16 @@ void registry_statistics(void) {
         rrddim_add(stm, "machines_urls",  NULL,  1, 1024, RRD_ALGORITHM_ABSOLUTE);
     }
 
-    struct aral_statistics *p_aral_stats = aral_statistics(registry.persons_aral);
+    struct aral_statistics *p_aral_stats = aral_get_statistics(registry.persons_aral);
     rrddim_set(stm, "persons",       (collected_number)p_aral_stats->structures.allocated_bytes + (collected_number)p_aral_stats->malloc.allocated_bytes + (collected_number)p_aral_stats->mmap.allocated_bytes);
 
-    struct aral_statistics *m_aral_stats = aral_statistics(registry.machines_aral);
+    struct aral_statistics *m_aral_stats = aral_get_statistics(registry.machines_aral);
     rrddim_set(stm, "machines",      (collected_number)m_aral_stats->structures.allocated_bytes + (collected_number)m_aral_stats->malloc.allocated_bytes + (collected_number)m_aral_stats->mmap.allocated_bytes);
 
-    struct aral_statistics *pu_aral_stats = aral_statistics(registry.person_urls_aral);
+    struct aral_statistics *pu_aral_stats = aral_get_statistics(registry.person_urls_aral);
     rrddim_set(stm, "persons_urls",  (collected_number)pu_aral_stats->structures.allocated_bytes + (collected_number)pu_aral_stats->malloc.allocated_bytes + (collected_number)pu_aral_stats->mmap.allocated_bytes);
 
-    struct aral_statistics *mu_aral_stats = aral_statistics(registry.machine_urls_aral);
+    struct aral_statistics *mu_aral_stats = aral_get_statistics(registry.machine_urls_aral);
     rrddim_set(stm, "machines_urls", (collected_number)mu_aral_stats->structures.allocated_bytes + (collected_number)mu_aral_stats->malloc.allocated_bytes + (collected_number)mu_aral_stats->mmap.allocated_bytes);
 
     rrdset_done(stm);

--- a/src/streaming/rrdpush.h
+++ b/src/streaming/rrdpush.h
@@ -601,7 +601,7 @@ static inline const char *rrdhost_dyncfg_status_to_string(RRDHOST_DYNCFG_STATUS 
     }
 }
 
-typedef struct rrdhost_status {
+typedef struct {
     RRDHOST *host;
     time_t now;
 

--- a/src/web/api/v2/api_v2_claim.c
+++ b/src/web/api/v2/api_v2_claim.c
@@ -97,6 +97,8 @@ static bool agent_can_be_claimed(void) {
         case CLOUD_STATUS_ONLINE:
             return false;
     }
+
+    return false;
 }
 
 typedef enum {


### PR DESCRIPTION
- [x] fix compilation warnings on windows
- [x] in queries, when a label is not set, add to the group-by key the word `[unset]`
- [x] fixed windows network interface charts to have the same labels