### PR TITLE
Improve Installer (Part II)

### DIFF
--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -155,7 +155,7 @@
             <Publish Dialog="ViewLicenseDlg2" Control="Next" Event="NewDialog" Value="InstallDirDlg" Condition="ETCNETDATACLAIMFILE" />
 
             <Publish Dialog="NDConfigDialog" Control="Back" Event="NewDialog" Value="ViewLicenseDlg2" />
-            <Publish Dialog="NDConfigDialog" Control="Next" Event="NewDialog" Value="InstallDirDlg" />
+            <Publish Dialog="NDConfigDialog" Control="Next" Event="NewDialog" Value="InstallDirDlg" Condition="((TOKEN = &quot;&quot;) AND (ROOMS = &quot;&quot;)) OR ((NOT (TOKEN = &quot;&quot;)) AND (NOT (ROOMS = &quot;&quot;)))" />
 
             <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="NDConfigDialog" />
             <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="20" />
@@ -231,21 +231,22 @@
                 <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="15" Transparent="yes" NoPrefix="yes" Text="Enter your Space's Claim Token and the Room IDs where you want to add the Agent." />
                 <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="Connect to the Cloud" />
 
-                <Control Id="WarningLabel" Type="Text" X="10" Y="60" Width="290" Height="15" Text="Agent already claimed? Click Next." />
+                <Control Id="WarningLabel1" Type="Text" X="10" Y="60" Width="290" Height="15" Text="Agent already claimed? Click 'Next'. For a first-time installation, please complete" />
+                <Control Id="WarningLabel2" Type="Text" X="10" Y="75" Width="290" Height="15" Text="the 'Claim Token' and 'Rooms ID(s)' fields." />
 
-                <Control Id="TokenLabel" Type="Text" X="10" Y="90" Width="55" Height="15" Text="Claim Token:" />
-                <Control Id="Token" Type="Edit" X="65" Y="90" Width="290" Height="18" Property="TOKEN" Text="{135}" />
+                <Control Id="TokenLabel" Type="Text" X="10" Y="100" Width="55" Height="15" Text="Claim Token:" />
+                <Control Id="Token" Type="Edit" X="65" Y="100" Width="290" Height="18" Property="TOKEN" Text="{135}" />
             
-                <Control Id="RoomsLabel" Type="Text" X="10" Y="105" Width="55" Height="15" Text="Rooms ID(s):" />
-                <Control Id="Rooms" Type="Edit" X="65" Y="105" Width="290" Height="18" Property="ROOMS" />
+                <Control Id="RoomsLabel" Type="Text" X="10" Y="115" Width="55" Height="15" Text="Rooms ID(s):" />
+                <Control Id="Rooms" Type="Edit" X="65" Y="115" Width="290" Height="18" Property="ROOMS" />
             
-                <Control Id="ProxyLabel" Type="Text" X="10" Y="120" Width="55" Height="15" Text="Proxy URL:" />
-                <Control Id="Proxy" Type="Edit" X="65" Y="120" Width="290" Height="18" Property="PROXY" />
+                <Control Id="ProxyLabel" Type="Text" X="10" Y="130" Width="55" Height="15" Text="Proxy URL:" />
+                <Control Id="Proxy" Type="Edit" X="65" Y="130" Width="290" Height="18" Property="PROXY" />
             
-                <Control Id="URLLabel" Type="Text" X="10" Y="135" Width="55" Height="15" Text="Cloud URL:" />
-                <Control Id="URL" Type="Edit" X="65" Y="135" Width="290" Height="18" Property="URL" />
+                <Control Id="URLLabel" Type="Text" X="10" Y="145" Width="55" Height="15" Text="Cloud URL:" />
+                <Control Id="URL" Type="Edit" X="65" Y="145" Width="290" Height="18" Property="URL" />
 
-                <Control Id="InsecureCheckbox" Type="CheckBox" X="10" Y="150" Width="290" Height="15" Property="INSECURE" CheckBoxValue="0"  Text="Insecure" />
+                <Control Id="InsecureCheckbox" Type="CheckBox" X="10" Y="160" Width="290" Height="15" Property="INSECURE" CheckBoxValue="0"  Text="Insecure" />
             
                 <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" />
                 <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)" />

--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -233,7 +233,6 @@
                 <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="Connect to the Cloud" />
 
                 <Control Id="WarningLabelOld" Type="Text" X="10" Y="60" Width="350" Height="15" Text="Agent already claimed? Click Next." />
-                <Control Id="WarningLabelNew0" Type="Text" X="10" Y="75" Width="350" Height="15" Text="If you want to connect to Netdata Cloud, enter your Claim Token and Room ID(s)." />
 
                 <Control Id="TokenLabel" Type="Text" X="10" Y="100" Width="55" Height="15" Text="Claim Token:" />
                 <Control Id="Token" Type="Edit" X="65" Y="100" Width="290" Height="18" Property="TOKEN" Text="{135}" />

--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -151,18 +151,16 @@
             <Publish Dialog="ViewLicenseDlg1" Control="Next" Event="NewDialog" Value="ViewLicenseDlg2" />
 
             <Publish Dialog="ViewLicenseDlg2" Control="Back" Event="NewDialog" Value="ViewLicenseDlg1" />
-            <Publish Dialog="ViewLicenseDlg2" Control="Next" Event="NewDialog" Value="NDConfigDialog" Condition="NOT ETCNETDATACLAIMFILE" />
-            <Publish Dialog="ViewLicenseDlg2" Control="Next" Event="NewDialog" Value="InstallDirDlg" Condition="ETCNETDATACLAIMFILE" />
+            <Publish Dialog="ViewLicenseDlg2" Control="Next" Event="NewDialog" Value="InstallDirDlg" />
 
-            <Publish Dialog="NDConfigDialog" Control="Back" Event="NewDialog" Value="ViewLicenseDlg2" />
-            <Publish Dialog="NDConfigDialog" Control="Next" Event="NewDialog" Value="InstallDirDlg" Condition="((TOKEN = &quot;&quot;) AND (ROOMS = &quot;&quot;)) OR ((NOT (TOKEN = &quot;&quot;)) AND (NOT (ROOMS = &quot;&quot;)))" />
-
-            <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="NDConfigDialog" />
-            <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="20" />
+            <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="ViewLicenseDlg2" />
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="NDConfigDialog" Order="20" />
             <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="10" />
             <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="10" />
             <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="20" />
 
+            <Publish Dialog="NDConfigDialog" Control="Back" Event="NewDialog" Value="InstallDirDlg" />
+            <Publish Dialog="NDConfigDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Condition="((TOKEN = &quot;&quot;) AND (ROOMS = &quot;&quot;)) OR ((NOT (TOKEN = &quot;&quot;)) AND (NOT (ROOMS = &quot;&quot;)))" />
 
             <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg" Order="1" Condition="NOT Installed OR WixUI_InstallMode = &quot;Change&quot;" />
             <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2" Condition="Installed AND NOT PATCH" />

--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -38,17 +38,6 @@
                 <ComponentRef Id="NetdataService" />
             </Feature>
 
-            <UI Id="FeatureTree_ViewLicense_X64">
-            </UI>
-            <UIRef Id="FeatureTree_ViewLicense" />
-
-            <WixVariable Id="WixUIBannerBmp" Value="Top.bmp" />
-            <WixVariable Id="WixUIDialogBmp" Value="BackGround.bmp" />
-            <UIRef Id="WixUI_ErrorProgressText" />
-            <ui:WixUI Id="FeatureTree_ViewLicense" />
-    </Package>
-
-    <Fragment>
             <StandardDirectory Id="ProgramFiles64Folder">
                 <Directory Id="INSTALLFOLDER" Name="Netdata">
                     <Directory Id="USRDIR" Name="usr">
@@ -64,12 +53,23 @@
                 </Directory>
             </StandardDirectory>
 
-            <Property Id="ETCNETDATACLAIMFILE">
-                <DirectorySearch Id="NetCoreDirectoryFoundx64" Path="[ETCDIRNETDATA]" >
+            <Property Id="OS_HAS_FILE" Secure="yes">
+                <DirectorySearch Id="NetCoreDirectoryFoundx64" Path="[ETCDIRNETDATA]" AssignToProperty="yes" >
                     <FileSearch Id="NetdataClaim" Name="claim.conf"/>
                 </DirectorySearch>
             </Property>
 
+            <UI Id="FeatureTree_ViewLicense_X64">
+            </UI>
+            <UIRef Id="FeatureTree_ViewLicense" />
+
+            <WixVariable Id="WixUIBannerBmp" Value="Top.bmp" />
+            <WixVariable Id="WixUIDialogBmp" Value="BackGround.bmp" />
+            <UIRef Id="WixUI_ErrorProgressText" />
+            <ui:WixUI Id="FeatureTree_ViewLicense" />
+    </Package>
+
+    <Fragment>
             <StandardDirectory Id="System64Folder">
             </StandardDirectory>
 
@@ -229,22 +229,22 @@
                 <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="15" Transparent="yes" NoPrefix="yes" Text="Enter your Space's Claim Token and the Room IDs where you want to add the Agent." />
                 <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="Connect to the Cloud" />
 
-                <Control Id="WarningLabel1" Type="Text" X="10" Y="60" Width="290" Height="15" Text="Agent already claimed? Click 'Next'. For a first-time installation, please complete" />
-                <Control Id="WarningLabel2" Type="Text" X="10" Y="75" Width="290" Height="15" Text="the 'Claim Token' and 'Rooms ID(s)' fields." />
+                <Control Id="WarningLabelOld" Type="Text" X="10" Y="60" Width="350" Height="15" Text="Your host was already claimed. Click 'Next'." HideCondition="NOT (OS_HAS_FILE = &quot;&quot;)" />
+                <Control Id="WarningLabelNew" Type="Text" X="10" Y="60" Width="350" Height="15" Text="For a first-time installation, please complete the 'Claim Token' and 'Rooms ID(s)' fields." HideCondition="(OS_HAS_FILE = &quot;&quot;)" />
 
-                <Control Id="TokenLabel" Type="Text" X="10" Y="100" Width="55" Height="15" Text="Claim Token:" />
-                <Control Id="Token" Type="Edit" X="65" Y="100" Width="290" Height="18" Property="TOKEN" Text="{135}" />
+                <Control Id="TokenLabel" Type="Text" X="10" Y="100" Width="55" Height="15" Text="Claim Token:" HideCondition="(OS_HAS_FILE = &quot;&quot;)"  />
+                <Control Id="Token" Type="Edit" X="65" Y="100" Width="290" Height="18" Property="TOKEN" Text="{135}" HideCondition="(OS_HAS_FILE = &quot;&quot;)"  />
             
-                <Control Id="RoomsLabel" Type="Text" X="10" Y="115" Width="55" Height="15" Text="Rooms ID(s):" />
-                <Control Id="Rooms" Type="Edit" X="65" Y="115" Width="290" Height="18" Property="ROOMS" />
+                <Control Id="RoomsLabel" Type="Text" X="10" Y="115" Width="55" Height="15" Text="Rooms ID(s):" HideCondition="(OS_HAS_FILE = &quot;&quot;)"  />
+                <Control Id="Rooms" Type="Edit" X="65" Y="115" Width="290" Height="18" Property="ROOMS" HideCondition="(OS_HAS_FILE = &quot;&quot;)"  />
             
-                <Control Id="ProxyLabel" Type="Text" X="10" Y="130" Width="55" Height="15" Text="Proxy URL:" />
-                <Control Id="Proxy" Type="Edit" X="65" Y="130" Width="290" Height="18" Property="PROXY" />
+                <Control Id="ProxyLabel" Type="Text" X="10" Y="130" Width="55" Height="15" Text="Proxy URL:" HideCondition="(OS_HAS_FILE = &quot;&quot;)"  />
+                <Control Id="Proxy" Type="Edit" X="65" Y="130" Width="290" Height="18" Property="PROXY" HideCondition="(OS_HAS_FILE = &quot;&quot;)"  />
             
-                <Control Id="URLLabel" Type="Text" X="10" Y="145" Width="55" Height="15" Text="Cloud URL:" />
-                <Control Id="URL" Type="Edit" X="65" Y="145" Width="290" Height="18" Property="URL" />
+                <Control Id="URLLabel" Type="Text" X="10" Y="145" Width="55" Height="15" Text="Cloud URL:" HideCondition="(OS_HAS_FILE = &quot;&quot;)"  />
+                <Control Id="URL" Type="Edit" X="65" Y="145" Width="290" Height="18" Property="URL" HideCondition="(OS_HAS_FILE = &quot;&quot;)"  />
 
-                <Control Id="InsecureCheckbox" Type="CheckBox" X="10" Y="160" Width="290" Height="15" Property="INSECURE" CheckBoxValue="0"  Text="Insecure" />
+                <Control Id="InsecureCheckbox" Type="CheckBox" X="10" Y="160" Width="290" Height="15" Property="INSECURE" CheckBoxValue="0"  Text="Insecure" HideCondition="(OS_HAS_FILE = &quot;&quot;)"  />
             
                 <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" />
                 <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)" />
@@ -255,3 +255,4 @@
         </UI>
     </Fragment>
 </Wix>
+

--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -25,6 +25,11 @@
 
             <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
 
+            <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Access Netdata dashboard" />
+            <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1" />
+            <Property Id="WixShellExecTarget" Value="http://localhost:19999" />
+            <CustomAction Id="LaunchApplication" DllEntry="WixShellExec" Impersonate="yes" BinaryRef="Wix4UtilCA_X86" />
+
             <Feature Id="Main">
                 <ComponentGroupRef Id="NetdataComponents" />
                 <ComponentRef Id="NetdataVarCache" />
@@ -142,6 +147,7 @@
             <DialogRef Id="UserExit" />
 
             <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999" />
+            <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="LaunchApplication" Condition="WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed" />
 
             <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="ViewLicenseDlg1" Condition="NOT Installed" />
             <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Condition="Installed AND PATCH" />

--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -231,8 +231,8 @@
                 <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="15" Transparent="yes" NoPrefix="yes" Text="Enter your Space's Claim Token and the Room IDs where you want to add the Agent." />
                 <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="Connect to the Cloud" />
 
-                <Control Id="WarningLabelOld" Type="Text" X="10" Y="60" Width="350" Height="15" Text="Agent already claimed. Click Next. If you want to connect, enter your Claim Token and Room ID(s)" />
-                <Control Id="WarningLabelNew" Type="Text" X="10" Y="75" Width="350" Height="15" Text=" to connect your Agent to Netdata Cloud." />
+                <Control Id="WarningLabelOld" Type="Text" X="10" Y="60" Width="350" Height="15" Text="Agent already claimed. Click Next." />
+                <Control Id="WarningLabelNew0" Type="Text" X="10" Y="75" Width="350" Height="15" Text="If you want to connectto Netdata Cloud, enter your Claim Token and Room ID(s)." />
 
                 <Control Id="TokenLabel" Type="Text" X="10" Y="100" Width="55" Height="15" Text="Claim Token:" />
                 <Control Id="Token" Type="Edit" X="65" Y="100" Width="290" Height="18" Property="TOKEN" Text="{135}" />

--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -38,6 +38,10 @@
                 <ComponentRef Id="NetdataService" />
             </Feature>
 
+            <UI Id="FeatureTree_ViewLicense_X64">
+            </UI>
+            <UIRef Id="FeatureTree_ViewLicense" />
+
             <WixVariable Id="WixUIBannerBmp" Value="Top.bmp" />
             <WixVariable Id="WixUIDialogBmp" Value="BackGround.bmp" />
             <UIRef Id="WixUI_ErrorProgressText" />
@@ -118,15 +122,6 @@
                                 Name="Netdata"
                                 Wait="yes" />
             </Component>
-    </Fragment>
-
-    <Fragment>
-            <UI Id="FeatureTree_ViewLicense_X64">
-                <Publish Dialog="ViewLicenseDlg1" Control="Print" Event="DoAction" Value="WixUIPrintEula_X64" />
-                <Publish Dialog="ViewLicenseDlg2" Control="Print" Event="DoAction" Value="WixUIPrintEula_X64" />
-            </UI>
-
-            <UIRef Id="FeatureTree_ViewLicense" />
     </Fragment>
 
     <Fragment>

--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -233,7 +233,7 @@
                 <Control Id="WarningLabel" Type="Text" X="10" Y="60" Width="290" Height="15" Text="Agent already claimed? Click Next." />
 
                 <Control Id="TokenLabel" Type="Text" X="10" Y="90" Width="55" Height="15" Text="Claim Token:" />
-                <Control Id="Token" Type="Edit" X="65" Y="90" Width="290" Height="18" Property="TOKEN" />
+                <Control Id="Token" Type="Edit" X="65" Y="90" Width="290" Height="18" Property="TOKEN" Text="{135}" />
             
                 <Control Id="RoomsLabel" Type="Text" X="10" Y="105" Width="55" Height="15" Text="Rooms ID(s):" />
                 <Control Id="Rooms" Type="Edit" X="65" Y="105" Width="290" Height="18" Property="ROOMS" />

--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -151,7 +151,7 @@
 
             <Publish Dialog="ViewLicenseDlg2" Control="Back" Event="NewDialog" Value="ViewLicenseDlg1" />
             <Publish Dialog="ViewLicenseDlg2" Control="Next" Event="NewDialog" Value="NDConfigDialog" Condition="NOT ETCNETDATACLAIMFILE" />
-            <Publish Dialog="ViewLicenseDlg2" Control="Next" Event="NewDialog" Value="NDConfigDialog" Condition="ETCNETDATACLAIMFILE" />
+            <Publish Dialog="ViewLicenseDlg2" Control="Next" Event="NewDialog" Value="InstallDirDlg" Condition="ETCNETDATACLAIMFILE" />
 
             <Publish Dialog="NDConfigDialog" Control="Back" Event="NewDialog" Value="ViewLicenseDlg2" />
             <Publish Dialog="NDConfigDialog" Control="Next" Event="NewDialog" Value="InstallDirDlg" />

--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -164,7 +164,7 @@
             <Publish Dialog="NDConfigDialog" Control="Back" Event="NewDialog" Value="ViewLicenseDlg2" />
             <Publish Dialog="NDConfigDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Condition="((TOKEN = &quot;&quot;) AND (ROOMS = &quot;&quot;)) OR ((NOT (TOKEN = &quot;&quot;)) AND (NOT (ROOMS = &quot;&quot;)))" />
 
-            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg" Order="1" Condition="NOT Installed OR WixUI_InstallMode = &quot;Change&quot;" />
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="NDConfigDialog" Order="1" Condition="NOT Installed OR WixUI_InstallMode = &quot;Change&quot;" />
             <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2" Condition="Installed AND NOT PATCH" />
             <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="3" Condition="Installed AND PATCH" />
             <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg" />
@@ -172,6 +172,7 @@
             <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg" />
             <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg" />
             <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg" />
+
         </UI>
 
         <UIRef Id="WixUI_Common" />
@@ -231,8 +232,8 @@
                 <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="15" Transparent="yes" NoPrefix="yes" Text="Enter your Space's Claim Token and the Room IDs where you want to add the Agent." />
                 <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="Connect to the Cloud" />
 
-                <Control Id="WarningLabelOld" Type="Text" X="10" Y="60" Width="350" Height="15" Text="Agent already claimed. Click Next." />
-                <Control Id="WarningLabelNew0" Type="Text" X="10" Y="75" Width="350" Height="15" Text="If you want to connectto Netdata Cloud, enter your Claim Token and Room ID(s)." />
+                <Control Id="WarningLabelOld" Type="Text" X="10" Y="60" Width="350" Height="15" Text="Agent already claimed? Click Next." />
+                <Control Id="WarningLabelNew0" Type="Text" X="10" Y="75" Width="350" Height="15" Text="If you want to connect to Netdata Cloud, enter your Claim Token and Room ID(s)." />
 
                 <Control Id="TokenLabel" Type="Text" X="10" Y="100" Width="55" Height="15" Text="Claim Token:" />
                 <Control Id="Token" Type="Edit" X="65" Y="100" Width="290" Height="18" Property="TOKEN" Text="{135}" />

--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -151,15 +151,17 @@
             <Publish Dialog="ViewLicenseDlg1" Control="Next" Event="NewDialog" Value="ViewLicenseDlg2" />
 
             <Publish Dialog="ViewLicenseDlg2" Control="Back" Event="NewDialog" Value="ViewLicenseDlg1" />
-            <Publish Dialog="ViewLicenseDlg2" Control="Next" Event="NewDialog" Value="InstallDirDlg" />
+            <Publish Dialog="ViewLicenseDlg2" Control="Next" Event="NewDialog" Value="NDConfigDialog" />
 
-            <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="ViewLicenseDlg2" />
+            <!-- We are hidden for while the directory to install netdata and forcing a default, because it is still necessary adjusts to test claim.conf in different directories -->
+
+            <!-- Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="ViewLicenseDlg2" />
             <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="NDConfigDialog" Order="20" />
             <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="10" />
             <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="10" />
-            <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="20" />
+            <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="20" / -->
 
-            <Publish Dialog="NDConfigDialog" Control="Back" Event="NewDialog" Value="InstallDirDlg" />
+            <Publish Dialog="NDConfigDialog" Control="Back" Event="NewDialog" Value="ViewLicenseDlg2" />
             <Publish Dialog="NDConfigDialog" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Condition="((TOKEN = &quot;&quot;) AND (ROOMS = &quot;&quot;)) OR ((NOT (TOKEN = &quot;&quot;)) AND (NOT (ROOMS = &quot;&quot;)))" />
 
             <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg" Order="1" Condition="NOT Installed OR WixUI_InstallMode = &quot;Change&quot;" />

--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -53,11 +53,11 @@
                 </Directory>
             </StandardDirectory>
 
-            <Property Id="OS_HAS_FILE" Secure="yes">
+            <!-- Property Id="OS_HAS_FILE" Secure="yes">
                 <DirectorySearch Id="NetCoreDirectoryFoundx64" Path="[ETCDIRNETDATA]" AssignToProperty="yes" >
                     <FileSearch Id="NetdataClaim" Name="claim.conf"/>
                 </DirectorySearch>
-            </Property>
+            </Property -->
 
             <UI Id="FeatureTree_ViewLicense_X64">
             </UI>
@@ -231,22 +231,22 @@
                 <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="15" Transparent="yes" NoPrefix="yes" Text="Enter your Space's Claim Token and the Room IDs where you want to add the Agent." />
                 <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="Connect to the Cloud" />
 
-                <Control Id="WarningLabelOld" Type="Text" X="10" Y="60" Width="350" Height="15" Text="Your host was already claimed. Click 'Next'." HideCondition="NOT (OS_HAS_FILE = &quot;&quot;)" />
-                <Control Id="WarningLabelNew" Type="Text" X="10" Y="60" Width="350" Height="15" Text="For a first-time installation, please complete the 'Claim Token' and 'Rooms ID(s)' fields." HideCondition="(OS_HAS_FILE = &quot;&quot;)" />
+                <Control Id="WarningLabelOld" Type="Text" X="10" Y="60" Width="350" Height="15" Text="Agent already claimed. Click Next. If you want to connect, enter your Claim Token and Room ID(s)" />
+                <Control Id="WarningLabelNew" Type="Text" X="10" Y="75" Width="350" Height="15" Text=" to connect your Agent to Netdata Cloud." />
 
-                <Control Id="TokenLabel" Type="Text" X="10" Y="100" Width="55" Height="15" Text="Claim Token:" HideCondition="(OS_HAS_FILE = &quot;&quot;)"  />
-                <Control Id="Token" Type="Edit" X="65" Y="100" Width="290" Height="18" Property="TOKEN" Text="{135}" HideCondition="(OS_HAS_FILE = &quot;&quot;)"  />
+                <Control Id="TokenLabel" Type="Text" X="10" Y="100" Width="55" Height="15" Text="Claim Token:" />
+                <Control Id="Token" Type="Edit" X="65" Y="100" Width="290" Height="18" Property="TOKEN" Text="{135}" />
             
-                <Control Id="RoomsLabel" Type="Text" X="10" Y="115" Width="55" Height="15" Text="Rooms ID(s):" HideCondition="(OS_HAS_FILE = &quot;&quot;)"  />
-                <Control Id="Rooms" Type="Edit" X="65" Y="115" Width="290" Height="18" Property="ROOMS" HideCondition="(OS_HAS_FILE = &quot;&quot;)"  />
+                <Control Id="RoomsLabel" Type="Text" X="10" Y="115" Width="55" Height="15" Text="Rooms ID(s):" />
+                <Control Id="Rooms" Type="Edit" X="65" Y="115" Width="290" Height="18" Property="ROOMS" />
             
-                <Control Id="ProxyLabel" Type="Text" X="10" Y="130" Width="55" Height="15" Text="Proxy URL:" HideCondition="(OS_HAS_FILE = &quot;&quot;)"  />
-                <Control Id="Proxy" Type="Edit" X="65" Y="130" Width="290" Height="18" Property="PROXY" HideCondition="(OS_HAS_FILE = &quot;&quot;)"  />
+                <Control Id="ProxyLabel" Type="Text" X="10" Y="130" Width="55" Height="15" Text="Proxy URL:" />
+                <Control Id="Proxy" Type="Edit" X="65" Y="130" Width="290" Height="18" Property="PROXY" />
             
-                <Control Id="URLLabel" Type="Text" X="10" Y="145" Width="55" Height="15" Text="Cloud URL:" HideCondition="(OS_HAS_FILE = &quot;&quot;)"  />
-                <Control Id="URL" Type="Edit" X="65" Y="145" Width="290" Height="18" Property="URL" HideCondition="(OS_HAS_FILE = &quot;&quot;)"  />
+                <Control Id="URLLabel" Type="Text" X="10" Y="145" Width="55" Height="15" Text="Cloud URL:" />
+                <Control Id="URL" Type="Edit" X="65" Y="145" Width="290" Height="18" Property="URL" />
 
-                <Control Id="InsecureCheckbox" Type="CheckBox" X="10" Y="160" Width="290" Height="15" Property="INSECURE" CheckBoxValue="0"  Text="Insecure" HideCondition="(OS_HAS_FILE = &quot;&quot;)"  />
+                <Control Id="InsecureCheckbox" Type="CheckBox" X="10" Y="160" Width="290" Height="15" Property="INSECURE" CheckBoxValue="0"  Text="Insecure" />
             
                 <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" />
                 <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)" />


### PR DESCRIPTION
##### Summary
This PR is bringing as updates to installer:

-  Launch Netdata when installation ends
- Fix button redirect
- Does not allow a token larger than expected.
- Does not allow users advance filling either Token or Room.

##### Test Plan

1. Compile this branch
2. Generate the installer
3. Install the final binary and verify that you do not have fields to claim the agent.
4. Remove Netdata and the claim.conf file.
5. Install netdata again, and this time you will have the fields to claim agent.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
