### PR TITLE
Queue alert transition store to the metadata thread

### DIFF
--- a/src/database/rrd.h
+++ b/src/database/rrd.h
@@ -1060,6 +1060,7 @@ struct alarm_entry {
     RRDCALC_STATUS new_status;
 
     uint32_t flags;
+    bool pending_save;
 
     int delay;
     time_t delay_up_to_timestamp;

--- a/src/database/sqlite/sqlite_metadata.h
+++ b/src/database/sqlite/sqlite_metadata.h
@@ -62,6 +62,8 @@ int sql_init_meta_database(db_check_action_type_t rebuild, int memory);
 void cleanup_agent_event_log(void);
 void add_agent_event(event_log_type_t event_id, int64_t value);
 usec_t get_agent_event_time_median(event_log_type_t event_id);
+void metadata_queue_ae_save(RRDHOST *host, ALARM_ENTRY *ae);
+void metadata_queue_ae_deletion(ALARM_ENTRY *ae);
 
 // UNIT TEST
 int metadata_unittest(void);


### PR DESCRIPTION
##### Summary
- Queue alert transitions to the metadata event loop to be saved
  - This unblocks receivers (children) that disconnect because they generate REMOVED transitions
- Handle deleting alert entries as well
   - During cleanup of alert transitions, if the alert transition has not been saved, let the event loop handle the deletion after the transition has been committed to the database.