### PR TITLE
chore(go.d/snmp): enable create_vnode by default

### DIFF
--- a/src/go/plugin/go.d/collector/snmp/collector.go
+++ b/src/go/plugin/go.d/collector/snmp/collector.go
@@ -32,7 +32,8 @@ func init() {
 func New() *Collector {
 	return &Collector{
 		Config: Config{
-			Community: "public",
+			CreateVnode: true,
+			Community:   "public",
 			Options: Options{
 				Port:           161,
 				Retries:        1,

--- a/src/go/plugin/go.d/collector/snmp/config_schema.json
+++ b/src/go/plugin/go.d/collector/snmp/config_schema.json
@@ -24,7 +24,8 @@
       "create_vnode": {
         "title": "Create",
         "description": "If set, the collector will create a [Virtual Node](https://learn.netdata.cloud/docs/netdata-agent/configuration/organize-systems-metrics-and-alerts#virtual-nodes) for this SNMP device, which will appear as a separate Node in Netdata.",
-        "type": "boolean"
+        "type": "boolean",
+        "default": true
       },
       "vnode": {
         "title": "Configuration",

--- a/src/go/plugin/go.d/collector/snmp/metadata.yaml
+++ b/src/go/plugin/go.d/collector/snmp/metadata.yaml
@@ -81,7 +81,7 @@ modules:
               required: true
             - name: create_vnode
               description: If set, the collector will create a Netdata Virtual Node for this SNMP device, which will appear as a separate Node in Netdata.
-              default_value: "false"
+              default_value: "true"
               required: false
             - name: vnode.guid
               description: A unique identifier for the Virtual Node. If not set, a GUID will be automatically generated from the device's IP address.


### PR DESCRIPTION
##### Summary

ssia, following the [v2.2.0 deprecation notice](https://github.com/netdata/netdata/releases/tag/v2.2.0#v220-deprecation-notice). 

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
