### PR TITLE
Reset parameter when generating an alert snapshot

### DIFF
--- a/src/database/sqlite/sqlite_aclk_alert.c
+++ b/src/database/sqlite/sqlite_aclk_alert.c
@@ -536,6 +536,7 @@ void rebuild_host_alert_version_table(RRDHOST *host)
     if (!PREPARE_STATEMENT(db_meta, SQL_REBUILD_HOST_ALERT_VERSION_TABLE, &res))
         return;
 
+    param = 0;
     SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, &host->host_id.uuid, sizeof(host->host_id.uuid), SQLITE_STATIC));
 
     param = 0;


### PR DESCRIPTION
##### Summary
- Fix an issue with parameter initialization during snapshot rebuild
