### PR TITLE
ci: increase static build timeout 180->300m

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,7 +246,7 @@ jobs:
         id: build
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 180
+          timeout_minutes: 300
           max_attempts: 3
           command: |
             export EXTRA_INSTALL_FLAGS=${{ needs.file-check.outputs.skip-go }}


### PR DESCRIPTION
##### Summary

Nightly static aarch64 fails with

> 2025-01-29T05:26:49.5834294Z ##[warning]Attempt 1 failed. Reason: Timeout of 10800000ms hit



##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
