### PR TITLE
Fix native package installation on RHEL.

### DIFF
--- a/packaging/installer/kickstart.sh
+++ b/packaging/installer/kickstart.sh
@@ -1515,7 +1515,22 @@ check_special_native_deps() {
   if [ "${DISTRO_COMPAT_NAME}" = "centos" ] && [ "${SYSVERSION}" -gt 6 ]; then
     progress "EPEL is required on this system, checking if it’s available."
 
-    if LC_ALL=C ${pm_cmd} search --nogpgcheck -v epel-release | grep -q "No matches found"; then
+    if [ "${SYSVERSION}" -ge 9 ]; then
+      progress "EPEL support requires CodeReady Builder repo on this system, attempting to enable it."
+
+      case "${DISTRO}" in
+        rhel) run_as_root subscription-manager repos --enable "codeready-builder-for-rhel-${SYSVERSION}-$(arch)-rpms" ;;
+        *) run_as_root dnf config-manager --set-enabled crb ;;
+      esac
+    fi
+
+    if [ "${DISTRO}" = "rhel" ]; then
+      # shellcheck disable=SC2086
+      if ! run_as_root env ${env} ${pm_cmd} ${install_subcmd} ${pkg_install_opts} "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${SYSVERSION}.noarch.rpm"; then
+        warning "Failed to install EPEL, even though it is required to install native packages on this system."
+        return 1
+      fi
+    elif LC_ALL=C ${pm_cmd} search --nogpgcheck -v epel-release | grep -q "No matches found"; then
       warning "Unable to find a suitable source for libuv, cannot install using native packages on this system."
       return 1
     else


### PR DESCRIPTION
##### Summary

- On all RHEL versions, correctly pull the EPEL release package from the Fedora project, since RHEL does not include it in their repos.
- On RHEL 9 and newer, as well as clones, enable the CodeReady Builder repo, which is apparently required there to make EPEL work at all, before installing EPEL.

##### Test Plan

Requires manual testing on affected systems.