### PR TITLE
Skip label cleanup during metadata processing

### DIFF
--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -837,24 +837,6 @@ static int chart_label_store_to_sql_callback(const char *name, const char *value
     return 1;
 }
 
-#define SQL_DELETE_CHART_LABEL "DELETE FROM chart_label WHERE chart_id = @chart_id"
-#define SQL_DELETE_CHART_LABEL_HISTORY "DELETE FROM chart_label WHERE date_created < %ld AND chart_id = @chart_id"
-
-static void clean_old_chart_labels(RRDSET *st)
-{
-    char sql[512];
-    time_t first_time_s = rrdset_first_entry_s(st);
-
-    if (unlikely(!first_time_s))
-        snprintfz(sql, sizeof(sql) - 1, SQL_DELETE_CHART_LABEL);
-    else
-        snprintfz(sql, sizeof(sql) - 1, SQL_DELETE_CHART_LABEL_HISTORY, first_time_s);
-
-    int rc = exec_statement_with_uuid(sql, &st->chart_uuid);
-    if (unlikely(rc))
-        error_report("METADATA: 'host:%s' Failed to clean old labels for chart %s", rrdhost_hostname(st->rrdhost), rrdset_name(st));
-}
-
 static int check_and_update_chart_labels(RRDSET *st, BUFFER *work_buffer, size_t *query_counter)
 {
     size_t old_version = st->rrdlabels_last_saved_version;
@@ -873,7 +855,6 @@ static int check_and_update_chart_labels(RRDSET *st, BUFFER *work_buffer, size_t
         (*query_counter)++;
     }
 
-    clean_old_chart_labels(st);
     return rc;
 }
 


### PR DESCRIPTION
##### Summary
- Skip label cleanup during metadata processing (it includes checks taking into account data retention which doesn't help that much)
