### PR TITLE
fix crash when cleaning up virtual nodes

### DIFF
--- a/src/libnetdata/object-state/object-state.h
+++ b/src/libnetdata/object-state/object-state.h
@@ -23,6 +23,7 @@ OBJECT_STATE_ID object_state_id(OBJECT_STATE *os);
 // increments the object's state id
 // enables using the object - users may acquire and release the object
 void object_state_activate(OBJECT_STATE *os);
+void object_state_activate_if_not_activated(OBJECT_STATE *os);
 
 // increments the object's state id
 // prevents users from acquiring it, and waits until all of its holders have released it

--- a/src/plugins.d/pluginsd_parser.c
+++ b/src/plugins.d/pluginsd_parser.c
@@ -204,7 +204,7 @@ static inline PARSER_RC pluginsd_host_define_end(char **words __maybe_unused, si
 
     rrdhost_option_set(host, RRDHOST_OPTION_VIRTUAL_HOST);
     rrdhost_flag_set(host, RRDHOST_FLAG_COLLECTOR_ONLINE);
-    object_state_activate(&host->state_id);
+    object_state_activate_if_not_activated(&host->state_id);
     ml_host_start(host);
     dyncfg_host_init(host);
     pulse_host_status(host, 0, 0); // this will detect the receiver status


### PR DESCRIPTION
when the receiver is null, there is no need to wait for anything