### PR TITLE
LTO Benchmark

### DIFF
--- a/src/daemon/pulse/pulse-daemon-memory-system.c
+++ b/src/daemon/pulse/pulse-daemon-memory-system.c
@@ -112,9 +112,62 @@ cleanup:
 void pulse_daemon_memory_system_do(bool extended) {
     if(!extended) return;
 
+    size_t glibc_mmaps = 0;
+    bool have_mallinfo = false;
+
+#ifdef HAVE_C_MALLINFO2
+    struct mallinfo2 mi = mallinfo2();
+    glibc_mmaps = mi.hblks;
+    if(mi.hblkhd || mi.fordblks) {
+        static RRDSET *st_mallinfo = NULL;
+        static RRDDIM *rd_used_mmap = NULL;
+        static RRDDIM *rd_used_arena = NULL;
+        static RRDDIM *rd_unused_fragments = NULL;
+        static RRDDIM *rd_unused_releasable = NULL;
+
+        if (unlikely(!st_mallinfo)) {
+            st_mallinfo = rrdset_create_localhost(
+                "netdata",
+                "glibc_mallinfo2",
+                NULL,
+                "Memory Usage",
+                NULL,
+                "Glibc Mallinfo2 Memory Distribution",
+                "bytes",
+                "netdata",
+                "pulse",
+                130130,
+                localhost->rrd_update_every,
+                RRDSET_TYPE_STACKED);
+
+            rd_unused_releasable = rrddim_add(st_mallinfo, "unused releasable", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_unused_fragments = rrddim_add(st_mallinfo, "unused fragments", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_used_arena = rrddim_add(st_mallinfo, "used arena", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+            rd_used_mmap = rrddim_add(st_mallinfo, "used mmap", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
+        }
+
+        // size_t total = mi.uordblks;
+        size_t used_mmap = mi.hblkhd;
+        size_t used_arena = (mi.arena > mi.fordblks) ? mi.arena - mi.fordblks : 0;
+
+        size_t unused_total = mi.fordblks;
+        size_t unused_releasable = mi.keepcost;
+        // size_t unused_fast = mi.fsmblks;
+        size_t unused_fragments = (unused_total > unused_releasable) ? unused_total - unused_releasable : 0;
+
+        rrddim_set_by_pointer(st_mallinfo, rd_unused_releasable, (collected_number)unused_releasable);
+        rrddim_set_by_pointer(st_mallinfo, rd_unused_fragments, (collected_number)unused_fragments);
+        rrddim_set_by_pointer(st_mallinfo, rd_used_arena, (collected_number)used_arena);
+        rrddim_set_by_pointer(st_mallinfo, rd_used_mmap, (collected_number)used_mmap);
+
+        rrdset_done(st_mallinfo);
+        have_mallinfo = true;
+    }
+#endif // HAVE_C_MALLINFO2
+
 #ifdef HAVE_C_MALLOC_INFO
     size_t glibc_arenas, glibc_allocated_arenas, glibc_unused_fast, glibc_unused_rest, glibc_allocated_mmap;
-    if(parse_malloc_info(&glibc_arenas, &glibc_allocated_arenas, &glibc_unused_fast, &glibc_unused_rest, &glibc_allocated_mmap)) {
+    if(!have_mallinfo && parse_malloc_info(&glibc_arenas, &glibc_allocated_arenas, &glibc_unused_fast, &glibc_unused_rest, &glibc_allocated_mmap)) {
         if (glibc_arenas) {
             static RRDSET *st_arenas = NULL;
             static RRDDIM *rd_arenas = NULL;
@@ -180,57 +233,6 @@ void pulse_daemon_memory_system_do(bool extended) {
         }
     }
 #endif
-
-    size_t glibc_mmaps = 0;
-
-#ifdef HAVE_C_MALLINFO2
-    struct mallinfo2 mi = mallinfo2();
-    glibc_mmaps = mi.hblks;
-    if((mi.hblkhd || mi.fordblks)) {
-        static RRDSET *st_mallinfo = NULL;
-        static RRDDIM *rd_used_mmap = NULL;
-        static RRDDIM *rd_used_arena = NULL;
-        static RRDDIM *rd_unused_fragments = NULL;
-        static RRDDIM *rd_unused_releasable = NULL;
-
-        if (unlikely(!st_mallinfo)) {
-            st_mallinfo = rrdset_create_localhost(
-                "netdata",
-                "glibc_mallinfo2",
-                NULL,
-                "Memory Usage",
-                NULL,
-                "Glibc Mallinfo2 Memory Distribution",
-                "bytes",
-                "netdata",
-                "pulse",
-                130130,
-                localhost->rrd_update_every,
-                RRDSET_TYPE_STACKED);
-
-            rd_unused_releasable = rrddim_add(st_mallinfo, "unused releasable", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-            rd_unused_fragments = rrddim_add(st_mallinfo, "unused fragments", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-            rd_used_arena = rrddim_add(st_mallinfo, "used arena", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-            rd_used_mmap = rrddim_add(st_mallinfo, "used mmap", NULL, 1, 1, RRD_ALGORITHM_ABSOLUTE);
-        }
-
-        // size_t total = mi.uordblks;
-        size_t used_mmap = mi.hblkhd;
-        size_t used_arena = (mi.arena > mi.fordblks) ? mi.arena - mi.fordblks : 0;
-
-        size_t unused_total = mi.fordblks;
-        size_t unused_releasable = mi.keepcost;
-        // size_t unused_fast = mi.fsmblks;
-        size_t unused_fragments = (unused_total > unused_releasable) ? unused_total - unused_releasable : 0;
-
-        rrddim_set_by_pointer(st_mallinfo, rd_unused_releasable, (collected_number)unused_releasable);
-        rrddim_set_by_pointer(st_mallinfo, rd_unused_fragments, (collected_number)unused_fragments);
-        rrddim_set_by_pointer(st_mallinfo, rd_used_arena, (collected_number)used_arena);
-        rrddim_set_by_pointer(st_mallinfo, rd_used_mmap, (collected_number)used_mmap);
-
-        rrdset_done(st_mallinfo);
-    }
-#endif // HAVE_C_MALLINFO2
 
     size_t netdata_mmaps = __atomic_load_n(&nd_mmap_count, __ATOMIC_RELAXED);
     size_t total_mmaps = netdata_mmaps + glibc_mmaps;

--- a/src/daemon/pulse/pulse-daemon-memory-system.c
+++ b/src/daemon/pulse/pulse-daemon-memory-system.c
@@ -109,11 +109,12 @@ cleanup:
 }
 #endif // HAVE_C_MALLOC_INFO
 
-void pulse_daemon_memory_system_do(bool extended __maybe_unused) {
+void pulse_daemon_memory_system_do(bool extended) {
+    if(!extended) return;
 
 #ifdef HAVE_C_MALLOC_INFO
     size_t glibc_arenas, glibc_allocated_arenas, glibc_unused_fast, glibc_unused_rest, glibc_allocated_mmap;
-    if(extended && parse_malloc_info(&glibc_arenas, &glibc_allocated_arenas, &glibc_unused_fast, &glibc_unused_rest, &glibc_allocated_mmap)) {
+    if(parse_malloc_info(&glibc_arenas, &glibc_allocated_arenas, &glibc_unused_fast, &glibc_unused_rest, &glibc_allocated_mmap)) {
         if (glibc_arenas) {
             static RRDSET *st_arenas = NULL;
             static RRDDIM *rd_arenas = NULL;
@@ -185,7 +186,7 @@ void pulse_daemon_memory_system_do(bool extended __maybe_unused) {
 #ifdef HAVE_C_MALLINFO2
     struct mallinfo2 mi = mallinfo2();
     glibc_mmaps = mi.hblks;
-    if(extended && (mi.hblkhd || mi.fordblks)) {
+    if((mi.hblkhd || mi.fordblks)) {
         static RRDSET *st_mallinfo = NULL;
         static RRDDIM *rd_used_mmap = NULL;
         static RRDDIM *rd_used_arena = NULL;

--- a/src/daemon/pulse/pulse-daemon-memory.c
+++ b/src/daemon/pulse/pulse-daemon-memory.c
@@ -19,9 +19,8 @@ void rrd_slot_memory_removed(size_t added) {
 
 struct netdata_buffers_statistics netdata_buffers_statistics = { 0 };
 
-void pulse_daemon_memory_system_do(bool extended);
+void pulse_daemon_memory_do(bool extended __maybe_unused) {
 
-void pulse_daemon_memory_do(bool extended) {
     {
         static RRDSET *st_memory = NULL;
         static RRDDIM *rd_db_dbengine = NULL;
@@ -307,6 +306,4 @@ void pulse_daemon_memory_do(bool extended) {
     }
 
     // ----------------------------------------------------------------------------------------------------------------
-
-    pulse_daemon_memory_system_do(extended);
 }

--- a/src/daemon/pulse/pulse-daemon-memory.h
+++ b/src/daemon/pulse/pulse-daemon-memory.h
@@ -24,6 +24,7 @@ extern struct netdata_buffers_statistics {
 
 #if defined(PULSE_INTERNALS)
 void pulse_daemon_memory_do(bool extended);
+void pulse_daemon_memory_system_do(bool extended);
 #endif
 
 void rrd_slot_memory_added(size_t added);

--- a/src/daemon/pulse/pulse.h
+++ b/src/daemon/pulse/pulse.h
@@ -30,6 +30,8 @@ extern bool pulse_extended_enabled;
 
 void *pulse_thread_main(void *ptr);
 void *pulse_thread_sqlite3_main(void *ptr);
+void *pulse_thread_workers_main(void *ptr);
+void *pulse_thread_memory_extended_main(void *ptr);
 
 #define p1_add_fetch(variable, value) __atomic_add_fetch(variable, value, __ATOMIC_RELAXED)
 #define p1_sub_fetch(variable, value) __atomic_sub_fetch(variable, value, __ATOMIC_RELAXED)

--- a/src/daemon/static_threads.c
+++ b/src/daemon/static_threads.c
@@ -66,6 +66,27 @@ const struct netdata_static_thread static_threads_common[] = {
         .start_routine = pulse_thread_sqlite3_main
     },
     {
+        .name = "PULSE-WORKERS",
+        .config_section = CONFIG_SECTION_PULSE,
+        .config_name = "extended",
+        .env_name = NULL,
+        .global_variable = &pulse_extended_enabled,
+        .enabled = 0, // the default value - it uses netdata.conf for users to enable it
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = pulse_thread_workers_main
+    },
+    {
+        .name = "PULSE-MEMORY",
+        .config_section = CONFIG_SECTION_PULSE,
+        .config_name = "extended",
+        .env_name = NULL,
+        .global_variable = &pulse_extended_enabled,
+        .enabled = 0, // the default value - it uses netdata.conf for users to enable it
+        .thread = NULL,
+        .init_routine = NULL,
+        .start_routine = pulse_thread_memory_extended_main},
+    {
         .name = "PLUGINSD",
         .config_section = NULL,
         .config_name = NULL,

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -487,7 +487,7 @@ static PGD *rrdeng_alloc_new_page_data(struct rrdeng_collect_handle *handle, use
     return d;
 }
 
-static void rrdeng_store_metric_append_point(STORAGE_COLLECT_HANDLE *sch,
+static ALWAYS_INLINE void rrdeng_store_metric_append_point(STORAGE_COLLECT_HANDLE *sch,
                                              const usec_t point_in_time_ut,
                                              const NETDATA_DOUBLE n,
                                              const NETDATA_DOUBLE min_value,
@@ -570,7 +570,7 @@ static void store_metric_next_error_log(struct rrdeng_collect_handle *handle __m
 #endif
 }
 
-void rrdeng_store_metric_next(STORAGE_COLLECT_HANDLE *sch,
+ALWAYS_INLINE void rrdeng_store_metric_next(STORAGE_COLLECT_HANDLE *sch,
                               const usec_t point_in_time_ut,
                               const NETDATA_DOUBLE n,
                               const NETDATA_DOUBLE min_value,

--- a/src/database/engine/rrdengineapi.c
+++ b/src/database/engine/rrdengineapi.c
@@ -803,7 +803,7 @@ void rrdeng_load_metric_init(STORAGE_METRIC_HANDLE *smh,
     }
 }
 
-static bool rrdeng_load_page_next(struct storage_engine_query_handle *seqh, bool debug_this __maybe_unused) {
+static inline bool rrdeng_load_page_next(struct storage_engine_query_handle *seqh, bool debug_this __maybe_unused) {
     struct rrdeng_query_handle *handle = (struct rrdeng_query_handle *)seqh->handle;
     struct rrdengine_instance *ctx = mrg_metric_ctx(handle->metric);
 
@@ -874,7 +874,7 @@ static bool rrdeng_load_page_next(struct storage_engine_query_handle *seqh, bool
 // Returns the metric and sets its timestamp into current_time
 // IT IS REQUIRED TO **ALWAYS** SET ALL RETURN VALUES (current_time, end_time, flags)
 // IT IS REQUIRED TO **ALWAYS** KEEP TRACK OF TIME, EVEN OUTSIDE THE DATABASE BOUNDARIES
-STORAGE_POINT rrdeng_load_metric_next(struct storage_engine_query_handle *seqh) {
+ALWAYS_INLINE STORAGE_POINT rrdeng_load_metric_next(struct storage_engine_query_handle *seqh) {
     struct rrdeng_query_handle *handle = (struct rrdeng_query_handle *)seqh->handle;
     STORAGE_POINT sp;
 

--- a/src/database/ram/rrddim_mem.c
+++ b/src/database/ram/rrddim_mem.c
@@ -390,7 +390,7 @@ void rrddim_query_init(STORAGE_METRIC_HANDLE *smh, struct storage_engine_query_h
 // Returns the metric and sets its timestamp into current_time
 // IT IS REQUIRED TO **ALWAYS** SET ALL RETURN VALUES (current_time, end_time, flags)
 // IT IS REQUIRED TO **ALWAYS** KEEP TRACK OF TIME, EVEN OUTSIDE THE DATABASE BOUNDARIES
-STORAGE_POINT rrddim_query_next_metric(struct storage_engine_query_handle *seqh) {
+ALWAYS_INLINE STORAGE_POINT rrddim_query_next_metric(struct storage_engine_query_handle *seqh) {
     struct mem_query_handle* h = (struct mem_query_handle*)seqh->handle;
     struct mem_metric_handle *mh = (struct mem_metric_handle *)h->smh;
     RRDDIM *rd = mh->rd;

--- a/src/database/storage-engine.h
+++ b/src/database/storage-engine.h
@@ -324,7 +324,7 @@ static inline void storage_engine_query_init(
 
 STORAGE_POINT rrdeng_load_metric_next(struct storage_engine_query_handle *seqh);
 STORAGE_POINT rrddim_query_next_metric(struct storage_engine_query_handle *seqh);
-static inline STORAGE_POINT storage_engine_query_next_metric(struct storage_engine_query_handle *seqh) {
+static ALWAYS_INLINE STORAGE_POINT storage_engine_query_next_metric(struct storage_engine_query_handle *seqh) {
     internal_fatal(!is_valid_backend(seqh->seb), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE
@@ -336,7 +336,7 @@ static inline STORAGE_POINT storage_engine_query_next_metric(struct storage_engi
 
 int rrdeng_load_metric_is_finished(struct storage_engine_query_handle *seqh);
 int rrddim_query_is_finished(struct storage_engine_query_handle *seqh);
-static inline int storage_engine_query_is_finished(struct storage_engine_query_handle *seqh) {
+static ALWAYS_INLINE int storage_engine_query_is_finished(struct storage_engine_query_handle *seqh) {
     internal_fatal(!is_valid_backend(seqh->seb), "STORAGE: invalid backend");
 
 #ifdef ENABLE_DBENGINE

--- a/src/libnetdata/common.h
+++ b/src/libnetdata/common.h
@@ -338,9 +338,11 @@ typedef uint32_t uid_t;
 #ifdef __GNUC__
 #define UNUSED_FUNCTION(x) __attribute__((unused)) UNUSED_##x
 #define ALWAYS_INLINE inline __attribute__((always_inline))
+#define ALWAYS_INLINE_ONLY __attribute__((always_inline))
 #else
 #define UNUSED_FUNCTION(x) UNUSED_##x
 #define ALWAYS_INLINE inline
+#define ALWAYS_INLINE_ONLY
 #endif
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/libnetdata/common.h
+++ b/src/libnetdata/common.h
@@ -337,8 +337,10 @@ typedef uint32_t uid_t;
 
 #ifdef __GNUC__
 #define UNUSED_FUNCTION(x) __attribute__((unused)) UNUSED_##x
+#define ALWAYS_INLINE inline __attribute__((always_inline))
 #else
 #define UNUSED_FUNCTION(x) UNUSED_##x
+#define ALWAYS_INLINE inline
 #endif
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/src/libnetdata/dictionary/dictionary-traversal.c
+++ b/src/libnetdata/dictionary/dictionary-traversal.c
@@ -52,7 +52,7 @@ void *dictionary_foreach_start_rw(DICTFE *dfe, DICTIONARY *dict, char rw) {
     return dfe->value;
 }
 
-void *dictionary_foreach_next(DICTFE *dfe) {
+ALWAYS_INLINE void *dictionary_foreach_next(DICTFE *dfe) {
     if(unlikely(!dfe || !dfe->dict)) return NULL;
 
     if(unlikely(is_dictionary_destroyed(dfe->dict))) {

--- a/src/libnetdata/dictionary/dictionary.c
+++ b/src/libnetdata/dictionary/dictionary.c
@@ -120,7 +120,8 @@ size_t dictionary_version(DICTIONARY *dict) {
 
     return __atomic_load_n(&dict->version, __ATOMIC_RELAXED);
 }
-size_t dictionary_entries(DICTIONARY *dict) {
+
+ALWAYS_INLINE size_t dictionary_entries(DICTIONARY *dict) {
     if(unlikely(!dict)) return 0;
 
     // this is required for views to return the right number
@@ -131,6 +132,7 @@ size_t dictionary_entries(DICTIONARY *dict) {
 
     return entries;
 }
+
 size_t dictionary_referenced_items(DICTIONARY *dict) {
     if(unlikely(!dict)) return 0;
 
@@ -742,11 +744,11 @@ void dictionary_acquired_item_release(DICTIONARY *dict, DICT_ITEM_CONST DICTIONA
 // ----------------------------------------------------------------------------
 // get the name/value of an item
 
-const char *dictionary_acquired_item_name(DICT_ITEM_CONST DICTIONARY_ITEM *item) {
+ALWAYS_INLINE const char *dictionary_acquired_item_name(DICT_ITEM_CONST DICTIONARY_ITEM *item) {
     return item_get_name(item);
 }
 
-void *dictionary_acquired_item_value(DICT_ITEM_CONST DICTIONARY_ITEM *item) {
+ALWAYS_INLINE void *dictionary_acquired_item_value(DICT_ITEM_CONST DICTIONARY_ITEM *item) {
     if(likely(item))
         return item->shared->value;
 

--- a/src/libnetdata/gorilla/gorilla.cc
+++ b/src/libnetdata/gorilla/gorilla.cc
@@ -352,7 +352,7 @@ extern "C" {
     {
         const uint32_t *data = gr->buffer->data;
 
-        if (gr->index + 1 > gr->entries) {
+        while (gr->index + 1 > gr->entries) {
             // We don't have any more entries to return. However, the writer
             // might have updated the buffer's entries. We need to check once
             // more in case more elements were added.
@@ -371,8 +371,10 @@ extern "C" {
 
                 // fprintf(stderr, "Consumed reader with %zu entries from buffer %p\n", gr->length, gr->buffer);
                 *gr = gorilla_reader_init(next_buffer);
-                return gorilla_reader_read(gr, number);
+                data = gr->buffer->data;
             }
+            else
+                break;
         }
 
         // read the first number

--- a/src/libnetdata/gorilla/gorilla.cc
+++ b/src/libnetdata/gorilla/gorilla.cc
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "libnetdata/common.h"
 #include "gorilla.h"
 
 #include <cassert>
@@ -112,17 +113,17 @@ void gorilla_writer_add_buffer(gorilla_writer_t *gw, gorilla_buffer_t *gbuf, siz
     if (gw->last_buffer)
         gw->last_buffer->header.next = gbuf;
 
-    __atomic_store_n(&gw->last_buffer, gbuf, __ATOMIC_RELAXED);
+    __atomic_store_n(&gw->last_buffer, gbuf, __ATOMIC_RELEASE);
 }
 
 uint32_t gorilla_writer_entries(const gorilla_writer_t *gw) {
     uint32_t entries = 0;
 
-    const gorilla_buffer_t *curr_gbuf = __atomic_load_n(&gw->head_buffer, __ATOMIC_SEQ_CST);
+    const gorilla_buffer_t *curr_gbuf = __atomic_load_n(&gw->head_buffer, __ATOMIC_ACQUIRE);
     do {
-        const gorilla_buffer_t *next_gbuf = __atomic_load_n(&curr_gbuf->header.next, __ATOMIC_SEQ_CST);
+        const gorilla_buffer_t *next_gbuf = __atomic_load_n(&curr_gbuf->header.next, __ATOMIC_ACQUIRE);
 
-        entries += __atomic_load_n(&curr_gbuf->header.entries, __ATOMIC_SEQ_CST);
+        entries += __atomic_load_n(&curr_gbuf->header.entries, __ATOMIC_ACQUIRE);
 
         curr_gbuf = next_gbuf;
     } while (curr_gbuf);
@@ -141,8 +142,8 @@ bool gorilla_writer_write(gorilla_writer_t *gw, uint32_t number)
             return false;
         bit_buffer_write(data, hdr->nbits, number, bit_size<uint32_t>());
 
-        __atomic_fetch_add(&hdr->nbits, bit_size<uint32_t>(), __ATOMIC_RELAXED);
-        __atomic_fetch_add(&hdr->entries, 1, __ATOMIC_RELAXED);
+        __atomic_fetch_add(&hdr->nbits, bit_size<uint32_t>(), __ATOMIC_RELEASE);
+        __atomic_fetch_add(&hdr->entries, 1, __ATOMIC_RELEASE);
         gw->prev_number = number;
         return true;
     }
@@ -153,15 +154,15 @@ bool gorilla_writer_write(gorilla_writer_t *gw, uint32_t number)
             return false;
 
         bit_buffer_write(data, hdr->nbits, static_cast<uint32_t>(1), 1);
-        __atomic_fetch_add(&hdr->nbits, 1, __ATOMIC_RELAXED);
-        __atomic_fetch_add(&hdr->entries, 1, __ATOMIC_RELAXED);
+        __atomic_fetch_add(&hdr->nbits, 1, __ATOMIC_RELEASE);
+        __atomic_fetch_add(&hdr->entries, 1, __ATOMIC_RELEASE);
         return true;
     }
 
     if (hdr->nbits + 1 >= gw->capacity)
         return false;
     bit_buffer_write(data, hdr->nbits, static_cast<uint32_t>(0), 1);
-    __atomic_fetch_add(&hdr->nbits, 1, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&hdr->nbits, 1, __ATOMIC_RELEASE);
 
     uint32_t xor_value = gw->prev_number ^ number;
     uint32_t xor_lzc = (bit_size<uint32_t>() == 32) ? __builtin_clz(xor_value) : __builtin_clzll(xor_value);
@@ -170,22 +171,22 @@ bool gorilla_writer_write(gorilla_writer_t *gw, uint32_t number)
     if (hdr->nbits + 1 >= gw->capacity)
         return false;
     bit_buffer_write(data, hdr->nbits, is_xor_lzc_same, 1);
-    __atomic_fetch_add(&hdr->nbits, 1, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&hdr->nbits, 1, __ATOMIC_RELEASE);
     
     if (!is_xor_lzc_same) {
         size_t bits_needed = (bit_size<uint32_t>() == 32) ? 5 : 6;
         if ((hdr->nbits + bits_needed) >= gw->capacity)
             return false;
         bit_buffer_write(data, hdr->nbits, xor_lzc, bits_needed);
-        __atomic_fetch_add(&hdr->nbits, bits_needed, __ATOMIC_RELAXED);
+        __atomic_fetch_add(&hdr->nbits, bits_needed, __ATOMIC_RELEASE);
     }
 
     // write the bits of the XOR'd value without the LZC prefix
     if (hdr->nbits + (bit_size<uint32_t>() - xor_lzc) >= gw->capacity)
         return false;
     bit_buffer_write(data, hdr->nbits, xor_value, bit_size<uint32_t>() - xor_lzc);
-    __atomic_fetch_add(&hdr->nbits, bit_size<uint32_t>() - xor_lzc, __ATOMIC_RELAXED);
-    __atomic_fetch_add(&hdr->entries, 1, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&hdr->nbits, bit_size<uint32_t>() - xor_lzc, __ATOMIC_RELEASE);
+    __atomic_fetch_add(&hdr->entries, 1, __ATOMIC_RELEASE);
 
     gw->prev_number = number;
     gw->prev_xor_lzc = xor_lzc;
@@ -198,7 +199,7 @@ gorilla_buffer_t *gorilla_writer_drop_head_buffer(gorilla_writer_t *gw) {
 
     gorilla_buffer_t *curr_head = gw->head_buffer;
     gorilla_buffer_t *next_head = gw->head_buffer->header.next;
-    __atomic_store_n(&gw->head_buffer, next_head, __ATOMIC_RELAXED);
+    __atomic_store_n(&gw->head_buffer, next_head, __ATOMIC_RELEASE);
     return curr_head;
 }
 
@@ -206,9 +207,9 @@ uint32_t gorilla_writer_actual_nbytes(const gorilla_writer_t *gw)
 {
     uint32_t nbytes = 0;
 
-    const gorilla_buffer_t *curr_gbuf = __atomic_load_n(&gw->head_buffer, __ATOMIC_SEQ_CST);
+    const gorilla_buffer_t *curr_gbuf = __atomic_load_n(&gw->head_buffer, __ATOMIC_ACQUIRE);
     do {
-        const gorilla_buffer_t *next_gbuf = __atomic_load_n(&curr_gbuf->header.next, __ATOMIC_SEQ_CST);
+        const gorilla_buffer_t *next_gbuf = __atomic_load_n(&curr_gbuf->header.next, __ATOMIC_ACQUIRE);
 
         nbytes += RRDENG_GORILLA_32BIT_BUFFER_SIZE;
 
@@ -222,14 +223,14 @@ uint32_t gorilla_writer_optimal_nbytes(const gorilla_writer_t *gw)
 {
     uint32_t nbytes = 0;
 
-    const gorilla_buffer_t *curr_gbuf = __atomic_load_n(&gw->head_buffer, __ATOMIC_SEQ_CST);
+    const gorilla_buffer_t *curr_gbuf = __atomic_load_n(&gw->head_buffer, __ATOMIC_ACQUIRE);
     do {
-        const gorilla_buffer_t *next_gbuf = __atomic_load_n(&curr_gbuf->header.next, __ATOMIC_SEQ_CST);
+        const gorilla_buffer_t *next_gbuf = __atomic_load_n(&curr_gbuf->header.next, __ATOMIC_ACQUIRE);
 
         if(next_gbuf)
             nbytes += RRDENG_GORILLA_32BIT_BUFFER_SIZE;
         else
-            nbytes += gorilla_buffer_nbytes(__atomic_load_n(&curr_gbuf->header.nbits, __ATOMIC_SEQ_CST));
+            nbytes += gorilla_buffer_nbytes(__atomic_load_n(&curr_gbuf->header.nbits, __ATOMIC_ACQUIRE));
 
         curr_gbuf = next_gbuf;
     } while (curr_gbuf);
@@ -312,10 +313,10 @@ size_t gorilla_buffer_unpatched_nbytes(const gorilla_buffer_t *gbuf) {
 
 gorilla_reader_t gorilla_writer_get_reader(const gorilla_writer_t *gw)
 {
-    const gorilla_buffer_t *buffer = __atomic_load_n(&gw->head_buffer, __ATOMIC_SEQ_CST);
+    const gorilla_buffer_t *buffer = __atomic_load_n(&gw->head_buffer, __ATOMIC_ACQUIRE);
 
-    uint32_t entries = __atomic_load_n(&buffer->header.entries, __ATOMIC_SEQ_CST);
-    uint32_t capacity = __atomic_load_n(&buffer->header.nbits, __ATOMIC_SEQ_CST);
+    uint32_t entries = __atomic_load_n(&buffer->header.entries, __ATOMIC_ACQUIRE);
+    uint32_t capacity = __atomic_load_n(&buffer->header.nbits, __ATOMIC_ACQUIRE);
 
     return gorilla_reader_t {
         .buffer = buffer,
@@ -331,8 +332,8 @@ gorilla_reader_t gorilla_writer_get_reader(const gorilla_writer_t *gw)
 
 gorilla_reader_t gorilla_reader_init(gorilla_buffer_t *gbuf)
 {
-    uint32_t entries = __atomic_load_n(&gbuf->header.entries, __ATOMIC_SEQ_CST);
-    uint32_t capacity = __atomic_load_n(&gbuf->header.nbits, __ATOMIC_SEQ_CST);
+    uint32_t entries = __atomic_load_n(&gbuf->header.entries, __ATOMIC_ACQUIRE);
+    uint32_t capacity = __atomic_load_n(&gbuf->header.nbits, __ATOMIC_ACQUIRE);
 
     return gorilla_reader_t {
         .buffer = gbuf,
@@ -354,13 +355,13 @@ bool gorilla_reader_read(gorilla_reader_t *gr, uint32_t *number)
         // We don't have any more entries to return. However, the writer
         // might have updated the buffer's entries. We need to check once
         // more in case more elements were added.
-        gr->entries = __atomic_load_n(&gr->buffer->header.entries, __ATOMIC_SEQ_CST);
-        gr->capacity = __atomic_load_n(&gr->buffer->header.nbits, __ATOMIC_SEQ_CST);
+        gr->entries = __atomic_load_n(&gr->buffer->header.entries, __ATOMIC_ACQUIRE);
+        gr->capacity = __atomic_load_n(&gr->buffer->header.nbits, __ATOMIC_ACQUIRE);
 
         // if the reader's current buffer has not been updated, we need to
         // check if it has a pointer to a next buffer.
         if (gr->index + 1 > gr->entries) {
-            gorilla_buffer_t *next_buffer = __atomic_load_n(&gr->buffer->header.next, __ATOMIC_SEQ_CST);
+            gorilla_buffer_t *next_buffer = __atomic_load_n(&gr->buffer->header.next, __ATOMIC_ACQUIRE);
 
             if (!next_buffer) {
                 // fprintf(stderr, "Consumed reader with %zu entries from buffer %p\n (No more buffers to read from)", gr->length, gr->buffer);
@@ -428,9 +429,9 @@ void aral_unmark_allocation(struct aral *ar, void *ptr);
 
 void gorilla_writer_aral_unmark(const gorilla_writer_t *gw, struct aral *ar)
 {
-    const gorilla_buffer_t *curr_gbuf = __atomic_load_n(&gw->head_buffer, __ATOMIC_SEQ_CST);
+    const gorilla_buffer_t *curr_gbuf = __atomic_load_n(&gw->head_buffer, __ATOMIC_ACQUIRE);
     do {
-        const gorilla_buffer_t *next_gbuf = __atomic_load_n(&curr_gbuf->header.next, __ATOMIC_SEQ_CST);
+        const gorilla_buffer_t *next_gbuf = __atomic_load_n(&curr_gbuf->header.next, __ATOMIC_ACQUIRE);
 
         // Call the C function here
         aral_unmark_allocation(ar, const_cast<void*>(static_cast<const void*>(curr_gbuf)));

--- a/src/libnetdata/log/nd_log.c
+++ b/src/libnetdata/log/nd_log.c
@@ -13,7 +13,7 @@ int aclklog_enabled = 0;
 
 // --------------------------------------------------------------------------------------------------------------------
 
-void errno_clear(void) {
+ALWAYS_INLINE void errno_clear(void) {
     errno = 0;
 
 #if defined(OS_WINDOWS)

--- a/src/libnetdata/os/gettid.c
+++ b/src/libnetdata/os/gettid.c
@@ -21,7 +21,7 @@ pid_t os_gettid(void) {
 }
 
 static __thread pid_t gettid_cached_tid = 0;
-pid_t gettid_cached(void) {
+ALWAYS_INLINE pid_t gettid_cached(void) {
     if(unlikely(gettid_cached_tid == 0))
         gettid_cached_tid = os_gettid();
 

--- a/src/libnetdata/storage_number/storage_number.c
+++ b/src/libnetdata/storage_number/storage_number.c
@@ -74,7 +74,7 @@ bool is_system_ieee754_double(void) {
     }
 }
 
-storage_number pack_storage_number(NETDATA_DOUBLE value, SN_FLAGS flags) {
+ALWAYS_INLINE storage_number pack_storage_number(NETDATA_DOUBLE value, SN_FLAGS flags) {
     // bit 32 = sign 0:positive, 1:negative
     // bit 31 = 0:divide, 1:multiply
     // bit 30, 29, 28 = (multiplier or divider) 0-7 (8 total)

--- a/src/libnetdata/storage_number/storage_number.h
+++ b/src/libnetdata/storage_number/storage_number.h
@@ -130,7 +130,7 @@ static inline NETDATA_DOUBLE unpack_storage_number(storage_number value) __attri
 #define MAX_INCREMENTAL_PERCENT_RATE 10
 
 
-static inline NETDATA_DOUBLE unpack_storage_number(storage_number value) {
+static ALWAYS_INLINE NETDATA_DOUBLE unpack_storage_number(storage_number value) {
     extern NETDATA_DOUBLE unpack_storage_number_lut10x[4 * 8];
 
     if(unlikely(value == SN_EMPTY_SLOT))

--- a/src/web/api/queries/query.c
+++ b/src/web/api/queries/query.c
@@ -703,7 +703,7 @@ static void rrdr_set_grouping_function(RRDR *r, RRDR_TIME_GROUPING group_method)
     }
 }
 
-static inline void time_grouping_add(RRDR *r, NETDATA_DOUBLE value, const RRDR_TIME_GROUPING add_flush) {
+static ALWAYS_INLINE void time_grouping_add(RRDR *r, NETDATA_DOUBLE value, const RRDR_TIME_GROUPING add_flush) {
     switch(add_flush) {
         case RRDR_GROUPING_AVERAGE:
             tg_average_add(r, value);
@@ -760,7 +760,7 @@ static inline void time_grouping_add(RRDR *r, NETDATA_DOUBLE value, const RRDR_T
     }
 }
 
-static inline NETDATA_DOUBLE time_grouping_flush(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr, const RRDR_TIME_GROUPING add_flush) {
+static ALWAYS_INLINE NETDATA_DOUBLE time_grouping_flush(RRDR *r, RRDR_VALUE_FLAGS *rrdr_value_options_ptr, const RRDR_TIME_GROUPING add_flush) {
     switch(add_flush) {
         case RRDR_GROUPING_AVERAGE:
             return tg_average_flush(r, rrdr_value_options_ptr);


### PR DESCRIPTION
This PR makes a number of adjustments in order for Netdata to have 2 critical paths fully inlined (LTO) eliminating most function calls:

1. Data Collection
2. Querying

The results are impressive:

When Netdata is compiled with this PR and LTO enabled:

- Data Collection: -20% in CPU consumption
- Querying: almost twice the speed (from 21M samples/s/thread to 39M samples/s/thread)

For critical functions, which are not inlined by default even with `-flto` given, we introduce an `ALWAYS_INLINE` macro which resolves to `__attribute__((always_inline))` on supported compilers (gcc, clang). This gives a strong hint to the compiler/linker that when LTO is enabled this function should be inlined.

---

The following additional changes are made:

- [x] gorilla compression now uses proper atomic memory ordering (acquire/release)
- [x] BUG: mallocinfo2 was called even when extended pulse was not enabled - fixed it
- [x] parts of pulse are now separate threads: workers and extended memory (both enabled in extended statistics)