### PR TITLE
dequeue from hub before deleting contexts

### DIFF
--- a/src/database/contexts/worker.c
+++ b/src/database/contexts/worker.c
@@ -14,6 +14,8 @@ static struct {
     .active_vs_archived_percentage = 50,
 };
 
+static void rrdcontext_dequeue_from_hub_queue(RRDCONTEXT *rc);
+
 static uint64_t rrdcontext_get_next_version(RRDCONTEXT *rc);
 
 static bool check_if_cloud_version_changed_unsafe(RRDCONTEXT *rc, bool sending __maybe_unused);
@@ -851,6 +853,7 @@ void rrdcontext_initial_processing_after_loading(RRDCONTEXT *rc) {
 }
 
 void rrdcontext_delete_after_loading(RRDHOST *host, RRDCONTEXT *rc) {
+    rrdcontext_dequeue_from_hub_queue(rc);
     rrdcontext_dequeue_from_post_processing(rc);
     dictionary_del(host->rrdctx.contexts, string2str(rc->id));
 }


### PR DESCRIPTION
fix heap-use-after-free while loading contexts