### PR TITLE
claiming should wait for node id and status ONLINE only

### DIFF
--- a/src/claim/claim.c
+++ b/src/claim/claim.c
@@ -197,7 +197,7 @@ CLOUD_STATUS claim_reload_and_wait_online(void) {
         int ms = 0;
         do {
             status = cloud_status();
-            if ((status == CLOUD_STATUS_ONLINE || status == CLOUD_STATUS_INDIRECT) && !UUIDiszero(localhost->host_id))
+            if ((status == CLOUD_STATUS_ONLINE) && !UUIDiszero(localhost->node_id))
                 break;
 
             sleep_usec(50 * USEC_PER_MS);


### PR DESCRIPTION
The function `claim_reload_and_wait_online()` should wait for a node id and claiming status ONLINE.
Before that PR it was checking for a machine guid and also claiming status INDIRECT, so the UI could not know when claiming is ready after claiming the agent.

@stelfrag this should probably go into the patch release.