### PR TITLE
fix(go.d/nvme): add missing "/dev/" prefix to device path for v2.11

### DIFF
--- a/src/go/plugin/go.d/collector/nvme/collector_test.go
+++ b/src/go/plugin/go.d/collector/nvme/collector_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/agent/module"
@@ -515,9 +516,12 @@ func (m *mockNVMeCLIExec) list() (*nvmeDeviceList, error) {
 	return &v, nil
 }
 
-func (m *mockNVMeCLIExec) smartLog(_ string) (*nvmeDeviceSmartLog, error) {
+func (m *mockNVMeCLIExec) smartLog(device string) (*nvmeDeviceSmartLog, error) {
 	if m.errOnSmartLog {
 		return nil, errors.New("mock.smartLog() error")
+	}
+	if !strings.HasPrefix(device, "/dev/") {
+		return nil, errors.New("mock.smartLog() expects device path /dev/")
 	}
 
 	var v nvmeDeviceSmartLog

--- a/src/go/plugin/go.d/collector/nvme/exec.go
+++ b/src/go/plugin/go.d/collector/nvme/exec.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -58,13 +59,17 @@ func (n *nvmeDeviceList) UnmarshalJSON(b []byte) error {
 		for _, subsystem := range device.Subsystems {
 			for _, controller := range subsystem.Controllers {
 				for _, namespace := range controller.Namespaces {
+					devPath := namespace.NameSpace
+					if !strings.HasPrefix(devPath, "/dev/") {
+						devPath = "/dev/" + devPath
+					}
 					n.Devices = append(n.Devices, struct {
 						DevicePath   string `json:"DevicePath"`
 						Firmware     string `json:"Firmware"`
 						ModelNumber  string `json:"ModelNumber"`
 						SerialNumber string `json:"SerialNumber"`
 					}{
-						DevicePath:   namespace.NameSpace,
+						DevicePath:   devPath,
 						Firmware:     controller.Firmware,
 						ModelNumber:  controller.ModelNumber,
 						SerialNumber: controller.SerialNumber,


### PR DESCRIPTION
##### Summary

Fixes https://github.com/netdata/netdata/issues/19500#issuecomment-2635157839


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
