### PR TITLE
Allow indirect access when agent is claimed, but offline (indirect cloud connectivity)

### DIFF
--- a/src/claim/claim_id.c
+++ b/src/claim/claim_id.c
@@ -106,7 +106,7 @@ CLAIM_ID rrdhost_claim_id_get(RRDHOST *host) {
 
     if(host == localhost) {
         ret.uuid = claim_id_get_uuid();
-        if(UUIDiszero(ret.uuid))
+        if(UUIDiszero(ret.uuid) || (!aclk_online() && !UUIDiszero(host->aclk.claim_id_of_parent)))
             ret.uuid = host->aclk.claim_id_of_parent;
     }
     else {

--- a/src/claim/cloud-status.c
+++ b/src/claim/cloud-status.c
@@ -107,7 +107,7 @@ CLOUD_STATUS buffer_json_cloud_status(BUFFER *wb, time_t now_s) {
 
             case CLOUD_STATUS_OFFLINE: {
                 // the agent is claimed, but cannot get online
-                CLAIM_ID claim_id = claim_id_get();
+                CLAIM_ID claim_id = rrdhost_claim_id_get(localhost);
                 buffer_json_member_add_string(wb, "claim_id", claim_id.str);
                 buffer_json_member_add_string(wb, "url", cloud_status_aclk_base_url());
                 buffer_json_member_add_string(wb, "reason", cloud_status_aclk_offline_reason());

--- a/src/registry/registry.c
+++ b/src/registry/registry.c
@@ -174,7 +174,7 @@ int registry_request_hello_json(RRDHOST *host, struct web_client *w, bool do_not
         if(!UUIDiszero(localhost->node_id))
             buffer_json_member_add_uuid(w->response.data, "node_id", localhost->node_id.uuid);
 
-        CLAIM_ID claim_id = claim_id_get();
+        CLAIM_ID claim_id = rrdhost_claim_id_get(host);
         if (claim_id_is_set(claim_id))
             buffer_json_member_add_string(w->response.data, "claim_id", claim_id.str);
 


### PR DESCRIPTION
use the parent claim id when agent is claimed but not connected to netdata cloud
