### PR TITLE
protection against extreme cardinality

### DIFF
--- a/src/database/contexts/contexts-loading.c
+++ b/src/database/contexts/contexts-loading.c
@@ -18,7 +18,7 @@ static void rrdinstance_load_dimension_callback(SQL_DIMENSION_DATA *sd, void *da
 
     UUIDMAP_ID id = uuidmap_create(sd->dim_id);
     time_t min_first_time_t = LONG_MAX, max_last_time_t = 0;
-    get_metric_retention_by_id(host, id, &min_first_time_t, &max_last_time_t);
+    get_metric_retention_by_id(host, id, &min_first_time_t, &max_last_time_t, NULL);
     if((!min_first_time_t || min_first_time_t == LONG_MAX) && !max_last_time_t) {
         uuidmap_free(id);
         th_zero_retention_metrics++;

--- a/src/database/contexts/internal.h
+++ b/src/database/contexts/internal.h
@@ -60,6 +60,7 @@ typedef enum __attribute__ ((__packed__)) {
     RRD_FLAG_UPDATE_REASON_UNUSED                  = (1 << 22), // this context is not used anymore
     RRD_FLAG_UPDATE_REASON_DB_ROTATION             = (1 << 23), // this context changed because of a db rotation
 
+    RRD_FLAG_NO_TIER0_RETENTION                    = (1 << 28),
     RRD_FLAG_MERGED_COLLECTED_RI_TO_RC             = (1 << 29),
 
     // action to perform on an object
@@ -471,7 +472,7 @@ void rrdcontext_update_from_collected_rrdinstance(RRDINSTANCE *ri);
 
 void rrdcontext_garbage_collect_single_host(RRDHOST *host, bool worker_jobs);
 
-void get_metric_retention_by_id(RRDHOST *host, UUIDMAP_ID id, time_t *min_first_time_t, time_t *max_last_time_t);
+void get_metric_retention_by_id(RRDHOST *host, UUIDMAP_ID id, time_t *min_first_time_t, time_t *max_last_time_t, bool *tier0_retention);
 
 void rrdcontext_delete_after_loading(RRDHOST *host, RRDCONTEXT *rc);
 void rrdcontext_initial_processing_after_loading(RRDCONTEXT *rc);

--- a/src/database/engine/metric.c
+++ b/src/database/engine/metric.c
@@ -459,6 +459,12 @@ inline time_t mrg_metric_get_first_time_s(MRG *mrg __maybe_unused, METRIC *metri
     return mrg_metric_get_first_time_s_smart(mrg, metric);
 }
 
+void mrg_metric_clear_retention(MRG *mrg __maybe_unused, METRIC *metric) {
+    __atomic_store_n(&metric->first_time_s, 0, __ATOMIC_RELAXED);
+    __atomic_store_n(&metric->latest_time_s_clean, 0, __ATOMIC_RELAXED);
+    __atomic_store_n(&metric->latest_time_s_hot, 0, __ATOMIC_RELAXED);
+}
+
 inline void mrg_metric_get_retention(MRG *mrg __maybe_unused, METRIC *metric, time_t *first_time_s, time_t *last_time_s, uint32_t *update_every_s) {
     time_t clean = __atomic_load_n(&metric->latest_time_s_clean, __ATOMIC_RELAXED);
     time_t hot = __atomic_load_n(&metric->latest_time_s_hot, __ATOMIC_RELAXED);
@@ -490,7 +496,7 @@ inline bool mrg_metric_set_clean_latest_time_s(MRG *mrg __maybe_unused, METRIC *
 }
 
 // returns true when metric still has retention
-inline bool mrg_metric_zero_disk_retention(MRG *mrg __maybe_unused, METRIC *metric) {
+inline bool mrg_metric_has_zero_disk_retention(MRG *mrg __maybe_unused, METRIC *metric) {
     Word_t section = mrg_metric_section(mrg, metric);
     bool do_again = false;
     size_t countdown = 5;

--- a/src/database/engine/metric.h
+++ b/src/database/engine/metric.h
@@ -53,7 +53,7 @@ bool mrg_metric_release_and_delete(MRG *mrg, METRIC *metric);
 
 Word_t mrg_metric_id(MRG *mrg, METRIC *metric);
 nd_uuid_t *mrg_metric_uuid(MRG *mrg, METRIC *metric);
-UUIDMAP_ID mrg_metric_uuidmap_id_dup(MRG *mrg __maybe_unused, METRIC *metric);
+UUIDMAP_ID mrg_metric_uuidmap_id_dup(MRG *mrg, METRIC *metric);
 Word_t mrg_metric_section(MRG *mrg, METRIC *metric);
 
 bool mrg_metric_set_first_time_s(MRG *mrg, METRIC *metric, time_t first_time_s);
@@ -71,7 +71,8 @@ uint32_t mrg_metric_get_update_every_s(MRG *mrg, METRIC *metric);
 
 void mrg_metric_expand_retention(MRG *mrg, METRIC *metric, time_t first_time_s, time_t last_time_s, uint32_t update_every_s);
 void mrg_metric_get_retention(MRG *mrg, METRIC *metric, time_t *first_time_s, time_t *last_time_s, uint32_t *update_every_s);
-bool mrg_metric_zero_disk_retention(MRG *mrg __maybe_unused, METRIC *metric);
+bool mrg_metric_has_zero_disk_retention(MRG *mrg, METRIC *metric);
+void mrg_metric_clear_retention(MRG *mrg, METRIC *metric);
 
 #ifdef NETDATA_INTERNAL_CHECKS
 bool mrg_metric_set_writer(MRG *mrg, METRIC *metric);

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -1179,7 +1179,7 @@ static void update_metrics_first_time_s(struct rrdengine_instance *ctx, struct r
             zero_disk_retention++;
 
             // there is no retention for this metric
-            bool has_retention = mrg_metric_zero_disk_retention(main_mrg, uuid_first_t_entry->metric);
+            bool has_retention = mrg_metric_has_zero_disk_retention(main_mrg, uuid_first_t_entry->metric);
             if (!has_retention) {
                 time_t first_time_s = mrg_metric_get_first_time_s(main_mrg, uuid_first_t_entry->metric);
                 time_t last_time_s = mrg_metric_get_latest_time_s(main_mrg, uuid_first_t_entry->metric);

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -1003,6 +1003,21 @@ bool rrdeng_metric_retention_by_id(STORAGE_INSTANCE *si, UUIDMAP_ID id, time_t *
     return true;
 }
 
+void rrdeng_metric_retention_delete_by_id(STORAGE_INSTANCE *si, UUIDMAP_ID id) {
+    struct rrdengine_instance *ctx = (struct rrdengine_instance *)si;
+    if (unlikely(!ctx)) {
+        netdata_log_error("DBENGINE: invalid STORAGE INSTANCE to %s()", __FUNCTION__);
+        return;
+    }
+
+    METRIC *metric = mrg_metric_get_and_acquire_by_id(main_mrg, id, (Word_t)ctx);
+    if (unlikely(!metric))
+        return;
+
+    mrg_metric_clear_retention(main_mrg, metric);
+    mrg_metric_release(main_mrg, metric);
+}
+
 uint64_t rrdeng_disk_space_max(STORAGE_INSTANCE *si) {
     struct rrdengine_instance *ctx = (struct rrdengine_instance *)si;
     return ctx->config.max_disk_space;

--- a/src/database/engine/rrdengineapi.h
+++ b/src/database/engine/rrdengineapi.h
@@ -78,6 +78,7 @@ void rrdeng_quiesce(struct rrdengine_instance *ctx);
 
 bool rrdeng_metric_retention_by_id(STORAGE_INSTANCE *si, UUIDMAP_ID id, time_t *first_entry_s, time_t *last_entry_s);
 bool rrdeng_metric_retention_by_uuid(STORAGE_INSTANCE *si, nd_uuid_t *dim_uuid, time_t *first_entry_s, time_t *last_entry_s);
+void rrdeng_metric_retention_delete_by_id(STORAGE_INSTANCE *si, UUIDMAP_ID id);
 
 extern STORAGE_METRICS_GROUP *rrdeng_metrics_group_get(STORAGE_INSTANCE *si, nd_uuid_t *uuid);
 extern void rrdeng_metrics_group_release(STORAGE_INSTANCE *si, STORAGE_METRICS_GROUP *smg);

--- a/src/database/ram/rrddim_mem.c
+++ b/src/database/ram/rrddim_mem.c
@@ -155,6 +155,10 @@ bool rrddim_metric_retention_by_id(STORAGE_INSTANCE *si __maybe_unused, UUIDMAP_
     return true;
 }
 
+void rrddim_retention_delete_by_id(STORAGE_INSTANCE *si __maybe_unused, UUIDMAP_ID id __maybe_unused) {
+    ;
+}
+
 void rrddim_store_metric_change_collection_frequency(STORAGE_COLLECT_HANDLE *sch, int update_every) {
     struct mem_collect_handle *ch = (struct mem_collect_handle *)sch;
     struct mem_metric_handle *mh = (struct mem_metric_handle *)ch->smh;

--- a/src/database/ram/rrddim_mem.h
+++ b/src/database/ram/rrddim_mem.h
@@ -30,6 +30,7 @@ void rrddim_metric_release(STORAGE_METRIC_HANDLE *smh);
 
 bool rrddim_metric_retention_by_id(STORAGE_INSTANCE *si, UUIDMAP_ID id, time_t *first_entry_s, time_t *last_entry_s);
 bool rrddim_metric_retention_by_uuid(STORAGE_INSTANCE *si, nd_uuid_t *uuid, time_t *first_entry_s, time_t *last_entry_s);
+void rrddim_retention_delete_by_id(STORAGE_INSTANCE *si, UUIDMAP_ID id);
 
 STORAGE_METRICS_GROUP *rrddim_metrics_group_get(STORAGE_INSTANCE *si, nd_uuid_t *uuid);
 void rrddim_metrics_group_release(STORAGE_INSTANCE *si, STORAGE_METRICS_GROUP *smg);

--- a/src/database/storage-engine.c
+++ b/src/database/storage-engine.c
@@ -19,6 +19,7 @@ static STORAGE_ENGINE engines[] = {
             .metric_release = rrddim_metric_release,
             .metric_retention_by_id = rrddim_metric_retention_by_id,
             .metric_retention_by_uuid = rrddim_metric_retention_by_uuid,
+            .metric_retention_delete_by_id = rrddim_retention_delete_by_id,
         }
     },
     {
@@ -33,6 +34,7 @@ static STORAGE_ENGINE engines[] = {
             .metric_release = rrddim_metric_release,
             .metric_retention_by_id = rrddim_metric_retention_by_id,
             .metric_retention_by_uuid = rrddim_metric_retention_by_uuid,
+            .metric_retention_delete_by_id = rrddim_retention_delete_by_id,
         }
     },
     {
@@ -47,6 +49,7 @@ static STORAGE_ENGINE engines[] = {
             .metric_release = rrddim_metric_release,
             .metric_retention_by_id = rrddim_metric_retention_by_id,
             .metric_retention_by_uuid = rrddim_metric_retention_by_uuid,
+            .metric_retention_delete_by_id = rrddim_retention_delete_by_id,
         }
     },
 #ifdef ENABLE_DBENGINE
@@ -62,6 +65,7 @@ static STORAGE_ENGINE engines[] = {
             .metric_release = rrdeng_metric_release,
             .metric_retention_by_id = rrdeng_metric_retention_by_id,
             .metric_retention_by_uuid = rrdeng_metric_retention_by_uuid,
+            .metric_retention_delete_by_id = rrdeng_metric_retention_delete_by_id,
         }
     },
 #endif

--- a/src/database/storage-engine.h
+++ b/src/database/storage-engine.h
@@ -66,6 +66,7 @@ typedef struct storage_engine_api {
     STORAGE_METRIC_HANDLE *(*metric_dup)(STORAGE_METRIC_HANDLE *);
     bool (*metric_retention_by_id)(STORAGE_INSTANCE *si, UUIDMAP_ID id, time_t *first_entry_s, time_t *last_entry_s);
     bool (*metric_retention_by_uuid)(STORAGE_INSTANCE *si, nd_uuid_t *uuid, time_t *first_entry_s, time_t *last_entry_s);
+    void (*metric_retention_delete_by_id)(STORAGE_INSTANCE *si, UUIDMAP_ID id);
 } STORAGE_ENGINE_API;
 
 typedef struct storage {


### PR DESCRIPTION
This PR adds the following logic:

1. When database rotation occurs
2. Counts the number of instances (with all their metrics) that have ZERO retention in tier0
3. If the these instances are more or equal to 1000
4. AND their percentage over all the instances of the context are more than 50%
5. It forcefully clears their retention in MRG
6. Which automatically triggers deleting them

The result is that it provides an automated way to protect Netdata against extreme cardinality:

1. If a metric is collected is excluded - it is never deleted
2. If a metric has retention in tier0, it is protected - it is never deleted
3. If a metric loses its tier0 retention AND it is part of context which has more than 50% of the instances without tier0 retention, then it is deleted.
