### PR TITLE
Improve ACLK query processing

### DIFF
--- a/src/aclk/aclk_query_queue.c
+++ b/src/aclk/aclk_query_queue.c
@@ -11,11 +11,35 @@ aclk_query_t aclk_query_new(aclk_query_type_t type)
 
 void aclk_query_free(aclk_query_t query)
 {
+    struct ctxs_checkpoint *cmd;
     switch (query->type) {
         case HTTP_API_V2:
             freez(query->data.http_api_v2.payload);
             if (query->data.http_api_v2.query != query->dedup_id)
                 freez(query->data.http_api_v2.query);
+            break;
+        case ALERT_START_STREAMING:
+            freez(query->data.node_id);
+            break;
+        case ALERT_CHECKPOINT:
+            freez(query->data.node_id);
+            freez(query->claim_id);
+            break;
+        case CREATE_NODE_INSTANCE:
+            freez(query->data.node_id);
+            freez(query->machine_guid);
+            break;
+        case CTX_STOP_STREAMING:
+            cmd = query->data.payload;
+            freez(cmd->claim_id);
+            freez(cmd->node_id);
+            freez(cmd);
+            break;
+        case CTX_CHECKPOINT:
+            cmd = query->data.payload;
+            freez(cmd->claim_id);
+            freez(cmd->node_id);
+            freez(cmd);
             break;
 
         default:

--- a/src/aclk/aclk_rx_msgs.c
+++ b/src/aclk/aclk_rx_msgs.c
@@ -256,12 +256,9 @@ int create_node_instance_result(const char *msg, size_t msg_len)
     netdata_log_debug(D_ACLK, "CreateNodeInstanceResult: guid:%s nodeid:%s", res.machine_guid, res.node_id);
 
     aclk_query_t query = aclk_query_new(CREATE_NODE_INSTANCE);
-    query->data.node_id = strdupz(res.node_id);
-    query->machine_guid = strdupz(res.machine_guid);
+    query->data.node_id = res.node_id;          // Will be freed on query free
+    query->machine_guid = res.machine_guid;     // Will be freed on query free
     aclk_add_job(query);
-
-    freez(res.node_id);
-    freez(res.machine_guid);
     return 0;
 }
 
@@ -306,10 +303,9 @@ int start_alarm_streaming(const char *msg, size_t msg_len)
         return 1;
     }
     aclk_query_t query = aclk_query_new(ALERT_START_STREAMING);
-    query->data.node_id = strdupz(res.node_id);
+    query->data.node_id = res.node_id;      // Will be freed on query free
     query->version = res.version;
     aclk_add_job(query);
-    freez(res.node_id);
     return 0;
 }
 
@@ -323,12 +319,10 @@ int send_alarm_checkpoint(const char *msg, size_t msg_len)
         return 1;
     }
     aclk_query_t query = aclk_query_new(ALERT_CHECKPOINT);
-    query->data.node_id = strdupz(sac.node_id);
-    query->claim_id = strdupz(sac.claim_id);
+    query->data.node_id = sac.node_id;  // Will be freed on query free
+    query->claim_id = sac.claim_id;
     query->version = sac.version;
     aclk_add_job(query);
-    freez(sac.node_id);
-    freez(sac.claim_id);
     return 0;
 }
 
@@ -354,8 +348,8 @@ int send_alarm_snapshot(const char *msg, size_t msg_len)
         return 1;
     }
     aclk_query_t query = aclk_query_new(ALERT_CHECKPOINT);
-    query->data.node_id = strdupz(sas->node_id);
-    query->claim_id = strdupz(sas->claim_id);
+    query->data.node_id = sas->node_id;     // Will be freed on query free
+    query->claim_id = sas->claim_id;        // Will be freed on query free
     query->version = 0; // force snapshot
     aclk_add_job(query);
     destroy_send_alarm_snapshot(sas);

--- a/src/aclk/schema-wrappers/alarm_stream.cc
+++ b/src/aclk/schema-wrappers/alarm_stream.cc
@@ -176,8 +176,6 @@ struct send_alarm_snapshot *parse_send_alarm_snapshot(const char *data, size_t l
 
 void destroy_send_alarm_snapshot(struct send_alarm_snapshot *ptr)
 {
-    freez(ptr->claim_id);
-    freez(ptr->node_id);
     freez(ptr->snapshot_uuid);
     freez(ptr);
 }

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -373,8 +373,6 @@ static void aclk_run_query(struct aclk_sync_config_s *config, aclk_query_t query
         return;
     }
 
-    struct ctxs_checkpoint *cmd;
-
     bool ok_to_send = true;
 
     switch (query->type) {
@@ -387,20 +385,12 @@ static void aclk_run_query(struct aclk_sync_config_s *config, aclk_query_t query
             break;
         case CTX_CHECKPOINT:;
             worker_is_busy(UV_EVENT_CTX_CHECKPOINT);
-            cmd = query->data.payload;
-            rrdcontext_hub_checkpoint_command(cmd);
-            freez(cmd->claim_id);
-            freez(cmd->node_id);
-            freez(cmd);
+            rrdcontext_hub_checkpoint_command(query->data.payload);
             ok_to_send = false;
             break;
         case CTX_STOP_STREAMING:
             worker_is_busy(UV_EVENT_CTX_STOP_STREAMING);
-            cmd = query->data.payload;
-            rrdcontext_hub_stop_streaming_command(cmd);
-            freez(cmd->claim_id);
-            freez(cmd->node_id);
-            freez(cmd);
+            rrdcontext_hub_stop_streaming_command(query->data.payload);
             ok_to_send = false;
             break;
         case SEND_NODE_INSTANCES:
@@ -411,21 +401,16 @@ static void aclk_run_query(struct aclk_sync_config_s *config, aclk_query_t query
         case ALERT_START_STREAMING:
             worker_is_busy(UV_EVENT_ALERT_START_STREAMING);
             aclk_start_alert_streaming(query->data.node_id, query->version);
-            freez(query->data.node_id);
             ok_to_send = false;
             break;
         case ALERT_CHECKPOINT:
             worker_is_busy(UV_EVENT_ALERT_CHECKPOINT);
             aclk_alert_version_check(query->data.node_id, query->claim_id, query->version);
-            freez(query->data.node_id);
-            freez(query->claim_id);
             ok_to_send = false;
             break;
         case CREATE_NODE_INSTANCE:
             worker_is_busy(UV_EVENT_CREATE_NODE_INSTANCE);
             create_node_instance_result_job(query->machine_guid, query->data.node_id);
-            freez(query->data.node_id);
-            freez(query->machine_guid);
             ok_to_send = false;
             break;
 


### PR DESCRIPTION
##### Summary
- Code cleanup. 
- Avoid allocating memory for parameters twice
- Fix memory leak during shutdown (resolve coverity issues)
