### PR TITLE
Remove UPS load charts if UPS load not found

### DIFF
--- a/src/go/plugin/go.d/collector/upsd/charts.go
+++ b/src/go/plugin/go.d/collector/upsd/charts.go
@@ -337,6 +337,8 @@ func (c *Collector) addUPSCharts(ups upsUnit) {
 		{varBatteryVoltage, upsBatteryVoltageChartTmpl.ID},
 		{varBatteryVoltageNominal, upsBatteryVoltageNominalChartTmpl.ID},
 
+		{varUpsLoad, upsLoadChartTmpl.ID},
+		{varUpsLoad, upsLoadUsageChartTmpl.ID},
 		{varUpsTemperature, upsTemperatureChartTmpl.ID},
 
 		{varInputVoltage, upsInputVoltageChartTmpl.ID},


### PR DESCRIPTION
##### Summary
Ignore `upsd.ups_load` and `upsd.ups_load_usage` charts if NUT does not have any data for those metrics (does not track the `ups.load` variable).

Fixes https://github.com/netdata/netdata/issues/19454

##### Test Plan

No test cases have been added&mdash;don't know how&mdash;but I am happy to add some test cases if someone can point me in the right direction.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
This affects only the upsd (NUT) collector by removing two charts if there is not data to display. This should make the output of Netdata more succinct and cleaner.
</details>
