### PR TITLE
Reduce EBPF memory usage

### DIFF
--- a/src/collectors/ebpf.plugin/ebpf.c
+++ b/src/collectors/ebpf.plugin/ebpf.c
@@ -993,8 +993,8 @@ static inline void ebpf_create_apps_for_module(ebpf_module_t *em, struct ebpf_ta
  */
 static void ebpf_create_apps_charts(struct ebpf_target *root)
 {
-    if (unlikely(!ebpf_pids))
-        return;
+//    if (unlikely(!ebpf_pids))
+//        return;
 
     struct ebpf_target *w;
     int newly_added = 0;
@@ -2675,7 +2675,7 @@ static void ebpf_allocate_common_vectors()
 {
     ebpf_judy_pid.pid_table = ebpf_allocate_pid_aral(NETDATA_EBPF_PID_SOCKET_ARAL_TABLE_NAME,
                                                      sizeof(netdata_ebpf_judy_pid_stats_t));
-    ebpf_pids = callocz((size_t)pid_max, sizeof(ebpf_pid_data_t));
+//    ebpf_pids = callocz((size_t)pid_max, sizeof(ebpf_pid_data_t));
     ebpf_aral_init();
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -620,7 +620,7 @@ static inline void link_all_processes_to_their_parents(void)
 
 //        pp = &ebpf_pids[p->ppid];
         pp = ebpf_find_pid_data(p->ppid);
-        if (likely(pp->pid)) {
+        if (likely(pp && pp->pid)) {
             p->parent = pp;
             pp->children_count++;
 

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -312,7 +312,7 @@ SPINLOCK ebpf_pid_spinlock = NETDATA_SPINLOCK_INITIALIZER;
 void ebpf_pid_del(pid_t pid)
 {
     spinlock_lock(&ebpf_pid_spinlock);
-    (void) JudyLDel(ebpf_pid_judyL, (Word_t) pid, PJE0);
+    (void) JudyLDel(&ebpf_pid_judyL, (Word_t) pid, PJE0);
     spinlock_unlock(&ebpf_pid_spinlock);
 }
 

--- a/src/collectors/ebpf.plugin/ebpf_apps.c
+++ b/src/collectors/ebpf.plugin/ebpf_apps.c
@@ -340,7 +340,7 @@ ebpf_pid_data_t *ebpf_find_or_create_pid_data(pid_t pid)
     ebpf_pid_data_t *pid_data = ebpf_find_pid_data_unsafe(pid);
     if (!pid_data) {
         Pvoid_t *Pvalue = JudyLIns(&ebpf_pid_judyL, (Word_t) pid, PJE0);
-        internal_fatal(!PValue || PValue == PJERR, "EBPF: pid judy array");
+        internal_fatal(!Pvalue || Pvalue == PJERR, "EBPF: pid judy array");
         if (likely(!*Pvalue))
             *Pvalue = pid_data = callocz(1, sizeof(*pid_data));
         else

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -201,7 +201,7 @@ typedef struct __attribute__((packed)) ebpf_pid_data {
 
 } ebpf_pid_data_t;
 
-extern ebpf_pid_data_t *ebpf_pids;
+//extern ebpf_pid_data_t *ebpf_pids;
 extern ebpf_pid_data_t *ebpf_pids_link_list;
 extern size_t ebpf_all_pids_count;
 extern size_t ebpf_hash_table_pids_count;
@@ -303,8 +303,11 @@ static inline void ebpf_process_release_publish(ebpf_publish_process_t *ptr)
     freez(ptr);
 }
 
+ebpf_pid_data_t *ebpf_find_pid_data(pid_t pid);
+
 static inline ebpf_pid_data_t *ebpf_get_pid_data(uint32_t pid, uint32_t tgid, char *name, uint32_t idx) {
-    ebpf_pid_data_t *ptr = &ebpf_pids[pid];
+//    ebpf_pid_data_t *ptr = &ebpf_pids[pid];
+    ebpf_pid_data_t *ptr = ebpf_find_pid_data(pid);
     ptr->thread_collecting |= 1<<idx;
     // The caller is getting data to work.
     if (!name && idx != EBPF_PIDS_PROC_FILE)

--- a/src/collectors/ebpf.plugin/ebpf_apps.h
+++ b/src/collectors/ebpf.plugin/ebpf_apps.h
@@ -303,11 +303,11 @@ static inline void ebpf_process_release_publish(ebpf_publish_process_t *ptr)
     freez(ptr);
 }
 
-ebpf_pid_data_t *ebpf_find_pid_data(pid_t pid);
+ebpf_pid_data_t *ebpf_find_or_create_pid_data(pid_t pid);
 
 static inline ebpf_pid_data_t *ebpf_get_pid_data(uint32_t pid, uint32_t tgid, char *name, uint32_t idx) {
 //    ebpf_pid_data_t *ptr = &ebpf_pids[pid];
-    ebpf_pid_data_t *ptr = ebpf_find_pid_data(pid);
+    ebpf_pid_data_t *ptr = ebpf_find_or_create_pid_data(pid);
     ptr->thread_collecting |= 1<<idx;
     // The caller is getting data to work.
     if (!name && idx != EBPF_PIDS_PROC_FILE)


### PR DESCRIPTION
##### Summary
- Hold process ids in an judy array (as needed)) instead of pre-allocating structures
