### PR TITLE
Fix metric retention check and cleanup

### DIFF
--- a/src/daemon/pulse/pulse-db-dbengine.c
+++ b/src/daemon/pulse/pulse-db-dbengine.c
@@ -836,7 +836,7 @@ void pulse_dbengine_do(bool extended) {
         priority++;
 
         rrddim_set_by_pointer(st_mrg_metrics, rd_mrg_metrics, (collected_number)mrg_stats.entries);
-        rrddim_set_by_pointer(st_mrg_metrics, rd_mrg_acquired, (collected_number)mrg_stats.entries_referenced);
+        rrddim_set_by_pointer(st_mrg_metrics, rd_mrg_acquired, (collected_number)mrg_stats.entries_acquired);
         rrddim_set_by_pointer(st_mrg_metrics, rd_mrg_collected, (collected_number)mrg_stats.writers);
         rrddim_set_by_pointer(st_mrg_metrics, rd_mrg_multiple_writers, (collected_number)mrg_stats.writers_conflicts);
 

--- a/src/database/engine/metric.h
+++ b/src/database/engine/metric.h
@@ -31,10 +31,10 @@ struct mrg_statistics {
     // --- atomic --- multiple readers / writers
 
     CACHE_LINE_PADDING();
-    size_t entries_referenced;
+    ssize_t entries_acquired;
 
     CACHE_LINE_PADDING();
-    size_t current_references;
+    ssize_t current_references;
 
     CACHE_LINE_PADDING();
     size_t search_hits;


### PR DESCRIPTION
##### Summary
-  fixed bug in mrg cleanup, not deleting metrics that do not have retention
-  fix for mrg acquired and referenced going negative

