### PR TITLE
Link the ebpf plugin against libbpf directly instead of through libnetdata.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2151,11 +2151,6 @@ if(OS_WINDOWS)
         endif()
 endif()
 
-# ebpf
-if(ENABLE_PLUGIN_EBPF)
-        netdata_add_libbpf_to_target(libnetdata)
-endif()
-
 # judy
 target_link_libraries(libnetdata PUBLIC judy)
 
@@ -2652,6 +2647,7 @@ if(ENABLE_PLUGIN_EBPF)
     add_executable(ebpf.plugin ${EBPF_PLUGIN_FILES})
     target_link_libraries(ebpf.plugin libnetdata)
 
+    netdata_add_libbpf_to_target(ebpf.plugin)
     netdata_add_ebpf_co_re_to_target(ebpf.plugin)
 
     install(TARGETS ebpf.plugin

--- a/packaging/cmake/Modules/NetdataLibBPF.cmake
+++ b/packaging/cmake/Modules/NetdataLibBPF.cmake
@@ -93,7 +93,7 @@ endfunction()
 
 # Add libbpf as a link dependency for the given target.
 function(netdata_add_libbpf_to_target _target)
-    target_link_libraries(${_target} PUBLIC libbpf_library)
+    target_link_libraries(${_target} libbpf_library)
     target_include_directories(${_target} BEFORE PUBLIC "${NETDATA_LIBBPF_INCLUDE_DIRECTORIES}")
     target_compile_options(${_target} PUBLIC "${NETDATA_LIBBPF_COMPILE_OPTIONS}")
     add_dependencies(${_target} libbpf)

--- a/src/libnetdata/libnetdata.h
+++ b/src/libnetdata/libnetdata.h
@@ -125,9 +125,6 @@ extern const char *netdata_configured_host_prefix;
 
 #include "log/systemd-journal-helpers.h"
 
-#if defined(HAVE_LIBBPF) && !defined(__cplusplus)
-#include "ebpf/ebpf.h"
-#endif
 #include "eval/eval.h"
 #include "statistical/statistical.h"
 #include "adaptive_resortable_list/adaptive_resortable_list.h"


### PR DESCRIPTION
##### Summary

Nothing else in our code base uses libbpf, so there is exactly zero reason to be linking it through libnetdata. Linking directly will cut down on our dependency tree in our native packages, and also reduce the work that needs to be done by the linker for static builds, as well as narrowing any potential attack surface.

##### Test Plan

Needs review and build testing.