### PR TITLE
Add a new agent status when connecting to the cloud

### DIFF
--- a/src/claim/cloud-status.c
+++ b/src/claim/cloud-status.c
@@ -17,6 +17,9 @@ const char *cloud_status_to_string(CLOUD_STATUS status) {
         case CLOUD_STATUS_ONLINE:
             return "online";
 
+        case CLOUD_STATUS_CONNECTING:
+            return "connecting";
+
         case CLOUD_STATUS_INDIRECT:
             return "indirect";
     }
@@ -26,8 +29,12 @@ CLOUD_STATUS cloud_status(void) {
     if(unlikely(aclk_disable_runtime))
         return CLOUD_STATUS_BANNED;
 
-    if(likely(aclk_online()))
-        return CLOUD_STATUS_ONLINE;
+    if(likely(aclk_online())) {
+        if (rrdhost_flag_check(localhost, RRDHOST_FLAG_ACLK_STREAM_CONTEXTS))
+            return CLOUD_STATUS_ONLINE;
+        else
+            return CLOUD_STATUS_CONNECTING;
+    }
 
     if(localhost->sender &&
         rrdhost_flag_check(localhost, RRDHOST_FLAG_STREAM_SENDER_READY_4_METRICS) &&

--- a/src/claim/cloud-status.h
+++ b/src/claim/cloud-status.h
@@ -10,6 +10,7 @@ typedef enum __attribute__((packed)) {
     CLOUD_STATUS_BANNED,            // the agent has been banned from cloud
     CLOUD_STATUS_OFFLINE,           // the agent tries to connect to cloud, but cannot do it
     CLOUD_STATUS_INDIRECT,          // the agent is connected to cloud via a parent
+    CLOUD_STATUS_CONNECTING,        // the agent is connecting
     CLOUD_STATUS_ONLINE,            // the agent is connected to cloud
 } CLOUD_STATUS;
 


### PR DESCRIPTION
##### Summary
- Add a new "connecting" status on the agent splash screen (Agent to cloud link)
  - The agent awaits a context checkpoint command to report "online" status

![image](https://github.com/user-attachments/assets/7ff8d25b-7205-4b36-a37b-61a981ca6d29)

