### PR TITLE
build: change go.mod version to 1.23.4 to fix win ci builds

### DIFF
--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/netdata/netdata/go/plugins
 
-go 1.23.6
+go 1.23.4
 
 replace github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.50.1
 

--- a/src/go/otel-collector/exporter/journaldexporter/go.mod
+++ b/src/go/otel-collector/exporter/journaldexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/netdata/netdata/otel-collector/exporter/journaldexporter
 
-go 1.23.6
+go 1.23.4
 
 require (
 	github.com/stretchr/testify v1.10.0


### PR DESCRIPTION
##### Summary

Fixes this issue

```
5-02-19T21:23:40.8732140Z -- Minimum required Go version determined to be 1.23.6
2025-02-19T21:23:40.9516263Z CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
2025-02-19T21:23:40.9517157Z   Could NOT find Go: Found unsuitable version "1.23.4", but required is at
2025-02-19T21:23:40.9517744Z   least "1.23.6" (found /mingw64/lib/go/bin/go.exe)
```

I have no idea why there is 1.23.4. I see that `Set Up Go` installs 1.23.6

<details><summary>screenshot</summary>

<img width="1160" alt="Screenshot 2025-02-20 at 10 40 42" src="https://github.com/user-attachments/assets/c4d8052b-d186-42ab-960f-6d06fdda78b0" />

<details>

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
