### PR TITLE
fix(go.d/mysql): fix typo in test name

### DIFF
--- a/src/go/plugin/go.d/collector/mysql/collector_test.go
+++ b/src/go/plugin/go.d/collector/mysql/collector_test.go
@@ -278,7 +278,7 @@ func TestCollector_Collect(t *testing.T) {
 		check       func(t *testing.T, my *Collector)
 	}
 	tests := map[string][]testCaseStep{
-		"MariaDB-Standalone[v5.5.46]: success on all queries": {
+		"MariaDB-Standalone[v5.5.64]: success on all queries": {
 			{
 				prepareMock: func(t *testing.T, m sqlmock.Sqlmock) {
 					mockExpect(t, m, queryShowVersion, dataMariaVer5564Version)


### PR DESCRIPTION
The mariadb patch version is 64 not 46, with respect to the test data.