### PR TITLE
MSSQL Multiple Instances (windows.plugin)

### DIFF
--- a/src/collectors/windows.plugin/perflib-mssql.c
+++ b/src/collectors/windows.plugin/perflib-mssql.c
@@ -310,9 +310,9 @@ static int mssql_fill_dictionary()
 
     DWORD i;
     char avalue[REGISTRY_MAX_VALUE] = {'\0'};
-    DWORD length = REGISTRY_MAX_VALUE;
     for (i = 0; i < values; i++) {
         avalue[0] = '\0';
+        DWORD length = REGISTRY_MAX_VALUE;
 
         ret = RegEnumValue(hKey, i, avalue, &length, NULL, NULL, NULL, NULL);
         if (ret != ERROR_SUCCESS)


### PR DESCRIPTION
##### Summary

Move the variable inside the loop to reset its value before calling `RegEnumValue` again. Without this change, MSSQL data cannot be collected properly.

![Fix](https://github.com/user-attachments/assets/e69dc1a8-9aee-467a-90f3-b6d9b54bbfe1)


##### Test Plan

1. Install MSSQL Server naming an instance.
2. Reinstall MSSQL in a different directory with a different instance name.
3. Compile this branch
4. Make an installer.
5. Install netdata.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
