### PR TITLE
Avoid zero timeout in libuv timers

### DIFF
--- a/src/aclk/aclk.c
+++ b/src/aclk/aclk.c
@@ -872,7 +872,7 @@ void *aclk_main(void *ptr)
 
         if (schedule_node_update) {
             worker_is_busy(WORKER_ACLK_NODE_UPDATE);
-            schedule_node_state_update(localhost, 0);
+            schedule_node_state_update(localhost, 10);
             schedule_node_update = false;
         }
 

--- a/src/health/health_event_loop.c
+++ b/src/health/health_event_loop.c
@@ -669,7 +669,7 @@ static void health_event_loop(void) {
                    "Postponing alarm checks for %"PRId32" seconds, "
                    "because it seems that the system was just resumed from suspension.",
                    (int32_t)health_globals.config.postpone_alarms_during_hibernation_for_seconds);
-            schedule_node_state_update(localhost, 0);
+            schedule_node_state_update(localhost, 10);
         }
 
         if (unlikely(silencers->all_alarms && silencers->stype == STYPE_DISABLE_ALARMS)) {


### PR DESCRIPTION
##### Summary
- This may cause high CPU usage in older libuv versions
