### PR TITLE
chore: remove netdata_configured_lock_dir

### DIFF
--- a/src/daemon/buildinfo.c
+++ b/src/daemon/buildinfo.c
@@ -1532,7 +1532,6 @@ static void populate_directories(void) {
     build_info_set_value(BIB_DIR_PLUGINS, netdata_configured_primary_plugins_dir);
     build_info_set_value(BIB_DIR_WEB, netdata_configured_web_dir);
     build_info_set_value(BIB_DIR_LOG, netdata_configured_log_dir);
-    build_info_set_value(BIB_DIR_LOCK, netdata_configured_lock_dir);
     build_info_set_value(BIB_DIR_HOME, netdata_configured_home_dir);
 }
 

--- a/src/daemon/common.h
+++ b/src/daemon/common.h
@@ -84,7 +84,6 @@ extern const char *netdata_configured_primary_plugins_dir;
 extern const char *netdata_configured_web_dir;
 extern const char *netdata_configured_cache_dir;
 extern const char *netdata_configured_varlib_dir;
-extern const char *netdata_configured_lock_dir;
 extern const char *netdata_configured_cloud_dir;
 extern const char *netdata_configured_home_dir;
 extern const char *netdata_configured_host_prefix;

--- a/src/daemon/config/netdata-conf-directories.c
+++ b/src/daemon/config/netdata-conf-directories.c
@@ -24,7 +24,6 @@ void netdata_conf_section_directories(void) {
     netdata_configured_cache_dir        = inicfg_get(&netdata_config, CONFIG_SECTION_DIRECTORIES, "cache",        netdata_configured_cache_dir);
     netdata_configured_varlib_dir       = inicfg_get(&netdata_config, CONFIG_SECTION_DIRECTORIES, "lib",          netdata_configured_varlib_dir);
 
-    netdata_configured_lock_dir = get_varlib_subdir_from_config(netdata_configured_varlib_dir, "lock");
     netdata_configured_cloud_dir = get_varlib_subdir_from_config(netdata_configured_varlib_dir, "cloud.d");
 
     pluginsd_initialize_plugin_directories();

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -77,15 +77,12 @@ static void clean_directory(const char *dirname)
 static void prepare_required_directories(uid_t uid, gid_t gid) {
     change_dir_ownership(netdata_configured_cache_dir, uid, gid, true);
     change_dir_ownership(netdata_configured_varlib_dir, uid, gid, false);
-    change_dir_ownership(netdata_configured_lock_dir, uid, gid, false);
     change_dir_ownership(netdata_configured_log_dir, uid, gid, false);
     change_dir_ownership(netdata_configured_cloud_dir, uid, gid, false);
 
     char filename[FILENAME_MAX + 1];
     snprintfz(filename, FILENAME_MAX, "%s/registry", netdata_configured_varlib_dir);
     change_dir_ownership(filename, uid, gid, false);
-
-    clean_directory(netdata_configured_lock_dir);
 }
 
 static int become_user(const char *username, int pid_fd) {

--- a/src/daemon/environment.c
+++ b/src/daemon/environment.c
@@ -49,7 +49,6 @@ void set_environment_for_plugins_and_scripts(void) {
     nd_setenv("NETDATA_WEB_DIR", verify_required_directory(netdata_configured_web_dir), 1);
     nd_setenv("NETDATA_CACHE_DIR", verify_or_create_required_directory(netdata_configured_cache_dir), 1);
     nd_setenv("NETDATA_LIB_DIR", verify_or_create_required_directory(netdata_configured_varlib_dir), 1);
-    nd_setenv("NETDATA_LOCK_DIR", verify_or_create_required_directory(netdata_configured_lock_dir), 1);
     nd_setenv("NETDATA_LOG_DIR", verify_or_create_required_directory(netdata_configured_log_dir), 1);
     nd_setenv("NETDATA_HOST_PREFIX", netdata_configured_host_prefix, 1);
 

--- a/src/daemon/h2o-common.c
+++ b/src/daemon/h2o-common.c
@@ -10,7 +10,6 @@ const char *netdata_configured_primary_plugins_dir = PLUGINS_DIR;
 const char *netdata_configured_web_dir             = WEB_DIR;
 const char *netdata_configured_cache_dir           = CACHE_DIR;
 const char *netdata_configured_varlib_dir          = VARLIB_DIR;
-const char *netdata_configured_lock_dir            = VARLIB_DIR "/lock";
 const char *netdata_configured_cloud_dir           = VARLIB_DIR "/cloud.d";
 const char *netdata_configured_home_dir            = VARLIB_DIR;
 const char *netdata_configured_host_prefix         = NULL;


### PR DESCRIPTION
##### Summary

Remove deprecated directory previously used by python.d and go.d plugins. This directory became obsolete after #19668.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
