### PR TITLE
Modify Claim Screen (Windows Installer)

### DIFF
--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+
 <Wix
     xmlns="http://wixtoolset.org/schemas/v4/wxs"
     xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util"

--- a/packaging/windows/netdata.wxs.in
+++ b/packaging/windows/netdata.wxs.in
@@ -70,12 +70,6 @@
                 </Directory>
             </StandardDirectory>
 
-            <!-- Property Id="OS_HAS_FILE" Secure="yes">
-                <DirectorySearch Id="NetCoreDirectoryFoundx64" Path="[ETCDIRNETDATA]" AssignToProperty="yes" >
-                    <FileSearch Id="NetdataClaim" Name="claim.conf"/>
-                </DirectorySearch>
-            </Property -->
-
             <UI Id="FeatureTree_ViewLicense_X64">
             </UI>
             <UIRef Id="FeatureTree_ViewLicense" />
@@ -277,6 +271,13 @@
     </Fragment>
 
     <Fragment>
+        <Property Id="OS_HAS_FILE">
+            <!-- Our variables are not defined during startup so we have to use this -->
+            <DirectorySearch Id="NetCoreDirectoryFoundx64" Path="C:\Program Files\Netdata\etc\netdata\">
+                <FileSearch Name="claim.conf" />
+            </DirectorySearch>
+        </Property>
+
         <UI>
             <Dialog Id="NDConfigDialog" Width="370" Height="270" Title="Netdata Cloud">
                 <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.LicenseAgreementDlgBannerBitmap)" />
@@ -285,21 +286,21 @@
                 <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="15" Transparent="yes" NoPrefix="yes" Text="Enter your Space's Claim Token and the Room IDs where you want to add the Agent." />
                 <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="Connect to the Cloud" />
 
-                <Control Id="WarningLabelOld" Type="Text" X="10" Y="60" Width="350" Height="15" Text="Agent already claimed? Click Next." />
+                <Control Id="WarningLabel" Type="Text" X="10" Y="60" Width="350" Height="15" Text="Agent already claimed! Click Next." HideCondition="NOT OS_HAS_FILE" />
 
-                <Control Id="TokenLabel" Type="Text" X="10" Y="100" Width="55" Height="15" Text="Claim Token:" />
-                <Control Id="Token" Type="Edit" X="65" Y="100" Width="290" Height="18" Property="TOKEN" Text="{135}" />
+                <Control Id="TokenLabel" Type="Text" X="10" Y="100" Width="55" Height="15" Text="Claim Token:" HideCondition="OS_HAS_FILE" />
+                <Control Id="Token" Type="Edit" X="65" Y="100" Width="290" Height="18" Property="TOKEN" Text="{135}" HideCondition="OS_HAS_FILE" />
             
-                <Control Id="RoomsLabel" Type="Text" X="10" Y="115" Width="55" Height="15" Text="Rooms ID(s):" />
-                <Control Id="Rooms" Type="Edit" X="65" Y="115" Width="290" Height="18" Property="ROOMS" />
+                <Control Id="RoomsLabel" Type="Text" X="10" Y="115" Width="55" Height="15" Text="Rooms ID(s):" HideCondition="OS_HAS_FILE" />
+                <Control Id="Rooms" Type="Edit" X="65" Y="115" Width="290" Height="18" Property="ROOMS" HideCondition="OS_HAS_FILE" />
             
-                <Control Id="ProxyLabel" Type="Text" X="10" Y="130" Width="55" Height="15" Text="Proxy URL:" />
-                <Control Id="Proxy" Type="Edit" X="65" Y="130" Width="290" Height="18" Property="PROXY" />
+                <Control Id="ProxyLabel" Type="Text" X="10" Y="130" Width="55" Height="15" Text="Proxy URL:" HideCondition="OS_HAS_FILE" />
+                <Control Id="Proxy" Type="Edit" X="65" Y="130" Width="290" Height="18" Property="PROXY" HideCondition="OS_HAS_FILE" />
             
-                <Control Id="URLLabel" Type="Text" X="10" Y="145" Width="55" Height="15" Text="Cloud URL:" />
-                <Control Id="URL" Type="Edit" X="65" Y="145" Width="290" Height="18" Property="URL" />
+                <Control Id="URLLabel" Type="Text" X="10" Y="145" Width="55" Height="15" Text="Cloud URL:" HideCondition="OS_HAS_FILE" />
+                <Control Id="URL" Type="Edit" X="65" Y="145" Width="290" Height="18" Property="URL" HideCondition="OS_HAS_FILE" />
 
-                <Control Id="InsecureCheckbox" Type="CheckBox" X="10" Y="160" Width="290" Height="15" Property="INSECURE" CheckBoxValue="0"  Text="Insecure" />
+                <Control Id="InsecureCheckbox" Type="CheckBox" X="10" Y="160" Width="290" Height="15" Property="INSECURE" CheckBoxValue="0"  Text="Insecure" HideCondition="OS_HAS_FILE" />
             
                 <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" />
                 <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)" />


### PR DESCRIPTION
##### Summary
This PR is modifying our installer to hide all fields on Claim Screen when there is already a claim.conf file generated during installation time.

##### Test Plan

1. Compile this branch
2. Make an installer
3. Remove your netdata using Windows Control Panel
4. If you already claimed your agent, rename your `c:\Program Files\Netdata\etc\netdata\claim.conf` and run the installer. You should have the following screen:

![without](https://github.com/user-attachments/assets/835d907f-3beb-4968-b554-14571fe341e1)

5. Stop the installation, and rename the file again to `c:\Program Files\Netdata\etc\netdata\claim.conf` . Run the installer again, this time you will have the following screen:

![with](https://github.com/user-attachments/assets/8b91f0f3-370b-4e18-87f3-168d27b34004)


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
Describe the PR affects users: 
- Which area of Netdata is affected by the change? Installer
- Can they see the change or is it an under the hood? If they can see it, where? Only when installing software.
- How is the user impacted by the change? They have a clear vision about connection with cloud.
- What are there any benefits of the change? Avoid confusions and save time during installation.
</details>
