### PR TITLE
Add Docker tags for the last few nightly builds.

### DIFF
--- a/.github/scripts/gen-docker-tags.py
+++ b/.github/scripts/gen-docker-tags.py
@@ -1,36 +1,67 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
+import os
 import sys
 
-github_event = sys.argv[1]
-version = sys.argv[2]
+from typing import Final
 
-REPO = 'netdata/netdata'
+github_event: Final = sys.argv[1]
+version: Final = sys.argv[2]
 
-REPOS = (
-    REPO,
-    f'quay.io/{REPO}',
-    f'ghcr.io/{REPO}',
-)
+REPO: Final = 'netdata/netdata'
+REPOS: Final = {
+    'docker': REPO,
+    'quay': f'quay.io/{REPO}',
+    'ghcr': f'ghcr.io/{REPO}',
+}
+
+REPO: Final = 'netdata/netdata'
+QUAY_REPO: Final = f'quay.io/{REPO}'
+GHCR_REPO: Final = f'ghcr.io/{REPO}'
+NIGHTLY_TAG: Final = 'edge'
+
+tags = {
+    k: [] for k in REPOS.keys()
+}
+
+nightly = False
 
 match version:
     case '':
-        tags = (f'{REPO}:test',)
+        for h in REPOS.keys():
+            tags[h] = [f'{REPOS[h]}:test']
     case 'nightly':
-        tags = tuple([
-            f'{r}:{t}' for r in REPOS for t in ('edge', 'latest')
-        ])
+        for h in REPOS.keys():
+            tags[h] = [f'{REPOS[h]}:{t}' for t in (NIGHTLY_TAG, 'latest')]
+
+        nightly = True
     case _:
         v = f'v{version}'.split('.')
 
-        tags = tuple([
-            f'{r}:{t}' for r in REPOS for t in (
-                v[0],
-                '.'.join(v[0:2]),
-                '.'.join(v[0:3]),
-            )
-        ])
+        versions: Final = (
+            v[0],
+            '.'.join(v[0:2]),
+            '.'.join(v[0:3]),
+            'stable',
+        )
 
-        tags = tags + tuple([f'{r}:stable' for r in REPOS])
+        for h in REPOS.keys():
+            tags[h] = [f'{REPOS[h]}:{t}' for t in versions]
 
-print(','.join(tags))
+all_tags = [x for y in tags.values() for x in y]
+
+
+def write_output(name: str, value: str) -> None:
+    with open(os.getenv('GITHUB_OUTPUT'), 'a') as f:
+        f.write(f'{name}={value}')
+
+
+write_output('tags', ','.join(all_tags))
+write_output('nightly', '1' if nightly else '0')
+write_output('nightly_tag', NIGHTLY_TAG)
+
+for h in REPOS.keys():
+    write_output(f'{h}_tags', ','.join(tags[h]))
+    write_output(f'{h}_repo', REPOS[h])

--- a/.github/scripts/rotate-docker-tags.sh
+++ b/.github/scripts/rotate-docker-tags.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+
+set -e
+
+repo="${1}"
+tag="${2}"
+count="${3}"
+
+retag_image() {
+    new_tag="${1}"
+    old_tag="${2}"
+
+    if docker manifest inspect "${old_tag}" > /dev/null; then
+        docker buildx imagetools create --tag "${new_tag}" "${old_tag}"
+    fi
+}
+
+for i in $(seq "${count}" -1 1); do
+    retag_image "${repo}:${tag}-${i}" "${repo}:${tag}-$((i - 1))"
+done
+
+retag_image "${repo}:${tag}-0" "${repo}:${tag}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,7 @@ on:
         required: true
 env:
   DISABLE_TELEMETRY: 1
+  NIGHTLY_COUNT: 4
 concurrency:
   group: docker-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
@@ -258,6 +259,14 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     outputs:
       tags: ${{ steps.tag.outputs.tags }}
+      nightly: ${{ steps.tag.outputs.nightly }}
+      nightly_tag: ${{ steps.tag.outputs.nightly_tag }}
+      docker_tags: ${{ steps.tag.outputs.docker_tags }}
+      quay_tags: ${{ steps.tag.outputs.quay_tags }}
+      ghcr_tags: ${{ steps.tag.outputs.ghcr_tags }}
+      docker_repo: ${{ steps.tag.outputs.docker_repo }}
+      quay_repo: ${{ steps.tag.outputs.quay_repo }}
+      ghcr_repo: ${{ steps.tag.outputs.ghcr_repo }}
     steps:
       - name: Checkout
         id: checkout
@@ -266,9 +275,9 @@ jobs:
         id: tag
         run: |
           if [ ${{ github.event_name }} = 'workflow_dispatch' ]; then
-            echo "tags=$(.github/scripts/gen-docker-tags.py ${{ github.event_name }} ${{ github.event.inputs.version }})" >> "${GITHUB_OUTPUT}"
+            .github/scripts/gen-docker-tags.py ${{ github.event_name }} ${{ github.event.inputs.version }}
           else
-            echo "tags=$(.github/scripts/gen-docker-tags.py ${{ github.event_name }} '')" >> "${GITHUB_OUTPUT}"
+            .github/scripts/gen-docker-tags.py ${{ github.event_name }} ''
           fi
 
   build-images-docker-hub:
@@ -398,6 +407,10 @@ jobs:
         id: manifest
         if: github.repository == 'netdata/netdata'
         run: docker buildx imagetools create $(.github/scripts/gen-docker-imagetool-args.py /tmp/digests '' "${{ needs.gen-tags.outputs.tags }}")
+      - name: Rotate Old Image Tags
+        id: rotate
+        if: github.repository == 'netdata/netdata' && needs.gen-tags.outputs.nightly == '1'
+        run: .github/scripts/rotate-docker-tags.sh ${{ needs.gen-tags.outputs.docker_repo }} ${{ needs.gen-tags.outputs.nightly_tag }} ${NIGHTLY_COUNT}
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
         env:
@@ -413,6 +426,7 @@ jobs:
               Setup buildx: ${{ steps.prepare.outcome }}
               Login to registry: ${{ steps.login.outcome }}
               Create and push manifest: ${{ steps.manifest.outcome }}
+              Rotate old image tags: ${{ steps.rotate.outcome }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: >-
           ${{
@@ -549,6 +563,10 @@ jobs:
         id: manifest
         if: github.repository == 'netdata/netdata'
         run: docker buildx imagetools create $(.github/scripts/gen-docker-imagetool-args.py /tmp/digests 'quay.io' "${{ needs.gen-tags.outputs.tags }}")
+      - name: Rotate Old Image Tags
+        id: rotate
+        if: github.repository == 'netdata/netdata' && needs.gen-tags.outputs.nightly == '1'
+        run: .github/scripts/rotate-docker-tags.sh ${{ needs.gen-tags.outputs.quay_repo }} ${{ needs.gen-tags.outputs.nightly_tag }} ${NIGHTLY_COUNT}
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
         env:
@@ -564,6 +582,7 @@ jobs:
               Setup buildx: ${{ steps.prepare.outcome }}
               Login to registry: ${{ steps.login.outcome }}
               Create and push manifest: ${{ steps.manifest.outcome }}
+              Rotate old image tags: ${{ steps.rotate.outcome }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: >-
           ${{
@@ -700,6 +719,10 @@ jobs:
         id: manifest
         if: github.repository == 'netdata/netdata'
         run: docker buildx imagetools create $(.github/scripts/gen-docker-imagetool-args.py /tmp/digests 'ghcr.io' "${{ needs.gen-tags.outputs.tags }}")
+      - name: Rotate Old Image Tags
+        id: rotate
+        if: github.repository == 'netdata/netdata' && needs.gen-tags.outputs.nightly == '1'
+        run: .github/scripts/rotate-docker-tags.sh ${{ needs.gen-tags.outputs.ghcr_repo }} ${{ needs.gen-tags.outputs.nightly_tag }} ${NIGHTLY_COUNT}
       - name: Failure Notification
         uses: rtCamp/action-slack-notify@v2
         env:
@@ -715,6 +738,7 @@ jobs:
               Setup buildx: ${{ steps.prepare.outcome }}
               Login to registry: ${{ steps.login.outcome }}
               Create and push manifest: ${{ steps.manifest.outcome }}
+              Rotate old image tags: ${{ steps.rotate.outcome }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: >-
           ${{


### PR DESCRIPTION
##### Summary

This adds new Docker tags for our nightly builds to track prior nightly builds relative to the current one.

The new tags take the form `edge-x` where the `x` is a number that represents how many builds previous to the current build the tag tracks. For example, `edge-1` is the build just prior to the current nightly version, while `edge-3` is three builds prior to the current nightly build.

These tags are rotated every time a nightly build is published. This approach was chosen to avoid the significant complexity that would be required to properly clean up old nightly build tags if we were tagging by actual nightly version instead of tagging relative to the current build.

The current configuration will track the 4 most recent nightly builds.

The special tag `edge-0` is a new alias for the current nightly build. This is only needed to allow the tag update logic to work correctly, as the workflow is intentionally configured to publish the new nightly images before rotating the tags for the old ones (so that if rotation fails it does not prevent us from publishing the current nightly).

##### Test Plan

n/a

##### Additional Information

This is being added primarily to allow us to roll back the `edge` tag in the event of known bad builds being published without breaking the ability to install nightly Docker builds.