### PR TITLE
Close database if we encounter error during startup

### DIFF
--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -775,9 +775,7 @@ int sql_init_meta_database(db_check_action_type_t rebuild, int memory)
         if (error_str)
             analytics_set_data_str(&analytics_data.netdata_fail_reason, error_str);
         freez(error_str);
-        sqlite3_close(db_meta);
-        db_meta = NULL;
-        return 1;
+        goto close_database;
     }
 
     if (rebuild & DB_CHECK_RECLAIM_SPACE) {

--- a/src/database/sqlite/sqlite_metadata.c
+++ b/src/database/sqlite/sqlite_metadata.c
@@ -830,17 +830,22 @@ int sql_init_meta_database(db_check_action_type_t rebuild, int memory)
         target_version = perform_database_migration(db_meta, DB_METADATA_VERSION);
 
     if (configure_sqlite_database(db_meta, target_version, "meta_config"))
-        return 1;
+        goto close_database;
 
     if (init_database_batch(db_meta, &database_config[0], "meta_init"))
-        return 1;
+        goto close_database;
 
     if (init_database_batch(db_meta, &database_cleanup[0], "meta_cleanup"))
-        return 1;
+        goto close_database;
 
     netdata_log_info("SQLite database initialization completed");
 
     return 0;
+
+close_database:
+    sqlite3_close(db_meta);
+    db_meta = NULL;
+    return 1;
 }
 
 // Metadata functions


### PR DESCRIPTION
##### Summary
- Close database when an error is detected and we will exit. 
  This will prevent an attempt to access the database again during shutdown. 
