### PR TITLE
Make handling of cross-platform emulation for static builds smarter.

### DIFF
--- a/packaging/makeself/build-static.sh
+++ b/packaging/makeself/build-static.sh
@@ -27,12 +27,7 @@ fi
 DOCKER_IMAGE_NAME="netdata/static-builder:v1"
 
 if [ "${BUILDARCH}" != "$(uname -m)" ] && [ -z "${SKIP_EMULATION}" ]; then
-    if [ "$(uname -m)" = "x86_64" ]; then
-        ${docker} run --rm --privileged multiarch/qemu-user-static --reset -p yes || exit 1
-    else
-        echo "Automatic cross-architecture builds are only supported on x86_64 hosts."
-        exit 1
-    fi
+    ${docker} run --rm --privileged tonistiigi/binfmt:master --install all || exit 1
 fi
 
 case "${BUILDARCH}" in


### PR DESCRIPTION
##### Summary

- Switch to using `tonistiigi/binfmt` instead of `multiarch/qemu-user-static`. This image is what Docker itself seems to recommend, and is both receiving more active updates than the old one _and_ supports usage on hosts other than 64-bit x86 systems.
- Only install emulation for the specific platform we need instead of installing for everything.
- Try to auto-detect an existing QEMU userspace emulation setup, and skip emulation if one is seen. This eliminates the need to manually override emulation setup, and thus also eliminates the possibility of accidentally breaking an existing emulation setup.

##### Test Plan

Needs local testing.