### PR TITLE
fix(netdata-updater.sh): use explicit paths for temp dir creation

### DIFF
--- a/packaging/installer/netdata-updater.sh
+++ b/packaging/installer/netdata-updater.sh
@@ -394,28 +394,29 @@ _cannot_use_tmpdir() {
   return "${ret}"
 }
 
-create_tmp_directory() {
+create_exec_tmp_directory() {
   if [ -n "${NETDATA_TMPDIR_PATH}" ]; then
     echo "${NETDATA_TMPDIR_PATH}"
-  else
-    if [ -z "${NETDATA_TMPDIR}" ] || _cannot_use_tmpdir "${NETDATA_TMPDIR}" ; then
-      if [ -z "${TMPDIR}" ] || _cannot_use_tmpdir "${TMPDIR}" ; then
-        if _cannot_use_tmpdir /tmp ; then
-          if _cannot_use_tmpdir "${PWD}" ; then
-            fatal "Unable to find a usable temporary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again." U0003
-          else
-            TMPDIR="${PWD}"
-          fi
-        else
-          TMPDIR="/tmp"
-        fi
-      fi
-    else
-      TMPDIR="${NETDATA_TMPDIR}"
-    fi
-
-    mktemp -d -t netdata-updater-XXXXXXXXXX
+    return
   fi
+
+  root_dir=""
+
+  if [ -n "${NETDATA_TMPDIR}" ] && ! _cannot_use_tmpdir "${NETDATA_TMPDIR}"; then
+    root_dir="${NETDATA_TMPDIR}"
+  elif [ -n "${TMPDIR}" ] && ! _cannot_use_tmpdir "${TMPDIR}"; then
+    root_dir="${TMPDIR}"
+  elif ! _cannot_use_tmpdir /tmp; then
+    root_dir="/tmp"
+  elif ! _cannot_use_tmpdir "${PWD}"; then
+    root_dir="${PWD}"
+  else
+    fatal "Unable to find a usable temporary directory. Please set \$TMPDIR to a path that is both writable and allows execution of files and try again." U0003
+  fi
+
+  TMPDIR="${root_dir}"
+
+  mktemp -d -p "${root_dir}" -t netdata-updater-XXXXXXXXXX
 }
 
 check_for_curl() {
@@ -526,7 +527,7 @@ get_netdata_latest_tag() {
 newer_commit_date() {
   info "Checking if a newer version of the updater script is available."
 
-  ndtmpdir="$(create_tmp_directory)"
+  ndtmpdir="$(create_exec_tmp_directory)"
   commit_check_file="${ndtmpdir}/latest-commit.json"
   commit_check_url="https://api.github.com/repos/netdata/netdata/commits?path=packaging%2Finstaller%2Fnetdata-updater.sh&page=1&per_page=1"
   python_version_check="
@@ -580,7 +581,7 @@ self_update() {
   if [ -z "${NETDATA_NO_UPDATER_SELF_UPDATE}" ] && newer_commit_date; then
     info "Downloading newest version of updater script."
 
-    ndtmpdir=$(create_tmp_directory)
+    ndtmpdir=$(create_exec_tmp_directory)
     cd "$ndtmpdir" || exit 1
 
     if _safe_download "https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/netdata-updater.sh" ./netdata-updater.sh; then
@@ -737,7 +738,7 @@ update_build() {
   [ -z "${logfile}" ] && info "Running on a terminal - (this script also supports running headless from crontab)"
 
   RUN_INSTALLER=0
-  ndtmpdir=$(create_tmp_directory)
+  ndtmpdir=$(create_exec_tmp_directory)
   cd "$ndtmpdir" || fatal "Failed to change current working directory to ${ndtmpdir}" U0016
 
   install_build_dependencies
@@ -836,7 +837,7 @@ update_build() {
 }
 
 update_static() {
-  ndtmpdir="$(create_tmp_directory)"
+  ndtmpdir="$(create_exec_tmp_directory)"
   PREVDIR="$(pwd)"
 
   info "Entering ${ndtmpdir}"


### PR DESCRIPTION
##### Summary

Fixes: #19291

~~Using `TMPDIR` environment variable to control `mktemp`'s output directory
location was unreliable.~~ `TMPDIR` was set but not exported, so `mktemp` in a subshell wouldn't see it.

```bash
# Doesn't work - TMPDIR not passed to mktemp's environment
TMPDIR="/tmp"
mktemp -d -t netdata-updater-XXXXXXXXXX

# Works - explicitly sets TMPDIR in mktemp's environment
TMPDIR="/tmp" mktemp -d -t netdata-updater-XXXXXXXXXX
```

Instead of relying on `TMPDIR` environment variable modification, this change
makes the temporary directory creation more explicit by using `mktemp`'s `-p` flag to specify the parent directory directly.

##### Test Plan

- Remount `/tmp` with `noexec`.
- Run the updater script manually and ensure it fallbacks to `pwd`.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
