### PR TITLE
Switch from x86 to ARM build host for POWER8+ builds.

### DIFF
--- a/.github/data/distros.yml
+++ b/.github/data/distros.yml
@@ -40,7 +40,7 @@ arch_data:  # Mapping of per-architecture matrix behavior.
   aarch64: *arm64
   ppc64le:
     qemu: true
-    runner: ubuntu-24.04
+    runner: ubuntu-24.04-arm
 static_arches:  # Static build architectures
   - x86_64
   - armv6l

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,6 +70,7 @@ jobs:
             .dockerignore
             CMakeLists.txt
             netdata-installer.sh
+            .github/data/distros.yml
             .github/workflows/docker.yml
             .github/scripts/docker-test.sh
             .github/scripts/gen-matrix-docker.py


### PR DESCRIPTION
##### Summary

This should improve build times at least a little bit.

##### Test Plan

Requires confirmation of 64-bit POWER8+ builds being successful in CI and taking less time than they currently do on the master branch.