### PR TITLE
Register service to delay start

### DIFF
--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -131,6 +131,12 @@
                                 Remove="uninstall"
                                 Name="Netdata"
                                 Wait="yes" />
+
+                 <RegistryValue Root="HKLM"
+                               Key="System\CurrentControlSet\Services\Netdata"
+                               Name="DelayedAutoStart"
+                               Value="1"
+                               Type="integer" />
             </Component>
     </Fragment>
 


### PR DESCRIPTION
##### Summary
- Register Agent service to `Automatic (delay start)`  when rebooting / starting a windows machines
  - We noticed that when it is configured as `Automatic` some metrics may be missing
    - This requires a service restart to resolve
- Existing installed Agent need to reconfigure the service to ` Automatic (delay start)`
