### PR TITLE
rw_spinlocks: allow recursive readers, even when writers are waiting

### DIFF
--- a/src/libnetdata/locks/rw-spinlock.c
+++ b/src/libnetdata/locks/rw-spinlock.c
@@ -7,26 +7,14 @@
 
 void rw_spinlock_init_with_trace(RW_SPINLOCK *rw_spinlock, const char *func) {
     rw_spinlock->readers = 0;
-    rw_spinlock->writers_waiting = 0;
     spinlock_init_with_trace(&rw_spinlock->spinlock, func);
 }
 
 void rw_spinlock_read_lock_with_trace(RW_SPINLOCK *rw_spinlock, const char *func) {
-    size_t spins = 0;
-    while(1) {
-        spinlock_lock_with_trace(&rw_spinlock->spinlock, func);
-        if (!rw_spinlock->writers_waiting) {
-            __atomic_add_fetch(&rw_spinlock->readers, 1, __ATOMIC_RELAXED);
-            spinlock_unlock_with_trace(&rw_spinlock->spinlock, func);
-            break;
-        }
+    spinlock_lock_with_trace(&rw_spinlock->spinlock, func);
+    __atomic_add_fetch(&rw_spinlock->readers, 1, __ATOMIC_RELAXED);
+    spinlock_unlock_with_trace(&rw_spinlock->spinlock, func);
 
-        spinlock_unlock_with_trace(&rw_spinlock->spinlock, func);
-        yield_the_processor(); // let the writer run
-        spins++;
-    }
-
-    worker_spinlock_contention(func, spins);
     nd_thread_rwspinlock_read_locked();
 }
 
@@ -44,24 +32,15 @@ void rw_spinlock_read_unlock_with_trace(RW_SPINLOCK *rw_spinlock, const char *fu
 
 void rw_spinlock_write_lock_with_trace(RW_SPINLOCK *rw_spinlock, const char *func) {
     size_t spins = 0;
-    for(size_t i = 1; true ;i++) {
+    while(true) {
         spinlock_lock_with_trace(&rw_spinlock->spinlock, func);
 
-        if(__atomic_load_n(&rw_spinlock->readers, __ATOMIC_RELAXED) == 0) {
-            if(spins != 0)
-                rw_spinlock->writers_waiting--;
+        if(__atomic_load_n(&rw_spinlock->readers, __ATOMIC_RELAXED) == 0)
             break;
-        }
-
-        if(spins == 0)
-            rw_spinlock->writers_waiting++;
 
         // Busy wait until all readers have released their locks.
         spinlock_unlock_with_trace(&rw_spinlock->spinlock, func);
-        if(i == 8 * 2) {
-            i = 0;
-            tinysleep();
-        }
+        tinysleep();
         spins++;
     }
 

--- a/src/libnetdata/locks/rw-spinlock.h
+++ b/src/libnetdata/locks/rw-spinlock.h
@@ -8,7 +8,6 @@
 
 typedef struct netdata_rw_spinlock {
     int32_t readers;
-    int32_t writers_waiting;
     SPINLOCK spinlock;
 } RW_SPINLOCK;
 


### PR DESCRIPTION
revert preferring writers in rw_spinlocks - recursive read locks are required by dictionary
