### PR TITLE
Fix SIGSEGV on static installs due to dengine log

### DIFF
--- a/packaging/makeself/jobs/99-makeself.install.sh
+++ b/packaging/makeself/jobs/99-makeself.install.sh
@@ -93,7 +93,7 @@ run "${NETDATA_MAKESELF_PATH}/makeself.sh" \
   --help-header "${NETDATA_MAKESELF_PATH}/makeself-help-header.txt" \
   "${NETDATA_INSTALL_PATH}" \
   "${NETDATA_INSTALL_PATH}.gz.run" \
-  "netdata, the real-time performance and health monitoring system" \
+  "Netdata, X-Ray Vision for your infrastructure" \
   ./system/post-installer.sh
 
 run rm "${NETDATA_MAKESELF_PATH}/makeself.lsm.tmp"

--- a/packaging/makeself/makeself.lsm
+++ b/packaging/makeself/makeself.lsm
@@ -6,7 +6,7 @@ Description:    netdata - X-Ray Vision for your infrastructure!
                 Per-second data collection, high-performance long-term storage, low-latency
                 visualization, machine-learning based anomaly detection, alerts and notifications,
                 advanced correlations and fast root cause analysis, native horizontal scalability.
-Keywords:       real-time performance and health monitoring
+Keywords:       X-Ray Vision for your infrastructure
 Author:         Netdata Inc.
 Maintained-by:  Netdata Inc.
 Original-site:  https://netdata.cloud/

--- a/src/database/engine/pdc.c
+++ b/src/database/engine/pdc.c
@@ -695,7 +695,71 @@ ALWAYS_INLINE VALIDATED_PAGE_DESCRIPTOR validate_extent_page_descr(const struct 
             "loaded", 0);
 }
 
-ALWAYS_INLINE VALIDATED_PAGE_DESCRIPTOR validate_page(
+static void validate_page_log(nd_uuid_t *uuid,
+                              time_t start_time_s,
+                              time_t end_time_s,
+                              uint32_t update_every_s,
+                              size_t page_length,
+                              size_t entries,
+                              time_t now_s,
+                              const char *msg,
+                              RRDENG_COLLECT_PAGE_FLAGS flags,
+                              VALIDATED_PAGE_DESCRIPTOR vd) {
+#ifndef NETDATA_INTERNAL_CHECKS
+    nd_log_limit_static_global_var(erl, 1, 0);
+#endif
+    char uuid_str[UUID_STR_LEN + 1];
+    uuid_unparse(*uuid, uuid_str);
+
+    CLEAN_BUFFER *wb = NULL; // will be automatically freed on function exit
+
+    if(flags) {
+        wb = buffer_create(0, NULL);
+        collect_page_flags_to_buffer(wb, flags);
+    }
+
+    if(!vd.is_valid) {
+#ifdef NETDATA_INTERNAL_CHECKS
+        internal_error(true,
+#else
+        nd_log_limit(&erl, NDLS_DAEMON, NDLP_ERR,
+#endif
+                       "DBENGINE: metric '%s' %s invalid page of type %u "
+                       "from %ld to %ld (now %ld), update every %u, page length %zu, entries %zu (flags: %s)",
+                       uuid_str, msg, (unsigned)vd.type,
+                       (long)vd.start_time_s, (long)vd.end_time_s, (long)now_s, (unsigned)vd.update_every_s, (size_t)vd.page_length, (size_t)vd.entries, wb?buffer_tostring(wb):""
+        );
+    }
+    else {
+        const char *err_valid = "";
+        const char *err_start = (vd.start_time_s == start_time_s) ? "" : "start time updated, ";
+        const char *err_end = (vd.end_time_s == end_time_s) ? "" : "end time updated, ";
+        const char *err_update = (vd.update_every_s == update_every_s) ? "" : "update every updated, ";
+        const char *err_length = (vd.page_length == page_length) ? "" : "page length updated, ";
+        const char *err_entries = (vd.entries == entries) ? "" : "entries updated, ";
+        const char *err_future = (now_s && vd.end_time_s <= now_s) ? "" : "future end time, ";
+
+#ifdef NETDATA_INTERNAL_CHECKS
+        internal_error(true,
+#else
+        nd_log_limit(&erl, NDLS_DAEMON, NDLP_ERR,
+#endif
+                       "DBENGINE: metric '%s' %s page of type %u "
+                       "from %ld to %ld (now %ld), update every %u, page length %zu, entries %zu (flags: %s), "
+                       "found inconsistent - the right is "
+                       "from %ld to %ld, update every %u, page length %zu, entries %zu: "
+                       "%s%s%s%s%s%s%s",
+                       uuid_str, msg ? msg : "", (unsigned)vd.type,
+                       (long)start_time_s, (long)end_time_s, (long)now_s, (unsigned)update_every_s,
+                       (unsigned)page_length, (size_t)entries, wb?buffer_tostring(wb):"",
+                       (long)vd.start_time_s, (long)vd.end_time_s, (unsigned)vd.update_every_s, (size_t)vd.page_length, (size_t)vd.entries,
+                       err_valid, err_start, err_end, err_update, err_length, err_entries, err_future
+        );
+    }
+}
+
+ALWAYS_INLINE
+VALIDATED_PAGE_DESCRIPTOR validate_page(
         nd_uuid_t *uuid,
         time_t start_time_s,
         time_t end_time_s,
@@ -804,60 +868,8 @@ ALWAYS_INLINE VALIDATED_PAGE_DESCRIPTOR validate_page(
         }
     }
 
-    if(unlikely(!vd.is_valid || updated)) {
-#ifndef NETDATA_INTERNAL_CHECKS
-        nd_log_limit_static_global_var(erl, 1, 0);
-#endif
-        char uuid_str[UUID_STR_LEN + 1];
-        uuid_unparse(*uuid, uuid_str);
-
-        BUFFER *wb = NULL;
-
-        if(flags) {
-            wb = buffer_create(0, NULL);
-            collect_page_flags_to_buffer(wb, flags);
-        }
-
-        if(!vd.is_valid) {
-#ifdef NETDATA_INTERNAL_CHECKS
-            internal_error(true,
-#else
-            nd_log_limit(&erl, NDLS_DAEMON, NDLP_ERR,
-#endif
-                        "DBENGINE: metric '%s' %s invalid page of type %u "
-                        "from %ld to %ld (now %ld), update every %u, page length %zu, entries %zu (flags: %s)",
-                        uuid_str, msg, vd.type,
-                        vd.start_time_s, vd.end_time_s, now_s, vd.update_every_s, vd.page_length, vd.entries, wb?buffer_tostring(wb):""
-            );
-        }
-        else {
-            const char *err_valid = "";
-            const char *err_start = (vd.start_time_s == start_time_s) ? "" : "start time updated, ";
-            const char *err_end = (vd.end_time_s == end_time_s) ? "" : "end time updated, ";
-            const char *err_update = (vd.update_every_s == update_every_s) ? "" : "update every updated, ";
-            const char *err_length = (vd.page_length == page_length) ? "" : "page length updated, ";
-            const char *err_entries = (vd.entries == entries) ? "" : "entries updated, ";
-            const char *err_future = (now_s && vd.end_time_s <= now_s) ? "" : "future end time, ";
-
-#ifdef NETDATA_INTERNAL_CHECKS
-            internal_error(true,
-#else
-            nd_log_limit(&erl, NDLS_DAEMON, NDLP_ERR,
-#endif
-                        "DBENGINE: metric '%s' %s page of type %u "
-                        "from %ld to %ld (now %ld), update every %u, page length %zu, entries %zu (flags: %s), "
-                        "found inconsistent - the right is "
-                        "from %ld to %ld, update every %u, page length %zu, entries %zu: "
-                        "%s%s%s%s%s%s%s",
-                        uuid_str, msg, vd.type,
-                        start_time_s, end_time_s, now_s, update_every_s, page_length, entries, wb?buffer_tostring(wb):"",
-                        vd.start_time_s, vd.end_time_s, vd.update_every_s, vd.page_length, vd.entries,
-                        err_valid, err_start, err_end, err_update, err_length, err_entries, err_future
-            );
-        }
-
-        buffer_free(wb);
-    }
+    if(unlikely(!vd.is_valid || updated))
+        validate_page_log(uuid, start_time_s, end_time_s, update_every_s, page_length, entries, now_s, msg, flags, vd);
 
     return vd;
 }

--- a/src/health/notifications/alarm-notify.sh.in
+++ b/src/health/notifications/alarm-notify.sh.in
@@ -3667,7 +3667,7 @@ Content-Transfer-Encoding: 8bit
                     <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:10px 25px;padding-top:0;padding-bottom:0;word-break:break-word;">
-                        <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#35414A;">© Netdata $(date +'%Y') - The real-time performance and health monitoring</div>
+                        <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#35414A;">© Netdata $(date +'%Y') - X-Ray Vision for your infrastructure</div>
                       </td>
                     </tr>
                     </tbody>


### PR DESCRIPTION
It seems there is some problem with static installs and muslc with a certain log that triggers a SIGSEGV inside a `vsprintf()`.

```
Thread 1 "netdata" received signal SIGSEGV, Segmentation fault.
0x00eda680 in memchr (src=src@entry=0x3c, c=c@entry=0, n=n@entry=2147483647) at src/string/memchr.c:17
17	src/string/memchr.c: No such file or directory.
(gdb) bt
#0  0x00eda680 in memchr (src=src@entry=0x3c, c=c@entry=0, n=n@entry=2147483647) at src/string/memchr.c:17
#1  0x00edae3c in strnlen (s=s@entry=0x3c <error: Cannot access memory at address 0x3c>, n=n@entry=2147483647) at src/string/strnlen.c:5
#2  0x00ed8d40 in printf_core (f=f@entry=0xbeff55f0, fmt=fmt@entry=0xf36934 "DBENGINE: metric '%s' %s page of type %u from %ld to %ld (now %ld), update every %u, page length %zu, entries %zu (flags: %s), found inconsistent - the right is from %ld to %ld, update every %u, page "..., ap=ap@entry=0xbeff54ec, 
    nl_arg=nl_arg@entry=0xbeff5518, nl_type=<optimized out>, nl_type@entry=0xbeff54f0) at src/stdio/vfprintf.c:599
#3  0x00ed9080 in vfprintf (f=f@entry=0xbeff55f0, fmt=fmt@entry=0xf36934 "DBENGINE: metric '%s' %s page of type %u from %ld to %ld (now %ld), update every %u, page length %zu, entries %zu (flags: %s), found inconsistent - the right is from %ld to %ld, update every %u, page "..., ap=..., ap@entry=...) at src/stdio/vfprintf.c:688
#4  0x00ed9f04 in vsnprintf (s=<optimized out>, n=1024, fmt=0xf36934 "DBENGINE: metric '%s' %s page of type %u from %ld to %ld (now %ld), update every %u, page length %zu, entries %zu (flags: %s), found inconsistent - the right is from %ld to %ld, update every %u, page "..., ap=...) at src/stdio/vsnprintf.c:54
#5  0x0070dd04 in buffer_vsprintf (wb=0xb66e4500, fmt=0xf36934 "DBENGINE: metric '%s' %s page of type %u from %ld to %ld (now %ld), update every %u, page length %zu, entries %zu (flags: %s), found inconsistent - the right is from %ld to %ld, update every %u, page "..., args=...) at /usr/include/fortify/stdio.h:80
#6  0x0086ed24 in nd_logger.constprop.0 () at /usr/src/netdata/src/libnetdata/log/nd_log.c:332
#7  0x00852fa0 in netdata_logger_with_limit.constprop.0 () at /usr/src/netdata/src/libnetdata/log/nd_log.c:450
#8  0x004f8a54 in journalfile_restore_extent_metadata (ctx=0x3c, journalfile=0x0, buf=0x7fffffff, max_size=60) at /usr/src/netdata/src/database/engine/pdc.c:845
#9  0x004ff610 in scan_data_files.lto_priv.0 (ctx=0x3c) at /usr/src/netdata/src/database/engine/journalfile.c:780
#10 0x00510530 in rrdeng_init (ctxp=0x0, dbfiles_path=0x0, disk_space_mb=1, tier=2588, max_retention_s=0) at /usr/src/netdata/src/database/engine/datafile.c:525
#11 0x0018669c in dbengine_tier_init (ptr=0xbeffb154) at /usr/src/netdata/src/daemon/config/netdata-conf-db.c:110
#12 0x0018b338 in netdata_conf_dbengine_init (hostname=0x3c <error: Cannot access memory at address 0x3c>) at /usr/src/netdata/src/daemon/config/netdata-conf-db.c:296
#13 0x00364e9c in rrd_init (hostname=0x3c <error: Cannot access memory at address 0x3c>, system_info=0xb6fbebe0, unittest=false) at /usr/src/netdata/src/database/rrd.c:92
#14 0x00151f20 in netdata_main (argc=60, argv=0x0) at /usr/src/netdata/src/daemon/main.c:1022
#15 0x0002f324 in main (argc=60, argv=0x0) at /usr/src/netdata/src/daemon/main.c:1129
```

This is probably related to LTO. I isolated the log from the inlining and also I rewrote it without using printf like functions.