### PR TITLE
Improve ACLK sync CPU usage

### DIFF
--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -509,6 +509,7 @@ static void aclk_synchronization(void *arg)
             }
         } while (opcode != ACLK_DATABASE_NOOP);
     }
+    config->initialized = false;
 
     if (!uv_timer_stop(&config->timer_req))
         uv_close((uv_handle_t *)&config->timer_req, NULL);

--- a/src/database/sqlite/sqlite_aclk_node.c
+++ b/src/database/sqlite/sqlite_aclk_node.c
@@ -154,6 +154,9 @@ void aclk_check_node_info_and_collectors(void)
             continue;
         }
 
+        if (!wc->node_info_send_time && !wc->node_collectors_send)
+            continue;
+
         if (unlikely(host_is_replicating(host))) {
             internal_error(true, "ACLK SYNC: Host %s is still replicating", rrdhost_hostname(host));
             replicating++;


### PR DESCRIPTION
##### Summary
- Avoid expensive checks on parents with a lot of children and charts
