### PR TITLE
Patch release 1.47.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,7 +330,6 @@ check_include_file("sys/mount.h" HAVE_SYS_MOUNT_H)
 check_include_file("sys/statvfs.h" HAVE_SYS_STATVFS_H)
 check_include_file("inttypes.h" HAVE_INTTYPES_H)
 check_include_file("stdint.h" HAVE_STDINT_H)
-check_include_file("sys/capability.h" HAVE_SYS_CAPABILITY_H)
 check_include_file("arpa/inet.h" HAVE_ARPA_INET_H)
 check_include_file("netinet/tcp.h" HAVE_NETINET_TCP_H)
 check_include_file("sys/ioctl.h" HAVE_SYS_IOCTL_H)
@@ -345,6 +344,9 @@ check_include_file("sys/socket.h" HAVE_SYS_SOCKET_H)
 check_include_file("sys/wait.h" HAVE_SYS_WAIT_H)
 check_include_file("sys/un.h" HAVE_SYS_UN_H)
 check_include_file("spawn.h" HAVE_SPAWN_H)
+if(OS_LINUX)
+    check_include_file("sys/capability.h" HAVE_SYS_CAPABILITY_H)
+endif()
 
 #
 # check symbols

--- a/src/collectors/freebsd.plugin/freebsd_kstat_zfs.c
+++ b/src/collectors/freebsd.plugin/freebsd_kstat_zfs.c
@@ -43,6 +43,8 @@ int do_kstat_zfs_misc_arcstats(int update_every, usec_t dt) {
         int hash_chains[5];
         int hash_chain_max[5];
         int p[5];
+        int pd[5];
+        int pm[5];
         int c[5];
         int c_min[5];
         int c_max[5];
@@ -145,7 +147,14 @@ int do_kstat_zfs_misc_arcstats(int update_every, usec_t dt) {
     GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.hash_collisions", mibs.hash_collisions, arcstats.hash_collisions);
     GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.hash_chains", mibs.hash_chains, arcstats.hash_chains);
     GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.hash_chain_max", mibs.hash_chain_max, arcstats.hash_chain_max);
+
+#if __FreeBSD_version >= 1400000
+    GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.pd", mibs.pd, arcstats.pd);
+    GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.pm", mibs.pm, arcstats.pm);
+#else
     GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.p", mibs.p, arcstats.p);
+#endif
+
     GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.c", mibs.c, arcstats.c);
     GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.c_min", mibs.c_min, arcstats.c_min);
     GETSYSCTL_SIMPLE("kstat.zfs.misc.arcstats.c_max", mibs.c_max, arcstats.c_max);

--- a/src/collectors/proc.plugin/proc_spl_kstat_zfs.c
+++ b/src/collectors/proc.plugin/proc_spl_kstat_zfs.c
@@ -54,6 +54,8 @@ int do_proc_spl_kstat_zfs_arcstats(int update_every, usec_t dt) {
         arl_expect(arl_base, "hash_chains", &arcstats.hash_chains);
         arl_expect(arl_base, "hash_chain_max", &arcstats.hash_chain_max);
         arl_expect(arl_base, "p", &arcstats.p);
+        arl_expect(arl_base, "pd", &arcstats.pd);
+        arl_expect(arl_base, "pm", &arcstats.pd);
         arl_expect(arl_base, "c", &arcstats.c);
         arl_expect(arl_base, "c_min", &arcstats.c_min);
         arl_expect(arl_base, "c_max", &arcstats.c_max);

--- a/src/collectors/proc.plugin/proc_spl_kstat_zfs.c
+++ b/src/collectors/proc.plugin/proc_spl_kstat_zfs.c
@@ -55,7 +55,7 @@ int do_proc_spl_kstat_zfs_arcstats(int update_every, usec_t dt) {
         arl_expect(arl_base, "hash_chain_max", &arcstats.hash_chain_max);
         arl_expect(arl_base, "p", &arcstats.p);
         arl_expect(arl_base, "pd", &arcstats.pd);
-        arl_expect(arl_base, "pm", &arcstats.pd);
+        arl_expect(arl_base, "pm", &arcstats.pm);
         arl_expect(arl_base, "c", &arcstats.c);
         arl_expect(arl_base, "c_min", &arcstats.c_min);
         arl_expect(arl_base, "c_max", &arcstats.c_max);

--- a/src/collectors/proc.plugin/zfs_common.c
+++ b/src/collectors/proc.plugin/zfs_common.c
@@ -560,7 +560,7 @@ void generate_charts_arc_summary(const char *plugin, const char *module, int upd
     //unsigned long long anon_hits = arcstats.hits - (arcstats.mfu_hits + arcstats.mru_hits + arcstats.mfu_ghost_hits + arcstats.mru_ghost_hits);
 
     unsigned long long arc_size = arcstats.size;
-    unsigned long long mru_size = arcstats.p;
+    unsigned long long mru_size = arcstats.p > 0 ? arcstats.p : arcstats.pd + arcstats.pm;
     //unsigned long long target_min_size = arcstats.c_min;
     //unsigned long long target_max_size = arcstats.c_max;
     unsigned long long target_size = arcstats.c;

--- a/src/collectors/proc.plugin/zfs_common.h
+++ b/src/collectors/proc.plugin/zfs_common.h
@@ -41,6 +41,8 @@ struct arcstats {
     unsigned long long hash_chains;
     unsigned long long hash_chain_max;
     unsigned long long p;
+    unsigned long long pd;
+    unsigned long long pm;
     unsigned long long c;
     unsigned long long c_min;
     unsigned long long c_max;

--- a/src/database/sqlite/sqlite_aclk_node.c
+++ b/src/database/sqlite/sqlite_aclk_node.c
@@ -167,6 +167,12 @@ void aclk_check_node_info_and_collectors(void)
         if (pp_queue_empty && wc->node_info_send_time && wc->node_info_send_time + 30 < now) {
             wc->node_info_send_time = 0;
             build_node_info(host);
+            if (netdata_cloud_enabled) {
+                netdata_mutex_lock(&host->receiver_lock);
+                int live = (host == localhost || host->receiver || !(rrdhost_flag_check(host, RRDHOST_FLAG_ORPHAN))) ? 1 : 0;
+                netdata_mutex_unlock(&host->receiver_lock);
+                aclk_host_state_update(host, live, 1);
+            }
             internal_error(true, "ACLK SYNC: Sending node info for %s", rrdhost_hostname(host));
         }
 

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -844,10 +844,10 @@ void sql_alert_store_config(RRD_ALERT_PROTOTYPE *ap)
     else
         SQLITE_BIND_FAIL(done, sqlite3_bind_null(res, ++param));
 
+    char repeat[255];
     if (!ap->config.has_custom_repeat_config)
         SQLITE_BIND_FAIL(done, sqlite3_bind_null(res, ++param));
     else {
-        char repeat[255];
         snprintfz(repeat, sizeof(repeat) - 1, "warning %us critical %us", ap->config.warn_repeat_every, ap->config.crit_repeat_every);
         SQLITE_BIND_FAIL(done, sqlite3_bind_text(res, ++param, repeat, -1, SQLITE_STATIC));
     }

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -757,20 +757,20 @@ done:
  * Store an alert config hash in the database
  */
 #define SQL_STORE_ALERT_CONFIG_HASH                                                                                    \
-    "insert or replace into alert_hash (hash_id, date_updated, alarm, template, "                                      \
+    "INSERT OR REPLACE INTO alert_hash (hash_id, date_updated, alarm, template, "                                      \
     "on_key, class, component, type, lookup, every, units, calc, "                                                     \
     "green, red, warn, crit, exec, to_key, info, delay, options, repeat, host_labels, "                                \
     "p_db_lookup_dimensions, p_db_lookup_method, p_db_lookup_options, p_db_lookup_after, "                             \
     "p_db_lookup_before, p_update_every, source, chart_labels, summary, time_group_condition, "                        \
     "time_group_value, dims_group, data_source) "                                                                      \
-    "values (@hash_id,UNIXEPOCH(),@alarm,@template,"                                                                   \
+    "VALUES (@hash_id,UNIXEPOCH(),@alarm,@template,"                                                                   \
     "@on_key,@class,@component,@type,@lookup,@every,@units,@calc,"                                                     \
     "@green,@red,@warn,@crit,@exec,@to_key,@info,@delay,@options,@repeat,@host_labels,"                                \
     "@p_db_lookup_dimensions,@p_db_lookup_method,@p_db_lookup_options,@p_db_lookup_after,"                             \
     "@p_db_lookup_before,@p_update_every,@source,@chart_labels,@summary, @time_group_condition, "                      \
     "@time_group_value, @dims_group, @data_source)"
 
-void sql_alert_store_config(RRD_ALERT_PROTOTYPE *ap __maybe_unused)
+void sql_alert_store_config(RRD_ALERT_PROTOTYPE *ap)
 {
     static __thread sqlite3_stmt *res = NULL;
     int param = 0;
@@ -778,7 +778,7 @@ void sql_alert_store_config(RRD_ALERT_PROTOTYPE *ap __maybe_unused)
     if (!PREPARE_COMPILED_STATEMENT(db_meta, SQL_STORE_ALERT_CONFIG_HASH, &res))
         return;
 
-    BUFFER *buf = buffer_create(128, NULL);
+    CLEAN_BUFFER *buf = buffer_create(128, NULL);
 
     SQLITE_BIND_FAIL(
         done, sqlite3_bind_blob(res, ++param, &ap->config.hash_id, sizeof(ap->config.hash_id), SQLITE_STATIC));
@@ -844,7 +844,14 @@ void sql_alert_store_config(RRD_ALERT_PROTOTYPE *ap __maybe_unused)
     else
         SQLITE_BIND_FAIL(done, sqlite3_bind_null(res, ++param));
 
-    SQLITE_BIND_FAIL(done, sqlite3_bind_int(res, ++param, ap->config.update_every));
+    if (!ap->config.has_custom_repeat_config)
+        SQLITE_BIND_FAIL(done, sqlite3_bind_null(res, ++param));
+    else {
+        char repeat[255];
+        snprintfz(repeat, sizeof(repeat) - 1, "warning %us critical %us", ap->config.warn_repeat_every, ap->config.crit_repeat_every);
+        SQLITE_BIND_FAIL(done, sqlite3_bind_text(res, ++param, repeat, -1, SQLITE_STATIC));
+    }
+
     SQLITE_BIND_FAIL(done, SQLITE3_BIND_STRING_OR_NULL(res, ++param, ap->match.host_labels));
 
     if (ap->config.after) {
@@ -877,7 +884,6 @@ void sql_alert_store_config(RRD_ALERT_PROTOTYPE *ap __maybe_unused)
         error_report("Failed to store alert config, rc = %d", rc);
 
 done:
-    buffer_free(buf);
     REPORT_BIND_FAIL(res, param);
     SQLITE_RESET(res);
 }

--- a/src/go/plugin/go.d/agent/discovery/sd/discoverer/netlisteners/netlisteners.go
+++ b/src/go/plugin/go.d/agent/discovery/sd/discoverer/netlisteners/netlisteners.go
@@ -131,7 +131,7 @@ func (d *Discoverer) Discover(ctx context.Context, in chan<- []model.TargetGroup
 func (d *Discoverer) discoverLocalListeners(ctx context.Context, in chan<- []model.TargetGroup) error {
 	bs, err := d.ll.discover(ctx)
 	if err != nil {
-		if errors.Is(err, context.Canceled) {
+		if errors.Is(err, context.DeadlineExceeded) {
 			// there is no point in continuing pointless attempts/use cpu
 			// https://github.com/netdata/netdata/discussions/18751#discussioncomment-10908472
 			if d.timeoutRuns++; d.timeoutRuns > 5 && d.successRuns == 0 {

--- a/src/go/plugin/go.d/agent/discovery/sd/discoverer/netlisteners/netlisteners.go
+++ b/src/go/plugin/go.d/agent/discovery/sd/discoverer/netlisteners/netlisteners.go
@@ -84,6 +84,9 @@ type (
 		cache      map[uint64]*cacheItem // [target.Hash]
 
 		started chan struct{}
+
+		successRuns int64
+		timeoutRuns int64
 	}
 	cacheItem struct {
 		lastSeenTime time.Time
@@ -118,7 +121,7 @@ func (d *Discoverer) Discover(ctx context.Context, in chan<- []model.TargetGroup
 			return
 		case <-tk.C:
 			if err := d.discoverLocalListeners(ctx, in); err != nil {
-				d.Warning(err)
+				d.Error(err)
 				return
 			}
 		}
@@ -129,10 +132,18 @@ func (d *Discoverer) discoverLocalListeners(ctx context.Context, in chan<- []mod
 	bs, err := d.ll.discover(ctx)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
+			// there is no point in continuing pointless attempts/use cpu
+			// https://github.com/netdata/netdata/discussions/18751#discussioncomment-10908472
+			if d.timeoutRuns++; d.timeoutRuns > 5 && d.successRuns == 0 {
+				return err
+			}
+			d.Warning(err)
 			return nil
 		}
 		return err
 	}
+
+	d.successRuns++
 
 	tgts, err := d.parseLocalListeners(bs)
 	if err != nil {

--- a/src/go/plugin/go.d/modules/nvidia_smi/charts.go
+++ b/src/go/plugin/go.d/modules/nvidia_smi/charts.go
@@ -4,6 +4,7 @@ package nvidia_smi
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/agent/module"
@@ -261,7 +262,7 @@ var (
 	}
 )
 
-func (nv *NvidiaSmi) addGPUXMLCharts(gpu gpuInfo) {
+func (nv *NvidiaSmi) addGpuCharts(gpu gpuInfo, index int) {
 	charts := gpuXMLCharts.Copy()
 
 	if !isValidValue(gpu.Utilization.GpuUtil) {
@@ -294,7 +295,7 @@ func (nv *NvidiaSmi) addGPUXMLCharts(gpu gpuInfo) {
 	for _, c := range *charts {
 		c.ID = fmt.Sprintf(c.ID, strings.ToLower(gpu.UUID))
 		c.Labels = []module.Label{
-			// csv output has no 'product_brand'
+			{Key: "index", Value: strconv.Itoa(index)},
 			{Key: "uuid", Value: gpu.UUID},
 			{Key: "product_name", Value: gpu.ProductName},
 		}

--- a/src/go/plugin/go.d/modules/nvidia_smi/collect.go
+++ b/src/go/plugin/go.d/modules/nvidia_smi/collect.go
@@ -38,7 +38,7 @@ func (nv *NvidiaSmi) collectGPUInfo(mx map[string]int64) error {
 	seenGPU := make(map[string]bool)
 	seenMIG := make(map[string]bool)
 
-	for _, gpu := range info.GPUs {
+	for i, gpu := range info.GPUs {
 		if !isValidValue(gpu.UUID) {
 			continue
 		}
@@ -49,7 +49,7 @@ func (nv *NvidiaSmi) collectGPUInfo(mx map[string]int64) error {
 
 		if !nv.gpus[px] {
 			nv.gpus[px] = true
-			nv.addGPUXMLCharts(gpu)
+			nv.addGpuCharts(gpu, i)
 		}
 
 		addMetric(mx, px+"pcie_bandwidth_usage_rx", gpu.PCI.RxUtil, 1024) // KB => bytes

--- a/src/go/plugin/go.d/modules/nvidia_smi/metadata.yaml
+++ b/src/go/plugin/go.d/modules/nvidia_smi/metadata.yaml
@@ -98,7 +98,9 @@ modules:
           description: These metrics refer to the GPU.
           labels:
             - name: uuid
-              description: GPU id (e.g. 00000000:00:04.0)
+              description: GPU uuid (e.g. GPU-27b94a00-ed54-5c24-b1fd-1054085de32a)
+            - name: index
+              description: GPU index (nvidia_smi typically orders GPUs by PCI bus ID)
             - name: product_name
               description: GPU product name (e.g. NVIDIA A100-SXM4-40GB)
           metrics:
@@ -211,7 +213,7 @@ modules:
           description: These metrics refer to the Multi-Instance GPU (MIG).
           labels:
             - name: uuid
-              description: GPU id (e.g. 00000000:00:04.0)
+              description: GPU uuid (e.g. GPU-27b94a00-ed54-5c24-b1fd-1054085de32a)
             - name: product_name
               description: GPU product name (e.g. NVIDIA A100-SXM4-40GB)
             - name: gpu_instance_id

--- a/src/health/rrdvar.c
+++ b/src/health/rrdvar.c
@@ -107,7 +107,7 @@ void rrdvar_host_variable_set(RRDHOST *host, const RRDVAR_ACQUIRED *rva, NETDATA
 // CUSTOM CHART VARIABLES
 
 const RRDVAR_ACQUIRED *rrdvar_chart_variable_add_and_acquire(RRDSET *st, const char *name) {
-    if(unlikely(!st->rrdvars)) return NULL;
+    if(unlikely(!st || !st->rrdvars)) return NULL;
 
     STRING *name_string = rrdvar_name_to_string(name);
     const RRDVAR_ACQUIRED *rs = rrdvar_add_and_acquire(st->rrdvars, name_string, NAN);
@@ -116,7 +116,7 @@ const RRDVAR_ACQUIRED *rrdvar_chart_variable_add_and_acquire(RRDSET *st, const c
 }
 
 void rrdvar_chart_variable_set(RRDSET *st, const RRDVAR_ACQUIRED *rva, NETDATA_DOUBLE value) {
-    if(unlikely(!st->rrdvars || !rva)) return;
+    if(unlikely(!st || !st->rrdvars || !rva)) return;
 
     RRDVAR *rv = dictionary_acquired_item_value((const DICTIONARY_ITEM *)rva);
     if(rv->value != value) {

--- a/src/health/rrdvar.h
+++ b/src/health/rrdvar.h
@@ -19,7 +19,7 @@ void rrdvar_host_variable_set(RRDHOST *host, const RRDVAR_ACQUIRED *rva, NETDATA
 int rrdvar_walkthrough_read(DICTIONARY *dict, int (*callback)(const DICTIONARY_ITEM *item, void *rrdvar, void *data), void *data);
 
 #define rrdvar_host_variable_release(host, rva) rrdvar_release((host)->rrdvars, rva)
-#define rrdvar_chart_variable_release(st, rva) rrdvar_release((st)->rrdvars, rva)
+#define rrdvar_chart_variable_release(st, rva) do { if(st) rrdvar_release((st)->rrdvars, rva); } while(0)
 void rrdvar_release(DICTIONARY *dict, const RRDVAR_ACQUIRED *rva);
 
 NETDATA_DOUBLE rrdvar2number(const RRDVAR_ACQUIRED *rva);


### PR DESCRIPTION
##### Summary
- fix(packaging): check for sys/capability.h only on Linux (#18849)
- add "index" label to GPU charts (#18833)
- fix(proc/proc_net_dev): delay collecting all virtual interfaces (#18812)
- fix(proc.plugin/zfs): fix arcstats.pm (#18758)
- fix(freebsd.plugin): fix sysctl arcstats.p fails on FreeBSD 14 (#18748)
- fix(go.d/sd/netlisteners): fix exec deadline exceeded check (#18774)
- fix(go.d/sd/net_listeners): exit if local-listeners constantly times out (#18757)
- Fix wrong variable scope
- Additional checks when acquiring/setting chart variable (https://github.com/netdata/netdata/pull/18804/commits/17ce74e66146955a870ba4e1f45c6d9470986a80) backport from (#18785) 
- Schedule a node state update after context load backport (#18795)
- Fix storing of repeat field (#18760)
