### PR TITLE
Reduce glibc memory fragmentation

### DIFF
--- a/src/daemon/pulse/pulse-daemon-memory.c
+++ b/src/daemon/pulse/pulse-daemon-memory.c
@@ -180,39 +180,6 @@ void pulse_daemon_memory_do(bool extended) {
 
     // ----------------------------------------------------------------------------------------------------------------
 
-    OS_SYSTEM_MEMORY sm = os_system_memory(true);
-    if (sm.ram_total_bytes && dbengine_out_of_memory_protection) {
-        static RRDSET *st_memory_available = NULL;
-        static RRDDIM *rd_available = NULL;
-
-        if (unlikely(!st_memory_available)) {
-            st_memory_available = rrdset_create_localhost(
-                "netdata",
-                "out_of_memory_protection",
-                NULL,
-                "Memory Usage",
-                NULL,
-                "Out of Memory Protection",
-                "bytes",
-                "netdata",
-                "pulse",
-                130102,
-                localhost->rrd_update_every,
-                RRDSET_TYPE_AREA);
-
-            rd_available = rrddim_add(st_memory_available, "available", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-        }
-
-        // the sum of all these needs to be above at the total buffers calculation
-        rrddim_set_by_pointer(
-            st_memory_available, rd_available,
-            (collected_number)sm.ram_available_bytes);
-
-        rrdset_done(st_memory_available);
-    }
-
-    // ----------------------------------------------------------------------------------------------------------------
-
     {
         static RRDSET *st_memory_buffers = NULL;
         static RRDDIM *rd_queries = NULL;
@@ -241,7 +208,7 @@ void pulse_daemon_memory_do(bool extended) {
                 "bytes",
                 "netdata",
                 "pulse",
-                130103,
+                130102,
                 localhost->rrd_update_every,
                 RRDSET_TYPE_STACKED);
 
@@ -278,6 +245,39 @@ void pulse_daemon_memory_do(bool extended) {
         rrddim_set_by_pointer(st_memory_buffers, rd_buffers_judy, (collected_number)judy_aral_free_bytes());
 
         rrdset_done(st_memory_buffers);
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+
+    OS_SYSTEM_MEMORY sm = os_system_memory(true);
+    if (sm.ram_total_bytes && dbengine_out_of_memory_protection) {
+        static RRDSET *st_memory_available = NULL;
+        static RRDDIM *rd_available = NULL;
+
+        if (unlikely(!st_memory_available)) {
+            st_memory_available = rrdset_create_localhost(
+                "netdata",
+                "out_of_memory_protection",
+                NULL,
+                "Memory Usage",
+                NULL,
+                "Out of Memory Protection",
+                "bytes",
+                "netdata",
+                "pulse",
+                130103,
+                localhost->rrd_update_every,
+                RRDSET_TYPE_AREA);
+
+            rd_available = rrddim_add(st_memory_available, "available", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        }
+
+        // the sum of all these needs to be above at the total buffers calculation
+        rrddim_set_by_pointer(
+            st_memory_available, rd_available,
+            (collected_number)sm.ram_available_bytes);
+
+        rrdset_done(st_memory_available);
     }
 
     // ----------------------------------------------------------------------------------------------------------------

--- a/src/libnetdata/onewayalloc/onewayalloc.c
+++ b/src/libnetdata/onewayalloc/onewayalloc.c
@@ -55,10 +55,17 @@ static OWA_PAGE *onewayalloc_create_internal(OWA_PAGE *head, size_t size_hint) {
     if(size_hint > size)
         size = size_hint;
 
-    // try to allocate half of the total we have allocated already
     if(head) {
-        size_t optimal_size = head->stats_pages_size / 2;
-        if(optimal_size > size) size = optimal_size;
+        // double the current allocation
+        size_t optimal_size = head->stats_pages_size;
+
+        // cap it at 1 MiB
+        if(optimal_size > 1ULL * 1024 * 1024)
+            optimal_size = 1ULL * 1024 * 1024;
+
+        // use the optimal if it is more than the required size
+        if(optimal_size > size)
+            size = optimal_size;
     }
 
     // Make sure our allocations are always a multiple of the hardware page size

--- a/src/libnetdata/onewayalloc/onewayalloc.c
+++ b/src/libnetdata/onewayalloc/onewayalloc.c
@@ -8,10 +8,10 @@ typedef struct owa_page {
     size_t stats_pages_size;
     size_t stats_mallocs_made;
     size_t stats_mallocs_size;
-    size_t size;        // the total size of the page
-    size_t offset;      // the first free byte of the page
-    struct owa_page *next;     // the next page on the list
-    struct owa_page *last;     // the last page on the list - we currently allocate on this
+    size_t size;                // the total size of the page
+    size_t offset;              // the first free byte of the page
+    struct owa_page *next;      // the next page on the list
+    struct owa_page *last;      // the last page on the list - we currently allocate on this
 } OWA_PAGE;
 
 static size_t onewayalloc_total_memory = 0;
@@ -30,7 +30,7 @@ static inline size_t natural_alignment(size_t size) {
 }
 
 // Create an OWA
-// Once it is created, the called may call the onewayalloc_mallocz()
+// Once it is created, the caller may call the onewayalloc_mallocz()
 // any number of times, for any amount of memory.
 
 static OWA_PAGE *onewayalloc_create_internal(OWA_PAGE *head, size_t size_hint) {
@@ -45,34 +45,37 @@ static OWA_PAGE *onewayalloc_create_internal(OWA_PAGE *head, size_t size_hint) {
     }
 
     // our default page size
-    size_t size = OWA_NATURAL_PAGE_SIZE;
+    size_t size = 32768;
 
     // make sure the new page will fit both the requested size
     // and the OWA_PAGE structure at its beginning
     size_hint += natural_alignment(sizeof(OWA_PAGE));
 
     // prefer the user size if it is bigger than our size
-    if(size_hint > size) size = size_hint;
+    if(size_hint > size)
+        size = size_hint;
 
     // try to allocate half of the total we have allocated already
-    if(likely(head)) {
+    if(head) {
         size_t optimal_size = head->stats_pages_size / 2;
         if(optimal_size > size) size = optimal_size;
     }
 
     // Make sure our allocations are always a multiple of the hardware page size
-    if(size % OWA_NATURAL_PAGE_SIZE) size = size + OWA_NATURAL_PAGE_SIZE - (size % OWA_NATURAL_PAGE_SIZE);
+    if(size % OWA_NATURAL_PAGE_SIZE)
+        size = size + OWA_NATURAL_PAGE_SIZE - (size % OWA_NATURAL_PAGE_SIZE);
 
-    // OWA_PAGE *page = (OWA_PAGE *)netdata_mmap(NULL, size, MAP_ANONYMOUS|MAP_PRIVATE, 0);
-    // if(unlikely(!page)) fatal("Cannot allocate onewayalloc buffer of size %zu", size);
-    OWA_PAGE *page = (OWA_PAGE *)mallocz(size);
+    // Use netdata_mmap instead of mallocz
+    OWA_PAGE *page = (OWA_PAGE *)netdata_mmap(NULL, size, MAP_ANONYMOUS|MAP_PRIVATE, 0, false, false, NULL);
+    if(unlikely(!page)) fatal("Cannot allocate onewayalloc buffer of size %zu", size);
+
     __atomic_add_fetch(&onewayalloc_total_memory, size, __ATOMIC_RELAXED);
 
     page->size = size;
     page->offset = natural_alignment(sizeof(OWA_PAGE));
     page->next = page->last = NULL;
 
-    if(unlikely(!head)) {
+    if(!head) {
         // this is the first time we are called
         head = page;
         head->stats_pages = 0;
@@ -205,8 +208,8 @@ void onewayalloc_destroy(ONEWAYALLOC *owa) {
         OWA_PAGE *p = page;
         page = page->next;
 
-        // munmap(p, p->size);
-        freez(p);
+        // Use netdata_munmap instead of freez
+        netdata_munmap(p, p->size);
     }
 
     __atomic_sub_fetch(&onewayalloc_total_memory, total_size, __ATOMIC_RELAXED);


### PR DESCRIPTION
- [x] reorder memory charts
- [x] ARAL: use mmap exclusively
- [x] ONEWAYALLOC: use mmap exclusively
- [ ] WEB CLIENTS: use aral
- [ ] STREAM: circular stream buffers use mmap
- [ ] HEALTH: all structures in aral