### PR TITLE
optimizations for servers with vast amounts of sockets

### DIFF
--- a/src/collectors/apps.plugin/apps_os_freebsd.c
+++ b/src/collectors/apps.plugin/apps_os_freebsd.c
@@ -98,13 +98,16 @@ bool apps_os_read_pid_fds_freebsd(struct pid_stat *p, void *ptr) {
         if (unlikely(fdid >= p->fds_size)) {
             // it is small, extend it
 
-            debug_log("extending fd memory slots for %s from %d to %d", pid_stat_comm(p), p->fds_size, fdid + MAX_SPARE_FDS);
+            uint32_t new_size = fds_new_size(p->fds_size, fdid);
 
-            p->fds = reallocz(p->fds, (fdid + MAX_SPARE_FDS) * sizeof(struct pid_fd));
+            debug_log("extending fd memory slots for %s from %u to %u",
+                      pid_stat_comm(p), p->fds_size, new_size);
+
+            p->fds = reallocz(p->fds, new_size * sizeof(struct pid_fd));
 
             // and initialize it
-            init_pid_fds(p, p->fds_size, (fdid + MAX_SPARE_FDS) - p->fds_size);
-            p->fds_size = fdid + MAX_SPARE_FDS;
+            init_pid_fds(p, p->fds_size, new_size - p->fds_size);
+            p->fds_size = new_size;
         }
 
         if (unlikely(p->fds[fdid].fd == 0)) {

--- a/src/collectors/apps.plugin/apps_pid.c
+++ b/src/collectors/apps.plugin/apps_pid.c
@@ -58,7 +58,7 @@ void apps_pids_init(void) {
 }
 
 static inline uint64_t pid_hash(pid_t pid) {
-    return ((uint64_t)pid << 31) + (uint64_t)pid; // we remove 1 bit when shifting to make it different
+    return XXH3_64bits(&pid, sizeof(pid));
 }
 
 inline struct pid_stat *find_pid_entry(pid_t pid) {

--- a/src/collectors/apps.plugin/apps_pid.c
+++ b/src/collectors/apps.plugin/apps_pid.c
@@ -81,8 +81,8 @@ struct pid_stat *get_or_allocate_pid_entry(pid_t pid) {
     p = aral_callocz(pids.all_pids.aral);
 
 #if (PROCESSES_HAVE_FDS == 1)
-    p->fds = mallocz(sizeof(struct pid_fd) * MAX_SPARE_FDS);
-    p->fds_size = MAX_SPARE_FDS;
+    p->fds = mallocz(sizeof(struct pid_fd) * 3); // stdin, stdout, stderr
+    p->fds_size = 3;
     init_pid_fds(p, 0, p->fds_size);
 #endif
 

--- a/src/collectors/apps.plugin/apps_pid_files.c
+++ b/src/collectors/apps.plugin/apps_pid_files.c
@@ -247,8 +247,10 @@ void file_descriptor_not_used(int id) {
 static inline void all_files_grow() {
     void *old = all_files;
 
+    uint32_t new_size = (all_files_size > 0) ? all_files_size * 2 : 2048;
+
     // there is no empty slot
-    all_files = reallocz(all_files, (all_files_size + FILE_DESCRIPTORS_INCREASE_STEP) * sizeof(struct file_descriptor));
+    all_files = reallocz(all_files, new_size * sizeof(struct file_descriptor));
 
     // if the address changed, we have to rebuild the index
     // since all pointers are now invalid
@@ -264,7 +266,7 @@ static inline void all_files_grow() {
 
     // initialize the newly added entries
 
-    for(uint32_t i = all_files_size; i < (all_files_size + FILE_DESCRIPTORS_INCREASE_STEP); i++) {
+    for(uint32_t i = all_files_size; i < new_size; i++) {
         all_files[i].count = 0;
         all_files[i].name = NULL;
 #ifdef NETDATA_INTERNAL_CHECKS
@@ -274,7 +276,7 @@ static inline void all_files_grow() {
     }
 
     if(unlikely(!all_files_size)) all_files_len = 1;
-    all_files_size += FILE_DESCRIPTORS_INCREASE_STEP;
+    all_files_size = new_size;
 }
 
 static inline uint32_t file_descriptor_set_on_empty_slot(const char *name, uint32_t hash, FD_FILETYPE type) {

--- a/src/collectors/apps.plugin/apps_pid_files.c
+++ b/src/collectors/apps.plugin/apps_pid_files.c
@@ -38,6 +38,14 @@ struct file_descriptor {
     FD_FILETYPE type;
 } *all_files = NULL;
 
+static uint32_t
+    all_files_len,
+    all_files_size;
+
+uint32_t all_file_len_get(void) {
+    return all_files_len;
+}
+
 // ----------------------------------------------------------------------------
 
 static inline void reallocate_target_fds(struct target *w) {
@@ -110,6 +118,15 @@ static inline void aggregate_fd_on_target(int fd, struct target *w) {
 }
 
 void aggregate_pid_fds_on_targets(struct pid_stat *p) {
+    if(enable_file_charts == CONFIG_BOOLEAN_AUTO && all_files_len > MAX_SYSTEM_FD_TO_ALLOW_FILES_PROCESSING) {
+        nd_log(NDLS_COLLECTORS, NDLP_NOTICE, "apps.plugin: the number of system file descriptors are too many (%u), "
+                                             "disabling file charts. If you want this enabled, set the 'with-files' "
+                                             "parameter to [plugin:apps] section of netdata.conf", all_files_size);
+
+        enable_file_charts = CONFIG_BOOLEAN_NO;
+        obsolete_file_charts = true;
+        return;
+    }
 
     if(unlikely(!p->updated)) {
         // the process is not running

--- a/src/collectors/apps.plugin/apps_plugin.c
+++ b/src/collectors/apps.plugin/apps_plugin.c
@@ -34,11 +34,14 @@ bool enable_groups_charts = true;
 bool include_exited_childs = true;
 bool proc_pid_cmdline_is_needed = true; // true when we need to read /proc/cmdline
 
-#if defined(OS_FREEBSD) || defined(OS_MACOS) || defined(OS_WINDOWS)
-bool enable_file_charts = false;
+#if defined(OS_FREEBSD) || defined(OS_MACOS)
+int enable_file_charts = CONFIG_BOOLEAN_NO;
 #elif defined(OS_LINUX)
-bool enable_file_charts = true;
+int enable_file_charts = CONFIG_BOOLEAN_AUTO;
+#elif defined(OS_WINDOWS)
+int enable_file_charts = CONFIG_BOOLEAN_YES;
 #endif
+bool obsolete_file_charts = false;
 
 // ----------------------------------------------------------------------------
 // internal counters
@@ -468,12 +471,12 @@ static void parse_args(int argc, char **argv)
 
 #if (PROCESSES_HAVE_FDS == 1)
         if(strcmp("with-files", argv[i]) == 0) {
-            enable_file_charts = 1;
+            enable_file_charts = CONFIG_BOOLEAN_YES;
             continue;
         }
 
         if(strcmp("no-files", argv[i]) == 0 || strcmp("without-files", argv[i]) == 0) {
-            enable_file_charts = 0;
+            enable_file_charts = CONFIG_BOOLEAN_NO;
             continue;
         }
 #endif

--- a/src/collectors/apps.plugin/apps_plugin.h
+++ b/src/collectors/apps.plugin/apps_plugin.h
@@ -151,6 +151,8 @@ extern int max_fds_cache_seconds;
 
 // --------------------------------------------------------------------------------------------------------------------
 
+#define MAX_SYSTEM_FD_TO_ALLOW_FILES_PROCESSING 100000
+
 extern pid_t INIT_PID;
 
 extern bool debug_enabled;
@@ -161,7 +163,8 @@ extern bool enable_groups_charts;
 extern bool include_exited_childs;
 extern bool enable_function_cmdline;
 extern bool proc_pid_cmdline_is_needed;
-extern bool enable_file_charts;
+extern int enable_file_charts;
+extern bool obsolete_file_charts;
 
 extern size_t
     global_iterations_counter,
@@ -177,10 +180,6 @@ extern size_t
 extern bool enable_guest_charts;
 extern bool show_guest_time;
 #endif
-
-extern uint32_t
-    all_files_len,
-    all_files_size;
 
 #if (ALL_PIDS_ARE_READ_INSTANTLY == 0)
 extern kernel_uint_t
@@ -463,6 +462,7 @@ struct pid_fd {
 
 #define pid_stat_comm(p) (string2str(p->comm))
 #define pid_stat_cmdline(p) (string2str(p->cmdline))
+uint32_t all_file_len_get(void);
 
 struct pid_stat {
     int32_t pid;

--- a/src/collectors/apps.plugin/apps_plugin.h
+++ b/src/collectors/apps.plugin/apps_plugin.h
@@ -212,11 +212,12 @@ extern netdata_mutex_t apps_and_stdout_mutex;
 #define MAX_CMDLINE 65536
 
 // ----------------------------------------------------------------------------
-// to avoid reallocating too frequently, we can increase the number of spare
-// file descriptors used by processes.
-// IMPORTANT:
-// having a lot of spares, increases the CPU utilization of the plugin.
-#define MAX_SPARE_FDS 1
+// to avoid reallocating too frequently when we add file descriptors,
+// we double the allocation at every increase request.
+
+static inline uint32_t fds_new_size(uint32_t old_size, uint32_t new_fd) {
+    return MAX(old_size * 2, new_fd + 1); // 1 space always
+}
 
 // ----------------------------------------------------------------------------
 // some variables for keeping track of processes count by states

--- a/src/libnetdata/maps/system-groups.h
+++ b/src/libnetdata/maps/system-groups.h
@@ -21,7 +21,8 @@ typedef struct groupnames_cache {
 static inline STRING *system_groupnames_cache_lookup_gid(GROUPNAMES_CACHE *gc, gid_t gid) {
     spinlock_lock(&gc->spinlock);
 
-    SIMPLE_HASHTABLE_SLOT_GROUPNAMES_CACHE *sl = simple_hashtable_get_slot_GROUPNAMES_CACHE(&gc->ht, gid, &gid, true);
+    XXH64_hash_t hash = XXH3_64bits(&gid, sizeof(gid));
+    SIMPLE_HASHTABLE_SLOT_GROUPNAMES_CACHE *sl = simple_hashtable_get_slot_GROUPNAMES_CACHE(&gc->ht, hash, &gid, true);
     STRING *g = SIMPLE_HASHTABLE_SLOT_DATA(sl);
     if(!g) {
         char tmp[1024 + 1];

--- a/src/libnetdata/maps/system-services.h
+++ b/src/libnetdata/maps/system-services.h
@@ -19,10 +19,6 @@ typedef struct servicenames_cache {
     SIMPLE_HASHTABLE_SERVICENAMES_CACHE ht;
 } SERVICENAMES_CACHE;
 
-static inline uint64_t system_servicenames_key(uint16_t port, uint16_t ipproto) {
-    return ((uint64_t)ipproto << 16) | (uint64_t)port;
-}
-
 static inline const char *system_servicenames_ipproto2str(uint16_t ipproto) {
     return (ipproto == IPPROTO_TCP) ? "tcp" : "udp";
 }
@@ -38,10 +34,18 @@ static inline const char *static_portnames(uint16_t port, uint16_t ipproto) {
 }
 
 static inline STRING *system_servicenames_cache_lookup(SERVICENAMES_CACHE *sc, uint16_t port, uint16_t ipproto) {
-    uint64_t key = system_servicenames_key(port, ipproto);
+    struct {
+        uint16_t ipproto;
+        uint16_t port;
+    } key = {
+        .ipproto = ipproto,
+        .port = port,
+    };
+    XXH64_hash_t hash = XXH3_64bits(&key, sizeof(key));
+
     spinlock_lock(&sc->spinlock);
 
-    SIMPLE_HASHTABLE_SLOT_SERVICENAMES_CACHE *sl = simple_hashtable_get_slot_SERVICENAMES_CACHE(&sc->ht, key, &key, true);
+    SIMPLE_HASHTABLE_SLOT_SERVICENAMES_CACHE *sl = simple_hashtable_get_slot_SERVICENAMES_CACHE(&sc->ht, hash, &key, true);
     STRING *s = SIMPLE_HASHTABLE_SLOT_DATA(sl);
     if (!s) {
         const char *st = static_portnames(port, ipproto);

--- a/src/libnetdata/maps/system-users.h
+++ b/src/libnetdata/maps/system-users.h
@@ -21,7 +21,8 @@ typedef struct usernames_cache {
 static inline STRING *system_usernames_cache_lookup_uid(USERNAMES_CACHE *uc, uid_t uid) {
     spinlock_lock(&uc->spinlock);
 
-    SIMPLE_HASHTABLE_SLOT_USERNAMES_CACHE *sl = simple_hashtable_get_slot_USERNAMES_CACHE(&uc->ht, uid, &uid, true);
+    XXH64_hash_t hash = XXH3_64bits(&uid, sizeof(uid));
+    SIMPLE_HASHTABLE_SLOT_USERNAMES_CACHE *sl = simple_hashtable_get_slot_USERNAMES_CACHE(&uc->ht, hash, &uid, true);
     STRING *u = SIMPLE_HASHTABLE_SLOT_DATA(sl);
     if(!u) {
         char tmp[1024 + 1];

--- a/src/libnetdata/query_progress/progress.c
+++ b/src/libnetdata/query_progress/progress.c
@@ -76,12 +76,7 @@ static struct progress {
 };
 
 SIMPLE_HASHTABLE_HASH query_hash(nd_uuid_t *transaction) {
-    struct uuid_hi_lo_t {
-        uint64_t hi;
-        uint64_t lo;
-    } *parts = (struct uuid_hi_lo_t *)transaction;
-
-    return parts->lo;
+    return XXH3_64bits(transaction, sizeof(*transaction));
 }
 
 static void query_progress_init_unsafe(void) {


### PR DESCRIPTION
- [x] local-sockets to quickly index sockets (affects `local-listeners` and `network-viewer.plugin`)
- [x] apps.plugin dynamically reallocates pid fds (eliminated frequent reallocs)
- [x] apps.plugin dynamically reallocates global index of fds (it had to reindex the global index too many times)
- [x] apps.plugin automatically disables monitoring file descriptors when there are more than 100k descriptors open
- [x] ensure all hashtable implementations use a proper random hash, instead of some id