### PR TITLE
Hyperv Collection (windows.plugin)

### DIFF
--- a/src/collectors/windows.plugin/perflib-hyperv.c
+++ b/src/collectors/windows.plugin/perflib-hyperv.c
@@ -1771,18 +1771,6 @@ hyperv_perf_item hyperv_perf_list[] = {
         .function_collect = do_hyperv_health_summary,
     },
 
-    {
-        .registry_name = "Hyper-V Hypervisor Root Partition",
-        .function_collect = do_hyperv_root_partition,
-        .dict_insert_cb = dict_hyperv_root_partition_insert_cb,
-        .dict_size = sizeof(struct hypervisor_root_partition),
-    },
-
-    {.registry_name = "Hyper-V Virtual Storage Device",
-     .function_collect = do_hyperv_storage_device,
-     .dict_insert_cb = dict_hyperv_storage_device_insert_cb,
-     .dict_size = sizeof(struct hypervisor_storage_device)},
-
     {.registry_name = "Hyper-V Virtual Switch",
      .function_collect = do_hyperv_switch,
      .dict_insert_cb = dict_hyperv_switch_insert_cb,
@@ -1797,6 +1785,16 @@ hyperv_perf_item hyperv_perf_list[] = {
      .function_collect = do_hyperv_processor,
      .dict_insert_cb = dict_hyperv_processor_insert_cb,
      .dict_size = sizeof(struct hypervisor_processor)},
+
+    {.registry_name = "Hyper-V Hypervisor Root Partition",
+     .function_collect = do_hyperv_root_partition,
+     .dict_insert_cb = dict_hyperv_root_partition_insert_cb,
+     .dict_size = sizeof(struct hypervisor_root_partition)},
+
+    {.registry_name = "Hyper-V Virtual Storage Device",
+     .function_collect = do_hyperv_storage_device,
+     .dict_insert_cb = dict_hyperv_storage_device_insert_cb,
+     .dict_size = sizeof(struct hypervisor_storage_device)},
 
     {.registry_name = NULL, .function_collect = NULL}};
 

--- a/src/collectors/windows.plugin/perflib-hyperv.c
+++ b/src/collectors/windows.plugin/perflib-hyperv.c
@@ -1817,7 +1817,7 @@ int do_PerflibHyperV(int update_every, usec_t dt __maybe_unused)
         // Find the registry ID using the registry name
         DWORD id = RegistryFindIDByName(hyperv_perf_list[i].registry_name);
         if (id == PERFLIB_REGISTRY_NAME_NOT_FOUND)
-            continue;
+            return -1;
 
         // Get the performance data using the registry ID
         PERF_DATA_BLOCK *pDataBlock = perflibGetPerformanceData(id);


### PR DESCRIPTION
##### Summary
After discovering that our Windows host likely had corrupted data, I recreated the scenario and observed a minor issue related to Hyper-V, which this PR addresses.

Disks and partitions can appear on hosts where Hyper-V is either not enabled or has been disabled. In these scenarios, I observed the collector encountering a "SIGSEGV" error. To prevent this issue, I am stopping the collection when a specific metric is unavailable.

##### Test Plan

1. Create a Hyper-V environment, or take a look in our hosts.
2. Install this branch.

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
