### PR TITLE
Streaming improvements No 12

### DIFF
--- a/src/collectors/debugfs.plugin/module-libsensors.c
+++ b/src/collectors/debugfs.plugin/module-libsensors.c
@@ -924,6 +924,10 @@ static SENSOR *sensor_get_or_create(DICTIONARY *dict, const sensors_chip_name *c
             string2str(s->feature.name));
     }
 
+    // we have to free this, because it is malloced from libsensors
+    if(label)
+        free((void *)label); // do not use freez() here - libsensors uses malloc()
+
     netdata_fix_chart_id(buf);
     s->id = string_strdupz(buf);
 

--- a/src/collectors/proc.plugin/proc_diskstats.c
+++ b/src/collectors/proc.plugin/proc_diskstats.c
@@ -340,7 +340,6 @@ static inline int is_major_enabled(int major) {
 
 static inline int get_disk_name_from_path(const char *path, char *result, size_t result_size, unsigned long major, unsigned long minor, char *disk, char *prefix, int depth) {
     //collector_info("DEVICE-MAPPER ('%s', %lu:%lu): examining directory '%s' (allowed depth %d).", disk, major, minor, path, depth);
-
     int found = 0, preferred = 0;
 
     char *first_result = mallocz(result_size + 1);
@@ -401,9 +400,8 @@ static inline int get_disk_name_from_path(const char *path, char *result, size_t
                 else
                     strncpyz(filename, result, FILENAME_MAX);
             }
-            else {
+            else
                 snprintfz(filename, FILENAME_MAX, "%s/%s", path, de->d_name);
-            }
 
             struct stat sb;
             if(stat(filename, &sb) == -1) {
@@ -426,10 +424,11 @@ static inline int get_disk_name_from_path(const char *path, char *result, size_t
             snprintfz(result, result_size - 1, "%s%s%s", (prefix)?prefix:"", (prefix)?"_":"", de->d_name);
 
             if(!found) {
-                strncpyz(first_result, result, result_size);
+                strncpyz(first_result, result, result_size - 1);
                 found = 1;
             }
 
+            result[result_size - 1] = '\0';
             if(simple_pattern_matches(preferred_ids, result)) {
                 preferred = 1;
                 break;
@@ -438,13 +437,11 @@ static inline int get_disk_name_from_path(const char *path, char *result, size_t
     }
     closedir(dir);
 
-
 failed:
-
     if(!found)
         result[0] = '\0';
     else if(!preferred)
-        strncpyz(result, first_result, result_size);
+        strncpyz(result, first_result, result_size - 1);
 
     freez(first_result);
 

--- a/src/daemon/pulse/pulse-daemon-memory.c
+++ b/src/daemon/pulse/pulse-daemon-memory.c
@@ -7,7 +7,7 @@
 #define dictionary_stats_memory_total(stats) \
     ((stats).memory.dict + (stats).memory.values + (stats).memory.index)
 
-struct netdata_buffers_statistics netdata_buffers_statistics = {};
+struct netdata_buffers_statistics netdata_buffers_statistics = { 0 };
 
 void pulse_daemon_memory_do(bool extended) {
     {

--- a/src/daemon/pulse/pulse-http-api.c
+++ b/src/daemon/pulse/pulse-http-api.c
@@ -19,7 +19,7 @@ static struct web_statistics {
 
     PAD64(uint64_t) content_size_uncompressed;
     PAD64(uint64_t) content_size_compressed;
-} web_statistics;
+} web_statistics = { 0 };
 
 uint64_t pulse_web_client_connected(void) {
     __atomic_fetch_add(&web_statistics.connected_clients, 1, __ATOMIC_RELAXED);

--- a/src/daemon/pulse/pulse-http-api.h
+++ b/src/daemon/pulse/pulse-http-api.h
@@ -5,7 +5,7 @@
 
 #include "daemon/common.h"
 
-uint64_t pulse_web_client_connected(void);
+void pulse_web_client_connected(void);
 void pulse_web_client_disconnected(void);
 
 void pulse_web_request_completed(uint64_t dt,

--- a/src/daemon/pulse/pulse-ingestion.c
+++ b/src/daemon/pulse/pulse-ingestion.c
@@ -5,7 +5,7 @@
 
 static struct ingest_statistics {
     uint64_t db_points_stored_per_tier[RRD_STORAGE_TIERS];
-} ingest_statistics;
+} ingest_statistics = { 0 };
 
 void pulse_queries_rrdset_collection_completed(size_t *points_read_per_tier_array) {
     for(size_t tier = 0; tier < nd_profile.storage_tiers;tier++) {

--- a/src/daemon/pulse/pulse-ml.c
+++ b/src/daemon/pulse/pulse-ml.c
@@ -12,7 +12,7 @@ static struct ml_statistics {
     PAD64(uint64_t) ml_memory_consumption;
     PAD64(uint64_t) ml_memory_new;
     PAD64(uint64_t) ml_memory_delete;
-} ml_statistics = {0};
+} ml_statistics = { 0 };
 
 void pulse_ml_models_received()
 {

--- a/src/daemon/pulse/pulse-queries.c
+++ b/src/daemon/pulse/pulse-queries.c
@@ -30,7 +30,7 @@ static struct query_statistics {
 
     PAD64(uint64_t) exporters_queries_made;
     PAD64(uint64_t) exporters_db_points_read;
-} query_statistics;
+} query_statistics = { 0 };
 
 void pulse_queries_ml_query_completed(size_t points_read) {
     __atomic_fetch_add(&query_statistics.ml_queries_made, 1, __ATOMIC_RELAXED);

--- a/src/daemon/pulse/pulse-sqlite3.c
+++ b/src/daemon/pulse/pulse-sqlite3.c
@@ -20,7 +20,7 @@ static struct sqlite3_statistics {
     PAD64(uint64_t) sqlite3_context_cache_spill;
     PAD64(uint64_t) sqlite3_metadata_cache_write;
     PAD64(uint64_t) sqlite3_context_cache_write;
-} sqlite3_statistics = { };
+} sqlite3_statistics = { 0 };
 
 void pulse_sqlite3_query_completed(bool success, bool busy, bool locked) {
     if(!sqlite3_statistics.enabled) return;

--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -706,7 +706,7 @@ static void pgc_queue_del(PGC *cache __maybe_unused, struct pgc_queue *q, PGC_PA
         DOUBLE_LINKED_LIST_REMOVE_ITEM_UNSAFE(sp->base, page, link.prev, link.next);
 
         if(!sp->base) {
-            size_t mem_before_judyl, mem_after_judyl;
+            ssize_t mem_before_judyl, mem_after_judyl;
 
             mem_before_judyl = JudyLMemUsed(q->sections_judy);
             int rc = JudyLDel(&q->sections_judy, page->section, PJE0);
@@ -717,7 +717,6 @@ static void pgc_queue_del(PGC *cache __maybe_unused, struct pgc_queue *q, PGC_PA
 
             // freez(sp);
             aral_freez(pgc_sections_aral, sp);
-            mem_after_judyl -= sizeof(struct section_pages);
             pgc_stats_queue_judy_change(cache, q, mem_before_judyl, mem_after_judyl);
         }
     }
@@ -1992,7 +1991,7 @@ static void *pgc_evict_thread(void *ptr) {
         job_id = new_job_id;
 
         if (nd_thread_signaled_to_cancel())
-            return NULL;
+            break;
 
         evict_pages(cache, 0, 0, true, false);
 

--- a/src/database/engine/cache.c
+++ b/src/database/engine/cache.c
@@ -71,7 +71,7 @@ struct pgc_page {
 };
 
 struct pgc_queue {
-    SPINLOCK spinlock;
+    WAITING_QUEUE *wq;
     union {
         PGC_PAGE *base;
         Pvoid_t sections_judy;
@@ -239,9 +239,14 @@ static inline size_t pgc_indexing_partition(PGC *cache, Word_t metric_id) {
     _result;                                                                            \
 })
 
-#define pgc_queue_trylock(cache, ll) spinlock_trylock(&(ll)->spinlock)
-#define pgc_queue_lock(cache, ll) spinlock_lock(&(ll)->spinlock)
-#define pgc_queue_unlock(cache, ll) spinlock_unlock(&(ll)->spinlock)
+#define PGC_QUEUE_LOCK_PRIO_COLLECTORS  WAITING_QUEUE_PRIO_URGENT
+#define PGC_QUEUE_LOCK_PRIO_EVICTORS    WAITING_QUEUE_PRIO_HIGH
+#define PGC_QUEUE_LOCK_PRIO_FLUSHERS    WAITING_QUEUE_PRIO_NORMAL
+#define PGC_QUEUE_LOCK_PRIO_OTHERS      WAITING_QUEUE_PRIO_LOW
+
+#define pgc_queue_trylock(cache, ll) waiting_queue_try_acquire((ll)->wq)
+#define pgc_queue_lock(cache, ll, prio) waiting_queue_acquire((ll)->wq, prio)
+#define pgc_queue_unlock(cache, ll) waiting_queue_release((ll)->wq)
 
 #define page_transition_trylock(cache, page) spinlock_trylock(&(page)->transition_spinlock)
 #define page_transition_lock(cache, page) spinlock_lock(&(page)->transition_spinlock)
@@ -590,9 +595,9 @@ static inline void pgc_stats_index_judy_change(PGC *cache, size_t mem_before_jud
     }
 }
 
-static void pgc_queue_add(PGC *cache __maybe_unused, struct pgc_queue *q, PGC_PAGE *page, bool having_lock) {
+static void pgc_queue_add(PGC *cache __maybe_unused, struct pgc_queue *q, PGC_PAGE *page, bool having_lock, WAITING_QUEUE_PRIORITY prio) {
     if(!having_lock)
-        pgc_queue_lock(cache, q);
+        pgc_queue_lock(cache, q, prio);
 
     internal_fatal(page_get_status_flags(page) != 0,
                    "DBENGINE CACHE: invalid page flags, the page has %d, but it is should be %d",
@@ -659,7 +664,7 @@ static void pgc_queue_add(PGC *cache __maybe_unused, struct pgc_queue *q, PGC_PA
         pgc_size_histogram_add(cache, &q->stats->size_histogram, page);
 }
 
-static void pgc_queue_del(PGC *cache __maybe_unused, struct pgc_queue *q, PGC_PAGE *page, bool having_lock) {
+static void pgc_queue_del(PGC *cache __maybe_unused, struct pgc_queue *q, PGC_PAGE *page, bool having_lock, WAITING_QUEUE_PRIORITY prio) {
     if(cache->config.stats)
         pgc_size_histogram_del(cache, &q->stats->size_histogram, page);
 
@@ -669,7 +674,7 @@ static void pgc_queue_del(PGC *cache __maybe_unused, struct pgc_queue *q, PGC_PA
     __atomic_add_fetch(&q->stats->removed_size, page->assumed_size, __ATOMIC_RELAXED);
 
     if(!having_lock)
-        pgc_queue_lock(cache, q);
+        pgc_queue_lock(cache, q, prio);
 
     internal_fatal(page_get_status_flags(page) != q->flags,
                    "DBENGINE CACHE: invalid page flags, the page has %d, but it is should be %d",
@@ -735,7 +740,7 @@ static inline void page_has_been_accessed(PGC *cache, PGC_PAGE *page) {
 // ----------------------------------------------------------------------------
 // state transitions
 
-static inline void page_set_clean(PGC *cache, PGC_PAGE *page, bool having_transition_lock, bool having_clean_lock) {
+static inline void page_set_clean(PGC *cache, PGC_PAGE *page, bool having_transition_lock, bool having_clean_lock, WAITING_QUEUE_PRIORITY prio) {
     if(!having_transition_lock)
         page_transition_lock(cache, page);
 
@@ -748,23 +753,23 @@ static inline void page_set_clean(PGC *cache, PGC_PAGE *page, bool having_transi
     }
 
     if(flags & PGC_PAGE_HOT)
-        pgc_queue_del(cache, &cache->hot, page, false);
+        pgc_queue_del(cache, &cache->hot, page, false, prio);
 
     if(flags & PGC_PAGE_DIRTY)
-        pgc_queue_del(cache, &cache->dirty, page, false);
+        pgc_queue_del(cache, &cache->dirty, page, false, prio);
 
     // first add to linked list, the set the flag (required for move_page_last())
-    pgc_queue_add(cache, &cache->clean, page, having_clean_lock);
+    pgc_queue_add(cache, &cache->clean, page, having_clean_lock, prio);
 
     if(!having_transition_lock)
         page_transition_unlock(cache, page);
 }
 
-static inline void page_set_dirty(PGC *cache, PGC_PAGE *page, bool having_hot_lock) {
+static inline void page_set_dirty(PGC *cache, PGC_PAGE *page, bool having_hot_lock, WAITING_QUEUE_PRIORITY prio) {
     if(!having_hot_lock)
         // to avoid deadlocks, we have to get the hot lock before the page transition
         // since this is what all_hot_to_dirty() does
-        pgc_queue_lock(cache, &cache->hot);
+        pgc_queue_lock(cache, &cache->hot, prio);
 
     page_transition_lock(cache, page);
 
@@ -784,17 +789,17 @@ static inline void page_set_dirty(PGC *cache, PGC_PAGE *page, bool having_hot_lo
     __atomic_add_fetch(&cache->stats.hot2dirty_size, page->assumed_size, __ATOMIC_RELAXED);
 
     if(likely(flags & PGC_PAGE_HOT))
-        pgc_queue_del(cache, &cache->hot, page, true);
+        pgc_queue_del(cache, &cache->hot, page, true, prio);
 
     if(!having_hot_lock)
         // we don't need the hot lock anymore
         pgc_queue_unlock(cache, &cache->hot);
 
     if(unlikely(flags & PGC_PAGE_CLEAN))
-        pgc_queue_del(cache, &cache->clean, page, false);
+        pgc_queue_del(cache, &cache->clean, page, false, prio);
 
     // first add to linked list, the set the flag (required for move_page_last())
-    pgc_queue_add(cache, &cache->dirty, page, false);
+    pgc_queue_add(cache, &cache->dirty, page, false, prio);
 
     __atomic_sub_fetch(&cache->stats.hot2dirty_entries, 1, __ATOMIC_RELAXED);
     __atomic_sub_fetch(&cache->stats.hot2dirty_size, page->assumed_size, __ATOMIC_RELAXED);
@@ -802,7 +807,7 @@ static inline void page_set_dirty(PGC *cache, PGC_PAGE *page, bool having_hot_lo
     page_transition_unlock(cache, page);
 }
 
-static inline void page_set_hot(PGC *cache, PGC_PAGE *page) {
+static inline void page_set_hot(PGC *cache, PGC_PAGE *page, WAITING_QUEUE_PRIORITY prio) {
     page_transition_lock(cache, page);
 
     PGC_PAGE_FLAGS flags = page_get_status_flags(page);
@@ -813,13 +818,13 @@ static inline void page_set_hot(PGC *cache, PGC_PAGE *page) {
     }
 
     if(flags & PGC_PAGE_DIRTY)
-        pgc_queue_del(cache, &cache->dirty, page, false);
+        pgc_queue_del(cache, &cache->dirty, page, false, prio);
 
     if(flags & PGC_PAGE_CLEAN)
-        pgc_queue_del(cache, &cache->clean, page, false);
+        pgc_queue_del(cache, &cache->clean, page, false, prio);
 
     // first add to linked list, the set the flag (required for move_page_last())
-    pgc_queue_add(cache, &cache->hot, page, false);
+    pgc_queue_add(cache, &cache->hot, page, false, prio);
 
     page_transition_unlock(cache, page);
 }
@@ -1098,10 +1103,10 @@ static inline bool make_acquired_page_clean_and_evict_or_page_release(PGC *cache
     pointer_check(cache, page);
 
     page_transition_lock(cache, page);
-    pgc_queue_lock(cache, &cache->clean);
+    pgc_queue_lock(cache, &cache->clean, PGC_QUEUE_LOCK_PRIO_EVICTORS);
 
     // make it clean - it does not have any accesses, so it will be prepended
-    page_set_clean(cache, page, true, true);
+    page_set_clean(cache, page, true, true, PGC_QUEUE_LOCK_PRIO_EVICTORS);
 
     if(!acquired_page_get_for_deletion_or_release_it(cache, page)) {
         pgc_queue_unlock(cache, &cache->clean);
@@ -1110,7 +1115,7 @@ static inline bool make_acquired_page_clean_and_evict_or_page_release(PGC *cache
     }
 
     // remove it from the linked list
-    pgc_queue_del(cache, &cache->clean, page, true);
+    pgc_queue_del(cache, &cache->clean, page, true, PGC_QUEUE_LOCK_PRIO_EVICTORS);
     pgc_queue_unlock(cache, &cache->clean);
     page_transition_unlock(cache, page);
 
@@ -1213,7 +1218,7 @@ static bool evict_pages_with_filter(PGC *cache, size_t max_skip, size_t max_evic
             // at this point we have the clean lock
         }
         else
-            pgc_queue_lock(cache, &cache->clean);
+            pgc_queue_lock(cache, &cache->clean, PGC_QUEUE_LOCK_PRIO_EVICTORS);
 
         timing_dbengine_evict_step(TIMING_STEP_DBENGINE_EVICT_LOCK);
 
@@ -1242,7 +1247,7 @@ static bool evict_pages_with_filter(PGC *cache, size_t max_skip, size_t max_evic
                 // we can delete this page
 
                 // remove it from the clean list
-                pgc_queue_del(cache, &cache->clean, page, true);
+                pgc_queue_del(cache, &cache->clean, page, true, PGC_QUEUE_LOCK_PRIO_EVICTORS);
 
                 __atomic_add_fetch(&cache->stats.evicting_entries, 1, __ATOMIC_RELAXED);
                 __atomic_add_fetch(&cache->stats.evicting_size, page->assumed_size, __ATOMIC_RELAXED);
@@ -1388,7 +1393,7 @@ static bool evict_pages_with_filter(PGC *cache, size_t max_skip, size_t max_evic
     } while(all_of_them || (total_pages_evicted < max_evict && total_pages_relocated < max_skip));
 
     if(all_of_them && !filter) {
-        pgc_queue_lock(cache, &cache->clean);
+        pgc_queue_lock(cache, &cache->clean, PGC_QUEUE_LOCK_PRIO_EVICTORS);
         size_t entries = __atomic_load_n(&cache->clean.stats->entries, __ATOMIC_RELAXED);
         if(entries) {
             nd_log_limit_static_global_var(erl, 1, 0);
@@ -1491,9 +1496,9 @@ static PGC_PAGE *page_add(PGC *cache, PGC_ENTRY *entry, bool *added) {
             pgc_index_write_unlock(cache, partition);
 
             if (entry->hot)
-                page_set_hot(cache, page);
+                page_set_hot(cache, page, PGC_QUEUE_LOCK_PRIO_COLLECTORS);
             else
-                page_set_clean(cache, page, false, false);
+                page_set_clean(cache, page, false, false, PGC_QUEUE_LOCK_PRIO_EVICTORS);
 
             PGC_REFERENCED_PAGES_PLUS1(cache, page);
 
@@ -1706,7 +1711,7 @@ cleanup:
 }
 
 static void all_hot_pages_to_dirty(PGC *cache, Word_t section) {
-    pgc_queue_lock(cache, &cache->hot);
+    pgc_queue_lock(cache, &cache->hot, PGC_QUEUE_LOCK_PRIO_COLLECTORS);
 
     bool first = true;
     Word_t last_section = (section == PGC_SECTION_ALL) ? 0 : section;
@@ -1722,7 +1727,7 @@ static void all_hot_pages_to_dirty(PGC *cache, Word_t section) {
             PGC_PAGE *next = page->link.next;
 
             if(page_acquire(cache, page)) {
-                page_set_dirty(cache, page, true);
+                page_set_dirty(cache, page, true, PGC_QUEUE_LOCK_PRIO_COLLECTORS);
                 page_release(cache, page, false);
                 // page ptr may be invalid now
             }
@@ -1750,7 +1755,7 @@ static bool flush_pages(PGC *cache, size_t max_flushes, Word_t section, bool wai
         // we got the lock at this point
     }
     else
-        pgc_queue_lock(cache, &cache->dirty);
+        pgc_queue_lock(cache, &cache->dirty, PGC_QUEUE_LOCK_PRIO_FLUSHERS);
 
     size_t optimal_flush_size = cache->config.max_dirty_pages_per_call;
     size_t dirty_version_at_entry = cache->dirty.version;
@@ -1847,7 +1852,7 @@ static bool flush_pages(PGC *cache, size_t max_flushes, Word_t section, bool wai
                 __atomic_add_fetch(&cache->stats.flushing_size, tpg->assumed_size, __ATOMIC_RELAXED);
 
                 // remove it from the dirty list
-                pgc_queue_del(cache, &cache->dirty, tpg, true);
+                pgc_queue_del(cache, &cache->dirty, tpg, true, PGC_QUEUE_LOCK_PRIO_FLUSHERS);
 
                 pages_removed_dirty_size += tpg->assumed_size;
                 pages_removed_dirty++;
@@ -1914,7 +1919,7 @@ static bool flush_pages(PGC *cache, size_t max_flushes, Word_t section, bool wai
             if(!tpg->accesses)
                 pages_to_evict++;
 
-            page_set_clean(cache, tpg, true, false);
+            page_set_clean(cache, tpg, true, false, PGC_QUEUE_LOCK_PRIO_FLUSHERS);
             page_transition_unlock(cache, tpg);
             page_release(cache, tpg, false);
             // tpg ptr may be invalid now
@@ -1934,7 +1939,7 @@ static bool flush_pages(PGC *cache, size_t max_flushes, Word_t section, bool wai
             }
         }
         else {
-            pgc_queue_lock(cache, &cache->dirty);
+            pgc_queue_lock(cache, &cache->dirty, PGC_QUEUE_LOCK_PRIO_FLUSHERS);
             have_dirty_lock = true;
         }
     }
@@ -2081,9 +2086,9 @@ PGC *pgc_create(const char *name,
 #endif
 
 
-    spinlock_init(&cache->hot.spinlock);
-    spinlock_init(&cache->dirty.spinlock);
-    spinlock_init(&cache->clean.spinlock);
+    cache->hot.wq = waiting_queue_create();
+    cache->dirty.wq = waiting_queue_create();
+    cache->clean.wq = waiting_queue_create();
 
     cache->hot.flags = PGC_PAGE_HOT;
     cache->hot.linked_list_in_sections_judy = true;
@@ -2150,6 +2155,10 @@ void pgc_destroy(PGC *cache) {
 #endif
         }
 
+        waiting_queue_destroy(cache->hot.wq);
+        waiting_queue_destroy(cache->dirty.wq);
+        waiting_queue_destroy(cache->clean.wq);
+
         freez(cache->index);
         freez(cache);
     }
@@ -2180,7 +2189,7 @@ void pgc_page_hot_to_dirty_and_release(PGC *cache, PGC_PAGE *page, bool never_fl
 //#endif
 
     // make page dirty
-    page_set_dirty(cache, page, false);
+    page_set_dirty(cache, page, false, PGC_QUEUE_LOCK_PRIO_COLLECTORS);
 
     // release the page
     page_release(cache, page, true);
@@ -2425,7 +2434,7 @@ void pgc_open_cache_to_journal_v2(PGC *cache, Word_t section, unsigned datafile_
     __atomic_add_fetch(&rrdeng_cache_efficiency_stats.journal_v2_indexing_started, 1, __ATOMIC_RELAXED);
     p2_add_fetch(&cache->stats.p2_workers_jv2_flush, 1);
 
-    pgc_queue_lock(cache, &cache->hot);
+    pgc_queue_lock(cache, &cache->hot, PGC_QUEUE_LOCK_PRIO_OTHERS);
 
     Pvoid_t JudyL_metrics = NULL;
     Pvoid_t JudyL_extents_pos = NULL;
@@ -2556,7 +2565,7 @@ void pgc_open_cache_to_journal_v2(PGC *cache, Word_t section, unsigned datafile_
         }
 
         yield_the_processor(); // do not lock too aggressively
-            pgc_queue_lock(cache, &cache->hot);
+        pgc_queue_lock(cache, &cache->hot, PGC_QUEUE_LOCK_PRIO_OTHERS);
     }
 
     spinlock_unlock(&sp->migration_to_v2_spinlock);
@@ -2580,7 +2589,7 @@ void pgc_open_cache_to_journal_v2(PGC *cache, Word_t section, unsigned datafile_
 
                 // balance-parents: transition from hot to clean directly
                 yield_the_processor(); // do not lock too aggressively
-                page_set_clean(cache, pi->page, true, false);
+                page_set_clean(cache, pi->page, true, false, PGC_QUEUE_LOCK_PRIO_OTHERS);
                 page_transition_unlock(cache, pi->page);
                 page_release(cache, pi->page, true);
 
@@ -2631,7 +2640,7 @@ void pgc_open_evict_clean_pages_of_datafile(PGC *cache, struct rrdengine_datafil
 size_t pgc_count_clean_pages_having_data_ptr(PGC *cache, Word_t section, void *ptr) {
     size_t found = 0;
 
-    pgc_queue_lock(cache, &cache->clean);
+    pgc_queue_lock(cache, &cache->clean, PGC_QUEUE_LOCK_PRIO_OTHERS);
     for(PGC_PAGE *page = cache->clean.base; page ;page = page->link.next)
         found += (page->data == ptr && page->section == section) ? 1 : 0;
     pgc_queue_unlock(cache, &cache->clean);
@@ -2642,7 +2651,7 @@ size_t pgc_count_clean_pages_having_data_ptr(PGC *cache, Word_t section, void *p
 size_t pgc_count_hot_pages_having_data_ptr(PGC *cache, Word_t section, void *ptr) {
     size_t found = 0;
 
-    pgc_queue_lock(cache, &cache->hot);
+    pgc_queue_lock(cache, &cache->hot, PGC_QUEUE_LOCK_PRIO_OTHERS);
     Pvoid_t *section_pages_pptr = JudyLGet(cache->hot.sections_judy, section, PJE0);
     if(section_pages_pptr) {
         struct section_pages *sp = *section_pages_pptr;

--- a/src/database/rrdlabels.c
+++ b/src/database/rrdlabels.c
@@ -168,14 +168,11 @@ static void delete_label(RRDLABEL *label)
         if (refcount == 0) {
             JudyAllocThreadPulseReset();
 
-            int ret = JudyHSDel(&global_labels.JudyHS, (void *)label, sizeof(*label), PJE0);
+            JudyHSDel(&global_labels.JudyHS, (void *)label, sizeof(*label), PJE0);
 
             int64_t judy_mem = JudyAllocThreadPulseGetAndReset();
 
-            if (unlikely(ret == JERR))
-                STATS_MINUS_MEMORY(&dictionary_stats_category_rrdlabels, judy_mem, sizeof(*rrdlabel), 0);
-            else
-                STATS_MINUS_MEMORY(&dictionary_stats_category_rrdlabels, judy_mem, sizeof(*rrdlabel), 0);
+            STATS_MINUS_MEMORY(&dictionary_stats_category_rrdlabels, judy_mem, sizeof(*rrdlabel), 0);
             string_freez(label->index.key);
             string_freez(label->index.value);
             freez(rrdlabel);

--- a/src/libnetdata/local-sockets/local-sockets.h
+++ b/src/libnetdata/local-sockets/local-sockets.h
@@ -472,8 +472,8 @@ static inline const char *local_sockets_protocol_name(LOCAL_SOCKET *n) {
 static inline void local_listeners_print_socket(LS_STATE *ls __maybe_unused, const LOCAL_SOCKET *nn, void *data __maybe_unused) {
     LOCAL_SOCKET *n = (LOCAL_SOCKET *)nn;
 
-    char local_address[INET6_ADDRSTRLEN];
-    char remote_address[INET6_ADDRSTRLEN];
+    char local_address[INET6_ADDRSTRLEN] = "";
+    char remote_address[INET6_ADDRSTRLEN] = "";
 
     if(n->local.family == AF_INET) {
         ipv4_address_to_txt(n->local.ip.ipv4, local_address);

--- a/src/libnetdata/log/systemd-cat-native.c
+++ b/src/libnetdata/log/systemd-cat-native.c
@@ -231,13 +231,13 @@ static CURLcode journal_remote_send_buffer(CURL* curl, BUFFER *msg) {
     if(verbose)
         log_message_to_stderr(msg, "REMOTE");
 
-    struct upload_data upload = {0};
-
     if (!curl || !buffer_strlen(msg))
         return CURLE_FAILED_INIT;
 
-    upload.data = (char *) buffer_tostring(msg);
-    upload.length = buffer_strlen(msg);
+    struct upload_data upload = {
+        .data = (char *) buffer_tostring(msg),
+        .length = buffer_strlen(msg),
+    };
 
     curl_easy_setopt(curl, CURLOPT_READDATA, &upload);
     curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)upload.length);
@@ -290,7 +290,7 @@ static log_to_journal_remote_ret_t log_input_to_journal_remote(const char *url, 
         fprintf(stderr, "WARNING: cannot read '%s'. Will generate a random _MACHINE_ID.\n", MACHINE_ID_PATH);
         nd_uuid_t uuid;
         uuid_generate_random(uuid);
-        uuid_unparse_lower_compact(uuid, global_boot_id);
+        uuid_unparse_lower_compact(uuid, global_machine_id);
     }
 
     if(global_stream_id[0] == '\0') {

--- a/src/libnetdata/socket/poll-events.c
+++ b/src/libnetdata/socket/poll-events.c
@@ -280,12 +280,9 @@ static int poll_process_new_tcp_connection(POLLINFO *pi, time_t now) {
                    "POLLFD: LISTENER: accept() failed.");
 
     }
-    else if(is_socket_closed(nfd)) {
-        nd_log_limit_static_global_var(erl, 10, 1000);
-        nd_log_limit(&erl, NDLS_DAEMON, NDLP_ERR,
-                     "POLLFD: LISTENER: received client socket %d is closed on accept(), dropping connection", nfd);
-            close(nfd);
-    }
+    else if(is_socket_closed(nfd))
+        close(nfd);
+
     else {
         // accept ok
 

--- a/src/libnetdata/socket/socket.c
+++ b/src/libnetdata/socket/socket.c
@@ -159,12 +159,14 @@ int sock_enlarge_rcv_buf(int fd) {
     if (getsockopt(fd, SOL_SOCKET, SO_RCVBUF, &current_bs, &optlen) == 0) {
         // Set the buffer size only if it's smaller than the desired size
         if (current_bs < bs) {
-            setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &bs, sizeof(bs));
+            if(setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &bs, sizeof(bs)) != 0)
+                return -1;
 
             // Re-check the buffer size after attempting to set it
             if (getsockopt(fd, SOL_SOCKET, SO_RCVBUF, &current_bs, &optlen) == 0)
                 ret = current_bs;
-        } else {
+        }
+        else {
             // Current buffer size is already large enough
             ret = current_bs;
         }
@@ -184,12 +186,14 @@ int sock_enlarge_snd_buf(int fd) {
     if (getsockopt(fd, SOL_SOCKET, SO_SNDBUF, &current_bs, &optlen) == 0) {
         // Set the buffer size only if it's smaller than the desired size
         if (current_bs < bs) {
-            setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &bs, sizeof(bs));
+            if(setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &bs, sizeof(bs)) != 0)
+                return -1;
 
             // Re-check the buffer size after attempting to set it
             if (getsockopt(fd, SOL_SOCKET, SO_SNDBUF, &current_bs, &optlen) == 0)
                 ret = current_bs;
-        } else {
+        }
+        else {
             // Current buffer size is already large enough
             ret = current_bs;
         }

--- a/src/libnetdata/waiting-queue/waiting-queue.c
+++ b/src/libnetdata/waiting-queue/waiting-queue.c
@@ -2,19 +2,73 @@
 
 #include "waiting-queue.h"
 
+#if defined(OS_LINUX)
+#include <linux/futex.h>
+#include <sys/syscall.h>
+
+typedef int WQ_COND;
+typedef SPINLOCK WQ_MUTEX;
+
+static inline int futex_wait(int *uaddr, int val) {
+    return syscall(SYS_futex, uaddr, FUTEX_WAIT_PRIVATE, val, NULL, NULL, 0);
+}
+
+static inline int futex_wake(int *uaddr, int n) {
+    return syscall(SYS_futex, uaddr, FUTEX_WAKE_PRIVATE, n, NULL, NULL, 0);
+}
+
+static int WQ_COND_init(WQ_COND *cond) { *(cond) = 0; return 0; }
+#define WQ_COND_destroy(cond) debug_dummy()
+
+static inline int WQ_COND_wait(WQ_COND *cond, WQ_MUTEX *mutex) {
+    int value = *cond;
+    spinlock_unlock(mutex);
+    futex_wait(cond, value);
+    spinlock_lock(mutex);
+    return 0;
+}
+
+static inline int WQ_COND_signal(WQ_COND *cond) {
+    __atomic_add_fetch(cond, 1, __ATOMIC_SEQ_CST);
+    futex_wake(cond, 1);
+    return 0;
+}
+
+#define WQ_MUTEX_init(mutex) ({ spinlock_init(mutex) ; 0; })
+#define WQ_MUTEX_destroy(mutex) debug_dummy()
+#define WQ_MUTEX_lock(mutex) spinlock_lock(mutex)
+#define WQ_MUTEX_unlock(mutex) spinlock_unlock(mutex)
+
+#else // !USE_FUTEX
+
+typedef uv_cond_t WQ_COND;
+typedef uv_mutex_t WQ_MUTEX;
+
+#define WQ_COND_init(cond) uv_cond_init(cond)
+#define WQ_COND_destroy(cond) uv_cond_destroy(cond)
+#define WQ_COND_wait(cond, mutex) uv_cond_wait(cond, mutex)
+#define WQ_COND_signal(cond) uv_cond_signal(cond)
+
+#define WQ_MUTEX_init(mutex) uv_mutex_init(mutex)
+#define WQ_MUTEX_destroy(mutex) uv_mutex_destroy(mutex)
+#define WQ_MUTEX_lock(mutex) uv_mutex_lock(mutex)
+#define WQ_MUTEX_unlock(mutex) uv_mutex_unlock(mutex)
+
+#endif // USE_FUTEX
+
 typedef struct waiting_thread {
-    uv_cond_t cond;          // condition variable for this thread
+    WQ_COND cond;               // condition variable for this thread
     usec_t waiting_since_ut;    // when we started waiting
-    Word_t order;
+    Word_t priority;
     struct waiting_thread *prev, *next;
 } WAITING_THREAD;
 
 struct waiting_queue {
-    uv_mutex_t mutex;           // protect the queue structure
+    WQ_MUTEX mutex;             // ensure acquirers and releasers are synchronized
     Word_t last_seqno;          // incrementing sequence counter
-    WAITING_THREAD *list;
-    size_t running;             // number of threads currently running/waiting
-    SPINLOCK spinlock;
+    SPINLOCK spinlock;          // ensures there is only 1 runner at a time
+    uint32_t running;           // number of threads, including the one holding the lock
+    WAITING_THREAD *list;       // the list of threads waiting, not including the 1 holding the lock
 };
 
 // Determine available bits based on system word size
@@ -41,7 +95,7 @@ static inline Word_t key_get_seqno(Word_t key) {
 WAITING_QUEUE *waiting_queue_create(void) {
     WAITING_QUEUE *wq = callocz(1, sizeof(WAITING_QUEUE));
 
-    int ret = uv_mutex_init(&wq->mutex);
+    int ret = WQ_MUTEX_init(&wq->mutex);
     if(ret != 0) {
         freez(wq);
         return NULL;
@@ -57,15 +111,15 @@ void waiting_queue_destroy(WAITING_QUEUE *wq) {
     if(!wq) return;
 
     if(wq->running)
-        fatal("WAITING_QUEUE: destroying waiting queue that still has %zu threads running/waiting", wq->running);
+        fatal("WAITING_QUEUE: destroying waiting queue that still has %u threads running/waiting", wq->running);
 
-    uv_mutex_destroy(&wq->mutex);
+    WQ_MUTEX_destroy(&wq->mutex);
     freez(wq);
 }
 
 static inline void WAITERS_SET(WAITING_QUEUE *wq, WAITING_THREAD *wt) {
     for(WAITING_THREAD *t = wq->list ; t ;t = t->next) {
-        if(wt->order < t->order) {
+        if(wt->priority < t->priority) {
             DOUBLE_LINKED_LIST_INSERT_ITEM_BEFORE_UNSAFE(wq->list, t, wt, prev, next);
             return;
         }
@@ -83,24 +137,34 @@ static inline WAITING_THREAD *WAITERS_FIRST(WAITING_QUEUE *wq) {
 
 static inline void WAITING_THREAD_init(WAITING_QUEUE *wq, WAITING_THREAD *wt, WAITING_QUEUE_PRIORITY priority) {
     Word_t seqno = __atomic_add_fetch(&wq->last_seqno, 1, __ATOMIC_RELAXED);
-    wt->order = make_key(priority, seqno);
+    wt->priority = make_key(priority, seqno);
     wt->waiting_since_ut = now_monotonic_usec();
     wt->prev = wt->next = NULL;
 
-    int ret = uv_cond_init(&wt->cond);
+    int ret = WQ_COND_init(&wt->cond);
     if(ret != 0)
         fatal("WAITING_QUEUE: cannot initialize condition variable");
 }
 
-static inline void WAITING_THREAD_cleanup(WAITING_QUEUE *wq __maybe_unused, WAITING_THREAD *wt) {
-    uv_cond_destroy(&wt->cond);
+static inline void WAITING_THREAD_cleanup(WAITING_QUEUE *wq __maybe_unused, WAITING_THREAD *wt __maybe_unused) {
+    WQ_COND_destroy(&wt->cond);
 }
 
-usec_t waiting_queue_wait(WAITING_QUEUE *wq, WAITING_QUEUE_PRIORITY priority) {
+bool waiting_queue_try_acquire(WAITING_QUEUE *wq) {
+    if(__atomic_add_fetch(&wq->running, 1, __ATOMIC_RELAXED) == 1 &&
+        spinlock_trylock(&wq->spinlock)) {
+        return true;
+    }
+
+    __atomic_sub_fetch(&wq->running, 1, __ATOMIC_RELAXED);
+    return false;
+}
+
+usec_t waiting_queue_acquire(WAITING_QUEUE *wq, WAITING_QUEUE_PRIORITY priority) {
     // Try fast path first - if we're the only one, just go
-    if(__atomic_add_fetch(&wq->running, 1, __ATOMIC_RELAXED) == 1) {
-        if(spinlock_trylock(&wq->spinlock))
-            return 0;
+    if(__atomic_add_fetch(&wq->running, 1, __ATOMIC_RELAXED) == 1 &&
+        spinlock_trylock(&wq->spinlock)) {
+        return 0;
     }
 
     // Slow path - need to wait
@@ -108,7 +172,7 @@ usec_t waiting_queue_wait(WAITING_QUEUE *wq, WAITING_QUEUE_PRIORITY priority) {
     WAITING_THREAD wt;
     WAITING_THREAD_init(wq, &wt, priority);
 
-    uv_mutex_lock(&wq->mutex);
+    WQ_MUTEX_lock(&wq->mutex);
     WAITERS_SET(wq, &wt);
 
     // Wait for our turn
@@ -116,17 +180,17 @@ usec_t waiting_queue_wait(WAITING_QUEUE *wq, WAITING_QUEUE_PRIORITY priority) {
         if (WAITERS_FIRST(wq) == &wt && spinlock_trylock(&wq->spinlock))
             break;
         else
-            uv_cond_wait(&wt.cond, &wq->mutex);
+            WQ_COND_wait(&wt.cond, &wq->mutex);
     } while(true);
 
     WAITERS_DEL(wq, &wt);
-    uv_mutex_unlock(&wq->mutex);
+    WQ_MUTEX_unlock(&wq->mutex);
     WAITING_THREAD_cleanup(wq, &wt);
 
     return now_monotonic_usec() - wt.waiting_since_ut;
 }
 
-void waiting_queue_done(WAITING_QUEUE *wq) {
+void waiting_queue_release(WAITING_QUEUE *wq) {
     spinlock_unlock(&wq->spinlock);
 
     // Fast path if we're alone
@@ -134,13 +198,13 @@ void waiting_queue_done(WAITING_QUEUE *wq) {
         return;
 
     // Slow path - need to signal next in line
-    uv_mutex_lock(&wq->mutex);
+    WQ_MUTEX_lock(&wq->mutex);
 
     // Wake up next in line if any
     if(wq->list)
-        uv_cond_signal(&wq->list->cond);
+        WQ_COND_signal(&wq->list->cond);
 
-    uv_mutex_unlock(&wq->mutex);
+    WQ_MUTEX_unlock(&wq->mutex);
 }
 
 size_t waiting_queue_waiting(WAITING_QUEUE *wq) {
@@ -183,8 +247,8 @@ static int unittest_functional(void) {
 
     // Test 1: Fast path should work with no contention
     fprintf(stderr, "  Test 1: Fast path - no contention: ");
-    usec_t wait_time = waiting_queue_wait(wq, WAITING_QUEUE_PRIO_NORMAL);
-    waiting_queue_done(wq);
+    usec_t wait_time = waiting_queue_acquire(wq, WAITING_QUEUE_PRIO_NORMAL);
+    waiting_queue_release(wq);
     if(wait_time != 0) {
         fprintf(stderr, "FAILED (waited %"PRIu64" usec)\n", wait_time);
         errors++;
@@ -210,8 +274,8 @@ static int unittest_functional(void) {
         WAITERS_DEL(wq, wt);
         __atomic_sub_fetch(&wq->running, 1, __ATOMIC_RELAXED);
 
-        WAITING_QUEUE_PRIORITY prio = key_get_priority(wt->order);
-        Word_t seqno = key_get_seqno(wt->order);
+        WAITING_QUEUE_PRIORITY prio = key_get_priority(wt->priority);
+        Word_t seqno = key_get_seqno(wt->priority);
 
         prio_counts[prio]++;
         if(prio < last_prio) {
@@ -265,7 +329,7 @@ static void *stress_thread(void *arg) {
     bool *stop_flag = args->stop_flag;
 
     while(!__atomic_load_n(stop_flag, __ATOMIC_ACQUIRE)) {
-        usec_t wait_time = waiting_queue_wait(wq, stats->priority);
+        usec_t wait_time = waiting_queue_acquire(wq, stats->priority);
         stats->executions++;
         stats->total_wait_time += wait_time;
         if(wait_time > stats->max_wait_time)
@@ -274,7 +338,7 @@ static void *stress_thread(void *arg) {
         if(with_sleep)
             tinysleep();
 
-        waiting_queue_done(wq);
+        waiting_queue_release(wq);
     }
 
     return NULL;

--- a/src/libnetdata/waiting-queue/waiting-queue.h
+++ b/src/libnetdata/waiting-queue/waiting-queue.h
@@ -4,7 +4,6 @@
 #define NETDATA_WAITING_QUEUE_H
 
 #include "libnetdata/libnetdata.h"
-#include <uv.h>
 
 /*
  * WAITING QUEUE
@@ -43,12 +42,15 @@ WAITING_QUEUE *waiting_queue_create(void);
 // Destroy a waiting queue - must be empty
 void waiting_queue_destroy(WAITING_QUEUE *wq);
 
+// Returns true when the queue is acquired
+bool waiting_queue_try_acquire(WAITING_QUEUE *wq);
+
 // Returns when it is our turn to run
 // Returns time spent waiting in microseconds
-usec_t waiting_queue_wait(WAITING_QUEUE *wq, WAITING_QUEUE_PRIORITY priority);
+usec_t waiting_queue_acquire(WAITING_QUEUE *wq, WAITING_QUEUE_PRIORITY priority);
 
 // Mark that we are done - wakes up the next in line
-void waiting_queue_done(WAITING_QUEUE *wq);
+void waiting_queue_release(WAITING_QUEUE *wq);
 
 // Return the number of threads currently waiting
 size_t waiting_queue_waiting(WAITING_QUEUE *wq);

--- a/src/streaming/stream-sender.c
+++ b/src/streaming/stream-sender.c
@@ -371,7 +371,7 @@ static void stream_sender_log_disconnection(struct stream_thread *sth, struct se
     ND_LOG_STACK_PUSH(lgs);
 
     nd_log(NDLS_DAEMON, NDLP_NOTICE,
-           "STREAM SND[%zu] '%s' [to %s]: sender disconnected from parent, reason: %s (replication in: %u, out: %u, pending: %u)",
+           "STREAM SND[%zu] '%s' [to %s]: sender disconnected from parent, reason: %s (replication in: %u, out: %u, pending: %zu)",
            sth->id, rrdhost_hostname(s->host), s->remote_ip, stream_handshake_error_to_string(reason),
            s->host->stream.snd.status.replication.counter_in, s->host->stream.snd.status.replication.counter_out,
            dictionary_entries(s->replication.requests));


### PR DESCRIPTION
- [x] do not log when a socket is found closed on `accept()`
- [x] waiting queue use `futex` under Linux for 30% better performance
- [x] pgc uses waiting queues for its queues locks, to avoid starvation under intense background activity (jv2 indexing, etc)