### PR TITLE
fix(go.d/nvidia_smi): disable loop mode by default on Win

### DIFF
--- a/src/go/plugin/go.d/modules/nvidia_smi/nvidia_smi.go
+++ b/src/go/plugin/go.d/modules/nvidia_smi/nvidia_smi.go
@@ -5,6 +5,7 @@ package nvidia_smi
 import (
 	_ "embed"
 	"errors"
+	"runtime"
 	"time"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/agent/module"
@@ -28,8 +29,10 @@ func init() {
 func New() *NvidiaSmi {
 	return &NvidiaSmi{
 		Config: Config{
-			Timeout:  confopt.Duration(time.Second * 10),
-			LoopMode: true,
+			Timeout: confopt.Duration(time.Second * 10),
+			// Disable loop mode on Windows due to go.d.plugin's non-graceful exit
+			// which can leave `nvidia_smi` processes running indefinitely.
+			LoopMode: !(runtime.GOOS == "windows"),
 		},
 		binName: "nvidia-smi",
 		charts:  &module.Charts{},


### PR DESCRIPTION
##### Summary

Disable loop mode on Windows due to go.d.plugin's non-graceful exit, which can keep `nvidia_smi` processes running indefinitely.

On Windows, we'll rely on the [QUIT](https://github.com/netdata/netdata/pull/19038) command instead of signals (when implemented in the Agent).

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
