### PR TITLE
Revert "Fix atomic builtins test that currently fails for llvm+compiler_rt when gcc is not present"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,8 +448,7 @@ int main() {
 
 check_cxx_source_compiles("
 int main() {
-        int test;
-        __atomic_load_n(&test, 0);
+        __atomic_load_8(nullptr, 0);
         return 0;
 }
 " HAVE_BUILTIN_ATOMICS)


### PR DESCRIPTION
Reverts netdata/netdata#18788

Compilation failure 

eg
```
/usr/bin/ld: liblibnetdata.a(libnetdata.c.o): undefined reference to symbol '__atomic_compare_exchange_8@@LIBATOMIC_1.0'
/usr/bin/ld: /lib/arm-linux-gnueabihf/libatomic.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```
```
Linux rpi4b-1 6.1.21-v8+ #1642 SMP PREEMPT Mon Apr  3 17:24:16 BST 2023 aarch64 GNU/Linux
```