### PR TITLE
Drop Fedora 39 from CI and package builds.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -182,13 +182,6 @@ include:
       repo_distro: fedora/40
     test:
       ebpf-core: true
-  - <<: *fedora
-    version: "39"
-    packages:
-      <<: *fedora_packages
-      repo_distro: fedora/39
-    test:
-      ebpf-core: true
 
   - &opensuse
     distro: opensuse
@@ -320,6 +313,13 @@ legacy: # Info for platforms we used to support and still need to handle package
     packages:
       <<: *fedora_packages
       repo_distro: fedora/38
+  - <<: *fedora
+    version: "39"
+    packages:
+      <<: *fedora_packages
+      repo_distro: fedora/39
+    test:
+      ebpf-core: true
   - <<: *opensuse
     version: "15.4"
     packages:


### PR DESCRIPTION
##### Summary

It went EOL upstream 2024-11-06.

##### Test Plan

n/a