### PR TITLE
local-listeners improvements

### DIFF
--- a/src/collectors/apps.plugin/apps_plugin.c
+++ b/src/collectors/apps.plugin/apps_plugin.c
@@ -704,7 +704,7 @@ int main(int argc, char **argv) {
     }
 #endif /* NETDATA_INTERNAL_CHECKS */
 
-    procfile_adaptive_initial_allocation = 1;
+    procfile_set_adaptive_allocation(true, 0, 0, 0);
     os_get_system_HZ();
     os_get_system_cpus_uncached();
     apps_managers_and_aggregators_init(); // before parsing args!

--- a/src/collectors/slabinfo.plugin/slabinfo.c
+++ b/src/collectors/slabinfo.plugin/slabinfo.c
@@ -167,7 +167,7 @@ struct slabinfo *read_file_slabinfo() {
     slabdebug("   Read %lu lines from procfile", (unsigned long)lines);
     for(l = 2; l < lines; l++) {
         if (unlikely(procfile_linewords(ff, l) < 14)) {
-            slabdebug("    Line %zu has only %zu words, skipping", l, procfile_linewords(ff,l));
+            slabdebug("    Line %zu has only %zu words, skipping", l, (size_t)procfile_linewords(ff,l));
             continue;
         }
 

--- a/src/collectors/utils/local_listeners.c
+++ b/src/collectors/utils/local_listeners.c
@@ -35,7 +35,9 @@ static const char *protocol_name(LOCAL_SOCKET *n) {
         return "UNKNOWN";
 }
 
-static void print_local_listeners(LS_STATE *ls __maybe_unused, LOCAL_SOCKET *n, void *data __maybe_unused) {
+static void print_local_listeners(LS_STATE *ls __maybe_unused, const LOCAL_SOCKET *nn, void *data __maybe_unused) {
+    LOCAL_SOCKET *n = (LOCAL_SOCKET *)nn;
+
     char local_address[INET6_ADDRSTRLEN];
     char remote_address[INET6_ADDRSTRLEN];
 
@@ -55,7 +57,9 @@ static void print_local_listeners(LS_STATE *ls __maybe_unused, LOCAL_SOCKET *n, 
     printf("%s|%s|%u|%s\n", protocol_name(n), local_address, n->local.port, string2str(n->cmdline));
 }
 
-static void print_local_listeners_debug(LS_STATE *ls __maybe_unused, LOCAL_SOCKET *n, void *data __maybe_unused) {
+static void print_local_listeners_debug(LS_STATE *ls __maybe_unused, const LOCAL_SOCKET *nn, void *data __maybe_unused) {
+    LOCAL_SOCKET *n = (LOCAL_SOCKET *)nn;
+
     char local_address[INET6_ADDRSTRLEN];
     char remote_address[INET6_ADDRSTRLEN];
 
@@ -304,16 +308,21 @@ int main(int argc, char **argv) {
         }
     }
 
+#if defined(LOCAL_SOCKETS_USE_SETNS)
     SPAWN_SERVER *spawn_server = spawn_server_create(SPAWN_SERVER_OPTION_CALLBACK, NULL, local_sockets_spawn_server_callback, argc, (const char **)argv);
     if(spawn_server == NULL) {
         fprintf(stderr, "Cannot create spawn server.\n");
         exit(1);
     }
+
     ls.spawn_server = spawn_server;
+#endif
 
     local_sockets_process(&ls);
 
+#if defined(LOCAL_SOCKETS_USE_SETNS)
     spawn_server_destroy(spawn_server);
+#endif
 
     getrusage(RUSAGE_SELF, &ended);
 
@@ -345,6 +354,35 @@ int main(int argc, char **argv) {
 
         duration_snprintf(buf, sizeof(buf), (int64_t)total_ut, "us", true);
         fprintf(stderr, "%20s: %6.2f%% %s\n", "TOTAL", 100.0, buf);
+
+        fprintf(stderr, "\n");
+        fprintf(stderr, "Namespaces    [ found: %zu, absent: %zu, invalid: %zu ]\n"
+#if defined(LOCAL_SOCKETS_USE_SETNS)
+                        "  \\_    forks [ tried: %zu, failed: %zu, unresponsive: %zu ]\n"
+                        "  \\_  sockets [ new: %zu, existing: %zu ]\n"
+#endif
+                , ls.stats.namespaces_found, ls.stats.namespaces_absent, ls.stats.namespaces_invalid
+#if defined(LOCAL_SOCKETS_USE_SETNS)
+                , ls.stats.namespaces_forks_attempted, ls.stats.namespaces_forks_failed, ls.stats.namespaces_forks_unresponsive
+                , ls.stats.namespaces_sockets_new, ls.stats.namespaces_sockets_existing
+#endif
+                );
+
+        fprintf(stderr, "\n");
+        fprintf(stderr, "Sockets       [ found: %zu ]\n",
+                ls.stats.sockets_added);
+
+        fprintf(stderr, "\n");
+        fprintf(stderr, "Main Procfile [ opens: %zu, reads: %zu, resizes: %zu, memory: %zu ]\n"
+                        "  \\_    reads [ total bytes read: %zu, average read size: %zu, max read size: %zu ]\n"
+                        "  \\_      max [ max file size: %zu, max lines: %zu, max words: %zu ]\n",
+                ls.stats.ff.opens, ls.stats.ff.reads, ls.stats.ff.resizes, ls.stats.ff.memory,
+                ls.stats.ff.total_read_bytes, ls.stats.ff.total_read_bytes / (ls.stats.ff.reads ? ls.stats.ff.reads : 1), ls.stats.ff.max_read_size,
+                ls.stats.ff.max_source_bytes, ls.stats.ff.max_lines, ls.stats.ff.max_words);
+
+        fprintf(stderr, "\n");
+        fprintf(stderr, "MNL           [ requests: %zu ]\n",
+                ls.stats.mnl_sends);
     }
 
     return 0;

--- a/src/collectors/utils/local_listeners.c
+++ b/src/collectors/utils/local_listeners.c
@@ -159,13 +159,15 @@ int main(int argc, char **argv) {
                     "\n"
                     " Current options:\n"
                     "\n"
-                    "    %s %s %s %s %s %s %s %s %s\n"
+                    "    %s %s %s %s %s %s %s %s %s %s %s %s\n"
                     "\n"
                     " Option 'debug' enables all sources and all directions and provides\n"
                     " a full dump of current sockets.\n"
                     "\n"
                     " Option 'report' reports timings per step while collecting and processing\n"
                     " system information.\n"
+                    "\n"
+                    " Option 'procfile' uses procfile to read proc files, instead of getline().\n"
                     "\n"
                     " DIRECTION DETECTION\n"
                     " The program detects the direction of the sockets using these rules:\n"
@@ -212,6 +214,9 @@ int main(int argc, char **argv) {
                     , ls.config.inbound ? "inbound" : "no-inbound"
                     , ls.config.outbound ? "outbound" : "no-outbound"
                     , ls.config.namespaces ? "namespaces" : "no-namespaces"
+                    , ls.config.no_mnl ? "no-mnl" : "mnl"
+                    , ls.config.procfile ? "procfile" : "no-procfile"
+                    , ls.config.report ? "report" : "no-report"
                     );
             exit(1);
         }
@@ -237,6 +242,7 @@ int main(int argc, char **argv) {
             ls.config.namespaces = true;
             ls.config.tcp_info = true;
             ls.config.uid = true;
+            ls.config.procfile = false;
             ls.config.max_errors = SIZE_MAX;
             ls.config.cb = print_local_listeners_debug;
 
@@ -297,6 +303,10 @@ int main(int argc, char **argv) {
         else if (strcmp("mnl", s) == 0) {
             ls.config.no_mnl = !positive;
             // fprintf(stderr, "%s mnl\n", positive ? "enabling" : "disabling");
+        }
+        else if (strcmp("procfile", s) == 0) {
+            ls.config.procfile = positive;
+            // fprintf(stderr, "%s procfile\n", positive ? "enabling" : "disabling");
         }
         else if (strcmp("report", s) == 0) {
             ls.config.report = positive;
@@ -381,7 +391,7 @@ int main(int argc, char **argv) {
                 ls.stats.ff.max_source_bytes, ls.stats.ff.max_lines, ls.stats.ff.max_words);
 
         fprintf(stderr, "\n");
-        fprintf(stderr, "MNL           [ requests: %zu ]\n",
+        fprintf(stderr, "MNL(without namespaces) [ requests: %zu ]\n",
                 ls.stats.mnl_sends);
     }
 

--- a/src/libnetdata/aral/aral.c
+++ b/src/libnetdata/aral/aral.c
@@ -799,6 +799,7 @@ ARAL *aral_create(const char *name, size_t element_size, size_t initial_page_ele
         aral_delete_leftover_files(ar->config.name, directory_name, file);
     }
 
+    errno_clear();
     internal_error(true,
                    "ARAL: '%s' "
                    "element size %zu (requested %zu bytes), "

--- a/src/libnetdata/log/nd_log.h
+++ b/src/libnetdata/log/nd_log.h
@@ -23,7 +23,7 @@ void chown_open_file(int fd, uid_t uid, gid_t gid);
 void nd_log_chown_log_files(uid_t uid, gid_t gid);
 void nd_log_set_flood_protection(size_t logs, time_t period);
 void nd_log_initialize_for_external_plugins(const char *name);
-void nd_log_reopen_log_files_for_spawn_server(void);
+void nd_log_reopen_log_files_for_spawn_server(const char *name);
 bool nd_log_journal_socket_available(void);
 ND_LOG_FIELD_ID nd_log_field_id_by_journal_name(const char *field, size_t len);
 int nd_log_priority2id(const char *priority);

--- a/src/libnetdata/maps/local-sockets.h
+++ b/src/libnetdata/maps/local-sockets.h
@@ -9,7 +9,10 @@
 #define _countof(x) (sizeof(x) / sizeof(*(x)))
 #endif
 
-#ifdef HAVE_LIBMNL
+// #define LOCAL_SOCKETS_USE_SETNS
+// #define USE_LIBMNL_AFTER_SETNS
+
+#if defined(HAVE_LIBMNL)
 #include <linux/rtnetlink.h>
 #include <linux/inet_diag.h>
 #include <linux/sock_diag.h>
@@ -67,7 +70,7 @@ struct local_port;
 // --------------------------------------------------------------------------------------------------------------------
 
 struct local_socket_state;
-typedef void (*local_sockets_cb_t)(struct local_socket_state *state, struct local_socket *n, void *data);
+typedef void (*local_sockets_cb_t)(struct local_socket_state *state, const struct local_socket *n, void *data);
 
 struct local_sockets_config {
     bool listening;
@@ -110,26 +113,44 @@ typedef struct local_socket_state {
 
     struct {
         size_t mnl_sends;
-        size_t namespaces_found;
         size_t tcp_info_received;
         size_t pid_fds_processed;
         size_t pid_fds_opendir_failed;
         size_t pid_fds_readlink_failed;
         size_t pid_fds_parse_failed;
         size_t errors_encountered;
+
+        size_t sockets_added;
+
+        size_t namespaces_found;
+        size_t namespaces_absent;
+        size_t namespaces_invalid;
+#if defined(LOCAL_SOCKETS_USE_SETNS)
+        size_t namespaces_forks_attempted;
+        size_t namespaces_forks_failed;
+        size_t namespaces_forks_unresponsive;
+        size_t namespaces_sockets_new;
+        size_t namespaces_sockets_existing;
+#endif
+
+        struct procfile_stats ff;
     } stats;
 
     size_t timings_idx;
-    struct timing_work timings[20];
+    struct timing_work timings[30];
 
+#if defined(LOCAL_SOCKETS_USE_SETNS)
     bool spawn_server_is_mine;
     SPAWN_SERVER *spawn_server;
+#endif
 
-#ifdef HAVE_LIBMNL
+#if defined(HAVE_LIBMNL)
     bool use_mnl;
     struct mnl_socket *nl;
     uint16_t tmp_protocol;
 #endif
+
+    procfile *ff;
 
     ARAL *local_socket_aral;
     ARAL *pid_socket_aral;
@@ -238,7 +259,9 @@ typedef struct local_socket {
 #endif
 } LOCAL_SOCKET;
 
+#if defined(LOCAL_SOCKETS_USE_SETNS)
 static inline int local_sockets_spawn_server_callback(SPAWN_REQUEST *request);
+#endif
 
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -269,7 +292,7 @@ static bool local_sockets_is_ipv4_mapped_ipv6_address(const struct in6_addr *add
     return memcmp(addr->s6_addr, ipv4_mapped_prefix, 12) == 0;
 }
 
-static bool local_sockets_is_loopback_address(struct socket_endpoint *se) {
+static bool local_sockets_is_loopback_address(const struct socket_endpoint *se) {
     if (se->family == AF_INET) {
         // For IPv4, loopback addresses are in the 127.0.0.0/8 range
         return (ntohl(se->ip.ipv4) >> 24) == 127; // Check if the first byte is 127
@@ -303,7 +326,7 @@ static inline bool local_sockets_is_ipv4_reserved_address(uint32_t ip) {
             );
 }
 
-static inline bool local_sockets_is_private_address(struct socket_endpoint *se) {
+static inline bool local_sockets_is_private_address(const struct socket_endpoint *se) {
     if (se->family == AF_INET) {
         return local_sockets_is_ipv4_reserved_address(se->ip.ipv4);
     }
@@ -337,7 +360,7 @@ static inline bool local_sockets_is_private_address(struct socket_endpoint *se) 
     return false;
 }
 
-static bool local_sockets_is_multicast_address(struct socket_endpoint *se) {
+static bool local_sockets_is_multicast_address(const struct socket_endpoint *se) {
     if (se->family == AF_INET) {
         // For IPv4, check if the address is 0.0.0.0
         uint32_t ip = htonl(se->ip.ipv4);
@@ -352,7 +375,7 @@ static bool local_sockets_is_multicast_address(struct socket_endpoint *se) {
     return false;
 }
 
-static bool local_sockets_is_zero_address(struct socket_endpoint *se) {
+static bool local_sockets_is_zero_address(const struct socket_endpoint *se) {
     if (se->family == AF_INET) {
         // For IPv4, check if the address is 0.0.0.0
         return se->ip.ipv4 == 0;
@@ -365,7 +388,7 @@ static bool local_sockets_is_zero_address(struct socket_endpoint *se) {
     return false;
 }
 
-static inline const char *local_sockets_address_space(struct socket_endpoint *se) {
+static inline const char *local_sockets_address_space(const struct socket_endpoint *se) {
     if(local_sockets_is_zero_address(se))
         return "zero";
     else if(local_sockets_is_loopback_address(se))
@@ -380,7 +403,7 @@ static inline const char *local_sockets_address_space(struct socket_endpoint *se
 
 // --------------------------------------------------------------------------------------------------------------------
 
-static inline bool is_local_socket_ipv46(LOCAL_SOCKET *n) {
+static inline bool is_local_socket_ipv46(const LOCAL_SOCKET *n) {
     return n->local.family == AF_INET6 &&
             n->direction == SOCKET_DIRECTION_LISTEN &&
             local_sockets_is_zero_address(&n->local) &&
@@ -615,6 +638,8 @@ static inline bool local_sockets_add_socket(LS_STATE *ls, LOCAL_SOCKET *tmp) {
         return false;
     }
 
+    ls->stats.sockets_added++;
+
     n = aral_mallocz(ls->local_socket_aral);
     *n = *tmp; // copy all contents
 
@@ -683,7 +708,7 @@ static inline bool local_sockets_add_socket(LS_STATE *ls, LOCAL_SOCKET *tmp) {
     return true;
 }
 
-#ifdef HAVE_LIBMNL
+#if defined(HAVE_LIBMNL)
 
 static inline void local_sockets_libmnl_init(LS_STATE *ls) {
     if(ls->config.no_mnl) return;
@@ -810,18 +835,22 @@ static inline bool local_sockets_libmnl_get_sockets(LS_STATE *ls, uint16_t famil
 
     ls->stats.mnl_sends++;
     if (mnl_socket_sendto(ls->nl, nlh, nlh->nlmsg_len) < 0) {
-        local_sockets_log(ls, "mnl_socket_send failed");
+        local_sockets_log(ls, "mnl_socket_sendto() failed");
         return false;
     }
 
     ssize_t ret;
     while ((ret = mnl_socket_recvfrom(ls->nl, buf, sizeof(buf))) > 0) {
         ret = mnl_cb_run(buf, ret, seq, portid, local_sockets_libmnl_cb_data, ls);
-        if (ret <= MNL_CB_STOP)
+        if (ret == MNL_CB_ERROR) {
+            local_sockets_log(ls, "mnl_cb_run() failed");
+            break;
+        }
+        else if (ret == MNL_CB_STOP)
             break;
     }
     if (ret == -1) {
-        local_sockets_log(ls, "mnl_socket_recvfrom");
+        local_sockets_log(ls, "mnl_socket_recvfrom() failed");
         return false;
     }
 
@@ -829,37 +858,35 @@ static inline bool local_sockets_libmnl_get_sockets(LS_STATE *ls, uint16_t famil
 }
 #endif // HAVE_LIBMNL
 
-static inline bool local_sockets_read_proc_net_x(LS_STATE *ls, const char *filename, uint16_t family, uint16_t protocol) {
-    static bool is_space[256] = {
-        [':'] = true,
-        [' '] = true,
-    };
+#define INITIALLY_EXPECTED_PROC_NET_LINES 16384
+#define PROC_NET_BYTES_PER_LINE 155
+#define PROC_NET_WORDS_PER_LINE 32
+#define INITIALLY_EXPECTED_PROC_NET_WORDS (INITIALLY_EXPECTED_PROC_NET_LINES * PROC_NET_WORDS_PER_LINE)
+#define INITIALLY_EXPECTED_PROC_NET_BYTES (INITIALLY_EXPECTED_PROC_NET_LINES * PROC_NET_BYTES_PER_LINE)
 
+static inline bool local_sockets_read_proc_net_x(LS_STATE *ls, const char *filename, uint16_t family, uint16_t protocol) {
     if(family != AF_INET && family != AF_INET6)
         return false;
 
-    FILE *fp = fopen(filename, "r");
-    if (fp == NULL)
-        return false;
+    procfile_set_adaptive_allocation(true, INITIALLY_EXPECTED_PROC_NET_BYTES, INITIALLY_EXPECTED_PROC_NET_LINES, INITIALLY_EXPECTED_PROC_NET_WORDS);
 
-    char *line = malloc(1024);  // no mallocz() here because getline() may resize
-    if(!line) {
-        fclose(fp);
-        return false;
-    }
+    bool was_ff_open = ls->ff;
+    ls->ff = procfile_reopen(ls->ff, filename, ls->ff ? NULL :" :", PROCFILE_FLAG_DEFAULT);
 
-    size_t len = 1024;
-    ssize_t read;
+    // we just created ff, copy our old stats to it
+    if(ls->ff && !was_ff_open) ls->ff->stats = ls->stats.ff;
 
-    ssize_t min_line_length = (family == AF_INET) ? 105 : 155;
-    size_t counter = 0;
+    ls->ff = procfile_readall(ls->ff);
+    if(!ls->ff) return false;
 
-    // Read line by line
-    while ((read = getline(&line, &len, fp)) != -1) {
-        if(counter++ == 0) continue; // skip the first line
+    // get the latest stats from ff;
+    ls->stats.ff = ls->ff->stats;
 
-        if(read < min_line_length) {
-            local_sockets_log(ls, "too small line No %zu of filename '%s': %s", counter, filename, line);
+    for(size_t l = 1; l < procfile_lines(ls->ff) ;l++) {
+        size_t words = procfile_linewords(ls->ff, l);
+        if(!words) continue;
+        if(words < 14) {
+            local_sockets_log(ls, "too small line No %zu of filename '%s' (has %zu words)", l, filename, words);
             continue;
         }
 
@@ -880,26 +907,24 @@ static inline bool local_sockets_read_proc_net_x(LS_STATE *ls, const char *filen
             .uid = UID_UNSET,
         };
 
-        char *words[32];
-        size_t num_words = quoted_strings_splitter(line, words, 32, is_space);
-        // char *sl_txt = get_word(words, num_words, 0);
-        char *local_ip_txt = get_word(words, num_words, 1);
-        char *local_port_txt = get_word(words, num_words, 2);
-        char *remote_ip_txt = get_word(words, num_words, 3);
-        char *remote_port_txt = get_word(words, num_words, 4);
-        char *state_txt = get_word(words, num_words, 5);
-        char *tx_queue_txt = get_word(words, num_words, 6);
-        char *rx_queue_txt = get_word(words, num_words, 7);
-        char *tr_txt = get_word(words, num_words, 8);
-        char *tm_when_txt = get_word(words, num_words, 9);
-        char *retrans_txt = get_word(words, num_words, 10);
-        char *uid_txt = get_word(words, num_words, 11);
-        // char *timeout_txt = get_word(words, num_words, 12);
-        char *inode_txt = get_word(words, num_words, 13);
+        // char *sl_txt = procfile_lineword(ls->ff, l, 0);
+        char *local_ip_txt = procfile_lineword(ls->ff, l, 1);
+        char *local_port_txt = procfile_lineword(ls->ff, l, 2);
+        char *remote_ip_txt = procfile_lineword(ls->ff, l, 3);
+        char *remote_port_txt = procfile_lineword(ls->ff, l, 4);
+        char *state_txt = procfile_lineword(ls->ff, l, 5);
+        char *tx_queue_txt = procfile_lineword(ls->ff, l, 6);
+        char *rx_queue_txt = procfile_lineword(ls->ff, l, 7);
+        char *tr_txt = procfile_lineword(ls->ff, l, 8);
+        char *tm_when_txt = procfile_lineword(ls->ff, l, 9);
+        char *retrans_txt = procfile_lineword(ls->ff, l, 10);
+        char *uid_txt = procfile_lineword(ls->ff, l, 11);
+        // char *timeout_txt = procfile_lineword(ls->ff, l, 12);
+        char *inode_txt = procfile_lineword(ls->ff, l, 13);
 
         if(!local_ip_txt || !local_port_txt || !remote_ip_txt || !remote_port_txt || !state_txt ||
             !tx_queue_txt || !rx_queue_txt || !tr_txt || !tm_when_txt || !retrans_txt || !uid_txt || !inode_txt) {
-            local_sockets_log(ls, "cannot parse ipv4 line No %zu of filename '%s'", counter, filename);
+            local_sockets_log(ls, "cannot parse ipv4 line No %zu of filename '%s'", l, filename);
             continue;
         }
 
@@ -925,11 +950,6 @@ static inline bool local_sockets_read_proc_net_x(LS_STATE *ls, const char *filen
 
         local_sockets_add_socket(ls, &n);
     }
-
-    fclose(fp);
-
-    if (line)
-        free(line); // no freez() here because getline() may resize
 
     return true;
 }
@@ -1025,30 +1045,39 @@ static inline void local_sockets_init(LS_STATE *ls) {
 
     memset(&ls->stats, 0, sizeof(ls->stats));
 
-#ifdef HAVE_LIBMNL
+#if defined(HAVE_LIBMNL)
     ls->use_mnl = false;
     ls->nl = NULL;
     ls->tmp_protocol = 0;
     local_sockets_libmnl_init(ls);
 #endif
 
+#if defined(LOCAL_SOCKETS_USE_SETNS)
     if(ls->config.namespaces && ls->spawn_server == NULL) {
         ls->spawn_server = spawn_server_create(SPAWN_SERVER_OPTION_CALLBACK, NULL, local_sockets_spawn_server_callback, 0, NULL);
         ls->spawn_server_is_mine = true;
     }
     else
         ls->spawn_server_is_mine = false;
+#endif
 }
 
 static inline void local_sockets_cleanup(LS_STATE *ls) {
+    if(ls->ff) {
+        ls->stats.ff = ls->ff->stats;
+        procfile_close(ls->ff);
+        ls->ff = NULL;
+    }
 
+#if defined(LOCAL_SOCKETS_USE_SETNS)
     if(ls->spawn_server_is_mine) {
         spawn_server_destroy(ls->spawn_server);
         ls->spawn_server = NULL;
         ls->spawn_server_is_mine = false;
     }
+#endif
 
-#ifdef HAVE_LIBMNL
+#if defined(HAVE_LIBMNL)
     local_sockets_libmnl_cleanup(ls);
 #endif
 
@@ -1087,19 +1116,6 @@ static inline void local_sockets_cleanup(LS_STATE *ls) {
 
 // --------------------------------------------------------------------------------------------------------------------
 
-static inline void local_sockets_do_family_protocol(LS_STATE *ls, const char *filename, uint16_t family, uint16_t protocol) {
-#ifdef HAVE_LIBMNL
-    if(!ls->config.no_mnl && ls->nl && ls->use_mnl) {
-        ls->use_mnl = local_sockets_libmnl_get_sockets(ls, family, protocol);
-
-        if(ls->use_mnl)
-            return;
-    }
-#endif
-
-    local_sockets_read_proc_net_x(ls, filename, family, protocol);
-}
-
 static inline void local_sockets_track_time(LS_STATE *ls, const char *name) {
     if(!ls->config.report || ls->timings_idx >= _countof(ls->timings))
         return;
@@ -1122,6 +1138,56 @@ static inline void local_sockets_track_time(LS_STATE *ls, const char *name) {
     }
 }
 
+static void local_sockets_track_time_by_protocol(LS_STATE *ls, bool mnl, uint16_t family, uint16_t protocol) {
+    if(mnl) {
+        if(family == AF_INET) {
+            if(protocol == IPPROTO_TCP)
+                local_sockets_track_time(ls, "mnl_read_tcp4");
+            else if(protocol == IPPROTO_UDP)
+                local_sockets_track_time(ls, "mnl_read_udp4");
+        }
+        else if(family == AF_INET6) {
+            if(protocol == IPPROTO_TCP)
+                local_sockets_track_time(ls, "mnl_read_tcp6");
+            else if(protocol == IPPROTO_UDP)
+                local_sockets_track_time(ls, "mnl_read_udp6");
+        }
+        else
+            local_sockets_track_time(ls, "mnl_read_unknown");
+    }
+    else {
+        if(family == AF_INET) {
+            if(protocol == IPPROTO_TCP)
+                local_sockets_track_time(ls, "proc_read_tcp4");
+            else if(protocol == IPPROTO_UDP)
+                local_sockets_track_time(ls, "proc_read_udp4");
+        }
+        else if(family == AF_INET6) {
+            if(protocol == IPPROTO_TCP)
+                local_sockets_track_time(ls, "proc_read_tcp6");
+            else if(protocol == IPPROTO_UDP)
+                local_sockets_track_time(ls, "proc_read_udp6");
+        }
+        else
+            local_sockets_track_time(ls, "proc_read_unknown");
+    }
+}
+
+static inline void local_sockets_do_family_protocol(LS_STATE *ls, const char *filename, uint16_t family, uint16_t protocol) {
+#if defined(HAVE_LIBMNL)
+    if(!ls->config.no_mnl && ls->nl && ls->use_mnl) {
+        local_sockets_track_time_by_protocol(ls, true, family, protocol);
+        ls->use_mnl = local_sockets_libmnl_get_sockets(ls, family, protocol);
+
+        if(ls->use_mnl)
+            return;
+    }
+#endif
+
+    local_sockets_track_time_by_protocol(ls, false, family, protocol);
+    local_sockets_read_proc_net_x(ls, filename, family, protocol);
+}
+
 static inline void local_sockets_read_all_system_sockets(LS_STATE *ls) {
     char path[FILENAME_MAX + 1];
 
@@ -1129,55 +1195,68 @@ static inline void local_sockets_read_all_system_sockets(LS_STATE *ls) {
         local_sockets_track_time(ls, "read_namespaces");
         snprintfz(path, sizeof(path), "%s/proc/self/ns/net", ls->config.host_prefix);
         local_sockets_read_proc_inode_link(ls, path, &ls->proc_self_net_ns_inode, "net");
-
     }
 
     if(ls->config.cmdline || ls->config.comm || ls->config.pid || ls->config.namespaces) {
-        local_sockets_track_time(ls, "read_proc_pids");
+        local_sockets_track_time(ls, "proc_read_pids");
         snprintfz(path, sizeof(path), "%s/proc", ls->config.host_prefix);
         local_sockets_find_all_sockets_in_proc(ls, path);
     }
 
     if(ls->config.tcp4) {
-        local_sockets_track_time(ls, "read_tcp4");
         snprintfz(path, sizeof(path), "%s/proc/net/tcp", ls->config.host_prefix);
         local_sockets_do_family_protocol(ls, path, AF_INET, IPPROTO_TCP);
     }
 
     if(ls->config.udp4) {
-        local_sockets_track_time(ls, "read_udp4");
         snprintfz(path, sizeof(path), "%s/proc/net/udp", ls->config.host_prefix);
         local_sockets_do_family_protocol(ls, path, AF_INET, IPPROTO_UDP);
     }
 
     if(ls->config.tcp6) {
-        local_sockets_track_time(ls, "read_tcp6");
         snprintfz(path, sizeof(path), "%s/proc/net/tcp6", ls->config.host_prefix);
         local_sockets_do_family_protocol(ls, path, AF_INET6, IPPROTO_TCP);
     }
 
     if(ls->config.udp6) {
-        local_sockets_track_time(ls, "read_udp6");
         snprintfz(path, sizeof(path), "%s/proc/net/udp6", ls->config.host_prefix);
         local_sockets_do_family_protocol(ls, path, AF_INET6, IPPROTO_UDP);
     }
 }
 
 // --------------------------------------------------------------------------------------------------------------------
+// switch namespaces to read namespace sockets
+
+#if defined(LOCAL_SOCKETS_USE_SETNS)
 
 struct local_sockets_child_work {
     int fd;
     uint64_t net_ns_inode;
 };
 
-static inline void local_sockets_send_to_parent(struct local_socket_state *ls __maybe_unused, struct local_socket *n, void *data) {
+#define LOCAL_SOCKET_TERMINATOR (struct local_socket) { \
+    .expires = UINT32_MAX,                              \
+    .timer = UINT8_MAX,                                 \
+    .inode = UINT64_MAX,                                \
+    .net_ns_inode = UINT64_MAX,                         \
+}
+
+static inline bool local_socket_is_terminator(const struct local_socket *n) {
+    static const struct local_socket t = LOCAL_SOCKET_TERMINATOR;
+    return (n->expires == t.expires &&
+            n->timer == t.timer &&
+            n->inode == t.inode &&
+            n->net_ns_inode == t.net_ns_inode);
+}
+
+static inline void local_sockets_send_to_parent(struct local_socket_state *ls, const struct local_socket *n, void *data) {
     struct local_sockets_child_work *cw = data;
     int fd = cw->fd;
 
-    if(n->net_ns_inode != cw->net_ns_inode)
-        return;
-
-    // local_sockets_log(ls, "child is sending inode %"PRIu64" of namespace %"PRIu64, n->inode, n->net_ns_inode);
+    if(!local_socket_is_terminator(n)) {
+        ls->stats.errors_encountered = 0;
+        local_sockets_log(ls, "child is sending inode %"PRIu64" of namespace %"PRIu64", from namespace %"PRIu64, n->inode, n->net_ns_inode, ls->proc_self_net_ns_inode);
+    }
 
     if(write(fd, n, sizeof(*n)) != sizeof(*n))
         local_sockets_log(ls, "failed to write local socket to pipe");
@@ -1192,6 +1271,8 @@ static inline void local_sockets_send_to_parent(struct local_socket_state *ls __
 }
 
 static inline int local_sockets_spawn_server_callback(SPAWN_REQUEST *request) {
+    static const struct local_socket terminator = LOCAL_SOCKET_TERMINATOR;
+
     LS_STATE ls = { 0 };
     ls.config = *((struct local_sockets_config *)request->data);
 
@@ -1201,9 +1282,13 @@ static inline int local_sockets_spawn_server_callback(SPAWN_REQUEST *request) {
     ls.config.pid = false;
     ls.config.namespaces = false;
 
+#if !defined(USE_LIBMNL_AFTER_SETNS)
+    ls.config.no_mnl = true; // disable mnl since this collects all sockets from the entire system
+#endif
+
     // initialize local sockets
     local_sockets_init(&ls);
-
+    ls.proc_self_net_ns_inode = ls.config.net_ns_inode;
     ls.config.host_prefix = ""; // we need the /proc of the container
 
     struct local_sockets_child_work cw = {
@@ -1213,13 +1298,15 @@ static inline int local_sockets_spawn_server_callback(SPAWN_REQUEST *request) {
 
     ls.config.cb = local_sockets_send_to_parent;
     ls.config.data = &cw;
-    ls.proc_self_net_ns_inode = ls.config.net_ns_inode;
 
     // switch namespace using the custom fd passed via the spawn server
     if (setns(request->fds[3], CLONE_NEWNET) == -1) {
         local_sockets_log(&ls, "failed to switch network namespace at child process using fd %d", request->fds[3]);
         return EXIT_FAILURE;
     }
+
+    // close the custom fd
+    close(request->fds[3]); request->fds[3] = -1;
 
     // read all sockets from /proc
     local_sockets_read_all_system_sockets(&ls);
@@ -1228,10 +1315,7 @@ static inline int local_sockets_spawn_server_callback(SPAWN_REQUEST *request) {
     local_sockets_foreach_local_socket_call_cb(&ls);
 
     // send the terminating socket
-    struct local_socket zero = {
-        .net_ns_inode = ls.config.net_ns_inode,
-    };
-    local_sockets_send_to_parent(&ls, &zero, &cw);
+    local_sockets_send_to_parent(&ls, &terminator, &cw);
 
     local_sockets_cleanup(&ls);
 
@@ -1246,6 +1330,8 @@ static inline bool local_sockets_get_namespace_sockets_with_pid(LS_STATE *ls, st
     int fd = open(filename, O_RDONLY | O_CLOEXEC);
     if (fd == -1) {
         local_sockets_log(ls, "cannot open file '%s'", filename);
+        if(ls->config.report)
+            __atomic_add_fetch(&ls->stats.namespaces_absent, 1, __ATOMIC_RELAXED);
         return false;
     }
 
@@ -1253,18 +1339,24 @@ static inline bool local_sockets_get_namespace_sockets_with_pid(LS_STATE *ls, st
     if (fstat(fd, &statbuf) == -1) {
         close(fd);
         local_sockets_log(ls, "failed to get file statistics for '%s'", filename);
+        if(ls->config.report)
+            __atomic_add_fetch(&ls->stats.namespaces_absent, 1, __ATOMIC_RELAXED);
         return false;
     }
 
     if (statbuf.st_ino != ps->net_ns_inode) {
         close(fd);
         local_sockets_log(ls, "pid %d is not in the wanted network namespace", ps->pid);
+        if(ls->config.report)
+            __atomic_add_fetch(&ls->stats.namespaces_invalid, 1, __ATOMIC_RELAXED);
         return false;
     }
 
     if(ls->spawn_server == NULL) {
         close(fd);
         local_sockets_log(ls, "spawn server is not available");
+        if(ls->config.report)
+            __atomic_add_fetch(&ls->stats.namespaces_forks_failed, 1, __ATOMIC_RELAXED);
         return false;
     }
 
@@ -1273,8 +1365,15 @@ static inline bool local_sockets_get_namespace_sockets_with_pid(LS_STATE *ls, st
     SPAWN_INSTANCE *si = spawn_server_exec(ls->spawn_server, STDERR_FILENO, fd, NULL, &config, sizeof(config), SPAWN_INSTANCE_TYPE_CALLBACK);
     close(fd); fd = -1;
 
+    if(ls->config.report)
+        __atomic_add_fetch(&ls->stats.namespaces_forks_attempted, 1, __ATOMIC_RELAXED);
+
     if(si == NULL) {
         local_sockets_log(ls, "cannot create spawn instance");
+
+        if(ls->config.report)
+            __atomic_add_fetch(&ls->stats.namespaces_forks_failed, 1, __ATOMIC_RELAXED);
+
         return false;
     }
 
@@ -1299,13 +1398,12 @@ static inline bool local_sockets_get_namespace_sockets_with_pid(LS_STATE *ls, st
 
         received++;
 
-        struct local_socket zero = {
-            .net_ns_inode = ps->net_ns_inode,
-        };
-        if(memcmp(&buf, &zero, sizeof(buf)) == 0) {
-            // the terminator
+        if(local_socket_is_terminator(&buf))
+            // the child finished
             break;
-        }
+
+        // overwrite the net_ns_inode we receive
+        buf.net_ns_inode = ps->net_ns_inode;
 
         spinlock_lock(&ls->spinlock);
 
@@ -1313,9 +1411,13 @@ static inline bool local_sockets_get_namespace_sockets_with_pid(LS_STATE *ls, st
         LOCAL_SOCKET *n = SIMPLE_HASHTABLE_SLOT_DATA(sl);
         if(n) {
             string_freez(buf.cmdline);
+
 //            local_sockets_log(ls,
 //                              "ns inode %" PRIu64" (comm: '%s', pid: %u, ns: %"PRIu64") already exists in hashtable (comm: '%s', pid: %u, ns: %"PRIu64") - ignoring duplicate",
 //                              buf.inode, buf.comm, buf.pid, buf.net_ns_inode, n->comm, n->pid, n->net_ns_inode);
+
+            if(ls->config.report)
+                __atomic_add_fetch(&ls->stats.namespaces_sockets_existing, 1, __ATOMIC_RELAXED);
         }
         else {
             n = aral_mallocz(ls->local_socket_aral);
@@ -1323,12 +1425,19 @@ static inline bool local_sockets_get_namespace_sockets_with_pid(LS_STATE *ls, st
             simple_hashtable_set_slot_LOCAL_SOCKET(&ls->sockets_hashtable, sl, n->inode, n);
 
             local_sockets_index_listening_port(ls, n);
+
+            if(ls->config.report)
+                __atomic_add_fetch(&ls->stats.namespaces_sockets_new, 1, __ATOMIC_RELAXED);
         }
 
         spinlock_unlock(&ls->spinlock);
     }
 
     spawn_server_exec_kill(ls->spawn_server, si);
+
+    if(ls->config.report && received == 0)
+        __atomic_add_fetch(&ls->stats.namespaces_forks_unresponsive, 1, __ATOMIC_RELAXED);
+
     return received > 0;
 }
 
@@ -1385,6 +1494,7 @@ static inline void local_sockets_namespaces(LS_STATE *ls) {
          const uint64_t inode = (uint64_t)SIMPLE_HASHTABLE_SLOT_DATA(sl);
 
         if(inode == ls->proc_self_net_ns_inode)
+            // skip our own namespace, we already have them
             continue;
 
         spinlock_unlock(&ls->spinlock);
@@ -1421,6 +1531,100 @@ static inline void local_sockets_namespaces(LS_STATE *ls) {
     }
 }
 
+#endif // LOCAL_SOCKETS_USE_SETNS
+
+// --------------------------------------------------------------------------------------------------------------------
+// read namespace sockets from the host's /proc
+
+#if !defined(LOCAL_SOCKETS_USE_SETNS)
+
+static inline bool local_sockets_namespaces_from_proc_with_pid(LS_STATE *ls, struct pid_socket *ps) {
+    char filename[1024];
+    snprintfz(filename, sizeof(filename), "%s/proc/%d/ns/net", ls->config.host_prefix, ps->pid);
+
+    // verify the pid is in the target namespace
+    int fd = open(filename, O_RDONLY | O_CLOEXEC);
+    if (fd == -1) {
+        local_sockets_log(ls, "cannot open file '%s'", filename);
+        if(ls->config.report)
+            __atomic_add_fetch(&ls->stats.namespaces_absent, 1, __ATOMIC_RELAXED);
+        return false;
+    }
+
+    struct stat statbuf;
+    if (fstat(fd, &statbuf) == -1) {
+        close(fd);
+        local_sockets_log(ls, "failed to get file statistics for '%s'", filename);
+        if(ls->config.report)
+            __atomic_add_fetch(&ls->stats.namespaces_absent, 1, __ATOMIC_RELAXED);
+        return false;
+    }
+
+    if (statbuf.st_ino != ps->net_ns_inode) {
+        close(fd);
+        local_sockets_log(ls, "pid %d is not in the wanted network namespace", ps->pid);
+        if(ls->config.report)
+            __atomic_add_fetch(&ls->stats.namespaces_invalid, 1, __ATOMIC_RELAXED);
+        return false;
+    }
+
+    char path[FILENAME_MAX + 1];
+
+    if(ls->config.tcp4) {
+        snprintfz(path, sizeof(path), "%s/proc/%d/net/tcp", ls->config.host_prefix, ps->pid);
+        if(!local_sockets_read_proc_net_x(ls, path, AF_INET, IPPROTO_TCP))
+            return false;
+    }
+
+    if(ls->config.udp4) {
+        snprintfz(path, sizeof(path), "%s/proc/%d/net/udp", ls->config.host_prefix, ps->pid);
+        if(!local_sockets_read_proc_net_x(ls, path, AF_INET, IPPROTO_UDP))
+            return false;
+    }
+
+    if(ls->config.tcp6) {
+        snprintfz(path, sizeof(path), "%s/proc/%d/net/tcp6", ls->config.host_prefix, ps->pid);
+        if(!local_sockets_read_proc_net_x(ls, path, AF_INET6, IPPROTO_TCP))
+            return false;
+    }
+
+    if(ls->config.udp6) {
+        snprintfz(path, sizeof(path), "%s/proc/%d/net/udp6", ls->config.host_prefix, ps->pid);
+        if(!local_sockets_read_proc_net_x(ls, path, AF_INET6, IPPROTO_UDP))
+            return false;
+    }
+
+    return true;
+}
+
+static inline void local_sockets_namespaces_from_proc(LS_STATE *ls) {
+    for(SIMPLE_HASHTABLE_SLOT_NET_NS *sl = simple_hashtable_first_read_only_NET_NS(&ls->ns_hashtable);
+         sl;
+         sl = simple_hashtable_next_read_only_NET_NS(&ls->ns_hashtable, sl)) {
+        const uint64_t inode = (uint64_t)SIMPLE_HASHTABLE_SLOT_DATA(sl);
+
+        if (inode == ls->proc_self_net_ns_inode)
+            // skip our own namespace, we already have them
+            continue;
+
+        ls->stats.namespaces_found++;
+
+        for(SIMPLE_HASHTABLE_SLOT_PID_SOCKET *sl_pid = simple_hashtable_first_read_only_PID_SOCKET(&ls->pid_sockets_hashtable) ;
+             sl_pid ;
+             sl_pid = simple_hashtable_next_read_only_PID_SOCKET(&ls->pid_sockets_hashtable, sl_pid)) {
+            struct pid_socket *ps = SIMPLE_HASHTABLE_SLOT_DATA(sl_pid);
+            if(!ps || ps->net_ns_inode != inode) continue;
+
+            // now we have a pid that has the same namespace inode
+
+            if(local_sockets_namespaces_from_proc_with_pid(ls, ps))
+                break;
+        }
+    }
+}
+
+#endif
+
 // --------------------------------------------------------------------------------------------------------------------
 
 static inline void local_sockets_process(LS_STATE *ls) {
@@ -1438,7 +1642,11 @@ static inline void local_sockets_process(LS_STATE *ls) {
     // check all socket namespaces
     if(ls->config.namespaces) {
         local_sockets_track_time(ls, "switch_namespaces");
+#if defined(LOCAL_SOCKETS_USE_SETNS)
         local_sockets_namespaces(ls);
+#else
+        local_sockets_namespaces_from_proc(ls);
+#endif
     }
 
     // detect the directions of the sockets
@@ -1456,7 +1664,7 @@ static inline void local_sockets_process(LS_STATE *ls) {
     local_sockets_cleanup(ls);
 }
 
-static inline void ipv6_address_to_txt(struct in6_addr *in6_addr, char *dst) {
+static inline void ipv6_address_to_txt(const struct in6_addr *in6_addr, char *dst) {
     struct sockaddr_in6 sa = { 0 };
 
     sa.sin6_family = AF_INET6;


### PR DESCRIPTION
## Procfile
- [x] procfile adaptive allocations now support initial sizing of all buffers.
- [x] procfile lines memory footprint almost halfed (changed size_t to uint32_t).
- [x] procfile exposes basic statistics about its operations.

## Local Sockets
- [x] local-sockets can now find namespace sockets from the /proc filesystem of the host (no need for setns()).
- [x] local-sockets now have 2 modes for supporting namespace sockets collection, controlled by LOCAL_SOCKETS_USE_SETNS.
- [x] local-sockets now uses procfile to read proc files (it is a user option).
- [x] local-sockets with no-mnl did not receive sockets information from namespaces - fixed it.

## Local-listeners
- [x] local-listeners now provide detailed statistics for various aspects of its operation.
- [x] local-listeners now provide different labels for libmnl timings and proc timings.

## Posix Spawn
- [x] posix spawn server now reopens logs as an external plugin (logging to DAEMON log from spawned callbacks is restored).
- [x] posix spawn server executing a callback, now does not leak file descriptors to the child.
