### PR TITLE
fix(netdata-updater.sh): ensure tmpdir-path argument is always passed

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -586,11 +586,13 @@ self_update() {
     if _safe_download "https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/netdata-updater.sh" ./netdata-updater.sh; then
       chmod +x ./netdata-updater.sh || exit 1
       export ENVIRONMENT_FILE="${ENVIRONMENT_FILE}"
-      force_update=""
-      [ "$NETDATA_FORCE_UPDATE" = "1" ] && force_update="--force-update"
-      interactive=""
-      [ "$INTERACTIVE" = "0" ] && interactive="--non-interactive"
-      exec ./netdata-updater.sh --not-running-from-cron --no-updater-self-update "$force_update" "$interactive" --tmpdir-path "$(pwd)"
+
+      cmd="./netdata-updater.sh --not-running-from-cron --no-updater-self-update"
+      [ "$NETDATA_FORCE_UPDATE" = "1" ] && cmd="$cmd --force-update"
+      [ "$INTERACTIVE" = "0" ] && cmd="$cmd --non-interactive"
+      cmd="$cmd --tmpdir-path $(pwd)"
+
+      exec $cmd
     else
       error "Failed to download newest version of updater script, continuing with current version."
     fi


### PR DESCRIPTION
##### Summary

When conditional parameters (`force-update`, `non-interactive`) were not set, the command construction led to improper argument handling, which caused the script to ignore the final parameter (`--tmpdir-path`).


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
