### PR TITLE
fix memory corruption in streaming

### DIFF
--- a/src/streaming/stream-receiver.c
+++ b/src/streaming/stream-receiver.c
@@ -1055,6 +1055,7 @@ void stream_receiver_replication_check_from_poll(struct stream_thread *sth, usec
                    __atomic_load_n(&host->stream.rcv.status.replication.counter_in, __ATOMIC_RELAXED));
 
             stream_receiver_remove(sth, rpt, STREAM_HANDSHAKE_DISCONNECT_REPLICATION_STALLED);
+            continue;
         }
 
         rpt->replication.last_checked_ut = rpt->replication.last_progress_ut;

--- a/src/streaming/stream-sender.c
+++ b/src/streaming/stream-sender.c
@@ -630,6 +630,7 @@ void stream_sender_replication_check_from_poll(struct stream_thread *sth, usec_t
                    __atomic_load_n(&host->stream.snd.status.replication.counter_out, __ATOMIC_RELAXED));
 
             stream_sender_move_running_to_connector_or_remove(sth, s, STREAM_HANDSHAKE_DISCONNECT_REPLICATION_STALLED, 0, true);
+            continue;
         }
 
         s->replication.last_checked_ut = s->replication.last_progress_ut;


### PR DESCRIPTION
When the receiver or the sender are disconnected due to stale replication, do not use their structures after the disconnection.