### PR TITLE
Collector configuration page edits

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -95,7 +95,6 @@ Use the alphabetized list below to find the answer to your single-term questions
 
 - [**Metrics Streaming Replication**](/docs/observability-centralization-points/README.md): Each node running Netdata can stream the metrics it collects, in real time, to another node. Metric streaming allows you to replicate metrics data across multiple nodes, or centralize all your metrics data into a single time-series database (TSDB).
 
-- [**Module**](/src/collectors/REFERENCE.md#enable-and-disable-a-specific-collection-module): A type of collector.
 
 ## N
 

--- a/docs/netdata-agent/configuration/common-configuration-changes.md
+++ b/docs/netdata-agent/configuration/common-configuration-changes.md
@@ -37,18 +37,8 @@ of 5 seconds.
 Every collector and plugin has its own `update every` setting, which you can also change in the `go.d.conf`,
 `python.d.conf` or `charts.d.conf` files, or in individual collector configuration files. If the `update
 every` for an individual collector is less than the global, the Netdata Agent uses the global setting. See
-the [enable or configure a collector](/src/collectors/REFERENCE.md#enable-and-disable-a-specific-collection-module)
+the [enable or configure a collector](/src/collectors/REFERENCE.md)
 doc for details.
-
-### Disable a collector or plugin
-
-Turn off entire plugins in
-the [`[plugins]` section](/src/daemon/config/README.md#plugins-section-options)
-of
-`netdata.conf`.
-
-To disable specific collectors, open `go.d.conf`, `python.d.conf` or `charts.d.conf` and find the line
-for that specific module. Uncomment the line and change its value to `no`.
 
 ## Modify alerts and notifications
 

--- a/docs/netdata-agent/configuration/common-configuration-changes.md
+++ b/docs/netdata-agent/configuration/common-configuration-changes.md
@@ -21,25 +21,6 @@ changes reflected in those visualizations due to the way Netdata Cloud proxies m
 
 Read our doc on [increasing long-term metrics storage](/docs/netdata-agent/configuration/optimizing-metrics-database/change-metrics-storage.md) for details.
 
-### Reduce the data collection frequency
-
-Change `update every` in
-the [`[global]` section](/src/daemon/config/README.md#global-section-options)
-of `netdata.conf` so
-that it is greater than `1`. An `update every` of `5` means the Netdata Agent enforces a _minimum_ collection frequency
-of 5 seconds.
-
-```text
-[global]
-    update every = 5
-```
-
-Every collector and plugin has its own `update every` setting, which you can also change in the `go.d.conf`,
-`python.d.conf` or `charts.d.conf` files, or in individual collector configuration files. If the `update
-every` for an individual collector is less than the global, the Netdata Agent uses the global setting. See
-the [enable or configure a collector](/src/collectors/REFERENCE.md)
-doc for details.
-
 ## Modify alerts and notifications
 
 Netdata's health monitoring watchdog uses hundreds of pre-configured health entities, with intelligent thresholds, to

--- a/docs/netdata-agent/configuration/optimize-the-netdata-agents-performance.md
+++ b/docs/netdata-agent/configuration/optimize-the-netdata-agents-performance.md
@@ -201,7 +201,7 @@ collects and visualizes metrics on application resource utilization:
     update every = 5
 ```
 
-To [configure an individual collector](/src/collectors/REFERENCE.md#configure-a-collector),
+To configure an individual collector,
 open its specific configuration file with `edit-config` and look for the `update_every` setting. For example, to reduce
 the frequency of the `nginx` collector, run `sudo ./edit-config go.d/nginx.conf`:
 

--- a/src/collectors/COLLECTORS.md
+++ b/src/collectors/COLLECTORS.md
@@ -3,7 +3,7 @@
 Netdata uses collectors to help you gather metrics from your favorite applications and services and view them in
 real-time, interactive charts. The following list includes all the integrations where Netdata can gather metrics from.
 
-Learn more about [how collectors work](/src/collectors/README.md), and then learn how to [enable or configure](/src/collectors/REFERENCE.md#enable-and-disable-a-specific-collection-module) a specific collector.
+Learn more about [how collectors work](/src/collectors/README.md), and then learn how to [enable or configure](/src/collectors/REFERENCE.md#enable-or-disable-collectors-and-plugins) a specific collector.
 
 > **Note**
 >

--- a/src/collectors/README.md
+++ b/src/collectors/README.md
@@ -11,11 +11,10 @@ If you don't see charts for your application, check our collectors' [configurati
 
 Netdata's collectors are specialized data collection plugins that gather metrics from various sources. They are divided into two main categories:
 
-| Type     | Description                                                           | Key Features                                                                                                                                                                                                           |
-|----------|-----------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Internal | Native collectors that gather system-level metrics                    | • Written in `C` for optimal performance<br/>• Run as threads within Netdata daemon<br/>• Zero external dependencies<br/>• Minimal system overhead                                                                        |
+| Type     | Description                                                           | Key Features                                                                                                                                                                                                               |
+|----------|-----------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Internal | Native collectors that gather system-level metrics                    | • Written in `C` for optimal performance<br/>• Run as threads within Netdata daemon<br/>• Zero external dependencies<br/>• Minimal system overhead                                                                         |
 | External | Modular collectors that gather metrics from applications and services | • Support multiple programming languages<br/>• Run as independent processes<br/>• Communicate via pipes with Netdata<br/>• Managed by [plugins.d](/src/plugins.d/README.md)<br/>• Examples: MySQL, Nginx, Redis collectors |
-
 
 ## Collector Privileges
 

--- a/src/collectors/REFERENCE.md
+++ b/src/collectors/REFERENCE.md
@@ -3,7 +3,7 @@
 The list of supported collectors can be found in the [Collecting Metrics](/src/collectors/README.md) section,
 and on [our website](https://www.netdata.cloud/integrations).
 
-The documentation of each Collector provides all the necessary configuration options and prerequisites for that collector. In most cases, either the charts are automatically generated without any configuration, or you just fulfil those prerequisites and configure the collector.
+The documentation of each Collector provides all the necessary configuration options and prerequisites for that collector. In most cases, either the charts are automatically generated without any configuration, or you fulfil those prerequisites and configure the collector.
 
 > **Info**
 >
@@ -38,7 +38,7 @@ After you make your changes, restart the Agent with the [appropriate method](/do
 
 ## Adjust data collection frequency
 
-In some scenarios you might want to increase or decrease the data collection frequency of the Collectors as it directly affects CPU utilization.
+In some scenarios, you might want to increase or decrease the data collection frequency of the Collectors as it directly affects CPU utilization.
 
 ### Global
 
@@ -49,7 +49,7 @@ The default is `1`, meaning that the Agent collects metrics every second.
 > **Note**
 >
 > If the `update every` for an individual collector is less than the global, the Netdata Agent uses the global setting.
-If you change this to `2`, Netdata enforces a minimum `update every` setting of 2 seconds, and collects metrics every other second, which will effectively halve CPU utilization.
+> If you change this to `2`, Netdata enforces a minimum `update every` setting of 2 seconds, and collects metrics every other second, which will effectively halve CPU utilization.
 
 ```text
 [global]
@@ -64,7 +64,7 @@ After you make your changes, restart the Agent with the [appropriate method](/do
 
 Every Collector and Plugin have their own `update every` settings, which you can also change in their respective configuration files.
 
-To reduce the collection frequency of a [Plugin](/src/collectors/README.md#collector-architecture-and-terminology), open `netdata.conf` using [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config) and find the appropriate section.
+To reduce the collection frequency of a plugin, open `netdata.conf` using [`edit-config`](/docs/netdata-agent/configuration/README.md#edit-a-configuration-file-using-edit-config) and find the appropriate section.
 
 For example, to reduce the frequency of the `apps` plugin:
 


### PR DESCRIPTION
##### Summary

@ilyam8 I would also consider the placing of this on Learn, it feels out of place being inside the "Collecting Metrics" section, it is an Agent configuration process mostly, what do you think?

I also don't like docs/netdata-agent/configuration/common-configuration-changes.md as a file, but I will decide what to do on it once the rest of the closed PR is split.