### PR TITLE
docs(start-stop-restart): fix restart typo

### DIFF
--- a/docs/netdata-agent/start-stop-restart.md
+++ b/docs/netdata-agent/start-stop-restart.md
@@ -10,11 +10,11 @@ The Netdata Agent automatically starts at boot after installation.
 
 ### Using `systemctl`, `service`, or `init.d`
 
-| Action  | Systemd                        | Non-systemd                  |
-|---------|--------------------------------|------------------------------|
-| start   | `sudo systemctl start netdata` | `sudo service netdata start` |
-| stop    | `sudo systemctl stop netdata`  | `sudo service netdata stop`  |
-| restart | `sudo systemctl stop netdata`  | `sudo service netdata stop`  |
+| Action  | Systemd                         | Non-systemd                    |
+|---------|---------------------------------|--------------------------------|
+| start   | `sudo systemctl start netdata`  | `sudo service netdata start`   |
+| stop    | `sudo systemctl stop netdata`   | `sudo service netdata stop`    |
+| restart | `sudo systemctl restart netdata`| `sudo service netdata restart` |
 
 ### Using `netdata`
 


### PR DESCRIPTION
##### Summary
This update corrects a documentation error where the restart action incorrectly used stop commands. It now properly uses `sudo systemctl restart netdata` and `sudo service netdata restart`. Fixes #nnn.

##### Test Plan
Manually verified that the restart commands work correctly:
- **Systemd**: `sudo systemctl restart netdata`
- **Non-systemd**: `sudo service netdata restart`

##### Additional Information
This change fixes a typo in the documentation. Users can now restart Netdata correctly without confusion.

<details> <summary>For users: How does this change affect me?</summary>
The net effect is an accurate documentation update, ensuring that restarting Netdata uses the proper commands.
</details>
