### PR TITLE
add randomness per thread to heartbeat

### DIFF
--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -155,7 +155,6 @@ static void connect_cb(uv_connect_t* req, int status)
 
 int main(int argc, char **argv)
 {
-    clocks_init();
     nd_log_initialize_for_external_plugins("netdatacli");
 
     int ret, i;

--- a/src/collectors/apps.plugin/apps_plugin.c
+++ b/src/collectors/apps.plugin/apps_plugin.c
@@ -708,7 +708,6 @@ int main(int argc, char **argv) {
 #endif /* NETDATA_INTERNAL_CHECKS */
 
     procfile_set_adaptive_allocation(true, 0, 0, 0);
-    os_get_system_HZ();
     os_get_system_cpus_uncached();
     apps_managers_and_aggregators_init(); // before parsing args!
     parse_args(argc, argv);

--- a/src/collectors/apps.plugin/apps_plugin.c
+++ b/src/collectors/apps.plugin/apps_plugin.c
@@ -763,10 +763,9 @@ int main(int argc, char **argv) {
     netdata_mutex_lock(&apps_and_stdout_mutex);
     APPS_PLUGIN_GLOBAL_FUNCTIONS();
 
-    usec_t step = update_every * USEC_PER_SEC;
     global_iterations_counter = 1;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, update_every * USEC_PER_SEC);
     for(; !apps_plugin_exit ; global_iterations_counter++) {
         netdata_mutex_unlock(&apps_and_stdout_mutex);
 
@@ -778,7 +777,7 @@ int main(int argc, char **argv) {
             dt = update_every * USEC_PER_SEC;
         }
         else
-            dt = heartbeat_next(&hb, step);
+            dt = heartbeat_next(&hb);
 
         netdata_mutex_lock(&apps_and_stdout_mutex);
 

--- a/src/collectors/apps.plugin/apps_plugin.c
+++ b/src/collectors/apps.plugin/apps_plugin.c
@@ -665,7 +665,6 @@ netdata_mutex_t apps_and_stdout_mutex = NETDATA_MUTEX_INITIALIZER;
 static bool apps_plugin_exit = false;
 
 int main(int argc, char **argv) {
-    clocks_init();
     nd_log_initialize_for_external_plugins("apps.plugin");
 
     pagesize = (size_t)sysconf(_SC_PAGESIZE);

--- a/src/collectors/cgroups.plugin/cgroup-network.c
+++ b/src/collectors/cgroups.plugin/cgroup-network.c
@@ -717,8 +717,6 @@ void usage(void) {
 int main(int argc, const char **argv) {
     pid_t pid = 0;
 
-    clocks_init();
-
     if (setresuid(0, 0, 0) == -1)
         collector_error("setresuid(0, 0, 0) failed.");
 

--- a/src/collectors/cgroups.plugin/sys_fs_cgroup.c
+++ b/src/collectors/cgroups.plugin/sys_fs_cgroup.c
@@ -1417,14 +1417,13 @@ void *cgroups_main(void *ptr) {
                             cgroup_function_systemd_top);
 
     heartbeat_t hb;
-    heartbeat_init(&hb);
-    usec_t step = cgroup_update_every * USEC_PER_SEC;
+    heartbeat_init(&hb, cgroup_update_every * USEC_PER_SEC);
     usec_t find_every = cgroup_check_for_new_every * USEC_PER_SEC, find_dt = 0;
 
     while(service_running(SERVICE_COLLECTORS)) {
         worker_is_idle();
 
-        usec_t hb_dt = heartbeat_next(&hb, step);
+        usec_t hb_dt = heartbeat_next(&hb);
 
         if (unlikely(!service_running(SERVICE_COLLECTORS)))
             break;

--- a/src/collectors/cups.plugin/cups_plugin.c
+++ b/src/collectors/cups.plugin/cups_plugin.c
@@ -226,7 +226,6 @@ void reset_metrics() {
 }
 
 int main(int argc, char **argv) {
-    clocks_init();
     nd_log_initialize_for_external_plugins("cups.plugin");
 
     parse_command_line(argc, argv);

--- a/src/collectors/cups.plugin/cups_plugin.c
+++ b/src/collectors/cups.plugin/cups_plugin.c
@@ -243,12 +243,11 @@ int main(int argc, char **argv) {
 
     time_t started_t = now_monotonic_sec();
     size_t iteration = 0;
-    usec_t step = netdata_update_every * USEC_PER_SEC;
 
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, netdata_update_every * USEC_PER_SEC);
     for (iteration = 0; 1; iteration++) {
-        heartbeat_next(&hb, step);
+        heartbeat_next(&hb);
 
         if (unlikely(netdata_exit))
             break;

--- a/src/collectors/debugfs.plugin/debugfs_plugin.c
+++ b/src/collectors/debugfs.plugin/debugfs_plugin.c
@@ -159,7 +159,6 @@ static void debugfs_parse_args(int argc, char **argv)
 
 int main(int argc, char **argv)
 {
-    clocks_init();
     nd_log_initialize_for_external_plugins("debugfs.plugin");
 
     netdata_configured_host_prefix = getenv("NETDATA_HOST_PREFIX");

--- a/src/collectors/debugfs.plugin/debugfs_plugin.c
+++ b/src/collectors/debugfs.plugin/debugfs_plugin.c
@@ -214,12 +214,11 @@ int main(int argc, char **argv)
     debugfs_parse_args(argc, argv);
 
     size_t iteration;
-    usec_t step = update_every * USEC_PER_SEC;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, update_every * USEC_PER_SEC);
 
     for (iteration = 0; iteration < 86400; iteration++) {
-        heartbeat_next(&hb, step);
+        heartbeat_next(&hb);
         int enabled = 0;
 
         for (int i = 0; debugfs_modules[i].name; i++) {

--- a/src/collectors/diskspace.plugin/plugin_diskspace.c
+++ b/src/collectors/diskspace.plugin/plugin_diskspace.c
@@ -544,11 +544,11 @@ void *diskspace_slow_worker(void *ptr)
     usec_t step = slow_update_every * USEC_PER_SEC;
     usec_t real_step = USEC_PER_SEC;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, USEC_PER_SEC);
 
     while(service_running(SERVICE_COLLECTORS)) {
         worker_is_idle();
-        heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
 
         if (real_step < step) {
             real_step += USEC_PER_SEC;
@@ -876,12 +876,11 @@ void *diskspace_main(void *ptr) {
         diskspace_slow_worker,
         &slow_worker_data);
 
-    usec_t step = update_every * USEC_PER_SEC;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, update_every * USEC_PER_SEC);
     while(service_running(SERVICE_COLLECTORS)) {
         worker_is_idle();
-        /* usec_t hb_dt = */ heartbeat_next(&hb, step);
+        /* usec_t hb_dt = */ heartbeat_next(&hb);
 
         if(unlikely(!service_running(SERVICE_COLLECTORS))) break;
 

--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -4076,15 +4076,14 @@ int main(int argc, char **argv)
         }
     }
 
-    usec_t step = USEC_PER_SEC;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, USEC_PER_SEC);
     int update_apps_every = (int) EBPF_CFG_UPDATE_APPS_EVERY_DEFAULT;
     int update_apps_list = update_apps_every - 1;
     int process_maps_per_core = ebpf_modules[EBPF_MODULE_PROCESS_IDX].maps_per_core;
     //Plugin will be killed when it receives a signal
     for ( ; !ebpf_plugin_stop(); global_iterations_counter++) {
-        (void)heartbeat_next(&hb, step);
+        (void)heartbeat_next(&hb);
 
         if (global_iterations_counter % EBPF_DEFAULT_UPDATE_EVERY == 0) {
             pthread_mutex_lock(&lock);

--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -4005,7 +4005,6 @@ static void ebpf_manage_pid(pid_t pid)
  */
 int main(int argc, char **argv)
 {
-    clocks_init();
     nd_log_initialize_for_external_plugins(NETDATA_EBPF_PLUGIN_NAME);
 
     ebpf_set_global_variables();

--- a/src/collectors/ebpf.plugin/ebpf_cachestat.c
+++ b/src/collectors/ebpf.plugin/ebpf_cachestat.c
@@ -837,9 +837,6 @@ void ebpf_resume_apps_data()
  */
 void *ebpf_read_cachestat_thread(void *ptr)
 {
-    heartbeat_t hb;
-    heartbeat_init(&hb);
-
     ebpf_module_t *em = (ebpf_module_t *)ptr;
 
     int maps_per_core = em->maps_per_core;
@@ -849,10 +846,11 @@ void *ebpf_read_cachestat_thread(void *ptr)
 
     uint32_t lifetime = em->lifetime;
     uint32_t running_time = 0;
-    usec_t period = update_every * USEC_PER_SEC;
     pids_fd[EBPF_PIDS_CACHESTAT_IDX] = cachestat_maps[NETDATA_CACHESTAT_PID_STATS].map_fd;
+    heartbeat_t hb;
+    heartbeat_init(&hb, update_every * USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, period);
+        (void)heartbeat_next(&hb);
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;
 
@@ -1401,7 +1399,7 @@ static void cachestat_collector(ebpf_module_t *em)
     int update_every = em->update_every;
     int maps_per_core = em->maps_per_core;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, USEC_PER_SEC);
     int counter = update_every - 1;
     //This will be cancelled by its parent
     uint32_t running_time = 0;
@@ -1409,7 +1407,7 @@ static void cachestat_collector(ebpf_module_t *em)
     netdata_idx_t *stats = em->hash_table_stats;
     memset(stats, 0, sizeof(em->hash_table_stats));
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        (void)heartbeat_next(&hb);
 
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;

--- a/src/collectors/ebpf.plugin/ebpf_cgroup.c
+++ b/src/collectors/ebpf.plugin/ebpf_cgroup.c
@@ -373,13 +373,12 @@ void ebpf_create_charts_on_systemd(ebpf_systemd_args_t *chart)
  */
 void *ebpf_cgroup_integration(void *ptr __maybe_unused)
 {
-    usec_t step = USEC_PER_SEC;
     int counter = NETDATA_EBPF_CGROUP_UPDATE - 1;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, USEC_PER_SEC);
     //Plugin will be killed when it receives a signal
     while (!ebpf_plugin_stop()) {
-        (void)heartbeat_next(&hb, step);
+        heartbeat_next(&hb);
 
         // We are using a small heartbeat time to wake up thread,
         // but we should not update so frequently the shared memory data

--- a/src/collectors/ebpf.plugin/ebpf_dcstat.c
+++ b/src/collectors/ebpf.plugin/ebpf_dcstat.c
@@ -639,9 +639,6 @@ void ebpf_dc_resume_apps_data()
  */
 void *ebpf_read_dcstat_thread(void *ptr)
 {
-    heartbeat_t hb;
-    heartbeat_init(&hb);
-
     ebpf_module_t *em = (ebpf_module_t *)ptr;
 
     int maps_per_core = em->maps_per_core;
@@ -654,10 +651,11 @@ void *ebpf_read_dcstat_thread(void *ptr)
 
     uint32_t lifetime = em->lifetime;
     uint32_t running_time = 0;
-    usec_t period = update_every * USEC_PER_SEC;
     pids_fd[EBPF_PIDS_DCSTAT_IDX] = dcstat_maps[NETDATA_DCSTAT_PID_STATS].map_fd;
+    heartbeat_t hb;
+    heartbeat_init(&hb, update_every * USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, period);
+        (void)heartbeat_next(&hb);
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;
 
@@ -1265,7 +1263,7 @@ static void dcstat_collector(ebpf_module_t *em)
     int cgroups = em->cgroup_charts;
     int update_every = em->update_every;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, USEC_PER_SEC);
     int counter = update_every - 1;
     int maps_per_core = em->maps_per_core;
     uint32_t running_time = 0;
@@ -1273,7 +1271,7 @@ static void dcstat_collector(ebpf_module_t *em)
     netdata_idx_t *stats = em->hash_table_stats;
     memset(stats, 0, sizeof(em->hash_table_stats));
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
 
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;

--- a/src/collectors/ebpf.plugin/ebpf_disk.c
+++ b/src/collectors/ebpf.plugin/ebpf_disk.c
@@ -771,13 +771,13 @@ static void disk_collector(ebpf_module_t *em)
 
     int update_every = em->update_every;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, USEC_PER_SEC);
     int counter = update_every - 1;
     int maps_per_core = em->maps_per_core;
     uint32_t running_time = 0;
     uint32_t lifetime = em->lifetime;
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
 
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;

--- a/src/collectors/ebpf.plugin/ebpf_fd.c
+++ b/src/collectors/ebpf.plugin/ebpf_fd.c
@@ -780,9 +780,6 @@ void ebpf_fd_resume_apps_data()
  */
 void *ebpf_read_fd_thread(void *ptr)
 {
-    heartbeat_t hb;
-    heartbeat_init(&hb);
-
     ebpf_module_t *em = (ebpf_module_t *)ptr;
 
     int maps_per_core = em->maps_per_core;
@@ -795,10 +792,12 @@ void *ebpf_read_fd_thread(void *ptr)
 
     uint32_t lifetime = em->lifetime;
     uint32_t running_time = 0;
-    int period = USEC_PER_SEC;
     pids_fd[EBPF_PIDS_FD_IDX] = fd_maps[NETDATA_FD_PID_STATS].map_fd;
+
+    heartbeat_t hb;
+    heartbeat_init(&hb, USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, period);
+        heartbeat_next(&hb);
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;
 
@@ -1213,8 +1212,6 @@ static void ebpf_fd_send_cgroup_data(ebpf_module_t *em)
 static void fd_collector(ebpf_module_t *em)
 {
     int cgroups = em->cgroup_charts;
-    heartbeat_t hb;
-    heartbeat_init(&hb);
     int update_every = em->update_every;
     int counter = update_every - 1;
     int maps_per_core = em->maps_per_core;
@@ -1222,8 +1219,10 @@ static void fd_collector(ebpf_module_t *em)
     uint32_t lifetime = em->lifetime;
     netdata_idx_t *stats = em->hash_table_stats;
     memset(stats, 0, sizeof(em->hash_table_stats));
+    heartbeat_t hb;
+    heartbeat_init(&hb, USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
 
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;

--- a/src/collectors/ebpf.plugin/ebpf_filesystem.c
+++ b/src/collectors/ebpf.plugin/ebpf_filesystem.c
@@ -980,13 +980,13 @@ static void ebpf_histogram_send_data()
 static void filesystem_collector(ebpf_module_t *em)
 {
     int update_every = em->update_every;
-    heartbeat_t hb;
-    heartbeat_init(&hb);
     int counter = update_every - 1;
     uint32_t running_time = 0;
     uint32_t lifetime = em->lifetime;
+    heartbeat_t hb;
+    heartbeat_init(&hb, USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
 
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;

--- a/src/collectors/ebpf.plugin/ebpf_functions.c
+++ b/src/collectors/ebpf.plugin/ebpf_functions.c
@@ -712,9 +712,9 @@ void *ebpf_function_thread(void *ptr)
     pthread_mutex_unlock(&lock);
 
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, USEC_PER_SEC);
     while(!ebpf_plugin_stop()) {
-        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
 
         if (ebpf_plugin_stop()) {
             break;

--- a/src/collectors/ebpf.plugin/ebpf_hardirq.c
+++ b/src/collectors/ebpf.plugin/ebpf_hardirq.c
@@ -571,15 +571,15 @@ static void hardirq_collector(ebpf_module_t *em)
     pthread_mutex_unlock(&lock);
 
     // loop and read from published data until ebpf plugin is closed.
-    heartbeat_t hb;
-    heartbeat_init(&hb);
     int update_every = em->update_every;
     int counter = update_every - 1;
     //This will be cancelled by its parent
     uint32_t running_time = 0;
     uint32_t lifetime = em->lifetime;
+    heartbeat_t hb;
+    heartbeat_init(&hb, USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
 
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;

--- a/src/collectors/ebpf.plugin/ebpf_mdflush.c
+++ b/src/collectors/ebpf.plugin/ebpf_mdflush.c
@@ -337,14 +337,14 @@ static void mdflush_collector(ebpf_module_t *em)
     pthread_mutex_unlock(&lock);
 
     // loop and read from published data until ebpf plugin is closed.
-    heartbeat_t hb;
-    heartbeat_init(&hb);
     int counter = update_every - 1;
     int maps_per_core = em->maps_per_core;
     uint32_t running_time = 0;
     uint32_t lifetime = em->lifetime;
+    heartbeat_t hb;
+    heartbeat_init(&hb, USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
 
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;

--- a/src/collectors/ebpf.plugin/ebpf_mount.c
+++ b/src/collectors/ebpf.plugin/ebpf_mount.c
@@ -361,15 +361,15 @@ static void mount_collector(ebpf_module_t *em)
 {
     memset(mount_hash_values, 0, sizeof(mount_hash_values));
 
-    heartbeat_t hb;
-    heartbeat_init(&hb);
     int update_every = em->update_every;
     int counter = update_every - 1;
     int maps_per_core = em->maps_per_core;
     uint32_t running_time = 0;
     uint32_t lifetime = em->lifetime;
+    heartbeat_t hb;
+    heartbeat_init(&hb, USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;
 

--- a/src/collectors/ebpf.plugin/ebpf_oomkill.c
+++ b/src/collectors/ebpf.plugin/ebpf_oomkill.c
@@ -459,14 +459,14 @@ static void oomkill_collector(ebpf_module_t *em)
     memset(keys, 0, sizeof(keys));
 
     // loop and read until ebpf plugin is closed.
-    heartbeat_t hb;
-    heartbeat_init(&hb);
     int counter = update_every - 1;
     uint32_t running_time = 0;
     uint32_t lifetime = em->lifetime;
     netdata_idx_t *stats = em->hash_table_stats;
+    heartbeat_t hb;
+    heartbeat_init(&hb, USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        (void)heartbeat_next(&hb);
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;
 

--- a/src/collectors/ebpf.plugin/ebpf_process.c
+++ b/src/collectors/ebpf.plugin/ebpf_process.c
@@ -1120,8 +1120,6 @@ void ebpf_process_update_cgroup_algorithm()
  */
 static void process_collector(ebpf_module_t *em)
 {
-    heartbeat_t hb;
-    heartbeat_init(&hb);
     int publish_global = em->global_charts;
     int cgroups = em->cgroup_charts;
     pthread_mutex_lock(&ebpf_exit_cleanup);
@@ -1137,9 +1135,11 @@ static void process_collector(ebpf_module_t *em)
     uint32_t lifetime = em->lifetime;
     netdata_idx_t *stats = em->hash_table_stats;
     memset(stats, 0, sizeof(em->hash_table_stats));
+    heartbeat_t hb;
+    heartbeat_init(&hb, USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        usec_t dt = heartbeat_next(&hb, USEC_PER_SEC);
-        (void)dt;
+        heartbeat_next(&hb);
+
         if (ebpf_plugin_stop())
             break;
 

--- a/src/collectors/ebpf.plugin/ebpf_shm.c
+++ b/src/collectors/ebpf.plugin/ebpf_shm.c
@@ -1058,9 +1058,6 @@ void ebpf_shm_resume_apps_data() {
  */
 void *ebpf_read_shm_thread(void *ptr)
 {
-    heartbeat_t hb;
-    heartbeat_init(&hb);
-
     ebpf_module_t *em = (ebpf_module_t *)ptr;
 
     int maps_per_core = em->maps_per_core;
@@ -1073,10 +1070,11 @@ void *ebpf_read_shm_thread(void *ptr)
 
     uint32_t lifetime = em->lifetime;
     uint32_t running_time = 0;
-    usec_t period = update_every * USEC_PER_SEC;
     pids_fd[EBPF_PIDS_SHM_IDX] = shm_maps[NETDATA_PID_SHM_TABLE].map_fd;
+    heartbeat_t hb;
+    heartbeat_init(&hb, update_every * USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, period);
+        (void)heartbeat_next(&hb);
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;
 
@@ -1107,16 +1105,17 @@ static void shm_collector(ebpf_module_t *em)
 {
     int cgroups = em->cgroup_charts;
     int update_every = em->update_every;
-    heartbeat_t hb;
-    heartbeat_init(&hb);
     int counter = update_every - 1;
     int maps_per_core = em->maps_per_core;
     uint32_t running_time = 0;
     uint32_t lifetime = em->lifetime;
     netdata_idx_t *stats = em->hash_table_stats;
     memset(stats, 0, sizeof(em->hash_table_stats));
+    heartbeat_t hb;
+    heartbeat_init(&hb, USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
+
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;
 

--- a/src/collectors/ebpf.plugin/ebpf_socket.c
+++ b/src/collectors/ebpf.plugin/ebpf_socket.c
@@ -1811,9 +1811,6 @@ void ebpf_socket_resume_apps_data()
  */
 void *ebpf_read_socket_thread(void *ptr)
 {
-    heartbeat_t hb;
-    heartbeat_init(&hb);
-
     ebpf_module_t *em = (ebpf_module_t *)ptr;
 
     ebpf_update_array_vectors(em);
@@ -1826,9 +1823,10 @@ void *ebpf_read_socket_thread(void *ptr)
 
     uint32_t running_time = 0;
     uint32_t lifetime = em->lifetime;
-    usec_t period = update_every * USEC_PER_SEC;
+    heartbeat_t hb;
+    heartbeat_init(&hb, update_every * USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, period);
+        heartbeat_next(&hb);
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;
 
@@ -2608,9 +2606,6 @@ static void ebpf_socket_send_cgroup_data(int update_every)
  */
 static void socket_collector(ebpf_module_t *em)
 {
-    heartbeat_t hb;
-    heartbeat_init(&hb);
-
     int cgroups = em->cgroup_charts;
     if (cgroups)
         ebpf_socket_update_cgroup_algorithm();
@@ -2623,8 +2618,10 @@ static void socket_collector(ebpf_module_t *em)
     uint32_t lifetime = em->lifetime;
     netdata_idx_t *stats = em->hash_table_stats;
     memset(stats, 0, sizeof(em->hash_table_stats));
+    heartbeat_t hb;
+    heartbeat_init(&hb, USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;
 

--- a/src/collectors/ebpf.plugin/ebpf_softirq.c
+++ b/src/collectors/ebpf.plugin/ebpf_softirq.c
@@ -209,7 +209,7 @@ static void softirq_collector(ebpf_module_t *em)
 
     // loop and read from published data until ebpf plugin is closed.
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, USEC_PER_SEC);
     int update_every = em->update_every;
     int counter = update_every - 1;
     int maps_per_core = em->maps_per_core;
@@ -217,7 +217,7 @@ static void softirq_collector(ebpf_module_t *em)
     uint32_t running_time = 0;
     uint32_t lifetime = em->lifetime;
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;
 

--- a/src/collectors/ebpf.plugin/ebpf_swap.c
+++ b/src/collectors/ebpf.plugin/ebpf_swap.c
@@ -592,9 +592,6 @@ end_swap_loop:
  */
 void *ebpf_read_swap_thread(void *ptr)
 {
-    heartbeat_t hb;
-    heartbeat_init(&hb);
-
     ebpf_module_t *em = (ebpf_module_t *)ptr;
 
     int maps_per_core = em->maps_per_core;
@@ -607,11 +604,12 @@ void *ebpf_read_swap_thread(void *ptr)
 
     uint32_t lifetime = em->lifetime;
     uint32_t running_time = 0;
-    usec_t period = update_every * USEC_PER_SEC;
     pids_fd[EBPF_PIDS_SWAP_IDX] = swap_maps[NETDATA_PID_SWAP_TABLE].map_fd;
 
+    heartbeat_t hb;
+    heartbeat_init(&hb, update_every * USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, period);
+        heartbeat_next(&hb);
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;
 
@@ -924,16 +922,17 @@ static void swap_collector(ebpf_module_t *em)
 {
     int cgroup = em->cgroup_charts;
     int update_every = em->update_every;
-    heartbeat_t hb;
-    heartbeat_init(&hb);
     int counter = update_every - 1;
     int maps_per_core = em->maps_per_core;
     uint32_t running_time = 0;
     uint32_t lifetime = em->lifetime;
     netdata_idx_t *stats = em->hash_table_stats;
     memset(stats, 0, sizeof(em->hash_table_stats));
+
+    heartbeat_t hb;
+    heartbeat_init(&hb, USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        (void)heartbeat_next(&hb);
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;
 

--- a/src/collectors/ebpf.plugin/ebpf_sync.c
+++ b/src/collectors/ebpf.plugin/ebpf_sync.c
@@ -554,15 +554,15 @@ static void sync_send_data()
 */
 static void sync_collector(ebpf_module_t *em)
 {
-    heartbeat_t hb;
-    heartbeat_init(&hb);
     int update_every = em->update_every;
     int counter = update_every - 1;
     int maps_per_core = em->maps_per_core;
     uint32_t running_time = 0;
     uint32_t lifetime = em->lifetime;
+    heartbeat_t hb;
+    heartbeat_init(&hb, USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;
 

--- a/src/collectors/ebpf.plugin/ebpf_vfs.c
+++ b/src/collectors/ebpf.plugin/ebpf_vfs.c
@@ -2060,9 +2060,6 @@ void ebpf_vfs_resume_apps_data() {
  */
 void *ebpf_read_vfs_thread(void *ptr)
 {
-    heartbeat_t hb;
-    heartbeat_init(&hb);
-
     ebpf_module_t *em = (ebpf_module_t *)ptr;
 
     int maps_per_core = em->maps_per_core;
@@ -2075,11 +2072,12 @@ void *ebpf_read_vfs_thread(void *ptr)
 
     uint32_t lifetime = em->lifetime;
     uint32_t running_time = 0;
-    usec_t period = update_every * USEC_PER_SEC;
     uint32_t max_period = EBPF_CLEANUP_FACTOR;
     pids_fd[EBPF_PIDS_VFS_IDX] = vfs_maps[NETDATA_VFS_PID].map_fd;
+    heartbeat_t hb;
+    heartbeat_init(&hb, update_every * USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, period);
+        heartbeat_next(&hb);
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;
 
@@ -2112,8 +2110,6 @@ void *ebpf_read_vfs_thread(void *ptr)
 static void vfs_collector(ebpf_module_t *em)
 {
     int cgroups = em->cgroup_charts;
-    heartbeat_t hb;
-    heartbeat_init(&hb);
     int update_every = em->update_every;
     int counter = update_every - 1;
     int maps_per_core = em->maps_per_core;
@@ -2121,8 +2117,10 @@ static void vfs_collector(ebpf_module_t *em)
     uint32_t lifetime = em->lifetime;
     netdata_idx_t *stats = em->hash_table_stats;
     memset(stats, 0, sizeof(em->hash_table_stats));
+    heartbeat_t hb;
+    heartbeat_init(&hb, USEC_PER_SEC);
     while (!ebpf_plugin_stop() && running_time < lifetime) {
-        (void)heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
         if (ebpf_plugin_stop() || ++counter != update_every)
             continue;
 

--- a/src/collectors/freebsd.plugin/plugin_freebsd.c
+++ b/src/collectors/freebsd.plugin/plugin_freebsd.c
@@ -105,14 +105,13 @@ void *freebsd_main(void *ptr)
         worker_register_job_name(i, freebsd_modules[i].dim);
     }
 
-    usec_t step = localhost->rrd_update_every * USEC_PER_SEC;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, localhost->rrd_update_every * USEC_PER_SEC);
 
     while(service_running(SERVICE_COLLECTORS))  {
         worker_is_idle();
 
-        usec_t hb_dt = heartbeat_next(&hb, step);
+        usec_t hb_dt = heartbeat_next(&hb);
 
        if (!service_running(SERVICE_COLLECTORS))
             break;

--- a/src/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/src/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -1647,7 +1647,6 @@ static void plugin_exit(int code) {
 }
 
 int main (int argc, char **argv) {
-    clocks_init();
     nd_log_initialize_for_external_plugins("freeipmi.plugin");
     netdata_threads_init_for_external_plugins(0); // set the default threads stack size here
 

--- a/src/collectors/freeipmi.plugin/freeipmi_plugin.c
+++ b/src/collectors/freeipmi.plugin/freeipmi_plugin.c
@@ -1240,9 +1240,9 @@ void *netdata_ipmi_collection_thread(void *ptr) {
     usec_t step = t->freq_s * USEC_PER_SEC;
 
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, step);
     while(++iteration) {
-        heartbeat_next(&hb, step);
+        heartbeat_next(&hb);
 
         if(t->debug)
             fprintf(stderr, "%s: calling netdata_ipmi_collect_data() for %s\n",
@@ -2000,15 +2000,13 @@ int main (int argc, char **argv) {
     time_t started_t = now_monotonic_sec();
 
     size_t iteration = 0;
-    usec_t step = 100 * USEC_PER_MS;
     bool global_chart_created = false;
     bool tty = isatty(fileno(stdout)) == 1;
 
     heartbeat_t hb;
-    heartbeat_init(&hb);
-
+    heartbeat_init(&hb, update_every * USEC_PER_SEC);
     for(iteration = 0; 1 ; iteration++) {
-        usec_t dt = heartbeat_next(&hb, step);
+        usec_t dt = heartbeat_next(&hb);
 
         if (!tty) {
             netdata_mutex_lock(&stdout_mutex);
@@ -2027,7 +2025,6 @@ int main (int argc, char **argv) {
 
         switch(state.sensors.status) {
             case ICS_RUNNING:
-                step = update_every * USEC_PER_SEC;
                 if(state.sensors.last_iteration_ut < now_monotonic_usec() - IPMI_RESTART_IF_SENSORS_DONT_ITERATE_EVERY_SECONDS * USEC_PER_SEC) {
                     collector_error("%s(): sensors have not be collected for %zu seconds. Exiting to restart.",
                                     __FUNCTION__, (size_t)((now_monotonic_usec() - state.sensors.last_iteration_ut) / USEC_PER_SEC));

--- a/src/collectors/macos.plugin/plugin_macos.c
+++ b/src/collectors/macos.plugin/plugin_macos.c
@@ -54,13 +54,12 @@ void *macos_main(void *ptr)
         worker_register_job_name(i, macos_modules[i].dim);
     }
 
-    usec_t step = localhost->rrd_update_every * USEC_PER_SEC;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, localhost->rrd_update_every * USEC_PER_SEC);
 
     while(service_running(SERVICE_COLLECTORS)) {
         worker_is_idle();
-        usec_t hb_dt = heartbeat_next(&hb, step);
+        usec_t hb_dt = heartbeat_next(&hb);
 
         if (!service_running(SERVICE_COLLECTORS))
             break;

--- a/src/collectors/network-viewer.plugin/network-viewer.c
+++ b/src/collectors/network-viewer.plugin/network-viewer.c
@@ -958,7 +958,6 @@ close_and_send:
 // main
 
 int main(int argc __maybe_unused, char **argv __maybe_unused) {
-    clocks_init();
     nd_thread_tag_set("NETWORK-VIEWER");
     nd_log_initialize_for_external_plugins("network-viewer.plugin");
 

--- a/src/collectors/network-viewer.plugin/network-viewer.c
+++ b/src/collectors/network-viewer.plugin/network-viewer.c
@@ -1020,7 +1020,7 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
     bool tty = isatty(fileno(stdout)) == 1;
 
     heartbeat_t hb;
-    heartbeat_init(&hb, USEC_PER_MS);
+    heartbeat_init(&hb, USEC_PER_SEC);
     while(!plugin_should_exit) {
 
         usec_t dt_ut = heartbeat_next(&hb);

--- a/src/collectors/network-viewer.plugin/network-viewer.c
+++ b/src/collectors/network-viewer.plugin/network-viewer.c
@@ -1016,15 +1016,14 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
 
     // ----------------------------------------------------------------------------------------------------------------
 
-    usec_t step_ut = 100 * USEC_PER_MS;
     usec_t send_newline_ut = 0;
     bool tty = isatty(fileno(stdout)) == 1;
 
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, USEC_PER_MS);
     while(!plugin_should_exit) {
 
-        usec_t dt_ut = heartbeat_next(&hb, step_ut);
+        usec_t dt_ut = heartbeat_next(&hb);
         send_newline_ut += dt_ut;
 
         if(!tty && send_newline_ut > USEC_PER_SEC) {

--- a/src/collectors/nfacct.plugin/plugin_nfacct.c
+++ b/src/collectors/nfacct.plugin/plugin_nfacct.c
@@ -832,12 +832,11 @@ int main(int argc, char **argv) {
     time_t started_t = now_monotonic_sec();
 
     size_t iteration;
-    usec_t step = netdata_update_every * USEC_PER_SEC;
 
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, netdata_update_every * USEC_PER_SEC);
     for(iteration = 0; 1; iteration++) {
-        usec_t dt = heartbeat_next(&hb, step);
+        usec_t dt = heartbeat_next(&hb);
 
         if(unlikely(netdata_exit)) break;
 

--- a/src/collectors/nfacct.plugin/plugin_nfacct.c
+++ b/src/collectors/nfacct.plugin/plugin_nfacct.c
@@ -747,7 +747,6 @@ void nfacct_signals()
 }
 
 int main(int argc, char **argv) {
-    clocks_init();
     nd_log_initialize_for_external_plugins("nfacct.plugin");
 
     // ------------------------------------------------------------------------

--- a/src/collectors/perf.plugin/perf_plugin.c
+++ b/src/collectors/perf.plugin/perf_plugin.c
@@ -1318,14 +1318,13 @@ int main(int argc, char **argv) {
     time_t started_t = now_monotonic_sec();
 
     size_t iteration;
-    usec_t step = update_every * USEC_PER_SEC;
 
     int perf = 1;
 
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, update_every * USEC_PER_SEC);
     for(iteration = 0; 1; iteration++) {
-        usec_t dt = heartbeat_next(&hb, step);
+        usec_t dt = heartbeat_next(&hb);
 
         if (unlikely(netdata_exit))
             break;

--- a/src/collectors/perf.plugin/perf_plugin.c
+++ b/src/collectors/perf.plugin/perf_plugin.c
@@ -1287,7 +1287,6 @@ void parse_command_line(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
-    clocks_init();
     nd_log_initialize_for_external_plugins("perf.plugin");
 
     parse_command_line(argc, argv);

--- a/src/collectors/proc.plugin/plugin_proc.c
+++ b/src/collectors/proc.plugin/plugin_proc.c
@@ -226,9 +226,8 @@ void *proc_main(void *ptr)
         worker_register_job_name(i, proc_modules[i].dim);
     }
 
-    usec_t step = localhost->rrd_update_every * USEC_PER_SEC;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, localhost->rrd_update_every * USEC_PER_SEC);
 
     inside_lxc_container = is_lxcfs_proc_mounted();
     is_mem_swap_enabled = is_swap_enabled();
@@ -245,7 +244,7 @@ void *proc_main(void *ptr)
 
     while(service_running(SERVICE_COLLECTORS)) {
         worker_is_idle();
-        usec_t hb_dt = heartbeat_next(&hb, step);
+        usec_t hb_dt = heartbeat_next(&hb);
 
         if(unlikely(!service_running(SERVICE_COLLECTORS)))
             break;

--- a/src/collectors/proc.plugin/proc_net_dev.c
+++ b/src/collectors/proc.plugin/proc_net_dev.c
@@ -1706,13 +1706,12 @@ void *netdev_main(void *ptr_is_null __maybe_unused)
                             "top", HTTP_ACCESS_ANONYMOUS_DATA,
                             netdev_function_net_interfaces);
 
-    usec_t step = localhost->rrd_update_every * USEC_PER_SEC;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, localhost->rrd_update_every * USEC_PER_SEC);
 
     while (service_running(SERVICE_COLLECTORS)) {
         worker_is_idle();
-        usec_t hb_dt = heartbeat_next(&hb, step);
+        usec_t hb_dt = heartbeat_next(&hb);
 
         if (unlikely(!service_running(SERVICE_COLLECTORS)))
             break;

--- a/src/collectors/profile.plugin/plugin_profile.cc
+++ b/src/collectors/profile.plugin/plugin_profile.cc
@@ -117,7 +117,7 @@ public:
         worker_register_job_custom_metric(WORKER_JOB_METRIC_POINTS_BACKFILLED, "points backfilled", "points", WORKER_METRIC_ABSOLUTE);
 
         heartbeat_t HB;
-        heartbeat_init(&HB);
+        heartbeat_init(&HB, UpdateEvery * USEC_PER_SEC);
 
         worker_is_busy(WORKER_JOB_CREATE_CHARTS);
         create();
@@ -157,7 +157,7 @@ public:
 
             if (CollectionTV.tv_sec >= NowTV.tv_sec) {
                 worker_is_idle();
-                heartbeat_next(&HB, UpdateEvery * USEC_PER_SEC);
+                heartbeat_next(&HB);
             }
         }
     }

--- a/src/collectors/slabinfo.plugin/slabinfo.c
+++ b/src/collectors/slabinfo.plugin/slabinfo.c
@@ -345,7 +345,6 @@ void usage(void) {
 }
 
 int main(int argc, char **argv) {
-    clocks_init();
     nd_log_initialize_for_external_plugins("slabinfo.plugin");
 
     program_name = argv[0];

--- a/src/collectors/statsd.plugin/statsd.c
+++ b/src/collectors/statsd.plugin/statsd.c
@@ -2818,12 +2818,11 @@ void *statsd_main(void *ptr) {
     // ----------------------------------------------------------------------------------------------------------------
     // statsd thread to turn metrics into charts
 
-    usec_t step = statsd.update_every * USEC_PER_SEC;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, statsd.update_every * USEC_PER_SEC);
     while(service_running(SERVICE_COLLECTORS)) {
         worker_is_idle();
-        heartbeat_next(&hb, step);
+        heartbeat_next(&hb);
 
         worker_is_busy(WORKER_STATSD_FLUSH_GAUGES);
         statsd_flush_index_metrics(&statsd.gauges,     statsd_flush_gauge);

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -18,7 +18,6 @@ static bool journal_data_directories_exist() {
 }
 
 int main(int argc __maybe_unused, char **argv __maybe_unused) {
-    clocks_init();
     nd_thread_tag_set("sd-jrnl.plugin");
     nd_log_initialize_for_external_plugins("systemd-journal.plugin");
 

--- a/src/collectors/systemd-journal.plugin/systemd-main.c
+++ b/src/collectors/systemd-journal.plugin/systemd-main.c
@@ -114,13 +114,12 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
 
     // ------------------------------------------------------------------------
 
-    const usec_t step_ut = 100 * USEC_PER_MS;
     usec_t send_newline_ut = 0;
     usec_t since_last_scan_ut = SYSTEMD_JOURNAL_ALL_FILES_SCAN_EVERY_USEC * 2; // something big to trigger scanning at start
     const bool tty = isatty(fileno(stdout)) == 1;
 
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, USEC_PER_SEC);
     while(!plugin_should_exit) {
 
         if(since_last_scan_ut > SYSTEMD_JOURNAL_ALL_FILES_SCAN_EVERY_USEC) {
@@ -128,7 +127,7 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
             since_last_scan_ut = 0;
         }
 
-        usec_t dt_ut = heartbeat_next(&hb, step_ut);
+        usec_t dt_ut = heartbeat_next(&hb);
         since_last_scan_ut += dt_ut;
         send_newline_ut += dt_ut;
 

--- a/src/collectors/timex.plugin/plugin_timex.c
+++ b/src/collectors/timex.plugin/plugin_timex.c
@@ -67,10 +67,10 @@ void *timex_main(void *ptr)
     usec_t step = update_every * USEC_PER_SEC;
     usec_t real_step = USEC_PER_SEC;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, USEC_PER_SEC);
     while (service_running(SERVICE_COLLECTORS)) {
         worker_is_idle();
-        heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
 
         if (real_step < step) {
             real_step += USEC_PER_SEC;

--- a/src/collectors/windows-events.plugin/windows-events.c
+++ b/src/collectors/windows-events.plugin/windows-events.c
@@ -1290,7 +1290,6 @@ void function_windows_events(const char *transaction, char *function, usec_t *st
 }
 
 int main(int argc __maybe_unused, char **argv __maybe_unused) {
-    clocks_init();
     nd_thread_tag_set("wevt.plugin");
     nd_log_initialize_for_external_plugins("windows-events.plugin");
 

--- a/src/collectors/windows-events.plugin/windows-events.c
+++ b/src/collectors/windows-events.plugin/windows-events.c
@@ -1369,14 +1369,13 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
 
     // ------------------------------------------------------------------------
 
-    const usec_t step_ut = 100 * USEC_PER_MS;
     usec_t send_newline_ut = 0;
     usec_t since_last_scan_ut = WINDOWS_EVENTS_SCAN_EVERY_USEC * 2; // something big to trigger scanning at start
     usec_t since_last_providers_release_ut = 0;
     const bool tty = isatty(fileno(stdout)) == 1;
 
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, USEC_PER_SEC);
     while(!plugin_should_exit) {
 
         if(since_last_scan_ut > WINDOWS_EVENTS_SCAN_EVERY_USEC) {
@@ -1389,7 +1388,7 @@ int main(int argc __maybe_unused, char **argv __maybe_unused) {
             since_last_providers_release_ut = 0;
         }
 
-        usec_t dt_ut = heartbeat_next(&hb, step_ut);
+        usec_t dt_ut = heartbeat_next(&hb);
         since_last_providers_release_ut += dt_ut;
         since_last_scan_ut += dt_ut;
         send_newline_ut += dt_ut;

--- a/src/collectors/windows.plugin/windows_plugin.c
+++ b/src/collectors/windows.plugin/windows_plugin.c
@@ -79,9 +79,8 @@ void *win_plugin_main(void *ptr) {
         worker_register_job_name(i, win_modules[i].dim);
     }
 
-    usec_t step = localhost->rrd_update_every * USEC_PER_SEC;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, localhost->rrd_update_every * USEC_PER_SEC);
 
 #define LGS_MODULE_ID 0
 
@@ -93,7 +92,7 @@ void *win_plugin_main(void *ptr) {
 
     while(service_running(SERVICE_COLLECTORS)) {
         worker_is_idle();
-        usec_t hb_dt = heartbeat_next(&hb, step);
+        usec_t hb_dt = heartbeat_next(&hb);
 
         if(unlikely(!service_running(SERVICE_COLLECTORS)))
             break;

--- a/src/collectors/xenstat.plugin/xenstat_plugin.c
+++ b/src/collectors/xenstat.plugin/xenstat_plugin.c
@@ -920,8 +920,6 @@ static void xenstat_send_domain_metrics() {
 }
 
 int main(int argc, char **argv) {
-    clocks_init();
-
     // ------------------------------------------------------------------------
     // initialization of netdata plugin
 

--- a/src/collectors/xenstat.plugin/xenstat_plugin.c
+++ b/src/collectors/xenstat.plugin/xenstat_plugin.c
@@ -1022,12 +1022,11 @@ int main(int argc, char **argv) {
     time_t started_t = now_monotonic_sec();
 
     size_t iteration;
-    usec_t step = netdata_update_every * USEC_PER_SEC;
 
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, netdata_update_every * USEC_PER_SEC);
     for(iteration = 0; 1; iteration++) {
-        usec_t dt = heartbeat_next(&hb, step);
+        usec_t dt = heartbeat_next(&hb);
 
         if(unlikely(netdata_exit)) break;
 

--- a/src/daemon/analytics.c
+++ b/src/daemon/analytics.c
@@ -569,14 +569,13 @@ void *analytics_main(void *ptr)
     CLEANUP_FUNCTION_REGISTER(analytics_main_cleanup) cleanup_ptr = ptr;
     unsigned int sec = 0;
     heartbeat_t hb;
-    heartbeat_init(&hb);
-    usec_t step_ut = USEC_PER_SEC;
+    heartbeat_init(&hb, USEC_PER_SEC);
 
     netdata_log_debug(D_ANALYTICS, "Analytics thread starts");
 
-    //first delay after agent start
+    // first delay after agent start
     while (service_running(SERVICE_ANALYTICS) && likely(sec <= ANALYTICS_INIT_SLEEP_SEC)) {
-        heartbeat_next(&hb, step_ut);
+        heartbeat_next(&hb);
         sec++;
     }
 
@@ -592,8 +591,8 @@ void *analytics_main(void *ptr)
 
     sec = 0;
     while (1) {
-        heartbeat_next(&hb, step_ut * 2);
-        sec += 2;
+        heartbeat_next(&hb);
+        sec++;
 
         if (unlikely(!service_running(SERVICE_ANALYTICS)))
             break;

--- a/src/daemon/global_statistics.c
+++ b/src/daemon/global_statistics.c
@@ -4229,7 +4229,7 @@ void *global_statistics_main(void *ptr)
 
     usec_t step = update_every * USEC_PER_SEC;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, USEC_PER_SEC);
     usec_t real_step = USEC_PER_SEC;
 
     // keep the randomness at zero
@@ -4238,7 +4238,7 @@ void *global_statistics_main(void *ptr)
 
     while (service_running(SERVICE_COLLECTORS)) {
         worker_is_idle();
-        heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
         if (real_step < step) {
             real_step += USEC_PER_SEC;
             continue;
@@ -4287,12 +4287,12 @@ void *global_statistics_extended_main(void *ptr)
 
     usec_t step = update_every * USEC_PER_SEC;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, USEC_PER_SEC);
     usec_t real_step = USEC_PER_SEC;
 
     while (service_running(SERVICE_COLLECTORS)) {
         worker_is_idle();
-        heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
         if (real_step < step) {
             real_step += USEC_PER_SEC;
             continue;

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -1357,7 +1357,6 @@ static void get_netdata_configured_variables()
     // --------------------------------------------------------------------
     // get various system parameters
 
-    os_get_system_HZ();
     os_get_system_cpus_uncached();
     os_get_system_pid_max();
 

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -1510,7 +1510,6 @@ int unittest_prepare_rrd(const char **user) {
 }
 
 int netdata_main(int argc, char **argv) {
-    clocks_init();
     string_init();
     analytics_init();
 

--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -297,7 +297,7 @@ void *service_main(void *ptr)
     CLEANUP_FUNCTION_REGISTER(service_main_cleanup) cleanup_ptr = ptr;
 
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, USEC_PER_SEC);
     usec_t step = USEC_PER_SEC * SERVICE_HEARTBEAT;
     usec_t real_step = USEC_PER_SEC;
 
@@ -305,7 +305,7 @@ void *service_main(void *ptr)
 
     while (service_running(SERVICE_MAINTENANCE)) {
         worker_is_idle();
-        heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
         if (real_step < step) {
             real_step += USEC_PER_SEC;
             continue;

--- a/src/database/contexts/worker.c
+++ b/src/database/contexts/worker.c
@@ -1099,12 +1099,11 @@ void *rrdcontext_main(void *ptr) {
     worker_register_job_custom_metric(WORKER_JOB_PP_QUEUE_SIZE, "post processing queue size", "contexts", WORKER_METRIC_ABSOLUTE);
 
     heartbeat_t hb;
-    heartbeat_init(&hb);
-    usec_t step = RRDCONTEXT_WORKER_THREAD_HEARTBEAT_USEC;
+    heartbeat_init(&hb, RRDCONTEXT_WORKER_THREAD_HEARTBEAT_USEC);
 
     while (service_running(SERVICE_CONTEXT)) {
         worker_is_idle();
-        heartbeat_next(&hb, step);
+        heartbeat_next(&hb);
 
         if(unlikely(!service_running(SERVICE_CONTEXT))) break;
 

--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -2366,7 +2366,7 @@ void *unittest_stress_test_collector(void *ptr) {
     time_t start_time_t = pgc_uts.first_time_t + 1;
 
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, pgc_uts.time_per_collection_ut);
 
     while(!__atomic_load_n(&pgc_uts.stop, __ATOMIC_RELAXED)) {
         // netdata_log_info("COLLECTOR %zu: collecting metrics %zu to %zu, from %ld to %lu", id, metric_start, metric_end, start_time_t, start_time_t + pgc_uts.points_per_page);
@@ -2393,7 +2393,7 @@ void *unittest_stress_test_collector(void *ptr) {
 
         time_t end_time_t = start_time_t + (time_t)pgc_uts.points_per_page;
         while(++start_time_t <= end_time_t && !__atomic_load_n(&pgc_uts.stop, __ATOMIC_RELAXED)) {
-            heartbeat_next(&hb, pgc_uts.time_per_collection_ut);
+            heartbeat_next(&hb);
 
             for (size_t i = metric_start; i < metric_end; i++) {
                 if(pgc_uts.metrics[i])
@@ -2480,9 +2480,9 @@ void *unittest_stress_test_queries(void *ptr) {
 
 void *unittest_stress_test_service(void *ptr) {
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, USEC_PER_SEC);
     while(!__atomic_load_n(&pgc_uts.stop, __ATOMIC_RELAXED)) {
-        heartbeat_next(&hb, 1 * USEC_PER_SEC);
+        heartbeat_next(&hb);
 
         pgc_flush_pages(pgc_uts.cache, 1000);
         pgc_evict_pages(pgc_uts.cache, 0, 0);
@@ -2545,7 +2545,7 @@ void unittest_stress_test(void) {
     }
 
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, USEC_PER_SEC);
 
     struct {
         size_t entries;
@@ -2578,7 +2578,7 @@ void unittest_stress_test(void) {
     } stats = {}, old_stats = {};
 
     for(int i = 0; i < 86400 ;i++) {
-        heartbeat_next(&hb, 1 * USEC_PER_SEC);
+        heartbeat_next(&hb);
 
         old_stats = stats;
         stats.entries       = __atomic_load_n(&pgc_uts.cache->stats.entries, __ATOMIC_RELAXED);

--- a/src/exporting/exporting_engine.c
+++ b/src/exporting/exporting_engine.c
@@ -195,12 +195,11 @@ void *exporting_main(void *ptr)
     RRDDIM *rd_main_system = NULL;
     create_main_rusage_chart(&st_main_rusage, &rd_main_user, &rd_main_system);
 
-    usec_t step_ut = localhost->rrd_update_every * USEC_PER_SEC;
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, localhost->rrd_update_every * USEC_PER_SEC);
 
     while (service_running(SERVICE_EXPORTERS)) {
-        heartbeat_next(&hb, step_ut);
+        heartbeat_next(&hb);
         engine->now = now_realtime_sec();
 
         if (mark_scheduled_instances(engine))

--- a/src/libnetdata/clocks/clocks.c
+++ b/src/libnetdata/clocks/clocks.c
@@ -296,10 +296,12 @@ static usec_t heartbeat_randomness(usec_t step) {
     struct {
         pid_t tid;
         usec_t now_ut;
+        char tag[ND_THREAD_TAG_MAX + 1];
     } key = {
         .tid = gettid(),
         .now_ut = now_realtime_usec(),
     };
+    strncpyz(key.tag, nd_thread_tag(), sizeof(key.tag) - 1);
     XXH64_hash_t hash = XXH3_64bits(&key, sizeof(key));
 
     usec_t max_randomness = MIN(step / 4, 300 * USEC_PER_MS);

--- a/src/libnetdata/clocks/clocks.c
+++ b/src/libnetdata/clocks/clocks.c
@@ -302,7 +302,8 @@ static usec_t heartbeat_randomness(usec_t step) {
     };
     XXH64_hash_t hash = XXH3_64bits(&key, sizeof(key));
 
-    usec_t alignment_ut = (step / 4) + (hash % (step / 3));
+    usec_t max_randomness = MIN(step / 4, 300 * USEC_PER_MS);
+    usec_t alignment_ut = (100 * USEC_PER_MS) + (hash % max_randomness);
     alignment_ut /= clock_realtime_resolution;
     alignment_ut *= clock_realtime_resolution;
 
@@ -310,6 +311,8 @@ static usec_t heartbeat_randomness(usec_t step) {
 }
 
 inline void heartbeat_init(heartbeat_t *hb, usec_t step) {
+    if(!step) step = USEC_PER_SEC;
+
     netdata_mutex_lock(&heartbeat_alignment_mutex);
     hb->statistics_id = heartbeat_alignment_id;
     heartbeat_alignment_id++;

--- a/src/libnetdata/clocks/clocks.c
+++ b/src/libnetdata/clocks/clocks.c
@@ -298,7 +298,7 @@ static usec_t heartbeat_randomness(usec_t step) {
         usec_t now_ut;
         char tag[ND_THREAD_TAG_MAX + 1];
     } key = {
-        .tid = gettid(),
+        .tid = os_gettid(),
         .now_ut = now_realtime_usec(),
     };
     strncpyz(key.tag, nd_thread_tag(), sizeof(key.tag) - 1);
@@ -328,7 +328,7 @@ inline void heartbeat_init(heartbeat_t *hb, usec_t step) {
         heartbeat_alignment_values[hb->statistics_id].dt = 0;
         heartbeat_alignment_values[hb->statistics_id].sequence = 0;
         heartbeat_alignment_values[hb->statistics_id].randomness = hb->randomness;
-        heartbeat_alignment_values[hb->statistics_id].tid = gettid();
+        heartbeat_alignment_values[hb->statistics_id].tid = os_gettid();
     }
 }
 

--- a/src/libnetdata/clocks/clocks.h
+++ b/src/libnetdata/clocks/clocks.h
@@ -26,6 +26,7 @@ typedef int64_t  smsec_t;
 typedef int64_t stime_t;
 
 typedef struct heartbeat {
+    usec_t step;
     usec_t realtime;
     usec_t randomness;
     size_t statistics_id;
@@ -139,12 +140,12 @@ msec_t timeval_msec(struct timeval *tv);
 usec_t dt_usec(struct timeval *now, struct timeval *old);
 susec_t dt_usec_signed(struct timeval *now, struct timeval *old);
 
-void heartbeat_init(heartbeat_t *hb);
+void heartbeat_init(heartbeat_t *hb, usec_t step);
 
 /* Sleeps until next multiple of tick using monotonic clock.
  * Returns elapsed time in microseconds since previous heartbeat
  */
-usec_t heartbeat_next(heartbeat_t *hb, usec_t tick);
+usec_t heartbeat_next(heartbeat_t *hb);
 
 void heartbeat_statistics(usec_t *min_ptr, usec_t *max_ptr, usec_t *average_ptr, size_t *count_ptr);
 

--- a/src/libnetdata/clocks/clocks.h
+++ b/src/libnetdata/clocks/clocks.h
@@ -152,8 +152,6 @@ void heartbeat_statistics(usec_t *min_ptr, usec_t *max_ptr, usec_t *average_ptr,
 void sleep_usec_with_now(usec_t usec, usec_t started_ut);
 #define sleep_usec(usec) sleep_usec_with_now(usec, 0)
 
-void clocks_init(void);
-
 // lower level functions - avoid using directly
 time_t now_sec(clockid_t clk_id);
 usec_t now_usec(clockid_t clk_id);

--- a/src/libnetdata/log/systemd-cat-native.c
+++ b/src/libnetdata/log/systemd-cat-native.c
@@ -737,7 +737,6 @@ cleanup:
 }
 
 int main(int argc, char *argv[]) {
-    clocks_init();
     nd_log_initialize_for_external_plugins(argv[0]);
 
     int timeout_ms = 0; // wait forever

--- a/src/libnetdata/os/os.c
+++ b/src/libnetdata/os/os.c
@@ -12,6 +12,7 @@ void os_get_system_HZ(void) {
 
     if ((ticks = sysconf(_SC_CLK_TCK)) == -1) {
         netdata_log_error("Cannot get system clock ticks");
+        ticks = 100;
     }
 
     system_hz = (unsigned int) ticks;

--- a/src/libnetdata/os/os.c
+++ b/src/libnetdata/os/os.c
@@ -6,7 +6,7 @@
 // system functions
 // to retrieve settings of the system
 
-unsigned int system_hz;
+unsigned int system_hz = 100;
 void os_get_system_HZ(void) {
     long ticks;
 

--- a/src/ml/ml.cc
+++ b/src/ml/ml.cc
@@ -1218,11 +1218,11 @@ ml_detect_main(void *arg)
     worker_register_job_name(WORKER_JOB_DETECTION_STATS, "training stats");
 
     heartbeat_t hb;
-    heartbeat_init(&hb);
+    heartbeat_init(&hb, USEC_PER_SEC);
 
     while (!Cfg.detection_stop && service_running(SERVICE_COLLECTORS)) {
         worker_is_idle();
-        heartbeat_next(&hb, USEC_PER_SEC);
+        heartbeat_next(&hb);
 
         RRDHOST *rh;
         rrd_rdlock();


### PR DESCRIPTION
Add randomness to Netdata threads to ensure they are not running concurrently. This is an attempt to lower the concurrency of Netdata threads and it affects CPU load in the following ways:

## When running a child Netdata

Data collection threads and other internal maintenance operations are not synchronized to wake up at the same time, reducing the run queue of the thread scheduler.

## When running multiple Netdata on the same hardware

Each Netdata now has its own unique anniversary timings, so even when running a lot of VMs on the same host, each of them running a Netdata instance. Now Netdata threads are randomly spread in the first 400ms of each second, lowering the demand for concurrent CPU cores.

## When running a Netdata parent

Each child Netdata pushing metrics to the parent will now have its own unique timings, spreading the reception of new data across the first 400ms of each second (assuming 1-second data collection).
