### PR TITLE
fix(go.d/mysql): don't collect global variables on every iteration

### DIFF
--- a/src/go/plugin/go.d/collector/mysql/collect.go
+++ b/src/go/plugin/go.d/collector/mysql/collect.go
@@ -57,6 +57,7 @@ func (c *Collector) collect() (map[string]int64, error) {
 		if err := c.collectGlobalVariables(); err != nil {
 			return nil, fmt.Errorf("error on collecting global variables: %v", err)
 		}
+		c.recheckGlobalVarsTime = now
 	}
 	mx["max_connections"] = c.varMaxConns
 	mx["table_open_cache"] = c.varTableOpenCache


### PR DESCRIPTION
It seems that we don't want to collect global variables on every iteration since PR [1]. However, `recheckGlobalVarsTime` variable was actually never set, therefore we are still collecting them on every iteration.

This change fixes the issue by setting `recheckGlobalVarsTime` to current timestamp when global variables are successfully collected.

[1] https://github.com/netdata/go.d.plugin/pull/767