### PR TITLE
chore(go.d/mysql): InnodbOSLogIO in MariaDB >= 10.8

### DIFF
--- a/src/go/plugin/go.d/collector/mysql/charts.go
+++ b/src/go/plugin/go.d/collector/mysql/charts.go
@@ -1202,6 +1202,12 @@ func (c *Collector) addInnoDBOSLogCharts() {
 	}
 }
 
+func (c *Collector) addInnoDBOSLogIOChart() {
+	if err := c.Charts().Add(chartInnoDBOSLogIO.Copy()); err != nil {
+		c.Warning(err)
+	}
+}
+
 func (c *Collector) addMyISAMCharts() {
 	if err := c.Charts().Add(*chartsMyISAM.Copy()...); err != nil {
 		c.Warning(err)

--- a/src/go/plugin/go.d/collector/mysql/collect.go
+++ b/src/go/plugin/go.d/collector/mysql/collect.go
@@ -38,6 +38,10 @@ func (c *Collector) collect() (map[string]int64, error) {
 
 	if hasInnodbOSLog(mx) {
 		c.addInnoDBOSLogOnce.Do(c.addInnoDBOSLogCharts)
+	} else if hasInnodbOSLogIO(mx) {
+		// most of Innodb_os_log_* status variables was removed in MariaDB 10.8
+		// but InnoDB_os_log_written was preserved
+		c.addInnoDBOSLogOnce.Do(c.addInnoDBOSLogIOChart)
 	}
 	if hasInnodbDeadlocks(mx) {
 		c.addInnodbDeadlocksOnce.Do(c.addInnodbDeadlocksChart)
@@ -124,6 +128,11 @@ func calcThreadCacheMisses(collected map[string]int64) {
 func hasInnodbOSLog(collected map[string]int64) bool {
 	// removed in MariaDB 10.8 (https://mariadb.com/kb/en/innodb-status-variables/#innodb_os_log_fsyncs)
 	_, ok := collected["innodb_os_log_fsyncs"]
+	return ok
+}
+
+func hasInnodbOSLogIO(collected map[string]int64) bool {
+	_, ok := collected["innodb_os_log_written"]
 	return ok
 }
 


### PR DESCRIPTION
The most of `Innodb_os_log_*` status variables was removed in Mariadb 10.8 except `InnoDB_os_log_written`. It still may be useful to collect it.

see https://mariadb.com/kb/en/innodb-status-variables/#innodb_os_log_written