### PR TITLE
Disable LTO for openSUSE package builds.

### DIFF
--- a/netdata.spec.in
+++ b/netdata.spec.in
@@ -336,7 +336,9 @@ happened, on your systems and applications.
 	-DUSE_CXX_11=On \
 	%endif
 	%endif
-	-DDISABLE_LTO=On \
+	%if 0%{?suse_version}
+	-DUSE_LTO=Off \
+	%endif
 	%if %{_have_cups}
 	-DENABLE_PLUGIN_CUPS=On \
 	%else


### PR DESCRIPTION
##### Summary

The build is failing there at the moment with LTO enabled, so just disable LTO for it.

##### Test Plan

CI passes for openSUSE packaging job.