### PR TITLE
PULSE: network traffic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1168,6 +1168,8 @@ set(DAEMON_FILES
         src/daemon/config/netdata-conf-profile.c
         src/daemon/config/netdata-conf-profile.h
         src/daemon/pulse/pulse-daemon-memory-system.c
+        src/daemon/pulse/pulse-network.c
+        src/daemon/pulse/pulse-network.h
 )
 
 set(H2O_FILES

--- a/src/aclk/aclk.c
+++ b/src/aclk/aclk.c
@@ -66,6 +66,13 @@ time_t aclk_block_until = 0;
 
 mqtt_wss_client mqttwss_client;
 
+struct mqtt_wss_stats aclk_statistics(void) {
+    if(mqttwss_client)
+        return mqtt_wss_get_stats(mqttwss_client);
+    else
+        return (struct mqtt_wss_stats) { 0 };
+}
+
 struct aclk_shared_state aclk_shared_state = {
     .mqtt_shutdown_msg_id = -1,
     .mqtt_shutdown_msg_rcvd = 0

--- a/src/aclk/aclk.c
+++ b/src/aclk/aclk.c
@@ -24,12 +24,17 @@ int aclk_pubacks_per_conn = 0; // How many PubAcks we got since MQTT conn est.
 int aclk_rcvd_cloud_msgs = 0;
 int aclk_connection_counter = 0;
 
+mqtt_wss_client mqttwss_client;
+
 static bool aclk_connected = false;
 static inline void aclk_set_connected(void) {
     __atomic_store_n(&aclk_connected, true, __ATOMIC_RELAXED);
 }
 static inline void aclk_set_disconnected(void) {
     __atomic_store_n(&aclk_connected, false, __ATOMIC_RELAXED);
+
+    if(mqttwss_client)
+        mqtt_wss_reset_stats(mqttwss_client);
 }
 
 inline bool aclk_online(void) {
@@ -63,8 +68,6 @@ time_t next_connection_attempt = 0;
 float last_backoff_value = 0;
 
 time_t aclk_block_until = 0;
-
-mqtt_wss_client mqttwss_client;
 
 struct mqtt_wss_stats aclk_statistics(void) {
     if(mqttwss_client)

--- a/src/aclk/aclk.h
+++ b/src/aclk/aclk.h
@@ -94,4 +94,6 @@ char *aclk_state_json(void);
 void add_aclk_host_labels(void);
 void aclk_queue_node_info(RRDHOST *host, bool immediate);
 
+struct mqtt_wss_stats aclk_statistics(void);
+
 #endif /* ACLK_H */

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -994,6 +994,13 @@ struct mqtt_wss_stats mqtt_wss_get_stats(mqtt_wss_client client)
     return current;
 }
 
+void mqtt_wss_reset_stats(mqtt_wss_client client)
+{
+    spinlock_lock(&client->stat_lock);
+    memset(&client->stats, 0, sizeof(client->stats));
+    spinlock_unlock(&client->stat_lock);
+}
+
 int mqtt_wss_set_topic_alias(mqtt_wss_client client, const char *topic)
 {
     return mqtt_ng_set_topic_alias(client->mqtt, topic);

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.c
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.c
@@ -989,7 +989,6 @@ struct mqtt_wss_stats mqtt_wss_get_stats(mqtt_wss_client client)
     struct mqtt_wss_stats current;
     spinlock_lock(&client->stat_lock);
     current = client->stats;
-    memset(&client->stats, 0, sizeof(client->stats));
     spinlock_unlock(&client->stat_lock);
     mqtt_ng_get_stats(client->mqtt, &current.mqtt);
     return current;

--- a/src/aclk/mqtt_websockets/mqtt_wss_client.h
+++ b/src/aclk/mqtt_websockets/mqtt_wss_client.h
@@ -141,6 +141,7 @@ struct mqtt_wss_stats {
 };
 
 struct mqtt_wss_stats mqtt_wss_get_stats(mqtt_wss_client client);
+void mqtt_wss_reset_stats(mqtt_wss_client client);
 
 #ifdef MQTT_WSS_DEBUG
 #include <openssl/ssl.h>

--- a/src/collectors/statsd.plugin/statsd.c
+++ b/src/collectors/statsd.plugin/statsd.c
@@ -965,6 +965,8 @@ static int statsd_rcv_callback(POLLINFO *pi, nd_poll_event_t *events) {
                     d->len += rc;
                     statsd.tcp_socket_reads++;
                     statsd.tcp_bytes_read += rc;
+
+                    pulse_statsd_received_bytes(rc);
                 }
 
                 if(likely(d->len > 0)) {
@@ -1016,12 +1018,15 @@ static int statsd_rcv_callback(POLLINFO *pi, nd_poll_event_t *events) {
                     statsd.udp_socket_reads++;
                     statsd.udp_packets_received += rc;
 
-                    size_t i;
+                    size_t i, total_size = 0;
                     for (i = 0; i < (size_t)rc; ++i) {
                         size_t len = (size_t)d->msgs[i].msg_len;
                         statsd.udp_bytes_read += len;
+                        total_size += len;
                         statsd_process(d->msgs[i].msg_hdr.msg_iov->iov_base, len, 0);
                     }
+
+                    pulse_statsd_received_bytes(total_size);
                 }
             } while (rc != -1);
 
@@ -1043,6 +1048,8 @@ static int statsd_rcv_callback(POLLINFO *pi, nd_poll_event_t *events) {
                     statsd.udp_packets_received++;
                     statsd.udp_bytes_read += rc;
                     statsd_process(d->buffer, (size_t) rc, 0);
+
+                    pulse_statsd_received_bytes(rc);
                 }
             } while (rc != -1);
 #endif

--- a/src/daemon/pulse/pulse-network.c
+++ b/src/daemon/pulse/pulse-network.c
@@ -154,36 +154,36 @@ void pulse_network_do(bool extended __maybe_unused) {
         rrdset_done(st_bytes);
     }
 
-    struct mqtt_wss_stats t = aclk_statistics();
-    if(t.bytes_rx || t.bytes_tx) {
-        static RRDSET *st_bytes = NULL;
-        static RRDDIM *rd_in = NULL,
-                      *rd_out = NULL;
+    if(aclk_online()) {
+        struct mqtt_wss_stats t = aclk_statistics();
+        if (t.bytes_rx || t.bytes_tx) {
+            static RRDSET *st_bytes = NULL;
+            static RRDDIM *rd_in = NULL, *rd_out = NULL;
 
-        if (unlikely(!st_bytes)) {
-            st_bytes = rrdset_create_localhost(
-                "netdata"
-                , "network_aclk"
-                , NULL
-                , PULSE_NETWORK_CHART_FAMILY
-                , PULSE_NETWORK_CHART_CONTEXT
-                , PULSE_NETWORK_CHART_TITLE
-                , PULSE_NETWORK_CHART_UNITS
-                , "netdata"
-                , "pulse"
-                , PULSE_NETWORK_CHART_PRIORITY
-                , localhost->rrd_update_every
-                , RRDSET_TYPE_AREA
-            );
+            if (unlikely(!st_bytes)) {
+                st_bytes = rrdset_create_localhost(
+                    "netdata",
+                    "network_aclk",
+                    NULL,
+                    PULSE_NETWORK_CHART_FAMILY,
+                    PULSE_NETWORK_CHART_CONTEXT,
+                    PULSE_NETWORK_CHART_TITLE,
+                    PULSE_NETWORK_CHART_UNITS,
+                    "netdata",
+                    "pulse",
+                    PULSE_NETWORK_CHART_PRIORITY,
+                    localhost->rrd_update_every,
+                    RRDSET_TYPE_AREA);
 
-            rrdlabels_add(st_bytes->rrdlabels, "endpoint", "aclk", RRDLABEL_SRC_AUTO);
+                rrdlabels_add(st_bytes->rrdlabels, "endpoint", "aclk", RRDLABEL_SRC_AUTO);
 
-            rd_in  = rrddim_add(st_bytes, "in",  NULL,  8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
-            rd_out = rrddim_add(st_bytes, "out", NULL, -8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
+                rd_in = rrddim_add(st_bytes, "in", NULL, 8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
+                rd_out = rrddim_add(st_bytes, "out", NULL, -8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
+            }
+
+            rrddim_set_by_pointer(st_bytes, rd_in, (collected_number)t.bytes_rx);
+            rrddim_set_by_pointer(st_bytes, rd_out, (collected_number)t.bytes_tx);
+            rrdset_done(st_bytes);
         }
-
-        rrddim_set_by_pointer(st_bytes, rd_in, (collected_number) t.bytes_rx);
-        rrddim_set_by_pointer(st_bytes, rd_out, (collected_number) t.bytes_tx);
-        rrdset_done(st_bytes);
     }
 }

--- a/src/daemon/pulse/pulse-network.c
+++ b/src/daemon/pulse/pulse-network.c
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#define PULSE_INTERNALS 1
+#include "pulse-network.h"
+
+#define PULSE_NETWORK_CHART_TITLE "Netdata Network Traffic"
+#define PULSE_NETWORK_CHART_FAMILY "Network Traffic"
+#define PULSE_NETWORK_CHART_CONTEXT "netdata.network"
+#define PULSE_NETWORK_CHART_UNITS "kilobits/s"
+#define PULSE_NETWORK_CHART_PRIORITY 130150
+
+static struct network_statistics {
+    bool extended;
+    PAD64(uint64_t) api_bytes_received;
+    PAD64(uint64_t) api_bytes_sent;
+    PAD64(uint64_t) statsd_bytes_received;
+    PAD64(uint64_t) statsd_bytes_sent;
+    PAD64(uint64_t) stream_bytes_received;
+    PAD64(uint64_t) stream_bytes_sent;
+} live_stats = { 0 };
+
+void pulse_web_server_received_bytes(size_t bytes) {
+    __atomic_add_fetch(&live_stats.api_bytes_received, bytes, __ATOMIC_RELAXED);
+}
+
+void pulse_web_server_sent_bytes(size_t bytes) {
+    __atomic_add_fetch(&live_stats.api_bytes_sent, bytes, __ATOMIC_RELAXED);
+}
+
+void pulse_statsd_received_bytes(size_t bytes) {
+    __atomic_add_fetch(&live_stats.statsd_bytes_received, bytes, __ATOMIC_RELAXED);
+}
+
+void pulse_statsd_sent_bytes(size_t bytes) {
+    __atomic_add_fetch(&live_stats.statsd_bytes_sent, bytes, __ATOMIC_RELAXED);
+}
+
+void pulse_stream_received_bytes(size_t bytes) {
+    __atomic_add_fetch(&live_stats.stream_bytes_received, bytes, __ATOMIC_RELAXED);
+}
+
+void pulse_stream_sent_bytes(size_t bytes) {
+    __atomic_add_fetch(&live_stats.stream_bytes_sent, bytes, __ATOMIC_RELAXED);
+}
+
+static inline void pulse_network_copy(struct network_statistics *gs) {
+    gs->api_bytes_received = __atomic_load_n(&live_stats.api_bytes_received, __ATOMIC_RELAXED);
+    gs->api_bytes_sent = __atomic_load_n(&live_stats.api_bytes_sent, __ATOMIC_RELAXED);
+    
+    gs->statsd_bytes_received = __atomic_load_n(&live_stats.statsd_bytes_received, __ATOMIC_RELAXED);
+    gs->statsd_bytes_sent = __atomic_load_n(&live_stats.statsd_bytes_sent, __ATOMIC_RELAXED);
+
+    gs->stream_bytes_received = __atomic_load_n(&live_stats.stream_bytes_received, __ATOMIC_RELAXED);
+    gs->stream_bytes_sent = __atomic_load_n(&live_stats.stream_bytes_sent, __ATOMIC_RELAXED);
+}
+
+void pulse_network_do(bool extended __maybe_unused) {
+    static struct network_statistics gs;
+    pulse_network_copy(&gs);
+
+    if(gs.api_bytes_received || gs.api_bytes_sent) {
+        static RRDSET *st_bytes = NULL;
+        static RRDDIM *rd_in = NULL,
+                      *rd_out = NULL;
+
+        if (unlikely(!st_bytes)) {
+            st_bytes = rrdset_create_localhost(
+                "netdata"
+                , "network_api"
+                , NULL
+                , PULSE_NETWORK_CHART_FAMILY
+                , PULSE_NETWORK_CHART_CONTEXT
+                , PULSE_NETWORK_CHART_TITLE
+                , PULSE_NETWORK_CHART_UNITS
+                , "netdata"
+                , "pulse"
+                , PULSE_NETWORK_CHART_PRIORITY
+                , localhost->rrd_update_every
+                , RRDSET_TYPE_AREA
+            );
+
+            rrdlabels_add(st_bytes->rrdlabels, "endpoint", "web-server", RRDLABEL_SRC_AUTO);
+            
+            rd_in  = rrddim_add(st_bytes, "in",  NULL,  8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
+            rd_out = rrddim_add(st_bytes, "out", NULL, -8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
+        }
+
+        rrddim_set_by_pointer(st_bytes, rd_in, (collected_number) gs.api_bytes_received);
+        rrddim_set_by_pointer(st_bytes, rd_out, (collected_number) gs.api_bytes_sent);
+        rrdset_done(st_bytes);
+    }
+
+    if(gs.statsd_bytes_received || gs.statsd_bytes_sent) {
+        static RRDSET *st_bytes = NULL;
+        static RRDDIM *rd_in = NULL,
+                      *rd_out = NULL;
+
+        if (unlikely(!st_bytes)) {
+            st_bytes = rrdset_create_localhost(
+                "netdata"
+                , "network_statsd"
+                , NULL
+                , PULSE_NETWORK_CHART_FAMILY
+                , PULSE_NETWORK_CHART_CONTEXT
+                , PULSE_NETWORK_CHART_TITLE
+                , PULSE_NETWORK_CHART_UNITS
+                , "netdata"
+                , "pulse"
+                , PULSE_NETWORK_CHART_PRIORITY
+                , localhost->rrd_update_every
+                , RRDSET_TYPE_AREA
+            );
+
+            rrdlabels_add(st_bytes->rrdlabels, "endpoint", "statsd", RRDLABEL_SRC_AUTO);
+
+            rd_in  = rrddim_add(st_bytes, "in",  NULL,  8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
+            rd_out = rrddim_add(st_bytes, "out", NULL, -8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
+        }
+
+        rrddim_set_by_pointer(st_bytes, rd_in, (collected_number) gs.statsd_bytes_received);
+        rrddim_set_by_pointer(st_bytes, rd_out, (collected_number) gs.statsd_bytes_sent);
+        rrdset_done(st_bytes);
+    }
+
+    if(gs.stream_bytes_received || gs.stream_bytes_sent) {
+        static RRDSET *st_bytes = NULL;
+        static RRDDIM *rd_in = NULL,
+                      *rd_out = NULL;
+
+        if (unlikely(!st_bytes)) {
+            st_bytes = rrdset_create_localhost(
+                "netdata"
+                , "network_streaming"
+                , NULL
+                , PULSE_NETWORK_CHART_FAMILY
+                , PULSE_NETWORK_CHART_CONTEXT
+                , PULSE_NETWORK_CHART_TITLE
+                , PULSE_NETWORK_CHART_UNITS
+                , "netdata"
+                , "pulse"
+                , PULSE_NETWORK_CHART_PRIORITY
+                , localhost->rrd_update_every
+                , RRDSET_TYPE_AREA
+            );
+
+            rrdlabels_add(st_bytes->rrdlabels, "endpoint", "streaming", RRDLABEL_SRC_AUTO);
+
+            rd_in  = rrddim_add(st_bytes, "in",  NULL,  8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
+            rd_out = rrddim_add(st_bytes, "out", NULL, -8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
+        }
+
+        rrddim_set_by_pointer(st_bytes, rd_in, (collected_number) gs.stream_bytes_received);
+        rrddim_set_by_pointer(st_bytes, rd_out, (collected_number) gs.stream_bytes_sent);
+        rrdset_done(st_bytes);
+    }
+
+    struct mqtt_wss_stats t = aclk_statistics();
+    if(t.bytes_rx || t.bytes_tx) {
+        static RRDSET *st_bytes = NULL;
+        static RRDDIM *rd_in = NULL,
+                      *rd_out = NULL;
+
+        if (unlikely(!st_bytes)) {
+            st_bytes = rrdset_create_localhost(
+                "netdata"
+                , "network_aclk"
+                , NULL
+                , PULSE_NETWORK_CHART_FAMILY
+                , PULSE_NETWORK_CHART_CONTEXT
+                , PULSE_NETWORK_CHART_TITLE
+                , PULSE_NETWORK_CHART_UNITS
+                , "netdata"
+                , "pulse"
+                , PULSE_NETWORK_CHART_PRIORITY
+                , localhost->rrd_update_every
+                , RRDSET_TYPE_AREA
+            );
+
+            rrdlabels_add(st_bytes->rrdlabels, "endpoint", "aclk", RRDLABEL_SRC_AUTO);
+
+            rd_in  = rrddim_add(st_bytes, "in",  NULL,  8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
+            rd_out = rrddim_add(st_bytes, "out", NULL, -8, BITS_IN_A_KILOBIT, RRD_ALGORITHM_INCREMENTAL);
+        }
+
+        rrddim_set_by_pointer(st_bytes, rd_in, (collected_number) t.bytes_rx);
+        rrddim_set_by_pointer(st_bytes, rd_out, (collected_number) t.bytes_tx);
+        rrdset_done(st_bytes);
+    }
+}

--- a/src/daemon/pulse/pulse-network.h
+++ b/src/daemon/pulse/pulse-network.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef NETDATA_PULSE_NETWORK_H
+#define NETDATA_PULSE_NETWORK_H
+
+#include "daemon/common.h"
+
+void pulse_network_do(bool extended);
+
+void pulse_web_server_received_bytes(size_t bytes);
+void pulse_web_server_sent_bytes(size_t bytes);
+
+void pulse_statsd_received_bytes(size_t bytes);
+void pulse_statsd_sent_bytes(size_t bytes);
+
+void pulse_stream_received_bytes(size_t bytes);
+void pulse_stream_sent_bytes(size_t bytes);
+
+#endif //NETDATA_PULSE_NETWORK_H

--- a/src/daemon/pulse/pulse.c
+++ b/src/daemon/pulse/pulse.c
@@ -18,8 +18,9 @@
 #define WORKER_JOB_MALLOC_TRACE         12
 #define WORKER_JOB_REGISTRY             13
 #define WORKER_JOB_ARAL                 14
+#define WORKER_JOB_NETWORK              15
 
-#if WORKER_UTILIZATION_MAX_JOB_TYPES < 15
+#if WORKER_UTILIZATION_MAX_JOB_TYPES < 16
 #error "WORKER_UTILIZATION_MAX_JOB_TYPES has to be at least 14"
 #endif
 
@@ -44,6 +45,7 @@ static void pulse_register_workers(void) {
     worker_register_job_name(WORKER_JOB_MALLOC_TRACE, "malloc_trace");
     worker_register_job_name(WORKER_JOB_REGISTRY, "registry");
     worker_register_job_name(WORKER_JOB_ARAL, "aral");
+    worker_register_job_name(WORKER_JOB_NETWORK, "network");
 }
 
 static void pulse_cleanup(void *pptr)
@@ -98,6 +100,9 @@ void *pulse_thread_main(void *ptr) {
 
         worker_is_busy(WORKER_JOB_QUERIES);
         pulse_queries_do(pulse_extended_enabled);
+
+        worker_is_busy(WORKER_JOB_NETWORK);
+        pulse_network_do(pulse_extended_enabled);
 
         worker_is_busy(WORKER_JOB_ML);
         pulse_ml_do(pulse_extended_enabled);

--- a/src/daemon/pulse/pulse.h
+++ b/src/daemon/pulse/pulse.h
@@ -24,6 +24,7 @@ extern bool pulse_extended_enabled;
 #include "pulse-workers.h"
 #include "pulse-trace-allocations.h"
 #include "pulse-aral.h"
+#include "pulse-network.h"
 
 void *pulse_thread_main(void *ptr);
 void *pulse_thread_sqlite3_main(void *ptr);

--- a/src/database/contexts/worker.c
+++ b/src/database/contexts/worker.c
@@ -407,7 +407,7 @@ static void rrdinstance_post_process_updates(RRDINSTANCE *ri, bool force, RRD_FL
     if(dictionary_entries(ri->rrdmetrics) > 0) {
         RRDMETRIC *rm;
         dfe_start_read((DICTIONARY *)ri->rrdmetrics, rm) {
-                    if(unlikely(!service_running(SERVICE_CONTEXT))) break;
+                    if(unlikely(worker_jobs && !service_running(SERVICE_CONTEXT))) break;
 
                     RRD_FLAGS reason_to_pass = reason;
                     if(rrd_flag_check(ri, RRD_FLAG_UPDATE_REASON_UPDATE_RETENTION))
@@ -516,7 +516,7 @@ static void rrdcontext_post_process_updates(RRDCONTEXT *rc, bool force, RRD_FLAG
     if(dictionary_entries(rc->rrdinstances) > 0) {
         RRDINSTANCE *ri;
         dfe_start_reentrant(rc->rrdinstances, ri) {
-                    if(unlikely(!service_running(SERVICE_CONTEXT))) break;
+                    if(unlikely(worker_jobs && !service_running(SERVICE_CONTEXT))) break;
 
                     RRD_FLAGS reason_to_pass = reason;
                     if(rrd_flag_check(rc, RRD_FLAG_UPDATE_REASON_UPDATE_RETENTION))
@@ -703,7 +703,7 @@ static void rrdcontext_dequeue_from_post_processing(RRDCONTEXT *rc) {
 
 void rrdcontext_initial_processing_after_loading(RRDCONTEXT *rc) {
     rrdcontext_dequeue_from_post_processing(rc);
-    rrdcontext_post_process_updates(rc, false, RRD_FLAG_NONE, true);
+    rrdcontext_post_process_updates(rc, false, RRD_FLAG_NONE, false);
 }
 
 void rrdcontext_delete_after_loading(RRDHOST *host, RRDCONTEXT *rc) {

--- a/src/database/sqlite/sqlite_aclk_node.c
+++ b/src/database/sqlite/sqlite_aclk_node.c
@@ -217,7 +217,7 @@ void aclk_check_node_info_and_collectors(void)
             context_pp_post = "')";
         }
 
-        nd_log_limit_static_thread_var(erl, 10, 100 * USEC_PER_MS);
+        nd_log_limit_static_global_var(erl, 10, 100 * USEC_PER_MS);
         nd_log_limit(&erl, NDLS_DAEMON, NDLP_INFO,
                      "NODES INFO: %zu nodes loading contexts%s%s%s, %zu receiving replication%s%s%s, %zu sending replication%s%s%s, %zu pending context post processing%s%s%s%s",
                      context_loading, context_loading_pre, context_loading_body, context_loading_post,

--- a/src/streaming/stream-sender.c
+++ b/src/streaming/stream-sender.c
@@ -622,6 +622,7 @@ bool stream_sender_send_data(struct stream_thread *sth, struct sender_state *s, 
 
         ssize_t rc = nd_sock_send_nowait(&s->sock, chunk, outstanding);
         if (likely(rc > 0)) {
+            pulse_stream_sent_bytes(rc);
             stream_circular_buffer_del_unsafe(s->scb, rc, now_ut);
             replication_sender_recalculate_buffer_used_ratio_unsafe(s);
             s->thread.last_traffic_ut = now_ut;
@@ -712,6 +713,7 @@ bool stream_sender_receive_data(struct stream_thread *sth, struct sender_state *
 
             s->thread.last_traffic_ut = now_ut;
             sth->snd.bytes_received += rc;
+            pulse_stream_received_bytes(rc);
 
             worker_is_busy(WORKER_SENDER_JOB_EXECUTE);
             stream_sender_execute_commands(s);


### PR DESCRIPTION
pulse now tracks network traffic for:

- [x] web server
- [x] statsd
- [x] streaming
- [x] aclk

This is in real-time, not after processing requests. Pulse has been hooked to the reception and dispatch of all the above.