### PR TITLE
disable libunwind on forked children

### DIFF
--- a/src/libnetdata/log/nd_log-init.c
+++ b/src/libnetdata/log/nd_log-init.c
@@ -274,6 +274,8 @@ int nd_log_systemd_journal_fd(void) {
 }
 
 void nd_log_reopen_log_files_for_spawn_server(const char *name) {
+    nd_log_forked = true;
+
     gettid_uncached();
 
     if(nd_log.syslog.initialized) {

--- a/src/libnetdata/log/nd_log-internals.h
+++ b/src/libnetdata/log/nd_log-internals.h
@@ -196,6 +196,8 @@ struct log_field;
 const char *errno_annotator(struct log_field *lf);
 const char *priority_annotator(struct log_field *lf);
 const char *timestamp_usec_annotator(struct log_field *lf);
+
+extern bool nd_log_forked;
 bool stack_trace_formatter(BUFFER *wb, void *data);
 
 #if defined(OS_WINDOWS)

--- a/src/libnetdata/spawn_server/spawn_server_nofork.c
+++ b/src/libnetdata/spawn_server/spawn_server_nofork.c
@@ -1210,6 +1210,8 @@ int spawn_server_exec_kill(SPAWN_SERVER *server, SPAWN_INSTANCE *instance, int t
 }
 
 SPAWN_INSTANCE* spawn_server_exec(SPAWN_SERVER *server, int stderr_fd, int custom_fd, const char **argv, const void *data, size_t data_size, SPAWN_INSTANCE_TYPE type) {
+    if(!server) return NULL;
+
     int pipe_stdin[2] = { -1, -1 }, pipe_stdout[2] = { -1, -1 };
 
     SPAWN_INSTANCE *instance = callocz(1, sizeof(SPAWN_INSTANCE));


### PR DESCRIPTION
libunwind does not work well after fork (it freezes), so we disable stack traces on forked processes
