### PR TITLE
Enable libunwind in Docker images.

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -27,6 +27,7 @@ WORKDIR /opt/netdata.git
 RUN chmod +x netdata-installer.sh && \
    cp -rp /deps/* /usr/local/ && \
    /bin/echo -e "INSTALL_TYPE='oci'\nPREBUILT_ARCH='$(uname -m)'" > ./system/.install-type && \
+   NETDATA_CMAKE_OPTIONS="$(dpkg-architecture --equal i386 || echo "-DENABLE_LIBUNWIND=On")" \
    CFLAGS="$(packaging/docker/gen-cflags.sh)" LDFLAGS="-Wl,--gc-sections" ./netdata-installer.sh --dont-wait --dont-start-it --use-system-protobuf \
    ${EXTRA_INSTALL_OPTS} --disable-ebpf --install-no-prefix / "$([ "$RELEASE_CHANNEL" = stable ] && echo --stable-channel)"
 


### PR DESCRIPTION
##### Summary

SSIA

##### Test Plan

Primary testing involves confirming that CI passes on this PR. Secondary testing involves building the Docker images locally and confirming that the executable in them is indeed linked to libunwind.

##### Additional Information

32-bit x86 images are being intentionally excluded from this, as libunwind does not appear to work correctly there and they are generally not used much.