### PR TITLE
Assorted systemd detection fixes

### DIFF
--- a/packaging/installer/functions.sh
+++ b/packaging/installer/functions.sh
@@ -597,11 +597,6 @@ issystemd() {
   ns=''
   systemctl=''
 
-  # if the directory /lib/systemd/system OR /usr/lib/systemd/system (SLES 12.x) does not exit, it is not systemd
-  if [ ! -d /lib/systemd/system ] && [ ! -d /usr/lib/systemd/system ]; then
-    return 1
-  fi
-
   # if there is no systemctl command, it is not systemd
   systemctl=$(command -v systemctl 2> /dev/null)
   if [ -z "${systemctl}" ] || [ ! -x "${systemctl}" ]; then

--- a/packaging/installer/netdata-uninstaller.sh
+++ b/packaging/installer/netdata-uninstaller.sh
@@ -463,11 +463,6 @@ issystemd() {
   ns=''
   systemctl=''
 
-  # if the directory /lib/systemd/system OR /usr/lib/systemd/system (SLES 12.x) does not exit, it is not systemd
-  if [ ! -d /lib/systemd/system ] && [ ! -d /usr/lib/systemd/system ]; then
-    return 1
-  fi
-
   # if there is no systemctl command, it is not systemd
   systemctl=$(command -v systemctl 2> /dev/null)
   if [ -z "${systemctl}" ] || [ ! -x "${systemctl}" ]; then

--- a/system/install-service.sh.in
+++ b/system/install-service.sh.in
@@ -185,11 +185,6 @@ _check_systemd() {
   myns=''
   ns=''
 
-  # if the directory /lib/systemd/system OR /usr/lib/systemd/system (SLES 12.x) does not exit, it is not systemd
-  if [ ! -d /lib/systemd/system ] && [ ! -d /usr/lib/systemd/system ]; then
-    echo "NO" && return 0
-  fi
-
   # if there is no systemctl command, it is not systemd
   [ -z "$(command -v systemctl 2>/dev/null || true)" ] && echo "NO" && return 0
 
@@ -198,21 +193,18 @@ _check_systemd() {
   # This may return a non-zero exit status in cases when it actually
   # succeeded for our purposes, so we need to toggle set -e off here.
   set +e
-  case "$(systemctl is-system-running)" in
+  systemd_state="$(systemctl is-system-running)"
+  set -e
+
+  case "${systemd_state}" in
     offline) echo "OFFLINE" && return 0 ;;
     unknown) : ;;
     "") : ;;
     *) echo "YES" && return 0 ;;
   esac
-  set -e
 
   # if pid 1 is systemd, it is systemd
   [ "$(basename "$(readlink /proc/1/exe)" 2> /dev/null)" = "systemd" ] && echo "YES" && return 0
-
-  # it ‘is’ systemd at this point, but systemd might not be running
-  # if not, return 2 to indicate ‘systemd, but not running’
-  pids=$(safe_pidof systemd 2> /dev/null)
-  [ -z "${pids}" ] && echo "OFFLINE" && return 0
 
   # check if the running systemd processes are not in our namespace
   myns="$(readlink /proc/self/ns/pid 2> /dev/null)"
@@ -223,8 +215,9 @@ _check_systemd() {
     [ -n "${myns}" ] && [ "${myns}" = "${ns}" ] && echo "YES" && return 0
   done
 
-  # else, it is not systemd
-  echo "NO"
+  # At this point, we know it’s a systemd system because systemctl
+  # exists, but systemd does not appear to be running, so indicate as such
+  echo "OFFLINE"
 }
 
 check_systemd() {


### PR DESCRIPTION
##### Summary

- Properly scope `set -e` changes to only affect `systemctl is-system-running` invocation.
- Skip checking for hard-coded unit file paths. Other paths may technically be used for unit files instead of what we hard-code, and the presence or abscence of any specific unit file path _does not_ reliably indicate the presence or abscence of systemd.

##### Test Plan

n/a