### PR TITLE
Revert "Update kickstart script to use new repository host."

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -53,8 +53,8 @@ INSTALL_DOC_URL="https://learn.netdata.cloud/docs/install-the-netdata-agent/one-
 PACKAGES_SCRIPT="https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh"
 PUBLIC_CLOUD_URL="https://app.netdata.cloud"
 RELEASE_INFO_URL="https://repo.netdata.cloud/releases"
-REPOCONFIG_DEB_URL_PREFIX="https://repository.netdata.cloud/repos/repoconfig"
-REPOCONFIG_RPM_URL_PREFIX="https://repository.netdata.cloud/repos/repoconfig"
+REPOCONFIG_DEB_URL_PREFIX="https://repo.netdata.cloud/repos/repoconfig"
+REPOCONFIG_RPM_URL_PREFIX="https://repo.netdata.cloud/repos/repoconfig"
 TELEMETRY_URL="https://us-east1-netdata-analytics-bi.cloudfunctions.net/ingest_agent_events"
 
 # ======================================================================


### PR DESCRIPTION
Reverts netdata/netdata#18962

Something is broken with the repository that did not show up in testing. Reverting for now while we figure out what’s wrong.