### PR TITLE
Start-stop-restart for windows, plus move info to its own file

### DIFF
--- a/docs/netdata-agent/reload-health-configuration.md
+++ b/docs/netdata-agent/reload-health-configuration.md
@@ -2,15 +2,8 @@
 
 ## Unix systems
 
-You do not need to restart the Netdata Agent between changes to health configuration files, such as specific health entities. Instead, use `netdatacli` and the `reload-health` option to prevent gaps in metrics collection.
+No need to restart the Netdata Agent after modifying health configuration files (alerts). Use `netdatacli` to avoid metric collection gaps.
 
 ```bash
 sudo netdatacli reload-health
-```
-
-If `netdatacli` doesn't work on your system, send a `SIGUSR2` signal to the daemon, which reloads health configuration
-without restarting the entire process.
-
-```bash
-killall -USR2 netdata
 ```

--- a/docs/netdata-agent/reload-health-configuration.md
+++ b/docs/netdata-agent/reload-health-configuration.md
@@ -1,0 +1,16 @@
+# Reload health configuration
+
+## Unix systems
+
+You do not need to restart the Netdata Agent between changes to health configuration files, such as specific health entities. Instead, use `netdatacli` and the `reload-health` option to prevent gaps in metrics collection.
+
+```bash
+sudo netdatacli reload-health
+```
+
+If `netdatacli` doesn't work on your system, send a `SIGUSR2` signal to the daemon, which reloads health configuration
+without restarting the entire process.
+
+```bash
+killall -USR2 netdata
+```

--- a/docs/netdata-agent/start-stop-restart.md
+++ b/docs/netdata-agent/start-stop-restart.md
@@ -1,16 +1,14 @@
 # Start, stop, or restart the Netdata Agent
 
-When you install the Netdata Agent, the [daemon](/src/daemon/README.md) is
-configured to start at boot and stop and restart/shutdown.
+When you install the Netdata Agent, the [daemon](/src/daemon/README.md) is configured to start at boot and stop and restart/shutdown.
 
-You will most often need to _restart_ the Agent to load new or editing configuration files.
-[Health configuration](#reload-health-configuration) files are the only exception, as they can be reloaded without restarting
-the entire Agent.
+> You will most often need to _restart_ the Agent to load new or editing configuration files. [Health configuration](/docs/netdata-agent/reload-health-configuration.md) files are the only exception, as they can be reloaded without restarting the entire Agent.
+>
+> Stopping or restarting the Netdata Agent will cause gaps in stored metrics until the `netdata` process initiates collectors and the database engine.
 
-Stopping or restarting the Netdata Agent will cause gaps in stored metrics until the `netdata` process initiates
-collectors and the database engine.
+## Unix systems
 
-## Using `systemctl`, `service`, or `init.d`
+### Using `systemctl`, `service`, or `init.d`
 
 This is the recommended way to start, stop, or restart the Netdata daemon.
 
@@ -22,7 +20,7 @@ If the above commands fail, or you know that you're using a non-systemd system, 
 
 - **service**: `sudo service netdata start`, `sudo service netdata stop`, `sudo service netdata restart`
 
-## Using `netdata`
+### Using `netdata`
 
 Use the `netdata` command, typically located at `/usr/sbin/netdata`, to start the Netdata daemon.
 
@@ -32,122 +30,20 @@ sudo netdata
 
 If you start the daemon this way, close it with `sudo killall netdata`.
 
-## Using `netdatacli`
+### Using `netdatacli`
 
-The Netdata Agent also comes with a [CLI tool](/src/cli/README.md) capable of performing shutdowns. Start the Agent back up
-using your preferred method listed above.
+The Netdata Agent also comes with a [CLI tool](/src/cli/README.md) capable of performing shutdowns. Start the Agent back up using your preferred method listed above.
 
 ```bash
 sudo netdatacli shutdown-agent
 ```
 
-## Netdata MSI installations
+## Windows systems
 
-Netdata provides an installer for Windows using WSL, on those installations by using a Windows terminal (e.g. the Command prompt or Windows Powershell) you can:
+> **Note**
+>
+> You will need to run Powershell as administrator.
 
-- Start Netdata, by running `start-netdata`
-- Stop Netdata, by running `stop-netdata`
-- Restart Netdata, by running `restart-netdata`
-
-## Reload health configuration
-
-You do not need to restart the Netdata Agent between changes to health configuration files, such as specific health
-entities. Instead, use [`netdatacli`](#using-netdatacli) and the `reload-health` option to prevent gaps in metrics
-collection.
-
-```bash
-sudo netdatacli reload-health
-```
-
-If `netdatacli` doesn't work on your system, send a `SIGUSR2` signal to the daemon, which reloads health configuration
-without restarting the entire process.
-
-```bash
-killall -USR2 netdata
-```
-
-## Force stop stalled or unresponsive `netdata` processes
-
-In rare cases, the Netdata Agent may stall or not properly close sockets, preventing a new process from starting. In
-these cases, try the following three commands:
-
-```bash
-sudo systemctl stop netdata
-sudo killall netdata
-ps aux| grep netdata
-```
-
-The output of `ps aux` should show no `netdata` or associated processes running. You can now start the Netdata Agent
-again with `service netdata start`, or the appropriate method for your system.
-
-## Starting Netdata at boot
-
-In the `system` directory you can find scripts and configurations for the
-various distros.
-
-### systemd
-
-The installer already installs `netdata.service` if it detects a systemd system.
-
-To install `netdata.service` by hand, run:
-
-```sh
-# stop Netdata
-killall netdata
-
-# copy netdata.service to systemd
-cp system/netdata.service /etc/systemd/system/
-
-# let systemd know there is a new service
-systemctl daemon-reload
-
-# enable Netdata at boot
-systemctl enable netdata
-
-# start Netdata
-systemctl start netdata
-```
-
-### init.d
-
-In the system directory you can find `netdata-lsb`. Copy it to the proper place according to your distribution
-documentation. For Ubuntu, this can be done via running the following commands as root.
-
-```sh
-# copy the Netdata startup file to /etc/init.d
-cp system/netdata-lsb /etc/init.d/netdata
-
-# make sure it is executable
-chmod +x /etc/init.d/netdata
-
-# enable it
-update-rc.d netdata defaults
-```
-
-### openrc (gentoo)
-
-In the `system` directory you can find `netdata-openrc`. Copy it to the proper
-place according to your distribution documentation.
-
-### CentOS / Red Hat Enterprise Linux
-
-For older versions of RHEL/CentOS that don't have systemd, an init script is included in the system directory. This can
-be installed by running the following commands as root.
-
-```sh
-# copy the Netdata startup file to /etc/init.d
-cp system/netdata-init-d /etc/init.d/netdata
-
-# make sure it is executable
-chmod +x /etc/init.d/netdata
-
-# enable it
-chkconfig --add netdata
-```
-
-_There have been some recent work on the init script, see PR
-<https://github.com/netdata/netdata/pull/403>_
-
-### other systems
-
-You can start Netdata by running it from `/etc/rc.local` or equivalent.
+- To **start** Netdata, run `Start-Service Netdata`.
+- To **stop** Netdata, run `Stop-Service Netdata`.
+- To **restart** Netdata, run `Restart-Service Netdata`.

--- a/docs/netdata-agent/start-stop-restart.md
+++ b/docs/netdata-agent/start-stop-restart.md
@@ -1,24 +1,20 @@
 # Start, stop, or restart the Netdata Agent
 
-When you install the Netdata Agent, the [daemon](/src/daemon/README.md) is configured to start at boot and stop and restart/shutdown.
+The Netdata Agent automatically starts at boot after installation.
 
-> You will most often need to _restart_ the Agent to load new or editing configuration files. [Health configuration](/docs/netdata-agent/reload-health-configuration.md) files are the only exception, as they can be reloaded without restarting the entire Agent.
+> In most cases, you need to **restart the Netdata service** to apply changes to configuration files. [Health configuration](/docs/netdata-agent/reload-health-configuration.md) files, which define alerts, are an exception. They can be reloaded **without restarting** by using the `netdatacli` tool.
 >
-> Stopping or restarting the Netdata Agent will cause gaps in stored metrics until the `netdata` process initiates collectors and the database engine.
+> Restarting the Netdata Agent will cause temporary gaps in your collected metrics. This occurs while the netdata process reinitializes its data collectors and database engine.
 
 ## Unix systems
 
 ### Using `systemctl`, `service`, or `init.d`
 
-This is the recommended way to start, stop, or restart the Netdata daemon.
-
-- To **start** Netdata, run `sudo systemctl start netdata`.
-- To **stop** Netdata, run `sudo systemctl stop netdata`.
-- To **restart** Netdata, run `sudo systemctl restart netdata`.
-
-If the above commands fail, or you know that you're using a non-systemd system, try using the `service` command:
-
-- **service**: `sudo service netdata start`, `sudo service netdata stop`, `sudo service netdata restart`
+| Action  | Systemd                        | Non-systemd                  |
+|---------|--------------------------------|------------------------------|
+| start   | `sudo systemctl start netdata` | `sudo service netdata start` |
+| stop    | `sudo systemctl stop netdata`  | `sudo service netdata stop`  |
+| restart | `sudo systemctl stop netdata`  | `sudo service netdata stop`  |
 
 ### Using `netdata`
 
@@ -42,7 +38,7 @@ sudo netdatacli shutdown-agent
 
 > **Note**
 >
-> You will need to run Powershell as administrator.
+> You will need to run PowerShell as administrator.
 
 - To **start** Netdata, run `Start-Service Netdata`.
 - To **stop** Netdata, run `Stop-Service Netdata`.

--- a/docs/netdata-agent/start-stop-restart.md
+++ b/docs/netdata-agent/start-stop-restart.md
@@ -47,3 +47,5 @@ sudo netdatacli shutdown-agent
 - To **start** Netdata, run `Start-Service Netdata`.
 - To **stop** Netdata, run `Stop-Service Netdata`.
 - To **restart** Netdata, run `Restart-Service Netdata`.
+
+If you prefer to manage the Agent through the GUI, you can start-stop and restart the `Netdata` service from the "Services" tab of Task Manager.


### PR DESCRIPTION
##### Summary

Remove useless info, as we state that the Agent is set to start at boot at the top of the file

Add Windows information (tried to keep it short, no description)

Move reload health configuration to its own file (Will need to add to Learn after this PR)