### PR TITLE
Add option to updater to report status of auto-updates on the system.

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -608,6 +608,18 @@ issystemd() {
     return 1
   fi
 
+  # Check the output of systemctl is-system-running.
+  # If this reports 'offline', it’s not systemd. If it reports 'unknown'
+  # or nothing at all (which indicates the command is not supported), it
+  # may or may not be systemd, so continue to other checks. If it reports
+  # anything else, it is systemd.
+  case "$(systemctl is-system-running)" in
+    offline) return 1 ;;
+    unknown) : ;;
+    "") : ;;
+    *) return 0 ;;
+  esac
+
   # if pid 1 is systemd, it is systemd
   [ "$(basename "$(readlink /proc/1/exe)" 2> /dev/null)" = "systemd" ] && return 0
 

--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -478,6 +478,18 @@ issystemd() {
     return 1
   fi
 
+  # Check the output of systemctl is-system-running.
+  # If this reports 'offline', it’s not systemd. If it reports 'unknown'
+  # or nothing at all (which indicates the command is not supported), it
+  # may or may not be systemd, so continue to other checks. If it reports
+  # anything else, it is systemd.
+  case "$(systemctl is-system-running)" in
+    offline) return 1 ;;
+    unknown) : ;;
+    "") : ;;
+    *) return 0 ;;
+  esac
+
   # if pid 1 is systemd, it is systemd
   [ "$(basename "$(readlink /proc/1/exe)" 2> /dev/null)" = "systemd" ] && return 0
 

--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -395,7 +395,7 @@ auto_update_status() {
   enabled=""
 
   if issystemd; then
-    if ( systemctl list-units --full -all | grep -Fq "netdata-updater.timer" ); then
+    if systemctl list-units --full -all | grep -Fq "netdata-updater.timer"; then
       if systemctl is-enabled netdata-updater.timer; then
         info "Auto-updates using a systemd timer unit are ENABLED"
         enabled="systemd"

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -193,6 +193,19 @@ _check_systemd() {
   # if there is no systemctl command, it is not systemd
   [ -z "$(command -v systemctl 2>/dev/null || true)" ] && echo "NO" && return 0
 
+  # Check the output of systemctl is-system-running.
+  #
+  # This may return a non-zero exit status in cases when it actually
+  # succeeded for our purposes, so we need to toggle set -e off here.
+  set +e
+  case "$(systemctl is-system-running)" in
+    offline) echo "OFFLINE" && return 0 ;;
+    unknown) : ;;
+    "") : ;;
+    *) echo "YES" && return 0 ;;
+  esac
+  set -e
+
   # if pid 1 is systemd, it is systemd
   [ "$(basename "$(readlink /proc/1/exe)" 2> /dev/null)" = "systemd" ] && echo "YES" && return 0
 


### PR DESCRIPTION
##### Summary

This adds a new option to the updater script, intended to be run interactively, named `--auto-update-status`. When run with this option, the updater script will print out messages to indicate the default auto-update scheduling method for the system, as well as whether or not auto-updates are enabled for each supported scheduling method (and a warning if more than one scheduling method has auto-updates enabled). Output looks like:

```
Thu Dec 19 07:42:50 AM EST 2024 : INFO: netdata-updater.sh:  The default auto-update scheduling method for this system is: drop-in periodic script
Thu Dec 19 07:42:50 AM EST 2024 : INFO: netdata-updater.sh:  Auto-updates using a systemd timer unit are NOT SUPPORTED due to: Systemd not present
Thu Dec 19 07:42:50 AM EST 2024 : INFO: netdata-updater.sh:  Auto-updates using a drop-in periodic script in /etc/cron.daily are DISABLED
Thu Dec 19 07:42:50 AM EST 2024 : INFO: netdata-updater.sh:  Auto-updates using a drop-in crontab are DISABLED
```

This is intended to simplify debugging of auto-update issues, as without it users have to inspect the filesystem manually to determine this information (and know a lot about the internals of the auto-update scheduling code).

##### Test Plan

Minimal manual testing required. The updater script from this PR should be run on a variety of systems with the new `--auto-update-status` option, and the output confirmed to be accurate for that system.