### PR TITLE
Free resources where writing datafile extents

### DIFF
--- a/src/database/engine/journalfile.c
+++ b/src/database/engine/journalfile.c
@@ -49,12 +49,12 @@ void journalfile_v1_extent_write(struct rrdengine_instance *ctx, struct rrdengin
     }
 
     uv_fs_req_cleanup(&io_descr->req);
+    ctx_current_disk_space_increase(ctx, wal->buf_size);
+    ctx_io_write_op_bytes(ctx, wal->buf_size);
+
     wal_release(wal);
     __atomic_sub_fetch(&ctx->atomic.extents_currently_being_flushed, 1, __ATOMIC_RELAXED);
     worker_is_idle();
-
-    ctx_current_disk_space_increase(ctx, wal->buf_size);
-    ctx_io_write_op_bytes(ctx, wal->buf_size);
 }
 
 void journalfile_v2_generate_path(struct rrdengine_datafile *datafile, char *str, size_t maxlen)

--- a/src/database/engine/rrdengine.c
+++ b/src/database/engine/rrdengine.c
@@ -905,6 +905,7 @@ static void *extent_write_tp_worker(
             netdata_log_error(
                 "DBENGINE: %s: uv_fs_write: %s", __func__, uv_strerror((int)xt_io_descr->uv_fs_request.result));
     }
+    uv_fs_req_cleanup(&xt_io_descr->uv_fs_request);
 
     if (likely(!df_write_error)) {
         journalfile_v1_extent_write(ctx, datafile, xt_io_descr->wal);


### PR DESCRIPTION
##### Summary
- Add missing call to `uv_fs_cleanup` to release resources
- Reorder release of the WAL when writing journal data