### PR TITLE
Fix memory leak

### DIFF
--- a/src/database/sqlite/sqlite_health.c
+++ b/src/database/sqlite/sqlite_health.c
@@ -183,9 +183,6 @@ static void insert_alert_queue(
     if (!host->aclk_config)
         return;
 
-    if (!PREPARE_STATEMENT(db_meta, SQL_INSERT_ALERT_PENDING_QUEUE, &res))
-        return;
-
     time_t submit_delay = trigger_time + calculate_delay(old_status, new_status);
 
     int param = 0;

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -2205,6 +2205,7 @@ static void metadata_scan_host(RRDHOST *host, BUFFER *work_buffer, size_t *query
 
     SQLITE_FINALIZE(ml_load_stmt);
     SQLITE_FINALIZE(store_dimension);
+    SQLITE_FINALIZE(store_chart);
 
     return;
 }

--- a/src/web/api/v2/api_v2_claim.c
+++ b/src/web/api/v2/api_v2_claim.c
@@ -90,6 +90,7 @@ static bool agent_can_be_claimed(void) {
 
         case CLOUD_STATUS_BANNED:
         case CLOUD_STATUS_ONLINE:
+        case CLOUD_STATUS_CONNECTING:
             return false;
     }
 


### PR DESCRIPTION
##### Summary
- Remove duplicate statement prepare in alert processing that results in memory leak (a few Kb)
- Finalize statement after chart metadata store (memory leak)
- Handle `CLOUD_STATUS_CONNECTING` state in `agent_can_be_claimed()` function
