### PR TITLE
Revert libunwind being enabled in Docker and DEB builds.

### DIFF
--- a/packaging/build-package.sh
+++ b/packaging/build-package.sh
@@ -59,22 +59,14 @@ case "${PKG_TYPE}" in
             amd64)
                 add_cmake_option ENABLE_PLUGIN_XENSTAT On
                 add_cmake_option ENABLE_PLUGIN_EBPF On
-                add_cmake_option ENABLE_LIBUNWIND On
                 ;;
             arm64)
                 add_cmake_option ENABLE_PLUGIN_XENSTAT On
                 add_cmake_option ENABLE_PLUGIN_EBPF Off
-                add_cmake_option ENABLE_LIBUNWIND On
-                ;;
-            armhf)
-                add_cmake_option ENABLE_PLUGIN_XENSTAT Off
-                add_cmake_option ENABLE_PLUGIN_EBPF Off
-                add_cmake_option ENABLE_LIBUNWIND On
                 ;;
             *)
                 add_cmake_option ENABLE_PLUGIN_XENSTAT Off
                 add_cmake_option ENABLE_PLUGIN_EBPF Off
-                add_cmake_option ENABLE_LIBUNWIND Off
                 ;;
         esac
         ;;

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -27,7 +27,6 @@ WORKDIR /opt/netdata.git
 RUN chmod +x netdata-installer.sh && \
    cp -rp /deps/* /usr/local/ && \
    /bin/echo -e "INSTALL_TYPE='oci'\nPREBUILT_ARCH='$(uname -m)'" > ./system/.install-type && \
-   NETDATA_CMAKE_OPTIONS="$(dpkg-architecture --equal i386 || echo "-DENABLE_LIBUNWIND=On")" \
    CFLAGS="$(packaging/docker/gen-cflags.sh)" LDFLAGS="-Wl,--gc-sections" ./netdata-installer.sh --dont-wait --dont-start-it --use-system-protobuf \
    ${EXTRA_INSTALL_OPTS} --disable-ebpf --install-no-prefix / "$([ "$RELEASE_CHANNEL" = stable ] && echo --stable-channel)"
 


### PR DESCRIPTION
##### Summary

This actually needs to wait until after the release, likely even longer (because it breaks 32-bit builds on 64-bit hosts).

##### Test Plan

n/a