### PR TITLE
Fix static builds to ensure usability on intended baseline hardware.

### DIFF
--- a/.github/scripts/build-static.sh
+++ b/.github/scripts/build-static.sh
@@ -13,30 +13,21 @@ VERSION="${VERSION:-"$(git describe)"}"
 BASENAME="$NAME-$BUILDARCH-$VERSION"
 
 prepare_build() {
-  progress "Preparing build"
-  (
-    test -d artifacts || mkdir -p artifacts
-  ) >&2
+  test -d artifacts || mkdir -p artifacts
 }
 
 build_static() {
-  progress "Building static ${BUILDARCH}"
-  (
-    EXTRA_INSTALL_FLAGS="${EXTRA_INSTALL_FLAGS}" USER="" ./packaging/makeself/build-static.sh "${BUILDARCH}"
-  ) >&2
+  EXTRA_INSTALL_FLAGS="${EXTRA_INSTALL_FLAGS}" USER="" ./packaging/makeself/build-static.sh "${BUILDARCH}"
 }
 
 prepare_assets() {
-  progress "Preparing assets"
-  (
-    cp packaging/version artifacts/latest-version.txt
+  cp packaging/version artifacts/latest-version.txt
 
-    cd artifacts || exit 1
-    ln -s "${BASENAME}.gz.run" "netdata-${BUILDARCH}-latest.gz.run"
-    if [ "${BUILDARCH}" = "x86_64" ]; then
-      ln -s "${BASENAME}.gz.run" netdata-latest.gz.run
-    fi
-  ) >&2
+  cd artifacts || exit 1
+  ln -s "${BASENAME}.gz.run" "netdata-${BUILDARCH}-latest.gz.run"
+  if [ "${BUILDARCH}" = "x86_64" ]; then
+    ln -s "${BASENAME}.gz.run" netdata-latest.gz.run
+  fi
 }
 
 steps="prepare_build build_static"

--- a/packaging/makeself/build-static.sh
+++ b/packaging/makeself/build-static.sh
@@ -29,6 +29,14 @@ DOCKER_IMAGE_NAME="netdata/static-builder:v1"
 if [ "${BUILDARCH}" != "$(uname -m)" ] && [ -z "${SKIP_EMULATION}" ]; then
     if [ "$(uname -m)" = "x86_64" ]; then
         ${docker} run --rm --privileged multiarch/qemu-user-static --reset -p yes || exit 1
+
+        case "${BUILDARCH}" in
+            x86_64) QEMU_CPU="Nehalem-v2" ;; # x86-64-v2 equivalent
+            armv6l) QEMU_CPU="arm1176" ;; # Raspbery Pi 1 equivalent
+            armv7l) QEMU_CPU="cortex-a7" ;; # Baseline ARMv7 CPU
+            aarch64) QEMU_CPU="cortex-a53" ;; # Baseline ARMv8 CPU
+            ppc64le) QEMU_CPU="power8nvl" ;; # Baseline POWER8+ CPU
+        esac
     else
         echo "Automatic cross-architecture builds are only supported on x86_64 hosts."
         exit 1
@@ -55,10 +63,12 @@ fi
 if [ -t 1 ]; then
   run ${docker} run --rm -e BUILDARCH="${BUILDARCH}" -a stdin -a stdout -a stderr -i -t -v "$(pwd)":/netdata:rw \
     --platform "${platform}" ${EXTRA_INSTALL_FLAGS:+-e EXTRA_INSTALL_FLAGS="${EXTRA_INSTALL_FLAGS}"} \
+    ${QEMU_CPU:+-e QEMU_CPU="${QEMU_CPU}"} \
     "${DOCKER_IMAGE_NAME}" /bin/sh /netdata/packaging/makeself/build.sh "${@}"
 else
   run ${docker} run --rm -e BUILDARCH="${BUILDARCH}" -v "$(pwd)":/netdata:rw \
     -e GITHUB_ACTIONS="${GITHUB_ACTIONS}" --platform "${platform}" \
     ${EXTRA_INSTALL_FLAGS:+-e EXTRA_INSTALL_FLAGS="${EXTRA_INSTALL_FLAGS}"} \
+    ${QEMU_CPU:+-e QEMU_CPU="${QEMU_CPU}"} \
     "${DOCKER_IMAGE_NAME}" /bin/sh /netdata/packaging/makeself/build.sh "${@}"
 fi

--- a/packaging/makeself/functions.sh
+++ b/packaging/makeself/functions.sh
@@ -6,10 +6,22 @@
 # allow running the jobs by hand
 [ -z "${NETDATA_BUILD_WITH_DEBUG}" ] && export NETDATA_BUILD_WITH_DEBUG=0
 [ -z "${NETDATA_INSTALL_PATH}" ] && export NETDATA_INSTALL_PATH="${1-/opt/netdata}"
-[ -z "${NETDATA_MAKESELF_PATH}" ] && NETDATA_MAKESELF_PATH="$(dirname "${0}")/../.."
-[ "${NETDATA_MAKESELF_PATH:0:1}" != "/" ] && NETDATA_MAKESELF_PATH="$(pwd)/${NETDATA_MAKESELF_PATH}"
-[ -z "${NETDATA_SOURCE_PATH}" ] && export NETDATA_SOURCE_PATH="${NETDATA_MAKESELF_PATH}/../.."
-export NETDATA_MAKESELF_PATH NETDATA_MAKESELF_PATH
+[ -z "${NETDATA_MAKESELF_PATH}" ] && NETDATA_MAKESELF_PATH="$(
+    self=${0}
+    while [ -L "${self}" ]
+    do
+        cd "${self%/*}" || exit 1
+        self=$(readlink "${self}")
+    done
+    cd "${self%/*}" || exit 1
+    cd ../.. || exit 1
+    echo "$(pwd -P)/${self##*/}"
+)"
+[ -z "${NETDATA_SOURCE_PATH}" ] && NETDATA_SOURCE_PATH="$(
+    cd "${NETDATA_MAKESELF_PATH}/../.." || exit 1
+    pwd -P
+)"
+export NETDATA_MAKESELF_PATH NETDATA_SOURCE_PATH
 export NULL=
 
 # make sure the path does not end with /

--- a/packaging/makeself/jobs/20-openssl.install.sh
+++ b/packaging/makeself/jobs/20-openssl.install.sh
@@ -8,8 +8,9 @@
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Building OpenSSL" || true
 
-export CFLAGS="${CFLAGS} -fno-lto -pipe"
-export LDFLAGS="${LDFLAGS} -static"
+export CFLAGS="${TUNING_FLAGS} -fno-lto -pipe"
+export CXXFLAGS="${CFLAGS}"
+export LDFLAGS="-static"
 export PKG_CONFIG="pkg-config --static"
 
 if [ -d "${NETDATA_MAKESELF_PATH}/tmp/openssl" ]; then

--- a/packaging/makeself/jobs/20-openssl.install.sh
+++ b/packaging/makeself/jobs/20-openssl.install.sh
@@ -8,8 +8,8 @@
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::Building OpenSSL" || true
 
-export CFLAGS='-fno-lto -pipe'
-export LDFLAGS='-static'
+export CFLAGS="${CFLAGS} -fno-lto -pipe"
+export LDFLAGS="${LDFLAGS} -static"
 export PKG_CONFIG="pkg-config --static"
 
 if [ -d "${NETDATA_MAKESELF_PATH}/tmp/openssl" ]; then

--- a/packaging/makeself/jobs/50-bash-5.1.16.install.sh
+++ b/packaging/makeself/jobs/50-bash-5.1.16.install.sh
@@ -12,7 +12,8 @@
 fetch "bash-${BASH_VERSION}" "${BASH_ARTIFACT_SOURCE}/bash-${BASH_VERSION}.tar.gz" \
     "${BASH_ARTIFACT_SHA256}" bash
 
-export CFLAGS="${CFLAGS} -pipe"
+export CFLAGS="${TUNING_FLAGS} -pipe"
+export CXXFLAGS="${CFLAGS}"
 export PKG_CONFIG_PATH="/openssl-static/lib64/pkgconfig"
 
 if [ "${CACHE_HIT:-0}" -eq 0 ]; then

--- a/packaging/makeself/jobs/50-bash-5.1.16.install.sh
+++ b/packaging/makeself/jobs/50-bash-5.1.16.install.sh
@@ -12,7 +12,7 @@
 fetch "bash-${BASH_VERSION}" "${BASH_ARTIFACT_SOURCE}/bash-${BASH_VERSION}.tar.gz" \
     "${BASH_ARTIFACT_SHA256}" bash
 
-export CFLAGS="-pipe"
+export CFLAGS="${CFLAGS} -pipe"
 export PKG_CONFIG_PATH="/openssl-static/lib64/pkgconfig"
 
 if [ "${CACHE_HIT:-0}" -eq 0 ]; then

--- a/packaging/makeself/jobs/50-curl.install.sh
+++ b/packaging/makeself/jobs/50-curl.install.sh
@@ -27,8 +27,9 @@ fi
 
 cd "${NETDATA_MAKESELF_PATH}/tmp/curl" || exit 1
 
-export CFLAGS="${CFLAGS} -I/openssl-static/include -pipe"
-export LDFLAGS="${CFLAGS} -static -L/openssl-static/lib64"
+export CFLAGS="${TUNING_FLAGS} -I/openssl-static/include -pipe"
+export CXXFLAGS="${CFLAGS}"
+export LDFLAGS="-static -L/openssl-static/lib64"
 export PKG_CONFIG="pkg-config --static"
 export PKG_CONFIG_PATH="/openssl-static/lib64/pkgconfig"
 

--- a/packaging/makeself/jobs/50-curl.install.sh
+++ b/packaging/makeself/jobs/50-curl.install.sh
@@ -27,8 +27,8 @@ fi
 
 cd "${NETDATA_MAKESELF_PATH}/tmp/curl" || exit 1
 
-export CFLAGS="-I/openssl-static/include -pipe"
-export LDFLAGS="-static -L/openssl-static/lib64"
+export CFLAGS="${CFLAGS} -I/openssl-static/include -pipe"
+export LDFLAGS="${CFLAGS} -static -L/openssl-static/lib64"
 export PKG_CONFIG="pkg-config --static"
 export PKG_CONFIG_PATH="/openssl-static/lib64/pkgconfig"
 

--- a/packaging/makeself/jobs/50-ioping-1.3.install.sh
+++ b/packaging/makeself/jobs/50-ioping-1.3.install.sh
@@ -12,7 +12,8 @@
 fetch "ioping-${IOPING_VERSION}" "${IOPING_SOURCE}/archive/refs/tags/v${IOPING_VERSION}.tar.gz" \
     "${IOPING_ARTIFACT_SHA256}" ioping
 
-export CFLAGS="${CFLAGS} -static -pipe"
+export CFLAGS="${TUNING_FLAGS} -static -pipe"
+export CXXFLAGS="${CFLAGS}"
 
 if [ "${CACHE_HIT:-0}" -eq 0 ]; then
     run make clean

--- a/packaging/makeself/jobs/50-ioping-1.3.install.sh
+++ b/packaging/makeself/jobs/50-ioping-1.3.install.sh
@@ -12,7 +12,7 @@
 fetch "ioping-${IOPING_VERSION}" "${IOPING_SOURCE}/archive/refs/tags/v${IOPING_VERSION}.tar.gz" \
     "${IOPING_ARTIFACT_SHA256}" ioping
 
-export CFLAGS="-static -pipe"
+export CFLAGS="${CFLAGS} -static -pipe"
 
 if [ "${CACHE_HIT:-0}" -eq 0 ]; then
     run make clean

--- a/packaging/makeself/jobs/50-libnetfilter_acct-1.0.3.install.sh
+++ b/packaging/makeself/jobs/50-libnetfilter_acct-1.0.3.install.sh
@@ -12,8 +12,9 @@
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::building libnetfilter_acct" || true
 
-export CFLAGS="${CFLAGS} -static -I/usr/include/libmnl -pipe"
-export LDFLAGS="${LDFLAGS} -static -L/usr/lib -lmnl"
+export CFLAGS="${TUNING_FLAGS} -static -I/usr/include/libmnl -pipe"
+export CXXFLAGS="${CFLAGS}"
+export LDFLAGS="-static -L/usr/lib -lmnl"
 export PKG_CONFIG="pkg-config --static"
 export PKG_CONFIG_PATH="/usr/lib/pkgconfig"
 

--- a/packaging/makeself/jobs/50-libnetfilter_acct-1.0.3.install.sh
+++ b/packaging/makeself/jobs/50-libnetfilter_acct-1.0.3.install.sh
@@ -12,8 +12,8 @@
 # shellcheck disable=SC2015
 [ "${GITHUB_ACTIONS}" = "true" ] && echo "::group::building libnetfilter_acct" || true
 
-export CFLAGS="-static -I/usr/include/libmnl -pipe"
-export LDFLAGS="-static -L/usr/lib -lmnl"
+export CFLAGS="${CFLAGS} -static -I/usr/include/libmnl -pipe"
+export LDFLAGS="${LDFLAGS} -static -L/usr/lib -lmnl"
 export PKG_CONFIG="pkg-config --static"
 export PKG_CONFIG_PATH="/usr/lib/pkgconfig"
 

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -7,12 +7,12 @@
 cd "${NETDATA_SOURCE_PATH}" || exit 1
 
 if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
-  export CFLAGS="-ffunction-sections -fdata-sections -static -O2 -funroll-loops -I/openssl-static/include -I/libnetfilter-acct-static/include/libnetfilter_acct -I/curl-local/include/curl -I/usr/include/libmnl -pipe"
+  export CFLAGS="${CFLAGS} -ffunction-sections -fdata-sections -static -O2 -funroll-loops -I/openssl-static/include -I/libnetfilter-acct-static/include/libnetfilter_acct -I/curl-local/include/curl -I/usr/include/libmnl -pipe"
 else
-  export CFLAGS="-static -O1 -pipe -ggdb -Wall -Wextra -Wformat-signedness -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include -I/libnetfilter-acct-static/include/libnetfilter_acct -I/curl-local/include/curl -I/usr/include/libmnl"
+  export CFLAGS="${CFLAGS} -static -O1 -pipe -ggdb -Wall -Wextra -Wformat-signedness -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include -I/libnetfilter-acct-static/include/libnetfilter_acct -I/curl-local/include/curl -I/usr/include/libmnl"
 fi
 
-export LDFLAGS="-Wl,--gc-sections -static -L/openssl-static/lib64 -L/libnetfilter-acct-static/lib -lnetfilter_acct -L/usr/lib -lmnl -L/usr/lib -lzstd -L/curl-local/lib"
+export LDFLAGS="${LDFLAGS} -Wl,--gc-sections -static -L/openssl-static/lib64 -L/libnetfilter-acct-static/lib -lnetfilter_acct -L/usr/lib -lmnl -L/usr/lib -lzstd -L/curl-local/lib"
 
 # We export this to 'yes', installer sets this to .environment.
 # The updater consumes this one, so that it can tell whether it should update a static install or a non-static one

--- a/packaging/makeself/jobs/70-netdata-git.install.sh
+++ b/packaging/makeself/jobs/70-netdata-git.install.sh
@@ -7,12 +7,12 @@
 cd "${NETDATA_SOURCE_PATH}" || exit 1
 
 if [ "${NETDATA_BUILD_WITH_DEBUG}" -eq 0 ]; then
-  export CFLAGS="${CFLAGS} -ffunction-sections -fdata-sections -static -O2 -funroll-loops -I/openssl-static/include -I/libnetfilter-acct-static/include/libnetfilter_acct -I/curl-local/include/curl -I/usr/include/libmnl -pipe"
+  export CFLAGS="${TUNING_FLAGS} -ffunction-sections -fdata-sections -static -O2 -funroll-loops -I/openssl-static/include -I/libnetfilter-acct-static/include/libnetfilter_acct -I/curl-local/include/curl -I/usr/include/libmnl -pipe"
 else
-  export CFLAGS="${CFLAGS} -static -O1 -pipe -ggdb -Wall -Wextra -Wformat-signedness -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include -I/libnetfilter-acct-static/include/libnetfilter_acct -I/curl-local/include/curl -I/usr/include/libmnl"
+  export CFLAGS="${TUNING_FLAGS} -static -O1 -pipe -ggdb -Wall -Wextra -Wformat-signedness -DNETDATA_INTERNAL_CHECKS=1 -I/openssl-static/include -I/libnetfilter-acct-static/include/libnetfilter_acct -I/curl-local/include/curl -I/usr/include/libmnl"
 fi
 
-export LDFLAGS="${LDFLAGS} -Wl,--gc-sections -static -L/openssl-static/lib64 -L/libnetfilter-acct-static/lib -lnetfilter_acct -L/usr/lib -lmnl -L/usr/lib -lzstd -L/curl-local/lib"
+export LDFLAGS="-Wl,--gc-sections -static -L/openssl-static/lib64 -L/libnetfilter-acct-static/lib -lnetfilter_acct -L/usr/lib -lmnl -L/usr/lib -lzstd -L/curl-local/lib"
 
 # We export this to 'yes', installer sets this to .environment.
 # The updater consumes this one, so that it can tell whether it should update a static install or a non-static one

--- a/packaging/makeself/jobs/99-makeself.install.sh
+++ b/packaging/makeself/jobs/99-makeself.install.sh
@@ -15,6 +15,7 @@ run cd "${NETDATA_SOURCE_PATH}" || exit 1
 # find the netdata version
 
 VERSION="$("${NETDATA_INSTALL_PARENT}/netdata/bin/netdata" -v | cut -f 2 -d ' ')"
+[ -z "${VERSION}" ] && VERSION="$(cat "${NETDATA_SOURCE_PATH}/packaging/version")"
 
 if [ "${VERSION}" == "" ]; then
   echo >&2 "Cannot find version number. Create makeself executable from source code with git tree structure."

--- a/packaging/makeself/jobs/99-makeself.install.sh
+++ b/packaging/makeself/jobs/99-makeself.install.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+set -x
+
 # shellcheck source=packaging/makeself/functions.sh
 . "$(dirname "${0}")/../functions.sh" "${@}" || exit 1
 

--- a/packaging/makeself/run-all-jobs.sh
+++ b/packaging/makeself/run-all-jobs.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+set -x
 set -e
 
 LC_ALL=C

--- a/packaging/makeself/run-all-jobs.sh
+++ b/packaging/makeself/run-all-jobs.sh
@@ -13,15 +13,24 @@ umask 002
 export NETDATA_INSTALL_PATH="${1-/opt/netdata}"
 
 # our source directory
-NETDATA_MAKESELF_PATH="$(dirname "${0}")"
+NETDATA_MAKESELF_PATH="$(
+    self=${0}
+    while [ -L "${self}" ]
+    do
+        cd "${self%/*}" || exit 1
+        self=$(readlink "${self}")
+    done
+    cd "${self%/*}" || exit 1
+    pwd -P
+)"
 export NETDATA_MAKESELF_PATH
-if [ "${NETDATA_MAKESELF_PATH:0:1}" != "/" ]; then
-  NETDATA_MAKESELF_PATH="$(pwd)/${NETDATA_MAKESELF_PATH}"
-  export NETDATA_MAKESELF_PATH
-fi
 
 # netdata source directory
-export NETDATA_SOURCE_PATH="${NETDATA_MAKESELF_PATH}/../.."
+NETDATA_SOURCE_PATH="$(
+    cd "${NETDATA_MAKESELF_PATH}/../.." || exit 1
+    pwd -P
+)"
+export NETDATA_SOURCE_PATH
 
 # make sure ${NULL} is empty
 export NULL=


### PR DESCRIPTION
##### Summary

Part of the intent of our static builds is to work (almost) everywhere with a given CPU architecture. However, we currently don’t do any checks to ensure this.

This PR adds overrides for QEMU CPU architectures during static builds to ensure this for non-x86 architectures. The newly enforced baselines are:

- ARM1176 for ARMv6 builds. This is consistent with the Raspberry Pi 1, which was our original target platform for this build, and will work on most commonly used ARMv6 hardware as well.
- ARM Cortex-A7 for ARMv7 builds. This is the de-facto architectural baseline for ARMv7, so things that run on it will run on pretty much all ARMv7 systems.
- ARM Cortex-A53 for 64-bit ARM builds. Again, this is the de-facto architectural baseline here, so it should run everywhere.
- POWER8+ for 64-bit little-endian PPC builds. This has always been our intended baseline for this architecture since it’s the earliest CPU architecture that is supported by ppc64le Linux distros.

It also adds explicit CFLAGS/CXXFLAGS overrides to ensure builds are done for the intended target platform.

##### Test Plan

CI passes on this PR.