### PR TITLE
added /api/v3/stream_path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1425,6 +1425,7 @@ set(WEB_PLUGIN_FILES
         src/web/server/static/static-threaded.h
         src/web/server/web_client_cache.c
         src/web/server/web_client_cache.h
+        src/web/api/v3/api_v3_stream_path.c
 )
 
 set(CLAIM_PLUGIN_FILES

--- a/src/database/contexts/api_v2_contexts.c
+++ b/src/database/contexts/api_v2_contexts.c
@@ -382,11 +382,11 @@ static void rrdcontext_to_json_v2_rrdhost(BUFFER *wb, RRDHOST *host, struct rrdc
     buffer_json_node_add_v2(wb, host, node_id, 0,
                             (ctl->mode & CONTEXTS_V2_AGENTS) && !(ctl->mode & CONTEXTS_V2_NODE_INSTANCES));
 
-    if(ctl->mode & (CONTEXTS_V2_NODES_INFO | CONTEXTS_V2_NODE_INSTANCES)) {
+    if(ctl->mode & (CONTEXTS_V2_NODES_INFO | CONTEXTS_V2_NODES_STREAM_PATH | CONTEXTS_V2_NODE_INSTANCES)) {
         RRDHOST_STATUS s;
         rrdhost_status(host, ctl->now, &s);
 
-        if (ctl->mode & (CONTEXTS_V2_NODES_INFO)) {
+        if (ctl->mode & (CONTEXTS_V2_NODES_INFO | CONTEXTS_V2_NODES_STREAM_PATH)) {
             buffer_json_member_add_string(wb, "v", rrdhost_program_version(host));
 
             host_labels2json(host, wb, "labels");
@@ -423,9 +423,14 @@ static void rrdcontext_to_json_v2_rrdhost(BUFFER *wb, RRDHOST *host, struct rrdc
             // reachable    - connected with live data
             // pruned       - not connected for some time and has been removed
             buffer_json_member_add_string(wb, "state", rrdhost_is_online(host) ? "reachable" : "stale");
+        }
 
+        if (ctl->mode & (CONTEXTS_V2_NODES_INFO)) {
             rrdhost_health_to_json_v2(wb, "health", &s);
             agent_capabilities_to_json(wb, host, "capabilities");
+        }
+
+        if (ctl->mode & (CONTEXTS_V2_NODES_STREAM_PATH)) {
             rrdhost_stream_path_to_json(wb, host, STREAM_PATH_JSON_MEMBER, false);
         }
 
@@ -608,6 +613,9 @@ static void buffer_json_contexts_v2_mode_to_array(BUFFER *wb, const char *key, C
     if(mode & CONTEXTS_V2_NODES_INFO)
         buffer_json_add_array_item_string(wb, "nodes-info");
 
+    if(mode & CONTEXTS_V2_NODES_STREAM_PATH)
+        buffer_json_add_array_item_string(wb, "nodes-stream-path");
+
     if(mode & CONTEXTS_V2_NODE_INSTANCES)
         buffer_json_add_array_item_string(wb, "nodes-instances");
 
@@ -750,7 +758,7 @@ int rrdcontext_to_json_v2(BUFFER *wb, struct api_v2_contexts_request *req, CONTE
     if(mode & (CONTEXTS_V2_AGENTS_INFO))
         mode |= CONTEXTS_V2_AGENTS;
 
-    if(mode & (CONTEXTS_V2_FUNCTIONS | CONTEXTS_V2_CONTEXTS | CONTEXTS_V2_SEARCH | CONTEXTS_V2_NODES_INFO | CONTEXTS_V2_NODE_INSTANCES))
+    if(mode & (CONTEXTS_V2_FUNCTIONS | CONTEXTS_V2_CONTEXTS | CONTEXTS_V2_SEARCH | CONTEXTS_V2_NODES_INFO | CONTEXTS_V2_NODES_STREAM_PATH | CONTEXTS_V2_NODE_INSTANCES))
         mode |= CONTEXTS_V2_NODES;
 
     if(mode & CONTEXTS_V2_ALERTS) {

--- a/src/database/contexts/rrdcontext.h
+++ b/src/database/contexts/rrdcontext.h
@@ -648,13 +648,14 @@ typedef enum __attribute__ ((__packed__)) {
     CONTEXTS_V2_NODES               = (1 << 2),
     CONTEXTS_V2_NODES_INFO          = (1 << 3),
     CONTEXTS_V2_NODE_INSTANCES      = (1 << 4),
-    CONTEXTS_V2_CONTEXTS            = (1 << 5),
-    CONTEXTS_V2_AGENTS              = (1 << 6),
-    CONTEXTS_V2_AGENTS_INFO         = (1 << 7),
-    CONTEXTS_V2_VERSIONS            = (1 << 8),
-    CONTEXTS_V2_FUNCTIONS           = (1 << 9),
-    CONTEXTS_V2_ALERTS              = (1 << 10),
-    CONTEXTS_V2_ALERT_TRANSITIONS   = (1 << 11),
+    CONTEXTS_V2_NODES_STREAM_PATH   = (1 << 5),
+    CONTEXTS_V2_CONTEXTS            = (1 << 6),
+    CONTEXTS_V2_AGENTS              = (1 << 7),
+    CONTEXTS_V2_AGENTS_INFO         = (1 << 8),
+    CONTEXTS_V2_VERSIONS            = (1 << 9),
+    CONTEXTS_V2_FUNCTIONS           = (1 << 10),
+    CONTEXTS_V2_ALERTS              = (1 << 11),
+    CONTEXTS_V2_ALERT_TRANSITIONS   = (1 << 12),
 } CONTEXTS_V2_MODE;
 
 int rrdcontext_to_json_v2(BUFFER *wb, struct api_v2_contexts_request *req, CONTEXTS_V2_MODE mode);

--- a/src/database/rrd.h
+++ b/src/database/rrd.h
@@ -1104,8 +1104,8 @@ typedef struct health {
     time_t health_delay_up_to;                     // a timestamp to delay alarms processing up to
     STRING *health_default_exec;                   // the full path of the alarms notifications program
     STRING *health_default_recipient;              // the default recipient for all alarms
-    unsigned int health_enabled;                   // 1 when this host has health enabled
-    bool use_summary_for_notifications;            // whether or not to use the summary field as a subject for notifications
+    bool health_enabled;                           // 1 when this host has health enabled
+    bool use_summary_for_notifications;            // whether to use the summary field as a subject for notifications
 } HEALTH;
 
 // ----------------------------------------------------------------------------

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -958,7 +958,7 @@ static int store_host_metadata(RRDHOST *host)
     SQLITE_BIND_FAIL(bind_fail, bind_text_null(res, ++param, rrdhost_program_name(host), 1));
     SQLITE_BIND_FAIL(bind_fail, bind_text_null(res, ++param, rrdhost_program_version(host), 1));
     SQLITE_BIND_FAIL(bind_fail, sqlite3_bind_int64(res, ++param, host->rrd_history_entries));
-    SQLITE_BIND_FAIL(bind_fail, sqlite3_bind_int(res, ++param, (int ) host->health.health_enabled));
+    SQLITE_BIND_FAIL(bind_fail, sqlite3_bind_int(res, ++param, (int)host->health.health_enabled));
     SQLITE_BIND_FAIL(bind_fail, sqlite3_bind_int64(res, ++param, (sqlite3_int64) host->last_connected));
 
     int store_rc = sqlite3_step_monitored(res);

--- a/src/streaming/stream-path.h
+++ b/src/streaming/stream-path.h
@@ -8,8 +8,12 @@
 #define STREAM_PATH_JSON_MEMBER "streaming_path"
 
 typedef enum __attribute__((packed)) {
-    STREAM_PATH_FLAG_NONE = 0,
-    STREAM_PATH_FLAG_ACLK = (1 << 0),
+    STREAM_PATH_FLAG_NONE       = 0,
+    STREAM_PATH_FLAG_ACLK       = (1 << 0),
+    STREAM_PATH_FLAG_HEALTH     = (1 << 1),
+    STREAM_PATH_FLAG_ML         = (1 << 2),
+    STREAM_PATH_FLAG_EPHEMERAL  = (1 << 3),
+    STREAM_PATH_FLAG_VIRTUAL    = (1 << 4),
 } STREAM_PATH_FLAGS;
 
 typedef struct stream_path {

--- a/src/web/api/v3/api_v3_calls.h
+++ b/src/web/api/v3/api_v3_calls.h
@@ -5,7 +5,11 @@
 
 #include "../web_api_v3.h"
 
+int api_v2_contexts_internal(RRDHOST *host, struct web_client *w, char *url, CONTEXTS_V2_MODE mode);
+#define api_v3_contexts_internal(host, w, url, mode) api_v2_contexts_internal(host, w, url, mode)
+
 int api_v3_settings(RRDHOST *host, struct web_client *w, char *url);
 int api_v3_me(RRDHOST *host, struct web_client *w, char *url);
+int api_v3_stream_path(RRDHOST *host __maybe_unused, struct web_client *w, char *url);
 
 #endif //NETDATA_API_V3_CALLS_H

--- a/src/web/api/v3/api_v3_stream_path.c
+++ b/src/web/api/v3/api_v3_stream_path.c
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "api_v3_calls.h"
+
+int api_v3_stream_path(RRDHOST *host __maybe_unused, struct web_client *w, char *url) {
+    return api_v3_contexts_internal(host, w, url, CONTEXTS_V2_NODES | CONTEXTS_V2_NODES_STREAM_PATH);
+}

--- a/src/web/api/web_api_v3.c
+++ b/src/web/api/web_api_v3.c
@@ -131,6 +131,14 @@ static struct web_api_command api_commands_v3[] = {
         .allow_subpaths = 0
     },
     {
+        .api = "stream_path",
+        .hash = 0,
+        .acl = HTTP_ACL_NODES,
+        .access = HTTP_ACCESS_ANONYMOUS_DATA,
+        .callback = api_v3_stream_path,
+        .allow_subpaths = 0
+    },
+    {
         .api = "versions",
         .hash = 0,
         .acl = HTTP_ACL_NOCHECK,


### PR DESCRIPTION
**Stream Path**: the ability of Netdata Agents to know the entire streaming path of each Netdata node. All Netdata nodes propagate the entire streaming path both forward (towards a Parent) and backward (towards a Child), so that all nodes involved in streaming are aware of the entire streaming path and all Netdata Agents involved.

- [x] added `/api/v3/stream_path`, this has the same semantics as `/api/v3/nodes`, `/api/v3/contexts`, etc, returning the entire stream path for all nodes matching the query.

- [x] added flags for know if the node is marked as `ephemeral` or `virtual`, and also if `health` and `ml` run
