### PR TITLE
Add a special version number to bypass alert snapshots

### DIFF
--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -787,6 +787,16 @@ done:
 
 static void schedule_alert_snapshot_if_needed(struct aclk_sync_cfg_t *wc, uint64_t cloud_version)
 {
+    if (cloud_version == 1) {
+        nd_log(
+            NDLS_ACCESS,
+            NDLP_NOTICE,
+            "Cloud requested not to verify alert version for host \"%s\", node \"%s\"",
+            rrdhost_hostname(wc->host),
+            wc->node_id);
+        return;
+    }
+
     uint64_t local_version = calculate_node_alert_version(wc->host);
     if (local_version != cloud_version) {
         nd_log(

--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -791,7 +791,7 @@ static void schedule_alert_snapshot_if_needed(struct aclk_sync_cfg_t *wc, uint64
         nd_log(
             NDLS_ACCESS,
             NDLP_NOTICE,
-            "Cloud requested not to verify alert version for host \"%s\", node \"%s\"",
+            "Cloud requested to skip alert version verification for host \"%s\", node \"%s\"",
             rrdhost_hostname(wc->host),
             wc->node_id);
         return;


### PR DESCRIPTION
##### Summary
- When the cloud includes version=1 in start streaming alerts  or version check, the agent will not perform a version check for snapshot
