### PR TITLE
cgroups.plugin: fixes to cgroup path validation

### DIFF
--- a/src/collectors/cgroups.plugin/cgroup-network.c
+++ b/src/collectors/cgroups.plugin/cgroup-network.c
@@ -634,6 +634,7 @@ int is_valid_path_symbol(char c) {
         case '_':   // underscore
         case '.':   // dot
         case ',':   // comma
+        case '@':   // systemd unit template specifier (/sys/fs/cgroup/machines.slice/systemd-nspawn@NAME.service)
             return 1;
 
         default:

--- a/src/collectors/cgroups.plugin/cgroup-network.c
+++ b/src/collectors/cgroups.plugin/cgroup-network.c
@@ -635,6 +635,8 @@ int is_valid_path_symbol(char c) {
 int verify_path(const char *path) {
     struct stat sb;
 
+    fatal_assert(path);
+
     char c;
     const char *s = path;
     while((c = *s++)) {

--- a/src/collectors/cgroups.plugin/cgroup-network.c
+++ b/src/collectors/cgroups.plugin/cgroup-network.c
@@ -611,10 +611,24 @@ void call_the_helper(pid_t pid, const char *cgroup) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "cannot execute cgroup-network helper script: %s", command);
 }
 
+int ishex(char c) {
+    return (c >= '0' && c <= '9') ||
+           (c >= 'a' && c <= 'f') ||
+           (c >= 'A' && c <= 'F');
+}
+
+int is_valid_hex_escape(const char *arg) {
+    fatal_assert(arg);
+
+    return (arg[0] == '\\') &&
+           (arg[1] == 'x') &&
+           ishex(arg[2]) &&
+           ishex(arg[3]);
+}
+
 int is_valid_path_symbol(char c) {
     switch(c) {
         case '/':   // path separators
-        case '\\':  // needed for virsh domains \x2d1\x2dname
         case ' ':   // space
         case '-':   // hyphen
         case '_':   // underscore
@@ -637,18 +651,16 @@ int verify_path(const char *path) {
 
     fatal_assert(path);
 
-    char c;
     const char *s = path;
-    while((c = *s++)) {
-        if(!( isalnum(c) || is_valid_path_symbol(c) )) {
+    while(*s != '\0') {
+        if (isalnum(*s) || is_valid_path_symbol(*s))
+            s += 1;
+        else if (*s == '\\' && is_valid_hex_escape(s))
+            s += 4;
+        else {
             nd_log(NDLS_COLLECTORS, NDLP_ERR, "invalid character in path '%s'", path);
             return -1;
         }
-    }
-
-    if(strstr(path, "\\") && !strstr(path, "\\x")) {
-        nd_log(NDLS_COLLECTORS, NDLP_ERR, "invalid escape sequence in path '%s'", path);
-        return 1;
     }
 
     if(strstr(path, "/../")) {


### PR DESCRIPTION

##### Summary

Two fixes to cgroup name validation in cgroup.plugin:
- **cgroups.plugin: fix escape sequence validation in cgroup paths**
- **cgroups.plugin: accept `@` in cgroup paths**

<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.
-->

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
- cgroup.plugin won't break with systemd-nspawn
- cgroup.plugin performs stricter cgroup name validation
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
