### PR TITLE
MSSQL Data FIle Size Metric (Windows plugin)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -876,6 +876,8 @@ set(LIBNETDATA_FILES
         src/libnetdata/os/windows-wmi/windows-wmi.h
         src/libnetdata/os/windows-wmi/windows-wmi-GetDiskDriveInfo.c
         src/libnetdata/os/windows-wmi/windows-wmi-GetDiskDriveInfo.h
+        src/libnetdata/os/windows-wmi/windows-wmi-GetMSSQLDataFileSize.c
+        src/libnetdata/os/windows-wmi/windows-wmi-GetMSSQLDataFileSize.h
         src/libnetdata/os/windows-perflib/perflib.c
         src/libnetdata/os/windows-perflib/perflib.h
         src/libnetdata/os/windows-perflib/perflib-names.c

--- a/src/collectors/windows.plugin/metadata.yaml
+++ b/src/collectors/windows.plugin/metadata.yaml
@@ -1776,6 +1776,12 @@ modules:
               chart_type: line
               dimensions:
                 - name: flushed
+            - name: mssql.database_data_files_size
+              description: Current database size
+              unit: bytes
+              chart_type: line
+              dimensions:
+                - name: size
   - meta:
       plugin_name: windows.plugin
       module_name: PerflibNetFramework

--- a/src/libnetdata/os/windows-wmi/windows-wmi-GetMSSQLDataFileSize.c
+++ b/src/libnetdata/os/windows-wmi/windows-wmi-GetMSSQLDataFileSize.c
@@ -18,6 +18,8 @@ size_t GetSQLDataFileSizeWMI()
 
     HRESULT hr;
     IEnumWbemClassObject *pEnumerator = NULL;
+    BSTR query = NULL;
+    BSTR wql = NULL;
 
     if (!DatabaseSize) {
         DatabaseSize = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_FIXED_SIZE,
@@ -28,8 +30,12 @@ size_t GetSQLDataFileSizeWMI()
     }
 
     // Execute the query, including new properties
-    BSTR query = SysAllocString(L"SELECT Name, DataFilesSizeKB FROM Win32_PerfRawData_MSSQLSERVER_SQLServerDatabases WHERE Name <> '_Total'");
-    BSTR wql = SysAllocString(L"WQL");
+    if (!query)
+        query = SysAllocString(L"SELECT Name, DataFilesSizeKB FROM Win32_PerfRawData_MSSQLSERVER_SQLServerDatabases WHERE Name <> '_Total'");
+
+    if (!wql)
+        wql = SysAllocString(L"WQL");
+
     hr = nd_wmi.pSvc->lpVtbl->ExecQuery(nd_wmi.pSvc,
                                         wql,
                                         query,

--- a/src/libnetdata/os/windows-wmi/windows-wmi-GetMSSQLDataFileSize.c
+++ b/src/libnetdata/os/windows-wmi/windows-wmi-GetMSSQLDataFileSize.c
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "windows-wmi-GetMSSQLDataFileSize.h"
+
+#if defined(OS_WINDOWS)
+
+DICTIONARY *DatabaseSize = NULL;
+
+void dict_mssql_insert_databases_size_cb(const DICTIONARY_ITEM *item __maybe_unused,
+                                         void *value __maybe_unused,
+                                         void *data __maybe_unused) {
+}
+
+size_t GetSQLDataFileSizeWMI()
+{
+    if (InitializeWMI() != S_OK)
+        return 0;
+
+    HRESULT hr;
+    IEnumWbemClassObject *pEnumerator = NULL;
+
+    if (!DatabaseSize) {
+        DatabaseSize = dictionary_create_advanced(DICT_OPTION_DONT_OVERWRITE_VALUE | DICT_OPTION_FIXED_SIZE,
+                                                  NULL,
+                                                  sizeof(unsigned long long));
+
+        dictionary_register_insert_callback(DatabaseSize, dict_mssql_insert_databases_size_cb, NULL);
+    }
+
+    // Execute the query, including new properties
+    BSTR query = SysAllocString(L"SELECT Name, DataFilesSizeKB FROM Win32_PerfRawData_MSSQLSERVER_SQLServerDatabases WHERE Name <> '_Total'");
+    BSTR wql = SysAllocString(L"WQL");
+    hr = nd_wmi.pSvc->lpVtbl->ExecQuery(nd_wmi.pSvc,
+                                        wql,
+                                        query,
+                                        WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
+                                        NULL,
+                                        &pEnumerator);
+
+    if (FAILED(hr)) {
+        nd_log(NDLS_COLLECTORS, NDLP_ERR, "GetSQLDataFileSizeWMI() WMI query failed. Error code = 0x%X", hr);
+        return 0;
+    }
+
+    // Iterate through the results
+    IWbemClassObject *pclsObj = NULL;
+    ULONG uReturn = 0;
+    size_t index = 0;
+    char DatabaseName[NETDATA_MSSQL_MAX_DB_NAME + 1];
+    while (pEnumerator) {
+        hr = pEnumerator->lpVtbl->Next(pEnumerator, WBEM_INFINITE, 1, &pclsObj, &uReturn);
+        if (0 == uReturn)
+            break;
+
+        VARIANT vtProp;
+
+        // Extract DeviceID
+        hr = pclsObj->lpVtbl->Get(pclsObj, L"Name", 0, &vtProp, 0, 0);
+        if (SUCCEEDED(hr) && vtProp.vt == VT_BSTR) {
+            wcstombs(DatabaseName, vtProp.bstrVal, sizeof(DatabaseName));
+        } else
+            DatabaseName[0] = '\0';
+        VariantClear(&vtProp);
+
+        // Extract Model
+        hr = pclsObj->lpVtbl->Get(pclsObj, L"DataFilesSizeKB", 0, &vtProp, 0, 0);
+        if (SUCCEEDED(hr) && vtProp.vt == VT_BSTR && DatabaseName[0]) {
+            char sizeStr[64];
+            wcstombs(sizeStr, vtProp.bstrVal, sizeof(sizeStr));
+
+            unsigned long long *value = dictionary_set(DatabaseSize, DatabaseName, NULL, sizeof(*value));
+            if (!value)
+                continue;
+
+            *value = strtoull(sizeStr, NULL, 10);
+        }
+        VariantClear(&vtProp);
+
+        pclsObj->lpVtbl->Release(pclsObj);
+        index++;
+    }
+
+    pEnumerator->lpVtbl->Release(pEnumerator);
+
+    return index;
+}
+
+#endif

--- a/src/libnetdata/os/windows-wmi/windows-wmi-GetMSSQLDataFileSize.h
+++ b/src/libnetdata/os/windows-wmi/windows-wmi-GetMSSQLDataFileSize.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_WINDOWS_WMI_GETMSSQLDATAFILESIZE_H
+#define NETDATA_WINDOWS_WMI_GETMSSQLDATAFILESIZE_H
+
+#include "windows-wmi.h"
+
+#if defined(OS_WINDOWS)
+
+// https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers?view=sql-server-ver16
+#define NETDATA_MSSQL_MAX_DB_NAME 128
+
+extern DICTIONARY *DatabaseSize;
+
+size_t GetSQLDataFileSizeWMI();
+
+#endif
+
+#endif //NETDATA_WINDOWS_WMI_GETMSSQLDATAFILESIZE_H

--- a/src/libnetdata/os/windows-wmi/windows-wmi.h
+++ b/src/libnetdata/os/windows-wmi/windows-wmi.h
@@ -17,6 +17,7 @@ HRESULT InitializeWMI(void);
 void CleanupWMI(void);
 
 #include "windows-wmi-GetDiskDriveInfo.h"
+#include "windows-wmi-GetMSSQLDataFileSize.h"
 
 #endif
 


### PR DESCRIPTION
##### Summary
After identifying issues with data collection using the registry, this PR updates the initial collection process to utilize WMI, which is more reliable across different environments and languages.

While it would be possible to use PDH for data collection, as done by Windows Exporter, we opted for WMI since we do not yet have any development with PDH. Additionally, I noticed feedback in other GitHub repositories indicating a preference for WMI over PDH for certain events.

Please note that this new metric will not appear under the `MS SQL` section in the cloud interface. Instead, it can be found by scrolling to the `SQL Server` section.

##### Test Plan

1. Compile this branch
2. Make an installer
3. Install it on a host with a MSSQL server installed.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
