### PR TITLE
Enable libunwind in DEB native packages.

### DIFF
--- a/packaging/build-package.sh
+++ b/packaging/build-package.sh
@@ -59,14 +59,22 @@ case "${PKG_TYPE}" in
             amd64)
                 add_cmake_option ENABLE_PLUGIN_XENSTAT On
                 add_cmake_option ENABLE_PLUGIN_EBPF On
+                add_cmake_option ENABLE_LIBUNWIND On
                 ;;
             arm64)
                 add_cmake_option ENABLE_PLUGIN_XENSTAT On
                 add_cmake_option ENABLE_PLUGIN_EBPF Off
+                add_cmake_option ENABLE_LIBUNWIND On
+                ;;
+            armhf)
+                add_cmake_option ENABLE_PLUGIN_XENSTAT Off
+                add_cmake_option ENABLE_PLUGIN_EBPF Off
+                add_cmake_option ENABLE_LIBUNWIND On
                 ;;
             *)
                 add_cmake_option ENABLE_PLUGIN_XENSTAT Off
                 add_cmake_option ENABLE_PLUGIN_EBPF Off
+                add_cmake_option ENABLE_LIBUNWIND Off
                 ;;
         esac
         ;;


### PR DESCRIPTION
##### Summary

Only on 64-bit x86, 32-bit ARM, and 64-bit ARM for the moment (32-bit x86 is broken because of issues in our handling of libunwind).

##### Test Plan

Primary testing involves verifying that CI passes on this PR. Additionally, the packages need to be built and installed locally to confirm that the binaries are linked against libunwind.