### PR TITLE
Precompile Python code on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3124,6 +3124,11 @@ if(ENABLE_PLUGIN_PYTHON)
           COMPONENT plugin-pythond
           DESTINATION usr/libexec/netdata/python.d)
 
+  if(OS_WINDOWS)
+    include(NetdataUtil)
+    precompile_python(usr/libexec/netdata/python.d plugin-pythond)
+  endif()
+
   install(FILES src/collectors/python.d.plugin/python.d.conf
           COMPONENT plugin-pythond
           DESTINATION usr/lib/netdata/conf.d)

--- a/packaging/cmake/Modules/NetdataUtil.cmake
+++ b/packaging/cmake/Modules/NetdataUtil.cmake
@@ -195,3 +195,27 @@ function(subdirlist result curdir)
 
   set(${result} ${dirlist} PARENT_SCOPE)
 endfunction()
+
+# Precompile python code in the specified directory relative to the
+# CMake install prefix at install time.
+# This must be called _after_ the install directive for the python code
+# in the specified directory
+function(precompile_python dir component)
+  find_package(Python3)
+
+  if(NOT ${Python3_Interpreter_FOUND})
+    message(STATUS "Could not find Python3, skipping precompilation of Python code.")
+    return()
+  endif()
+
+  set(prefix [=[${CMAKE_INSTALL_PREFIX}]=])
+
+  install(
+    CODE "message(STATUS \"Precompiling Python3 code in ${prefix}/${dir}\")"
+    COMPONENT ${component}
+  )
+  install(
+    CODE "execute_process(COMMAND ${Python3_Interpreter} -O -m compileall -j0 -o2 ${prefix}/${dir} WORKING_DIRECTORY ${prefix}/${dir})"
+    COMPONENT ${component}
+  )
+endfunction()


### PR DESCRIPTION
##### Summary

This ensures that the compiled Python code is included in the installer correctly, which in turn ensures it gets cleaned up correctly on uninstall.

Long-term we may also add this for the Linux native packages and possibly also our Docker images, but for the moment it’s Windows-only.

##### Test Plan

Requires manual checking of the MSI installer produced by this PR.