### PR TITLE
fix(go.d/mysql): handle Cpu_time in microseconds in v10.11.11+

### DIFF
--- a/src/go/plugin/go.d/collector/mysql/collect_user_statistics.go
+++ b/src/go/plugin/go.d/collector/mysql/collect_user_statistics.go
@@ -27,13 +27,18 @@ func (c *Collector) collectUserStatistics(mx map[string]int64) error {
 				c.addUserStatisticsCharts(user)
 			}
 		case "Cpu_time":
-			if c.isMariaDB && c.version.GTE(semver.Version{Major: 11, Minor: 4, Patch: 5}) {
+			needsDivision := c.isMariaDB &&
+				((c.version.Major == 10 && c.version.GTE(semver.Version{Major: 10, Minor: 11, Patch: 11})) ||
+					c.version.GTE(semver.Version{Major: 11, Minor: 4, Patch: 5}))
+
+			key := strings.ToLower(prefix + column)
+			if needsDivision {
 				// TODO: theoretically should divide by 1e6 to convert to seconds,
 				// but empirically need 1e7 to match pre-11.4.5 values.
 				// Needs investigation - possible unit reporting inconsistency in MariaDB
-				mx[strings.ToLower(prefix+column)] = int64(parseFloat(value) / 1e7 * 1000)
+				mx[key] = int64(parseFloat(value) / 1e7 * 1000)
 			} else {
-				mx[strings.ToLower(prefix+column)] = int64(parseFloat(value) * 1000)
+				mx[key] = int64(parseFloat(value) * 1000)
 			}
 		case
 			"Total_connections",


### PR DESCRIPTION
##### Summary

Implements #19618 patch for MariaDB v10.11.11+. I guess MariaDB backported that change into the v10 branch.

##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
