### PR TITLE
Switch DEB/RPM repositories to new subdomain.

### DIFF
--- a/packaging/repoconfig/CMakeLists.txt
+++ b/packaging/repoconfig/CMakeLists.txt
@@ -9,8 +9,8 @@ list(APPEND DEB_DISTROS debian ubuntu)
 
 set(DEB_GPG_KEY_SOURCE "https://repo.netdata.cloud/netdatabot.gpg.key")
 
-set(PACKAGE_VERSION 3)
-set(PACKAGE_RELEASE 5)
+set(PACKAGE_VERSION 4)
+set(PACKAGE_RELEASE 1)
 
 set(CPACK_THREADS 0)
 set(CPACK_STRIP_FILES NO)

--- a/packaging/repoconfig/deb.changelog
+++ b/packaging/repoconfig/deb.changelog
@@ -1,6 +1,12 @@
+@PKG_NAME@ (4-1) unstable; urgency=medium
+
+  * Update repositories to new subdomain
+
+ -- Austin Hemmelgarn <austin@netdata.cloud>  Thu, 31 Oct 2024 11:00:00 -0400
+
 @PKG_NAME@ (3-5) unstable; urgency=medium
 
-  * Swithc DEB packages to fetch repo metadata by hash.
+  * Switch DEB packages to fetch repo metadata by hash.
 
  -- Austin Hemmelgarn <austin@netdata.cloud>  Thu, 12 Sep 2024 07:27:00 -0400
 

--- a/packaging/repoconfig/netdata.repo.dnf
+++ b/packaging/repoconfig/netdata.repo.dnf
@@ -1,19 +1,19 @@
 [netdata]
 name=Netdata
-baseurl=https://repo.netdata.cloud/repos/@VARIANT@/@DIST_NAME@/@DIST_VERSION@/$basearch
+baseurl=https://repository.netdata.cloud/repos/@VARIANT@/@DIST_NAME@/@DIST_VERSION@/$basearch
 repo_gpgcheck=1
 gpgcheck=1
-gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
+gpgkey=https://repository.netdata.cloud/netdatabot.gpg.key
 enabled=1
 sslverify=1
 priority=50
 
 [netdata-repoconfig]
 name=Netdata Repository Config
-baseurl=https://repo.netdata.cloud/repos/repoconfig/@DIST_NAME@/@DIST_VERSION@/$basearch
+baseurl=https://repository.netdata.cloud/repos/repoconfig/@DIST_NAME@/@DIST_VERSION@/$basearch
 repo_gpgcheck=1
 gpgcheck=1
-gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
+gpgkey=https://repository.netdata.cloud/netdatabot.gpg.key
 enabled=1
 sslverify=1
 priority=50

--- a/packaging/repoconfig/netdata.repo.zypp
+++ b/packaging/repoconfig/netdata.repo.zypp
@@ -1,19 +1,19 @@
 [netdata]
 name=Netdata
-baseurl=https://repo.netdata.cloud/repos/@VARIANT@/@DIST_NAME@/@DIST_VERSION@/$basearch
+baseurl=https://repository.netdata.cloud/repos/@VARIANT@/@DIST_NAME@/@DIST_VERSION@/$basearch
 repo_gpgcheck=1
 pkg_gpgcheck=1
-gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
+gpgkey=https://repository.netdata.cloud/netdatabot.gpg.key
 enabled=1
 type=rpm-md
 autorefresh=1
 
 [netdata-repoconfig]
 name=Netdata Repoconfig
-baseurl=https://repo.netdata.cloud/repos/repoconfig/@DIST_NAME@/@DIST_VERSION@/$basearch
+baseurl=https://repository.netdata.cloud/repos/repoconfig/@DIST_NAME@/@DIST_VERSION@/$basearch
 repo_gpgcheck=1
 pkg_gpgcheck=1
-gpgkey=https://repo.netdata.cloud/netdatabot.gpg.key
+gpgkey=https://repository.netdata.cloud/netdatabot.gpg.key
 enabled=1
 type=rpm-md
 autorefresh=1

--- a/packaging/repoconfig/netdata.sources.in
+++ b/packaging/repoconfig/netdata.sources.in
@@ -1,6 +1,6 @@
 X-Repolib-Name: Netdata @VARIANT@ repository
 Types: deb
-URIs: http://repo.netdata.cloud/repos/@VARIANT@/@DIST_NAME@/
+URIs: http://repository.netdata.cloud/repos/@VARIANT@/@DIST_NAME@/
 Suites: @SUITE@/
 Signed-By: /usr/share/keyrings/netdata-archive-keyring.gpg
 By-Hash: Yes
@@ -8,7 +8,7 @@ Enabled: Yes
 
 X-Repolib-Name: Netdata repository configuration repository
 Types: deb
-URIs: http://repo.netdata.cloud/repos/repoconfig/@DIST_NAME@/
+URIs: http://repository.netdata.cloud/repos/repoconfig/@DIST_NAME@/
 Suites: @SUITE@/
 Signed-By: /usr/share/keyrings/netdata-archive-keyring.gpg
 By-Hash: Yes

--- a/packaging/repoconfig/rpm.changelog
+++ b/packaging/repoconfig/rpm.changelog
@@ -1,3 +1,5 @@
+* Thu Oct 31 2024 Austin Hemmelgarn <austin@netdata.cloud> 4-1
+- Switch repos to new subdomain.
 * Thu Sep 17 2024 Austin Hemmelgarn <austin@netdata.cloud> 3-5
 - Fix changelog formatting.
 * Mon Aug 19 2024 Austin Hemmelgarn <austin@netdata.cloud> 3-4


### PR DESCRIPTION
##### Summary

This switches over to the new hosting for the repository data itself. Users should not see any difference other than the URLs and possibly the IP addresses being accessed.

##### Test Plan

n/a