### PR TITLE
change dim order because of colours in reboot_required

### DIFF
--- a/src/collectors/proc.plugin/run_reboot_required.c
+++ b/src/collectors/proc.plugin/run_reboot_required.c
@@ -57,15 +57,15 @@ int do_run_reboot_required(int update_every, usec_t dt) {
             update_every,
             RRDSET_TYPE_LINE);
 
-        rd_required = rrddim_add(st, "required", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
         rd_not_required = rrddim_add(st, "not_required", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        rd_required = rrddim_add(st, "required", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
     }
 
     struct stat buf;
     bool exists = (stat(signal_file_path, &buf) == 0);
 
-    rrddim_set_by_pointer(st, rd_required, exists ? 1 : 0);
     rrddim_set_by_pointer(st, rd_not_required, exists ? 0 : 1);
+    rrddim_set_by_pointer(st, rd_required, exists ? 1 : 0);
     rrdset_done(st);
 
     return 0;


### PR DESCRIPTION
##### Summary

I didn't notice that "not_required" was red.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
