### PR TITLE
fix: exclude volumes w/o drive letter from disk_space_usage_alert

### DIFF
--- a/src/health/health.d/disks.conf
+++ b/src/health/health.d/disks.conf
@@ -12,7 +12,7 @@
        class: Utilization
         type: System
    component: Disk
-chart labels: mount_point=!/dev !/dev/* !/run !/run/* *
+chart labels: mount_point=!/dev !/dev/* !/run !/run/* !HarddiskVolume* *
         calc: $used * 100 / ($avail + $used)
        units: %
        every: 1m


### PR DESCRIPTION
##### Summary

Fixes: #18993

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
