### PR TITLE
Do not register removed node on agent restart

### DIFF
--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -131,7 +131,7 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
     char guid[UUID_STR_LEN];
     uuid_unparse_lower(*(nd_uuid_t *)argv[IDX_HOST_ID], guid);
 
-    if (is_ephemeral && rrdhost_free_ephemeral_time_s && age > rrdhost_free_ephemeral_time_s) {
+    if (is_ephemeral && ((!is_registered && last_connected == 1) || (rrdhost_free_ephemeral_time_s && age > rrdhost_free_ephemeral_time_s))) {
         netdata_log_info(
             "%s ephemeral hostname \"%s\" with GUID \"%s\", age = %ld seconds (limit %ld seconds)",
             is_registered ? "Loading registered" : "Skipping unregistered",

--- a/src/database/sqlite/sqlite_aclk.c
+++ b/src/database/sqlite/sqlite_aclk.c
@@ -141,7 +141,7 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
             rrdhost_free_ephemeral_time_s);
 
         if (!is_registered)
-            return 0;
+           goto done;
     }
 
     struct rrdhost_system_info *system_info = rrdhost_system_info_create();
@@ -196,6 +196,8 @@ static int create_host_callback(void *data, int argc, char **argv, char **column
     internal_error(true, "Adding archived host \"%s\" with GUID \"%s\" node id = \"%s\"  ephemeral=%d",
                    rrdhost_hostname(host), host->machine_guid, node_str, is_ephemeral);
 #endif
+
+done:
     return 0;
 }
 


### PR DESCRIPTION
##### Summary
- Detect if node has been removed and do not register on agent restart

##### Test
- Setup claimed parent - child
  - Config on parent should be 
```
      [db]  
      cleanup ephemeral hosts after = off
```
- Start both, notice child connecting to parent and cloud
- Stop child
- Run `netdatacli remote-stale-node ALL_NODES` 
  - Notice child being unregistered -- eg. should not be in api/v3/node_instances
  - Restart parent -- notice the child is registered again
- Repeat with this PR
  - Child should not be registered after parent restart
