### PR TITLE
fix(go.d/mongodb): add missing disconnect in initClient

### DIFF
--- a/src/go/plugin/go.d/collector/mongodb/client.go
+++ b/src/go/plugin/go.d/collector/mongodb/client.go
@@ -254,6 +254,7 @@ func (c *mongoClient) initClient(uri string, timeout time.Duration) error {
 	defer cancelPing()
 
 	if err := client.Ping(ctxPing, nil); err != nil {
+		_ = client.Disconnect(ctxConn)
 		return err
 	}
 


### PR DESCRIPTION
##### Summary

[Reported on Forum](https://community.netdata.cloud/t/prohibit-netdata-from-scanning-or-binding-to-port-range/6097/4).

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
