### PR TITLE
fix(apps.plugin): add tini to Linux managers

### DIFF
--- a/src/collectors/apps.plugin/apps_groups.conf
+++ b/src/collectors/apps.plugin/apps_groups.conf
@@ -12,7 +12,7 @@
 #managers: clear
 
 ## Linux process managers
-#managers: init systemd containerd-shim-runc-v2 dumb-init gnome-shell docker-init
+#managers: init systemd containerd-shim-runc-v2 dumb-init gnome-shell docker-init tini
 #managers: spawn-plugins openrc-run.sh crond plasmashell xfwm4
 
 ## FreeBSD process managers

--- a/src/collectors/apps.plugin/apps_targets.c
+++ b/src/collectors/apps.plugin/apps_targets.c
@@ -94,6 +94,7 @@ void apps_managers_and_aggregators_init(void) {
     managed_list_add(&tree.managers, "systemd");                    // lxc containers and host systems (this also catches "systemd --user")
     managed_list_add(&tree.managers, "containerd-shim-runc-v2");    // docker containers
     managed_list_add(&tree.managers, "docker-init");                // docker containers
+    managed_list_add(&tree.managers, "tini");                       // docker containers (https://github.com/krallin/tini)
     managed_list_add(&tree.managers, "dumb-init");                  // some docker containers use this
     managed_list_add(&tree.managers, "openrc-run.sh");              // openrc
     managed_list_add(&tree.managers, "crond");                      // linux crond


### PR DESCRIPTION
##### Summary

Add https://github.com/krallin/tini. Some docker images use it (e.g. [mariadb/maxscale](https://hub.docker.com/r/mariadb/maxscale) (related issue #12830)).

Without this fix, `apps.plugin` fails to identify MaxScale (Docker) as an app and aggregates it into the `tini` group.



##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
