### PR TITLE
Add instructions for Docker Compose

### DIFF
--- a/src/health/notifications/email/README.md
+++ b/src/health/notifications/email/README.md
@@ -87,19 +87,6 @@ SEND_EMAIL="YES"
 DEFAULT_RECIPIENT_EMAIL="recipient@example.com"
 
 ```
-##### Docker Compose
-
-Emails are sent with `msmtp`, and you need a basic configuration for it to work. 
-
-1. Add a [msmtprc](https://marlam.de/msmtp/msmtprc.txt) config file on your Docker root folder, and edit it according to your needs.
-2. Link it into your Netdata Docker with this:
-```yaml
-    volumes:
-      - /path/to/netdata-docker/msmtprc:/etc/msmtprc:ro
-```
-3. Update your docker with `docker compose up -d`.
-4. Enter the docker container with `docker exec -it netdata /bin/bash`.
-5. Follow the instructions [above](https://github.com/netdata/netdata/blob/master/src/health/notifications/email/README.md#file) on how to edit the config file with `edit-config`.
 
 ## Troubleshooting
 

--- a/src/health/notifications/email/README.md
+++ b/src/health/notifications/email/README.md
@@ -99,7 +99,7 @@ Emails are sent with `msmtp`, and you need a basic configuration for it to work.
 ```
 3. Update your docker with `docker compose up -d`
 4. Enter the docker container with `docker exec -it netdata /bin/bash`.
-5. Follow the instructions [above](https://github.com/netdata/netdata/master/src/health/notifications/email/README.md#file) on how to edit the config file with `edit-config`.
+5. Follow the instructions [above](https://github.com/netdata/netdata/blob/master/src/health/notifications/email/README.md#file) on how to edit the config file with `edit-config`.
 
 ## Troubleshooting
 

--- a/src/health/notifications/email/README.md
+++ b/src/health/notifications/email/README.md
@@ -97,7 +97,7 @@ Emails are sent with `msmtp`, and you need a basic configuration for it to work.
     volumes:
       - /path/to/netdata-docker/msmtprc:/etc/msmtprc:ro
 ```
-3. Update your docker with `docker compose up -d`
+3. Update your docker with `docker compose up -d`.
 4. Enter the docker container with `docker exec -it netdata /bin/bash`.
 5. Follow the instructions [above](https://github.com/netdata/netdata/blob/master/src/health/notifications/email/README.md#file) on how to edit the config file with `edit-config`.
 

--- a/src/health/notifications/email/README.md
+++ b/src/health/notifications/email/README.md
@@ -87,7 +87,19 @@ SEND_EMAIL="YES"
 DEFAULT_RECIPIENT_EMAIL="recipient@example.com"
 
 ```
+##### Docker Compose
 
+Emails are sent with `msmtp`, and you need a basic configuration for it to work. 
+
+1. Add a [msmtprc](https://marlam.de/msmtp/msmtprc.txt) config file on your Docker root folder, and edit it according to your needs.
+2. Link it into your Netdata Docker with this:
+```yaml
+    volumes:
+      - /path/to/netdata-docker/msmtprc:/etc/msmtprc:ro
+```
+3. Update your docker with `docker compose up -d`
+4. Enter the docker container with `docker exec -it netdata /bin/bash`.
+5. Follow the instructions [above](https://github.com/netdata/netdata/master/src/health/notifications/email/README.md#file) on how to edit the config file with `edit-config`.
 
 ## Troubleshooting
 

--- a/src/health/notifications/email/metadata.yaml
+++ b/src/health/notifications/email/metadata.yaml
@@ -20,6 +20,18 @@
           description: |
             - A working sendmail command is required for email alerts to work. Almost all MTAs provide a sendmail interface. Netdata sends all emails as user netdata, so make sure your sendmail works for local users.
             - Access to the terminal where Netdata Agent is running
+            - When running Netdata with Docker Compose the emails are sent with `msmtp`, and you need a basic configuration for it to work. 
+              
+              - Add a [msmtprc](https://marlam.de/msmtp/msmtprc.txt) config file on your Docker root folder, and edit it according to your needs.
+              - Link it into your Netdata container with this:
+              
+                ```yaml
+                    volumes:
+                      - /path/to/netdata-docker/msmtprc:/etc/msmtprc:ro
+                ```
+              
+              - Update your container with `docker compose up -d`.
+
     configuration:
       file:
         name: 'health_alarm_notify.conf'


### PR DESCRIPTION
Add instructions on how to setup email notifications when running Docker Compose.

Please add this to metadata as well. 

Thanks!

(Related to this: https://github.com/netdata/helper-images/pull/307)