### PR TITLE
Update CI to generate MSI installer for Windows using WiX.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -343,7 +343,7 @@ jobs:
           trusted-signing-account-name: Netdata
           certificate-profile-name: Netdata
           files-folder: ${{ github.workspace }}\packaging\windows
-          files-folder-filter: exe
+          files-folder-filter: msi
           file-digest: SHA256
           timestamp-rfc3161: "http://timestamp.acs.microsoft.com"
           timestamp-digest: SHA256
@@ -352,7 +352,7 @@ jobs:
         uses: actions/upload-artifact@v4.4.2
         with:
           name: windows-x86_64-installer
-          path: packaging\windows\netdata*.exe
+          path: packaging\windows\netdata*.msi
           retention-days: 30
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2

--- a/.gitignore
+++ b/.gitignore
@@ -196,9 +196,5 @@ build/
 src/go/plugin/go.d/bin/
 src/go/plugin/go.d/vendor
 
-# ignore nsis installer
-packaging/utils/netdata-installer-x64.exe
-
 # ignore files used with msi installer
-packaging/utils/*.msi
-
+packaging/windows/*.msi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2469,6 +2469,7 @@ if(OS_WINDOWS)
         configure_file(packaging/windows/resources/netdata.manifest.in ${CMAKE_SOURCE_DIR}/packaging/windows/resources/netdata.manifest @ONLY)
 
         configure_file(packaging/windows/netdata.wxs.in netdata.wxs @ONLY)
+        configure_file(packaging/windows/NetdataWhite.ico NetdataWhite.ico COPYONLY)
 endif()
 
 add_executable(netdata

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2468,7 +2468,7 @@ if(OS_WINDOWS)
         set(NETDATA_RES_FILES "packaging/windows/resources/netdata.rc")
         configure_file(packaging/windows/resources/netdata.manifest.in ${CMAKE_SOURCE_DIR}/packaging/windows/resources/netdata.manifest @ONLY)
 
-        configure_file(packaging/windows/netdata.wxs.in ${CMAKE_SOURCE_DIR}/packaging/windows/netdata.wxs @ONLY)
+        configure_file(packaging/windows/netdata.wxs.in netdata.wxs @ONLY)
 endif()
 
 add_executable(netdata

--- a/packaging/windows/compile-on-windows.sh
+++ b/packaging/windows/compile-on-windows.sh
@@ -6,7 +6,7 @@ CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-RelWithDebInfo}"
 # shellcheck source=./win-build-dir.sh
 . "${REPO_ROOT}/packaging/windows/win-build-dir.sh"
 
-set -exu -o pipefail
+set -eu -o pipefail
 
 if [ -d "${build}" ]; then
 	rm -rf "${build}"

--- a/packaging/windows/get-win-build-path.sh
+++ b/packaging/windows/get-win-build-path.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+REPO_ROOT="$(dirname "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd -P)")")"
+
+# shellcheck source=./win-build-dir.sh
+. "${REPO_ROOT}/packaging/windows/win-build-dir.sh"
+
+cygpath -wa "${build}"

--- a/packaging/windows/install-dependencies.ps1
+++ b/packaging/windows/install-dependencies.ps1
@@ -82,3 +82,24 @@ if ($LastExitcode -ne 0) {
         exit 1
     }
 }
+
+Write-Host "Installing WiX toolset"
+dotnet tool install wix
+
+if ($LastExitcode -ne 0) {
+    exit 1
+}
+
+Write-Host "Adding WiX extensions"
+
+wix extension -g add WixToolset.Util.wixext
+
+if ($LastExitcode -ne 0) {
+    exit 1
+}
+
+wix extension -g add WixToolset.UI.wixext
+
+if ($LastExitcode -ne 0) {
+    exit 1
+}

--- a/packaging/windows/install-dependencies.ps1
+++ b/packaging/windows/install-dependencies.ps1
@@ -84,7 +84,7 @@ if ($LastExitcode -ne 0) {
 }
 
 Write-Host "Installing WiX toolset"
-dotnet tool install wix
+dotnet tool install -g wix
 
 if ($LastExitcode -ne 0) {
     exit 1

--- a/packaging/windows/package-windows.sh
+++ b/packaging/windows/package-windows.sh
@@ -2,21 +2,10 @@
 
 repo_root="$(dirname "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd -P)")")"
 
-if [ -n "${BUILD_DIR}" ]; then
-    build="${BUILD_DIR}"
-elif [ -n "${OSTYPE}" ]; then
-    if [ -n "${MSYSTEM}" ]; then
-        build="${repo_root}/build-${OSTYPE}-${MSYSTEM}"
-    else
-        build="${repo_root}/build-${OSTYPE}"
-    fi
-elif [ "$USER" = "vk" ]; then
-    build="${repo_root}/build"
-else
-    build="${repo_root}/build"
-fi
+# shellcheck source=./win-build-dir.sh
+. "${repo_root}/packaging/windows/win-build-dir.sh"
 
-set -exu -o pipefail
+set -eu -o pipefail
 
 # Regenerate keys everytime there is an update
 if [ -d /opt/netdata/etc/pki/ ]; then
@@ -48,13 +37,8 @@ if [ ! -f "/cloud.txt" ]; then
 fi
 ${GITHUB_ACTIONS+echo "::endgroup::"}
 
-${GITHUB_ACTIONS+echo "::group::Packaging"}
+${GITHUB_ACTIONS+echo "::group::Copy Files"}
 tar -xf /msys2-latest.tar.zst -C /opt/netdata/ || exit 1
 cp -R /opt/netdata/msys64/* /opt/netdata/ || exit 1
 rm -rf /opt/netdata/msys64/
-NDVERSION=$"$(grep 'CMAKE_PROJECT_VERSION:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
-NDMAJORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MAJOR:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
-NDMINORVERSION=$"$(grep 'CMAKE_PROJECT_VERSION_MINOR:STATIC' "${build}/CMakeCache.txt"| cut -d= -f2)"
-
-/mingw64/bin/makensis.exe -DCURRVERSION="${NDVERSION}" -DMAJORVERSION="${NDMAJORVERSION}" -DMINORVERSION="${NDMINORVERSION}" "${repo_root}/packaging/windows/installer.nsi"
 ${GITHUB_ACTIONS+echo "::endgroup::"}

--- a/packaging/windows/package.ps1
+++ b/packaging/windows/package.ps1
@@ -14,3 +14,21 @@ $env:CHERE_INVOKING = 'yes'
 if ($LastExitcode -ne 0) {
     exit 1
 }
+
+if ($null -eq $env:BUILD_DIR) {
+    $builddir = & $msysbash -l "$PSScriptRoot\get-win-build-path.sh"
+
+    if ($LastExitcode -ne 0) {
+        exit 1
+    }
+} else {
+    $builddir = $env:BUILD_DIR
+}
+
+$wixarch = "x64"
+
+wix build -arch $wixarch -ext WixToolset.Util.wixext -ext WixToolset.UI.wixext -out "$PSScriptRoot\netdata-$wixarch.msi" "$builddir\netdata.wxs"
+
+if ($LastExitcode -ne 0) {
+    exit 1
+}

--- a/packaging/windows/package.ps1
+++ b/packaging/windows/package.ps1
@@ -25,10 +25,15 @@ if ($null -eq $env:BUILD_DIR) {
     $builddir = $env:BUILD_DIR
 }
 
+Push-Location "$builddir"
+
 $wixarch = "x64"
 
-wix build -arch $wixarch -ext WixToolset.Util.wixext -ext WixToolset.UI.wixext -out "$PSScriptRoot\netdata-$wixarch.msi" "$builddir\netdata.wxs"
+wix build -arch $wixarch -ext WixToolset.Util.wixext -ext WixToolset.UI.wixext -out "$PSScriptRoot\netdata-$wixarch.msi" netdata.wxs
 
 if ($LastExitcode -ne 0) {
+    Pop-Location
     exit 1
 }
+
+Pop-Location

--- a/packaging/windows/win-build-dir.sh
+++ b/packaging/windows/win-build-dir.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 
 if [ -n "${BUILD_DIR}" ]; then
-    if (echo "${BUILD_DIR}" | grep -q -E "^[A-Z]:\\\\"); then
-        build="$(echo "${BUILD_DIR}" | sed -e 's/\\/\//g' -e 's/^\([A-Z]\):\//\/\1\//' -)"
-    else
-        build="${BUILD_DIR}"
-    fi
+    build="$(cygpath -u "${BUILD_DIR}")"
 elif [ -n "${OSTYPE}" ]; then
     if [ -n "${MSYSTEM}" ]; then
         build="${REPO_ROOT}/build-${OSTYPE}-${MSYSTEM}"


### PR DESCRIPTION
##### Summary

We plan to switch to MSI packages long-term for installation on Windows.

In addition to the CI change, this PR also:

- Adds installation of WiX and the required WiX extensions to the dependency handling script. Note that this requires a working copy of the .NET SDK with NuGet set up correctly for it to work (having a working install of a recent version of Visual Studio will generally meet this requirement).
- Updates the Windows build/packaging scripts so that they use the same logic to determine build directories in all places.
- Updates the build directory handling code to use `cygpath` to convert paths between Windows/Unix style instead of a complicated `sed` expression.
- Updates the code that templates the WiX source file to put the generated file in the build directory instead of the source directory.
- Fixes the `.gitignore` file to exclude MSI files in the correct directory (and removes the exception for the old installer).
- Removes tracing from the Windows build/packaging shell scripts. It isn’t needed for regular runs and makes the output harder to read.

##### Test Plan

Windows CI passes on this PR and generates a usable MSI installer artifact.