### PR TITLE
Calculate currently collected metrics

### DIFF
--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -73,14 +73,14 @@ static inline bool svc_rrdset_archive_obsolete_dimensions(RRDSET *st, bool all_d
             if(rd->collector.last_collected_time.tv_sec + rrdset_free_obsolete_time_s < now) {
                 size_t references = dictionary_acquired_item_references(rd_dfe.item);
                 if(references == 1) {
-//                    netdata_log_info("Removing obsolete dimension 'host:%s/chart:%s/dim:%s'",
-//                                     rrdhost_hostname(st->rrdhost), rrdset_id(st), rrddim_id(rd));
+                    netdata_log_info("Removing obsolete dimension 'host:%s/chart:%s/dim:%s'",
+                                     rrdhost_hostname(st->rrdhost), rrdset_id(st), rrddim_id(rd));
                     svc_rrddim_obsolete_to_archive(rd);
                     dim_archives++;
                 }
-//                else
-//                    netdata_log_info("Cannot remove obsolete dimension 'host:%s/chart:%s/dim:%s'",
-//                            rrdhost_hostname(st->rrdhost), rrdset_id(st), rrddim_id(rd));
+                else
+                    netdata_log_info("Cannot remove obsolete dimension 'host:%s/chart:%s/dim:%s'",
+                            rrdhost_hostname(st->rrdhost), rrdset_id(st), rrddim_id(rd));
             }
         }
     }

--- a/src/database/contexts/api_v2_contexts.c
+++ b/src/database/contexts/api_v2_contexts.c
@@ -442,6 +442,28 @@ static void rrdcontext_to_json_v2_rrdhost(BUFFER *wb, RRDHOST *host, struct rrdc
                     buffer_json_member_add_time_t(wb, "first_time", s.db.first_time_s);
                     buffer_json_member_add_time_t(wb, "last_time", s.db.last_time_s);
                     buffer_json_member_add_uint64(wb, "metrics", s.db.metrics);
+
+                    spinlock_lock(&s.host->accounting.spinlock);
+                    int64_t count = 0;
+
+                    if (s.host->accounting.cache_timestamp &&
+                        ctl->now - s.host->accounting.cache_timestamp < host->rrd_update_every * 1.5)
+                        count = s.host->accounting.currently_collected;
+                    else {
+                        Pvoid_t *Pvalue;
+                        bool first = true;
+                        Word_t dimension_id = 0;
+                        while ((Pvalue = JudyLFirstThenNext(s.host->accounting.JudyL, &dimension_id, &first))) {
+                            RRDDIM *rd = *Pvalue;
+                            if (rd->collector.last_collected_time.tv_sec > ctl->now - (rd->rrdset->update_every * 2))
+                                count++;
+                        }
+                        s.host->accounting.currently_collected = count;
+                        s.host->accounting.cache_timestamp = ctl->now;
+                    }
+                    spinlock_unlock(&s.host->accounting.spinlock);
+
+                    buffer_json_member_add_uint64(wb, "currently_collected_metrics", count);
                     buffer_json_member_add_uint64(wb, "instances", s.db.instances);
                     buffer_json_member_add_uint64(wb, "contexts", s.db.contexts);
                 }

--- a/src/database/contexts/api_v2_contexts_agents.c
+++ b/src/database/contexts/api_v2_contexts_agents.c
@@ -31,6 +31,8 @@ void buffer_json_agents_v2(BUFFER *wb, struct query_timings *timings, time_t now
 
         buffer_json_cloud_status(wb, now_s);
 
+        size_t currently_collected_metrics = 0;
+
         buffer_json_member_add_object(wb, "nodes");
         {
             size_t receiving = 0, archived = 0, sending = 0, total = 0;
@@ -47,6 +49,7 @@ void buffer_json_agents_v2(BUFFER *wb, struct query_timings *timings, time_t now
                     else
                         archived++;
                 }
+                currently_collected_metrics += host->accounting.currently_collected;
             }
             dfe_done(host);
 
@@ -82,7 +85,7 @@ void buffer_json_agents_v2(BUFFER *wb, struct query_timings *timings, time_t now
             }
 #endif
             time_t first_time_s = storage_engine_global_first_time_s(eng->seb, localhost->db[tier].si);
-            size_t currently_collected_metrics = storage_engine_collected_metrics(eng->seb, localhost->db[tier].si);
+//            size_t currently_collected_metrics = storage_engine_collected_metrics(eng->seb, localhost->db[tier].si);
 
             NETDATA_DOUBLE percent;
             if (used && max)

--- a/src/database/rrd.h
+++ b/src/database/rrd.h
@@ -284,6 +284,7 @@ struct rrddim {
 
     int32_t multiplier;                             // the multiplier of the collected values
     int32_t divisor;                                // the divider of the collected values
+    int32_t dimension_id;                           // Dimension id
 
     // ------------------------------------------------------------------------
     // operational state members
@@ -1175,6 +1176,14 @@ struct rrdhost {
 
     int32_t rrd_update_every;                       // the update frequency of the host
     int32_t rrd_history_entries;                    // the number of history entries for the host's charts
+
+    struct {
+        uint32_t dimension_count;                   // Dimension count for this host
+        uint32_t currently_collected;               // Currectly collected metrics cache
+        time_t cache_timestamp;
+        Pvoid_t JudyL;                              // Store metrics collected -- link to rrddim
+        SPINLOCK spinlock;
+    } accounting;
 
     RRD_MEMORY_MODE rrd_memory_mode;                // the configured memory more for the charts of this host
                                                     // the actual per tier is at .db[tier].mode

--- a/src/web/api/formatters/rrdset2json.c
+++ b/src/web/api/formatters/rrdset2json.c
@@ -59,6 +59,7 @@ void rrdset2json(RRDSET *st, BUFFER *wb, size_t *dimensions_count, size_t *memor
 
             buffer_json_member_add_object(wb, rrddim_id(rd));
             buffer_json_member_add_string(wb, "name", rrddim_name(rd));
+            buffer_json_member_add_int64(wb, "dimension_id", rd->dimension_id);
             buffer_json_object_close(wb);
 
             dimensions++;


### PR DESCRIPTION
##### Summary
Count the metrics currently collected based on the most recent collection timestamp. A metric is considered "collected" if it has been updated within less than twice the update interval configured for the chart.

- The `db` section of the api/v3/node_instances now includes a `currently_collected_metrics` field.
- The `db_size` section has also been updated to include the `currently_collected_metrics` field, which represents the total number of collected metrics across all nodes.

Example of `api/v3/node_instances`

Previously collected metrics were up to 4749 but currently 3742 are actively being collected

```
          "db": {
            "status": "online",
            "liveness": "live",
            "mode": "dbengine",
            "first_time": 1729008840,
            "last_time": 1729158373,
            "metrics": 4749,
            "currently_collected_metrics": 3742,
            "instances": 2012,
            "contexts": 222
          },
```

Issuing `/api/v3/node_instances` a few seconds later shows the new `currently_collected_metrics` 

```
          "db": {
            "status": "online",
            "liveness": "live",
            "mode": "dbengine",
            "first_time": 1729008840,
            "last_time": 1729158479,
            "metrics": 4749,
            "currently_collected_metrics": 4293,
            "instances": 2012,
            "contexts": 222
          },
```


