### PR TITLE
chore(go.d/ping): set privileged by default for dyncfg jobs

### DIFF
--- a/src/go/plugin/go.d/collector/ping/config_schema.json
+++ b/src/go/plugin/go.d/collector/ping/config_schema.json
@@ -13,9 +13,9 @@
       },
       "privileged": {
         "title": "Privileged mode",
-        "description": "If unset, sends unprivileged UDP ping packets (require [additional configuration](https://github.com/netdata/netdata/tree/master/src/go/plugin/go.d/collector/ping#overview)); otherwise, sends raw ICMP ping packets ([not recommended](https://github.com/netdata/netdata/issues/15410)).",
+        "description": "If set, sends raw ICMP ping packets; otherwise, sends unprivileged UDP ping packets (require [additional configuration](https://github.com/netdata/netdata/tree/master/src/go/plugin/go.d/collector/ping#overview)).",
         "type": "boolean",
-        "default": false
+        "default": true
       },
       "hosts": {
         "title": "Network hosts",

--- a/src/go/plugin/go.d/collector/ping/metadata.yaml
+++ b/src/go/plugin/go.d/collector/ping/metadata.yaml
@@ -94,9 +94,9 @@ modules:
               default_value: ""
               required: false
             - name: privileged
-              description: Ping packets type. "no" means send an "unprivileged" UDP ping,  "yes" - raw ICMP ping.
+              description: Ping packets type. "yes" means raw ICMP ping, "no" - "unprivileged" UDP ping.
               default_value: true
-              required: false
+              required: true
             - name: packets
               description: Number of ping packets to send.
               default_value: 5


### PR DESCRIPTION
##### Summary

The performance issue in privileged mode [was fixed](https://github.com/netdata/netdata/issues/15410#issuecomment-2612437503).

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
