### PR TITLE
prevent memory corruption in dbengine

### DIFF
--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -911,8 +911,8 @@ void rrdeng_load_metric_finalize(struct storage_engine_query_handle *seqh)
         pgdc_reset(&handle->pgdc, NULL, UINT32_MAX);
     }
 
-    if(!pdc_release_and_destroy_if_unreferenced(handle->pdc, false, false))
-        __atomic_store_n(&handle->pdc->workers_should_stop, true, __ATOMIC_RELAXED);
+    __atomic_store_n(&handle->pdc->workers_should_stop, true, __ATOMIC_RELAXED);
+    pdc_release_and_destroy_if_unreferenced(handle->pdc, false, false);
 
     unregister_query_handle(handle);
     rrdeng_query_handle_release(handle);


### PR DESCRIPTION
Prevent this memory corruption:

![image](https://github.com/user-attachments/assets/d0a267f1-d80f-441d-a4ec-b48d971e6f2b)
