### PR TITLE
Fix power draw reading in gpu_info.go

### DIFF
--- a/src/go/plugin/go.d/collector/nvidia_smi/gpu_info.go
+++ b/src/go/plugin/go.d/collector/nvidia_smi/gpu_info.go
@@ -81,7 +81,7 @@ type (
 	gpuPowerReadings struct {
 		//PowerState         string `xml:"power_state"`
 		//PowerManagement    string `xml:"power_management"`
-		PowerDraw string `xml:"power_draw"`
+		PowerDraw string `xml:"average_power_draw"`
 		//PowerLimit         string `xml:"power_limit"`
 		//DefaultPowerLimit  string `xml:"default_power_limit"`
 		//EnforcedPowerLimit string `xml:"enforced_power_limit"`


### PR DESCRIPTION
I can't describe exactly since which release, but it must happen in the last 2 weeks and it must be related to a nvidia-smi binary change. Maybe you upgraded the version in your docker container.

Everything related to my nvidia gpu works as expected, except the power usage report, which is gone since 1 or 2 releases.

I already check the output of my nvidia-smi command inside the container of netdata and everything works.

I guess that one of the xml tag names changed.

In your code of you gpu_info.go file inside the nvidia_smi collector, you check the xml tag "gpu_power_readings / power_draw"

But if I check the xml output, there are only "gpu_power_readings / average_power_draw" and "gpu_power_readings / instant_power_draw"

So, I guess you must just switch to one of these fields.

----- Update ---- 

I think it is related to the latest nvidia driver update. I'm using version 570.124.04  