### PR TITLE
status file improvements 12

### DIFF
--- a/src/daemon/daemon-status-file.c
+++ b/src/daemon/daemon-status-file.c
@@ -835,15 +835,13 @@ static enum crash_report_t check_crash_reports_config(void) {
     return rc;
 }
 
-void daemon_status_file_check_crash(void) {
-    FUNCTION_RUN_ONCE();
-
+void daemon_status_file_init(void) {
     static_save_buffer_init();
-
     mallocz_register_out_of_memory_cb(daemon_status_file_out_of_memory);
-
     daemon_status_file_load(&last_session_status);
-    daemon_status_file_startup_step("startup(read status file)");
+}
+
+void daemon_status_file_check_crash(void) {
     struct log_priority pri = PRI_ALL_NORMAL;
 
     bool new_version = strcmp(last_session_status.version, session_status.version) != 0;
@@ -1051,8 +1049,6 @@ void daemon_status_file_check_crash(void) {
         !dedup_already_posted(&session_status, daemon_status_file_hash(&last_session_status, msg, cause))
 
         ) {
-        daemon_status_file_startup_step("startup(post status file)");
-
         netdata_conf_ssl();
 
         struct post_status_file_thread_data d = {

--- a/src/daemon/daemon-status-file.h
+++ b/src/daemon/daemon-status-file.h
@@ -100,6 +100,7 @@ bool daemon_status_file_was_incomplete_shutdown(void);
 void daemon_status_file_startup_step(const char *step);
 void daemon_status_file_shutdown_step(const char *step);
 
+void daemon_status_file_init(void);
 void daemon_status_file_register_fatal(const char *filename, const char *function, const char *message, const char *errno_str, const char *stack_trace, long line);
 
 #endif //NETDATA_DAEMON_STATUS_FILE_H

--- a/src/daemon/daemon.c
+++ b/src/daemon/daemon.c
@@ -4,24 +4,6 @@
 #include <sched.h>
 
 char *pidfile = NULL;
-char *netdata_exe_path = NULL;
-
-void get_netdata_execution_path(void) {
-    struct passwd *passwd = getpwuid(getuid());
-    char *user = (passwd && passwd->pw_name) ? passwd->pw_name : "";
-
-    char b[FILENAME_MAX + 1];
-    size_t b_size = sizeof(b) - 1;
-    int ret = uv_exepath(b, &b_size);
-    if (ret != 0) {
-        fatal("Cannot start netdata without getting execution path. "
-            "(uv_exepath(\"%s\", %zu), user: '%s', failed: %s).",
-            b, b_size, user, uv_strerror(ret));
-    }
-    b[b_size] = '\0';
-
-    netdata_exe_path = strdupz(b);
-}
 
 static void fix_directory_file_permissions(const char *dirname, uid_t uid, gid_t gid, bool recursive)
 {

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -8,7 +8,6 @@ int become_daemon(int dont_fork, const char *user);
 void get_netdata_execution_path(void);
 
 extern char *pidfile;
-extern char *netdata_exe_path;
 
 void verify_required_directory(const char *env, const char *dir, bool create_it, int perms);
 

--- a/src/daemon/libuv_workers.c
+++ b/src/daemon/libuv_workers.c
@@ -3,14 +3,8 @@
 #include <daemon/main.h>
 #include "libuv_workers.h"
 
-// Register workers
-void register_libuv_worker_jobs() {
-    static __thread bool registered = false;
-
-    if(likely(registered))
-        return;
-
-    registered = true;
+static void register_libuv_worker_jobs_internal(void) {
+    signals_block_all_except_deadly();
 
     worker_register("LIBUV");
 
@@ -98,4 +92,16 @@ void register_libuv_worker_jobs() {
     char buf[NETDATA_THREAD_TAG_MAX + 1];
     snprintfz(buf, NETDATA_THREAD_TAG_MAX, "UV_WORKER[%d]", worker_id);
     uv_thread_set_name_np(buf);
+}
+
+// Register workers
+ALWAYS_INLINE
+void register_libuv_worker_jobs() {
+    static __thread bool registered = false;
+
+    if(likely(registered))
+        return;
+
+    registered = true;
+    register_libuv_worker_jobs_internal();
 }

--- a/src/daemon/main.c
+++ b/src/daemon/main.c
@@ -780,7 +780,9 @@ int netdata_main(int argc, char **argv) {
     netdata_conf_section_global(); // get hostname, host prefix, profile, etc
     registry_init(); // for machine_guid, must be after netdata_conf_section_global()
 
-    // make sure we are the only instance running
+    // ----------------------------------------------------------------------------------------------------------------
+    delta_startup_time("run dir");
+
     {
         const char *run_dir = os_run_dir(true);
         if(!run_dir) {

--- a/src/libnetdata/exit/exit_initiated.c
+++ b/src/libnetdata/exit/exit_initiated.c
@@ -95,7 +95,7 @@ static bool is_system_shutdown(void) {
 static const char *self_path = NULL;
 static OS_FILE_METADATA self = { 0 };
 
-void exit_initiated_reset(void) {
+void exit_initiated_init(void) {
     exit_initiated = EXIT_REASON_NONE;
 
     freez((char *)self_path);

--- a/src/libnetdata/exit/exit_initiated.h
+++ b/src/libnetdata/exit/exit_initiated.h
@@ -52,7 +52,7 @@ BITMAP_STR_DEFINE_FUNCTIONS_EXTERN(EXIT_REASON);
 
 extern volatile EXIT_REASON exit_initiated;
 
-void exit_initiated_reset(void);
+void exit_initiated_init(void);
 void exit_initiated_set(EXIT_REASON reason);
 void exit_initiated_add(EXIT_REASON reason);
 

--- a/src/libnetdata/signals/signals.c
+++ b/src/libnetdata/signals/signals.c
@@ -34,9 +34,12 @@ void signals_unblock(int signals[], size_t count) {
         nd_log(NDLS_COLLECTORS, NDLP_ERR, "SIGNALS: cannot unmask signals");
 }
 
-void signals_block_all_except_deadly(void) {
-    signals_block_all();
-
+void signals_unblock_deadly(void) {
     int deadly_signals[] = {SIGBUS, SIGSEGV, SIGFPE, SIGILL, SIGABRT};
     signals_unblock(deadly_signals, _countof(deadly_signals));
+}
+
+void signals_block_all_except_deadly(void) {
+    signals_block_all();
+    signals_unblock_deadly();
 }

--- a/src/libnetdata/signals/signals.h
+++ b/src/libnetdata/signals/signals.h
@@ -10,5 +10,6 @@ void signals_block_all(void);
 
 void signals_unblock_one(int signo);
 void signals_unblock(int signals[], size_t count);
+void signals_unblock_deadly(void);
 
 #endif //NETDATA_SIGNALS_H

--- a/src/libnetdata/threads/threads.c
+++ b/src/libnetdata/threads/threads.c
@@ -211,7 +211,7 @@ size_t netdata_threads_init(void) {
 // ----------------------------------------------------------------------------
 // late initialization
 
-void netdata_threads_init_after_fork(size_t stacksize) {
+void netdata_threads_set_stack_size(size_t stacksize) {
     int i;
 
     // set pthread stack size
@@ -234,7 +234,7 @@ void netdata_threads_init_for_external_plugins(size_t stacksize) {
     if(default_stacksize < 1 * 1024 * 1024)
         default_stacksize = 1 * 1024 * 1024;
 
-    netdata_threads_init_after_fork(stacksize ? stacksize : default_stacksize);
+    netdata_threads_set_stack_size(stacksize ? stacksize : default_stacksize);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/libnetdata/threads/threads.h
+++ b/src/libnetdata/threads/threads.h
@@ -69,7 +69,7 @@ int nd_thread_has_tag(void);
 #define THREAD_TAG_STREAM_SENDER "SNDR"
 
 size_t netdata_threads_init(void);
-void netdata_threads_init_after_fork(size_t stacksize);
+void netdata_threads_set_stack_size(size_t stacksize);
 void netdata_threads_init_for_external_plugins(size_t stacksize);
 
 ND_THREAD *nd_thread_create(const char *tag, NETDATA_THREAD_OPTIONS options, void *(*start_routine) (void *), void *arg);


### PR DESCRIPTION
- [x] make sure libuv threads have the deadly signals properly unblocked - trying to find out why stack traces are missing in a few cases.
- [x] trace the `startup(become deamon)` SIGSEGV on static builds running on raspbian - added more details to understand which section crashes.
- [x] optimize the startup process to have the signal handler running as early as possible.