### PR TITLE
Integrate OpenTelemetry collector build into build system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3031,7 +3031,7 @@ endif()
 if(ENABLE_PLUGIN_OTEL)
   add_subdirectory(${CMAKE_SOURCE_DIR}/src/go/otel-collector)
 
-  install(PROGRAMS ${CMAKE_BINARY_DIR}/otelcol-plugin/otelcol.plugin
+  install(PROGRAMS ${CMAKE_BINARY_DIR}/otel-collector/otelcol.plugin
           COMPONENT plugin-otelcol
           DESTINATION usr/libexec/netdata/plugins.d)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3029,7 +3029,7 @@ endif()
 #
 
 if(ENABLE_PLUGIN_OTEL)
-  add_subdirectory(${CMAKE_SOURCE_DIR}/src/go/otel-collector)
+  include(${CMAKE_SOURCE_DIR}/src/go/otel-collector/CMakeLists.txt)
 
   install(PROGRAMS ${CMAKE_BINARY_DIR}/otel-collector/otelcol.plugin
           COMPONENT plugin-otelcol

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,7 @@ mark_as_advanced(ENABLE_DASHBOARD)
 
 # Data collection plugins
 option(ENABLE_PLUGIN_GO "Enable metric collectors written in Go" ${DEFAULT_FEATURE_STATE})
+option(ENABLE_PLUGIN_OTEL "Enable metrics collection via OpenTelemetry collector" False)
 option(ENABLE_PLUGIN_PYTHON "Enable metric collectors written in Python" ${DEFAULT_FEATURE_STATE})
 
 cmake_dependent_option(ENABLE_PLUGIN_APPS "Enable per-process resource usage monitoring" ${DEFAULT_FEATURE_STATE} "OS_LINUX OR OS_FREEBSD OR OS_MACOS OR OS_WINDOWS" False)
@@ -303,7 +304,7 @@ if(ENABLE_JEMALLOC)
     endif()
 endif()
 
-if(ENABLE_PLUGIN_GO)
+if(ENABLE_PLUGIN_GO OR ENABLE_PLUGIN_OTEL)
     include(NetdataGoTools)
 
     find_min_go_version("${CMAKE_SOURCE_DIR}/src/go")
@@ -3021,6 +3022,18 @@ if(ENABLE_PLUGIN_GO)
     install(PROGRAMS ${CMAKE_BINARY_DIR}/go.d.plugin
             COMPONENT plugin-go
             DESTINATION usr/libexec/netdata/plugins.d)
+endif()
+
+#
+# Handle OTel Collector plugin
+#
+
+if(ENABLE_PLUGIN_OTEL)
+  add_subdirectory(${CMAKE_SOURCE_DIR}/src/go/otel-collector)
+
+  install(PROGRAMS ${CMAKE_BINARY_DIR}/otelcol-plugin/otelcol.plugin
+          COMPONENT plugin-otelcol
+          DESTINATION usr/libexec/netdata/plugins.d)
 endif()
 
 #

--- a/packaging/cmake/Modules/NetdataGoTools.cmake
+++ b/packaging/cmake/Modules/NetdataGoTools.cmake
@@ -49,9 +49,6 @@ endmacro()
 # All files found will be checked for a `go` directive, and the
 # MIN_GO_VERSION variable will be set to the highest version
 # number found among these directives.
-#
-# Only works on UNIX-like systems, because it has to process the go.mod
-# files in ways that CMake can't do on it's own.
 function(find_min_go_version src_tree)
     message(STATUS "Determining minimum required version of Go for this build")
 
@@ -61,14 +58,10 @@ function(find_min_go_version src_tree)
 
     foreach(f IN ITEMS ${go_mod_files})
         message(VERBOSE "Checking Go version specified in ${f}")
-        execute_process(
-            COMMAND grep -E "^go .*$" ${f}
-            COMMAND cut -f 2 -d " "
-            RESULT_VARIABLE version_check_result
-            OUTPUT_VARIABLE go_mod_version
-        )
+        file(STRINGS "${f}" match_line REGEX "^go .*$")
 
-        if(version_check_result EQUAL 0)
+        if(match_line)
+            list(GET match_line 0 go_mod_version)
             string(REGEX MATCH "([0-9]+\\.[0-9]+(\\.[0-9]+)?)" go_mod_version "${go_mod_version}")
 
             if(go_mod_version VERSION_GREATER result)

--- a/src/go/otel-collector/CMakeLists.txt
+++ b/src/go/otel-collector/CMakeLists.txt
@@ -1,78 +1,58 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-cmake_minimum_required(VERSION 3.16.0...3.30)
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../packaging/cmake/Modules")
-
-if(NOT DEFINED NETDATA_VERSION_STRING)
-  set(NETDATA_VERSION_STRING v0.0.0)
-endif()
-
-foreach(v IN ITEMS MAJOR MINOR PATCH TWEAK)
-  if(NOT DEFINED NETDATA_VERSION_${v})
-    set(NETDATA_VERSION_${v} 0)
+function(_handle_otel)
+  if(CMAKE_BUILD_TYPE STREQUAL Debug)
+    set(DEBUG_BUILD True)
+  else()
+    set(DEBUG_BUILD False)
   endif()
-endforeach()
 
-project(netdata-otel-collector
-        VERSION "${NETDATA_VERSION_MAJOR}.${NETDATA_VERSION_MINOR}.${NETDATA_VERSION_PATCH}.${NETDATA_VERSION_TWEAK}"
-        HOMEPAGE_URL "https://www.netdata.cloud"
-        LANGUAGES NONE)
+  message(STATUS "Generating OpenTelemetry Collector Builder configuration")
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/release-config.yaml.in"
+                "${CMAKE_BINARY_DIR}/otel-build-config.yaml"
+                @ONLY)
+  message(STATUS "Generating OpenTelemetry Collector Builder configuration -- Done")
 
-if(CMAKE_BUILD_TYPE STREQUAL Debug)
-  set(DEBUG_BUILD True)
-else()
-  set(DEBUG_BUILD False)
-endif()
-
-include(NetdataGoTools)
-
-find_min_go_version("${CMAKE_CURRENT_SOURCE_DIR}")
-
-find_package(Go "${MIN_GO_VERSION}" REQUIRED)
-
-message(STATUS "Generating OpenTelemetry Collector Builder configuration")
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/release-config.yaml.in"
-               "${CMAKE_BINARY_DIR}/otel-build-config.yaml"
-               @ONLY)
-message(STATUS "Generating OpenTelemetry Collector Builder configuration -- Done")
-
-message(STATUS "Fetching OpenTelemetry Collector Builder")
-set(OLD_GOBIN $ENV{GOBIN})
-set(ENV{GOBIN} ${CMAKE_BINARY_DIR}/bin)
-execute_process(
-  COMMAND ${GO_EXECUTABLE} install go.opentelemetry.io/collector/cmd/builder@latest
-  RESULT_VARIABLE otel_builder_install
-)
-set(ENV{GOBIN} ${OLD_GOBIN})
-
-if(otel_builder_install)
-  message(FATAL_ERROR "Fetching OpenTelemetry Collector Builder --Failed")
-else()
-  message(STATUS "Fetching OpenTelemetry Collector Builder -- Success")
-endif()
-
-set(DIRS "exporter/journaldexporter")
-set(otelcol_deps "")
-
-foreach(dir IN LISTS DIRS)
-  file(GLOB_RECURSE deps CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${dir}/*.go")
-  list(APPEND otelcol_deps "${deps}")
-  list(APPEND otelcol_deps
-    "${CMAKE_CURRENT_SOURCE_DIR}/${dir}/go.mod"
-    "${CMAKE_CURRENT_SOURCE_DIR}/${dir}/go.sum"
+  message(STATUS "Fetching OpenTelemetry Collector Builder")
+  set(OLD_GOBIN $ENV{GOBIN})
+  set(ENV{GOBIN} ${CMAKE_BINARY_DIR}/bin)
+  execute_process(
+    COMMAND ${GO_EXECUTABLE} install go.opentelemetry.io/collector/cmd/builder@latest
+    RESULT_VARIABLE otel_builder_install
   )
-endforeach()
+  set(ENV{GOBIN} ${OLD_GOBIN})
 
-add_custom_command(
-  OUTPUT otel-collector/otelcol.plugin
-  COMMAND ${CMAKE_BINARY_DIR}/bin/builder --config=${CMAKE_BINARY_DIR}/otel-build-config.yaml
-  DEPENDS ${otelcol_deps}
-  COMMENT "Building otelcol.plugin"
-  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-  VERBATIM
-)
-add_custom_target(
-  plugin-otelcol ALL
-  DEPENDS otel-collector/otelcol.plugin
-)
+  if(otel_builder_install)
+    message(FATAL_ERROR "Fetching OpenTelemetry Collector Builder --Failed")
+  else()
+    message(STATUS "Fetching OpenTelemetry Collector Builder -- Success")
+  endif()
+
+  set(DIRS "exporter/journaldexporter")
+  set(otelcol_deps "")
+
+  foreach(dir IN LISTS DIRS)
+    file(GLOB_RECURSE deps CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${dir}/*.go")
+    list(APPEND otelcol_deps "${deps}")
+    list(APPEND otelcol_deps
+      "${CMAKE_CURRENT_SOURCE_DIR}/${dir}/go.mod"
+      "${CMAKE_CURRENT_SOURCE_DIR}/${dir}/go.sum"
+    )
+  endforeach()
+
+  add_custom_command(
+    OUTPUT otel-collector/otelcol.plugin
+    COMMAND ${CMAKE_BINARY_DIR}/bin/builder --config=${CMAKE_BINARY_DIR}/otel-build-config.yaml
+    DEPENDS ${otelcol_deps}
+    COMMENT "Building otelcol.plugin"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    VERBATIM
+  )
+
+  add_custom_target(
+    plugin-otelcol ALL
+    DEPENDS otel-collector/otelcol.plugin
+  )
+endfunction()
+
+handle_otel()

--- a/src/go/otel-collector/CMakeLists.txt
+++ b/src/go/otel-collector/CMakeLists.txt
@@ -33,7 +33,7 @@ find_package(Go "${MIN_GO_VERSION}" REQUIRED)
 
 message(STATUS "Generating OpenTelemetry Collector Builder configuration")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/release-config.yaml.in"
-               "${CMAKE_BINARY_DIR}/otel-config.yaml"
+               "${CMAKE_BINARY_DIR}/otel-build-config.yaml"
                @ONLY)
 message(STATUS "Generating OpenTelemetry Collector Builder configuration -- Done")
 
@@ -66,7 +66,7 @@ endforeach()
 
 add_custom_command(
   OUTPUT otelcol-plugin/otelcol.plugin
-  COMMAND ${CMAKE_BINARY_DIR}/bin/builder --config=${CMAKE_BINARY_DIR}/otel-config.yaml
+  COMMAND ${CMAKE_BINARY_DIR}/bin/builder --config=${CMAKE_BINARY_DIR}/otel-build-config.yaml
   DEPENDS ${otelcol_deps}
   COMMENT "Building otelcol.plugin"
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/src/go/otel-collector/CMakeLists.txt
+++ b/src/go/otel-collector/CMakeLists.txt
@@ -65,7 +65,7 @@ foreach(dir IN LISTS DIRS)
 endforeach()
 
 add_custom_command(
-  OUTPUT otelcol-plugin/otelcol.plugin
+  OUTPUT otel-collector/otelcol.plugin
   COMMAND ${CMAKE_BINARY_DIR}/bin/builder --config=${CMAKE_BINARY_DIR}/otel-build-config.yaml
   DEPENDS ${otelcol_deps}
   COMMENT "Building otelcol.plugin"
@@ -74,5 +74,5 @@ add_custom_command(
 )
 add_custom_target(
   plugin-otelcol ALL
-  DEPENDS otelcol-plugin/otelcol.plugin
+  DEPENDS otel-collector/otelcol.plugin
 )

--- a/src/go/otel-collector/CMakeLists.txt
+++ b/src/go/otel-collector/CMakeLists.txt
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+cmake_minimum_required(VERSION 3.16.0...3.30)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../packaging/cmake/Modules")
+
+if(NOT DEFINED NETDATA_VERSION_STRING)
+  set(NETDATA_VERSION_STRING v0.0.0)
+endif()
+
+foreach(v IN ITEMS MAJOR MINOR PATCH TWEAK)
+  if(NOT DEFINED NETDATA_VERSION_${v})
+    set(NETDATA_VERSION_${v} 0)
+  endif()
+endforeach()
+
+project(netdata-otel-collector
+        VERSION "${NETDATA_VERSION_MAJOR}.${NETDATA_VERSION_MINOR}.${NETDATA_VERSION_PATCH}.${NETDATA_VERSION_TWEAK}"
+        HOMEPAGE_URL "https://www.netdata.cloud"
+        LANGUAGES NONE)
+
+if(CMAKE_BUILD_TYPE STREQUAL Debug)
+  set(DEBUG_BUILD True)
+else()
+  set(DEBUG_BUILD False)
+endif()
+
+include(NetdataGoTools)
+
+find_min_go_version("${CMAKE_CURRENT_SOURCE_DIR}")
+
+find_package(Go "${MIN_GO_VERSION}" REQUIRED)
+
+message(STATUS "Generating OpenTelemetry Collector Builder configuration")
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/release-config.yaml.in"
+               "${CMAKE_BINARY_DIR}/otel-config.yaml"
+               @ONLY)
+message(STATUS "Generating OpenTelemetry Collector Builder configuration -- Done")
+
+message(STATUS "Fetching OpenTelemetry Collector Builder")
+set(OLD_GOBIN $ENV{GOBIN})
+set(ENV{GOBIN} ${CMAKE_BINARY_DIR}/bin)
+execute_process(
+  COMMAND ${GO_EXECUTABLE} install go.opentelemetry.io/collector/cmd/builder@latest
+  RESULT_VARIABLE otel_builder_install
+)
+set(ENV{GOBIN} ${OLD_GOBIN})
+
+if(otel_builder_install)
+  message(FATAL_ERROR "Fetching OpenTelemetry Collector Builder --Failed")
+else()
+  message(STATUS "Fetching OpenTelemetry Collector Builder -- Success")
+endif()
+
+set(DIRS "exporter/journaldexporter")
+set(otelcol_deps "")
+
+foreach(dir IN LISTS DIRS)
+  file(GLOB_RECURSE deps CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${dir}/*.go")
+  list(APPEND otelcol_deps "${deps}")
+  list(APPEND otelcol_deps
+    "${CMAKE_CURRENT_SOURCE_DIR}/${dir}/go.mod"
+    "${CMAKE_CURRENT_SOURCE_DIR}/${dir}/go.sum"
+  )
+endforeach()
+
+add_custom_command(
+  OUTPUT otelcol-plugin/otelcol.plugin
+  COMMAND ${CMAKE_BINARY_DIR}/bin/builder --config=${CMAKE_BINARY_DIR}/otel-config.yaml
+  DEPENDS ${otelcol_deps}
+  COMMENT "Building otelcol.plugin"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  VERBATIM
+)
+add_custom_target(
+  plugin-otelcol ALL
+  DEPENDS otelcol-plugin/otelcol.plugin
+)

--- a/src/go/otel-collector/release-config.yaml.in
+++ b/src/go/otel-collector/release-config.yaml.in
@@ -2,9 +2,9 @@ dist:
   name: otelcol.plugin
   module: github.com/netdata/netdata/otel-collector
   description: OpenTelemetry Collector Distribution built for Netdata
-  output_path: "@CMAKE_BINARY_DIR@/otel-collector"
-  version: "@NETDATA_VERSION_STRING@"
-  go: "@GO_EXECUTABLE@"
+  output_path: @CMAKE_BINARY_DIR@/otel-collector
+  version: @NETDATA_VERSION_STRING@
+  go: @GO_EXECUTABLE@
   debug_compilation: @DEBUG_BUILD@
 
 receivers:

--- a/src/go/otel-collector/release-config.yaml.in
+++ b/src/go/otel-collector/release-config.yaml.in
@@ -1,0 +1,21 @@
+dist:
+  name: otelcol.plugin
+  module: github.com/netdata/netdata/otel-collector
+  description: OpenTelemetry Collector Distribution built for Netdata
+  output_path: "@CMAKE_BINARY_DIR@/otel-collector"
+  version: "@NETDATA_VERSION_STRING@"
+  go: "@GO_EXECUTABLE@"
+  debug_compilation: @DEBUG_BUILD@
+
+receivers:
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.120.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.120.0
+
+exporters:
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.120.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.120.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.120.0
+  - gomod: github.com/netdata/netdata/otel-collector/exporter/journaldexporter v0.0.0
+
+replaces:
+  - github.com/netdata/netdata/otel-collector/exporter/journaldexporter => @CMAKE_CURRENT_SOURCE_DIR@/exporter/journaldexporter


### PR DESCRIPTION
##### Summary

This adds initial integration of the new OpenTelemetry collector into our build system. Currently, this is disabled by default and must be explicitly enabled at build time with `-DENABLE_PLUGIN_OTEL=On`. It also does not include any packaging integration, and can only be used with local builds currently.

Additionally:
- The build configuration used by the OpenTelemetry Collector Builder is generated at runtime from a template file to ensure that:
    - The version is matched to the the Netdata agent version being used for the build.
    - The collector is built in debug mode if the CMake build type is set to `Debug`.
    - The same version of the Go toolchain that has been selected by the build infrastructure is also used for building the collector (this mostly matters because it improves package cache efficiency, but it also helps ensure consistency for the final build between the Go plugin and the OTel Collector plugin).
    - The source and output directories are appropriately mapped to the correct locations relative to the CMake build and source directories.
- This intentionally uses a copy of the OpenTelemetry Collector Builder fetched and installed into the build directory itself as we cannot rely on any arbitrary system command called ‘builder’ to be what we need, and the official builds don’t support all platforms we need to build for (and thus we are stuck using `go install` to pull it anyway). This also minimizes the impact on the user environment from building (building software should not arbitrarily install new commands system-wide or user-wide).
- This restructures the handling of detection of the required Go version for builds to avoid needing to invoke external commands (which will both make it more portable and should make it marginally faster).

##### Test Plan

Requires specific review from @ilyam8

##### Additional Information

Going forwards, packaging will be handled as a separate PR once this gets closer to being ready for release.

When adding new overrides for local components to the build configuration, the override targets _must_ be specified using `@CMAKE_CURRENT_SOURCE_DIR@` like the existing journaldexporter replacement directive does. This template variable will always contain the absolute path to the `src/go/otel-collector` directory at the time this file is templated.