### PR TITLE
proc.plugin: add `ifb4*` to excluded interface name patterns

### DIFF
--- a/src/collectors/proc.plugin/proc_net_dev.c
+++ b/src/collectors/proc.plugin/proc_net_dev.c
@@ -909,7 +909,7 @@ int do_proc_net_dev(int update_every, usec_t dt) {
             config_get(
                 CONFIG_SECTION_PLUGIN_PROC_NETDEV,
                 "disable by default interfaces matching",
-                "lo fireqos* *-ifb fwpr* fwbr* fwln*"),
+                "lo fireqos* *-ifb fwpr* fwbr* fwln* ifb4*"),
             NULL,
             SIMPLE_PATTERN_EXACT,
             true);


### PR DESCRIPTION
##### Summary

The `ifb4*` names are used for IFB interfaces by the [sqm-scripts][1]
project.  Ignore them similarly to the `*-ifb` interfaces.

[1]: https://github.com/tohojo/sqm-scripts

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>

- when using sqm-scripts to configure traffic shaping/policing, internal network
  interfaces created by sqm-scripts will be ignored by default, matching the
  behavior when using FireQOS.

</details>
