### PR TITLE
Remove openSUSE 15.5 from CI and package builds.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -209,12 +209,6 @@ include:
         - aarch64
     test:
       ebpf-core: true
-  - <<: *opensuse
-    version: "15.5"
-    base_image: opensuse/leap:15.5
-    packages:
-      <<: *opensuse_packages
-      repo_distro: opensuse/15.5
 
   - &oracle
     distro: oraclelinux
@@ -331,6 +325,12 @@ legacy: # Info for platforms we used to support and still need to handle package
     packages:
       <<: *opensuse_packages
       repo_distro: opensuse/15.4
+  - <<: *opensuse
+    version: "15.5"
+    base_image: opensuse/leap:15.5
+    packages:
+      <<: *opensuse_packages
+      repo_distro: opensuse/15.5
   - <<: *centos_stream
     version: '8'
     base_image: 'quay.io/centos/centos:stream8'


### PR DESCRIPTION
##### Summary

It went EOL upstream as of 2024-12-31.

##### Test Plan

n/a

##### Additional Information

Resolves: #19113