### PR TITLE
Improve data write

### DIFF
--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -1,32 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "rrdengine.h"
 
-static void after_extent_write_journalfile_v1_io(uv_fs_t* req)
-{
-    worker_is_busy(RRDENG_FLUSH_TRANSACTION_BUFFER_CB);
-
-    WAL *wal = req->data;
-    struct generic_io_descriptor *io_descr = &wal->io_descr;
-    struct rrdengine_instance *ctx = io_descr->ctx;
-
-    netdata_log_debug(D_RRDENGINE, "%s: Journal block was written to disk.", __func__);
-    if (req->result < 0) {
-        ctx_io_error(ctx);
-        netdata_log_error("DBENGINE: %s: uv_fs_write: %s", __func__, uv_strerror((int)req->result));
-    } else {
-        netdata_log_debug(D_RRDENGINE, "%s: Journal block was written to disk.", __func__);
-    }
-
-    uv_fs_req_cleanup(req);
-    wal_release(wal);
-
-    __atomic_sub_fetch(&ctx->atomic.extents_currently_being_flushed, 1, __ATOMIC_RELAXED);
-
-    worker_is_idle();
-}
-
 /* Careful to always call this before creating a new journal file */
-void journalfile_v1_extent_write(struct rrdengine_instance *ctx, struct rrdengine_datafile *datafile, WAL *wal, uv_loop_t *loop)
+void journalfile_v1_extent_write(struct rrdengine_instance *ctx, struct rrdengine_datafile *datafile, WAL *wal)
 {
     int ret;
     struct generic_io_descriptor *io_descr;
@@ -48,12 +24,22 @@ void journalfile_v1_extent_write(struct rrdengine_instance *ctx, struct rrdengin
 
     io_descr->req.data = wal;
     io_descr->data = journalfile;
-    io_descr->completion = NULL;
 
     io_descr->iov = uv_buf_init((void *)io_descr->buf, wal->buf_size);
-    ret = uv_fs_write(loop, &io_descr->req, journalfile->file, &io_descr->iov, 1,
-                      (int64_t)io_descr->pos, after_extent_write_journalfile_v1_io);
+    ret = uv_fs_write(NULL, &io_descr->req, journalfile->file, &io_descr->iov, 1, (int64_t)io_descr->pos, NULL);
     fatal_assert(-1 != ret);
+
+    if (io_descr->req.result < 0) {
+        ctx_io_error(ctx);
+        netdata_log_error("DBENGINE: %s: uv_fs_write: %s", __func__, uv_strerror((int)io_descr->req.result));
+    } else {
+        netdata_log_debug(D_RRDENGINE, "%s: Journal block was written to disk.", __func__);
+    }
+
+    uv_fs_req_cleanup(&io_descr->req);
+    wal_release(wal);
+    __atomic_sub_fetch(&ctx->atomic.extents_currently_being_flushed, 1, __ATOMIC_RELAXED);
+    worker_is_idle();
 
     ctx_current_disk_space_increase(ctx, wal->buf_size);
     ctx_io_write_op_bytes(ctx, wal->buf_size);
@@ -534,13 +520,13 @@ int journalfile_destroy_unsafe(struct rrdengine_journalfile *journalfile, struct
     journalfile_v2_generate_path(datafile, path_v2, sizeof(path));
 
     if (journalfile->file) {
-    ret = uv_fs_ftruncate(NULL, &req, journalfile->file, 0, NULL);
-    if (ret < 0) {
-        netdata_log_error("DBENGINE: uv_fs_ftruncate(%s): %s", path, uv_strerror(ret));
-        ctx_fs_error(ctx);
-    }
-    uv_fs_req_cleanup(&req);
-        (void) close_uv_file(datafile, journalfile->file);
+        ret = uv_fs_ftruncate(NULL, &req, journalfile->file, 0, NULL);
+        if (ret < 0) {
+            netdata_log_error("DBENGINE: uv_fs_ftruncate(%s): %s", path, uv_strerror(ret));
+            ctx_fs_error(ctx);
+        }
+        uv_fs_req_cleanup(&req);
+        (void)close_uv_file(datafile, journalfile->file);
     }
 
     // This is the new journal v2 index file

--- a/src/database/engine/journalfile.h
+++ b/src/database/engine/journalfile.h
@@ -141,7 +141,7 @@ struct wal;
 void journalfile_v1_generate_path(struct rrdengine_datafile *datafile, char *str, size_t maxlen);
 void journalfile_v2_generate_path(struct rrdengine_datafile *datafile, char *str, size_t maxlen);
 struct rrdengine_journalfile *journalfile_alloc_and_init(struct rrdengine_datafile *datafile);
-void journalfile_v1_extent_write(struct rrdengine_instance *ctx, struct rrdengine_datafile *datafile, struct wal *wal, uv_loop_t *loop);
+void journalfile_v1_extent_write(struct rrdengine_instance *ctx, struct rrdengine_datafile *datafile, struct wal *wal);
 int journalfile_close(struct rrdengine_journalfile *journalfile, struct rrdengine_datafile *datafile);
 int journalfile_unlink(struct rrdengine_journalfile *journalfile);
 int journalfile_destroy_unsafe(struct rrdengine_journalfile *journalfile, struct rrdengine_datafile *datafile);

--- a/src/database/engine/pagecache.c
+++ b/src/database/engine/pagecache.c
@@ -46,9 +46,6 @@ static void main_cache_flush_dirty_page_callback(PGC *cache __maybe_unused, PGC_
         descr->page_length = pgd_disk_footprint(descr->pgd);
 
         DOUBLE_LINKED_LIST_APPEND_ITEM_UNSAFE(base, descr, link.prev, link.next);
-
-        // TODO: ask @stelfrag/@ktsaou about this.
-        // internal_fatal(descr->page_length > RRDENG_BLOCK_SIZE, "DBENGINE: faulty page length calculation");
     }
 
     struct completion completion;

--- a/src/database/engine/rrdengine.h
+++ b/src/database/engine/rrdengine.h
@@ -248,7 +248,6 @@ enum rrdeng_opcode {
     RRDENG_OPCODE_QUERY,
     RRDENG_OPCODE_EXTENT_WRITE,
     RRDENG_OPCODE_EXTENT_READ,
-    RRDENG_OPCODE_FLUSHED_TO_OPEN,
     RRDENG_OPCODE_DATABASE_ROTATE,
     RRDENG_OPCODE_JOURNAL_INDEX,
     RRDENG_OPCODE_FLUSH_MAIN,
@@ -269,10 +268,10 @@ enum rrdeng_opcode {
 // RRDENG_MAX_OPCODE + opcode            : reserved for the callbacks of each opcode
 // RRDENG_MAX_OPCODE + RRDENG_MAX_OPCODE : reserved for the timer
 #define RRDENG_TIMER_CB (RRDENG_OPCODE_MAX + RRDENG_OPCODE_MAX)
-#define RRDENG_FLUSH_TRANSACTION_BUFFER_CB (RRDENG_TIMER_CB + 1)
-#define RRDENG_OPCODES_WAITING             (RRDENG_TIMER_CB + 2)
-#define RRDENG_WORKS_DISPATCHED            (RRDENG_TIMER_CB + 3)
-#define RRDENG_WORKS_EXECUTING             (RRDENG_TIMER_CB + 4)
+#define RRDENG_OPCODES_WAITING             (RRDENG_TIMER_CB + 1)
+#define RRDENG_WORKS_DISPATCHED            (RRDENG_TIMER_CB + 2)
+#define RRDENG_WORKS_EXECUTING             (RRDENG_TIMER_CB + 3)
+#define RRDENG_RETENTION_TIMER_CB          (RRDENG_TIMER_CB + 4)
 
 struct extent_io_data {
     unsigned fileno;
@@ -291,7 +290,6 @@ struct extent_io_descriptor {
     struct wal *wal;
     uint64_t pos;
     unsigned bytes;
-    struct completion *completion;
     unsigned descr_count;
     struct page_descr_with_data *descr_array[MAX_PAGES_PER_EXTENT];
     struct rrdengine_datafile *datafile;
@@ -306,7 +304,6 @@ struct generic_io_descriptor {
     void *data;
     uint64_t pos;
     unsigned bytes;
-    struct completion *completion;
 };
 
 typedef struct wal {


### PR DESCRIPTION
##### Summary
- Use a single worker thread to write data to both the datafile and journalfile.

Currently, separate worker threads handle these writes, using callbacks for coordination.

This PR updates the process to perform all writes within a single worker thread.