### PR TITLE
Locks Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -955,6 +955,8 @@ set(LIBNETDATA_FILES
         src/libnetdata/object-state/object-state.h
         src/libnetdata/locks/benchmark.c
         src/libnetdata/locks/benchmark.h
+        src/libnetdata/locks/benchmark-rw.c
+        src/libnetdata/locks/benchmark-rw.h
 )
 
 set(LIBH2O_FILES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -953,6 +953,8 @@ set(LIBNETDATA_FILES
         src/libnetdata/locks/waitq.h
         src/libnetdata/object-state/object-state.c
         src/libnetdata/object-state/object-state.h
+        src/libnetdata/locks/benchmark.c
+        src/libnetdata/locks/benchmark.h
 )
 
 set(LIBH2O_FILES

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -407,6 +407,10 @@ int netdata_main(int argc, char **argv) {
                             unittest_running = true;
                             return locks_stress_test();
                         }
+                        else if(strcmp(optarg, "rwlockstest") == 0) {
+                            unittest_running = true;
+                            return rwlocks_stress_test();
+                        }
                         else if(strcmp(optarg, "stringtest") == 0)  {
                             unittest_running = true;
                             return string_unittest(10000);

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -403,6 +403,10 @@ int netdata_main(int argc, char **argv) {
                             unittest_running = true;
                             return unittest_waiting_queue();
                         }
+                        else if(strcmp(optarg, "lockstest") == 0) {
+                            unittest_running = true;
+                            return locks_stress_test();
+                        }
                         else if(strcmp(optarg, "stringtest") == 0)  {
                             unittest_running = true;
                             return string_unittest(10000);

--- a/src/libnetdata/libnetdata.h
+++ b/src/libnetdata/libnetdata.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #include "atomics/atomics.h"
 #include "libjudy/judy-malloc.h"
-
+#include "locks/benchmark.h"
 #include "object-state/object-state.h"
 #include "storage-point.h"
 #include "paths/paths.h"

--- a/src/libnetdata/libnetdata.h
+++ b/src/libnetdata/libnetdata.h
@@ -17,6 +17,7 @@ extern "C" {
 #include "atomics/atomics.h"
 #include "libjudy/judy-malloc.h"
 #include "locks/benchmark.h"
+#include "locks/benchmark-rw.h"
 #include "object-state/object-state.h"
 #include "storage-point.h"
 #include "paths/paths.h"

--- a/src/libnetdata/locks/benchmark-rw.c
+++ b/src/libnetdata/locks/benchmark-rw.c
@@ -1,0 +1,439 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "benchmark-rw.h"
+
+#define MAX_THREADS 64
+#define TEST_DURATION_SEC 1
+#define STOP_SIGNAL UINT64_MAX
+#define MAX_CONFIGS 10
+
+// Structure to store summary statistics
+typedef struct {
+    double ops_per_sec[2][MAX_CONFIGS];          // [lock_type][config_index], Total ops/sec
+    double reader_ops_per_sec[2][MAX_CONFIGS];   // [lock_type][config_index], Reader ops/sec
+    double writer_ops_per_sec[2][MAX_CONFIGS];   // [lock_type][config_index], Writer ops/sec
+    int readers[MAX_CONFIGS];                    // Number of readers for each config
+    int writers[MAX_CONFIGS];                    // Number of writers for each config
+    int config_count;                            // Number of configurations tested
+} summary_stats_t;
+
+typedef struct {
+    // Protected state to validate reader/writer mutual exclusion
+    volatile int readers;           // Number of active readers
+    volatile int writers;           // Number of active writers
+    volatile uint64_t violations;   // Counter for reader/writer violations
+
+    // Protected counter for actual work
+    uint64_t counter;
+
+    // Statistics per thread
+    struct {
+        uint64_t operations;        // Number of read/write operations
+        usec_t test_time;          // Time spent in test
+        volatile int ready;         // Thread completed flag
+    } stats[MAX_THREADS];
+
+    // Per-thread control
+    struct {
+        pthread_cond_t cond;              // Thread start condition
+        pthread_mutex_t cond_mutex;       // Mutex for condition
+        uint64_t run_flag;               // Thread run control
+    } thread_controls[MAX_THREADS];
+} rwlock_control_t;
+
+typedef enum {
+    THREAD_READER,
+    THREAD_WRITER
+} thread_type_t;
+
+typedef struct {
+    int thread_id;
+    thread_type_t type;
+    void *lock;                  // Points to either pthread_rwlock_t or RW_SPINLOCK
+    bool is_spinlock;            // true for RW_SPINLOCK, false for pthread_rwlock_t
+    rwlock_control_t *control;
+    ND_THREAD *thread;
+} thread_context_t;
+
+static inline void verify_no_violations(rwlock_control_t *control) {
+    if(__atomic_load_n(&control->violations, __ATOMIC_RELAXED) > 0) {
+        fprintf(stderr, "\nFATAL ERROR: Detected %"PRIu64" read/write violations!\n"
+                        "This indicates readers and writers were concurrently inside the lock.\n",
+                control->violations);
+        exit(1);
+    }
+}
+
+static inline void check_access_safety(rwlock_control_t *control, thread_type_t type) {
+    if(type == THREAD_READER) {
+        // Reader entering critical section
+        __atomic_add_fetch(&control->readers, 1, __ATOMIC_RELAXED);
+
+        // Check if we have any writers - this would be a violation
+        if(__atomic_load_n(&control->writers, __ATOMIC_RELAXED) > 0) {
+            __atomic_add_fetch(&control->violations, 1, __ATOMIC_RELAXED);
+        }
+    }
+    else {
+        // Writer entering critical section
+        int writers = __atomic_add_fetch(&control->writers, 1, __ATOMIC_RELAXED);
+
+        // Check for other writers - violation!
+        if(writers > 1) {
+            __atomic_add_fetch(&control->violations, 1, __ATOMIC_RELAXED);
+        }
+
+        // Check if we have any readers - this would be a violation
+        if(__atomic_load_n(&control->readers, __ATOMIC_RELAXED) > 0) {
+            __atomic_add_fetch(&control->violations, 1, __ATOMIC_RELAXED);
+        }
+    }
+}
+
+static void release_access(rwlock_control_t *control, thread_type_t type) {
+    if(type == THREAD_READER) {
+        __atomic_sub_fetch(&control->readers, 1, __ATOMIC_RELAXED);
+    }
+    else {
+        __atomic_sub_fetch(&control->writers, 1, __ATOMIC_RELAXED);
+    }
+}
+
+static void wait_for_start(pthread_cond_t *cond, pthread_mutex_t *mutex, uint64_t *flag) {
+    pthread_mutex_lock(mutex);
+    while (*flag == 0)
+        pthread_cond_wait(cond, mutex);
+    pthread_mutex_unlock(mutex);
+}
+
+static void* benchmark_thread(void *arg) {
+    thread_context_t *ctx = (thread_context_t *)arg;
+    rwlock_control_t *control = ctx->control;
+
+    while(1) {
+        // Wait for start signal
+        wait_for_start(&control->thread_controls[ctx->thread_id].cond,
+                       &control->thread_controls[ctx->thread_id].cond_mutex,
+                       &control->thread_controls[ctx->thread_id].run_flag);
+
+        if (control->thread_controls[ctx->thread_id].run_flag == STOP_SIGNAL)
+            break;
+
+        usec_t start = now_monotonic_high_precision_usec();
+        uint64_t operations = 0;
+
+        while (control->thread_controls[ctx->thread_id].run_flag) {
+            if(ctx->is_spinlock) {
+                RW_SPINLOCK *spinlock = ctx->lock;
+                if(ctx->type == THREAD_READER) {
+                    rw_spinlock_read_lock(spinlock);
+                    check_access_safety(control, THREAD_READER);
+                    control->counter++;  // Just to do some work
+                    release_access(control, THREAD_READER);
+                    rw_spinlock_read_unlock(spinlock);
+                }
+                else {
+                    rw_spinlock_write_lock(spinlock);
+                    check_access_safety(control, THREAD_WRITER);
+                    control->counter++;
+                    release_access(control, THREAD_WRITER);
+                    rw_spinlock_write_unlock(spinlock);
+                }
+            }
+            else {
+                pthread_rwlock_t *rwlock = ctx->lock;
+                if(ctx->type == THREAD_READER) {
+                    pthread_rwlock_rdlock(rwlock);
+                    check_access_safety(control, THREAD_READER);
+                    control->counter++;
+                    release_access(control, THREAD_READER);
+                    pthread_rwlock_unlock(rwlock);
+                }
+                else {
+                    pthread_rwlock_wrlock(rwlock);
+                    check_access_safety(control, THREAD_WRITER);
+                    control->counter++;
+                    release_access(control, THREAD_WRITER);
+                    pthread_rwlock_unlock(rwlock);
+                }
+            }
+            operations++;
+        }
+
+        // Store results
+        usec_t test_time = now_monotonic_high_precision_usec() - start;
+        __atomic_store_n(&control->stats[ctx->thread_id].test_time, test_time, __ATOMIC_RELEASE);
+        __atomic_store_n(&control->stats[ctx->thread_id].operations, operations, __ATOMIC_RELEASE);
+        __atomic_store_n(&control->stats[ctx->thread_id].ready, 1, __ATOMIC_RELEASE);
+    }
+
+    return NULL;
+}
+
+static void print_summary(const summary_stats_t *summary) {
+    fprintf(stderr, "\n=== Performance Summary (Million operations/sec) ===\n\n");
+    fprintf(stderr, "%-16s %-8s %-8s %-16s %-16s\n",
+            "Lock Type", "Readers", "Writers", "Reader Ops/s", "Writer Ops/s");
+    fprintf(stderr, "----------------------------------------------------------------------\n");
+
+    const char *lock_names[] = {"pthread_rwlock", "rw_spinlock"};
+
+    for (int config = 0; config < summary->config_count; config++) {
+        for (int lock_type = 0; lock_type < 2; lock_type++) {
+            // double total_ops = summary->ops_per_sec[lock_type][config];
+            int readers = summary->readers[config];
+            int writers = summary->writers[config];
+
+            // Get the actual reader and writer operations
+            double reader_ops = readers > 0 ? summary->reader_ops_per_sec[lock_type][config] : 0;
+            double writer_ops = writers > 0 ? summary->writer_ops_per_sec[lock_type][config] : 0;
+
+            fprintf(stderr, "%-16s %-8d %-8d %-16.2f %-16.2f\n",
+                    lock_names[lock_type],
+                    readers,
+                    writers,
+                    reader_ops / 1000000.0,
+                    writer_ops / 1000000.0);
+        }
+        // Add a separator between configurations
+        if (config < summary->config_count - 1)
+            fprintf(stderr, "----------------------------------------------------------------------\n");
+    }
+    fprintf(stderr, "\n");
+}
+
+static void print_thread_stats(const char *test_name, int readers, int writers,
+                               thread_context_t *contexts, rwlock_control_t *control,
+                               summary_stats_t *summary, int config_idx, int lock_type) {
+    fprintf(stderr, "\n%-20s (readers: %d, writers: %d)\n", test_name, readers, writers);
+    fprintf(stderr, "%4s %8s %12s %12s %12s\n",
+            "THR", "TYPE", "OPS", "OPS/SEC", "TIME (ms)");
+
+    uint64_t total_ops = 0;
+    double total_ops_per_sec = 0;
+    double reader_ops_per_sec = 0;
+    double writer_ops_per_sec = 0;
+
+    for(int i = 0; i < readers + writers; i++) {
+        uint64_t ops = __atomic_load_n(&control->stats[i].operations, __ATOMIC_RELAXED);
+        usec_t time = __atomic_load_n(&control->stats[i].test_time, __ATOMIC_RELAXED);
+        double ops_per_sec = (double)ops * USEC_PER_SEC / time;
+
+        fprintf(stderr, "%4d %8s %12"PRIu64" %12.0f %12.2f\n",
+                i,
+                contexts[i].type == THREAD_READER ? "READER" : "WRITER",
+                ops,
+                ops_per_sec,
+                (double)time / 1000.0);
+
+        total_ops += ops;
+        total_ops_per_sec += ops_per_sec;
+
+        if (contexts[i].type == THREAD_READER) {
+            reader_ops_per_sec += ops_per_sec;
+        } else {
+            writer_ops_per_sec += ops_per_sec;
+        }
+    }
+
+    fprintf(stderr, "%4s %8s %12"PRIu64" %12.0f\n",
+            "TOT", "", total_ops, total_ops_per_sec);
+
+    // Store in summary
+    summary->ops_per_sec[lock_type][config_idx] = total_ops_per_sec;
+    summary->reader_ops_per_sec[lock_type][config_idx] = reader_ops_per_sec;
+    summary->writer_ops_per_sec[lock_type][config_idx] = writer_ops_per_sec;
+    summary->readers[config_idx] = readers;
+    summary->writers[config_idx] = writers;
+
+    verify_no_violations(control);
+}
+
+
+static void run_test(const char *name, int readers, int writers,
+                     thread_context_t *contexts, rwlock_control_t *control,
+                     summary_stats_t *summary, int config_idx, int lock_type) {
+    fprintf(stderr, "\nRunning test: %s with %d readers and %d writers...\n",
+            name, readers, writers);
+
+    // Reset all stats and control
+    memset(&control->stats, 0, sizeof(control->stats));
+    control->counter = 0;
+    control->readers = 0;
+    control->writers = 0;
+    control->violations = 0;
+
+    int total_threads = readers + writers;
+
+    // Signal threads to start
+    for(int i = 0; i < total_threads; i++) {
+        pthread_mutex_lock(&control->thread_controls[i].cond_mutex);
+        control->thread_controls[i].run_flag = 1;
+        pthread_cond_signal(&control->thread_controls[i].cond);
+        pthread_mutex_unlock(&control->thread_controls[i].cond_mutex);
+    }
+
+    // Wait for test duration
+    sleep_usec(TEST_DURATION_SEC * USEC_PER_SEC);
+
+    // Signal threads to stop
+    for(int i = 0; i < total_threads; i++) {
+        __atomic_store_n(&control->thread_controls[i].run_flag, 0, __ATOMIC_RELEASE);
+    }
+
+    // Wait for threads to report results
+    for(int i = 0; i < total_threads; i++) {
+        while(!__atomic_load_n(&control->stats[i].ready, __ATOMIC_ACQUIRE))
+            sleep_usec(10);
+    }
+
+    print_thread_stats(name, readers, writers, contexts, control, summary, config_idx, lock_type);
+}
+
+int rwlocks_stress_test(void) {
+    pthread_rwlock_t pthread_rwlock = PTHREAD_RWLOCK_INITIALIZER;
+    RW_SPINLOCK rw_spinlock = RW_SPINLOCK_INITIALIZER;
+    summary_stats_t summary = {0};
+
+    // Initialize control structures
+    rwlock_control_t pthread_control = { 0 };
+    rwlock_control_t spinlock_control = { 0 };
+
+    // Initialize per-thread controls for both locks
+    for(int i = 0; i < MAX_THREADS; i++) {
+        pthread_control.thread_controls[i].cond = (pthread_cond_t)PTHREAD_COND_INITIALIZER;
+        pthread_control.thread_controls[i].cond_mutex = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
+        pthread_control.thread_controls[i].run_flag = 0;
+
+        spinlock_control.thread_controls[i].cond = (pthread_cond_t)PTHREAD_COND_INITIALIZER;
+        spinlock_control.thread_controls[i].cond_mutex = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
+        spinlock_control.thread_controls[i].run_flag = 0;
+    }
+
+    // Create thread contexts
+    thread_context_t pthread_contexts[MAX_THREADS];
+    thread_context_t spinlock_contexts[MAX_THREADS];
+
+    fprintf(stderr, "\nStarting RW locks benchmark...\n");
+
+    // Test configurations: [readers, writers]
+    int configs[][2] = {
+        {1, 0},   // Single reader
+        {0, 1},   // Single writer
+        {1, 1},   // One reader + one writer
+        {2, 1},   // Two readers + one writer
+        {1, 2},   // One reader + two writers
+        {2, 2},   // Two readers + two writers
+        {4, 1},   // Four readers + one writer
+        {1, 4},   // One reader + four writers
+        {4, 4},   // Four readers + four writers
+    };
+
+    const int num_configs = sizeof(configs) / sizeof(configs[0]);
+    summary.config_count = num_configs;
+
+    // Create all threads
+    for(int i = 0; i < MAX_THREADS; i++) {
+        char thr_name[32];
+
+        // Initialize pthread contexts
+        pthread_contexts[i] = (thread_context_t){
+            .thread_id = i,
+            .type = i % 2 == 0 ? THREAD_READER :THREAD_WRITER,
+            .lock = &pthread_rwlock,
+            .is_spinlock = false,
+            .control = &pthread_control
+        };
+
+        snprintf(thr_name, sizeof(thr_name), "pthread_rw%d", i);
+        pthread_contexts[i].thread = nd_thread_create(
+            thr_name,
+            NETDATA_THREAD_OPTION_DONT_LOG | NETDATA_THREAD_OPTION_JOINABLE,
+            benchmark_thread,
+            &pthread_contexts[i]);
+
+        // Initialize spinlock contexts
+        spinlock_contexts[i] = (thread_context_t){
+            .thread_id = i,
+            .type = i % 2 == 0 ? THREAD_READER : THREAD_WRITER,
+            .lock = &rw_spinlock,
+            .is_spinlock = true,
+            .control = &spinlock_control
+        };
+
+        snprintf(thr_name, sizeof(thr_name), "spin_rw%d", i);
+        spinlock_contexts[i].thread = nd_thread_create(
+            thr_name,
+            NETDATA_THREAD_OPTION_DONT_LOG | NETDATA_THREAD_OPTION_JOINABLE,
+            benchmark_thread,
+            &spinlock_contexts[i]);
+    }
+
+    // Run all configurations
+    for(int i = 0; i < num_configs; i++) {
+        int readers = configs[i][0];
+        int writers = configs[i][1];
+
+        // Create all threads
+        int thread_idx = 0;
+
+        // First assign reader threads
+        for(int r = 0; r < readers; r++) {
+            pthread_contexts[thread_idx].type = THREAD_READER;
+            spinlock_contexts[thread_idx].type = THREAD_READER;
+            thread_idx++;
+        }
+
+        // Then assign writer threads
+        for(int w = 0; w < writers; w++) {
+            pthread_contexts[thread_idx].type = THREAD_WRITER;
+            spinlock_contexts[thread_idx].type = THREAD_WRITER;
+            thread_idx++;
+        }
+
+        char test_name[64];
+        snprintf(test_name, sizeof(test_name), "pthread_rwlock %dR/%dW", readers, writers);
+        run_test(test_name, readers, writers, pthread_contexts, &pthread_control, &summary, i, 0);
+
+        snprintf(test_name, sizeof(test_name), "rw_spinlock %dR/%dW", readers, writers);
+        run_test(test_name, readers, writers, spinlock_contexts, &spinlock_control, &summary, i, 1);
+    }
+
+    // Print the summary table
+    print_summary(&summary);
+
+    // Stop all threads
+    fprintf(stderr, "\nStopping threads...\n");
+    for(int i = 0; i < MAX_THREADS; i++) {
+        // Signal pthread threads
+        pthread_mutex_lock(&pthread_control.thread_controls[i].cond_mutex);
+        pthread_control.thread_controls[i].run_flag = STOP_SIGNAL;
+        pthread_cond_signal(&pthread_control.thread_controls[i].cond);
+        pthread_mutex_unlock(&pthread_control.thread_controls[i].cond_mutex);
+
+        // Signal spinlock threads
+        pthread_mutex_lock(&spinlock_control.thread_controls[i].cond_mutex);
+        spinlock_control.thread_controls[i].run_flag = STOP_SIGNAL;
+        pthread_cond_signal(&spinlock_control.thread_controls[i].cond);
+        pthread_mutex_unlock(&spinlock_control.thread_controls[i].cond_mutex);
+    }
+
+    // Join all threads
+    fprintf(stderr, "\nWaiting for threads to exit...\n");
+    for(int i = 0; i < MAX_THREADS; i++) {
+        nd_thread_join(pthread_contexts[i].thread);
+        nd_thread_join(spinlock_contexts[i].thread);
+    }
+
+    // Cleanup condition variables and mutexes
+    for(int i = 0; i < MAX_THREADS; i++) {
+        pthread_cond_destroy(&pthread_control.thread_controls[i].cond);
+        pthread_mutex_destroy(&pthread_control.thread_controls[i].cond_mutex);
+        pthread_cond_destroy(&spinlock_control.thread_controls[i].cond);
+        pthread_mutex_destroy(&spinlock_control.thread_controls[i].cond_mutex);
+    }
+
+    pthread_rwlock_destroy(&pthread_rwlock);
+
+    return 0;
+}

--- a/src/libnetdata/locks/benchmark-rw.h
+++ b/src/libnetdata/locks/benchmark-rw.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_BENCHMARK_RW_H
+#define NETDATA_BENCHMARK_RW_H
+
+#include "../libnetdata.h"
+
+int rwlocks_stress_test(void);
+
+#endif //NETDATA_BENCHMARK_RW_H

--- a/src/libnetdata/locks/benchmark.c
+++ b/src/libnetdata/locks/benchmark.c
@@ -299,7 +299,7 @@ static void set_waitq_priorities(int thread_count, thread_context_t *contexts) {
             contexts[3].priority = WAITQ_PRIO_LOW;
             break;
 
-        default:  // 8, 16, 32
+        default: { // 8, 16, 32
             int threads_per_priority = thread_count / 4;
             int remainder = thread_count % 4;
             int thread_idx = 0;
@@ -313,6 +313,7 @@ static void set_waitq_priorities(int thread_count, thread_context_t *contexts) {
                 }
             }
             break;
+        }
     }
 }
 

--- a/src/libnetdata/locks/benchmark.c
+++ b/src/libnetdata/locks/benchmark.c
@@ -1,0 +1,433 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "benchmark.h"
+
+#define MAX_THREADS 64
+#define TEST_DURATION_SEC 1
+#define STOP_SIGNAL UINT64_MAX
+#define NUM_LOCK_TYPES 5
+
+// Structure to store summary stats
+typedef struct {
+    double locks_per_sec[NUM_LOCK_TYPES][7];  // [lock_type][thread_count_index]
+} summary_stats_t;
+
+typedef struct {
+    uint64_t locks;
+    usec_t test_time;
+    volatile int ready;
+} thread_stats_t;
+
+typedef struct {
+    pthread_cond_t cond;              // Individual condition for each thread
+    pthread_mutex_t cond_mutex;       // Individual mutex for each thread
+    uint64_t run_flag;               // Individual run flag for each thread
+} thread_control_t;
+
+typedef struct {
+    uint64_t protected_counter;
+    thread_stats_t stats[MAX_THREADS];
+    thread_control_t thread_controls[MAX_THREADS];  // Array of per-thread controls
+} lock_control_t;
+
+typedef enum {
+    LOCK_MUTEX,
+    LOCK_RWLOCK,
+    LOCK_SPINLOCK,
+    LOCK_RW_SPINLOCK,
+    LOCK_WAITQ
+} lock_type_t;
+
+typedef struct {
+    int thread_id;
+    lock_type_t type;
+    WAITQ_PRIORITY priority;    // For waitq only
+    lock_control_t *control;
+    void *lock;                 // Points to the actual lock
+    ND_THREAD *thread;
+} thread_context_t;
+
+static const char *lock_names[] = {
+    "Mutex",
+    "RWLock",
+    "Spinlock",
+    "RW Spinlock",
+    "WaitQ"
+};
+
+static const char *priority_to_string(WAITQ_PRIORITY p) {
+    switch(p) {
+        case WAITQ_PRIO_URGENT: return "URGENT";
+        case WAITQ_PRIO_HIGH:   return "HIGH";
+        case WAITQ_PRIO_NORMAL: return "NORMAL";
+        case WAITQ_PRIO_LOW:    return "LOW";
+        default:                return "UNKNOWN";
+    }
+}
+
+static void print_summary(const summary_stats_t *summary) {
+    fprintf(stderr, "\n=== Performance Summary (Million locks/sec) ===\n\n");
+    fprintf(stderr, "%-12s %8s %8s %8s %8s %8s %8s %8s\n",
+                                "Lock Type", "1", "2", "4", "8", "16", "32", "64");
+    fprintf(stderr, "------------------------------------------------------------------------------\n");
+
+    for(int type = 0; type < NUM_LOCK_TYPES; type++) {
+        fprintf(stderr, "%-12s", lock_names[type]);
+        for(int i = 0; i < 7; i++) {  // 6 different thread counts
+            fprintf(stderr, " %8.2f", summary->locks_per_sec[type][i] / 1000000.0);
+        }
+        fprintf(stderr, "\n");
+    }
+    fprintf(stderr, "\n");
+}
+
+static void wait_for_signal(pthread_cond_t *cond, pthread_mutex_t *mutex, uint64_t *flag) {
+    pthread_mutex_lock(mutex);
+    while (*flag == 0)
+        pthread_cond_wait(cond, mutex);
+    pthread_mutex_unlock(mutex);
+}
+
+static void* benchmark_thread(void *arg) {
+    thread_context_t *ctx = (thread_context_t *)arg;
+    thread_stats_t *stats = &ctx->control->stats[ctx->thread_id];
+    thread_control_t *thread_control = &ctx->control->thread_controls[ctx->thread_id];
+
+    while(1) {
+        wait_for_signal(&thread_control->cond, &thread_control->cond_mutex, &thread_control->run_flag);
+
+        if (thread_control->run_flag == STOP_SIGNAL)
+            break;
+
+        usec_t start = now_monotonic_high_precision_usec();
+        uint64_t local_counter = 0;
+
+        switch(ctx->type) {
+            case LOCK_MUTEX: {
+                pthread_mutex_t *mutex = ctx->lock;
+                while (thread_control->run_flag) {
+                    pthread_mutex_lock(mutex);
+                    ctx->control->protected_counter++;
+                    pthread_mutex_unlock(mutex);
+                    local_counter++;
+                }
+                break;
+            }
+
+            case LOCK_RWLOCK: {
+                pthread_rwlock_t *rwlock = ctx->lock;
+                while (thread_control->run_flag) {
+                    pthread_rwlock_wrlock(rwlock);
+                    ctx->control->protected_counter++;
+                    pthread_rwlock_unlock(rwlock);
+                    local_counter++;
+                }
+                break;
+            }
+
+            case LOCK_SPINLOCK: {
+                SPINLOCK *spinlock = ctx->lock;
+                while (thread_control->run_flag) {
+                    spinlock_lock(spinlock);
+                    ctx->control->protected_counter++;
+                    spinlock_unlock(spinlock);
+                    local_counter++;
+                }
+                break;
+            }
+
+            case LOCK_RW_SPINLOCK: {
+                RW_SPINLOCK *rw_spinlock = ctx->lock;
+                while (thread_control->run_flag) {
+                    rw_spinlock_write_lock(rw_spinlock);
+                    ctx->control->protected_counter++;
+                    rw_spinlock_write_unlock(rw_spinlock);
+                    local_counter++;
+                }
+                break;
+            }
+
+            case LOCK_WAITQ: {
+                WAITQ *waitq = ctx->lock;
+                WAITQ_PRIORITY priority = ctx->priority;
+                while (thread_control->run_flag) {
+                    waitq_acquire(waitq, priority);
+                    ctx->control->protected_counter++;
+                    waitq_release(waitq);
+                    local_counter++;
+                }
+                break;
+            }
+        }
+
+        // Store results atomically
+        usec_t test_time = now_monotonic_high_precision_usec() - start;
+        __atomic_store_n(&stats->test_time, test_time, __ATOMIC_RELEASE);
+        __atomic_store_n(&stats->locks, local_counter, __ATOMIC_RELEASE);
+        __atomic_store_n(&stats->ready, 1, __ATOMIC_RELEASE);
+    }
+
+    return NULL;
+}
+
+static void print_thread_stats(const char *test_name, int threads, thread_context_t *contexts,
+                               thread_stats_t *stats, uint64_t protected_counter,
+                               summary_stats_t *summary, int thread_count_idx) {
+    fprintf(stderr, "\n%-20s (threads: %d)\n", test_name, threads);
+    if (strcmp(test_name, "WaitQ") == 0) {
+        fprintf(stderr, "%4s %8s %12s %12s %12s\n",
+                "THR", "PRIO", "LOCKS", "LOCKS/SEC", "TIME (ms)");
+    }
+    else {
+        fprintf(stderr, "%4s %12s %12s %12s\n",
+                "THR", "LOCKS", "LOCKS/SEC", "TIME (ms)");
+    }
+
+    uint64_t total_locks = 0;
+    double total_locks_per_sec = 0;
+
+    for(int i = 0; i < threads; i++) {
+        uint64_t locks = __atomic_load_n(&stats[i].locks, __ATOMIC_ACQUIRE);
+        usec_t time = __atomic_load_n(&stats[i].test_time, __ATOMIC_ACQUIRE);
+        double locks_per_sec = (double)locks * USEC_PER_SEC / time;
+        total_locks_per_sec += locks_per_sec;
+
+        if (strcmp(test_name, "WaitQ") == 0) {
+            fprintf(stderr, "%4d %8s %12"PRIu64" %12.0f %12.2f\n",
+                    i,
+                    priority_to_string(contexts[i].priority),
+                    locks,
+                    locks_per_sec,
+                    (double)time / 1000.0);
+        }
+        else {
+            fprintf(stderr, "%4d %12"PRIu64" %12.0f %12.2f\n",
+                    i, locks, locks_per_sec,
+                    (double)time / 1000.0);
+        }
+
+        total_locks += locks;
+    }
+
+    if(total_locks != protected_counter) {
+        fprintf(stderr, "\nERROR: Counter mismatch!\n");
+        fprintf(stderr, "Sum of thread counters: %"PRIu64"\n", total_locks);
+        fprintf(stderr, "Protected counter: %"PRIu64"\n", protected_counter);
+        fprintf(stderr, "Difference: %"PRIu64"\n",
+                total_locks > protected_counter ?
+                    total_locks - protected_counter :
+                    protected_counter - total_locks);
+
+        fflush(stderr);
+        _exit(1);
+    }
+
+    fprintf(stderr, "%4s %12"PRIu64"\n", "TOT", total_locks);
+
+    // Store in summary for the final table
+    summary->locks_per_sec[contexts[0].type][thread_count_idx] = total_locks_per_sec;
+}
+
+static void run_test(const char *name, int threads, thread_context_t *contexts,
+                     lock_control_t *control, summary_stats_t *summary) {
+    fprintf(stderr, "\nRunning test: %s with %d threads...\n", name, threads);
+
+    // Reset stats and counter
+    for(int i = 0; i < threads; i++) {
+        __atomic_store_n(&control->stats[i].locks, 0, __ATOMIC_RELEASE);
+        __atomic_store_n(&control->stats[i].test_time, 0, __ATOMIC_RELEASE);
+        __atomic_store_n(&control->stats[i].ready, 0, __ATOMIC_RELEASE);
+    }
+    control->protected_counter = 0;
+
+    // Signal only the threads we need for this test
+    for(int i = 0; i < threads; i++) {
+        thread_control_t *thread_control = &control->thread_controls[i];
+        pthread_mutex_lock(&thread_control->cond_mutex);
+        thread_control->run_flag = 1;
+        pthread_cond_signal(&thread_control->cond);
+        pthread_mutex_unlock(&thread_control->cond_mutex);
+    }
+
+    // Wait for test duration
+    sleep_usec(TEST_DURATION_SEC * USEC_PER_SEC);
+
+    // Signal threads to stop
+    for(int i = 0; i < threads; i++) {
+        thread_control_t *thread_control = &control->thread_controls[i];
+        __atomic_store_n(&thread_control->run_flag, 0, __ATOMIC_RELEASE);
+    }
+
+    // Wait for threads to report results
+    for(int i = 0; i < threads; i++) {
+        while(!__atomic_load_n(&control->stats[i].ready, __ATOMIC_ACQUIRE))
+            sleep_usec(10);
+    }
+
+    // Get thread count index for summary
+    int thread_count_idx;
+    switch(threads) {
+        case 1: thread_count_idx = 0; break;
+        case 2: thread_count_idx = 1; break;
+        case 4: thread_count_idx = 2; break;
+        case 8: thread_count_idx = 3; break;
+        case 16: thread_count_idx = 4; break;
+        case 32: thread_count_idx = 5; break;
+        case 64: thread_count_idx = 6; break;
+        default: thread_count_idx = 0; break;
+    }
+
+    print_thread_stats(name, threads, contexts, control->stats, control->protected_counter,
+                       summary, thread_count_idx);
+}
+
+static void set_waitq_priorities(int thread_count, thread_context_t *contexts) {
+    switch(thread_count) {
+        case 1:
+            contexts[0].priority = WAITQ_PRIO_URGENT;
+            break;
+
+        case 2:
+            contexts[0].priority = WAITQ_PRIO_URGENT;
+            contexts[1].priority = WAITQ_PRIO_HIGH;
+            break;
+
+        case 4:
+            contexts[0].priority = WAITQ_PRIO_URGENT;
+            contexts[1].priority = WAITQ_PRIO_HIGH;
+            contexts[2].priority = WAITQ_PRIO_NORMAL;
+            contexts[3].priority = WAITQ_PRIO_LOW;
+            break;
+
+        default:  // 8, 16, 32
+            int threads_per_priority = thread_count / 4;
+            int remainder = thread_count % 4;
+            int thread_idx = 0;
+
+            for (int prio = WAITQ_PRIO_URGENT; prio <= WAITQ_PRIO_LOW; prio++) {
+                int count = threads_per_priority + (remainder > 0 ? 1 : 0);
+                remainder--;
+
+                for (int i = 0; i < count && thread_idx < thread_count; i++) {
+                    contexts[thread_idx++].priority = prio;
+                }
+            }
+            break;
+    }
+}
+
+int locks_stress_test(void) {
+    summary_stats_t summary = {0};
+
+    // Initialize actual locks
+    pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+    pthread_rwlock_t rwlock = PTHREAD_RWLOCK_INITIALIZER;
+    SPINLOCK spinlock = SPINLOCK_INITIALIZER;
+    RW_SPINLOCK rw_spinlock = RW_SPINLOCK_INITIALIZER;
+    WAITQ waitq = WAITQ_INITIALIZER;
+
+    void *locks[] = {
+        &mutex,
+        &rwlock,
+        &spinlock,
+        &rw_spinlock,
+        &waitq
+    };
+
+    // Initialize control structures
+    lock_control_t controls[NUM_LOCK_TYPES] = { 0 };
+    for(int i = 0; i < NUM_LOCK_TYPES; i++) {
+        // Initialize per-thread condition variables and mutexes
+        for(int j = 0; j < MAX_THREADS; j++) {
+            controls[i].thread_controls[j].cond = (pthread_cond_t)PTHREAD_COND_INITIALIZER;
+            controls[i].thread_controls[j].cond_mutex = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
+            controls[i].thread_controls[j].run_flag = 0;
+        }
+    }
+
+    // Initialize thread arrays
+    thread_context_t *threads[NUM_LOCK_TYPES];
+    for(int i = 0; i < NUM_LOCK_TYPES; i++) {
+        threads[i] = calloc(MAX_THREADS, sizeof(thread_context_t));
+        if(!threads[i]) {
+            fprintf(stderr, "Failed to allocate memory for threads\n");
+            return 1;
+        }
+
+        // Initialize thread contexts
+        for(int j = 0; j < MAX_THREADS; j++) {
+            threads[i][j] = (thread_context_t){
+                .thread_id = j,
+                .type = i,
+                .control = &controls[i],
+                .lock = locks[i]
+            };
+        }
+    }
+
+    // Create all threads
+    fprintf(stderr, "Creating threads...\n");
+    for(int type = 0; type < NUM_LOCK_TYPES; type++) {
+        for(int i = 0; i < MAX_THREADS; i++) {
+            char thr_name[32];
+            snprintf(thr_name, sizeof(thr_name), "%s%d", lock_names[type], i);
+            threads[type][i].thread = nd_thread_create(
+                thr_name,
+                NETDATA_THREAD_OPTION_DONT_LOG | NETDATA_THREAD_OPTION_JOINABLE,
+                benchmark_thread,
+                &threads[type][i]);
+        }
+    }
+
+    // Run tests with different thread counts
+    int thread_counts[] = {1, 2, 4, 8, 16, 32, 64};
+
+    // Warm up the CPU
+    sleep_usec(100000);
+
+    for(size_t i = 0; i < sizeof(thread_counts)/sizeof(thread_counts[0]); i++) {
+        int count = thread_counts[i];
+
+        // Set waitq priorities for this test
+        set_waitq_priorities(count, threads[LOCK_WAITQ]);
+
+        // Run test for each lock type
+        for(int type = 0; type < NUM_LOCK_TYPES; type++) {
+            run_test(lock_names[type], count, threads[type], &controls[type], &summary);
+        }
+    }
+
+    // Print the summary table
+    print_summary(&summary);
+
+    // Signal all threads to exit
+    fprintf(stderr, "\nStopping threads...\n");
+    for(int type = 0; type < NUM_LOCK_TYPES; type++) {
+        for(int i = 0; i < MAX_THREADS; i++) {
+            thread_control_t *thread_control = &controls[type].thread_controls[i];
+            pthread_mutex_lock(&thread_control->cond_mutex);
+            thread_control->run_flag = STOP_SIGNAL;
+            pthread_cond_signal(&thread_control->cond);
+            pthread_mutex_unlock(&thread_control->cond_mutex);
+        }
+    }
+
+    // Join all threads
+    fprintf(stderr, "\nWaiting for threads to exit...\n");
+    for(int type = 0; type < NUM_LOCK_TYPES; type++) {
+        for(int i = 0; i < MAX_THREADS; i++) {
+            nd_thread_join(threads[type][i].thread);
+        }
+    }
+
+    // Cleanup condition variables and mutexes
+    for(int type = 0; type < NUM_LOCK_TYPES; type++) {
+        for(int i = 0; i < MAX_THREADS; i++) {
+            pthread_cond_destroy(&controls[type].thread_controls[i].cond);
+            pthread_mutex_destroy(&controls[type].thread_controls[i].cond_mutex);
+        }
+        free(threads[type]);
+    }
+
+    return 0;
+}

--- a/src/libnetdata/locks/benchmark.h
+++ b/src/libnetdata/locks/benchmark.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_BENCHMARK_H
+#define NETDATA_BENCHMARK_H
+
+#include "../libnetdata.h"
+
+int locks_stress_test(void);
+
+#endif //NETDATA_BENCHMARK_H

--- a/src/libnetdata/locks/rw-spinlock.h
+++ b/src/libnetdata/locks/rw-spinlock.h
@@ -8,7 +8,7 @@
 
 typedef struct netdata_rw_spinlock {
     pid_t writer;
-    REFCOUNT counter; // positive is readers, negative is a writer
+    uint32_t counter;
 } RW_SPINLOCK;
 
 #define RW_SPINLOCK_INITIALIZER { .counter = 0, .writer = 0, }

--- a/src/libnetdata/locks/waitq.c
+++ b/src/libnetdata/locks/waitq.c
@@ -83,7 +83,7 @@ void waitq_acquire_with_trace(WAITQ *waitq, WAITQ_PRIORITY priority, const char 
                 worker_spinlock_contention(func, spins);
                 return;
             }
-            tinysleep();
+            yield_the_processor();
         }
 
         // Back off


### PR DESCRIPTION
- [x] benchmark and stress locks and r/w locks
- [x] new rw-spinlock implementation
- [x] performance improvements on waitq

```
# netdata -W lockstest

=== Performance Summary (Million locks/sec) ===

Lock Type           1        2        4        8       16       32       64
------------------------------------------------------------------------------
Mutex           87.81    25.42    27.61    16.86    16.07    15.19    15.61
RWLock          55.10    12.10    10.72     7.04     6.17     0.21     0.54
Spinlock       149.16   150.38   146.49   140.79   129.87   123.25   119.32
RW Spinlock     81.00    80.94    79.86    76.91    69.93    65.11    61.80
WaitQ           51.61    51.49    51.40    48.03    40.17    38.65    29.24
```

## Claude Analysis

### Mutex (pthread_mutex_t):

- Good single-threaded performance (87.81M ops/sec)
- Performance drops significantly with 2+ threads (down to ~25M ops/sec)
- Stabilizes around 15-16M ops/sec with higher thread counts
- Behavior reflects kernel-level context switching overhead
- Shows moderate scaling up to 4 threads then plateaus

### RWLock (pthread_rwlock_t):

- Moderate single-threaded performance (55.10M ops/sec)
- Poor scaling with multiple threads
- Catastrophic performance drop at high thread counts (32-64 threads dropping to <1M ops/sec)
- Suggests heavy contention and potential reader-writer starvation
- Most severely impacted by high thread counts among all lock types

### Spinlock:

> A simple lock that uses atomic test-and-set operations to acquire access while continuously attempting to gain the lock. When contention occurs, it implements an exponential backoff strategy - starting at 1μs and doubling up to 512μs - to reduce CPU usage and give other threads a chance.

- Exceptional single-threaded performance (149.16M ops/sec)
- Nearly perfect scaling up to 2 threads (150.38M ops/sec)
- Maintains very high performance even with multiple threads
- Best overall scaling among all lock types
- Gradual degradation at high thread counts but still achieves 119.32M ops/sec at 64 threads
- Demonstrates spinlocks are highly efficient for short-duration critical sections

### RW Spinlock:

> A reader-writer lock using an optimistic approach with simple atomic operations rather than compare-and-swap (CAS). It uses a clever bit-field design where the highest bit indicates a writer and remaining bits count readers, allowing multiple readers or a single writer using just basic atomic adds and subtracts.

- Strong single-threaded performance (81.00M ops/sec)
- Maintains consistent performance across thread counts
- Better scaling than pthread_rwlock but lower raw performance than pure spinlock
- Shows moderate degradation at high thread counts (61.80M ops/sec at 64 threads)
- Reader-writer separation adds overhead but maintains good scalability

### WaitQ:

> A priority-aware queue-based lock that combines a spinlock with sequence numbers to ensure fairness within priority levels. It uses atomic operations to manage a 64-bit ordering value (priority in upper 32 bits, sequence in lower 32 bits), allowing threads to efficiently determine their turn without heavy synchronization.

- Good single-threaded performance (51.61M ops/sec)
- Very stable performance up to 4 threads
- Gradual decline in performance with more threads
- Shows good fairness characteristics due to its priority+FIFO design
- Better than mutex/rwlock at high thread counts
- Achieves 29.24M ops/sec at 64 threads, suggesting good contention handling

### Key Observations:

1. Spinlocks significantly outperform kernel-based synchronization (mutex/rwlock) for short-duration critical sections
2. Reader-writer variants (RWLock, RW Spinlock) show more overhead than their simple counterparts
3. WaitQ provides consistent and predictable scaling behavior
4. Traditional pthread primitives (mutex/rwlock) struggle with high thread counts
5. The test likely involves very short critical sections, which favors spinlock-based approaches

### Recommendations:
- For short critical sections with high contention: Use spinlocks
- When requiring reader/writer separation: RW Spinlock preferred over pthread_rwlock
- When fairness and predictable performance matter: Consider WaitQ
- For longer critical sections or when kernel interaction is necessary: pthread_mutex_t
- Avoid pthread_rwlock_t in high-contention scenarios with many threads

---

R/W locks performance

This test shows lower numbers than the previous, because the test validates possible discrepancies (more than 1 writer allowed in, readers and writers allowed in, etc).


```
# netdata -W rwlockstest

=== Performance Summary (Million operations/sec) ===

Lock Type        Readers  Writers  Reader Ops/s     Writer Ops/s    
----------------------------------------------------------------------
pthread_rwlock   1        0        48.66            0.00            
rw_spinlock      1        0        52.20            0.00            
----------------------------------------------------------------------
pthread_rwlock   0        1        0.00             36.36           
rw_spinlock      0        1        0.00             48.11           
----------------------------------------------------------------------
pthread_rwlock   1        1        0.21             0.18            
rw_spinlock      1        1        22.36            20.29           
----------------------------------------------------------------------
pthread_rwlock   2        1        14.20            0.04            
rw_spinlock      2        1        20.93            0.01            
----------------------------------------------------------------------
pthread_rwlock   1        2        0.35             0.18            
rw_spinlock      1        2        15.62            28.33           
----------------------------------------------------------------------
pthread_rwlock   2        2        12.94            0.05            
rw_spinlock      2        2        21.12            0.13            
----------------------------------------------------------------------
pthread_rwlock   4        1        22.29            0.00            
rw_spinlock      4        1        23.57            0.00            
----------------------------------------------------------------------
pthread_rwlock   1        4        0.42             0.16            
rw_spinlock      1        4        7.37             37.09           
----------------------------------------------------------------------
pthread_rwlock   4        4        20.81            0.00            
rw_spinlock      4        4        23.79            0.04
```

## Claude Analysis

### Reader/Writer Lock Performance Analysis

#### Pure Reader Performance (1R/0W):
- Both locks show good throughput with a single reader
- RW spinlock slightly outperforms pthread_rwlock (52.2M vs 48.7M ops/sec)
- These numbers establish the baseline for uncontended read performance

#### Pure Writer Performance (0R/1W):
- RW spinlock shows significantly better write performance (48.1M vs 36.4M ops/sec)
- The gap is larger for writes than reads, suggesting better write optimization in the spinlock

### Mixed Workload Observations:

#### Balanced Reader/Writer (1R/1W):
- Dramatic difference in performance between implementations
- pthread_rwlock shows severe performance degradation (~0.2M ops/sec for both)
- RW spinlock maintains good throughput (~20-22M ops/sec for both)
- Indicates much better contention handling in the spinlock implementation

#### Reader-Heavy (2R/1W, 4R/1W):
- Both implementations favor readers over writers
- pthread_rwlock shows near-zero writer throughput
- RW spinlock maintains better reader throughput but also shows writer starvation
- Scaling improves with more readers (4R better than 2R)

#### Writer-Heavy (1R/2W, 1R/4W):
- RW spinlock shows excellent writer scaling
- In 1R/4W case, spinlock achieves 37M ops/sec for writers
- pthread_rwlock shows poor performance with multiple writers
- Demonstrates spinlock's superior writer handling

### Key Findings:
1. The validation overhead reveals true contention patterns
2. Writer starvation is a significant issue in both implementations
3. RW spinlock handles mixed workloads much better than pthread_rwlock
4. Reader scalability is good in both implementations
5. Writer performance heavily depends on implementation

### Performance vs Previous Test:
- Lower absolute numbers due to validation overhead
- More realistic representation of actual usage patterns
- Better insight into reader/writer fairness
- Validation ensures correctness of concurrent access
- Trade-off between raw speed and guaranteed correctness
