### PR TITLE
feat(cgroup-name.sh): Add support for `netdata.cloud/*` container labels

### DIFF
--- a/src/collectors/cgroups.plugin/cgroup-name.sh.in
+++ b/src/collectors/cgroups.plugin/cgroup-name.sh.in
@@ -119,13 +119,21 @@ function parse_docker_like_inspect_output() {
   if [ -n "${IMAGE_NAME}" ]; then
     LABELS="image=\"${IMAGE_NAME}\""
   fi
+
+  while IFS= read -r line; do
+    if [[ -n "$line" && $line == LABEL_netdata.cloud/* ]]; then
+      IFS="=" read -r lname lval <<<"$line"
+      lname=${lname#LABEL_}
+      LABELS="$LABELS,${lname}=\"${lval}\""
+    fi
+  done <<<"$output"
 }
 
 function docker_like_get_name_command() {
   local command="${1}"
   local id="${2}"
-  info "Running command: ${command} inspect --format='{{range .Config.Env}}{{println .}}{{end}}CONT_NAME={{ .Name}}' \"${id}\""
-  if OUTPUT="$(${command} inspect --format='{{range .Config.Env}}{{println .}}{{end}}CONT_NAME={{ .Name}}{{println}}IMAGE_NAME={{ .Config.Image}}' "${id}")" &&
+  # shellcheck disable=SC2016
+  if OUTPUT="$(${command} inspect --format='{{range .Config.Env}}{{println .}}{{end}}{{range $key, $value := .Config.Labels}}LABEL_{{$key}}={{$value}}{{println}}{{end}}IMAGE_NAME={{.Config.Image}}{{println}}CONT_NAME={{.Name}}' "${id}")" &&
     [ -n "$OUTPUT" ]; then
       parse_docker_like_inspect_output "$OUTPUT"
   fi
@@ -151,7 +159,7 @@ function docker_like_get_name_api() {
     info "Running API command: curl \"${host}${path}\""
     JSON=$(curl -sS "${host}${path}")
   fi
-  if OUTPUT=$(echo "${JSON}" | jq -r '.Config.Env[]?,"CONT_NAME=\(.Name)","IMAGE_NAME=\(.Config.Image)"') && [ -n "$OUTPUT" ]; then
+  if OUTPUT=$(echo "${JSON}" | jq -r '.Config.Env[]?, "CONT_NAME=\(.Name)", "IMAGE_NAME=\(.Config.Image)", (.Config.Labels | to_entries[] | "LABEL_\(.key)=\(.value)")') && [ -n "$OUTPUT" ]; then
     parse_docker_like_inspect_output "$OUTPUT"
   fi
   return 0
@@ -424,7 +432,7 @@ function k8s_get_kubepod_name() {
     jq_filter+='namespace=\"\(.metadata.namespace)\",'
     jq_filter+='pod_name=\"\(.metadata.name)\",'
     jq_filter+='pod_uid=\"\(.metadata.uid)\",'
-    #jq_filter+='\(.metadata.labels | to_entries | map("pod_label_"+.key+"=\""+.value+"\"") | join(",") | if length > 0 then .+"," else . end)'
+    jq_filter+='\((.metadata.annotations // {}) | to_entries | map(select(.key | startswith("netdata.cloud/")) | .key+"=\""+.value+"\"") | join(",") | if length > 0 then .+"," else . end)'
     jq_filter+='\((.metadata.ownerReferences[]? | select(.controller==true) | "controller_kind=\""+.kind+"\",controller_name=\""+.name+"\",") // "")'
     jq_filter+='node_name=\"\(.spec.nodeName)\",'
     jq_filter+='" + '


### PR DESCRIPTION
##### Summary

This PR adds support for container configuration via:

- Docker: container labels.
- Kubernetes: pod annotations.


to `cgroup-name.sh`. The next PR will add handling of `netdata.cloud/*` labels to groups.plugin.

Note: 
##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
