### PR TITLE
Simplify the rrdhost_ingestion_status call

### DIFF
--- a/src/database/rrdhost-status.h
+++ b/src/database/rrdhost-status.h
@@ -166,6 +166,7 @@ typedef struct rrdhost_status_t {
 } RRDHOST_STATUS;
 
 void rrdhost_status(RRDHOST *host, time_t now, RRDHOST_STATUS *s);
+RRDHOST_INGEST_STATUS rrdhost_get_ingest_status(RRDHOST *host, time_t now);
 RRDHOST_INGEST_STATUS rrdhost_ingestion_status(RRDHOST *host);
 int16_t rrdhost_ingestion_hops(RRDHOST *host);
 


### PR DESCRIPTION
##### Summary
- Use `rrdhost_get_ingest_status`  (a simplified version of `rrdhost_status`) to  return the injest status of a host. 
  - The state is used to propagate a node state update message to the cloud