### PR TITLE
improvement(go.d/k8s_state): collect cronjobs

### DIFF
--- a/src/go/plugin/go.d/collector/k8s_state/charts.go
+++ b/src/go/plugin/go.d/collector/k8s_state/charts.go
@@ -851,7 +851,7 @@ var (
 		Priority: prioCronJobJobsCountByStatus,
 		Type:     module.Stacked,
 		Dims: module.Dims{
-			{ID: "cronjob_%s_complete_jobs", Name: "complete"},
+			{ID: "cronjob_%s_complete_jobs", Name: "completed"},
 			{ID: "cronjob_%s_failed_jobs", Name: "failed"},
 			{ID: "cronjob_%s_running_jobs", Name: "running"},
 			{ID: "cronjob_%s_suspended_jobs", Name: "suspended"},

--- a/src/go/plugin/go.d/collector/k8s_state/collect.go
+++ b/src/go/plugin/go.d/collector/k8s_state/collect.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/netdata/netdata/go/plugins/plugin/go.d/agent/module"
@@ -110,6 +111,7 @@ func (c *Collector) collectKubeState(mx map[string]int64) {
 	c.collectPodsState(mx)
 	c.collectNodesState(mx)
 	c.collectDeploymentState(mx)
+	c.collectCronJobState(mx)
 }
 
 func (c *Collector) collectPodsState(mx map[string]int64) {
@@ -346,6 +348,59 @@ func (c *Collector) collectDeploymentState(mx map[string]int64) {
 				mx[px+"condition_progressing"] = v
 			case appsv1.DeploymentReplicaFailure:
 				mx[px+"condition_replica_failure"] = v
+			}
+		}
+
+		return false
+	})
+}
+
+func (c *Collector) collectCronJobState(mx map[string]int64) {
+	now := time.Now()
+
+	maps.DeleteFunc(c.state.jobs, func(s string, st *jobState) bool {
+		return st.deleted
+	})
+
+	maps.DeleteFunc(c.state.cronJobs, func(s string, st *cronJobState) bool {
+		if st.deleted {
+			c.removeCronJobCharts(st)
+			return true
+		}
+		if st.new {
+			c.addCronJobCharts(st)
+			st.new = false
+		}
+
+		px := fmt.Sprintf("cronjob_%s_", st.id())
+
+		mx[px+"age"] = int64(now.Sub(st.creationTime).Seconds())
+
+		mx[px+"running_jobs"] = 0
+		mx[px+"failed_jobs"] = 0
+		mx[px+"complete_jobs"] = 0
+		mx[px+"suspended_jobs"] = 0
+
+		for _, job := range c.state.jobs {
+			switch {
+			case job.controller.kind != "CronJob", job.controller.uid != st.uid, job.startTime == nil:
+				continue
+			case job.active > 0:
+				mx[px+"running_jobs"]++
+			case len(job.conditions) > 0:
+				for _, cond := range job.conditions {
+					if cond.Status != corev1.ConditionTrue {
+						continue
+					}
+					switch cond.Type {
+					case batchv1.JobFailed:
+						mx[px+"failed_jobs"]++
+					case batchv1.JobComplete:
+						mx[px+"complete_jobs"]++
+					case batchv1.JobSuspended:
+						mx[px+"suspended_jobs"]++
+					}
+				}
 			}
 		}
 

--- a/src/go/plugin/go.d/collector/k8s_state/collector.go
+++ b/src/go/plugin/go.d/collector/k8s_state/collector.go
@@ -31,7 +31,7 @@ func init() {
 
 func New() *Collector {
 	return &Collector{
-		initDelay:     time.Second * 3,
+		initDelay:     time.Second * 10,
 		newKubeClient: newKubeClient,
 		charts:        baseCharts.Copy(),
 		once:          &sync.Once{},

--- a/src/go/plugin/go.d/collector/k8s_state/discover_pod.go
+++ b/src/go/plugin/go.d/collector/k8s_state/discover_pod.go
@@ -19,7 +19,7 @@ func newPodDiscoverer(si cache.SharedInformer, l *logger.Logger) *podDiscoverer 
 		panic("nil pod shared informer")
 	}
 
-	queue := workqueue.NewTypedWithConfig(workqueue.TypedQueueConfig[any]{Name: "pod"})
+	queue := workqueue.NewTypedWithConfig(workqueue.TypedQueueConfig[string]{Name: "pod"})
 
 	_, _ = si.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj any) { enqueue(queue, obj) },
@@ -48,7 +48,7 @@ func (r podResource) value() any             { return r.val }
 type podDiscoverer struct {
 	*logger.Logger
 	informer cache.SharedInformer
-	queue    *workqueue.Typed[any]
+	queue    *workqueue.Typed[string]
 	readyCh  chan struct{}
 	stopCh   chan struct{}
 }
@@ -76,15 +76,14 @@ func (d *podDiscoverer) stopped() bool { return isChanClosed(d.stopCh) }
 
 func (d *podDiscoverer) runDiscover(ctx context.Context, in chan<- resource) {
 	for {
-		item, shutdown := d.queue.Get()
+		key, shutdown := d.queue.Get()
 		if shutdown {
 			return
 		}
 
 		func() {
-			defer d.queue.Done(item)
+			defer d.queue.Done(key)
 
-			key := item.(string)
 			ns, name, err := cache.SplitMetaNamespaceKey(key)
 			if err != nil {
 				return

--- a/src/go/plugin/go.d/collector/k8s_state/metadata.yaml
+++ b/src/go/plugin/go.d/collector/k8s_state/metadata.yaml
@@ -247,6 +247,33 @@ modules:
               chart_type: line
               dimensions:
                 - name: age
+        - name: cronjob
+          description: These metrics refer to CronJobs.
+          labels:
+            - name: k8s_cluster_id
+              description: Cluster ID. This is equal to the kube-system namespace UID.
+            - name: k8s_cluster_name
+              description: Cluster name. Cluster name discovery only works in GKE.
+            - name: k8s_cronjob_name
+              description: CronJob name.
+            - name: k8s_namespace
+              description: Namespace.
+          metrics:
+            - name: k8s_state.cronjob_jobs_count_by_status
+              description: CronJob Jobs Count by Status
+              unit: 'jobs'
+              chart_type: stacked
+              dimensions:
+                - name: complete
+                - name: failed
+                - name: running
+                - name: suspended
+            - name: k8s_state.cronjob_age
+              description: CronJob Age
+              unit: 'seconds'
+              chart_type: line
+              dimensions:
+                - name: age
         - name: pod
           description: These metrics refer to the Pod.
           labels:

--- a/src/go/plugin/go.d/collector/k8s_state/metadata.yaml
+++ b/src/go/plugin/go.d/collector/k8s_state/metadata.yaml
@@ -264,7 +264,7 @@ modules:
               unit: 'jobs'
               chart_type: stacked
               dimensions:
-                - name: complete
+                - name: completed
                 - name: failed
                 - name: running
                 - name: suspended

--- a/src/go/plugin/go.d/collector/k8s_state/resource.go
+++ b/src/go/plugin/go.d/collector/k8s_state/resource.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -21,6 +22,8 @@ const (
 	kubeResourceNode kubeResourceKind = iota + 1
 	kubeResourcePod
 	kubeResourceDeployment
+	kubeResourceCronJob
+	kubeResourceJob
 )
 
 func toNode(i any) (*corev1.Node, error) {
@@ -53,5 +56,27 @@ func toDeployment(i any) (*appsv1.Deployment, error) {
 		return toDeployment(v.value())
 	default:
 		return nil, fmt.Errorf("unexpected type: %T (expected %T or %T)", v, &appsv1.Deployment{}, resource(nil))
+	}
+}
+
+func toCronJob(i any) (*batchv1.CronJob, error) {
+	switch v := i.(type) {
+	case *batchv1.CronJob:
+		return v, nil
+	case resource:
+		return toCronJob(v.value())
+	default:
+		return nil, fmt.Errorf("unexpected type: %T (expected %T or %T)", v, &batchv1.CronJob{}, resource(nil))
+	}
+}
+
+func toJob(i any) (*batchv1.Job, error) {
+	switch v := i.(type) {
+	case *batchv1.Job:
+		return v, nil
+	case resource:
+		return toJob(v.value())
+	default:
+		return nil, fmt.Errorf("unexpected type: %T (expected %T or %T)", v, &batchv1.Job{}, resource(nil))
 	}
 }

--- a/src/go/plugin/go.d/collector/k8s_state/update_cronjob_state.go
+++ b/src/go/plugin/go.d/collector/k8s_state/update_cronjob_state.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package k8s_state
+
+func (c *Collector) updateCronJobState(r resource) {
+	if r.value() == nil {
+		if rs, ok := c.state.cronJobs[r.source()]; ok {
+			rs.deleted = true
+		}
+		return
+	}
+
+	cj, err := toCronJob(r)
+	if err != nil {
+		c.Warning(err)
+		return
+	}
+
+	_, ok := c.state.cronJobs[r.source()]
+	if !ok {
+		st := newCronJobState()
+		c.state.cronJobs[r.source()] = st
+
+		st.uid = string(cj.UID)
+		st.name = cj.Name
+		st.namespace = cj.Namespace
+		st.creationTime = cj.CreationTimestamp.Time
+	}
+}

--- a/src/go/plugin/go.d/collector/k8s_state/update_job_state.go
+++ b/src/go/plugin/go.d/collector/k8s_state/update_job_state.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package k8s_state
+
+import (
+	"slices"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (c *Collector) updateJobState(r resource) {
+	if r.value() == nil {
+		if rs, ok := c.state.jobs[r.source()]; ok {
+			rs.deleted = true
+		}
+		return
+	}
+
+	job, err := toJob(r)
+	if err != nil {
+		c.Warning(err)
+		return
+	}
+
+	if !slices.ContainsFunc(job.OwnerReferences, func(ref metav1.OwnerReference) bool {
+		return ref.Controller != nil && *ref.Controller && ref.Kind == "CronJob"
+	}) {
+		return
+	}
+
+	st, ok := c.state.jobs[r.source()]
+	if !ok {
+		st = newJobState()
+		c.state.jobs[r.source()] = st
+
+		st.uid = string(job.UID)
+		st.name = job.Name
+		st.namespace = job.Namespace
+		st.creationTime = job.CreationTimestamp.Time
+
+		for _, ref := range job.OwnerReferences {
+			if ref.Controller != nil && *ref.Controller {
+				st.controller.kind = ref.Kind
+				st.controller.name = ref.Name
+				st.controller.uid = string(ref.UID)
+			}
+		}
+	}
+
+	if job.Status.StartTime != nil {
+		st.startTime = ptr(job.Status.StartTime.Time)
+	}
+
+	st.active = job.Status.Active
+
+	st.conditions = job.Status.Conditions
+
+	st.uncountedTerminatedPods.succeeded = 0
+	st.uncountedTerminatedPods.failed = 0
+
+	if v := job.Status.UncountedTerminatedPods; v != nil {
+		st.uncountedTerminatedPods.succeeded = len(v.Succeeded)
+		st.uncountedTerminatedPods.failed = len(v.Failed)
+	}
+
+}

--- a/src/go/plugin/go.d/collector/k8s_state/update_state.go
+++ b/src/go/plugin/go.d/collector/k8s_state/update_state.go
@@ -7,15 +7,19 @@ func (c *Collector) runUpdateState(in <-chan resource) {
 		select {
 		case <-c.ctx.Done():
 			return
-		case r := <-in:
+		case res := <-in:
 			c.state.Lock()
-			switch r.kind() {
+			switch res.kind() {
 			case kubeResourceNode:
-				c.updateNodeState(r)
+				c.updateNodeState(res)
 			case kubeResourcePod:
-				c.updatePodState(r)
+				c.updatePodState(res)
 			case kubeResourceDeployment:
-				c.updateDeploymentState(r)
+				c.updateDeploymentState(res)
+			case kubeResourceCronJob:
+				c.updateCronJobState(res)
+			case kubeResourceJob:
+				c.updateJobState(res)
 			}
 			c.state.Unlock()
 		}
@@ -26,4 +30,8 @@ func copyLabels(dst, src map[string]string) {
 	for k, v := range src {
 		dst[k] = v
 	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }


### PR DESCRIPTION
##### Summary

This PR adds basic CronJob monitoring by tracking jobs by their status:

- **Complete**: Successfully finished jobs.
- **Failed**: Jobs that terminated with errors.
- **Running**: Currently active jobs.
- **Suspended**: Jobs paused by the system.

Note that the metrics history depth is controlled by the CronJob's `successfulJobsHistoryLimit` and `failedJobsHistoryLimit settings`, which determine how many completed/failed jobs are retained in the system.


##### Test Plan

<!--
Provide enough detail so that your reviewer can understand which test cases you
have covered, and recreate them if necessary. If our CI covers sufficient tests, then state which tests cover the change.
-->

##### Additional Information
<!-- This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue. -->

<details> <summary>For users: How does this change affect me?</summary>
  <!--
Describe the PR affects users: 
- Which area of Netdata is affected by the change?
- Can they see the change or is it an under the hood? If they can see it, where?
- How is the user impacted by the change? 
- What are there any benefits of the change? 
-->
</details>
