### PR TITLE
fix(go.d/rabbitmq): handle insufficient perms when querying definitions

### DIFF
--- a/src/go/plugin/go.d/collector/rabbitmq/collect_nodes.go
+++ b/src/go/plugin/go.d/collector/rabbitmq/collect_nodes.go
@@ -4,6 +4,7 @@ package rabbitmq
 
 import (
 	"fmt"
+
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/metrix"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/pkg/web"

--- a/src/go/plugin/go.d/collector/rabbitmq/collector.go
+++ b/src/go/plugin/go.d/collector/rabbitmq/collector.go
@@ -42,8 +42,9 @@ func New() *Collector {
 			CollectQueues: false,
 		},
 
-		charts: &module.Charts{},
-		cache:  newCache(),
+		charts:           &module.Charts{},
+		cache:            newCache(),
+		queryClusterMeta: true,
 	}
 }
 
@@ -62,9 +63,10 @@ type Collector struct {
 
 	httpClient *http.Client
 
-	clusterName string
-	clusterId   string
-	cache       *cache
+	queryClusterMeta bool
+	clusterName      string
+	clusterId        string
+	cache            *cache
 }
 
 func (c *Collector) Configuration() any {

--- a/src/go/plugin/go.d/collector/rabbitmq/collector_test.go
+++ b/src/go/plugin/go.d/collector/rabbitmq/collector_test.go
@@ -20,6 +20,7 @@ var (
 	dataConfigJSON, _ = os.ReadFile("testdata/config.json")
 	dataConfigYAML, _ = os.ReadFile("testdata/config.yaml")
 
+	dataClusterWhoami, _      = os.ReadFile("testdata/v4.0.3/cluster/whoami.json")
 	dataClusterDefinitions, _ = os.ReadFile("testdata/v4.0.3/cluster/definitions.json")
 	dataClusterOverview, _    = os.ReadFile("testdata/v4.0.3/cluster/overview.json")
 	dataClusterNodes, _       = os.ReadFile("testdata/v4.0.3/cluster/nodes.json")
@@ -31,6 +32,7 @@ func Test_testDataIsValid(t *testing.T) {
 	for name, data := range map[string][]byte{
 		"dataConfigJSON":         dataConfigJSON,
 		"dataConfigYAML":         dataConfigYAML,
+		"dataClusterWhoami":      dataClusterWhoami,
 		"dataClusterDefinitions": dataClusterDefinitions,
 		"dataClusterOverview":    dataClusterOverview,
 		"dataClusterNodes":       dataClusterNodes,
@@ -379,6 +381,8 @@ func caseClusterOk() (*Collector, func()) {
 		http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
+				case urlPathAPIWhoami:
+					_, _ = w.Write(dataClusterWhoami)
 				case urlPathAPIDefinitions:
 					_, _ = w.Write(dataClusterDefinitions)
 				case urlPathAPIOverview:

--- a/src/go/plugin/go.d/collector/rabbitmq/restapi.go
+++ b/src/go/plugin/go.d/collector/rabbitmq/restapi.go
@@ -3,12 +3,18 @@
 package rabbitmq
 
 const (
+	urlPathAPIWhoami      = "/api/whoami"
 	urlPathAPIDefinitions = "/api/definitions"
 	urlPathAPIOverview    = "/api/overview"
 	urlPathAPINodes       = "/api/nodes"
 	urlPathAPIVhosts      = "/api/vhosts"
 	urlPathAPIQueues      = "/api/queues"
 )
+
+type apiWhoamiResp struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+}
 
 type apiDefinitionsResp struct {
 	RabbitmqVersion string `json:"rabbitmq_version"`

--- a/src/go/plugin/go.d/collector/rabbitmq/testdata/v4.0.3/cluster/whoami.json
+++ b/src/go/plugin/go.d/collector/rabbitmq/testdata/v4.0.3/cluster/whoami.json
@@ -1,0 +1,7 @@
+{
+  "name": "guest",
+  "tags": [
+    "administrator"
+  ],
+  "is_internal_user": true
+}


### PR DESCRIPTION
##### Summary

In RabbitMQ, querying the `/api/definitions` endpoint requires administrative privileges.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
