### PR TITLE
fix incomplete implementation of journal watcher

### DIFF
--- a/src/collectors/systemd-journal.plugin/systemd-journal-watcher.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-watcher.c
@@ -86,8 +86,8 @@ static int add_watch(Watcher *watcher, int inotifyFd, const char *path) {
     else {
         t->path = strdupz(path);
 
-        nd_log(NDLS_COLLECTORS, NDLP_DEBUG,
-               "JOURNAL WATCHER: watching directory: '%s'",
+        nd_log(NDLS_COLLECTORS, NDLP_INFO,
+               "JOURNAL WATCHER DEBUG: watching directory: '%s'",
                path);
 
     }
@@ -99,8 +99,8 @@ static void remove_watch(Watcher *watcher, int inotifyFd, int wd) {
     for (i = 0; i < watcher->watchCount; ++i) {
         if (watcher->watchList[i].wd == wd) {
 
-            nd_log(NDLS_COLLECTORS, NDLP_DEBUG,
-                   "JOURNAL WATCHER: removing watch from directory: '%s'",
+            nd_log(NDLS_COLLECTORS, NDLP_INFO,
+                   "JOURNAL WATCHER DEBUG: removing watch from directory: '%s'",
                    watcher->watchList[i].path);
 
             inotify_rm_watch(inotifyFd, watcher->watchList[i].wd);
@@ -224,8 +224,8 @@ void process_event(Watcher *watcher, int inotifyFd, struct inotify_event *event)
     if(event->mask & IN_ISDIR) {
         if (event->mask & (IN_DELETE | IN_MOVED_FROM)) {
             // A directory is deleted or moved out
-            nd_log(NDLS_COLLECTORS, NDLP_DEBUG,
-                    "JOURNAL WATCHER: Directory deleted or moved out: '%s'",
+            nd_log(NDLS_COLLECTORS, NDLP_INFO,
+                    "JOURNAL WATCHER DEBUG: Directory deleted or moved out: '%s'",
                     fullPath);
 
             // Remove the watch - implement this function based on how you manage your watches
@@ -233,8 +233,8 @@ void process_event(Watcher *watcher, int inotifyFd, struct inotify_event *event)
         }
         else if (event->mask & (IN_CREATE | IN_MOVED_TO)) {
             // A new directory is created or moved in
-            nd_log(NDLS_COLLECTORS, NDLP_DEBUG,
-                    "JOURNAL WATCHER: New directory created or moved in: '%s'",
+            nd_log(NDLS_COLLECTORS, NDLP_INFO,
+                    "JOURNAL WATCHER DEBUG: New directory created or moved in: '%s'",
                     fullPath);
 
             // Start watching the new directory - recursive watch
@@ -251,8 +251,8 @@ void process_event(Watcher *watcher, int inotifyFd, struct inotify_event *event)
         dictionary_set(watcher->pending, fullPath, NULL, 0);
     }
     else
-        nd_log(NDLS_COLLECTORS, NDLP_DEBUG,
-               "JOURNAL WATCHER: ignoring event with mask %u for file '%s'",
+        nd_log(NDLS_COLLECTORS, NDLP_INFO,
+               "JOURNAL WATCHER DEBUG: ignoring event with mask %u for file '%s'",
                event->mask, fullPath);
 }
 
@@ -263,15 +263,15 @@ static void process_pending(Watcher *watcher) {
         const char *fullPath = x_dfe.name;
 
         if(stat(fullPath, &info) != 0) {
-            nd_log(NDLS_COLLECTORS, NDLP_DEBUG,
-                   "JOURNAL WATCHER: file '%s' no longer exists, removing it from the registry",
+            nd_log(NDLS_COLLECTORS, NDLP_INFO,
+                   "JOURNAL WATCHER DEBUG: file '%s' no longer exists, removing it from the registry",
                    fullPath);
 
             dictionary_del(journal_files_registry, fullPath);
         }
         else if(S_ISREG(info.st_mode)) {
-            nd_log(NDLS_COLLECTORS, NDLP_DEBUG,
-                    "JOURNAL WATCHER: file '%s' has been added/updated, updating the registry",
+            nd_log(NDLS_COLLECTORS, NDLP_INFO,
+                    "JOURNAL WATCHER DEBUG: file '%s' has been added/updated, updating the registry",
                     fullPath);
 
             struct journal_file t = {

--- a/src/collectors/systemd-journal.plugin/systemd-journal-watcher.c
+++ b/src/collectors/systemd-journal.plugin/systemd-journal-watcher.c
@@ -35,7 +35,9 @@ ENUM_STR_MAP_DEFINE(INOTIFY_MASK) = {
     {.id = IN_ONLYDIR, .name = "IN_ONLYDIR"},
     {.id = IN_DONT_FOLLOW, .name = "IN_DONT_FOLLOW"},
     {.id = IN_EXCL_UNLINK, .name = "IN_EXCL_UNLINK"},
+#ifdef IN_MASK_CREATE
     {.id = IN_MASK_CREATE, .name = "IN_MASK_CREATE"},
+#endif
     {.id = IN_MASK_ADD, .name = "IN_MASK_ADD"},
     {.id = IN_ISDIR, .name = "IN_ISDIR"},
     {.id = IN_ONESHOT, .name = "IN_ONESHOT"},

--- a/src/libnetdata/dictionary/dictionary-item.h
+++ b/src/libnetdata/dictionary/dictionary-item.h
@@ -216,8 +216,6 @@ static inline size_t dict_item_free_with_hooks(DICTIONARY *dict, DICTIONARY_ITEM
     size_t item_size = 0, key_size = 0, value_size = 0;
 
     key_size += item->key_len;
-    if(unlikely(!(dict->options & DICT_OPTION_NAME_LINK_DONT_CLONE)))
-        item_free_name(dict, item);
 
     if(item_shared_release_and_check_if_it_can_be_freed(dict, item)) {
         dictionary_execute_delete_callback(dict, item);
@@ -233,6 +231,10 @@ static inline size_t dict_item_free_with_hooks(DICTIONARY *dict, DICTIONARY_ITEM
         item->shared = NULL;
         item_size += sizeof(DICTIONARY_ITEM_SHARED);
     }
+
+    // free the name after calling the delete callback
+    if(unlikely(!(dict->options & DICT_OPTION_NAME_LINK_DONT_CLONE)))
+        item_free_name(dict, item);
 
     aral_freez(dict_items_aral, item);
 


### PR DESCRIPTION
- [x] The parsing of inotify events was incomplete. Fixed it.
- [x] The subpath checking parameters were reversed. Fixed it.
- [x] Keeps tracking of directory symlinks (maps of source - destination).
- [x] Fixed bug in dictionary, where the name of the item was freed before calling the deletion callback, which in some cases was using the freed name (use-after-free bug).

Still valid bugs:

If a destination directory has more than one symlinks to it, deleting 1 of the symlinks stops watching the directory and all its files. So, the watcher does not keep a count of references. It just executes events without knowing that there are multiple links to the same destination.