### PR TITLE
CGROUP labels

### DIFF
--- a/src/collectors/cgroups.plugin/cgroup-discovery.c
+++ b/src/collectors/cgroups.plugin/cgroup-discovery.c
@@ -157,15 +157,59 @@ static inline void substitute_dots_in_id(char *s) {
 // ----------------------------------------------------------------------------
 // parse k8s labels
 
-char *cgroup_parse_resolved_name_and_labels(RRDLABELS *labels, char *data) {
+#define CGROUP_NETDATA_CLOUD_LABEL_PREFIX "netdata.cloud/"
+#define CGROUP_RENAME_LABEL "name="
+#define CGROUP_IGNORE_LABEL "ignore="
+
+static char *cgroup_parse_resolved_name_and_labels(struct cgroup *cg, char *data) {
+    if (!cg->chart_labels)
+        cg->chart_labels = rrdlabels_create();
+
+    rrdlabels_unmark_all(cg->chart_labels);
+
     // the first word, up to the first space is the name
     char *name = strsep_skip_consecutive_separators(&data, " ");
+
+    bool ignored = false;
 
     // the rest are key=value pairs separated by comma
     while(data) {
         char *pair = strsep_skip_consecutive_separators(&data, ",");
-        rrdlabels_add_pair(labels, pair, RRDLABEL_SRC_AUTO | RRDLABEL_SRC_K8S);
+
+        if(strncmp(pair, CGROUP_NETDATA_CLOUD_LABEL_PREFIX, sizeof(CGROUP_NETDATA_CLOUD_LABEL_PREFIX) - 1) == 0) {
+            // a netdata.cloud label
+            char *key = &pair[sizeof(CGROUP_NETDATA_CLOUD_LABEL_PREFIX) - 1];
+
+            if(strncmp(key, CGROUP_RENAME_LABEL, sizeof(CGROUP_RENAME_LABEL) - 1) == 0) {
+                char *n = &key[sizeof(CGROUP_RENAME_LABEL) - 1];
+                if(*n) name = n;
+
+                // no need to add this label
+            }
+            else if(strncmp(key, CGROUP_IGNORE_LABEL, sizeof(CGROUP_IGNORE_LABEL) - 1) == 0) {
+                char *v = &key[sizeof(CGROUP_IGNORE_LABEL) - 1];
+                if(strcasecmp(v, "true") == 0 || strcasecmp(v, "yes") == 0)
+                    ignored = true;
+                else
+                    ignored = false;
+
+                // no need to add this label
+            }
+            else
+                // add the label, without the "netdata.cloud/" prefix
+                rrdlabels_add_pair(cg->chart_labels, key, RRDLABEL_SRC_AUTO | RRDLABEL_SRC_K8S);
+        }
+        else
+            // add the label as-is
+            rrdlabels_add_pair(cg->chart_labels, pair, RRDLABEL_SRC_AUTO | RRDLABEL_SRC_K8S);
     }
+
+    rrdlabels_remove_all_unmarked(cg->chart_labels);
+
+    if(ignored)
+        cg->options |= CGROUP_OPTIONS_DISABLED_EXCLUDED;
+    else
+        cg->options &= ~CGROUP_OPTIONS_DISABLED_EXCLUDED;
 
     return name;
 }
@@ -187,8 +231,8 @@ static inline void discovery_rename_cgroup(struct cgroup *cg) {
         return;
     }
 
-    char buffer[CGROUP_CHARTID_LINE_MAX + 1];
-    char *new_name = fgets(buffer, CGROUP_CHARTID_LINE_MAX, spawn_popen_stdout(instance));
+    char buffer[8192]; // we need some size for labels
+    char *new_name = fgets(buffer, sizeof(buffer), spawn_popen_stdout(instance));
     int exit_code = spawn_popen_wait(instance);
 
     switch (exit_code) {
@@ -212,12 +256,7 @@ static inline void discovery_rename_cgroup(struct cgroup *cg) {
     if (!(new_name = trim(new_name)))
         return;
 
-    if (!cg->chart_labels)
-        cg->chart_labels = rrdlabels_create();
-    // read the new labels and remove the obsolete ones
-    rrdlabels_unmark_all(cg->chart_labels);
-    char *name = cgroup_parse_resolved_name_and_labels(cg->chart_labels, new_name);
-    rrdlabels_remove_all_unmarked(cg->chart_labels);
+    char *name = cgroup_parse_resolved_name_and_labels(cg, new_name);
 
     freez(cg->name);
     cg->name = strdupz(name);
@@ -1182,6 +1221,11 @@ static inline void discovery_process_cgroup(struct cgroup *cg) {
             cg->chart_labels = rrdlabels_create();
         rrdlabels_add(cg->chart_labels, "service_name", cg->name, RRDLABEL_SRC_AUTO);
         cg->enabled = 1;
+        return;
+    }
+
+    if (cg->options & CGROUP_OPTIONS_DISABLED_EXCLUDED) {
+        cg->enabled = 0;
         return;
     }
 

--- a/src/collectors/cgroups.plugin/sys_fs_cgroup.h
+++ b/src/collectors/cgroups.plugin/sys_fs_cgroup.h
@@ -9,9 +9,10 @@
 #define PLUGIN_CGROUPS_MODULE_SYSTEMD_NAME "systemd"
 #define PLUGIN_CGROUPS_MODULE_CGROUPS_NAME "/sys/fs/cgroup"
 
-#define CGROUP_OPTIONS_DISABLED_DUPLICATE   0x00000001
-#define CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE 0x00000002
-#define CGROUP_OPTIONS_IS_UNIFIED           0x00000004
+#define CGROUP_OPTIONS_DISABLED_DUPLICATE   (1 << 0)
+#define CGROUP_OPTIONS_SYSTEM_SLICE_SERVICE (1 << 1)
+#define CGROUP_OPTIONS_IS_UNIFIED           (1 << 2)
+#define CGROUP_OPTIONS_DISABLED_EXCLUDED    (1 << 3)
 
 typedef struct netdata_ebpf_cgroup_shm_header {
     int cgroup_root_count;
@@ -42,7 +43,5 @@ typedef struct netdata_ebpf_cgroup_shm {
 #define NETDATA_NAMED_SEMAPHORE_EBPF_CGROUP_NAME "/netdata_sem_cgroup_ebpf"
 
 #include "../proc.plugin/plugin_proc.h"
-
-char *cgroup_parse_resolved_name_and_labels(RRDLABELS *labels, char *data);
 
 #endif //NETDATA_SYS_FS_CGROUP_H


### PR DESCRIPTION
use labels `netdata.cloud/ignore` and `netdata.cloud/cgroup.name` to control the groups

Fixes: #12147