### PR TITLE
Verify and cleanup deleted contexts

### DIFF
--- a/src/database/sqlite/sqlite_context.c
+++ b/src/database/sqlite/sqlite_context.c
@@ -13,6 +13,13 @@ const char *database_context_config[] = {
     "last_time_t INT NOT NULL, deleted INT NOT NULL, "
     "family TEXT, PRIMARY KEY (host_id, id))",
 
+    "CREATE TABLE IF NOT EXISTS context_metadata_cleanup (id INTEGER PRIMARY KEY, host_id BLOB, context TEXT NOT NULL, "
+    "UNIQUE (host_id, context))",
+
+    "CREATE TRIGGER IF NOT EXISTS del_context1 AFTER DELETE ON context "
+    "BEGIN INSERT INTO context_metadata_cleanup (host_id, context) "
+    "VALUES (old.host_id, old.id) ON CONFLICT DO NOTHING; END",
+
     NULL
 };
 
@@ -261,8 +268,83 @@ done:
     return (rc_stored != SQLITE_DONE);
 }
 
-// Delete a context
 
+// Schedule context cleanup for host
+#define CTX_GET_CONTEXT_META_CLEANUP_LIST "SELECT id, context FROM context_metadata_cleanup WHERE host_id = @host_id"
+#define CTX_DELETE_CONTEXT_META_CLEANUP_ITEM "DELETE FROM context_metadata_cleanup WHERE id = @id"
+
+void ctx_get_context_list_to_cleanup(nd_uuid_t *host_uuid, void (*cleanup_cb)(Pvoid_t JudyL, void *data), void *data)
+{
+    if (unlikely(!host_uuid))
+        return;
+
+    sqlite3_stmt *res = NULL;
+
+    if (!PREPARE_STATEMENT(db_context_meta, CTX_GET_CONTEXT_META_CLEANUP_LIST, &res))
+        return;
+
+    int param = 0;
+    SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, host_uuid, sizeof(*host_uuid), SQLITE_STATIC));
+    param = 0;
+
+    int64_t id;
+    const char *context;
+    Pvoid_t JudyL = NULL;
+    Pvoid_t CTX_JudyL = NULL;
+    Pvoid_t *Pvalue;
+    while (sqlite3_step_monitored(res) == SQLITE_ROW) {
+        id = sqlite3_column_int64(res, 0);
+        context = (char *) sqlite3_column_text(res, 1);
+        STRING *ctx = string_strdupz(context);
+        Pvalue = JudyLIns(&CTX_JudyL, (Word_t) ctx, PJE0);
+        if (*Pvalue)
+            string_freez(ctx);
+        else
+            *(int *)Pvalue = 1;
+
+        (void) JudyLIns(&JudyL, id, PJE0);
+    }
+    SQLITE_FINALIZE(res);
+
+    if (CTX_JudyL) {
+        cleanup_cb(CTX_JudyL, data);
+
+        bool first = true;
+        Word_t Index = 0;
+        while ((Pvalue = JudyLFirstThenNext(CTX_JudyL, &Index, &first))) {
+            STRING *ctx = (STRING *) Index;
+            string_freez(ctx);
+        }
+    }
+    (void)JudyLFreeArray(&CTX_JudyL, PJE0);
+
+    if (!JudyL)
+        return;
+
+    if (!PREPARE_STATEMENT(db_context_meta, CTX_DELETE_CONTEXT_META_CLEANUP_ITEM, &res))
+        return;
+
+    bool first = true;
+    Word_t Index = 0;
+
+    while ((Pvalue = JudyLFirstThenNext(JudyL, &Index, &first))) {
+        param = 0;
+        SQLITE_BIND_FAIL(done, sqlite3_bind_int64(res, ++param, Index));
+        param = 0;
+
+        int rc = sqlite3_step_monitored(res);
+        if (rc != SQLITE_DONE)
+            error_report("Failed to delete context check entry, rc = %d", rc);
+        SQLITE_RESET(res);
+    }
+    (void) JudyLFreeArray(&JudyL, PJE0);
+
+done:
+    REPORT_BIND_FAIL(res, param);
+    SQLITE_FINALIZE(res);
+}
+
+// Delete a context
 #define CTX_DELETE_CONTEXT "DELETE FROM context WHERE host_id = @host_id AND id = @context"
 int ctx_delete_context(nd_uuid_t *host_uuid, VERSIONED_CONTEXT_DATA *context_data)
 {

--- a/src/database/sqlite/sqlite_context.c
+++ b/src/database/sqlite/sqlite_context.c
@@ -13,12 +13,12 @@ const char *database_context_config[] = {
     "last_time_t INT NOT NULL, deleted INT NOT NULL, "
     "family TEXT, PRIMARY KEY (host_id, id))",
 
-    "CREATE TABLE IF NOT EXISTS context_metadata_cleanup (id INTEGER PRIMARY KEY, host_id BLOB, context TEXT NOT NULL, "
+    "CREATE TABLE IF NOT EXISTS context_metadata_cleanup (id INTEGER PRIMARY KEY, host_id BLOB, context TEXT NOT NULL, date_created INT, "
     "UNIQUE (host_id, context))",
 
     "CREATE TRIGGER IF NOT EXISTS del_context1 AFTER DELETE ON context "
-    "BEGIN INSERT INTO context_metadata_cleanup (host_id, context) "
-    "VALUES (old.host_id, old.id) ON CONFLICT DO NOTHING; END",
+    "BEGIN INSERT INTO context_metadata_cleanup (host_id, context, date_created) "
+    "VALUES (old.host_id, old.id, UNIXEPOCH()) ON CONFLICT DO UPDATE SET date_created = excluded.date_created; END",
 
     NULL
 };

--- a/src/database/sqlite/sqlite_context.h
+++ b/src/database/sqlite/sqlite_context.h
@@ -64,6 +64,7 @@ void ctx_get_dimension_list(nd_uuid_t *host_uuid, void (*dict_cb)(SQL_DIMENSION_
 int ctx_store_context(nd_uuid_t *host_uuid, VERSIONED_CONTEXT_DATA *context_data);
 
 void ctx_get_context_list_to_cleanup(nd_uuid_t *host_uuid, void (*cleanup_cb)(Pvoid_t context, void *data), void *data);
+void ctx_delete_metadata_cleanup_context(sqlite3_stmt **context_res, nd_uuid_t(*host_uuid), const char *context);
 
 #define ctx_update_context(host_uuid, context_data)    ctx_store_context(host_uuid, context_data)
 

--- a/src/database/sqlite/sqlite_context.h
+++ b/src/database/sqlite/sqlite_context.h
@@ -63,6 +63,8 @@ void ctx_get_dimension_list(nd_uuid_t *host_uuid, void (*dict_cb)(SQL_DIMENSION_
 
 int ctx_store_context(nd_uuid_t *host_uuid, VERSIONED_CONTEXT_DATA *context_data);
 
+void ctx_get_context_list_to_cleanup(nd_uuid_t *host_uuid, void (*cleanup_cb)(Pvoid_t context, void *data), void *data);
+
 #define ctx_update_context(host_uuid, context_data)    ctx_store_context(host_uuid, context_data)
 
 int ctx_delete_context(nd_uuid_t *host_id, VERSIONED_CONTEXT_DATA *context_data);


### PR DESCRIPTION
##### Summary
- During database rotation, contexts may be deleted due to no data retention. Cleanup for those is now prioritized
