### PR TITLE
add Group=netdata to systemd unit file

### DIFF
--- a/system/systemd/netdata.service.in
+++ b/system/systemd/netdata.service.in
@@ -10,6 +10,7 @@ Wants=network-online.target nss-lookup.target
 LogNamespace=netdata
 Type=simple
 User=root
+Group=netdata
 RuntimeDirectory=netdata
 RuntimeDirectoryMode=0775
 PIDFile=/run/netdata/netdata.pid

--- a/system/systemd/netdata.service.in
+++ b/system/systemd/netdata.service.in
@@ -18,7 +18,6 @@ ExecStart=@sbindir_POST@/netdata -P /run/netdata/netdata.pid -D
 ExecStartPre=/bin/mkdir -p @localstatedir_POST@/cache/netdata
 ExecStartPre=/bin/chown -R @netdata_user_POST@ @localstatedir_POST@/cache/netdata
 ExecStartPre=/bin/mkdir -p /run/netdata
-ExecStartPre=/bin/chown -R @netdata_user_POST@ /run/netdata
 PermissionsStartOnly=true
 
 # saving a big db on slow disks may need some time

--- a/system/systemd/netdata.service.in
+++ b/system/systemd/netdata.service.in
@@ -17,7 +17,6 @@ PIDFile=/run/netdata/netdata.pid
 ExecStart=@sbindir_POST@/netdata -P /run/netdata/netdata.pid -D
 ExecStartPre=/bin/mkdir -p @localstatedir_POST@/cache/netdata
 ExecStartPre=/bin/chown -R @netdata_user_POST@ @localstatedir_POST@/cache/netdata
-ExecStartPre=/bin/mkdir -p /run/netdata
 PermissionsStartOnly=true
 
 # saving a big db on slow disks may need some time

--- a/system/systemd/netdata.service.v235.in
+++ b/system/systemd/netdata.service.v235.in
@@ -10,6 +10,7 @@ Wants=network-online.target nss-lookup.target
 LogNamespace=netdata
 Type=simple
 User=root
+Group=netdata
 EnvironmentFile=-/etc/default/netdata
 ExecStart=@sbindir_POST@/netdata -D $EXTRA_OPTS
 


### PR DESCRIPTION
##### Summary

Add `Group=netdata` to the systemd unit file to grant the netdata user access to `/run/netdata/`. This allows netdata's IPC socket to be stored in a dedicated directory instead of `/tmp`.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
