### PR TITLE
Fix contexts stay not-live when children reconnect

### DIFF
--- a/src/database/contexts/instance.c
+++ b/src/database/contexts/instance.c
@@ -420,8 +420,14 @@ static inline RRDINSTANCE *rrdset_get_rrdinstance_with_trace(RRDSET *st, const c
     return ri;
 }
 
-static inline void rrdinstance_rrdset_not_collected(RRDSET *st) {
+ALWAYS_INLINE void rrdinstance_rrdset_not_collected(RRDSET *st) {
     st->rrdcontexts.collected = false;
+
+    RRDDIM *rd;
+    rrddim_foreach_read(rd, st) {
+        rrdmetric_not_collected_rrddim(rd);
+    }
+    rrddim_foreach_done(rd);
 }
 
 inline void rrdinstance_rrdset_is_freed(RRDSET *st) {

--- a/src/database/contexts/instance.c
+++ b/src/database/contexts/instance.c
@@ -456,8 +456,8 @@ inline void rrdinstance_rrdset_is_freed(RRDSET *st) {
     st->rrdcontexts.rrdcontext = NULL;
 }
 
-inline void rrdinstance_rrdset_has_updated_retention(RRDSET *st) {
-    rrdinstance_rrdset_not_collected(st);
+ALWAYS_INLINE void rrdinstance_rrdset_has_updated_retention(RRDSET *st) {
+    // rrdinstance_rrdset_not_collected(st);
 
     RRDINSTANCE *ri = rrdset_get_rrdinstance(st);
     if(unlikely(!ri)) return;

--- a/src/database/contexts/internal.h
+++ b/src/database/contexts/internal.h
@@ -125,7 +125,7 @@ extern struct rrdcontext_reason rrdcontext_reasons[];
 // NEVER alter RRD_FLAG_COLLECTED, RRD_FLAG_ARCHIVED, RRD_FLAG_DELETED with this
 #define rrd_flag_clear(obj, flag) __atomic_and_fetch(&((obj)->flags), ~(flag), __ATOMIC_SEQ_CST)
 
-static inline RRD_FLAGS
+static ALWAYS_INLINE RRD_FLAGS
 rrd_flag_add_remove_atomic(RRD_FLAGS *flags, RRD_FLAGS check, RRD_FLAGS conditionally_add, RRD_FLAGS always_remove) {
     RRD_FLAGS expected, desired;
 
@@ -143,7 +143,7 @@ rrd_flag_add_remove_atomic(RRD_FLAGS *flags, RRD_FLAGS check, RRD_FLAGS conditio
     return expected;
 }
 
-static inline RRD_FLAGS
+static ALWAYS_INLINE RRD_FLAGS
 rrd_flags_replace_atomic(RRD_FLAGS *flags, RRD_FLAGS desired) {
     RRD_FLAGS expected;
     
@@ -297,25 +297,27 @@ typedef struct rrdcontext {
 // ----------------------------------------------------------------------------
 // helpers for counting collected metrics, instances and contexts
 
-static inline void rrdmetric_set_collected(RRDMETRIC *rm) {
+static ALWAYS_INLINE void rrdmetric_set_collected(RRDMETRIC *rm) {
     RRD_FLAGS old = rrd_flag_set_collected(rm);
     if(!(old & RRD_FLAG_COLLECTED))
         __atomic_add_fetch(&rm->ri->rc->rrdhost->collected.metrics_count, 1, __ATOMIC_RELAXED);
+
+    rm->rrddim->rrdcontexts.collected = true;
 }
 
-static inline void rrdmetric_set_archived(RRDMETRIC *rm) {
+static ALWAYS_INLINE void rrdmetric_set_archived(RRDMETRIC *rm) {
     RRD_FLAGS old = rrd_flag_set_archived(rm);
     if(old & RRD_FLAG_COLLECTED)
         __atomic_sub_fetch(&rm->ri->rc->rrdhost->collected.metrics_count, 1, __ATOMIC_RELAXED);
 }
 
-static inline void rrdmetric_set_deleted(RRDMETRIC *rm, RRD_FLAGS reason) {
+static ALWAYS_INLINE void rrdmetric_set_deleted(RRDMETRIC *rm, RRD_FLAGS reason) {
     RRD_FLAGS old = rrd_flag_set_deleted(rm, reason);
     if(old & RRD_FLAG_COLLECTED)
         __atomic_sub_fetch(&rm->ri->rc->rrdhost->collected.metrics_count, 1, __ATOMIC_RELAXED);
 }
 
-static inline void rrdmetric_set_deleted_overwrite(RRDMETRIC *rm, RRD_FLAGS replacement) {
+static ALWAYS_INLINE void rrdmetric_set_deleted_overwrite(RRDMETRIC *rm, RRD_FLAGS replacement) {
     replacement &= ~(RRD_FLAG_COLLECTED|RRD_FLAG_ARCHIVED|RRD_FLAG_DELETED);
     replacement |= RRD_FLAG_DELETED;
     RRD_FLAGS old = rrd_flags_replace_atomic(&rm->flags, replacement);
@@ -323,25 +325,25 @@ static inline void rrdmetric_set_deleted_overwrite(RRDMETRIC *rm, RRD_FLAGS repl
         __atomic_sub_fetch(&rm->ri->rc->rrdhost->collected.metrics_count, 1, __ATOMIC_RELAXED);
 }
 
-static inline void rrdinstance_set_collected(RRDINSTANCE *ri) {
+static ALWAYS_INLINE void rrdinstance_set_collected(RRDINSTANCE *ri) {
     RRD_FLAGS old = rrd_flag_set_collected(ri);
     if(!(old & RRD_FLAG_COLLECTED))
         __atomic_add_fetch(&ri->rc->rrdhost->collected.instances_count, 1, __ATOMIC_RELAXED);
 }
 
-static inline void rrdinstance_set_archived(RRDINSTANCE *ri) {
+static ALWAYS_INLINE void rrdinstance_set_archived(RRDINSTANCE *ri) {
     RRD_FLAGS old = rrd_flag_set_archived(ri);
     if(old & RRD_FLAG_COLLECTED)
         __atomic_sub_fetch(&ri->rc->rrdhost->collected.instances_count, 1, __ATOMIC_RELAXED);
 }
 
-static inline void rrdinstance_set_deleted(RRDINSTANCE *ri, RRD_FLAGS reason) {
+static ALWAYS_INLINE void rrdinstance_set_deleted(RRDINSTANCE *ri, RRD_FLAGS reason) {
     RRD_FLAGS old = rrd_flag_set_deleted(ri, reason);
     if(old & RRD_FLAG_COLLECTED)
         __atomic_sub_fetch(&ri->rc->rrdhost->collected.instances_count, 1, __ATOMIC_RELAXED);
 }
 
-static inline void rrdinstance_set_deleted_overwrite(RRDINSTANCE *ri, RRD_FLAGS replacement) {
+static ALWAYS_INLINE void rrdinstance_set_deleted_overwrite(RRDINSTANCE *ri, RRD_FLAGS replacement) {
     replacement &= ~(RRD_FLAG_COLLECTED|RRD_FLAG_ARCHIVED|RRD_FLAG_DELETED);
     replacement |= RRD_FLAG_DELETED;
     RRD_FLAGS old = rrd_flags_replace_atomic(&ri->flags, replacement);
@@ -349,19 +351,19 @@ static inline void rrdinstance_set_deleted_overwrite(RRDINSTANCE *ri, RRD_FLAGS 
         __atomic_sub_fetch(&ri->rc->rrdhost->collected.instances_count, 1, __ATOMIC_RELAXED);
 }
 
-static inline void rrdcontext_set_collected(RRDCONTEXT *rc) {
+static ALWAYS_INLINE void rrdcontext_set_collected(RRDCONTEXT *rc) {
     RRD_FLAGS old = rrd_flag_set_collected(rc);
     if(!(old & RRD_FLAG_COLLECTED))
         __atomic_add_fetch(&rc->rrdhost->collected.contexts_count, 1, __ATOMIC_RELAXED);
 }
 
-static inline void rrdcontext_set_archived(RRDCONTEXT *rc) {
+static ALWAYS_INLINE void rrdcontext_set_archived(RRDCONTEXT *rc) {
     RRD_FLAGS old = rrd_flag_set_archived(rc);
     if(old & RRD_FLAG_COLLECTED)
         __atomic_sub_fetch(&rc->rrdhost->collected.contexts_count, 1, __ATOMIC_RELAXED);
 }
 
-static inline void rrdcontext_set_deleted(RRDCONTEXT *rc, RRD_FLAGS reason) {
+static ALWAYS_INLINE void rrdcontext_set_deleted(RRDCONTEXT *rc, RRD_FLAGS reason) {
     RRD_FLAGS old = rrd_flag_set_deleted(rc, reason);
     if(old & RRD_FLAG_COLLECTED)
         __atomic_sub_fetch(&rc->rrdhost->collected.contexts_count, 1, __ATOMIC_RELAXED);
@@ -372,16 +374,16 @@ static inline void rrdcontext_set_deleted(RRDCONTEXT *rc, RRD_FLAGS reason) {
 
 bool rrdmetric_update_retention(RRDMETRIC *rm);
 
-static inline RRDMETRIC *rrdmetric_acquired_value(RRDMETRIC_ACQUIRED *rma) {
+static ALWAYS_INLINE RRDMETRIC *rrdmetric_acquired_value(RRDMETRIC_ACQUIRED *rma) {
     return dictionary_acquired_item_value((DICTIONARY_ITEM *)rma);
 }
 
-static inline RRDMETRIC_ACQUIRED *rrdmetric_acquired_dup(RRDMETRIC_ACQUIRED *rma) {
+static ALWAYS_INLINE RRDMETRIC_ACQUIRED *rrdmetric_acquired_dup(RRDMETRIC_ACQUIRED *rma) {
     RRDMETRIC *rm = rrdmetric_acquired_value(rma);
     return (RRDMETRIC_ACQUIRED *)dictionary_acquired_item_dup(rm->ri->rrdmetrics, (DICTIONARY_ITEM *)rma);
 }
 
-static inline void rrdmetric_release(RRDMETRIC_ACQUIRED *rma) {
+static ALWAYS_INLINE void rrdmetric_release(RRDMETRIC_ACQUIRED *rma) {
     RRDMETRIC *rm = rrdmetric_acquired_value(rma);
     dictionary_acquired_item_release(rm->ri->rrdmetrics, (DICTIONARY_ITEM *)rma);
 }
@@ -389,20 +391,21 @@ static inline void rrdmetric_release(RRDMETRIC_ACQUIRED *rma) {
 void rrdmetric_rrddim_is_freed(RRDDIM *rd);
 void rrdmetric_updated_rrddim_flags(RRDDIM *rd);
 void rrdmetric_collected_rrddim(RRDDIM *rd);
+void rrdmetric_not_collected_rrddim(RRDDIM *rd);
 
 // ----------------------------------------------------------------------------
 // helper one-liners for RRDINSTANCE
 
-static inline RRDINSTANCE *rrdinstance_acquired_value(RRDINSTANCE_ACQUIRED *ria) {
+static ALWAYS_INLINE RRDINSTANCE *rrdinstance_acquired_value(RRDINSTANCE_ACQUIRED *ria) {
     return dictionary_acquired_item_value((DICTIONARY_ITEM *)ria);
 }
 
-static inline RRDINSTANCE_ACQUIRED *rrdinstance_acquired_dup(RRDINSTANCE_ACQUIRED *ria) {
+static ALWAYS_INLINE RRDINSTANCE_ACQUIRED *rrdinstance_acquired_dup(RRDINSTANCE_ACQUIRED *ria) {
     RRDINSTANCE *ri = rrdinstance_acquired_value(ria);
     return (RRDINSTANCE_ACQUIRED *)dictionary_acquired_item_dup(ri->rc->rrdinstances, (DICTIONARY_ITEM *)ria);
 }
 
-static inline void rrdinstance_release(RRDINSTANCE_ACQUIRED *ria) {
+static ALWAYS_INLINE void rrdinstance_release(RRDINSTANCE_ACQUIRED *ria) {
     RRDINSTANCE *ri = rrdinstance_acquired_value(ria);
     dictionary_acquired_item_release(ri->rc->rrdinstances, (DICTIONARY_ITEM *)ria);
 }
@@ -414,22 +417,23 @@ void rrdinstance_updated_rrdset_name(RRDSET *st);
 void rrdinstance_updated_rrdset_flags_no_action(RRDINSTANCE *ri, RRDSET *st);
 void rrdinstance_updated_rrdset_flags(RRDSET *st);
 void rrdinstance_collected_rrdset(RRDSET *st);
+void rrdinstance_rrdset_not_collected(RRDSET *st);
 
 void rrdcontext_queue_for_post_processing(RRDCONTEXT *rc, const char *function, RRD_FLAGS flags);
 
 // ----------------------------------------------------------------------------
 // helper one-liners for RRDCONTEXT
 
-static inline RRDCONTEXT *rrdcontext_acquired_value(RRDCONTEXT_ACQUIRED *rca) {
+static ALWAYS_INLINE RRDCONTEXT *rrdcontext_acquired_value(RRDCONTEXT_ACQUIRED *rca) {
     return dictionary_acquired_item_value((DICTIONARY_ITEM *)rca);
 }
 
-static inline RRDCONTEXT_ACQUIRED *rrdcontext_acquired_dup(RRDCONTEXT_ACQUIRED *rca) {
+static ALWAYS_INLINE RRDCONTEXT_ACQUIRED *rrdcontext_acquired_dup(RRDCONTEXT_ACQUIRED *rca) {
     RRDCONTEXT *rc = rrdcontext_acquired_value(rca);
     return (RRDCONTEXT_ACQUIRED *)dictionary_acquired_item_dup(rc->rrdhost->rrdctx.contexts, (DICTIONARY_ITEM *)rca);
 }
 
-static inline void rrdcontext_release(RRDCONTEXT_ACQUIRED *rca) {
+static ALWAYS_INLINE void rrdcontext_release(RRDCONTEXT_ACQUIRED *rca) {
     RRDCONTEXT *rc = rrdcontext_acquired_value(rca);
     dictionary_acquired_item_release(rc->rrdhost->rrdctx.contexts, (DICTIONARY_ITEM *)rca);
 }

--- a/src/database/contexts/rrdcontext.c
+++ b/src/database/contexts/rrdcontext.c
@@ -40,51 +40,51 @@ void rrd_reasons_to_buffer_json_array_items(RRD_FLAGS flags, BUFFER *wb) {
 // ----------------------------------------------------------------------------
 // public API
 
-void rrdcontext_updated_rrddim(RRDDIM *rd) {
+ALWAYS_INLINE void rrdcontext_updated_rrddim(RRDDIM *rd) {
     rrdmetric_from_rrddim(rd);
 }
 
-void rrdcontext_removed_rrddim(RRDDIM *rd) {
+ALWAYS_INLINE void rrdcontext_removed_rrddim(RRDDIM *rd) {
     rrdmetric_rrddim_is_freed(rd);
 }
 
-void rrdcontext_updated_rrddim_algorithm(RRDDIM *rd) {
+ALWAYS_INLINE void rrdcontext_updated_rrddim_algorithm(RRDDIM *rd) {
     rrdmetric_updated_rrddim_flags(rd);
 }
 
-void rrdcontext_updated_rrddim_multiplier(RRDDIM *rd) {
+ALWAYS_INLINE void rrdcontext_updated_rrddim_multiplier(RRDDIM *rd) {
     rrdmetric_updated_rrddim_flags(rd);
 }
 
-void rrdcontext_updated_rrddim_divisor(RRDDIM *rd) {
+ALWAYS_INLINE void rrdcontext_updated_rrddim_divisor(RRDDIM *rd) {
     rrdmetric_updated_rrddim_flags(rd);
 }
 
-void rrdcontext_updated_rrddim_flags(RRDDIM *rd) {
+ALWAYS_INLINE void rrdcontext_updated_rrddim_flags(RRDDIM *rd) {
     rrdmetric_updated_rrddim_flags(rd);
 }
 
-void rrdcontext_collected_rrddim(RRDDIM *rd) {
+ALWAYS_INLINE void rrdcontext_collected_rrddim(RRDDIM *rd) {
     rrdmetric_collected_rrddim(rd);
 }
 
-void rrdcontext_updated_rrdset(RRDSET *st) {
+ALWAYS_INLINE void rrdcontext_updated_rrdset(RRDSET *st) {
     rrdinstance_from_rrdset(st);
 }
 
-void rrdcontext_removed_rrdset(RRDSET *st) {
+ALWAYS_INLINE void rrdcontext_removed_rrdset(RRDSET *st) {
     rrdinstance_rrdset_is_freed(st);
 }
 
-void rrdcontext_updated_retention_rrdset(RRDSET *st) {
+ALWAYS_INLINE void rrdcontext_updated_retention_rrdset(RRDSET *st) {
     rrdinstance_rrdset_has_updated_retention(st);
 }
 
-void rrdcontext_updated_rrdset_name(RRDSET *st) {
+ALWAYS_INLINE void rrdcontext_updated_rrdset_name(RRDSET *st) {
     rrdinstance_updated_rrdset_name(st);
 }
 
-void rrdcontext_updated_rrdset_flags(RRDSET *st) {
+ALWAYS_INLINE void rrdcontext_updated_rrdset_flags(RRDSET *st) {
     rrdinstance_updated_rrdset_flags(st);
 }
 
@@ -92,11 +92,11 @@ ALWAYS_INLINE void rrdcontext_collected_rrdset(RRDSET *st) {
     rrdinstance_collected_rrdset(st);
 }
 
-void rrdcontext_host_child_disconnected(RRDHOST *host) {
+ALWAYS_INLINE void rrdcontext_host_child_disconnected(RRDHOST *host) {
     rrdcontext_recalculate_host_retention(host, RRD_FLAG_UPDATE_REASON_DISCONNECTED_CHILD, false);
 }
 
-void rrdcontext_host_child_connected(RRDHOST *host) {
+ALWAYS_INLINE void rrdcontext_host_child_connected(RRDHOST *host) {
     // clear the rrdcontexts status cache inside RRDSET and RRDDIM
     RRDSET *st;
     rrdset_foreach_read(st, host) {
@@ -106,7 +106,7 @@ void rrdcontext_host_child_connected(RRDHOST *host) {
 }
 
 usec_t rrdcontext_next_db_rotation_ut = 0;
-void rrdcontext_db_rotation(void) {
+ALWAYS_INLINE void rrdcontext_db_rotation(void) {
     // called when the db rotates its database
     rrdcontext_next_db_rotation_ut = now_realtime_usec() + FULL_RETENTION_SCAN_DELAY_AFTER_DB_ROTATION_SECS * USEC_PER_SEC;
 }


### PR DESCRIPTION
The agent is caching a boolean about RRDDIMs being collected or not. It uses this boolean to avoid more expensive processing when simply collecting data (between iterations).

Unfortunately this cached boolean was not reset when children get reconnected and in some cases the contexts were left in an inconsistent state regarding their liveness.

Fixed it. Now these cached flags are reset or child reconnect.