### PR TITLE
Fix MSSQL Instance

### DIFF
--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -175,8 +175,8 @@ static void initialize_mssql_objects(struct mssql_instance *p, const char *insta
     } else if (!strcmp(instance, "SQLEXPRESS")) {
         strncpyz(prefix, "MSSQL$SQLEXPRESS:", sizeof(prefix) - 1);
     } else {
-        char *express = (!is_sqlexpress) ? "" : "SQLEXPRESS";
-        snprintfz(prefix, sizeof(prefix) - 1, "MSSQL$%s:%s:", express, instance);
+        char *express = (!is_sqlexpress) ? "" : "SQLEXPRESS:";
+        snprintfz(prefix, sizeof(prefix) - 1, "MSSQL$%s%s:", express, instance);
     }
 
     size_t length = strlen(prefix);


### PR DESCRIPTION
##### Summary

This PR addresses issues related to the absence of default SQL Server instances.

##### Test Plan
1. Install a SQL Server using a [non default](https://docs.microfocus.com/doc/Operations_Bridge_Manager/24.4/SqlInstances) instance name 
2. Install this branch.


##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
