### PR TITLE
Add support for systemd NOTIFY_SOCKET in agent core.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,9 @@ mark_as_advanced(ENABLE_H2O)
 option(ENABLE_SENTRY "Build with Sentry Native crash reporting" False)
 mark_as_advanced(ENABLE_SENTRY)
 
+cmake_dependent_option(ENABLE_SYSTEMD_NOTIFY "Build with systemd NOTIFY_SOCKET support" True "OS_LINUX" False)
+mark_as_advanced(ENABLE_SYSTEMD_NOTIFY)
+
 option(BUILD_FOR_PACKAGING "Include component files for native packages" False)
 mark_as_advanced(BUILD_FOR_PACKAGING)
 
@@ -1136,6 +1139,15 @@ set(DAEMON_FILES
         src/daemon/config/netdata-conf-profile.c
         src/daemon/config/netdata-conf-profile.h
 )
+
+set(SYSTEMD_NOTIFY_FILES
+  src/daemon/systemd-notify.c
+  src/daemon/systemd-notify.h
+)
+
+if(ENABLE_SYSTEMD_NOTIFY)
+  list(APPEND DAEMON_FILES ${SYSTEMD_NOTIFY_FILES})
+endif()
 
 set(H2O_FILES
         src/web/server/h2o/http_server.c

--- a/packaging/cmake/config.cmake.h.in
+++ b/packaging/cmake/config.cmake.h.in
@@ -181,6 +181,8 @@
 #cmakedefine HAVE_ETW
 #cmakedefine RUN_UNDER_CLION
 
+#cmakedefine ENABLE_SYSTEMD_NOTIFY
+
 // /* Enable GNU extensions on systems that have them.  */
 // #ifndef _GNU_SOURCE
 // # define _GNU_SOURCE 1

--- a/src/daemon/daemon-shutdown.c
+++ b/src/daemon/daemon-shutdown.c
@@ -12,6 +12,10 @@
 #include "sentry-native/sentry-native.h"
 #endif
 
+#ifdef ENABLE_SYSTEMD_NOTIFY
+#include "systemd-notify.h"
+#endif
+
 void web_client_cache_destroy(void);
 
 extern struct netdata_static_thread *static_threads;
@@ -138,6 +142,10 @@ static void rrdeng_flush_everything_and_wait(bool wait_flush, bool wait_collecto
 
 void netdata_cleanup_and_exit(int ret, const char *action, const char *action_result, const char *action_data) {
     netdata_exit = 1;
+
+#ifdef ENABLE_SYSTEMD_NOTIFY
+    notify_stopping();
+#endif
 
 #ifdef ENABLE_DBENGINE
     if(!ret && dbengine_enabled)

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -17,6 +17,10 @@
 #include "sentry-native/sentry-native.h"
 #endif
 
+#ifdef ENABLE_SYSTEMD_NOTIFY
+#include "systemd-notify.h"
+#endif
+
 #if defined(ENV32BIT)
 #warning COMPILING 32BIT NETDATA
 #endif
@@ -1048,6 +1052,10 @@ int main(int argc, char *argv[])
     int rc = netdata_main(argc, argv);
     if (rc != 10)
         return rc;
+
+#ifdef ENABLE_SYSTEMD_NOTIFY
+    notify_ready();
+#endif
 
     nd_process_signals();
     return 1;

--- a/src/daemon/signals.c
+++ b/src/daemon/signals.c
@@ -143,9 +143,7 @@ void nd_process_signals(void) {
                             case NETDATA_SIGNAL_EXIT_CLEANLY:
                                 nd_log_limits_unlimited();
                                 netdata_log_info("SIGNAL: Received %s. Cleaning up to exit...", name);
-                                commands_exit();
-                                netdata_cleanup_and_exit(0, NULL, NULL, NULL);
-                                exit(0);
+                                execute_command(CMD_EXIT, NULL, NULL);
                                 break;
 
                             case NETDATA_SIGNAL_FATAL:

--- a/src/daemon/signals.c
+++ b/src/daemon/signals.c
@@ -2,10 +2,6 @@
 
 #include "common.h"
 
-#ifdef ENABLE_SYSTEMD_NOTIFY
-#include "systemd-notify.h"
-#endif
-
 typedef enum signal_action {
     NETDATA_SIGNAL_END_OF_LIST,
     NETDATA_SIGNAL_IGNORE,
@@ -147,9 +143,6 @@ void nd_process_signals(void) {
                             case NETDATA_SIGNAL_EXIT_CLEANLY:
                                 nd_log_limits_unlimited();
                                 netdata_log_info("SIGNAL: Received %s. Cleaning up to exit...", name);
-#ifdef ENABLE_SYSTEMD_NOTIFY
-                                notify_stopping();
-#endif
                                 commands_exit();
                                 netdata_cleanup_and_exit(0, NULL, NULL, NULL);
                                 exit(0);

--- a/src/daemon/signals.c
+++ b/src/daemon/signals.c
@@ -2,6 +2,10 @@
 
 #include "common.h"
 
+#ifdef ENABLE_SYSTEMD_NOTIFY
+#include "systemd-notify.h"
+#endif
+
 typedef enum signal_action {
     NETDATA_SIGNAL_END_OF_LIST,
     NETDATA_SIGNAL_IGNORE,
@@ -143,6 +147,9 @@ void nd_process_signals(void) {
                             case NETDATA_SIGNAL_EXIT_CLEANLY:
                                 nd_log_limits_unlimited();
                                 netdata_log_info("SIGNAL: Received %s. Cleaning up to exit...", name);
+#ifdef ENABLE_SYSTEMD_NOTIFY
+                                notify_stopping();
+#endif
                                 commands_exit();
                                 netdata_cleanup_and_exit(0, NULL, NULL, NULL);
                                 exit(0);

--- a/src/daemon/systemd-notify.c
+++ b/src/daemon/systemd-notify.c
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/* This is a standalone implementation of the systemd notify protocol with no external dependencies.
+ * It was adapted from the MIT-0 licensed implementation found in the sd_notify(3) man page provided
+ * with systemd v257.1.
+ *
+ * The protocol itself is defined both in the aforementioned man page, as well as at https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html
+ * Said protocol is guaranteed stable per systemd's normal stability guarantees for external APIs.
+ *
+ * We use this instead of linking against libsystemd for sd_notify() support so that we can still use it with our static builds.
+ */
+
+#define _GNU_SOURCE 1
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <time.h>
+#include <unistd.h>
+
+#define _cleanup_(f) __attribute__((cleanup(f)))
+
+static void closep(int *fd) {
+  if (!fd || *fd < 0)
+    return;
+
+  close(*fd);
+  *fd = -1;
+}
+
+// Send a notification to the service manager.
+static int notify(const char *message) {
+  union sockaddr_union {
+    struct sockaddr sa;
+    struct sockaddr_un sun;
+  } socket_addr = {
+    .sun.sun_family = AF_UNIX,
+  };
+  size_t path_length, message_length;
+  _cleanup_(closep) int fd = -1;
+  const char *socket_path;
+
+  /* Verify the argument first */
+  if (!message)
+    return -EINVAL;
+
+  message_length = strlen(message);
+  if (message_length == 0)
+    return -EINVAL;
+
+  /* If the variable is not set, the protocol is a noop */
+  socket_path = getenv("NOTIFY_SOCKET");
+  if (!socket_path)
+    return 0; /* Not set? Nothing to do */
+
+  /* Only AF_UNIX is supported, with path or abstract sockets */
+  if (socket_path[0] != '/' && socket_path[0] != '@')
+    return -EAFNOSUPPORT;
+
+  path_length = strlen(socket_path);
+  /* Ensure there is room for NUL byte */
+  if (path_length >= sizeof(socket_addr.sun.sun_path))
+    return -E2BIG;
+
+  memcpy(socket_addr.sun.sun_path, socket_path, path_length);
+
+  /* Support for abstract socket */
+  if (socket_addr.sun.sun_path[0] == '@')
+    socket_addr.sun.sun_path[0] = 0;
+
+  fd = socket(AF_UNIX, SOCK_DGRAM|SOCK_CLOEXEC, 0);
+  if (fd < 0)
+    return -errno;
+
+  if (connect(fd, &socket_addr.sa, offsetof(struct sockaddr_un, sun_path) + path_length) != 0)
+    return -errno;
+
+  ssize_t written = write(fd, message, message_length);
+  if (written != (ssize_t) message_length)
+    return written < 0 ? -errno : -EPROTO;
+
+  return 1; /* Notified! */
+}
+
+// Notify the service manager that Netdata has finished startup successfully.
+int notify_ready(void) {
+  return notify("READY=1");
+}
+
+// Notify the service manager that Netdata is reloading.
+int notify_reloading(void) {
+  /* A buffer with length sufficient to format the maximum UINT64 value. */
+  char reload_message[sizeof("RELOADING=1\nMONOTONIC_USEC=18446744073709551615")];
+  struct timespec ts;
+  uint64_t now;
+
+  /* Notify systemd that we are reloading, including a CLOCK_MONOTONIC timestamp in usec
+   * so that the program is compatible with a Type=notify-reload service. */
+
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) < 0)
+    return -errno;
+
+  if (ts.tv_sec < 0 || ts.tv_nsec < 0 ||
+      (uint64_t) ts.tv_sec > (UINT64_MAX - (ts.tv_nsec / 1000ULL)) / 1000000ULL)
+    return -EINVAL;
+
+  now = (uint64_t) ts.tv_sec * 1000000ULL + (uint64_t) ts.tv_nsec / 1000ULL;
+
+  if (snprintf(reload_message, sizeof(reload_message), "RELOADING=1\nMONOTONIC_USEC=%" PRIu64, now) < 0)
+    return -EINVAL;
+
+  return notify(reload_message);
+}
+
+// Notify the service manager that Netdata is stopping.
+int notify_stopping(void) {
+  return notify("STOPPING=1");
+}

--- a/src/daemon/systemd-notify.h
+++ b/src/daemon/systemd-notify.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef ND_SYSTEMD_NOTIFY_H
+#define ND_SYSTEMD_NOTIFY_H 1
+
+int notify_ready(void);
+int notify_reloading(void);
+int notify_stopping(void);
+
+#endif /* ND_SYSTEMD_NOTIFY_H */

--- a/system/systemd/netdata.service.in
+++ b/system/systemd/netdata.service.in
@@ -8,7 +8,7 @@ Wants=network-online.target nss-lookup.target
 
 [Service]
 LogNamespace=netdata
-Type=simple
+Type=notify
 User=root
 RuntimeDirectory=netdata
 RuntimeDirectoryMode=0775
@@ -19,6 +19,7 @@ ExecStartPre=/bin/chown -R @netdata_user_POST@ @localstatedir_POST@/cache/netdat
 ExecStartPre=/bin/mkdir -p /run/netdata
 ExecStartPre=/bin/chown -R @netdata_user_POST@ /run/netdata
 PermissionsStartOnly=true
+NotifyAccess=exec
 
 # saving a big db on slow disks may need some time
 TimeoutStopSec=150

--- a/system/systemd/netdata.service.v235.in
+++ b/system/systemd/netdata.service.v235.in
@@ -8,10 +8,11 @@ Wants=network-online.target nss-lookup.target
 
 [Service]
 LogNamespace=netdata
-Type=simple
+Type=notify
 User=root
 EnvironmentFile=-/etc/default/netdata
 ExecStart=@sbindir_POST@/netdata -D $EXTRA_OPTS
+NotifyAccess=exec
 
 # saving a big db on slow disks may need some time
 TimeoutStopSec=150


### PR DESCRIPTION
##### Summary

This adds support for using systemd’s service notification functionality to inform the service manager that Netdata has successfully finished startup and that it is shutting down when told to do so.

The primary advantage of this for our usage is that it ensures that on systemd systems Netdata will only be shown as running once it has actually finished startup, instead of the current arrangement where it is considered running as soon as the service manager forks the process, and that it will be shown as stopping when actually shutting down (and that using `netdatacli shutdown-agent` will result in the shutdown being reported cleanly to the service manager).

This, in turn, gets a couple of other improvements:

- `systemctl start netdata` will only return once the agent is actually running.
- `systemctl start netdata` will properly report an error if there is a startup issue in the agent.
- Any services that depend on Netdata will only be started _after_ the agent finishes startup, ensuring that they can depend on the agent actually being running.

Internally, this uses a stand-alone implementation of this functionality instead of relying on the one provided by libsystemd, as handling it this way enables us to support it even on static builds. The actual implementation is almost entirely copied from the MIT-0 licensed example implementation provided by systemd itself.

This is built by default on Linux systems, and should have near zero overhead for each notify call (one `strlen()` call, one `getenv()` call, and three trivial conditional checks) when not actually being used. It can be disabled at build time using `-DENABLE_SYSTEMD_NOTIFY=Off`. Support for other UNIX-like platforms is theoretically possible, but not particularly useful. Support for Windows would require a non-trivial restructure of some of the code, as it takes advantage of a feature that is not supported by MSVC to greatly simplify the code.

##### Test Plan

Basic testing involves building the agent from this PR and running it via systemd with the changes to the unit file outlined in this PR (change `Type=simple` to `Type=notify` and add `NotifyAccess=exec` in the `[Service]` section). If everything is working, the service will be marked as started slower than it normally would be, but will correctly reflect that the agent is in fact running.

Further testing can be done by intentionally inducing various startup failures in the agent and confirming that not only does the unit get never get marked started, but also the systemctl command reports an error.

Additional testing is required on non-systemd systems to confirm that the build still works there and nothing is broken.

##### Additional Information

Documentation of the protocol involved here can be found at https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html (or in `man 3 sd_notify` on most systems using systemd). This is also the source of most of the implementation included in this PR (though since it’s MIT-0 licensed, we don’t have to provide any attribution and we can also license our copy as GPL-3 like the rest of Netdata).

Long-term, I would like to expand this to include reload notification handling, as well as more concrete status updates to the service manager (which can be more easily queried and presented by front-end tools for working with systemd).

In addition to the primary changes, this tidies up the clean exit handling so that it is consistent with most of the other signal handling code and doesn’t potentially call the exit cleanup code twice.