### PR TITLE
Remove macOS 12 from CI, and add macOS 15.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1042,12 +1042,12 @@ jobs:
       max-parallel: 8
       matrix:
         include:
-          - name: macos-12
-            runner: macos-12
           - name: macos-13
             runner: macos-13
           - name: macos-14-M1
             runner: macos-14
+          - name: macos-15-M1
+            runner: macos-15
     steps:
       - name: Skip Check
         id: skip


### PR DESCRIPTION
##### Summary

macOS 12 is EOL as of approximately 1 month ago, and macOS 15 has been out for just as long, so it’s high time we updated our macOS CI jobs accordingly.

##### Test Plan

CI jobs are run correctly on this PR.

Note that if the build is broken on macOS 15, that _IS NOT_ a blocker for this PR to be merged, and should be dealt with in it’s own PR.