### PR TITLE
Fix alert transition

### DIFF
--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -322,7 +322,7 @@ static void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae)
         health_log_id = (size_t)sqlite3_column_int64(res, 0);
         sql_health_alarm_log_insert_detail(host, health_log_id, ae);
         insert_alert_queue(
-            host, health_log_id, (int64_t)ae->unique_id, (int64_t)ae->alarm_id, ae->old_status, ae->new_status);
+            host, health_log_id, (int64_t)ae->unique_id, (int64_t)ae->alarm_id, ae->old_status, ae->new_status, ae->when);
     } else
         error_report("HEALTH [%s]: Failed to execute SQL_INSERT_HEALTH_LOG, rc = %d", rrdhost_hostname(host), rc);
 

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -128,11 +128,11 @@ int calculate_delay(RRDCALC_STATUS old_status, RRDCALC_STATUS new_status)
         case RRDCALC_STATUS_WARNING:
         case RRDCALC_STATUS_CRITICAL:
             switch (new_status) {
-                case RRDCALC_STATUS_REMOVED:
                 case RRDCALC_STATUS_UNINITIALIZED:
                 case RRDCALC_STATUS_UNDEFINED:
                     delay = ALERT_TRANSITION_DELAY_LONG;
                     break;
+                case RRDCALC_STATUS_REMOVED:
                 case RRDCALC_STATUS_CLEAR:
                     delay = ALERT_TRANSITION_DELAY_SHORT;
                     break;

--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -474,6 +474,7 @@ static void sql_inject_removed_status(
     SQLITE_BIND_FAIL(done, sqlite3_bind_blob(res, ++param, last_transition, sizeof(*last_transition), SQLITE_STATIC));
 
     param = 0;
+    time_t now = now_realtime_sec();
     while (sqlite3_step_monitored(res) == SQLITE_ROW) {
         //update the old entry in health_log_detail
         sql_set_updated_by_in_health_log_detail(unique_id, max_unique_id, last_transition);
@@ -483,7 +484,7 @@ static void sql_inject_removed_status(
         int64_t health_log_id = sqlite3_column_int64(res, 0);
         RRDCALC_STATUS old_status = (RRDCALC_STATUS)sqlite3_column_double(res, 1);
         insert_alert_queue(
-            host, health_log_id, (int64_t)max_unique_id, (int64_t)alarm_id, old_status, RRDCALC_STATUS_REMOVED);
+            host, health_log_id, (int64_t)max_unique_id, (int64_t)alarm_id, old_status, RRDCALC_STATUS_REMOVED, now);
     }
 
 done:


### PR DESCRIPTION
##### Summary
- Fix the alert transition delay from warning or critical to removed to be 10 seconds (it was 10 mins)
  - A removed state could be due to a node reconnecting, the short delay may be enough to avoid transmitting two alert state changes to the cloud
- Use the actual alert trigger time (rather than the current time) to adjust the scheduled time to send to cloud
   - As rate as it might be, additional delay may be added if processing takes longer than expected between trigger time and time to be added in the queue. 