### PR TITLE
Health transition saving optimization

### DIFF
--- a/src/health/health.h
+++ b/src/health/health.h
@@ -58,7 +58,7 @@ void health_api_v1_chart_variables2json(RRDSET *st, BUFFER *wb);
 void health_api_v1_chart_custom_variables2json(RRDSET *st, BUFFER *buf);
 
 int health_alarm_log_open(RRDHOST *host);
-void health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae);
+void health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae, bool async);
 void health_alarm_log_load(RRDHOST *host);
 
 ALARM_ENTRY* health_create_alarm_entry(
@@ -73,7 +73,7 @@ ALARM_ENTRY* health_create_alarm_entry(
     int delay,
     HEALTH_ENTRY_FLAGS flags);
 
-void health_alarm_log_add_entry(RRDHOST *host, ALARM_ENTRY *ae);
+void health_alarm_log_add_entry(RRDHOST *host, ALARM_ENTRY *ae, bool async);
 
 const char *health_user_config_dir(void);
 const char *health_stock_config_dir(void);

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -303,7 +303,7 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
 
                 if (ae) {
                     health_log_alert(host, ae);
-                    health_alarm_log_add_entry(host, ae);
+                    health_alarm_log_add_entry(host, ae, false);
                     rc->old_status = rc->status;
                     rc->status = RRDCALC_STATUS_REMOVED;
                     rc->last_status_change = now_tmp;
@@ -506,7 +506,7 @@ static void health_event_loop_for_host(RRDHOST *host, bool apply_hibernation_del
                     );
 
                 health_log_alert(host, ae);
-                health_alarm_log_add_entry(host, ae);
+                health_alarm_log_add_entry(host, ae, false);
 
                 nd_log(NDLS_DAEMON, NDLP_DEBUG,
                        "[%s]: Alert event for [%s.%s], value [%s], status [%s].",

--- a/src/health/health_notifications.c
+++ b/src/health/health_notifications.c
@@ -485,7 +485,7 @@ void health_send_notification(RRDHOST *host, ALARM_ENTRY *ae, struct health_rais
         else
             netdata_log_error("Failed to execute alarm notification");
 
-        health_alarm_log_save(host, ae);
+        health_alarm_log_save(host, ae, false);
     }
     else
         netdata_log_error("Failed to format command arguments");
@@ -497,7 +497,7 @@ void health_send_notification(RRDHOST *host, ALARM_ENTRY *ae, struct health_rais
 
     return; //health_alarm_wait_for_execution
 done:
-    health_alarm_log_save(host, ae);
+    health_alarm_log_save(host, ae, false);
 }
 
 bool health_alarm_log_get_global_id_and_transition_id_for_rrdcalc(RRDCALC *rc, usec_t *global_id, nd_uuid_t *transitions_id) {

--- a/src/health/rrdcalc.c
+++ b/src/health/rrdcalc.c
@@ -243,9 +243,8 @@ static void rrdcalc_link_to_rrdset(RRDCALC *rc) {
         rrdcalc_isrepeating(rc)?HEALTH_ENTRY_FLAG_IS_REPEATING:0);
 
     health_log_alert(host, ae);
-    health_alarm_log_add_entry(host, ae);
+    health_alarm_log_add_entry(host, ae, false);
     rrdset_flag_set(st, RRDSET_FLAG_HAS_RRDCALC_LINKED);
-
 }
 
 static void rrdcalc_unlink_from_rrdset(RRDCALC *rc, bool having_ll_wrlock) {
@@ -277,7 +276,7 @@ static void rrdcalc_unlink_from_rrdset(RRDCALC *rc, bool having_ll_wrlock) {
                 0);
 
             health_log_alert(host, ae);
-            health_alarm_log_add_entry(host, ae);
+            health_alarm_log_add_entry(host, ae, true);
         }
     }
 


### PR DESCRIPTION
##### Summary
- Use both sync or async save mode for health transitions. 
  When a child disconnects health transitions will be stored asynchronously so as not to block the receiver thread cleanup process.
- The main health processing thread will store transitions synchronously. 
  This will allow to better process alert snapshots and individual alert transitions that need to reach the cloud 
