### PR TITLE
Actually handle the `-fexceptions` requirement correctly in our build system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,11 +83,6 @@ if(USE_MOLD)
         endif()
 endif()
 
-check_c_compiler_flag("-fexceptions" HAVE_FEXCEPTIONS)
-if (NOT HAVE_FEXCEPTIONS)
-    message(FATAL_ERROR "Missing required compiler flag: -fexceptions.")
-endif()
-
 set(CONFIG_H_DIR ${CMAKE_BINARY_DIR})
 set(CONFIG_H ${CONFIG_H_DIR}/config.h)
 

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -227,11 +227,6 @@ int unittest_prepare_rrd(const char **user) {
 }
 
 int netdata_main(int argc, char **argv) {
-#if !defined(HAVE_FEXCEPTIONS)
-    fprintf(stderr, "Netdata has been compiled without these required compiler flags: -fexceptions.\n");
-    exit(1);
-#endif
-
     string_init();
     analytics_init();
 


### PR DESCRIPTION
##### Summary

The existing attempt in our code to require `-fexceptions` in the compiler flags is fundamentally broken because:

1. It only actually checks if the flag is _supported_, not if it’s enabled, and doesn’t try to enable it if it is supported.
2. It adds pointless code at runtime because the build itself will fail if the flag is not handled.

This PR:

- Fixes the location of the check at build time so that it’s actually handled with all of our other handling of compiler flags, like it should have been in the first place (and like was brought up in a review comment on the PR that added this...).
- Fixes the build time check itself to actually ensure the flag gets added to the compiler/linker flags, and throw a fatal error if that cannot be done.
- Drops the runtime check, which will never actually be hit because it’s only trying to duplicate the build time check, and it is actually _impossible_ to make this check work as intended at runtime in a platform-agnostic manner.

##### Test Plan

CI passes on this PR.